### PR TITLE
sql: make database, table, view and columns lookups properly case-sensitive

### DIFF
--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -327,7 +327,7 @@ func (at *allocatorTest) printRebalanceStats(db *gosql.DB, host string) error {
 	{
 		var rebalanceIntervalStr string
 		if err := db.QueryRow(
-			`SELECT (SELECT MAX(timestamp) FROM rangelog) - (SELECT MAX(timestamp) FROM eventlog WHERE eventType=$1)`,
+			`SELECT (SELECT MAX(timestamp) FROM rangelog) - (SELECT MAX(timestamp) FROM eventlog WHERE "eventType"=$1)`,
 			sql.EventLogNodeJoin,
 		).Scan(&rebalanceIntervalStr); err != nil {
 			return err
@@ -393,8 +393,8 @@ func (at *allocatorTest) allocatorStats(db *gosql.DB) (s replicationStats, err e
 		storage.RangeLogEventType_remove.String(),
 	}
 
-	q := `SELECT NOW()-timestamp, rangeID, storeID, eventType FROM rangelog WHERE ` +
-		`timestamp=(SELECT MAX(timestamp) FROM rangelog WHERE eventType IN ($1, $2, $3))`
+	q := `SELECT NOW()-timestamp, "rangeID", "storeID", "eventType" FROM rangelog WHERE ` +
+		`timestamp=(SELECT MAX(timestamp) FROM rangelog WHERE "eventType" IN ($1, $2, $3))`
 
 	var elapsedStr string
 

--- a/pkg/acceptance/event_log_test.go
+++ b/pkg/acceptance/event_log_test.go
@@ -65,7 +65,7 @@ func testEventLogInner(
 		// Query all node join events. There should be one for each node in the
 		// cluster.
 		rows, err := db.Query(
-			"SELECT targetID, info FROM system.eventlog WHERE eventType = $1",
+			`SELECT "targetID", info FROM system.eventlog WHERE "eventType" = $1`,
 			string(csql.EventLogNodeJoin))
 		if err != nil {
 			return err
@@ -135,7 +135,7 @@ func testEventLogInner(
 
 		// Query all node restart events. There should only be one.
 		rows, err := db.Query(
-			"SELECT targetID, info FROM system.eventlog WHERE eventType = $1",
+			`SELECT "targetID", info FROM system.eventlog WHERE "eventType" = $1`,
 			string(csql.EventLogNodeRestart))
 		if err != nil {
 			return err

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -903,7 +903,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 		// customers is aware of the view that depends on it.
 		if _, err := db.DB.Exec(`DROP TABLE store.customers`); !testutils.IsError(err,
-			`cannot drop table "customers" because view "early_customers" depends on it`,
+			`cannot drop relation "customers" because view "early_customers" depends on it`,
 		) {
 			t.Fatal(err)
 		}
@@ -935,7 +935,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 		// customers is aware of the view that depends on it.
 		if _, err := db.DB.Exec(`DROP TABLE store.customers`); !testutils.IsError(err,
-			`cannot drop table "customers" because view "storestats.ordercounts" depends on it`,
+			`cannot drop relation "customers" because view "storestats.ordercounts" depends on it`,
 		) {
 			t.Fatal(err)
 		}
@@ -946,7 +946,7 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 
 		// orders is aware of the view that depends on it.
 		if _, err := db.DB.Exec(`DROP TABLE store.orders`); !testutils.IsError(err,
-			`cannot drop table "orders" because view "storestats.ordercounts" depends on it`,
+			`cannot drop relation "orders" because view "storestats.ordercounts" depends on it`,
 		) {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -73,7 +73,7 @@ func Load(
 		SELECT
 			d.descriptor
 		FROM system.namespace n INNER JOIN system.descriptor d ON n.id = d.id
-		WHERE n.parentID = $1
+		WHERE n."parentID" = $1
 		AND n.name = $2`,
 		keys.RootNamespaceID,
 		database,
@@ -174,7 +174,7 @@ func Load(
 			if tableDesc == nil {
 				return BackupDescriptor{}, errors.Errorf("expected previous CREATE TABLE %s statement", name)
 			}
-			if parser.ReNormalizeName(name) != parser.ReNormalizeName(tableName) {
+			if name != tableName {
 				return BackupDescriptor{}, errors.Errorf("unexpected INSERT for table %s after CREATE TABLE %s", name, tableName)
 			}
 			outOfOrder := false

--- a/pkg/ccl/sqlccl/targets.go
+++ b/pkg/ccl/sqlccl/targets.go
@@ -32,7 +32,7 @@ func descriptorsMatchingTargets(
 
 	starByDatabase := make(map[string]validity, len(targets.Databases))
 	for _, d := range targets.Databases {
-		starByDatabase[d.Normalize()] = maybeValid
+		starByDatabase[string(d)] = maybeValid
 	}
 
 	type table struct {
@@ -55,9 +55,9 @@ func descriptorsMatchingTargets(
 					return nil, err
 				}
 			}
-			db := p.DatabaseName.Normalize()
+			db := string(p.DatabaseName)
 			tablesByDatabase[db] = append(tablesByDatabase[db], table{
-				name:     p.TableName.Normalize(),
+				name:     string(p.TableName),
 				validity: maybeValid,
 			})
 		case *parser.AllTablesSelector:
@@ -66,7 +66,7 @@ func descriptorsMatchingTargets(
 					return nil, err
 				}
 			}
-			starByDatabase[p.Database.Normalize()] = maybeValid
+			starByDatabase[string(p.Database)] = maybeValid
 		default:
 			return nil, errors.Errorf("unknown pattern %T: %+v", pattern, pattern)
 		}
@@ -78,7 +78,7 @@ func descriptorsMatchingTargets(
 	for _, desc := range descriptors {
 		if dbDesc := desc.GetDatabase(); dbDesc != nil {
 			databasesByID[dbDesc.ID] = dbDesc
-			normalizedDBName := parser.ReNormalizeName(dbDesc.Name)
+			normalizedDBName := dbDesc.Name
 			if _, ok := starByDatabase[normalizedDBName]; ok {
 				starByDatabase[normalizedDBName] = valid
 				ret = append(ret, desc)
@@ -94,10 +94,10 @@ func descriptorsMatchingTargets(
 			if !ok {
 				return nil, errors.Errorf("unknown ParentID: %d", tableDesc.ParentID)
 			}
-			normalizedDBName := parser.ReNormalizeName(dbDesc.Name)
+			normalizedDBName := dbDesc.Name
 			if tables, ok := tablesByDatabase[normalizedDBName]; ok {
 				for i := range tables {
-					if parser.ReNormalizeName(tables[i].name) == parser.ReNormalizeName(tableDesc.Name) {
+					if tables[i].name == tableDesc.Name {
 						tables[i].validity = valid
 						ret = append(ret, desc)
 						break

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -282,7 +282,7 @@ func getMetadataForTable(
 		`, ts), []driver.Value{tableName, dbName})
 	if err != nil {
 		if err == io.EOF {
-			return tableMetadata{}, errors.Errorf("table %s.%s does not exist", dbName, tableName)
+			return tableMetadata{}, errors.Errorf("relation %s does not exist", name)
 		}
 		return tableMetadata{}, err
 	}

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -562,7 +562,7 @@ INSERT INTO t (i, j) VALUES
 
 	if out, err := c.RunWithCaptureArgs([]string{"dump", "d", "t", "--as-of", "2000-01-01 00:00:00"}); err != nil {
 		t.Fatal(err)
-	} else if !strings.Contains(string(out), "table d.t does not exist") {
+	} else if !strings.Contains(string(out), "relation d.t does not exist") {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -153,8 +153,8 @@ func queryDescriptors(conn *sqlConn) (map[sqlbase.ID]*sqlbase.Descriptor, error)
 
 func queryNamespace(conn *sqlConn, parentID sqlbase.ID, name string) (sqlbase.ID, error) {
 	rows, err := makeQuery(
-		`SELECT id FROM system.namespace WHERE parentID = $1 AND name = $2`,
-		parentID, parser.Name(name).Normalize())(conn)
+		`SELECT id FROM system.namespace WHERE "parentID" = $1 AND name = $2`,
+		parentID, name)(conn)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -320,7 +320,7 @@ func checkQueryResults(results []sql.Result, numResults int) error {
 }
 
 func eventlogUniqueIDDefault(ctx context.Context, r runner) error {
-	const alterStmt = "ALTER TABLE system.eventlog ALTER COLUMN uniqueID SET DEFAULT uuid_v4();"
+	const alterStmt = `ALTER TABLE system.eventlog ALTER COLUMN "uniqueID" SET DEFAULT uuid_v4();`
 
 	// System tables can only be modified by a privileged internal user.
 	session := r.newRootSession(ctx)

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -364,7 +364,7 @@ func TestAdminAPITableDoesNotExist(t *testing.T) {
 	}
 
 	const badTablePath = "databases/system/tables/" + fakename
-	const tableErrPattern = `table \\"system.` + fakename + `\\" does not exist`
+	const tableErrPattern = `relation \\"system.` + fakename + `\\" does not exist`
 	if err := getAdminJSONProto(s, badTablePath, nil); !testutils.IsError(err, tableErrPattern) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, tableErrPattern)
 	}
@@ -390,7 +390,7 @@ func TestAdminAPITableSQLInjection(t *testing.T) {
 
 	const fakeTable = "users;DROP DATABASE system;"
 	const path = "databases/system/tables/" + fakeTable
-	const errPattern = `table \"system.\\\"` + fakeTable + `\\\"\" does not exist`
+	const errPattern = `relation \"system.` + fakeTable + `\" does not exist`
 	if err := getAdminJSONProto(s, path, nil); !testutils.IsError(err, regexp.QuoteMeta(errPattern)) {
 		t.Fatalf("unexpected error: %v\nexpected: %s", err, errPattern)
 	}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -674,7 +674,7 @@ func TestAdminAPIUsers(t *testing.T) {
 	session.StartUnlimitedMonitor()
 	defer session.Finish(ts.sqlExecutor)
 	query := `
-INSERT INTO system.users (username, hashedPassword)
+INSERT INTO system.users (username, "hashedPassword")
 VALUES ('admin', 'abc'), ('bob', 'xyz')`
 	res := ts.sqlExecutor.ExecuteStatements(session, query, nil)
 	defer res.Close(ctx)

--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -73,7 +73,7 @@ func TestSettingsRefresh(t *testing.T) {
 
 	db := sqlutils.MakeSQLRunner(t, rawDB)
 
-	insertQ := `UPSERT INTO system.settings (name, value, lastUpdated, valueType)
+	insertQ := `UPSERT INTO system.settings (name, value, "lastUpdated", "valueType")
 		VALUES ($1, $2, NOW(), $3)`
 	deleteQ := "DELETE FROM system.settings WHERE name = $1"
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -53,7 +53,7 @@ func (p *planner) AlterTable(ctx context.Context, n *parser.AlterTable) (planNod
 		if n.IfExists {
 			return &emptyNode{}, nil
 		}
-		return nil, sqlbase.NewUndefinedTableError(tn.String())
+		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}
 
 	if err := p.CheckPrivilege(tableDesc, privilege.CREATE); err != nil {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -131,7 +131,7 @@ func (n *alterTableNode) Start(ctx context.Context) error {
 				if err := idx.FillColumns(d.Columns); err != nil {
 					return err
 				}
-				_, dropped, err := n.tableDesc.FindIndexByName(d.Name)
+				_, dropped, err := n.tableDesc.FindIndexByName(string(d.Name))
 				if err == nil {
 					if dropped {
 						return fmt.Errorf("index %q being dropped, try again later", d.Name)

--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -65,7 +65,7 @@ func TestAsOfTime(t *testing.T) {
 	if err := db.QueryRow("CREATE DATABASE d; SELECT cluster_logical_timestamp()").Scan(&tsDBExists); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Query(fmt.Sprintf(query, tsDBExists), 0); !testutils.IsError(err, `pq: table "d.t" does not exist`) {
+	if _, err := db.Query(fmt.Sprintf(query, tsDBExists), 0); !testutils.IsError(err, `pq: relation "d.t" does not exist`) {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -347,16 +347,16 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR DEFAULT 'i', FAMILY (k),
 	}
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{Descriptor_: &sqlbase.DescriptorMutation_Column{Column: &tableDesc.Columns[len(tableDesc.Columns)-1]}}}
 	tableDesc.Columns = tableDesc.Columns[:len(tableDesc.Columns)-1]
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, col i, id 3") {
+	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state UNKNOWN, direction NONE, col "i", id 3`) {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = sqlbase.DescriptorMutation_DELETE_ONLY
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state DELETE_ONLY, direction NONE, col i, id 3") {
+	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state DELETE_ONLY, direction NONE, col "i", id 3`) {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = sqlbase.DescriptorMutation_UNKNOWN
 	tableDesc.Mutations[0].Direction = sqlbase.DescriptorMutation_DROP
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction DROP, col i, id 3") {
+	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state UNKNOWN, direction DROP, col "i", id 3`) {
 		t.Fatal(err)
 	}
 }

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -99,8 +99,7 @@ func (mt mutationTest) makeMutationsActive() {
 // writeColumnMutation adds column as a mutation and writes the
 // descriptor to the DB.
 func (mt mutationTest) writeColumnMutation(column string, m sqlbase.DescriptorMutation) {
-	name := parser.Name(column)
-	col, _, err := mt.tableDesc.FindColumnByName(name)
+	col, _, err := mt.tableDesc.FindColumnByName(parser.Name(column))
 	if err != nil {
 		mt.Fatal(err)
 	}
@@ -365,8 +364,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR DEFAULT 'i', FAMILY (k),
 // descriptor to the DB.
 func (mt mutationTest) writeIndexMutation(index string, m sqlbase.DescriptorMutation) {
 	tableDesc := mt.tableDesc
-	name := parser.Name(index)
-	idx, _, err := tableDesc.FindIndexByName(name)
+	idx, _, err := tableDesc.FindIndexByName(index)
 	if err != nil {
 		mt.Fatal(err)
 	}

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -242,7 +242,7 @@ func TestDistBackfill(t *testing.T) {
 	cdb := tc.Server(0).KVClient().(*client.DB)
 
 	sqlutils.CreateTable(
-		t, tc.ServerConn(0), "NumToSquare", "x INT PRIMARY KEY, xsquared INT",
+		t, tc.ServerConn(0), "numtosquare", "x INT PRIMARY KEY, xsquared INT",
 		n,
 		sqlutils.ToRowFn(sqlutils.RowIdxFn, func(row int) parser.Datum {
 			return parser.NewDInt(parser.DInt(row * row))
@@ -250,12 +250,12 @@ func TestDistBackfill(t *testing.T) {
 	)
 
 	sqlutils.CreateTable(
-		t, tc.ServerConn(0), "NumToStr", "y INT PRIMARY KEY, str STRING",
+		t, tc.ServerConn(0), "numtostr", "y INT PRIMARY KEY, str STRING",
 		n*n,
 		sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowEnglishFn),
 	)
 	// Split the table into multiple ranges.
-	descNumToStr := sqlbase.GetTableDescriptor(cdb, "test", "NumToStr")
+	descNumToStr := sqlbase.GetTableDescriptor(cdb, "test", "numtostr")
 	// SplitTable moves the right range, so we split things back to front
 	// in order to move less data.
 	for i := numNodes - 1; i > 0; i-- {
@@ -265,11 +265,11 @@ func TestDistBackfill(t *testing.T) {
 	r := sqlutils.MakeSQLRunner(t, tc.ServerConn(0))
 	r.DB.SetMaxOpenConns(1)
 	r.Exec("SET DISTSQL = OFF")
-	if _, err := tc.ServerConn(0).Exec("CREATE INDEX foo ON NumToStr (str)"); err != nil {
+	if _, err := tc.ServerConn(0).Exec(`CREATE INDEX foo ON numtostr (str)`); err != nil {
 		t.Fatal(err)
 	}
 	r.Exec("SET DISTSQL = ALWAYS")
-	res := r.QueryStr("SELECT str FROM NumToStr@foo")
+	res := r.QueryStr(`SELECT str FROM numtostr@foo`)
 	if len(res) != n*n {
 		t.Errorf("expected %d entries, got %d", n*n, len(res))
 	}
@@ -418,7 +418,7 @@ func TestDistSQLRangeCachesIntegrationTest(t *testing.T) {
 	// of the splits and still holds the state after the first dummy query at the
 	// beginning of the test, which had everything on the first node.
 	query := `SELECT COUNT(1) FROM "left" INNER JOIN "right" USING (num)`
-	row := db3.QueryRow(fmt.Sprintf("SELECT JSON FROM [EXPLAIN (DISTSQL) %v]", query))
+	row := db3.QueryRow(fmt.Sprintf(`SELECT "JSON" FROM [EXPLAIN (DISTSQL) %v]`, query))
 	var json string
 	if err := row.Scan(&json); err != nil {
 		t.Fatal(err)
@@ -445,7 +445,7 @@ func TestDistSQLRangeCachesIntegrationTest(t *testing.T) {
 	// Now assert that new plans correctly contain all the nodes. This is expected
 	// to be a result of the caches having been updated on the gateway by the
 	// previous query.
-	row = db3.QueryRow(fmt.Sprintf("SELECT JSON FROM [EXPLAIN (DISTSQL) %v]", query))
+	row = db3.QueryRow(fmt.Sprintf(`SELECT "JSON" FROM [EXPLAIN (DISTSQL) %v]`, query))
 	if err := row.Scan(&json); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/doc.go
+++ b/pkg/sql/doc.go
@@ -66,7 +66,7 @@ database/table name to ID and from ID to descriptor:
     "parentID" INT,
     "name"     CHAR,
     "id"       INT,
-    PRIMARY KEY (parentID, name)
+    PRIMARY KEY ("parentID", name)
   );
 
   Create TABLE system.descriptor (
@@ -79,7 +79,7 @@ databases reside. In order to look up the ID of a database given its name, the
 system runs the underlying key-value operations that correspond to the following
 query:
 
-  SELECT id FROM system.namespace WHERE parentID = 0 AND name = <database-name>
+  SELECT id FROM system.namespace WHERE "parentID" = 0 AND name = <database-name>
 
 And given a database/table ID, the system looks up the descriptor using the
 following query:

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -69,7 +69,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *parser.DropDatabase) (pla
 		return nil, err
 	}
 
-	tbNames, err := getTableNames(ctx, p.txn, p.getVirtualTabler(), dbDesc)
+	tbNames, err := getTableNames(ctx, p.txn, p.getVirtualTabler(), dbDesc, false)
 	if err != nil {
 		return nil, err
 	}
@@ -430,10 +430,10 @@ func (p *planner) DropView(ctx context.Context, n *parser.DropView) (planNode, e
 				continue
 			}
 			// View does not exist, but we want it to: error out.
-			return nil, sqlbase.NewUndefinedViewError(name.String())
+			return nil, sqlbase.NewUndefinedRelationError(tn)
 		}
 		if !droppedDesc.IsView() {
-			return nil, sqlbase.NewWrongObjectTypeError(name.String(), "view")
+			return nil, sqlbase.NewWrongObjectTypeError(tn, "view")
 		}
 
 		td = append(td, droppedDesc)
@@ -535,10 +535,10 @@ func (p *planner) DropTable(ctx context.Context, n *parser.DropTable) (planNode,
 				continue
 			}
 			// Table does not exist, but we want it to: error out.
-			return nil, sqlbase.NewUndefinedTableError(name.String())
+			return nil, sqlbase.NewUndefinedRelationError(tn)
 		}
 		if !droppedDesc.IsTable() {
-			return nil, sqlbase.NewWrongObjectTypeError(name.String(), "table")
+			return nil, sqlbase.NewWrongObjectTypeError(tn, "table")
 		}
 		td = append(td, droppedDesc)
 	}

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -281,7 +281,7 @@ func (p *planner) dropIndexByName(
 	behavior parser.DropBehavior,
 	stmt string,
 ) error {
-	idx, dropped, err := tableDesc.FindIndexByName(idxName)
+	idx, dropped, err := tableDesc.FindIndexByName(string(idxName))
 	if err != nil {
 		if ifExists {
 			// Noop.

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -529,12 +529,12 @@ func TestDropTable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Test that dropped table cannot be used. This prevents
+	// Test that deleted table cannot be used. This prevents
 	// regressions where name -> descriptor ID caches might make
 	// this statement erronously work.
 	if _, err := sqlDB.Exec(
 		`SELECT * FROM t.kv`,
-	); !testutils.IsError(err, `table "t.kv" does not exist`) {
+	); !testutils.IsError(err, `relation "t.kv" does not exist`) {
 		t.Fatalf("different error than expected: %+v", err)
 	}
 
@@ -667,7 +667,7 @@ func TestDropTableInterleavedDeleteData(t *testing.T) {
 	// Test that deleted table cannot be used. This prevents regressions where
 	// name -> descriptor ID caches might make this statement erronously work.
 	if _, err := sqlDB.Exec(`SELECT * FROM t.intlv`); !testutils.IsError(
-		err, `table "t.intlv" does not exist`,
+		err, `relation "t.intlv" does not exist`,
 	) {
 		t.Fatalf("different error than expected: %v", err)
 	}

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -103,7 +103,7 @@ func (ev EventLogger) InsertEventRecord(
 
 	const insertEventTableStmt = `
 INSERT INTO system.eventlog (
-  timestamp, eventType, targetID, reportingID, info
+  timestamp, "eventType", "targetID", "reportingID", info
 )
 VALUES(
   now(), $1, $2, $3, $4

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -369,7 +369,7 @@ func (p *planner) processColumns(
 			return nil, pgerror.UnimplementedWithIssueErrorf(8318, "compound types not supported yet: %q", n)
 		}
 
-		col, err := tableDesc.FindActiveColumnByName(c.ColumnName)
+		col, err := tableDesc.FindActiveColumnByName(string(c.ColumnName))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -109,7 +109,7 @@ func getTableID(ctx context.Context, p *planner, tn *parser.TableName) (sqlbase.
 		return 0, err
 	}
 	if !gr.Exists() {
-		return 0, sqlbase.NewUndefinedTableError(parser.AsString(tn))
+		return 0, sqlbase.NewUndefinedRelationError(tn)
 	}
 	return sqlbase.ID(gr.ValueInt()), nil
 }

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -174,7 +174,7 @@ func commonColumns(left, right *dataSourceInfo) parser.NameList {
 				continue
 			}
 
-			if parser.ReNormalizeName(cLeft.Name) == parser.ReNormalizeName(cRight.Name) {
+			if cLeft.Name == cRight.Name {
 				res = append(res, parser.Name(cLeft.Name))
 			}
 		}

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -168,8 +168,8 @@ func makeUsingPredicate(
 ) (*joinPredicate, *dataSourceInfo, error) {
 	seenNames := make(map[string]struct{})
 
-	for _, unnormalizedColName := range colNames {
-		colName := unnormalizedColName.Normalize()
+	for _, syntaxColName := range colNames {
+		colName := string(syntaxColName)
 		// Check for USING(x,x)
 		if _, ok := seenNames[colName]; ok {
 			return nil, nil, fmt.Errorf("column %q appears more than once in USING clause", colName)
@@ -223,8 +223,8 @@ func makeEqualityPredicate(
 
 	// Find out which columns are involved in EqualityPredicate.
 	for i := range leftColNames {
-		leftColName := leftColNames[i].Normalize()
-		rightColName := rightColNames[i].Normalize()
+		leftColName := string(leftColNames[i])
+		rightColName := string(rightColNames[i])
 
 		// Find the column name on the left.
 		leftIdx, leftType, err := pickUsingColumn(left.sourceColumns, leftColName, "left")
@@ -311,8 +311,8 @@ func makeEqualityPredicate(
 	// anonymous data source.
 	for i := 0; i < numMergedEqualityColumns; i++ {
 		anonymousAlias.columnRange = append(anonymousAlias.columnRange, i)
-		hiddenLeftNames = append(hiddenLeftNames, parser.ReNormalizeName(left.sourceColumns[i].Name))
-		hiddenRightNames = append(hiddenRightNames, parser.ReNormalizeName(right.sourceColumns[i].Name))
+		hiddenLeftNames = append(hiddenLeftNames, left.sourceColumns[i].Name)
+		hiddenRightNames = append(hiddenRightNames, right.sourceColumns[i].Name)
 	}
 
 	// Now collect the other table-less columns into the anonymous data
@@ -327,7 +327,7 @@ func makeEqualityPredicate(
 			for _, colIdx := range alias.columnRange {
 				isHidden := false
 				for _, hiddenName := range hiddenNames {
-					if parser.ReNormalizeName(cols[colIdx].Name) == hiddenName {
+					if cols[colIdx].Name == hiddenName {
 						isHidden = true
 						break
 					}
@@ -473,7 +473,7 @@ func pickUsingColumn(
 		if col.Hidden {
 			continue
 		}
-		if parser.ReNormalizeName(col.Name) == colName {
+		if col.Name == colName {
 			idx = j
 		}
 	}

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -325,8 +325,8 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 	}
 }
 
-// Test that table names are not treated as case sensitive by the name cache.
-func TestTableNameNotCaseSensitive(t *testing.T) {
+// Test that table names are treated as case sensitive by the name cache.
+func TestTableNameCaseSensitive(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
@@ -346,13 +346,10 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 
-	// Check that we can get the table by a different name.
+	// Check that we cannot get the table by a different name.
 	lease := leaseManager.tableNames.get(tableDesc.ParentID, "tEsT", s.Clock())
-	if lease == nil {
-		t.Fatalf("no name cache entry")
-	}
-	if err := leaseManager.Release(lease.TableDescriptor); err != nil {
-		t.Fatal(err)
+	if lease != nil {
+		t.Fatalf("lease manager incorrectly found table with different case")
 	}
 }
 

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -76,7 +76,7 @@ func (t *leaseTest) cleanup() {
 
 func (t *leaseTest) getLeases(descID sqlbase.ID) string {
 	sql := `
-SELECT version, nodeID FROM system.lease WHERE descID = $1 ORDER BY version, nodeID
+SELECT version, "nodeID" FROM system.lease WHERE "descID" = $1 ORDER BY version, "nodeID"
 `
 	rows, err := t.db.Query(sql, descID)
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -565,10 +565,10 @@ INSERT INTO privs VALUES (1)
 
 user testuser
 
-statement error user testuser does not have CREATE privilege on table privs
+statement error user testuser does not have CREATE privilege on relation privs
 ALTER TABLE privs ADD c INT
 
-statement error user testuser does not have CREATE privilege on table privs
+statement error user testuser does not have CREATE privilege on relation privs
 ALTER TABLE privs ADD CONSTRAINT foo UNIQUE (b)
 
 user root
@@ -599,10 +599,10 @@ a     INT  false NULL    {primary,foo}
 b     INT  true  NULL    {foo}
 c     INT  true  NULL    {}
 
-statement error table "nonexistent" does not exist
+statement error relation "nonexistent" does not exist
 ALTER TABLE nonexistent SPLIT AT VALUES (42)
 
-statement error table "nonexistent" does not exist
+statement error relation "nonexistent" does not exist
 ALTER INDEX nonexistent@noindex SPLIT AT VALUES (42)
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -1,0 +1,274 @@
+# Case sensitivity of database names
+
+statement ok
+CREATE DATABASE D
+
+statement ok
+SHOW TABLES FROM d
+
+statement error database "D" does not exist
+SHOW TABLES FROM "D"
+
+statement ok
+CREATE DATABASE "E"
+
+statement error database "e" does not exist
+SHOW TABLES FROM e
+
+statement ok
+SHOW TABLES FROM "E"
+
+# Case sensitivity of table names:
+# When non-quoted, table names are normalized during creation.
+
+statement ok
+CREATE TABLE A(x INT)
+
+statement error relation "A" does not exist
+SHOW COLUMNS FROM "A"
+
+statement error relation "A" does not exist
+SHOW INDEXES FROM "A"
+
+statement error relation "A" does not exist
+SHOW CREATE TABLE "A"
+
+statement error relation "A" does not exist
+SHOW GRANTS ON TABLE "A"
+
+statement error relation "test.A" does not exist
+SHOW GRANTS ON TABLE test."A"
+
+statement error relation "A" does not exist
+SHOW CONSTRAINTS FROM "A"
+
+statement error relation "A" does not exist
+SELECT * FROM "A"
+
+statement error relation "A" does not exist
+INSERT INTO "A"(x) VALUES(1)
+
+statement error relation "A" does not exist
+UPDATE "A" SET x = 42
+
+statement error relation "A" does not exist
+DELETE FROM "A"
+
+statement error relation "A" does not exist
+TRUNCATE "A"
+
+statement error relation "A" does not exist
+DROP TABLE "A"
+
+statement ok
+SHOW COLUMNS FROM a
+
+statement ok
+SHOW INDEXES FROM a
+
+statement ok
+SHOW CREATE TABLE a
+
+statement ok
+SHOW CONSTRAINTS FROM a
+
+statement ok
+SELECT * FROM a
+
+statement ok
+INSERT INTO a(x) VALUES(1)
+
+statement ok
+UPDATE a SET x = 42
+
+statement ok
+DELETE FROM a
+
+statement ok
+TRUNCATE a
+
+statement ok
+DROP TABLE a
+
+# When quoted, a table name does not get normalized during create, and
+# must be thus quoted during use.
+
+statement ok
+CREATE TABLE "B"(x INT)
+
+statement error relation "b" does not exist
+SHOW COLUMNS FROM B
+
+statement error relation "b" does not exist
+SHOW INDEXES FROM B
+
+statement error relation "b" does not exist
+SHOW CREATE TABLE B
+
+statement error relation "b" does not exist
+SHOW GRANTS ON TABLE B
+
+statement error relation "test.b" does not exist
+SHOW GRANTS ON TABLE test.B
+
+statement error relation "b" does not exist
+SHOW CONSTRAINTS FROM B
+
+statement error relation "b" does not exist
+SELECT * FROM B
+
+statement error relation "b" does not exist
+INSERT INTO B(x) VALUES(1)
+
+statement error relation "b" does not exist
+UPDATE B SET x = 42
+
+statement error relation "b" does not exist
+DELETE FROM B
+
+statement error relation "b" does not exist
+TRUNCATE B
+
+statement error relation "b" does not exist
+DROP TABLE B
+
+statement ok
+SHOW COLUMNS FROM "B"
+
+statement ok
+SHOW INDEXES FROM "B"
+
+statement ok
+SHOW CREATE TABLE "B"
+
+statement ok
+SHOW GRANTS ON TABLE "B"
+
+statement ok
+SHOW GRANTS ON TABLE test."B"
+
+statement ok
+SHOW CONSTRAINTS FROM "B"
+
+statement ok
+SELECT * FROM "B"
+
+statement ok
+INSERT INTO "B"(x) VALUES(1)
+
+statement ok
+UPDATE "B" SET x = 42
+
+statement ok
+DELETE FROM "B"
+
+statement ok
+TRUNCATE "B"
+
+statement ok
+DROP TABLE "B"
+
+# Case sensitivity of column names.
+
+statement ok
+CREATE TABLE foo(X INT, "Y" INT)
+
+query III colnames
+SELECT x, X, "Y" FROM foo
+----
+x x Y
+
+statement error column name "X" not found
+SELECT "X" FROM foo
+
+statement error column name "y" not found
+SELECT Y FROM foo
+
+# The following should not be ambiguous.
+query II colnames
+SELECT Y, "Y" FROM (SELECT x as y, "Y" FROM foo)
+----
+y Y
+
+# Case sensitivity of view names.
+
+statement ok
+CREATE VIEW XV AS SELECT X, "Y" FROM foo
+
+query TT
+SHOW CREATE VIEW xv
+----
+xv  CREATE VIEW xv AS SELECT x, "Y" FROM test.foo
+
+query error relation "XV" does not exist
+SHOW CREATE VIEW "XV"
+
+statement ok
+CREATE VIEW "YV" AS SELECT X, "Y" FROM foo
+
+query TT
+SHOW CREATE VIEW "YV"
+----
+"YV"  CREATE VIEW "YV" AS SELECT x, "Y" FROM test.foo
+
+query error relation "yv" does not exist
+SHOW CREATE VIEW YV
+
+# Case sensitivity of index names.
+
+statement ok
+CREATE TABLE a(x INT, y INT, CONSTRAINT Foo PRIMARY KEY(x)); CREATE INDEX I ON a(y)
+
+statement error index "I" not found
+SELECT * FROM a@"I"
+
+statement error index "Foo" not found
+SELECT * FROM a@"Foo"
+
+statement error index a@"I" not found
+SELECT * FROM a ORDER BY INDEX a@"I"
+
+statement error index a@"Foo" not found
+SELECT * FROM a ORDER BY INDEX a@"Foo"
+
+statement error index "I" does not exist
+DROP INDEX a@"I"
+
+statement ok
+SELECT * FROM a@I
+
+statement ok
+SELECT * FROM a@Foo
+
+statement ok
+SELECT * FROM a ORDER BY INDEX a@I
+
+statement ok
+SELECT * FROM a ORDER BY INDEX a@Foo
+
+statement ok
+DROP INDEX a@I
+
+# Unicode sequences are preserved.
+
+statement ok
+CREATE TABLE Amelie("Amélie" INT, "Amélie" INT); INSERT INTO Amelie VALUES (1, 2)
+
+# Check that the column names were encoded properly
+query I
+SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'amelie' AND column_name::BYTES = b'Ame\xcc\x81lie'
+----
+1
+
+query I
+SELECT ordinal_position FROM information_schema.columns WHERE table_name = 'amelie' AND column_name::BYTES = b'Am\xc3\xa9lie'
+----
+2
+
+# Check that the non-normalized names propagate throughout until results.
+
+query II colnames
+SELECT "Amélie", "Amélie" FROM Amelie
+----
+Amélie Amélie
+2      1

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -73,7 +73,7 @@ SELECT * FROM smtng.something ORDER BY 1 LIMIT 1
 ----
 cups 10
 
-statement error pq: table "something" does not exist
+statement error pq: relation "something" does not exist
 SELECT * FROM something LIMIT 1
 
 # Check for memory leak (#10466)

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -121,7 +121,7 @@ output row: [2 2 2]
 fetched: /t/primary/1/b/c -> /1/1
 output row: [1 1 1]
 
-statement error pgcode 42P01 table "foo" does not exist
+statement error pgcode 42P01 relation "foo" does not exist
 CREATE INDEX fail ON foo (b DESC)
 
 statement ok
@@ -135,7 +135,7 @@ CREATE TABLE privs (a INT PRIMARY KEY, b INT)
 
 user testuser
 
-statement error user testuser does not have CREATE privilege on table privs
+statement error user testuser does not have CREATE privilege on relation privs
 CREATE INDEX foo ON privs (b)
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -131,7 +131,7 @@ test
 statement ok
 CREATE DATABASE b
 
-statement error table "b.a" does not exist
+statement error relation "b.a" does not exist
 SELECT * FROM b.a
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -43,7 +43,7 @@ SET DISTSQL = ON
 # We hardcode the plan for the testcase that follows to make it easier to debug
 # errors caused by changing planning logic.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzElEFLwzAYhu_-CnlPCjksbTdnT_O4g06mnqSH2HyUwtaUJAVl9L9Lm8Nc2RJhhR6T9Pme702THFApSS9iTwbpJzgYIjDEYEjAMEfGUGuVkzFKd584YC2_kc4YyqpubDedMeRKE9IDbGl3hBTv4mtHWxKSNBgkWVHuekmty73QPysprADDprHp7YojaxlUY48FjRUFIeUt-7_0qSg0FcKqgfPt4_luxe8vSqKLkmPtplJakiZ5UjprR2wjPmmDT7HBAek4GxxNkSwgHSdZPEWygHScZMkUyQLS8a_7GcmWTK0qQ4Nrf77yrHsOSBbk3g6jGp3Tq1Z5r3HDTc_1E5KMdavcDdaVW-oa_AtzLxydwHwIR35zQB176cQPJ9f0PffCC795cY35wQsv_eblNeZH_7-aBY6J_5AN3Vl78xsAAP__L_yi-A==
 
@@ -53,7 +53,7 @@ SELECT SUM(a) FROM data
 55000
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM((a-1)*1000 + (b-1)*100 + (c-1)*10 + (d-1)) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM((a-1)*1000 + (b-1)*100 + (c-1)*10 + (d-1)) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzclDFvuzAQxff_p_jrJrd1JQwkTT3RMUPTKk2nisHFJ4SUYGQbqVXEd6-AqAkoMZXCxIb9eP7dO1u3h1xJXIkdGuAfwICCDxQCoBAChRnEFAqtEjRG6fqX1rCUX8A9CllelLbejikkSiPwPdjMbhE4bMTnFtcoJGqgINGKbNtACp3thP6OpLACKKwxl6j5f0IIidg945wvV5ubW-Z53uH7jpDI7yiHz0YJTpWjEIW_-xBXFFRpj8UaK1IEzir690BPaaoxFVb18ry9P5OIXYb4FyHHs8tcaYkaZefouBqxjKBTBpva5Q0EGufy_Kl1bSDQOF0Lpta1gUDjdC2cWtcGAo0_Xs9A1mgKlRvsjdnzJ3v1-EWZYjurjSp1gq9aJQ2mXb40vmZDorGtytrFMm-lusBTM3Oa_Y6Z9c2-mzyADpzu0G0Or6l75jTP3eT5NeQHp3nhJi-uIT-678obeCbuR9Znx9W_nwAAAP__yKUKhg==
 
@@ -63,7 +63,7 @@ SELECT SUM((a-1)*1000 + (b-1)*100 + (c-1)*10 + (d-1)) FROM data
 49995000
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), COUNT(a), MAX(a) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), COUNT(a), MAX(a) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzElE1r4zAQhu_7K5b3tAs6RLaTzfqU0FMOSUo-oFBMUa3BGBLLSDK0BP_3Yrs0jUnk0pD6Zkl-9LzDiDkgU5IWYk8G4SM4GDww-GAIwDBExJBrFZMxSle_NMBMviAcMKRZXthqO2KIlSaEB9jU7gghNuJ5RysSkjQYJFmR7mpJrtO90K8TKawAw7Kw4e8JR1QyqMIeLzRWJISQl-zr0mmSaEqEVS3nejv_M-F_wXC33C4279_z6UP9dUntXVQfjUWmtCRN8kQYld8Kt97On2ZVPO8jnn85nn8Sj_fRjg7pLdvh9VFvh_SW9fp91NshvWW9QR_1dkh_arycUa_I5Coz1Boz528eVOOHZELNrDKq0DHdaxXXmma5rLl6Q5KxzSlvFrOsOaoCfoa5E_ZOYN6GPbe5Q-076cANB9fkHjrhkds8usb8zwmP3ebxNeb_7l4NOp6J-5G13VH56y0AAP__vVfAow==
 
@@ -73,7 +73,7 @@ SELECT SUM(a), COUNT(a), MAX(a) FROM data
 55000 10000 10
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a+b), COUNT(a+b), MAX(a+b) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a+b), COUNT(a+b), MAX(a+b) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzElE2L2zAQhu_9FeU9tVSHyHbS1CeHnnJIUvIBhWKK1hqMIbGMJMMuwf99sb1sNiaRlw1Z3yzJj553GDFH5ErSUhzIIPwHDgYPDD4YAjCMETMUWiVkjNL1Ly0wl48IRwxZXpS23o4ZEqUJ4RE2s3tCiK142NOahCQNBklWZPtGUujsIPRTJIUVYFhTLkmHXyP-I_IQVwyqtKdrjRUpIeQVe796lqaaUmFVx7zZLb5F_DsYfq92y-3L92L2t_m6pvauqk_GMldakiZ5JoyrD4Xb7Bb_53U87zWefz2efxaPD9eUHvU9m-INV3WP-p5V-8NV3aO-Z9XBcFX3qD9r7FxQr8kUKjfUGT-Xbx7VY4lkSu0MM6rUCf3RKmk07XLVcM2GJGPbU94u5nl7VAd8C3Mn7J3BvAt7bnOP2nfSgRsObsk9dsITt3lyi_mnE566zdNbzL_cvRr1PBP3I-u64-rLcwAAAP__jFnJfA==
 
@@ -83,7 +83,7 @@ SELECT SUM(a+b), COUNT(a+b), MAX(a+b) FROM data
 110000 10000 20
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM((a-1)*1000) + SUM((b-1)*100) + SUM((c-1)*10) + SUM(d-1) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM((a-1)*1000) + SUM((b-1)*100) + SUM((c-1)*10) + SUM(d-1) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzcVU2rnDAU3fdXPO5KOymY6Ht9zSpdzqKvZfq6Ki5ScxFhnpEkQsvgfy8a5kOZiYUpLtzdnHg859xckgPUWuGLfEML_CdQIMCAQAoEMiDwCDmBxugCrdWm_8QTtuo38IRAVTet6-GcQKENAj-Aq9wegcOr_LXHHUqFBggodLLaDyKNqd6k-SOUdBII7LBWaPhDJOgHyjnfvrzG72mSJL4mD5Fgo40znl7iR1hkRxTyjoBu3dmjdbJE4LQj_57jc1kaLKXTkxjff3yJBI2B-IqdqvRUZfFNC-ymhbNyW2uj0KAaCefdfzd5cQiRoBvB4o1I443IbtpPR_bpSiZhJscSk8BW0sqZHEu0Ml1JK2dyLNHKbCWtnMmx9FV_xcIObaNri5Mr__qfk_4pQFWifzesbk2B34wuBhm__DrwBkChdX6X-sW29lu9wUsyDZLZiEynZBZWnpFOg-wsTM7u8f0YJD-FlZ_uUf4YJD-HlZ_vUf4UPqtkZkzCQzbVzrt3fwMAAP__GXsv8A==
 
@@ -93,7 +93,7 @@ SELECT SUM((a-1)*1000) + SUM((b-1)*100) + SUM((c-1)*10) + SUM(d-1) FROM data
 49995000
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), MIN(b), MAX(c), COUNT(d) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), MIN(b), MAX(c), COUNT(d) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzElM-rozAQx-_7VyxzsjCHRm236yllTx7aLv0BC4ssWTOI0BpJIuxS_N8f6qGv0sYHfejNJH7y-TIT5gqFkrQVFzIQ_QYGCD4gBIAQAsICEoRSq5SMUbr5pQNi-Q-iOUJelJVtthOEVGmC6Ao2t2eCCI7i75n2JCRpQJBkRX5uJaXOL0L_51JYAQi7ykZfOUPuIw-Qh5DUCKqyt5uNFRlBxGr8uH2dZZoyYVVPfjhtPM5mgLCJtx7326_1L48HzdeP3Wl79Hg4exrCfxri5q4KpSVpknfqpP60mIfT5k88EDS4C8om7dWAfZxe-ZOWYMA-TgmCSUswYB-nBOGkJRiwjz-0HoTYkylVYag3vB7fPG-GGsmMugloVKVT-qlV2mq65a7l2g1JxnanrFvERXfUBHwPMyfs38GsD_tu84A6cNKhGw5fyb1wwku3efmK-ZsTXrnNq1fM3929mg88E_cj67uT-stbAAAA__-dk9aZ
 
@@ -105,7 +105,7 @@ SELECT SUM(a), MIN(b), MAX(c), COUNT(d) FROM data
 # AVG is more tricky: we do two aggregations (for the sum and for the count)
 # and calculate the average at the end.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT AVG(a+b+c+d) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT AVG(a+b+c+d) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzMlF9rszAUh-_fT_FyrioNrIm267zK2FUv2o7-uRoyMnMQoTWSRNgofvehXrSVNo61A-9M4s_nOZ5wDpApiQuxRwPhG1AgwICADwQCIDCGiECuVYzGKF290gRm8hPCEYE0ywtbbUcEYqURwgPY1O4QQtiIjx2uUEjUQECiFemuhuQ63Qv9xaWwAgisMJOow_-DAadDzrwh970hDyAqCajCHgHGigQhpCX5ucRzkmhMhFUth_V2PuDUAwIvy-1iUz9fA7KrwCOnyJSWqFGeYaLyV0rr7fx9Vkkx7-T_cPrA2VVJ_0yS9qE1HRL3bw3rQ9UdEvev2u9D1R0S96866EPVHRJ_O3wuAFdocpUZbA2hy18eVcMJZYLNJDOq0DG-ahXXmGa5rHP1hkRjm1PaLGZZc1QJnoapM8zOwrQdZm5yB9p3pgN3OLjFe-wMT9zkyS3kR2d46iZPbyE_uXs16rgm7kvWZkflv-8AAAD__wNOyoE=
 
@@ -117,7 +117,7 @@ SELECT AVG(a+b+c+d) FROM data
 # Test various combinations of aggregation functions and verify that the
 # aggregation processors are set up correctly.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), AVG(b), SUM(c), AVG(d), SUM(a+b+c+d) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), AVG(b), SUM(c), AVG(d), SUM(a+b+c+d) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzMlc-K2zAQxu99CjOnmAxsJCvJ1ieVnnLY3ZLdnIopajSYQNYKkgIti9-92O7mj9vIC77oNh7p8_fTzCC9QWU0PapXcpB_BwYIHBAyQBCAMIcC4WDNlpwzttnSCVb6F-QzhF11OPomXSBsjSXI38Dv_J4ghxf1c09rUposIGjyardvTQ5296rsb6mVV4CwpkqTzRPJMJEcE5lhIgUmk4lkU8nTqczSqRRQ1Ajm6M-GzquSIGc1fhzqS1laKpU3PabnzcNEshSwi3gTfX3aPL78jdtsdorExbo4ZefpTUh-E_LMdqyM1WRJX6EV9chjPG8efqwa0B7-O_LFjsUpv0z_6czde2Pk_E4uMJHLm6fNrk7LYpyTAag45oTHWLkBqDgql8VYuQGoOConYqzcAFQclRt4etbkDqZy1Lvd___nWXPrky6peyKcOdotfbNm29p0n0-trk1ocr5bZd3HquqWGsBLMQuK-ZWY9cU87DxgnQXVIiwWY7jnQfEi7LwY47wMiu_DzvdjnD-HezUbGJPwkPW9i_rTnwAAAP__NswiNA==
 
@@ -127,7 +127,7 @@ SELECT SUM(a), AVG(b), SUM(c), AVG(d), SUM(a+b+c+d) FROM data
 55000 5.5 55000 5.5 220000
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), MIN(b), MAX(c), COUNT(d), AVG(a+b+c+d) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), MIN(b), MAX(c), COUNT(d), AVG(a+b+c+d) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzMlMGK2zAQhu99CjMnmww0ku1065OWnnJItmQ3UCimqNFgDFnLSDK0LH73Yhu6iUnkQgrxbTTSr__TaJg3qLSirXwlC9l3YIDAASEGhAQQUsgRaqMPZK023ZFBsFa_IFsilFXduC6dIxy0IcjewJXuSJDBi_x5pB1JRQYQFDlZHnuT2pSv0vwWSjoJCDuqFJksEAwDwTEQMQYiwSAMBVsIHi1EHC1EAnmLoBv3bmidLAgy1uK_Qz0WhaFCOj1iet5vQsEiQNist6HgffT4LRRxF3152m9fQpF0cX8yPcmm0VU0fhXtnaiptFFkSJ0B5e1_g3_eb36sL-D_za8izy-I9KNYXX1gfPZANseGmIC6Z0PwOdZrAuqe9YrnWK8JqHvWK5ljvSag5jKgL6DtyNa6sjQa1JdvXnYDnFRBw7S3ujEH-mr0obcZlk-9rk8osm7YZcNiXQ1bHeCpmHnF_EzMxmLud56wjr3qxC9ObuFOveKV33l1i_Mnr_jB7_xwi_Nn_18tJ9rE32Rj77z98CcAAP__n84T3g==
 
@@ -138,7 +138,7 @@ SELECT SUM(a), MIN(b), MAX(c), COUNT(d), AVG(a+b+c+d) FROM data
 
 # We don't yet support local stages for STDDEV, VARIANCE.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), round(STDDEV(b), 1) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), round(STDDEV(b), 1) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzMkjFv8jAQhvfvV6B3AukGbOAbPKUSHRgKFdAuVQY3PkWRwI5sR2qF8t-rOAMFQaWKgY7ny3PPq-g9wDrDS73nAPUGAYIEYQLCFIQZckLtXcEhON990gML8wE1JlS2bmL3nBMK5xnqgFjFHUNhq993vGZt2INgOOpqlyS1r_baf2ZGRw3CqolqkAnKJPKW4Jp4vBmiLhlKtHTFe9Q11nnDns2JLG8vJHsoS8-lju4s2OblaZiJEQib7Xz--DrMZDes2Rr2KePAu8aaYSZJKKUWy-3oamZ5klnc6V_JO3knd_JO_0AnL3jXHGpnA5918_LlcddZNiX3BQ-u8QU_e1ckTT-uEpceDIfYb0U_LGxapYDfYfEj_P8EHp_D8hbz5BZ4egs8-xWct_--AgAA__-0Nqbd
 
@@ -148,7 +148,7 @@ SELECT SUM(a), round(STDDEV(b), 1) FROM data
 55000 2.9
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(a), round(VARIANCE(b), 1) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), round(VARIANCE(b), 1) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzMkjFrwzAQhff-ivCmBG6InKSDJofSwUOT4qZdigfVOowhkYwkQ0vwfy-WhzQhKZQM6Xg6f_c9zNvDWM0rtWMP-Q4BQgLCDIQ5CAsUhMbZkr23rv9kADL9CTkl1KZpQ_9cEErrGHKPUIctQ2KjPracs9LsQNAcVL2NksbVO-W-Uq2CAmHdBjlKBaUJio5g23C46YOqGFJ0dMF70LXGOs2O9ZGs6M4kW1aV40oFexLs5fVpnIoJCG_LPFuuHh7HadKPORvNLqYcOdsaPU4TElLKbLWZXEydHKUWN_pbyY28sxt55_-glWe8OfvGGs8n7Tx_edq3lnXFQ8W9bV3Jz86WUTOM68jFB80-DFsxDJmJqxjwJyx-he-P4OkpnFxjnl0Dz6-BF3-Ci-7uOwAA__9fiKdc
 
@@ -161,7 +161,7 @@ SELECT SUM(a), round(VARIANCE(b), 1) FROM data
 # and so it retains the primary key ordering, which is why we don't need to
 # specify rowsort.
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT DISTINCT (a) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT (a) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzElLFqwzAQhvc-RfnXaohsJ009ZeiSpSmhW_GgWkcQJJaRZGgJfvdia0gdGqlgF4-S_N13vyzujEpLehEnssjfwcGQgCEFQwaGJQqG2uiSrNWm-8QDW_mJfMGgqrpx3XbBUGpDyM9wyh0JOd7Ex5H2JCQZMEhyQh17SW3USZivjRROgGHXuPx-w1G0DLpxl4LWiQMh5y37u_RZWaeq0g2Nmy7XzkgyJIOu5KbrotC-zrXhAUU7fUPpoCE-x41HpJPeeDJHwIh00oDpHAEj0kkDZnMEjEj_bSj84tqTrXVlaeC6VXnRTQySB_ITxurGlPRqdNlr_HLXc_2GJOv8KfeLbeWPugZ_wjwIJwOYX8NJ2BxRp0E6C8PZmL6XQXgVNq_GmB-D8DpsXo8xP4X_1SLyTMKP7NpdtHffAQAA___TIK7L
 
@@ -180,7 +180,7 @@ SELECT DISTINCT (a) FROM data
 10
 
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM (DISTINCT A) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM (DISTINCT A) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzElDFvqzAUhff3K6IzvSd5iIHkpUypmoWhSZWkU8Xg4iuElGBkG6lVxH-vgCEFJaYSlRhtc853j7nXF-RK0lacySB8AweDBwYfDAEYFogZCq0SMkbp-pNWEMkPhHOGLC9KW2_HDInShPACm9kTIcRRvJ9oT0KSBoMkK7JTAyl0dhb6cy2FFWDYlTacrTniikGV9mporEgJIa_Yz6GbzNgsT2yX6HD37rpfTctcaUmaZMc1rm7wH9NUUyqs6mU-vD7_3USHY7R9Os7W_N_devxOPXyKKx6Ajrxib4pIA9CRkfwpIg1AR0YKpog0AP3F2b7hvidTqNxQb8ZvO8_r2SeZUvtQGFXqhF60ShpMu9w1umZDkrHtKW8XUd4e1QV-F3On2OuIeV_suckDaN-pDtziYEzdC6d46SYvx5D_O8UrN3k1hvzg_lfzgTZxN1mfHVd_vgIAAP__YDabVw==
 
@@ -190,7 +190,7 @@ SELECT SUM (DISTINCT A) FROM data
 55
 
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM (DISTINCT A), SUM (DISTINCT B) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM (DISTINCT A), SUM (DISTINCT B) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzElEGLozAUx-_7Kcr_tIUcGrXdrieX7cXDtkvbPS0eMuYhQmskiTBD8bsP6qGjtHHAAY9J_L3f-8fwbiiUpL24kkH4HxwMHhh8MARgWCNhKLVKyRilm086IJavCFcMeVFWttlOGFKlCeENNrcXQoizeLnQkYQkDQZJVuSXVlLq_Cr0WySFFWA4VDZcRJxFHpKaQVX2XtNYkRFCXrPPe3e5sXmR2r7ULfCeCu51q0JpSZpkr3BSP2jhV5ZpyoRVg-Snf3--7-LTOd7_Pi8ivgQbbHnLpy36vRb5THc_4p1-995MwUa804P5MwUb8U4PFswUbMT7tWPggeBIplSFocE4eFx51YwJkhl1M8WoSqf0V6u01XTLQ8u1G5KM7U55t4iL7qhp8CPMnbDXg_kQ9tzmEbXvpAM3HEzpe-2EN27zZor5hxPeus3bKeaf7n-1Gnkm7kc2dCf1t_cAAAD__zMkpi0=
 
@@ -200,7 +200,7 @@ SELECT SUM (DISTINCT A), SUM (DISTINCT B) from data
 55 55
 
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT DISTINCT a, b FROM data WHERE (a + b + c) = 27 ORDER BY c,b,a]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT a, b FROM data WHERE (a + b + c) = 27 ORDER BY c,b,a]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzMlT9r3TAUxfd-CnOnhHeHSPLLH0FBQym8JSlptuJBtS7B4FhGkqEl-LsX20P6TC2lOAYvBkk--h0dDtxXaKyhe_1CHuQPYIDAAUEAQg4IRygQWmdL8t664ZdJcDK_QF4hVE3bhWG7QCitI5CvEKpQE0h40j9reiRtyAGCoaCreoS0rnrR7rcyOmhA-FrVgZzMLi4Uyw6Z4pfDV1xmnzN-I6U83T8BwkMXZKYYKo5KQNEj2C68wX3QzwSS9fh-g9-tC3NvShxQ8QMqdng3lP8P9EvlQ9WUYYYdGIsAsQh4u9c6Q47M8muK_oPc5Gdu2N5LkDC4TQkS0PUl4HuPPWFwm9gT0PWxi73HnjC4TewJ6PrY873HnjC4TewJ6MdOmn8AHsm3tvF0Bli6-WoYP2SeaRpb3naupG_OliNmWj6MunHDkA_TKZsWp2Y6Ggz-LWZRMY-LeVQszsRsLhZx29dxdB5VH-PiY1ScIF-vefRNVHwbJ99GxXdx8d0a2yzRsVTJ4i1jiZqxVT1jiaLlCXi8aSxRNRbv2tx70X_6EwAA__9T--XY
 
@@ -219,7 +219,7 @@ SELECT DISTINCT a, b FROM data WHERE (a + b + c) = 27 ORDER BY c,b,a
 7 10
 
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT DISTINCT a, b FROM data WHERE (a + b + c) = 27 ORDER BY b,a,c]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT a, b FROM data WHERE (a + b + c) = 27 ORDER BY b,a,c]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzMlU9r3DAQxe_9FGZOCTuHSPLmj6CgQynsJSlpbsUH1RqCYWMZSYaW4O9ebBfSNbWUsAh8MUjy0--J92BeobWG7vULeZA_gAECBwQBCCUg7KFC6JytyXvrxl9mwcH8AnmF0LRdH8btCqG2jkC-QmjCkUDCk_55pEfShhwgGAq6OU6QzjUv2v1WRgcNCF-bYyAni4sLxYpdofjl-BWXxeeC30gpD_dPgPDQB1kohoqjElANCLYPb3Af9DOBZAO-3-B368LSm-I7VGyHSuzeDeUfgX5pfGjaOiywI2MEOkOOzF_oKlGsEt9Adr5q_XnVkMteeWKPbb0mCYN5apKAZqgJ33oOCYN5ckhAM-Qgtp5DwmCeHBLQDDmUW88hYTBPDglo5vH1H-Ij-c62nk6IazdfjTONzDPNs9Db3tX0zdl6wszLh0k3bRjyYT5l8-LQzkejwX_FLCrmcTGPisWJmC3FIm77Oo4uo-p9XLyPihPk63MefRMV38bJt1HxXVx8d45tluhYqmTxlrFEzdhZPWOJopUJeLxpLFE1Fu_a0ns1fPoTAAD__11-AZs=
 
@@ -238,12 +238,12 @@ SELECT DISTINCT a, b FROM data WHERE (a + b + c) = 27 ORDER BY b,a,c
 10 10
 
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT c, d, SUM(a+c) + AVG(b+d) FROM data GROUP BY c, d]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT c, d, SUM(a+c) + AVG(b+d) FROM data GROUP BY c, d]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzclstr20AQxu_9K8ycErKlntUqD51U2h58iFOc-FRMUazBMThas5KhIfh_LyuV-qF4JkIO2L6tHj_N7HzffugVMptSP3mmHKJfgKBAg4IAFBhQEMJIwdzZMeW5df6VCuilfyDqKphm80Xhb48UjK0jiF6hmBYzgggekscZDShJyYGClIpkOiuLzN30OXEvcZoUCSgYUJaSizpxoDqxUZ0YL8qlvogNjJYK7KJYVcmLZEIQ4VK9v5Ovk4mjSVLYrUZiVLHfbe_7j_7DWYznq7X26_vh7Vkc_F8Zv_p2N_TPzflWa6tqjy-dpyR_eqvUaLnagd65g9WnFpl1KTlKNz5WfuUj93g_vP3d82-E5-v6oBdF_dPpSxzuFCdoIk7ffrbzzZ7rFTkrmP0Ost7PrsLhRmE8mNMgdHIEpwFP9zQI4uz5NOiDMaXQyRGYUp-uKQVx9mzK4GBMKXRyBKYMTteUgjh7NqU5GFMKnRyBKc3pmlIQ5wN_Zt-oNqB8brOc3vW32vWDpnRClSq5Xbgx_XR2XJapLu9KrryRUl5UT7G66GXVI9_gOozbMK7DegPGZvBVGxixFR22om94WrMDD_iBByxs-MqGhbWgdcjSlzx82cYoPCwYhYclowi0YBSBFoxyxQ78mh_4dRuj3PCZ0BVCoRYpjVKBp6VY4GkxFwRcCgYBFwTHWrBszl0Lc-eTRdAc-WhBIxSvhUsj0XlaEp2nRdEFXBJdwCXR-VxFIVixljGNROczBoWQwVrKNBKdpyXReVoUXcAl0QVcEp1PWC0krOZ_2rZFHy0__Q0AAP__JIWJCQ==
 
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT c, d, SUM(a+c) + AVG(b+d) FROM data GROUP BY c, d ORDER BY c, d]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT c, d, SUM(a+c) + AVG(b+d) FROM data GROUP BY c, d ORDER BY c, d]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzcl89v2k4Qxe_fvwLNKRH7VZm1TRKftmp74BBSQThVqHLwiCARL1obqVHE_17ZrsrvGdBSCbgtmOc36_f2I_wBmU2pm7xRDvEPQFCgQUEACkJQEMFQwczZEeW5deVPakEn_QVxS8Ekm82L8uuhgpF1BPEHFJNiShDDc_IypR4lKTlQkFKRTKaVycxN3hL3btKkSEBBj7KUXNwwgWqYUDUMNqulbpoQhgsFdl4sXfIiGRPEuFCHT_J5PHY0Tgq7MYhBZcrddr5-6z7fGLxdrnW57g8eb0zwdxWWqy9Pg_J6eLsx2tLt5b3xmuSvu6yGi-UO9N4dLG81z6xLyVG6drPqLv9yj_3B489O-YvodjUfLENRf3L6ZKK94QTHhNO1_9vZ-szbjlwVwmPc-tYVm3002FRGN_caRAcktSunlRsftO99_u01fzybUydMcgGnDq_31AnhnPjUCW7-p06fTeuFSS6g9fp6Wy-Ec-LWC27-rQ_OpvXCJBfQ-uB6Wy-Ec-LWC27-rQ_PpvXCJBfQ-vB6Wy-Ec-LWC26nfa_YYdCjfGaznA56Y2iVSVI6pjr23M7diL47O6ps6o9Pla76IqW8qK9i_aGT1ZfKAVfFuCnGVbFeE-Nx4nsfMQZeai9vLXhr9oEH_AMPWHHIi0NWHPFjR6xYt3nrNqu-48V3Pi3jxULSvFhqmaD28pZads8-8Af-gT_wTGgJUOCRIvQMt07XurkWzLeO11FI4tUSF3i1CCVB7ucuFQZ5tKDAFuThgpEg5_EidYbHCwp8QS_ACGopNT_ESHI_d7EzPGVQwAzynNECZ7QXZzTPGS1wRntxRlALqQlqqTOS3M9d_PvDc0YLnNE8Z7TAGX0cZ4aL_34HAAD__0igjN0=
 
@@ -353,13 +353,13 @@ SELECT c, d, SUM(a+c) + AVG(b+d) FROM data GROUP BY c, d ORDER BY c, d
 
 # There should be no "by hash" routers if there is a single stream.
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT c, d, SUM(a+c) + AVG(b+d) FROM data WHERE a > 9 GROUP BY c, d]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT c, d, SUM(a+c) + AVG(b+d) FROM data WHERE a > 9 GROUP BY c, d]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJyUkT9r8zAQxvf3U5hnSsi9ENnpokmBlpKhaUnTLsWDah3GkFhGUqAl-LsXWUP-QN12e3R3v9MP7ojWGl7rPXvINwgQblASOmcr9t66WE5DK_MBOSc0bXcIsVwSKusY8ojQhB1DYm3_2w4Ew0E3u2GoJ9hDOCE-6Johi57O1orxtVv9vuMNa8PuYjk61-y1-1RGBw3ChlvDTmaqoEwtKFNiNsR8phb4zkT8xWRZ145rHeyViBKkchBWt3fr7USJ6SnnMT-_PExUEdPy9X6iFtNzWxEVKVPFmGZ-ofnDHTbsO9t6_tUp5n1JYFNzurW3B1fxk7PV8E16Pg7cUDDsQ-oW6bFqUysKnsNiFM7H4XwUnl_BZf_vKwAA__84MeIZ
 
 # Distributed final stage without local stage.
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT STDDEV(a+b) FROM data GROUP BY c, d]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT STDDEV(a+b) FROM data GROUP BY c, d]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlU1r3DAQhu_9FcucWjoFy3bS1CcX0kMuadmGXooPympwFjaWkWRoCPvfi-3A1m46s6Ae7KM_nvl4XpCeobGGbvUjeSh-ggKEFBAyQMgB4QIqhNbZHXlvXf_LCNyYX1AkCPum7UL_ukLYWUdQPEPYhwNBAXf6_kBb0oYcIBgKen8YmrRu_6jdU2l00ICwpcaQKzZlhpsyx02p3pcpVEcE24WX8qeq90-bB-0fphVLhQNSIfiga4JCHfEfk55KdY11hhyZSbGhynyXz3XtqNbButcaI3y_u77-8uNtmb2bDX6aKP2_E93aD7ad_fZ642zSWK0mNLW40NLVuEsX5y5bjbtsce7y1bjLF-dOuKS25FvbeDrrJE36icnUNK7nbed29M3Z3dBmfPw6cMPpZciH8evLw00zfuoHPB_OY-DLGPgqBlYJT6s5nfxJpzycsrCa-k7mdBYTFg8LYfGwEBYPC2EJOwth5TFhXcTo5mFBNw8LunlY0C3sLOi-jNH9MUY3Dwu6eVjQzcOCbmFnQfdVjO5PMbp5WNDNw4JuHhZ0CztLJ_9fFwfruzq--R0AAP__AzrR6w==
 
@@ -405,7 +405,7 @@ NULL       /0       {5}       5
 /99        NULL     {5}       5
 
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT COUNT(*) FROM one AS a, one AS b, two AS c]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT COUNT(*) FROM one AS a, one AS b, two AS c]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzUk89LwzAUx-_-FfJOCjms2Q81J8WL87DKnHiQIrF51MKWV5IUlbH_XZoeZuuWUSYFj03yeZ9vX17WoEnhTK7QgniBCBhwYDCGhEFhKEVryVRb9cGp-gQxYJDronTVcsIgJYMg1uByt0QQsJBvS5yjVGiAgUIn86UvXph8Jc3XNWkEBnHpxCkkGwZUum0162SGIKIN69nI9xq3olKTUWhQNTRJRR46siP2nbTv95TrdupwztE_yTnucoM3WWYwk45aitv4abZ4ncfPj2fne02Thik6clbcBx2clWHDyHt_D30Y-Z8au3f1wMTM0RakLbYnfGflQTXWqDKsn4ml0qT4YCj1mvoz9pxfUGhdvTusP6bab_lL-AlHQZiHYd7BzNvwMAiPGvCgDY-C8FUYHnf451-xJ8d0--KYbl92ip1sTr4DAAD__7dOXWU=
 
@@ -418,7 +418,7 @@ statement error memory budget exceeded
 SELECT SUM(d1.a), MAX(d1.a), MIN(d1.a) FROM data as d1, data as d2 GROUP BY (d1.b, d1.c, d1.d, d2.a, d2.b, d2.c, d2.d)
 
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM(a), SUM(b), SUM(c) FROM data GROUP BY d HAVING SUM(a+b) > 10]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), SUM(b), SUM(c) FROM data GROUP BY d HAVING SUM(a+b) > 10]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzcls9r2zAUx-_7K8w7NUyDyLKzVieXtYPAmo6sO205qNHDNaSWkWVYKfnfh23aNO6ql6IdTE6Wf3z8nvz58vAjlEbjQt1jDfIXcGAQAwMBDBJgkMKKQWXNGuva2PaRHpjrPyCnDIqyalx7ecVgbSyCfARXuA2ChBt1u8ElKo0WGGh0qth0RSpb3Cv7kGnlFDBYYqnRyihLWJTxj1ncHljUHQWstgxM43ZlaqdyBMm37PBWzvPcYq6cGXSStfv98fPqJIsnTyvxvEqeV2m7ml9cLm5OMj4Z9LQrc_sQ3an6blAjhdV213f8Zt-79zSlsRot6r03dW85eGfpU-98Qu7xa7FxnQEe_W6mU4ERn0opLy6_zK_OvwGD68bJVkgmWJa8qUT8360tzCdTDR77d-FkrzAfTyyJVkYbS368sYzHkw6ildGmIz7edIjxpINoZbTpEMebjmQ86SBaGW06kuNNB_EPusS6MmWNB_3RTNuto86x_061aewav1uz7sr0p9cd113QWLv-Lu9P5mV_q23wJcyHMH8Jx3swfx88C4HPQmAe1DdP_XTs_d7CDwu_rJnfVuKlUz-chqj2w4RqP0yo9sOUaoImVM9CVH_2wqd-WachsvwwIcsPE7L8MCWLoAlZZyGyODFFqTEaNkfDBmnYJA0cpWGzlAcNU05M04SQ9mqcvkuan6ak-WlKmp8mpRE4Je3VUPVKW20__A0AAP__VLJtsg==
 
@@ -437,7 +437,7 @@ SELECT SUM(a), SUM(b), SUM(c) FROM data GROUP BY d HAVING SUM(a+b) > 10
 5500  5500  5500
 
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT AVG(a+b), c FROM data GROUP BY c, d HAVING c = d]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT AVG(a+b), c FROM data GROUP BY c, d HAVING c = d]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzcls9r2zAUx-_7K8w7tUxjlX9krWGgsR-QQ9ORNqdhhho9XENqGVmBlZL_fcg-OE5bvRb1kORmy_r4Pfnz5eFHqLXCmbzHFvI_wIFBDAwSYJACgwwKBo3RS2xbbdyWHpiqf5CfMajqZm3dcsFgqQ1C_gi2siuEHG7k7QrnKBUaYKDQymrVFWlMdS_Ng1DSSmDwq1pZNHkkkuhrJFzVOdaqX2GRSFkk-EcRQ7FhoNd2KNhaWSLkfMNe39S3sjRYSqt3ehKcCXfw6Y-fs5sTwU-H69hdXy8uT0Tirr5fLdxqcjraPW5uqHf7EN3J9u65YsVmOEP84hmGV61rbRQaVKOXdW95_1NeLy7_Tt16urUnOx3J-dy5yV4Uk7zvoWb6k252tj1fOB0V5vsYU6Kpg4gpP8aYxvuYFqKpg0hLfIxpSfYxLURTB5GW5BjTku5jWoimDiIt6TGmhfiTnWPb6LrFV_0RnblDoyqx_0KtXpsl_jZ62ZXpb686rltQ2Nr-Ke9vpnX_yDW4DfNdmG_D8Qjmb4MnIfBFCMyD-uaZn4693zvxw4lf1sRvK_XSmR_OQlT7YUK1HyZU-2FKNUETqichqr944XO_rPMQWX6YkOWHCVl-mJJF0ISsixBZnJii1BgNm6NhgzRskgaO0rBZyoOGKSemaUpIezJO3yTNT1PS_DQlzU-T0gickvZkqHqlFZsP_wMAAP__ALeCAg==
 
@@ -456,7 +456,7 @@ SELECT AVG(a+b), c FROM data GROUP BY c, d HAVING c = d
 11  10
 
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM(a+b), SUM(a+b) FILTER (WHERE a < d), SUM(a+b) FILTER (WHERE a = c) FROM data GROUP BY d]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a+b), SUM(a+b) FILTER (WHERE a < d), SUM(a+b) FILTER (WHERE a = c) FROM data GROUP BY d]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlkFr20wQhu_frxBzivm24NXKbiIoqNAUDK1bXPfU6rDRDorB0YqVBA3B_71IoiiW0xmH7UE-2Vrp2XlHzzLoCQprcK0fsIL4B0gQEIIABQIiELCAVEDpbIZVZV37SA-szC-I5wJ2RdnU7XIqILMOIX6CelfvEWLY6rs9blAbdCDAYK13-65I6XYP2j0mRtcaBGywMOjiIIlEkMj_k7D9-dnM5yrrl94lCtKDANvUQ7Wq1jlCLA_i_ETv89xhrms7CpS0bX_7_vkqCWfDv-Dj6tP2dhMk6oW19uWsPtyut1eJnI3SDQXvHoN7Xd2PqkWQHoYOwr92MOzTFNYZdGiOdup2ObvH6E8XcnbarRr3MORT_zbf2r6x5eixlwtHR4Xl5A4bk-gCDpuc-GELJ-ecSXQBzsOJO1eTc84kugDnauLOo8k5ZxJdgPNo4s6ZT7UNVqUtKjzrS2He5keTY99sZRuX4Vdns65Mf_ml47oFg1Xd35X9xarob7UBn8NyDMvncHgEy9fBSx_4xgeWXrnlgqZD8n0rGla0rCVtKyLpBQ0vfFTTMKOahhnVNMypZmhG9dJH9VsSvqZlXfvIomFGFg0zsmiYk8XQjKwbH1mSmaLcGPWbo36D1G-Seo5Sv1kqvYapZKZpxEg7GaevkkbTnDSa5qTRNCuNwTlpJ0OVlJYe_vsdAAD__9nAPb8=
 
@@ -476,7 +476,7 @@ SELECT SUM(a+b), SUM(a+b) FILTER (WHERE a < d), SUM(a+b) FILTER (WHERE a = c) FR
 
 # Same query but restricted to a single range; no local aggregation stage.
 query T
-SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM(a+b), SUM(a+b) FILTER (WHERE a < d), SUM(a+b) FILTER (WHERE a = c) FROM data WHERE a = 1 GROUP BY d]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a+b), SUM(a+b) FILTER (WHERE a < d), SUM(a+b) FILTER (WHERE a = c) FROM data WHERE a = 1 GROUP BY d]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJyUkc9L_DAQxe_fv6K801eM0KZ7CgjxoLCgq9T1pD3EZiiF3U5JUlCW_u_S5rA_cKueknkzn8njZYeWLa3MljzUKzIISJQCneOKvGc3ynFoaT-gUoGm7fowyqVAxY6gdghN2BAUVnzFHQQsBdNspqFBgPuwR3wwNUHlgzhYm82vXZv3DRVkLLmj5ehcszXuU1sTDAQKai05leiFSHR2qeV4vPVpmldRutY5zjnK_uLopq4d1SbwiSE9Jvj88vBfy4v9Lblb3q9vi0Tn32iLs47kkaMfoi_Id9x6-lX66VAKkK0pfq_n3lX05Lianonl48RNgiUfYjePxbKNrdHgIZzNwnIelrNwegKXw7-vAAAA__97O9_r
 
@@ -496,13 +496,13 @@ SELECT SUM(a+b), SUM(a+b) FILTER (WHERE a < d), SUM(a+b) FILTER (WHERE a = c) FR
 
 # Verify the XOR execution plan
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT XOR_AGG(TO_HEX(a)::bytes) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT XOR_AGG(TO_HEX(a)::bytes) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzMlE1r4zAQhu_7K5b3tAs6xB_JZnVKFpaQy2Zxc2gpJqjW4BoSy0gypAT_92L7kMYkciEu-CjJ7zzPyGJOyJWkf-JABvwZHhh8MARgCMEwRcxQaJWQMUrXn7SBtTyCTxiyvChtvR0zJEoT-Ak2s3sCx1a87CkiIUmDQZIV2b6BFDo7CP22kMIKMESUS9L8u1W7Vzr-WHg_Of_ztP37gLhiUKU9I4wVKYF7Ffu8xjJNNaXCqo7F4ybaLVermncT5N8EneuXudKSNMmL8nE1sEpwoeKN4-p7NIa7en8c_fZoDNdvMI5-ezSG6zccR789Gl8zSq6AIjKFyg11Rsr1ypN61JBMqZ1LRpU6of9aJQ2mXW6aXLMhydj21GsX67w9qgU_hj1n2L8Ie92w7yb3oANnOnSHw3u8p87wzE2e3UP-5QzP3eT5PeTf7n816Xkm7kfWZcfVt_cAAAD__xxcyAs=
 
 # Verify the XOR execution plan
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT XOR_AGG(a) FROM data]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT XOR_AGG(a) FROM data]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzElMFruzAUx--_v-LH97RBDo3arvPUnkov6yg7DIaMzDxEaI0kETaK__tQD12lTQY6PCbx8z7vG8M7oVCSnsSRDOI3cDAEYAjBEIFhjoSh1ColY5RuPumArfxEPGPIi7KyzXbCkCpNiE-wuT0QYryIjwPtSUjSYJBkRX5oJaXOj0J_raSwAgy7ysb_VxxJzaAqey5orMgIMa_Z76XrLNOUCat6ztfd_n292dyt-P1NUXBTdK5fFUpL0iQvyif1yK2EF63wKS7aIx3vooMp0nmk46ULp0jnkY6XLpoinUf6NyPgimhPplSFod4ouF551owIkhl188SoSqf0rFXaarrlruXaDUnGdqe8W2yL7qhp8CfMnXBwAfM-HLjNHnXopCM3HA3pe-6EF27zYoj5wQkv3eblEPOj-1_NPM_E_cj67qT-9x0AAP__oluqJA==
 
@@ -518,7 +518,7 @@ SELECT MAX(t.a), MIN(t.b), AVG(t.c) FROM (VALUES (1, 2, 3), (4, 5, 6), (7, 8, 0)
 7 5 3
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT MAX(t.a), MIN(t.b), AVG(t.c)  FROM (VALUES (1, 2, 3), (4, 5, 6), (7, 8, 0)) AS t(a, b, c) WHERE b > 3]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT MAX(t.a), MIN(t.b), AVG(t.c)  FROM (VALUES (1, 2, 3), (4, 5, 6), (7, 8, 0)) AS t(a, b, c) WHERE b > 3]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJyUkE9LxDAUxO9-ijCnLuTQPxfJqfWg9LBVRBZBeyjtoxZrUvISEJZ-d0lz0BVW3FveTCa_yTtCm4Ga7oMY6gUZWonFmp6YjQ1SvFAPn1CpxKQX74LcSvTGEtQRbnIzQeHQzZ4YEgO5bprje9fiRiSF6N-8fucdJG6n2ZFVoszFq0_TgkShlKqbJ7SrhPHuG8CuGwkqXeX_S1TjaGnsnLGnRfbVc1JmocC-bpIyD6fqcJeUxe4sOLsE_Ei8GM10gj3_pVaChpHihtl429ODNf2GieP9ltuEgdhFN4tDraMVCv4MZ3-G81_hdr36CgAA__91iaO-
 
@@ -528,6 +528,6 @@ SELECT * FROM (VALUES (1, '222'), (2, '444')) t1(a,b) JOIN (VALUES (1, 100.0), (
 1 222 1 100.0
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM (VALUES (1, '222'), (2, '444')) t1(a,b) JOIN (VALUES (1, 100.0), (3, 32.0)) t2(a,b) ON t1.a = t2.a]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM (VALUES (1, '222'), (2, '444')) t1(a,b) JOIN (VALUES (1, 100.0), (3, 32.0)) t2(a,b) ON t1.a = t2.a]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJykkDFrwzAQhff-CnNTAjfYTuggKJhOTYemdOhSNBjrapu6OqOToBD834ulIXVoWkI26e6-e-_eASwbeqo_SUC9QQEaYXTckAi7uZQGduYLVI7Q2zH4uawRGnYE6gC-9wOBgtd6CCSAYMjX_ZD2bbP7bFVmTRfsh6xBTwgc_HGJ-LolUPmEVwrdXit03B8sO0OOzEJCz-R_I7-4faile-Tekls6Hujdr6pifef6tosvQNgHr7KqwKrEaoPV9uwdxSWBvZCMbIVO7zmTkEYg01IKRTi4hp4dN1EmffeRiwVD4lO3TJ-dja1o8CdcXACXp3D5J7xZwPmkp5vvAAAA__-HZe5E

--- a/pkg/sql/logictest/testdata/logic_test/distsql_indexjoin
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_indexjoin
@@ -23,23 +23,23 @@ NULL       /100     {1}       1
 /400       NULL     {5}       5
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM t WHERE v > 100]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM t WHERE v > 100]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lE1rwkAQhu_9FeU9TyFfWptTrvagRXorOaTZQQK6E3Y3paX430vcQqPoWhE97sw88-Q9ZL6hRfGsWrNF_oYYhASEFIQMhBFKQmukZmvF9CMemKpP5BGh0W3nfNk1bsXI0Wkxig0rEBS7qln1_XJTEmoxjPxvdCYP0u6NEaRzv0tLgnXVkpGnGxqI44H4wNrX6n3FC64Um53l-CgcCPPO5fdFjGOu-BzXszT6kKo1zboyX0MhFQkV6VFtsqNNbhjxhOtaEdMbRjzhulbE7IYRT7iuFTEKaxdsW9GW__WXR_2RYLVkf1GsdKbmFyP1VuOf8y23LSi2znef_GOqfav_wCEcB-EkDCdBONqB4304DcJZ2JxdYh4F4XHYPL7E_BiEJ2Hz5Cxzubn7CQAA___NyjVY
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT * FROM t WHERE v > 100 ORDER BY v]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM t WHERE v > 100 ORDER BY v]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lDFr8zAQhvfvV3y8a69gy06aevKaDkkJ3YoH1TqCIbGMJJeW4v9eYhUah0RpCPEo6Z577h10X6i14oXcskX2ihgEAUICQgrCBAWhMbpka7XZlXhgrj6QRYSqblrnr13lNowM2ig2rEBQ7GS16fvm4g5FVxBKbRjZb_VC3-tmUFt0BN26n74FwTq5ZmRJR3vueM99pO2LfNvwiqViMxzkPXcgLFuX_c9jygVO6eJLdE-6qo_ZGlNtpfk8cFKenNSKgVaMm_KM7lYpk3FTntHdKmU6bsozululjMLaFdtG15b_9OOj3cJgtWa_YKxuTcnPRpe9xh-XPddfKLbOvz76w7z2T7sB9-E4CIswLIJwNIDjQzgJwmnYnF5jngThadg8vcb8EIRnYfPsInPR_fsOAAD__wDzN84=
 
 # Here we care about ordering by v, but v is not otherwise used.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT w FROM t WHERE v > 100 ORDER BY v]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT w FROM t WHERE v > 100 ORDER BY v]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lDFr8zAQhvfvV3y8a69gy06aevKaDkkJ3YoH1TqCIbGMJJeW4v9eYhVql1RpCPEo6Z577h10H6i14pXcs0X2jBgEAUICQgrCDAWhMbpka7U5lHhgqd6QRYSqblrnr13ldowM2ig2rEBQ7GS16_vm4gZFVxBKbRjZd_VK3-pmVFt0BN26r74FwTq5ZWRJRwN3PHAfafskX3a8YanYjAd5zR0I69Zl__OYcoHfdPE5ugdd1cdsjan20rwPnEnIKUZOMW3EE7qrREymjXhCd5WI6bQRT-iuEjEKOzdsG11b_tMvjw5LgtWW_VKxujUlPxpd9hp_XPdcf6HYOv967w_L2j8dBhzCcRAWYVgE4WgExz_hJAinYXN6iXkWhOdh8_wS810QXoTNi7PMRffvMwAA__-JWjVa
 
 # The single join reader should be on node 5, and doesn't need to output v.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT w FROM t WHERE v > 400 ORDER BY v]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT w FROM t WHERE v > 400 ORDER BY v]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJyUkT1PwzAQhnd-BXpnI8WJWDx1LUOLKjaUwcSnylLqs-wLAlX57yjxQIpooON9PO9jnc8I7GhnT5RhXqGh8IhWISbuKGdOU7ssbd0HTKXgQxxkarcKHSeCOUO89ASDHT9whIIjsb6fl0YFHuQbyWKPBNOMahGr12Nf7FtPB7KO0kU43jcChf0g5n6jcc2lb3E9sQ-_qWLyJ5s-F8LmqrC-EP5xswPlyCHTv85Wja0CuSOVf8k8pI6eE3ezppT7mZsbjrKUaVOKbSij6YFLWK_C9Tpcr8LVD7gd774CAAD__z-Sz4E=

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -56,7 +56,7 @@ SET DISTSQL = ON
 # We hardcode the plan for the testcase that follows to make it easier to debug
 # errors caused by changing planning logic.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT 5, 2+y, * FROM NumToStr WHERE y <= 10 ORDER BY str]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT 5, 2+y, * FROM NumToStr WHERE y <= 10 ORDER BY str]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJyUkDFrwzAQhff-CnNrNESmXTR59ZIWN1vRoFpHMNg6c3eGluD_XiwNbQMuzSDQvaf33UNXSBTxFCYUcG9gwRuYmXoUId6k8qCNH-COBoY0L7rJ3kBPjOCuoIOOCA7O4X3EDkNEBgMRNQxjhs48TIE_m7RMSqKb22GKyK56cs61p7Op6nI5NNZU-dTgVwO06PdC0XBBcHY1_y_1Sqy3fZrHwy68vgfeocyUBH_h98jH1RvAeMHyq0IL9_jC1Oc1ZXzOuSxEFC2uLUObirUV_Bm2f4brm7BfH74CAAD__ydlozk=
 
@@ -77,7 +77,7 @@ SELECT 5, 2+y, * FROM NumToStr WHERE y <= 10 ORDER BY str
 
 # Query which requires a full table scan.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT 5, 2 + y, * FROM NumToStr WHERE y % 1000 = 0 ORDER BY str]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT 5, 2 + y, * FROM NumToStr WHERE y % 1000 = 0 ORDER BY str]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlMFqwzAMhu97iiAYbNSD2Em7zjDIadBLN7reRg5ZLEogjYLtwEbpu4_Eg66ldQrZJYdAbOnX9yMZ7aAihctsiwbkB3BgIIBBBAxiYDCFlEGtKUdjSLcpTrBQXyBDBkVVN7a9ThnkpBHkDmxhSwQJ6-yzxBVmCjUwUGizouwgtS62mf5OqmZrydg2-lKUFrUM7hIe3AY8DEMp5WK5vg-eg99fYLDCSrVZU3fDAuF-JglnQfcJSPcMqLEHW8ZmGwTJ9-x66--k7anrJJ5cLC4uFj_UJK1QozpX9IyDJT1QfZR7iR0dsfl4Z9JjfdhMxHj70mN9WF-i8falx_qwvsTj7UuP9f_bbWeKr9DUVBm8anOF7eJDtUG3KA01Osc3TXmHccfXTtddKDTWRbk7LCoXag3-FXOvWByJ-alY-Mk96Mirjv3ieIjvqVc885NnQ8iPXvHcT54PIT_5ZxX2PBP_Iztlp_ubnwAAAP__UGjpww==
 
@@ -97,7 +97,7 @@ SELECT 5, 2 + y, * FROM NumToStr WHERE y % 1000 = 0 ORDER BY str
 
 # Query with a restricted span + filter.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT str FROM NumToStr WHERE y < 10 AND str LIKE '%e%' ORDER BY y]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT str FROM NumToStr WHERE y < 10 AND str LIKE '%e%' ORDER BY y]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJyMj7FqwzAYhPc-hTkIWTTEHTVlaYtpSYqbrXhQrSMIbMlIv6Al6N2LraF0KHS8-6S7-2_wwfJkZibod7QYFJYYRqYU4mrVB539hD4oOL9kWe1BYQyR0DeIk4nQuJiPiT2NZYSCpRg3baFLdLOJX0efZwlJVvroJmHUzfG-eemeH5r9jru91vrt0nenJyics6wUQ1EIWX5ak5grodui_r-sZ1qCT_w166_kQxkUaK-s16eQ48jXGMatpsrz9m8zLJNU2lbR-YrKUO6-AwAA__873XJx
 
@@ -114,7 +114,7 @@ nine
 
 # Query which requires a full table scan.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT str FROM NumToStr WHERE y % 1000 = 0 AND str LIKE '%i%' ORDER BY y]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT str FROM NumToStr WHERE y % 1000 = 0 AND str LIKE '%i%' ORDER BY y]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlEtr4zAUhffzK8SBkITRgKUksxAMeKAPTItT0uyKF651CQbHMpIMLcH_vdiGpi5NH2Tlne_j45xjuDqgNJridE8O6gECHBIcC3AswbFCwlFZk5FzxrYrPRDpJ6iAIy-r2rfthCMzlqAO8LkvCArb9LGgDaWaLDg0-TQvOpHK5vvUPodlvffG-XZ6lReerGKzWSjYhIkgCJRSUbyds3_s9fN_fMFmoWS30c0lm07yyVQpdb_dRPH1HBzr2isWSh4KJA2Hqf3RnPPpjqBEw08EOPo2VpMlPfQcyt9Img9SxuaPqQa7p7TlQFuM_efJsQdYjD3AcuwBvnhANuQqUzr61nUF7XGS3lF_zM7UNqM7a7JOpi_XHdc1NDnfT0VfRGU36gy-hcWn8N8BHLyH5TnKi3Pg5Tnw6kdw0vx6CQAA___v9_DI
 
@@ -132,7 +132,7 @@ nine-zero-zero-zero
 #
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON y = xsquared]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON y = xsquared]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlVFr2zAQgN_3K8o9taBBJDvLYhj4cd1DO8rehh_U6JYYEsuTZFgp-e_D9iC1k93FqA_Joy19p7vv4O4VKmvwQe_QQ_YTJAhQICABASkImEMhoHZ2hd5b117pgXvzB7KZgLKqm9D-LgSsrEPIXiGUYYuQwQ_9vMUn1AYdCDAYdLntHqldudPuJa-aXbD-d6MdgoDHJmQ3uRS5gmIvwDbhX-hDxOeXm432m2G07n4hwAe9RsjkXrx7isHF5CcH-an_5neI01TWGXRoBpGKluSunCjyq_abb7asxjVu8Ve4zdXdF1euN-E2l3dvq0xHVR4qSCIqOJHeg_1o63GhJx9OBw_LC2-tvPrWqgs3rK7ecHLhhpOrN5xeuOH06g0zK_YJfW0rj2dN-FmbPpo19jq8bdwKvzu76p7pPx87rpuvBn3oT1X_cV_1R22C58PzGHgRAy9jYClpWk4wpqbB8xh4EQMvY-CRsSNajenZWzqhdSckLIe-Z2M6jWkWDTPNomGmWTTMNIuGuWbNY5r1KUY3DTO6aZjRTcOMbhrmdC9idH-O0U3DjG4aZnTTMKObhjndyxjdcsqyPJ6hU7blVJob_lP25VSacy6Ptgcpvdh_-BsAAP__m1K8ow==
 
@@ -152,7 +152,7 @@ SELECT x, str FROM NumToSquare JOIN NumToStr ON y = xsquared
 # Sum the numbers in the NumToStr table. The expected result is
 #  n * n * (n * n + 1) / 2
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT SUM(y) FROM NumToStr]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(y) FROM NumToStr]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzElLFOwzAQhneeAv0TSB7qJC0lUxk7QFGBCWUw8SmK1MaR7UigKu-OEg-lUWsjNVJG-_Ldd-fYd0ClJL2IPRmkn-BgiMAQgyEBwxwZQ61VTsYo3X3igLX8RjpjKKu6sd12xpArTUgPsKXdEVK8i68dbUlI0mCQZEW56yW1LvdC_6yqZm-VsV1009j0dsWRtQyqscekxoqCkPKW_V_8VBSaCmHVwPv28Xy34vcXJdFFyTF3UyktSZM8SZ21I5YRn5TBpzrkgHicQ46m6i4gHqe7eKruAuJxukum6i4gHv_5n5FsydSqMjQYA-czz7rxQLIgN0uManROr1rlvcYtNz3Xb0gy1kW5W6wrF-oK_AtzLxydwHwIR35zQB176cQPJ9fUPffCC795cY35wQsv_eblNeZH_7-aBa6J_5IN3Vl78xsAAP___russg==
 
@@ -163,7 +163,7 @@ SELECT SUM(y) FROM NumToStr
 
 # Count the rows in the NumToStr table.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT COUNT(*) FROM NumToStr]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT COUNT(*) FROM NumToStr]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzElE1r4zAQhu_7K5b3lAUdItvJZn3K0lMOjUs-6KGYoFqDMSSWkWRoCf7vxfYhjUnklqT4KMnPPPPKYo7IlaSlOJBB-AIOBg8MPhgCMEwQMxRaJWSM0vUnLbCQbwjHDFlelLbejhkSpQnhETaze0KIjXjd04qEJA0GSVZk-0ZS6Owg9Ps8Lw9WGVufRqUNfyOuGFRpTyWNFSkh5BX7uvZ_mmpKhVUd60O0XW52q-h5Pfpz1eRdNZ0EZa60JE3yrH5cfaOX9fZxt1huRnN-vRX_rBU-zF33aO94194wAXu0dwzoDxOwR3vHgMEwAXu0PzQOLphWZAqVG-qMhcuVx_W4IJlSO1uMKnVCT1oljaZdRg3XbEgytj3l7WKRt0d1g59h7oS9M5h3Yc9t7lH7Tjpww8EtfU-c8NRtnt5i_uuEZ27z7BbzP_e_Gvc8E_cj67rj6tdHAAAA__84_rTI
 
@@ -174,7 +174,7 @@ SELECT COUNT(*) FROM NumToStr
 
 # Count how many numbers contain the digit 5.
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT COUNT(*) FROM NumToStr WHERE str LIKE '%five%']
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT COUNT(*) FROM NumToStr WHERE str LIKE '%five%']
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzMlM-Lm0AUx-_9K-RBSApziD-SpnNKKW2RtlqMoYdFguu8FcE4MjMuuwT_90U9ZCPJuEuy4NF5fufz4b3hHaDgDL14jxLoHZhAwAICNhBwgMACIgKl4AlKyUXzSxdw2RPQOYGsKCvVHEcEEi4Q6AFUpnIECmF8n2OAMUMBBBiqOMtbSCmyfSye10W1V1yqpvozyxUKaqwt44_7-4cxnTxkjziZUko3YeB6v4CAXylqQFQT4JU6YqWKUwRq1uTtat_SVGAaK94z--5vvXAX-P83s88XSdZF0hFQFVwwFMhO7o_qd7hstn93rhfO1uZlFftExRzvPAbUbjgPa7xNGFC7YRPs8TZhQO2GTXDG24QBtQ9aT2dIAcqSFxJ7a-r8zfNmfSFLsdt1klciwX-CJy2m-_TbXHvAUKquanYfbtGVGsHXYVMbtk7CZj9s6ckDaFubdvRh5xrvhTa81JOX15C_aMMrPXl1DfmrflbzgWeif2R9dlR_egkAAP__3ivlzg==
 
@@ -190,12 +190,12 @@ SELECT COUNT(*) FROM NumToStr WHERE str LIKE '%five%'
 #
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr LIMIT 5]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr LIMIT 5]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzEk7tq60AQhvvzFOav94B1S7GVW0Owg0kXVGy0g1mQdsReIMHo3YNWhSPjxAQVKmdG3_wfYvYCy5oOqiMP-YYMAjkECgiUEKhQC_SOG_Ke3fjJBOz1B-RWwNg-hrFdCzTsCPKCYEJLkHhV7y2dSGlyENAUlGlTSO9Mp9znzsYusA_j9BiD3OzG9GfTmbCpUA8CHMN1vQ_qTJDZIH5QuCZHy06TIz3LrYc7kgf-z_1c75FBPjPI1v8J-foKxfoK5foKDx7EiXzP1tPNVd7fvB2vlfSZptP2HF1DL46bFDOVx8SlhiYfpmk2FXubRknwO5z9Cj_N4O0tnC9JLpbA5RK4-hNcD_--AgAA__9hcK3z
 
 query T
-SELECT url FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr ORDER BY y LIMIT 5]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr ORDER BY y LIMIT 5]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzEkz9r8zAQxvf3U4RnfVWw_KeDJq-BkpTQrXhQrSMIbJ-RZGgJ_u7F8pC6NA3Fg0fd3e-eH-Z8QceGDrolD_UKCYEUAhkEcggUqAR6xzV5z24amYG9eYdKBGzXD2EqVwI1O4K6INjQEBRe9FtDJ9KGHAQMBW2bGNI722r3UXZDG9iHqXscgtqVU_qTbW3YFahGAR7Cdb0P-kxQchQ3FK7J7Aw5MsvUUv5HNf7geeAH7pez9yTShYTc_juk2ytk2yvk2yvc-SdO5HvuPC3yb21Opmslc6b5uj0PrqZnx3WMmZ_HyMWCIR_mrpwf-y62ouBXWP4KPy7g5DucrknO1sD5Grj4E1yN_z4DAAD__zIVrfA=
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -100,7 +100,7 @@ GRANT ALL ON d2.v3 TO testuser
 
 user testuser
 
-statement error user testuser does not have DROP privilege on view v4
+statement error user testuser does not have DROP privilege on relation v4
 DROP DATABASE d1
 
 user root
@@ -153,13 +153,13 @@ test
 query error database "d1" does not exist
 SELECT * FROM d1.v2
 
-query error table "d2.v2" does not exist
+query error relation "d2.v2" does not exist
 SELECT * FROM d2.v2
 
-query error table "d2.v3" does not exist
+query error relation "d2.v3" does not exist
 SELECT * FROM d2.v3
 
-query error table "d2.v4" does not exist
+query error relation "d2.v4" does not exist
 SELECT * FROM d2.v4
 
 query TT

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -67,7 +67,7 @@ users  bar      true    2    name    ASC        false    false
 
 user testuser
 
-statement error user testuser does not have CREATE privilege on table users
+statement error user testuser does not have CREATE privilege on relation users
 DROP INDEX users@bar
 
 user root
@@ -151,7 +151,7 @@ GRANT ALL ON v to testuser
 
 user testuser
 
-statement error user testuser does not have DROP privilege on view v2
+statement error user testuser does not have DROP privilege on relation v2
 DROP INDEX users@foo CASCADE
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -32,10 +32,10 @@ SHOW TABLES FROM test
 Table
 b
 
-statement error table "a" does not exist
+statement error relation "a" does not exist
 SELECT * FROM a
 
-statement error table "a" does not exist
+statement error relation "a" does not exist
 DROP TABLE a
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -109,5 +109,5 @@ user4
 
 user testuser
 
-statement error pq: user testuser does not have DELETE privilege on table users
+statement error pq: user testuser does not have DELETE privilege on relation users
 DROP USER user2

--- a/pkg/sql/logictest/testdata/logic_test/drop_view
+++ b/pkg/sql/logictest/testdata/logic_test/drop_view
@@ -19,13 +19,13 @@ a
 b
 c
 
-statement error cannot drop table "a" because view "b" depends on it
+statement error cannot drop relation "a" because view "b" depends on it
 DROP TABLE a
 
 statement error pgcode 42809 "b" is not a table
 DROP TABLE b
 
-statement error cannot drop view "b" because view "c" depends on it
+statement error cannot drop relation "b" because view "c" depends on it
 DROP VIEW b
 
 statement ok
@@ -34,7 +34,7 @@ CREATE VIEW d AS SELECT k,v FROM a
 statement ok
 CREATE VIEW diamond AS SELECT COUNT(*) FROM b AS b JOIN d AS d ON b.k = d.k
 
-statement error cannot drop view "d" because view "diamond" depends on it
+statement error cannot drop relation "d" because view "diamond" depends on it
 DROP VIEW d
 
 statement ok
@@ -51,10 +51,10 @@ diamond
 
 user testuser
 
-statement error user testuser does not have DROP privilege on view diamond
+statement error user testuser does not have DROP privilege on relation diamond
 DROP VIEW diamond
 
-statement error cannot drop view "d" because view "diamond" depends on it
+statement error cannot drop relation "d" because view "diamond" depends on it
 DROP VIEW d
 
 user root
@@ -101,10 +101,10 @@ d
 testuser1
 testuser2
 
-statement error cannot drop view "testuser1" because view "testuser2" depends on it
+statement error cannot drop relation "testuser1" because view "testuser2" depends on it
 DROP VIEW testuser1
 
-statement error cannot drop view "testuser1" because view "testuser2" depends on it
+statement error cannot drop relation "testuser1" because view "testuser2" depends on it
 DROP VIEW testuser1 RESTRICT
 
 statement ok
@@ -115,7 +115,7 @@ SHOW TABLES FROM test
 ----
 d
 
-statement error pgcode 42P01 view "testuser2" does not exist
+statement error pgcode 42P01 relation "testuser2" does not exist
 DROP VIEW testuser2
 
 user root
@@ -134,7 +134,7 @@ GRANT ALL ON d to testuser
 
 user testuser
 
-statement error user testuser does not have DROP privilege on view diamond
+statement error user testuser does not have DROP privilege on relation diamond
 DROP TABLE a CASCADE
 
 user root
@@ -152,7 +152,7 @@ CREATE VIEW x AS VALUES (1, 2), (3, 4)
 statement ok
 CREATE VIEW y AS SELECT column1, column2 FROM x
 
-statement error cannot drop view "x" because view "y" depends on it
+statement error cannot drop relation "x" because view "y" depends on it
 DROP VIEW x
 
 statement ok
@@ -164,7 +164,7 @@ CREATE VIEW x AS VALUES (1, 2), (3, 4)
 statement ok
 CREATE VIEW y AS SELECT column1, column2 FROM x
 
-statement error cannot drop view "x" because view "y" depends on it
+statement error cannot drop relation "x" because view "y" depends on it
 DROP VIEW x
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/errors
+++ b/pkg/sql/logictest/testdata/logic_test/errors
@@ -1,22 +1,22 @@
 # LogicTest: default distsql
 
-statement error pgcode 42P01 table "fake1" does not exist
+statement error pgcode 42P01 relation "fake1" does not exist
 ALTER TABLE fake1 DROP COLUMN a
 
-statement error pgcode 42P01 table "fake2" does not exist
+statement error pgcode 42P01 relation "fake2" does not exist
 CREATE INDEX i ON fake2 (a)
 
-statement error pgcode 42P01 table "fake3" does not exist
+statement error pgcode 42P01 relation "fake3" does not exist
 DROP INDEX fake3@i
 
-statement error pgcode 42P01 table "fake4" does not exist
+statement error pgcode 42P01 relation "fake4" does not exist
 DROP TABLE fake4
 
-statement error pgcode 42P01 table "fake5" does not exist
+statement error pgcode 42P01 relation "fake5" does not exist
 SHOW COLUMNS FROM fake5
 
-statement error pgcode 42P01 table "fake6" does not exist
+statement error pgcode 42P01 relation "fake6" does not exist
 INSERT INTO fake6 VALUES (1, 2)
 
-statement error pgcode 42P01 table "fake7" does not exist
+statement error pgcode 42P01 relation "fake7" does not exist
 SELECT * FROM fake7

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -22,8 +22,8 @@ CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
 ##################
 
 query II rowsort
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'create_table'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'create_table'
 ----
 51 1
 52 1
@@ -33,17 +33,17 @@ WHERE eventType = 'create_table'
 ##################
 
 query II
-SELECT targetID, reportingID
+SELECT "targetID", "reportingID"
 FROM system.eventlog
-WHERE eventType = 'create_table'
+WHERE "eventType" = 'create_table'
   AND info LIKE '%CREATE TABLE test.a%'
 ----
 51 1
 
 query II
-SELECT targetID, reportingID
+SELECT "targetID", "reportingID"
 FROM system.eventlog
-WHERE eventType = 'create_table'
+WHERE "eventType" = 'create_table'
   AND info LIKE '%CREATE TABLE IF NOT EXISTS test.b%'
 ----
 52 1
@@ -54,7 +54,7 @@ WHERE eventType = 'create_table'
 query I
 SELECT COUNT(*)
 FROM system.eventlog
-WHERE eventType = 'create_table'
+WHERE "eventType" = 'create_table'
   AND info LIKE '%CREATE TABLE badtable%'
 ----
 0
@@ -63,8 +63,8 @@ WHERE eventType = 'create_table'
 ##################
 
 query II
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'alter_table'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'alter_table'
 ----
 12 1
 
@@ -72,29 +72,29 @@ statement ok
 ALTER TABLE test.a ADD val INT
 
 query II rowsort
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'alter_table'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'alter_table'
 ----
 12 1
 51 1
 
 query II
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'finish_schema_change'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'finish_schema_change'
 ----
 51 1
 
 query II
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'reverse_schema_change'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'reverse_schema_change'
 ----
 
 # Verify the contents of the 'Info' field of each log message using a LIKE
 # statement.
 ##################
 query II
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'alter_table'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'alter_table'
   AND info LIKE '%ALTER TABLE test.a%'
 ----
 51 1
@@ -110,23 +110,23 @@ statement error pq: duplicate key value \(val\)=\(1\) violates unique constraint
 ALTER TABLE test.a ADD CONSTRAINT foo UNIQUE(val)
 
 query II rowsort
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'alter_table'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'alter_table'
 ----
 12 1
 51 1
 51 1
 
 query II rowsort
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'finish_schema_change'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'finish_schema_change'
 ----
 51 1
 51 1
 
 query II rowsort
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'reverse_schema_change'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'reverse_schema_change'
 ----
 51 1
 
@@ -137,15 +137,15 @@ statement ok
 CREATE INDEX a_foo ON test.a (val)
 
 query II
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'create_index'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'create_index'
   AND info LIKE '%a_foo%'
 ----
 51 1
 
 query II rowsort
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'finish_schema_change'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'finish_schema_change'
 ----
 51 1
 51 1
@@ -158,15 +158,15 @@ statement ok
 DROP INDEX test.a@a_foo
 
 query II
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'drop_index'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'drop_index'
   AND info LIKE '%a_foo%'
 ----
 51 1
 
 query II rowsort
-SELECT targetID, reportingID FROM system.eventlog
-WHERE eventType = 'finish_schema_change'
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'finish_schema_change'
 ----
 51 1
 51 1
@@ -191,9 +191,9 @@ DROP TABLE IF EXISTS test.b
 ##################
 
 query II rowsort
-SELECT targetID, reportingID
+SELECT "targetID", "reportingID"
 FROM system.eventlog
-WHERE eventType = 'drop_table'
+WHERE "eventType" = 'drop_table'
 ----
 51 1
 52 1
@@ -202,17 +202,17 @@ WHERE eventType = 'drop_table'
 ##################
 
 query II
-SELECT targetID, reportingID
+SELECT "targetID", "reportingID"
 FROM system.eventlog
-WHERE eventType = 'drop_table'
+WHERE "eventType" = 'drop_table'
   AND info LIKE '%DROP TABLE test.a%'
 ----
 51 1
 
 query II
-SELECT targetID, reportingID
+SELECT "targetID", "reportingID"
 FROM system.eventlog
-WHERE eventType = 'drop_table'
+WHERE "eventType" = 'drop_table'
   AND info LIKE '%DROP TABLE IF EXISTS test.b%'
 ----
 52 1
@@ -239,17 +239,17 @@ CREATE DATABASE IF NOT EXISTS othereventlogtest
 ##################
 
 query II
-SELECT targetID, reportingID
+SELECT "targetID", "reportingID"
 FROM system.eventlog
-WHERE eventType = 'create_database'
+WHERE "eventType" = 'create_database'
   AND info LIKE '%CREATE DATABASE eventlogtest%'
 ----
 53 1
 
 query II
-SELECT targetID, reportingID
+SELECT "targetID", "reportingID"
 FROM system.eventlog
-WHERE eventType = 'create_database'
+WHERE "eventType" = 'create_database'
   AND info LIKE '%CREATE DATABASE IF NOT EXISTS othereventlogtest%'
 ----
 54 1
@@ -282,17 +282,17 @@ DROP DATABASE IF EXISTS othereventlogtest
 ##################
 
 query II
-SELECT targetID, reportingID
+SELECT "targetID", "reportingID"
 FROM system.eventlog
-WHERE eventType = 'drop_database'
+WHERE "eventType" = 'drop_database'
   AND info LIKE '%DROP DATABASE eventlogtest%'
 ----
 53 1
 
 query II
-SELECT targetID, reportingID
+SELECT "targetID", "reportingID"
 FROM system.eventlog
-WHERE eventType = 'drop_database'
+WHERE "eventType" = 'drop_database'
   AND info LIKE '%DROP DATABASE IF EXISTS othereventlogtest%'
 ----
 54 1
@@ -300,9 +300,9 @@ WHERE eventType = 'drop_database'
 # verify cascading table drops are logged.
 ##################
 query II
-SELECT targetID, reportingID
+SELECT "targetID", "reportingID"
 FROM system.eventlog
-WHERE eventType = 'drop_database'
+WHERE "eventType" = 'drop_database'
   AND info LIKE '%testtable%'
   AND info LIKE '%anothertesttable%'
 ----

--- a/pkg/sql/logictest/testdata/logic_test/explain_distsql
+++ b/pkg/sql/logictest/testdata/logic_test/explain_distsql
@@ -16,61 +16,61 @@ Automatic URL JSON
 
 # Full table scan - distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv]
 ----
 true
 
 # Partial scan - don't distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k=1]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k=1]
 ----
 false
 
 # Partial scan - don't distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k>1]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k>1]
 ----
 false
 
 # Partial scan with filter - distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k>1 AND v=1]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k>1 AND v=1]
 ----
 true
 
 # Sort - distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k>1 ORDER BY v]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k>1 ORDER BY v]
 ----
 true
 
 # Aggregation - distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT k, SUM(v) FROM kv WHERE k>1 GROUP BY k]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT k, SUM(v) FROM kv WHERE k>1 GROUP BY k]
 ----
 true
 
 # Hard limit in scan - don't distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv LIMIT 1]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv LIMIT 1]
 ----
 false
 
 # Soft limit in scan - don't distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE v=1 LIMIT 1]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE v=1 LIMIT 1]
 ----
 false
 
 # Limit after sort - distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k>1 ORDER BY v LIMIT 1]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE k>1 ORDER BY v LIMIT 1]
 ----
 true
 
 # Limit after aggregation - distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT k, SUM(v) FROM kv WHERE k>1 GROUP BY k LIMIT 1]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT k, SUM(v) FROM kv WHERE k>1 GROUP BY k LIMIT 1]
 ----
 true
 
@@ -79,13 +79,13 @@ CREATE TABLE kw (k INT PRIMARY KEY, w INT)
 
 # Join - distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv NATURAL JOIN kw]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv NATURAL JOIN kw]
 ----
 true
 
 # Join with span - distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM kv NATURAL JOIN kw WHERE k=1]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv NATURAL JOIN kw WHERE k=1]
 ----
 true
 
@@ -94,18 +94,18 @@ CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX b (b))
 
 # Index join - don't distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM abc WHERE b=1]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM abc WHERE b=1]
 ----
 false
 
 # Index join with filter on result - don't distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM abc WHERE b>1 AND c%2=0]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM abc WHERE b>1 AND c%2=0]
 ----
 false
 
 # Index join with filter on index scan - distribute.
 query B
-SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT * FROM abc WHERE b=1 AND a%2=0]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM abc WHERE b=1 AND a%2=0]
 ----
 true

--- a/pkg/sql/logictest/testdata/logic_test/explain_plan
+++ b/pkg/sql/logictest/testdata/logic_test/explain_plan
@@ -15,7 +15,7 @@ EXPLAIN INSERT INTO t VALUES (1, 2)
 1          size  2 columns, 1 row
 
 query I
-SELECT MAX(LEVEL) FROM [EXPLAIN INSERT INTO t VALUES (1, 2)]
+SELECT MAX("Level") FROM [EXPLAIN INSERT INTO t VALUES (1, 2)]
 ----
 1
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -13,19 +13,19 @@ Database User      Privileges
 a        readwrite ALL
 a        root      ALL
 
-statement error table "a.t" does not exist
+statement error relation "a.t" does not exist
 SHOW GRANTS ON a.t
 
-statement error table "test.t" does not exist
+statement error relation "t" does not exist
 SHOW GRANTS ON t
 
 statement ok
 SET DATABASE = a
 
-statement error table "a.t" does not exist
+statement error relation "t" does not exist
 SHOW GRANTS ON t
 
-statement error table "a.t" does not exist
+statement error relation "a.t" does not exist
 GRANT ALL ON a.t TO readwrite
 
 statement ok
@@ -263,7 +263,7 @@ GRANT ALL ON a.t@xyz TO readwrite
 statement error pq: no database specified: *
 GRANT ALL ON * TO readwrite
 
-statement error table "a.tt" does not exist
+statement error relation "a.tt" does not exist
 GRANT ALL ON a.t, a.tt TO readwrite
 
 # '*' doesn't work for databases.

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -29,58 +29,58 @@ DROP DATABASE other_db
 
 # Verify information_schema tables handle mutation statements correctly.
 
-statement error user root does not have DROP privilege on table tables
+statement error user root does not have DROP privilege on relation tables
 ALTER TABLE information_schema.tables RENAME TO information_schema.bad
 
-statement error user root does not have CREATE privilege on table tables
+statement error user root does not have CREATE privilege on relation tables
 ALTER TABLE information_schema.tables RENAME COLUMN x TO y
 
-statement error user root does not have CREATE privilege on table tables
+statement error user root does not have CREATE privilege on relation tables
 ALTER TABLE information_schema.tables ADD COLUMN x DECIMAL
 
-statement error user root does not have CREATE privilege on table tables
+statement error user root does not have CREATE privilege on relation tables
 ALTER TABLE information_schema.tables DROP COLUMN x
 
-statement error user root does not have CREATE privilege on table tables
+statement error user root does not have CREATE privilege on relation tables
 ALTER TABLE information_schema.tables ADD CONSTRAINT foo UNIQUE (b)
 
-statement error user root does not have CREATE privilege on table tables
+statement error user root does not have CREATE privilege on relation tables
 ALTER TABLE information_schema.tables DROP CONSTRAINT bar
 
-statement error user root does not have CREATE privilege on table tables
+statement error user root does not have CREATE privilege on relation tables
 ALTER TABLE information_schema.tables ALTER COLUMN x SET DEFAULT 'foo'
 
-statement error user root does not have CREATE privilege on table tables
+statement error user root does not have CREATE privilege on relation tables
 ALTER TABLE information_schema.tables ALTER x DROP NOT NULL
 
-statement error user root does not have CREATE privilege on table tables
+statement error user root does not have CREATE privilege on relation tables
 CREATE INDEX i on information_schema.tables (x)
 
-statement error user root does not have DROP privilege on table tables
+statement error user root does not have DROP privilege on relation tables
 DROP TABLE information_schema.tables
 
-statement error user root does not have CREATE privilege on table tables
+statement error user root does not have CREATE privilege on relation tables
 DROP INDEX information_schema.tables@i
 
-statement error user root does not have GRANT privilege on table tables
+statement error user root does not have GRANT privilege on relation tables
 GRANT CREATE ON information_schema.tables TO root
 
-statement error user root does not have GRANT privilege on table tables
+statement error user root does not have GRANT privilege on relation tables
 REVOKE CREATE ON information_schema.tables FROM root
 
 
 # Verify information_schema tables handles read-only property correctly.
 
-query error user root does not have DELETE privilege on table tables
+query error user root does not have DELETE privilege on relation tables
 DELETE FROM information_schema.tables
 
-query error user root does not have INSERT privilege on table tables
+query error user root does not have INSERT privilege on relation tables
 INSERT INTO information_schema.tables VALUES ('abc')
 
-statement error user root does not have UPDATE privilege on table tables
+statement error user root does not have UPDATE privilege on relation tables
 UPDATE information_schema.tables SET a = 'abc'
 
-statement error user root does not have DROP privilege on table tables
+statement error user root does not have DROP privilege on relation tables
 TRUNCATE TABLE information_schema.tables
 
 

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -1,6 +1,6 @@
 # LogicTest: default parallel-stmts
 
-statement error table "kv" does not exist
+statement error relation "kv" does not exist
 INSERT INTO kv VALUES ('a', 'b')
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -186,7 +186,7 @@ SELECT * FROM p1_0
 statement ok
 DROP TABLE p2 CASCADE
 
-statement error table "p0" does not exist
+statement error relation "p0" does not exist
 SELECT * FROM p0
 
 # Validation and descriptor bookkeeping
@@ -222,7 +222,7 @@ all_interleaves   CREATE TABLE all_interleaves (
                     FAMILY "primary" (b, c, d)
                   ) INTERLEAVE IN PARENT p1_1 (b)
 
-statement error table "missing" does not exist
+statement error relation "missing" does not exist
 CREATE TABLE err (f FLOAT PRIMARY KEY) INTERLEAVE IN PARENT missing (f)
 
 statement error interleaved columns must match parent

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -761,7 +761,7 @@ SELECT * FROM [EXPLAIN SELECT
 	   pkc.relname,
 	   con.conname,
 	   pos.n
-  ] WHERE type <> 'values' AND field <> 'size'
+  ] WHERE "Type" <> 'values' AND "Field" <> 'size'
 ----
 0   sort
 0              order     +pktable_schem,+pktable_name,+fk_name,+key_seq

--- a/pkg/sql/logictest/testdata/logic_test/multi_statement
+++ b/pkg/sql/logictest/testdata/logic_test/multi_statement
@@ -61,5 +61,5 @@ SELECT * from kv; ROLLBACK
 statement ok
 ROLLBACK
 
-statement error pq: table "system.t" does not exist
+statement error pq: relation "system.t" does not exist
 BEGIN TRANSACTION; SELECT * FROM system.t; INSERT INTO t(a) VALUES (1)

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -132,14 +132,14 @@ EXPLAIN(METADATA) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@f
 3          spans     ALL
 
 # Check the extended syntax cannot be used in case of renames.
-statement error table "test.kv" not selected in FROM clause
+statement error source name "kv" not found in FROM clause
 SELECT * FROM kv AS a, kv AS b ORDER BY PRIMARY KEY kv
 
 # The INDEX/PRIMARY syntax can only be used when the data source
 # is a real table, not an alias.
 #
-statement error table "test.kv" not selected in FROM clause
+statement error source name "kv" not found in FROM clause
 SELECT k FROM (SELECT @1, @1 FROM generate_series(1,10)) AS kv(k,v) ORDER BY PRIMARY KEY kv
 
-statement error table "test.kv" not selected in FROM clause
+statement error source name "kv" not found in FROM clause
 CREATE TABLE unrelated(x INT); SELECT * FROM unrelated ORDER BY PRIMARY KEY kv

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -135,7 +135,7 @@ numeric  numeric
 query error type 'foo.' does not exist
 SELECT 'foo.'::REGTYPE
 
-query error table "blah" does not exist
+query error relation "blah" does not exist
 SELECT 'blah'::REGCLASS
 
 query error unknown function: blah\(\)
@@ -222,7 +222,7 @@ SET DATABASE = otherdb
 
 user testuser
 
-query error table "a" does not exist
+query error relation "a" does not exist
 SELECT 'a'::regclass
 
 user root
@@ -260,5 +260,5 @@ SET DATABASE = thirddb
 # still exists in another database, the query does fail (regclass
 # does not automatically search in other dbs, even for the root user).
 
-query error table "a" does not exist
+query error relation "a" does not exist
 SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -186,7 +186,7 @@ hascase
 statement ok
 CREATE TABLE "quotedCase" (id INT PRIMARY KEY)
 
-query error relation 'quotedcase' does not exist
+query error relation "quotedcase" does not exist
 SELECT relname from pg_class where oid='quotedCase'::regclass
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/privileges_database
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_database
@@ -129,7 +129,7 @@ GRANT ALL ON DATABASE a TO bar
 statement ok
 REVOKE ALL ON DATABASE a FROM bar
 
-statement error user testuser does not have DROP privilege on table t
+statement error user testuser does not have DROP privilege on relation t
 DROP DATABASE a
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -57,40 +57,40 @@ SET DATABASE = a
 statement ok
 SHOW GRANTS ON t
 
-statement error pq: user testuser has no privileges on table t
+statement error pq: user testuser has no privileges on relation t
 SHOW COLUMNS FROM t
 
-statement error user testuser does not have GRANT privilege on table t
+statement error user testuser does not have GRANT privilege on relation t
 GRANT ALL ON t TO bar
 
-statement error user testuser does not have GRANT privilege on table t
+statement error user testuser does not have GRANT privilege on relation t
 REVOKE ALL ON t FROM bar
 
-statement error user testuser does not have INSERT privilege on table t
+statement error user testuser does not have INSERT privilege on relation t
 INSERT INTO t VALUES(1, 1),(2, 2)
 
-statement error user testuser does not have SELECT privilege on table t
+statement error user testuser does not have SELECT privilege on relation t
 SELECT * FROM t
 
 statement ok
 SELECT 1
 
-statement error user testuser does not have DELETE privilege on table t
+statement error user testuser does not have DELETE privilege on relation t
 DELETE FROM t
 
-statement error user testuser does not have DELETE privilege on table t
+statement error user testuser does not have DELETE privilege on relation t
 DELETE FROM t where k = 1
 
-statement error user testuser does not have UPDATE privilege on table t
+statement error user testuser does not have UPDATE privilege on relation t
 UPDATE t SET v = 0
 
-statement error user testuser does not have UPDATE privilege on table t
+statement error user testuser does not have UPDATE privilege on relation t
 UPDATE t SET v = 2 WHERE k = 2
 
-statement error user testuser does not have DROP privilege on table t
+statement error user testuser does not have DROP privilege on relation t
 TRUNCATE t
 
-statement error user testuser does not have DROP privilege on table t
+statement error user testuser does not have DROP privilege on relation t
 DROP TABLE t
 
 # Grant SELECT privilege.
@@ -107,13 +107,13 @@ SHOW COLUMNS FROM t
 k INT false NULL {primary}
 v INT true  NULL {}
 
-statement error user testuser does not have GRANT privilege on table t
+statement error user testuser does not have GRANT privilege on relation t
 GRANT ALL ON t TO bar
 
-statement error user testuser does not have GRANT privilege on table t
+statement error user testuser does not have GRANT privilege on relation t
 REVOKE ALL ON t FROM bar
 
-statement error user testuser does not have INSERT privilege on table t
+statement error user testuser does not have INSERT privilege on relation t
 INSERT INTO t VALUES(1, 1),(2, 2)
 
 statement ok
@@ -122,22 +122,22 @@ SELECT * FROM t
 statement ok
 SELECT 1
 
-statement error user testuser does not have DELETE privilege on table t
+statement error user testuser does not have DELETE privilege on relation t
 DELETE FROM t
 
-statement error user testuser does not have DELETE privilege on table t
+statement error user testuser does not have DELETE privilege on relation t
 DELETE FROM t where k = 1
 
-statement error user testuser does not have UPDATE privilege on table t
+statement error user testuser does not have UPDATE privilege on relation t
 UPDATE t SET v = 0
 
-statement error user testuser does not have UPDATE privilege on table t
+statement error user testuser does not have UPDATE privilege on relation t
 UPDATE t SET v = 2 WHERE k = 2
 
-statement error user testuser does not have DROP privilege on table t
+statement error user testuser does not have DROP privilege on relation t
 TRUNCATE t
 
-statement error user testuser does not have DROP privilege on table t
+statement error user testuser does not have DROP privilege on relation t
 DROP TABLE t
 
 # Grant all but SELECT privilege.
@@ -160,22 +160,22 @@ REVOKE ALL ON t FROM bar
 statement ok
 INSERT INTO t VALUES(1, 1),(2, 2)
 
-statement error user testuser does not have SELECT privilege on table t
+statement error user testuser does not have SELECT privilege on relation t
 SELECT * FROM t
 
 statement ok
 SELECT 1
 
-statement error user testuser does not have SELECT privilege on table t
+statement error user testuser does not have SELECT privilege on relation t
 DELETE FROM t
 
-statement error user testuser does not have SELECT privilege on table t
+statement error user testuser does not have SELECT privilege on relation t
 DELETE FROM t where k = 1
 
-statement error user testuser does not have SELECT privilege on table t
+statement error user testuser does not have SELECT privilege on relation t
 UPDATE t SET v = 0
 
-statement error user testuser does not have SELECT privilege on table t
+statement error user testuser does not have SELECT privilege on relation t
 UPDATE t SET v = 2 WHERE k = 2
 
 statement ok
@@ -242,7 +242,7 @@ user testuser
 statement ok
 INSERT INTO t VALUES (1, 2) ON CONFLICT (k) DO NOTHING
 
-statement error user testuser does not have UPDATE privilege on table t
+statement error user testuser does not have UPDATE privilege on relation t
 INSERT INTO t VALUES (1, 2) ON CONFLICT (k) DO UPDATE SET v = excluded.v
 
 # Grant UPDATE privilege (in addition to INSERT).
@@ -271,16 +271,16 @@ CREATE TABLE t (k INT PRIMARY KEY, v int)
 
 user testuser
 
-statement error user testuser has no privileges on table t
+statement error user testuser has no privileges on relation t
 SHOW COLUMNS FROM t
 
-statement error user testuser has no privileges on table t
+statement error user testuser has no privileges on relation t
 SHOW CREATE TABLE t
 
-statement error user testuser has no privileges on table t
+statement error user testuser has no privileges on relation t
 SHOW INDEX FROM t
 
-statement error user testuser has no privileges on table t
+statement error user testuser has no privileges on relation t
 SHOW CONSTRAINTS FROM t
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -49,7 +49,7 @@ id name  species
 
 user testuser
 
-statement error user testuser does not have CREATE privilege on table users
+statement error user testuser does not have CREATE privilege on relation users
 ALTER TABLE users RENAME COLUMN name TO username
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -34,7 +34,7 @@ SELECT * FROM kv
 statement ok
 ALTER DATABASE test RENAME TO u
 
-statement error table "kv" does not exist
+statement error relation "kv" does not exist
 SELECT * FROM kv
 ----
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -52,7 +52,7 @@ users  bar      true    2    name    ASC        false    false
 
 user testuser
 
-statement error user testuser does not have CREATE privilege on table users
+statement error user testuser does not have CREATE privilege on relation users
 ALTER INDEX users@bar RENAME TO rar
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -1,6 +1,6 @@
 # LogicTest: default parallel-stmts distsql
 
-statement error pgcode 42P01 table "foo" does not exist
+statement error pgcode 42P01 relation "foo" does not exist
 ALTER TABLE foo RENAME TO bar
 
 statement ok
@@ -29,7 +29,7 @@ kv
 statement ok
 ALTER TABLE kv RENAME TO new_kv
 
-statement error pgcode 42P01 table "kv" does not exist
+statement error pgcode 42P01 relation "kv" does not exist
 SELECT * FROM kv
 
 query II rowsort
@@ -72,7 +72,7 @@ ALTER TABLE t RENAME TO new_kv
 
 user testuser
 
-statement error user testuser does not have DROP privilege on table t
+statement error user testuser does not have DROP privilege on relation t
 ALTER TABLE test.t RENAME TO t2
 
 user root
@@ -156,5 +156,5 @@ ALTER TABLE test2.v1 RENAME TO test2.v2
 statement error pgcode 42809 "test2.v1" is not a table
 ALTER TABLE test2.v1 RENAME TO test2.v1
 
-statement error cannot rename table "test2.t2" because view "v1" depends on it
+statement error cannot rename relation "test2.t2" because view "v1" depends on it
 ALTER TABLE test2.t2 RENAME TO test2.t3

--- a/pkg/sql/logictest/testdata/logic_test/rename_view
+++ b/pkg/sql/logictest/testdata/logic_test/rename_view
@@ -1,6 +1,6 @@
 # LogicTest: default parallel-stmts distsql
 
-statement error pgcode 42P01 view "foo" does not exist
+statement error pgcode 42P01 relation "foo" does not exist
 ALTER VIEW foo RENAME TO bar
 
 statement ok
@@ -39,7 +39,7 @@ ALTER TABLE v RENAME TO new_v
 statement ok
 ALTER VIEW v RENAME TO new_v
 
-statement error pgcode 42P01 table "v" does not exist
+statement error pgcode 42P01 relation "v" does not exist
 SELECT * FROM v
 
 query II rowsort
@@ -86,7 +86,7 @@ ALTER VIEW v RENAME TO new_v
 
 user testuser
 
-statement error user testuser does not have DROP privilege on view v
+statement error user testuser does not have DROP privilege on relation v
 ALTER VIEW test.v RENAME TO v2
 
 user root
@@ -166,14 +166,14 @@ SELECT * FROM test2.v2
 statement ok
 CREATE VIEW v3 AS SELECT COUNT(*) FROM test2.v AS v JOIN test2.v2 AS v2 ON v.k > v2.c1
 
-statement error cannot rename view "test2.v" because view "test.v3" depends on it
+statement error cannot rename relation "test2.v" because view "test.v3" depends on it
 ALTER VIEW test2.v RENAME TO test2.v3
 
-statement error cannot rename view "test2.v2" because view "test.v3" depends on it
+statement error cannot rename relation "test2.v2" because view "test.v3" depends on it
 ALTER VIEW test2.v2 RENAME TO v4
 
 statement ok
 ALTER VIEW v3 RENAME TO v4
 
-statement error cannot rename view "test2.v2" because view "test.v4" depends on it
+statement error cannot rename relation "test2.v2" because view "test.v4" depends on it
 ALTER VIEW test2.v2 RENAME TO v5

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -170,7 +170,7 @@ k
 a
 
 query T
-SELECT "Foo"."V" FROM kv AS foo WHERE foo.k = 'a'
+SELECT "foo"."v" FROM kv AS foo WHERE foo.k = 'a'
 ----
 NULL
 

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -156,7 +156,7 @@ SELECT 1, * FROM nocols
 query error "kv.*" cannot be aliased
 SELECT kv.* AS foo FROM kv
 
-query error table "bar.kv" not selected in FROM clause
+query error source name "bar.kv" not found in FROM clause
 SELECT bar.kv.* FROM kv
 
 # Don't panic with invalid names (#8024)
@@ -281,7 +281,7 @@ SELECT xyzw.y FROM test.xyzw@foo WHERE z = 3
 ----
 2
 
-query error table "test.unknown" does not exist
+query error relation "test.unknown" does not exist
 SELECT z FROM test.unknown@foo WHERE y = 5
 
 query error index "unknown" not found

--- a/pkg/sql/logictest/testdata/logic_test/select_search_path
+++ b/pkg/sql/logictest/testdata/logic_test/select_search_path
@@ -52,7 +52,7 @@ SELECT COUNT(*) FROM numbers
 ----
 0
 
-query error pq: table "words" does not exist
+query error pq: relation "words" does not exist
 SELECT COUNT(*) FROM words
 
 query I
@@ -86,7 +86,7 @@ SELECT COUNT(DISTINCT(1)) FROM pg_tables
 statement ok
 SET DATABASE = t2
 
-query error pq: table "numbers" does not exist
+query error pq: relation "numbers" does not exist
 SELECT COUNT(*) FROM numbers
 
 query I

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -343,11 +343,11 @@ somesetting   somevalue
 
 user testuser
 
-statement error user testuser does not have SELECT privilege on table settings
+statement error user testuser does not have SELECT privilege on relation settings
 select name from system.settings
 ----
 
-statement error user testuser does not have INSERT privilege on table settings
+statement error user testuser does not have INSERT privilege on relation settings
 UPSERT INTO system.settings (name, value) VALUES ('somesetting', 'somevalueother')
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -127,7 +127,7 @@ SHOW COLUMNS FROM users
 query error database "foo" does not exist
 SHOW COLUMNS FROM foo.users
 
-query error table "test.users" does not exist
+query error relation "test.users" does not exist
 SHOW COLUMNS FROM test.users
 
 query error no database specified
@@ -136,7 +136,7 @@ SHOW INDEXES FROM users
 query error database "foo" does not exist
 SHOW INDEXES FROM foo.users
 
-query error table "test.users" does not exist
+query error relation "test.users" does not exist
 SHOW INDEXES FROM test.users
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -728,7 +728,7 @@ SELECT COUNT(*) FROM kv WHERE k = 'savepoint'
 statement ok
 BEGIN TRANSACTION; SAVEPOINT cockroach_restart
 
-statement error pq: table "bogus_name" does not exist
+statement error pq: relation "bogus_name" does not exist
 SELECT * from bogus_name
 
 query T
@@ -763,7 +763,7 @@ ROLLBACK
 statement ok
 BEGIN
 
-statement error pq: table "bogus_name" does not exist
+statement error pq: relation "bogus_name" does not exist
 SELECT * from bogus_name
 
 statement error SAVEPOINT COCKROACH_RESTART has not been used

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -55,11 +55,11 @@ CREATE USER ""
 
 user testuser
 
-statement error pq: user testuser does not have INSERT privilege on table users
+statement error pq: user testuser does not have INSERT privilege on relation users
 CREATE USER user4
 
-statement error pq: user testuser does not have INSERT privilege on table users
+statement error pq: user testuser does not have INSERT privilege on relation users
 UPSERT INTO system.users VALUES (user1, 'newpassword')
 
-statement error pq: user testuser does not have SELECT privilege on table users
+statement error pq: user testuser does not have SELECT privilege on relation users
 SHOW USERS

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -24,7 +24,7 @@ CREATE VIEW v3 (x) AS select a, b from t
 statement error pgcode 42601 CREATE VIEW specifies 3 column names, but data source has 2 columns
 CREATE VIEW v4 (x, y, z) AS select a, b from t
 
-statement error pgcode 42P01 table "dne" does not exist
+statement error pgcode 42P01 relation "dne" does not exist
 CREATE VIEW v5 AS select a, b from dne
 
 statement ok
@@ -156,13 +156,13 @@ SELECT * FROM t
 2 98
 3 97
 
-query error user testuser does not have SELECT privilege on view v1
+query error user testuser does not have SELECT privilege on relation v1
 SELECT * FROM v1
 
-query error user testuser does not have SELECT privilege on view v6
+query error user testuser does not have SELECT privilege on relation v6
 SELECT * FROM v6
 
-query error user testuser has no privileges on view v1
+query error user testuser has no privileges on relation v1
 SHOW CREATE VIEW v1
 
 user root
@@ -175,7 +175,7 @@ GRANT SELECT ON v1 TO testuser
 
 user testuser
 
-query error user testuser does not have SELECT privilege on table t
+query error user testuser does not have SELECT privilege on relation t
 SELECT * FROM t
 
 query II rowsort
@@ -185,7 +185,7 @@ SELECT * FROM v1
 2 98
 3 97
 
-query error user testuser does not have SELECT privilege on view v6
+query error user testuser does not have SELECT privilege on relation v6
 SELECT * FROM v6
 
 query TT
@@ -203,10 +203,10 @@ GRANT SELECT ON v6 TO testuser
 
 user testuser
 
-query error user testuser does not have SELECT privilege on table t
+query error user testuser does not have SELECT privilege on relation t
 SELECT * FROM t
 
-query error user testuser does not have SELECT privilege on view v1
+query error user testuser does not have SELECT privilege on relation v1
 SELECT * FROM v1
 
 query II rowsort
@@ -224,10 +224,10 @@ DROP TABLE v1
 statement error pgcode 42809 "t" is not a view
 DROP VIEW t
 
-statement error cannot drop view "v1" because view "v6" depends on it
+statement error cannot drop relation "v1" because view "v6" depends on it
 DROP VIEW v1
 
-statement error cannot drop view "v2" because view "test2.v1" depends on it
+statement error cannot drop relation "v2" because view "test2.v1" depends on it
 DROP VIEW v2
 
 statement ok
@@ -242,7 +242,7 @@ DROP VIEW v2
 statement ok
 DROP VIEW v1
 
-statement error pgcode 42P01 view "v1" does not exist
+statement error pgcode 42P01 relation "v1" does not exist
 DROP VIEW v1
 
 # Verify correct rejection of star expressions

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -390,7 +390,7 @@ SELECT sum (Caps15951. a) FROM Caps15951 GROUP BY b ORDER BY b
 6
 
 query R
-SELECT sum ("Caps15951". a) FROM "Caps15951" GROUP BY b ORDER BY b
+SELECT sum ("caps15951". a) FROM "caps15951" GROUP BY b ORDER BY b
 ----
 1
 3

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -2471,7 +2471,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 				// when creating tables - table names are normalized (downcased) unless
 				// they're double quoted.
 				if !hadQuotes {
-					s = ReNormalizeName(s)
+					s = Name(s).Normalize()
 				}
 				t := &NormalizableTableName{
 					TableNameReference: UnresolvedName{

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -197,6 +197,11 @@ func AsString(n NodeFormatter) string {
 	return AsStringWithFlags(n, FmtSimple)
 }
 
+// ErrString pretty prints a node to a string. Identifiers are not quoted.
+func ErrString(n NodeFormatter) string {
+	return AsStringWithFlags(n, FmtBareIdentifiers)
+}
+
 // Serialize pretty prints a node to a string using FmtParsable; it is
 // appropriate when we store expressions into strings that are later parsed back
 // into expressions.

--- a/pkg/sql/parser/name_part.go
+++ b/pkg/sql/parser/name_part.go
@@ -82,13 +82,6 @@ func (n Name) Normalize() string {
 	return norm.NFC.String(lower)
 }
 
-// ReNormalizeName performs the same work as NormalizeName but when
-// the string originates from the database. We define a different
-// function so as to be able to track usage of this function (cf. #8200).
-func ReNormalizeName(name string) string {
-	return Name(name).Normalize()
-}
-
 // ToStrings converts the name list to an array of regular strings.
 func (l NameList) ToStrings() []string {
 	if l == nil {

--- a/pkg/sql/parser/normalize_test.go
+++ b/pkg/sql/parser/normalize_test.go
@@ -20,26 +20,7 @@ import (
 	"testing"
 
 	"golang.org/x/net/context"
-
-	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
-
-func TestReNormalizeName(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	testCases := []struct {
-		in, expected string
-	}{
-		{"HELLO", "hello"},                            // Lowercase is the norm
-		{"ıİ", "ii"},                                  // Turkish/Azeri special cases
-		{"no\u0308rmalization", "n\u00f6rmalization"}, // NFD -> NFC.
-	}
-	for _, test := range testCases {
-		s := ReNormalizeName(test.in)
-		if test.expected != s {
-			t.Errorf("%s: expected %s, but found %s", test.in, test.expected, s)
-		}
-	}
-}
 
 func TestNormalizeExpr(t *testing.T) {
 	defer mockNameTypes(map[string]Type{

--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -486,7 +486,7 @@ func (s *Scanner) scanIdent(lval *sqlSymType) {
 	start := s.pos - 1
 	for ; isIdentMiddle(s.peek()); s.pos++ {
 	}
-	lval.str = ReNormalizeName(s.in[start:s.pos])
+	lval.str = Name(s.in[start:s.pos]).Normalize()
 	if id, ok := keywords[strings.ToUpper(lval.str)]; ok {
 		lval.id = id
 	} else {

--- a/pkg/sql/parser/table_name.go
+++ b/pkg/sql/parser/table_name.go
@@ -131,18 +131,6 @@ func (t *TableName) String() string { return AsString(t) }
 // NormalizeTableName implements the TableNameReference interface.
 func (t *TableName) NormalizeTableName() (*TableName, error) { return t, nil }
 
-// NormalizedTableName normalize DatabaseName and TableName to lowercase
-// and performs Unicode Normalization.
-func (t *TableName) NormalizedTableName() TableName {
-	return TableName{
-		PrefixName:                Name(t.PrefixName.Normalize()),
-		DatabaseName:              Name(t.DatabaseName.Normalize()),
-		TableName:                 Name(t.TableName.Normalize()),
-		DBNameOriginallyOmitted:   t.DBNameOriginallyOmitted,
-		PrefixOriginallySpecified: t.PrefixOriginallySpecified,
-	}
-}
-
 // Table retrieves the unqualified table name.
 func (t *TableName) Table() string {
 	return string(t.TableName)

--- a/pkg/sql/parser/table_name_test.go
+++ b/pkg/sql/parser/table_name_test.go
@@ -41,7 +41,7 @@ func TestNormalizeTableName(t *testing.T) {
 		{`foo`, ``, ``, `no database specified`},
 		{`foo@bar`, ``, ``, `syntax error`},
 		{`test.*`, ``, ``, `invalid table name: "test\.\*"`},
-		{`p."".bar`, ``, ``, `empty database name: "p.\\"\\".bar"`},
+		{`p."".bar`, ``, ``, `empty database name: "p\.\.bar"`},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/sql/parser/var_name.go
+++ b/pkg/sql/parser/var_name.go
@@ -19,6 +19,8 @@ package parser
 import (
 	"bytes"
 	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 )
 
 // Variable names are used in multiples places in SQL:
@@ -115,7 +117,7 @@ type AllColumnsSelector struct {
 
 // Format implements the NodeFormatter interface.
 func (a *AllColumnsSelector) Format(buf *bytes.Buffer, f FmtFlags) {
-	if a.TableName.DatabaseName != "" {
+	if !a.TableName.DBNameOriginallyOmitted {
 		FormatNode(buf, f, a.TableName.DatabaseName)
 		buf.WriteByte('.')
 	}
@@ -152,7 +154,7 @@ type ColumnItem struct {
 // Format implements the NodeFormatter interface.
 func (c *ColumnItem) Format(buf *bytes.Buffer, f FmtFlags) {
 	if c.TableName.TableName != "" {
-		if c.TableName.DatabaseName != "" {
+		if !c.TableName.DBNameOriginallyOmitted {
 			FormatNode(buf, f, c.TableName.DatabaseName)
 			buf.WriteByte('.')
 		}
@@ -188,6 +190,10 @@ func (c *ColumnItem) ResolvedType() Type {
 		return nil
 	}
 	return presetTypesForTesting[c.String()]
+}
+
+func newInvColRef(fmt string, args ...interface{}) error {
+	return pgerror.NewErrorf(pgerror.CodeInvalidColumnReferenceError, fmt, args...)
 }
 
 // NormalizeVarName normalizes a UnresolvedName for all the forms it can have
@@ -229,14 +235,14 @@ func (n UnresolvedName) NormalizeVarName() (VarName, error) {
 	// The element at position i - 1 must be the column name.
 	// (We don't support record types yet.)
 	if i == 0 {
-		return nil, fmt.Errorf("invalid column name: %q", n)
+		return nil, newInvColRef("invalid column name: %q", n)
 	}
 	colName, ok := n[i-1].(Name)
 	if !ok {
-		return nil, fmt.Errorf("invalid column name: %q", n[:i])
+		return nil, newInvColRef("invalid column name: %q", n[:i])
 	}
 	if len(colName) == 0 {
-		return nil, fmt.Errorf("empty column name: %q", n)
+		return nil, newInvColRef("empty column name: %q", n)
 	}
 
 	// Everything afterwards is the selector.
@@ -261,16 +267,16 @@ func (n UnresolvedName) NormalizeVarName() (VarName, error) {
 // column item (e.g. UPDATE LHS, INSERT, etc.).
 func (n UnresolvedName) NormalizeUnqualifiedColumnItem() (*ColumnItem, error) {
 	if len(n) == 0 {
-		return nil, fmt.Errorf("invalid column name: %q", n)
+		return nil, newInvColRef("invalid column name: %q", n)
 	}
 
 	colName, ok := n[0].(Name)
 	if !ok {
-		return nil, fmt.Errorf("invalid column name: %q", n)
+		return nil, newInvColRef("invalid column name: %q", n)
 	}
 
 	if colName == "" {
-		return nil, fmt.Errorf("empty column name: %q", n)
+		return nil, newInvColRef("empty column name: %q", n)
 	}
 
 	// Remainder is a selector.

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1097,7 +1097,7 @@ func TestPGPreparedExec(t *testing.T) {
 			"DROP TABLE d.t",
 			[]preparedExecTest{
 				baseTest,
-				baseTest.Error(`pq: table "d.t" does not exist`),
+				baseTest.Error(`pq: relation "d.t" does not exist`),
 			},
 		},
 		{

--- a/pkg/sql/rename.go
+++ b/pkg/sql/rename.go
@@ -267,8 +267,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *parser.RenameIndex) (planN
 		return nil, err
 	}
 
-	normIdxName := n.Index.Index.Normalize()
-	idx, _, err := tableDesc.FindIndexByName(n.Index.Index)
+	idx, _, err := tableDesc.FindIndexByName(string(n.Index.Index))
 	if err != nil {
 		if n.IfExists {
 			// Noop.
@@ -293,18 +292,17 @@ func (p *planner) RenameIndex(ctx context.Context, n *parser.RenameIndex) (planN
 	if n.NewName == "" {
 		return nil, errEmptyIndexName
 	}
-	normNewIdxName := n.NewName.Normalize()
 
-	if normIdxName == normNewIdxName {
+	if n.Index.Index == n.NewName {
 		// Noop.
 		return &emptyNode{}, nil
 	}
 
-	if _, _, err := tableDesc.FindIndexByName(n.NewName); err == nil {
-		return nil, fmt.Errorf("index name %q already exists", n.NewName)
+	if _, _, err := tableDesc.FindIndexByName(string(n.NewName)); err == nil {
+		return nil, fmt.Errorf("index name %q already exists", string(n.NewName))
 	}
 
-	tableDesc.RenameIndexDescriptor(idx, normNewIdxName)
+	tableDesc.RenameIndexDescriptor(idx, string(n.NewName))
 
 	if err := tableDesc.SetUpVersion(); err != nil {
 		return nil, err
@@ -350,8 +348,6 @@ func (p *planner) RenameColumn(ctx context.Context, n *parser.RenameColumn) (pla
 	if n.NewName == "" {
 		return nil, errEmptyColumnName
 	}
-	normNewColName := n.NewName.Normalize()
-	normColName := n.Name.Normalize()
 
 	col, _, err := tableDesc.FindColumnByName(n.Name)
 	// n.IfExists only applies to table, no need to check here.
@@ -372,7 +368,7 @@ func (p *planner) RenameColumn(ctx context.Context, n *parser.RenameColumn) (pla
 		}
 	}
 
-	if normColName == normNewColName {
+	if n.Name == n.NewName {
 		// Noop.
 		return &emptyNode{}, nil
 	}
@@ -388,7 +384,7 @@ func (p *planner) RenameColumn(ctx context.Context, n *parser.RenameColumn) (pla
 				return err, false, nil
 			}
 			if c, ok := v.(*parser.ColumnItem); ok {
-				if c.ColumnName.Normalize() == normColName {
+				if string(c.ColumnName) == string(n.Name) {
 					c.ColumnName = n.NewName
 				}
 			}
@@ -416,7 +412,7 @@ func (p *planner) RenameColumn(ctx context.Context, n *parser.RenameColumn) (pla
 		}
 	}
 	// Rename the column in the indexes.
-	tableDesc.RenameColumnDescriptor(col, normNewColName)
+	tableDesc.RenameColumnDescriptor(col, string(n.NewName))
 
 	if err := tableDesc.SetUpVersion(); err != nil {
 		return nil, err

--- a/pkg/sql/rename.go
+++ b/pkg/sql/rename.go
@@ -67,7 +67,7 @@ func (p *planner) RenameDatabase(ctx context.Context, n *parser.RenameDatabase) 
 	// are currently just stored as strings, they explicitly specify the database
 	// name. Rather than trying to rewrite them with the changed DB name, we
 	// simply disallow such renames for now.
-	tbNames, err := getTableNames(ctx, p.txn, p.getVirtualTabler(), dbDesc)
+	tbNames, err := getTableNames(ctx, p.txn, p.getVirtualTabler(), dbDesc, false)
 	if err != nil {
 		return nil, err
 	}
@@ -144,10 +144,10 @@ func (p *planner) RenameTable(ctx context.Context, n *parser.RenameTable) (planN
 				return &emptyNode{}, nil
 			}
 			// Key does not exist, but we want it to: error out.
-			return nil, sqlbase.NewUndefinedViewError(oldTn.String())
+			return nil, sqlbase.NewUndefinedRelationError(oldTn)
 		}
 		if tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
-			return nil, sqlbase.NewUndefinedViewError(oldTn.String())
+			return nil, sqlbase.NewUndefinedRelationError(oldTn)
 		}
 	} else {
 		tableDesc, err = getTableDesc(ctx, p.txn, p.getVirtualTabler(), oldTn)
@@ -160,10 +160,10 @@ func (p *planner) RenameTable(ctx context.Context, n *parser.RenameTable) (planN
 				return &emptyNode{}, nil
 			}
 			// Key does not exist, but we want it to: error out.
-			return nil, sqlbase.NewUndefinedTableError(oldTn.String())
+			return nil, sqlbase.NewUndefinedRelationError(oldTn)
 		}
 		if tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
-			return nil, sqlbase.NewUndefinedTableError(oldTn.String())
+			return nil, sqlbase.NewUndefinedRelationError(oldTn)
 		}
 	}
 

--- a/pkg/sql/rename_test.go
+++ b/pkg/sql/rename_test.go
@@ -229,7 +229,7 @@ CREATE TABLE test.t (a INT PRIMARY KEY);
 		t.Fatalf(`still have lease on "t"`)
 	}
 	if _, err := db.Exec("SELECT * FROM test.t"); !testutils.IsError(
-		err, `table "test.t" does not exist`) {
+		err, `relation "test.t" does not exist`) {
 		t.Fatal(err)
 	}
 	close(renameUnblocked)

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -205,12 +205,12 @@ func (n *scanNode) initTable(
 func (n *scanNode) lookupSpecifiedIndex(indexHints *parser.IndexHints) error {
 	if indexHints.Index != "" {
 		// Search index by name.
-		indexName := indexHints.Index.Normalize()
-		if indexName == parser.ReNormalizeName(n.desc.PrimaryIndex.Name) {
+		indexName := string(indexHints.Index)
+		if indexName == n.desc.PrimaryIndex.Name {
 			n.specifiedIndex = &n.desc.PrimaryIndex
 		} else {
 			for i := range n.desc.Indexes {
-				if indexName == parser.ReNormalizeName(n.desc.Indexes[i].Name) {
+				if indexName == n.desc.Indexes[i].Name {
 					n.specifiedIndex = &n.desc.Indexes[i]
 					break
 				}

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -117,7 +117,7 @@ func (p *planner) setClusterSetting(
 		if err != nil {
 			return nil, err
 		}
-		upsertQ := "UPSERT INTO system.settings (name, value, lastUpdated, valueType) VALUES ($1, $2, NOW(), $3)"
+		upsertQ := `UPSERT INTO system.settings (name, value, "lastUpdated", "valueType") VALUES ($1, $2, NOW(), $3)`
 		if _, err := ie.ExecuteStatementInTransaction(
 			ctx, "update-setting", p.txn, upsertQ, name, encoded, typ.Typ(),
 		); err != nil {

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -74,7 +74,7 @@ func checkTableExists(ctx context.Context, p *planner, tn *parser.TableName) err
 		return err
 	}
 	if len(values) == 0 {
-		return sqlbase.NewUndefinedTableError(tn.String())
+		return sqlbase.NewUndefinedRelationError(tn)
 	}
 	return nil
 }
@@ -95,7 +95,7 @@ func checkTablePrivileges(ctx context.Context, p *planner, tn *parser.TableName)
 		return err
 	}
 	if len(values) == 0 {
-		return fmt.Errorf("user %s has no privileges on table %s", p.session.User, tn.String())
+		return fmt.Errorf("user %s has no privileges on relation %s", p.session.User, tn.String())
 	}
 	return nil
 }
@@ -736,7 +736,7 @@ func (p *planner) ShowConstraints(
 
 	desc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
 	if err != nil {
-		return nil, err
+		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}
 	if err := p.anyPrivilege(desc); err != nil {
 		return nil, err

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -145,9 +145,9 @@ func (p *planner) orderBy(
 				// handles cases like:
 				//
 				//   SELECT a AS b FROM t ORDER BY b
-				target := c.ColumnName.Normalize()
+				target := string(c.ColumnName)
 				for j, col := range columns {
-					if parser.ReNormalizeName(col.Name) == target {
+					if col.Name == target {
 						if index != -1 {
 							// There is more than one render alias that matches the ORDER BY
 							// clause. Here, SQL92 is specific as to what should be done:
@@ -273,16 +273,15 @@ func (p *planner) rewriteIndexOrderings(
 			if err != nil {
 				return nil, err
 			}
-			normIdxName := o.Index.Normalize()
 			var idxDesc *sqlbase.IndexDescriptor
-			if normIdxName == "" || normIdxName == parser.ReNormalizeName(desc.PrimaryIndex.Name) {
+			if o.Index == "" || string(o.Index) == desc.PrimaryIndex.Name {
 				// ORDER BY PRIMARY KEY / ORDER BY INDEX t@primary
 				idxDesc = &desc.PrimaryIndex
 			} else {
 				// ORDER BY INDEX t@somename
 				// We need to search for the index with that name.
 				for i := range desc.Indexes {
-					if normIdxName == parser.ReNormalizeName(desc.Indexes[i].Name) {
+					if string(o.Index) == desc.Indexes[i].Name {
 						idxDesc = &desc.Indexes[i]
 						break
 					}

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -126,18 +126,14 @@ func IsUndefinedDatabaseError(err error) bool {
 	return errHasCode(err, pgerror.CodeInvalidCatalogNameError)
 }
 
-// NewUndefinedTableError creates an error that represents a missing database table.
-func NewUndefinedTableError(name string) error {
-	return pgerror.NewErrorf(pgerror.CodeUndefinedTableError, "table %q does not exist", name)
+// NewUndefinedRelationError creates an error that represents a missing database table or view.
+func NewUndefinedRelationError(name parser.NodeFormatter) error {
+	return pgerror.NewErrorf(pgerror.CodeUndefinedTableError,
+		"relation %q does not exist", parser.ErrString(name))
 }
 
-// NewUndefinedViewError creates an error that represents a missing database view.
-func NewUndefinedViewError(name string) error {
-	return pgerror.NewErrorf(pgerror.CodeUndefinedTableError, "view %q does not exist", name)
-}
-
-// IsUndefinedTableError returns true if the error is for an undefined table.
-func IsUndefinedTableError(err error) bool {
+// IsUndefinedRelationError returns true if the error is for an undefined table.
+func IsUndefinedRelationError(err error) bool {
 	return errHasCode(err, pgerror.CodeUndefinedTableError)
 }
 
@@ -152,8 +148,9 @@ func NewRelationAlreadyExistsError(name string) error {
 }
 
 // NewWrongObjectTypeError creates a wrong object type error.
-func NewWrongObjectTypeError(name, desiredObjType string) error {
-	return pgerror.NewErrorf(pgerror.CodeWrongObjectTypeError, "%q is not a %s", name, desiredObjType)
+func NewWrongObjectTypeError(name *parser.TableName, desiredObjType string) error {
+	return pgerror.NewErrorf(pgerror.CodeWrongObjectTypeError, "%q is not a %s",
+		parser.ErrString(name), desiredObjType)
 }
 
 // NewSyntaxError creates a syntax error.

--- a/pkg/sql/sqlbase/keys.go
+++ b/pkg/sql/sqlbase/keys.go
@@ -19,7 +19,6 @@ package sqlbase
 import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
@@ -27,12 +26,11 @@ import (
 // to generate the prefix key to use to scan over all of the names for the
 // specified parentID.
 func MakeNameMetadataKey(parentID ID, name string) roachpb.Key {
-	normName := parser.ReNormalizeName(name)
 	k := keys.MakeTablePrefix(uint32(NamespaceTable.ID))
 	k = encoding.EncodeUvarintAscending(k, uint64(NamespaceTable.PrimaryIndex.ID))
 	k = encoding.EncodeUvarintAscending(k, uint64(parentID))
 	if name != "" {
-		k = encoding.EncodeBytesAscending(k, []byte(normName))
+		k = encoding.EncodeBytesAscending(k, []byte(name))
 		k = keys.MakeFamilyKey(k, uint32(NamespaceTable.Columns[2].ID))
 	}
 	return k

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -191,7 +191,7 @@ func (desc *IndexDescriptor) allocateName(tableDesc *TableDescriptor) {
 	name := baseName
 
 	exists := func(name string) bool {
-		_, _, err := tableDesc.findIndexByNormalizedName(name)
+		_, _, err := tableDesc.FindIndexByName(name)
 		return err == nil
 	}
 	for i := 1; exists(name); i++ {
@@ -513,7 +513,7 @@ func (desc *TableDescriptor) AllocateIDs() error {
 			columnID = desc.NextColumnID
 			desc.NextColumnID++
 		}
-		columnNames[parser.ReNormalizeName(c.Name)] = columnID
+		columnNames[c.Name] = columnID
 		c.ID = columnID
 	}
 	for i := range desc.Columns {
@@ -638,7 +638,7 @@ func (desc *TableDescriptor) allocateIndexIDs(columnNames map[string]ColumnID) e
 				index.ColumnIDs = append(index.ColumnIDs, 0)
 			}
 			if index.ColumnIDs[j] == 0 {
-				index.ColumnIDs[j] = columnNames[parser.ReNormalizeName(colName)]
+				index.ColumnIDs[j] = columnNames[colName]
 			}
 		}
 
@@ -712,7 +712,7 @@ func (desc *TableDescriptor) allocateColumnFamilyIDs(columnNames map[string]Colu
 				family.ColumnIDs = append(family.ColumnIDs, 0)
 			}
 			if family.ColumnIDs[j] == 0 {
-				family.ColumnIDs[j] = columnNames[parser.ReNormalizeName(colName)]
+				family.ColumnIDs[j] = columnNames[colName]
 			}
 			columnsInFamilies[family.ColumnIDs[j]] = struct{}{}
 		}
@@ -1006,11 +1006,10 @@ func (desc *TableDescriptor) ValidateTable() error {
 			return fmt.Errorf("invalid column ID %d", column.ID)
 		}
 
-		normName := parser.ReNormalizeName(column.Name)
-		if _, ok := columnNames[normName]; ok {
+		if _, ok := columnNames[column.Name]; ok {
 			return fmt.Errorf("duplicate column name: %q", column.Name)
 		}
-		columnNames[normName] = column.ID
+		columnNames[column.Name] = column.ID
 
 		if other, ok := columnIDs[column.ID]; ok {
 			return fmt.Errorf("column %q duplicate ID of column %q: %d",
@@ -1079,11 +1078,10 @@ func (desc *TableDescriptor) validateColumnFamilies(
 			return nil, err
 		}
 
-		normName := parser.ReNormalizeName(family.Name)
-		if _, ok := familyNames[normName]; ok {
+		if _, ok := familyNames[family.Name]; ok {
 			return nil, fmt.Errorf("duplicate family name: %q", family.Name)
 		}
-		familyNames[normName] = struct{}{}
+		familyNames[family.Name] = struct{}{}
 
 		if other, ok := familyIDs[family.ID]; ok {
 			return nil, fmt.Errorf("family %q duplicate ID of family %q: %d",
@@ -1106,7 +1104,7 @@ func (desc *TableDescriptor) validateColumnFamilies(
 			if !ok {
 				return nil, fmt.Errorf("family %q contains unknown column \"%d\"", family.Name, colID)
 			}
-			if parser.ReNormalizeName(name) != parser.ReNormalizeName(family.ColumnNames[i]) {
+			if name != family.ColumnNames[i] {
 				return nil, fmt.Errorf("family %q column %d should have name %q, but found name %q",
 					family.Name, colID, name, family.ColumnNames[i])
 			}
@@ -1146,11 +1144,10 @@ func (desc *TableDescriptor) validateTableIndexes(
 			return fmt.Errorf("invalid index ID %d", index.ID)
 		}
 
-		normName := parser.ReNormalizeName(index.Name)
-		if _, ok := indexNames[normName]; ok {
+		if _, ok := indexNames[index.Name]; ok {
 			return fmt.Errorf("duplicate index name: %q", index.Name)
 		}
-		indexNames[normName] = struct{}{}
+		indexNames[index.Name] = struct{}{}
 
 		if other, ok := indexIDs[index.ID]; ok {
 			return fmt.Errorf("index %q duplicate ID of index %q: %d",
@@ -1177,7 +1174,7 @@ func (desc *TableDescriptor) validateTableIndexes(
 		}
 
 		for i, name := range index.ColumnNames {
-			colID, ok := columnNames[parser.ReNormalizeName(name)]
+			colID, ok := columnNames[name]
 			if !ok {
 				return fmt.Errorf("index %q contains unknown column %q", index.Name, name)
 			}
@@ -1305,9 +1302,8 @@ func (desc *TableDescriptor) AddColumnToFamilyMaybeCreate(
 ) error {
 	idx := int(-1)
 	if len(family) > 0 {
-		normName := parser.ReNormalizeName(family)
 		for i := range desc.Families {
-			if parser.ReNormalizeName(desc.Families[i].Name) == normName {
+			if desc.Families[i].Name == family {
 				idx = i
 				break
 			}
@@ -1387,7 +1383,7 @@ func (desc *TableDescriptor) FindActiveColumnsByNames(
 ) ([]ColumnDescriptor, error) {
 	cols := make([]ColumnDescriptor, len(names))
 	for i := range names {
-		c, err := desc.FindActiveColumnByName(names[i])
+		c, err := desc.FindActiveColumnByName(string(names[i]))
 		if err != nil {
 			return nil, err
 		}
@@ -1396,30 +1392,23 @@ func (desc *TableDescriptor) FindActiveColumnsByNames(
 	return cols, nil
 }
 
-// findColumnByNormalizedName finds the column with the specified name.
-func (desc *TableDescriptor) findColumnByNormalizedName(
-	normName string,
-) (ColumnDescriptor, bool, error) {
+// FindColumnByName finds the column with the specified name. It returns
+// an active column or a column from the mutation list. It returns true
+// if the column is being dropped.
+func (desc *TableDescriptor) FindColumnByName(name parser.Name) (ColumnDescriptor, bool, error) {
 	for i, c := range desc.Columns {
-		if parser.ReNormalizeName(c.Name) == normName {
+		if c.Name == string(name) {
 			return desc.Columns[i], false, nil
 		}
 	}
 	for _, m := range desc.Mutations {
 		if c := m.GetColumn(); c != nil {
-			if parser.ReNormalizeName(c.Name) == normName {
+			if c.Name == string(name) {
 				return *c, m.Direction == DescriptorMutation_DROP, nil
 			}
 		}
 	}
-	return ColumnDescriptor{}, false, fmt.Errorf("column %q does not exist", normName)
-}
-
-// FindColumnByName finds the column with the specified name. It returns
-// an active column or a column from the mutation list. It returns true
-// if the column is being dropped.
-func (desc *TableDescriptor) FindColumnByName(name parser.Name) (ColumnDescriptor, bool, error) {
-	return desc.findColumnByNormalizedName(name.Normalize())
+	return ColumnDescriptor{}, false, fmt.Errorf("column %q does not exist", name)
 }
 
 // UpdateColumnDescriptor updates an existing column descriptor.
@@ -1440,21 +1429,14 @@ func (desc *TableDescriptor) UpdateColumnDescriptor(column ColumnDescriptor) {
 	panic(fmt.Sprintf("column %q does not exist", column.Name))
 }
 
-// FindActiveColumnByNormalizedName finds an active column with the specified normalized name.
-func (desc *TableDescriptor) FindActiveColumnByNormalizedName(
-	normName string,
-) (ColumnDescriptor, error) {
+// FindActiveColumnByName finds an active column with the specified name.
+func (desc *TableDescriptor) FindActiveColumnByName(name string) (ColumnDescriptor, error) {
 	for _, c := range desc.Columns {
-		if parser.ReNormalizeName(c.Name) == normName {
+		if c.Name == name {
 			return c, nil
 		}
 	}
-	return ColumnDescriptor{}, fmt.Errorf("column %q does not exist", normName)
-}
-
-// FindActiveColumnByName calls FindActiveColumnByNormalizedName on a normalized argument.
-func (desc *TableDescriptor) FindActiveColumnByName(name parser.Name) (ColumnDescriptor, error) {
-	return desc.FindActiveColumnByNormalizedName(name.Normalize())
+	return ColumnDescriptor{}, fmt.Errorf("column %q does not exist", name)
 }
 
 // FindColumnByID finds the column with specified ID.
@@ -1494,29 +1476,22 @@ func (desc *TableDescriptor) FindFamilyByID(id FamilyID) (*ColumnFamilyDescripto
 	return nil, fmt.Errorf("family-id \"%d\" does not exist", id)
 }
 
-// findIndexByNormalizedName finds the index with the specified name.
-func (desc *TableDescriptor) findIndexByNormalizedName(
-	normName string,
-) (IndexDescriptor, bool, error) {
+// FindIndexByName finds the index with the specified name in the active
+// list or the mutations list. It returns true if the index is being dropped.
+func (desc *TableDescriptor) FindIndexByName(name string) (IndexDescriptor, bool, error) {
 	for i, idx := range desc.Indexes {
-		if parser.ReNormalizeName(idx.Name) == normName {
+		if idx.Name == name {
 			return desc.Indexes[i], false, nil
 		}
 	}
 	for _, m := range desc.Mutations {
 		if idx := m.GetIndex(); idx != nil {
-			if parser.ReNormalizeName(idx.Name) == normName {
+			if idx.Name == name {
 				return *idx, m.Direction == DescriptorMutation_DROP, nil
 			}
 		}
 	}
-	return IndexDescriptor{}, false, fmt.Errorf("index %q does not exist", normName)
-}
-
-// FindIndexByName finds the index with the specified name in the active
-// list or the mutations list. It returns true if the index is being dropped.
-func (desc *TableDescriptor) FindIndexByName(name parser.Name) (IndexDescriptor, bool, error) {
-	return desc.findIndexByNormalizedName(name.Normalize())
+	return IndexDescriptor{}, false, fmt.Errorf("index %q does not exist", name)
 }
 
 // RenameIndexDescriptor renames an index descriptor.

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -635,7 +635,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			}},
 		},
 		{
-			err: `missing fk back reference to foo.bar from baz.qux`,
+			err: `missing fk back reference to "foo"@"bar" from "baz"@"qux"`,
 			desc: TableDescriptor{
 				ID:   51,
 				Name: "foo",
@@ -679,7 +679,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			}},
 		},
 		{
-			err: `broken fk backward reference from foo.bar to baz.qux`,
+			err: `broken fk backward reference from "foo"@"bar" to "baz"@"qux"`,
 			desc: TableDescriptor{
 				ID:   51,
 				Name: "foo",
@@ -730,7 +730,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			}},
 		},
 		{
-			err: `missing interleave back reference to foo.bar from baz.qux`,
+			err: `missing interleave back reference to "foo"@"bar" from "baz"@"qux"`,
 			desc: TableDescriptor{
 				ID:   51,
 				Name: "foo",
@@ -776,7 +776,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			}},
 		},
 		{
-			err: `broken interleave backward reference from foo.bar to baz.qux`,
+			err: `broken interleave backward reference from "foo"@"bar" to "baz"@"qux"`,
 			desc: TableDescriptor{
 				ID:   51,
 				Name: "foo",

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -315,7 +315,7 @@ func (tc *TableCollection) getTableVersion(
 	// continue to use N to refer to X even if N is renamed during the
 	// transaction.
 	for _, table := range tc.tables {
-		if parser.ReNormalizeName(table.Name) == tn.TableName.Normalize() &&
+		if table.Name == string(tn.TableName) &&
 			table.ParentID == dbID {
 			if log.V(2) {
 				log.Infof(ctx, "found table in table collection for table '%s'", tn)
@@ -623,7 +623,7 @@ func (p *planner) getQualifiedTableName(
 func (p *planner) findTableContainingIndex(
 	ctx context.Context, txn *client.Txn, vt VirtualTabler, dbName parser.Name, idxName parser.Name,
 ) (result *parser.TableName, err error) {
-	dbDesc, err := MustGetDatabaseDesc(ctx, txn, vt, dbName.Normalize())
+	dbDesc, err := MustGetDatabaseDesc(ctx, txn, vt, string(dbName))
 	if err != nil {
 		return nil, err
 	}
@@ -633,7 +633,6 @@ func (p *planner) findTableContainingIndex(
 		return nil, err
 	}
 
-	normName := idxName.Normalize()
 	result = nil
 	for i := range tns {
 		tn := &tns[i]
@@ -643,18 +642,18 @@ func (p *planner) findTableContainingIndex(
 		if err != nil {
 			return nil, err
 		}
-		_, dropped, err := tableDesc.FindIndexByName(idxName)
+		_, dropped, err := tableDesc.FindIndexByName(string(idxName))
 		if err != nil || dropped {
 			continue
 		}
 		if result != nil {
 			return nil, fmt.Errorf("index name %q is ambiguous (found in %s and %s)",
-				normName, tn.String(), result.String())
+				idxName, tn.String(), result.String())
 		}
 		result = tn
 	}
 	if result == nil {
-		return nil, fmt.Errorf("index %q does not exist", normName)
+		return nil, fmt.Errorf("index %q does not exist", idxName)
 	}
 	return result, nil
 }
@@ -721,7 +720,7 @@ func (p *planner) getTableAndIndex(
 	if tableWithIndex == nil {
 		index = tableDesc.PrimaryIndex
 	} else {
-		idx, dropped, err := tableDesc.FindIndexByName(tableWithIndex.Index)
+		idx, dropped, err := tableDesc.FindIndexByName(string(tableWithIndex.Index))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -105,7 +105,7 @@ func getTableOrViewDesc(
 ) (*sqlbase.TableDescriptor, error) {
 	virtual, err := vt.getVirtualTableDesc(tn)
 	if err != nil || virtual != nil {
-		if sqlbase.IsUndefinedTableError(err) {
+		if sqlbase.IsUndefinedRelationError(err) {
 			return nil, nil
 		}
 		return virtual, err
@@ -141,7 +141,7 @@ func getTableDesc(
 		return desc, err
 	}
 	if desc != nil && !desc.IsTable() {
-		return nil, sqlbase.NewWrongObjectTypeError(tn.String(), "table")
+		return nil, sqlbase.NewWrongObjectTypeError(tn, "table")
 	}
 	return desc, nil
 }
@@ -159,7 +159,7 @@ func getViewDesc(
 		return desc, err
 	}
 	if desc != nil && !desc.IsView() {
-		return nil, sqlbase.NewWrongObjectTypeError(tn.String(), "view")
+		return nil, sqlbase.NewWrongObjectTypeError(tn, "view")
 	}
 	return desc, nil
 }
@@ -175,7 +175,7 @@ func mustGetTableOrViewDesc(
 		return nil, err
 	}
 	if desc == nil {
-		return nil, sqlbase.NewUndefinedTableError(tn.String())
+		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}
 	if err := filterTableState(desc); err != nil {
 		if !allowAdding && err != errTableAdding {
@@ -196,7 +196,7 @@ func mustGetTableDesc(
 		return nil, err
 	}
 	if desc == nil {
-		return nil, sqlbase.NewUndefinedTableError(tn.String())
+		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}
 	if err := filterTableState(desc); err != nil {
 		if !allowAdding && err != errTableAdding {
@@ -216,7 +216,7 @@ func mustGetViewDesc(
 		return nil, err
 	}
 	if desc == nil {
-		return nil, sqlbase.NewUndefinedViewError(tn.String())
+		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}
 	if err := filterTableState(desc); err != nil {
 		return nil, err
@@ -329,7 +329,7 @@ func (tc *TableCollection) getTableVersion(
 		if err == sqlbase.ErrDescriptorNotFound {
 			// Transform the descriptor error into an error that references the
 			// table's name.
-			return nil, sqlbase.NewUndefinedTableError(tn.String())
+			return nil, sqlbase.NewUndefinedRelationError(tn)
 		}
 		return nil, err
 	}
@@ -383,7 +383,8 @@ func (tc *TableCollection) getTableVersionByID(
 		if err == sqlbase.ErrDescriptorNotFound {
 			// Transform the descriptor error into an error that references the
 			// table's ID.
-			return nil, sqlbase.NewUndefinedTableError(fmt.Sprintf("<id=%d>", tableID))
+			return nil, sqlbase.NewUndefinedRelationError(
+				&parser.TableRef{TableID: int64(tableID)})
 		}
 		return nil, err
 	}
@@ -414,10 +415,14 @@ func (tc *TableCollection) releaseTables(ctx context.Context) {
 // getTableNames retrieves the list of qualified names of tables
 // present in the given database.
 func getTableNames(
-	ctx context.Context, txn *client.Txn, vt VirtualTabler, dbDesc *sqlbase.DatabaseDescriptor,
+	ctx context.Context,
+	txn *client.Txn,
+	vt VirtualTabler,
+	dbDesc *sqlbase.DatabaseDescriptor,
+	dbNameOriginallyOmitted bool,
 ) (parser.TableNames, error) {
 	if e, ok := vt.getVirtualSchemaEntry(dbDesc.Name); ok {
-		return e.tableNames(), nil
+		return e.tableNames(dbNameOriginallyOmitted), nil
 	}
 
 	prefix := sqlbase.MakeNameMetadataKey(dbDesc.ID, "")
@@ -434,8 +439,9 @@ func getTableNames(
 			return nil, err
 		}
 		tn := parser.TableName{
-			DatabaseName: parser.Name(dbDesc.Name),
-			TableName:    parser.Name(tableName),
+			DatabaseName:            parser.Name(dbDesc.Name),
+			TableName:               parser.Name(tableName),
+			DBNameOriginallyOmitted: dbNameOriginallyOmitted,
 		}
 		tableNames = append(tableNames, tn)
 	}
@@ -538,7 +544,7 @@ func expandTableGlob(
 		return nil, err
 	}
 
-	tableNames, err := getTableNames(ctx, txn, vt, dbDesc)
+	tableNames, err := getTableNames(ctx, txn, vt, dbDesc, glob.DBNameOriginallyOmitted)
 	if err != nil {
 		return nil, err
 	}
@@ -566,7 +572,7 @@ func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *parser.Table
 	if p.session.Database != "" {
 		t.DatabaseName = parser.Name(p.session.Database)
 		desc, err := descFunc(ctx, p.txn, p.getVirtualTabler(), &t)
-		if err != nil && !sqlbase.IsUndefinedTableError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
+		if err != nil && !sqlbase.IsUndefinedRelationError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
 			return err
 		}
 		if desc != nil {
@@ -581,7 +587,7 @@ func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *parser.Table
 	for _, database := range p.session.SearchPath {
 		t.DatabaseName = parser.Name(database)
 		desc, err := descFunc(ctx, p.txn, p.getVirtualTabler(), &t)
-		if err != nil && !sqlbase.IsUndefinedTableError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
+		if err != nil && !sqlbase.IsUndefinedRelationError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
 			return err
 		}
 		if desc != nil {
@@ -591,7 +597,7 @@ func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *parser.Table
 		}
 	}
 
-	return sqlbase.NewUndefinedTableError(string(t.TableName))
+	return sqlbase.NewUndefinedRelationError(&t)
 }
 
 // getQualifiedTableName returns the database-qualified name of the table
@@ -622,7 +628,7 @@ func (p *planner) findTableContainingIndex(
 		return nil, err
 	}
 
-	tns, err := getTableNames(ctx, txn, vt, dbDesc)
+	tns, err := getTableNames(ctx, txn, vt, dbDesc, false)
 	if err != nil {
 		return nil, err
 	}
@@ -704,7 +710,7 @@ func (p *planner) getTableAndIndex(
 		return nil, nil, err
 	}
 	if tableDesc == nil {
-		return nil, nil, sqlbase.NewUndefinedTableError(tn.String())
+		return nil, nil, sqlbase.NewUndefinedRelationError(tn)
 	}
 	if err := p.CheckPrivilege(tableDesc, privilege); err != nil {
 		return nil, nil, err

--- a/pkg/sql/table_ref_test.go
+++ b/pkg/sql/table_ref_test.go
@@ -90,7 +90,7 @@ ALTER TABLE test.t DROP COLUMN xx;
 		{fmt.Sprintf("[%d(%d, %d, %d)] as t", tID, cID, bID, aID), `(c, d, p)`, ``},
 		{fmt.Sprintf("[%d(%d, %d, %d)] as t(c, b, a)", tID, cID, bID, aID), `(c, b, a)`, ``},
 		{fmt.Sprintf("[%d()] as t", tID), `()`, ``},
-		{`[666()] as t`, ``, `pq: table "<id=666>" does not exist`},
+		{`[666()] as t`, ``, `pq: relation "[666]" does not exist`},
 		{fmt.Sprintf("[%d(666)] as t", tID), ``, `pq: column 666 does not exist`},
 		{fmt.Sprintf("test.t@[%d]", pkID), `(p, d, c)`, ``},
 		{fmt.Sprintf("test.t@[%d]", secID), `(p, d, c)`, ``},

--- a/pkg/sql/table_ref_test.go
+++ b/pkg/sql/table_ref_test.go
@@ -105,7 +105,7 @@ ALTER TABLE test.t DROP COLUMN xx;
 	}
 
 	for i, d := range testData {
-		sql := "SELECT Columns FROM [EXPLAIN(METADATA) SELECT * FROM " + d.tableExpr + "]"
+		sql := `SELECT "Columns" FROM [EXPLAIN(METADATA) SELECT * FROM ` + d.tableExpr + "]"
 		var columns string
 		if err := db.QueryRow(sql).Scan(&columns); err != nil {
 			if d.expectedError != "" {

--- a/pkg/sql/table_split_test.go
+++ b/pkg/sql/table_split_test.go
@@ -46,7 +46,7 @@ func TestSplitAtTableBoundary(t *testing.T) {
 
 	const tableIDQuery = `
 SELECT tables.id FROM system.namespace tables
-  JOIN system.namespace dbs ON dbs.id = tables.parentid
+  JOIN system.namespace dbs ON dbs.id = tables."parentID"
   WHERE dbs.name = $1 AND tables.name = $2
 `
 	var tableID uint32

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1337,7 +1337,7 @@ func TestDistSQLRetryableError(t *testing.T) {
 	}
 
 	// Let's make sure that DISTSQL will actually be used.
-	row := txn.QueryRow("SELECT automatic FROM [EXPLAIN (DISTSQL) SELECT COUNT(1) FROM t]")
+	row := txn.QueryRow(`SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT COUNT(1) FROM t]`)
 	var automatic bool
 	if err := row.Scan(&automatic); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -207,7 +207,7 @@ func upsertExprsAndIndex(
 			return false
 		}
 		for i, colName := range index.ColumnNames {
-			if parser.ReNormalizeName(colName) != onConflict.Columns[i].Normalize() {
+			if colName != string(onConflict.Columns[i]) {
 				return false
 			}
 		}

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -40,7 +40,7 @@ func GetUserHashedPassword(
 	if err := executor.cfg.DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		p := makeInternalPlanner("get-pwd", txn, security.RootUser, metrics)
 		defer finishInternalPlanner(p)
-		const getHashedPassword = `SELECT hashedPassword FROM system.users ` +
+		const getHashedPassword = `SELECT "hashedPassword" FROM system.users ` +
 			`WHERE username=$1`
 		values, err := p.QueryRow(ctx, getHashedPassword, normalizedUsername)
 		if err != nil {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -191,14 +191,14 @@ var varGen = map[string]sessionVar{
 			if err != nil {
 				return err
 			}
-			switch parser.Name(s).Normalize() {
-			case parser.ReNormalizeName("off"):
+			switch strings.ToLower(s) {
+			case "off":
 				session.DistSQLMode = DistSQLOff
-			case parser.ReNormalizeName("on"):
+			case "on":
 				session.DistSQLMode = DistSQLOn
-			case parser.ReNormalizeName("auto"):
+			case "auto":
 				session.DistSQLMode = DistSQLAuto
-			case parser.ReNormalizeName("always"):
+			case "always":
 				session.DistSQLMode = DistSQLAlways
 			default:
 				return fmt.Errorf("set distsql: \"%s\" not supported", s)
@@ -244,7 +244,7 @@ var varGen = map[string]sessionVar{
 				if s == pgCatalogName {
 					foundPgCatalog = true
 				}
-				newSearchPath[i] = parser.Name(s).Normalize()
+				newSearchPath[i] = s
 			}
 			if !foundPgCatalog {
 				// "The system catalog schema, pg_catalog, is always searched,
@@ -281,7 +281,7 @@ var varGen = map[string]sessionVar{
 			if err != nil {
 				return err
 			}
-			if parser.Name(s).Normalize() != parser.ReNormalizeName("on") {
+			if strings.ToLower(s) != "on" {
 				return fmt.Errorf("set standard_conforming_strings: \"%s\" not supported", s)
 			}
 

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -80,12 +80,13 @@ type virtualSchemaEntry struct {
 	orderedTableNames []string
 }
 
-func (e virtualSchemaEntry) tableNames() parser.TableNames {
+func (e virtualSchemaEntry) tableNames(dbNameOriginallyOmitted bool) parser.TableNames {
 	var res parser.TableNames
 	for _, tableName := range e.orderedTableNames {
 		tn := parser.TableName{
-			DatabaseName: parser.Name(e.desc.Name),
-			TableName:    parser.Name(tableName),
+			DatabaseName:            parser.Name(e.desc.Name),
+			TableName:               parser.Name(tableName),
+			DBNameOriginallyOmitted: dbNameOriginallyOmitted,
 		}
 		res = append(res, tn)
 	}
@@ -241,7 +242,7 @@ func (vs *virtualSchemaHolder) getVirtualTableEntry(
 		if t, ok := db.tables[tn.TableName.Normalize()]; ok {
 			return t, nil
 		}
-		return virtualTableEntry{}, sqlbase.NewUndefinedTableError(tn.String())
+		return virtualTableEntry{}, sqlbase.NewUndefinedRelationError(tn)
 	}
 	return virtualTableEntry{}, nil
 }

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -238,8 +238,8 @@ func (e *Executor) IsVirtualDatabase(name string) bool {
 func (vs *virtualSchemaHolder) getVirtualTableEntry(
 	tn *parser.TableName,
 ) (virtualTableEntry, error) {
-	if db, ok := vs.getVirtualSchemaEntry(tn.DatabaseName.Normalize()); ok {
-		if t, ok := db.tables[tn.TableName.Normalize()]; ok {
+	if db, ok := vs.getVirtualSchemaEntry(string(tn.DatabaseName)); ok {
+		if t, ok := db.tables[string(tn.TableName)]; ok {
 			return t, nil
 		}
 		return virtualTableEntry{}, sqlbase.NewUndefinedRelationError(tn)

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -157,7 +157,7 @@ func (n *windowNode) constructWindowDefinitions(
 	// Process each named window specification on the select clause.
 	namedWindowSpecs := make(map[string]*parser.WindowDef, len(sc.Window))
 	for _, windowDef := range sc.Window {
-		name := windowDef.Name.Normalize()
+		name := string(windowDef.Name)
 		if _, ok := namedWindowSpecs[name]; ok {
 			return errors.Errorf("window %q is already defined", name)
 		}
@@ -229,12 +229,12 @@ func constructWindowDef(
 	case def.RefName != "":
 		// SELECT rank() OVER (w) FROM t WINDOW w as (...)
 		// We copy the referenced window specification, and modify it if necessary.
-		refName = def.RefName.Normalize()
+		refName = string(def.RefName)
 		modifyRef = true
 	case def.Name != "":
 		// SELECT rank() OVER w FROM t WINDOW w as (...)
 		// We use the referenced window specification directly, without modification.
-		refName = def.Name.Normalize()
+		refName = string(def.Name)
 	}
 	if refName == "" {
 		return def, nil

--- a/pkg/storage/log.go
+++ b/pkg/storage/log.go
@@ -45,7 +45,7 @@ func (s *Store) insertRangeLogEvent(
 
 	const insertEventTableStmt = `
 INSERT INTO system.rangelog (
-  timestamp, rangeID, storeID, eventType, otherRangeID, info
+  timestamp, "rangeID", "storeID", "eventType", "otherRangeID", info
 )
 VALUES(
   $1, $2, $3, $4, $5, $6

--- a/pkg/storage/log_test.go
+++ b/pkg/storage/log_test.go
@@ -46,7 +46,7 @@ func TestLogSplits(t *testing.T) {
 	countSplits := func() int {
 		var count int
 		err := db.QueryRowContext(ctx,
-			`SELECT COUNT(*) FROM system.rangelog WHERE eventType = $1`,
+			`SELECT COUNT(*) FROM system.rangelog WHERE "eventType" = $1`,
 			storage.RangeLogEventType_split.String()).Scan(&count)
 		if err != nil {
 			t.Fatal(err)
@@ -77,7 +77,7 @@ func TestLogSplits(t *testing.T) {
 	// verify that RangeID always increases (a good way to see that the splits
 	// are logged correctly)
 	rows, err := db.QueryContext(ctx,
-		`SELECT rangeID, otherRangeID, info FROM system.rangelog WHERE eventType = $1`,
+		`SELECT "rangeID", "otherRangeID", info FROM system.rangelog WHERE "eventType" = $1`,
 		storage.RangeLogEventType_split.String(),
 	)
 	if err != nil {
@@ -191,7 +191,7 @@ func TestLogRebalances(t *testing.T) {
 
 	// verify that two add replica events have been logged.
 	rows, err := sqlDB.QueryContext(ctx,
-		`SELECT rangeID, info FROM system.rangelog WHERE eventType = $1`,
+		`SELECT "rangeID", info FROM system.rangelog WHERE "eventType" = $1`,
 		storage.RangeLogEventType_add.String(),
 	)
 	if err != nil {
@@ -235,7 +235,7 @@ func TestLogRebalances(t *testing.T) {
 
 	// verify that one remove replica event was logged.
 	rows, err = sqlDB.QueryContext(ctx,
-		`SELECT rangeID, info FROM system.rangelog WHERE eventType = $1`,
+		`SELECT "rangeID", info FROM system.rangelog WHERE "eventType" = $1`,
 		storage.RangeLogEventType_remove.String(),
 	)
 	if err != nil {

--- a/pkg/testutils/sqlutils/table_id.go
+++ b/pkg/testutils/sqlutils/table_id.go
@@ -23,7 +23,7 @@ import (
 // QueryDatabaseID returns the database ID of the specified database using the
 // system.namespace table.
 func QueryDatabaseID(sqlDB *gosql.DB, dbName string) (uint32, error) {
-	dbIDQuery := `SELECT id FROM system.namespace WHERE name = $1 AND parentID = 0`
+	dbIDQuery := `SELECT id FROM system.namespace WHERE name = $1 AND "parentID" = 0`
 	var dbID uint32
 	result := sqlDB.QueryRow(dbIDQuery, dbName)
 	if err := result.Scan(&dbID); err != nil {
@@ -37,7 +37,7 @@ func QueryDatabaseID(sqlDB *gosql.DB, dbName string) (uint32, error) {
 func QueryTableID(sqlDB *gosql.DB, dbName, tableName string) (uint32, error) {
 	tableIDQuery := `
  SELECT tables.id FROM system.namespace tables
-   JOIN system.namespace dbs ON dbs.id = tables.parentid
+   JOIN system.namespace dbs ON dbs.id = tables."parentID"
    WHERE dbs.name = $1 AND tables.name = $2
  `
 	var tableID uint32


### PR DESCRIPTION
### sql: sanitize the production of error message for tables/views

- use the same word "relation" for tables and views for permission
  errors and "descriptor does not exist" errors, for consistency with
  the existing "already exists" message that already uses the word
  "relation".

- ensure that names containing special characters are not
  doubly quoted in the error message.

### sql: make table and view lookups properly case-sensitive

An earlier change introduced pre-normalization of descriptor names
upon descriptor creation, thereby aiming for two goals:

- normalize descriptor names upon creation of the descriptor, so as to
  avoid the time overhead of re-normalizing the name on every access;

- creating a distinction, like one exists in postgres, between
  descriptors created with the syntax `"A"` and the syntax `A` - the
  latter is normalized, the former is not. This makes case sensitivity
  opt-in for client applications.

Unfortunately, prior to this patch, most SQL statements also used a
case-insensitive *lookup* of database/table/view/column names from
storage, preventing the aforementioned benefits.

This patch completes the earlier change by making name lookups
case-sensitive. An exhaustive set of tests is modified/introduced to confirm
that the change is invisible to most common use cases -- i.e. as long
as client apps were not double quoting their identifiers.

Fixes #8862.
Fixes #16858.