### PR TITLE
storage: Deflake TestSplitSnapshotRace_SnapshotWins

### DIFF
--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1166,6 +1166,17 @@ func runSetupSplitSnapshotRace(
 	// Store 3 still has the old value, but 4 and 5 are up to date.
 	mtc.waitForValues(rightKey, []int64{0, 0, 0, 2, 5, 5})
 
+	// Scan the meta ranges to resolve all intents
+	if _, pErr := client.SendWrapped(context.Background(), mtc.distSenders[0],
+		&roachpb.ScanRequest{
+			Span: roachpb.Span{
+				Key:    keys.MetaMin,
+				EndKey: keys.MetaMax,
+			},
+		}); pErr != nil {
+		t.Fatal(pErr)
+	}
+
 	// Stop the remaining data stores.
 	mtc.stopStore(1)
 	mtc.stopStore(2)

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -476,6 +476,7 @@ func (t *multiTestContextKVTransport) SendNext(ctx context.Context, done chan<- 
 		t.mtc.mu.RUnlock()
 		// Make a copy and clone txn of batch args for sending.
 		baCopy := t.args
+		baCopy.Replica = rep.ReplicaDescriptor
 		if txn := baCopy.Txn; txn != nil {
 			txnClone := baCopy.Txn.Clone()
 			baCopy.Txn = &txnClone


### PR DESCRIPTION
multiTestContext was not properly filling in the destination of its
request, leading to a fallback search in Stores.Send which could send
a request to a stale replica when combined with outdated information
in the DistSender's cache.

Specifically, a request to the post-split RHS was being sent to a
pre-split replica, which did not have a quorum because the LHS stores
were stopped, so it spun endlessly trying to get a lease.

Fixes #16251