### PR TITLE
build: remove snappy build directory when rebuilding

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -383,6 +383,7 @@ $(ROCKSDB_DIR)/Makefile: $(C_DEPS_DIR)/rocksdb-rebuild $(ROCKSDB_SRC_DIR)/.extra
 	@# RocksDB release that includes https://github.com/facebook/rocksdb/pull/2300.
 
 $(SNAPPY_DIR)/Makefile: $(C_DEPS_DIR)/snappy-rebuild $(SNAPPY_SRC_DIR)/.extracted
+	rm -rf $(SNAPPY_DIR)
 	mkdir -p $(SNAPPY_DIR)
 	@# NOTE: If you change the configure flags below, bump the version in
 	@# $(C_DEPS_DIR)/snappy-rebuild. See above for rationale.


### PR DESCRIPTION
This prevents cache pollution issues which are currently preventing
releases from building.