### PR TITLE
storage/engine: trim RocksDB compaction stats

### DIFF
--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -2014,7 +2014,7 @@ DBStatus DBSnapshot::GetStats(DBStatsResult* stats) {
 
 DBString DBImpl::GetCompactionStats() {
   std::string tmp;
-  rep->GetProperty("rocksdb.cfstats", &tmp);
+  rep->GetProperty("rocksdb.cfstats-no-file-histogram", &tmp);
   return ToDBString(tmp);
 }
 


### PR DESCRIPTION
RocksDB recently chaned "cfstats" to include per-level file read latency
histograms. This is very verbose and not currently useful. Use the new
"cfstats-no-file-histogram" stat which does not include this detail.