### PR TITLE
sql: handle nil children of union

### DIFF
--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -108,8 +108,12 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 		setUnlimited(n.table)
 
 	case *unionNode:
-		applyLimit(n.right, numRows, true)
-		applyLimit(n.left, numRows, true)
+		if n.right != nil {
+			applyLimit(n.right, numRows, true)
+		}
+		if n.left != nil {
+			applyLimit(n.left, numRows, true)
+		}
 
 	case *distinctNode:
 		applyLimit(n.plan, numRows, true)

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -169,6 +169,15 @@ EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 2          table  uniontest@primary
 2          spans  ALL
 
+query II
+SELECT * FROM (SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1);
+----
+1 1
+
+query II
+SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1;
+----
+1 1
 
 query error each UNION query must have the same number of columns: 2 vs 1
 SELECT 1, 2 UNION SELECT 3


### PR DESCRIPTION
Previously, cases like the included test cases would panic, because
unionNodes set their children to nil once they are consumed, and in
certain cases they can be consumed during planning. This commit moves
limit propagation to before plans are started so they are guaranteed to
be in a state unaffected by the surrounding nodes. Alternatively we
could add a nil check in limit_opt, which would also be reasonable if we
consider nil left and rights to be valid states for a unionNode at the
time we are performing the limit propagation.

Worth noting that the current implementation actually will propagate
limits through subqueries multiple times, since startSubqueryPlans will
also call startPlan on the subqueries.