### PR TITLE
tracing: support zipkin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -39,6 +39,12 @@
   revision = "d311c76e775b5092c023569caacdbb4e569c3243"
 
 [[projects]]
+  name = "github.com/Shopify/sarama"
+  packages = ["."]
+  revision = "c01858abb625b73a3af51d0798e4ad42c8147093"
+  version = "v1.12.0"
+
+[[projects]]
   name = "github.com/Sirupsen/logrus"
   packages = ["."]
   revision = "5e5dc898656f695e2a086b8e12559febbfc01562"
@@ -57,6 +63,12 @@
   name = "github.com/abourget/teamcity"
   packages = ["."]
   revision = "e241104394f91bf4e65048f9ea5d0c0f3c25b35e"
+
+[[projects]]
+  name = "github.com/apache/thrift"
+  packages = ["lib/go/thrift"]
+  revision = "b2a4d4ae21c789b689dd162deb819665567f481c"
+  version = "0.10.0"
 
 [[projects]]
   name = "github.com/armon/go-radix"
@@ -149,6 +161,12 @@
   revision = "bcc0a711c5e6bbe72c7cb13d81c7109b45267fd2"
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
   revision = "d2709f9f1f31ebcda9651b03077758c1f3a0018c"
@@ -180,6 +198,24 @@
   revision = "259d2a102b871d17f30e3cd9881a642961a1e486"
 
 [[projects]]
+  name = "github.com/eapache/go-resiliency"
+  packages = ["breaker"]
+  revision = "6800482f2c813e689c88b7ed3282262385011890"
+  version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/eapache/go-xerial-snappy"
+  packages = ["."]
+  revision = "bb955e01b9346ac19dc29eb16586c90ded99a98c"
+
+[[projects]]
+  name = "github.com/eapache/queue"
+  packages = ["."]
+  revision = "ded5959c0d4e360646dc9e9908cff48666781367"
+  version = "v1.0.2"
+
+[[projects]]
   name = "github.com/elastic/gosigar"
   packages = [".","sys/windows"]
   revision = "6c665a6256a84b6a2d1e207216e0e0d315e84135"
@@ -209,6 +245,12 @@
   name = "github.com/go-ini/ini"
   packages = ["."]
   revision = "e7fea39b01aea8d5671f6858f0532f56e8bff3a5"
+
+[[projects]]
+  name = "github.com/go-logfmt/logfmt"
+  packages = ["."]
+  revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
+  version = "v0.3.0"
 
 [[projects]]
   name = "github.com/go-ole/go-ole"
@@ -343,6 +385,12 @@
   revision = "813725a7c183ac304d1ed8fb7e37a567733e9c05"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/kr/logfmt"
+  packages = ["."]
+  revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
+
+[[projects]]
   name = "github.com/kr/pretty"
   packages = ["."]
   revision = "cfb55aafdaf3ec08f0db22699ab822c50091b1c4"
@@ -421,6 +469,12 @@
   revision = "eaaf4e1eeb7a5373b38e70901270c83577dc6fb9"
 
 [[projects]]
+  name = "github.com/openzipkin/zipkin-go-opentracing"
+  packages = [".","_thrift/gen-go/scribe","_thrift/gen-go/zipkincore","flag","types","wire"]
+  revision = "d88c90182f3fb514be54a1c7adc11a04d41c7da9"
+  version = "v0.2.4"
+
+[[projects]]
   name = "github.com/pelletier/go-buffruneio"
   packages = ["."]
   revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
@@ -441,6 +495,18 @@
   name = "github.com/petermattis/goid"
   packages = ["."]
   revision = "0ded85884ba5c4c9267fcd5a149061f7c3455eee"
+
+[[projects]]
+  name = "github.com/pierrec/lz4"
+  packages = ["."]
+  revision = "5c9560bfa9ace2bf86080bf40d46b34ae44604df"
+  version = "v1.0"
+
+[[projects]]
+  name = "github.com/pierrec/xxHash"
+  packages = ["xxHash32"]
+  revision = "f051bb7f1d1aaf1b5a665d74fb6b0217712c69f7"
+  version = "v0.1.1"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -535,7 +601,7 @@
 
 [[projects]]
   name = "golang.org/x/sync"
-  packages = ["errgroup","singleflight"]
+  packages = ["errgroup","singleflight","syncmap"]
   revision = "f52d1811a62927559de87708c8913c1650ce4f26"
 
 [[projects]]
@@ -592,6 +658,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c0370c19c12f78eb457fb3f4aea735bc7fe630af4c6f8a9294e9db502ec87dfa"
+  inputs-digest = "09a9217496fab13afb4b353178d58311dc7262b4e28ef300849786a7aba7b40f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -194,7 +194,9 @@ func bootstrapCluster(
 	cfg.MetricsSampleInterval = time.Duration(math.MaxInt64)
 	cfg.HistogramWindowInterval = time.Duration(math.MaxInt64)
 	cfg.ConsistencyCheckInterval = 10 * time.Minute
-	cfg.AmbientCtx.Tracer = tracing.NewTracer()
+	tr := tracing.NewTracer()
+	defer tr.Close()
+	cfg.AmbientCtx.Tracer = tr
 	// Create a KV DB with a local sender.
 	stores := storage.NewStores(cfg.AmbientCtx, cfg.Clock)
 	sender := kv.NewTxnCoordSender(cfg.AmbientCtx, stores, cfg.Clock, false, stopper, txnMetrics)

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -50,7 +50,7 @@ query TTTT colnames
 SELECT * FROM [SHOW ALL CLUSTER SETTINGS] WHERE name != 'diagnostics.reporting.enabled'
 ----
 name                                               current_value  type  description
-cluster.organization                     					           			s     organization name
+cluster.organization                                              s     organization name
 diagnostics.reporting.interval                     1h0m0s         d     interval at which diagnostics data should be reported
 diagnostics.reporting.report_metrics               true           b     enable collection and reporting diagnostic metrics to cockroach labs
 diagnostics.reporting.send_crash_reports           true           b     send crash and panic reports
@@ -75,6 +75,7 @@ sql.trace.session_eventlog.enabled                 false          b     set to t
 sql.trace.txn.enable_threshold                     0s             d     duration beyond which all transactions are traced (set to 0 to disable)
 trace.debug.enable                                 false          b     if set, traces for recent requests can be seen in the /debug page
 trace.lightstep.token                                             s     if set, traces go to Lightstep using this token
+trace.zipkin.collector                                            s     if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.
 
 
 

--- a/pkg/testutils/trace.go
+++ b/pkg/testutils/trace.go
@@ -43,6 +43,7 @@ func MakeRecordCtx() (context.Context, func() string) {
 			dump = tracing.FormatRecordedSpans(tracing.GetRecording(sp))
 			tracing.StopRecording(sp)
 			sp.Finish()
+			tr.Close()
 			cancel()
 		})
 		return dump

--- a/pkg/util/log/ambient_context_test.go
+++ b/pkg/util/log/ambient_context_test.go
@@ -47,7 +47,7 @@ func TestAnnotateCtxTags(t *testing.T) {
 
 func TestAnnotateCtxSpan(t *testing.T) {
 	tracer := tracing.NewTracer()
-	tracer.(*tracing.Tracer).SetForceRealSpans(true)
+	tracer.SetForceRealSpans(true)
 
 	ac := AmbientContext{}
 	ac.AddLogTag("ambient", nil)

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -71,7 +71,7 @@ func TestTrace(t *testing.T) {
 	Event(ctx, "should-not-show-up")
 
 	tracer := tracing.NewTracer()
-	tracer.(*tracing.Tracer).SetForceRealSpans(true)
+	tracer.SetForceRealSpans(true)
 	sp := tracer.StartSpan("s")
 	tracing.StartRecording(sp, tracing.SingleNodeRecording)
 	ctxWithSpan := opentracing.ContextWithSpan(ctx, sp)
@@ -101,7 +101,7 @@ func TestTraceWithTags(t *testing.T) {
 	ctx = WithLogTagInt(ctx, "tag", 1)
 
 	tracer := tracing.NewTracer()
-	tracer.(*tracing.Tracer).SetForceRealSpans(true)
+	tracer.SetForceRealSpans(true)
 	sp := tracer.StartSpan("s")
 	ctxWithSpan := opentracing.ContextWithSpan(ctx, sp)
 	tracing.StartRecording(sp, tracing.SingleNodeRecording)
@@ -187,7 +187,7 @@ func TestEventLogAndTrace(t *testing.T) {
 	ErrEvent(ctxWithEventLog, "testerr")
 
 	tracer := tracing.NewTracer()
-	tracer.(*tracing.Tracer).SetForceRealSpans(true)
+	tracer.SetForceRealSpans(true)
 	sp := tracer.StartSpan("s")
 	tracing.StartRecording(sp, tracing.SingleNodeRecording)
 	ctxWithBoth := opentracing.ContextWithSpan(ctxWithEventLog, sp)

--- a/pkg/util/tracing/shadow.go
+++ b/pkg/util/tracing/shadow.go
@@ -127,7 +127,7 @@ func createLightStepTracer(token string) (shadowTracerManager, opentracing.Trace
 var zipkinCollector = settings.RegisterStringSetting(
 	"trace.zipkin.collector",
 	"if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.",
-	"127.0.0.1:9411",
+	"",
 )
 
 func createZipkinTracer(collectorAddr string) (shadowTracerManager, opentracing.Tracer) {
@@ -137,7 +137,8 @@ func createZipkinTracer(collectorAddr string) (shadowTracerManager, opentracing.
 		zipkin.HTTPLogger(zipkin.LoggerFunc(func(keyvals ...interface{}) error {
 			// These logs are from the collector (e.g. errors sending data, dropped
 			// traces). We can't use `log` from this package so print them to stderr.
-			fmt.Fprintln(os.Stderr, "Zipkin collector: ", keyvals...)
+			toPrint := append([]interface{}{"Zipkin collector"}, keyvals...)
+			fmt.Fprintln(os.Stderr, toPrint)
 			return nil
 		})),
 	)

--- a/pkg/util/tracing/shadow.go
+++ b/pkg/util/tracing/shadow.go
@@ -23,9 +23,13 @@
 package tracing
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	lightstep "github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
+	zipkin "github.com/openzipkin/zipkin-go-opentracing"
 )
 
 type shadowTracerManager interface {
@@ -47,6 +51,18 @@ func (lightStepManager) Close(tr opentracing.Tracer) {
 	// https://github.com/lightstep/lightstep-tracer-go/pull/85#discussion_r123800322).
 	_ = lightstep.FlushLightStepTracer(tr)
 	_ = lightstep.CloseTracer(tr)
+}
+
+type zipkinManager struct {
+	collector zipkin.Collector
+}
+
+func (*zipkinManager) Name() string {
+	return "zipkin"
+}
+
+func (m *zipkinManager) Close(tr opentracing.Tracer) {
+	_ = m.collector.Close()
 }
 
 type shadowTracer struct {
@@ -99,8 +115,8 @@ var lightStepToken = settings.RegisterStringSetting(
 	"",
 )
 
-func createLightStepTracer(token string) opentracing.Tracer {
-	return lightstep.NewTracer(lightstep.Options{
+func createLightStepTracer(token string) (shadowTracerManager, opentracing.Tracer) {
+	return lightStepManager{}, lightstep.NewTracer(lightstep.Options{
 		AccessToken:      token,
 		MaxLogsPerSpan:   maxLogsPerSpan,
 		MaxBufferedSpans: 10000,
@@ -108,13 +124,48 @@ func createLightStepTracer(token string) opentracing.Tracer {
 	})
 }
 
+var zipkinCollector = settings.RegisterStringSetting(
+	"trace.zipkin.collector",
+	"if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.",
+	"127.0.0.1:9411",
+)
+
+func createZipkinTracer(collectorAddr string) (shadowTracerManager, opentracing.Tracer) {
+	// Create our HTTP collector.
+	collector, err := zipkin.NewHTTPCollector(
+		fmt.Sprintf("http://%s/api/v1/spans", collectorAddr),
+		zipkin.HTTPLogger(zipkin.LoggerFunc(func(keyvals ...interface{}) error {
+			// These logs are from the collector (e.g. errors sending data, dropped
+			// traces). We can't use `log` from this package so print them to stderr.
+			fmt.Fprintln(os.Stderr, "Zipkin collector: ", keyvals...)
+			return nil
+		})),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create our recorder.
+	recorder := zipkin.NewRecorder(collector, false /* !debug */, "0.0.0.0:0", "cockroach")
+
+	// Create our tracer.
+	zipkinTr, err := zipkin.NewTracer(recorder)
+	if err != nil {
+		panic(err)
+	}
+	return &zipkinManager{collector: collector}, zipkinTr
+}
+
 // We don't call OnChange inline above because it causes an "initialization
 // loop" compile error.
 var _ = lightStepToken.OnChange(updateShadowTracers)
+var _ = zipkinCollector.OnChange(updateShadowTracers)
 
 func updateShadowTracer(t *Tracer) {
 	if lsToken := lightStepToken.Get(); lsToken != "" {
-		t.setShadowTracer(lightStepManager{}, createLightStepTracer(lsToken))
+		t.setShadowTracer(createLightStepTracer(lsToken))
+	} else if zipkinAddr := zipkinCollector.Get(); zipkinAddr != "" {
+		t.setShadowTracer(createZipkinTracer(zipkinAddr))
 	} else {
 		t.setShadowTracer(nil, nil)
 	}

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -103,7 +103,7 @@ var _ opentracing.Tracer = &Tracer{}
 
 // NewTracer creates a Tracer. The cluster settings control whether
 // we trace to net/trace and/or lightstep.
-func NewTracer() opentracing.Tracer {
+func NewTracer() *Tracer {
 	t := &Tracer{}
 	t.noopSpan.tracer = t
 	updateShadowTracer(t)

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -265,7 +265,7 @@ func TestLightstepContext(t *testing.T) {
 		MaxLogsPerSpan: maxLogsPerSpan,
 		UseGRPC:        true,
 	})
-	tr.(*Tracer).setShadowTracer(lightStepManager{}, lsTr)
+	tr.setShadowTracer(lightStepManager{}, lsTr)
 	s := tr.StartSpan("test")
 
 	const testBaggageKey = "test-baggage"


### PR DESCRIPTION
To try this out locally:
 - set up a zipkin instance using `docker run -d -p 9411:9411 openzipkin/zipkin`
 - set `trace.zipkin.collector` to `127.0.0.1:9411`