### PR TITLE
Update jemalloc to correct symbol detection issues

### DIFF
--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -51,6 +51,7 @@ var libsRe = func() *regexp.Regexp {
 		regexp.QuoteMeta("linux-vdso.so."),
 		regexp.QuoteMeta("librt.so."),
 		regexp.QuoteMeta("libpthread.so."),
+		regexp.QuoteMeta("libdl.so."),
 		regexp.QuoteMeta("libm.so."),
 		regexp.QuoteMeta("libc.so."),
 		strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),


### PR DESCRIPTION
This should once again allow mac,windows cross compilation to work.