### PR TITLE
storage/engine: use kMinOverlappingRatio

### DIFF
--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -1543,6 +1543,7 @@ rocksdb::Options DBMakeOptions(DBOptions db_opts) {
   options.statistics = rocksdb::CreateDBStatistics();
   options.table_factory.reset(rocksdb::NewBlockBasedTableFactory(table_options));
   options.max_open_files = db_opts.max_open_files;
+  options.compaction_pri = rocksdb::kMinOverlappingRatio;
   // Periodically sync the WAL to smooth out writes. Not performing
   // such syncs can be faster but can cause performance blips when the
   // OS decides it needs to flush data.


### PR DESCRIPTION
Switch from kByCompensatedSize to kMinOverlappingRatio which is intended
to reduce write amplification. Note that kMinOverlappingRatio seems to
be the setting recommended by MyRocks. For a write only workload (`ycsb
--workload F`), this reduced write amplification from 16.9 to 16.2 and
boosted write throughput by 5%.

Fixes #9213