### PR TITLE
sql: propagate types to ON CONFLICT DO UPDATE exprs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -247,3 +247,16 @@ query ITII
 SELECT * FROM issue_14052_2;
 ----
 1  BAR  5  5
+
+# Make sure the column types are propagated when type checking the ON CONFLICT
+# expressions. See #16873.
+statement ok
+CREATE TABLE issue_16873 (col int PRIMARY KEY, date TIMESTAMP);
+
+statement ok
+INSERT INTO issue_16873 VALUES (1,clock_timestamp())
+ON CONFLICT (col) DO UPDATE SET date = clock_timestamp() WHERE col = 1;
+
+statement ok
+INSERT INTO issue_16873 VALUES (1,clock_timestamp())
+ON CONFLICT (col) DO UPDATE SET date = clock_timestamp() WHERE col = 1;

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -127,8 +127,9 @@ func (p *planner) makeUpsertHelper(
 	var evalExprs []parser.TypedExpr
 	ivarHelper := parser.MakeIndexedVarHelper(helper, len(sourceInfo.sourceColumns)+len(excludedSourceInfo.sourceColumns))
 	sources := multiSourceInfo{sourceInfo, excludedSourceInfo}
-	for _, expr := range untupledExprs {
-		normExpr, err := p.analyzeExpr(ctx, expr, sources, ivarHelper, parser.TypeAny, false, "")
+	for i, expr := range untupledExprs {
+		typ := updateCols[i].Type.ToDatumType()
+		normExpr, err := p.analyzeExpr(ctx, expr, sources, ivarHelper, typ, true, "ON CONFLICT")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously, column types weren't propagated into the type checker for ON
CONFLICT DO UPDATE expressions, so expressions that required a desired
type (such as builtins with multiple different overloads) couldn't type
check properly in those positions.

Fixes #16873.