### PR TITLE
sql: bump up mem_usage threshold from 10k to 1mb

### DIFF
--- a/pkg/sql/session_mem_usage.go
+++ b/pkg/sql/session_mem_usage.go
@@ -98,7 +98,7 @@ func (w WrappedMemoryAccount) ResizeItem(ctx context.Context, oldSize, newSize i
 // noteworthyMemoryUsageBytes is the minimum size tracked by a
 // transaction or session monitor before the monitor starts explicitly
 // logging overall usage growth in the log.
-var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_SESSION_MEMORY_USAGE", 10*1024)
+var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_SESSION_MEMORY_USAGE", 1024*1024)
 
 // StartMonitor interfaces between Session and mon.MemoryMonitor
 func (s *Session) StartMonitor(pool *mon.MemoryMonitor, reserved mon.BoundAccount) {


### PR DESCRIPTION
Now that we've let the system bake for a while with a low threshold for
when to log that the session and transaction memory usage increased and
have caught obvious leaks, we can safely up the log threshold to quiet
down the logs for tests and production.