### PR TITLE
storage: Use separate locks when updating our own liveness

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -105,7 +105,8 @@ type NodeLiveness struct {
 	livenessThreshold time.Duration
 	heartbeatInterval time.Duration
 	pauseHeartbeat    atomic.Value // contains a bool
-	sem               chan struct{}
+	selfSem           chan struct{}
+	otherSem          chan struct{}
 	triggerHeartbeat  chan struct{} // for testing
 	metrics           LivenessMetrics
 
@@ -135,7 +136,8 @@ func NewNodeLiveness(
 		gossip:            g,
 		livenessThreshold: livenessThreshold,
 		heartbeatInterval: livenessThreshold - renewalDuration,
-		sem:               make(chan struct{}, 1),
+		selfSem:           make(chan struct{}, 1),
+		otherSem:          make(chan struct{}, 1),
 		triggerHeartbeat:  make(chan struct{}, 1),
 	}
 	nl.metrics = LivenessMetrics{
@@ -154,6 +156,13 @@ func NewNodeLiveness(
 }
 
 var errNodeDrainingSet = errors.New("node is already draining")
+
+func (nl *NodeLiveness) sem(nodeID roachpb.NodeID) chan struct{} {
+	if nodeID == nl.gossip.NodeID.Get() {
+		return nl.selfSem
+	}
+	return nl.otherSem
+}
 
 // SetDraining calls PauseHeartbeat with the given boolean and then attempts to
 // update the liveness record.
@@ -203,18 +212,20 @@ func (nl *NodeLiveness) SetDecommissioning(
 func (nl *NodeLiveness) setDrainingInternal(
 	ctx context.Context, liveness *Liveness, drain bool,
 ) error {
+	nodeID := nl.gossip.NodeID.Get()
+	sem := nl.sem(nodeID)
 	// Allow only one attempt to set the draining field at a time.
 	select {
-	case nl.sem <- struct{}{}:
+	case sem <- struct{}{}:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 	defer func() {
-		<-nl.sem
+		<-sem
 	}()
 
 	newLiveness := Liveness{
-		NodeID: nl.gossip.NodeID.Get(),
+		NodeID: nodeID,
 		Epoch:  1,
 	}
 	if liveness != nil {
@@ -242,10 +253,11 @@ func (nl *NodeLiveness) setDecommissioningInternal(
 ) error {
 	// Allow only one attempt to set the decommissioning field at a time if it is this node.
 	if nodeID == nl.gossip.NodeID.Get() {
+		sem := nl.sem(nodeID)
 		select {
-		case nl.sem <- struct{}{}:
+		case sem <- struct{}{}:
 			defer func() {
-				<-nl.sem
+				<-sem
 			}()
 		case <-ctx.Done():
 			return ctx.Err()
@@ -369,17 +381,19 @@ func (nl *NodeLiveness) heartbeatInternal(
 		}(timeutil.Now())
 
 		// Allow only one heartbeat at a time.
+		nodeID := nl.gossip.NodeID.Get()
+		sem := nl.sem(nodeID)
 		select {
-		case nl.sem <- struct{}{}:
+		case sem <- struct{}{}:
 		case <-ctx.Done():
 			return ctx.Err()
 		}
 		defer func() {
-			<-nl.sem
+			<-sem
 		}()
 
 		newLiveness := Liveness{
-			NodeID: nl.gossip.NodeID.Get(),
+			NodeID: nodeID,
 			Epoch:  1,
 		}
 		if liveness != nil {
@@ -520,13 +534,14 @@ var errEpochAlreadyIncremented = errors.New("epoch already incremented")
 // gathered through gossip, an error is returned.
 func (nl *NodeLiveness) IncrementEpoch(ctx context.Context, liveness *Liveness) error {
 	// Allow only one increment at a time.
+	sem := nl.sem(liveness.NodeID)
 	select {
-	case nl.sem <- struct{}{}:
+	case sem <- struct{}{}:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 	defer func() {
-		<-nl.sem
+		<-sem
 	}()
 
 	if liveness.isLive(nl.clock.Now(), nl.clock.MaxOffset()) {


### PR DESCRIPTION
There's no reason to block our own liveness updates when incrementing
another node's epoch; doing so could cause cascading failures when
the liveness span gets slow.

This was originally suspected as the cause of #16565 (and was proposed
in #16564). That issue turned out to have other causes, but this
change seems like a good idea anyway.