### PR TITLE
scripts: point pprof at binary

### DIFF
--- a/scripts/pprof
+++ b/scripts/pprof
@@ -36,4 +36,4 @@ cleanup() {
 
 trap cleanup EXIT
 
-go tool pprof "http://127.0.0.1:${port}/debug/pprof/${profile_type}"
+go tool pprof cockroach "http://127.0.0.1:${port}/debug/pprof/${profile_type}"


### PR DESCRIPTION
Without it, `list` does not find the sources. Perhaps there is
a better way - it is awkward that you need a local copy of the
remote cockroach binary.