### PR TITLE
storage: implement disk-based sideloaded storage

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -74,16 +74,7 @@ func backupRestoreTestSetupWithParams(
 
 	dir, dirCleanupFn := testutils.TempDir(t)
 
-	temp := filepath.Join(dir, "must-be-cleaned-up")
-
 	tc = testcluster.StartTestCluster(t, clusterSize, params)
-	for _, s := range tc.Servers {
-		for _, e := range s.Engines() {
-			if err := e.SetAuxiliaryDir(temp); err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
 
 	const payloadSize = 100
 	splits := 10
@@ -102,18 +93,27 @@ func backupRestoreTestSetupWithParams(
 	}
 
 	cleanupFn := func() {
-		testutils.SucceedsSoon(t, func() error {
-			items, err := ioutil.ReadDir(temp)
-			if err != nil && !os.IsNotExist(err) {
-				t.Fatal(err)
+		tempDirs := []string{dir}
+		for _, s := range tc.Servers {
+			for _, e := range s.Engines() {
+				tempDirs = append(tempDirs, e.GetAuxiliaryDir())
 			}
-			for _, leftover := range items {
-				return errors.Errorf("found %q remaining in tempdir", leftover.Name())
-			}
-			return nil
-		})
-		tc.Stopper().Stop(context.TODO())
-		dirCleanupFn()
+		}
+		tc.Stopper().Stop(context.TODO()) // cleans up in memory storage's auxiliary dirs
+		dirCleanupFn()                    // cleans up dir, which is the nodelocal:// storage
+
+		for _, temp := range tempDirs {
+			testutils.SucceedsSoon(t, func() error {
+				items, err := ioutil.ReadDir(temp)
+				if err != nil && !os.IsNotExist(err) {
+					t.Fatal(err)
+				}
+				for _, leftover := range items {
+					return errors.Errorf("found %q remaining in %s", leftover.Name(), temp)
+				}
+				return nil
+			})
+		}
 	}
 
 	return ctx, "nodelocal://" + dir, tc, sqlDB, cleanupFn

--- a/pkg/storage/client_replica_gc_test.go
+++ b/pkg/storage/client_replica_gc_test.go
@@ -83,15 +83,16 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 		// Put some bogus data on the replica which we're about to remove. Then,
 		// at the end of the test, check that that sideloaded storage is now
 		// empty (in other words, GC'ing the Replica took care of cleanup).
-		repl1.PutBogusSideloadedData(12345, 6789)
+		repl1.PutBogusSideloadedData()
+		if !repl1.HasBogusSideloadedData() {
+			t.Fatal("sideloaded storage ate our data")
+		}
 
 		defer func() {
 			if !t.Failed() {
 				testutils.SucceedsSoon(t, func() error {
-					if count := repl1.SideloadedDataCount(); count != 0 {
-						return errors.Errorf(
-							"first replica still has %d sideloaded files despite GC", count,
-						)
+					if repl1.HasBogusSideloadedData() {
+						return errors.Errorf("first replica still has sideloaded files despite GC")
 					}
 					return nil
 				})

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -201,10 +201,6 @@ type Engine interface {
 	//
 	// Not thread safe.
 	GetAuxiliaryDir() string
-	// SetAuxiliaryDir changes the path returned by GetAuxiliaryDir.
-	//
-	// Not thread safe.
-	SetAuxiliaryDir(string) error
 	// NewBatch returns a new instance of a batched engine which wraps
 	// this engine. Batched engines accumulate all mutations and apply
 	// them atomically on a call to Commit().

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -22,6 +22,7 @@ package engine
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -353,8 +354,7 @@ func NewRocksDB(cfg RocksDBConfig, cache RocksDBCache) (*RocksDB, error) {
 		cache: cache.ref(),
 	}
 
-	auxDir := filepath.Join(cfg.Dir, "auxiliary")
-	if err := r.SetAuxiliaryDir(auxDir); err != nil {
+	if err := r.setAuxiliaryDir(filepath.Join(cfg.Dir, "auxiliary")); err != nil {
 		return nil, err
 	}
 
@@ -376,7 +376,11 @@ func newMemRocksDB(
 		cache: cache.ref(),
 	}
 
-	if err := r.SetAuxiliaryDir(os.TempDir()); err != nil {
+	tempDir, err := ioutil.TempDir(os.TempDir(), ".inmemrocksdb")
+	if err != nil {
+		return nil, err
+	}
+	if err := r.setAuxiliaryDir(filepath.Join(tempDir, "./auxiliary")); err != nil {
 		return nil, err
 	}
 
@@ -512,6 +516,10 @@ func (r *RocksDB) Close() {
 	if len(r.cfg.Dir) == 0 {
 		if log.V(1) {
 			log.Infof(context.TODO(), "closing in-memory rocksdb instance")
+		}
+		// Remove the temporary directory when the engine is in-memory.
+		if err := os.RemoveAll(r.auxDir); err != nil {
+			log.Warning(context.TODO(), err)
 		}
 	} else {
 		log.Infof(context.TODO(), "closing rocksdb instance at %q", r.cfg.Dir)
@@ -2099,12 +2107,7 @@ func (r *RocksDB) GetAuxiliaryDir() string {
 	return r.auxDir
 }
 
-// SetAuxiliaryDir changes the auxiliary storage path for this engine.
-// Never call this.
-//
-// TODO(tschottdorf,danhhz): remove the only "real" use in backup_test.go
-// and this method.
-func (r *RocksDB) SetAuxiliaryDir(d string) error {
+func (r *RocksDB) setAuxiliaryDir(d string) error {
 	if err := os.MkdirAll(d, 0755); err != nil {
 		return err
 	}

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -15,9 +15,6 @@
 package storage
 
 import (
-	"fmt"
-	"path/filepath"
-
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -49,83 +46,8 @@ type sideloadStorage interface {
 	// the given one.
 	TruncateTo(_ context.Context, index uint64) error
 	// Returns an absolute path to the file that Get() would return the contents
-	// of.
+	// of. Does not check whether the file actually exists.
 	Filename(_ context.Context, index, term uint64) (string, error)
-}
-
-type slKey struct {
-	index, term uint64
-}
-
-type inMemSideloadStorage struct {
-	m      map[slKey][]byte
-	prefix string
-}
-
-func newInMemSideloadStorage(
-	rangeID roachpb.RangeID, replicaID roachpb.ReplicaID, baseDir string,
-) sideloadStorage {
-	return &inMemSideloadStorage{
-		prefix: filepath.Join(baseDir, fmt.Sprintf("%d.%d", rangeID, replicaID)),
-		m:      make(map[slKey][]byte),
-	}
-}
-
-func (imss *inMemSideloadStorage) key(index, term uint64) slKey {
-	return slKey{index: index, term: term}
-}
-
-func (imss *inMemSideloadStorage) PutIfNotExists(
-	_ context.Context, index, term uint64, contents []byte,
-) error {
-	key := imss.key(index, term)
-	if _, ok := imss.m[key]; ok {
-		return nil
-	}
-	imss.m[key] = contents
-	return nil
-}
-
-func (imss *inMemSideloadStorage) Get(_ context.Context, index, term uint64) ([]byte, error) {
-	key := imss.key(index, term)
-	data, ok := imss.m[key]
-	if !ok {
-		return nil, errSideloadedFileNotFound
-	}
-	return data, nil
-}
-
-func (imss *inMemSideloadStorage) Filename(_ context.Context, index, term uint64) (string, error) {
-	key := imss.key(index, term)
-	_, ok := imss.m[key]
-	if !ok {
-		return "", errSideloadedFileNotFound
-	}
-	return filepath.Join(imss.prefix, fmt.Sprintf("i%d.t%d", index, term)), nil
-}
-
-func (imss *inMemSideloadStorage) Purge(_ context.Context, index, term uint64) error {
-	k := imss.key(index, term)
-	if _, ok := imss.m[k]; !ok {
-		return errSideloadedFileNotFound
-	}
-	delete(imss.m, k)
-	return nil
-}
-
-func (imss *inMemSideloadStorage) Clear(_ context.Context) error {
-	imss.m = make(map[slKey][]byte)
-	return nil
-}
-
-func (imss *inMemSideloadStorage) TruncateTo(_ context.Context, index uint64) error {
-	// Not efficient, but this storage is for testing purposes only anyway.
-	for k := range imss.m {
-		if k.index < index {
-			delete(imss.m, k)
-		}
-	}
-	return nil
 }
 
 // maybeSideloadEntriesRaftMuLocked should be called with a slice of "fat"

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -1,0 +1,139 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/pkg/errors"
+)
+
+var _ sideloadStorage = &diskSideloadStorage{}
+
+type diskSideloadStorage struct {
+	dir string
+}
+
+func newDiskSideloadStorage(
+	rangeID roachpb.RangeID, replicaID roachpb.ReplicaID, baseDir string,
+) (sideloadStorage, error) {
+	ss := &diskSideloadStorage{
+		dir: filepath.Join(baseDir, fmt.Sprintf("%d.%d", rangeID, replicaID)),
+	}
+	if err := ss.createDir(); err != nil {
+		return nil, err
+	}
+	return ss, nil
+}
+
+func (ss *diskSideloadStorage) createDir() error {
+	return os.MkdirAll(ss.dir, 0755)
+}
+
+func (ss *diskSideloadStorage) PutIfNotExists(
+	ctx context.Context, index, term uint64, contents []byte,
+) error {
+	filename := ss.filename(ctx, index, term)
+	if _, err := os.Stat(filename); err == nil {
+		// File exists.
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	// File does not exist yet. There's a chance the whole path is missing (for
+	// example after Clear()), in which case handle that transparently.
+	for {
+		// Use 0644 since that's what RocksDB uses:
+		// https://github.com/facebook/rocksdb/blob/56656e12d67d8a63f1e4c4214da9feeec2bd442b/env/env_posix.cc#L171
+		if err := ioutil.WriteFile(filename, contents, 0644); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		if err := ss.createDir(); err != nil {
+			return err
+		}
+		continue
+	}
+}
+
+func (ss *diskSideloadStorage) Get(ctx context.Context, index, term uint64) ([]byte, error) {
+	filename := ss.filename(ctx, index, term)
+	b, err := ioutil.ReadFile(filename)
+	if os.IsNotExist(err) {
+		return nil, errSideloadedFileNotFound
+	}
+	return b, err
+}
+
+func (ss *diskSideloadStorage) Filename(ctx context.Context, index, term uint64) (string, error) {
+	return ss.filename(ctx, index, term), nil
+}
+
+func (ss *diskSideloadStorage) filename(ctx context.Context, index, term uint64) string {
+	return filepath.Join(ss.dir, fmt.Sprintf("i%d.t%d", index, term))
+}
+
+func (ss *diskSideloadStorage) Purge(ctx context.Context, index, term uint64) error {
+	return ss.purgeFile(ctx, ss.filename(ctx, index, term))
+}
+
+func (ss *diskSideloadStorage) purgeFile(ctx context.Context, filename string) error {
+	if err := os.Remove(filename); err != nil {
+		if os.IsNotExist(err) {
+			return errSideloadedFileNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+func (ss *diskSideloadStorage) Clear(_ context.Context) error {
+	return os.RemoveAll(ss.dir)
+}
+
+func (ss *diskSideloadStorage) TruncateTo(ctx context.Context, index uint64) error {
+	matches, err := filepath.Glob(filepath.Join(ss.dir, "i*.t*"))
+	if err != nil {
+		return err
+	}
+	for _, match := range matches {
+		base := filepath.Base(match)
+		if len(base) < 1 || base[0] != 'i' {
+			continue
+		}
+		base = base[1:]
+		upToDot := strings.SplitN(base, ".", 2)
+		i, err := strconv.ParseUint(upToDot[0], 10, 64)
+		if err != nil {
+			return errors.Wrapf(err, "while parsing %q during TruncateTo", match)
+		}
+		if i >= index {
+			continue
+		}
+		if err := ss.purgeFile(ctx, match); err != nil {
+			return errors.Wrapf(err, "while purging %q", match)
+		}
+	}
+	return nil
+}

--- a/pkg/storage/replica_sideload_inmem.go
+++ b/pkg/storage/replica_sideload_inmem.go
@@ -1,0 +1,103 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+type slKey struct {
+	index, term uint64
+}
+
+type inMemSideloadStorage struct {
+	m      map[slKey][]byte
+	prefix string
+}
+
+func mustNewInMemSideloadStorage(
+	rangeID roachpb.RangeID, replicaID roachpb.ReplicaID, baseDir string,
+) sideloadStorage {
+	ss, err := newInMemSideloadStorage(rangeID, replicaID, baseDir)
+	if err != nil {
+		panic(err)
+	}
+	return ss
+}
+
+func newInMemSideloadStorage(
+	rangeID roachpb.RangeID, replicaID roachpb.ReplicaID, baseDir string,
+) (sideloadStorage, error) {
+	return &inMemSideloadStorage{
+		prefix: filepath.Join(baseDir, fmt.Sprintf("%d.%d", rangeID, replicaID)),
+		m:      make(map[slKey][]byte),
+	}, nil
+}
+func (ss *inMemSideloadStorage) key(index, term uint64) slKey {
+	return slKey{index: index, term: term}
+}
+
+func (ss *inMemSideloadStorage) PutIfNotExists(
+	_ context.Context, index, term uint64, contents []byte,
+) error {
+	key := ss.key(index, term)
+	if _, ok := ss.m[key]; ok {
+		return nil
+	}
+	ss.m[key] = contents
+	return nil
+}
+
+func (ss *inMemSideloadStorage) Get(_ context.Context, index, term uint64) ([]byte, error) {
+	key := ss.key(index, term)
+	data, ok := ss.m[key]
+	if !ok {
+		return nil, errSideloadedFileNotFound
+	}
+	return data, nil
+}
+
+func (ss *inMemSideloadStorage) Filename(_ context.Context, index, term uint64) (string, error) {
+	return filepath.Join(ss.prefix, fmt.Sprintf("i%d.t%d", index, term)), nil
+}
+
+func (ss *inMemSideloadStorage) Purge(_ context.Context, index, term uint64) error {
+	k := ss.key(index, term)
+	if _, ok := ss.m[k]; !ok {
+		return errSideloadedFileNotFound
+	}
+	delete(ss.m, k)
+	return nil
+}
+
+func (ss *inMemSideloadStorage) Clear(_ context.Context) error {
+	ss.m = make(map[slKey][]byte)
+	return nil
+}
+
+func (ss *inMemSideloadStorage) TruncateTo(_ context.Context, index uint64) error {
+	// Not efficient, but this storage is for testing purposes only anyway.
+	for k := range ss.m {
+		if k.index < index {
+			delete(ss.m, k)
+		}
+	}
+	return nil
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3795,10 +3795,13 @@ func (s *Store) tryGetOrCreateReplica(
 			}
 			return nil, false, errRetry
 		}
-		if err := repl.setReplicaID(replicaID); err != nil {
+		repl.mu.Lock()
+		if err := repl.setReplicaIDRaftMuLockedMuLocked(replicaID); err != nil {
+			repl.mu.Unlock()
 			repl.raftMu.Unlock()
 			return nil, false, err
 		}
+		repl.mu.Unlock()
 		return repl, false, nil
 	}
 


### PR DESCRIPTION
Tests are TODO. Out for early review since it's indispensable for serious
testing of RESTORE (the in-memory storage does not get ejected eagerly
enough since the Raft log queue is unaware of sideloaded data, so you
quickly get OOMs).

cc @danhhz