### PR TITLE
allocsim: Print number of range relocations in output

### DIFF
--- a/pkg/cmd/allocsim/configs/multiple-nodes-per-locality-low-latency.json
+++ b/pkg/cmd/allocsim/configs/multiple-nodes-per-locality-low-latency.json
@@ -1,0 +1,17 @@
+{
+  "NumWorkers": 32,
+  "Localities": [
+    {
+      "Name": "1",
+      "NumNodes": 3
+    },
+    {
+      "Name": "2",
+      "NumNodes": 3
+    },
+    {
+      "Name": "3",
+      "NumNodes": 3
+    }
+  ]
+}


### PR DESCRIPTION
Also add a second config with multiple nodes per locality.

New output looks like:

```
_elapsed__ops/sec__average__latency___errors_replicas_________________1_________________2_________________3_________________4
   3m30s    693.8    670.2    1.5ms        0      738      179/62/29/21        193/60/2/3        186/56/1/5        180/61/0/0
```