### PR TITLE
storage/engine: use SyncWAL instead of sync on commit

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -62,6 +62,7 @@ kv.raft_log.synchronize                            true           b     set to t
 kv.snapshot_rebalance.max_rate                     2.0 MiB        z     the rate limit (bytes/sec) to use for rebalance snapshots
 kv.snapshot_recovery.max_rate                      8.0 MiB        z     the rate limit (bytes/sec) to use for recovery snapshots
 kv.transaction.max_intents                         100000         i     maximum number of write intents allowed for a KV transaction
+rocksdb.min_wal_sync_interval                      1ms            d     minimum duration between syncs of the RocksDB WAL
 server.declined_reservation_timeout                1s             d     the amount of time to consider the store throttled for up-replication after a reservation was declined
 server.failed_reservation_timeout                  5s             d     the amount of time to consider the store throttled for up-replication after a failed reservation call
 server.remote_debugging.mode                       local          s     set to enable remote debugging, localhost-only or disable (any, local, off)

--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -1667,6 +1667,10 @@ DBStatus DBFlush(DBEngine* db) {
   return ToDBStatus(db->rep->Flush(options));
 }
 
+DBStatus DBSyncWAL(DBEngine* db) {
+  return ToDBStatus(db->rep->SyncWAL());
+}
+
 DBStatus DBCompact(DBEngine* db) {
   rocksdb::CompactRangeOptions options;
   // By default, RocksDB doesn't recompact the bottom level (unless

--- a/pkg/storage/engine/db.h
+++ b/pkg/storage/engine/db.h
@@ -102,6 +102,10 @@ void DBClose(DBEngine* db);
 // complete.
 DBStatus DBFlush(DBEngine* db);
 
+// Syncs the RocksDB WAL ensuring all data is persisted to
+// disk. Blocks until the operation is complete.
+DBStatus DBSyncWAL(DBEngine* db);
+
 // Forces an immediate compaction over all keys.
 DBStatus DBCompact(DBEngine* db);
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3193,6 +3193,17 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	writer.Close()
 	// Synchronously commit the batch with the Raft log entries and Raft hard
 	// state as we're promising not to lose this data.
+	//
+	// Note that the data is visible to other goroutines before it is synced to
+	// disk. This is fine. The important constraints are that these syncs happen
+	// before Raft messages are sent and before the call to RawNode.Advance. Our
+	// regular locking is sufficient for this and if other goroutines can see the
+	// data early, that's fine. In particular, snapshots are not a problem (I
+	// think they're the only thing that might access log entries or HardState
+	// from other goroutines). Snapshots do not include either the HardState or
+	// uncommitted log entries, and even if they did include log entries that
+	// were not persisted to disk, it wouldn't be a problem because raft does not
+	// infer the that entries are persisted on the node that sends a snapshot.
 	start := timeutil.Now()
 	if err := batch.Commit(syncRaftLog.Get() && rd.MustSync); err != nil {
 		return stats, err


### PR DESCRIPTION
The previous implementation of batching for synced commits had the
unfortunate property that commits that did not require syncing were
required to wait for the WAL to be synced. When RocksDB writes a batch
with sync==true it internally does:

  1. Add batch to WAL
  2. Sync WAL
  3. Add entries to mem table

Switch to using SyncWAL to explicitly sync the WAL after writing a
batch. This is slightly different semantics from the above:

  1. Add batch to WAL
  2. Add entries to mem table
  3. Sync WAL

The advantage of this new approach is that non-synced batches do not
have to wait for the WAL to sync. Prior to this change, it was observed
that essentially every batch was waiting for a WAL sync. Approximately
half of all batch commits are performed with sync==true (half of all
batch commits are for Raft log entries or Raft state). Forcing the
non-synced commits to wait for the WAL added significant time.

Reworked the implementation of batch grouping. The sequence number
mechanism was replaced by per-batch condition variables embedded in the
rocksDBBatch structure. Once a batch is committed (and synced if
requested), the condition variable is signalled ensuring that only the
desired goroutines are woken instead of waking all of the goroutines
waiting on the condition. Syncing of the WAL is performed by a dedicated
thread add only the batches which specify sync==true wait for the
syncing to occur.

Added "rocksdb.min_wal_sync_interval" which adds specifies a minimum
delay to wait between calls to SyncWAL. The default of 1ms was
experimentally determined to reduce disk IOs by ~50% (vs 0ms) while leaving write
throughput unchanged.

For a write-only workload (`ycsb -workload F`), write throughput
improved by 15%. Raft command commit latency (unsynced commits) dropped
from 30-40ms to 6-10ms.