### PR TITLE
rpc: Slightly clarify the clock offset suicide error message

### DIFF
--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -226,10 +226,12 @@ func (r *RemoteClockMonitor) VerifyClockOffset(ctx context.Context) error {
 		r.metrics.ClockOffsetStdDevNanos.Update(int64(stdDev))
 
 		if numClocks > 0 && healthyOffsetCount <= numClocks/2 {
-			return errors.Errorf("fewer than half the known nodes are within the maximum offset of %s (%d of %d)", maxOffset, healthyOffsetCount, numClocks)
+			return errors.Errorf(
+				"clock synchronization error: this node is more than %s away from at least half of the known nodes (%d of %d are within the offset)",
+				maxOffset, healthyOffsetCount, numClocks)
 		}
 		if log.V(1) {
-			log.Infof(ctx, "%d of %d nodes are within the maximum offset of %s", healthyOffsetCount, numClocks, maxOffset)
+			log.Infof(ctx, "%d of %d nodes are within the maximum clock offset of %s", healthyOffsetCount, numClocks, maxOffset)
 		}
 	}
 

--- a/pkg/rpc/clock_offset_test.go
+++ b/pkg/rpc/clock_offset_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
-const errOffsetGreaterThanMaxOffset = "fewer than half the known nodes are within the maximum offset"
+const errOffsetGreaterThanMaxOffset = "clock synchronization error: this node is more than .+ away from at least half of the known nodes"
 
 // TestUpdateOffset tests the three cases that UpdateOffset should or should
 // not update the offset for an addr.


### PR DESCRIPTION
We've had a couple users not be sure what it meant, hopefully this
helps.

@onkar, would this have helped you? It would have printed as:

`fewer than half the known nodes are within the maximum clock offset of 500ms (0 of 1); check your machines' clock synchronization`