### PR TITLE
storage: optimize replicaRaftStorage.Term

### DIFF
--- a/pkg/storage/entry_cache_test.go
+++ b/pkg/storage/entry_cache_test.go
@@ -56,6 +56,15 @@ func verifyGet(
 	if nextIndex != expNextIndex {
 		t.Fatalf("expected next index %d; got %d", nextIndex, expNextIndex)
 	}
+	for _, e := range ents {
+		term, ok := rec.getTerm(rangeID, e.Index)
+		if !ok {
+			t.Fatalf("expected to be able to retrieve term")
+		}
+		if term != e.Term {
+			t.Fatalf("expected term %d, but got %d", e.Term, term)
+		}
+	}
 }
 
 func TestEntryCache(t *testing.T) {
@@ -92,6 +101,12 @@ func TestEntryCache(t *testing.T) {
 	rec.delEntries(rangeID, 10, 11)
 	// Verify get of entries at end of range.
 	verifyGet(t, rec, rangeID, 8, 11, ents[7:9], 10)
+
+	for _, index := range []uint64{0, 12} {
+		if term, ok := rec.getTerm(rangeID, index); ok {
+			t.Fatalf("expected no term, but found %d", term)
+		}
+	}
 }
 
 func TestEntryCacheClearTo(t *testing.T) {

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -249,8 +249,8 @@ func (r *replicaRaftStorage) Term(i uint64) (uint64, error) {
 	return term(ctx, readonly, r.RangeID, r.store.raftEntryCache, i)
 }
 
-// raftTermLocked requires that r.mu is held.
-func (r *Replica) raftTermLocked(i uint64) (uint64, error) {
+// raftTermLocked requires that r.mu is locked for reading.
+func (r *Replica) raftTermRLocked(i uint64) (uint64, error) {
 	return (*replicaRaftStorage)(r).Term(i)
 }
 

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -640,7 +640,9 @@ func (rec ReplicaEvalContext) FirstIndex() (uint64, error) {
 
 // Term returns the term of the given entry in the raft log.
 func (rec ReplicaEvalContext) Term(i uint64) (uint64, error) {
-	return rec.repl.raftTermLocked(i)
+	rec.repl.mu.RLock()
+	defer rec.repl.mu.RUnlock()
+	return rec.repl.raftTermRLocked(i)
 }
 
 // Fields backed by on-disk data must be registered in the SpanSet.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5184,7 +5184,7 @@ func TestTruncateLog(t *testing.T) {
 
 	// The term of the last truncated entry is still available.
 	tc.repl.mu.Lock()
-	term, err := tc.repl.raftTermLocked(indexes[4])
+	term, err := tc.repl.raftTermRLocked(indexes[4])
 	tc.repl.mu.Unlock()
 	if err != nil {
 		t.Fatal(err)
@@ -5195,7 +5195,7 @@ func TestTruncateLog(t *testing.T) {
 
 	// The terms of older entries are gone.
 	tc.repl.mu.Lock()
-	_, err = tc.repl.raftTermLocked(indexes[3])
+	_, err = tc.repl.raftTermRLocked(indexes[3])
 	tc.repl.mu.Unlock()
 	if err != raft.ErrCompacted {
 		t.Errorf("expected ErrCompacted, got %s", err)
@@ -5217,7 +5217,7 @@ func TestTruncateLog(t *testing.T) {
 
 	tc.repl.mu.Lock()
 	// The term of the last truncated entry is still available.
-	term, err = tc.repl.raftTermLocked(indexes[4])
+	term, err = tc.repl.raftTermRLocked(indexes[4])
 	tc.repl.mu.Unlock()
 	if err != nil {
 		t.Fatal(err)
@@ -6143,20 +6143,20 @@ func TestTerm(t *testing.T) {
 	}
 
 	// Truncated logs should return an ErrCompacted error.
-	if _, err := tc.repl.raftTermLocked(indexes[1]); err != raft.ErrCompacted {
+	if _, err := tc.repl.raftTermRLocked(indexes[1]); err != raft.ErrCompacted {
 		t.Errorf("expected ErrCompacted, got %s", err)
 	}
-	if _, err := tc.repl.raftTermLocked(indexes[3]); err != raft.ErrCompacted {
+	if _, err := tc.repl.raftTermRLocked(indexes[3]); err != raft.ErrCompacted {
 		t.Errorf("expected ErrCompacted, got %s", err)
 	}
 
 	// FirstIndex-1 should return the term of firstIndex.
-	firstIndexTerm, err := tc.repl.raftTermLocked(firstIndex)
+	firstIndexTerm, err := tc.repl.raftTermRLocked(firstIndex)
 	if err != nil {
 		t.Errorf("expect no error, got %s", err)
 	}
 
-	term, err := tc.repl.raftTermLocked(indexes[4])
+	term, err := tc.repl.raftTermRLocked(indexes[4])
 	if err != nil {
 		t.Errorf("expect no error, got %s", err)
 	}
@@ -6170,15 +6170,15 @@ func TestTerm(t *testing.T) {
 	}
 
 	// Last index should return correctly.
-	if _, err := tc.repl.raftTermLocked(lastIndex); err != nil {
+	if _, err := tc.repl.raftTermRLocked(lastIndex); err != nil {
 		t.Errorf("expected no error, got %s", err)
 	}
 
 	// Terms for after the last index should return ErrUnavailable.
-	if _, err := tc.repl.raftTermLocked(lastIndex + 1); err != raft.ErrUnavailable {
+	if _, err := tc.repl.raftTermRLocked(lastIndex + 1); err != raft.ErrUnavailable {
 		t.Errorf("expected ErrUnavailable, got %s", err)
 	}
-	if _, err := tc.repl.raftTermLocked(indexes[9] + 1000); err != raft.ErrUnavailable {
+	if _, err := tc.repl.raftTermRLocked(indexes[9] + 1000); err != raft.ErrUnavailable {
 		t.Errorf("expected ErrUnavailable, got %s", err)
 	}
 }


### PR DESCRIPTION
replicaRaftStorage.Term() is called frequently by the Raft code to retrieve
the term for the last index. Optimize this case by caching the term of the
last index in Replica.mu similar to the way we cache the last index itself.

Add raftEntryCache.getTerm() for retrieving the term for a particular log
entry. This code path is hit during Raft log truncation.

Use a read-only engine instead of a RocksDB snapshot for
replicaRaftStorage.{Term,Entries}. Both these methods are called from Raft
with Replica.mu held meaning there is no danger of the underlying data
changing. This avoids 2 cgo calls (to create and destroy the snapshot) in
the common case that the snapshot isn't even used because we've hit the
Raft entries cache.