### PR TITLE
kv: don't send NoopRequest

### DIFF
--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
-//
-// Author: Tobias Schottdorf
 
 package kv
 
@@ -24,19 +22,19 @@ import (
 )
 
 var emptySpan = roachpb.Span{}
-var noopRequest = roachpb.NoopRequest{}
 
-// truncate restricts all contained requests to the given key range
-// and returns a new BatchRequest.
-// All requests contained in that batch are "truncated" to the given
-// span, inserting NoopRequest appropriately to replace requests which
-// are left without a key range to operate on. The number of non-noop
-// requests after truncation is returned.
-func truncate(ba roachpb.BatchRequest, rs roachpb.RSpan) (roachpb.BatchRequest, int, error) {
+// truncate restricts all contained requests to the given key range and returns
+// a new, truncated, BatchRequest. All requests contained in that batch are
+// "truncated" to the given span, and requests which are found to not overlap
+// the given span at all are removed. A mapping of response index to batch index
+// is returned. For example, if
+//
+// ba = Put[a], Put[c], Put[b],
+// rs = [a,bb],
+//
+// then truncate(ba,rs) returns a batch (Put[a], Put[b]) and positions [0,2].
+func truncate(ba roachpb.BatchRequest, rs roachpb.RSpan) (roachpb.BatchRequest, []int, error) {
 	truncateOne := func(args roachpb.Request) (bool, roachpb.Span, error) {
-		if _, ok := args.(*roachpb.NoopRequest); ok {
-			return true, emptySpan, nil
-		}
 		header := args.Header()
 		if !roachpb.IsRange(args) {
 			// This is a point request.
@@ -98,33 +96,32 @@ func truncate(ba roachpb.BatchRequest, rs roachpb.RSpan) (roachpb.BatchRequest, 
 		return true, header, nil
 	}
 
-	var numNoop int
+	// TODO(tschottdorf): optimize so that we don't always make a new request
+	// slice, only when something changed (copy-on-write).
+
+	var positions []int
 	truncBA := ba
-	truncBA.Requests = make([]roachpb.RequestUnion, len(ba.Requests))
+	truncBA.Requests = nil
 	for pos, arg := range ba.Requests {
 		hasRequest, newHeader, err := truncateOne(arg.GetInner())
-		if !hasRequest {
-			// We omit this one, i.e. replace it with a Noop.
-			numNoop++
-			union := roachpb.RequestUnion{}
-			union.MustSetInner(&noopRequest)
-			truncBA.Requests[pos] = union
-		} else {
+		if hasRequest {
 			// Keep the old one. If we must adjust the header, must copy.
 			if inner := ba.Requests[pos].GetInner(); newHeader.Equal(inner.Header()) {
-				truncBA.Requests[pos] = ba.Requests[pos]
+				truncBA.Requests = append(truncBA.Requests, ba.Requests[pos])
 			} else {
+				var union roachpb.RequestUnion
 				shallowCopy := inner.ShallowCopy()
 				shallowCopy.SetHeader(newHeader)
-				union := &truncBA.Requests[pos] // avoid operating on copy
 				union.MustSetInner(shallowCopy)
+				truncBA.Requests = append(truncBA.Requests, union)
 			}
+			positions = append(positions, pos)
 		}
 		if err != nil {
-			return roachpb.BatchRequest{}, 0, err
+			return roachpb.BatchRequest{}, nil, err
 		}
 	}
-	return truncBA, len(ba.Requests) - numNoop, nil
+	return truncBA, positions, nil
 }
 
 // prev gives the right boundary of the union of all requests which don't

--- a/pkg/kv/batch_test.go
+++ b/pkg/kv/batch_test.go
@@ -11,8 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
-//
-// Author: Tobias Schottdorf
 
 package kv
 

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -1809,7 +1809,7 @@ func TestMultiRangeSplitEndTransaction(t *testing.T) {
 			// would actually be fine, but it doesn't seem worth optimizing at
 			// this point.
 			roachpb.Key("a1"), roachpb.Key("b1"), roachpb.Key("a1"),
-			[][]roachpb.Method{{roachpb.Put, roachpb.Noop}, {roachpb.Noop, roachpb.Put}, {roachpb.EndTransaction}},
+			[][]roachpb.Method{{roachpb.Put}, {roachpb.Put}, {roachpb.EndTransaction}},
 		},
 		{
 			// Both writes go to the second range, but not EndTransaction.

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -1755,8 +1755,8 @@ type BatchResponse_Header struct {
 	// transaction. The transaction timestamp and/or priority may have
 	// been updated, depending on the outcome of the request.
 	Txn *Transaction `protobuf:"bytes,3,opt,name=txn" json:"txn,omitempty"`
-	// now is the current time at the node sending the response,
-	// which can be used by the receiver to update its local HLC.
+	// now is the highest current time from any node contacted during the request.
+	// It can be used by the receiver to update its local HLC.
 	Now cockroach_util_hlc.Timestamp `protobuf:"bytes,5,opt,name=now" json:"now"`
 	// collected_spans stores trace spans recorded during the execution of this
 	// request.

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1073,12 +1073,13 @@ message BatchResponse {
     // transaction. The transaction timestamp and/or priority may have
     // been updated, depending on the outcome of the request.
     optional Transaction txn = 3;
-    // now is the current time at the node sending the response,
-    // which can be used by the receiver to update its local HLC.
+    // now is the highest current time from any node contacted during the request.
+    // It can be used by the receiver to update its local HLC.
     optional util.hlc.Timestamp now = 5 [(gogoproto.nullable) = false];
     // collected_spans stores trace spans recorded during the execution of this
     // request.
     repeated util.tracing.RecordedSpan collected_spans = 6 [(gogoproto.nullable) = false];
+    // NB: if you add a field here, don't forget to update combine().
   }
   optional Header header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   repeated ResponseUnion responses = 2 [(gogoproto.nullable) = false];


### PR DESCRIPTION
Also fixes funky code introduced ages ago<sup>[1]</sup> which meant that during
limited batches, results could remain unpopulated. We've never hit this in
practice, but it looked pretty bad.

Closes #16744.
Fixes #12142.

[1]:
https://github.com/cockroachdb/cockroach/pull/5092/files#diff-c7b3757cf7a8d326bfaf580795bad34dR775