### PR TITLE
c-deps: localize RocksDB's SSE4.2 usage to CRC32C

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -386,10 +386,10 @@ $(ROCKSDB_DIR)/Makefile: $(C_DEPS_DIR)/rocksdb-rebuild | libsnappy $(if $(USE_ST
 	@# NOTE: If you change the CMake flags below, bump the version in
 	@# $(C_DEPS_DIR)/rocksdb-rebuild. See above for rationale.
 	cd $(ROCKSDB_DIR) && cmake $(CMAKE_FLAGS) $(ROCKSDB_SRC_DIR) \
-	  $(if $(findstring release,$(TYPE)),,-DWITH_$(if $(findstring mingw,$(TARGET_TRIPLE)),AVX2,SSE42)=OFF) \
+	  -DWITH_$(if $(findstring mingw,$(TARGET_TRIPLE)),AVX2,SSE42)=OFF \
 	  -DSNAPPY_LIBRARIES=$(SNAPPY_DIR)/libsnappy.a -DSNAPPY_INCLUDE_DIR="$(SNAPPY_SRC_DIR);$(SNAPPY_DIR)" -DWITH_SNAPPY=ON \
 	  $(if $(USE_STDMALLOC),,-DJEMALLOC_LIBRARIES=$(JEMALLOC_DIR)/lib/libjemalloc.a -DJEMALLOC_INCLUDE_DIR=$(JEMALLOC_DIR)/include -DWITH_JEMALLOC=ON) \
-	  $(if $(ENABLE_ROCKSDB_ASSERTIONS),,-DCMAKE_CXX_FLAGS=-DNDEBUG)
+	  -DCMAKE_CXX_FLAGS="-msse3 $(if $(ENABLE_ROCKSDB_ASSERTIONS),,-DNDEBUG)"
 	@# TODO(benesch): Tweak how we pass -DNDEBUG above when we upgrade to a
 	@# RocksDB release that includes https://github.com/facebook/rocksdb/pull/2300.
 

--- a/c-deps/rocksdb-rebuild
+++ b/c-deps/rocksdb-rebuild
@@ -1,4 +1,4 @@
 Bump the version below when changing rocksdb CMake flags. Search for "BUILD
 ARTIFACT CACHING" in build/common.mk for rationale.
 
-4
+5


### PR DESCRIPTION
This is the culmination of a free Friday project. See [benesch/bincheck](https://github.com/benesch/bincheck) for the (semi-)automatic verification half.

@tamird can I use your new benchmark infrastructure somehow to validate the performance claims I'm making below? I haven't actually measured the performance of this yet, but figured I'd just word the commit message as if I had. (I have, however, verified that this no longer causes `SIGILL`s on my emulated pre-SSE4.2 CPU.)

---

Previously, RocksDB was compiled with `-msse4.2` across the board. The compiler, unsurprisingly took the liberty of actually emitting SSE4.2 instructions, which could cause `SIGILL` crashes on pre-SSE4.2 CPUs (i.e, CPUs released before ca. November 2008).

The only part of RocksDB that really benefits from SSE4.2 instructions, however, is the CRC32C checksum code, which can use the hardware CRC32C instructions provided by SSE4.2. This commit simply removes `-msse4.2` from the RocksDB compile flags, and renables it for the FastCRC32 function only via a GCC attribute. Since FastCRC32 is already properly guarded by a CPUID check, which falls back to a slower implementation at runtime if the CPU does not support SSE4.2, this should get us nearly all of the performance benefits of compiling with `-msse4.2` while still supporting pre-SSE4.2 CPUs.

Fixes #15589.