### PR TITLE
cli: return an error if using root without valid certificates

### DIFF
--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -69,6 +69,13 @@ send "\\q\r"
 eexpect $prompt
 end_test
 
+start_test "Check that root cannot use password."
+# Run as root but with a non-existent certs directory.
+send "$argv sql --certs-dir=non-existent-dir\r"
+eexpect "Error: connections with user root must use a client certificate"
+eexpect "Failed running \"sql\""
+end_test
+
 start_test "Check that CREATE USER WITH PASSWORD can be used from transactions."
 # Create a user from a transaction.
 send "$argv sql --certs-dir=$certs_dir\r"


### PR DESCRIPTION
Fixes #16817

We take the lack of client certificates as a hint that we should prompt
for a password.
Before this, we would attempt to connect to the server and get an error
back: `user root must use certificate authentication instead of password
authentication`.

Instead, fail in the password-prompt logic, making it clear that you
need root certificates.