### PR TITLE
sql: make parallel test errors more visible

### DIFF
--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -1704,6 +1704,7 @@ func (t *logicTest) Error(args ...interface{}) {
 	if *showSQL {
 		t.outf("\t-- FAIL")
 	}
+	log.Error(context.Background(), args...)
 	t.t.Error(args...)
 	t.failures++
 }
@@ -1715,6 +1716,7 @@ func (t *logicTest) Errorf(format string, args ...interface{}) {
 	if *showSQL {
 		t.outf("\t-- FAIL")
 	}
+	log.Errorf(context.Background(), format, args...)
 	t.t.Errorf(format, args...)
 	t.failures++
 }
@@ -1725,6 +1727,7 @@ func (t *logicTest) Fatal(args ...interface{}) {
 	if *showSQL {
 		fmt.Println()
 	}
+	log.Error(context.Background(), args...)
 	t.t.Fatal(args...)
 }
 
@@ -1734,6 +1737,7 @@ func (t *logicTest) Fatalf(format string, args ...interface{}) {
 	if *showSQL {
 		fmt.Println()
 	}
+	log.Errorf(context.Background(), format, args...)
 	t.t.Fatalf(format, args...)
 }
 

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -83,6 +83,7 @@ func (t *parallelTest) processTestFile(path string, nodeIdx int, db *gosql.DB, c
 		verbose: testing.Verbose() || log.V(1),
 	}
 	if err := l.processTestFile(path, testClusterConfig{}); err != nil {
+		log.Errorf(context.Background(), "error processing %s: %s", path, err)
 		t.Error(err)
 	}
 }
@@ -243,12 +244,20 @@ func TestParallel(t *testing.T) {
 		t.Fatalf("No testfiles found (glob: %s)", glob)
 	}
 	total := 0
+	failed := 0
 	for _, path := range paths {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			pt := parallelTest{T: t, ctx: context.Background()}
 			pt.run(path)
 			total++
+			if t.Failed() {
+				failed++
+			}
 		})
 	}
-	log.Infof(context.Background(), "%d parallel tests passed", total)
+	if failed == 0 {
+		log.Infof(context.Background(), "%d parallel tests passed", total)
+	} else {
+		log.Infof(context.Background(), "%d out of %d parallel tests failed", failed, total)
+	}
 }


### PR DESCRIPTION
I saw a parallel test failure under `make stress` where I couldn't find the
error message (probably because it wasn't ran with `-test.v`). Improving the
error reporting to also show the error in our logs, and correcting the final
"N tests passed" message.