### PR TITLE
kv: Speed up TestSendNext_NonRetryableApplicationError

### DIFF
--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -555,7 +555,17 @@ func makeReplicas(addrs ...net.Addr) ReplicaSlice {
 func sendBatch(
 	ctx context.Context, opts SendOptions, addrs []net.Addr, rpcContext *rpc.Context,
 ) (*roachpb.BatchResponse, error) {
-	ds := NewDistSender(DistSenderConfig{}, nil)
+	ds := NewDistSender(DistSenderConfig{
+		// After an error, we wait for up to PendingRPCTimeout to reduce
+		// the chance of returning AmbiguousResultError. These tests
+		// predate that mechanism and will wait for the full duration of
+		// PendingRPCTimeout (specifically in
+		// TestSendNext_NonRetryableApplicationError, so set it to
+		// something small.
+		// TODO(bdarnell): this is related to #16181. If we come up with
+		// an alternative solution there, we may be able to remove this.
+		PendingRPCTimeout: time.Millisecond,
+	}, nil)
 	opts.metrics = &ds.metrics
 	return ds.sendToReplicas(ctx, opts, 0, makeReplicas(addrs...), roachpb.BatchRequest{}, rpcContext)
 }


### PR DESCRIPTION
This test has taken a full minute ever since #15603

Fixes #16947