### PR TITLE
storage: Track replica stats for up to 30 minutes rather than 25

### DIFF
--- a/pkg/storage/replica_stats.go
+++ b/pkg/storage/replica_stats.go
@@ -51,7 +51,7 @@ type replicaStats struct {
 	mu struct {
 		syncutil.Mutex
 		idx        int
-		requests   [5]perLocalityCounts
+		requests   [6]perLocalityCounts
 		lastRotate time.Time
 		lastReset  time.Time
 	}


### PR DESCRIPTION
This is just something that's been bugging me when explaining it out
loud -- it's easier to say that we make decisions based on the last
half hour of data than the last 25 minutes.