### PR TITLE
logictest: fix flaky test of automatic retry

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -622,14 +622,14 @@ statement ok
 BEGIN TRANSACTION; SAVEPOINT cockroach_restart; SELECT 1;
 
 query error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
-SELECT CRDB_INTERNAL.FORCE_RETRY('50ms':::INTERVAL)
+SELECT CRDB_INTERNAL.FORCE_RETRY('1h':::INTERVAL)
 
 statement ok
 ROLLBACK TO SAVEPOINT COCKROACH_RESTART;
 
 # This is the automatic retry we care about.
 statement ok
-SELECT CRDB_INTERNAL.FORCE_RETRY('100ms':::INTERVAL)
+SELECT CRDB_INTERNAL.FORCE_RETRY('50ms':::INTERVAL)
 
 statement ok
 ROLLBACK


### PR DESCRIPTION
We were setting up a txn for a retry for a short amount of time only, which
could lead to failures if that time had already passed before the retry.
Now using a one hour interval in the case in which we expect to receive
the error anyway, and a short one where we can afford to be flaky (since we
expect an internal restart).

Fixes #16914.