### PR TITLE
logictest: don't skip under stress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ stressrace: TESTTIMEOUT := $(RACETIMEOUT)
 stress: ## Run tests under stress.
 stressrace: ## Run tests under stress with the race detector enabled.
 stress stressrace: $(C_LIBS_CCL) $(CGO_FLAGS_FILES) $(BOOTSTRAP_TARGET)
-	$(GO) list -tags '$(TAGS)' -f '$(XGO) test -v $(GOFLAGS) -tags '\''$(TAGS)'\'' -ldflags '\''$(LINKFLAGS)'\'' -i -c {{.ImportPath}} -o '\''{{.Dir}}'\''/stress.test && (cd '\''{{.Dir}}'\'' && if [ -f stress.test ]; then COCKROACH_STRESS=true stress $(STRESSFLAGS) ./stress.test -test.run '\''$(TESTS)'\'' $(if $(BENCHES),-test.bench '\''$(BENCHES)'\'') -test.timeout $(TESTTIMEOUT) $(TESTFLAGS); fi)' $(PKG) | $(SHELL)
+	$(GO) list -tags '$(TAGS)' -f '$(XGO) test -v $(GOFLAGS) -tags '\''$(TAGS)'\'' -ldflags '\''$(LINKFLAGS)'\'' -i -c {{.ImportPath}} -o '\''{{.Dir}}'\''/stress.test && (cd '\''{{.Dir}}'\'' && if [ -f stress.test ]; then stress $(STRESSFLAGS) ./stress.test -test.run '\''$(TESTS)'\'' $(if $(BENCHES),-test.bench '\''$(BENCHES)'\'') -test.timeout $(TESTTIMEOUT) $(TESTFLAGS); fi)' $(PKG) | $(SHELL)
 
 .PHONY: upload-coverage
 upload-coverage: $(BOOTSTRAP_TARGET)

--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -9,7 +9,7 @@ exit_status=0
 
 build/builder.sh go install ./pkg/cmd/github-post
 
-build/builder.sh env \
+build/builder.sh env COCKROACH_NIGHTLY_STRESS=true \
 		 make stress \
 		 PKG="$PKG" GOFLAGS="${GOFLAGS:-}" TAGS="${TAGS:-}" \
 		 TESTTIMEOUT=30m TESTFLAGS='-test.v' \

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -176,7 +176,7 @@ func TestClientConnSettings(t *testing.T) {
 
 	// For some reason, when run under stress all these test cases fail due to the
 	// `--host` flag being unknown to quitCmd. Just skip this under stress.
-	if testutils.Stress() {
+	if testutils.NightlyStress() {
 		t.Skip()
 	}
 

--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -237,6 +237,7 @@ func main() {
 					fmt.Sprintf("TESTS=%s", tests),
 					fmt.Sprintf("STRESSFLAGS=-stderr -maxfails 1 -maxtime %s", duration),
 				)
+				cmd.Env = append(os.Environ(), "COCKROACH_NIGHTLY_STRESS=true")
 				cmd.Dir = crdb.Dir
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr

--- a/pkg/cmd/teamcity-trigger/main.go
+++ b/pkg/cmd/teamcity-trigger/main.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/abourget/teamcity"
 	"github.com/kisielk/gotool"
@@ -71,6 +72,7 @@ func runTC(queueBuildFn func(map[string]string)) {
 		{"env.GOFLAGS": "-race"},
 		{"env.TAGS": "deadlock"},
 	} {
+		properties["COCKROACH_NIGHTLY_STRESS"] = strconv.FormatBool(true)
 		for _, importPath := range importPaths {
 			properties["env.PKG"] = importPath
 

--- a/pkg/gossip/convergence_test.go
+++ b/pkg/gossip/convergence_test.go
@@ -59,7 +59,7 @@ func connectionsRefused(network *simulation.Network) int64 {
 // As of Jan 2017, this normally takes ~12 cycles and 8-12 refused connections.
 func TestConvergence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if testutils.Stress() {
+	if testutils.NightlyStress() {
 		t.Skip()
 	}
 
@@ -92,7 +92,7 @@ func TestConvergence(t *testing.T) {
 // As of Jan 2017, this normally takes 8-9 cycles and 50-60 refused connections.
 func TestNetworkReachesEquilibrium(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	if testutils.Stress() {
+	if testutils.NightlyStress() {
 		t.Skip()
 	}
 

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -1431,7 +1431,8 @@ func (t *logicTest) runFile(path string, config testClusterConfig) {
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if testutils.Stress() {
+	if testutils.NightlyStress() {
+		// See https://github.com/cockroachdb/cockroach/pull/10966.
 		t.Skip()
 	}
 

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -369,7 +369,7 @@ func TestReadAmplification(t *testing.T) {
 func TestConcurrentBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if testutils.Stress() {
+	if testutils.NightlyStress() {
 		t.Skip()
 	}
 

--- a/pkg/testutils/stress.go
+++ b/pkg/testutils/stress.go
@@ -14,12 +14,14 @@
 
 package testutils
 
-import "github.com/cockroachdb/cockroach/pkg/util/envutil"
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+)
 
-var stress = envutil.EnvOrDefaultBool("COCKROACH_STRESS", false)
+var stress = envutil.EnvOrDefaultBool("COCKROACH_NIGHTLY_STRESS", false)
 
-// Stress returns true iff the process is running as part of CockroachDB's
+// NightlyStress returns true iff the process is running as part of CockroachDB's
 // nightly stress tests.
-func Stress() bool {
+func NightlyStress() bool {
 	return stress
 }


### PR DESCRIPTION
I'm not sure why we decided to do this in the first place, but it's really
annoying not to be able to stress test logic tests, especially since it
isn't obvious that it's not possible until you waste some time and find out.