### PR TITLE
kv: remove timeouts

### DIFF
--- a/pkg/base/constants.go
+++ b/pkg/base/constants.go
@@ -32,29 +32,6 @@ const (
 	// it may be aborted by conflicting txns.
 	DefaultHeartbeatInterval = 1 * time.Second
 
-	// DefaultSendNextTimeout is the duration to wait before trying another
-	// replica to send a KV batch.
-	//
-	// TODO(peter): The SendNextTimeout mechanism is intended to lower tail
-	// latencies by performing "speculative retries". In order to do so, the
-	// timeout needs to by very low, but it can't be too low or we add
-	// unnecessary network traffic and increase the likelihood of ambiguous
-	// results. The SendNextTimeout mechanism has been the source of several bugs
-	// and it is questionable about whether it is still necessary given that we
-	// shut down the connection on heartbeat timeouts.
-	//
-	//   https://github.com/cockroachdb/cockroach/issues/15687
-	//   https://github.com/cockroachdb/cockroach/issues/16119
-	//
-	// In advance of removing the SendNextTimeout mechanism completely, we're
-	// setting the value very high and will be paying attention to tail
-	// latencies.
-	DefaultSendNextTimeout = 10 * time.Minute
-
-	// DefaultPendingRPCTimeout is the duration to wait for outstanding RPCs
-	// after receiving an error.
-	DefaultPendingRPCTimeout = time.Minute
-
 	// SlowRequestThreshold is the amount of time to wait before considering a
 	// request to be "slow".
 	SlowRequestThreshold = 60 * time.Second

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -69,8 +69,6 @@ type TestServerArgs struct {
 	SSLCertsDir              string
 	TimeSeriesQueryWorkerMax int
 	SQLMemoryPoolSize        int64
-	SendNextTimeout          time.Duration
-	PendingRPCTimeout        time.Duration
 	ListeningURLFile         string
 
 	// If set, this will be appended to the Postgres URL by functions that

--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -26,6 +26,7 @@ type ModuleTestingKnobs interface {
 // system for testing.
 type TestingKnobs struct {
 	Store            ModuleTestingKnobs
+	DistSender       ModuleTestingKnobs
 	SQLExecutor      ModuleTestingKnobs
 	SQLLeaseManager  ModuleTestingKnobs
 	SQLSchemaChanger ModuleTestingKnobs

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1139,9 +1139,8 @@ func (ds *DistSender) sendToReplicas(
 	var haveCommit bool
 	// We only check for committed txns, not aborts because aborts may
 	// be retried without any risk of inconsistencies.
-	if etArg, ok := args.GetArg(roachpb.EndTransaction); ok &&
-		etArg.(*roachpb.EndTransactionRequest).Commit {
-		haveCommit = true
+	if etArg, ok := args.GetArg(roachpb.EndTransaction); ok {
+		haveCommit = etArg.(*roachpb.EndTransactionRequest).Commit
 	}
 	done := make(chan BatchCall, len(replicas))
 

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -19,7 +19,6 @@ package kv
 import (
 	"fmt"
 	"sync/atomic"
-	"time"
 	"unsafe"
 
 	"google.golang.org/grpc"
@@ -67,9 +66,6 @@ var (
 	metaTransportLocalSentCount = metric.Metadata{
 		Name: "distsender.rpc.sent.local",
 		Help: "Number of local RPCs sent"}
-	metaDistSenderSendNextTimeoutCount = metric.Metadata{
-		Name: "distsender.rpc.sent.sendnexttimeout",
-		Help: "Number of RPCs sent due to outstanding RPCs not returning promptly"}
 	metaDistSenderNextReplicaErrCount = metric.Metadata{
 		Name: "distsender.rpc.sent.nextreplicaerror",
 		Help: "Number of RPCs sent due to per-replica errors"}
@@ -87,7 +83,6 @@ type DistSenderMetrics struct {
 	PartialBatchCount      *metric.Counter
 	SentCount              *metric.Counter
 	LocalSentCount         *metric.Counter
-	SendNextTimeoutCount   *metric.Counter
 	NextReplicaErrCount    *metric.Counter
 	NotLeaseHolderErrCount *metric.Counter
 	SlowRequestsCount      *metric.Gauge
@@ -99,7 +94,6 @@ func makeDistSenderMetrics() DistSenderMetrics {
 		PartialBatchCount:      metric.NewCounter(metaDistSenderPartialBatchCount),
 		SentCount:              metric.NewCounter(metaTransportSentCount),
 		LocalSentCount:         metric.NewCounter(metaTransportLocalSentCount),
-		SendNextTimeoutCount:   metric.NewCounter(metaDistSenderSendNextTimeoutCount),
 		NextReplicaErrCount:    metric.NewCounter(metaDistSenderNextReplicaErrCount),
 		NotLeaseHolderErrCount: metric.NewCounter(metaDistSenderNotLeaseHolderErrCount),
 		SlowRequestsCount:      metric.NewGauge(metaSlowDistSenderRequests),
@@ -141,14 +135,12 @@ type DistSender struct {
 	rangeCache           *RangeDescriptorCache
 	rangeLookupMaxRanges int32
 	// leaseHolderCache caches range lease holders by range ID.
-	leaseHolderCache  *LeaseHolderCache
-	transportFactory  TransportFactory
-	rpcContext        *rpc.Context
-	rpcRetryOptions   retry.Options
-	sendNextTimeout   time.Duration
-	pendingRPCTimeout time.Duration
-	asyncSenderSem    chan struct{}
-	asyncSenderCount  int32
+	leaseHolderCache *LeaseHolderCache
+	transportFactory TransportFactory
+	rpcContext       *rpc.Context
+	rpcRetryOptions  retry.Options
+	asyncSenderSem   chan struct{}
+	asyncSenderCount int32
 }
 
 var _ client.Sender = &DistSender{}
@@ -168,19 +160,29 @@ type DistSenderConfig struct {
 	// nodeDescriptor, if provided, is used to describe which node the DistSender
 	// lives on, for instance when deciding where to send RPCs.
 	// Usually it is filled in from the Gossip network on demand.
-	nodeDescriptor *roachpb.NodeDescriptor
-	// The RPC dispatcher. Defaults to grpc but can be changed here for testing
-	// purposes.
-	TransportFactory  TransportFactory
+	nodeDescriptor    *roachpb.NodeDescriptor
 	RPCContext        *rpc.Context
 	RangeDescriptorDB RangeDescriptorDB
-	SendNextTimeout   time.Duration
-	PendingRPCTimeout time.Duration
 	// SenderConcurrency specifies the parallelization available when
 	// splitting batches into multiple requests when they span ranges.
 	// TODO(spencer): This is per-process. We should add a per-batch limit.
 	SenderConcurrency int32
+
+	TestingKnobs DistSenderTestingKnobs
 }
+
+// DistSenderTestingKnobs is a part of the context used to control parts of
+// the system.
+type DistSenderTestingKnobs struct {
+	// The RPC dispatcher. Defaults to grpc but can be changed here for
+	// testing purposes.
+	TransportFactory TransportFactory
+}
+
+var _ base.ModuleTestingKnobs = &DistSenderTestingKnobs{}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*DistSenderTestingKnobs) ModuleTestingKnobs() {}
 
 // NewDistSender returns a batch.Sender instance which connects to the
 // Cockroach cluster via the supplied gossip instance. Supplying a
@@ -218,10 +220,10 @@ func NewDistSender(cfg DistSenderConfig, g *gossip.Gossip) *DistSender {
 	if cfg.RangeLookupMaxRanges <= 0 {
 		ds.rangeLookupMaxRanges = defaultRangeLookupMaxRanges
 	}
-	if tf := cfg.TransportFactory; tf != nil {
+	if tf := cfg.TestingKnobs.TransportFactory; tf != nil {
 		ds.transportFactory = tf
 	} else {
-		ds.transportFactory = grpcTransportFactory
+		ds.transportFactory = GRPCTransportFactory
 	}
 	ds.rpcRetryOptions = base.DefaultRetryOptions()
 	if cfg.RPCRetryOptions != nil {
@@ -232,16 +234,6 @@ func NewDistSender(cfg DistSenderConfig, g *gossip.Gossip) *DistSender {
 		if ds.rpcRetryOptions.Closer == nil {
 			ds.rpcRetryOptions.Closer = ds.rpcContext.Stopper.ShouldQuiesce()
 		}
-	}
-	if cfg.SendNextTimeout != 0 {
-		ds.sendNextTimeout = cfg.SendNextTimeout
-	} else {
-		ds.sendNextTimeout = base.DefaultSendNextTimeout
-	}
-	if cfg.PendingRPCTimeout != 0 {
-		ds.pendingRPCTimeout = cfg.PendingRPCTimeout
-	} else {
-		ds.pendingRPCTimeout = base.DefaultPendingRPCTimeout
 	}
 	if cfg.SenderConcurrency != 0 {
 		ds.asyncSenderSem = make(chan struct{}, cfg.SenderConcurrency)
@@ -398,14 +390,10 @@ func (ds *DistSender) sendRPC(
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	rpcOpts := SendOptions{
-		SendNextTimeout: ds.sendNextTimeout,
-		metrics:         &ds.metrics,
-	}
 	tracing.AnnotateTrace()
 	defer tracing.AnnotateTrace()
 
-	return ds.sendToReplicas(ctx, rpcOpts, rangeID, replicas, ba, ds.rpcContext)
+	return ds.sendToReplicas(ctx, SendOptions{metrics: &ds.metrics}, rangeID, replicas, ba, ds.rpcContext)
 }
 
 // CountRanges returns the number of ranges that encompass the given key span.
@@ -471,6 +459,7 @@ func (ds *DistSender) sendSingleRange(
 
 	br, err := ds.sendRPC(ctx, desc.RangeID, replicas, ba)
 	if err != nil {
+		log.ErrEvent(ctx, err.Error())
 		return nil, roachpb.NewError(err)
 	}
 
@@ -1142,7 +1131,6 @@ func (ds *DistSender) sendToReplicas(
 	if etArg, ok := args.GetArg(roachpb.EndTransaction); ok {
 		haveCommit = etArg.(*roachpb.EndTransactionRequest).Commit
 	}
-	done := make(chan BatchCall, len(replicas))
 
 	transport, err := ds.transportFactory(opts, rpcContext, replicas, args)
 	if err != nil {
@@ -1153,41 +1141,19 @@ func (ds *DistSender) sendToReplicas(
 		return nil, roachpb.NewSendError(
 			fmt.Sprintf("sending to all %d replicas failed", len(replicas)))
 	}
-
-	// Send the first request.
-	pending := 1
-	if log.V(2) || log.HasSpanOrEvent(ctx) {
-		log.VEventf(ctx, 2, "r%d: sending batch %s to %s",
-			rangeID, args.Summary(), transport.NextReplica())
-	}
+	// Must be buffered because tests have blocking SendNext implementations.
+	done := make(chan BatchCall, 1)
+	log.VEventf(ctx, 2, "r%d: sending batch %s to %s", rangeID, args.Summary(), transport.NextReplica())
 	transport.SendNext(ctx, done)
 
 	// Wait for completions. This loop will retry operations that fail
 	// with errors that reflect per-replica state and may succeed on
 	// other replicas.
-	sendNextTimer := timeutil.NewTimer()
 	slowTimer := timeutil.NewTimer()
-	defer sendNextTimer.Stop()
 	defer slowTimer.Stop()
 	slowTimer.Reset(base.SlowRequestThreshold)
 	for {
-		if timeout, ok := transport.SendNextTimeout(opts.SendNextTimeout); ok {
-			// Only start the send-next timer if we haven't exhausted the transport
-			// (i.e. there is another replica to send to).
-			sendNextTimer.Reset(timeout)
-		}
-
 		select {
-		case <-sendNextTimer.C:
-			sendNextTimer.Read = true
-			// On successive RPC timeouts, send to additional replicas if available.
-			if !transport.IsExhausted() {
-				ds.metrics.SendNextTimeoutCount.Inc(1)
-				log.VEventf(ctx, 2, "timeout, trying next peer: %s", transport.NextReplica())
-				pending++
-				transport.SendNext(ctx, done)
-			}
-
 		case <-slowTimer.C:
 			log.Warningf(ctx, "have been waiting %s sending RPC to r%d for batch: %s",
 				base.SlowRequestThreshold, rangeID, args)
@@ -1195,97 +1161,7 @@ func (ds *DistSender) sendToReplicas(
 			defer ds.metrics.SlowRequestsCount.Dec(1)
 
 		case call := <-done:
-			pending--
-			err := call.Err
-			if err == nil {
-				// Determine whether the error must be propagated immediately or whether
-				// sending can continue to alternate replicas.
-				propagateError := false
-				switch tErr := call.Reply.Error.GetDetail().(type) {
-				case nil:
-					return call.Reply, nil
-				case *roachpb.StoreNotFoundError, *roachpb.NodeUnavailableError:
-					// These errors are likely to be unique to the replica that reported
-					// them, so no action is required before the next retry.
-				case *roachpb.NotLeaseHolderError:
-					ds.metrics.NotLeaseHolderErrCount.Inc(1)
-					if lh := tErr.LeaseHolder; lh != nil {
-						// If the replica we contacted knows the new lease holder, update the cache.
-						ds.updateLeaseHolderCache(ctx, rangeID, *lh)
-
-						// If the implicated leaseholder is not a known replica,
-						// return a RangeNotFoundError to signal eviction of the
-						// cached RangeDescriptor and re-send.
-						if replicas.FindReplica(lh.StoreID) == -1 {
-							// Replace NotLeaseHolderError with RangeNotFoundError.
-							log.ErrEventf(ctx, "reported lease holder %s not in replicas slice %+v", lh, replicas)
-							call.Reply.Error = roachpb.NewError(roachpb.NewRangeNotFoundError(rangeID))
-							propagateError = true
-						} else {
-							// Move the new lease holder to the head of the queue for the next retry.
-							transport.MoveToFront(*lh)
-						}
-					}
-				default:
-					propagateError = true
-				}
-
-				log.ErrEventf(ctx, "application error: %s", call.Reply.Error)
-
-				if propagateError {
-					if pending > 0 {
-						// If there are still pending RPCs, try to wait them out.
-						//
-						// Note that ambiguous result errors can arrive from these
-						// in-flight RPCs, so if we've sent any, we better wait
-						// for them, even if we're not going to generate ambiguous
-						// results from them ourselves.
-						timer := time.NewTimer(ds.pendingRPCTimeout)
-						defer timer.Stop()
-					pendingLoop:
-						for pending > 0 {
-							select {
-							case pendingCall := <-done:
-								pending--
-								if err := pendingCall.Err; err != nil {
-									if grpc.Code(err) != codes.Unavailable {
-										ambiguousError = err
-									}
-								} else if pendingCall.Reply.Error == nil {
-									return pendingCall.Reply, nil
-								}
-							case <-timer.C:
-								break pendingLoop
-							}
-						}
-					}
-
-					// The error received is likely not specific to this
-					// replica, so we should return it instead of trying other
-					// replicas. However, if we're trying to commit a
-					// transaction and there are still other RPCs outstanding
-					// or an ambiguous RPC error was already received, we must
-					// return an ambiguous commit error instead of the
-					// returned error.
-					if haveCommit {
-						if pending > 0 || ambiguousError != nil {
-							log.ErrEventf(ctx, "returning ambiguous result (error=%v pending=%d)", ambiguousError, pending)
-							return nil, roachpb.NewAmbiguousResultError(
-								fmt.Sprintf("error=%v pending=%d", ambiguousError, pending))
-						}
-					}
-					return call.Reply, nil
-				}
-
-				// Extract the detail so it can be included in the error
-				// message if this is our last replica.
-				//
-				// TODO(bdarnell): The last error is not necessarily the best
-				// one to return; we may want to remember the "best" error
-				// we've seen (for example, a NotLeaseHolderError conveys more
-				// information than a RangeNotFound).
-				err = call.Reply.Error.GoError()
-			} else {
+			if err := call.Err; err != nil {
 				// All connection errors except for an unavailable node (this
 				// is GRPC's fail-fast error), may mean that the request
 				// succeeded on the remote server, but we were unable to
@@ -1308,37 +1184,70 @@ func (ds *DistSender) sendToReplicas(
 				// See https://github.com/grpc/grpc-go/blob/52f6504dc290bd928a8139ba94e3ab32ed9a6273/call.go#L182
 				// See https://github.com/grpc/grpc-go/blob/52f6504dc290bd928a8139ba94e3ab32ed9a6273/stream.go#L158
 				if haveCommit && grpc.Code(err) != codes.Unavailable {
-					log.ErrEventf(ctx, "txn may have committed despite RPC error: %s", err)
 					ambiguousError = err
-				} else {
-					log.ErrEventf(ctx, "RPC error: %s", err)
 				}
+				log.ErrEventf(ctx, "RPC error: %s", err)
+			} else {
+				propagateError := false
+				switch tErr := call.Reply.Error.GetDetail().(type) {
+				case nil:
+					return call.Reply, nil
+				case *roachpb.StoreNotFoundError, *roachpb.NodeUnavailableError:
+					// These errors are likely to be unique to the replica that reported
+					// them, so no action is required before the next retry.
+				case *roachpb.NotLeaseHolderError:
+					ds.metrics.NotLeaseHolderErrCount.Inc(1)
+					if lh := tErr.LeaseHolder; lh != nil {
+						// If the replica we contacted knows the new lease holder, update the cache.
+						ds.updateLeaseHolderCache(ctx, rangeID, *lh)
+
+						// If the implicated leaseholder is not a known replica,
+						// return a RangeNotFoundError to signal eviction of the
+						// cached RangeDescriptor and re-send.
+						if replicas.FindReplica(lh.StoreID) == -1 {
+							// Replace NotLeaseHolderError with RangeNotFoundError.
+							call.Reply.Error = roachpb.NewError(roachpb.NewRangeNotFoundError(rangeID))
+							propagateError = true
+						} else {
+							// Move the new lease holder to the head of the queue for the next retry.
+							transport.MoveToFront(*lh)
+						}
+					}
+				default:
+					propagateError = true
+				}
+
+				if propagateError {
+					if ambiguousError != nil {
+						return nil, roachpb.NewAmbiguousResultError(fmt.Sprintf("error=%s", ambiguousError))
+					}
+
+					// The error received is likely not specific to this
+					// replica, so we should return it instead of trying other
+					// replicas.
+					return call.Reply, nil
+				}
+
+				log.ErrEventf(ctx, "application error: %s", call.Reply.Error)
 			}
 
-			// Send to additional replicas if available.
-			if !transport.IsExhausted() {
-				ds.metrics.NextReplicaErrCount.Inc(1)
-				log.VEventf(ctx, 2, "error, trying next peer: %s", transport.NextReplica())
-				pending++
-				transport.SendNext(ctx, done)
-			}
-			if pending == 0 {
+			if transport.IsExhausted() {
 				if ambiguousError != nil {
-					err = roachpb.NewAmbiguousResultError(
-						fmt.Sprintf(
-							"sending to all %d replicas failed, but txn commit was possibly masked by: %s",
-							len(replicas),
-							ambiguousError,
-						),
-					)
-				} else {
-					err = roachpb.NewSendError(
-						fmt.Sprintf("sending to all %d replicas failed; last error: %s", len(replicas), err),
-					)
+					return nil, roachpb.NewAmbiguousResultError(fmt.Sprintf("error=%s", ambiguousError))
 				}
-				log.ErrEvent(ctx, err.Error())
-				return nil, err
+
+				// TODO(bdarnell): The last error is not necessarily the best
+				// one to return; we may want to remember the "best" error
+				// we've seen (for example, a NotLeaseHolderError conveys more
+				// information than a RangeNotFound).
+				return nil, roachpb.NewSendError(
+					fmt.Sprintf("sending to all %d replicas failed; last error: %v", len(replicas), call),
+				)
 			}
+
+			ds.metrics.NextReplicaErrCount.Inc(1)
+			log.VEventf(ctx, 2, "error: %v; trying next peer %s", call, transport.NextReplica())
+			transport.SendNext(ctx, done)
 		}
 	}
 }

--- a/pkg/kv/local_test_cluster_util.go
+++ b/pkg/kv/local_test_cluster_util.go
@@ -66,17 +66,19 @@ func InitSenderForLocalTestCluster(
 		Clock:           clock,
 		RPCRetryOptions: &retryOpts,
 		nodeDescriptor:  nodeDesc,
-		TransportFactory: func(
-			opts SendOptions,
-			rpcContext *rpc.Context,
-			replicas ReplicaSlice,
-			args roachpb.BatchRequest,
-		) (Transport, error) {
-			transport, err := senderTransportFactory(opts, rpcContext, replicas, args)
-			if err != nil {
-				return nil, err
-			}
-			return &localTestClusterTransport{transport, latency}, nil
+		TestingKnobs: DistSenderTestingKnobs{
+			TransportFactory: func(
+				opts SendOptions,
+				rpcContext *rpc.Context,
+				replicas ReplicaSlice,
+				args roachpb.BatchRequest,
+			) (Transport, error) {
+				transport, err := senderTransportFactory(opts, rpcContext, replicas, args)
+				if err != nil {
+					return nil, err
+				}
+				return &localTestClusterTransport{transport, latency}, nil
+			},
 		},
 	}, gossip)
 

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -91,278 +90,12 @@ func TestSendToOneClient(t *testing.T) {
 	s, ln := newTestServer(t, rpcContext)
 	roachpb.RegisterInternalServer(s, Node(0))
 
-	reply, err := sendBatch(context.Background(), nil, SendOptions{}, []net.Addr{ln.Addr()}, rpcContext)
+	reply, err := sendBatch(context.Background(), nil, []net.Addr{ln.Addr()}, rpcContext)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if reply == nil {
 		t.Errorf("expected reply")
-	}
-}
-
-// channelSaveTransport captures the 'done' channels of every RPC it
-// "sends".
-type channelSaveTransport struct {
-	ch        chan chan<- BatchCall
-	remaining int
-}
-
-func (c *channelSaveTransport) IsExhausted() bool {
-	return c.remaining <= 0
-}
-
-func (c *channelSaveTransport) SendNextTimeout(defaultTimeout time.Duration) (time.Duration, bool) {
-	if c.IsExhausted() {
-		return 0, false
-	}
-	return defaultTimeout, true
-}
-
-func (c *channelSaveTransport) SendNext(_ context.Context, done chan<- BatchCall) {
-	c.remaining--
-	c.ch <- done
-}
-
-func (*channelSaveTransport) NextReplica() roachpb.ReplicaDescriptor {
-	return roachpb.ReplicaDescriptor{}
-}
-
-func (*channelSaveTransport) MoveToFront(roachpb.ReplicaDescriptor) {
-}
-
-func (*channelSaveTransport) Close() {
-}
-
-// setupSendNextTest sets up a situation in which SendNextTimeout has
-// caused RPCs to be sent to all three replicas simultaneously. The
-// caller may then cause those RPCs to finish by writing to one of the
-// 'done' channels in the first return value; the second returned
-// channel will contain the final result of the send() call.
-//
-// TODO(bdarnell): all the 'done' channels are currently the same.
-// Either give each call its own channel, return a list of (replica
-// descriptor, channel) pair, or decide we don't care about
-// distinguishing them and just send a single channel.
-func setupSendNextTest(t *testing.T) ([]chan<- BatchCall, chan BatchCall, *stop.Stopper) {
-	stopper := stop.NewStopper()
-	nodeContext := rpc.NewContext(
-		log.AmbientContext{},
-		testutils.NewNodeTestBaseContext(),
-		hlc.NewClock(hlc.UnixNano, time.Nanosecond),
-		stopper,
-	)
-
-	addrs := []net.Addr{
-		util.NewUnresolvedAddr("dummy", "1"),
-		util.NewUnresolvedAddr("dummy", "2"),
-		util.NewUnresolvedAddr("dummy", "3"),
-	}
-
-	doneChanChan := make(chan chan<- BatchCall, len(addrs))
-
-	sendChan := make(chan BatchCall, 1)
-	go func() {
-		// Send the batch. This will block until we signal one of the done
-		// channels.
-		br, err := sendBatch(
-			context.Background(),
-			func(
-				_ SendOptions,
-				_ *rpc.Context,
-				replicas ReplicaSlice,
-				_ roachpb.BatchRequest,
-			) (Transport, error) {
-				return &channelSaveTransport{
-					ch:        doneChanChan,
-					remaining: len(replicas),
-				}, nil
-			},
-			SendOptions{SendNextTimeout: time.Millisecond},
-			addrs,
-			nodeContext,
-		)
-		sendChan <- BatchCall{br, err}
-	}()
-
-	doneChans := make([]chan<- BatchCall, len(addrs))
-	for i := range doneChans {
-		// Note that this blocks until the replica has been contacted.
-		doneChans[i] = <-doneChanChan
-	}
-	return doneChans, sendChan, stopper
-}
-
-// Test the behavior of SendNextTimeout when all servers are slow to
-// respond (but successful).
-func TestSendNext_AllSlow(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop(context.TODO())
-
-	// Now that all replicas have been contacted, let one finish.
-	doneChans[1] <- BatchCall{
-		Reply: &roachpb.BatchResponse{
-			BatchResponse_Header: roachpb.BatchResponse_Header{
-				Now: hlc.Timestamp{Logical: 42},
-			},
-		},
-		Err: nil,
-	}
-
-	// The RPC now completes successfully.
-	bc := <-sendChan
-	if bc.Err != nil {
-		t.Fatal(bc.Err)
-	}
-	// Make sure the response we sent in is the one we get back.
-	if bc.Reply.Now.Logical != 42 {
-		t.Errorf("got unexpected response: %s", bc.Reply)
-	}
-}
-
-// Test the behavior of SendNextTimeout when some servers return
-// RPC errors but one succeeds.
-func TestSendNext_RPCErrorThenSuccess(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop(context.TODO())
-
-	// Now that all replicas have been contacted, let two finish with
-	// retryable errors.
-	for i := 1; i <= 2; i++ {
-		doneChans[i] <- BatchCall{
-			Reply: nil,
-			Err:   roachpb.NewSendError("boom"),
-		}
-	}
-
-	// The client is still waiting for the third slow RPC to complete.
-	select {
-	case bc := <-sendChan:
-		t.Fatalf("got unexpected response %v", bc)
-	default:
-	}
-
-	// Now let the final server complete the RPC successfully.
-	doneChans[0] <- BatchCall{
-		Reply: &roachpb.BatchResponse{},
-		Err:   nil,
-	}
-
-	// The client side now completes successfully.
-	bc := <-sendChan
-	if bc.Err != nil {
-		t.Fatal(bc.Err)
-	}
-}
-
-// Test the behavior of SendNextTimeout when all servers return
-// RPC errors (this is effectively the same whether
-// SendNextTimeout is used or not).
-func TestSendNext_AllRPCErrors(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop(context.TODO())
-
-	// All replicas finish with RPC errors.
-	for i := 0; i <= 2; i++ {
-		doneChans[i] <- BatchCall{
-			Reply: nil,
-			Err:   errors.New("boom"),
-		}
-	}
-
-	// The client side completes with a retryable send error.
-	bc := <-sendChan
-	if _, ok := bc.Err.(*roachpb.SendError); !ok {
-		t.Errorf("did not get expected SendError; got %T instead", bc.Err)
-	}
-}
-
-func TestSendNext_RetryableApplicationErrorThenSuccess(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop(context.TODO())
-
-	// One replica finishes with a retryable error.
-	doneChans[1] <- BatchCall{
-		Reply: &roachpb.BatchResponse{
-			BatchResponse_Header: roachpb.BatchResponse_Header{
-				Error: roachpb.NewError(roachpb.NewStoreNotFoundError(1)),
-			},
-		},
-	}
-
-	// A second replica finishes successfully.
-	doneChans[2] <- BatchCall{
-		Reply: &roachpb.BatchResponse{},
-	}
-
-	// The client send finishes with the second response.
-	bc := <-sendChan
-	if bc.Err != nil {
-		t.Fatalf("unexpected RPC error: %s", bc.Err)
-	}
-	if bc.Reply.Error != nil {
-		t.Errorf("expected successful reply, got %s", bc.Reply.Error)
-	}
-}
-
-func TestSendNext_AllRetryableApplicationErrors(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop(context.TODO())
-
-	// All replicas finish with a retryable error.
-	for _, ch := range doneChans {
-		ch <- BatchCall{
-			Reply: &roachpb.BatchResponse{
-				BatchResponse_Header: roachpb.BatchResponse_Header{
-					Error: roachpb.NewError(roachpb.NewStoreNotFoundError(1)),
-				},
-			},
-		}
-	}
-
-	// The client send finishes with one of the errors, wrapped in a SendError.
-	bc := <-sendChan
-	if bc.Err == nil {
-		t.Fatalf("expected SendError, got err=nil and reply=%s", bc.Reply)
-	} else if _, ok := bc.Err.(*roachpb.SendError); !ok {
-		t.Fatalf("expected SendError, got err=%s", bc.Err)
-	} else if exp := "store 1 was not found"; !testutils.IsError(bc.Err, exp) {
-		t.Errorf("expected SendError to contain %q, but got %v", exp, bc.Err)
-	}
-}
-
-func TestSendNext_NonRetryableApplicationError(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	doneChans, sendChan, stopper := setupSendNextTest(t)
-	defer stopper.Stop(context.TODO())
-
-	// One replica finishes with a non-retryable error.
-	doneChans[1] <- BatchCall{
-		Reply: &roachpb.BatchResponse{
-			BatchResponse_Header: roachpb.BatchResponse_Header{
-				Error: roachpb.NewError(roachpb.NewTransactionReplayError()),
-			},
-		},
-	}
-
-	// The client completes with that error, without waiting for the
-	// others to finish.
-	bc := <-sendChan
-	if bc.Err != nil {
-		t.Fatalf("expected error in payload, not rpc error %s", bc.Err)
-	}
-	if _, ok := bc.Reply.Error.GetDetail().(*roachpb.TransactionReplayError); !ok {
-		t.Errorf("expected TransactionReplayError, got %v", bc.Reply.Error)
 	}
 }
 
@@ -377,13 +110,6 @@ type firstNErrorTransport struct {
 
 func (f *firstNErrorTransport) IsExhausted() bool {
 	return f.numSent >= len(f.replicas)
-}
-
-func (f *firstNErrorTransport) SendNextTimeout(defaultTimeout time.Duration) (time.Duration, bool) {
-	if f.IsExhausted() {
-		return 0, false
-	}
-	return defaultTimeout, true
 }
 
 func (f *firstNErrorTransport) SendNext(_ context.Context, done chan<- BatchCall) {
@@ -463,7 +189,6 @@ func TestComplexScenarios(t *testing.T) {
 					numErrors: test.numErrors,
 				}, nil
 			},
-			SendOptions{},
 			serverAddrs,
 			nodeContext,
 		)
@@ -557,24 +282,12 @@ func makeReplicas(addrs ...net.Addr) ReplicaSlice {
 
 // sendBatch sends Batch requests to specified addresses using send.
 func sendBatch(
-	ctx context.Context,
-	transportFactory TransportFactory,
-	opts SendOptions,
-	addrs []net.Addr,
-	rpcContext *rpc.Context,
+	ctx context.Context, transportFactory TransportFactory, addrs []net.Addr, rpcContext *rpc.Context,
 ) (*roachpb.BatchResponse, error) {
 	ds := NewDistSender(DistSenderConfig{
-		TransportFactory: transportFactory,
-		// After an error, we wait for up to PendingRPCTimeout to reduce
-		// the chance of returning AmbiguousResultError. These tests
-		// predate that mechanism and will wait for the full duration of
-		// PendingRPCTimeout (specifically in
-		// TestSendNext_NonRetryableApplicationError, so set it to
-		// something small.
-		// TODO(bdarnell): this is related to #16181. If we come up with
-		// an alternative solution there, we may be able to remove this.
-		PendingRPCTimeout: time.Millisecond,
+		TestingKnobs: DistSenderTestingKnobs{
+			TransportFactory: transportFactory,
+		},
 	}, nil)
-	opts.metrics = &ds.metrics
-	return ds.sendToReplicas(ctx, opts, 0, makeReplicas(addrs...), roachpb.BatchRequest{}, rpcContext)
+	return ds.sendToReplicas(ctx, SendOptions{metrics: &ds.metrics}, 0, makeReplicas(addrs...), roachpb.BatchRequest{}, rpcContext)
 }

--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -43,8 +43,6 @@ type SendOptions struct {
 	// other replicas in a set.
 	SendNextTimeout time.Duration
 
-	transportFactory TransportFactory
-
 	metrics *DistSenderMetrics
 }
 

--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -39,10 +39,6 @@ import (
 // more replicas, depending on error conditions and how many successful
 // responses are required.
 type SendOptions struct {
-	// SendNextTimeout is the duration after which RPCs are sent to
-	// other replicas in a set.
-	SendNextTimeout time.Duration
-
 	metrics *DistSenderMetrics
 }
 
@@ -86,12 +82,6 @@ type TransportFactory func(
 type Transport interface {
 	// IsExhausted returns true if there are no more replicas to try.
 	IsExhausted() bool
-
-	// SendNextTimeout returns the timeout after which the next untried,
-	// or retryable, replica may be attempted. Returns a duration
-	// indicating when another replica should be tried, and a bool
-	// indicating whether one should be (if false, duration will be 0).
-	SendNextTimeout(time.Duration) (time.Duration, bool)
 
 	// SendNext sends the rpc (captured at creation time) to the next
 	// replica. May panic if the transport is exhausted. Should not
@@ -159,11 +149,10 @@ type grpcTransport struct {
 	clientPendingMu syncutil.Mutex // protects access to all batchClient pending flags
 }
 
-// IsExhausted returns false if there are any untried replicas
-// remaining. If there are none, it attempts to resurrect replicas
-// which were tried but failed with a retryable error and have a
-// deadline set which has elapsed. If any where resurrected, returns
-// false; true otherwise.
+// IsExhausted returns false if there are any untried replicas remaining. If
+// there are none, it attempts to resurrect replicas which were tried but
+// failed with a retryable error. If any where resurrected, returns false;
+// true otherwise.
 func (gt *grpcTransport) IsExhausted() bool {
 	gt.clientPendingMu.Lock()
 	defer gt.clientPendingMu.Unlock()
@@ -188,31 +177,6 @@ func (gt *grpcTransport) maybeResurrectRetryables() bool {
 		gt.moveToFrontLocked(c.args.Replica)
 	}
 	return len(resurrect) > 0
-}
-
-// SendNextTimeout returns the default SendOpts.SendNextTimeout if
-// there are any untried replicas in the transport. Otherwise, it
-// returns the earliest deadline of any replicas which experienced
-// retryable errors.
-func (gt *grpcTransport) SendNextTimeout(defaultTimeout time.Duration) (time.Duration, bool) {
-	gt.clientPendingMu.Lock()
-	defer gt.clientPendingMu.Unlock()
-	if gt.clientIndex < len(gt.orderedClients) {
-		return defaultTimeout, true
-	}
-	var deadline time.Time
-	for i := 0; i < gt.clientIndex; i++ {
-		if c := gt.orderedClients[i]; !c.pending && c.retryable {
-			if (deadline == time.Time{}) || c.deadline.Before(deadline) {
-				deadline = c.deadline
-			}
-		}
-	}
-	if (deadline == time.Time{}) {
-		return 0, false
-	}
-	// Returning a negative duration is legal.
-	return deadline.Sub(timeutil.Now()), true
 }
 
 // SendNext invokes the specified RPC on the supplied client when the
@@ -269,8 +233,8 @@ func (gt *grpcTransport) SendNext(ctx context.Context, done chan<- BatchCall) {
 		// NotLeaseHolderErrors can be retried.
 		var retryable bool
 		if reply != nil && reply.Error != nil {
-			// TODO(spencer): pass the lease expiration when setting the state to
-			// set a more efficient deadline for retrying this replica.
+			// TODO(spencer): pass the lease expiration when setting the state
+			// to set a more efficient deadline for retrying this replica.
 			if _, ok := reply.Error.GetDetail().(*roachpb.NotLeaseHolderError); ok {
 				retryable = true
 			}
@@ -301,7 +265,8 @@ func (gt *grpcTransport) moveToFrontLocked(replica roachpb.ReplicaDescriptor) {
 			if gt.orderedClients[i].pending {
 				return
 			}
-			// Clear the retryable bit and deadline, as this replica is being made available.
+			// Clear the retryable bit as this replica is being made
+			// available.
 			gt.orderedClients[i].retryable = false
 			gt.orderedClients[i].deadline = time.Time{}
 			// If we've already processed the replica, decrement the current
@@ -335,9 +300,9 @@ func (gt *grpcTransport) setState(replica roachpb.ReplicaDescriptor, pending, re
 			gt.orderedClients[i].pending = pending
 			gt.orderedClients[i].retryable = retryable
 			if retryable {
-				gt.orderedClients[i].deadline = timeutil.Now().Add(gt.opts.SendNextTimeout)
+				gt.orderedClients[i].deadline = timeutil.Now().Add(time.Second)
 			}
-			return
+			break
 		}
 	}
 }
@@ -386,13 +351,6 @@ type senderTransport struct {
 
 func (s *senderTransport) IsExhausted() bool {
 	return s.called
-}
-
-func (s *senderTransport) SendNextTimeout(defaultTimeout time.Duration) (time.Duration, bool) {
-	if s.IsExhausted() {
-		return 0, false
-	}
-	return defaultTimeout, true
 }
 
 func (s *senderTransport) SendNext(ctx context.Context, done chan<- BatchCall) {

--- a/pkg/kv/transport_race.go
+++ b/pkg/kv/transport_race.go
@@ -52,10 +52,10 @@ func jitter(avgInterval time.Duration) time.Duration {
 	return time.Duration(rand.Int63n(int64(2 * avgInterval)))
 }
 
-// grpcTransportFactory during race builds wraps the implementation and
+// GRPCTransportFactory during race builds wraps the implementation and
 // intercepts all BatchRequests, reading them in a tight loop. This allows the
 // race detector to catch any mutations of a batch passed to the transport.
-func grpcTransportFactory(
+func GRPCTransportFactory(
 	opts SendOptions, rpcContext *rpc.Context, replicas ReplicaSlice, args roachpb.BatchRequest,
 ) (Transport, error) {
 	if atomic.AddInt32(&running, 1) <= 1 {

--- a/pkg/kv/transport_regular.go
+++ b/pkg/kv/transport_regular.go
@@ -24,7 +24,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 )
 
-func grpcTransportFactory(
+// GRPCTransportFactory is the default TransportFactory, using GRPC.
+func GRPCTransportFactory(
 	opts SendOptions, rpcContext *rpc.Context, replicas ReplicaSlice, args roachpb.BatchRequest,
 ) (Transport, error) {
 	return grpcTransportFactoryImpl(opts, rpcContext, replicas, args)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -210,13 +210,6 @@ type Config struct {
 	// Environment Variable: COCKROACH_TIME_UNTIL_STORE_DEAD
 	TimeUntilStoreDead *settings.DurationSetting
 
-	// SendNextTimeout is the time after which an alternate replica will
-	// be used to attempt sending a KV batch.
-	// Environment Variable: COCKROACH_SEND_NEXT_TIMEOUT
-	SendNextTimeout time.Duration
-
-	PendingRPCTimeout time.Duration
-
 	// TestingKnobs is used for internal test controls only.
 	TestingKnobs base.TestingKnobs
 
@@ -383,8 +376,6 @@ func MakeConfig() Config {
 		ConsistencyCheckInterval: defaultConsistencyCheckInterval,
 		MetricsSampleInterval:    defaultMetricsSampleInterval,
 		TimeUntilStoreDead:       timeUntilStoreDead,
-		SendNextTimeout:          base.DefaultSendNextTimeout,
-		PendingRPCTimeout:        base.DefaultPendingRPCTimeout,
 		EventLogEnabled:          defaultEventLogEnabled,
 		Stores: base.StoreSpecList{
 			Specs: []base.StoreSpec{storeSpec},
@@ -408,8 +399,6 @@ func (cfg *Config) String() string {
 	fmt.Fprintln(w, "consistency check interval\t", cfg.ConsistencyCheckInterval)
 	fmt.Fprintln(w, "metrics sample interval\t", cfg.MetricsSampleInterval)
 	fmt.Fprintln(w, "time until store dead\t", cfg.TimeUntilStoreDead)
-	fmt.Fprintln(w, "send next timeout\t", cfg.SendNextTimeout)
-	fmt.Fprintln(w, "pending RPC timeout\t", cfg.PendingRPCTimeout)
 	fmt.Fprintln(w, "event log enabled\t", cfg.EventLogEnabled)
 	fmt.Fprintln(w, "linearizable\t", cfg.Linearizable)
 	if cfg.ListeningURLFile != "" {
@@ -597,7 +586,6 @@ func (cfg *Config) readEnvironmentVariables() {
 	cfg.MetricsSampleInterval = envutil.EnvOrDefaultDuration("COCKROACH_METRICS_SAMPLE_INTERVAL", cfg.MetricsSampleInterval)
 	cfg.ScanInterval = envutil.EnvOrDefaultDuration("COCKROACH_SCAN_INTERVAL", cfg.ScanInterval)
 	cfg.ScanMaxIdleTime = envutil.EnvOrDefaultDuration("COCKROACH_SCAN_MAX_IDLE_TIME", cfg.ScanMaxIdleTime)
-	cfg.SendNextTimeout = envutil.EnvOrDefaultDuration("COCKROACH_SEND_NEXT_TIMEOUT", cfg.SendNextTimeout)
 	cfg.ConsistencyCheckInterval = envutil.EnvOrDefaultDuration("COCKROACH_CONSISTENCY_CHECK_INTERVAL", cfg.ConsistencyCheckInterval)
 }
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -130,12 +130,6 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.SQLMemoryPoolSize != 0 {
 		cfg.SQLMemoryPoolSize = params.SQLMemoryPoolSize
 	}
-	if params.SendNextTimeout != 0 {
-		cfg.SendNextTimeout = params.SendNextTimeout
-	}
-	if params.PendingRPCTimeout != 0 {
-		cfg.PendingRPCTimeout = params.PendingRPCTimeout
-	}
 	cfg.JoinList = []string{params.JoinAddr}
 	if cfg.Insecure {
 		// Whenever we can (i.e. in insecure mode), use IsolatedTestAddr

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -21,69 +21,122 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
-	"time"
 
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/lib/pq"
 )
 
-// TestAmbiguousCommitDueToLeadershipChange verifies that an ambiguous
-// commit error is returned from sql.Exec in situations where an
-// EndTransaction is part of a batch and the disposition of the batch
-// request is unknown after a network failure or timeout. The goal
-// here is to prevent spurious transaction retries after the initial
-// transaction actually succeeded. In cases where there's an
-// auto-generated primary key, this can result in silent
-// duplications. In cases where the primary key is specified in
-// advance, it can result in violated uniqueness constraints, or
-// duplicate key violations. See #6053, #7604, and #10023.
-func TestAmbiguousCommitDueToLeadershipChange(t *testing.T) {
+type interceptingTransport struct {
+	kv.Transport
+	sendNext func(context.Context, chan<- kv.BatchCall)
+}
+
+func (t *interceptingTransport) SendNext(ctx context.Context, done chan<- kv.BatchCall) {
+	if fn := t.sendNext; fn != nil {
+		fn(ctx, done)
+	} else {
+		t.Transport.SendNext(ctx, done)
+	}
+}
+
+// TestAmbiguousCommit verifies that an ambiguous commit error is returned
+// from sql.Exec in situations where an EndTransaction is part of a batch and
+// the disposition of the batch request is unknown after a network failure or
+// timeout. The goal here is to prevent spurious transaction retries after the
+// initial transaction actually succeeded. In cases where there's an auto-
+// generated primary key, this can result in silent duplications. In cases
+// where the primary key is specified in advance, it can result in violated
+// uniqueness constraints, or duplicate key violations. See #6053, #7604, and
+// #10023.
+func TestAmbiguousCommit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	for _, requireDistSenderRetry := range []bool{true, false} {
-		t.Run(fmt.Sprintf("retry=%t", requireDistSenderRetry), func(t *testing.T) {
-			// Create a command filter which prevents EndTransaction from
-			// returning a response.
-			params := base.TestServerArgs{}
-			committed := make(chan struct{})
-			wait := make(chan struct{})
+	for _, ambiguousSuccess := range []bool{true, false} {
+		t.Run(fmt.Sprintf("ambiguousSuccess=%t", ambiguousSuccess), func(t *testing.T) {
+			var params base.TestServerArgs
+			var processed int32
 			var tableStartKey atomic.Value
-			var responseCount int32
 
-			// Prevent the first conditional put on table 51 from returning to
-			// waiting client in order to simulate a lost update or slow network
-			// link.
-			params.Knobs.Store = &storage.StoreTestingKnobs{
-				TestingResponseFilter: func(ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
-					req, ok := ba.GetArg(roachpb.ConditionalPut)
-					tsk := tableStartKey.Load()
-					if tsk == nil {
-						return nil
-					}
-					if !ok || !bytes.HasPrefix(req.Header().Key, tsk.([]byte)) {
-						return nil
-					}
-					// If this is the first write to the table, wait to respond to the
-					// client in order to simulate a retry.
-					if atomic.AddInt32(&responseCount, 1) == 1 {
-						close(committed)
-						<-wait
-					}
+			translateToRPCError := roachpb.NewError(errors.Errorf("%s: RPC error: success=%t", t.Name(), ambiguousSuccess))
+
+			maybeRPCError := func(req *roachpb.ConditionalPutRequest) *roachpb.Error {
+				tsk, ok := tableStartKey.Load().([]byte)
+				if !ok {
 					return nil
+				}
+				if !bytes.HasPrefix(req.Header().Key, tsk) {
+					return nil
+				}
+				if atomic.AddInt32(&processed, 1) == 1 {
+					return translateToRPCError
+				}
+				return nil
+			}
+
+			params.Knobs.DistSender = &kv.DistSenderTestingKnobs{
+				TransportFactory: func(opts kv.SendOptions, rpcContext *rpc.Context, replicas kv.ReplicaSlice, args roachpb.BatchRequest) (kv.Transport, error) {
+					transport, err := kv.GRPCTransportFactory(opts, rpcContext, replicas, args)
+					return &interceptingTransport{
+						Transport: transport,
+						sendNext: func(ctx context.Context, done chan<- kv.BatchCall) {
+							if ambiguousSuccess {
+								interceptDone := make(chan kv.BatchCall)
+								transport.SendNext(ctx, interceptDone)
+								call := <-interceptDone
+								if pErr := call.Reply.Error; pErr.Equal(translateToRPCError) {
+									// Translate the injected error into an RPC
+									// error to simulate an ambiguous result.
+									done <- kv.BatchCall{Err: pErr.GoError()}
+								} else {
+									// Either the call succeeded or we got a non-
+									// sentinel error; let normal machinery do its
+									// thing.
+									done <- call
+								}
+							} else {
+								if req, ok := args.GetArg(roachpb.ConditionalPut); ok {
+									if pErr := maybeRPCError(req.(*roachpb.ConditionalPutRequest)); pErr != nil {
+										// Blackhole the RPC and return an
+										// error to simulate an ambiguous
+										// result.
+										done <- kv.BatchCall{Err: pErr.GoError()}
+
+										return
+									}
+								}
+								transport.SendNext(ctx, done)
+							}
+						},
+					}, err
 				},
 			}
-			params.SendNextTimeout = 50 * time.Millisecond
-			params.PendingRPCTimeout = 50 * time.Millisecond
+
+			{
+				storeTestingKnobs := new(storage.StoreTestingKnobs)
+
+				if ambiguousSuccess {
+					storeTestingKnobs.TestingResponseFilter = func(args roachpb.BatchRequest, _ *roachpb.BatchResponse) *roachpb.Error {
+						if req, ok := args.GetArg(roachpb.ConditionalPut); ok {
+							return maybeRPCError(req.(*roachpb.ConditionalPutRequest))
+						}
+						return nil
+					}
+				}
+				params.Knobs.Store = storeTestingKnobs
+			}
+
 			testClusterArgs := base.TestClusterArgs{
 				ReplicationMode: base.ReplicationAuto,
 				ServerArgs:      params,
@@ -92,12 +145,16 @@ func TestAmbiguousCommitDueToLeadershipChange(t *testing.T) {
 			tc := testcluster.StartTestCluster(t, numReplicas, testClusterArgs)
 			defer tc.Stopper().Stop(context.TODO())
 
-			sqlDB := sqlutils.MakeSQLRunner(t, tc.Conns[0])
+			sqlDB := tc.Conns[0]
 
-			sqlDB.Exec(`CREATE DATABASE test`)
-			sqlDB.Exec(`CREATE TABLE test.t (k SERIAL PRIMARY KEY, v INT)`)
+			if _, err := sqlDB.Exec(`CREATE DATABASE test`); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := sqlDB.Exec(`CREATE TABLE test.t (k SERIAL PRIMARY KEY, v INT)`); err != nil {
+				t.Fatal(err)
+			}
 
-			tableID, err := sqlutils.QueryTableID(tc.Conns[0], "test", "t")
+			tableID, err := sqlutils.QueryTableID(sqlDB, "test", "t")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -108,75 +165,36 @@ func TestAmbiguousCommitDueToLeadershipChange(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Lookup the lease.
-			tableRangeDesc, err := tc.LookupRange(tableStartKey.Load().([]byte))
-			if err != nil {
+			// Ensure that the dist sender's cache is up to date before
+			// fault injection.
+			if rows, err := sqlDB.Query(`SELECT * FROM test.t`); err != nil {
+				t.Fatal(err)
+			} else if err := rows.Close(); err != nil {
 				t.Fatal(err)
 			}
-			// Loop until we can get the lease holder. We query in the loop to
-			// ensure that the lease is acquired.
-			var leaseHolder roachpb.ReplicationTarget
-			testutils.SucceedsSoon(t, func() error {
-				rows := sqlDB.Query(`SELECT * FROM test.t`)
-				rows.Close()
-				leaseHolder, err = tc.FindRangeLeaseHolder(
-					tableRangeDesc,
-					&roachpb.ReplicationTarget{
-						NodeID:  tc.Servers[0].GetNode().Descriptor.NodeID,
-						StoreID: tc.Servers[0].GetFirstStoreID(),
-					})
-				return err
-			})
 
-			// In a goroutine, send an insert which will commit but not return
-			// from the leader (due to the command filter we installed on node 0).
-			sqlErrCh := make(chan error, 1)
-			go func() {
-				// Use a connection other than through the node which is the current
-				// leaseholder to ensure that we use GRPC instead of the local server.
-				// If we use a local server, the hanging response we simulate takes
-				// up the dist sender thread of execution because local requests are
-				// executed synchronously.
-				sqlConn := tc.Conns[leaseHolder.NodeID%numReplicas]
-				_, err := sqlConn.Exec(`INSERT INTO test.t (v) VALUES (1)`)
-				sqlErrCh <- err
-				close(wait)
-			}()
-			// Wait until the insert has committed.
-			<-committed
-
-			// If requested, wait for two further attempts from the distributed sender.
-			if requireDistSenderRetry {
-				// Wait for twice the send next timeout.
-				time.Sleep(2 * params.SendNextTimeout)
-			}
-
-			// Find a node other than the current lease holder to transfer the lease to.
-			for i, s := range tc.Servers {
-				if leaseHolder.StoreID != s.GetFirstStoreID() {
-					if err := tc.TransferRangeLease(tableRangeDesc, tc.Target(i)); err != nil {
-						t.Fatal(err)
+			if _, err := sqlDB.Exec(`INSERT INTO test.t (v) VALUES (1)`); ambiguousSuccess {
+				if pqErr, ok := err.(*pq.Error); ok {
+					if pqErr.Code != pgerror.CodeStatementCompletionUnknownError {
+						t.Errorf("expected code %q, got %q (err: %s)",
+							pgerror.CodeStatementCompletionUnknownError, pqErr.Code, err)
 					}
-					break
+				} else {
+					t.Errorf("expected pq error; got %v", err)
 				}
-			}
-
-			// Wait for the error from the pending SQL insert.
-			err = <-sqlErrCh
-			if pqErr, ok := err.(*pq.Error); !ok {
-				t.Errorf("expected ambiguous commit error with correct code; got %v", err)
 			} else {
-				if pqErr.Code != pgerror.CodeStatementCompletionUnknownError {
-					t.Errorf("expected code %q, got %q (err: %s)",
-						pgerror.CodeStatementCompletionUnknownError, pqErr.Code, err)
+				if err != nil {
+					t.Error(err)
 				}
 			}
 
 			// Verify a single row exists in the table.
 			var rowCount int
-			sqlDB.QueryRow(`SELECT count(*) FROM test.t`).Scan(&rowCount)
-			if rowCount != 1 {
-				t.Errorf("expected 1 row but found %d", rowCount)
+			if err := sqlDB.QueryRow(`SELECT count(*) FROM test.t`).Scan(&rowCount); err != nil {
+				t.Fatal(err)
+			}
+			if e := 1; rowCount != e {
+				t.Errorf("expected %d row(s) but found %d", e, rowCount)
 			}
 		})
 	}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -469,7 +469,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	}
 
 	repl1.mu.Lock()
-	expErr := repl1.mu.destroyed
+	expErr := roachpb.NewError(repl1.mu.destroyed)
 	lease := *repl1.mu.state.Lease
 	repl1.mu.Unlock()
 
@@ -477,10 +477,10 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 		t.Fatal("replica was not marked as destroyed")
 	}
 
-	if _, _, _, err := repl1.propose(
+	if _, _, _, pErr := repl1.propose(
 		context.Background(), lease, roachpb.BatchRequest{}, nil, nil,
-	); err != expErr {
-		t.Fatalf("expected error %s, but got %v", expErr, err)
+	); !pErr.Equal(expErr) {
+		t.Fatalf("expected error %s, but got %v", expErr, pErr)
 	}
 }
 


### PR DESCRIPTION
Reviewer note: this is nearly all code deletion when viewed with whitespace ignored, except for one line in `pkg/kv/transport.go` where I hardcoded `time.Second` in the clients' deadline field.

~~I don't feel great about removing `TestAmbiguousCommitDueToLeadershipChange`, but I don't know how to rewrite that test in the absence of `SendNextTimeout`; the scenario tested there seems no longer to be possible.~~