### PR TITLE
sql: do not use leased table descriptors modified during a transaction

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -111,6 +111,8 @@ func (n *createDatabaseNode) Start(ctx context.Context) error {
 		); err != nil {
 			return err
 		}
+		n.p.session.tables.addUncommittedDatabase(
+			desc.Name, desc.ID, false /* dropped */)
 	}
 	return nil
 }

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -283,6 +283,11 @@ func (p *planner) renameDatabase(
 	b.Put(descKey, descDesc)
 	b.Del(oldKey)
 
+	p.session.tables.addUncommittedDatabase(
+		oldName, descID, true /* dropped */)
+	p.session.tables.addUncommittedDatabase(
+		newName, descID, false /* dropped */)
+
 	if err := p.txn.Run(ctx, b); err != nil {
 		if _, ok := err.(*roachpb.ConditionFailedError); ok {
 			return onAlreadyExists()

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -152,6 +152,10 @@ func (p *planner) createDescriptorWithID(
 		return expectDescriptor(systemConfig, descKey, descDesc)
 	})
 
+	if desc, ok := descriptor.(*sqlbase.TableDescriptor); ok {
+		p.session.tables.addUncommittedTable(*desc)
+	}
+
 	return p.txn.Run(ctx, b)
 }
 

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -184,6 +184,8 @@ func (n *dropDatabaseNode) Start(ctx context.Context) error {
 		return nil
 	})
 
+	n.p.session.tables.addUncommittedDatabase(n.dbDesc.Name, n.dbDesc.ID, true /*dropped*/)
+
 	if err := n.p.txn.Run(ctx, b); err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -158,3 +158,99 @@ ALTER TABLE test2.v1 RENAME TO test2.v1
 
 statement error cannot rename relation "test2.t2" because view "v1" depends on it
 ALTER TABLE test2.t2 RENAME TO test2.t3
+
+# Tests that uncommitted database or table names can be used by statements
+# in the same transaction. Also tests that if the transaction doesn't commit
+# the names are discarded and cannot be used by future transactions.
+
+statement ok
+BEGIN
+
+statement ok
+CREATE DATABASE d; CREATE TABLE d.kv (k CHAR PRIMARY KEY, v CHAR);
+
+statement ok
+INSERT INTO d.kv (k,v) VALUES ('a', 'b')
+
+statement ok
+COMMIT
+
+statement ok
+INSERT INTO d.kv (k,v) VALUES ('c', 'd')
+
+# A table rename disallows the use of the old name
+statement ok
+BEGIN
+
+statement ok
+ALTER TABLE d.kv RENAME TO d.kv2
+
+statement ok
+INSERT INTO d.kv2 (k,v) VALUES ('e', 'f')
+
+statement error relation \"d.kv\" does not exist
+INSERT INTO d.kv (k,v) VALUES ('g', 'h')
+
+statement ok
+ROLLBACK
+
+# A database rename disallows the use of the old name.
+statement ok
+BEGIN
+
+statement ok
+ALTER DATABASE d RENAME TO dnew
+
+statement ok
+INSERT INTO dnew.kv (k,v) VALUES ('e', 'f')
+
+statement error relation \"d.kv\" does not exist
+INSERT INTO d.kv (k,v) VALUES ('g', 'h')
+
+statement ok
+ROLLBACK
+
+# The reuse of a name is allowed.
+statement ok
+BEGIN
+
+statement ok
+ALTER DATABASE d RENAME TO dnew; CREATE DATABASE d; CREATE TABLE d.kv (k CHAR PRIMARY KEY, v CHAR)
+
+statement ok
+INSERT INTO d.kv (k,v) VALUES ('a', 'b')
+
+statement ok
+COMMIT
+
+# Check that on a rollback a database name cannot be used.
+statement ok
+BEGIN
+
+statement ok
+CREATE DATABASE dd; CREATE TABLE dd.kv (k CHAR PRIMARY KEY, v CHAR)
+
+statement ok
+INSERT INTO dd.kv (k,v) VALUES ('a', 'b')
+
+statement ok
+ROLLBACK
+
+statement error database \"dd\" does not exist
+INSERT INTO dd.kv (k,v) VALUES ('c', 'd')
+
+# Check that on a rollback a table name cannot be used.
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE d.kv2 (k CHAR PRIMARY KEY, v CHAR)
+
+statement ok
+INSERT INTO d.kv2 (k,v) VALUES ('a', 'b')
+
+statement ok
+ROLLBACK
+
+statement error relation \"d.kv2\" does not exist
+INSERT INTO d.kv2 (k,v) VALUES ('c', 'd')

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -227,22 +227,6 @@ SELECT span, operation, regexp_replace(message, '\d\d\d\d\d+', '...PK...') as me
 (0,1)  starting plan  querying next range at /Table/3/1/1/2/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
 (0,1)  starting plan  r1: sending batch 5 CPut to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/51/"kv2"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/53/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/1/"lease"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/11/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  r1: sending batch 1 CPut, 1 BeginTxn to (n1,s1):1
-(0,1)  starting plan  r1: sending batch 1 EndTxn to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/52/1
 (0,1)  starting plan  r1: sending batch 1 Scan to (n1,s1):1
 (0,1)  starting plan  fetched: /kv/primary/1/v -> /2

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -498,26 +498,13 @@ func TestPGPrepareWithCreateDropInTxn(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		stmt, err := tx.Prepare(`INSERT INTO d.kv (k,v) VALUES ($1, $2);`)
-		if err != nil {
-			t.Fatal(err)
+		if _, err := tx.Prepare(`
+INSERT INTO d.kv (k,v) VALUES ($1, $2);
+`); !testutils.IsError(err, "relation \"d.kv\" does not exist") {
+			t.Fatalf("err = %v", err)
 		}
 
-		// INSERT works because it is using a cached descriptor that is leased.
-		res, err := stmt.Exec('c', 'd')
-		if err != nil {
-			t.Fatal(err)
-		}
-		stmt.Close()
-		affected, err := res.RowsAffected()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if affected != 1 {
-			t.Fatalf("unexpected number of rows affected: %d", affected)
-		}
-
-		if err := tx.Commit(); err != nil {
+		if err := tx.Rollback(); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/sql/rename_test.go
+++ b/pkg/sql/rename_test.go
@@ -256,28 +256,51 @@ CREATE TABLE test.t (a INT PRIMARY KEY);
 		t.Fatal(err)
 	}
 
-	txn, err := db.Begin()
-	if err != nil {
+	// Make sure we take a lease on the version called "t".
+	if _, err := db.Exec("SELECT * FROM test.t"); err != nil {
 		t.Fatal(err)
+	}
+	{
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := txn.Exec("ALTER TABLE test.t RENAME TO test.t2"); err != nil {
+			t.Fatal(err)
+		}
+		// Check that we can use the new name.
+		if _, err := txn.Exec("SELECT * FROM test.t2"); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := txn.Commit(); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	// Make sure we take a lease on the version called "t".
-	if _, err := txn.Exec("SELECT * FROM test.t"); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := txn.Exec("ALTER TABLE test.t RENAME TO test.t2"); err != nil {
-		t.Fatal(err)
-	}
-	// Check that we can use the new name.
-	if _, err := txn.Exec("SELECT * FROM test.t2"); err != nil {
-		t.Fatal(err)
-	}
-	// Check that we can also use the old name, since we have a lease on it.
-	if _, err := txn.Exec("SELECT * FROM test.t"); err != nil {
-		t.Fatal(err)
-	}
-	if err := txn.Commit(); err != nil {
-		t.Fatal(err)
+	{
+		txn, err := db.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := txn.Exec("ALTER TABLE test.t2 RENAME TO test.t"); err != nil {
+			t.Fatal(err)
+		}
+		// Check that we can use the new name.
+		if _, err := txn.Exec("SELECT * FROM test.t"); err != nil {
+			t.Fatal(err)
+		}
+		// Check that we cannot use the old name.
+		if _, err := txn.Exec(`
+SELECT * FROM test.t2
+`); !testutils.IsError(err, "relation \"test.t2\" does not exist") {
+			t.Fatalf("err = %v", err)
+		}
+		if err := txn.Rollback(); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
This change makes a sql transaction cache table descriptors modified
by it and use them within the transaction without leasing the descriptors
themselves. This allows a transaction to consistently see its own changes.

The need for this change is described here:

https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/table_descriptor_lease.md#accommodating-schema-changes-within-transactions

In the future, we plan to decouple the user transaction from the
transaction acquiring a lease. This change will prevent a
deadlock between an open transaction that has modified a descriptor
and the other transaction that is attempting to acquire a lease
on the descriptor. This change breaks the dependency between these
two transactions, by having the former not depend on the latter.