### PR TITLE
sqlccl: use AddSSTable in RESTORE and tweak some constants

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -9,6 +9,8 @@
 package sqlccl
 
 import (
+	"runtime"
+
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
@@ -515,11 +517,11 @@ func PresplitRanges(baseCtx context.Context, db client.DB, input []roachpb.Key) 
 		return nil
 	}
 
-	// 20 was picked because it's small enough that the 2tb restore acceptance
-	// test finishes smoothly on GCE and large enough that it only takes ~8
-	// minutes to presplit for a ~16000 range dataset.
+	// 100 was picked because it's small enough that a ~16000 presplit restore
+	// finishes smoothly on a 4-node azure production cluster.
+	//
 	// TODO(dan): See if there's some better solution #14798.
-	const splitsPerSecond, splitsBurst = 20, 1
+	const splitsPerSecond, splitsBurst = 100, 1
 	limiter := rate.NewLimiter(splitsPerSecond, splitsBurst)
 
 	g, ctx := errgroup.WithContext(ctx)
@@ -786,14 +788,15 @@ func Restore(
 	// transfers, poor performance on SQL workloads, etc) as well as log spam
 	// about slow distsender requests. Rate limit them here, too.
 	//
-	// Use the number of nodes in the cluster as the number of outstanding
-	// Import requests for the rate limiting. TODO(dan): This is very
-	// conservative, see if we can bump it back up by rate limiting WriteBatch.
+	// Use the number of cpus across all nodes in the cluster as the number of
+	// outstanding Import requests for the rate limiting. Note that this assumes
+	// all nodes in the cluster have the same number of cpus, but it's okay if
+	// that's wrong.
 	//
 	// TODO(dan): Make this limiting per node.
 	//
 	// TODO(dan): See if there's some better solution than rate-limiting #14798.
-	maxConcurrentImports := clusterNodeCount(p.ExecCfg().Gossip)
+	maxConcurrentImports := clusterNodeCount(p.ExecCfg().Gossip) * runtime.NumCPU()
 	importsSem := make(chan struct{}, maxConcurrentImports)
 
 	log.Eventf(ctx, "commencing import of data with concurrency %d", maxConcurrentImports)

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -11,6 +11,7 @@ package storageccl
 import (
 	"bytes"
 	"io/ioutil"
+	"runtime"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -30,12 +31,11 @@ import (
 
 // importRequestLimit is the number of Import requests that can run at once.
 // Each downloads a file from cloud storage to a temp file, iterates it, and
-// sends WriteBatch requests to batch insert it. After accounting for write
-// amplification, a single ImportRequest and the resulting WriteBatch
-// requests is enough to keep an SSD busy. Any more and we risk contending
-// RocksDB, which slows down heartbeats, which can cause mass lease
-// transfers.
-const importRequestLimit = 1
+// sends AddSSTable requests to batch insert it. Import and the resulting
+// AddSSTable calls are mostly cpu-bound at this point so allow NumCPU of them
+// to be running concurrently, which will hopefully hit the sweet spot between
+// maximizing throughput and minimizing thrashing.
+var importRequestLimit = runtime.NumCPU()
 
 var importRequestLimiter = makeConcurrentRequestLimiter(importRequestLimit)
 
@@ -53,8 +53,8 @@ var importBatchSize = func() *settings.ByteSizeSetting {
 var AddSSTableEnabled = func() *settings.BoolSetting {
 	s := settings.RegisterBoolSetting(
 		"kv.import.experimental_addsstable.enabled",
-		"set to true to use the AddSSTable command in Import",
-		false,
+		"set to true to use the AddSSTable command in Import or false to use WriteBatch",
+		true,
 	)
 	s.Hide()
 	return s


### PR DESCRIPTION
AddSSTable is baked enough for us to turn in on in alphas and start
production testing it. As a result, we can make some of the RESTORE
constants less restrictive.