### PR TITLE
build: avoid MACOSX_DEPLOYMENT_TARGET warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ override TAGS += make $(NATIVE_SPECIFIER_TAG)
 # to the host machine's actual macOS version works around this. See:
 # https://github.com/jemalloc/jemalloc/issues/494.
 ifdef MACOS
-export MACOSX_DEPLOYMENT_TARGET ?= $(shell sw_vers -productVersion)
+export MACOSX_DEPLOYMENT_TARGET ?= $(shell sw_vers -productVersion | grep -oE '[0-9]+\.[0-9]+')
 endif
 
 XGO := $(strip $(if $(XGOOS),GOOS=$(XGOOS)) $(if $(XGOARCH),GOARCH=$(XGOARCH)) $(if $(XHOST_TRIPLE),CC=$(CC_PATH) CXX=$(CXX_PATH)) $(GO))


### PR DESCRIPTION
Deep in the internals of the macOS build toolchain, the
MACOSX_DEPLOYMENT_TARGET defaults to "MAJOR.MINOR", not
"MAJOR.MINOR.PATCH", like we were using. This would result in warning
spam like

    ld: warning: object file
    (/Users/benesch/go/native/x86_64-apple-darwin16.6.0/jemalloc/lib/libjemalloc.a(pages.o))
    was built for newer OSX version (10.12.5) than being linked (10.12)

when running a bare `go build` or `go test`, because the C dependencies
were necessarily built with Make and thus saw the overridden
MACOSX_DEPLOYMENT_TARGET, but the bare `go build`/`go test` invoked the
linker directly, without the overriden MACOSX_DEPLOYMENT_TARGET.

This is arguably a bug in macOS, but the fix is easy: don't include
".PATCH" when we override MACOSX_DEPLOYMENT_TARGET from Make.

----

Split from #16907, which is blocked until Go 1.9 is released. This commit, however, is ready to go now.