### PR TITLE
storage: resurrect cgo-free MVCCComputeStats

### DIFF
--- a/pkg/ccl/storageccl/bench_test.go
+++ b/pkg/ccl/storageccl/bench_test.go
@@ -33,7 +33,7 @@ func BenchmarkAddSSTable(b *testing.B) {
 	tempDir, dirCleanupFn := testutils.TempDir(b)
 	defer dirCleanupFn()
 
-	for _, numEntries := range []int{100, 1000, 10000} {
+	for _, numEntries := range []int{100, 1000, 10000, 300000} {
 		b.Run(fmt.Sprintf("numEntries=%d", numEntries), func(b *testing.B) {
 			bankData := sampledataccl.BankRows(numEntries)
 			backupDir := filepath.Join(tempDir, strconv.Itoa(numEntries))
@@ -150,7 +150,7 @@ func runBenchmarkImport(b *testing.B) {
 	tempDir, dirCleanupFn := testutils.TempDir(b)
 	defer dirCleanupFn()
 
-	for _, numEntries := range []int{1, 100, 10000, 100000} {
+	for _, numEntries := range []int{1, 100, 10000, 300000} {
 		b.Run(fmt.Sprintf("numEntries=%d", numEntries), func(b *testing.B) {
 			bankData := sampledataccl.BankRows(numEntries)
 			backupDir := filepath.Join(tempDir, strconv.Itoa(numEntries))

--- a/pkg/storage/engine/build_default.go
+++ b/pkg/storage/engine/build_default.go
@@ -13,8 +13,9 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-// +build race
+// +build !race
 
-package storage
+package engine
 
-const raceEnabled = true
+// RaceEnabled is true if CockroachDB was built with the race build tag.
+const RaceEnabled = false

--- a/pkg/storage/engine/build_race.go
+++ b/pkg/storage/engine/build_race.go
@@ -13,8 +13,9 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-// +build !race
+// +build race
 
-package storage
+package engine
 
-const raceEnabled = false
+// RaceEnabled is true if CockroachDB was built with the race build tag.
+const RaceEnabled = true

--- a/pkg/storage/engine/db.cc
+++ b/pkg/storage/engine/db.cc
@@ -2236,6 +2236,8 @@ inline int64_t age_factor(int64_t fromNS, int64_t toNS) {
 // in (*MVCCStats).AgeTo. Passing now_nanos in is semantically tricky if there
 // is a chance that we run into values ahead of now_nanos. Instead, now_nanos
 // should be taken as a hint but determined by the max timestamp encountered.
+//
+// This implementation must match engine.ComputeStatsGo.
 MVCCStatsResult MVCCComputeStatsInternal(
     ::rocksdb::Iterator *const iter_rep, DBKey start, DBKey end, int64_t now_nanos) {
   MVCCStatsResult stats;
@@ -2325,7 +2327,7 @@ MVCCStatsResult MVCCComputeStatsInternal(
           stats.intent_age += age_factor(meta.timestamp().wall_time(), now_nanos);
         }
         if (meta.key_bytes() != kMVCCVersionTimestampSize) {
-          stats.status = FmtStatus("expected mvcc metadata val bytes to equal %d; got %d",
+          stats.status = FmtStatus("expected mvcc metadata key bytes to equal %d; got %d",
                                    kMVCCVersionTimestampSize, int(meta.key_bytes()));
           break;
         }

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2336,3 +2336,129 @@ func willOverflow(a, b int64) bool {
 	}
 	return math.MinInt64-b > a
 }
+
+// ComputeStatsGo scans the underlying engine from start to end keys and
+// computes stats counters based on the values. This method is used after a
+// range is split to recompute stats for each subrange. The start key is always
+// adjusted to avoid counting local keys in the event stats are being recomputed
+// for the first range (i.e. the one with start key == KeyMin). The nowNanos arg
+// specifies the wall time in nanoseconds since the epoch and is used to compute
+// the total age of all intents.
+//
+// Most codepaths will be computing stats on a RocksDB iterator, which is
+// implemented in c++, so iter.ComputeStats will save several cgo calls per kv
+// processed. (Plus, on equal footing, the c++ implementation is slightly
+// faster.) ComputeStatsGo is here for codepaths that have a pure-go
+// implementation of SimpleIterator.
+//
+// This implementation must match engine/db.cc:MVCCComputeStatsInternal.
+func ComputeStatsGo(
+	iter SimpleIterator, start, end MVCCKey, nowNanos int64,
+) (enginepb.MVCCStats, error) {
+	var ms enginepb.MVCCStats
+
+	meta := &enginepb.MVCCMetadata{}
+	var prevKey []byte
+	first := false
+
+	iter.Seek(start)
+	for ; ; iter.Next() {
+		ok, err := iter.Valid()
+		if err != nil {
+			return ms, err
+		}
+		if !ok || !iter.UnsafeKey().Less(end) {
+			break
+		}
+
+		unsafeKey := iter.UnsafeKey()
+		unsafeValue := iter.UnsafeValue()
+
+		isSys := bytes.Compare(unsafeKey.Key, keys.LocalMax) < 0
+		isValue := unsafeKey.IsValue()
+		implicitMeta := isValue && !bytes.Equal(unsafeKey.Key, prevKey)
+		prevKey = append(prevKey[:0], unsafeKey.Key...)
+
+		if implicitMeta {
+			// No MVCCMetadata entry for this series of keys.
+			meta.Reset()
+			meta.KeyBytes = mvccVersionTimestampSize
+			meta.ValBytes = int64(len(unsafeValue))
+			meta.Deleted = len(unsafeValue) == 0
+			meta.Timestamp.WallTime = unsafeKey.Timestamp.WallTime
+		}
+
+		if !isValue || implicitMeta {
+			metaKeySize := int64(len(unsafeKey.Key)) + 1
+			var metaValSize int64
+			if !implicitMeta {
+				metaValSize = int64(len(unsafeValue))
+			}
+			totalBytes := metaKeySize + metaValSize
+			first = true
+
+			if !implicitMeta {
+				if err := proto.Unmarshal(unsafeValue, meta); err != nil {
+					return ms, errors.Wrap(err, "unable to decode MVCCMetadata")
+				}
+			}
+
+			if isSys {
+				ms.SysBytes += totalBytes
+				ms.SysCount++
+			} else {
+				if !meta.Deleted {
+					ms.LiveBytes += totalBytes
+					ms.LiveCount++
+				} else {
+					// First value is deleted, so it's GC'able; add meta key & value bytes to age stat.
+					ms.GCBytesAge += totalBytes * (nowNanos/1E9 - meta.Timestamp.WallTime/1E9)
+				}
+				ms.KeyBytes += metaKeySize
+				ms.ValBytes += metaValSize
+				ms.KeyCount++
+				if meta.IsInline() {
+					ms.ValCount++
+				}
+			}
+			if !implicitMeta {
+				continue
+			}
+		}
+
+		totalBytes := int64(len(unsafeValue)) + mvccVersionTimestampSize
+		if isSys {
+			ms.SysBytes += totalBytes
+		} else {
+			if first {
+				first = false
+				if !meta.Deleted {
+					ms.LiveBytes += totalBytes
+				} else {
+					// First value is deleted, so it's GC'able; add key & value bytes to age stat.
+					ms.GCBytesAge += totalBytes * (nowNanos/1E9 - meta.Timestamp.WallTime/1E9)
+				}
+				if meta.Txn != nil {
+					ms.IntentBytes += totalBytes
+					ms.IntentCount++
+					ms.IntentAge += nowNanos/1E9 - meta.Timestamp.WallTime/1E9
+				}
+				if meta.KeyBytes != mvccVersionTimestampSize {
+					return ms, errors.Errorf("expected mvcc metadata key bytes to equal %d; got %d", mvccVersionTimestampSize, meta.KeyBytes)
+				}
+				if meta.ValBytes != int64(len(unsafeValue)) {
+					return ms, errors.Errorf("expected mvcc metadata val bytes to equal %d; got %d", len(unsafeValue), meta.ValBytes)
+				}
+			} else {
+				// Overwritten value; add value bytes to the GC'able bytes age stat.
+				ms.GCBytesAge += totalBytes * (nowNanos/1E9 - unsafeKey.Timestamp.WallTime/1E9)
+			}
+			ms.KeyBytes += mvccVersionTimestampSize
+			ms.ValBytes += int64(len(unsafeValue))
+			ms.ValCount++
+		}
+	}
+
+	ms.LastUpdateNanos = nowNanos
+	return ms, nil
+}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4544,7 +4544,7 @@ func (r *Replica) evaluateTxnWriteBatch(
 
 		// If all writes occurred at the intended timestamp, we've succeeded on the fast path.
 		batch := r.store.Engine().NewBatch()
-		if raceEnabled && spans != nil {
+		if engine.RaceEnabled && spans != nil {
 			batch = makeSpanSetBatch(batch, spans)
 		}
 		rec := ReplicaEvalContext{r, spans}
@@ -4596,7 +4596,7 @@ func (r *Replica) evaluateTxnWriteBatch(
 	}
 
 	batch := r.store.Engine().NewBatch()
-	if raceEnabled && spans != nil {
+	if engine.RaceEnabled && spans != nil {
 		batch = makeSpanSetBatch(batch, spans)
 	}
 	rec := ReplicaEvalContext{r, spans}


### PR DESCRIPTION
Use it in evalAddSSTable. The canonical impl is in c++, but the overhead
of starting up an in-mem rocksdb and linking in an sstable was showing
up in RESTORE performance.

This implementation is based on a resurrection of the original go impl:
https://github.com/cockroachdb/cockroach/pull/3155/files#diff-6d2dccecc0623fb6dd5456ae18bbf19e
A couple things had diverged, so I tweaked it to be a direct line by
line port, modulo one difference in what the iterator returns for key
(an encoded key in c++ an unencoded one in go).

name                            old time/op    new time/op     delta
AddSSTable/numEntries=100-8       2.74ms ± 1%     1.36ms ±23%   -50.35%  (p=0.008 n=5+5)
AddSSTable/numEntries=1000-8      9.22ms ±30%     4.04ms ±11%   -56.15%  (p=0.008 n=5+5)
AddSSTable/numEntries=10000-8     48.6ms ±16%     22.6ms ±29%   -53.63%  (p=0.008 n=5+5)
AddSSTable/numEntries=300000-8     1.77s ±46%      1.28s ±83%      ~     (p=0.151 n=5+5)

name                            old speed      new speed       delta
AddSSTable/numEntries=100-8     6.77MB/s ± 1%  13.83MB/s ±20%  +104.16%  (p=0.008 n=5+5)
AddSSTable/numEntries=1000-8    19.1MB/s ±25%   42.7MB/s ±11%  +123.68%  (p=0.008 n=5+5)
AddSSTable/numEntries=10000-8   35.5MB/s ±15%   77.4MB/s ±24%  +118.11%  (p=0.008 n=5+5)
AddSSTable/numEntries=300000-8  30.5MB/s ±35%   47.0MB/s ±53%      ~     (p=0.151 n=5+5)

This obviously wants tests, but this is as far as I got before the offsite, so getting it out for early review on the approach.