### PR TITLE
sql: enable configuration of the default time zone

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -101,6 +101,13 @@ left unspecified, defaults to 25% of the physical memory, or 512MB if
 the memory size cannot be determined.`,
 	}
 
+	SQLTz = FlagInfo{
+		Name: "sql-time-zone",
+		Description: `
+Default time zone for newly created SQL sessions. If left unspecified,
+defaults to UTC.`,
+	}
+
 	Cache = FlagInfo{
 		Name: "cache",
 		Description: `

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -272,6 +272,8 @@ func init() {
 
 		sqlSize := humanizeutil.NewBytesValue(&serverCfg.SQLMemoryPoolSize)
 		varFlag(f, sqlSize, cliflags.SQLMem)
+
+		stringFlag(f, &serverCfg.SQLDefaultTimeZone, cliflags.SQLTz, serverCfg.SQLDefaultTimeZone)
 	}
 
 	for _, cmd := range certCmds {

--- a/pkg/cli/interactive_tests/test_time_zone.tcl
+++ b/pkg/cli/interactive_tests/test_time_zone.tcl
@@ -1,0 +1,67 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+# Set up the initial cluster.
+start_server $argv
+
+spawn $argv sql
+eexpect root@
+
+start_test "Check that the uninitialized default time zone is UTC"
+send "SHOW TIME ZONE;\r"
+eexpect "UTC"
+eexpect root@
+send "\\q\r"
+eexpect eof
+end_test
+
+proc check_alt_tz {argv alttz check checktime} {
+    global spawn_id
+
+    # Re-launch a server with a different default time zone
+    stop_server $argv
+    report "BEGIN START ALT TZ SERVER"
+    system "$argv start --insecure --sql-time-zone=$alttz --background -s=path=logs/db --pid-file=pid_fifo >>expect-cmd.log 2>&1 & cat pid_fifo >server_pid"
+    report "END START ALT TZ SERVER"
+
+    # Check the alt TZ with a client
+    spawn $argv sql
+    eexpect root@
+    send "SHOW TIME ZONE;\r"
+    eexpect $check
+    eexpect root@
+
+    send "SELECT '1970-01-01 00:00:00'::TIMESTAMPTZ::STRING AS result;\r"
+    eexpect result
+    eexpect $checktime
+    eexpect root@
+
+    send "\\q\r"
+    eexpect eof
+}
+
+start_test "Check that the default can be overridden"
+check_alt_tz $argv "Europe/Amsterdam" "Europe/Amsterdam" "1969-12-31 23:00:00+00:00"
+check_alt_tz $argv "\"'Europe/Amsterdam'\"" "Europe/Amsterdam" "1969-12-31 23:00:00+00:00"
+check_alt_tz $argv "gmt" "GMT" "1970-01-01 00:00:00+00:00"
+check_alt_tz $argv "-5" " -5" "1970-01-01 05:00:00+00:00"
+check_alt_tz $argv "-5.5" " -5.5" "1970-01-01 05:30:00+00:00"
+check_alt_tz $argv "\"interval '-5 hour'\"" "'-5h'" "1970-01-01 05:00:00+00:00"
+end_test
+
+start_test "Check that invalid time zones are properly rejected"
+stop_server $argv
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+send "$argv start --insecure --sql-time-zone=someinvalidstring -spath=logs/db \r"
+eexpect "failed to start server"
+eexpect "cannot find time zone"
+eexpect ":/# "
+send "exit\r"
+eexpect eof
+
+end_test

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -55,6 +55,7 @@ const (
 	defaultCGroupMemPath            = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
 	defaultCacheSize                = 512 << 20 // 512 MB
 	defaultSQLMemoryPoolSize        = 512 << 20 // 512 MB
+	defaultSQLDefaultTimeZone       = "UTC"
 	defaultScanInterval             = 10 * time.Minute
 	defaultConsistencyCheckInterval = 24 * time.Hour
 	defaultScanMaxIdleTime          = 200 * time.Millisecond
@@ -145,6 +146,11 @@ type Config struct {
 	// SQLMemoryPoolSize is the amount of memory in bytes that can be
 	// used by SQL clients to store row data in server RAM.
 	SQLMemoryPoolSize int64
+
+	// SQLDefaultTimeZone is the default time zone for newly
+	// created SQL sessions. See the comments at the start
+	// of time_zone.go.
+	SQLDefaultTimeZone string
 
 	// Parsed values.
 
@@ -378,6 +384,7 @@ func MakeConfig() Config {
 		MaxOffset:                MaxOffsetType(base.DefaultMaxClockOffset),
 		CacheSize:                defaultCacheSize,
 		SQLMemoryPoolSize:        defaultSQLMemoryPoolSize,
+		SQLDefaultTimeZone:       defaultSQLDefaultTimeZone,
 		ScanInterval:             defaultScanInterval,
 		ScanMaxIdleTime:          defaultScanMaxIdleTime,
 		ConsistencyCheckInterval: defaultConsistencyCheckInterval,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -437,6 +437,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.sqlExecutor = sql.NewExecutor(execCfg, s.stopper)
 	s.registry.AddMetricStruct(s.sqlExecutor)
 
+	if err := s.sqlExecutor.LoadDefaultLocation(ctx, cfg.SQLDefaultTimeZone, &s.internalMemMetrics); err != nil {
+		return nil, err
+	}
+
 	s.pgServer = pgwire.MakeServer(
 		s.cfg.AmbientCtx,
 		s.cfg.Config,

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -224,6 +224,10 @@ type Executor struct {
 
 	distSQLPlanner *distSQLPlanner
 
+	// defaultLocation is the default time zone for new SQL
+	// sessions. See the explanatory comments in time_zone.go.
+	defaultLocation *time.Location
+
 	// Application-level SQL statistics
 	sqlStats sqlStats
 
@@ -346,13 +350,14 @@ func NewExecutor(cfg ExecutorConfig, stopper *stop.Stopper) *Executor {
 			6*metricsSampleInterval),
 		SQLServiceLatency: metric.NewLatency(MetaSQLServiceLatency,
 			6*metricsSampleInterval),
-		UpdateCount: metric.NewCounter(MetaUpdate),
-		InsertCount: metric.NewCounter(MetaInsert),
-		DeleteCount: metric.NewCounter(MetaDelete),
-		DdlCount:    metric.NewCounter(MetaDdl),
-		MiscCount:   metric.NewCounter(MetaMisc),
-		QueryCount:  metric.NewCounter(MetaQuery),
-		sqlStats:    sqlStats{apps: make(map[string]*appStats)},
+		UpdateCount:     metric.NewCounter(MetaUpdate),
+		InsertCount:     metric.NewCounter(MetaInsert),
+		DeleteCount:     metric.NewCounter(MetaDelete),
+		DdlCount:        metric.NewCounter(MetaDdl),
+		MiscCount:       metric.NewCounter(MetaMisc),
+		QueryCount:      metric.NewCounter(MetaQuery),
+		sqlStats:        sqlStats{apps: make(map[string]*appStats)},
+		defaultLocation: time.UTC,
 	}
 }
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -121,14 +121,14 @@ func DistSQLExecModeFromInt(val int64) DistSQLExecMode {
 
 // DistSQLExecModeFromString converts a string into a DistSQLExecMode
 func DistSQLExecModeFromString(val string) DistSQLExecMode {
-	switch strings.ToUpper(val) {
-	case "OFF":
+	switch strings.ToLower(val) {
+	case "off":
 		return DistSQLOff
-	case "AUTO":
+	case "auto":
 		return DistSQLAuto
-	case "ON":
+	case "on":
 		return DistSQLOn
-	case "ALWAYS":
+	case "always":
 		return DistSQLAlways
 	default:
 		panic(fmt.Sprintf("unknown DistSQL mode %s", val))
@@ -139,11 +139,11 @@ func DistSQLExecModeFromString(val string) DistSQLExecMode {
 var DistSQLClusterExecMode = settings.RegisterEnumSetting(
 	"sql.defaults.distsql",
 	"Default distributed SQL execution mode",
-	"Auto",
+	"auto",
 	map[int64]string{
-		int64(DistSQLOff):  "Off",
-		int64(DistSQLAuto): "Auto",
-		int64(DistSQLOn):   "On",
+		int64(DistSQLOff):  "off",
+		int64(DistSQLAuto): "auto",
+		int64(DistSQLOn):   "on",
 	},
 )
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -412,7 +412,7 @@ func NewSession(
 		Database:         args.Database,
 		DistSQLMode:      distSQLMode,
 		SearchPath:       sqlbase.DefaultSearchPath,
-		Location:         time.UTC,
+		Location:         e.defaultLocation,
 		User:             args.User,
 		virtualSchemas:   e.virtualSchemas,
 		execCfg:          &e.cfg,

--- a/pkg/sql/time_zone.go
+++ b/pkg/sql/time_zone.go
@@ -1,0 +1,89 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+
+package sql
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func setTimeZone(_ context.Context, session *Session, values []parser.TypedExpr) error {
+	if len(values) != 1 {
+		return errors.New("set time zone requires a single argument")
+	}
+	evalCtx := session.evalCtx()
+	d, err := values[0].Eval(&evalCtx)
+	if err != nil {
+		return err
+	}
+
+	var loc *time.Location
+	var offset int64
+	switch v := parser.UnwrapDatum(d).(type) {
+	case *parser.DString:
+		location := string(*v)
+		loc, err = timeutil.LoadLocation(location)
+		if err != nil {
+			var err1 error
+			loc, err1 = timeutil.LoadLocation(strings.ToUpper(location))
+			if err1 != nil {
+				loc, err1 = timeutil.LoadLocation(strings.ToTitle(location))
+				if err1 != nil {
+					return fmt.Errorf("cannot find time zone %q: %v", location, err)
+				}
+			}
+		}
+
+	case *parser.DInterval:
+		offset, _, _, err = v.Duration.Div(time.Second.Nanoseconds()).Encode()
+		if err != nil {
+			return err
+		}
+
+	case *parser.DInt:
+		offset = int64(*v) * 60 * 60
+
+	case *parser.DFloat:
+		offset = int64(float64(*v) * 60.0 * 60.0)
+
+	case *parser.DDecimal:
+		sixty := apd.New(60, 0)
+		ed := apd.MakeErrDecimal(parser.ExactCtx)
+		ed.Mul(sixty, sixty, sixty)
+		ed.Mul(sixty, sixty, &v.Decimal)
+		offset = ed.Int64(sixty)
+		if ed.Err() != nil {
+			return fmt.Errorf("time zone value %s would overflow an int64", sixty)
+		}
+
+	default:
+		return fmt.Errorf("bad time zone value: %s", d.String())
+	}
+	if loc == nil {
+		loc = sqlbase.FixedOffsetTimeZoneToLocation(int(offset), d.String())
+	}
+	session.Location = loc
+	return nil
+}


### PR DESCRIPTION
This patch makes it possible to configure the default SQL session
time zone, using a new command-line flag `--sql-time-zone`.

This choice of mechanism is motivated by two factors:

- the configuration should not be dynamic beyond node start-up,
  because clients would react poorly to a change in the default across
  an automatic reconnect; and
- we can't use a cluster setting, because these are not guaranteed
  to propagate early and be available when the defaults are loaded.

Fixes  #16029.