### PR TITLE
azworker: auto shutdown

### DIFF
--- a/build/bootstrap/autoshutdown.cron.sh
+++ b/build/bootstrap/autoshutdown.cron.sh
@@ -7,12 +7,13 @@
 
 set -euxo pipefail
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <num_periods>"
+if [ -z "$1" ]; then
+  echo "Usage: $0 <num_periods> [shutdown command...]"
   exit 1
 fi
 
 MAX_COUNT="$1"
+shift
 
 if ! [ "$MAX_COUNT" -gt 0 -a "$MAX_COUNT" -lt 10000 ]; then
   echo "Invalid argument '$MAX_COUNT'"
@@ -25,7 +26,8 @@ fi
 FILE=/dev/shm/autoshutdown-count
 COUNT=0
 
-if [ -f /.active ] || w -hs | grep -q pts; then
+
+if [ -f /.active ] || w -hs | grep pts | grep -vq "pts/[0-9]* *tmux"; then
   # Auto-shutdown is disabled (via /.active) or there is a remote session.
   echo 0 > $FILE
   exit 0
@@ -39,6 +41,14 @@ COUNT=$((COUNT+1))
 
 if [ $COUNT -le $MAX_COUNT ]; then
   echo $COUNT > $FILE
-else
+  exit 0
+fi
+
+# Shut down.
+
+if [ -z "$1" ]; then
   /sbin/shutdown -h
+else
+  # Run whatever command was passed on the command line.
+  $@
 fi

--- a/build/bootstrap/install-azure-cli.sh
+++ b/build/bootstrap/install-azure-cli.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# On a Debian/Ubuntu system, installs the Azure CLI.
+
+set -euxo pipefail
+
+# Instructions from https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | \
+     sudo tee /etc/apt/sources.list.d/azure-cli.list
+
+sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893
+sudo apt-get install -y apt-transport-https
+sudo apt-get update
+sudo apt-get install -y azure-cli

--- a/scripts/azworker.sh
+++ b/scripts/azworker.sh
@@ -22,6 +22,8 @@ IP=${NAME}
 DOMAIN=cockroach-${NAME}
 FQDN=${DOMAIN}.${LOCATION}.cloudapp.azure.com
 
+# TODO(radu): switch to the newer "az" CLI.
+
 case ${1-} in
   create)
     if azure group show "${RG}" >/dev/null 2>/dev/null; then
@@ -59,6 +61,11 @@ case ${1-} in
     rsync -az "$(dirname "${0}")/../build/disable-hyperv-timesync.sh" "${USER}@${FQDN}:bootstrap/"
     ssh -A "${USER}@${FQDN}" ./bootstrap/bootstrap-debian.sh
     ssh -A "${USER}@${FQDN}" ./bootstrap/disable-hyperv-timesync.sh
+    ssh -A "${USER}@${FQDN}" ./bootstrap/install-azure-cli.sh
+
+    # Copy the azure config (including credentials!).
+    ssh -A "${USER}@${FQDN}" "mkdir .azure"
+    rsync -az ~/.azure/*.json "${USER}@${FQDN}:.azure/"
 
     # Set up tmux configuration (for persistent SSH).
     if [ -e ~/.tmux.conf ]; then
@@ -69,12 +76,8 @@ case ${1-} in
       ssh -A "${USER}@${FQDN}" "echo 'set -g terminal-overrides \"xterm*:XT:smcup@:rmcup@\"' >> .tmux.conf"
     fi
 
-    # TODO(bdarnell): autoshutdown.cron.sh does not work on azure. It
-    # halts the VM, but halting the VM doesn't stop billing. The VM
-    # must instead be "deallocated" with the azure API.
-    # Install automatic shutdown after ten minutes of operation without a
-    # logged in user. To disable this, `sudo touch /.active`.
-    #ssh "${USER}@${FQDN}" "sudo cp bootstrap/autoshutdown.cron.sh /root/; echo '* * * * * /root/autoshutdown.cron.sh 10' | sudo crontab -i -"
+    # shellcheck disable=SC2029
+    ssh "${USER}@${FQDN}" "echo '* * * * * /home/radu/bootstrap/autoshutdown.cron.sh 10 az vm deallocate --resource-group \"${RG}\" --name \"${NAME}\"' | crontab -"
 
     echo "VM now running at ${FQDN}"
     ;;


### PR DESCRIPTION
Making auto shutdown work for azworker. We install the azure cli and copy the
credentials so the VM can run `az vm deallocate`.

We also change the shutdown script to ignore `pts` terminals used by `tmux`.

I ran some tests but I'm still testing it.