### PR TITLE
libroach: add encoding tests

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -444,6 +444,10 @@ libroach: $(LIBROACH_DIR)/Makefile
 libroachccl: $(LIBROACH_DIR)/Makefile
 	@$(MAKE) --no-print-directory -C $(LIBROACH_DIR) -j$(NCPUS) roachccl
 
+.PHONY: check-libroach
+check-libroach:
+	@$(MAKE) --no-print-directory -C $(LIBROACH_DIR) check
+
 .PHONY: clean-c-deps
 clean-c-deps:
 	rm -rf $(JEMALLOC_DIR) && git -C $(JEMALLOC_SRC_DIR) clean -dxf

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -18,7 +18,8 @@ build/builder.sh make lint 2>&1 | tee artifacts/lint.log | go-test-teamcity
 build/builder.sh make generate
 build/builder.sh /bin/bash -c '! git status --porcelain | read || (git status; git diff -a 1>&2; exit 1)'
 
-# Run the UI tests. This logically belongs in teamcity-test.sh, but we do it
-# here to minimize total build time since the rest of this script completes
-# faster than the non-UI tests.
+# Run the UI tests and libroach tests. These logically belong in
+# teamcity-test.sh, but we do it here to minimize total build time since the
+# rest of this script completes much faster than teamcity-test.sh.
 build/builder.sh make -C pkg/ui
+build/builder.sh make check-libroach

--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -47,7 +47,20 @@ target_include_directories(roachccl
 )
 target_link_libraries(roachccl roach)
 
-set_target_properties(roach roachccl PROPERTIES
+include(CTest)
+enable_testing()
+
+add_executable(encoding_test encoding_test.cc)
+target_include_directories(encoding_test PRIVATE ../rocksdb/include)
+target_link_libraries(encoding_test roach)
+add_test(encoding_test encoding_test)
+
+add_custom_target(check
+  COMMAND ${CMAKE_CTEST_COMMAND} -V
+  DEPENDS encoding_test
+)
+
+set_target_properties(roach roachccl encoding_test PROPERTIES
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED YES
   CXX_EXTENSIONS NO

--- a/c-deps/libroach/encoding.cc
+++ b/c-deps/libroach/encoding.cc
@@ -15,10 +15,7 @@
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 // Author: Peter Mattis (peter@cockroachlabs.com)
 
-#include "rocksdb/slice.h"
 #include "encoding.h"
-
-// TODO(benesch): Set up a CI pipeline to test these functions.
 
 void EncodeUint32(std::string* buf, uint32_t v) {
   const uint8_t tmp[sizeof(v)] = {

--- a/c-deps/libroach/encoding.h
+++ b/c-deps/libroach/encoding.h
@@ -18,6 +18,7 @@
 #define ROACHLIB_ENCODING_H
 
 #include <stdint.h>
+#include <rocksdb/slice.h>
 
 // EncodeUint32 encodes the uint32 value using a big-endian 4 byte
 // representation. The bytes are appended to the supplied buffer.

--- a/c-deps/libroach/encoding_test.cc
+++ b/c-deps/libroach/encoding_test.cc
@@ -1,0 +1,76 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+#include <cstdint>
+#include <cinttypes>
+#include <random>
+#include <vector>
+#include "encoding.h"
+
+int main() {
+  std::vector<uint32_t> cases32 {
+    0, 1, 2, 3,
+    1 << 16, (1 << 16) - 1, (1 << 16) + 1,
+    1 << 24, (1 << 24) - 1, (1 << 24) + 1,
+    UINT32_MAX, UINT32_MAX - 1,
+  };
+
+  std::vector<uint64_t> cases64 {
+    (1ULL << 32) + 1,
+    1ULL << 40, (1ULL << 40) - 1, (1ULL << 40) + 1,
+    1ULL << 48, (1ULL << 48) - 1, (1ULL << 48) + 1,
+    1ULL << 56, (1ULL << 56) - 1, (1ULL << 56) + 1,
+    UINT64_MAX - 1, UINT64_MAX
+  };
+
+  std::mt19937 rng;
+  std::uniform_int_distribution<uint32_t> uniform32;
+  std::uniform_int_distribution<uint64_t> uniform64;
+  for (int i = 0; i < 32; i++) {
+    cases32.push_back(uniform32(rng));
+    cases64.push_back(uniform64(rng));
+  }
+
+  cases64.insert(cases64.end(), cases32.begin(), cases32.end());
+
+  int nfailed = 0;
+
+  for (auto it = cases32.begin(); it != cases32.end(); it++) {
+    std::string buf;
+    EncodeUint32(&buf, *it);
+    uint32_t out;
+    rocksdb::Slice slice(buf);
+    DecodeUint32(&slice, &out);
+    if (*it != out) {
+      nfailed++;
+      printf("uint32: %" PRIu32 " != %" PRIu32 "\n", *it, out);
+    }
+  }
+
+  for (auto it = cases64.begin(); it != cases64.end(); it++) {
+    std::string buf;
+    EncodeUint64(&buf, *it);
+    uint64_t out;
+    rocksdb::Slice slice(buf);
+    DecodeUint64(&slice, &out);
+    if (*it != out) {
+      nfailed++;
+      printf("uint64: %" PRIu64 " != %" PRIu64 "\n", *it, out);
+    }
+  }
+
+  return nfailed > 0;
+}


### PR DESCRIPTION
Only the second commit is out for review here; 2bf250b is tracked in #17035.

---

Complete a TODO now that cgo is no longer in the way. This paves the way for future libroach tests.