### PR TITLE
libroach: port hash/crc32's ieee implementation to c

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -41,6 +41,7 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
 # unzip - terraform
 # xz-utils - msan: libcxx / CRDB build system
 # yarn - ui: all
+# zlib1g-dev - libroach: crc32_test
 RUN apt-get update && apt-get install -y --no-install-recommends \
     autoconf \
     bison \
@@ -65,7 +66,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     texinfo \
     unzip \
     xz-utils \
-    yarn
+    yarn \
+    zlib1g-dev
 
 RUN mkdir crosstool-ng \
  && curl -fsSL http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.23.0.tar.xz | tar --strip-components=1 -C crosstool-ng -xJ \

--- a/build/common.mk
+++ b/build/common.mk
@@ -444,6 +444,10 @@ libroach: $(LIBROACH_DIR)/Makefile
 libroachccl: $(LIBROACH_DIR)/Makefile
 	@$(MAKE) --no-print-directory -C $(LIBROACH_DIR) -j$(NCPUS) roachccl
 
+.PHONY: check-libroach
+check-libroach:
+	@$(MAKE) --no-print-directory -C $(LIBROACH_DIR) check
+
 .PHONY: clean-c-deps
 clean-c-deps:
 	rm -rf $(JEMALLOC_DIR) && git -C $(JEMALLOC_SRC_DIR) clean -dxf

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -18,7 +18,8 @@ build/builder.sh make lint 2>&1 | tee artifacts/lint.log | go-test-teamcity
 build/builder.sh make generate
 build/builder.sh /bin/bash -c '! git status --porcelain | read || (git status; git diff -a 1>&2; exit 1)'
 
-# Run the UI tests. This logically belongs in teamcity-test.sh, but we do it
-# here to minimize total build time since the rest of this script completes
-# faster than the non-UI tests.
+# Run the UI tests and libroach tests. These logically belong in
+# teamcity-test.sh, but we do it here to minimize total build time since the
+# rest of this script completes much faster than teamcity-test.sh.
 build/builder.sh make -C pkg/ui
+build/builder.sh make check-libroach

--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -47,7 +47,20 @@ target_include_directories(roachccl
 )
 target_link_libraries(roachccl roach)
 
-set_target_properties(roach roachccl PROPERTIES
+include(CTest)
+enable_testing()
+
+add_executable(encoding_test encoding_test.cc)
+target_include_directories(encoding_test PRIVATE ../rocksdb/include)
+target_link_libraries(encoding_test roach)
+add_test(encoding_test encoding_test)
+
+add_custom_target(check
+  COMMAND ${CMAKE_CTEST_COMMAND} -V
+  DEPENDS encoding_test
+)
+
+set_target_properties(roach roachccl encoding_test PROPERTIES
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED YES
   CXX_EXTENSIONS NO

--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -20,9 +20,11 @@
 # The CXX_STANDARD property was introduced in version 3.1.
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
-project(roachlib)
+project(roachlib LANGUAGES C CXX ASM)
 
 add_library(roach
+  crc32.c
+  crc32_amd64.S
   db.cc
   encoding.cc
   eventlistener.cc
@@ -47,6 +49,9 @@ target_include_directories(roachccl
 )
 target_link_libraries(roachccl roach)
 
+add_executable(crc32_bench crc32_bench.c testutil.c)
+target_link_libraries(crc32_bench roach)
+
 include(CTest)
 enable_testing()
 
@@ -55,9 +60,17 @@ target_include_directories(encoding_test PRIVATE ../rocksdb/include)
 target_link_libraries(encoding_test roach)
 add_test(encoding_test encoding_test)
 
+add_executable(crc32_test
+  crc32_test.c
+  crc32_amd64.S
+  testutil.c
+)
+target_link_libraries(crc32_test z)
+add_test(crc32_test crc32_test)
+
 add_custom_target(check
   COMMAND ${CMAKE_CTEST_COMMAND} -V
-  DEPENDS encoding_test
+  DEPENDS encoding_test crc32_test
 )
 
 set_target_properties(roach roachccl encoding_test PROPERTIES

--- a/c-deps/libroach/LICENSE.golang
+++ b/c-deps/libroach/LICENSE.golang
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/c-deps/libroach/crc32.c
+++ b/c-deps/libroach/crc32.c
@@ -1,0 +1,126 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// This file is derived from the hash/crc32 implementation in the Go
+// Programming Language and is thus additionally subject to the terms
+// of the Go license in LICENSE.golang.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+#include "crc32.h"
+
+#include <cpuid.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+static const size_t slicing_cutoff = 16;
+
+static const uint32_t poly_ieee = 0xedb88320;
+
+static uint32_t table_ieee[8][256];
+
+crc32_fn_t *crc32ieee = NULL;
+
+#ifdef CRC32_TEST
+static uint32_t
+crc32ieee_simple(uint32_t crc, const unsigned char* buf, size_t len) {
+  crc = ~crc;
+  for (size_t i = 0; i < len; i++) {
+    crc ^= buf[i];
+    for (int j = 0; j < 8; j++)
+      crc = (crc >> 1) ^ (poly_ieee & -(crc & 1));
+  }
+  return ~crc;
+}
+#endif
+
+// Byte by byte, using a 256-entry lookup table.
+static uint32_t
+crc32ieee_table(uint32_t crc, const unsigned char* buf, size_t len) {
+  crc = ~crc;
+  for (size_t i = 0; i < len; i++) {
+    crc = table_ieee[0][(unsigned char)((crc & 0xff) ^ buf[i])] ^ (crc >> 8);
+  }
+  return ~crc;
+}
+
+// Slicing by eight.
+static uint32_t
+crc32ieee_slicing8(uint32_t crc, const unsigned char* buf, size_t len) {
+  if (len >= slicing_cutoff) {
+    crc = ~crc;
+    while (len > 8) {
+      crc ^= buf[0] | buf[1] << 8 | buf[2] << 16 | buf[3] << 24;
+      crc = table_ieee[0][buf[7]] ^ table_ieee[1][buf[6]] ^
+            table_ieee[2][buf[5]] ^ table_ieee[3][buf[4]] ^
+            table_ieee[4][crc >> 24] ^ table_ieee[5][(crc >> 16) & 0xff] ^
+            table_ieee[6][(crc >> 8) & 0xff] ^ table_ieee[7][crc & 0xff];
+      buf += 8;
+      len -= 8;
+    }
+    crc = ~crc;
+  }
+  if (len == 0) {
+    return crc;
+  }
+  return crc32ieee_table(crc, buf, len);
+}
+
+// Implemented in assembly. See crc32_amd64.S.
+extern crc32_fn_t crc32ieee_clmul_impl;
+
+static uint32_t
+crc32ieee_clmul(uint32_t crc, const unsigned char* buf, size_t len) {
+  if (len >= 64) {
+    crc = ~crc32ieee_clmul_impl(~crc, buf, len);
+    buf += len - (len & 15);
+    len &= 15;
+  }
+  if (len == 0) {
+    return crc;
+  }
+  return crc32ieee_slicing8(crc, buf, len);
+}
+
+// Inspect CPUID for PCLMULQDQ and SSE4.1 feature flags.
+// For details, see Wikipedia: https://en.wikipedia.org/wiki/CPUID
+static bool
+crc32ieee_clmul_supported(void) {
+  unsigned eax, ebx, ecx, edx;
+  return __get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & 0x80002);
+}
+
+__attribute__((constructor)) void
+crc32ieee_init() {
+  for (int i = 0; i < 256; i++) {
+    uint32_t crc = i;
+    for (int j = 0; j < 8; j++) {
+      if ((crc & 1) == 1) {
+        crc = (crc >> 1) ^ poly_ieee;
+      } else {
+        crc >>= 1;
+      }
+    }
+    table_ieee[0][i] = crc;
+  }
+  for (int i = 0; i < 256; i++) {
+    uint32_t crc = table_ieee[0][i];
+    for (int j = 1; j < 8; j++) {
+      crc = table_ieee[0][crc & 0xff] ^ (crc >> 8);
+      table_ieee[j][i] = crc;
+    }
+  }
+
+  crc32ieee = crc32ieee_clmul_supported() ? crc32ieee_clmul : crc32ieee_slicing8;
+}

--- a/c-deps/libroach/crc32.h
+++ b/c-deps/libroach/crc32.h
@@ -1,0 +1,49 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+// libcrc32 implements CRC32, the 32-bit cyclic redundancy check, using the IEEE
+// polynomial (0xedb88320 in little-endian). See Wikipedia for details on the
+// mathematics: http://en.wikipedia.org/wiki/Cyclic_redundancy_check
+//
+// For AMD64 platforms with support for both CLMUL and SSE4.1, libcrc32 uses a
+// highly-optimized assembly implementation. On other platforms, or on small
+// inputs, libcrc32 falls back to a simpler but still fast "slicing by eight"
+// implementation. See the comments in the implementation for details.
+
+#ifndef CRC32_H
+#define CRC32_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// crc32_fn_t is the function signature of all crc32 implementations.
+typedef uint32_t (crc32_fn_t)(uint32_t crc, const unsigned char* buf, size_t len);
+
+// Update the running checksum `crc` with `len` bytes from `buf` using the IEEE
+// polynomial and returns the new checksum. To initialize a new running
+// checksum, provide a `crc` of 0:
+//
+//     uint32_t checksum = 0;
+//     while ((char* block = next_block())) {
+//         checksum = crc32ieee(checksum, block, BLOCKSZ);
+//     }
+//
+// This function is compatible with the `crc32` function provided by zlib. In
+// particular, providing a `NULL` buffer will unconditionally return the
+// required initial CRC value, 0, regardless of the value of `crc` or `len`.
+extern crc32_fn_t *crc32ieee;
+
+#endif

--- a/c-deps/libroach/crc32_amd64.S
+++ b/c-deps/libroach/crc32_amd64.S
@@ -1,0 +1,194 @@
+/* Copyright 2017 The Cockroach Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * This file is derived from the hash/crc32 implementation in the Go
+ * Programming Language and is thus additionally subject to the terms
+ * of the Go license in LICENSE.golang.
+ *
+ * Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+ */
+
+/* 
+ * This implementation is nearly a direct translation of Go's optimized AMD64
+ * CRC32 implementation [0], which uses a non-standard syntax, into GNU assembly
+ * syntax. The technique uses carry-less multiplication instructions that
+ * operate on two double quadword (64-bit) operands at a time, and is described
+ * in detail in an Intel whitepaper, "Fast CRC Computation for Generic
+ * Polynomials Using PCLMULQDQ Instruction" [1].
+ *
+ * [0]: https://github.com/golang/go/blob/f3e6216450866f761cc22c042798c88062319867/src/hash/crc32/crc32_amd64.s
+ * [1]: https://www.intel.com/content/dam/www/public/us/en/documents/white-papers/fast-crc-computation-generic-polynomials-pclmulqdq-paper.pdf
+ */
+
+/*
+ * These constants are lifted from the Linux kernel, since they avoid the costly
+ * PSHUFB 16 byte reversal proposed in the original Intel paper.
+ *
+ * NB: Each literal below is 33 bits, so each label points to 128 bits.
+ */
+
+.align 16
+
+.Lr2r1:
+  .quad 0x154442bd4
+  .quad 0x1c6e41596
+
+.Lr4r3:
+  .quad 0x1751997d0
+  .quad 0x0ccaa009e
+
+.Lr5:
+  .quad 0x163cd6124
+  .quad 0x000000000
+
+.Lrupoly:
+  .quad 0x1db710641
+  .quad 0x1f7011641
+
+.text
+
+/* crc32ieee_clmul_impl(uint32_t crc, const char* buf, size_t len); */
+.global _crc32ieee_clmul_impl
+_crc32ieee_clmul_impl:
+  #define crc %edi
+  #define buf %rsi
+  #define len %rdx
+
+  pushq %rbp
+  movq %rsp, %rbp
+
+  movd crc, %xmm0
+  
+  movdqu 0x00(buf), %xmm1
+  movdqu 0x10(buf), %xmm2
+  movdqu 0x20(buf), %xmm3
+  movdqu 0x30(buf), %xmm4
+
+  pxor %xmm0, %xmm1
+  add $0x40, buf
+  sub $0x40, len
+  cmp $0x40, len
+  jb remain64
+
+  movdqa .Lr2r1(%rip), %xmm0
+
+loopback64:
+  movdqa %xmm1, %xmm5
+  movdqa %xmm2, %xmm6
+  movdqa %xmm3, %xmm7
+  movdqa %xmm4, %xmm8
+
+  pclmulqdq $0x00, %xmm0, %xmm1
+  pclmulqdq $0x00, %xmm0, %xmm2
+  pclmulqdq $0x00, %xmm0, %xmm3
+  pclmulqdq $0x00, %xmm0, %xmm4
+
+  /* Load next 64 bytes early. */
+  movdqu 0x00(buf), %xmm11
+  movdqu 0x10(buf), %xmm12
+  movdqu 0x20(buf), %xmm13
+  movdqu 0x30(buf), %xmm14
+
+  pclmulqdq $0x11, %xmm0, %xmm5
+  pclmulqdq $0x11, %xmm0, %xmm6
+  pclmulqdq $0x11, %xmm0, %xmm7
+  pclmulqdq $0x11, %xmm0, %xmm8
+
+  pxor %xmm5, %xmm1
+  pxor %xmm6, %xmm2
+  pxor %xmm7, %xmm3
+  pxor %xmm8, %xmm4
+
+  pxor %xmm11, %xmm1
+  pxor %xmm12, %xmm2
+  pxor %xmm13, %xmm3
+  pxor %xmm14, %xmm4
+
+  add $0x40, buf
+  sub $0x40, len
+  cmp $0x40, len
+  jge loopback64
+
+  /* Fold result into a single register, %xmm1. */
+remain64:
+  movdqa .Lr4r3(%rip), %xmm0
+
+  movdqa %xmm1, %xmm5
+  pclmulqdq $0x00, %xmm0, %xmm1
+  pclmulqdq $0x11, %xmm0, %xmm5
+  pxor %xmm5, %xmm1
+  pxor %xmm2, %xmm1
+
+  movdqa %xmm1, %xmm5
+  pclmulqdq $0x00, %xmm0, %xmm1
+  pclmulqdq $0x11, %xmm0, %xmm5
+  pxor %xmm5, %xmm1
+  pxor %xmm3, %xmm1
+
+  movdqa %xmm1, %xmm5
+  pclmulqdq $0x00, %xmm0, %xmm1
+  pclmulqdq $0x11, %xmm0, %xmm5
+  pxor %xmm5, %xmm1
+  pxor %xmm4, %xmm1
+
+  cmp $0x10, len
+  jb finish
+
+  /* Encode 16 bytes. */
+remain16:
+  movdqu 0x00(buf), %xmm10
+
+  movdqa %xmm1, %xmm5
+  pclmulqdq $0x00, %xmm0, %xmm1
+  pclmulqdq $0x11, %xmm0, %xmm5
+  pxor %xmm5, %xmm1
+  pxor %xmm10, %xmm1
+
+  add $0x10, buf
+  sub $0x10, len
+  cmp $0x10, len
+  jge remain16
+
+  /* Fold final result into 32 bits and return. */
+finish:
+  pcmpeqb %xmm3, %xmm3
+  pclmulqdq $0x01, %xmm1, %xmm0
+  psrldq $0x08, %xmm1
+  pxor %xmm0, %xmm1
+
+  movdqa %xmm1, %xmm2
+  movdqa .Lr5(%rip), %xmm0
+
+  /* Create a mask to select the lower 32-bits; we don't care about the
+   * upper 96 bits. */
+  psrlq $0x20, %xmm3
+
+  psrldq $0x04, %xmm2
+  pand %xmm3, %xmm1
+  pclmulqdq $0x00, %xmm0, %xmm1
+  pxor %xmm2, %xmm1
+
+  movdqa .Lrupoly(%rip), %xmm0
+
+  movdqa %xmm1, %xmm2
+  pand %xmm3, %xmm1
+  pclmulqdq $0x10, %xmm0, %xmm1
+  pand %xmm3, %xmm1
+  pclmulqdq $0x00, %xmm0, %xmm1
+  pxor %xmm2, %xmm1
+
+  pextrd $0x01, %xmm1, %eax
+
+  leave
+  ret

--- a/c-deps/libroach/crc32_bench.c
+++ b/c-deps/libroach/crc32_bench.c
@@ -1,0 +1,138 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+#include "crc32.h"
+#include "testutil.h"
+
+#include <err.h>
+#include <inttypes.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+
+struct experiment {
+    size_t len;
+    size_t offset;
+    uint64_t rounds;
+};
+
+struct experiment experiments[] = {
+    // Experiments to match Go's hash/crc32 package.
+    {15, 0, 30000000},
+    {15, 1, 30000000},
+    {40, 0, 30000000},
+    {40, 1, 30000000},
+    {512, 0, 20000000},
+    {512, 1, 20000000},
+    {1 << 10, 0, 20000000},
+    {1 << 10, 1, 20000000},
+    {4 << 10, 0, 5000000},
+    {4 << 10, 1, 5000000},
+    {32 << 10, 0, 500000},
+    {32 << 10, 1, 500000},
+
+    // Experiments to match Fastmail's CRC32 roundup.
+    // See: https://github.com/robn/crc32-bench.
+    {16, 0, 100000000},
+    {24, 0, 100000000},
+    {32, 0, 100000000},
+    {64, 0, 100000000},
+    {128, 0, 100000000},
+    {256, 0, 100000000},
+    {64 << 20, 0, 1000},
+};
+
+enum output_formats {
+    FORMAT_DEFAULT,
+    FORMAT_GO,
+};
+
+static int64_t
+benchmark(const unsigned char* buf, size_t len, uint64_t rounds) {
+    struct timeval start, end;
+
+    gettimeofday(&start, 0);
+    for (int i = 0; i < rounds; i++) {
+        volatile uint32_t crc = crc32ieee(0, buf, len);
+    }
+    gettimeofday(&end, 0);
+
+    struct timeval tv;
+    timersub(&end, &start, &tv);
+
+    return ((int64_t) tv.tv_sec * 1000000 + tv.tv_usec);
+}
+
+static void __attribute__((noreturn))
+usage(void) {
+    fprintf(stderr, "usage: crc32_bench [--format=<go|default>]\n");
+    exit(1);
+}
+
+int
+main(int argc, char* argv[]) {
+    enum output_formats format = FORMAT_DEFAULT;
+    static struct option long_options[] = {
+        {"format", required_argument, NULL, 'f'},
+        {0, 0, 0, 0},
+    };
+    int ch;
+    while ((ch = getopt_long(argc, argv, "f:", long_options, NULL)) != -1) {
+        if (ch == 'f') {
+            if (strncmp(optarg, "go", 2) == 0) {
+                format = FORMAT_GO;
+            } else if (strncmp(optarg, "default", 7) != 0) {
+                usage();
+            }
+        } else {
+            usage();
+        }
+    }
+    if (argc - optind != 0) {
+        warnx("unexpected positional arguments");
+        usage();
+    }
+    argv += optind;
+
+    for (size_t i = 0; i < ARRAY_SIZE(experiments); i++) {
+        struct experiment *e = &experiments[i];
+        unsigned char* buf = make_bytes(e->len + e->offset);
+        uint64_t total_us = benchmark(buf + e->offset, e->len, e->rounds);
+        double avg_ns = total_us * 1e3 / e->rounds;
+        double throughput = (e->len * e->rounds) * 1e6 / total_us / (1 << 20);
+        char* len_units = (format == FORMAT_DEFAULT) ? "B" : "";
+        if (e->len >= 1024) {
+            e->len /= 1024;
+            len_units = "kB";
+        }
+        if (e->len >= 1024) {
+            e->len /= 1024;
+            len_units = "mB";
+        }
+        if (format == FORMAT_GO) {
+            printf("BenchmarkCRC32/poly=IEEE/size=%zu%s/align=%zu-8\t%9" PRIu64"\t%0.1f ns/op\t%0.2f MB/s\n",
+                e->len, len_units, e->offset, e->rounds, avg_ns, throughput);
+        } else {
+            printf("%zu%s x %" PRIu64 ": %.2fs total, %.2f avg\n",
+                e->len, len_units, e->rounds,
+                total_us / 1e6, avg_ns);
+        }
+        free(buf);
+    }
+    return 0;
+}

--- a/c-deps/libroach/crc32_test.c
+++ b/c-deps/libroach/crc32_test.c
@@ -1,0 +1,131 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+#define CRC32_TEST
+
+#include "crc32.c"
+#include "testutil.h"
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zlib.h>
+
+static int ntests;
+static int nfailed;
+
+struct test_case {
+  uint32_t expected;
+  char* data;
+};
+
+static struct test_case test_cases[] = {
+  {0x0, ""},
+  {0xe8b7be43, "a"},
+  {0x9e83486d, "ab"},
+  {0x352441c2, "abc"},
+  {0xed82cd11, "abcd"},
+  {0x8587d865, "abcde"},
+  {0x4b8e39ef, "abcdef"},
+  {0x312a6aa6, "abcdefg"},
+  {0xaeef2a50, "abcdefgh"},
+  {0x8da988af, "abcdefghi"},
+  {0x3981703a, "abcdefghij"},
+  {0x6b9cdfe7, "Discard medicine more than two years old."},
+  {0xc90ef73f, "He who has a shady past knows that nice guys finish last."},
+  {0xb902341f, "I wouldn't marry him with a ten foot pole."},
+  {0x42080e8, "Free! Free!/A trip/to Mars/for 900/empty jars/Burma Shave"},
+  {0x154c6d11, "The days of the digital watch are numbered.  -Tom Stoppard"},
+  {0x4c418325, "Nepal premier won't resign."},
+  {0x33955150, "For every action there is an equal and opposite government program."},
+  {0x26216a4b, "His money is twice tainted: 'taint yours and 'taint mine."},
+  {0x1abbe45e, "There is no reason for any individual to have a computer in their home. -Ken Olsen, 1977"},
+  {0xc89a94f7, "It's a tiny change to the code and not completely disgusting. - Bob Manchek"},
+  {0xab3abe14, "size:  a.out:  bad magic"},
+  {0xbab102b6, "The major problem is with sendmail.  -Mark Horton"},
+  {0x999149d7, "Give me a rock, paper and scissors and I will move the world.  CCFestoon"},
+  {0x6d52a33c, "If the enemy is within range, then so are you."},
+  {0x90631e8d, "It's well we cannot hear the screams/That we create in others' dreams."},
+  {0x78309130, "You remind me of a TV show, but that's all right: I watch it anyway."},
+  {0x7d0a377f, "C is as portable as Stonehedge!!"},
+  {0x8c79fd79, "Even if I could be Shakespeare, I think I should still choose to be Faraday. - A. Huxley"},
+  {0xa20b7167, "The fugacity of a constituent in a mixture of gases at a given temperature is proportional to its mole fraction.  Lewis-Randall Rule"},
+  {0x8e0bb443, "How can you write a big system without C++?  -Paul Glick"},
+};
+
+static size_t cross_check_lens[] = {
+  0, 1, 2, 3, 4, 5, 10, 16, 50, 63, 64, 65, 100, 127, 128, 129, 255, 256, 257,
+  300, 312, 384, 416, 448, 480, 500, 501, 502, 503, 504, 505, 512, 513, 1000,
+  1024, 2000, 4030, 4031, 4032, 4033, 4036, 4040, 4048, 4096, 5000, 10000,
+  1 << 20,
+};
+
+static void
+test_golden(const char* name, crc32_fn_t crc32_fn) {
+  for (int i = 0; i < ARRAY_SIZE(test_cases); i++) {
+    ntests++;
+
+    struct test_case *tc = &test_cases[i];
+    uint32_t actual = crc32_fn(0, (unsigned char *)tc->data, strlen(tc->data));
+    if (actual != tc->expected) {
+      nfailed++;
+      printf("test_golden:%s:%02d: expected 0x%08x, actual 0x%08x\n",
+        name, i, tc->expected, actual);
+    }
+  }
+}
+
+static void
+test_cross_check(const char* name, crc32_fn_t crc32_fn1, crc32_fn_t crc32_fn2) {
+  for (int i = 0; i < ARRAY_SIZE(cross_check_lens); i++) {
+    ntests++;
+
+    size_t len = cross_check_lens[i];
+    unsigned char* buf = make_bytes(len);
+    uint32_t crc1 = crc32_fn1(0, buf, len);
+    uint32_t crc2 = crc32_fn2(0, buf, len);
+    if (crc1 != crc2) {
+      nfailed++;
+      printf("test_cross_check:%s:%02d: 0x%08x != 0x%08x (%zu bytes)\n",
+        name, i, crc1, crc2, len);
+    }
+    free(buf);
+  }
+}
+
+static uint32_t
+crc32_zlib(uint32_t crc, const unsigned char* buf, size_t len) {
+  return crc32((unsigned long) crc, buf, (unsigned long) len);
+}
+
+int main() {
+  test_golden("simple", crc32ieee_simple);
+  test_golden("table", crc32ieee_table);
+  test_golden("slicing8", crc32ieee_slicing8);
+  test_golden("clmul", crc32ieee_clmul);
+  test_golden("default", crc32ieee);
+
+  test_cross_check("table vs. simple", crc32ieee_table, crc32ieee_simple);
+  test_cross_check("slicing8 vs. simple", crc32ieee_slicing8, crc32ieee_simple);
+  test_cross_check("clmul vs. simple", crc32ieee_clmul, crc32ieee_simple);
+  test_cross_check("default vs. simple", crc32ieee, crc32ieee_simple);
+  test_cross_check("default vs. zlib", crc32ieee, crc32_zlib);
+
+  printf("%s (%d tests, %d failures)\n",
+    (nfailed > 0 ? "FAIL" : "PASS"), ntests, nfailed);
+  return nfailed > 0;
+}

--- a/c-deps/libroach/encoding.cc
+++ b/c-deps/libroach/encoding.cc
@@ -15,10 +15,7 @@
 // Author: Spencer Kimball (spencer.kimball@gmail.com)
 // Author: Peter Mattis (peter@cockroachlabs.com)
 
-#include "rocksdb/slice.h"
 #include "encoding.h"
-
-// TODO(benesch): Set up a CI pipeline to test these functions.
 
 void EncodeUint32(std::string* buf, uint32_t v) {
   const uint8_t tmp[sizeof(v)] = {

--- a/c-deps/libroach/encoding.h
+++ b/c-deps/libroach/encoding.h
@@ -18,6 +18,7 @@
 #define ROACHLIB_ENCODING_H
 
 #include <stdint.h>
+#include <rocksdb/slice.h>
 
 // EncodeUint32 encodes the uint32 value using a big-endian 4 byte
 // representation. The bytes are appended to the supplied buffer.

--- a/c-deps/libroach/encoding_test.cc
+++ b/c-deps/libroach/encoding_test.cc
@@ -1,0 +1,76 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+#include <cstdint>
+#include <cinttypes>
+#include <random>
+#include <vector>
+#include "encoding.h"
+
+int main() {
+  std::vector<uint32_t> cases32 {
+    0, 1, 2, 3,
+    1 << 16, (1 << 16) - 1, (1 << 16) + 1,
+    1 << 24, (1 << 24) - 1, (1 << 24) + 1,
+    UINT32_MAX, UINT32_MAX - 1,
+  };
+
+  std::vector<uint64_t> cases64 {
+    (1ULL << 32) + 1,
+    1ULL << 40, (1ULL << 40) - 1, (1ULL << 40) + 1,
+    1ULL << 48, (1ULL << 48) - 1, (1ULL << 48) + 1,
+    1ULL << 56, (1ULL << 56) - 1, (1ULL << 56) + 1,
+    UINT64_MAX - 1, UINT64_MAX
+  };
+
+  std::mt19937 rng;
+  std::uniform_int_distribution<uint32_t> uniform32;
+  std::uniform_int_distribution<uint64_t> uniform64;
+  for (int i = 0; i < 32; i++) {
+    cases32.push_back(uniform32(rng));
+    cases64.push_back(uniform64(rng));
+  }
+
+  cases64.insert(cases64.end(), cases32.begin(), cases32.end());
+
+  int nfailed = 0;
+
+  for (auto it = cases32.begin(); it != cases32.end(); it++) {
+    std::string buf;
+    EncodeUint32(&buf, *it);
+    uint32_t out;
+    rocksdb::Slice slice(buf);
+    DecodeUint32(&slice, &out);
+    if (*it != out) {
+      nfailed++;
+      printf("uint32: %" PRIu32 " != %" PRIu32 "\n", *it, out);
+    }
+  }
+
+  for (auto it = cases64.begin(); it != cases64.end(); it++) {
+    std::string buf;
+    EncodeUint64(&buf, *it);
+    uint64_t out;
+    rocksdb::Slice slice(buf);
+    DecodeUint64(&slice, &out);
+    if (*it != out) {
+      nfailed++;
+      printf("uint64: %" PRIu64 " != %" PRIu64 "\n", *it, out);
+    }
+  }
+
+  return nfailed > 0;
+}

--- a/c-deps/libroach/testutil.c
+++ b/c-deps/libroach/testutil.c
@@ -1,0 +1,31 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+#include <err.h>
+#include <stdlib.h>
+#include "testutil.h"
+
+unsigned char*
+make_bytes(size_t len) {
+  long* buf = malloc(len);
+  if (buf == NULL) {
+    err(1, "out of memory");
+  }
+  for (size_t i = 0; i < len / sizeof(long); i++) {
+    buf[i] = mrand48();
+  }
+  return (unsigned char *) buf;
+}

--- a/c-deps/libroach/testutil.h
+++ b/c-deps/libroach/testutil.h
@@ -1,0 +1,19 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
+unsigned char* make_bytes(size_t len);


### PR DESCRIPTION
This is a Friday project to validate a hunch I have that moving all of restore's SST work into C++ will yield a nice performance boost. Getting a fast CRC32 implementation was step 1. Please don't give this a thorough review yet—I haven't had the chance to ask @danhhz if this is even a road we want to seriously explore.

Only the last commit here is out for (proof-of-concept only) review; the first two commits are tracked in #17035 and #17039 respectively.

---

Port Go's highly-optimized AMD64 implementation of CRC32 with the IEEE polynomial to C.

Go 1.9beta2:
```
BenchmarkCRC32/poly=IEEE/size=15/align=0-8         	30000000	        52.0 ns/op	 288.37 MB/s
BenchmarkCRC32/poly=IEEE/size=15/align=1-8         	30000000	        51.9 ns/op	 289.20 MB/s
BenchmarkCRC32/poly=IEEE/size=40/align=0-8         	30000000	        47.5 ns/op	 842.13 MB/s
BenchmarkCRC32/poly=IEEE/size=40/align=1-8         	30000000	        47.5 ns/op	 841.89 MB/s
BenchmarkCRC32/poly=IEEE/size=512/align=0-8        	20000000	        66.3 ns/op	7721.03 MB/s
BenchmarkCRC32/poly=IEEE/size=512/align=1-8        	20000000	        66.7 ns/op	7679.31 MB/s
BenchmarkCRC32/poly=IEEE/size=1kB/align=0-8        	20000000	       111 ns/op	9217.26 MB/s
BenchmarkCRC32/poly=IEEE/size=1kB/align=1-8        	20000000	       115 ns/op	8840.18 MB/s
BenchmarkCRC32/poly=IEEE/size=4kB/align=0-8        	 5000000	       392 ns/op	10443.18 MB/s
BenchmarkCRC32/poly=IEEE/size=4kB/align=1-8        	 5000000	       342 ns/op	11969.82 MB/s
BenchmarkCRC32/poly=IEEE/size=32kB/align=0-8       	  500000	      2574 ns/op	12730.15 MB/s
BenchmarkCRC32/poly=IEEE/size=32kB/align=1-8       	  500000	      2599 ns/op	12603.22 MB/s
```

C:

```
BenchmarkCRC32/poly=IEEE/size=15/align=0-8		 30000000	23.5 ns/op	608.08 MB/s
BenchmarkCRC32/poly=IEEE/size=15/align=1-8		 30000000	23.0 ns/op	621.36 MB/s
BenchmarkCRC32/poly=IEEE/size=40/align=0-8		 30000000	37.4 ns/op	1018.66 MB/s
BenchmarkCRC32/poly=IEEE/size=40/align=1-8		 30000000	38.0 ns/op	1002.82 MB/s
BenchmarkCRC32/poly=IEEE/size=512/align=0-8		 20000000	51.1 ns/op	9548.67 MB/s
BenchmarkCRC32/poly=IEEE/size=512/align=1-8		 20000000	50.7 ns/op	9637.17 MB/s
BenchmarkCRC32/poly=IEEE/size=1kB/align=0-8		 20000000	91.3 ns/op	10698.23 MB/s
BenchmarkCRC32/poly=IEEE/size=1kB/align=1-8		 20000000	91.9 ns/op	10625.31 MB/s
BenchmarkCRC32/poly=IEEE/size=4kB/align=0-8		  5000000	332.9 ns/op	11735.48 MB/s
BenchmarkCRC32/poly=IEEE/size=4kB/align=1-8		  5000000	332.3 ns/op	11754.54 MB/s
BenchmarkCRC32/poly=IEEE/size=32kB/align=0-8	   500000	2516.3 ns/op	12418.92 MB/s
BenchmarkCRC32/poly=IEEE/size=32kB/align=1-8	   500000	2624.0 ns/op	11909.40 MB/s
```

benchstat:

```
name                                 old time/op    new time/op     delta
CRC32/poly=IEEE/size=15/align=0-8      53.0ns ± 1%     23.9ns ± 3%   -54.83%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=15/align=1-8      53.1ns ± 1%     23.7ns ± 3%   -55.31%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=40/align=0-8      48.2ns ± 1%     28.7ns ± 2%   -40.42%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=40/align=1-8      48.5ns ± 2%     28.9ns ± 2%   -40.32%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=512/align=0-8     65.1ns ± 2%     52.0ns ± 1%   -20.21%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=512/align=1-8     65.7ns ± 1%     52.6ns ± 2%   -19.91%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=1kB/align=0-8      106ns ± 2%       94ns ± 1%   -11.40%  (p=0.016 n=5+4)
CRC32/poly=IEEE/size=1kB/align=1-8      106ns ± 1%       97ns ± 8%    -8.96%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=4kB/align=0-8      357ns ± 9%      341ns ± 2%    -4.49%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=4kB/align=1-8      347ns ± 1%      338ns ± 2%      ~     (p=0.056 n=5+5)
CRC32/poly=IEEE/size=32kB/align=0-8    2.59µs ± 1%     2.63µs ± 5%      ~     (p=0.690 n=5+5)
CRC32/poly=IEEE/size=32kB/align=1-8    2.64µs ± 1%     2.67µs ±13%      ~     (p=0.500 n=5+5)

name                                 old speed      new speed       delta
CRC32/poly=IEEE/size=15/align=0-8     283MB/s ± 1%    598MB/s ± 3%  +111.25%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=15/align=1-8     282MB/s ± 1%    603MB/s ± 3%  +113.60%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=40/align=0-8     829MB/s ± 1%   1328MB/s ± 2%   +60.19%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=40/align=1-8     826MB/s ± 2%   1320MB/s ± 2%   +59.89%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=512/align=0-8   7.86GB/s ± 2%   9.40GB/s ± 1%   +19.52%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=512/align=1-8   7.79GB/s ± 1%   9.28GB/s ± 2%   +19.12%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=1kB/align=0-8   9.58GB/s ± 1%  10.36GB/s ± 0%    +8.14%  (p=0.016 n=5+4)
CRC32/poly=IEEE/size=1kB/align=1-8   9.60GB/s ± 1%  10.12GB/s ± 8%      ~     (p=0.151 n=5+5)
CRC32/poly=IEEE/size=4kB/align=0-8   11.5GB/s ± 8%   11.5GB/s ± 2%      ~     (p=0.310 n=5+5)
CRC32/poly=IEEE/size=4kB/align=1-8   11.8GB/s ± 1%   11.6GB/s ± 3%      ~     (p=0.310 n=5+5)
CRC32/poly=IEEE/size=32kB/align=0-8  12.6GB/s ± 1%   11.9GB/s ± 5%    -5.76%  (p=0.008 n=5+5)
CRC32/poly=IEEE/size=32kB/align=1-8  12.4GB/s ± 1%   11.8GB/s ±12%    -5.44%  (p=0.008 n=5+5)
```