### PR TITLE
pkg/cli: check error before returning io.EOF on empty row

### DIFF
--- a/pkg/cli/format_table.go
+++ b/pkg/cli/format_table.go
@@ -75,11 +75,11 @@ type rowIter struct {
 
 func (iter *rowIter) Next() (row []string, err error) {
 	nextRowString, err := getNextRowStrings(iter.rows, iter.showMoreChars)
-	if nextRowString == nil {
-		return nil, io.EOF
-	}
 	if err != nil {
 		return nil, err
+	}
+	if nextRowString == nil {
+		return nil, io.EOF
 	}
 	return nextRowString, nil
 }


### PR DESCRIPTION
This PR modifies the `(*rowIter).Next()` to check and return any error returned by `getNextRowStrings()` instead of returning `io.EOF` immediately.  Spotted while reading some code.