### PR TITLE
storage: don't chuck tombstone mvcc timestamps

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -273,6 +273,11 @@ func (v *Value) ShallowClone() *Value {
 	return &t
 }
 
+// IsPresent returns true if the value is present (existent and not a tombstone).
+func (v *Value) IsPresent() bool {
+	return v != nil && len(v.RawBytes) != 0
+}
+
 // MakeValueFromString returns a value with bytes and tag set.
 func MakeValueFromString(s string) Value {
 	v := Value{}


### PR DESCRIPTION
Previously, the timestamps of tombstone MVCC values were thrown away
before passing to the value functions of put commands, rendering it
impossible to craft a conditional put that took into account the
MVCC timestamp of a previous value if that previous value could be a
tombstone.

Now, value functions are always passed a roachpb.Value if there is an
MVCC value present at the requested key, even if the value is a
tombstone.

Other APIs are unaffected.