### PR TITLE
distsql, ui: query count metrics

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -281,10 +281,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 	rootSQLMemoryMonitor.Start(context.Background(), nil, mon.MakeStandaloneBudget(s.cfg.SQLMemoryPoolSize))
 
-	distSQLMemMetrics := sql.MakeMemMetrics("distsql", cfg.HistogramWindowInterval())
-	s.registry.AddMetric(distSQLMemMetrics.CurBytesCount)
-	s.registry.AddMetric(distSQLMemMetrics.MaxBytesHist)
-
 	// Set up the DistSQL temp engine.
 
 	// Check if all our configured stores are in-memory. if this is the case, we
@@ -313,7 +309,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		}
 	}
 
-	distSQLMetrics := distsqlrun.MakeDistSQLMetrics()
+	distSQLMetrics := distsqlrun.MakeDistSQLMetrics(cfg.HistogramWindowInterval())
 	s.registry.AddMetricStruct(distSQLMetrics)
 
 	// Set up the DistSQL server.
@@ -329,8 +325,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		TempStorage: tempEngine,
 
 		ParentMemoryMonitor: &rootSQLMemoryMonitor,
-		Counter:             distSQLMemMetrics.CurBytesCount,
-		Hist:                distSQLMemMetrics.MaxBytesHist,
 
 		Metrics: &distSQLMetrics,
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -281,9 +281,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 	rootSQLMemoryMonitor.Start(context.Background(), nil, mon.MakeStandaloneBudget(s.cfg.SQLMemoryPoolSize))
 
-	distSQLMetrics := sql.MakeMemMetrics("distsql", cfg.HistogramWindowInterval())
-	s.registry.AddMetric(distSQLMetrics.CurBytesCount)
-	s.registry.AddMetric(distSQLMetrics.MaxBytesHist)
+	distSQLMemMetrics := sql.MakeMemMetrics("distsql", cfg.HistogramWindowInterval())
+	s.registry.AddMetric(distSQLMemMetrics.CurBytesCount)
+	s.registry.AddMetric(distSQLMemMetrics.MaxBytesHist)
 
 	// Set up the DistSQL temp engine.
 
@@ -313,6 +313,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		}
 	}
 
+	distSQLMetrics := distsqlrun.MakeDistSQLMetrics()
+	s.registry.AddMetricStruct(distSQLMetrics)
+
 	// Set up the DistSQL server.
 	distSQLCfg := distsqlrun.ServerConfig{
 		AmbientContext: s.cfg.AmbientCtx,
@@ -326,8 +329,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		TempStorage: tempEngine,
 
 		ParentMemoryMonitor: &rootSQLMemoryMonitor,
-		Counter:             distSQLMetrics.CurBytesCount,
-		Hist:                distSQLMetrics.MaxBytesHist,
+		Counter:             distSQLMemMetrics.CurBytesCount,
+		Hist:                distSQLMemMetrics.MaxBytesHist,
+
+		Metrics: &distSQLMetrics,
 	}
 	if distSQLTestingKnobs := s.cfg.TestingKnobs.DistSQL; distSQLTestingKnobs != nil {
 		distSQLCfg.TestingKnobs = *distSQLTestingKnobs.(*distsqlrun.TestingKnobs)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -125,6 +125,9 @@ func (dsp *distSQLPlanner) Run(
 
 	log.VEvent(ctx, 1, "running DistSQL plan")
 
+	dsp.distSQLSrv.ServerConfig.Metrics.QueryStart()
+	defer dsp.distSQLSrv.ServerConfig.Metrics.QueryStop()
+
 	recv.resultToStreamColMap = plan.planToStreamColMap
 	thisNodeID := dsp.nodeDesc.NodeID
 

--- a/pkg/sql/distsqlrun/metrics.go
+++ b/pkg/sql/distsqlrun/metrics.go
@@ -1,0 +1,82 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Andrew Dona-Couch (andrew@cockroachlabs.com)
+
+package distsqlrun
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
+
+// DistSQLMetrics contains pointers to the metrics for
+// monitoring DistSQL processing.
+type DistSQLMetrics struct {
+	QueriesActive *metric.Gauge
+	QueriesTotal  *metric.Counter
+	FlowsActive   *metric.Gauge
+	FlowsTotal    *metric.Counter
+}
+
+// MetricStruct implements the metrics.Struct interface.
+func (DistSQLMetrics) MetricStruct() {}
+
+var _ metric.Struct = DistSQLMetrics{}
+
+var (
+	metaQueriesActive = metric.Metadata{
+		Name: "sql.distsql.queries.active",
+		Help: "Number of distributed SQL queries currently active"}
+	metaQueriesTotal = metric.Metadata{
+		Name: "sql.distsql.queries.total",
+		Help: "Number of distributed SQL queries executed"}
+	metaFlowsActive = metric.Metadata{
+		Name: "sql.distsql.flows.active",
+		Help: "Number of distributed SQL flows currently active"}
+	metaFlowsTotal = metric.Metadata{
+		Name: "sql.distsql.flows.total",
+		Help: "Number of distributed SQL flows executed"}
+)
+
+// MakeDistSQLMetrics instantiates the metrics holder for DistSQL monitoring.
+func MakeDistSQLMetrics() DistSQLMetrics {
+	return DistSQLMetrics{
+		QueriesActive: metric.NewGauge(metaQueriesActive),
+		QueriesTotal:  metric.NewCounter(metaQueriesTotal),
+		FlowsActive:   metric.NewGauge(metaFlowsActive),
+		FlowsTotal:    metric.NewCounter(metaFlowsTotal),
+	}
+}
+
+// QueryStart registers the start of a new DistSQL query.
+func (m *DistSQLMetrics) QueryStart() {
+	m.QueriesActive.Inc(1)
+	m.QueriesTotal.Inc(1)
+}
+
+// QueryStop registers the end of a DistSQL query.
+func (m *DistSQLMetrics) QueryStop() {
+	m.QueriesActive.Dec(1)
+}
+
+// FlowStart registers the start of a new DistSQL flow.
+func (m *DistSQLMetrics) FlowStart() {
+	m.FlowsActive.Inc(1)
+	m.FlowsTotal.Inc(1)
+}
+
+// FlowStop registers the end of a DistSQL flow.
+func (m *DistSQLMetrics) FlowStop() {
+	m.FlowsActive.Dec(1)
+}

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -95,13 +95,17 @@ type ServerConfig struct {
 	TestingKnobs TestingKnobs
 
 	ParentMemoryMonitor *mon.MemoryMonitor
-	Counter             *metric.Counter
-	Hist                *metric.Histogram
+
+	// TODO(couchand): move these into the DistSQLMetrics struct
+	Counter *metric.Counter
+	Hist    *metric.Histogram
 
 	// TempStorage is used by some DistSQL processors to store rows when the
 	// working set is larger than can be stored in memory. It can be nil, if this
 	// cockroach node does not have an engine for temporary storage.
 	TempStorage engine.Engine
+
+	Metrics *DistSQLMetrics
 
 	// NodeID is the id of the node on which this Server is running.
 	NodeID    *base.NodeIDContainer
@@ -129,7 +133,7 @@ func NewServer(ctx context.Context, cfg ServerConfig) *ServerImpl {
 		ServerConfig:  cfg,
 		regexpCache:   parser.NewRegexpCache(512),
 		flowRegistry:  makeFlowRegistry(),
-		flowScheduler: newFlowScheduler(cfg.AmbientContext, cfg.Stopper),
+		flowScheduler: newFlowScheduler(cfg.AmbientContext, cfg.Stopper, cfg.Metrics),
 		memMonitor: mon.MakeMonitor("distsql",
 			cfg.Counter, cfg.Hist, -1 /* increment: use default block size */, noteworthyMemoryUsageBytes),
 		tempStorage: cfg.TempStorage,

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -51,6 +51,34 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="Active Distributed SQL Queries"
+      sources={nodeSources}
+      tooltip={`The total number of distributed SQL queries currently running ${tooltipSelection}.`}
+    >
+      <Axis>
+        <Metric name="cr.node.sql.distsql.queries.active" title="Active Queries" />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Active Flows for Distributed SQL Queries"
+      tooltip="The number of flows on each node contributing to currently running distributed SQL queries."
+    >
+      <Axis>
+        {
+          _.map(nodeIDs, (node) => (
+            <Metric
+              key={node}
+              name="cr.node.sql.distsql.flows.active"
+              title={nodeAddress(nodesSummary, node)}
+              sources={[node]}
+            />
+          ))
+        }
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Service Latency: SQL, 99th percentile"
       tooltip={(
         <div>


### PR DESCRIPTION
This adds metrics for counts of active DistSQL queries and flows, which
will give some visibility into the status of long-running queries.

Contributes to #12143.