### PR TITLE
distsql: add a simple benchmark to the HashJoiner

### DIFF
--- a/pkg/sql/distsqlrun/testutils.go
+++ b/pkg/sql/distsqlrun/testutils.go
@@ -32,11 +32,19 @@ type RepeatableRowSource struct {
 var _ RowSource = &RepeatableRowSource{}
 
 // NewRepeatableRowSource creates a RepeatableRowSource with the given schema
-// and rows.
+// and rows. types is optional if at least one row is provided.
 func NewRepeatableRowSource(
 	types []sqlbase.ColumnType, rows sqlbase.EncDatumRows,
 ) *RepeatableRowSource {
-	return &RepeatableRowSource{rows: rows, types: types}
+	r := &RepeatableRowSource{rows: rows, types: types}
+	if len(r.rows) > 0 && r.types == nil {
+		inferredTypes := make([]sqlbase.ColumnType, len(r.rows[0]))
+		for i, d := range r.rows[0] {
+			inferredTypes[i] = d.Type
+		}
+		r.types = inferredTypes
+	}
+	return r
 }
 
 // Types is part of the RowSource interface.


### PR DESCRIPTION
More complex benchmarks are out of this PR's scope. This benchmark will be good to ensure that there are no performance regressions introduced by upcoming changes to the HashJoiner to make it fall back to disk if a memory limit is reached.

```
$ make bench PKG=./pkg/sql/distsqlrun BENCHES=BenchmarkHashJoiner TESTFLAGS="-count 20"
name                          time/op
HashJoiner/InputSize=0-8      9.53µs ± 7%
HashJoiner/InputSize=4-8      18.4µs ± 2%
HashJoiner/InputSize=16-8     38.8µs ± 2%
HashJoiner/InputSize=256-8     466µs ± 4%
HashJoiner/InputSize=4096-8   7.83ms ± 2%
HashJoiner/InputSize=65536-8   133ms ± 6%
```