### PR TITLE
util: add migration stub

### DIFF
--- a/pkg/util/migration_stub.go
+++ b/pkg/util/migration_stub.go
@@ -1,0 +1,26 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import "github.com/cockroachdb/cockroach/pkg/util/envutil"
+
+var _ = IsMigrated()
+
+// IsMigrated gives a crude way of landing changes that need a migration until
+// #16977 is implemented. When IsMigrated() returns false (the default),
+// mixed-cluster compatibility with 1.0 is required.
+func IsMigrated() bool {
+	return envutil.EnvOrDefaultBool("COCKROACH_MIGRATED", false)
+}


### PR DESCRIPTION
Pending #16977, this gives a crude way of landing changes that
will need a proper migration.

The "problem" with this change is that this means that tests won't be run with
the new code completely active. We can change that, but it would approximately
double time spent in CI, so that I'm not convinced it's worth it at this point.
Instead, the "new mode" should be tested thoroughly when it can properly be
migrated into.