### PR TITLE
sql: improve string formatting for postgres-compat

### DIFF
--- a/pkg/acceptance/node_test.go
+++ b/pkg/acceptance/node_test.go
@@ -52,12 +52,13 @@ const client = new pg.Client(config);
 client.connect(function (err) {
   if (err) throw err;
 
-  client.query("SELECT 1 as first, 2+$1 as second", [%v], function (err, results) {
+  client.query("SELECT 1 as first, 2+$1 as second, ARRAY['\"','',''] as third", [%v], function (err, results) {
     if (err) throw err;
 
     assert.deepEqual(results.rows, [{
       first: 1,
-      second: 5
+      second: 5,
+      third: ['"', '', '']
     }]);
     client.end(function (err) {
       if (err) throw err;

--- a/pkg/acceptance/python_test.go
+++ b/pkg/acceptance/python_test.go
@@ -63,4 +63,11 @@ d = v[0][0]
 assert type(d) is decimal.Decimal
 # Use of compare_total here guarantees that we didn't just get '10' back, we got '1e1'.
 assert d.compare_total(decimal.Decimal('1e1')) == 0
+
+# Verify arrays with strings can be parsed.
+cur = conn.cursor()
+cur.execute("SELECT ARRAY['foo','bar','baz']")
+v = cur.fetchall()
+d = v[0][0]
+assert d == ["foo","bar","baz"]
 `

--- a/pkg/cli/sql_util_test.go
+++ b/pkg/cli/sql_util_test.go
@@ -129,8 +129,8 @@ SET
 	}
 
 	expectedRows := [][]string{
-		{`parentID`, `INT`, `false`, `NULL`, `{primary}`},
-		{`name`, `STRING`, `false`, `NULL`, `{primary}`},
+		{`parentID`, `INT`, `false`, `NULL`, `"{\"primary\"}"`},
+		{`name`, `STRING`, `false`, `NULL`, `"{\"primary\"}"`},
 		{`id`, `INT`, `true`, `NULL`, `{}`},
 	}
 	if !reflect.DeepEqual(expectedRows, rows) {
@@ -143,13 +143,13 @@ SET
 	}
 
 	expected = `
-+----------+--------+-------+---------+-----------+
-|  Field   |  Type  | Null  | Default |  Indices  |
-+----------+--------+-------+---------+-----------+
-| parentID | INT    | false | NULL    | {primary} |
-| name     | STRING | false | NULL    | {primary} |
-| id       | INT    | true  | NULL    | {}        |
-+----------+--------+-------+---------+-----------+
++----------+--------+-------+---------+-------------+
+|  Field   |  Type  | Null  | Default |   Indices   |
++----------+--------+-------+---------+-------------+
+| parentID | INT    | false | NULL    | {"primary"} |
+| name     | STRING | false | NULL    | {"primary"} |
+| id       | INT    | true  | NULL    | {}          |
++----------+--------+-------+---------+-------------+
 (3 rows)
 `
 

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -858,8 +858,8 @@ CREATE TABLE t.test (a CHAR PRIMARY KEY, b CHAR, c CHAR, INDEX foo (c));
 	mt.CheckQueryResults(
 		"SHOW COLUMNS FROM t.test",
 		[][]string{
-			{"a", "STRING", "false", "NULL", "{primary,ufo}"},
-			{"d", "STRING", "true", "NULL", "{ufo}"},
+			{"a", "STRING", "false", "NULL", "{\"primary\",\"ufo\"}"},
+			{"d", "STRING", "true", "NULL", "{\"ufo\"}"},
 			{"e", "STRING", "true", "NULL", "{}"},
 		},
 	)

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -495,7 +495,7 @@ NULL NULL NULL NULL
 query TT
 SELECT ARRAY_AGG(k), ARRAY_AGG(s) FROM kv
 ----
-{1,3,5,6,7,8} {a,a,NULL,b,b,A}
+{1,3,5,6,7,8} {"a","a",NULL,"b","b","A"}
 
 query T
 SELECT array_agg(s) FROM kv WHERE s IS NULL

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -29,8 +29,8 @@ query TTBTT colnames
 SHOW COLUMNS FROM t
 ----
 Field Type Null  Default Indices
-a     INT  false NULL    {primary,t_f_idx}
-f     INT  true  NULL    {t_f_idx}
+a     INT  false NULL    {"primary","t_f_idx"}
+f     INT  true  NULL    {"t_f_idx"}
 b     INT  true  NULL    {}
 
 statement ok
@@ -419,11 +419,11 @@ query TTBTT colnames
 SHOW COLUMNS FROM tt
 ----
 Field  Type     Null   Default       Indices
-a      INT      false  NULL          {primary,tt_s_key,tt_t_key}
+a      INT      false  NULL          {"primary","tt_s_key","tt_t_key"}
 q      DECIMAL  false  NULL          {}
 r      DECIMAL  true   NULL          {}
-s      DECIMAL  false  NULL          {tt_s_key}
-t      DECIMAL  true   4.0:::DECIMAL {tt_t_key}
+s      DECIMAL  false  NULL          {"tt_s_key"}
+t      DECIMAL  true   4.0:::DECIMAL {"tt_t_key"}
 
 # Default values can be added and changed after table creation.
 statement ok
@@ -577,7 +577,7 @@ query TTBTT colnames
 SHOW COLUMNS FROM privs
 ----
 Field Type Null  Default Indices
-a     INT  false NULL    {primary}
+a     INT  false NULL    {"primary"}
 b     INT  true  NULL    {}
 
 statement ok
@@ -595,8 +595,8 @@ query TTBTT colnames
 SHOW COLUMNS FROM privs
 ----
 Field Type Null  Default Indices
-a     INT  false NULL    {primary,foo}
-b     INT  true  NULL    {foo}
+a     INT  false NULL    {"primary","foo"}
+b     INT  true  NULL    {"foo"}
 c     INT  true  NULL    {}
 
 statement error relation "nonexistent" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -16,13 +16,33 @@ SELECT ARRAY['a', true, 1]
 query T
 SELECT ARRAY['a,', 'b{', 'c}', 'd', 'e f']
 ----
-{'a,','b{','c}',d,'e f'}
+{"a,","b{","c}","d","e f"}
 
 # TODO(jordan): #16487
 # query T
 # SELECT ARRAY[e'g\x10h']
 # ----
 # {g\x10h}
+
+query TTTTTTT
+SELECT '', 'NULL', 'Null', 'null', NULL, '"', e'\''
+----
+  NULL Null null NULL " '
+
+query T
+SELECT ARRAY['', 'NULL', 'Null', 'null', NULL, '"', e'\'']
+----
+{"","NULL","Null","null",NULL,"\"","'"}
+
+query T
+SELECT ARRAY[e'\n', e'g\x10h']
+----
+{"\n","g\x10h"}
+
+query T
+SELECT ARRAY['foo', 'bar']
+----
+{"foo","bar"}
 
 # array construction from subqueries
 
@@ -39,7 +59,7 @@ SELECT ARRAY(VALUES (1),(2),(1))
 query T
 SELECT ARRAY(VALUES ('a'),('b'),('c'))
 ----
-{a,b,c}
+{"a","b","c"}
 
 query error subquery must return only one column, found 2
 SELECT ARRAY(SELECT 1, 2)

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1213,12 +1213,12 @@ SELECT foo.* IS NOT TRUE FROM (VALUES (1)) AS foo(x)
 query T
 SELECT CURRENT_SCHEMAS(true)
 ----
-{test,pg_catalog}
+{"test","pg_catalog"}
 
 query T
 SELECT CURRENT_SCHEMAS(false)
 ----
-{test}
+{"test"}
 
 query error pq: unknown signature: current_schemas()
 SELECT CURRENT_SCHEMAS()

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -647,7 +647,7 @@ CREATE TABLE tz (
 query TTBTT
 SHOW COLUMNS FROM tz
 ----
-a     INT                       false     NULL {primary}
+a     INT                       false     NULL {"primary"}
 b     TIMESTAMP                 true      NULL {}
 c     TIMESTAMP WITH TIME ZONE  true      NULL {}
 d     TIMESTAMP WITH TIME ZONE  true      NULL {}

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -35,7 +35,7 @@ query TTBTT colnames
 SHOW COLUMNS FROM t
 ----
 Field Type      Null  Default  Indices
-a     INT       false 42:::INT {primary}
+a     INT       false 42:::INT {"primary"}
 b     TIMESTAMP true  now()    {}
 c     FLOAT     true  random() {}
 
@@ -117,6 +117,6 @@ query TTBTT colnames
 SHOW COLUMNS FROM v
 ----
 Field Type      Null  Default  Indices
-a     INT       false NULL     {primary}
+a     INT       false NULL     {"primary"}
 b     TIMESTAMP true  NULL     {}
 c     INT       true  NULL     {}

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -67,9 +67,9 @@ GROUP BY i.relname,
          ix.indkey
 ORDER BY i.relname
 ----
-name              primary  unique  indkey  column_indexes  column_names  definition
-customers_id_idx  false    false   2       {1,2}           {name,id}     CREATE INDEX customers_id_idx ON test.customers (id ASC)
-primary           true     true    1       {1,2}           {name,id}     CREATE UNIQUE INDEX "primary" ON test.customers ("name" ASC)
+name              primary  unique  indkey  column_indexes  column_names      definition
+customers_id_idx  false    false   2       {1,2}           {"name","id"}     CREATE INDEX customers_id_idx ON test.customers (id ASC)
+primary           true     true    1       {1,2}           {"name","id"}     CREATE UNIQUE INDEX "primary" ON test.customers ("name" ASC)
 
 
 query TT colnames

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -104,7 +104,7 @@ user testuser
 query TTBTT
 SHOW COLUMNS FROM t
 ----
-k INT false NULL {primary}
+k INT false NULL {"primary"}
 v INT true  NULL {}
 
 statement error user testuser does not have GRANT privilege on relation t

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -94,76 +94,76 @@ SELECT length(descriptor) * (id - 1) FROM system.descriptor WHERE id = 1
 query TTBTT
 SHOW COLUMNS FROM system.namespace
 ----
-parentID  INT     false  NULL  {primary}
-name      STRING  false  NULL  {primary}
+parentID  INT     false  NULL  {"primary"}
+name      STRING  false  NULL  {"primary"}
 id        INT     true   NULL  {}
 
 query TTBTT
 SHOW COLUMNS FROM system.descriptor
 ----
-id         INT   false NULL {primary}
+id         INT   false NULL {"primary"}
 descriptor BYTES true  NULL {}
 
 query TTBTT
 SHOW COLUMNS FROM system.users
 ----
-username        STRING  false  NULL  {primary}
+username        STRING  false  NULL  {"primary"}
 hashedPassword  BYTES   true   NULL  {}
 
 query TTBTT
 SHOW COLUMNS FROM system.zones
 ----
-id     INT   false NULL {primary}
+id     INT   false NULL {"primary"}
 config BYTES true  NULL {}
 
 query TTBTT
 SHOW COLUMNS FROM system.lease
 ----
-descID      INT        false  NULL  {primary}
-version     INT        false  NULL  {primary}
-nodeID      INT        false  NULL  {primary}
-expiration  TIMESTAMP  false  NULL  {primary}
+descID      INT        false  NULL  {"primary"}
+version     INT        false  NULL  {"primary"}
+nodeID      INT        false  NULL  {"primary"}
+expiration  TIMESTAMP  false  NULL  {"primary"}
 
 query TTBTT
 SHOW COLUMNS FROM system.eventlog
 ----
-timestamp    TIMESTAMP  false  NULL       {primary}
+timestamp    TIMESTAMP  false  NULL       {"primary"}
 eventType    STRING     false  NULL       {}
 targetID     INT        false  NULL       {}
 reportingID  INT        false  NULL       {}
 info         STRING     true   NULL       {}
-uniqueID     BYTES      false  uuid_v4()  {primary}
+uniqueID     BYTES      false  uuid_v4()  {"primary"}
 
 query TTBTT
 SHOW COLUMNS FROM system.rangelog
 ----
-timestamp     TIMESTAMP  false  NULL            {primary}
+timestamp     TIMESTAMP  false  NULL            {"primary"}
 rangeID       INT        false  NULL            {}
 storeID       INT        false  NULL            {}
 eventType     STRING     false  NULL            {}
 otherRangeID  INT        true   NULL            {}
 info          STRING     true   NULL            {}
-uniqueID      INT        false  unique_rowid()  {primary}
+uniqueID      INT        false  unique_rowid()  {"primary"}
 
 query TTBTT
 SHOW COLUMNS FROM system.ui
 ----
-key          STRING     false  NULL  {primary}
+key          STRING     false  NULL  {"primary"}
 value        BYTES      true   NULL  {}
 lastUpdated  TIMESTAMP  false  NULL  {}
 
 query TTBTT
 SHOW COLUMNS FROM system.jobs
 ----
-id       INT        false  unique_rowid()  {primary,jobs_status_created_idx}
-status   STRING     false  NULL            {jobs_status_created_idx}
-created  TIMESTAMP  false  now()           {jobs_status_created_idx}
+id       INT        false  unique_rowid()  {"primary","jobs_status_created_idx"}
+status   STRING     false  NULL            {"jobs_status_created_idx"}
+created  TIMESTAMP  false  now()           {"jobs_status_created_idx"}
 payload  BYTES      false  NULL            {}
 
 query TTBTT
 SHOW COLUMNS FROM system.settings
 ----
-name         STRING     false  NULL   {primary}
+name         STRING     false  NULL   {"primary"}
 value        STRING     false  NULL   {}
 lastUpdated  TIMESTAMP  false  now()  {}
 valueType    STRING     true   NULL   {}

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -79,7 +79,7 @@ query TTBTT colnames
 SHOW COLUMNS FROM d
 ----
 Field Type   Null  Default Indices
-id    INT    false NULL    {primary}
+id    INT    false NULL    {"primary"}
 
 statement ok
 CREATE TABLE e (
@@ -90,7 +90,7 @@ query TTBTT colnames
 SHOW COLUMNS FROM e
 ----
 Field Type   Null   Default Indices
-id    INT    false  NULL    {primary}
+id    INT    false  NULL    {"primary"}
 
 statement ok
 CREATE TABLE f (
@@ -104,9 +104,9 @@ query TTBTT colnames
 SHOW COLUMNS FROM f
 ----
 Field Type   Null  Default Indices
-a     INT   false  NULL    {primary}
-b     INT   false  NULL    {primary}
-c     INT   false  NULL    {primary}
+a     INT   false  NULL    {"primary"}
+b     INT   false  NULL    {"primary"}
+c     INT   false  NULL    {"primary"}
 
 query T
 SHOW TABLES FROM test
@@ -160,8 +160,8 @@ query TTBTT colnames
 SHOW COLUMNS FROM test.users
 ----
 Field       Type        Null    Default Indices
-id          INT         false   NULL    {primary,foo,bar}
-name        STRING      false   NULL    {foo,bar}
+id          INT         false   NULL    {"primary","foo","bar"}
+name        STRING      false   NULL    {"foo","bar"}
 title       STRING      true    NULL    {}
 nickname    STRING      true    NULL	{}
 username    STRING(10)  true    NULL	{}

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -765,7 +765,11 @@ func (*DString) AmbiguousFormat() bool { return true }
 
 // Format implements the NodeFormatter interface.
 func (d *DString) Format(buf *bytes.Buffer, f FmtFlags) {
-	encodeSQLStringWithFlags(buf, string(*d), f)
+	if f.withinArray {
+		encodeSQLStringInsideArray(buf, string(*d))
+	} else {
+		encodeSQLStringWithFlags(buf, string(*d), f)
+	}
 }
 
 // Size implements the Datum interface.

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -43,6 +43,8 @@ type fmtFlags struct {
 	bareStrings bool
 	// If true, identifiers will be rendered without wrapping quotes.
 	bareIdentifiers bool
+	// If true, strings will be formatted for being contents of ARRAYs.
+	withinArray bool
 	// If true, datums and placeholders will have type annotations (like
 	// :::interval) as necessary to disambiguate between possible type
 	// resolutions.
@@ -69,6 +71,10 @@ var FmtShowTypes FmtFlags = &fmtFlags{showTypes: true}
 // FmtBareStrings instructs the pretty-printer to print strings without
 // wrapping quotes, if the string contains no special characters.
 var FmtBareStrings FmtFlags = &fmtFlags{bareStrings: true}
+
+// FmtArrays instructs the pretty-printer to print strings without
+// wrapping quotes, if the string contains no special characters.
+var FmtArrays FmtFlags = &fmtFlags{withinArray: true}
 
 // FmtBareIdentifiers instructs the pretty-printer to print
 // identifiers without wrapping quotes in any case.

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"go/constant"
 	"reflect"
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -1647,4 +1648,18 @@ func testEncodeString(t *testing.T, input []byte, encode func(*bytes.Buffer, str
 		t.Fatalf("expected %s, but found %s", sql, stmt)
 	}
 	return stmt
+}
+
+func BenchmarkEncodeSQLString(b *testing.B) {
+	str := strings.Repeat("foo", 10000)
+	b.Run("old version", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			encodeSQLStringWithFlags(bytes.NewBuffer(nil), str, FmtBareStrings)
+		}
+	})
+	b.Run("new version", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			encodeSQLStringInsideArray(bytes.NewBuffer(nil), str)
+		}
+	})
 }

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -652,7 +652,7 @@ func TestPGPreparedQuery(t *testing.T) {
 		},
 		"SHOW COLUMNS FROM system.users": {
 			baseTest.
-				Results("username", "STRING", false, gosql.NullBool{}, "{primary}").
+				Results("username", "STRING", false, gosql.NullBool{}, "{\"primary\"}").
 				Results("hashedPassword", "BYTES", true, gosql.NullBool{}, "{}"),
 		},
 		"SHOW DATABASES": {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -196,10 +196,8 @@ func (b *writeBuffer) writeTextDatum(
 			if i > 0 {
 				b.variablePutbuf.WriteString(sep)
 			}
-			// TODO(radu): we are relying on Format but this doesn't work correctly
-			// if we have an array inside this array. To support nested arrays, we
-			// would need to recurse or add a special FmtFlag.
-			parser.FormatNode(&b.variablePutbuf, parser.FmtBareStrings, d)
+			// TODO(justin): add a test for nested arrays.
+			parser.FormatNode(&b.variablePutbuf, parser.FmtArrays, d)
 		}
 		b.variablePutbuf.WriteString(end)
 		b.writeLengthPrefixedVariablePutbuf()


### PR DESCRIPTION
Three main changes here:
* When formatting strings for arrays, postgres uses double quotes rather
  than single quotes.
* When outputting strings in bare-mode, postgres quotes both `NULL` and
  ``.
* When outputting strings within arrays, don't prefix strings with
  escape sequences with `e` (doesn't completely deal with #16487,
  though, as we are overly aggressive with double quotes, I think)

These three changes are required for the node.js postgres driver.