### PR TITLE
engine: fix bug in (MVCCKey).Less

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -114,7 +114,9 @@ func (k MVCCKey) Less(l MVCCKey) bool {
 	if c := k.Key.Compare(l.Key); c != 0 {
 		return c < 0
 	}
-	if !l.IsValue() {
+	if !k.IsValue() {
+		return l.IsValue()
+	} else if !l.IsValue() {
 		return false
 	}
 	return l.Timestamp.Less(k.Timestamp)

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -250,6 +251,7 @@ func TestMVCCKeys(t *testing.T) {
 	}
 	sortKeys := make(mvccKeys, len(keys))
 	copy(sortKeys, keys)
+	shuffle.Shuffle(sortKeys)
 	sort.Sort(sortKeys)
 	if !reflect.DeepEqual(sortKeys, keys) {
 		t.Errorf("expected keys to sort in order %s, but got %s", keys, sortKeys)


### PR DESCRIPTION
Given key=a,ts=0 and key=a,ts=1, the previous implementation would
return false regardless of which is the argument and which the receiver,
but they're not equal. This violates expectations of Less.

It looks like it's trying to sort in the same order as our encoded keys
do in RocksDB, so I made it match that. Namely, sort first by key, then
sort ts=0 first, then other timestamps in descending order.