### PR TITLE
storageccl: don't clear existing data in AddSSTable

### DIFF
--- a/pkg/ccl/storageccl/add_sstable.go
+++ b/pkg/ccl/storageccl/add_sstable.go
@@ -36,54 +36,43 @@ func evalAddSSTable(
 	args := cArgs.Args.(*roachpb.AddSSTableRequest)
 	h := cArgs.Header
 	ms := cArgs.Stats
+	mvccStartKey, mvccEndKey := engine.MVCCKey{Key: args.Key}, engine.MVCCKey{Key: args.EndKey}
 
 	// TODO(tschottdorf): restore the below in some form (gets in the way of testing).
 	// _, span := tracing.ChildSpan(ctx, fmt.Sprintf("AddSSTable [%s,%s)", args.Key, args.EndKey))
 	// defer tracing.FinishSpan(span)
 	log.Eventf(ctx, "evaluating AddSSTable")
 
+	// Compute the stats for any existing data in the affected span. The sstable
+	// being ingested can overwrite all, some, or none of the existing kvs.
+	// (Note: the expected case is that it's none or, in the case of a retry of
+	// the request, all.) So subtract out the existing mvcc stats, and add back
+	// what they'll be after the sstable is ingested.
+	existingIter := batch.NewIterator(false)
+	defer existingIter.Close()
+	existingIter.Seek(mvccStartKey)
+	if ok, err := existingIter.Valid(); err != nil {
+		return storage.EvalResult{}, errors.Wrap(err, "computing existing stats")
+	} else if ok && existingIter.UnsafeKey().Less(mvccEndKey) {
+		log.Eventf(ctx, "target key range not empty, will merge existing data with sstable")
+	}
+	// This ComputeStats is cheap if the span is empty.
+	existingStats, err := existingIter.ComputeStats(mvccStartKey, mvccEndKey, h.Timestamp.WallTime)
+	if err != nil {
+		return storage.EvalResult{}, errors.Wrap(err, "computing existing stats")
+	}
+	ms.Subtract(existingStats)
+
 	// Verify that the keys in the sstable are within the range specified by the
 	// request header, verify the key-value checksums, and compute the new
 	// MVCCStats.
-	mvccStartKey, mvccEndKey := engine.MVCCKey{Key: args.Key}, engine.MVCCKey{Key: args.EndKey}
-	stats, err := verifySSTable(args.Data, mvccStartKey, mvccEndKey, h.Timestamp.WallTime)
+	stats, err := verifySSTable(
+		existingIter, args.Data, mvccStartKey, mvccEndKey, h.Timestamp.WallTime)
 	if err != nil {
 		return storage.EvalResult{}, errors.Wrap(err, "verifying sstable data")
 	}
-
-	// Check if there was data in the affected keyrange. If so, delete it.
-	existingStats, err := clearExistingData(ctx, batch, mvccStartKey, mvccEndKey, h.Timestamp.WallTime)
-	if err != nil {
-		return storage.EvalResult{}, errors.Wrap(err, "clearing existing data")
-	}
-
-	if existingStats != (enginepb.MVCCStats{}) {
-		log.Eventf(ctx, "key range contains existing data %+v, falling back to regular WriteBatch", existingStats)
-		ms.Subtract(existingStats) // account for clearExistingData
-
-		// If we're overwriting data, linking the SSTable is tricky since we have
-		// to link before we delete, and so the deletions could clobber the data
-		// in the SSTable. Instead, we put everything into a WriteBatch. Not
-		// pretty, but this case should be the exception.
-		reader := engine.MakeRocksDBSstFileReader()
-		defer reader.Close()
-		if err := reader.IngestExternalFile(args.Data); err != nil {
-			return storage.EvalResult{}, errors.Wrap(err, "while preparing SSTable for copy into WriteBatch")
-		}
-		var v roachpb.Value
-		if err := reader.Iterate(mvccStartKey, mvccEndKey, func(kv engine.MVCCKeyValue) (bool, error) {
-			v.RawBytes = kv.Value
-			return false, engine.MVCCPut(ctx, batch, ms, kv.Key.Key, kv.Key.Timestamp, v, nil /* txn */)
-		}); err != nil {
-			return storage.EvalResult{}, errors.Wrap(err, "copying SSTable into batch")
-		}
-		// Return with only a WriteBatch and no sideloading.
-		return storage.EvalResult{}, nil
-	}
-
-	// More frequent case: the underlying key range is empty and we can ingest an SSTable.
-	log.Event(ctx, "key range is empty; commencing with SSTable proposal")
 	ms.Add(stats)
+
 	return storage.EvalResult{
 		Replicated: storagebase.ReplicatedEvalResult{
 			AddSSTable: &storagebase.ReplicatedEvalResult_AddSSTable{
@@ -95,18 +84,18 @@ func evalAddSSTable(
 }
 
 func verifySSTable(
-	data []byte, start, end engine.MVCCKey, nowNanos int64,
+	existingIter engine.SimpleIterator, data []byte, start, end engine.MVCCKey, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	iter, err := engineccl.NewMemSSTIterator(data)
+	dataIter, err := engineccl.NewMemSSTIterator(data)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
-	defer iter.Close()
+	defer dataIter.Close()
 
-	iter.Seek(engine.MVCCKey{Key: keys.MinKey})
-	ok, err := iter.Valid()
-	for ; ok; ok, err = iter.Valid() {
-		unsafeKey := iter.UnsafeKey()
+	dataIter.Seek(engine.MVCCKey{Key: keys.MinKey})
+	ok, err := dataIter.Valid()
+	for ; ok; ok, err = dataIter.Valid() {
+		unsafeKey := dataIter.UnsafeKey()
 		if unsafeKey.Less(start) || !unsafeKey.Less(end) {
 			// TODO(dan): Add a new field in roachpb.Error, so the client can
 			// catch this and retry. It can happen if the range splits between
@@ -115,65 +104,26 @@ func verifySSTable(
 				unsafeKey.Key, start.Key, end.Key)
 		}
 
-		v := roachpb.Value{RawBytes: iter.UnsafeValue()}
+		v := roachpb.Value{RawBytes: dataIter.UnsafeValue()}
 		if err := v.Verify(unsafeKey.Key); err != nil {
 			return enginepb.MVCCStats{}, err
 		}
-		iter.Next()
+		dataIter.Next()
 	}
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
+
+	// In the case that two iterators have an entry with the same key and
+	// timestamp, MultiIterator breaks ties by preferring later ones in the
+	// ordering. So it's important that the sstable iterator comes after the one
+	// for the existing data (because the sstable will overwrite it when
+	// ingested).
+	mergedIter := engineccl.MakeMultiIterator([]engine.SimpleIterator{existingIter, dataIter})
+	defer mergedIter.Close()
 
 	// TODO(dan): This unnecessarily iterates the sstable a second time, see if
 	// combining this computation with the above checksum verification speeds
 	// anything up.
-	return engine.ComputeStatsGo(iter, start, end, nowNanos)
-}
-
-func clearExistingData(
-	ctx context.Context, batch engine.ReadWriter, start, end engine.MVCCKey, nowNanos int64,
-) (enginepb.MVCCStats, error) {
-	{
-		isEmpty := true
-		if err := batch.Iterate(start, end, func(_ engine.MVCCKeyValue) (bool, error) {
-			isEmpty = false
-			return true, nil // stop right away
-		}); err != nil {
-			return enginepb.MVCCStats{}, errors.Wrap(err, "while checking for empty key space")
-		}
-
-		if isEmpty {
-			return enginepb.MVCCStats{}, nil
-		}
-	}
-
-	iter := batch.NewIterator(false)
-	defer iter.Close()
-
-	iter.Seek(start)
-	if ok, err := iter.Valid(); err != nil {
-		return enginepb.MVCCStats{}, err
-	} else if ok && !iter.UnsafeKey().Less(end) {
-		return enginepb.MVCCStats{}, nil
-	}
-
-	existingStats, err := iter.ComputeStats(start, end, nowNanos)
-	if err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-
-	log.Eventf(ctx, "target key range not empty, will clear existing data: %+v", existingStats)
-	// If this is a SpanSetIterator, we have to unwrap it because
-	// ClearIterRange needs a plain rocksdb iterator (and can't unwrap
-	// it itself because of import cycles).
-	if ssi, ok := iter.(*storage.SpanSetIterator); ok {
-		iter = ssi.Iterator()
-	}
-	// TODO(dan): Ideally, this would use `batch.ClearRange` but it doesn't
-	// yet work with read-write batches (or IngestExternalData).
-	if err := batch.ClearIterRange(iter, start, end); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-	return existingStats, nil
+	return engine.ComputeStatsGo(mergedIter, start, end, nowNanos)
 }

--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -10,12 +10,16 @@ package storageccl
 
 import (
 	"bytes"
+	"fmt"
+	"math/rand"
 	"reflect"
+	"sort"
 	"testing"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -24,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/kr/pretty"
 )
 
@@ -48,7 +53,7 @@ func TestDBAddSSTable(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	{
-		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 2}}
 		data, err := singleKVSSTable(key, roachpb.MakeValueFromString("1").RawBytes)
 		if err != nil {
 			t.Fatalf("%+v", err)
@@ -67,6 +72,7 @@ func TestDBAddSSTable(t *testing.T) {
 			t.Fatalf("expected request range error got: %+v", err)
 		}
 
+		// Do an initial ingest.
 		ingestCtx, collect := testutils.MakeRecordCtx()
 		defer collect()
 		if err := db.ExperimentalAddSSTable(ingestCtx, "b", "c", data); err != nil {
@@ -74,62 +80,74 @@ func TestDBAddSSTable(t *testing.T) {
 		}
 		if err := testutils.MatchInOrder(collect(),
 			"evaluating AddSSTable",
-			"key range is empty; commencing with SSTable proposal",
 			"sideloadable proposal detected",
 			"ingested SSTable at index",
 		); err != nil {
 			t.Fatal(err)
 		}
 
-		if result, err := db.Get(ctx, "bb"); err != nil {
+		if r, err := db.Get(ctx, "bb"); err != nil {
 			t.Fatalf("%+v", err)
-		} else if result := result.ValueBytes(); !bytes.Equal([]byte("1"), result) {
-			t.Errorf("expected %q, got %q", []byte("1"), result)
+		} else if expected := []byte("1"); !bytes.Equal(expected, r.ValueBytes()) {
+			t.Errorf("expected %q, got %q", expected, r.ValueBytes())
 		}
 	}
 
-	// Key range in request span is not empty.
-	//
-	// Doing the same ingestion multiple times highlights the case in which the
-	// deletion of existing data overlaps the data being ingested. This case is
-	// central in that it's likely the scenario in practice, and that a lot of
-	// special care goes into handling it (TL;DR is we can't ingest and clear
-	// overlapping data safely; instead we don't use sideloading).
-	ingestCtx, collect := testutils.MakeRecordCtx()
-	defer collect()
-	for i := 0; i < 2; i++ {
-		key := engine.MVCCKey{Key: []byte("bb2"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	// Check that ingesting a key with an earlier mvcc timestamp doesn't affect
+	// the value returned by Get.
+	{
+		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
 		data, err := singleKVSSTable(key, roachpb.MakeValueFromString("2").RawBytes)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if err := db.ExperimentalAddSSTable(ingestCtx, "b", "c", data); err != nil {
+
+		if err := db.ExperimentalAddSSTable(ctx, "b", "c", data); err != nil {
 			t.Fatalf("%+v", err)
 		}
-
-		if result, err := db.Get(ctx, "bb2"); err != nil {
+		if r, err := db.Get(ctx, "bb"); err != nil {
 			t.Fatalf("%+v", err)
-		} else if result := result.ValueBytes(); !bytes.Equal([]byte("2"), result) {
-			t.Errorf("expected %q, got %q", []byte("2"), result)
-		}
-
-		if result, err := db.Get(ctx, "bb"); err != nil {
-			t.Fatalf("%+v", err)
-		} else if result := result.ValueBytes(); result != nil {
-			t.Errorf("expected nil, got %q", result)
+		} else if expected := []byte("1"); !bytes.Equal(expected, r.ValueBytes()) {
+			t.Errorf("expected %q, got %q", expected, r.ValueBytes())
 		}
 	}
-	if err := testutils.MatchInOrder(collect(),
-		"evaluating AddSSTable",
-		"target key range not empty, will clear existing data",
-		"key range contains existing data",
-		"falling back to regular WriteBatch",
-		"evaluating AddSSTable",
-		"target key range not empty, will clear existing data",
-		"key range contains existing data",
-		"falling back to regular WriteBatch",
-	); err != nil {
-		t.Fatal(err)
+
+	// Key range in request span is not empty. First time through a different
+	// key is present. Second time through checks the idempotency.
+	{
+		key := engine.MVCCKey{Key: []byte("bc"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		data, err := singleKVSSTable(key, roachpb.MakeValueFromString("3").RawBytes)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		for i := 0; i < 2; i++ {
+			ingestCtx, collect := testutils.MakeRecordCtx()
+			defer collect()
+
+			if err := db.ExperimentalAddSSTable(ingestCtx, "b", "c", data); err != nil {
+				t.Fatalf("%+v", err)
+			}
+			if err := testutils.MatchInOrder(collect(),
+				"evaluating AddSSTable",
+				"target key range not empty, will merge existing data with sstable",
+				"sideloadable proposal detected",
+				"ingested SSTable at index",
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			if r, err := db.Get(ctx, "bb"); err != nil {
+				t.Fatalf("%+v", err)
+			} else if expected := []byte("1"); !bytes.Equal(expected, r.ValueBytes()) {
+				t.Errorf("expected %q, got %q", expected, r.ValueBytes())
+			}
+			if r, err := db.Get(ctx, "bc"); err != nil {
+				t.Fatalf("%+v", err)
+			} else if expected := []byte("3"); !bytes.Equal(expected, r.ValueBytes()) {
+				t.Errorf("expected %q, got %q", expected, r.ValueBytes())
+			}
+		}
 	}
 
 	// Invalid key/value entry checksum.
@@ -148,66 +166,150 @@ func TestDBAddSSTable(t *testing.T) {
 	}
 }
 
+func randomMVCCKeyValues(rng *rand.Rand, numKVs int) []engine.MVCCKeyValue {
+	kvs := make([]engine.MVCCKeyValue, numKVs)
+	for i := range kvs {
+		kvs[i] = engine.MVCCKeyValue{
+			Key: engine.MVCCKey{
+				Key:       randutil.RandBytes(rng, 1),
+				Timestamp: hlc.Timestamp{WallTime: 1 + rand.Int63n(10)},
+			},
+			Value: roachpb.MakeValueFromBytes(randutil.RandBytes(rng, rng.Intn(10))).RawBytes,
+		}
+		if rng.Intn(100) < 25 {
+			// 25% of the time, make the entry a deletion tombstone.
+			kvs[i].Value = nil
+		}
+	}
+	return kvs
+}
+
+type mvccKeyValues []engine.MVCCKeyValue
+
+func (kvs mvccKeyValues) Len() int           { return len(kvs) }
+func (kvs mvccKeyValues) Less(i, j int) bool { return kvs[i].Key.Less(kvs[j].Key) }
+func (kvs mvccKeyValues) Swap(i, j int)      { kvs[i], kvs[j] = kvs[j], kvs[i] }
+
 func TestAddSSTableMVCCStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	rng, seed := randutil.NewPseudoRand()
+	t.Logf("random seed: %d", seed)
+
+	const numIterations, maxKVs = 10, 100
 
 	ctx := context.Background()
 	e := engine.NewInMem(roachpb.Attributes{}, 1<<20)
 	defer e.Close()
 
-	key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
-	data, err := singleKVSSTable(key, roachpb.MakeValueFromString("1").RawBytes)
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
-	span := roachpb.Span{Key: []byte("b"), EndKey: []byte("c")}
+	// This test repeatedly:
+	// - puts some random data in an engine
+	// - randomly makes one key an intent
+	// - puts some random data in an sst
+	// - computes pre-ingest mvcc stats for the engine
+	// - gets the mvcc stats diff from evalAddSSTable for the sst
+	// - ingests the sstable into the engine
+	// - computes post-ingest mvcc stats for the engine
+	// - compares pre-ingest + diff stats vs post-ingest stats
+	//
+	// Each time through, the engine accumulates more directly Put keys and more
+	// ingested sstables.
+	var nowNanos int64
+	for i := 0; i < numIterations; i++ {
+		nowNanos += rng.Int63n(1e9)
+		for _, kv := range randomMVCCKeyValues(rng, 1+rand.Intn(maxKVs)) {
+			if err := e.Put(kv.Key, kv.Value); err != nil {
+				t.Fatalf("%+v", err)
+			}
+		}
+		// Add in a random metadata key.
+		if err := engine.MVCCPut(
+			ctx, e, nil, randutil.RandBytes(rng, 1), hlc.Timestamp{WallTime: nowNanos},
+			roachpb.MakeValueFromBytes(randutil.RandBytes(rng, rng.Intn(10))),
+			&roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Timestamp: hlc.Timestamp{WallTime: nowNanos}}},
+		); err != nil {
+			_, isTransactionRetryError := err.(*roachpb.TransactionRetryError)
+			if !isTransactionRetryError {
+				t.Fatalf("%+v", err)
+			}
+		}
 
-	// AddSSTable deletes any data that exists in the keyrange before applying
-	// the batch. Put something there to delete. The mvcc stats should be
-	// adjusted accordingly.
-	const numInitialEntries = 100
-	for i := 0; i < numInitialEntries; i++ {
-		if err := e.Put(engine.MVCCKey{Key: append([]byte("b"), byte(i))}, nil); err != nil {
+		sstBytes := func() []byte {
+			sst, err := engine.MakeRocksDBSstFileWriter()
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			defer sst.Close()
+			sstKVs := mvccKeyValues(randomMVCCKeyValues(rng, 1+rand.Intn(maxKVs)))
+			sort.Sort(sstKVs)
+			var prevKey engine.MVCCKey
+			for _, kv := range sstKVs {
+				if kv.Key.Equal(prevKey) {
+					// RocksDB doesn't let us add the same key twice.
+					continue
+				}
+				prevKey.Key = append(prevKey.Key[:0], kv.Key.Key...)
+				prevKey.Timestamp = kv.Key.Timestamp
+				if err := sst.Add(kv); err != nil {
+					t.Fatalf("%+v", err)
+				}
+			}
+			sstBytes, err := sst.Finish()
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			return sstBytes
+		}()
+
+		nowNanos += rng.Int63n(1e9)
+		cArgs := storage.CommandArgs{
+			Header: roachpb.Header{
+				Timestamp: hlc.Timestamp{WallTime: nowNanos},
+			},
+			Args: &roachpb.AddSSTableRequest{
+				Span: roachpb.Span{Key: keys.MinKey, EndKey: keys.MaxKey},
+				Data: sstBytes,
+			},
+			Stats: &enginepb.MVCCStats{},
+		}
+		_, err := evalAddSSTable(ctx, e, cArgs, nil)
+		if err != nil {
 			t.Fatalf("%+v", err)
 		}
-	}
 
-	cArgs := storage.CommandArgs{
-		Args: &roachpb.AddSSTableRequest{
-			Span: span,
-			Data: data,
-		},
-		// Start with some stats to represent data throughout the replica's
-		// keyrange.
-		Stats: &enginepb.MVCCStats{
-			LiveBytes: 10000,
-			LiveCount: 10000,
-			KeyBytes:  10000,
-			KeyCount:  10000,
-			ValBytes:  10000,
-			ValCount:  10000,
-		},
-	}
-	if _, err := evalAddSSTable(ctx, e, cArgs, nil); err != nil {
-		t.Fatalf("%+v", err)
-	}
+		// After evalAddSSTable, cArgs.Stats contains a diff to the existing
+		// stats. Make sure recomputing from scratch gets the same answer as
+		// applying the diff to the stats
+		beforeStats := func() enginepb.MVCCStats {
+			iter := e.NewIterator(false)
+			defer iter.Close()
+			beforeStats, err := engine.ComputeStatsGo(iter, engine.NilKey, engine.MVCCKeyMax, nowNanos)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			return beforeStats
+		}()
+		beforeStats.Add(*cArgs.Stats)
 
-	expectedStats := &enginepb.MVCCStats{
-		LiveBytes:       9721,
-		LiveCount:       9901,
-		KeyBytes:        9715,
-		KeyCount:        9901,
-		ValBytes:        10006,
-		ValCount:        10001,
-		LastUpdateNanos: key.Timestamp.WallTime,
-	}
+		filename := fmt.Sprintf("/%d.sst", i)
+		if err := e.WriteFile(filename, sstBytes); err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if err := e.IngestExternalFile(ctx, filename, false /* move */); err != nil {
+			t.Fatalf("%+v", err)
+		}
 
-	if !reflect.DeepEqual(expectedStats, cArgs.Stats) {
-		t.Errorf("mvcc stats mismatch: diff(expected, actual): %s", pretty.Diff(expectedStats, cArgs.Stats))
-	}
+		afterStats := func() enginepb.MVCCStats {
+			iter := e.NewIterator(false)
+			defer iter.Close()
+			afterStats, err := engine.ComputeStatsGo(iter, engine.NilKey, engine.MVCCKeyMax, nowNanos)
+			if err != nil {
+				t.Fatalf("%+v", err)
+			}
+			return afterStats
+		}()
 
-	// TODO(dan): The WriteBatch test runs this again to test the idempotence,
-	// but AddSSTable requires the ReplicatedEvalResult to be resolved before
-	// this will work. Rewrite this test to use TestServer and add the
-	// idempotence test back.
+		if !reflect.DeepEqual(beforeStats, afterStats) {
+			t.Errorf("mvcc stats mismatch: diff(expected, actual): %s", pretty.Diff(afterStats, beforeStats))
+		}
+	}
 }

--- a/pkg/ccl/storageccl/engineccl/sst_iterator.go
+++ b/pkg/ccl/storageccl/engineccl/sst_iterator.go
@@ -93,7 +93,7 @@ func (r *sstIterator) Close() {
 // Seek implements the engine.SimpleIterator interface.
 func (r *sstIterator) Seek(key engine.MVCCKey) {
 	if r.iter != nil {
-		if r.err = errors.Wrap(r.sst.Close(), "resetting sstable iterator"); r.err != nil {
+		if r.err = errors.Wrap(r.iter.Close(), "resetting sstable iterator"); r.err != nil {
 			return
 		}
 	}

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/pkg/errors"
@@ -77,4 +78,51 @@ func evalWriteBatch(
 		return storage.EvalResult{}, err
 	}
 	return storage.EvalResult{}, nil
+}
+
+func clearExistingData(
+	ctx context.Context, batch engine.ReadWriter, start, end engine.MVCCKey, nowNanos int64,
+) (enginepb.MVCCStats, error) {
+	{
+		isEmpty := true
+		if err := batch.Iterate(start, end, func(_ engine.MVCCKeyValue) (bool, error) {
+			isEmpty = false
+			return true, nil // stop right away
+		}); err != nil {
+			return enginepb.MVCCStats{}, errors.Wrap(err, "while checking for empty key space")
+		}
+
+		if isEmpty {
+			return enginepb.MVCCStats{}, nil
+		}
+	}
+
+	iter := batch.NewIterator(false)
+	defer iter.Close()
+
+	iter.Seek(start)
+	if ok, err := iter.Valid(); err != nil {
+		return enginepb.MVCCStats{}, err
+	} else if ok && !iter.UnsafeKey().Less(end) {
+		return enginepb.MVCCStats{}, nil
+	}
+
+	existingStats, err := iter.ComputeStats(start, end, nowNanos)
+	if err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+
+	log.Eventf(ctx, "target key range not empty, will clear existing data: %+v", existingStats)
+	// If this is a SpanSetIterator, we have to unwrap it because
+	// ClearIterRange needs a plain rocksdb iterator (and can't unwrap
+	// it itself because of import cycles).
+	if ssi, ok := iter.(*storage.SpanSetIterator); ok {
+		iter = ssi.Iterator()
+	}
+	// TODO(dan): Ideally, this would use `batch.ClearRange` but it doesn't
+	// yet work with read-write batches (or IngestExternalData).
+	if err := batch.ClearIterRange(iter, start, end); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	return existingStats, nil
 }


### PR DESCRIPTION
Any given AddSSTable command needs to be idempotent, so we can retry it
(in the face of AmbiguousResultError, etc). Previously, this was
accomplished by clearing the request span before ingest. This meant that
when the request completed successfully, the affected span contained
exactly the data in the payload sstable.

Instead, ingest the file and adjust MVCCStats as appropriate. Motivations:

- An unlikely race condition in the upcoming resumable RESTORE
  coordinator work. It will be possible that one half of a split-brain
  RESTORE will finish and expose the table publicly for writes before
  the other half gets off one last AddSSTable. This would destroy user
  data in a subtle, non-transactional way.

- Adding a range tombstone basically guarantees that the ingested
  sstable will be placed in L0 instead of some lower level, increasing
  read amplification.