### PR TITLE
sql: avoid mixing/clobbering reported stats buckets

### DIFF
--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -268,9 +268,16 @@ func TestReportUsage(t *testing.T) {
 				keys[k] = struct{}{}
 			}
 			for _, expected := range expectedStatements {
-				if _, ok := app[expected]; !ok {
-					t.Fatalf("expected %q in app %s: %+v", expected, appName, keys)
+				if _, ok := app[expected]; ok {
+					continue
 				}
+				if _, ok := app[expected]; ok {
+					continue
+				}
+				if _, ok := app["+"+expected]; ok {
+					continue
+				}
+				t.Fatalf("expected %q in app %s: %+v", expected, appName, keys)
 			}
 		}
 	}

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -288,7 +288,7 @@ func (e *Executor) GetScrubbedStmtStats() AppStatementStatistics {
 			scrubbed, ok := scrubStmtStatKey(vt, q.stmt)
 			if ok {
 				stats.Lock()
-				m[scrubbed] = stats.data
+				m[q.flags()+scrubbed] = stats.data
 				stats.Unlock()
 			}
 		}


### PR DESCRIPTION
previously we were iterating over collected stats and filling collected stats buckets by query.
unfortunately in doing so, we were ignoring the other flags (failed, distsql) that are used in
collection buckets, and thus only the last collection bucket as randomly iterated would be
reported for a given query.

in 1.1, this is fixed by just reporting all buckets as a list, structured. That was part of
a larger change though (protobuf-strucutured reporting, #16955). This is a much smaller change,
just mangling the string bucket keys by prepending single-char identifiers for the distsql and
failed flags, thus ensuring distinct keys.