### PR TITLE
storage: hold raftMu when requiring Raft-consistent snapshot

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2607,7 +2607,7 @@ func (r *Replica) adminSplitWithDescriptor(
 		var foundSplitKey roachpb.Key
 		if len(args.SplitKey) == 0 {
 			// Find a key to split by size.
-			snap := r.store.NewSnapshot()
+			snap := r.store.engine.NewSnapshot()
 			defer snap.Close()
 			var err error
 			targetSize := r.GetMaxBytes() / 2

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -411,7 +411,9 @@ func (r *Replica) computeChecksumPostApply(
 	r.mu.checksums[id] = replicaChecksum{started: true, notify: notify}
 	desc := *r.mu.state.Desc
 	r.mu.Unlock()
-	snap := r.store.NewSnapshot()
+	// Caller is holding raftMu, so an engine snapshot is automatically
+	// Raft-consistent (i.e. not in the middle of an AddSSTable).
+	snap := r.store.engine.NewSnapshot()
 
 	// Compute SHA asynchronously and store it in a map by UUID.
 	if err := stopper.RunAsyncTask(ctx, "storage.Replica: computing checksum", func(ctx context.Context) {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2279,11 +2279,6 @@ func (s *Store) processRangeDescriptorUpdateLocked(ctx context.Context, repl *Re
 	return nil
 }
 
-// NewSnapshot creates a new snapshot engine.
-func (s *Store) NewSnapshot() engine.Reader {
-	return s.engine.NewSnapshot()
-}
-
 // Attrs returns the attributes of the underlying store.
 func (s *Store) Attrs() roachpb.Attributes {
 	return s.engine.Attrs()


### PR DESCRIPTION
I went through the other call sites and none need it. Open to ideas
for not getting it wrong in future code changes, but it does not seem
particularly urgent.

See #16263.