### PR TITLE
sql/parser: lazily alloc collate.Buffer

### DIFF
--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -786,7 +786,7 @@ type DCollatedString struct {
 // construct collation keys efficiently.
 type CollationEnvironment struct {
 	cache  map[string]collationEnvironmentCacheEntry
-	buffer collate.Buffer
+	buffer *collate.Buffer
 }
 
 type collationEnvironmentCacheEntry struct {
@@ -814,7 +814,10 @@ func NewDCollatedString(
 	contents string, locale string, env *CollationEnvironment,
 ) *DCollatedString {
 	entry := env.getCacheEntry(locale)
-	key := entry.collator.KeyFromString(&env.buffer, contents)
+	if env.buffer == nil {
+		env.buffer = &collate.Buffer{}
+	}
+	key := entry.collator.KeyFromString(env.buffer, contents)
 	d := DCollatedString{contents, entry.locale, make([]byte, len(key))}
 	copy(d.Key, key)
 	env.buffer.Reset()


### PR DESCRIPTION
Lazily allocate collate.Buffer as it is a heavyweight structure. This
reduces the size of a scanNode from 7496 bytes to 3384 bytes. For a
read-only workload, this reduced total allocated bytes by 16% and
resulted in a 5% improvement in throughput.

See #14927