### PR TITLE
sql: ensure that planToString doesn't cause panics with subqueries (again)

### DIFF
--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -108,6 +108,14 @@ func FmtReformatTableNames(
 	return &f
 }
 
+// StripTypeFormatting removes the flag that extracts types from the format flags,
+// so as to enable rendering expressions for which types have not been computed yet.
+func StripTypeFormatting(f FmtFlags) FmtFlags {
+	nf := *f
+	nf.showTypes = false
+	return &nf
+}
+
 // FmtExpr returns FmtFlags that indicate how the pretty-printer
 // should format expressions.
 func FmtExpr(base FmtFlags, showTypes bool, symbolicVars bool, showTableAliases bool) FmtFlags {

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -73,13 +73,11 @@ func (s *subquery) Format(buf *bytes.Buffer, f parser.FmtFlags) {
 	if s.execMode == execModeExists {
 		buf.WriteString("EXISTS ")
 	}
-	if f == parser.FmtShowTypes {
-		// TODO(knz/nvanbenschoten): It is not possible to extract types
-		// from the subquery using Format, because type checking does not
-		// replace the sub-expressions of a SelectClause node in-place.
-		f = parser.FmtSimple
-	}
-	parser.FormatNode(buf, f, s.subquery)
+	// Note: we remove the flag to print types, because subqueries can
+	// be printed in a context where type resolution has not occurred
+	// yet. We do not use FmtSimple directly however, in case the
+	// caller wants to use other flags (e.g. to anonymize identifiers).
+	parser.FormatNode(buf, parser.StripTypeFormatting(f), s.subquery)
 }
 
 func (s *subquery) String() string { return parser.AsString(s) }


### PR DESCRIPTION
(This bug only affects users running with --verbosity 3 or --vmodule=plan=3.)

planToString really would like to print out a representation of the
logical plan containing the results of type checking. Now, when an
expression inside a logical plan contains a subquery, planToString()
must show a representation of this subquery *despite the fact that the
AST for the subquery was not modified by type checking*. There was a
bug in there, and this patch fixes it.

Some more details: consider that the result of type checking lives in
the logical plan for the subquery, not the input AST. For a subquery,
the AST and the subquery plan are two different things living
side-by-side inside the expression (as a sql.subquery{...} node). The
types inside the subquery are part of the subquery plan, not the
subquery AST.

For example, with `SELECT 1 WHERE 2 = (SELECT k IN kv)` the logical
plan contains a filter expression `2 = (...)` containing a subquery
`SELECT k in kv`. In the expression node (a `ComparisonExpr`) there is
a `subquery` node containing both the AST for `SELECT k in kv` and a
logical plan (a table scan with a single-column render).

What should planToString() output for the outer query, if it wants to
display the filter expression *and the types involved in the filter
expression*?

We could let it print just literally "`2[int] = (...)[int]`" ("two
square bracket int square bracket equal parenthesis *dot dot dot*
parenthesis square bracket int square bracket"), eliding the text of
the subquery, and only print the subquery plan below in the "flattened
tree" formatting (as it already does).

However, for the sake of readability, to remind the user that they are
looking at a subquery, planToString() also includes the text
representation of the subquery's SQL, ie. a rendering of its
AST. *However, it cannot request printing of types in that AST's
expressions!* That's because type checking did not modify the subquery
AST - the types live in the subquery plan, which is printed
separately. Requesting the types would cause a call to
`ResolvedType()` on many datums which disable this, as they should, as
an assertion against wrong use of expressions.

Prior to this patch the `Format` method for the `sql.subquery` node
was a bit sloppy about disabling the printing of types. This patch
solves the problem by ensuring that the printing of types in subquery
ASTs is always disabled.

Fixes  #17077.