### PR TITLE
sql/parser: missing case for bool in type switch

### DIFF
--- a/pkg/sql/parser/col_types.go
+++ b/pkg/sql/parser/col_types.go
@@ -433,6 +433,8 @@ func (node *OidColType) String() string            { return AsString(node) }
 // normalization.
 func DatumTypeToColumnType(t Type) (ColumnType, error) {
 	switch t {
+	case TypeBool:
+		return boolColTypeBool, nil
 	case TypeInt:
 		return intColTypeInt, nil
 	case TypeFloat:

--- a/pkg/sql/testdata/logic_test/create_as
+++ b/pkg/sql/testdata/logic_test/create_as
@@ -98,3 +98,17 @@ CREATE TABLE foo3 (x) AS VALUES (1), (NULL); SELECT * FROM foo3 ORDER BY x
 ----
 NULL
 1
+
+statement ok
+CREATE TABLE bool1 (a boolean not null)
+
+statement ok
+INSERT INTO bool1 VALUES (true)
+
+statement ok
+CREATE TABLE bool2 AS SELECT * FROM bool1
+
+query B
+SELECT * FROM bool2
+----
+true


### PR DESCRIPTION
This is a partial cherry-pick from master, as we applied the same fix
there.

Fixes #17087.
Fixes #15827.

cc @cockroachdb/release 