### PR TITLE
scripts: use latest 16.04 image to create azworker

### DIFF
--- a/scripts/azworker.sh
+++ b/scripts/azworker.sh
@@ -41,7 +41,7 @@ case ${1-} in
         --name "${NAME}" \
         --location "${LOCATION}" \
         --os-type linux \
-        --image-urn canonical:UbuntuServer:16.04.0-LTS:latest \
+        --image-urn canonical:UbuntuServer:16.04-LTS:latest \
         --ssh-publickey-file ~/.ssh/id_rsa.pub \
         --admin-username "${USER}" \
         --vm-size "${MACHINE_SIZE}" \


### PR DESCRIPTION
No point in pinning to 16.04.0 when `build/bootstrap-debian.sh` does an `apt-get dist-upgrade`. Using the latest 16.04 image (16.04.02 at the time of this commit) makes the `dist-upgrade` essentially a noop, instead of the 5m it currently takes because 16.04.0 is so out of date.