### PR TITLE
sql: pass/return leased TableDescriptors by reference

### DIFF
--- a/pkg/sql/helpers_test.go
+++ b/pkg/sql/helpers_test.go
@@ -57,7 +57,7 @@ func NewLeaseRemovalTracker() *LeaseRemovalTracker {
 // TrackRemoval starts monitoring lease removals for a particular lease.
 // This should be called before triggering the operation that (asynchronously)
 // removes the lease.
-func (w *LeaseRemovalTracker) TrackRemoval(table sqlbase.TableDescriptor) RemovalTracker {
+func (w *LeaseRemovalTracker) TrackRemoval(table *sqlbase.TableDescriptor) RemovalTracker {
 	id := tableVersionID{
 		id:      table.ID,
 		version: table.Version,

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -110,8 +110,8 @@ func (t *leaseTest) expectLeases(descID sqlbase.ID, expected string) {
 
 func (t *leaseTest) acquire(
 	nodeID uint32, descID sqlbase.ID, version sqlbase.DescriptorVersion,
-) (sqlbase.TableDescriptor, hlc.Timestamp, error) {
-	var table sqlbase.TableDescriptor
+) (*sqlbase.TableDescriptor, hlc.Timestamp, error) {
+	var table *sqlbase.TableDescriptor
 	var expiration hlc.Timestamp
 	err := t.kvDB.Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
 		var err error
@@ -123,7 +123,7 @@ func (t *leaseTest) acquire(
 
 func (t *leaseTest) mustAcquire(
 	nodeID uint32, descID sqlbase.ID, version sqlbase.DescriptorVersion,
-) (sqlbase.TableDescriptor, hlc.Timestamp) {
+) (*sqlbase.TableDescriptor, hlc.Timestamp) {
 	table, expiration, err := t.acquire(nodeID, descID, version)
 	if err != nil {
 		t.Fatal(err)
@@ -131,7 +131,7 @@ func (t *leaseTest) mustAcquire(
 	return table, expiration
 }
 
-func (t *leaseTest) release(nodeID uint32, table sqlbase.TableDescriptor) error {
+func (t *leaseTest) release(nodeID uint32, table *sqlbase.TableDescriptor) error {
 	return t.node(nodeID).Release(table)
 }
 
@@ -140,7 +140,7 @@ func (t *leaseTest) release(nodeID uint32, table sqlbase.TableDescriptor) error 
 // store (i.e. it's not expired and it's not for an old descriptor version),
 // this shouldn't be set.
 func (t *leaseTest) mustRelease(
-	nodeID uint32, table sqlbase.TableDescriptor, leaseRemovalTracker *sql.LeaseRemovalTracker,
+	nodeID uint32, table *sqlbase.TableDescriptor, leaseRemovalTracker *sql.LeaseRemovalTracker,
 ) {
 	var tracker sql.RemovalTracker
 	if leaseRemovalTracker != nil {
@@ -560,8 +560,8 @@ func isDeleted(tableID sqlbase.ID, cfg config.SystemConfig) bool {
 
 func acquire(
 	ctx context.Context, s *server.TestServer, descID sqlbase.ID, version sqlbase.DescriptorVersion,
-) (sqlbase.TableDescriptor, hlc.Timestamp, error) {
-	var table sqlbase.TableDescriptor
+) (*sqlbase.TableDescriptor, hlc.Timestamp, error) {
+	var table *sqlbase.TableDescriptor
 	var expiration hlc.Timestamp
 	err := s.DB().Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
 		var err error


### PR DESCRIPTION
A TableDescriptor is 632 bytes. Passing/returning it by value is a
pessimization. Change TableCollection.getTableVersion to return a
pointer to the internal table descriptor. The callers of this function
are either the only users of the TableCollection or make a local copy of
the descriptor (e.g. scanNode). Reduces allocated bytes in simple
read-only queries by 5%.