### PR TITLE
sql/sqlbase: shrink RowFetcher and kvFetcher

### DIFF
--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -391,6 +391,7 @@ func TestCommonMethods(t *testing.T) {
 		{txnType, "Exec"}:                            {},
 		{txnType, "ResetDeadline"}:                   {},
 		{txnType, "Run"}:                             {},
+		{txnType, "Send"}:                            {},
 		{txnType, "SetDebugName"}:                    {},
 		{txnType, "SetFixedTimestamp"}:               {},
 		{txnType, "SetIsolation"}:                    {},

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -440,7 +440,7 @@ func (txn *Txn) Run(ctx context.Context, b *Batch) error {
 	if err := b.prepare(); err != nil {
 		return err
 	}
-	return sendAndFill(ctx, txn.send, b)
+	return sendAndFill(ctx, txn.Send, b)
 }
 
 func (txn *Txn) commit(ctx context.Context) error {
@@ -577,7 +577,7 @@ func (txn *Txn) sendEndTxnReq(
 ) *roachpb.Error {
 	var ba roachpb.BatchRequest
 	ba.Add(endTxnReq(commit, deadline, txn.systemConfigTrigger))
-	_, pErr := txn.send(ctx, ba)
+	_, pErr := txn.Send(ctx, ba)
 	return pErr
 }
 
@@ -793,13 +793,13 @@ func (txn *Txn) ensureProtoLocked() {
 	txn.mu.Proto = *newTxn
 }
 
-// send runs the specified calls synchronously in a single batch and
+// Send runs the specified calls synchronously in a single batch and
 // returns any errors. If the transaction is read-only or has already
 // been successfully committed or aborted, a potential trailing
 // EndTransaction call is silently dropped, allowing the caller to
 // always commit or clean-up explicitly even when that may not be
 // required (or even erroneous). Returns (nil, nil) for an empty batch.
-func (txn *Txn) send(
+func (txn *Txn) Send(
 	ctx context.Context, ba roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	// It doesn't make sense to use inconsistent reads in a transaction. However,

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -197,7 +197,7 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 	txn := NewTxn(db)
 
 	for testIdx = range testCases {
-		if _, pErr := txn.send(context.Background(), ba); pErr != nil {
+		if _, pErr := txn.Send(context.Background(), ba); pErr != nil {
 			t.Fatal(pErr)
 		}
 	}
@@ -729,7 +729,7 @@ func TestSetPriority(t *testing.T) {
 	if err := txn.SetUserPriority(expected); err != nil {
 		t.Fatal(err)
 	}
-	if _, pErr := txn.send(context.Background(), roachpb.BatchRequest{}); pErr != nil {
+	if _, pErr := txn.Send(context.Background(), roachpb.BatchRequest{}); pErr != nil {
 		t.Fatal(pErr)
 	}
 
@@ -737,7 +737,7 @@ func TestSetPriority(t *testing.T) {
 	expected = roachpb.UserPriority(-13)
 	txn = NewTxn(db)
 	txn.InternalSetPriority(13)
-	if _, pErr := txn.send(context.Background(), roachpb.BatchRequest{}); pErr != nil {
+	if _, pErr := txn.Send(context.Background(), roachpb.BatchRequest{}); pErr != nil {
 		t.Fatal(pErr)
 	}
 }


### PR DESCRIPTION
Shrink the size of kvFetcher from 1736 bytes to 128 bytes. Since kvFetcher
is the largest component of RowFetcher, this results in RowFetcher
shrinking from 2432 bytes to 824 bytes.

Switch from using a client.Batch in kvFetcher to directly sending a
BatchRequest. A client.Batch is somewhat heavy (1600 bytes) and the request
and response processing here is simple (consisting solely of Scan and
ReverseScan). Using a BatchRequest and processing the BatchResponse avoids
a number of allocations needed to adhere to the client.Batch interface.

In a read-only workload, this reduces allocated bytes by 16% and improves
throughput by 4%.

Lazily allocate RowFetcher.prettyValueBuf. It is rarely used but it takes
up 104 bytes. This shrinks RowFetcher from 824 bytes to 728 bytes.