### PR TITLE
storage: Update timestamp cache before updating a lease on a replica

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -436,9 +436,12 @@ func (r *Replica) computeChecksumPostApply(
 
 // leasePostApply is called when a RequestLease or TransferLease
 // request is executed for a range.
-func (r *Replica) leasePostApply(
-	ctx context.Context, newLease roachpb.Lease, replicaID roachpb.ReplicaID, prevLease roachpb.Lease,
-) {
+func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
+	r.mu.Lock()
+	replicaID := r.mu.replicaID
+	prevLease := *r.mu.state.Lease
+	r.mu.Unlock()
+
 	iAmTheLeaseHolder := newLease.Replica.ReplicaID == replicaID
 	leaseChangingHands := prevLease.Replica.StoreID != newLease.Replica.StoreID
 
@@ -478,14 +481,23 @@ func (r *Replica) leasePostApply(
 		if r.leaseholderStats != nil {
 			r.leaseholderStats.resetRequestCounts()
 		}
-
-		// Gossip the first range whenever its lease is acquired. We check to
-		// make sure the lease is active so that a trailing replica won't process
-		// an old lease request and attempt to gossip the first range.
-		if r.IsFirstRange() && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
-			r.gossipFirstRange(ctx)
-		}
 	}
+
+	// We're setting the new lease after we've updated the timestamp cache in
+	// order to avoid race conditions where a replica starts serving requests
+	// for a lease without first having taken into account requests served
+	// by the previous lease holder.
+	r.mu.Lock()
+	r.mu.state.Lease = &newLease
+	r.mu.Unlock()
+
+	// Gossip the first range whenever its lease is acquired. We check to
+	// make sure the lease is active so that a trailing replica won't process
+	// an old lease request and attempt to gossip the first range.
+	if leaseChangingHands && iAmTheLeaseHolder && r.IsFirstRange() && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
+		r.gossipFirstRange(ctx)
+	}
+
 	if leaseChangingHands && !iAmTheLeaseHolder {
 		// Also clear and disable the push transaction queue. Any waiters
 		// must be redirected to the new lease holder.
@@ -739,13 +751,7 @@ func (r *Replica) handleReplicatedEvalResult(
 	if newLease := rResult.State.Lease; newLease != nil {
 		rResult.State.Lease = nil // for assertion
 
-		r.mu.Lock()
-		replicaID := r.mu.replicaID
-		prevLease := *r.mu.state.Lease
-		r.mu.state.Lease = newLease
-		r.mu.Unlock()
-
-		r.leasePostApply(ctx, *newLease, replicaID, prevLease)
+		r.leasePostApply(ctx, *newLease)
 	}
 
 	if newTruncState := rResult.State.TruncatedState; newTruncState != nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1849,15 +1849,15 @@ func splitPostApply(
 	// Copy the minLeaseProposedTS from the LHS.
 	rightRng.mu.minLeaseProposedTS = r.mu.minLeaseProposedTS
 	rightLease := *rightRng.mu.state.Lease
-	rightReplicaID := rightRng.mu.replicaID
 	rightRng.mu.Unlock()
 	r.mu.Unlock()
 	log.Event(ctx, "copied timestamp cache")
 
 	// Invoke the leasePostApply method to ensure we properly initialize
 	// the replica according to whether it holds the lease. This enables
-	// the PushTxnQueue. Note that we pass in an empty lease for prevLease.
-	rightRng.leasePostApply(ctx, rightLease, rightReplicaID, roachpb.Lease{})
+	// the PushTxnQueue. Note that we pass in an right lease for prevLease so
+	// that we don't unnecessarily update the timestamp cache.
+	rightRng.leasePostApply(ctx, rightLease)
 
 	// Add the RHS replica to the store. This step atomically updates
 	// the EndKey of the LHS replica and also adds the RHS replica


### PR DESCRIPTION
- Before we would update the in-memory lease on a replica,
unlock it and then we would update the timestamp cache. This would
allow a replica to start processing requests for a lease without
first having taken into account reads served from the old lease
holder. We could see this by running:
make stress PKG=./pkg/sql/logictest
TESTS=TestParallel/subquery_retry_multinode STRESSFLAGS='-p 32'

This would fail because we would have duplicate values in a table
where inserts should have had monotonically increasing values.

- After this change the test passes. We also updated splitPostApply,
to send the current lease as the previous lease to leasePostApply to
prevent an update to the timestamp cache when a lease hasn't changed
hands.

Closes #16610