### PR TITLE
sql: do not close sortNode.valueIter

### DIFF
--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -423,9 +423,8 @@ func (n *sortNode) Close(ctx context.Context) {
 	if n.sortStrategy != nil {
 		n.sortStrategy.Close(ctx)
 	}
-	if n.valueIter != nil {
-		n.valueIter.Close(ctx)
-	}
+	// n.valueIter points to either n.plan or n.sortStrategy and thus has already
+	// been closed.
 }
 
 // valueIterator provides iterative access to a value source's values and


### PR DESCRIPTION
Do not close sortNode.valueIter as it points to either sortNode.plan or
sortNode.sortStrategy which have already been closed. This was causing
double closes of plan nodes and preventing pool allocation.

See #17099