### PR TITLE
sql,sql/sqlbase: plumb *DatumAlloc into RowFetcher

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -259,7 +259,8 @@ func convertRecord(
 		}
 	}
 
-	ri, err := sqlbase.MakeRowInserter(nil /* txn */, tableDesc, nil /* fkTables */, tableDesc.Columns, false /* checkFKs */)
+	ri, err := sqlbase.MakeRowInserter(nil /* txn */, tableDesc, nil, /* fkTables */
+		tableDesc.Columns, false /* checkFKs */, &sqlbase.DatumAlloc{})
 	if err != nil {
 		return errors.Wrap(err, "make row inserter")
 	}

--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -159,7 +159,8 @@ func Load(
 				Union: &sqlbase.Descriptor_Table{Table: tableDesc},
 			})
 
-			ri, err = sqlbase.MakeRowInserter(nil, tableDesc, nil, tableDesc.Columns, true)
+			ri, err = sqlbase.MakeRowInserter(nil, tableDesc, nil, tableDesc.Columns,
+				true, &sqlbase.DatumAlloc{})
 			if err != nil {
 				return BackupDescriptor{}, errors.Wrap(err, "make row inserter")
 			}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -258,6 +258,7 @@ func (sc *SchemaChanger) truncateIndexes(
 	if sc.testingKnobs.BackfillChunkSize > 0 {
 		chunkSize = sc.testingKnobs.BackfillChunkSize
 	}
+	alloc := &sqlbase.DatumAlloc{}
 	for _, desc := range dropped {
 		var resume roachpb.Span
 		lastCheckpoint := timeutil.Now()
@@ -294,11 +295,11 @@ func (sc *SchemaChanger) truncateIndexes(
 					return err
 				}
 
-				rd, err := sqlbase.MakeRowDeleter(txn, tableDesc, nil, nil, false)
+				rd, err := sqlbase.MakeRowDeleter(txn, tableDesc, nil, nil, false, alloc)
 				if err != nil {
 					return err
 				}
-				td := tableDeleter{rd: rd}
+				td := tableDeleter{rd: rd, alloc: alloc}
 				if err := td.init(txn); err != nil {
 					return err
 				}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -67,11 +67,12 @@ func (p *planner) Delete(
 	if err := p.fillFKTableMap(ctx, fkTables); err != nil {
 		return nil, err
 	}
-	rd, err := sqlbase.MakeRowDeleter(p.txn, en.tableDesc, fkTables, requestedCols, sqlbase.CheckFKs)
+	rd, err := sqlbase.MakeRowDeleter(p.txn, en.tableDesc, fkTables, requestedCols,
+		sqlbase.CheckFKs, &p.alloc)
 	if err != nil {
 		return nil, err
 	}
-	tw := tableDeleter{rd: rd, autoCommit: p.autoCommit}
+	tw := tableDeleter{rd: rd, autoCommit: p.autoCommit, alloc: &p.alloc}
 
 	// TODO(knz): Until we split the creation of the node from Start()
 	// for the SelectClause too, we cannot cache this. This is because

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -61,6 +61,7 @@ type backfiller struct {
 	output  RowReceiver
 	flowCtx *FlowCtx
 	fetcher sqlbase.RowFetcher
+	alloc   sqlbase.DatumAlloc
 }
 
 // Run is part of the processor interface.

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -127,7 +127,8 @@ func (cb *columnBackfiller) init() error {
 		colIdxMap[c.ID] = i
 	}
 	return cb.fetcher.Init(
-		&desc, colIdxMap, &desc.PrimaryIndex, false, false, desc.Columns, valNeededForCol, false,
+		&desc, colIdxMap, &desc.PrimaryIndex, false, false, desc.Columns,
+		valNeededForCol, false, &cb.alloc,
 	)
 }
 
@@ -168,7 +169,8 @@ func (cb *columnBackfiller) runChunk(
 		requestedCols = append(requestedCols, tableDesc.Columns...)
 		requestedCols = append(requestedCols, cb.added...)
 		ru, err := sqlbase.MakeRowUpdater(
-			txn, &tableDesc, fkTables, cb.updateCols, requestedCols, sqlbase.RowUpdaterOnlyColumns,
+			txn, &tableDesc, fkTables, cb.updateCols, requestedCols,
+			sqlbase.RowUpdaterOnlyColumns, &cb.alloc,
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -101,7 +101,8 @@ func (ib *indexBackfiller) init() error {
 	}
 
 	return ib.fetcher.Init(
-		&desc, ib.colIdxMap, &desc.PrimaryIndex, false, false, cols, valNeededForCol, false,
+		&desc, ib.colIdxMap, &desc.PrimaryIndex, false, false, cols,
+		valNeededForCol, false, &ib.alloc,
 	)
 }
 

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -40,6 +40,7 @@ type joinReader struct {
 	index *sqlbase.IndexDescriptor
 
 	fetcher sqlbase.RowFetcher
+	alloc   sqlbase.DatumAlloc
 
 	input RowSource
 	out   procOutputHelper
@@ -76,7 +77,8 @@ func newJoinReader(
 
 	var err error
 	jr.index, _, err = initRowFetcher(
-		&jr.fetcher, &jr.desc, int(spec.IndexIdx), false /* reverse */, jr.out.neededColumns(),
+		&jr.fetcher, &jr.desc, int(spec.IndexIdx), false, /* reverse */
+		jr.out.neededColumns(), &jr.alloc,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -132,7 +132,8 @@ func (p *planner) Insert(
 	if err := p.fillFKTableMap(ctx, fkTables); err != nil {
 		return nil, err
 	}
-	ri, err := sqlbase.MakeRowInserter(p.txn, en.tableDesc, fkTables, cols, sqlbase.CheckFKs)
+	ri, err := sqlbase.MakeRowInserter(p.txn, en.tableDesc, fkTables, cols,
+		sqlbase.CheckFKs, &p.alloc)
 	if err != nil {
 		return nil, err
 	}
@@ -154,6 +155,7 @@ func (p *planner) Insert(
 				ri:            ri,
 				autoCommit:    p.autoCommit,
 				conflictIndex: *conflictIndex,
+				alloc:         &p.alloc,
 			}
 		} else {
 			names, err := p.namesForExprs(updateExprs)
@@ -189,6 +191,7 @@ func (p *planner) Insert(
 			tw = &tableUpserter{
 				ri:            ri,
 				autoCommit:    p.autoCommit,
+				alloc:         &p.alloc,
 				fkTables:      fkTables,
 				updateCols:    updateCols,
 				conflictIndex: *conflictIndex,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -76,6 +76,11 @@ type planner struct {
 	subqueryPlanVisitor   subqueryPlanVisitor
 	nameResolutionVisitor nameResolutionVisitor
 	srfExtractionVisitor  srfExtractionVisitor
+
+	// Use a common datum allocator across all the plan nodes. This separates the
+	// plan lifetime from the lifetime of returned results allowing plan nodes to
+	// be pool allocated.
+	alloc sqlbase.DatumAlloc
 }
 
 var emptyPlanner planner

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -117,7 +117,7 @@ func (n *scanNode) disableBatchLimit() {
 
 func (n *scanNode) Start(context.Context) error {
 	return n.fetcher.Init(&n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex, n.cols,
-		n.valNeededForCol, false /* returnRangeInfo */)
+		n.valNeededForCol, false /* returnRangeInfo */, &n.p.alloc)
 }
 
 func (n *scanNode) Close(context.Context) {}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -270,7 +270,8 @@ func (p *planner) Update(
 	if err := p.fillFKTableMap(ctx, fkTables); err != nil {
 		return nil, err
 	}
-	ru, err := sqlbase.MakeRowUpdater(p.txn, en.tableDesc, fkTables, updateCols, requestedCols, sqlbase.RowUpdaterDefault)
+	ru, err := sqlbase.MakeRowUpdater(p.txn, en.tableDesc, fkTables, updateCols,
+		requestedCols, sqlbase.RowUpdaterDefault, &p.alloc)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Replace the embedded RowFetcher DatumAlloc with a *DatumAlloc that has
been passed to RowFetcher.Init. This allows sharing a single DatumAlloc
amongst disparate parts of a query plan. More importantly, it allows
separating the DatumAlloc lifetime from the lifetime of the query
plan. Add a planner.alloc (DatumAlloc) field that is shared amongst the
plan nodes created for a query.