### PR TITLE
sql: fix a use-after-close of a planNode

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1753,8 +1753,6 @@ func (e *Executor) execStmtInParallel(stmt Statement, planner *planner) (Result,
 	}
 
 	session.parallelizeQueue.Add(ctx, plan, func(plan planNode) error {
-		defer plan.Close(ctx)
-
 		result, err := makeRes(stmt, planner, plan)
 		if err != nil {
 			return err

--- a/pkg/sql/parallel_stmts.go
+++ b/pkg/sql/parallel_stmts.go
@@ -109,15 +109,16 @@ func (pq *ParallelizeQueue) Add(ctx context.Context, plan planNode, exec func(pl
 		err := exec(plan)
 
 		pq.mu.Lock()
-		defer pq.mu.Unlock()
-
 		if pq.err == nil {
 			// If we have not already seen an error since the last Wait, set the
 			// error state.
 			pq.err = err
 		}
-
 		finishLocked()
+		pq.mu.Unlock()
+
+		// Close the plan after removing it from the plans map and analyzer.
+		plan.Close(ctx)
 	}()
 }
 


### PR DESCRIPTION
Plans executed via ParallelizeQueue.Add were being used after being
closed because the close was happening before the plan was removed from
the internal plans map and analyzer. This use-after-close prevents pool
allocation of plan nodes.