### PR TITLE
sql: reuse TableCollection.tables between statements

### DIFF
--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -403,14 +403,14 @@ func (tc *TableCollection) getTableVersionByID(
 
 // releaseTables releases all tables currently held by the Session.
 func (tc *TableCollection) releaseTables(ctx context.Context) {
-	if tc.tables != nil {
+	if len(tc.tables) > 0 {
 		log.VEventf(ctx, 2, "releasing %d tables", len(tc.tables))
 		for i := range tc.tables {
 			if err := tc.leaseMgr.Release(&tc.tables[i]); err != nil {
 				log.Warning(ctx, err)
 			}
 		}
-		tc.tables = nil
+		tc.tables = tc.tables[:0]
 	}
 }
 


### PR DESCRIPTION
```
name                  old time/op    new time/op    delta
KV/Scan/SQL/rows=1-8     181µs ± 1%     181µs ± 1%    ~     (p=0.796 n=9+10)

name                  old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-8    21.1kB ± 0%    20.5kB ± 0%  -3.04%  (p=0.000 n=9+10)

name                  old allocs/op  new allocs/op  delta
KV/Scan/SQL/rows=1-8       283 ± 0%       282 ± 0%  -0.35%  (p=0.000 n=10+9)
```