### PR TITLE
sql/jobs: introduce per-server job registry

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -593,7 +593,7 @@ func backupPlanHook(
 		if err != nil {
 			return nil, err
 		}
-		job := jobs.NewJob(p.ExecCfg().DB, sql.InternalExecutor{LeaseManager: p.LeaseMgr()}, jobs.Record{
+		job := p.ExecCfg().JobRegistry.NewJob(jobs.Record{
 			Description: description,
 			Username:    p.User(),
 			Details:     jobs.BackupDetails{},

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -924,7 +924,7 @@ func restorePlanHook(
 		if err != nil {
 			return nil, err
 		}
-		job := jobs.NewJob(p.ExecCfg().DB, sql.InternalExecutor{LeaseManager: p.LeaseMgr()}, jobs.Record{
+		job := p.ExecCfg().JobRegistry.NewJob(jobs.Record{
 			Description: description,
 			Username:    p.User(),
 			Details:     jobs.RestoreDetails{},

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -229,6 +229,14 @@ func (ts *TestServer) Clock() *hlc.Clock {
 	return nil
 }
 
+// JobRegistry returns the *jobs.Registry as an interface{}.
+func (ts *TestServer) JobRegistry() interface{} {
+	if ts != nil {
+		return ts.jobRegistry
+	}
+	return nil
+}
+
 // RPCContext returns the rpc context used by the TestServer.
 func (ts *TestServer) RPCContext() *rpc.Context {
 	if ts != nil {

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -260,6 +261,7 @@ type ExecutorConfig struct {
 	StatusServer    serverpb.StatusServer
 	SessionRegistry *SessionRegistry
 	QueryRegistry   *QueryRegistry
+	JobRegistry     *jobs.Registry
 
 	TestingKnobs              *ExecutorTestingKnobs
 	SchemaChangerTestingKnobs *SchemaChangerTestingKnobs

--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -40,8 +39,11 @@ import (
 // the Job field after the job has been created will not be written to the
 // database, however, even when calling e.g. Started or Succeeded.
 type Job struct {
-	db     *client.DB
-	ex     sqlutil.InternalExecutor
+	// TODO(benesch): avoid giving Job a reference to Registry. This will likely
+	// require inverting control: rather than having the worker call Created,
+	// Started, etc., have Registry call a setupFn and a workFn as appropriate.
+	registry *Registry
+
 	id     *int64
 	Record Record
 	txn    *client.Txn
@@ -79,26 +81,8 @@ const (
 	StatusSucceeded Status = "succeeded"
 )
 
-// NewJob creates a new Job.
-func NewJob(db *client.DB, ex sqlutil.InternalExecutor, record Record) *Job {
-	return &Job{
-		db:     db,
-		ex:     ex,
-		Record: record,
-	}
-}
-
-// GetJob creates a new Job initialized from a previously created
-// job id.
-func GetJob(
-	ctx context.Context, db *client.DB, ex sqlutil.InternalExecutor, id int64,
-) (*Job, error) {
-	j := &Job{
-		db: db,
-		ex: ex,
-		id: &id,
-	}
-	if err := j.runInTxn(ctx, func(ctx context.Context, txn *client.Txn) error {
+func (j *Job) load(ctx context.Context) error {
+	return j.runInTxn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		payload, err := j.retrievePayload(ctx, txn)
 		if err != nil {
 			return err
@@ -120,10 +104,7 @@ func GetJob(
 		// Job so far.
 		j.mu.payload = *payload
 		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return j, nil
+	})
 }
 
 func (j *Job) runInTxn(
@@ -136,7 +117,7 @@ func (j *Job) runInTxn(
 				return retryable(ctx, txn)
 			})
 	}
-	return j.db.Txn(ctx, retryable)
+	return j.registry.db.Txn(ctx, retryable)
 }
 
 // WithTxn sets the transaction that this Job will use for its next operation.
@@ -288,7 +269,7 @@ func (j *Job) insert(ctx context.Context, payload *Payload) error {
 		}
 
 		const stmt = "INSERT INTO system.jobs (status, payload) VALUES ($1, $2) RETURNING id"
-		row, err = j.ex.QueryRowInTransaction(ctx, "job-insert", txn, stmt, StatusPending, payloadBytes)
+		row, err = j.registry.ex.QueryRowInTransaction(ctx, "job-insert", txn, stmt, StatusPending, payloadBytes)
 		return err
 	}); err != nil {
 		return err
@@ -301,7 +282,7 @@ func (j *Job) insert(ctx context.Context, payload *Payload) error {
 
 func (j *Job) retrievePayload(ctx context.Context, txn *client.Txn) (*Payload, error) {
 	const selectStmt = "SELECT payload FROM system.jobs WHERE id = $1"
-	row, err := j.ex.QueryRowInTransaction(ctx, "log-job", txn, selectStmt, *j.id)
+	row, err := j.registry.ex.QueryRowInTransaction(ctx, "log-job", txn, selectStmt, *j.id)
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +318,7 @@ func (j *Job) update(
 		}
 
 		const updateStmt = "UPDATE system.jobs SET status = $1, payload = $2 WHERE id = $3"
-		n, err := j.ex.ExecuteStatementInTransaction(
+		n, err := j.registry.ex.ExecuteStatementInTransaction(
 			ctx, "job-update", txn, updateStmt, newStatus, payloadBytes, *j.id)
 		if err != nil {
 			return err

--- a/pkg/sql/jobs/registry.go
+++ b/pkg/sql/jobs/registry.go
@@ -1,0 +1,56 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+package jobs
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+)
+
+// Registry creates Jobs, and will soon manage their leases and cancelation.
+type Registry struct {
+	db *client.DB
+	ex sqlutil.InternalExecutor
+}
+
+// MakeRegistry creates a new Registry.
+func MakeRegistry(db *client.DB, ex sqlutil.InternalExecutor) *Registry {
+	return &Registry{db: db, ex: ex}
+}
+
+// NewJob creates a new Job.
+func (r *Registry) NewJob(record Record) *Job {
+	return &Job{
+		Record:   record,
+		registry: r,
+	}
+}
+
+// LoadJob loads an existing job with the given jobID from the system.jobs
+// table.
+func (r *Registry) LoadJob(ctx context.Context, jobID int64) (*Job, error) {
+	j := &Job{
+		id:       &jobID,
+		registry: r,
+	}
+	if err := j.load(ctx); err != nil {
+		return nil, err
+	}
+	return j, nil
+}

--- a/pkg/sql/jobs/registry_test.go
+++ b/pkg/sql/jobs/registry_test.go
@@ -1,0 +1,59 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+package jobs_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/kr/pretty"
+)
+
+func TestRegistryRoundtripJob(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	registry := s.JobRegistry().(*jobs.Registry)
+	defer s.Stopper().Stop(ctx)
+
+	storedJob := registry.NewJob(jobs.Record{
+		Description:   "beep boop",
+		Username:      "robot",
+		DescriptorIDs: sqlbase.IDs{42},
+		Details:       jobs.RestoreDetails{},
+	})
+	if err := storedJob.Created(ctx); err != nil {
+		t.Fatal(err)
+	}
+	retrievedJob, err := registry.LoadJob(ctx, *storedJob.ID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e, a := storedJob, retrievedJob; !reflect.DeepEqual(e, a) {
+		diff := strings.Join(pretty.Diff(e, a), "\n")
+		t.Fatalf("stored job did not match retrieved job:\n%s", diff)
+	}
+}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -575,7 +575,7 @@ func (p *planner) createSchemaChangeJob(
 		DescriptorIDs: sqlbase.IDs{tableDesc.GetID()},
 		Details:       jobs.SchemaChangeDetails{},
 	}
-	job := jobs.NewJob(p.ExecCfg().DB, InternalExecutor{LeaseManager: p.session.tables.leaseMgr}, jobRecord)
+	job := p.ExecCfg().JobRegistry.NewJob(jobRecord)
 	if err := job.WithTxn(p.txn).Created(ctx); err != nil {
 		return sqlbase.InvalidMutationID, nil
 	}
@@ -589,10 +589,11 @@ func (p *planner) notifySchemaChange(
 	tableDesc *sqlbase.TableDescriptor, mutationID sqlbase.MutationID,
 ) {
 	sc := SchemaChanger{
-		tableID:    tableDesc.GetID(),
-		mutationID: mutationID,
-		nodeID:     p.evalCtx.NodeID,
-		leaseMgr:   p.LeaseMgr(),
+		tableID:     tableDesc.GetID(),
+		mutationID:  mutationID,
+		nodeID:      p.evalCtx.NodeID,
+		leaseMgr:    p.LeaseMgr(),
+		jobRegistry: p.ExecCfg().JobRegistry,
 	}
 	p.session.TxnState.schemaChangers.queueSchemaChanger(sc)
 }

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -83,6 +83,9 @@ type TestServerInterface interface {
 	// DistSQLServer returns the *distsqlrun.ServerImpl as an interface{}.
 	DistSQLServer() interface{}
 
+	// JobRegistry returns the *jobs.Registry as an interface{}.
+	JobRegistry() interface{}
+
 	// SetDistSQLSpanResolver changes the SpanResolver used for DistSQL inside the
 	// server's executor. The argument must be a distsqlplan.SpanResolver
 	// instance.


### PR DESCRIPTION
Introduce a `jobs.Registry` object that gets attached to a `server.Server`. At present, the registry only creates new jobs via `Registry.NewJob` and loads existing jobs via `Registry.LoadJob`, replacing the clunky`jobs.NewJob` and `jobs.GetJob` functions, which required passing a `sql.InternalExecutor` on every call.

Forthcoming commits will need `jobs.Registry` to manage job leases and cancelation.