### PR TITLE
sqlccl: benchmark scan of restored data vs original

### DIFF
--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -43,7 +43,8 @@ func init() {
 	storage.SetImportCmd(evalImport)
 }
 
-var importBatchSize = func() *settings.ByteSizeSetting {
+// ImportBatchSize is exposed for testing.
+var ImportBatchSize = func() *settings.ByteSizeSetting {
 	s := settings.RegisterByteSizeSetting("kv.import.batch_size", "", 2<<20)
 	s.Hide()
 	return s
@@ -331,7 +332,7 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 			return nil, errors.Wrapf(err, "adding to batch: %s -> %s", key, value.PrettyPrint())
 		}
 
-		if size := batcher.Size(); size > importBatchSize.Get() {
+		if size := batcher.Size(); size > ImportBatchSize.Get() {
 			finishBatcher := batcher
 			batcher = nil
 			log.Eventf(gCtx, "triggering finish of batch of size %s", humanizeutil.IBytes(size))


### PR DESCRIPTION
Due to the 2MB chunking of AddSSTable requests, RESTORE'd data ends up
with my small sstables RocksDB L6. This benchmark attempts to track what
if any impact that has by scanning two idential tables, one of which was
filled via INSERT and the other via RESTORE.

name                                     time/op
BenchmarkScanInsertVsRestore/INSERT-8    0.25ns ± 3%
BenchmarkScanInsertVsRestore/RESTORE-8   0.24ns ± 0%

@petermattis Do you think this is a reasonable way to do this comparison? Is there some better test I should be doing?