### PR TITLE
cherry-pick: storage: Update timestamp cache before updating a lease on a replica

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1827,16 +1827,16 @@ func splitPostApply(
 	rightRng.mu.Lock()
 	// Copy the minLeaseProposedTS from the LHS.
 	rightRng.mu.minLeaseProposedTS = r.mu.minLeaseProposedTS
-	rightLease := rightRng.mu.state.Lease
-	rightReplicaID := rightRng.mu.replicaID
+	rightLease := *rightRng.mu.state.Lease
 	rightRng.mu.Unlock()
 	r.mu.Unlock()
 	log.Event(ctx, "copied timestamp cache")
 
 	// Invoke the leasePostApply method to ensure we properly initialize
 	// the replica according to whether it holds the lease. This enables
-	// the PushTxnQueue. Note that we pass in an empty lease for prevLease.
-	rightRng.leasePostApply(ctx, rightLease, rightReplicaID, &roachpb.Lease{})
+	// the PushTxnQueue. Note that we pass in an right lease for prevLease so
+	// that we don't unnecessarily update the timestamp cache.
+	rightRng.leasePostApply(ctx, rightLease)
 
 	// Add the RHS replica to the store. This step atomically updates
 	// the EndKey of the LHS replica and also adds the RHS replica


### PR DESCRIPTION
- Before we would update the in-memory lease on a replica,
unlock it and then we would update the timestamp cache. This would
allow a replica to start processing requests for a lease without
first having taken into account reads served from the old lease
holder. We could see this by running:
make stress PKG=./pkg/sql/logictest
TESTS=TestParallel/subquery_retry_multinode STRESSFLAGS='-p 32'

This would fail because we would have duplicate values in a table
where inserts should have had monotonically increasing values.

- After this change the test passes. We also updated splitPostApply,
to send the current lease as the previous lease to leasePostApply to
prevent an update to the timestamp cache when a lease hasn't changed
hands.

cc @cockroachdb/release