### PR TITLE
cli/server: Use AdvertiseAddr instead of Addr where appropriate

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -624,7 +624,7 @@ func setupAndInitializeLoggingAndProfiling(startCtx context.Context) (*stop.Stop
 }
 
 func addrWithDefaultHost(addr string) (string, error) {
-	host, port, err := net.SplitHostPort(baseCfg.Addr)
+	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -910,7 +910,7 @@ func (s *Server) Start(ctx context.Context) error {
 	s.stopper.AddCloser(stop.CloserFn(gwCancel))
 
 	// Setup HTTP<->gRPC handlers.
-	conn, err := s.rpcContext.GRPCDial(s.cfg.Addr)
+	conn, err := s.rpcContext.GRPCDial(s.cfg.AdvertiseAddr)
 	if err != nil {
 		return errors.Errorf("error constructing grpc-gateway: %s; are your certificates valid?", err)
 	}


### PR DESCRIPTION
**cli: Fix internal client connections to use AdvertiseAddr, not Addr**

As far as I can tell, this wasn't actually breaking anything, since
getClientGRPCConn, the only caller of addrWithDefaultHost, isn't called
from within the start command, which is the only command where
AdvertiseAddr can differ from Addr.

Fixes #17143

**server: Use AdvertiseAddr instead of Addr HTTP<->gRPC connections**

Fixes #10374