### PR TITLE
sql: support ON CONFLICT ... RETURNING

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -159,7 +159,7 @@ func (d *deleteNode) Next(params runParams) (bool, error) {
 				return false, err
 			}
 			// We're done. Finish the batch.
-			err = d.tw.finalize(params.ctx, traceKV)
+			_, err = d.tw.finalize(params.ctx, traceKV)
 		}
 		return false, err
 	}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -57,12 +57,17 @@ type insertNode struct {
 	insertColIDtoRowIndex map[sqlbase.ColumnID]int
 	tw                    tableWriter
 
+	isUpsertReturning bool
+
 	run struct {
 		// The following fields are populated during Start().
 		editNodeRun
 
 		rowIdxToRetIdx []int
 		rowTemplate    parser.Datums
+
+		doneUpserting bool
+		rowsUpserted  *sqlbase.RowContainer
 	}
 }
 
@@ -82,16 +87,15 @@ func (p *planner) Insert(
 	if err != nil {
 		return nil, err
 	}
+	isUpsertReturning := false
 	if n.OnConflict != nil {
 		if !n.OnConflict.DoNothing {
 			if err := p.CheckPrivilege(en.tableDesc, privilege.UPDATE); err != nil {
 				return nil, err
 			}
 		}
-		// TODO(dan): Support RETURNING in UPSERTs.
 		if _, ok := n.Returning.(*parser.ReturningExprs); ok {
-			return nil, pgerror.UnimplementedWithIssueErrorf(6637,
-				"RETURNING is not supported with UPSERT")
+			isUpsertReturning = true
 		}
 	}
 
@@ -179,6 +183,7 @@ func (p *planner) Insert(
 				conflictIndex: *conflictIndex,
 				alloc:         &p.alloc,
 				mon:           &p.session.TxnState.mon,
+				collectRows:   isUpsertReturning,
 			}
 			tw = tu
 		} else {
@@ -218,6 +223,7 @@ func (p *planner) Insert(
 				autoCommit:    p.autoCommit,
 				alloc:         &p.alloc,
 				mon:           &p.session.TxnState.mon,
+				collectRows:   isUpsertReturning,
 				fkTables:      fkTables,
 				updateCols:    updateCols,
 				conflictIndex: *conflictIndex,
@@ -235,7 +241,8 @@ func (p *planner) Insert(
 		defaultExprs:          defaultExprs,
 		insertCols:            ri.InsertCols,
 		insertColIDtoRowIndex: ri.InsertColIDtoRowIndex,
-		tw: tw,
+		isUpsertReturning:     isUpsertReturning,
+		tw:                    tw,
 	}
 
 	if err := in.checkHelper.init(ctx, p, tn, en.tableDesc); err != nil {
@@ -252,6 +259,7 @@ func (p *planner) Insert(
 
 func (n *insertNode) Start(params runParams) error {
 	// Prepare structures for building values to pass to rh.
+	// TODO(couchand): Delete this, use tablewriter interface.
 	if n.rh.exprs != nil {
 		// In some cases (e.g. `INSERT INTO t (a) ...`) rowVals does not contain all the table
 		// columns. We need to pass values for all table columns to rh, in the correct order; we
@@ -282,8 +290,13 @@ func (n *insertNode) Start(params runParams) error {
 }
 
 func (n *insertNode) Close(ctx context.Context) {
-	n.run.rows.Close(ctx)
 	n.tw.close(ctx)
+	n.run.rows.Close(ctx)
+	n.run.rows = nil
+	if n.run.rowsUpserted != nil {
+		n.run.rowsUpserted.Close(ctx)
+		n.run.rowsUpserted = nil
+	}
 	switch t := n.tw.(type) {
 	case *tableInserter:
 		*t = tableInserter{}
@@ -297,13 +310,57 @@ func (n *insertNode) Close(ctx context.Context) {
 }
 
 func (n *insertNode) Next(params runParams) (bool, error) {
+	if n.isUpsertReturning {
+		return n.drain(params)
+	}
+
+	return n.internalNext(params)
+}
+
+// Because TableUpserter batches the upserts, we need to completely drain the
+// source and handle all the rows before returning from the first call to Next,
+// so that we can return an upserted row from each call to Values.
+func (n *insertNode) drain(params runParams) (bool, error) {
+	for !n.run.doneUpserting {
+		_, err := n.internalNext(params)
+		if err != nil {
+			return false, err
+		}
+	}
+	hasRows := n.run.rowsUpserted.Len() > 0
+	return hasRows, nil
+}
+
+func (n *insertNode) internalNext(params runParams) (bool, error) {
 	if next, err := n.run.rows.Next(params); !next {
 		if err == nil {
 			if err := params.p.cancelChecker.Check(); err != nil {
 				return false, err
 			}
 			// We're done. Finish the batch.
-			err = n.tw.finalize(params.ctx, params.p.session.Tracing.KVTracingEnabled())
+			rows, err := n.tw.finalize(params.ctx, params.p.session.Tracing.KVTracingEnabled())
+			if err != nil {
+				return false, err
+			}
+
+			if n.isUpsertReturning {
+				n.run.rowsUpserted = sqlbase.NewRowContainer(
+					params.p.session.TxnState.makeBoundAccount(),
+					sqlbase.ColTypeInfoFromResCols(n.rh.columns),
+					rows.Len(),
+				)
+				for i := 0; i < rows.Len(); i++ {
+					cooked, err := n.rh.cookResultRow(rows.At(i))
+					if err != nil {
+						return false, err
+					}
+					_, err = n.run.rowsUpserted.AddRow(params.ctx, cooked)
+					if err != nil {
+						return false, err
+					}
+				}
+				n.run.doneUpserting = true
+			}
 		}
 		return false, err
 	}
@@ -325,17 +382,20 @@ func (n *insertNode) Next(params runParams) (bool, error) {
 		return false, err
 	}
 
-	for i, val := range rowVals {
-		if n.run.rowTemplate != nil {
-			n.run.rowTemplate[n.run.rowIdxToRetIdx[i]] = val
+	// Handle regular INSERT ... RETURNING without ON CONFLICT clause
+	if !n.isUpsertReturning {
+		for i, val := range rowVals {
+			if n.run.rowTemplate != nil {
+				n.run.rowTemplate[n.run.rowIdxToRetIdx[i]] = val
+			}
 		}
-	}
 
-	resultRow, err := n.rh.cookResultRow(n.run.rowTemplate)
-	if err != nil {
-		return false, err
+		resultRow, err := n.rh.cookResultRow(n.run.rowTemplate)
+		if err != nil {
+			return false, err
+		}
+		n.run.resultRow = resultRow
 	}
-	n.run.resultRow = resultRow
 
 	return true, nil
 }
@@ -508,5 +568,11 @@ func fillDefaults(
 }
 
 func (n *insertNode) Values() parser.Datums {
-	return n.run.resultRow
+	if !n.isUpsertReturning {
+		return n.run.resultRow
+	}
+
+	row := n.run.rowsUpserted.At(0)
+	n.run.rowsUpserted.PopFirst()
+	return row
 }

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -40,10 +40,6 @@ INSERT INTO kv VALUES (2, 10) ON CONFLICT (k) DO UPDATE SET k = 3, v = 10
 statement error UPSERT/ON CONFLICT DO UPDATE command cannot affect row a second time
 UPSERT INTO kv VALUES (10, 10), (10, 11)
 
-# TODO(dan): Implement RETURNING with upsert
-statement error unimplemented: RETURNING is not supported with UPSERT \(see issue https://github.com/cockroachdb/cockroach/issues/6637\)
-UPSERT INTO kv VALUES (10, 10) RETURNING *
-
 statement ok
 INSERT INTO kv VALUES (9, 9) ON CONFLICT (k) DO UPDATE SET (k, v) = (excluded.k + 2, excluded.v + 3)
 
@@ -65,6 +61,11 @@ SELECT * FROM kv ORDER BY (k, v)
 11 12
 13 13
 
+query II
+INSERT INTO kv VALUES (10, 10), (11, 11) ON CONFLICT (k) DO UPDATE SET v = excluded.v RETURNING *
+----
+10 10
+11 11
 
 statement ok
 CREATE TABLE abc (
@@ -160,6 +161,72 @@ INSERT INTO excluded VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET b = excluded.b
 
 statement error ambiguous source name: "excluded"
 UPSERT INTO excluded VALUES (1, 1)
+
+# Tests for upsert/on conflict returning
+statement ok
+CREATE TABLE upsert_returning (a INT PRIMARY KEY, b INT, c INT, d INT DEFAULT -1)
+
+statement ok
+INSERT INTO upsert_returning VALUES (1, 1, NULL)
+
+# Handle INSERT ... ON CONFLICT ... RETURNING
+query IIII
+INSERT INTO upsert_returning (a, c) VALUES (1, 1), (2, 2) ON CONFLICT (a) DO UPDATE SET c = excluded.c RETURNING *
+----
+1 1 1 -1
+2 NULL 2 -1
+
+# Handle INSERT ... ON CONFLICT DO NOTHING ... RETURNING
+query IIII
+INSERT INTO upsert_returning (a, c) VALUES (1, 1), (3, 3) ON CONFLICT (a) DO NOTHING RETURNING *
+----
+3 NULL 3 -1
+
+# Handle UPSERT ... RETURNING
+query IIII
+UPSERT INTO upsert_returning (a, c) VALUES (1, 10), (3, 30) RETURNING *
+----
+1 1 10 -1
+3 NULL 30 -1
+
+# Ensure returned values are inserted values after conflict resolution
+query I
+SELECT b FROM upsert_returning WHERE a = 1
+----
+1
+
+query I
+INSERT INTO upsert_returning (a, b) VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET b = excluded.b + upsert_returning.b + 1 RETURNING b
+----
+3
+
+# Handle expressions within returning clause
+query I
+UPSERT INTO upsert_returning (a, b) VALUES (1, 2), (2, 3), (4, 3) RETURNING a+b+d
+----
+2
+4
+6
+
+# Handle upsert fast path with autocommit
+query IIII
+UPSERT INTO upsert_returning VALUES (1, 2, 3, 4), (5, 6, 7, 8) RETURNING *
+----
+1 2 3 4
+5 6 7 8
+
+# Handle upsert fast path without autocommit
+statement ok
+BEGIN
+
+query IIII
+upsert INTO upsert_returning VALUES (1, 5, 4, 3), (6, 5, 4, 3) RETURNING *
+----
+1 5 4 3
+6 5 4 3
+
+statement ok
+COMMIT
 
 # For #6710. Add an unused column to disable the fast path which doesn't have this bug.
 statement ok

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -421,7 +421,7 @@ func (u *updateNode) Next(params runParams) (bool, error) {
 				return false, err
 			}
 			// We're done. Finish the batch.
-			err = u.tw.finalize(params.ctx, params.p.session.Tracing.KVTracingEnabled())
+			_, err = u.tw.finalize(params.ctx, params.p.session.Tracing.KVTracingEnabled())
 		}
 		return false, err
 	}


### PR DESCRIPTION
This is a rough first pass at adding support for a `RETURNING` clause in `UPSERT` and `INSERT ... ON CONFLICT` statements.  Not ready to merge, putting this up for early feedback.  I'm playing fast and loose about allocations, but based on the surrounding code I have a feeling we'll want to be more thoughtful about them.  There are a number of TODOs, some of which should be taken care of here and some of which are just reminders of interface inconsistencies that could be cleaned up.

The general approach here is to have the upsert node run to completion, keeping the batch of all result rows, then doling them out one at a time on calls to `Values`.

I chatted with @knz about this and I agree with him that this approach leaves something to be desired: it would be much cleaner to get rid of the `returningHelper` and make edit nodes act properly as data sources, adding a render node after them if they have a `RETURNING` clause.  However, this change was much easier for me to wrap my head around, and if we want to get support for this feature in for 1.1 this might be the way to go as it does seem to be smaller.  In any case I'll go ahead with looking at refactoring away the returning helpers to get a sense for what that will take.

(closes #6637)

cc: @cockroachdb/sql-execution 