### PR TITLE
util: make migration_stub a cluster setting

### DIFF
--- a/pkg/util/migration_stub.go
+++ b/pkg/util/migration_stub.go
@@ -14,11 +14,26 @@
 
 package util
 
-import "github.com/cockroachdb/cockroach/pkg/util/envutil"
+import (
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+)
+
+var isMigratedSetting *settings.BoolSetting
+var isMigratedEnv = envutil.EnvOrDefaultBool("COCKROACH_MIGRATED", false)
+
+func init() {
+	isMigratedSetting = settings.RegisterBoolSetting(
+		"experimental.migrated",
+		"set to true to pretend the cluster migrated its minimum version to 1.1 (overridden by COCKROACH_MIGRATED env var).",
+		true,
+	)
+	isMigratedSetting.Hide()
+}
 
 // IsMigrated gives a crude way of landing changes that need a migration until
 // #16977 is implemented. When IsMigrated() returns false (the default),
 // mixed-cluster compatibility with 1.0 is required.
 func IsMigrated() bool {
-	return envutil.EnvOrDefaultBool("COCKROACH_MIGRATED", false)
+	return isMigratedSetting.Get() || isMigratedEnv
 }


### PR DESCRIPTION
This allows changing the setting during development, which allows for at least
rudimentary tests.

cc @irfansharif thought you might be able to use this. If not, no need to
merge.