### PR TITLE
sql, tests: change empty strings rendering in sqllogictest suite

### DIFF
--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -1287,6 +1287,10 @@ func (t *logicTest) execQuery(query logicQuery) error {
 						val = str
 					}
 				}
+				// Empty strings are rendered as "·" (middle dot)
+				if val == "" {
+					val = "·"
+				}
 				// We split string results on whitespace and append a separate result
 				// for each string. A bit unusual, but otherwise we can't match strings
 				// containing whitespace.

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -253,14 +253,14 @@ SELECT COUNT(*), s FROM kv GROUP BY UPPER(s)
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
-0  group                                       ("count(*)", "k + v")
-0          aggregate 0  count_rows()
-0          aggregate 1  test.kv.k + test.kv.v
-1  render                                      ("k + v")
-1          render 0     test.kv.k + test.kv.v
-2  scan                                        (k, v, w[omitted], s[omitted])
-2          table        kv@primary
-2          spans        ALL
+0  group   ·            ·                      ("count(*)", "k + v")           ·
+0  ·       aggregate 0  count_rows()           ·                               ·
+0  ·       aggregate 1  test.kv.k + test.kv.v  ·                               ·
+1  render  ·            ·                      ("k + v")                       ·
+1  ·       render 0     test.kv.k + test.kv.v  ·                               ·
+2  scan    ·            ·                      (k, v, w[omitted], s[omitted])  ·
+2  ·       table        kv@primary             ·                               ·
+2  ·       spans        ALL                    ·                               ·
 
 query II rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k+v
@@ -277,19 +277,19 @@ SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
-0  render                             ("count(*)", "k + v")
-0          render 0     "count(*)"
-0          render 1     k + v
-1  group                              ("count(*)", k, v)
-1          aggregate 0  count_rows()
-1          aggregate 1  test.kv.k
-1          aggregate 2  test.kv.v
-2  render                             (k, v)
-2          render 0     test.kv.k
-2          render 1     test.kv.v
-3  scan                               (k, v, w[omitted], s[omitted])
-3          table        kv@primary
-3          spans        ALL
+0  render  ·            ·             ("count(*)", "k + v")           ·
+0  ·       render 0     "count(*)"    ·                               ·
+0  ·       render 1     k + v         ·                               ·
+1  group   ·            ·             ("count(*)", k, v)              ·
+1  ·       aggregate 0  count_rows()  ·                               ·
+1  ·       aggregate 1  test.kv.k     ·                               ·
+1  ·       aggregate 2  test.kv.v     ·                               ·
+2  render  ·            ·             (k, v)                          ·
+2  ·       render 0     test.kv.k     ·                               ·
+2  ·       render 1     test.kv.v     ·                               ·
+3  scan    ·            ·             (k, v, w[omitted], s[omitted])  ·
+3  ·       table        kv@primary    ·                               ·
+3  ·       spans        ALL           ·                               ·
 
 query II rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k, v
@@ -532,26 +532,26 @@ SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
 query ITTT
 EXPLAIN (EXPRS) SELECT COUNT(k) FROM kv
 ----
-0  group
-0          aggregate 0  count(k)
-1  render
-1          render 0     k
-2  scan
-2          table        kv@primary
-2          spans        ALL
+0  group   ·            ·
+0  ·       aggregate 0  count(k)
+1  render  ·            ·
+1  ·       render 0     k
+2  scan    ·            ·
+2  ·       table        kv@primary
+2  ·       spans        ALL
 
 query ITTT
 EXPLAIN (EXPRS) SELECT COUNT(k), SUM(k), MAX(k) FROM kv
 ----
-0  group
-0          aggregate 0  count(k)
-0          aggregate 1  sum(k)
-0          aggregate 2  max(k)
-1  render
-1          render 0     k
-2  scan
-2          table        kv@primary
-2          spans        ALL
+0  group   ·            ·
+0  ·       aggregate 0  count(k)
+0  ·       aggregate 1  sum(k)
+0  ·       aggregate 2  max(k)
+1  render  ·            ·
+1  ·       render 0     k
+2  scan    ·            ·
+2  ·       table        kv@primary
+2  ·       spans        ALL
 
 statement ok
 CREATE TABLE abc (
@@ -567,14 +567,14 @@ INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::
 query ITTT
 EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
 ----
-0  group
-0          aggregate 0  min(a)
-1  render
-1          render 0     a
-2  scan
-2          table        abc@primary
-2          spans        /#-
-2          limit        1
+0  group   ·            ·
+0  ·       aggregate 0  min(a)
+1  render  ·            ·
+1  ·       render 0     a
+2  scan    ·            ·
+2  ·       table        abc@primary
+2  ·       spans        /#-
+2  ·       limit        1
 
 query TRBR
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
@@ -647,14 +647,14 @@ SELECT MIN(x) FROM xyz
 query ITTT
 EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz
 ----
-0  group
-0          aggregate 0  min(x)
-1  render
-1          render 0     x
-2  scan
-2          table        xyz@xy
-2          spans        /#-
-2          limit        1
+0  group   ·            ·
+0  ·       aggregate 0  min(x)
+1  render  ·            ·
+1  ·       render 0     x
+2  scan    ·            ·
+2  ·       table        xyz@xy
+2  ·       spans        /#-
+2  ·       limit        1
 
 query I
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
@@ -664,14 +664,14 @@ SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 query ITTT
 EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
-0  group
-0          aggregate 0  min(x)
-1  render
-1          render 0     x
-2  scan
-2          table        xyz@xy
-2          spans        /0-/1 /4-/5 /7-/8
-2          limit        1
+0  group   ·            ·
+0  ·       aggregate 0  min(x)
+1  render  ·            ·
+1  ·       render 0     x
+2  scan    ·            ·
+2  ·       table        xyz@xy
+2  ·       spans        /0-/1 /4-/5 /7-/8
+2  ·       limit        1
 
 query I
 SELECT MAX(x) FROM xyz
@@ -681,14 +681,14 @@ SELECT MAX(x) FROM xyz
 query ITTT
 EXPLAIN (EXPRS) SELECT MAX(x) FROM xyz
 ----
-0  group
-0           aggregate 0  max(x)
-1  render
-1           render 0     x
-2  revscan
-2           table        xyz@xy
-2           spans        /#-
-2           limit        1
+0  group    ·            ·
+0  ·        aggregate 0  max(x)
+1  render   ·            ·
+1  ·        render 0     x
+2  revscan  ·            ·
+2  ·        table        xyz@xy
+2  ·        spans        /#-
+2  ·        limit        1
 
 query I
 SELECT MIN(y) FROM xyz WHERE x = 1
@@ -698,14 +698,14 @@ SELECT MIN(y) FROM xyz WHERE x = 1
 query ITTT
 EXPLAIN (EXPRS) SELECT MIN(y) FROM xyz WHERE x = 1
 ----
-0  group
-0          aggregate 0  min(y)
-1  render
-1          render 0     y
-2  scan
-2          table        xyz@xy
-2          spans        /1/#-/2
-2          limit        1
+0  group   ·            ·
+0  ·       aggregate 0  min(y)
+1  render  ·            ·
+1  ·       render 0     y
+2  scan    ·            ·
+2  ·       table        xyz@xy
+2  ·       spans        /1/#-/2
+2  ·       limit        1
 
 query I
 SELECT MAX(y) FROM xyz WHERE x = 1
@@ -715,14 +715,14 @@ SELECT MAX(y) FROM xyz WHERE x = 1
 query ITTT
 EXPLAIN (EXPRS) SELECT MAX(y) FROM xyz WHERE x = 1
 ----
-0  group
-0           aggregate 0  max(y)
-1  render
-1           render 0     y
-2  revscan
-2           table        xyz@xy
-2           spans        /1/#-/2
-2           limit        1
+0  group    ·            ·
+0  ·        aggregate 0  max(y)
+1  render   ·            ·
+1  ·        render 0     y
+2  revscan  ·            ·
+2  ·        table        xyz@xy
+2  ·        spans        /1/#-/2
+2  ·        limit        1
 
 query I
 SELECT MIN(y) FROM xyz WHERE x = 7
@@ -732,14 +732,14 @@ NULL
 query ITTT
 EXPLAIN (EXPRS) SELECT MIN(y) FROM xyz WHERE x = 7
 ----
-0  group
-0          aggregate 0  min(y)
-1  render
-1          render 0     y
-2  scan
-2          table        xyz@xy
-2          spans        /7/#-/8
-2          limit        1
+0  group   ·            ·
+0  ·       aggregate 0  min(y)
+1  render  ·            ·
+1  ·       render 0     y
+2  scan    ·            ·
+2  ·       table        xyz@xy
+2  ·       spans        /7/#-/8
+2  ·       limit        1
 
 query I
 SELECT MAX(y) FROM xyz WHERE x = 7
@@ -749,14 +749,14 @@ NULL
 query ITTT
 EXPLAIN (EXPRS) SELECT MAX(y) FROM xyz WHERE x = 7
 ----
-0  group
-0           aggregate 0  max(y)
-1  render
-1           render 0     y
-2  revscan
-2           table        xyz@xy
-2           spans        /7/#-/8
-2           limit        1
+0  group    ·            ·
+0  ·        aggregate 0  max(y)
+1  render   ·            ·
+1  ·        render 0     y
+2  revscan  ·            ·
+2  ·        table        xyz@xy
+2  ·        spans        /7/#-/8
+2  ·        limit        1
 
 query I
 SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
@@ -766,14 +766,14 @@ SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 query ITTT
 EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
-0  group
-0          aggregate 0  min(x)
-1  render
-1          render 0     x
-2  scan
-2          table        xyz@zyx
-2          spans        /3/2/#-/3/3
-2          limit        1
+0  group   ·            ·
+0  ·       aggregate 0  min(x)
+1  render  ·            ·
+1  ·       render 0     x
+2  scan    ·            ·
+2  ·       table        xyz@zyx
+2  ·       spans        /3/2/#-/3/3
+2  ·       limit        1
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)]
@@ -790,14 +790,14 @@ SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 query ITTT
 EXPLAIN (EXPRS) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
-0  group
-0           aggregate 0  max(x)
-1  render
-1           render 0     x
-2  revscan
-2           table        xyz@zyx
-2           spans        /3/2/#-/3/3
-2           limit        1
+0  group    ·            ·
+0  ·        aggregate 0  max(x)
+1  render   ·            ·
+1  ·        render 0     x
+2  revscan  ·            ·
+2  ·        table        xyz@zyx
+2  ·        spans        /3/2/#-/3/3
+2  ·        limit        1
 
 query RRR
 SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz
@@ -831,13 +831,13 @@ NULL
 query ITTT
 EXPLAIN (EXPRS) SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
-0  group
-0          aggregate 0  variance(x)
-1  render
-1          render 0     x
-2  scan
-2          table        xyz@xy
-2          spans        /1-/2
+0  group   ·            ·
+0  ·       aggregate 0  variance(x)
+1  render  ·            ·
+1  ·       render 0     x
+2  scan    ·            ·
+2  ·       table        xyz@xy
+2  ·       spans        /1-/2
 
 query RRR
 SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
@@ -945,14 +945,14 @@ INSERT INTO ab VALUES
 query ITTT
 EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
 ----
-0  group
-0          aggregate 0  min(a)
-1  render
-1          render 0     a
-2  scan
-2          table        abc@primary
-2          spans        /#-
-2          limit        1
+0  group   ·            ·
+0  ·       aggregate 0  min(a)
+1  render  ·            ·
+1  ·       render 0     a
+2  scan    ·            ·
+2  ·       table        abc@primary
+2  ·       spans        /#-
+2  ·       limit        1
 
 # Verify we only buffer one row.
 query T
@@ -966,14 +966,14 @@ output row: [1]
 query ITTT
 EXPLAIN (EXPRS) SELECT MAX(a) FROM abc
 ----
-0  group
-0           aggregate 0  max(a)
-1  render
-1           render 0     a
-2  revscan
-2           table        abc@primary
-2           spans        /#-
-2           limit        1
+0  group    ·            ·
+0  ·        aggregate 0  max(a)
+1  render   ·            ·
+1  ·        render 0     a
+2  revscan  ·            ·
+2  ·        table        abc@primary
+2  ·        spans        /#-
+2  ·        limit        1
 
 # Verify we only buffer one row.
 query T
@@ -987,61 +987,61 @@ output row: [5]
 query ITTT
 EXPLAIN (EXPRS) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 ----
-0  sort
-0          order        +"count(k)"
-1  group
-1          aggregate 0  v
-1          aggregate 1  count(k)
-2  render
-2          render 0     v
-2          render 1     k
-3  scan
-3          table        kv@primary
-3          spans        ALL
+0  sort    ·            ·
+0  ·       order        +"count(k)"
+1  group   ·            ·
+1  ·       aggregate 0  v
+1  ·       aggregate 1  count(k)
+2  render  ·            ·
+2  ·       render 0     v
+2  ·       render 1     k
+3  scan    ·            ·
+3  ·       table        kv@primary
+3  ·       spans        ALL
 
 query ITTT
 EXPLAIN (EXPRS) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 ----
-0  sort
-0          order        +"count(*)"
-1  group
-1          aggregate 0  v
-1          aggregate 1  count_rows()
-2  render
-2          render 0     v
-3  scan
-3          table        kv@primary
-3          spans        ALL
+0  sort    ·            ·
+0  ·       order        +"count(*)"
+1  group   ·            ·
+1  ·       aggregate 0  v
+1  ·       aggregate 1  count_rows()
+2  render  ·            ·
+2  ·       render 0     v
+3  scan    ·            ·
+3  ·       table        kv@primary
+3  ·       spans        ALL
 
 query ITTT
 EXPLAIN (EXPRS) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
 ----
-0  sort
-0          order        +"count(1)"
-1  group
-1          aggregate 0  v
-1          aggregate 1  count(1)
-2  render
-2          render 0     v
-2          render 1     1
-3  scan
-3          table        kv@primary
-3          spans        ALL
+0  sort    ·            ·
+0  ·       order        +"count(1)"
+1  group   ·            ·
+1  ·       aggregate 0  v
+1  ·       aggregate 1  count(1)
+2  render  ·            ·
+2  ·       render 0     v
+2  ·       render 1     1
+3  scan    ·            ·
+3  ·       table        kv@primary
+3  ·       spans        ALL
 
 # Check that filters propagate through no-op aggregation.
 query ITTT
 EXPLAIN(EXPRS) SELECT * FROM (SELECT v, COUNT(1) FROM kv GROUP BY v) WHERE v > 10
 ----
-0  group
-0          aggregate 0  v
-0          aggregate 1  count(1)
-1  render
-1          render 0     v
-1          render 1     1
-2  scan
-2          table        kv@primary
-2          spans        ALL
-2          filter       v > 10
+0  group   ·            ·
+0  ·       aggregate 0  v
+0  ·       aggregate 1  count(1)
+1  render  ·            ·
+1  ·       render 0     v
+1  ·       render 1     1
+2  scan    ·            ·
+2  ·       table        kv@primary
+2  ·       spans        ALL
+2  ·       filter       v > 10
 
 # Verify that FILTER works.
 
@@ -1092,38 +1092,38 @@ SELECT v, COUNT(*) FILTER (WHERE COUNT(*) > 5) FROM filter_test GROUP BY v
 query ITTT
 EXPLAIN (EXPRS) SELECT COUNT(*) FILTER (WHERE k>5), MAX(k>5) FILTER(WHERE k>5) FROM filter_test GROUP BY v
 ----
-0  group
-0          aggregate 0  count_rows() FILTER (WHERE k > 5)
-0          aggregate 1  max(k > 5) FILTER (WHERE k > 5)
-1  render
-1          render 0     v
-1          render 1     k > 5
-2  scan
-2          table        filter_test@primary
-2          spans        ALL
+0  group   ·            ·
+0  ·       aggregate 0  count_rows() FILTER (WHERE k > 5)
+0  ·       aggregate 1  max(k > 5) FILTER (WHERE k > 5)
+1  render  ·            ·
+1  ·       render 0     v
+1  ·       render 1     k > 5
+2  scan    ·            ·
+2  ·       table        filter_test@primary
+2  ·       spans        ALL
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 ----
-0  group                                                                                ("count(*) FILTER (WHERE k > 5)" int)
-0          aggregate 0  (count_rows() FILTER (WHERE ((k)[int] > (5)[int])[bool]))[int]
-1  render                                                                               (v int, "k > 5" bool)
-1          render 0     (v)[int]
-1          render 1     ((k)[int] > (5)[int])[bool]
-2  scan                                                                                 (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)
-2          table        filter_test@primary
-2          spans        ALL
+0  group   ·            ·                                                               ("count(*) FILTER (WHERE k > 5)" int)                          ·
+0  ·       aggregate 0  (count_rows() FILTER (WHERE ((k)[int] > (5)[int])[bool]))[int]  ·                                                              ·
+1  render  ·            ·                                                               (v int, "k > 5" bool)                                          ·
+1  ·       render 0     (v)[int]                                                        ·                                                              ·
+1  ·       render 1     ((k)[int] > (5)[int])[bool]                                     ·                                                              ·
+2  scan    ·            ·                                                               (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)  ·
+2  ·       table        filter_test@primary                                             ·                                                              ·
+2  ·       spans        ALL                                                             ·                                                              ·
 
 # Tests with * inside GROUP BY.
 query ITTT
 EXPLAIN (EXPRS) SELECT 1 FROM kv GROUP BY kv.*;
 ----
-0  render
-0          render 0  1
-1  group
-2  scan
-2          table     kv@primary
-2          spans     ALL
+0  render  ·         ·
+0  ·       render 0  1
+1  group   ·         ·
+2  scan    ·         ·
+2  ·       table     kv@primary
+2  ·       spans     ALL
 
 query I
 SELECT 1 FROM kv GROUP BY kv.*;
@@ -1138,23 +1138,23 @@ SELECT 1 FROM kv GROUP BY kv.*;
 query ITTT
 EXPLAIN (EXPRS) SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
-0  group
-0          aggregate 0  sum(d)
-1  render
-1          render 0     k
-1          render 1     v
-1          render 2     w
-1          render 3     s
-1          render 4     d
-2  join
-2          type         inner
-2          pred         test.kv.k >= test.abc.d
-3  scan
-3          table        kv@primary
-3          spans        ALL
-3  scan
-3          table        abc@primary
-3          spans        ALL
+0  group   ·            ·
+0  ·       aggregate 0  sum(d)
+1  render  ·            ·
+1  ·       render 0     k
+1  ·       render 1     v
+1  ·       render 2     w
+1  ·       render 3     s
+1  ·       render 4     d
+2  join    ·            ·
+2  ·       type         inner
+2  ·       pred         test.kv.k >= test.abc.d
+3  scan    ·            ·
+3  ·       table        kv@primary
+3  ·       spans        ALL
+3  scan    ·            ·
+3  ·       table        abc@primary
+3  ·       spans        ALL
 
 query R rowsort
 SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
@@ -1176,14 +1176,14 @@ INSERT INTO opt_test VALUES (1, NULL), (2, 10), (3, NULL), (4, 5)
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
 ----
-0  group                                      ("min(v)")
-0          aggregate 0  min(test.opt_test.v)
-1  render                                     (v)              +v
-1          render 0     test.opt_test.v
-2  scan                                       (k[omitted], v)  +v
-2          table        opt_test@v
-2          spans        /#-
-2          limit        1
+0  group   ·            ·                     ("min(v)")       ·
+0  ·       aggregate 0  min(test.opt_test.v)  ·                ·
+1  render  ·            ·                     (v)              +v
+1  ·       render 0     test.opt_test.v       ·                ·
+2  scan    ·            ·                     (k[omitted], v)  +v
+2  ·       table        opt_test@v            ·                ·
+2  ·       spans        /#-                   ·                ·
+2  ·       limit        1                     ·                ·
 
 # Without the "v IS NOT NULL" constraint, this result would incorrectly be NULL.
 query I
@@ -1201,14 +1201,14 @@ SELECT MIN(v) FROM opt_test@primary
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
 ----
-0  group                                      ("min(v)")
-0          aggregate 0  min(test.opt_test.v)
-1  render                                     (v)         +v
-1          render 0     test.opt_test.v
-2  scan                                       (k, v)      +v
-2          table        opt_test@v
-2          spans        /#-
-2          filter       k != 4
+0  group   ·            ·                     ("min(v)")  ·
+0  ·       aggregate 0  min(test.opt_test.v)  ·           ·
+1  render  ·            ·                     (v)         +v
+1  ·       render 0     test.opt_test.v       ·           ·
+2  scan    ·            ·                     (k, v)      +v
+2  ·       table        opt_test@v            ·           ·
+2  ·       spans        /#-                   ·           ·
+2  ·       filter       k != 4                ·           ·
 
 query I
 SELECT MIN(v) FROM opt_test WHERE k <> 4
@@ -1221,24 +1221,24 @@ SELECT MIN(v) FROM opt_test WHERE k <> 4
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
 ----
-0  group                                                    ("min(v + 1)")
-0          aggregate 0  min(test.opt_test.v + 1)
-1  render                                                   ("v + 1")
-1          render 0     test.opt_test.v + 1
-2  scan                                                     (k, v)
-2          table        opt_test@primary
-2          spans        /#-
-2          filter       (k != 4) AND ((v + 1) IS NOT NULL)
+0  group   ·            ·                                   ("min(v + 1)")  ·
+0  ·       aggregate 0  min(test.opt_test.v + 1)            ·               ·
+1  render  ·            ·                                   ("v + 1")       ·
+1  ·       render 0     test.opt_test.v + 1                 ·               ·
+2  scan    ·            ·                                   (k, v)          ·
+2  ·       table        opt_test@primary                    ·               ·
+2  ·       spans        /#-                                 ·               ·
+2  ·       filter       (k != 4) AND ((v + 1) IS NOT NULL)  ·               ·
 
 # Verify that we don't use the optimization if there is a GROUP BY.
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
 ----
-0  group                                     ("min(v)")
-0         aggregate 0  min(test.opt_test.v)
-1  scan                                      (k, v)
-1         table        opt_test@primary
-1         spans        ALL
+0  group  ·            ·                     ("min(v)")  ·
+0  ·      aggregate 0  min(test.opt_test.v)  ·           ·
+1  scan   ·            ·                     (k, v)      ·
+1  ·      table        opt_test@primary      ·           ·
+1  ·      spans        ALL                   ·           ·
 
 query I rowsort
 SELECT MIN(v) FROM opt_test GROUP BY k

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -49,7 +49,7 @@ FROM crdb_internal.jobs
 ORDER BY created DESC
 LIMIT 1
 ----
-SCHEMA CHANGE  ALTER TABLE t ADD CONSTRAINT foo UNIQUE (b)  root  succeeded  1
+SCHEMA CHANGE  ALTER TABLE t ADD CONSTRAINT foo UNIQUE (b)  root  succeeded  1  ·
 
 statement error duplicate constraint name: "foo"
 ALTER TABLE t ADD CONSTRAINT foo UNIQUE (b)
@@ -87,7 +87,7 @@ FROM crdb_internal.jobs
 ORDER BY created DESC
 LIMIT 2
 ----
-SCHEMA CHANGE  ROLL BACK ALTER TABLE t ADD CONSTRAINT bar UNIQUE (c)  root  succeeded  1.00
+SCHEMA CHANGE  ROLL BACK ALTER TABLE t ADD CONSTRAINT bar UNIQUE (c)  root  succeeded  1.00  ·
 SCHEMA CHANGE  ALTER TABLE t ADD CONSTRAINT bar UNIQUE (c)            root  failed     0.10  duplicate key value (c)=(1) violates unique constraint "bar"
 
 query IIII colnames,rowsort
@@ -286,7 +286,7 @@ FROM crdb_internal.jobs
 ORDER BY created DESC
 LIMIT 1
 ----
-SCHEMA CHANGE  DROP INDEX t@t_f_idx  root  succeeded  1
+SCHEMA CHANGE  DROP INDEX t@t_f_idx  root  succeeded  1  ·
 
 statement ok
 ALTER TABLE t DROP COLUMN f
@@ -623,14 +623,14 @@ CREATE TABLE s (k1 INT, k2 INT, v INT, PRIMARY KEY (k1,k2))
 query ITTTTT colnames
 EXPLAIN (METADATA) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
 ----
-Level  Type    Field  Description  Columns        Ordering
-0      split                       (key, pretty)
-1      limit                       (k1, k2)              +k1
-2      render                      (k1, k2)              +k1
-3      scan                        (k1, k2, v[omitted])  +k1
-3              table  s@primary
-3              spans  ALL
-3              limit  3
+Level  Type    Field  Description  Columns               Ordering
+0      split   ·      ·            (key, pretty)         ·
+1      limit   ·      ·            (k1, k2)              +k1
+2      render  ·      ·            (k1, k2)              +k1
+3      scan    ·      ·            (k1, k2, v[omitted])  +k1
+3      ·       table  s@primary    ·                     ·
+3      ·       spans  ALL          ·                     ·
+3      ·       limit  3            ·                     ·
 
 # Verify that impure defaults are evaluated separately on each row
 # (#14352)

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -27,7 +27,7 @@ SELECT ARRAY['a,', 'b{', 'c}', 'd', 'e f']
 query TTTTTTT
 SELECT '', 'NULL', 'Null', 'null', NULL, '"', e'\''
 ----
-  NULL Null null NULL " '
+·  NULL  Null  null  NULL  "  '
 
 query T
 SELECT ARRAY['', 'NULL', 'Null', 'null', NULL, '"', e'\'']

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
@@ -74,10 +74,10 @@ CREATE INDEX ON t (b, a) STORING (c)
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -95,10 +95,10 @@ x  5
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@t_b_a_idx
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_b_a_idx
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -136,10 +136,10 @@ UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -157,10 +157,10 @@ AA  2
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@t_b_a_idx
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_b_a_idx
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -183,10 +183,10 @@ DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -202,10 +202,10 @@ AA  2
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@t_b_a_idx
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_b_a_idx
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
@@ -74,10 +74,10 @@ CREATE INDEX ON t (a, b) STORING (c)
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@t_a_b_idx
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_a_b_idx
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -95,10 +95,10 @@ x  5
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -136,10 +136,10 @@ UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@t_a_b_idx
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_a_b_idx
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -157,10 +157,10 @@ xx  5
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -183,10 +183,10 @@ DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@t_a_b_idx
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_a_b_idx
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -198,10 +198,10 @@ xx  5
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
@@ -31,10 +31,10 @@ CREATE UNIQUE INDEX ON t (b, a)
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -52,10 +52,10 @@ x  5
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@t_b_a_key
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_b_a_key
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -93,10 +93,10 @@ UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -114,10 +114,10 @@ AA  2
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@t_b_a_key
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_b_a_key
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -140,10 +140,10 @@ DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -159,10 +159,10 @@ AA  2
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@t_b_a_key
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_b_a_key
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
@@ -31,10 +31,10 @@ CREATE UNIQUE INDEX ON t (a, b)
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@t_a_b_key
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_a_b_key
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -52,10 +52,10 @@ x  5
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -93,10 +93,10 @@ UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@t_a_b_key
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_a_b_key
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -114,10 +114,10 @@ xx  5
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -140,10 +140,10 @@ DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render
-1  scan
-1          table  t@t_a_b_key
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@t_a_b_key
+1  ·       spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -155,10 +155,10 @@ xx  5
 query ITTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/deep_interleaving
+++ b/pkg/sql/logictest/testdata/logic_test/deep_interleaving
@@ -65,9 +65,9 @@ INSERT INTO level4 VALUES
 query ITTT
 EXPLAIN SELECT * FROM level4
 ----
-0  scan
-0        table  level4@primary
-0        spans  ALL
+0  scan  ·      ·
+0  ·     table  level4@primary
+0  ·     spans  ALL
 
 query III
 SELECT * FROM level4
@@ -103,9 +103,9 @@ SELECT * FROM level4
 query ITTT
 EXPLAIN SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 ----
-0  scan
-0        table  level4@primary
-0        spans  /2/#/52/1/#/53/1-/3
+0  scan  ·      ·
+0  ·     table  level4@primary
+0  ·     spans  /2/#/52/1/#/53/1-/3
 
 query III
 SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
@@ -123,9 +123,9 @@ SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 query ITTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 ----
-0  scan
-0        table  level4@primary
-0        spans  /2/#/52/1/#/53/1/11-/2/#/52/1/#/53/1/30
+0  scan  ·      ·
+0  ·     table  level4@primary
+0  ·     spans  /2/#/52/1/#/53/1/11-/2/#/52/1/#/53/1/30
 
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
@@ -137,9 +137,9 @@ SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 query ITTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
 ----
-0  scan
-0        table  level4@primary
-0        spans  /2/#/52/1/#/53/1/20/101/#/54/1-/2/#/52/1/#/53/1/20/300
+0  scan  ·      ·
+0  ·     table  level4@primary
+0  ·     spans  /2/#/52/1/#/53/1/20/101/#/54/1-/2/#/52/1/#/53/1/20/300
 
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
@@ -149,9 +149,9 @@ SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
 query ITTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
 ----
-0  scan
-0        table  level4@primary
-0        spans  /2/#/52/1/#/53/1/20/200/#/54/1-/2/#/52/1/#/53/1/20/201
+0  scan  ·      ·
+0  ·     table  level4@primary
+0  ·     spans  /2/#/52/1/#/53/1/20/200/#/54/1-/2/#/52/1/#/53/1/20/201
 
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -144,12 +144,12 @@ query ITTT colnames
 EXPLAIN DELETE FROM unindexed
 ----
 Level  Type    Field  Description
-0      delete
-0              from   unindexed
-1      render
-2      scan
-2              table  unindexed@primary
-2              spans  ALL
+0      delete  ·      ·
+0      ·       from   unindexed
+1      render  ·      ·
+2      scan    ·      ·
+2      ·       table  unindexed@primary
+2      ·       spans  ALL
 
 query II colnames,rowsort
 SELECT k, v FROM unindexed

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -44,11 +44,11 @@ SELECT y FROM (SELECT DISTINCT y, z FROM xyz)
 query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz
 ----
-0  distinct
-1  render
-2  scan
-2            table  xyz@primary
-2            spans  ALL
+0  distinct  ·      ·
+1  render    ·      ·
+2  scan      ·      ·
+2  ·         table  xyz@primary
+2  ·         spans  ALL
 
 query II partialsort(2)
 SELECT DISTINCT y, z FROM xyz ORDER BY z
@@ -62,12 +62,12 @@ SELECT DISTINCT y, z FROM xyz ORDER BY z
 query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
-0  distinct
-0            key    y, z
-1  render
-2  scan
-2            table  xyz@foo
-2            spans  ALL
+0  distinct  ·      ·
+0  ·         key    y, z
+1  render    ·      ·
+2  scan      ·      ·
+2  ·         table  xyz@foo
+2  ·         spans  ALL
 
 query II partialsort(1)
 SELECT DISTINCT y, z FROM xyz ORDER BY y
@@ -81,14 +81,14 @@ SELECT DISTINCT y, z FROM xyz ORDER BY y
 query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
 ----
-0  distinct
-0            key    y
-1  sort
-1            order  +y
-2  render
-3  scan
-3            table  xyz@foo
-3            spans  ALL
+0  distinct  ·      ·
+0  ·         key    y
+1  sort      ·      ·
+1  ·         order  +y
+2  render    ·      ·
+3  scan      ·      ·
+3  ·         table  xyz@foo
+3  ·         spans  ALL
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY y, z
@@ -102,14 +102,14 @@ SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 query ITTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 ----
-0  distinct
-0            key    y, z
-1  sort
-1            order  +y,+z
-2  render
-3  scan
-3            table  xyz@foo
-3            spans  ALL
+0  distinct  ·      ·
+0  ·         key    y, z
+1  sort      ·      ·
+1  ·         order  +y,+z
+2  render    ·      ·
+3  scan      ·      ·
+3  ·         table  xyz@foo
+3  ·         spans  ALL
 
 query I
 SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
@@ -121,14 +121,14 @@ SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
 query ITTT
 EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 ----
-0  distinct
-0            key    y + z
-1  sort
-1            order  +"y + z"
-2  render
-3  scan
-3            table  xyz@primary
-3            spans  ALL
+0  distinct  ·      ·
+0  ·         key    y + z
+1  sort      ·      ·
+1  ·         order  +"y + z"
+2  render    ·      ·
+3  scan      ·      ·
+3  ·         table  xyz@primary
+3  ·         spans  ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by z
@@ -140,13 +140,13 @@ SELECT DISTINCT y AS w FROM xyz ORDER by z
 query ITTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY z
 ----
-0  distinct
-1  nosort
-1            order  +z
-2  render
-3  scan
-3            table  xyz@foo
-3            spans  ALL
+0  distinct  ·      ·
+1  nosort    ·      ·
+1  ·         order  +z
+2  render    ·      ·
+3  scan      ·      ·
+3  ·         table  xyz@foo
+3  ·         spans  ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by y
@@ -158,14 +158,14 @@ SELECT DISTINCT y AS w FROM xyz ORDER by y
 query ITTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 ----
-0  distinct
-0            key    w
-1  sort
-1            order  +w
-2  render
-3  scan
-3            table  xyz@foo
-3            spans  ALL
+0  distinct  ·      ·
+0  ·         key    w
+1  sort      ·      ·
+1  ·         order  +w
+2  render    ·      ·
+3  scan      ·      ·
+3  ·         table  xyz@foo
+3  ·         spans  ALL
 
 # Insert NULL values for z.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -3,23 +3,23 @@
 query ITTT colnames
 EXPLAIN (PLAN) SELECT 1
 ----
-Level  Type    Field Description
-0      render
-1      nullrow
+Level  Type     Field  Description
+0      render   ·      ·
+1      nullrow  ·      ·
 
 query ITTTTT colnames
 EXPLAIN (PLAN,METADATA) SELECT 1
 ----
 Level  Type     Field  Description  Columns  Ordering
-0      render                       ("1")    ="1"
-1      nullrow                      ()
+0      render   ·      ·            ("1")    ="1"
+1      nullrow  ·      ·            ()       ·
 
 query ITTTTT colnames
 EXPLAIN (METADATA,PLAN) SELECT 1
 ----
 Level  Type     Field  Description  Columns  Ordering
-0      render                       ("1")    ="1"
-1      nullrow                      ()
+0      render   ·      ·            ("1")    ="1"
+1      nullrow  ·      ·            ()       ·
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT 1]
@@ -31,9 +31,9 @@ query ITTTTT colnames
 EXPLAIN (TYPES) SELECT 1
 ----
 Level  Type     Field     Description  Columns    Ordering
-0      render                          ("1" int)  ="1"
-0               render 0  (1)[int]
-1      nullrow                         ()
+0      render   ·         ·            ("1" int)  ="1"
+0      ·        render 0  (1)[int]     ·          ·
+1      nullrow  ·         ·            ()         ·
 
 statement error cannot set EXPLAIN mode more than once
 EXPLAIN (PLAN,PLAN) SELECT 1
@@ -48,26 +48,26 @@ EXPLAIN (PLAN,UNKNOWN) SELECT 1
 query ITTTTT
 EXPLAIN (METADATA) SHOW TRACE FOR SELECT 1
 ----
-0  sort                                 ("timestamp", age, message, context, operation, span)                             +"timestamp"
-0                  order  +"timestamp"
-1  window                               ("timestamp", age, message, context, operation, span)
-2  render                               ("timestamp", """timestamp""", message, context, operation, span)
-3  window                               ("timestamp", message, context, operation, span)
-4  render                               ("timestamp", message, context, operation, span, txn_idx, span_idx, message_idx)
-5  show trace for                       (txn_idx, span_idx, message_idx, "timestamp", duration, operation, message)
-6  render                               ("1")                                                                             ="1"
-7  nullrow                              ()
+0  sort            ·      ·             ("timestamp", age, message, context, operation, span)                             +"timestamp"
+0  ·               order  +"timestamp"  ·                                                                                 ·
+1  window          ·      ·             ("timestamp", age, message, context, operation, span)                             ·
+2  render          ·      ·             ("timestamp", """timestamp""", message, context, operation, span)                 ·
+3  window          ·      ·             ("timestamp", message, context, operation, span)                                  ·
+4  render          ·      ·             ("timestamp", message, context, operation, span, txn_idx, span_idx, message_idx)  ·
+5  show trace for  ·      ·             (txn_idx, span_idx, message_idx, "timestamp", duration, operation, message)       ·
+6  render          ·      ·             ("1")                                                                             ="1"
+7  nullrow         ·      ·             ()                                                                                ·
 
 # Ensure that all relevant statement types can be explained
 query ITTT
 EXPLAIN CREATE DATABASE foo
 ----
-0 create database
+0  create database  ·  ·
 
 query ITTT
 EXPLAIN CREATE TABLE foo (x INT)
 ----
-0 create table
+0  create table  ·  ·
 
 statement ok
 CREATE TABLE foo (x INT)
@@ -75,7 +75,7 @@ CREATE TABLE foo (x INT)
 query ITTT
 EXPLAIN CREATE INDEX a ON foo(x)
 ----
-0 create index
+0  create index  ·  ·
 
 statement ok
 CREATE DATABASE foo
@@ -83,15 +83,15 @@ CREATE DATABASE foo
 query ITTT
 EXPLAIN DROP DATABASE foo
 ----
-0 drop database
+0  drop database  ·  ·
 
 # explain SHOW JOBS - beware to test this before the CREATE INDEX
 # below, otherwise the result becomes non-deterministic.
 query ITTT
 EXPLAIN SHOW JOBS
 ----
-0  values
-0          size  12 columns, 0 rows
+0  values  ·     ·
+0  ·       size  12 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)
@@ -99,135 +99,135 @@ CREATE INDEX a ON foo(x)
 query ITTT
 EXPLAIN DROP INDEX foo@a
 ----
-0 drop index
+0  drop index  ·  ·
 
 query ITTT
 EXPLAIN ALTER TABLE foo ADD COLUMN y INT
 ----
-0 alter table
+0  alter table  ·  ·
 
 query ITTT
 EXPLAIN (EXPRS) ALTER TABLE foo SPLIT AT VALUES (42)
 ----
-0  split
-1  values
-1          size           1 column, 1 row
-1          row 0, expr 0  42
+0  split   ·              ·
+1  values  ·              ·
+1  ·       size           1 column, 1 row
+1  ·       row 0, expr 0  42
 
 query ITTT
 EXPLAIN DROP TABLE foo
 ----
-0 drop table
+0  drop table  ·  ·
 
 query ITTT
 EXPLAIN SHOW DATABASES
 ----
-0  sort
-0          order  +"Database"
-1  render
-2  values
-2          size   4 columns, 6 rows
+0  sort    ·      ·
+0  ·       order  +"Database"
+1  render  ·      ·
+2  values  ·      ·
+2  ·       size   4 columns, 6 rows
 
 query ITTT
 EXPLAIN SHOW TABLES
 ----
-0  sort
-0          order  +"Table"
-1  render
-2  filter
-3  values
-3          size   5 columns, 60 rows
+0  sort    ·      ·
+0  ·       order  +"Table"
+1  render  ·      ·
+2  filter  ·      ·
+3  values  ·      ·
+3  ·       size   5 columns, 60 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
 ----
-0  render
-1  filter
-2  values
-2          size  2 columns, 19 rows
+0  render  ·     ·
+1  filter  ·     ·
+2  values  ·     ·
+2  ·       size  2 columns, 19 rows
 
 query ITTT
 EXPLAIN SHOW TIME ZONE
 ----
-0  render
-1  filter
-2  values
-2          size  2 columns, 19 rows
+0  render  ·     ·
+1  filter  ·     ·
+2  values  ·     ·
+2  ·       size  2 columns, 19 rows
 
 query ITTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
-0  render
-1  filter
-2  values
-2          size  2 columns, 19 rows
+0  render  ·     ·
+1  filter  ·     ·
+2  values  ·     ·
+2  ·       size  2 columns, 19 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 ----
-0  render
-1  filter
-2  values
-2          size  2 columns, 19 rows
+0  render  ·     ·
+1  filter  ·     ·
+2  values  ·     ·
+2  ·       size  2 columns, 19 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION PRIORITY
 ----
-0  render
-1  filter
-2  values
-2          size  2 columns, 19 rows
+0  render  ·     ·
+1  filter  ·     ·
+2  values  ·     ·
+2  ·       size  2 columns, 19 rows
 
 query ITTT
 EXPLAIN SHOW COLUMNS FROM foo
 ----
-0  sort
-0          order     +ordinal_position
-1  render
-2  group
-3  render
-4  join
-4          type      left outer
-4          equality  (column_name) = (column_name)
-5  render
-6  filter
-7  values
-7          size      13 columns, 508 rows
-5  render
-6  filter
-7  values
-7          size      13 columns, 22 rows
+0  sort    ·         ·
+0  ·       order     +ordinal_position
+1  render  ·         ·
+2  group   ·         ·
+3  render  ·         ·
+4  join    ·         ·
+4  ·       type      left outer
+4  ·       equality  (column_name) = (column_name)
+5  render  ·         ·
+6  filter  ·         ·
+7  values  ·         ·
+7  ·       size      13 columns, 508 rows
+5  render  ·         ·
+6  filter  ·         ·
+7  values  ·         ·
+7  ·       size      13 columns, 22 rows
 
 query ITTT
 EXPLAIN SHOW GRANTS ON foo
 ----
-0  sort
-0          order  +"Table",+"User",+"Privileges"
-1  render
-2  filter
-3  values
-3          size   8 columns, 45 rows
+0  sort    ·      ·
+0  ·       order  +"Table",+"User",+"Privileges"
+1  render  ·      ·
+2  filter  ·      ·
+3  values  ·      ·
+3  ·       size   8 columns, 45 rows
 
 query ITTT
 EXPLAIN SHOW INDEX FROM foo
 ----
-0  render
-1  filter
-2  values
-2          size  13 columns, 22 rows
+0  render  ·     ·
+1  filter  ·     ·
+2  values  ·     ·
+2  ·       size  13 columns, 22 rows
 
 query ITTT
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
-0  sort
-0          order  +"Table",+"Name"
-1  values
-1          size   5 columns, 0 rows
+0  sort    ·      ·
+0  ·       order  +"Table",+"Name"
+1  values  ·      ·
+1  ·       size   5 columns, 0 rows
 
 query ITTT
 EXPLAIN SHOW USERS
 ----
-0  render
-1  scan
-1        table  users@primary
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  users@primary
+1  ·       spans  ALL

--- a/pkg/sql/logictest/testdata/logic_test/explain_plan
+++ b/pkg/sql/logictest/testdata/logic_test/explain_plan
@@ -9,10 +9,10 @@ CREATE TABLE t (
 query ITTT
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
-0  insert
-0          into  t(k, v)
-1  values
-1          size  2 columns, 1 row
+0  insert  ·     ·
+0  ·       into  t(k, v)
+1  values  ·     ·
+1  ·       size  2 columns, 1 row
 
 query I
 SELECT MAX("Level") FROM [EXPLAIN INSERT INTO t VALUES (1, 2)]
@@ -25,76 +25,76 @@ INSERT INTO t VALUES (1, 2)
 query ITTT
 EXPLAIN SELECT * FROM t
 ----
-0  scan
-0        table  t@primary
-0        spans  ALL
+0  scan  ·      ·
+0  ·     table  t@primary
+0  ·     spans  ALL
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM t
 ----
-0  scan                      (k, v)
-0          table  t@primary
-0          spans  ALL
+0  scan  ·      ·          (k, v)  ·
+0  ·     table  t@primary  ·       ·
+0  ·     spans  ALL        ·       ·
 
 query ITTT
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
-0  scan
-0        table  t@primary
-0        spans  /1-/2 /3-/4
+0  scan  ·      ·
+0  ·     table  t@primary
+0  ·     spans  /1-/2 /3-/4
 
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----
-0  scan                                  (k, v)
-0                 table     t@primary
-0                 spans     ALL
-0                 filter    (k % 2) = 0
+0  scan  ·       ·            (k, v)  ·
+0  ·     table   t@primary    ·       ·
+0  ·     spans   ALL          ·       ·
+0  ·     filter  (k % 2) = 0  ·       ·
 
 query ITTT
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
-0  values
-0          size  3 columns, 2 rows
+0  values  ·     ·
+0  ·       size  3 columns, 2 rows
 
 query ITTT
 EXPLAIN VALUES (1)
 ----
-0  values
-0          size  1 column, 1 row
+0  values  ·     ·
+0  ·       size  1 column, 1 row
 
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
 ----
-0  limit
-0                 count     1
-0                 offset    1
-1  ordinality
-2  scan
-2                 table     t@primary
-2                 spans     ALL
-2                 limit     2
+0  limit       ·       ·
+0  ·           count   1
+0  ·           offset  1
+1  ordinality  ·       ·
+2  scan        ·       ·
+2  ·           table   t@primary
+2  ·           spans   ALL
+2  ·           limit   2
 
 query ITTT
 EXPLAIN SELECT DISTINCT * FROM t
 ----
-0  distinct
-0            key    k
-1  scan
-1            table  t@primary
-1            spans  ALL
+0  distinct  ·      ·
+0  ·         key    k
+1  scan      ·      ·
+1  ·         table  t@primary
+1  ·         spans  ALL
 
 query ITTT
 EXPLAIN (EXPRS) SELECT DISTINCT * FROM t LIMIT 1 OFFSET 1
 ----
-0  limit
-0                 count     1
-0                 offset    1
-1  distinct
-1                 key       k
-2  scan
-2                 table     t@primary
-2                 spans     ALL
+0  limit     ·       ·
+0  ·         count   1
+0  ·         offset  1
+1  distinct  ·       ·
+1  ·         key     k
+2  scan      ·       ·
+2  ·         table   t@primary
+2  ·         spans   ALL
 
 # Ensure EXPLAIN EXECUTE works properly
 
@@ -104,13 +104,13 @@ PREPARE x AS SELECT DISTINCT * from t LIMIT $1
 query ITTT
 EXPLAIN (EXPRS) EXECUTE x(3)
 ----
-0  limit
-0                 count     3
-1  distinct
-1                 key       k
-2  scan
-2                 table     t@primary
-2                 spans     ALL
+0  limit     ·      ·
+0  ·         count  3
+1  distinct  ·      ·
+1  ·         key    k
+2  scan      ·      ·
+2  ·         table  t@primary
+2  ·         spans  ALL
 
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))
@@ -118,12 +118,12 @@ CREATE TABLE tc (a INT, b INT, INDEX c(a))
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-0  sort                           (a, b)                                   =a,+b
-0              order  +b
-1  render                         (a, b)                                   =a
-2  index-join                     (a, b, rowid[hidden,omitted])            =a
-3  scan                           (a[omitted], b[omitted], rowid[hidden])  =a
-3              table  tc@c
-3              spans  /10-/11
-3  scan                           (a, b, rowid[hidden,omitted])
-3              table  tc@primary
+0  sort        ·      ·           (a, b)                                   =a,+b
+0  ·           order  +b          ·                                        ·
+1  render      ·      ·           (a, b)                                   =a
+2  index-join  ·      ·           (a, b, rowid[hidden,omitted])            =a
+3  scan        ·      ·           (a[omitted], b[omitted], rowid[hidden])  =a
+3  ·           table  tc@c        ·                                        ·
+3  ·           spans  /10-/11     ·                                        ·
+3  scan        ·      ·           (a, b, rowid[hidden,omitted])            ·
+3  ·           table  tc@primary  ·                                        ·

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -10,12 +10,12 @@ query ITTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
 Level  Type    Field          Description       Columns                     Ordering
-0      insert                                   ()
-0              into           t(k, v)
-1      values                                   (column1 int, column2 int)
-1              size           2 columns, 1 row
-1              row 0, expr 0  (1)[int]
-1              row 0, expr 1  (2)[int]
+0      insert  ·              ·                 ()                          ·
+0      ·       into           t(k, v)           ·                           ·
+1      values  ·              ·                 (column1 int, column2 int)  ·
+1      ·       size           2 columns, 1 row  ·                           ·
+1      ·       row 0, expr 0  (1)[int]          ·                           ·
+1      ·       row 0, expr 1  (2)[int]          ·                           ·
 
 statement ok
 INSERT INTO t VALUES (1, 2)
@@ -23,229 +23,229 @@ INSERT INTO t VALUES (1, 2)
 query ITTTTT
 EXPLAIN (TYPES) SELECT 42
 ----
-0  render                        ("42" int)  ="42"
-0           render 0  (42)[int]
-1  nullrow                       ()
+0  render   ·         ·          ("42" int)  ="42"
+0  ·        render 0  (42)[int]  ·           ·
+1  nullrow  ·         ·          ()          ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t
 ----
-0  scan                    (k int, v int)
-0        table  t@primary
-0        spans  ALL
+0  scan  ·      ·          (k int, v int)  ·
+0  ·     table  t@primary  ·               ·
+0  ·     spans  ALL        ·               ·
 
 query ITTTTT
 EXPLAIN (TYPES,SYMVARS) SELECT k FROM t
 ----
-0  render                      (k int)
-0         render 0  (@1)[int]
-1  scan                        (k int, v[omitted] int)
-1         table     t@primary
-1         spans     ALL
+0  render  ·         ·          (k int)                  ·
+0  ·       render 0  (@1)[int]  ·                        ·
+1  scan    ·         ·          (k int, v[omitted] int)  ·
+1  ·       table     t@primary  ·                        ·
+1  ·       spans     ALL        ·                        ·
 
 query ITTTTT
 EXPLAIN (TYPES,QUALIFY) SELECT k FROM t
 ----
-0  render                            (k int)
-0         render 0  (test.t.k)[int]
-1  scan                              (k int, v[omitted] int)
-1         table     t@primary
-1         spans     ALL
+0  render  ·         ·                (k int)                  ·
+0  ·       render 0  (test.t.k)[int]  ·                        ·
+1  scan    ·         ·                (k int, v[omitted] int)  ·
+1  ·       table     t@primary        ·                        ·
+1  ·       spans     ALL              ·                        ·
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
 ----
-0  render                                           (k int, v int)
-0          render 0  (k)[int]
-0          render 1  (v)[int]
-1  scan                                             (k int, v int)
-1          table     t@primary
-1          filter    ((v)[int] > (123)[int])[bool]
+0  render  ·         ·                              (k int, v int)  ·
+0  ·       render 0  (k)[int]                       ·               ·
+0  ·       render 1  (v)[int]                       ·               ·
+1  scan    ·         ·                              (k int, v int)  ·
+1  ·       table     t@primary                      ·               ·
+1  ·       filter    ((v)[int] > (123)[int])[bool]  ·               ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-0  scan                                                    (k int, v int)
-0                 table     t@primary
-0                 spans     ALL
-0                 filter    ((v)[int] > (123)[int])[bool]
+0  scan  ·       ·                              (k int, v int)  ·
+0  ·     table   t@primary                      ·               ·
+0  ·     spans   ALL                            ·               ·
+0  ·     filter  ((v)[int] > (123)[int])[bool]  ·               ·
 
 query ITTTTT
 EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
 ----
-0  values                                    (column1 int, column2 int, column3 int)
-0          size           3 columns, 2 rows
-0          row 0, expr 0  (1)[int]
-0          row 0, expr 1  (2)[int]
-0          row 0, expr 2  (3)[int]
-0          row 1, expr 0  (4)[int]
-0          row 1, expr 1  (5)[int]
-0          row 1, expr 2  (6)[int]
+0  values  ·              ·                  (column1 int, column2 int, column3 int)  ·
+0  ·       size           3 columns, 2 rows  ·                                        ·
+0  ·       row 0, expr 0  (1)[int]           ·                                        ·
+0  ·       row 0, expr 1  (2)[int]           ·                                        ·
+0  ·       row 0, expr 2  (3)[int]           ·                                        ·
+0  ·       row 1, expr 0  (4)[int]           ·                                        ·
+0  ·       row 1, expr 1  (5)[int]           ·                                        ·
+0  ·       row 1, expr 2  (6)[int]           ·                                        ·
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND COUNT(k)>1
 ----
-0  render                                                                                          (z int, v int)
-0          render 0     ((2)[int] * ("count(k)")[int])[int]
-0          render 1     (v)[int]
-1  filter                                                                                          (v int, "count(k)" int, "count(k)" int, v int)
-1          filter       (("count(k)")[int] > (1)[int])[bool]
-2  group                                                                                           (v int, "count(k)" int, "count(k)" int, v int)
-2          aggregate 0  (v)[int]
-2          aggregate 1  (count((k)[int]))[int]
-2          aggregate 2  (count((k)[int]))[int]
-2          aggregate 3  (v)[int]
-3  render                                                                                          (v int, k int)
-3          render 0     (v)[int]
-3          render 1     (k)[int]
-4  scan                                                                                            (k int, v int)
-4          table        t@primary
-4          filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]
+0  render  ·            ·                                                                          (z int, v int)                                  ·
+0  ·       render 0     ((2)[int] * ("count(k)")[int])[int]                                        ·                                               ·
+0  ·       render 1     (v)[int]                                                                   ·                                               ·
+1  filter  ·            ·                                                                          (v int, "count(k)" int, "count(k)" int, v int)  ·
+1  ·       filter       (("count(k)")[int] > (1)[int])[bool]                                       ·                                               ·
+2  group   ·            ·                                                                          (v int, "count(k)" int, "count(k)" int, v int)  ·
+2  ·       aggregate 0  (v)[int]                                                                   ·                                               ·
+2  ·       aggregate 1  (count((k)[int]))[int]                                                     ·                                               ·
+2  ·       aggregate 2  (count((k)[int]))[int]                                                     ·                                               ·
+2  ·       aggregate 3  (v)[int]                                                                   ·                                               ·
+3  render  ·            ·                                                                          (v int, k int)                                  ·
+3  ·       render 0     (v)[int]                                                                   ·                                               ·
+3  ·       render 1     (k)[int]                                                                   ·                                               ·
+4  scan    ·            ·                                                                          (k int, v int)                                  ·
+4  ·       table        t@primary                                                                  ·                                               ·
+4  ·       filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]  ·                                               ·
 
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND COUNT(k)>1
 ----
-0  render                                                     (z int, v int)
-0          render 0     ((2)[int] * ("count(k)")[int])[int]
-0          render 1     (v)[int]
-1  filter                                                     (v int, "count(k)" int, "count(k)" int, v int)
-1          filter       (("count(k)")[int] > (1)[int])[bool]
-2  group                                                      (v int, "count(k)" int, "count(k)" int, v int)
-2          aggregate 0  (v)[int]
-2          aggregate 1  (count((k)[int]))[int]
-2          aggregate 2  (count((k)[int]))[int]
-2          aggregate 3  (v)[int]
-3  render                                                     (v int, k int)
-3          render 0     (v)[int]
-3          render 1     (k)[int]
-4  empty                                                      ()
+0  render  ·            ·                                     (z int, v int)                                  ·
+0  ·       render 0     ((2)[int] * ("count(k)")[int])[int]   ·                                               ·
+0  ·       render 1     (v)[int]                              ·                                               ·
+1  filter  ·            ·                                     (v int, "count(k)" int, "count(k)" int, v int)  ·
+1  ·       filter       (("count(k)")[int] > (1)[int])[bool]  ·                                               ·
+2  group   ·            ·                                     (v int, "count(k)" int, "count(k)" int, v int)  ·
+2  ·       aggregate 0  (v)[int]                              ·                                               ·
+2  ·       aggregate 1  (count((k)[int]))[int]                ·                                               ·
+2  ·       aggregate 2  (count((k)[int]))[int]                ·                                               ·
+2  ·       aggregate 3  (v)[int]                              ·                                               ·
+3  render  ·            ·                                     (v int, k int)                                  ·
+3  ·       render 0     (v)[int]                              ·                                               ·
+3  ·       render 1     (k)[int]                              ·                                               ·
+4  empty   ·            ·                                     ()                                              ·
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1
 ----
-0  delete                                         ()
-0          from      t
-1  render                                         (k int)
-1          render 0  (k)[int]
-2  scan                                           (k int, v int)
-2          table     t@primary
-2          filter    ((v)[int] > (1)[int])[bool]
+0  delete  ·         ·                            ()              ·
+0  ·       from      t                            ·               ·
+1  render  ·         ·                            (k int)         ·
+1  ·       render 0  (k)[int]                     ·               ·
+2  scan    ·         ·                            (k int, v int)  ·
+2  ·       table     t@primary                    ·               ·
+2  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
 
 query ITTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-0  delete                                                ()
-0                 from      t
-1  render                                                (k int)
-1                 render 0  (k)[int]
-2  scan                                                  (k int, v int)
-2                 table     t@primary
-2                 spans     ALL
-2                 filter    ((v)[int] > (1)[int])[bool]
+0  delete  ·         ·                            ()              ·
+0  ·       from      t                            ·               ·
+1  render  ·         ·                            (k int)         ·
+1  ·       render 0  (k)[int]                     ·               ·
+2  scan    ·         ·                            (k int, v int)  ·
+2  ·       table     t@primary                    ·               ·
+2  ·       spans     ALL                          ·               ·
+2  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
 
 query ITTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-0  update                                                  ()
-0                 table     t
-0                 set       v
-1  render                                                  (k int, v int, "k + 1" int)
-1                 render 0  (k)[int]
-1                 render 1  (v)[int]
-1                 render 2  ((k)[int] + (1)[int])[int]
-2  scan                                                    (k int, v int)
-2                 table     t@primary
-2                 spans     ALL
-2                 filter    ((v)[int] > (123)[int])[bool]
+0  update  ·         ·                              ()                           ·
+0  ·       table     t                              ·                            ·
+0  ·       set       v                              ·                            ·
+1  render  ·         ·                              (k int, v int, "k + 1" int)  ·
+1  ·       render 0  (k)[int]                       ·                            ·
+1  ·       render 1  (v)[int]                       ·                            ·
+1  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
+2  scan    ·         ·                              (k int, v int)               ·
+2  ·       table     t@primary                      ·                            ·
+2  ·       spans     ALL                            ·                            ·
+2  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-0  update                                           ()
-0          table     t
-0          set       v
-1  render                                           (k int, v int, "k + 1" int)
-1          render 0  (k)[int]
-1          render 1  (v)[int]
-1          render 2  ((k)[int] + (1)[int])[int]
-2  scan                                             (k int, v int)
-2          table     t@primary
-2          filter    ((v)[int] > (123)[int])[bool]
+0  update  ·         ·                              ()                           ·
+0  ·       table     t                              ·                            ·
+0  ·       set       v                              ·                            ·
+1  render  ·         ·                              (k int, v int, "k + 1" int)  ·
+1  ·       render 0  (k)[int]                       ·                            ·
+1  ·       render 1  (v)[int]                       ·                            ·
+1  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
+2  scan    ·         ·                              (k int, v int)               ·
+2  ·       table     t@primary                      ·                            ·
+2  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
 
 query ITTTTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 ----
-0  union                                   (column1 int)
-1  values                                  (column1 int)
-1          size           1 column, 1 row
-1          row 0, expr 0  (1)[int]
-1  values                                  (column1 int)
-1          size           1 column, 1 row
-1          row 0, expr 0  (2)[int]
+0  union   ·              ·                (column1 int)  ·
+1  values  ·              ·                (column1 int)  ·
+1  ·       size           1 column, 1 row  ·              ·
+1  ·       row 0, expr 0  (1)[int]         ·              ·
+1  values  ·              ·                (column1 int)  ·
+1  ·       size           1 column, 1 row  ·              ·
+1  ·       row 0, expr 0  (2)[int]         ·              ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-0  distinct                            (k int)                  +k,unique
-0                 key       k
-1  render                              (k int)                  +k,unique
-1                 render 0  (k)[int]
-2  scan                                (k int, v[omitted] int)  +k,unique
-2                 table     t@primary
-2                 spans     ALL
+0  distinct  ·         ·          (k int)                  +k,unique
+0  ·         key       k          ·                        ·
+1  render    ·         ·          (k int)                  +k,unique
+1  ·         render 0  (k)[int]   ·                        ·
+2  scan      ·         ·          (k int, v[omitted] int)  +k,unique
+2  ·         table     t@primary  ·                        ·
+2  ·         spans     ALL        ·                        ·
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT DISTINCT k FROM t
 ----
-0  distinct                       (k int)
-1  render                         (k int)
-1            render 0  (k)[int]
-2  scan                           (k int, v[omitted] int)
-2            table     t@primary
+0  distinct  ·         ·          (k int)                  ·
+1  render    ·         ·          (k int)                  ·
+1  ·         render 0  (k)[int]   ·                        ·
+2  scan      ·         ·          (k int, v[omitted] int)  ·
+2  ·         table     t@primary  ·                        ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 ----
-0  sort                                (v int)                  +v
-0                 order     +v
-1  render                              (v int)
-1                 render 0  (v)[int]
-2  scan                                (k[omitted] int, v int)
-2                 table     t@primary
-2                 spans     ALL
+0  sort    ·         ·          (v int)                  +v
+0  ·       order     +v         ·                        ·
+1  render  ·         ·          (v int)                  ·
+1  ·       render 0  (v)[int]   ·                        ·
+2  scan    ·         ·          (k[omitted] int, v int)  ·
+2  ·       table     t@primary  ·                        ·
+2  ·       spans     ALL        ·                        ·
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t ORDER BY v
 ----
-0  nosort                       (v int)
-0          order     +v
-1  render                       (v int)
-1          render 0  (v)[int]
-2  scan                         (k[omitted] int, v int)
-2          table     t@primary
+0  nosort  ·         ·          (v int)                  ·
+0  ·       order     +v         ·                        ·
+1  render  ·         ·          (v int)                  ·
+1  ·       render 0  (v)[int]   ·                        ·
+2  scan    ·         ·          (k[omitted] int, v int)  ·
+2  ·       table     t@primary  ·                        ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 ----
-0  limit                               (v int)
-0                 count     (1)[int]
-1  render                              (v int)
-1                 render 0  (v)[int]
-2  scan                                (k[omitted] int, v int)
-2                 table     t@primary
-2                 spans     ALL
-2                 limit     1
+0  limit   ·         ·          (v int)                  ·
+0  ·       count     (1)[int]   ·                        ·
+1  render  ·         ·          (v int)                  ·
+1  ·       render 0  (v)[int]   ·                        ·
+2  scan    ·         ·          (k[omitted] int, v int)  ·
+2  ·       table     t@primary  ·                        ·
+2  ·       spans     ALL        ·                        ·
+2  ·       limit     1          ·                        ·
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t LIMIT 1
 ----
-0  limit                        (v int)
-0          count     (1)[int]
-1  render                       (v int)
-1          render 0  (v)[int]
-2  scan                         (k[omitted] int, v int)
-2          table     t@primary
+0  limit   ·         ·          (v int)                  ·
+0  ·       count     (1)[int]   ·                        ·
+1  render  ·         ·          (v int)                  ·
+1  ·       render 0  (v)[int]   ·                        ·
+2  scan    ·         ·          (k[omitted] int, v int)  ·
+2  ·       table     t@primary  ·                        ·
 
 statement ok
 CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
@@ -253,54 +253,54 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0  render                                                 (x int, y int)
-0                 render 0  (x)[int]
-0                 render 1  (y)[int]
-1  index-join                                             (x int, y int, rowid[hidden,omitted] int)
-2  scan                                                   (x[omitted] int, y[omitted] int, rowid[hidden] int)
-2                 table     tt@a
-2                 spans     /#-/10
-2  scan                                                   (x int, y int, rowid[hidden,omitted] int)
-2                 table     tt@primary
-2                 filter    ((y)[int] > (10)[int])[bool]
+0  render      ·         ·                             (x int, y int)                                       ·
+0  ·           render 0  (x)[int]                      ·                                                    ·
+0  ·           render 1  (y)[int]                      ·                                                    ·
+1  index-join  ·         ·                             (x int, y int, rowid[hidden,omitted] int)            ·
+2  scan        ·         ·                             (x[omitted] int, y[omitted] int, rowid[hidden] int)  ·
+2  ·           table     tt@a                          ·                                                    ·
+2  ·           spans     /#-/10                        ·                                                    ·
+2  scan        ·         ·                             (x int, y int, rowid[hidden,omitted] int)            ·
+2  ·           table     tt@primary                    ·                                                    ·
+2  ·           filter    ((y)[int] > (10)[int])[bool]  ·                                                    ·
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0  render                                                                                       (x int, y int)
-0          render 0  (x)[int]
-0          render 1  (y)[int]
-1  scan                                                                                         (x int, y int, rowid[hidden,omitted] int)
-1          table     tt@primary
-1          filter    ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]
+0  render  ·         ·                                                                          (x int, y int)                             ·
+0  ·       render 0  (x)[int]                                                                   ·                                          ·
+0  ·       render 1  (y)[int]                                                                   ·                                          ·
+1  scan    ·         ·                                                                          (x int, y int, rowid[hidden,omitted] int)  ·
+1  ·       table     tt@primary                                                                 ·                                          ·
+1  ·       filter    ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·                                          ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT $1 + 2 AS a
 ----
-0  render                                          (a int)  =a
-0           render 0  (($1)[int] + (2)[int])[int]
-1  nullrow                                         ()
+0  render   ·         ·                            (a int)  =a
+0  ·        render 0  (($1)[int] + (2)[int])[int]  ·        ·
+1  nullrow  ·         ·                            ()       ·
 
 query ITTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT ABS(2-3) AS a
 ----
-0  render                                    (a int)  =a
-0           render 0  (abs((-1)[int]))[int]
-1  nullrow                                   ()
+0  render   ·         ·                      (a int)  =a
+0  ·        render 0  (abs((-1)[int]))[int]  ·        ·
+1  nullrow  ·         ·                      ()       ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT ABS(2-3) AS a
 ----
-0  render                       (a int)  =a
-0           render 0  (1)[int]
-1  nullrow                      ()
+0  render   ·         ·         (a int)  =a
+0  ·        render 0  (1)[int]  ·        ·
+1  nullrow  ·         ·         ()       ·
 
 # Check array subscripts (#13811)
 query ITTTTT
 EXPLAIN (TYPES) SELECT x[1] FROM (SELECT ARRAY[1,2,3] AS x)
 ----
-0  render                                                         ("x[1]" int)
-0           render 0  ((x)[int[]][(1)[int]])[int]
-1  render                                                         (x int[])     =x
-1           render 0  (ARRAY[(1)[int],(2)[int],(3)[int]])[int[]]
-2  nullrow                                                        ()
+0  render   ·         ·                                           ("x[1]" int)  ·
+0  ·        render 0  ((x)[int[]][(1)[int]])[int]                 ·             ·
+1  render   ·         ·                                           (x int[])     =x
+1  ·        render 0  (ARRAY[(1)[int],(2)[int],(3)[int]])[int[]]  ·             ·
+2  nullrow  ·         ·                                           ()            ·

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -265,16 +265,16 @@ output row: ['f' 'g']
 query TT
 SELECT * FROM kv ORDER BY k
 ----
-A    NULL
-a    b
-c    d
-e    f
-f    g
-g
-nil1 NULL
-nil2 NULL
-nil3 NULL
-nil4 NULL
+A     NULL
+a     b
+c     d
+e     f
+f     g
+g     ·
+nil1  NULL
+nil2  NULL
+nil3  NULL
+nil4  NULL
 
 statement ok
 CREATE TABLE kv2 (
@@ -581,14 +581,14 @@ INSERT INTO select_t VALUES(1, 2),(2,3),(3,4)
 query ITTT
 EXPLAIN (PLAN,EXPRS) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 ----
-0  insert
-0                 into      insert_t(x, v)
-1  limit
-1                 count     1
-2  scan
-2                 table     select_t@primary
-2                 spans     ALL
-2                 limit     1
+0  insert  ·      ·
+0  ·       into   insert_t(x, v)
+1  limit   ·      ·
+1  ·       count  1
+2  scan    ·      ·
+2  ·       table  select_t@primary
+2  ·       spans  ALL
+2  ·       limit  1
 
 statement ok
 INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
@@ -612,29 +612,29 @@ SELECT * FROM insert_t
 query ITTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES(1,'AAA'),(2,'BBB') LIMIT 1
 ----
-0  insert
-0          into           insert_t(x, v)
-1  limit
-2  values
-2          size           2 columns, 2 rows
+0  insert  ·     ·
+0  ·       into  insert_t(x, v)
+1  limit   ·     ·
+2  values  ·     ·
+2  ·       size  2 columns, 2 rows
 
 query ITTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB')) LIMIT 1
 ----
-0  insert
-0          into           insert_t(x, v)
-1  limit
-2  values
-2          size           2 columns, 2 rows
+0  insert  ·     ·
+0  ·       into  insert_t(x, v)
+1  limit   ·     ·
+2  values  ·     ·
+2  ·       size  2 columns, 2 rows
 
 query ITTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB') LIMIT 1)
 ----
-0  insert
-0          into  insert_t(x, v)
-1  limit
-2  values
-2          size  2 columns, 2 rows
+0  insert  ·     ·
+0  ·       into  insert_t(x, v)
+1  limit   ·     ·
+2  values  ·     ·
+2  ·       size  2 columns, 2 rows
 
 statement error pq: multiple LIMIT clauses not allowed
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,'AAA'),(2,'BBB') LIMIT 1) LIMIT 1

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -288,9 +288,9 @@ SELECT * FROM orders WHERE customer = 1 AND id = 1000
 query ITTT
 EXPLAIN SELECT * FROM orders WHERE customer = 1 AND id = 1000
 ----
-0  scan
-0        table  orders@primary
-0        spans  /1/#/64/1/1000-/1/#/64/1/1001
+0  scan  ·      ·
+0  ·     table  orders@primary
+0  ·     spans  /1/#/64/1/1000-/1/#/64/1/1001
 
 # Check that interleaving can occur across databases
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -412,126 +412,126 @@ x  x  y  b  d  e
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
-0  render
-0                 render 0  x
-0                 render 1  y
-1  join
-1                 type      inner
-1                 equality  (x) = (x)
-2  scan
-2                 table     onecolumn@primary
-2                 spans     ALL
-2  scan
-2                 table     twocolumn@primary
-2                 spans     ALL
+0  render  ·         ·
+0  ·       render 0  x
+0  ·       render 1  y
+1  join    ·         ·
+1  ·       type      inner
+1  ·       equality  (x) = (x)
+2  scan    ·         ·
+2  ·       table     onecolumn@primary
+2  ·       spans     ALL
+2  scan    ·         ·
+2  ·       table     twocolumn@primary
+2  ·       spans     ALL
 
 # Check EXPLAIN.
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
-0  render
-0                 render 0  x
-0                 render 1  y
-0                 render 2  x
-0                 render 3  y
-1  join
-1                 type      inner
-1                 equality  (x) = (y)
-2  scan
-2                 table     twocolumn@primary
-2                 spans     ALL
-2  scan
-2                 table     twocolumn@primary
-2                 spans     ALL
+0  render  ·         ·
+0  ·       render 0  x
+0  ·       render 1  y
+0  ·       render 2  x
+0  ·       render 3  y
+1  join    ·         ·
+1  ·       type      inner
+1  ·       equality  (x) = (y)
+2  scan    ·         ·
+2  ·       table     twocolumn@primary
+2  ·       spans     ALL
+2  scan    ·         ·
+2  ·       table     twocolumn@primary
+2  ·       spans     ALL
 
 # Check EXPLAIN.
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
-0  render
-0                 render 0  x
-0                 render 1  y
-0                 render 2  x
-0                 render 3  y
-1  join
-1                 type      cross
-2  scan
-2                 table     twocolumn@primary
-2                 spans     ALL
-2                 filter    x = 44
-2  scan
-2                 table     twocolumn@primary
-2                 spans     ALL
+0  render  ·         ·
+0  ·       render 0  x
+0  ·       render 1  y
+0  ·       render 2  x
+0  ·       render 3  y
+1  join    ·         ·
+1  ·       type      cross
+2  scan    ·         ·
+2  ·       table     twocolumn@primary
+2  ·       spans     ALL
+2  ·       filter    x = 44
+2  scan    ·         ·
+2  ·       table     twocolumn@primary
+2  ·       spans     ALL
 
 # Check EXPLAIN.
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
-0  render
-0                 render 0  x
-0                 render 1  x
-0                 render 2  y
-1  join
-1                 type      inner
-1                 equality  (x) = (y)
-2  scan
-2                 table     onecolumn@primary
-2                 spans     ALL
-2  scan
-2                 table     twocolumn@primary
-2                 spans     ALL
+0  render  ·         ·
+0  ·       render 0  x
+0  ·       render 1  x
+0  ·       render 2  y
+1  join    ·         ·
+1  ·       type      inner
+1  ·       equality  (x) = (y)
+2  scan    ·         ·
+2  ·       table     onecolumn@primary
+2  ·       spans     ALL
+2  scan    ·         ·
+2  ·       table     twocolumn@primary
+2  ·       spans     ALL
 
 # Check EXPLAIN.
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
-0  render
-0                 render 0  x
-0                 render 1  x
-0                 render 2  y
-1  join
-1                 type      inner
-1                 equality  (x) = (y)
-2  scan
-2                 table     onecolumn@primary
-2                 spans     ALL
-2  scan
-2                 table     twocolumn@primary
-2                 spans     ALL
+0  render  ·         ·
+0  ·       render 0  x
+0  ·       render 1  x
+0  ·       render 2  y
+1  join    ·         ·
+1  ·       type      inner
+1  ·       equality  (x) = (y)
+2  scan    ·         ·
+2  ·       table     onecolumn@primary
+2  ·       spans     ALL
+2  scan    ·         ·
+2  ·       table     twocolumn@primary
+2  ·       spans     ALL
 
 
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
 ----
-0  limit
-0                 count     1
-1  render
-1                 render 0  x
-1                 render 1  x
-1                 render 2  y
-1                 render 3  b
-1                 render 4  d
-1                 render 5  e
-2  join
-2                 type      inner
-2                 equality  (b, x) = (d, d)
-3  join
-3                 type      inner
-3                 equality  (x) = (b)
-4  join
-4                 type      cross
-5  scan
-5                 table     onecolumn@primary
-5                 spans     ALL
-5  scan
-5                 table     twocolumn@primary
-5                 spans     ALL
-4  scan
-4                 table     onecolumn@primary
-4                 spans     ALL
-3  scan
-3                 table     twocolumn@primary
-3                 spans     ALL
+0  limit   ·         ·
+0  ·       count     1
+1  render  ·         ·
+1  ·       render 0  x
+1  ·       render 1  x
+1  ·       render 2  y
+1  ·       render 3  b
+1  ·       render 4  d
+1  ·       render 5  e
+2  join    ·         ·
+2  ·       type      inner
+2  ·       equality  (b, x) = (d, d)
+3  join    ·         ·
+3  ·       type      inner
+3  ·       equality  (x) = (b)
+4  join    ·         ·
+4  ·       type      cross
+5  scan    ·         ·
+5  ·       table     onecolumn@primary
+5  ·       spans     ALL
+5  scan    ·         ·
+5  ·       table     twocolumn@primary
+5  ·       spans     ALL
+4  scan    ·         ·
+4  ·       table     onecolumn@primary
+4  ·       spans     ALL
+3  scan    ·         ·
+3  ·       table     twocolumn@primary
+3  ·       spans     ALL
 
 # Check sub-queries in ON conditions.
 query III colnames
@@ -623,74 +623,74 @@ CREATE TABLE s(x INT); INSERT INTO s(x) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(
 query ITTTTT
 EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
-0  render                            (x, y)
-1  join                              (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
-1          type   cross
-2  scan                              (x, y[omitted], rowid[hidden,omitted])
-2          table  twocolumn@primary
-2          spans  ALL
-2  scan                              (x[omitted], y, rowid[hidden,omitted])
-2          table  twocolumn@primary
-2          spans  ALL
+0  render  ·      ·                  (x, y)                                                                        ·
+1  join    ·      ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
+1  ·       type   cross              ·                                                                             ·
+2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                        ·
+2  ·       table  twocolumn@primary  ·                                                                             ·
+2  ·       spans  ALL                ·                                                                             ·
+2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                        ·
+2  ·       table  twocolumn@primary  ·                                                                             ·
+2  ·       spans  ALL                ·                                                                             ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
-0  render                               (y)
-1  join                                 (x[omitted], x[hidden,omitted], y[omitted], rowid[hidden,omitted], x[hidden,omitted], y, rowid[hidden,omitted])
-1          type      inner
-1          equality  (x) = (x)
-2  scan                                 (x, y[omitted], rowid[hidden,omitted])
-2          table     twocolumn@primary
-2          spans     ALL
-2  scan                                 (x, y, rowid[hidden,omitted])
-2          table     twocolumn@primary
-2          spans     ALL
+0  render  ·         ·                  (y)                                                                                                              ·
+1  join    ·         ·                  (x[omitted], x[hidden,omitted], y[omitted], rowid[hidden,omitted], x[hidden,omitted], y, rowid[hidden,omitted])  ·
+1  ·       type      inner              ·                                                                                                                ·
+1  ·       equality  (x) = (x)          ·                                                                                                                ·
+2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                                           ·
+2  ·       table     twocolumn@primary  ·                                                                                                                ·
+2  ·       spans     ALL                ·                                                                                                                ·
+2  scan    ·         ·                  (x, y, rowid[hidden,omitted])                                                                                    ·
+2  ·       table     twocolumn@primary  ·                                                                                                                ·
+2  ·       spans     ALL                ·                                                                                                                ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
-0  render                               (y)
-1  join                                 (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])
-1          type      inner
-1          equality  (x) = (x)
-2  scan                                 (x, y[omitted], rowid[hidden,omitted])
-2          table     twocolumn@primary
-2          spans     ALL
-2  scan                                 (x, y, rowid[hidden,omitted])
-2          table     twocolumn@primary
-2          spans     ALL
+0  render  ·         ·                  (y)                                                                                    ·
+1  join    ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
+1  ·       type      inner              ·                                                                                      ·
+1  ·       equality  (x) = (x)          ·                                                                                      ·
+2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 ·
+2  ·       table     twocolumn@primary  ·                                                                                      ·
+2  ·       spans     ALL                ·                                                                                      ·
+2  scan    ·         ·                  (x, y, rowid[hidden,omitted])                                                          ·
+2  ·       table     twocolumn@primary  ·                                                                                      ·
+2  ·       spans     ALL                ·                                                                                      ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
-0  render                            (x)
-1  join                              (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])
-1          type   inner
-2  scan                              (x, y[omitted], rowid[hidden,omitted])
-2          table  twocolumn@primary
-2          spans  ALL
-2  scan                              (x[omitted], y, rowid[hidden,omitted])
-2          table  twocolumn@primary
-2          spans  ALL
+0  render  ·      ·                  (x)                                                                                    ·
+1  join    ·      ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
+1  ·       type   inner              ·                                                                                      ·
+2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                                 ·
+2  ·       table  twocolumn@primary  ·                                                                                      ·
+2  ·       spans  ALL                ·                                                                                      ·
+2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                                 ·
+2  ·       table  twocolumn@primary  ·                                                                                      ·
+2  ·       spans  ALL                ·                                                                                      ·
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
                 INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
-0  sort                                 (k, u, w)                                        +u
-0          order     +u
-1  render                               (k, u, w)
-2  join                                 (k, u, k[hidden,omitted], k[hidden,omitted], w)
-2          type      inner
-2          equality  (k) = (k)
-3  sort                                 (u, k)                                           +k
-3          order     +k
-4  values                               (u, k)
-4          size      2 columns, 2 rows
-3  values                               (column1, column2)
-3          size      2 columns, 2 rows
+0  sort    ·         ·                  (k, u, w)                                        +u
+0  ·       order     +u                 ·                                                ·
+1  render  ·         ·                  (k, u, w)                                        ·
+2  join    ·         ·                  (k, u, k[hidden,omitted], k[hidden,omitted], w)  ·
+2  ·       type      inner              ·                                                ·
+2  ·       equality  (k) = (k)          ·                                                ·
+3  sort    ·         ·                  (u, k)                                           +k
+3  ·       order     +k                 ·                                                ·
+4  values  ·         ·                  (u, k)                                           ·
+4  ·       size      2 columns, 2 rows  ·                                                ·
+3  values  ·         ·                  (column1, column2)                               ·
+3  ·       size      2 columns, 2 rows  ·                                                ·
 
 # Ensure that large cross-joins are optimized somehow (#10633)
 statement ok
@@ -763,39 +763,39 @@ SELECT * FROM [EXPLAIN SELECT
 	   pos.n
   ] WHERE "Type" <> 'values' AND "Field" <> 'size'
 ----
-0   sort
-0              order     +pktable_schem,+pktable_name,+fk_name,+key_seq
-1   render
-2   join
-2              type      inner
-2              equality  (oid) = (relnamespace)
-3   join
-3              type      inner
-3              equality  (oid, oid) = (attrelid, confrelid)
-4   join
-4              type      inner
-5   join
-5              type      inner
-5              equality  (oid) = (relnamespace)
-6   filter
-6   join
-6              type      inner
-6              equality  (oid, oid) = (attrelid, conrelid)
-7   filter
-7   join
-7              type      inner
-8   join
-8              type      inner
-8              equality  (oid) = (objid)
-9   filter
-9   join
-9              type      cross
-10  generator
-10  join
-10             type      inner
-10             equality  (refobjid) = (oid)
-11  filter
-11  filter
+0   sort       ·         ·
+0   ·          order     +pktable_schem,+pktable_name,+fk_name,+key_seq
+1   render     ·         ·
+2   join       ·         ·
+2   ·          type      inner
+2   ·          equality  (oid) = (relnamespace)
+3   join       ·         ·
+3   ·          type      inner
+3   ·          equality  (oid, oid) = (attrelid, confrelid)
+4   join       ·         ·
+4   ·          type      inner
+5   join       ·         ·
+5   ·          type      inner
+5   ·          equality  (oid) = (relnamespace)
+6   filter     ·         ·
+6   join       ·         ·
+6   ·          type      inner
+6   ·          equality  (oid, oid) = (attrelid, conrelid)
+7   filter     ·         ·
+7   join       ·         ·
+7   ·          type      inner
+8   join       ·         ·
+8   ·          type      inner
+8   ·          equality  (oid) = (objid)
+9   filter     ·         ·
+9   join       ·         ·
+9   ·          type      cross
+10  generator  ·         ·
+10  join       ·         ·
+10  ·          type      inner
+10  ·          equality  (refobjid) = (oid)
+11  filter     ·         ·
+11  filter     ·         ·
 
 query TTTTTTTTIIITTI
 SELECT     NULL::text  AS pktable_cat,
@@ -883,16 +883,16 @@ INSERT INTO pairs VALUES (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (2,3), (2,4),
 query ITTT
 EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
-0  render
-1  join
-1        type      inner
-1        equality  (b) = (n)
-2  scan
-2        table     pairs@primary
-2        spans     ALL
-2  scan
-2        table     square@primary
-2        spans     ALL
+0  render  ·         ·
+1  join    ·         ·
+1  ·       type      inner
+1  ·       equality  (b) = (n)
+2  scan    ·         ·
+2  ·       table     pairs@primary
+2  ·       spans     ALL
+2  scan    ·         ·
+2  ·       table     square@primary
+2  ·       spans     ALL
 
 query IIII rowsort
 SELECT * FROM pairs, square WHERE pairs.b = square.n
@@ -917,20 +917,20 @@ SELECT * FROM pairs, square WHERE pairs.b = square.n
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 ----
-0  render                                                            (a, b, n, sq)
-0          render 0  test.pairs.a
-0          render 1  test.pairs.b
-0          render 2  test.square.n
-0          render 3  test.square.sq
-1  join                                                              (a, b, rowid[hidden,omitted], n, sq)
-1          type      inner
-1          pred      (test.pairs.a + test.pairs.b) = test.square.sq
-2  scan                                                              (a, b, rowid[hidden,omitted])
-2          table     pairs@primary
-2          spans     ALL
-2  scan                                                              (n, sq)
-2          table     square@primary
-2          spans     ALL
+0  render  ·         ·                                               (a, b, n, sq)                         ·
+0  ·       render 0  test.pairs.a                                    ·                                     ·
+0  ·       render 1  test.pairs.b                                    ·                                     ·
+0  ·       render 2  test.square.n                                   ·                                     ·
+0  ·       render 3  test.square.sq                                  ·                                     ·
+1  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
+1  ·       type      inner                                           ·                                     ·
+1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
+2  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         ·
+2  ·       table     pairs@primary                                   ·                                     ·
+2  ·       spans     ALL                                             ·                                     ·
+2  scan    ·         ·                                               (n, sq)                               ·
+2  ·       table     square@primary                                  ·                                     ·
+2  ·       spans     ALL                                             ·                                     ·
 
 query IIII rowsort
 SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
@@ -945,27 +945,27 @@ SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
 ----
-0  render                                         (a, b, n, sq)
-0          render 0  a
-0          render 1  b
-0          render 2  n
-0          render 3  sq
-1  filter                                         (a, b, sum, n, sq)
-1          filter    sum = sq
-2  render                                         (a, b, sum, n, sq)
-2          render 0  test.pairs.a
-2          render 1  test.pairs.b
-2          render 2  test.pairs.a + test.pairs.b
-2          render 3  test.square.n
-2          render 4  test.square.sq
-3  join                                           (a, b, rowid[hidden,omitted], n, sq)
-3          type      cross
-4  scan                                           (a, b, rowid[hidden,omitted])
-4          table     pairs@primary
-4          spans     ALL
-4  scan                                           (n, sq)
-4          table     square@primary
-4          spans     ALL
+0  render  ·         ·                            (a, b, n, sq)                         ·
+0  ·       render 0  a                            ·                                     ·
+0  ·       render 1  b                            ·                                     ·
+0  ·       render 2  n                            ·                                     ·
+0  ·       render 3  sq                           ·                                     ·
+1  filter  ·         ·                            (a, b, sum, n, sq)                    ·
+1  ·       filter    sum = sq                     ·                                     ·
+2  render  ·         ·                            (a, b, sum, n, sq)                    ·
+2  ·       render 0  test.pairs.a                 ·                                     ·
+2  ·       render 1  test.pairs.b                 ·                                     ·
+2  ·       render 2  test.pairs.a + test.pairs.b  ·                                     ·
+2  ·       render 3  test.square.n                ·                                     ·
+2  ·       render 4  test.square.sq               ·                                     ·
+3  join    ·         ·                            (a, b, rowid[hidden,omitted], n, sq)  ·
+3  ·       type      cross                        ·                                     ·
+4  scan    ·         ·                            (a, b, rowid[hidden,omitted])         ·
+4  ·       table     pairs@primary                ·                                     ·
+4  ·       spans     ALL                          ·                                     ·
+4  scan    ·         ·                            (n, sq)                               ·
+4  ·       table     square@primary               ·                                     ·
+4  ·       spans     ALL                          ·                                     ·
 
 query IIII rowsort
 SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
@@ -978,20 +978,20 @@ SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WH
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
-0  render                                                            (a, b, n, sq)
-0          render 0  test.pairs.a
-0          render 1  test.pairs.b
-0          render 2  test.square.n
-0          render 3  test.square.sq
-1  join                                                              (a, b, rowid[hidden,omitted], n, sq)
-1          type      full outer
-1          pred      (test.pairs.a + test.pairs.b) = test.square.sq
-2  scan                                                              (a, b, rowid[hidden,omitted])
-2          table     pairs@primary
-2          spans     ALL
-2  scan                                                              (n, sq)
-2          table     square@primary
-2          spans     ALL
+0  render  ·         ·                                               (a, b, n, sq)                         ·
+0  ·       render 0  test.pairs.a                                    ·                                     ·
+0  ·       render 1  test.pairs.b                                    ·                                     ·
+0  ·       render 2  test.square.n                                   ·                                     ·
+0  ·       render 3  test.square.sq                                  ·                                     ·
+1  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
+1  ·       type      full outer                                      ·                                     ·
+1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
+2  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         ·
+2  ·       table     pairs@primary                                   ·                                     ·
+2  ·       spans     ALL                                             ·                                     ·
+2  scan    ·         ·                                               (n, sq)                               ·
+2  ·       table     square@primary                                  ·                                     ·
+2  ·       spans     ALL                                             ·                                     ·
 
 query IIII rowsort
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
@@ -1019,22 +1019,22 @@ NULL  NULL  6     36
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
-0  render                                                            (a, b, n, sq)
-0          render 0  test.pairs.a
-0          render 1  test.pairs.b
-0          render 2  test.square.n
-0          render 3  test.square.sq
-1  filter                                                            (a, b, rowid[hidden,omitted], n, sq)
-1          filter    (test.pairs.b % 2) != (test.square.sq % 2)
-2  join                                                              (a, b, rowid[hidden,omitted], n, sq)
-2          type      full outer
-2          pred      (test.pairs.a + test.pairs.b) = test.square.sq
-3  scan                                                              (a, b, rowid[hidden,omitted])
-3          table     pairs@primary
-3          spans     ALL
-3  scan                                                              (n, sq)
-3          table     square@primary
-3          spans     ALL
+0  render  ·         ·                                               (a, b, n, sq)                         ·
+0  ·       render 0  test.pairs.a                                    ·                                     ·
+0  ·       render 1  test.pairs.b                                    ·                                     ·
+0  ·       render 2  test.square.n                                   ·                                     ·
+0  ·       render 3  test.square.sq                                  ·                                     ·
+1  filter  ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
+1  ·       filter    (test.pairs.b % 2) != (test.square.sq % 2)      ·                                     ·
+2  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
+2  ·       type      full outer                                      ·                                     ·
+2  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
+3  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         ·
+3  ·       table     pairs@primary                                   ·                                     ·
+3  ·       spans     ALL                                             ·                                     ·
+3  scan    ·         ·                                               (n, sq)                               ·
+3  ·       table     square@primary                                  ·                                     ·
+3  ·       spans     ALL                                             ·                                     ·
 
 query IIII rowsort
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -61,12 +61,12 @@ query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
 ----
 Level  Type        Field   Description  Columns                      Ordering
-0      limit                            (k, v, w)                    +v
-0                  count   2
-1      index-join                       (k, v, w)                    +v
-2      scan                             (k, v[omitted], w[omitted])  +v
-2                  table   t@t_v_idx
-2                  spans   /5-
-2      scan                             (k, v, w)
-2                  table   t@primary
-2                  filter  w > 30
+0      limit       ·       ·            (k, v, w)                    +v
+0      ·           count   2            ·                            ·
+1      index-join  ·       ·            (k, v, w)                    +v
+2      scan        ·       ·            (k, v[omitted], w[omitted])  +v
+2      ·           table   t@t_v_idx    ·                            ·
+2      ·           spans   /5-          ·                            ·
+2      scan        ·       ·            (k, v, w)                    ·
+2      ·           table   t@primary    ·                            ·
+2      ·           filter  w > 30       ·                            ·

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -3,103 +3,103 @@
 query ITTTTT
 EXPLAIN (METADATA,NOOPTIMIZE) SELECT 1 FROM (SELECT 2 AS s)
 ----
-0  render       ("1")  ="1"
-1  render       (s)    =s
-2  nullrow      ()
+0  render   ·  ·  ("1")  ="1"
+1  render   ·  ·  (s)    =s
+2  nullrow  ·  ·  ()     ·
 
 # Propagation to data sources.
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s)
 ----
-0  render       ("1")         ="1"
-1  render       (s[omitted])
-2  nullrow      ()
+0  render   ·  ·  ("1")         ="1"
+1  render   ·  ·  (s[omitted])  ·
+2  nullrow  ·  ·  ()            ·
 
 # Propagation through CREATE TABLE.
 query ITTTTT
 EXPLAIN (METADATA) CREATE TABLE t AS SELECT 1 FROM (SELECT 2 AS s)
 ----
-0  create table      ()
-1  render            ("1")         ="1"
-2  render            (s[omitted])
-3  nullrow           ()
+0  create table  ·  ·  ()            ·
+1  render        ·  ·  ("1")         ="1"
+2  render        ·  ·  (s[omitted])  ·
+3  nullrow       ·  ·  ()            ·
 
 # Propagation through LIMIT.
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s) LIMIT 1
 ----
-0  limit        ("1")         ="1"
-1  render       ("1")         ="1"
-2  render       (s[omitted])
-3  nullrow      ()
+0  limit    ·  ·  ("1")         ="1"
+1  render   ·  ·  ("1")         ="1"
+2  render   ·  ·  (s[omitted])  ·
+3  nullrow  ·  ·  ()            ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s LIMIT 1)
 ----
-0  render       ("1")         ="1"
-1  limit        (s[omitted])
-2  render       (s[omitted])
-3  nullrow      ()
+0  render   ·  ·  ("1")         ="1"
+1  limit    ·  ·  (s[omitted])  ·
+2  render   ·  ·  (s[omitted])  ·
+3  nullrow  ·  ·  ()            ·
 
 # Propagation through UNION.
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION SELECT 2 AS s)
 ----
-0  render       ("1")  ="1"
-1  union        (s)
-2  render       (s)    =s
-3  nullrow      ()
-2  render       (s)    =s
-3  nullrow      ()
+0  render   ·  ·  ("1")  ="1"
+1  union    ·  ·  (s)    ·
+2  render   ·  ·  (s)    =s
+3  nullrow  ·  ·  ()     ·
+2  render   ·  ·  (s)    =s
+3  nullrow  ·  ·  ()     ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION ALL SELECT 2 AS s)
 ----
-0  render       ("1")         ="1"
-1  append       (s[omitted])
-2  render       (s[omitted])
-3  nullrow      ()
-2  render       (s[omitted])
-3  nullrow      ()
+0  render   ·  ·  ("1")         ="1"
+1  append   ·  ·  (s[omitted])  ·
+2  render   ·  ·  (s[omitted])  ·
+3  nullrow  ·  ·  ()            ·
+2  render   ·  ·  (s[omitted])  ·
+3  nullrow  ·  ·  ()            ·
 
 # Propagation through WITH ORDINALITY.
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s) WITH ORDINALITY
 ----
-0  render          ("1")                       ="1"
-1  ordinality      (s[omitted], "ordinality")  +"ordinality",unique
-2  render          (s[omitted])
-3  nullrow         ()
+0  render      ·  ·  ("1")                       ="1"
+1  ordinality  ·  ·  (s[omitted], "ordinality")  +"ordinality",unique
+2  render      ·  ·  (s[omitted])                ·
+3  nullrow     ·  ·  ()                          ·
 
 # Propagation through sort, when the sorting column is in the results.
 query ITTTTT
 EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y) ORDER BY x
 ----
-0  render       (x)              =x
-1  render       (x, y[omitted])  =x
-2  nullrow      ()
+0  render   ·  ·  (x)              =x
+1  render   ·  ·  (x, y[omitted])  =x
+2  nullrow  ·  ·  ()               ·
 
 # Propagation through sort, when the sorting column is not in the results.
 query ITTTTT
 EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y, 3 AS z) ORDER BY y
 ----
-0  nosort              (x)                 =x
-0           order  +y
-1  render              (x, y)              =x,=y
-2  render              (x, y, z[omitted])  =x,=y
-3  nullrow             ()
+0  nosort   ·      ·   (x)                 =x
+0  ·        order  +y  ·                   ·
+1  render   ·      ·   (x, y)              =x,=y
+2  render   ·      ·   (x, y, z[omitted])  =x,=y
+3  nullrow  ·      ·   ()                  ·
 
 # Propagation to sub-queries.
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
 ----
-0  render                  (y)           =y
-0           subqueries  1
-1  limit                   (x)           =x
-2  render                  (x)           =x
-3  render                  (s[omitted])
-4  nullrow                 ()
-1  nullrow                 ()
+0  render   ·           ·  (y)           =y
+0  ·        subqueries  1  ·             ·
+1  limit    ·           ·  (x)           =x
+2  render   ·           ·  (x)           =x
+3  render   ·           ·  (s[omitted])  ·
+4  nullrow  ·           ·  ()            ·
+1  nullrow  ·           ·  ()            ·
 
 # Propagation through table scans.
 statement ok
@@ -108,64 +108,64 @@ CREATE TABLE kv(k INT PRIMARY KEY, v INT)
 query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM kv
 ----
-0  render                     ("1")                     ="1"
-1  scan                       (k[omitted], v[omitted])
-1          table  kv@primary
-1          spans  ALL
+0  render  ·      ·           ("1")                     ="1"
+1  scan    ·      ·           (k[omitted], v[omitted])  ·
+1  ·       table  kv@primary  ·                         ·
+1  ·       spans  ALL         ·                         ·
 
 # Propagation through DISTINCT.
 query ITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT v FROM kv
 ----
-0  distinct                     (v)
-1  render                       (v)
-2  scan                         (k[omitted], v)
-2            table  kv@primary
-2            spans  ALL
+0  distinct  ·      ·           (v)              ·
+1  render    ·      ·           (v)              ·
+2  scan      ·      ·           (k[omitted], v)  ·
+2  ·         table  kv@primary  ·                ·
+2  ·         spans  ALL         ·                ·
 
 # Propagation through INSERT.
 query ITTTTT
 EXPLAIN (METADATA) INSERT INTO kv(k, v) SELECT 1, 2 FROM (SELECT 3 AS x, 4 AS y)
 ----
-0  insert                   ()
-0           into  kv(k, v)
-1  render                   ("1", "2")                ="1",="2"
-2  render                   (x[omitted], y[omitted])
-3  nullrow                  ()
+0  insert   ·     ·         ()                        ·
+0  ·        into  kv(k, v)  ·                         ·
+1  render   ·     ·         ("1", "2")                ="1",="2"
+2  render   ·     ·         (x[omitted], y[omitted])  ·
+3  nullrow  ·     ·         ()                        ·
 
 # Propagation through DELETE.
 query ITTTTT
 EXPLAIN (METADATA) DELETE FROM kv WHERE k = 3
 ----
-0   delete                         ()
-0            from    kv
-1   render                         (k)
-2   scan                           (k, v[omitted])
-2            table   kv@primary
-2            spans   /3-/4
+0  delete  ·      ·           ()               ·
+0  ·       from   kv          ·                ·
+1  render  ·      ·           (k)              ·
+2  scan    ·      ·           (k, v[omitted])  ·
+2  ·       table  kv@primary  ·                ·
+2  ·       spans  /3-/4       ·                ·
 
 # Ensure that propagations through a render node removes the renders
 # and properly propagates the remaining needed columns.
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT x FROM (SELECT 1 AS x, y FROM (SELECT 2 AS y))
 ----
-0  render                   (x)              =x
-0           render 0  x
-1  render                   (x, y[omitted])  =x
-1           render 0  1
-1           render 1  NULL
-2  render                   (y[omitted])
-2           render 0  NULL
-3  nullrow                  ()
+0  render   ·         ·     (x)              =x
+0  ·        render 0  x     ·                ·
+1  render   ·         ·     (x, y[omitted])  =x
+1  ·        render 0  1     ·                ·
+1  ·        render 1  NULL  ·                ·
+2  render   ·         ·     (y[omitted])     ·
+2  ·        render 0  NULL  ·                ·
+3  nullrow  ·         ·     ()               ·
 
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT k+1 AS x, v-2 AS y FROM kv)
 ----
-0  render                        ("1")                     ="1"
-0          render 0  1
-1  scan                          (k[omitted], v[omitted])
-1          table     kv@primary
-1          spans     ALL
+0  render  ·         ·           ("1")                     ="1"
+0  ·       render 0  1           ·                         ·
+1  scan    ·         ·           (k[omitted], v[omitted])  ·
+1  ·       table     kv@primary  ·                         ·
+1  ·       spans     ALL         ·                         ·
 
 statement ok
 CREATE TABLE a ("name" string, age int);
@@ -173,12 +173,12 @@ CREATE TABLE a ("name" string, age int);
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT "name", age FROM a);
 ----
-0  group                              ("count(*)")
-0          aggregate 0  count_rows()
-1  render                             ()
-2  render                             ("name"[omitted], age[omitted])
-2          render 0     NULL
-2          render 1     NULL
-3  scan                               ("name"[omitted], age[omitted], rowid[hidden,omitted])
-3          table        a@primary
-3          spans        ALL
+0  group   ·            ·             ("count(*)")                                            ·
+0  ·       aggregate 0  count_rows()  ·                                                       ·
+1  render  ·            ·             ()                                                      ·
+2  render  ·            ·             ("name"[omitted], age[omitted])                         ·
+2  ·       render 0     NULL          ·                                                       ·
+2  ·       render 1     NULL          ·                                                       ·
+3  scan    ·            ·             ("name"[omitted], age[omitted], rowid[hidden,omitted])  ·
+3  ·       table        a@primary     ·                                                       ·
+3  ·       spans        ALL           ·                                                       ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -43,12 +43,12 @@ SELECT a, b FROM t ORDER BY b
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
-0  sort
-0        order  +b
-1  render
-2  scan
-2        table  t@primary
-2        spans  ALL
+0  sort    ·      ·
+0  ·       order  +b
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  t@primary
+2  ·       spans  ALL
 
 query II
 SELECT a, b FROM t ORDER BY b DESC
@@ -60,12 +60,12 @@ SELECT a, b FROM t ORDER BY b DESC
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
-0  sort
-0        order  -b
-1  render
-2  scan
-2        table  t@primary
-2        spans  ALL
+0  sort    ·      ·
+0  ·       order  -b
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  t@primary
+2  ·       spans  ALL
 
 query I
 SELECT a FROM t ORDER BY 1 DESC
@@ -77,14 +77,14 @@ SELECT a FROM t ORDER BY 1 DESC
 query ITTT
 EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
-0  limit
-1  sort
-1         order     +b
-1         strategy  top 2
-2  render
-3  scan
-3         table     t@primary
-3         spans     ALL
+0  limit   ·         ·
+1  sort    ·         ·
+1  ·       order     +b
+1  ·       strategy  top 2
+2  render  ·         ·
+3  scan    ·         ·
+3  ·       table     t@primary
+3  ·       spans     ALL
 
 query II
 SELECT a, b FROM t ORDER BY b DESC LIMIT 2
@@ -95,15 +95,15 @@ SELECT a, b FROM t ORDER BY b DESC LIMIT 2
 query ITTT
 EXPLAIN SELECT DISTINCT a FROM t ORDER BY b LIMIT 2
 ----
-0  limit
-1  distinct
-2  sort
-2            order     +b
-2            strategy  iterative
-3  render
-4  scan
-4            table     t@primary
-4            spans     ALL
+0  limit     ·         ·
+1  distinct  ·         ·
+2  sort      ·         ·
+2  ·         order     +b
+2  ·         strategy  iterative
+3  render    ·         ·
+4  scan      ·         ·
+4  ·         table     t@primary
+4  ·         spans     ALL
 
 query I
 SELECT DISTINCT a FROM t ORDER BY b DESC LIMIT 2
@@ -153,45 +153,45 @@ SELECT b FROM t ORDER BY a DESC
 query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
-0  nosort
-0           order  -a
-1  render
-2  revscan
-2           table  t@primary
-2           spans  ALL
+0  nosort   ·      ·
+0  ·        order  -a
+1  render   ·      ·
+2  revscan  ·      ·
+2  ·        table  t@primary
+2  ·        spans  ALL
 
 # Check that LIMIT propagates past nosort nodes.
 query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a LIMIT 1
 ----
-0  limit
-1  nosort
-1          order  +a
-2  render
-3  scan
-3          table  t@primary
-3          spans  ALL
-3          limit  1
+0  limit   ·      ·
+1  nosort  ·      ·
+1  ·       order  +a
+2  render  ·      ·
+3  scan    ·      ·
+3  ·       table  t@primary
+3  ·       spans  ALL
+3  ·       limit  1
 
 query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
-0  nosort
-0           order  -a,+b
-1  render
-2  revscan
-2           table  t@primary
-2           spans  ALL
+0  nosort   ·      ·
+0  ·        order  -a,+b
+1  render   ·      ·
+2  revscan  ·      ·
+2  ·        table  t@primary
+2  ·        spans  ALL
 
 query ITTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
-0  nosort
-0           order  -a,-b
-1  render
-2  revscan
-2           table  t@primary
-2           spans  ALL
+0  nosort   ·      ·
+0  ·        order  -a,-b
+1  render   ·      ·
+2  revscan  ·      ·
+2  ·        table  t@primary
+2  ·        spans  ALL
 
 statement ok
 INSERT INTO t VALUES (4, 7), (5, 7)
@@ -309,63 +309,63 @@ SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER 
 query ITTT
 EXPLAIN SELECT * FROM t ORDER BY 1+2
 ----
-0  nosort
-0          order  +"1 + 2"
-1  render
-2  scan
-2          table  t@primary
-2          spans  ALL
+0  nosort  ·      ·
+0  ·       order  +"1 + 2"
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  t@primary
+2  ·       spans  ALL
 
 query ITTT
 EXPLAIN SELECT 1, * FROM t ORDER BY 1
 ----
-0  render
-1  scan
-1          table  t@primary
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@primary
+1  ·       spans  ALL
 
 query ITTT
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
-0  nosort
-0          order  +"length('abc')"
-1  render
-2  scan
-2          table  t@primary
-2          spans  ALL
+0  nosort  ·      ·
+0  ·       order  +"length('abc')"
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  t@primary
+2  ·       spans  ALL
 
 # Check that the sort key reuses the existing render.
 query ITTTTT
 EXPLAIN (METADATA) SELECT b+2 FROM t ORDER BY b+2
 ----
-0  sort                      ("b + 2")                    +"b + 2"
-0          order  +"b + 2"
-1  render                    ("b + 2")
-2  scan                      (a[omitted], b, c[omitted])
-2          table  t@primary
-2          spans  ALL
+0  sort    ·      ·          ("b + 2")                    +"b + 2"
+0  ·       order  +"b + 2"   ·                            ·
+1  render  ·      ·          ("b + 2")                    ·
+2  scan    ·      ·          (a[omitted], b, c[omitted])  ·
+2  ·       table  t@primary  ·                            ·
+2  ·       spans  ALL        ·                            ·
 
 # Check that the sort picks up a renamed render properly.
 query ITTTTT
 EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY y
 ----
-0  sort                      (y)                          +y
-0          order  +y
-1  render                    (y)
-2  scan                      (a[omitted], b, c[omitted])
-2          table  t@primary
-2          spans  ALL
+0  sort    ·      ·          (y)                          +y
+0  ·       order  +y         ·                            ·
+1  render  ·      ·          (y)                          ·
+2  scan    ·      ·          (a[omitted], b, c[omitted])  ·
+2  ·       table  t@primary  ·                            ·
+2  ·       spans  ALL        ·                            ·
 
 # Check that the sort reuses a render behind a rename properly.
 query ITTTTT
 EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
 ----
-0  sort                      (y)                          +y
-0          order  +y
-1  render                    (y)
-2  scan                      (a[omitted], b, c[omitted])
-2          table  t@primary
-2          spans  ALL
+0  sort    ·      ·          (y)                          +y
+0  ·       order  +y         ·                            ·
+1  render  ·      ·          (y)                          ·
+2  scan    ·      ·          (a[omitted], b, c[omitted])  ·
+2  ·       table  t@primary  ·                            ·
+2  ·       spans  ALL        ·                            ·
 
 statement ok
 CREATE TABLE abc (
@@ -403,9 +403,9 @@ output row: [4 5 6 'Two']
 query ITTT
 EXPLAIN SELECT * FROM abc ORDER BY a
 ----
-0  scan
-0        table  abc@primary
-0        spans  ALL
+0  scan  ·      ·
+0  ·     table  abc@primary
+0  ·     spans  ALL
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT a, b FROM abc ORDER BY b, a]
@@ -419,88 +419,88 @@ output row: [4 5]
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, a
 ----
-0  render
-1  scan
-1        table  abc@ba
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abc@ba
+1  ·       spans  ALL
 
 # The non-unique index ba includes column c (required to make the keys unique)
 # so the results will already be sorted.
 query ITTT
 EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
-0  render
-1  scan
-1        table  abc@ba
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abc@ba
+1  ·       spans  ALL
 
 # We use the WHERE condition to force the use of index ba.
 query ITTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
-0  sort
-0              order  +b,+a,+d
-1  index-join
-2  scan
-2              table  abc@ba
-2              spans  /11-
-2  scan
-2              table  abc@primary
+0  sort        ·      ·
+0  ·           order  +b,+a,+d
+1  index-join  ·      ·
+2  scan        ·      ·
+2  ·           table  abc@ba
+2  ·           spans  /11-
+2  scan        ·      ·
+2  ·           table  abc@primary
 
 # We cannot have rows with identical values for a,b,c so we don't need to
 # sort for d.
 query ITTT
 EXPLAIN SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
 ----
-0  index-join
-1  scan
-1              table  abc@ba
-1              spans  /11-
-1  scan
-1              table  abc@primary
+0  index-join  ·      ·
+1  scan        ·      ·
+1  ·           table  abc@ba
+1  ·           spans  /11-
+1  scan        ·      ·
+1  ·           table  abc@primary
 
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
-0  nosort
-0          order  +b,+c
-1  render
-2  scan
-2          table  abc@bc
-2          spans  ALL
+0  nosort  ·      ·
+0  ·       order  +b,+c
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  abc@bc
+2  ·       spans  ALL
 
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
-0  nosort                        (a, b)                 +b
-0          order     +b,+c
-1  render                        (a, b, c)              +b,+c,unique
-1          render 0  test.abc.a
-1          render 1  test.abc.b
-1          render 2  test.abc.c
-2  scan                          (a, b, c, d[omitted])  +b,+c,unique
-2          table     abc@bc
-2          spans     ALL
+0  nosort  ·         ·           (a, b)                 +b
+0  ·       order     +b,+c       ·                      ·
+1  render  ·         ·           (a, b, c)              +b,+c,unique
+1  ·       render 0  test.abc.a  ·                      ·
+1  ·       render 1  test.abc.b  ·                      ·
+1  ·       render 2  test.abc.c  ·                      ·
+2  scan    ·         ·           (a, b, c, d[omitted])  +b,+c,unique
+2  ·       table     abc@bc      ·                      ·
+2  ·       spans     ALL         ·                      ·
 
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
-0  nosort
-0          order  +b,+c,+a
-1  render
-2  scan
-2          table  abc@bc
-2          spans  ALL
+0  nosort  ·      ·
+0  ·       order  +b,+c,+a
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  abc@bc
+2  ·       spans  ALL
 
 query ITTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
-0  nosort
-0          order  +b,+c,-a
-1  render
-2  scan
-2          table  abc@bc
-2          spans  ALL
+0  nosort  ·      ·
+0  ·       order  +b,+c,-a
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  abc@bc
+2  ·       spans  ALL
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT b, c FROM abc ORDER BY b, c]
@@ -534,10 +534,10 @@ output row: [1]
 query ITTT
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
-0  render
-1  revscan
-1           table  abc@primary
-1           spans  ALL
+0  render   ·      ·
+1  revscan  ·      ·
+1  ·        table  abc@primary
+1  ·        spans  ALL
 
 query I
 SELECT a FROM abc ORDER BY a DESC
@@ -558,29 +558,29 @@ SELECT a FROM abc ORDER BY a DESC OFFSET 1
 query ITTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
-0  render
-1  scan
-1        table  abc@bc
-1        spans  /2-/3
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abc@bc
+1  ·       spans  /2-/3
 
 query ITTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
-0  render
-1  revscan
-1           table  abc@bc
-1           spans  /2-/3
+0  render   ·      ·
+1  revscan  ·      ·
+1  ·        table  abc@bc
+1  ·        spans  /2-/3
 
 # Verify that the ordering of the primary index is still used for the outer sort.
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-0  nosort                      (b, c)                 +b,+c
-0          order  +b,+c
-1  render                      (b, c, a[omitted])     =a,+b,+c,unique
-2  scan                        (a, b, c, d[omitted])  =a,+b,+c,unique
-2          table  abc@primary
-2          spans  /1-/2
+0  nosort  ·      ·            (b, c)                 +b,+c
+0  ·       order  +b,+c        ·                      ·
+1  render  ·      ·            (b, c, a[omitted])     =a,+b,+c,unique
+2  scan    ·      ·            (a, b, c, d[omitted])  =a,+b,+c,unique
+2  ·       table  abc@primary  ·                      ·
+2  ·       spans  /1-/2        ·                      ·
 
 statement ok
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
@@ -591,9 +591,9 @@ INSERT INTO bar VALUES (0, NULL), (1, NULL)
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM bar ORDER BY baz, id
 ----
-0  scan                    (id, baz)  +baz,unique
-0        table  bar@i_bar
-0        spans  ALL
+0  scan  ·      ·          (id, baz)  +baz,unique
+0  ·     table  bar@i_bar  ·          ·
+0  ·     spans  ALL        ·          ·
 
 # Here rowsort is needed because the ORDER BY clause does not guarantee any
 # relative ordering between rows where baz is NULL. As we see above, because
@@ -621,34 +621,34 @@ INSERT INTO abcd VALUES (1, 4, 2, 3), (2, 3, 4, 1), (3, 2, 1, 2), (4, 4, 1, 1)
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
-0  render
-1  scan
-1        table  abcd@abc
-1        spans  /1/4-/1/5
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@abc
+1  ·       spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
-0  render
-1  scan
-1        table  abcd@abc
-1        spans  /1/4-/1/5
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@abc
+1  ·       spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
-0  render
-1  scan
-1        table  abcd@abc
-1        spans  /1/4-/1/5
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@abc
+1  ·       spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
-0  render
-1  scan
-1        table  abcd@abc
-1        spans  /1/4-/1/5
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@abc
+1  ·       spans  /1/4-/1/5
 
 statement ok
 CREATE TABLE nan (id INT PRIMARY KEY, x REAL)
@@ -667,71 +667,71 @@ NaN
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
-0  sort                             (x)  +x
-0          order  +x
-1  values                           (x)
-1          size   1 column, 3 rows
+0  sort    ·      ·                 (x)  +x
+0  ·       order  +x                ·    ·
+1  values  ·      ·                 (x)  ·
+1  ·       size   1 column, 3 rows  ·    ·
 
 query ITTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
 ----
-0  ordinality
-1  values
-1              size  1 column, 3 rows
+0  ordinality  ·     ·
+1  values      ·     ·
+1  ·           size  1 column, 3 rows
 
 query ITTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
 ----
-0  sort
-0              order  -"ordinality"
-1  ordinality
-2  values
-2              size   1 column, 3 rows
+0  sort        ·      ·
+0  ·           order  -"ordinality"
+1  ordinality  ·      ·
+2  values      ·      ·
+2  ·           size   1 column, 3 rows
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
-0  ordinality                          (x, "ordinality")  +"ordinality",unique
-1  values                              (x)
-1              size  1 column, 3 rows
+0  ordinality  ·     ·                 (x, "ordinality")  +"ordinality",unique
+1  values      ·     ·                 (x)                ·
+1  ·           size  1 column, 3 rows  ·                  ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
-0  ordinality                           (x, "ordinality")  +x
-1  sort                                 (x)                +x
-1              order  +x
-2  values                               (x)
-2              size   1 column, 3 rows
+0  ordinality  ·      ·                 (x, "ordinality")  +x
+1  sort        ·      ·                 (x)                +x
+1  ·           order  +x                ·                  ·
+2  values      ·      ·                 (x)                ·
+2  ·           size   1 column, 3 rows  ·                  ·
 
 # Check that the ordering of the source does not propagate blindly to RETURNING.
 query ITTTTT
 EXPLAIN (METADATA) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 ----
-0  insert                  (b)
-0           into  t(a, b)
-1  render                  (x, y)  =x,=y
-2  nullrow                 ()
+0  insert   ·     ·        (b)     ·
+0  ·        into  t(a, b)  ·       ·
+1  render   ·     ·        (x, y)  =x,=y
+2  nullrow  ·     ·        ()      ·
 
 query ITTTTT
 EXPLAIN (METADATA) DELETE FROM t WHERE a = 3 RETURNING b
 ----
-0  delete                    (b)
-0          from   t
-1  scan                      (a, b, c)
-1          table  t@primary
-1          spans  /3-/4
+0  delete  ·      ·          (b)        ·
+0  ·       from   t          ·          ·
+1  scan    ·      ·          (a, b, c)  ·
+1  ·       table  t@primary  ·          ·
+1  ·       spans  /3-/4      ·          ·
 
 query ITTTTT
 EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b
 ----
-0  update                    (b)
-0          table  t
-0          set    c
-1  render                    (a, b, c, "true")  ="true"
-2  scan                      (a, b, c)
-2          table  t@primary
-2          spans  ALL
+0  update  ·      ·          (b)                ·
+0  ·       table  t          ·                  ·
+0  ·       set    c          ·                  ·
+1  render  ·      ·          (a, b, c, "true")  ="true"
+2  scan    ·      ·          (a, b, c)          ·
+2  ·       table  t@primary  ·                  ·
+2  ·       spans  ALL        ·                  ·
 
 statement ok
 CREATE TABLE uvwxyz (
@@ -750,10 +750,10 @@ CREATE TABLE uvwxyz (
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
-0  render                      (y, w, x)                                                             =y,+w,+x
-1  scan                        (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  =y,+w,+x
-1          table  uvwxyz@ywxz
-1          spans  /1-/2
+0  render  ·      ·            (y, w, x)                                                             =y,+w,+x
+1  scan    ·      ·            (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  =y,+w,+x
+1  ·       table  uvwxyz@ywxz  ·                                                                     ·
+1  ·       spans  /1-/2        ·                                                                     ·
 
 
 statement ok
@@ -770,9 +770,9 @@ CREATE TABLE blocks (
 query ITTTTT
 EXPLAIN (METADATA) SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
 ----
-0  limit                          (block_id, writer_id, block_num, block_id)            +block_id,+writer_id,+block_num,unique
-1  render                         (block_id, writer_id, block_num, block_id)            +block_id,+writer_id,+block_num,unique
-2  scan                           (block_id, writer_id, block_num, raw_bytes[omitted])  +block_id,+writer_id,+block_num,unique
-2          table  blocks@primary
-2          spans  ALL
-2          limit  1
+0  limit   ·      ·               (block_id, writer_id, block_num, block_id)            +block_id,+writer_id,+block_num,unique
+1  render  ·      ·               (block_id, writer_id, block_num, block_id)            +block_id,+writer_id,+block_num,unique
+2  scan    ·      ·               (block_id, writer_id, block_num, raw_bytes[omitted])  +block_id,+writer_id,+block_num,unique
+2  ·       table  blocks@primary  ·                                                     ·
+2  ·       spans  ALL             ·                                                     ·
+2  ·       limit  1               ·                                                     ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -4,78 +4,78 @@ CREATE TABLE kv(k INT PRIMARY KEY, v INT); CREATE INDEX foo ON kv(v DESC)
 query ITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv
 ----
-0  nosort                     (v)
-0          order  +k
-1  render                     (v, k)  +k,unique
-2  scan                       (k, v)  +k,unique
-2          table  kv@primary
-2          spans  ALL
+0  nosort  ·      ·           (v)     ·
+0  ·       order  +k          ·       ·
+1  render  ·      ·           (v, k)  +k,unique
+2  scan    ·      ·           (k, v)  +k,unique
+2  ·       table  kv@primary  ·       ·
+2  ·       spans  ALL         ·       ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
 ----
-0  nosort                     (v)
-0          order  +k
-1  render                     (v, k)  +k,unique
-2  scan                       (k, v)  +k,unique
-2          table  kv@primary
-2          spans  ALL
+0  nosort  ·      ·           (v)     ·
+0  ·       order  +k          ·       ·
+1  render  ·      ·           (v, k)  +k,unique
+2  scan    ·      ·           (k, v)  +k,unique
+2  ·       table  kv@primary  ·       ·
+2  ·       spans  ALL         ·       ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
 ----
-0  nosort                      (v)
-0           order  -k
-1  render                      (v, k)  -k,unique
-2  revscan                     (k, v)  -k,unique
-2           table  kv@primary
-2           spans  ALL
+0  nosort   ·      ·           (v)     ·
+0  ·        order  -k          ·       ·
+1  render   ·      ·           (v, k)  -k,unique
+2  revscan  ·      ·           (k, v)  -k,unique
+2  ·        table  kv@primary  ·       ·
+2  ·        spans  ALL         ·       ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
 ----
-0  sort                            (k)
-0           order  +v,+k,+"v - 2"
-1  render                          (k, v, "v - 2")  +v
-2  revscan                         (k, v)           +v
-2           table  kv@foo
-2           spans  ALL
+0  sort     ·      ·               (k)              ·
+0  ·        order  +v,+k,+"v - 2"  ·                ·
+1  render   ·      ·               (k, v, "v - 2")  +v
+2  revscan  ·      ·               (k, v)           +v
+2  ·        table  kv@foo          ·                ·
+2  ·        spans  ALL             ·                ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
-0  nosort                 (k)
-0          order  -v
-1  scan                   (k, v)  -v
-1          table  kv@foo
-1          spans  ALL
+0  nosort  ·      ·       (k)     ·
+0  ·       order  -v      ·       ·
+1  scan    ·      ·       (k, v)  -v
+1  ·       table  kv@foo  ·       ·
+1  ·       spans  ALL     ·       ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
-0  nosort                 (k)
-0          order  -v
-1  scan                   (k, v)  -v
-1          table  kv@foo
-1          spans  ALL
+0  nosort  ·      ·       (k)     ·
+0  ·       order  -v      ·       ·
+1  scan    ·      ·       (k, v)  -v
+1  ·       table  kv@foo  ·       ·
+1  ·       spans  ALL     ·       ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
-0  nosort                  (k)
-0           order  +v
-1  revscan                 (k, v)  +v
-1           table  kv@foo
-1           spans  ALL
+0  nosort   ·      ·       (k)     ·
+0  ·        order  +v      ·       ·
+1  revscan  ·      ·       (k, v)  +v
+1  ·        table  kv@foo  ·       ·
+1  ·        spans  ALL     ·       ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
-0  nosort                 (k)
-0          order  -v,+k
-1  scan                   (k, v)  -v,+k,unique
-1          table  kv@foo
-1          spans  ALL
+0  nosort  ·      ·       (k)     ·
+0  ·       order  -v,+k   ·       ·
+1  scan    ·      ·       (k, v)  -v,+k,unique
+1  ·       table  kv@foo  ·       ·
+1  ·       spans  ALL     ·       ·
 
 # Check the syntax can be used with joins.
 #
@@ -86,50 +86,50 @@ EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 query ITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv JOIN (VALUES (1,2)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
-0  sort                                (k)
-0          order     -v
-1  render                              (k, v)
-2  join                                (k, v, a[omitted], b[omitted])
-2          type      inner
-2          equality  (k) = (a)
-3  scan                                (k, v)
-3          table     kv@primary
-3          spans     ALL
-3  values                              (column1, column2[omitted])
-3          size      2 columns, 1 row
+0  sort    ·         ·                 (k)                             ·
+0  ·       order     -v                ·                               ·
+1  render  ·         ·                 (k, v)                          ·
+2  join    ·         ·                 (k, v, a[omitted], b[omitted])  ·
+2  ·       type      inner             ·                               ·
+2  ·       equality  (k) = (a)         ·                               ·
+3  scan    ·         ·                 (k, v)                          ·
+3  ·       table     kv@primary        ·                               ·
+3  ·       spans     ALL               ·                               ·
+3  values  ·         ·                 (column1, column2[omitted])     ·
+3  ·       size      2 columns, 1 row  ·                               ·
 
 query ITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-0  sort                               (k)
-0          order     -v
-1  render                             (k, v)
-2  join                               (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])
-2          type      inner
-2          equality  (k, v) = (k, v)
-3  scan                               (k, v)
-3          table     kv@primary
-3          spans     ALL
-3  scan                               (k, v)
-3          table     kv@primary
-3          spans     ALL
+0  sort    ·         ·                (k)                                                                                  ·
+0  ·       order     -v               ·                                                                                    ·
+1  render  ·         ·                (k, v)                                                                               ·
+2  join    ·         ·                (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])  ·
+2  ·       type      inner            ·                                                                                    ·
+2  ·       equality  (k, v) = (k, v)  ·                                                                                    ·
+3  scan    ·         ·                (k, v)                                                                               ·
+3  ·       table     kv@primary       ·                                                                                    ·
+3  ·       spans     ALL              ·                                                                                    ·
+3  scan    ·         ·                (k, v)                                                                               ·
+3  ·       table     kv@primary       ·                                                                                    ·
+3  ·       spans     ALL              ·                                                                                    ·
 
 # The underlying index can be forced manually, of course.
 query ITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@foo
 ----
-0  sort                               (k)
-0          order     -v
-1  render                             (k, v)
-2  join                               (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])
-2          type      inner
-2          equality  (k, v) = (k, v)
-3  scan                               (k, v)
-3          table     kv@foo
-3          spans     ALL
-3  scan                               (k, v)
-3          table     kv@foo
-3          spans     ALL
+0  sort    ·         ·                (k)                                                                                  ·
+0  ·       order     -v               ·                                                                                    ·
+1  render  ·         ·                (k, v)                                                                               ·
+2  join    ·         ·                (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])  ·
+2  ·       type      inner            ·                                                                                    ·
+2  ·       equality  (k, v) = (k, v)  ·                                                                                    ·
+3  scan    ·         ·                (k, v)                                                                               ·
+3  ·       table     kv@foo           ·                                                                                    ·
+3  ·       spans     ALL              ·                                                                                    ·
+3  scan    ·         ·                (k, v)                                                                               ·
+3  ·       table     kv@foo           ·                                                                                    ·
+3  ·       spans     ALL              ·                                                                                    ·
 
 # Check the extended syntax cannot be used in case of renames.
 statement error source name "kv" not found in FROM clause

--- a/pkg/sql/logictest/testdata/logic_test/ordinal_references
+++ b/pkg/sql/logictest/testdata/logic_test/ordinal_references
@@ -50,14 +50,14 @@ a 3
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
-0  sort                           (b, a)                         +a
-0          order     +a
-1  render                         (b, a)
-1          render 0  test.foo.b
-1          render 1  test.foo.a
-2  scan                           (a, b, rowid[hidden,omitted])
-2          table     foo@primary
-2          spans     ALL
+0  sort    ·         ·            (b, a)                         +a
+0  ·       order     +a           ·                              ·
+1  render  ·         ·            (b, a)                         ·
+1  ·       render 0  test.foo.b   ·                              ·
+1  ·       render 1  test.foo.a   ·                              ·
+2  scan    ·         ·            (a, b, rowid[hidden,omitted])  ·
+2  ·       table     foo@primary  ·                              ·
+2  ·       spans     ALL          ·                              ·
 
 statement ok
 INSERT INTO foo(a, b) VALUES (4, 'c'), (5, 'c'), (6, 'c')
@@ -83,25 +83,25 @@ SELECT SUM(a) AS s FROM foo GROUP BY @2 ORDER BY s
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
-0  group                                 (m)
-0          aggregate 0  min(test.foo.a)
-1  render                                (a)
-1          render 0     test.foo.a
-2  scan                                  (a, b[omitted], rowid[hidden,omitted])
-2          table        foo@primary
-2          spans        ALL
+0  group   ·            ·                (m)                                     ·
+0  ·       aggregate 0  min(test.foo.a)  ·                                       ·
+1  render  ·            ·                (a)                                     ·
+1  ·       render 0     test.foo.a       ·                                       ·
+2  scan    ·            ·                (a, b[omitted], rowid[hidden,omitted])  ·
+2  ·       table        foo@primary      ·                                       ·
+2  ·       spans        ALL              ·                                       ·
 
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
-0  group                                 (m)
-0          aggregate 0  min(test.foo.a)
-1  render                                (b, a)
-1          render 0     test.foo.b
-1          render 1     test.foo.a
-2  scan                                  (a, b, rowid[hidden,omitted])
-2          table        foo@primary
-2          spans        ALL
+0  group   ·            ·                (m)                            ·
+0  ·       aggregate 0  min(test.foo.a)  ·                              ·
+1  render  ·            ·                (b, a)                         ·
+1  ·       render 0     test.foo.b       ·                              ·
+1  ·       render 1     test.foo.a       ·                              ·
+2  scan    ·            ·                (a, b, rowid[hidden,omitted])  ·
+2  ·       table        foo@primary      ·                              ·
+2  ·       spans        ALL              ·                              ·
 
 statement error column reference @1 not allowed in this context
 INSERT INTO foo(a, b) VALUES (@1, @2)

--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -85,18 +85,18 @@ true
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
 ----
-0  ordinality                      (x, "ordinality")  +x,unique
-1  scan                            (x)                +x,unique
-1              table  foo@primary
-1              spans  /"a\x00"-
+0  ordinality  ·      ·            (x, "ordinality")  +x,unique
+1  scan        ·      ·            (x)                +x,unique
+1  ·           table  foo@primary  ·                  ·
+1  ·           spans  /"a\x00"-    ·                  ·
 
 # Show that the primary key cannot be used with a PK predicate
 # outside of ordinalityNode.
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
 ----
-0  filter                          (x, "ordinality")  +x,unique
-1  ordinality                      (x, "ordinality")  +x,unique
-2  scan                            (x)                +x,unique
-2              table  foo@primary
-2              spans  ALL
+0  filter      ·      ·            (x, "ordinality")  +x,unique
+1  ordinality  ·      ·            (x, "ordinality")  +x,unique
+2  scan        ·      ·            (x)                +x,unique
+2  ·           table  foo@primary  ·                  ·
+2  ·           spans  ALL          ·                  ·

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -947,14 +947,14 @@ query TTTTTT colnames
 SELECT name, setting, category, short_desc, extra_desc, vartype FROM pg_catalog.pg_settings
 ----
 name                           setting       category  short_desc  extra_desc  vartype
-application_name                             NULL      NULL        NULL        string
+application_name               ·             NULL      NULL        NULL        string
 client_encoding                UTF8          NULL      NULL        NULL        string
-client_min_messages                          NULL      NULL        NULL        string
+client_min_messages            ·             NULL      NULL        NULL        string
 database                       test          NULL      NULL        NULL        string
 datestyle                      ISO           NULL      NULL        NULL        string
 default_transaction_isolation  SERIALIZABLE  NULL      NULL        NULL        string
 distsql                        off           NULL      NULL        NULL        string
-extra_float_digits                           NULL      NULL        NULL        string
+extra_float_digits             ·             NULL      NULL        NULL        string
 max_index_keys                 32            NULL      NULL        NULL        string
 node_id                        1             NULL      NULL        NULL        string
 search_path                    pg_catalog    NULL      NULL        NULL        string
@@ -971,14 +971,14 @@ query TTTTTTT colnames
 SELECT name, setting, unit, context, enumvals, boot_val, reset_val FROM pg_catalog.pg_settings
 ----
 name                           setting       unit  context  enumvals  boot_val      reset_val
-application_name                             NULL  user     NULL
+application_name               ·             NULL  user     NULL      ·             ·
 client_encoding                UTF8          NULL  user     NULL      UTF8          UTF8
-client_min_messages                          NULL  user     NULL
+client_min_messages            ·             NULL  user     NULL      ·             ·
 database                       test          NULL  user     NULL      test          test
 datestyle                      ISO           NULL  user     NULL      ISO           ISO
 default_transaction_isolation  SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
 distsql                        off           NULL  user     NULL      off           off
-extra_float_digits                           NULL  user     NULL
+extra_float_digits             ·             NULL  user     NULL      ·             ·
 max_index_keys                 32            NULL  user     NULL      32            32
 node_id                        1             NULL  user     NULL      1             1
 search_path                    pg_catalog    NULL  user     NULL      pg_catalog    pg_catalog

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -48,9 +48,9 @@ pg_constraint
 query ITTTTT
 EXPLAIN (TYPES) SELECT 'pg_constraint'::REGCLASS
 ----
-0  render                                        ("'pg_constraint'::REGCLASS" regclass)  ="'pg_constraint'::REGCLASS"
-0           render 0  (pg_constraint)[regclass]
-1  nullrow                                       ()
+0  render   ·         ·                          ("'pg_constraint'::REGCLASS" regclass)  ="'pg_constraint'::REGCLASS"
+0  ·        render 0  (pg_constraint)[regclass]  ·                                       ·
+1  nullrow  ·         ·                          ()                                      ·
 
 query OO
 SELECT '"pg_constraint"'::REGCLASS, '  "pg_constraint" '::REGCLASS

--- a/pkg/sql/logictest/testdata/logic_test/postgresjoin
+++ b/pkg/sql/logictest/testdata/logic_test/postgresjoin
@@ -1967,4 +1967,3 @@ DROP TABLE J1_TBL
 
 statement ok
 DROP TABLE J2_TBL
-

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -113,13 +113,13 @@ query ITTTTT colnames
 EXPLAIN (METADATA) ALTER TABLE t SPLIT AT SELECT k1,k2 FROM t ORDER BY k1 LIMIT 3
 ----
 Level  Type    Field  Description  Columns                           Ordering
-0      split                       (key, pretty)
-1      limit                       (k1, k2)                          +k1
-2      render                      (k1, k2)                          +k1
-3      scan                        (k1, k2, v[omitted], w[omitted])  +k1
-3              table  t@primary
-3              spans  ALL
-3              limit  3
+0      split   ·      ·            (key, pretty)                     ·
+1      limit   ·      ·            (k1, k2)                          +k1
+2      render  ·      ·            (k1, k2)                          +k1
+3      scan    ·      ·            (k1, k2, v[omitted], w[omitted])  +k1
+3      ·       table  t@primary    ·                                 ·
+3      ·       spans  ALL          ·                                 ·
+3      ·       limit  3            ·                                 ·
 
 # -- Tests with interleaved tables --
 

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -145,19 +145,19 @@ output row: [2]
 query ITTT
 EXPLAIN SELECT * FROM t x JOIN t y USING(b) WHERE x.b < '3'
 ----
-0  render
-1  join
-1              type      inner
-1              equality  (b) = (b)
-2  index-join
-3  scan
-3              table     t@bc
-3              spans     /#-/"3"
-3  scan
-3              table     t@primary
-2  scan
-2              table     t@primary
-2              spans     ALL
+0  render      ·         ·
+1  join        ·         ·
+1  ·           type      inner
+1  ·           equality  (b) = (b)
+2  index-join  ·         ·
+3  scan        ·         ·
+3  ·           table     t@bc
+3  ·           spans     /#-/"3"
+3  scan        ·         ·
+3  ·           table     t@primary
+2  scan        ·         ·
+2  ·           table     t@primary
+2  ·           spans     ALL
 
 statement ok
 TRUNCATE TABLE t
@@ -190,8 +190,8 @@ SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE a > 1 AND b > 'b']
 query ITTT
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
-0 render
-1 empty
+0  render  ·  ·
+1  empty   ·  ·
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b]
@@ -310,8 +310,8 @@ output row: [3 4]
 query ITTT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
-0 render
-1 empty
+0  render  ·  ·
+1  empty   ·  ·
 
 # Make sure that mixed type comparison operations are not used
 # for selecting indexes.
@@ -345,82 +345,82 @@ SELECT b FROM t WHERE c > 4.0 AND a < 4
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1
 ----
-0  render
-1  scan
-1        table  t@bc
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@bc
+1  ·       spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c < 1 AND b < 5
 ----
-0  render
-1  scan
-1        table  t@bc
-1        spans  /#-/4/1
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@bc
+1  ·       spans  /#-/4/1
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1.0
 ----
-0  render
-1  scan
-1        table  t@bc
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@bc
+1  ·       spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c < 1.0
 ----
-0  render
-1  scan
-1        table  t@bc
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@bc
+1  ·       spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE c > 1.0 AND b < 5
 ----
-0  render
-1  scan
-1        table  t@bc
-1        spans  /#-/5
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@bc
+1  ·       spans  /#-/5
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE b < 5.0 AND c < 1
 ----
-0  render
-1  scan
-1        table  t@bc
-1        spans  /#-/4/1
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@bc
+1  ·       spans  /#-/4/1
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5, 1)
 ----
-0  render
-1  scan
-1        table  t@bc
-1        spans  /5/1-/5/2
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@bc
+1  ·       spans  /5/1-/5/2
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.0, 1)
 ----
-0  render
-1  scan
-1        table  t@bc
-1        spans  /5/1-/5/2
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@bc
+1  ·       spans  /5/1-/5/2
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
 ----
-0  render
-1  scan
-1          table  t@bc
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@bc
+1  ·       spans  ALL
 
 query ITTT
 EXPLAIN SELECT a FROM t WHERE b IN (5.0, 1)
 ----
-0  render
-1  scan
-1        table  t@b_desc
-1        spans  /-6-/-5 /-2-/-1
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t@b_desc
+1  ·       spans  /-6-/-5 /-2-/-1
 
 statement ok
 CREATE TABLE abcd (
@@ -437,18 +437,18 @@ CREATE TABLE abcd (
 query ITTT
 EXPLAIN SELECT b FROM abcd WHERE (a, b) = (1, 4)
 ----
-0  render
-1  scan
-1        table  abcd@abcd
-1        spans  /1/4-/1/5
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@abcd
+1  ·       spans  /1/4-/1/5
 
 query ITTT
 EXPLAIN SELECT b FROM abcd WHERE (a, b) IN ((1, 4), (2, 9))
 ----
-0  render
-1  scan
-1        table  abcd@abcd
-1        spans  /1/4-/1/5 /2/9-/2/10
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@abcd
+1  ·       spans  /1/4-/1/5 /2/9-/2/10
 
 statement ok
 CREATE TABLE ab (
@@ -474,10 +474,10 @@ SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 query ITTT
 EXPLAIN SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 ----
-0  render
-1  scan
-1        table  ab@baz
-1        spans  /#-/1/"c"
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  ab@baz
+1  ·       spans  /#-/1/"c"
 
 # Check that primary key definitions can indicate index ordering,
 # and this information is subsequently used during index selection
@@ -494,22 +494,22 @@ abz    abz_c_b_key  true      3  a       ASC        false    true
 query ITTT
 EXPLAIN SELECT a FROM abz ORDER BY a DESC LIMIT 1
 ----
-0  limit
-1  render
-2  scan
-2          table  abz@primary
-2          spans  ALL
-2          limit            1
+0  limit   ·      ·
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  abz@primary
+2  ·       spans  ALL
+2  ·       limit  1
 
 query ITTT
 EXPLAIN SELECT c FROM abz ORDER BY c DESC LIMIT 1
 ----
-0  limit
-1  render
-2  scan
-2          table  abz@abz_c_b_key
-2          spans  ALL
-2          limit            1
+0  limit   ·      ·
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  abz@abz_c_b_key
+2  ·       spans  ALL
+2  ·       limit  1
 
 # Issue #14426: verify we don't have an internal filter that contains "a IN ()"
 # (which causes an error in DistSQL due to expression serialization).
@@ -523,12 +523,12 @@ CREATE TABLE tab0(
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
 ----
-0  render                                                  (k)
-0          render 0  test.tab0.k
-1  scan                                                    (k, a, b)
-1          table     tab0@primary
-1          spans     ALL
-1          filter    ((a IN (6)) AND (a > 6)) OR (b >= 4)
+0  render  ·         ·                                     (k)        ·
+0  ·       render 0  test.tab0.k                           ·          ·
+1  scan    ·         ·                                     (k, a, b)  ·
+1  ·       table     tab0@primary                          ·          ·
+1  ·       spans     ALL                                   ·          ·
+1  ·       filter    ((a IN (6)) AND (a > 6)) OR (b >= 4)  ·          ·
 
 query I
 SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
@@ -610,14 +610,14 @@ CREATE TABLE test2 (id BIGSERIAL PRIMARY KEY, k TEXT UNIQUE, v INT DEFAULT 42);
 query ITTT
 EXPLAIN SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20
 ----
-0  limit
-1  index-join
-2  revscan
-2             table  test2@test2_k_key
-2              spans  /#-/"100\x00"
-2              limit  20
-2  scan
-2              table  test2@primary
+0  limit       ·      ·
+1  index-join  ·      ·
+2  revscan     ·      ·
+2  ·           table  test2@test2_k_key
+2  ·           spans  /#-/"100\x00"
+2  ·           limit  20
+2  scan        ·      ·
+2  ·           table  test2@primary
 
 # Result check: The following query must not issue more than the
 # requested LIMIT K/V reads, even though an index join batches 100

--- a/pkg/sql/logictest/testdata/logic_test/select_index_hints
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_hints
@@ -25,9 +25,9 @@ SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
-0  scan
-0        table  abcd@primary
-0        spans  /20-/31
+0  scan  ·      ·
+0  ·     table  abcd@primary
+0  ·     spans  /20-/31
 
 # Force primary
 
@@ -40,9 +40,9 @@ SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
-0  scan
-0        table  abcd@primary
-0        spans  /20-/31
+0  scan  ·      ·
+0  ·     table  abcd@primary
+0  ·     spans  /20-/31
 
 # Force index b
 
@@ -55,12 +55,12 @@ SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-0  index-join
-1  scan
-1              table  abcd@b
-1              spans  ALL
-1  scan
-1              table  abcd@primary
+0  index-join  ·      ·
+1  scan        ·      ·
+1  ·           table  abcd@b
+1  ·           spans  ALL
+1  scan        ·      ·
+1  ·           table  abcd@primary
 
 # Force index cd
 
@@ -73,21 +73,21 @@ SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
-0  index-join
-1  scan
-1              table  abcd@cd
-1              spans  ALL
-1  scan
-1              table  abcd@primary
+0  index-join  ·      ·
+1  scan        ·      ·
+1  ·           table  abcd@cd
+1  ·           spans  ALL
+1  scan        ·      ·
+1  ·           table  abcd@primary
 
 # Force index bcd
 
 query ITTT
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
-0  scan
-0        table  abcd@bcd
-0        spans  ALL
+0  scan  ·      ·
+0  ·     table  abcd@bcd
+0  ·     spans  ALL
 
 query IIII rowsort
 SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
@@ -100,23 +100,23 @@ SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 query ITTT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-0  render
-1  scan
-1        table  abcd@b
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@b
+1  ·       spans  ALL
 
 # Force index b (non-covering due to WHERE clause)
 
 query ITTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
-0  render
-1  index-join
-2  scan
-2              table  abcd@b
-2              spans  ALL
-2  scan
-2              table  abcd@primary
+0  render      ·      ·
+1  index-join  ·      ·
+2  scan        ·      ·
+2  ·           table  abcd@b
+2  ·           spans  ALL
+2  scan        ·      ·
+2  ·           table  abcd@primary
 
 # No hint, should be using index cd
 
@@ -129,10 +129,10 @@ SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 query ITTT
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
-0  render
-1  scan
-1        table  abcd@cd
-1        spans  /20-/40
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@cd
+1  ·       spans  /20-/40
 
 # Force no index
 
@@ -145,10 +145,10 @@ SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 query ITTT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
-0  render
-1  scan
-1        table  abcd@primary
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@primary
+1  ·       spans  ALL
 
 # Force index b
 
@@ -161,13 +161,13 @@ SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 query ITTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
-0  render
-1  index-join
-2  scan
-2              table  abcd@b
-2              spans  ALL
-2  scan
-2              table  abcd@primary
+0  render      ·      ·
+1  index-join  ·      ·
+2  scan        ·      ·
+2  ·           table  abcd@b
+2  ·           spans  ALL
+2  scan        ·      ·
+2  ·           table  abcd@primary
 
 query error index \"badidx\" not found
 SELECT * FROM abcd@badidx
@@ -178,50 +178,50 @@ SELECT * FROM abcd@{FORCE_INDEX=badidx}
 query ITTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
-0  index-join
-1  scan
-1              table  abcd@b
-1              spans  ALL
-1  scan
-1              table  abcd@primary
+0  index-join  ·      ·
+1  scan        ·      ·
+1  ·           table  abcd@b
+1  ·           spans  ALL
+1  scan        ·      ·
+1  ·           table  abcd@primary
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
-0  render
-1  index-join
-2  scan
-2              table  abcd@cd
-2              spans  /10-/11
-2  scan
-2              table  abcd@primary
+0  render      ·      ·
+1  index-join  ·      ·
+2  scan        ·      ·
+2  ·           table  abcd@cd
+2  ·           spans  /10-/11
+2  scan        ·      ·
+2  ·           table  abcd@primary
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
-0  render
-1  scan
-1        table  abcd@bcd
-1        hint   no index join
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@bcd
+1  ·       hint   no index join
+1  ·       spans  ALL
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd,NO_INDEX_JOIN} WHERE c = 10
 ----
-0  render
-1  scan
-1        table  abcd@bcd
-1        hint   no index join
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@bcd
+1  ·       hint   no index join
+1  ·       spans  ALL
 
 query ITTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary,NO_INDEX_JOIN} WHERE c = 10
 ----
-0  render
-1  scan
-1        table  abcd@primary
-1        hint   no index join
-1        spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  abcd@primary
+1  ·       hint   no index join
+1  ·       spans  ALL
 
 query error index \"cd\" is not covering and NO_INDEX_JOIN was specified
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=cd,NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
@@ -57,12 +57,12 @@ ALTER INDEX c SPLIT AT VALUES (10)
 query ITTT
 EXPLAIN SELECT * FROM t WHERE (c >= 80) ORDER BY c
 ----
-0  index-join
-1  scan
-1              table  t@c
-1              spans  /80-
-1  scan
-1              table  t@primary
+0  index-join  ·      ·
+1  scan        ·      ·
+1  ·           table  t@c
+1  ·           spans  /80-
+1  scan        ·      ·
+1  ·           table  t@primary
 
 query IIII partialsort(3)
 SELECT * FROM t WHERE (c >= 80) ORDER BY c

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
@@ -20,12 +20,12 @@ INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 query ITTT
 EXPLAIN SELECT * FROM t WHERE b = 2
 ----
-0  index-join
-1  scan
-1              table  t@b
-1              spans  /2-/3
-1  scan
-1              table  t@primary
+0  index-join  ·      ·
+1  scan        ·      ·
+1  ·           table  t@b
+1  ·           spans  /2-/3
+1  scan        ·      ·
+1  ·           table  t@primary
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE b = 2]
@@ -46,12 +46,12 @@ SELECT * FROM t WHERE b = 2
 query ITTT
 EXPLAIN SELECT * FROM t WHERE c = 6
 ----
-0  index-join
-1  scan
-1              table  t@c
-1              spans  /6-/7
-1  scan
-1              table  t@primary
+0  index-join  ·      ·
+1  scan        ·      ·
+1  ·           table  t@c
+1  ·           spans  /6-/7
+1  scan        ·      ·
+1  ·           table  t@primary
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE c = 7]
@@ -72,12 +72,12 @@ SELECT * FROM t WHERE c = 7
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 ----
-0  index-join                    (a, b, c, d)                             -c,unique
-1  revscan                       (a, b[omitted], c[omitted], d[omitted])  -c,unique
-1              table  t@c
-1              spans  /1-
-1  scan                          (a, b, c, d)
-1              table  t@primary
+0  index-join  ·      ·          (a, b, c, d)                             -c,unique
+1  revscan     ·      ·          (a, b[omitted], c[omitted], d[omitted])  -c,unique
+1  ·           table  t@c        ·                                        ·
+1  ·           spans  /1-        ·                                        ·
+1  scan        ·      ·          (a, b, c, d)                             ·
+1  ·           table  t@primary  ·                                        ·
 
 query IIII
 SELECT * FROM t WHERE c > 0 ORDER BY c DESC
@@ -88,12 +88,12 @@ SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 query ITTT
 EXPLAIN SELECT * FROM t WHERE c > 0 ORDER BY c
 ----
-0  index-join
-1  scan
-1              table  t@c
-1              spans  /1-
-1  scan
-1              table  t@primary
+0  index-join  ·      ·
+1  scan        ·      ·
+1  ·           table  t@c
+1  ·           spans  /1-
+1  scan        ·      ·
+1  ·           table  t@primary
 
 query IIII
 SELECT * FROM t WHERE c > 0 AND d = 8
@@ -103,12 +103,12 @@ SELECT * FROM t WHERE c > 0 AND d = 8
 query ITTT
 EXPLAIN SELECT * FROM t WHERE c > 0 AND d = 8
 ----
-0  index-join
-1  scan
-1              table  t@c
-1              spans  /1-
-1  scan
-1              table  t@primary
+0  index-join  ·      ·
+1  scan        ·      ·
+1  ·           table  t@c
+1  ·           spans  /1-
+1  scan        ·      ·
+1  ·           table  t@primary
 
 # The following testcases verify that when we have a small limit, we prefer an
 # order-matching index.
@@ -116,57 +116,57 @@ EXPLAIN SELECT * FROM t WHERE c > 0 AND d = 8
 query ITTT
 EXPLAIN SELECT * FROM t ORDER BY c
 ----
-0  sort
-0        order  +c
-1  scan
-1        table  t@primary
-1        spans  ALL
+0  sort  ·      ·
+0  ·     order  +c
+1  scan  ·      ·
+1  ·     table  t@primary
+1  ·     spans  ALL
 
 query ITTT
 EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5
 ----
-0  limit
-1  index-join
-2  scan
-2              table  t@c
-2              spans  ALL
-2              limit  5
-2  scan
-2              table  t@primary
+0  limit       ·      ·
+1  index-join  ·      ·
+2  scan        ·      ·
+2  ·           table  t@c
+2  ·           spans  ALL
+2  ·           limit  5
+2  scan        ·      ·
+2  ·           table  t@primary
 
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c OFFSET 5
 ----
-0  limit
-0         offset    5
-1  sort
-1         order     +c
-2  scan
-2         table     t@primary
-2         spans     ALL
+0  limit  ·       ·
+0  ·      offset  5
+1  sort   ·       ·
+1  ·      order   +c
+2  scan   ·       ·
+2  ·      table   t@primary
+2  ·      spans   ALL
 
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
 ----
-0  limit
-0              count     5
-0              offset    5
-1  index-join
-2  scan
-2              table     t@c
-2              spans     ALL
-2              limit     10
-2  scan
-2              table     t@primary
+0  limit       ·       ·
+0  ·           count   5
+0  ·           offset  5
+1  index-join  ·       ·
+2  scan        ·       ·
+2  ·           table   t@c
+2  ·           spans   ALL
+2  ·           limit   10
+2  scan        ·       ·
+2  ·           table   t@primary
 
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c LIMIT 1000000
 ----
-0  limit
-0          count     1000000
-1  sort
-1          order     +c
-1          strategy  top 1000000
-2  scan
-2          table     t@primary
-2          spans     ALL
+0  limit  ·         ·
+0  ·      count     1000000
+1  sort   ·         ·
+1  ·      order     +c
+1  ·      strategy  top 1000000
+2  scan   ·         ·
+2  ·      table     t@primary
+2  ·      spans     ALL

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
@@ -32,13 +32,13 @@ INSERT INTO t VALUES
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM t WHERE b = 2 AND c % 2 = 0
 ----
-0  index-join
-1  scan
-1                 table     t@bc
-1                 spans     /2-/3
-1                 filter    (c % 2) = 0
-1  scan
-1                 table     t@primary
+0  index-join  ·       ·
+1  scan        ·       ·
+1  ·           table   t@bc
+1  ·           spans   /2-/3
+1  ·           filter  (c % 2) = 0
+1  scan        ·       ·
+1  ·           table   t@primary
 
 # We do NOT look up the table row for '21' and '23'.
 query T
@@ -57,13 +57,13 @@ output row: [5 2 2 '22']
 query ITTT
 EXPLAIN (EXPRS) SELECT * FROM t WHERE b = 2 AND c != b
 ----
-0  index-join
-1  scan
-1                 table     t@bc
-1                 spans     /2-/3
-1                 filter    c != b
-1  scan
-1                 table     t@primary
+0  index-join  ·       ·
+1  scan        ·       ·
+1  ·           table   t@bc
+1  ·           spans   /2-/3
+1  ·           filter  c != b
+1  scan        ·       ·
+1  ·           table   t@primary
 
 # We do NOT look up the table row for '22'.
 query T
@@ -134,14 +134,14 @@ output row: [9 3 3 '33']
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
 ----
-0  render                           (a)
-0              render 0  test.t.a
-1  index-join                       (a, b[omitted], c[omitted], s[omitted])
-2  scan                             (a, b[omitted], c[omitted], s[omitted])
-2              table     t@bc
-2              spans     /2-/3
-2  scan                             (a, b[omitted], c[omitted], s[omitted])
-2              table     t@primary
+0  render      ·         ·          (a)                                      ·
+0  ·           render 0  test.t.a   ·                                        ·
+1  index-join  ·         ·          (a, b[omitted], c[omitted], s[omitted])  ·
+2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  ·
+2  ·           table     t@bc       ·                                        ·
+2  ·           spans     /2-/3      ·                                        ·
+2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  ·
+2  ·           table     t@primary  ·                                        ·
 
 query I rowsort
 SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -39,6 +39,7 @@ query T colnames
 SHOW DATABASE
 ----
 database
+·
 
 
 statement error no database specified
@@ -78,12 +79,12 @@ SHOW ALL
 ----
 application_name               helloworld
 client_encoding                UTF8
-client_min_messages
+client_min_messages            ·
 database                       foo
 datestyle                      ISO
 default_transaction_isolation  SERIALIZABLE
 distsql                        off
-extra_float_digits
+extra_float_digits             ·
 max_index_keys                 32
 node_id                        1
 search_path                    pg_catalog

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -20,14 +20,14 @@ query TT colnames
 SELECT * FROM [SHOW ALL]
 ----
 variable                       value
-application_name
+application_name               ·
 client_encoding                UTF8
-client_min_messages
+client_min_messages            ·
 database                       test
 datestyle                      ISO
 default_transaction_isolation  SERIALIZABLE
 distsql                        off
-extra_float_digits
+extra_float_digits             ·
 max_index_keys                 32
 node_id                        1
 search_path                    pg_catalog
@@ -50,7 +50,7 @@ query TTTT colnames
 SELECT * FROM [SHOW ALL CLUSTER SETTINGS] WHERE name != 'diagnostics.reporting.enabled'
 ----
 name                                               current_value  type  description
-cluster.organization                                              s     organization name
+cluster.organization                               ·              s     organization name
 diagnostics.reporting.interval                     1h0m0s         d     interval at which diagnostics data should be reported
 diagnostics.reporting.report_metrics               true           b     enable collection and reporting diagnostic metrics to cockroach labs
 diagnostics.reporting.send_crash_reports           true           b     send crash and panic reports
@@ -76,8 +76,8 @@ sql.trace.log_statement_execute                    false          b     set to t
 sql.trace.session_eventlog.enabled                 false          b     set to true to enable session tracing
 sql.trace.txn.enable_threshold                     0s             d     duration beyond which all transactions are traced (set to 0 to disable)
 trace.debug.enable                                 false          b     if set, traces for recent requests can be seen in the /debug page
-trace.lightstep.token                                             s     if set, traces go to Lightstep using this token
-trace.zipkin.collector                                            s     if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.
+trace.lightstep.token                              ·              s     if set, traces go to Lightstep using this token
+trace.zipkin.collector                             ·              s     if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.
 
 
 
@@ -146,8 +146,8 @@ zones
 query ITTTT colnames
 SELECT node_id,username,application_name,active_queries,kv_txn FROM [SHOW SESSIONS]
 ----
-node_id   username   application_name  active_queries                                                                                       kv_txn
-1         root                         SELECT node_id, username, application_name, active_queries, kv_txn FROM [SHOW CLUSTER SESSIONS];     NULL
+node_id  username  application_name  active_queries                                                                                     kv_txn
+1        root      ·                 SELECT node_id, username, application_name, active_queries, kv_txn FROM [SHOW CLUSTER SESSIONS];   NULL
 
 query ITT colnames
 SELECT node_id, username, query FROM [SHOW QUERIES]

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -98,17 +98,17 @@ query TT colnames
 SELECT key,flags FROM crdb_internal.node_statement_statistics WHERE application_name = 'valuetest' ORDER BY key, flags
 ----
 key                                                      flags
-INSERT INTO test VALUES (_, _, _)
-SELECT ROW(_, _, _, _, _) FROM test WHERE _
-SELECT key FROM crdb_internal.node_statement_statistics
-SELECT sin(_)
+INSERT INTO test VALUES (_, _, _)                        ·
+SELECT ROW(_, _, _, _, _) FROM test WHERE _              ·
+SELECT key FROM crdb_internal.node_statement_statistics  ·
+SELECT sin(_)                                            ·
 SELECT sqrt(-_)                                          !
-SELECT x FROM (VALUES (_, _, _)) AS t (x)
+SELECT x FROM (VALUES (_, _, _)) AS t (x)                ·
 SELECT x FROM test WHERE y = (_ / z)                     !+
-SELECT x FROM test WHERE y IN (_, _)
+SELECT x FROM test WHERE y IN (_, _)                     ·
 SELECT x FROM test WHERE y IN (_, _)                     +
-SELECT x FROM test WHERE y IN (_, _, _ + x, _, _)
-SELECT x FROM test WHERE y NOT IN (_, _)
+SELECT x FROM test WHERE y IN (_, _, _ + x, _, _)        ·
+SELECT x FROM test WHERE y NOT IN (_, _)                 ·
 
 # Check that names are anonymized properly:
 # - virtual table names are preserved

--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -101,10 +101,10 @@ DELETE FROM t14601 WHERE a > 'a' AND a < 'c'
 query ITTT
 EXPLAIN SELECT a FROM t14601 ORDER BY a
 ----
-0  render
-1  scan
-1          table  t14601@i14601
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t14601@i14601
+1  ·       spans  ALL
 
 query T
 SELECT a FROM t14601 ORDER BY a
@@ -148,10 +148,10 @@ UPDATE t14601a SET b = NOT b WHERE a > 'a' AND a < 'c'
 query ITTT
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
-0  render
-1  scan
-1          table  t14601a@i14601a
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t14601a@i14601a
+1  ·       spans  ALL
 
 query TB
 SELECT a, b FROM t14601a ORDER BY a
@@ -188,10 +188,10 @@ UPDATE t14601a SET b = NOT b WHERE a > 'a' AND a < 'c'
 query ITTT
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
-0  render
-1  scan
-1          table  t14601a@i14601a
-1          spans  ALL
+0  render  ·      ·
+1  scan    ·      ·
+1  ·       table  t14601a@i14601a
+1  ·       spans  ALL
 
 query TB
 SELECT a, b FROM t14601a ORDER BY a

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -45,13 +45,13 @@ INSERT INTO abc VALUES (1, 2, 3), (4, 5, 6)
 query ITTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
-0  split
-1  values
-1           size        1 column, 1 row
-1           subqueries  1
-2  limit
-3  render
-4  nullrow
+0  split    ·           ·
+1  values   ·           ·
+1  ·        size        1 column, 1 row
+1  ·        subqueries  1
+2  limit    ·           ·
+3  render   ·           ·
+4  nullrow  ·           ·
 
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
@@ -78,14 +78,14 @@ SELECT (SELECT a FROM abc)
 query ITTT
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
-0  render
-0           subqueries  1
-1  limit
-2  render
-3  scan
-3           table       abc@primary
-3           spans       ALL
-1  nullrow
+0  render   ·           ·
+0  ·        subqueries  1
+1  limit    ·           ·
+2  render   ·           ·
+3  scan     ·           ·
+3  ·        table       abc@primary
+3  ·        spans       ALL
+1  nullrow  ·           ·
 
 query I
 SELECT (SELECT a FROM abc WHERE false)
@@ -288,10 +288,10 @@ foo1 moo2 moo3
 query ITTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
 ----
-0  sort
-0          order  +foo1
-1  values
-1          size   3 columns, 3 rows
+0  sort    ·      ·
+0  ·       order  +foo1
+1  values  ·      ·
+1  ·       size   3 columns, 3 rows
 
 query II colnames
 SELECT a, b FROM (VALUES (1, 2, 3), (3, 4, 7), (5, 6, 10)) AS foo (a, b, c) WHERE a + b = c
@@ -342,15 +342,15 @@ true
 query ITTTTT
 EXPLAIN (METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
 ----
-0  render                           (x)
-1  scan                             (x, y[omitted], z[omitted])
-1          table       xyz@primary
-1          spans       ALL
-1          subqueries  1
-2  render                           (x)
-3  scan                             (x, y[omitted], z[omitted])
-3          table       xyz@primary
-3          spans       ALL
+0  render  ·           ·            (x)                          ·
+1  scan    ·           ·            (x, y[omitted], z[omitted])  ·
+1  ·       table       xyz@primary  ·                            ·
+1  ·       spans       ALL          ·                            ·
+1  ·       subqueries  1            ·                            ·
+2  render  ·           ·            (x)                          ·
+3  scan    ·           ·            (x, y[omitted], z[omitted])  ·
+3  ·       table       xyz@primary  ·                            ·
+3  ·       spans       ALL          ·                            ·
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not
@@ -371,20 +371,20 @@ SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col
 query ITTT
 EXPLAIN SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-0  render
-1  index-join
-2  scan
-2              table       tab4@idx_tab4_0
-2              spans       /#-/5.38/1
-2              subqueries  1
-3  render
-4  scan
-4              table       tab4@primary
-4              spans       ALL
-2  scan
-2              table       tab4@primary
-2              subqueries  1
-3  render
-4  scan
-4              table       tab4@primary
-4              spans       ALL
+0  render      ·           ·
+1  index-join  ·           ·
+2  scan        ·           ·
+2  ·           table       tab4@idx_tab4_0
+2  ·           spans       /#-/5.38/1
+2  ·           subqueries  1
+3  render      ·           ·
+4  scan        ·           ·
+4  ·           table       tab4@primary
+4  ·           spans       ALL
+2  scan        ·           ·
+2  ·           table       tab4@primary
+2  ·           subqueries  1
+3  render      ·           ·
+4  scan        ·           ·
+4  ·           table       tab4@primary
+4  ·           spans       ALL

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -146,28 +146,28 @@ SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 
 query ITTT rowsort
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
-0  union
-1  render
-2  scan
-2          table  uniontest@primary
-2          spans  ALL
-1  render
-2  scan
-2          table  uniontest@primary
-2          spans  ALL
+0  union   ·      ·
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  uniontest@primary
+2  ·       spans  ALL
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  uniontest@primary
+2  ·       spans  ALL
 
 query ITTT rowsort
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
-0  append
-1  render
-2  scan
-2          table  uniontest@primary
-2          spans  ALL
-1  render
-2  scan
-2          table  uniontest@primary
-2          spans  ALL
+0  append  ·      ·
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  uniontest@primary
+2  ·       spans  ALL
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  uniontest@primary
+2  ·       spans  ALL
 
 query II
 SELECT * FROM (SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1);
@@ -204,9 +204,9 @@ SELECT 1 UNION SELECT 3 ORDER BY z
 query ITTT
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
-0  union
-1  render
-2  values
-2          size  3 columns, 5 rows
-1  values
-1          size  1 column, 1 row
+0  union   ·     ·
+1  render  ·     ·
+2  values  ·     ·
+2  ·       size  3 columns, 5 rows
+1  values  ·     ·
+1  ·       size  1 column, 1 row

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -336,44 +336,44 @@ SELECT * from xyz
 query ITTT
 EXPLAIN UPDATE xyz SET y = x
 ----
-0  update
-0         table  xyz
-0         set    y
-1  scan
-1         table  xyz@primary
-1         spans  ALL
+0  update  ·      ·
+0  ·       table  xyz
+0  ·       set    y
+1  scan    ·      ·
+1  ·       table  xyz@primary
+1  ·       spans  ALL
 
 query ITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (1, 2)
 ----
-0  update                      ()
-0          table  xyz
-0          set    x, y
-1  render                      (x, y, z, "1", "2")  ="1",="2"
-2  scan                        (x, y, z)
-2          table  xyz@primary
-2          spans  ALL
+0  update  ·      ·            ()                   ·
+0  ·       table  xyz          ·                    ·
+0  ·       set    x, y         ·                    ·
+1  render  ·      ·            (x, y, z, "1", "2")  ="1",="2"
+2  scan    ·      ·            (x, y, z)            ·
+2  ·       table  xyz@primary  ·                    ·
+2  ·       spans  ALL          ·                    ·
 
 query ITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (y, x)
 ----
-0  update                      ()
-0          table  xyz
-0          set    x, y
-1  scan                        (x, y, z)
-1          table  xyz@primary
-1          spans  ALL
+0  update  ·      ·            ()         ·
+0  ·       table  xyz          ·          ·
+0  ·       set    x, y         ·          ·
+1  scan    ·      ·            (x, y, z)  ·
+1  ·       table  xyz@primary  ·          ·
+1  ·       spans  ALL          ·          ·
 
 query ITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (2, 2)
 ----
-0  update                      ()
-0          table  xyz
-0          set    x, y
-1  render                      (x, y, z, "2")  ="2"
-2  scan                        (x, y, z)
-2          table  xyz@primary
-2          spans  ALL
+0  update  ·      ·            ()              ·
+0  ·       table  xyz          ·               ·
+0  ·       set    x, y         ·               ·
+1  render  ·      ·            (x, y, z, "2")  ="2"
+2  scan    ·      ·            (x, y, z)       ·
+2  ·       table  xyz@primary  ·               ·
+2  ·       spans  ALL          ·               ·
 
 statement ok
 CREATE TABLE lots (

--- a/pkg/sql/logictest/testdata/logic_test/values
+++ b/pkg/sql/logictest/testdata/logic_test/values
@@ -31,9 +31,9 @@ VALUES ((SELECT 1)), ((SELECT 2))
 query ITTT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
-0  values
-0           size        1 column, 2 rows
-0           subqueries  1
-1  limit
-2  render
-3  nullrow
+0  values   ·           ·
+0  ·        size        1 column, 2 rows
+0  ·        subqueries  1
+1  limit    ·           ·
+2  render   ·           ·
+3  nullrow  ·           ·

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -476,13 +476,13 @@ SELECT k, max(stddev) OVER (ORDER BY d DESC) FROM (SELECT k, d, stddev(d) OVER (
 query ITTT
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-0  sort
-0          order  +"variance(d) OVER w",+k
-1  window
-2  render
-3  scan
-3          table  kv@primary
-3          spans  ALL
+0  sort    ·      ·
+0  ·       order  +"variance(d) OVER w",+k
+1  window  ·      ·
+2  render  ·      ·
+3  scan    ·      ·
+3  ·       table  kv@primary
+3  ·       spans  ALL
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k]
@@ -515,135 +515,135 @@ output row: [8 3.5355339059327376220]
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-0  sort                                                        (k int, "stddev(d) OVER w" decimal)
-0          order     +"variance(d) OVER w",+k
-1  window                                                      (k int, "stddev(d) OVER w" decimal, "variance(d) OVER w" decimal)
-1          window 0  (stddev((d)[decimal]) OVER w)[decimal]
-1          window 1  (variance((d)[decimal]) OVER w)[decimal]
-1          render 1  (stddev((d)[decimal]) OVER w)[decimal]
-1          render 2  (variance((d)[decimal]) OVER w)[decimal]
-2  render                                                      (k int, d decimal, d decimal, v int)
-2          render 0  (k)[int]
-2          render 1  (d)[decimal]
-2          render 2  (d)[decimal]
-2          render 3  (v)[int]
-3  scan                                                        (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
-3          table     kv@primary
-3          spans     ALL
+0  sort    ·         ·                                         (k int, "stddev(d) OVER w" decimal)                                                              ·
+0  ·       order     +"variance(d) OVER w",+k                  ·                                                                                                ·
+1  window  ·         ·                                         (k int, "stddev(d) OVER w" decimal, "variance(d) OVER w" decimal)                                ·
+1  ·       window 0  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
+1  ·       window 1  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
+1  ·       render 1  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
+1  ·       render 2  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
+2  render  ·         ·                                         (k int, d decimal, d decimal, v int)                                                             ·
+2  ·       render 0  (k)[int]                                  ·                                                                                                ·
+2  ·       render 1  (d)[decimal]                              ·                                                                                                ·
+2  ·       render 2  (d)[decimal]                              ·                                                                                                ·
+2  ·       render 3  (v)[int]                                  ·                                                                                                ·
+3  scan    ·         ·                                         (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  ·
+3  ·       table     kv@primary                                ·                                                                                                ·
+3  ·       spans     ALL                                       ·                                                                                                ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  sort                                                                                           (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-0          order     +"variance(d) OVER (PARTITION BY v, 100)",+k
-1  window                                                                                         (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
-1          window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-1          window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-1          render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-1          render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-2  render                                                                                         (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                              ="'a'",="100"
-2          render 0  (k)[int]
-2          render 1  (d)[decimal]
-2          render 2  (d)[decimal]
-2          render 3  (v)[int]
-2          render 4  ('a')[string]
-2          render 5  (100)[int]
-3  scan                                                                                           (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
-3          table     kv@primary
-3          spans     ALL
+0  sort    ·         ·                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    ·
+0  ·       order     +"variance(d) OVER (PARTITION BY v, 100)",+k                                 ·                                                                                                          ·
+1  window  ·         ·                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)  ·
+1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                          ·
+1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                          ·
+1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                          ·
+1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                          ·
+2  render  ·         ·                                                                            (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                              ="'a'",="100"
+2  ·       render 0  (k)[int]                                                                     ·                                                                                                          ·
+2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                          ·
+2  ·       render 2  (d)[decimal]                                                                 ·                                                                                                          ·
+2  ·       render 3  (v)[int]                                                                     ·                                                                                                          ·
+2  ·       render 4  ('a')[string]                                                                ·                                                                                                          ·
+2  ·       render 5  (100)[int]                                                                   ·                                                                                                          ·
+3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)            ·
+3  ·       table     kv@primary                                                                   ·                                                                                                          ·
+3  ·       spans     ALL                                                                          ·                                                                                                          ·
 
 query ITTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
-0  sort                                                                                           (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          +k
-0          order     +k
-1  window                                                                                         (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-1          window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-1          render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-2  render                                                                                         (k int, d decimal, v int, "'a'" string)                                                          ="'a'"
-2          render 0  (k)[int]
-2          render 1  (d)[decimal]
-2          render 2  (v)[int]
-2          render 3  ('a')[string]
-3  scan                                                                                           (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
-3          table     kv@primary
-3          spans     ALL
+0  sort    ·         ·                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          +k
+0  ·       order     +k                                                                           ·                                                                                                ·
+1  window  ·         ·                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          ·
+1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+2  render  ·         ·                                                                            (k int, d decimal, v int, "'a'" string)                                                          ="'a'"
+2  ·       render 0  (k)[int]                                                                     ·                                                                                                ·
+2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                ·
+2  ·       render 2  (v)[int]                                                                     ·                                                                                                ·
+2  ·       render 3  ('a')[string]                                                                ·                                                                                                ·
+3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  ·
+3  ·       table     kv@primary                                                                   ·                                                                                                ·
+3  ·       spans     ALL                                                                          ·                                                                                                ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  sort                                                                                                                 (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-0          order     +"variance(d) OVER (PARTITION BY v, 100)",+k
-1  window                                                                                                               (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
-1          window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-1          window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-1          render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]
-1          render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-2  render                                                                                                               (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                                  ="'a'",="100"
-2          render 0  (k)[int]
-2          render 1  (d)[decimal]
-2          render 2  (d)[decimal]
-2          render 3  (v)[int]
-2          render 4  ('a')[string]
-2          render 5  (100)[int]
-3  scan                                                                                                                 (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
-3          table     kv@primary
-3          spans     ALL
+0  sort    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    ·
+0  ·       order     +"variance(d) OVER (PARTITION BY v, 100)",+k                                                       ·                                                                                                              ·
+1  window  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)  ·
+1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                        ·                                                                                                              ·
+1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                              ·
+1  ·       render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                              ·
+1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                              ·
+2  render  ·         ·                                                                                                  (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                                  ="'a'",="100"
+2  ·       render 0  (k)[int]                                                                                           ·                                                                                                              ·
+2  ·       render 1  (d)[decimal]                                                                                       ·                                                                                                              ·
+2  ·       render 2  (d)[decimal]                                                                                       ·                                                                                                              ·
+2  ·       render 3  (v)[int]                                                                                           ·                                                                                                              ·
+2  ·       render 4  ('a')[string]                                                                                      ·                                                                                                              ·
+2  ·       render 5  (100)[int]                                                                                         ·                                                                                                              ·
+3  scan    ·         ·                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                ·
+3  ·       table     kv@primary                                                                                         ·                                                                                                              ·
+3  ·       spans     ALL                                                                                                ·                                                                                                              ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
-0  sort                                                                                                                                ("max(k)" int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-0          order        +"variance(d) OVER (PARTITION BY v, 100)"
-1  window                                                                                                                              ("max(k)" int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)
-1          window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-1          window 1     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-1          render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]
-1          render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]
-2  render                                                                                                                              ("max(k)" int, d decimal, d decimal, v int, "'a'" string, "100" int)                                                       ="'a'",="100"
-2          render 0     ("max(k)")[int]
-2          render 1     (d)[decimal]
-2          render 2     (d)[decimal]
-2          render 3     (v)[int]
-2          render 4     ('a')[string]
-2          render 5     (100)[int]
-3  group                                                                                                                               ("max(k)" int, d decimal, d decimal, v int)
-3          aggregate 0  (max((k)[int]))[int]
-3          aggregate 1  (d)[decimal]
-3          aggregate 2  (d)[decimal]
-3          aggregate 3  (v)[int]
-4  render                                                                                                                              (d decimal, v int, k int)
-4          render 0     (d)[decimal]
-4          render 1     (v)[int]
-4          render 2     (k)[int]
-5  scan                                                                                                                                (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
-5          table        kv@primary
-5          spans        ALL
+0  sort    ·            ·                                                                                                              ("max(k)" int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    ·
+0  ·       order        +"variance(d) OVER (PARTITION BY v, 100)"                                                                      ·                                                                                                                          ·
+1  window  ·            ·                                                                                                              ("max(k)" int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)  ·
+1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                                    ·                                                                                                                          ·
+1  ·       window 1     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                                          ·
+1  ·       render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                                          ·
+1  ·       render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                                          ·
+2  render  ·            ·                                                                                                              ("max(k)" int, d decimal, d decimal, v int, "'a'" string, "100" int)                                                       ="'a'",="100"
+2  ·       render 0     ("max(k)")[int]                                                                                                ·                                                                                                                          ·
+2  ·       render 1     (d)[decimal]                                                                                                   ·                                                                                                                          ·
+2  ·       render 2     (d)[decimal]                                                                                                   ·                                                                                                                          ·
+2  ·       render 3     (v)[int]                                                                                                       ·                                                                                                                          ·
+2  ·       render 4     ('a')[string]                                                                                                  ·                                                                                                                          ·
+2  ·       render 5     (100)[int]                                                                                                     ·                                                                                                                          ·
+3  group   ·            ·                                                                                                              ("max(k)" int, d decimal, d decimal, v int)                                                                                ·
+3  ·       aggregate 0  (max((k)[int]))[int]                                                                                           ·                                                                                                                          ·
+3  ·       aggregate 1  (d)[decimal]                                                                                                   ·                                                                                                                          ·
+3  ·       aggregate 2  (d)[decimal]                                                                                                   ·                                                                                                                          ·
+3  ·       aggregate 3  (v)[int]                                                                                                       ·                                                                                                                          ·
+4  render  ·            ·                                                                                                              (d decimal, v int, k int)                                                                                                  ·
+4  ·       render 0     (d)[decimal]                                                                                                   ·                                                                                                                          ·
+4  ·       render 1     (v)[int]                                                                                                       ·                                                                                                                          ·
+4  ·       render 2     (k)[int]                                                                                                       ·                                                                                                                          ·
+5  scan    ·            ·                                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                            ·
+5  ·       table        kv@primary                                                                                                     ·                                                                                                                          ·
+5  ·       spans        ALL                                                                                                            ·                                                                                                                          ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT MAX(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
 ----
-0  sort                                                                                              ("max(k)" int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                   +"max(k)"
-0          order        +"max(k)"
-1  window                                                                                            ("max(k)" int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)
-1          window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-1          render 1     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]
-2  render                                                                                            ("max(k)" int, d decimal, v int, "'a'" string)                                                   ="'a'"
-2          render 0     ("max(k)")[int]
-2          render 1     (d)[decimal]
-2          render 2     (v)[int]
-2          render 3     ('a')[string]
-3  group                                                                                             ("max(k)" int, d decimal, v int)
-3          aggregate 0  (max((k)[int]))[int]
-3          aggregate 1  (d)[decimal]
-3          aggregate 2  (v)[int]
-4  render                                                                                            (d decimal, v int, k int)
-4          render 0     (d)[decimal]
-4          render 1     (v)[int]
-4          render 2     (k)[int]
-5  scan                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)
-5          table        kv@primary
-5          spans        ALL
+0  sort    ·            ·                                                                            ("max(k)" int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                   +"max(k)"
+0  ·       order        +"max(k)"                                                                    ·                                                                                                ·
+1  window  ·            ·                                                                            ("max(k)" int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                   ·
+1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+1  ·       render 1     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+2  render  ·            ·                                                                            ("max(k)" int, d decimal, v int, "'a'" string)                                                   ="'a'"
+2  ·       render 0     ("max(k)")[int]                                                              ·                                                                                                ·
+2  ·       render 1     (d)[decimal]                                                                 ·                                                                                                ·
+2  ·       render 2     (v)[int]                                                                     ·                                                                                                ·
+2  ·       render 3     ('a')[string]                                                                ·                                                                                                ·
+3  group   ·            ·                                                                            ("max(k)" int, d decimal, v int)                                                                 ·
+3  ·       aggregate 0  (max((k)[int]))[int]                                                         ·                                                                                                ·
+3  ·       aggregate 1  (d)[decimal]                                                                 ·                                                                                                ·
+3  ·       aggregate 2  (v)[int]                                                                     ·                                                                                                ·
+4  render  ·            ·                                                                            (d decimal, v int, k int)                                                                        ·
+4  ·       render 0     (d)[decimal]                                                                 ·                                                                                                ·
+4  ·       render 1     (v)[int]                                                                     ·                                                                                                ·
+4  ·       render 2     (k)[int]                                                                     ·                                                                                                ·
+5  scan    ·            ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  ·
+5  ·       table        kv@primary                                                                   ·                                                                                                ·
+5  ·       spans        ALL                                                                          ·                                                                                                ·
 
 statement OK
 INSERT INTO kv VALUES


### PR DESCRIPTION
Right now empty string values are not rendered as [documentation](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki) suggests:

> In the results section, integer values are rendered as if by printf("%d"). Floating point values are rendered as if by printf("%.3f"). NULL values are rendered as "NULL". Empty strings are rendered as "(empty)". Within non-empty strings, all control characters and unprintable characters are rendered as "@".

Some problems arise with empty strings. Sometimes empty string is not added to the row (while parsing test file and query result), and sorting sorts "interleaved" rows instead (because it expects 5 columns and get only 4 thus taking 1 element from neighbor row). Simple fix solves that but requires to rewrite logictest files.

This PR renders empty strings with "(empty)" and modifies all logic test files to make tests pass.

Closes #17134.