### PR TITLE
vendor: bump grpc to 1.5.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -643,8 +643,8 @@
 [[projects]]
   name = "google.golang.org/grpc"
   packages = [".","codes","credentials","credentials/oauth","grpclb/grpc_lb_v1","grpclog","internal","keepalive","metadata","naming","peer","stats","status","tap","transport"]
-  revision = "d8960bd63c6743defa6d54926e5edfa8e4a28e43"
-  version = "v1.4.0"
+  revision = "172ccacff3cfbddedcf1ba5ea06cda943bc976c1"
+  version = "v1.5.0"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
@@ -659,6 +659,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "09a9217496fab13afb4b353178d58311dc7262b4e28ef300849786a7aba7b40f"
+  inputs-digest = "7da157eca498fe957e185931fe43036e08ed977ae4abd7fe9a7cac5ac001a465"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -426,6 +426,12 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 		RPCContext := newInsecureRPCContext(stopper)
 
 		server := rpc.NewServer(RPCContext)
+		// node ID must be non-zero
+		gnode := NewTest(
+			roachpb.NodeID(i+1), RPCContext, server, stopper, metric.NewRegistry(),
+		)
+		g = append(g, gnode)
+
 		ln, err := netutil.ListenAndServeGRPC(stopper, server, util.IsolatedTestAddr)
 		if err != nil {
 			t.Fatal(err)
@@ -442,11 +448,6 @@ func TestClientRegisterWithInitNodeID(t *testing.T) {
 			t.Fatal(err)
 		}
 		resolvers = append(resolvers, resolver)
-		// node ID must be non-zero
-		gnode := NewTest(
-			roachpb.NodeID(i+1), RPCContext, server, stopper, metric.NewRegistry(),
-		)
-		g = append(g, gnode)
 		gnode.Start(ln.Addr(), resolvers)
 	}
 

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -309,6 +309,9 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 			// Do the pings even when there are no ongoing RPCs.
 			PermitWithoutStream: true,
 		}))
+		dialOpts = append(dialOpts,
+			grpc.WithInitialWindowSize(initialWindowSize),
+			grpc.WithInitialConnWindowSize(initialConnWindowSize))
 		dialOpts = append(dialOpts, opts...)
 
 		if SourceAddr != nil {

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -763,6 +763,11 @@ func (m *multiTestContext) addStore(idx int) {
 		}
 	}
 
+	sender := storage.NewStores(ambient, clock)
+	sender.AddStore(store)
+	storesServer := storage.MakeServer(&roachpb.NodeDescriptor{NodeID: nodeID}, sender)
+	storage.RegisterConsistencyServer(grpcServer, storesServer)
+
 	ln, err := netutil.ListenAndServeGRPC(m.transportStopper, grpcServer, util.TestAddr)
 	if err != nil {
 		m.t.Fatal(err)
@@ -779,11 +784,6 @@ func (m *multiTestContext) addStore(idx int) {
 	if ok {
 		m.t.Fatalf("node %d already listening", nodeID)
 	}
-
-	sender := storage.NewStores(ambient, clock)
-	sender.AddStore(store)
-	storesServer := storage.MakeServer(m.nodeDesc(nodeID), sender)
-	storage.RegisterConsistencyServer(grpcServer, storesServer)
 
 	// Add newly created objects to the multiTestContext's collections.
 	// (these must be populated before the store is started so that

--- a/pkg/storage/raft_transport_test.go
+++ b/pkg/storage/raft_transport_test.go
@@ -145,10 +145,6 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 	nodeID roachpb.NodeID, addr net.Addr, stopper *stop.Stopper,
 ) (*storage.RaftTransport, net.Addr) {
 	grpcServer := rpc.NewServer(rttc.nodeRPCContext)
-	ln, err := netutil.ListenAndServeGRPC(stopper, grpcServer, addr)
-	if err != nil {
-		rttc.t.Fatal(err)
-	}
 	transport := storage.NewRaftTransport(
 		log.AmbientContext{},
 		storage.GossipAddressResolver(rttc.gossip),
@@ -156,6 +152,10 @@ func (rttc *raftTransportTestContext) AddNodeWithoutGossip(
 		rttc.nodeRPCContext,
 	)
 	rttc.transports[nodeID] = transport
+	ln, err := netutil.ListenAndServeGRPC(stopper, grpcServer, addr)
+	if err != nil {
+		rttc.t.Fatal(err)
+	}
 	return transport, ln.Addr()
 }
 


### PR DESCRIPTION
The test changes were needed to fix badness where we were registering a
server after gRPC started listening. This was always invalid, but now
gRPC detects and complains about it.