### PR TITLE
storage: Decrease minimum stats collection period for lease transfers

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -65,7 +65,7 @@ var (
 	// making decisions based on them. The higher this is, the less likely
 	// thrashing is (up to a point).
 	// Made configurable for the sake of testing.
-	MinLeaseTransferStatsDuration = replStatsRotateInterval
+	MinLeaseTransferStatsDuration = 30 * time.Second
 
 	// EnableLoadBasedLeaseRebalancing controls whether lease rebalancing is done
 	// via the new heuristic based on request load and latency or via the simpler


### PR DESCRIPTION
5 minutes (the previous value) is a long time to have to wait at startup
before moving any leases around. The only reason this was previously set
so high was because we were using raw request counts rather than request
QPS in the lease transfer logic, but we switched that over in
e40519bd3ddd045c629e7b2b90d6cc80d578a32a.

It's debatable whether this should be configurable. I don't think that
that it needs to be, but am open to thoughts.

cc @robert-s-lee 