### PR TITLE
sql/jobs: more cleanup

### DIFF
--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -36,8 +36,8 @@ import (
 // Job manages logging the progress of long-running system processes, like
 // backups and restores, to the system.jobs table.
 //
-// The Record field can be directly modified before Created is called. Updates to
-// the Job field after the job has been created will not be written to the
+// The Record field can be directly modified before Created is called. Updates
+// to the Record field after the job has been created will not be written to the
 // database, however, even when calling e.g. Started or Succeeded.
 type Job struct {
 	// TODO(benesch): avoid giving Job a reference to Registry. This will likely
@@ -62,8 +62,7 @@ var _ Details = BackupDetails{}
 var _ Details = RestoreDetails{}
 var _ Details = SchemaChangeDetails{}
 
-// Record stores the job fields that are not automatically managed by
-// Job.
+// Record stores the job fields that are not automatically managed by Job.
 type Record struct {
 	Description   string
 	Username      string
@@ -387,8 +386,8 @@ func (p *Payload) UnwrapDetails() (Details, error) {
 	}
 }
 
-// UnmarshalPayload unmarshals and returns the Payload encoded in the
-// input datum, which should be a DBytes.
+// UnmarshalPayload unmarshals and returns the Payload encoded in the input
+// datum, which should be a parser.DBytes.
 func UnmarshalPayload(datum parser.Datum) (*Payload, error) {
 	payload := &Payload{}
 	bytes, ok := datum.(*parser.DBytes)

--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -18,7 +18,6 @@ package jobs
 
 import (
 	"fmt"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -111,7 +110,7 @@ func (j *Job) Started(ctx context.Context) error {
 			// Already started - do nothing.
 			return false, nil
 		}
-		payload.StartedMicros = roundTimestamp(timeutil.Now())
+		payload.StartedMicros = timeutil.ToUnixMicros(timeutil.Now())
 		return true, nil
 	})
 }
@@ -171,7 +170,7 @@ func (j *Job) Failed(ctx context.Context, err error) {
 			return false, nil
 		}
 		payload.Error = err.Error()
-		payload.FinishedMicros = roundTimestamp(timeutil.Now())
+		payload.FinishedMicros = timeutil.ToUnixMicros(timeutil.Now())
 		return true, nil
 	})
 	if internalErr != nil {
@@ -188,7 +187,7 @@ func (j *Job) Succeeded(ctx context.Context) error {
 			// Already finished - do nothing.
 			return false, nil
 		}
-		payload.FinishedMicros = roundTimestamp(timeutil.Now())
+		payload.FinishedMicros = timeutil.ToUnixMicros(timeutil.Now())
 		payload.FractionCompleted = 1.0
 		return true, nil
 	})
@@ -260,7 +259,7 @@ func (j *Job) insert(ctx context.Context, payload *Payload) error {
 
 	var row parser.Datums
 	if err := j.runInTxn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		payload.ModifiedMicros = roundTimestamp(txn.Proto().OrigTimestamp.GoTime())
+		payload.ModifiedMicros = timeutil.ToUnixMicros(txn.Proto().OrigTimestamp.GoTime())
 		payloadBytes, err := protoutil.Marshal(payload)
 		if err != nil {
 			return err
@@ -299,7 +298,7 @@ func (j *Job) update(
 		if !doUpdate {
 			return nil
 		}
-		payload.ModifiedMicros = roundTimestamp(timeutil.Now())
+		payload.ModifiedMicros = timeutil.ToUnixMicros(timeutil.Now())
 		payloadBytes, err := protoutil.Marshal(payload)
 		if err != nil {
 			return err
@@ -399,11 +398,4 @@ func UnmarshalPayload(datum parser.Datum) (*Payload, error) {
 		return nil, err
 	}
 	return payload, nil
-}
-
-// TIMESTAMP columns round to the nearest microsecond, so we replicate that
-// behavior for our protobuf fields. Naive truncation can lead to anomalies
-// where jobs are started before they're created.
-func roundTimestamp(ts time.Time) int64 {
-	return ts.Round(time.Microsecond).UnixNano() / time.Microsecond.Nanoseconds()
 }

--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -58,6 +58,10 @@ type Job struct {
 // Details is a marker interface for job details proto structs.
 type Details interface{}
 
+var _ Details = BackupDetails{}
+var _ Details = RestoreDetails{}
+var _ Details = SchemaChangeDetails{}
+
 // Record stores the job fields that are not automatically managed by
 // Job.
 type Record struct {
@@ -81,46 +85,6 @@ const (
 	// StatusSucceeded is for jobs that have successfully completed.
 	StatusSucceeded Status = "succeeded"
 )
-
-func (j *Job) load(ctx context.Context) error {
-	return j.runInTxn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		payload, err := j.retrievePayload(ctx, txn)
-		if err != nil {
-			return err
-		}
-		j.Record.Description = payload.Description
-		j.Record.Username = payload.Username
-		j.Record.DescriptorIDs = payload.DescriptorIDs
-		if j.Record.Details, err = payload.UnwrapDetails(); err != nil {
-			return err
-		}
-		// Don't need to lock because we're the only one who has a handle on this
-		// Job so far.
-		j.mu.payload = *payload
-		return nil
-	})
-}
-
-func (j *Job) runInTxn(
-	ctx context.Context, retryable func(context.Context, *client.Txn) error,
-) error {
-	if j.txn != nil {
-		defer func() { j.txn = nil }()
-		return j.txn.Exec(ctx, client.TxnExecOptions{AutoRetry: true, AssignTimestampImmediately: true},
-			func(ctx context.Context, txn *client.Txn, _ *client.TxnExecOptions) error {
-				return retryable(ctx, txn)
-			})
-	}
-	return j.registry.db.Txn(ctx, retryable)
-}
-
-// WithTxn sets the transaction that this Job will use for its next operation.
-// If the transaction is nil, the Job will create a one-off transaction instead.
-// If you use WithTxn, this Job will no longer be threadsafe.
-func (j *Job) WithTxn(txn *client.Txn) *Job {
-	j.txn = txn
-	return j
-}
 
 // ID returns the ID of the job that this Job is currently tracking. This will
 // be nil if Created has not yet been called.
@@ -239,6 +203,56 @@ func (j *Job) Payload() Payload {
 	return j.mu.payload
 }
 
+// WithTxn sets the transaction that this Job will use for its next operation.
+// If the transaction is nil, the Job will create a one-off transaction instead.
+// If you use WithTxn, this Job will no longer be threadsafe.
+func (j *Job) WithTxn(txn *client.Txn) *Job {
+	j.txn = txn
+	return j
+}
+
+func (j *Job) runInTxn(
+	ctx context.Context, retryable func(context.Context, *client.Txn) error,
+) error {
+	if j.txn != nil {
+		defer func() { j.txn = nil }()
+		return j.txn.Exec(ctx, client.TxnExecOptions{AutoRetry: true, AssignTimestampImmediately: true},
+			func(ctx context.Context, txn *client.Txn, _ *client.TxnExecOptions) error {
+				return retryable(ctx, txn)
+			})
+	}
+	return j.registry.db.Txn(ctx, retryable)
+}
+
+func (j *Job) load(ctx context.Context) error {
+	return j.runInTxn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		payload, err := j.loadPayload(ctx, txn)
+		if err != nil {
+			return err
+		}
+		j.Record.Description = payload.Description
+		j.Record.Username = payload.Username
+		j.Record.DescriptorIDs = payload.DescriptorIDs
+		if j.Record.Details, err = payload.UnwrapDetails(); err != nil {
+			return err
+		}
+		// Don't need to lock because we're the only one who has a handle on this
+		// Job so far.
+		j.mu.payload = *payload
+		return nil
+	})
+}
+
+func (j *Job) loadPayload(ctx context.Context, txn *client.Txn) (*Payload, error) {
+	const selectStmt = "SELECT payload FROM system.jobs WHERE id = $1"
+	row, err := j.registry.ex.QueryRowInTransaction(ctx, "log-job", txn, selectStmt, *j.id)
+	if err != nil {
+		return nil, err
+	}
+
+	return UnmarshalPayload(row[0])
+}
+
 func (j *Job) insert(ctx context.Context, payload *Payload) error {
 	if j.id != nil {
 		// Already created - do nothing.
@@ -265,16 +279,6 @@ func (j *Job) insert(ctx context.Context, payload *Payload) error {
 	return nil
 }
 
-func (j *Job) retrievePayload(ctx context.Context, txn *client.Txn) (*Payload, error) {
-	const selectStmt = "SELECT payload FROM system.jobs WHERE id = $1"
-	row, err := j.registry.ex.QueryRowInTransaction(ctx, "log-job", txn, selectStmt, *j.id)
-	if err != nil {
-		return nil, err
-	}
-
-	return UnmarshalPayload(row[0])
-}
-
 func (j *Job) update(
 	ctx context.Context, newStatus Status, updateFn func(*Payload) (doUpdate bool, err error),
 ) error {
@@ -285,7 +289,7 @@ func (j *Job) update(
 	var payload *Payload
 	if err := j.runInTxn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		var err error
-		payload, err = j.retrievePayload(ctx, txn)
+		payload, err = j.loadPayload(ctx, txn)
 		if err != nil {
 			return err
 		}
@@ -404,7 +408,3 @@ func UnmarshalPayload(datum parser.Datum) (*Payload, error) {
 func roundTimestamp(ts time.Time) int64 {
 	return ts.Round(time.Microsecond).UnixNano() / time.Microsecond.Nanoseconds()
 }
-
-var _ Details = BackupDetails{}
-var _ Details = RestoreDetails{}
-var _ Details = SchemaChangeDetails{}

--- a/pkg/sql/jobs/jobs_test.go
+++ b/pkg/sql/jobs/jobs_test.go
@@ -160,7 +160,7 @@ func verifyJobRecord(
 	return testSource(`[SHOW JOBS]`)
 }
 
-func TestJobLogger(t *testing.T) {
+func TestJobLifecycle(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.TODO()

--- a/pkg/sql/jobs/jobs_test.go
+++ b/pkg/sql/jobs/jobs_test.go
@@ -324,12 +324,16 @@ func TestJobLogger(t *testing.T) {
 	})
 
 	t.Run("bad job details fail", func(t *testing.T) {
+		defer func() {
+			if r, ok := recover().(string); !ok || !strings.Contains(r, "unknown details type int") {
+				t.Fatalf("expected 'unknown details type int', but got: %v", r)
+			}
+		}()
+
 		job := registry.NewJob(jobs.Record{
 			Details: 42,
 		})
-		if err := job.Created(ctx); !testutils.IsError(err, "unsupported job details type int") {
-			t.Fatalf("expected 'unsupported job details type int', but got %v", err)
-		}
+		_ = job.Created(ctx)
 	})
 
 	t.Run("update before create fails", func(t *testing.T) {

--- a/pkg/sql/jobs/jobs_test.go
+++ b/pkg/sql/jobs/jobs_test.go
@@ -418,4 +418,29 @@ func TestJobLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("set details works", func(t *testing.T) {
+		record := jobs.Record{Details: jobs.RestoreDetails{}}
+		expect := expectation{
+			DB:     sqlDB,
+			Record: record,
+			Type:   jobs.TypeRestore,
+			Before: timeutil.Now(),
+		}
+		job := registry.NewJob(record)
+		if err := job.Created(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if err := expect.verify(job.ID(), jobs.StatusPending); err != nil {
+			t.Fatal(err)
+		}
+		newDetails := jobs.RestoreDetails{LowWaterMark: []byte{42}}
+		expect.Record.Details = newDetails
+		if err := job.SetDetails(ctx, newDetails); err != nil {
+			t.Fatal(err)
+		}
+		if err := expect.verify(job.ID(), jobs.StatusPending); err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/pkg/sql/jobs/jobs_test.go
+++ b/pkg/sql/jobs/jobs_test.go
@@ -103,7 +103,7 @@ func verifyJobRecord(
 			return errors.Errorf("JobRecords do not match:\n%s", diff)
 		}
 
-		// Verify Record-managed fields.
+		// Verify internally-managed fields.
 		status := jobs.Status(statusString)
 		if e, a := expectedStatus, status; e != a {
 			return errors.Errorf("expected status %v, got %v", e, a)
@@ -115,7 +115,7 @@ func verifyJobRecord(
 			return errors.Errorf("expected fraction completed %f, got %f", e, a)
 		}
 
-		// Check Record-managed timestamps for sanity.
+		// Check internally-managed timestamps for sanity.
 		verifyModifiedAgainst := func(name string, ts time.Time) error {
 			if modified.Time.Before(ts) {
 				return errors.Errorf("modified time %v before %s time %v", modified, name, ts)

--- a/pkg/sql/jobs/jobs_test.go
+++ b/pkg/sql/jobs/jobs_test.go
@@ -93,9 +93,9 @@ func (expected *expectation) verify(id *int64, expectedStatus jobs.Status) error
 	}
 
 	// Check internally-managed timestamps for sanity.
-	started := time.Unix(0, payload.StartedMicros*time.Microsecond.Nanoseconds())
-	modified := time.Unix(0, payload.ModifiedMicros*time.Microsecond.Nanoseconds())
-	finished := time.Unix(0, payload.FinishedMicros*time.Microsecond.Nanoseconds())
+	started := timeutil.FromUnixMicros(payload.StartedMicros)
+	modified := timeutil.FromUnixMicros(payload.ModifiedMicros)
+	finished := timeutil.FromUnixMicros(payload.FinishedMicros)
 
 	verifyModifiedAgainst := func(name string, ts time.Time) error {
 		if modified.Before(ts) {
@@ -117,10 +117,10 @@ func (expected *expectation) verify(id *int64, expectedStatus jobs.Status) error
 		return verifyModifiedAgainst("created", created)
 	}
 
-	if started == time.Unix(0, 0) && status == jobs.StatusSucceeded {
+	if started == timeutil.UnixEpoch && status == jobs.StatusSucceeded {
 		return errors.Errorf("started time is empty but job claims to be successful")
 	}
-	if started != time.Unix(0, 0) && created.After(started) {
+	if started != timeutil.UnixEpoch && created.After(started) {
 		return errors.Errorf("created time %v is after started time %v", created, started)
 	}
 	if status == jobs.StatusRunning {

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -526,7 +526,7 @@ func TestShowJobs(t *testing.T) {
 			return ids
 		}(),
 		Error:   in.err,
-		Details: &jobs.Payload_SchemaChange{SchemaChange: &jobs.SchemaChangeDetails{}},
+		Details: jobs.WrapPayloadDetails(jobs.SchemaChangeDetails{}),
 	}).Marshal()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -19,17 +19,23 @@ package sql_test
 import (
 	gosql "database/sql"
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/kr/pretty"
+	"github.com/lib/pq"
 )
 
 func TestShowCreateTable(t *testing.T) {
@@ -455,4 +461,94 @@ func TestShowQueries(t *testing.T) {
 		t.Fatal(err)
 	}
 
+}
+
+// TestShowJobs manually inserts a row into system.jobs and checks that the
+// encoded protobuf payload is properly decoded and visible in both SHOW JOBS
+// and crdb_internal.jobs.
+func TestShowJobs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := createTestServerParams()
+	s, rawSQLDB, _ := serverutils.StartServer(t, params)
+	sqlDB := sqlutils.MakeSQLRunner(t, rawSQLDB)
+	defer s.Stopper().Stop(context.TODO())
+
+	// row represents a row returned from crdb_internal.jobs or SHOW JOBS, but
+	// *not* a row in system.jobs.
+	type row struct {
+		id                int64
+		typ               string
+		status            string
+		description       string
+		username          string
+		descriptorIDs     pq.Int64Array
+		err               string
+		created           time.Time
+		started           time.Time
+		finished          time.Time
+		modified          time.Time
+		fractionCompleted float32
+	}
+
+	in := row{
+		id:            42,
+		typ:           "SCHEMA CHANGE",
+		status:        "superfailed",
+		description:   "failjob",
+		username:      "failure",
+		descriptorIDs: pq.Int64Array{42},
+		err:           "boom",
+		// lib/pq returns time.Time objects with goofy locations, which breaks
+		// reflect.DeepEqual without this time.FixedZone song and dance.
+		// See: https://github.com/lib/pq/issues/329
+		created:           time.Unix(1, 0).In(time.FixedZone("", 0)),
+		started:           time.Unix(2, 0).In(time.FixedZone("", 0)),
+		finished:          time.Unix(3, 0).In(time.FixedZone("", 0)),
+		modified:          time.Unix(4, 0).In(time.FixedZone("", 0)),
+		fractionCompleted: 0.42,
+	}
+
+	// system.jobs is part proper SQL columns, part protobuf, so we can't use the
+	// row struct directly.
+	inPayload, err := (&jobs.Payload{
+		Description:       in.description,
+		StartedMicros:     in.started.UnixNano() / time.Microsecond.Nanoseconds(),
+		FinishedMicros:    in.finished.UnixNano() / time.Microsecond.Nanoseconds(),
+		ModifiedMicros:    in.modified.UnixNano() / time.Microsecond.Nanoseconds(),
+		FractionCompleted: in.fractionCompleted,
+		Username:          in.username,
+		DescriptorIDs: func() sqlbase.IDs {
+			var ids sqlbase.IDs
+			for _, id := range in.descriptorIDs {
+				ids = append(ids, sqlbase.ID(id))
+			}
+			return ids
+		}(),
+		Error:   in.err,
+		Details: &jobs.Payload_SchemaChange{SchemaChange: &jobs.SchemaChangeDetails{}},
+	}).Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.Exec(
+		`INSERT INTO system.jobs (id, status, created, payload) VALUES ($1, $2, $3, $4)`,
+		in.id, in.status, in.created, inPayload,
+	)
+
+	for _, source := range []string{"[SHOW JOBS]", "crdb_internal.jobs"} {
+		var out row
+		sqlDB.QueryRow(fmt.Sprintf(`
+			SELECT id, type, status, created, description, started, finished,
+						 modified, fraction_completed, username, descriptor_ids, error
+			FROM %s`, source),
+		).Scan(
+			&out.id, &out.typ, &out.status, &out.created, &out.description, &out.started, &out.finished,
+			&out.modified, &out.fractionCompleted, &out.username, &out.descriptorIDs, &out.err,
+		)
+		if !reflect.DeepEqual(in, out) {
+			diff := strings.Join(pretty.Diff(in, out), "\n")
+			t.Fatalf("in job did not match out job:\n%s", diff)
+		}
+	}
 }

--- a/pkg/util/timeutil/main_test.go
+++ b/pkg/util/timeutil/main_test.go
@@ -14,4 +14,15 @@
 
 package timeutil
 
-import _ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
+import (
+	"os"
+	"testing"
+
+	_ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	os.Exit(m.Run())
+}

--- a/pkg/util/timeutil/time.go
+++ b/pkg/util/timeutil/time.go
@@ -54,3 +54,21 @@ func Now() time.Time {
 func Since(t time.Time) time.Duration {
 	return Now().Sub(t)
 }
+
+// UnixEpoch represents the Unix epoch, January 1, 1970 UTC.
+var UnixEpoch = time.Unix(0, 0)
+
+// FromUnixMicros returns the local time.Time corresponding to the given Unix
+// time, usec microseconds since UnixEpoch. In Go's current time.Time
+// implementation, all possible values for us can be represented as a time.Time.
+func FromUnixMicros(us int64) time.Time {
+	return time.Unix(us/1e6, (us%1e6)*1e3)
+}
+
+// ToUnixMicros returns t as the number of microseconds elapsed since UnixEpoch.
+// Fractional microseconds are rounded, half up, using time.Round. Similar to
+// time.Time.UnixNano, the result is undefined if the Unix time in microseconds
+// cannot be represented by an int64.
+func ToUnixMicros(t time.Time) int64 {
+	return t.Unix()*1e6 + int64(t.Round(time.Microsecond).Nanosecond())/1e3
+}

--- a/pkg/util/timeutil/time_test.go
+++ b/pkg/util/timeutil/time_test.go
@@ -1,0 +1,71 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// Author: Nikhil Benesch (nikhil.benesch@gmail.com)
+
+package timeutil
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestUnixMicros(t *testing.T) {
+	testCases := []struct {
+		us      int64
+		utcTime time.Time
+	}{
+		{-1, time.Date(1969, 12, 31, 23, 59, 59, 999999000, time.UTC)},
+		{0, time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)},
+		{1, time.Date(1970, 1, 1, 0, 0, 0, 1000, time.UTC)},
+		{4242424242424242, time.Date(2104, 6, 9, 3, 10, 42, 424242000, time.UTC)},
+		{math.MaxInt64, time.Date(294247, 1, 10, 4, 0, 54, 775807000, time.UTC)},
+		{-62135596800000000, time.Time{}},
+	}
+	for i, testCase := range testCases {
+		if e, a := testCase.utcTime, FromUnixMicros(testCase.us).UTC(); e != a {
+			t.Errorf("%d:FromUnixMicro: expected %v, but got %v", i, e, a)
+		}
+
+		if e, a := testCase.us, ToUnixMicros(testCase.utcTime); e != a {
+			t.Errorf("%d:ToUnixMicro: expected %v, but got %v", i, e, a)
+		}
+	}
+
+	for i := 0; i < 32; i++ {
+		us := rand.Int63()
+		if e, a := us, ToUnixMicros(FromUnixMicros(us)); e != a {
+			t.Errorf("%d did not roundtrip; got back %d", e, a)
+		}
+	}
+}
+
+func TestUnixMicrosRounding(t *testing.T) {
+	testCases := []struct {
+		us      int64
+		utcTime time.Time
+	}{
+		{0, time.Date(1970, 1, 1, 0, 0, 0, 1, time.UTC)},
+		{0, time.Date(1970, 1, 1, 0, 0, 0, 499, time.UTC)},
+		{1, time.Date(1970, 1, 1, 0, 0, 0, 500, time.UTC)},
+		{1, time.Date(1970, 1, 1, 0, 0, 0, 999, time.UTC)},
+	}
+	for i, testCase := range testCases {
+		if e, a := testCase.us, ToUnixMicros(testCase.utcTime); e != a {
+			t.Errorf("%d:ToUnixMicro: expected %v, but got %v", i, e, a)
+		}
+	}
+}


### PR DESCRIPTION
A few more small cleanups for sql/jobs. In particular, `TestJobs` was getting to the point that I was having trouble keeping track of what it was testing. This is net positive lines of code, but I think it's much nicer to limit knowledge of `SHOW JOBS` and `crdb_internal.jobs` to the sql package.

Ignore the first commit—that's tracked in #17136. Here's the relevant compare view: https://github.com/benesch/cockroach/compare/job-cleanup~7...benesch:job-cleanup?expand=1
