### PR TITLE
server: Add system.sessions table

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -400,7 +400,7 @@ func Example_ranges() {
 	// 	0: node-id=1 store-id=1
 	// /System/"tse"-"ranges3" [4]
 	// 	0: node-id=1 store-id=1
-	// "ranges3"-/Table/SystemConfigSpan/Start [11]
+	// "ranges3"-/Table/SystemConfigSpan/Start [15]
 	// 	0: node-id=1 store-id=1
 	// /Table/SystemConfigSpan/Start-/Table/11 [5]
 	// 	0: node-id=1 store-id=1
@@ -412,9 +412,17 @@ func Example_ranges() {
 	// 	0: node-id=1 store-id=1
 	// /Table/14-/Table/15 [9]
 	// 	0: node-id=1 store-id=1
-	// /Table/15-/Max [10]
+	// /Table/15-/Table/16 [10]
 	// 	0: node-id=1 store-id=1
-	// 11 result(s)
+	// /Table/16-/Table/17 [11]
+	// 	0: node-id=1 store-id=1
+	// /Table/17-/Table/18 [12]
+	// 	0: node-id=1 store-id=1
+	// /Table/18-/Table/19 [13]
+	// 	0: node-id=1 store-id=1
+	// /Table/19-/Max [14]
+	// 	0: node-id=1 store-id=1
+	// 15 result(s)
 }
 
 func Example_logging() {
@@ -475,7 +483,7 @@ func Example_max_results() {
 	// 	0: node-id=1 store-id=1
 	// /System/"tse"-"max_results3" [4]
 	// 	0: node-id=1 store-id=1
-	// "max_results3"-"max_results4" [11]
+	// "max_results3"-"max_results4" [15]
 	// 	0: node-id=1 store-id=1
 	// 5 result(s)
 }
@@ -1429,7 +1437,7 @@ func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 	}{
 		{"live_bytes", 5, 50000},
 		{"key_bytes", 6, 30000},
-		{"value_bytes", 7, 50000},
+		{"value_bytes", 7, 100000},
 		{"intent_bytes", 8, 30000},
 		{"system_bytes", 9, 30000},
 		{"leader_ranges", 10, 3},
@@ -1615,6 +1623,10 @@ writing ` + os.DevNull + `
   debug/nodes/1/ranges/8
   debug/nodes/1/ranges/9
   debug/nodes/1/ranges/10
+  debug/nodes/1/ranges/11
+  debug/nodes/1/ranges/12
+  debug/nodes/1/ranges/13
+  debug/nodes/1/ranges/14
   debug/schema/system@details
   debug/schema/system/descriptor
   debug/schema/system/eventlog
@@ -1625,6 +1637,7 @@ writing ` + os.DevNull + `
   debug/schema/system/settings
   debug/schema/system/ui
   debug/schema/system/users
+  debug/schema/system/web_sessions
   debug/schema/system/zones
 `
 

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -285,19 +285,17 @@ const (
 	ZonesTableID      = 5
 	SettingsTableID   = 6
 
-	// Reserved IDs for other system tables. If you're adding a new system table,
-	// it probably belongs here.
+	// Reserved IDs for other system tables. Note that some of these IDs refer
+	// to "Ranges" instead of a Table - these IDs are needed to store custom
+	// configuration for non-table ranges (e.g. Zone Configs).
 	// NOTE: IDs must be <= MaxReservedDescID.
-	LeaseTableID      = 11
-	EventLogTableID   = 12
-	RangeEventTableID = 13
-	UITableID         = 14
-	JobsTableID       = 15
-
-	// Reserved IDs used to refer to certain parts of the system ranges that
-	// come before the system config span and user table ranges.
-	// NOTE: IDs must be <= MaxReservedDescID.
+	LeaseTableID       = 11
+	EventLogTableID    = 12
+	RangeEventTableID  = 13
+	UITableID          = 14
+	JobsTableID        = 15
 	MetaRangesID       = 16
 	SystemRangesID     = 17
 	TimeseriesRangesID = 18
+	WebSessionsTableID = 19
 )

--- a/pkg/migration/sqlmigrations/migrations.go
+++ b/pkg/migration/sqlmigrations/migrations.go
@@ -69,6 +69,14 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		name:   "establish conservative dependencies for views #17280 #17269",
 		workFn: repopulateViewDeps,
 	},
+	{
+		name:           "create system.sessions table",
+		workFn:         createWebSessionsTable,
+		newDescriptors: 1,
+		// The table ID for the sessions table is greater than the previous
+		// table ID by 4 (3 IDs were reserved for non-table entities).
+		newRanges: 4,
+	},
 }
 
 // migrationDescriptor describes a single migration hook that's used to modify
@@ -351,6 +359,10 @@ func createJobsTable(ctx context.Context, r runner) error {
 
 func createSettingsTable(ctx context.Context, r runner) error {
 	return createSystemTable(ctx, r, sqlbase.SettingsTable)
+}
+
+func createWebSessionsTable(ctx context.Context, r runner) error {
+	return createSystemTable(ctx, r, sqlbase.WebSessionsTable)
 }
 
 func createSystemTable(ctx context.Context, r runner, desc sqlbase.TableDescriptor) error {

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -136,7 +136,7 @@ EXPLAIN SHOW TABLES
 1  render  ·      ·
 2  filter  ·      ·
 3  values  ·      ·
-3  ·       size   5 columns, 60 rows
+3  ·       size   5 columns, 61 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -192,11 +192,11 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·
-7  ·       size      13 columns, 509 rows
+7  ·       size      13 columns, 517 rows
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·
-7  ·       size      13 columns, 22 rows
+7  ·       size      13 columns, 27 rows
 
 query ITTT
 EXPLAIN SHOW GRANTS ON foo
@@ -206,7 +206,8 @@ EXPLAIN SHOW GRANTS ON foo
 1  render  ·      ·
 2  filter  ·      ·
 3  values  ·      ·
-3  ·       size   8 columns, 45 rows
+3  ·       size   8 columns, 50 rows
+
 
 query ITTT
 EXPLAIN SHOW INDEX FROM foo
@@ -214,7 +215,7 @@ EXPLAIN SHOW INDEX FROM foo
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  13 columns, 22 rows
+2  ·       size  13 columns, 27 rows
 
 query ITTT
 EXPLAIN SHOW CONSTRAINTS FROM foo

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -262,6 +262,7 @@ system              rangelog
 system              settings
 system              ui
 system              users
+system              web_sessions
 system              zones
 
 statement ok
@@ -330,6 +331,7 @@ SELECT table_name FROM information_schema.tables WHERE table_name > 't'  ORDER B
 ----
 zones
 xyz
+web_sessions
 views
 users
 user_privileges
@@ -404,6 +406,7 @@ def            system              rangelog                   BASE TABLE   1
 def            system              settings                   BASE TABLE   1
 def            system              ui                         BASE TABLE   1
 def            system              users                      BASE TABLE   1
+def            system              web_sessions               BASE TABLE   1
 def            system              zones                      BASE TABLE   1
 
 statement ok
@@ -456,17 +459,18 @@ SELECT *
 FROM information_schema.table_constraints
 ORDER BY TABLE_NAME, CONSTRAINT_TYPE, CONSTRAINT_NAME
 ----
-constraint_catalog  constraint_schema  constraint_name  table_schema  table_name  constraint_type
-def                 system             primary          system        descriptor  PRIMARY KEY
-def                 system             primary          system        eventlog    PRIMARY KEY
-def                 system             primary          system        jobs        PRIMARY KEY
-def                 system             primary          system        lease       PRIMARY KEY
-def                 system             primary          system        namespace   PRIMARY KEY
-def                 system             primary          system        rangelog    PRIMARY KEY
-def                 system             primary          system        settings    PRIMARY KEY
-def                 system             primary          system        ui          PRIMARY KEY
-def                 system             primary          system        users       PRIMARY KEY
-def                 system             primary          system        zones       PRIMARY KEY
+constraint_catalog  constraint_schema  constraint_name  table_schema  table_name    constraint_type
+def                 system             primary          system        descriptor    PRIMARY KEY
+def                 system             primary          system        eventlog      PRIMARY KEY
+def                 system             primary          system        jobs          PRIMARY KEY
+def                 system             primary          system        lease         PRIMARY KEY
+def                 system             primary          system        namespace     PRIMARY KEY
+def                 system             primary          system        rangelog      PRIMARY KEY
+def                 system             primary          system        settings      PRIMARY KEY
+def                 system             primary          system        ui            PRIMARY KEY
+def                 system             primary          system        users         PRIMARY KEY
+def                 system             primary          system        web_sessions  PRIMARY KEY
+def                 system             primary          system        zones         PRIMARY KEY
 
 statement ok
 CREATE DATABASE constraint_db
@@ -511,44 +515,52 @@ SELECT table_catalog, table_schema, table_name, column_name, ordinal_position
 FROM information_schema.columns
 WHERE table_schema != 'information_schema' AND table_schema != 'pg_catalog' AND table_schema != 'crdb_internal'
 ----
-table_catalog  table_schema  table_name  column_name     ordinal_position
-def            system        descriptor  id              1
-def            system        descriptor  descriptor      2
-def            system        eventlog    timestamp       1
-def            system        eventlog    eventType       2
-def            system        eventlog    targetID        3
-def            system        eventlog    reportingID     4
-def            system        eventlog    info            5
-def            system        eventlog    uniqueID        6
-def            system        jobs        id              1
-def            system        jobs        status          2
-def            system        jobs        created         3
-def            system        jobs        payload         4
-def            system        lease       descID          1
-def            system        lease       version         2
-def            system        lease       nodeID          3
-def            system        lease       expiration      4
-def            system        namespace   parentID        1
-def            system        namespace   name            2
-def            system        namespace   id              3
-def            system        rangelog    timestamp       1
-def            system        rangelog    rangeID         2
-def            system        rangelog    storeID         3
-def            system        rangelog    eventType       4
-def            system        rangelog    otherRangeID    5
-def            system        rangelog    info            6
-def            system        rangelog    uniqueID        7
-def            system        settings    name            1
-def            system        settings    value           2
-def            system        settings    lastUpdated     3
-def            system        settings    valueType       4
-def            system        ui          key             1
-def            system        ui          value           2
-def            system        ui          lastUpdated     3
-def            system        users       username        1
-def            system        users       hashedPassword  2
-def            system        zones       id              1
-def            system        zones       config          2
+table_catalog  table_schema  table_name    column_name     ordinal_position  
+def            system        descriptor    id              1                 
+def            system        descriptor    descriptor      2                 
+def            system        eventlog      timestamp       1                 
+def            system        eventlog      eventType       2                 
+def            system        eventlog      targetID        3                 
+def            system        eventlog      reportingID     4                 
+def            system        eventlog      info            5                 
+def            system        eventlog      uniqueID        6                 
+def            system        jobs          id              1                 
+def            system        jobs          status          2                 
+def            system        jobs          created         3                 
+def            system        jobs          payload         4                 
+def            system        lease         descID          1                 
+def            system        lease         version         2                 
+def            system        lease         nodeID          3                 
+def            system        lease         expiration      4                 
+def            system        namespace     parentID        1                 
+def            system        namespace     name            2                 
+def            system        namespace     id              3                 
+def            system        rangelog      timestamp       1                 
+def            system        rangelog      rangeID         2                 
+def            system        rangelog      storeID         3                 
+def            system        rangelog      eventType       4                 
+def            system        rangelog      otherRangeID    5                 
+def            system        rangelog      info            6                 
+def            system        rangelog      uniqueID        7                 
+def            system        settings      name            1                 
+def            system        settings      value           2                 
+def            system        settings      lastUpdated     3                 
+def            system        settings      valueType       4                 
+def            system        ui            key             1                 
+def            system        ui            value           2                 
+def            system        ui            lastUpdated     3                 
+def            system        users         username        1                 
+def            system        users         hashedPassword  2                 
+def            system        web_sessions  id              1                 
+def            system        web_sessions  hashedSecret    2                 
+def            system        web_sessions  username        3                 
+def            system        web_sessions  createdAt       4                 
+def            system        web_sessions  expiresAt       5                 
+def            system        web_sessions  revokedAt       6                 
+def            system        web_sessions  lastUsedAt      7                 
+def            system        web_sessions  auditInfo       8                 
+def            system        zones         id              1                 
+def            system        zones         config          2
 
 statement ok
 SET DATABASE = test
@@ -726,51 +738,56 @@ root      def            test          ALL             NULL
 query TTTTTTTT colnames
 SELECT * FROM information_schema.table_privileges
 ----
-grantor  grantee  table_catalog  table_schema  table_name  privilege_type  is_grantable  with_hierarchy
-NULL     root     def            system        descriptor  GRANT           NULL          NULL
-NULL     root     def            system        descriptor  SELECT          NULL          NULL
-NULL     root     def            system        eventlog    DELETE          NULL          NULL
-NULL     root     def            system        eventlog    GRANT           NULL          NULL
-NULL     root     def            system        eventlog    INSERT          NULL          NULL
-NULL     root     def            system        eventlog    SELECT          NULL          NULL
-NULL     root     def            system        eventlog    UPDATE          NULL          NULL
-NULL     root     def            system        jobs        DELETE          NULL          NULL
-NULL     root     def            system        jobs        GRANT           NULL          NULL
-NULL     root     def            system        jobs        INSERT          NULL          NULL
-NULL     root     def            system        jobs        SELECT          NULL          NULL
-NULL     root     def            system        jobs        UPDATE          NULL          NULL
-NULL     root     def            system        lease       DELETE          NULL          NULL
-NULL     root     def            system        lease       GRANT           NULL          NULL
-NULL     root     def            system        lease       INSERT          NULL          NULL
-NULL     root     def            system        lease       SELECT          NULL          NULL
-NULL     root     def            system        lease       UPDATE          NULL          NULL
-NULL     root     def            system        namespace   GRANT           NULL          NULL
-NULL     root     def            system        namespace   SELECT          NULL          NULL
-NULL     root     def            system        rangelog    DELETE          NULL          NULL
-NULL     root     def            system        rangelog    GRANT           NULL          NULL
-NULL     root     def            system        rangelog    INSERT          NULL          NULL
-NULL     root     def            system        rangelog    SELECT          NULL          NULL
-NULL     root     def            system        rangelog    UPDATE          NULL          NULL
-NULL     root     def            system        settings    DELETE          NULL          NULL
-NULL     root     def            system        settings    GRANT           NULL          NULL
-NULL     root     def            system        settings    INSERT          NULL          NULL
-NULL     root     def            system        settings    SELECT          NULL          NULL
-NULL     root     def            system        settings    UPDATE          NULL          NULL
-NULL     root     def            system        ui          DELETE          NULL          NULL
-NULL     root     def            system        ui          GRANT           NULL          NULL
-NULL     root     def            system        ui          INSERT          NULL          NULL
-NULL     root     def            system        ui          SELECT          NULL          NULL
-NULL     root     def            system        ui          UPDATE          NULL          NULL
-NULL     root     def            system        users       DELETE          NULL          NULL
-NULL     root     def            system        users       GRANT           NULL          NULL
-NULL     root     def            system        users       INSERT          NULL          NULL
-NULL     root     def            system        users       SELECT          NULL          NULL
-NULL     root     def            system        users       UPDATE          NULL          NULL
-NULL     root     def            system        zones       DELETE          NULL          NULL
-NULL     root     def            system        zones       GRANT           NULL          NULL
-NULL     root     def            system        zones       INSERT          NULL          NULL
-NULL     root     def            system        zones       SELECT          NULL          NULL
-NULL     root     def            system        zones       UPDATE          NULL          NULL
+grantor  grantee  table_catalog  table_schema  table_name    privilege_type  is_grantable  with_hierarchy  
+NULL     root     def            system        descriptor    GRANT           NULL          NULL            
+NULL     root     def            system        descriptor    SELECT          NULL          NULL            
+NULL     root     def            system        eventlog      DELETE          NULL          NULL            
+NULL     root     def            system        eventlog      GRANT           NULL          NULL            
+NULL     root     def            system        eventlog      INSERT          NULL          NULL            
+NULL     root     def            system        eventlog      SELECT          NULL          NULL            
+NULL     root     def            system        eventlog      UPDATE          NULL          NULL            
+NULL     root     def            system        jobs          DELETE          NULL          NULL            
+NULL     root     def            system        jobs          GRANT           NULL          NULL            
+NULL     root     def            system        jobs          INSERT          NULL          NULL            
+NULL     root     def            system        jobs          SELECT          NULL          NULL            
+NULL     root     def            system        jobs          UPDATE          NULL          NULL            
+NULL     root     def            system        lease         DELETE          NULL          NULL            
+NULL     root     def            system        lease         GRANT           NULL          NULL            
+NULL     root     def            system        lease         INSERT          NULL          NULL            
+NULL     root     def            system        lease         SELECT          NULL          NULL            
+NULL     root     def            system        lease         UPDATE          NULL          NULL            
+NULL     root     def            system        namespace     GRANT           NULL          NULL            
+NULL     root     def            system        namespace     SELECT          NULL          NULL            
+NULL     root     def            system        rangelog      DELETE          NULL          NULL            
+NULL     root     def            system        rangelog      GRANT           NULL          NULL            
+NULL     root     def            system        rangelog      INSERT          NULL          NULL            
+NULL     root     def            system        rangelog      SELECT          NULL          NULL            
+NULL     root     def            system        rangelog      UPDATE          NULL          NULL            
+NULL     root     def            system        settings      DELETE          NULL          NULL            
+NULL     root     def            system        settings      GRANT           NULL          NULL            
+NULL     root     def            system        settings      INSERT          NULL          NULL            
+NULL     root     def            system        settings      SELECT          NULL          NULL            
+NULL     root     def            system        settings      UPDATE          NULL          NULL            
+NULL     root     def            system        ui            DELETE          NULL          NULL            
+NULL     root     def            system        ui            GRANT           NULL          NULL            
+NULL     root     def            system        ui            INSERT          NULL          NULL            
+NULL     root     def            system        ui            SELECT          NULL          NULL            
+NULL     root     def            system        ui            UPDATE          NULL          NULL            
+NULL     root     def            system        users         DELETE          NULL          NULL            
+NULL     root     def            system        users         GRANT           NULL          NULL            
+NULL     root     def            system        users         INSERT          NULL          NULL            
+NULL     root     def            system        users         SELECT          NULL          NULL            
+NULL     root     def            system        users         UPDATE          NULL          NULL            
+NULL     root     def            system        web_sessions  DELETE          NULL          NULL            
+NULL     root     def            system        web_sessions  GRANT           NULL          NULL            
+NULL     root     def            system        web_sessions  INSERT          NULL          NULL            
+NULL     root     def            system        web_sessions  SELECT          NULL          NULL            
+NULL     root     def            system        web_sessions  UPDATE          NULL          NULL            
+NULL     root     def            system        zones         DELETE          NULL          NULL            
+NULL     root     def            system        zones         GRANT           NULL          NULL            
+NULL     root     def            system        zones         INSERT          NULL          NULL            
+NULL     root     def            system        zones         SELECT          NULL          NULL            
+NULL     root     def            system        zones         UPDATE          NULL          NULL
 
 statement ok
 CREATE TABLE other_db.xyz (i INT)

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -144,6 +144,7 @@ rangelog
 settings
 ui
 users
+web_sessions
 zones
 
 query ITTTT colnames

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -21,6 +21,7 @@ rangelog
 settings
 ui
 users
+web_sessions
 zones
 
 query T
@@ -49,24 +50,27 @@ fetched: /namespace/primary/1/'ui'/id -> 14
 output row: [1 'ui' 14]
 fetched: /namespace/primary/1/'users'/id -> 4
 output row: [1 'users' 4]
+fetched: /namespace/primary/1/'web_sessions'/id -> 19
+output row: [1 'web_sessions' 19]
 fetched: /namespace/primary/1/'zones'/id -> 5
 output row: [1 'zones' 5]
 
 query ITI rowsort
 SELECT * FROM system.namespace
 ----
-0 system     1
-0 test       50
-1 descriptor 3
-1 eventlog   12
-1 jobs       15
-1 lease      11
-1 namespace  2
-1 rangelog   13
-1 settings   6
-1 ui         14
-1 users      4
-1 zones      5
+0 system        1
+0 test          50
+1 descriptor    3
+1 eventlog      12
+1 jobs          15
+1 lease         11
+1 namespace     2
+1 rangelog      13
+1 settings      6
+1 ui            14
+1 users         4
+1 web_sessions  19
+1 zones         5
 
 query I rowsort
 SELECT id FROM system.descriptor
@@ -82,6 +86,7 @@ SELECT id FROM system.descriptor
 13
 14
 15
+19
 50
 
 # Verify we can read "protobuf" columns.

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -654,7 +654,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("users", "primary", true, 1, "username", "ASC", false, false),
 		},
 		"SHOW TABLES FROM system": {
-			baseTest.Results("descriptor").Others(9),
+			baseTest.Results("descriptor").Others(10),
 		},
 		"SHOW CONSTRAINTS FROM system.users": {
 			baseTest.Results("users", "primary", "PRIMARY KEY", "username", gosql.NullString{}),

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -121,6 +121,25 @@ CREATE TABLE system.jobs (
 	INDEX (status, created),
 	FAMILY (id, status, created, payload)
 );`
+
+	// web_sessions are used to track authenticated user actions over stateless
+	// connections, such as the cookie-based authentication used by the Admin
+	// UI.
+	// Design outlined in /docs/RFCS/web_session_login.rfc
+	WebSessionsTableSchema = `
+CREATE TABLE system.web_sessions (
+	id             SERIAL     PRIMARY KEY,
+	"hashedSecret" BYTES      NOT NULL,
+	username       STRING     NOT NULL,
+	"createdAt"    TIMESTAMP  NOT NULL DEFAULT now(),
+	"expiresAt"    TIMESTAMP  NOT NULL,
+	"revokedAt"    TIMESTAMP,
+	"lastUsedAt"   TIMESTAMP  NOT NULL DEFAULT now(),
+	"auditInfo"    STRING,
+	INDEX("expiresAt"),
+	INDEX("createdAt"),
+	FAMILY(id, "hashedSecret", username, "createdAt", "expiresAt", "revokedAt", "lastUsedAt", "auditInfo")
+);`
 )
 
 func pk(name string) IndexDescriptor {
@@ -172,7 +191,8 @@ var SystemAllowedPrivileges = map[ID]privilege.Lists{
 	// users will be able to modify system tables' schemas at will. CREATE and
 	// DROP privileges are allowed on the above system tables for backwards
 	// compatibility reasons only!
-	keys.JobsTableID: {privilege.ReadWriteData},
+	keys.JobsTableID:        {privilege.ReadWriteData},
+	keys.WebSessionsTableID: {privilege.ReadWriteData},
 }
 
 // SystemDesiredPrivileges returns the desired privilege list (i.e., the
@@ -519,6 +539,72 @@ var (
 		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.JobsTableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
+	}
+
+	// WebSessions table to authenticate sessions over stateless connections.
+	WebSessionsTable = TableDescriptor{
+		Name:     "web_sessions",
+		ID:       19,
+		ParentID: 1,
+		Version:  1,
+		Columns: []ColumnDescriptor{
+			{Name: "id", ID: 1, Type: colTypeInt, DefaultExpr: &uniqueRowIDString},
+			{Name: "hashedSecret", ID: 2, Type: colTypeBytes},
+			{Name: "username", ID: 3, Type: colTypeString},
+			{Name: "createdAt", ID: 4, Type: colTypeTimestamp, DefaultExpr: &nowString},
+			{Name: "expiresAt", ID: 5, Type: colTypeTimestamp},
+			{Name: "revokedAt", ID: 6, Type: colTypeTimestamp, Nullable: true},
+			{Name: "lastUsedAt", ID: 7, Type: colTypeTimestamp, DefaultExpr: &nowString},
+			{Name: "auditInfo", ID: 8, Type: colTypeString, Nullable: true},
+		},
+		NextColumnID: 9,
+		Families: []ColumnFamilyDescriptor{
+			{
+				Name: "fam_0_id_hashedSecret_username_createdAt_expiresAt_revokedAt_lastUsedAt_auditInfo",
+				ID:   0,
+				ColumnNames: []string{
+					"id",
+					"hashedSecret",
+					"username",
+					"createdAt",
+					"expiresAt",
+					"revokedAt",
+					"lastUsedAt",
+					"auditInfo",
+				},
+				ColumnIDs: []ColumnID{1, 2, 3, 4, 5, 6, 7, 8},
+			},
+		},
+		NextFamilyID: 1,
+		PrimaryIndex: pk("id"),
+		Indexes: []IndexDescriptor{
+			{
+				Name:             "web_sessions_expiresAt_idx",
+				ID:               2,
+				Unique:           false,
+				ColumnNames:      []string{"expiresAt"},
+				ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+				ColumnIDs:        []ColumnID{5},
+				ExtraColumnIDs:   []ColumnID{1},
+			},
+			{
+				Name:             "web_sessions_createdAt_idx",
+				ID:               3,
+				Unique:           false,
+				ColumnNames:      []string{"createdAt"},
+				ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+				ColumnIDs:        []ColumnID{4},
+				ExtraColumnIDs:   []ColumnID{1},
+			},
+		},
+		NextIndexID: 4,
+		Privileges: &PrivilegeDescriptor{
+			Users: []UserPrivileges{
+				{User: "root", Privileges: 0x1f0},
+			},
+		},
+		NextMutationID: 1,
+		FormatVersion:  3,
 	}
 )
 

--- a/pkg/sql/system_table_test.go
+++ b/pkg/sql/system_table_test.go
@@ -117,6 +117,7 @@ func TestSystemTableLiterals(t *testing.T) {
 		{keys.UITableID, sqlbase.UITableSchema, sqlbase.UITable},
 		{keys.JobsTableID, sqlbase.JobsTableSchema, sqlbase.JobsTable},
 		{keys.SettingsTableID, sqlbase.SettingsTableSchema, sqlbase.SettingsTable},
+		{keys.WebSessionsTableID, sqlbase.WebSessionsTableSchema, sqlbase.WebSessionsTable},
 	} {
 		gen, err := sql.CreateTestTableDescriptor(
 			context.TODO(),

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1516,26 +1516,11 @@ func TestSystemZoneConfigs(t *testing.T) {
 	ctx := context.TODO()
 	defer tc.Stopper().Stop(ctx)
 
-	// Before moving forward, pre-split the keys for the system zone configs.
-	// If we don't do this, the test can flake on the splits happening at an
-	// inopportune time (or on the replicate queue blocking on a needed split
-	// if we disable the split queue).
-	splitKeys := []roachpb.Key{
-		keys.MakeTablePrefix(keys.MetaRangesID),
-		keys.MakeTablePrefix(keys.TimeseriesRangesID),
-		keys.MakeTablePrefix(keys.SystemRangesID),
-	}
-	for _, key := range splitKeys {
-		if _, _, err := tc.SplitRange(key); err != nil {
-			t.Fatalf("failed to split at key %s: %s", key, err)
-		}
-	}
-
 	expectedRanges, err := tc.Servers[0].ExpectedInitialRangeCount()
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedReplicas := (expectedRanges + len(splitKeys)) * int(config.DefaultZoneConfig().NumReplicas)
+	expectedReplicas := expectedRanges * int(config.DefaultZoneConfig().NumReplicas)
 
 	waitForReplicas := func() error {
 		var conflictingID roachpb.RangeID


### PR DESCRIPTION
Add system.sessions table, which will be used to create user login
sessions for the Admin UI. Includes:

+ Definition of the new table
+ A backwards-compatible migration to add the table
+ Added a case to `TestSystemTableLiterals` to verify the new table
+ Updated a multitude of tests which explictly check the system schema,
they now account for the new table.