### PR TITLE
tracing: rework local Batch logic+ some bug fixes

### DIFF
--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -251,7 +251,6 @@ func (br *BatchResponse) Combine(otherBatch *BatchResponse, positions []int) err
 		}
 	}
 	br.Txn.Update(otherBatch.Txn)
-	br.CollectedSpans = append(br.CollectedSpans, otherBatch.CollectedSpans...)
 	return nil
 }
 

--- a/pkg/util/tracing/shadow.go
+++ b/pkg/util/tracing/shadow.go
@@ -27,6 +27,7 @@ import (
 	"os"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	lightstep "github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
 	zipkin "github.com/openzipkin/zipkin-go-opentracing"
@@ -112,7 +113,7 @@ func linkShadowSpan(
 var lightStepToken = settings.RegisterStringSetting(
 	"trace.lightstep.token",
 	"if set, traces go to Lightstep using this token",
-	"",
+	envutil.EnvOrDefaultString("COCKROACH_TEST_LIGHTSTEP_TOKEN", ""),
 )
 
 func createLightStepTracer(token string) (shadowTracerManager, opentracing.Tracer) {
@@ -127,7 +128,7 @@ func createLightStepTracer(token string) (shadowTracerManager, opentracing.Trace
 var zipkinCollector = settings.RegisterStringSetting(
 	"trace.zipkin.collector",
 	"if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.",
-	"",
+	envutil.EnvOrDefaultString("COCKROACH_TEST_ZIPKIN_COLLECTOR", ""),
 )
 
 func createZipkinTracer(collectorAddr string) (shadowTracerManager, opentracing.Tracer) {

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -238,10 +238,6 @@ func (t *Tracer) StartSpan(
 	}
 	s.mu.duration = -1
 
-	for k, v := range sso.Tags {
-		s.SetTag(k, v)
-	}
-
 	if !hasParent {
 		// No parent Span; allocate new trace id.
 		s.TraceID = uint64(rand.Int63())
@@ -279,11 +275,14 @@ func (t *Tracer) StartSpan(
 		}
 	}
 
-	if netTrace || shadowTr != nil {
-		// Copy baggage items to tags so they show up in the shadow tracer UI or x/net/trace.
-		for k, v := range s.mu.Baggage {
-			s.SetTag(k, v)
-		}
+	for k, v := range sso.Tags {
+		s.SetTag(k, v)
+	}
+
+	// Copy baggage items to tags so they show up in the shadow tracer UI,
+	// x/net/trace, or recordings.
+	for k, v := range s.mu.Baggage {
+		s.SetTag(k, v)
 	}
 
 	return s

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -137,17 +137,6 @@ func (s *span) enableRecording(group *spanGroup, recType RecordingType) {
 	group.addSpan(s)
 }
 
-// GetSpanTag returns the value of a tag in a span.
-func GetSpanTag(os opentracing.Span, key string) interface{} {
-	if _, noop := os.(*noopSpan); noop {
-		return nil
-	}
-	sp := os.(*span)
-	sp.mu.Lock()
-	defer sp.mu.Unlock()
-	return sp.mu.tags[key]
-}
-
 // StartRecording enables recording on the span. Events from this point forward
 // are recorded; also, all direct and indirect child spans started from now on
 // will be part of the same recording.


### PR DESCRIPTION
### tracing: env vars for default value for lightstep and zipkin

Adding env vars to allow use of Lightstep or Zipkin with `make test` without
modifying code.

### tracing: don't combine CollectedSpans twice

As of #12142, we accidentally append CollectedSpans twice when combining BatchResponses. This leads to duplicate spans with snowball tracing.

### tracing: set StartSpan tags after setting up the spa

We were setting the StartSpan tags too early: the span wasn't yet set up so the tags weren't being recorded.

### tracing: rework local Batch logic

To determine if a Batch is local or comes from gRPC, we check for a special tag set by the gRPC interceptor in the current span. This is not currently working in all cases - if we are not recording, we don't actually remember the tag.

Fortunately, we have a more reliable mechanism (which I wasn't aware of before) to determine if a batch is local (`IsLocalRequest`). This change switches the logic to use `IsLocalRequest` and removes `tracing.GetSpanTag`.

A remaining issue is that `TestTrace` was passing even though snowball tracing was broken. This is because we see the gRPC client-side Batch span and that's good enough as far as the test is concerned. This problem will go away when we remove the gRPC client-side span (requires an upstream change to the interceptors).

Fixes #17175.