### PR TITLE
kv: more efficient trace spans

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -259,7 +259,7 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv2]
 (0,1)  starting plan   DelRange /Table/53/1 - /Table/53/2
 (0,1)  starting plan   querying next range at /Table/53/1
 (0,1)  starting plan   r1: sending batch 1 DelRng, 1 BeginTxn, 1 EndTxn to (n1,s1):1
-(0,6)  consuming rows  fast path - rows affected: 2
+(0,4)  consuming rows  fast path - rows affected: 2
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DROP TABLE t.kv2] WHERE message NOT LIKE '%Z/%'

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -74,7 +74,6 @@ func TestTrace(t *testing.T) {
 			},
 			expSpans: []string{
 				"sql txn implicit",
-				"grpcTransport SendNext",
 				"/cockroach.roachpb.Internal/Batch",
 			},
 		},
@@ -110,7 +109,6 @@ func TestTrace(t *testing.T) {
 			},
 			expSpans: []string{
 				"sql txn implicit",
-				"grpcTransport SendNext",
 				"flow",
 				"table reader",
 				"/cockroach.roachpb.Internal/Batch",
@@ -136,7 +134,6 @@ func TestTrace(t *testing.T) {
 				"sql txn implicit",
 				"starting plan",
 				"consuming rows",
-				"grpcTransport SendNext",
 				"/cockroach.roachpb.Internal/Batch",
 			},
 		},


### PR DESCRIPTION
It's late and there may be a brain fart or two, but the basic principle in this
PR should work.

----

@jordanlewis pointed out in #17174 that we are creating various spans in the
kv subsystem that aren't helpful and do little more than clutter the UI. One
offender was the span opened by `SendNext`, which was especially annoying
since it wasn't a plain "child span" but a complete forked span (which means
that it could outlive the parent span). This was born out of necessity: the
goroutines launched by SendNext could outlive the caller's use of the
transport. This is fixed here and the behavior now is the following:

- always use the existing span for requests to the local server
- always use the existing span unless we're launching a second goroutine
- otherwise, use a ChildSpan (not a forked span). This is safe because:
- upon closing the transport, force the caller to wait for all goroutines
  to finish (cancels all contexts to make that faster).

In the usual case, we send exactly one RPC which then will always be logged
into the caller's existing span, so we shouldn't be seeing SendNext child
spans usually.