### PR TITLE
retry: avoid use of nil context

### DIFF
--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -46,7 +46,7 @@ type Retry struct {
 // Start returns a new Retry initialized to some default values. The Retry can
 // then be used in an exponential-backoff retry loop.
 func Start(opts Options) Retry {
-	return StartWithCtx(nil, opts)
+	return StartWithCtx(context.Background(), opts)
 }
 
 // StartWithCtx returns a new Retry initialized to some default values. The
@@ -67,9 +67,7 @@ func StartWithCtx(ctx context.Context, opts Options) Retry {
 	}
 
 	r := Retry{opts: opts}
-	if ctx != nil {
-		r.ctxDoneChan = ctx.Done()
-	}
+	r.ctxDoneChan = ctx.Done()
 	r.Reset()
 	return r
 }

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 func TestRetryExceedsMaxBackoff(t *testing.T) {
@@ -141,7 +143,7 @@ func TestRetryWithMaxAttempts(t *testing.T) {
 		return expectedErr
 	}
 
-	actualErr := WithMaxAttempts(nil, opts, maxAttempts, errFn)
+	actualErr := WithMaxAttempts(context.TODO(), opts, maxAttempts, errFn)
 	if actualErr != expectedErr {
 		t.Fatalf("expected err %v, got %v", expectedErr, actualErr)
 	}


### PR DESCRIPTION
Caught by Metacheck presumably because I'm running go1.9? Either way, this
was slightly sketchy.