### PR TITLE
tracing: avoid gRPC packets/op regression when tracing is disabled

### DIFF
--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -163,7 +163,7 @@ func (t *Tracer) StartSpan(
 	// case) with a noop context, return a noop span now.
 	if len(opts) == 1 {
 		if o, ok := opts[0].(opentracing.SpanReference); ok {
-			if _, noopCtx := o.ReferencedContext.(noopSpanContext); noopCtx {
+			if IsNoopContext(o.ReferencedContext) {
 				return &t.noopSpan
 			}
 		}
@@ -198,7 +198,7 @@ func (t *Tracer) StartSpan(
 		if r.ReferencedContext == nil {
 			continue
 		}
-		if _, noopCtx := r.ReferencedContext.(noopSpanContext); noopCtx {
+		if IsNoopContext(r.ReferencedContext) {
 			continue
 		}
 		hasParent = true
@@ -372,7 +372,7 @@ func (fn textMapWriterFn) Set(key, val string) {
 func (t *Tracer) Inject(
 	osc opentracing.SpanContext, format interface{}, carrier interface{},
 ) error {
-	if _, noopCtx := osc.(noopSpanContext); noopCtx {
+	if IsNoopContext(osc) {
 		// Fast path when tracing is disabled. Extract will accept an empty map as a
 		// noop context.
 		return nil

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -236,6 +236,13 @@ func IsBlackHoleSpan(s opentracing.Span) bool {
 	return !sp.isRecording() && sp.netTr == nil && sp.shadowTr == nil
 }
 
+// IsNoopContext returns true if the span context is from a "no-op" span. If
+// this is true, any span derived from this context will be a "black hole span".
+func IsNoopContext(spanCtx opentracing.SpanContext) bool {
+	_, noop := spanCtx.(noopSpanContext)
+	return noop
+}
+
 // Finish is part of the opentracing.Span interface.
 func (s *span) Finish() {
 	s.FinishWithOptions(opentracing.FinishOptions{})


### PR DESCRIPTION
The OpenTracing gRPC interceptor is causing increased packets/op, even when
tracing is disabled (#17177). Fixing this by using a callback that can
short-circuit the interceptor's work.