### PR TITLE
distsql: add external storage to the hashJoiner

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -297,8 +297,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 	var tempEngine engine.Engine
 
-	if allInMemory {
-		log.Warning(ctx, "all stores are configured as in-memory stores, so not setting up a temporary store. Queries with working set larger than memory will fail")
+	if allInMemory && !s.cfg.TempStore.InMemory {
+		log.Warning(ctx, "all stores are configured as in-memory stores, so not setting up a disk-backed temporary store. Queries with working set larger than memory will fail")
 	} else {
 		var err error
 		// Set up TempEngine for DistSQL. Note that it could be nil, which we support,

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -157,9 +157,11 @@ func (rs ReportingSettings) HasCrashReportsEnabled() bool {
 
 // DistSQLSettings is the subset of ClusterSettings affecting DistSQL.
 type DistSQLSettings struct {
-	DistSQLUseTempStorage *settings.BoolSetting
-	DistributeIndexJoin   *settings.BoolSetting
-	PlanMergeJoins        *settings.BoolSetting
+	DistSQLUseTempStorage      *settings.BoolSetting
+	DistSQLUseTempStorageSorts *settings.BoolSetting
+	DistSQLUseTempStorageJoins *settings.BoolSetting
+	DistributeIndexJoin        *settings.BoolSetting
+	PlanMergeJoins             *settings.BoolSetting
 }
 
 // SQLStatsSettings is the subset of ClusterSettings affecting SQL statistics
@@ -454,6 +456,18 @@ func MakeClusterSettings() *Settings {
 		"sql.defaults.distsql.tempstorage",
 		"set to true to enable use of disk for larger distributed sql queries",
 		false,
+	)
+
+	s.DistSQLUseTempStorageSorts = r.RegisterBoolSetting(
+		"sql.defaults.distsql.tempstorage.sorts",
+		"set to true to enable use of disk for distributed sql sorts. sql.defaults.distsql.tempstorage must be true",
+		true,
+	)
+
+	s.DistSQLUseTempStorageJoins = r.RegisterBoolSetting(
+		"sql.defaults.distsql.tempstorage.joins",
+		"set to true to enable use of disk for distributed sql joins. sql.defaults.distsql.tempstorage must be true",
+		true,
 	)
 
 	// StmtStatsEnable determines whether to collect per-statement

--- a/pkg/sql/distsqlrun/hash_row_container.go
+++ b/pkg/sql/distsqlrun/hash_row_container.go
@@ -1,0 +1,301 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"unsafe"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/mon"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+)
+
+// rowMarkerIterator is a rowIterator that can be used to mark rows.
+type rowMarkerIterator interface {
+	rowIterator
+	Mark(ctx context.Context, mark bool) error
+}
+
+// hashRowContainer is a container used to store rows according to an encoding
+// of given equality columns. The stored rows can then be probed to return a
+// bucket of matching rows. Additionally, each stored row can be marked and all
+// rows that are unmarked can be iterated over. An example of where this is
+// useful is in full/outer joins. The caller can mark all matched rows and
+// iterate over the unmarked rows to produce a result.
+type hashRowContainer interface {
+	// Init initializes the hashRowContainer with the given equality columns.
+	// The hashRowContainer will store rows in buckets matching the encoding
+	// of their storedEqCols and given a row, will return rows in the bucket
+	// matching the encoding of its probeEqCols.
+	Init(ctx context.Context, storedEqCols, probeEqCols columns) error
+	AddRow(context.Context, sqlbase.EncDatumRow) error
+
+	// NewBucketIterator returns a rowMarkerIterator that iterates over a bucket
+	// of rows that match the given row on equality columns. This iterator can
+	// also be used to mark rows.
+	// Rows are marked because of the use of this interface by the hashJoiner.
+	// Given a row, the hashJoiner does not necessarily want to emit all rows
+	// that match on equality columns. There is an additional `ON` clause that
+	// specifies an arbitrary expression that matching rows must pass to be
+	// emitted. For full/outer joins, this is tracked through marking rows if
+	// they match and then iterating over all unmarked rows to emit those that
+	// did not match.
+	NewBucketIterator(context.Context, sqlbase.EncDatumRow) (rowMarkerIterator, error)
+
+	// NewUnmarkedIterator returns a rowIterator that iterates over unmarked
+	// rows.
+	NewUnmarkedIterator(context.Context) rowIterator
+
+	// Close frees up resources held by the hashRowContainer.
+	Close(context.Context)
+}
+
+// columnEncoder is a utility struct used by implementations of hashRowContainer
+// to encode equality columns, the result of which is used as a key to a bucket.
+type columnEncoder struct {
+	scratch    []byte
+	datumAlloc sqlbase.DatumAlloc
+}
+
+// TODO(asubiotto): This logic could be shared with the diskRowContainer.
+func (e columnEncoder) encodeEqualityCols(
+	ctx context.Context, row sqlbase.EncDatumRow, eqCols columns,
+) ([]byte, error) {
+	encoded, hasNull, err := encodeColumnsOfRow(
+		&e.datumAlloc, e.scratch, row, eqCols, false, /* encodeNull */
+	)
+	if err != nil {
+		return nil, err
+	}
+	e.scratch = encoded[:0]
+	if hasNull {
+		log.Fatal(ctx, "cannot process rows with NULL in an equality column")
+	}
+	return encoded, nil
+}
+
+const sizeOfBucket = int64(unsafe.Sizeof([]int{}))
+const sizeOfRowIdx = int64(unsafe.Sizeof(int(0)))
+const sizeOfBoolSlice = int64(unsafe.Sizeof([]bool{}))
+const sizeOfBool = int64(unsafe.Sizeof(false))
+
+// hashMemRowContainer is an in-memory implementation of a hashRowContainer.
+// The rows are stored in an underlying memRowContainer and an accompanying
+// map stores the mapping from equality column encodings to indices in the
+// memRowContainer corresponding to matching rows.
+// NOTE: Once a row is marked, adding more rows to the hashMemRowContainer
+// results in undefined behavior. It is not necessary to do otherwise for the
+// current usage of hashMemRowContainer and allows us to assume that a memory
+// error can only occur at the start of the marking phase, thus not having to
+// deal with half-emitted buckets and marks when falling back to disk.
+type hashMemRowContainer struct {
+	// TODO(asubiotto): This memRowContainer then has an underlying
+	// sqlbase.RowContainer. This can be cleaned up.
+	*memRowContainer
+	columnEncoder
+
+	// marked specifies for each row in memRowContainer whether that row has
+	// been marked. Used for iterating over unmarked rows.
+	marked []bool
+
+	// buckets contains the indices into memRowContainer for a given group
+	// key (which is the encoding of storedEqCols).
+	buckets map[string][]int
+	// bucketsAcc is the memory account for the buckets. The datums themselves
+	// are all in the memRowContainer.
+	bucketsAcc mon.BoundAccount
+
+	// {stored, probe}eqCols contain the indices of the columns of a row that
+	// are encoded and used as a key into buckets. probeEqCols are used in
+	// NewBucketIterator(), and storedEqCols are used in AddRow().
+	storedEqCols columns
+	probeEqCols  columns
+}
+
+var _ hashRowContainer = &hashMemRowContainer{}
+
+// makeHashMemRowContainer creates a hashMemRowContainer from the given
+// rowContainer. This rowContainer must still be Close()d by the caller.
+func makeHashMemRowContainer(
+	ctx context.Context, rowContainer *memRowContainer,
+) hashMemRowContainer {
+	return hashMemRowContainer{
+		memRowContainer: rowContainer,
+		buckets:         make(map[string][]int),
+		bucketsAcc:      rowContainer.evalCtx.Mon.MakeBoundAccount(),
+	}
+}
+
+// Init implements the hashRowContainer interface.
+func (h *hashMemRowContainer) Init(ctx context.Context, storedEqCols, probeEqCols columns) error {
+	if h.storedEqCols != nil || h.probeEqCols != nil {
+		return errors.New("hashMemRowContainer has already been initialized")
+	}
+
+	h.storedEqCols = storedEqCols
+	h.probeEqCols = probeEqCols
+
+	// Build buckets from the rowContainer.
+	for rowIdx := 0; rowIdx < h.Len(); rowIdx++ {
+		if err := h.addRowToBucket(ctx, h.EncRow(rowIdx), rowIdx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AddRow adds a row to the hashMemRowContainer. This row is unmarked by default.
+func (h *hashMemRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) error {
+	rowIdx := h.Len()
+	if err := h.memRowContainer.AddRow(ctx, row); err != nil {
+		return err
+	}
+	return h.addRowToBucket(ctx, row, rowIdx)
+}
+
+// Close implements the hashRowContainer interface.
+func (h *hashMemRowContainer) Close(ctx context.Context) {
+	h.bucketsAcc.Close(ctx)
+}
+
+// addRowToBucket is a helper function that encodes the equality columns of the
+// given row and appends the rowIdx to the matching bucket.
+func (h *hashMemRowContainer) addRowToBucket(
+	ctx context.Context, row sqlbase.EncDatumRow, rowIdx int,
+) error {
+	encoded, err := h.encodeEqualityCols(ctx, row, h.storedEqCols)
+	if err != nil {
+		return err
+	}
+
+	_, ok := h.buckets[string(encoded)]
+
+	usage := sizeOfRowIdx
+	if !ok {
+		usage += int64(len(encoded))
+		usage += sizeOfBucket
+	}
+
+	if err := h.bucketsAcc.Grow(ctx, usage); err != nil {
+		return err
+	}
+
+	h.buckets[string(encoded)] = append(h.buckets[string(encoded)], rowIdx)
+	return nil
+}
+
+// hashMemRowBucketIterator iterates over the rows in a bucket.
+type hashMemRowBucketIterator struct {
+	*hashMemRowContainer
+	// rowIdxs are the indices of rows in the bucket.
+	rowIdxs []int
+	curIdx  int
+}
+
+var _ rowMarkerIterator = &hashMemRowBucketIterator{}
+
+// NewBucketIterator implements the hashRowContainer interface.
+func (h *hashMemRowContainer) NewBucketIterator(
+	ctx context.Context, row sqlbase.EncDatumRow,
+) (rowMarkerIterator, error) {
+	encoded, err := h.encodeEqualityCols(ctx, row, h.probeEqCols)
+	if err != nil {
+		return nil, err
+	}
+
+	return &hashMemRowBucketIterator{hashMemRowContainer: h, rowIdxs: h.buckets[string(encoded)]}, nil
+}
+
+// Rewind implements the rowIterator interface.
+func (i *hashMemRowBucketIterator) Rewind() {
+	i.curIdx = 0
+}
+
+// Valid implements the rowIterator interface.
+func (i *hashMemRowBucketIterator) Valid() (bool, error) {
+	return i.curIdx < len(i.rowIdxs), nil
+}
+
+// Next implements the rowIterator interface.
+func (i *hashMemRowBucketIterator) Next() {
+	i.curIdx++
+}
+
+// Row implements the rowIterator interface.
+func (i *hashMemRowBucketIterator) Row() (sqlbase.EncDatumRow, error) {
+	return i.EncRow(i.rowIdxs[i.curIdx]), nil
+}
+
+// Mark implements the rowMarkerIterator interface.
+func (i *hashMemRowBucketIterator) Mark(ctx context.Context, mark bool) error {
+	if i.marked == nil {
+		if err := i.bucketsAcc.Grow(ctx, sizeOfBoolSlice+(sizeOfBool*int64(i.Len()))); err != nil {
+			return err
+		}
+		i.marked = make([]bool, i.Len())
+	}
+
+	i.marked[i.rowIdxs[i.curIdx]] = mark
+	return nil
+}
+
+// Close implements the rowIterator interface.
+func (i *hashMemRowBucketIterator) Close() {}
+
+// hashMemRowIterator iterates over all unmarked rows in a hashMemRowContainer.
+type hashMemRowIterator struct {
+	*hashMemRowContainer
+	curIdx int
+}
+
+var _ rowIterator = &hashMemRowIterator{}
+
+// NewUnmarkedIterator implements the hashRowContainer interface.
+func (h *hashMemRowContainer) NewUnmarkedIterator(ctx context.Context) rowIterator {
+	return &hashMemRowIterator{hashMemRowContainer: h}
+}
+
+// Rewind implements the rowIterator interface.
+func (i *hashMemRowIterator) Rewind() {
+	i.curIdx = -1
+	// Next will advance curIdx to the first unmarked row.
+	i.Next()
+}
+
+// Valid implements the rowIterator interface.
+func (i *hashMemRowIterator) Valid() (bool, error) {
+	return i.curIdx < i.Len(), nil
+}
+
+// Next implements the rowIterator interface.
+func (i *hashMemRowIterator) Next() {
+	// Move the curIdx to the next unmarked row.
+	i.curIdx++
+	if i.marked != nil {
+		for ; i.curIdx < len(i.marked) && i.marked[i.curIdx]; i.curIdx++ {
+		}
+	}
+}
+
+// Row implements the rowIterator interface.
+func (i *hashMemRowIterator) Row() (sqlbase.EncDatumRow, error) {
+	return i.EncRow(i.curIdx), nil
+}
+
+// Close implements the rowIterator interface.
+func (i *hashMemRowIterator) Close() {}

--- a/pkg/sql/distsqlrun/hash_row_container.go
+++ b/pkg/sql/distsqlrun/hash_row_container.go
@@ -15,12 +15,16 @@
 package distsqlrun
 
 import (
+	"bytes"
 	"unsafe"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 )
@@ -39,10 +43,17 @@ type rowMarkerIterator interface {
 // iterate over the unmarked rows to produce a result.
 type hashRowContainer interface {
 	// Init initializes the hashRowContainer with the given equality columns.
-	// The hashRowContainer will store rows in buckets matching the encoding
-	// of their storedEqCols and given a row, will return rows in the bucket
-	// matching the encoding of its probeEqCols.
-	Init(ctx context.Context, storedEqCols, probeEqCols columns) error
+	//	- shouldMark specifies whether the caller cares about marking rows. If
+	//	  not, the hashRowContainer will not perform any row marking logic. This
+	//	  is meant to optimize space usage and runtime.
+	//	- types is the schema of rows that will be added to this container.
+	//	- storedEqCols are the equality columns of rows stored in this
+	// 	  container.
+	// 	  i.e. when adding a row, the columns specified by storedEqCols are used
+	// 	  to get the bucket that the row should be added to.
+	Init(
+		ctx context.Context, shouldMark bool, types []sqlbase.ColumnType, storedEqCols columns,
+	) error
 	AddRow(context.Context, sqlbase.EncDatumRow) error
 
 	// NewBucketIterator returns a rowMarkerIterator that iterates over a bucket
@@ -55,9 +66,14 @@ type hashRowContainer interface {
 	// emitted. For full/outer joins, this is tracked through marking rows if
 	// they match and then iterating over all unmarked rows to emit those that
 	// did not match.
-	NewBucketIterator(context.Context, sqlbase.EncDatumRow) (rowMarkerIterator, error)
+	// 	- probeEqCols are the equality columns of the given row that are used to
+	// 	  get the bucket of matching rows.
+	NewBucketIterator(
+		ctx context.Context, row sqlbase.EncDatumRow, probeEqCols columns,
+	) (rowMarkerIterator, error)
 
 	// NewUnmarkedIterator returns a rowIterator that iterates over unmarked
+	// rows. If shouldMark was false in Init(), this iterator iterates over all
 	// rows.
 	NewUnmarkedIterator(context.Context) rowIterator
 
@@ -72,6 +88,9 @@ type columnEncoder struct {
 	datumAlloc sqlbase.DatumAlloc
 }
 
+// encodeEqualityCols returns the encoding of the specified columns of the given
+// row. The returned byte slice is only valid until the next call to
+// encodeEqualityColumns().
 // TODO(asubiotto): This logic could be shared with the diskRowContainer.
 func (e columnEncoder) encodeEqualityCols(
 	ctx context.Context, row sqlbase.EncDatumRow, eqCols columns,
@@ -104,10 +123,12 @@ const sizeOfBool = int64(unsafe.Sizeof(false))
 // error can only occur at the start of the marking phase, thus not having to
 // deal with half-emitted buckets and marks when falling back to disk.
 type hashMemRowContainer struct {
-	// TODO(asubiotto): This memRowContainer then has an underlying
-	// sqlbase.RowContainer. This can be cleaned up.
 	*memRowContainer
 	columnEncoder
+
+	// shouldMark specifies whether the caller cares about marking rows. If not,
+	// marked is never initialized.
+	shouldMark bool
 
 	// marked specifies for each row in memRowContainer whether that row has
 	// been marked. Used for iterating over unmarked rows.
@@ -120,20 +141,16 @@ type hashMemRowContainer struct {
 	// are all in the memRowContainer.
 	bucketsAcc mon.BoundAccount
 
-	// {stored, probe}eqCols contain the indices of the columns of a row that
-	// are encoded and used as a key into buckets. probeEqCols are used in
-	// NewBucketIterator(), and storedEqCols are used in AddRow().
+	// storedEqCols contains the indices of the columns of a row that are
+	// encoded and used as a key into buckets when adding a row.
 	storedEqCols columns
-	probeEqCols  columns
 }
 
 var _ hashRowContainer = &hashMemRowContainer{}
 
 // makeHashMemRowContainer creates a hashMemRowContainer from the given
 // rowContainer. This rowContainer must still be Close()d by the caller.
-func makeHashMemRowContainer(
-	ctx context.Context, rowContainer *memRowContainer,
-) hashMemRowContainer {
+func makeHashMemRowContainer(rowContainer *memRowContainer) hashMemRowContainer {
 	return hashMemRowContainer{
 		memRowContainer: rowContainer,
 		buckets:         make(map[string][]int),
@@ -141,14 +158,17 @@ func makeHashMemRowContainer(
 	}
 }
 
-// Init implements the hashRowContainer interface.
-func (h *hashMemRowContainer) Init(ctx context.Context, storedEqCols, probeEqCols columns) error {
-	if h.storedEqCols != nil || h.probeEqCols != nil {
+// Init implements the hashRowContainer interface. types is ignored because the
+// schema is inferred from the memRowContainer.
+func (h *hashMemRowContainer) Init(
+	ctx context.Context, shouldMark bool, _ []sqlbase.ColumnType, storedEqCols columns,
+) error {
+	if h.storedEqCols != nil {
 		return errors.New("hashMemRowContainer has already been initialized")
 	}
 
+	h.shouldMark = shouldMark
 	h.storedEqCols = storedEqCols
-	h.probeEqCols = probeEqCols
 
 	// Build buckets from the rowContainer.
 	for rowIdx := 0; rowIdx < h.Len(); rowIdx++ {
@@ -211,9 +231,9 @@ var _ rowMarkerIterator = &hashMemRowBucketIterator{}
 
 // NewBucketIterator implements the hashRowContainer interface.
 func (h *hashMemRowContainer) NewBucketIterator(
-	ctx context.Context, row sqlbase.EncDatumRow,
+	ctx context.Context, row sqlbase.EncDatumRow, probeEqCols columns,
 ) (rowMarkerIterator, error) {
-	encoded, err := h.encodeEqualityCols(ctx, row, h.probeEqCols)
+	encoded, err := h.encodeEqualityCols(ctx, row, probeEqCols)
 	if err != nil {
 		return nil, err
 	}
@@ -243,6 +263,9 @@ func (i *hashMemRowBucketIterator) Row() (sqlbase.EncDatumRow, error) {
 
 // Mark implements the rowMarkerIterator interface.
 func (i *hashMemRowBucketIterator) Mark(ctx context.Context, mark bool) error {
+	if !i.shouldMark {
+		log.Fatal(ctx, "hash mem row container not set up for marking")
+	}
 	if i.marked == nil {
 		if err := i.bucketsAcc.Grow(ctx, sizeOfBoolSlice+(sizeOfBool*int64(i.Len()))); err != nil {
 			return err
@@ -299,3 +322,234 @@ func (i *hashMemRowIterator) Row() (sqlbase.EncDatumRow, error) {
 
 // Close implements the rowIterator interface.
 func (i *hashMemRowIterator) Close() {}
+
+// hashDiskRowContainer is an on-disk implementation of a hashRowContainer.
+// The rows are stored in an underlying diskRowContainer with an extra boolean
+// column to keep track of that row's mark.
+type hashDiskRowContainer struct {
+	diskRowContainer
+	columnEncoder
+
+	diskMonitor *mon.BytesMonitor
+	// shouldMark specifies whether the caller cares about marking rows. If not,
+	// rows are stored with one less column (which usually specifies that row's
+	// mark).
+	shouldMark    bool
+	engine        engine.Engine
+	scratchEncRow sqlbase.EncDatumRow
+}
+
+var _ hashRowContainer = &hashDiskRowContainer{}
+
+var (
+	encodedTrue  = encoding.EncodeBoolValue(nil, encoding.NoColumnID, true)
+	encodedFalse = encoding.EncodeBoolValue(nil, encoding.NoColumnID, false)
+)
+
+// makeHashDiskRowContainer creates a hashDiskRowContainer with the given engine
+// as the underlying store that rows are stored on. shouldMark specifies whether
+// the hashDiskRowContainer should set itself up to mark rows.
+func makeHashDiskRowContainer(diskMonitor *mon.BytesMonitor, e engine.Engine) hashDiskRowContainer {
+	return hashDiskRowContainer{diskMonitor: diskMonitor, engine: e}
+}
+
+// Init implements the hashRowContainer interface.
+func (h *hashDiskRowContainer) Init(
+	ctx context.Context, shouldMark bool, types []sqlbase.ColumnType, storedEqCols columns,
+) error {
+	// Provide the diskRowContainer with an ordering on the equality columns of
+	// the rows that we will store. This will result in rows with the
+	// same equality columns ocurring contiguously in the keyspace.
+	ordering := make(sqlbase.ColumnOrdering, len(storedEqCols))
+	for i := range ordering {
+		ordering[i] = sqlbase.ColumnOrderInfo{
+			ColIdx:    int(storedEqCols[i]),
+			Direction: encoding.Ascending,
+		}
+	}
+
+	h.shouldMark = shouldMark
+
+	storedTypes := types
+	if h.shouldMark {
+		// Add a boolean column to the end of the rows to implement marking rows.
+		storedTypes = make([]sqlbase.ColumnType, len(types)+1)
+		copy(storedTypes, types)
+		storedTypes[len(storedTypes)-1] = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BOOL}
+
+		h.scratchEncRow = make(sqlbase.EncDatumRow, len(storedTypes))
+		// Initialize the last column of the scratch row we use in AddRow() to
+		// be unmarked.
+		h.scratchEncRow[len(h.scratchEncRow)-1] = sqlbase.DatumToEncDatum(
+			sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BOOL},
+			parser.MakeDBool(false),
+		)
+	}
+
+	h.diskRowContainer = makeDiskRowContainer(ctx, h.diskMonitor, storedTypes, ordering, h.engine)
+	return nil
+}
+
+// AddRow adds a row to the hashDiskRowContainer. This row is unmarked by
+// default.
+func (h *hashDiskRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) error {
+	var err error
+	if h.shouldMark {
+		// len(h.scratchEncRow) == len(row) + 1 if h.shouldMark == true. The
+		// last column has been initialized to a false mark in Init().
+		copy(h.scratchEncRow, row)
+		err = h.diskRowContainer.AddRow(ctx, h.scratchEncRow)
+	} else {
+		err = h.diskRowContainer.AddRow(ctx, row)
+	}
+	return err
+}
+
+// hashDiskRowBucketIterator iterates over the rows in a bucket.
+type hashDiskRowBucketIterator struct {
+	diskRowIterator
+	hashDiskRowContainer *hashDiskRowContainer
+	// encodedEqCols is the encoding of the equality columns of the rows in the
+	// bucket that this iterator iterates over.
+	encodedEqCols []byte
+}
+
+var _ rowMarkerIterator = hashDiskRowBucketIterator{}
+
+// NewBucketIterator implements the hashRowContainer interface.
+func (h *hashDiskRowContainer) NewBucketIterator(
+	ctx context.Context, row sqlbase.EncDatumRow, probeEqCols columns,
+) (rowMarkerIterator, error) {
+	encoded, err := h.encodeEqualityCols(ctx, row, probeEqCols)
+	if err != nil {
+		return nil, err
+	}
+	encodedEqCols := make([]byte, len(encoded))
+	copy(encodedEqCols, encoded)
+
+	return hashDiskRowBucketIterator{
+		diskRowIterator:      h.NewIterator(ctx).(diskRowIterator),
+		hashDiskRowContainer: h,
+		encodedEqCols:        encodedEqCols,
+	}, nil
+}
+
+// Rewind implements the rowIterator interface.
+func (i hashDiskRowBucketIterator) Rewind() {
+	i.Seek(i.encodedEqCols)
+}
+
+// Valid implements the rowIterator interface.
+func (i hashDiskRowBucketIterator) Valid() (bool, error) {
+	ok, err := i.diskRowIterator.Valid()
+	if !ok || err != nil {
+		return ok, err
+	}
+	// Since the underlying map is sorted, once the key prefix does not equal
+	// the encoded equality columns, we have gone past the end of the bucket.
+	// TODO(asubiotto): Make UnsafeKey() and UnsafeValue() part of the
+	// SortedDiskMapIterator interface to avoid allocation here, in Mark(), and
+	// isRowMarked().
+	return bytes.HasPrefix(i.Key(), i.encodedEqCols), nil
+}
+
+// Row implements the rowIterator interface.
+func (i hashDiskRowBucketIterator) Row() (sqlbase.EncDatumRow, error) {
+	row, err := i.diskRowIterator.Row()
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the mark from the end of the row.
+	if i.hashDiskRowContainer.shouldMark {
+		row = row[:len(row)-1]
+	}
+	return row, nil
+}
+
+// Mark implements the rowMarkerIterator interface.
+func (i hashDiskRowBucketIterator) Mark(ctx context.Context, mark bool) error {
+	if !i.hashDiskRowContainer.shouldMark {
+		log.Fatal(ctx, "hash disk row container not set up for marking")
+	}
+	markBytes := encodedFalse
+	if mark {
+		markBytes = encodedTrue
+	}
+	// rowVal are the non-equality encoded columns, the last of which is the
+	// column we use to mark a row.
+	rowVal := i.Value()
+	originalLen := len(rowVal)
+	rowVal = append(rowVal, markBytes...)
+
+	// Write the new encoding of mark over the old encoding of mark and truncate
+	// the extra bytes.
+	copy(rowVal[originalLen-len(markBytes):], rowVal[originalLen:])
+	rowVal = rowVal[:originalLen]
+
+	// These marks only matter when using a hashDiskRowIterator to iterate over
+	// unmarked rows. The writes are flushed when creating a NewIterator() in
+	// NewUnmarkedIterator().
+	return i.hashDiskRowContainer.bufferedRows.Put(i.Key(), rowVal)
+}
+
+// hashDiskRowIterator iterates over all unmarked rows in a
+// hashDiskRowContainer.
+type hashDiskRowIterator struct {
+	diskRowIterator
+}
+
+var _ rowIterator = hashDiskRowIterator{}
+
+// NewUnmarkedIterator implements the hashRowContainer interface.
+func (h *hashDiskRowContainer) NewUnmarkedIterator(ctx context.Context) rowIterator {
+	if h.shouldMark {
+		return hashDiskRowIterator{
+			diskRowIterator: h.NewIterator(ctx).(diskRowIterator),
+		}
+	}
+	return h.NewIterator(ctx)
+}
+
+// Rewind implements the rowIterator interface.
+func (i hashDiskRowIterator) Rewind() {
+	i.diskRowIterator.Rewind()
+	// If the current row is marked, move the iterator to the next unmarked row.
+	if i.isRowMarked() {
+		i.Next()
+	}
+}
+
+// Next implements the rowIterator interface.
+func (i hashDiskRowIterator) Next() {
+	i.diskRowIterator.Next()
+	for i.isRowMarked() {
+		i.diskRowIterator.Next()
+	}
+}
+
+// Row implements the rowIterator interface.
+func (i hashDiskRowIterator) Row() (sqlbase.EncDatumRow, error) {
+	row, err := i.diskRowIterator.Row()
+	if err != nil {
+		return nil, err
+	}
+
+	// Remove the mark from the end of the row.
+	row = row[:len(row)-1]
+	return row, nil
+}
+
+// isRowMarked returns true if the current row is marked or false if it wasn't
+// marked or there was an error establishing the row's validity. Subsequent
+// calls to Valid() will uncover this error.
+func (i hashDiskRowIterator) isRowMarked() bool {
+	// isRowMarked is not necessarily called after Valid().
+	ok, err := i.diskRowIterator.Valid()
+	if !ok || err != nil {
+		return false
+	}
+
+	rowVal := i.Value()
+	return bytes.Equal(rowVal[len(rowVal)-len(encodedTrue):], encodedTrue)
+}

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -158,7 +158,8 @@ func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 		defer log.Infof(ctx, "exiting hash joiner run")
 	}
 
-	useTempStorage := h.flowCtx.Settings.DistSQLUseTempStorage.Get() ||
+	useTempStorage := (h.flowCtx.Settings.DistSQLUseTempStorage.Get() &&
+		h.flowCtx.Settings.DistSQLUseTempStorageJoins.Get()) ||
 		h.testingKnobMemLimit > 0 ||
 		h.testingKnobMemFailPoint != unset
 	evalCtx := h.flowCtx.EvalCtx

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -16,33 +16,18 @@ package distsqlrun
 
 import (
 	"sync"
-	"unsafe"
 
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/pkg/errors"
 )
-
-// bucket contains the set of rows for a given group key (comprised of
-// columns specified by the join constraints).
-type bucket struct {
-	// rows holds indices of rows into the hashJoiner's rows container.
-	rows []int
-	// seen is only used for outer joins; there is an entry for each row in `rows`
-	// indicating if that row had at least a matching row in the opposite stream
-	// ("matching" meaning that the ON condition passed).
-	seen []bool
-}
 
 // hashJoinerInitialBufferSize controls the size of the initial buffering phase
 // (see hashJoiner).
 const hashJoinerInitialBufferSize = 4 * 1024 * 1024
-
-const sizeOfBucket = int64(unsafe.Sizeof(bucket{}))
-const sizeOfRowIdx = int64(unsafe.Sizeof(int(0)))
 
 // HashJoiner performs a hash join.
 //
@@ -73,18 +58,9 @@ type hashJoiner struct {
 	// start of the other stream.
 	rows [2]memRowContainer
 
-	// storedSide is set by the initial buffering phase and indicates which stream
-	// we store fully and build the hashtable from.
+	// storedSide is set by the initial buffering phase and indicates which
+	// stream we store fully and build the hashRowContainer from.
 	storedSide joinSide
-
-	// bucketsAcc is the memory account for the buckets. The datums themselves are
-	// all in the rows container.
-	bucketsAcc mon.BoundAccount
-
-	scratch []byte
-
-	buckets    map[string]bucket
-	datumAlloc sqlbase.DatumAlloc
 }
 
 var _ Processor = &hashJoiner{}
@@ -99,8 +75,6 @@ func newHashJoiner(
 ) (*hashJoiner, error) {
 	h := &hashJoiner{
 		initialBufferSize: hashJoinerInitialBufferSize,
-		buckets:           make(map[string]bucket),
-		bucketsAcc:        flowCtx.EvalCtx.Mon.MakeBoundAccount(),
 	}
 	h.rows[leftSide].init(nil /* ordering */, leftSource.Types(), &flowCtx.EvalCtx)
 	h.rows[rightSide].init(nil /* ordering */, rightSource.Types(), &flowCtx.EvalCtx)
@@ -117,9 +91,6 @@ func newHashJoiner(
 
 	return h, nil
 }
-
-const sizeOfBoolSlice = unsafe.Sizeof([]bool{})
-const sizeOfBool = unsafe.Sizeof(true)
 
 // Run is part of the processor interface.
 func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
@@ -138,9 +109,9 @@ func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 	defer h.rows[leftSide].Close(ctx)
 	defer h.rows[rightSide].Close(ctx)
-	defer h.bucketsAcc.Close(ctx)
 
-	if earlyExit, err := h.bufferPhase(ctx); earlyExit || err != nil {
+	streamConsumed, earlyExit, err := h.bufferPhase(ctx)
+	if earlyExit || err != nil {
 		if err != nil {
 			// We got an error. We still want to drain. Any error encountered while
 			// draining will be swallowed, and the original error will be forwarded to
@@ -157,28 +128,34 @@ func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 		srcToClose = h.rightSource
 	}
 
-	if err := h.buildPhase(ctx); err != nil {
-		log.Infof(ctx, "build phase error %s", err)
-		DrainAndClose(ctx, h.out.output, err /* cause */, srcToClose)
+	storedRows := makeHashMemRowContainer(ctx, &h.rows[h.storedSide])
+	if err := storedRows.Init(
+		ctx, h.eqCols[h.storedSide], h.eqCols[otherSide(h.storedSide)],
+	); err != nil {
+		// We got an error. We still want to drain. Any error encountered while
+		// draining will be swallowed, and the original error will be forwarded
+		// to the consumer.
+		err = errors.Wrap(err, "error creating hash row container")
+		log.Info(ctx, err)
+		DrainAndClose(ctx, h.out.output, err /* cause */, h.leftSource, h.rightSource)
 		return
 	}
+	defer storedRows.Close(ctx)
 
-	// Allocate seen slices to produce results for unmatched stored rows,
-	// for FULL OUTER AND LEFT/RIGHT OUTER (depending on which stream we store).
-	if shouldEmitUnmatchedRow(h.storedSide, h.joinType) {
-		for k, bucket := range h.buckets {
-			if err := h.bucketsAcc.Grow(
-				ctx, int64(sizeOfBoolSlice+uintptr(len(bucket.rows))*sizeOfBool),
-			); err != nil {
-				DrainAndClose(ctx, h.out.output, err, srcToClose)
-				return
+	// If the buffer phase did not fully consume the chosen stream, we proceed
+	// to a build phase which will do so.
+	if !streamConsumed {
+		if earlyExit, err := h.buildPhase(ctx, &storedRows); earlyExit || err != nil {
+			if err != nil {
+				log.Infof(ctx, "build phase error %s", err)
 			}
-			bucket.seen = make([]bool, len(bucket.rows))
-			h.buckets[k] = bucket
+			DrainAndClose(ctx, h.out.output, err /* cause */, srcToClose)
+			return
 		}
 	}
 	log.VEventf(ctx, 1, "build phase complete")
-	if earlyExit, err := h.probePhase(ctx); earlyExit || err != nil {
+
+	if earlyExit, err := h.probePhase(ctx, &storedRows); earlyExit || err != nil {
 		if err != nil {
 			// We got an error. We still want to drain. Any error encountered while
 			// draining will be swallowed, and the original error will be forwarded to
@@ -242,8 +219,12 @@ func (h *hashJoiner) receiveRow(
 //
 // A successful initial buffering phase sets h.storedSide.
 //
+// If streamConsumed is set, the chosen stream has been fully consumed.
+//
 // If earlyExit is set, the output doesn't need more rows.
-func (h *hashJoiner) bufferPhase(ctx context.Context) (earlyExit bool, _ error) {
+func (h *hashJoiner) bufferPhase(
+	ctx context.Context,
+) (streamConsumed bool, earlyExit bool, _ error) {
 	srcs := [2]RowSource{h.leftSource, h.rightSource}
 	for {
 		leftUsage := h.rows[leftSide].MemUsage()
@@ -259,39 +240,27 @@ func (h *hashJoiner) bufferPhase(ctx context.Context) (earlyExit bool, _ error) 
 		row, earlyExit, err := h.receiveRow(ctx, srcs[side], side)
 		if row == nil {
 			if err != nil {
-				return false, err
+				return false, false, err
 			}
 			if earlyExit {
-				return true, nil
+				return false, true, nil
 			}
 
 			// This stream is done, great! We will build the hashtable using this
 			// stream.
 			h.storedSide = side
-			return false, nil
+			return true, false, nil
 		}
 		// Add the row to the correct container.
 		if err := h.rows[side].AddRow(ctx, row); err != nil {
-			return false, err
+			return false, false, err
 		}
 	}
 
 	// We did not find a short stream. Stop reading for both streams, just
-	// choose the right stream and consume it.
+	// choose the right stream.
 	h.storedSide = rightSide
-
-	for {
-		row, earlyExit, err := h.receiveRow(ctx, h.rightSource, rightSide)
-		if row == nil {
-			if err != nil {
-				return false, err
-			}
-			return earlyExit, nil
-		}
-		if err := h.rows[rightSide].AddRow(ctx, row); err != nil {
-			return false, err
-		}
-	}
+	return false, false, nil
 }
 
 // buildPhase constructs our internal hash map of rows seen. This is done
@@ -300,92 +269,78 @@ func (h *hashJoiner) bufferPhase(ctx context.Context) (earlyExit bool, _ error) 
 // have a NULL in an equality column (and thus will not match anything), it
 // might be routed directly to the output (for outer joins). In such cases it is
 // possible that the buildPhase will fully satisfy the consumer.
-func (h *hashJoiner) buildPhase(ctx context.Context) error {
-	storedRows := &h.rows[h.storedSide]
-
-	for rowIdx := 0; rowIdx < storedRows.Len(); rowIdx++ {
-		row := storedRows.EncRow(rowIdx)
-
-		encoded, hasNull, err := encodeColumnsOfRow(
-			&h.datumAlloc, h.scratch, row, h.eqCols[h.storedSide], false, /* encodeNull */
-		)
-		if err != nil {
-			return err
-		}
-
-		h.scratch = encoded[:0]
-
-		if hasNull {
-			panic("NULLs not detected during receive")
-		}
-
-		b, bucketExists := h.buckets[string(encoded)]
-
-		// Acount for the memory usage of rowIdx, map key, and bucket.
-		usage := sizeOfRowIdx
-		if !bucketExists {
-			usage += int64(len(encoded))
-			usage += sizeOfBucket
-		}
-
-		if err := h.bucketsAcc.Grow(ctx, usage); err != nil {
-			return err
-		}
-
-		b.rows = append(b.rows, rowIdx)
-		h.buckets[string(encoded)] = b
-	}
-	return nil
-}
-
-func (h *hashJoiner) probeRow(
-	ctx context.Context, row sqlbase.EncDatumRow,
+func (h *hashJoiner) buildPhase(
+	ctx context.Context, storedRows hashRowContainer,
 ) (earlyExit bool, _ error) {
-	side := otherSide(h.storedSide)
-	encoded, hasNull, err := encodeColumnsOfRow(
-		&h.datumAlloc, h.scratch, row, h.eqCols[side], false, /* encodeNull */
-	)
-	if err != nil {
-		return false, err
-	}
-	h.scratch = encoded[:0]
-
-	if hasNull {
-		panic("NULLs not detected during receive")
+	// Consume the rest of the stream chosen to be stored.
+	source := h.rightSource
+	if h.storedSide == leftSide {
+		source = h.leftSource
 	}
 
-	matched := false
-	if b, ok := h.buckets[string(encoded)]; ok {
-		for i, otherRowIdx := range b.rows {
-			otherRow := h.rows[h.storedSide].EncRow(otherRowIdx)
-
-			var renderedRow sqlbase.EncDatumRow
-			var err error
-			if h.storedSide == rightSide {
-				renderedRow, err = h.render(row, otherRow)
-			} else {
-				renderedRow, err = h.render(otherRow, row)
-			}
-
+	for {
+		row, earlyExit, err := h.receiveRow(ctx, source, h.storedSide)
+		if row == nil {
 			if err != nil {
 				return false, err
 			}
-			// If the ON condition failed, renderedRow is nil.
-			if renderedRow != nil {
-				matched = true
-				if b.seen != nil {
-					// Mark the right row as matched (for right/full outer join).
-					b.seen[i] = true
-				}
-				consumerStatus, err := h.out.EmitRow(ctx, renderedRow)
-				if err != nil || consumerStatus != NeedMoreRows {
-					return true, nil
-				}
+			return earlyExit, nil
+		}
+		if err := storedRows.AddRow(ctx, row); err != nil {
+			return false, err
+		}
+	}
+}
+
+func (h *hashJoiner) probeRow(
+	ctx context.Context, row sqlbase.EncDatumRow, storedRows hashRowContainer,
+) (earlyExit bool, _ error) {
+	// probeMatched specifies whether the row we are probing with has at least
+	// one match.
+	probeMatched := false
+	i, err := storedRows.NewBucketIterator(ctx, row)
+	if err != nil {
+		return false, err
+	}
+	defer i.Close()
+	for i.Rewind(); ; i.Next() {
+		if ok, err := i.Valid(); err != nil {
+			return false, err
+		} else if !ok {
+			break
+		}
+		otherRow, err := i.Row()
+		if err != nil {
+			return false, err
+		}
+
+		var renderedRow sqlbase.EncDatumRow
+		if h.storedSide == rightSide {
+			renderedRow, err = h.render(row, otherRow)
+		} else {
+			renderedRow, err = h.render(otherRow, row)
+		}
+
+		if err != nil {
+			return false, err
+		}
+		// If the ON condition failed, renderedRow is nil.
+		if renderedRow != nil {
+			probeMatched = true
+			// Mark the row on the stored side. The unmarked rows can then be
+			// iterated over for {right, left} outer joins (depending on
+			// storedSide) and full outer joins.
+			if err := i.Mark(ctx, true); err != nil {
+				return false, nil
+			}
+			consumerStatus, err := h.out.EmitRow(ctx, renderedRow)
+			if err != nil || consumerStatus != NeedMoreRows {
+				return true, nil
 			}
 		}
 	}
 
-	if !matched && !h.maybeEmitUnmatchedRow(ctx, row, otherSide(h.storedSide)) {
+	if !probeMatched && !h.maybeEmitUnmatchedRow(ctx, row, otherSide(h.storedSide)) {
 		return true, nil
 	}
 	return false, nil
@@ -399,7 +354,9 @@ func (h *hashJoiner) probeRow(
 //
 // In error or earlyExit cases it is the caller's responsibility to drain the
 // input stream and close the output stream.
-func (h *hashJoiner) probePhase(ctx context.Context) (earlyExit bool, _ error) {
+func (h *hashJoiner) probePhase(
+	ctx context.Context, storedRows hashRowContainer,
+) (earlyExit bool, _ error) {
 	side := otherSide(h.storedSide)
 
 	src := h.leftSource
@@ -410,7 +367,7 @@ func (h *hashJoiner) probePhase(ctx context.Context) (earlyExit bool, _ error) {
 	// First process the rows that were already buffered.
 	for i := 0; i < bufferedRows.Len(); i++ {
 		row := bufferedRows.EncRow(i)
-		earlyExit, err := h.probeRow(ctx, row)
+		earlyExit, err := h.probeRow(ctx, row, storedRows)
 		if earlyExit || err != nil {
 			return earlyExit, err
 		}
@@ -425,7 +382,7 @@ func (h *hashJoiner) probePhase(ctx context.Context) (earlyExit bool, _ error) {
 			}
 			break
 		}
-		if earlyExit, err := h.probeRow(ctx, row); earlyExit || err != nil {
+		if earlyExit, err := h.probeRow(ctx, row, storedRows); earlyExit || err != nil {
 			return earlyExit, err
 		}
 	}
@@ -433,13 +390,22 @@ func (h *hashJoiner) probePhase(ctx context.Context) (earlyExit bool, _ error) {
 	if shouldEmitUnmatchedRow(h.storedSide, h.joinType) {
 		// Produce results for unmatched rows, for FULL OUTER AND LEFT/RIGHT OUTER
 		// (depending on which stream we use).
-		storedRows := &h.rows[h.storedSide]
-		for _, b := range h.buckets {
-			for i, seen := range b.seen {
-				if !seen && !h.maybeEmitUnmatchedRow(ctx, storedRows.EncRow(b.rows[i]), h.storedSide) {
-					return true, nil
-				}
+		i := storedRows.NewUnmarkedIterator(ctx)
+		defer i.Close()
+		for i.Rewind(); ; i.Next() {
+			if ok, err := i.Valid(); err != nil {
+				return false, err
+			} else if !ok {
+				break
 			}
+			row, err := i.Row()
+			if err != nil {
+				return false, err
+			}
+			if !h.maybeEmitUnmatchedRow(ctx, row, h.storedSide) {
+				return true, nil
+			}
+
 		}
 	}
 

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -506,7 +506,7 @@ func TestHashJoiner(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			// Run tests with a variety of initial buffer sizes.
 			for _, initialBuffer := range []int64{0, 32, 64, 128, 1024 * 1024} {
-				t.Run(fmt.Sprintf("%d", initialBuffer), func(t *testing.T) {
+				t.Run(fmt.Sprintf("InitialBuffer=%d", initialBuffer), func(t *testing.T) {
 					hs := c.spec
 					leftInput := NewRowBuffer(nil /* types */, c.inputs[0], RowBufferArgs{})
 					rightInput := NewRowBuffer(nil /* types */, c.inputs[1], RowBufferArgs{})

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -585,7 +585,7 @@ func TestHashJoiner(t *testing.T) {
 		for _, memLimit := range []int64{1, 256, 512, 1024, 2048} {
 			t.Run(fmt.Sprintf("MemLimit=%d", memLimit), func(t *testing.T) {
 				if err := testFunc(t, func(h *hashJoiner) {
-					h.testingKnobMemLimit = memLimit
+					h.flowCtx.testingKnobs.MemoryLimitBytes = memLimit
 				}); err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -16,15 +16,19 @@ package distsqlrun
 
 import (
 	"fmt"
+	math "math"
 	"sort"
 	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/pkg/errors"
@@ -502,39 +506,91 @@ func TestHashJoiner(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+	tempEngine, err := engine.NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	evalCtx := parser.MakeTestingEvalContext()
+	defer evalCtx.Stop(ctx)
+	diskMonitor := mon.MakeMonitor(
+		"test-disk",
+		mon.DiskResource,
+		nil, /* curCount */
+		nil, /* maxHist */
+		-1,  /* increment: use default block size */
+		math.MaxInt64,
+	)
+	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	defer diskMonitor.Stop(ctx)
+
 	for _, c := range testCases {
-		t.Run("", func(t *testing.T) {
-			// Run tests with a variety of initial buffer sizes.
-			for _, initialBuffer := range []int64{0, 32, 64, 128, 1024 * 1024} {
-				t.Run(fmt.Sprintf("InitialBuffer=%d", initialBuffer), func(t *testing.T) {
-					hs := c.spec
-					leftInput := NewRowBuffer(nil /* types */, c.inputs[0], RowBufferArgs{})
-					rightInput := NewRowBuffer(nil /* types */, c.inputs[1], RowBufferArgs{})
-					out := &RowBuffer{}
-					evalCtx := parser.MakeTestingEvalContext()
-					defer evalCtx.Stop(context.Background())
-					flowCtx := FlowCtx{Settings: cluster.MakeClusterSettings(), EvalCtx: evalCtx}
-
-					post := PostProcessSpec{Projection: true, OutputColumns: c.outCols}
-					h, err := newHashJoiner(&flowCtx, &hs, leftInput, rightInput, &post, out)
-					if err != nil {
-						t.Fatal(err)
-					}
-					h.initialBufferSize = initialBuffer
-
-					h.Run(context.Background(), nil)
-
-					if !out.ProducerClosed {
-						t.Fatalf("output RowReceiver not closed")
-					}
-
-					if err := checkExpectedRows(c.expected, out); err != nil {
-						fmt.Println(err)
-						t.Fatal(err)
-					}
-				})
+		// testFunc is a helper function that runs a hashJoin with the current
+		// test case after running the provided setup function.
+		testFunc := func(t *testing.T, setup func(h *hashJoiner)) error {
+			leftInput := NewRowBuffer(nil /* types */, c.inputs[0], RowBufferArgs{})
+			rightInput := NewRowBuffer(nil /* types */, c.inputs[1], RowBufferArgs{})
+			out := &RowBuffer{}
+			flowCtx := FlowCtx{
+				Settings:    cluster.MakeClusterSettings(),
+				EvalCtx:     evalCtx,
+				tempStorage: tempEngine,
+				diskMonitor: &diskMonitor,
 			}
-		})
+
+			post := PostProcessSpec{Projection: true, OutputColumns: c.outCols}
+			h, err := newHashJoiner(&flowCtx, &c.spec, leftInput, rightInput, &post, out)
+			if err != nil {
+				return err
+			}
+			setup(h)
+			h.Run(ctx, nil)
+
+			if !out.ProducerClosed {
+				return errors.New("output RowReceiver not closed")
+			}
+
+			return checkExpectedRows(c.expected, out)
+		}
+
+		// Run test with a variety of initial buffer sizes.
+		for _, initialBuffer := range []int64{0, 32, 64, 128, 1024 * 1024} {
+			t.Run(fmt.Sprintf("InitialBuffer=%d", initialBuffer), func(t *testing.T) {
+				if err := testFunc(t, func(h *hashJoiner) {
+					h.initialBufferSize = initialBuffer
+				}); err != nil {
+					t.Fatal(err)
+				}
+			})
+		}
+
+		// Run tests with a probability of the run failing with a memory error.
+		// These verify that the hashJoiner falls back to disk correctly in all
+		// cases.
+		for i := 0; i < 5; i++ {
+			memFailPoint := buffer
+			t.Run(fmt.Sprintf("MemFailPoint=%s", memFailPoint), func(t *testing.T) {
+				if err := testFunc(t, func(h *hashJoiner) {
+					h.testingKnobMemFailPoint = memFailPoint
+					h.testingKnobFailProbability = 0.5
+				}); err != nil {
+					t.Fatal(err)
+				}
+			})
+		}
+
+		// Run test with a variety of memory limits.
+		for _, memLimit := range []int64{1, 256, 512, 1024, 2048} {
+			t.Run(fmt.Sprintf("MemLimit=%d", memLimit), func(t *testing.T) {
+				if err := testFunc(t, func(h *hashJoiner) {
+					h.testingKnobMemLimit = memLimit
+				}); err != nil {
+					t.Fatal(err)
+				}
+			})
+		}
 	}
 }
 

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -395,6 +395,12 @@ type TestingKnobs struct {
 	// executing the chunk. It is always called even when the backfill
 	// function returns an error, or if the table has already been dropped.
 	RunAfterBackfillChunk func()
+
+	// MemoryLimitBytes specifies a maximum amount of working memory that a
+	// processor that supports falling back to disk can use. Must be >= 1 to
+	// enable. Once this limit is hit, processors employ their on-disk
+	// implementation regardless of applicable cluster settings.
+	MemoryLimitBytes int64
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -68,6 +68,11 @@ const Version = 4
 // compatible with; see above.
 const MinAcceptedVersion = 4
 
+// workMemBytes specifies the maximum amount of memory in bytes a processor can
+// use. This limit is only observed if the use of temporary storage is enabled
+// (see sql.defaults.distsql.tempstorage).
+var workMemBytes = envutil.EnvOrDefaultInt64("COCKROACH_WORK_MEM", 64*1024*1024 /* 64MB */)
+
 var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_DISTSQL_MEMORY_USAGE", 10*1024)
 
 // All queries that spill over to disk will be limited to use
@@ -163,7 +168,7 @@ func NewServer(ctx context.Context, cfg ServerConfig) *ServerImpl {
 		mon.DiskResource,
 		nil,                 /* curCount */
 		nil,                 /* maxHist */
-		workMem,             /* increment: same size as processor's memory budget */
+		workMemBytes,        /* increment: same size as processor's memory budget */
 		diskMonitorBudget/2, /* noteworthy */
 	)
 	ds.diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(diskMonitorBudget))

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -79,8 +78,6 @@ func newSorter(
 	return s, nil
 }
 
-var workMem = envutil.EnvOrDefaultInt64("COCKROACH_WORK_MEM", 64*1024*1024 /* 64MB */)
-
 // Run is part of the processor interface.
 func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {
@@ -107,7 +104,7 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 		// The strategy will overflow to disk if this limit is not enough.
 		limit := s.testingKnobMemLimit
 		if limit <= 0 {
-			limit = workMem
+			limit = workMemBytes
 		}
 		limitedMon := mon.MakeMonitorInheritWithLimit(
 			"sortall-limited", limit, s.flowCtx.EvalCtx.Mon,

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -96,7 +96,9 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 	var sv memRowContainer
 	// Enable fall back to disk if the cluster setting is set or a memory limit
 	// has been set through testing.
-	useTempStorage := s.flowCtx.Settings.DistSQLUseTempStorage.Get() || s.testingKnobMemLimit > 0
+	useTempStorage := (s.flowCtx.Settings.DistSQLUseTempStorage.Get() &&
+		s.flowCtx.Settings.DistSQLUseTempStorageSorts.Get()) ||
+		s.testingKnobMemLimit > 0
 	if s.matchLen == 0 && s.count == 0 && useTempStorage {
 		// We will use the sortAllStrategy in this case and potentially fall
 		// back to disk.

--- a/pkg/sql/distsqlrun/sorterstrategy.go
+++ b/pkg/sql/distsqlrun/sorterstrategy.go
@@ -74,15 +74,30 @@ func (ss *sortAllStrategy) Execute(ctx context.Context, s *sorter) error {
 		return errors.Wrap(err, "external storage not provided on this cockroach node")
 	}
 	log.VEventf(ctx, 2, "falling back to disk")
-	// The diskContainer will free the memory taken up by ss.rows as it is
-	// created from them.
-	diskContainer, err := makeDiskRowContainer(
-		ctx, s.flowCtx.diskMonitor, ss.rows.types, ss.rows.ordering, ss.rows, s.tempStorage,
+	diskContainer := makeDiskRowContainer(
+		ctx, s.flowCtx.diskMonitor, ss.rows.types, ss.rows.ordering, s.tempStorage,
 	)
-	if err != nil {
-		return err
-	}
 	defer diskContainer.Close(ctx)
+
+	// Transfer the rows from memory to disk. Note that this frees up the
+	// memory taken up by ss.rows.
+	i := ss.rows.NewIterator(ctx)
+	defer i.Close()
+	for i.Rewind(); ; i.Next() {
+		if ok, err := i.Valid(); err != nil {
+			return err
+		} else if !ok {
+			break
+		}
+		memRow, err := i.Row()
+		if err != nil {
+			return err
+		}
+		if err := diskContainer.AddRow(ctx, memRow); err != nil {
+			return err
+		}
+	}
+
 	// Add the row that caused the memory container to run out of memory.
 	if err := diskContainer.AddRow(ctx, row); err != nil {
 		return err

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
@@ -242,6 +243,9 @@ type testClusterConfig struct {
 	useFakeSpanResolver bool
 	// if non-empty, overrides the default distsql mode.
 	overrideDistSQLMode string
+	// if set, queries using distSQL processors that can fall back to disk do
+	// so immediately, using only their disk-based implementation.
+	distSQLUseDisk bool
 	// if set, any logic statement expected to succeed and parallelizable
 	// using RETURNING NOTHING syntax will be parallelized transparently.
 	// See logicStatement.parallelizeStmts.
@@ -258,6 +262,7 @@ var logicTestConfigs = []testClusterConfig{
 	{name: "default", numNodes: 1, overrideDistSQLMode: "Off"},
 	{name: "parallel-stmts", numNodes: 1, parallelStmts: true, overrideDistSQLMode: "Off"},
 	{name: "distsql", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "On"},
+	{name: "distsql-disk", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "On", distSQLUseDisk: true},
 	{name: "5node", numNodes: 5, overrideDistSQLMode: "Off"},
 }
 
@@ -637,7 +642,7 @@ func (t *logicTest) setUser(user string) func() {
 	return cleanupFunc
 }
 
-func (t *logicTest) setup(numNodes int, useFakeSpanResolver bool, overrideDistSQLMode string) {
+func (t *logicTest) setup(cfg testClusterConfig) {
 	// TODO(pmattis): Add a flag to make it easy to run the tests against a local
 	// MySQL or Postgres instance.
 	// TODO(andrei): if createTestServerParams() is used here, the command filter
@@ -660,8 +665,13 @@ func (t *logicTest) setup(numNodes int, useFakeSpanResolver bool, overrideDistSQ
 		// matter where the data really is.
 		ReplicationMode: base.ReplicationManual,
 	}
-	t.cluster = serverutils.StartTestCluster(t.t, numNodes, params)
-	if useFakeSpanResolver {
+	if cfg.distSQLUseDisk {
+		params.ServerArgs.Knobs.DistSQL = &distsqlrun.TestingKnobs{
+			MemoryLimitBytes: 1,
+		}
+	}
+	t.cluster = serverutils.StartTestCluster(t.t, cfg.numNodes, params)
+	if cfg.useFakeSpanResolver {
 		fakeResolver := distsqlutils.FakeResolverForTestCluster(t.cluster)
 		t.cluster.Server(t.nodeIdx).SetDistSQLSpanResolver(fakeResolver)
 	}
@@ -676,8 +686,8 @@ func (t *logicTest) setup(numNodes int, useFakeSpanResolver bool, overrideDistSQ
 		// locking in the DistSQL setting for that session. If we change it
 		// after, we might still see the old value in tests since they use the
 		// existing Session.
-		if overrideDistSQLMode != "" {
-			mode := cluster.DistSQLExecModeFromString(overrideDistSQLMode)
+		if cfg.overrideDistSQLMode != "" {
+			mode := cluster.DistSQLExecModeFromString(cfg.overrideDistSQLMode)
 			server.ClusterSettings().DistSQLClusterExecMode.Override(int64(mode))
 		}
 	}
@@ -1562,8 +1572,7 @@ func TestLogic(t *testing.T) {
 					if *printErrorSummary {
 						defer lt.printErrorSummary()
 					}
-					lt.setup(cfg.numNodes, cfg.useFakeSpanResolver, cfg.overrideDistSQLMode)
-
+					lt.setup(cfg)
 					lt.runFile(path, cfg)
 
 					progress.Lock()

--- a/pkg/sql/logictest/testdata/logic_test/postgresjoin
+++ b/pkg/sql/logictest/testdata/logic_test/postgresjoin
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 # These are postgres regress sql join test suite
 # https://github.com/postgres/postgres/blob/master/src/test/regress/sql/join.sql

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -74,6 +74,8 @@ server.time_until_store_dead                       5m0s           d     the time
 server.web_session_timeout                         168h0m0s       d     the duration that a newly created web session will be valid
 sql.defaults.distsql                               0              e     Default distributed SQL execution mode [off = 0, auto = 1, on = 2]
 sql.defaults.distsql.tempstorage                   false          b     set to true to enable use of disk for larger distributed sql queries
+sql.defaults.distsql.tempstorage.joins             true           b     set to true to enable use of disk for distributed sql joins. sql.defaults.distsql.tempstorage must be true
+sql.defaults.distsql.tempstorage.sorts             true           b     set to true to enable use of disk for distributed sql sorts. sql.defaults.distsql.tempstorage must be true
 sql.distsql.distribute_index_joins                 true           b     if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader
 sql.distsql.merge_joins.enabled                    true           b     if set, we plan merge joins when possible
 sql.metrics.statement_details.dump_to_logs         false          b     dump collected statement statistics to node logs when periodically cleared


### PR DESCRIPTION
This PR is composed of two commits. The first one creates an interface and puts the current in-memory implementation behind it and the second one implements an on-disk version of this interface. The in-memory changes result have the following impact on performance:
```
$ make bench PKG=./pkg/sql/distsqlrun BENCHES=BenchmarkHashJoiner TESTFLAGS="-count 20" > hashchanges
$ benchstat hashbench hashchanges
name                          old time/op  new time/op  delta
HashJoiner/InputSize=0-8      9.53µs ± 7%  4.44µs ± 1%  -53.44%  (p=0.000 n=20+18)
HashJoiner/InputSize=4-8      18.4µs ± 2%  14.4µs ± 2%  -21.58%  (p=0.000 n=18+20)
HashJoiner/InputSize=16-8     38.8µs ± 2%  40.2µs ± 6%   +3.69%  (p=0.000 n=19+20)
HashJoiner/InputSize=256-8     466µs ± 4%   582µs ± 5%  +24.84%  (p=0.000 n=20+20)
HashJoiner/InputSize=4096-8   7.83ms ± 2%  9.41ms ± 3%  +20.07%  (p=0.000 n=20+20)
HashJoiner/InputSize=65536-8   133ms ± 6%   156ms ± 4%  +16.81%  (p=0.000 n=20+20)
```
I believe this can be improved with changes to the marking API.

The on-disk implementation is currently tested by setting `testingKnobMemLimit = 1` to force immediate use of disk.

There is still some work to be done regarding:
1) Changing tests to test both the in-memory and on-disk implementation. The interaction between these two also needs to be tested.
2) The marking API has to be changed (this is not necessary for functionality but if there is time it's worth it to tackle this second point)

@arjunravinarayan will be testing this on a production cluster in the meantime

cc @cockroachdb/distsql 