### PR TITLE
sql: refactor tableUpserter to use RowContainer for batched rows

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -137,6 +137,7 @@ func (d *deleteNode) Start(params runParams) error {
 
 func (d *deleteNode) Close(ctx context.Context) {
 	d.run.rows.Close(ctx)
+	d.tw.close(ctx)
 	*d = deleteNode{}
 	deleteNodePool.Put(d)
 }

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -178,6 +178,7 @@ func (p *planner) Insert(
 				autoCommit:    p.autoCommit,
 				conflictIndex: *conflictIndex,
 				alloc:         &p.alloc,
+				mon:           &p.session.TxnState.mon,
 			}
 			tw = tu
 		} else {
@@ -216,6 +217,7 @@ func (p *planner) Insert(
 				ri:            ri,
 				autoCommit:    p.autoCommit,
 				alloc:         &p.alloc,
+				mon:           &p.session.TxnState.mon,
 				fkTables:      fkTables,
 				updateCols:    updateCols,
 				conflictIndex: *conflictIndex,
@@ -281,6 +283,7 @@ func (n *insertNode) Start(params runParams) error {
 
 func (n *insertNode) Close(ctx context.Context) {
 	n.run.rows.Close(ctx)
+	n.tw.close(ctx)
 	switch t := n.tw.(type) {
 	case *tableInserter:
 		*t = tableInserter{}

--- a/pkg/sql/sqlbase/row_container.go
+++ b/pkg/sql/sqlbase/row_container.go
@@ -92,6 +92,15 @@ func ColTypeInfoFromColTypes(colTypes []ColumnType) ColTypeInfo {
 	return ColTypeInfo{colTypes: colTypes}
 }
 
+// ColTypeInfoFromColDescs creates a ColTypeInfo from []ColumnDescriptor.
+func ColTypeInfoFromColDescs(colDescs []ColumnDescriptor) ColTypeInfo {
+	colTypes := make([]ColumnType, len(colDescs))
+	for i, colDesc := range colDescs {
+		colTypes[i] = colDesc.Type
+	}
+	return ColTypeInfoFromColTypes(colTypes)
+}
+
 // NumColumns returns the number of columns in the type.
 func (ti ColTypeInfo) NumColumns() int {
 	if ti.resCols != nil {

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -84,6 +85,9 @@ type tableWriter interface {
 	// can determine ahead of time that this isn't true, we should true to
 	// constrain these spans.
 	spans() (reads, writes roachpb.Spans, err error)
+
+	// close frees all resources held by the tableWriter.
+	close(ctx context.Context)
 }
 
 var _ tableWriter = (*tableInserter)(nil)
@@ -146,6 +150,8 @@ type tableUpdater struct {
 	b   *client.Batch
 }
 
+func (ti *tableInserter) close(_ context.Context) {}
+
 func (tu *tableUpdater) walkExprs(_ func(desc string, index int, expr parser.TypedExpr)) {}
 
 func (tu *tableUpdater) init(txn *client.Txn) error {
@@ -183,6 +189,8 @@ func (tu *tableUpdater) spans() (reads, writes roachpb.Spans, err error) {
 	return collectTableWriterSpans(tu.ru.Helper.TableDesc, tu.ru.Fks)
 }
 
+func (tu *tableUpdater) close(_ context.Context) {}
+
 type tableUpsertEvaler interface {
 	expressionCarrier
 
@@ -219,6 +227,7 @@ type tableUpserter struct {
 	conflictIndex sqlbase.IndexDescriptor
 	isUpsertAlias bool
 	alloc         *sqlbase.DatumAlloc
+	mon           *mon.MemoryMonitor
 
 	// These are set for ON CONFLICT DO UPDATE, but not for DO NOTHING
 	updateCols []sqlbase.ColumnDescriptor
@@ -239,7 +248,7 @@ type tableUpserter struct {
 	fastPathKeys  map[string]struct{}
 
 	// Batched up in run/flush.
-	insertRows []parser.Datums
+	insertRows sqlbase.RowContainer
 
 	// For allocation avoidance.
 	indexKeyPrefix []byte
@@ -306,6 +315,10 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 		}
 	}
 
+	tu.insertRows = sqlbase.MakeRowContainer(
+		tu.mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromColDescs(tu.ri.InsertCols), 0,
+	)
+
 	valNeededForCol := make([]bool, len(tu.fetchCols))
 	for i, col := range tu.fetchCols {
 		if _, ok := tu.fetchColIDtoRowIndex[col.ID]; ok {
@@ -336,26 +349,21 @@ func (tu *tableUpserter) row(
 		return nil, err
 	}
 
-	// Copy the row because the `tableWriter` interface guarantees that it's not
-	// used after this returns.
-	tu.insertRows = append(tu.insertRows, append([]parser.Datum(nil), row...))
+	_, err := tu.insertRows.AddRow(ctx, row)
 	// TODO(dan): If len(tu.insertRows) > some threshold, call flush().
-	return nil, nil
+	return nil, err
 }
 
 // flush commits to tu.txn any rows batched up in tu.insertRows.
 func (tu *tableUpserter) flush(ctx context.Context, finalize, traceKV bool) error {
-	defer func() {
-		tu.insertRows = nil
-	}()
-
 	existingRows, err := tu.fetchExisting(ctx, traceKV)
 	if err != nil {
 		return err
 	}
 
 	b := tu.txn.NewBatch()
-	for i, insertRow := range tu.insertRows {
+	for i := 0; i < tu.insertRows.Len(); i++ {
+		insertRow := tu.insertRows.At(i)
 		existingRow := existingRows[i]
 
 		if existingRow == nil {
@@ -396,13 +404,14 @@ func (tu *tableUpserter) flush(ctx context.Context, finalize, traceKV bool) erro
 // upsertRowPKs returns the primary keys of any rows with potential upsert
 // conflicts.
 func (tu *tableUpserter) upsertRowPKs(ctx context.Context, traceKV bool) ([]roachpb.Key, error) {
-	upsertRowPKs := make([]roachpb.Key, len(tu.insertRows))
+	upsertRowPKs := make([]roachpb.Key, tu.insertRows.Len())
 
 	if tu.conflictIndex.ID == tu.tableDesc.PrimaryIndex.ID {
 		// If the conflict index is the primary index, we can compute them directly.
 		// In this case, the slice will be filled, but not all rows will have
 		// conflicts.
-		for i, insertRow := range tu.insertRows {
+		for i := 0; i < tu.insertRows.Len(); i++ {
+			insertRow := tu.insertRows.At(i)
 			upsertRowPK, _, err := sqlbase.EncodeIndexKey(
 				tu.tableDesc, &tu.conflictIndex, tu.ri.InsertColIDtoRowIndex, insertRow, tu.indexKeyPrefix)
 			if err != nil {
@@ -418,7 +427,8 @@ func (tu *tableUpserter) upsertRowPKs(ctx context.Context, traceKV bool) ([]roac
 	// case, some spots in the slice will be nil (indicating no conflict) and the
 	// others will be conflicting rows.
 	b := tu.txn.NewBatch()
-	for _, insertRow := range tu.insertRows {
+	for i := 0; i < tu.insertRows.Len(); i++ {
+		insertRow := tu.insertRows.At(i)
 		entry, err := sqlbase.EncodeSecondaryIndex(
 			tu.tableDesc, &tu.conflictIndex, tu.ri.InsertColIDtoRowIndex, insertRow)
 		if err != nil {
@@ -448,7 +458,7 @@ func (tu *tableUpserter) upsertRowPKs(ctx context.Context, traceKV bool) ([]roac
 			}
 		} else if len(result.Rows) > 1 {
 			panic(fmt.Errorf(
-				"Expected <= 1 but got %d conflicts for row %s", len(result.Rows), tu.insertRows[i]))
+				"Expected <= 1 but got %d conflicts for row %s", len(result.Rows), tu.insertRows.At(i)))
 		}
 	}
 
@@ -525,6 +535,10 @@ func (tu *tableUpserter) finalize(ctx context.Context, traceKV bool) error {
 
 func (tu *tableUpserter) spans() (reads, writes roachpb.Spans, err error) {
 	return collectTableWriterSpans(tu.ri.Helper.TableDesc, tu.ri.Fks)
+}
+
+func (tu *tableUpserter) close(ctx context.Context) {
+	tu.insertRows.Close(ctx)
 }
 
 // tableDeleter handles writing kvs and forming table rows for deletes.
@@ -828,3 +842,5 @@ func collectTableWriterSpans(
 	}
 	return fkReads, tableSpans, nil
 }
+
+func (td *tableDeleter) close(_ context.Context) {}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -408,6 +408,7 @@ func (u *updateNode) Start(params runParams) error {
 
 func (u *updateNode) Close(ctx context.Context) {
 	u.run.rows.Close(ctx)
+	u.tw.close(ctx)
 	*u = updateNode{}
 	updateNodePool.Put(u)
 }


### PR DESCRIPTION
This refactors tableUpserter so the storage of the row batch uses a
RowContainer instead of just a []Datums for proper memory accounting.

cc: @cockroachdb/sql-execution 