### PR TITLE
sql: Temporarily revert per-statement context forking to address memory leak

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -362,9 +362,6 @@ func (r *QueryRegistry) Cancel(queryID string, username string) (bool, error) {
 			return false, fmt.Errorf("query ID %s not found", queryID)
 		}
 
-		// Close the context
-		queryMeta.cancel()
-
 		// Atomically set isCancelled to 1
 		atomic.StoreInt32(&queryMeta.isCancelled, 1)
 
@@ -1098,8 +1095,9 @@ func (e *Executor) execStmtsInCurrentTxn(
 		stmt.queryID = queryID
 		stmt.queryMeta = queryMeta
 
-		// Fork context for this statement.
-		queryMeta.ctx, queryMeta.cancel = context.WithCancel(session.Ctx())
+		// TODO(itsbilal): Fork a statement-specific context here, that gets cancelled
+		// upon request by user.
+		queryMeta.ctx = session.Ctx()
 
 		session.addActiveQuery(queryID, queryMeta)
 		defer session.removeActiveQuery(stmt.queryID)

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -177,12 +177,8 @@ type queryMeta struct {
 	// Current phase of execution of query.
 	phase queryPhase
 
-	// Context associated with this query. Forked from session.Ctx().
+	// Context associated with this query.
 	ctx context.Context
-
-	// Cancellation handle - calling this function cancels the context associated
-	// with this query.
-	cancel context.CancelFunc
 
 	// Flag that denotes if this query has been cancelled yet. Set and checked
 	// using sync.atomic.{Load,Store}Int32.


### PR DESCRIPTION
Original PR: #17003 

Not cancelling the context right after forking it was causing a memory leak. Simply cancelling the context after every statement doesn't work, since the heartbeat loop detects it and prematurely aborts the transaction ([see the comment here](https://github.com/cockroachdb/cockroach/blob/master/pkg/kv/txn_coord_sender.go#L619)).

While I work on a fix, here's a direct revert of just that part of the PR.