### PR TITLE
sql: change query ID type from string to Uint128

### DIFF
--- a/pkg/sql/prepare.go
+++ b/pkg/sql/prepare.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 )
 
 // PreparedStatement is a SQL statement that has been parsed and the types
@@ -61,7 +62,7 @@ func (p *PreparedStatement) close(ctx context.Context, s *Session) {
 type Statement struct {
 	AST           parser.Statement
 	ExpectedTypes sqlbase.ResultColumns
-	queryID       string
+	queryID       uint128.Uint128
 	queryMeta     *queryMeta
 }
 

--- a/pkg/sql/run_control.go
+++ b/pkg/sql/run_control.go
@@ -66,7 +66,7 @@ func (n *cancelQueryNode) Start(params runParams) error {
 
 	request := &serverpb.CancelQueryRequest{
 		NodeId:   fmt.Sprintf("%d", nodeID),
-		QueryID:  queryID.GetString(),
+		QueryID:  queryIDString,
 		Username: n.p.session.User,
 	}
 
@@ -76,7 +76,7 @@ func (n *cancelQueryNode) Start(params runParams) error {
 	}
 
 	if !response.Cancelled {
-		return fmt.Errorf("Could not cancel query %s: %s", queryID.GetString(), response.Error)
+		return fmt.Errorf("Could not cancel query %s: %s", queryID, response.Error)
 	}
 
 	return nil

--- a/pkg/util/uint128/uint128.go
+++ b/pkg/util/uint128/uint128.go
@@ -37,8 +37,8 @@ func (u Uint128) GetBytes() []byte {
 	return buf
 }
 
-// GetString returns a hexadecimal string representation.
-func (u Uint128) GetString() string {
+// String returns a hexadecimal string representation.
+func (u Uint128) String() string {
 	return hex.EncodeToString(u.GetBytes())
 }
 

--- a/pkg/util/uint128/uint128_test.go
+++ b/pkg/util/uint128/uint128_test.go
@@ -37,7 +37,7 @@ func TestString(t *testing.T) {
 
 	i, _ := FromString(s)
 
-	if s != i.GetString() {
+	if s != i.String() {
 		t.Errorf("incorrect string representation for num: %v", i)
 	}
 }


### PR DESCRIPTION
Change the query ID type that is commonly used from string to
Uint128. This avoids the conversion to/from string in the common case,
reserving such conversion for when queries are listed and cancelled. The
Uint128 representation is smaller, faster to hash (for maps), faster to
compare and doesn't require an allocation.