### PR TITLE
vendor: Update coreos/etcd; pick up pre-vote patch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -151,9 +151,10 @@
   revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
 
 [[projects]]
+  branch = "master"
   name = "github.com/coreos/etcd"
   packages = ["raft","raft/raftpb"]
-  revision = "6dd807481cebac062e82c5ecaecdb2c3d0f605ad"
+  revision = "d2654f85223276cfb6c1803d6e2bcc5db91c17ba"
 
 [[projects]]
   name = "github.com/cpuguy83/go-md2man"
@@ -659,6 +660,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7da157eca498fe957e185931fe43036e08ed977ae4abd7fe9a7cac5ac001a465"
+  inputs-digest = "f9ae1d1f3ee2271b84771ce05b074f3438cc66b54910b9355d1789b157e774ad"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,3 +48,7 @@ ignored = [
   name = "github.com/chzyer/readline"
   source = "https://github.com/cockroachdb/readline"
   branch = "master"
+
+[[constraint]]
+  name = "github.com/coreos/etcd"
+  branch = "master"


### PR DESCRIPTION
Additionally default `COCKROACH_ENABLE_PREVOTE` to true. If I'm not mistaken `COCKROACH_TICK_QUIESCED` can be removed now.

---
Changes to `vendored`: Needed to pick up coreos/etcd@a92ceeec257e98d30d51639ee9007a0eb29599a1, coreos/etcd@93826f2f78128fb7775f5cca61728cc05befa0aa (https://github.com/coreos/etcd/pull/8288). Part of cockroachdb/cockroach#16950.

```
github.com/coreos/etcd/raft/node_test.go       |   32 +++
github.com/coreos/etcd/raft/raft.go            |   72 +++++--
github.com/coreos/etcd/raft/raft_test.go       |  160 +++++++++++++-
github.com/coreos/etcd/raft/raftpb/raft.pb.go  |   76 +++++--
github.com/coreos/etcd/raft/read_only.go       |    2 +-
github.com/coreos/etcd/raft/status.go          |   18 +-
```

This picks up https://github.com/coreos/etcd/pull/7987 which we don't use as yet, so should be fine. Also picks up https://github.com/coreos/etcd/pull/7761 which should be fine. `raft/raftpb/raft.pb.go` was regenerated in https://github.com/coreos/etcd/pull/8084, which I'm less sure about, is this safe for us?

+cc @bdarnell