### PR TITLE
distsql: basic planning for merge joins

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -84,7 +85,18 @@ var logPlanDiagram = envutil.EnvOrDefaultBool("COCKROACH_DISTSQL_LOG_PLAN", fals
 // If true, for index joins  we instantiate a join reader on every node that
 // has a stream (usually from a table reader). If false, there is a single join
 // reader.
-var distributeIndexJoin = envutil.EnvOrDefaultBool("COCKROACH_DISTSQL_DISTRIBUTE_INDEX_JOIN", true)
+var distributeIndexJoin = settings.RegisterBoolSetting(
+	"sql.distsql.distribute_index_joins",
+	"if set, for index joins we instantiate a join reader on every node that has a "+
+		"stream; if not set, we use a single join reader",
+	true,
+)
+
+var planMergeJoins = settings.RegisterBoolSetting(
+	"sql.distsql.merge_joins.enabled",
+	"if set, we plan merge joins when possible",
+	true,
+)
 
 func newDistSQLPlanner(
 	nodeDesc roachpb.NodeDescriptor,
@@ -1221,7 +1233,7 @@ ColLoop:
 		plan.planToStreamColMap[col] = i
 	}
 
-	if distributeIndexJoin && len(plan.ResultRouters) > 1 {
+	if distributeIndexJoin.Get() && len(plan.ResultRouters) > 1 {
 		// Instantiate one join reader for every stream.
 		plan.AddNoGroupingStage(
 			distsqlrun.ProcessorCoreUnion{JoinReader: &joinReaderSpec},
@@ -1316,17 +1328,26 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 
 	// Nodes where we will run the join processors.
 	var nodes []roachpb.NodeID
-	var joinerSpec distsqlrun.HashJoinerSpec
+
+	// We initialize these properties of the joiner. They will then be used to
+	// fill in the processor spec. See descriptions for HashJoinerSpec.
+	var joinType distsqlrun.JoinType
+	var onExpr distsqlrun.Expression
+	var leftEqCols, rightEqCols []uint32
+	var leftMergeOrd, rightMergeOrd distsqlrun.Ordering
+	var mergedColumns bool
 
 	switch n.joinType {
 	case joinTypeInner:
-		joinerSpec.Type = distsqlrun.JoinType_INNER
+		joinType = distsqlrun.JoinType_INNER
 	case joinTypeFullOuter:
-		joinerSpec.Type = distsqlrun.JoinType_FULL_OUTER
+		joinType = distsqlrun.JoinType_FULL_OUTER
 	case joinTypeRightOuter:
-		joinerSpec.Type = distsqlrun.JoinType_RIGHT_OUTER
+		joinType = distsqlrun.JoinType_RIGHT_OUTER
 	case joinTypeLeftOuter:
-		joinerSpec.Type = distsqlrun.JoinType_LEFT_OUTER
+		joinType = distsqlrun.JoinType_LEFT_OUTER
+	default:
+		panic(fmt.Sprintf("invalid join type %d", n.joinType))
 	}
 
 	// Figure out the left and right types.
@@ -1354,13 +1375,37 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 		}
 
 		// Set up the equality columns.
-		joinerSpec.LeftEqColumns = make([]uint32, numEq)
+		leftEqCols = make([]uint32, numEq)
 		for i, leftPlanCol := range n.pred.leftEqualityIndices {
-			joinerSpec.LeftEqColumns[i] = uint32(leftPlan.planToStreamColMap[leftPlanCol])
+			leftEqCols[i] = uint32(leftPlan.planToStreamColMap[leftPlanCol])
 		}
-		joinerSpec.RightEqColumns = make([]uint32, numEq)
+		rightEqCols = make([]uint32, numEq)
 		for i, rightPlanCol := range n.pred.rightEqualityIndices {
-			joinerSpec.RightEqColumns[i] = uint32(rightPlan.planToStreamColMap[rightPlanCol])
+			rightEqCols[i] = uint32(rightPlan.planToStreamColMap[rightPlanCol])
+		}
+		if planMergeJoins.Get() && len(n.mergeJoinOrdering) > 0 &&
+			joinType == distsqlrun.JoinType_INNER {
+			// TODO(radu): we currently only use merge joins when we have an ordering on
+			// all equality columns. We should relax this by either:
+			//  - implementing a hybrid hash/merge processor which implements merge
+			//    logic on the columns we have an ordering on, and within each merge
+			//    group uses a hashmap on the remaining columns
+			//  - or: adding a sort processor to complete the order
+			if len(n.mergeJoinOrdering) == len(n.pred.leftEqualityIndices) {
+				// Excellent! We can use the merge joiner.
+				leftMergeOrd.Columns = make([]distsqlrun.Ordering_Column, len(n.mergeJoinOrdering))
+				rightMergeOrd.Columns = make([]distsqlrun.Ordering_Column, len(n.mergeJoinOrdering))
+				for i, c := range n.mergeJoinOrdering {
+					leftMergeOrd.Columns[i].ColIdx = leftEqCols[c.ColIdx]
+					rightMergeOrd.Columns[i].ColIdx = rightEqCols[c.ColIdx]
+					dir := distsqlrun.Ordering_Column_ASC
+					if c.Direction == encoding.Descending {
+						dir = distsqlrun.Ordering_Column_DESC
+					}
+					leftMergeOrd.Columns[i].Direction = dir
+					rightMergeOrd.Columns[i].Direction = dir
+				}
+			}
 		}
 	} else {
 		// Without column equality, we cannot distribute the join. Run a
@@ -1411,7 +1456,7 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 				joinToStreamColMap[joinCol] = addOutCol(uint32(i))
 			} else {
 				// For inner joins, merged columns are always equivalent to the left columns)
-				joinToStreamColMap[joinCol] = addOutCol(joinerSpec.LeftEqColumns[i])
+				joinToStreamColMap[joinCol] = addOutCol(leftEqCols[i])
 			}
 		}
 		joinCol++
@@ -1433,10 +1478,10 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 		joinCol++
 	}
 	if mergedColNum != 0 {
-		if mergedColNum != len(joinerSpec.LeftEqColumns) {
+		if mergedColNum != len(leftEqCols) {
 			panic("merged columns number is different from equality columns")
 		}
-		joinerSpec.MergedColumns = true
+		mergedColumns = true
 	}
 
 	if n.pred.onCond != nil {
@@ -1455,7 +1500,29 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 		for i := 0; i < n.pred.numRightCols; i++ {
 			joinColMap = append(joinColMap, mergedColNum+rightPlan.planToStreamColMap[i]+len(leftTypes))
 		}
-		joinerSpec.OnExpr = distsqlplan.MakeExpression(n.pred.onCond, joinColMap)
+		onExpr = distsqlplan.MakeExpression(n.pred.onCond, joinColMap)
+	}
+
+	// Create the Core spec.
+	var core distsqlrun.ProcessorCoreUnion
+	if leftMergeOrd.Columns == nil {
+		core.HashJoiner = &distsqlrun.HashJoinerSpec{
+			LeftEqColumns:  leftEqCols,
+			RightEqColumns: rightEqCols,
+			OnExpr:         onExpr,
+			Type:           joinType,
+			MergedColumns:  mergedColumns,
+		}
+	} else {
+		if mergedColumns {
+			panic("merged columns not supported by merge join")
+		}
+		core.MergeJoiner = &distsqlrun.MergeJoinerSpec{
+			LeftOrdering:  leftMergeOrd,
+			RightOrdering: rightMergeOrd,
+			OnExpr:        onExpr,
+			Type:          joinType,
+		}
 	}
 
 	pIdxStart := distsqlplan.ProcessorIdx(len(p.Processors))
@@ -1469,7 +1536,7 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 					{ColumnTypes: leftTypes},
 					{ColumnTypes: rightTypes},
 				},
-				Core:    distsqlrun.ProcessorCoreUnion{HashJoiner: &joinerSpec},
+				Core:    core,
 				Post:    post,
 				Output:  []distsqlrun.OutputRouterSpec{{Type: distsqlrun.OutputRouterSpec_PASS_THROUGH}},
 				StageID: stageID,
@@ -1489,7 +1556,7 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 						{ColumnTypes: leftTypes},
 						{ColumnTypes: rightTypes},
 					},
-					Core:    distsqlrun.ProcessorCoreUnion{HashJoiner: &joinerSpec},
+					Core:    core,
 					Post:    post,
 					Output:  []distsqlrun.OutputRouterSpec{{Type: distsqlrun.OutputRouterSpec_PASS_THROUGH}},
 					StageID: stageID,
@@ -1502,14 +1569,14 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 		for _, resultProc := range leftRouters {
 			p.Processors[resultProc].Spec.Output[0] = distsqlrun.OutputRouterSpec{
 				Type:        distsqlrun.OutputRouterSpec_BY_HASH,
-				HashColumns: joinerSpec.LeftEqColumns,
+				HashColumns: leftEqCols,
 			}
 		}
 		// Set up the right routers.
 		for _, resultProc := range rightRouters {
 			p.Processors[resultProc].Spec.Output[0] = distsqlrun.OutputRouterSpec{
 				Type:        distsqlrun.OutputRouterSpec_BY_HASH,
-				HashColumns: joinerSpec.RightEqColumns,
+				HashColumns: rightEqCols,
 			}
 		}
 	}
@@ -1522,9 +1589,9 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 
 		// Connect left routers to the processor's first input. Currently the join
 		// node doesn't care about the orderings of the left and right results.
-		p.MergeResultStreams(leftRouters, bucket, distsqlrun.Ordering{}, pIdx, 0)
+		p.MergeResultStreams(leftRouters, bucket, leftMergeOrd, pIdx, 0)
 		// Connect right routers to the processor's second input.
-		p.MergeResultStreams(rightRouters, bucket, distsqlrun.Ordering{}, pIdx, 1)
+		p.MergeResultStreams(rightRouters, bucket, rightMergeOrd, pIdx, 1)
 
 		p.ResultRouters = append(p.ResultRouters, pIdx)
 	}

--- a/pkg/sql/distsqlrun/flow_diagram.go
+++ b/pkg/sql/distsqlrun/flow_diagram.go
@@ -150,6 +150,18 @@ func (hj *HashJoinerSpec) summary() (string, []string) {
 	return "HashJoiner", details
 }
 
+func (hj *MergeJoinerSpec) summary() (string, []string) {
+	details := make([]string, 1, 2)
+	details[0] = fmt.Sprintf(
+		"left(%s)=right(%s)", hj.LeftOrdering.diagramString(), hj.RightOrdering.diagramString(),
+	)
+
+	if hj.OnExpr.Expr != "" {
+		details = append(details, fmt.Sprintf("ON %s", hj.OnExpr.Expr))
+	}
+	return "MergeJoiner", details
+}
+
 func (s *SorterSpec) summary() (string, []string) {
 	details := []string{s.OutputOrdering.diagramString()}
 	if s.OrderingMatchLen != 0 {

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -134,6 +134,13 @@ type joinNode struct {
 	// pred represents the join predicate.
 	pred *joinPredicate
 
+	// mergeJoinOrdering is set during expandPlan if the left and right sides have
+	// similar ordering on the equality columns (or a subset of them). The column
+	// indices refer to equality columns: a ColIdx of i refers to left column
+	// pred.leftEqualityIndices[i] and right column pred.rightEqualityIndices[i].
+	// See computeMergeJoinOrdering. This information is used by distsql planning.
+	mergeJoinOrdering sqlbase.ColumnOrdering
+
 	// columns contains the metadata for the results of this node.
 	columns sqlbase.ResultColumns
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -144,6 +144,38 @@ SELECT i, to_english(i*i) FROM GENERATE_SERIES(1, 100) AS g(i)
 query IT rowsort label-sq-str
 SELECT x, str FROM NumToSquare JOIN NumToStr ON y = xsquared
 
+# Merge join.
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
+----
+0  render  ·               ·                    (x, str)                                 ·
+0  ·       render 0        test.numtosquare.x   ·                                        ·
+0  ·       render 1        test.numtostr.str    ·                                        ·
+1  join    ·               ·                    (x, xsquared[omitted], y[omitted], str)  ·
+1  ·       type            inner                ·                                        ·
+1  ·       equality        (x) = (y)            ·                                        ·
+1  ·       mergeJoinOrder  +"(x=y)"             ·                                        ·
+2  scan    ·               ·                    (x, xsquared[omitted])                   +x,unique
+2  ·       table           numtosquare@primary  ·                                        ·
+2  ·       spans           ALL                  ·                                        ·
+2  ·       filter          (x % 2) = 0          ·                                        ·
+2  scan    ·               ·                    (y, str)                                 +y,unique
+2  ·       table           numtostr@primary     ·                                        ·
+2  ·       spans           ALL                  ·                                        ·
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzclUFr2zAUx-_7FObBoKUaWLKzLIKCT4MMlo7S2_DBjd4Sg2N5kgwrJd992NpI42RSjHYIvsWxfn7v_3ug9wq1FLgqdqiBfwcKBBgQSIBACgRmkBNolFyj1lJ1RyywFL-AxwTKumlN93dOYC0VAn8FU5oKgcNT8VzhIxYCFRAQaIqy6os0qtwV6iWr252R-mdbKAQCn8vKoOLRTUaj9xHjnC9XT7fRfRTbn0DgoTU8yijkewKyNX9KHyo-v0TbQm-Pq_XncwLaFBsETvfkv0cw6tAcyVhQf-yf_R2-09ZSCVQojr6Ud-TfI-cOQEbvbK1hzq-oNvhFlvUwZ4U_zE1G727vVbnZ2p9vsyaDrIccSUCOMx2u5AfZDOOeLZweFaZXPmA6kQGzK_fMJuI5uXLPyUQ8p1fuOZ2IZ88CfkTdyFrjRTd_3CVAsUErRctWrfGbkuu-jH186Ln-3hWojX3L7MOytq-6Bi-HZyHwPARehMCUumk6whgbB89C4HkIvAiBB8ZOaDak47d04tadOGF67Dse0mnIsNywZ1hu2DMsN-wZlhv2DWsWMqyPIbrdsEe3G_bodsMe3W7Yp3seovtTiG437NHthj263bBHtxv26V6E6KZjluXpHTpmW46lfZf_mH05lvY5pyfbwyk937_7HQAA__8EY8gd
+
+# Save the result of the following statement to a label.
+query IT rowsort label-sq-2-str
+SELECT 2*i, to_english(2*i) FROM GENERATE_SERIES(1, 50) AS g(i)
+
+# Compare the results of this query to the one above.
+query IT rowsort label-sq-2-str
+SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
+
 
 #
 # -- Aggregation tests --

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -758,9 +758,9 @@ SELECT * FROM [EXPLAIN SELECT
   AND      fkn.nspname = 'test'
   AND      fkc.relname = 'orders'
   ORDER BY pkn.nspname,
-	   pkc.relname,
-	   con.conname,
-	   pos.n
+           pkc.relname,
+           con.conname,
+           pos.n
   ] WHERE "Type" <> 'values' AND "Field" <> 'size'
 ----
 0   sort       ·         ·
@@ -1109,3 +1109,83 @@ NULL       2      2
 NULL       3      3
  201    NULL    201
  401    NULL    401
+
+# Tests for merge join ordering information.
+statement ok
+CREATE TABLE pkBA (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a))
+
+statement ok
+CREATE TABLE pkBC (a INT, b INT, c INT, d INT, PRIMARY KEY(b,c))
+
+statement ok
+CREATE TABLE pkBAC (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,c))
+
+statement ok
+CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
+----
+0  join  ·               ·                      (a, b, c, d, a, b, c, d)  ·
+0  ·     type            inner                  ·                         ·
+0  ·     equality        (a, b, c) = (a, b, c)  ·                         ·
+0  ·     mergeJoinOrder  +"(b=b)"               ·                         ·
+1  scan  ·               ·                      (a, b, c, d)              +b
+1  ·     table           pkba@primary           ·                         ·
+1  ·     spans           ALL                    ·                         ·
+1  scan  ·               ·                      (a, b, c, d)              +b
+1  ·     table           pkbc@primary           ·                         ·
+1  ·     spans           ALL                    ·                         ·
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
+----
+0  render  ·               ·                            (a, b, c, d)                                                                                                                                                          ·
+0  ·       render 0        a                            ·                                                                                                                                                                     ·
+0  ·       render 1        b                            ·                                                                                                                                                                     ·
+0  ·       render 2        c                            ·                                                                                                                                                                     ·
+0  ·       render 3        d                            ·                                                                                                                                                                     ·
+1  join    ·               ·                            (a, b, c, d, a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d[hidden,omitted], a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d[hidden,omitted])  ·
+1  ·       type            inner                        ·                                                                                                                                                                     ·
+1  ·       equality        (a, b, c, d) = (a, b, c, d)  ·                                                                                                                                                                     ·
+1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(d=d)"   ·                                                                                                                                                                     ·
+2  scan    ·               ·                            (a, b, c, d)                                                                                                                                                          +b,+a,unique
+2  ·       table           pkba@primary                 ·                                                                                                                                                                     ·
+2  ·       spans           ALL                          ·                                                                                                                                                                     ·
+2  scan    ·               ·                            (a, b, c, d)                                                                                                                                                          +b,+a,+d,unique
+2  ·       table           pkbad@primary                ·                                                                                                                                                                     ·
+2  ·       spans           ALL                          ·                                                                                                                                                                     ·
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
+----
+0  render  ·               ·                           (a, b, c, d, d)                                                                                                                    ·
+0  ·       render 0        a                           ·                                                                                                                                  ·
+0  ·       render 1        b                           ·                                                                                                                                  ·
+0  ·       render 2        c                           ·                                                                                                                                  ·
+0  ·       render 3        l.d                         ·                                                                                                                                  ·
+0  ·       render 4        r.d                         ·                                                                                                                                  ·
+1  join    ·               ·                           (a, b, c, a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d, a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d)  ·
+1  ·       type            inner                       ·                                                                                                                                  ·
+1  ·       equality        (a, b, c) = (a, b, c)       ·                                                                                                                                  ·
+1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                                                                                                                                  ·
+2  scan    ·               ·                           (a, b, c, d)                                                                                                                       +b,+a,+c,unique
+2  ·       table           pkbac@primary               ·                                                                                                                                  ·
+2  ·       spans           ALL                         ·                                                                                                                                  ·
+2  scan    ·               ·                           (a, b, c, d)                                                                                                                       +b,+a,+c,unique
+2  ·       table           pkbac@primary               ·                                                                                                                                  ·
+2  ·       spans           ALL                         ·                                                                                                                                  ·
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
+----
+0  join  ·               ·                           (a, b, c, d, a, b, c, d)  ·
+0  ·     type            inner                       ·                         ·
+0  ·     equality        (c, a, b) = (d, a, b)       ·                         ·
+0  ·     mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
+1  scan  ·               ·                           (a, b, c, d)              +b,+a,+c,unique
+1  ·     table           pkbac@primary               ·                         ·
+1  ·     spans           ALL                         ·                         ·
+1  scan  ·               ·                           (a, b, c, d)              +b,+a,+d,unique
+1  ·     table           pkbad@primary               ·                         ·
+1  ·     spans           ALL                         ·                         ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -101,35 +101,37 @@ EXPLAIN(METADATA) SELECT k FROM kv JOIN (VALUES (1,2)) AS z(a,b) ON kv.k = z.a O
 query ITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-0  sort    ·         ·                (k)                                                                                  ·
-0  ·       order     -v               ·                                                                                    ·
-1  render  ·         ·                (k, v)                                                                               ·
-2  join    ·         ·                (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])  ·
-2  ·       type      inner            ·                                                                                    ·
-2  ·       equality  (k, v) = (k, v)  ·                                                                                    ·
-3  scan    ·         ·                (k, v)                                                                               ·
-3  ·       table     kv@primary       ·                                                                                    ·
-3  ·       spans     ALL              ·                                                                                    ·
-3  scan    ·         ·                (k, v)                                                                               ·
-3  ·       table     kv@primary       ·                                                                                    ·
-3  ·       spans     ALL              ·                                                                                    ·
+0  sort    ·               ·                (k)                                                                                  ·
+0  ·       order           -v               ·                                                                                    ·
+1  render  ·               ·                (k, v)                                                                               ·
+2  join    ·               ·                (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])  ·
+2  ·       type            inner            ·                                                                                    ·
+2  ·       equality        (k, v) = (k, v)  ·                                                                                    ·
+2  ·       mergeJoinOrder  +"(k=k)"         ·                                                                                    ·
+3  scan    ·               ·                (k, v)                                                                               +k,unique
+3  ·       table           kv@primary       ·                                                                                    ·
+3  ·       spans           ALL              ·                                                                                    ·
+3  scan    ·               ·                (k, v)                                                                               +k,unique
+3  ·       table           kv@primary       ·                                                                                    ·
+3  ·       spans           ALL              ·                                                                                    ·
 
 # The underlying index can be forced manually, of course.
 query ITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@foo
 ----
-0  sort    ·         ·                (k)                                                                                  ·
-0  ·       order     -v               ·                                                                                    ·
-1  render  ·         ·                (k, v)                                                                               ·
-2  join    ·         ·                (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])  ·
-2  ·       type      inner            ·                                                                                    ·
-2  ·       equality  (k, v) = (k, v)  ·                                                                                    ·
-3  scan    ·         ·                (k, v)                                                                               ·
-3  ·       table     kv@foo           ·                                                                                    ·
-3  ·       spans     ALL              ·                                                                                    ·
-3  scan    ·         ·                (k, v)                                                                               ·
-3  ·       table     kv@foo           ·                                                                                    ·
-3  ·       spans     ALL              ·                                                                                    ·
+0  sort    ·               ·                  (k)                                                                                  ·
+0  ·       order           -v                 ·                                                                                    ·
+1  render  ·               ·                  (k, v)                                                                               ·
+2  join    ·               ·                  (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])  ·
+2  ·       type            inner              ·                                                                                    ·
+2  ·       equality        (k, v) = (k, v)    ·                                                                                    ·
+2  ·       mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                                                                                    ·
+3  scan    ·               ·                  (k, v)                                                                               -v,+k,unique
+3  ·       table           kv@foo             ·                                                                                    ·
+3  ·       spans           ALL                ·                                                                                    ·
+3  scan    ·               ·                  (k, v)                                                                               -v,+k,unique
+3  ·       table           kv@foo             ·                                                                                    ·
+3  ·       spans           ALL                ·                                                                                    ·
 
 # Check the extended syntax cannot be used in case of renames.
 statement error source name "kv" not found in FROM clause

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -69,6 +69,8 @@ server.remote_debugging.mode                       local          s     set to e
 server.time_until_store_dead                       5m0s           d     the time after which if there is no new gossiped information about a store, it is considered dead
 sql.defaults.distsql                               1              e     Default distributed SQL execution mode [off = 0, auto = 1, on = 2]
 sql.defaults.distsql.tempstorage                   false          b     set to true to enable use of disk for larger distributed sql queries
+sql.distsql.distribute_index_joins                 true           b     if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader
+sql.distsql.merge_joins.enabled                    true           b     if set, we plan merge joins when possible
 sql.metrics.statement_details.dump_to_logs         false          b     dump collected statement statistics to node logs when periodically cleared
 sql.metrics.statement_details.enabled              true           b     collect per-statement query statistics
 sql.metrics.statement_details.threshold            0s             d     minmum execution time to cause statics to be collected

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -200,6 +200,15 @@ func (v *planVisitor) visit(plan planNode) {
 				buf.WriteByte(')')
 				v.observer.attr(name, "equality", buf.String())
 			}
+			if len(n.mergeJoinOrdering) > 0 {
+				// The ordering refers to equality columns
+				eqCols := make(sqlbase.ResultColumns, len(n.pred.leftEqualityIndices))
+				for i := range eqCols {
+					eqCols[i].Name = fmt.Sprintf("(%s=%s)", n.pred.leftColNames[i], n.pred.rightColNames[i])
+				}
+				order := orderingInfo{ordering: n.mergeJoinOrdering}
+				v.observer.attr(name, "mergeJoinOrder", order.AsString(eqCols))
+			}
 		}
 		subplans := v.expr(name, "pred", -1, n.pred.onCond, nil)
 		v.subqueries(name, subplans)


### PR DESCRIPTION
We detect when the two sides of the join have matching orderings on all equality
columns and use the merge joiner.

Note that as things stand, the join node does not guarantee any output ordering.
This means that we may have an unnecessary sorter after a merge join, or - much
more importantly - the output of a merge join won't be used as the input of
another merge join.

Updates #16580.

I have not looked at the running time of a merge join vs hash join on a large dataset (TPC-H). I was hoping @arjunravinarayan could help with that. Even a single-node deployment would give us a good idea of the speed difference.