### PR TITLE
sql: teach ConvertBatchError to handle composite encoding

### DIFF
--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -222,7 +222,9 @@ func WriteResumeSpan(
 }
 
 // ConvertBackfillError returns a cleaner SQL error for a failed Batch.
-func ConvertBackfillError(tableDesc *sqlbase.TableDescriptor, b *client.Batch) error {
+func ConvertBackfillError(
+	ctx context.Context, tableDesc *sqlbase.TableDescriptor, b *client.Batch,
+) error {
 	// A backfill on a new schema element has failed and the batch contains
 	// information useful in printing a sensible error. However
 	// ConvertBatchError() will only work correctly if the schema elements
@@ -237,5 +239,5 @@ func ConvertBackfillError(tableDesc *sqlbase.TableDescriptor, b *client.Batch) e
 		}
 		desc.MakeMutationComplete(mutation)
 	}
-	return sqlbase.ConvertBatchError(desc, b)
+	return sqlbase.ConvertBatchError(ctx, desc, b)
 }

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -237,7 +237,7 @@ func (cb *columnBackfiller) runChunk(
 		}
 		// Write the new row values.
 		if err := txn.CommitInBatch(ctx, b); err != nil {
-			return ConvertBackfillError(&cb.spec.Table, b)
+			return ConvertBackfillError(ctx, &cb.spec.Table, b)
 		}
 		return nil
 	})

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -167,7 +167,7 @@ func (ib *indexBackfiller) runChunk(
 		}
 		// Write the new index values.
 		if err := txn.CommitInBatch(ctx, b); err != nil {
-			return ConvertBackfillError(&ib.spec.Table, b)
+			return ConvertBackfillError(ctx, &ib.spec.Table, b)
 		}
 		return nil
 	})

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
@@ -10,12 +10,8 @@ CREATE TABLE p (
 statement ok
 INSERT INTO p VALUES ('a' COLLATE en_u_ks_level1)
 
-# TODO(eisen): the interactive message is
-# > pq: TODO(eisen): cannot decode collation key: "\x15\xef"
-# Here and below, we can do better.
-#
-# statement error
-# INSERT INTO p VALUES ('A' COLLATE en_u_ks_level1)
+statement error duplicate key value \(a\)=\('a' COLLATE en_u_ks_level1\) violates unique constraint "primary"
+INSERT INTO p VALUES ('A' COLLATE en_u_ks_level1)
 
 statement ok
 INSERT INTO p VALUES ('b' COLLATE en_u_ks_level1)

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -127,7 +127,7 @@ func (ti *tableInserter) finalize(ctx context.Context, _ bool) error {
 	}
 
 	if err != nil {
-		return sqlbase.ConvertBatchError(ti.ri.Helper.TableDesc, ti.b)
+		return sqlbase.ConvertBatchError(ctx, ti.ri.Helper.TableDesc, ti.b)
 	}
 	return nil
 }
@@ -174,7 +174,7 @@ func (tu *tableUpdater) finalize(ctx context.Context, _ bool) error {
 	}
 
 	if err != nil {
-		return sqlbase.ConvertBatchError(tu.ru.Helper.TableDesc, tu.b)
+		return sqlbase.ConvertBatchError(ctx, tu.ru.Helper.TableDesc, tu.b)
 	}
 	return nil
 }
@@ -388,7 +388,7 @@ func (tu *tableUpserter) flush(ctx context.Context, finalize, traceKV bool) erro
 		err = tu.txn.Run(ctx, b)
 	}
 	if err != nil {
-		return sqlbase.ConvertBatchError(tu.tableDesc, b)
+		return sqlbase.ConvertBatchError(ctx, tu.tableDesc, b)
 	}
 	return nil
 }


### PR DESCRIPTION
ConvertBatchError previously implemented its own key decoding. This
commit replaces that implementation with RowFetcher, splitting kvFetcher
into an interface (kvFetcher) and an implementation (txnKVFetcher) to
make this possible.

Fixes #14166.