### PR TITLE
sql: Cancel txn context on query cancellation

### DIFF
--- a/docs/RFCS/query_cancellation.md
+++ b/docs/RFCS/query_cancellation.md
@@ -101,13 +101,15 @@ root@:26257/> SELECT node_id, id, query FROM [SHOW CLUSTER QUERIES];
 
 ## Context forking / query cancellation mechanism
 
-The `context.Context` will be forked in the SQL executor for each statement, and the cancellation handle
-will be stored inside the `queryMeta` struct for that query. There will also be an integer flag that,
-when set to 1 (using an `atomic.StoreInt32()`), will signal cancellation. PlanNodes that do in-memory
+We will reuse the transaction's context at the query level; all query cancellations will close the entire transaction's
+context. Forking a query-specific context would be technically challenging due to [context scoping assumptions made in
+the TxnCoordSender](https://github.com/cockroachdb/cockroach/blob/8ff5ff97df139fa5958e15a2fd5ffa65e09b49ff/pkg/kv/txn_coord_sender.go#L619). The
+`queryMeta` will store a reference to the txn context. There will also be an integer flag in `queryMeta`
+that, when set to 1 (using an `atomic.StoreInt32()`), will signal cancellation. PlanNodes that do in-memory
 processing such as insertNode's insert batching, and sortNode's sorting, will periodically check
 for this flag (such as once every some tens of thousands of rows).
 
-Any `CANCEL QUERY` statements directed at that query will close that context's `Done` channel, which would
+Any `CANCEL QUERY` statements directed at that query will close the txn context's `Done` channel, which would
 error out any RPCs being made for that query. The cancellation flag would also be atomically set to 1,
 which would cause any planNodes that check it periodically to return a cancellation error. The error would
 propagate to the SQL executor which would then mark the SQL transaction as aborted. The client would

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -16,6 +16,7 @@ package sql_test
 
 import (
 	gosql "database/sql"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -23,7 +24,10 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -73,4 +77,94 @@ func TestCancelSelectQuery(t *testing.T) {
 		t.Fatal("no error received from query supposed to be cancelled")
 	}
 
+}
+
+func TestCancelParallelQuery(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	const queryToBlock = "INSERT INTO nums VALUES (1) RETURNING NOTHING;"
+	const queryToCancel = "INSERT INTO nums2 VALUES (2) RETURNING NOTHING;"
+	const sqlToRun = "BEGIN TRANSACTION; " + queryToBlock + queryToCancel + " COMMIT;"
+
+	// conn1 is used for the txn above. conn2 is solely for the CANCEL statement.
+	var conn1 *gosql.DB
+	var conn2 *gosql.DB
+
+	// Up to two goroutines could generate errors (one for each query).
+	errChan := make(chan error, 1)
+	errChan2 := make(chan error, 1)
+
+	sem := make(chan struct{})
+
+	tc := serverutils.StartTestCluster(t, 2, /* numNodes */
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+			ServerArgs: base.TestServerArgs{
+				UseDatabase: "test",
+				Knobs: base.TestingKnobs{
+					SQLExecutor: &sql.ExecutorTestingKnobs{
+						BeforeExecute: func(ctx context.Context, stmt string, isDistributed bool) {
+							// if queryToBlock
+							if strings.Contains(stmt, "(1)") {
+								// Block start of execution until queryToCancel has been cancelled
+								<-sem
+							}
+						},
+						AfterExecute: func(ctx context.Context, stmt string, res *sql.Result, err error) {
+							// if queryToBlock
+							if strings.Contains(stmt, "(1)") {
+								// Ensure queryToBlock errored out with the cancellation error.
+								if err == nil {
+									errChan <- errors.New("didn't get an error from query that should have been indirectly cancelled")
+								} else if !testutils.IsError(err, ".*query execution cancelled.*") {
+									errChan <- err
+								}
+								close(errChan)
+							} else if strings.Contains(stmt, "(2)") { // if queryToCancel
+								// This query should have finished successfully; if not,
+								// report that error.
+								if err != nil {
+									errChan2 <- err
+								}
+
+								// Cancel this query, even though it has already completed execution.
+								// The other query (queryToBlock) should return a cancellation error.
+								const cancelQuery = "CANCEL QUERY (SELECT query_id FROM [SHOW CLUSTER QUERIES] WHERE node_id = 1 AND query LIKE '%INSERT INTO nums2 VALUES (2%')"
+								if _, err := conn2.Exec(cancelQuery); err != nil {
+									errChan2 <- err
+								}
+								close(errChan2)
+
+								// Unblock queryToBlock
+								sem <- struct{}{}
+								close(sem)
+							}
+						},
+					},
+				},
+			},
+		})
+	defer tc.Stopper().Stop(context.TODO())
+
+	conn1 = tc.ServerConn(0)
+	conn2 = tc.ServerConn(1)
+
+	sqlutils.CreateTable(t, conn1, "nums", "num INT", 0, nil)
+	sqlutils.CreateTable(t, conn1, "nums2", "num INT", 0, nil)
+
+	// Start the txn. Both queries should run in parallel - and queryToBlock
+	// should error out.
+	_, err := conn1.Exec(sqlToRun)
+	if err != nil && !testutils.IsError(err, ".*query execution cancelled.*") {
+		t.Fatal(err)
+	} else if err == nil {
+		t.Fatal("didn't get an error from txn that should have been cancelled")
+	}
+
+	// Ensure both channels are closed.
+	if err := <-errChan2; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-errChan; err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
This reverts some of the changes made in #17003 and #17200. In particular:

#17003 made new contexts for every statement, but didn't cancel them after statement execution, resulting in a memory leak. 
#17200 did a quick-fix for that memory leak by not forking that context, at the expense of not being able to leverage the context in cancellation.

This PR restores the context cancellation behaviour introduced in #17003 , except at the transaction level - cancelling a query closes its transaction's context. The `TxnCoordSender` [isn't set up to handle contexts with a smaller lifetime than the transaction itself](https://github.com/cockroachdb/cockroach/blob/master/pkg/kv/txn_coord_sender.go#L619),