### PR TITLE
sql: escape BYTES column names

### DIFF
--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -129,7 +129,7 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 		// if they're different types.
 		switch col.Type.SemanticType {
 		case sqlbase.ColumnType_BYTES:
-			cols = append(cols, fmt.Sprintf("%s:::bytes", col.Name))
+			cols = append(cols, fmt.Sprintf("%s:::bytes", parser.Name(col.Name).String()))
 		default:
 			cols = append(cols, fmt.Sprintf("%s::string::bytes", parser.Name(col.Name).String()))
 		}

--- a/pkg/sql/show_fingerprints_test.go
+++ b/pkg/sql/show_fingerprints_test.go
@@ -69,13 +69,19 @@ func TestShowFingerprintsColumnNames(t *testing.T) {
 
 	sqlDB := sqlutils.MakeSQLRunner(t, tc.ServerConn(0))
 	sqlDB.Exec(`CREATE DATABASE d`)
-	sqlDB.Exec(`CREATE TABLE d.t (a INT PRIMARY KEY, b INT, INDEX b_idx (b))`)
+	sqlDB.Exec(`CREATE TABLE d.t (
+		lowercase INT PRIMARY KEY,
+		"cApiTaLInT" INT,
+		"cApiTaLByTEs" BYTES,
+		INDEX capital_int_idx ("cApiTaLInT"),
+		INDEX capital_bytes_idx ("cApiTaLByTEs")
+	)`)
 
-	sqlDB.Exec(`INSERT INTO d.t VALUES (1, 2)`)
+	sqlDB.Exec(`INSERT INTO d.t VALUES (1, 2, 'a')`)
 	fprint1 := sqlDB.QueryStr(`SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE d.t`)
 
 	sqlDB.Exec(`TRUNCATE TABLE d.t`)
-	sqlDB.Exec(`INSERT INTO d.t VALUES (3, 4)`)
+	sqlDB.Exec(`INSERT INTO d.t VALUES (3, 4, 'b')`)
 	fprint2 := sqlDB.QueryStr(`SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE d.t`)
 
 	if reflect.DeepEqual(fprint1, fprint2) {


### PR DESCRIPTION
This escaping was somehow only applied to non-BYTES columns, which broke
`SHOW EXPERIMENTAL FINGERPRINTS` on system.users, which has a
camel-cased BYTES column, `hashedPassword`.