### PR TITLE
sqlccl: write backup checkpoint on every response in test

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -580,7 +580,7 @@ func TestBackupRestoreCheckpointing(t *testing.T) {
 	defer func(oldInterval time.Duration) {
 		sqlccl.BackupCheckpointInterval = oldInterval
 	}(sqlccl.BackupCheckpointInterval)
-	sqlccl.BackupCheckpointInterval = time.Millisecond
+	sqlccl.BackupCheckpointInterval = 0
 
 	var checkpointPath string
 


### PR DESCRIPTION
Currently, TestBackupRestoreCheckpointing is locally flaky for me,
because it depends on the order in which ExportResponses are received.

First, note that a checkpoint is written only when at least one
ExportResponse_File has been returned, and that it's perfectly valid for
an ExportResponse to return no files (when the requested span has no
data).

So, consider that TestBackupRestoreCheckpointing runs a backup that
generates about ten ExportRequests and verifies that the checkpoint
exists after five ExportResponses have been returned. Suppose we're
unlucky, and the first response to return has no files. Since we've
never run a checkpoint before, we'll reset the last checkpoint time to
the current time, but when we go to actually write the checkpoint, we'll
skip it because there are no files to write yet. If the remaining four
ExportResponses return within 1ms, none of them will attempt to write a
checkpoint because they're within the BackupCheckpointInterval, and so
no checkpoint exists when the test goes looking for it.

Avoid this by setting BackupRestoreCheckpointInterval to 0 in tests,
which forces every ExportResponse to write a checkpoint. Since this
backup generates less than five ExportResponses with no files, at least
one of the first five responses must return a file and thus write a
checkpoint, and so the checkpoint will exist by the time the test makes
its assertion.