### PR TITLE
storage: rate limit disk writes on behalf of bulk io

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -56,6 +56,7 @@ diagnostics.reporting.report_metrics               true           b     enable c
 diagnostics.reporting.send_crash_reports           true           b     send crash and panic reports
 kv.allocator.lease_rebalancing_aggressiveness      1E+00          f     set greater than 1.0 to rebalance leases toward load more aggressively, or between 0 and 1.0 to be more conservative about rebalancing leases
 kv.allocator.load_based_lease_rebalancing.enabled  true           b     set to enable rebalancing of range leases based on load and latency
+kv.bulk_io_write.max_rate                          8.0 EiB        z     the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops
 kv.gc.batch_size                                   100000         i     maximum number of keys in a batch for MVCC garbage collection
 kv.raft.command.max_size                           64 MiB         z     maximum size of a raft command
 kv.raft_log.synchronize                            true           b     set to true to synchronize on Raft log writes to persistent storage

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -579,6 +579,8 @@ func addSSTablePreApply(
 	}
 	path += ".ingested"
 
+	limitBulkIOWrite(ctx, len(sst.Data))
+
 	var move bool
 	if inmem, ok := eng.(engine.InMem); ok {
 		path = fmt.Sprintf("%x", checksum)

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -15,14 +15,68 @@
 package storage
 
 import (
+	"math"
+	"runtime/debug"
+	"time"
+
 	"golang.org/x/net/context"
+	"golang.org/x/time/rate"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/pkg/errors"
 )
+
+var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
+	"kv.bulk_io_write.max_rate",
+	"the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops",
+	math.MaxInt64,
+)
+
+const (
+	bulkIOWriteLimiterBurst    = 2 * 1024 * 1024 // 2MB
+	bulkIOWriteLimiterLongWait = 500 * time.Millisecond
+)
+
+// TODO(dan): This limiting should be per-store and shared between any
+// operations that need lots of disk throughput.
+var bulkIOWriteLimiter = rate.NewLimiter(
+	rate.Limit(bulkIOWriteLimit.Get()),
+	bulkIOWriteLimiterBurst,
+)
+
+func limitBulkIOWrite(ctx context.Context, cost int) {
+	// TODO(dan): Investigate instead using bulkIOWriteLimit.OnChange to update
+	// the limiter.
+	bulkIOWriteLimiter.SetLimit(rate.Limit(bulkIOWriteLimit.Get()))
+
+	// The limiter disallows anything greater than its burst (set to
+	// bulkIOWriteLimiterBurst), so cap the batch size if it would overflow.
+	//
+	// TODO(dan): This obviously means the limiter is no longer accounting for
+	// the full cost. I've tried calling WaitN in a loop to fully cover the
+	// cost, but that doesn't seem to be as smooth in practice (TPCH-10 restores
+	// on azure local disks), I think because the file is written all at once at
+	// the end. This could be fixed by writing the file in chunks, which also
+	// would likely help the overall smoothness, too.
+	if cost > bulkIOWriteLimiterBurst {
+		cost = bulkIOWriteLimiterBurst
+	}
+
+	begin := timeutil.Now()
+	if err := bulkIOWriteLimiter.WaitN(ctx, cost); err != nil {
+		log.Errorf(ctx, "error rate limiting bulk io write: %+v", err)
+	}
+
+	if d := timeutil.Since(begin); d > bulkIOWriteLimiterLongWait {
+		log.Warningf(ctx, "bulk io write limiter took %s (>%s):\n%s",
+			d, bulkIOWriteLimiterLongWait, debug.Stack())
+	}
+}
 
 var errSideloadedFileNotFound = errors.New("sideloaded file not found")
 

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -53,6 +53,8 @@ func (ss *diskSideloadStorage) createDir() error {
 func (ss *diskSideloadStorage) PutIfNotExists(
 	ctx context.Context, index, term uint64, contents []byte,
 ) error {
+	limitBulkIOWrite(ctx, len(contents))
+
 	filename := ss.filename(ctx, index, term)
 	if _, err := os.Stat(filename); err == nil {
 		// File exists.


### PR DESCRIPTION
Our old friends "batch commit took" and "slow heartbeat took" have
returned.

Many of our RESTORE stability problems seem to be starting with
overloaded disks, which caused contention in RocksDB, which slowed down
heartbeats, which caused mass lease transfers. IngestExternalFile and
diskSideloadStorage are the largest part of this, so add a rate limit
directly for that.

Resurrection of #15436.