### PR TITLE
acceptance: use native go ssh instead of shelling out

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -388,6 +388,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/kr/fs"
+  packages = ["."]
+  revision = "2788f0dbd16903de03cb8186e5c7d97b69ad387b"
+
+[[projects]]
+  branch = "master"
   name = "github.com/kr/logfmt"
   packages = ["."]
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
@@ -517,6 +523,12 @@
   version = "v0.8.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/pkg/sftp"
+  packages = ["."]
+  revision = "22f089b9c4056cf774ebd695b687d469f2ad4650"
+
+[[projects]]
   name = "github.com/prometheus/client_model"
   packages = ["go"]
   revision = "6f3806018612930941127f2a7c6c453ba2c527d2"
@@ -583,7 +595,7 @@
 
 [[projects]]
   name = "golang.org/x/crypto"
-  packages = ["bcrypt","blowfish","ssh/terminal"]
+  packages = ["bcrypt","blowfish","curve25519","ed25519","ed25519/internal/edwards25519","ssh","ssh/terminal"]
   revision = "728b753d0135da6801d45a38e6f43ff55779c5c2"
 
 [[projects]]
@@ -661,6 +673,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ae8de04e8e36f3cc180ca9ce133a9577e8d670f566429a7a4274873f95b84b32"
+  inputs-digest = "f7ab65f3b9d17385a080aadceac05318a94426aac13787c92c6c681480a67411"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/build/errcheck_excludes.txt
+++ b/build/errcheck_excludes.txt
@@ -1,6 +1,9 @@
 (*database/sql.DB).Close
 (*database/sql.Rows).Close
 (*database/sql.Stmt).Close
+(*github.com/cockroachdb/cockroach/vendor/github.com/pkg/sftp.clientConn).Close
+(*github.com/cockroachdb/cockroach/vendor/github.com/pkg/sftp.File).Close
+(*github.com/cockroachdb/cockroach/vendor/golang.org/x/crypto/ssh.Session).Close
 (*os.File).Close
 (io.Closer).Close
 (net.Conn).Close

--- a/pkg/acceptance/terrafarm/farmer.go
+++ b/pkg/acceptance/terrafarm/farmer.go
@@ -20,11 +20,13 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -33,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
-	"github.com/pkg/errors"
 )
 
 // The constants below are the possible values of the KeepCluster field.
@@ -49,6 +50,7 @@ const (
 type node struct {
 	hostname  string
 	processes []string
+	ssh       *ssh.Client
 }
 
 // A Farmer sets up and manipulates a test cluster via terraform.
@@ -165,28 +167,104 @@ func (f *Farmer) AbsLogDir() string {
 
 // CollectLogs copies all possibly interesting files from all available peers
 // if LogDir is not empty.
-func (f *Farmer) CollectLogs() {
-	if f.LogDir == "" {
-		return
+func (f *Farmer) CollectLogs() error {
+	logDir := f.AbsLogDir()
+	if logDir == "" {
+		return nil
 	}
-	if err := os.MkdirAll(f.AbsLogDir(), 0777); err != nil {
-		fmt.Fprint(os.Stderr, err)
-		return
-	}
-	const src = "logs"
+
 	for i := 0; i < f.NumNodes(); i++ {
-		if err := f.scp(f.Hostname(i), f.defaultKeyFile(), src,
-			filepath.Join(f.AbsLogDir(), "node."+strconv.Itoa(i))); err != nil {
-			f.logf("error collecting %s from host %s: %s\n", src, f.Hostname(i), err)
+		dst := filepath.Join(logDir, fmt.Sprintf("node.%d", i))
+
+		host := f.Hostname(i)
+
+		c, err := f.getSSH(host, f.defaultKeyFile())
+		if err != nil {
+			return errors.Wrapf(err, "could not establish ssh connection to %q", host)
+		}
+
+		sftp, err := sftp.NewClient(c)
+		if err != nil {
+			return errors.Wrapf(err, "could not establish stfp connection to %q", host)
+		}
+		defer sftp.Close()
+
+		src := "logs"
+
+		lstat, err := sftp.Lstat(src)
+		if err != nil {
+			return errors.Wrapf(err, "could not lstat %q on %q", src, host)
+		}
+		if lstat.Mode()&os.ModeSymlink != 0 {
+			srcRead, err := sftp.ReadLink(src)
+			if err != nil {
+				return errors.Wrapf(err, "could not read link %q on %q", src, host)
+			}
+			src = srcRead
+		}
+
+		if err := os.Mkdir(dst, 0777); err != nil {
+			return errors.Wrapf(err, "could not create destination directory %q", dst)
+		}
+
+		for w := sftp.Walk(src); w.Step(); {
+			if err := w.Err(); err != nil {
+				return errors.Wrapf(err, "error walking %q on %q", src, host)
+			}
+
+			if err := func() error {
+				srcPath := w.Path()
+				srcPathRel, err := filepath.Rel(src, srcPath)
+				if err != nil {
+					return err
+				}
+				destPath := filepath.Join(dst, srcPathRel)
+
+				switch mode := w.Stat().Mode(); {
+				case mode&os.ModeDir != 0:
+					// Skip the top level directory.
+					if srcPath == src {
+						return nil
+					}
+					return errors.Wrapf(os.Mkdir(destPath, mode), "could not create destination directory %q", destPath)
+				case mode&os.ModeSymlink != 0:
+					srcPathRead, err := sftp.ReadLink(srcPath)
+					if err != nil {
+						return errors.Wrapf(err, "could not read link %q on %q", src, host)
+					}
+					return os.Symlink(srcPathRead, destPath)
+				}
+
+				srcFile, err := sftp.Open(srcPath)
+				if err != nil {
+					return errors.Wrapf(err, "could not open %q on %q", srcPath, host)
+				}
+				defer srcFile.Close()
+
+				destFile, err := os.Create(destPath)
+				if err != nil {
+					return errors.Wrapf(err, "could not create destination file %q", destPath)
+				}
+				defer destFile.Close()
+
+				if _, err := io.Copy(destFile, srcFile); err != nil {
+					return errors.Wrapf(err, "could not copy %q on %q to %q", srcPath, host, destPath)
+				}
+				return errors.Wrapf(destFile.Close(), "could not close destination file %q", destPath)
+			}(); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 // Destroy collects the logs and tears down the cluster.
 func (f *Farmer) Destroy(t testing.TB) error {
-	f.CollectLogs()
-	if f.LogDir != "" {
-		defer f.logf("logs copied to %s\n", f.AbsLogDir())
+	if err := f.CollectLogs(); err != nil {
+		f.logf("error collecting cluster logs: %s\n", err)
+	} else if logDir := f.AbsLogDir(); logDir != "" {
+		defer f.logf("logs copied to %s\n", logDir)
 	}
 
 	wd, err := os.Getwd()
@@ -305,7 +383,7 @@ func (f *Farmer) AssertState(ctx context.Context, t testing.TB, host, proc, expS
 		t.Fatal(err)
 	}
 	if !strings.Contains(out, expState) {
-		t.Fatalf("%s (%s) is not in expected state %s:\n%s", proc, host, expState, out)
+		t.Fatalf("%q (%q) is not in expected state %q:\n%q", proc, host, expState, out)
 	}
 }
 

--- a/pkg/acceptance/terraform_test.go
+++ b/pkg/acceptance/terraform_test.go
@@ -36,7 +36,11 @@ func TestBuildBabyCluster(t *testing.T) {
 
 	ctx := context.Background()
 	f := MakeFarmer(t, "baby", stopper)
-	defer f.CollectLogs()
+	defer func() {
+		if err := f.CollectLogs(); err != nil {
+			t.Logf("error collecting cluster logs: %s\n", err)
+		}
+	}()
 	if err := f.Resize(1); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This paves the way for running processes from the test orchestrator
rather than relying on supervisor on the remote side.

Reviewers: early feedback? I'm going to try to test this, too.