### PR TITLE
server: Fix Flaky TestClientNodeID

### DIFF
--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -136,13 +136,14 @@ func startFakeServerGossips(
 	rRPCContext := newInsecureRPCContext(stopper)
 
 	rserver := rpc.NewServer(rRPCContext)
+	remote := newFakeGossipServer(rserver, stopper)
 	rln, err := netutil.ListenAndServeGRPC(stopper, rserver, util.IsolatedTestAddr)
 	if err != nil {
 		t.Fatal(err)
 	}
-	remote := newFakeGossipServer(rserver, stopper)
 	addr := rln.Addr()
 	remote.nodeAddr = util.MakeUnresolvedAddr(addr.Network(), addr.String())
+
 	return local, remote
 }
 


### PR DESCRIPTION
The flake was caused by a new assertion added to Grpc, a dependency we
recently updated to a new version. Just needed to re-order two calls to
avoid a race condition.

Repairs one of the flakes in #17226