### PR TITLE
ui: expose system jobs

### DIFF
--- a/pkg/sql/split_at_test.go
+++ b/pkg/sql/split_at_test.go
@@ -21,8 +21,10 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -185,6 +187,9 @@ func TestScatter(t *testing.T) {
 		}
 		leaseHolders[leaseHolder]++
 	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
 	if numRows != 100 {
 		t.Fatalf("expected 100 ranges, got %d", numRows)
 	}
@@ -192,5 +197,61 @@ func TestScatter(t *testing.T) {
 		if count < 20 {
 			t.Errorf("less than 20 leaseholders on host %d (only %d)", i, count)
 		}
+	}
+}
+
+// TestScatterResponse ensures that ALTER TABLE... SCATTER includes one row of
+// output per range in the table. It does *not* test that scatter properly
+// distributes replicas and leases; see TestScatter for that.
+//
+// TODO(benesch): consider folding this test into TestScatter once TestScatter
+// is unskipped.
+func TestScatterResponse(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	sqlutils.CreateTable(
+		t, sqlDB, "t",
+		"k INT PRIMARY KEY, v INT",
+		1000,
+		sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowModuloFn(10)),
+	)
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "test", "t")
+
+	r := sqlutils.MakeSQLRunner(t, sqlDB)
+	r.Exec("ALTER TABLE test.t SPLIT AT (SELECT i*10 FROM generate_series(1, 99) AS g(i))")
+	rows := r.Query("ALTER TABLE test.t SCATTER")
+
+	i := 0
+	for ; rows.Next(); i++ {
+		var actualKey []byte
+		var pretty string
+		if err := rows.Scan(&actualKey, &pretty); err != nil {
+			t.Fatal(err)
+		}
+		var expectedKey roachpb.Key
+		if i == 0 {
+			expectedKey = keys.MakeTablePrefix(uint32(tableDesc.ID))
+		} else {
+			var err error
+			expectedKey, err = sqlbase.MakePrimaryIndexKey(tableDesc, i*10)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		if e, a := expectedKey, roachpb.Key(actualKey); !e.Equal(a) {
+			t.Errorf("%d: expected split key %s, but got %s", i, e, a)
+		}
+		if e, a := expectedKey.String(), pretty; e != a {
+			t.Errorf("%d: expected pretty split key %s, but got %s", i, e, a)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if e, a := 100, i; e != a {
+		t.Fatalf("expected %d rows, but got %d", e, a)
 	}
 }

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -4061,5 +4061,12 @@ func (r *Replica) adminScatter(
 		return roachpb.AdminScatterResponse{}, ctx.Err()
 	}
 
-	return roachpb.AdminScatterResponse{}, nil
+	return roachpb.AdminScatterResponse{
+		Ranges: []roachpb.AdminScatterResponse_Range{{
+			Span: roachpb.Span{
+				Key:    desc.StartKey.AsRawKey(),
+				EndKey: desc.EndKey.AsRawKey(),
+			},
+		}},
+	}, nil
 }

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -69,6 +69,7 @@
     "nvd3": "^1.8.5",
     "prop-types": "^15.5.10",
     "protobufjs": "^6.7.3",
+    "rc-progress": "^2.2.1",
     "react": "^15.4.2",
     "react-addons-create-fragment": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",

--- a/pkg/ui/src/hacks/rc-progress.d.ts
+++ b/pkg/ui/src/hacks/rc-progress.d.ts
@@ -1,0 +1,12 @@
+// TODO(benesch): upstream this.
+
+declare module "rc-progress" {
+  export interface LineProps {
+    strokeWidth?: number;
+    trailWidth?: number;
+    className?: string;
+    percent?: number;
+  }
+  export class Line extends React.Component<LineProps, {}> {
+  }
+}

--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -28,6 +28,8 @@ import Layout from "src/views/app/containers/layout";
 import { DatabaseTablesList, DatabaseGrantsList } from "src/views/databases/containers/databases";
 import TableDetails from "src/views/databases/containers/tableDetails";
 
+import JobsPage from "src/views/jobs";
+
 import NodesOverview from "src/views/cluster/containers/nodesOverview";
 import NodeOverview from "src/views/cluster/containers/nodeOverview";
 import NodeGraphs from "src/views/cluster/containers/nodeGraphs";
@@ -70,6 +72,7 @@ ReactDOM.render(
           <Route path="grants" component={ DatabaseGrantsList } />
           <Route path={ `database/:${databaseNameAttr}/table/:${tableNameAttr}` } component={ TableDetails } />
         </Route>
+        <Route path="jobs" component={ JobsPage } />
         <Route path="raft" component={ Raft }>
           <IndexRedirect to="ranges" />
           <Route path="ranges" component={ RaftRanges } />

--- a/pkg/ui/src/redux/apiReducers.ts
+++ b/pkg/ui/src/redux/apiReducers.ts
@@ -7,6 +7,7 @@ import * as api from "src/util/api";
 import { VersionList } from "src/interfaces/cockroachlabs";
 import { versionCheck } from "src/util/cockroachlabsAPI";
 import { NodeStatus$Properties, RollupStoreMetrics } from "src/util/proto";
+import * as protos from "src/js/protos";
 
 // The primary export of this file are the "refresh" functions of the various
 // reducers, which are used by many react components to request fresh data.
@@ -67,6 +68,15 @@ export const refreshLogs = logsReducerObj.refresh;
 const livenessReducerObj = new CachedDataReducer(api.getLiveness, "liveness", moment.duration(10, "s"));
 export const refreshLiveness = livenessReducerObj.refresh;
 
+export const jobsKey = (status: string, type: protos.cockroach.sql.jobs.Type, limit: number) =>
+  `${encodeURIComponent(status)}/${encodeURIComponent(type.toString())}/${encodeURIComponent(limit.toString())}`;
+
+const jobsRequestKey = (req: api.JobsRequestMessage): string =>
+  jobsKey(req.status, req.type, req.limit);
+
+const jobsReducerObj = new KeyedCachedDataReducer(api.getJobs, "jobs", jobsRequestKey);
+export const refreshJobs = jobsReducerObj.refresh;
+
 export const queryToID = (req: api.QueryPlanRequestMessage): string => req.query;
 
 const queryPlanReducerObj = new CachedDataReducer(api.getQueryPlan, "queryPlan");
@@ -91,6 +101,7 @@ export interface APIReducersState {
   tableStats: KeyedCachedDataReducerState<api.TableStatsResponseMessage>;
   logs: CachedDataReducerState<api.LogEntriesResponseMessage>;
   liveness: CachedDataReducerState<api.LivenessResponseMessage>;
+  jobs: KeyedCachedDataReducerState<api.JobsResponseMessage>;
   queryPlan: CachedDataReducerState<api.QueryPlanResponseMessage>;
   problemRanges: CachedDataReducerState<api.ProblemRangesResponseMessage>;
   certificates: CachedDataReducerState<api.CertificatesResponseMessage>;
@@ -109,6 +120,7 @@ export default combineReducers<APIReducersState>({
   [tableStatsReducerObj.actionNamespace]: tableStatsReducerObj.reducer,
   [logsReducerObj.actionNamespace]: logsReducerObj.reducer,
   [livenessReducerObj.actionNamespace]: livenessReducerObj.reducer,
+  [jobsReducerObj.actionNamespace]: jobsReducerObj.reducer,
   [queryPlanReducerObj.actionNamespace]: queryPlanReducerObj.reducer,
   [problemRangesReducerObj.actionNamespace]: problemRangesReducerObj.reducer,
   [certificatesReducerObj.actionNamespace]: certificatesReducerObj.reducer,

--- a/pkg/ui/src/util/api.ts
+++ b/pkg/ui/src/util/api.ts
@@ -50,6 +50,9 @@ export type LogEntriesResponseMessage = protos.cockroach.server.serverpb.LogEntr
 export type LivenessRequestMessage = protos.cockroach.server.serverpb.LivenessRequest;
 export type LivenessResponseMessage = protos.cockroach.server.serverpb.LivenessResponse;
 
+export type JobsRequestMessage = protos.cockroach.server.serverpb.JobsRequest;
+export type JobsResponseMessage = protos.cockroach.server.serverpb.JobsResponse;
+
 export type QueryPlanRequestMessage = protos.cockroach.server.serverpb.QueryPlanRequest;
 export type QueryPlanResponseMessage = protos.cockroach.server.serverpb.QueryPlanResponse;
 
@@ -194,6 +197,10 @@ export function queryTimeSeries(req: TimeSeriesQueryRequestMessage, timeout?: mo
 // getHealth gets health data
 export function getHealth(_req: HealthRequestMessage, timeout?: moment.Duration): Promise<HealthResponseMessage> {
   return timeoutFetch(serverpb.HealthResponse, `${API_PREFIX}/health`, null, timeout);
+}
+
+export function getJobs(req: JobsRequestMessage, timeout?: moment.Duration): Promise<JobsResponseMessage> {
+  return timeoutFetch(serverpb.JobsResponse, `${API_PREFIX}/jobs?status=${req.status}&type=${req.type}&limit=${req.limit}`, null, timeout);
 }
 
 // getCluster gets info about the cluster

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -37,6 +37,7 @@ export default class extends React.Component<{}, {}> {
       <ul className="navigation-bar__list">
         <IconLink to="/cluster" icon={Icons.clusterIcon} title="Cluster" />
         <IconLink to="/databases" icon={Icons.databaseIcon} title="Databases"/>
+        <IconLink to="/jobs" icon={Icons.jobsIcon} title="Jobs"/>
       </ul>
       <ul className="navigation-bar__list navigation-bar__list--bottom">
         <IconLink to="/" icon={Icons.cockroachIcon} className="cockroach" />

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -36,7 +36,7 @@ export interface SimplifiedEvent {
 // Specialization of generic SortedTable component:
 //   https://github.com/Microsoft/TypeScript/issues/3960
 //
-// The variable name must start with a capital letter or TSX will not recognize
+// The variable name must start with a capital letter or JSX will not recognize
 // it as a component.
 // tslint:disable-next-line:variable-name
 const EventSortedTable = SortedTable as new () => SortedTable<SimplifiedEvent>;

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -28,7 +28,7 @@ const deadNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
 // Specialization of generic SortedTable component:
 //   https://github.com/Microsoft/TypeScript/issues/3960
 //
-// The variable name must start with a capital letter or TSX will not recognize
+// The variable name must start with a capital letter or JSX will not recognize
 // it as a component.
 // tslint:disable-next-line:variable-name
 const NodeSortedTable = SortedTable as new () => SortedTable<NodeStatus$Properties>;

--- a/pkg/ui/src/views/databases/containers/databaseGrants/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseGrants/index.tsx
@@ -20,7 +20,7 @@ import {
 // Specialization of generic SortedTable component:
 //   https://github.com/Microsoft/TypeScript/issues/3960
 //
-// The variable name must start with a capital letter or TSX will not recognize
+// The variable name must start with a capital letter or JSX will not recognize
 // it as a component.
 // tslint:disable-next-line:variable-name
 export const DatabaseGrantsSortedTable = SortedTable as new () => SortedTable<protos.cockroach.server.serverpb.DatabaseDetailsResponse.Grant>;

--- a/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
+++ b/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
@@ -20,7 +20,7 @@ import * as hljs from "highlight.js";
 // Specialization of generic SortedTable component:
 //   https://github.com/Microsoft/TypeScript/issues/3960
 //
-// The variable name must start with a capital letter or TSX will not recognize
+// The variable name must start with a capital letter or JSX will not recognize
 // it as a component.
 // tslint:disable-next-line:variable-name
 export const GrantsSortedTable = SortedTable as new () => SortedTable<protos.cockroach.server.serverpb.TableDetailsResponse.Grant$Properties>;

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -1,0 +1,248 @@
+import moment from "moment";
+import { Line } from "rc-progress";
+import React from "react";
+import { connect } from "react-redux";
+
+import * as protos from "src/js/protos";
+import { jobsKey, refreshJobs } from "src/redux/apiReducers";
+import { LocalSetting } from "src/redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+import { TimestampToMoment } from "src/util/convert";
+import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
+import { PageConfig, PageConfigItem } from "src/views/shared/components/pageconfig";
+import { SortSetting } from "src/views/shared/components/sortabletable";
+import { ColumnDescriptor, SortedTable } from "src/views/shared/components/sortedtable";
+
+type Job = protos.cockroach.server.serverpb.JobsResponse.Job;
+
+type JobType = protos.cockroach.sql.jobs.Type;
+const jobType = protos.cockroach.sql.jobs.Type;
+
+const JobsRequest = protos.cockroach.server.serverpb.JobsRequest;
+
+const statusOptions = [
+  { value: "", label: "All" },
+  { value: "pending", label: "Pending" },
+  { value: "running", label: "Running" },
+  { value: "succeeded", label: "Succeeded" },
+  { value: "failed", label: "Failed" },
+];
+
+const statusSetting = new LocalSetting<AdminUIState, string>(
+  "jobs/status_setting", s => s.localSettings, statusOptions[0].value,
+);
+
+const typeOptions = [
+  { value: jobType.UNSPECIFIED.toString(), label: "All" },
+  { value: jobType.BACKUP.toString(), label: "Backups" },
+  { value: jobType.RESTORE.toString(), label: "Restores" },
+  { value: jobType.SCHEMA_CHANGE.toString(), label: "Schema changes" },
+];
+
+const typeSetting = new LocalSetting<AdminUIState, number>(
+  "jobs/type_setting", s => s.localSettings, jobType.UNSPECIFIED,
+);
+
+const showOptions = [
+  { value: "50", label: "First 50" },
+  { value: "0", label: "All" },
+];
+
+const showSetting = new LocalSetting<AdminUIState, string>(
+  "jobs/show_setting", s => s.localSettings, showOptions[0].value,
+);
+
+// Moment cannot render durations (moment/moment#1048). Hack it ourselves.
+const formatDuration = (d: moment.Duration) =>
+  [d.asHours().toFixed(0), d.minutes(), d.seconds()]
+    .map(c => ("0" + c).slice(-2))
+    .join(":");
+
+class JobStatusCell extends React.Component<{job: Job}, {}> {
+  is(...statuses: string[]) {
+    return statuses.indexOf(this.props.job.status) !== -1;
+  }
+
+  renderProgress() {
+    if (this.is("succeeded", "failed")) {
+      return <span className="jobs-table__status">{this.props.job.status}</span>;
+    }
+    const percent = this.props.job.fraction_completed * 100;
+    return <div>
+      <Line percent={percent} strokeWidth={10} trailWidth={10} className="jobs-table__progress-bar" />
+      <span title={percent.toFixed(3) + "%"}>{percent.toFixed(1) + "%"}</span>
+    </div>;
+  }
+
+  renderDuration() {
+    const started = TimestampToMoment(this.props.job.started);
+    const finished = TimestampToMoment(this.props.job.finished);
+    const modified = TimestampToMoment(this.props.job.modified);
+    if (this.is("pending")) {
+      return "Pending";
+    } else if (this.is("running")) {
+      const remainingMillis = modified.diff(started) / this.props.job.fraction_completed;
+      return formatDuration(moment.duration(remainingMillis)) + " remaining";
+    } else if (this.is("succeeded")) {
+      return "Duration: " + formatDuration(moment.duration(finished.diff(started)));
+    }
+  }
+
+  render() {
+      return <div>
+        {this.renderProgress()}
+        <br />
+        <span className="jobs-table__duration">{this.renderDuration()}</span>
+      </div>;
+  }
+}
+
+// Specialization of generic SortedTable component:
+//   https://github.com/Microsoft/TypeScript/issues/3960
+//
+// The variable name must start with a capital letter or JSX will not recognize
+// it as a component.
+// tslint:disable-next-line:variable-name
+const JobsSortedTable = SortedTable as new () => SortedTable<Job>;
+
+const jobsTableColumns: ColumnDescriptor<Job>[] = [
+  {
+    title: "User",
+    cell: job => job.username,
+    sort: job => job.username,
+  },
+  {
+    title: "Description",
+    cell: job => job.description,
+    sort: job => job.description,
+    className: "jobs-table__cell--description",
+  },
+  {
+    title: "Creation Time",
+    cell: job => TimestampToMoment(job.created).fromNow(),
+    sort: job => TimestampToMoment(job.created).valueOf(),
+  },
+  {
+    title: "Status",
+    cell: job => <JobStatusCell job={job} />,
+    sort: job => job.fraction_completed,
+  },
+];
+
+const sortSetting = new LocalSetting<AdminUIState, SortSetting>(
+  "jobs/sort_setting",
+  s => s.localSettings,
+  { sortKey: 2 /* creation time */, ascending: false },
+);
+
+interface JobsTableProps {
+  sort: SortSetting;
+  status: string;
+  show: string;
+  type: number;
+  setSort: (value: SortSetting) => void;
+  setStatus: (value: string) => void;
+  setShow: (value: string) => void;
+  setType: (value: JobType) => void;
+  refreshJobs: typeof refreshJobs;
+  jobs: Job[];
+}
+
+class JobsTable extends React.Component<JobsTableProps, {}> {
+  static title() {
+    return "Jobs";
+  }
+
+  refresh(props = this.props) {
+    props.refreshJobs(new JobsRequest({
+      status: props.status,
+      type: props.type,
+      limit: parseInt(props.show, 10),
+    }));
+  }
+
+  componentWillMount() {
+    this.refresh();
+  }
+
+  componentWillReceiveProps(props: JobsTableProps) {
+    this.refresh(props);
+  }
+
+  onStatusSelected = (selected: DropdownOption) => {
+    this.props.setStatus(selected.value);
+  }
+
+  onTypeSelected = (selected: DropdownOption) => {
+    this.props.setType(parseInt(selected.value, 10));
+  }
+
+  onShowSelected = (selected: DropdownOption) => {
+    this.props.setShow(selected.value);
+  }
+
+  render() {
+    return <div>
+      <PageConfig>
+        <PageConfigItem>
+          <Dropdown
+            title="Status"
+            options={statusOptions}
+            selected={this.props.status}
+            onChange={this.onStatusSelected}
+          />
+        </PageConfigItem>
+        <PageConfigItem>
+          <Dropdown
+            title="Type"
+            options={typeOptions}
+            selected={this.props.type.toString()}
+            onChange={this.onTypeSelected}
+          />
+        </PageConfigItem>
+        <PageConfigItem>
+          <Dropdown
+            title="Show"
+            options={showOptions}
+            selected={this.props.show}
+            onChange={this.onShowSelected}
+          />
+        </PageConfigItem>
+      </PageConfig>
+      <section className="section">
+        <div className="content">
+          <JobsSortedTable
+            data={this.props.jobs && this.props.jobs.length > 0 && this.props.jobs}
+            sortSetting={this.props.sort}
+            onChangeSortSetting={this.props.setSort}
+            className="jobs-table"
+            rowClass={job => "jobs-table__row--" + job.status}
+            columns={jobsTableColumns}
+          />
+        </div>
+      </section>
+    </div>;
+  }
+}
+
+const mapStateToProps = (state: AdminUIState) => {
+  const sort = sortSetting.selector(state);
+  const status = statusSetting.selector(state);
+  const show = showSetting.selector(state);
+  const type = typeSetting.selector(state);
+  const key = jobsKey(status, type, parseInt(show, 10));
+  const jobs = state.cachedData.jobs[key];
+  return {
+    sort, status, show, type, jobs: jobs && jobs.data && jobs.data.jobs,
+  };
+};
+
+const actions = {
+  setSort: sortSetting.set,
+  setStatus: statusSetting.set,
+  setShow: showSetting.set,
+  setType: typeSetting.set,
+  refreshJobs,
+};
+
+export default connect(mapStateToProps, actions)(JobsTable);

--- a/pkg/ui/src/views/shared/components/icons/index.tsx
+++ b/pkg/ui/src/views/shared/components/icons/index.tsx
@@ -1,7 +1,4 @@
-// Exports the following icons as SVG strings:
-//
-// clusterIcon, cockroachIcon, databaseIcon, gearIcon
-// nodesIcon, storesIcon, usersIcon
+// Exports icons as SVG strings.
 
 export const clusterIcon: string = `<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
   <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
@@ -209,6 +206,15 @@ export const logsIcon: string = `<svg width="23px" height="24px" viewBox="0 0 23
         </g>
       </g>
     </g>
+  </g>
+</svg>`;
+
+export const jobsIcon: string = `<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 24 24" xml:space="preserve" width="24" height="24">
+  <g class="nc-icon-wrapper" fill="#959797">
+    <polyline data-color="color-2" fill="none" stroke="#959797" stroke-width="2" stroke-linecap="square" stroke-miterlimit="10" points=" 8,5 8,1 16,1 16,5 " stroke-linejoin="miter"></polyline>
+    <polyline fill="none" stroke="#959797" stroke-width="2" stroke-linecap="square" stroke-miterlimit="10" points="9,15 1,15 1,5 23,5 23,15 15,15 " stroke-linejoin="miter"></polyline>
+    <polyline fill="none" stroke="#959797" stroke-width="2" stroke-linecap="square" stroke-miterlimit="10" points="22,18 22,23 2,23 2,18 " stroke-linejoin="miter"></polyline>
+    <rect data-color="color-2" x="9" y="13" fill="none" stroke="#959797" stroke-width="2" stroke-linecap="square" stroke-miterlimit="10" width="6" height="4" stroke-linejoin="miter"></rect>
   </g>
 </svg>`;
 

--- a/pkg/ui/src/views/shared/components/sortabletable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortabletable/index.tsx
@@ -48,6 +48,10 @@ interface TableProps {
   // Callback that should be invoked when the user want to change the sort
   // setting.
   onChangeSortSetting?: { (ss: SortSetting): void };
+  // className to be applied to the table element.
+  className?: string;
+  // A function that returns the class to apply to a given row.
+  rowClass?: (rowIndex: number) => string;
 }
 
 /**
@@ -68,6 +72,7 @@ export class SortableTable extends React.Component<TableProps, {}> {
         ascending: false,
       },
       onChangeSortSetting: (_ss) => {},
+      rowClass: (_rowIndex) => "",
   };
 
   clickSort(clickedSortKey: any) {
@@ -94,7 +99,7 @@ export class SortableTable extends React.Component<TableProps, {}> {
   render() {
     const { sortSetting, columns } = this.props;
 
-    return <table className="sort-table">
+    return <table className={classNames("sort-table", this.props.className)}>
      <thead>
         <tr className="sort-table__row sort-table__row--header">
           {_.map(columns, (c: SortableColumn, colIndex: number) => {
@@ -120,7 +125,9 @@ export class SortableTable extends React.Component<TableProps, {}> {
       </thead>
       <tbody>
         {_.times(this.props.count, (rowIndex) => {
-          return <tr key={rowIndex} className="sort-table__row sort-table__row--body">
+          const classes = classNames("sort-table__row", "sort-table__row--body",
+            this.props.rowClass(rowIndex));
+          return <tr key={rowIndex} className={classes}>
             {
               _.map(columns, (c: SortableColumn, colIndex: number) => {
                 return <td className={classNames("sort-table__cell", c.className)} key={colIndex}>{c.cell(rowIndex)}</td>;

--- a/pkg/ui/src/views/shared/components/sortedtable/index.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/index.tsx
@@ -41,6 +41,10 @@ interface SortedTableProps<T> {
   // Callback that should be invoked when the user want to change the sort
   // setting.
   onChangeSortSetting?: { (ss: SortSetting): void };
+  // className to be applied to the table element.
+  className?: string;
+  // A function that returns the class to apply to a given row.
+  rowClass?: (obj: T) => string;
 }
 
 /**
@@ -55,6 +59,10 @@ interface SortedTableProps<T> {
  * all data rows to be displayed are available locally on the client side.
  */
 export class SortedTable<T> extends React.Component<SortedTableProps<T>, {}> {
+  static defaultProps: Partial<SortedTableProps<any>> = {
+    rowClass: (_obj: any) => "",
+  };
+
   rollups = createSelector(
     (props: SortedTableProps<T>) => props.data,
     (props: SortedTableProps<T>) => props.columns,
@@ -104,13 +112,23 @@ export class SortedTable<T> extends React.Component<SortedTableProps<T>, {}> {
       });
     });
 
+  rowClass = createSelector(
+    this.sorted,
+    (props: SortedTableProps<T>) => props.rowClass,
+    (sorted: T[], rowClass: (obj: T) => string) => {
+      return (index: number) => rowClass(sorted[index]);
+    },
+  );
+
   render() {
     const { data, sortSetting, onChangeSortSetting } = this.props;
     if (data) {
       return <SortableTable count={data.length}
                             sortSetting={sortSetting}
                             onChangeSortSetting={onChangeSortSetting}
-                            columns={this.columns(this.props)}/>;
+                            columns={this.columns(this.props)}
+                            rowClass={this.rowClass(this.props)}
+                            className={this.props.className} />;
     }
     return <div>No results.</div>;
   }

--- a/pkg/ui/src/views/shared/components/sortedtable/sortedtable.spec.tsx
+++ b/pkg/ui/src/views/shared/components/sortedtable/sortedtable.spec.tsx
@@ -28,7 +28,7 @@ const columns: ColumnDescriptor<TestRow>[] = [
 // Specialization of generic SortedTable component:
 //   https://github.com/Microsoft/TypeScript/issues/3960
 //
-// The variable name must start with a capital letter or TSX will not recognize
+// The variable name must start with a capital letter or JSX will not recognize
 // it as a component.
 // tslint:disable-next-line:variable-name
 const TestSortedTable = SortedTable as new () => SortedTable<TestRow>;

--- a/pkg/ui/styl/app.styl
+++ b/pkg/ui/styl/app.styl
@@ -28,6 +28,7 @@ permissions and limitations under the License.
 
 @require 'pages/cluster.styl'
 @require 'pages/databases.styl'
+@require 'pages/jobs.styl'
 @require 'pages/nodes.styl'
 @require 'pages/queryplan.styl'
 @require 'pages/reports.styl'

--- a/pkg/ui/styl/layout/navigation-bar.styl
+++ b/pkg/ui/styl/layout/navigation-bar.styl
@@ -61,12 +61,16 @@ $subnav-underline-height = 3px
     &.normal
       path
         fill $body-color
+      polyline, rect
+        stroke $body-color
 
       &.active, &.active:hover, &:hover
         color $link-color
 
         path
           fill $link-color
+        polyline, rect
+          stroke $link-color
 
     &.cockroach
       padding-top 10px

--- a/pkg/ui/styl/pages/jobs.styl
+++ b/pkg/ui/styl/pages/jobs.styl
@@ -1,0 +1,30 @@
+.jobs-table
+  &__row
+    &--succeeded td
+      color lighten($body-color, 25%)
+
+    &--failed
+      & + &  // Match two adjacent failed rows.
+        border-top 1px solid $table-border-color
+
+      td
+        background-color lighten($notification-alert-fill-color, 75%)
+
+      .jobs-table__status
+        color $alert-color
+
+  &__cell--description
+    font-family Inconsolata-Regular
+    max-width 500px
+    white-space normal
+    word-wrap break-word
+
+  &__progress-bar
+    padding-right .7em
+    width 120px
+
+  &__duration
+    font-style italic
+
+  &__status
+    text-transform capitalize

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -915,7 +915,7 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
@@ -4654,6 +4654,13 @@ raw-body@~2.2.0:
     bytes "2.4.0"
     iconv-lite "0.4.15"
     unpipe "1.0.0"
+
+rc-progress@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/rc-progress/-/rc-progress-2.2.1.tgz#3fdefb16bf94f43c187cdbbdeb9fc5010b367ef9"
+  dependencies:
+    babel-runtime "^6.23.0"
+    prop-types "^15.5.8"
 
 rc@^1.1.7:
   version "1.2.1"


### PR DESCRIPTION
Add a new page to the admin UI that provides a graphical, interactive
interface to `SHOW JOBS`.

![screenshot 2017-08-02 18 36 35](https://user-images.githubusercontent.com/882976/28898043-9cf373ee-77b1-11e7-890b-e87c91a75688.png)

Closes #13604.