### PR TITLE
rsg: unwrap type for GenerateRandomArg

### DIFF
--- a/pkg/internal/rsg/rsg.go
+++ b/pkg/internal/rsg/rsg.go
@@ -210,7 +210,7 @@ func (r *RSG) Float64() float64 {
 }
 
 // GenerateRandomArg generates a random, valid, SQL function argument of
-// the spcified type.
+// the specified type.
 func (r *RSG) GenerateRandomArg(typ parser.Type) string {
 	if r.Intn(10) == 0 {
 		return "NULL"
@@ -252,7 +252,7 @@ func (r *RSG) GenerateRandomArg(typ parser.Type) string {
 		v = "NULL"
 	default:
 		// Check types that can't be compared using equality
-		switch typ.(type) {
+		switch parser.UnwrapType(typ).(type) {
 		case parser.TTuple,
 			parser.TArray:
 			v = "NULL"


### PR DESCRIPTION
The tests failed with this error:
```
panic: unknown arg type: int[] (parser.tOidWrapper)

goroutine 8407589 [running]:
github.com/cockroachdb/cockroach/pkg/internal/rsg.(*RSG).GenerateRandomArg(0xc432806390,
0x2798e00, 0xc42030f600, 0xc4235a3801, 0xc4312a8180)
```

I haven't been able to reproduce this locally, but I think this should
fix it in the short term. In the longer term I'll add an actual
generator for arrays.