### PR TITLE
distsql: add disk usage accounting for external storage

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -69,7 +69,7 @@ var errAdminAPIError = grpc.Errorf(codes.Internal, "An internal server error "+
 // the cockroach cluster.
 type adminServer struct {
 	server     *Server
-	memMonitor mon.MemoryMonitor
+	memMonitor mon.BytesMonitor
 	memMetrics *sql.MemoryMetrics
 }
 
@@ -85,7 +85,12 @@ func newAdminServer(s *Server) *adminServer {
 	// TODO(knz): We do not limit memory usage by admin operations
 	// yet. Is this wise?
 	server.memMonitor = mon.MakeUnlimitedMonitor(
-		context.Background(), "admin", nil, nil, noteworthyAdminMemoryUsageBytes,
+		context.Background(),
+		"admin",
+		mon.MemoryResource,
+		nil,
+		nil,
+		noteworthyAdminMemoryUsageBytes,
 	)
 	return server
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -272,6 +272,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// this monitor will be setting their own noteworthy limits.
 	rootSQLMemoryMonitor := mon.MakeMonitor(
 		"root",
+		mon.MemoryResource,
 		nil,           /* curCount */
 		nil,           /* maxHist */
 		-1,            /* increment: use default increment */

--- a/pkg/sql/distsqlrun/disk_row_container.go
+++ b/pkg/sql/distsqlrun/disk_row_container.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -30,6 +31,8 @@ import (
 // created through NewIterator() to read the rows in sorted order.
 type diskRowContainer struct {
 	diskMap engine.SortedDiskMap
+	// diskAcc keeps track of disk usage.
+	diskAcc mon.BoundAccount
 	// bufferedRows buffers writes to the diskMap.
 	bufferedRows  engine.SortedDiskMapBatchWriter
 	scratchKey    []byte
@@ -62,6 +65,7 @@ var _ sortableRowContainer = &diskRowContainer{}
 // rowContainer and deletes them so rowContainer cannot be used after creating
 // a diskRowContainer. The caller must still Close() the rowContainer.
 // Arguments:
+// 	- diskMonitor is used to monitor this diskRowContainer's disk usage.
 // 	- types is the schema of rows that will be added to this container.
 // 	- ordering is the output ordering; the order in which rows should be sorted.
 // 	- rowContainer contains the initial set of rows that this diskRowContainer
@@ -69,6 +73,7 @@ var _ sortableRowContainer = &diskRowContainer{}
 // 	- e is the underlying store that rows are stored on.
 func makeDiskRowContainer(
 	ctx context.Context,
+	diskMonitor *mon.BytesMonitor,
 	types []sqlbase.ColumnType,
 	ordering sqlbase.ColumnOrdering,
 	rowContainer *memRowContainer,
@@ -77,6 +82,7 @@ func makeDiskRowContainer(
 	diskMap := engine.NewRocksDBMap(e)
 	d := diskRowContainer{
 		diskMap:       diskMap,
+		diskAcc:       diskMonitor.MakeBoundAccount(),
 		types:         types,
 		ordering:      ordering,
 		scratchEncRow: make(sqlbase.EncDatumRow, len(types)),
@@ -154,10 +160,11 @@ func (d *diskRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) 
 
 	// Put a unique row to keep track of duplicates. Note that this will not
 	// mess with key decoding.
-	if err := d.bufferedRows.Put(
-		encoding.EncodeUvarintAscending(d.scratchKey, d.rowID),
-		d.scratchVal,
-	); err != nil {
+	d.scratchKey = encoding.EncodeUvarintAscending(d.scratchKey, d.rowID)
+	if err := d.diskAcc.Grow(ctx, int64(len(d.scratchKey)+len(d.scratchVal))); err != nil {
+		return err
+	}
+	if err := d.bufferedRows.Put(d.scratchKey, d.scratchVal); err != nil {
 		return err
 	}
 	d.scratchKey = d.scratchKey[:0]
@@ -175,6 +182,7 @@ func (d *diskRowContainer) Close(ctx context.Context) {
 	// in the following Close.
 	_ = d.bufferedRows.Close(ctx)
 	d.diskMap.Close(ctx)
+	d.diskAcc.Close(ctx)
 }
 
 // keyValToRow decodes a key and a value byte slice stored with AddRow() into

--- a/pkg/sql/distsqlrun/disk_row_container_test.go
+++ b/pkg/sql/distsqlrun/disk_row_container_test.go
@@ -15,13 +15,16 @@
 package distsqlrun
 
 import (
+	math "math"
 	"math/rand"
 	"testing"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -98,6 +101,16 @@ func TestDiskRowContainer(t *testing.T) {
 	rng := rand.New(rand.NewSource(int64(timeutil.Now().UnixNano())))
 
 	evalCtx := parser.MakeTestingEvalContext()
+	diskMonitor := mon.MakeMonitor(
+		"test-disk",
+		mon.DiskResource,
+		nil, /* curCount */
+		nil, /* maxHist */
+		-1,  /* increment: use default block size */
+		math.MaxInt64,
+	)
+	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	defer diskMonitor.Stop(ctx)
 	t.Run("EncodeDecode", func(t *testing.T) {
 		for i := 0; i < 100; i++ {
 			// Test with different orderings so that we have a mix of key and
@@ -110,7 +123,7 @@ func TestDiskRowContainer(t *testing.T) {
 				row := sqlbase.RandEncDatumRowOfTypes(rng, types)
 				func() {
 					d, err := makeDiskRowContainer(
-						ctx, types, ordering, &memRowContainer{}, tempEngine,
+						ctx, &diskMonitor, types, ordering, &memRowContainer{}, tempEngine,
 					)
 					if err != nil {
 						t.Fatal(err)
@@ -181,6 +194,7 @@ func TestDiskRowContainer(t *testing.T) {
 
 				d, err := makeDiskRowContainer(
 					ctx,
+					&diskMonitor,
 					types,
 					ordering,
 					&memoryContainer,
@@ -251,4 +265,46 @@ func TestDiskRowContainer(t *testing.T) {
 			}()
 		}
 	})
+}
+
+func TestDiskRowContainerDiskFull(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tempEngine, err := engine.NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tempEngine.Close()
+
+	// Make a monitor with no capacity.
+	monitor := mon.MakeMonitor(
+		"test-disk",
+		mon.DiskResource,
+		nil, /* curCount */
+		nil, /* maxHist */
+		-1,  /* increment: use default block size */
+		math.MaxInt64,
+	)
+	monitor.Start(ctx, nil, mon.MakeStandaloneBudget(0 /* capacity */))
+
+	columnTypeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
+	d, err := makeDiskRowContainer(
+		ctx,
+		&monitor,
+		[]sqlbase.ColumnType{columnTypeInt},
+		sqlbase.ColumnOrdering{sqlbase.ColumnOrderInfo{ColIdx: 0, Direction: encoding.Ascending}},
+		&memRowContainer{},
+		tempEngine,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close(ctx)
+
+	row := sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(columnTypeInt, parser.NewDInt(parser.DInt(1)))}
+	err = d.AddRow(ctx, row)
+	if pgErr, ok := err.(*pgerror.Error); !(ok && pgErr.Code == pgerror.CodeDiskFullError) {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -74,6 +75,8 @@ type FlowCtx struct {
 	// tempStorage is used by some DistSQL processors to store Rows when the
 	// working set is larger than can be stored in memory.
 	tempStorage engine.Engine
+	// diskMonitor is used to monitor temporary storage disk usage.
+	diskMonitor *mon.BytesMonitor
 
 	// JobRegistry is used during backfill to load jobs which keep state.
 	JobRegistry *jobs.Registry

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -92,7 +92,7 @@ type ServerConfig struct {
 	Stopper      *stop.Stopper
 	TestingKnobs TestingKnobs
 
-	ParentMemoryMonitor *mon.MemoryMonitor
+	ParentMemoryMonitor *mon.BytesMonitor
 
 	// TempStorage is used by some DistSQL processors to store rows when the
 	// working set is larger than can be stored in memory. It can be nil, if this
@@ -114,7 +114,7 @@ type ServerImpl struct {
 	ServerConfig
 	flowRegistry  *flowRegistry
 	flowScheduler *flowScheduler
-	memMonitor    mon.MemoryMonitor
+	memMonitor    mon.BytesMonitor
 	regexpCache   *parser.RegexpCache
 	// tempStorage is used by some DistSQL processors to store working sets
 	// larger than memory. It can be nil, in which case processors should still
@@ -131,8 +131,14 @@ func NewServer(ctx context.Context, cfg ServerConfig) *ServerImpl {
 		regexpCache:   parser.NewRegexpCache(512),
 		flowRegistry:  makeFlowRegistry(),
 		flowScheduler: newFlowScheduler(cfg.AmbientContext, cfg.Stopper, cfg.Metrics),
-		memMonitor: mon.MakeMonitor("distsql",
-			cfg.Metrics.CurBytesCount, cfg.Metrics.MaxBytesHist, -1 /* increment: use default block size */, noteworthyMemoryUsageBytes),
+		memMonitor: mon.MakeMonitor(
+			"distsql",
+			mon.MemoryResource,
+			cfg.Metrics.CurBytesCount,
+			cfg.Metrics.MaxBytesHist,
+			-1, /* increment: use default block size */
+			noteworthyMemoryUsageBytes,
+		),
 		tempStorage: cfg.TempStorage,
 	}
 	ds.memMonitor.Start(ctx, cfg.ParentMemoryMonitor, mon.BoundAccount{})
@@ -177,8 +183,14 @@ func (ds *ServerImpl) setupFlow(
 	ctx = opentracing.ContextWithSpan(ctx, sp)
 
 	// The monitor and account opened here are closed in Flow.Cleanup().
-	monitor := mon.MakeMonitor("flow",
-		ds.Metrics.CurBytesCount, ds.Metrics.MaxBytesHist, -1 /* use default block size */, noteworthyMemoryUsageBytes)
+	monitor := mon.MakeMonitor(
+		"flow",
+		mon.MemoryResource,
+		ds.Metrics.CurBytesCount,
+		ds.Metrics.MaxBytesHist,
+		-1, /* use default block size */
+		noteworthyMemoryUsageBytes,
+	)
 	monitor.Start(ctx, &ds.memMonitor, mon.BoundAccount{})
 	acc := monitor.MakeBoundAccount()
 

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -16,10 +16,12 @@ package distsqlrun
 
 import (
 	"fmt"
+	math "math"
 	"math/rand"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -183,6 +185,24 @@ func TestSorter(t *testing.T) {
 	}
 	defer tempEngine.Close()
 
+	evalCtx := parser.MakeTestingEvalContext()
+	defer evalCtx.Stop(ctx)
+	diskMonitor := mon.MakeMonitor(
+		"test-disk",
+		mon.DiskResource,
+		nil, /* curCount */
+		nil, /* maxHist */
+		-1,  /* increment: use default block size */
+		math.MaxInt64,
+	)
+	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
+	defer diskMonitor.Stop(ctx)
+	flowCtx := FlowCtx{
+		evalCtx:     evalCtx,
+		tempStorage: tempEngine,
+		diskMonitor: &diskMonitor,
+	}
+
 	for _, c := range testCases {
 		// Test with several memory limits:
 		// 0: Use the default limit.
@@ -200,12 +220,6 @@ func TestSorter(t *testing.T) {
 				}
 				in := NewRowBuffer(types, c.input, RowBufferArgs{})
 				out := &RowBuffer{}
-				evalCtx := parser.MakeTestingEvalContext()
-				defer evalCtx.Stop(ctx)
-				flowCtx := FlowCtx{
-					evalCtx:     evalCtx,
-					tempStorage: tempEngine,
-				}
 
 				s, err := newSorter(&flowCtx, &c.spec, in, &c.post, out)
 				if err != nil {

--- a/pkg/sql/distsqlrun/sorterstrategy.go
+++ b/pkg/sql/distsqlrun/sorterstrategy.go
@@ -77,7 +77,7 @@ func (ss *sortAllStrategy) Execute(ctx context.Context, s *sorter) error {
 	// The diskContainer will free the memory taken up by ss.rows as it is
 	// created from them.
 	diskContainer, err := makeDiskRowContainer(
-		ctx, ss.rows.types, ss.rows.ordering, ss.rows, s.tempStorage,
+		ctx, s.flowCtx.diskMonitor, ss.rows.types, ss.rows.ordering, ss.rows, s.tempStorage,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/mon/bytes_usage_test.go
+++ b/pkg/sql/mon/bytes_usage_test.go
@@ -43,10 +43,10 @@ func TestMemoryAllocations(t *testing.T) {
 	t.Logf("random seed: %v", seed)
 
 	ctx := context.Background()
-	accs := make([]MemoryAccount, 4)
+	accs := make([]BytesAccount, 4)
 
-	var pool MemoryMonitor
-	var m MemoryMonitor
+	var pool BytesMonitor
+	var m BytesMonitor
 	var paramHeader func()
 
 	// The following invariants will be checked at every step of the
@@ -131,11 +131,11 @@ func TestMemoryAllocations(t *testing.T) {
 	}
 
 	for _, max := range maxs {
-		pool = MakeMonitor("test", nil, nil, 1, 1000)
+		pool = MakeMonitor("test", MemoryResource, nil, nil, 1, 1000)
 		pool.Start(ctx, nil, MakeStandaloneBudget(max))
 
 		for _, hf := range hysteresisFactors {
-			maxAllocatedButUnusedMemoryBlocks = hf
+			maxAllocatedButUnusedBlocks = hf
 
 			for _, pb := range preBudgets {
 				mmax := pb + max
@@ -145,7 +145,7 @@ func TestMemoryAllocations(t *testing.T) {
 
 					// We start with a fresh monitor for every set of
 					// parameters.
-					m = MakeMonitor("test", nil, nil, pa, 1000)
+					m = MakeMonitor("test", MemoryResource, nil, nil, pa, 1000)
 					m.Start(ctx, &pool, MakeStandaloneBudget(pb))
 
 					for i := 0; i < numAccountOps; i++ {
@@ -205,16 +205,16 @@ func TestMemoryAllocations(t *testing.T) {
 	}
 }
 
-func TestMemoryAccount(t *testing.T) {
+func TestBytesAccount(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	m := MakeMonitor("test", nil, nil, 1, 1000)
+	m := MakeMonitor("test", MemoryResource, nil, nil, 1, 1000)
 	m.Start(ctx, nil, MakeStandaloneBudget(100))
 	m.poolAllocationSize = 1
-	maxAllocatedButUnusedMemoryBlocks = 1
+	maxAllocatedButUnusedBlocks = 1
 
-	var a1, a2 MemoryAccount
+	var a1, a2 BytesAccount
 
 	m.OpenAccount(&a1)
 	m.OpenAccount(&a2)
@@ -263,28 +263,28 @@ func TestMemoryAccount(t *testing.T) {
 	m.Stop(ctx)
 }
 
-func TestMemoryMonitor(t *testing.T) {
+func TestBytesMonitor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	m := MakeMonitor("test", nil, nil, 1, 1000)
+	m := MakeMonitor("test", MemoryResource, nil, nil, 1, 1000)
 	m.Start(ctx, nil, MakeStandaloneBudget(100))
-	maxAllocatedButUnusedMemoryBlocks = 1
+	maxAllocatedButUnusedBlocks = 1
 
-	if err := m.reserveMemory(ctx, 10); err != nil {
+	if err := m.reserveBytes(ctx, 10); err != nil {
 		t.Fatalf("monitor refused small allocation: %v", err)
 	}
-	if err := m.reserveMemory(ctx, 91); err == nil {
+	if err := m.reserveBytes(ctx, 91); err == nil {
 		t.Fatalf("monitor accepted excessive allocation: %v", err)
 	}
-	if err := m.reserveMemory(ctx, 90); err != nil {
+	if err := m.reserveBytes(ctx, 90); err != nil {
 		t.Fatalf("monitor refused top allocation: %v", err)
 	}
 	if m.mu.curAllocated != 100 {
 		t.Fatalf("incorrect current allocation: got %d, expected %d", m.mu.curAllocated, 100)
 	}
 
-	m.releaseMemory(ctx, 90) // Should succeed without panic.
+	m.releaseBytes(ctx, 90) // Should succeed without panic.
 	if m.mu.curAllocated != 10 {
 		t.Fatalf("incorrect current allocation: got %d, expected %d", m.mu.curAllocated, 10)
 	}
@@ -292,21 +292,21 @@ func TestMemoryMonitor(t *testing.T) {
 		t.Fatalf("incorrect max allocation: got %d, expected %d", m.mu.maxAllocated, 100)
 	}
 
-	m.releaseMemory(ctx, 10) // Should succeed without panic.
+	m.releaseBytes(ctx, 10) // Should succeed without panic.
 	if m.mu.curAllocated != 0 {
 		t.Fatalf("incorrect current allocation: got %d, expected %d", m.mu.curAllocated, 0)
 	}
 
-	limitedMonitor := MakeMonitorWithLimit("testlimit", 10, nil, nil, 1, 1000)
+	limitedMonitor := MakeMonitorWithLimit("testlimit", MemoryResource, 10, nil, nil, 1, 1000)
 	limitedMonitor.Start(ctx, &m, BoundAccount{})
 
-	if err := limitedMonitor.reserveMemory(ctx, 10); err != nil {
+	if err := limitedMonitor.reserveBytes(ctx, 10); err != nil {
 		t.Fatalf("limited monitor refused small allocation: %v", err)
 	}
-	if err := limitedMonitor.reserveMemory(ctx, 1); err == nil {
+	if err := limitedMonitor.reserveBytes(ctx, 1); err == nil {
 		t.Fatal("limited monitor allowed allocation over limit")
 	}
-	limitedMonitor.releaseMemory(ctx, 10)
+	limitedMonitor.releaseBytes(ctx, 10)
 
 	limitedMonitor.Stop(ctx)
 	m.Stop(ctx)

--- a/pkg/sql/mon/resource.go
+++ b/pkg/sql/mon/resource.go
@@ -1,0 +1,57 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package mon
+
+import "github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+
+// Resource is an interface used to abstract the specifics of tracking bytes
+// usage by different types of resources.
+type Resource interface {
+	NewBudgetExceededError(requestedBytes int64, budgetBytes int64) error
+}
+
+// memoryResource is a Resource that represents memory.
+type memoryResource struct{}
+
+// MemoryResource is a utility singleton used as an argument when creating a
+// BytesMonitor to indicate that the monitor will be tracking memory usage.
+var MemoryResource Resource = memoryResource{}
+
+// NewBudgetExceededError implements the Resource interface.
+func (m memoryResource) NewBudgetExceededError(requestedBytes int64, budgetBytes int64) error {
+	return pgerror.NewErrorf(
+		pgerror.CodeOutOfMemoryError,
+		"memory budget exceeded: %d bytes requested, %d bytes in budget",
+		requestedBytes,
+		budgetBytes,
+	)
+}
+
+// diskResource is a Resource that represents disk.
+type diskResource struct{}
+
+// DiskResource is a utility singleton used as an argument when creating a
+// BytesMonitor to indicate that the monitor will be tracking disk usage.
+var DiskResource Resource = diskResource{}
+
+// NewBudgetExceededError implements the Resource interface.
+func (d diskResource) NewBudgetExceededError(requestedBytes int64, budgetBytes int64) error {
+	return pgerror.NewErrorf(
+		pgerror.CodeDiskFullError,
+		"disk budget exceeded: %d bytes requested, %d bytes in budget",
+		requestedBytes,
+		budgetBytes,
+	)
+}

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1871,7 +1871,7 @@ type EvalContext struct {
 
 	collationEnv CollationEnvironment
 
-	Mon *mon.MemoryMonitor
+	Mon *mon.BytesMonitor
 
 	// ActiveMemAcc is the account to which values are allocated during
 	// evaluation. It can change over the course of evaluation, such as on a
@@ -1884,6 +1884,7 @@ func MakeTestingEvalContext() EvalContext {
 	ctx := EvalContext{}
 	monitor := mon.MakeMonitor(
 		"test-monitor",
+		mon.MemoryResource,
 		nil,           /* curCount */
 		nil,           /* maxHist */
 		-1,            /* increment */

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -186,11 +186,11 @@ type v3Conn struct {
 
 	metrics *ServerMetrics
 
-	sqlMemoryPool *mon.MemoryMonitor
+	sqlMemoryPool *mon.BytesMonitor
 }
 
 func makeV3Conn(
-	conn net.Conn, metrics *ServerMetrics, sqlMemoryPool *mon.MemoryMonitor, executor *sql.Executor,
+	conn net.Conn, metrics *ServerMetrics, sqlMemoryPool *mon.BytesMonitor, executor *sql.Executor,
 ) v3Conn {
 	return v3Conn{
 		conn:          conn,

--- a/pkg/sql/pgwire/v3_test.go
+++ b/pkg/sql/pgwire/v3_test.go
@@ -35,7 +35,9 @@ import (
 
 func makeTestV3Conn(c net.Conn) v3Conn {
 	metrics := makeServerMetrics(nil, metric.TestSampleInterval)
-	mon := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, 1000)
+	mon := mon.MakeUnlimitedMonitor(
+		context.Background(), "test", mon.MemoryResource, nil, nil, 1000,
+	)
 	exec := sql.NewExecutor(
 		sql.ExecutorConfig{
 			AmbientCtx:              log.AmbientContext{Tracer: tracing.NewTracer()},

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -127,16 +127,19 @@ func makeInternalPlanner(
 
 	s.mon = mon.MakeUnlimitedMonitor(ctx,
 		"internal-root",
+		mon.MemoryResource,
 		memMetrics.CurBytesCount, memMetrics.MaxBytesHist,
 		noteworthyInternalMemoryUsageBytes)
 
 	s.sessionMon = mon.MakeMonitor("internal-session",
+		mon.MemoryResource,
 		memMetrics.SessionCurBytesCount,
 		memMetrics.SessionMaxBytesHist,
 		-1, noteworthyInternalMemoryUsageBytes/5)
 	s.sessionMon.Start(ctx, &s.mon, mon.BoundAccount{})
 
 	s.TxnState.mon = mon.MakeMonitor("internal-txn",
+		mon.MemoryResource,
 		memMetrics.TxnCurBytesCount,
 		memMetrics.TxnMaxBytesHist,
 		-1, noteworthyInternalMemoryUsageBytes/5)

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -320,8 +320,8 @@ type Session struct {
 	// is typically caused by transactions, not sessions. The reason why
 	// sessionMon and mon are split is to enable separate reporting of
 	// statistics for result sets (which escape transactions).
-	mon        mon.MemoryMonitor
-	sessionMon mon.MemoryMonitor
+	mon        mon.BytesMonitor
+	sessionMon mon.BytesMonitor
 	// emergencyShutdown is set to true by EmergencyClose() to
 	// indicate to Finish() that the session is already closed.
 	emergencyShutdown bool
@@ -506,7 +506,7 @@ func (s *Session) Finish(e *Executor) {
 		return
 	}
 
-	if s.mon == (mon.MemoryMonitor{}) {
+	if s.mon == (mon.BytesMonitor{}) {
 		// This check won't catch the cases where Finish is never called, but it's
 		// proven to be easier to remember to call Finish than it is to call
 		// StartMonitor.
@@ -878,7 +878,7 @@ type txnState struct {
 	// planNode in the midst of performing a computation. We
 	// host this here instead of TxnState because TxnState is
 	// fully reset upon each call to resetForNewSQLTxn().
-	mon mon.MemoryMonitor
+	mon mon.BytesMonitor
 }
 
 // State returns the current state of the session.

--- a/pkg/sql/session_mem_usage.go
+++ b/pkg/sql/session_mem_usage.go
@@ -40,7 +40,7 @@ func (ts *txnState) OpenAccount() WrappableMemoryAccount {
 // WrappableMemoryAccount encapsulates a MemoryAccount to
 // give it the Wsession()/Wtxn() method below.
 type WrappableMemoryAccount struct {
-	acc mon.MemoryAccount
+	acc mon.BytesAccount
 }
 
 // Wsession captures the current session monitor pointer so it can be provided
@@ -64,8 +64,8 @@ func (w *WrappableMemoryAccount) Wtxn(s *Session) WrappedMemoryAccount {
 // WrappedMemoryAccount is the transient structure that carries
 // the extra argument to the MemoryAccount APIs.
 type WrappedMemoryAccount struct {
-	acc *mon.MemoryAccount
-	mon *mon.MemoryMonitor
+	acc *mon.BytesAccount
+	mon *mon.BytesMonitor
 }
 
 // OpenAndInit interfaces between Session and mon.MemoryMonitor.
@@ -99,7 +99,7 @@ func (w WrappedMemoryAccount) ResizeItem(ctx context.Context, oldSize, newSize i
 var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_SESSION_MEMORY_USAGE", 1024*1024)
 
 // StartMonitor interfaces between Session and mon.MemoryMonitor
-func (s *Session) StartMonitor(pool *mon.MemoryMonitor, reserved mon.BoundAccount) {
+func (s *Session) StartMonitor(pool *mon.BytesMonitor, reserved mon.BoundAccount) {
 	// Note: we pass `reserved` to s.mon where it causes `s.mon` to act
 	// as a buffer. This is not done for sessionMon nor TxnState.mon:
 	// these monitors don't start with any buffer, so they'll need to
@@ -107,6 +107,7 @@ func (s *Session) StartMonitor(pool *mon.MemoryMonitor, reserved mon.BoundAccoun
 	// allocation. This is acceptable because the session is single
 	// threaded, and the point of buffering is just to avoid contention.
 	s.mon = mon.MakeMonitor("root",
+		mon.MemoryResource,
 		s.memMetrics.CurBytesCount,
 		s.memMetrics.MaxBytesHist,
 		-1, math.MaxInt64)
@@ -118,6 +119,7 @@ func (s *Session) StartMonitor(pool *mon.MemoryMonitor, reserved mon.BoundAccoun
 func (s *Session) StartUnlimitedMonitor() {
 	s.mon = mon.MakeUnlimitedMonitor(s.context,
 		"root",
+		mon.MemoryResource,
 		s.memMetrics.CurBytesCount,
 		s.memMetrics.MaxBytesHist,
 		math.MaxInt64,
@@ -127,6 +129,7 @@ func (s *Session) StartUnlimitedMonitor() {
 
 func (s *Session) deriveAndStartMonitors() {
 	s.sessionMon = mon.MakeMonitor("session",
+		mon.MemoryResource,
 		s.memMetrics.SessionCurBytesCount,
 		s.memMetrics.SessionMaxBytesHist,
 		-1, noteworthyMemoryUsageBytes)
@@ -135,6 +138,7 @@ func (s *Session) deriveAndStartMonitors() {
 	// We merely prepare the txn monitor here. It is fully started in
 	// resetForNewSQLTxn().
 	s.TxnState.mon = mon.MakeMonitor("txn",
+		mon.MemoryResource,
 		s.memMetrics.TxnCurBytesCount,
 		s.memMetrics.TxnMaxBytesHist,
 		-1, noteworthyMemoryUsageBytes)

--- a/pkg/sql/sqlbase/row_container_test.go
+++ b/pkg/sql/sqlbase/row_container_test.go
@@ -35,7 +35,9 @@ func TestRowContainer(t *testing.T) {
 				for i := range resCol {
 					resCol[i] = ResultColumn{Typ: parser.TypeInt}
 				}
-				m := mon.MakeUnlimitedMonitor(context.Background(), "test", nil, nil, math.MaxInt64)
+				m := mon.MakeUnlimitedMonitor(
+					context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64,
+				)
 				rc := NewRowContainer(m.MakeBoundAccount(), ColTypeInfoFromResCols(resCol), 0)
 				row := make(parser.Datums, numCols)
 				for i := 0; i < numRows; i++ {

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -225,7 +225,7 @@ type tableUpserter struct {
 	conflictIndex sqlbase.IndexDescriptor
 	isUpsertAlias bool
 	alloc         *sqlbase.DatumAlloc
-	mon           *mon.MemoryMonitor
+	mon           *mon.BytesMonitor
 	collectRows   bool
 
 	// These are set for ON CONFLICT DO UPDATE, but not for DO NOTHING


### PR DESCRIPTION
Add an additional monitor to the distsql server which is plumbed down to the diskRowContainer to track and limit disk usage.

This is basically what's needed to limit the disk usage of processors spilling over to disk. I'm uncomfortable with `pkg/sql/mon` being so memory specific in name. Should that be changed before this PR goes in?

cc @petermattis 