### PR TITLE
sql: ensure that planNodes are Close()d on error after expansion

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/planning_errors
+++ b/pkg/sql/logictest/testdata/logic_test/planning_errors
@@ -1,0 +1,10 @@
+# Check that plans that fail during expansion/optimization do not cause
+# memory leaks. #17274
+
+statement error index "aa" is not covering
+CREATE TABLE kv(k INT, v INT);
+ CREATE INDEX aa ON kv(v);
+ SELECT k FROM [SHOW JOBS], kv@{FORCE_INDEX=aa,NO_INDEX_JOIN};
+
+statement error relation "nonexistent" does not exist
+SELECT * FROM [SHOW JOBS], [SHOW CREATE TABLE nonexistent];

--- a/pkg/sql/optimize.go
+++ b/pkg/sql/optimize.go
@@ -26,6 +26,10 @@ import (
 // includes calling expandPlan(). The SQL "prepare" phase, as well as
 // the EXPLAIN statement, should merely build the plan node(s) and
 // call optimizePlan(). This is called automatically by makePlan().
+//
+// The plan returned by optimizePlan *must* be Close()d, even in case
+// of error, because it may contain memory-registered data structures
+// and other things that need clean up.
 func (p *planner) optimizePlan(
 	ctx context.Context, plan planNode, needed []bool,
 ) (planNode, error) {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -202,6 +202,9 @@ func (p *planner) makePlan(ctx context.Context, stmt Statement) (planNode, error
 	needed := allColumns(plan)
 	plan, err = p.optimizePlan(ctx, plan, needed)
 	if err != nil {
+		// Once the plan has undergone optimization, it may contain
+		// monitor-registered memory, even in case of error.
+		plan.Close(ctx)
 		return nil, err
 	}
 


### PR DESCRIPTION
Prior to this patch, if plan expansion would fail (e.g. due to an
expansion-time error like a column requested from a non-covering
index), the plan would be abandoned without being `Close()`d. However,
if the error would occur after some vtable was successfully expanded,
or some other `delayedNode` action causing some Closable state to
appear in the planNode, the abandonment was really a resource leak,
and detected as such with a panic.

This patch addresses the issue by ensuring `Close()` is invoked, even
upon error during plan expansion.

Fixes #17274.