### PR TITLE
sql: un-break view descriptors by being more conservative about dependencies

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -975,9 +975,12 @@ func TestBackupRestoreCrossTableReferences(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// columns not depended on by the view are unaffected.
-		db.Exec(`ALTER TABLE store.customers DROP COLUMN email`)
-		db.CheckQueryResults(`SELECT * FROM store.early_customers`, origEarlyCustomers)
+		// We want to be able to drop columns not used by the view,
+		// however the detection thereof is currently broken - #17269.
+		//
+		// // columns not depended on by the view are unaffected.
+		// db.Exec(`ALTER TABLE store.customers DROP COLUMN email`)
+		// db.CheckQueryResults(`SELECT * FROM store.early_customers`, origEarlyCustomers)
 
 		db.Exec(`DROP TABLE store.customers CASCADE`)
 	})

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -1614,10 +1614,15 @@ func (b *backrefCollector) enterNode(ctx context.Context, _ string, plan planNod
 			ref.IndexID = scan.index.ID
 		}
 		for i := range scan.cols {
-			// Only include the columns that are actually needed.
-			if scan.valNeededForCol[i] {
-				ref.ColumnIDs = append(ref.ColumnIDs, scan.cols[i].ID)
-			}
+			// TODO(knz): We would like to only include the columns that are
+			// actually needed.
+			// Unfortunately, this breaks views defined like this:
+			//     CREATE VIEW xx AS SELECT k FROM (SELECT k, v FROM kv)
+			// See #17269.
+			//
+			// if scan.valNeededForCol[i] {
+			ref.ColumnIDs = append(ref.ColumnIDs, scan.cols[i].ID)
+			// }
 		}
 		desc.DependedOnBy = append(desc.DependedOnBy, ref)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -324,8 +324,13 @@ ALTER TABLE t DROP COLUMN y
 statement error cannot drop column "e" because view "v" depends on it
 ALTER TABLE t DROP COLUMN e
 
-statement ok
+# TODO(knz): this statement should succeed after #17269 is fixed.
+statement error cannot drop column "d" because view "v" depends on it
 ALTER TABLE t DROP COLUMN d
+
+# TODO(knz): remove the following once the test above succeeds.
+statement ok
+ALTER TABLE t DROP COLUMN d CASCADE
 
 statement ok
 ALTER TABLE t DROP COLUMN e CASCADE

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -91,8 +91,9 @@ ALTER TABLE users RENAME COLUMN id TO uid
 statement error cannot rename column "username" because view "v1" depends on it
 ALTER TABLE users RENAME COLUMN username TO name
 
-statement ok
-ALTER TABLE users RENAME COLUMN species TO title
+# TODO(knz): restore test after #17269 / #10083 is fixed.
+#statement ok
+#ALTER TABLE users RENAME COLUMN species TO title
 
 statement ok
 CREATE VIEW v2 AS SELECT id from users
@@ -103,5 +104,6 @@ DROP VIEW v1
 statement error cannot rename column "id" because view "v2" depends on it
 ALTER TABLE users RENAME COLUMN id TO uid
 
-statement ok
-ALTER TABLE users RENAME COLUMN username TO name
+# TODO(knz): restore test after #17269 / #10083 is fixed.
+# statement ok
+# ALTER TABLE users RENAME COLUMN username TO name


### PR DESCRIPTION
Prior to this patch, a view defined with

```sql
CREATE VIEW vx AS SELECT k FROM (SELECT k, v FROM kv)
```

would only establish a dependency on column `k` of `kv`. Subsequently,
`ALTER TABLE kv DROP COLUMN v` would be allowed without error and the
view would become broken.

There is a spectrum of solutions, see the discussion on #17269.

This patch implements the simplest solution that still allows schema
changes on depended-on tables: when a view is created, it now
establishes a dependency on *all the columns that existed at the time
the view is created*. New columns can be added without error; a
subsequent patch can also address #10083 (renaming columns depended on
by views) which is an orthogonal issue.