### PR TITLE
cherrypick: sql: ensure that planNodes are Close()d on error after expansion

### DIFF
--- a/pkg/sql/optimize.go
+++ b/pkg/sql/optimize.go
@@ -26,6 +26,10 @@ import (
 // includes calling expandPlan(). The SQL "prepare" phase, as well as
 // the EXPLAIN statement, should merely build the plan node(s) and
 // call optimizePlan(). This is called automatically by makePlan().
+//
+// The plan returned by optimizePlan *must* be Close()d, even in case
+// of error, because it may contain memory-registered data structures
+// and other things that need clean up.
 func (p *planner) optimizePlan(
 	ctx context.Context, plan planNode, needed []bool,
 ) (planNode, error) {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -222,6 +222,9 @@ func (p *planner) makePlan(ctx context.Context, stmt parser.Statement) (planNode
 	needed := allColumns(plan)
 	plan, err = p.optimizePlan(ctx, plan, needed)
 	if err != nil {
+		// Once the plan has undergone optimization, it may contain
+		// monitor-registered memory, even in case of error.
+		plan.Close(ctx)
 		return nil, err
 	}
 

--- a/pkg/sql/testdata/logic_test/planning_errors
+++ b/pkg/sql/testdata/logic_test/planning_errors
@@ -1,0 +1,8 @@
+# Check that plans that fail during expansion/optimization do not cause
+# memory leaks. #17274
+
+statement error index "aa" is not covering
+CREATE TABLE kv(k INT, v INT);
+ CREATE INDEX aa ON kv(v);
+ SELECT k FROM crdb_internal.leases, kv@{FORCE_INDEX=aa,NO_INDEX_JOIN};
+


### PR DESCRIPTION
Prior to this patch, if plan expansion would fail (e.g. due to an
expansion-time error like a column requested from a non-covering
index), the plan would be abandoned without being `Close()`d. However,
if the error would occur after some vtable was successfully expanded,
or some other `delayedNode` action causing some Closable state to
appear in the planNode, the abandonment was really a resource leak,
and detected as such with a panic.

This patch addresses the issue by ensuring `Close()` is invoked, even
upon error during plan expansion.

cc @cockroachdb/release 