### PR TITLE
storage: Always gossip system config after lease changes hands

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -811,6 +811,16 @@ func (g *Gossip) GetInfoProto(key string, msg proto.Message) error {
 	return proto.Unmarshal(bytes, msg)
 }
 
+// InfoOriginatedHere returns true iff the latest info for the provided key
+// originated on this node. This is useful for ensuring that the system config
+// is regossiped as soon as possible when its lease changes hands.
+func (g *Gossip) InfoOriginatedHere(key string) bool {
+	g.mu.Lock()
+	info := g.mu.is.getInfo(key)
+	g.mu.Unlock()
+	return info != nil && info.NodeID == g.NodeID.Get()
+}
+
 // GetInfoStatus returns the a copy of the contents of the infostore.
 func (g *Gossip) GetInfoStatus() InfoStatus {
 	g.mu.Lock()

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5012,7 +5012,8 @@ func (r *Replica) maybeGossipSystemConfig(ctx context.Context) error {
 		return errors.Wrap(err, "could not load SystemConfig span")
 	}
 
-	if gossipedCfg, ok := r.store.Gossip().GetSystemConfig(); ok && gossipedCfg.Equal(loadedCfg) {
+	if gossipedCfg, ok := r.store.Gossip().GetSystemConfig(); ok && gossipedCfg.Equal(loadedCfg) &&
+		r.store.Gossip().InfoOriginatedHere(gossip.KeySystemConfig) {
 		log.VEventf(ctx, 2, "not gossiping unchanged system config")
 		return nil
 	}


### PR DESCRIPTION
Without doing this, it's possible for n1 to gossip the system config,
lose its lease, and restart with the source node of the system config
gossip still being n1. If this happens, other nodes will not provide the
system config gossip back to n1 because its watermark for itself will be
higher than the system config's timestamp.

I think it's better to add this "last-gossiped-from-here" check to the
universal code path for gossiping the system config than to change only
the leaseChangingHands code path, since it's possible that one of the
other checks or an error preventing gossip could trigger from there and
then we wouldn't know the next time through that we should gossip it.

This fixes the main problem seen in #17272