### PR TITLE
sql: log queries executed via execParsed

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -636,6 +636,10 @@ func (e *Executor) ExecutePreparedStatement(
 func (e *Executor) execPrepared(
 	session *Session, stmt *PreparedStatement, pinfo *parser.PlaceholderInfo,
 ) (StatementResults, error) {
+	if log.V(2) || logStatementsExecuteEnabled.Get() {
+		log.Infof(session.Ctx(), "execPrepared: %s", stmt.Str)
+	}
+
 	var stmts StatementList
 	if stmt.Statement != nil {
 		stmts = StatementList{{


### PR DESCRIPTION
Previously we were only logging queries executed via execRequest. So any
prepared query was not logged.