### PR TITLE
sql: accept FQTNs in RETURNING clauses

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
+// checkHelper validates check constraints on rows, on INSERT and UPDATE.
 type checkHelper struct {
 	exprs        []parser.TypedExpr
 	cols         []sqlbase.ColumnDescriptor

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -106,7 +106,7 @@ func (p *planner) Delete(
 	}
 
 	if err := dn.run.initEditNode(
-		ctx, &dn.editNodeBase, rows, &dn.tw, n.Returning, desiredTypes); err != nil {
+		ctx, &dn.editNodeBase, rows, &dn.tw, tn, n.Returning, desiredTypes); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -243,7 +243,7 @@ func (p *planner) Insert(
 	}
 
 	if err := in.run.initEditNode(
-		ctx, &in.editNodeBase, rows, in.tw, n.Returning, desiredTypes); err != nil {
+		ctx, &in.editNodeBase, rows, in.tw, tn, n.Returning, desiredTypes); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -490,6 +490,10 @@ INSERT INTO return AS r VALUES (5, 6)
 # statement ok
 # INSERT INTO return AS r VALUES (5, 6) RETURNING r.a
 
+# #17008: allow fully-qualified table names in RETURNING clauses
+statement ok
+INSERT INTO return VALUES (5, 6) RETURNING test.return.a
+
 statement error cannot use "x.\*" in this context
 INSERT INTO return VALUES (1, 2) RETURNING x.*[1]
 

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -53,7 +53,7 @@ func (p *planner) newReturningHelper(
 	ctx context.Context,
 	r parser.ReturningClause,
 	desiredTypes []parser.Type,
-	alias string,
+	tn *parser.TableName,
 	tablecols []sqlbase.ColumnDescriptor,
 ) (*returningHelper, error) {
 	rh := &returningHelper{
@@ -78,9 +78,8 @@ func (p *planner) newReturningHelper(
 	}
 
 	rh.columns = make(sqlbase.ResultColumns, 0, len(rExprs))
-	aliasTableName := parser.TableName{TableName: parser.Name(alias)}
 	rh.source = newSourceInfoForSingleTable(
-		aliasTableName, sqlbase.ResultColumnsFromColDescs(tablecols),
+		*tn, sqlbase.ResultColumnsFromColDescs(tablecols),
 	)
 	rh.exprs = make([]parser.TypedExpr, 0, len(rExprs))
 	ivarHelper := parser.MakeIndexedVarHelper(rh, len(tablecols))

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -83,13 +83,14 @@ func (r *editNodeRun) initEditNode(
 	en *editNodeBase,
 	rows planNode,
 	tw tableWriter,
+	tn *parser.TableName,
 	re parser.ReturningClause,
 	desiredTypes []parser.Type,
 ) error {
 	r.rows = rows
 	r.tw = tw
 
-	rh, err := en.p.newReturningHelper(ctx, re, desiredTypes, en.tableDesc.Name, en.tableDesc.Columns)
+	rh, err := en.p.newReturningHelper(ctx, re, desiredTypes, tn, en.tableDesc.Columns)
 	if err != nil {
 		return err
 	}
@@ -224,7 +225,6 @@ func addOrMergeExpr(
 // Privileges: UPDATE and SELECT on table. We currently always use a select statement.
 //   Notes: postgres requires UPDATE. Requires SELECT with WHERE clause with table.
 //          mysql requires UPDATE. Also requires SELECT with WHERE clause with table.
-// TODO(guanqun): need to support CHECK in UPDATE
 func (p *planner) Update(
 	ctx context.Context, n *parser.Update, desiredTypes []parser.Type,
 ) (planNode, error) {
@@ -393,7 +393,7 @@ func (p *planner) Update(
 		return nil, err
 	}
 	if err := un.run.initEditNode(
-		ctx, &un.editNodeBase, rows, &un.tw, n.Returning, desiredTypes); err != nil {
+		ctx, &un.editNodeBase, rows, &un.tw, tn, n.Returning, desiredTypes); err != nil {
 		return nil, err
 	}
 	return un, nil


### PR DESCRIPTION
Permit fully-qualified table names in RETURNING clauses.

Previously, doing so would return an error:

```
INSERT INTO d.t VALUES (1) RETURNING d.t.c;
pq: table "d.t" not selected in FROM clause
```

Fixes #17008.