### PR TITLE
sqlbase, distsql: (memory) row container fixes

### DIFF
--- a/pkg/sql/distsqlrun/disk_row_container.go
+++ b/pkg/sql/distsqlrun/disk_row_container.go
@@ -73,7 +73,7 @@ func makeDiskRowContainer(
 	ctx context.Context,
 	types []sqlbase.ColumnType,
 	ordering sqlbase.ColumnOrdering,
-	rowContainer memRowContainer,
+	rowContainer *memRowContainer,
 	e engine.Engine,
 ) (diskRowContainer, error) {
 	diskMap := engine.NewRocksDBMap(e)

--- a/pkg/sql/distsqlrun/disk_row_container_test.go
+++ b/pkg/sql/distsqlrun/disk_row_container_test.go
@@ -112,7 +112,7 @@ func TestDiskRowContainer(t *testing.T) {
 				row := sqlbase.EncDatumRow(sqlbase.RandEncDatumSliceOfTypes(rng, types))
 				func() {
 					d, err := makeDiskRowContainer(
-						ctx, types, ordering, memRowContainer{}, tempEngine,
+						ctx, types, ordering, &memRowContainer{}, tempEngine,
 					)
 					if err != nil {
 						t.Fatal(err)
@@ -171,7 +171,8 @@ func TestDiskRowContainer(t *testing.T) {
 			func() {
 				// Make the diskRowContainer with half of these rows and insert
 				// the other half normally.
-				memoryContainer := makeRowContainer(ordering, types, &evalCtx)
+				var memoryContainer memRowContainer
+				memoryContainer.init(ordering, types, &evalCtx)
 				defer memoryContainer.Close(ctx)
 				midIdx := len(rows) / 2
 				for i := 0; i < midIdx; i++ {
@@ -184,7 +185,7 @@ func TestDiskRowContainer(t *testing.T) {
 					ctx,
 					types,
 					ordering,
-					memoryContainer,
+					&memoryContainer,
 					tempEngine,
 				)
 				if err != nil {
@@ -199,7 +200,8 @@ func TestDiskRowContainer(t *testing.T) {
 
 				// Make another row container that stores all the rows then sort
 				// it to compare equality.
-				sortedRows := makeRowContainer(ordering, types, &evalCtx)
+				var sortedRows memRowContainer
+				sortedRows.init(ordering, types, &evalCtx)
 				defer sortedRows.Close(ctx)
 				for _, row := range rows {
 					if err := sortedRows.AddRow(ctx, row); err != nil {

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -105,8 +105,8 @@ func newHashJoiner(
 		buckets:           make(map[string]bucket),
 		bucketsAcc:        flowCtx.evalCtx.Mon.MakeBoundAccount(),
 	}
-	h.rows[leftSide] = makeRowContainer(nil /* ordering */, leftSource.Types(), &flowCtx.evalCtx)
-	h.rows[rightSide] = makeRowContainer(nil /* ordering */, rightSource.Types(), &flowCtx.evalCtx)
+	h.rows[leftSide].init(nil /* ordering */, leftSource.Types(), &flowCtx.evalCtx)
+	h.rows[rightSide].init(nil /* ordering */, rightSource.Types(), &flowCtx.evalCtx)
 
 	numMergedColumns := 0
 	if spec.MergedColumns {

--- a/pkg/sql/distsqlrun/row_container.go
+++ b/pkg/sql/distsqlrun/row_container.go
@@ -94,18 +94,16 @@ type memRowContainer struct {
 var _ heap.Interface = &memRowContainer{}
 var _ sortableRowContainer = &memRowContainer{}
 
-func makeRowContainer(
+func (mc *memRowContainer) init(
 	ordering sqlbase.ColumnOrdering, types []sqlbase.ColumnType, evalCtx *parser.EvalContext,
-) memRowContainer {
+) {
 	acc := evalCtx.Mon.MakeBoundAccount()
-	return memRowContainer{
-		RowContainer:  sqlbase.MakeRowContainer(acc, sqlbase.ColTypeInfoFromColTypes(types), 0),
-		types:         types,
-		ordering:      ordering,
-		scratchRow:    make(parser.Datums, len(types)),
-		scratchEncRow: make(sqlbase.EncDatumRow, len(types)),
-		evalCtx:       evalCtx,
-	}
+	mc.RowContainer.Init(acc, sqlbase.ColTypeInfoFromColTypes(types), 0)
+	mc.types = types
+	mc.ordering = ordering
+	mc.scratchRow = make(parser.Datums, len(types))
+	mc.scratchEncRow = make(sqlbase.EncDatumRow, len(types))
+	mc.evalCtx = evalCtx
 }
 
 // Less is part of heap.Interface and is only meant to be used internally.

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -414,9 +414,6 @@ SELECT COUNT(*) FROM one AS a, one AS b, two AS c
 ----
 1000
 
-statement error memory budget exceeded
-SELECT SUM(d1.a), MAX(d1.a), MIN(d1.a) FROM data as d1, data as d2 GROUP BY (d1.b, d1.c, d1.d, d2.a, d2.b, d2.c, d2.d)
-
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), SUM(b), SUM(c) FROM data GROUP BY d HAVING SUM(a+b) > 10]
 ----

--- a/pkg/sql/mon/mem_usage.go
+++ b/pkg/sql/mon/mem_usage.go
@@ -541,9 +541,14 @@ func (b *BoundAccount) ResizeItem(ctx context.Context, oldSz, newSz int64) error
 	return b.mon.ResizeItem(ctx, &b.MemoryAccount, oldSz, newSz)
 }
 
-// Grow is an accessor for b.mon.Grow.
+// Grow is an accessor for b.mon.GrowAccount.
 func (b *BoundAccount) Grow(ctx context.Context, x int64) error {
 	return b.mon.GrowAccount(ctx, &b.MemoryAccount, x)
+}
+
+// Shrink is an accessor for b.mon.ShrinkAccount.
+func (b *BoundAccount) Shrink(ctx context.Context, x int64) {
+	b.mon.ShrinkAccount(ctx, &b.MemoryAccount, x)
 }
 
 // reserveMemory declares an allocation to this monitor. An error is

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -315,7 +315,7 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 		}
 	}
 
-	tu.insertRows = sqlbase.MakeRowContainer(
+	tu.insertRows.Init(
 		tu.mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromColDescs(tu.ri.InsertCols), 0,
 	)
 


### PR DESCRIPTION
#### distsql: rename receiver for memRowContainer methods

The `sv` was left over from `sorterValues`; renaming to `mc`.

#### sqlbase: disallow copying of RowContainers

While working on another change, I encountered a bug (exposed by
`TestDiskContainer`): we are passing a `memRowContainer` by value and modifying
it. This results in incorrect memory accounting (the memory account is embedded
in the structure).

The fix is easy - we just need to pass a pointer. To prevent similar bugs, we
disallow copying of `RowContainer` (using `NoCopy`). The `MakeRowContainer`
function is replaced with an `Init` method.

#### sqlbase: release memory when popping rows from RowContainer

This wasn't critical before because we were always popping rows during a
draining (followed by a call to `Clear` or `Close`). With the buffering router,
we will be alternating between popping rows and adding more rows, so we need to
release the memory.

Removing a distsql_agg "memory exceeded" test - it inadvertently used tuples and
wasn't run via distsql, and it now times out with local SQL (it no longer
exceeds the budget).
