### PR TITLE
sql: make scanNode embed a reference to the table descriptor, not a copy

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -535,7 +535,7 @@ func initTableReaderSpec(
 	n *scanNode,
 ) (distsqlrun.TableReaderSpec, distsqlrun.PostProcessSpec, error) {
 	s := distsqlrun.TableReaderSpec{
-		Table:   n.desc,
+		Table:   *n.desc,
 		Reverse: n.reverse,
 	}
 	if n.index != &n.desc.PrimaryIndex {
@@ -1205,7 +1205,7 @@ ColLoop:
 	}
 
 	joinReaderSpec := distsqlrun.JoinReaderSpec{
-		Table:    n.index.desc,
+		Table:    *n.index.desc,
 		IndexIdx: 0,
 	}
 

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -124,6 +124,7 @@ func (p *planner) makeIndexJoin(
 	// Create a new scanNode that will be used with the primary index.
 	table := p.Scan()
 	table.desc = origScan.desc
+	table.descCopy = origScan.descCopy
 	// Note: initDescDefaults can only error out if its 2nd argument is not nil.
 	_ = table.initDescDefaults(origScan.scanVisibility, nil)
 	table.initOrdering(0)
@@ -194,7 +195,7 @@ func (p *planner) makeIndexJoin(
 
 	indexScan.initOrdering(exactPrefix)
 
-	primaryKeyPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(&table.desc, table.index.ID))
+	primaryKeyPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(table.desc, table.index.ID))
 
 	node := &indexJoinNode{
 		index:             indexScan,
@@ -255,7 +256,7 @@ func (n *indexJoinNode) Next(params runParams) (bool, error) {
 
 			vals := n.index.Values()
 			primaryIndexKey, _, err := sqlbase.EncodeIndexKey(
-				&n.table.desc, n.table.index, n.colIDtoRowIndex, vals, n.primaryKeyPrefix)
+				n.table.desc, n.table.index, n.colIDtoRowIndex, vals, n.primaryKeyPrefix)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -124,7 +124,6 @@ func (p *planner) makeIndexJoin(
 	// Create a new scanNode that will be used with the primary index.
 	table := p.Scan()
 	table.desc = origScan.desc
-	table.descCopy = origScan.descCopy
 	// Note: initDescDefaults can only error out if its 2nd argument is not nil.
 	_ = table.initDescDefaults(origScan.scanVisibility, nil)
 	table.initOrdering(0)

--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -94,7 +94,7 @@ func (p *planner) selectIndex(
 		// No where-clause, no ordering, and no specified index.
 		s.initOrdering(0)
 		var err error
-		s.spans, err = makeSpans(nil, &s.desc, s.index)
+		s.spans, err = makeSpans(nil, s.desc, s.index)
 		if err != nil {
 			return nil, errors.Wrapf(err, "table ID = %d, index ID = %d", s.desc.ID, s.index.ID)
 		}
@@ -106,17 +106,17 @@ func (p *planner) selectIndex(
 		// An explicit secondary index was requested. Only add it to the candidate
 		// indexes list.
 		candidates = append(candidates, &indexInfo{
-			desc:  &s.desc,
+			desc:  s.desc,
 			index: s.specifiedIndex,
 		})
 	} else {
 		candidates = append(candidates, &indexInfo{
-			desc:  &s.desc,
+			desc:  s.desc,
 			index: &s.desc.PrimaryIndex,
 		})
 		for i := range s.desc.Indexes {
 			candidates = append(candidates, &indexInfo{
-				desc:  &s.desc,
+				desc:  s.desc,
 				index: &s.desc.Indexes[i],
 			})
 		}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -19,8 +19,10 @@ package sql
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"sync"
 
+	"github.com/kr/pretty"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -29,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -41,9 +44,10 @@ var scanNodePool = sync.Pool{
 // A scanNode handles scanning over the key/value pairs for a table and
 // reconstructing them into rows.
 type scanNode struct {
-	p     *planner
-	desc  sqlbase.TableDescriptor
-	index *sqlbase.IndexDescriptor
+	p        *planner
+	desc     *sqlbase.TableDescriptor
+	descCopy sqlbase.TableDescriptor
+	index    *sqlbase.IndexDescriptor
 
 	// Set if an index was explicitly specified.
 	specifiedIndex *sqlbase.IndexDescriptor
@@ -125,11 +129,15 @@ func (n *scanNode) disableBatchLimit() {
 }
 
 func (n *scanNode) Start(runParams) error {
-	return n.fetcher.Init(&n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex, n.cols,
+	return n.fetcher.Init(n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex, n.cols,
 		n.valNeededForCol, false /* returnRangeInfo */, &n.p.alloc)
 }
 
-func (n *scanNode) Close(context.Context) {
+func (n *scanNode) Close(ctx context.Context) {
+	if n.desc != nil && !reflect.DeepEqual(n.descCopy, *n.desc) {
+		log.Fatalf(ctx, "scanNode.desc unexpectedly modified:\n%s",
+			pretty.Diff(*n.desc, n.descCopy))
+	}
 	*n = scanNode{}
 	scanNodePool.Put(n)
 }
@@ -197,10 +205,11 @@ func (n *scanNode) initTable(
 	scanVisibility scanVisibility,
 	wantedColumns []parser.ColumnID,
 ) error {
-	n.desc = *desc
+	n.desc = desc
+	n.descCopy = *desc
 
 	if !p.skipSelectPrivilegeChecks {
-		if err := p.CheckPrivilege(&n.desc, privilege.SELECT); err != nil {
+		if err := p.CheckPrivilege(n.desc, privilege.SELECT); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -27,7 +27,7 @@ import (
 func testInitDummySelectNode(desc *sqlbase.TableDescriptor) *renderNode {
 	p := makeTestPlanner()
 	scan := &scanNode{p: p}
-	scan.desc = *desc
+	scan.desc = desc
 	// Note: scan.initDescDefaults only returns an error if its 2nd argument is not nil.
 	_ = scan.initDescDefaults(publicColumns, nil)
 


### PR DESCRIPTION
Prior to this patch scanNode was hosting a copy of the table descriptor.
This is not necessary since the scanNode is not modifying it.