### PR TITLE
sql: re-vamp the view dependency analysis

### DIFF
--- a/pkg/migration/sqlmigrations/migrations.go
+++ b/pkg/migration/sqlmigrations/migrations.go
@@ -66,7 +66,7 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		workFn: optInToDiagnosticsStatReporting,
 	},
 	{
-		name:   "establish conservative dependencies for views #17280 #17269",
+		name:   "establish conservative dependencies for views #17280 #17269 #17306",
 		workFn: repopulateViewDeps,
 	},
 	{
@@ -344,6 +344,7 @@ func eventlogUniqueIDDefault(ctx context.Context, r runner) error {
 	var err error
 	for retry := retry.Start(retry.Options{MaxRetries: 5}); retry.Next(); {
 		res := r.sqlExecutor.ExecuteStatements(session, alterStmt, nil)
+		defer res.Close(ctx)
 		err = checkQueryResults(res.ResultList, 1)
 		if err == nil {
 			break
@@ -410,47 +411,16 @@ func optInToDiagnosticsStatReporting(ctx context.Context, r runner) error {
 		if err == nil {
 			break
 		}
-		log.Warningf(ctx, "failed attempt to update setting: %s", err)
+		log.Warningf(ctx, "failed attempt to update setting: %v", err)
 	}
 	return err
 }
 
-// repopulateViewDeps ensures that each view V that depends on a table
-// T depends on all columns in T. (#17269)
+// repopulateViewDeps recomputes the dependencies of all views, as
+// they might not have been computed properly previously.
+// (#17269 #17306)
 func repopulateViewDeps(ctx context.Context, r runner) error {
-	descKey := sqlbase.MakeAllDescsMetadataKey()
-
 	return r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		// Retrieve all the descriptors.
-		kvs, err := txn.Scan(ctx, descKey, descKey.PrefixEnd(), 0)
-		if err != nil {
-			return err
-		}
-
-		// For each descriptor, reset the depended-on list.
-		b := txn.NewBatch()
-		for _, kv := range kvs {
-			desc := &sqlbase.Descriptor{}
-			if err := kv.ValueProto(desc); err != nil {
-				return err
-			}
-			switch t := desc.Union.(type) {
-			case *sqlbase.Descriptor_Table:
-				tdesc := t.Table
-				columns := make([]sqlbase.ColumnID, len(tdesc.Columns))
-				for i, col := range tdesc.Columns {
-					columns[i] = col.ID
-				}
-				for i := range tdesc.DependedOnBy {
-					// Make all columns a dependency.
-					tdesc.DependedOnBy[i].ColumnIDs = columns
-				}
-				b.Put(sqlbase.MakeDescMetadataKey(desc.GetID()), desc)
-			}
-		}
-		if err := txn.SetSystemConfigTrigger(); err != nil {
-			return err
-		}
-		return txn.Run(ctx, b)
+		return sql.RecomputeViewDependencies(ctx, txn, r.sqlExecutor)
 	})
 }

--- a/pkg/migration/sqlmigrations/migrations_test.go
+++ b/pkg/migration/sqlmigrations/migrations_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,6 +28,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -497,6 +500,197 @@ func TestCreateSystemTable(t *testing.T) {
 	backwardCompatibleMigrations = append(backwardCompatibleMigrations, migrationDescriptor{
 		name:   "create system.jobs table",
 		workFn: createJobsTable,
+	})
+	if err := mgr.EnsureMigrations(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdateViewDependenciesMigration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	// remove the view update migration so we can test its effects.
+	newMigrations := make([]migrationDescriptor, 0, len(backwardCompatibleMigrations))
+	for _, m := range backwardCompatibleMigrations {
+		if strings.HasPrefix(m.name, "establish conservative dependencies for views") {
+			continue
+		}
+		newMigrations = append(newMigrations, m)
+	}
+
+	// We also hijack the migration process to capture the SQL memory
+	// metric object, needed below.
+	var memMetrics *sql.MemoryMetrics
+	newMigrations = append(newMigrations,
+		migrationDescriptor{
+			name: "capture mem metrics",
+			workFn: func(ctx context.Context, r runner) error {
+				memMetrics = r.memMetrics
+				return nil
+			},
+		})
+	backwardCompatibleMigrations = newMigrations
+
+	t.Log("starting server")
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	t.Log("create test tables")
+
+	const createStmts = `
+CREATE DATABASE test;
+CREATE DATABASE test2;
+SET DATABASE=test;
+
+CREATE TABLE t(x INT, y INT);
+CREATE VIEW v1 AS SELECT x FROM t WHERE false;
+CREATE VIEW v2 AS SELECT x FROM v1;
+
+CREATE TABLE u(x INT, y INT);
+CREATE VIEW v3 AS SELECT x FROM (SELECT x, y FROM u);
+
+CREATE VIEW v4 AS SELECT id from system.descriptor;
+
+CREATE TABLE w(x INT);
+CREATE VIEW test2.v5 AS SELECT x FROM w;
+
+CREATE TABLE x(x INT);
+CREATE INDEX y ON x(x);
+CREATE VIEW v6 AS SELECT x FROM x@y;
+`
+	if _, err := sqlDB.Exec(createStmts); err != nil {
+		t.Fatal(err)
+	}
+
+	testDesc := []struct {
+		dbName parser.Name
+		tname  parser.Name
+		desc   *sqlbase.TableDescriptor
+	}{
+		{"test", "t", nil},
+		{"test", "v1", nil},
+		{"test", "u", nil},
+		{"test", "w", nil},
+		{"test", "x", nil},
+		{"system", "descriptor", nil},
+	}
+
+	t.Log("fetch descriptors")
+
+	e := s.Executor().(*sql.Executor)
+	vt := e.GetVirtualTabler()
+
+	if err := kvDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		for i := range testDesc {
+			desc, err := sql.MustGetTableOrViewDesc(ctx, txn, vt,
+				&parser.TableName{DatabaseName: testDesc[i].dbName, TableName: testDesc[i].tname}, true)
+			if err != nil {
+				return err
+			}
+			testDesc[i].desc = desc
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now, corrupt the descriptors by breaking their dependency information.
+	t.Log("break descriptors")
+	if err := kvDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		if err := txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
+		for _, t := range testDesc {
+			t.desc.UpVersion = true
+			t.desc.DependedOnBy = nil
+			t.desc.DependedOnBy = nil
+
+			descKey := sqlbase.MakeDescMetadataKey(t.desc.GetID())
+			descVal := sqlbase.WrapDescriptor(t.desc)
+			if err := txn.Put(ctx, descKey, descVal); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Break further by deleting the referenced tables. This has become possible
+	// because the dependency links have been broken above.
+	t.Log("delete tables")
+
+	if _, err := sqlDB.Exec(`
+DROP TABLE test.t;
+DROP VIEW test.v1;
+DROP TABLE test.u;
+DROP TABLE test.w;
+DROP INDEX test.x@y;
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the views are effectively broken.
+	t.Log("check views are broken")
+
+	for _, vname := range []string{"test.v2", "test.v3", "test2.v5", "test.v6"} {
+		_, err := sqlDB.Exec(fmt.Sprintf(`TABLE %s`, vname))
+		if !testutils.IsError(err,
+			`relation ".*" does not exist|index ".*" not found|table is being dropped`) {
+			t.Fatalf("%s: unexpected error: %v", vname, err)
+		}
+	}
+
+	// Restore missing dependencies for the rest of the test.
+	t.Log("restore dependencies")
+
+	if _, err := sqlDB.Exec(`
+CREATE TABLE test.t(x INT, y INT);
+CREATE TABLE test.u(x INT, y INT);
+CREATE TABLE test.w(x INT);
+CREATE VIEW test.v1 AS SELECT x FROM test.t WHERE false;
+CREATE INDEX y ON test.x(x);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the migration outside the context of a migration manager
+	// such that its work gets done but the key indicating it's been completed
+	// doesn't get written.
+	t.Log("fix view deps manually")
+	if err := repopulateViewDeps(ctx, runner{db: kvDB, sqlExecutor: e}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the views are fixed now.
+	t.Log("check views working")
+
+	// Check the views can be queried.
+	for _, vname := range []string{"test.v1", "test.v2", "test.v3", "test.v4", "test2.v5", "test.v6"} {
+		if _, err := sqlDB.Exec(fmt.Sprintf("TABLE %s", vname)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Check that the tables cannot be dropped any more.
+	for _, tn := range []string{"TABLE test.t", "TABLE test.u", "TABLE test.w", "INDEX test.x@y"} {
+		_, err := sqlDB.Exec(fmt.Sprintf(`DROP %s`, tn))
+		if !testutils.IsError(err,
+			`cannot drop (relation|index) .* because view .* depends on it`) {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	// Finally, try running the migration and make sure it still succeeds.
+	// This verifies the idempotency of the migration.
+	t.Log("run migration")
+
+	mgr := NewManager(s.Stopper(), kvDB, e, s.Clock(), memMetrics, "clientID")
+	backwardCompatibleMigrations = append(backwardCompatibleMigrations, migrationDescriptor{
+		name:   "repopulate view dependencies",
+		workFn: repopulateViewDeps,
 	})
 	if err := mgr.EnsureMigrations(ctx); err != nil {
 		t.Fatal(err)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -452,6 +452,11 @@ func (ts *TestServer) LeaseManager() interface{} {
 	return ts.leaseMgr
 }
 
+// Executor is part of TestServerInterface.
+func (ts *TestServer) Executor() interface{} {
+	return ts.sqlExecutor
+}
+
 // GetNode exposes the Server's Node.
 func (ts *TestServer) GetNode() *Node {
 	return ts.node

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -55,6 +55,11 @@ var crdbInternal = virtualSchema{
 		crdbInternalClusterSessionsTable,
 		crdbInternalBuiltinFunctionsTable,
 		crdbInternalCreateStmtsTable,
+		crdbInternalTableColumnsTable,
+		crdbInternalTableIndicesTable,
+		crdbInternalIndexColumnsTable,
+		crdbInternalBackwardDependenciesTable,
+		crdbInternalForwardDependenciesTable,
 	},
 }
 
@@ -467,7 +472,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 // session (via SET TRACING={ON/OFF})
 var crdbInternalSessionTraceTable = virtualSchemaTable{
 	schema: `
-CREATE TABLE crdb_internal.session_trace(
+CREATE TABLE crdb_internal.session_trace (
   txn_idx     INT NOT NULL,        -- The transaction's 0-based index, among all
                                    -- transactions that have been traced.
                                    -- Only filled for the first log message in a
@@ -781,6 +786,7 @@ CREATE TABLE crdb_internal.builtin_functions (
 var crdbInternalCreateStmtsTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.create_statements (
+  database_id      INT,
   database_name    STRING NOT NULL,
   descriptor_id    INT,
   descriptor_type  STRING NOT NULL,
@@ -837,7 +843,12 @@ CREATE TABLE crdb_internal.create_statements (
 				if table.ID != keys.VirtualDescriptorID {
 					descID = parser.NewDInt(parser.DInt(table.ID))
 				}
+				dbDescID := parser.DNull
+				if db.ID != keys.VirtualDescriptorID {
+					dbDescID = parser.NewDInt(parser.DInt(db.ID))
+				}
 				return addRow(
+					dbDescID,
 					parser.NewDString(db.Name),
 					descID,
 					descType,
@@ -846,6 +857,392 @@ CREATE TABLE crdb_internal.create_statements (
 					parser.NewDString(strings.Join(depNames, ", ")),
 					parser.NewDString(table.State.String()),
 				)
+			})
+	},
+}
+
+// crdbInternalTableColumnsTable exposes the column descriptors.
+var crdbInternalTableColumnsTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.table_columns (
+  descriptor_id    INT,
+  descriptor_name  STRING NOT NULL,
+  column_id        INT NOT NULL,
+  column_name      STRING NOT NULL,
+  column_type      STRING NOT NULL,
+  nullable         BOOL NOT NULL,
+  default_expr     STRING,
+  hidden           BOOL NOT NULL
+)
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		return forEachTableDescAll(ctx, p, prefix,
+			func(_ *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+				tableID := parser.DNull
+				if table.ID != keys.VirtualDescriptorID {
+					tableID = parser.NewDInt(parser.DInt(table.ID))
+				}
+				tableName := parser.NewDString(table.Name)
+				for _, col := range table.Columns {
+					defStr := parser.DNull
+					if col.DefaultExpr != nil {
+						defStr = parser.NewDString(*col.DefaultExpr)
+					}
+					if err := addRow(
+						tableID,
+						tableName,
+						parser.NewDInt(parser.DInt(col.ID)),
+						parser.NewDString(col.Name),
+						parser.NewDString(col.Type.String()),
+						parser.MakeDBool(parser.DBool(col.Nullable)),
+						defStr,
+						parser.MakeDBool(parser.DBool(col.Hidden)),
+					); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+	},
+}
+
+// crdbInternalTableIndicesTable exposes the index descriptors.
+var crdbInternalTableIndicesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.table_indexes (
+  descriptor_id    INT,
+  descriptor_name  STRING NOT NULL,
+  index_id         INT NOT NULL,
+  index_name       STRING NOT NULL,
+  index_type       STRING NOT NULL,
+  is_unique        BOOL NOT NULL
+)
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		primary := parser.NewDString("primary")
+		secondary := parser.NewDString("secondary")
+		return forEachTableDescAll(ctx, p, prefix,
+			func(_ *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+				tableID := parser.DNull
+				if table.ID != keys.VirtualDescriptorID {
+					tableID = parser.NewDInt(parser.DInt(table.ID))
+				}
+				tableName := parser.NewDString(table.Name)
+				if err := addRow(
+					tableID,
+					tableName,
+					parser.NewDInt(parser.DInt(table.PrimaryIndex.ID)),
+					parser.NewDString(table.PrimaryIndex.Name),
+					primary,
+					parser.MakeDBool(parser.DBool(table.PrimaryIndex.Unique)),
+				); err != nil {
+					return err
+				}
+				for _, idx := range table.Indexes {
+					if err := addRow(
+						tableID,
+						tableName,
+						parser.NewDInt(parser.DInt(idx.ID)),
+						parser.NewDString(idx.Name),
+						secondary,
+						parser.MakeDBool(parser.DBool(idx.Unique)),
+					); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+	},
+}
+
+// crdbInternalIndexColumnsTable exposes the index columns.
+var crdbInternalIndexColumnsTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.index_columns (
+  descriptor_id    INT,
+  descriptor_name  STRING NOT NULL,
+  index_id         INT NOT NULL,
+  index_name       STRING NOT NULL,
+  column_type      STRING NOT NULL,
+  column_id        INT NOT NULL,
+  column_name      STRING,
+  column_direction STRING
+)
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		key := parser.NewDString("key")
+		storing := parser.NewDString("storing")
+		extra := parser.NewDString("extra")
+		composite := parser.NewDString("composite")
+		idxDirMap := map[sqlbase.IndexDescriptor_Direction]parser.Datum{
+			sqlbase.IndexDescriptor_ASC:  parser.NewDString(sqlbase.IndexDescriptor_ASC.String()),
+			sqlbase.IndexDescriptor_DESC: parser.NewDString(sqlbase.IndexDescriptor_DESC.String()),
+		}
+		return forEachTableDescAll(ctx, p, prefix,
+			func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+				tableID := parser.DNull
+				if table.ID != keys.VirtualDescriptorID {
+					tableID = parser.NewDInt(parser.DInt(table.ID))
+				}
+				tableName := parser.NewDString(table.Name)
+				reportIndex := func(idx *sqlbase.IndexDescriptor) error {
+					idxID := parser.NewDInt(parser.DInt(idx.ID))
+					idxName := parser.NewDString(idx.Name)
+
+					// Report the main (key) columns.
+					for i, c := range idx.ColumnIDs {
+						colName := parser.DNull
+						colDir := parser.DNull
+						if i >= len(idx.ColumnNames) {
+							log.Errorf(ctx, "index descriptor for [%d@%d] (%s.%s@%s) has more key column IDs (%d) than names (%d) (corrupted schema?)",
+								table.ID, idx.ID, db.Name, table.Name, idx.Name,
+								len(idx.ColumnIDs), len(idx.ColumnNames))
+						} else {
+							colName = parser.NewDString(idx.ColumnNames[i])
+						}
+						if i >= len(idx.ColumnDirections) {
+							log.Errorf(ctx, "index descriptor for [%d@%d] (%s.%s@%s) has more key column IDs (%d) than directions (%d) (corrupted schema?)",
+								table.ID, idx.ID, db.Name, table.Name, idx.Name,
+								len(idx.ColumnIDs), len(idx.ColumnDirections))
+						} else {
+							colDir = idxDirMap[idx.ColumnDirections[i]]
+						}
+
+						if err := addRow(
+							tableID, tableName, idxID, idxName,
+							key, parser.NewDInt(parser.DInt(c)), colName, colDir,
+						); err != nil {
+							return err
+						}
+					}
+
+					// Report the stored columns.
+					for _, c := range idx.StoreColumnIDs {
+						if err := addRow(
+							tableID, tableName, idxID, idxName,
+							storing, parser.NewDInt(parser.DInt(c)), parser.DNull, parser.DNull,
+						); err != nil {
+							return err
+						}
+					}
+
+					// Report the extra columns.
+					for _, c := range idx.ExtraColumnIDs {
+						if err := addRow(
+							tableID, tableName, idxID, idxName,
+							extra, parser.NewDInt(parser.DInt(c)), parser.DNull, parser.DNull,
+						); err != nil {
+							return err
+						}
+					}
+
+					// Report the composite columns
+					for _, c := range idx.CompositeColumnIDs {
+						if err := addRow(
+							tableID, tableName, idxID, idxName,
+							composite, parser.NewDInt(parser.DInt(c)), parser.DNull, parser.DNull,
+						); err != nil {
+							return err
+						}
+					}
+
+					return nil
+				}
+
+				if err := reportIndex(&table.PrimaryIndex); err != nil {
+					return err
+				}
+				for i := range table.Indexes {
+					if err := reportIndex(&table.Indexes[i]); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+	},
+}
+
+// crdbInternalBackwardDependenciesTable exposes the backward
+// inter-descriptor dependencies.
+var crdbInternalBackwardDependenciesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.backward_dependencies (
+  descriptor_id      INT,
+  descriptor_name    STRING NOT NULL,
+  index_id           INT,
+  dependson_id       INT NOT NULL,
+  dependson_type     STRING NOT NULL,
+  dependson_index_id INT,
+  dependson_name     STRING,
+  dependson_details  STRING
+)
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		fkDep := parser.NewDString("fk")
+		viewDep := parser.NewDString("view")
+		interleaveDep := parser.NewDString("interleave")
+		return forEachTableDescAll(ctx, p, prefix,
+			func(_ *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+				tableID := parser.DNull
+				if table.ID != keys.VirtualDescriptorID {
+					tableID = parser.NewDInt(parser.DInt(table.ID))
+				}
+				tableName := parser.NewDString(table.Name)
+
+				reportIdxDeps := func(idx *sqlbase.IndexDescriptor) error {
+					idxID := parser.NewDInt(parser.DInt(idx.ID))
+					if idx.ForeignKey.Table != 0 {
+						fkRef := &idx.ForeignKey
+						if err := addRow(
+							tableID, tableName,
+							idxID,
+							parser.NewDInt(parser.DInt(fkRef.Table)),
+							fkDep,
+							parser.NewDInt(parser.DInt(fkRef.Index)),
+							parser.NewDString(fkRef.Name),
+							parser.NewDString(fmt.Sprintf("SharedPrefixLen: %d", fkRef.SharedPrefixLen)),
+						); err != nil {
+							return err
+						}
+					}
+
+					for _, interleaveParent := range idx.Interleave.Ancestors {
+						if err := addRow(
+							tableID, tableName,
+							idxID,
+							parser.NewDInt(parser.DInt(interleaveParent.TableID)),
+							interleaveDep,
+							parser.NewDInt(parser.DInt(interleaveParent.IndexID)),
+							parser.DNull,
+							parser.NewDString(fmt.Sprintf("SharedPrefixLen: %d",
+								interleaveParent.SharedPrefixLen)),
+						); err != nil {
+							return err
+						}
+					}
+					return nil
+				}
+
+				// Record the backward references of the primary index.
+				if err := reportIdxDeps(&table.PrimaryIndex); err != nil {
+					return err
+				}
+
+				// Record the backward references of secondary indexes.
+				for i := range table.Indexes {
+					if err := reportIdxDeps(&table.Indexes[i]); err != nil {
+						return err
+					}
+				}
+
+				// Record the view dependencies.
+				for _, tIdx := range table.DependsOn {
+					if err := addRow(
+						tableID, tableName,
+						parser.DNull,
+						parser.NewDInt(parser.DInt(tIdx)),
+						viewDep,
+						parser.DNull,
+						parser.DNull,
+						parser.DNull,
+					); err != nil {
+						return err
+					}
+				}
+
+				return nil
+			})
+	},
+}
+
+// crdbInternalForwardDependenciesTable exposes the forward
+// inter-descriptor dependencies.
+var crdbInternalForwardDependenciesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.forward_dependencies (
+  descriptor_id         INT,
+  descriptor_name       STRING NOT NULL,
+  index_id              INT,
+  dependedonby_id       INT NOT NULL,
+  dependedonby_type     STRING NOT NULL,
+  dependedonby_index_id INT,
+  dependedonby_name     STRING,
+  dependedonby_details  STRING
+)
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		fkDep := parser.NewDString("fk")
+		viewDep := parser.NewDString("view")
+		interleaveDep := parser.NewDString("interleave")
+		return forEachTableDescAll(ctx, p, prefix,
+			func(_ *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+				tableID := parser.DNull
+				if table.ID != keys.VirtualDescriptorID {
+					tableID = parser.NewDInt(parser.DInt(table.ID))
+				}
+				tableName := parser.NewDString(table.Name)
+
+				reportIdxDeps := func(idx *sqlbase.IndexDescriptor) error {
+					idxID := parser.NewDInt(parser.DInt(idx.ID))
+					for _, fkRef := range idx.ReferencedBy {
+						if err := addRow(
+							tableID, tableName,
+							idxID,
+							parser.NewDInt(parser.DInt(fkRef.Table)),
+							fkDep,
+							parser.NewDInt(parser.DInt(fkRef.Index)),
+							parser.NewDString(fkRef.Name),
+							parser.NewDString(fmt.Sprintf("SharedPrefixLen: %d", fkRef.SharedPrefixLen)),
+						); err != nil {
+							return err
+						}
+					}
+
+					for _, interleaveRef := range idx.InterleavedBy {
+						if err := addRow(
+							tableID, tableName,
+							idxID,
+							parser.NewDInt(parser.DInt(interleaveRef.Table)),
+							interleaveDep,
+							parser.NewDInt(parser.DInt(interleaveRef.Index)),
+							parser.DNull,
+							parser.NewDString(fmt.Sprintf("SharedPrefixLen: %d",
+								interleaveRef.SharedPrefixLen)),
+						); err != nil {
+							return err
+						}
+					}
+					return nil
+				}
+
+				// Record the backward references of the primary index.
+				if err := reportIdxDeps(&table.PrimaryIndex); err != nil {
+					return err
+				}
+
+				// Record the backward references of secondary indexes.
+				for i := range table.Indexes {
+					if err := reportIdxDeps(&table.Indexes[i]); err != nil {
+						return err
+					}
+				}
+
+				// Record the view dependencies.
+				for _, dep := range table.DependedOnBy {
+					if err := addRow(
+						tableID, tableName,
+						parser.DNull,
+						parser.NewDInt(parser.DInt(dep.ID)),
+						viewDep,
+						parser.NewDInt(parser.DInt(dep.IndexID)),
+						parser.DNull,
+						parser.NewDString(fmt.Sprintf("Columns: %v", dep.ColumnIDs)),
+					); err != nil {
+						return err
+					}
+				}
+
+				return nil
 			})
 	},
 }

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -20,7 +20,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -32,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
 )
 
 type createDatabaseNode struct {
@@ -133,7 +133,7 @@ func (p *planner) CreateIndex(ctx context.Context, n *parser.CreateIndex) (planN
 		return nil, err
 	}
 
-	tableDesc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
+	tableDesc, err := MustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
 	if err != nil {
 		return nil, err
 	}
@@ -317,12 +317,16 @@ func (*createUserNode) Next(runParams) (bool, error) { return false, nil }
 func (*createUserNode) Close(context.Context)        {}
 func (*createUserNode) Values() parser.Datums        { return parser.Datums{} }
 
+// createViewNode represents a CREATE VIEW statement.
 type createViewNode struct {
-	p           *planner
-	n           *parser.CreateView
-	dbDesc      *sqlbase.DatabaseDescriptor
-	sourcePlan  planNode
-	sourceQuery string
+	p             *planner
+	n             *parser.CreateView
+	dbDesc        *sqlbase.DatabaseDescriptor
+	sourceColumns sqlbase.ResultColumns
+	// planDeps tracks which tables and views the view being created
+	// depends on. This is collected during the construction of
+	// the view query's logical plan.
+	planDeps planDependencies
 }
 
 // CreateView creates a view.
@@ -345,37 +349,11 @@ func (p *planner) CreateView(ctx context.Context, n *parser.CreateView) (planNod
 		return nil, err
 	}
 
-	// To avoid races with ongoing schema changes to tables that the view
-	// depends on, make sure we use the most recent versions of table
-	// descriptors rather than the copies in the lease cache.
-	defer func(prev bool) { p.avoidCachedDescriptors = prev }(p.avoidCachedDescriptors)
-	p.avoidCachedDescriptors = true
-
-	// Now generate the source plan.
-	sourcePlan, err := p.Select(ctx, n.AsSource, []parser.Type{})
-	if err != nil {
-		return nil, err
-	}
-
-	var result *createViewNode
-	defer func() {
-		// Ensure that we clean up after ourselves if an error occurs, because if
-		// construction of the planNode fails, Close() won't be called on it.
-		if result == nil {
-			sourcePlan.Close(ctx)
-			p.avoidCachedDescriptors = false
-		}
-	}()
-
-	numColNames := len(n.ColumnNames)
-	numColumns := len(planColumns(sourcePlan))
-	if numColNames != 0 && numColNames != numColumns {
-		return nil, sqlbase.NewSyntaxError(fmt.Sprintf(
-			"CREATE VIEW specifies %d column name%s, but data source has %d column%s",
-			numColNames, util.Pluralize(int64(numColNames)),
-			numColumns, util.Pluralize(int64(numColumns))))
-	}
-
+	// Ensure that all the table names are properly qualified.  The
+	// traversal will update the NormalizableTableNames in-place, so the
+	// changes are persisted in n.AsSource. We use parser.FormatNode
+	// merely as a traversal method; its output buffer is discarded
+	// immediately after the traversal because it is not needed further.
 	var queryBuf bytes.Buffer
 	var fmtErr error
 	parser.FormatNode(
@@ -385,11 +363,13 @@ func (p *planner) CreateView(ctx context.Context, n *parser.CreateView) (planNod
 			func(t *parser.NormalizableTableName, buf *bytes.Buffer, f parser.FmtFlags) {
 				tn, err := p.QualifyWithDatabase(ctx, t)
 				if err != nil {
-					log.Warningf(ctx, "failed to qualify table name %q with database name: %v", t, err)
+					log.Warningf(ctx, "failed to qualify table name %q with database name: %v",
+						parser.ErrString(t), err)
 					fmtErr = err
-					t.TableNameReference.Format(buf, f)
+					return
 				}
-				tn.Format(buf, f)
+				// Persist the database prefix expansion.
+				tn.DBNameOriginallyOmitted = false
 			},
 		),
 		n.AsSource,
@@ -398,21 +378,29 @@ func (p *planner) CreateView(ctx context.Context, n *parser.CreateView) (planNod
 		return nil, fmtErr
 	}
 
-	// TODO(a-robinson): Support star expressions as soon as we can (#10028).
-	if p.planContainsStar(ctx, sourcePlan) {
-		return nil, fmt.Errorf("views do not currently support * expressions")
+	planDeps, sourceColumns, err := p.analyzeViewQuery(ctx, n.AsSource)
+	if err != nil {
+		return nil, err
 	}
 
-	// Set result rather than just returnning to ensure the defer'ed cleanup
-	// doesn't trigger.
-	result = &createViewNode{
-		p:           p,
-		n:           n,
-		dbDesc:      dbDesc,
-		sourcePlan:  sourcePlan,
-		sourceQuery: queryBuf.String(),
+	numColNames := len(n.ColumnNames)
+	numColumns := len(sourceColumns)
+	if numColNames != 0 && numColNames != numColumns {
+		return nil, sqlbase.NewSyntaxError(fmt.Sprintf(
+			"CREATE VIEW specifies %d column name%s, but data source has %d column%s",
+			numColNames, util.Pluralize(int64(numColNames)),
+			numColumns, util.Pluralize(int64(numColumns))))
 	}
-	return result, nil
+
+	log.VEventf(ctx, 2, "collected view dependencies:\n%s", planDeps.String())
+
+	return &createViewNode{
+		p:             p,
+		n:             n,
+		dbDesc:        dbDesc,
+		sourceColumns: sourceColumns,
+		planDeps:      planDeps,
+	}, nil
 }
 
 func (n *createViewNode) Start(params runParams) error {
@@ -434,16 +422,14 @@ func (n *createViewNode) Start(params runParams) error {
 	// Inherit permissions from the database descriptor.
 	privs := n.dbDesc.GetPrivileges()
 
-	affected := make(map[sqlbase.ID]sqlbase.TableDescriptor)
 	desc, err := n.makeViewTableDesc(
 		params.ctx,
 		viewName,
 		n.n.ColumnNames,
 		n.dbDesc.ID,
 		id,
-		planColumns(n.sourcePlan),
+		n.sourceColumns,
 		privs,
-		affected,
 		&n.p.evalCtx,
 	)
 	if err != nil {
@@ -454,16 +440,32 @@ func (n *createViewNode) Start(params runParams) error {
 		return err
 	}
 
+	// Collect all the tables/views this view depends on.
+	for backrefID := range n.planDeps {
+		desc.DependsOn = append(desc.DependsOn, backrefID)
+	}
+
 	if err = n.p.createDescriptorWithID(params.ctx, key, id, &desc); err != nil {
 		return err
 	}
 
 	// Persist the back-references in all referenced table descriptors.
-	for _, updated := range affected {
-		if err := n.p.saveNonmutationAndNotify(params.ctx, &updated); err != nil {
+	for _, updated := range n.planDeps {
+		backrefDesc := *updated.desc
+		for _, dep := range updated.deps {
+			// The logical plan constructor merely registered the dependencies.
+			// It did not populate the "ID" field of TableDescriptor_Reference,
+			// because the ID of the newly created view descriptor was not
+			// yet known.
+			// We need to do it here.
+			dep.ID = desc.ID
+			backrefDesc.DependedOnBy = append(backrefDesc.DependedOnBy, dep)
+		}
+		if err := n.p.saveNonmutationAndNotify(params.ctx, &backrefDesc); err != nil {
 			return err
 		}
 	}
+
 	if desc.Adding() {
 		n.p.notifySchemaChange(&desc, sqlbase.InvalidMutationID)
 	}
@@ -491,10 +493,7 @@ func (n *createViewNode) Start(params runParams) error {
 	return nil
 }
 
-func (n *createViewNode) Close(ctx context.Context) {
-	n.sourcePlan.Close(ctx)
-	n.sourcePlan = nil
-}
+func (n *createViewNode) Close(ctx context.Context) {}
 
 func (*createViewNode) Next(runParams) (bool, error) { return false, nil }
 func (*createViewNode) Values() parser.Datums        { return parser.Datums{} }
@@ -1020,7 +1019,7 @@ func addInterleave(
 		return err
 	}
 
-	parentTable, err := mustGetTableDesc(ctx, txn, vt, tn, true /*allowAdding*/)
+	parentTable, err := MustGetTableDesc(ctx, txn, vt, tn, true /*allowAdding*/)
 	if err != nil {
 		return err
 	}
@@ -1123,7 +1122,6 @@ func (n *createViewNode) makeViewTableDesc(
 	id sqlbase.ID,
 	resultColumns []sqlbase.ResultColumn,
 	privileges *sqlbase.PrivilegeDescriptor,
-	affected map[sqlbase.ID]sqlbase.TableDescriptor,
 	evalCtx *parser.EvalContext,
 ) (sqlbase.TableDescriptor, error) {
 	desc := sqlbase.TableDescriptor{
@@ -1133,7 +1131,7 @@ func (n *createViewNode) makeViewTableDesc(
 		FormatVersion: sqlbase.FamilyFormatVersion,
 		Version:       1,
 		Privileges:    privileges,
-		ViewQuery:     n.sourceQuery,
+		ViewQuery:     parser.AsStringWithFlags(n.n.AsSource, parser.FmtParsable),
 	}
 	for i, colRes := range resultColumns {
 		colType, err := parser.DatumTypeToColumnType(colRes.Typ)
@@ -1151,8 +1149,6 @@ func (n *createViewNode) makeViewTableDesc(
 		}
 		desc.AddColumn(*col)
 	}
-
-	n.resolveViewDependencies(ctx, &desc, affected)
 
 	return desc, desc.AllocateIDs()
 }
@@ -1537,117 +1533,6 @@ func makeCheckConstraint(
 		}
 	}
 	return &sqlbase.TableDescriptor_CheckConstraint{Expr: parser.Serialize(d.Expr), Name: name}, nil
-}
-
-// resolveViewDependencies looks up the tables included in a view's query
-// and adds metadata representing those dependencies to both the new view's
-// descriptor and the dependend-upon tables' descriptors. The modified table
-// descriptors are put into the backrefs map of other tables so that they can
-// be updated when this view is created.
-func (n *createViewNode) resolveViewDependencies(
-	ctx context.Context,
-	tbl *sqlbase.TableDescriptor,
-	backrefs map[sqlbase.ID]sqlbase.TableDescriptor,
-) {
-	n.p.populateViewBackrefs(ctx, n.sourcePlan, tbl, backrefs)
-
-	// Also create the forward references in the new view's descriptor.
-	tbl.DependsOn = make([]sqlbase.ID, 0, len(backrefs))
-	for id := range backrefs {
-		tbl.DependsOn = append(tbl.DependsOn, id)
-	}
-}
-
-// populateViewBackrefs adds back-references to the descriptor for each referenced
-// table / view in the plan.
-func (p *planner) populateViewBackrefs(
-	ctx context.Context,
-	plan planNode,
-	tbl *sqlbase.TableDescriptor,
-	backrefs map[sqlbase.ID]sqlbase.TableDescriptor,
-) {
-	b := &backrefCollector{p: p, tbl: tbl, backrefs: backrefs}
-	_ = walkPlan(ctx, plan, planObserver{enterNode: b.enterNode})
-}
-
-type backrefCollector struct {
-	p   *planner
-	tbl *sqlbase.TableDescriptor
-	// backrefs contains the descriptor back-references. We store copies
-	// instead of pointers so as to not modify the descriptors in-place
-	// when updating dependencies.
-	backrefs map[sqlbase.ID]sqlbase.TableDescriptor
-}
-
-// enterNode is used by a planObserver.
-func (b *backrefCollector) enterNode(ctx context.Context, _ string, plan planNode) bool {
-	// I was initially concerned about doing type assertions on every node in
-	// the tree, but it's actually faster than a string comparison on the name
-	// returned by ExplainPlan, judging by a mini-benchmark run on my laptop
-	// with go 1.7.1.
-	if sel, ok := plan.(*renderNode); ok {
-		// If this is a view, we don't want to resolve the underlying scan(s).
-		// We instead prefer to track the dependency on the view itself rather
-		// than on its indirect dependencies.
-		if sel.source.info.viewDesc != nil {
-			populateViewBackrefFromViewDesc(sel.source.info.viewDesc, b.tbl, b.backrefs)
-			// Return early to avoid processing the view's underlying query.
-			return false
-		}
-	} else if join, ok := plan.(*joinNode); ok {
-		if join.left.info.viewDesc != nil {
-			populateViewBackrefFromViewDesc(join.left.info.viewDesc, b.tbl, b.backrefs)
-		} else {
-			b.p.populateViewBackrefs(ctx, join.left.plan, b.tbl, b.backrefs)
-		}
-		if join.right.info.viewDesc != nil {
-			populateViewBackrefFromViewDesc(join.right.info.viewDesc, b.tbl, b.backrefs)
-		} else {
-			b.p.populateViewBackrefs(ctx, join.right.plan, b.tbl, b.backrefs)
-		}
-		// Return early to avoid re-processing the children.
-		return false
-	} else if scan, ok := plan.(*scanNode); ok {
-		desc, ok := b.backrefs[scan.desc.ID]
-		if !ok {
-			desc = *scan.desc
-		}
-		ref := sqlbase.TableDescriptor_Reference{
-			ID:        b.tbl.ID,
-			ColumnIDs: make([]sqlbase.ColumnID, 0, len(scan.cols)),
-		}
-		if scan.index != nil && scan.isSecondaryIndex {
-			ref.IndexID = scan.index.ID
-		}
-		for i := range scan.cols {
-			// TODO(knz): We would like to only include the columns that are
-			// actually needed.
-			// Unfortunately, this breaks views defined like this:
-			//     CREATE VIEW xx AS SELECT k FROM (SELECT k, v FROM kv)
-			// See #17269.
-			//
-			// if scan.valNeededForCol[i] {
-			ref.ColumnIDs = append(ref.ColumnIDs, scan.cols[i].ID)
-			// }
-		}
-		desc.DependedOnBy = append(desc.DependedOnBy, ref)
-		b.backrefs[scan.desc.ID] = desc
-	}
-	return true
-}
-
-func populateViewBackrefFromViewDesc(
-	dependency *sqlbase.TableDescriptor,
-	tbl *sqlbase.TableDescriptor,
-	backrefs map[sqlbase.ID]sqlbase.TableDescriptor,
-) {
-	desc, ok := backrefs[dependency.ID]
-	if !ok {
-		desc = *dependency
-	}
-	ref := sqlbase.TableDescriptor_Reference{ID: tbl.ID}
-	desc.DependedOnBy = append(desc.DependedOnBy, ref)
-	backrefs[desc.ID] = desc
 }
 
 // planContainsStar returns true if one of the render nodes in the

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -124,10 +124,6 @@ type dataSourceInfo struct {
 	// column but might be different if the statement renames
 	// them using AS.
 	sourceAliases sourceAliases
-
-	// viewDesc is nothing more than an annotation used to indicate that the
-	// columns are defined as part of a view.
-	viewDesc *sqlbase.TableDescriptor
 }
 
 // planDataSource contains the data source information for data
@@ -546,7 +542,7 @@ func (p *planner) getTableDesc(
 		// specified time, and never lease anything. The proto transaction already
 		// has its timestamps set correctly so getTableOrViewDesc will fetch with
 		// the correct timestamp.
-		return mustGetTableOrViewDesc(
+		return MustGetTableOrViewDesc(
 			ctx, p.txn, p.getVirtualTabler(), tn, false /*allowAdding*/)
 	}
 	return p.session.tables.getTableVersion(ctx, p.txn, p.getVirtualTabler(), tn)
@@ -611,15 +607,27 @@ func (p *planner) getViewPlan(
 		defer func() { p.skipSelectPrivilegeChecks = false }()
 	}
 
+	// Register the dependency to the planner, if requested.
+	if p.planDeps != nil {
+		usedColumns := make([]sqlbase.ColumnID, len(desc.Columns))
+		for i := range desc.Columns {
+			usedColumns[i] = desc.Columns[i].ID
+		}
+		deps := p.planDeps[desc.ID]
+		deps.desc = desc
+		deps.deps = append(deps.deps, sqlbase.TableDescriptor_Reference{ColumnIDs: usedColumns})
+		p.planDeps[desc.ID] = deps
+
+		// We are only interested in the dependency to this view descriptor. Any
+		// further dependency by the view's query should not be tracked in this planner.
+		defer func(prev planDependencies) { p.planDeps = prev }(p.planDeps)
+		p.planDeps = nil
+	}
+
 	// TODO(a-robinson): Support ORDER BY and LIMIT in views. Is it as simple as
 	// just passing the entire select here or will inserting an ORDER BY in the
 	// middle of a query plan break things?
-	plan, err := p.getSubqueryPlan(ctx, *tn, sel.Select, sqlbase.ResultColumnsFromColDescs(desc.Columns))
-	if err != nil {
-		return plan, err
-	}
-	plan.info.viewDesc = desc
-	return plan, nil
+	return p.getSubqueryPlan(ctx, *tn, sel.Select, sqlbase.ResultColumnsFromColDescs(desc.Columns))
 }
 
 // getSubqueryPlan builds a planDataSource for a select statement, including

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -282,7 +282,7 @@ func getDescriptorsFromTargetList(
 			return nil, err
 		}
 		for i := range tables {
-			descriptor, err := mustGetTableOrViewDesc(
+			descriptor, err := MustGetTableOrViewDesc(
 				ctx, txn, vt, &tables[i], true /*allowAdding*/)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -234,7 +234,7 @@ func (p *planner) DropIndex(ctx context.Context, n *parser.DropIndex) (planNode,
 			return nil, err
 		}
 
-		tableDesc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
+		tableDesc, err := MustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -456,6 +456,11 @@ func (e *Executor) Start(
 	startupSession.Finish(e)
 }
 
+// GetVirtualTabler retrieves the VirtualTabler reference for this executor.
+func (e *Executor) GetVirtualTabler() VirtualTabler {
+	return &e.virtualSchemas
+}
+
 // SetDistSQLSpanResolver changes the SpanResolver used for DistSQL. It is the
 // caller's responsibility to make sure no queries are being run with DistSQL at
 // the same time.

--- a/pkg/sql/filter_opt.go
+++ b/pkg/sql/filter_opt.go
@@ -263,11 +263,6 @@ func (p *planner) propagateFilters(
 			}
 		}
 
-	case *createViewNode:
-		if n.sourcePlan, err = p.triggerFilterPropagation(ctx, n.sourcePlan); err != nil {
-			return plan, extraFilter, err
-		}
-
 	case *deleteNode:
 		if n.run.rows, err = p.triggerFilterPropagation(ctx, n.run.rows); err != nil {
 			return plan, extraFilter, err
@@ -323,6 +318,7 @@ func (p *planner) propagateFilters(
 	case *createDatabaseNode:
 	case *createIndexNode:
 	case *createUserNode:
+	case *createViewNode:
 	case *dropDatabaseNode:
 	case *dropIndexNode:
 	case *dropTableNode:

--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -147,8 +147,6 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 		if n.sourcePlan != nil {
 			applyLimit(n.sourcePlan, numRows, soft)
 		}
-	case *createViewNode:
-		setUnlimited(n.sourcePlan)
 	case *explainDistSQLNode:
 		setUnlimited(n.plan)
 	case *traceNode:
@@ -171,6 +169,7 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 	case *createDatabaseNode:
 	case *createIndexNode:
 	case *createUserNode:
+	case *createViewNode:
 	case *dropDatabaseNode:
 	case *dropIndexNode:
 	case *dropTableNode:

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -128,10 +128,10 @@ SELECT * FROM crdb_internal.builtin_functions WHERE function = ''
 ----
 function  signature  category  details
 
-query ITITTTTT colnames
+query ITITTTT colnames
 SELECT * FROM crdb_internal.create_statements WHERE database_name = ''
 ----
-database_id  database_name  descriptor_id  descriptor_type  descriptor_name  create_statement  dependencies  state
+database_id  database_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state
 
 query ITITTBTB colnames
 SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -69,9 +69,95 @@ Version
 
 # The validity of the rows in this table are tested elsewhere; we merely assert the columns.
 query ITTTTTTTTTRT colnames
-SELECT * FROM crdb_internal.jobs
+SELECT * FROM crdb_internal.jobs WHERE false
 ----
 id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error
+
+query IITTITTT colnames
+SELECT * FROM crdb_internal.schema_changes WHERE table_id < 0
+----
+table_id  parent_id  name  type  target_id  target_name  state  direction
+
+query IITITB colnames
+SELECT * FROM crdb_internal.leases WHERE node_id < 0
+----
+node_id  table_id  name  parent_id  expiration  deleted
+
+query ITTTTIIITFFFFFFFFFFFF colnames
+SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
+----
+node_id  application_name  flags  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var
+
+query IIITTTT colnames
+SELECT * FROM crdb_internal.session_trace WHERE txn_idx < 0
+----
+txn_idx  span_idx  message_idx  timestamp  duration  operation  message
+
+query TTTT colnames
+SELECT * FROM crdb_internal.cluster_settings WHERE name = ''
+----
+name  current_value  type  description
+
+query TT colnames
+SELECT * FROM crdb_internal.session_variables WHERE variable = ''
+----
+variable                       value
+
+query TITTTTTBT colnames
+SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
+----
+query_id  node_id  username  start  query  client_address  application_name  distributed  phase
+
+query TITTTTTBT colnames
+SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
+----
+query_id  node_id  username  start  query  client_address  application_name  distributed  phase
+
+query ITTTTTTT colnames
+SELECT * FROM crdb_internal.node_sessions WHERE node_id < 0
+----
+node_id  username  client_address  application_name  active_queries  session_start  oldest_query_start  kv_txn
+
+query ITTTTTTT colnames
+SELECT * FROM crdb_internal.cluster_sessions WHERE node_id < 0
+----
+node_id  username  client_address  application_name  active_queries  session_start  oldest_query_start  kv_txn
+
+query TTTT colnames
+SELECT * FROM crdb_internal.builtin_functions WHERE function = ''
+----
+function  signature  category  details
+
+query ITITTTTT colnames
+SELECT * FROM crdb_internal.create_statements WHERE database_name = ''
+----
+database_id  database_name  descriptor_id  descriptor_type  descriptor_name  create_statement  dependencies  state
+
+query ITITTBTB colnames
+SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
+----
+descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
+
+query ITITTB colnames
+SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
+----
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique
+
+query ITITTITT colnames
+SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''
+----
+descriptor_id  descriptor_name  index_id  index_name  column_type  column_id  column_name  column_direction
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name = ''
+----
+descriptor_id  descriptor_name  index_id  dependson_id  dependson_type  dependson_index_id  dependson_name  dependson_details
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name = ''
+----
+descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
+
 
 query error pq: foo
 SELECT crdb_internal.force_error('', 'foo')

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -30,7 +30,7 @@ descriptor_id  descriptor_name  column_id  column_name  column_type             
 56             test_kvi2        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
 56             test_kvi2        2          v            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
 57             test_v1          1          v            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
-58             test_v2          1          v            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+59             test_v2          1          v            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
 
 query ITITTB colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id
@@ -49,7 +49,7 @@ descriptor_id  descriptor_name  index_id  index_name       index_type  is_unique
 56             test_kvi2        1         primary          primary     true
 56             test_kvi2        2         test_kvi2_idx    secondary   true
 57             test_v1          0         ·                primary     false
-58             test_v2          0         ·                primary     false
+59             test_v2          0         ·                primary     false
 
 query ITITTITT colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, column_type, column_id
@@ -86,7 +86,7 @@ descriptor_id  descriptor_name  index_id  dependson_id  dependson_type  dependso
 55             test_kvi1        1         51            interleave      1                   NULL              SharedPrefixLen: 1
 56             test_kvi2        2         51            interleave      1                   NULL              SharedPrefixLen: 1
 57             test_v1          NULL      51            view            NULL                NULL              NULL
-58             test_v2          NULL      57            view            NULL                NULL              NULL
+59             test_v2          NULL      57            view            NULL                NULL              NULL
 
 query ITIITITT colnames
 SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
@@ -98,24 +98,21 @@ descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  de
 51             test_kv          1         55               interleave         1                      NULL               SharedPrefixLen: 0
 51             test_kv          1         56               interleave         2                      NULL               SharedPrefixLen: 0
 51             test_kv          2         54               fk                 2                      ·                  SharedPrefixLen: 0
-57             test_v1          NULL      58               view               0                      NULL               Columns: []
+57             test_v1          NULL      59               view               0                      NULL               Columns: [1]
 
-# TODO(knz): in the output from the last statement above we can see
-# that the Columns[] field for the forward dependency in test_v1 is
-# broken. Fix it.
-
-# Demonstrates views are broken #17306.
-# TODO(knz): Fix this.
+# Checks view dependencies (#17306)
 statement ok
-CREATE TABLE broken_t(k INT, v INT);
-  CREATE VIEW broken_v AS SELECT v FROM broken_t WHERE FALSE
+CREATE TABLE moretest_t(k INT, v INT);
+  CREATE VIEW moretest_v AS SELECT v FROM moretest_t WHERE FALSE
 
 query ITIITITT colnames
-SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'broken_%' ORDER BY descriptor_id, index_id, dependson_type, dependson_id, dependson_index_id
+SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'moretest_%' ORDER BY descriptor_id, index_id, dependson_type, dependson_id, dependson_index_id
 ----
-descriptor_id  descriptor_name  index_id  dependson_id  dependson_type  dependson_index_id  dependson_name    dependson_details
+descriptor_id  descriptor_name  index_id  dependson_id  dependson_type  dependson_index_id  dependson_name  dependson_details
+62             moretest_v       NULL      60            view            NULL                NULL            NULL
 
 query ITIITITT colnames
-SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'broken_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
+SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'moretest_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
 ----
 descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
+60             moretest_t       NULL      62               view               0                      NULL               Columns: [1 2 3]

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -1,0 +1,121 @@
+statement ok
+CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
+  CREATE UNIQUE INDEX test_v_idx ON test_kv(v);
+  CREATE INDEX test_v_idx2 ON test_kv(v DESC) STORING(k);
+  CREATE INDEX test_v_idx3 ON test_kv(w) STORING(v);
+  CREATE TABLE test_kvr1(k INT PRIMARY KEY REFERENCES test_kv(k));
+  CREATE TABLE test_kvr2(k INT, v INT UNIQUE REFERENCES test_kv(k));
+  CREATE TABLE test_kvr3(k INT, v INT UNIQUE REFERENCES test_kv(v));
+  CREATE TABLE test_kvi1(k INT PRIMARY KEY) INTERLEAVE IN PARENT test_kv(k);
+  CREATE TABLE test_kvi2(k INT PRIMARY KEY, v INT);
+  CREATE UNIQUE INDEX test_kvi2_idx ON test_kvi2(v) INTERLEAVE IN PARENT test_kv(v);
+  CREATE VIEW test_v1 AS SELECT v FROM test_kv;
+  CREATE VIEW test_v2 AS SELECT v FROM test_v1;
+
+query ITITTBTB colnames
+SELECT * FROM crdb_internal.table_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, column_id
+----
+descriptor_id  descriptor_name  column_id  column_name  column_type                                                   nullable  default_expr    hidden
+51             test_kv          1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+51             test_kv          2          v            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+51             test_kv          3          w            semantic_type:DECIMAL width:0 precision:0 visible_type:NONE   true      NULL            false
+52             test_kvr1        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+53             test_kvr2        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+53             test_kvr2        2          v            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+53             test_kvr2        3          rowid        semantic_type:INT width:0 precision:0 visible_type:NONE       false     unique_rowid()  true
+54             test_kvr3        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+54             test_kvr3        2          v            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+54             test_kvr3        3          rowid        semantic_type:INT width:0 precision:0 visible_type:NONE       false     unique_rowid()  true
+55             test_kvi1        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+56             test_kvi2        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+56             test_kvi2        2          v            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+57             test_v1          1          v            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+58             test_v2          1          v            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+
+query ITITTB colnames
+SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id
+----
+descriptor_id  descriptor_name  index_id  index_name       index_type  is_unique
+51             test_kv          1         primary          primary     true
+51             test_kv          2         test_v_idx       secondary   true
+51             test_kv          3         test_v_idx2      secondary   false
+51             test_kv          4         test_v_idx3      secondary   false
+52             test_kvr1        1         primary          primary     true
+53             test_kvr2        1         primary          primary     true
+53             test_kvr2        2         test_kvr2_v_key  secondary   true
+54             test_kvr3        1         primary          primary     true
+54             test_kvr3        2         test_kvr3_v_key  secondary   true
+55             test_kvi1        1         primary          primary     true
+56             test_kvi2        1         primary          primary     true
+56             test_kvi2        2         test_kvi2_idx    secondary   true
+57             test_v1          0         ·                primary     false
+58             test_v2          0         ·                primary     false
+
+query ITITTITT colnames
+SELECT * FROM crdb_internal.index_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, column_type, column_id
+----
+descriptor_id  descriptor_name  index_id  index_name       column_type  column_id  column_name  column_direction
+51             test_kv          1         primary          key          1          k            ASC
+51             test_kv          2         test_v_idx       extra        1          NULL         NULL
+51             test_kv          2         test_v_idx       key          2          v            ASC
+51             test_kv          3         test_v_idx2      extra        1          NULL         NULL
+51             test_kv          3         test_v_idx2      key          2          v            DESC
+51             test_kv          4         test_v_idx3      composite    3          NULL         NULL
+51             test_kv          4         test_v_idx3      extra        1          NULL         NULL
+51             test_kv          4         test_v_idx3      key          3          w            ASC
+51             test_kv          4         test_v_idx3      storing      2          NULL         NULL
+52             test_kvr1        1         primary          key          1          k            ASC
+53             test_kvr2        1         primary          key          3          rowid        ASC
+53             test_kvr2        2         test_kvr2_v_key  extra        3          NULL         NULL
+53             test_kvr2        2         test_kvr2_v_key  key          2          v            ASC
+54             test_kvr3        1         primary          key          3          rowid        ASC
+54             test_kvr3        2         test_kvr3_v_key  extra        3          NULL         NULL
+54             test_kvr3        2         test_kvr3_v_key  key          2          v            ASC
+55             test_kvi1        1         primary          key          1          k            ASC
+56             test_kvi2        1         primary          key          1          k            ASC
+56             test_kvi2        2         test_kvi2_idx    extra        1          NULL         NULL
+56             test_kvi2        2         test_kvi2_idx    key          2          v            ASC
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, dependson_type, dependson_id, dependson_index_id
+----
+descriptor_id  descriptor_name  index_id  dependson_id  dependson_type  dependson_index_id  dependson_name    dependson_details
+52             test_kvr1        1         51            fk              1                   fk_k_ref_test_kv  SharedPrefixLen: 1
+53             test_kvr2        2         51            fk              1                   fk_v_ref_test_kv  SharedPrefixLen: 1
+54             test_kvr3        2         51            fk              2                   fk_v_ref_test_kv  SharedPrefixLen: 1
+55             test_kvi1        1         51            interleave      1                   NULL              SharedPrefixLen: 1
+56             test_kvi2        2         51            interleave      1                   NULL              SharedPrefixLen: 1
+57             test_v1          NULL      51            view            NULL                NULL              NULL
+58             test_v2          NULL      57            view            NULL                NULL              NULL
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
+----
+descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
+51             test_kv          NULL      57               view               0                      NULL               Columns: [1 2 3]
+51             test_kv          1         52               fk                 1                      ·                  SharedPrefixLen: 0
+51             test_kv          1         53               fk                 2                      ·                  SharedPrefixLen: 0
+51             test_kv          1         55               interleave         1                      NULL               SharedPrefixLen: 0
+51             test_kv          1         56               interleave         2                      NULL               SharedPrefixLen: 0
+51             test_kv          2         54               fk                 2                      ·                  SharedPrefixLen: 0
+57             test_v1          NULL      58               view               0                      NULL               Columns: []
+
+# TODO(knz): in the output from the last statement above we can see
+# that the Columns[] field for the forward dependency in test_v1 is
+# broken. Fix it.
+
+# Demonstrates views are broken #17306.
+# TODO(knz): Fix this.
+statement ok
+CREATE TABLE broken_t(k INT, v INT);
+  CREATE VIEW broken_v AS SELECT v FROM broken_t WHERE FALSE
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'broken_%' ORDER BY descriptor_id, index_id, dependson_type, dependson_id, dependson_index_id
+----
+descriptor_id  descriptor_name  index_id  dependson_id  dependson_type  dependson_index_id  dependson_name    dependson_details
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'broken_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
+----
+descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -136,7 +136,7 @@ EXPLAIN SHOW TABLES
 1  render  ·      ·
 2  filter  ·      ·
 3  values  ·      ·
-3  ·       size   5 columns, 61 rows
+3  ·       size   5 columns, 66 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -192,7 +192,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·
-7  ·       size      13 columns, 517 rows
+7  ·       size      13 columns, 556 rows
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -192,7 +192,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·
-7  ·       size      13 columns, 556 rows
+7  ·       size      13 columns, 555 rows
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -204,11 +204,14 @@ DROP DATABASE other_db
 query TT
 select table_schema, table_name FROM information_schema.tables ORDER BY 1, 2
 ----
+crdb_internal       backward_dependencies
 crdb_internal       builtin_functions
 crdb_internal       cluster_queries
 crdb_internal       cluster_sessions
 crdb_internal       cluster_settings
 crdb_internal       create_statements
+crdb_internal       forward_dependencies
+crdb_internal       index_columns
 crdb_internal       jobs
 crdb_internal       leases
 crdb_internal       node_build_info
@@ -218,6 +221,8 @@ crdb_internal       node_statement_statistics
 crdb_internal       schema_changes
 crdb_internal       session_trace
 crdb_internal       session_variables
+crdb_internal       table_columns
+crdb_internal       table_indexes
 crdb_internal       tables
 information_schema  columns
 information_schema  key_column_usage
@@ -339,18 +344,23 @@ ui
 tables
 tables
 table_privileges
+table_indexes
 table_constraints
+table_columns
 
 # Check that the metadata is reported properly.
 query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
 table_catalog  table_schema        table_name                 table_type   version
+def            crdb_internal       backward_dependencies      SYSTEM VIEW  1
 def            crdb_internal       builtin_functions          SYSTEM VIEW  1
 def            crdb_internal       cluster_queries            SYSTEM VIEW  1
 def            crdb_internal       cluster_sessions           SYSTEM VIEW  1
 def            crdb_internal       cluster_settings           SYSTEM VIEW  1
 def            crdb_internal       create_statements          SYSTEM VIEW  1
+def            crdb_internal       forward_dependencies       SYSTEM VIEW  1
+def            crdb_internal       index_columns              SYSTEM VIEW  1
 def            crdb_internal       jobs                       SYSTEM VIEW  1
 def            crdb_internal       leases                     SYSTEM VIEW  1
 def            crdb_internal       node_build_info            SYSTEM VIEW  1
@@ -360,6 +370,8 @@ def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
 def            crdb_internal       schema_changes             SYSTEM VIEW  1
 def            crdb_internal       session_trace              SYSTEM VIEW  1
 def            crdb_internal       session_variables          SYSTEM VIEW  1
+def            crdb_internal       table_columns              SYSTEM VIEW  1
+def            crdb_internal       table_indexes              SYSTEM VIEW  1
 def            crdb_internal       tables                     SYSTEM VIEW  1
 def            information_schema  columns                    SYSTEM VIEW  1
 def            information_schema  key_column_usage           SYSTEM VIEW  1

--- a/pkg/sql/needed_columns.go
+++ b/pkg/sql/needed_columns.go
@@ -30,9 +30,6 @@ func setNeededColumns(plan planNode, needed []bool) {
 			setNeededColumns(n.sourcePlan, allColumns(n.sourcePlan))
 		}
 
-	case *createViewNode:
-		setNeededColumns(n.sourcePlan, allColumns(n.sourcePlan))
-
 	case *explainDistSQLNode:
 		setNeededColumns(n.plan, allColumns(n.plan))
 
@@ -192,6 +189,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *createDatabaseNode:
 	case *createIndexNode:
 	case *createUserNode:
+	case *createViewNode:
 	case *dropDatabaseNode:
 	case *dropIndexNode:
 	case *dropTableNode:

--- a/pkg/sql/rename.go
+++ b/pkg/sql/rename.go
@@ -260,7 +260,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *parser.RenameIndex) (planN
 		return nil, err
 	}
 
-	tableDesc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
+	tableDesc, err := MustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -201,7 +201,8 @@ func (sc *SchemaChanger) ExtendLease(
 	return nil
 }
 
-func dropTableName(
+// DropTableName removes a mapping from name to ID from the KV database.
+func DropTableName(
 	ctx context.Context, tableDesc *sqlbase.TableDescriptor, db *client.DB, traceKV bool,
 ) error {
 	_, nameKey, _ := GetKeysForTableDescriptor(tableDesc)
@@ -227,7 +228,8 @@ func dropTableName(
 	})
 }
 
-func dropTableDesc(
+// DropTableDesc removes a descriptor from the KV database.
+func DropTableDesc(
 	ctx context.Context, tableDesc *sqlbase.TableDescriptor, db *client.DB, traceKV bool,
 ) error {
 	zoneKey, _, descKey := GetKeysForTableDescriptor(tableDesc)
@@ -269,7 +271,7 @@ func (sc *SchemaChanger) maybeAddDropRename(
 			return false, err
 		}
 
-		if err := dropTableName(ctx, table /* false */, &sc.db, false /* traceKV */); err != nil {
+		if err := DropTableName(ctx, table /* false */, &sc.db, false /* traceKV */); err != nil {
 			return false, err
 		}
 
@@ -282,7 +284,7 @@ func (sc *SchemaChanger) maybeAddDropRename(
 			return false, err
 		}
 
-		return true, dropTableDesc(ctx, table, &sc.db, false /* traceKV */)
+		return true, DropTableDesc(ctx, table, &sc.db, false /* traceKV */)
 	}
 
 	if table.Adding() {

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -40,7 +40,7 @@ func checkDBExists(ctx context.Context, p *planner, db string) error {
 
 // checkTableExists checks if the table exists by using the security.RootUser.
 func checkTableExists(ctx context.Context, p *planner, tn *parser.TableName) error {
-	if _, err := mustGetTableOrViewDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/); err != nil {
+	if _, err := MustGetTableOrViewDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/); err != nil {
 		return sqlbase.NewUndefinedRelationError(tn)
 	}
 	return nil
@@ -207,7 +207,7 @@ func (p *planner) showTableDetails(
 		if err := checkDBExists(ctx, p, db); err != nil {
 			return err
 		}
-		desc, err := mustGetTableOrViewDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /* allowAdding */)
+		desc, err := MustGetTableOrViewDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /* allowAdding */)
 		if err != nil {
 			return err
 		}
@@ -515,7 +515,7 @@ func (p *planner) ShowConstraints(
 		return nil, err
 	}
 
-	desc, err := mustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
+	desc, err := MustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)
 	if err != nil {
 		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -67,7 +67,7 @@ func (p *planner) ShowFingerprints(
 		txn.SetFixedTimestamp(ts)
 
 		var err error
-		tableDesc, err = mustGetTableDesc(
+		tableDesc, err = MustGetTableDesc(
 			ctx, txn, p.getVirtualTabler(), tn, false /*allowAdding*/)
 		return err
 	}); err != nil {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -161,10 +161,10 @@ func getViewDesc(
 	return desc, nil
 }
 
-// mustGetTableOrViewDesc returns a table descriptor for either a table or
+// MustGetTableOrViewDesc returns a table descriptor for either a table or
 // view, or an error if the descriptor is not found. allowAdding when set allows
 // a table descriptor in the ADD state to also be returned.
-func mustGetTableOrViewDesc(
+func MustGetTableOrViewDesc(
 	ctx context.Context, txn *client.Txn, vt VirtualTabler, tn *parser.TableName, allowAdding bool,
 ) (*sqlbase.TableDescriptor, error) {
 	desc, err := getTableOrViewDesc(ctx, txn, vt, tn)
@@ -182,10 +182,10 @@ func mustGetTableOrViewDesc(
 	return desc, nil
 }
 
-// mustGetTableDesc returns a table descriptor for a table, or an error if
+// MustGetTableDesc returns a table descriptor for a table, or an error if
 // the descriptor is not found. allowAdding when set allows a table descriptor
 // in the ADD state to also be returned.
-func mustGetTableDesc(
+func MustGetTableDesc(
 	ctx context.Context, txn *client.Txn, vt VirtualTabler, tn *parser.TableName, allowAdding bool,
 ) (*sqlbase.TableDescriptor, error) {
 	desc, err := getTableDesc(ctx, txn, vt, tn)
@@ -304,7 +304,7 @@ func (tc *TableCollection) getTableVersion(
 		//   so they cannot be leased. Instead, we simply return the static
 		//   descriptor and rely on the immutability privileges set on the
 		//   descriptors to cause upper layers to reject mutations statements.
-		tbl, err := mustGetTableDesc(ctx, txn, vt, tn, false /*allowAdding*/)
+		tbl, err := MustGetTableDesc(ctx, txn, vt, tn, false /*allowAdding*/)
 		if err != nil {
 			return nil, err
 		}
@@ -739,7 +739,7 @@ func (p *planner) findTableContainingIndex(
 	result = nil
 	for i := range tns {
 		tn := &tns[i]
-		tableDesc, err := mustGetTableDesc(
+		tableDesc, err := MustGetTableDesc(
 			ctx, p.txn, p.getVirtualTabler(), tn, true, /*allowAdding*/
 		)
 		if err != nil {
@@ -833,4 +833,24 @@ func (p *planner) getTableAndIndex(
 		index = idx
 	}
 	return tableDesc, &index, nil
+}
+
+// resolveTableNameFromID computes a table name suitable for logging
+// from the table ID and the ID-to-desc mappings.
+func resolveTableNameFromID(
+	ctx context.Context,
+	tableID sqlbase.ID,
+	tables map[sqlbase.ID]*sqlbase.TableDescriptor,
+	databases map[sqlbase.ID]*sqlbase.DatabaseDescriptor,
+) string {
+	table := tables[tableID]
+	tn := parser.TableName{TableName: parser.Name(table.Name)}
+	if parentDB, ok := databases[table.ParentID]; ok {
+		tn.DatabaseName = parser.Name(parentDB.Name)
+	} else {
+		tn.DatabaseName = parser.Name(fmt.Sprintf("[%d]", table.ParentID))
+		log.Errorf(ctx, "relation [%d] (%q) has no parent database (corrupted schema?)",
+			tableID, parser.ErrString(&tn))
+	}
+	return parser.ErrString(&tn)
 }

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -51,7 +51,7 @@ func (p *planner) Truncate(ctx context.Context, n *parser.Truncate) (planNode, e
 			return nil, err
 		}
 
-		tableDesc, err := mustGetTableOrViewDesc(
+		tableDesc, err := MustGetTableOrViewDesc(
 			ctx, p.txn, p.getVirtualTabler(), tn, true, /* allowAdding */
 		)
 		if err != nil {

--- a/pkg/sql/views.go
+++ b/pkg/sql/views.go
@@ -1,0 +1,264 @@
+// Copyright 2015 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"bytes"
+	"fmt"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// planDependencyInfo collects the dependencies related to a single
+// table -- which index and columns are being depended upon.
+type planDependencyInfo struct {
+	// desc is a reference to the descriptor for the table being
+	// depended on.
+	desc *sqlbase.TableDescriptor
+	// deps is the list of ways in which the current plan depends on
+	// that table. There can be more than one entries when the same
+	// table is used in different places. The entries can also be
+	// different because some may reference an index and others may
+	// reference only a subset of the table's columns.
+	// Note: the "ID" field of TableDescriptor_Reference is not
+	// (and cannot be) filled during plan construction / dependency
+	// analysis because the descriptor that is using this dependency
+	// has not been constructed yet.
+	deps []sqlbase.TableDescriptor_Reference
+}
+
+// planDependencies maps the ID of a table depended upon to a list of
+// detailed dependencies on that table.
+type planDependencies map[sqlbase.ID]planDependencyInfo
+
+// String implements the fmt.Stringer interface.
+func (d planDependencies) String() string {
+	var buf bytes.Buffer
+	for id, deps := range d {
+		fmt.Fprintf(&buf, "%d (%q):", id, parser.ErrString(parser.Name(deps.desc.Name)))
+		for _, dep := range deps.deps {
+			buf.WriteString(" [")
+			if dep.IndexID != 0 {
+				fmt.Fprintf(&buf, "idx: %d ", dep.IndexID)
+			}
+			fmt.Fprintf(&buf, "cols: %v]", dep.ColumnIDs)
+		}
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}
+
+// analyzeViewQuery extracts the set of dependencies (tables and views
+// that this view's query depends on), together with the more detailed
+// information about which indexes and columns are needed from each
+// dependency. The set of columns from the view query's results is
+// also returned.
+func (p *planner) analyzeViewQuery(
+	ctx context.Context, viewSelect *parser.Select,
+) (planDependencies, sqlbase.ResultColumns, error) {
+	// To avoid races with ongoing schema changes to tables that the view
+	// depends on, make sure we use the most recent versions of table
+	// descriptors rather than the copies in the lease cache.
+	defer func(prev bool) { p.avoidCachedDescriptors = prev }(p.avoidCachedDescriptors)
+	p.avoidCachedDescriptors = true
+
+	// Request dependency tracking.
+	defer func(prev planDependencies) { p.planDeps = prev }(p.planDeps)
+	p.planDeps = make(planDependencies)
+
+	// Now generate the source plan.
+	sourcePlan, err := p.Select(ctx, viewSelect, []parser.Type{})
+	if err != nil {
+		return nil, nil, err
+	}
+	// The plan will not be needed further.
+	defer sourcePlan.Close(ctx)
+
+	// TODO(a-robinson): Support star expressions as soon as we can (#10028).
+	if p.planContainsStar(ctx, sourcePlan) {
+		return nil, nil, fmt.Errorf("views do not currently support * expressions")
+	}
+
+	return p.planDeps, planColumns(sourcePlan), nil
+}
+
+// RecomputeViewDependencies does the work of CREATE VIEW w.r.t.
+// dependencies over again. Used by a migration to fix existing
+// view descriptors created prior to fixing #17269 and #17306;
+// it may also be used by a future "fsck" utility.
+func RecomputeViewDependencies(ctx context.Context, txn *client.Txn, e *Executor) error {
+	lm := e.cfg.LeaseManager
+	// We run as NodeUser because we may update system descriptors.
+	p := makeInternalPlanner("recompute-view-dependencies", txn, security.NodeUser, lm.memMetrics)
+	defer finishInternalPlanner(p)
+	p.session.tables.leaseMgr = lm
+
+	log.VEventf(ctx, 2, "recomputing view dependencies")
+
+	// The transaction may modify some system tables (e.g. if a view
+	// uses one). Ensure the transaction is anchored to the system
+	// range.
+	if err := txn.SetSystemConfigTrigger(); err != nil {
+		return err
+	}
+
+	// We set "avoidCachedDescriptors" so that the plan constructions
+	// below are forced to read the descriptors within the
+	// transaction. This is necessary to ensure that the descriptors are
+	// read and written within the same transaction, so that the update
+	// appears transactional.
+	p.avoidCachedDescriptors = true
+
+	// Collect all the descriptors.
+	databases := make(map[sqlbase.ID]*sqlbase.DatabaseDescriptor)
+	tables := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
+	descs, err := getAllDescriptors(ctx, p.txn)
+	if err != nil {
+		return err
+	}
+	for _, desc := range descs {
+		if db, ok := desc.(*sqlbase.DatabaseDescriptor); ok {
+			databases[db.ID] = db
+		} else if table, ok := desc.(*sqlbase.TableDescriptor); ok {
+			tables[table.ID] = table
+		}
+	}
+
+	// For each view, analyze the dependencies again.
+	allViewDeps := make(map[sqlbase.ID]planDependencies)
+	for tableID, table := range tables {
+		if !table.IsView() || table.Dropped() {
+			continue
+		}
+
+		tn := resolveTableNameFromID(ctx, tableID, tables, databases)
+
+		// Is the view query valid?
+		stmt, err := parser.ParseOne(table.ViewQuery)
+		if err != nil {
+			log.Errorf(ctx, "view [%d] (%q) has broken query %q: %v",
+				tableID, tn, table.ViewQuery, err)
+			continue
+		}
+
+		// Request dependency tracking and generate the source plan
+		// to collect the dependencies.
+		p.planDeps = make(planDependencies)
+		sourcePlan, err := p.newPlan(ctx, stmt, []parser.Type{})
+		if err != nil {
+			log.Errorf(ctx, "view [%d] (%q) has broken query %q: %v",
+				tableID, tn, table.ViewQuery, err)
+			continue
+		}
+		// The plan is not used further, throw it away.
+		sourcePlan.Close(ctx)
+
+		log.VEventf(ctx, 1, "collected dependencies for view [%d] (%q):\n%s",
+			tableID, tn, p.planDeps.String())
+		allViewDeps[tableID] = p.planDeps
+	}
+
+	affected := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
+
+	// Clear all the backward dependencies.
+	for tableID, table := range tables {
+		if len(table.DependedOnBy) > 0 {
+			table.DependedOnBy = nil
+			affected[tableID] = table
+		}
+	}
+
+	// Now re-build the dependencies.
+	for viewID, viewDeps := range allViewDeps {
+		viewDesc := tables[viewID]
+
+		// Register the backward dependencies from the view to the tables
+		// it depends on.
+		viewDesc.DependsOn = make([]sqlbase.ID, 0, len(viewDeps))
+		for backrefID := range viewDeps {
+			viewDesc.DependsOn = append(viewDesc.DependsOn, backrefID)
+		}
+
+		// Register the forward dependencies from the tables depended on
+		// to the view.
+		for backrefID, updated := range viewDeps {
+			backrefDesc := tables[backrefID]
+			for _, dep := range updated.deps {
+				// The logical plan constructor merely registered the dependencies.
+				// It did not populate the "ID" field of TableDescriptor_Reference.
+				// We need to do it here.
+				dep.ID = viewID
+				backrefDesc.DependedOnBy = append(backrefDesc.DependedOnBy, dep)
+			}
+			affected[backrefID] = backrefDesc
+		}
+
+		affected[viewID] = viewDesc
+	}
+
+	// Now persist all the changes.
+	for _, updated := range affected {
+		// First log the changes being made.
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "relation [%d] (%q):",
+			updated.ID, resolveTableNameFromID(ctx, updated.ID, tables, databases))
+		if len(updated.DependsOn) == 0 && len(updated.DependedOnBy) == 0 {
+			buf.WriteString(" (no dependency links)")
+		} else {
+			buf.WriteByte('\n')
+		}
+		// Log the backward dependencies.
+		if len(updated.DependsOn) > 0 {
+			buf.WriteString("uses:")
+			for _, depID := range updated.DependsOn {
+				fmt.Fprintf(&buf, " [%d] (%q)", depID, resolveTableNameFromID(ctx, depID, tables, databases))
+			}
+			buf.WriteByte('\n')
+		}
+		// Log the forward dependencies.
+		if len(updated.DependedOnBy) > 0 {
+			buf.WriteString("depended on by: ")
+			for i, dep := range updated.DependedOnBy {
+				if i > 0 {
+					buf.WriteString(", ")
+				}
+				fmt.Fprintf(&buf, "[%d] (%q): ",
+					dep.ID, resolveTableNameFromID(ctx, dep.ID, tables, databases))
+				if dep.IndexID != 0 {
+					fmt.Fprintf(&buf, "idx: %d ", dep.IndexID)
+				}
+				fmt.Fprintf(&buf, "cols: %v", dep.ColumnIDs)
+			}
+			buf.WriteByte('\n')
+		}
+		log.VEventf(ctx, 1, "updated deps: %s", buf.String())
+
+		// Then register the update.
+		if !updated.Dropped() {
+			updated.UpVersion = true
+		}
+		if err := p.writeTableDesc(ctx, updated); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -359,9 +359,8 @@ func (v *planVisitor) visit(plan planNode) {
 
 	case *createViewNode:
 		if v.observer.attr != nil {
-			v.observer.attr(name, "query", n.sourceQuery)
+			v.observer.attr(name, "query", parser.AsStringWithFlags(n.n.AsSource, parser.FmtParsable))
 		}
-		v.visit(n.sourcePlan)
 
 	case *delayedNode:
 		if v.observer.attr != nil {

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -68,6 +68,9 @@ type TestServerInterface interface {
 	// LeaseManager() returns the *sql.LeaseManager as an interface{}.
 	LeaseManager() interface{}
 
+	// Executor() returns the *sql.Executor as an interface{}.
+	Executor() interface{}
+
 	// Gossip returns the gossip used by the TestServer.
 	Gossip() *gossip.Gossip
 


### PR DESCRIPTION
Prior to this patch, view dependency analysis during CREATE VIEW was broken because it would only check dependencies after plan optimization, i.e. possibly after some dependency were lost. For example, with the queries:  

```sql
CREATE VIEW v AS SELECT k FROM (SELECT k,v FROM kv) -- loses dependency on kv.v 
CREATE VIEW v AS SELECT k,v FROM kv WHERE FALSE -- loses dependency on kv
 ```  

This patch addresses the issue as follows:  
- the dependencies are now collected during the initial construction   of the query plan, before any optimization are applied. This way we  ensure the dependency tracking is complete. 
- a migration is implemented that will fix any view descriptor and   corresponding dependency information that was populated prior to this fix.

Fixes #17306.
Fixes #17290.
Replaces 74c7b0fd20d3da721c0f2323fc09be480d3244ab (reverted via #17305)
Needed for #15388.