### PR TITLE
sql: fix remaining unhandled ORDER BY INDEX cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -143,3 +143,10 @@ SELECT k FROM (SELECT @1, @1 FROM generate_series(1,10)) AS kv(k,v) ORDER BY PRI
 
 statement error source name "kv" not found in FROM clause
 CREATE TABLE unrelated(x INT); SELECT * FROM unrelated ORDER BY PRIMARY KEY kv
+
+# Check that prepare doesn't crash on ORDER BY PK clauses #17312
+statement ok
+PREPARE a AS (TABLE kv) ORDER BY PRIMARY KEY kv
+
+statement error ORDER BY INDEX in window definition is not supported
+SELECT avg(k) OVER (ORDER BY PRIMARY KEY kv) FROM kv

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -397,6 +397,9 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired Type) (TypedExpr, erro
 			expr.WindowDef.Partitions[i] = typedPartition
 		}
 		for i, orderBy := range expr.WindowDef.OrderBy {
+			if orderBy.OrderType != OrderByColumn {
+				return nil, errors.New("ORDER BY INDEX in window definition is not supported")
+			}
 			typedOrderBy, err := orderBy.Expr.TypeCheck(ctx, TypeAny)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/parser/walk.go
+++ b/pkg/sql/parser/walk.go
@@ -209,7 +209,7 @@ func (expr *FuncExpr) CopyNode() *FuncExpr {
 		if len(windowDef.OrderBy) > 0 {
 			newOrderBy := make(OrderBy, len(windowDef.OrderBy))
 			for i, o := range windowDef.OrderBy {
-				newOrderBy[i] = &Order{Expr: o.Expr, Direction: o.Direction}
+				newOrderBy[i] = &Order{OrderType: o.OrderType, Expr: o.Expr, Direction: o.Direction}
 			}
 			windowDef.OrderBy = newOrderBy
 		}
@@ -240,6 +240,9 @@ func (expr *FuncExpr) Walk(v Visitor) Expr {
 			}
 		}
 		for i := range expr.WindowDef.OrderBy {
+			if expr.WindowDef.OrderBy[i].OrderType != OrderByColumn {
+				continue
+			}
 			e, changed := WalkExpr(v, expr.WindowDef.OrderBy[i].Expr)
 			if changed {
 				if ret == expr {
@@ -693,6 +696,9 @@ func (stmt *ReturningExprs) CopyNode() *ReturningExprs {
 func walkOrderBy(v Visitor, order OrderBy) (OrderBy, bool) {
 	copied := false
 	for i := range order {
+		if order[i].OrderType != OrderByColumn {
+			continue
+		}
 		e, changed := WalkExpr(v, order[i].Expr)
 		if changed {
 			if !copied {


### PR DESCRIPTION
Some code paths didn't check Order.OrderType properly, causing panics
due to unexpected nil Expr fields. This is now fixed.

Fixes #17312.