### PR TITLE
sql: support array append and equality

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -35,6 +35,11 @@ SELECT ARRAY['', 'NULL', 'Null', 'null', NULL, '"', e'\'']
 {"","NULL","Null","null",NULL,"\"","'"}
 
 query T
+SELECT NULL::INT[]
+----
+NULL
+
+query T
 SELECT ARRAY[e'\n', e'g\x10h']
 ----
 {"\n","g\x10h"}
@@ -576,3 +581,166 @@ DROP TABLE a
 # TODO(justin)
 statement error collated strings not allowed as array contents
 CREATE TABLE a (b STRING[] COLLATE en)
+
+# Array operators
+
+# Element append
+
+query T
+SELECT ARRAY['a','b','c'] || 'd'
+----
+{"a","b","c","d"}
+
+query T
+SELECT ARRAY[1,2,3] || 4
+----
+{1,2,3,4}
+
+query T
+SELECT NULL::INT[] || 4
+----
+{4}
+
+query T
+SELECT 4 || NULL::INT[]
+----
+{4}
+
+query T
+SELECT ARRAY[1,2,3] || NULL::INT
+----
+{1,2,3,NULL}
+
+query T
+SELECT NULL::INT[] || NULL::INT
+----
+{NULL}
+
+query T
+SELECT NULL::INT || ARRAY[1,2,3]
+----
+{NULL,1,2,3}
+
+query TT
+SELECT NULL::INT || NULL::INT[], NULL::INT[] || NULL::INT
+----
+{NULL} {NULL}
+
+query T
+SELECT 1 || ARRAY[2,3,4]
+----
+{1,2,3,4}
+
+# This is a departure from Postgres' behaviour.
+# In Postgres, ARRAY[1,2,3] || NULL = ARRAY[1,2,3].
+
+query T
+SELECT ARRAY[1,2,3] || NULL
+----
+{1,2,3}
+
+query T
+SELECT NULL || ARRAY[1,2,3]
+----
+{1,2,3}
+
+# This test is here because its typechecking is related to the above
+
+query TT
+SELECT NULL || 'asdf', 'asdf' || NULL
+----
+NULL NULL
+
+statement ok
+CREATE TABLE a (b INT[])
+
+# Ensure arrays appended to still encode properly.
+
+statement ok
+INSERT INTO a VALUES (ARRAY[])
+
+statement ok
+UPDATE a SET b = b || 1
+
+statement ok
+UPDATE a SET b = b || 2
+
+statement ok
+UPDATE a SET b = b || 3
+
+statement ok
+UPDATE a SET b = b || 4
+
+query T
+SELECT b FROM a
+----
+{1,2,3,4}
+
+statement ok
+UPDATE a SET b = NULL::INT || b || NULL::INT
+
+query T
+SELECT b FROM a
+----
+{NULL,1,2,3,4,NULL}
+
+# Array append
+
+query T
+SELECT ARRAY[1,2,3] || ARRAY[4,5,6]
+----
+{1,2,3,4,5,6}
+
+query T
+SELECT ARRAY['a','b','c'] || ARRAY['d','e','f']
+----
+{"a","b","c","d","e","f"}
+
+query T
+SELECT ARRAY[1,2,3] || NULL::INT[]
+----
+{1,2,3}
+
+query T
+SELECT NULL::INT[] || ARRAY[4,5,6]
+----
+{4,5,6}
+
+query T
+SELECT NULL::INT[] || NULL::INT[]
+----
+NULL
+
+# Array equality
+
+query B
+SELECT ARRAY[1,2,3] = ARRAY[1,2,3]
+----
+true
+
+query B
+SELECT ARRAY[1,2,4] = ARRAY[1,2,3]
+----
+false
+
+query B
+SELECT ARRAY[1,2,3] != ARRAY[1,2,3]
+----
+false
+
+query B
+SELECT ARRAY[1,2,4] != ARRAY[1,2,3]
+----
+true
+
+query B
+SELECT ARRAY[1,2,4] = NULL
+----
+NULL
+
+# This behaviour is surprising (one might expect that the result would be
+# NULL), but it's how Postgres behaves.
+query B
+SELECT ARRAY[1,2,NULL] = ARRAY[1,2,3]
+----
+false

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -1117,6 +1117,8 @@ func validCastTypes(t Type) []Type {
 		// directly to collated string.
 		if t.FamilyEqual(TypeCollatedString) {
 			return stringCastTypes
+		} else if t.FamilyEqual(TypeArray) {
+			return []Type{TypeNull}
 		}
 		return nil
 	}

--- a/pkg/sql/parser/normalize.go
+++ b/pkg/sql/parser/normalize.go
@@ -126,7 +126,7 @@ func (expr *BinaryExpr) normalize(v *normalizeVisitor) TypedExpr {
 	right := expr.TypedRight()
 	expectedType := expr.ResolvedType()
 
-	if left == DNull || right == DNull {
+	if !expr.fn.nullableArgs && (left == DNull || right == DNull) {
 		return DNull
 	}
 


### PR DESCRIPTION
This commit adds support for the array append operator (||) for both
elements and arrays, along with array equality testing.