### PR TITLE
distsql: buffer messages in routers

### DIFF
--- a/docs/RFCS/distsql_buffering_router.md
+++ b/docs/RFCS/distsql_buffering_router.md
@@ -1,5 +1,5 @@
 - Feature Name: distsql buffering hash router
-- Status: draft
+- Status: completed
 - Start Date: 2017-07-19
 - Authors: Radu
 - RFC PR: [#17105](https://github.com/cockroachdb/cockroach/pull/17105)

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -83,6 +83,8 @@ func GetAggregateInfo(
 // aggregator's output schema is comprised of what is specified by the
 // accompanying SELECT expressions.
 type aggregator struct {
+	processorBase
+
 	flowCtx     *FlowCtx
 	input       RowSource
 	funcs       []*aggregateFuncHolder
@@ -95,8 +97,6 @@ type aggregator struct {
 	aggregations []AggregatorSpec_Aggregation
 
 	buckets map[string]struct{} // The set of bucket keys.
-
-	out procOutputHelper
 }
 
 var _ processor = &aggregator{}

--- a/pkg/sql/distsqlrun/algebraic_set_op.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op.go
@@ -28,11 +28,12 @@ import (
 // algebraicSetOp is a processor for the algebraic set operations,
 // currently just EXCEPT ALL.
 type algebraicSetOp struct {
+	processorBase
+
 	leftSource, rightSource RowSource
 	opType                  AlgebraicSetOpSpec_SetOpType
 	ordering                Ordering
 	datumAlloc              *sqlbase.DatumAlloc
-	out                     procOutputHelper
 }
 
 var _ processor = &algebraicSetOp{}

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -63,6 +63,12 @@ type backfiller struct {
 	alloc   sqlbase.DatumAlloc
 }
 
+// OutputTypes is part of the processor interface.
+func (*backfiller) OutputTypes() []sqlbase.ColumnType {
+	// No output types.
+	return nil
+}
+
 // Run is part of the processor interface.
 func (b *backfiller) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -594,7 +594,7 @@ func (rb *RowBuffer) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 
 // ConsumerDone is part of the RowSource interface.
 func (rb *RowBuffer) ConsumerDone() {
-	rb.ConsumerStatus = DrainRequested
+	atomic.StoreUint32((*uint32)(&rb.ConsumerStatus), uint32(DrainRequested))
 	if rb.args.OnConsumerDone != nil {
 		rb.args.OnConsumerDone(rb)
 	}
@@ -602,7 +602,7 @@ func (rb *RowBuffer) ConsumerDone() {
 
 // ConsumerClosed is part of the RowSource interface.
 func (rb *RowBuffer) ConsumerClosed() {
-	rb.ConsumerStatus = ConsumerClosed
+	atomic.StoreUint32((*uint32)(&rb.ConsumerStatus), uint32(ConsumerClosed))
 	if rb.args.OnConsumerClosed != nil {
 		rb.args.OnConsumerClosed(rb)
 	}

--- a/pkg/sql/distsqlrun/cluster_test.go
+++ b/pkg/sql/distsqlrun/cluster_test.go
@@ -282,11 +282,9 @@ func ignoreMisplannedRanges(metas []ProducerMetadata) []ProducerMetadata {
 }
 
 // TestLimitedBufferingDeadlock sets up a scenario which leads to deadlock if
-// the hash router blocks whenever one of the consumers blocks (#17097).
+// a single consumer can block the entire router (#17097).
 func TestLimitedBufferingDeadlock(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
-	t.Skip("#17097")
 
 	tc := serverutils.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(context.TODO())

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -25,6 +25,8 @@ import (
 )
 
 type distinct struct {
+	processorBase
+
 	flowCtx      *FlowCtx
 	input        RowSource
 	lastGroupKey sqlbase.EncDatumRow
@@ -33,7 +35,6 @@ type distinct struct {
 	distinctCols map[uint32]struct{}
 	memAcc       mon.BoundAccount
 	datumAlloc   sqlbase.DatumAlloc
-	out          procOutputHelper
 }
 
 var _ processor = &distinct{}

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -92,13 +92,19 @@ const (
 	FlowFinished
 )
 
+type startable interface {
+	start(ctx context.Context, wg *sync.WaitGroup)
+}
+
 // Flow represents a flow which consists of processors and streams.
 type Flow struct {
 	FlowCtx
 
 	flowRegistry *flowRegistry
 	processors   []processor
-	outboxes     []*outbox
+	// startables are entities that must be started when the flow starts;
+	// currently these are outboxes.
+	startables []startable
 	// syncFlowConsumer is a special outbox which instead of sending rows to
 	// another host, returns them directly (as a result to a SetupSyncFlow RPC,
 	// or to the local host).
@@ -183,7 +189,7 @@ func (f *Flow) setupOutboundStream(spec StreamEndpointSpec) (RowReceiver, error)
 
 	case StreamEndpointSpec_REMOTE:
 		outbox := newOutbox(&f.FlowCtx, spec.TargetAddr, f.id, sid)
-		f.outboxes = append(f.outboxes, outbox)
+		f.startables = append(f.startables, outbox)
 		return outbox, nil
 
 	case StreamEndpointSpec_LOCAL:
@@ -307,20 +313,20 @@ func (f *Flow) setup(ctx context.Context, spec *FlowSpec) error {
 func (f *Flow) Start(ctx context.Context, doneFn func()) {
 	f.doneFn = doneFn
 	log.VEventf(
-		ctx, 1, "starting (%d processors, %d outboxes)", len(f.outboxes), len(f.processors),
+		ctx, 1, "starting (%d processors, %d startables)", len(f.processors), len(f.startables),
 	)
 	f.status = FlowRunning
 
 	// Once we call RegisterFlow, the inbound streams become accessible; we must
 	// set up the WaitGroup counter before.
-	f.waitGroup.Add(len(f.inboundStreams) + len(f.outboxes) + len(f.processors))
+	f.waitGroup.Add(len(f.inboundStreams) + len(f.processors))
 
 	f.flowRegistry.RegisterFlow(ctx, f.id, f, f.inboundStreams, flowStreamDefaultTimeout)
 	if log.V(1) {
 		log.Infof(ctx, "registered flow %s", f.id.Short())
 	}
-	for _, o := range f.outboxes {
-		o.start(ctx, &f.waitGroup)
+	for _, s := range f.startables {
+		s.start(ctx, &f.waitGroup)
 	}
 	for _, p := range f.processors {
 		go p.Run(ctx, &f.waitGroup)

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -22,6 +22,8 @@ import (
 )
 
 type joinerBase struct {
+	processorBase
+
 	leftSource, rightSource RowSource
 
 	joinType    joinType
@@ -39,8 +41,6 @@ type joinerBase struct {
 	// columns must be merged at the beginning of each result row. This
 	// is the desired behavior for USING and NATURAL JOIN.
 	numMergedEqualityColumns int
-
-	out procOutputHelper
 }
 
 func (jb *joinerBase) init(

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -32,6 +32,8 @@ import (
 const joinReaderBatchSize = 100
 
 type joinReader struct {
+	processorBase
+
 	flowCtx *FlowCtx
 
 	desc  sqlbase.TableDescriptor
@@ -41,7 +43,6 @@ type joinReader struct {
 	alloc   sqlbase.DatumAlloc
 
 	input RowSource
-	out   procOutputHelper
 }
 
 var _ processor = &joinReader{}

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -60,7 +60,6 @@ func TestOutbox(t *testing.T) {
 	streamID := StreamID(42)
 	outbox := newOutbox(&flowCtx, addr.String(), flowID, streamID)
 	var outboxWG sync.WaitGroup
-	outboxWG.Add(1)
 	// Start the outbox. This should cause the stream to connect, even though
 	// we're not sending any rows.
 	outbox.start(context.TODO(), &outboxWG)
@@ -216,7 +215,6 @@ func TestOutboxInitializesStreamBeforeRecevingAnyRows(t *testing.T) {
 	outbox := newOutbox(&flowCtx, addr.String(), flowID, streamID)
 
 	var outboxWG sync.WaitGroup
-	outboxWG.Add(1)
 	// Start the outbox. This should cause the stream to connect, even though
 	// we're not sending any rows.
 	outbox.start(context.TODO(), &outboxWG)
@@ -280,7 +278,6 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 			streamID := StreamID(42)
 			var outbox *outbox
 			var wg sync.WaitGroup
-			wg.Add(1)
 			var expectedErr error
 			consumerReceivedMsg := make(chan struct{})
 			if tc.outboxIsClient {

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -43,10 +43,23 @@ type procOutputHelper struct {
 	output          RowReceiver
 	rowAlloc        sqlbase.EncDatumRowAlloc
 
-	filter      *exprHelper
+	filter *exprHelper
+	// renderExprs is set if we have a rendering. Only one of renderExprs and
+	// outputCols can be set.
 	renderExprs []exprHelper
-	renderTypes []sqlbase.ColumnType
-	outputCols  []uint32
+	// outputCols is set if we have a projection. Only one of renderExprs and
+	// outputCols can be set.
+	outputCols []uint32
+
+	// outputTypes is the schema of the rows produced by the processor after
+	// post-processing (i.e. the rows that are pushed through a router).
+	//
+	// If renderExprs is set, these types correspond to the types of those
+	// expressions.
+	// If outpuCols is set, these types correspond to the types of
+	// those columns.
+	// If neither is set, this is the internal schema of the processor.
+	outputTypes []sqlbase.ColumnType
 
 	// offset is the number of rows that are suppressed.
 	offset uint64
@@ -60,6 +73,8 @@ type procOutputHelper struct {
 // init sets up a procOutputHelper. The types describe the internal schema of
 // the processor (as described for each processor core spec); they can be
 // omitted if there is no filtering expression.
+// Note that the types slice may be stored directly; the caller should not
+// modify it.
 func (h *procOutputHelper) init(
 	post *PostProcessSpec,
 	types []sqlbase.ColumnType,
@@ -91,15 +106,21 @@ func (h *procOutputHelper) init(
 			// nil indicates no projection; use an empty slice.
 			h.outputCols = make([]uint32, 0)
 		}
+		h.outputTypes = make([]sqlbase.ColumnType, len(h.outputCols))
+		for i, c := range h.outputCols {
+			h.outputTypes[i] = types[c]
+		}
 	} else if len(post.RenderExprs) > 0 {
 		h.renderExprs = make([]exprHelper, len(post.RenderExprs))
-		h.renderTypes = make([]sqlbase.ColumnType, len(post.RenderExprs))
+		h.outputTypes = make([]sqlbase.ColumnType, len(post.RenderExprs))
 		for i, expr := range post.RenderExprs {
 			if err := h.renderExprs[i].init(expr, types, evalCtx); err != nil {
 				return err
 			}
-			h.renderTypes[i] = sqlbase.DatumTypeToColumnType(h.renderExprs[i].expr.ResolvedType())
+			h.outputTypes[i] = sqlbase.DatumTypeToColumnType(h.renderExprs[i].expr.ResolvedType())
 		}
+	} else {
+		h.outputTypes = types
 	}
 
 	h.offset = post.Offset
@@ -254,7 +275,7 @@ func (h *procOutputHelper) emitRow(
 			if err != nil {
 				return ConsumerClosed, err
 			}
-			outRow[i] = sqlbase.DatumToEncDatum(h.renderTypes[i], datum)
+			outRow[i] = sqlbase.DatumToEncDatum(h.outputTypes[i], datum)
 		}
 	} else if h.outputCols != nil {
 		// Projection.

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -31,6 +31,10 @@ import (
 // processor is a common interface implemented by all processors, used by the
 // higher-level flow orchestration code.
 type processor interface {
+	// OutputTypes returns the column types of the results (that are to be fed
+	// through an output router).
+	OutputTypes() []sqlbase.ColumnType
+
 	// Run is the main loop of the processor.
 	// If wg is non-nil, wg.Done is called before exiting.
 	Run(ctx context.Context, wg *sync.WaitGroup)
@@ -307,14 +311,24 @@ func (h *procOutputHelper) close() {
 	h.output.ProducerDone()
 }
 
+type processorBase struct {
+	out procOutputHelper
+}
+
+// OutputTypes is part of the processor interface.
+func (pb *processorBase) OutputTypes() []sqlbase.ColumnType {
+	return pb.out.outputTypes
+}
+
 // noopProcessor is a processor that simply passes rows through from the
 // synchronizer to the post-processing stage. It can be useful for its
 // post-processing or in the last stage of a computation, where we may only
 // need the synchronizer to join streams.
 type noopProcessor struct {
+	processorBase
+
 	flowCtx *FlowCtx
 	input   RowSource
-	out     procOutputHelper
 }
 
 var _ processor = &noopProcessor{}

--- a/pkg/sql/distsqlrun/routers.go
+++ b/pkg/sql/distsqlrun/routers.go
@@ -19,6 +19,8 @@ package distsqlrun
 
 import (
 	"hash/crc32"
+	"sync"
+	"sync/atomic"
 
 	"golang.org/x/net/context"
 
@@ -26,21 +28,26 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-func makeRouter(spec *OutputRouterSpec, streams []RowReceiver) (RowReceiver, error) {
+type router interface {
+	RowReceiver
+	startable
+	init(flowCtx *FlowCtx, types []sqlbase.ColumnType)
+}
+
+// makeRouter creates a router. The router's init must be called before the
+// router can be started.
+//
+// Pass-through routers are not supported; the higher layer is expected to elide
+// them.
+func makeRouter(spec *OutputRouterSpec, streams []RowReceiver) (router, error) {
 	if len(streams) == 0 {
 		return nil, errors.Errorf("no streams in router")
 	}
 
 	switch spec.Type {
-	case OutputRouterSpec_PASS_THROUGH:
-		if len(streams) != 1 {
-			return nil, errors.Errorf("expected one stream for passthrough router")
-		}
-		// No router.
-		return streams[0], nil
-
 	case OutputRouterSpec_BY_HASH:
 		return makeHashRouter(spec.HashColumns, streams)
 
@@ -52,27 +59,259 @@ func makeRouter(spec *OutputRouterSpec, streams []RowReceiver) (RowReceiver, err
 	}
 }
 
-type routerBase struct {
-	streams []RowReceiver
-	// The last observed status of the each. This dictates whether we can forward
-	// data on each of these channels.
-	streamStatus []ConsumerStatus
-	// How many of streams are not in the DrainRequested or ConsumerClosed state.
-	numNonDrainingStreams int
-	// aggregatedStatus maintains a unified view across all streamStatus'es.
-	// Namely, if at least one of them is NeedMoreRows, this will be NeedMoreRows.
-	// If all of them are ShutdownNoDrain, this will (eventually) be
-	// ShutdownNoDrain. Otherwise, this will be DrainRequested.
-	aggregatedStatus ConsumerStatus
+const routerRowBufSize = rowChannelBufSize
+
+// routerOutput is the data associated with one router consumer.
+type routerOutput struct {
+	stream RowReceiver
+	mu     struct {
+		syncutil.Mutex
+		// cond is signaled whenever the main router routine adds a metadata item, a
+		// row, or sets producerDone.
+		cond         *sync.Cond
+		streamStatus ConsumerStatus
+
+		metadataBuf []ProducerMetadata
+		// The "level 1" row buffer is used first, to avoid going through the row
+		// container if we don't need to buffer many rows. The buffer is a circular
+		// FIFO queue, with rowBufLen elements and the left-most (oldest) element at
+		// rowBufLeft.
+		rowBuf                [routerRowBufSize]sqlbase.EncDatumRow
+		rowBufLeft, rowBufLen uint32
+
+		// The "level 2" rowContainer is used when we need to buffer more rows than
+		// rowBuf allows. The row container always contains rows "older" than those
+		// in rowBuf. The oldest rows are at the beginning of the row container.
+		// TODO(radu,arjun): fall back to a disk container when it gets too big.
+		rowContainer memRowContainer
+		producerDone bool
+	}
+	// TODO(radu): add padding of size sys.CacheLineSize to ensure there is no
+	// false-sharing?
 }
 
-func makeRouterBase(streams []RowReceiver) routerBase {
-	return routerBase{
-		streams: streams,
-		// Initialized to NeedsMoreRows.
-		streamStatus:          make([]ConsumerStatus, len(streams)),
-		numNonDrainingStreams: len(streams),
+func (ro *routerOutput) addMetadataLocked(meta ProducerMetadata) {
+	// We don't need any fancy buffering because normally there is not a lot of
+	// metadata being passed around.
+	ro.mu.metadataBuf = append(ro.mu.metadataBuf, meta)
+}
+
+// addRowLocked adds a row to rowBuf (potentially evicting an older row into
+// rowContainer).
+func (ro *routerOutput) addRowLocked(ctx context.Context, row sqlbase.EncDatumRow) error {
+	if ro.mu.streamStatus != NeedMoreRows {
+		// The consumer doesn't want more rows; drop the row.
+		return nil
 	}
+	if ro.mu.rowBufLen == routerRowBufSize {
+		// Take out the oldest row in rowBuf and put it in rowContainer.
+		evictedRow := ro.mu.rowBuf[ro.mu.rowBufLeft]
+		if err := ro.mu.rowContainer.AddRow(ctx, evictedRow); err != nil {
+			return err
+		}
+
+		ro.mu.rowBufLeft = (ro.mu.rowBufLeft + 1) % routerRowBufSize
+		ro.mu.rowBufLen--
+	}
+	ro.mu.rowBuf[(ro.mu.rowBufLeft+ro.mu.rowBufLen)%routerRowBufSize] = row
+	ro.mu.rowBufLen++
+	return nil
+}
+
+func (ro *routerOutput) popRowsLocked(rowBuf []sqlbase.EncDatumRow) []sqlbase.EncDatumRow {
+	n := 0
+	// First try to get rows from the row container.
+	for ; n < len(rowBuf) && ro.mu.rowContainer.Len() > 0; n++ {
+		// TODO(radu): use an EncDatumRowAlloc?
+		row := ro.mu.rowContainer.EncRow(0)
+		rowBuf[n] = make(sqlbase.EncDatumRow, len(row))
+		copy(rowBuf[n], row)
+		ro.mu.rowContainer.PopFirst()
+	}
+	// If the row container is empty, get more rows from the row buffer.
+	for ; n < len(rowBuf) && ro.mu.rowBufLen > 0; n++ {
+		rowBuf[n] = ro.mu.rowBuf[ro.mu.rowBufLeft]
+		ro.mu.rowBufLeft = (ro.mu.rowBufLeft + 1) % routerRowBufSize
+		ro.mu.rowBufLen--
+	}
+	return rowBuf[:n]
+}
+
+// See the comment for routerBase.semaphoreCount.
+const semaphorePeriod = 8
+
+type routerBase struct {
+	outputs []routerOutput
+
+	// How many of streams are not in the DrainRequested or ConsumerClosed state.
+	numNonDrainingStreams int32
+
+	// aggregatedStatus is an atomic that maintains a unified view across all
+	// streamStatus'es.  Namely, if at least one of them is NeedMoreRows, this
+	// will be NeedMoreRows. If all of them are ConsumerClosed, this will
+	// (eventually) be ConsumerClosed. Otherwise, this will be DrainRequested.
+	aggregatedStatus uint32
+
+	// We use a semaphore of size len(outputs) and acquire it whenever we Push
+	// to each stream as well as in the router's main Push routine. This ensures
+	// that if all outputs are blocked, the main router routine blocks as well
+	// (preventing runaway buffering if the source is faster than the consumers).
+	semaphore chan struct{}
+
+	// To reduce synchronization overhead, we only acquire the semaphore once for
+	// every semaphorePeriod rows. This count keeps track of how many rows we
+	// saw since the last time we took the semaphore.
+	semaphoreCount int32
+}
+
+func (rb *routerBase) aggStatus() ConsumerStatus {
+	return ConsumerStatus(atomic.LoadUint32(&rb.aggregatedStatus))
+}
+
+func (rb *routerBase) setupStreams(streams []RowReceiver) {
+	rb.numNonDrainingStreams = int32(len(streams))
+	rb.semaphore = make(chan struct{}, len(streams))
+	rb.outputs = make([]routerOutput, len(streams))
+	for i := range rb.outputs {
+		ro := &rb.outputs[i]
+		ro.stream = streams[i]
+		ro.mu.cond = sync.NewCond(&ro.mu.Mutex)
+		ro.mu.streamStatus = NeedMoreRows
+	}
+}
+
+// init must be called after setupStreams but before start.
+func (rb *routerBase) init(flowCtx *FlowCtx, types []sqlbase.ColumnType) {
+	for i := range rb.outputs {
+		// This method must be called before we start() so we don't need
+		// to take the mutex.
+		rb.outputs[i].mu.rowContainer.init(nil /* ordering */, types, &flowCtx.evalCtx)
+	}
+}
+
+// start must be called after init.
+func (rb *routerBase) start(ctx context.Context, wg *sync.WaitGroup) {
+	wg.Add(len(rb.outputs))
+	for i := range rb.outputs {
+		go func(rb *routerBase, ro *routerOutput, wg *sync.WaitGroup) {
+			rowBuf := make([]sqlbase.EncDatumRow, routerRowBufSize)
+			streamStatus := NeedMoreRows
+			ro.mu.Lock()
+			for {
+				// Send any metadata that has been buffered.
+				if len(ro.mu.metadataBuf) > 0 {
+					m := ro.mu.metadataBuf[0]
+					ro.mu.metadataBuf = ro.mu.metadataBuf[1:]
+
+					ro.mu.Unlock()
+
+					rb.semaphore <- struct{}{}
+					status := ro.stream.Push(nil /*row*/, m)
+					<-rb.semaphore
+
+					rb.updateStreamState(&streamStatus, status)
+					ro.mu.Lock()
+					ro.mu.streamStatus = streamStatus
+					continue
+				}
+
+				// Send any rows that have been buffered. We grab multiple rows at a
+				// time to reduce contention.
+				if rows := ro.popRowsLocked(rowBuf); len(rows) > 0 {
+					ro.mu.Unlock()
+					rb.semaphore <- struct{}{}
+					for _, row := range rows {
+						status := ro.stream.Push(row, ProducerMetadata{})
+						rb.updateStreamState(&streamStatus, status)
+					}
+					<-rb.semaphore
+					ro.mu.Lock()
+					ro.mu.streamStatus = streamStatus
+					continue
+				}
+
+				// No rows or metadata buffered; see if the producer is done.
+				if ro.mu.producerDone {
+					ro.stream.ProducerDone()
+					break
+				}
+
+				// Nothing to do; wait.
+				ro.mu.cond.Wait()
+			}
+			ro.mu.rowContainer.Close(ctx)
+			ro.mu.Unlock()
+			wg.Done()
+		}(rb, &rb.outputs[i], wg)
+	}
+}
+
+// ProducerDone is part of the RowReceiver interface.
+func (rb *routerBase) ProducerDone() {
+	for i := range rb.outputs {
+		o := &rb.outputs[i]
+		o.mu.Lock()
+		o.mu.producerDone = true
+		o.mu.Unlock()
+		o.mu.cond.Signal()
+	}
+}
+
+// updateStreamState updates the status of one stream and, if this was the last
+// open stream, it also updates rb.aggregatedStatus.
+func (rb *routerBase) updateStreamState(streamStatus *ConsumerStatus, newState ConsumerStatus) {
+	if newState != *streamStatus {
+		if *streamStatus == NeedMoreRows {
+			// A stream state never goes from draining to non-draining, so we can assume
+			// that this stream is now draining or closed.
+			if atomic.AddInt32(&rb.numNonDrainingStreams, -1) == 0 {
+				// Update aggregatedStatus, if the current value is NeedMoreRows.
+				atomic.CompareAndSwapUint32(
+					&rb.aggregatedStatus,
+					uint32(NeedMoreRows),
+					uint32(DrainRequested),
+				)
+			}
+		}
+		*streamStatus = newState
+	}
+}
+
+// fwdMetadata forwards a metadata record to the first stream that's still
+// accepting data.
+func (rb *routerBase) fwdMetadata(meta ProducerMetadata) {
+	if meta.Empty() {
+		log.Fatalf(context.TODO(), "asked to fwd empty metadata")
+	}
+
+	rb.semaphore <- struct{}{}
+
+	for i := range rb.outputs {
+		ro := &rb.outputs[i]
+		ro.mu.Lock()
+		if ro.mu.streamStatus != ConsumerClosed {
+			ro.addMetadataLocked(meta)
+			ro.mu.Unlock()
+			ro.mu.cond.Signal()
+			<-rb.semaphore
+			return
+		}
+		ro.mu.Unlock()
+	}
+
+	<-rb.semaphore
+	// If we got here it means that we couldn't even forward metadata anywhere;
+	// all streams are closed.
+	atomic.StoreUint32(&rb.aggregatedStatus, uint32(ConsumerClosed))
+}
+
+func (rb *routerBase) shouldUseSemaphore() bool {
+	rb.semaphoreCount++
+	if rb.semaphoreCount >= semaphorePeriod {
+		rb.semaphoreCount = 0
+		return true
+	}
+	return false
 }
 
 type mirrorRouter struct {
@@ -87,93 +326,67 @@ type hashRouter struct {
 	alloc    sqlbase.DatumAlloc
 }
 
-var _ RowReceiver = &hashRouter{}
 var _ RowReceiver = &mirrorRouter{}
+var _ RowReceiver = &hashRouter{}
 
-var crc32Table = crc32.MakeTable(crc32.Castagnoli)
-
-func makeMirrorRouter(streams []RowReceiver) (*mirrorRouter, error) {
+func makeMirrorRouter(streams []RowReceiver) (router, error) {
 	if len(streams) < 2 {
 		return nil, errors.Errorf("need at least two streams for mirror router")
 	}
-	return &mirrorRouter{
-		routerBase: makeRouterBase(streams),
-	}, nil
+	mr := &mirrorRouter{}
+	mr.routerBase.setupStreams(streams)
+	return mr, nil
 }
 
-func makeHashRouter(hashCols []uint32, streams []RowReceiver) (*hashRouter, error) {
+// Push is part of the RowReceiver interface.
+func (mr *mirrorRouter) Push(row sqlbase.EncDatumRow, meta ProducerMetadata) ConsumerStatus {
+	aggStatus := mr.aggStatus()
+	if !meta.Empty() {
+		mr.fwdMetadata(meta)
+		return aggStatus
+	}
+	if aggStatus != NeedMoreRows {
+		return aggStatus
+	}
+
+	useSema := mr.shouldUseSemaphore()
+	if useSema {
+		mr.semaphore <- struct{}{}
+	}
+
+	for i := range mr.outputs {
+		ro := &mr.outputs[i]
+		ro.mu.Lock()
+		err := ro.addRowLocked(context.TODO(), row)
+		ro.mu.Unlock()
+		if err != nil {
+			if useSema {
+				<-mr.semaphore
+			}
+			mr.fwdMetadata(ProducerMetadata{Err: err})
+			atomic.StoreUint32(&mr.aggregatedStatus, uint32(ConsumerClosed))
+			return ConsumerClosed
+		}
+		ro.mu.cond.Signal()
+	}
+	if useSema {
+		<-mr.semaphore
+	}
+	return aggStatus
+}
+
+var crc32Table = crc32.MakeTable(crc32.Castagnoli)
+
+func makeHashRouter(hashCols []uint32, streams []RowReceiver) (router, error) {
 	if len(streams) < 2 {
 		return nil, errors.Errorf("need at least two streams for hash router")
 	}
 	if len(hashCols) == 0 {
 		return nil, errors.Errorf("no hash columns for BY_HASH router")
 	}
-	return &hashRouter{
-		routerBase: makeRouterBase(streams),
-		hashCols:   hashCols,
-	}, nil
-}
-
-// ProducerDone is part of the RowReceiver interface.
-func (rb *routerBase) ProducerDone() {
-	for _, s := range rb.streams {
-		s.ProducerDone()
-	}
-}
-
-// updateStreamState updates the status of one stream and, if this was the last
-// open stream, it also updates rb.aggregatedStatus.
-func (rb *routerBase) updateStreamState(streamIdx int, newState ConsumerStatus) {
-	if newState != rb.streamStatus[streamIdx] && rb.streamStatus[streamIdx] == NeedMoreRows {
-		rb.streamStatus[streamIdx] = newState
-		// A stream state never goes from draining to non-draining, so we can assume
-		// that this stream is now draining or closed.
-		rb.numNonDrainingStreams--
-	}
-	if rb.aggregatedStatus == NeedMoreRows && rb.numNonDrainingStreams == 0 {
-		rb.aggregatedStatus = DrainRequested
-	}
-}
-
-// fwdMetadata forwards a metadata record to the first stream that's still
-// accepting data.
-func (rb *routerBase) fwdMetadata(meta ProducerMetadata) {
-	if meta.Empty() {
-		log.Fatalf(context.TODO(), "asked to fwd empty metadata")
-	}
-	for i := range rb.streams {
-		if rb.streamStatus[i] != ConsumerClosed {
-			newStatus := rb.streams[i].Push(nil /*row*/, meta)
-			rb.updateStreamState(i, newStatus)
-			if newStatus != ConsumerClosed {
-				// We've successfully forwarded the row.
-				return
-			}
-		}
-	}
-	// If we got here it means that we couldn't even forward metadata anywhere;
-	// all streams are closed.
-	rb.aggregatedStatus = ConsumerClosed
-}
-
-// Push is part of the RowReceiver interface.
-func (mr *mirrorRouter) Push(row sqlbase.EncDatumRow, meta ProducerMetadata) ConsumerStatus {
-	if !meta.Empty() {
-		mr.fwdMetadata(meta)
-		return mr.aggregatedStatus
-	}
-	if mr.aggregatedStatus != NeedMoreRows {
-		return mr.aggregatedStatus
-	}
-
-	// Each row is sent to all the output streams that are still open.
-	for i := range mr.streams {
-		if mr.streamStatus[i] == NeedMoreRows {
-			newStatus := mr.streams[i].Push(row, ProducerMetadata{})
-			mr.updateStreamState(i, newStatus)
-		}
-	}
-	return mr.aggregatedStatus
+	hr := &hashRouter{hashCols: hashCols}
+	hr.routerBase.setupStreams(streams)
+	return hr, nil
 }
 
 // Push is part of the RowReceiver interface.
@@ -181,26 +394,38 @@ func (mr *mirrorRouter) Push(row sqlbase.EncDatumRow, meta ProducerMetadata) Con
 // If, according to the hash, the row needs to go to a consumer that's draining
 // or closed, the row is silently dropped.
 func (hr *hashRouter) Push(row sqlbase.EncDatumRow, meta ProducerMetadata) ConsumerStatus {
+	aggStatus := hr.aggStatus()
 	if !meta.Empty() {
 		hr.fwdMetadata(meta)
-		return hr.aggregatedStatus
+		// fwdMetadata can change the status, re-read it.
+		return hr.aggStatus()
 	}
-	if hr.aggregatedStatus != NeedMoreRows {
-		return hr.aggregatedStatus
+	if aggStatus != NeedMoreRows {
+		return aggStatus
+	}
+
+	useSema := hr.shouldUseSemaphore()
+	if useSema {
+		hr.semaphore <- struct{}{}
 	}
 
 	streamIdx, err := hr.computeDestination(row)
+	if err == nil {
+		ro := &hr.outputs[streamIdx]
+		ro.mu.Lock()
+		err = ro.addRowLocked(context.TODO(), row)
+		ro.mu.Unlock()
+		ro.mu.cond.Signal()
+	}
+	if useSema {
+		<-hr.semaphore
+	}
 	if err != nil {
 		hr.fwdMetadata(ProducerMetadata{Err: err})
-		hr.aggregatedStatus = ConsumerClosed
+		atomic.StoreUint32(&hr.aggregatedStatus, uint32(ConsumerClosed))
 		return ConsumerClosed
 	}
-
-	if hr.streamStatus[streamIdx] == NeedMoreRows {
-		newStatus := hr.streams[streamIdx].Push(row, ProducerMetadata{})
-		hr.updateStreamState(streamIdx, newStatus)
-	}
-	return hr.aggregatedStatus
+	return aggStatus
 }
 
 // computeDestination hashes a row and returns the index of the output stream on
@@ -226,5 +451,5 @@ func (hr *hashRouter) computeDestination(row sqlbase.EncDatumRow) (int, error) {
 	// We use CRC32-C because it makes for a decent hash function and is faster
 	// than most hashing algorithms (on recent x86 platforms where it is hardware
 	// accelerated).
-	return int(crc32.Update(0, crc32Table, hr.buffer) % uint32(len(hr.streams))), nil
+	return int(crc32.Update(0, crc32Table, hr.buffer) % uint32(len(hr.outputs))), nil
 }

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -212,42 +212,29 @@ func TestMirrorRouter(t *testing.T) {
 // not closed, and ConsumerClosed should be returned afterwards.
 func TestConsumerStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mirrorRouterFactory := func() (RowReceiver, []RowSource, error) {
-		bufs := make([]*RowBuffer, 2)
-		recvs := make([]RowReceiver, 2)
-		srcs := make([]RowSource, 2)
-		for i := 0; i < 2; i++ {
-			bufs[i] = &RowBuffer{}
-			recvs[i] = bufs[i]
-			srcs[i] = bufs[i]
-		}
-		mr, err := makeMirrorRouter(recvs)
-		return mr, srcs, err
-	}
-	hashRouterFactory := func() (RowReceiver, []RowSource, error) {
-		bufs := make([]*RowBuffer, 2)
-		recvs := make([]RowReceiver, 2)
-		srcs := make([]RowSource, 2)
-		for i := 0; i < 2; i++ {
-			bufs[i] = &RowBuffer{}
-			recvs[i] = bufs[i]
-			srcs[i] = bufs[i]
-		}
-		mr, err := makeHashRouter([]uint32{0} /* hashCols */, recvs)
-		return mr, srcs, err
-	}
-
 	testCases := []struct {
-		name          string
-		routerFactory func() (RowReceiver, []RowSource, error)
+		name string
+		spec OutputRouterSpec
 	}{
-		{"MirrorRouter", mirrorRouterFactory},
-		{"HashRouter", hashRouterFactory},
+		{
+			name: "MirrorRouter",
+			spec: OutputRouterSpec{Type: OutputRouterSpec_MIRROR},
+		},
+		{
+			name: "HashRouter",
+			spec: OutputRouterSpec{Type: OutputRouterSpec_BY_HASH, HashColumns: []uint32{0}},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			router, srcs, err := tc.routerFactory()
+			bufs := make([]*RowBuffer, 2)
+			recvs := make([]RowReceiver, 2)
+			for i := 0; i < 2; i++ {
+				bufs[i] = &RowBuffer{}
+				recvs[i] = bufs[i]
+			}
+			router, err := makeRouter(&tc.spec, recvs)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -256,11 +243,11 @@ func TestConsumerStatus(t *testing.T) {
 			var row0, row1 sqlbase.EncDatumRow
 			if hr, ok := router.(*hashRouter); ok {
 				var err error
-				row0, err = preimageAttack(hr, 0, len(srcs))
+				row0, err = preimageAttack(hr, 0, len(bufs))
 				if err != nil {
 					t.Fatal(err)
 				}
-				row1, err = preimageAttack(hr, 1, len(srcs))
+				row1, err = preimageAttack(hr, 1, len(bufs))
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -279,7 +266,7 @@ func TestConsumerStatus(t *testing.T) {
 
 			// Start draining stream 0. Keep expecting NeedMoreRows, regardless on
 			// which stream we send.
-			srcs[0].ConsumerDone()
+			bufs[0].ConsumerDone()
 			consumerStatus = router.Push(row0, ProducerMetadata{})
 			if consumerStatus != NeedMoreRows {
 				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
@@ -290,7 +277,7 @@ func TestConsumerStatus(t *testing.T) {
 			}
 
 			// Close stream 0. Continue to expect NeedMoreRows.
-			srcs[0].ConsumerClosed()
+			bufs[0].ConsumerClosed()
 			consumerStatus = router.Push(row0, ProducerMetadata{})
 			if consumerStatus != NeedMoreRows {
 				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
@@ -302,7 +289,7 @@ func TestConsumerStatus(t *testing.T) {
 
 			// Start draining stream 1. Now that all streams are draining, expect
 			// DrainRequested.
-			srcs[1].ConsumerDone()
+			bufs[1].ConsumerDone()
 			consumerStatus = router.Push(row1, ProducerMetadata{})
 			if consumerStatus != DrainRequested {
 				t.Fatalf("expected status %d, got: %d", DrainRequested, consumerStatus)
@@ -311,7 +298,7 @@ func TestConsumerStatus(t *testing.T) {
 			// Close stream 1. Everything's closed now, but the routers currently
 			// only detect this when trying to send metadata - so we still expect
 			// DrainRequested.
-			srcs[1].ConsumerClosed()
+			bufs[1].ConsumerClosed()
 			consumerStatus = router.Push(row1, ProducerMetadata{})
 			if consumerStatus != DrainRequested {
 				t.Fatalf("expected status %d, got: %d", DrainRequested, consumerStatus)
@@ -319,7 +306,6 @@ func TestConsumerStatus(t *testing.T) {
 
 			// Attempt to send some metadata. This will cause the router to observe
 			// that everything's closed now.
-			srcs[1].ConsumerClosed()
 			consumerStatus = router.Push(
 				nil /* row */, ProducerMetadata{Err: errors.Errorf("test error")})
 			if consumerStatus != ConsumerClosed {
@@ -350,86 +336,71 @@ func preimageAttack(hr *hashRouter, streamIdx int, numStreams int) (sqlbase.EncD
 // stream that's not closed.
 func TestMetadataIsForwarded(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mirrorRouterFactory := func() (RowReceiver, []RowSource, error) {
-		bufs := make([]*RowBuffer, 2)
-		recvs := make([]RowReceiver, 2)
-		srcs := make([]RowSource, 2)
-		for i := 0; i < 2; i++ {
-			bufs[i] = &RowBuffer{}
-			recvs[i] = bufs[i]
-			srcs[i] = bufs[i]
-		}
-		mr, err := makeMirrorRouter(recvs)
-		return mr, srcs, err
-	}
-	hashRouterFactory := func() (RowReceiver, []RowSource, error) {
-		bufs := make([]*RowBuffer, 2)
-		recvs := make([]RowReceiver, 2)
-		srcs := make([]RowSource, 2)
-		for i := 0; i < 2; i++ {
-			bufs[i] = &RowBuffer{}
-			recvs[i] = bufs[i]
-			srcs[i] = bufs[i]
-		}
-		mr, err := makeHashRouter([]uint32{0} /* hashCols */, recvs)
-		return mr, srcs, err
-	}
 
 	testCases := []struct {
-		name          string
-		routerFactory func() (RowReceiver, []RowSource, error)
+		name string
+		spec OutputRouterSpec
 	}{
-		{"MirrorRouter", mirrorRouterFactory},
-		{"HashRouter", hashRouterFactory},
+		{
+			name: "MirrorRouter",
+			spec: OutputRouterSpec{Type: OutputRouterSpec_MIRROR},
+		},
+		{
+			name: "HashRouter",
+			spec: OutputRouterSpec{Type: OutputRouterSpec_BY_HASH, HashColumns: []uint32{0}},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			router, srcs, err := tc.routerFactory()
+			bufs := make([]*RowBuffer, 2)
+			recvs := make([]RowReceiver, 2)
+			for i := 0; i < 2; i++ {
+				bufs[i] = &RowBuffer{}
+				recvs[i] = bufs[i]
+			}
+			router, err := makeRouter(&tc.spec, recvs)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			// Push metadata. It should be fwd to src[0].
+			// Push metadata; it should go to stream 0.
 			consumerStatus := router.Push(
 				nil /* row */, ProducerMetadata{Err: errors.Errorf("test error 1")})
 			if consumerStatus != NeedMoreRows {
 				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 			}
 
-			// Call src[0].ConsumerDone() and then push metadata. It should still be
-			// fwd to src[0].
-			srcs[0].ConsumerDone()
+			bufs[0].ConsumerDone()
+			// Push metadata; it should still go to stream 0.
 			consumerStatus = router.Push(
 				nil /* row */, ProducerMetadata{Err: errors.Errorf("test error 2")})
 			if consumerStatus != NeedMoreRows {
 				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 			}
 
-			// Call src[0].ConsumerClosed() and then push metadata. It should be fwd
-			// to src[1].
-			srcs[0].ConsumerClosed()
+			bufs[0].ConsumerClosed()
+			// Metadata should now go to stream 1.
 			consumerStatus = router.Push(
 				nil /* row */, ProducerMetadata{Err: errors.Errorf("test error 3")})
 			if consumerStatus != NeedMoreRows {
 				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 			}
 
-			// Call src[1].ConsumerClosed() and then push metadata. It should not be
-			// fwd anywhere.
-			srcs[1].ConsumerClosed()
+			bufs[1].ConsumerClosed()
+			// Metadata should not go anywhere.
 			consumerStatus = router.Push(
 				nil /* row */, ProducerMetadata{Err: errors.Errorf("test error 4")})
 			if consumerStatus != ConsumerClosed {
 				t.Fatalf("expected status %d, got: %d", ConsumerClosed, consumerStatus)
 			}
 
-			r0 := getRecordsSummary(srcs[0])
+			r0 := getRecordsSummary(bufs[0])
 			exp0 := "test error 1, test error 2"
 			if r0 != exp0 {
 				t.Fatalf("expected records: %q, got: %q", exp0, r0)
 			}
-			r1 := getRecordsSummary(srcs[1])
+			r1 := getRecordsSummary(bufs[1])
 			exp1 := "test error 3"
 			if r1 != exp1 {
 				t.Fatalf("expected records: %q, got: %q", exp1, r1)

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -15,14 +15,18 @@
 package distsqlrun
 
 import (
-	"bytes"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
@@ -65,6 +69,16 @@ func TestHashRouter(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			flowCtx := FlowCtx{evalCtx: parser.MakeTestingEvalContext()}
+
+			types := make([]sqlbase.ColumnType, numCols)
+			for i := range types {
+				types[i] = vals[i][0].Type
+			}
+			hr.init(&flowCtx, types)
+			var wg sync.WaitGroup
+			hr.start(context.TODO(), &wg)
+
 			for i := 0; i < numRows; i++ {
 				row := make(sqlbase.EncDatumRow, numCols)
 				for j := 0; j < numCols; j++ {
@@ -75,6 +89,7 @@ func TestHashRouter(t *testing.T) {
 				}
 			}
 			hr.ProducerDone()
+			wg.Wait()
 
 			rows := make([]sqlbase.EncDatumRows, len(bufs))
 			for i, b := range bufs {
@@ -155,6 +170,15 @@ func TestMirrorRouter(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		flowCtx := FlowCtx{evalCtx: parser.MakeTestingEvalContext()}
+		types := make([]sqlbase.ColumnType, numCols)
+		for i := range types {
+			types[i] = vals[i][0].Type
+		}
+		mr.init(&flowCtx, types)
+		var wg sync.WaitGroup
+		mr.start(context.TODO(), &wg)
+
 		for i := 0; i < numRows; i++ {
 			row := make(sqlbase.EncDatumRow, numCols)
 			for j := 0; j < numCols; j++ {
@@ -165,6 +189,7 @@ func TestMirrorRouter(t *testing.T) {
 			}
 		}
 		mr.ProducerDone()
+		wg.Wait()
 
 		rows := make([]sqlbase.EncDatumRows, len(bufs))
 		for i, b := range bufs {
@@ -238,22 +263,28 @@ func TestConsumerStatus(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			colTypes := []sqlbase.ColumnType{{SemanticType: sqlbase.ColumnType_INT}}
+			flowCtx := FlowCtx{evalCtx: parser.MakeTestingEvalContext()}
+			router.init(&flowCtx, colTypes)
+			var wg sync.WaitGroup
+			router.start(context.TODO(), &wg)
+
 			// row0 will be a row that the hash router sends to the first stream, row1
 			// to the 2nd stream.
 			var row0, row1 sqlbase.EncDatumRow
 			if hr, ok := router.(*hashRouter); ok {
 				var err error
-				row0, err = preimageAttack(hr, 0, len(bufs))
+				row0, err = preimageAttack(colTypes, hr, 0, len(bufs))
 				if err != nil {
 					t.Fatal(err)
 				}
-				row1, err = preimageAttack(hr, 1, len(bufs))
+				row1, err = preimageAttack(colTypes, hr, 1, len(bufs))
 				if err != nil {
 					t.Fatal(err)
 				}
 			} else {
 				rng, _ := randutil.NewPseudoRand()
-				vals := sqlbase.RandEncDatumSlices(rng, 1 /* numSets */, 1 /* numValsPerSet */)
+				vals := sqlbase.RandEncDatumRowsOfTypes(rng, 1 /* numRows */, colTypes)
 				row0 = vals[0]
 				row1 = row0
 			}
@@ -290,10 +321,13 @@ func TestConsumerStatus(t *testing.T) {
 			// Start draining stream 1. Now that all streams are draining, expect
 			// DrainRequested.
 			bufs[1].ConsumerDone()
-			consumerStatus = router.Push(row1, ProducerMetadata{})
-			if consumerStatus != DrainRequested {
-				t.Fatalf("expected status %d, got: %d", DrainRequested, consumerStatus)
-			}
+			testutils.SucceedsSoon(t, func() error {
+				status := router.Push(row1, ProducerMetadata{})
+				if status != DrainRequested {
+					return fmt.Errorf("expected status %d, got: %d", DrainRequested, consumerStatus)
+				}
+				return nil
+			})
 
 			// Close stream 1. Everything's closed now, but the routers currently
 			// only detect this when trying to send metadata - so we still expect
@@ -306,27 +340,35 @@ func TestConsumerStatus(t *testing.T) {
 
 			// Attempt to send some metadata. This will cause the router to observe
 			// that everything's closed now.
-			consumerStatus = router.Push(
-				nil /* row */, ProducerMetadata{Err: errors.Errorf("test error")})
-			if consumerStatus != ConsumerClosed {
-				t.Fatalf("expected status %d, got: %d", ConsumerClosed, consumerStatus)
-			}
+			testutils.SucceedsSoon(t, func() error {
+				consumerStatus := router.Push(
+					nil /* row */, ProducerMetadata{Err: errors.Errorf("test error")},
+				)
+				if consumerStatus != ConsumerClosed {
+					return fmt.Errorf("expected status %d, got: %d", ConsumerClosed, consumerStatus)
+				}
+				return nil
+			})
+			router.ProducerDone()
+			wg.Wait()
 		})
 	}
 }
 
 // preimageAttack finds a row that hashes to a particular output stream. It's
 // assumed that hr is configured for rows with one column.
-func preimageAttack(hr *hashRouter, streamIdx int, numStreams int) (sqlbase.EncDatumRow, error) {
+func preimageAttack(
+	colTypes []sqlbase.ColumnType, hr *hashRouter, streamIdx int, numStreams int,
+) (sqlbase.EncDatumRow, error) {
 	rng, _ := randutil.NewPseudoRand()
 	for {
-		vals := sqlbase.RandEncDatumSlices(rng, 1 /* numSets */, 1 /* numValsPerSet */)
-		curStreamIdx, err := hr.computeDestination(vals[0])
+		vals := sqlbase.RandEncDatumRowOfTypes(rng, colTypes)
+		curStreamIdx, err := hr.computeDestination(vals)
 		if err != nil {
 			return nil, err
 		}
 		if curStreamIdx == streamIdx {
-			return vals[0], nil
+			return vals, nil
 		}
 	}
 }
@@ -353,86 +395,200 @@ func TestMetadataIsForwarded(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			bufs := make([]*RowBuffer, 2)
+			chans := make([]RowChannel, 2)
 			recvs := make([]RowReceiver, 2)
 			for i := 0; i < 2; i++ {
-				bufs[i] = &RowBuffer{}
-				recvs[i] = bufs[i]
+				chans[i].InitWithBufSize(nil /* no column types */, 1)
+				recvs[i] = &chans[i]
 			}
 			router, err := makeRouter(&tc.spec, recvs)
 			if err != nil {
 				t.Fatal(err)
 			}
+			flowCtx := FlowCtx{evalCtx: parser.MakeTestingEvalContext()}
+			router.init(&flowCtx, nil /* no column types */)
+			var wg sync.WaitGroup
+			router.start(context.TODO(), &wg)
+
+			err1 := errors.Errorf("test error 1")
+			err2 := errors.Errorf("test error 2")
+			err3 := errors.Errorf("test error 3")
+			err4 := errors.Errorf("test error 4")
 
 			// Push metadata; it should go to stream 0.
-			consumerStatus := router.Push(
-				nil /* row */, ProducerMetadata{Err: errors.Errorf("test error 1")})
-			if consumerStatus != NeedMoreRows {
-				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
+			for i := 0; i < 10; i++ {
+				consumerStatus := router.Push(nil /* row */, ProducerMetadata{Err: err1})
+				if consumerStatus != NeedMoreRows {
+					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
+				}
+				_, meta := chans[0].Next()
+				if meta.Err != err1 {
+					t.Fatalf("unexpected meta.Err %v, expected %s", meta.Err, err1)
+				}
 			}
 
-			bufs[0].ConsumerDone()
+			chans[0].ConsumerDone()
 			// Push metadata; it should still go to stream 0.
-			consumerStatus = router.Push(
-				nil /* row */, ProducerMetadata{Err: errors.Errorf("test error 2")})
-			if consumerStatus != NeedMoreRows {
-				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
+			for i := 0; i < 10; i++ {
+				consumerStatus := router.Push(nil /* row */, ProducerMetadata{Err: err2})
+				if consumerStatus != NeedMoreRows {
+					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
+				}
+				_, meta := chans[0].Next()
+				if meta.Err != err2 {
+					t.Fatalf("unexpected meta.Err %v, expected %s", meta.Err, err2)
+				}
 			}
 
-			bufs[0].ConsumerClosed()
-			// Metadata should now go to stream 1.
-			consumerStatus = router.Push(
-				nil /* row */, ProducerMetadata{Err: errors.Errorf("test error 3")})
-			if consumerStatus != NeedMoreRows {
-				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
+			chans[0].ConsumerClosed()
+
+			// Metadata should switch to going to stream 1 once the new status is
+			// observed.
+			testutils.SucceedsSoon(t, func() error {
+				consumerStatus := router.Push(nil /* row */, ProducerMetadata{Err: err3})
+				if consumerStatus != NeedMoreRows {
+					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
+				}
+				// Receive on stream 1 if there is a message waiting. Metadata may still
+				// try to go to 0 for a little while.
+				select {
+				case d := <-chans[1].C:
+					if d.Meta.Err != err3 {
+						t.Fatalf("unexpected meta.Err %v, expected %s", d.Meta.Err, err3)
+					}
+					return nil
+				default:
+					return errors.Errorf("no metadata on stream 1")
+				}
+			})
+
+			chans[1].ConsumerClosed()
+
+			// Start drain the channels in the background.
+			for i := range chans {
+				go drainRowChannel(&chans[i])
 			}
 
-			bufs[1].ConsumerClosed()
-			// Metadata should not go anywhere.
-			consumerStatus = router.Push(
-				nil /* row */, ProducerMetadata{Err: errors.Errorf("test error 4")})
-			if consumerStatus != ConsumerClosed {
-				t.Fatalf("expected status %d, got: %d", ConsumerClosed, consumerStatus)
-			}
+			testutils.SucceedsSoon(t, func() error {
+				consumerStatus := router.Push(nil /* row */, ProducerMetadata{Err: err4})
+				if consumerStatus != ConsumerClosed {
+					return fmt.Errorf("expected status %d, got: %d", ConsumerClosed, consumerStatus)
+				}
+				return nil
+			})
 
-			r0 := getRecordsSummary(bufs[0])
-			exp0 := "test error 1, test error 2"
-			if r0 != exp0 {
-				t.Fatalf("expected records: %q, got: %q", exp0, r0)
-			}
-			r1 := getRecordsSummary(bufs[1])
-			exp1 := "test error 3"
-			if r1 != exp1 {
-				t.Fatalf("expected records: %q, got: %q", exp1, r1)
-			}
+			router.ProducerDone()
+
+			wg.Wait()
 		})
 	}
 }
 
-func getRecordsSummary(src RowSource) string {
-	var b bytes.Buffer
-	first := true
+func drainRowChannel(rc *RowChannel) {
 	for {
-		row, meta := src.Next()
+		row, meta := rc.Next()
 		if row == nil && meta.Empty() {
-			return b.String()
+			return
 		}
-		if !first {
-			b.Write([]byte(", "))
-		}
-		first = false
-		if row != nil {
-			if len(row) != 1 {
-				b.Write([]byte("<row>"))
-			} else {
-				b.Write([]byte(row[0].String()))
+	}
+}
+
+// TestRouterBlocks verifies that routers block if all their consumers are
+// blocked.
+func TestRouterBlocks(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		name string
+		spec OutputRouterSpec
+	}{
+		{
+			name: "MirrorRouter",
+			spec: OutputRouterSpec{Type: OutputRouterSpec_MIRROR},
+		},
+		{
+			name: "HashRouter",
+			spec: OutputRouterSpec{Type: OutputRouterSpec_BY_HASH, HashColumns: []uint32{0}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			colTypes := []sqlbase.ColumnType{{SemanticType: sqlbase.ColumnType_INT}}
+			chans := make([]RowChannel, 2)
+			recvs := make([]RowReceiver, 2)
+			for i := 0; i < 2; i++ {
+				chans[i].InitWithBufSize(colTypes, 1)
+				recvs[i] = &chans[i]
 			}
-		} else {
-			if meta.Err != nil {
-				b.Write([]byte(meta.Err.Error()))
-			} else {
-				b.Write([]byte("<ranges>"))
+			router, err := makeRouter(&tc.spec, recvs)
+			if err != nil {
+				t.Fatal(err)
 			}
-		}
+			flowCtx := FlowCtx{evalCtx: parser.MakeTestingEvalContext()}
+			router.init(&flowCtx, colTypes)
+			var wg sync.WaitGroup
+			router.start(context.TODO(), &wg)
+
+			// Set up a goroutine that tries to send rows until the stop channel
+			// is closed.
+			wg.Add(1)
+			var numRowsSent uint32
+			stop := make(chan struct{})
+			go func() {
+				rng, _ := randutil.NewPseudoRand()
+			Loop:
+				for {
+					select {
+					case <-stop:
+						break Loop
+					default:
+						row := sqlbase.RandEncDatumRowOfTypes(rng, colTypes)
+						status := router.Push(row, ProducerMetadata{})
+						if status != NeedMoreRows {
+							break Loop
+						}
+						atomic.AddUint32(&numRowsSent, 1)
+					}
+				}
+				router.ProducerDone()
+				wg.Done()
+			}()
+
+			// We are no reading from the row channels; the router should become
+			// blocked after trying to send a row to each stream. We sample the number
+			// of rows sent and verify that it stops increasing.
+			var lastVal uint32
+			iterationsWithNoChange := 0
+			const itDuration = time.Millisecond
+			const timeout = 5 * time.Second
+			for i := 0; ; i++ {
+				if i > int(timeout/itDuration) {
+					t.Fatalf("the number of rows sent still increasing after %s", timeout)
+				}
+				time.Sleep(itDuration)
+				val := atomic.LoadUint32(&numRowsSent)
+				// If we see a ridiculously high value, exit early.
+				if val > 1000000 {
+					t.Fatalf("pushed too many rows (%d)", val)
+				}
+				if val != lastVal {
+					lastVal = val
+					iterationsWithNoChange = 0
+					continue
+				}
+				iterationsWithNoChange++
+				if iterationsWithNoChange > 5 {
+					break
+				}
+			}
+			close(stop)
+
+			// Drain the channels.
+			for i := range chans {
+				go drainRowChannel(&chans[i])
+			}
+			wg.Wait()
+		})
 	}
 }

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -262,7 +262,6 @@ func (ds *ServerImpl) RunSyncFlow(stream DistSQL_RunSyncFlowServer) error {
 	mbox.setFlowCtx(&f.FlowCtx)
 
 	if err := ds.Stopper.RunTask(ctx, "distsqlrun.ServerImpl: sync flow", func(ctx context.Context) {
-		f.waitGroup.Add(1)
 		mbox.start(ctx, &f.waitGroup)
 		f.Start(ctx, func() {})
 		f.Wait()

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -31,13 +31,14 @@ import (
 // that this is a no-grouping aggregator and therefore it does not produce a global ordering but
 // simply guarantees an intra-stream ordering on the physical output stream.
 type sorter struct {
+	processorBase
+
 	flowCtx *FlowCtx
 	// input is a row source without metadata; the metadata is directed straight
 	// to out.output.
 	input NoMetadataRowSource
 	// rawInput is the true input, not wrapped in a NoMetadataRowSource.
 	rawInput RowSource
-	out      procOutputHelper
 	ordering sqlbase.ColumnOrdering
 	matchLen uint32
 	// count is the maximum number of rows that the sorter will push to the

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -32,6 +32,8 @@ import (
 // desired column values to an output RowReceiver.
 // See docs/RFCS/distributed_sql.md
 type tableReader struct {
+	processorBase
+
 	flowCtx *FlowCtx
 
 	tableID   sqlbase.ID
@@ -40,8 +42,6 @@ type tableReader struct {
 
 	fetcher sqlbase.RowFetcher
 	alloc   sqlbase.DatumAlloc
-
-	out procOutputHelper
 }
 
 var _ processor = &tableReader{}

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -26,10 +26,11 @@ import (
 // valuesProcessor is a processor that has no inputs and generates "pre-canned"
 // rows.
 type valuesProcessor struct {
+	processorBase
+
 	flowCtx *FlowCtx
 	columns []DatumInfo
 	data    [][]byte
-	out     procOutputHelper
 }
 
 var _ processor = &valuesProcessor{}


### PR DESCRIPTION
#### distsql: generalize outbox.start calls

We will require a start call for the new hash router, similar to outboxes.
Making the flow code keep track of a list of generic `startable`s instead of
outboxes. Also moving the WaitGroup.Add() calls inside start.

#### distsql: expose output types in procOutputHelper
#### distsql: add OutputTypes method to processor interface

#### distsql: minor cleanup to router tests

Remove the factory methods and just use `makeRouter`. Also remove a duplicate
`ConsumerClosed` call.

#### distsql: buffer messages in routers

This change implements RFC #17105 to avoid deadlocks in distsql: instead of the
routers blocking whenever some consumer is blocked, they now block only when all
consumers are blocked.

The router tests are adjusted; they need to be more relaxed as the consumer
state changes are no longer synchronous. Also enabling the deadlock test and
adding a new test that verifies the router blocks when expected (I verified the
test fails if we remove the semaphore).

Fixes #17097.
