### PR TITLE
sql: implement array functions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -744,3 +744,97 @@ query B
 SELECT ARRAY[1,2,NULL] = ARRAY[1,2,3]
 ----
 false
+
+# ARRAY_APPEND function
+
+query TT
+SELECT ARRAY_APPEND(ARRAY[1,2,3], 4), ARRAY_APPEND(ARRAY[1,2,3], NULL::INT)
+----
+{1,2,3,4} {1,2,3,NULL}
+
+query TT
+SELECT ARRAY_APPEND(NULL::INT[], 4), ARRAY_APPEND(NULL::INT[], NULL::INT)
+----
+{4} {NULL}
+
+# ARRAY_PREPEND function
+
+query TT
+SELECT ARRAY_PREPEND(4, ARRAY[1,2,3]), ARRAY_PREPEND(NULL::INT, ARRAY[1,2,3])
+----
+{4,1,2,3} {NULL,1,2,3}
+
+query TT
+SELECT ARRAY_PREPEND(4, NULL::INT[]), ARRAY_PREPEND(NULL::INT, NULL::INT[])
+----
+{4} {NULL}
+
+# ARRAY_CAT function
+
+query TT
+SELECT ARRAY_CAT(ARRAY[1,2,3], ARRAY[4,5,6]), ARRAY_CAT(ARRAY[1,2,3], NULL::INT[])
+----
+{1,2,3,4,5,6} {1,2,3}
+
+query TT
+SELECT ARRAY_CAT(NULL::INT[], ARRAY[4,5,6]), ARRAY_CAT(NULL::INT[], NULL::INT[])
+----
+{4,5,6} NULL
+
+# ARRAY_REMOVE function
+
+query T
+SELECT ARRAY_REMOVE(ARRAY[1,2,3,2], 2)
+----
+{1,3}
+
+query T
+SELECT ARRAY_REMOVE(ARRAY[1,2,3,NULL::INT], NULL::INT)
+----
+{1,2,3}
+
+query T
+SELECT ARRAY_REMOVE(NULL::INT[], NULL::INT)
+----
+NULL
+
+# ARRAY_REPLACE function
+
+query T
+SELECT ARRAY_REPLACE(ARRAY[1,2,5,4], 5, 3)
+----
+{1,2,3,4}
+
+query TT
+SELECT ARRAY_REPLACE(ARRAY[1,2,NULL,4], NULL::INT, 3), ARRAY_REPLACE(NULL::INT[], 5, 3)
+----
+{1,2,3,4} NULL
+
+# ARRAY_POSITION function
+
+query I
+SELECT ARRAY_POSITION(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], 'mon')
+----
+2
+
+query I
+SELECT ARRAY_POSITION(ARRAY['sun','mon','tue','wed','thu','fri','sat','mon'], 'abc')
+----
+NULL
+
+query I
+SELECT ARRAY_POSITION(NULL::STRING[], 'abc')
+----
+NULL
+
+# ARRAY_POSITIONS function
+
+query TT
+SELECT ARRAY_POSITIONS(ARRAY['A','A','B','A'], 'A'), ARRAY_POSITIONS(ARRAY['A','A','B','A'], 'C')
+----
+{1,2,4} {}
+
+query T
+SELECT ARRAY_POSITIONS(NULL::STRING[], 'A')
+----
+NULL

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -193,6 +193,36 @@ func (BinOp) preferred() bool {
 	return false
 }
 
+func appendToMaybeNullArray(typ Type, left Datum, right Datum) (Datum, error) {
+	result := NewDArray(typ)
+	if left != DNull {
+		for _, e := range MustBeDArray(left).Array {
+			if err := result.Append(e); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := result.Append(right); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func prependToMaybeNullArray(typ Type, left Datum, right Datum) (Datum, error) {
+	result := NewDArray(typ)
+	if err := result.Append(left); err != nil {
+		return nil, err
+	}
+	if right != DNull {
+		for _, e := range MustBeDArray(right).Array {
+			if err := result.Append(e); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return result, nil
+}
+
 // TODO(justin): these might be improved by making arrays into an interface and
 // then introducing a ConcatenatedArray implementation which just references two
 // existing arrays. This would optimize the common case of appending an element
@@ -206,18 +236,7 @@ func initArrayElementConcatenation() {
 			ReturnType:   TArray{typ},
 			nullableArgs: true,
 			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				result := NewDArray(typ)
-				if left != DNull {
-					for _, e := range MustBeDArray(left).Array {
-						if err := result.Append(e); err != nil {
-							return nil, err
-						}
-					}
-				}
-				if err := result.Append(right); err != nil {
-					return nil, err
-				}
-				return result, nil
+				return appendToMaybeNullArray(typ, left, right)
 			},
 		})
 
@@ -227,21 +246,32 @@ func initArrayElementConcatenation() {
 			ReturnType:   TArray{typ},
 			nullableArgs: true,
 			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				result := NewDArray(typ)
-				if err := result.Append(left); err != nil {
-					return nil, err
-				}
-				if right != DNull {
-					for _, e := range MustBeDArray(right).Array {
-						if err := result.Append(e); err != nil {
-							return nil, err
-						}
-					}
-				}
-				return result, nil
+				return prependToMaybeNullArray(typ, left, right)
 			},
 		})
 	}
+}
+
+func concatArrays(typ Type, left Datum, right Datum) (Datum, error) {
+	if left == DNull && right == DNull {
+		return DNull, nil
+	}
+	result := NewDArray(typ)
+	if left != DNull {
+		for _, e := range MustBeDArray(left).Array {
+			if err := result.Append(e); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if right != DNull {
+		for _, e := range MustBeDArray(right).Array {
+			if err := result.Append(e); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func initArrayToArrayConcatenation() {
@@ -253,25 +283,7 @@ func initArrayToArrayConcatenation() {
 			ReturnType:   TArray{typ},
 			nullableArgs: true,
 			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				if left == DNull && right == DNull {
-					return DNull, nil
-				}
-				result := NewDArray(typ)
-				if left != DNull {
-					for _, e := range MustBeDArray(left).Array {
-						if err := result.Append(e); err != nil {
-							return nil, err
-						}
-					}
-				}
-				if right != DNull {
-					for _, e := range MustBeDArray(right).Array {
-						if err := result.Append(e); err != nil {
-							return nil, err
-						}
-					}
-				}
-				return result, nil
+				return concatArrays(typ, left, right)
 			},
 		})
 	}


### PR DESCRIPTION
First commit is #17318, which this depends on.

This commit implements the following functions that operate on arrays,
which are documented at
https://www.postgresql.org/docs/10/static/functions-array.html.

* ARRAY_APPEND
* ARRAY_CAT
* ARRAY_PREPEND
* ARRAY_REMOVE
* ARRAY_REPLACE
* ARRAY_POSITION
* ARRAY_POSITIONS

I picked out a bunch that seemed the most useful, we can do more if we
think that they will be valuable.