### PR TITLE
storage: Clean up code for computing node liveness / lease durations

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -81,11 +81,15 @@ const (
 	rangeLeaseRaftElectionTimeoutMultiplier = 3
 
 	// rangeLeaseRenewalFraction specifies what fraction the range lease renewal
-	// duration should be of the range lease active time.
-	rangeLeaseRenewalFraction = 0.8
+	// duration should be of the range lease active time. For example, with a
+	// value of 0.2 and a lease duration of 10 seconds, leases would be eagerly
+	// renewed 2 seconds into each lease.
+	rangeLeaseRenewalFraction = 0.5
 
 	// livenessRenewalFraction specifies what fraction the node liveness renewal
-	// duration should be of the node liveness duration.
+	// duration should be of the node liveness duration. For example, with a
+	// value of 0.2 and a liveness duration of 10 seconds, each node's liveness
+	// record would be eagerly renewed after 2 seconds.
 	livenessRenewalFraction = 0.5
 
 	// replicaRequestQueueSize specifies the maximum number of requests to queue
@@ -148,8 +152,8 @@ func RaftElectionTimeout(
 func RangeLeaseDurations(
 	raftElectionTimeout time.Duration,
 ) (rangeLeaseActive time.Duration, rangeLeaseRenewal time.Duration) {
-	rangeLeaseActive = rangeLeaseRaftElectionTimeoutMultiplier * raftElectionTimeout
-	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * (1 - rangeLeaseRenewalFraction))
+	rangeLeaseActive = time.Duration(rangeLeaseRaftElectionTimeoutMultiplier * float64(raftElectionTimeout))
+	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * rangeLeaseRenewalFraction)
 	return
 }
 


### PR DESCRIPTION
This is just pulling the least controversial parts of #15331 back in.
It's only refactoring -- no runtime values are changing.

(The reason no values are changing is because we previously were using the node liveness durations for both node liveness and range leases, and while we aren't doing that anymore, I've changed `rangeLeaseRenewalFraction` to be the same as `livenessRenewalFraction`).