### PR TITLE
sql/parser: fix verification of '+' and '-' signs in interval parts

### DIFF
--- a/pkg/sql/parser/interval.go
+++ b/pkg/sql/parser/interval.go
@@ -200,7 +200,10 @@ func sqlStdToDuration(s string) (duration.Duration, error) {
 				part = part[1:]
 			}
 		}
-		if part[0] == '-' {
+		if len(part) == 0 {
+			return d, errors.Errorf(errInvalidSQLDuration, s)
+		}
+		if part[0] == '-' || part[0] == '+' {
 			return d, errors.Errorf(errInvalidSQLDuration, s)
 		}
 


### PR DESCRIPTION
interval.sqlStdToDuration didn't check that interval part can be '+' or start with '++', '--', "+++", "---" etc

fixes #17308 