### PR TITLE
cli: bump max bytes in TestNodeStatus

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1435,7 +1435,7 @@ func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 		idx    int
 		maxval int64
 	}{
-		{"live_bytes", 5, 50000},
+		{"live_bytes", 5, 100000},
 		{"key_bytes", 6, 30000},
 		{"value_bytes", 7, 100000},
 		{"intent_bytes", 8, 30000},


### PR DESCRIPTION
We are probably storing more data now and the test was not updated.
This is not the first time this size has been bumped.