### PR TITLE
build: avoid Git race condition when computing build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,9 +352,17 @@ $(ARCHIVE).tmp: .buildinfo/tag .buildinfo/rev
 .buildinfo:
 	@mkdir -p $@
 
+# Do not use plumbing commands, like git diff-index, in this target. Our build
+# process modifies files quickly enough that plumbing commands report false
+# positives on filesystems with only one second of resolution as a performance
+# optimization. Porcelain commands, like git diff, exist to detect and remove
+# these false positives.
+#
+# For details, see the "Possible timestamp problems with diff-files?" thread on
+# the Git mailing list (http://marc.info/?l=git&m=131687596307197).
 .buildinfo/tag: | .buildinfo
 	@{ git describe --tags --exact-match 2> /dev/null || git rev-parse --short HEAD; } | tr -d \\n > $@
-	@git diff-index --quiet HEAD || echo -dirty >> $@
+	@git diff --quiet HEAD || echo -dirty >> $@
 
 .buildinfo/rev: | .buildinfo
 	@git rev-parse HEAD > $@

--- a/build/teamcity-publish-s3-binaries.sh
+++ b/build/teamcity-publish-s3-binaries.sh
@@ -7,25 +7,9 @@ set -euxo pipefail
 
 export BUILDER_HIDE_GOPATH_SRC=1
 
-echo 'starting release build'
-cat .buildinfo/tag || true
-cat .buildinfo/rev || true
-build/builder.sh git status
-
 build/builder.sh go install ./pkg/cmd/publish-artifacts
-
-echo 'installed release builder'
-cat .buildinfo/tag || true
-cat .buildinfo/rev || true
-build/builder.sh git status
-
 build/builder.sh env \
 	AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
 	AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
 	TC_BUILD_BRANCH="$TC_BUILD_BRANCH" \
 	publish-artifacts "$@"
-
-echo 'built and uploaded artifacts'
-cat .buildinfo/tag || true
-cat .buildinfo/rev || true
-build/builder.sh git status

--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -2,6 +2,15 @@
 
 set -euo pipefail
 
+# Regression test for #14284, where builds were erroneously marked as dirty when
+# build/variables.mk was out of date due to a race condition in Git.
+touch -m -t 197001010000 build/variables.mk
+build/builder.sh make .buildinfo/tag
+if grep -F --quiet -- dirty .buildinfo/tag; then
+  echo "error: build tag recorded as dirty: $(<.buildinfo/tag)" >&2
+  exit 1
+fi
+
 build/builder.sh make archive ARCHIVE=build/cockroach.src.tgz
 
 # We use test the source archive in a minimal image; the builder image bundles


### PR DESCRIPTION
Occasionally, TeamCity release builds would have a build tag that ended
with "-dirty", despite being built from a clean checkout. Turns out this
was due to an performance optimization in `git diff-index`. Git plumbing
commands can report false positives if files change too quickly on a
filesystem where mtimes have only one-second resolution; Git porcelain
commands exist to detect and remove these race conditions.

The solution is to simply use the corresponding porcelain command, `git
diff`, in place of `git diff-index`.

Fixes #14284.