### PR TITLE
cli/sql: print the execution time of statements

### DIFF
--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -223,7 +223,7 @@ func runListCerts(cmd *cobra.Command, args []string) error {
 		addRow(cert, fmt.Sprintf("user: %s", user))
 	}
 
-	return printQueryOutput(os.Stdout, certTableHeaders, newRowSliceIter(rows), "", cliCtx.tableDisplayFormat)
+	return printQueryOutput(os.Stdout, certTableHeaders, newRowSliceIter(rows), "")
 }
 
 var certCmds = []*cobra.Command{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -49,6 +49,9 @@ type cliContext struct {
 
 	// tableDisplayFormat indicates how to format result tables.
 	tableDisplayFormat tableDisplayFormat
+
+	// showTimes indicates whether to display query times after each result line.
+	showTimes bool
 }
 
 type tableDisplayFormat int

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -64,6 +64,7 @@ var serverSSLCertsDir string
 // InitCLIDefaults is used for testing.
 func InitCLIDefaults() {
 	cliCtx.tableDisplayFormat = tableDisplayTSV
+	cliCtx.showTimes = false
 	dumpCtx.dumpMode = dumpBoth
 }
 
@@ -356,7 +357,10 @@ func init() {
 	// By default, these commands print their output as pretty-formatted
 	// tables on terminals, and TSV when redirected to a file. The user
 	// can override with --format.
+	// By default, query times are not displayed. The default is overridden
+	// in the CLI shell.
 	cliCtx.tableDisplayFormat = tableDisplayTSV
+	cliCtx.showTimes = false
 	if isInteractive {
 		cliCtx.tableDisplayFormat = tableDisplayPretty
 	}

--- a/pkg/cli/format_table.go
+++ b/pkg/cli/format_table.go
@@ -96,16 +96,14 @@ func newRowIter(rows *sqlRows, showMoreChars bool) *rowIter {
 // printQueryOutput takes a list of column names and a list of row contents
 // writes a formatted table to 'w', or simply the tag if empty. Note that
 // printQueryOutput expects the tag to already be properly formatted.
-func printQueryOutput(
-	w io.Writer, cols []string, allRows rowStrIter, tag string, displayFormat tableDisplayFormat,
-) error {
+func printQueryOutput(w io.Writer, cols []string, allRows rowStrIter, tag string) error {
 	if len(cols) == 0 {
 		// This operation did not return rows, just show the tag.
 		fmt.Fprintln(w, tag)
 		return nil
 	}
 
-	switch displayFormat {
+	switch cliCtx.tableDisplayFormat {
 	case tableDisplayPretty:
 		// Initialize tablewriter and set column names as the header row.
 		table := tablewriter.NewWriter(w)
@@ -141,7 +139,7 @@ func printQueryOutput(
 			util.Pluralize(int64(len(allRowsSlice))))
 
 		csvWriter := csv.NewWriter(w)
-		if displayFormat == tableDisplayTSV {
+		if cliCtx.tableDisplayFormat == tableDisplayTSV {
 			csvWriter.Comma = '\t'
 		}
 		_ = csvWriter.Write(cols)

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -69,7 +69,7 @@ func runLsNodes(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	return printQueryOutput(os.Stdout, lsNodesColumnHeaders, newRowSliceIter(rows), "", cliCtx.tableDisplayFormat)
+	return printQueryOutput(os.Stdout, lsNodesColumnHeaders, newRowSliceIter(rows), "")
 }
 
 var nodesColumnHeaders = []string{
@@ -138,8 +138,7 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("expected no arguments or a single node ID")
 	}
 
-	return printQueryOutput(os.Stdout, nodesColumnHeaders, newRowSliceIter(nodeStatusesToRows(nodeStatuses)), "",
-		cliCtx.tableDisplayFormat)
+	return printQueryOutput(os.Stdout, nodesColumnHeaders, newRowSliceIter(nodeStatusesToRows(nodeStatuses)), "")
 }
 
 // nodeStatusesToRows converts NodeStatuses to SQL-like result rows, so that we can pretty-print

--- a/pkg/cli/sql_util_test.go
+++ b/pkg/cli/sql_util_test.go
@@ -101,9 +101,10 @@ func TestRunQuery(t *testing.T) {
 	// Use a buffer as the io.Writer.
 	var b bytes.Buffer
 
+	cliCtx.tableDisplayFormat = tableDisplayPretty
+
 	// Non-query statement.
-	if err := runQueryAndFormatResults(conn, &b, makeQuery(`SET DATABASE=system`),
-		tableDisplayPretty); err != nil {
+	if err := runQueryAndFormatResults(conn, &b, makeQuery(`SET DATABASE=system`)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -136,7 +137,7 @@ SET
 	}
 
 	if err := runQueryAndFormatResults(conn, &b,
-		makeQuery(`SHOW COLUMNS FROM system.namespace`), tableDisplayPretty); err != nil {
+		makeQuery(`SHOW COLUMNS FROM system.namespace`)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -158,8 +159,7 @@ SET
 
 	// Test placeholders.
 	if err := runQueryAndFormatResults(conn, &b,
-		makeQuery(`SELECT * FROM system.namespace WHERE name=$1`, "descriptor"),
-		tableDisplayPretty); err != nil {
+		makeQuery(`SELECT * FROM system.namespace WHERE name=$1`, "descriptor")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -178,7 +178,7 @@ SET
 
 	// Test multiple results.
 	if err := runQueryAndFormatResults(conn, &b,
-		makeQuery(`SELECT 1; SELECT 2, 3; SELECT 'hello'`), tableDisplayPretty); err != nil {
+		makeQuery(`SELECT 1; SELECT 2, 3; SELECT 'hello'`)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -45,7 +45,7 @@ func runGetUser(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 	return runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(`SELECT * FROM system.users WHERE username=$1`, args[0]), cliCtx.tableDisplayFormat)
+		makeQuery(`SELECT * FROM system.users WHERE username=$1`, args[0]))
 }
 
 // A lsUsersCmd command displays a list of users.
@@ -68,7 +68,7 @@ func runLsUsers(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 	return runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(`SELECT username FROM system.users`), cliCtx.tableDisplayFormat)
+		makeQuery(`SELECT username FROM system.users`))
 }
 
 // A rmUserCmd command removes the user for the specified username.
@@ -91,8 +91,7 @@ func runRmUser(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 	return runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(`DELETE FROM system.users WHERE username=$1`, args[0]),
-		cliCtx.tableDisplayFormat)
+		makeQuery(`DELETE FROM system.users WHERE username=$1`, args[0]))
 }
 
 // A setUserCmd command creates a new or updates an existing user.
@@ -138,8 +137,7 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 	// TODO(asubiotto): Implement appropriate server-side authorization rules
 	// for users to be able to change their own passwords.
 	return runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(`UPSERT INTO system.users VALUES ($1, $2)`, username, hashed),
-		cliCtx.tableDisplayFormat)
+		makeQuery(`UPSERT INTO system.users VALUES ($1, $2)`, username, hashed))
 }
 
 var userCmds = []*cobra.Command{

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -402,7 +402,7 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 		}
 
 		if err := runQueryAndFormatResults(conn, os.Stdout,
-			makeQuery(`DELETE FROM system.zones WHERE id=$1`, id), cliCtx.tableDisplayFormat); err != nil {
+			makeQuery(`DELETE FROM system.zones WHERE id=$1`, id)); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This patch adds the printing of query time after query results in the
CLI SQL shell. This helps users who use the CLI to try out queries
interactively and see which one performs faster.

Example output:
```
root@:26257/> create table test.kv(k int primary key, v int);
CREATE TABLE

Time: 20.596987ms

root@:26257/> create index vidx on test.kv(v);
CREATE INDEX

Time: 135.309993ms

root@:26257/> select * from test.kv;
+---+---+
| k | v |
+---+---+
+---+---+
(0 rows)

Time: 1.126903ms

root@:26257/>
```

This can be disabled/enabled with `\set show_time` / `\unset show_time`

The time display is automatically enabled when two conditions are met:
- the shell is interactive;
- the output format is `pretty`.

The first condition ensures that the results stay deterministic when
output is redirected, e.g. in tests. The second condition ensures that
a script that intends to have output formatted as valid HTML, CSV,
etc., does not get its output polluted by timing information.

Suggested by / informs #17353.