### PR TITLE
server/status: ignore cgoTotal memory in test

### DIFF
--- a/pkg/server/status/jemalloc_test.go
+++ b/pkg/server/status/jemalloc_test.go
@@ -28,23 +28,19 @@ func TestJemalloc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.TODO()
-	cgoAllocated, cgoTotal, err := getJemallocStats(ctx)
+	cgoAllocated, _, err := getJemallocStats(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i := 0; i < 10; i++ {
 		allocateMemory()
-		cgoAllocatedN, cgoTotalN, err := getJemallocStats(ctx)
+		cgoAllocatedN, _, err := getJemallocStats(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if cgoAllocatedN == cgoAllocated {
 			t.Errorf("allocated stat not incremented on allocation: %d", cgoAllocated)
 		}
-		if cgoTotalN == cgoTotal {
-			t.Errorf("total stat not incremented on allocation: %d", cgoTotal)
-		}
 		cgoAllocated = cgoAllocatedN
-		cgoTotal = cgoTotalN
 	}
 }


### PR DESCRIPTION
This test calls malloc(16 << 10) 10 times and checks that the jemalloc
stats increase each time. It looks like for some reason jemalloc
pre-allocated a larger chunk this time and so the "total" stat (but not
the "allocated" stat) remained constant. Checking for just the allocated
stat should suffice for the purposes of this test.

Closes #16517.