### PR TITLE
config: bump base GC time to 25 hours

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -531,7 +531,7 @@ func Example_zone() {
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 1
 	// constraints: [us-east-1a, ssd]
 	// zone ls
@@ -542,7 +542,7 @@ func Example_zone() {
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 1
 	// constraints: []
 	// zone get system.nonexistent
@@ -552,7 +552,7 @@ func Example_zone() {
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 1
 	// constraints: [us-east-1a, ssd]
 	// zone set system.lease --file=./testdata/zone_attrs.yaml
@@ -565,7 +565,7 @@ func Example_zone() {
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 3
 	// constraints: [us-east-1a, ssd]
 	// zone get system
@@ -573,7 +573,7 @@ func Example_zone() {
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 3
 	// constraints: [us-east-1a, ssd]
 	// zone rm system
@@ -586,21 +586,21 @@ func Example_zone() {
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 3
 	// constraints: []
 	// zone set .system --file=./testdata/zone_range_max_bytes.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 3
 	// constraints: []
 	// zone set .timeseries --file=./testdata/zone_range_max_bytes.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 3
 	// constraints: []
 	// zone get .system
@@ -608,7 +608,7 @@ func Example_zone() {
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 3
 	// constraints: []
 	// zone ls
@@ -620,7 +620,7 @@ func Example_zone() {
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 3
 	// constraints: []
 	// zone get system
@@ -628,14 +628,14 @@ func Example_zone() {
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 3
 	// constraints: []
 	// zone set .default --disable-replication
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 1
 	// constraints: []
 	// zone get system
@@ -643,7 +643,7 @@ func Example_zone() {
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 86400
+	//   ttlseconds: 90000
 	// num_replicas: 1
 	// constraints: []
 	// zone rm .meta

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,7 +47,15 @@ var (
 		RangeMinBytes: 1 << 20,  // 1 MB
 		RangeMaxBytes: 64 << 20, // 64 MB
 		GC: GCPolicy{
-			TTLSeconds: 24 * 60 * 60, // 1 day
+			// Use 25 hours instead of the previous 24 to make users successful by
+			// default. Users desiring to take incremental backups every 24h may
+			// incorrectly assume that the previous default 24h was sufficient to do
+			// that. But the equation for incremental backups is:
+			// 	GC TTLSeconds >= (desired backup interval) + (time to perform incremental backup)
+			// We think most new users' incremental backups will complete within an
+			// hour, and larger clusters will have more experienced operators and will
+			// understand how to change these settings if needed.
+			TTLSeconds: 25 * 60 * 60,
 		},
 	}
 


### PR DESCRIPTION
The motivation for this change is to help new users correctly
support their own cluster. Say a new users starts up a new
cluster and begins putting data into it. They would like to
have backups, so they start taking daily (full) backups. They
quickly notice these take a long time, and would like to move
to something incremental. They read the docs about [incremental
backups](https://www.cockroachlabs.com/docs/stable/backup.html#incremental-backups)
which say:

> You can only create incremental backups within the garbage collection
period of the base backup's most recent timestamp.

The user clicks the link to the zone docs and quickly finds out
the default GC interval is 24 hours and makes the obvious (though
incorrect) assumption that they can safely perform incremental backups
every 24 hours. This assumption is incorrect because "within" from
the docs above means that the backup process, which is made up of many
queued requests, must start its last request before the GC interval.

The equation relating these things together is:

`GC interval = (desired backup interval) + (time to perform incremental
backup) + (fudge factor)`

So if users want to do a daily backup, they need the GC interval to
be 24h + something, and for new clusters an hour is almost certainly
good enough. We assume that as clusters become larger, the operators
will be more familiar with the system, will read more docs, and be
aware of this above equation (which we also need to document in the
incremental backup section, since it's not very obvious). But for most
people running a cluster, we'd like them to be successful by default.

We are aware that there are good arguments for reducing the default
GC time, and those can certainly be discussed elsewhere. However we
think that changing this time from 24h to 25h doesn't have any real
impact on any of those decisions since it is such a small change,
and so this PR shouldn't be blocked because of that uncertainty.