### PR TITLE
sql/pgwire: reject prepared queries with too many arguments

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1665,3 +1665,35 @@ func TestPGWireResultChange(t *testing.T) {
 		t.Fatalf("expected %d rows, got %d", count, countAfter)
 	}
 }
+
+func TestPGWireTooManyArguments(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	pgURL, cleanupFn := sqlutils.PGUrl(t, s.ServingAddr(), t.Name(), url.User(security.RootUser))
+	defer cleanupFn()
+
+	db, err := gosql.Open("postgres", pgURL.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	query := "SELECT"
+
+	args := make([]interface{}, 1<<16)
+	for i := 1; i <= 1<<16; i++ {
+		comma := ","
+		if i == 1 {
+			comma = ""
+		}
+		query += fmt.Sprintf("%s $%d::int", comma, i)
+		args[i-1] = i
+	}
+	query += ";"
+
+	if _, err := db.Prepare(query); !testutils.IsError(err, "more than 65535 arguments") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"math"
 )
 
 //go:generate stringer -type=clientMessageType
@@ -517,6 +518,13 @@ func (c *v3Conn) handleSimpleQuery(buf *readBuffer) error {
 	return c.finishExecute(results, nil, true, 0)
 }
 
+// maxPreparedStatementArgs is the maximum number of arguments a prepared
+// statement can have when prepared via the Postgres wire protocol. This is not
+// documented by Postgres, but is a consequence of the fact that a 16-bit
+// integer in the wire format is used to indicate the number of values to bind
+// during prepared statement execution.
+const maxPreparedStatementArgs int = math.MaxUint16
+
 func (c *v3Conn) handleParse(buf *readBuffer) error {
 	name, err := buf.getString()
 	if err != nil {
@@ -567,6 +575,10 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 	}
 	// Convert the inferred SQL types back to an array of pgwire Oids.
 	inTypes := make([]oid.Oid, 0, len(stmt.SQLTypes))
+	if len(stmt.SQLTypes) > maxPreparedStatementArgs {
+		return c.sendError(pgerror.NewErrorf(pgerror.CodeProtocolViolationError,
+			"more than 65535 arguments to prepared statement: %d", len(stmt.SQLTypes)))
+	}
 	for k, t := range stmt.SQLTypes {
 		i, err := strconv.Atoi(k)
 		if err != nil || i < 1 {


### PR DESCRIPTION
The Postgres wire protocol imposes a hard cap of 65535 on the number of
arguments allowed in a prepared statement.

Under certain circumstances, we were erroneously permitting
wire-protocol prepares of queries with more than that number of
arguments, which led to server crashes when trying to execute them.

Now, we notice when a prepared query has too many arguments and return
a corresponding error during the prepare phase.

Closes #17236.