### PR TITLE
kv: change LeaseHolderCache.mu to a RWMutex

### DIFF
--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -793,7 +793,7 @@ func TestEvictCacheOnError(t *testing.T) {
 			RangeDescriptorDB: defaultMockRangeDescriptorDB,
 		}
 		ds := NewDistSender(cfg, g)
-		ds.updateLeaseHolderCache(context.TODO(), 1, leaseHolder)
+		ds.leaseHolderCache.Update(context.TODO(), 1, leaseHolder)
 		key := roachpb.Key("a")
 		put := roachpb.NewPut(key, roachpb.MakeValueFromString("value"))
 


### PR DESCRIPTION
The leaseholder cache is consulted on every RPC, though updated much
less frequently.

Remove duplicate logging and normalize the LeaseHolderCache spelling of
"lease holder" to "leaseholder" which we use almost everywhere else in
the code base.

Fixes #17202