### PR TITLE
CODEOWNERS: associate libroach appropriately

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,3 +43,6 @@
 /Gopkg.*               @cockroachdb/build
 /.*                    @cockroachdb/build
 /.github/              @cockroachdb/build
+
+/c-deps/libroach/      @cockroachdb/core
+/c-deps/libroach/ccl/  @cockroachdb/core @cockroachdb/sql-ccl


### PR DESCRIPTION
Even though libroach lives in c-deps, it belongs to core (and part of it
belongs to sqlccl), not build.