### PR TITLE
sql/jobs: fix race in TestRegistryCancel

### DIFF
--- a/pkg/sql/jobs/helpers_test.go
+++ b/pkg/sql/jobs/helpers_test.go
@@ -82,7 +82,8 @@ func (nl *FakeNodeLiveness) Self() (*storage.Liveness, error) {
 	}
 	nl.mu.Lock()
 	defer nl.mu.Unlock()
-	return nl.mu.livenessMap[FakeNodeID.Get()], nil
+	selfCopy := *nl.mu.livenessMap[FakeNodeID.Get()]
+	return &selfCopy, nil
 }
 
 // GetLivenesses implements the implicit storage.NodeLiveness interface.


### PR DESCRIPTION
Merely an oversight; GetLivenesses() has always expected concurrent
reads from the registry loop and properly copies the livenesses it
returns, while Self() did not.