### PR TITLE
sqlccl: skip flaky TestBackupRestoreInterleaved

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -803,6 +803,8 @@ func TestBackupRestoreResume(t *testing.T) {
 
 func TestBackupRestoreInterleaved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#17402 currently flaky")
+
 	const numAccounts = 10
 
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)


### PR DESCRIPTION
This is flaking a lot and getting in the way of merging PRs. Skip while
I investigate.