### PR TITLE
storageccl: codify and test existing exportStore api semantics

### DIFF
--- a/build/style_test.go
+++ b/build/style_test.go
@@ -563,6 +563,7 @@ func TestStyle(t *testing.T) {
 			stream.GrepNot(`cockroach/pkg/(base|security|util/(log|randutil|stop)): log$`),
 			stream.GrepNot(`cockroach/pkg/(server/serverpb|ts/tspb): github\.com/golang/protobuf/proto$`),
 			stream.GrepNot(`cockroach/pkg/util/caller: path$`),
+			stream.GrepNot(`cockroach/pkg/ccl/storageccl: path$`),
 			stream.GrepNot(`cockroach/pkg/util/uuid: github\.com/satori/go\.uuid$`),
 		), func(s string) {
 			switch {


### PR DESCRIPTION
as matt found in testing, our stores already essentially all allowed this usage, but to rely on it, we want to document and test it.
this makes sure that we can provide the full path to a file as the prefix in an exportStore, and then simply use an empty basepath
when attempting to read or write individual files to just operate on the file pointed to in the base path.

This also converts all our filepath.Join to path.Join, which only really matters on windows.