### PR TITLE
sqlccl: allocate restored table ids in the same order as in the backup

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -803,8 +803,6 @@ func TestBackupRestoreResume(t *testing.T) {
 
 func TestBackupRestoreInterleaved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#17402 currently flaky")
-
 	const numAccounts = 10
 
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts)

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -45,6 +45,13 @@ func (ids IDs) Len() int           { return len(ids) }
 func (ids IDs) Less(i, j int) bool { return ids[i] < ids[j] }
 func (ids IDs) Swap(i, j int)      { ids[i], ids[j] = ids[j], ids[i] }
 
+// TableDescriptors is a sortable list of *TableDescriptors.
+type TableDescriptors []*TableDescriptor
+
+func (t TableDescriptors) Len() int           { return len(t) }
+func (t TableDescriptors) Less(i, j int) bool { return t[i].ID < t[j].ID }
+func (t TableDescriptors) Swap(i, j int)      { t[i], t[j] = t[j], t[i] }
+
 // ColumnID is a custom type for ColumnDescriptor IDs.
 type ColumnID parser.ColumnID
 


### PR DESCRIPTION
The ordering of the new IDs must be the same as the old ones, otherwise
the keys may sort differently after they're rekeyed. We could handle
this by chunking the AddSSTable calls more finely in Import, but it
would be a big performance hit.

Fixes #17402.