### PR TITLE
ui: add debug page for raft message counts

### DIFF
--- a/pkg/server/debug.go
+++ b/pkg/server/debug.go
@@ -173,7 +173,7 @@ func init() {
       </tr>
       <tr>
         <td>raft</td>
-        <td><a href="/_status/raft">raft</a></td>
+        <td><a href="/_status/raft">raft</a>, <a href="../#/raft/messages/all">messages</a></td>
       </tr>
       <tr>
         <td>security</td>

--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -37,6 +37,7 @@ import { EventPage } from "src/views/cluster/containers/events";
 import QueryPlan from "src/views/devtools/containers/queryPlan";
 import Raft from "src/views/devtools/containers/raft";
 import RaftRanges from "src/views/devtools/containers/raftRanges";
+import RaftMessages from "src/views/devtools/containers/raftMessages";
 import ClusterViz from "src/views/devtools/containers/clusterViz";
 import ProblemRanges from "src/views/reports/containers/problemRanges";
 import Network from "src/views/reports/containers/network";
@@ -72,6 +73,8 @@ ReactDOM.render(
         <Route path="raft" component={ Raft }>
           <IndexRedirect to="ranges" />
           <Route path="ranges" component={ RaftRanges } />
+          <Route path="messages/all" component={ RaftMessages } />
+          <Route path={`messages/node/:${nodeIDAttr}`} component={ RaftMessages } />
         </Route>
         <Route path="queryplan" component={ QueryPlan } />
         <Route path="clusterviz" component={ ClusterViz } />

--- a/pkg/ui/src/views/devtools/containers/raft/index.tsx
+++ b/pkg/ui/src/views/devtools/containers/raft/index.tsx
@@ -17,6 +17,7 @@ export default class Layout extends React.Component<{}, {}> {
       <div className="nav-container">
         <ul className="nav">
           <ListLink to="/raft/ranges">Ranges</ListLink>
+          <ListLink to="/raft/messages/all">Messages</ListLink>
         </ul>
       </div>
       { this.props.children }

--- a/pkg/ui/src/views/devtools/containers/raftMessages/index.tsx
+++ b/pkg/ui/src/views/devtools/containers/raftMessages/index.tsx
@@ -1,0 +1,178 @@
+import _ from "lodash";
+import PropTypes from "prop-types";
+import React from "react";
+import { connect } from "react-redux";
+import { InjectedRouter, RouterState } from "react-router";
+import { createSelector } from "reselect";
+
+import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
+import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
+import { AdminUIState } from "src/redux/state";
+import { nodeIDAttr } from "src/util/constants";
+import {
+  GraphDashboardProps, storeIDsForNode,
+} from "src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils";
+import TimeScaleDropdown from "src/views/cluster/containers/timescale";
+import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
+import { PageConfig, PageConfigItem } from "src/views/shared/components/pageconfig";
+import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
+
+import messagesDashboard from "./messages";
+
+// The properties required by a NodeGraphs component.
+interface NodeGraphsOwnProps {
+  refreshNodes: typeof refreshNodes;
+  refreshLiveness: typeof refreshLiveness;
+  nodesQueryValid: boolean;
+  livenessQueryValid: boolean;
+  nodesSummary: NodesSummary;
+}
+
+type NodeGraphsProps = NodeGraphsOwnProps & RouterState;
+
+/**
+ * NodeGraphs renders the main content of the cluster graphs page.
+ */
+class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
+  // Magic to add react router to the context.
+  // See https://github.com/ReactTraining/react-router/issues/975
+  // TODO(mrtracy): Switch this, and the other uses of contextTypes, to use the
+  // 'withRouter' HoC after upgrading to react-router 4.x.
+  static contextTypes = {
+    router: PropTypes.object.isRequired,
+  };
+  context: { router: InjectedRouter & RouterState; };
+
+  /**
+   * Selector to compute node dropdown options from the current node summary
+   * collection.
+   */
+  private nodeDropdownOptions = createSelector(
+    (summary: NodesSummary) => summary.nodeStatuses,
+    (nodeStatuses): DropdownOption[] => {
+      const base = [{value: "", label: "Cluster"}];
+      return base.concat(_.map(nodeStatuses, (ns) => {
+        return {
+          value: ns.desc.node_id.toString(),
+          label: ns.desc.address.address_field,
+        };
+      }));
+    },
+  );
+
+  static title() {
+    return "Raft Messages";
+  }
+
+  refresh(props = this.props) {
+    if (!props.nodesQueryValid) {
+      props.refreshNodes();
+    }
+    if (!props.livenessQueryValid) {
+      props.refreshLiveness();
+    }
+  }
+
+  setClusterPath(nodeID: string) {
+    if (!_.isString(nodeID) || nodeID === "") {
+      this.context.router.push("/raft/messages/all/");
+    } else {
+      this.context.router.push(`/raft/messages/node/${nodeID}`);
+    }
+  }
+
+  nodeChange = (selected: DropdownOption) => {
+    this.setClusterPath(selected.value);
+  }
+
+  componentWillMount() {
+    this.refresh();
+  }
+
+  componentWillReceiveProps(props: NodeGraphsProps) {
+    this.refresh(props);
+  }
+
+  render() {
+    const { params, nodesSummary } = this.props;
+
+    const selectedNode = params[nodeIDAttr] || "";
+    const nodeSources = (selectedNode !== "") ? [selectedNode] : null;
+
+    // When "all" is the selected source, some graphs display a line for every
+    // node in the cluster using the nodeIDs collection. However, if a specific
+    // node is already selected, these per-node graphs should only display data
+    // only for the selected node.
+    const nodeIDs = nodeSources ? nodeSources : nodesSummary.nodeIDs;
+
+    // If a single node is selected, we need to restrict the set of stores
+    // queried for per-store metrics (only stores that belong to that node will
+    // be queried).
+    const storeSources = nodeSources ? storeIDsForNode(nodesSummary, nodeSources[0]) : null;
+
+    // tooltipSelection is a string used in tooltips to reference the currently
+    // selected nodes. This is a prepositional phrase, currently either "across
+    // all nodes" or "on node X".
+    const tooltipSelection = (nodeSources && nodeSources.length === 1)
+                              ? `on node ${nodeSources[0]}`
+                              : "across all nodes";
+
+    const dashboardProps: GraphDashboardProps = {
+      nodeIDs,
+      nodesSummary,
+      nodeSources,
+      storeSources,
+      tooltipSelection,
+    };
+
+    // Generate graphs for the current dashboard, wrapping each one in a
+    // MetricsDataProvider with a unique key.
+    const graphs = messagesDashboard(dashboardProps);
+    const graphComponents = _.map(graphs, (graph, idx) => {
+      const key = `nodes.raftMessages.${idx}`;
+      return (
+        <div key={key}>
+          <MetricsDataProvider id={key}>
+            {graph}
+          </MetricsDataProvider>
+        </div>
+      );
+    });
+
+    return (
+      <div>
+        <PageConfig>
+          <PageConfigItem>
+            <Dropdown
+              title="Graph"
+              options={this.nodeDropdownOptions(this.props.nodesSummary)}
+              selected={selectedNode}
+              onChange={this.nodeChange}
+            />
+          </PageConfigItem>
+          <PageConfigItem>
+            <TimeScaleDropdown />
+          </PageConfigItem>
+        </PageConfig>
+        <div className="section l-columns">
+          <div className="chart-group l-columns__left">
+            { graphComponents }
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state: AdminUIState) {
+  return {
+    nodesSummary: nodesSummarySelector(state),
+    nodesQueryValid: state.cachedData.nodes.valid,
+    livenessQueryValid: state.cachedData.nodes.valid,
+  };
+}
+const actions = {
+  refreshNodes,
+  refreshLiveness,
+};
+export default connect(mapStateToProps, actions)(NodeGraphs);

--- a/pkg/ui/src/views/devtools/containers/raftMessages/messages.tsx
+++ b/pkg/ui/src/views/devtools/containers/raftMessages/messages.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+
+import { LineGraph } from "src/views/cluster/components/linegraph";
+import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
+
+import { GraphDashboardProps } from "src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils";
+
+export default function (props: GraphDashboardProps) {
+  const { nodeSources, tooltipSelection } = props;
+
+  return [
+    <LineGraph
+      title="Raft App"
+      sources={nodeSources}
+      tooltip={`The number of raft app messages ${tooltipSelection}`}
+    >
+      <Axis>
+        <Metric name="cr.store.raft.rcvd.app" title="App" nonNegativeRate />
+        <Metric name="cr.store.raft.rcvd.appresp" title="AppResp" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Raft Heartbeat"
+      sources={nodeSources}
+      tooltip={`The number of raft heartbeat messages ${tooltipSelection}`}
+    >
+      <Axis>
+        <Metric name="cr.store.raft.rcvd.heartbeat" title="Heartbeat" nonNegativeRate />
+        <Metric name="cr.store.raft.rcvd.heartbeatresp" title="HeartbeatResp" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Raft Other"
+      sources={nodeSources}
+      tooltip={`The number of other raft messages ${tooltipSelection}`}
+    >
+      <Axis>
+        <Metric name="cr.store.raft.rcvd.prop" title="Prop" nonNegativeRate />
+        <Metric name="cr.store.raft.rcvd.vote" title="Vote" nonNegativeRate />
+        <Metric name="cr.store.raft.rcvd.voteresp" title="VoteResp" nonNegativeRate />
+        <Metric name="cr.store.raft.rcvd.snap" title="Snap" nonNegativeRate />
+        <Metric name="cr.store.raft.rcvd.transferleader" title="TransferLeader" nonNegativeRate />
+        <Metric name="cr.store.raft.rcvd.timeoutnow" title="TimeoutNow" nonNegativeRate />
+        <Metric name="cr.store.raft.rcvd.prevote" title="PreVote" nonNegativeRate />
+        <Metric name="cr.store.raft.rcvd.prevoteresp" title="PreVoteResp" nonNegativeRate />
+        <Metric name="cr.store.raft.rcvd.dropped" title="Dropped" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Raft Time"
+      sources={nodeSources}
+      tooltip={`The time spent in store.processRaft() ${tooltipSelection}`}
+    >
+      <Axis units={AxisUnits.Duration}>
+        <Metric name="cr.store.raft.process.workingnanos" title="Working" nonNegativeRate />
+        <Metric name="cr.store.raft.process.tickingnanos" title="Ticking" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Raft Ticks"
+      sources={nodeSources}
+      tooltip={`The number of raft ticks queued ${tooltipSelection}`}
+    >
+      <Axis>
+        <Metric name="cr.store.raft.ticks" title="Ticks" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Pending Heartbeats"
+      sources={nodeSources}
+      tooltip={`The number of raft heartbeats and responses waiting to be coalesced ${tooltipSelection}`}
+    >
+      <Axis>
+        <Metric name="cr.store.raft.heartbeats.pending" title="Pending" />
+      </Axis>
+    </LineGraph>,
+
+  ];
+}


### PR DESCRIPTION
This adds a new debug page (well, a tab on the raft page) with timeseries charts for counts of raft messages.  Closes #17298.

Note that there's a bunch of copy-paste from the main cluster timeseries page.  We probably want to clean that up moving forward, but it's probably fine for now.  (Feel free to disagree and ask me to refactor that if you feel strongly).