### PR TITLE
kv: properly merge CollectedSpans for split BatchResponses

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -636,7 +636,9 @@ func (ds *DistSender) Send(
 		reply.Responses = append(reply.Responses, rpl.Responses...)
 		reply.CollectedSpans = append(reply.CollectedSpans, rpl.CollectedSpans...)
 	}
-	reply.BatchResponse_Header = rplChunks[len(rplChunks)-1].BatchResponse_Header
+	lastHeader := rplChunks[len(rplChunks)-1].BatchResponse_Header
+	lastHeader.CollectedSpans = reply.CollectedSpans
+	reply.BatchResponse_Header = lastHeader
 	return reply, nil
 }
 

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -843,9 +843,6 @@ func (n *Node) Batch(
 // and "child of remote span" cases are important, as this RPC can be called
 // either through the network or directly if the caller is local.
 //
-// remoteTranceContext is the span context of this remote call. Can be
-// nil if this call is not remote.
-//
 // It returns the derived context and a cleanup function to be called when
 // servicing the RPC is done. The cleanup function will close the span and, in
 // case the span was the child of a remote span and "snowball tracing" was


### PR DESCRIPTION
Previously we would only return the `CollectedSpans` of the last
`BatchResponse` component for a given `BatchRequest` sent by
`DistSender`. This bug was subtle and stayed hidden for two reasons:
- `CollectedSpans` are only used for snowball tracing when sending
  remote RPCs, so the issue would never be seen in a single node
  deployment.
- Very few `BatchRequest`s get split in practice, as we try hard
  to send batches using 1 phase commit wherever possible.

The test added will fail for the `node-1` and `node-2` subtests without
this fix, which demonstrates the existence of the bug.