### PR TITLE
storage: Fix flake in TestQuotaPool

### DIFF
--- a/pkg/storage/client_raft_log_queue_test.go
+++ b/pkg/storage/client_raft_log_queue_test.go
@@ -48,7 +48,7 @@ func TestRaftLogQueue(t *testing.T) {
 	// us in this test.
 	sc := storage.TestStoreConfig(nil)
 	sc.RaftTickInterval = math.MaxInt32
-	sc.RaftElectionTimeoutTicks = 1000000
+	setRaftElectionTimeoutTicks(&sc, 1000000)
 	mtc.storeConfig = &sc
 
 	defer mtc.Stop()

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -45,6 +45,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
+func setRaftElectionTimeoutTicks(sc *storage.StoreConfig, newVal int) {
+	sc.RaftElectionTimeoutTicks = newVal
+	// Recompute settings that are derived from RaftElectionTimeoutTicks.
+	// Not doing this has caused flakiness in the past (#17376).
+	sc.RangeLeaseActiveDuration, sc.RangeLeaseRenewalDuration = storage.RangeLeaseDurations(
+		storage.RaftElectionTimeout(sc.RaftTickInterval, sc.RaftElectionTimeoutTicks))
+}
+
 // mustGetInt decodes an int64 value from the bytes field of the receiver
 // and panics if the bytes field is not 0 or 8 bytes in length.
 func mustGetInt(v *roachpb.Value) int64 {
@@ -1169,7 +1177,7 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	}
 
 	// Don't timeout raft leader.
-	sc.RaftElectionTimeoutTicks = 1000000
+	setRaftElectionTimeoutTicks(&sc, 1000000)
 	mtc := &multiTestContext{
 		storeConfig: &sc,
 	}
@@ -1473,7 +1481,7 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 	// Don't timeout raft leaders or range leases (see the relation between
 	// RaftElectionTimeoutTicks and rangeLeaseActiveDuration). This test expects
 	// mtc.stores[0] to hold the range lease for range 1.
-	sc.RaftElectionTimeoutTicks = 1000000
+	setRaftElectionTimeoutTicks(&sc, 1000000)
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
@@ -1700,7 +1708,7 @@ func TestQuotaPool(t *testing.T) {
 	sc := storage.TestStoreConfig(nil)
 	// Suppress timeout-based elections to avoid leadership changes in ways
 	// this test doesn't expect.
-	sc.RaftElectionTimeoutTicks = 100000
+	setRaftElectionTimeoutTicks(&sc, 100000)
 	mtc := &multiTestContext{storeConfig: &sc}
 	mtc.Start(t, numReplicas)
 	defer mtc.Stop()
@@ -3269,7 +3277,7 @@ func TestTransferRaftLeadership(t *testing.T) {
 	// heavily loaded CPU is enough to reach the raft election timeout
 	// and cause leadership to change hands in ways this test doesn't
 	// expect.
-	sc.RaftElectionTimeoutTicks = 100000
+	setRaftElectionTimeoutTicks(&sc, 100000)
 	// This test can rapidly advance the clock via mtc.advanceClock(),
 	// which could lead the replication queue to consider a store dead
 	// and remove a replica in the middle of the test. Disable the

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1567,7 +1567,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 func TestLeaderAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeConfig := storage.TestStoreConfig(nil)
-	storeConfig.RaftElectionTimeoutTicks = 1000000
+	setRaftElectionTimeoutTicks(&storeConfig, 1000000)
 	mtc := &multiTestContext{
 		storeConfig: &storeConfig,
 	}


### PR DESCRIPTION
TestStoreConfig initializes RaftElectionTimeoutTicks and also calculates
a couple of lease-related settings based on it. If we change
RaftElectionTimeoutTicks after the store config has filled its defaults
in, we should recalculate those lease-related settings.

Without this change, running `make stressrace` would fail in about 2
minutes. With it, I've been running make stressrace for more than 10
minutes without fail.

Fixes #17376