### PR TITLE
sql: implement new crdb_internal virtual tables to inspect descriptors

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -55,6 +55,11 @@ var crdbInternal = virtualSchema{
 		crdbInternalClusterSessionsTable,
 		crdbInternalBuiltinFunctionsTable,
 		crdbInternalCreateStmtsTable,
+		crdbInternalTableColumnsTable,
+		crdbInternalTableIndicesTable,
+		crdbInternalIndexColumnsTable,
+		crdbInternalBackwardDependenciesTable,
+		crdbInternalForwardDependenciesTable,
 	},
 }
 
@@ -467,7 +472,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 // session (via SET TRACING={ON/OFF})
 var crdbInternalSessionTraceTable = virtualSchemaTable{
 	schema: `
-CREATE TABLE crdb_internal.session_trace(
+CREATE TABLE crdb_internal.session_trace (
   txn_idx     INT NOT NULL,        -- The transaction's 0-based index, among all
                                    -- transactions that have been traced.
                                    -- Only filled for the first log message in a
@@ -781,6 +786,7 @@ CREATE TABLE crdb_internal.builtin_functions (
 var crdbInternalCreateStmtsTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.create_statements (
+  database_id      INT,
   database_name    STRING NOT NULL,
   descriptor_id    INT,
   descriptor_type  STRING NOT NULL,
@@ -837,7 +843,12 @@ CREATE TABLE crdb_internal.create_statements (
 				if table.ID != keys.VirtualDescriptorID {
 					descID = parser.NewDInt(parser.DInt(table.ID))
 				}
+				dbDescID := parser.DNull
+				if db.ID != keys.VirtualDescriptorID {
+					dbDescID = parser.NewDInt(parser.DInt(db.ID))
+				}
 				return addRow(
+					dbDescID,
 					parser.NewDString(db.Name),
 					descID,
 					descType,
@@ -846,6 +857,392 @@ CREATE TABLE crdb_internal.create_statements (
 					parser.NewDString(strings.Join(depNames, ", ")),
 					parser.NewDString(table.State.String()),
 				)
+			})
+	},
+}
+
+// crdbInternalTableColumnsTable exposes the column descriptors.
+var crdbInternalTableColumnsTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.table_columns (
+  descriptor_id    INT,
+  descriptor_name  STRING NOT NULL,
+  column_id        INT NOT NULL,
+  column_name      STRING NOT NULL,
+  column_type      STRING NOT NULL,
+  nullable         BOOL NOT NULL,
+  default_expr     STRING,
+  hidden           BOOL NOT NULL
+)
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		return forEachTableDescAll(ctx, p, prefix,
+			func(_ *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+				tableID := parser.DNull
+				if table.ID != keys.VirtualDescriptorID {
+					tableID = parser.NewDInt(parser.DInt(table.ID))
+				}
+				tableName := parser.NewDString(table.Name)
+				for _, col := range table.Columns {
+					defStr := parser.DNull
+					if col.DefaultExpr != nil {
+						defStr = parser.NewDString(*col.DefaultExpr)
+					}
+					if err := addRow(
+						tableID,
+						tableName,
+						parser.NewDInt(parser.DInt(col.ID)),
+						parser.NewDString(col.Name),
+						parser.NewDString(col.Type.String()),
+						parser.MakeDBool(parser.DBool(col.Nullable)),
+						defStr,
+						parser.MakeDBool(parser.DBool(col.Hidden)),
+					); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+	},
+}
+
+// crdbInternalTableIndicesTable exposes the index descriptors.
+var crdbInternalTableIndicesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.table_indexes (
+  descriptor_id    INT,
+  descriptor_name  STRING NOT NULL,
+  index_id         INT NOT NULL,
+  index_name       STRING NOT NULL,
+  index_type       STRING NOT NULL,
+  is_unique        BOOL NOT NULL
+)
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		primary := parser.NewDString("primary")
+		secondary := parser.NewDString("secondary")
+		return forEachTableDescAll(ctx, p, prefix,
+			func(_ *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+				tableID := parser.DNull
+				if table.ID != keys.VirtualDescriptorID {
+					tableID = parser.NewDInt(parser.DInt(table.ID))
+				}
+				tableName := parser.NewDString(table.Name)
+				if err := addRow(
+					tableID,
+					tableName,
+					parser.NewDInt(parser.DInt(table.PrimaryIndex.ID)),
+					parser.NewDString(table.PrimaryIndex.Name),
+					primary,
+					parser.MakeDBool(parser.DBool(table.PrimaryIndex.Unique)),
+				); err != nil {
+					return err
+				}
+				for _, idx := range table.Indexes {
+					if err := addRow(
+						tableID,
+						tableName,
+						parser.NewDInt(parser.DInt(idx.ID)),
+						parser.NewDString(idx.Name),
+						secondary,
+						parser.MakeDBool(parser.DBool(idx.Unique)),
+					); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+	},
+}
+
+// crdbInternalIndexColumnsTable exposes the index columns.
+var crdbInternalIndexColumnsTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.index_columns (
+  descriptor_id    INT,
+  descriptor_name  STRING NOT NULL,
+  index_id         INT NOT NULL,
+  index_name       STRING NOT NULL,
+  column_type      STRING NOT NULL,
+  column_id        INT NOT NULL,
+  column_name      STRING,
+  column_direction STRING
+)
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		key := parser.NewDString("key")
+		storing := parser.NewDString("storing")
+		extra := parser.NewDString("extra")
+		composite := parser.NewDString("composite")
+		idxDirMap := map[sqlbase.IndexDescriptor_Direction]parser.Datum{
+			sqlbase.IndexDescriptor_ASC:  parser.NewDString(sqlbase.IndexDescriptor_ASC.String()),
+			sqlbase.IndexDescriptor_DESC: parser.NewDString(sqlbase.IndexDescriptor_DESC.String()),
+		}
+		return forEachTableDescAll(ctx, p, prefix,
+			func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+				tableID := parser.DNull
+				if table.ID != keys.VirtualDescriptorID {
+					tableID = parser.NewDInt(parser.DInt(table.ID))
+				}
+				tableName := parser.NewDString(table.Name)
+				reportIndex := func(idx *sqlbase.IndexDescriptor) error {
+					idxID := parser.NewDInt(parser.DInt(idx.ID))
+					idxName := parser.NewDString(idx.Name)
+
+					// Report the main (key) columns.
+					for i, c := range idx.ColumnIDs {
+						colName := parser.DNull
+						colDir := parser.DNull
+						if i >= len(idx.ColumnNames) {
+							log.Errorf(ctx, "index descriptor for [%d@%d] (%s.%s@%s) has more key column IDs (%d) than names (%d) (corrupted schema?)",
+								table.ID, idx.ID, db.Name, table.Name, idx.Name,
+								len(idx.ColumnIDs), len(idx.ColumnNames))
+						} else {
+							colName = parser.NewDString(idx.ColumnNames[i])
+						}
+						if i >= len(idx.ColumnDirections) {
+							log.Errorf(ctx, "index descriptor for [%d@%d] (%s.%s@%s) has more key column IDs (%d) than directions (%d) (corrupted schema?)",
+								table.ID, idx.ID, db.Name, table.Name, idx.Name,
+								len(idx.ColumnIDs), len(idx.ColumnDirections))
+						} else {
+							colDir = idxDirMap[idx.ColumnDirections[i]]
+						}
+
+						if err := addRow(
+							tableID, tableName, idxID, idxName,
+							key, parser.NewDInt(parser.DInt(c)), colName, colDir,
+						); err != nil {
+							return err
+						}
+					}
+
+					// Report the stored columns.
+					for _, c := range idx.StoreColumnIDs {
+						if err := addRow(
+							tableID, tableName, idxID, idxName,
+							storing, parser.NewDInt(parser.DInt(c)), parser.DNull, parser.DNull,
+						); err != nil {
+							return err
+						}
+					}
+
+					// Report the extra columns.
+					for _, c := range idx.ExtraColumnIDs {
+						if err := addRow(
+							tableID, tableName, idxID, idxName,
+							extra, parser.NewDInt(parser.DInt(c)), parser.DNull, parser.DNull,
+						); err != nil {
+							return err
+						}
+					}
+
+					// Report the composite columns
+					for _, c := range idx.CompositeColumnIDs {
+						if err := addRow(
+							tableID, tableName, idxID, idxName,
+							composite, parser.NewDInt(parser.DInt(c)), parser.DNull, parser.DNull,
+						); err != nil {
+							return err
+						}
+					}
+
+					return nil
+				}
+
+				if err := reportIndex(&table.PrimaryIndex); err != nil {
+					return err
+				}
+				for i := range table.Indexes {
+					if err := reportIndex(&table.Indexes[i]); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+	},
+}
+
+// crdbInternalBackwardDependenciesTable exposes the backward
+// inter-descriptor dependencies.
+var crdbInternalBackwardDependenciesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.backward_dependencies (
+  descriptor_id      INT,
+  descriptor_name    STRING NOT NULL,
+  index_id           INT,
+  dependson_id       INT NOT NULL,
+  dependson_type     STRING NOT NULL,
+  dependson_index_id INT,
+  dependson_name     STRING,
+  dependson_details  STRING
+)
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		fkDep := parser.NewDString("fk")
+		viewDep := parser.NewDString("view")
+		interleaveDep := parser.NewDString("interleave")
+		return forEachTableDescAll(ctx, p, prefix,
+			func(_ *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+				tableID := parser.DNull
+				if table.ID != keys.VirtualDescriptorID {
+					tableID = parser.NewDInt(parser.DInt(table.ID))
+				}
+				tableName := parser.NewDString(table.Name)
+
+				reportIdxDeps := func(idx *sqlbase.IndexDescriptor) error {
+					idxID := parser.NewDInt(parser.DInt(idx.ID))
+					if idx.ForeignKey.Table != 0 {
+						fkRef := &idx.ForeignKey
+						if err := addRow(
+							tableID, tableName,
+							idxID,
+							parser.NewDInt(parser.DInt(fkRef.Table)),
+							fkDep,
+							parser.NewDInt(parser.DInt(fkRef.Index)),
+							parser.NewDString(fkRef.Name),
+							parser.NewDString(fmt.Sprintf("SharedPrefixLen: %d", fkRef.SharedPrefixLen)),
+						); err != nil {
+							return err
+						}
+					}
+
+					for _, interleaveParent := range idx.Interleave.Ancestors {
+						if err := addRow(
+							tableID, tableName,
+							idxID,
+							parser.NewDInt(parser.DInt(interleaveParent.TableID)),
+							interleaveDep,
+							parser.NewDInt(parser.DInt(interleaveParent.IndexID)),
+							parser.DNull,
+							parser.NewDString(fmt.Sprintf("SharedPrefixLen: %d",
+								interleaveParent.SharedPrefixLen)),
+						); err != nil {
+							return err
+						}
+					}
+					return nil
+				}
+
+				// Record the backward references of the primary index.
+				if err := reportIdxDeps(&table.PrimaryIndex); err != nil {
+					return err
+				}
+
+				// Record the backward references of secondary indexes.
+				for i := range table.Indexes {
+					if err := reportIdxDeps(&table.Indexes[i]); err != nil {
+						return err
+					}
+				}
+
+				// Record the view dependencies.
+				for _, tIdx := range table.DependsOn {
+					if err := addRow(
+						tableID, tableName,
+						parser.DNull,
+						parser.NewDInt(parser.DInt(tIdx)),
+						viewDep,
+						parser.DNull,
+						parser.DNull,
+						parser.DNull,
+					); err != nil {
+						return err
+					}
+				}
+
+				return nil
+			})
+	},
+}
+
+// crdbInternalForwardDependenciesTable exposes the forward
+// inter-descriptor dependencies.
+var crdbInternalForwardDependenciesTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE crdb_internal.forward_dependencies (
+  descriptor_id         INT,
+  descriptor_name       STRING NOT NULL,
+  index_id              INT,
+  dependedonby_id       INT NOT NULL,
+  dependedonby_type     STRING NOT NULL,
+  dependedonby_index_id INT,
+  dependedonby_name     STRING,
+  dependedonby_details  STRING
+)
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...parser.Datum) error) error {
+		fkDep := parser.NewDString("fk")
+		viewDep := parser.NewDString("view")
+		interleaveDep := parser.NewDString("interleave")
+		return forEachTableDescAll(ctx, p, prefix,
+			func(_ *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+				tableID := parser.DNull
+				if table.ID != keys.VirtualDescriptorID {
+					tableID = parser.NewDInt(parser.DInt(table.ID))
+				}
+				tableName := parser.NewDString(table.Name)
+
+				reportIdxDeps := func(idx *sqlbase.IndexDescriptor) error {
+					idxID := parser.NewDInt(parser.DInt(idx.ID))
+					for _, fkRef := range idx.ReferencedBy {
+						if err := addRow(
+							tableID, tableName,
+							idxID,
+							parser.NewDInt(parser.DInt(fkRef.Table)),
+							fkDep,
+							parser.NewDInt(parser.DInt(fkRef.Index)),
+							parser.NewDString(fkRef.Name),
+							parser.NewDString(fmt.Sprintf("SharedPrefixLen: %d", fkRef.SharedPrefixLen)),
+						); err != nil {
+							return err
+						}
+					}
+
+					for _, interleaveRef := range idx.InterleavedBy {
+						if err := addRow(
+							tableID, tableName,
+							idxID,
+							parser.NewDInt(parser.DInt(interleaveRef.Table)),
+							interleaveDep,
+							parser.NewDInt(parser.DInt(interleaveRef.Index)),
+							parser.DNull,
+							parser.NewDString(fmt.Sprintf("SharedPrefixLen: %d",
+								interleaveRef.SharedPrefixLen)),
+						); err != nil {
+							return err
+						}
+					}
+					return nil
+				}
+
+				// Record the backward references of the primary index.
+				if err := reportIdxDeps(&table.PrimaryIndex); err != nil {
+					return err
+				}
+
+				// Record the backward references of secondary indexes.
+				for i := range table.Indexes {
+					if err := reportIdxDeps(&table.Indexes[i]); err != nil {
+						return err
+					}
+				}
+
+				// Record the view dependencies.
+				for _, dep := range table.DependedOnBy {
+					if err := addRow(
+						tableID, tableName,
+						parser.DNull,
+						parser.NewDInt(parser.DInt(dep.ID)),
+						viewDep,
+						parser.NewDInt(parser.DInt(dep.IndexID)),
+						parser.DNull,
+						parser.NewDString(fmt.Sprintf("Columns: %v", dep.ColumnIDs)),
+					); err != nil {
+						return err
+					}
+				}
+
+				return nil
 			})
 	},
 }

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -128,10 +128,10 @@ SELECT * FROM crdb_internal.builtin_functions WHERE function = ''
 ----
 function  signature  category  details
 
-query ITITTTTT colnames
+query ITITTTT colnames
 SELECT * FROM crdb_internal.create_statements WHERE database_name = ''
 ----
-database_id  database_name  descriptor_id  descriptor_type  descriptor_name  create_statement  dependencies  state
+database_id  database_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state
 
 query ITITTBTB colnames
 SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -69,9 +69,95 @@ Version
 
 # The validity of the rows in this table are tested elsewhere; we merely assert the columns.
 query ITTTTTTTTTRT colnames
-SELECT * FROM crdb_internal.jobs
+SELECT * FROM crdb_internal.jobs WHERE false
 ----
 id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error
+
+query IITTITTT colnames
+SELECT * FROM crdb_internal.schema_changes WHERE table_id < 0
+----
+table_id  parent_id  name  type  target_id  target_name  state  direction
+
+query IITITB colnames
+SELECT * FROM crdb_internal.leases WHERE node_id < 0
+----
+node_id  table_id  name  parent_id  expiration  deleted
+
+query ITTTTIIITFFFFFFFFFFFF colnames
+SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
+----
+node_id  application_name  flags  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var
+
+query IIITTTT colnames
+SELECT * FROM crdb_internal.session_trace WHERE txn_idx < 0
+----
+txn_idx  span_idx  message_idx  timestamp  duration  operation  message
+
+query TTTT colnames
+SELECT * FROM crdb_internal.cluster_settings WHERE name = ''
+----
+name  current_value  type  description
+
+query TT colnames
+SELECT * FROM crdb_internal.session_variables WHERE variable = ''
+----
+variable                       value
+
+query TITTTTTBT colnames
+SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
+----
+query_id  node_id  username  start  query  client_address  application_name  distributed  phase
+
+query TITTTTTBT colnames
+SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
+----
+query_id  node_id  username  start  query  client_address  application_name  distributed  phase
+
+query ITTTTTTT colnames
+SELECT * FROM crdb_internal.node_sessions WHERE node_id < 0
+----
+node_id  username  client_address  application_name  active_queries  session_start  oldest_query_start  kv_txn
+
+query ITTTTTTT colnames
+SELECT * FROM crdb_internal.cluster_sessions WHERE node_id < 0
+----
+node_id  username  client_address  application_name  active_queries  session_start  oldest_query_start  kv_txn
+
+query TTTT colnames
+SELECT * FROM crdb_internal.builtin_functions WHERE function = ''
+----
+function  signature  category  details
+
+query ITITTTTT colnames
+SELECT * FROM crdb_internal.create_statements WHERE database_name = ''
+----
+database_id  database_name  descriptor_id  descriptor_type  descriptor_name  create_statement  dependencies  state
+
+query ITITTBTB colnames
+SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
+----
+descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
+
+query ITITTB colnames
+SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
+----
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique
+
+query ITITTITT colnames
+SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''
+----
+descriptor_id  descriptor_name  index_id  index_name  column_type  column_id  column_name  column_direction
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name = ''
+----
+descriptor_id  descriptor_name  index_id  dependson_id  dependson_type  dependson_index_id  dependson_name  dependson_details
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name = ''
+----
+descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
+
 
 query error pq: foo
 SELECT crdb_internal.force_error('', 'foo')

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -1,0 +1,121 @@
+statement ok
+CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
+  CREATE UNIQUE INDEX test_v_idx ON test_kv(v);
+  CREATE INDEX test_v_idx2 ON test_kv(v DESC) STORING(k);
+  CREATE INDEX test_v_idx3 ON test_kv(w) STORING(v);
+  CREATE TABLE test_kvr1(k INT PRIMARY KEY REFERENCES test_kv(k));
+  CREATE TABLE test_kvr2(k INT, v INT UNIQUE REFERENCES test_kv(k));
+  CREATE TABLE test_kvr3(k INT, v INT UNIQUE REFERENCES test_kv(v));
+  CREATE TABLE test_kvi1(k INT PRIMARY KEY) INTERLEAVE IN PARENT test_kv(k);
+  CREATE TABLE test_kvi2(k INT PRIMARY KEY, v INT);
+  CREATE UNIQUE INDEX test_kvi2_idx ON test_kvi2(v) INTERLEAVE IN PARENT test_kv(v);
+  CREATE VIEW test_v1 AS SELECT v FROM test_kv;
+  CREATE VIEW test_v2 AS SELECT v FROM test_v1;
+
+query ITITTBTB colnames
+SELECT * FROM crdb_internal.table_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, column_id
+----
+descriptor_id  descriptor_name  column_id  column_name  column_type                                                   nullable  default_expr    hidden
+51             test_kv          1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+51             test_kv          2          v            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+51             test_kv          3          w            semantic_type:DECIMAL width:0 precision:0 visible_type:NONE   true      NULL            false
+52             test_kvr1        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+53             test_kvr2        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+53             test_kvr2        2          v            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+53             test_kvr2        3          rowid        semantic_type:INT width:0 precision:0 visible_type:NONE       false     unique_rowid()  true
+54             test_kvr3        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+54             test_kvr3        2          v            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+54             test_kvr3        3          rowid        semantic_type:INT width:0 precision:0 visible_type:NONE       false     unique_rowid()  true
+55             test_kvi1        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+56             test_kvi2        1          k            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+56             test_kvi2        2          v            semantic_type:INT width:0 precision:0 visible_type:NONE       true      NULL            false
+57             test_v1          1          v            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+58             test_v2          1          v            semantic_type:INT width:0 precision:0 visible_type:NONE       false     NULL            false
+
+query ITITTB colnames
+SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id
+----
+descriptor_id  descriptor_name  index_id  index_name       index_type  is_unique
+51             test_kv          1         primary          primary     true
+51             test_kv          2         test_v_idx       secondary   true
+51             test_kv          3         test_v_idx2      secondary   false
+51             test_kv          4         test_v_idx3      secondary   false
+52             test_kvr1        1         primary          primary     true
+53             test_kvr2        1         primary          primary     true
+53             test_kvr2        2         test_kvr2_v_key  secondary   true
+54             test_kvr3        1         primary          primary     true
+54             test_kvr3        2         test_kvr3_v_key  secondary   true
+55             test_kvi1        1         primary          primary     true
+56             test_kvi2        1         primary          primary     true
+56             test_kvi2        2         test_kvi2_idx    secondary   true
+57             test_v1          0         ·                primary     false
+58             test_v2          0         ·                primary     false
+
+query ITITTITT colnames
+SELECT * FROM crdb_internal.index_columns WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, column_type, column_id
+----
+descriptor_id  descriptor_name  index_id  index_name       column_type  column_id  column_name  column_direction
+51             test_kv          1         primary          key          1          k            ASC
+51             test_kv          2         test_v_idx       extra        1          NULL         NULL
+51             test_kv          2         test_v_idx       key          2          v            ASC
+51             test_kv          3         test_v_idx2      extra        1          NULL         NULL
+51             test_kv          3         test_v_idx2      key          2          v            DESC
+51             test_kv          4         test_v_idx3      composite    3          NULL         NULL
+51             test_kv          4         test_v_idx3      extra        1          NULL         NULL
+51             test_kv          4         test_v_idx3      key          3          w            ASC
+51             test_kv          4         test_v_idx3      storing      2          NULL         NULL
+52             test_kvr1        1         primary          key          1          k            ASC
+53             test_kvr2        1         primary          key          3          rowid        ASC
+53             test_kvr2        2         test_kvr2_v_key  extra        3          NULL         NULL
+53             test_kvr2        2         test_kvr2_v_key  key          2          v            ASC
+54             test_kvr3        1         primary          key          3          rowid        ASC
+54             test_kvr3        2         test_kvr3_v_key  extra        3          NULL         NULL
+54             test_kvr3        2         test_kvr3_v_key  key          2          v            ASC
+55             test_kvi1        1         primary          key          1          k            ASC
+56             test_kvi2        1         primary          key          1          k            ASC
+56             test_kvi2        2         test_kvi2_idx    extra        1          NULL         NULL
+56             test_kvi2        2         test_kvi2_idx    key          2          v            ASC
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, dependson_type, dependson_id, dependson_index_id
+----
+descriptor_id  descriptor_name  index_id  dependson_id  dependson_type  dependson_index_id  dependson_name    dependson_details
+52             test_kvr1        1         51            fk              1                   fk_k_ref_test_kv  SharedPrefixLen: 1
+53             test_kvr2        2         51            fk              1                   fk_v_ref_test_kv  SharedPrefixLen: 1
+54             test_kvr3        2         51            fk              2                   fk_v_ref_test_kv  SharedPrefixLen: 1
+55             test_kvi1        1         51            interleave      1                   NULL              SharedPrefixLen: 1
+56             test_kvi2        2         51            interleave      1                   NULL              SharedPrefixLen: 1
+57             test_v1          NULL      51            view            NULL                NULL              NULL
+58             test_v2          NULL      57            view            NULL                NULL              NULL
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'test_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
+----
+descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
+51             test_kv          NULL      57               view               0                      NULL               Columns: [1 2 3]
+51             test_kv          1         52               fk                 1                      ·                  SharedPrefixLen: 0
+51             test_kv          1         53               fk                 2                      ·                  SharedPrefixLen: 0
+51             test_kv          1         55               interleave         1                      NULL               SharedPrefixLen: 0
+51             test_kv          1         56               interleave         2                      NULL               SharedPrefixLen: 0
+51             test_kv          2         54               fk                 2                      ·                  SharedPrefixLen: 0
+57             test_v1          NULL      58               view               0                      NULL               Columns: []
+
+# TODO(knz): in the output from the last statement above we can see
+# that the Columns[] field for the forward dependency in test_v1 is
+# broken. Fix it.
+
+# Demonstrates views are broken #17306.
+# TODO(knz): Fix this.
+statement ok
+CREATE TABLE broken_t(k INT, v INT);
+  CREATE VIEW broken_v AS SELECT v FROM broken_t WHERE FALSE
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'broken_%' ORDER BY descriptor_id, index_id, dependson_type, dependson_id, dependson_index_id
+----
+descriptor_id  descriptor_name  index_id  dependson_id  dependson_type  dependson_index_id  dependson_name    dependson_details
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'broken_%' ORDER BY descriptor_id, index_id, dependedonby_type, dependedonby_id, dependedonby_index_id
+----
+descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -136,7 +136,7 @@ EXPLAIN SHOW TABLES
 1  render  ·      ·
 2  filter  ·      ·
 3  values  ·      ·
-3  ·       size   5 columns, 61 rows
+3  ·       size   5 columns, 66 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -192,7 +192,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·
-7  ·       size      13 columns, 517 rows
+7  ·       size      13 columns, 556 rows
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -192,7 +192,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·
-7  ·       size      13 columns, 556 rows
+7  ·       size      13 columns, 555 rows
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -204,11 +204,14 @@ DROP DATABASE other_db
 query TT
 select table_schema, table_name FROM information_schema.tables ORDER BY 1, 2
 ----
+crdb_internal       backward_dependencies
 crdb_internal       builtin_functions
 crdb_internal       cluster_queries
 crdb_internal       cluster_sessions
 crdb_internal       cluster_settings
 crdb_internal       create_statements
+crdb_internal       forward_dependencies
+crdb_internal       index_columns
 crdb_internal       jobs
 crdb_internal       leases
 crdb_internal       node_build_info
@@ -218,6 +221,8 @@ crdb_internal       node_statement_statistics
 crdb_internal       schema_changes
 crdb_internal       session_trace
 crdb_internal       session_variables
+crdb_internal       table_columns
+crdb_internal       table_indexes
 crdb_internal       tables
 information_schema  columns
 information_schema  key_column_usage
@@ -339,18 +344,23 @@ ui
 tables
 tables
 table_privileges
+table_indexes
 table_constraints
+table_columns
 
 # Check that the metadata is reported properly.
 query TTTTI colnames
 SELECT * FROM information_schema.tables
 ----
 table_catalog  table_schema        table_name                 table_type   version
+def            crdb_internal       backward_dependencies      SYSTEM VIEW  1
 def            crdb_internal       builtin_functions          SYSTEM VIEW  1
 def            crdb_internal       cluster_queries            SYSTEM VIEW  1
 def            crdb_internal       cluster_sessions           SYSTEM VIEW  1
 def            crdb_internal       cluster_settings           SYSTEM VIEW  1
 def            crdb_internal       create_statements          SYSTEM VIEW  1
+def            crdb_internal       forward_dependencies       SYSTEM VIEW  1
+def            crdb_internal       index_columns              SYSTEM VIEW  1
 def            crdb_internal       jobs                       SYSTEM VIEW  1
 def            crdb_internal       leases                     SYSTEM VIEW  1
 def            crdb_internal       node_build_info            SYSTEM VIEW  1
@@ -360,6 +370,8 @@ def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
 def            crdb_internal       schema_changes             SYSTEM VIEW  1
 def            crdb_internal       session_trace              SYSTEM VIEW  1
 def            crdb_internal       session_variables          SYSTEM VIEW  1
+def            crdb_internal       table_columns              SYSTEM VIEW  1
+def            crdb_internal       table_indexes              SYSTEM VIEW  1
 def            crdb_internal       tables                     SYSTEM VIEW  1
 def            information_schema  columns                    SYSTEM VIEW  1
 def            information_schema  key_column_usage           SYSTEM VIEW  1


### PR DESCRIPTION
The views in pg_catalog and information_schema provide introspection
over the logical schema (pure SQL view) however when testing/debugging
it is also important to see the descriptor IDs and also other fields
of descriptors.

This patch provides help for debugging with the following new virtual
tables:

- `crdb_internal.table_columns`: detailed column IDs and properties
- `crdb_internal.table_indexes`: detailed index IDs and index properties
- `crdb_internal.index_columns`: what columns are indexed and how
- `crdb_internal.backward_dependencies`: which other descriptors each descriptor depends on
- `crdb_internal.forward_dependencies`: which other descriptors each descriptor is depended on by

These virtual tables are intended to display the contents of
descriptors without any data transformation, so as to reveal any error
in the descriptors, if any.

Debugging/fsck tools can later use these to check schema validity.

Needed to test  #17310.

cc @cockroachdb/sql 