### PR TITLE
sql: support streaming results in planHook

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -841,7 +841,7 @@ func restore(
 
 func restorePlanHook(
 	stmt parser.Statement, p sql.PlanHookState,
-) (func(context.Context) ([]parser.Datums, error), sqlbase.ResultColumns, error) {
+) (func(context.Context, chan<- parser.Datums) error, sqlbase.ResultColumns, error) {
 	restoreStmt, ok := stmt.(*parser.Restore)
 	if !ok {
 		return nil, nil, nil
@@ -870,30 +870,30 @@ func restorePlanHook(
 		{Name: "system_records", Typ: parser.TypeInt},
 		{Name: "bytes", Typ: parser.TypeInt},
 	}
-	fn := func(ctx context.Context) ([]parser.Datums, error) {
+	fn := func(ctx context.Context, resultsCh chan<- parser.Datums) error {
 		// TODO(dan): Move this span into sql.
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
 		from, err := fromFn()
 		if err != nil {
-			return nil, err
+			return err
 		}
 		backupDescs, err := loadBackupDescs(ctx, from)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		sqlDescs, err := selectTargets(backupDescs, restoreStmt.Targets)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		tableRewrites, err := allocateTableRewrites(ctx, p, sqlDescs, restoreStmt.Options)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		description, err := restoreJobDescription(restoreStmt, from)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		job := p.ExecCfg().JobRegistry.NewJob(jobs.Record{
 			Description: description,
@@ -919,14 +919,13 @@ func restorePlanHook(
 			job,
 		)
 		if err := job.FinishedWith(ctx, restoreErr); err != nil {
-			return nil, err
+			return err
 		}
 		if restoreErr != nil {
-			return nil, restoreErr
+			return restoreErr
 		}
-		// TODO(benesch): emit periodic progress updates once we have the
-		// infrastructure to stream responses.
-		ret := []parser.Datums{{
+		// TODO(benesch): emit periodic progress updates.
+		resultsCh <- parser.Datums{
 			parser.NewDInt(parser.DInt(*job.ID())),
 			parser.NewDString(string(jobs.StatusSucceeded)),
 			parser.NewDFloat(parser.DFloat(1.0)),
@@ -934,8 +933,8 @@ func restorePlanHook(
 			parser.NewDInt(parser.DInt(res.IndexEntries)),
 			parser.NewDInt(parser.DInt(res.SystemRecords)),
 			parser.NewDInt(parser.DInt(res.DataSize)),
-		}}
-		return ret, nil
+		}
+		return nil
 	}
 	return fn, header, nil
 }

--- a/pkg/sql/logictest/main_test.go
+++ b/pkg/sql/logictest/main_test.go
@@ -39,7 +39,7 @@ import (
 func init() {
 	testingPlanHook := func(
 		stmt parser.Statement, state sql.PlanHookState,
-	) (func(context.Context) ([]parser.Datums, error), sqlbase.ResultColumns, error) {
+	) (func(context.Context, chan<- parser.Datums) error, sqlbase.ResultColumns, error) {
 		show, ok := stmt.(*parser.Show)
 		if !ok || show.Name != "planhook" {
 			return nil, nil, nil
@@ -47,10 +47,9 @@ func init() {
 		header := sqlbase.ResultColumns{
 			{Name: "value", Typ: parser.TypeString},
 		}
-		return func(_ context.Context) ([]parser.Datums, error) {
-			return []parser.Datums{
-				{parser.NewDString(show.Name)},
-			}, nil
+		return func(_ context.Context, resultsCh chan<- parser.Datums) error {
+			resultsCh <- parser.Datums{parser.NewDString(show.Name)}
+			return nil
 		}, header, nil
 	}
 	sql.AddPlanHook(testingPlanHook)

--- a/pkg/sql/main_test.go
+++ b/pkg/sql/main_test.go
@@ -197,7 +197,7 @@ func createTestServerParams() (base.TestServerArgs, *CommandFilters) {
 func init() {
 	testingPlanHook := func(
 		stmt parser.Statement, state sql.PlanHookState,
-	) (func(context.Context) ([]parser.Datums, error), sqlbase.ResultColumns, error) {
+	) (func(context.Context, chan<- parser.Datums) error, sqlbase.ResultColumns, error) {
 		show, ok := stmt.(*parser.Show)
 		if !ok || show.Name != "planhook" {
 			return nil, nil, nil
@@ -205,10 +205,9 @@ func init() {
 		header := sqlbase.ResultColumns{
 			{Name: "value", Typ: parser.TypeString},
 		}
-		return func(_ context.Context) ([]parser.Datums, error) {
-			return []parser.Datums{
-				{parser.NewDString(show.Name)},
-			}, nil
+		return func(_ context.Context, resultsCh chan<- parser.Datums) error {
+			resultsCh <- parser.Datums{parser.NewDString(show.Name)}
+			return nil
 		}, header, nil
 	}
 	sql.AddPlanHook(testingPlanHook)

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -26,12 +26,16 @@ import (
 // implementation of certain sql statements to live outside of the sql package.
 //
 // To intercept a statement the function should return a non-nil function for
-// `fn` as well as the appropriate sqlbase.ResultColumns describing the results it will
-// return (if any). `fn` will be called during the `Start` phase of plan
-// execution.
+// `fn` as well as the appropriate sqlbase.ResultColumns describing the results
+// it will return (if any). `fn` will be called in a goroutine during the
+// `Start` phase of plan execution.
+//
+// The channel argument to `fn` is used to return results with the client. It's
+// a blocking channel, so implementors should be careful to only use blocking
+// sends on it when necessary.
 type planHookFn func(
 	parser.Statement, PlanHookState,
-) (fn func(context.Context) ([]parser.Datums, error), header sqlbase.ResultColumns, err error)
+) (fn func(context.Context, chan<- parser.Datums) error, header sqlbase.ResultColumns, err error)
 
 var planHooks []planHookFn
 
@@ -51,36 +55,46 @@ type PlanHookState interface {
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a
 // parser.Statement. If the func returned by the hook is non-nil, it is used to
-// construct a planNode that runs that func during Start.
+// construct a planNode that runs that func in a goroutine during Start.
 func AddPlanHook(f planHookFn) {
 	planHooks = append(planHooks, f)
 }
 
-// hookFnNode is a planNode implemented in terms of a function. It runs the
-// provided function during Start and serves the results it returned.
+// hookFnNode is a planNode implemented in terms of a function. It begins the
+// provided function during Start and serves the results it returns over the
+// channel.
 type hookFnNode struct {
-	f func(context.Context) ([]parser.Datums, error)
-
+	f      func(context.Context, chan<- parser.Datums) error
 	header sqlbase.ResultColumns
 
-	res    []parser.Datums
-	resIdx int
+	resultsCh chan parser.Datums
+	errCh     chan error
+
+	row parser.Datums
 }
 
 func (*hookFnNode) Close(context.Context) {}
 
 func (f *hookFnNode) Start(params runParams) error {
-	var err error
-	f.res, err = f.f(params.ctx)
-	f.resIdx = -1
-	return err
+	// TODO(dan): Make sure the resultCollector is set to flush after every row.
+	f.resultsCh = make(chan parser.Datums)
+	f.errCh = make(chan error)
+	go func() {
+		f.errCh <- f.f(params.ctx, f.resultsCh)
+		close(f.errCh)
+		close(f.resultsCh)
+	}()
+	return nil
 }
 
-func (f *hookFnNode) Next(runParams) (bool, error) {
-	if f.res == nil {
-		return false, nil
+func (f *hookFnNode) Next(params runParams) (bool, error) {
+	select {
+	case <-params.ctx.Done():
+		return false, params.ctx.Err()
+	case err := <-f.errCh:
+		return false, err
+	case f.row = <-f.resultsCh:
+		return true, nil
 	}
-	f.resIdx++
-	return f.resIdx < len(f.res), nil
 }
-func (f *hookFnNode) Values() parser.Datums { return f.res[f.resIdx] }
+func (f *hookFnNode) Values() parser.Datums { return f.row }


### PR DESCRIPTION
BACKUP and RESTORE's result columns were picked such that they could
take advantage of streaming results for progress updates. This commit
updates the planHook plumbing to begin the work fn in a goroutine in
Start and use a channel to stream results back to Next/Values.

The results channel is not buffered, so plan hook implementors should
use select when updates should not block.