### PR TITLE
sql: support WHERE clause in INSERT ... ON CONFLICT

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -206,7 +206,8 @@ func (p *planner) Insert(
 			}
 
 			helper, err := p.makeUpsertHelper(
-				ctx, tn, en.tableDesc, ri.InsertCols, updateCols, updateExprs, conflictIndex)
+				ctx, tn, en.tableDesc, ri.InsertCols, updateCols, updateExprs, conflictIndex, n.OnConflict.Where,
+			)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -148,8 +148,10 @@ INSERT INTO t5 VALUES (1, 10, 9) ON CONFLICT (k) DO NOTHING
 statement error failed to satisfy CHECK constraint
 INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING
 
+# n.b. the fully-qualified name below is required, as there are two providers of
+# the column named `k` here, the original table and the `excluded` pseudo-table.
 statement error failed to satisfy CHECK constraint
-INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = 12 WHERE k = 2
+INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = 12 WHERE t5.k = 2
 
 statement error failed to satisfy CHECK constraint
 UPSERT INTO t5 VALUES (2, 11, 12)
@@ -173,13 +175,13 @@ SELECT * FROM t5
 2 11  9
 
 statement error failed to satisfy CHECK constraint
-INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = 12 WHERE k = 2
+INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = 12 WHERE t5.k = 2
 
 statement error failed to satisfy CHECK constraint
 UPSERT INTO t5 VALUES (2, 11, 12)
 
 statement error failed to satisfy CHECK constraint
-INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = t5.a + 1 WHERE k = 2
+INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = t5.a + 1 WHERE t5.k = 2
 
 query III rowsort
 SELECT * FROM t5

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -320,10 +320,39 @@ SELECT * FROM issue_14052_2;
 statement ok
 CREATE TABLE issue_16873 (col int PRIMARY KEY, date TIMESTAMP);
 
+# n.b. the fully-qualified names below are required, as there are two providers of
+# the column named `col` here, the original table and the `excluded` pseudo-table.
 statement ok
 INSERT INTO issue_16873 VALUES (1,clock_timestamp())
-ON CONFLICT (col) DO UPDATE SET date = clock_timestamp() WHERE col = 1;
+ON CONFLICT (col) DO UPDATE SET date = clock_timestamp() WHERE issue_16873.col = 1;
 
 statement ok
 INSERT INTO issue_16873 VALUES (1,clock_timestamp())
-ON CONFLICT (col) DO UPDATE SET date = clock_timestamp() WHERE col = 1;
+ON CONFLICT (col) DO UPDATE SET date = clock_timestamp() WHERE issue_16873.col = 1;
+
+# For #17339.  Support WHERE clause in ON CONFLICT handling.
+statement ok
+CREATE TABLE issue_17339 (a int primary key, b int);
+
+statement ok
+INSERT INTO issue_17339 VALUES (1, 1), (2, 0);
+
+statement ok
+INSERT INTO issue_17339 VALUES (1, 0), (2, 2)
+ON CONFLICT (a) DO UPDATE SET b = excluded.b WHERE excluded.b > issue_17339.b;
+
+query II
+SELECT * FROM issue_17339 ORDER BY a;
+----
+1 1
+2 2
+
+statement ok
+INSERT INTO issue_17339 VALUES (1, 0), (2, 1)
+ON CONFLICT (a) DO UPDATE SET b = excluded.b WHERE TRUE;
+
+query II
+SELECT * FROM issue_17339 ORDER BY a;
+----
+1 0
+2 1

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -201,6 +201,10 @@ type tableUpsertEvaler interface {
 	// eval returns the values for the update case of an upsert, given the row
 	// that would have been inserted and the existing (conflicting) values.
 	eval(insertRow parser.Datums, existingRow parser.Datums) (parser.Datums, error)
+
+	// shouldUpdate returns the result of evaluating the WHERE clause of the
+	// ON CONFLICT ... DO UPDATE clause.
+	shouldUpdate(insertRow parser.Datums, existingRow parser.Datums) (bool, error)
 }
 
 // tableUpserter handles writing kvs and forming table rows for upserts.
@@ -430,6 +434,15 @@ func (tu *tableUpserter) flush(
 			// If len(tu.updateCols) == 0, then we're in the DO NOTHING case.
 			if len(tu.updateCols) > 0 {
 				existingValues := existingRow[:len(tu.ru.FetchCols)]
+				shouldUpdate, err := tu.evaler.shouldUpdate(insertRow, existingValues)
+				if err != nil {
+					return nil, err
+				}
+
+				if !shouldUpdate {
+					continue
+				}
+
 				updateValues, err := tu.evaler.eval(insertRow, existingValues)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
This adds support for conditional updates in INSERT ... ON CONFLICT
statements.  Previously, the WHERE clause was parsed but silently thrown
away.  Now we're typechecking it then using it to determine which rows
to update when a conflict is encountered.

Closes #17339.