### PR TITLE
migrations: temporarily disable TestUpdateViewDependenciesMigration

### DIFF
--- a/pkg/migration/sqlmigrations/migrations_test.go
+++ b/pkg/migration/sqlmigrations/migrations_test.go
@@ -508,6 +508,8 @@ func TestCreateSystemTable(t *testing.T) {
 
 func TestUpdateViewDependenciesMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#17438")
+
 	ctx := context.Background()
 
 	// remove the view update migration so we can test its effects.


### PR DESCRIPTION
Disabling test while I investigate the problem.

Updates #17438.