### PR TITLE
sqlccl: return correct error when waitgroup fails mid-spawn

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -779,7 +779,7 @@ func restore(
 		select {
 		case importsSem <- struct{}{}:
 		case <-gCtx.Done():
-			return failed, gCtx.Err()
+			return failed, errors.Wrapf(g.Wait(), "importing %d ranges", len(importSpans))
 		}
 		log.Event(importCtx, "acquired semaphore")
 


### PR DESCRIPTION
`gCtx.Err()` is always `context.Canceled`. The error which actually
caused the context to be canceled is returned by `g.Wait()`.
Additionally add an `errors.Wrapf` so it's not as painful to track this
error down in the future.