### PR TITLE
acceptance: use locally built cockroach binary by default

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -12,6 +12,13 @@ export BUILDER_HIDE_GOPATH_SRC=1
 mkdir -p artifacts/acceptance
 export TMPDIR=$PWD/artifacts/acceptance
 
-build/builder.sh make TYPE=release-linux-gnu testbuild TAGS=acceptance PKG=./pkg/acceptance
+TYPE=release-$(go env GOOS)
+case $TYPE in
+  *-linux)
+    TYPE+=-gnu
+    ;;
+esac
+
+build/builder.sh make TYPE=$TYPE testbuild TAGS=acceptance PKG=./pkg/acceptance
 cd pkg/acceptance
 ./acceptance.test -nodes 4 -l "$TMPDIR" -test.v -test.timeout 10m 2>&1 | tee "$TMPDIR/acceptance.log" | go-test-teamcity

--- a/build/teamcity-nightly-acceptance.sh
+++ b/build/teamcity-nightly-acceptance.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Required setup:
+# 1. Have an Azure account.
+# 2. Set the ARM_SUBSCRIPTION_ID, ARM_CLIENT_ID, ARM_CLIENT_SECRET, and
+#    ARM_TENANT_ID variables as documented here:
+#  https://www.terraform.io/docs/providers/azurerm/#argument-reference
+# 3. If running on your local machine, have a symlink to `cat` named
+#    `go-test-teamcity` on your PATH.
+
+# Example use:
+#
+# COCKROACH_EXTRA_FLAGS='-tf.keep-cluster=failed' build/teamcity-nightly-acceptance.sh TestUpreplicate_1To3Small
+
+set -euxo pipefail
+
+export BUILDER_HIDE_GOPATH_SRC=1
+
+TESTNAME=$1
+
+case $TESTNAME in
+  TestUpreplicate_1To3Small)
+    TESTTIMEOUT=2h
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608'
+    ;;
+  TestRebalance_3To5Small)
+    TESTTIMEOUT=2h
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -at.std-dev 14'
+    ;;
+  TestRebalance_3To5Small_WithSchemaChanges)
+    TESTTIMEOUT=24h
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -at.std-dev 14'
+    ;;
+  TestSteady_3Small)
+    TESTTIMEOUT=24h
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -at.std-dev 14'
+    ;;
+  TestSteady_6Medium)
+    TESTTIMEOUT=24h
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -at.std-dev 100'
+    ;;
+  TestUpreplicate_1To6Medium)
+    TESTTIMEOUT=18h
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -at.std-dev 52'
+    ;;
+  TestContinuousLoad_BlockWriter)
+    TESTTIMEOUT=6h
+    COCKROACH_EXTRA_FLAGS+=' -nodes 4'
+    ;;
+  TestContinuousLoad_Photos)
+    TESTTIMEOUT=6h
+    COCKROACH_EXTRA_FLAGS+=' -nodes 4'
+    ;;
+  *)
+    echo "unknown test name $TESTNAME"
+    exit 1
+    ;;
+esac
+
+"$(dirname "${0}")"/../pkg/acceptance/prepare.sh
+
+[ -f ~/.ssh/terraform ] || ssh-keygen -f ~/.ssh/terraform -N ''
+
+# The log files that should be created by -l below can only
+# be created if the parent directory already exists. Ensure
+# that it exists before running the test.
+mkdir -p artifacts/acceptance
+export TMPDIR=$PWD/artifacts/acceptance
+
+TYPE=release-$(go env GOOS)
+case $TYPE in
+  *-linux)
+    TYPE+=-gnu
+    ;;
+esac
+
+build/builder.sh make TYPE=$TYPE testbuild PKG=./pkg/acceptance
+cd pkg/acceptance
+# shellcheck disable=SC2086
+./acceptance.test -l "$TMPDIR" -test.v -test.timeout $TESTTIMEOUT -test.run "\A$TESTNAME\z" -show-logs -remote -key-name terraform \
+  $COCKROACH_EXTRA_FLAGS | go-test-teamcity

--- a/build/teamcity-publish-artifacts.sh
+++ b/build/teamcity-publish-artifacts.sh
@@ -15,7 +15,14 @@ if [[ "$TC_BUILD_BRANCH" != *alpha* ]] && [ "$TEAMCITY_BUILDCONF_NAME" == 'Publi
 	cp cockroach-linux-2.6.32-gnu-amd64 build/deploy/cockroach
 	docker build --tag=$image:{latest,"$TC_BUILD_BRANCH"} build/deploy
 
-	build/builder.sh make TYPE=release-linux-gnu testbuild TAGS=acceptance PKG=./pkg/acceptance
+	TYPE=release-$(go env GOOS)
+	case $TYPE in
+	  *-linux)
+	    TYPE+=-gnu
+	    ;;
+	esac
+
+	build/builder.sh make TYPE=$TYPE testbuild TAGS=acceptance PKG=./pkg/acceptance
 	(cd pkg/acceptance && ./acceptance.test -i $image -b /cockroach/cockroach -nodes 4 -test.v -test.timeout -5m)
 
 	sed "s/<EMAIL>/$DOCKER_EMAIL/;s/<AUTH>/$DOCKER_AUTH/" < build/.dockercfg.in > ~/.dockercfg

--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -184,10 +184,10 @@ func (at *allocatorTest) Run(ctx context.Context, t *testing.T) {
 	at.f.Assert(ctx, t)
 
 	log.Infof(ctx, "starting load on cluster")
-	if err := at.f.StartLoad(ctx, "block_writer", *flagCLTWriters); err != nil {
+	if err := at.f.StartLoad(ctx, "block_writer"); err != nil {
 		t.Fatal(err)
 	}
-	if err := at.f.StartLoad(ctx, "photos", *flagCLTWriters); err != nil {
+	if err := at.f.StartLoad(ctx, "photos"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -14,49 +14,8 @@
 
 package acceptance
 
-// All tests in this file are remote tests that use Terrafarm to manage
-// and run tests against dedicated test clusters.
-//
-// Required setup:
-// 1. Have an Azure account.
-// 2. Passphrase-less SSH key in ~/.ssh/{azure,azure.pub}.
-// 3. Set the ARM_SUBSCRIPTION_ID, ARM_CLIENT_ID, ARM_CLIENT_SECRET, and
-//    ARM_TENANT_ID variables as documented here:
-//    https://www.terraform.io/docs/providers/azurerm/#argument-reference
-//
-// Example use:
-//
-// make test \
-//	 TESTTIMEOUT=48h \
-//	 PKG=./pkg/acceptance \
-//	 TESTS='^TestRebalance_3To5Small$$' \
-//	 TESTFLAGS='-v -remote -key-name azure -cwd terraform/azure -tf.keep-cluster=failed'
-//
-// Things to note:
-// - You must use an SSH key without a passphrase. This is a Terraform
-//   requirement.
-// - If you want to manually fiddle with a test cluster, start the test with
-//   `-tf.keep-cluster=failed". After the cluster has been created, press
-//   Control-C and the cluster will remain up.
-// - These tests rely on a specific Terraform config that's specified using the
-//   -cwd test flag.
-// - You *must* set the TESTTIMEOUT high enough for any of these tests to
-//   finish. To be really safe, specify a timeout of at least 24 hours.
-// - There are various flags that start with `tf.` that control the
-//   of Terrafarm and allocator tests, respectively. For example, you can add
-//   "-tf.cockroach-binary" to TESTFLAGS to specify a custom Linux CockroachDB
-//   binary. If omitted, your test will use the latest CircleCI Linux build.
-//   Note that the location has to be specified relative to the terraform
-//   working directory, so typically `-tf.cockroach-binary=../../cockroach`.
-//   This must be a linux binary; on a mac you must build with
-//   `build/builder.sh make build`.
-//
-// Troubleshooting:
-// - The minimum recommended version of Terraform is 0.7.2. If you see strange
-//   Terraform errors, upgrade your install of Terraform. Terraform 0.8.x or
-//   later might not work because of breaking changes to Terraform.
-// - Adding `-tf.keep-cluster=always` to your TESTFLAGS allows the cluster to
-//   stay around after the test completes.
+// Running these tests is best done using build/teamcity-nightly-
+// acceptance.sh. See instructions therein.
 
 import (
 	gosql "database/sql"

--- a/pkg/acceptance/continuous_load_test.go
+++ b/pkg/acceptance/continuous_load_test.go
@@ -31,21 +31,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-// Run tests in this file as follows:
+// Running these tests is best done using build/teamcity-nightly-
+// acceptance.sh. See instructions therein.
 //
-// make test \
-//   PKG=./pkg/acceptance \
-//   TESTTIMEOUT=6h \
-//   TESTS=ContinuousLoad_BlockWriter \
-//   TESTFLAGS='-v -remote -key-name azure -cwd terraform/azure -nodes 4 -tf.keep-cluster=failed'
-//
-// Load is generated for the duration specified by TESTTIMEOUT, minus some time
-// required for the orderly teardown of resources created by the test.  Because
-// of the time required to create and destroy a test cluster (presently up to
-// 10 minutes), you should use a TESTTIMEOUT that's at least a few hours.
-//
-// Refer to the file-level comments in acceptance/allocator_test.go for more
-// tips on running these tests.
+// These tests run for the duration specified by the testing package's timeout
+// flag, minus some time required for the orderly teardown of resources
+// created by the test. Because of the time required to create and destroy a
+// test cluster (presently up to 10 minutes), you should use a timeout of at
+// least a few hours.
 
 // continuousLoadTest generates continuous load against a remote test cluster
 // created specifically for the test.

--- a/pkg/acceptance/continuous_load_test.go
+++ b/pkg/acceptance/continuous_load_test.go
@@ -128,7 +128,7 @@ func (cl continuousLoadTest) Run(ctx context.Context, t testing.TB) {
 		t.Fatal(err)
 	}
 	start := timeutil.Now()
-	if err := f.StartLoad(ctx, cl.Process, *flagCLTWriters); err != nil {
+	if err := f.StartLoad(ctx, cl.Process); err != nil {
 		t.Fatal(err)
 	}
 	f.Assert(ctx, t)

--- a/pkg/acceptance/terrafarm/farmer.go
+++ b/pkg/acceptance/terrafarm/farmer.go
@@ -16,6 +16,7 @@ package terrafarm
 
 import (
 	"bytes"
+	"flag"
 	"fmt"
 	"io"
 	"net"
@@ -579,9 +580,14 @@ func (f *Farmer) logf(format string, args ...interface{}) {
 	}
 }
 
+var flagCLTWriters = flag.Int("clt.writers", -1, "# of load generators to spawn (defaults to # of nodes)")
+
 // StartLoad starts n loadGenerator processes.
-func (f *Farmer) StartLoad(ctx context.Context, loadGenerator string, n int) error {
-	if n > f.NumNodes() {
+func (f *Farmer) StartLoad(ctx context.Context, loadGenerator string) error {
+	n := *flagCLTWriters
+	if n == -1 {
+		n = f.NumNodes()
+	} else if n > f.NumNodes() {
 		return errors.Errorf("writers (%d) > nodes (%d)", n, f.NumNodes())
 	}
 

--- a/pkg/acceptance/terrafarm/farmer.go
+++ b/pkg/acceptance/terrafarm/farmer.go
@@ -127,6 +127,10 @@ func (f *Farmer) Resize(nodes int) error {
 	if nodes == 0 {
 		args = f.appendDefaults(append([]string{"destroy", "--force"}, args...))
 	} else {
+		if stdout, stderr, err := f.run("terraform", "init"); err != nil {
+			return errors.Wrapf(err, "failed: %s %s\nstdout:\n%s\nstderr:\n%s", "terraform", args, stdout, stderr)
+		}
+
 		args = f.appendDefaults(append([]string{"apply"}, args...))
 
 		if len(f.CockroachBinary) > 0 {

--- a/pkg/acceptance/terrafarm/run.go
+++ b/pkg/acceptance/terrafarm/run.go
@@ -52,15 +52,6 @@ func (f *Farmer) run(cmd string, args ...string) (string, string, error) {
 	return outBuf.String(), errBuf.String(), err
 }
 
-func (f *Farmer) appendDefaults(args []string) []string {
-	return append(
-		args,
-		"-no-color",
-		"-var=key_name="+f.KeyName,
-		"-state="+f.StateFile,
-		`-var=prefix="`+f.Prefix+`"`)
-}
-
 func (f *Farmer) output(key string) []string {
 	o, _, err := f.run("terraform", "output", "-state="+f.StateFile, "-no-color", key)
 	if _, ok := err.(*exec.ExitError); err != nil && !ok {

--- a/pkg/acceptance/terraform/azure/.gitignore
+++ b/pkg/acceptance/terraform/azure/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/pkg/acceptance/terraform/azure/main.tf
+++ b/pkg/acceptance/terraform/azure/main.tf
@@ -197,17 +197,14 @@ resource "null_resource" "cockroach-runner" {
   }
 
   provisioner "file" {
-    # If no binary is specified, we'll copy /dev/null (always 0 bytes) to the
-    # instance. The "remote-exec" block will then overwrite that. There's no
-    # such thing as conditional file copying in Terraform, so we fake it.
-    source = "${coalesce(var.cockroach_binary, "/dev/null")}"
+    source = "${var.cockroach_binary}"
     destination = "/home/ubuntu/cockroach"
   }
 
   # Launch CockroachDB.
   provisioner "remote-exec" {
     inline = [
-      "chmod +x nodectl disable-hyperv-timesync.sh",
+      "chmod +x cockroach nodectl disable-hyperv-timesync.sh",
       # For consistency with other Terraform configs, we create the store in
       # /mnt/data0.
       "sudo mkdir /mnt/data0",
@@ -229,9 +226,6 @@ resource "null_resource" "cockroach-runner" {
       # Send logs to local SSD.
       "mkdir /mnt/data0/logs",
       "ln -sf /mnt/data0/logs logs",
-      # Install CockroachDB.
-      "[ $(stat --format=%s cockroach) -ne 0 ] || curl -sfSL https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.${var.cockroach_sha} -o cockroach",
-      "chmod +x cockroach",
       # Install load generators.
       "curl -sfSL https://edge-binaries.cockroachdb.com/examples-go/block_writer.${var.block_writer_sha} -o block_writer",
       "chmod +x block_writer",

--- a/pkg/acceptance/terraform/azure/main.tf
+++ b/pkg/acceptance/terraform/azure/main.tf
@@ -201,7 +201,7 @@ resource "null_resource" "cockroach-runner" {
   # Launch CockroachDB.
   provisioner "remote-exec" {
     inline = [
-      "chmod 755 cockroach nodectl disable-hyperv-timesync.sh",
+      "chmod +x nodectl disable-hyperv-timesync.sh",
       # For consistency with other Terraform configs, we create the store in
       # /mnt/data0.
       "sudo mkdir /mnt/data0",
@@ -217,15 +217,15 @@ resource "null_resource" "cockroach-runner" {
       "curl -sS https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -",
       "sudo apt-get -qqy update >/dev/null",
       "sudo apt-get -qqy install google-cloud-sdk >/dev/null",
-      # Install CockroachDB.
+      # Disable hypervisor clock sync, because it can cause an unrecoverable
+      # amount of clock skew. This also forces an NTP sync.
+      "./disable-hyperv-timesync.sh",
+      # Send logs to local SSD.
       "mkdir /mnt/data0/logs",
       "ln -sf /mnt/data0/logs logs",
       # Install CockroachDB.
       "[ $(stat --format=%s cockroach) -ne 0 ] || curl -sfSL https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.${var.cockroach_sha} -o cockroach",
       "chmod +x cockroach",
-      # Disable hypervisor clock sync, because it can cause an unrecoverable
-      # amount of clock skew. This also forces an NTP sync.
-      "./disable-hyperv-timesync.sh",
       # Install load generators.
       "curl -sfSL https://edge-binaries.cockroachdb.com/examples-go/block_writer.${var.block_writer_sha} -o block_writer",
       "chmod +x block_writer",

--- a/pkg/acceptance/terraform/azure/main.tf
+++ b/pkg/acceptance/terraform/azure/main.tf
@@ -17,6 +17,12 @@ provider "azurerm" {
   #
   # See https://www.terraform.io/docs/providers/azurerm to understand the Azure
   # permissions needed to run Terraform against it.
+
+  version = "~> 0.1"
+}
+
+provider "null" {
+  version = "~> 0.1"
 }
 
 #

--- a/pkg/acceptance/terraform/azure/variables.tf
+++ b/pkg/acceptance/terraform/azure/variables.tf
@@ -1,5 +1,5 @@
-# Path to the cockroach binary. An empty value results in the latest official
-# binary being used.
+# Path to the cockroach binary. Must always be specified; a default is
+# provided to work around https://github.com/hashicorp/terraform/issues/5425.
 variable "cockroach_binary" {
   default = ""
 }
@@ -12,11 +12,6 @@ variable "cockroach_binary" {
 # support password-protected keys.
 variable "key_name" {
   default = "google_compute_engine"
-}
-
-# SHA of the cockroach binary to pull down. If default, the latest is fetched.
-variable "cockroach_sha" {
-  default = "LATEST"
 }
 
 # SHA of the block_writer binary to pull down. If default, the latest is fetched.

--- a/pkg/acceptance/terraform/azure/variables.tf
+++ b/pkg/acceptance/terraform/azure/variables.tf
@@ -1,14 +1,51 @@
-# Number of CockroachDB instances. This is overridden by terrafarm.
+# Path to the cockroach binary. An empty value results in the latest official
+# binary being used.
+variable "cockroach_binary" {
+  default = ""
+}
+
+# Name of the ssh key pair to use.
+#
+# The path is expanded to: ~/.ssh/<key_name>.pub
+#
+# Note that this key *must not* be password-protected. Terraform doesn't
+# support password-protected keys.
+variable "key_name" {
+  default = "google_compute_engine"
+}
+
+# SHA of the cockroach binary to pull down. If default, the latest is fetched.
+variable "cockroach_sha" {
+  default = "LATEST"
+}
+
+# SHA of the block_writer binary to pull down. If default, the latest is fetched.
+variable "block_writer_sha" {
+  default = "LATEST"
+}
+
+# SHA of the photos binary to pull down. If default, the latest is fetched.
+variable "photos_sha" {
+  default = "LATEST"
+}
+
+# Prefix to prepend to all resource names.
+variable "prefix" {
+  default = "alloctest"
+}
+
 variable "num_instances" {
+  # Nonsense, but terraform needs values for all variables when destroying.
+  # https://github.com/hashicorp/terraform/issues/5425.
   default = "0"
 }
 
-# Azure location to use.
+# Azure configs.
+
 variable "azure_location" {
   default = "eastus"
 }
 
-# GCE image name.
 variable "azure_image" {
   default = "canonical:UbuntuServer:16.04.0-LTS:latest"
 }
@@ -40,42 +77,4 @@ variable "vhd_storage_container" {
 variable "azure_vm_size" {
   # 4cpu, 14Gib ram, 200GiB SSD
   default = "Standard_D3"
-}
-
-# Path to the cockroach binary. An empty value results in the latest official
-# binary being used.
-variable "cockroach_binary" {
-  default = ""
-}
-
-# Name of the ssh key pair to use for GCE instances.
-# The public key will be passed at instance creation, and the private
-# key will be used by the local ssh client.
-#
-# Note that this key *must not* be password-protected. Terraform doesn't support
-# password-protected keys.
-#
-# The path is expanded to: ~/.ssh/<key_name>.pub
-variable "key_name" {
-  default = "azure"
-}
-
-# SHA of the cockroach binary to pull down. If default, the latest is fetched.
-variable "cockroach_sha" {
-  default = "LATEST"
-}
-
-# SHA of the block_writer binary to pull down. If default, the latest is fetched.
-variable "block_writer_sha" {
-  default = "LATEST"
-}
-
-# SHA of the photos binary to pull down. If default, the latest is fetched.
-variable "photos_sha" {
-  default = "LATEST"
-}
-
-# Prefix to prepend to all GC resource names.
-variable "prefix" {
-  default = "alloctest"
 }

--- a/pkg/acceptance/terraform/azure/variables.tf
+++ b/pkg/acceptance/terraform/azure/variables.tf
@@ -18,20 +18,21 @@ variable "azure_resource_group" {
 }
 
 variable "azure_vhd_storage_account" {
-  # Only lowercase letters and numbers are allowed by Azure. This account needs
-  # to belong to ${var.vhd_azure_resource_group}.
-  #
   # This must be created before applying this Terraform config, because creation
   # of storage accounts through the Azure API routinely timeout as of 1/4/2017.
   # Creating storage accounts dynamically also requires dynamic generation of
   # a storage account name, which seems to trigger this issue:
   #
   # https://github.com/hashicorp/terraform/issues/6699
+  #
+  # Using a static storage account name also has the benefit of making it
+  # easier to expunge leaked VHDs, which continue to occur as of 2017-08-09.
+  # Only lowercase letters and numbers are allowed by Azure.
   default = "cockroachnightlyvhd"
 }
 
 variable "vhd_storage_container" {
-  # This must be a storage container associated with ${var.azure_stoarge_account}.
+  # Must belong to ${var.azure_vhd_storage_account}.
   default = "vhds"
 }
 

--- a/pkg/acceptance/terraform/gce/main.tf
+++ b/pkg/acceptance/terraform/gce/main.tf
@@ -2,6 +2,10 @@ provider "google" {
   region = "${var.gce_region}"
 }
 
+provider "null" {
+  version = "~> 0.1"
+}
+
 resource "google_compute_instance" "cockroach" {
   count = "${var.num_instances}"
 

--- a/pkg/acceptance/terraform/gce/main.tf
+++ b/pkg/acceptance/terraform/gce/main.tf
@@ -29,7 +29,7 @@ resource "google_compute_instance" "cockroach" {
   network_interface {
     network = "default"
     access_config {
-        # Ephemeral
+      # Ephemeral
     }
   }
 

--- a/pkg/acceptance/terraform/gce/main.tf
+++ b/pkg/acceptance/terraform/gce/main.tf
@@ -46,3 +46,56 @@ resource "google_compute_instance" "cockroach" {
     scopes = ["https://www.googleapis.com/auth/compute.readonly", "https://www.googleapis.com/auth/devstorage.read_write"]
   }
 }
+
+# Set up CockroachDB nodes.
+resource "null_resource" "cockroach-runner" {
+  count = "${var.num_instances}"
+
+  connection {
+    user = "ubuntu"
+    private_key = "${file(format("~/.ssh/%s", var.key_name))}"
+    host = "${element(google_compute_instance.cockroach.*.network_interface.0.access_config.0.assigned_nat_ip, count.index)}"
+  }
+
+  provisioner "file" {
+    source = "../common/nodectl"
+    destination = "/home/ubuntu/nodectl"
+  }
+
+  provisioner "file" {
+    # If no binary is specified, we'll copy /dev/null (always 0 bytes) to the
+    # instance. The "remote-exec" block will then overwrite that. There's no
+    # such thing as conditional file copying in Terraform, so we fake it.
+    source = "${coalesce(var.cockroach_binary, "/dev/null")}"
+    destination = "/home/ubuntu/cockroach"
+  }
+
+  # Launch CockroachDB.
+  provisioner "remote-exec" {
+      inline = [
+      "chmod +x nodectl",
+      # Create file system on local SSD for the CockroachDB store and mount it.
+      "sudo mkdir /mnt/data0",
+      "sudo mkfs.ext4 -qF /dev/disk/by-id/google-local-ssd-0",
+      "sudo mount -o discard,defaults /dev/disk/by-id/google-local-ssd-0 /mnt/data0",
+      "sudo chown ubuntu:ubuntu /mnt/data0",
+      # Install test dependencies.
+      "export CLOUD_SDK_REPO=\"cloud-sdk-$(lsb_release -c -s)\"",
+      "echo \"deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main\" | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list",
+      "curl -sS https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -",
+      "sudo apt-get -qqy update >/dev/null",
+      "sudo apt-get -qqy install google-cloud-sdk >/dev/null",
+      # Send logs to local SSD.
+      "mkdir /mnt/data0/logs",
+      "ln -sf /mnt/data0/logs logs",
+      # Install CockroachDB.
+      "[ $(stat --format=%s cockroach) -ne 0 ] || curl -sfSL https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.${var.cockroach_sha} -o cockroach",
+      "chmod +x cockroach",
+      # Install load generators.
+      "curl -sfSL https://edge-binaries.cockroachdb.com/examples-go/block_writer.${var.block_writer_sha} -o block_writer",
+      "chmod +x block_writer",
+      "curl -sfSL https://edge-binaries.cockroachdb.com/examples-go/photos.${var.photos_sha} -o photos",
+      "chmod +x photos",
+    ]
+  }
+}

--- a/pkg/acceptance/terraform/gce/variables.tf
+++ b/pkg/acceptance/terraform/gce/variables.tf
@@ -1,5 +1,5 @@
-# Path to the cockroach binary. An empty value results in the latest official
-# binary being used.
+# Path to the cockroach binary. Must always be specified; a default is
+# provided to work around https://github.com/hashicorp/terraform/issues/5425.
 variable "cockroach_binary" {
   default = ""
 }
@@ -12,11 +12,6 @@ variable "cockroach_binary" {
 # support password-protected keys.
 variable "key_name" {
   default = "google_compute_engine"
-}
-
-# SHA of the cockroach binary to pull down. If default, the latest is fetched.
-variable "cockroach_sha" {
-  default = "LATEST"
 }
 
 # SHA of the block_writer binary to pull down. If default, the latest is fetched.

--- a/pkg/acceptance/terraform/gce/variables.tf
+++ b/pkg/acceptance/terraform/gce/variables.tf
@@ -1,42 +1,15 @@
-# Number of CockroachDB instances. This is overridden by terrafarm.
-variable "num_instances" {
-  default = "0"
-}
-
-# GCE region to use.
-variable "gce_region" {
-  default = "us-east1"
-}
-
-# GCE zone to use.
-variable "gce_zone" {
-  default = "us-east1-c"
-}
-
-# GCE image name.
-variable "gce_image" {
-  default = "ubuntu-os-cloud/ubuntu-1604-xenial-v20160815"
-}
-
-# Machine type for non-DB nodes (e.g. load generators).
-variable "gce_machine_type" {
-  default = "n1-standard-4"
-}
-
 # Path to the cockroach binary. An empty value results in the latest official
 # binary being used.
 variable "cockroach_binary" {
   default = ""
 }
 
-# Name of the ssh key pair to use for GCE instances.
-# The public key will be passed at instance creation, and the private
-# key will be used by the local ssh client.
+# Name of the ssh key pair to use.
 #
 # The path is expanded to: ~/.ssh/<key_name>.pub
 #
-# If you use `gcloud compute ssh` or `gcloud compute copy-files`, you may want
-# to leave this as "google_compute_engine" for convenience.
+# Note that this key *must not* be password-protected. Terraform doesn't
+# support password-protected keys.
 variable "key_name" {
   default = "google_compute_engine"
 }
@@ -56,22 +29,43 @@ variable "photos_sha" {
   default = "LATEST"
 }
 
-# Prefix to prepend to all GC resource names.
+# Prefix to prepend to all resource names.
 variable "prefix" {
   default = "alloctest"
 }
 
-# Machine type for CockroachDB nodes.
+variable "num_instances" {
+  # Nonsense, but terraform needs values for all variables when destroying.
+  # https://github.com/hashicorp/terraform/issues/5425.
+  default = "0"
+}
+
+# GCE configs.
+
+variable "gce_region" {
+  default = "us-east1"
+}
+
+variable "gce_zone" {
+  default = "us-east1-c"
+}
+
+variable "gce_image" {
+  default = "ubuntu-os-cloud/ubuntu-1604-xenial-v20160815"
+}
+
+variable "gce_machine_type" {
+  default = "n1-standard-4"
+}
+
 variable "cockroach_machine_type" {
   default = "n1-standard-4"
 }
 
-# Size of root partition for CockroachDB nodes.
 variable "cockroach_root_disk_size" {
   default = "10" # GB
 }
 
-# Controls the disk type for the root partition of CockroachDB nodes.
 variable "cockroach_root_disk_type" {
-  default = "pd-standard" # can set this to 'pd-ssd' for persistent SSD
+  default = "pd-standard"
 }

--- a/pkg/acceptance/util.go
+++ b/pkg/acceptance/util.go
@@ -76,10 +76,6 @@ func init() {
 		"keep the cluster after the test, either 'always', 'never', or 'failed'")
 
 	flag.Parse()
-
-	if *flagCLTWriters == -1 {
-		*flagCLTWriters = *flagNodes
-	}
 }
 
 var flagDuration = flag.Duration("d", cluster.DefaultDuration, "duration to run the test")
@@ -116,10 +112,6 @@ var flagTFCockroachEnv = flag.String("tf.cockroach-env", "",
 // Allocator test flags.
 var flagATMaxStdDev = flag.Float64("at.std-dev", 10,
 	"maximum standard deviation of replica counts")
-
-// continuousLoadTest (CLT) flags.
-var flagCLTWriters = flag.Int("clt.writers", -1,
-	"# of load generators to spawn (defaults to # of nodes)")
 var flagCLTMinQPS = flag.Float64("clt.min-qps", 5.0,
 	"fail load tests when queries per second drops below this during a health check interval")
 

--- a/pkg/acceptance/util.go
+++ b/pkg/acceptance/util.go
@@ -102,8 +102,6 @@ var flagTFReuseCluster = flag.String("reuse", "",
 )
 
 var flagTFKeepCluster = keepClusterVar(terrafarm.KeepClusterNever) // see init()
-var flagTFCockroachBinary = flag.String("tf.cockroach-binary", "",
-	"path to custom CockroachDB binary to use for allocator tests")
 var flagTFCockroachFlags = flag.String("tf.cockroach-flags", "",
 	"command-line flags to pass to cockroach for allocator tests")
 var flagTFCockroachEnv = flag.String("tf.cockroach-env", "",
@@ -284,7 +282,7 @@ func MakeFarmer(t testing.TB, prefix string, stopper *stop.Stopper) *terrafarm.F
 		Cwd:             *flagCwd,
 		LogDir:          logDir,
 		KeyName:         *flagKeyName,
-		CockroachBinary: *flagTFCockroachBinary,
+		CockroachBinary: *cluster.CockroachBinary,
 		CockroachFlags:  stores + " " + *flagTFCockroachFlags,
 		CockroachEnv:    cockroachEnv,
 		Prefix:          name,


### PR DESCRIPTION
I think we're going to have to make the nightlies depend on bleeding edge build (so that the binary can be downloaded) but that seems OK.