### PR TITLE
sql: fix flake in TestTrace/ShowTraceForSplitBatch

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -145,13 +145,12 @@ func TestTrace(t *testing.T) {
 				// and will split the underlying BatchRequest/BatchResponse. Tracing
 				// in the presence of multi-part batches is what we want to test here.
 				return sqlDB.Query(
-					"SELECT operation op FROM [SHOW TRACE FOR DELETE FROM test.bar] " +
+					"SELECT DISTINCT(operation) op FROM [SHOW TRACE FOR DELETE FROM test.bar] " +
 						"WHERE message LIKE '%1 DelRng%' ORDER BY op")
 			},
 			expSpans: []string{
 				"kv.DistSender: sending partial batch",
 				"starting plan",
-				"/cockroach.roachpb.Internal/Batch",
 				"/cockroach.roachpb.Internal/Batch",
 			},
 		},


### PR DESCRIPTION
Fixes #17421.

Previously, `TestTrace/ShowTraceForSplitBatch` asserted that a specific number
of tracing operations would be present in its `SHOW TRACE` results. In the case
of an auto-retried statement, there would be extra operations. This change adds
a DISTINCT operation to deduplicate these operations so that auto-retries will
no longer fail the test, as is done in the other sub-tests.