### PR TITLE
storage: fix panic on destroyed quota pool access

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6110,6 +6110,35 @@ func TestReplicaDestroy(t *testing.T) {
 	}
 }
 
+// TestQuotaPoolAccessOnDestroyedReplica tests the occurrence of #17303 where
+// following a leader replica getting destroyed, the scheduling of
+// handleRaftReady twice on the replica would cause a panic when
+// finding a nil/closed quota pool.
+func TestQuotaPoolAccessOnDestroyedReplica(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	tc.Start(t, stopper)
+
+	repl, err := tc.store.GetReplica(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tc.store.removeReplicaImpl(context.TODO(), repl, *repl.Desc(), true); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := repl.handleRaftReady(IncomingSnapshot{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := repl.handleRaftReady(IncomingSnapshot{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestEntries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	tc := testContext{}


### PR DESCRIPTION
Fixes #17303.

If we're the leader and we get destroyed, we nil out/close the quota
pool the next time we're in the handleRaftReady goroutine (if ever).
If we receive another raft ready message hitting the same code path
(handleRaftReady) and we're effectively still the leader
(Replica.mu.leaderID == Replica.mu.replicaID), we have a nil quota pool
despite being leader. It isn't that we have an uninitialized quota pool,
we just destroyed it previously.

The likelihood of this happening is incredibly rare, effectively we'd
have to schedule the handleRaftReady goroutine twice in the brief window
of time between when a replica is marked to be destroyed and is cleaned
up to prevent further raft processing.

In order to simulate this in test the following suffices:

    store.RemoveReplica(repl)
    repl.handleRaftReady()
    repl.handleRaftReady()