### PR TITLE
storage: retry when test code wins the race against raft

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1958,7 +1958,7 @@ outer:
 				t.Fatal("could not find raft replica")
 			}
 		}
-		t.Fatal("could not find raft leader")
+		i-- // try again
 	}
 }
 


### PR DESCRIPTION
Before this change:
```
--- FAIL: TestReportUnreachableRemoveRace (1.43s)
	client_raft_test.go:1961: could not find raft leader
FAIL

ERROR: exit status 1

121 runs completed, 1 failures, over 1m56s
```

After this change:
```
535 runs completed, 0 failures, over 8m31s
```

Fixes #17494.