### PR TITLE
sql: propagate errors on missing type switch

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1393,7 +1393,12 @@ func getTypesForPlanResult(node planNode, planToStreamColMap []int) []sqlbase.Co
 		// No remapping.
 		types := make([]sqlbase.ColumnType, len(nodeColumns))
 		for i := range nodeColumns {
-			types[i] = sqlbase.DatumTypeToColumnType(nodeColumns[i].Typ)
+			colTyp, err := sqlbase.DatumTypeToColumnType(nodeColumns[i].Typ)
+			if err != nil {
+				// TODO(radu): propagate this instead of panicking
+				panic(err)
+			}
+			types[i] = colTyp
 		}
 		return types
 	}
@@ -1406,7 +1411,12 @@ func getTypesForPlanResult(node planNode, planToStreamColMap []int) []sqlbase.Co
 	types := make([]sqlbase.ColumnType, numCols)
 	for nodeCol, streamCol := range planToStreamColMap {
 		if streamCol != -1 {
-			types[streamCol] = sqlbase.DatumTypeToColumnType(nodeColumns[nodeCol].Typ)
+			colTyp, err := sqlbase.DatumTypeToColumnType(nodeColumns[nodeCol].Typ)
+			if err != nil {
+				// TODO(radu): propagate this instead of panicking
+				panic(err)
+			}
+			types[streamCol] = colTyp
 		}
 	}
 	return types
@@ -1816,7 +1826,11 @@ func (dsp *distSQLPlanner) createPlanForValues(
 	types := make([]sqlbase.ColumnType, columns)
 
 	for i, t := range n.columns {
-		types[i] = sqlbase.DatumTypeToColumnType(t.Typ)
+		colTyp, err := sqlbase.DatumTypeToColumnType(t.Typ)
+		if err != nil {
+			return physicalPlan{}, err
+		}
+		types[i] = colTyp
 		s.Columns[i].Encoding = sqlbase.DatumEncoding_VALUE
 		s.Columns[i].Type = types[i]
 	}

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -67,7 +67,12 @@ func GetAggregateInfo(
 			constructAgg := func(evalCtx *parser.EvalContext) parser.AggregateFunc {
 				return b.AggregateFunc(datumTypes, evalCtx)
 			}
-			return constructAgg, sqlbase.DatumTypeToColumnType(b.FixedReturnType()), nil
+
+			colTyp, err := sqlbase.DatumTypeToColumnType(b.FixedReturnType())
+			if err != nil {
+				return nil, sqlbase.ColumnType{}, err
+			}
+			return constructAgg, colTyp, nil
 		}
 	}
 	return nil, sqlbase.ColumnType{}, errors.Errorf(

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -121,7 +121,11 @@ func (h *ProcOutputHelper) Init(
 			if err := h.renderExprs[i].init(expr, types, evalCtx); err != nil {
 				return err
 			}
-			h.outputTypes[i] = sqlbase.DatumTypeToColumnType(h.renderExprs[i].expr.ResolvedType())
+			colTyp, err := sqlbase.DatumTypeToColumnType(h.renderExprs[i].expr.ResolvedType())
+			if err != nil {
+				return err
+			}
+			h.outputTypes[i] = colTyp
 		}
 	} else {
 		h.outputTypes = types


### PR DESCRIPTION
Previously, DatumTypeToColumnSemanticType and DatumTypeToColumnType
would panic if there was a missing case in the type switch. This caused
several panics on unsupported features in production, producing point
release bugfixes on several occasions.

There's no need to panic on these missing cases - an error is perfectly
sufficient.

cc @RaduBerinde - there's a case that was kind of annoying to propagate errors through on the DistSQL side, so I restored the old behavior (panicking) and added a TODO for you to resolve as you wish.