### PR TITLE
ui: handle decommissioned nodes

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -25,6 +25,10 @@ const deadNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
   "nodes/dead_sort_setting", (s) => s.localSettings,
 );
 
+const decommissionedNodesSortSetting = new LocalSetting<AdminUIState, SortSetting>(
+  "nodes/decommissioned_sort_setting", (s) => s.localSettings,
+);
+
 // Specialization of generic SortedTable component:
 //   https://github.com/Microsoft/TypeScript/issues/3960
 //
@@ -35,7 +39,7 @@ const NodeSortedTable = SortedTable as new () => SortedTable<NodeStatus$Properti
 
 /**
  * NodeCategoryListProps are the properties shared by both LiveNodeList and
- * DeadNodeList.
+ * NotLiveNodeList.
  */
 interface NodeCategoryListProps {
   sortSetting: SortSetting;
@@ -143,18 +147,26 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
 }
 
 /**
- * DeadNodeList renders a sortable table of all "dead" nodes on the cluster.
+ * NotLiveNodeListProps are the properties of NotLiveNodeList.
  */
-class DeadNodeList extends React.Component<NodeCategoryListProps, {}> {
+interface NotLiveNodeListProps extends NodeCategoryListProps {
+  title: string;
+}
+
+/**
+ * NotLiveNodeList renders a sortable table of all "dead" or "decommissioned"
+ * nodes on the cluster.
+ */
+class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
   render() {
-    const { statuses, nodesSummary, sortSetting } = this.props;
+    const { title, statuses, nodesSummary, sortSetting } = this.props;
     if (!statuses || statuses.length === 0) {
       return null;
     }
 
     return <div>
       <section className="header header--subsection">
-        Dead Nodes
+        {title}
       </section>
       <section className="section">
         <NodeSortedTable
@@ -216,19 +228,26 @@ const nodeQueryValid = (state: AdminUIState): boolean => state.cachedData.nodes.
 const partitionedStatuses = createSelector(
   nodesSummarySelector,
   (summary) => {
-    const liveOrDead = _.partition(
+    return _.groupBy(
       summary.nodeStatuses,
-      (ns) => summary.livenessStatusByNodeID[ns.desc.node_id] !== LivenessStatus.DEAD,
+      (ns) => {
+        switch (summary.livenessStatusByNodeID[ns.desc.node_id]) {
+          case LivenessStatus.HEALTHY:
+          case LivenessStatus.SUSPECT:
+            return "live";
+          case LivenessStatus.DECOMMISSIONED:
+            return "decommissioned";
+          case LivenessStatus.DEAD:
+          default:
+            return "dead";
+        }
+      },
     );
-    return {
-      live: liveOrDead[0],
-      dead: liveOrDead[1],
-    };
   },
 );
 
 /**
- * LiveNodesConnected is a redux-connected HOC of LiveNodes.
+ * LiveNodesConnected is a redux-connected HOC of LiveNodeList.
  */
 // tslint:disable-next-line:variable-name
 const LiveNodesConnected = connect(
@@ -246,13 +265,14 @@ const LiveNodesConnected = connect(
 )(LiveNodeList);
 
 /**
- * DeadNodesConnected is a redux-connected HOC of DeadNodes.
+ * DeadNodesConnected is a redux-connected HOC of NotLiveNodeList.
  */
 // tslint:disable-next-line:variable-name
 const DeadNodesConnected = connect(
   (state: AdminUIState) => {
     const statuses = partitionedStatuses(state);
     return {
+      title: "Dead Nodes",
       sortSetting: deadNodesSortSetting.selector(state),
       statuses: statuses.dead,
       nodesSummary: nodesSummarySelector(state),
@@ -261,7 +281,26 @@ const DeadNodesConnected = connect(
   {
     setSort: deadNodesSortSetting.set,
   },
-)(DeadNodeList);
+)(NotLiveNodeList);
+
+/**
+ * DecommissionedNodesConnected is a redux-connected HOC of NotLiveNodeList.
+ */
+// tslint:disable-next-line:variable-name
+const DecommissionedNodesConnected = connect(
+  (state: AdminUIState) => {
+    const statuses = partitionedStatuses(state);
+    return {
+      title: "Decommissioned Nodes",
+      sortSetting: decommissionedNodesSortSetting.selector(state),
+      statuses: statuses.decommissioned,
+      nodesSummary: nodesSummarySelector(state),
+    };
+  },
+  {
+    setSort: decommissionedNodesSortSetting.set,
+  },
+)(NotLiveNodeList);
 
 /**
  * NodesMainProps is the type of the props object that must be passed to
@@ -302,6 +341,7 @@ class NodesMain extends React.Component<NodesMainProps, {}> {
       </section>
       <LiveNodesConnected />
       <DeadNodesConnected />
+      <DecommissionedNodesConnected />
     </div>;
   }
 }


### PR DESCRIPTION
Hide decommissioned nodes from node counts, and break them out into
their own table on the nodes overview page.

Addresses #6198.

![screenshot 2017-08-09 11 23 24](https://user-images.githubusercontent.com/882976/29130308-7013fc36-7cf7-11e7-94dc-f841eb43a8ef.png)

![screenshot 2017-08-09 11 23 29](https://user-images.githubusercontent.com/882976/29130312-729590d2-7cf7-11e7-9ca2-1ac47eb308ad.png)