### PR TITLE
decommissioning: Adding flags to the node status command.

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1364,6 +1364,42 @@ func TestNodeStatus(t *testing.T) {
 	}
 	checkNodeStatus(t, c, out, start)
 
+	out, err = c.RunWithCapture("node status --ranges --format=pretty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkNodeStatus(t, c, out, start)
+
+	out, err = c.RunWithCapture("node status --stats --format=pretty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkNodeStatus(t, c, out, start)
+
+	out, err = c.RunWithCapture("node status --ranges --stats --format=pretty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkNodeStatus(t, c, out, start)
+
+	out, err = c.RunWithCapture("node status --decommission --format=pretty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkNodeStatus(t, c, out, start)
+
+	out, err = c.RunWithCapture("node status --ranges --stats --decommission --format=pretty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkNodeStatus(t, c, out, start)
+
+	out, err = c.RunWithCapture("node status --all --format=pretty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkNodeStatus(t, c, out, start)
+
 	out, err = c.RunWithCapture("node status --format=pretty")
 	if err != nil {
 		t.Fatal(err)
@@ -1374,6 +1410,12 @@ func TestNodeStatus(t *testing.T) {
 func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 	buf := bytes.NewBufferString(output)
 	s := bufio.NewScanner(buf)
+
+	type testCase struct {
+		name   string
+		idx    int
+		maxval int64
+	}
 
 	// Skip command line.
 	if !s.Scan() {
@@ -1390,8 +1432,8 @@ func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-	if !reflect.DeepEqual(cols, statusNodesColumnHeaders) {
-		t.Fatalf("columns (%s) don't match expected (%s)", cols, statusNodesColumnHeaders)
+	if !reflect.DeepEqual(cols, getStatusNodeHeaders()) {
+		t.Fatalf("columns (%s) don't match expected (%s)", cols, getStatusNodeHeaders())
 	}
 
 	checkSeparatorLine(t, s)
@@ -1429,21 +1471,37 @@ func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 	checkTimeElapsed(t, fields[3], 15*time.Second, start)
 	checkTimeElapsed(t, fields[4], 15*time.Second, start)
 
-	// Verify all byte/range metrics.
-	testcases := []struct {
-		name   string
-		idx    int
-		maxval int64
-	}{
-		{"live_bytes", 5, 100000},
-		{"key_bytes", 6, 30000},
-		{"value_bytes", 7, 100000},
-		{"intent_bytes", 8, 30000},
-		{"system_bytes", 9, 30000},
-		{"leader_ranges", 10, 3},
-		{"repl_ranges", 11, 3},
-		{"avail_ranges", 12, 3},
+	testcases := []testCase{}
+
+	// We're skipping over the first 5 default fields such as node id and
+	// address. They don't need closer checks.
+	baseIdx := len(baseNodeColumnHeaders)
+
+	// Adding fields that need verification for --range flag.
+	if nodeCtx.statusShowRanges || nodeCtx.statusShowAll {
+		testcases = append(testcases,
+			testCase{"leader_ranges", baseIdx, 3},
+			testCase{"repl_ranges", baseIdx + 1, 3},
+			testCase{"avail_ranges", baseIdx + 2, 3},
+		)
+
+		// Ranges actually adds 5 fields, but we only need to check
+		// the 3 above.
+		baseIdx += len(statusNodesColumnHeadersForRanges)
 	}
+
+	// Adding fields that need verification for --stats flag.
+	if nodeCtx.statusShowStats || nodeCtx.statusShowAll {
+		testcases = append(testcases,
+			testCase{"live_bytes", baseIdx, 100000},
+			testCase{"key_bytes", baseIdx + 1, 30000},
+			testCase{"value_bytes", baseIdx + 2, 100000},
+			testCase{"intent_bytes", baseIdx + 3, 30000},
+			testCase{"system_bytes", baseIdx + 4, 30000},
+		)
+		baseIdx += len(statusNodesColumnHeadersForStats)
+	}
+
 	for _, tc := range testcases {
 		val, err := strconv.ParseInt(fields[tc.idx], 10, 64)
 		if err != nil {
@@ -1497,7 +1555,7 @@ func extractFields(line string) ([]string, error) {
 	// fields has two extra entries, one for the empty token to the left of the first
 	// |, and another empty one to the right of the final |. So, we need to take those
 	// out.
-	if a, e := len(fields), len(statusNodesColumnHeaders)+2; a != e {
+	if a, e := len(fields), len(getStatusNodeHeaders())+2; a != e {
 		return nil, errors.Errorf("can't extract fields: # of fields (%d) != expected (%d)", a, e)
 	}
 	fields = fields[1 : len(fields)-1]

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -504,4 +504,28 @@ Takes any of the following values:
 
 </PRE>`,
 	}
+
+	NodeRanges = FlagInfo{
+		Name: "ranges",
+		Description: `
+		 Show node details for ranges and replicas.`,
+	}
+
+	NodeStats = FlagInfo{
+		Name: "stats",
+		Description: `
+		 Show node disk usage details.`,
+	}
+
+	NodeAll = FlagInfo{
+		Name: "all",
+		Description: `
+		 Show all node details.`,
+	}
+
+	NodeDecommission = FlagInfo{
+		Name: "decommission",
+		Description: `
+		 Show node decomissioning details.`,
+	}
 )

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -300,7 +300,11 @@ var quitCtx struct {
 
 // nodeCtx captures the command-line parameters of the `node` command.
 var nodeCtx = struct {
-	nodeDecommissionWait nodeDecommissionWaitType
+	nodeDecommissionWait   nodeDecommissionWaitType
+	statusShowRanges       bool
+	statusShowStats        bool
+	statusShowDecommission bool
+	statusShowAll          bool
 }{
 	nodeDecommissionWait: nodeDecommissionWaitAll,
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -308,6 +308,15 @@ func init() {
 		stringFlag(f, &baseCfg.SSLCertsDir, cliflags.CertsDir, base.DefaultCertsDirectory)
 	}
 
+	// Node Status command.
+	{
+		f := statusNodeCmd.Flags()
+		boolFlag(f, &nodeCtx.statusShowRanges, cliflags.NodeRanges, false)
+		boolFlag(f, &nodeCtx.statusShowStats, cliflags.NodeStats, false)
+		boolFlag(f, &nodeCtx.statusShowAll, cliflags.NodeAll, false)
+		boolFlag(f, &nodeCtx.statusShowDecommission, cliflags.NodeDecommission, false)
+	}
+
 	// Decommission command.
 	varFlag(decommissionNodeCmd.Flags(), &nodeCtx.nodeDecommissionWait, cliflags.Wait)
 

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -77,22 +77,35 @@ func runLsNodes(cmd *cobra.Command, args []string) error {
 	return printQueryOutput(os.Stdout, lsNodesColumnHeaders, newRowSliceIter(rows), "")
 }
 
-var statusNodesColumnHeaders = []string{
+var baseNodeColumnHeaders = []string{
 	"id",
 	"address",
 	"build",
 	"updated_at",
 	"started_at",
-	"live_bytes",
-	"key_bytes",
-	"value_bytes",
-	"intent_bytes",
-	"system_bytes",
+}
+
+var statusNodesColumnHeadersForRanges = []string{
 	"replicas_leaders",
 	"replicas_leaseholders",
 	"ranges",
 	"ranges_unavailable",
 	"ranges_underreplicated",
+}
+
+var statusNodesColumnHeadersForStats = []string{
+	"live_bytes",
+	"key_bytes",
+	"value_bytes",
+	"intent_bytes",
+	"system_bytes",
+}
+
+var statusNodesColumnHeadersForDecommission = []string{
+	"is_live",
+	"gossiped_replicas",
+	"is_decommissioning",
+	"is_draining",
 }
 
 var statusNodeCmd = &cobra.Command{
@@ -115,6 +128,8 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 	ctx := stopperContext(stopper)
 	defer stopper.Stop(ctx)
 
+	var decommissionStatusRequest *serverpb.DecommissionStatusRequest
+
 	switch len(args) {
 	case 0:
 		// Show status for all nodes.
@@ -123,12 +138,22 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		nodeStatuses = nodes.Nodes
+		decommissionStatusRequest = &serverpb.DecommissionStatusRequest{
+			NodeIDs: []roachpb.NodeID{},
+		}
 
 	case 1:
 		nodeID := args[0]
 		nodeStatus, err := c.Node(ctx, &serverpb.NodeRequest{NodeId: nodeID})
 		if err != nil {
 			return err
+		}
+		nodeIDs, err := parseNodeIDs(args)
+		if err != nil {
+			return err
+		}
+		decommissionStatusRequest = &serverpb.DecommissionStatusRequest{
+			NodeIDs: nodeIDs,
 		}
 		if nodeStatus.Desc.NodeID == 0 {
 			// I'm not sure why the status call doesn't return an error when the given NodeID doesn't
@@ -143,12 +168,44 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 		return errors.Errorf("expected no arguments or a single node ID")
 	}
 
-	return printQueryOutput(os.Stdout, statusNodesColumnHeaders, newRowSliceIter(nodeStatusesToRows(nodeStatuses)), "")
+	var decommissionStatusResp *serverpb.DecommissionStatusResponse
+	if nodeCtx.statusShowDecommission || nodeCtx.statusShowAll {
+		cAdmin, stopperAdmin, err := getAdminClient()
+		if err != nil {
+			return err
+		}
+		ctxAdmin := stopperContext(stopperAdmin)
+		defer stopperAdmin.Stop(ctxAdmin)
+
+		decommissionStatusResp, err = cAdmin.DecommissionStatus(ctxAdmin, decommissionStatusRequest)
+		if err != nil {
+			return err
+		}
+	}
+
+	return printQueryOutput(os.Stdout, getStatusNodeHeaders(), newRowSliceIter(nodeStatusesToRows(nodeStatuses, decommissionStatusResp)), "")
+}
+
+func getStatusNodeHeaders() []string {
+	headers := baseNodeColumnHeaders
+
+	if nodeCtx.statusShowAll || nodeCtx.statusShowRanges {
+		headers = append(headers, statusNodesColumnHeadersForRanges...)
+	}
+	if nodeCtx.statusShowAll || nodeCtx.statusShowStats {
+		headers = append(headers, statusNodesColumnHeadersForStats...)
+	}
+	if nodeCtx.statusShowAll || nodeCtx.statusShowDecommission {
+		headers = append(headers, statusNodesColumnHeadersForDecommission...)
+	}
+	return headers
 }
 
 // nodeStatusesToRows converts NodeStatuses to SQL-like result rows, so that we can pretty-print
-// them.
-func nodeStatusesToRows(statuses []status.NodeStatus) [][]string {
+// them. We also pass a decommission status object if status was called with the --decommission flag.
+func nodeStatusesToRows(
+	statuses []status.NodeStatus, decomStatus *serverpb.DecommissionStatusResponse,
+) [][]string {
 	// Create results that are like the results for SQL results, so that we can pretty-print them.
 	var rows [][]string
 	for _, nodeStatus := range statuses {
@@ -166,23 +223,34 @@ func nodeStatusesToRows(statuses []status.NodeStatus) [][]string {
 			}
 		}
 
-		rows = append(rows, []string{
-			strconv.FormatInt(int64(nodeStatus.Desc.NodeID), 10),
+		row := []string{strconv.FormatInt(int64(nodeStatus.Desc.NodeID), 10),
 			hostPort,
 			build,
 			updatedAtStr,
-			startedAtStr,
-			strconv.FormatInt(int64(metricVals["livebytes"]), 10),
-			strconv.FormatInt(int64(metricVals["keybytes"]), 10),
-			strconv.FormatInt(int64(metricVals["valbytes"]), 10),
-			strconv.FormatInt(int64(metricVals["intentbytes"]), 10),
-			strconv.FormatInt(int64(metricVals["sysbytes"]), 10),
-			strconv.FormatInt(int64(metricVals["replicas.leaders"]), 10),
-			strconv.FormatInt(int64(metricVals["replicas.leaseholders"]), 10),
-			strconv.FormatInt(int64(metricVals["ranges"]), 10),
-			strconv.FormatInt(int64(metricVals["ranges.unavailable"]), 10),
-			strconv.FormatInt(int64(metricVals["ranges.underreplicated"]), 10),
-		})
+			startedAtStr}
+
+		if nodeCtx.statusShowAll || nodeCtx.statusShowRanges {
+			row = append(row,
+				strconv.FormatInt(int64(metricVals["replicas.leaders"]), 10),
+				strconv.FormatInt(int64(metricVals["replicas.leaseholders"]), 10),
+				strconv.FormatInt(int64(metricVals["ranges"]), 10),
+				strconv.FormatInt(int64(metricVals["ranges.unavailable"]), 10),
+				strconv.FormatInt(int64(metricVals["ranges.underreplicated"]), 10),
+			)
+		}
+		if nodeCtx.statusShowAll || nodeCtx.statusShowStats {
+			row = append(row,
+				strconv.FormatInt(int64(metricVals["livebytes"]), 10),
+				strconv.FormatInt(int64(metricVals["keybytes"]), 10),
+				strconv.FormatInt(int64(metricVals["valbytes"]), 10),
+				strconv.FormatInt(int64(metricVals["intentbytes"]), 10),
+				strconv.FormatInt(int64(metricVals["sysbytes"]), 10),
+			)
+		}
+		if nodeCtx.statusShowAll || nodeCtx.statusShowDecommission {
+			row = append(row, decommissionResponseValueToRows(decomStatus.Status)[0][1:]...)
+		}
+		rows = append(rows, row)
 	}
 	return rows
 }
@@ -190,7 +258,7 @@ func nodeStatusesToRows(statuses []status.NodeStatus) [][]string {
 var decommissionNodesColumnHeaders = []string{
 	"id",
 	"is_live",
-	"replicas",
+	"gossiped_replicas",
 	"is_decommissioning",
 	"is_draining",
 }
@@ -221,6 +289,9 @@ func parseNodeIDs(strNodeIDs []string) ([]roachpb.NodeID, error) {
 }
 
 func runDecommissionNode(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return usageAndError(cmd)
+	}
 	c, stopper, err := getAdminClient()
 	if err != nil {
 		return err
@@ -228,14 +299,6 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 	ctx := stopperContext(stopper)
 	defer stopper.Stop(ctx)
 
-	if len(args) == 0 {
-		req := &serverpb.DecommissionStatusRequest{}
-		resp, err := c.DecommissionStatus(ctx, req)
-		if err != nil {
-			return err
-		}
-		return printDecommissionStatus(*resp)
-	}
 	return runDecommissionNodeImpl(ctx, c, nodeCtx.nodeDecommissionWait, args)
 }
 


### PR DESCRIPTION
Before the node status command would return a fairly large
and hard to read table.

Now we'll have --ranges, --stats, --decommission and --all flags.
--ranges will return metrics related to ranges and replicas.
--stats will return storage metrics.
--decommission will return decomissioning metrics.
--all will return everything.
If multiple flags are set then metrics will be concatenated.

Closes #17419