### PR TITLE
timeutil: deflake TestTimerStop

### DIFF
--- a/pkg/util/timeutil/timer_test.go
+++ b/pkg/util/timeutil/timer_test.go
@@ -15,6 +15,7 @@
 package timeutil
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -41,17 +42,36 @@ func TestTimerTimeout(t *testing.T) {
 }
 
 func TestTimerStop(t *testing.T) {
-	var timer Timer
-	timer.Reset(timeStep)
-	if stopped := timer.Stop(); !stopped {
-		t.Errorf("expected Stop to return true, got false")
+	for sleepMult := time.Duration(0); sleepMult < 3; sleepMult++ {
+		sleepDur := sleepMult * timeStep
+		t.Run(fmt.Sprintf("sleepDur=%d*timeStep", sleepMult), func(t *testing.T) {
+			var timer Timer
+			timer.Reset(timeStep)
+			time.Sleep(sleepDur)
+
+			// Get a handle to the timer channel before calling Stop, because Stop
+			// clears the struct.
+			c := timer.C
+
+			// Even though we sleep for a certain duration which we know to be more
+			// or less than the timer's duration, we can't assert whether the timer
+			// fires before calling timer.Stop because we have no control over the
+			// scheduler. Instead, we handle both cases to avoid flakiness and assert
+			// that Stop returns the correct status.
+			stopped := timer.Stop()
+			select {
+			case <-c:
+				if stopped {
+					t.Errorf("timer unexpectedly fired after stopping")
+				}
+			case <-time.After(5 * timeStep):
+				if !stopped {
+					t.Errorf("timer did not fire after failing to stop")
+				}
+			}
+		})
 	}
 
-	select {
-	case <-timer.C:
-		t.Errorf("expected timer to stop after call to Stop; got timer that was not stopped")
-	case <-time.After(5 * timeStep):
-	}
 }
 
 func TestTimerUninitializedStopNoop(t *testing.T) {


### PR DESCRIPTION
Fixes #15837.

Previously, `TestTimerStop` called `timer.Reset` and `timer.Stop`
back-to-back, asserting that the timer never went off. This was flaky
because we could have been preempted in-between these calls in a way that
the timer did go off before calling `Stop`. We now handle both cases and
sleep for different amounts of time between the `Reset` and the `Stop`.