### PR TITLE
storage: disallow splits in meta2 ranges

### DIFF
--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -254,14 +254,16 @@ func TestMetaScanBounds(t *testing.T) {
 		},
 	}
 	for i, test := range testCases {
-		resStart, resEnd, err := MetaScanBounds(test.key)
+		res, err := MetaScanBounds(test.key)
 
 		if !testutils.IsError(err, test.expError) {
 			t.Errorf("expected error: %s ; got %v", test.expError, err)
 		}
 
-		if !resStart.Equal(test.expStart) || !resEnd.Equal(test.expEnd) {
-			t.Errorf("%d: range bounds %q-%q don't match expected bounds %q-%q for key %q", i, resStart, resEnd, test.expStart, test.expEnd, test.key)
+		expected := roachpb.RSpan{Key: test.expStart, EndKey: test.expEnd}
+		if !res.Equal(expected) {
+			t.Errorf("%d: range bounds %s don't match expected bounds %s for key %s",
+				i, res, expected, roachpb.Key(test.key))
 		}
 	}
 }
@@ -322,14 +324,16 @@ func TestMetaReverseScanBounds(t *testing.T) {
 		},
 	}
 	for i, test := range testCases {
-		resStart, resEnd, err := MetaReverseScanBounds(roachpb.RKey(test.key))
+		res, err := MetaReverseScanBounds(roachpb.RKey(test.key))
 
 		if !testutils.IsError(err, test.expError) {
 			t.Errorf("expected error %q ; got %v", test.expError, err)
 		}
 
-		if !resStart.Equal(test.expStart) || !resEnd.Equal(test.expEnd) {
-			t.Errorf("%d: range bounds %q-%q don't match expected bounds %q-%q for key %q", i, resStart, resEnd, test.expStart, test.expEnd, test.key)
+		expected := roachpb.RSpan{Key: test.expStart, EndKey: test.expEnd}
+		if !res.Equal(expected) {
+			t.Errorf("%d: range bounds %s don't match expected bounds %s for key %s",
+				i, res, expected, roachpb.Key(test.key))
 		}
 	}
 }

--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -17,8 +17,13 @@ package keys
 import "github.com/cockroachdb/cockroach/pkg/roachpb"
 
 var (
-	// Meta1Span holds all first level addressing.
-	Meta1Span = roachpb.Span{Key: roachpb.KeyMin, EndKey: Meta2Prefix}
+	// MetaSpan holds all the addressing records.
+	//
+	// TODO(peter): Allow splitting of meta2 records. This requires enhancement
+	// to range lookup. See #16266.
+	//
+	//  Meta1Span = roachpb.Span{Key: roachpb.KeyMin, EndKey: Meta2Prefix}
+	MetaSpan = roachpb.Span{Key: roachpb.KeyMin, EndKey: MetaMax}
 
 	// NodeLivenessSpan holds the liveness records for nodes in the cluster.
 	NodeLivenessSpan = roachpb.Span{Key: NodeLivenessPrefix, EndKey: NodeLivenessKeyMax}
@@ -27,8 +32,8 @@ var (
 	SystemConfigSpan = roachpb.Span{Key: SystemConfigSplitKey, EndKey: SystemConfigTableDataMax}
 
 	// NoSplitSpans describes the ranges that should never be split.
-	// Meta1Span: needed to find other ranges.
+	// MetaSpan: needed to find other ranges.
 	// NodeLivenessSpan: liveness information on nodes in the cluster.
 	// SystemConfigSpan: system objects which will be gossiped.
-	NoSplitSpans = []roachpb.Span{Meta1Span, NodeLivenessSpan, SystemConfigSpan}
+	NoSplitSpans = []roachpb.Span{MetaSpan, NodeLivenessSpan, SystemConfigSpan}
 )

--- a/pkg/kv/split_test.go
+++ b/pkg/kv/split_test.go
@@ -105,8 +105,11 @@ func TestRangeSplitMeta(t *testing.T) {
 
 	ctx := context.TODO()
 
-	splitKeys := []roachpb.RKey{roachpb.RKey("G"), mustMeta(roachpb.RKey("F")),
-		mustMeta(roachpb.RKey("K")), mustMeta(roachpb.RKey("H"))}
+	// TODO(peter): revert when we allow meta2 splitting. See #16266.
+	// splitKeys := []roachpb.RKey{roachpb.RKey("G"), mustMeta(roachpb.RKey("F")),
+	// 	mustMeta(roachpb.RKey("K")), mustMeta(roachpb.RKey("H"))}
+	splitKeys := []roachpb.RKey{roachpb.RKey("G"), roachpb.RKey("F"),
+		roachpb.RKey("K"), roachpb.RKey("H")}
 
 	// Execute the consecutive splits.
 	for _, splitRKey := range splitKeys {

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -2995,9 +2995,9 @@ func TestValidSplitKeys(t *testing.T) {
 		{roachpb.Key("\x02"), false},
 		{roachpb.Key("\x02\x00"), false},
 		{roachpb.Key("\x02\xff"), false},
-		{roachpb.Key("\x03"), true},
-		{roachpb.Key("\x03\x00"), true},
-		{roachpb.Key("\x03\xff"), true},
+		{roachpb.Key("\x03"), false},
+		{roachpb.Key("\x03\x00"), false},
+		{roachpb.Key("\x03\xff"), false},
 		{roachpb.Key("\x03\xff\xff"), false},
 		{roachpb.Key("\x04"), true},
 		{roachpb.Key("\x05"), true},
@@ -3109,7 +3109,9 @@ func TestFindValidSplitKeys(t *testing.T) {
 				roachpb.Key("\x03\x00"),
 				roachpb.Key("\x03\xff"),
 			},
-			expSplit: roachpb.Key("\x03"),
+			// TODO(peter): revert when we allow meta2 splitting. See #16266.
+			// expSplit: roachpb.Key("\x03"),
+			expSplit: nil,
 			expError: false,
 		},
 		// Even lopsided, always split at meta2.
@@ -3120,7 +3122,9 @@ func TestFindValidSplitKeys(t *testing.T) {
 				roachpb.Key("\x02\xff"),
 				roachpb.Key("\x03"),
 			},
-			expSplit: roachpb.Key("\x03"),
+			// TODO(peter): revert when we allow meta2 splitting. See #16266.
+			// expSplit: roachpb.Key("\x03"),
+			expSplit: nil,
 			expError: false,
 		},
 		// Lopsided, truncate non-zone prefix.

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -121,7 +121,7 @@ var commands = map[roachpb.Method]Command{
 	roachpb.ReverseScan:        {DeclareKeys: DefaultDeclareKeys, Eval: evalReverseScan},
 	roachpb.BeginTransaction:   {DeclareKeys: declareKeysBeginTransaction, Eval: evalBeginTransaction},
 	roachpb.EndTransaction:     {DeclareKeys: declareKeysEndTransaction, Eval: evalEndTransaction},
-	roachpb.RangeLookup:        {DeclareKeys: DefaultDeclareKeys, Eval: evalRangeLookup},
+	roachpb.RangeLookup:        {DeclareKeys: declareKeysRangeLookup, Eval: evalRangeLookup},
 	roachpb.HeartbeatTxn:       {DeclareKeys: declareKeysHeartbeatTransaction, Eval: evalHeartbeatTxn},
 	roachpb.GC:                 {DeclareKeys: declareKeysGC, Eval: evalGC},
 	roachpb.PushTxn:            {DeclareKeys: declareKeysPushTransaction, Eval: evalPushTxn},
@@ -1087,6 +1087,13 @@ func runCommitTrigger(
 	return EvalResult{}, nil
 }
 
+func declareKeysRangeLookup(
+	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *SpanSet,
+) {
+	DefaultDeclareKeys(desc, header, req, spans)
+	spans.Add(SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})
+}
+
 // evalRangeLookup is used to look up RangeDescriptors - a RangeDescriptor
 // is a metadata structure which describes the key range and replica locations
 // of a distinct range in the cluster.
@@ -1140,6 +1147,11 @@ func evalRangeLookup(
 		return EvalResult{}, errors.Errorf("range lookup specified invalid maximum range count %d: must be > 0", rangeCount)
 	}
 
+	desc, err := cArgs.EvalCtx.Desc()
+	if err != nil {
+		return EvalResult{}, err
+	}
+
 	var checkAndUnmarshal func(roachpb.Value) (*roachpb.RangeDescriptor, error)
 
 	var kvs []roachpb.KeyValue // kv descriptor pairs in scan order
@@ -1158,14 +1170,18 @@ func evalRangeLookup(
 		// We want to search for the metadata key greater than
 		// args.Key. Scan for both the requested key and the keys immediately
 		// afterwards, up to MaxRanges.
-		startKey, endKey, err := keys.MetaScanBounds(key)
+		span, err := keys.MetaScanBounds(key)
+		if err != nil {
+			return EvalResult{}, err
+		}
+		span, err = span.Intersect(desc)
 		if err != nil {
 			return EvalResult{}, err
 		}
 
 		// Scan for descriptors.
 		kvs, _, intents, err = engine.MVCCScan(
-			ctx, batch, startKey, endKey, rangeCount, ts, consistent, txn,
+			ctx, batch, span.Key.AsRawKey(), span.EndKey.AsRawKey(), rangeCount, ts, consistent, txn,
 		)
 		if err != nil {
 			// An error here is likely a WriteIntentError when reading consistently.
@@ -1212,13 +1228,17 @@ func evalRangeLookup(
 		}
 
 		if key.Less(roachpb.RKey(keys.Meta2KeyMax)) {
-			startKey, endKey, err := keys.MetaScanBounds(key)
+			span, err := keys.MetaScanBounds(key)
+			if err != nil {
+				return EvalResult{}, err
+			}
+			span, err = span.Intersect(desc)
 			if err != nil {
 				return EvalResult{}, err
 			}
 
 			kvs, _, intents, err = engine.MVCCScan(
-				ctx, batch, startKey, endKey, 1, ts, consistent, txn,
+				ctx, batch, span.Key.AsRawKey(), span.EndKey.AsRawKey(), 1, ts, consistent, txn,
 			)
 			if err != nil {
 				return EvalResult{}, err
@@ -1227,13 +1247,18 @@ func evalRangeLookup(
 		// We want to search for the metadata key just less or equal to
 		// args.Key. Scan in reverse order for both the requested key and the
 		// keys immediately backwards, up to MaxRanges.
-		startKey, endKey, err := keys.MetaReverseScanBounds(key)
+		span, err := keys.MetaReverseScanBounds(key)
 		if err != nil {
 			return EvalResult{}, err
 		}
+		span, err = span.Intersect(desc)
+		if err != nil {
+			return EvalResult{}, err
+		}
+
 		// Reverse scan for descriptors.
 		revKVs, _, revIntents, err := engine.MVCCReverseScan(
-			ctx, batch, startKey, endKey, rangeCount, ts, consistent, txn,
+			ctx, batch, span.Key.AsRawKey(), span.EndKey.AsRawKey(), rangeCount, ts, consistent, txn,
 		)
 		if err != nil {
 			// An error here is likely a WriteIntentError when reading consistently.
@@ -1304,12 +1329,30 @@ func evalRangeLookup(
 	}
 
 	if len(reply.Ranges) == 0 {
-		// No matching results were returned from the scan. This should
-		// never happen with the above logic.
+		// No matching results were returned from the scan. This can happen when
+		// meta2 ranges split (so for now such splitting is disabled). Remember
+		// that the range addressing keys are generated from the end key of a range
+		// descriptor, not the start key. Consider the scenario:
+		//
+		//   range 1 [a, e):
+		//     b -> [a, b)
+		//     c -> [b, c)
+		//     d -> [c, d)
+		//   range 2 [e, g):
+		//     e -> [d, e)
+		//     f -> [e, f)
+		//     g -> [f, g)
+		//
+		// Now consider looking up the range containing key `d`. The DistSender
+		// routing logic would send the RangeLookup request to range 1 since `d`
+		// lies within the bounds of that range. But notice that the range
+		// descriptor containing `d` lies in range 2. Boom! A real fix will involve
+		// additional logic in the RangeDescriptorCache range lookup state machine.
+		//
+		// See #16266.
 		var buf bytes.Buffer
-		buf.WriteString("range lookup of meta key '")
-		buf.Write(args.Key)
-		buf.WriteString("' found only non-matching ranges:")
+		fmt.Fprintf(&buf, "range lookup of meta key '%[1]s' [%[1]x] found only non-matching ranges:",
+			args.Key)
 		for _, desc := range reply.PrefetchedRanges {
 			buf.WriteByte('\n')
 			buf.WriteString(desc.String())


### PR DESCRIPTION
Truncate range lookup scans to the range.

See #16266