### PR TITLE
storage: fix split tests and revive TestStoreRangeSplitAtRangeBounds

### DIFF
--- a/pkg/storage/client_lease_test.go
+++ b/pkg/storage/client_lease_test.go
@@ -48,7 +48,7 @@ func TestStoreRangeLease(t *testing.T) {
 
 			splitKeys := []roachpb.Key{roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")}
 			for _, splitKey := range splitKeys {
-				splitArgs := adminSplitArgs(splitKey, splitKey)
+				splitArgs := adminSplitArgs(splitKey)
 				if _, pErr := client.SendWrapped(context.Background(), mtc.distSenders[0], splitArgs); pErr != nil {
 					t.Fatal(pErr)
 				}
@@ -108,7 +108,7 @@ func TestStoreRangeLeaseSwitcheroo(t *testing.T) {
 	mtc.Start(t, 1)
 
 	splitKey := roachpb.Key("a")
-	splitArgs := adminSplitArgs(splitKey, splitKey)
+	splitArgs := adminSplitArgs(splitKey)
 	if _, pErr := client.SendWrapped(context.Background(), mtc.distSenders[0], splitArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -173,7 +173,7 @@ func TestStoreGossipSystemData(t *testing.T) {
 	mtc.Start(t, 1)
 
 	splitKey := keys.SystemConfigSplitKey
-	splitArgs := adminSplitArgs(splitKey, splitKey)
+	splitArgs := adminSplitArgs(splitKey)
 	if _, pErr := client.SendWrapped(context.Background(), mtc.distSenders[0], splitArgs); pErr != nil {
 		t.Fatal(pErr)
 	}

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -47,7 +47,7 @@ func adminMergeArgs(key roachpb.Key) *roachpb.AdminMergeRequest {
 func createSplitRanges(
 	store *storage.Store,
 ) (*roachpb.RangeDescriptor, *roachpb.RangeDescriptor, *roachpb.Error) {
-	args := adminSplitArgs(roachpb.KeyMin, []byte("b"))
+	args := adminSplitArgs(roachpb.Key("b"))
 	if _, err := client.SendWrapped(context.Background(), rg1(store), args); err != nil {
 		return nil, nil, err
 	}
@@ -328,11 +328,11 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 	store := mtc.stores[0]
 
 	// Split into 3 ranges
-	argsSplit := adminSplitArgs(roachpb.KeyMin, []byte("d"))
+	argsSplit := adminSplitArgs(roachpb.Key("d"))
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), argsSplit); pErr != nil {
 		t.Fatalf("Can't split range %s", pErr)
 	}
-	argsSplit = adminSplitArgs(roachpb.KeyMin, []byte("b"))
+	argsSplit = adminSplitArgs(roachpb.Key("b"))
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), argsSplit); pErr != nil {
 		t.Fatalf("Can't split range %s", pErr)
 	}
@@ -440,7 +440,7 @@ func BenchmarkStoreRangeMerge(b *testing.B) {
 	store := createTestStoreWithConfig(b, stopper, storeCfg)
 
 	// Perform initial split of ranges.
-	sArgs := adminSplitArgs(roachpb.KeyMin, []byte("b"))
+	sArgs := adminSplitArgs(roachpb.Key("b"))
 	if _, err := client.SendWrapped(context.Background(), rg1(store), sArgs); err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -186,7 +186,7 @@ func TestStoreMetrics(t *testing.T) {
 	}
 
 	// Perform a split, which has special metrics handling.
-	splitArgs := adminSplitArgs(roachpb.KeyMin, roachpb.Key("m"))
+	splitArgs := adminSplitArgs(roachpb.Key("m"))
 	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -118,7 +118,7 @@ func TestStoreRecoverFromEngine(t *testing.T) {
 		if _, err := increment(rangeID, key2, 5); err != nil {
 			t.Fatal(err)
 		}
-		splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+		splitArgs := adminSplitArgs(splitKey)
 		if _, err := client.SendWrapped(context.Background(), rg1(store), splitArgs); err != nil {
 			t.Fatal(err)
 		}
@@ -897,7 +897,7 @@ func TestReplicateAfterRemoveAndSplit(t *testing.T) {
 
 	// Split the range.
 	splitKey := roachpb.Key("m")
-	splitArgs := adminSplitArgs(splitKey, splitKey)
+	splitArgs := adminSplitArgs(splitKey)
 	if _, err := rep1.AdminSplit(context.Background(), *splitArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -1977,7 +1977,7 @@ func TestReplicateAfterSplit(t *testing.T) {
 
 	store0 := mtc.stores[0]
 	// Make the split
-	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+	splitArgs := adminSplitArgs(splitKey)
 	if _, err := client.SendWrapped(context.Background(), rg1(store0), splitArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -2049,7 +2049,7 @@ func TestReplicaRemovalCampaign(t *testing.T) {
 			store0 := mtc.stores[0]
 
 			// Make the split.
-			splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+			splitArgs := adminSplitArgs(splitKey)
 			if _, err := client.SendWrapped(context.Background(), rg1(store0), splitArgs); err != nil {
 				t.Fatal(err)
 			}
@@ -2120,7 +2120,7 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 	mtc.Start(t, 3)
 
 	// Make the split.
-	splitArgs := adminSplitArgs(roachpb.KeyMin, []byte("b"))
+	splitArgs := adminSplitArgs(roachpb.Key("b"))
 	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -2929,7 +2929,7 @@ func TestReplicaLazyLoad(t *testing.T) {
 	// We use UserTableDataMin to avoid having the range activated to
 	// gossip system table data.
 	splitKey := keys.UserTableDataMin
-	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+	splitArgs := adminSplitArgs(splitKey)
 	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -3290,7 +3290,7 @@ func TestTransferRaftLeadership(t *testing.T) {
 
 	{
 		// Split off a range to avoid interacting with the initial splits.
-		splitArgs := adminSplitArgs(key, key)
+		splitArgs := adminSplitArgs(key)
 		if _, err := client.SendWrapped(context.Background(), mtc.distSenders[0], splitArgs); err != nil {
 			t.Fatal(err)
 		}
@@ -3427,7 +3427,7 @@ func TestRaftBlockedReplica(t *testing.T) {
 	mtc.Start(t, 3)
 
 	// Create 2 ranges by splitting range 1.
-	splitArgs := adminSplitArgs(roachpb.KeyMin, []byte("b"))
+	splitArgs := adminSplitArgs(roachpb.Key("b"))
 	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -3553,7 +3553,7 @@ func TestInitRaftGroupOnRequest(t *testing.T) {
 	// We use UserTableDataMin to avoid having the range activated to
 	// gossip system table data.
 	splitKey := keys.UserTableDataMin
-	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+	splitArgs := adminSplitArgs(splitKey)
 	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -338,10 +338,10 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	// Init test ranges:
 	// ["","a"), ["a","c"), ["c","e"), ["e","g") and ["g","\xff\xff").
 	splits := []*roachpb.AdminSplitRequest{
-		adminSplitArgs(roachpb.Key("g"), roachpb.Key("g")),
-		adminSplitArgs(roachpb.Key("e"), roachpb.Key("e")),
-		adminSplitArgs(roachpb.Key("c"), roachpb.Key("c")),
-		adminSplitArgs(roachpb.Key("a"), roachpb.Key("a")),
+		adminSplitArgs(roachpb.Key("g")),
+		adminSplitArgs(roachpb.Key("e")),
+		adminSplitArgs(roachpb.Key("c")),
+		adminSplitArgs(roachpb.Key("a")),
 	}
 
 	for _, split := range splits {
@@ -798,7 +798,7 @@ func TestLeaseMetricsOnSplitAndTransfer(t *testing.T) {
 
 	// Split the key space at key "a".
 	splitKey := roachpb.RKey("a")
-	splitArgs := adminSplitArgs(splitKey.AsRawKey(), splitKey.AsRawKey())
+	splitArgs := adminSplitArgs(splitKey.AsRawKey())
 	if _, pErr := client.SendWrapped(
 		context.Background(), rg1(mtc.stores[0]), splitArgs,
 	); pErr != nil {
@@ -1170,7 +1170,7 @@ func TestRangeInfo(t *testing.T) {
 
 	// Split the key space at key "a".
 	splitKey := roachpb.RKey("a")
-	splitArgs := adminSplitArgs(splitKey.AsRawKey(), splitKey.AsRawKey())
+	splitArgs := adminSplitArgs(splitKey.AsRawKey())
 	if _, pErr := client.SendWrapped(
 		context.Background(), rg1(mtc.stores[0]), splitArgs,
 	); pErr != nil {
@@ -1350,7 +1350,7 @@ func TestCampaignOnLazyRaftGroupInitialization(t *testing.T) {
 	// Split so we can rely on RHS range being quiescent after a restart.
 	// We use UserTableDataMin to avoid having the range activated to
 	// gossip system table data.
-	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+	splitArgs := adminSplitArgs(splitKey)
 	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -54,10 +54,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-func adminSplitArgs(key, splitKey roachpb.Key) *roachpb.AdminSplitRequest {
+// adminSplitArgs creates an AdminSplitRequest for the provided split key.
+func adminSplitArgs(splitKey roachpb.Key) *roachpb.AdminSplitRequest {
 	return &roachpb.AdminSplitRequest{
 		Span: roachpb.Span{
-			Key: key,
+			Key: splitKey,
 		},
 		SplitKey: splitKey,
 	}
@@ -81,7 +82,7 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 		keys.Meta2KeyMax,
 		keys.MakeTablePrefix(10 /* system descriptor ID */),
 	} {
-		args := adminSplitArgs(roachpb.KeyMin, key)
+		args := adminSplitArgs(key)
 		_, pErr := client.SendWrapped(context.Background(), rg1(store), args)
 		if !testutils.IsPError(pErr, "cannot split") {
 			t.Errorf("%q: unexpected split error %s", key, pErr)
@@ -100,7 +101,7 @@ func TestStoreRangeSplitAtTablePrefix(t *testing.T) {
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	key := keys.UserTableDataMin
-	args := adminSplitArgs(key, key)
+	args := adminSplitArgs(key)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
 		t.Fatalf("%q: split unexpected error: %s", key, pErr)
 	}
@@ -178,7 +179,7 @@ func TestStoreRangeSplitInsideRow(t *testing.T) {
 	}
 
 	// Split between col1Key and col2Key by splitting before col2Key.
-	args := adminSplitArgs(col2Key, col2Key)
+	args := adminSplitArgs(col2Key)
 	_, pErr := client.SendWrapped(context.Background(), rg1(store), args)
 	if pErr != nil {
 		t.Fatalf("%s: split unexpected error: %s", col1Key, pErr)
@@ -227,7 +228,7 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 
 	// Split the range.
 	splitKey := roachpb.Key("m")
-	args := adminSplitArgs(roachpb.KeyMin, splitKey)
+	args := adminSplitArgs(splitKey)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -283,7 +284,7 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
-	args := adminSplitArgs(roachpb.KeyMin, []byte("a"))
+	args := adminSplitArgs(roachpb.Key("a"))
 	if _, err := client.SendWrapped(context.Background(), rg1(store), args); err != nil {
 		t.Fatal(err)
 	}
@@ -292,7 +293,7 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 		t.Fatalf("split succeeded unexpectedly")
 	}
 	// Now try to split at start of new range.
-	args = adminSplitArgs(roachpb.KeyMin, []byte("a"))
+	args = adminSplitArgs(roachpb.Key("a"))
 	if _, err := client.SendWrapped(context.Background(), rg1(store), args); err == nil {
 		t.Fatalf("split succeeded unexpectedly")
 	}
@@ -314,7 +315,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 	errCh := make(chan *roachpb.Error, concurrentCount)
 	for i := 0; i < concurrentCount; i++ {
 		go func() {
-			args := adminSplitArgs(roachpb.KeyMin, splitKey)
+			args := adminSplitArgs(splitKey)
 			_, pErr := client.SendWrapped(context.Background(), rg1(store), args)
 			errCh <- pErr
 		}()
@@ -327,7 +328,7 @@ func TestStoreRangeSplitConcurrent(t *testing.T) {
 			// The only expected error from concurrent splits is the split key being
 			// outside the bounds for the range. Note that conflicting range
 			// descriptor errors are retried internally.
-			if !testutils.IsError(pErr.GoError(), "requested split key .* out of bounds of") {
+			if _, ok := pErr.GetDetail().(*roachpb.RangeKeyMismatchError); !ok {
 				t.Fatalf("unexpected error: %v", pErr)
 			}
 			failureCount++
@@ -406,7 +407,7 @@ func TestStoreRangeSplitIdempotency(t *testing.T) {
 	keyBytes, valBytes := ms.KeyBytes, ms.ValBytes
 
 	// Split the range.
-	args := adminSplitArgs(roachpb.KeyMin, splitKey)
+	args := adminSplitArgs(splitKey)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -515,7 +516,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 
 	// Split the range after the last table data key.
 	keyPrefix := keys.MakeTablePrefix(keys.MaxReservedDescID + 1)
-	args := adminSplitArgs(roachpb.KeyMin, keyPrefix)
+	args := adminSplitArgs(keyPrefix)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -548,7 +549,7 @@ func TestStoreRangeSplitStats(t *testing.T) {
 	manual.Increment(100)
 
 	// Split the range at approximate halfway point.
-	args = adminSplitArgs(keyPrefix, midKey)
+	args = adminSplitArgs(midKey)
 	if _, pErr := client.SendWrappedWith(context.Background(), rg1(store), roachpb.Header{
 		RangeID: repl.RangeID,
 	}, args); pErr != nil {
@@ -647,7 +648,7 @@ func TestStoreEmptyRangeSnapshotSize(t *testing.T) {
 	// Split the range after the last table data key to get a range that contains
 	// no user data.
 	splitKey := keys.MakeTablePrefix(keys.MaxReservedDescID + 1)
-	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+	splitArgs := adminSplitArgs(splitKey)
 	if _, err := client.SendWrapped(ctx, mtc.distSenders[0], splitArgs); err != nil {
 		t.Fatal(err)
 	}
@@ -713,7 +714,7 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 
 	// Split the range after the last table data key.
 	keyPrefix := keys.MakeTablePrefix(keys.MaxReservedDescID + 1)
-	args := adminSplitArgs(roachpb.KeyMin, keyPrefix)
+	args := adminSplitArgs(keyPrefix)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -731,7 +732,7 @@ func TestStoreRangeSplitStatsWithMerges(t *testing.T) {
 	manual.Increment(100)
 
 	// Split the range at approximate halfway point.
-	args = adminSplitArgs(keyPrefix, midKey)
+	args = adminSplitArgs(midKey)
 	if _, pErr := client.SendWrappedWith(context.Background(), rg1(store), roachpb.Header{
 		RangeID: repl.RangeID,
 	}, args); pErr != nil {
@@ -1048,7 +1049,7 @@ func runSetupSplitSnapshotRace(
 	}
 
 	// Split the system range from the rest of the keyspace.
-	splitArgs := adminSplitArgs(roachpb.KeyMin, keys.SystemMax)
+	splitArgs := adminSplitArgs(keys.SystemMax)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -1074,7 +1075,7 @@ func runSetupSplitSnapshotRace(
 	mtc.advanceClock(context.TODO())
 
 	// Split the data range.
-	splitArgs = adminSplitArgs(keys.SystemMax, roachpb.Key("m"))
+	splitArgs = adminSplitArgs(roachpb.Key("m"))
 	if _, pErr := client.SendWrapped(context.Background(), mtc.distSenders[0], splitArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -1410,7 +1411,7 @@ func TestStoreSplitGCThreshold(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	args := adminSplitArgs(splitKey, splitKey)
+	args := adminSplitArgs(splitKey)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -1507,7 +1508,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 			// towards "a" (so that the range being split is always the first
 			// range).
 			splitKey := roachpb.Key(encoding.EncodeVarintDescending([]byte("a"), int64(i)))
-			splitArgs := adminSplitArgs(keys.SystemMax, splitKey)
+			splitArgs := adminSplitArgs(splitKey)
 			_, pErr := client.SendWrapped(context.Background(), mtc.distSenders[0], splitArgs)
 			errChan <- pErr
 		}()
@@ -1580,7 +1581,7 @@ func TestLeaderAfterSplit(t *testing.T) {
 	splitKey := roachpb.Key("m")
 	rightKey := roachpb.Key("z")
 
-	splitArgs := adminSplitArgs(roachpb.KeyMin, splitKey)
+	splitArgs := adminSplitArgs(splitKey)
 	if _, pErr := client.SendWrapped(context.Background(), mtc.distSenders[0], splitArgs); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -1604,7 +1605,7 @@ func BenchmarkStoreRangeSplit(b *testing.B) {
 	store := createTestStoreWithConfig(b, stopper, storeCfg)
 
 	// Perform initial split of ranges.
-	sArgs := adminSplitArgs(roachpb.KeyMin, []byte("b"))
+	sArgs := adminSplitArgs(roachpb.Key("b"))
 	if _, err := client.SendWrapped(context.Background(), rg1(store), sArgs); err != nil {
 		b.Fatal(err)
 	}
@@ -1771,7 +1772,7 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 	manual.Increment(storage.GetGCQueueTxnCleanupThreshold().Nanoseconds() + 1)
 
 	// First, create a split after addressing records.
-	args := adminSplitArgs(roachpb.KeyMin, keys.SystemPrefix)
+	args := adminSplitArgs(keys.SystemPrefix)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -1787,7 +1788,7 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 		if log.V(1) {
 			log.Infof(context.TODO(), "splitting at %s", splitKey)
 		}
-		args := adminSplitArgs(keys.SystemMax, splitKey.AsRawKey())
+		args := adminSplitArgs(splitKey.AsRawKey())
 		_, pErr := client.SendWrappedWith(context.Background(), store, roachpb.Header{
 			RangeID: store.LookupReplica(splitKey, nil).RangeID,
 		}, args)
@@ -1922,7 +1923,7 @@ func TestStorePushTxnQueueEnabledOnSplit(t *testing.T) {
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	key := keys.UserTableDataMin
-	args := adminSplitArgs(key, key)
+	args := adminSplitArgs(key)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
 		t.Fatalf("%q: split unexpected error: %s", key, pErr)
 	}
@@ -1945,7 +1946,7 @@ func TestDistributedTxnCleanup(t *testing.T) {
 
 	// Split at "a".
 	lhsKey := roachpb.Key("a")
-	args := adminSplitArgs(lhsKey, lhsKey)
+	args := adminSplitArgs(lhsKey)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
 		t.Fatalf("split at %q: %s", lhsKey, pErr)
 	}
@@ -1953,7 +1954,7 @@ func TestDistributedTxnCleanup(t *testing.T) {
 
 	// Split at "b".
 	rhsKey := roachpb.Key("b")
-	args = adminSplitArgs(rhsKey, rhsKey)
+	args = adminSplitArgs(rhsKey)
 	if _, pErr := client.SendWrappedWith(context.Background(), store, roachpb.Header{
 		RangeID: lhs.RangeID,
 	}, args); pErr != nil {
@@ -2127,7 +2128,7 @@ func TestPushTxnQueueDependencyCycleWithRangeSplit(t *testing.T) {
 			rhsKey := roachpb.Key("b")
 
 			// Split at "a".
-			args := adminSplitArgs(lhsKey, lhsKey)
+			args := adminSplitArgs(lhsKey)
 			if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); pErr != nil {
 				t.Fatalf("split at %q: %s", lhsKey, pErr)
 			}
@@ -2191,7 +2192,7 @@ func TestPushTxnQueueDependencyCycleWithRangeSplit(t *testing.T) {
 			<-firstPush
 
 			// Split at "b".
-			args = adminSplitArgs(rhsKey, rhsKey)
+			args = adminSplitArgs(rhsKey)
 			if _, pErr := client.SendWrappedWith(context.Background(), store, roachpb.Header{
 				RangeID: lhs.RangeID,
 			}, args); pErr != nil {
@@ -2280,7 +2281,7 @@ func TestStoreCapacityAfterSplit(t *testing.T) {
 	}
 
 	// Split the range to verify stats work properly with more than one range.
-	sArgs := adminSplitArgs(key, key)
+	sArgs := adminSplitArgs(key)
 	if _, pErr := client.SendWrapped(context.Background(), rg1(s), sArgs); pErr != nil {
 		t.Fatal(pErr)
 	}

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -271,11 +271,12 @@ func TestStoreRangeSplitIntents(t *testing.T) {
 	}
 }
 
-// TestStoreRangeSplitAtRangeBounds verifies a range cannot be split
-// at its start or end keys (would create zero-length range!). This
-// sort of thing might happen in the wild if two split requests
-// arrived for same key. The first one succeeds and second would try
-// to split at the start of the newly split range.
+// TestStoreRangeSplitAtRangeBounds verifies that attempting to
+// split a range at its start key is a no-op and does not actually
+// perform a split (would create zero-length range!). This sort
+// of thing might happen in the wild if two split requests arrived for
+// same key. The first one succeeds and second would try to split
+// at the start of the newly split range.
 func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
@@ -284,18 +285,34 @@ func TestStoreRangeSplitAtRangeBounds(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
-	args := adminSplitArgs(roachpb.Key("a"))
-	if _, err := client.SendWrapped(context.Background(), rg1(store), args); err != nil {
-		t.Fatal(err)
+	// Split range 1 at an arbitrary key.
+	key := roachpb.Key("a")
+	h := roachpb.Header{RangeID: 1}
+	args := adminSplitArgs(key)
+	if _, pErr := client.SendWrappedWith(context.Background(), store, h, args); pErr != nil {
+		t.Fatal(pErr)
 	}
-	// This second split will try to split at end of first split range.
-	if _, err := client.SendWrapped(context.Background(), rg1(store), args); err == nil {
-		t.Fatalf("split succeeded unexpectedly")
+	replCount := store.ReplicaCount()
+
+	// An AdminSplit request sent to the end of the old range
+	// should fail with a RangeKeyMismatchError.
+	_, pErr := client.SendWrappedWith(context.Background(), store, h, args)
+	if _, ok := pErr.GetDetail().(*roachpb.RangeKeyMismatchError); !ok {
+		t.Fatalf("expected RangeKeyMismatchError, found: %v", pErr)
 	}
-	// Now try to split at start of new range.
-	args = adminSplitArgs(roachpb.Key("a"))
-	if _, err := client.SendWrapped(context.Background(), rg1(store), args); err == nil {
-		t.Fatalf("split succeeded unexpectedly")
+
+	// An AdminSplit request sent to the start of the new range
+	// should succeed but no new ranges should be created.
+	newRng := store.LookupReplica(roachpb.RKey(key), nil)
+	h.RangeID = newRng.RangeID
+	if _, pErr := client.SendWrappedWith(context.Background(), store, h, args); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	newReplCount := store.ReplicaCount()
+	if replCount != newReplCount {
+		t.Fatalf("splitting at a range boundary should not create a new range; before second split "+
+			"found %d ranges, after second split found %d ranges", replCount, newReplCount)
 	}
 }
 

--- a/pkg/storage/client_status_test.go
+++ b/pkg/storage/client_status_test.go
@@ -35,9 +35,9 @@ func TestComputeStatsForKeySpan(t *testing.T) {
 	// Create a number of ranges using splits.
 	splitKeys := []string{"a", "c", "e", "g", "i"}
 	for _, k := range splitKeys {
-		key := []byte(k)
-		repl := mtc.stores[0].LookupReplica(key, roachpb.RKeyMin)
-		args := adminSplitArgs(key, key)
+		key := roachpb.Key(k)
+		repl := mtc.stores[0].LookupReplica(roachpb.RKey(key), roachpb.RKeyMin)
+		args := adminSplitArgs(key)
 		header := roachpb.Header{
 			RangeID: repl.RangeID,
 		}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2634,10 +2634,9 @@ func (r *Replica) adminSplitWithDescriptor(
 		}
 	}
 
-	// First verify this condition so that it will not return
-	// roachpb.NewRangeKeyMismatchError if splitKey equals to desc.EndKey,
-	// otherwise it will cause infinite retry loop.
-	if desc.StartKey.Equal(splitKey) || desc.EndKey.Equal(splitKey) {
+	// If the range starts at the splitKey, we treat the AdminSplit
+	// as a no-op and return success instead of throwing an error.
+	if desc.StartKey.Equal(splitKey) {
 		log.Event(ctx, "range already split")
 		return reply, false, nil
 	}

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -109,7 +109,7 @@ func TestTimeSeriesMaintenanceQueue(t *testing.T) {
 	splitKeys := []roachpb.Key{roachpb.Key("c"), roachpb.Key("b"), roachpb.Key("a")}
 	for _, k := range splitKeys {
 		repl := store.LookupReplica(roachpb.RKey(k), nil)
-		args := adminSplitArgs(k, k)
+		args := adminSplitArgs(k)
 		if _, pErr := client.SendWrappedWith(context.Background(), store, roachpb.Header{
 			RangeID: repl.RangeID,
 		}, args); pErr != nil {


### PR DESCRIPTION
Prompted by a few issues I noticed when looking at #17565.

Most of the split tests were using `adminSplitArgs`, which took an unnecessary
argument which allowed a lot of callers to use it incorrectly. The first commit
addresses this.

`TestStoreRangeSplitAtRangeBounds` had rotted because some refactoring
since its introduction in 0187440 had begun sending the split requests to the
wrong range. Because of this, it was not picked up by #14273.
