### PR TITLE
sql/parser: fix syntax error in help.awk on old awks

### DIFF
--- a/pkg/sql/parser/help.awk
+++ b/pkg/sql/parser/help.awk
@@ -122,7 +122,7 @@ BEGIN {
     next
 }
 
-(/^[^/]/ || /^\/\/ %End/) && inhelp == 1 {
+(/^[^\/]/ || /^\/\/ %End/) && inhelp == 1 {
     # If we were accumulating a string, close it.
     if (instring == 1) {
         print "`,"

--- a/pkg/sql/parser/replace_help_rules.awk
+++ b/pkg/sql/parser/replace_help_rules.awk
@@ -16,7 +16,7 @@
         #    ^^^^^^^^^^^^^^^^^^^ take this
         rulename = substr(rulename, index($0, "|")+1)
     }
-    printf "%s %prec VALUES | %s HELPTOKEN %%prec UMINUS { return helpWith(sqllex, \"%s\") }\n", prefix, rulename, helpkey
+    printf "%s %%prec VALUES | %s HELPTOKEN %%prec UMINUS { return helpWith(sqllex, \"%s\") }\n", prefix, rulename, helpkey
     next
 }
 /\/\/ SHOW HELP:/ {


### PR DESCRIPTION
On macOS, awk is very old (awk version 20070501), and complains
about a syntax error in help.awk:

    awk: nonterminated character class ^[^
     source line number 125 source file help.awk
     context is
          >>> [^/ <<< ]/ || /^\/\/ %End/) && inhelp == 1 {

The solution is simple: escape the `/` within the character class with a
backslash. Newer awks are apparently smart enough to do this
automatically.