### PR TITLE
storage: Revert recent node liveness / range lease cleanups

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/pkg/errors"
@@ -50,31 +49,12 @@ const (
 	// NetworkTimeout is the timeout used for network operations.
 	NetworkTimeout = 3 * time.Second
 
+	// DefaultRaftTickInterval is the default resolution of the Raft timer.
+	DefaultRaftTickInterval = 200 * time.Millisecond
+
 	// DefaultCertsDirectory is the default value for the cert directory flag.
 	DefaultCertsDirectory = "${HOME}/.cockroach-certs"
-
-	// defaultRaftTickInterval is the default resolution of the Raft timer.
-	defaultRaftTickInterval = 200 * time.Millisecond
-
-	// rangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the
-	// leader lease active duration should be of the raft election timeout.
-	rangeLeaseRaftElectionTimeoutMultiplier = 3
-
-	// rangeLeaseRenewalFraction specifies what fraction the range lease
-	// renewal duration should be of the range lease active time. For example,
-	// with a value of 0.2 and a lease duration of 10 seconds, leases would be
-	// eagerly renewed 2 seconds into each lease.
-	rangeLeaseRenewalFraction = 0.5
-
-	// livenessRenewalFraction specifies what fraction the node liveness
-	// renewal duration should be of the node liveness duration. For example,
-	// with a value of 0.2 and a liveness duration of 10 seconds, each node's
-	// liveness record would be eagerly renewed after 2 seconds.
-	livenessRenewalFraction = 0.5
 )
-
-var defaultRaftElectionTimeoutTicks = envutil.EnvOrDefaultInt(
-	"COCKROACH_RAFT_ELECTION_TIMEOUT_TICKS", 15)
 
 type lazyHTTPClient struct {
 	once       sync.Once
@@ -306,65 +286,6 @@ func (cfg *Config) GetHTTPClient() (http.Client, error) {
 	})
 
 	return cfg.httpClient.httpClient, cfg.httpClient.err
-}
-
-// RaftConfig holds raft tuning parameters.
-type RaftConfig struct {
-	// RaftTickInterval is the resolution of the Raft timer.
-	RaftTickInterval time.Duration
-
-	// RaftElectionTimeoutTicks is the number of raft ticks before the
-	// previous election expires. This value is inherited by individual stores
-	// unless overridden.
-	RaftElectionTimeoutTicks int
-}
-
-// SetDefaults initializes unset fields.
-func (cfg *RaftConfig) SetDefaults() {
-	if cfg.RaftTickInterval == 0 {
-		cfg.RaftTickInterval = defaultRaftTickInterval
-	}
-	if cfg.RaftElectionTimeoutTicks == 0 {
-		cfg.RaftElectionTimeoutTicks = defaultRaftElectionTimeoutTicks
-	}
-}
-
-// RaftElectionTimeout returns the raft election timeout, as computed from the
-// tick interval and number of election timeout ticks.
-func (cfg RaftConfig) RaftElectionTimeout() time.Duration {
-	return time.Duration(cfg.RaftElectionTimeoutTicks) * cfg.RaftTickInterval
-}
-
-// RangeLeaseDurations computes durations for range lease expiration and
-// renewal based on a default multiple of Raft election timeout.
-func (cfg RaftConfig) RangeLeaseDurations() (rangeLeaseActive, rangeLeaseRenewal time.Duration) {
-	rangeLeaseActive = time.Duration(rangeLeaseRaftElectionTimeoutMultiplier * float64(cfg.RaftElectionTimeout()))
-	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * rangeLeaseRenewalFraction)
-	return
-}
-
-// RangeLeaseActiveDuration is the duration of the active period of leader
-// leases requested.
-func (cfg RaftConfig) RangeLeaseActiveDuration() time.Duration {
-	rangeLeaseActive, _ := cfg.RangeLeaseDurations()
-	return rangeLeaseActive
-}
-
-// RangeLeaseRenewalDuration specifies a time interval at the end of the
-// active lease interval (i.e. bounded to the right by the start of the stasis
-// period) during which operations will trigger an asynchronous renewal of the
-// lease.
-func (cfg RaftConfig) RangeLeaseRenewalDuration() time.Duration {
-	_, rangeLeaseRenewal := cfg.RangeLeaseDurations()
-	return rangeLeaseRenewal
-}
-
-// NodeLivenessDurations computes durations for node liveness expiration and
-// renewal based on a default multiple of Raft election timeout.
-func (cfg RaftConfig) NodeLivenessDurations() (livenessActive, livenessRenewal time.Duration) {
-	livenessActive = cfg.RangeLeaseActiveDuration()
-	livenessRenewal = time.Duration(float64(livenessActive) * livenessRenewalFraction)
-	return
 }
 
 // DefaultRetryOptions should be used for retrying most

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -33,7 +33,6 @@ type TestServerArgs struct {
 	Knobs TestingKnobs
 
 	*cluster.Settings
-	RaftConfig
 
 	// PartOfCluster must be set if the TestServer is joining others in a cluster.
 	// If not set (and hence the server is the only one in the cluster), the
@@ -63,6 +62,8 @@ type TestServerArgs struct {
 	Insecure                 bool
 	RetryOptions             retry.Options
 	MetricsSampleInterval    time.Duration
+	RaftTickInterval         time.Duration
+	RaftElectionTimeoutTicks int
 	SocketFile               string
 	ScanInterval             time.Duration
 	ScanMaxIdleTime          time.Duration

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -111,8 +111,6 @@ type Config struct {
 
 	Settings *cluster.Settings
 
-	base.RaftConfig
-
 	// Unix socket: for postgres only.
 	SocketFile string
 
@@ -172,6 +170,14 @@ type Config struct {
 	// failures, and increase the frequency and impact of
 	// ReadWithinUncertaintyIntervalError.
 	MaxOffset MaxOffsetType
+
+	// RaftTickInterval is the resolution of the Raft timer.
+	RaftTickInterval time.Duration
+
+	// RaftElectionTimeoutTicks is the number of raft ticks before the
+	// previous election expires. This value is inherited by individual
+	// stores unless overridden.
+	RaftElectionTimeoutTicks int
 
 	// MetricsSamplePeriod determines the time between records of
 	// server internal metrics.
@@ -392,7 +398,6 @@ func MakeConfig(st *cluster.Settings) Config {
 	cfg.AmbientCtx.Tracer = st.Tracer
 
 	cfg.Config.InitDefaults()
-	cfg.RaftConfig.SetDefaults()
 	return cfg
 }
 

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -98,7 +98,8 @@ func createTestNode(
 	cfg.Transport = storage.NewDummyRaftTransport(st)
 	cfg.MetricsSampleInterval = metric.TestSampleInterval
 	cfg.HistogramWindowInterval = metric.TestSampleInterval
-	active, renewal := cfg.NodeLivenessDurations()
+	active, renewal := storage.NodeLivenessDurations(
+		storage.RaftElectionTimeout(cfg.RaftTickInterval, cfg.RaftElectionTimeoutTicks))
 	cfg.NodeLiveness = storage.NewNodeLiveness(
 		cfg.AmbientCtx,
 		cfg.Clock,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -231,12 +231,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 	s.db = client.NewDB(s.txnCoordSender, s.clock)
 
-	raftElectionTimeout := storage.RaftElectionTimeout(s.cfg.RaftTickInterval, s.cfg.RaftElectionTimeoutTicks)
-	nlActive, nlRenewal := storage.NodeLivenessDurations(raftElectionTimeout)
-	rlActive, rlRenewal := storage.RangeLeaseDurations(raftElectionTimeout)
-
+	active, renewal := storage.NodeLivenessDurations(
+		storage.RaftElectionTimeout(s.cfg.RaftTickInterval, s.cfg.RaftElectionTimeoutTicks))
 	s.nodeLiveness = storage.NewNodeLiveness(
-		s.cfg.AmbientCtx, s.clock, s.db, s.gossip, nlActive, nlRenewal,
+		s.cfg.AmbientCtx, s.clock, s.db, s.gossip, active, renewal,
 	)
 	s.registry.AddMetricStruct(s.nodeLiveness.Metrics())
 
@@ -318,8 +316,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		StorePool:                      s.storePool,
 		SQLExecutor:                    sqlExecutor,
 		LogRangeEvents:                 s.cfg.EventLogEnabled,
-		RangeLeaseActiveDuration:       rlActive,
-		RangeLeaseRenewalDuration:      rlRenewal,
+		RangeLeaseActiveDuration:       active,
+		RangeLeaseRenewalDuration:      renewal,
 		TimeSeriesDataStore:            s.tsDB,
 
 		EnableEpochRangeLeases: true,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -231,7 +231,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 	s.db = client.NewDB(s.txnCoordSender, s.clock)
 
-	nlActive, nlRenewal := s.cfg.NodeLivenessDurations()
+	raftElectionTimeout := storage.RaftElectionTimeout(s.cfg.RaftTickInterval, s.cfg.RaftElectionTimeoutTicks)
+	nlActive, nlRenewal := storage.NodeLivenessDurations(raftElectionTimeout)
+	rlActive, rlRenewal := storage.RangeLeaseDurations(raftElectionTimeout)
 
 	s.nodeLiveness = storage.NewNodeLiveness(
 		s.cfg.AmbientCtx, s.clock, s.db, s.gossip, nlActive, nlRenewal,
@@ -300,13 +302,13 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	storeCfg := storage.StoreConfig{
 		Settings:                       st,
 		AmbientCtx:                     s.cfg.AmbientCtx,
-		RaftConfig:                     s.cfg.RaftConfig,
 		Clock:                          s.clock,
 		DB:                             s.db,
 		Gossip:                         s.gossip,
 		NodeLiveness:                   s.nodeLiveness,
 		Transport:                      s.raftTransport,
 		RPCContext:                     s.rpcContext,
+		RaftTickInterval:               s.cfg.RaftTickInterval,
 		ScanInterval:                   s.cfg.ScanInterval,
 		ScanMaxIdleTime:                s.cfg.ScanMaxIdleTime,
 		ConsistencyCheckInterval:       s.cfg.ConsistencyCheckInterval,
@@ -316,6 +318,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		StorePool:                      s.storePool,
 		SQLExecutor:                    sqlExecutor,
 		LogRangeEvents:                 s.cfg.EventLogEnabled,
+		RangeLeaseActiveDuration:       rlActive,
+		RangeLeaseRenewalDuration:      rlRenewal,
 		TimeSeriesDataStore:            s.tsDB,
 
 		EnableEpochRangeLeases: true,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -102,8 +102,6 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	cfg := makeTestConfig(st)
 	cfg.TestingKnobs = params.Knobs
-	cfg.RaftConfig = params.RaftConfig
-	cfg.RaftConfig.SetDefaults()
 	if params.JoinAddr != "" {
 		cfg.JoinList = []string{params.JoinAddr}
 	}
@@ -112,6 +110,12 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.RetryOptions = params.RetryOptions
 	if params.MetricsSampleInterval != 0 {
 		cfg.MetricsSampleInterval = params.MetricsSampleInterval
+	}
+	if params.RaftTickInterval != 0 {
+		cfg.RaftTickInterval = params.RaftTickInterval
+	}
+	if params.RaftElectionTimeoutTicks != 0 {
+		cfg.RaftElectionTimeoutTicks = params.RaftElectionTimeoutTicks
 	}
 	if knobs := params.Knobs.Store; knobs != nil {
 		if mo := knobs.(*storage.StoreTestingKnobs).MaxOffset; mo != 0 {

--- a/pkg/storage/client_raft_log_queue_test.go
+++ b/pkg/storage/client_raft_log_queue_test.go
@@ -48,7 +48,7 @@ func TestRaftLogQueue(t *testing.T) {
 	// us in this test.
 	sc := storage.TestStoreConfig(nil)
 	sc.RaftTickInterval = math.MaxInt32
-	sc.RaftElectionTimeoutTicks = 1000000
+	setRaftElectionTimeoutTicks(&sc, 1000000)
 	mtc.storeConfig = &sc
 
 	defer mtc.Stop()

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -46,6 +46,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
+func setRaftElectionTimeoutTicks(sc *storage.StoreConfig, newVal int) {
+	sc.RaftElectionTimeoutTicks = newVal
+	// Recompute settings that are derived from RaftElectionTimeoutTicks.
+	// Not doing this has caused flakiness in the past (#17376).
+	sc.RangeLeaseActiveDuration, sc.RangeLeaseRenewalDuration = storage.RangeLeaseDurations(
+		storage.RaftElectionTimeout(sc.RaftTickInterval, sc.RaftElectionTimeoutTicks))
+}
+
 // mustGetInt decodes an int64 value from the bytes field of the receiver
 // and panics if the bytes field is not 0 or 8 bytes in length.
 func mustGetInt(v *roachpb.Value) int64 {
@@ -1170,7 +1178,7 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 	}
 
 	// Don't timeout raft leader.
-	sc.RaftElectionTimeoutTicks = 1000000
+	setRaftElectionTimeoutTicks(&sc, 1000000)
 	mtc := &multiTestContext{
 		storeConfig: &sc,
 	}
@@ -1474,7 +1482,7 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 	// Don't timeout raft leaders or range leases (see the relation between
 	// RaftElectionTimeoutTicks and rangeLeaseActiveDuration). This test expects
 	// mtc.stores[0] to hold the range lease for range 1.
-	sc.RaftElectionTimeoutTicks = 1000000
+	setRaftElectionTimeoutTicks(&sc, 1000000)
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
@@ -1701,7 +1709,7 @@ func TestQuotaPool(t *testing.T) {
 	sc := storage.TestStoreConfig(nil)
 	// Suppress timeout-based elections to avoid leadership changes in ways
 	// this test doesn't expect.
-	sc.RaftElectionTimeoutTicks = 100000
+	setRaftElectionTimeoutTicks(&sc, 100000)
 	mtc := &multiTestContext{storeConfig: &sc}
 	mtc.Start(t, numReplicas)
 	defer mtc.Stop()
@@ -3274,7 +3282,7 @@ func TestTransferRaftLeadership(t *testing.T) {
 	// heavily loaded CPU is enough to reach the raft election timeout
 	// and cause leadership to change hands in ways this test doesn't
 	// expect.
-	sc.RaftElectionTimeoutTicks = 100000
+	setRaftElectionTimeoutTicks(&sc, 100000)
 	// This test can rapidly advance the clock via mtc.advanceClock(),
 	// which could lead the replication queue to consider a store dead
 	// and remove a replica in the middle of the test. Disable the

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1385,7 +1385,8 @@ func TestCampaignOnLazyRaftGroupInitialization(t *testing.T) {
 						t.Fatal(err)
 					}
 				}
-				mtc.manualClock.Increment(sc.RaftElectionTimeout().Nanoseconds())
+				mtc.manualClock.Increment(
+					storage.RaftElectionTimeout(sc.RaftTickInterval, sc.RaftElectionTimeoutTicks).Nanoseconds())
 			},
 			expCampaigns: map[roachpb.ReplicaID]bool{
 				1: true,

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1585,7 +1585,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 func TestLeaderAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeConfig := storage.TestStoreConfig(nil)
-	storeConfig.RaftElectionTimeoutTicks = 1000000
+	setRaftElectionTimeoutTicks(&storeConfig, 1000000)
 	mtc := &multiTestContext{
 		storeConfig: &storeConfig,
 	}

--- a/pkg/storage/gossip_test.go
+++ b/pkg/storage/gossip_test.go
@@ -142,15 +142,15 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 	// the replaced node's leases to time out, but has still shown itself to be
 	// long enough to avoid flakes.
 	serverArgs := base.TestServerArgs{
-		Addr:     util.IsolatedTestAddr.String(),
-		Insecure: true, // because our certs are only valid for 127.0.0.1
+		Addr:                     util.IsolatedTestAddr.String(),
+		Insecure:                 true, // because our certs are only valid for 127.0.0.1
+		RaftTickInterval:         50 * time.Millisecond,
+		RaftElectionTimeoutTicks: 10,
 		RetryOptions: retry.Options{
 			InitialBackoff: 10 * time.Millisecond,
 			MaxBackoff:     50 * time.Millisecond,
 		},
 	}
-	serverArgs.RaftTickInterval = 50 * time.Millisecond
-	serverArgs.RaftElectionTimeoutTicks = 10
 
 	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1286,7 +1286,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 				// already an extension pending.
 				_, requestPending := r.mu.pendingLeaseRequest.RequestPending()
 				if !requestPending && r.requiresExpiringLeaseRLocked() {
-					renewal := status.lease.Expiration.Add(-r.store.cfg.RangeLeaseRenewalDuration().Nanoseconds(), 0)
+					renewal := status.lease.Expiration.Add(-int64(r.store.cfg.RangeLeaseRenewalDuration), 0)
 					if !timestamp.Less(renewal) {
 						if log.V(2) {
 							log.Infof(ctx, "extending lease %s at %s", status.lease, timestamp)

--- a/pkg/storage/replica_range_lease.go
+++ b/pkg/storage/replica_range_lease.go
@@ -120,7 +120,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 	}
 
 	if repl.requiresExpiringLeaseRLocked() {
-		reqLease.Expiration = status.timestamp.Add(int64(repl.store.cfg.RangeLeaseActiveDuration()), 0)
+		reqLease.Expiration = status.timestamp.Add(int64(repl.store.cfg.RangeLeaseActiveDuration), 0)
 	} else {
 		// Get the liveness for the next lease holder and set the epoch in the lease request.
 		liveness, err := repl.store.cfg.NodeLiveness.GetLiveness(nextLeaseHolder.NodeID)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -74,6 +74,22 @@ const (
 	// store's Raft log entry cache.
 	defaultRaftEntryCacheSize = 1 << 24 // 16M
 
+	// rangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the leader
+	// lease active duration should be of the raft election timeout.
+	rangeLeaseRaftElectionTimeoutMultiplier = 3
+
+	// rangeLeaseRenewalFraction specifies what fraction the range lease renewal
+	// duration should be of the range lease active time. For example, with a
+	// value of 0.2 and a lease duration of 10 seconds, leases would be eagerly
+	// renewed 2 seconds into each lease.
+	rangeLeaseRenewalFraction = 0.5
+
+	// livenessRenewalFraction specifies what fraction the node liveness renewal
+	// duration should be of the node liveness duration. For example, with a
+	// value of 0.2 and a liveness duration of 10 seconds, each node's liveness
+	// record would be eagerly renewed after 2 seconds.
+	livenessRenewalFraction = 0.5
+
 	// replicaRequestQueueSize specifies the maximum number of requests to queue
 	// for a replica.
 	replicaRequestQueueSize = 100
@@ -104,11 +120,50 @@ var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeTy
 	roachpb.REMOVE_REPLICA: raftpb.ConfChangeRemoveNode,
 }
 
+var defaultRaftElectionTimeoutTicks = envutil.EnvOrDefaultInt(
+	"COCKROACH_RAFT_ELECTION_TIMEOUT_TICKS", 15)
+
 var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_SCHEDULER_CONCURRENCY", 8*runtime.NumCPU())
 
 var enablePreVote = envutil.EnvOrDefaultBool(
 	"COCKROACH_ENABLE_PREVOTE", false)
+
+// RaftElectionTimeout returns the raft election timeout, as computed
+// from the specified tick interval and number of election timeout
+// ticks. If raftElectionTimeoutTicks is 0, uses the value of
+// defaultRaftElectionTimeoutTicks.
+func RaftElectionTimeout(
+	raftTickInterval time.Duration, raftElectionTimeoutTicks int,
+) time.Duration {
+	if raftTickInterval == 0 {
+		raftTickInterval = base.DefaultRaftTickInterval
+	}
+	if raftElectionTimeoutTicks == 0 {
+		raftElectionTimeoutTicks = defaultRaftElectionTimeoutTicks
+	}
+	return time.Duration(raftElectionTimeoutTicks) * raftTickInterval
+}
+
+// RangeLeaseDurations computes durations for range lease expiration
+// and renewal based on a default multiple of Raft election timeout.
+func RangeLeaseDurations(
+	raftElectionTimeout time.Duration,
+) (rangeLeaseActive time.Duration, rangeLeaseRenewal time.Duration) {
+	rangeLeaseActive = time.Duration(rangeLeaseRaftElectionTimeoutMultiplier * float64(raftElectionTimeout))
+	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * rangeLeaseRenewalFraction)
+	return
+}
+
+// NodeLivenessDurations computes durations for node liveness expiration
+// and renewal based on a default multiple of Raft election timeout.
+func NodeLivenessDurations(
+	raftElectionTimeout time.Duration,
+) (livenessActive time.Duration, livenessRenewal time.Duration) {
+	livenessActive, _ = RangeLeaseDurations(raftElectionTimeout)
+	livenessRenewal = time.Duration(float64(livenessActive) * livenessRenewalFraction)
+	return
+}
 
 // TestStoreConfig has some fields initialized with values relevant in tests.
 func TestStoreConfig(clock *hlc.Clock) StoreConfig {
@@ -117,11 +172,13 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 	}
 	st := cluster.MakeTestingClusterSettings()
 	sc := StoreConfig{
-		Settings:   st,
-		AmbientCtx: log.AmbientContext{Tracer: st.Tracer},
-		Clock:      clock,
+		Settings:                       st,
+		AmbientCtx:                     log.AmbientContext{Tracer: st.Tracer},
+		Clock:                          clock,
+		RaftTickInterval:               100 * time.Millisecond,
 		CoalescedHeartbeatsInterval:    50 * time.Millisecond,
 		RaftHeartbeatIntervalTicks:     1,
+		RaftElectionTimeoutTicks:       3,
 		ScanInterval:                   10 * time.Minute,
 		ConsistencyCheckInterval:       10 * time.Minute,
 		ConsistencyCheckPanicOnFailure: true,
@@ -129,8 +186,6 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 		HistogramWindowInterval:        metric.TestSampleInterval,
 		EnableEpochRangeLeases:         true,
 	}
-	sc.RaftElectionTimeoutTicks = 3
-	sc.RaftTickInterval = 100 * time.Millisecond
 	sc.SetDefaults()
 	return sc
 }
@@ -535,7 +590,6 @@ var _ client.Sender = &Store{}
 // a store; the rest will have sane defaults set if omitted.
 type StoreConfig struct {
 	AmbientCtx log.AmbientContext
-	base.RaftConfig
 
 	Settings     *cluster.Settings
 	Clock        *hlc.Clock
@@ -559,6 +613,10 @@ type StoreConfig struct {
 	// finish or be pushed by a higher priority contender.
 	DontRetryPushTxnFailures bool
 
+	// RaftTickInterval is the resolution of the Raft timer; other raft timeouts
+	// are defined in terms of multiples of this value.
+	RaftTickInterval time.Duration
+
 	// CoalescedHeartbeatsInterval is the interval for which heartbeat messages
 	// are queued and then sent as a single coalesced heartbeat; it is a
 	// fraction of the RaftTickInterval so that heartbeats don't get delayed by
@@ -581,6 +639,12 @@ type StoreConfig struct {
 
 	// RaftHeartbeatIntervalTicks is the number of ticks that pass between heartbeats.
 	RaftHeartbeatIntervalTicks int
+
+	// RaftElectionTimeoutTicks is the number of ticks that must pass before a follower
+	// considers a leader to have failed and calls a new election. Should be significantly
+	// higher than RaftHeartbeatIntervalTicks. The raft paper recommends a value of 150ms
+	// for local networks.
+	RaftElectionTimeoutTicks int
 
 	// ScanInterval is the default value for the scan interval
 	ScanInterval time.Duration
@@ -612,6 +676,16 @@ type StoreConfig struct {
 	// snapshots and the maximum number of non-empty snapshots that are permitted
 	// to be applied concurrently.
 	concurrentSnapshotApplyLimit int
+
+	// RangeLeaseActiveDuration is the duration of the active period of leader
+	// leases requested.
+	RangeLeaseActiveDuration time.Duration
+
+	// RangeLeaseRenewalDuration specifies a time interval at the end of the
+	// active lease interval (i.e. bounded to the right by the start of the stasis
+	// period) during which operations will trigger an asynchronous renewal of the
+	// lease.
+	RangeLeaseRenewalDuration time.Duration
 
 	// MetricsSampleInterval is (server.Context).MetricsSampleInterval
 	MetricsSampleInterval time.Duration
@@ -777,13 +851,17 @@ func (sc *StoreConfig) Valid() bool {
 // suitable for use on a local network.
 // TODO(tschottdorf): see if this ought to be configurable via flags.
 func (sc *StoreConfig) SetDefaults() {
-	sc.RaftConfig.SetDefaults()
-
+	if sc.RaftTickInterval == 0 {
+		sc.RaftTickInterval = base.DefaultRaftTickInterval
+	}
 	if sc.CoalescedHeartbeatsInterval == 0 {
 		sc.CoalescedHeartbeatsInterval = sc.RaftTickInterval / 2
 	}
 	if sc.RaftHeartbeatIntervalTicks == 0 {
 		sc.RaftHeartbeatIntervalTicks = defaultHeartbeatIntervalTicks
+	}
+	if sc.RaftElectionTimeoutTicks == 0 {
+		sc.RaftElectionTimeoutTicks = defaultRaftElectionTimeoutTicks
 	}
 	if sc.RaftEntryCacheSize == 0 {
 		sc.RaftEntryCacheSize = defaultRaftEntryCacheSize
@@ -793,6 +871,15 @@ func (sc *StoreConfig) SetDefaults() {
 		// throughput.
 		sc.concurrentSnapshotApplyLimit =
 			envutil.EnvOrDefaultInt("COCKROACH_CONCURRENT_SNAPSHOT_APPLY_LIMIT", 1)
+	}
+
+	rangeLeaseActiveDuration, rangeLeaseRenewalDuration :=
+		RangeLeaseDurations(RaftElectionTimeout(sc.RaftTickInterval, sc.RaftElectionTimeoutTicks))
+	if sc.RangeLeaseActiveDuration == 0 {
+		sc.RangeLeaseActiveDuration = rangeLeaseActiveDuration
+	}
+	if sc.RangeLeaseRenewalDuration == 0 {
+		sc.RangeLeaseRenewalDuration = rangeLeaseRenewalDuration
 	}
 
 	if sc.GossipWhenCapacityDeltaExceedsFraction == 0 {
@@ -811,7 +898,7 @@ func (sc *StoreConfig) LeaseExpiration() int64 {
 		// Don't do shady math on clockless reads.
 		maxOffset = 0
 	}
-	return 2 * (sc.RangeLeaseActiveDuration() + maxOffset).Nanoseconds()
+	return 2 * int64(sc.RangeLeaseActiveDuration+maxOffset)
 }
 
 // NewStore returns a new instance of a store.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -79,15 +79,11 @@ const (
 	rangeLeaseRaftElectionTimeoutMultiplier = 3
 
 	// rangeLeaseRenewalFraction specifies what fraction the range lease renewal
-	// duration should be of the range lease active time. For example, with a
-	// value of 0.2 and a lease duration of 10 seconds, leases would be eagerly
-	// renewed 2 seconds into each lease.
-	rangeLeaseRenewalFraction = 0.5
+	// duration should be of the range lease active time.
+	rangeLeaseRenewalFraction = 0.8
 
 	// livenessRenewalFraction specifies what fraction the node liveness renewal
-	// duration should be of the node liveness duration. For example, with a
-	// value of 0.2 and a liveness duration of 10 seconds, each node's liveness
-	// record would be eagerly renewed after 2 seconds.
+	// duration should be of the node liveness duration.
 	livenessRenewalFraction = 0.5
 
 	// replicaRequestQueueSize specifies the maximum number of requests to queue
@@ -150,8 +146,8 @@ func RaftElectionTimeout(
 func RangeLeaseDurations(
 	raftElectionTimeout time.Duration,
 ) (rangeLeaseActive time.Duration, rangeLeaseRenewal time.Duration) {
-	rangeLeaseActive = time.Duration(rangeLeaseRaftElectionTimeoutMultiplier * float64(raftElectionTimeout))
-	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * rangeLeaseRenewalFraction)
+	rangeLeaseActive = rangeLeaseRaftElectionTimeoutMultiplier * raftElectionTimeout
+	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * (1 - rangeLeaseRenewalFraction))
 	return
 }
 

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -125,7 +125,8 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 	cfg.AmbientCtx = ambient
 	cfg.DB = ltc.DB
 	cfg.Gossip = ltc.Gossip
-	active, renewal := cfg.NodeLivenessDurations()
+	active, renewal := storage.NodeLivenessDurations(
+		storage.RaftElectionTimeout(cfg.RaftTickInterval, cfg.RaftElectionTimeoutTicks))
 	cfg.NodeLiveness = storage.NewNodeLiveness(
 		cfg.AmbientCtx,
 		cfg.Clock,


### PR DESCRIPTION
Also includes a silly little change for deflaking `TestSnapshotAfterTruncation`.

I'm sure there's a stupid reason why these refactorings (really just my initial one, but it's hard to revert that without also reverting the DRY commit) broke `multiTestContext`, but it's not worth dealing with them right now.

There's also an off chance this will help reduce the flakiness of https://github.com/cockroachdb/cockroach/issues/17365 which @asubiotto mentioned became more flaky recently, but I haven't tested that out.