### PR TITLE
acceptance: Fix allocator 1-to-3 test to work in a new 4-node world

### DIFF
--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -184,10 +184,10 @@ func (at *allocatorTest) Run(ctx context.Context, t *testing.T) {
 	at.f.Assert(ctx, t)
 
 	log.Infof(ctx, "starting load on cluster")
-	if err := at.f.StartLoad(ctx, "block_writer", *flagCLTWriters); err != nil {
+	if err := at.f.StartLoad(ctx, "block_writer", at.EndNodes); err != nil {
 		t.Fatal(err)
 	}
-	if err := at.f.StartLoad(ctx, "photos", *flagCLTWriters); err != nil {
+	if err := at.f.StartLoad(ctx, "photos", at.EndNodes); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This was broken by cd4f85cf829b49abd31918a5128ca0e17acb3bd9, causing
every run since to fail with this error:

[TestUpreplicate_1To3Small] allocator_test.go:188: writers (4) > nodes (3)