### PR TITLE
log: ensure Fatal calls are reported even if logs don't go to stderr

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -6,10 +6,21 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
+start_test "Check that a server encountering a fatal error when not logging to stderr shows the fatal error."
+send "$argv start -s=path=logs/db --insecure\r"
+eexpect "CockroachDB node starting"
+system "$argv sql --insecure -e \"select crdb_internal.force_log_fatal('helloworld')\" || true"
+eexpect "\r\nF"
+eexpect "helloworld"
+eexpect ":/# "
+send "echo \$?\r"
+eexpect "255"
+eexpect ":/# "
+end_test
+
 start_test "Check that a server started with only in-memory stores and no --log-dir automatically logs to stderr."
 send "$argv start --insecure --store=type=mem,size=1GiB\r"
-eexpect "CockroachDB"
-eexpect "starting cockroach node"
+eexpect "CockroachDB node starting"
 end_test
 
 # Stop it.
@@ -25,8 +36,7 @@ stop_server $argv
 
 start_test "Check that a server started with --logtostderr logs even info messages to stderr."
 send "$argv start -s=path=logs/db --insecure --logtostderr\r"
-eexpect "CockroachDB"
-eexpect "starting cockroach node"
+eexpect "CockroachDB node starting"
 end_test
 
 # Stop it.

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -737,7 +737,9 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 		}
 	}
 
-	if s >= l.stderrThreshold.get() {
+	if s >= l.stderrThreshold.get() || (s == Severity_FATAL && stderrRedirected) {
+		// We force-copy FATAL messages to stderr, because the process is bound
+		// to terminate and the user will want to know why.
 		l.outputToStderr(entry, stacks)
 	}
 	if logDir.isSet() && s >= l.fileThreshold.get() {


### PR DESCRIPTION
Suggested by https://github.com/cockroachdb/docs/issues/1805.

@bdarnell I'd happily test this if we had a way to reliably cause a fatal error on the regular code paths. Is there such a thing?

(Will also backport the change to 1.0 after this merges)