### PR TITLE
sql/jobs: avoid stalled jobs

### DIFF
--- a/pkg/sql/jobs/helpers_test.go
+++ b/pkg/sql/jobs/helpers_test.go
@@ -24,6 +24,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
+func ResetResumeHooks() func() {
+	oldResumeHooks := resumeHooks
+	return func() { resumeHooks = oldResumeHooks }
+}
+
 // FakeNodeID is a dummy node ID for use in tests. It always stores 1.
 var FakeNodeID = func() *base.NodeIDContainer {
 	nodeID := base.NodeIDContainer{}

--- a/pkg/sql/jobs/main_test.go
+++ b/pkg/sql/jobs/main_test.go
@@ -32,3 +32,5 @@ func TestMain(m *testing.M) {
 	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
 	os.Exit(m.Run())
 }
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/sql/jobs/registry_external_test.go
+++ b/pkg/sql/jobs/registry_external_test.go
@@ -64,6 +64,8 @@ func TestRoundtripJob(t *testing.T) {
 }
 
 func TestRegistryResumeExpiredLease(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	ctx := context.Background()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
@@ -171,6 +173,8 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 }
 
 func TestRegistryResumeActiveLease(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval
 	}(jobs.DefaultAdoptInterval)

--- a/pkg/sql/jobs/registry_test.go
+++ b/pkg/sql/jobs/registry_test.go
@@ -27,10 +27,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 func TestRegistryCancelation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	ctx, stopper := context.Background(), stop.NewStopper()
 	defer stopper.Stop(ctx)
 
@@ -119,6 +122,8 @@ func TestRegistryCancelation(t *testing.T) {
 }
 
 func TestRegistryRegister(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	var db *client.DB
 	var ex sqlutil.InternalExecutor
 	var gossip *gossip.Gossip


### PR DESCRIPTION
If a node holds the lease for a job, teach it to check whether its
actually running that job and resume it if its not. Otherwise, the job
will be stuck until that node is restarted, as the other nodes in the
cluster see a valid lease and assume the job is running.

This state, where a node holds a valid lease for a job it's not running,
occurs when the node overcautiously cancels all its jobs due to e.g. a
slow heartbeat response. If that heartbeat managed to successfully
extend the liveness lease, the node will have stopped running jobs on
which it still had valid leases.