### PR TITLE
storage: Allocator improvements for empty stores and ranges

### DIFF
--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -781,27 +781,33 @@ func percentileScore(
 		} else if rangeVal > percentiles.P75 {
 			return -0.5
 		}
+		// else rangeVal >= percentiles.P25 && rangeVal <= percentiles.P75
 		// It may be better to return more than 0 here, since taking on an
 		// average range isn't necessarily bad, but for now let's see how this works.
 		return 0
 	} else if rcs == overfull {
 		// If this store has too many ranges, we're ok with moving any range that's
 		// at least somewhat sizable in this dimension, since we want to reduce both
-		// the range count and this metric. Moving extreme outliers may be
-		// undesirable, though.
-		if rangeVal < percentiles.P10 || rangeVal > percentiles.P90 {
-			return 1
-		} else if rangeVal <= percentiles.P25 || rangeVal >= percentiles.P75 {
+		// the range count and this metric. Moving extreme outliers may be less
+		// desirable, though, so favor very heavy ranges slightly less and disfavor
+		// very light ranges.
+		//
+		// Note that we can't truly disfavor large ranges, since that prevents us
+		// from rebalancing nonempty ranges to empty stores (since all nonempty
+		// ranges will be greater than an empty store's P90).
+		if rangeVal > percentiles.P90 {
+			return -0.5
+		} else if rangeVal >= percentiles.P25 {
+			return -1
+		} else if rangeVal >= percentiles.P10 {
 			return 0
 		}
-		return -1
+		// else rangeVal < percentiles.P10
+		return 0.5
 	} else if rcs == underfull {
 		// If this store has too few ranges but is overloaded on some other
 		// dimension, we need to prioritize moving away replicas that are
 		// high in that dimension and accepting replicas that are low in it.
-		//
-		// TODO(a-robinson): Will this cause thrashing if one range has
-		// significantly more QPS than all other ranges?
 		if rangeVal < percentiles.P10 {
 			return 1
 		} else if rangeVal < percentiles.P25 {
@@ -811,6 +817,7 @@ func percentileScore(
 		} else if rangeVal > percentiles.P75 {
 			return -0.5
 		}
+		// else rangeVal >= percentiles.P25 && rangeVal <= percentiles.P75
 		return 0
 	}
 	panic(fmt.Sprintf("reached unreachable code: %+v; %+v; %+v", rcs, percentiles, rangeVal))


### PR DESCRIPTION
I ended up reproducing this on indigo rather than on a local 4 node cluster, but I'm pretty confident it should fix what @cuongdo has been seeing in #17456. I'll try a bit more to repro that before this change using @cuongdo's latest comment there in order to more properly confirm that this fixes it.

The second commit doesn't fix this specific issue, but is fairly related.