### PR TITLE
cliccl: add “cockroach utils file-serve” utility

### DIFF
--- a/pkg/ccl/cliccl/httpserver.go
+++ b/pkg/ccl/cliccl/httpserver.go
@@ -1,0 +1,80 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package cliccl
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
+	"github.com/cockroachdb/cockroach/pkg/cli"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	httpServerCmd := &cobra.Command{
+		Use:   "file-serve <path>",
+		Short: "start a simple static file HTTP server",
+		Long: `
+Runs a simple, static file HTTP server that supports GET, PUT and DELETE in <path>.
+  - GET looks in <path> for requested path, returning its content, or a 404 if it does not exist.
+  - PUT creates or replaces requested path in <path> with with the content of the request body.
+  - DELETE deletes the requested path in <path> if it exists.
+
+No HTTP request should be able to read or modify a file outside of <path>.
+
+This implements the API required by the HTTP external storage option in BACKUP and RESTORE.`,
+		RunE: cli.MaybeDecorateGRPCError(runHTTPServer),
+	}
+	flags := httpServerCmd.PersistentFlags()
+	flags.StringVar(&httpServerPort, "listen", ":8082", "port (or host:port) to bind")
+
+	utilCmds := &cobra.Command{
+		Use:   "utils [command]",
+		Short: "utility commands",
+		Long:  `Commands for helpers and utilities.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Usage()
+		},
+	}
+	cli.AddCmd(utilCmds)
+	utilCmds.AddCommand(httpServerCmd)
+}
+
+var (
+	httpServerPort string
+)
+
+func runHTTPServer(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	if len(args) != 1 {
+		if err := cmd.Usage(); err != nil {
+			return err
+		}
+		return errors.New("must provide path")
+	}
+	base := filepath.Clean(args[0])
+
+	if err := os.MkdirAll(base, 0700); err != nil {
+		return errors.Wrap(err, "could not create base path")
+	}
+
+	log.Shout(ctx, log.Severity_DEFAULT,
+		fmt.Sprintf("starting http static file server in %s, listening on %s", base, httpServerPort))
+
+	return http.ListenAndServe(httpServerPort, storageccl.MakeHTTPFileServer(ctx, base))
+}

--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -548,12 +548,31 @@ func (s *azureStorage) Close() error {
 }
 
 // MakeHTTPFileServer returns a handler for GET/PUT/DELETE requests in `path`.
+//
+// This implements the methods used by the HTTP exportStorage implementation,
+// for use in tests or in the standalone helper utility `files-server` command.
 func MakeHTTPFileServer(ctx context.Context, base string) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		localfile := filepath.Join(base, filepath.Clean(filepath.FromSlash(r.URL.Path)))
+
+		// NB: filepath.Join above calls filepath.Clean, which flattens `../`.
+		if !strings.HasPrefix(localfile, base) {
+			http.Error(w, "invalid path", 400)
+			return
+		}
+
+		if log.V(1) {
+			log.Infof(ctx, "%s %q (%q)", r.Method, r.URL.Path, localfile)
+		}
+
 		switch r.Method {
 		case "PUT":
+			if err := os.MkdirAll(filepath.Dir(localfile), 0700); err != nil {
+				log.Warning(ctx, errors.Wrap(err, "could not create parents for requested path"))
+				http.Error(w, err.Error(), 500)
+				return
+			}
 			f, err := os.Create(localfile)
 			if err != nil {
 				log.Warning(ctx, errors.Wrap(err, "could not create requested path"))
@@ -561,7 +580,6 @@ func MakeHTTPFileServer(ctx context.Context, base string) http.HandlerFunc {
 				return
 			}
 			defer f.Close()
-			defer r.Body.Close()
 			if _, err := io.Copy(f, r.Body); err != nil {
 				log.Warning(ctx, errors.Wrap(err, "could not create requested path"))
 				http.Error(w, err.Error(), 500)

--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
@@ -544,4 +545,37 @@ func (s *azureStorage) Delete(_ context.Context, basename string) error {
 
 func (s *azureStorage) Close() error {
 	return nil
+}
+
+// MakeHTTPFileServer returns a handler for GET/PUT/DELETE requests in `path`.
+func MakeHTTPFileServer(ctx context.Context, base string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		localfile := filepath.Join(base, filepath.Clean(filepath.FromSlash(r.URL.Path)))
+		switch r.Method {
+		case "PUT":
+			f, err := os.Create(localfile)
+			if err != nil {
+				log.Warning(ctx, errors.Wrap(err, "could not create requested path"))
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			defer f.Close()
+			defer r.Body.Close()
+			if _, err := io.Copy(f, r.Body); err != nil {
+				log.Warning(ctx, errors.Wrap(err, "could not create requested path"))
+				http.Error(w, err.Error(), 500)
+				return
+			}
+		case "GET":
+			http.ServeFile(w, r, localfile)
+		case "DELETE":
+			if err := os.Remove(localfile); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+		default:
+			http.Error(w, "unsupported method "+r.Method, 400)
+		}
+	})
 }

--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -12,14 +12,12 @@ import (
 	"bytes"
 	"crypto/rand"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -204,33 +202,12 @@ func TestPutHttp(t *testing.T) {
 
 	makeServer := func() (*url.URL, func() int, func()) {
 		var files int
+		handler := MakeHTTPFileServer(context.TODO(), tmp)
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			defer r.Body.Close()
-			localfile := filepath.Join(tmp, filepath.Base(r.URL.Path))
-			switch r.Method {
-			case "PUT":
-				f, err := os.Create(localfile)
-				if err != nil {
-					http.Error(w, err.Error(), 500)
-					return
-				}
-				defer f.Close()
-				defer r.Body.Close()
-				if _, err := io.Copy(f, r.Body); err != nil {
-					http.Error(w, err.Error(), 500)
-					return
-				}
+			if r.Method == "PUT" {
 				files++
-			case "GET":
-				http.ServeFile(w, r, localfile)
-			case "DELETE":
-				if err := os.Remove(localfile); err != nil {
-					http.Error(w, err.Error(), 500)
-					return
-				}
-			default:
-				http.Error(w, "unsupported method "+r.Method, 400)
 			}
+			handler(w, r)
 		}))
 		t.Logf("Mock HTTP Storage %q", srv.URL)
 		uri, err := url.Parse(srv.URL)

--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -156,6 +156,9 @@ func testExportStore(t *testing.T, storeURI string, skipSingleFile bool) {
 		if !bytes.Equal(content, []byte("aaa")) {
 			t.Fatalf("wrong content")
 		}
+		if err := s.Delete(ctx, "A"); err != nil {
+			t.Fatal(err)
+		}
 	})
 	t.Run("write-single-file-by-uri", func(t *testing.T) {
 		singleFile := storeFromURI(ctx, t, appendPath(t, storeURI, "B"))
@@ -172,6 +175,9 @@ func testExportStore(t *testing.T, storeURI string, skipSingleFile bool) {
 		defer res.Close()
 		content, err := ioutil.ReadAll(res)
 		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Delete(ctx, "B"); err != nil {
 			t.Fatal(err)
 		}
 		// Verify the result contains what we wrote.


### PR DESCRIPTION
This allows exposing a directory as an HTTP service that supports GET,
PUT and DELETE requests to static files — the API required by the HTTP
Export Storage implementation. This provides a quick and simple way to
use some host or hosts as export storage