### PR TITLE
settings: min_wal_sync_interval defaults to 0ms

### DIFF
--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -346,7 +346,7 @@ func MakeClusterSettings() *Settings {
 	s.MinWALSyncInterval = r.RegisterDurationSetting(
 		"rocksdb.min_wal_sync_interval",
 		"minimum duration between syncs of the RocksDB WAL",
-		1*time.Millisecond)
+		0*time.Millisecond)
 
 	// EnableLoadBasedLeaseRebalancing controls whether lease rebalancing is done
 	// via the new heuristic based on request load and latency or via the simpler

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -66,7 +66,7 @@ kv.raft_log.synchronize                            true           b     set to t
 kv.snapshot_rebalance.max_rate                     2.0 MiB        z     the rate limit (bytes/sec) to use for rebalance snapshots
 kv.snapshot_recovery.max_rate                      8.0 MiB        z     the rate limit (bytes/sec) to use for recovery snapshots
 kv.transaction.max_intents                         100000         i     maximum number of write intents allowed for a KV transaction
-rocksdb.min_wal_sync_interval                      1ms            d     minimum duration between syncs of the RocksDB WAL
+rocksdb.min_wal_sync_interval                      0s             d     minimum duration between syncs of the RocksDB WAL
 server.declined_reservation_timeout                1s             d     the amount of time to consider the store throttled for up-replication after a reservation was declined
 server.failed_reservation_timeout                  5s             d     the amount of time to consider the store throttled for up-replication after a failed reservation call
 server.remote_debugging.mode                       local          s     set to enable remote debugging, localhost-only or disable (any, local, off)


### PR DESCRIPTION
Previously, the default min_wal_sync_interval was 1ms, which provided
modest performance gains for certain workloads but severe penalties for
others.

Now, the default is 0ms.

This produces a ~450% speed boost against `kv --read-percent=0 --cycle-length 1` and a ~30% speed boost effect against `tpcc`.

Closes #17557.