### PR TITLE
sql/cli: make the CLI shell set application_name if no URL is specified

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -207,6 +207,7 @@ func (cfg *Config) PGURL(user *url.Userinfo) (*url.URL, error) {
 			options.Add("sslkey", keyPath)
 		}
 	}
+	options.Add("application_name", "cockroach")
 
 	return &url.URL{
 		Scheme:   "postgresql",

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -674,6 +674,7 @@ func Example_sql() {
 	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
+	c.RunWithArgs([]string{"sql", "-e", "show application_name"})
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
 	c.RunWithArgs([]string{"sql", "-e", "select 3", "-e", "select * from t.f"})
 	c.RunWithArgs([]string{"sql", "-e", "begin", "-e", "select 3", "-e", "commit"})
@@ -689,6 +690,10 @@ func Example_sql() {
 	c.RunWithArgs([]string{"sql", "-d", "nonexistent", "-e", "create database nonexistent; create table foo(x int); select * from foo"})
 
 	// Output:
+	// sql -e show application_name
+	// 1 row
+	// application_name
+	// cockroach
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
 	// INSERT 1
 	// sql -e select 3 -e select * from t.f


### PR DESCRIPTION
This mimics the behavior of `psql` and ensures that SQL sessions from
the command line identify themselves with `application_name =
'cockroach'`, unless an URL was specified. (The application_name can
also be overridden in a URL with `postgres://...&application_name=blah`)

This can ease DBA inspection of running sessions/queries, by enabling
filtering (or excluding) interactive sessions.

(Nice-to-have, I found myself wanting this while testing SHOW CLUSTER QUERIES/SESSIONS.)