### PR TITLE
sql, cli/sql: provide a "safe updates" mode for interactive sessions

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -675,6 +675,7 @@ func Example_sql() {
 	defer c.cleanup()
 
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
+	c.RunWithArgs([]string{"sql", "--safe-updates", "-e", "drop database t"})
 	c.RunWithArgs([]string{"sql", "-e", "select 3", "-e", "select * from t.f"})
 	c.RunWithArgs([]string{"sql", "-e", "begin", "-e", "select 3", "-e", "commit"})
 	c.RunWithArgs([]string{"sql", "-e", "select * from t.f"})
@@ -691,6 +692,8 @@ func Example_sql() {
 	// Output:
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
 	// INSERT 1
+	// sql --safe-updates -e drop database t
+	// pq: rejected: database is not empty; DROP DATABASE will delete all contents recursively (sql_safe_updates = true)
 	// sql -e select 3 -e select * from t.f
 	// 1 row
 	// 3

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -153,6 +153,13 @@ with a non-zero status code and further statements are not executed. The
 results of each SQL statement are printed on the standard output.`,
 	}
 
+	SafeUpdates = FlagInfo{
+		Name: "safe-updates",
+		Description: `
+Disallow SQL statements that may have undesired side effects. For example
+a DELETE or UPDATE without a WHERE clause. This helps prevent accidents.`,
+	}
+
 	TableDisplayFormat = FlagInfo{
 		Name: "format",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -138,6 +138,10 @@ var sqlCtx = struct {
 
 	// execStmts is a list of statements to execute.
 	execStmts statementsValue
+
+	// safeUpdates indicates whether to not set
+	// reject_dangerous_statements in the CLI shell.
+	safeUpdates bool
 }{cliContext: &cliCtx}
 
 // dumpCtx captures the command-line parameters of the `sql` command.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -329,6 +329,8 @@ func init() {
 	boolFlag(zf, &zoneCtx.zoneDisableReplication, cliflags.ZoneDisableReplication, false)
 
 	varFlag(sqlShellCmd.Flags(), &sqlCtx.execStmts, cliflags.Execute)
+	boolFlag(sqlShellCmd.Flags(), &sqlCtx.safeUpdates, cliflags.SafeUpdates, false)
+
 	varFlag(dumpCmd.Flags(), &dumpCtx.dumpMode, cliflags.DumpMode)
 	stringFlag(dumpCmd.Flags(), &dumpCtx.asOf, cliflags.DumpTime, "")
 

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/lib/pq"
 	"github.com/spf13/cobra"
 )
 
@@ -864,6 +865,14 @@ func (c *cliState) doRunStatement(nextState cliStateEnum) cliStateEnum {
 	c.exitErr = runQueryAndFormatResults(c.conn, os.Stdout, makeQuery(c.concatLines))
 	if c.exitErr != nil {
 		fmt.Fprintln(stderr, c.exitErr)
+		if pqErr, ok := c.exitErr.(*pq.Error); ok {
+			if pqErr.Detail != "" {
+				fmt.Fprintln(stderr, "DETAIL:", pqErr.Detail)
+			}
+			if pqErr.Hint != "" {
+				fmt.Fprintln(stderr, "HINT:", pqErr.Hint)
+			}
+		}
 		if c.errExit {
 			return cliStop
 		}

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1003,6 +1003,12 @@ func runTerm(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if sqlCtx.safeUpdates {
+		if err := conn.Exec("SET sql_safe_updates = TRUE", nil); err != nil {
+			return err
+		}
+	}
+
 	if len(sqlCtx.execStmts) > 0 {
 		// Single-line sql; run as simple as possible, without noise on stdout.
 		return runStatements(conn, sqlCtx.execStmts)

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -181,6 +181,10 @@ func (n *alterTableNode) Start(params runParams) error {
 			}
 
 		case *parser.AlterTableDropColumn:
+			if params.p.session.SafeUpdates {
+				return pgerror.NewDangerousStatementErrorf("ALTER TABLE DROP COLUMN will remove all data in that column")
+			}
+
 			col, dropped, err := n.tableDesc.FindColumnByName(t.Column)
 			if err != nil {
 				if t.IfExists {

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -71,6 +71,11 @@ func (p *planner) DropDatabase(ctx context.Context, n *parser.DropDatabase) (pla
 		return nil, err
 	}
 
+	if len(tbNames) > 0 && p.session.SafeUpdates {
+		return nil, pgerror.NewDangerousStatementErrorf(
+			"database is not empty; DROP DATABASE will delete all contents recursively")
+	}
+
 	td := make([]*sqlbase.TableDescriptor, len(tbNames))
 	for i := range tbNames {
 		tbDesc, err := p.dropTableOrViewPrepare(ctx, &tbNames[i])

--- a/pkg/sql/logictest/testdata/logic_test/dangerous_statements
+++ b/pkg/sql/logictest/testdata/logic_test/dangerous_statements
@@ -1,0 +1,17 @@
+statement ok
+CREATE TABLE foo(x INT)
+
+statement ok
+SET sql_safe_updates = true
+
+statement error rejected: UPDATE without WHERE clause
+UPDATE foo SET x = 3
+
+statement error rejected: DELETE without WHERE clause
+DELETE FROM foo
+
+statement error rejected: database is not empty
+DROP DATABASE test
+
+statement error rejected: ALTER TABLE DROP COLUMN
+ALTER TABLE foo DROP COLUMN x

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -144,7 +144,7 @@ EXPLAIN SHOW DATABASE
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 19 rows
+2  ·       size  2 columns, 20 rows
 
 query ITTT
 EXPLAIN SHOW TIME ZONE
@@ -152,7 +152,7 @@ EXPLAIN SHOW TIME ZONE
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 19 rows
+2  ·       size  2 columns, 20 rows
 
 query ITTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -160,7 +160,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 19 rows
+2  ·       size  2 columns, 20 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -168,7 +168,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 19 rows
+2  ·       size  2 columns, 20 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -176,7 +176,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 19 rows
+2  ·       size  2 columns, 20 rows
 
 query ITTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -960,6 +960,7 @@ node_id                        1             NULL      NULL        NULL        s
 search_path                    pg_catalog    NULL      NULL        NULL        string
 server_version                 9.5.0         NULL      NULL        NULL        string
 session_user                   root          NULL      NULL        NULL        string
+sql_safe_updates               false         NULL      NULL        NULL        string
 standard_conforming_strings    on            NULL      NULL        NULL        string
 time zone                      UTC           NULL      NULL        NULL        string
 tracing                        off           NULL      NULL        NULL        string
@@ -984,6 +985,7 @@ node_id                        1             NULL  user     NULL      1         
 search_path                    pg_catalog    NULL  user     NULL      pg_catalog    pg_catalog
 server_version                 9.5.0         NULL  user     NULL      9.5.0         9.5.0
 session_user                   root          NULL  user     NULL      root          root
+sql_safe_updates               false         NULL  user     NULL      false         false
 standard_conforming_strings    on            NULL  user     NULL      on            on
 time zone                      UTC           NULL  user     NULL      UTC           UTC
 tracing                        off           NULL  user     NULL      off           off
@@ -1008,6 +1010,7 @@ node_id                        NULL    NULL     NULL     NULL        NULL
 search_path                    NULL    NULL     NULL     NULL        NULL
 server_version                 NULL    NULL     NULL     NULL        NULL
 session_user                   NULL    NULL     NULL     NULL        NULL
+sql_safe_updates               NULL    NULL     NULL     NULL        NULL
 standard_conforming_strings    NULL    NULL     NULL     NULL        NULL
 time zone                      NULL    NULL     NULL     NULL        NULL
 tracing                        NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -90,6 +90,7 @@ node_id                        1
 search_path                    pg_catalog
 server_version                 9.5.0
 session_user                   root
+sql_safe_updates               false
 standard_conforming_strings    on
 time zone                      UTC
 tracing                        off

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -33,6 +33,7 @@ node_id                        1
 search_path                    pg_catalog
 server_version                 9.5.0
 session_user                   root
+sql_safe_updates               false
 standard_conforming_strings    on
 time zone                      UTC
 tracing                        off

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -42,6 +42,18 @@ func NewErrorf(code string, format string, args ...interface{}) *Error {
 	}
 }
 
+// SetHintf annotates an Error object with a hint.
+func (pg *Error) SetHintf(f string, args ...interface{}) *Error {
+	pg.Hint = fmt.Sprintf(f, args...)
+	return pg
+}
+
+// SetDetailf annotates an Error object with details.
+func (pg *Error) SetDetailf(f string, args ...interface{}) *Error {
+	pg.Detail = fmt.Sprintf(f, args...)
+	return pg
+}
+
 // AnnotateError adds a prefix to the message of an error, maintaining its pg
 // error code and source if it is a pgerror.Error.
 func AnnotateError(prefix string, err error) error {

--- a/pkg/sql/pgwire/pgerror/errors.go
+++ b/pkg/sql/pgwire/pgerror/errors.go
@@ -15,6 +15,7 @@
 package pgerror
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
@@ -40,6 +41,15 @@ func NewErrorf(code string, format string, args ...interface{}) *Error {
 		Code:    code,
 		Source:  &srcCtx,
 	}
+}
+
+// NewDangerousStatementErrorf creates a new Error for "rejected dangerous statements".
+func NewDangerousStatementErrorf(format string, args ...interface{}) *Error {
+	var buf bytes.Buffer
+	buf.WriteString("rejected: ")
+	fmt.Fprintf(&buf, format, args...)
+	buf.WriteString(" (sql_safe_updates = true)")
+	return NewError(CodeWarningError, buf.String())
 }
 
 // SetHintf annotates an Error object with a hint.

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -157,6 +157,9 @@ type Session struct {
 	SearchPath parser.SearchPath
 	// User is the name of the user logged into the session.
 	User string
+	// SafeUpdates causes errors when the client
+	// sends syntax that may have unwanted side effects.
+	SafeUpdates bool
 
 	//
 	// Session parameters, non-user-configurable.

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -372,9 +372,9 @@ WHERE message LIKE 'fetched: %'
 
 	// We failed to substitute; this is an internal error.
 	err = pgerror.NewErrorf(pgerror.CodeInternalError,
-		"invalid logical plan structure:\n%s\nwhile inserting:\n%s",
-		planToString(ctx, plan),
-		planToString(ctx, tracePlan))
+		"invalid logical plan structure:\n%s", planToString(ctx, plan),
+	).SetDetailf(
+		"while inserting:\n%s", planToString(ctx, tracePlan))
 	plan.Close(ctx)
 	stmtPlan.Close(ctx)
 	tracePlan.Close(ctx)

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -226,6 +227,10 @@ func addOrMergeExpr(
 func (p *planner) Update(
 	ctx context.Context, n *parser.Update, desiredTypes []parser.Type,
 ) (planNode, error) {
+	if n.Where == nil && p.session.SafeUpdates {
+		return nil, pgerror.NewDangerousStatementErrorf("UPDATE without WHERE clause")
+	}
+
 	tracing.AnnotateTrace()
 
 	tn, err := p.getAliasedTableName(n.Table)


### PR DESCRIPTION
New SQL session variable `sql_safe_updates` to prevent users from having data accidents. Enable with `cockroach sql --safe-updates` or the SET statement.

Fixes #3943.

cc @bdarnell 