### PR TITLE
cli/sql: handle protocol errors caused by COPY in a user-friendly manner

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -687,6 +687,8 @@ func Example_sql() {
 	// It must be possible to create the current database after the
 	// connection was established.
 	c.RunWithArgs([]string{"sql", "-d", "nonexistent", "-e", "create database nonexistent; create table foo(x int); select * from foo"})
+	// COPY should return an intelligible error message.
+	c.RunWithArgs([]string{"sql", "-e", "copy t.f from stdin"})
 
 	// Output:
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
@@ -735,6 +737,8 @@ func Example_sql() {
 	// sql -d nonexistent -e create database nonexistent; create table foo(x int); select * from foo
 	// 0 rows
 	// x
+	// sql -e copy t.f from stdin
+	// woops! COPY has confused this client! Suggestion: use 'psql' for COPY
 }
 
 func Example_sql_format() {


### PR DESCRIPTION
Prior to this patch, issuing COPY on the SQL CLI would cause
a non-recoverable protocol error with an unscrutable error message:

```
root@:26257/test> copy kv from stdin;
pq: unknown response for simple query: 'G'
error retrieving the transaction status: driver: bad connection
connection lost; opening new connection: all session settings will be lost
root@:26257/ ?>
```

This patch enhances UX by providing a friendly error message instead:

```
root@:26257/test> copy kv from stdin;
woops! COPY has confused this client! Suggestion: use 'psql' for COPY.
connection lost; opening new connection: all session settings will be lost
root@:26257/test>
```

Fixes #17577.