### PR TITLE
storage: Only count expiration/epoch lease metric for leaseholders

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -99,10 +99,10 @@ var (
 		Help: "Number of failed lease transfers"}
 	metaLeaseExpirationCount = metric.Metadata{
 		Name: "leases.expiration",
-		Help: "Number of replicas using expiration-based leases"}
+		Help: "Number of replica leaseholders using expiration-based leases"}
 	metaLeaseEpochCount = metric.Metadata{
 		Name: "leases.epoch",
-		Help: "Number of replicas using epoch-based leases"}
+		Help: "Number of replica leaseholders using epoch-based leases"}
 
 	// Storage metrics.
 	metaLiveBytes = metric.Metadata{

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3940,13 +3940,13 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		}
 		if metrics.Leaseholder {
 			leaseHolderCount++
-		}
-		switch metrics.LeaseType {
-		case roachpb.LeaseNone:
-		case roachpb.LeaseExpiration:
-			leaseExpirationCount++
-		case roachpb.LeaseEpoch:
-			leaseEpochCount++
+			switch metrics.LeaseType {
+			case roachpb.LeaseNone:
+			case roachpb.LeaseExpiration:
+				leaseExpirationCount++
+			case roachpb.LeaseEpoch:
+				leaseEpochCount++
+			}
 		}
 		if metrics.Quiescent {
 			quiescentCount++


### PR DESCRIPTION
The current formulation of the metric makes no sense, since it can't be
meaningfully aggregated after-the-fact. It either needs to be changed to
only track the lease types for replicas that the node holds the lease
for (which I imagine is what most people thought it meant), or it needs
to make sure that only one replica counts each range. The comment in
TestLeaseMetricsOnSplitAndTransfer makes me think that may have been the
original intention, with only the highest replica ID for a range
reporting that range's lease type.

I chose the former in this commit, but would be willing to switch to the
latter.