### PR TITLE
sql: Log cluster settings changes to the event log

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -726,6 +726,7 @@ func TestAdminAPIEvents(t *testing.T) {
 		"CREATE TABLE api_test.tbl3 (a INT)",
 		"DROP TABLE api_test.tbl1",
 		"DROP TABLE api_test.tbl2",
+		"SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = false;",
 	}
 	for _, q := range setupQueries {
 		res, err := ts.sqlExecutor.ExecuteStatementsBuffered(session, q, nil, 1)
@@ -749,6 +750,7 @@ func TestAdminAPIEvents(t *testing.T) {
 		{sql.EventLogCreateDatabase, false, 0, 1},
 		{sql.EventLogDropTable, false, 0, 2},
 		{sql.EventLogCreateTable, false, 0, 3},
+		{sql.EventLogSetClusterSetting, false, 0, 2},
 		{sql.EventLogCreateTable, true, 0, 3},
 		{sql.EventLogCreateTable, true, -1, 3},
 		{sql.EventLogCreateTable, true, 2, 2},
@@ -804,7 +806,7 @@ func TestAdminAPIEvents(t *testing.T) {
 					}
 				}
 
-				if e.TargetID == 0 {
+				if e.TargetID == 0 && e.EventType != string(sql.EventLogSetClusterSetting) {
 					t.Errorf("%d: missing/empty TargetID", i)
 				}
 				if e.ReportingID == 0 {

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -65,6 +65,9 @@ const (
 	// EventLogNodeRestart is recorded when an existing node rejoins the cluster
 	// after being offline.
 	EventLogNodeRestart EventLogType = "node_restart"
+
+	// EventLogSetClusterSetting is recorded when a cluster setting is changed.
+	EventLogSetClusterSetting EventLogType = "set_cluster_setting"
 )
 
 // An EventLogger exposes methods used to record events to the event table.

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -307,3 +307,28 @@ WHERE "eventType" = 'drop_database'
   AND info LIKE '%anothertesttable%'
 ----
 53 1
+
+##################
+# Cluster Settings
+##################
+
+# Set and unset a cluster setting
+##################
+
+statement ok
+SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = false
+
+statement ok
+SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = DEFAULT
+
+# verify setting changes are logged
+##################
+query IIT
+SELECT "targetID", "reportingID", "info"
+FROM system.eventlog
+WHERE "eventType" = 'set_cluster_setting'
+ORDER BY "timestamp"
+----
+0 1 {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"node"}
+0 1 {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
+0 1 {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}

--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -33,13 +33,16 @@ export const FINISH_SCHEMA_CHANGE = "finish_schema_change";
 export const NODE_JOIN = "node_join";
 // Recorded when an existing node rejoins the cluster after being offline.
 export const NODE_RESTART = "node_restart";
+// Recorded when a cluster setting is changed.
+export const SET_CLUSTER_SETTING = "set_cluster_setting";
 
 // Node Event Types
 export const nodeEvents = [NODE_JOIN, NODE_RESTART];
 export const databaseEvents = [CREATE_DATABASE, DROP_DATABASE];
 export const tableEvents = [CREATE_TABLE, DROP_TABLE, ALTER_TABLE, CREATE_INDEX,
   DROP_INDEX, CREATE_VIEW, DROP_VIEW, REVERSE_SCHEMA_CHANGE, FINISH_SCHEMA_CHANGE];
-export const allEvents = [...nodeEvents, ...databaseEvents, ...tableEvents];
+export const settingsEvents = [SET_CLUSTER_SETTING];
+export const allEvents = [...nodeEvents, ...databaseEvents, ...tableEvents, ...settingsEvents];
 
 interface EventSet {
   [key: string]: number;
@@ -48,6 +51,7 @@ interface EventSet {
 const nodeEventSet = _.invert<EventSet>(nodeEvents);
 const databaseEventSet = _.invert<EventSet>(databaseEvents);
 const tableEventSet = _.invert<EventSet>(tableEvents);
+const settingsEventSet = _.invert<EventSet>(settingsEvents);
 
 export function isNodeEvent(e: Event): boolean {
   return !_.isUndefined(nodeEventSet[e.event_type]);
@@ -59,4 +63,8 @@ export function isDatabaseEvent(e: Event): boolean {
 
 export function isTableEvent(e: Event): boolean {
   return !_.isUndefined(tableEventSet[e.event_type]);
+}
+
+export function isSettingsEvent(e: Event): boolean {
+  return !_.isUndefined(settingsEventSet[e.event_type]);
 }

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -56,6 +56,8 @@ export function getEventInfo(e: Event$Properties): SimplifiedEvent {
     TableName: string,
     User: string,
     ViewName: string,
+    SettingName: string,
+    Value: string,
   } = protobuf.util.isset(e, "info") ? JSON.parse(e.info) : {};
   const targetId: number = e.target_id ? e.target_id.toNumber() : null;
   let content: React.ReactNode;
@@ -106,6 +108,9 @@ export function getEventInfo(e: Event$Properties): SimplifiedEvent {
       break;
     case eventTypes.NODE_RESTART:
       content = <span>Node Rejoined: Node {targetId} rejoined the cluster</span>;
+      break;
+    case eventTypes.SET_CLUSTER_SETTING:
+      content = <span>Cluster Setting Changed: User {info.User} set {info.SettingName} to {info.Value}</span>;
       break;
     default:
       content = <span>Unknown Event Type: {e.event_type}, content: {s(info)}</span>;


### PR DESCRIPTION
It's nice when debugging things to be able to see all possible events that could have influenced things, and settings changes could definitely influence things. The only downside I see of this is that will now always include initially setting `diagnostics.reporting.enabled` in new clusters as an event unless we do something special to avoid it.

Fixes #17589