### PR TITLE
kv: bump the leaseholder cache size

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -44,7 +44,7 @@ const (
 	// lookup.
 	defaultRangeLookupMaxRanges = 8
 	// The default size of the range lease holder cache.
-	defaultLeaseHolderCacheSize = 1 << 16
+	defaultLeaseHolderCacheSize = 1 << 20
 	// The default size of the range descriptor cache.
 	defaultRangeDescriptorCacheSize = 1 << 20
 	// The default limit for asynchronous senders.


### PR DESCRIPTION
Making the leaseholder cache smaller than the range descriptor cache was
a bit silly. And the previous setting was way too small for large
clusters.