### PR TITLE
sqlmigrations: add default .meta zone config

### DIFF
--- a/pkg/acceptance/gossip_peerings_test.go
+++ b/pkg/acceptance/gossip_peerings_test.go
@@ -231,8 +231,10 @@ func testGossipRestartFirstNodeNeedsIncomingInner(
 		t.Fatal(err)
 	}
 
-	if _, _, err := c.ExecCLI(ctx, 0, []string{"zone", "set", ".default", "-f", zoneFile}); err != nil {
-		t.Fatal(err)
+	for _, zone := range []string{".default", ".meta", ".liveness"} {
+		if _, _, err := c.ExecCLI(ctx, 0, []string{"zone", "set", zone, "-f", zoneFile}); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	db := makePGClient(t, c.PGUrl(ctx, 0))

--- a/pkg/ccl/cliccl/cli_test.go
+++ b/pkg/ccl/cliccl/cli_test.go
@@ -167,6 +167,8 @@ func Example_cclzone() {
 	// constraints: [us-east-1a, ssd]
 	// zone ls
 	// .default
+	// .liveness
+	// .meta
 	// db.t.p1
 	// db.t@primary
 	// zone rm db.t@primary
@@ -189,6 +191,8 @@ func Example_cclzone() {
 	// constraints: [us-east-1a, ssd]
 	// zone ls
 	// .default
+	// .liveness
+	// .meta
 	// db.t.p1
 	// zone rm db.t.p0
 	// CONFIGURE ZONE 0
@@ -196,4 +200,6 @@ func Example_cclzone() {
 	// CONFIGURE ZONE 1
 	// zone ls
 	// .default
+	// .liveness
+	// .meta
 }

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -496,6 +496,7 @@ func Example_zone() {
 	c.Run("zone ls")
 	c.Run("zone set system --file=./testdata/zone_attrs.yaml")
 	c.Run("zone ls")
+	c.Run("zone get .liveness")
 	c.Run("zone get .meta")
 	c.Run("zone get system.nonexistent")
 	c.Run("zone get system.descriptor")
@@ -507,6 +508,7 @@ func Example_zone() {
 	c.Run("zone rm system")
 	c.Run("zone ls")
 	c.Run("zone rm .default")
+	c.Run("zone set .liveness --file=./testdata/zone_range_max_bytes.yaml")
 	c.Run("zone set .meta --file=./testdata/zone_range_max_bytes.yaml")
 	c.Run("zone set .system --file=./testdata/zone_range_max_bytes.yaml")
 	c.Run("zone set .timeseries --file=./testdata/zone_range_max_bytes.yaml")
@@ -516,11 +518,13 @@ func Example_zone() {
 	c.Run("zone get system")
 	c.Run("zone set .default --disable-replication")
 	c.Run("zone get system")
+	c.Run("zone rm .liveness")
 	c.Run("zone rm .meta")
 	c.Run("zone rm .system")
 	c.Run("zone ls")
 	c.Run("zone rm .timeseries")
 	c.Run("zone ls")
+	c.Run("zone rm .liveness")
 	c.Run("zone rm .meta")
 	c.Run("zone rm .system")
 	c.Run("zone rm .timeseries")
@@ -529,6 +533,8 @@ func Example_zone() {
 	// Output:
 	// zone ls
 	// .default
+	// .liveness
+	// .meta
 	// zone set system --file=./testdata/zone_attrs.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
@@ -538,13 +544,23 @@ func Example_zone() {
 	// constraints: [us-east-1a, ssd]
 	// zone ls
 	// .default
+	// .liveness
+	// .meta
 	// system
-	// zone get .meta
-	// .default
+	// zone get .liveness
+	// .liveness
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
 	// gc:
-	//   ttlseconds: 90000
+	//   ttlseconds: 600
+	// num_replicas: 1
+	// constraints: []
+	// zone get .meta
+	// .meta
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 3600
 	// num_replicas: 1
 	// constraints: []
 	// zone get system.nonexistent
@@ -582,13 +598,22 @@ func Example_zone() {
 	// CONFIGURE ZONE 1
 	// zone ls
 	// .default
+	// .liveness
+	// .meta
 	// zone rm .default
 	// pq: cannot remove default zone
+	// zone set .liveness --file=./testdata/zone_range_max_bytes.yaml
+	// range_min_bytes: 1048576
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 600
+	// num_replicas: 3
+	// constraints: []
 	// zone set .meta --file=./testdata/zone_range_max_bytes.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
 	// gc:
-	//   ttlseconds: 90000
+	//   ttlseconds: 3600
 	// num_replicas: 3
 	// constraints: []
 	// zone set .system --file=./testdata/zone_range_max_bytes.yaml
@@ -615,6 +640,7 @@ func Example_zone() {
 	// constraints: []
 	// zone ls
 	// .default
+	// .liveness
 	// .meta
 	// .system
 	// .timeseries
@@ -648,6 +674,8 @@ func Example_zone() {
 	//   ttlseconds: 90000
 	// num_replicas: 1
 	// constraints: []
+	// zone rm .liveness
+	// CONFIGURE ZONE 1
 	// zone rm .meta
 	// CONFIGURE ZONE 1
 	// zone rm .system
@@ -659,6 +687,8 @@ func Example_zone() {
 	// CONFIGURE ZONE 1
 	// zone ls
 	// .default
+	// zone rm .liveness
+	// CONFIGURE ZONE 0
 	// zone rm .meta
 	// CONFIGURE ZONE 0
 	// zone rm .system

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -217,10 +217,14 @@ func (s SystemConfig) GetZoneConfigForKey(key roachpb.RKey) (ZoneConfig, error) 
 	// Special-case known system ranges to their special zone configs.
 	if key.Equal(roachpb.RKeyMin) || bytes.HasPrefix(key, keys.Meta1Prefix) || bytes.HasPrefix(key, keys.Meta2Prefix) {
 		objectID = keys.MetaRangesID
-	} else if bytes.HasPrefix(key, keys.TimeseriesPrefix) {
-		objectID = keys.TimeseriesRangesID
 	} else if bytes.HasPrefix(key, keys.SystemPrefix) {
-		objectID = keys.SystemRangesID
+		if bytes.HasPrefix(key, keys.NodeLivenessPrefix) {
+			objectID = keys.LivenessRangesID
+		} else if bytes.HasPrefix(key, keys.TimeseriesPrefix) {
+			objectID = keys.TimeseriesRangesID
+		} else {
+			objectID = keys.SystemRangesID
+		}
 	}
 
 	return s.getZoneConfigForID(objectID, keySuffix)

--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -377,7 +377,7 @@ func TestGetZoneConfigForKey(t *testing.T) {
 		{roachpb.RKey(keys.SystemPrefix), keys.SystemRangesID},
 		{roachpb.RKey(keys.SystemPrefix.Next()), keys.SystemRangesID},
 		{roachpb.RKey(keys.MigrationLease), keys.SystemRangesID},
-		{roachpb.RKey(keys.NodeLivenessPrefix), keys.SystemRangesID},
+		{roachpb.RKey(keys.NodeLivenessPrefix), keys.LivenessRangesID},
 		{roachpb.RKey(keys.DescIDGenerator), keys.SystemRangesID},
 		{roachpb.RKey(keys.NodeIDGenerator), keys.SystemRangesID},
 		{roachpb.RKey(keys.RangeIDGenerator), keys.SystemRangesID},

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -31,6 +31,7 @@ import (
 // can be targeted by zone configs.
 const (
 	DefaultZoneName    = "default"
+	LivenessZoneName   = "liveness"
 	MetaZoneName       = "meta"
 	SystemZoneName     = "system"
 	TimeseriesZoneName = "timeseries"
@@ -40,6 +41,7 @@ const (
 // install an entry into the system.zones table.
 var NamedZones = map[string]uint32{
 	DefaultZoneName:    keys.RootNamespaceID,
+	LivenessZoneName:   keys.LivenessRangesID,
 	MetaZoneName:       keys.MetaRangesID,
 	SystemZoneName:     keys.SystemRangesID,
 	TimeseriesZoneName: keys.TimeseriesRangesID,

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -316,4 +316,5 @@ const (
 	WebSessionsTableID     = 19
 	TableStatisticsTableID = 20
 	LocationsTableID       = 21
+	LivenessRangesID       = 22
 )

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -165,7 +165,6 @@ id  cli_specifier  config_yaml  config_proto
 
 statement ok
 INSERT INTO system.zones (id, config) VALUES
-  (16, (SELECT config_proto FROM crdb_internal.zones WHERE id = 0)),
   (17, (SELECT config_proto FROM crdb_internal.zones WHERE id = 0)),
   (18, (SELECT config_proto FROM crdb_internal.zones WHERE id = 0)),
   (51, (SELECT config_proto FROM crdb_internal.zones WHERE id = 0)),
@@ -178,6 +177,7 @@ SELECT id, cli_specifier FROM crdb_internal.zones ORDER BY id
 16  .meta
 17  .system
 18  .timeseries
+22  .liveness
 51  testdb
 52  testdb.foo
 

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -77,7 +77,8 @@ func TestQueryCounts(t *testing.T) {
 	// Initialize accum while accounting for system migrations that may have run
 	// DDL statements.
 	accum := queryCounter{
-		insertCount: 2, // version setting population migration and root user addition.
+		selectCount: 2, // non-zero due to migrations
+		insertCount: 4, // non-zero due to migrations
 		ddlCount:    s.MustGetSQLCounter(sql.MetaDdl.Name),
 		miscCount:   s.MustGetSQLCounter(sql.MetaMisc.Name),
 	}
@@ -188,7 +189,7 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 	if err := checkCounterEQ(s, sql.MetaTxnCommit, 0); err != nil {
 		t.Error(err)
 	}
-	if err := checkCounterEQ(s, sql.MetaInsert, 3); err != nil {
+	if err := checkCounterEQ(s, sql.MetaInsert, 5); err != nil {
 		t.Error(err)
 	}
 }
@@ -216,7 +217,7 @@ func TestAbortCountErrorDuringTransaction(t *testing.T) {
 	if err := checkCounterEQ(s, sql.MetaTxnBegin, 1); err != nil {
 		t.Error(err)
 	}
-	if err := checkCounterEQ(s, sql.MetaSelect, 1); err != nil {
+	if err := checkCounterEQ(s, sql.MetaSelect, 3); err != nil {
 		t.Error(err)
 	}
 

--- a/pkg/sql/zone_test.go
+++ b/pkg/sql/zone_test.go
@@ -41,6 +41,10 @@ func TestValidSetShowZones(t *testing.T) {
 
 	yamlDefault := fmt.Sprintf("gc: {ttlseconds: %d}", config.DefaultZoneConfig().GC.TTLSeconds)
 	yamlOverride := "gc: {ttlseconds: 42}"
+	metaZoneConfig := config.DefaultZoneConfig()
+	metaZoneConfig.GC.TTLSeconds = 60 * 60
+	livenessZoneConfig := config.DefaultZoneConfig()
+	livenessZoneConfig.GC.TTLSeconds = 10 * 60
 	zoneOverride := config.DefaultZoneConfig()
 	zoneOverride.GC.TTLSeconds = 42
 
@@ -54,7 +58,17 @@ func TestValidSetShowZones(t *testing.T) {
 		CLISpecifier: ".default",
 		Config:       zoneOverride,
 	}
+	livenessRow := sqlutils.ZoneRow{
+		ID:           keys.LivenessRangesID,
+		CLISpecifier: ".liveness",
+		Config:       livenessZoneConfig,
+	}
 	metaRow := sqlutils.ZoneRow{
+		ID:           keys.MetaRangesID,
+		CLISpecifier: ".meta",
+		Config:       metaZoneConfig,
+	}
+	metaOverrideRow := sqlutils.ZoneRow{
 		ID:           keys.MetaRangesID,
 		CLISpecifier: ".meta",
 		Config:       zoneOverride,
@@ -81,9 +95,11 @@ func TestValidSetShowZones(t *testing.T) {
 	}
 
 	// Ensure the default is reported for all zones at first.
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultRow, metaRow, livenessRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE default", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", metaRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE liveness", livenessRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE system", defaultRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE system.lease", defaultRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", defaultRow)
@@ -92,8 +108,9 @@ func TestValidSetShowZones(t *testing.T) {
 	// Ensure a database zone config applies to that database and its tables, and
 	// no other zones.
 	sqlutils.SetZoneConfig(t, sqlDB, "DATABASE d", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow, dbRow)
-	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", defaultRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultRow, metaRow, livenessRow, dbRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", metaRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE system", defaultRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE system.lease", defaultRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", dbRow)
@@ -101,8 +118,9 @@ func TestValidSetShowZones(t *testing.T) {
 
 	// Ensure a table zone config applies to that table and no others.
 	sqlutils.SetZoneConfig(t, sqlDB, "TABLE d.t", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow, dbRow, tableRow)
-	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", defaultRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultRow, metaRow, livenessRow, dbRow, tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", metaRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE system", defaultRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE system.lease", defaultRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", dbRow)
@@ -110,8 +128,9 @@ func TestValidSetShowZones(t *testing.T) {
 
 	// Ensure a named zone config applies to that named zone and no others.
 	sqlutils.SetZoneConfig(t, sqlDB, "RANGE meta", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow, metaRow, dbRow, tableRow)
-	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", metaRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultRow, metaOverrideRow, livenessRow, dbRow, tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", metaOverrideRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE system", defaultRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE system.lease", defaultRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", dbRow)
@@ -120,8 +139,9 @@ func TestValidSetShowZones(t *testing.T) {
 	// Ensure updating the default zone propagates to zones without an override,
 	// but not to those with overrides.
 	sqlutils.SetZoneConfig(t, sqlDB, "RANGE default", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultOverrideRow, metaRow, dbRow, tableRow)
-	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", metaRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultOverrideRow, metaOverrideRow, livenessRow, dbRow, tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", metaOverrideRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE system", defaultOverrideRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE system.lease", defaultOverrideRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", dbRow)
@@ -130,18 +150,21 @@ func TestValidSetShowZones(t *testing.T) {
 	// Ensure deleting a database deletes only the database zone, and not the
 	// table zone.
 	sqlutils.DeleteZoneConfig(t, sqlDB, "DATABASE d")
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultOverrideRow, metaRow, tableRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultOverrideRow, metaOverrideRow, livenessRow, tableRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", defaultOverrideRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", tableRow)
 
 	// Ensure deleting a table zone works.
 	sqlutils.DeleteZoneConfig(t, sqlDB, "TABLE d.t")
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultOverrideRow, metaRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultOverrideRow, metaOverrideRow, livenessRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", defaultOverrideRow)
 
 	// Ensure deleting a named zone works.
 	sqlutils.DeleteZoneConfig(t, sqlDB, "RANGE meta")
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultOverrideRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultOverrideRow, livenessRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", defaultOverrideRow)
 
 	// Ensure deleting non-overridden zones is not an error.
@@ -152,7 +175,8 @@ func TestValidSetShowZones(t *testing.T) {
 	// Ensure updating the default zone config applies to zones that have had
 	// overrides added and removed.
 	sqlutils.SetZoneConfig(t, sqlDB, "RANGE default", yamlDefault)
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultRow, livenessRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE default", defaultRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE meta", defaultRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE system", defaultRow)
@@ -163,7 +187,8 @@ func TestValidSetShowZones(t *testing.T) {
 	// Ensure the system database zone can be configured, even though zones on
 	// config tables are disallowed.
 	sqlutils.SetZoneConfig(t, sqlDB, "DATABASE system", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow, systemRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultRow, systemRow, livenessRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE system", systemRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE system.namespace", systemRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE system.jobs", systemRow)
@@ -171,7 +196,8 @@ func TestValidSetShowZones(t *testing.T) {
 	// Ensure zones for non-config tables in the system database can be
 	// configured.
 	sqlutils.SetZoneConfig(t, sqlDB, "TABLE system.jobs", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow, systemRow, jobsRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB,
+		defaultRow, systemRow, jobsRow, livenessRow)
 	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE system.jobs", jobsRow)
 
 	// Ensure zone configs are read transactionally instead of from the cached

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -42,6 +43,10 @@ import (
 var (
 	leaseDuration        = time.Minute
 	leaseRefreshInterval = leaseDuration / 5
+)
+
+const (
+	addDefaultMetaAndLivenessZoneConfigsName = "add default .meta and .liveness zone configs"
 )
 
 // backwardCompatibleMigrations is a hard-coded list of migrations to be run on
@@ -104,6 +109,10 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		workFn:         createLocationsTable,
 		newDescriptors: 1,
 		newRanges:      1,
+	},
+	{
+		name:   addDefaultMetaAndLivenessZoneConfigsName,
+		workFn: addDefaultMetaAndLivenessZoneConfigs,
 	},
 }
 
@@ -521,4 +530,111 @@ func addRootUser(ctx context.Context, r runner) error {
 		res.Close(ctx)
 	}
 	return err
+}
+
+func addDefaultMetaAndLivenessZoneConfigs(ctx context.Context, r runner) error {
+	defaultTTLSeconds := config.DefaultZoneConfig().GC.TTLSeconds
+
+	// Retrieve the existing .meta zone config.
+	metaZone, err := getZoneConfig(ctx, r, keys.MetaRangesID)
+	if err != nil {
+		return err
+	}
+	// Update the GC TTL seconds if it still at the default setting.
+	if metaZone.GC.TTLSeconds == defaultTTLSeconds {
+		metaZone.GC.TTLSeconds = 60 * 60 // 1h
+	}
+	if err := upsertZoneConfig(ctx, r, keys.MetaRangesID, metaZone); err != nil {
+		return err
+	}
+
+	// The liveness range was previously covered by the ".system" zone. Grab the
+	// existing ".system" zone (if any) for modification.
+	livenessZone, err := getZoneConfig(ctx, r, keys.SystemRangesID)
+	if err != nil {
+		return err
+	}
+	// We set the .liveness zone config regardless, but only update the TTL
+	// seconds if it is still at the default setting.
+	if livenessZone.GC.TTLSeconds == defaultTTLSeconds {
+		livenessZone.GC.TTLSeconds = 10 * 60 // 10m
+	}
+	return upsertZoneConfig(ctx, r, keys.LivenessRangesID, livenessZone)
+}
+
+func upsertZoneConfig(ctx context.Context, r runner, id uint32, zone config.ZoneConfig) error {
+	buf, err := protoutil.Marshal(&zone)
+	if err != nil {
+		return err
+	}
+
+	const stmt = `UPSERT INTO system.zones (id, config) VALUES ($1, $2)`
+	pl := tree.MakePlaceholderInfo()
+	pl.SetValue("1", tree.NewDInt(tree.DInt(id)))
+	pl.SetValue("2", tree.NewDString(string(buf)))
+
+	// System tables can only be modified by a privileged internal user.
+	session := r.newRootSession(ctx)
+	defer session.Finish(r.sqlExecutor)
+
+	// Retry a limited number of times because returning an error and letting
+	// the node kill itself is better than holding the migration lease for an
+	// arbitrarily long time.
+	for retry := retry.Start(retry.Options{MaxRetries: 5}); retry.Next(); {
+		var res sql.StatementResults
+		res, err = r.sqlExecutor.ExecuteStatementsBuffered(session, stmt, &pl, 1)
+		if err == nil {
+			res.Close(ctx)
+			break
+		}
+		log.Warningf(ctx, "failed attempt to add .%s zone config: %s",
+			config.NamedZonesByID[id], err)
+	}
+	return err
+}
+
+func getZoneConfig(ctx context.Context, r runner, id uint32) (config.ZoneConfig, error) {
+	stmt := fmt.Sprintf(
+		`SELECT config_proto FROM [EXPERIMENTAL SHOW ZONE CONFIGURATION FOR RANGE %s]`,
+		config.NamedZonesByID[id])
+
+	session := r.newRootSession(ctx)
+	defer session.Finish(r.sqlExecutor)
+
+	// Retry a limited number of times because returning an error and letting the
+	// node kill itself is better than holding the migration lease for an
+	// arbitrarily long time.
+	var err error
+	for retry := retry.Start(retry.Options{MaxRetries: 5}); retry.Next(); {
+		var res sql.StatementResults
+		res, err = r.sqlExecutor.ExecuteStatementsBuffered(session, stmt, nil, 1)
+		if err != nil {
+			log.Warningf(ctx, "failed attempt to retrieve .%s zone config: %s",
+				config.NamedZonesByID[id], err)
+			continue
+		}
+		defer res.Close(ctx)
+
+		// TODO(peter): This is very manual. Is there a better way?
+		if len(res.ResultList) == 0 || res.ResultList[0].Rows.Len() == 0 {
+			break
+		}
+		row := res.ResultList[0].Rows.At(0)
+		if len(row) != 1 {
+			break
+		}
+		data, ok := row[0].(*tree.DBytes)
+		if !ok {
+			break
+		}
+		var zone config.ZoneConfig
+		if err = protoutil.Unmarshal([]byte(*data), &zone); err != nil {
+			break
+		}
+		return zone, nil
+	}
+
+	err = fmt.Errorf("failed attempt to retrieve .%s zone config: %v",
+		config.NamedZonesByID[id], err)
+	return config.ZoneConfig{}, err
 }

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1600,6 +1600,6 @@ func TestSystemZoneConfigs(t *testing.T) {
 	zoneConfig = config.DefaultZoneConfig()
 	zoneConfig.NumReplicas += 2
 	config.TestingSetZoneConfig(keys.SystemRangesID, zoneConfig)
-	expectedReplicas += 8
+	expectedReplicas += 6
 	testutils.SucceedsSoon(t, waitForReplicas)
 }


### PR DESCRIPTION
Default the .meta zone config to 5 replicas and 1h GC TTL. The higher
replication reflects the relative danger of significant data loss and
unavailability for the meta ranges. The shorter GC TTL reflects the lack
of need for ever performing historical queries on these ranges coupled
with the desire to keep the meta ranges smaller.

See #16266
See #14990