### PR TITLE
log: don't crash on nil ReportingSettings

### DIFF
--- a/pkg/migration/sqlmigrations/main_test.go
+++ b/pkg/migration/sqlmigrations/main_test.go
@@ -21,20 +21,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func TestMain(m *testing.M) {
 	security.SetAssetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
-
-	// TestLeaseExpiration needs log.ReportingSettingsSingleton populated as it
-	// calls log.Fatal.
-	st := cluster.MakeClusterSettings()
-	f := log.ReportingSettings(st.ReportingSettings)
-	log.ReportingSettingsSingleton.Store(&f)
 
 	os.Exit(m.Run())
 }

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -151,8 +151,9 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 
 		// We load the ReportingSettings from the a global singleton in this
 		// call path. See the singleton's comment for a rationale.
-		reportingSettings := (ReportingSettingsSingleton.Load()).(*ReportingSettings)
-		sendCrashReport(ctx, *reportingSettings, reportable, depth+1)
+		if reportingSettings, ok := (ReportingSettingsSingleton.Load()).(*ReportingSettings); ok {
+			sendCrashReport(ctx, *reportingSettings, reportable, depth+1)
+		}
 	}
 	// MakeMessage already added the tags when forming msg, we don't want
 	// eventInternal to prepend them again.


### PR DESCRIPTION
I could alternatively have populated the singleton from every `main_test.go`,
but that seems more trouble than it's worth.

cc @nvanbenschoten

Closes #17620.