### PR TITLE
sql: return correct pgerror code for CHECK errors

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -126,7 +126,8 @@ func (c *checkHelper) check(ctx *parser.EvalContext) error {
 			return err
 		} else if !res && d != parser.DNull {
 			// Failed to satisfy CHECK constraint.
-			return fmt.Errorf("failed to satisfy CHECK constraint (%s)", expr)
+			return pgerror.NewErrorf(pgerror.CodeCheckViolationError,
+				"failed to satisfy CHECK constraint (%s)", expr)
 		}
 	}
 	return nil

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -17,13 +17,13 @@ ALTER TABLE t1 DROP COLUMN to_delete
 statement ok
 INSERT INTO t1 (a, b) VALUES (4, -2)
 
-statement error pq: failed to satisfy CHECK constraint \(a > 0\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(a > 0\)
 INSERT INTO t1 VALUES (-3, -1)
 
-statement error pq: failed to satisfy CHECK constraint \(b < 0\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(b < 0\)
 INSERT INTO t1 VALUES (3, 1)
 
-statement error pq: failed to satisfy CHECK constraint \(b > -100\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(b > -100\)
 INSERT INTO t1 VALUES (3, -101)
 
 statement ok
@@ -38,7 +38,7 @@ INSERT INTO t1 (b) VALUES (-1)
 statement ok
 CREATE TABLE t2 (a INT DEFAULT -1 CHECK (a >= 0), b INT CHECK (b <= 0), CHECK (b < a))
 
-statement error pq: failed to satisfy CHECK constraint \(a >= 0\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(a >= 0\)
 INSERT INTO t2 (b) VALUES (-2)
 
 ### Rename column with check constraint
@@ -46,10 +46,10 @@ INSERT INTO t2 (b) VALUES (-2)
 statement ok
 ALTER TABLE t2 RENAME COLUMN b TO c
 
-statement error pq: failed to satisfy CHECK constraint \(c <= 0\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(c <= 0\)
 INSERT INTO t2 (a, c) VALUES (2, 1)
 
-statement error pq: failed to satisfy CHECK constraint \(c < a\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(c < a\)
 INSERT INTO t2 (a, c) VALUES (0, 0)
 
 statement ok
@@ -61,7 +61,7 @@ CREATE TABLE t3 (a INT, b INT CHECK (b < a))
 statement ok
 INSERT INTO t3 (a, b) VALUES (3, 2)
 
-statement error pq: failed to satisfy CHECK constraint \(b < a\)
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(b < a\)
 INSERT INTO t3 (a, b) VALUES (2, 3)
 
 # Verify we don't accept COUNT(*)
@@ -107,7 +107,7 @@ CREATE TABLE t4 (a INT, b INT DEFAULT 5, c INT, d INT, CHECK (a < b), CONSTRAINT
 statement ok
 INSERT INTO t4 (a, b) VALUES (2, 3)
 
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 INSERT INTO t4 (a) VALUES (6)
 
 statement ok
@@ -116,7 +116,7 @@ INSERT INTO t4 VALUES (1, 2, 3, 4)
 statement ok
 INSERT INTO t4 VALUES (NULL, 2, 22, NULL)
 
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 INSERT INTO t4 VALUES (1, 2, 3, 19)
 
 query II
@@ -124,13 +124,13 @@ SELECT * from t3
 ----
 3 2
 
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 UPDATE t3 SET b = 3 WHERE a = 3
 
 statement ok
 UPDATE t3 SET b = 1 WHERE a = 3
 
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 UPDATE t4 SET a = 2 WHERE c = 3
 
 statement ok
@@ -139,21 +139,21 @@ UPDATE t4 SET a = 0 WHERE c = 3
 statement ok
 CREATE TABLE t5 (k INT PRIMARY KEY, a INT, b int CHECK (a > b))
 
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING
 
 statement ok
 INSERT INTO t5 VALUES (1, 10, 9) ON CONFLICT (k) DO NOTHING
 
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 INSERT INTO t5 VALUES (1, 10, 20) ON CONFLICT (k) DO NOTHING
 
 # n.b. the fully-qualified name below is required, as there are two providers of
 # the column named `k` here, the original table and the `excluded` pseudo-table.
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = 12 WHERE t5.k = 2
 
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 UPSERT INTO t5 VALUES (2, 11, 12)
 
 statement ok
@@ -174,13 +174,13 @@ SELECT * FROM t5
 1 10  9
 2 11  9
 
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = 12 WHERE t5.k = 2
 
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 UPSERT INTO t5 VALUES (2, 11, 12)
 
-statement error failed to satisfy CHECK constraint
+statement error pgcode 23514 failed to satisfy CHECK constraint
 INSERT INTO t5 VALUES (2, 11, 12) ON CONFLICT (k) DO UPDATE SET b = t5.a + 1 WHERE t5.k = 2
 
 query III rowsort


### PR DESCRIPTION
Same issue as #16836 except for CHECK constraints.