### PR TITLE
sql: Throw error earlier for a non null column without a default.

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -83,6 +83,17 @@ func (n *alterTableNode) Start(params runParams) error {
 			if err != nil {
 				return err
 			}
+			// We're checking to see if a user is trying add a non-nullable column without a default to a
+			// non empty table by scanning the primary index span with a limit of 1 to see if any key exists.
+			if !col.Nullable && col.DefaultExpr == nil {
+				kvs, err := params.p.txn.Scan(params.ctx, n.tableDesc.PrimaryIndexSpan().Key, n.tableDesc.PrimaryIndexSpan().EndKey, 1)
+				if err != nil {
+					return err
+				}
+				if len(kvs) > 0 {
+					return sqlbase.NewNonNullViolationError(col.Name)
+				}
+			}
 			_, dropped, err := n.tableDesc.FindColumnByName(d.Name)
 			if err == nil {
 				if dropped {

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -72,12 +72,6 @@ func (cb *columnBackfiller) init() error {
 	// colIdxMap maps ColumnIDs to indices into desc.Columns and desc.Mutations.
 	var colIdxMap map[sqlbase.ColumnID]int
 
-	// Note if there is a new non nullable column with no default value.
-	// If that's the case, and we end up reading a non-zero amount of data,
-	// we need a throw an error since the old columns will already violate the
-	// not null constraint.
-	// TODO(jordan): detect this earlier. #14455
-	addingNonNullableColumn := false
 	if len(desc.Mutations) > 0 {
 		for _, m := range desc.Mutations {
 			if ColumnMutationFilter(m) {
@@ -85,9 +79,6 @@ func (cb *columnBackfiller) init() error {
 				case sqlbase.DescriptorMutation_ADD:
 					desc := *m.GetColumn()
 					cb.added = append(cb.added, desc)
-					if desc.DefaultExpr == nil && !desc.Nullable {
-						addingNonNullableColumn = true
-					}
 				case sqlbase.DescriptorMutation_DROP:
 					cb.dropped = append(cb.dropped, *m.GetColumn())
 				}
@@ -100,7 +91,7 @@ func (cb *columnBackfiller) init() error {
 	}
 
 	cb.updateCols = append(cb.added, cb.dropped...)
-	if len(cb.dropped) > 0 || addingNonNullableColumn || len(defaultExprs) > 0 {
+	if len(cb.dropped) > 0 || len(defaultExprs) > 0 {
 		// Populate default values.
 		cb.updateExprs = make([]parser.TypedExpr, len(cb.updateCols))
 		for j := range cb.added {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -407,6 +407,8 @@ CREATE INDEX foo ON t.test (v)
 	}
 }
 
+// checkTableKeyCount returns the number of KVs in the DB, the multiple should be the
+// number of columns.
 func checkTableKeyCount(ctx context.Context, kvDB *client.DB, multiple int, maxValue int) error {
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 	tablePrefix := roachpb.Key(keys.MakeTablePrefix(uint32(tableDesc.ID)))
@@ -1561,7 +1563,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	// Create a column that is not NULL. This schema change doesn't return an
 	// error only because we've turned off the synchronous execution path; it
 	// will eventually fail when run by the asynchronous path.
-	if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD a INT NOT NULL, ADD c INT`); err != nil {
+	if _, err := sqlDB.Exec(`ALTER TABLE t.test ADD a INT DEFAULT 0 UNIQUE, ADD c INT`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1588,7 +1590,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	}
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-	if e := 7; e != len(tableDesc.Mutations) {
+	if e := 8; e != len(tableDesc.Mutations) {
 		t.Fatalf("e = %d, v = %d", e, len(tableDesc.Mutations))
 	}
 


### PR DESCRIPTION
Before when a user would specify a non null column without a
default for a non-empty table, we wouldn't validate this until the
dist sql layer. This would then result in a rollback of the mutation.

Now we do this check right in the sql layer so we can fail eariler
without a rollback.

Closes #14455