### PR TITLE
sql/jobs: ignore duplicate registrations during resumptions

### DIFF
--- a/pkg/sql/jobs/registry_test.go
+++ b/pkg/sql/jobs/registry_test.go
@@ -134,7 +134,7 @@ func TestRegistryRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := registry.register(42, &Job{}); !testutils.IsError(err, "already tracking job ID") {
+	if err := registry.register(42, &Job{}); !testutils.IsError(err, "job 42 is already registered") {
 		t.Fatalf("expected 'already tracking job ID', but got '%s'", err)
 	}
 


### PR DESCRIPTION
Sorry to keep sending PRs your way, @a-robinson. Hopefully this is the last of them for a while.

---

TestBackupRestoreControlJob would flake approximately once every hundred
iterations due to a double resumption bug that would fail the job.  For
1.1, we won't be able to avoid the double resumption, but it's harmless
so we can simply ignore it. See the comment within for details.

Fixes #17631.