### PR TITLE
build,scripts,acceptance: Use newer base image on GCE

### DIFF
--- a/build/jepsen/terraform/variables.tf
+++ b/build/jepsen/terraform/variables.tf
@@ -24,7 +24,7 @@ variable "gce_zone" {
 
 # GCE image name.
 variable "gce_image" {
-  default = "ubuntu-os-cloud/ubuntu-1604-xenial-v20160815"
+  default = "ubuntu-os-cloud/ubuntu-1604-lts"
 }
 
 # Name of the ssh key pair to use for GCE instances.

--- a/pkg/acceptance/terraform/gce/variables.tf
+++ b/pkg/acceptance/terraform/gce/variables.tf
@@ -46,7 +46,7 @@ variable "gce_zone" {
 }
 
 variable "gce_image" {
-  default = "ubuntu-os-cloud/ubuntu-1604-xenial-v20160815"
+  default = "ubuntu-os-cloud/ubuntu-1604-lts"
 }
 
 variable "gce_machine_type" {

--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -14,7 +14,7 @@ case ${1-} in
            --network "default" \
            --maintenance-policy "MIGRATE" \
            --image-project "ubuntu-os-cloud" \
-           --image "ubuntu-1604-xenial-v20170113" \
+           --image "ubuntu-1604-lts" \
            --boot-disk-size "100" \
            --boot-disk-type "pd-ssd" \
            --boot-disk-device-name "${NAME}"


### PR DESCRIPTION
Improve instance start-up time by pre-installing newer base packages.