### PR TITLE
storage: Re-add replica to replicate queue after rebalancing

### DIFF
--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -490,6 +490,7 @@ func (rq *replicateQueue) processOneChange(
 					ctx, repl, rebalanceReplica, desc, SnapshotRequest_REBALANCE); err != nil {
 					return false, err
 				}
+				return true, nil
 			}
 		}
 


### PR DESCRIPTION
I broke this in 24ce72220b5f2d35e165409e90bf65ec8d4db690

This may be very slightly affecting the accuracy of your testing of #17644, since the replicate queue would tell you that it's ok to transfer the lease before down-replicating has happened.