### PR TITLE
cherrypick: sql: two bugfixes to fks that use a partial index

### DIFF
--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -594,6 +594,11 @@ func (p *planner) CreateTable(ctx context.Context, n *parser.CreateTable) (planN
 	return &createTableNode{p: p, n: n, dbDesc: dbDesc, sourcePlan: sourcePlan}, nil
 }
 
+// hoistConstraints finds column constraints defined inline with the columns
+// and moves them into n.Defs as constraints. For example, the foreign key
+// constraint in `CREATE TABLE foo (a INT REFERENCES bar(a))` gets pulled into
+// a top level fk constraint like
+// `CREATE TABLE foo (a int CONSTRAINT .. FOREIGN KEY(a) REFERENCES bar(a)`.
 func hoistConstraints(n *parser.CreateTable) {
 	for _, d := range n.Defs {
 		if col, ok := d.(*parser.ColumnTableDef); ok {

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -450,7 +450,7 @@ func (p *planner) showCreateTable(
 			}
 			fmt.Fprintf(&buf, ",\n\tCONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)",
 				parser.Name(fk.Name),
-				quoteNames(idx.ColumnNames...),
+				quoteNames(idx.ColumnNames[0:idx.ForeignKey.SharedPrefixLen]...),
 				parser.Name(fkTable.Name),
 				quoteNames(fkIdx.ColumnNames...),
 			)

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -312,8 +312,8 @@ func makeBaseFKHelper(
 func (f baseFKHelper) check(ctx context.Context, values parser.Datums) (parser.Datums, error) {
 	var key roachpb.Key
 	if values != nil {
-		keyBytes, _, err := EncodeIndexKey(
-			f.searchTable, f.searchIdx, f.ids, values, f.searchPrefix)
+		keyBytes, _, err := EncodePartialIndexKey(
+			f.searchTable, f.searchIdx, f.prefixLen, f.ids, values, f.searchPrefix)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/testdata/logic_test/fk
+++ b/pkg/sql/testdata/logic_test/fk
@@ -468,6 +468,17 @@ refpairs  refpairs_a_b_c_idx  false   2    b       ASC        false    false
 refpairs  refpairs_a_b_c_idx  false   3    c       ASC        false    false
 refpairs  refpairs_a_b_c_idx  false   4    rowid   ASC        false    true
 
+query TT
+SHOW CREATE TABLE refpairs
+----
+refpairs  CREATE TABLE refpairs (
+    a INT NULL,
+    b STRING NULL,
+    c INT NULL,
+    CONSTRAINT fk_a_ref_pairs FOREIGN KEY (a, b) REFERENCES pairs (src, dest),
+    FAMILY "primary" (a, b, c, rowid)
+)
+
 statement error foreign key violation: value \[100 'two'\] not found in pairs@pairs_src_dest_key \[src dest\]
 INSERT INTO refpairs VALUES (100, 'two'), (200, 'two')
 

--- a/pkg/sql/testdata/logic_test/fk
+++ b/pkg/sql/testdata/logic_test/fk
@@ -472,13 +472,16 @@ statement error foreign key violation: value \[100 'two'\] not found in pairs@pa
 INSERT INTO refpairs VALUES (100, 'two'), (200, 'two')
 
 statement ok
-INSERT INTO refpairs VALUES (100, 'one'), (200, 'two')
+INSERT INTO refpairs VALUES (100, 'one', 3), (200, 'two', null)
 
 statement error foreign key violation: values \[200 'two'\] in columns \[src dest\] referenced in table "refpairs"
 UPDATE pairs SET dest = 'too' WHERE id = 2
 
 statement error foreign key violation: values \[200 'two'\] in columns \[src dest\] referenced in table "refpairs"
 DELETE FROM pairs WHERE id = 2
+
+statement error foreign key violation: values \[100 'one'\] in columns \[src dest\] referenced in table "refpairs"
+DELETE FROM pairs WHERE id = 1
 
 # since PKs are handled differently than other indexes, check pk<->pk ref with no other indexes in play.
 statement ok


### PR DESCRIPTION
Cherrypick of #17638.

Previously, tables with foreign key references that were a prefix of a pre-existing index could have their foreign key constraints violated by deletion from the referenced table.

This means that any tables created on 1.0 (and earlier) versions with foreign key constraints on an index prefix might have constraint violations if rows were deleted from the referenced table.

The tests missed this case because of an unhappy coincidence - the proximal cause of the failure mode was that the key into the referencing index was encoded with the full length of the referencing index, even though the foreign key itself had less columns that that index. This
caused the key to contain NULL values at the end. The test case that was supposed to guard against this problem had NULL values in the referencing value at the end positions of the key, so a match was found and the deletion was prevented.

Also, SHOW CREATE TABLE for tables with such foreign keys produced incorrect output.

Fixes #17626.

cc @cockroachdb/release 