### PR TITLE
distsql: use temp storage by default

### DIFF
--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -583,7 +583,7 @@ func MakeClusterSettings(minVersion, serverVersion roachpb.Version) *Settings {
 	s.DistSQLUseTempStorage = r.RegisterBoolSetting(
 		"sql.defaults.distsql.tempstorage",
 		"set to true to enable use of disk for larger distributed sql queries",
-		false,
+		true,
 	)
 
 	s.DistSQLUseTempStorageSorts = r.RegisterBoolSetting(

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -73,7 +73,7 @@ server.remote_debugging.mode                       local          s     set to e
 server.time_until_store_dead                       5m0s           d     the time after which if there is no new gossiped information about a store, it is considered dead
 server.web_session_timeout                         168h0m0s       d     the duration that a newly created web session will be valid
 sql.defaults.distsql                               0              e     Default distributed SQL execution mode [off = 0, auto = 1, on = 2]
-sql.defaults.distsql.tempstorage                   false          b     set to true to enable use of disk for larger distributed sql queries
+sql.defaults.distsql.tempstorage                   true           b     set to true to enable use of disk for larger distributed sql queries
 sql.defaults.distsql.tempstorage.joins             true           b     set to true to enable use of disk for distributed sql joins. sql.defaults.distsql.tempstorage must be true
 sql.defaults.distsql.tempstorage.sorts             true           b     set to true to enable use of disk for distributed sql sorts. sql.defaults.distsql.tempstorage must be true
 sql.distsql.distribute_index_joins                 true           b     if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader


### PR DESCRIPTION
Tested external storage on the TPC-H scalefactor 10 dataset and as discussed in last week's meeting, turning the cluster setting on by default.