### PR TITLE
sql: typo in comment

### DIFF
--- a/pkg/sql/mon/bytes_usage.go
+++ b/pkg/sql/mon/bytes_usage.go
@@ -506,7 +506,7 @@ func MakeStandaloneBudget(capacity int64) BoundAccount {
 	return BoundAccount{BytesAccount: BytesAccount{curAllocated: capacity}}
 }
 
-// MakeBoundAccount greates a BoundAccount connected to the given monitor.
+// MakeBoundAccount creates a BoundAccount connected to the given monitor.
 func (mm *BytesMonitor) MakeBoundAccount() BoundAccount {
 	return BoundAccount{mon: mm}
 }


### PR DESCRIPTION
Found when chasing a memory accounting rabbithole.