### PR TITLE
ui: Make graph tooltip more visible

### DIFF
--- a/pkg/ui/src/views/cluster/components/visualization/index.tsx
+++ b/pkg/ui/src/views/cluster/components/visualization/index.tsx
@@ -52,12 +52,12 @@ export default class extends React.Component<VisualizationProps, {}> {
     return (
       <div className={vizClasses}>
         <div className="visualization__header">
-          <div className="visualization__title">
+          <span className="visualization__title">
             {title}
-          </div>
+          </span>
           {
             this.props.subtitle ?
-              <div className="visualization__subtitle">{this.props.subtitle}</div>
+              <span className="visualization__subtitle">{this.props.subtitle}</span>
               : null
           }
           {

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -38,41 +38,43 @@ $viz-sides = 62px
       align-items center
 
   &__header
+    display flex
+    justify-content center
+    align-items center
     padding 15px 25px 0
-    clearfix()
-    text-align center
 
   &__title
     font-size 14px
     font-family Lato-Bold
     color $body-color
-    display inline
 
   &__subtitle
     color $tooltip-color
     margin-left 5px
     font-size 12px
     font-family Lato-Regular
-    display inline
 
   &__spinner
     width 40px
     height 40px
 
   &__tooltip
-    float right
+    width 36px  // Reserve space for 10px padding around centered 16px icon
+    height 16px
 
   &__tooltip-hover-area
-    padding 5px 10px
+    width 100%
+    padding 0px 10px
 
   &__info-icon
-    width 12px
-    height 12px
+    width 16px
+    height 16px
     border-radius 50%
     border 1px solid $tooltip-color
-    font-size 10px
+    font-size 12px
+    line-height 14px  // Visual tweak to vertically center the exclamation mark
+    text-align center
     color $tooltip-color
-    line-height 10px
 
   .hover-tooltip--hovered &__info-icon
     border-color $body-color

--- a/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
+++ b/pkg/ui/src/views/shared/components/toolTip/tooltip.styl
@@ -37,7 +37,7 @@
     position absolute
     top -10px
     left 100%
-    width 300px
+    width 400px
     padding 10px
     border-radius 5px
     border 1px solid rgba(0, 0, 0, .1)


### PR DESCRIPTION
Improves the visibility of the graph icon by moving it next to the graph
title and increasing its size. The visualization CSS now uses flexbox to
center graph title content.

Resolves #16366

<img width="1301" alt="screen shot 2017-08-15 at 5 37 20 pm" src="https://user-images.githubusercontent.com/6969858/29338218-3a35778a-81e2-11e7-9158-708a4d5ddee1.png">
