### PR TITLE
cherrypick: sql: disallow AS OF SYSTEM TIME 0, add more AS OF tests

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -115,45 +115,50 @@ func TestAsOfTime(t *testing.T) {
 	}
 
 	// Future queries shouldn't work.
-	if err := db.QueryRow("SELECT a FROM d.t AS OF SYSTEM TIME '2200-01-01'").Scan(&i); err == nil {
-		t.Fatal("expected error")
-	} else if !testutils.IsError(err, "pq: cannot specify timestamp in the future") {
+	if err := db.QueryRow("SELECT a FROM d.t AS OF SYSTEM TIME '2200-01-01'").Scan(&i); !testutils.IsError(err, "pq: AS OF SYSTEM TIME: cannot specify timestamp in the future") {
 		t.Fatal(err)
 	}
 
 	// Verify queries with positive scale work properly.
-	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1e1"); err == nil {
-		t.Fatal("expected error")
-	} else if !testutils.IsError(err, `pq: database "d" does not exist`) {
+	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1e1"); !testutils.IsError(err, `pq: database "d" does not exist`) {
 		t.Fatal(err)
 	}
 
 	// Verify queries with large exponents error properly.
-	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1e40"); err == nil {
-		t.Fatal("expected error")
-	} else if !testutils.IsError(err, "value out of range") {
+	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1e40"); !testutils.IsError(err, "value out of range") {
 		t.Fatal(err)
 	}
 
 	// Verify logical parts parse with < 10 digits.
-	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1.123456789"); err == nil {
-		t.Fatal("expected error")
-	} else if !testutils.IsError(err, `pq: database "d" does not exist`) {
+	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1.123456789"); !testutils.IsError(err, `pq: database "d" does not exist`) {
 		t.Fatal(err)
 	}
 
 	// Verify logical parts parse with == 10 digits.
-	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1.1234567890"); err == nil {
-		t.Fatal("expected error")
-	} else if !testutils.IsError(err, `pq: database "d" does not exist`) {
+	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1.1234567890"); !testutils.IsError(err, `pq: database "d" does not exist`) {
 		t.Fatal(err)
 	}
 
 	// Too much logical precision is an error.
-	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1.12345678901"); err == nil {
-		t.Fatal("expected error")
-	} else if !testutils.IsError(err, "logical part has too many digits") {
+	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 1.12345678901"); !testutils.IsError(err, "logical part has too many digits") {
 		t.Fatal(err)
+	}
+
+	// Ditto, as string.
+	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME '1.12345678901'"); !testutils.IsError(err, "logical part has too many digits") {
+		t.Fatal(err)
+	}
+
+	// String values that are neither timestamps nor decimals are an error.
+	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 'xxx'"); !testutils.IsError(err, "value is neither interval nor decimal") {
+		t.Fatal(err)
+	}
+
+	// Zero is not a valid value.
+	for _, zero := range []string{"0", "'0'", "0.0000000000", "'0.0000000000'"} {
+		if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME " + zero); !testutils.IsError(err, "zero timestamp is invalid") {
+			t.Fatal(err)
+		}
 	}
 
 	// Old queries shouldn't work.
@@ -164,9 +169,7 @@ func TestAsOfTime(t *testing.T) {
 	}
 
 	// Subqueries shouldn't work.
-	if _, err := db.Query(fmt.Sprintf("SELECT (SELECT a FROM d.t AS OF SYSTEM TIME %s)", tsVal1)); err == nil {
-		t.Fatal("expected error")
-	} else if !testutils.IsError(err, "pq: unexpected AS OF SYSTEM TIME") {
+	if _, err := db.Query(fmt.Sprintf("SELECT (SELECT a FROM d.t AS OF SYSTEM TIME %s)", tsVal1)); !testutils.IsError(err, "pq: unexpected AS OF SYSTEM TIME") {
 		t.Fatal(err)
 	}
 
@@ -181,9 +184,7 @@ func TestAsOfTime(t *testing.T) {
 	}
 
 	// Can't use in a transaction.
-	if _, err := db.Query(fmt.Sprintf("BEGIN; SELECT a FROM d.t AS OF SYSTEM TIME %s; COMMIT;", tsVal1)); err == nil {
-		t.Fatal("expected error")
-	} else if !testutils.IsError(err, "pq: unexpected AS OF SYSTEM TIME") {
+	if _, err := db.Query(fmt.Sprintf("BEGIN; SELECT a FROM d.t AS OF SYSTEM TIME %s; COMMIT;", tsVal1)); !testutils.IsError(err, "pq: unexpected AS OF SYSTEM TIME") {
 		t.Fatal(err)
 	}
 }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1792,7 +1792,6 @@ func checkResultType(typ parser.Type) error {
 func EvalAsOfTimestamp(
 	evalCtx *parser.EvalContext, asOf parser.AsOfClause, max hlc.Timestamp,
 ) (hlc.Timestamp, error) {
-	var ts hlc.Timestamp
 	te, err := asOf.Expr.TypeCheck(nil, parser.TypeString)
 	if err != nil {
 		return hlc.Timestamp{}, err
@@ -1801,6 +1800,10 @@ func EvalAsOfTimestamp(
 	if err != nil {
 		return hlc.Timestamp{}, err
 	}
+
+	var ts hlc.Timestamp
+	var convErr error
+
 	switch d := d.(type) {
 	case *parser.DString:
 		s := string(*d)
@@ -1811,23 +1814,30 @@ func EvalAsOfTimestamp(
 			break
 		}
 		// Attempt to parse as a decimal.
-		if dec, _, err := apd.NewFromString(s); err == nil {
-			if ts, err = decimalToHLC(dec); err == nil {
-				break
-			}
+		if dec, _, err := apd.NewFromString(s); err != nil {
+			// Override the error. It would be misleading to fail with a
+			// DECIMAL conversion error if a user was attempting to use a
+			// timestamp string and the conversion above failed.
+			convErr = errors.Errorf("AS OF SYSTEM TIME: value is neither interval nor decimal")
+		} else {
+			ts, convErr = decimalToHLC(dec)
 		}
-		return hlc.Timestamp{}, fmt.Errorf("could not parse '%s' as timestamp", s)
 	case *parser.DInt:
 		ts.WallTime = int64(*d)
 	case *parser.DDecimal:
-		if ts, err = decimalToHLC(&d.Decimal); err != nil {
-			return hlc.Timestamp{}, err
-		}
+		ts, convErr = decimalToHLC(&d.Decimal)
 	default:
-		return hlc.Timestamp{}, fmt.Errorf("unexpected AS OF SYSTEM TIME argument: %s (%T)", d.ResolvedType(), d)
+		convErr = errors.Errorf("AS OF SYSTEM TIME: expected timestamp, got %s (%T)", d.ResolvedType(), d)
 	}
-	if max.Less(ts) {
-		return hlc.Timestamp{}, fmt.Errorf("cannot specify timestamp in the future")
+	if convErr != nil {
+		return ts, convErr
+	}
+
+	var zero hlc.Timestamp
+	if ts == zero {
+		return ts, errors.Errorf("AS OF SYSTEM TIME: zero timestamp is invalid")
+	} else if max.Less(ts) {
+		return ts, errors.Errorf("AS OF SYSTEM TIME: cannot specify timestamp in the future")
 	}
 	return ts, nil
 }
@@ -1840,7 +1850,7 @@ func decimalToHLC(d *apd.Decimal) (hlc.Timestamp, error) {
 	parts := strings.SplitN(s, ".", 2)
 	nanos, err := strconv.ParseInt(parts[0], 10, 64)
 	if err != nil {
-		return hlc.Timestamp{}, errors.Wrap(err, "parse AS OF SYSTEM TIME argument")
+		return hlc.Timestamp{}, errors.Wrap(err, "AS OF SYSTEM TIME: parsing argument")
 	}
 	var logical int64
 	if len(parts) > 1 {
@@ -1850,13 +1860,13 @@ func decimalToHLC(d *apd.Decimal) (hlc.Timestamp, error) {
 		const logicalLength = 10
 		p := parts[1]
 		if lp := len(p); lp > logicalLength {
-			return hlc.Timestamp{}, errors.Errorf("bad AS OF SYSTEM TIME argument: logical part has too many digits")
+			return hlc.Timestamp{}, errors.Errorf("AS OF SYSTEM TIME: logical part has too many digits")
 		} else if lp < logicalLength {
 			p += strings.Repeat("0", logicalLength-lp)
 		}
 		logical, err = strconv.ParseInt(p, 10, 32)
 		if err != nil {
-			return hlc.Timestamp{}, errors.Wrap(err, "parse AS OF SYSTEM TIME argument")
+			return hlc.Timestamp{}, errors.Wrap(err, "AS OF SYSTEM TIME: parsing argument")
 		}
 	}
 	return hlc.Timestamp{


### PR DESCRIPTION
Fixes a client-induced panic.

1.0 counterpart of #17680.
