### PR TITLE
sql: bugfix for retries w/ streaming results

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -825,11 +825,11 @@ func (e *Executor) execParsed(
 				session.DefaultIsolationLevel,
 				roachpb.NormalUserPriority,
 			)
+			txnState.autoRetry = true
 		} else {
 			// If we are in a txn, the first batch get auto-retried.
 			txnState.autoRetry = txnState.State() == FirstBatch
 		}
-		execOpt.AutoRetry = txnState.autoRetry
 		if txnState.State() == NoTxn {
 			panic("we failed to initialize a txn")
 		}
@@ -877,12 +877,26 @@ func (e *Executor) execParsed(
 
 			return err
 		}
-		// This is where the magic happens - we ask db to run a KV txn and possibly retry it.
 		txn := txnState.mu.txn // this might be nil if the txn was already aborted.
-		err := txn.Exec(session.Ctx(), execOpt, txnClosure)
+		var err error
+		for {
+			// This is where the magic happens - we ask the kv database to run a
+			// transaction.
+			err = txn.Exec(session.Ctx(), execOpt, txnClosure)
+			_, retryable := err.(*roachpb.HandledRetryableTxnError)
 
-		if err != nil && (log.V(2) || e.cfg.Settings.LogStatementsExecuteEnabled.Get()) {
-			log.Infof(session.Ctx(), "execParsed: error: %v", err)
+			if err != nil {
+				if !retryable && (log.V(2) || e.cfg.Settings.LogStatementsExecuteEnabled.Get()) {
+					log.Infof(session.Ctx(), "execParsed: error: %v", err)
+				}
+			}
+
+			if !retryable || !txnState.autoRetry || groupResultWriter.ResultsSentToClient() {
+				break
+			} else {
+				log.VEventf(session.Ctx(), 2, "automatically retrying transaction: %s because of error: %s",
+					txn.DebugName(), err)
+			}
 		}
 
 		// Update the Err field of the last result if the error was coming from
@@ -1161,8 +1175,7 @@ func (e *Executor) execStmtsInCurrentTxn(
 			case Open, FirstBatch:
 				err = e.execStmtInOpenTxn(
 					session, stmt, pinfo, txnPrefix && (i == 0), /* firstInTxn */
-					avoidCachedDescriptors, automaticRetryCount, statementResultWriter,
-					groupResultWriter.ResultsSentToClient)
+					avoidCachedDescriptors, automaticRetryCount, statementResultWriter)
 			case Aborted, RestartWait:
 				err = e.execStmtInAbortedTxn(session, stmt, groupResultWriter)
 			case CommitWait:
@@ -1377,7 +1390,6 @@ func (e *Executor) execStmtInOpenTxn(
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
 	statementResultWriter StatementResultWriter,
-	resultsSentToClient func() bool,
 ) (err error) {
 	txnState := &session.TxnState
 	if !txnState.TxnIsOpen() {
@@ -1396,6 +1408,9 @@ func (e *Executor) execStmtInOpenTxn(
 		if err != nil {
 			if !txnState.TxnIsOpen() {
 				panic(fmt.Sprintf("unexpected txnState when cleaning up: %v", txnState.State()))
+			}
+			if statementResultWriter.ResultsSentToClient() {
+				txnState.autoRetry = false
 			}
 			txnState.updateStateAndCleanupOnErr(err, e)
 
@@ -1428,8 +1443,7 @@ func (e *Executor) execStmtInOpenTxn(
 				// client.Txn.
 				roachpb.Transaction{},
 			)
-		} else if txnState.State() == FirstBatch &&
-			!canStayInFirstBatchState(stmt) && !resultsSentToClient() {
+		} else if txnState.State() == FirstBatch && !canStayInFirstBatchState(stmt) {
 			// Transition from FirstBatch to Open except in the case of special
 			// statements that don't return results to the client. This transition
 			// does not affect the current batch - future statements in it will still

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -816,3 +816,32 @@ SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
 
 statement ok
 ROLLBACK
+
+# Retryable error after results are streamed should be sent back to the client.
+statement error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
+BEGIN; SELECT * from generate_series(1, 10000); SELECT CRDB_INTERNAL.FORCE_RETRY('1s');
+
+query T
+SHOW TRANSACTION STATUS
+----
+Aborted
+
+statement ok
+ROLLBACK
+
+statement error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
+BEGIN; SAVEPOINT cockroach_restart; SELECT * from generate_series(1, 10000); SELECT CRDB_INTERNAL.FORCE_RETRY('1s');
+
+query T
+SHOW TRANSACTION STATUS
+----
+RestartWait
+
+statement ok
+ROLLBACK
+
+# Retryable error before results are streamed should be retried as normal.
+query I
+BEGIN; SAVEPOINT cockroach_restart; SELECT 1; SELECT CRDB_INTERNAL.FORCE_RETRY('100ms'); COMMIT
+----
+1

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -998,8 +998,6 @@ func (ts *txnState) updateStateAndCleanupOnErr(err error, e *Executor) {
 		ts.resetStateAndTxn(Aborted)
 	} else {
 		// If we got a retriable error, move the SQL txn to the RestartWait state.
-		// Note that TransactionAborted is also a retriable error, handled here;
-		// in this case cleanup for the txn has been done for us under the hood.
 		ts.SetState(RestartWait)
 	}
 }


### PR DESCRIPTION
This moves the responsibility for automatic retries from `txn.Exec` into the executor and ensures that we stop retrying if we have already streamed results.

This is a WIP because it now produces an incorrect state change:

```
root@:26257/> begin; SELECT generate_series(1, 10000); select crdb_internal.force_retry('1s'); end;
pq: restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
root@:26257 RETRY>
```

The correct state for this scenario would be `ERROR`, since we didn't issue a `SAVEPOINT cockroach_restart` before the error occurred.

Fixes #17592.