### PR TITLE
sql: Adding support for bytea hex format

### DIFF
--- a/pkg/sql/parser/constant.go
+++ b/pkg/sql/parser/constant.go
@@ -421,8 +421,9 @@ func (expr *StrVal) ResolveAsType(ctx *SemaContext, typ Type) (Datum, error) {
 		expr.resString = DString(expr.s)
 		return NewDNameFromDString(&expr.resString), nil
 	case TypeBytes:
-		expr.resBytes = DBytes(expr.s)
-		return &expr.resBytes, nil
+		s, err := ParseDByte(expr.s)
+		expr.resBytes = *s
+		return &expr.resBytes, err
 	case TypeBool:
 		return ParseDBool(expr.s)
 	case TypeDate:

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -16,6 +16,7 @@ package parser
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"math/big"
@@ -197,6 +198,18 @@ func ParseDBool(s string) (*DBool, error) {
 		return nil, makeParseError(s, TypeBool, err)
 	}
 	return MakeDBool(DBool(b)), nil
+}
+
+// ParseDByte parses a string representation of hex encoded binary data.
+func ParseDByte(s string) (*DBytes, error) {
+	if len(s) > 2 && (s[0] == '\\' && (s[1] == 'x' || s[1] == 'X')) {
+		hexstr, err := hex.DecodeString(s[2:])
+		if err != nil {
+			return NewDBytes(DBytes(s)), nil
+		}
+		return NewDBytes(DBytes(hexstr)), nil
+	}
+	return NewDBytes(DBytes(s)), nil
 }
 
 // ParseDUuidFromString parses and returns the *DUuid Datum value represented

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -2419,7 +2419,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 	case *BytesColType:
 		switch t := d.(type) {
 		case *DString:
-			return NewDBytes(DBytes(*t)), nil
+			return ParseDByte(string(*t))
 		case *DCollatedString:
 			return NewDBytes(DBytes(t.Contents)), nil
 		case *DUuid:

--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -103,6 +103,10 @@ func TestEval(t *testing.T) {
 		{`x'636174'`, `b'cat'`},
 		{`X'636174'`, `b'cat'`},
 		{`x'636174'::string`, `'cat'`},
+		{`e'\\x636174'::BYTES`, `b'cat'`},
+		{`e'\\X636174'::BYTES`, `b'cat'`},
+		{`e'\\x636174'::STRING::BYTES`, `b'cat'`},
+		{`e'\\x636174'::STRING`, `e'\\x636174'`},
 		// String concatenation.
 		{`'a' || 'b'`, `'ab'`},
 		{`'a' || (1 + 2)::char`, `'a3'`},


### PR DESCRIPTION
Before this change escaped bytea hex data would be saved as an escaped
string.

After this change binary data with the [e,E]'\\[X,x] prefix will be
parsed as binary.

Closes #15880