### PR TITLE
migrations: populate initial version setting

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -200,15 +200,19 @@ var (
 	SystemPrefix = roachpb.Key{systemPrefixByte}
 	SystemMax    = roachpb.Key{systemMaxByte}
 
+	// BootstrapVersion is the key at which clusters bootstrapped with a version
+	// > 1.0 persist the version at which they were bootstrapped.
+	BootstrapVersionKey = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("bootstrap-version")))
+
 	// MigrationPrefix specifies the key prefix to store all migration details.
 	MigrationPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("system-version/")))
-
-	// MigrationKeyMax is the maximum value for any system migration key.
-	MigrationKeyMax = MigrationPrefix.PrefixEnd()
 
 	// MigrationLease is the key that nodes must take a lease on in order to run
 	// system migrations on the cluster.
 	MigrationLease = roachpb.Key(makeKey(MigrationPrefix, roachpb.RKey("lease")))
+
+	// MigrationKeyMax is the maximum value for any system migration key.
+	MigrationKeyMax = MigrationPrefix.PrefixEnd()
 
 	// NodeLivenessPrefix specifies the key prefix for the node liveness
 	// table.  Note that this should sort before the rest of the system

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -750,7 +750,7 @@ func TestAdminAPIEvents(t *testing.T) {
 		{sql.EventLogCreateDatabase, false, 0, 1},
 		{sql.EventLogDropTable, false, 0, 2},
 		{sql.EventLogCreateTable, false, 0, 3},
-		{sql.EventLogSetClusterSetting, false, 0, 2},
+		{sql.EventLogSetClusterSetting, false, 0, 3},
 		{sql.EventLogCreateTable, true, 0, 3},
 		{sql.EventLogCreateTable, true, -1, 3},
 		{sql.EventLogCreateTable, true, 2, 2},

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -215,7 +215,10 @@ func bootstrapCluster(
 		// first store.
 		if i == 0 {
 			initialValues := GetBootstrapSchema().GetInitialValues()
-			if err := s.BootstrapRange(initialValues); err != nil {
+			// The MinimumVersion is the ServerVersion when we are bootstrapping
+			// a cluster (except in some tests that specifically want to set up
+			// an "old-looking" cluster).
+			if err := s.BootstrapRange(initialValues, bootstrapVersion.MinimumVersion); err != nil {
 				return uuid.UUID{}, err
 			}
 		}

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -208,6 +208,7 @@ func TestBootstrapCluster(t *testing.T) {
 	var expectedKeys = keySlice{
 		testutils.MakeKey(roachpb.Key("\x02"), roachpb.KeyMax),
 		testutils.MakeKey(roachpb.Key("\x03"), roachpb.KeyMax),
+		roachpb.Key("\x04bootstrap-version"),
 		roachpb.Key("\x04node-idgen"),
 		roachpb.Key("\x04store-idgen"),
 	}

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -326,7 +326,7 @@ SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = DEFAULT
 query IIT
 SELECT "targetID", "reportingID", "info"
 FROM system.eventlog
-WHERE "eventType" = 'set_cluster_setting'
+WHERE "eventType" = 'set_cluster_setting' AND info NOT LIKE '%version%'
 ORDER BY "timestamp"
 ----
 0 1 {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"node"}

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -332,16 +332,19 @@ GRANT ALL ON system.lease TO root
 statement ok
 GRANT ALL ON system.lease TO testuser
 
+# NB: the "order by" is necessary or this test is flaky under DistSQL.
+# This is somewhat surprising.
 query T
-select name from system.settings
+select name from system.settings order by name
 ----
 diagnostics.reporting.enabled
+version
 
 statement ok
 INSERT INTO system.settings (name, value) VALUES ('somesetting', 'somevalue')
 
 query TT
-select name, value from system.settings order by name
+select name, value from system.settings where name != 'version' order by name
 ----
 diagnostics.reporting.enabled  true
 somesetting   somevalue

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -76,8 +76,9 @@ func TestQueryCounts(t *testing.T) {
 	// Initialize accum while accounting for system migrations that may have run
 	// DDL statements.
 	accum := queryCounter{
-		ddlCount:  s.MustGetSQLCounter(sql.MetaDdl.Name),
-		miscCount: s.MustGetSQLCounter(sql.MetaMisc.Name),
+		insertCount: 1, // version setting population migration
+		ddlCount:    s.MustGetSQLCounter(sql.MetaDdl.Name),
+		miscCount:   s.MustGetSQLCounter(sql.MetaMisc.Name),
 	}
 
 	for _, tc := range testcases {
@@ -186,7 +187,7 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 	if err := checkCounterEQ(s, sql.MetaTxnCommit, 0); err != nil {
 		t.Error(err)
 	}
-	if err := checkCounterEQ(s, sql.MetaInsert, 1); err != nil {
+	if err := checkCounterEQ(s, sql.MetaInsert, 2); err != nil {
 		t.Error(err)
 	}
 }

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -104,11 +104,12 @@ func (p *planner) showClusterSetting(ctx context.Context, name string) (planNode
 					prevRawVal = []byte(string(*dStr))
 				}
 				// Note that if no entry is found, we pretend that an entry
-				// exists which is the version used for the running binary.
-				// This is a bit awkward, but we have no good way of ensuring
-				// that this entry is written at cluster bootstrap time.
-				// Subject to change. See
-				// https://github.com/cockroachdb/cockroach/issues/17389
+				// exists which is the version used for the running binary. This
+				// may not be 100.00% correct, but it will do. The input is
+				// checked more thoroughly when a user tries to change the
+				// value, and the corresponding sql migration that makes sure
+				// the above select finds something usually runs pretty quickly
+				// when the cluster is bootstrapped.
 				_, obj, err := s.Validate(prevRawVal, nil)
 				if err != nil {
 					return nil, errors.Errorf("unable to read existing value: %s", err)

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -161,7 +161,7 @@ func createTestStoreWithEngine(
 	}
 	stores.AddStore(store)
 	if bootstrap {
-		err := store.BootstrapRange(sqlbase.MakeMetadataSchema().GetInitialValues())
+		err := store.BootstrapRange(sqlbase.MakeMetadataSchema().GetInitialValues(), storeCfg.Settings.Version.ServerVersion)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -757,7 +757,7 @@ func (m *multiTestContext) addStore(idx int) {
 
 		// Bootstrap the initial range on the first store
 		if idx == 0 {
-			err := store.BootstrapRange(sqlbase.MakeMetadataSchema().GetInitialValues())
+			err := store.BootstrapRange(sqlbase.MakeMetadataSchema().GetInitialValues(), cfg.Settings.Version.ServerVersion)
 			if err != nil {
 				m.t.Fatal(err)
 			}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -177,7 +177,7 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 		tc.store.splitQueue.SetDisabled(true)
 
 		if tc.repl == nil && tc.bootstrapMode == bootstrapRangeWithMetadata {
-			if err := tc.store.BootstrapRange(nil); err != nil {
+			if err := tc.store.BootstrapRange(nil, cfg.Settings.Version.ServerVersion); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -144,7 +144,7 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 	); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.BootstrapRange(nil); err != nil {
+	if err := store.BootstrapRange(nil, cfg.Settings.Version.ServerVersion); err != nil {
 		t.Fatal(err)
 	}
 	return store
@@ -213,7 +213,7 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 		}
 
 		// Bootstrap first range.
-		if err := store.BootstrapRange(nil); err != nil {
+		if err := store.BootstrapRange(nil, cfg.Settings.Version.ServerVersion); err != nil {
 			t.Errorf("failure to create first range: %s", err)
 		}
 	}

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -154,7 +154,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 	}
 
 	ltc.Stores.AddStore(ltc.Store)
-	if err := ltc.Store.BootstrapRange(nil); err != nil {
+	if err := ltc.Store.BootstrapRange(nil, cfg.Settings.Version.ServerVersion); err != nil {
 		t.Fatalf("unable to start local test cluster: %s", err)
 	}
 	if err := ltc.Store.Start(ctx, ltc.Stopper); err != nil {


### PR DESCRIPTION
Add a bootstrap version which is populated when a cluster running >1.0 is
bootstrapped. Use it to populate the settings table via a sql migration. At the
same time, prevent `SET CLUSTER SETTING version = 'x'` from working until that
migration has run.

This solves one remaining headache for [version migrations][1] by giving it
authoritative information on the currently running cluster version during
upgrades.

Fixes #17389.

[1]: https://github.com/cockroachdb/cockroach/pull/16977