### PR TITLE
cmd/benchmark: allow custom commands

### DIFF
--- a/pkg/cmd/benchmark/main.go
+++ b/pkg/cmd/benchmark/main.go
@@ -29,9 +29,8 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/perf/storage"
 
@@ -82,98 +81,21 @@ func do(ctx context.Context) error {
 		return errors.Wrap(err, "could not read service account JSON")
 	}
 
-	findArgs := []string{".", "-type", "f", "-name", "*.test"}
-
-	// Find and delete the per-package *.test binaries; we'll be rebuilding
-	// them below.
-	{
-		cmd := exec.CommandContext(ctx, "find", append(findArgs, "-delete")...)
-		cmd.Dir = rootPkg.Dir
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+	var buffers []bytes.Buffer
+	if len(os.Args) > 1 {
+		var outBuf, errBuf bytes.Buffer
+		cmd := exec.CommandContext(ctx, os.Args[0], os.Args[1:]...)
+		cmd.Stdout = &outBuf
+		cmd.Stderr = &errBuf
 		if err := cmd.Run(); err != nil {
-			return errors.Wrap(err, "could not remove old test binaries")
+			return errors.Wrapf(err, "could not run %s: %s", cmd.Args, errBuf.String())
 		}
-	}
-
-	// Rebuild the per-package *.test binaries.
-	{
-		typ := "release-" + runtime.GOOS
-		if strings.HasSuffix(typ, "linux") {
-			typ += "-gnu"
-		}
-
-		cmd := exec.CommandContext(ctx, "make", "-s", "testbuild", "TYPE="+typ)
-		cmd.Dir = rootPkg.Dir
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return errors.Wrap(err, "could not build test binaries")
-		}
-	}
-
-	// Find the per-package *.test binaries we built.
-	var binaries []string
-	{
-		cmd := exec.CommandContext(ctx, "find", findArgs...)
-		cmd.Dir = rootPkg.Dir
-		out, err := cmd.Output()
+		buffers = append(buffers, outBuf)
+	} else {
+		var err error
+		buffers, err = doBenchmarks(ctx, rootPkg)
 		if err != nil {
-			return errors.Wrapf(err, "could not find new test binaries: %s", out)
-		}
-		scanner := bufio.NewScanner(bytes.NewReader(out))
-		for scanner.Scan() {
-			binaries = append(binaries, scanner.Text())
-		}
-		if err := scanner.Err(); err != nil {
-			return errors.Wrap(err, "could not find new test binaries")
-		}
-	}
-
-	buffers := make([]bytes.Buffer, numIterations)
-	for i := range buffers {
-		buffer := &buffers[i]
-
-		if _, err := fmt.Fprintf(
-			buffer,
-			"commit: %s\ncommit-time: %s\nbranch: %s\niteration: %d\nstart-time: %s\n",
-			commit,
-			commitTime,
-			"master",
-			i,
-			timeutil.Now().UTC().Format(time.RFC3339),
-		); err != nil {
-			return errors.Wrapf(err, "could not write header on iteration %d", i)
-		}
-
-		for _, txt := range binaries {
-			binaryPath, err := filepath.Abs(txt)
-			if err != nil {
-				return errors.Wrapf(err, "could not find test binary %s on iteration %d", txt, i)
-			}
-
-			{
-				relativePath, err := filepath.Rel(rootPkg.Dir, binaryPath)
-				if err != nil {
-					return errors.Wrapf(err, "could not get relative path to binary %s on iteration %d", binaryPath, i)
-				}
-				pkgName := path.Join(crdb, filepath.Dir(relativePath))
-
-				if _, err := fmt.Fprintf(buffer, "pkg: %s\n", pkgName); err != nil {
-					return errors.Wrapf(err, "could not write package name %s on iteration %d", pkgName, i)
-				}
-			}
-
-			cmd := exec.CommandContext(ctx, binaryPath, "-test.timeout", "0", "-test.run", "-", "-test.bench", ".", "-test.benchmem")
-			cmd.Dir = filepath.Dir(binaryPath)
-			cmd.Stdout = buffer
-			cmd.Stderr = os.Stderr
-
-			log.Printf("iteration %d running: %s", i, cmd.Args)
-
-			if err := cmd.Run(); err != nil {
-				return errors.Wrapf(err, "could not run test binary %s on iteration %d", binaryPath, i)
-			}
+			return err
 		}
 	}
 
@@ -192,6 +114,19 @@ func do(ctx context.Context) error {
 			if err != nil {
 				return errors.Wrap(err, "could not create upload file")
 			}
+
+			if _, err := fmt.Fprintf(
+				w,
+				"commit: %s\ncommit-time: %s\nbranch: %s\niteration: %d\nstart-time: %s\n",
+				commit,
+				commitTime,
+				"master",
+				i,
+				timeutil.Now().UTC().Format(time.RFC3339),
+			); err != nil {
+				return errors.Wrapf(err, "could not write header on iteration %d", i)
+			}
+
 			if _, err := io.Copy(w, buffer); err != nil {
 				return errors.Wrapf(err, "could not write to upload file")
 			}
@@ -210,4 +145,91 @@ func do(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func doBenchmarks(ctx context.Context, rootPkg *build.Package) ([]bytes.Buffer, error) {
+	findArgs := []string{".", "-type", "f", "-name", "*.test"}
+
+	// Find and delete the per-package *.test binaries; we'll be rebuilding
+	// them below.
+	{
+		cmd := exec.CommandContext(ctx, "find", append(findArgs, "-delete")...)
+		cmd.Dir = rootPkg.Dir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return nil, errors.Wrap(err, "could not remove old test binaries")
+		}
+	}
+
+	// Rebuild the per-package *.test binaries.
+	{
+		typ := "release-" + runtime.GOOS
+		if strings.HasSuffix(typ, "linux") {
+			typ += "-gnu"
+		}
+
+		cmd := exec.CommandContext(ctx, "make", "-s", "testbuild", "TYPE="+typ)
+		cmd.Dir = rootPkg.Dir
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return nil, errors.Wrap(err, "could not build test binaries")
+		}
+	}
+
+	// Find the per-package *.test binaries we built.
+	var binaries []string
+	{
+		cmd := exec.CommandContext(ctx, "find", findArgs...)
+		cmd.Dir = rootPkg.Dir
+		out, err := cmd.Output()
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not find new test binaries: %s", out)
+		}
+		scanner := bufio.NewScanner(bytes.NewReader(out))
+		for scanner.Scan() {
+			binaries = append(binaries, scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			return nil, errors.Wrap(err, "could not find new test binaries")
+		}
+	}
+
+	buffers := make([]bytes.Buffer, numIterations)
+	for i := range buffers {
+		buffer := &buffers[i]
+
+		for _, txt := range binaries {
+			binaryPath, err := filepath.Abs(txt)
+			if err != nil {
+				return nil, errors.Wrapf(err, "could not find test binary %s on iteration %d", txt, i)
+			}
+
+			{
+				relativePath, err := filepath.Rel(rootPkg.Dir, binaryPath)
+				if err != nil {
+					return nil, errors.Wrapf(err, "could not get relative path to binary %s on iteration %d", binaryPath, i)
+				}
+				pkgName := path.Join(crdb, filepath.Dir(relativePath))
+
+				if _, err := fmt.Fprintf(buffer, "pkg: %s\n", pkgName); err != nil {
+					return nil, errors.Wrapf(err, "could not write package name %s on iteration %d", pkgName, i)
+				}
+			}
+
+			cmd := exec.CommandContext(ctx, binaryPath, "-test.timeout", "0", "-test.run", "-", "-test.bench", ".", "-test.benchmem")
+			cmd.Dir = filepath.Dir(binaryPath)
+			cmd.Stdout = buffer
+			cmd.Stderr = os.Stderr
+
+			log.Printf("iteration %d running: %s", i, cmd.Args)
+
+			if err := cmd.Run(); err != nil {
+				return nil, errors.Wrapf(err, "could not run test binary %s on iteration %d", binaryPath, i)
+			}
+		}
+	}
+
+	return buffers, nil
 }


### PR DESCRIPTION
It is now possible to run `benchmark <cmd> [args...]`, which will cause
the program to use the stdout of `<cmd> [args...]` as the "benchmark
results" to be uploaded.

Note that the output of `<cmd> [args...]` must conform to the Go
benchmark data format[0].

https://github.com/golang/proposal/blob/master/design/14313-benchmark-format.md

This will allow us to run manual runs of `roachperf test denim nightly | tee bench.txt && benchmark cat bench.txt` to upload e.g. YCSB results until we have our acceptance infrastructure in order.