### PR TITLE
build: add tc script for use in post-build step

### DIFF
--- a/build/teamcity-assert-clean.sh
+++ b/build/teamcity-assert-clean.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+export BUILDER_HIDE_GOPATH_SRC=1
+
+build/builder.sh /bin/bash -c '! git status --porcelain | read || (git status; git diff -a 1>&2; exit 1)'


### PR DESCRIPTION
if a build is leaving the workspace with uncommited changes, it should fail, rather than the next, unsuspecting build having to deal with them