### PR TITLE
rpc: Set gRPC server KeepaliveEnforcementPolicy

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -113,6 +113,13 @@ func NewServer(ctx *Context) *grpc.Server {
 		// streams/requests on either the client or server.
 		grpc.MaxConcurrentStreams(math.MaxInt32),
 		grpc.RPCDecompressor(snappyDecompressor{}),
+		// By default, gRPC disconnects clients that send "too many" pings,
+		// but we don't really care about that, so configure the server to be
+		// as permissive as possible.
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             time.Nanosecond,
+			PermitWithoutStream: true,
+		}),
 	}
 	// Compression is enabled separately from decompression to allow staged
 	// rollout.


### PR DESCRIPTION
gRPC servers close client connections that send "too many" pings, so
it's only safe to use client configurations that send frequent pings
with servers that have updated their KeepaliveEnforcementPolicy
accordingly.

This manifested in CockroachDB as closed connections between nodes
with log messages containing "EnhanceYourCalm"