### PR TITLE
sqlccl: specify temp directory during local CSV transforms

### DIFF
--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -9,6 +9,8 @@
 package cliccl
 
 import (
+	"os"
+
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
@@ -38,8 +40,8 @@ comment are ignored. Fields are considered null if equal to nullif
 The backup's tables are created in the "csv" database.
 
 It requires approximately 2x the size of the data files of free disk
-space. An intermediate copy will be stored in the OS temp directory,
-and the final copy in the dest directory.
+space. An intermediate copy will be stored in the location specified
+by the --tempdir argument, and the final copy in the dest directory.
 
 For example, if there were a file at /data/names containing:
 
@@ -64,6 +66,7 @@ Then the file could be converted and saved to /data/backup with:
 	flags.StringVar(&csvNullIf, "nullif", "", "if specified, the value of NULL; can specify the empty string")
 	flags.StringVar(&csvComma, "delimiter", "", "if specified, the CSV delimiter instead of a comma")
 	flags.StringVar(&csvComment, "comment", "", "if specified, allows comment lines starting with this character")
+	flags.StringVar(&csvTempDir, "tempdir", os.TempDir(), "directory to store intermediate temp files")
 
 	loadCmds := &cobra.Command{
 		Use:   "load [command]",
@@ -84,6 +87,7 @@ var (
 	csvDest      string
 	csvNullIf    string
 	csvTableName string
+	csvTempDir   string
 )
 
 func runLoadCSV(cmd *cobra.Command, args []string) error {
@@ -125,6 +129,7 @@ func runLoadCSV(cmd *cobra.Command, args []string) error {
 		comment,
 		nullIf,
 		sstMaxSize,
+		csvTempDir,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Change the local CSV transform to take a RocksDB engine instead of
a directory, which allows for correctly supporting the CLI (OS temp)
and server (temp storage) use cases.

This adds a new flag to the `load csv` subcommand: tempdir, which
overrides the OS temp dir used for intermediate storage. Notably the
default is listed in the help text, making it explicit to the user
where the data will be stored if no option is passed.

For the SQL invocation that uses the local transform, pass down the
server's temp storage instead of using the OS temp dir.

This adds a new function that creates a RocksDB store instead of a
map. That is, it allows for duplicate keys instead of overwriting
them. This functionality is needed for CSV writing, which requires
that duplicate keys are kept so it can detect primary key or unique
index violations. The CSV code was previously doing that itself, but
has been moved to use the common temp storage location. Instead of
forcing the CSV code to do its own duplication-allowance by appending
to keys (like the distsqlrun/diskRowContainer), we can more easily
do it here in the MVCC timestamp.

This uncovered a bug in the distributed CSV import that failed
to detect duplicate PK and unique index keys. Using the common
RocksDBStore now makes the code the same across both CSV
implementations.

Fixes #17707