### PR TITLE
distsqlrun: skip flaky TestRouters

### DIFF
--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -58,6 +58,9 @@ func setupRouter(
 
 func TestRouters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/17721")
+
 	const numCols = 6
 	const numRows = 200
 


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/17721.