### PR TITLE
server: create in-memory temp store when first store is in-memory

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -294,11 +294,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	serverCfg.SSLCertsDir = startCtx.serverSSLCertsDir
 	serverCfg.User = security.NodeUser
 
-	var err error
-	serverCfg.TempStore, err = server.MakeTempStoreSpecFromStoreSpec(serverCfg.Stores.Specs[0])
-	if err != nil {
-		return err
-	}
+	serverCfg.TempStore = server.MakeTempStoreSpecFromStoreSpec(serverCfg.Stores.Specs[0])
 
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -212,5 +213,41 @@ func TestFilterGossipBootstrapResolvers(t *testing.T) {
 		t.Fatalf("expected one resolver; got %+v", filtered)
 	} else if filtered[0].Addr() != resolverSpecs[1] {
 		t.Fatalf("expected resolver to be %q; got %q", resolverSpecs[1], filtered[0].Addr())
+	}
+}
+
+func TestTempStoreDerivation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		firstStoreArg    string
+		expectedTempSpec base.StoreSpec
+	}{
+		{
+			firstStoreArg:    "type=mem,size=1GiB",
+			expectedTempSpec: base.StoreSpec{InMemory: true},
+		},
+		{
+			firstStoreArg:    "type=mem,size=1GiB,attrs=garbage:moregarbage",
+			expectedTempSpec: base.StoreSpec{InMemory: true},
+		},
+		{
+			firstStoreArg:    "path=/foo/bar",
+			expectedTempSpec: base.StoreSpec{Path: "/foo/bar/local"},
+		},
+	}
+
+	for i, tc := range testCases {
+		spec, err := base.NewStoreSpec(tc.firstStoreArg)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if e, a := tc.expectedTempSpec, MakeTempStoreSpecFromStoreSpec(spec); e.String() != a.String() {
+			t.Fatalf(
+				"%d: temp store spec did not match expected:\n%s",
+				i, strings.Join(pretty.Diff(e, a), "\n"),
+			)
+		}
 	}
 }

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -32,9 +32,8 @@ import (
 // could not set up a temporary Engine.
 func NewTempEngine(ctx context.Context, storeCfg base.StoreSpec) (Engine, error) {
 	if storeCfg.InMemory {
-		// TODO(arjun): Copy the size in a principled fashion from the main store
-		// after #16750 is addressed.
-		return NewInMem(roachpb.Attributes{}, 0 /*cacheSize */), nil
+		// TODO(arjun): Limit the size of the store once #16750 is addressed.
+		return NewInMem(storeCfg.Attributes, 0 /* cacheSize */), nil
 	}
 
 	if err := cleanupTempStorageDirs(ctx, storeCfg.Path, nil /* *WaitGroup */); err != nil {


### PR DESCRIPTION
Prior to 6316bf4, if all non-temp stores were in-memory, the server
would assume that the user did not want to write any data to disk and
skip creating a temp store. This was the right behavior from the the
user's perspective, but rather annoying for any code path that relied on
the temp store, as each path needed to check whether a temp store
actually existed. So, to avoid these checks, 6316bf4 mandated the presence
of a temp store.

This, however, broke the desired behavior from the user's perspective,
as a `local` temp store will be written in the CWD when all stores are
in-memory. Satisfy everyone by making the temp store in-memory iff the
first store is in memory.