### PR TITLE
build: prevent writing files as root in verify-archive

### DIFF
--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -15,9 +15,13 @@ build/builder.sh make archive ARCHIVE=build/cockroach.src.tgz
 
 # We use test the source archive in a minimal image; the builder image bundles
 # too much developer configuration to simulate a build on a fresh user machine.
+#
+# NB: This docker container runs as root. Be sure to mount any bind volumes as
+# read-only to avoid creating root-owned directories and files on the host
+# machine.
 docker run \
   --rm \
-  --volume="$(cd "$(dirname "$0")" && pwd):/work" \
+  --volume="$(cd "$(dirname "$0")" && pwd):/work:ro" \
   --workdir="/work" \
   golang:stretch ./verify-archive.sh
 


### PR DESCRIPTION
Guarantee that teamcity-verify-archive.sh does not write to the host as
root. Any root-owned directories in the Git checkout will brick a
TeamCity agent. Though the script run inside the container,
verify-archive.sh, is theoretically configured not to write to disk via
in-memory stores, bugs in CockroachDB occasionally ignore this
configuration. Mounting the directory as read-only ensures that the
commit which causes erroneous writes to disk will cause a CI failure.
Before, the offending commit would succeed, but all future builds on
the agent would choke on the root-owned directory.