### PR TITLE
logictest: better settings overrides

### DIFF
--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -707,24 +707,30 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 		t.cluster.Server(t.nodeIdx).SetDistSQLSpanResolver(fakeResolver)
 	}
 
-	for i := 0; i < t.cluster.NumServers(); i++ {
-		server := t.cluster.Server(i)
-		// We want to collect SQL per-statement statistics in tests,
-		// regardless of what the environment / config says.
-		st := server.ClusterSettings()
-		st.Manual.Store(true)
-		st.StmtStatsEnable.Override(true)
-
-		// NB: We must set this before the Exec() below as that opens a session,
-		// locking in the DistSQL setting for that session. If we change it
-		// after, we might still see the old value in tests since they use the
-		// existing Session.
-		if cfg.overrideDistSQLMode != "" {
-			mode := cluster.DistSQLExecModeFromString(cfg.overrideDistSQLMode)
-			st := server.ClusterSettings()
-			st.Manual.Store(true)
-			st.DistSQLClusterExecMode.Override(int64(mode))
+	if cfg.overrideDistSQLMode != "" {
+		// TODO(tschottdorf): avoid Sprintf after https://github.com/cockroachdb/cockroach/pull/17591.
+		if _, err := t.cluster.ServerConn(0).Exec(
+			fmt.Sprintf("SET CLUSTER SETTING sql.defaults.distsql = '%s'", cfg.overrideDistSQLMode),
+		); err != nil {
+			t.Fatal(err)
 		}
+		wantedMode := cluster.DistSQLExecModeFromString(cfg.overrideDistSQLMode) // off => 0, etc
+		// Wait until all servers are aware of the setting.
+		testutils.SucceedsSoon(t.t, func() error {
+			for i := 0; i < t.cluster.NumServers(); i++ {
+				var m cluster.DistSQLExecMode
+				err := t.cluster.ServerConn(i % t.cluster.NumServers()).QueryRow(
+					"SHOW CLUSTER SETTING sql.defaults.distsql",
+				).Scan(&m)
+				if err != nil {
+					t.Fatal(errors.Wrapf(err, "%d", i))
+				}
+				if m != wantedMode {
+					return errors.Errorf("node %d is still waiting for update of DistSQLMode to %s (have %s)", i, wantedMode, m)
+				}
+			}
+			return nil
+		})
 	}
 
 	// db may change over the lifetime of this function, with intermediate

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -326,7 +326,7 @@ SET CLUSTER SETTING kv.allocator.load_based_lease_rebalancing.enabled = DEFAULT
 query IIT
 SELECT "targetID", "reportingID", "info"
 FROM system.eventlog
-WHERE "eventType" = 'set_cluster_setting' AND info NOT LIKE '%version%'
+WHERE "eventType" = 'set_cluster_setting' AND info NOT LIKE '%version%' AND info NOT LIKE '%sql.defaults.distsql%'
 ORDER BY "timestamp"
 ----
 0 1 {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"node"}

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -153,10 +153,10 @@ web_sessions
 zones
 
 query ITTT colnames
-SELECT node_id,username,application_name,active_queries FROM [SHOW SESSIONS]
+SELECT node_id,username,application_name,active_queries FROM [SHOW SESSIONS] WHERE active_queries != ''
 ----
 node_id  username  application_name  active_queries                                   
-1        root      ·                 SELECT node_id, username, application_name, active_queries FROM [SHOW CLUSTER SESSIONS];
+1        root      ·                 SELECT node_id, username, application_name, active_queries FROM [SHOW CLUSTER SESSIONS] WHERE active_queries != '';
 
 query ITT colnames
 SELECT node_id, username, query FROM [SHOW QUERIES]

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -335,7 +335,7 @@ GRANT ALL ON system.lease TO testuser
 # NB: the "order by" is necessary or this test is flaky under DistSQL.
 # This is somewhat surprising.
 query T
-select name from system.settings order by name
+select name from system.settings where name != 'sql.defaults.distsql' order by name
 ----
 diagnostics.reporting.enabled
 version
@@ -344,7 +344,7 @@ statement ok
 INSERT INTO system.settings (name, value) VALUES ('somesetting', 'somevalue')
 
 query TT
-select name, value from system.settings where name != 'version' order by name
+select name, value from system.settings where name != 'version' AND name != 'sql.defaults.distsql' order by name
 ----
 diagnostics.reporting.enabled  true
 somesetting   somevalue


### PR DESCRIPTION
We were using a manually updated cluster setting in logictests when
overriding settings, which was flaky. Even if it hadn't been flaky,
it's better to make logictests operate on as standard a cluster as
we can, so instead of overrides we now use "SET CLUSTER SETTING ..."
and wait until that has propagated everywhere.