### PR TITLE
CODEOWNERS: remove roachpb from core-prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,6 @@
 /pkg/gossip/                 @cockroachdb/core-prs
 /pkg/internal/               @cockroachdb/core-prs
 /pkg/kv/                     @cockroachdb/core-prs
-/pkg/roachpb/                @cockroachdb/core-prs
 /pkg/rpc/                    @cockroachdb/core-prs
 /pkg/server/                 @cockroachdb/core-prs
 /pkg/storage/                @cockroachdb/core-prs
@@ -36,7 +35,7 @@
 
 /pkg/sql/executor*           @cockroachdb/sql-execution-prs
 /pkg/sql/mon/                @cockroachdb/sql-execution-prs
-/pkg/sql/sqlutil/*executor* @cockroachdb/sql-execution-prs
+/pkg/sql/sqlutil/*executor*  @cockroachdb/sql-execution-prs
 
 /pkg/sql/schema*             @cockroachdb/sql-async-prs
 /pkg/sql/lease*              @cockroachdb/sql-async-prs


### PR DESCRIPTION
This casts an overly wide net, causing core-prs to receive lots of
review requests that do not require their guidance.