### PR TITLE
libroach, keys: emulate `DB::SyncWAL()` on Windows

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -201,6 +201,7 @@ struct DBIterator {
 // kKeyLocalRangePrefix are the mvcc-encoded prefixes.
 const rocksdb::Slice kKeyLocalRangeIDPrefix("\x01i", 2);
 const rocksdb::Slice kKeyLocalMax("\x02", 1);
+const rocksdb::Slice kKeyLocalStoreSync("\x01ssync\x00", 7);
 
 const DBStatus kSuccess = { NULL, 0 };
 
@@ -1691,7 +1692,23 @@ DBStatus DBFlush(DBEngine* db) {
 }
 
 DBStatus DBSyncWAL(DBEngine* db) {
-  return ToDBStatus(db->rep->SyncWAL());
+  #ifdef _WIN32
+    // On Windows, DB::SyncWAL() is not implemented due to fact that
+    // `WinWritableFile` is not thread safe. To get around that, the only other
+    // methods that can be used to ensure that a sync is triggered is to either
+    // flush the memtables or perform a write with `WriteOptions.sync=true`. See
+    // https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ for more details.
+    // Please also see #17442 for more discussion on the topic.
+
+    // So in order to force a sync, we issue a write to a single store local key
+    // with `sync=true`. The key used for this has been set aside for just this
+    // purpose.
+    rocksdb::WriteOptions options;
+    options.sync = true;
+    return ToDBStatus(db->rep->Put(options, kKeyLocalStoreSync, ""));
+  #else
+    return ToDBStatus(db->rep->SyncWAL());
+  #endif
 }
 
 DBStatus DBCompact(DBEngine* db) {

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -88,6 +88,8 @@ var (
 	// is to allow a restarting node to discover approximately how long it has
 	// been down without needing to retrieve liveness records from the cluster.
 	localStoreLastUpSuffix = []byte("uptm")
+	// Windows-specific sync key. See `db.cc:DBSyncWAL` for details.
+	localStoreSyncSuffix = []byte("sync")
 
 	// LocalRangeIDPrefix is the prefix identifying per-range data
 	// indexed by Range ID. The Range ID is appended to this prefix,

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -59,6 +59,12 @@ func StoreLastUpKey() roachpb.Key {
 	return MakeStoreKey(localStoreLastUpSuffix, nil)
 }
 
+// StoreSyncKey returns a store-local key used on for emulating `DB::SyncWAL` on
+// Windows. See `db.cc:DBSyncWAL` for details.
+func StoreSyncKey() roachpb.Key {
+	return MakeStoreKey(localStoreSyncSuffix, nil)
+}
+
 // NodeLivenessKey returns the key for the node liveness record.
 func NodeLivenessKey(nodeID roachpb.NodeID) roachpb.Key {
 	key := make(roachpb.Key, 0, len(NodeLivenessPrefix)+9)

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -180,6 +180,7 @@ var constSubKeyDict = []struct {
 	{"/storeIdent", localStoreIdentSuffix},
 	{"/gossipBootstrap", localStoreGossipSuffix},
 	{"/clusterVersion", localStoreClusterVersionSuffix},
+	{"/sync", localStoreSyncSuffix},
 }
 
 func localStoreKeyPrint(key roachpb.Key) string {

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -47,6 +47,7 @@ func TestPrettyPrint(t *testing.T) {
 		{StoreIdentKey(), "/Local/Store/storeIdent"},
 		{StoreGossipKey(), "/Local/Store/gossipBootstrap"},
 		{StoreClusterVersionKey(), "/Local/Store/clusterVersion"},
+		{StoreSyncKey(), "/Local/Store/sync"},
 
 		{AbortCacheKey(roachpb.RangeID(1000001), txnID), fmt.Sprintf(`/Local/RangeID/1000001/r/AbortCache/%q`, txnID)},
 		{RaftTombstoneKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RaftTombstone"},


### PR DESCRIPTION
In windows, rocksdb's `DB:SyncWAL()` function is not implemented due to fact
that `WinWritableFile` is not thread safe. To get around that, the only other
methods than can be used to ensure that a sync is triggered is to either flush
the memtables or perform a write with `WriteOptions.sync=true`. See
https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ for more details.
Please also see #17442 for more discussion on the topic.

So the solution in this case is to issue a write to a single store local key
with `sync=true`. In this commit, that key reserved to ensure that we never
accidentally use it for some other purpose.

This has been tested on Windows.

Fixes #17442.