### PR TITLE
build: Run allocator acceptance tests with verbose logging

### DIFF
--- a/build/teamcity-nightly-acceptance.sh
+++ b/build/teamcity-nightly-acceptance.sh
@@ -23,15 +23,15 @@ PKG=./pkg/acceptance
 case $TESTNAME in
   TestUpreplicate_1To3Small)
     TESTTIMEOUT=2h
-    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608'
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5"'
     ;;
   TestRebalance_3To5Small)
     TESTTIMEOUT=2h
-    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -at.std-dev 14'
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 14'
     ;;
   TestRebalance_3To5Small_WithSchemaChanges)
     TESTTIMEOUT=24h
-    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -at.std-dev 14'
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 14'
     ;;
   TestSteady_3Small)
     TESTTIMEOUT=24h
@@ -39,11 +39,11 @@ case $TESTNAME in
     ;;
   TestSteady_6Medium)
     TESTTIMEOUT=24h
-    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -at.std-dev 100'
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 100'
     ;;
   TestUpreplicate_1To6Medium)
     TESTTIMEOUT=18h
-    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -at.std-dev 52'
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 52'
     ;;
   TestContinuousLoad_BlockWriter)
     TESTTIMEOUT=6h


### PR DESCRIPTION
Without these, the logs don't include any info to help debug failures,
and after the cluster has shut down there's really nothing to go by.

I'm still in the process of testing this out, so I won't merge it until I've verified it works and does what I want.

This will help confirm my hypotheses on #17685, assuming a run fails again soon, and will help with future debugging of these tests.