### PR TITLE
sql: CANCEL QUERY error tweaks, SHOW SESSIONS semicolon removal

### DIFF
--- a/pkg/sql/cancel_checker.go
+++ b/pkg/sql/cancel_checker.go
@@ -15,7 +15,7 @@
 package sql
 
 import (
-	"errors"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 // Interval of rows to wait between cancellation checks.
@@ -69,7 +69,7 @@ func (c *cancelChecker) Check() error {
 	c.rowsSinceLastCheck++
 
 	if c.isCancelled {
-		return errors.New("query execution cancelled")
+		return sqlbase.NewQueryCanceledError()
 	}
 	return nil
 }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -697,9 +697,11 @@ func populateSessionsTable(
 		var oldestStart time.Time
 		var oldestStartDatum parser.Datum
 
-		for _, query := range session.ActiveQueries {
+		for idx, query := range session.ActiveQueries {
+			if idx > 0 {
+				activeQueries.WriteString("; ")
+			}
 			activeQueries.WriteString(query.Sql)
-			activeQueries.WriteString("; ")
 
 			if oldestStart.IsZero() || query.Start.Before(oldestStart) {
 				oldestStart = query.Start

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -155,8 +155,8 @@ zones
 query ITTT colnames
 SELECT node_id,username,application_name,active_queries FROM [SHOW SESSIONS] WHERE active_queries != ''
 ----
-node_id  username  application_name  active_queries                                   
-1        root      ·                 SELECT node_id, username, application_name, active_queries FROM [SHOW CLUSTER SESSIONS] WHERE active_queries != '';
+node_id  username  application_name  active_queries
+1        root      ·                 SELECT node_id, username, application_name, active_queries FROM [SHOW CLUSTER SESSIONS] WHERE active_queries != ''
 
 query ITT colnames
 SELECT node_id, username, query FROM [SHOW QUERIES]

--- a/pkg/sql/run_control.go
+++ b/pkg/sql/run_control.go
@@ -149,7 +149,7 @@ func (n *cancelQueryNode) Start(params runParams) error {
 	queryIDString := parser.AsStringWithFlags(queryIDDatum, parser.FmtBareStrings)
 	queryID, err := uint128.FromString(queryIDString)
 	if err != nil {
-		return errors.Wrapf(err, "Invalid query ID '%s'", queryIDString)
+		return errors.Wrapf(err, "invalid query ID '%s'", queryIDString)
 	}
 
 	// Get the lowest 32 bits of the query ID.
@@ -167,7 +167,7 @@ func (n *cancelQueryNode) Start(params runParams) error {
 	}
 
 	if !response.Cancelled {
-		return fmt.Errorf("Could not cancel query %s: %s", queryID, response.Error)
+		return fmt.Errorf("could not cancel query %s: %s", queryID, response.Error)
 	}
 
 	return nil

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -197,6 +197,16 @@ func NewStatementCompletionUnknownError(err *roachpb.AmbiguousResultError) error
 	return pgerror.NewErrorf(pgerror.CodeStatementCompletionUnknownError, err.Error())
 }
 
+// NewQueryCanceledError creates a query cancellation error.
+func NewQueryCanceledError() error {
+	return pgerror.NewErrorf(pgerror.CodeQueryCanceledError, "query execution canceled")
+}
+
+// IsQueryCanceledError checks whether this is a query canceled error.
+func IsQueryCanceledError(err error) bool {
+	return errHasCode(err, pgerror.CodeQueryCanceledError) || strings.Contains(err.Error(), "query execution canceled")
+}
+
 func errHasCode(err error, code string) bool {
 	if pgErr, ok := pgerror.GetPGCause(err); ok {
 		return pgErr.Code == code


### PR DESCRIPTION
- Lowercase CANCEL QUERY errors to follow convention.
- Add pgcode to query cancelled error.
- Remove the semicolon at the end of `active_queries` in `SHOW SESSIONS`, to make the output match that of the `query` field in `SHOW QUERIES`.