### PR TITLE
scripts: fix gceworker image specification

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -14,7 +14,7 @@ case ${1-} in
            --network "default" \
            --maintenance-policy "MIGRATE" \
            --image-project "ubuntu-os-cloud" \
-           --image "ubuntu-1604-lts" \
+           --image-family "ubuntu-1604-lts" \
            --boot-disk-size "100" \
            --boot-disk-type "pd-ssd" \
            --boot-disk-device-name "${NAME}"


### PR DESCRIPTION
8ee67db switched our GCE VMs to use a newer version of Ubuntu 16.04.
I suggested we use "ubuntu-1604-lts", which will automatically stay
up-to-date; unfortunately, turns out that requires "--image-family", not
"--image". 😞 