### PR TITLE
sql: tighten dependency span analysis for INSERT ... VALUES

### DIFF
--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -229,7 +229,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR DEFAULT 'i', FAMILY (k),
 			} else {
 				_, err = sqlDB.Exec(`INSERT INTO t.test VALUES ('b', 'y', 'i')`)
 			}
-			if !testutils.IsError(err, "INSERT error: table t.test has 2 columns but 3 values were supplied") {
+			if !testutils.IsError(err, "INSERT has more expressions than target columns, 3 expressions for 2 targets") {
 				t.Fatal(err)
 			}
 
@@ -290,7 +290,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR DEFAULT 'i', FAMILY (k),
 			// Updating column "i" for a row fails.
 			if useUpsert {
 				_, err := sqlDB.Exec(`UPSERT INTO t.test VALUES ('a', 'u', 'u')`)
-				if !testutils.IsError(err, `table t.test has 2 columns but 3 values were supplied`) {
+				if !testutils.IsError(err, `INSERT has more expressions than target columns, 3 expressions for 2 targets`) {
 					t.Fatal(err)
 				}
 			} else {
@@ -622,11 +622,13 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR, INDEX foo (i, v), FAMIL
 
 				// Updating column "i" for a row fails.
 				if useUpsert {
-					if _, err := sqlDB.Exec(`UPSERT INTO t.test VALUES ('a', 'u', 'u')`); !testutils.IsError(err, `table t.test has 2 columns but 3 values were supplied`) {
+					_, err := sqlDB.Exec(`UPSERT INTO t.test VALUES ('a', 'u', 'u')`)
+					if !testutils.IsError(err, `INSERT has more expressions than target columns, 3 expressions for 2 targets`) {
 						t.Error(err)
 					}
 				} else {
-					if _, err := sqlDB.Exec(`UPDATE t.test SET (v, i) = ('u', 'u') WHERE k = 'a'`); !testutils.IsError(err, `column "i" does not exist`) {
+					_, err := sqlDB.Exec(`UPDATE t.test SET (v, i) = ('u', 'u') WHERE k = 'a'`)
+					if !testutils.IsError(err, `column "i" does not exist`) {
 						t.Error(err)
 					}
 				}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1902,6 +1902,10 @@ func (e *Executor) execStmtInParallel(
 ) error {
 	session := planner.session
 	ctx := session.Ctx()
+	params := runParams{
+		ctx: ctx,
+		p:   planner,
+	}
 
 	plan, err := planner.makePlan(ctx, stmt)
 	if err != nil {
@@ -1918,7 +1922,7 @@ func (e *Executor) execStmtInParallel(
 	// send the mock result back to the client.
 	session.setQueryExecutionMode(stmt.queryID, false /* isDistributed */, true /* isParallel */)
 
-	session.parallelizeQueue.Add(ctx, plan, func(plan planNode) error {
+	session.parallelizeQueue.Add(params, plan, func(plan planNode) error {
 		// TODO(andrei): this should really be a result writer implementation that
 		// does nothing.
 		bufferedWriter := newBufferedWriter(session.makeBoundAccount())

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1922,7 +1922,7 @@ func (e *Executor) execStmtInParallel(
 	// send the mock result back to the client.
 	session.setQueryExecutionMode(stmt.queryID, false /* isDistributed */, true /* isParallel */)
 
-	session.parallelizeQueue.Add(params, plan, func(plan planNode) error {
+	if err := session.parallelizeQueue.Add(params, plan, func(plan planNode) error {
 		// TODO(andrei): this should really be a result writer implementation that
 		// does nothing.
 		bufferedWriter := newBufferedWriter(session.makeBoundAccount())
@@ -1947,7 +1947,10 @@ func (e *Executor) execStmtInParallel(
 		// Deregister query from registry.
 		session.removeActiveQuery(stmt.queryID)
 		return err
-	})
+	}); err != nil {
+		return err
+	}
+
 	return statementResultWriter.EndResult()
 }
 

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -984,22 +984,6 @@ func (e *Executor) execParsed(
 	return nil
 }
 
-// If the plan has a fast path we attempt to query that,
-// otherwise we fall back to counting via plan.Next().
-func countRowsAffected(runParams runParams, p planNode) (int, error) {
-	if a, ok := p.(planNodeFastPath); ok {
-		if count, res := a.FastPathResults(); res {
-			return count, nil
-		}
-	}
-	count := 0
-	next, err := p.Next(runParams)
-	for ; next; next, err = p.Next(runParams) {
-		count++
-	}
-	return count, err
-}
-
 // runTxnAttempt is used in the closure we pass to txn.Exec(). It
 // will be called possibly multiple times (if opt.AutoRetry is set).
 //
@@ -1717,14 +1701,11 @@ func (e *Executor) execClassic(
 	planner *planner, plan planNode, rowResultWriter StatementResultWriter,
 ) error {
 	ctx := planner.session.Ctx()
+
+	// Create a BoundAccount to track the memory usage of each row.
 	rowAcc := planner.evalCtx.Mon.MakeBoundAccount()
 	planner.evalCtx.ActiveMemAcc = &rowAcc
-	// We enclose this in a func because in the parser.Rows case we swap out the
-	// account, so we want to ensure that we close the currently active account at
-	// the conclusion of this function.
-	defer func() {
-		planner.evalCtx.ActiveMemAcc.Close(ctx)
-	}()
+	defer rowAcc.Close(ctx)
 
 	if err := planner.startPlan(ctx, plan); err != nil {
 		return err
@@ -1744,24 +1725,14 @@ func (e *Executor) execClassic(
 		rowResultWriter.IncrementRowsAffected(count)
 
 	case parser.Rows:
-		next, err := plan.Next(params)
-		for ; next; next, err = plan.Next(params) {
-			planner.evalCtx.ActiveMemAcc.Close(ctx)
-			rowAcc = planner.evalCtx.Mon.MakeBoundAccount()
-			planner.evalCtx.ActiveMemAcc = &rowAcc
-
-			// The plan.Values Datums needs to be copied on each iteration.
-			values := plan.Values()
-
+		err := forEachRow(params, plan, func(values parser.Datums) error {
 			for _, val := range values {
 				if err := checkResultType(val.ResolvedType()); err != nil {
 					return err
 				}
 			}
-			if err := rowResultWriter.AddRow(ctx, values); err != nil {
-				return err
-			}
-		}
+			return rowResultWriter.AddRow(ctx, values)
+		})
 		if err != nil {
 			return err
 		}
@@ -1771,6 +1742,41 @@ func (e *Executor) execClassic(
 		}
 	}
 	return nil
+}
+
+// forEachRow calls the provided closure for each successful call to
+// planNode.Next with planNode.Values, making sure to properly track memory
+// usage.
+func forEachRow(params runParams, p planNode, f func(parser.Datums) error) error {
+	next, err := p.Next(params)
+	for ; next; next, err = p.Next(params) {
+		// If we're tracking memory, clear the previous row's memory account.
+		if params.p.evalCtx.ActiveMemAcc != nil {
+			params.p.evalCtx.ActiveMemAcc.Clear(params.ctx)
+		}
+
+		if err := f(p.Values()); err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// If the plan has a fast path we attempt to query that,
+// otherwise we fall back to counting via plan.Next().
+func countRowsAffected(params runParams, p planNode) (int, error) {
+	if a, ok := p.(planNodeFastPath); ok {
+		if count, res := a.FastPathResults(); res {
+			return count, nil
+		}
+	}
+
+	count := 0
+	err := forEachRow(params, p, func(_ parser.Datums) error {
+		count++
+		return nil
+	})
+	return count, err
 }
 
 // shouldUseDistSQL determines whether we should use DistSQL for a plan, based

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -643,3 +643,7 @@ func (n *insertNode) Values() parser.Datums {
 	n.run.rowsUpserted.PopFirst()
 	return row
 }
+
+func (n *insertNode) isUpsert() bool {
+	return n.n.OnConflict != nil
+}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -108,7 +108,9 @@ func (p *planner) Insert(
 		}
 	}
 	// Number of columns expecting an input. This doesn't include the
-	// columns receiving a default value.
+	// columns receiving a default value except in the case where the
+	// insert source is a ValuesClause, which is handled below with
+	// fillDefaults and its addedCols return value.
 	numInputColumns := len(cols)
 
 	cols, defaultExprs, err :=
@@ -126,7 +128,15 @@ func (p *planner) Insert(
 			return nil, err
 		}
 		if values != nil {
-			src = fillDefaults(defaultExprs, cols, values)
+			var addedCols int
+			src, addedCols, err = fillDefaults(defaultExprs, cols, values)
+			if err != nil {
+				return nil, err
+			}
+			// If we added any columns for DEFAULT expressions at the end of each
+			// tuple, we expect to see extra columns come up from the data source
+			// planNode. Account for that here.
+			numInputColumns += addedCols
 		}
 		insertRows = src
 	}
@@ -411,8 +421,9 @@ func GenerateInsertRow(
 ) (parser.Datums, error) {
 	// The values for the row may be shorter than the number of columns being
 	// inserted into. Generate default values for those columns using the
-	// default expressions.
-
+	// default expressions. This will not happen if the row tuple was produced
+	// by a ValuesClause, because all default expressions will have been populated
+	// already by fillDefaults.
 	if len(rowVals) < len(insertCols) {
 		// It's not cool to append to the slice returned by a node; make a copy.
 		oldVals := rowVals
@@ -535,35 +546,72 @@ func getDefaultValuesClause(
 	return &parser.ValuesClause{Tuples: []*parser.Tuple{{Exprs: row}}}
 }
 
+// fillDefaults populates default expressions in the provided ValuesClause,
+// returning a new ValuesClause with expressions for all columns in cols. Each
+// default value in the Tuples will be replaced with either the corresponding
+// column's default expressions if one exists, or NULL if one does not. There
+// are two parts of a Tuple that fillDefaults will populate:
+// - DefaultVal exprs (`VALUES (1, 2, DEFAULT)`) will be replaced by their
+//   column's default expression (or NULL).
+// - If tuples contain fewer elements than the number of columns, the missing
+//   columns will be added with their default expressions (or NULL).
+//
+// The function returns a ValuesClause with defaults filled, along with the
+// number of elements added to each Tuple in the ValuesClause. This will be
+// the same for each Tuple.
 func fillDefaults(
 	defaultExprs []parser.TypedExpr, cols []sqlbase.ColumnDescriptor, values *parser.ValuesClause,
-) *parser.ValuesClause {
+) (*parser.ValuesClause, int, error) {
 	ret := values
-	for tIdx, tuple := range values.Tuples {
+	copyValues := func() {
+		if ret == values {
+			ret = &parser.ValuesClause{Tuples: append([]*parser.Tuple(nil), values.Tuples...)}
+		}
+	}
+
+	defaultExpr := func(idx int) parser.Expr {
+		if defaultExprs == nil || idx >= len(defaultExprs) {
+			// The case where idx is too large for defaultExprs will be
+			// transformed into an error by the check on the number of
+			// columns in Insert().
+			return parser.DNull
+		}
+		return defaultExprs[idx]
+	}
+
+	numColsOrig := len(ret.Tuples[0].Exprs)
+	for tIdx, tuple := range ret.Tuples {
+		if a, e := len(tuple.Exprs), numColsOrig; a != e {
+			return nil, 0, newValuesListLenErr(e, a)
+		}
+
 		tupleCopied := false
+		copyTuple := func() {
+			if !tupleCopied {
+				copyValues()
+				tuple = &parser.Tuple{Exprs: append([]parser.Expr(nil), tuple.Exprs...)}
+				ret.Tuples[tIdx] = tuple
+				tupleCopied = true
+			}
+		}
+
 		for eIdx, val := range tuple.Exprs {
 			switch val.(type) {
 			case parser.DefaultVal:
-				if !tupleCopied {
-					if ret == values {
-						ret = &parser.ValuesClause{Tuples: append([]*parser.Tuple(nil), values.Tuples...)}
-					}
-					ret.Tuples[tIdx] =
-						&parser.Tuple{Exprs: append([]parser.Expr(nil), tuple.Exprs...)}
-					tupleCopied = true
-				}
-				if defaultExprs == nil || eIdx >= len(defaultExprs) {
-					// The case where eIdx is too large for defaultExprs will be
-					// transformed into an error by the check on the number of
-					// columns in Insert().
-					ret.Tuples[tIdx].Exprs[eIdx] = parser.DNull
-				} else {
-					ret.Tuples[tIdx].Exprs[eIdx] = defaultExprs[eIdx]
-				}
+				copyTuple()
+				tuple.Exprs[eIdx] = defaultExpr(eIdx)
 			}
 		}
+
+		// The values for the row may be shorter than the number of columns being
+		// inserted into. Populate default expressions for those columns.
+		for i := len(tuple.Exprs); i < len(cols); i++ {
+			copyTuple()
+			tuple.Exprs = append(tuple.Exprs, defaultExpr(len(tuple.Exprs)))
+		}
 	}
-	return ret
+	numColsFinal := len(ret.Tuples[0].Exprs)
+	return ret, numColsFinal - numColsOrig, nil
 }
 
 func (n *insertNode) Values() parser.Datums {

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -387,11 +387,14 @@ SELECT v, k FROM kv5@a
 ----
 NULL a
 
-statement ok
-CREATE TABLE boom (id INT PRIMARY KEY)
+statement error INSERT has more expressions than target columns, 3 expressions for 2 targets
+INSERT INTO kv VALUES ('a', 'b', 'c')
 
-statement error INSERT error: table boom has \d+ columns but \d+ values were supplied
-INSERT INTO boom VALUES(1,2)
+statement error INSERT has more expressions than target columns, 2 expressions for 1 targets
+INSERT INTO kv (k) VALUES ('a', 'b')
+
+statement error INSERT has more target columns than expressions, 1 expressions for 2 targets
+INSERT INTO kv5 (k, v) VALUES ('a')
 
 statement ok
 CREATE TABLE return (a INT DEFAULT 3, b INT)
@@ -563,7 +566,7 @@ INSERT INTO blindcput values (1, 1), (2, 2), (3, 3), (4, 4), (1, 5)
 statement ok
 CREATE TABLE nocols()
 
-statement error INSERT error: table nocols has \d+ columns but \d+ values were supplied
+statement error INSERT has more expressions than target columns, 2 expressions for 0 targets
 INSERT INTO nocols VALUES (true, default)
 
 statement error compound types not supported yet: "kv.k"

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -370,7 +370,10 @@ CREATE TABLE kv5 (
 )
 
 statement ok
-INSERT INTO kv5 VALUES('a', NULL)
+INSERT INTO kv5 VALUES ('a', NULL)
+
+statement error VALUES lists must all be the same length, expected 1 columns, found 2
+INSERT INTO kv5 VALUES ('b'), ('c', DEFAULT)
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM kv5@a]

--- a/pkg/sql/logictest/testdata/logic_test/values
+++ b/pkg/sql/logictest/testdata/logic_test/values
@@ -7,7 +7,7 @@ column1 column2 column3
 1       2       3
 4       5       6
 
-query error VALUES lists must all be the same length
+query error VALUES lists must all be the same length, expected 1 columns, found 2
 VALUES (1), (2, 3)
 
 query I

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -109,7 +109,7 @@ type planNode interface {
 	// encountered or if there is no more work to do. For statements
 	// that return a result set, the Values() method will return one row
 	// of results each time that Next() returns true.
-	// See executor.go: countRowsAffected() and execStmt() for an example.
+	// See executor.go: forEachRow() for an example.
 	//
 	// Available after Start(). It is illegal to call Next() after it returns
 	// false.

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -25,7 +25,7 @@ var noColumns = make(sqlbase.ResultColumns, 0)
 //
 // The length of the returned slice is guaranteed to be equal to the
 // length of the tuple returned by the planNode's Values() method
-// during local exeecution.
+// during local execution.
 //
 // The returned slice is *not* mutable. To modify the result column
 // set, implement a separate recursion (e.g. needed_columns.go) or use

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 )
 
@@ -43,6 +45,13 @@ func collectSpans(params runParams, plan planNode) (reads, writes roachpb.Spans,
 	case *updateNode:
 		return editNodeSpans(params, &n.run.editNodeRun)
 	case *insertNode:
+		if v, ok := n.run.editNodeRun.rows.(*valuesNode); ok && !n.isUpsert() {
+			// subqueries, even within valuesNodes, can be arbitrarily complex,
+			// so we can't run the valuesNode ahead of time if they are present.
+			if v.isConst {
+				return insertNodeWithValuesSpans(params, n, v)
+			}
+		}
 		return editNodeSpans(params, &n.run.editNodeRun)
 	case *deleteNode:
 		return editNodeSpans(params, &n.run.editNodeRun)
@@ -83,6 +92,15 @@ func collectSpans(params runParams, plan planNode) (reads, writes roachpb.Spans,
 	panic(fmt.Sprintf("don't know how to collect spans for node %T", plan))
 }
 
+// editNodeSpans determines the read and write spans for an editNodeRun
+// instance. It is conservative and assumes that anything in the table might be
+// touched because it performs no predicate analysis. Interestingly, performing
+// this analysis fully with optimal span bounds would reduce to the analysis
+// required for predicate locking. Predicate locking is a concurrency control
+// locking strategy where locks are based upon logical conditions.
+//
+// Where possible, we should try to specialize this analysis like we do with
+// insertNodeWithValuesSpans.
 func editNodeSpans(params runParams, r *editNodeRun) (reads, writes roachpb.Spans, err error) {
 	scanReads, scanWrites, err := collectSpans(params, r.rows)
 	if err != nil {
@@ -92,10 +110,7 @@ func editNodeSpans(params runParams, r *editNodeRun) (reads, writes roachpb.Span
 		return nil, nil, errors.Errorf("unexpected scan span writes: %v", scanWrites)
 	}
 
-	writerReads, writerWrites, err := tableWriterSpans(params, r.tw)
-	if err != nil {
-		return nil, nil, err
-	}
+	writerReads, writerWrites := tableWriterSpans(params, r.tw)
 
 	sqReads, err := collectSubquerySpans(params, r.rows)
 	if err != nil {
@@ -105,16 +120,76 @@ func editNodeSpans(params runParams, r *editNodeRun) (reads, writes roachpb.Span
 	return append(scanReads, append(writerReads, sqReads...)...), writerWrites, nil
 }
 
-func tableWriterSpans(params runParams, tw tableWriter) (reads, writes roachpb.Spans, err error) {
+func tableWriterSpans(params runParams, tw tableWriter) (reads, writes roachpb.Spans) {
 	// We don't generally know which spans we will be modifying so we must be
-	// conservative and assume anything in the table might change. See TODO on
-	// tableWriter.spans for discussion on constraining spans wherever possible.
+	// conservative and assume anything in the table might change.
 	tableSpans := tw.tableDesc().AllIndexSpans()
-	fkReads, fkWrites := tw.fkSpanCollector().CollectSpans()
-	if len(fkWrites) > 0 {
-		return nil, nil, errors.Errorf("unexpected foreign key span writes: %v", fkWrites)
+	fkReads := tw.fkSpanCollector().CollectSpans()
+	return fkReads, tableSpans
+}
+
+// insertNodeWithValuesSpans is a special case of editNodeSpans. It tightens the
+// predicted read and write-sets for INSERT ... VALUES statements. The function
+// does so by evaluating the VALUES clause ahead of time and computing the
+// specific index spans that will be touched by each VALUES tuple. valuesNode
+// can not contain subqueries.
+func insertNodeWithValuesSpans(
+	params runParams, n *insertNode, v *valuesNode,
+) (reads, writes roachpb.Spans, err error) {
+
+	// addWriteKey adds a write span for the given index key.
+	addWriteKey := func(key roachpb.Key) {
+		writes = append(writes, roachpb.Span{
+			Key:    key,
+			EndKey: key.PrefixEnd(),
+		})
 	}
-	return fkReads, tableSpans, nil
+
+	// Run the valuesNode to completion while tracking its memory usage.
+	// Importantly, we only Reset the valuesNode, instead of Closing it when
+	// completed, so that the values don't need to be computed again during
+	// plan execution.
+	rowAcc := params.p.evalCtx.Mon.MakeBoundAccount()
+	params.p.evalCtx.ActiveMemAcc = &rowAcc
+	defer rowAcc.Close(params.ctx)
+
+	defer v.Reset(params.ctx)
+	if err = v.Start(params); err != nil {
+		return nil, nil, err
+	}
+
+	if err := forEachRow(params, v, func(values parser.Datums) error {
+		// insertNode uses fillDefaults to fill all defaults if it's data source
+		// is a valuesNode. This is important, because it means that the result
+		// of all DEFAULT expressions will be retained from span collection to
+		// plan execution.
+		if a, e := len(values), len(n.insertCols); a < e {
+			log.Fatalf(params.ctx, "missing columns for row; want %d, got %d", e, a)
+		}
+
+		// Determine the table spans that the current values tuple will mutate.
+		ti := n.run.editNodeRun.tw.(*tableInserter)
+		primaryKey, secondaryKeys, err := ti.ri.EncodeIndexesForRow(values)
+		if err != nil {
+			return err
+		}
+		addWriteKey(primaryKey)
+		for _, secondaryKey := range secondaryKeys {
+			addWriteKey(secondaryKey.Key)
+		}
+
+		// Determine the table spans that foreign key constraints will require
+		// us to read during FK validation.
+		fkReads, err := ti.fkSpanCollector().CollectSpansForValues(values)
+		if err != nil {
+			return err
+		}
+		reads = append(reads, fkReads...)
+		return nil
+	}); err != nil {
+		return nil, nil, err
+	}
+	return reads, writes, nil
 }
 
 func indexJoinSpans(params runParams, n *indexJoinNode) (reads, writes roachpb.Spans, err error) {

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -17,8 +17,6 @@ package sql
 import (
 	"fmt"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/pkg/errors"
 )
@@ -30,7 +28,7 @@ import (
 // set are disjoint. It is an error for a planNode to touch any span outside
 // those that it reports from this method, but a planNode is not required to
 // touch all spans that it reports.
-func collectSpans(ctx context.Context, plan planNode) (reads, writes roachpb.Spans, err error) {
+func collectSpans(params runParams, plan planNode) (reads, writes roachpb.Spans, err error) {
 	switch n := plan.(type) {
 	case
 		*valueGenerator,
@@ -43,52 +41,50 @@ func collectSpans(ctx context.Context, plan planNode) (reads, writes roachpb.Spa
 		return n.spans, nil, nil
 
 	case *updateNode:
-		return n.run.collectSpans(ctx)
+		return n.run.collectSpans(params)
 	case *insertNode:
-		return n.run.collectSpans(ctx)
+		return n.run.collectSpans(params)
 	case *deleteNode:
-		return n.run.collectSpans(ctx)
+		return n.run.collectSpans(params)
 
 	case *delayedNode:
-		return collectSpans(ctx, n.plan)
+		return collectSpans(params, n.plan)
 	case *distinctNode:
-		return collectSpans(ctx, n.plan)
+		return collectSpans(params, n.plan)
 	case *explainDistSQLNode:
-		return collectSpans(ctx, n.plan)
+		return collectSpans(params, n.plan)
 	case *explainPlanNode:
-		return collectSpans(ctx, n.plan)
+		return collectSpans(params, n.plan)
 	case *traceNode:
-		return collectSpans(ctx, n.plan)
+		return collectSpans(params, n.plan)
 	case *limitNode:
-		return collectSpans(ctx, n.plan)
+		return collectSpans(params, n.plan)
 	case *sortNode:
-		return collectSpans(ctx, n.plan)
+		return collectSpans(params, n.plan)
 	case *groupNode:
-		return collectSpans(ctx, n.plan)
+		return collectSpans(params, n.plan)
 	case *windowNode:
-		return collectSpans(ctx, n.plan)
+		return collectSpans(params, n.plan)
 	case *ordinalityNode:
-		return collectSpans(ctx, n.source)
+		return collectSpans(params, n.source)
 	case *filterNode:
-		return collectSpans(ctx, n.source.plan)
+		return collectSpans(params, n.source.plan)
 	case *renderNode:
-		return collectSpans(ctx, n.source.plan)
+		return collectSpans(params, n.source.plan)
 
 	case *indexJoinNode:
-		return indexJoinSpans(ctx, n)
+		return indexJoinSpans(params, n)
 	case *joinNode:
-		return concatSpans(ctx, n.left.plan, n.right.plan)
+		return concatSpans(params, n.left.plan, n.right.plan)
 	case *unionNode:
-		return concatSpans(ctx, n.left, n.right)
+		return concatSpans(params, n.left, n.right)
 	}
 
 	panic(fmt.Sprintf("don't know how to collect spans for node %T", plan))
 }
 
-func indexJoinSpans(
-	ctx context.Context, n *indexJoinNode,
-) (reads, writes roachpb.Spans, err error) {
-	indexReads, indexWrites, err := collectSpans(ctx, n.index)
+func indexJoinSpans(params runParams, n *indexJoinNode) (reads, writes roachpb.Spans, err error) {
+	indexReads, indexWrites, err := collectSpans(params, n.index)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -103,14 +99,12 @@ func indexJoinSpans(
 	return append(indexReads, primaryReads), nil, nil
 }
 
-func concatSpans(
-	ctx context.Context, left, right planNode,
-) (reads, writes roachpb.Spans, err error) {
-	leftReads, leftWrites, err := collectSpans(ctx, left)
+func concatSpans(params runParams, left, right planNode) (reads, writes roachpb.Spans, err error) {
+	leftReads, leftWrites, err := collectSpans(params, left)
 	if err != nil {
 		return nil, nil, err
 	}
-	rightReads, rightWrites, err := collectSpans(ctx, right)
+	rightReads, rightWrites, err := collectSpans(params, right)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -264,24 +264,15 @@ func (p *planner) queryRows(
 		ctx: ctx,
 		p:   p,
 	}
-	if next, err := plan.Next(params); err != nil || !next {
-		return nil, err
-	}
-
 	var rows []parser.Datums
-	for {
-		if values := plan.Values(); values != nil {
+	if err = forEachRow(params, plan, func(values parser.Datums) error {
+		if values != nil {
 			valCopy := append(parser.Datums(nil), values...)
 			rows = append(rows, valCopy)
 		}
-
-		next, err := plan.Next(params)
-		if err != nil {
-			return nil, err
-		}
-		if !next {
-			break
-		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 	return rows, nil
 }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -94,6 +94,9 @@ type planner struct {
 	// logical plan construction. This is used by CREATE VIEW until
 	// #10028 is addressed.
 	hasStar bool
+	// hasSubqueries collects whether any subqueries expansion has
+	// occurred during logical plan construction.
+	hasSubqueries bool
 
 	// Avoid allocations by embedding commonly used objects and visitors.
 	parser                parser.Parser

--- a/pkg/sql/sqlbase/rowwriter.go
+++ b/pkg/sql/sqlbase/rowwriter.go
@@ -343,6 +343,15 @@ func (ri *RowInserter) InsertRow(
 	return nil
 }
 
+// EncodeIndexesForRow encodes the provided values into their primary and
+// secondary index keys. The secondaryIndexEntries are only valid until the next
+// call to EncodeIndexesForRow.
+func (ri *RowInserter) EncodeIndexesForRow(
+	values []parser.Datum,
+) (primaryIndexKey []byte, secondaryIndexEntries []IndexEntry, err error) {
+	return ri.Helper.encodeIndexes(ri.InsertColIDtoRowIndex, values)
+}
+
 // RowUpdater abstracts the key/value operations for updating table rows.
 type RowUpdater struct {
 	Helper                rowHelper

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -281,13 +281,13 @@ func (p *planner) startSubqueryPlans(ctx context.Context, plan planNode) error {
 // subquerySpanCollector is responsible for collecting all read spans that
 // subqueries in a query plan may touch. Subqueries should never be performing
 // any write operations, so only the read spans are collected.
-// FOR REVIEW: this assumption is correct, right?
 type subquerySpanCollector struct {
-	reads roachpb.Spans
+	params runParams
+	reads  roachpb.Spans
 }
 
 func (v *subquerySpanCollector) subqueryNode(ctx context.Context, sq *subquery) error {
-	reads, writes, err := collectSpans(ctx, sq.plan)
+	reads, writes, err := collectSpans(v.params, sq.plan)
 	if err != nil {
 		return err
 	}
@@ -298,10 +298,10 @@ func (v *subquerySpanCollector) subqueryNode(ctx context.Context, sq *subquery) 
 	return nil
 }
 
-func collectSubquerySpans(ctx context.Context, plan planNode) (roachpb.Spans, error) {
-	var v subquerySpanCollector
+func collectSubquerySpans(params runParams, plan planNode) (roachpb.Spans, error) {
+	v := subquerySpanCollector{params: params}
 	po := planObserver{subqueryNode: v.subqueryNode}
-	if err := walkPlan(ctx, plan, po); err != nil {
+	if err := walkPlan(params.ctx, plan, po); err != nil {
 		return nil, err
 	}
 	return v.reads, nil

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -348,6 +348,8 @@ func (v *subqueryVisitor) VisitPre(expr parser.Expr) (recurse bool, newExpr pars
 		}
 	}
 
+	v.hasSubqueries = true
+
 	// Calling newPlan() might recursively invoke expandSubqueries, so we need to preserve
 	// the state of the visitor across the call to newPlan().
 	visitorCopy := v.planner.subqueryVisitor

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -74,15 +74,12 @@ type tableWriter interface {
 	// this a separate parameter as opposed to a Value field on the context.
 	finalize(ctx context.Context, traceKV bool) (*sqlbase.RowContainer, error)
 
-	// spans collects the upper bound set of read and write spans that the
-	// tableWriter will touch when executed. This is contractual, and the
-	// tableWriter will not touch any keys outside of the spans reported here.
-	//
-	// TODO(nvanbenschoten): we are currently pretty pessimistic here, assuming
-	// that table operations will touch the entire table. In cases where we
-	// can determine ahead of time that this isn't true, we should try to
-	// constrain these spans.
-	spans() (reads, writes roachpb.Spans, err error)
+	// tableDesc returns the TableDescriptor for the table that the tableWriter
+	// will modify.
+	tableDesc() *sqlbase.TableDescriptor
+
+	// fkSpanCollector returns the FkSpanCollector for the tableWriter.
+	fkSpanCollector() sqlbase.FkSpanCollector
 
 	// close frees all resources held by the tableWriter.
 	close(ctx context.Context)
@@ -134,8 +131,12 @@ func (ti *tableInserter) finalize(ctx context.Context, _ bool) (*sqlbase.RowCont
 	return nil, nil
 }
 
-func (ti *tableInserter) spans() (reads, writes roachpb.Spans, err error) {
-	return collectTableWriterSpans(ti.ri.Helper.TableDesc, ti.ri.Fks)
+func (ti *tableInserter) tableDesc() *sqlbase.TableDescriptor {
+	return ti.ri.Helper.TableDesc
+}
+
+func (ti *tableInserter) fkSpanCollector() sqlbase.FkSpanCollector {
+	return ti.ri.Fks
 }
 
 // tableUpdater handles writing kvs and forming table rows for updates.
@@ -183,8 +184,12 @@ func (tu *tableUpdater) finalize(ctx context.Context, _ bool) (*sqlbase.RowConta
 	return nil, nil
 }
 
-func (tu *tableUpdater) spans() (reads, writes roachpb.Spans, err error) {
-	return collectTableWriterSpans(tu.ru.Helper.TableDesc, tu.ru.Fks)
+func (tu *tableUpdater) tableDesc() *sqlbase.TableDescriptor {
+	return tu.ru.Helper.TableDesc
+}
+
+func (tu *tableUpdater) fkSpanCollector() sqlbase.FkSpanCollector {
+	return tu.ru.Fks
 }
 
 func (tu *tableUpdater) close(_ context.Context) {}
@@ -238,7 +243,6 @@ type tableUpserter struct {
 
 	// Set by init.
 	txn                   *client.Txn
-	tableDesc             *sqlbase.TableDescriptor
 	fkTables              sqlbase.TableLookupsByID // for fk checks in update case
 	ru                    sqlbase.RowUpdater
 	updateColIDtoRowIndex map[sqlbase.ColumnID]int
@@ -267,9 +271,10 @@ func (tu *tableUpserter) walkExprs(walk func(desc string, index int, expr parser
 }
 
 func (tu *tableUpserter) init(txn *client.Txn) error {
+	tableDesc := tu.tableDesc()
+
 	tu.txn = txn
-	tu.tableDesc = tu.ri.Helper.TableDesc
-	tu.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(tu.tableDesc, tu.tableDesc.PrimaryIndex.ID)
+	tu.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
 
 	tu.insertRows.Init(
 		tu.mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromColDescs(tu.ri.InsertCols), 0,
@@ -285,14 +290,14 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 		// Tables with secondary indexes are not eligible for fast path (it
 		// would be easy to add the new secondary index entry but we can't clean
 		// up the old one without the previous values).
-		len(tu.tableDesc.Indexes) == 0 &&
+		len(tableDesc.Indexes) == 0 &&
 		// When adding or removing a column in a schema change (mutation), the user
 		// can't specify it, which means we need to do a lookup and so we can't use
 		// the fast path. When adding or removing an index, same result, so the fast
 		// path is disabled during all mutations.
-		len(tu.tableDesc.Mutations) == 0 &&
+		len(tableDesc.Mutations) == 0 &&
 		// For the fast path, all columns must be specified in the insert.
-		len(tu.ri.InsertCols) == len(tu.tableDesc.Columns)
+		len(tu.ri.InsertCols) == len(tableDesc.Columns)
 	if enableFastPath {
 		tu.fastPathBatch = tu.txn.NewBatch()
 		tu.fastPathKeys = make(map[string]struct{})
@@ -301,7 +306,7 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 
 	// TODO(dan): This could be made tighter, just the rows needed for the ON
 	// CONFLICT and RETURNING exprs.
-	requestedCols := tu.tableDesc.Columns
+	requestedCols := tableDesc.Columns
 
 	if len(tu.updateCols) == 0 {
 		tu.fetchCols = requestedCols
@@ -309,7 +314,7 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 	} else {
 		var err error
 		tu.ru, err = sqlbase.MakeRowUpdater(
-			txn, tu.tableDesc, tu.fkTables, tu.updateCols, requestedCols,
+			txn, tableDesc, tu.fkTables, tu.updateCols, requestedCols,
 			sqlbase.RowUpdaterDefault, tu.alloc,
 		)
 		if err != nil {
@@ -337,7 +342,7 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 	}
 
 	return tu.fetcher.Init(
-		tu.tableDesc, tu.fetchColIDtoRowIndex, &tu.tableDesc.PrimaryIndex,
+		tableDesc, tu.fetchColIDtoRowIndex, &tableDesc.PrimaryIndex,
 		false /* reverse */, false, /* isSecondaryIndex */
 		tu.fetchCols, valNeededForCol, false /*returnRangeInfo*/, tu.alloc)
 }
@@ -346,8 +351,9 @@ func (tu *tableUpserter) row(
 	ctx context.Context, row parser.Datums, traceKV bool,
 ) (parser.Datums, error) {
 	if tu.fastPathBatch != nil {
+		tableDesc := tu.tableDesc()
 		primaryKey, _, err := sqlbase.EncodeIndexKey(
-			tu.tableDesc, &tu.tableDesc.PrimaryIndex, tu.ri.InsertColIDtoRowIndex, row, tu.indexKeyPrefix)
+			tableDesc, &tableDesc.PrimaryIndex, tu.ri.InsertColIDtoRowIndex, row, tu.indexKeyPrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -375,6 +381,7 @@ func (tu *tableUpserter) row(
 func (tu *tableUpserter) flush(
 	ctx context.Context, finalize, traceKV bool,
 ) (*sqlbase.RowContainer, error) {
+	tableDesc := tu.tableDesc()
 	existingRows, err := tu.fetchExisting(ctx, traceKV)
 	if err != nil {
 		return nil, err
@@ -384,7 +391,7 @@ func (tu *tableUpserter) flush(
 	if tu.collectRows {
 		tu.rowsUpserted = sqlbase.NewRowContainer(
 			tu.mon.MakeBoundAccount(),
-			sqlbase.ColTypeInfoFromColDescs(tu.tableDesc.Columns),
+			sqlbase.ColTypeInfoFromColDescs(tableDesc.Columns),
 			tu.insertRows.Len(),
 		)
 
@@ -393,14 +400,14 @@ func (tu *tableUpserter) flush(
 		// to rh, in the correct order; we will use rowTemplate for this. We
 		// also need a table that maps row indices to rowTemplate indices to
 		// fill in the row values; any absent values will be NULLs.
-		rowTemplate = make(parser.Datums, len(tu.tableDesc.Columns))
+		rowTemplate = make(parser.Datums, len(tableDesc.Columns))
 		for i := range rowTemplate {
 			rowTemplate[i] = parser.DNull
 		}
 	}
 
 	colIDToRetIndex := map[sqlbase.ColumnID]int{}
-	for i, col := range tu.tableDesc.Columns {
+	for i, col := range tableDesc.Columns {
 		colIDToRetIndex[col.ID] = i
 	}
 
@@ -470,7 +477,7 @@ func (tu *tableUpserter) flush(
 		err = tu.txn.Run(ctx, b)
 	}
 	if err != nil {
-		return nil, sqlbase.ConvertBatchError(ctx, tu.tableDesc, b)
+		return nil, sqlbase.ConvertBatchError(ctx, tableDesc, b)
 	}
 	return tu.rowsUpserted, nil
 }
@@ -480,14 +487,15 @@ func (tu *tableUpserter) flush(
 func (tu *tableUpserter) upsertRowPKs(ctx context.Context, traceKV bool) ([]roachpb.Key, error) {
 	upsertRowPKs := make([]roachpb.Key, tu.insertRows.Len())
 
-	if tu.conflictIndex.ID == tu.tableDesc.PrimaryIndex.ID {
+	tableDesc := tu.tableDesc()
+	if tu.conflictIndex.ID == tableDesc.PrimaryIndex.ID {
 		// If the conflict index is the primary index, we can compute them directly.
 		// In this case, the slice will be filled, but not all rows will have
 		// conflicts.
 		for i := 0; i < tu.insertRows.Len(); i++ {
 			insertRow := tu.insertRows.At(i)
 			upsertRowPK, _, err := sqlbase.EncodeIndexKey(
-				tu.tableDesc, &tu.conflictIndex, tu.ri.InsertColIDtoRowIndex, insertRow, tu.indexKeyPrefix)
+				tableDesc, &tu.conflictIndex, tu.ri.InsertColIDtoRowIndex, insertRow, tu.indexKeyPrefix)
 			if err != nil {
 				return nil, err
 			}
@@ -504,7 +512,7 @@ func (tu *tableUpserter) upsertRowPKs(ctx context.Context, traceKV bool) ([]roac
 	for i := 0; i < tu.insertRows.Len(); i++ {
 		insertRow := tu.insertRows.At(i)
 		entry, err := sqlbase.EncodeSecondaryIndex(
-			tu.tableDesc, &tu.conflictIndex, tu.ri.InsertColIDtoRowIndex, insertRow)
+			tableDesc, &tu.conflictIndex, tu.ri.InsertColIDtoRowIndex, insertRow)
 		if err != nil {
 			return nil, err
 		}
@@ -524,7 +532,7 @@ func (tu *tableUpserter) upsertRowPKs(ctx context.Context, traceKV bool) ([]roac
 			if result.Rows[0].Value == nil {
 				upsertRowPKs[i] = nil
 			} else {
-				upsertRowPK, err := sqlbase.ExtractIndexKey(tu.alloc, tu.tableDesc, result.Rows[0])
+				upsertRowPK, err := sqlbase.ExtractIndexKey(tu.alloc, tableDesc, result.Rows[0])
 				if err != nil {
 					return nil, err
 				}
@@ -543,6 +551,8 @@ func (tu *tableUpserter) upsertRowPKs(ctx context.Context, traceKV bool) ([]roac
 // ones in tu.insertRows. The returned slice is the same length as tu.insertRows
 // and a nil entry indicates no conflict.
 func (tu *tableUpserter) fetchExisting(ctx context.Context, traceKV bool) ([]parser.Datums, error) {
+	tableDesc := tu.tableDesc()
+
 	primaryKeys, err := tu.upsertRowPKs(ctx, traceKV)
 	if err != nil {
 		return nil, err
@@ -580,7 +590,7 @@ func (tu *tableUpserter) fetchExisting(ctx context.Context, traceKV bool) ([]par
 		}
 
 		rowPrimaryKey, _, err := sqlbase.EncodeIndexKey(
-			tu.tableDesc, &tu.tableDesc.PrimaryIndex, tu.fetchColIDtoRowIndex, row, tu.indexKeyPrefix)
+			tableDesc, &tableDesc.PrimaryIndex, tu.fetchColIDtoRowIndex, row, tu.indexKeyPrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -623,8 +633,12 @@ func (tu *tableUpserter) finalize(
 	return tu.flush(ctx, true /* finalize */, traceKV)
 }
 
-func (tu *tableUpserter) spans() (reads, writes roachpb.Spans, err error) {
-	return collectTableWriterSpans(tu.ri.Helper.TableDesc, tu.ri.Fks)
+func (tu *tableUpserter) tableDesc() *sqlbase.TableDescriptor {
+	return tu.ri.Helper.TableDesc
+}
+
+func (tu *tableUpserter) fkSpanCollector() sqlbase.FkSpanCollector {
+	return tu.ri.Fks
 }
 
 func (tu *tableUpserter) close(ctx context.Context) {
@@ -920,22 +934,12 @@ func (td *tableDeleter) deleteIndexScan(
 	return resume, err
 }
 
-func (td *tableDeleter) spans() (reads, writes roachpb.Spans, err error) {
-	return collectTableWriterSpans(td.rd.Helper.TableDesc, td.rd.Fks)
+func (td *tableDeleter) tableDesc() *sqlbase.TableDescriptor {
+	return td.rd.Helper.TableDesc
 }
 
-func collectTableWriterSpans(
-	desc *sqlbase.TableDescriptor, fks sqlbase.FkSpanCollector,
-) (reads, writes roachpb.Spans, err error) {
-	// We don't generally know which spans we will be modifying so we must be
-	// conservative and assume anything in the table might change. See TODO on
-	// tableWriter.spans for discussion on constraining spans wherever possible.
-	tableSpans := desc.AllIndexSpans()
-	fkReads, fkWrites := fks.CollectSpans()
-	if len(fkWrites) > 0 {
-		return nil, nil, errors.Errorf("unexpected foreign key span writes: %v", fkWrites)
-	}
-	return fkReads, tableSpans, nil
+func (td *tableDeleter) fkSpanCollector() sqlbase.FkSpanCollector {
+	return td.rd.Fks
 }
 
 func (td *tableDeleter) close(_ context.Context) {}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -80,7 +80,7 @@ type tableWriter interface {
 	//
 	// TODO(nvanbenschoten): we are currently pretty pessimistic here, assuming
 	// that table operations will touch the entire table. In cases where we
-	// can determine ahead of time that this isn't true, we should true to
+	// can determine ahead of time that this isn't true, we should try to
 	// constrain these spans.
 	spans() (reads, writes roachpb.Spans, err error)
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -109,8 +109,8 @@ func (r *editNodeRun) startEditNode(params runParams, en *editNodeBase) error {
 	return r.rows.Start(params)
 }
 
-func (r *editNodeRun) collectSpans(ctx context.Context) (reads, writes roachpb.Spans, err error) {
-	scanReads, scanWrites, err := collectSpans(ctx, r.rows)
+func (r *editNodeRun) collectSpans(params runParams) (reads, writes roachpb.Spans, err error) {
+	scanReads, scanWrites, err := collectSpans(params, r.rows)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -123,7 +123,7 @@ func (r *editNodeRun) collectSpans(ctx context.Context) (reads, writes roachpb.S
 	if err != nil {
 		return nil, nil, err
 	}
-	sqReads, err := collectSubquerySpans(ctx, r.rows)
+	sqReads, err := collectSubquerySpans(params, r.rows)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -20,7 +20,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -107,27 +106,6 @@ func (r *editNodeRun) startEditNode(params runParams, en *editNodeBase) error {
 	}
 
 	return r.rows.Start(params)
-}
-
-func (r *editNodeRun) collectSpans(params runParams) (reads, writes roachpb.Spans, err error) {
-	scanReads, scanWrites, err := collectSpans(params, r.rows)
-	if err != nil {
-		return nil, nil, err
-	}
-	if len(scanWrites) > 0 {
-		return nil, nil, errors.Errorf("unexpected scan span writes: %v", scanWrites)
-	}
-	// TODO(nvanbenschoten): if we notice that r.rows is a ValuesClause, we
-	// may be able to contrain the tableWriter Spans.
-	writerReads, writerWrites, err := r.tw.spans()
-	if err != nil {
-		return nil, nil, err
-	}
-	sqReads, err := collectSubquerySpans(params, r.rows)
-	if err != nil {
-		return nil, nil, err
-	}
-	return append(scanReads, append(writerReads, sqReads...)...), writerWrites, nil
 }
 
 type updateNode struct {

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func newValuesListLenErr(exp, got int) error {
@@ -39,12 +40,16 @@ type valuesNode struct {
 	tuples   [][]parser.TypedExpr
 	rows     *sqlbase.RowContainer
 
+	// isConst is set if the valuesNode only contains constant expressions (no
+	// subqueries). In this case, rows will be evaluated during the first call
+	// to planNode.Start and memoized for future consumption. A valuesNode with
+	// isConst = true can serve its values multiple times. See valuesNode.Reset.
+	isConst bool
+
 	// rowsPopped is used for heaps, it indicates the number of rows that were
 	// "popped". These rows are still part of the underlying sqlbase.RowContainer, in the
 	// range [rows.Len()-n.rowsPopped, rows.Len).
 	rowsPopped int
-
-	desiredTypes []parser.Type // This can be removed when we only type check once.
 
 	nextRow       int  // The index of the next row.
 	invertSorting bool // Inverts the sorting predicate.
@@ -57,6 +62,7 @@ func (p *planner) newContainerValuesNode(columns sqlbase.ResultColumns, capacity
 		rows: sqlbase.NewRowContainer(
 			p.session.TxnState.makeBoundAccount(), sqlbase.ColTypeInfoFromResCols(columns), capacity,
 		),
+		isConst: true,
 	}
 }
 
@@ -64,9 +70,9 @@ func (p *planner) ValuesClause(
 	ctx context.Context, n *parser.ValuesClause, desiredTypes []parser.Type,
 ) (planNode, error) {
 	v := &valuesNode{
-		p:            p,
-		n:            n,
-		desiredTypes: desiredTypes,
+		p:       p,
+		n:       n,
+		isConst: true,
 	}
 	if len(n.Tuples) == 0 {
 		return v, nil
@@ -78,6 +84,9 @@ func (p *planner) ValuesClause(
 	tupleBuf := make([]parser.TypedExpr, len(n.Tuples)*numCols)
 
 	v.columns = make(sqlbase.ResultColumns, 0, numCols)
+
+	defer func(prev bool) { p.hasSubqueries = prev }(p.hasSubqueries)
+	p.hasSubqueries = false
 
 	for num, tuple := range n.Tuples {
 		if a, e := len(tuple.Exprs), numCols; a != e {
@@ -118,11 +127,21 @@ func (p *planner) ValuesClause(
 		v.tuples = append(v.tuples, tupleRow)
 	}
 
+	// TODO(nvanbenschoten): if v.isConst, we should be able to evaluate n.rows
+	// ahead of time. This requires changing the contract for planNode.Close such
+	// that it must always be called unless an error is returned from a planNode
+	// constructor. This would simplify the Close contract, but would make some
+	// code (like in planner.SelectClause) more messy.
+	v.isConst = !p.hasSubqueries
 	return v, nil
 }
 
+// Start implements the planNode interface.
 func (n *valuesNode) Start(params runParams) error {
-	if n.n == nil {
+	if n.rows != nil {
+		if !n.isConst {
+			log.Fatalf(params.ctx, "valuesNode evaluted twice")
+		}
 		return nil
 	}
 
@@ -167,6 +186,16 @@ func (n *valuesNode) Next(runParams) (bool, error) {
 	}
 	n.nextRow++
 	return true, nil
+}
+
+// Reset resets the valuesNode processing state without requiring recomputation
+// of the values tuples if the valuesNode is processed again. Reset can only
+// be called if valuesNode.isConst.
+func (n *valuesNode) Reset(ctx context.Context) {
+	if !n.isConst {
+		log.Fatalf(ctx, "valuesNode.Reset can only be called on constant valuesNodes")
+	}
+	n.nextRow = 0
 }
 
 func (n *valuesNode) Close(ctx context.Context) {

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -19,11 +19,17 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
+
+func newValuesListLenErr(exp, got int) error {
+	return errors.Errorf("VALUES lists must all be the same length, expected %d columns, found %d",
+		exp, got)
+}
 
 type valuesNode struct {
 	n        *parser.ValuesClause
@@ -75,7 +81,7 @@ func (p *planner) ValuesClause(
 
 	for num, tuple := range n.Tuples {
 		if a, e := len(tuple.Exprs), numCols; a != e {
-			return nil, fmt.Errorf("VALUES lists must all be the same length, %d for %d", a, e)
+			return nil, newValuesListLenErr(e, a)
 		}
 
 		// Chop off prefix of tupleBuf and limit its capacity.


### PR DESCRIPTION
Fixes #14953.

Previously, the `roachpb.Spans` reported by `collectSpans` for queries like
`INSERT INTO t VALUES (...)` would span the entire table being modified.
This prevented inserts into the same table from being run in parallel.
This change tightens the predicted read and write-sets for `INSERT ... VALUES`
statements. It does so by evaluating the `VALUES` clause ahead of time and
computing the specific index spans that will be touched by each `VALUES` tuple.

The following two statements will now be considered independent by
`spanBasedDependencyAnalyzer`:

```
INSERT INTO t VALUES (1, 2) RETURNING NOTHING
INSERT INTO t VALUES (3, 4) RETURNING NOTHING
```