### PR TITLE
sql: add crdb_internal.node_runtime_info

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -16,7 +16,6 @@ package base
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
 	"net/url"
 	"sync"
@@ -158,8 +157,11 @@ func (cfg *Config) HTTPRequestScheme() string {
 }
 
 // AdminURL returns the URL for the admin UI.
-func (cfg *Config) AdminURL() string {
-	return fmt.Sprintf("%s://%s", cfg.HTTPRequestScheme(), cfg.HTTPAddr)
+func (cfg *Config) AdminURL() *url.URL {
+	return &url.URL{
+		Scheme: cfg.HTTPRequestScheme(),
+		Host:   cfg.HTTPAddr,
+	}
 }
 
 // GetClientCertPaths returns the paths to the client cert and key.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -388,6 +388,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	nodeInfo := sql.NodeInfo{
+		AdminURL:     cfg.AdminURL,
+		PGURL:        cfg.PGURL,
 		ClusterID:    s.ClusterID,
 		NodeID:       &s.nodeIDContainer,
 		Organization: s.st.ClusterOrganization,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -420,7 +420,7 @@ func (ts *TestServer) WriteSummaries() error {
 
 // AdminURL implements TestServerInterface.
 func (ts *TestServer) AdminURL() string {
-	return ts.Cfg.AdminURL()
+	return ts.Cfg.AdminURL().String()
 }
 
 // GetHTTPClient implements TestServerInterface.

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -16,6 +16,7 @@ package sql
 
 import (
 	"fmt"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -239,6 +240,8 @@ type NodeInfo struct {
 	ClusterID    func() uuid.UUID
 	NodeID       *base.NodeIDContainer
 	Organization *settings.StringSetting
+	AdminURL     func() *url.URL
+	PGURL        func(*url.Userinfo) (*url.URL, error)
 }
 
 // An ExecutorConfig encompasses the auxiliary objects and configuration

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -171,6 +171,23 @@ select crdb_internal.force_retry(interval '0s')
 ----
 0
 
+query ITTT colnames
+select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
+----
+node_id component field  value
+1       DB        URL    postgresql://root@127.0.0.1:<port>?sslcert=test_certs%2Fclient.root.crt&sslkey=test_certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=test_certs%2Fca.crt
+1       DB        Scheme postgresql
+1       DB        User   root
+1       DB        Host   127.0.0.1
+1       DB        Port   <port>
+1       DB        Path   ·
+1       UI        URL    https://127.0.0.1:<port>
+1       UI        Scheme https
+1       UI        User   ·
+1       UI        Host   127.0.0.1
+1       UI        Port   <port>
+1       UI        Path   ·
+
 user testuser
 
 query error pq: insufficient privilege
@@ -181,3 +198,6 @@ select crdb_internal.force_panic('foo')
 
 query error pq: insufficient privilege
 select crdb_internal.force_log_fatal('foo')
+
+query error pq: only root can access the node runtime information
+select * from crdb_internal.node_runtime_info

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -136,7 +136,7 @@ EXPLAIN SHOW TABLES
 1  render  ·      ·
 2  filter  ·      ·
 3  values  ·      ·
-3  ·       size   5 columns, 66 rows
+3  ·       size   5 columns, 67 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -192,7 +192,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·
-7  ·       size      13 columns, 557 rows
+7  ·       size      13 columns, 561 rows
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -216,6 +216,7 @@ crdb_internal       jobs
 crdb_internal       leases
 crdb_internal       node_build_info
 crdb_internal       node_queries
+crdb_internal       node_runtime_info
 crdb_internal       node_sessions
 crdb_internal       node_statement_statistics
 crdb_internal       schema_changes
@@ -365,6 +366,7 @@ def            crdb_internal       jobs                       SYSTEM VIEW  1
 def            crdb_internal       leases                     SYSTEM VIEW  1
 def            crdb_internal       node_build_info            SYSTEM VIEW  1
 def            crdb_internal       node_queries               SYSTEM VIEW  1
+def            crdb_internal       node_runtime_info          SYSTEM VIEW  1
 def            crdb_internal       node_sessions              SYSTEM VIEW  1
 def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
 def            crdb_internal       schema_changes             SYSTEM VIEW  1


### PR DESCRIPTION
Inspired by https://github.com/cockroachdb/cockroach/pull/17686, for which
this was useful (to obtain the AdminURL's port). I'm not sure if there are
security implications (i.e. should this be limited to root if it isn't
already?), but this seemed handy to have.

```
root@:26257/> SELECT * FROM crdb_internal.node_runtime_info;
+---------+----------+---------------------------------------------------+
| node_id |  field   |                       value                       |
+---------+----------+---------------------------------------------------+
|       1 | AdminURL | http://macts-2.local:50558                        |
|       1 | PGURL    | postgresql://@macts-2.local:26257?sslmode=disable |
+---------+----------+---------------------------------------------------+
(2 rows)
```