### PR TITLE
roachpb: format roachpb.Key as hex when requested

### DIFF
--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -16,6 +16,7 @@ package keys
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"testing"
@@ -209,5 +210,18 @@ func TestPrettyPrintRange(t *testing.T) {
 		if str != tc.expected {
 			t.Errorf("%d: expected \"%s\", got \"%s\"", i, tc.expected, str)
 		}
+	}
+}
+
+func TestFormatHexKey(t *testing.T) {
+	// Verify that we properly handling the 'x' formatting verb in
+	// roachpb.Key.Format.
+	key := StoreIdentKey()
+	decoded, err := hex.DecodeString(fmt.Sprintf("%x", key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(key, decoded) {
+		t.Fatalf("expected %s, but found %s", key, decoded)
 	}
 }

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -193,10 +193,12 @@ func (k Key) String() string {
 func (k Key) Format(f fmt.State, verb rune) {
 	// Note: this implementation doesn't handle the width and precision
 	// specifiers such as "%20.10s".
-	if PrettyPrintKey != nil {
+	if verb == 'x' {
+		fmt.Fprintf(f, "%x", []byte(k))
+	} else if PrettyPrintKey != nil {
 		fmt.Fprint(f, PrettyPrintKey(k))
 	} else {
-		fmt.Fprintf(f, strconv.Quote(string(k)))
+		fmt.Fprint(f, strconv.Quote(string(k)))
 	}
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6740,23 +6740,23 @@ func TestDiffRange(t *testing.T) {
 -0.000001729,1 "a"
 -  ts:1970-01-01 00:00:00.000001729 +0000 UTC
 -  value:foo
--  raw_key:"a" raw_value:666f6f
+-  raw_key:61 raw_value:666f6f
 +0.000001729,1 "ab"
 +  ts:1970-01-01 00:00:00.000001729 +0000 UTC
 +  value:foo
-+  raw_key:"ab" raw_value:666f6f
++  raw_key:6162 raw_value:666f6f
 -0.000001729,1 "abcd"
 -  ts:1970-01-01 00:00:00.000001729 +0000 UTC
 -  value:foo
--  raw_key:"abcd" raw_value:666f6f
+-  raw_key:61626364 raw_value:666f6f
 +0.000001729,1 "abcdef"
 +  ts:1970-01-01 00:00:00.000001729 +0000 UTC
 +  value:foo
-+  raw_key:"abcdef" raw_value:666f6f
++  raw_key:616263646566 raw_value:666f6f
 +0.000000000,0 "foo"
 +  ts:<zero>
 +  value:foo
-+  raw_key:"foo" raw_value:666f6f
++  raw_key:666f6f raw_value:666f6f
 `
 
 	if diff := stringDiff.String(); diff != expDiff {


### PR DESCRIPTION
Otherwise, we get the somewhat surprising behavior of `fmt.Sprintf("%x",
key)` returning a pretty-printed key.