### PR TITLE
storage: make resolveIntent's signature less error prone

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -570,7 +570,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 		defer snap.Close()
 		_, info, err := storage.RunGC(context.Background(), &desc, snap, hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
 			config.GCPolicy{TTLSeconds: 24 * 60 * 60 /* 1 day */}, func(_ hlc.Timestamp, _ *roachpb.Transaction, _ roachpb.PushTxnType) {
-			}, func(_ []roachpb.Intent, _, _ bool) error { return nil })
+			}, func(_ []roachpb.Intent, _ storage.ResolveOptions) error { return nil })
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -4366,7 +4366,7 @@ func TestReplicaResolveIntentNoWait(t *testing.T) {
 			Span:   roachpb.Span{Key: key},
 			Txn:    txn.TxnMeta,
 			Status: txn.Status,
-		}}, false /* !wait */, false /* !poison; irrelevant */); pErr != nil {
+		}}, ResolveOptions{Wait: false, Poison: false}); pErr != nil {
 		t.Fatal(pErr)
 	}
 	testutils.SucceedsSoon(t, func() error {


### PR DESCRIPTION
It's too easy to switch the position of the two booleans.
See https://github.com/cockroachdb/cockroach/issues/16266#issuecomment-323618842.