### PR TITLE
acceptance: avoid startup races by listing all nodes in --join

### DIFF
--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -128,6 +128,8 @@ func (at *allocatorTest) Run(ctx context.Context, t *testing.T) {
 	}
 
 	log.Info(ctx, "restarting cluster with archived store(s)")
+	// Ensure all nodes get --join flags on restart.
+	at.f.SkipClusterInit = true
 	ch := make(chan error)
 	for i := 0; i < at.f.NumNodes(); i++ {
 		go func(i int) { ch <- at.f.Restart(ctx, i) }(i)

--- a/pkg/acceptance/terrafarm/farmer.go
+++ b/pkg/acceptance/terrafarm/farmer.go
@@ -463,14 +463,16 @@ func (f *Farmer) Restart(ctx context.Context, i int) error {
 		pidFileName,
 	)
 
-	if f.SkipClusterInit {
+	if f.SkipClusterInit || i != 0 {
+		// Unless we're the first node and we're bootstrapping this cluster, list
+		// every other node in the cluster in the --join flag. (Since we start nodes
+		// in parallel, every non-bootstrapping node needs to know about all the
+		// other nodes to avoid startup races.)
 		hosts := make([]string, len(f.nodes))
 		for i := range hosts {
 			hosts[i] = f.nodes[i].hostname
 		}
 		cmd += " --join=" + strings.Join(hosts, ",")
-	} else if i > 0 {
-		cmd += " --join=" + f.nodes[i-1].hostname
 	}
 
 	c, err := f.getSSH(f.nodes[i].hostname, f.defaultKeyFile())


### PR DESCRIPTION
Since terrafarm now starts nodes in parallel, we need to list all nodes
in the --join flag to avoid startup races. Previously, node N would join
with only N-1, but that required node N-1 to start before node N.