### PR TITLE
storage: Add total bytes metric for admin UI replication graph

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -114,6 +114,9 @@ var (
 	metaValBytes = metric.Metadata{
 		Name: "valbytes",
 		Help: "Number of bytes taken up by values"}
+	metaTotalBytes = metric.Metadata{
+		Name: "totalbytes",
+		Help: "Total number of bytes taken up by keys and values including non-live data"}
 	metaIntentBytes = metric.Metadata{
 		Name: "intentbytes",
 		Help: "Number of bytes in intent KV pairs"}
@@ -510,6 +513,7 @@ type StoreMetrics struct {
 	LiveBytes       *metric.Gauge
 	KeyBytes        *metric.Gauge
 	ValBytes        *metric.Gauge
+	TotalBytes      *metric.Gauge
 	IntentBytes     *metric.Gauge
 	LiveCount       *metric.Gauge
 	KeyCount        *metric.Gauge
@@ -702,6 +706,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		LiveBytes:       metric.NewGauge(metaLiveBytes),
 		KeyBytes:        metric.NewGauge(metaKeyBytes),
 		ValBytes:        metric.NewGauge(metaValBytes),
+		TotalBytes:      metric.NewGauge(metaTotalBytes),
 		IntentBytes:     metric.NewGauge(metaIntentBytes),
 		LiveCount:       metric.NewGauge(metaLiveCount),
 		KeyCount:        metric.NewGauge(metaKeyCount),
@@ -868,6 +873,7 @@ func (sm *StoreMetrics) updateMVCCGaugesLocked() {
 	sm.LiveBytes.Update(sm.mu.stats.LiveBytes)
 	sm.KeyBytes.Update(sm.mu.stats.KeyBytes)
 	sm.ValBytes.Update(sm.mu.stats.ValBytes)
+	sm.TotalBytes.Update(sm.mu.stats.Total())
 	sm.IntentBytes.Update(sm.mu.stats.IntentBytes)
 	sm.LiveCount.Update(sm.mu.stats.LiveCount)
 	sm.KeyCount.Update(sm.mu.stats.KeyCount)

--- a/pkg/ui/src/util/proto.ts
+++ b/pkg/ui/src/util/proto.ts
@@ -48,6 +48,7 @@ export namespace MetricConstants {
   export const liveBytes: string = "livebytes";
   export const keyBytes: string = "keybytes";
   export const valBytes: string = "valbytes";
+  export const totalBytes: string = "totalbytes";
   export const intentBytes: string = "intentbytes";
   export const liveCount: string = "livecount";
   export const keyCount: string = "keycount";

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -51,13 +51,13 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Live Bytes per Store" tooltip={`The number of live bytes of data on each store.`}>
+    <LineGraph title="Logical Bytes per Store" tooltip={`The number of logical bytes of data on each store.`}>
       <Axis units={AxisUnits.Bytes}>
         {
           _.map(nodeIDs, (nid) => (
             <Metric
               key={nid}
-              name="cr.store.livebytes"
+              name="cr.store.totalbytes"
               title={nodeAddress(nodesSummary, nid)}
               sources={storeIDsForNode(nodesSummary, nid)}
             />


### PR DESCRIPTION
Fixes #17753

As mentioned on #17753, this is only needed if we don't have a way to add two metrics together in an admin UI graph, but I don't think we currently have the ability to do that.