### PR TITLE
sql: remove n^2 algorithm in addOrReuseRenders

### DIFF
--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -242,7 +242,7 @@ func (p *planner) groupBy(
 		if err != nil {
 			return nil, nil, err
 		}
-		postRender.addRenderColumn(renderExpr, origColumns[i])
+		postRender.addRenderColumn(renderExpr, symbolicExprStr(renderExpr), origColumns[i])
 	}
 
 	postRender.source.info = newSourceInfoForSingleTable(anonymousTable, group.columns)

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -90,7 +90,14 @@ func (s *renderNode) equivalentRenders(i, j int) bool {
 // isRenderEquivalent is a helper function for equivalentRenders() and
 // addOrMergeRenders(). Do not use directly.
 func (s *renderNode) isRenderEquivalent(exprStr string, j int) bool {
-	return symbolicExprStr(s.render[j]) == exprStr
+	otherExprStr := s.renderStrings[j]
+	// otherExprStr may be the empty string if the render columns were reset.
+	// In that case, just recompute on demand.
+	if otherExprStr == "" {
+		otherExprStr = symbolicExprStr(s.render[j])
+		s.renderStrings[j] = otherExprStr
+	}
+	return otherExprStr == exprStr
 }
 
 // addOrReuseRender adds the given result column to the select render list and
@@ -100,13 +107,13 @@ func (s *renderNode) isRenderEquivalent(exprStr string, j int) bool {
 func (s *renderNode) addOrReuseRender(
 	col sqlbase.ResultColumn, expr parser.TypedExpr, reuseExistingRender bool,
 ) (colIdx int) {
+	exprStr := symbolicExprStr(expr)
 	if reuseExistingRender && len(s.render) > 0 {
 		// Now, try to find an equivalent render. We use the syntax
 		// representation as approximation of equivalence.  At this
 		// point the expressions must have underwent name resolution
 		// already so that comparison occurs after replacing column names
 		// to IndexedVars.
-		exprStr := symbolicExprStr(expr)
 		for j := range s.render {
 			if s.isRenderEquivalent(exprStr, j) {
 				return j
@@ -114,7 +121,7 @@ func (s *renderNode) addOrReuseRender(
 		}
 	}
 
-	s.addRenderColumn(expr, col)
+	s.addRenderColumn(expr, exprStr, col)
 
 	return len(s.render) - 1
 }


### PR DESCRIPTION
addOrReuseRenders iterates through a list of columns and expressions,
adding renders for them or reusing old renders for them if possible. It
checks for reuse by stringifying the expressions with a special format
flag.

This used to result in n^2 stringifications since we weren't memoizing
the stringified expressions. This commit adds a cache for those.