### PR TITLE
sql: Exclude statements that spawn jobs from showing up in query tables.

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1094,12 +1094,18 @@ func (e *Executor) execStmtsInCurrentTxn(
 		queryMeta.ctx = txnState.Ctx
 		queryMeta.ctxCancel = txnState.cancel
 
-		// For parallel/async queries, we deregister queryMeta from these registries
-		// after execution finishes in the parallelizeQueue. For all other (synchronous) queries,
-		// we deregister these in session.FinishPlan when all results have been sent. We cannot
-		// deregister asynchronous queries in session.FinishPlan because they may still be
-		// executing at that instant.
-		session.addActiveQuery(queryID, queryMeta)
+		// Ignore statements that spawn jobs from SHOW QUERIES and from being cancellable
+		// using CANCEL QUERY. Jobs have their own run control statements (CANCEL JOB,
+		// PAUSE JOB, etc). We implement this ignore by not registering queryMeta in
+		// session.mu.ActiveQueries.
+		if _, ok := stmt.AST.(parser.HiddenFromShowQueries); !ok {
+			// For parallel/async queries, we deregister queryMeta from these registries
+			// after execution finishes in the parallelizeQueue. For all other
+			// (synchronous) queries, we deregister these in session.FinishPlan when
+			// all results have been sent. We cannot deregister asynchronous queries in
+			// session.FinishPlan because they may still be executing at that instant.
+			session.addActiveQuery(queryID, queryMeta)
+		}
 
 		var stmtStrBefore string
 		// TODO(nvanbenschoten): Constant literals can change their representation (1.0000 -> 1) when type checking,

--- a/pkg/sql/parser/stmt.go
+++ b/pkg/sql/parser/stmt.go
@@ -78,6 +78,14 @@ type HiddenFromStats interface {
 	hiddenFromStats()
 }
 
+// HiddenFromShowQueries is a pseudo-interface to be implemented
+// by statements that should not show up in SHOW QUERIES (and are hence
+// not cancellable using CANCEL QUERY either). Usually implemented by
+// statements that spawn jobs.
+type HiddenFromShowQueries interface {
+	hiddenFromShowQueries()
+}
+
 // IndependentFromParallelizedPriors is a pseudo-interface to be implemented
 // by statements which do not force parallel statement execution synchronization
 // when they run.
@@ -91,11 +99,15 @@ func (*AlterTable) StatementType() StatementType { return DDL }
 // StatementTag returns a short string identifying the type of statement.
 func (*AlterTable) StatementTag() string { return "ALTER TABLE" }
 
+func (*AlterTable) hiddenFromShowQueries() {}
+
 // StatementType implements the Statement interface.
 func (*Backup) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*Backup) StatementTag() string { return "BACKUP" }
+
+func (*Backup) hiddenFromShowQueries() {}
 
 // StatementType implements the Statement interface.
 func (*BeginTransaction) StatementType() StatementType { return Ack }
@@ -324,6 +336,8 @@ func (*Restore) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
 func (*Restore) StatementTag() string { return "RESTORE" }
+
+func (*Restore) hiddenFromShowQueries() {}
 
 // StatementType implements the Statement interface.
 func (*ResumeJob) StatementType() StatementType { return Ack }


### PR DESCRIPTION
Add a type switch for the AST, and manually exclude BACKUP/RESTORE/ALTER TABLEss from being added to `session.mu.ActiveQueries`, making them uncancellable and "invisible" to `SHOW QUERIES`.

Fixes #17730 .