### PR TITLE
server, settings, util/log: add a cluster setting to block vmodule requests

### DIFF
--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -224,6 +224,7 @@ type StorageSettings struct {
 type UISettings struct {
 	WebSessionTimeout *settings.DurationSetting
 	DebugRemote       *settings.StringSetting
+	DebugVModule      *settings.BoolSetting
 }
 
 // CCLSettings is the subset of ClusterSettings affecting
@@ -694,6 +695,13 @@ func MakeClusterSettings(minVersion, serverVersion roachpb.Version) *Settings {
 			}
 		},
 	)
+
+	s.DebugVModule = r.RegisterBoolSetting(
+		"server.remote_debugging.vmodule",
+		"set to enable remote control over vmodule (this can severely impact performance)",
+		false,
+	)
+
 	s.ClusterOrganization = r.RegisterStringSetting("cluster.organization", "organization name", "")
 
 	// FIXME(tschottdorf): should be NonNegative?

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -70,6 +70,7 @@ rocksdb.min_wal_sync_interval                      0s             d     minimum 
 server.declined_reservation_timeout                1s             d     the amount of time to consider the store throttled for up-replication after a reservation was declined
 server.failed_reservation_timeout                  5s             d     the amount of time to consider the store throttled for up-replication after a failed reservation call
 server.remote_debugging.mode                       local          s     set to enable remote debugging, localhost-only or disable (any, local, off)
+server.remote_debugging.vmodule                    false          b     set to enable remote control over vmodule (this can severely impact performance)
 server.time_until_store_dead                       5m0s           d     the time after which if there is no new gossiped information about a store, it is considered dead
 server.web_session_timeout                         168h0m0s       d     the duration that a newly created web session will be valid
 sql.defaults.distsql                               0              e     Default distributed SQL execution mode [off = 0, auto = 1, on = 2]

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -17,26 +17,12 @@ package log
 import (
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	"golang.org/x/net/context"
 )
 
-const httpLogLevelPrefix = "/debug/vmodule/"
-
-func handleVModule(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	spec := r.RequestURI[len(httpLogLevelPrefix):]
-	if err := logging.vmodule.Set(spec); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-	Infof(context.Background(), "vmodule changed to: %s", spec)
-	fmt.Fprint(w, "ok: "+spec)
-}
-
 func init() {
-	http.Handle(httpLogLevelPrefix, http.HandlerFunc(handleVModule))
 	copyStandardLogTo("INFO")
 }
 
@@ -191,4 +177,9 @@ func (e Entry) Format(w io.Writer) error {
 	defer logging.putBuffer(buf)
 	_, err := w.Write(buf.Bytes())
 	return err
+}
+
+// SetVModule alters the vmodule logging level to the passed in value.
+func SetVModule(value string) error {
+	return logging.vmodule.Set(value)
 }


### PR DESCRIPTION
This required moving the handling of the vmodule endpoint out of logging and into dubug, but it does seem more at home there.

Closes #16508.