### PR TITLE
storage: avoid timer deadlock in quotaPool + add lint check

### DIFF
--- a/pkg/cmd/metacheck/main.go
+++ b/pkg/cmd/metacheck/main.go
@@ -15,7 +15,9 @@
 package main
 
 import (
+	"fmt"
 	"go/ast"
+	"go/token"
 	"go/types"
 	"log"
 	"os"
@@ -39,7 +41,8 @@ func (m *metaChecker) Init(program *lint.Program) {
 
 func (m *metaChecker) Funcs() map[string]lint.Func {
 	funcs := map[string]lint.Func{
-		"FloatToUnsigned": checkConvertFloatToUnsigned,
+		"FloatToUnsigned":   checkConvertFloatToUnsigned,
+		"TimeutilTimerRead": checkSetTimeutilTimerRead,
 	}
 	for _, checker := range m.checkers {
 		for k, v := range checker.Funcs() {
@@ -51,6 +54,12 @@ func (m *metaChecker) Funcs() map[string]lint.Func {
 		}
 	}
 	return funcs
+}
+
+func forAllFiles(j *lint.Job, fn func(node ast.Node) bool) {
+	for _, f := range j.Program.Files {
+		ast.Inspect(f, fn)
+	}
 }
 
 // @ianlancetaylor via golang-nuts[0]:
@@ -75,8 +84,8 @@ func (m *metaChecker) Funcs() map[string]lint.Func {
 //
 // TODO(tamird): upstream this.
 func checkConvertFloatToUnsigned(j *lint.Job) {
-	fn := func(node ast.Node) bool {
-		call, ok := node.(*ast.CallExpr)
+	forAllFiles(j, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
@@ -98,10 +107,166 @@ func checkConvertFloatToUnsigned(j *lint.Job) {
 			j.Errorf(arg, "do not convert a floating point number to an unsigned integer type")
 		}
 		return true
+	})
+}
+
+func walkForStmts(n ast.Node, fn func(s ast.Stmt) bool) bool {
+	fr, ok := n.(*ast.ForStmt)
+	if !ok {
+		return true
 	}
-	for _, f := range j.Program.Files {
-		ast.Inspect(f, fn)
+	return walkStmts(fr.Body.List, fn)
+}
+
+func walkSelectStmts(n ast.Node, fn func(s ast.Stmt) bool) bool {
+	sel, ok := n.(*ast.SelectStmt)
+	if !ok {
+		return true
 	}
+	return walkStmts(sel.Body.List, fn)
+}
+
+func walkStmts(stmts []ast.Stmt, fn func(s ast.Stmt) bool) bool {
+	for _, stmt := range stmts {
+		if !fn(stmt) {
+			return false
+		}
+	}
+	return true
+}
+
+// checkSetTimeutilTimerRead assures that timeutil.Timer objects are used
+// correctly, to avoid race conditions and deadlocks. These timers require
+// callers to set their Read field to true when their channel has been received
+// on. If this field is not set and the timer's Reset method is called, we will
+// deadlock. This lint assures that the Read field is set in the most common
+// case where Reset is used, within a for-loop where each iteration blocks
+// on a select statement. The timers are usually used as timeouts on these
+// select statements, and need to be reset after each iteration.
+//
+// for {
+//   timer.Reset(...)
+//   select {
+//     case <-timer.C:
+//       timer.Read = true   <--  lint verifies that this line is present
+//     case ...:
+//   }
+// }
+//
+func checkSetTimeutilTimerRead(j *lint.Job) {
+	var timerType *types.Named
+	func() {
+		for _, typVal := range j.Program.Info.Types {
+			if typ, ok := typVal.Type.(*types.Named); ok {
+				if typ.String() == "github.com/cockroachdb/cockroach/pkg/util/timeutil.Timer" {
+					timerType = typ
+					return
+				}
+			}
+		}
+		log.Fatal("no timeutil.Timer type found")
+	}()
+
+	const chanName = "C"
+	func() {
+		if typ, ok := timerType.Underlying().(*types.Struct); ok {
+			for i := 0; i < typ.NumFields(); i++ {
+				if typ.Field(i).Name() == chanName {
+					return
+				}
+			}
+		}
+		log.Fatalf("no field called %q in type %s", chanName, timerType)
+	}()
+
+	selectorIsTimer := func(s *ast.SelectorExpr) bool {
+		selTyp := j.Program.Info.TypeOf(s.X)
+		if ptr, ok := selTyp.(*types.Pointer); ok {
+			selTyp = ptr.Elem()
+		}
+		return selTyp == timerType
+	}
+
+	forAllFiles(j, func(n ast.Node) bool {
+		return walkForStmts(n, func(s ast.Stmt) bool {
+			return walkSelectStmts(s, func(s ast.Stmt) bool {
+				comm, ok := s.(*ast.CommClause)
+				if !ok || comm.Comm == nil /* default: */ {
+					return true
+				}
+
+				// if receiving on a timer's C chan.
+				var unary ast.Expr
+				switch v := comm.Comm.(type) {
+				case *ast.AssignStmt:
+					// case `now := <-timer.C:`
+					unary = v.Rhs[0]
+				case *ast.ExprStmt:
+					// case `<-timer.C:`
+					unary = v.X
+				default:
+					return true
+				}
+				chanRead, ok := unary.(*ast.UnaryExpr)
+				if !ok || chanRead.Op != token.ARROW {
+					return true
+				}
+				selector, ok := chanRead.X.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				if !selectorIsTimer(selector) {
+					return true
+				}
+				selectorName := fmt.Sprint(selector.X)
+				if selector.Sel.String() != chanName {
+					return true
+				}
+
+				// Verify that the case body contains `timer.Read = true`.
+				noRead := walkStmts(comm.Body, func(s ast.Stmt) bool {
+					assign, ok := s.(*ast.AssignStmt)
+					if !ok || assign.Tok != token.ASSIGN {
+						return true
+					}
+					for i := range assign.Lhs {
+						l, r := assign.Lhs[i], assign.Rhs[i]
+
+						// if assignment to correct field in timer.
+						assignSelector, ok := l.(*ast.SelectorExpr)
+						if !ok {
+							return true
+						}
+						if !selectorIsTimer(assignSelector) {
+							return true
+						}
+						if fmt.Sprint(assignSelector.X) != selectorName {
+							return true
+						}
+						if assignSelector.Sel.String() != "Read" {
+							return true
+						}
+
+						// if assigning `true`.
+						val, ok := r.(*ast.Ident)
+						if !ok {
+							return true
+						}
+						if val.String() == "true" {
+							// returning false will short-circuit walkStmts and assign
+							// noRead to false instead of the default value of true.
+							return false
+						}
+					}
+					return true
+				})
+				if noRead {
+					j.Errorf(comm, "must set timer.Read = true after reading from timer.C (see timeutil/timer.go)")
+				}
+				return true
+			})
+		})
+	})
 }
 
 func main() {

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1152,6 +1152,7 @@ func (ds *DistSender) sendToReplicas(
 	for {
 		select {
 		case <-slowTimer.C:
+			slowTimer.Read = true
 			log.Warningf(ctx, "have been waiting %s sending RPC to r%d for batch: %s",
 				base.SlowRequestThreshold, rangeID, args)
 			ds.metrics.SlowRequestsCount.Inc(1)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1376,6 +1376,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 					log.Eventf(ctx, "lease acquisition succeeded: %+v", status.lease)
 					return nil
 				case <-slowTimer.C:
+					slowTimer.Read = true
 					log.Warningf(ctx, "have been waiting %s attempting to acquire lease",
 						base.SlowRequestThreshold)
 					r.store.metrics.SlowLeaseRequests.Inc(1)
@@ -2627,6 +2628,7 @@ func (r *Replica) tryExecuteWriteBatch(
 			}
 			return propResult.Reply, propResult.Err, propResult.ProposalRetry
 		case <-slowTimer.C:
+			slowTimer.Read = true
 			log.Warningf(ctx, "have been waiting %s for proposing command %s",
 				base.SlowRequestThreshold, ba)
 			r.store.metrics.SlowRaftRequests.Inc(1)


### PR DESCRIPTION
Maybe fixes #17524.

When a `timeutil.Timer` is read from, it needs to set `timer.Read = true`
before calling `timer.Reset` or it risks deadlocking itself. A deadlock
in the `quotaPool` was possible because it missed this step. Once the
`quotaPool` deadlocked, it would block the `CommandQueue` and wreak havoc
on a cluster.

To prevent against this happening again, this change adds a new lint check that
assures that `timeutil.Timer` is used correctly.

> checkSetTimeutilTimerRead assures that timeutil.Timer objects are used
> correctly, to avoid race conditions and deadlocks. These timers require
> callers to set their Read field to true when their channel has been received
> on. If this field is not set and the timer's Reset method is called, we will
> deadlock. This lint assures that the Read field is set in the most common
> case where Reset is used, within a for-loop where each iteration blocks
> on a select statement. The timers are usually used as timeouts on these
> select statements, and need to be reset after each iteration.
>
> ```
> for {
>   timer.Reset(...)
>   select {
>     case <-timer.C:
>       timer.Read = true   <--  lint verifies that this line is present
>     case ...:
>   }
> }
> ```

Note that the lint is triggered even if `Reset` is not present in each iteration.
Even though this case will not deadlock without the `timer.Read = true`, I
think it's safer to mandate that all select cases set the `Read` flag anyway.
This prevents against issues calling `Reset` sometime after the `for` loop, which
could still deadlock.

@tschottdorf for the first commit, @tamird for the second.