### PR TITLE
sql: up the noteworthy distsql mem usage to 1mb

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -80,7 +80,7 @@ const MinAcceptedVersion DistSQLVersion = 4
 // (see sql.defaults.distsql.tempstorage).
 var workMemBytes = envutil.EnvOrDefaultInt64("COCKROACH_WORK_MEM", 64*1024*1024 /* 64MB */)
 
-var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_DISTSQL_MEMORY_USAGE", 10*1024)
+var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_DISTSQL_MEMORY_USAGE", 1024*1024 /* 1MB */)
 
 // All queries that spill over to disk will be limited to use
 // total space / diskBudgetTotalSizeDivisor.


### PR DESCRIPTION
The default noteworthy distsql memory usage threshold used to be 10kb,
which led to a lot of log spam in common queries. Up the threshold to 1
megabyte.