### PR TITLE
storage: enable pre-vote by default

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -45,7 +45,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -96,8 +95,6 @@ var defaultProposalQuota = raftLogMaxSize / 4
 // resolved synchronously with EndTransaction). Certain tests become
 // simpler with this being turned off.
 var txnAutoGC = true
-
-var tickQuiesced = envutil.EnvOrDefaultBool("COCKROACH_TICK_QUIESCED", true)
 
 // raftInitialLog{Index,Term} are the starting points for the raft log. We
 // bootstrap the raft membership by synthesizing a snapshot as if there were
@@ -3518,7 +3515,7 @@ func (r *Replica) tick() (bool, error) {
 		//
 		// For more details, see #9372.
 		// TODO(bdarnell): remove this once we have fully switched to PreVote
-		if tickQuiesced {
+		if !enablePreVote {
 			r.mu.internalRaftGroup.TickQuiesced()
 		}
 		return false, nil
@@ -3554,7 +3551,7 @@ func (r *Replica) maybeTickQuiesced() bool {
 		done = true
 	} else if r.mu.quiescent {
 		done = true
-		if tickQuiesced {
+		if !enablePreVote {
 			// NB: It is safe to call TickQuiesced without holding Replica.raftMu
 			// because that method simply increments a counter without performing any
 			// other logic.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -108,7 +108,7 @@ var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_SCHEDULER_CONCURRENCY", 8*runtime.NumCPU())
 
 var enablePreVote = envutil.EnvOrDefaultBool(
-	"COCKROACH_ENABLE_PREVOTE", false)
+	"COCKROACH_ENABLE_PREVOTE", true)
 
 // TestStoreConfig has some fields initialized with values relevant in tests.
 func TestStoreConfig(clock *hlc.Clock) StoreConfig {


### PR DESCRIPTION
Tested on `blue` under heavy chaos for half a week, tested on `ultramarine` for a week. Part of #16950.

crontab for `blue`:
```cron
0  0-23/8 * * * /home/cockroach/chaos_runner.sh 60 1200
48 0-23/8 * * * /home/cockroach/chaos_runner.sh 60 1200
36 1-23/8 * * * /home/cockroach/chaos_runner.sh 60 1200
24 2-23/8 * * * /home/cockroach/chaos_runner.sh 60 1200
12 3-23/8 * * * /home/cockroach/chaos_runner.sh 60 1200
0  4-23/8 * * * /home/cockroach/chaos_runner.sh 60 1200
48 4-23/8 * * * /home/cockroach/chaos_runner.sh 60 1200
36 5-23/8 * * * /home/cockroach/chaos_runner.sh 60 1200
24 6-23/8 * * * /home/cockroach/chaos_runner.sh 60 1200
12 7-23/8 * * * /home/cockroach/chaos_runner.sh 60 1200
```

crontab for `ultramarine`:
```cron
0  * * * * /home/cockroach/chaos_runner.sh 60 600
14 * * * * /home/cockroach/chaos_runner.sh 60 600
29 * * * * /home/cockroach/chaos_runner.sh 60 600
44 * * * * /home/cockroach/chaos_runner.sh 60 600
```

![image](https://user-images.githubusercontent.com/10536690/29573551-413af014-872d-11e7-9d7e-47ae424e9d0e.png)

Last ultramarine chaos run can be found [here](https://monitoring.crdb.io/dashboard/db/cockroach-summary?from=1502939240894&to=now&orgId=1&var-cluster=ultramarine&var-node=All&var-rate_interval=5m). Nothing jumps out to me. Ditto for the logs on `ultramarine`, still present (`blue` was wiped out for 1.0.5 testing).

+cc @bdarnell 