### PR TITLE
storage: only fire slow timers once

### DIFF
--- a/pkg/storage/quota_pool.go
+++ b/pkg/storage/quota_pool.go
@@ -143,8 +143,10 @@ func (qp *quotaPool) acquire(ctx context.Context, v int64) error {
 	defer slowTimer.Stop()
 	start := timeutil.Now()
 
+	// Intentionally reset only once, for we care more about the select duration in
+	// goroutine profiles than periodic logging.
+	slowTimer.Reset(base.SlowRequestThreshold)
 	for {
-		slowTimer.Reset(base.SlowRequestThreshold)
 		select {
 		case now := <-slowTimer.C:
 			slowTimer.Read = true
@@ -190,8 +192,8 @@ func (qp *quotaPool) acquire(ctx context.Context, v int64) error {
 	// next in line (if any).
 
 	var acquired int64
+	slowTimer.Reset(base.SlowRequestThreshold)
 	for acquired < v {
-		slowTimer.Reset(base.SlowRequestThreshold)
 		select {
 		case now := <-slowTimer.C:
 			slowTimer.Read = true


### PR DESCRIPTION
Before this change, deadlocked selects would artificially "wrap around"
regularly, which makes it harder to spot them in goroutine profiles.

cc @nvanbenschoten