### PR TITLE
sql: support star expansion in sub-expressions

### DIFF
--- a/pkg/sql/analyze.go
+++ b/pkg/sql/analyze.go
@@ -1649,10 +1649,12 @@ func (p *planner) analyzeExpr(
 	if sources == nil {
 		resolved = replaced
 	} else {
-		resolved, _, err = p.resolveNames(replaced, sources, iVarHelper)
+		var hasStar bool
+		resolved, _, hasStar, err = p.resolveNames(replaced, sources, iVarHelper)
 		if err != nil {
 			return nil, err
 		}
+		p.hasStar = p.hasStar || hasStar
 	}
 
 	// Type check.

--- a/pkg/sql/analyze_test.go
+++ b/pkg/sql/analyze_test.go
@@ -79,7 +79,7 @@ func parseAndNormalizeExpr(
 
 	// Perform name resolution because {analyze,simplify}Expr want
 	// expressions containing IndexedVars.
-	if expr, _, err = sel.resolveNames(expr); err != nil {
+	if expr, _, _, err = sel.resolveNames(expr); err != nil {
 		t.Fatalf("%s: %v", sql, err)
 	}
 	typedExpr, err := parser.TypeCheck(expr, nil, parser.TypeAny)

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -1541,30 +1541,3 @@ func makeCheckConstraint(
 	}
 	return &sqlbase.TableDescriptor_CheckConstraint{Expr: parser.Serialize(d.Expr), Name: name}, nil
 }
-
-// planContainsStar returns true if one of the render nodes in the
-// plan contains a star expansion.
-func (p *planner) planContainsStar(ctx context.Context, plan planNode) bool {
-	s := &starDetector{}
-	_ = walkPlan(ctx, plan, planObserver{enterNode: s.enterNode})
-	return s.foundStar
-}
-
-// starDetector supports planContainsStar().
-type starDetector struct {
-	foundStar bool
-}
-
-// enterNode implements the planObserver interface.
-func (s *starDetector) enterNode(_ context.Context, _ string, plan planNode) bool {
-	if s.foundStar {
-		return false
-	}
-	if sel, ok := plan.(*renderNode); ok {
-		if sel.isStar {
-			s.foundStar = true
-			return false
-		}
-	}
-	return true
-}

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -164,7 +164,7 @@ func (p *planner) groupBy(
 		if err != nil {
 			return nil, nil, err
 		}
-		r.isStar = r.isStar || hasStar
+		p.hasStar = p.hasStar || hasStar
 		colIdxs := r.addOrReuseRenders(cols, exprs, true /* reuseExistingRender */)
 		if !hasStar {
 			groupStrs[symbolicExprStr(g)] = colIdxs[0]

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -110,9 +110,30 @@ func (p *planner) groupBy(
 			// below. We do however need to resolveNames so the
 			// AssertNoAggregationOrWindowing call below can find resolved
 			// FunctionDefs in the AST (instead of UnresolvedNames).
-			resolvedExpr, _, err := p.resolveNames(expr, r.sourceInfo, r.ivarHelper)
-			if err != nil {
-				return nil, nil, err
+
+			// While doing so, we must be careful not to expand top-level
+			// stars, because this is handled specially by
+			// computeRenderAllowingStars below.
+			skipResolve := false
+			if vName, ok := expr.(parser.VarName); ok {
+				v, err := vName.NormalizeVarName()
+				if err != nil {
+					return nil, nil, err
+				}
+				switch v.(type) {
+				case parser.UnqualifiedStar, *parser.AllColumnsSelector:
+					skipResolve = true
+				}
+			}
+
+			resolvedExpr := expr
+			if !skipResolve {
+				var hasStar bool
+				resolvedExpr, _, hasStar, err = p.resolveNames(expr, r.sourceInfo, r.ivarHelper)
+				if err != nil {
+					return nil, nil, err
+				}
+				p.hasStar = p.hasStar || hasStar
 			}
 			groupByExprs[i] = resolvedExpr
 		}

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -431,8 +431,10 @@ SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM kv
 count(*)  count(k)  count(kv.v)
 6         6         5
 
-query error cannot use "kv\.\*" in this context
+query I
 SELECT COUNT(kv.*) FROM kv
+----
+6
 
 query III
 SELECT COUNT(DISTINCT k), COUNT(DISTINCT v), COUNT(DISTINCT (v)) FROM kv

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1195,24 +1195,24 @@ query error pq: cos\(\): cannot use "\*" in this context
 SELECT COS(*) FROM system.namespace
 
 # Don't panic with invalid names (#8045)
-query error rtrim\(\): cannot use "nonexistent.\*" in this context
+query error cannot use "nonexistent.\*" without a FROM clause
 SELECT TRIM(TRAILING nonexistent.*[1])
 
-query error rtrim\(\): cannot use "foo.\*" in this context
+query error rtrim\(\): cannot subscript type tuple
 SELECT TRIM(TRAILING foo.*[1]) FROM (VALUES (1)) AS foo(x)
 
 # Don't panic with invalid names (#8044)
-query error cannot use "nonexistent.\*" in this context
+query error cannot use "nonexistent.\*" without a FROM clause
 SELECT OVERLAY(nonexistent.* PLACING 'string' FROM 'string')
 
-query error cannot use "foo.\*" in this context
+query error unknown signature
 SELECT OVERLAY(foo.* PLACING 'string' FROM 'string') FROM (VALUES (1)) AS foo(x)
 
 # Don't panic with invalid names (#8023)
-query error cannot use "nonexistent.\*" in this context
+query error cannot use "nonexistent.\*" without a FROM clause
 SELECT nonexistent.* IS NOT TRUE
 
-query error cannot use "foo.\*" in this context
+query error unsupported comparison operator: <tuple{int}> IS NOT <bool>
 SELECT foo.* IS NOT TRUE FROM (VALUES (1)) AS foo(x)
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -494,7 +494,7 @@ INSERT INTO return AS r VALUES (5, 6)
 statement ok
 INSERT INTO return VALUES (5, 6) RETURNING test.return.a
 
-statement error cannot use "x.\*" in this context
+statement error source name "x" not found in FROM clause
 INSERT INTO return VALUES (1, 2) RETURNING x.*[1]
 
 statement error column name "x" not found

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -160,7 +160,7 @@ query error source name "bar.kv" not found in FROM clause
 SELECT bar.kv.* FROM kv
 
 # Don't panic with invalid names (#8024)
-query error cannot use "kv.\*" in this context
+query error cannot subscript type tuple\{string, string\} because it is not an array
 SELECT kv.*[1] FROM kv
 
 query T colnames

--- a/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
+++ b/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
@@ -1,0 +1,118 @@
+statement ok
+CREATE TABLE a(x, y) AS VALUES (1, 1), (2, 2)
+
+query II
+SELECT a.* FROM a
+----
+1  1
+2  2
+
+query T
+SELECT (a.*) FROM a
+----
+(1,1)
+(2,2)
+
+query I
+SELECT COUNT(*) FROM a x, a y
+----
+4
+
+query I
+SELECT COUNT(DISTINCT x.*) FROM a x, a y
+----
+2
+
+query ITTTTT
+EXPLAIN(VERBOSE) SELECT COUNT(DISTINCT x.*) FROM a x, a y
+----
+0  group   ·            ·                           ("count(DISTINCT x.*)")                                                       ·
+0  ·       aggregate 0  count(DISTINCT (x.x, x.y))  ·                                                                             ·
+1  render  ·            ·                           ("(x, y)")                                                                    ·
+1  ·       render 0     (x.x, x.y)                  ·                                                                             ·
+2  join    ·            ·                           (x, y, rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
+2  ·       type         cross                       ·                                                                             ·
+3  scan    ·            ·                           (x, y, rowid[hidden,omitted])                                                 ·
+3  ·       table        a@primary                   ·                                                                             ·
+3  ·       spans        ALL                         ·                                                                             ·
+3  scan    ·            ·                           (x[omitted], y[omitted], rowid[hidden,omitted])                               ·
+3  ·       table        a@primary                   ·                                                                             ·
+3  ·       spans        ALL                         ·                                                                             ·
+
+query ITTT
+EXPLAIN(EXPRS) SELECT * FROM a ORDER BY a.*
+----
+0  sort    ·         ·
+0  ·       order     +x,+y
+1  render  ·         ·
+1  ·       render 0  x
+1  ·       render 1  y
+2  scan    ·         ·
+2  ·       table     a@primary
+2  ·       spans     ALL
+
+query ITTT
+EXPLAIN(EXPRS) SELECT * FROM a ORDER BY (a.*)
+----
+0  sort    ·         ·
+0  ·       order     +x,+y
+1  render  ·         ·
+1  ·       render 0  x
+1  ·       render 1  y
+2  scan    ·         ·
+2  ·       table     a@primary
+2  ·       spans     ALL
+
+query ITTT
+EXPLAIN(EXPRS) SELECT MIN(y.x) FROM a x, a y GROUP BY x.*
+----
+0  group   ·            ·
+0  ·       aggregate 0  min(x)
+1  render  ·            ·
+1  ·       render 0     x
+1  ·       render 1     y
+1  ·       render 2     x
+2  join    ·            ·
+2  ·       type         cross
+3  scan    ·            ·
+3  ·       table        a@primary
+3  ·       spans        ALL
+3  scan    ·            ·
+3  ·       table        a@primary
+3  ·       spans        ALL
+
+query ITTT
+EXPLAIN(EXPRS) SELECT MIN(y.x) FROM a x, a y GROUP BY (1, (x.*))
+----
+0  group   ·            ·
+0  ·       aggregate 0  min(x)
+1  render  ·            ·
+1  ·       render 0     (1, (x, y))
+1  ·       render 1     x
+2  join    ·            ·
+2  ·       type         cross
+3  scan    ·            ·
+3  ·       table        a@primary
+3  ·       spans        ALL
+3  scan    ·            ·
+3  ·       table        a@primary
+3  ·       spans        ALL
+
+# A useful optimization: naked tuple expansion in GROUP BY clause.
+query ITTT
+EXPLAIN(EXPRS) SELECT MIN(y.x) FROM a x, a y GROUP BY (x.*)
+----
+0  group   ·            ·
+0  ·       aggregate 0  min(x)
+1  render  ·            ·
+1  ·       render 0     x
+1  ·       render 1     y
+1  ·       render 2     x
+2  join    ·            ·
+2  ·       type         cross
+3  scan    ·            ·
+3  ·       table        a@primary
+3  ·       spans        ALL
+3  scan    ·            ·
+3  ·       table        a@primary
+3  ·       spans        ALL

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -90,6 +90,11 @@ type planner struct {
 	// TODO(knz): Remove this in favor of a better encapsulated mechanism.
 	planDeps planDependencies
 
+	// hasStar collects whether any star expansion has occurred during
+	// logical plan construction. This is used by CREATE VIEW until
+	// #10028 is addressed.
+	hasStar bool
+
 	// Avoid allocations by embedding commonly used objects and visitors.
 	parser                parser.Parser
 	subqueryVisitor       subqueryVisitor

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -62,11 +62,8 @@ type renderNode struct {
 	// symbolic representations.
 	renderStrings []string
 
+	// columns is the set of result columns.
 	columns sqlbase.ResultColumns
-
-	// A piece of metadata to indicate whether a star expression was expanded
-	// during rendering.
-	isStar bool
 
 	// The number of initial columns - before adding any internal render
 	// targets for grouping, filtering or ordering. The original columns
@@ -344,7 +341,7 @@ func (r *renderNode) initTargets(
 			return err
 		}
 
-		r.isStar = r.isStar || hasStar
+		r.planner.hasStar = r.planner.hasStar || hasStar
 		_ = r.addOrReuseRenders(cols, exprs, false)
 	}
 	// `groupBy` or `orderBy` may internally add additional columns which we

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -588,7 +588,7 @@ func (r *renderNode) computeOrdering(fromOrder orderingInfo) {
 
 	// Detect constants.
 	for col, expr := range r.render {
-		_, hasRowDependentValues, err := r.resolveNames(expr)
+		_, hasRowDependentValues, _, err := r.resolveNames(expr)
 		if err != nil {
 			// If we get an error here, the expression must contain an unresolved name
 			// or invalid indexed var; ignore.

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -57,7 +57,7 @@ func TestRetryResolveNames(t *testing.T) {
 	}
 
 	for i := 0; i < 2; i++ {
-		newExpr, _, err := s.resolveNames(expr)
+		newExpr, _, _, err := s.resolveNames(expr)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -413,7 +413,7 @@ func (p *planner) orderBy(
 			if err != nil {
 				return nil, err
 			}
-			s.isStar = s.isStar || hasStar
+			p.hasStar = p.hasStar || hasStar
 
 			if len(cols) == 0 {
 				// Nothing was expanded! No order here.

--- a/pkg/sql/views.go
+++ b/pkg/sql/views.go
@@ -84,6 +84,10 @@ func (p *planner) analyzeViewQuery(
 	defer func(prev planDependencies) { p.planDeps = prev }(p.planDeps)
 	p.planDeps = make(planDependencies)
 
+	// Request star detection
+	defer func(prev bool) { p.hasStar = prev }(p.hasStar)
+	p.hasStar = false
+
 	// Now generate the source plan.
 	sourcePlan, err := p.Select(ctx, viewSelect, []parser.Type{})
 	if err != nil {
@@ -93,7 +97,7 @@ func (p *planner) analyzeViewQuery(
 	defer sourcePlan.Close(ctx)
 
 	// TODO(a-robinson): Support star expressions as soon as we can (#10028).
-	if p.planContainsStar(ctx, sourcePlan) {
+	if p.hasStar {
 		return nil, nil, fmt.Errorf("views do not currently support * expressions")
 	}
 


### PR DESCRIPTION
```sql
SELECT kv.* FROM kv                 -> SELECT k, v FROM kv
SELECT (kv.*) FROM kv               -> SELECT (k, v) FROM kv
SELECT COUNT(DISTINCT kv.*) FROM kv -> SELECT COUNT(DISTINCT (k, v)) FROM kv

-- previously unsupported:
SELECT COUNT(DISTINCT a.*) FROM kv a, kv b
   -> SELECT COUNT(DISTINCT (a.k, a.v)) FROM kv a, kv b
```

For docs: this lifts a previously documented known limitation.

Fixes #15750.