### PR TITLE
sql: optimize SRF rewriting to avoid cross joins in simple cases

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -8,6 +8,11 @@ generate_series
 2
 3
 
+query ITTT
+EXPLAIN SELECT * FROM GENERATE_SERIES(1, 3)
+----
+0  generator  ·  ·
+
 query II colnames
 SELECT * FROM GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
 ----
@@ -16,6 +21,14 @@ generate_series  generate_series
 1                2
 2                1
 2                2
+
+query ITTT
+EXPLAIN SELECT * FROM GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
+----
+0  join       ·     ·
+0  ·          type  cross
+1  generator  ·     ·
+1  generator  ·     ·
 
 query I
 SELECT * FROM GENERATE_SERIES(3, 1, -1)
@@ -66,6 +79,11 @@ generate_series
 1
 2
 
+query ITTT
+EXPLAIN SELECT GENERATE_SERIES(1, 3)
+----
+0  generator  ·  ·
+
 query II colnames
 SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(3, 4)
 ----
@@ -74,6 +92,14 @@ generate_series             generate_series
 1                           4
 2                           3
 2                           4
+
+query ITTT
+EXPLAIN SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
+----
+0  join       ·     ·
+0  ·          type  cross
+1  generator  ·     ·
+1  generator  ·     ·
 
 statement ok
 CREATE TABLE t (a string)
@@ -97,6 +123,31 @@ cat  bird  1  3
 cat  bird  1  4
 cat  bird  2  3
 cat  bird  2  4
+
+query ITTT
+EXPLAIN(EXPRS) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
+----
+0  render     ·         ·
+0  ·          render 0  a
+0  ·          render 1  b
+0  ·          render 2  generate_series
+0  ·          render 3  generate_series
+1  join       ·         ·
+1  ·          type      cross
+2  join       ·         ·
+2  ·          type      cross
+3  join       ·         ·
+3  ·          type      cross
+4  scan       ·         ·
+4  ·          table     t@primary
+4  ·          spans     ALL
+4  scan       ·         ·
+4  ·          table     u@primary
+4  ·          spans     ALL
+3  generator  ·         ·
+3  ·          expr      generate_series(1, 2)
+2  generator  ·         ·
+2  ·          expr      generate_series(3, 4)
 
 query TTII
 SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series(3, 4) AS b


### PR DESCRIPTION
tl;dr: make a common case faster and use less memory.

Set-generating functions (SRFs) are meant to be used as operand to a
FROM clause, for example `SELECT * FROM generate_series(1, 10)`.

However, PostgreSQL also supports the degenerate syntax

```sql
SELECT generate_series() FROM x, y, z
```

which (somewhat counter-intuitively, but oh well) really means:

```sql
SELECT generate_series FROM x, y, z, generate_series() as unnamed(generate_series)
```

In other words, a SRF present in the render part of a SELECT clause is
interpreted as the source of a cross-join with the existing FROM
clause. This recursively extends to multiple SRFs, for example:

```sql
SELECT generate_series(1,2), generate_series(2,3) FROM x, y, z
-- is really, in disguise:
SELECT a.generate_series, b.generate_series
  FROM x, y, z,
       generate_series(1,2) AS a(generate_series),
       generate_series(2,3) AS b(generate_series)
```

An interesting edge case, unfortunately rather common in interactive
shells, is the case of `SELECT generate_series()` *without a FROM
clause*. This is common because SRFs look like functions and users
when exploring will try out "functions" in that way.

Now, what does a SELECT clause mean without a FROM clause?

From a relational-algebraic perspective, "SELECT X FROM Y" means "for
every row in Y, render X". Now, if there is no FROM clause, we still
see a result. How can that be? This is because SQL mandates that a
missing FROM clause is substituted by *a virtual data source with no
columns and exactly one row*. This is called the "unary source".

In CockroachDB we use `emptyNode{results:true}` to represent this.

Therefore, the query `SELECT generate_series()` really means
`SELECT ... FROM <unary> CROSS JOIN generate_series()`.

Without further consideration, this is semantically correct and
produces valid results: the result of a cross join between the unary
source with any source Y returns the same rows as Y.

The issue that this patch addresses is that this particular flavor of
join (with a SRF operand) is not distributed and executed using an
in-memory hash join. This in turns requires accumulating all the
rows from the RHS of the join in memory before the join "resolves"
and sees that all these rows can be emitted as-is as a result.

This behavior, combined with the announcement of a prior patch that
makes CockroachDB "stream results" during execution towards the
client, creates a possible user surprise: despite the fact CockroachDB
streams results, a "simple query" like `SELECT
generate_series(1,10000000)` would not be streamed (and possibly cause
memory exhaustion), while the more canonical `SELECT * FROM
generate_series(1,10000000)` would be streamed properly (because it
doesn't hide a cross-join in disguise).

To address this possible surprise, this patch special-cases the
expansion of a SRF in render position to a cross-join, when the
existing FROM clause is the unary source. In that case, the SRF is
used as-is and no join is generated.

Idea courtesy of @jordanlewis + @justinj.

Fixes  #17546.