### PR TITLE
distsqlplan: fix span resolver

### DIFF
--- a/pkg/sql/distsqlplan/span_resolver.go
+++ b/pkg/sql/distsqlplan/span_resolver.go
@@ -315,9 +315,10 @@ func (it *spanResolverIterator) ReplicaInfo(ctx context.Context) (kv.ReplicaInfo
 		if err != nil {
 			// Ignore the error; ask the oracle to pick another replica below.
 			log.VEventf(ctx, 2, "failed to resolve node %d: %s", repl.NodeID, err)
+		} else {
+			repl.NodeDesc = nd
+			resolvedLH = true
 		}
-		repl.NodeDesc = nd
-		resolvedLH = true
 	}
 	if !resolvedLH {
 		leaseHolder, err := it.oracle.ChoosePreferredLeaseHolder(


### PR DESCRIPTION
If the SpanResolverIterator finds a leaseholder in the leaseHolderCache
but the respective node is not gossiping its descriptor any more, it was
supposed to assign another lease holder, but it was failing to do so.
I believe this cache-gossip inconsistency can happen when a node is
removed from the cluster.

Fixes #16127