### PR TITLE
storage: undo quota acquisition on failed proposals

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2592,9 +2592,6 @@ func (r *Replica) tryExecuteWriteBatch(
 	log.Event(ctx, "applied timestamp cache")
 
 	ch, tryAbandon, undoQuotaAcquisition, pErr := r.propose(ctx, lease, ba, endCmds, spans)
-	if pErr != nil {
-		return nil, pErr, proposalNoRetry
-	}
 	defer func() {
 		// NB: We may be double free-ing here, consider the following cases:
 		//  - The request was evaluated and the command resulted in an error, but a
@@ -2605,6 +2602,9 @@ func (r *Replica) tryExecuteWriteBatch(
 			undoQuotaAcquisition()
 		}
 	}()
+	if pErr != nil {
+		return nil, pErr, proposalNoRetry
+	}
 
 	// After the command is proposed to Raft, invoking endCmds.done is now the
 	// responsibility of processRaftCommand.


### PR DESCRIPTION
This was an oversight introduced in #15802, the `undoQuotaAcquisition`
was intended to be used for all proposal errors but we seem to have
skipped the very first one. It was a relic of the earlier structure 
where in the event of proposal errors the acquired quota was
released within `Replica.propose` itself, and not left to the caller.

Fixes #17826 (hopefully, still being tested) but should be corrected
anyway.

+cc @benesch