### PR TITLE
sql: fix behavior for dropping interleaved indexes

### DIFF
--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -883,9 +883,15 @@ func (p *planner) removeInterleaveBackReference(
 		return nil
 	}
 	ancestor := idx.Interleave.Ancestors[len(idx.Interleave.Ancestors)-1]
-	t, err := sqlbase.GetTableDescFromID(ctx, p.txn, ancestor.TableID)
-	if err != nil {
-		return errors.Errorf("error resolving referenced table ID %d: %v", ancestor.TableID, err)
+	var t *sqlbase.TableDescriptor
+	if ancestor.TableID == tableDesc.ID {
+		t = tableDesc
+	} else {
+		lookup, err := sqlbase.GetTableDescFromID(ctx, p.txn, ancestor.TableID)
+		if err != nil {
+			return errors.Errorf("error resolving referenced table ID %d: %v", ancestor.TableID, err)
+		}
+		t = lookup
 	}
 	if t.Dropped() {
 		// The referenced table is being dropped. No need to modify it further.
@@ -900,7 +906,10 @@ func (p *planner) removeInterleaveBackReference(
 			targetIdx.InterleavedBy = append(targetIdx.InterleavedBy[:k], targetIdx.InterleavedBy[k+1:]...)
 		}
 	}
-	return p.saveNonmutationAndNotify(ctx, t)
+	if t != tableDesc {
+		return p.saveNonmutationAndNotify(ctx, t)
+	}
+	return nil
 }
 
 func verifyDropTableMetadata(

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -304,3 +304,17 @@ interdb                               CREATE TABLE interdb (
                                       CONSTRAINT "primary" PRIMARY KEY (x ASC),
                                       FAMILY "primary" (x)
 ) INTERLEAVE IN PARENT other.foo (x)
+
+statement ok
+CREATE TABLE t1 (id1 INT PRIMARY KEY, id2 INT, id3 INT);
+
+statement ok
+CREATE INDEX c on t1 (id2)
+   STORING (id1,id3)
+   INTERLEAVE in PARENT t1 (id2);
+
+statement ok
+DROP INDEX t1@c;
+
+statement ok
+DROP TABLE t1


### PR DESCRIPTION
Before when we dropped an interleaved index on a table referring to
itself, the table descriptor wouldn't get updated properly and future
DDL operations on that table would fail.

Now save the descriptor correctly so the drop operation will leave the
table descriptor in a good state.

Closes #16471

cc @danhhz 