### PR TITLE
sql: Record user-provided value to event log when a setting is changed

### DIFF
--- a/pkg/sql/parser/constant.go
+++ b/pkg/sql/parser/constant.go
@@ -353,7 +353,7 @@ func (expr *StrVal) Format(buf *bytes.Buffer, f FmtFlags) {
 	if expr.bytesEsc {
 		encodeSQLBytes(buf, expr.s)
 	} else {
-		encodeSQLString(buf, expr.s)
+		encodeSQLStringWithFlags(buf, expr.s, f)
 	}
 }
 

--- a/pkg/sql/parser/format_test.go
+++ b/pkg/sql/parser/format_test.go
@@ -96,6 +96,8 @@ func TestFormatStatement(t *testing.T) {
 			`SET "time zone" = 'utc'`},
 		{`SET "time zone" = UTC`, FmtBareIdentifiers,
 			`SET time zone = 'utc'`},
+		{`SET "time zone" = UTC`, FmtBareStrings,
+			`SET "time zone" = utc`},
 	}
 
 	for i, test := range testData {


### PR DESCRIPTION
Rather than using the encoded version, which for state-machine settings
(like the cluster version) can be a protocol buffer.

To make this work, I needed parser.StrVal.Format to respect the provided
format strings. To my untrained eye this looked like a bug, but there
may be a reason for it that I'm not aware of.

Fixes #17854

I hope one of you can correct me on the `StrVal.Format` change if there really is a reason for it not to respect formatting flags.