### PR TITLE
cli/sql: set sql_safe_updates by default; provide --unsafe-updates to override

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -676,7 +676,7 @@ func Example_sql() {
 
 	c.RunWithArgs([]string{"sql", "-e", "show application_name"})
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
-	c.RunWithArgs([]string{"sql", "--safe-updates", "-e", "delete from t.f"})
+	c.RunWithArgs([]string{"sql", "-e", "delete from t.f"})
 	c.RunWithArgs([]string{"sql", "-e", "select 3", "-e", "select * from t.f"})
 	c.RunWithArgs([]string{"sql", "-e", "begin", "-e", "select 3", "-e", "commit"})
 	c.RunWithArgs([]string{"sql", "-e", "select * from t.f"})
@@ -699,7 +699,7 @@ func Example_sql() {
 	// cockroach
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
 	// INSERT 1
-	// sql --safe-updates -e delete from t.f
+	// sql -e delete from t.f
 	// pq: rejected: DELETE without WHERE clause (sql_safe_updates = true)
 	// sql -e select 3 -e select * from t.f
 	// 1 row

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -153,11 +153,13 @@ with a non-zero status code and further statements are not executed. The
 results of each SQL statement are printed on the standard output.`,
 	}
 
-	SafeUpdates = FlagInfo{
-		Name: "safe-updates",
+	UnsafeUpdates = FlagInfo{
+		Name: "unsafe-updates",
 		Description: `
-Disallow SQL statements that may have undesired side effects. For example
-a DELETE or UPDATE without a WHERE clause. This helps prevent accidents.`,
+Allow SQL statements that may have undesired side effects. For example
+a DELETE or UPDATE without a WHERE clause. By default, such statements
+are rejected to prevent accidents. This can also be overridden in a
+session with SET sql_safe_updates = FALSE.`,
 	}
 
 	TableDisplayFormat = FlagInfo{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -139,9 +139,9 @@ var sqlCtx = struct {
 	// execStmts is a list of statements to execute.
 	execStmts statementsValue
 
-	// safeUpdates indicates whether to not set
-	// reject_dangerous_statements in the CLI shell.
-	safeUpdates bool
+	// unsafeUpdates indicates whether to unset
+	// sql_safe_updates in the CLI shell.
+	unsafeUpdates bool
 }{cliContext: &cliCtx}
 
 // dumpCtx captures the command-line parameters of the `sql` command.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -329,7 +329,7 @@ func init() {
 	boolFlag(zf, &zoneCtx.zoneDisableReplication, cliflags.ZoneDisableReplication, false)
 
 	varFlag(sqlShellCmd.Flags(), &sqlCtx.execStmts, cliflags.Execute)
-	boolFlag(sqlShellCmd.Flags(), &sqlCtx.safeUpdates, cliflags.SafeUpdates, false)
+	boolFlag(sqlShellCmd.Flags(), &sqlCtx.unsafeUpdates, cliflags.UnsafeUpdates, false)
 
 	varFlag(dumpCmd.Flags(), &dumpCtx.dumpMode, cliflags.DumpMode)
 	stringFlag(dumpCmd.Flags(), &dumpCtx.asOf, cliflags.DumpTime, "")

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1003,7 +1003,7 @@ func runTerm(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if sqlCtx.safeUpdates {
+	if !sqlCtx.unsafeUpdates {
 		if err := conn.Exec("SET sql_safe_updates = TRUE", nil); err != nil {
 			return err
 		}


### PR DESCRIPTION
Based off  #17926; will rebase when that merges.

For docs: now only DELETE and UPDATE without WHERE, and ALTER DROP COLUMN, are affected by the "safe updates" mode. The command-line flag is renamed from `--safe-updates` to `--unsafe-updates`.

Followup to  #17604.
Really fixes #3943.