### PR TITLE
cli/interactive_tests: don't fail a test if the after-test clean-up fails

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -35,7 +35,11 @@ proc report {text} {
     # Docker is obnoxious in that it doesn't support setting `umask`.
     # Also CockroachDB doesn't honor umask anyway.
     # So we simply come after the fact and adjust the permissions.
-    system "find logs -exec chmod a+rw '{}' \\;"
+    #
+    # However as this may be done concurrently with a server shutting
+    # down, the find may race with the deletion of files by the
+    # server. Tolerate that.
+    system "find logs -exec chmod a+rw '{}' \\; || true"
 }
 
 # Catch signals


### PR DESCRIPTION
Fixes #17880.