### PR TITLE
cherrypick: mvcc: continue scanning if MVCCReverseScan falls off end of range

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1721,26 +1721,36 @@ func MVCCIterate(
 		}
 
 		if reverse {
-			if ok, err := iter.Valid(); err != nil {
+			valid, err := iter.Valid()
+			if err != nil {
 				return nil, err
-			} else if ok {
-				if buf.meta.IsInline() {
+			}
+
+			if buf.meta.IsInline() {
+				if valid {
 					// The current entry is an inline value. We can reach the previous
 					// entry using Prev() which is slightly faster than PrevKey().
+					//
+					// As usual, the iterator must be valid because an inline key should
+					// never result in a version scan that brings us to an invalid key.
 					iter.Prev()
-				} else {
-					// This is subtle: mvccGetInternal might already have advanced us to the
-					// next key in which case we have to reset our position.
-					if !iter.UnsafeKey().Key.Equal(metaKey.Key) {
-						iter.Seek(metaKey)
-						if ok, err := iter.Valid(); err != nil {
-							return nil, err
-						} else if ok {
-							iter.Prev()
-						}
-					} else {
-						iter.PrevKey()
+				}
+			} else {
+				// This is subtle: mvccGetInternal might already have advanced
+				// us to the next key in which case we have to reset our
+				// position. We also Seek when iter.Valid says that the iterator
+				// is invalid, because mvccGetInternal might have advanced us
+				// out of the valid range and we may even have reached KeyMax.
+				// In this case, we still want to continue scanning backwards.
+				if !valid || !iter.UnsafeKey().Key.Equal(metaKey.Key) {
+					iter.Seek(metaKey)
+					if ok, err := iter.Valid(); err != nil {
+						return nil, err
+					} else if ok {
+						iter.Prev()
 					}
+				} else {
+					iter.PrevKey()
 				}
 			}
 		} else {

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -2279,6 +2279,41 @@ func TestMVCCReverseScan(t *testing.T) {
 	}
 }
 
+// TestMVCCReverseScanFirstKeyInFuture verifies that when MVCCReverseScan scans
+// encounter a key with only future timestamps first, that it skips the key and
+// continues to scan in reverse. #17825 was caused by this not working correctly.
+func TestMVCCReverseScanFirstKeyInFuture(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	engine := createTestEngine()
+	defer engine.Close()
+
+	// The value at key2 will be at a lower timestamp than the ReverseScan, but
+	// the value at key3 will be at a larger timetamp. The ReverseScan should
+	// see key3 and ignore it because none of it versions are at a low enough
+	// timestamp to read. It should then continue scanning backwards and find a
+	// value at key2.
+	//
+	// Before fixing #17825, the MVCC version scan on key3 would fall out of the
+	// scan bounds and if it never found another valid key before reaching
+	// KeyMax, would stop the ReverseScan from continuing.
+	if err := MVCCPut(context.Background(), engine, nil, testKey2, hlc.Timestamp{WallTime: 1}, value2, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := MVCCPut(context.Background(), engine, nil, testKey3, hlc.Timestamp{WallTime: 3}, value3, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	kvs, _, _, err := MVCCReverseScan(context.Background(), engine, testKey1, testKey4, math.MaxInt64, hlc.Timestamp{WallTime: 2}, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(kvs) != 1 ||
+		!bytes.Equal(kvs[0].Key, testKey2) ||
+		!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
+		t.Errorf("unexpected value: %v", kvs)
+	}
+}
+
 func TestMVCCResolveTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	engine := createTestEngine()


### PR DESCRIPTION
Fixes #17825.

When an `mvccGetInternal` call scans off the end of a key range
while attempting to find a value at a certain timestamp,
`MVCCReverseScan` shouldn't stop scanning backwards. This change
fixes this behavior by ignoring the `iter.Valid` in `MVCCIterate`
until after the iterator has scanned to the previous key.

cc @cockroachdb/release