### PR TITLE
cli/interactive_tests: re-enable test_sql_mem_monitor

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -35,7 +35,12 @@ proc report {text} {
     # Docker is obnoxious in that it doesn't support setting `umask`.
     # Also CockroachDB doesn't honor umask anyway.
     # So we simply come after the fact and adjust the permissions.
-    system "find logs -exec chmod a+rw '{}' \\;"
+    #
+    # The find may race with a cockroach process shutting down in the
+    # background; cockroach might be deleting files as they are being
+    # found, causing chmod to not find its target file. We ignore
+    # these errors.
+    system "find logs -exec chmod a+rw '{}' \\; || true"
 }
 
 # Catch signals

--- a/pkg/cli/interactive_tests/test_log_flags.tcl
+++ b/pkg/cli/interactive_tests/test_log_flags.tcl
@@ -12,7 +12,7 @@ eexpect ":/# "
 # errors when parsing flags in that context cause the (test) process
 # to exit entirely (it has errorHandling set to ExitOnError).
 
-# Check that log files are created by default in the store directory.
+start_test "Check that log files are created by default in the store directory."
 send "$argv start --insecure --store=path=logs/mystore\r"
 eexpect "node starting"
 interrupt
@@ -20,8 +20,9 @@ eexpect ":/# "
 send "ls logs/mystore/logs\r"
 eexpect "cockroach.log"
 eexpect ":/# "
+end_test
 
-# Check that an empty `-log-dir` disables file logging.
+start_test "Check that an empty -log-dir disables file logging."
 send "$argv start --insecure --store=path=logs/mystore2 --log-dir=\r"
 eexpect "node starting"
 interrupt
@@ -29,19 +30,22 @@ eexpect ":/# "
 send "ls logs/mystore2/logs 2>/dev/null | wc -l\r"
 eexpect "0"
 eexpect ":/# "
+end_test
 
-# Check that leading tildes are properly rejected.
+start_test "Check that leading tildes are properly rejected."
 send "$argv start --insecure -s=path=logs/db --log-dir=\~/blah\r"
 eexpect "log directory cannot start with '~'"
 eexpect ":/# "
+end_test
 
-# Check that the user can override.
+start_test "Check that the user can override."
 send "$argv start --insecure -s=path=logs/db --log-dir=logs/blah/\~/blah\r"
 eexpect "logs: *blah/~/blah"
 interrupt
 eexpect ":/# "
+end_test
 
-# Check that TRUE and FALSE are valid values for the severity flags.
+start_test "Check that TRUE and FALSE are valid values for the severity flags."
 send "$argv start --insecure -s=path=logs/db --logtostderr=false\r"
 eexpect "node starting"
 interrupt
@@ -57,6 +61,7 @@ eexpect ":/# "
 send "$argv start --insecure -s=path=logs/db --logtostderr=cantparse\r"
 eexpect "parsing \"cantparse\": invalid syntax"
 eexpect ":/# "
+end_test
 
 send "exit 0\r"
 eexpect eof


### PR DESCRIPTION
This test was previously disabled because it leaked root-owned files
caused by distsql temp storage. Actually the root problem was more
serious than that, the test should not have been using distsqsl in the
first place!

This patch corrects the root cause and re-enables the patch.

Also, this test as test_log_flags really *must* use
`start_test`/`end_test`. These two commands also ensure the
directories created by the cockroach process(es) are writable outside
of docker.

By doing so we guarantee that reenabling the test will never cause CI
agents to become hosed with undeletable root-owned files.

(This requirement may be lifted in the future by ensuring
the processes run with the host UID inside docker, but this will be
addressed by a separate patch.)

Supersedes  #17890.
Fixes #17880.