### PR TITLE
keys: improve pretty printing of range local keys

### DIFF
--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -394,7 +394,13 @@ func localRangeKeyPrint(key roachpb.Key) string {
 			}
 		}
 	}
-	fmt.Fprintf(&buf, "%s", decodeKeyPrint(key))
+
+	_, decodedKey, err := encoding.DecodeBytesAscending([]byte(key), nil)
+	if err != nil {
+		fmt.Fprintf(&buf, "%s", decodeKeyPrint(key))
+	} else {
+		fmt.Fprintf(&buf, "%s", roachpb.Key(decodedKey))
+	}
 
 	return buf.String()
 }

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -66,7 +66,7 @@ func TestPrettyPrint(t *testing.T) {
 		{RangeLastReplicaGCTimestampKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RangeLastReplicaGCTimestamp"},
 		{RangeLastVerificationTimestampKeyDeprecated(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RangeLastVerificationTimestamp"},
 
-		{MakeRangeKeyPrefix(roachpb.RKey("ok")), `/Local/Range/"ok"`},
+		{MakeRangeKeyPrefix(roachpb.RKey(MakeTablePrefix(42))), `/Local/Range/Table/42`},
 		{RangeDescriptorKey(roachpb.RKey(MakeTablePrefix(42))), `/Local/Range/Table/42/RangeDescriptor`},
 		{TransactionKey(roachpb.Key(MakeTablePrefix(42)), txnID), fmt.Sprintf(`/Local/Range/Table/42/Transaction/%q`, txnID)},
 		{QueueLastProcessedKey(roachpb.RKey(MakeTablePrefix(42)), "foo"), `/Local/Range/Table/42/QueueLastProcessed/"foo"`},
@@ -84,7 +84,7 @@ func TestPrettyPrint(t *testing.T) {
 		{SystemMax, "/System/Max"},
 
 		// key of key
-		{RangeMetaKey(roachpb.RKey(MakeRangeKeyPrefix(roachpb.RKey("ok")))), `/Meta2/Local/Range/"ok"`},
+		{RangeMetaKey(roachpb.RKey(MakeRangeKeyPrefix(MakeTablePrefix(42)))), `/Meta2/Local/Range/Table/42`},
 		{RangeMetaKey(roachpb.RKey(makeKey(MakeTablePrefix(42), roachpb.RKey("foo")))), `/Meta2/Table/42/"foo"`},
 		{RangeMetaKey(roachpb.RKey(makeKey(Meta2Prefix, roachpb.Key("foo")))), `/Meta1/"foo"`},
 


### PR DESCRIPTION
Follow on to #17778. We use bare range local keys (without a suffix)
during splits to lock an entire range of keys.