### PR TITLE
sql: return error when escaped bytea format can't be parsed

### DIFF
--- a/pkg/sql/parser/constant.go
+++ b/pkg/sql/parser/constant.go
@@ -424,7 +424,9 @@ func (expr *StrVal) ResolveAsType(ctx *SemaContext, typ Type) (Datum, error) {
 		return NewDNameFromDString(&expr.resString), nil
 	case TypeBytes:
 		s, err := ParseDByte(expr.s)
-		expr.resBytes = *s
+		if err == nil {
+			expr.resBytes = *s
+		}
 		return &expr.resBytes, err
 	case TypeBool:
 		return ParseDBool(expr.s)

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -207,7 +207,7 @@ func ParseDByte(s string) (*DBytes, error) {
 	if len(s) > 2 && (s[0] == '\\' && (s[1] == 'x' || s[1] == 'X')) {
 		hexstr, err := hex.DecodeString(s[2:])
 		if err != nil {
-			return NewDBytes(DBytes(s)), nil
+			return nil, makeParseError(s, TypeBytes, err)
 		}
 		return NewDBytes(DBytes(hexstr)), nil
 	}

--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -1057,6 +1057,7 @@ func TestEvalError(t *testing.T) {
 		{`'1- 2:3:4 9'::interval`,
 			`could not parse '1- 2:3:4 9' as type interval: invalid input syntax for type interval 1- 2:3:4 9`},
 		{`b'\xff\xfe\xfd'::string`, `invalid UTF-8: "\xff\xfe\xfd"`},
+		{`e'\\x6sdfsd36174'::BYTES`, `could not parse '\x6sdfsd36174' as type bytes: encoding/hex: odd length hex string`},
 		{`ARRAY[NULL, ARRAY[1, 2]]`, `multidimensional arrays must have array expressions with matching dimensions`},
 		{`ARRAY[ARRAY[1, 2], NULL]`, `multidimensional arrays must have array expressions with matching dimensions`},
 		{`ARRAY[ARRAY[1, 2], ARRAY[1]]`, `multidimensional arrays must have array expressions with matching dimensions`},


### PR DESCRIPTION
Before if we received escaped bytea input that couldn't be parsed
correctly, we would return the string.

Now we will return an error messaage.