### PR TITLE
sqlccl: add endtime to CSV backup descriptors

### DIFF
--- a/pkg/ccl/sqlccl/backup.pb.go
+++ b/pkg/ccl/sqlccl/backup.pb.go
@@ -49,7 +49,9 @@ type BackupDescriptor struct {
 	EndTime   cockroach_util_hlc.Timestamp `protobuf:"bytes,2,opt,name=end_time,json=endTime" json:"end_time"`
 	// Spans contains the spans requested for backup. The keyranges covered by
 	// `files` may be a subset of this if there were ranges with no changes since
-	// the last backup.
+	// the last backup. For all tables in the backup descriptor, these spans must
+	// completely cover each table's span. For example, if a table with ID 51 were
+	// being backed up, then the span `/Table/5{1-2}` must be completely covered.
 	Spans         []cockroach_roachpb1.Span                           `protobuf:"bytes,3,rep,name=spans" json:"spans"`
 	Files         []BackupDescriptor_File                             `protobuf:"bytes,4,rep,name=files" json:"files"`
 	Descriptors   []cockroach_sql_sqlbase1.Descriptor                 `protobuf:"bytes,5,rep,name=descriptors" json:"descriptors"`

--- a/pkg/ccl/sqlccl/backup.proto
+++ b/pkg/ccl/sqlccl/backup.proto
@@ -38,7 +38,9 @@ message BackupDescriptor {
   util.hlc.Timestamp end_time = 2 [(gogoproto.nullable) = false];
   // Spans contains the spans requested for backup. The keyranges covered by
   // `files` may be a subset of this if there were ranges with no changes since
-  // the last backup.
+  // the last backup. For all tables in the backup descriptor, these spans must
+  // completely cover each table's span. For example, if a table with ID 51 were
+  // being backed up, then the span `/Table/5{1-2}` must be completely covered.
   repeated roachpb.Span spans = 3 [(gogoproto.nullable) = false];
   repeated File files = 4 [(gogoproto.nullable) = false];
   repeated sql.sqlbase.Descriptor descriptors = 5 [(gogoproto.nullable) = false];


### PR DESCRIPTION
In addition to passing down the backup walltime to the descriptor,
this change corrects the way CSV backup descriptors set their
spans. Previously they set their spans to the first and last key in the
generated data. Restore verifies that it can fully restore a table by
making sure it has data covering all spans of that table. Thus, the
previous code didn't report that it actually had all of the table's
data even though it did.

The reason that this only occurred when specifying the EndTime in
the backup descriptor is that the "no backup covers time" error from
makeImportSpans assumes that the end time is not the zero value.

Fixes #17526