### PR TITLE
ui: fix "capacity used" percentage in summary bar

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -55,7 +55,7 @@ export default function(props: ClusterSummaryProps) {
   // Capacity math used in the summary status section.
   const { capacityAvailable, capacityUsed } = props.nodesSummary.nodeSums;
   const usableCapacity = capacityAvailable + capacityUsed;
-  const capacityPercent = usableCapacity !== 0 ? (capacityUsed / (usableCapacity * 100)) : 100;
+  const capacityPercent = usableCapacity !== 0 ? ((capacityUsed / usableCapacity) * 100) : 100;
 
   return (
     <div>


### PR DESCRIPTION
Fixes #17912. This was broken by #17733.

Blue after the change:
<img width="344" alt="screen shot 2017-08-24 at 7 32 41 pm" src="https://user-images.githubusercontent.com/7085343/29693399-5cee626e-8903-11e7-9db8-11dfbbe5e3b2.png">

I'll push embedded.go once it's done taking forever to generate.

@jordanlewis @bdarnell 