### PR TITLE
acceptance/terrafarm: show destroy command after control-C

### DIFF
--- a/pkg/acceptance/terrafarm/farmer.go
+++ b/pkg/acceptance/terrafarm/farmer.go
@@ -307,7 +307,7 @@ func (f *Farmer) Destroy(t testing.TB) error {
 	if (t.Failed() && f.KeepCluster == KeepClusterFailed) ||
 		f.KeepCluster == KeepClusterAlways {
 
-		t.Logf("not destroying; run:\n(cd %s && terraform destroy -force -state %[2]s && rm %[2]s)",
+		f.logf("not destroying; run:\n(cd %s && terraform destroy -force -state %[2]s && rm %[2]s)\n",
 			baseDir, f.StateFile)
 		return nil
 	}


### PR DESCRIPTION
When `-tf.keep-cluster=failed` or `-tf.keep-cluster=always` are
specified (usually for debugging an issue), `Farmer` is supposed to show
the command line for destroying the cluster. However, it seems that
`(*testing.T).Logf` stops working after SIGINT. This change logs the
destroy command using `(*Farmer).logf`, which is basically a Printf.

Fixes #17906