### PR TITLE
storage: trace pushee status after push

### DIFF
--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -229,6 +229,7 @@ func (ir *intentResolver) maybePushTransactions(
 			panic(fmt.Sprintf("have two PushTxn responses for %s", txn.ID))
 		}
 		pushedTxns[txn.ID] = txn
+		log.Eventf(ctx, "%s is now %s", txn.ID, txn.Status)
 	}
 
 	var resolveIntents []roachpb.Intent


### PR DESCRIPTION
This would have been interesting to know during a debugging session today.