### PR TITLE
storage/engine: multiply recommended open files by 64

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -91,7 +91,7 @@ const (
 	// RecommendedMaxOpenFiles is the recommended value for rocksDB's
 	// max_open_files option. If more file descriptors are available than the
 	// recommended number, than the default value is used.
-	RecommendedMaxOpenFiles = 10000
+	RecommendedMaxOpenFiles = 640000
 	// MinimumMaxOpenFiles is the minimum value that rocksDB's max_open_files
 	// option can be set to. While this should be set as high as possible, the
 	// minimum total for a single store node must be under 2048 for Windows


### PR DESCRIPTION
@petermattis @bdarnell any worries about this?

----

Our previous value for RecommendedMaxOpenFiles was presumably tuned
based on a L6 file size of 128MB. Restores, however, will cause
thousands of 2MB SSTs to be ingested, so we'll have 64 times as many
files as previously expected for a given amount of data. Bump the
RecommendedMaxOpen files accordingly.

We'll document that you may need to bump the open files hard limit to
perform a large restore.