### PR TITLE
storage: Consider recently-added replicas healthy when rebalancing

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -338,6 +338,12 @@ type Replica struct {
 		// The ID of the leader replica within the Raft group. Used to determine
 		// when the leadership changes.
 		leaderID roachpb.ReplicaID
+		// The most recently added replica for the range and when it was added.
+		// Used to determine whether a replica is new enough that we shouldn't
+		// penalize it for being slightly behind. These field gets cleared out once
+		// we know that the replica has caught up.
+		lastReplicaAdded     roachpb.ReplicaID
+		lastReplicaAddedTime time.Time
 
 		// The last seen replica descriptors from incoming Raft messages. These are
 		// stored so that the replica still knows the replica descriptors for itself
@@ -992,6 +998,13 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 			if progress.Match > 0 && progress.Match < minIndex {
 				minIndex = progress.Match
 			}
+			// If this is the most recently added replica and it has caught up, clear
+			// our state that was tracking it. This is unrelated to managing proposal
+			// quota, but this is a convenient place to do so.
+			if rep.ReplicaID == r.mu.lastReplicaAdded && progress.Match >= status.Commit {
+				r.mu.lastReplicaAdded = 0
+				r.mu.lastReplicaAddedTime = time.Time{}
+			}
 		}
 	}
 
@@ -1454,8 +1467,35 @@ func (r *Replica) setDescWithoutProcessUpdate(desc *roachpb.RangeDescriptor) {
 			r.mu.state.Desc, desc)
 	}
 
+	newMaxID := maxReplicaID(desc)
+	if newMaxID > r.mu.lastReplicaAdded {
+		r.mu.lastReplicaAdded = newMaxID
+		r.mu.lastReplicaAddedTime = timeutil.Now()
+	}
+
 	r.rangeStr.store(r.mu.replicaID, desc)
 	r.mu.state.Desc = desc
+}
+
+func maxReplicaID(desc *roachpb.RangeDescriptor) roachpb.ReplicaID {
+	if desc == nil || !desc.IsInitialized() {
+		return 0
+	}
+	var maxID roachpb.ReplicaID
+	for _, repl := range desc.Replicas {
+		if repl.ReplicaID > maxID {
+			maxID = repl.ReplicaID
+		}
+	}
+	return maxID
+}
+
+// LastReplicaAdded returns the ID of the most recently added replica and the
+// time at which it was added.
+func (r *Replica) LastReplicaAdded() (roachpb.ReplicaID, time.Time) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.mu.lastReplicaAdded, r.mu.lastReplicaAddedTime
 }
 
 // GetReplicaDescriptor returns the replica for this range from the range

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -43,6 +43,14 @@ const (
 	// for rebalancing. It does not prevent transferring leases in order to allow
 	// a replica to be removed from a range.
 	minLeaseTransferInterval = time.Second
+
+	// newReplicaGracePeriod is the amount of time that we allow for a new
+	// replica's raft state to catch up to the leader's before we start
+	// considering it to be behind for the sake of rebalancing. We choose a
+	// large value here because snapshots of large replicas can take a while
+	// in high latency clusters, and not allowing enough of a cushion can
+	// make rebalance thrashing more likely (#17879).
+	newReplicaGracePeriod = 5 * time.Minute
 )
 
 var (
@@ -338,7 +346,13 @@ func (rq *replicateQueue) processOneChange(
 		if log.V(1) {
 			log.Infof(ctx, "removing a replica")
 		}
-		candidates := filterUnremovableReplicas(repl.RaftStatus(), desc.Replicas)
+		lastReplAdded, lastAddedTime := repl.LastReplicaAdded()
+		if timeutil.Since(lastAddedTime) < newReplicaGracePeriod {
+			lastReplAdded = 0
+		}
+		candidates := filterUnremovableReplicas(repl.RaftStatus(), desc.Replicas, lastReplAdded)
+		log.VEventf(ctx, 3, "filtered unremovable replicas from %v to get %v as candidates for removal",
+			desc.Replicas, candidates)
 		removeReplica, details, err := rq.allocator.RemoveTarget(ctx, zone.Constraints, candidates, rangeInfo)
 		if err != nil {
 			return false, err
@@ -530,7 +544,7 @@ func (rq *replicateQueue) transferLease(
 	checkTransferLeaseSource bool,
 	checkCandidateFullness bool,
 ) (bool, error) {
-	candidates := filterBehindReplicas(repl.RaftStatus(), desc.Replicas)
+	candidates := filterBehindReplicas(repl.RaftStatus(), desc.Replicas, 0 /* brandNewReplicaID */)
 	if target := rq.allocator.TransferLeaseTarget(
 		ctx,
 		zone.Constraints,


### PR DESCRIPTION
Fixes #17879 

For what it's worth, this is running on indigo in the exact same configuration as before and I'm no longer seeing the problem.