### PR TITLE
ui: small fixes to the range debug page

### DIFF
--- a/pkg/ui/src/redux/apiReducers.ts
+++ b/pkg/ui/src/redux/apiReducers.ts
@@ -34,7 +34,7 @@ function rollupStoreMetrics(res: api.NodesResponseMessage): NodeStatus$Propertie
 export const nodesReducerObj = new CachedDataReducer((req: api.NodesRequestMessage, timeout?: moment.Duration) => api.getNodes(req, timeout).then(rollupStoreMetrics), "nodes", moment.duration(10, "s"));
 export const refreshNodes = nodesReducerObj.refresh;
 
-const raftReducerObj = new CachedDataReducer(api.raftDebug, "raft");
+const raftReducerObj = new CachedDataReducer(api.raftDebug, "raft", moment.duration(10, "s"));
 export const refreshRaft = raftReducerObj.refresh;
 
 export const versionReducerObj = new CachedDataReducer(versionCheck, "version");
@@ -82,13 +82,13 @@ export const queryToID = (req: api.QueryPlanRequestMessage): string => req.query
 const queryPlanReducerObj = new CachedDataReducer(api.getQueryPlan, "queryPlan");
 export const refreshQueryPlan = queryPlanReducerObj.refresh;
 
-const problemRangesReducerObj = new CachedDataReducer(api.getProblemRanges, "problemRanges");
+const problemRangesReducerObj = new CachedDataReducer(api.getProblemRanges, "problemRanges", moment.duration(10, "s"));
 export const refreshProblemRanges = problemRangesReducerObj.refresh;
 
-const certificatesReducerObj = new CachedDataReducer(api.getCertificates, "certificates");
+const certificatesReducerObj = new CachedDataReducer(api.getCertificates, "certificates", moment.duration(10, "s"));
 export const refreshCertificates = certificatesReducerObj.refresh;
 
-const rangeReducerObj = new CachedDataReducer(api.getRange, "range");
+const rangeReducerObj = new CachedDataReducer(api.getRange, "range", moment.duration(10, "s"));
 export const refreshRange = rangeReducerObj.refresh;
 
 export interface APIReducersState {

--- a/pkg/ui/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/logTable.tsx
@@ -102,7 +102,7 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
             {
               _.map(log.events, (event, key) => (
                 <tr key={key} className="log-table__row">
-                  <td className="log-table__cell">{Print.Timestamp(event.timestamp)}</td>
+                  <td className="log-table__cell log-table__cell--date">{Print.Timestamp(event.timestamp)}</td>
                   <td className="log-table__cell">s{event.store_id}</td>
                   <td className="log-table__cell">{printLogEventType(event.event_type)}</td>
                   <td className="log-table__cell">{this.renderRangeID(event.range_id)}</td>

--- a/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
@@ -330,6 +330,7 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
       const leaseHolder = localReplica.replica_id === lease.replica.replica_id;
       const mvcc = info.state.state.stats;
       const raftState = this.contentRaftState(info.raft_state.state);
+      const vote = FixLong(info.raft_state.hard_state.vote);
       if (raftState.value[0] === "dormant") {
         dormantStoreIDs.add(info.source_store_id);
       }
@@ -346,35 +347,35 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
         leaseEpoch: epoch ? this.createContent(lease.epoch) : rangeTableEmptyContent,
         leaseStart: this.contentTimestamp(lease.start),
         leaseExpiration: epoch ? rangeTableEmptyContent : this.contentTimestamp(lease.expiration),
-        leaseAppliedIndex: this.createContent(info.state.state.lease_applied_index),
+        leaseAppliedIndex: this.createContent(FixLong(info.state.state.lease_applied_index)),
         raftLeader: this.createContent(
-          info.raft_state.lead,
+          FixLong(info.raft_state.lead),
           raftLeader ? "range-table__cell--raftstate-leader" : "range-table__cell--raftstate-follower",
         ),
-        vote: this.createContent(info.raft_state.hard_state.vote),
-        term: this.createContent(info.raft_state.hard_state.term),
-        applied: this.createContent(info.raft_state.applied),
-        commit: this.createContent(info.raft_state.hard_state.commit),
-        lastIndex: this.createContent(info.state.lastIndex),
-        logSize: this.createContent(info.state.raft_log_size),
+        vote: this.createContent(vote.greaterThan(0) ? vote : "-"),
+        term: this.createContent(FixLong(info.raft_state.hard_state.term)),
+        applied: this.createContent(FixLong(info.raft_state.applied)),
+        commit: this.createContent(FixLong(info.raft_state.hard_state.commit)),
+        lastIndex: this.createContent(FixLong(info.state.lastIndex)),
+        logSize: this.createContent(FixLong(info.state.raft_log_size)),
         leaseHolderQPS: leaseHolder ? this.createContent(info.stats.queries_per_second.toFixed(4)) : rangeTableEmptyContent,
         keysWrittenPS: this.createContent(info.stats.writes_per_second.toFixed(4)),
-        approxProposalQuota: raftLeader ? this.createContent(info.state.approximate_proposal_quota) : rangeTableEmptyContent,
-        pendingCommands: this.createContent(info.state.num_pending),
+        approxProposalQuota: raftLeader ? this.createContent(FixLong(info.state.approximate_proposal_quota)) : rangeTableEmptyContent,
+        pendingCommands: this.createContent(FixLong(info.state.num_pending)),
         droppedCommands: this.createContent(
-          info.state.num_dropped,
+          FixLong(info.state.num_dropped),
           FixLong(info.state.num_dropped).greaterThan(0) ? "range-table__cell--dropped-commands" : "",
         ),
-        truncatedIndex: this.createContent(info.state.state.truncated_state.index),
-        truncatedTerm: this.createContent(info.state.state.truncated_state.term),
-        mvccLastUpdate: this.contentNanos(mvcc.last_update_nanos),
-        mvccIntentAge: this.contentDuration(mvcc.intent_age),
-        mvccGGBytesAge: this.contentDuration(mvcc.gc_bytes_age),
-        mvccLiveBytesCount: this.contentMVCC(mvcc.live_bytes, mvcc.live_count),
-        mvccKeyBytesCount: this.contentMVCC(mvcc.key_bytes, mvcc.key_count),
-        mvccValueBytesCount: this.contentMVCC(mvcc.val_bytes, mvcc.val_count),
-        mvccIntentBytesCount: this.contentMVCC(mvcc.intent_bytes, mvcc.intent_count),
-        mvccSystemBytesCount: this.contentMVCC(mvcc.sys_bytes, mvcc.sys_count),
+        truncatedIndex: this.createContent(FixLong(info.state.state.truncated_state.index)),
+        truncatedTerm: this.createContent(FixLong(info.state.state.truncated_state.term)),
+        mvccLastUpdate: this.contentNanos(FixLong(mvcc.last_update_nanos)),
+        mvccIntentAge: this.contentDuration(FixLong(mvcc.intent_age)),
+        mvccGGBytesAge: this.contentDuration(FixLong(mvcc.gc_bytes_age)),
+        mvccLiveBytesCount: this.contentMVCC(FixLong(mvcc.live_bytes), FixLong(mvcc.live_count)),
+        mvccKeyBytesCount: this.contentMVCC(FixLong(mvcc.key_bytes), FixLong(mvcc.key_count)),
+        mvccValueBytesCount: this.contentMVCC(FixLong(mvcc.val_bytes), FixLong(mvcc.val_count)),
+        mvccIntentBytesCount: this.contentMVCC(FixLong(mvcc.intent_bytes), FixLong(mvcc.intent_count)),
+        mvccSystemBytesCount: this.contentMVCC(FixLong(mvcc.sys_bytes), FixLong(mvcc.sys_count)),
       });
     });
 

--- a/pkg/ui/styl/pages/reports.styl
+++ b/pkg/ui/styl/pages/reports.styl
@@ -177,6 +177,9 @@ $reports-table
     white-space normal
     max-width none
 
+    &--date
+      min-width 14rem
+
 .lease-table
   @extend $reports-table
   font-size 12px


### PR DESCRIPTION
- All debug calls now have a timeout of 10s instead of 30ms.
- Replace a replica's non-vote with a `-` instead of a `0`.
- All Logs used to display the range details table are now wrapped with FixLong for safety.
- The range log table timestamp column is not scaled so the date won't wrap.

Fixes #17909.