### PR TITLE
sql: check that incoming params are valid UTF-8

### DIFF
--- a/pkg/acceptance/node_test.go
+++ b/pkg/acceptance/node_test.go
@@ -47,20 +47,60 @@ const config = {
 
 const client = new pg.Client(config);
 
+// Assert that the given error is not null and matches the given regex.
+function isError(err, expected) {
+  if (!err) return false;
+  return expected.test(err.toString());
+}
+
+function testSelect(client) {
+  return new Promise(resolve => {
+    client.query("SELECT 1 as first, 2+$1 as second, ARRAY['\"','',''] as third", [%v], function (err, results) {
+      if (err) throw err;
+
+      assert.deepEqual(results.rows, [{
+        first: 1,
+        second: 5,
+        third: ['"', '', '']
+      }]);
+
+      resolve();
+    });
+  });
+}
+
+function testSendInvalidUTF8(client) {
+  return new Promise(resolve => {
+    client.query({
+      text: 'SELECT $1::STRING',
+      values: [new Buffer([167])]
+    }, function (err, results) {
+      if (!isError(err, /invalid UTF-8 sequence/)) throw new Error('expected error, got ' + err.toString());
+      resolve();
+    });
+  });
+}
+
+function runTests(client, ...tests) {
+  if (tests.length === 0) {
+    return Promise.resolve();
+  } else {
+    return tests[0](client).then(() => runTests(client, ...tests.slice(1)));
+  }
+}
+
 client.connect(function (err) {
   if (err) throw err;
 
-  client.query("SELECT 1 as first, 2+$1 as second, ARRAY['\"','',''] as third", [%v], function (err, results) {
-    if (err) throw err;
-
-    assert.deepEqual(results.rows, [{
-      first: 1,
-      second: 5,
-      third: ['"', '', '']
-    }]);
+  runTests(client,
+    testSendInvalidUTF8,
+    testSelect
+  ).then(result => {
     client.end(function (err) {
       if (err) throw err;
     });
+  }).catch(err => {
+    throw err;
   });
 });
 `

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -23,10 +23,12 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/lib/pq"
@@ -705,12 +707,29 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 	// Types with identical text/binary handling.
 	switch id {
 	case oid.T_text, oid.T_varchar:
+		if err := validateStringBytes(b); err != nil {
+			return nil, err
+		}
 		return parser.NewDString(string(b)), nil
 	case oid.T_name:
+		if err := validateStringBytes(b); err != nil {
+			return nil, err
+		}
 		return parser.NewDName(string(b)), nil
 	default:
 		return nil, errors.Errorf("unsupported OID %v with format code %s", id, code)
 	}
+}
+
+var invalidUTF8Error = pgerror.NewErrorf(pgerror.CodeCharacterNotInRepertoireError, "invalid UTF-8 sequence")
+
+// Values which are going to be converted to strings (STRING and NAME) need to
+// be valid UTF-8 for us to accept them.
+func validateStringBytes(b []byte) error {
+	if !utf8.Valid(b) {
+		return invalidUTF8Error
+	}
+	return nil
 }
 
 func decodeBinaryArray(b []byte, code formatCode) (parser.Datum, error) {


### PR DESCRIPTION
Fixes #16378.

I think it's possible that there is a lingering issue here with regards
to the oid.T__text case, but the relevant code exists in lib/pq and I
was unable to test this case regardless.

Had to restructure the node test a little bit to easily support multiple tests,
maybe Nathan can take a look at that one since I believe he wrote it originally?

Managed to find this panic thanks to go-fuzz!