### PR TITLE
storage: transfer all pending prerequisites during command cancellation

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -82,9 +82,13 @@ type cmd struct {
 	expanded bool // have the children been added
 	children []cmd
 
-	prereqs   []*cmd
-	pending   chan struct{} // closed when complete
-	cancelled bool
+	// In both child and parent cmds, prereqs points to
+	// the prereqsBuf of the parent cmd. This means we
+	// don't need to keep multiple *cmd slices in-sync.
+	prereqs    *[]*cmd
+	prereqsBuf []*cmd
+
+	pending chan struct{} // closed when complete
 }
 
 // ID implements interval.Interface.
@@ -131,6 +135,93 @@ func (c *cmd) String() string {
 		}
 	}
 	return buf.String()
+}
+
+// PendingPrereq returns the prerequisite command that should be waited on next,
+// or nil if the receiver has no more prerequisites to wait on.
+func (c *cmd) PendingPrereq() *cmd {
+	if len(*c.prereqs) == 0 {
+		return nil
+	}
+	return (*c.prereqs)[0]
+}
+
+// ResolvePendingPrereq removes the first prerequisite in the cmd's prereq
+// slice. While doing so, transfer any prerequisites of this prereq that were
+// still pending when this prereq was removed from the CommandQueue.
+//
+// cmd.PendingPrereq().pending must be closed for this call to be safe.
+func (c *cmd) ResolvePendingPrereq() {
+	pre := c.PendingPrereq()
+	if pre == nil {
+		panic("ResolvePendingPrereq with no pending prereq")
+	}
+
+	// Either the prerequisite command finished executing or it was cancelled.
+	// If the command finished cleanly, there's nothing for us to do except
+	// remove it from our list and wait for the next prerequisite to finish.
+	// Here, len(prereq.prereqs) == 0 so the append below will be a no-op.
+	// Removing the prereq from our own list is important so that it is not
+	// transferred to our dependents when we finish pending (either from
+	// completion or cancellation).
+	//
+	// If the prerequisite command was cancelled, we have to handle the
+	// cancellation here. We do this by migrating transitive dependencies from
+	// cancelled prerequisite to the current command. All prerequisites of the
+	// prerequisite that was just cancelled that were still pending at the time
+	// of cancellation are now this command's direct prerequisites. The append
+	// does not need to be synchronized, because prereq.prereqs will only ever
+	// be mutated on the other side of the prereq.pending closing, which the Go
+	// Memory Model promises is safe.
+	//
+	// While it may be possible that some of these transitive dependencies no
+	// longer overlap the current command, they are still required, because they
+	// themselves might be dependent on a command that overlaps both the current
+	// and prerequisite command.
+	//
+	// For instance, take the following dependency graph, where command 3 was
+	// cancelled. We need to set command 2 as a prerequisite of command 4 even
+	// though they do not overlap because command 2 has a dependency on command
+	// 1, which does overlap command 4. We could try to catch this situation and
+	// set command 1 as a prerequisite of command 4 directly, but this approach
+	// would require much more complexity and would need to traverse all the way
+	// up the dependency graph in the worst case.
+	//
+	//  cmd 1:   -------------
+	//                     |
+	//  cmd 2:           -----
+	//                     |
+	//  cmd 3:     xxxxxxxxxxx
+	//              |
+	//  cmd 4:   -----
+	//
+	// It is also be possible that some of the transitive dependencies are
+	// unnecessary and that we're being pessimistic here. An example case for
+	// this is shown in the following dependency graph, where a write separating
+	// two reads is cancelled. During the cancellation, command 3 will take
+	// command 1 as it's prerequisite even though reads do not need to wait on
+	// other reads. We could be smarter here and detect these cases, but the
+	// pessimism does not affect correctness.
+	//
+	// cmd 1 [R]:   -----
+	//                |
+	// cmd 2 [W]:   xxxxx
+	//                |
+	// cmd 3 [R]:   -----
+	//
+	// The interaction between commands' timestamps and their resulting
+	// dependencies (see rules in command_queue.go) will work as expected with
+	// regard to properly transferring dependencies. This is because these
+	// timestamp rules all exhibit a transitive relationship.
+	*c.prereqs = append(*c.prereqs, *pre.prereqs...)
+
+	// Truncate the command's prerequisite list so that it no longer includes
+	// the first prerequisite. Before doing so, nil out prefix of slice to allow
+	// GC of the first command. Without this, large chunks of the dependency
+	// graph would be prevented from being GCed longer than necessary,
+	// especially during cascade command cancellation.
+	(*c.prereqs)[0] = nil
+	(*c.prereqs) = (*c.prereqs)[1:]
 }
 
 // NewCommandQueue returns a new command queue. The boolean specifies whether
@@ -567,7 +658,8 @@ func (cq *CommandQueue) add(
 	cmd.key = coveringSpan.AsRange()
 	cmd.readOnly = readOnly
 	cmd.timestamp = timestamp
-	cmd.prereqs = prereqs
+	cmd.prereqsBuf = prereqs
+	cmd.prereqs = &cmd.prereqsBuf
 
 	cmd.expanded = false
 	if len(spans) > 1 {
@@ -579,6 +671,8 @@ func (cq *CommandQueue) add(
 			child.key = span.AsRange()
 			child.readOnly = readOnly
 			child.timestamp = timestamp
+			child.prereqs = &cmd.prereqsBuf
+
 			child.expanded = true
 		}
 	}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2067,89 +2067,32 @@ func (r *Replica) beginCmds(
 				if newCmd == nil {
 					continue
 				}
-				// Loop over each command's prereqs. This cannot be a for-range loop, because we
-				// may grow the newCmd.prereqs slice with transitive dependencies of cancelled
-				// prerequisites.
-				for i := 0; i < len(newCmd.prereqs); i++ {
-					prereq := newCmd.prereqs[i]
+				// Loop until the command has no more pending prerequisites. Resolving cancelled
+				// prerequisites can add new transitive dependencies to a command, so newCmd.prereqs
+				// should not be accessed directly (see ResolvePendingPrereq).
+				for {
+					pre := newCmd.PendingPrereq()
+					if pre == nil {
+						break
+					}
 					select {
-					case <-prereq.pending:
-						// Either the prerequisite command finished executing or it was cancelled.
-						// If the command finished cleanly, there's nothing for us to do except wait
-						// for the next prerequisite to finish. However, if the command was
-						// cancelled, we have to handle the cancellation here. This check does not
-						// need to be synchronized, because prereq.cancelled will only ever be set
-						// on the other side of the prereq.pending closing (see below), which the Go
-						// Memory Model promises is safe. Similarly, a command's prereqs will only
-						// ever be mutated on the other side of the prereq.pending closing.
-						if prereq.cancelled {
-							// Migrate transitive dependencies from cancelled prerequisite to
-							// current command. All prerequisites of the prerequisite that was just
-							// cancelled are now this command's direct prerequisites.
-							//
-							// While it may be possible that some of these transitive dependencies
-							// no longer overlap the current command, they are still required,
-							// because they themselves might be dependent on a command that overlaps
-							// both the current and prerequisite command.
-							//
-							// For instance, take the following dependency graph, where command 3
-							// was cancelled. We need to set command 2 as a prerequisite of command
-							// 4 even though they do not overlap because command 2 has a dependency
-							// on command 1, which does overlap command 4. We could try to catch
-							// this situation and set command 1 as a prerequisite of command 4
-							// directly, but this approach would require much more complexity and
-							// would need to traverse all the way up the dependency graph in the
-							// worst case.
-							//
-							//  cmd 1:   -------------
-							//                     |
-							//  cmd 2:           -----
-							//                     |
-							//  cmd 3:     xxxxxxxxxxx
-							//              |
-							//  cmd 4:   -----
-							//
-							// It is also be possible that some of the transitive dependencies are
-							// unnecessary and that we're being pessimistic here. An example case
-							// for this is shown in the following dependency graph, where a write
-							// separating two reads is cancelled. During the cancellation, command 3
-							// will take command 1 as it's prerequisite even though reads do not
-							// need to wait on other reads. We could be smarter here and detect
-							// these cases, but the pessimism does not affect correctness.
-							//
-							// cmd 1 [R]:   -----
-							//                |
-							// cmd 2 [W]:   xxxxx
-							//                |
-							// cmd 3 [R]:   -----
-							//
-							// The interaction between commands' timestamps and their resulting
-							// dependencies (see rules in command_queue.go) will work as expected
-							// with regard to properly transferring dependencies. This is because
-							// these timestamp rules all exhibit a transitive relationship.
-							newCmd.prereqs = append(newCmd.prereqs, prereq.prereqs...)
-						}
+					case <-pre.pending:
+						// The prerequisite command has finished so remove it from our prereq list.
+						// If the prereq still has pending dependencies, migrate them.
+						newCmd.ResolvePendingPrereq()
 					case <-ctxDone:
 						err := ctx.Err()
 						errStr := fmt.Sprintf("%s while in command queue: %s", err, ba)
 						log.Warning(ctx, errStr)
 						log.ErrEvent(ctx, errStr)
 
-						// Truncate the cancelled command's prerequisite list to only those
-						// prerequisites that have not yet been waited on. Before doing so,
-						// nil out prefix of slice to allow GC of all prerequisite commands
-						// that have already completed. This prevents us from leaking large
-						// chunks of the dependency graph.
-						for j := range newCmd.prereqs[:i] {
-							newCmd.prereqs[j] = nil
-						}
-						newCmd.prereqs = newCmd.prereqs[i:]
-						newCmd.cancelled = true
-
 						// Remove the command from the command queue immediately. Dependents will
-						// transfer transitive dependencies when they try to block on this command.
-						// New commands that would have established a dependency on this command
-						// will never see it, which is fine.
+						// transfer transitive dependencies when they try to block on this command,
+						// because our prereqs slice is not empty. This migration of dependencies
+						// will happen for each dependent in ResolvePendingPrereq, which will notice
+						// that our prereqs slice was not empty when we stopped pending and will
+						// adopt our prerequisites in turn. New commands that would have established
+						// a dependency on this command will never see it, which is fine.
 						if fn := r.store.cfg.TestingKnobs.OnCommandQueueAction; fn != nil {
 							fn(ba, storagebase.CommandQueueCancellation)
 						}
@@ -2161,11 +2104,6 @@ func (r *Replica) beginCmds(
 						return nil, &roachpb.NodeUnavailableError{}
 					}
 				}
-
-				// Set prereqs to nil so that the prereq slice and all referenced commands can be
-				// GCed. This also means that when we eventually close our pending channel, none
-				// of our dependencies will be migrated to commands that are waiting on us.
-				newCmd.prereqs = nil
 			}
 		}
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1866,6 +1866,9 @@ func (ec *endCmds) done(br *roachpb.BatchResponse, pErr *roachpb.Error, retry pr
 		ec.repl.store.tsCacheMu.Unlock()
 	}
 
+	if fn := ec.repl.store.cfg.TestingKnobs.OnCommandQueueAction; fn != nil {
+		fn(&ec.ba, storagebase.CommandQueueFinishExecuting)
+	}
 	ec.repl.removeCmdsFromCommandQueue(ec.cmds)
 }
 
@@ -2053,6 +2056,9 @@ func (r *Replica) beginCmds(
 		if prereqCount > 0 {
 			log.Eventf(ctx, "waiting for %d overlapping requests", prereqCount)
 		}
+		if fn := r.store.cfg.TestingKnobs.OnCommandQueueAction; fn != nil {
+			fn(ba, storagebase.CommandQueueWaitForPrereqs)
+		}
 
 		for _, accessCmds := range newCmds {
 			for _, newCmd := range accessCmds {
@@ -2144,6 +2150,9 @@ func (r *Replica) beginCmds(
 						// transfer transitive dependencies when they try to block on this command.
 						// New commands that would have established a dependency on this command
 						// will never see it, which is fine.
+						if fn := r.store.cfg.TestingKnobs.OnCommandQueueAction; fn != nil {
+							fn(ba, storagebase.CommandQueueCancellation)
+						}
 						r.removeCmdsFromCommandQueue(newCmds)
 						return nil, err
 					case <-r.store.stopper.ShouldQuiesce():
@@ -2153,12 +2162,18 @@ func (r *Replica) beginCmds(
 					}
 				}
 
-				// Set prereqs to nil so that the prereq slice and all referenced commands can be GCed.
+				// Set prereqs to nil so that the prereq slice and all referenced commands can be
+				// GCed. This also means that when we eventually close our pending channel, none
+				// of our dependencies will be migrated to commands that are waiting on us.
 				newCmd.prereqs = nil
 			}
 		}
+
 		if prereqCount > 0 {
 			log.Eventf(ctx, "waited %s for overlapping requests", timeutil.Since(beforeWait))
+		}
+		if fn := r.store.cfg.TestingKnobs.OnCommandQueueAction; fn != nil {
+			fn(ba, storagebase.CommandQueueBeginExecuting)
 		}
 	} else {
 		log.Event(ctx, "operation accepts inconsistent results")

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2256,11 +2256,6 @@ func TestReplicaCommandQueueInconsistent(t *testing.T) {
 	// Success.
 }
 
-type cancellationTestInstruction struct {
-	span   roachpb.Span
-	cancel bool
-}
-
 // TestReplicaCommandQueueCancellation verifies that commands which are
 // waiting on the command queue do not execute or deadlock if their context
 // is cancelled, and that commands dependent on cancelled commands execute
@@ -2288,19 +2283,19 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 
 	testCases := []struct {
 		name   string
-		instrs []cancellationTestInstruction
+		instrs []cancelInstr
 	}{
 		//  -----      -----     -----      xxxxx
 		//    |    ->    |    &    |    ->    |    etc.
 		//  -----      xxxxx     -----      -----
-		{name: "SingleDependency", instrs: []cancellationTestInstruction{
+		{name: "SingleDependency", instrs: []cancelInstr{
 			{span: spanAF},
 			{span: spanAF},
 		}},
 		//  --------      xxxxxxxx      --------      xxxxxxxx     --------      --------
 		//   |    |   ->   |    |    &   |    |   ->   |    |   &   |    |   ->   |    |   etc.
 		//  ---  ---      ---  ---      ---  ---      xxx  xxx     ---  ---      xxx  xxx
-		{name: "MultipleDependencies", instrs: []cancellationTestInstruction{
+		{name: "MultipleDependencies", instrs: []cancelInstr{
 			{span: spanAF},
 			{span: spanAC},
 			{span: spanDF},
@@ -2310,7 +2305,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 		//  -----  ->  xxxxx   &   -----  ->  xxxxx   &   -----  ->  xxxxx  etc.
 		//    |          |           |          |           |          |
 		//  -----      -----       -----      -----       -----      xxxxx
-		{name: "DependencyChain", instrs: []cancellationTestInstruction{
+		{name: "DependencyChain", instrs: []cancelInstr{
 			{span: spanAF},
 			{span: spanAF},
 			{span: spanAF},
@@ -2320,7 +2315,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 		//  -----------  ->  xxxxxxxxxxx  &  -----------  ->  -----------  etc.
 		//       |                |               |                |
 		//      ---              ---             ---              xxx
-		{name: "SplitDependencyChain", instrs: []cancellationTestInstruction{
+		{name: "SplitDependencyChain", instrs: []cancelInstr{
 			{span: spanAB},
 			{span: spanEF},
 			{span: spanAF},
@@ -2333,7 +2328,7 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 		//    ---------          xxxxxxxxx         ---------          ---------
 		//     |                  |                 |                  |
 		//  -----              -----             -----              xxxxx
-		{name: "NonOverlappingDependencyChain", instrs: []cancellationTestInstruction{
+		{name: "NonOverlappingDependencyChain", instrs: []cancelInstr{
 			{span: spanAF},
 			{span: spanDF},
 			{span: spanBE},
@@ -2344,8 +2339,8 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Run every permutation of command cancellation as a separate subtest
 			// for the current instruction configuration.
-			var permuteTestInstrs func(pre, post []cancellationTestInstruction)
-			permuteTestInstrs = func(pre, post []cancellationTestInstruction) {
+			var permuteInstrs func(pre, post []cancelInstr)
+			permuteInstrs = func(pre, post []cancelInstr) {
 				if len(post) == 0 {
 					// Create a name for this permutation.
 					// C = cancel
@@ -2360,7 +2355,8 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 					}
 
 					t.Run(permName.String(), func(t *testing.T) {
-						testReplicaCommandQueueCancellationInstrs(t, pre)
+						ct := newCmdQCancelTest(t)
+						ct.Run(pre)
 					})
 					return
 				}
@@ -2368,11 +2364,11 @@ func TestReplicaCommandQueueCancellation(t *testing.T) {
 				instr := post[0]
 				rest := post[1:]
 				instr.cancel = false
-				permuteTestInstrs(append(pre, instr), rest)
+				permuteInstrs(append(pre, instr), rest)
 				instr.cancel = true
-				permuteTestInstrs(append(pre, instr), rest)
+				permuteInstrs(append(pre, instr), rest)
 			}
-			permuteTestInstrs(nil, tc.instrs)
+			permuteInstrs(nil, tc.instrs)
 		})
 	}
 }
@@ -2396,141 +2392,364 @@ func TestReplicaCommandQueueCancellationRandom(t *testing.T) {
 	const trials = 25
 	for i := 0; i < trials; i++ {
 		commandCount := randutil.RandIntInRange(rng, 0, 25)
-		instructions := make([]cancellationTestInstruction, commandCount)
-		for j := range instructions {
+		instrs := make([]cancelInstr, commandCount)
+		for j := range instrs {
 			startKey := randKey()
 			endKey := randKey()
 			if startKey.Compare(endKey) >= 0 {
 				endKey = startKey.Next()
 			}
-			instructions[j] = cancellationTestInstruction{
+			instrs[j] = cancelInstr{
 				span:   roachpb.Span{Key: startKey, EndKey: endKey},
 				cancel: randBool(),
 			}
 		}
-		testReplicaCommandQueueCancellationInstrs(t, instructions)
+		ct := newCmdQCancelTest(t)
+		ct.Run(instrs)
 	}
 }
 
-func testReplicaCommandQueueCancellationInstrs(t *testing.T, instrs []cancellationTestInstruction) {
-	// Intercept DeleteRangeRequests and block them.
-	blockingDone := make(chan struct{})
+type cancelInstr struct {
+	span   roachpb.Span
+	cancel bool
+	expErr string
 
-	tc := testContext{}
-	tsc := TestStoreConfig(nil)
-	tsc.TestingKnobs.TestingEvalFilter =
-		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
-			if _, ok := filterArgs.Req.(*roachpb.DeleteRangeRequest); ok {
-				<-blockingDone
+	reqOverride *roachpb.BatchRequest // overrides span when present
+}
+
+func (ci cancelInstr) req() *roachpb.BatchRequest {
+	if req := ci.reqOverride; req != nil {
+		if s := ci.span; s.Key != nil || s.EndKey != nil {
+			panic(fmt.Sprintf("if overriding instr request, span must be empty; found %v", ci))
+		}
+		if req.Timestamp.WallTime != cmdQCancelTestTimestamp {
+			panic(fmt.Sprintf("BatchRequest should have WallTime %v; found %v",
+				cmdQCancelTestTimestamp, req.Timestamp.WallTime))
+		}
+		return req
+	}
+	// Default to a DeleteRangeRequest because it performs a single write over its Span.
+	ba := roachpb.BatchRequest{}
+	ba.Timestamp = hlc.Timestamp{WallTime: cmdQCancelTestTimestamp}
+	ba.Add(&roachpb.DeleteRangeRequest{Span: ci.span})
+	return &ba
+}
+
+type cmdQCancelTest struct {
+	testing.TB
+	s   *stop.Stopper
+	tc  testContext
+	tsc StoreConfig
+
+	// the following channels intercept requests and block them.
+	blockCmdBegin, blockCmdFinish chan struct{}
+	// the following channels track CommandQueueActions.
+	enteredCmdQ, cancelledCmd, startingCmd chan struct{}
+
+	cmds map[int]*testCmd
+}
+
+type testCmd struct {
+	id      int
+	spanSet *SpanSet
+	prereqs map[int]struct{}
+	cancel  context.CancelFunc
+	done    <-chan *roachpb.Error
+	expErr  string
+}
+
+func newCmdQCancelTest(t *testing.T) *cmdQCancelTest {
+	ct := &cmdQCancelTest{
+		TB:            t,
+		s:             stop.NewStopper(),
+		tsc:           TestStoreConfig(nil),
+		blockCmdBegin: make(chan struct{}),
+		enteredCmdQ:   make(chan struct{}),
+		cancelledCmd:  make(chan struct{}),
+		startingCmd:   make(chan struct{}),
+		cmds:          make(map[int]*testCmd),
+	}
+	ct.tsc.TestingKnobs.OnCommandQueueAction = ct.onCmdQAction
+	return ct
+}
+
+// letCmdsRun unblocks commands in the CommandQueue that are ready to run. They
+// will then be blocked when they try to exit the CommandQueue.
+func (ct *cmdQCancelTest) letCmdsRun() {
+	ct.blockCmdFinish = make(chan struct{})
+	close(ct.blockCmdBegin)
+}
+
+// letCmdsFinish unblocks commands that are ready to exit the CommandQueue and
+// finish. It resets the block on cmds in the CommandQueue so that they don't
+// immediately start running.
+func (ct *cmdQCancelTest) letCmdsFinish() {
+	ct.blockCmdBegin = make(chan struct{})
+	close(ct.blockCmdFinish)
+}
+
+const (
+	// cmdQCancelTestTimestamp is the WallTime all BatchRequests in
+	// cmdQCancelTest should use. This allows them to be identified and
+	// intercepted by the onCmdQAction handler.
+	cmdQCancelTestTimestamp = 12345
+	// cmdQCancelTestDeadlockTimeout is the timeout used in cmdQCancelTest to
+	// determine that a deadlock has occurred.
+	cmdQCancelTestDeadlockTimeout = 500 * time.Millisecond
+)
+
+// onCmdQAction instruments CommandQueueActions, sending to different channels
+// depending on the action. The instrumentation is also used to block commands
+// at different stages of execution.
+func (ct *cmdQCancelTest) onCmdQAction(
+	ba *roachpb.BatchRequest, action storagebase.CommandQueueAction,
+) {
+	if ba.Header.Timestamp.WallTime == cmdQCancelTestTimestamp {
+		quiesce := ct.s.ShouldQuiesce()
+		switch action {
+		case storagebase.CommandQueueWaitForPrereqs:
+			select {
+			case ct.enteredCmdQ <- struct{}{}:
+			case <-quiesce:
 			}
-			return nil
+		case storagebase.CommandQueueCancellation:
+			select {
+			case ct.cancelledCmd <- struct{}{}:
+			case <-quiesce:
+			}
+		case storagebase.CommandQueueBeginExecuting:
+			select {
+			case <-ct.blockCmdBegin:
+			case <-quiesce:
+			}
+			select {
+			case ct.startingCmd <- struct{}{}:
+			case <-quiesce:
+			}
+		case storagebase.CommandQueueFinishExecuting:
+			select {
+			case <-ct.blockCmdFinish:
+			case <-quiesce:
+			}
 		}
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	tc.StartWithStoreConfig(t, stopper, tsc)
+	}
+}
 
-	// startBlockingCmd will create a goroutine to send a read-write request
-	// over the given span. It returns a channel that will be given the result
-	// of the request when it completes.
-	startBlockingCmd := func(ctx context.Context, span roachpb.Span) <-chan *roachpb.Error {
-		done := make(chan *roachpb.Error)
-
-		if err := stopper.RunAsyncTask(context.Background(), "test", func(_ context.Context) {
-			ba := roachpb.BatchRequest{}
-			ba.Add(&roachpb.DeleteRangeRequest{
-				Span: span,
-			})
-			_, pErr := tc.Sender().Send(ctx, ba)
-			done <- pErr
-		}); err != nil {
-			t.Fatal(err)
+// startInstr will create a goroutine to send the BatchRequest. It returns a
+// channel that will be given the result of the request when it completes.
+func (ct *cmdQCancelTest) startInstr(
+	ctx context.Context, ba *roachpb.BatchRequest,
+) <-chan *roachpb.Error {
+	done := make(chan *roachpb.Error)
+	if err := ct.s.RunAsyncTask(context.Background(), "test", func(_ context.Context) {
+		_, pErr := ct.tc.Sender().Send(ctx, *ba)
+		select {
+		case done <- pErr:
+		case <-ct.s.ShouldQuiesce():
 		}
+	}); err != nil {
+		ct.Fatal(err)
+	}
+	return done
+}
 
-		return done
+func spanSetsOverlap(ss, ss2 *SpanSet) bool {
+	for ac1 := SpanAccess(0); ac1 < numSpanAccess; ac1++ {
+		for ac2 := SpanAccess(0); ac2 < numSpanAccess; ac2++ {
+			if ac1 == SpanReadOnly && ac2 == SpanReadOnly {
+				// Reads ignore other reads.
+				continue
+			}
+			for sc := spanScope(0); sc < numSpanScope; sc++ {
+				for _, s := range ss.spans[ac1][sc] {
+					for _, s2 := range ss2.spans[ac2][sc] {
+						if s.Overlaps(s2) {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+// insertCmds inserts each command into the CommandQueue, populating the cmds map
+// while doing so.
+func (ct *cmdQCancelTest) insertCmds(instrs []cancelInstr) {
+	if instrs[0].cancel {
+		ct.Fatalf("the first cancelInstr cannot be cancelled")
 	}
 
-	// We always add an initial instruction that will block all commands to
-	// prevent leading cancelled commands from immediately executing. This is
-	// used to build up a dependency configuration in the CommandQueue before
-	// cancelling some instructions and releasing the gate (the blockingDone chan)
-	// to let the others through.
-	initial := cancellationTestInstruction{
+	for i, instr := range instrs {
+		// Create a new context for each instruction. Ignore the cancel function
+		// if we don't want to cancel the cmd.
+		ctx, cancel := context.WithCancel(context.Background())
+		if !instr.cancel {
+			cancel = nil
+		}
+
+		ba := instr.req()
+		spanSet, err := collectSpans(roachpb.RangeDescriptor{}, ba)
+		if err != nil {
+			ct.Fatal(err)
+		}
+
+		// Start command and wait until the new command is in the command queue.
+		cmdDone := ct.startInstr(ctx, ba)
+		select {
+		case <-ct.enteredCmdQ:
+		case <-time.After(cmdQCancelTestDeadlockTimeout):
+			ct.Fatalf("request %v never entered CommandQueue", ba)
+		}
+
+		// Determine the prereq set of each command, including all transitive
+		// dependencies. Add the new command to the cmds map.
+		prereqs := make(map[int]struct{})
+		for j, prevCmd := range ct.cmds {
+			if spanSetsOverlap(spanSet, prevCmd.spanSet) {
+				prereqs[j] = struct{}{}
+				for trans := range prevCmd.prereqs {
+					prereqs[trans] = struct{}{}
+				}
+			} else if j == 0 {
+				ct.Fatalf("all instruction spans should overlap the initial span; found %v",
+					instr.span)
+			}
+		}
+		ct.cmds[i] = &testCmd{
+			id:      i,
+			spanSet: spanSet,
+			prereqs: prereqs,
+			cancel:  cancel,
+			done:    cmdDone,
+			expErr:  instr.expErr,
+		}
+	}
+}
+
+// cancelCmds cancels all testCmds that need to be cancelled in a
+// non-deterministic order.
+func (ct *cmdQCancelTest) cancelCmds() {
+	perm := rand.Perm(len(ct.cmds))
+	for _, idx := range perm {
+		cmd := ct.cmds[idx]
+		if cancel := cmd.cancel; cancel != nil {
+			// Cancel the context on each cmd that should be cancelled.
+			cancel()
+
+			// If either of these deadlocks, the command was never cancelled and may have
+			// unexpectedly begun executing. Indeed, the absence of such a deadlock is
+			// what's being tested here.
+			select {
+			case <-ct.cancelledCmd:
+			case <-time.After(cmdQCancelTestDeadlockTimeout):
+				ct.Fatalf("command %d never left CommandQueue after cancellation", idx)
+			}
+			select {
+			case pErr := <-cmd.done:
+				if ctxCancelErr := context.Canceled; !testutils.IsPError(pErr, ctxCancelErr.Error()) {
+					ct.Fatalf("expected error %v for cmd %d, found %v", ctxCancelErr, idx, pErr)
+				}
+			case <-time.After(cmdQCancelTestDeadlockTimeout):
+				ct.Fatalf("command %d never returned to client after cancellation", idx)
+			}
+
+			// Remove the command from the cmds map and delete it from the
+			// prereq sets of all pending cmds.
+			delete(ct.cmds, idx)
+			for _, cmd := range ct.cmds {
+				delete(cmd.prereqs, idx)
+			}
+		}
+	}
+}
+
+// runCmds runs all testCmds that were not cancelled.
+func (ct *cmdQCancelTest) runCmds() {
+	for len(ct.cmds) > 0 {
+		// Determine the commands we expect to be ready to run. Remove these
+		// from the cmds map and from the prereq sets of all cmds still pending.
+		var readyToRun []*testCmd
+		for i, cmd := range ct.cmds {
+			if len(cmd.prereqs) == 0 {
+				readyToRun = append(readyToRun, cmd)
+				delete(ct.cmds, i)
+			}
+		}
+
+		readyLen := len(readyToRun)
+		if readyLen == 0 {
+			ct.Fatal("found no commands ready to run")
+		}
+		for _, cmd := range ct.cmds {
+			for _, ready := range readyToRun {
+				delete(cmd.prereqs, ready.id)
+			}
+		}
+
+		// We should see exactly this many commands begin executing. If we see
+		// fewer or more we'll deadlock, which is what we're testing for.
+		ct.letCmdsRun()
+		for i := range readyToRun {
+			select {
+			case <-ct.startingCmd:
+			case <-time.After(cmdQCancelTestDeadlockTimeout):
+				ct.Fatalf("expected %d commands to begin running together, saw %d", readyLen, i)
+			}
+		}
+		select {
+		case <-ct.startingCmd:
+			ct.Fatalf("expected %d commands to begin running together, saw extra", readyLen)
+		case <-time.After(cmdQCancelTestDeadlockTimeout / 10):
+		}
+
+		// We should see exactly this many command finish. Again, the absence
+		// of a deadlock is what we're testing for.
+		ct.letCmdsFinish()
+		for _, running := range readyToRun {
+			select {
+			case pErr := <-running.done:
+				if running.expErr == "" {
+					if pErr != nil {
+						ct.Fatalf("expected no error for cmd %d, found %v", running.id, pErr)
+					}
+				} else {
+					if !testutils.IsPError(pErr, running.expErr) {
+						ct.Fatalf("expected error %q for cmd %d, found %v",
+							running.expErr, running.id, pErr)
+					}
+				}
+			case <-time.After(cmdQCancelTestDeadlockTimeout):
+				ct.Fatalf("command %d never returned to client", running.id)
+			}
+		}
+	}
+}
+
+// Run runs the cmdQCancelTest with the provided cancelInstrs.
+func (ct *cmdQCancelTest) Run(instrs []cancelInstr) {
+	// Create an initial span that will block all others until we're ready to
+	// begin monitoring. This initial span cannot be cancelled before exiting
+	// the prereq wait period.
+	initial := cancelInstr{
 		span:   roachpb.Span{Key: keys.SystemMax, EndKey: keys.TableDataMin},
 		cancel: false,
 	}
-	instrs = append([]cancellationTestInstruction{initial}, instrs...)
 
-	type cancellation struct {
-		cancel context.CancelFunc
-		done   <-chan *roachpb.Error
-	}
-	var cancellations []cancellation
-	var completions []<-chan *roachpb.Error
+	ct.RunWithoutInitialSpan(append([]cancelInstr{initial}, instrs...))
+}
 
-	for i, instruction := range instrs {
-		if !instruction.span.Overlaps(initial.span) {
-			t.Fatalf("all instruction spans should overlap the initial span; found %v",
-				instruction.span)
-		}
+// RunWithoutInitialSpan runs the cmdQCancelTest with the provided cancelInstrs.
+// The first cancelInstrs should be a prereq of all other instructions and cannot be
+// cancelled. Use ct.Run to assure this.
+func (ct *cmdQCancelTest) RunWithoutInitialSpan(instrs []cancelInstr) {
+	defer ct.s.Stop(context.Background())
+	ct.tc.StartWithStoreConfig(ct, ct.s, ct.tsc)
 
-		// Send a command for the instruction with a new context.
-		ctx, cancel := context.WithCancel(context.Background())
-		cmdDone := startBlockingCmd(ctx, instruction.span)
-
-		// Wait until the new command is in the command queue.
-		testutils.SucceedsSoon(t, func() error {
-			tc.repl.cmdQMu.Lock()
-			l := tc.repl.cmdQMu.queues[spanGlobal].treeSize()
-			tc.repl.cmdQMu.Unlock()
-			if e := i + 1; l != e {
-				return errors.Errorf("%d of %d commands in the command queue", l, e)
-			}
-			return nil
-		})
-
-		// Maintain a handle to check when the command completes, as well as
-		// a cancellation function for commands that should be cancelled.
-		if instruction.cancel {
-			cancellations = append(cancellations, cancellation{
-				cancel: cancel,
-				done:   cmdDone,
-			})
-		} else {
-			completions = append(completions, cmdDone)
-		}
-	}
-
-	// Cancel all commands that should be cancelled, in a non-deterministic order.
-	perm := rand.Perm(len(cancellations))
-	for _, idx := range perm {
-		cancellation := cancellations[idx]
-		cancellation.cancel()
-
-		// If this deadlocks, the command has unexpectedly begun executing and was
-		// trapped in the command filter. Indeed, the absence of such a deadlock is
-		// what's being tested here.
-		if pErr := <-cancellation.done; !testutils.IsPError(pErr, context.Canceled.Error()) {
-			t.Fatal(pErr)
-		}
-	}
-
-	// Release all remaining commands and allow them to complete, this time in-order.
-	// If this deadlocks, it is a sign that a dependency on a cancelled command was
-	// not correctly handled.
-	close(blockingDone)
-	for _, done := range completions {
-		if pErr := <-done; pErr != nil {
-			t.Fatal(pErr)
-		}
-	}
-
-	// Assert that the command queue is empty and that both successful and cancelled
-	// commands were cleaned up.
-	tc.repl.cmdQMu.Lock()
-	defer tc.repl.cmdQMu.Unlock()
-	if l := tc.repl.cmdQMu.queues[spanGlobal].treeSize(); l != 0 {
-		t.Fatalf("expected command queue to be empty, found %d remaining commands", l)
-	}
+	ct.insertCmds(instrs)
+	ct.cancelCmds()
+	ct.runCmds()
 }
 
 // TestReplicaCommandQueueSelfOverlap verifies that self-overlapping

--- a/pkg/storage/storagebase/base.go
+++ b/pkg/storage/storagebase/base.go
@@ -60,3 +60,25 @@ type ReplicaApplyFilter func(args ApplyFilterArgs) *roachpb.Error
 // response returned to a waiting client after a replica command has
 // been processed. This filter is invoked only by the command proposer.
 type ReplicaResponseFilter func(roachpb.BatchRequest, *roachpb.BatchResponse) *roachpb.Error
+
+// CommandQueueAction is an action taken by a BatchRequest's batchCmdSet on the
+// CommandQueue.
+type CommandQueueAction int
+
+const (
+	// CommandQueueWaitForPrereqs represents the state of a batchCmdSet when it
+	// has just inserted itself into the CommandQueue and is beginning to wait
+	// for prereqs to finish execution.
+	CommandQueueWaitForPrereqs CommandQueueAction = iota
+	// CommandQueueCancellation represents the state of a batchCmdSet when it
+	// is cancelled while waiting for prerequisites to finish and is forced to
+	// remove itself from the CommandQueue without executing.
+	CommandQueueCancellation
+	// CommandQueueBeginExecuting represents the state of a batchCmdSet when it
+	// has finished waiting for all prereqs to finish execution and is now free
+	// to execute itself.
+	CommandQueueBeginExecuting
+	// CommandQueueFinishExecuting represents the state of a batchCmdSet when it
+	// has finished executing and will remove itself from the CommandQueue.
+	CommandQueueFinishExecuting
+)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -677,6 +677,9 @@ type StoreTestingKnobs struct {
 	// when initializing the Raft group. Note that this method is invoked
 	// with both Replica.raftMu and Replica.mu locked.
 	OnCampaign func(*Replica)
+	// OnCommandQueueAction is called when the BatchRequest performs an action
+	// on the CommandQueue.
+	OnCommandQueueAction func(*roachpb.BatchRequest, storagebase.CommandQueueAction)
 	// MaxOffset, if set, overrides the server clock's MaxOffset at server
 	// creation time.
 	// See also DisableMaxOffsetCheck.


### PR DESCRIPTION
Fixes #16266.

The first two commits overhaul the `cmdQCancelTest` type, which allows us to do more in-depth testing on command cancellation. This includes testing exactly where each command is with respect to the `CommandQueue` at a given time (pending, cancelled, running, or finished). We can then assert that dependencies are properly maintained during command cancellation. The test framework also adds support for handling local keys, which are tested in more depth in the fourth commit.

The third commit fixes the issue discussed in #16266.
The use of the `cancelled` flag on `cmds` in the `CommandQueue` was flawed in
two ways. First, we were only setting it on the `cmd` for the
SpanAccess/spanScope combination that was active during the context
cancellation. This meant that `cmds` in later SpanAccess/spanScope combinations
would not have the flag set even if its corresponding batch was cancelled.
Second, neither the `cancelled` flag nor the `prereq` list was not being set on
child `cmds`, only on parent `cmds`. This meant that context cancellation would
not work properly for BatchRequests that create more than one `*cmd` for any
access/scope combination.

This commit fixes both of these issues by removing the `cancelled` flag and
making sure that parent and child `cmds` keep `prereqs` in-sync. Instead of
using the `cancelled` flag to signify a cancelled `cmd`, we now
uses the `cmd.prereq` slice itself to signify `cmd` cancellation. `cmds` now
remove prerequisites from their `prereq` set as the prereqs stop pending.
If a `cmd` cancels early, it will leave around a non-empty `prereq` set.
The transitive dependency migration happens whenever a prereqs stop pending
while still holding onto prereqs itself. In this case, the dependent command
will add all remaining prereqs to its set. This should be less error-prone
and more easy to reason about since we have to maintain less state.

\cc. @petermattis @tschottdorf 