### PR TITLE
kv: add kv.range_descriptor_cache.size

### DIFF
--- a/pkg/kv/leaseholder_cache.go
+++ b/pkg/kv/leaseholder_cache.go
@@ -34,12 +34,12 @@ type LeaseHolderCache struct {
 // NewLeaseHolderCache creates a new leaseHolderCache of the given size.
 // The underlying cache internally uses a hash map, so lookups
 // are cheap.
-func NewLeaseHolderCache(size int) *LeaseHolderCache {
+func NewLeaseHolderCache(size func() int64) *LeaseHolderCache {
 	return &LeaseHolderCache{
 		cache: cache.NewUnorderedCache(cache.Config{
 			Policy: cache.CacheLRU,
 			ShouldEvict: func(s int, key, value interface{}) bool {
-				return s > size
+				return int64(s) > size()
 			},
 		}),
 	}

--- a/pkg/kv/leaseholder_cache_test.go
+++ b/pkg/kv/leaseholder_cache_test.go
@@ -23,10 +23,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
+func staticSize(size int64) func() int64 {
+	return func() int64 {
+		return size
+	}
+}
+
 func TestLeaseHolderCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.TODO()
-	lc := NewLeaseHolderCache(3)
+	lc := NewLeaseHolderCache(staticSize(3))
 	if repDesc, ok := lc.Lookup(ctx, 12); ok {
 		t.Errorf("lookup of missing key returned: %+v", repDesc)
 	}

--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -142,12 +142,12 @@ func makeLookupRequestKey(key roachpb.RKey, evictToken *EvictionToken, useRevers
 // NewRangeDescriptorCache returns a new RangeDescriptorCache which
 // uses the given RangeDescriptorDB as the underlying source of range
 // descriptors.
-func NewRangeDescriptorCache(db RangeDescriptorDB, size int) *RangeDescriptorCache {
+func NewRangeDescriptorCache(db RangeDescriptorDB, size func() int64) *RangeDescriptorCache {
 	rdc := &RangeDescriptorCache{db: db}
 	rdc.rangeCache.cache = cache.NewOrderedCache(cache.Config{
 		Policy: cache.CacheLRU,
 		ShouldEvict: func(n int, _, _ interface{}) bool {
-			return n > size
+			return int64(n) > size()
 		},
 	})
 	return rdc

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -190,7 +190,7 @@ func initTestDescriptorDB(t *testing.T) *testDescriptorDB {
 			db.splitRange(t, mustMeta(roachpb.RKey(string(char))))
 		}
 	}
-	db.cache = NewRangeDescriptorCache(db, 2<<10)
+	db.cache = NewRangeDescriptorCache(db, staticSize(2<<10))
 	return db
 }
 
@@ -769,7 +769,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 		EndKey:   roachpb.RKeyMax,
 	}
 
-	cache := NewRangeDescriptorCache(nil, 2<<10)
+	cache := NewRangeDescriptorCache(nil, staticSize(2<<10))
 	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), defDesc)
 
 	// Now, add a new, overlapping set of descriptors.
@@ -865,7 +865,7 @@ func TestRangeCacheClearOverlappingMeta(t *testing.T) {
 		EndKey:   roachpb.RKeyMax,
 	}
 
-	cache := NewRangeDescriptorCache(nil, 2<<10)
+	cache := NewRangeDescriptorCache(nil, staticSize(2<<10))
 	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(firstDesc.EndKey)),
 		firstDesc)
 	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(restDesc.EndKey)),
@@ -899,7 +899,7 @@ func TestGetCachedRangeDescriptorInclusive(t *testing.T) {
 		{StartKey: roachpb.RKey("g"), EndKey: roachpb.RKey("z")},
 	}
 
-	cache := NewRangeDescriptorCache(nil, 2<<10)
+	cache := NewRangeDescriptorCache(nil, staticSize(2<<10))
 	for _, rd := range testData {
 		cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(rd.EndKey)), rd)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -208,6 +208,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	retryOpts.Closer = s.stopper.ShouldQuiesce()
 	distSenderCfg := kv.DistSenderConfig{
 		AmbientCtx:      s.cfg.AmbientCtx,
+		Settings:        st,
 		Clock:           s.clock,
 		RPCContext:      s.rpcContext,
 		RPCRetryOptions: &retryOpts,

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -218,6 +218,7 @@ type StorageSettings struct {
 	ImportBatchSize             *settings.ByteSizeSetting
 	AddSSTableEnabled           *settings.BoolSetting
 	MaxIntents                  *settings.IntSetting
+	RangeDescriptorCacheSize    *settings.IntSetting
 
 	ConsistencyCheckInterval *settings.DurationSetting
 }
@@ -467,6 +468,11 @@ func MakeClusterSettings(minVersion, serverVersion roachpb.Version) *Settings {
 	s.MaxIntents = r.RegisterIntSetting(
 		"kv.transaction.max_intents",
 		"maximum number of write intents allowed for a KV transaction", 100000)
+
+	s.RangeDescriptorCacheSize = r.RegisterIntSetting(
+		"kv.range_descriptor_cache.size",
+		"maximum number of entries in the range descriptor and leaseholder caches",
+		1e6)
 
 	s.MinWALSyncInterval = r.RegisterDurationSetting(
 		"rocksdb.min_wal_sync_interval",

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -287,8 +287,9 @@ func TestDistBackfill(t *testing.T) {
 func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	rangeCache := kv.NewRangeDescriptorCache(nil /* db */, 2<<10 /* size */)
-	leaseCache := kv.NewLeaseHolderCache(2 << 10 /* size */)
+	size := func() int64 { return 2 << 10 }
+	rangeCache := kv.NewRangeDescriptorCache(nil /* db */, size)
+	leaseCache := kv.NewLeaseHolderCache(size)
 	r, err := makeDistSQLReceiver(
 		context.TODO(), nil /* sink */, rangeCache, leaseCache, nil /* txn */, nil /* updateClock */)
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -64,6 +64,7 @@ kv.bulk_io_write.max_rate                          8.0 EiB        z     the rate
 kv.gc.batch_size                                   100000         i     maximum number of keys in a batch for MVCC garbage collection
 kv.raft.command.max_size                           64 MiB         z     maximum size of a raft command
 kv.raft_log.synchronize                            true           b     set to true to synchronize on Raft log writes to persistent storage
+kv.range_descriptor_cache.size                     1000000        i     maximum number of entries in the range descriptor and leaseholder caches
 kv.snapshot_rebalance.max_rate                     2.0 MiB        z     the rate limit (bytes/sec) to use for rebalance snapshots
 kv.snapshot_recovery.max_rate                      8.0 MiB        z     the rate limit (bytes/sec) to use for recovery snapshots
 kv.transaction.max_intents                         100000         i     maximum number of write intents allowed for a KV transaction


### PR DESCRIPTION
Use `kv.range_descriptor_cache.size` for controlling the size of both
the range descriptor cache and the leaseholder cache.

Remove some unused fields from DistSenderConfig. Not much point in
providing for configuration if we never use it. If we ever need to
configure `RangeLookupMaxRanges` or `SenderConcurrency`, cluster
settings are likely a better approach.

See #17531