### PR TITLE
settings: enable net/trace initially

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -751,7 +751,7 @@ func TestAdminAPIEvents(t *testing.T) {
 		{sql.EventLogCreateDatabase, false, 0, 1},
 		{sql.EventLogDropTable, false, 0, 2},
 		{sql.EventLogCreateTable, false, 0, 3},
-		{sql.EventLogSetClusterSetting, false, 0, 3},
+		{sql.EventLogSetClusterSetting, false, 0, 4},
 		{sql.EventLogCreateTable, true, 0, 3},
 		{sql.EventLogCreateTable, true, -1, 3},
 		{sql.EventLogCreateTable, true, 2, 2},

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -330,5 +330,6 @@ WHERE "eventType" = 'set_cluster_setting' AND info NOT LIKE '%version%' AND info
 ORDER BY "timestamp"
 ----
 0 1 {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"node"}
+0 1 {"SettingName":"trace.debug.enable","Value":"false","User":"node"}
 0 1 {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
 0 1 {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -338,6 +338,7 @@ query T
 select name from system.settings where name != 'sql.defaults.distsql' order by name
 ----
 diagnostics.reporting.enabled
+trace.debug.enable
 version
 
 statement ok
@@ -347,7 +348,8 @@ query TT
 select name, value from system.settings where name != 'version' AND name != 'sql.defaults.distsql' order by name
 ----
 diagnostics.reporting.enabled  true
-somesetting   somevalue
+somesetting                    somevalue
+trace.debug.enable             false
 
 user testuser
 

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -59,7 +59,11 @@ const (
 var enableNetTrace = settings.RegisterBoolSetting(
 	"trace.debug.enable",
 	"if set, traces for recent requests can be seen in the /debug page",
-	false,
+	// This setting defaults to true, but there is a sql migration that sets it
+	// to false. The effect is that we have tracing when the server starts and
+	// gets stuck there, without paying the overhead of having it on all the
+	// time (unless that's how the operator explicitly configures the cluster).
+	true,
 )
 
 var lightstepToken = settings.RegisterStringSetting(


### PR DESCRIPTION
Override the net/trace setting to true so that we get traces at least until we
get the authoritative setting from the settings table. This is useful to allow
diagnosing a server that doesn't manage to connect to the rest of the cluster,
and in particular, we can always see the "server start" trace that tracks the
node's boot process, which can be useful to diagnose slow boot times.