### PR TITLE
tracing: don't set baggage item multiple times

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -330,10 +330,8 @@ func (tc *TxnCoordSender) Send(
 		txnID := ba.Txn.ID
 
 		// Associate the txnID with the trace. We need to do this after the
-		// maybeBeginTxn call. We set both a baggage item and a tag because only
-		// tags show up in the Lightstep UI.
+		// maybeBeginTxn call.
 		txnIDStr := txnID.String()
-		sp.SetTag("txnID", txnIDStr)
 		sp.SetBaggageItem("txnID", txnIDStr)
 
 		var et *roachpb.EndTransactionRequest

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -380,6 +380,10 @@ func (s *span) SetBaggageItem(restrictedKey, value string) opentracing.Span {
 }
 
 func (s *span) setBaggageItemLocked(restrictedKey, value string) opentracing.Span {
+	if oldVal, ok := s.mu.Baggage[restrictedKey]; ok && oldVal == value {
+		// No-op.
+		return s
+	}
 	if s.mu.Baggage == nil {
 		s.mu.Baggage = make(map[string]string)
 	}


### PR DESCRIPTION
We were setting both a tag and baggage item for the txn id, but the tracer now
automatically sets tags for baggage items; we only need to set the baggage item.

In addition, we now detect attempts to set a baggage item to the same value
multiple times.

Fixes #17530.