### PR TITLE
acceptanceccl: use gce for 2tb restore test

### DIFF
--- a/build/teamcity-nightly-acceptance.sh
+++ b/build/teamcity-nightly-acceptance.sh
@@ -66,7 +66,7 @@ case $TESTNAME in
   BenchmarkRestoreBig|BenchmarkRestoreTPCH10/numNodes=1|BenchmarkRestoreTPCH10/numNodes=3|BenchmarkRestoreTPCH10/numNodes=10|BenchmarkRestore2TB|BenchmarkBackup2TB)
     PKG=./pkg/ccl/acceptanceccl
     TESTTIMEOUT=2h
-    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.storage-location=westus'
+    COCKROACH_EXTRA_FLAGS+=" -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.storage-location=westus -cwd=$PWD/pkg/acceptance/terraform/gce"
     ;;
   *)
     echo "unknown test name $TESTNAME"


### PR DESCRIPTION
Azure's machines are demonstratably less reliable and more troublesome
than GCE. We fully intend to get them working next, but in the meantime,
having GCE run daily and catching anything that isn't a result of azure
machine/disk badness will be invaluable.

Also sneak in enabling remote debugging on the 2tb restore test.