### PR TITLE
settings: remove "experimental" from addsstable cluster setting

### DIFF
--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -728,7 +728,7 @@ func MakeClusterSettings(minVersion, serverVersion roachpb.Version) *Settings {
 	s.ImportBatchSize.Hide()
 
 	s.AddSSTableEnabled = r.RegisterBoolSetting(
-		"kv.import.experimental_addsstable.enabled",
+		"kv.import.addsstable.enabled",
 		"set to true to use the AddSSTable command in Import or false to use WriteBatch",
 		true,
 	)


### PR DESCRIPTION
AddSSTable is no longer experimental. This is a hidden setting and has
only been present in alpha builds, so there should be no backward
compatibility concerns.