### PR TITLE
server,storage/engine: enforce rocksdb max open file limit

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -325,13 +325,13 @@ func GetTotalMemory(ctx context.Context) (int64, error) {
 // On Windows there is no need to change the file descriptor, known as handles,
 // limit. This limit cannot be changed and is approximately 16,711,680. See
 // https://blogs.technet.microsoft.com/markrussinovich/2009/09/29/pushing-the-limits-of-windows-handles/
-func setOpenFileLimit(physicalStoreCount int) (int, error) {
+func setOpenFileLimit(physicalStoreCount int) (uint64, error) {
 	return setOpenFileLimitInner(physicalStoreCount)
 }
 
 // SetOpenFileLimitForOneStore sets the soft limit for open file descriptors
 // when there is only one store.
-func SetOpenFileLimitForOneStore() (int, error) {
+func SetOpenFileLimitForOneStore() (uint64, error) {
 	return setOpenFileLimit(1)
 }
 

--- a/pkg/server/config_unix.go
+++ b/pkg/server/config_unix.go
@@ -32,16 +32,16 @@ type rlimit struct {
 	Cur, Max uint64
 }
 
-func setOpenFileLimitInner(physicalStoreCount int) (int, error) {
+func setOpenFileLimitInner(physicalStoreCount int) (uint64, error) {
 	minimumOpenFileLimit := uint64(physicalStoreCount*engine.MinimumMaxOpenFiles + minimumNetworkFileDescriptors)
 	networkConstrainedFileLimit := uint64(physicalStoreCount*engine.RecommendedMaxOpenFiles + minimumNetworkFileDescriptors)
 	recommendedOpenFileLimit := uint64(physicalStoreCount*engine.RecommendedMaxOpenFiles + recommendedNetworkFileDescriptors)
 	var rLimit rlimit
 	if err := getRlimitNoFile(&rLimit); err != nil {
 		if log.V(1) {
-			log.Infof(context.TODO(), "could not get rlimit; setting maxOpenFiles to the default value %d - %s", engine.DefaultMaxOpenFiles, err)
+			log.Infof(context.TODO(), "could not get rlimit; setting maxOpenFiles to the recommended value %d - %s", engine.RecommendedMaxOpenFiles, err)
 		}
-		return engine.DefaultMaxOpenFiles, nil
+		return engine.RecommendedMaxOpenFiles, nil
 	}
 
 	// The max open file descriptor limit is too low.
@@ -50,12 +50,6 @@ func setOpenFileLimitInner(physicalStoreCount int) (int, error) {
 			rLimit.Max,
 			minimumOpenFileLimit,
 			productionSettingsWebpage)
-	}
-
-	// If current open file descriptor limit is higher than the recommended
-	// value, we can just use the default value.
-	if rLimit.Cur > recommendedOpenFileLimit {
-		return engine.DefaultMaxOpenFiles, nil
 	}
 
 	// If the current limit is less than the recommended limit, set the current
@@ -93,31 +87,35 @@ func setOpenFileLimitInner(physicalStoreCount int) (int, error) {
 			productionSettingsWebpage)
 	}
 
-	// If we have the desired number, just use the default values.
-	if rLimit.Cur >= recommendedOpenFileLimit {
-		return engine.DefaultMaxOpenFiles, nil
+	if rLimit.Cur < recommendedOpenFileLimit {
+		// We're still below the recommended amount, we should always show a
+		// warning.
+		log.Warningf(context.TODO(), "soft open file descriptor limit %d is under the recommended limit %d; this may decrease performance\n%s",
+			rLimit.Cur,
+			recommendedOpenFileLimit,
+			productionSettingsWebpage)
 	}
 
-	// We're still below the recommended amount, we should always show a
-	// warning.
-	log.Warningf(context.TODO(), "soft open file descriptor limit %d is under the recommended limit %d; this may decrease performance\n%s",
-		rLimit.Cur,
-		recommendedOpenFileLimit,
-		productionSettingsWebpage)
-
-	// if we have no physical stores, return 0.
+	// If we have no physical stores, return 0.
 	if physicalStoreCount == 0 {
 		return 0, nil
 	}
 
-	// If we have more than enough file descriptors to hit the recommend number
+	// If the current open file descriptor limit meets or exceeds the recommended
+	// value, we can divide up the current limit, less what we need for
+	// networking, between the stores.
+	if rLimit.Cur >= recommendedOpenFileLimit {
+		return (rLimit.Cur - recommendedNetworkFileDescriptors) / uint64(physicalStoreCount), nil
+	}
+
+	// If we have more than enough file descriptors to hit the recommended number
 	// for each store, than only constrain the network ones by giving the stores
 	// their full recommended number.
 	if rLimit.Cur >= networkConstrainedFileLimit {
-		return engine.DefaultMaxOpenFiles, nil
+		return engine.RecommendedMaxOpenFiles, nil
 	}
 
 	// Always sacrifice all but the minimum needed network descriptors to be
 	// used by the stores.
-	return int(rLimit.Cur-minimumNetworkFileDescriptors) / physicalStoreCount, nil
+	return (rLimit.Cur - minimumNetworkFileDescriptors) / uint64(physicalStoreCount), nil
 }

--- a/pkg/server/config_windows.go
+++ b/pkg/server/config_windows.go
@@ -18,6 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
-func setOpenFileLimitInner(physicalStoreCount int) (int, error) {
+func setOpenFileLimitInner(physicalStoreCount int) (uint64, error) {
 	return engine.DefaultMaxOpenFiles, nil
 }

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -85,14 +85,10 @@ const (
 	// RocksDB default is 4KB. This sets it to 32KB.
 	defaultBlockSize = 32 << 10
 
-	// DefaultMaxOpenFiles is the default value for rocksDB's max_open_files
-	// option.
-	DefaultMaxOpenFiles = -1
-	// RecommendedMaxOpenFiles is the recommended value for rocksDB's
-	// max_open_files option. If more file descriptors are available than the
-	// recommended number, than the default value is used.
+	// RecommendedMaxOpenFiles is the recommended value for RocksDB's
+	// max_open_files option.
 	RecommendedMaxOpenFiles = 10000
-	// MinimumMaxOpenFiles is the minimum value that rocksDB's max_open_files
+	// MinimumMaxOpenFiles is the minimum value that RocksDB's max_open_files
 	// option can be set to. While this should be set as high as possible, the
 	// minimum total for a single store node must be under 2048 for Windows
 	// compatibility. See:
@@ -297,7 +293,7 @@ type RocksDBConfig struct {
 	MaxSizeBytes int64
 	// MaxOpenFiles controls the maximum number of file descriptors RocksDB
 	// creates. If MaxOpenFiles is zero, this is set to DefaultMaxOpenFiles.
-	MaxOpenFiles int
+	MaxOpenFiles uint64
 	// WarnLargeBatchThreshold controls if a log message is printed when a
 	// WriteBatch takes longer than WarnLargeBatchThreshold. If it is set to
 	// zero, no log messages are ever printed.
@@ -428,7 +424,7 @@ func (r *RocksDB) open() error {
 
 	blockSize := envutil.EnvOrDefaultBytes("COCKROACH_ROCKSDB_BLOCK_SIZE", defaultBlockSize)
 	walTTL := envutil.EnvOrDefaultDuration("COCKROACH_ROCKSDB_WAL_TTL", 0).Seconds()
-	maxOpenFiles := DefaultMaxOpenFiles
+	maxOpenFiles := uint64(RecommendedMaxOpenFiles)
 	if r.cfg.MaxOpenFiles != 0 {
 		maxOpenFiles = r.cfg.MaxOpenFiles
 	}


### PR DESCRIPTION
An alternative to #17928. @petermattis let me know if you'd like me to test this. As I mentioned, all I've done so far is observe a slight slowdown in `BenchmarkIterOnEngine`:

```
name                                 old time/op  new time/op  delta
IterOnEngine_RocksDB/writes=10-8     2.08µs ± 5%  2.13µs ± 2%    ~     (p=0.548 n=5+5)
IterOnEngine_RocksDB/writes=100-8    2.22µs ± 4%  2.26µs ± 4%    ~     (p=0.548 n=5+5)
IterOnEngine_RocksDB/writes=1000-8   2.27µs ± 1%  2.46µs ± 4%  +8.41%  (p=0.008 n=5+5)
IterOnEngine_RocksDB/writes=10000-8  2.61µs ± 5%  2.66µs ± 2%    ~     (p=0.421 n=5+5)
```

---

Previously, if we had a large-enough open file ulimit, we'd configure
RocksDB without an open file limit (`max_open_files = -1`). This
configuration enabled a fast path where RocksDB could avoid an lookup in
its open files cache, since it could assume that every opened file would
stay open forever.

Unfortunately, a 2TB restore creates tens of thousands of 2MB SSTs,
quickly exceeding the open file ulimit of 10k. With `max_open_files = -1`
the call to `open` that exceeds the limit crashes the server.

Instead, set the `max_open_files` to the configured ulimit so that
RocksDB evicts a file that hasn't been recently accessed instead of
crashing the server. This introduces two performance hits: an obvious
hit, where accessing restored data is slow because the necessary files
have been evicted from the open files cache, and a less-obvious hit,
where every operation now requires an open-file cache lookup, even when
the number of SSTs is well below the open file limit.