### PR TITLE
sqlccl: option to skip restoring transformed csv data

### DIFF
--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -299,7 +299,7 @@ func TestImportStmt(t *testing.T) {
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, nodes, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(t, tc.Conns[0])
+	conn := tc.Conns[0]
 
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
@@ -429,6 +429,7 @@ func TestImportStmt(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			sqlDB := sqlutils.MakeSQLRunner(t, conn)
 			sqlDB.Exec(fmt.Sprintf(`CREATE DATABASE csv%d`, i))
 			sqlDB.Exec(fmt.Sprintf(`SET DATABASE = csv%d`, i))
 


### PR DESCRIPTION
This is expected to be useful in deployments where operators may want to use non-production machines to do the
transform process and then only need to restore in production, or for a one-time transform of some testdata
(e.g. TPC-H) that can then be loaded repeatedly via RESTORE.