### PR TITLE
settings: disable stats-based rebalancing by default

### DIFF
--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -506,7 +506,7 @@ func MakeClusterSettings(minVersion, serverVersion roachpb.Version) *Settings {
 	s.EnableStatsBasedRebalancing = r.RegisterBoolSetting(
 		"kv.allocator.stat_based_rebalancing.enabled",
 		"set to enable rebalancing of range replicas based on write load and disk usage",
-		true)
+		false)
 
 	// rangeRebalanceThreshold is the minimum ratio of a store's range count to
 	// the mean range count at which that store is considered overfull or underfull

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -58,7 +58,7 @@ diagnostics.reporting.send_crash_reports           true           b     send cra
 kv.allocator.lease_rebalancing_aggressiveness      1E+00          f     set greater than 1.0 to rebalance leases toward load more aggressively, or between 0 and 1.0 to be more conservative about rebalancing leases
 kv.allocator.load_based_lease_rebalancing.enabled  true           b     set to enable rebalancing of range leases based on load and latency
 kv.allocator.range_rebalance_threshold             5E-02          f     minimum fraction away from the mean a store's range count can be before it is considered overfull or underfull
-kv.allocator.stat_based_rebalancing.enabled        true           b     set to enable rebalancing of range replicas based on write load and disk usage
+kv.allocator.stat_based_rebalancing.enabled        false          b     set to enable rebalancing of range replicas based on write load and disk usage
 kv.allocator.stat_rebalance_threshold              2E-01          f     minimum fraction away from the mean a store's stats (like disk usage or writes per second) can be before it is considered overfull or underfull
 kv.bulk_io_write.max_rate                          8.0 EiB        z     the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops
 kv.gc.batch_size                                   100000         i     maximum number of keys in a batch for MVCC garbage collection

--- a/pkg/storage/allocator_scorer_test.go
+++ b/pkg/storage/allocator_scorer_test.go
@@ -781,6 +781,7 @@ func TestBalanceScore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	st := cluster.MakeTestingClusterSettings()
+	st.EnableStatsBasedRebalancing.Override(true)
 
 	storeList := StoreList{
 		candidateRanges:          stat{mean: 1000},
@@ -942,6 +943,7 @@ func TestRebalanceConvergesOnMean(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	st := cluster.MakeTestingClusterSettings()
+	st.EnableStatsBasedRebalancing.Override(true)
 
 	const diskCapacity = 2000
 	storeList := StoreList{


### PR DESCRIPTION
We can re-enable it early in the 1.2 cycle, but it's not important
enough to be worth the risks entailed for 1.1.

Fixes #17645