### PR TITLE
AddSSTable cleanups

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -224,26 +224,6 @@ func TestBackupRestoreLocal(t *testing.T) {
 	backupAndRestore(ctx, t, sqlDB, dir, numAccounts)
 }
 
-func enableAddSSTable(st *cluster.Settings) {
-	st.Manual.Store(true)
-	st.AddSSTableEnabled.Override(true)
-}
-
-func disableAddSSTable(st *cluster.Settings) {
-	st.Manual.Store(true)
-	st.AddSSTableEnabled.Override(false)
-}
-
-func TestBackupRestoreAddSSTable(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	const numAccounts = 1000
-	ctx, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts, enableAddSSTable)
-	defer cleanupFn()
-
-	backupAndRestore(ctx, t, sqlDB, dir, numAccounts)
-}
-
 func TestBackupRestoreEmpty(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/ccl/sqlccl/bench_test.go
+++ b/pkg/ccl/sqlccl/bench_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/sampledataccl"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -70,20 +69,11 @@ func BenchmarkClusterBackup(b *testing.B) {
 }
 
 func BenchmarkClusterRestore(b *testing.B) {
-	b.Run("AddSSTable", func(b *testing.B) {
-		runBenchmarkClusterRestore(b, enableAddSSTable)
-	})
-	b.Run("WriteBatch", func(b *testing.B) {
-		runBenchmarkClusterRestore(b, disableAddSSTable)
-	})
-}
-
-func runBenchmarkClusterRestore(b *testing.B, init func(*cluster.Settings)) {
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
 
-	_, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0, init)
+	_, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0, initNone)
 	defer cleanup()
 	sqlDB.Exec(`DROP TABLE data.bank`)
 


### PR DESCRIPTION
ccl: remove some WriteBatch benchmarks cruft

During the WriteBatch to AddSStable transition, we made some benchmarks
run with both so we could compare them. We don't really need the
WriteBatch ones anymore.

--
storageccl: run AddSSTable tests also with on-disk stores

The code path is a bit different between them (uses different RocksDB
envs) and this is below raft, so we should definitely be testing both.

--
sqlccl: remove AddSSTable specific backup/restore test

AddSSTable is now the default so it's not testing anything additional.
