### PR TITLE
storage: avoid a reference to Transaction proto in TimestampCache

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/rlmcpherson/s3gof3r"
@@ -83,15 +82,6 @@ const (
 	consultsTSCache // mutating commands which write data at a timestamp
 	updatesTSCache  // commands which read data at a timestamp
 )
-
-// GetTxnID returns the transaction ID if the header has a transaction
-// or nil otherwise.
-func (h Header) GetTxnID() *uuid.UUID {
-	if h.Txn == nil {
-		return nil
-	}
-	return &h.Txn.ID
-}
 
 // IsReadOnly returns true iff the request is read-only.
 func IsReadOnly(args Request) bool {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1875,7 +1875,9 @@ func makeCacheRequest(
 	cr := cacheRequest{
 		span:      span,
 		timestamp: ba.Timestamp,
-		txnID:     ba.GetTxnID(),
+	}
+	if ba.Txn != nil {
+		cr.txnID = ba.Txn.ID
 	}
 
 	for i, union := range ba.Requests {
@@ -2240,7 +2242,7 @@ func (r *Replica) applyTimestampCache(ba *roachpb.BatchRequest) (bool, *roachpb.
 			// key to look for an entry which would indicate this transaction
 			// has already been finalized, in which case this is a replay.
 			if _, ok := args.(*roachpb.BeginTransactionRequest); ok {
-				key := keys.TransactionKey(header.Key, *ba.GetTxnID())
+				key := keys.TransactionKey(header.Key, ba.Txn.ID)
 				wTS, _, wOK := r.store.tsCacheMu.cache.GetMaxWrite(key, nil)
 				if wOK {
 					return bumped, roachpb.NewError(roachpb.NewTransactionReplayError())


### PR DESCRIPTION
Remove the reference to `TxnMeta.ID` that was being held by the
`cacheRequest` structure used by `TimestampCache`. #17299 made
`TxnMeta.ID` non-nullable (i.e. embedded the ID in `TxnMeta`) so a
reference to `TxnMeta.ID` also pinned `TxnMeta` and the structure it is
embedded in (`Transaction`). `Transaction` weights in at 216 bytes so
this reference to 16 bytes of data was resulting in an extra 200 bytes
of un-gc'able memory causing the `TimestampCache` to use appropximately
twice as much memory as expected.