### PR TITLE
distsqlrun: properly account for top-k sorting memory

### DIFF
--- a/pkg/sql/distsqlrun/row_container_test.go
+++ b/pkg/sql/distsqlrun/row_container_test.go
@@ -75,7 +75,7 @@ func TestRowContainerReplaceMax(t *testing.T) {
 	mc.InitMaxHeap()
 	// Replace some of the rows with large rows.
 	for i := 0; i < 1000; i++ {
-		err := mc.MaybeReplaceMax(makeRow(rng.Intn(10000), rng.Intn(100)))
+		err := mc.MaybeReplaceMax(ctx, makeRow(rng.Intn(10000), rng.Intn(100)))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/distsqlrun/row_container_test.go
+++ b/pkg/sql/distsqlrun/row_container_test.go
@@ -1,0 +1,88 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"math"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/mon"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// TestRowContainerReplaceMax verifies that MaybeReplaceMax correctly adjusts
+// the memory accounting.
+func TestRowContainerReplaceMax(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	rng, _ := randutil.NewPseudoRand()
+
+	evalCtx := parser.NewTestingEvalContext()
+	defer evalCtx.Stop(ctx)
+
+	typeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
+	typeStr := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_STRING}
+
+	makeRow := func(intVal int, strLen int) sqlbase.EncDatumRow {
+		var b []byte
+		for i := 0; i < strLen; i++ {
+			b = append(b, 'a')
+		}
+		return sqlbase.EncDatumRow{
+			sqlbase.DatumToEncDatum(typeInt, parser.NewDInt(parser.DInt(intVal))),
+			sqlbase.DatumToEncDatum(typeStr, parser.NewDString(string(b))),
+		}
+	}
+
+	m := mon.MakeUnlimitedMonitor(
+		context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64,
+	)
+	defer m.Stop(ctx)
+
+	var mc memRowContainer
+	mc.initWithMon(
+		sqlbase.ColumnOrdering{{ColIdx: 0, Direction: encoding.Ascending}},
+		[]sqlbase.ColumnType{typeInt, typeStr}, evalCtx, &m,
+	)
+	defer mc.Close(ctx)
+
+	// Initialize the heap with small rows.
+	for i := 0; i < 1000; i++ {
+		err := mc.AddRow(ctx, makeRow(rng.Intn(10000), rng.Intn(10)))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	mc.InitMaxHeap()
+	// Replace some of the rows with large rows.
+	for i := 0; i < 1000; i++ {
+		err := mc.MaybeReplaceMax(makeRow(rng.Intn(10000), rng.Intn(100)))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Now pop the rows, which shrinks the memory account according to the current
+	// row sizes. If we did not account for the larger rows, this will panic.
+	for mc.Len() > 0 {
+		mc.PopFirst()
+	}
+}

--- a/pkg/sql/distsqlrun/sorterstrategy.go
+++ b/pkg/sql/distsqlrun/sorterstrategy.go
@@ -215,7 +215,7 @@ func (ss *sortTopKStrategy) Execute(ctx context.Context, s *sorter) error {
 			}
 			// Replace the max value if the new row is smaller, maintaining the
 			// max-heap.
-			if err := ss.rows.MaybeReplaceMax(row); err != nil {
+			if err := ss.rows.MaybeReplaceMax(ctx, row); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/sqlbase/row_container_test.go
+++ b/pkg/sql/sqlbase/row_container_test.go
@@ -69,6 +69,8 @@ func TestRowContainer(t *testing.T) {
 						}
 					}
 				}
+				rc.Close(context.Background())
+				m.Stop(context.Background())
 			}
 		}
 	}


### PR DESCRIPTION
@RaduBerinde, I'm struggling to write a test for this. Might you want to take over the PR? :)

---

When replacing a row during a top-k sorting, adjust the memory budget
for the difference between the old row and the new row.

Fix #17980.