### PR TITLE
storageccl: bump import batch size to maximum possible

### DIFF
--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -38,6 +38,29 @@ import (
 	"github.com/pkg/errors"
 )
 
+func TestMaxImportBatchSize(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		importBatchSize int64
+		maxCommandSize  int64
+		expected        int64
+	}{
+		{importBatchSize: 2 << 20, maxCommandSize: 64 << 20, expected: 2 << 20},
+		{importBatchSize: 128 << 20, maxCommandSize: 64 << 20, expected: 63 << 20},
+		{importBatchSize: 64 << 20, maxCommandSize: 64 << 20, expected: 63 << 20},
+		{importBatchSize: 63 << 20, maxCommandSize: 64 << 20, expected: 63 << 20},
+	}
+	for i, testCase := range testCases {
+		settings := cluster.MakeTestingClusterSettings()
+		settings.ImportBatchSize.Override(testCase.importBatchSize)
+		settings.MaxCommandSize.Override(testCase.maxCommandSize)
+		if e, a := maxImportBatchSize(settings), testCase.expected; e != a {
+			t.Errorf("%d: expected max batch size %d, but got %d", i, e, a)
+		}
+	}
+}
+
 func slurpSSTablesLatestKey(
 	t *testing.T, dir string, paths []string, kr prefixRewriter,
 ) []engine.MVCCKeyValue {

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -735,7 +735,7 @@ func MakeClusterSettings(minVersion, serverVersion roachpb.Version) *Settings {
 		true,
 	)
 
-	s.ImportBatchSize = r.RegisterByteSizeSetting("kv.import.batch_size", "", 2<<20)
+	s.ImportBatchSize = r.RegisterByteSizeSetting("kv.import.batch_size", "", 63<<20)
 	s.ImportBatchSize.Hide()
 
 	s.AddSSTableEnabled = r.RegisterBoolSetting(


### PR DESCRIPTION
@tschottdorf this actually seems to work as long as we limit the number of import requests per node to 1.

----

Running into the open file limit means death for a cluster. At the
moment, RocksDB doesn't keep track of how many files it has open, so it
will crash the server when it runs into the open files ulimit and the
next call to open fails. If #17958 lands, RocksDB will instead close
open files to stay beneath the limit, but its eviction policy causes
slow commits that lead to node liveness failures.

A 2TB restore currently creates thousands of 2MB SSTs and quickly runs
into the open file limit. Make the SSTs much larger to avoid the
problem.  This commit raises the hard cap from 2MB to 63MB. (Any higher
and we'd exceed the maximum Raft command size.) In practice, most SSTs
that import deals with are slightly smaller than 63MB, as backup
generates range-sized SSTs (32-64MB).