### PR TITLE
sqlccl: use unsafe key in import sst iteration

### DIFF
--- a/pkg/storage/engine/disk_map.go
+++ b/pkg/storage/engine/disk_map.go
@@ -59,6 +59,13 @@ type SortedDiskMapIterator interface {
 	// after the next call to Seek(), Rewind(), or Next().
 	Value() []byte
 
+	// UnsafeKey returns the same value as Key, but the memory is invalidated on
+	// the next call to {Next,Rewind,Seek,Close}.
+	UnsafeKey() []byte
+	// UnsafeValue returns the same value as Value, but the memory is
+	// invalidated on the next call to {Next,Rewind,Seek,Close}.
+	UnsafeValue() []byte
+
 	// Close frees up resources held by the iterator.
 	Close()
 }
@@ -248,6 +255,16 @@ func (i *RocksDBMapIterator) Key() []byte {
 // Value implements the SortedDiskMapIterator interface.
 func (i *RocksDBMapIterator) Value() []byte {
 	return i.iter.Value()
+}
+
+// UnsafeKey implements the SortedDiskMapIterator interface.
+func (i *RocksDBMapIterator) UnsafeKey() []byte {
+	return i.iter.UnsafeKey().Key[len(i.prefix):]
+}
+
+// UnsafeValue implements the SortedDiskMapIterator interface.
+func (i *RocksDBMapIterator) UnsafeValue() []byte {
+	return i.iter.UnsafeValue()
 }
 
 // Close implements the SortedDiskMapIterator interface.


### PR DESCRIPTION
```
Import-8    6.91ms ± 3%    7.16ms ±13%    ~      (p=0.408 n=8+10)

name      old alloc/op   new alloc/op   delta
Import-8    2.48MB ± 1%    2.45MB ± 1%  -1.19%  (p=0.000 n=10+10)

name      old allocs/op  new allocs/op  delta
Import-8     42.8k ± 0%     39.8k ± 0%  -7.00%  (p=0.000 n=10+10)
```