### PR TITLE
setting: move back to a global registry

### DIFF
--- a/docs/RFCS/20170608_decommission.md
+++ b/docs/RFCS/20170608_decommission.md
@@ -134,7 +134,7 @@ states:
 
 Regardless of which state the dead node has, it cannot set its `Draining` flag
 because it is dead. Instead, its leases will expire and will be taken by other
-nodes. After `COCKROACH_TIME_UNTIL_STORE_DEAD` elapses, the replicas of its
+nodes. After `server.time_until_store_dead` elapses, the replicas of its
 ranges will actively be rebalanced. Wait for the replica count to reach 0 as for
 live nodes.
 
@@ -147,13 +147,13 @@ decommissioning process.
 No changes required. The existing CockroachDB process, described below, is
 sufficient.
 
-During a temporary removal, `COCKROACH_TIME_UNTIL_STORE_DEAD` could be updated
+During a temporary removal, `server.time_until_store_dead` could be updated
 to to the length of the downtime to avoid unnecessary movement of ranges.
 However, it is difficult to predict the length of downtime. This is an
 optimization which could be implemented later.
 
 After a node is detected as unavailable for more than
-`COCKROACH_TIME_UNTIL_STORE_DEAD` (an env variable with default: 5 minutes), the
+`server.time_until_store_dead` (an env variable with default: 5 minutes), the
 node is marked as incommunicado and the cluster decides that the node may not be
 coming back and moves the data elsewhere. Its leases would have been transferred
 to other nodes as soon as they expired without being renewed. Ranges are
@@ -211,7 +211,7 @@ be nice to proactively detect this but the effort required is disproportionate
 compared to the gain.
 
 Recently dead nodes may cause decommissioning to hang until
-`COCKROACH_TIME_UNTIL_STORE_DEAD` elapses.
+`server.time_until_store_dead` elapses.
 
 Recommissioning, i.e. undoing a decommission, requires node restart. We could
 avoid this: if the node is live, the coordinating process can directly tell it

--- a/docs/RFCS/20170815_version_migration.md
+++ b/docs/RFCS/20170815_version_migration.md
@@ -466,31 +466,11 @@ func (ecv *ExposedClusterVersion) BootstrapVersion() ClusterVersion
 func (ecv *ExposedClusterVersion) IsActive(v roachpb.Version) bool
 ```
 
-The remaining complexity lies in how `version *settings.StateMachineSetting` is initialized:
-
-```go
-s.version = r.RegisterStateMachineSetting("version",
-		"set the active cluster version in the format '<major>.<minor>'.", // hide optional `-<unstable>`
-		versionTransformer(minVersion, serverVersion, func() ClusterVersion {
-			return *s.baseVersion.Load().(*ClusterVersion)
-		}),
-	)
-```
-
-where `versionTransformer` contains all of the update logic (mod reading from
-the table: we've updated the settings framework to use the table for all
-`StateMachineSettings`, of which this is the only instance at the time of
-writing):
-
-```go
-func versionTransformer(
-	minSupportedVersion, serverVersion roachpb.Version, defaultVersion func() ClusterVersion,
-) settings.TransformerFn {
-  // ...
-}
-```
-
-The returned `settings.TransformerFn` takes
+The remaining complexity lies in the transformer function for
+`version *settings.StateMachineSetting`. It contains all of the update logic
+(mod reading from the table: we've updated the settings framework to use the
+table for all `StateMachineSettings`, of which this is the only instance at the
+time of writing); `versionTransformer` takes
 
 - the previous encoded value (i.e. a marshalled `ClusterVersion`)
 - the desired transition, if any (for example "1.2").

--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -600,7 +600,7 @@ func backupPlanHook(
 	}
 
 	if err := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization.Get(), "BACKUP",
+		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "BACKUP",
 	); err != nil {
 		return nil, nil, err
 	}
@@ -804,7 +804,7 @@ func showBackupPlanHook(
 	}
 
 	if err := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization.Get(), "SHOW BACKUP",
+		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "SHOW BACKUP",
 	); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -436,10 +436,10 @@ func writeRocksDB(
 	cache := engine.NewRocksDBCache(0)
 	defer cache.Release()
 	r, err := engine.NewRocksDB(engine.RocksDBConfig{
-		RocksDBSettings: cluster.MakeTestingClusterSettings().RocksDBSettings,
-		Dir:             rocksdbDir,
-		MaxSizeBytes:    0,
-		MaxOpenFiles:    1024,
+		Settings:     cluster.MakeTestingClusterSettings(),
+		Dir:          rocksdbDir,
+		MaxSizeBytes: 0,
+		MaxOpenFiles: 1024,
 	}, cache)
 	if err != nil {
 		return 0, errors.Wrap(err, "create rocksdb instance")

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -857,7 +857,7 @@ func restorePlanHook(
 		return nil, nil, nil
 	}
 	if err := utilccl.CheckEnterpriseEnabled(
-		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization.Get(), "RESTORE",
+		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "RESTORE",
 	); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -53,8 +53,8 @@ func loadTestData(
 
 	eng, err := engine.NewRocksDB(
 		engine.RocksDBConfig{
-			RocksDBSettings: cluster.MakeTestingClusterSettings().RocksDBSettings,
-			Dir:             dir,
+			Settings: cluster.MakeTestingClusterSettings(),
+			Dir:      dir,
 		},
 		engine.RocksDBCache{},
 	)

--- a/pkg/ccl/storageccl/engineccl/mvcc_test.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc_test.go
@@ -89,8 +89,8 @@ func TestMVCCIterateIncremental(t *testing.T) {
 	ctx := context.Background()
 	e, err := engine.NewRocksDB(
 		engine.RocksDBConfig{
-			RocksDBSettings: cluster.MakeTestingClusterSettings().RocksDBSettings,
-			Dir:             dir,
+			Settings: cluster.MakeTestingClusterSettings(),
+			Dir:      dir,
 		},
 		engine.RocksDBCache{},
 	)

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -52,10 +52,10 @@ func TestMaxImportBatchSize(t *testing.T) {
 		{importBatchSize: 63 << 20, maxCommandSize: 64 << 20, expected: 63 << 20},
 	}
 	for i, testCase := range testCases {
-		settings := cluster.MakeTestingClusterSettings()
-		settings.ImportBatchSize.Override(testCase.importBatchSize)
-		settings.MaxCommandSize.Override(testCase.maxCommandSize)
-		if e, a := maxImportBatchSize(settings), testCase.expected; e != a {
+		st := cluster.MakeTestingClusterSettings()
+		importBatchSize.Override(&st.SV, testCase.importBatchSize)
+		storage.MaxCommandSize.Override(&st.SV, testCase.maxCommandSize)
+		if e, a := maxImportBatchSize(st), testCase.expected; e != a {
 			t.Errorf("%d: expected max batch size %d, but got %d", i, e, a)
 		}
 	}
@@ -134,7 +134,7 @@ func TestImport(t *testing.T) {
 	t.Run("WriteBatch", func(t *testing.T) {
 		disableSSTable := func(st *cluster.Settings) {
 			st.Manual.Store(true)
-			st.AddSSTableEnabled.Override(false)
+			AddSSTableEnabled.Override(&st.SV, false)
 		}
 		t.Run("batch=default", func(t *testing.T) {
 			runTestImport(t, disableSSTable)
@@ -144,7 +144,7 @@ func TestImport(t *testing.T) {
 			// the threshold to force it.
 			init := func(st *cluster.Settings) {
 				st.Manual.Store(true)
-				st.ImportBatchSize.Override(1)
+				importBatchSize.Override(&st.SV, 1)
 			}
 			runTestImport(t, init)
 		})
@@ -152,7 +152,7 @@ func TestImport(t *testing.T) {
 	t.Run("AddSSTable", func(t *testing.T) {
 		enableSSTable := func(st *cluster.Settings) {
 			st.Manual.Store(true)
-			st.AddSSTableEnabled.Override(true)
+			AddSSTableEnabled.Override(&st.SV, true)
 		}
 		t.Run("batch=default", func(t *testing.T) {
 			runTestImport(t, enableSSTable)
@@ -162,7 +162,7 @@ func TestImport(t *testing.T) {
 			// the threshold to force it.
 			init := func(st *cluster.Settings) {
 				enableSSTable(st)
-				st.ImportBatchSize.Override(1)
+				importBatchSize.Override(&st.SV, 1)
 			}
 			runTestImport(t, init)
 		})

--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -12,10 +12,25 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/licenseccl"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
+
+var enterpriseLicense = settings.RegisterValidatedStringSetting(
+	"enterprise.license",
+	"the encoded cluster license",
+	"",
+	func(s string) error {
+		_, err := licenseccl.Decode(s)
+		return err
+	},
+)
+
+func init() {
+	enterpriseLicense.Hide()
+}
 
 var testingEnterpriseEnabled = false
 
@@ -44,7 +59,7 @@ func checkEnterpriseEnabledAt(
 	var lic *licenseccl.License
 	// FIXME(tschottdorf): see whether it makes sense to cache the decoded
 	// license.
-	if str := st.EnterpriseLicense.Get(); str != "" {
+	if str := enterpriseLicense.Get(&st.SV); str != "" {
 		var err error
 		if lic, err = licenseccl.Decode(str); err != nil {
 			return err

--- a/pkg/ccl/utilccl/licenseccl/license.go
+++ b/pkg/ccl/utilccl/licenseccl/license.go
@@ -16,16 +16,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
-
-func init() {
-	cluster.ValidateEnterpriseLicense = func(s string) error {
-		_, err := Decode(s)
-		return err
-	}
-}
 
 // LicensePrefix is a prefix on license strings to make them easily recognized.
 const LicensePrefix = "crl-0-"

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -45,7 +45,7 @@ func Main() {
 		os.Args[1],
 	)
 
-	defer log.RecoverAndReportPanic(context.Background(), serverCfg.Settings.ReportingSettings)
+	defer log.RecoverAndReportPanic(context.Background(), &serverCfg.Settings.SV)
 
 	if err := Run(os.Args[1:]); err != nil {
 		fmt.Fprintf(stderr, "Failed running %q\n", os.Args[1])

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -63,8 +63,7 @@ var serverCfg = func() server.Config {
 	// /debug/requests handler.
 	server.ClusterSettings = st
 	// A similar singleton reference exists in the log package. See comment there.
-	f := log.ReportingSettings(st.ReportingSettings)
-	log.ReportingSettingsSingleton.Store(&f)
+	log.ReportingSettingsSingleton.Store(&st.SV)
 
 	return server.MakeConfig(st)
 }()

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -78,9 +78,9 @@ func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (*engine.R
 	}
 	db, err := engine.NewRocksDB(
 		engine.RocksDBConfig{
-			RocksDBSettings: serverCfg.Settings.RocksDBSettings,
-			Dir:             dir,
-			MaxOpenFiles:    maxOpenFiles,
+			Settings:     serverCfg.Settings,
+			Dir:          dir,
+			MaxOpenFiles: maxOpenFiles,
 		},
 		cache,
 	)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -211,7 +211,7 @@ func initCPUProfile(ctx context.Context, dir string) {
 	}
 
 	go func() {
-		defer log.RecoverAndReportPanic(ctx, serverCfg.Settings.ReportingSettings)
+		defer log.RecoverAndReportPanic(ctx, &serverCfg.Settings.SV)
 
 		ctx := context.Background()
 
@@ -332,7 +332,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 		defer log.Flush()
 		defer func() {
 			if s != nil {
-				log.RecoverAndReportPanic(startCtx, s.ClusterSettings().ReportingSettings)
+				log.RecoverAndReportPanic(startCtx, &s.ClusterSettings().SV)
 			}
 		}()
 		defer sp.Finish()

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
@@ -835,16 +836,16 @@ func TestAdminAPISettings(t *testing.T) {
 	// Any bool that defaults to true will work here.
 	const settingKey = "diagnostics.reporting.report_metrics"
 	st := s.ClusterSettings()
-	allKeys := st.Keys()
+	allKeys := settings.Keys()
 
 	checkSetting := func(t *testing.T, k string, v serverpb.SettingsResponse_Value) {
-		ref, ok := st.Lookup(k)
+		ref, ok := settings.Lookup(k)
 		if !ok {
 			t.Fatalf("%s: not found after initial lookup", k)
 		}
 		typ := ref.Typ()
 
-		if ref.String() != v.Value {
+		if ref.String(&st.SV) != v.Value {
 			t.Errorf("%s: expected value %s, got %s", k, ref, v.Value)
 		}
 

--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -301,7 +301,7 @@ WHERE id = $1`
 	if err := verifyTimestamp(sessLastUsed, timeBoundBefore, timeBoundAfter); err != nil {
 		t.Fatalf("bad lastUsedAt timestamp: %s", err)
 	}
-	timeout := s.ClusterSettings().WebSessionTimeout.Get()
+	timeout := webSessionTimeout.Get(&s.ClusterSettings().SV)
 	if err := verifyTimestamp(
 		sessExpires, timeBoundBefore.Add(timeout), timeBoundAfter.Add(timeout),
 	); err != nil {

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -110,9 +110,6 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		if err := os.Unsetenv("COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE"); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.Unsetenv("COCKROACH_TIME_UNTIL_STORE_DEAD"); err != nil {
-			t.Fatal(err)
-		}
 		envutil.ClearEnvCache()
 	}
 	defer resetEnvVar()
@@ -158,7 +155,6 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		"COCKROACH_METRICS_SAMPLE_INTERVAL",
 		"COCKROACH_SCAN_INTERVAL",
 		"COCKROACH_SCAN_MAX_IDLE_TIME",
-		"COCKROACH_TIME_UNTIL_STORE_DEAD",
 	} {
 		t.Run("invalid", func(t *testing.T) {
 			if err := os.Setenv(envVar, "abcd"); err != nil {

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -106,13 +105,13 @@ func createTestNode(
 		active,
 		renewal,
 	)
+	storage.TimeUntilStoreDead.Override(&cfg.Settings.SV, 10*time.Millisecond)
 	cfg.StorePool = storage.NewStorePool(
 		cfg.AmbientCtx,
 		st,
 		cfg.Gossip,
 		cfg.Clock,
 		storage.MakeStorePoolNodeLivenessFunc(cfg.NodeLiveness),
-		settings.TestingDuration(time.Millisecond*10),
 		/* deterministic */ false,
 	)
 	metricsRecorder := status.NewMetricsRecorder(cfg.Clock, cfg.NodeLiveness,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -245,7 +245,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		s.gossip,
 		s.clock,
 		storage.MakeStorePoolNodeLivenessFunc(s.nodeLiveness),
-		s.cfg.TimeUntilStoreDead,
 		/* deterministic */ false,
 	)
 
@@ -387,11 +386,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	}
 
 	nodeInfo := sql.NodeInfo{
-		AdminURL:     cfg.AdminURL,
-		PGURL:        cfg.PGURL,
-		ClusterID:    s.ClusterID,
-		NodeID:       &s.nodeIDContainer,
-		Organization: s.st.ClusterOrganization,
+		AdminURL:  cfg.AdminURL,
+		PGURL:     cfg.PGURL,
+		ClusterID: s.ClusterID,
+		NodeID:    &s.nodeIDContainer,
 	}
 
 	// Set up Executor
@@ -523,7 +521,7 @@ func inspectEngines(
 // The passed context can be used to trace the server startup. The context
 // should represent the general startup operation.
 func (s *Server) Start(ctx context.Context) error {
-	if s.st.Registry == nil {
+	if !s.st.Initialized {
 		return errors.New("must pass initialized ClusterSettings")
 	}
 	ctx = s.AnnotateCtx(ctx)

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnosticspb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -69,6 +70,18 @@ const (
 	updateMaxVersionsToReport = 3
 
 	updateCheckJitterSeconds = 120
+)
+
+var diagnosticReportFrequency = settings.RegisterNonNegativeDurationSetting(
+	"diagnostics.reporting.interval",
+	"interval at which diagnostics data should be reported",
+	time.Hour,
+)
+
+var diagnosticsMetricsEnabled = settings.RegisterBoolSetting(
+	"diagnostics.reporting.report_metrics",
+	"enable collection and reporting diagnostic metrics to cockroach labs",
+	true,
 )
 
 // randomly shift `d` to be up to `jitterSec` shorter or longer.
@@ -211,13 +224,13 @@ func (s *Server) maybeReportDiagnostics(
 	// TODO(dt): we should allow tuning the reset and report intervals separately.
 	// Consider something like rand.Float() > resetFreq/reportFreq here to sample
 	// stat reset periods for reporting.
-	if s.st.DiagnosticsReportingEnabled.Get() && s.st.DiagnosticsMetricsEnabled.Get() {
+	if log.DiagnosticsReportingEnabled.Get(&s.st.SV) && diagnosticsMetricsEnabled.Get(&s.st.SV) {
 		s.reportDiagnostics(running)
 	}
 	s.sqlExecutor.ResetStatementStats(ctx)
 	s.sqlExecutor.ResetUnimplementedCounts()
 
-	return scheduled.Add(s.st.DiagnosticReportFrequency.Get())
+	return scheduled.Add(diagnosticReportFrequency.Get(&s.st.SV))
 }
 
 func (s *Server) getReportingInfo(ctx context.Context) *diagnosticspb.DiagnosticReport {

--- a/pkg/settings/bool.go
+++ b/pkg/settings/bool.go
@@ -14,28 +14,23 @@
 
 package settings
 
-import (
-	"sync/atomic"
-)
-
 // BoolSetting is the interface of a setting variable that will be
 // updated automatically when the corresponding cluster-wide setting
 // of type "bool" is updated.
 type BoolSetting struct {
 	common
-	v            int32
 	defaultValue bool
 }
 
 var _ Setting = &BoolSetting{}
 
 // Get retrieves the bool value in the setting.
-func (b *BoolSetting) Get() bool {
-	return atomic.LoadInt32(&b.v) != 0
+func (b *BoolSetting) Get(sv *Values) bool {
+	return sv.getInt64(b.slotIdx) != 0
 }
 
-func (b *BoolSetting) String() string {
-	return EncodeBool(b.Get())
+func (b *BoolSetting) String(sv *Values) string {
+	return EncodeBool(b.Get(sv))
 }
 
 // Typ returns the short (1 char) string denoting the type of setting.
@@ -45,52 +40,25 @@ func (*BoolSetting) Typ() string {
 
 // Override changes the setting without validation.
 // For testing usage only.
-func (b *BoolSetting) Override(v bool) {
-	vInt := int32(0)
+func (b *BoolSetting) Override(sv *Values, v bool) {
+	vInt := int64(0)
 	if v {
 		vInt = 1
 	}
-	if atomic.SwapInt32(&b.v, vInt) != vInt {
-		b.changed()
-	}
+	sv.setInt64(b.slotIdx, vInt)
 }
 
-func (b *BoolSetting) set(v bool) {
-	b.Override(v)
+func (b *BoolSetting) set(sv *Values, v bool) {
+	b.Override(sv, v)
 }
 
-func (b *BoolSetting) setToDefault() {
-	b.set(b.defaultValue)
+func (b *BoolSetting) setToDefault(sv *Values) {
+	b.set(sv, b.defaultValue)
 }
 
 // RegisterBoolSetting defines a new setting with type bool.
-func (r *Registry) RegisterBoolSetting(key, desc string, defaultValue bool) *BoolSetting {
+func RegisterBoolSetting(key, desc string, defaultValue bool) *BoolSetting {
 	setting := &BoolSetting{defaultValue: defaultValue}
-	r.register(key, desc, setting)
+	register(key, desc, setting)
 	return setting
-}
-
-// TestingSetBool returns a mock, unregistered bool setting for testing. It
-// takes a pointer to a BoolSetting reference, swapping in the mock setting.
-// It returns a cleanup function that swaps back the original setting. This
-// function should not be used by tests that run in parallel, as it could
-// result in race detector failures, as well as if the cleanup functions are
-// called out of order. The original Setting remains registered for
-// gossip-driven updates which become visible when it is restored.
-func TestingSetBool(s **BoolSetting, v bool) func() {
-	saved := *s
-	if v {
-		*s = &BoolSetting{v: 1}
-	} else {
-		*s = &BoolSetting{v: 0}
-	}
-	return func() {
-		*s = saved
-	}
-}
-
-// OnChange registers a callback to be called when the setting changes.
-func (b *BoolSetting) OnChange(fn func()) *BoolSetting {
-	b.setOnChange(fn)
-	return b
 }

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -34,18 +34,18 @@ func (*ByteSizeSetting) Typ() string {
 	return "z"
 }
 
-func (b *ByteSizeSetting) String() string {
-	return humanizeutil.IBytes(b.Get())
+func (b *ByteSizeSetting) String(sv *Values) string {
+	return humanizeutil.IBytes(b.Get(sv))
 }
 
 // RegisterByteSizeSetting defines a new setting with type bytesize.
-func (r *Registry) RegisterByteSizeSetting(key, desc string, defaultValue int64) *ByteSizeSetting {
-	return r.RegisterValidatedByteSizeSetting(key, desc, defaultValue, nil)
+func RegisterByteSizeSetting(key, desc string, defaultValue int64) *ByteSizeSetting {
+	return RegisterValidatedByteSizeSetting(key, desc, defaultValue, nil)
 }
 
 // RegisterValidatedByteSizeSetting defines a new setting with type bytesize
 // with a validation function.
-func (r *Registry) RegisterValidatedByteSizeSetting(
+func RegisterValidatedByteSizeSetting(
 	key, desc string, defaultValue int64, validateFn func(int64) error,
 ) *ByteSizeSetting {
 	if validateFn != nil {
@@ -57,22 +57,6 @@ func (r *Registry) RegisterValidatedByteSizeSetting(
 		defaultValue: defaultValue,
 		validateFn:   validateFn,
 	}}
-	r.register(key, desc, setting)
+	register(key, desc, setting)
 	return setting
-}
-
-// TestingSetByteSize returns a mock bytesize setting for testing. See
-// TestingSetBool for more details.
-func TestingSetByteSize(s **ByteSizeSetting, v int64) func() {
-	saved := *s
-	*s = &ByteSizeSetting{IntSetting{v: v}}
-	return func() {
-		*s = saved
-	}
-}
-
-// OnChange registers a callback to be called when the setting changes.
-func (b *ByteSizeSetting) OnChange(fn func()) *ByteSizeSetting {
-	b.setOnChange(fn)
-	return b
 }

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -15,231 +15,18 @@
 package cluster
 
 import (
-	"fmt"
 	"math"
-	"strings"
 	"sync/atomic"
-	"time"
 
 	"golang.org/x/net/context"
 	"golang.org/x/time/rate"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/pkg/errors"
 )
-
-// ValidateEnterpriseLicense is the validator for the enterprise license cluster
-// setting. It is overridden on import by the `licenseccl` package. For pure OSS
-// builds, returns an error for all nonempty strings.
-var ValidateEnterpriseLicense = func(s string) error {
-	if s != "" {
-		return errors.New("not available in the pure OpenSource version of CockroachDB")
-	}
-	return nil
-}
-
-// BulkIOWriteLimiterBurst is the burst for the BulkIOWriteLimiter cluster setting.
-const BulkIOWriteLimiterBurst = 2 * 1024 * 1024 // 2MB
-
-// MaxCommandSizeFloor is the minimum allowed value for the MaxCommandSize
-// cluster setting.
-const MaxCommandSizeFloor = 4 << 20 // 4MB
-
-// DebugRemoteMode controls who can access /debug/requests.
-type DebugRemoteMode string
-
-const (
-	// DebugRemoteOff disallows access to /debug/requests.
-	DebugRemoteOff DebugRemoteMode = "off"
-	// DebugRemoteLocal allows only host-local access to /debug/requests.
-	DebugRemoteLocal DebugRemoteMode = "local"
-	// DebugRemoteAny allows all access to /debug/requests.
-	DebugRemoteAny DebugRemoteMode = "any"
-)
-
-// DistSQLExecMode controls if and when the Executor uses DistSQL.
-type DistSQLExecMode int64
-
-const (
-	// DistSQLOff means that we never use distSQL.
-	DistSQLOff DistSQLExecMode = iota
-	// DistSQLAuto means that we automatically decide on a case-by-case basis if
-	// we use distSQL.
-	DistSQLAuto
-	// DistSQLOn means that we use distSQL for queries that are supported.
-	DistSQLOn
-	// DistSQLAlways means that we only use distSQL; unsupported queries fail.
-	DistSQLAlways
-)
-
-func (m DistSQLExecMode) String() string {
-	switch m {
-	case DistSQLOff:
-		return "off"
-	case DistSQLAuto:
-		return "auto"
-	case DistSQLOn:
-		return "on"
-	case DistSQLAlways:
-		return "always"
-	default:
-		return fmt.Sprintf("invalid (%d)", m)
-	}
-}
-
-// DistSQLExecModeFromString converts a string into a DistSQLExecMode
-func DistSQLExecModeFromString(val string) DistSQLExecMode {
-	switch strings.ToUpper(val) {
-	case "OFF":
-		return DistSQLOff
-	case "AUTO":
-		return DistSQLAuto
-	case "ON":
-		return DistSQLOn
-	case "ALWAYS":
-		return DistSQLAlways
-	default:
-		panic(fmt.Sprintf("unknown DistSQL mode %s", val))
-	}
-}
-
-// TracingSettings is the subset of ClusterSettings affecting tracing.
-type TracingSettings struct {
-	EnableNetTrace  *settings.BoolSetting
-	LightstepToken  *settings.StringSetting
-	ZipkinCollector *settings.StringSetting
-
-	Tracer *tracing.Tracer
-}
-
-type tracingReconfigurationOptions struct {
-	ts TracingSettings
-}
-
-var _ tracing.ReconfigurationOptions = tracingReconfigurationOptions{}
-
-func (t tracingReconfigurationOptions) EnableNetTrace() bool {
-	return t.ts.EnableNetTrace.Get()
-}
-
-func (t tracingReconfigurationOptions) LightstepToken() string {
-	return t.ts.LightstepToken.Get()
-}
-
-func (t tracingReconfigurationOptions) ZipkinAddr() string {
-	return t.ts.ZipkinCollector.Get()
-}
-
-// ReportingSettings is the subset of ClusterSettings affecting crash and
-// diagnostics reporting.
-type ReportingSettings struct {
-	DiagnosticsReportingEnabled *settings.BoolSetting
-	CrashReports                *settings.BoolSetting
-	DiagnosticsMetricsEnabled   *settings.BoolSetting
-
-	// TODO(dt): this should be split from the report interval.
-	// statsResetFrequency = settings.RegisterDurationSetting(
-	// 	"sql.metrics.statement_details.reset_interval",
-	// 	"interval at which the collected statement statistics should be reset",
-	// 	time.Hour,
-	// )
-	DiagnosticReportFrequency *settings.DurationSetting
-}
-
-// HasDiagnosticsReportingEnabled returns true when the underlying cluster setting is true.
-func (rs ReportingSettings) HasDiagnosticsReportingEnabled() bool {
-	return rs.DiagnosticsReportingEnabled.Get()
-}
-
-// HasCrashReportsEnabled returns true when the underlying cluster setting is
-// true.
-func (rs ReportingSettings) HasCrashReportsEnabled() bool {
-	return rs.CrashReports.Get()
-}
-
-// DistSQLSettings is the subset of ClusterSettings affecting DistSQL.
-type DistSQLSettings struct {
-	DistSQLUseTempStorage      *settings.BoolSetting
-	DistSQLUseTempStorageSorts *settings.BoolSetting
-	DistSQLUseTempStorageJoins *settings.BoolSetting
-	DistributeIndexJoin        *settings.BoolSetting
-	PlanMergeJoins             *settings.BoolSetting
-}
-
-// SQLStatsSettings is the subset of ClusterSettings affecting SQL statistics
-// collection.
-type SQLStatsSettings struct {
-	StmtStatsEnable                    *settings.BoolSetting
-	SQLStatsCollectionLatencyThreshold *settings.DurationSetting
-	DumpStmtStatsToLogBeforeReset      *settings.BoolSetting
-}
-
-// SQLSessionSettings is the subset of ClusterSettings affecting SQL
-// sessions.
-type SQLSessionSettings struct {
-	TraceTxnThreshold           *settings.DurationSetting
-	TraceSessionEventLogEnabled *settings.BoolSetting
-	LogStatementsExecuteEnabled *settings.BoolSetting
-	DistSQLClusterExecMode      *settings.EnumSetting
-}
-
-// RocksDBSettings is the subset of ClusterSettings affecting RocksDB
-// instances.
-type RocksDBSettings struct {
-	MinWALSyncInterval *settings.DurationSetting
-}
-
-// RebalancingSettings is the subset of ClusterSettings affecting
-// rebalancing.
-type RebalancingSettings struct {
-	EnableLoadBasedLeaseRebalancing *settings.BoolSetting
-	LeaseRebalancingAggressiveness  *settings.FloatSetting
-	EnableStatsBasedRebalancing     *settings.BoolSetting
-	StatRebalanceThreshold          *settings.FloatSetting
-	RangeRebalanceThreshold         *settings.FloatSetting
-
-	TimeUntilStoreDead *settings.DurationSetting
-}
-
-// StorageSettings is the subset of ClusterSettings affecting the storage
-// layer.
-type StorageSettings struct {
-	SyncRaftLog    *settings.BoolSetting
-	MaxCommandSize *settings.ByteSizeSetting
-	GCBatchSize    *settings.IntSetting
-
-	BulkIOWriteLimit   *settings.ByteSizeSetting
-	BulkIOWriteLimiter *rate.Limiter
-
-	RebalanceSnapshotRate       *settings.ByteSizeSetting
-	RecoverySnapshotRate        *settings.ByteSizeSetting
-	DeclinedReservationsTimeout *settings.DurationSetting
-	FailedReservationsTimeout   *settings.DurationSetting
-	ImportBatchSize             *settings.ByteSizeSetting
-	AddSSTableEnabled           *settings.BoolSetting
-	MaxIntents                  *settings.IntSetting
-	RangeDescriptorCacheSize    *settings.IntSetting
-
-	ConsistencyCheckInterval *settings.DurationSetting
-}
-
-// UISettings is the subset of ClusterSettings affecting the UI.
-type UISettings struct {
-	WebSessionTimeout *settings.DurationSetting
-	DebugRemote       *settings.StringSetting
-}
-
-// CCLSettings is the subset of ClusterSettings affecting
-// enterprise-related functionality.
-type CCLSettings struct {
-	EnterpriseLicense   *settings.StringSetting
-	ClusterOrganization *settings.StringSetting
-}
 
 // Settings is the collection of cluster settings. For a running CockroachDB
 // node, there is a single instance of ClusterSetting which is shared across all
@@ -272,28 +59,37 @@ type CCLSettings struct {
 // cluster settings don't play a crucial role, MakeTestingClusterSetting() is
 // provided; it is pre-initialized to the binary's ServerVersion.
 type Settings struct {
+	SV settings.Values
+
 	// Manual defaults to false. If set, lets this ClusterSetting's MakeUpdater
 	// method return a dummy updater that simply throws away all values. This is
 	// for use in tests for which manual control is desired.
 	Manual atomic.Value // bool
-	// A Registry populated with all of the individual cluster settings.
-	settings.Registry
-
-	TracingSettings
-	ReportingSettings
-	RocksDBSettings
-	RebalancingSettings
-	StorageSettings
-	SQLStatsSettings
-	SQLSessionSettings
-	DistSQLSettings
-	UISettings
-	CCLSettings
 
 	Version ExposedClusterVersion
+
+	Tracer             *tracing.Tracer
+	BulkIOWriteLimiter *rate.Limiter
+
+	Initialized bool
 }
 
 const keyVersionSetting = "version"
+
+var version = settings.RegisterStateMachineSetting(keyVersionSetting,
+	"set the active cluster version in the format '<major>.<minor>'.", // hide optional `-<unstable>`
+	settings.TransformerFn(versionTransformer),
+)
+
+// BulkIOWriteLimit is defined here because it is used by BulkIOWriteLimiter.
+var BulkIOWriteLimit = settings.RegisterByteSizeSetting(
+	"kv.bulk_io_write.max_rate",
+	"the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops",
+	math.MaxInt64,
+)
+
+// BulkIOWriteLimiterBurst is the burst for the BulkIOWriteLimiter cluster setting.
+const BulkIOWriteLimiterBurst = 2 * 1024 * 1024 // 2MB
 
 // InitializeVersion initializes the Version field of this setting. Before this
 // method has been called, usage of the Version field is illegal and leads to a
@@ -304,8 +100,8 @@ func (s *Settings) InitializeVersion(cv ClusterVersion) error {
 		return err
 	}
 	// Note that we don't call `updater.ResetRemaining()`.
-	updater := settings.NewUpdater(s.Registry)
-	if err := updater.Set(keyVersionSetting, string(b), s.Version.version.Typ()); err != nil {
+	updater := settings.NewUpdater(&s.SV)
+	if err := updater.Set(keyVersionSetting, string(b), version.Typ()); err != nil {
 		return err
 	}
 	s.Version.baseVersion.Store(&cv)
@@ -319,7 +115,6 @@ type ExposedClusterVersion struct {
 	MinSupportedVersion roachpb.Version
 	ServerVersion       roachpb.Version
 	baseVersion         atomic.Value // stores *ClusterVersion
-	version             *settings.StateMachineSetting
 	cb                  func(ClusterVersion)
 }
 
@@ -374,9 +169,7 @@ func MakeTestingClusterSettings() *Settings {
 // MakeClusterSettings makes a new ClusterSettings object for the given minimum
 // supported and server version, respectively.
 func MakeClusterSettings(minVersion, serverVersion roachpb.Version) *Settings {
-	var s Settings
-	r := settings.NewRegistry()
-	s.Registry = r
+	s := &Settings{}
 
 	// Initialize the setting. Note that baseVersion starts out with the zero
 	// cluster version, for which the transformer accepts any new version. After
@@ -387,13 +180,14 @@ func MakeClusterSettings(minVersion, serverVersion roachpb.Version) *Settings {
 	s.Version.MinSupportedVersion = minVersion
 	s.Version.ServerVersion = serverVersion
 	s.Version.baseVersion.Store(&ClusterVersion{})
-	s.Version.version = r.RegisterStateMachineSetting(keyVersionSetting,
-		"set the active cluster version in the format '<major>.<minor>'.", // hide optional `-<unstable>`
-		versionTransformer(minVersion, serverVersion, func() ClusterVersion {
-			return *s.Version.baseVersion.Load().(*ClusterVersion)
-		}),
-	).OnChange(func() {
-		_, obj, err := s.Version.version.Transformer([]byte(s.Version.version.Get()), nil)
+	sv := &s.SV
+	sv.Init(s)
+
+	s.Tracer = tracing.NewTracer()
+	s.Tracer.Configure(sv)
+
+	version.SetOnChange(sv, func() {
+		_, obj, err := version.Validate(sv, []byte(version.Get(sv)), nil)
 		if err != nil {
 			log.Fatal(context.Background(), err)
 		}
@@ -408,348 +202,19 @@ func MakeClusterSettings(minVersion, serverVersion roachpb.Version) *Settings {
 		s.Version.baseVersion.Store(&newV)
 	})
 
-	s.Tracer = tracing.NewTracer()
-
-	tracingOnChange := func() {
-		s.Tracer.Reconfigure(tracingReconfigurationOptions{s.TracingSettings})
-	}
-
-	s.EnableNetTrace = r.RegisterBoolSetting(
-		"trace.debug.enable",
-		"if set, traces for recent requests can be seen in the /debug page",
-		false,
-	).OnChange(tracingOnChange)
-
-	s.LightstepToken = r.RegisterStringSetting(
-		"trace.lightstep.token",
-		"if set, traces go to Lightstep using this token",
-		envutil.EnvOrDefaultString("COCKROACH_TEST_LIGHTSTEP_TOKEN", ""),
-	).OnChange(tracingOnChange)
-
-	s.ZipkinCollector = r.RegisterStringSetting(
-		"trace.zipkin.collector",
-		"if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.",
-		envutil.EnvOrDefaultString("COCKROACH_TEST_ZIPKIN_COLLECTOR", ""),
-	).OnChange(tracingOnChange)
-
-	crashReportsOnChange := func() {
-		f := log.ReportingSettings(s.ReportingSettings)
-		log.ReportingSettingsSingleton.Store(&f)
-	}
-
-	// DiagnosticsReportingEnabled wraps "diagnostics.reporting.enabled".
-	//
-	// "diagnostics.reporting.enabled" enables reporting of metrics related to a
-	// node's storage (number, size and health of ranges) back to CockroachDB.
-	// Collecting this data from production clusters helps us understand and improve
-	// how our storage systems behave in real-world use cases.
-	//
-	// Note: while the setting itself is actually defined with a default value of
-	// `false`, it is usually automatically set to `true` when a cluster is created
-	// (or is migrated from a earlier beta version). This can be prevented with the
-	// env var COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING.
-	//
-	// Doing this, rather than just using a default of `true`, means that a node
-	// will not errantly send a report using a default before loading settings.
-	s.DiagnosticsReportingEnabled = r.RegisterBoolSetting(
-		"diagnostics.reporting.enabled",
-		"enable reporting diagnostic metrics to cockroach labs",
-		false,
-	).OnChange(crashReportsOnChange)
-
-	s.CrashReports = r.RegisterBoolSetting(
-		"diagnostics.reporting.send_crash_reports",
-		"send crash and panic reports",
-		true,
-	).OnChange(crashReportsOnChange)
-
-	// maxIntents is the limit for the number of intents that can be
-	// written in a single transaction. All intents used by a transaction
-	// must be included in the EndTransactionRequest, and processing a
-	// large EndTransactionRequest currently consumes a larage amount of
-	// memory. Limit the number of intents to keep this from causing the
-	// server to run out of memory.
-	s.MaxIntents = r.RegisterIntSetting(
-		"kv.transaction.max_intents",
-		"maximum number of write intents allowed for a KV transaction", 100000)
-
-	s.RangeDescriptorCacheSize = r.RegisterIntSetting(
-		"kv.range_descriptor_cache.size",
-		"maximum number of entries in the range descriptor and leaseholder caches",
-		1e6)
-
-	s.MinWALSyncInterval = r.RegisterDurationSetting(
-		"rocksdb.min_wal_sync_interval",
-		"minimum duration between syncs of the RocksDB WAL",
-		0*time.Millisecond)
-
-	// EnableLoadBasedLeaseRebalancing controls whether lease rebalancing is done
-	// via the new heuristic based on request load and latency or via the simpler
-	// approach that purely seeks to balance the number of leases per node evenly.
-	s.EnableLoadBasedLeaseRebalancing = r.RegisterBoolSetting(
-		"kv.allocator.load_based_lease_rebalancing.enabled",
-		"set to enable rebalancing of range leases based on load and latency",
-		true)
-
-	// LeaseRebalancingAggressiveness enables users to tweak how aggressive their
-	// cluster is at moving leases towards the localities where the most requests
-	// are coming from. Settings lower than 1.0 will make the system less
-	// aggressive about moving leases toward requests than the default, while
-	// settings greater than 1.0 will cause more aggressive placement.
-	//
-	// Setting this to 0 effectively disables load-based lease rebalancing, and
-	// settings less than 0 are disallowed.
-	s.LeaseRebalancingAggressiveness = r.RegisterNonNegativeFloatSetting(
-		"kv.allocator.lease_rebalancing_aggressiveness",
-		"set greater than 1.0 to rebalance leases toward load more aggressively, "+
-			"or between 0 and 1.0 to be more conservative about rebalancing leases",
-		1.0)
-
-	// EnableStatsBasedRebalancing controls whether range rebalancing takes
-	// additional variables such as write load and disk usage into account.
-	// If disabled, rebalancing is done purely based on replica count.
-	s.EnableStatsBasedRebalancing = r.RegisterBoolSetting(
-		"kv.allocator.stat_based_rebalancing.enabled",
-		"set to enable rebalancing of range replicas based on write load and disk usage",
-		false)
-
-	// rangeRebalanceThreshold is the minimum ratio of a store's range count to
-	// the mean range count at which that store is considered overfull or underfull
-	// of ranges.
-	s.RangeRebalanceThreshold = r.RegisterNonNegativeFloatSetting(
-		"kv.allocator.range_rebalance_threshold",
-		"minimum fraction away from the mean a store's range count can be before it is considered overfull or underfull",
-		0.05)
-
-	// StatRebalanceThreshold is the the same as rangeRebalanceThreshold, but for
-	// statistics other than range count. This should be larger than
-	// rangeRebalanceThreshold because certain stats (like keys written per second)
-	// are inherently less stable and thus we need to be a little more forgiving to
-	// avoid thrashing.
-	//
-	// Note that there isn't a ton of science behind this number, but setting it
-	// to .05 and .1 were shown to cause some instability in clusters without load
-	// on them.
-	//
-	// TODO(a-robinson): Should disk usage be held to a higher standard than this?
-	s.StatRebalanceThreshold = r.RegisterNonNegativeFloatSetting(
-		"kv.allocator.stat_rebalance_threshold",
-		"minimum fraction away from the mean a store's stats (like disk usage or writes per second) can be before it is considered overfull or underfull",
-		0.20)
-
-	s.SyncRaftLog = r.RegisterBoolSetting(
-		"kv.raft_log.synchronize",
-		"set to true to synchronize on Raft log writes to persistent storage",
-		true)
-
-	s.MaxCommandSize = r.RegisterValidatedByteSizeSetting(
-		"kv.raft.command.max_size",
-		"maximum size of a raft command",
-		64<<20,
-		func(size int64) error {
-			if size < MaxCommandSizeFloor {
-				return fmt.Errorf("max_size must be greater than %s", humanizeutil.IBytes(MaxCommandSizeFloor))
-			}
-			return nil
-		})
-
-	// gcBatchSize controls the amount of work done in a single pass of
-	// MVCC GC. Setting this too high may block the range for too long
-	// (especially a risk in the system ranges), while setting it too low
-	// may allow ranges to grow too large if we are unable to keep up with
-	// the amount of garbage generated.
-	s.GCBatchSize = r.RegisterIntSetting("kv.gc.batch_size",
-		"maximum number of keys in a batch for MVCC garbage collection",
-		100000)
-
-	s.BulkIOWriteLimit = r.RegisterByteSizeSetting(
-		"kv.bulk_io_write.max_rate",
-		"the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops",
-		math.MaxInt64,
-	)
+	log.ReportingSettingsSingleton.Store(sv)
 
 	// TODO(dan): This limiting should be per-store and shared between any
 	// operations that need lots of disk throughput.
-	s.BulkIOWriteLimiter = rate.NewLimiter(rate.Limit(s.BulkIOWriteLimit.Get()), BulkIOWriteLimiterBurst)
+	s.BulkIOWriteLimiter = rate.NewLimiter(rate.Limit(BulkIOWriteLimit.Get(sv)), BulkIOWriteLimiterBurst)
 
-	s.BulkIOWriteLimit.OnChange(func() {
-		s.BulkIOWriteLimiter.SetLimit(rate.Limit(s.BulkIOWriteLimit.Get()))
+	BulkIOWriteLimit.SetOnChange(sv, func() {
+		s.BulkIOWriteLimiter.SetLimit(rate.Limit(BulkIOWriteLimit.Get(sv)))
 	})
 
-	s.RebalanceSnapshotRate = r.RegisterByteSizeSetting(
-		"kv.snapshot_rebalance.max_rate",
-		"the rate limit (bytes/sec) to use for rebalance snapshots",
-		envutil.EnvOrDefaultBytes("COCKROACH_PREEMPTIVE_SNAPSHOT_RATE", 2<<20))
-	s.RecoverySnapshotRate = r.RegisterByteSizeSetting(
-		"kv.snapshot_recovery.max_rate",
-		"the rate limit (bytes/sec) to use for recovery snapshots",
-		envutil.EnvOrDefaultBytes("COCKROACH_RAFT_SNAPSHOT_RATE", 8<<20))
+	s.Initialized = true
 
-	// declinedReservationsTimeout needs to be non-zero to prevent useless retries
-	// in the replicateQueue.process() retry loop.
-	s.DeclinedReservationsTimeout = r.RegisterNonNegativeDurationSetting(
-		"server.declined_reservation_timeout",
-		"the amount of time to consider the store throttled for up-replication after a reservation was declined",
-		1*time.Second,
-	)
-
-	s.FailedReservationsTimeout = r.RegisterNonNegativeDurationSetting(
-		"server.failed_reservation_timeout",
-		"the amount of time to consider the store throttled for up-replication after a failed reservation call",
-		5*time.Second,
-	)
-
-	s.ConsistencyCheckInterval = r.RegisterNonNegativeDurationSetting(
-		"server.consistency_check.interval",
-		"the time between range consistency checks; set to 0 to disable consistency checking",
-		24*time.Hour,
-	)
-
-	s.DistSQLUseTempStorage = r.RegisterBoolSetting(
-		"sql.defaults.distsql.tempstorage",
-		"set to true to enable use of disk for larger distributed sql queries",
-		true,
-	)
-
-	s.DistSQLUseTempStorageSorts = r.RegisterBoolSetting(
-		"sql.defaults.distsql.tempstorage.sorts",
-		"set to true to enable use of disk for distributed sql sorts. sql.defaults.distsql.tempstorage must be true",
-		true,
-	)
-
-	s.DistSQLUseTempStorageJoins = r.RegisterBoolSetting(
-		"sql.defaults.distsql.tempstorage.joins",
-		"set to true to enable use of disk for distributed sql joins. sql.defaults.distsql.tempstorage must be true",
-		true,
-	)
-
-	// StmtStatsEnable determines whether to collect per-statement
-	// statistics.
-	s.StmtStatsEnable = r.RegisterBoolSetting(
-		"sql.metrics.statement_details.enabled", "collect per-statement query statistics", true,
-	)
-
-	// SQLStatsCollectionLatencyThreshold specifies the minimum amount of time
-	// consumed by a SQL statement before it is collected for statistics reporting.
-	s.SQLStatsCollectionLatencyThreshold = r.RegisterDurationSetting(
-		"sql.metrics.statement_details.threshold",
-		"minimum execution time to cause statistics to be collected",
-		0,
-	)
-
-	s.DumpStmtStatsToLogBeforeReset = r.RegisterBoolSetting(
-		"sql.metrics.statement_details.dump_to_logs",
-		"dump collected statement statistics to node logs when periodically cleared",
-		false,
-	)
-
-	// If true, for index joins  we instantiate a join reader on every node that
-	// has a stream (usually from a table reader). If false, there is a single join
-	// reader.
-	s.DistributeIndexJoin = r.RegisterBoolSetting(
-		"sql.distsql.distribute_index_joins",
-		"if set, for index joins we instantiate a join reader on every node that has a "+
-			"stream; if not set, we use a single join reader",
-		true,
-	)
-
-	s.PlanMergeJoins = r.RegisterBoolSetting(
-		"sql.distsql.merge_joins.enabled",
-		"if set, we plan merge joins when possible",
-		true,
-	)
-
-	// traceTxnThreshold can be used to log SQL transactions that take
-	// longer than duration to complete. For example, traceTxnThreshold=1s
-	// will log the trace for any transaction that takes 1s or longer. To
-	// log traces for all transactions use traceTxnThreshold=1ns. Note
-	// that any positive duration will enable tracing and will slow down
-	// all execution because traces are gathered for all transactions even
-	// if they are not output.
-	s.TraceTxnThreshold = r.RegisterDurationSetting(
-		"sql.trace.txn.enable_threshold",
-		"duration beyond which all transactions are traced (set to 0 to disable)", 0)
-
-	// traceSessionEventLogEnabled can be used to enable the event log
-	// that is normally kept for every SQL connection. The event log has a
-	// non-trivial performance impact and also reveals SQL statements
-	// which may be a privacy concern.
-	s.TraceSessionEventLogEnabled = r.RegisterBoolSetting(
-		"sql.trace.session_eventlog.enabled",
-		"set to true to enable session tracing", false)
-
-	// logStatementsExecuteEnabled causes the Executor to log executed
-	// statements and, if any, resulting errors.
-	s.LogStatementsExecuteEnabled = r.RegisterBoolSetting(
-		"sql.trace.log_statement_execute",
-		"set to true to enable logging of executed statements", false)
-
-	// DistSQLClusterExecMode controls the cluster default for when DistSQL is used.
-	s.DistSQLClusterExecMode = r.RegisterEnumSetting(
-		"sql.defaults.distsql",
-		"Default distributed SQL execution mode",
-		"Auto",
-		map[int64]string{
-			int64(DistSQLOff):  "Off",
-			int64(DistSQLAuto): "Auto",
-			int64(DistSQLOn):   "On",
-		},
-	)
-
-	s.WebSessionTimeout = r.RegisterNonNegativeDurationSetting(
-		"server.web_session_timeout",
-		"the duration that a newly created web session will be valid",
-		7*24*time.Hour)
-
-	s.TimeUntilStoreDead = r.RegisterNonNegativeDurationSetting(
-		"server.time_until_store_dead",
-		"the time after which if there is no new gossiped information about a store, it is considered dead",
-		5*time.Minute)
-
-	s.DebugRemote = r.RegisterValidatedStringSetting(
-		"server.remote_debugging.mode",
-		"set to enable remote debugging, localhost-only or disable (any, local, off)",
-		"local",
-		func(s string) error {
-			switch DebugRemoteMode(strings.ToLower(s)) {
-			case DebugRemoteOff, DebugRemoteLocal, DebugRemoteAny:
-				return nil
-			default:
-				return errors.Errorf("invalid mode: '%s'", s)
-			}
-		},
-	)
-
-	s.ClusterOrganization = r.RegisterStringSetting("cluster.organization", "organization name", "")
-
-	// FIXME(tschottdorf): should be NonNegative?
-	s.DiagnosticReportFrequency = r.RegisterDurationSetting(
-		"diagnostics.reporting.interval",
-		"interval at which diagnostics data should be reported",
-		time.Hour,
-	)
-
-	s.DiagnosticsMetricsEnabled = r.RegisterBoolSetting(
-		"diagnostics.reporting.report_metrics",
-		"enable collection and reporting diagnostic metrics to cockroach labs",
-		true,
-	)
-
-	s.ImportBatchSize = r.RegisterByteSizeSetting("kv.import.batch_size", "", 63<<20)
-	s.ImportBatchSize.Hide()
-
-	s.AddSSTableEnabled = r.RegisterBoolSetting(
-		"kv.import.addsstable.enabled",
-		"set to true to use the AddSSTable command in Import or false to use WriteBatch",
-		true,
-	)
-	s.AddSSTableEnabled.Hide()
-
-	s.EnterpriseLicense = r.RegisterValidatedStringSetting(
-		"enterprise.license", "the encoded cluster license", "",
-		ValidateEnterpriseLicense)
-	s.EnterpriseLicense.Hide()
-	return &s
+	return s
 }
 
 // MakeUpdater returns a new Updater, pre-alloced to the registry size. Note
@@ -759,7 +224,7 @@ func (s *Settings) MakeUpdater() settings.Updater {
 	if isManual, ok := s.Manual.Load().(bool); ok && isManual {
 		return &settings.NoopUpdater{}
 	}
-	return settings.NewUpdater(s.Registry)
+	return settings.NewUpdater(&s.SV)
 }
 
 type stringedVersion ClusterVersion
@@ -771,67 +236,80 @@ func (sv *stringedVersion) String() string {
 	return sv.MinimumVersion.String()
 }
 
+// versionTransformer is the transformer function for the version StateMachine.
+// It has access to the Settings struct via the opaque member of settings.Values.
 func versionTransformer(
-	minSupportedVersion, serverVersion roachpb.Version, defaultVersion func() ClusterVersion,
-) settings.TransformerFn {
-	return func(curRawProto []byte, versionBump *string) (newRawProto []byte, versionStringer interface{}, _ error) {
-		defer func() {
-			if versionStringer != nil {
-				versionStringer = (*stringedVersion)(versionStringer.(*ClusterVersion))
-			}
-		}()
-		var oldV ClusterVersion
-
-		// If no old value supplied, fill in the default.
-		if curRawProto == nil {
-			oldV = defaultVersion()
-			var err error
-			curRawProto, err = oldV.Marshal()
-			if err != nil {
-				return nil, nil, err
-			}
+	sv *settings.Values, curRawProto []byte, versionBump *string,
+) (newRawProto []byte, versionStringer interface{}, _ error) {
+	opaque := sv.Opaque()
+	if opaque == settings.TestOpaque {
+		// This is a test where a cluster.Settings is not set up yet. In that case
+		// this function is ran only once, on initialization.
+		if curRawProto != nil || versionBump != nil {
+			panic("modifying version when TestOpaque is set")
 		}
+		return nil, nil, nil
+	}
+	s := opaque.(*Settings)
+	minSupportedVersion := s.Version.MinSupportedVersion
+	serverVersion := s.Version.ServerVersion
 
-		if err := oldV.Unmarshal(curRawProto); err != nil {
-			return nil, nil, err
+	defer func() {
+		if versionStringer != nil {
+			versionStringer = (*stringedVersion)(versionStringer.(*ClusterVersion))
 		}
-		if versionBump == nil {
-			// Round-trip the existing value, but only if it passes sanity
-			// checks. This is also the path taken when the setting gets updated
-			// via the gossip callback.
-			if serverVersion.Less(oldV.MinimumVersion) {
-				log.Fatalf(context.TODO(), "node at %s cannot run at %s", serverVersion, oldV.MinimumVersion)
-			}
-			if (oldV.MinimumVersion != roachpb.Version{}) && oldV.MinimumVersion.Less(minSupportedVersion) {
-				log.Fatalf(context.TODO(), "node at %s cannot run at %s (minimum version is %s)", serverVersion, oldV.MinimumVersion, minSupportedVersion)
-			}
-			return curRawProto, &oldV, nil
-		}
+	}()
+	var oldV ClusterVersion
 
-		// We have a new proposed update to the value, validate it.
-		minVersion, err := roachpb.ParseVersion(*versionBump)
+	// If no old value supplied, fill in the default.
+	if curRawProto == nil {
+		oldV = *s.Version.baseVersion.Load().(*ClusterVersion)
+		var err error
+		curRawProto, err = oldV.Marshal()
 		if err != nil {
 			return nil, nil, err
 		}
-		newV := oldV
-		newV.UseVersion = minVersion
-		newV.MinimumVersion = minVersion
-
-		if minVersion.Less(oldV.MinimumVersion) {
-			return nil, nil, errors.Errorf("cannot downgrade from %s to %s", oldV.MinimumVersion, minVersion)
-		}
-
-		if oldV != (ClusterVersion{}) && !oldV.MinimumVersion.CanBump(minVersion) {
-			return nil, nil, errors.Errorf("cannot upgrade directly from %s to %s", oldV.MinimumVersion, minVersion)
-		}
-
-		if serverVersion.Less(minVersion) {
-			// TODO(tschottdorf): also ask gossip about other nodes.
-			return nil, nil, errors.Errorf("cannot upgrade to %s: node running %s",
-				minVersion, serverVersion)
-		}
-
-		b, err := newV.Marshal()
-		return b, &newV, err
 	}
+
+	if err := oldV.Unmarshal(curRawProto); err != nil {
+		return nil, nil, err
+	}
+	if versionBump == nil {
+		// Round-trip the existing value, but only if it passes sanity
+		// checks. This is also the path taken when the setting gets updated
+		// via the gossip callback.
+		if serverVersion.Less(oldV.MinimumVersion) {
+			log.Fatalf(context.TODO(), "node at %s cannot run at %s", serverVersion, oldV.MinimumVersion)
+		}
+		if (oldV.MinimumVersion != roachpb.Version{}) && oldV.MinimumVersion.Less(minSupportedVersion) {
+			log.Fatalf(context.TODO(), "node at %s cannot run at %s (minimum version is %s)", serverVersion, oldV.MinimumVersion, minSupportedVersion)
+		}
+		return curRawProto, &oldV, nil
+	}
+
+	// We have a new proposed update to the value, validate it.
+	minVersion, err := roachpb.ParseVersion(*versionBump)
+	if err != nil {
+		return nil, nil, err
+	}
+	newV := oldV
+	newV.UseVersion = minVersion
+	newV.MinimumVersion = minVersion
+
+	if minVersion.Less(oldV.MinimumVersion) {
+		return nil, nil, errors.Errorf("cannot downgrade from %s to %s", oldV.MinimumVersion, minVersion)
+	}
+
+	if oldV != (ClusterVersion{}) && !oldV.MinimumVersion.CanBump(minVersion) {
+		return nil, nil, errors.Errorf("cannot upgrade directly from %s to %s", oldV.MinimumVersion, minVersion)
+	}
+
+	if serverVersion.Less(minVersion) {
+		// TODO(tschottdorf): also ask gossip about other nodes.
+		return nil, nil, errors.Errorf("cannot upgrade to %s: node running %s",
+			minVersion, serverVersion)
+	}
+
+	b, err := newV.Marshal()
+	return b, &newV, err
 }

--- a/pkg/settings/enum.go
+++ b/pkg/settings/enum.go
@@ -54,11 +54,11 @@ func (e *EnumSetting) ParseEnum(raw string) (int64, bool) {
 	return v, ok
 }
 
-func (e *EnumSetting) set(k int64) error {
+func (e *EnumSetting) set(sv *Values, k int64) error {
 	if _, ok := e.enumValues[k]; !ok {
 		return errors.Errorf("unrecognized value %d", k)
 	}
-	return e.IntSetting.set(k)
+	return e.IntSetting.set(sv, k)
 }
 
 func enumValuesToDesc(enumValues map[int64]string) string {
@@ -81,7 +81,7 @@ func enumValuesToDesc(enumValues map[int64]string) string {
 }
 
 // RegisterEnumSetting defines a new setting with type int.
-func (r *Registry) RegisterEnumSetting(
+func RegisterEnumSetting(
 	key, desc string, defaultValue string, enumValues map[int64]string,
 ) *EnumSetting {
 	enumValuesLower := make(map[int64]string)
@@ -104,25 +104,6 @@ func (r *Registry) RegisterEnumSetting(
 		enumValues: enumValuesLower,
 	}
 
-	r.register(key, fmt.Sprintf("%s %s", desc, enumValuesToDesc(enumValues)), setting)
+	register(key, fmt.Sprintf("%s %s", desc, enumValuesToDesc(enumValues)), setting)
 	return setting
-}
-
-// TestingSetEnum returns a mock, unregistered enum setting for testing. See
-// TestingSetBool for more details.
-func TestingSetEnum(s **EnumSetting, i int64) func() {
-	saved := *s
-	*s = &EnumSetting{
-		IntSetting: IntSetting{v: i},
-		enumValues: saved.enumValues,
-	}
-	return func() {
-		*s = saved
-	}
-}
-
-// OnChange registers a callback to be called when the setting changes.
-func (e *EnumSetting) OnChange(fn func()) *EnumSetting {
-	e.setOnChange(fn)
-	return e
 }

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -16,7 +16,6 @@ package settings
 
 import (
 	"math"
-	"sync/atomic"
 
 	"github.com/pkg/errors"
 )
@@ -27,19 +26,18 @@ import (
 type FloatSetting struct {
 	common
 	defaultValue float64
-	v            uint64
 	validateFn   func(float64) error
 }
 
 var _ Setting = &FloatSetting{}
 
 // Get retrieves the float value in the setting.
-func (f *FloatSetting) Get() float64 {
-	return math.Float64frombits(atomic.LoadUint64(&f.v))
+func (f *FloatSetting) Get(sv *Values) float64 {
+	return math.Float64frombits(uint64(sv.getInt64(f.slotIdx)))
 }
 
-func (f *FloatSetting) String() string {
-	return EncodeFloat(f.Get())
+func (f *FloatSetting) String(sv *Values) string {
+	return EncodeFloat(f.Get(sv))
 }
 
 // Typ returns the short (1 char) string denoting the type of setting.
@@ -57,29 +55,27 @@ func (f *FloatSetting) Validate(v float64) error {
 	return nil
 }
 
-func (f *FloatSetting) set(v float64) error {
+func (f *FloatSetting) set(sv *Values, v float64) error {
 	if err := f.Validate(v); err != nil {
 		return err
 	}
-	if bits := math.Float64bits(v); atomic.SwapUint64(&f.v, bits) != bits {
-		f.changed()
-	}
+	sv.setInt64(f.slotIdx, int64(math.Float64bits(v)))
 	return nil
 }
 
-func (f *FloatSetting) setToDefault() {
-	if err := f.set(f.defaultValue); err != nil {
+func (f *FloatSetting) setToDefault(sv *Values) {
+	if err := f.set(sv, f.defaultValue); err != nil {
 		panic(err)
 	}
 }
 
 // RegisterFloatSetting defines a new setting with type float.
-func (r *Registry) RegisterFloatSetting(key, desc string, defaultValue float64) *FloatSetting {
-	return r.RegisterValidatedFloatSetting(key, desc, defaultValue, nil)
+func RegisterFloatSetting(key, desc string, defaultValue float64) *FloatSetting {
+	return RegisterValidatedFloatSetting(key, desc, defaultValue, nil)
 }
 
 // RegisterValidatedFloatSetting defines a new setting with type float.
-func (r *Registry) RegisterValidatedFloatSetting(
+func RegisterValidatedFloatSetting(
 	key, desc string, defaultValue float64, validateFn func(float64) error,
 ) *FloatSetting {
 	if validateFn != nil {
@@ -91,38 +87,16 @@ func (r *Registry) RegisterValidatedFloatSetting(
 		defaultValue: defaultValue,
 		validateFn:   validateFn,
 	}
-	r.register(key, desc, setting)
+	register(key, desc, setting)
 	return setting
 }
 
 // RegisterNonNegativeFloatSetting defines a new setting with type float.
-func (r *Registry) RegisterNonNegativeFloatSetting(
-	key, desc string, defaultValue float64,
-) *FloatSetting {
-	return r.RegisterValidatedFloatSetting(key, desc, defaultValue, func(v float64) error {
+func RegisterNonNegativeFloatSetting(key, desc string, defaultValue float64) *FloatSetting {
+	return RegisterValidatedFloatSetting(key, desc, defaultValue, func(v float64) error {
 		if v < 0 {
 			return errors.Errorf("cannot set %s to a negative value: %f", key, v)
 		}
 		return nil
 	})
-}
-
-// TestingSetFloat returns a mock, unregistered float setting for testing. See
-// TestingSetBool for more details.
-func TestingSetFloat(s **FloatSetting, v float64) func() {
-	saved := *s
-	tmp := &FloatSetting{}
-	if err := tmp.set(v); err != nil {
-		panic(err)
-	}
-	*s = tmp
-	return func() {
-		*s = saved
-	}
-}
-
-// OnChange registers a callback to be called when the setting changes.
-func (f *FloatSetting) OnChange(fn func()) *FloatSetting {
-	f.common.setOnChange(fn)
-	return f
 }

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -14,22 +14,118 @@
 
 package settings
 
-// Setting implementions wrap a val with atomic access.
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+const maxSettings = 128
+
+// Values is a container that stores values for all registered settings.
+// Each setting is assigned a unique slot (up to maxSettings).
+// Note that slot indices are 1-based (this is to trigger panics if an
+// uninitialized slot index is used).
+type Values struct {
+	intVals     [maxSettings]int64
+	genericVals [maxSettings]atomic.Value
+	onChange    [maxSettings]func()
+	// opaque is an arbitrary object that can be set by a higher layer to make it
+	// accessible from certain callbacks (like state machine transformers).
+	opaque interface{}
+}
+
+type testOpaqueType struct{}
+
+// TestOpaque can be passed to Values.Init when we are testing the settings
+// infrastructure.
+var TestOpaque interface{} = testOpaqueType{}
+
+// Init must be called before using a Values instance; it initializes all
+// variables to their defaults.
+//
+// The opaque argument can be retrieved later via Opaque().
+func (sv *Values) Init(opaque interface{}) {
+	sv.opaque = opaque
+	for _, s := range Registry {
+		s.setToDefault(sv)
+	}
+}
+
+// Opaque returns the argument passed to Init.
+func (sv *Values) Opaque() interface{} {
+	return sv.opaque
+}
+
+func (sv *Values) settingChanged(slotIdx int) {
+	if fn := sv.onChange[slotIdx]; fn != nil {
+		fn()
+	}
+}
+
+func (sv *Values) getInt64(slotIdx int) int64 {
+	return atomic.LoadInt64(&sv.intVals[slotIdx-1])
+}
+
+func (sv *Values) setInt64(slotIdx int, newVal int64) {
+	if atomic.SwapInt64(&sv.intVals[slotIdx-1], newVal) != newVal {
+		sv.settingChanged(slotIdx)
+	}
+}
+
+func (sv *Values) getGeneric(slotIdx int) interface{} {
+	return sv.genericVals[slotIdx-1].Load()
+}
+
+func (sv *Values) setGeneric(slotIdx int, newVal interface{}) {
+	sv.genericVals[slotIdx-1].Store(newVal)
+	sv.settingChanged(slotIdx)
+}
+
+// setOnChange installs a callback to be called when a setting's value changes.
+// `fn` should avoid doing long-running or blocking work as it is called on the
+// goroutine which handles all settings updates.
+//
+// Cannot be called concurrently with setGeneric/setInt64.
+func (sv *Values) setOnChange(slotIdx int, fn func()) {
+	if sv.onChange[slotIdx] != nil {
+		panic("registered multiple on-change callbacks")
+	}
+	sv.onChange[slotIdx] = fn
+}
+
+// Setting is a descriptor for each setting; once it is initialized, it is
+// immutable. The values for the settings are stored separately, in
+// Values. This way we can have a global set of registered settings, each
+// with potentially multiple instances.
 type Setting interface {
-	setToDefault()
+	setToDefault(sv *Values)
 	// Typ returns the short (1 char) string denoting the type of setting.
 	Typ() string
-	String() string
+	String(sv *Values) string
 
 	Description() string
 	setDescription(desc string)
+	setSlotIdx(slotIdx int)
 	Hidden() bool
+
+	SetOnChange(sv *Values, fn func())
 }
 
 type common struct {
 	description string
 	hidden      bool
-	onChange    func()
+	// Each setting has a slotIdx which is used as a handle with Values.
+	slotIdx int
+}
+
+func (i *common) setSlotIdx(slotIdx int) {
+	if slotIdx < 1 {
+		panic(fmt.Sprintf("Invalid slot index %d", slotIdx))
+	}
+	if slotIdx > maxSettings {
+		panic(fmt.Sprintf("too many settings; increase maxSettings"))
+	}
+	i.slotIdx = slotIdx
 }
 
 func (i *common) setDescription(s string) {
@@ -43,12 +139,6 @@ func (i common) Hidden() bool {
 	return i.hidden
 }
 
-func (i common) changed() {
-	if i.onChange != nil {
-		i.onChange()
-	}
-}
-
 // Hide prevents a setting from showing up in SHOW ALL CLUSTER SETTINGS. It can
 // still be used with SET and SHOW if the exact setting name is known. Use Hide
 // for in-development features and other settings that should not be
@@ -57,15 +147,17 @@ func (i *common) Hide() {
 	i.hidden = true
 }
 
-// setOnChange installs a callback to be called when a setting's value changes.
+// SetOnChange installs a callback to be called when a setting's value changes.
 // `fn` should avoid doing long-running or blocking work as it is called on the
 // goroutine which handles all settings updates.
-func (i *common) setOnChange(fn func()) {
-	i.onChange = fn
+//
+// Cannot be called while the setting is being changed.
+func (i *common) SetOnChange(sv *Values, fn func()) {
+	sv.setOnChange(i.slotIdx, fn)
 }
 
 type numericSetting interface {
 	Setting
 	Validate(i int64) error
-	set(i int64) error
+	set(sv *Values, i int64) error
 }

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -49,7 +49,7 @@ func (d *dummy) Marshal() ([]byte, error) {
 	return []byte(d.msg1 + "." + d.growsbyone), nil
 }
 
-var dummyTransformer = func(old []byte, update *string) ([]byte, interface{}, error) {
+var dummyTransformer = func(sv *settings.Values, old []byte, update *string) ([]byte, interface{}, error) {
 	var oldD dummy
 
 	// If no old value supplied, fill in the default.
@@ -98,26 +98,23 @@ var changes = struct {
 	mA       int
 }{}
 
-var r = settings.NewRegistry()
-
-var boolTA = r.RegisterBoolSetting("bool.t", "", true).OnChange(func() { changes.boolTA++ })
-var boolFA = r.RegisterBoolSetting("bool.f", "", false)
-var strFooA = r.RegisterStringSetting("str.foo", "", "").OnChange(func() { changes.strFooA++ })
-var strBarA = r.RegisterStringSetting("str.bar", "", "bar")
-var i1A = r.RegisterIntSetting("i.1", "", 0).OnChange(func() { changes.i1A++ })
-var i2A = r.RegisterIntSetting("i.2", "", 5)
-var fA = r.RegisterFloatSetting("f", "", 5.4).OnChange(func() { changes.fA++ })
-var dA = r.RegisterDurationSetting("d", "", time.Second).OnChange(func() { changes.dA++ })
-var eA = r.RegisterEnumSetting("e", "", "foo", map[int64]string{1: "foo", 2: "bar", 3: "baz"}).
-	OnChange(func() { changes.eA++ })
-var byteSize = r.RegisterByteSizeSetting("zzz", "", mb).OnChange(func() { changes.byteSize++ })
-var mA = r.RegisterStateMachineSetting("statemachine", "foo", dummyTransformer).OnChange(func() { changes.mA++ })
+var boolTA = settings.RegisterBoolSetting("bool.t", "", true)
+var boolFA = settings.RegisterBoolSetting("bool.f", "", false)
+var strFooA = settings.RegisterStringSetting("str.foo", "", "")
+var strBarA = settings.RegisterStringSetting("str.bar", "", "bar")
+var i1A = settings.RegisterIntSetting("i.1", "", 0)
+var i2A = settings.RegisterIntSetting("i.2", "", 5)
+var fA = settings.RegisterFloatSetting("f", "", 5.4)
+var dA = settings.RegisterDurationSetting("d", "", time.Second)
+var eA = settings.RegisterEnumSetting("e", "", "foo", map[int64]string{1: "foo", 2: "bar", 3: "baz"})
+var byteSize = settings.RegisterByteSizeSetting("zzz", "", mb)
+var mA = settings.RegisterStateMachineSetting("statemachine", "foo", dummyTransformer)
 
 func init() {
-	r.RegisterBoolSetting("sekretz", "", false).Hide()
+	settings.RegisterBoolSetting("sekretz", "", false).Hide()
 }
 
-var strVal = r.RegisterValidatedStringSetting(
+var strVal = settings.RegisterValidatedStringSetting(
 	"str.val", "", "", func(v string) error {
 		for _, c := range v {
 			if !unicode.IsLetter(c) {
@@ -126,16 +123,16 @@ var strVal = r.RegisterValidatedStringSetting(
 		}
 		return nil
 	})
-var dVal = r.RegisterNonNegativeDurationSetting("dVal", "", time.Second)
-var fVal = r.RegisterNonNegativeFloatSetting("fVal", "", 5.4)
-var byteSizeVal = r.RegisterValidatedByteSizeSetting(
+var dVal = settings.RegisterNonNegativeDurationSetting("dVal", "", time.Second)
+var fVal = settings.RegisterNonNegativeFloatSetting("fVal", "", 5.4)
+var byteSizeVal = settings.RegisterValidatedByteSizeSetting(
 	"byteSize.Val", "", mb, func(v int64) error {
 		if v < 0 {
 			return errors.Errorf("bytesize cannot be negative")
 		}
 		return nil
 	})
-var iVal = r.RegisterValidatedIntSetting(
+var iVal = settings.RegisterValidatedIntSetting(
 	"i.Val", "", 0, func(v int64) error {
 		if v < 0 {
 			return errors.Errorf("int cannot be negative")
@@ -144,123 +141,135 @@ var iVal = r.RegisterValidatedIntSetting(
 	})
 
 func TestCache(t *testing.T) {
+	sv := &settings.Values{}
+	sv.Init(settings.TestOpaque)
+
+	boolTA.SetOnChange(sv, func() { changes.boolTA++ })
+	strFooA.SetOnChange(sv, func() { changes.strFooA++ })
+	i1A.SetOnChange(sv, func() { changes.i1A++ })
+	fA.SetOnChange(sv, func() { changes.fA++ })
+	dA.SetOnChange(sv, func() { changes.dA++ })
+	eA.SetOnChange(sv, func() { changes.eA++ })
+	byteSize.SetOnChange(sv, func() { changes.byteSize++ })
+	mA.SetOnChange(sv, func() { changes.mA++ })
+
 	t.Run("StateMachineSetting", func(t *testing.T) {
-		mB := r.RegisterStateMachineSetting("local.m", "foo", dummyTransformer)
-		if exp, act := "&{default -}", mB.String(); exp != act {
+		mB := settings.RegisterStateMachineSetting("local.m", "foo", dummyTransformer)
+		if exp, act := "&{default -}", mB.String(sv); exp != act {
 			t.Fatalf("wanted %q, got %q", exp, act)
 		}
 		growsTooFast := "grows too fast"
-		if _, _, err := mB.Validate(nil, &growsTooFast); !testutils.IsError(err, "must grow by exactly one") {
+		if _, _, err := mB.Validate(sv, nil, &growsTooFast); !testutils.IsError(err, "must grow by exactly one") {
 			t.Fatal(err)
 		}
 		hasDots := "a."
-		if _, _, err := mB.Validate(nil, &hasDots); !testutils.IsError(err, "must not contain dots") {
+		if _, _, err := mB.Validate(sv, nil, &hasDots); !testutils.IsError(err, "must not contain dots") {
 			t.Fatal(err)
 		}
 		ab := "ab"
-		if _, _, err := mB.Validate(nil, &ab); err != nil {
+		if _, _, err := mB.Validate(sv, nil, &ab); err != nil {
 			t.Fatal(err)
 		}
-		if _, _, err := mB.Validate([]byte("takes.precedence"), &ab); !testutils.IsError(err, "must grow by exactly one") {
+		if _, _, err := mB.Validate(sv, []byte("takes.precedence"), &ab); !testutils.IsError(err, "must grow by exactly one") {
 			t.Fatal(err)
 		}
 		precedenceX := "precedencex"
-		if _, _, err := mB.Validate([]byte("takes.precedence"), &precedenceX); err != nil {
+		if _, _, err := mB.Validate(sv, []byte("takes.precedence"), &precedenceX); err != nil {
 			t.Fatal(err)
 		}
-		u := settings.NewUpdater(r)
+		u := settings.NewUpdater(sv)
 		if err := u.Set("local.m", "default.XX", "m"); err != nil {
 			t.Fatal(err)
 		}
 		u.ResetRemaining()
-		if exp, act := "&{default XX}", mB.String(); exp != act {
+		if exp, act := "&{default XX}", mB.String(sv); exp != act {
 			t.Fatalf("wanted %q, got %q", exp, act)
 		}
 	})
 
 	t.Run("defaults", func(t *testing.T) {
-		if expected, actual := false, boolFA.Get(); expected != actual {
+		if expected, actual := false, boolFA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := true, boolTA.Get(); expected != actual {
+		if expected, actual := true, boolTA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "", strFooA.Get(); expected != actual {
+		if expected, actual := "", strFooA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "bar", strBarA.Get(); expected != actual {
+		if expected, actual := "bar", strBarA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "", strVal.Get(); expected != actual {
+		if expected, actual := "", strVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := int64(0), i1A.Get(); expected != actual {
+		if expected, actual := int64(0), i1A.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := int64(5), i2A.Get(); expected != actual {
+		if expected, actual := int64(5), i2A.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := int64(0), iVal.Get(); expected != actual {
+		if expected, actual := int64(0), iVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 5.4, fA.Get(); expected != actual {
+		if expected, actual := 5.4, fA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 5.4, fVal.Get(); expected != actual {
+		if expected, actual := 5.4, fVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := time.Second, dA.Get(); expected != actual {
+		if expected, actual := time.Second, dA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := time.Second, dVal.Get(); expected != actual {
+		if expected, actual := time.Second, dVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := mb, byteSize.Get(); expected != actual {
+		if expected, actual := mb, byteSize.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := mb, byteSizeVal.Get(); expected != actual {
+		if expected, actual := mb, byteSizeVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := int64(1), eA.Get(); expected != actual {
+		if expected, actual := int64(1), eA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "default.-", mA.Get(); expected != actual {
+		if expected, actual := "default.-", mA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})
 
 	t.Run("lookup", func(t *testing.T) {
-		if actual, ok := r.Lookup("i.1"); !ok || i1A != actual {
+		if actual, ok := settings.Lookup("i.1"); !ok || i1A != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", i1A, actual, ok)
 		}
-		if actual, ok := r.Lookup("i.Val"); !ok || iVal != actual {
+		if actual, ok := settings.Lookup("i.Val"); !ok || iVal != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", iVal, actual, ok)
 		}
-		if actual, ok := r.Lookup("f"); !ok || fA != actual {
+		if actual, ok := settings.Lookup("f"); !ok || fA != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", fA, actual, ok)
 		}
-		if actual, ok := r.Lookup("fVal"); !ok || fVal != actual {
+		if actual, ok := settings.Lookup("fVal"); !ok || fVal != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", fVal, actual, ok)
 		}
-		if actual, ok := r.Lookup("d"); !ok || dA != actual {
+		if actual, ok := settings.Lookup("d"); !ok || dA != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", dA, actual, ok)
 		}
-		if actual, ok := r.Lookup("dVal"); !ok || dVal != actual {
+		if actual, ok := settings.Lookup("dVal"); !ok || dVal != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", dVal, actual, ok)
 		}
-		if actual, ok := r.Lookup("e"); !ok || eA != actual {
+		if actual, ok := settings.Lookup("e"); !ok || eA != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", eA, actual, ok)
 		}
-		if actual, ok := r.Lookup("statemachine"); !ok || mA != actual {
+		if actual, ok := settings.Lookup("statemachine"); !ok || mA != actual {
 			t.Fatalf("expected %v, got %v (exists: %v)", mA, actual, ok)
 		}
-		if actual, ok := r.Lookup("dne"); ok {
+		if actual, ok := settings.Lookup("dne"); ok {
 			t.Fatalf("expected nothing, got %v", actual)
 		}
 	})
 
 	t.Run("read and write each type", func(t *testing.T) {
-		u := settings.NewUpdater(r)
+		u := settings.NewUpdater(sv)
 		if expected, actual := 0, changes.boolTA; expected != actual {
 			t.Fatalf("expected %d, got %d", expected, actual)
 		}
@@ -348,55 +357,55 @@ func TestCache(t *testing.T) {
 		}
 		u.ResetRemaining()
 
-		if expected, actual := false, boolTA.Get(); expected != actual {
+		if expected, actual := false, boolTA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := true, boolFA.Get(); expected != actual {
+		if expected, actual := true, boolFA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "baz", strFooA.Get(); expected != actual {
+		if expected, actual := "baz", strFooA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "valid", strVal.Get(); expected != actual {
+		if expected, actual := "valid", strVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := int64(3), i2A.Get(); expected != actual {
+		if expected, actual := int64(3), i2A.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 3.1, fA.Get(); expected != actual {
+		if expected, actual := 3.1, fA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 3.1, fVal.Get(); expected != actual {
+		if expected, actual := 3.1, fVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 2*time.Hour, dA.Get(); expected != actual {
+		if expected, actual := 2*time.Hour, dA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := 2*time.Hour, dVal.Get(); expected != actual {
+		if expected, actual := 2*time.Hour, dVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := int64(2), eA.Get(); expected != actual {
+		if expected, actual := int64(2), eA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := mb*5, byteSize.Get(); expected != actual {
+		if expected, actual := mb*5, byteSize.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := mb*5, byteSizeVal.Get(); expected != actual {
+		if expected, actual := mb*5, byteSizeVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
-		if expected, actual := "default.AB", mA.Get(); expected != actual {
+		if expected, actual := "default.AB", mA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
 		// We didn't change this one, so should still see the default.
-		if expected, actual := "bar", strBarA.Get(); expected != actual {
+		if expected, actual := "bar", strBarA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})
 
 	t.Run("any setting not included in an Updater reverts to default", func(t *testing.T) {
 		{
-			u := settings.NewUpdater(r)
+			u := settings.NewUpdater(sv)
 			if err := u.Set("bool.f", settings.EncodeBool(true), "b"); err != nil {
 				t.Fatal(err)
 			}
@@ -418,12 +427,12 @@ func TestCache(t *testing.T) {
 			u.ResetRemaining()
 		}
 
-		if expected, actual := true, boolFA.Get(); expected != actual {
+		if expected, actual := true, boolFA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 		// If the updater doesn't have a key, e.g. if the setting has been deleted,
 		// Doneing it from the cache.
-		settings.NewUpdater(r).ResetRemaining()
+		settings.NewUpdater(sv).ResetRemaining()
 
 		if expected, actual := 2, changes.boolTA; expected != actual {
 			t.Fatalf("expected %d, got %d", expected, actual)
@@ -433,29 +442,29 @@ func TestCache(t *testing.T) {
 			t.Fatalf("expected %d, got %d", expected, actual)
 		}
 
-		if expected, actual := false, boolFA.Get(); expected != actual {
+		if expected, actual := false, boolFA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
-		if expected, actual := false, boolFA.Get(); expected != actual {
+		if expected, actual := false, boolFA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})
 
 	t.Run("an invalid update to a given setting preserves its previously set value", func(t *testing.T) {
 		{
-			u := settings.NewUpdater(r)
+			u := settings.NewUpdater(sv)
 			if err := u.Set("i.2", settings.EncodeInt(9), "i"); err != nil {
 				t.Fatal(err)
 			}
 			u.ResetRemaining()
 		}
-		before := i2A.Get()
+		before := i2A.Get(sv)
 
 		// Doneing after attempting to set with wrong type preserves the current
 		// value.
 		{
-			u := settings.NewUpdater(r)
+			u := settings.NewUpdater(sv)
 			if err := u.Set("i.2", settings.EncodeBool(false), "b"); !testutils.IsError(err,
 				"setting 'i.2' defined as type i, not b",
 			) {
@@ -464,14 +473,14 @@ func TestCache(t *testing.T) {
 			u.ResetRemaining()
 		}
 
-		if expected, actual := before, i2A.Get(); expected != actual {
+		if expected, actual := before, i2A.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
 		// Doneing after attempting to set with the wrong type preserves the
 		// current value.
 		{
-			u := settings.NewUpdater(r)
+			u := settings.NewUpdater(sv)
 			if err := u.Set("i.2", settings.EncodeBool(false), "i"); !testutils.IsError(err,
 				"strconv.Atoi: parsing \"false\": invalid syntax",
 			) {
@@ -480,15 +489,15 @@ func TestCache(t *testing.T) {
 			u.ResetRemaining()
 		}
 
-		if expected, actual := before, i2A.Get(); expected != actual {
+		if expected, actual := before, i2A.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
 		// Doneing after attempting to set with invalid value preserves the
 		// current value.
-		beforestrVal := strVal.Get()
+		beforestrVal := strVal.Get(sv)
 		{
-			u := settings.NewUpdater(r)
+			u := settings.NewUpdater(sv)
 			if err := u.Set("str.val", "abc2def", "s"); !testutils.IsError(err,
 				"not all runes of abc2def are letters: 2",
 			) {
@@ -496,13 +505,13 @@ func TestCache(t *testing.T) {
 			}
 			u.ResetRemaining()
 		}
-		if expected, actual := beforestrVal, strVal.Get(); expected != actual {
+		if expected, actual := beforestrVal, strVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
-		beforeDVal := dVal.Get()
+		beforeDVal := dVal.Get(sv)
 		{
-			u := settings.NewUpdater(r)
+			u := settings.NewUpdater(sv)
 			if err := u.Set("dVal", settings.EncodeDuration(-time.Hour), "d"); !testutils.IsError(err,
 				"cannot set dVal to a negative duration: -1h0m0s",
 			) {
@@ -510,13 +519,13 @@ func TestCache(t *testing.T) {
 			}
 			u.ResetRemaining()
 		}
-		if expected, actual := beforeDVal, dVal.Get(); expected != actual {
+		if expected, actual := beforeDVal, dVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
-		beforeByteSizeVal := byteSizeVal.Get()
+		beforeByteSizeVal := byteSizeVal.Get(sv)
 		{
-			u := settings.NewUpdater(r)
+			u := settings.NewUpdater(sv)
 			if err := u.Set("byteSize.Val", settings.EncodeInt(-mb), "z"); !testutils.IsError(err,
 				"bytesize cannot be negative",
 			) {
@@ -524,13 +533,13 @@ func TestCache(t *testing.T) {
 			}
 			u.ResetRemaining()
 		}
-		if expected, actual := beforeByteSizeVal, byteSizeVal.Get(); expected != actual {
+		if expected, actual := beforeByteSizeVal, byteSizeVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
-		beforeFVal := fVal.Get()
+		beforeFVal := fVal.Get(sv)
 		{
-			u := settings.NewUpdater(r)
+			u := settings.NewUpdater(sv)
 			if err := u.Set("fVal", settings.EncodeFloat(-1.1), "f"); !testutils.IsError(err,
 				"cannot set fVal to a negative value: -1.1",
 			) {
@@ -538,13 +547,13 @@ func TestCache(t *testing.T) {
 			}
 			u.ResetRemaining()
 		}
-		if expected, actual := beforeFVal, fVal.Get(); expected != actual {
+		if expected, actual := beforeFVal, fVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
-		beforeIVal := iVal.Get()
+		beforeIVal := iVal.Get(sv)
 		{
-			u := settings.NewUpdater(r)
+			u := settings.NewUpdater(sv)
 			if err := u.Set("i.Val", settings.EncodeInt(-1), "i"); !testutils.IsError(err,
 				"int cannot be negative",
 			) {
@@ -552,13 +561,13 @@ func TestCache(t *testing.T) {
 			}
 			u.ResetRemaining()
 		}
-		if expected, actual := beforeIVal, iVal.Get(); expected != actual {
+		if expected, actual := beforeIVal, iVal.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 
-		beforeMarsh := mA.Get()
+		beforeMarsh := mA.Get(sv)
 		{
-			u := settings.NewUpdater(r)
+			u := settings.NewUpdater(sv)
 			if err := u.Set("statemachine", "too.many.dots", "m"); !testutils.IsError(err,
 				"expected two parts",
 			) {
@@ -566,109 +575,16 @@ func TestCache(t *testing.T) {
 			}
 			u.ResetRemaining()
 		}
-		if expected, actual := beforeMarsh, mA.Get(); expected != actual {
+		if expected, actual := beforeMarsh, mA.Get(sv); expected != actual {
 			t.Fatalf("expected %v, got %v", expected, actual)
 		}
 	})
 
-	t.Run("mocks", func(t *testing.T) {
-		{
-			f := settings.TestingSetBool(&boolFA, true)
-			if expected, actual := true, boolFA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-			f()
-			if expected, actual := false, boolFA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-		}
-
-		{
-			f := settings.TestingSetString(&strBarA, "override")
-			if expected, actual := "override", strBarA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-			f()
-			if expected, actual := "bar", strBarA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-		}
-
-		{
-			f := settings.TestingSetInt(&i1A, 64)
-			if expected, actual := int64(64), i1A.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-			f()
-			if expected, actual := int64(0), i1A.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-		}
-
-		{
-			f := settings.TestingSetFloat(&fA, 6.7)
-			if expected, actual := 6.7, fA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-			f()
-			if expected, actual := 5.4, fA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-		}
-
-		{
-			f := settings.TestingSetDuration(&dA, 10*time.Hour)
-			if expected, actual := 10*time.Hour, dA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-			f()
-			if expected, actual := time.Second, dA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-		}
-
-		{
-			f := settings.TestingSetEnum(&eA, 3)
-			if expected, actual := int64(3), eA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-			f()
-			if expected, actual := int64(1), eA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-		}
-
-		{
-			f := settings.TestingSetByteSize(&byteSize, mb*7)
-			if expected, actual := mb*7, byteSize.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-			f()
-			if expected, actual := mb, byteSize.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-		}
-
-		{
-			f := settings.TestingSetStatemachine(&mA, settings.TransformerFn(
-				func(_ []byte, _ *string) ([]byte, interface{}, error) {
-					return []byte("encfoo"), "foo", nil
-				},
-			))
-			if expected, actual := "encfoo", mA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-			f()
-			if expected, actual := "default.-", mA.Get(); expected != actual {
-				t.Fatalf("expected %v, got %v", expected, actual)
-			}
-		}
-	})
 }
 
 func TestHide(t *testing.T) {
 	keys := make(map[string]struct{})
-	for _, k := range r.Keys() {
+	for _, k := range settings.Keys() {
 		keys[k] = struct{}{}
 	}
 	if _, ok := keys["bool.t"]; !ok {

--- a/pkg/settings/string.go
+++ b/pkg/settings/string.go
@@ -15,8 +15,6 @@
 package settings
 
 import (
-	"sync/atomic"
-
 	"github.com/pkg/errors"
 )
 
@@ -25,15 +23,14 @@ import (
 // of type "string" is updated.
 type StringSetting struct {
 	defaultValue string
-	v            atomic.Value
 	validateFn   func(string) error
 	common
 }
 
 var _ Setting = &StringSetting{}
 
-func (s *StringSetting) String() string {
-	return s.Get()
+func (s *StringSetting) String(sv *Values) string {
+	return s.Get(sv)
 }
 
 // Typ returns the short (1 char) string denoting the type of setting.
@@ -42,8 +39,8 @@ func (*StringSetting) Typ() string {
 }
 
 // Get retrieves the string value in the setting.
-func (s *StringSetting) Get() string {
-	loaded := s.v.Load()
+func (s *StringSetting) Get(sv *Values) string {
+	loaded := sv.getGeneric(s.slotIdx)
 	if loaded == nil {
 		return ""
 	}
@@ -60,32 +57,30 @@ func (s *StringSetting) Validate(v string) error {
 	return nil
 }
 
-func (s *StringSetting) set(v string) error {
+func (s *StringSetting) set(sv *Values, v string) error {
 	if err := s.Validate(v); err != nil {
 		return err
 	}
-	if s.Get() == v {
-		return nil
+	if s.Get(sv) != v {
+		sv.setGeneric(s.slotIdx, v)
 	}
-	s.v.Store(v)
-	s.changed()
 	return nil
 }
 
-func (s *StringSetting) setToDefault() {
-	if err := s.set(s.defaultValue); err != nil {
+func (s *StringSetting) setToDefault(sv *Values) {
+	if err := s.set(sv, s.defaultValue); err != nil {
 		panic(err)
 	}
 }
 
 // RegisterStringSetting defines a new setting with type string.
-func (r *Registry) RegisterStringSetting(key, desc string, defaultValue string) *StringSetting {
-	return r.RegisterValidatedStringSetting(key, desc, defaultValue, nil)
+func RegisterStringSetting(key, desc string, defaultValue string) *StringSetting {
+	return RegisterValidatedStringSetting(key, desc, defaultValue, nil)
 }
 
 // RegisterValidatedStringSetting defines a new setting with type string with a
 // validation function.
-func (r *Registry) RegisterValidatedStringSetting(
+func RegisterValidatedStringSetting(
 	key, desc string, defaultValue string, validateFn func(string) error,
 ) *StringSetting {
 	if validateFn != nil {
@@ -97,27 +92,6 @@ func (r *Registry) RegisterValidatedStringSetting(
 		defaultValue: defaultValue,
 		validateFn:   validateFn,
 	}
-	r.register(key, desc, setting)
+	register(key, desc, setting)
 	return setting
-}
-
-// TestingSetString returns a mock, unregistered string setting for testing. See
-// TestingSetBool for more details.
-func TestingSetString(s **StringSetting, v string) func() {
-	saved := *s
-	tmp := &StringSetting{}
-	if err := tmp.set(v); err != nil {
-		panic(err)
-	}
-	*s = tmp
-	return func() {
-		*s = saved
-	}
-}
-
-// OnChange registers a callback to be called when the setting changes.
-// This overrides the `common`` impl to return the concrete impl type.
-func (s *StringSetting) OnChange(fn func()) *StringSetting {
-	s.setOnChange(fn)
-	return s
 }

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -42,8 +42,8 @@ func EncodeFloat(f float64) string {
 }
 
 type updater struct {
-	r Registry
-	m map[string]struct{}
+	sv *Values
+	m  map[string]struct{}
 }
 
 // Updater is a helper for updating the in-memory settings.
@@ -67,16 +67,16 @@ func (u NoopUpdater) Set(_, _, _ string) error { return nil }
 func (u NoopUpdater) ResetRemaining() {}
 
 // NewUpdater makes an Updater.
-func NewUpdater(r Registry) Updater {
+func NewUpdater(sv *Values) Updater {
 	return updater{
-		m: make(map[string]struct{}, len(r)),
-		r: r,
+		m:  make(map[string]struct{}, len(Registry)),
+		sv: sv,
 	}
 }
 
 // Set attempts to parse and update a setting and notes that it was updated.
 func (u updater) Set(key, rawValue string, vt string) error {
-	d, ok := u.r[key]
+	d, ok := Registry[key]
 	if !ok {
 		// Likely a new setting this old node doesn't know about.
 		return errors.Errorf("unknown setting '%s'", key)
@@ -90,49 +90,49 @@ func (u updater) Set(key, rawValue string, vt string) error {
 
 	switch setting := d.(type) {
 	case *StringSetting:
-		return setting.set(rawValue)
+		return setting.set(u.sv, rawValue)
 	case *BoolSetting:
 		b, err := strconv.ParseBool(rawValue)
 		if err != nil {
 			return err
 		}
-		setting.set(b)
+		setting.set(u.sv, b)
 		return nil
 	case numericSetting:
 		i, err := strconv.Atoi(rawValue)
 		if err != nil {
 			return err
 		}
-		return setting.set(int64(i))
+		return setting.set(u.sv, int64(i))
 	case *FloatSetting:
 		f, err := strconv.ParseFloat(rawValue, 64)
 		if err != nil {
 			return err
 		}
-		return setting.set(f)
+		return setting.set(u.sv, f)
 	case *DurationSetting:
 		d, err := time.ParseDuration(rawValue)
 		if err != nil {
 			return err
 		}
-		return setting.set(d)
+		return setting.set(u.sv, d)
 	case *EnumSetting:
 		i, err := strconv.Atoi(rawValue)
 		if err != nil {
 			return err
 		}
-		return setting.set(int64(i))
+		return setting.set(u.sv, int64(i))
 	case *StateMachineSetting:
-		return setting.set([]byte(rawValue))
+		return setting.set(u.sv, []byte(rawValue))
 	}
 	return nil
 }
 
 // ResetRemaining sets all settings not updated by the updater to their default values.
 func (u updater) ResetRemaining() {
-	for k, v := range u.r {
+	for k, v := range Registry {
 		if _, ok := u.m[k]; !ok {
-			v.setToDefault()
+			v.setToDefault(u.sv)
 		}
 	}
 }

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -147,7 +147,7 @@ func TestAmbiguousCommit(t *testing.T) {
 			for _, server := range tc.Servers {
 				st := server.ClusterSettings()
 				st.Manual.Store(true)
-				st.DistSQLClusterExecMode.Override(int64(cluster.DistSQLOff))
+				sql.DistSQLClusterExecMode.Override(&st.SV, int64(sql.DistSQLOff))
 			}
 
 			sqlDB := tc.Conns[0]

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -160,8 +160,8 @@ func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 		defer log.Infof(ctx, "exiting hash joiner run")
 	}
 
-	useTempStorage := (h.flowCtx.Settings.DistSQLUseTempStorage.Get() &&
-		h.flowCtx.Settings.DistSQLUseTempStorageJoins.Get()) ||
+	st := h.flowCtx.Settings
+	useTempStorage := (distSQLUseTempStorage.Get(&st.SV) && distSQLUseTempStorageJoins.Get(&st.SV)) ||
 		h.flowCtx.testingKnobs.MemoryLimitBytes > 0 ||
 		h.testingKnobMemFailPoint != unset
 	rowContainerMon := h.flowCtx.EvalCtx.Mon

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -686,7 +686,7 @@ func TestHashJoinerDrain(t *testing.T) {
 	// Since the use of external storage overrides h.initialBufferSize, disable
 	// it for this test.
 	settings := cluster.MakeTestingClusterSettings()
-	settings.DistSQLSettings.DistSQLUseTempStorage.Override(false)
+	distSQLUseTempStorage.Override(&settings.SV, false)
 	flowCtx := FlowCtx{Settings: settings, EvalCtx: evalCtx}
 
 	post := PostProcessSpec{Projection: true, OutputColumns: outCols}

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
@@ -74,6 +75,24 @@ const Version DistSQLVersion = 5
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.
 const MinAcceptedVersion DistSQLVersion = 4
+
+var distSQLUseTempStorage = settings.RegisterBoolSetting(
+	"sql.defaults.distsql.tempstorage",
+	"set to true to enable use of disk for larger distributed sql queries",
+	true,
+)
+
+var distSQLUseTempStorageSorts = settings.RegisterBoolSetting(
+	"sql.defaults.distsql.tempstorage.sorts",
+	"set to true to enable use of disk for distributed sql sorts. sql.defaults.distsql.tempstorage must be true",
+	true,
+)
+
+var distSQLUseTempStorageJoins = settings.RegisterBoolSetting(
+	"sql.defaults.distsql.tempstorage.joins",
+	"set to true to enable use of disk for distributed sql joins. sql.defaults.distsql.tempstorage must be true",
+	true,
+)
 
 // workMemBytes specifies the maximum amount of memory in bytes a processor can
 // use. This limit is only observed if the use of temporary storage is enabled

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -96,8 +96,8 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 	var sv memRowContainer
 	// Enable fall back to disk if the cluster setting is set or a memory limit
 	// has been set through testing.
-	useTempStorage := (s.flowCtx.Settings.DistSQLUseTempStorage.Get() &&
-		s.flowCtx.Settings.DistSQLUseTempStorageSorts.Get()) ||
+	st := s.flowCtx.Settings
+	useTempStorage := (distSQLUseTempStorage.Get(&st.SV) && distSQLUseTempStorageSorts.Get(&st.SV)) ||
 		s.testingKnobMemLimit > 0
 	rowContainerMon := s.flowCtx.EvalCtx.Mon
 	if s.matchLen == 0 && s.count == 0 && useTempStorage {

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -715,11 +715,11 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 		); err != nil {
 			t.Fatal(err)
 		}
-		wantedMode := cluster.DistSQLExecModeFromString(cfg.overrideDistSQLMode) // off => 0, etc
+		wantedMode := sql.DistSQLExecModeFromString(cfg.overrideDistSQLMode) // off => 0, etc
 		// Wait until all servers are aware of the setting.
 		testutils.SucceedsSoon(t.t, func() error {
 			for i := 0; i < t.cluster.NumServers(); i++ {
-				var m cluster.DistSQLExecMode
+				var m sql.DistSQLExecMode
 				err := t.cluster.ServerConn(i % t.cluster.NumServers()).QueryRow(
 					"SHOW CLUSTER SETTING sql.defaults.distsql",
 				).Scan(&m)

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -199,10 +198,10 @@ func (t *parallelTest) setup(spec *parTestSpec) {
 
 	for i := 0; i < t.cluster.NumServers(); i++ {
 		server := t.cluster.Server(i)
-		mode := cluster.DistSQLOff
+		mode := sql.DistSQLOff
 		st := server.ClusterSettings()
 		st.Manual.Store(true)
-		st.DistSQLClusterExecMode.Override(int64(mode))
+		sql.DistSQLClusterExecMode.Override(&st.SV, int64(mode))
 	}
 
 	t.clients = make([][]*gosql.DB, spec.ClusterSize)

--- a/pkg/sql/monotonic_insert_test.go
+++ b/pkg/sql/monotonic_insert_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -80,14 +80,14 @@ type mtClient struct {
 func TestMonotonicInserts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	for _, distSQLMode := range []cluster.DistSQLExecMode{cluster.DistSQLOff, cluster.DistSQLOn} {
+	for _, distSQLMode := range []sql.DistSQLExecMode{sql.DistSQLOff, sql.DistSQLOn} {
 		t.Run(fmt.Sprintf("distsql=%s", distSQLMode), func(t *testing.T) {
 			testMonotonicInserts(t, distSQLMode)
 		})
 	}
 }
 
-func testMonotonicInserts(t *testing.T, distSQLMode cluster.DistSQLExecMode) {
+func testMonotonicInserts(t *testing.T, distSQLMode sql.DistSQLExecMode) {
 	defer leaktest.AfterTest(t)()
 
 	if testing.Short() {
@@ -107,7 +107,7 @@ func testMonotonicInserts(t *testing.T, distSQLMode cluster.DistSQLExecMode) {
 	for _, server := range tc.Servers {
 		st := server.ClusterSettings()
 		st.Manual.Store(true)
-		st.DistSQLClusterExecMode.Override(int64(distSQLMode))
+		sql.DistSQLClusterExecMode.Override(&st.SV, int64(distSQLMode))
 	}
 
 	var clients []mtClient

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -56,7 +56,8 @@ func (p *planner) ShowClusterSetting(
 			"TABLE crdb_internal.cluster_settings", nil, nil)
 	}
 
-	val, ok := p.session.execCfg.Settings.Registry.Lookup(name)
+	st := p.session.execCfg.Settings
+	val, ok := settings.Lookup(name)
 	if !ok {
 		return nil, errors.Errorf("unknown setting: %q", name)
 	}
@@ -84,9 +85,9 @@ func (p *planner) ShowClusterSetting(
 			d := parser.DNull
 			switch s := val.(type) {
 			case *settings.IntSetting:
-				d = parser.NewDInt(parser.DInt(s.Get()))
+				d = parser.NewDInt(parser.DInt(s.Get(&st.SV)))
 			case *settings.StringSetting:
-				d = parser.NewDString(s.String())
+				d = parser.NewDString(s.String(&st.SV))
 			case *settings.StateMachineSetting:
 				// Show consistent values for statemachine settings. This isn't necessary
 				// for correctness, but helpful for testability.
@@ -114,21 +115,21 @@ func (p *planner) ShowClusterSetting(
 				// value, and the corresponding sql migration that makes sure
 				// the above select finds something usually runs pretty quickly
 				// when the cluster is bootstrapped.
-				_, obj, err := s.Validate(prevRawVal, nil)
+				_, obj, err := s.Validate(&st.SV, prevRawVal, nil)
 				if err != nil {
 					return nil, errors.Errorf("unable to read existing value: %s", err)
 				}
 				d = parser.NewDString(obj.(fmt.Stringer).String())
 			case *settings.BoolSetting:
-				d = parser.MakeDBool(parser.DBool(s.Get()))
+				d = parser.MakeDBool(parser.DBool(s.Get(&st.SV)))
 			case *settings.FloatSetting:
-				d = parser.NewDFloat(parser.DFloat(s.Get()))
+				d = parser.NewDFloat(parser.DFloat(s.Get(&st.SV)))
 			case *settings.DurationSetting:
-				d = &parser.DInterval{Duration: duration.Duration{Nanos: s.Get().Nanoseconds()}}
+				d = &parser.DInterval{Duration: duration.Duration{Nanos: s.Get(&st.SV).Nanoseconds()}}
 			case *settings.EnumSetting:
-				d = parser.NewDInt(parser.DInt(s.Get()))
+				d = parser.NewDInt(parser.DInt(s.Get(&st.SV)))
 			case *settings.ByteSizeSetting:
-				d = parser.NewDString(s.String())
+				d = parser.NewDString(s.String(&st.SV))
 			}
 
 			v := p.newContainerValuesNode(columns, 0)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -23,7 +23,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -195,13 +194,13 @@ var varGen = map[string]sessionVar{
 			}
 			switch strings.ToLower(s) {
 			case "off":
-				session.DistSQLMode = cluster.DistSQLOff
+				session.DistSQLMode = DistSQLOff
 			case "on":
-				session.DistSQLMode = cluster.DistSQLOn
+				session.DistSQLMode = DistSQLOn
 			case "auto":
-				session.DistSQLMode = cluster.DistSQLAuto
+				session.DistSQLMode = DistSQLAuto
 			case "always":
-				session.DistSQLMode = cluster.DistSQLAlways
+				session.DistSQLMode = DistSQLAlways
 			default:
 				return fmt.Errorf("set distsql: \"%s\" not supported", s)
 			}
@@ -212,7 +211,7 @@ var varGen = map[string]sessionVar{
 			return session.DistSQLMode.String()
 		},
 		Reset: func(session *Session) error {
-			session.DistSQLMode = cluster.DistSQLExecMode(session.execCfg.Settings.DistSQLClusterExecMode.Get())
+			session.DistSQLMode = DistSQLExecMode(DistSQLClusterExecMode.Get(&session.execCfg.Settings.SV))
 			return nil
 		},
 	},

--- a/pkg/storage/allocator_scorer_test.go
+++ b/pkg/storage/allocator_scorer_test.go
@@ -781,7 +781,7 @@ func TestBalanceScore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	st := cluster.MakeTestingClusterSettings()
-	st.EnableStatsBasedRebalancing.Override(true)
+	EnableStatsBasedRebalancing.Override(&st.SV, true)
 
 	storeList := StoreList{
 		candidateRanges:          stat{mean: 1000},
@@ -943,7 +943,7 @@ func TestRebalanceConvergesOnMean(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	st := cluster.MakeTestingClusterSettings()
-	st.EnableStatsBasedRebalancing.Override(true)
+	EnableStatsBasedRebalancing.Override(&st.SV, true)
 
 	const diskCapacity = 2000
 	storeList := StoreList{

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -48,7 +48,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -666,13 +665,13 @@ func (m *multiTestContext) populateDB(idx int, stopper *stop.Stopper) {
 }
 
 func (m *multiTestContext) populateStorePool(idx int, nodeLiveness *storage.NodeLiveness) {
+	storage.TimeUntilStoreDead.Override(&m.storeConfig.Settings.SV, m.timeUntilStoreDead)
 	m.storePools[idx] = storage.NewStorePool(
 		log.AmbientContext{Tracer: m.storeConfig.Settings.Tracer},
 		m.storeConfig.Settings,
 		m.gossips[idx],
 		m.clock,
 		storage.MakeStorePoolNodeLivenessFunc(nodeLiveness),
-		settings.TestingDuration(m.timeUntilStoreDead),
 		/* deterministic */ false,
 	)
 }

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -27,8 +27,8 @@ import (
 func setupMVCCRocksDB(b testing.TB, dir string) Engine {
 	rocksdb, err := NewRocksDB(
 		RocksDBConfig{
-			RocksDBSettings: cluster.MakeTestingClusterSettings().RocksDBSettings,
-			Dir:             dir,
+			Settings: cluster.MakeTestingClusterSettings(),
+			Dir:      dir,
 		},
 		RocksDBCache{},
 	)

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -261,8 +261,8 @@ func openRocksDBWithVersion(t *testing.T, hasVersionFile bool, ver Version) erro
 
 	rocksdb, err := NewRocksDB(
 		RocksDBConfig{
-			RocksDBSettings: cluster.MakeTestingClusterSettings().RocksDBSettings,
-			Dir:             dir,
+			Settings: cluster.MakeTestingClusterSettings(),
+			Dir:      dir,
 		},
 		RocksDBCache{},
 	)
@@ -388,8 +388,8 @@ func TestConcurrentBatch(t *testing.T) {
 
 	db, err := NewRocksDB(
 		RocksDBConfig{
-			RocksDBSettings: cluster.MakeTestingClusterSettings().RocksDBSettings,
-			Dir:             dir,
+			Settings: cluster.MakeTestingClusterSettings(),
+			Dir:      dir,
 		},
 		RocksDBCache{},
 	)
@@ -577,8 +577,8 @@ func TestRocksDBTimeBound(t *testing.T) {
 
 	rocksdb, err := NewRocksDB(
 		RocksDBConfig{
-			RocksDBSettings: cluster.MakeTestingClusterSettings().RocksDBSettings,
-			Dir:             dir,
+			Settings: cluster.MakeTestingClusterSettings(),
+			Dir:      dir,
 		},
 		RocksDBCache{},
 	)

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -45,11 +45,11 @@ func NewTempEngine(ctx context.Context, storeCfg base.StoreSpec) (Engine, error)
 	st := cluster.MakeClusterSettings(cluster.BinaryServerVersion, cluster.BinaryServerVersion)
 
 	rocksDBCfg := RocksDBConfig{
-		RocksDBSettings: st.RocksDBSettings,
-		Attrs:           roachpb.Attributes{},
-		Dir:             storeCfg.Path,
-		MaxSizeBytes:    0,   // TODO(arjun): Revisit this.
-		MaxOpenFiles:    128, // TODO(arjun): Revisit this.
+		Settings:     st,
+		Attrs:        roachpb.Attributes{},
+		Dir:          storeCfg.Path,
+		MaxSizeBytes: 0,   // TODO(arjun): Revisit this.
+		MaxOpenFiles: 128, // TODO(arjun): Revisit this.
 	}
 	rocksDBCache := NewRocksDBCache(0)
 	rocksdb, err := NewRocksDB(rocksDBCfg, rocksDBCache)

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -216,6 +215,7 @@ func (s *Store) ReservationCount() int {
 }
 
 func NewTestStorePool(cfg StoreConfig) *StorePool {
+	TimeUntilStoreDead.Override(&cfg.Settings.SV, TestTimeUntilStoreDeadOff)
 	return NewStorePool(
 		cfg.AmbientCtx,
 		cfg.Settings,
@@ -224,7 +224,6 @@ func NewTestStorePool(cfg StoreConfig) *StorePool {
 		func(roachpb.NodeID, time.Time, time.Duration) nodeStatus {
 			return nodeStatusLive
 		},
-		settings.TestingDuration(TestTimeUntilStoreDeadOff),
 		/* deterministic */ false,
 	)
 }

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -806,7 +806,7 @@ func (r *Replica) applySnapshot(
 	}
 
 	// We've written Raft log entries, so we need to sync the WAL.
-	if err := batch.Commit(r.store.cfg.Settings.SyncRaftLog.Get()); err != nil {
+	if err := batch.Commit(syncRaftLog.Get(&r.store.cfg.Settings.SV)); err != nil {
 		return err
 	}
 	stats.commit = timeutil.Now()

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -33,7 +33,7 @@ const bulkIOWriteLimiterLongWait = 500 * time.Millisecond
 
 func limitBulkIOWrite(ctx context.Context, st *cluster.Settings, cost int) {
 	// The limiter disallows anything greater than its burst (set to
-	// bulkIOWriteLimiterBurst), so cap the batch size if it would overflow.
+	// BulkIOWriteLimiterBurst), so cap the batch size if it would overflow.
 	//
 	// TODO(dan): This obviously means the limiter is no longer accounting for
 	// the full cost. I've tried calling WaitN in a loop to fully cover the

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8567,12 +8567,12 @@ func TestCommandTooLarge(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 	tc.Start(t, stopper)
 
-	tc.store.cfg.Settings.Manual.Store(true)
-	maxCommandSize := tc.store.cfg.Settings.MaxCommandSize
-	maxCommandSize.Override(1024)
+	st := tc.store.cfg.Settings
+	st.Manual.Store(true)
+	MaxCommandSize.Override(&st.SV, 1024)
 
 	args := putArgs(roachpb.Key("k"),
-		[]byte(strings.Repeat("a", int(maxCommandSize.Get()))))
+		[]byte(strings.Repeat("a", int(MaxCommandSize.Get(&st.SV)))))
 	if _, pErr := tc.SendWrapped(&args); !testutils.IsPError(pErr, "command is too large") {
 		t.Fatalf("did not get expected error: %v", pErr)
 	}

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -60,7 +60,7 @@ func TestReplicateQueueRebalance(t *testing.T) {
 	for _, server := range tc.Servers {
 		st := server.ClusterSettings()
 		st.Manual.Store(true)
-		st.EnableStatsBasedRebalancing.Override(false)
+		storage.EnableStatsBasedRebalancing.Override(&st.SV, false)
 	}
 
 	const newRanges = 5

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -134,13 +133,13 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 		active,
 		renewal,
 	)
+	storage.TimeUntilStoreDead.Override(&cfg.Settings.SV, storage.TestTimeUntilStoreDead)
 	cfg.StorePool = storage.NewStorePool(
 		cfg.AmbientCtx,
 		cfg.Settings,
 		cfg.Gossip,
 		cfg.Clock,
 		storage.MakeStorePoolNodeLivenessFunc(cfg.NodeLiveness),
-		settings.TestingDuration(storage.TestTimeUntilStoreDead),
 		/* deterministic */ false,
 	)
 	cfg.Transport = transport

--- a/pkg/util/log/crash_reporting_packet_test.go
+++ b/pkg/util/log/crash_reporting_packet_test.go
@@ -49,7 +49,7 @@ func TestCrashReportingPacket(t *testing.T) {
 
 	st := cluster.MakeTestingClusterSettings()
 	// Enable all crash-reporting settings.
-	st.DiagnosticsReportingEnabled.Override(true)
+	log.DiagnosticsReportingEnabled.Override(&st.SV, true)
 
 	defer log.TestingSetCrashReportingURL("https://ignored:ignored@ignored/ignored")()
 
@@ -74,13 +74,13 @@ func TestCrashReportingPacket(t *testing.T) {
 
 	func() {
 		defer expectPanic("before server start")
-		defer log.RecoverAndReportPanic(ctx, st)
+		defer log.RecoverAndReportPanic(ctx, &st.SV)
 		panic("oh te noes!")
 	}()
 
 	func() {
 		defer expectPanic("after server start")
-		defer log.RecoverAndReportPanic(ctx, st)
+		defer log.RecoverAndReportPanic(ctx, &st.SV)
 		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 		s.Stopper().Stop(ctx)
 		panic("oh te noes!")

--- a/pkg/util/log/main_test.go
+++ b/pkg/util/log/main_test.go
@@ -21,27 +21,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
-type dummyReportingSettings struct {
-	diagnosticsReportingEnabled, crashReportsEnabled bool
-}
-
-func (d dummyReportingSettings) HasDiagnosticsReportingEnabled() bool {
-	return d.diagnosticsReportingEnabled
-}
-func (d dummyReportingSettings) HasCrashReportsEnabled() bool {
-	return d.crashReportsEnabled
-}
-
 func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	security.SetAssetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
-	f := log.ReportingSettings(dummyReportingSettings{})
-	log.ReportingSettingsSingleton.Store(&f)
+
+	// MakeTestingClusterSettings initializes log.ReportingSettings to this
+	// instance of setting values.
+	st := cluster.MakeTestingClusterSettings()
+	log.DiagnosticsReportingEnabled.Override(&st.SV, false)
+	log.CrashReports.Override(&st.SV, false)
+
 	os.Exit(m.Run())
 }

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -22,6 +22,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	otlog "github.com/opentracing/opentracing-go/log"
 )
@@ -151,8 +152,8 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 
 		// We load the ReportingSettings from the a global singleton in this
 		// call path. See the singleton's comment for a rationale.
-		if reportingSettings, ok := (ReportingSettingsSingleton.Load()).(*ReportingSettings); ok {
-			sendCrashReport(ctx, *reportingSettings, reportable, depth+1)
+		if sv, ok := (ReportingSettingsSingleton.Load()).(*settings.Values); ok {
+			sendCrashReport(ctx, sv, reportable, depth+1)
 		}
 	}
 	// MakeMessage already added the tags when forming msg, we don't want

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -176,8 +177,8 @@ func (s *Stopper) Recover(ctx context.Context) {
 		}
 		// FIXME(tschottdorf): should find a way to plumb ReportingSettings here.
 		// Certainly the Stopper could hold them.
-		if reportingSettings, ok := (log.ReportingSettingsSingleton.Load()).(*log.ReportingSettings); ok {
-			log.ReportPanic(ctx, *reportingSettings, r, 1)
+		if sv, ok := (log.ReportingSettingsSingleton.Load()).(*settings.Values); ok {
+			log.ReportPanic(ctx, sv, r, 1)
 		}
 		panic(r)
 	}


### PR DESCRIPTION
This change moves back the registration of cluster setting to global statements
in the appropriate packages while retaining the benefits achieved by #17486.

We separate the immutable aspects of a setting (like description, default value)
from the mutable aspect (current value). The Setting now represents the
immutable aspect; the values are stored in a separate container
`settings.Values`. Each setting has a corresponding "slot" in the container;
this mapping is static. Each server has its own values container (part of
`cluster.Settings`). Of course, we now have to pass a reference to this
container wherever we get or set a setting.

Fixes #17512.