### PR TITLE
sql: put parallel stmts behind environment variable in v1.0 

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1194,6 +1194,14 @@ func (e *Executor) execStmtInOpenTxn(
 	// execution. If neither of these cases are true, we need to synchronize
 	// parallel execution by letting it drain before we can begin executing ourselves.
 	parallelize := IsStmtParallelized(stmt)
+	if parallelize {
+		if !enableParallelStmts {
+			return Result{}, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError,
+				"parallel statement execution is disabled by default until v1.1. "+
+					"use the environment variable `COCKROACH_ENABLE_PARALLEL_STMTS` to override")
+		}
+	}
+
 	_, independentFromParallelStmts := stmt.(parser.IndependentFromParallelizedPriors)
 	if !(parallelize || independentFromParallelStmts) {
 		if err := session.parallelizeQueue.Wait(); err != nil {

--- a/pkg/sql/logic_test.go
+++ b/pkg/sql/logic_test.go
@@ -1337,6 +1337,7 @@ func (t *logicTest) runFile(path string, config testClusterConfig) {
 
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer sql.TestingEnableParallelStmts()()
 
 	if testutils.Stress() {
 		t.Skip()

--- a/pkg/sql/parallel_stmts.go
+++ b/pkg/sql/parallel_stmts.go
@@ -23,9 +23,26 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
+
+// enableParallelStmts can be used to enable parallel statement
+// execution. Parallel statement execution was known to be buggy
+// in Cockroach 1.0. This was fixed in #17627, but the fix was
+// too big to cherry-pick back into v1.0.
+var enableParallelStmts = envutil.EnvOrDefaultBool(
+	"COCKROACH_ENABLE_PARALLEL_STMTS", false)
+
+// TestingEnableParallelStmts enables parallel statement execution.
+// It returns a function that disables the feature again.
+func TestingEnableParallelStmts() func() {
+	enableParallelStmts = true
+	return func() {
+		enableParallelStmts = false
+	}
+}
 
 // ParallelizeQueue maintains a set of planNodes running with parallelized execution.
 // Parallelized execution means that multiple statements run asynchronously, with

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -439,3 +439,22 @@ func TestSpanBasedDependencyAnalyzer(t *testing.T) {
 		}
 	}
 }
+
+func TestParallelStmtsDisabled(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	if _, err := db.Exec(`CREATE DATABASE test`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE test.foo (k INT PRIMARY KEY)`); err != nil {
+		t.Fatal(err)
+	}
+
+	expectErr := "parallel statement execution is disabled by default until v1.1"
+	_, err := db.Exec(`INSERT INTO test.foo VALUES (1) RETURNING NOTHING`)
+	if !testutils.IsError(err, expectErr) {
+		t.Fatalf("expected error %q, found %v", expectErr, err)
+	}
+}


### PR DESCRIPTION
Parallel statements were not safe for general use because of their
behavior when confronted with retryable errors. This was fixed in #17627,
but the fix is too big to cherry-pick back into v1.0.