### PR TITLE
sql: scope ResultsGroup's as SQL transactions

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -505,7 +505,7 @@ func (c *cliState) refreshTransactionStatus() {
 	case sql.RestartWait.String():
 		c.lastKnownTxnStatus = " RETRY"
 	case sql.Open.String():
-		// The state FirstBatch is reported by the server as Open, so no need to
+		// The state AutoRetry is reported by the server as Open, so no need to
 		// handle it here.
 		c.lastKnownTxnStatus = "  OPEN"
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -214,7 +214,7 @@ func (dsp *distSQLPlanner) Run(
 	return nil
 }
 
-// distSQLReceiver is a RowReceiver that sends results to a StatementResultWriter.
+// distSQLReceiver is a RowReceiver that writes results to a rowResultWriter.
 // This is where the DistSQL execution meets the SQL Session - the RowContainer
 // comes from a client Session.
 //
@@ -260,8 +260,8 @@ type distSQLReceiver struct {
 	updateClock func(observedTs hlc.Timestamp)
 }
 
-// rowResultWriter is a subset of StatementResultWriter for use in the
-// distSQLReceiver -- also implemented bufferedRowWriter as a one off.
+// rowResultWriter is a subset of StatementResult to be used with the
+// distSQLReceiver. It's implemented by RowResultWriter.
 type rowResultWriter interface {
 	// AddRow takes the passed in row and adds it to the current result.
 	AddRow(ctx context.Context, row parser.Datums) error

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -308,8 +308,8 @@ type ExecutorTestingKnobs struct {
 	// for the new metadata to back-propagate through gossip.
 	WaitForGossipUpdate bool
 
-	// CheckStmtStringChange causes Executor.execStmtsInCurrentTxn to verify
-	// that executed statements are not modified during execution.
+	// CheckStmtStringChange causes Executor.execStmtGroup to verify that executed
+	// statements are not modified during execution.
 	CheckStmtStringChange bool
 
 	// StatementFilter can be used to trap execution of SQL statements and
@@ -747,7 +747,8 @@ func (e *Executor) execRequest(
 	return e.execParsed(session, stmts, pinfo, copymsg)
 }
 
-// execParsed returns query execution errors and communication errors.
+// execParsed executes a batch of statements received as a unit from the client
+// and returns query execution errors and communication errors.
 func (e *Executor) execParsed(
 	session *Session, stmts StatementList, pinfo *parser.PlaceholderInfo, copymsg copyMsg,
 ) error {
@@ -764,10 +765,6 @@ func (e *Executor) execParsed(
 		// Each iteration consumes a transaction's worth of statements. Any error
 		// that is encountered resets stmts.
 
-		// TODO(andrei): NewResultsGroup() should only be called if inTxn == false.
-		// Also, we're currently not always closing this txnResults, which is
-		// against the contract.
-		txnResults := resultWriter.NewResultsGroup()
 		inTxn := txnState.State() != NoTxn
 		execOpt := client.TxnExecOptions{}
 		// Figure out the statements out of which we're going to try to consume
@@ -777,9 +774,9 @@ func (e *Executor) execParsed(
 		// If protoTS is set, the transaction proto sets its Orig and Max timestamps
 		// to it each retry.
 		var protoTS *hlc.Timestamp
-		// We can AutoRetry the next batch of statements if we're in a clean state
-		// (i.e. the next statements we're going to see are the first statements in
-		// a transaction).
+		// If we're not in a transaction, then the next statement is part of a new
+		// transaction (implicit txn or explicit txn). We do the corresponding state
+		// reset.
 		if !inTxn {
 			// Detect implicit transactions - they need to be autocommitted.
 			if _, isBegin := stmts[0].AST.(*parser.BeginTransaction); !isBegin {
@@ -808,11 +805,9 @@ func (e *Executor) execParsed(
 				session.DefaultIsolationLevel,
 				roachpb.NormalUserPriority,
 			)
-		} else {
-			// If we are in a txn, the first batch get auto-retried.
-			txnState.autoRetry = txnState.State() == FirstBatch
 		}
-		execOpt.AutoRetry = txnState.autoRetry
+		execOpt.AutoRetry = txnState.State() == AutoRetry
+
 		if txnState.State() == NoTxn {
 			panic("we failed to initialize a txn")
 		}
@@ -837,11 +832,11 @@ func (e *Executor) execParsed(
 			}
 
 			// Some results may have been produced by a previous attempt.
-			txnResults.Reset(session.Ctx())
+			txnState.txnResults.Reset(session.Ctx())
 			var err error
 			remainingStmts, err = runTxnAttempt(
-				e, session, stmtsToExec, pinfo, origState, opt,
-				!inTxn /* txnPrefix */, avoidCachedDescriptors, automaticRetryCount, txnResults)
+				e, session, stmtsToExec, pinfo, origState,
+				!inTxn /* txnPrefix */, avoidCachedDescriptors, automaticRetryCount, txnState.txnResults)
 
 			// TODO(andrei): Until #7881 fixed.
 			if err == nil && txnState.State() == Aborted {
@@ -863,9 +858,8 @@ func (e *Executor) execParsed(
 		// This is where the magic happens - we ask db to run a KV txn and possibly retry it.
 		txn := txnState.mu.txn // this might be nil if the txn was already aborted.
 		err := txn.Exec(session.Ctx(), execOpt, txnClosure)
-
 		if err != nil && (log.V(2) || logStatementsExecuteEnabled.Get(&e.cfg.Settings.SV)) {
-			log.Infof(session.Ctx(), "execParsed: error: %v", err)
+			log.Infof(session.Ctx(), "execParsed: error: %v. state: %s", err, txnState.State())
 		}
 
 		// Update the Err field of the last result if the error was coming from
@@ -922,7 +916,6 @@ func (e *Executor) execParsed(
 		// If we're no longer in a transaction, finish the trace.
 		if txnState.State() == NoTxn {
 			txnState.finishSQLTxn(session)
-			txnResults.Close()
 		}
 
 		// Verify that the metadata callback fails, if one was set. This is
@@ -987,24 +980,38 @@ func (e *Executor) execParsed(
 	return nil
 }
 
-// runTxnAttempt is used in the closure we pass to txn.Exec(). It
-// will be called possibly multiple times (if opt.AutoRetry is set).
+// runTxnAttempt is used in the closure we pass to txn.Exec(). It will be called
+// possibly multiple times with the same set to statements.
+// It takes in a batch of statements and executes a prefix of them corresponding
+// to one transaction. More technically, it runs them one by one until either:
+// - a statement returns an error
+// - the end of the the batch is reached
+// - a statement transition the state to a non-"open" one, meaning that we're
+// not in a transaction any more (or we are in a transaction but in an error
+// state, although this also triggers the error condition above).
 //
-// txnPrefix: set if the statements represent the first batch of statements in a
-// 	txn. Used to trap nested BEGINs.
-// txnResults: used to pass query results to the caller.
+// This method may transition the state from AutoRetry to Open if the end of the
+// batch is reached.
+//
+// Args:
+// txnPrefix: set if the start of the batch corresponds to the start of the
+// current transaction. Used to trap nested BEGINs.
+// txnResults: used to push query results.
+//
+// It returns all the statements that were not executed.
 func runTxnAttempt(
 	e *Executor,
 	session *Session,
 	stmts StatementList,
 	pinfo *parser.PlaceholderInfo,
 	origState TxnStateEnum,
-	opt *client.TxnExecOptions,
 	txnPrefix bool,
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
 	txnResults ResultsGroup,
 ) (StatementList, error) {
+
+	txnState := &session.TxnState
 
 	// Ignore the state that might have been set by a previous try of this
 	// closure. By putting these modifications to txnState behind the
@@ -1012,173 +1019,191 @@ func runTxnAttempt(
 	// statements are still executing and reading from the state. This
 	// means that no synchronization is necessary to prevent data races.
 	if automaticRetryCount > 0 {
-		session.TxnState.SetState(origState)
-		session.TxnState.commitSeen = false
+		txnState.SetState(origState)
+		txnState.commitSeen = false
 	}
 
-	remainingStmts, err := e.execStmtsInCurrentTxn(
-		session, stmts, pinfo,
-		txnPrefix, avoidCachedDescriptors, automaticRetryCount, txnResults)
+	// Keep track of whether we've seen any statement that will force us to
+	// transition from AutoRetry to Open at the end of the batch (assuming we are
+	// currently in AutoRetry and we get to the end of the batch, both of which
+	// may not hold).
+	encounteredNonAutoRetryStmt := false
+	var i int
+	var stmt Statement
+	for i, stmt = range stmts {
+		encounteredNonAutoRetryStmt = encounteredNonAutoRetryStmt || !canStayInAutoRetryState(stmt)
 
-	if opt.AutoCommit && len(remainingStmts) > 0 {
-		panic("implicit txn failed to execute all stmts")
-	}
-	return remainingStmts, err
-}
-
-// execStmtsInCurrentTxn consumes a prefix of stmts, namely the
-// statements belonging to a single SQL transaction. It executes in
-// the session's current transaction, which is assumed to exist.
-//
-// COMMIT/ROLLBACK statements can end the current transaction. If that happens,
-// this method returns, and the remaining statements are returned.
-//
-// If an error occurs while executing a statement, the SQL txn will be
-// considered aborted and subsequent statements will be discarded (they will
-// not be executed, they will not be returned for future execution, they will
-// not generate results). Note that this also includes COMMIT/ROLLBACK
-// statements. Further note that errTransactionAborted is no exception -
-// encountering it will discard subsequent statements. This means that, to
-// recover from an aborted txn, a COMMIT/ROLLBACK statement needs to be the
-// first one in stmts.
-//
-// Args:
-// session: the session to execute the statement in.
-// stmts: the semicolon-separated list of statements to execute.
-// pinfo: the placeholders to use in the statements.
-// txnPrefix: set if the statements represent the first batch of statements in a
-// 	txn. Used to trap nested BEGINs.
-// avoidCachedDescriptors: set if the statement execution should avoid
-//  using cached descriptors.
-// automaticRetryCount: increases with each retry; 0 for the first attempt.
-// txnResults: used to pass query results to the caller.
-//
-// Returns:
-//  - the statements that haven't been executed because the transaction has
-//    been committed or rolled back. In returning an error, this will be nil.
-//  - the error encountered while executing statements, if any. If an error
-//    occurred, it corresponds to the last result returned. Subsequent statements
-//    have not been executed. Note that usually the error is not reflected in
-//    this last result; the caller is responsible copying it into the result
-//    after converting it adequately.
-func (e *Executor) execStmtsInCurrentTxn(
-	session *Session,
-	stmts StatementList,
-	pinfo *parser.PlaceholderInfo,
-	txnPrefix bool,
-	avoidCachedDescriptors bool,
-	automaticRetryCount int,
-	txnResults ResultsGroup,
-) (StatementList, error) {
-	txnState := &session.TxnState
-	if txnState.State() == NoTxn {
-		panic("execStmtsInCurrentTransaction called outside of a txn")
-	}
-
-	for i, stmt := range stmts {
 		if log.V(2) || logStatementsExecuteEnabled.Get(&e.cfg.Settings.SV) ||
 			log.HasSpanOrEvent(session.Ctx()) {
 			log.VEventf(session.Ctx(), 2, "executing %d/%d: %s", i+1, len(stmts), stmt)
 		}
 
-		queryID := e.generateQueryID()
-
-		queryMeta := &queryMeta{
-			start: session.phaseTimes[sessionEndParse],
-			stmt:  stmt.AST,
-			phase: preparing,
-		}
-
-		stmt.queryID = queryID
-		stmt.queryMeta = queryMeta
-
-		// Cancelling a query cancels its transaction's context. Copy reference to
-		// txn context and its cancellation function here.
-		//
-		// TODO(itsbilal): Ideally we'd like to fork off a context for each individual
-		// statement. But the heartbeat loop in TxnCoordSender currently assumes that the context of the
-		// first operation in a txn batch lasts at least as long as the transaction itself. Once that
-		// sender is able to distinguish between statement and transaction contexts, queryMeta could
-		// move to per-statement contexts.
-		queryMeta.ctx = txnState.Ctx
-		queryMeta.ctxCancel = txnState.cancel
-
-		// Ignore statements that spawn jobs from SHOW QUERIES and from being cancellable
-		// using CANCEL QUERY. Jobs have their own run control statements (CANCEL JOB,
-		// PAUSE JOB, etc). We implement this ignore by not registering queryMeta in
-		// session.mu.ActiveQueries.
-		if _, ok := stmt.AST.(parser.HiddenFromShowQueries); !ok {
-			// For parallel/async queries, we deregister queryMeta from these registries
-			// after execution finishes in the parallelizeQueue. For all other
-			// (synchronous) queries, we deregister these in session.FinishPlan when
-			// all results have been sent. We cannot deregister asynchronous queries in
-			// session.FinishPlan because they may still be executing at that instant.
-			session.addActiveQuery(queryID, queryMeta)
-		}
-
-		var stmtStrBefore string
-		// TODO(nvanbenschoten): Constant literals can change their representation (1.0000 -> 1) when type checking,
-		// so we need to reconsider how this works.
-		if (e.cfg.TestingKnobs.CheckStmtStringChange && false) ||
-			(e.cfg.TestingKnobs.StatementFilter != nil) {
-			// We do "statement string change" if a StatementFilter is installed,
-			// because the StatementFilter relies on the textual representation of
-			// statements to not change from what the client sends.
-			stmtStrBefore = stmt.String()
-		}
-
+		// Create a StatementResult to receive the results of the statement that
+		// we're about to run. e.execStmt() will take ownership and close the
+		// result.
 		stmtResult := txnResults.NewStatementResult()
-		var err error
-		// Run SHOW TRANSACTION STATUS in a separate code path so it is
-		// always guaranteed to execute regardless of the current transaction state.
-		if _, ok := stmt.AST.(*parser.ShowTransactionStatus); ok {
-			err = runShowTransactionState(session, stmtResult)
-		} else {
-			switch txnState.State() {
-			case Open, FirstBatch:
-				err = e.execStmtInOpenTxn(
-					session, stmt, pinfo, txnPrefix && (i == 0), /* firstInTxn */
-					avoidCachedDescriptors, automaticRetryCount, stmtResult,
-					txnResults.ResultsSentToClient)
-			case Aborted, RestartWait:
-				err = e.execStmtInAbortedTxn(session, stmt, txnResults)
-			case CommitWait:
-				err = e.execStmtInCommitWaitTxn(session, stmt, stmtResult)
-			default:
-				panic(fmt.Sprintf("unexpected txn state: %s", txnState.State()))
-			}
-			if (e.cfg.TestingKnobs.CheckStmtStringChange && false) ||
-				(e.cfg.TestingKnobs.StatementFilter != nil) {
-				if after := stmt.String(); after != stmtStrBefore {
-					panic(fmt.Sprintf("statement changed after exec; before:\n    %s\nafter:\n    %s",
-						stmtStrBefore, after))
-				}
-			}
-		}
-		if filter := e.cfg.TestingKnobs.StatementFilter; filter != nil {
-			if err := filter(session.Ctx(), stmt.String(), session.ResultsWriter, err); err != nil {
-				return nil, err
-			}
-		}
-		if err != nil {
-			// If error contains a context cancellation error, wrap it with a
-			// user-friendly query execution cancelled one.
-			if strings.Contains(err.Error(), "context canceled") {
-				err = errors.Wrapf(err, "query execution canceled")
-			}
-			// After an error happened, skip executing all the remaining statements
-			// in this batch.  This is Postgres behavior, and it makes sense as the
-			// protocol doesn't let you return results after an error.
+		if err := e.execSingleStatement(
+			session, stmt, pinfo,
+			txnPrefix && i == 0, /* firstInTxn */
+			avoidCachedDescriptors, automaticRetryCount, stmtResult,
+		); err != nil {
 			return nil, err
 		}
-		if txnState.State() == NoTxn {
-			// If the transaction is done, return the remaining statements to
-			// be executed as a different group.
-			return stmts[i+1:], nil
+
+		// If the transaction is done, stop executing more statements.
+		if !txnState.TxnIsOpen() {
+			break
 		}
 	}
-	// If we got here, we've managed to consume all statements and we're still in a txn.
-	return nil, nil
+
+	// Flush the results accumulated in AutoRetry. We want possible future
+	// Reset()s to not discard them since we're not going to retry the
+	// statements. We also want future ResultsSentToClient() calls to return
+	// false.
+	if err := txnState.txnResults.Flush(session.Ctx()); err != nil {
+		txnState.updateStateAndCleanupOnErr(err, e)
+		return nil, err
+	}
+
+	// If we're still in AutoRetry but we've seen statements that would need to be
+	// retried if we'd later want to retry the transaction, we transition to Open.
+	// Automatic retries are not possible beyond this point.
+	if txnState.State() == AutoRetry && encounteredNonAutoRetryStmt {
+		txnState.SetState(Open)
+	}
+	// Return the statements that weren't executed in the current txn, so they can
+	// be executed in the context of other transactions. The set can be empty if
+	// we executed everything that was passed in.
+	return stmts[i+1:], nil
+}
+
+// execSingleStatement executes one statement by dispatching according to the
+// current state.
+//
+// If an error occurs while executing the statement, the SQL txn will be
+// considered aborted and subsequent statements will be discarded (they will not
+// be executed, they will not be returned for future execution, they will not
+// generate results). Note that this also includes COMMIT/ROLLBACK statements.
+// Further note that errTransactionAborted is no exception - encountering it
+// will discard subsequent statements. This means that, to recover from an
+// aborted txn, a COMMIT/ROLLBACK statement needs to be the first one in stmts.
+//
+// Args:
+// session:    The session to execute the statement in.
+// stmt: 		   The statement to execute.
+// pinfo:      The placeholders to use in the statements.
+// firstInTxn: Set if the statements represents the first statement in a txn.
+//   Used to trap nested BEGINs.
+// avoidCachedDescriptors: Set if the statement execution should avoid
+//   using cached descriptors.
+// automaticRetryCount: Increases with each retry; 0 for the first attempt.
+// res:                 Used to pass query results to the caller.
+//
+// Returns the error encountered while executing the query, if any.
+func (e *Executor) execSingleStatement(
+	session *Session,
+	stmt Statement,
+	pinfo *parser.PlaceholderInfo,
+	firstInTxn bool,
+	avoidCachedDescriptors bool,
+	automaticRetryCount int,
+	res StatementResult,
+) error {
+	txnState := &session.TxnState
+	if txnState.State() == NoTxn {
+		panic("execStmt called outside of a txn")
+	}
+
+	queryID := e.generateQueryID()
+
+	queryMeta := &queryMeta{
+		start: session.phaseTimes[sessionEndParse],
+		stmt:  stmt.AST,
+		phase: preparing,
+	}
+
+	stmt.queryID = queryID
+	stmt.queryMeta = queryMeta
+
+	// Cancelling a query cancels its transaction's context. Copy reference to
+	// txn context and its cancellation function here.
+	//
+	// TODO(itsbilal): Ideally we'd like to fork off a context for each individual
+	// statement. But the heartbeat loop in TxnCoordSender currently assumes that the context of the
+	// first operation in a txn batch lasts at least as long as the transaction itself. Once that
+	// sender is able to distinguish between statement and transaction contexts, queryMeta could
+	// move to per-statement contexts.
+	queryMeta.ctx = txnState.Ctx
+	queryMeta.ctxCancel = txnState.cancel
+
+	// Ignore statements that spawn jobs from SHOW QUERIES and from being cancellable
+	// using CANCEL QUERY. Jobs have their own run control statements (CANCEL JOB,
+	// PAUSE JOB, etc). We implement this ignore by not registering queryMeta in
+	// session.mu.ActiveQueries.
+	if _, ok := stmt.AST.(parser.HiddenFromShowQueries); !ok {
+		// For parallel/async queries, we deregister queryMeta from these registries
+		// after execution finishes in the parallelizeQueue. For all other
+		// (synchronous) queries, we deregister these in session.FinishPlan when
+		// all results have been sent. We cannot deregister asynchronous queries in
+		// session.FinishPlan because they may still be executing at that instant.
+		session.addActiveQuery(queryID, queryMeta)
+	}
+
+	var stmtStrBefore string
+	// TODO(nvanbenschoten): Constant literals can change their representation (1.0000 -> 1) when type checking,
+	// so we need to reconsider how this works.
+	if (e.cfg.TestingKnobs.CheckStmtStringChange && false) ||
+		(e.cfg.TestingKnobs.StatementFilter != nil) {
+		// We do "statement string change" if a StatementFilter is installed,
+		// because the StatementFilter relies on the textual representation of
+		// statements to not change from what the client sends.
+		stmtStrBefore = stmt.String()
+	}
+
+	var err error
+	// Run SHOW TRANSACTION STATUS in a separate code path so it is
+	// always guaranteed to execute regardless of the current transaction state.
+	if _, ok := stmt.AST.(*parser.ShowTransactionStatus); ok {
+		err = runShowTransactionState(session, res)
+	} else {
+		switch txnState.State() {
+		case Open, AutoRetry:
+			err = e.execStmtInOpenTxn(
+				session, stmt, pinfo, firstInTxn,
+				avoidCachedDescriptors, automaticRetryCount, res)
+		case Aborted, RestartWait:
+			err = e.execStmtInAbortedTxn(session, stmt, res)
+		case CommitWait:
+			err = e.execStmtInCommitWaitTxn(session, stmt, res)
+		default:
+			panic(fmt.Sprintf("unexpected txn state: %s", txnState.State()))
+		}
+
+		if (e.cfg.TestingKnobs.CheckStmtStringChange && false) ||
+			(e.cfg.TestingKnobs.StatementFilter != nil) {
+			if after := stmt.String(); after != stmtStrBefore {
+				panic(fmt.Sprintf("statement changed after exec; before:\n    %s\nafter:\n    %s",
+					stmtStrBefore, after))
+			}
+		}
+	}
+	if filter := e.cfg.TestingKnobs.StatementFilter; filter != nil {
+		if err := filter(session.Ctx(), stmt.String(), session.ResultsWriter, err); err != nil {
+			return err
+		}
+	}
+	if err != nil {
+		// If error contains a context cancellation error, wrap it with a
+		// user-friendly query execution cancelled one.
+		if strings.Contains(err.Error(), "context canceled") {
+			err = errors.Wrapf(err, "query execution canceled")
+		}
+		// After an error happened, skip executing all the remaining statements
+		// in this batch.  This is Postgres behavior, and it makes sense as the
+		// protocol doesn't let you return results after an error.
+		return err
+	}
+	return nil
 }
 
 // getTransactionState retrieves a text representation of the given state.
@@ -1187,9 +1212,9 @@ func getTransactionState(txnState *txnState) string {
 	if txnState.implicitTxn {
 		state = NoTxn
 	}
-	// For the purposes of representing the states to client, make the FirstBatch
+	// For the purposes of representing the states to client, make the AutoRetry
 	// state look like Open.
-	if state == FirstBatch {
+	if state == AutoRetry {
 		state = Open
 	}
 	return state.String()
@@ -1213,9 +1238,8 @@ func runShowTransactionState(session *Session, res StatementResult) error {
 // - ROLLBACK TO SAVEPOINT / SAVEPOINT: reopens the current transaction,
 //   allowing it to be retried.
 func (e *Executor) execStmtInAbortedTxn(
-	session *Session, stmt Statement, txnResults ResultsGroup,
+	session *Session, stmt Statement, res StatementResult,
 ) error {
-	res := txnResults.NewStatementResult()
 	txnState := &session.TxnState
 	if txnState.State() != Aborted && txnState.State() != RestartWait {
 		panic("execStmtInAbortedTxn called outside of an aborted txn")
@@ -1264,8 +1288,8 @@ func (e *Executor) execStmtInAbortedTxn(
 			return err
 		}
 		if txnState.State() == RestartWait {
-			// Reset the state to FirstBatch. We're in an "open" txn again.
-			txnState.SetState(FirstBatch)
+			// Reset the state to AutoRetry. We're in an "open" txn again.
+			txnState.SetState(AutoRetry)
 		} else {
 			// We accept ROLLBACK TO SAVEPOINT even after non-retryable errors to make
 			// it easy for client libraries that want to indiscriminately issue
@@ -1276,7 +1300,6 @@ func (e *Executor) execStmtInAbortedTxn(
 			// same sql timestamp and isolation as the current one.
 			curTs, curIso, curPri := txnState.sqlTimestamp, txnState.isolation, txnState.priority
 			txnState.finishSQLTxn(session)
-			txnResults.Close()
 			txnState.resetForNewSQLTxn(
 				e, session,
 				false /* implicitTxn */, true, /* retryIntent */
@@ -1343,8 +1366,7 @@ func sessionEventf(session *Session, format string, args ...interface{}) {
 // Results are written to res.
 //
 // The current transaction might be committed/rolled back when this returns.
-// It might also transition to the aborted or RestartWait state, and it
-// might transition from FirstBatch to Open.
+// It might also transition to the aborted or RestartWait state.
 //
 // Args:
 // session: the session to execute the statement in.
@@ -1356,11 +1378,6 @@ func sessionEventf(session *Session, format string, args ...interface{}) {
 //  using cached descriptors.
 // automaticRetryCount: increases with each retry; 0 for the first attempt.
 // res: the writer to send results to.
-// resultsSentToClient: a function used to query the module that communicates
-// with the client about whether results have been sent to the client up to a
-// point in time. Used to decide on some state transitions. TODO(andrei): the
-// presence of this param suggests that the state transition business might
-// belong better one level up from this method.
 func (e *Executor) execStmtInOpenTxn(
 	session *Session,
 	stmt Statement,
@@ -1369,7 +1386,6 @@ func (e *Executor) execStmtInOpenTxn(
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
 	res StatementResult,
-	resultsSentToClient func() bool,
 ) (err error) {
 	txnState := &session.TxnState
 	if !txnState.TxnIsOpen() {
@@ -1396,7 +1412,7 @@ func (e *Executor) execStmtInOpenTxn(
 				// txn in the Aborted state; we transition back to NoTxn.
 				txnState.resetStateAndTxn(NoTxn)
 			}
-		} else if txnState.autoRetry && txnState.isSerializableRestart() {
+		} else if txnState.State() == AutoRetry && txnState.isSerializableRestart() {
 			// If we just ran a statement synchronously, then the parallel queue
 			// would have been synchronized first, so this would be a no-op.
 			// However, if we just ran a statement asynchronously, then the
@@ -1433,13 +1449,6 @@ func (e *Executor) execStmtInOpenTxn(
 				// client.Txn.
 				roachpb.Transaction{},
 			)
-		} else if txnState.State() == FirstBatch &&
-			!canStayInFirstBatchState(stmt) && !resultsSentToClient() {
-			// Transition from FirstBatch to Open except in the case of special
-			// statements that don't return results to the client. This transition
-			// does not affect the current batch - future statements in it will still
-			// be retried automatically.
-			txnState.SetState(Open)
 		}
 	}()
 
@@ -1510,9 +1519,16 @@ func (e *Executor) execStmtInOpenTxn(
 			err := fmt.Errorf("SAVEPOINT %s has not been used", parser.RestartSavepointName)
 			return err
 		}
+
+		res.BeginResult((*parser.Savepoint)(nil))
+		if err := res.CloseResult(); err != nil {
+			return err
+		}
+
+		// Move the state to AutoRetry; we're morally beginning a new transaction.
+		txnState.SetState(AutoRetry)
 		// If commands have already been sent through the transaction,
-		// restart the client txn's proto to increment the epoch. The SQL
-		// txn's state is already set to OPEN.
+		// restart the client txn's proto to increment the epoch.
 		if txnState.mu.txn.CommandCount() > 0 {
 			// TODO(andrei): Should the timestamp below be e.cfg.Clock.Now(), so that
 			// the transaction gets a new timestamp?
@@ -1522,8 +1538,7 @@ func (e *Executor) execStmtInOpenTxn(
 		if err != nil {
 			return err
 		}
-		res.BeginResult((*parser.Savepoint)(nil))
-		return res.CloseResult()
+		return nil
 
 	case *parser.Prepare:
 		// This must be handled here instead of the common path below
@@ -2255,20 +2270,26 @@ func isRollbackToSavepoint(stmt Statement) bool {
 	return isSet
 }
 
-// canStayInFirstBatchState returns true if the statement can leave the
-// transaction in the FirstBatch state (as opposed to transitioning it to Open).
+// canStayInAutoRetryState returns true if the statement, by itself, should not
+// cause the session to transition from AutoRetry->Open at the end of the
+// statement's batch. In other words, if the state was AutoRetry at a certain
+// time, and afterwards only statements recognized by this method run until the
+// end of a batch, then the end of the batch shouldn't perform the
+// AutoRetry->Open transition that ends of batches usually perform.
 //
-// Only statements that affect the transaction state in such a way such that a
-// restart would not destroy the state can currently be added here; we don't
-// replay past batches in case of a restart. So, for example, RETURNING NOTHING
-// statements can't be put here without adding some replay capability.
-// TODO(andrei): support RETURNING NOTHING statements.
-func canStayInFirstBatchState(stmt Statement) bool {
+// Statements in this category may not be executed again in case of an automatic
+// retry, so they need to have two properties:
+// 1) They can only affect the transaction state in such a way that a
+// restart would not destroy the statement's effect. So, for example, RETURNING
+// NOTHING statements can't be put here without adding some replay capability.
+// 2) The results and side-effects they produce must not depend on any previous
+// statements ran in the transaction.
+func canStayInAutoRetryState(stmt Statement) bool {
 	return isBegin(stmt) ||
 		isSavepoint(stmt) ||
 		isSetTransaction(stmt) ||
 		// ROLLBACK TO SAVEPOINT does its own state transitions; if it leaves the
-		// transaction in the FirstBatch state, don't mess with it.
+		// transaction in the AutoRetriable state, don't mess with it.
 		isRollbackToSavepoint(stmt)
 }
 

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -73,7 +73,7 @@ func (e *Executor) recordStatementSummary(
 	stmt Statement,
 	distSQLUsed bool,
 	automaticRetryCount int,
-	resultWriter StatementResultWriter,
+	resultWriter StatementResult,
 	err error,
 ) {
 	phaseTimes := &planner.phaseTimes

--- a/pkg/sql/logictest/testdata/logic_test/manual_retry
+++ b/pkg/sql/logictest/testdata/logic_test/manual_retry
@@ -10,7 +10,7 @@ SELECT CRDB_INTERNAL.FORCE_RETRY('50ms':::INTERVAL)
 statement ok
 BEGIN TRANSACTION; SAVEPOINT cockroach_restart
 
-# The SELECT 1 is necessary to take the session out of the FirstBatch state,
+# The SELECT 1 is necessary to take the session out of the AutoRetry state,
 # otherwise the statement below would be retries automatically.
 statement ok
 SELECT 1

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -538,7 +538,7 @@ statement ok
 COMMIT
 
 # RestartWait state
-# The SELECT 1 is necessary to move the txn out of the FirstBatch state,
+# The SELECT 1 is necessary to move the txn out of the AutoRetry state,
 # otherwise the next statement is automatically retried on the server.
 statement ok
 BEGIN TRANSACTION; SAVEPOINT cockroach_restart; SELECT 1
@@ -583,7 +583,7 @@ ROLLBACK
 
 # Automatic retries for the first batch even when that first batch comes after
 # the BEGIN and the BEGIN also has special statements that don't move the txn
-# state out of the "FirstBatch" state.
+# state out of the "AutoRetry" state.
 statement ok
 BEGIN TRANSACTION; SAVEPOINT cockroach_restart; SET TRANSACTION PRIORITY HIGH; SET TRANSACTION ISOLATION LEVEL SNAPSHOT;
 
@@ -806,7 +806,7 @@ BEGIN ISOLATION LEVEL SERIALIZABLE, ISOLATION LEVEL SERIALIZABLE
 
 # Retryable error in a txn that hasn't performed any KV operations. It used to
 # not work.
-# The SELECT 1 is necessary to take the session out of the FirstBatch state,
+# The SELECT 1 is necessary to take the session out of the AutoRetry state,
 # otherwise the statement below would be retries automatically.
 statement ok
 BEGIN; SELECT 1

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -160,7 +160,7 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Run a batch of statements to move the txn out of the FirstBatch state,
+	// Run a batch of statements to move the txn out of the AutoRetry state,
 	// otherwise the INSERT below would be automatically retried.
 	if _, err := txn.Exec("SELECT 1"); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -199,7 +199,9 @@ type v3Conn struct {
 }
 
 type streamingState struct {
-	// Query state.
+
+	/* Current batch state */
+
 	// formatCodes is an array of which indicates whether each column of a row
 	// should be sent as binary or text format. If it is nil then we send as text.
 	formatCodes     []formatCode
@@ -208,7 +210,13 @@ type streamingState struct {
 	emptyQuery      bool
 	err             error
 
-	// Current transaction state.
+	// hasSentResults is set if any results in the current batch have been sent on
+	// the client connection. This is used to back the
+	// ResultGroup.ResultsSentToClient() interface.
+	// TODO(andrei): The bookkeeping for this member is currently broken - it's
+	// reset after every batch of statements even if a batch continues a previous
+	// txn (result group). This is coupled with the Executor creating a new group
+	// for every batch.
 	hasSentResults bool
 
 	// TODO(tso): this can theoretically be combined with v3conn.writeBuf.
@@ -216,11 +224,13 @@ type streamingState struct {
 	// bytes and write them to buf. We do this since we need to length prefix
 	// each message and this is icky to figure out ahead of time.
 	buf bytes.Buffer
+
 	// txnStartIdx is the start of the current transaction in the buf. We keep
 	// track of this so that we can reset the current transaction if we retry.
 	txnStartIdx int
 
-	// Current statement state.
+	/* Current statement state */
+
 	pgTag         string
 	columns       sqlbase.ResultColumns
 	statementType parser.StatementType
@@ -574,8 +584,10 @@ func (c *v3Conn) handleSimpleQuery(buf *readBuffer) error {
 	}
 
 	tracing.AnnotateTrace()
-	c.streamingState.reset(nil, true /* sendDescription */, 0)
-	c.session.ResultWriter = c
+	c.streamingState.reset(
+		nil /* formatCodes */, true /* sendDescription */, 0, /* limit */
+	)
+	c.session.ResultsWriter = c
 	if err := c.executor.ExecuteStatements(c.session, query, nil); err != nil {
 		if err := c.setError(err); err != nil {
 			return err
@@ -914,7 +926,7 @@ func (c *v3Conn) handleExecute(buf *readBuffer) error {
 
 	tracing.AnnotateTrace()
 	c.streamingState.reset(portalMeta.outFormats, false /* sendDescription */, int(limit))
-	c.session.ResultWriter = c
+	c.session.ResultsWriter = c
 	err = c.executor.ExecutePreparedStatement(c.session, stmt, pinfo)
 	if err != nil {
 		if err := c.setError(err); err != nil {
@@ -1104,45 +1116,45 @@ func (c *v3Conn) copyIn(ctx context.Context, columns []sqlbase.ResultColumn) (in
 	}
 }
 
-// NewGroupResultWriter implements the ResultWriter interface.
-func (c *v3Conn) NewGroupResultWriter() sql.GroupResultWriter {
+// NewResultsGroup is part of the ResultsWriter interface.
+func (c *v3Conn) NewResultsGroup() sql.ResultsGroup {
 	return c
 }
 
-// SetEmptyQuery implements the ResultWriter interface.
+// SetEmptyQuery is part of the ResultsWriter interface.
 func (c *v3Conn) SetEmptyQuery() {
 	c.streamingState.emptyQuery = true
 }
 
-// SetEmptyQuery implements the GroupResultWriter interface.
-func (c *v3Conn) NewStatementResultWriter() sql.StatementResultWriter {
+// SetEmptyQuery implements the ResultsGroup interface.
+func (c *v3Conn) NewStatementResult() sql.StatementResult {
 	return c
 }
 
-// ResultsSentToClient implements the GroupResultWriter interface.
+// ResultsSentToClient implements the ResultsGroup interface.
 func (c *v3Conn) ResultsSentToClient() bool {
 	return c.streamingState.hasSentResults
 }
 
-// End implements the GroupResultWriter interface.
-func (c *v3Conn) End() {
+// Close implements the ResultsGroup interface.
+func (c *v3Conn) Close() {
 	s := &c.streamingState
 	s.txnStartIdx = s.buf.Len()
 	s.emptyQuery = false
 	s.hasSentResults = false
 }
 
-// Reset implements the GroupResultWriter interface.
+// Reset implements the ResultsGroup interface.
 func (c *v3Conn) Reset(ctx context.Context) {
 	s := &c.streamingState
 	if s.hasSentResults {
-		panic("cannot reset if we've already sent results for this txn")
+		panic("cannot reset if we've already sent results for group")
 	}
 	s.emptyQuery = false
 	s.buf.Truncate(s.txnStartIdx)
 }
 
-// BeginResult implements the StatementResultWriter interface.
+// BeginResult implements the StatementResult interface.
 func (c *v3Conn) BeginResult(stmt parser.Statement) {
 	state := &c.streamingState
 	state.pgTag = stmt.StatementTag()
@@ -1151,23 +1163,24 @@ func (c *v3Conn) BeginResult(stmt parser.Statement) {
 	state.firstRow = true
 }
 
-// GetPGTag implements the StatementResultWriter interface.
+// GetPGTag implements the StatementResult interface.
 func (c *v3Conn) PGTag() string {
 	return c.streamingState.pgTag
 }
 
-// SetColumns implements the StatementResultWriter interface.
+// SetColumns implements the StatementResult interface.
 func (c *v3Conn) SetColumns(columns sqlbase.ResultColumns) {
 	c.streamingState.columns = columns
 }
 
-// RowsAffected implements the StatementResultWriter interface.
+// RowsAffected implements the StatementResult interface.
 func (c *v3Conn) RowsAffected() int {
 	return c.streamingState.rowsAffected
 }
 
-// EndResult implements the StatementResultWriter interface.
-func (c *v3Conn) EndResult() error {
+// CloseResult implements the StatementResult interface.
+// It sends a "command complete" server message.
+func (c *v3Conn) CloseResult() error {
 	state := &c.streamingState
 	if state.err != nil {
 		return state.err
@@ -1257,7 +1270,7 @@ func (c *v3Conn) setError(err error) error {
 	state.hasSentResults = true
 	state.err = err
 	state.buf.Truncate(state.txnStartIdx)
-	if err := c.flush(true); err != nil {
+	if err := c.flush(true /* forceSend */); err != nil {
 		return sql.NewWireFailureError(err)
 	}
 	if err := c.sendError(err); err != nil {
@@ -1266,17 +1279,17 @@ func (c *v3Conn) setError(err error) error {
 	return nil
 }
 
-// StatementType implements the StatementResultWriter interface.
+// StatementType implements the StatementResult interface.
 func (c *v3Conn) StatementType() parser.StatementType {
 	return c.streamingState.statementType
 }
 
-// IncrementRowsAffected implements the StatementResultWriter interface.
+// IncrementRowsAffected implements the StatementResult interface.
 func (c *v3Conn) IncrementRowsAffected(n int) {
 	c.streamingState.rowsAffected += n
 }
 
-// AddRow implements the StatementResultWriter interface.
+// AddRow implements the StatementResult interface.
 func (c *v3Conn) AddRow(ctx context.Context, row parser.Datums) error {
 	state := &c.streamingState
 	if state.err != nil {

--- a/pkg/sql/results_writer.go
+++ b/pkg/sql/results_writer.go
@@ -106,13 +106,37 @@ type ResultsGroup interface {
 	// called on the previous one.
 	NewStatementResult() StatementResult
 
+	// Flush informs the ResultsGroup that the caller relinquishes the capability
+	// to Reset() the results that have been already been accumulated on this
+	// group. This means that future Reset() calls will only reset up to the
+	// current point in the stream - only future results will be discarded. This
+	// is used to ensure that some results are always sent to the client even if
+	// further statements are retried automatically; it supports the statements
+	// run in the AutoRetry state: these statements are not executed again when
+	// doing an automatic retry, and so their results shouldn't be reset.
+	//
+	// It is illegal to call this while any StatementResults on this group are
+	// open.
+	//
+	// Like StatementResult.AddRow(), Flush returns communication errors, if any.
+	// TODO(andrei): provide guidance on handling these errors.
+	Flush(context.Context) error
+
 	// ResultsSentToClient returns true if any results pertaining to this group
-	// have been sent to the consumer.
+	// beyond the last Flush() point have been sent to the consumer.
+	// Remember that the implementation is free to buffer or send results to the
+	// client whenever it pleases. This method checks to see if the implementation
+	// has in fact sent anything so far.
+	//
+	// TODO(andrei): add a note about the synchronous nature of the implementation
+	// imposed by this interface.
 	ResultsSentToClient() bool
 
-	// Reset discards all the group's results. It is illegal to call Reset if any
-	// results have already been sent to the consumer; this can be tested with
-	// ResultsSentToClient().
+	// Reset discards all the accumulated results from the last Flush() call
+	// onwards (or from the moment the group was created if Flush() was never
+	// called).
+	// It is illegal to call Reset if any results have already been sent to the
+	// consumer; this can be tested with ResultsSentToClient().
 	Reset(context.Context)
 }
 
@@ -191,6 +215,8 @@ func (b *bufferedWriter) ResultsSentToClient() bool {
 
 // Close implements the ResultsGroup interface.
 func (b *bufferedWriter) Close() {
+	// TODO(andrei): The work that's duplicated from CloseResult() should not be
+	// performed by this method.
 	if b.resultInProgress {
 		b.currentGroupResults = append(b.currentGroupResults, b.currentResult)
 		b.resultInProgress = false
@@ -198,6 +224,16 @@ func (b *bufferedWriter) Close() {
 	b.pastResults = append(b.pastResults, b.currentGroupResults...)
 	b.currentGroupResults = nil
 	b.resultInProgress = false
+}
+
+// Flush implements the ResultsGroup interface.
+func (b *bufferedWriter) Flush(context.Context) error {
+	if b.resultInProgress {
+		panic("can't flush while a StatementResult is in progress")
+	}
+	b.pastResults = append(b.pastResults, b.currentGroupResults...)
+	b.currentGroupResults = nil
+	return nil
 }
 
 // Reset implements the ResultsGroup interface.

--- a/pkg/sql/results_writer.go
+++ b/pkg/sql/results_writer.go
@@ -37,36 +37,91 @@ func NewWireFailureError(err error) error {
 	return WireFailureError{err}
 }
 
-// ResultWriter is an interface which is used to store results from query
-// execution. Implementations could be buffered, immediately stream to the
-// client, or a bit of both. There are two implementations: v3conn and
-// bufferedWriter.
-type ResultWriter interface {
-	NewGroupResultWriter() GroupResultWriter
+// ResultsWriter is the interface used to by the Executor to produce results for
+// query execution for a SQL client. The main implementer is v3Conn, which
+// streams the results on a SQL network connection. There's also bufferedWriter,
+// which buffers all results in memory.
+//
+// ResultsWriter is built with the SQL session model in mind: queries from a
+// given SQL client (which we'll call the consumer to not confuse it with
+// clients of this interface - the Executor) keep coming out of band and all of
+// their results (generally, datum tuples) are pushed to a single ResultsWriter.
+// The ResultsWriter needs to be made aware of which results pertain to which
+// statement, as implementations need to split results accordingly. The
+// ResultsWriter also supports the notion of a "results group": the
+// ResultsWriter sequentially goes through groups of results and the group is
+// the level at which a client can request for results to be dropped; a group
+// can be reset, meaning that the consumer will not receive any of them. Only
+// the current group can be reset; the client gives up the ability to reset a
+// group the moment it closes it.  This feature is used to support the automatic
+// retries that we do for SQL transactions - groups will correspond to
+// transactions and, when the Executor decides to automatically retry a
+// transaction, it will reset its group (as it can't automatically retry if any
+// results have been sent to the consumer).
+//
+// Example usage:
+//
+//  var rw ResultsWriter
+//  group := rw.NewResultsGroup()
+//  defer group.Close()
+//  sr := group.NewStatementResult()
+//  for each result row {
+//    if err := sr.AddRow(...); err != nil {
+//      // send err to the client in another way
+//    }
+//  }
+//  sr.CloseResult()
+//  group.Close()
+//
+type ResultsWriter interface {
+	// NewResultsGroup creates a new ResultGroup and indicates that future results
+	// are part of a new result group.
+	//
+	// A single group can be ongoing on a ResultsWriter at a time; it is illegal to
+	// create a new group before the previous one has been Close()d.
+	NewResultsGroup() ResultsGroup
+
 	// SetEmptyQuery is used to indicate that there are no statements to run.
 	// Empty queries are different than queries with no results.
 	SetEmptyQuery()
 }
 
-// GroupResultWriter provides an interface for a single transaction. Its methods
-// deal with automatic retries primarily.
-type GroupResultWriter interface {
-	NewStatementResultWriter() StatementResultWriter
-	// ResultsSentToClient returns true if this group has sent any results to the
-	// client in the current transaction.
+// ResultsGroup is used to produce a result group (see ResultsWriter).
+type ResultsGroup interface {
+	// Close should be called once all the results for a group have been produced
+	// (i.e. after all StatementResults have been closed). It informs the
+	// implementation that the results are not going to be reset any more, and
+	// thus can be sent to the client.
+	//
+	// Close has to be called before new groups are created.  It's illegal to call
+	// Close before CloseResult() has been called on all of the group's
+	// StatementResults.
+	Close()
+
+	// NewStatementResult creates a new StatementResult, indicating that future
+	// results are part of a new SQL query.
+	//
+	// A single StatementResult can be active on a ResultGroup at a time; it is
+	// illegal to create a new StatementResult before CloseResult() has been
+	// called on the previous one.
+	NewStatementResult() StatementResult
+
+	// ResultsSentToClient returns true if any results pertaining to this group
+	// have been sent to the consumer.
 	ResultsSentToClient() bool
-	// End should be called before new groups can be created.
-	End()
-	// Reset discards all the current buffered results (if any) when we attempt
-	// to automatically retry the current transaction.
-	Reset(ctx context.Context)
+
+	// Reset discards all the group's results. It is illegal to call Reset if any
+	// results have already been sent to the consumer; this can be tested with
+	// ResultsSentToClient().
+	Reset(context.Context)
 }
 
-// StatementResultWriter provides a writer interface for a single statement.
-type StatementResultWriter interface {
+// StatementResult is used to produce results for a single query (see
+// ResultsWriter).
+type StatementResult interface {
 	// BeginResult should be called prior to any of the other methods.
 	// TODO(andrei): remove BeginResult and SetColumns, and have
-	// NewStatementResultWriter take in a parser.Statement
+	// NewStatementResult() take in a parser.Statement
 	BeginResult(stmt parser.Statement)
 	// GetPGTag returns the PGTag of the statement passed into BeginResult.
 	PGTag() string
@@ -84,9 +139,12 @@ type StatementResultWriter interface {
 	// RowsAffected returns either the number of times AddRow was called, or the
 	// sum of all n passed into IncrementRowsAffected.
 	RowsAffected() int
-	// EndResult ends the current result. Cannot be called unless there's a
-	// corresponding BeginResult prior.
-	EndResult() error
+	// CloseResult ends the current result. The v3Conn will send control codes to
+	// the client informing it that the result for a statement is now complete.
+	//
+	// CloseResult cannot be called unless there's a corresponding BeginResult
+	// prior.
+	CloseResult() error
 }
 
 type bufferedWriter struct {
@@ -112,27 +170,27 @@ func (b *bufferedWriter) results() StatementResults {
 	return StatementResults{b.pastResults, len(b.pastResults) == 0}
 }
 
-// NewGroupResultWriter implements the ResultWriter interface.
-func (b *bufferedWriter) NewGroupResultWriter() GroupResultWriter {
+// NewResultsGroup is part of the ResultsWriter interface.
+func (b *bufferedWriter) NewResultsGroup() ResultsGroup {
 	return b
 }
 
-// SetEmptyQuery implements the ResultWriter interface.
+// SetEmptyQuery is part of the ResultsWriter interface.
 func (b *bufferedWriter) SetEmptyQuery() {
 }
 
-// SetEmptyQuery implements the GroupResultWriter interface.
-func (b *bufferedWriter) NewStatementResultWriter() StatementResultWriter {
+// SetEmptyQuery implements the ResultsGroup interface.
+func (b *bufferedWriter) NewStatementResult() StatementResult {
 	return b
 }
 
-// CanAutomaticallyRetry implements the GroupResultWriter interface.
+// CanAutomaticallyRetry implements the ResultsGroup interface.
 func (b *bufferedWriter) ResultsSentToClient() bool {
 	return false
 }
 
-// End implements the GroupResultWriter interface.
-func (b *bufferedWriter) End() {
+// Close implements the ResultsGroup interface.
+func (b *bufferedWriter) Close() {
 	if b.resultInProgress {
 		b.currentGroupResults = append(b.currentGroupResults, b.currentResult)
 		b.resultInProgress = false
@@ -142,7 +200,7 @@ func (b *bufferedWriter) End() {
 	b.resultInProgress = false
 }
 
-// Reset implements the GroupResultWriter interface.
+// Reset implements the ResultsGroup interface.
 func (b *bufferedWriter) Reset(ctx context.Context) {
 	if b.currentGroupResults != nil {
 		b.currentGroupResults.Close(ctx)
@@ -151,7 +209,7 @@ func (b *bufferedWriter) Reset(ctx context.Context) {
 	b.resultInProgress = false
 }
 
-// BeginResult implements the StatementResultWriter interface.
+// BeginResult implements the StatementResult interface.
 func (b *bufferedWriter) BeginResult(stmt parser.Statement) {
 	if b.resultInProgress {
 		panic("can't start new result before ending the previous")
@@ -160,12 +218,12 @@ func (b *bufferedWriter) BeginResult(stmt parser.Statement) {
 	b.currentResult = Result{PGTag: stmt.StatementTag(), Type: stmt.StatementType()}
 }
 
-// GetPGTag implements the StatementResultWriter interface.
+// GetPGTag implements the StatementResult interface.
 func (b *bufferedWriter) PGTag() string {
 	return b.currentResult.PGTag
 }
 
-// SetColumns implements the StatementResultWriter interface.
+// SetColumns implements the StatementResult interface.
 func (b *bufferedWriter) SetColumns(columns sqlbase.ResultColumns) {
 	if !b.resultInProgress {
 		panic("no result in progress")
@@ -179,7 +237,7 @@ func (b *bufferedWriter) SetColumns(columns sqlbase.ResultColumns) {
 	}
 }
 
-// RowsAffected implements the StatementResultWriter interface.
+// RowsAffected implements the StatementResult interface.
 func (b *bufferedWriter) RowsAffected() int {
 	if b.currentResult.Type == parser.Rows {
 		return b.currentResult.Rows.Len()
@@ -187,8 +245,8 @@ func (b *bufferedWriter) RowsAffected() int {
 	return b.currentResult.RowsAffected
 }
 
-// EndResult implements the StatementResultWriter interface.
-func (b *bufferedWriter) EndResult() error {
+// CloseResult implements the StatementResult interface.
+func (b *bufferedWriter) CloseResult() error {
 	if !b.resultInProgress {
 		panic("no result in progress")
 	}
@@ -197,12 +255,12 @@ func (b *bufferedWriter) EndResult() error {
 	return nil
 }
 
-// StatementType implements the StatementResultWriter interface.
+// StatementType implements the StatementResult interface.
 func (b *bufferedWriter) StatementType() parser.StatementType {
 	return b.currentResult.Type
 }
 
-// IncrementRowsAffected implements the StatementResultWriter interface.
+// IncrementRowsAffected implements the StatementResult interface.
 func (b *bufferedWriter) IncrementRowsAffected(n int) {
 	if !b.resultInProgress {
 		panic("no result in progress")
@@ -210,7 +268,7 @@ func (b *bufferedWriter) IncrementRowsAffected(n int) {
 	b.currentResult.RowsAffected += n
 }
 
-// AddRow implements the StatementResultWriter interface.
+// AddRow implements the StatementResult interface.
 func (b *bufferedWriter) AddRow(ctx context.Context, row parser.Datums) error {
 	if !b.resultInProgress {
 		panic("no result in progress")

--- a/pkg/sql/results_writer_test.go
+++ b/pkg/sql/results_writer_test.go
@@ -187,14 +187,14 @@ func TestBufferedWriterReset(t *testing.T) {
 	acc := memMon.MakeBoundAccount()
 
 	writer := newBufferedWriter(acc)
-	gw := writer.NewGroupResultWriter().(*bufferedWriter)
-	sw := gw.NewStatementResultWriter()
+	gw := writer.NewResultsGroup().(*bufferedWriter)
+	sw := gw.NewStatementResult()
 	sw.BeginResult((*parser.Select)(nil))
 	sw.SetColumns(sqlbase.ResultColumns{{Name: "test", Typ: parser.TypeString}})
 	if err := sw.AddRow(ctx, parser.Datums{parser.DNull}); err != nil {
 		t.Fatal(err)
 	}
-	if err := sw.EndResult(); err != nil {
+	if err := sw.CloseResult(); err != nil {
 		t.Fatal(err)
 	}
 	if numRes := len(gw.currentGroupResults); numRes != 1 {
@@ -228,7 +228,7 @@ func TestStreamingWireFailure(t *testing.T) {
 								}
 							}
 						},
-						AfterExecute: func(ctx context.Context, stmt string, resultWriter StatementResultWriter, err error) {
+						AfterExecute: func(ctx context.Context, stmt string, resultWriter StatementResult, err error) {
 							if strings.Contains(stmt, "generate_series") {
 								errChan <- err
 								close(errChan)

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -115,7 +115,7 @@ func TestCancelParallelQuery(t *testing.T) {
 								<-sem
 							}
 						},
-						AfterExecute: func(ctx context.Context, stmt string, resultWriter sql.StatementResultWriter, err error) {
+						AfterExecute: func(ctx context.Context, stmt string, resultWriter sql.StatementResult, err error) {
 							// if queryToBlock
 							if strings.Contains(stmt, "(1)") {
 								// Ensure queryToBlock errored out with the cancellation error.

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -879,22 +879,32 @@ const (
 	// queries.
 	NoTxn TxnStateEnum = iota
 
-	// A txn is in scope, and we're currently executing statements from the first
-	// batch of statements using the transaction. If BEGIN was the last (or the
-	// only) statement in a batch, that batch doesn't count (the next batch will
-	// be considered the first one). The first batch of statements can be
-	// automatically retried in case of retryable errors since there's been no
-	// client logic relying on reads performed in the transaction.
+	// Like Open, a txn is in scope. The difference is that, while in the
+	// AutoRetry state, a retriable error will be handled by an automatic
+	// transaction retry, whereas we can't do that in Open. There's a caveat -
+	// even if we're in AutoRetry, we can't do automatic retries if any
+	// results for statements in the current transaction have already been
+	// delivered to the client.
+	// In principle, we can do automatic retries for the first batch of statements
+	// in a transaction. There is an extension to the rule, though: for
+	// example, is we get a batch with "BEGIN; SET TRANSACTION ISOLATION LEVEL
+	// foo; SAVEPOINT cockroach_restart;" followed by a 2nd batch, we can
+	// automatically retry the 2nd batch even though the statements in the first
+	// batch will not be executed again and their results have already been sent
+	// to the clients. We can do this because some statements are special in that
+	// their execution always generates exactly the same results to the consumer
+	// (i.e. the SQL client).
 	//
-	// A BEGIN statement makes the transaction enter this state (from a previous
-	// NoTxn state). The end of the first batch of statements, if executed
-	// successfully, will move the state to Open.
-	//
-	// TODO(andrei): It'd be cool if exiting this state would be based not on
-	// batches sent by the client, but results being sent by the server to the
-	// client (i.e. the client can send 100 batches but, if we haven't sent it any
-	// results yet, we know that we can still retry them all).
-	FirstBatch
+	// TODO(andrei): This state shouldn't exist; the decision about whether we can
+	// retry automatically or not should be entirely dynamic, based on which
+	// results we've delivered to the client already. It should have nothing to do
+	// with the client's batching of statements. For example, the client can send
+	// 100 batches but, if we haven't sent it any results yet, we should still be
+	// able to retry them all). Currently the splitting into batches is relevant
+	// because we don't keep track of statements from previous batches, so we
+	// would not be capable of retrying them even if we knew that no results have
+	// been delivered.
+	AutoRetry
 
 	// A txn is in scope.
 	Open
@@ -912,7 +922,7 @@ const (
 
 // Some states mean that a client.Txn is open, others don't.
 func (s TxnStateEnum) kvTxnIsOpen() bool {
-	return s == Open || s == FirstBatch || s == RestartWait
+	return s == Open || s == AutoRetry || s == RestartWait
 }
 
 // txnState contains state associated with an ongoing SQL txn.
@@ -926,7 +936,7 @@ type txnState struct {
 	//
 	// NOTE: Only state updates that are inconsequential to statement execution
 	// are allowed concurrently with the execution of the parallizeQueue (e.g.
-	// Open->FirstBatch).
+	// Open->AutoRetry).
 	state TxnStateEnum
 
 	// Mutable fields accessed from goroutines not synchronized by this txn's session,
@@ -939,6 +949,10 @@ type txnState struct {
 
 		txn *client.Txn
 	}
+
+	// If we're in a SQL txn, txnResults is the ResultsGroup that statements in
+	// this transaction should write results to.
+	txnResults ResultsGroup
 
 	// Ctx is the context for everything running in this SQL txn.
 	Ctx context.Context
@@ -955,11 +969,6 @@ type txnState struct {
 	// If set, the user declared the intention to retry the txn in case of retriable
 	// errors. The txn will enter a RestartWait state in case of such errors.
 	retryIntent bool
-
-	// The transaction will be retried in case of retriable error. The retry will be
-	// automatic (done by Txn.Exec()). This field behaves the same as retryIntent,
-	// except it's reset in between client round trips.
-	autoRetry bool
 
 	// A COMMIT statement has been processed. Useful for allowing the txn to
 	// survive retriable errors if it will be auto-retried (BEGIN; ... COMMIT; in
@@ -1001,7 +1010,7 @@ func (ts *txnState) SetState(val TxnStateEnum) {
 // TxnIsOpen returns true if we are presently inside a SQL txn, and the txn is
 // not in an error state.
 func (ts *txnState) TxnIsOpen() bool {
-	return ts.State() == Open || ts.State() == FirstBatch
+	return ts.State() == Open || ts.State() == AutoRetry
 }
 
 // resetForNewSQLTxn (re)initializes the txnState for a new transaction.
@@ -1024,18 +1033,18 @@ func (ts *txnState) resetForNewSQLTxn(
 	isolation enginepb.IsolationType,
 	priority roachpb.UserPriority,
 ) {
-	if ts.sp != nil {
-		panic(fmt.Sprintf("txnState.reset() called on ts with active span. How come "+
-			"finishSQLTxn() wasn't called previously? ts: %+v", ts))
+	if ts.sp != nil || ts.txnResults != nil {
+		log.Fatalf(s.Ctx(),
+			"txnState.reset() called on ts with active span or active txnResults. "+
+				"How come finishSQLTxn() wasn't called previously? ts: %+v", ts)
 	}
 
 	ts.retryIntent = retryIntent
 	// Reset state vars to defaults.
-	ts.autoRetry = true
 	ts.commitSeen = false
 	ts.sqlTimestamp = sqlTimestamp
-
 	ts.implicitTxn = implicitTxn
+	ts.txnResults = s.ResultsWriter.NewResultsGroup()
 
 	// Create a context for this transaction. It will include a
 	// root span that will contain everything executed as part of the
@@ -1088,7 +1097,7 @@ func (ts *txnState) resetForNewSQLTxn(
 
 	ts.sp = sp
 	ts.Ctx, ts.cancel = context.WithCancel(ctx)
-	ts.SetState(FirstBatch)
+	ts.SetState(AutoRetry)
 	s.Tracing.onNewSQLTxn(ts.sp)
 
 	ts.mon.Start(ctx, &s.mon, mon.BoundAccount{})
@@ -1115,7 +1124,7 @@ func (ts *txnState) resetForNewSQLTxn(
 // willBeRetried returns true if the SQL transaction is going to be retried
 // because of err.
 func (ts *txnState) willBeRetried() bool {
-	return ts.autoRetry || ts.retryIntent
+	return ts.State() == AutoRetry || ts.retryIntent
 }
 
 // resetStateAndTxn moves the txnState into a specified state, as a result of
@@ -1135,8 +1144,9 @@ func (ts *txnState) resetStateAndTxn(state TxnStateEnum) {
 	ts.mu.Unlock()
 }
 
-// finishSQLTxn closes the root span for the current SQL txn.  This needs to be
-// called before resetForNewSQLTxn() is called for starting another SQL txn.
+// finishSQLTxn finalizes a transaction's results and closes the root span for
+// the current SQL txn. This needs to be called before resetForNewSQLTxn() is
+// called for starting another SQL txn.
 func (ts *txnState) finishSQLTxn(s *Session) {
 	ts.mon.Stop(ts.Ctx)
 	if ts.cancel != nil {
@@ -1146,6 +1156,11 @@ func (ts *txnState) finishSQLTxn(s *Session) {
 	if ts.sp == nil {
 		panic("No span in context? Was resetForNewSQLTxn() called previously?")
 	}
+
+	// Finalize the transaction's results.
+	ts.txnResults.Close()
+	ts.txnResults = nil
+
 	sampledFor7881 := (ts.sp.BaggageItem(keyFor7881Sample) != "")
 	ts.sp.Finish()
 	if err := s.Tracing.onFinishSQLTxn(ts.sp); err != nil {

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -290,11 +290,10 @@ type Session struct {
 	// indicate to Finish() that the session is already closed.
 	emergencyShutdown bool
 
-	// ResultWriter is where the results of query/statement should be written
-	// to, including errors when they happen. This corresponds to a network
-	// connection (pgwire.v3conn) for client connections and a
+	// ResultsWriter is where query results are written to. It's set to a
+	// pgwire.v3conn for sessions opened for SQL client connections and a
 	// bufferedResultWriter for internal uses.
-	ResultWriter ResultWriter
+	ResultsWriter ResultsWriter
 
 	Tracing SessionTracing
 

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -405,7 +405,7 @@ func TestShowQueries(t *testing.T) {
 				UseDatabase: "test",
 				Knobs: base.TestingKnobs{
 					SQLExecutor: &sql.ExecutorTestingKnobs{
-						StatementFilter: func(ctx context.Context, stmt string, resultWriter sql.ResultWriter, err error) error {
+						StatementFilter: func(ctx context.Context, stmt string, resultWriter sql.ResultsWriter, err error) error {
 							if stmt == selectStmt {
 								const showQuery = "SELECT node_id, query FROM [SHOW CLUSTER QUERIES]"
 

--- a/pkg/sql/txn.go
+++ b/pkg/sql/txn.go
@@ -23,15 +23,13 @@ import (
 
 // BeginTransaction starts a new transaction.
 func (p *planner) BeginTransaction(n *parser.BeginTransaction) (planNode, error) {
-	if p.txn == nil {
-		return nil, errors.Errorf("the server should have already created a transaction")
+	if p.session.TxnState.State() != AutoRetry || p.txn == nil {
+		return nil, errors.Errorf("the server should have already created a transaction. "+
+			"state: %s", p.session.TxnState.State())
 	}
 	if err := p.setTransactionModes(n.Modes); err != nil {
 		return nil, err
 	}
-
-	// Enter the FirstBatch state.
-	p.session.TxnState.SetState(FirstBatch)
 
 	return &zeroNode{}, nil
 }

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -336,7 +336,7 @@ func (ta *TxnAborter) GetExecCount(stmt string) (int, bool) {
 }
 
 func (ta *TxnAborter) statementFilter(
-	ctx context.Context, stmt string, r sql.ResultWriter, err error,
+	ctx context.Context, stmt string, r sql.ResultsWriter, err error,
 ) error {
 	ta.mu.Lock()
 	ri, ok := ta.mu.stmtsToAbort[stmt]
@@ -1671,7 +1671,7 @@ func TestPushedTxnDetection(t *testing.T) {
 	var s serverutils.TestServerInterface
 	params, _ := createTestServerParams()
 	params.Knobs.SQLExecutor = &sql.ExecutorTestingKnobs{
-		StatementFilter: func(ctx context.Context, stmt string, r sql.ResultWriter, err error) error {
+		StatementFilter: func(ctx context.Context, stmt string, r sql.ResultsWriter, err error) error {
 			if atomic.LoadInt64(&injectRead) == 0 {
 				return nil
 			}

--- a/pkg/sql/txnstateenum_string.go
+++ b/pkg/sql/txnstateenum_string.go
@@ -4,9 +4,9 @@ package sql
 
 import "fmt"
 
-const _TxnStateEnum_name = "NoTxnFirstBatchOpenAbortedRestartWaitCommitWait"
+const _TxnStateEnum_name = "NoTxnAutoRetryOpenAbortedRestartWaitCommitWait"
 
-var _TxnStateEnum_index = [...]uint8{0, 5, 15, 19, 26, 37, 47}
+var _TxnStateEnum_index = [...]uint8{0, 5, 14, 18, 25, 36, 46}
 
 func (i TxnStateEnum) String() string {
 	if i < 0 || i >= TxnStateEnum(len(_TxnStateEnum_index)-1) {

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -342,7 +342,7 @@ func eventlogUniqueIDDefault(ctx context.Context, r runner) error {
 	var err error
 	for retry := retry.Start(retry.Options{MaxRetries: 5}); retry.Next(); {
 		var res sql.StatementResults
-		res, err = r.sqlExecutor.ExecuteStatementsBuffered(session, alterStmt, nil, 1)
+		res, err = r.sqlExecutor.ExecuteStatementsBuffered(session, alterStmt, nil /* pinfo */, 1 /* expectedNumResults */)
 		if err == nil {
 			res.Close(ctx)
 			break


### PR DESCRIPTION
The ResultsGroup interface is meant to represent a transaction's
results. Its main affordance, besides allowing statement results to be
streamed, is letting the client Reset() it, discarding all accumulated
results. This is meant to support automatic txn retries, when previous
results need to be dropped.
Instances of ResultsGroup were supposed to correspond to transaction but
that's not what the code was doing. A ResultsGroup was created for each
transaction, but one was also created at the beginning of each batch
regardless of whether we were already inside a txn or not.

This patch properly ties ResultsGroups to txns, like the interface
intended (otherwise it's hard to say what one of these "groups" is). The
group can now be stored in the txnState, where it belongs, and
initialized/closed in resetStateForNewSQLTxni()/finishSQLTxn(), like its
other txn-scoped brethren. This also means that ResultsGroups are now
always closed - before you could have dangling ones which is a violation
of the interface contract.

This proper scoping triggered the need for an extension to the
interface: the point of the interface is letting you discard past
results, but not all results should be discarded. Namely, results of
special statements that leave a txn in the FirstBatch state (BEGIN,
SAVEPOINT, etc) should not be discarded, because they will not be
retried. More exactly, before this patch, whether or not these
statements were automatically retried depended on whether they happened
to be part of the same batch as the later statement that caught a
retriable error - if so, they were retried, if not they weren't. When
they were retried, their previous results were _not_ Reset(), and
vice-versa. This is where the fact that we created new groups for new
batches was useful: it helped with not resetting results from a previous
batch.  The new solution to this problem is a Flush() method, which
provides a reference point for future Reset()s - they'll only discard up
to the flush point, going backwards.

The introduction of Flush() in turn triggered a modest restructuring of
Executor internals; the problem is that the natural time to Flush() is
when transitioning from the FirstBatch state to Open. But, alas, before
this patch, automatic retries were scoped like invocations of
execStmtsInCurrentTxn(), which dealt with all the statements in a
transaction (or at least a prefix of a transaction, if a statements
batch finished in the middle of a txn). The FirstBatch->Open transition
happened within a call to execStmtsInCurrentTxn() and so, if we were to
Flush() at this time and then retry, statements that we've flushed would
be re-executed and produce duplicate resuls => no good.
This patch solves the issue by having changing the semantics of
FirstBatch and the moment when the state transition happens. FirstBatch
never had a proper definition; it has now been renamed to AutoRetry and
gets clear semantics - this state is like Open, plus, if a retriable
error happens while we're in this state, we can auto-retry the
transaction (more exactly, we can retry the transaction by retrying the
part of the current batch that is part of the current transaction).
The txnState.autoRetry field is gone - a big win in itself. The state
alone now dictates whether we can auto-retry or not.
Transactions always start in AutoRetry and move to Open at the end of a
batch.