### PR TITLE
storage: avoid transaction ID pointers in timestamp cache API

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2241,7 +2241,7 @@ func (r *Replica) applyTimestampCache(ba *roachpb.BatchRequest) (bool, *roachpb.
 			// Forward the timestamp if there's been a more recent read (by someone else).
 			rTS, rTxnID, _ := r.store.tsCacheMu.cache.GetMaxRead(header.Key, header.EndKey)
 			if ba.Txn != nil {
-				if rTxnID == nil || ba.Txn.ID != *rTxnID {
+				if ba.Txn.ID != rTxnID {
 					nextTS := rTS.Next()
 					if ba.Txn.Timestamp.Less(nextTS) {
 						txn := ba.Txn.Clone()
@@ -2259,7 +2259,7 @@ func (r *Replica) applyTimestampCache(ba *roachpb.BatchRequest) (bool, *roachpb.
 			// write timestamp cache.
 			wTS, wTxnID, _ := r.store.tsCacheMu.cache.GetMaxWrite(header.Key, header.EndKey)
 			if ba.Txn != nil {
-				if wTxnID == nil || ba.Txn.ID != *wTxnID {
+				if ba.Txn.ID != wTxnID {
 					if !wTS.Less(ba.Txn.Timestamp) {
 						txn := ba.Txn.Clone()
 						bumped = txn.Timestamp.Forward(wTS.Next()) || bumped

--- a/pkg/storage/timestamp_cache.go
+++ b/pkg/storage/timestamp_cache.go
@@ -20,14 +20,12 @@ import (
 	"unsafe"
 
 	"github.com/google/btree"
-	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -153,14 +151,14 @@ type timestampCache struct {
 // timestamp cache for a range. Also see timestampCache.getMax where this txn
 // ID is checked in order to return whether the max read/write timestamp came
 // from a regular entry or one of these low water mark entries.
-var lowWaterTxnIDMarker = func() *uuid.UUID {
+var lowWaterTxnIDMarker = func() uuid.UUID {
 	// The specific txn ID used here isn't important. We use something that is a)
 	// non-zero and b) obvious.
 	u, err := uuid.FromString("11111111-1111-1111-1111-111111111111")
 	if err != nil {
-		log.Fatal(context.Background(), err)
+		panic(err)
 	}
-	return &u
+	return u
 }()
 
 // A cacheValue combines the timestamp with an optional txn ID.
@@ -229,7 +227,7 @@ func (tc *timestampCache) len() int {
 // whether the command adding this timestamp should update the read
 // timestamp; false to update the write timestamp cache.
 func (tc *timestampCache) add(
-	start, end roachpb.Key, timestamp hlc.Timestamp, txnID *uuid.UUID, readTSCache bool,
+	start, end roachpb.Key, timestamp hlc.Timestamp, txnID uuid.UUID, readTSCache bool,
 ) {
 	// This gives us a memory-efficient end key if end is empty.
 	if len(end) == 0 {
@@ -245,12 +243,8 @@ func (tc *timestampCache) add(
 			tcache = tc.rCache
 		}
 
-		if txnID == nil {
-			txnID = &zeroTxnID
-		}
-
 		addRange := func(r interval.Range) {
-			value := cacheValue{timestamp: timestamp, txnID: *txnID}
+			value := cacheValue{timestamp: timestamp, txnID: txnID}
 			key := tcache.MakeKey(r.Start, r.End)
 			entry := makeCacheEntry(key, value)
 			tc.bytes += cacheEntrySize(r.Start, r.End)
@@ -294,7 +288,7 @@ func (tc *timestampCache) add(
 					//
 					// New: ------------
 					// Old:
-					*cv = cacheValue{timestamp: timestamp, txnID: *txnID}
+					*cv = cacheValue{timestamp: timestamp, txnID: txnID}
 					tcache.MoveToEnd(entry)
 					return
 				case sCmp <= 0 && eCmp >= 0:
@@ -391,7 +385,7 @@ func (tc *timestampCache) add(
 				default:
 					panic(fmt.Sprintf("no overlap between %v and %v", key.Range, r))
 				}
-			} else if cv.txnID == *txnID {
+			} else if cv.txnID == txnID {
 				// The existing interval has a timestamp equal to the new
 				// interval, and the same transaction ID.
 				switch {
@@ -489,7 +483,7 @@ func (tc *timestampCache) add(
 					cv.txnID = zeroTxnID
 
 					newKey := tcache.MakeKey(r.Start, key.Start)
-					newEntry := makeCacheEntry(newKey, cacheValue{timestamp: timestamp, txnID: *txnID})
+					newEntry := makeCacheEntry(newKey, cacheValue{timestamp: timestamp, txnID: txnID})
 					addEntryAfter(newEntry, entry)
 					r.Start = key.End
 				case sCmp > 0 && eCmp < 0:
@@ -502,7 +496,7 @@ func (tc *timestampCache) add(
 					// New:
 					// Nil:     ====
 					// Old: ----    ----
-					*txnID = zeroTxnID
+					txnID = zeroTxnID
 					oldEnd := key.End
 					key.End = r.Start
 
@@ -519,7 +513,7 @@ func (tc *timestampCache) add(
 					// New:
 					// Nil:     ========
 					// Old: ----
-					*txnID = zeroTxnID
+					txnID = zeroTxnID
 					key.End = r.Start
 				case sCmp == 0:
 					// Old contains new, left-aligned; truncate old start and
@@ -530,7 +524,7 @@ func (tc *timestampCache) add(
 					// New:
 					// Nil: ========
 					// Old:         ----
-					*txnID = zeroTxnID
+					txnID = zeroTxnID
 					key.Start = r.End
 				case eCmp > 0:
 					// Left partial overlap; truncate old end and split new into
@@ -656,11 +650,11 @@ func (tc *timestampCache) ExpandRequests(timestamp hlc.Timestamp, span roachpb.R
 		tc.bytes -= reqSize
 		for i := range req.reads {
 			sp := &req.reads[i]
-			tc.add(sp.Key, sp.EndKey, req.timestamp, &req.txnID, true /* readTSCache */)
+			tc.add(sp.Key, sp.EndKey, req.timestamp, req.txnID, true /* readTSCache */)
 		}
 		for i := range req.writes {
 			sp := &req.writes[i]
-			tc.add(sp.Key, sp.EndKey, req.timestamp, &req.txnID, false /* !readTSCache */)
+			tc.add(sp.Key, sp.EndKey, req.timestamp, req.txnID, false /* !readTSCache */)
 		}
 		if req.txn.Key != nil {
 			// Make the transaction key from the request key. We're guaranteed
@@ -668,7 +662,7 @@ func (tc *timestampCache) ExpandRequests(timestamp hlc.Timestamp, span roachpb.R
 			// EndTransactionRequests.
 			key := keys.TransactionKey(req.txn.Key, req.txnID)
 			// We set txnID=nil because we want hits for same txn ID.
-			tc.add(key, nil, req.timestamp, nil, false /* !readTSCache */)
+			tc.add(key, nil, req.timestamp, zeroTxnID, false /* !readTSCache */)
 		}
 	}
 }
@@ -681,7 +675,7 @@ func (tc *timestampCache) ExpandRequests(timestamp hlc.Timestamp, span roachpb.R
 // the read timestamps. Also returns an "ok" bool, indicating whether
 // an explicit match of the interval was found in the cache (as
 // opposed to using the low-water mark).
-func (tc *timestampCache) GetMaxRead(start, end roachpb.Key) (hlc.Timestamp, *uuid.UUID, bool) {
+func (tc *timestampCache) GetMaxRead(start, end roachpb.Key) (hlc.Timestamp, uuid.UUID, bool) {
 	return tc.getMax(start, end, true)
 }
 
@@ -693,19 +687,19 @@ func (tc *timestampCache) GetMaxRead(start, end roachpb.Key) (hlc.Timestamp, *uu
 // the write timestamps. Also returns an "ok" bool, indicating whether
 // an explicit match of the interval was found in the cache (as
 // opposed to using the low-water mark).
-func (tc *timestampCache) GetMaxWrite(start, end roachpb.Key) (hlc.Timestamp, *uuid.UUID, bool) {
+func (tc *timestampCache) GetMaxWrite(start, end roachpb.Key) (hlc.Timestamp, uuid.UUID, bool) {
 	return tc.getMax(start, end, false)
 }
 
 func (tc *timestampCache) getMax(
 	start, end roachpb.Key, readTSCache bool,
-) (hlc.Timestamp, *uuid.UUID, bool) {
+) (hlc.Timestamp, uuid.UUID, bool) {
 	if len(end) == 0 {
 		end = start.Next()
 	}
 	var ok bool
 	maxTS := tc.lowWater
-	var maxTxnID *uuid.UUID
+	var maxTxnID uuid.UUID
 	cache := tc.wCache
 	if readTSCache {
 		cache = tc.rCache
@@ -715,17 +709,12 @@ func (tc *timestampCache) getMax(
 		if maxTS.Less(ce.timestamp) {
 			ok = true
 			maxTS = ce.timestamp
-			if ce.txnID == zeroTxnID {
-				maxTxnID = nil
-			} else {
-				maxTxnID = &ce.txnID
-			}
-		} else if maxTS == ce.timestamp && maxTxnID != nil &&
-			(ce.txnID == zeroTxnID || *maxTxnID != ce.txnID) {
-			maxTxnID = nil
+			maxTxnID = ce.txnID
+		} else if maxTS == ce.timestamp && maxTxnID != ce.txnID {
+			maxTxnID = zeroTxnID
 		}
 	}
-	if maxTxnID != nil && *maxTxnID == *lowWaterTxnIDMarker {
+	if maxTxnID == lowWaterTxnIDMarker {
 		ok = false
 	}
 	return maxTS, maxTxnID, ok

--- a/pkg/storage/timestamp_cache_test.go
+++ b/pkg/storage/timestamp_cache_test.go
@@ -36,7 +36,7 @@ func TestTimestampCache(t *testing.T) {
 	tc.lowWater = hlc.Timestamp{WallTime: baseTS}
 
 	// First simulate a read of just "a" at time 50.
-	tc.add(roachpb.Key("a"), nil, hlc.Timestamp{WallTime: 50}, nil, true)
+	tc.add(roachpb.Key("a"), nil, hlc.Timestamp{WallTime: 50}, zeroTxnID, true)
 	// Although we added "a" at time 50, the internal cache should still
 	// be empty because the t=50 < baseTS.
 	if tc.rCache.Len() > 0 {
@@ -61,7 +61,7 @@ func TestTimestampCache(t *testing.T) {
 
 	// Sim a read of "b"-"c" at a time above the low-water mark.
 	ts := clock.Now()
-	tc.add(roachpb.Key("b"), roachpb.Key("c"), ts, nil, true)
+	tc.add(roachpb.Key("b"), roachpb.Key("c"), ts, zeroTxnID, true)
 
 	// Verify all permutations of direct and range access.
 	if rTS, _, ok := tc.GetMaxRead(roachpb.Key("b"), nil); rTS != ts || !ok {
@@ -113,11 +113,11 @@ func TestTimestampCacheEviction(t *testing.T) {
 	// Increment time to the low water mark + 1.
 	manual.Increment(1)
 	aTS := clock.Now()
-	tc.add(roachpb.Key("a"), nil, aTS, nil, true)
+	tc.add(roachpb.Key("a"), nil, aTS, zeroTxnID, true)
 
 	// Increment time by the MinTSCacheWindow and add another key.
 	manual.Increment(MinTSCacheWindow.Nanoseconds())
-	tc.add(roachpb.Key("b"), nil, clock.Now(), nil, true)
+	tc.add(roachpb.Key("b"), nil, clock.Now(), zeroTxnID, true)
 
 	// Verify looking up key "c" returns the new low water mark ("a"'s timestamp).
 	if rTS, _, ok := tc.GetMaxRead(roachpb.Key("c"), nil); rTS != aTS || ok {
@@ -138,7 +138,7 @@ func TestTimestampCacheNoEviction(t *testing.T) {
 	// Increment time to the low water mark + 1.
 	manual.Increment(1)
 	aTS := clock.Now()
-	tc.add(roachpb.Key("a"), nil, aTS, nil, true)
+	tc.add(roachpb.Key("a"), nil, aTS, zeroTxnID, true)
 	tc.AddRequest(cacheRequest{
 		reads:     []roachpb.Span{{Key: roachpb.Key("c")}},
 		timestamp: aTS,
@@ -146,7 +146,7 @@ func TestTimestampCacheNoEviction(t *testing.T) {
 
 	// Increment time by the MinTSCacheWindow and add another key.
 	manual.Increment(MinTSCacheWindow.Nanoseconds())
-	tc.add(roachpb.Key("b"), nil, clock.Now(), nil, true)
+	tc.add(roachpb.Key("b"), nil, clock.Now(), zeroTxnID, true)
 	tc.AddRequest(cacheRequest{
 		reads:     []roachpb.Span{{Key: roachpb.Key("d")}},
 		timestamp: clock.Now(),
@@ -190,7 +190,7 @@ func TestTimestampCacheExpandRequests(t *testing.T) {
 
 type txnState struct {
 	ts hlc.Timestamp
-	id *uuid.UUID
+	id uuid.UUID
 }
 
 type layeredIntervalTestCase struct {
@@ -207,7 +207,7 @@ func assertTS(
 	tc *timestampCache,
 	start, end roachpb.Key,
 	expectedTS hlc.Timestamp,
-	expectedTxnID *uuid.UUID,
+	expectedTxnID uuid.UUID,
 ) {
 	var keys string
 	if len(end) == 0 {
@@ -219,28 +219,19 @@ func assertTS(
 	if ts != expectedTS {
 		t.Errorf("expected %s to have timestamp %v, found %v", keys, expectedTS, ts)
 	}
-	if expectedTxnID == nil {
-		if txnID != nil {
-			t.Errorf("expected %s to have no txn id, but found %s", keys, txnID.Short())
-		}
-	} else {
-		if txnID == nil {
-			t.Errorf("expected %s to have txn id %s, but found nil", keys, expectedTxnID.Short())
-		} else if *txnID != *expectedTxnID {
-			t.Errorf("expected %s to have txn id %s, but found %s",
-				keys, expectedTxnID.Short(), txnID.Short())
-		}
+	if txnID != expectedTxnID {
+		t.Errorf("expected %s to have txn id %s, but found %s", keys, expectedTxnID.Short(), txnID.Short())
 	}
 }
 
-// nilIfSimul returns nil if this test involves multiple transactions
-// with the same timestamp (i.e. the timestamps in txns are identical
-// but the transaction ids are not), and the given txnID if they are
-// not. This is because timestampCache.GetMaxRead must not return a
-// transaction ID when two different transactions have the same timestamp.
-func nilIfSimul(txns []txnState, txnID *uuid.UUID) *uuid.UUID {
-	if txns[0].ts == txns[1].ts && *txns[0].id != *txns[1].id {
-		return nil
+// zeroIfSimul returns zeroTxnID if this test involves multiple transactions
+// with the same timestamp (i.e. the timestamps in txns are identical but the
+// transaction ids are not), and the given txnID if they are not. This is
+// because timestampCache.GetMaxRead must not return a transaction ID when two
+// different transactions have the same timestamp.
+func zeroIfSimul(txns []txnState, txnID uuid.UUID) uuid.UUID {
+	if txns[0].ts == txns[1].ts && txns[0].id != txns[1].id {
+		return zeroTxnID
 	}
 	return txnID
 }
@@ -264,14 +255,14 @@ var layeredIntervalTestCase1 = layeredIntervalTestCase{
 		abbTx, beTx, cTx := txns[0], txns[1], txns[2]
 
 		assertTS(t, tc, roachpb.Key("a"), nil, abbTx.ts, abbTx.id)
-		assertTS(t, tc, roachpb.Key("b"), nil, beTx.ts, nilIfSimul(txns, beTx.id))
-		assertTS(t, tc, roachpb.Key("c"), nil, cTx.ts, nilIfSimul(txns, cTx.id))
+		assertTS(t, tc, roachpb.Key("b"), nil, beTx.ts, zeroIfSimul(txns, beTx.id))
+		assertTS(t, tc, roachpb.Key("c"), nil, cTx.ts, zeroIfSimul(txns, cTx.id))
 		assertTS(t, tc, roachpb.Key("d"), nil, beTx.ts, beTx.id)
 		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("b"), abbTx.ts, abbTx.id)
-		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("c"), beTx.ts, nilIfSimul(txns, beTx.id))
-		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("d"), cTx.ts, nilIfSimul(txns, cTx.id))
-		assertTS(t, tc, roachpb.Key("b"), roachpb.Key("d"), cTx.ts, nilIfSimul(txns, cTx.id))
-		assertTS(t, tc, roachpb.Key("c"), roachpb.Key("d"), cTx.ts, nilIfSimul(txns, cTx.id))
+		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("c"), beTx.ts, zeroIfSimul(txns, beTx.id))
+		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("d"), cTx.ts, zeroIfSimul(txns, cTx.id))
+		assertTS(t, tc, roachpb.Key("b"), roachpb.Key("d"), cTx.ts, zeroIfSimul(txns, cTx.id))
+		assertTS(t, tc, roachpb.Key("c"), roachpb.Key("d"), cTx.ts, zeroIfSimul(txns, cTx.id))
 		assertTS(t, tc, roachpb.Key("c0"), roachpb.Key("d"), beTx.ts, beTx.id)
 	},
 }
@@ -295,11 +286,11 @@ var layeredIntervalTestCase2 = layeredIntervalTestCase{
 		_, bfTx, acTx := txns[0], txns[1], txns[2]
 
 		assertTS(t, tc, roachpb.Key("a"), nil, acTx.ts, acTx.id)
-		assertTS(t, tc, roachpb.Key("b"), nil, acTx.ts, nilIfSimul(txns, acTx.id))
+		assertTS(t, tc, roachpb.Key("b"), nil, acTx.ts, zeroIfSimul(txns, acTx.id))
 		assertTS(t, tc, roachpb.Key("c"), nil, bfTx.ts, bfTx.id)
-		assertTS(t, tc, roachpb.Key("d"), nil, bfTx.ts, nilIfSimul(txns, bfTx.id))
-		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("c"), acTx.ts, nilIfSimul(txns, acTx.id))
-		assertTS(t, tc, roachpb.Key("b"), roachpb.Key("d"), acTx.ts, nilIfSimul(txns, acTx.id))
+		assertTS(t, tc, roachpb.Key("d"), nil, bfTx.ts, zeroIfSimul(txns, bfTx.id))
+		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("c"), acTx.ts, zeroIfSimul(txns, acTx.id))
+		assertTS(t, tc, roachpb.Key("b"), roachpb.Key("d"), acTx.ts, zeroIfSimul(txns, acTx.id))
 		assertTS(t, tc, roachpb.Key("c"), roachpb.Key("d"), bfTx.ts, bfTx.id)
 		assertTS(t, tc, roachpb.Key("c0"), roachpb.Key("d"), bfTx.ts, bfTx.id)
 	},
@@ -321,11 +312,11 @@ var layeredIntervalTestCase3 = layeredIntervalTestCase{
 		acTx, bcTx := txns[0], txns[1]
 
 		assertTS(t, tc, roachpb.Key("a"), nil, acTx.ts, acTx.id)
-		assertTS(t, tc, roachpb.Key("b"), nil, bcTx.ts, nilIfSimul(txns, bcTx.id))
-		assertTS(t, tc, roachpb.Key("c"), nil, tc.lowWater, nil)
-		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("c"), bcTx.ts, nilIfSimul(txns, bcTx.id))
+		assertTS(t, tc, roachpb.Key("b"), nil, bcTx.ts, zeroIfSimul(txns, bcTx.id))
+		assertTS(t, tc, roachpb.Key("c"), nil, tc.lowWater, zeroTxnID)
+		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("c"), bcTx.ts, zeroIfSimul(txns, bcTx.id))
 		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("b"), acTx.ts, acTx.id)
-		assertTS(t, tc, roachpb.Key("b"), roachpb.Key("c"), bcTx.ts, nilIfSimul(txns, bcTx.id))
+		assertTS(t, tc, roachpb.Key("b"), roachpb.Key("c"), bcTx.ts, zeroIfSimul(txns, bcTx.id))
 	},
 }
 
@@ -344,11 +335,11 @@ var layeredIntervalTestCase4 = layeredIntervalTestCase{
 	validator: func(t *testing.T, tc *timestampCache, txns []txnState) {
 		acTx, abTx := txns[0], txns[1]
 
-		assertTS(t, tc, roachpb.Key("a"), nil, abTx.ts, nilIfSimul(txns, abTx.id))
+		assertTS(t, tc, roachpb.Key("a"), nil, abTx.ts, zeroIfSimul(txns, abTx.id))
 		assertTS(t, tc, roachpb.Key("b"), nil, acTx.ts, acTx.id)
-		assertTS(t, tc, roachpb.Key("c"), nil, tc.lowWater, nil)
-		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("c"), abTx.ts, nilIfSimul(txns, abTx.id))
-		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("b"), abTx.ts, nilIfSimul(txns, abTx.id))
+		assertTS(t, tc, roachpb.Key("c"), nil, tc.lowWater, zeroTxnID)
+		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("c"), abTx.ts, zeroIfSimul(txns, abTx.id))
+		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("b"), abTx.ts, zeroIfSimul(txns, abTx.id))
 		assertTS(t, tc, roachpb.Key("b"), roachpb.Key("c"), acTx.ts, acTx.id)
 	},
 }
@@ -360,7 +351,7 @@ var layeredIntervalTestCase5 = layeredIntervalTestCase{
 		{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
 	},
 	validator: func(t *testing.T, tc *timestampCache, txns []txnState) {
-		assertTS(t, tc, roachpb.Key("a"), nil, txns[1].ts, nilIfSimul(txns, txns[1].id))
+		assertTS(t, tc, roachpb.Key("a"), nil, txns[1].ts, zeroIfSimul(txns, txns[1].id))
 	},
 }
 
@@ -414,12 +405,11 @@ func TestTimestampCacheLayeredIntervals(t *testing.T) {
 									if sameTxn {
 										id := uuid.MakeV4()
 										for i := range testCase.spans {
-											txns[i].id = &id
+											txns[i].id = id
 										}
 									} else {
 										for i := range testCase.spans {
-											u := uuid.MakeV4()
-											txns[i].id = &u
+											txns[i].id = uuid.MakeV4()
 										}
 									}
 
@@ -466,7 +456,7 @@ func TestTimestampCacheClear(t *testing.T) {
 	key := roachpb.Key("a")
 
 	ts := clock.Now()
-	tc.add(key, nil, ts, nil, true)
+	tc.add(key, nil, ts, zeroTxnID, true)
 
 	manual.Increment(5000000)
 
@@ -494,15 +484,15 @@ func TestTimestampCacheReadVsWrite(t *testing.T) {
 
 	// Add read-only non-txn entry at current time.
 	ts1 := clock.Now()
-	tc.add(roachpb.Key("a"), roachpb.Key("b"), ts1, nil, true)
+	tc.add(roachpb.Key("a"), roachpb.Key("b"), ts1, zeroTxnID, true)
 
 	// Add two successive txn entries; one read-only and one read-write.
 	txn1ID := uuid.MakeV4()
 	txn2ID := uuid.MakeV4()
 	ts2 := clock.Now()
-	tc.add(roachpb.Key("a"), nil, ts2, &txn1ID, true)
+	tc.add(roachpb.Key("a"), nil, ts2, txn1ID, true)
 	ts3 := clock.Now()
-	tc.add(roachpb.Key("a"), nil, ts3, &txn2ID, false)
+	tc.add(roachpb.Key("a"), nil, ts3, txn2ID, false)
 
 	rTS, _, rOK := tc.GetMaxRead(roachpb.Key("a"), nil)
 	wTS, _, wOK := tc.GetMaxWrite(roachpb.Key("a"), nil)
@@ -526,18 +516,18 @@ func TestTimestampCacheEqualTimestamps(t *testing.T) {
 
 	// Add two non-overlapping transactions at the same timestamp.
 	ts1 := clock.Now()
-	tc.add(roachpb.Key("a"), roachpb.Key("b"), ts1, &txn1, true)
-	tc.add(roachpb.Key("b"), roachpb.Key("c"), ts1, &txn2, true)
+	tc.add(roachpb.Key("a"), roachpb.Key("b"), ts1, txn1, true)
+	tc.add(roachpb.Key("b"), roachpb.Key("c"), ts1, txn2, true)
 
 	// When querying either side separately, the transaction ID is returned.
 	if ts, txn, _ := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("b")); ts != ts1 {
 		t.Errorf("expected 'a'-'b' to have timestamp %s, but found %s", ts1, ts)
-	} else if *txn != txn1 {
+	} else if txn != txn1 {
 		t.Errorf("expected 'a'-'b' to have txn id %s, but found %s", txn1, txn)
 	}
 	if ts, txn, _ := tc.GetMaxRead(roachpb.Key("b"), roachpb.Key("c")); ts != ts1 {
 		t.Errorf("expected 'b'-'c' to have timestamp %s, but found %s", ts1, ts)
-	} else if *txn != txn2 {
+	} else if txn != txn2 {
 		t.Errorf("expected 'b'-'c' to have txn id %s, but found %s", txn2, txn)
 	}
 
@@ -545,8 +535,8 @@ func TestTimestampCacheEqualTimestamps(t *testing.T) {
 	// can proceed here.
 	if ts, txn, _ := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("c")); ts != ts1 {
 		t.Errorf("expected 'a'-'c' to have timestamp %s, but found %s", ts1, ts)
-	} else if txn != nil {
-		t.Errorf("expected 'a'-'c' to have nil txn id, but found %s", txn)
+	} else if txn != zeroTxnID {
+		t.Errorf("expected 'a'-'c' to have zero txn id, but found %s", txn)
 	}
 }
 
@@ -559,15 +549,15 @@ func BenchmarkTimestampCacheInsertion(b *testing.B) {
 		tc.Clear(clock.Now())
 
 		cdTS := clock.Now()
-		tc.add(roachpb.Key("c"), roachpb.Key("d"), cdTS, nil, true)
+		tc.add(roachpb.Key("c"), roachpb.Key("d"), cdTS, zeroTxnID, true)
 
 		beTS := clock.Now()
-		tc.add(roachpb.Key("b"), roachpb.Key("e"), beTS, nil, true)
+		tc.add(roachpb.Key("b"), roachpb.Key("e"), beTS, zeroTxnID, true)
 
 		adTS := clock.Now()
-		tc.add(roachpb.Key("a"), roachpb.Key("d"), adTS, nil, true)
+		tc.add(roachpb.Key("a"), roachpb.Key("d"), adTS, zeroTxnID, true)
 
 		cfTS := clock.Now()
-		tc.add(roachpb.Key("c"), roachpb.Key("f"), cfTS, nil, true)
+		tc.add(roachpb.Key("c"), roachpb.Key("f"), cfTS, zeroTxnID, true)
 	}
 }


### PR DESCRIPTION
d0cf7d8 changed the timestamp cache internals to avoid retaining
pointers for reasons of memory retention; this commit propagates that
change to the TS cache API surface, slightly simplifying various code
paths.

-----

@petermattis: was there a reason you avoided this in d0cf7d8?