### PR TITLE
cli/dump: format Datums with FmtParsable

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -410,7 +410,7 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, md tableMetadat
 	// pk holds the last values of the fetched primary keys
 	var pk []driver.Value
 	q := fmt.Sprintf(bs, "")
-	inserts := make([][]string, 0, insertRows)
+	inserts := make([]string, 0, insertRows)
 	for {
 		rows, err := conn.Query(q, pk)
 		if err != nil {
@@ -432,39 +432,48 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, md tableMetadat
 			}
 			pk = vals[:md.numIndexCols]
 			vals = vals[md.numIndexCols:]
-			ivals := make([]string, len(vals))
+			var ivals bytes.Buffer
 			// Values need to be correctly encoded for INSERT statements in a text file.
 			for si, sv := range vals {
+				if si > 0 {
+					ivals.WriteString(", ")
+				}
+				var d parser.Datum
 				switch t := sv.(type) {
 				case nil:
-					ivals[si] = "NULL"
+					d = parser.DNull
 				case bool:
-					ivals[si] = parser.MakeDBool(parser.DBool(t)).String()
+					d = parser.MakeDBool(parser.DBool(t))
 				case int64:
-					ivals[si] = parser.NewDInt(parser.DInt(t)).String()
+					d = parser.NewDInt(parser.DInt(t))
 				case float64:
-					ivals[si] = parser.NewDFloat(parser.DFloat(t)).String()
+					d = parser.NewDFloat(parser.DFloat(t))
 				case string:
-					ivals[si] = parser.NewDString(t).String()
+					d = parser.NewDString(t)
 				case []byte:
 					switch ct := md.columnTypes[cols[si]]; ct {
 					case "INTERVAL":
-						ivals[si] = fmt.Sprintf("'%s'", t)
+						d, err = parser.ParseDInterval(string(t))
+						if err != nil {
+							panic(err)
+						}
 					case "BYTES":
-						ivals[si] = parser.NewDBytes(parser.DBytes(t)).String()
+						d = parser.NewDBytes(parser.DBytes(t))
 					default:
 						// STRING and DECIMAL types can have optional length
 						// suffixes, so only examine the prefix of the type.
 						if strings.HasPrefix(md.columnTypes[cols[si]], "STRING") {
-							ivals[si] = parser.NewDString(string(t)).String()
+							d = parser.NewDString(string(t))
 						} else if strings.HasPrefix(md.columnTypes[cols[si]], "DECIMAL") {
-							ivals[si] = string(t)
+							d, err = parser.ParseDDecimal(string(t))
+							if err != nil {
+								panic(err)
+							}
 						} else {
 							panic(errors.Errorf("unknown []byte type: %s, %v: %s", t, cols[si], md.columnTypes[cols[si]]))
 						}
 					}
 				case time.Time:
-					var d parser.Datum
 					ct := md.columnTypes[cols[si]]
 					switch ct {
 					case "DATE":
@@ -476,12 +485,12 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, md tableMetadat
 					default:
 						panic(errors.Errorf("unknown timestamp type: %s, %v: %s", t, cols[si], md.columnTypes[cols[si]]))
 					}
-					ivals[si] = d.String()
 				default:
 					panic(errors.Errorf("unknown field type: %T (%s)", t, cols[si]))
 				}
+				d.Format(&ivals, parser.FmtParsable)
 			}
-			inserts = append(inserts, ivals)
+			inserts = append(inserts, ivals.String())
 			i++
 			if len(inserts) == cap(inserts) {
 				writeInserts(w, md, inserts)
@@ -510,20 +519,13 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, md tableMetadat
 	return nil
 }
 
-func writeInserts(w io.Writer, md tableMetadata, inserts [][]string) {
+func writeInserts(w io.Writer, md tableMetadata, inserts []string) {
 	fmt.Fprintf(w, "\nINSERT INTO %s (%s) VALUES", md.name.TableName, md.columnNames)
 	for idx, values := range inserts {
 		if idx > 0 {
 			fmt.Fprint(w, ",")
 		}
-		fmt.Fprint(w, "\n\t(")
-		for vi, v := range values {
-			if vi > 0 {
-				fmt.Fprint(w, ", ")
-			}
-			fmt.Fprint(w, v)
-		}
-		fmt.Fprint(w, ")")
+		fmt.Fprintf(w, "\n\t(%s)", values)
 	}
 	fmt.Fprintln(w, ";")
 }

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -78,12 +78,12 @@ func TestDumpRow(t *testing.T) {
 		's'
 	);
 	INSERT INTO d.t VALUES (DEFAULT);
-	INSERT INTO d.t (f) VALUES (
-		CAST('+Inf' AS FLOAT)
+	INSERT INTO d.t (f, e) VALUES (
+		CAST('+Inf' AS FLOAT), CAST('+Inf' AS DECIMAL)
 	), (
-		CAST('-Inf' AS FLOAT)
+		CAST('-Inf' AS FLOAT), CAST('-Inf' AS DECIMAL)
 	), (
-		CAST('NaN' AS FLOAT)
+		CAST('NaN' AS FLOAT), CAST('NaN' AS DECIMAL)
 	);
 `
 
@@ -118,9 +118,9 @@ CREATE TABLE t (
 INSERT INTO t (i, f, s, b, d, t, n, o, e, tz, e1, e2, s1) VALUES
 	(1, 2.3, 'striiing', b'a1b2c3', '2016-03-26', '2016-01-25 10:10:10+00:00', '2h30m30s', true, 1.2345, '2016-01-25 10:10:10+00:00', 3, 4.5, 's'),
 	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-	(NULL, +Inf, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-	(NULL, -Inf, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-	(NULL, NaN, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+	(NULL, '+Inf', NULL, NULL, NULL, NULL, NULL, NULL, 'Infinity', NULL, NULL, NULL, NULL),
+	(NULL, '-Inf', NULL, NULL, NULL, NULL, NULL, NULL, '-Infinity', NULL, NULL, NULL, NULL),
+	(NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL, 'NaN', NULL, NULL, NULL, NULL);
 `
 
 	if string(out) != expect {

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -529,11 +529,18 @@ func (*DFloat) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DFloat) Format(buf *bytes.Buffer, f FmtFlags) {
 	fl := float64(*d)
+	quote := f.disambiguateDatumTypes && (math.IsNaN(fl) || math.IsInf(fl, 0))
+	if quote {
+		buf.WriteByte('\'')
+	}
 	if _, frac := math.Modf(fl); frac == 0 && -1000000 < *d && *d < 1000000 {
 		// d is a small whole number. Ensure it is printed using a decimal point.
 		fmt.Fprintf(buf, "%.1f", fl)
 	} else {
 		fmt.Fprintf(buf, "%g", fl)
+	}
+	if quote {
+		buf.WriteByte('\'')
 	}
 }
 
@@ -656,7 +663,7 @@ func (d *DDecimal) Format(buf *bytes.Buffer, f FmtFlags) {
 	}
 	buf.WriteString(d.Decimal.String())
 	if quote {
-		buf.WriteString(`'::DECIMAL`)
+		buf.WriteByte('\'')
 	}
 }
 

--- a/pkg/sql/parser/format_test.go
+++ b/pkg/sql/parser/format_test.go
@@ -164,6 +164,10 @@ func TestFormatExpr(t *testing.T) {
 			`now() - '2003-01-01 00:00:00+00:00'`},
 		{`now() - timestamp '2003-01-01'`, FmtParsable,
 			`now() - '2003-01-01 00:00:00+00:00':::TIMESTAMP`},
+		{`'+Inf':::DECIMAL + '-Inf':::DECIMAL + 'NaN':::DECIMAL`, FmtParsable,
+			`('Infinity':::DECIMAL + '-Infinity':::DECIMAL) + 'NaN':::DECIMAL`},
+		{`'+Inf':::FLOAT + '-Inf':::FLOAT + 'NaN':::FLOAT`, FmtParsable,
+			`('+Inf':::FLOAT + '-Inf':::FLOAT) + 'NaN':::FLOAT`},
 
 		{`(123:::INT, 123:::DECIMAL)`, FmtCheckEquivalence,
 			`(123:::INT, 123:::DECIMAL)`},

--- a/pkg/sql/parser/type_check_test.go
+++ b/pkg/sql/parser/type_check_test.go
@@ -104,15 +104,15 @@ func TestTypeCheck(t *testing.T) {
 		{`1:::DECIMAL + $1`, `1:::DECIMAL + $1:::DECIMAL`},
 		{`$1:::INT`, `$1:::INT`},
 
-		// These outputs, while bizarre looking, are correct and expected.
-		// The first cast is caused by ReType in normalize.go. The type annotation
-		// is caused by the call to Serialize, which formats the output using the
-		// Parseable formatter which inserts type annotations at the end of all
-		// well-typed atums. And the final cast is caused by the test itself.
-		{`'NaN'::decimal`, `'NaN'::DECIMAL:::DECIMAL::DECIMAL`},
-		{`'-NaN'::decimal`, `'NaN'::DECIMAL:::DECIMAL::DECIMAL`},
-		{`'Inf'::decimal`, `'Infinity'::DECIMAL:::DECIMAL::DECIMAL`},
-		{`'-Inf'::decimal`, `'-Infinity'::DECIMAL:::DECIMAL::DECIMAL`},
+		// These outputs, while bizarre looking, are correct and expected. The
+		// type annotation is caused by the call to Serialize, which formats the
+		// output using the Parseable formatter which inserts type annotations
+		// at the end of all well-typed datums. And the second cast is caused by
+		// the test itself.
+		{`'NaN'::decimal`, `'NaN':::DECIMAL::DECIMAL`},
+		{`'-NaN'::decimal`, `'NaN':::DECIMAL::DECIMAL`},
+		{`'Inf'::decimal`, `'Infinity':::DECIMAL::DECIMAL`},
+		{`'-Inf'::decimal`, `'-Infinity':::DECIMAL::DECIMAL`},
 	}
 	for _, d := range testData {
 		expr, err := ParseExpr(d.expr)
@@ -135,10 +135,10 @@ func TestTypeCheckNormalize(t *testing.T) {
 		expr     string
 		expected string
 	}{
-		{`'NaN'::decimal`, `'NaN'::DECIMAL:::DECIMAL`},
-		{`'-NaN'::decimal`, `'NaN'::DECIMAL:::DECIMAL`},
-		{`'Inf'::decimal`, `'Infinity'::DECIMAL:::DECIMAL`},
-		{`'-Inf'::decimal`, `'-Infinity'::DECIMAL:::DECIMAL`},
+		{`'NaN'::decimal`, `'NaN':::DECIMAL`},
+		{`'-NaN'::decimal`, `'NaN':::DECIMAL`},
+		{`'Inf'::decimal`, `'Infinity':::DECIMAL`},
+		{`'-Inf'::decimal`, `'-Infinity':::DECIMAL`},
 	}
 	for _, d := range testData {
 		t.Run(d.expr, func(t *testing.T) {


### PR DESCRIPTION
Fixes #17981.

`cockroach dump` was not using an `FmtFlag` with `disambiguateDatumTypes`,
which meant that certain values like `NaN` and `Inf` did not round-trip.

To do this we needed to treat `disambiguateDatumTypes` correctly in `DFloat`, which
is what the first commit addresses.