### PR TITLE
storageccl: turn default import batch size down to 32MB

### DIFF
--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -42,7 +42,7 @@ var importRequestLimiter = makeConcurrentRequestLimiter(importRequestLimit)
 var importBatchSize = settings.RegisterByteSizeSetting(
 	"kv.import.batch_size",
 	"",
-	63<<20,
+	32<<20,
 )
 
 // AddSSTableEnabled wraps "kv.import.experimental_addsstable.enabled".


### PR DESCRIPTION
63MB seemed like a safe size for the import batch size, but resulted in errors
like

    command is too large: 68166516 bytes (max: 67108864)

on some restores. Turn the size down to 32MB to avoid these errors.