### PR TITLE
sql: logic test directive fixes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Case sensitivity of database names
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/dangerous_statements
+++ b/pkg/sql/logictest/testdata/logic_test/dangerous_statements
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE foo(x INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/deep_interleaving
+++ b/pkg/sql/logictest/testdata/logic_test/deep_interleaving
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Test index selection for deeply interleaved tables.
 # These tests are in their own file because table IDs appear in the EXPLAIN output.
 
@@ -69,7 +71,7 @@ EXPLAIN SELECT * FROM level4
 0  ·     table  level4@primary
 0  ·     spans  ALL
 
-query III
+query III rowsort
 SELECT * FROM level4
 ----
 1  10  100
@@ -107,7 +109,7 @@ EXPLAIN SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 0  ·     table  level4@primary
 0  ·     spans  /2/#/52/1/#/53/1-/3
 
-query III
+query III rowsort
 SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 ----
 2  10  100
@@ -127,7 +129,7 @@ EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 0  ·     table  level4@primary
 0  ·     spans  /2/#/52/1/#/53/1/11-/2/#/52/1/#/53/1/30
 
-query III
+query III rowsort
 SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 ----
 2  20  100

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);
   CREATE UNIQUE INDEX test_v_idx ON test_kv(v);

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 SET SEARCH_PATH = foo
 

--- a/pkg/sql/logictest/testdata/logic_test/name_escapes
+++ b/pkg/sql/logictest/testdata/logic_test/name_escapes
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 # Check that the various things in a table definition are properly escaped when
 # printed out.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -1,3 +1,5 @@
+# LogicTest: default distsql
+
 statement ok
 CREATE TABLE kv(k INT PRIMARY KEY, v INT); CREATE INDEX foo ON kv(v DESC)
 

--- a/pkg/sql/logictest/testdata/logic_test/planning_errors
+++ b/pkg/sql/logictest/testdata/logic_test/planning_errors
@@ -1,3 +1,5 @@
+# LogicTest: default
+
 # Check that plans that fail during expansion/optimization do not cause
 # memory leaks. #17274
 

--- a/pkg/sql/logictest/testdata/logic_test/reset
+++ b/pkg/sql/logictest/testdata/logic_test/reset
@@ -1,3 +1,5 @@
+# LogicTest: default
+
 statement error unknown variable: "foo"
 RESET FOO
 

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -1,3 +1,5 @@
+# LogicTest: default
+
 query T colnames
 SELECT * FROM [SHOW client_encoding]
 ----
@@ -207,11 +209,11 @@ SELECT * FROM [SHOW CREATE TABLE system.descriptor]
 ----
 Table              CreateTable
 system.descriptor  CREATE TABLE descriptor (
-		   id INT NOT NULL,
-		   descriptor BYTES NULL,
-		   CONSTRAINT "primary" PRIMARY KEY (id ASC),
-		   FAMILY "primary" (id),
-		   FAMILY fam_2_descriptor (descriptor)
+  id INT NOT NULL,
+  descriptor BYTES NULL,
+  CONSTRAINT "primary" PRIMARY KEY (id ASC),
+  FAMILY "primary" (id),
+  FAMILY fam_2_descriptor (descriptor)
 )
 
 

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -1,3 +1,5 @@
+# LogicTest: default
+
 # Prepare a trace to be inspected below.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
+++ b/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
@@ -1,3 +1,5 @@
+# LogicTest: default
+
 statement ok
 CREATE TABLE a(x, y) AS VALUES (1, 1), (2, 2)
 


### PR DESCRIPTION
#### sql: logic test directive fixes

Adding directives to test files that lack one, along with some test corrections.

Fixes #18025.

#### sql: lint for logictest directives

Adding a linter that verifies all logictest files have directives.