### PR TITLE
storage/engine,storageccl: account for entire SST size

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -2484,11 +2484,12 @@ DBStatus DBSstFileWriterOpen(DBSstFileWriter* fw) {
   return kSuccess;
 }
 
-DBStatus DBSstFileWriterAdd(DBSstFileWriter* fw, DBKey key, DBSlice val) {
+DBStatus DBSstFileWriterAdd(DBSstFileWriter* fw, DBKey key, DBSlice val, uint64_t* file_size) {
   rocksdb::Status status = fw->rep.Add(EncodeKey(key), ToSlice(val));
   if (!status.ok()) {
     return ToDBStatus(status);
   }
+  *file_size = fw->rep.FileSize();
   return kSuccess;
 }
 

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -273,8 +273,8 @@ DBStatus DBSstFileWriterOpen(DBSstFileWriter* fw);
 // Adds a kv entry to the sstable being built. An error is returned if it is
 // not greater than any previously added entry (according to the comparator
 // configured during writer creation). `Open` must have been called. `Close`
-// cannot have been called.
-DBStatus DBSstFileWriterAdd(DBSstFileWriter* fw, DBKey key, DBSlice val);
+// cannot have been called. The updated file size is stored in `file_size`.
+DBStatus DBSstFileWriterAdd(DBSstFileWriter* fw, DBKey key, DBSlice val, uint64_t* file_size);
 
 // Finalizes the writer and stores the constructed file's contents in *data. At
 // least one kv entry must have been added. May only be called once.

--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -530,7 +530,7 @@ func writeRocksDB(
 		if err := sst.Add(kv); err != nil {
 			return 0, errors.Wrapf(err, errSSTCreationMaybeDuplicateTemplate, kv.Key.Key)
 		}
-		if sst.DataSize > sstMaxSize {
+		if sst.FileSize() > sstMaxSize {
 			if err := writeSST(firstKey, kv.Key.Key.Next()); err != nil {
 				return 0, err
 			}

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -42,7 +42,7 @@ var importRequestLimiter = makeConcurrentRequestLimiter(importRequestLimit)
 var importBatchSize = settings.RegisterByteSizeSetting(
 	"kv.import.batch_size",
 	"",
-	32<<20,
+	63<<20,
 )
 
 // AddSSTableEnabled wraps "kv.import.experimental_addsstable.enabled".
@@ -86,7 +86,8 @@ func maxImportBatchSize(st *cluster.Settings) int64 {
 
 type importBatcher interface {
 	Add(engine.MVCCKey, []byte) error
-	Size() int64
+	DataSize() int64
+	FileSize() int64
 	Finish(context.Context, *client.DB) error
 	Close()
 }
@@ -113,7 +114,11 @@ func (b *writeBatcher) Add(key engine.MVCCKey, value []byte) error {
 	return nil
 }
 
-func (b *writeBatcher) Size() int64 {
+func (b *writeBatcher) DataSize() int64 {
+	return int64(b.batch.Len())
+}
+
+func (b *writeBatcher) FileSize() int64 {
 	return int64(b.batch.Len())
 }
 
@@ -166,7 +171,11 @@ func (b *sstBatcher) Add(key engine.MVCCKey, value []byte) error {
 	return b.sstWriter.Add(engine.MVCCKeyValue{Key: key, Value: value})
 }
 
-func (b *sstBatcher) Size() int64 {
+func (b *sstBatcher) FileSize() int64 {
+	return b.sstWriter.FileSize()
+}
+
+func (b *sstBatcher) DataSize() int64 {
 	return b.sstWriter.DataSize
 }
 
@@ -354,7 +363,7 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 			return nil, errors.Wrapf(err, "adding to batch: %s -> %s", key, value.PrettyPrint())
 		}
 
-		if size := batcher.Size(); size > maxImportBatchSize(cArgs.EvalCtx.ClusterSettings()) {
+		if size := batcher.FileSize(); size > maxImportBatchSize(cArgs.EvalCtx.ClusterSettings()) {
 			finishBatcher := batcher
 			batcher = nil
 			log.Eventf(gCtx, "triggering finish of batch of size %s", humanizeutil.IBytes(size))
@@ -369,7 +378,7 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 		}
 	}
 	// Flush out the last batch.
-	if batcher.Size() > 0 {
+	if batcher.DataSize() > 0 {
 		g.Go(func() error {
 			defer log.Event(ctx, "finished batch")
 			defer batcher.Close()

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2066,6 +2066,9 @@ type RocksDBSstFileWriter struct {
 	fw *C.DBSstFileWriter
 	// DataSize tracks the total key and value bytes added so far.
 	DataSize int64
+	// fileSize tracks the total size of the SST file. It is typically larger than
+	// DataSize as it includes the overhead from the metadata and encoding scheme.
+	fileSize C.uint64_t
 }
 
 // MakeRocksDBSstFileWriter creates a new RocksDBSstFileWriter with the default
@@ -2084,7 +2087,13 @@ func (fw *RocksDBSstFileWriter) Add(kv MVCCKeyValue) error {
 		return errors.New("cannot call Open on a closed writer")
 	}
 	fw.DataSize += int64(len(kv.Key.Key)) + int64(len(kv.Value))
-	return statusToError(C.DBSstFileWriterAdd(fw.fw, goToCKey(kv.Key), goToCSlice(kv.Value)))
+	return statusToError(C.DBSstFileWriterAdd(
+		fw.fw, goToCKey(kv.Key), goToCSlice(kv.Value), &fw.fileSize))
+}
+
+// FileSize returns the current size of the SST file in bytes.
+func (fw *RocksDBSstFileWriter) FileSize() int64 {
+	return int64(fw.fileSize)
 }
 
 // Finish finalizes the writer and returns the constructed file's contents. At


### PR DESCRIPTION
We weren't properly accounting for the full size of the SST when
determining where to chunk SSTs for import. This matters now that we
need to keep the size of an AddSSTable command from exceeding the
maximum Raft command size. For context, a DataSize of 53MB can translate
to a FileSize of 64MB.