### PR TITLE
sqlccl: improve scatter usage in RESTORE

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -716,17 +716,9 @@ func restore(
 		// leaseholders, so presplit and scatter the ranges to balance the work
 		// among many nodes.
 		for i, importSpan := range importSpans {
-			var newSpan roachpb.Span
-			{
-				var ok bool
-				newSpan.Key, ok, _ = kr.RewriteKey(append([]byte(nil), importSpan.Key...))
-				if !ok {
-					return errors.Errorf("could not rewrite key: %s", importSpan.Key)
-				}
-				newSpan.EndKey, ok, _ = kr.RewriteKey(append([]byte(nil), importSpan.EndKey...))
-				if !ok {
-					return errors.Errorf("could not rewrite key: %s", importSpan.EndKey)
-				}
+			newSpan, err := kr.RewriteSpan(importSpan.Span)
+			if err != nil {
+				return err
 			}
 
 			log.VEventf(restoreCtx, 1, "presplitting %d of %d", i+1, len(importSpans))

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -211,19 +211,6 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 		return nil, errors.Wrap(err, "make key rewriter")
 	}
 
-	var importStart, importEnd roachpb.Key
-	{
-		var ok bool
-		importStart, ok, _ = kr.RewriteKey(append([]byte(nil), args.DataSpan.Key...))
-		if !ok {
-			return nil, errors.Errorf("could not rewrite span start key: %s", importStart)
-		}
-		importEnd, ok, _ = kr.RewriteKey(append([]byte(nil), args.DataSpan.EndKey...))
-		if !ok {
-			return nil, errors.Errorf("could not rewrite span end key: %s", importEnd)
-		}
-	}
-
 	if err := importRequestLimiter.beginLimitedRequest(ctx); err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -188,3 +188,23 @@ func (kr *KeyRewriter) RewriteKey(key []byte) ([]byte, bool, error) {
 	key = append(prefix, k...)
 	return key, true, nil
 }
+
+// RewriteSpan returns a new span with both Key and EndKey rewritten using
+// RewriteKey. An error is returned if either was not matched for rewrite.
+func (kr *KeyRewriter) RewriteSpan(span roachpb.Span) (roachpb.Span, error) {
+	newKey, ok, err := kr.RewriteKey(append([]byte(nil), span.Key...))
+	if err != nil {
+		return roachpb.Span{}, errors.Wrapf(err, "could not rewrite key: %s", span.Key)
+	}
+	if !ok {
+		return roachpb.Span{}, errors.Errorf("could not rewrite key: %s", span.Key)
+	}
+	newEndKey, ok, err := kr.RewriteKey(append([]byte(nil), span.EndKey...))
+	if err != nil {
+		return roachpb.Span{}, errors.Wrapf(err, "could not rewrite key: %s", span.EndKey)
+	}
+	if !ok {
+		return roachpb.Span{}, errors.Errorf("could not rewrite key: %s", span.EndKey)
+	}
+	return roachpb.Span{Key: newKey, EndKey: newEndKey}, nil
+}


### PR DESCRIPTION
Lowers BenchmarkRestore2TB from ~3.5h to ~55m. This commit is a very
close derivative of an idea that benesch had, so all credit goes to
him.

Splits and scatters are now run with some amount of parallelism but also
staying as close to the order in importSpans as possible (the more out
of order, the more work is done if a RESTORE job loses its lease and has
to be restarted).

At a high level, this is accomplished by splitting and scattering large
"chunks" from the front of importEntries in one goroutine, each of which
are in turn passed to one of many worker goroutines that split and
scatter the individual entries.

![image](https://user-images.githubusercontent.com/52528/29893935-b61f8c62-8da1-11e7-9f7e-cd2ad0428e84.png)

![image](https://user-images.githubusercontent.com/52528/29893944-bdf767ca-8da1-11e7-81d3-8817e83f1c91.png)
