### PR TITLE
sql: adjust cost function for index selection

### DIFF
--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -17,6 +17,7 @@ package sql
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"sort"
 
 	"golang.org/x/net/context"
@@ -30,6 +31,7 @@ import (
 )
 
 const nonCoveringIndexPenalty = 10
+const nonMatchingCostFactor = 2
 
 // analyzeOrderingFn is the interface through which the index selection code
 // discovers how useful is the ordering provided by a certain index. The higher
@@ -435,7 +437,13 @@ func (v *indexInfo) analyzeOrdering(
 		v.reverse = true
 	}
 	weight := float64(orderCols+1) / float64(match+1)
-	v.cost *= weight
+
+	// This is largely arbitrary - we up the priority of this slightly so that it
+	// overcomes the cost of having an index with a large number of columns.
+	// See #15649 for a case where this was an issue.
+	// This uses Pow to be consistent with the other cost modifications which are
+	// all multiplicative.
+	v.cost *= math.Pow(weight, nonMatchingCostFactor)
 
 	if match == orderCols && preferOrderMatching {
 		// Offset the non-covering index cost penalty.

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -592,6 +592,38 @@ SELECT * FROM t12022@i WHERE (c1, c2) < (2, true) ORDER BY (c1, c2);
 1  true
 2  false
 
+# Regression tests for #15649.
+
+statement ok
+CREATE TABLE test15649 (
+  id INT NOT NULL,
+  midname STRING NULL,
+  name STRING NULL,
+  CONSTRAINT "primary" PRIMARY KEY (id ASC),
+  INDEX test_name_idx (name ASC),
+  FAMILY "primary" (id, midname, name)
+)
+
+query ITTT
+EXPLAIN SELECT id FROM test15649 ORDER BY id asc LIMIT 10 offset 100;
+----
+0  limit   ·      ·
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  test15649@primary
+2  ·       spans  ALL
+2  ·       limit  110
+
+query ITTT
+EXPLAIN SELECT id FROM test15649 ORDER BY id asc LIMIT 10 offset 10000;
+----
+0  limit   ·      ·
+1  render  ·      ·
+2  scan    ·      ·
+2  ·       table  test15649@primary
+2  ·       spans  ALL
+2  ·       limit  10010
+
 # Check that no extraneous rows are fetched due to excessive batching (#15910)
 # The test is composed of three parts: populate a table, check
 # that the problematic plan is properly derived from the test query,


### PR DESCRIPTION
Fixes #15649.

This is a pretty arbitrary change, I debated making this cost add
instead of multiply, but I figured this made more sense as all the
existing cost changes are multiplicative. Not sure how to gain
confidence that this won't regress any existing index selections,
besides the fact that this passes the logic test for index selection.