### PR TITLE
sqlccl: support relative directories in nodelocal

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -1577,6 +1577,13 @@ func TestAsOfSystemTimeOnRestoredData(t *testing.T) {
 	defer cleanupFn()
 	sqlDB.Exec(`DROP TABLE data.bank`)
 
+	// backupRestoreTestSetup sets nodelocal:// on dir, so strip it off.
+	url, err := url.Parse(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir = url.Path
+
 	const numAccounts = 10
 	bankData := sampledataccl.BankRows(numAccounts)
 	backup, err := sampledataccl.ToBackup(t, bankData, filepath.Join(dir, "backup"))
@@ -1586,7 +1593,7 @@ func TestAsOfSystemTimeOnRestoredData(t *testing.T) {
 
 	var beforeTs string
 	sqlDB.QueryRow(`SELECT cluster_logical_timestamp()`).Scan(&beforeTs)
-	sqlDB.Exec(`RESTORE data.* FROM $1`, backup.BaseDir)
+	sqlDB.Exec(`RESTORE data.* FROM $1`, fmt.Sprintf("nodelocal://%s", backup.BaseDir))
 	var afterTs string
 	sqlDB.QueryRow(`SELECT cluster_logical_timestamp()`).Scan(&afterTs)
 

--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -69,13 +69,17 @@ func LoadCSV(
 	if table == "" {
 		return 0, 0, 0, errors.New("no table specified")
 	}
+	table, err = storageccl.MakeLocalStorageURI(table)
+	if err != nil {
+		return 0, 0, 0, err
+	}
 	if dest == "" {
 		return 0, 0, 0, errors.New("no destination specified")
 	}
 	if len(dataFiles) == 0 {
 		dataFiles = []string{fmt.Sprintf("%s.dat", table)}
 	}
-	createTable, err := readCreateTableFromStore(ctx, fmt.Sprintf("nodelocal://%s", table))
+	createTable, err := readCreateTableFromStore(ctx, table)
 	if err != nil {
 		return 0, 0, 0, err
 	}
@@ -88,10 +92,16 @@ func LoadCSV(
 	}
 
 	for i, f := range dataFiles {
-		dataFiles[i] = fmt.Sprintf("nodelocal://%s", f)
+		dataFiles[i], err = storageccl.MakeLocalStorageURI(f)
+		if err != nil {
+			return 0, 0, 0, err
+		}
 	}
 	// TODO(mjibson): allow users to optionally specify a full URI to an export store.
-	dest = fmt.Sprintf("nodelocal://%s", dest)
+	dest, err = storageccl.MakeLocalStorageURI(dest)
+	if err != nil {
+		return 0, 0, 0, err
+	}
 
 	rocksdbDir, err := ioutil.TempDir(tempDir, "cockroach-csv-rocksdb")
 	if err != nil {

--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -64,6 +64,20 @@ func TestLoadCSV(t *testing.T) {
 	tablePath := filepath.Join(tmp, tableName)
 	dataPath := filepath.Join(tmp, csvName)
 
+	// Make tablePath and dataPath relative to ensure relative directories work.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tablePath, err = filepath.Rel(cwd, tablePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataPath, err = filepath.Rel(cwd, dataPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if err := ioutil.WriteFile(tablePath, []byte(tableCreate), 0666); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -187,7 +187,12 @@ func TestPutLocal(t *testing.T) {
 	p, cleanupFn := testutils.TempDir(t)
 	defer cleanupFn()
 
-	testExportStore(t, fmt.Sprintf("nodelocal://%s", p), false)
+	dest, err := MakeLocalStorageURI(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testExportStore(t, dest, false)
 }
 
 func TestPutHttp(t *testing.T) {


### PR DESCRIPTION
A previous change broke relative directories for `load csv` because
nodelocal didn't treat relative directories correctly. The URLs,
when parsed, would use the first directory part as the URL host,
which was ignored, and thus broke the remainder of the path.

Due to the new checking in nodelocal about Host, this uncovered a
bug where we were double appending `nodelocal://` to some test data.