### PR TITLE
cli: Fix internal client connections to use AdvertiseAddr, not Addr

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -620,7 +620,7 @@ func setupAndInitializeLoggingAndProfiling(ctx context.Context) (*stop.Stopper, 
 }
 
 func addrWithDefaultHost(addr string) (string, error) {
-	host, port, err := net.SplitHostPort(baseCfg.Addr)
+	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
As far as I can tell, this wasn't actually breaking anything, since
getClientGRPCConn, the only caller of addrWithDefaultHost, isn't called
from within the start command, which is the only command where
AdvertiseAddr can differ from Addr.

Fixes #17143

Pulled out of #17145, which also included a much more controversial commit.