### PR TITLE
sqlccl: rename IMPORT comma option to delimiter

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	importOptionComma         = "comma"
+	importOptionDelimiter     = "delimiter"
 	importOptionComment       = "comment"
 	importOptionDistributed   = "distributed"
 	importOptionNullIf        = "nullif"
@@ -708,7 +708,7 @@ func importPlanHook(
 		}
 
 		var comma rune
-		if override, ok := opts[importOptionComma]; ok {
+		if override, ok := opts[importOptionDelimiter]; ok {
 			comma, err = util.GetSingleRune(override)
 			if err != nil {
 				return errors.Wrap(err, "invalid comma value")

--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -224,7 +224,7 @@ func TestLoadCSVPrimaryDuplicateSSTBoundary(t *testing.T) {
 	}
 }
 
-// TestLoadCSVOptions tests sqlccl.LoadCSV with the comma, comment, and nullif
+// TestLoadCSVOptions tests sqlccl.LoadCSV with the delimiter, comment, and nullif
 // options set.
 func TestLoadCSVOptions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -393,7 +393,7 @@ func TestImportStmt(t *testing.T) {
 		},
 		{
 			"schema-in-query-opts",
-			`IMPORT TABLE t (a int primary key, b string, index (b), index (a, b)) CSV DATA (%s) WITH temp = $1, comma = '|', comment = '#', nullif=''`,
+			`IMPORT TABLE t (a int primary key, b string, index (b), index (a, b)) CSV DATA (%s) WITH temp = $1, delimiter = '|', comment = '#', nullif=''`,
 			nil,
 			filesWithOpts,
 			"",
@@ -414,14 +414,14 @@ func TestImportStmt(t *testing.T) {
 		},
 		{
 			"schema-in-query-dist-opts",
-			`IMPORT TABLE t (a int primary key, b string, index (b), index (a, b)) CSV DATA (%s) WITH temp = $1, distributed, comma = '|', comment = '#', nullif=''`,
+			`IMPORT TABLE t (a int primary key, b string, index (b), index (a, b)) CSV DATA (%s) WITH temp = $1, distributed, delimiter = '|', comment = '#', nullif=''`,
 			nil,
 			filesWithOpts,
 			"",
 		},
 		{
 			"schema-in-query-transform-only",
-			`IMPORT TABLE t (a int primary key, b string, index (b), index (a, b)) CSV DATA (%s) WITH temp = $1, distributed, comma = '|', comment = '#', nullif='', transform_only`,
+			`IMPORT TABLE t (a int primary key, b string, index (b), index (a, b)) CSV DATA (%s) WITH temp = $1, distributed, delimiter = '|', comment = '#', nullif='', transform_only`,
 			nil,
 			filesWithOpts,
 			"",


### PR DESCRIPTION
This makes `load csv` and IMPORT option names the same.