### PR TITLE
libroach: emulate DB::SyncWAL on Windows using WriteBatch::LogData

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -88,8 +88,6 @@ var (
 	// is to allow a restarting node to discover approximately how long it has
 	// been down without needing to retrieve liveness records from the cluster.
 	localStoreLastUpSuffix = []byte("uptm")
-	// Windows-specific sync key. See `db.cc:DBSyncWAL` for details.
-	localStoreSyncSuffix = []byte("sync")
 
 	// LocalRangeIDPrefix is the prefix identifying per-range data
 	// indexed by Range ID. The Range ID is appended to this prefix,

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -59,12 +59,6 @@ func StoreLastUpKey() roachpb.Key {
 	return MakeStoreKey(localStoreLastUpSuffix, nil)
 }
 
-// StoreSyncKey returns a store-local key used on for emulating `DB::SyncWAL` on
-// Windows. See `db.cc:DBSyncWAL` for details.
-func StoreSyncKey() roachpb.Key {
-	return MakeStoreKey(localStoreSyncSuffix, nil)
-}
-
 // NodeLivenessKey returns the key for the node liveness record.
 func NodeLivenessKey(nodeID roachpb.NodeID) roachpb.Key {
 	key := make(roachpb.Key, 0, len(NodeLivenessPrefix)+9)

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -180,7 +180,6 @@ var constSubKeyDict = []struct {
 	{"/storeIdent", localStoreIdentSuffix},
 	{"/gossipBootstrap", localStoreGossipSuffix},
 	{"/clusterVersion", localStoreClusterVersionSuffix},
-	{"/sync", localStoreSyncSuffix},
 }
 
 func localStoreKeyPrint(key roachpb.Key) string {

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -47,7 +47,6 @@ func TestPrettyPrint(t *testing.T) {
 		{StoreIdentKey(), "/Local/Store/storeIdent"},
 		{StoreGossipKey(), "/Local/Store/gossipBootstrap"},
 		{StoreClusterVersionKey(), "/Local/Store/clusterVersion"},
-		{StoreSyncKey(), "/Local/Store/sync"},
 
 		{AbortCacheKey(roachpb.RangeID(1000001), txnID), fmt.Sprintf(`/Local/RangeID/1000001/r/AbortCache/%q`, txnID)},
 		{RaftTombstoneKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RaftTombstone"},


### PR DESCRIPTION
Using WriteBatch::LogData avoids adding a key to the memtable for every
sync (a small performance win) and also avoids the need for
StoreSyncKey().