### PR TITLE
sql: test and correct rounding for nan/inf on decimal/float

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -758,6 +758,23 @@ SELECT round(123.456::decimal, -1), round(123.456::decimal, -2), round(123.456::
 ----
 1.2E+2  1E+2  0E+3  0E+200
 
+query RRRR
+SELECT round('nan'::decimal), round('nan'::decimal, 1), round('nan'::float), round('nan'::float, 1)
+----
+NaN NaN NaN NaN
+
+# Match postgres float round for inf.
+query RRRR
+SELECT round('inf'::float), round('inf'::float, 1), round('-inf'::float), round('-inf'::float, 1)
+----
++Inf  +Inf  -Inf  -Inf
+
+# But decimal round (which isn't supported at all in postgres because
+# postgres doesn't support NaN or Inf for its decimals) conforms to
+# the GDA spec.
+query error invalid operation
+SELECT round('inf'::decimal)
+
 query error invalid operation
 SELECT round(1::decimal, 3000)
 

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1385,8 +1385,12 @@ var Builtins = map[string][]Builtin{
 			Types:      ArgTypes{{"input", TypeFloat}, {"decimal_accuracy", TypeInt}},
 			ReturnType: fixedReturnType(TypeFloat),
 			fn: func(_ *EvalContext, args Datums) (Datum, error) {
+				f := float64(*args[0].(*DFloat))
+				if math.IsInf(f, 0) || math.IsNaN(f) {
+					return args[0], nil
+				}
 				var x apd.Decimal
-				if _, err := x.SetFloat64(float64(*args[0].(*DFloat))); err != nil {
+				if _, err := x.SetFloat64(f); err != nil {
 					return nil, err
 				}
 


### PR DESCRIPTION
This matches postgres behavior for floats, and keeps to the GDA
spec for decimals, even though those are different results. This
is precedented by other behavior between decimal and float being
different, most obviously with their default rounding modes.

Fixes #15860