### PR TITLE
sql: improve the index cannot be found in any tables error

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -200,9 +200,8 @@ a  false
 b  false
 c  false
 
-# TODO(jordanlewis): https://github.com/cockroachdb/cockroach/issues/17493
-# statement ok
-# DROP INDEX i14601a
+statement ok
+DROP INDEX i14601a
 
 query TB
 SELECT a, b FROM t14601a ORDER BY a

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -767,7 +767,7 @@ func (p *planner) findTableContainingIndex(
 		result = tn
 	}
 	if result == nil {
-		return nil, fmt.Errorf("index %q does not exist", idxName)
+		return nil, fmt.Errorf("index %q not in any of the tables %v", idxName, tns)
 	}
 	return result, nil
 }


### PR DESCRIPTION
reenable disabled test in logic_test/storing because issue #17493
cannot be reproduce. We will depend on the better error message
to debug this problem when it occurs.