### PR TITLE
sql/parser: use %q for parse error

### DIFF
--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -183,7 +183,7 @@ func makeParseError(s string, typ Type, err error) error {
 		suffix = fmt.Sprintf(": %v", err)
 	}
 	return pgerror.NewErrorf(
-		pgerror.CodeInvalidTextRepresentationError, "could not parse '%s' as type %s%s", s, typ, suffix)
+		pgerror.CodeInvalidTextRepresentationError, "could not parse %q as type %s%s", s, typ, suffix)
 }
 
 func makeUnsupportedComparisonMessage(d1, d2 Datum) string {


### PR DESCRIPTION
This prevents really weird error messages that are rendered on a
terminal when a `\r` is present. For example:

```
6' as type int: strconv.ParseInt: parsing "3\r6": invalid syntaxparse "test1" as INTEGER: could not parse '3
```

Which was supposed to be

```
pq: <omitted>: row 4: parse "test1" as INTEGER: could not parse '3
6' as type int: strconv.ParseInt: parsing "3\r6": invalid syntax
```