### PR TITLE
storage: account for sideloaded data in Replica.mu.raftLogSize

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3273,15 +3273,18 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	if len(rd.Entries) > 0 {
 		// All of the entries are appended to distinct keys, returning a new
 		// last index.
-		thinEntries, err := r.maybeSideloadEntriesRaftMuLocked(ctx, rd.Entries)
+		thinEntries, sideLoadedEntriesSize, err := r.maybeSideloadEntriesRaftMuLocked(ctx, rd.Entries)
 		if err != nil {
 			return stats, err
 		}
+		oldSize := raftLogSize
+		raftLogSize += sideLoadedEntriesSize
 		if lastIndex, lastTerm, raftLogSize, err = r.append(
 			ctx, writer, lastIndex, lastTerm, raftLogSize, thinEntries,
 		); err != nil {
 			return stats, err
 		}
+		log.Infof(ctx, "raft log delta: %d", raftLogSize-oldSize)
 	}
 	if !raft.IsEmptyHardState(rd.HardState) {
 		if err := r.raftMu.stateLoader.setHardState(ctx, writer, rd.HardState); err != nil {

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -763,10 +763,12 @@ func (r *Replica) applySnapshot(
 	thinEntries := logEntries
 	if replicaID != 0 {
 		var err error
-		thinEntries, err = r.maybeSideloadEntriesRaftMuLocked(ctx, logEntries)
+		var sideloadedEntriesSize int64
+		thinEntries, sideloadedEntriesSize, err = r.maybeSideloadEntriesRaftMuLocked(ctx, logEntries)
 		if err != nil {
 			return err
 		}
+		raftLogSize += sideloadedEntriesSize
 	}
 
 	// Write the snapshot's Raft log into the range.


### PR DESCRIPTION
Fixes #18077