### PR TITLE
log: Include raft functions and server uptime in sentry crash reports

### DIFF
--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -171,7 +171,10 @@ func SetupCrashReporter(ctx context.Context, cmd string) {
 	})
 }
 
-var crdbPaths = []string{"github.com/cockroachdb/cockroach"}
+var crdbPaths = []string{
+	"github.com/cockroachdb/cockroach",
+	"github.com/coreos/etcd/raft",
+}
 
 func sendCrashReport(ctx context.Context, sv *settings.Values, r interface{}, depth int) {
 	if !DiagnosticsReportingEnabled.Get(sv) || !CrashReports.Get(sv) {

--- a/pkg/util/log/crash_reporting_packet_test.go
+++ b/pkg/util/log/crash_reporting_packet_test.go
@@ -90,8 +90,8 @@ func TestCrashReportingPacket(t *testing.T) {
 		serverID *regexp.Regexp
 		tagCount int
 	}{
-		{regexp.MustCompile(`^$`), 5},
-		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 8},
+		{regexp.MustCompile(`^$`), 6},
+		{regexp.MustCompile(`^[a-z0-9]{8}-1$`), 9},
 	}
 
 	if e, a := len(expectations), len(packets); e != a {

--- a/pkg/util/log/crash_reporting_test.go
+++ b/pkg/util/log/crash_reporting_test.go
@@ -16,6 +16,7 @@ package log
 
 import (
 	"testing"
+	"time"
 )
 
 func TestCrashReportingFormatSave(t *testing.T) {
@@ -40,4 +41,37 @@ func TestingSetCrashReportingURL(url string) func() {
 	oldCrashReportURL := crashReportURL
 	crashReportURL = url
 	return func() { crashReportURL = oldCrashReportURL }
+}
+
+func TestUptimeTag(t *testing.T) {
+	startTime = time.Unix(0, 0)
+	testCases := []struct {
+		crashTime time.Time
+		expected  string
+	}{
+		{time.Unix(0, 0), "<1s"},
+		{time.Unix(0, 0), "<1s"},
+		{time.Unix(1, 0), "<10s"},
+		{time.Unix(9, 0), "<10s"},
+		{time.Unix(10, 0), "<1m"},
+		{time.Unix(59, 0), "<1m"},
+		{time.Unix(60, 0), "<10m"},
+		{time.Unix(9*60, 0), "<10m"},
+		{time.Unix(10*60, 0), "<1h"},
+		{time.Unix(59*60, 0), "<1h"},
+		{time.Unix(60*60, 0), "<10h"},
+		{time.Unix(9*60*60, 0), "<10h"},
+		{time.Unix(10*60*60, 0), "<1d"},
+		{time.Unix(23*60*60, 0), "<1d"},
+		{time.Unix(24*60*60, 0), "<2d"},
+		{time.Unix(47*60*60, 0), "<2d"},
+		{time.Unix(119*60*60, 0), "<5d"},
+		{time.Unix(10*24*60*60, 0), "<11d"},
+		{time.Unix(365*24*60*60, 0), "<366d"},
+	}
+	for _, tc := range testCases {
+		if a, e := uptimeTag(tc.crashTime), tc.expected; a != e {
+			t.Errorf("uptimeTag(%v) got %v, want %v)", tc.crashTime, a, e)
+		}
+	}
 }


### PR DESCRIPTION
**log: Include raft functions in sentry stacktraces**

Given that raft is a pretty important dependency and that it makes
function calls back into our code, it seems more than worth including
its function call in our sentry stacktraces, which would help with
issues like #14231.

It's kind of a shame that specifying the packages is even needed, but
it looks like it is, judging by the raven-go source code.

**log: Include approximate server uptime in sentry crash reports**

This would be helpful to determine if crashes are happening during
startup or as part of the steady-state operation of a cluster, which
would be useful for crashes such as #16600 and #18085.