### PR TITLE
pgwire: remove bogus empty commandComplete

### DIFF
--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -1336,10 +1336,11 @@ func (c *v3Conn) done() error {
 
 	var err error
 	if state.emptyQuery {
+		// Generally a commandComplete message is written by each statement as it
+		// finishes writing its results. Except in this emptyQuery case, where the
+		// protocol mandates a particular response.
 		c.writeBuf.initMsg(serverMsgEmptyQuery)
 		err = c.writeBuf.finishMsg(c.wr)
-	} else if !state.hasSentResults {
-		err = c.sendCommandComplete(nil, c.wr)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This patch removes the sending of a funky commandComplete message with
an empty command tag. The current code doesn't make much sense - it send
the message if results have been produced by the last transaction.
Before the recent move to results streaming, the code was sending this
message if, after executing a _batch_, it didn't get any results. I
can't see how that case would ever happen (and checked that it didn't
happen in our tests), because we have special handling of query strings
that don't result in any statements.
Also, the protocol doesn't say anything about such a message with an
empty tag.