### PR TITLE
sql: correct behaviour of current_schemas(false)

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -250,7 +250,7 @@ func makeCSVTableDescriptor(
 		ctx,
 		nil, /* txn */
 		sql.NilVirtualTabler,
-		nil, /* SearchPath */
+		parser.SearchPath{},
 		create,
 		parentID,
 		tableID,

--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -148,7 +148,7 @@ func Load(
 			// only uses txn for resolving FKs and interleaved tables, neither of which
 			// are present here.
 			var txn *client.Txn
-			desc, err := sql.MakeTableDesc(ctx, txn, sql.NilVirtualTabler, nil, s, dbDesc.ID, 0 /* table ID */, ts, privs, affected, dbDesc.Name, &evalCtx)
+			desc, err := sql.MakeTableDesc(ctx, txn, sql.NilVirtualTabler, parser.SearchPath{}, s, dbDesc.ID, 0 /* table ID */, ts, privs, affected, dbDesc.Name, &evalCtx)
 			if err != nil {
 				return BackupDescriptor{}, errors.Wrap(err, "make table desc")
 			}

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -1161,7 +1161,7 @@ func (n *createViewNode) makeViewTableDesc(
 			columnTableDef.Name = columnNames[i]
 		}
 		// We pass an empty search path here because there are no names to resolve.
-		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, nil, evalCtx)
+		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, parser.SearchPath{}, evalCtx)
 		if err != nil {
 			return desc, err
 		}
@@ -1197,7 +1197,7 @@ func makeTableDescIfAs(
 			columnTableDef.Name = p.AsColumnNames[i]
 		}
 		// We pass an empty search path here because we do not have any expressions to resolve.
-		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, nil, evalCtx)
+		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, parser.SearchPath{}, evalCtx)
 		if err != nil {
 			return desc, err
 		}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -139,7 +139,8 @@ func (dsp *distSQLPlanner) Run(
 	thisNodeID := dsp.nodeDesc.NodeID
 
 	evalCtxProto := distsqlrun.MakeEvalContext(evalCtx)
-	for _, s := range evalCtx.SearchPath {
+	iter := evalCtx.SearchPath.Iter()
+	for s, ok := iter(); ok; s, ok = iter() {
 		evalCtxProto.SearchPath = append(evalCtxProto.SearchPath, s)
 	}
 

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -281,7 +281,7 @@ func (ds *ServerImpl) setupFlow(
 		Location:     &location,
 		Database:     req.EvalContext.Database,
 		User:         req.EvalContext.User,
-		SearchPath:   parser.SearchPath(req.EvalContext.SearchPath),
+		SearchPath:   parser.MakeSearchPath(req.EvalContext.SearchPath),
 		ClusterID:    ds.ServerConfig.ClusterID,
 		NodeID:       nodeID,
 		ReCache:      ds.regexpCache,

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	informationSchemaName = "information_schema"
-	pgCatalogName         = "pg_catalog"
+	pgCatalogName         = parser.PgCatalogName
 )
 
 var informationSchema = virtualSchema{

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1246,6 +1246,22 @@ SELECT CURRENT_SCHEMAS(false)
 ----
 {"test"}
 
+statement ok
+SET SEARCH_PATH=test,pg_catalog
+
+query T
+SELECT CURRENT_SCHEMAS(true)
+----
+{"test","pg_catalog"}
+
+query T
+SELECT CURRENT_SCHEMAS(false)
+----
+{"test","pg_catalog"}
+
+statement ok
+RESET SEARCH_PATH
+
 query error pq: unknown signature: current_schemas()
 SELECT CURRENT_SCHEMAS()
 

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -6,7 +6,7 @@ SET SEARCH_PATH = foo
 query T
 SHOW SEARCH_PATH
 ----
-pg_catalog, foo
+foo
 
 statement ok
 DISCARD ALL
@@ -14,7 +14,7 @@ DISCARD ALL
 query T
 SHOW SEARCH_PATH
 ----
-pg_catalog
+·
 
 query T
 SET "time zone" = 'Europe/Amsterdam'; SHOW TIME ZONE

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -957,7 +957,7 @@ distsql                        off           NULL      NULL        NULL        s
 extra_float_digits             ·             NULL      NULL        NULL        string
 max_index_keys                 32            NULL      NULL        NULL        string
 node_id                        1             NULL      NULL        NULL        string
-search_path                    pg_catalog    NULL      NULL        NULL        string
+search_path                    ·             NULL      NULL        NULL        string
 server_version                 9.5.0         NULL      NULL        NULL        string
 session_user                   root          NULL      NULL        NULL        string
 sql_safe_updates               false         NULL      NULL        NULL        string
@@ -982,7 +982,7 @@ distsql                        off           NULL  user     NULL      off       
 extra_float_digits             ·             NULL  user     NULL      ·             ·
 max_index_keys                 32            NULL  user     NULL      32            32
 node_id                        1             NULL  user     NULL      1             1
-search_path                    pg_catalog    NULL  user     NULL      pg_catalog    pg_catalog
+search_path                    ·             NULL  user     NULL      ·             ·
 server_version                 9.5.0         NULL  user     NULL      9.5.0         9.5.0
 session_user                   root          NULL  user     NULL      root          root
 sql_safe_updates               false         NULL  user     NULL      false         false

--- a/pkg/sql/logictest/testdata/logic_test/reset
+++ b/pkg/sql/logictest/testdata/logic_test/reset
@@ -9,7 +9,7 @@ SET SEARCH_PATH = foo
 query T
 SHOW SEARCH_PATH
 ----
-pg_catalog, foo
+foo
 
 statement ok
 RESET SEARCH_PATH
@@ -17,7 +17,7 @@ RESET SEARCH_PATH
 query T
 SHOW SEARCH_PATH
 ----
-pg_catalog
+·
 
 statement error variable "server_version" cannot be reset
 RESET SERVER_VERSION
@@ -30,7 +30,7 @@ SET search_path = foo
 query T
 SHOW search_path
 ----
-pg_catalog, foo
+foo
 
 statement ok
 RESET search_path
@@ -38,7 +38,7 @@ RESET search_path
 query T
 SHOW search_path
 ----
-pg_catalog
+·
 
 statement ok
 RESET client_encoding; RESET NAMES

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -87,7 +87,7 @@ distsql                        off
 extra_float_digits             ·
 max_index_keys                 32
 node_id                        1
-search_path                    pg_catalog
+search_path                    ·
 server_version                 9.5.0
 session_user                   root
 sql_safe_updates               false

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -32,7 +32,7 @@ distsql                        off
 extra_float_digits             ·
 max_index_keys                 32
 node_id                        1
-search_path                    pg_catalog
+search_path                    ·
 server_version                 9.5.0
 session_user                   root
 sql_safe_updates               false

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1783,8 +1783,14 @@ CockroachDB supports the following flags:
 						return nil, err
 					}
 				}
-				for _, p := range ctx.SearchPath {
-					if !includePgCatalog && p == "pg_catalog" {
+				var iter func() (string, bool)
+				if includePgCatalog {
+					iter = ctx.SearchPath.Iter()
+				} else {
+					iter = ctx.SearchPath.IterWithoutImplicitPGCatalog()
+				}
+				for p, ok := iter(); ok; p, ok = iter() {
+					if p == ctx.Database {
 						continue
 					}
 					if err := schemas.Append(NewDString(p)); err != nil {

--- a/pkg/sql/parser/function_definition.go
+++ b/pkg/sql/parser/function_definition.go
@@ -61,10 +61,6 @@ func (fd *FunctionDefinition) Format(buf *bytes.Buffer, f FmtFlags) {
 
 func (fd *FunctionDefinition) String() string { return AsString(fd) }
 
-// SearchPath represents a list of namespaces to search builtins in.
-// The names must be normalized (as per Name.Normalize) already.
-type SearchPath []string
-
 // ResolveFunction transforms an UnresolvedName to a FunctionDefinition.
 func (n UnresolvedName) ResolveFunction(searchPath SearchPath) (*FunctionDefinition, error) {
 	fn, err := n.normalizeFunctionName()
@@ -108,7 +104,8 @@ func (n UnresolvedName) ResolveFunction(searchPath SearchPath) (*FunctionDefinit
 		if prefix == "" {
 			// The function wasn't qualified, so we must search for it via
 			// the search path first.
-			for _, alt := range searchPath {
+			iter := searchPath.Iter()
+			for alt, ok := iter(); ok; alt, ok = iter() {
 				fullName = alt + "." + smallName
 				if def, ok = funDefs[fullName]; ok {
 					found = true

--- a/pkg/sql/parser/function_name_test.go
+++ b/pkg/sql/parser/function_name_test.go
@@ -34,7 +34,7 @@ func TestResolveFunction(t *testing.T) {
 		{`foo.*`, ``, `invalid function name: foo.*`},
 	}
 
-	searchPath := []string{"pg_catalog"}
+	searchPath := MakeSearchPath([]string{"pg_catalog"})
 	for _, tc := range testCases {
 		stmt, err := ParseOne("SELECT " + tc.in + "(1)")
 		if err != nil {

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -91,7 +91,7 @@ func helpWith(sqllex sqlLexer, helpText string) int {
 // "in error", with the error set to a contextual help message about
 // the current built-in function.
 func helpWithFunction(sqllex sqlLexer, f ResolvableFunctionReference) int {
-	d, err := f.Resolve(nil)
+	d, err := f.Resolve(SearchPath{})
 	if err != nil {
 		return 1
 	}

--- a/pkg/sql/parser/search_path.go
+++ b/pkg/sql/parser/search_path.go
@@ -1,0 +1,86 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import (
+	"strings"
+)
+
+// PgCatalogName is the name of the pg_catalog system database.
+const PgCatalogName = "pg_catalog"
+
+// SearchPath represents a list of namespaces to search builtins in.
+// The names must be normalized (as per Name.Normalize) already.
+type SearchPath struct {
+	paths             []string
+	containsPgCatalog bool
+}
+
+// MakeSearchPath returns a new SearchPath struct.
+func MakeSearchPath(paths []string) SearchPath {
+	containsPgCatalog := false
+	for _, e := range paths {
+		if e == PgCatalogName {
+			containsPgCatalog = true
+			break
+		}
+	}
+	return SearchPath{
+		paths:             paths,
+		containsPgCatalog: containsPgCatalog,
+	}
+}
+
+// Iter returns an iterator through the search path. We must include the
+// implicit pg_catalog at the beginning of the search path, unless it has been
+// explicitly set later by the user.
+// "The system catalog schema, pg_catalog, is always searched, whether it is
+// mentioned in the path or not. If it is mentioned in the path then it will be
+// searched in the specified order. If pg_catalog is not in the path then it
+// will be searched before searching any of the path items."
+// - https://www.postgresql.org/docs/9.1/static/runtime-config-client.html
+func (s SearchPath) Iter() func() (next string, ok bool) {
+	i := -1
+	if s.containsPgCatalog {
+		i = 0
+	}
+	return func() (next string, ok bool) {
+		if i == -1 {
+			i++
+			return PgCatalogName, true
+		}
+		if i < len(s.paths) {
+			i++
+			return s.paths[i-1], true
+		}
+		return "", false
+	}
+}
+
+// IterWithoutImplicitPGCatalog is the same as Iter, but does not include the implicit pg_catalog.
+func (s SearchPath) IterWithoutImplicitPGCatalog() func() (next string, ok bool) {
+	i := 0
+	return func() (next string, ok bool) {
+		if i < len(s.paths) {
+			i++
+			return s.paths[i-1], true
+		}
+		return "", false
+	}
+}
+
+func (s SearchPath) String() string {
+	return strings.Join(s.paths, ", ")
+}

--- a/pkg/sql/parser/search_path_test.go
+++ b/pkg/sql/parser/search_path_test.go
@@ -1,0 +1,60 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestImpliedSearchPath(t *testing.T) {
+	testCases := []struct {
+		explicitSearchPath                         []string
+		expectedSearchPath                         []string
+		expectedSearchPathWithoutImplicitPgCatalog []string
+	}{
+		{[]string{}, []string{`pg_catalog`}, []string{}},
+		{[]string{`pg_catalog`}, []string{`pg_catalog`}, []string{`pg_catalog`}},
+		{[]string{`foobar`, `pg_catalog`}, []string{`foobar`, `pg_catalog`}, []string{`foobar`, `pg_catalog`}},
+		{[]string{`foobar`}, []string{`pg_catalog`, `foobar`}, []string{`foobar`}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(strings.Join(tc.explicitSearchPath, ","), func(t *testing.T) {
+			searchPath := MakeSearchPath(tc.explicitSearchPath)
+			actualSearchPath := make([]string, 0)
+			iter := searchPath.Iter()
+			for p, ok := iter(); ok; p, ok = iter() {
+				actualSearchPath = append(actualSearchPath, p)
+			}
+			if !reflect.DeepEqual(tc.expectedSearchPath, actualSearchPath) {
+				t.Errorf(`Expected search path to be %#v, but was %#v.`, tc.expectedSearchPath, actualSearchPath)
+			}
+		})
+
+		t.Run(strings.Join(tc.explicitSearchPath, ",")+"/no-pg-catalog", func(t *testing.T) {
+			searchPath := MakeSearchPath(tc.explicitSearchPath)
+			actualSearchPath := make([]string, 0)
+			iter := searchPath.IterWithoutImplicitPGCatalog()
+			for p, ok := iter(); ok; p, ok = iter() {
+				actualSearchPath = append(actualSearchPath, p)
+			}
+			if !reflect.DeepEqual(tc.expectedSearchPathWithoutImplicitPgCatalog, actualSearchPath) {
+				t.Errorf(`Expected search path to be %#v, but was %#v.`, tc.expectedSearchPathWithoutImplicitPgCatalog, actualSearchPath)
+			}
+		})
+	}
+}

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -37,7 +37,7 @@ type SemaContext struct {
 	// SearchPath indicates where to search for unqualified function
 	// names. The path elements must be normalized via Name.Normalize()
 	// already.
-	SearchPath []string
+	SearchPath SearchPath
 
 	// privileged, if true, enables "unsafe" builtins, e.g. those
 	// from the crdb_internal namespace. Must be set only for

--- a/pkg/sql/sqlbase/constants.go
+++ b/pkg/sql/sqlbase/constants.go
@@ -17,4 +17,4 @@ package sqlbase
 import "github.com/cockroachdb/cockroach/pkg/sql/parser"
 
 // DefaultSearchPath is the search path used by virgin sessions.
-var DefaultSearchPath = parser.SearchPath{"pg_catalog"}
+var DefaultSearchPath = parser.SearchPath{}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -698,7 +698,8 @@ func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *parser.Table
 
 	// Not found using the current session's database, so try
 	// the search path instead.
-	for _, database := range p.session.SearchPath {
+	iter := p.session.SearchPath.Iter()
+	for database, ok := iter(); ok; database, ok = iter() {
 		t.DatabaseName = parser.Name(database)
 		desc, err := descFunc(ctx, p.txn, p.getVirtualTabler(), &t)
 		if err != nil && !sqlbase.IsUndefinedRelationError(err) && !sqlbase.IsUndefinedDatabaseError(err) {


### PR DESCRIPTION
Fixes #13997.

The iteration of the session search path is more complex than just
looping through a list - it always includes pg_catalog, but there is an
observable difference between pg_catalog existing within the actual
search path itself and not.

Previously, we would always explicitly include pg_catalog within the
search path. This change abstracts the iteration of the search path to
add the pg_catalog when necessary, and makes the fields on SearchPath
private so that one doesn't accidentally iterate it manually.

Worth noting that this still isn't 100% accurate - Postgres'
current_schemas doesn't show entries in the search_path which are not
actual schemas.