### PR TITLE
sql: expose job leaseholder node in crdb_internal.jobs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -68,10 +68,10 @@ Version
 
 
 # The validity of the rows in this table are tested elsewhere; we merely assert the columns.
-query ITTTTTTTTTRT colnames
+query ITTTTTTTTTRTI colnames
 SELECT * FROM crdb_internal.jobs WHERE false
 ----
-id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error
+id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error  coordinator_id
 
 query IITTITTT colnames
 SELECT * FROM crdb_internal.schema_changes WHERE table_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -91,7 +91,7 @@ query ITTT
 EXPLAIN SHOW JOBS
 ----
 0  values  ·     ·
-0  ·       size  12 columns, 0 rows
+0  ·       size  13 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)
@@ -193,7 +193,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·
-7  ·       size      13 columns, 573 rows
+7  ·       size      13 columns, 574 rows
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -253,7 +253,7 @@ SELECT * FROM [SHOW TRACE FOR SELECT 1] LIMIT 0
 ----
 timestamp age message context operation span
 
-query ITTTTTTTTTRT colnames
+query ITTTTTTTTTRTI colnames
 SELECT * FROM [SHOW JOBS] LIMIT 0
 ----
-id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error
+id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error  coordinator_id


### PR DESCRIPTION
Omit it from SHOW JOBS in case we change our minds.

@benesch I'm actually leaning toward adding this to SHOW JOBS as well. Thoughts?