### PR TITLE
storage: disable raft pre-vote

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -110,7 +110,7 @@ var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_SCHEDULER_CONCURRENCY", 8*runtime.NumCPU())
 
 var enablePreVote = envutil.EnvOrDefaultBool(
-	"COCKROACH_ENABLE_PREVOTE", true)
+	"COCKROACH_ENABLE_PREVOTE", false)
 
 // TestStoreConfig has some fields initialized with values relevant in tests.
 func TestStoreConfig(clock *hlc.Clock) StoreConfig {


### PR DESCRIPTION
In light of issues `blue` and `adriatic` ran into this week hitting 0
QPS and maintaining non-zero MsgPreVote{,Resp} message counts thereon
forth. Disable it ahead of the v1.1 branch cut.

+cc @bdarnell, merge when approved, I'll be AFK today morning.