### PR TITLE
sql: ensure that index name resolution is idempotent

### DIFF
--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -236,7 +236,7 @@ type fullIndexName struct {
 func (p *planner) DropIndex(ctx context.Context, n *parser.DropIndex) (planNode, error) {
 	idxNames := make([]fullIndexName, len(n.IndexList))
 	for i, index := range n.IndexList {
-		tn, err := p.expandIndexName(ctx, index)
+		evalIndex, tn, err := p.expandIndexName(ctx, *index)
 		if err != nil {
 			return nil, err
 		}
@@ -251,7 +251,7 @@ func (p *planner) DropIndex(ctx context.Context, n *parser.DropIndex) (planNode,
 		}
 
 		idxNames[i].tn = tn
-		idxNames[i].idxName = index.Index
+		idxNames[i].idxName = evalIndex.Index
 	}
 	return &dropIndexNode{n: n, idxNames: idxNames}, nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -278,7 +278,7 @@ statement ok
 INSERT INTO t (a, d, x, y, z) VALUES (33, 34, DECIMAL '2.0', DECIMAL '2.1', DECIMAL '2.2')
 
 statement ok
-DROP INDEX t@t_f_idx
+DROP INDEX t_f_idx
 
 query TTTTRT
 SELECT type, description, username, status, fraction_completed, error
@@ -286,7 +286,7 @@ FROM crdb_internal.jobs
 ORDER BY created DESC
 LIMIT 1
 ----
-SCHEMA CHANGE  DROP INDEX test.t@t_f_idx  root  succeeded  1  ·
+SCHEMA CHANGE  DROP INDEX t_f_idx  root  succeeded  1  ·
 
 statement ok
 ALTER TABLE t DROP COLUMN f


### PR DESCRIPTION
Ensure that index name resolution is unaffected by transaction
retries.

fixes #17493 

this reopens  #18036

@dt I don't know what to do here regarding modifying the parse tree based on store state. I'd prefer fixing the logictest issue and reopening the lack of seeing database/table name in the jobs table.