### PR TITLE
storage: Remove very chatty log line that looks accidental

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3276,14 +3276,12 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		if err != nil {
 			return stats, err
 		}
-		oldSize := raftLogSize
 		raftLogSize += sideLoadedEntriesSize
 		if lastIndex, lastTerm, raftLogSize, err = r.append(
 			ctx, writer, lastIndex, lastTerm, raftLogSize, thinEntries,
 		); err != nil {
 			return stats, err
 		}
-		log.Infof(ctx, "raft log delta: %d", raftLogSize-oldSize)
 	}
 	if !raft.IsEmptyHardState(rd.HardState) {
 		if err := r.raftMu.stateLoader.setHardState(ctx, writer, rd.HardState); err != nil {


### PR DESCRIPTION
Added in 45396f80916f6bbff015de4658fe4a8e54cf7f7b

@petermattis this looks like it was some debug logging that you left in given how chatty it is.