### PR TITLE
server: avoid referencing removed constant in windows config

### DIFF
--- a/pkg/server/config_windows.go
+++ b/pkg/server/config_windows.go
@@ -19,5 +19,5 @@ import (
 )
 
 func setOpenFileLimitInner(physicalStoreCount int) (uint64, error) {
-	return engine.DefaultMaxOpenFiles, nil
+	return engine.RecommendedMaxOpenFiles, nil
 }


### PR DESCRIPTION
The engine.DefaultMaxOpenFiles constant was removed in 3e01f8c (#17958),
but a reference to it was left in config_windows.go. (I overlooked this
because the file is only compiled when building for Windows.)

🤦‍♂️ 