### PR TITLE
acceptance: recreate snapshots used for allocator tests

### DIFF
--- a/build/teamcity-nightly-acceptance.sh
+++ b/build/teamcity-nightly-acceptance.sh
@@ -32,11 +32,11 @@ PKG=./pkg/acceptance
 
 case $TESTNAME in
   TestUpreplicate_1To3Small)
-    TESTTIMEOUT=2h
+    TESTTIMEOUT=4h
     COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5"'
     ;;
   TestRebalance_3To5Small)
-    TESTTIMEOUT=2h
+    TESTTIMEOUT=4h
     COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 14'
     ;;
   TestRebalance_3To5Small_WithSchemaChanges)

--- a/docs/cloud-resources.md
+++ b/docs/cloud-resources.md
@@ -24,9 +24,9 @@ hierarchy looks like this:
   * **store-dumps/** — gzipped tarballs of raw stores (i.e., `cockroach-data`
                        directories), used to test allocator rebalancing and
                        backups without manually inserting gigabytes of data.
-    * **1node-10gb-262ranges/**
+    * **1node-17gb-841ranges/** - source: `RESTORE` of `tpch10`
     * **1node-108gb-2065ranges/**
-    * **3nodes-10g-262ranges/**
+    * **3nodes-17gb-841ranges/** - source: `RESTORE` of `tpch10`
     * **6nodes-56gb-1038ranges/**
     * **10nodes-2tb-50000ranges/**
   * **csvs/** — huge CSVs used to test distributed CSV import (`IMPORT...`).

--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -50,9 +50,9 @@ const (
 // Paths to cloud storage blobs that contain stores with pre-generated data.
 // Please keep /docs/cloud-resources.md up-to-date if you change these.
 const (
-	fixtureStore1s = "store-dumps/1node-10gb-262ranges"
+	fixtureStore1s = "store-dumps/1node-17gb-841ranges"
 	fixtureStore1m = "store-dumps/1node-108gb-2065ranges"
-	fixtureStore3s = "store-dumps/3nodes-10g-262ranges"
+	fixtureStore3s = "store-dumps/3nodes-17gb-841ranges"
 	fixtureStore6m = "store-dumps/6nodes-56gb-1038ranges"
 )
 


### PR DESCRIPTION
Point to newly created snapshots of RESTOREd TPC-H scale factor 10 data
for the 1->3 small and 3->5 small allocator tests.  The snapshots we've
been using predate 1.0 by a good margin, so they result in flaky allocator
tests.

Note that the 3->5 schema change test needs to change before it'll
succeed, because the underlying schema has changed from `block_writer`'s
to TPC-H.

I don't have time to fix the 6-node tests now.

Fixes #17989