### PR TITLE
storage: log errSystemConfigIntent in maybeGossipSystemConfig at V2

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5093,6 +5093,9 @@ func (r *Replica) shouldGossip() bool {
 //
 // maybeGossipSystemConfig must only be called from Raft commands
 // (which provide the necessary serialization to avoid data races).
+//
+// TODO(nvanbenschoten,bdarnell): even though this is best effort, we
+// should log louder when we continually fail to gossip system config.
 func (r *Replica) maybeGossipSystemConfig(ctx context.Context) error {
 	if r.store.Gossip() == nil {
 		log.VEventf(ctx, 2, "not gossiping system config because gossip isn't initialized")
@@ -5115,6 +5118,10 @@ func (r *Replica) maybeGossipSystemConfig(ctx context.Context) error {
 	// TODO(marc): check for bad split in the middle of the SystemConfig span.
 	loadedCfg, err := r.loadSystemConfig(ctx)
 	if err != nil {
+		if err == errSystemConfigIntent {
+			log.VEventf(ctx, 2, "not gossiping system config because intents were found on SystemConfigSpan")
+			return nil
+		}
 		return errors.Wrap(err, "could not load SystemConfig span")
 	}
 


### PR DESCRIPTION
Closes #5327.

`maybeGossipSystemConfig` is best effort, and simply logs without
throwing an error for most states where it's unable to gossip. However,
previously we were returning an error when we saw `errSystemConfigIntent`.

`errSystemConfigIntent` comes from `loadSystemConfig`, which performs an
`INCONSISTENT` scan on the `SystemConfigSpan`. This means that if we observe
intents then the read may not have been consistent. In this case, we
don't want to throw an error, just log at a high verbosity that we
weren't able to gossip. As the comment in `loadSystemConfig` says: "next
time around we'll hopefully have more luck".