### PR TITLE
storage: Log a help message if raft data is missing

### DIFF
--- a/pkg/storage/raft.go
+++ b/pkg/storage/raft.go
@@ -18,6 +18,7 @@ package storage
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"golang.org/x/net/context"
 
@@ -99,13 +100,41 @@ func (r *raftLogger) Fatalf(format string, v ...interface{}) {
 func (r *raftLogger) Panic(v ...interface{}) {
 	s := fmt.Sprint(v...)
 	log.ErrorfDepth(r.ctx, 1, s)
+	if is14231Error(s) {
+		log.Shout(r.ctx, log.Severity_ERROR, is14231HelpMessage)
+	}
 	panic(s)
 }
 
 func (r *raftLogger) Panicf(format string, v ...interface{}) {
-	log.ErrorfDepth(r.ctx, 1, format, v...)
+	s := fmt.Sprintf(format, v...)
+	log.ErrorfDepth(r.ctx, 1, s)
+	if is14231Error(s) {
+		log.Shout(r.ctx, log.Severity_ERROR, is14231HelpMessage)
+	}
 	panic(fmt.Sprintf(format, v...))
 }
+
+// Returns whether the provided error message matches the error observed in
+// issue #14231. Such errors are likely to be the result of wiping a store's
+// data directory and bringing it back online without join flags but with the
+// same address, node ID, and store ID, and join flags. While we should prevent
+// these errors in our next release, for now the best we can do is help users
+// understand them.
+//
+// TODO(#14231): Remove this method once the issue is fixed (hopefully in 1.2).
+func is14231Error(s string) bool {
+	return strings.Contains(s, "is out of range [lastIndex(") &&
+		strings.Contains(s, "Was the raft log corrupted, truncated, or lost?")
+}
+
+// TODO(#14231): Remove this once the issue is fixed (hopefully in 1.2).
+const is14231HelpMessage = "Server crashing due to missing data. Was the server restarted with a\n" +
+	"different store directory than before? A --join parameter must be specified\n" +
+	"in order to make restarts with a new store directory safe. Please try again\n" +
+	"with a new directory and a valid --join flag. If this server was started with\n" +
+	"its old data or with a valid --join parameter and you are still seeing this,\n" +
+	"please report an issue at https://github.com/cockroachdb/cockroach/issues/new"
 
 func logRaftReady(ctx context.Context, ready raft.Ready) {
 	if log.V(5) {


### PR DESCRIPTION
A hacky stopgap to try to explain what's happening if someone runs
into #14231. It's not great, but seems better than leaving users with
a hard-to-understand raft error if they make a configuration mistake.

This results in stderr output like this when I reproduce locally:

```
*
* ERROR: [n1,s1,r3/1:/System/NodeLiveness{-Max}] Server crashing due to missing data. Was the server restarted with a different store directory than before? A --join parameter must be specified in order to make restarts with a new store directory safe. Please try again with a new directory and a valid --join flag. If this server was started with its old data or with a valid --join parameter and you are still seeing this message, please report an issue at https://github.com/cockroachdb/cockroach/issues/new
*
*
* ERROR: [n1,s1] a panic has occurred!
*
tocommit(52) is out of range [lastIndex(20)]. Was the raft log corrupted, truncated, or lost?
```

I'm not a huge fan of this, but it's [happened quite a lot since 1.0 was released](https://sentry.io/cockroach-labs/cockroachdb/issues/270588925/) so it seems worth trying to give users some sort of explanation.