### PR TITLE
ui: fixes to the debug pages

### DIFF
--- a/pkg/ui/src/views/reports/containers/certificates/index.tsx
+++ b/pkg/ui/src/views/reports/containers/certificates/index.tsx
@@ -138,7 +138,8 @@ class Certificates extends React.Component<CertificatesProps, {}> {
     if (!_.isNil(this.props.lastError)) {
       return (
         <div className="section">
-          <h1>Error loading certificates for node {nodeID}</h1>
+          <h1>Certificates</h1>
+          <h2>Error loading certificates for node {nodeID}</h2>
         </div>
       );
     }
@@ -146,15 +147,17 @@ class Certificates extends React.Component<CertificatesProps, {}> {
     if (_.isEmpty(certificates)) {
       return (
         <div className="section">
-          <h1>Loading cluster status...</h1>
+          <h1>Certificates</h1>
+          <h2>Loading cluster status...</h2>
         </div>
       );
     }
 
     if (_.isEmpty(certificates.certificates)) {
       return (
-        <div>
-          <h1>No certificates were found on node {this.props.params[nodeIDAttr]}.</h1>
+        <div className="section">
+          <h1>Certificates</h1>
+          <h2>No certificates were found on node {this.props.params[nodeIDAttr]}.</h2>
         </div>
       );
     }
@@ -167,8 +170,9 @@ class Certificates extends React.Component<CertificatesProps, {}> {
     }
 
     return (
-      <div>
-        <h1>{header} certificates</h1>
+      <div className="section">
+        <h1>Certificates</h1>
+        <h2>{header} certificates</h2>
         {
           _.map(certificates.certificates, (cert, key) => (
             this.renderCert(cert, key)

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -32,7 +32,7 @@ function DebugTableRow(props: { title: string, children?: React.ReactNode }) {
 function DebugTable(props: { heading: string, children?: React.ReactNode }) {
   return (
     <div>
-      <h3>{props.heading}</h3>
+      <h2>{props.heading}</h2>
       <table className="debug-table">
         <tbody>
           {props.children}
@@ -45,7 +45,7 @@ function DebugTable(props: { heading: string, children?: React.ReactNode }) {
 export default function Debug() {
   return (
     <div className="section">
-      <h2>Advanced Debugging</h2>
+      <h1>Advanced Debugging</h1>
       <DebugTable heading="Reports">
         <DebugTableRow title="Node Diagnostics">
           <DebugTableLink name="All Nodes" url="#/reports/nodes" />

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -156,7 +156,8 @@ function createHeaderCell(staleIDs: Set<number>, id: Identity, key: number) {
 
 const loading = (
   <div className="section">
-    <h1>Loading cluster status...</h1>
+    <h1>Network Diagnostics</h1>
+    <h2>Loading cluster status...</h2>
   </div>
 );
 

--- a/pkg/ui/src/views/reports/containers/nodes/index.tsx
+++ b/pkg/ui/src/views/reports/containers/nodes/index.tsx
@@ -33,7 +33,8 @@ const detailTimeFormat = "Y/MM/DD HH:mm:ss";
 
 const loading = (
   <div className="section">
-    <h1>Loading cluster status...</h1>
+    <h1>Node Diagnostics</h1>
+    <h2>Loading cluster status...</h2>
   </div>
 );
 

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -85,7 +85,8 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
     if (!problemRanges) {
       return (
         <div className="section">
-          <h1>Loading cluster status...</h1>
+          <h1>Problem Ranges Report</h1>
+          <h2>Loading cluster status...</h2>
         </div>
       );
     }
@@ -114,7 +115,8 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
     if (validIDs.length === 0) {
       return (
         <div className="section">
-          <h1>{titleText}</h1>
+          <h1>Problem Ranges Report</h1>
+          <h2>{titleText}</h2>
           <ConnectionsTable problemRanges={problemRanges} />
         </div>
       );
@@ -123,7 +125,8 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
     const problems = _.values(problemRanges.problems_by_node_id);
     return (
       <div className="section">
-        <h1>{titleText}</h1>
+        <h1>Problem Ranges Report</h1>
+        <h2>{titleText}</h2>
         <ProblemRangeList
           name="Unavailable"
           problems={problems}

--- a/pkg/ui/src/views/reports/containers/range/index.tsx
+++ b/pkg/ui/src/views/reports/containers/range/index.tsx
@@ -1,6 +1,5 @@
 import _ from "lodash";
 import Long from "long";
-import moment from "moment";
 import React from "react";
 import { connect } from "react-redux";
 import { RouterState } from "react-router";
@@ -10,7 +9,6 @@ import { refreshRange, refreshAllocatorRange } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { rangeIDAttr } from "src/util/constants";
 import { FixLong } from "src/util/fixLong";
-import Print from "src/views/reports/containers/range/print";
 import ConnectionsTable from "src/views/reports/containers/range/connectionsTable";
 import RangeTable from "src/views/reports/containers/range/rangeTable";
 import LogTable from "src/views/reports/containers/range/logTable";
@@ -36,7 +34,7 @@ function ErrorPage(props: {
 }) {
   return (
     <div className="section">
-      <h1>Range r{props.rangeID}</h1>
+      <h1>Range Report for r{props.rangeID}</h1>
       <h2>{props.errorText}</h2>
       {
         _.isNil(props.rangeResponse) ? null : <ConnectionsTable rangeResponse={props.rangeResponse} />
@@ -137,7 +135,7 @@ class Range extends React.Component<RangeProps, {}> {
 
     return (
       <div className="section">
-        <h1>Range r{responseRangeID.toString()} at {Print.Time(moment().utc())} UTC</h1>
+        <h1>Range Report for r{responseRangeID.toString()}</h1>
         <RangeTable infos={infos} replicas={replicas} />
         <LeaseTable info={_.head(infos)} />
         <LogTable rangeID={responseRangeID} log={range.range_log} />

--- a/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
@@ -431,35 +431,38 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
     });
 
     return (
-      <table className="range-table">
-        <tbody>
-          {
-            _.map(rangeTableDisplayList, (title, key) => (
-              this.renderRangeRow(
-                title,
-                detailsByStoreID,
-                dormantStoreIDs,
-                leader.source_store_id,
-                sortedStoreIDs,
-                key,
-              )
-            ))
-          }
-          {
-            _.map(replicas, (replica, key) => (
-              this.renderRangeReplicaRow(
-                replicasByReplicaIDByStoreID,
-                replica,
-                leaderReplicaIDs,
-                dormantStoreIDs,
-                sortedStoreIDs,
-                rangeID,
-                "replica" + key,
-              )
-            ))
-          }
-        </tbody>
-      </table>
+      <div>
+        <h2>Range r{rangeID.toString()} at {Print.Time(moment().utc())} UTC</h2>
+        <table className="range-table">
+          <tbody>
+            {
+              _.map(rangeTableDisplayList, (title, key) => (
+                this.renderRangeRow(
+                  title,
+                  detailsByStoreID,
+                  dormantStoreIDs,
+                  leader.source_store_id,
+                  sortedStoreIDs,
+                  key,
+                )
+              ))
+            }
+            {
+              _.map(replicas, (replica, key) => (
+                this.renderRangeReplicaRow(
+                  replicasByReplicaIDByStoreID,
+                  replica,
+                  leaderReplicaIDs,
+                  dormantStoreIDs,
+                  sortedStoreIDs,
+                  rangeID,
+                  "replica" + key,
+                )
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
     );
   }
 }

--- a/pkg/ui/styl/pages/reports.styl
+++ b/pkg/ui/styl/pages/reports.styl
@@ -124,10 +124,12 @@ $reports-table
     background-color white
     padding 6px 12px
     max-width none
+    width 100%
 
     &--header
       background-color $link-color
       text-align right
+      width unset
 
     &--header-warning
       color $alert-color


### PR DESCRIPTION
With https://github.com/cockroachdb/cockroach/commit/aa5e6c667a311c65e305b6ce441ee620245205a3 merged, it made the debug pages quite messy. This is a quick fix for them.

Follow up work will be to replace the loading messages with the new Loading component and consolidate the error messages.

Before:
<img width="866" alt="screen shot 2017-09-01 at 18 12 31" src="https://user-images.githubusercontent.com/1614265/29990346-888a76de-8f47-11e7-90f0-a539a1f8d71d.png">

After:
<img width="1069" alt="screen shot 2017-09-01 at 18 57 21" src="https://user-images.githubusercontent.com/1614265/29990349-89cf0f00-8f47-11e7-851d-e1b3f7a7e0df.png">

All debug pages have been updated to match.