### PR TITLE
server,storage,sql: record node {de,re}commissioning in the event log

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -613,7 +613,7 @@ func TestHeartbeatCallbackForDecommissioning(t *testing.T) {
 		}
 		break
 	}
-	if err := nodeLiveness.SetDecommissioning(context.Background(), ts.nodeIDContainer.Get(), true); err != nil {
+	if _, err := nodeLiveness.SetDecommissioning(context.Background(), ts.nodeIDContainer.Get(), true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -65,6 +65,12 @@ const (
 	// EventLogNodeRestart is recorded when an existing node rejoins the cluster
 	// after being offline.
 	EventLogNodeRestart EventLogType = "node_restart"
+	// EventLogNodeDecommissioned is recorded when a node is marked as
+	// decommissioning.
+	EventLogNodeDecommissioned EventLogType = "node_decommissioned"
+	// EventLogNodeRecommissioned is recorded when a decommissioned node is
+	// recommissioned.
+	EventLogNodeRecommissioned EventLogType = "node_recommissioned"
 
 	// EventLogSetClusterSetting is recorded when a cluster setting is changed.
 	EventLogSetClusterSetting EventLogType = "set_cluster_setting"

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2477,7 +2477,7 @@ func TestStoreRangeMoveDecommissioning(t *testing.T) {
 	ctx := context.Background()
 	decommingNodeIdx := 2
 	decommingNodeID := mtc.idents[decommingNodeIdx].NodeID
-	if err := mtc.nodeLivenesses[decommingNodeIdx].
+	if _, err := mtc.nodeLivenesses[decommingNodeIdx].
 		SetDecommissioning(ctx, decommingNodeID, true); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -504,6 +504,6 @@ func (nl *NodeLiveness) SetDrainingInternal(
 
 func (nl *NodeLiveness) SetDecommissioningInternal(
 	ctx context.Context, nodeID roachpb.NodeID, liveness *Liveness, decommission bool,
-) error {
+) (changeCommitted bool, err error) {
 	return nl.setDecommissioningInternal(ctx, nodeID, liveness, decommission)
 }

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -734,12 +734,12 @@ func testNodeLivenessSetDecommissioning(t *testing.T, decommissionNodeIdx int) {
 
 	// Verify success on failed update of a liveness record that already has the
 	// given decommissioning setting.
-	if err := callerNodeLiveness.SetDecommissioningInternal(ctx, nodeID, &storage.Liveness{}, false); err != nil {
+	if _, err := callerNodeLiveness.SetDecommissioningInternal(ctx, nodeID, &storage.Liveness{}, false); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set a node to decommissioning state.
-	if err := callerNodeLiveness.SetDecommissioning(ctx, nodeID, true); err != nil {
+	if _, err := callerNodeLiveness.SetDecommissioning(ctx, nodeID, true); err != nil {
 		t.Fatal(err)
 	}
 	verifyNodeIsDecommissioning(t, mtc, nodeID)

--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -33,11 +33,15 @@ export const FINISH_SCHEMA_CHANGE = "finish_schema_change";
 export const NODE_JOIN = "node_join";
 // Recorded when an existing node rejoins the cluster after being offline.
 export const NODE_RESTART = "node_restart";
+// Recorded when a node is marked as decommissioning.
+export const NODE_DECOMMISSIONED = "node_decommissioned";
+// Recorded when a decommissioned node is recommissioned.
+export const NODE_RECOMMISSIONED = "node_recommissioned";
 // Recorded when a cluster setting is changed.
 export const SET_CLUSTER_SETTING = "set_cluster_setting";
 
 // Node Event Types
-export const nodeEvents = [NODE_JOIN, NODE_RESTART];
+export const nodeEvents = [NODE_JOIN, NODE_RESTART, NODE_DECOMMISSIONED, NODE_RECOMMISSIONED];
 export const databaseEvents = [CREATE_DATABASE, DROP_DATABASE];
 export const tableEvents = [CREATE_TABLE, DROP_TABLE, ALTER_TABLE, CREATE_INDEX,
   DROP_INDEX, CREATE_VIEW, DROP_VIEW, REVERSE_SCHEMA_CHANGE, FINISH_SCHEMA_CHANGE];

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -106,6 +106,12 @@ export function getEventInfo(e: Event$Properties): SimplifiedEvent {
     case eventTypes.NODE_JOIN:
       content = <span>Node Joined: Node {targetId} joined the cluster</span>;
       break;
+    case eventTypes.NODE_DECOMMISSIONED:
+      content = <span>Node Decommissioned: Node {targetId} was decommissioned</span>;
+      break;
+    case eventTypes.NODE_RECOMMISSIONED:
+      content = <span>Node Recommissioned: Node {targetId} was recommissioned</span>;
+      break;
     case eventTypes.NODE_RESTART:
       content = <span>Node Rejoined: Node {targetId} rejoined the cluster</span>;
       break;


### PR DESCRIPTION
Fixes #17677.

/cc @a-robinson @tschottdorf can one or both of you review? This wasn't quite as simple as I'd hoped. The naive solution spams the event log with duplicate entries because `./node decommission FOO` fires off many decommissioning requests in quick succession.

Also, note that `TestDecommission` is currently `t.Skip`ped, so the test won't run until #17995 is fixed. (I did manually verify my addition by replacing the `decommission --wait all` that hangs forever with a `decommission --wait none` and verifying that the `CheckQueryResults` succeeds.)