### PR TITLE
sql/jobs: avoid race when stopper stops

### DIFF
--- a/pkg/sql/jobs/registry.go
+++ b/pkg/sql/jobs/registry.go
@@ -139,7 +139,7 @@ func (r *Registry) Start(
 		for {
 			select {
 			case <-time.After(adoptInterval):
-				if err := r.maybeAdoptJob(ctx, nl); err != nil {
+				if err := r.maybeAdoptJob(ctx, stopper, nl); err != nil {
 					log.Errorf(ctx, "error while adopting jobs: %+v", err)
 				}
 			case <-stopper.ShouldStop():
@@ -189,7 +189,7 @@ func AddResumeHook(fn resumeHookFn) {
 	resumeHooks = append(resumeHooks, fn)
 }
 
-func (r *Registry) maybeAdoptJob(ctx context.Context, nl nodeLiveness) error {
+func (r *Registry) maybeAdoptJob(ctx context.Context, stopper stop.Stopper, nl nodeLiveness) error {
 	var rows []parser.Datums
 	if err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		var err error
@@ -289,7 +289,9 @@ func (r *Registry) maybeAdoptJob(ctx context.Context, nl nodeLiveness) error {
 			continue
 		}
 
-		go func() {
+		ctx := stopper.WithCancel(ctx)
+		jobName := fmt.Sprintf("jobs.Registry: resume job %d", *id)
+		stopper.RunAsyncTask(ctx, jobName, func(ctx context.Context) {
 			log.Infof(ctx, "job %d: resuming", *id)
 			err := resumeFn(ctx, &job)
 			if _, isDuplicate := errors.Cause(err).(*duplicateRegistrationError); isDuplicate {
@@ -314,7 +316,7 @@ func (r *Registry) maybeAdoptJob(ctx context.Context, nl nodeLiveness) error {
 				// Nowhere to report this error but the log.
 				log.Errorf(ctx, "job %d: ignoring FinishedWith error: %+v", *id, err)
 			}
-		}()
+		})
 
 		// Only adopt one job per turn to allow other nodes their fair share.
 		break


### PR DESCRIPTION
Resuming a job might register tasks with the server's stopper. If we get
unlucky, the job we've resumed will register a stopper task right after
someone has called stopper.Stop(). This triggers a race on the stopper's
internal wait group because wg.Add(1) is called after wg.Wait().

Fix the issue by registering each resumed job as an async task with the
stopper. The stopper will wait for all outstanding async tasks to
complete before calling wg.Wait(), avoiding the race.

Fixes #18177.

---

@a-robinson, would love your advice here whenever you get a free second. Doesn't seem super pressing, though, since this only affects server shutdown (and tests). Still trying to repro this failure on my azworker, though I _think_ this is the only possible cause of the failure in the linked issue. At this point, looking more for feedback on whether this is a reasonable use of a stopper async task.