### PR TITLE
storage: deflake TestRangeTransferLease

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -55,9 +55,9 @@ const (
 	// defaultRaftTickInterval is the default resolution of the Raft timer.
 	defaultRaftTickInterval = 200 * time.Millisecond
 
-	// rangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the
+	// defaultRangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the
 	// leader lease active duration should be of the raft election timeout.
-	rangeLeaseRaftElectionTimeoutMultiplier = 3
+	defaultRangeLeaseRaftElectionTimeoutMultiplier = 3
 
 	// rangeLeaseRenewalFraction specifies what fraction the range lease
 	// renewal duration should be of the range lease active time. For example,
@@ -320,6 +320,10 @@ type RaftConfig struct {
 	// previous election expires. This value is inherited by individual stores
 	// unless overridden.
 	RaftElectionTimeoutTicks int
+
+	// RangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the leader
+	// lease active duration should be of the raft election timeout.
+	RangeLeaseRaftElectionTimeoutMultiplier float64
 }
 
 // SetDefaults initializes unset fields.
@@ -329,6 +333,9 @@ func (cfg *RaftConfig) SetDefaults() {
 	}
 	if cfg.RaftElectionTimeoutTicks == 0 {
 		cfg.RaftElectionTimeoutTicks = defaultRaftElectionTimeoutTicks
+	}
+	if cfg.RangeLeaseRaftElectionTimeoutMultiplier == 0 {
+		cfg.RangeLeaseRaftElectionTimeoutMultiplier = defaultRangeLeaseRaftElectionTimeoutMultiplier
 	}
 }
 
@@ -341,7 +348,8 @@ func (cfg RaftConfig) RaftElectionTimeout() time.Duration {
 // RangeLeaseDurations computes durations for range lease expiration and
 // renewal based on a default multiple of Raft election timeout.
 func (cfg RaftConfig) RangeLeaseDurations() (rangeLeaseActive, rangeLeaseRenewal time.Duration) {
-	rangeLeaseActive = time.Duration(rangeLeaseRaftElectionTimeoutMultiplier * float64(cfg.RaftElectionTimeout()))
+	rangeLeaseActive = time.Duration(cfg.RangeLeaseRaftElectionTimeoutMultiplier *
+		float64(cfg.RaftElectionTimeout()))
 	rangeLeaseRenewal = time.Duration(float64(rangeLeaseActive) * rangeLeaseRenewalFraction)
 	return
 }

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -466,6 +466,10 @@ func TestRangeLookupUseReverse(t *testing.T) {
 func TestRangeTransferLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	cfg := storage.TestStoreConfig(nil)
+	// Ensure the node liveness duration isn't too short. By default it is 900ms
+	// for TestStoreConfig().
+	cfg.RangeLeaseRaftElectionTimeoutMultiplier =
+		float64((9 * time.Second) / cfg.RaftElectionTimeout())
 	var filterMu syncutil.Mutex
 	var filter func(filterArgs storagebase.FilterArgs) *roachpb.Error
 	cfg.TestingKnobs.TestingEvalFilter =
@@ -578,7 +582,18 @@ func TestRangeTransferLease(t *testing.T) {
 	forceLeaseExtension := func(sender *storage.Stores, lease roachpb.Lease) error {
 		shouldRenewTS := lease.Expiration.Add(-1, 0)
 		mtc.manualClock.Set(shouldRenewTS.WallTime + 1)
-		return sendRead(sender).GoError()
+		err := sendRead(sender).GoError()
+		if err != nil {
+			// We can sometimes receive an error from our renewal attempt because the
+			// lease transfer ends up causing the renewal to re-propose and second
+			// attempt fails because it's already been renewed. This used to work
+			// before we compared the proposer's lease with the actual lease because
+			// the renewed lease still encompassed the previous request.
+			if _, ok := err.(*roachpb.NotLeaseHolderError); ok {
+				err = nil
+			}
+		}
+		return err
 	}
 	t.Run("Transfer", func(t *testing.T) {
 		origLease, _ := replica0.GetLease()
@@ -651,7 +666,12 @@ func TestRangeTransferLease(t *testing.T) {
 		transferErrCh := make(chan error)
 		go func() {
 			// Transfer back from replica1 to replica0.
-			transferErrCh <- replica1.AdminTransferLease(context.Background(), replica0Desc.StoreID)
+			err := replica1.AdminTransferLease(context.Background(), replica0Desc.StoreID)
+			// Ignore not leaseholder errors which can arise due to re-proposals.
+			if _, ok := err.(*roachpb.NotLeaseHolderError); ok {
+				err = nil
+			}
+			transferErrCh <- err
 		}()
 		// Wait for the transfer to be blocked by the extension.
 		<-transferBlocked
@@ -660,16 +680,8 @@ func TestRangeTransferLease(t *testing.T) {
 		checkHasLease(t, mtc.senders[0])
 		setFilter(false, nil)
 
-		// We can sometimes receive an error from our renewal attempt
-		// because the lease transfer ends up causing the renewal to
-		// re-propose and second attempt fails because it's already been
-		// renewed. This used to work before we compared the proposer's lease
-		// with the actual lease because the renewed lease still encompassed the
-		// previous request.
 		if err := <-renewalErrCh; err != nil {
-			if _, ok := err.(*roachpb.NotLeaseHolderError); !ok {
-				t.Errorf("expected not lease holder error due to re-proposal; got %s", err)
-			}
+			t.Errorf("unexpected error from lease renewal: %s", err)
 		}
 		if err := <-transferErrCh; err != nil {
 			t.Errorf("unexpected error from lease transfer: %s", err)
@@ -717,7 +729,7 @@ func TestRangeTransferLease(t *testing.T) {
 		if !ok {
 			t.Fatalf("expected %T, got %s", &roachpb.NotLeaseHolderError{}, pErr)
 		}
-		if *(nlhe.LeaseHolder) != replica1Desc {
+		if nlhe.LeaseHolder == nil || *nlhe.LeaseHolder != replica1Desc {
 			t.Fatalf("expected lease holder %+v, got %+v",
 				replica1Desc, nlhe.LeaseHolder)
 		}
@@ -754,16 +766,8 @@ func TestRangeTransferLease(t *testing.T) {
 		checkHasLease(t, mtc.senders[0])
 		setFilter(false, nil)
 
-		// We can sometimes receive an error from our renewal attempt
-		// because the lease transfer ends up causing the renewal to
-		// re-propose and second attempt fails because it's already been
-		// renewed. This used to work before we compared the proposer's lease
-		// with the actual lease because the renewed lease still encompassed the
-		// previous request.
 		if err := <-renewalErrCh; err != nil {
-			if _, ok := err.(*roachpb.NotLeaseHolderError); !ok {
-				t.Errorf("expected not lease holder error due to re-proposal; got %s", err)
-			}
+			t.Errorf("unexpected error from lease renewal: %s", err)
 		}
 	})
 }

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -765,9 +765,10 @@ func TestReplicaLease(t *testing.T) {
 
 	// Test that leases with invalid times are rejected.
 	// Start leases at a point that avoids overlapping with the existing lease.
-	one := hlc.Timestamp{WallTime: time.Second.Nanoseconds(), Logical: 0}
+	leaseDuration := tc.store.cfg.RangeLeaseActiveDuration()
+	start := hlc.Timestamp{WallTime: (time.Second + leaseDuration).Nanoseconds(), Logical: 0}
 	for _, lease := range []roachpb.Lease{
-		{Start: one, Expiration: hlc.Timestamp{}},
+		{Start: start, Expiration: hlc.Timestamp{}},
 	} {
 		if _, err := evalRequestLease(context.Background(), tc.store.Engine(),
 			CommandArgs{

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -129,6 +129,9 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 		HistogramWindowInterval:     metric.TestSampleInterval,
 		EnableEpochRangeLeases:      true,
 	}
+
+	// Use shorter Raft tick settings in order to minimize start up and failover
+	// time in tests.
 	sc.RaftElectionTimeoutTicks = 3
 	sc.RaftTickInterval = 100 * time.Millisecond
 	sc.SetDefaults()


### PR DESCRIPTION
The StoreConfig returned by TestStoreConfig was computing a 900ms range
lease and node liveness duration. This is quite short and can be
exceeded during stress/race testing leading to hard to diagnose
problems. Now we ensure that the lease durations computed by
TestStoreConfig are the same as the default StoreConfig. At the time of
writing, this is a 9s lease and node liveness duration.

Fixes #17365