### PR TITLE
storage: drop cmdQCancelTest progress timeout

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2695,6 +2695,11 @@ const (
 	// cmdQCancelTestDeadlockTimeout is the timeout used in cmdQCancelTest to
 	// determine that a deadlock has occurred.
 	cmdQCancelTestDeadlockTimeout = 500 * time.Millisecond
+	// cmdQCancelTestProgressTimeout is the timeout used in cmdQCancelTest to
+	// wait for any unexpected progress, before determining that progress has
+	// properly halted. Once this timeout expires, the cmdQCancelTest unblocks
+	// other commands to allow for further progress.
+	cmdQCancelTestProgressTimeout = 10 * time.Millisecond
 )
 
 // onCmdQAction instruments CommandQueueActions, sending to different channels
@@ -2897,7 +2902,7 @@ func (ct *cmdQCancelTest) runCmds() {
 		select {
 		case <-ct.startingCmd:
 			ct.Fatalf("expected %d commands to begin running together, saw extra", readyLen)
-		case <-time.After(cmdQCancelTestDeadlockTimeout / 10):
+		case <-time.After(cmdQCancelTestProgressTimeout):
 		}
 
 		// We should see exactly this many command finish. Again, the absence


### PR DESCRIPTION
`cmdQCancelTest` has a timeout that waits for a certain period to assure
that all forward progress has properly halted, before unblocking
the next back of commands. This change drops this timeout from `50ms` to
`10ms`.

This slices `15s` off the runtime of `make test PKG=./pkg/storage`.