### PR TITLE
build: adjust 3->5 allocator test success criteria

### DIFF
--- a/build/teamcity-nightly-acceptance.sh
+++ b/build/teamcity-nightly-acceptance.sh
@@ -37,11 +37,11 @@ case $TESTNAME in
     ;;
   TestRebalance_3To5Small)
     TESTTIMEOUT=4h
-    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 14'
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 42'
     ;;
   TestRebalance_3To5Small_WithSchemaChanges)
     TESTTIMEOUT=24h
-    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 14'
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 42'
     ;;
   TestSteady_3Small)
     TESTTIMEOUT=24h


### PR DESCRIPTION
I recently recreated the snapshot for the "small" nightly allocator
tests. In the process, the # of ranges increased without a
proportionate increase the maximum allowed standard deviation for
replica counts. This fixes that oversight.