### PR TITLE
util/interval: add btree flag

### DIFF
--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -11,6 +11,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 )
 
 // ErrInvertedRange is returned if an interval is used where the start value is greater
@@ -195,8 +197,13 @@ type TreeIterator interface {
 	Next() (Interface, bool)
 }
 
+var useBTreeImpl = envutil.EnvOrDefaultBool("COCKROACH_INTERVAL_BTREE", false)
+
 // NewTree creates a new interval tree with the given overlapper function. It
 // uses the augmented Left-Leaning Red Black tree implementation.
 func NewTree(overlapper Overlapper) Tree {
+	if useBTreeImpl {
+		return newBTree(overlapper)
+	}
 	return newLLBRTree(overlapper)
 }


### PR DESCRIPTION
still off by default, but I want to give this a try.

early local benchmarks look promising:
```
name                              old time/op    new time/op    delta
PgbenchQueryParallel/Cockroach-4    5.15ms ± 6%    4.52ms ± 8%  -12.11%  (p=0.000 n=13+15)

name                              old alloc/op   new alloc/op   delta
PgbenchQueryParallel/Cockroach-4     636kB ± 1%     636kB ± 1%     ~     (p=0.821 n=13+15)

name                              old allocs/op  new allocs/op  delta
PgbenchQueryParallel/Cockroach-4     6.78k ± 1%     6.77k ± 1%     ~     (p=0.369 n=13+15)
```