### PR TITLE
acceptance: de-flake TestDecommission

### DIFF
--- a/pkg/acceptance/decommission_test.go
+++ b/pkg/acceptance/decommission_test.go
@@ -38,8 +38,6 @@ import (
 // TestDecommission starts up an >3 node cluster and decomissions and
 // recommissions nodes in various ways.
 func TestDecommission(t *testing.T) {
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/17995")
-
 	RunLocal(t, func(t *testing.T) {
 		s := log.Scope(t)
 		defer s.Close(t)

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -199,19 +199,40 @@ func (nl *NodeLiveness) SetDecommissioning(
 	ctx context.Context, nodeID roachpb.NodeID, decommission bool,
 ) (changeCommitted bool, err error) {
 	ctx = nl.ambientCtx.AnnotateCtx(ctx)
-	for {
+
+	attempt := func() (bool, error) {
+		// Allow only one decommissioning attempt in flight per node at a time.
+		// This is required for correct results since we may otherwise race with
+		// concurrent `IncrementEpoch` calls and get stuck in a situation in
+		// which the cached liveness is has decommissioning=false while it's
+		// really true, and that means that SetDecommissioning becomes a no-op
+		// (which is correct) but that our cached liveness never updates to
+		// reflect that.
+		//
+		// See https://github.com/cockroachdb/cockroach/issues/17995.
+		sem := nl.sem(nodeID)
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+		defer func() {
+			<-sem
+		}()
+
 		oldLiveness, err := nl.GetLiveness(nodeID) // need new liveness in each iteration
 		if err != nil {
 			return false, errors.Wrap(err, "unable to get liveness")
 		}
-		changeCommitted, err := nl.setDecommissioningInternal(ctx, nodeID, oldLiveness, decommission)
-		if err != nil {
-			if errors.Cause(err) == errChangeDecommissioningFailed {
-				continue // expected when epoch incremented
-			}
-			return false, err
+		return nl.setDecommissioningInternal(ctx, nodeID, oldLiveness, decommission)
+	}
+
+	for {
+		changeCommitted, err := attempt()
+		if errors.Cause(err) == errChangeDecommissioningFailed {
+			continue // expected when epoch incremented
 		}
-		return changeCommitted, nil
+		return changeCommitted, err
 	}
 }
 
@@ -257,19 +278,6 @@ func (nl *NodeLiveness) setDrainingInternal(
 func (nl *NodeLiveness) setDecommissioningInternal(
 	ctx context.Context, nodeID roachpb.NodeID, liveness *Liveness, decommission bool,
 ) (changeCommitted bool, err error) {
-	// Allow only one attempt to set the decommissioning field at a time if it is this node.
-	if nodeID == nl.gossip.NodeID.Get() {
-		sem := nl.sem(nodeID)
-		select {
-		case sem <- struct{}{}:
-			defer func() {
-				<-sem
-			}()
-		case <-ctx.Done():
-			return false, ctx.Err()
-		}
-	}
-
 	newLiveness := Liveness{
 		NodeID: nodeID,
 		Epoch:  1,

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -720,7 +720,12 @@ func (nl *NodeLiveness) livenessGossipUpdate(key string, content roachpb.Value) 
 	var callbacks []IsLiveCallback
 	nl.mu.Lock()
 	exLiveness, ok := nl.mu.nodes[liveness.NodeID]
-	if !ok || exLiveness.Expiration.Less(liveness.Expiration) || exLiveness.Epoch < liveness.Epoch || exLiveness.Draining != liveness.Draining {
+	apply := !ok ||
+		exLiveness.Expiration.Less(liveness.Expiration) ||
+		exLiveness.Epoch < liveness.Epoch ||
+		exLiveness.Draining != liveness.Draining ||
+		exLiveness.Decommissioning != liveness.Decommissioning
+	if apply {
 		nl.mu.nodes[liveness.NodeID] = liveness
 
 		// If isLive status is now true, but previously false, invoke any registered callbacks.


### PR DESCRIPTION
The test frequently got stuck during `decommission --wait` for a
freshly killed node, due to the following:

- node 1 gets killed
- node 3 increments node 1's epoch
- everything from now on happens on node 2
- calls IncrementEpoch, which stalls for now
- sets node 1's decommissioning flag
- gossip fires and updates node1's liveness map entry
- IncrementEpoch continues
- it fails (since the decommissioning flag mismatches)
- blindly updates the liveness[1], effectively clobbering its in-memory state
- calls to Decommission for node1 now turn into no-ops on node2, but
  when the liveness is queried, it looks like node1 isn't decommissioning.

Interestingly, when I looked at the liveness output as seen by the other two
nodes, they always had the same problem. Perhaps something else is at work on
top of the above? I filed an issue to investigate & fix the problematic behavior
of IncrementEpoch:

https://github.com/cockroachdb/cockroach/issues/18219

For this PR, I am simply using the semaphore to avoid interleavings between
IncrementEpoch and Decommission, and was able to run the test 10x without it
hanging (usually would hang every other time before, maybe more often).

Fixes #17995.

[1]: https://github.com/cockroachdb/cockroach/blob/a9ef8342681baa571ab552d2dc93185ac8eccb49/pkg/storage/node_liveness.go#L566-L572