### PR TITLE
cherry-pick: log: allow fully-verbose exfiltration

### DIFF
--- a/pkg/acceptance/debug_remote_test.go
+++ b/pkg/acceptance/debug_remote_test.go
@@ -75,6 +75,7 @@ func testDebugRemote(t *testing.T) {
 				"/debug/requests",
 				"/debug/range?id=1",
 				"/debug/certificates",
+				"/debug/logspy?duration=1ns",
 			} {
 				t.Run(url, func(t *testing.T) {
 					resp, err := cluster.HTTPClient.Get(l.URL(ctx, 0) + url)

--- a/pkg/server/debug.go
+++ b/pkg/server/debug.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 	"github.com/rcrowley/go-metrics/exp"
@@ -37,6 +38,8 @@ import (
 // debugEndpoint is the prefix of golang's standard debug functionality
 // for access to exported vars and pprof tools.
 const debugEndpoint = "/debug/"
+
+const debugLogSpyEndpoint = "/debug/logspy"
 
 // We use the default http mux for the debug endpoint (as pprof and net/trace
 // register to that via import, and go-metrics registers to that via exp.Exp())
@@ -149,6 +152,11 @@ func init() {
 </html>
 `)
 	})
+
+	spy := logSpy{
+		setIntercept: log.Intercept,
+	}
+	debugServeMux.HandleFunc(debugLogSpyEndpoint, spy.handleDebugLogSpy)
 
 	// This registers a superset of the variables exposed through the /debug/vars endpoint
 	// onto the /debug/metrics endpoint. It includes all expvars registered globally and

--- a/pkg/server/debug_logspy.go
+++ b/pkg/server/debug_logspy.go
@@ -1,0 +1,237 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
+)
+
+// regexpAsString wraps a *regexp.Regexp for better printing and
+// JSON unmarshaling.
+type regexpAsString struct {
+	re *regexp.Regexp
+}
+
+func (r regexpAsString) String() string {
+	if r.re == nil {
+		return ".*"
+	}
+	return r.re.String()
+}
+
+func (r *regexpAsString) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	var err error
+	(*r).re, err = regexp.Compile(s)
+	return err
+}
+
+// intAsString wraps an int that can be populated from a JSON string.
+type intAsString int
+
+func (i *intAsString) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	var err error
+	*(*int)(i), err = strconv.Atoi(s)
+	return err
+}
+
+// durationAsString wraps a time.Duration that can be populated from a JSON
+// string.
+type durationAsString time.Duration
+
+func (d *durationAsString) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	var err error
+	*(*time.Duration)(d), err = time.ParseDuration(s)
+	return err
+}
+
+func (d durationAsString) String() string {
+	return time.Duration(d).String()
+}
+
+const (
+	logSpyDefaultDuration = durationAsString(10 * time.Second)
+	logSpyMaxDuration     = durationAsString(time.Minute)
+	logSpyDefaultCount    = 1000
+	logSpyChanCap         = 4096
+)
+
+type logSpyOptions struct {
+	Count    intAsString
+	Duration durationAsString
+	Grep     regexpAsString
+}
+
+func logSpyOptionsFromValues(values url.Values) (logSpyOptions, error) {
+	rawValues := map[string]string{}
+	for k, vals := range values {
+		if len(vals) > 0 {
+			rawValues[k] = vals[0]
+		}
+	}
+	data, err := json.Marshal(rawValues)
+	if err != nil {
+		return logSpyOptions{}, err
+	}
+	var opts logSpyOptions
+	if err := json.Unmarshal(data, &opts); err != nil {
+		return logSpyOptions{}, err
+	}
+	if opts.Duration == 0 {
+		if opts.Count > 0 {
+			opts.Duration = logSpyMaxDuration
+		} else {
+			opts.Duration = logSpyDefaultDuration
+		}
+	} else if opts.Duration > logSpyMaxDuration {
+		return logSpyOptions{}, errors.Errorf("duration %s is too large (limit is %s)", opts.Duration, logSpyMaxDuration)
+	}
+
+	if opts.Count == 0 {
+		opts.Count = logSpyDefaultCount
+	}
+	return opts, nil
+}
+
+type logSpy struct {
+	active       int32 // updated atomically between 0 and 1
+	setIntercept func(ctx context.Context, f log.InterceptorFn)
+}
+
+func (spy *logSpy) handleDebugLogSpy(w http.ResponseWriter, r *http.Request) {
+	opts, err := logSpyOptionsFromValues(r.URL.Query())
+	if err != nil {
+		http.Error(w, "while parsing options: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if swapped := atomic.CompareAndSwapInt32(&spy.active, 0, 1); !swapped {
+		http.Error(w, "a log interception is already in progress", http.StatusInternalServerError)
+		return
+	}
+	defer atomic.StoreInt32(&spy.active, 0)
+
+	w.Header().Add("Content-type", "text/plain; charset=UTF-8")
+	ctx := r.Context()
+	if err := spy.run(ctx, w, opts); err != nil {
+		// This is likely a broken HTTP connection, so nothing too unexpected.
+		log.Info(ctx, err)
+	}
+}
+
+func (spy *logSpy) run(ctx context.Context, w io.Writer, opts logSpyOptions) (err error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(opts.Duration))
+	defer cancel()
+
+	var countDropped int32
+	defer func() {
+		if err == nil {
+			if dropped := atomic.LoadInt32(&countDropped); dropped > 0 {
+				f, l, _ := caller.Lookup(0)
+				entry := log.MakeEntry(
+					log.Severity_WARNING, timeutil.Now().UnixNano(), f, l,
+					fmt.Sprintf("%d messages were dropped", dropped))
+				err = entry.Format(w) // modify return value
+			}
+		}
+	}()
+
+	// Note that in the code below, this channel is never closed. This is
+	// because we don't know when that is safe. This is sketchy in general but
+	// OK here since we don't have to guarantee that the channel is fully
+	// consumed.
+	entries := make(chan log.Entry, logSpyChanCap)
+
+	{
+		f, l, _ := caller.Lookup(0)
+		entry := log.MakeEntry(
+			log.Severity_INFO, timeutil.Now().UnixNano(), f, l,
+			fmt.Sprintf("intercepting logs with options %+v", opts))
+		entries <- entry
+	}
+
+	spy.setIntercept(ctx, func(entry log.Entry) {
+		if re := opts.Grep.re; re != nil && !re.MatchString(entry.Message) && !re.MatchString(entry.File) {
+			return
+		}
+
+		select {
+		case entries <- entry:
+		default:
+			// Consumer fell behind, just drop the message.
+			atomic.AddInt32(&countDropped, 1)
+		}
+	})
+
+	defer spy.setIntercept(ctx, nil)
+
+	const flushInterval = time.Second
+	var flushTimer timeutil.Timer
+	defer flushTimer.Stop()
+	flushTimer.Reset(flushInterval)
+
+	var count intAsString
+	var done <-chan struct{} // set later; helps always send header message
+	for {
+		select {
+		case <-done:
+
+			return
+		case entry := <-entries:
+			if err := entry.Format(w); err != nil {
+				return errors.Wrapf(err, "while writing entry %v", entry)
+			}
+			count++
+			if count > opts.Count {
+				return nil
+			}
+			if done == nil {
+				done = ctx.Done()
+			}
+		case <-flushTimer.C:
+			flushTimer.Read = true
+			flushTimer.Reset(flushInterval)
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		}
+	}
+}

--- a/pkg/server/debug_logspy_test.go
+++ b/pkg/server/debug_logspy_test.go
@@ -1,0 +1,336 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/pkg/errors"
+)
+
+func TestDebugLogSpyOptions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		vals    url.Values
+		expOpts logSpyOptions
+		expErr  string
+	}{
+		{
+			// Example where everything is specified (and parsed).
+			vals: map[string][]string{
+				"NonexistentOptionIsIgnored": {"banana"},
+				"Count":    {"123"},
+				"Duration": {"9s"},
+				"Grep":     {`^foo$`},
+			},
+			expOpts: logSpyOptions{
+				Count:    123,
+				Duration: durationAsString(9 * time.Second),
+				Grep:     regexpAsString{regexp.MustCompile(`^foo$`)},
+			},
+		},
+		{
+			// When nothing is given, default to "infinite" count and a 5s duration.
+			expOpts: logSpyOptions{
+				Count:    logSpyDefaultCount,
+				Duration: logSpyDefaultDuration,
+			},
+		},
+		{
+			// When a count is given but no duration, default the duration to the
+			// maximum allowed.
+			vals: map[string][]string{
+				"Count": {"1"},
+			},
+			expOpts: logSpyOptions{
+				Count:    1,
+				Duration: durationAsString(logSpyMaxDuration),
+			},
+		},
+		{
+			// Can't spy for too long.
+			vals: map[string][]string{
+				"Duration": {(2 * logSpyMaxDuration).String()},
+			},
+			expErr: regexp.QuoteMeta(`duration 2m0s is too large (limit is 1m0s)`),
+		},
+		// Various parse errors.
+		{
+			vals: map[string][]string{
+				"Count": {"bellpepper is not a number"},
+			},
+			expErr: `strconv.Atoi: parsing "bellpepper is not a number": invalid syntax`,
+		},
+		{
+			vals: map[string][]string{
+				"Duration": {"very long"},
+			},
+			expErr: `time: invalid duration very long`,
+		},
+		{
+			vals: map[string][]string{
+				"Grep": {"(unresolved parentheses = tension"},
+			},
+			expErr: regexp.QuoteMeta("error parsing regexp: missing closing ): `(unresolved parentheses = tension`"),
+		},
+	}
+
+	for i, test := range testCases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			opts, err := logSpyOptionsFromValues(test.vals)
+			if !testutils.IsError(err, test.expErr) {
+				t.Fatalf("unexpected error: %s [expected %s]", err, test.expErr)
+			}
+			if isStr, shouldStr := fmt.Sprintf("%v", opts), fmt.Sprintf("%v", test.expOpts); isStr != shouldStr {
+				t.Fatalf("wanted: %s\ngot: %s", shouldStr, isStr)
+			}
+		})
+	}
+}
+
+func TestDebugLogSpyHandle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Verify that a parse error doesn't execute anything.
+	{
+		spy := logSpy{
+			setIntercept: func(ctx context.Context, f log.InterceptorFn) {
+				t.Fatal("tried to intercept")
+			},
+		}
+
+		r := httptest.NewRequest("GET", "/?duration=notaduration", nil)
+		rec := httptest.NewRecorder()
+		spy.handleDebugLogSpy(rec, r)
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("unexpected status: %d", rec.Code)
+		}
+		exp := "while parsing options: time: invalid duration notaduration\n"
+		if body := rec.Body.String(); body != exp {
+			t.Fatalf("expected: %q\ngot: %q", exp, body)
+		}
+	}
+
+	// Verify that overlapping intercepts are prevented.
+	{
+		waiting := make(chan struct{})
+		waitingAlias := waiting
+		spy := logSpy{
+			setIntercept: func(ctx context.Context, f log.InterceptorFn) {
+				if f != nil && waitingAlias != nil {
+					close(waitingAlias)
+					waitingAlias = nil
+					<-ctx.Done()
+				}
+			},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		{
+			r := httptest.NewRequest("GET", "/?duration=1m", nil)
+			r = r.WithContext(ctx)
+			rec := httptest.NewRecorder()
+			go spy.handleDebugLogSpy(rec, r)
+		}
+
+		<-waiting // goroutine is now armed, new requests should bounce
+
+		request := func() (int, string) {
+			rec := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/", nil)
+			ctx, c := context.WithCancel(context.Background())
+			c() // intentionally to avoid doing any real work
+			r = r.WithContext(ctx)
+			spy.handleDebugLogSpy(rec, r)
+			resp := rec.Result()
+			defer resp.Body.Close()
+			bodyBytes, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				panic(err)
+			}
+			return resp.StatusCode, string(bodyBytes)
+		}
+
+		for {
+			status, body := request()
+
+			if cancel != nil {
+				cancel() // cancel open request, should finish soon
+				cancel = nil
+			}
+
+			if cancel != nil || status == http.StatusInternalServerError {
+				exp := "a log interception is already in progress\n"
+				if status != http.StatusInternalServerError || body != exp {
+					t.Fatalf("expected: %d %q\ngot: %d %q",
+						http.StatusInternalServerError, exp,
+						status, body)
+				}
+				continue
+			} else {
+				if status != http.StatusOK {
+					t.Fatalf("%d %s", status, body)
+				}
+				if re := regexp.MustCompile(`intercepting logs with options`); !re.MatchString(body) {
+					t.Fatal(body)
+				}
+				break
+			}
+		}
+	}
+}
+
+func TestDebugLogSpyRun(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	send := make(chan log.InterceptorFn, 1)
+	spy := logSpy{
+		setIntercept: func(ctx context.Context, f log.InterceptorFn) {
+			send <- f
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var buf bytes.Buffer
+	go func() {
+		if err := spy.run(ctx, &buf, logSpyOptions{
+			Duration: durationAsString(time.Hour),
+			Count:    2,
+			Grep:     regexpAsString{re: regexp.MustCompile(`first\.go|#2`)},
+		}); err != nil {
+			panic(err)
+		}
+		close(send)
+	}()
+
+	f := <-send
+
+	f(log.Entry{
+		File:    "first.go",
+		Line:    1,
+		Message: "#1",
+	})
+	f(log.Entry{
+		File:    "nonmatching.go",
+		Line:    12345,
+		Message: "ignored because neither message nor file match",
+	})
+	f(log.Entry{
+		File:    "second.go",
+		Line:    2,
+		Message: "#2",
+	})
+	if undoF := <-send; undoF != nil {
+		t.Fatal("interceptor closed with non-nil function")
+	}
+
+	for i := 0; i < 10000; i++ {
+		// f could be invoked arbitrarily after the operation finishes (though
+		// in reality the duration would be limited to the blink of an eye). It
+		// must not fill up a channel and block, or panic.
+		f(log.Entry{})
+	}
+
+	body := buf.String()
+	re := regexp.MustCompile(
+		`(?m:.*intercepting.*\n.*first\.go:1\s+#1\n.*second\.go:2\s+#2)`,
+	)
+	if !re.MatchString(body) {
+		t.Fatal(body)
+	}
+}
+
+type brokenConnWriter struct {
+	syncutil.Mutex // for stalling progress
+	fail           *regexp.Regexp
+	buf            bytes.Buffer
+}
+
+func (bcw *brokenConnWriter) Write(p []byte) (int, error) {
+	bcw.Lock()
+	defer bcw.Unlock()
+	if bcw.fail.Match(p) {
+		return 0, errors.Errorf("boom on: %q", p)
+	}
+	return bcw.buf.Write(p)
+}
+
+func TestDebugLogSpyBrokenConnection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, test := range []struct {
+		name, failStr string
+	}{
+		{name: "OnEntry", failStr: "foobar #1"},
+		{name: "OnDropped", failStr: "messages were dropped"},
+	} {
+		send := make(chan log.InterceptorFn, 1)
+		spy := logSpy{
+			setIntercept: func(_ context.Context, f log.InterceptorFn) {
+				send <- f
+			},
+		}
+
+		w := &brokenConnWriter{
+			fail: regexp.MustCompile(test.failStr),
+		}
+
+		go func() {
+			f := <-send
+			// Block the writer while we create entries. That way, the spy will
+			// have to drop entries and that's what we want (in one of the
+			// tests. In the other, we error out earlier instead, so causing
+			// dropped entries doesn't hurt either).
+			w.Lock()
+			defer w.Unlock()
+			for i := 0; i < 2*logSpyChanCap; i++ {
+				f(log.Entry{
+					File:    "fake.go",
+					Line:    int64(i),
+					Message: fmt.Sprintf("foobar #%d", i),
+				})
+			}
+		}()
+
+		ctx := context.Background()
+
+		func() {
+			if err := spy.run(ctx, w, logSpyOptions{
+				Duration: durationAsString(time.Hour),
+				Count:    logSpyChanCap + 1,
+			}); !testutils.IsError(err, test.failStr) {
+				t.Fatal(err)
+			}
+		}()
+	}
+}

--- a/pkg/server/status/runtime_jemalloc.go
+++ b/pkg/server/status/runtime_jemalloc.go
@@ -84,6 +84,7 @@ package status
 import "C"
 
 import (
+	"math"
 	"reflect"
 	"strings"
 
@@ -118,7 +119,11 @@ func getJemallocStats(ctx context.Context) (uint, uint, error) {
 		log.Infof(ctx, "jemalloc stats: %s", strings.Join(stats, " "))
 	}
 
-	if log.V(3) {
+	// NB: the `!V(MaxInt32)` condition is a workaround to not spew this to the
+	// logs whenever log interception (log spy) is active. If we refactored
+	// je_malloc_stats_print to return a string that we can `log.Infof` instead,
+	// we wouldn't need this.
+	if log.V(3) && !log.V(math.MaxInt32) {
 		// Detailed jemalloc stats (very verbose, includes per-arena stats).
 		C.je_malloc_stats_print(nil, nil, nil)
 	}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/petermattis/goid"
+
 	"golang.org/x/net/context"
 )
 
@@ -169,6 +171,18 @@ func FatalfDepth(ctx context.Context, depth int, format string, args ...interfac
 // higher.
 func V(level level) bool {
 	return VDepth(level, 1)
+}
+
+// MakeEntry creates an Entry.
+func MakeEntry(s Severity, t int64, file string, line int, msg string) Entry {
+	return Entry{
+		Severity:  s,
+		Time:      t,
+		Goroutine: goid.Get(),
+		File:      file,
+		Line:      int64(line),
+		Message:   msg,
+	}
 }
 
 // Format writes the log entry to the specified writer.


### PR DESCRIPTION
While debugging production clusters, it has occurred frequently that
we needed to bump `--vmodule` to get at relevant log traffic from, say,
the bowels of Raft. In production settings and in particular with clusters
that we don't have direct access to, this has proven difficult and time-
consuming.

The idea here is to have an easily accessible endpoint that can "siphon off"
small chunks of completely verbose log traffic for short amounts of time.

Whether this endpoint is accessible from the cli, sql shell, debug ui or all
of them remains to be decided. For now, I went with the easiest option:

```
$ curl -N 'http://localhost:8080/debug/logspy?grep=raft.go'
I170904 12:57:06.695875 320 server/debug_logspy.go:158  intercepting logs with options {Count:2147483647 Duration:5s Grep:raft.go}
I170904 12:57:09.637463 82 storage/raft.go:136  [n1,s1,r3/1:/System/NodeLiveness{-Max}] raft ready
  HardState updated: {Term:73 Vote:1 Commit:12465 XXX_unrecognized:[]}
  New Entry[0]: 73/12465 EntryNormal [103e53c3f0061a4e] [453]
  Committed Entry[0]: 73/12465 EntryNormal [103e53c3f0061a4e] [453]
```