### PR TITLE
storage: Fix off-by-one error in getEstimatedBehindCountRLocked

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1082,10 +1082,10 @@ func (r *Replica) getEstimatedBehindCountRLocked(raftStatus *raft.Status) int64 
 		// We haven't heard from the leader, assume we're far behind. This is the
 		// case that is commonly hit when a node restarts. In particular, we hit
 		// this case until an election timeout passes and canCampaignIdleReplica
-		// starts to return true. The results it that a restarted node will
+		// starts to return true. The result is that a restarted node will
 		// consider its replicas far behind initially which will in turn cause it
 		// to reject rebalances.
-		return prohibitRebalancesBehindThreshold
+		return prohibitRebalancesBehindThreshold + 1
 	}
 	if r.mu.estimatedCommitIndex >= r.mu.state.RaftAppliedIndex {
 		return int64(r.mu.estimatedCommitIndex - r.mu.state.RaftAppliedIndex)


### PR DESCRIPTION
The intent of this code was to return an estimated count that would
disable rebalancing, but it was actually returning the maximum value
that wouldn't disable rebalancing, making it so that two replicas had
to be behind before rebalancing would be disabled by
Store.updateReplicationGauges.

This wasn't truly breaking anything, but it was making issues
like #17375 appear less frequently than they otherwise would.