### PR TITLE
cherrypick: storage: Keep estimatedCommitIndex up to date on raft leader

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1508,8 +1508,6 @@ func TestDrainRangeRejection(t *testing.T) {
 func TestSystemZoneConfigs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	t.Skip("https://github.com/cockroachdb/cockroach/issues/17375")
-
 	if testing.Short() {
 		t.Skip("short flag")
 	}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3343,6 +3343,9 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	r.mu.lastTerm = lastTerm
 	r.mu.raftLogSize = raftLogSize
 	r.mu.leaderID = leaderID
+	if r.mu.replicaID == leaderID && !raft.IsEmptyHardState(rd.HardState) {
+		r.setEstimatedCommitIndexLocked(rd.HardState.Commit)
+	}
 	r.mu.Unlock()
 
 	for _, message := range rd.Messages {


### PR DESCRIPTION
Since we only previously only bumped Replica.mu.estimatedCommitIndex
based on received raft messages, the raft leader never incremented its
own commit index. This meant that after losing/transferring its
leadership, there would be a short period of time during which a
replica's getEstimatedBehindCountRLocked method would assume that it had
never heard from the leader. This causes Store.updateReplicationGauges
to disable rebalancing to the store until the next time it runs.

Fixes #17375, because it was frequently happening that node 1 would
transfer away a few leases and then have its rebalancing disabled as a
result of this chain of events. Since the test waits for rebalancing to
happen, it would then time out.