### PR TITLE
sql/pgwire: simplify COPY ... FROM STDIN data flow

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -688,6 +688,7 @@ func (e *Executor) CopyDone(session *Session) error {
 
 // CopyEnd ends the COPY mode. Any buffered data is discarded.
 func (s *Session) CopyEnd(ctx context.Context) {
+	s.copyFrom.Close(ctx)
 	s.copyFrom = nil
 }
 


### PR DESCRIPTION
COPY FROM STDIN in a post-streaming-results world had an inadvertent
re-entrancy into the main executor flow. This was confusing and possibly
incorrect. The way it worked before was that running `CloseResult` on
the `COPY FROM` statement itself would initialize and run the entire
COPY state machine, which needs to re-enter the executor leading to
that possible incorrectness.

This refactor removes the recursive flow. Now, `CloseResult` on `COPY
FROM` merely sends the magic "ready for copy in" message to the client.
Then, once we return from the executor for `COPY FROM`, the pgwire
implementation switches from its ordinary state machine to the COPY
state machine and runs until completion, at which point it returns
control to the ordinary state machine.

Also, a small refactor to store a `Session` inside of the `copyNode` instead of a `planner`, which was not necessary.

Fixes #18175.
Fixes #17941.
Fixes #18133.