### PR TITLE
distsql: enable sending arrays over distsql

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -251,8 +251,7 @@ func (dsp *distSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 
 	case *renderNode:
 		for i, e := range n.render {
-			if typ := n.columns[i].Typ; typ.FamilyEqual(parser.TypeTuple) ||
-				typ.FamilyEqual(parser.TypeArray) {
+			if typ := n.columns[i].Typ; typ.FamilyEqual(parser.TypeTuple) {
 				return 0, newQueryNotSupportedErrorf("unsupported render type %s", typ)
 			}
 			if err := dsp.checkExpr(e); err != nil {

--- a/pkg/sql/distsqlrun/stream_encoder.go
+++ b/pkg/sql/distsqlrun/stream_encoder.go
@@ -104,7 +104,8 @@ func (se *StreamEncoder) AddRow(row sqlbase.EncDatumRow) error {
 			if !ok {
 				enc = preferredEncoding
 			}
-			if enc != sqlbase.DatumEncoding_VALUE && sqlbase.HasCompositeKeyEncoding(row[i].Type.SemanticType) {
+			if enc != sqlbase.DatumEncoding_VALUE && (sqlbase.HasCompositeKeyEncoding(row[i].Type.SemanticType) ||
+				sqlbase.MustBeValueEncoded(row[i].Type.SemanticType)) {
 				// Force VALUE encoding for composite types (key encodings may lose data).
 				enc = sqlbase.DatumEncoding_VALUE
 			}

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -10,6 +10,23 @@ SELECT ARRAY[1, 2, 3]
 ----
 {1,2,3}
 
+statement ok
+CREATE TABLE k (
+  k INT PRIMARY KEY
+)
+
+statement ok
+INSERT INTO k VALUES (1), (2), (3), (4), (5)
+
+query T rowsort
+SELECT ARRAY[k] FROM k
+----
+{1}
+{2}
+{3}
+{4}
+{5}
+
 query error expected 1 to be of type bool, found type int
 SELECT ARRAY['a', true, 1]
 
@@ -387,7 +404,7 @@ DELETE FROM a
 statement ok
 INSERT INTO a VALUES (ARRAY[NULL::INT]), (ARRAY[NULL::INT, 1]), (ARRAY[1, NULL::INT]), (ARRAY[NULL::INT, NULL::INT])
 
-query T
+query T rowsort
 SELECT * FROM a
 ----
 {NULL}
@@ -456,7 +473,7 @@ CREATE TABLE a (b BOOL[])
 statement ok
 INSERT INTO a VALUES (ARRAY[]), (ARRAY[TRUE]), (ARRAY[FALSE]), (ARRAY[TRUE, TRUE]), (ARRAY[FALSE, TRUE])
 
-query T
+query T rowsort
 SELECT b FROM a
 ----
 {}
@@ -604,7 +621,7 @@ CREATE TABLE a (b STRING[] COLLATE en)
 statement ok
 INSERT INTO a VALUES (ARRAY['hello' COLLATE en]), (ARRAY['goodbye' COLLATE en])
 
-query T
+query T rowsort
 SELECT * FROM a
 ----
 {"hello"}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -590,6 +590,12 @@ func HasCompositeKeyEncoding(semanticType ColumnType_SemanticType) bool {
 	return false
 }
 
+// MustBeValueEncoded returns true if columns of the given kind can only be value
+// encoded.
+func MustBeValueEncoded(semanticType ColumnType_SemanticType) bool {
+	return semanticType == ColumnType_ARRAY
+}
+
 // HasOldStoredColumns returns whether the index has stored columns in the old
 // format (data encoded the same way as if they were in an implicit column).
 func (desc *IndexDescriptor) HasOldStoredColumns() bool {
@@ -1280,7 +1286,7 @@ func fitColumnToFamily(desc TableDescriptor, col ColumnDescriptor) (int, bool) {
 
 // columnTypeIsIndexable returns whether the type t is valid as an indexed column.
 func columnTypeIsIndexable(t ColumnType) bool {
-	return t.SemanticType != ColumnType_ARRAY
+	return !MustBeValueEncoded(t.SemanticType)
 }
 
 func notIndexableError(cols []ColumnDescriptor) error {


### PR DESCRIPTION
🔬🐶. Relevant info for someone who knows more about distSQL is that
arrays have a value encoding but no key encoding.