### PR TITLE
storage: Add test that the first timeseries range uses epoch leases

### DIFF
--- a/pkg/storage/client_lease_test.go
+++ b/pkg/storage/client_lease_test.go
@@ -46,7 +46,13 @@ func TestStoreRangeLease(t *testing.T) {
 			defer mtc.Stop()
 			mtc.Start(t, 1)
 
-			splitKeys := []roachpb.Key{roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")}
+			// NodeLivenessKeyMax is a static split point, so this is always
+			// the start key of the first range that uses epoch-based
+			// leases. Splitting on it here is redundant, but we want to include
+			// it in our tests of lease types below.
+			splitKeys := []roachpb.Key{
+				keys.NodeLivenessKeyMax, roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c"),
+			}
 			for _, splitKey := range splitKeys {
 				splitArgs := adminSplitArgs(splitKey)
 				if _, pErr := client.SendWrapped(context.Background(), mtc.distSenders[0], splitArgs); pErr != nil {


### PR DESCRIPTION
A screenshot in
https://github.com/cockroachdb/cockroach/issues/17524#issuecomment-324759187
made me think we might have an off-by-one error here (because it
showed the range starting with NodeLivenessKeyMax using an
expiration-based lease), but it was a false alarm caused by a bug in
the range debug page (#17843). In any case, it's good to test here.