### PR TITLE
util: union-find data structure

### DIFF
--- a/pkg/util/union_find.go
+++ b/pkg/util/union_find.go
@@ -1,0 +1,96 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+// UnionFind implements the union find structure, with union by rank and path
+// compression heuristics. Find and Union operations are effectively constant
+// time. The data structure uses O(N) space where N is the largest element. It
+// sizes itself as necessary; there are no allocations if Union is never called.
+type UnionFind struct {
+	nodes []ufNode
+}
+
+// ufNode represents an element of a UnionFind data structure. The elements are
+// organized as nodes in a forest; two elements are in the same group if they
+// are part of the same tree.
+type ufNode struct {
+	// parent is the parent node. All nodes in a tree are part of the same group;
+	// the representative of that group is the root node.
+	parent int32
+	// the rank is the maximum depth of the subtree rooted at this node; only used
+	// for the root of each tree.
+	rank int32
+}
+
+// Find returns the representative of the group that n is part of.
+// Two elements a, b are in the same group iff Find(a) == Find(b).
+func (f *UnionFind) Find(n int32) int32 {
+	if int(n) >= len(f.nodes) {
+		// n was never touched by a Union call.
+		return n
+	}
+
+	parent := f.nodes[n].parent
+	grandparent := f.nodes[parent].parent
+
+	// Fast path if the element is connected directly to the root of the group (or
+	// is the root).
+	if grandparent == parent {
+		return parent
+	}
+
+	i := grandparent
+	for {
+		p := f.nodes[i].parent
+		if p == i {
+			break
+		}
+		i = p
+	}
+
+	// Compress the path.
+	root := i
+	for i := n; i != root; {
+		i, f.nodes[i].parent = f.nodes[i].parent, root
+	}
+	return root
+}
+
+// Union joins the groups to which a and b belong.
+func (f *UnionFind) Union(a, b int32) {
+	// Substitute a, b with the roots of the corresponding trees.
+	a = f.Find(a)
+	b = f.Find(b)
+	if a == b {
+		// Already part of the same group.
+		return
+	}
+	// Extend the slice with single-element groups as necessary.
+	for i := int32(len(f.nodes)); i <= a || i <= b; i++ {
+		f.nodes = append(f.nodes, ufNode{parent: i})
+	}
+	an := &f.nodes[a]
+	bn := &f.nodes[b]
+	if an.rank < bn.rank {
+		// A's tree is shallower than B's tree; choose B as the root.
+		an.parent = b
+	} else {
+		// Choose A as the root.
+		bn.parent = a
+		if an.rank == bn.rank {
+			an.rank++
+		}
+	}
+}

--- a/pkg/util/union_find_test.go
+++ b/pkg/util/union_find_test.go
@@ -1,0 +1,57 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestUnionFind(t *testing.T) {
+	rng, _ := randutil.NewPseudoRand()
+	for _, n := range []int32{2, 3, 4, 10, 50, 100, 1000} {
+		group := make([]int, n)
+		for i := range group {
+			group[i] = i
+		}
+		uf := UnionFind{}
+		for i := int32(0); i < 100*n; i++ {
+			x := rng.Int31n(n)
+			y := rng.Int31n(n)
+			// 99% of the time we check if x and y are in the same group; 1% of
+			// the time we union them.
+			if rng.Intn(100) > 0 {
+				gx := uf.Find(x)
+				gy := uf.Find(y)
+				if (gx == gy) != (group[x] == group[y]) {
+					t.Fatalf(
+						"Find(%d)=%d, Find(%d)=%d, groups %d, %d",
+						x, gx, y, gy, group[x], group[y],
+					)
+				}
+			} else {
+				uf.Union(x, y)
+				gx := group[x]
+				gy := group[y]
+				for i := range group {
+					if group[i] == gx {
+						group[i] = gy
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implementing a union-find (aka disjoint-set) data structure.

The intention is that this will be used for representing equivalency groups (replacing the column groups in `orderingInfo`).