### PR TITLE
cherrypick-1.1: sql: minor fix to `SHOW TESTING_RANGES`

### DIFF
--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -154,7 +154,7 @@ func (n *showRangesNode) Close(_ context.Context) {
 func scanMetaKVs(
 	ctx context.Context, txn *client.Txn, span roachpb.Span,
 ) ([]client.KeyValue, error) {
-	metaStart := keys.RangeMetaKey(keys.MustAddr(span.Key))
+	metaStart := keys.RangeMetaKey(keys.MustAddr(span.Key).Next())
 	metaEnd := keys.RangeMetaKey(keys.MustAddr(span.EndKey))
 
 	kvs, err := txn.Scan(ctx, metaStart, metaEnd, 0)


### PR DESCRIPTION
Cherry-pick of #18236.

When showing ranges for a table, if we happen to have a split exactly at the
index start key `/tableID/priIdxID` we are showing an extra range. The issue is
that we are looking up the meta range for the span start key; the fix is to look
for the next key so we skip any range that ends exactly at this key.

Before:
```
root@:26257/tpch> show testing_ranges from table customer;
+-----------+---------+----------+--------------+
| Start Key | End Key | Replicas | Lease Holder |
+-----------+---------+----------+--------------+
| NULL      |         | {1,2,3}  |            3 |
|           | NULL    | {1,2,3}  |            3 |
+-----------+---------+----------+--------------+
```

After:
```
root@:26257/tpch> SHOW TESTING_RANGES FROM TABLE customer;
+-----------+---------+----------+--------------+
| Start Key | End Key | Replicas | Lease Holder |
+-----------+---------+----------+--------------+
| NULL      | NULL    | {1,2,3}  |            1 |
+-----------+---------+----------+--------------+
```

Relevant to the second issue described in #17432.