### PR TITLE
ui: Adjust Threshold for Suspect Nodes

### DIFF
--- a/pkg/ui/src/redux/cachedDataReducer.spec.ts
+++ b/pkg/ui/src/redux/cachedDataReducer.spec.ts
@@ -58,6 +58,7 @@ describe("basic cachedDataReducer", function () {
         state = reducer(state, testReducerObj.requestData());
         expected = new CachedDataReducerState<Response>();
         expected.inFlight = true;
+        expected.requestedAt = testMoment;
         assert.deepEqual(state, expected);
       });
 
@@ -113,6 +114,7 @@ describe("basic cachedDataReducer", function () {
           expected = new CachedDataReducerState<Response>();
           expected.valid = true;
           expected.data = new Response(testString);
+          expected.requestedAt = testMoment;
           expected.setAt = testMoment;
           expected.lastError = null;
           assert.deepEqual(state.cachedData.test, expected);
@@ -211,6 +213,7 @@ describe("keyed cachedDataReducer", function () {
         state = reducer(state, testReducerObj.cachedDataReducer.requestData(request));
         expected = new KeyedCachedDataReducerState<Response>();
         expected[id] = new CachedDataReducerState<Response>();
+        expected[id].requestedAt = testMoment;
         expected[id].inFlight = true;
         assert.deepEqual(state, expected);
       });

--- a/pkg/ui/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/src/redux/cachedDataReducer.ts
@@ -18,6 +18,7 @@ export class CachedDataReducerState<TResponseMessage> {
   data: TResponseMessage; // the latest data received
   inFlight = false; // true if a request is in flight
   valid = false; // true if data has been received and has not been invalidated
+  requestedAt: moment.Moment; // Timestamp when data was last requested.
   setAt: moment.Moment; // Timestamp when this data was last updated.
   lastError: Error; // populated with the most recent error, if the last request failed
 }
@@ -87,6 +88,7 @@ export class CachedDataReducer<TRequest, TResponseMessage> {
       case this.REQUEST:
         // A request is in progress.
         state = _.clone(state);
+        state.requestedAt = this.timeSource();
         state.inFlight = true;
         return state;
       case this.RECEIVE:


### PR DESCRIPTION
The criteria for marking a node as "suspect" in the UI may have been too
strict, resulting in occasions where working nodes are being marked as
suspect. This commit is assuming that the issue arises from a
combination of latency and clock skew.

+ Previously, the UI marked nodes as "suspect" if their liveness
expiration time had elapsed as of the timestamp when liveness records
were recieved. This commit now compares liveness expirations to the
timestamp when liveness records were *requested*, which should eliminate
latency from the round trip call as a factor.
+ Additionally, a five second grace period has been added to the suspect
computation.

We expect that the combination of these two measures should relieve the
issue.

Resolves #17840