### PR TITLE
ui: lint config files

### DIFF
--- a/pkg/ui/Makefile
+++ b/pkg/ui/Makefile
@@ -34,6 +34,8 @@ generate: $(GOBINDATA_TARGET)
 lint: $(YARN_INSTALLED_TARGET) | protos
 	yarn run -- stylint -c .stylintrc styl
 	yarn run -- tslint -c tslint.json -p tsconfig.json --type-check
+	@# TODO(benesch): Invoke tslint just once when palantir/tslint#2827 is fixed.
+	yarn run -- tslint -c tslint.json *.js
 
 .PHONY: test
 test: $(YARN_INSTALLED_TARGET) | protos

--- a/pkg/ui/karma.conf.js
+++ b/pkg/ui/karma.conf.js
@@ -1,48 +1,72 @@
 // Karma configuration
 // Generated on Wed Mar 22 2017 16:39:26 GMT-0400 (EDT)
 
-'use strict';
+"use strict";
 
-const webpackConfig = require('./webpack.config');
+const webpackConfig = require("./webpack.config");
 
 module.exports = function(config) {
   config.set({
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: false,
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '',
+    basePath: "",
 
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ["jsdom"],
 
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['mocha', 'chai', 'sinon'],
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
 
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity,
 
     // list of files / patterns to load in the browser
     files: [
-      'src/**/*.spec.*'
+      "src/**/*.spec.*",
     ],
 
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ["mocha", "chai", "sinon"],
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
 
     // TODO(tamird): https://github.com/webpack-contrib/karma-webpack/issues/188.
     mime: {
-      'text/x-typescript': ['ts','tsx'],
+      "text/x-typescript": ["ts", "tsx"],
     },
 
+    // web server port
+    port: 9876,
 
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      'src/**/*.spec.*': ['webpack', 'sourcemap'],
+      "src/**/*.spec.*": ["webpack", "sourcemap"],
     },
 
+    // test results reporter to use
+    // possible values: "dots", "progress"
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ["progress"],
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
 
     // https://github.com/airbnb/enzyme/blob/master/docs/guides/webpack.md
     webpack: Object.assign(webpackConfig, {
-      devtool: 'source-map',
+      devtool: "source-map",
       externals: {
-        'react/addons': true,
-        'react/lib/ExecutionEnvironment': true,
-        'react/lib/ReactContext': true,
+        "react/addons": true,
+        "react/lib/ExecutionEnvironment": true,
+        "react/lib/ReactContext": true,
       },
     }),
 
@@ -52,41 +76,5 @@ module.exports = function(config) {
       noInfo: true,
       stats: webpackConfig.stats,
     },
-
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
-    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
-
-
-    // web server port
-    port: 9876,
-
-
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
-
-
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
-
-
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
-
-
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['jsdom'],
-
-
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true,
-
-    // Concurrency level
-    // how many browser should be started simultaneous
-    concurrency: Infinity
-  })
-}
+  });
+};

--- a/pkg/ui/proxy.js
+++ b/pkg/ui/proxy.js
@@ -3,37 +3,39 @@
 // Simple proxy server that serves the UI from one Cockroach instance and
 // proxies requests to another Cockroach instance.
 
-const express = require('express');
-const proxy = require('http-proxy-middleware');
-const webpackDevMiddleware = require('webpack-dev-middleware');
-const webpack = require('webpack');
-const webpackConfig = require('./webpack.config');
+const express = require("express");
+const proxy = require("http-proxy-middleware");
+const webpackDevMiddleware = require("webpack-dev-middleware");
+const webpack = require("webpack");
+const webpackConfig = require("./webpack.config");
 
 const app = express();
 
 const compiler = webpack(Object.assign(webpackConfig, {
-  devtool: 'source-map',
+  devtool: "source-map",
 }));
 
-const argv = require('yargs')
-  .usage('Usage: $0 <remote-cockroach-ui-url> [options]')
+const argv = require("yargs")
+  .usage("Usage: $0 <remote-cockroach-ui-url> [options]")
   .demand(1)
-  .default('port', 3000, 'The port to run this proxy server on')
-  .example(`$0 https://myroach:8080`, 'Serve UI resources (HTML, JS, CSS) from localhost:8080, while serving API data requests from https://myroach:8080')
-  .help('h')
-  .alias('h', 'help')
-  .alias('p', 'port')
+  .default("port", 3000, "The port to run this proxy server on")
+  .example(`$0 https://myroach:8080`, "Serve UI resources (HTML, JS, CSS) from localhost:8080, " +
+    "while serving API data requests from https://myroach:8080")
+  .help("h")
+  .alias("h", "help")
+  .alias("p", "port")
   .argv;
 
-const port = argv.port, remote = argv._[0];
+const port = argv.port;
+const remote = argv._[0];
 
 app.use(webpackDevMiddleware(compiler, {
   stats: webpackConfig.stats,
 }));
 
-app.use('/', proxy({
-  target: remote,
+app.use("/", proxy({
   secure: false,
+  target: remote,
 }));
 
 console.log(`Proxying requests to ${remote} at http://localhost:${port}`);

--- a/pkg/ui/tslint.json
+++ b/pkg/ui/tslint.json
@@ -55,8 +55,8 @@
     "no-string-literal": true,
     "no-switch-case-fall-through": true,
     "trailing-comma": [true, {
-        "multiline": "always",
-        "singleline": "never"
+      "multiline": "always",
+      "singleline": "never"
     }],
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
@@ -115,5 +115,105 @@
       "check-separator",
       "check-type"
     ]
+  },
+  "jsRules": {
+    "align": {
+      "options": [
+        "parameters",
+        "statements"
+      ]
+    },
+    "class-name": true,
+    "curly": true,
+    "eofline": true,
+    "forin": true,
+    "import-spacing": true,
+    "indent":  {
+      "options": ["spaces"]
+    },
+    "jsdoc-format": true,
+    "label-position": true,
+    "max-line-length": {
+      "options": [120]
+    },
+    "new-parens": true,
+    "no-arg": true,
+    "no-bitwise": true,
+    "no-conditional-assignment": true,
+    "no-consecutive-blank-lines": true,
+    "no-console": true,
+    "no-construct": true,
+    "no-debugger": true,
+    "no-duplicate-super": true,
+    "no-duplicate-variable": true,
+    "no-empty": true,
+    "no-eval": true,
+    "no-reference": true,
+    "no-shadowed-variable": true,
+    "no-string-literal": true,
+    "no-string-throw": true,
+    "no-switch-case-fall-through": false,
+    "no-trailing-whitespace": true,
+    "no-unused-expression": true,
+    "no-use-before-declare": false,
+    "object-literal-sort-keys": true,
+    "one-line": {
+      "options": [
+        "check-catch",
+        "check-else",
+        "check-finally",
+        "check-open-brace",
+        "check-whitespace"
+      ]
+    },
+    "one-variable-per-declaration": {
+      "options": ["ignore-for-loop"]
+    },
+    "quotemark": {
+      "options": [
+        "double",
+        "avoid-escape"
+      ]
+    },
+    "radix": true,
+    "semicolon": {
+      "options": ["always"]
+    },
+    "space-before-function-paren": {
+      "options": {
+        "anonymous": "never",
+        "asyncArrow": "always",
+        "constructor": "never",
+        "method": "never",
+        "named": "never"
+      }
+    },
+    "trailing-comma": {
+      "options": {
+        "multiline": "always",
+        "singleline": "never"
+      }
+    },
+    "triple-equals": {
+      "options": ["allow-null-check"]
+    },
+    "use-isnan": true,
+    "variable-name": {
+      "options": [
+        "ban-keywords",
+        "check-format",
+        "allow-pascal-case"
+      ]
+    },
+    "whitespace": {
+      "options": [
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type",
+        "check-typecast"
+      ]
+    }
   }
 }

--- a/pkg/ui/webpack.config.js
+++ b/pkg/ui/webpack.config.js
@@ -1,19 +1,19 @@
-'use strict;'
+"use strict";
 
-const path = require('path');
-const rimraf = require('rimraf');
+const path = require("path");
+const rimraf = require("rimraf");
 
-const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
-const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const FaviconsWebpackPlugin = require("favicons-webpack-plugin");
+const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 
-const title = 'Cockroach Console';
+const title = "Cockroach Console";
 
 // Remove a broken dependency that Yarn insists upon installing before every
 // Webpack compile. We also do this when installing dependencies via Make, but
-// it's common to run e.g. `yarn add` manually without re-running Make, which
+// it"s common to run e.g. `yarn add` manually without re-running Make, which
 // will reinstall the broken dependency. The error this dependency causes is
-// horribly cryptic, so it's important to remove it aggressively.
+// horribly cryptic, so it"s important to remove it aggressively.
 //
 // See: https://github.com/yarnpkg/yarn/issues/2987
 class RemoveBrokenDependenciesPlugin {
@@ -22,51 +22,52 @@ class RemoveBrokenDependenciesPlugin {
   }
 }
 
+// tslint:disable:object-literal-sort-keys
 module.exports = {
-  entry: './src/index.tsx',
+  entry: "./src/index.tsx",
   output: {
-    filename: 'bundle.js',
-    path: __dirname + '/dist',
+    filename: "bundle.js",
+    path: __dirname + "/dist",
   },
 
   resolve: {
     // Add resolvable extensions.
-    extensions: ['.ts', '.tsx', '.js', '.json', '.styl', '.css'],
+    extensions: [".ts", ".tsx", ".js", ".json", ".styl", ".css"],
     // Resolve modules from src directory or node_modules.
-    // The 'path.resolve' is used to make these into absolute paths, meaning
+    // The "path.resolve" is used to make these into absolute paths, meaning
     // that only the exact directory is checked. A relative path would follow
     // the resolution behavior used by node.js for "node_modules", which checks
     // for a "node_modules" child directory located in either the current
     // directory *or in any parent directory*.
-    modules: [path.resolve(__dirname), path.resolve(__dirname, "node_modules")]
+    modules: [path.resolve(__dirname), path.resolve(__dirname, "node_modules")],
   },
 
   module: {
     rules: [
-      { test: /\.css$/, use: [ 'style-loader', 'css-loader' ] },
+      { test: /\.css$/, use: [ "style-loader", "css-loader" ] },
       {
         test: /\.styl$/,
         use: [
-          'cache-loader',
-          'thread-loader',
-          'style-loader',
-          'css-loader',
+          "cache-loader",
+          "thread-loader",
+          "style-loader",
+          "css-loader",
           {
-            loader: 'stylus-loader',
+            loader: "stylus-loader",
             options: {
-              use: [require('nib')()],
+              use: [require("nib")()],
             },
           },
         ],
       },
       {
         test: /\.(png|jpg|gif|svg|eot|ttf|woff|woff2)$/,
-        loader: 'url-loader',
+        loader: "url-loader",
         options: {
           limit: 10000,
         },
       },
-      { test: /\.html$/, loader: 'file-loader' },
+      { test: /\.html$/, loader: "file-loader" },
 
       // TODO(tamird,mrtracy,spencerkimball): Configure this to use an include
       // list when all of our first-party code has been written in typescript.
@@ -77,21 +78,21 @@ module.exports = {
         // the specific packages in node_modules that actually use ES6.
         // https://github.com/babel/babel-loader/issues/171
         exclude: /node_modules\/(?!analytics-node)/,
-        use: ['cache-loader', 'thread-loader', 'babel-loader'],
+        use: ["cache-loader", "thread-loader", "babel-loader"],
       },
 
       {
         test: /\.tsx?$/,
         use: [
-          'cache-loader',
-          'thread-loader',
-          'babel-loader',
-          { loader: 'ts-loader', options: { happyPackMode: true } },
-        ]
+          "cache-loader",
+          "thread-loader",
+          "babel-loader",
+          { loader: "ts-loader", options: { happyPackMode: true } },
+        ],
       },
 
-      // All output '.js' files will have any sourcemaps re-processed by 'source-map-loader'.
-      { enforce: 'pre', test: /\.js$/, loader: 'source-map-loader' },
+      // All output ".js" files will have any sourcemaps re-processed by "source-map-loader".
+      { enforce: "pre", test: /\.js$/, loader: "source-map-loader" },
     ],
   },
 
@@ -99,7 +100,7 @@ module.exports = {
     new ForkTsCheckerWebpackPlugin({ checkSyntacticErrors: true }),
     new RemoveBrokenDependenciesPlugin(),
     new FaviconsWebpackPlugin({
-      logo: './logo.png',
+      logo: "./logo.png",
       persistentCache: false,
       inject: true,
       title: title,
@@ -114,9 +115,9 @@ module.exports = {
     }),
     new HtmlWebpackPlugin({
       title: title,
-      template: require('html-webpack-template'),
+      template: require("html-webpack-template"),
       inject: false,
-      appMountId: 'react-layout',
+      appMountId: "react-layout",
     }),
   ],
 


### PR DESCRIPTION
These JS config files were causing Codacy failures, but weren't being
linted by our TeamCity. Enable linting of our config files (and fix the
lint errors within).