### PR TITLE
distsql: knobs for temp storage size

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -161,7 +161,7 @@ func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 
 	st := h.flowCtx.Settings
-	useTempStorage := (distSQLUseTempStorage.Get(&st.SV) && distSQLUseTempStorageJoins.Get(&st.SV)) ||
+	useTempStorage := settingUseTempStorageJoins.Get(&st.SV) ||
 		h.flowCtx.testingKnobs.MemoryLimitBytes > 0 ||
 		h.testingKnobMemFailPoint != unset
 	rowContainerMon := h.flowCtx.EvalCtx.Mon
@@ -170,7 +170,7 @@ func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 		// The hashJoiner will overflow to disk if this limit is not enough.
 		limit := h.flowCtx.testingKnobs.MemoryLimitBytes
 		if limit <= 0 {
-			limit = workMemBytes
+			limit = settingWorkMemBytes.Get(&st.SV)
 		}
 		limitedMon := mon.MakeMonitorInheritWithLimit("hashjoiner-limited", limit, rowContainerMon)
 		limitedMon.Start(ctx, rowContainerMon, mon.BoundAccount{})

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -686,7 +686,7 @@ func TestHashJoinerDrain(t *testing.T) {
 	// Since the use of external storage overrides h.initialBufferSize, disable
 	// it for this test.
 	settings := cluster.MakeTestingClusterSettings()
-	distSQLUseTempStorage.Override(&settings.SV, false)
+	settingUseTempStorageJoins.Override(&settings.SV, false)
 	flowCtx := FlowCtx{Settings: settings, EvalCtx: evalCtx}
 
 	post := PostProcessSpec{Projection: true, OutputColumns: outCols}

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -15,6 +15,7 @@
 package distsqlrun
 
 import (
+	"fmt"
 	"io"
 	"time"
 
@@ -76,34 +77,43 @@ const Version DistSQLVersion = 5
 // compatible with; see above.
 const MinAcceptedVersion DistSQLVersion = 4
 
-var distSQLUseTempStorage = settings.RegisterBoolSetting(
-	"sql.defaults.distsql.tempstorage",
-	"set to true to enable use of disk for larger distributed sql queries",
+var settingUseTempStorageSorts = settings.RegisterBoolSetting(
+	"sql.distsql.temp_storage.sorts",
+	"set to true to enable use of disk for distributed sql sorts",
 	true,
 )
 
-var distSQLUseTempStorageSorts = settings.RegisterBoolSetting(
-	"sql.defaults.distsql.tempstorage.sorts",
-	"set to true to enable use of disk for distributed sql sorts. sql.defaults.distsql.tempstorage must be true",
+var settingUseTempStorageJoins = settings.RegisterBoolSetting(
+	"sql.distsql.temp_storage.joins",
+	"set to true to enable use of disk for distributed sql joins",
 	true,
 )
 
-var distSQLUseTempStorageJoins = settings.RegisterBoolSetting(
-	"sql.defaults.distsql.tempstorage.joins",
-	"set to true to enable use of disk for distributed sql joins. sql.defaults.distsql.tempstorage must be true",
-	true,
+var settingWorkMemBytes = settings.RegisterByteSizeSetting(
+	"sql.distsql.temp_storage.workmem",
+	"maximum amount of memory in bytes a processor can use before falling back to temp storage (requires restart)",
+	64*1024*1024, /* 64MB */
 )
 
-// workMemBytes specifies the maximum amount of memory in bytes a processor can
-// use. This limit is only observed if the use of temporary storage is enabled
-// (see sql.defaults.distsql.tempstorage).
-var workMemBytes = envutil.EnvOrDefaultInt64("COCKROACH_WORK_MEM", 64*1024*1024 /* 64MB */)
+var settingDiskBudgetPercent = settings.RegisterValidatedIntSetting(
+	"sql.distsql.temp_storage.max_percent",
+	"maximum amount of disk space used for queries (as a percentage of the total capacity; requires restart); also see sql.distsql.temp_storage.max_bytes",
+	10,
+	func(val int64) error {
+		if val < 1 || val > 100 {
+			return fmt.Errorf("value must be between 1 and 100")
+		}
+		return nil
+	},
+)
+
+var settingDiskBudgetAbsolute = settings.RegisterByteSizeSetting(
+	"sql.distsql.temp_storage.max_bytes",
+	"maximum amount of disk space used for queries (in bytes; requires restart); also see sql.distsql.temp_storage.max_percent",
+	32*1024*1024*1024, /* 32GB */
+)
 
 var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_DISTSQL_MEMORY_USAGE", 1024*1024 /* 1MB */)
-
-// All queries that spill over to disk will be limited to use
-// total space / diskBudgetTotalSizeDivisor.
-const diskBudgetTotalSizeDivisor = 4
 
 // ServerConfig encompasses the configuration required to create a
 // DistSQLServer.
@@ -186,14 +196,19 @@ func NewServer(ctx context.Context, cfg ServerConfig) *ServerImpl {
 			errors.Wrap(err, "could not get temporary storage capacity"),
 		)
 	}
-	diskMonitorBudget := capacity.Capacity / diskBudgetTotalSizeDivisor
+	// We limit the disk usage to both a percentage of the total capacity and an
+	// absolute value (whichever is smaller).
+	diskMonitorBudget := capacity.Capacity * 100 / settingDiskBudgetPercent.Get(&ds.Settings.SV)
+	if maxBytes := settingDiskBudgetAbsolute.Get(&ds.Settings.SV); maxBytes < diskMonitorBudget {
+		diskMonitorBudget = maxBytes
+	}
 	ds.diskMonitor = mon.MakeMonitor(
 		"distsql-tempstorage",
 		mon.DiskResource,
-		nil,                 /* curCount */
-		nil,                 /* maxHist */
-		workMemBytes,        /* increment: same size as processor's memory budget */
-		diskMonitorBudget/2, /* noteworthy */
+		nil,                  /* curCount */
+		nil,                  /* maxHist */
+		64*1024*1024,         /* increment */
+		diskMonitorBudget/10, /* noteworthy */
 	)
 	ds.diskMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(diskMonitorBudget))
 	return ds

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -97,8 +97,7 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 	// Enable fall back to disk if the cluster setting is set or a memory limit
 	// has been set through testing.
 	st := s.flowCtx.Settings
-	useTempStorage := (distSQLUseTempStorage.Get(&st.SV) && distSQLUseTempStorageSorts.Get(&st.SV)) ||
-		s.testingKnobMemLimit > 0
+	useTempStorage := settingUseTempStorageSorts.Get(&st.SV) || s.testingKnobMemLimit > 0
 	rowContainerMon := s.flowCtx.EvalCtx.Mon
 	if s.matchLen == 0 && s.count == 0 && useTempStorage {
 		// We will use the sortAllStrategy in this case and potentially fall
@@ -107,7 +106,7 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 		// The strategy will overflow to disk if this limit is not enough.
 		limit := s.testingKnobMemLimit
 		if limit <= 0 {
-			limit = workMemBytes
+			limit = settingWorkMemBytes.Get(&st.SV)
 		}
 		limitedMon := mon.MakeMonitorInheritWithLimit(
 			"sortall-limited", limit, s.flowCtx.EvalCtx.Mon,

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -78,11 +78,13 @@ server.remote_debugging.mode                       local          s     set to e
 server.time_until_store_dead                       5m0s           d     the time after which if there is no new gossiped information about a store, it is considered dead
 server.web_session_timeout                         168h0m0s       d     the duration that a newly created web session will be valid
 sql.defaults.distsql                               0              e     Default distributed SQL execution mode [off = 0, auto = 1, on = 2]
-sql.defaults.distsql.tempstorage                   true           b     set to true to enable use of disk for larger distributed sql queries
-sql.defaults.distsql.tempstorage.joins             true           b     set to true to enable use of disk for distributed sql joins. sql.defaults.distsql.tempstorage must be true
-sql.defaults.distsql.tempstorage.sorts             true           b     set to true to enable use of disk for distributed sql sorts. sql.defaults.distsql.tempstorage must be true
 sql.distsql.distribute_index_joins                 true           b     if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader
 sql.distsql.merge_joins.enabled                    true           b     if set, we plan merge joins when possible
+sql.distsql.temp_storage.joins                     true           b     set to true to enable use of disk for distributed sql joins
+sql.distsql.temp_storage.max_bytes                 32 GiB         z     maximum amount of disk space used for queries (in bytes; requires restart); also see sql.distsql.temp_storage.max_percent
+sql.distsql.temp_storage.max_percent               10             i     maximum amount of disk space used for queries (as a percentage of the total capacity; requires restart); also see sql.distsql.temp_storage.max_bytes
+sql.distsql.temp_storage.sorts                     true           b     set to true to enable use of disk for distributed sql sorts
+sql.distsql.temp_storage.workmem                   64 MiB         z     maximum amount of memory in bytes a processor can use before falling back to temp storage (requires restart)
 sql.metrics.statement_details.dump_to_logs         false          b     dump collected statement statistics to node logs when periodically cleared
 sql.metrics.statement_details.enabled              true           b     collect per-statement query statistics
 sql.metrics.statement_details.threshold            0s             d     minimum execution time to cause statistics to be collected


### PR DESCRIPTION
Adding cluster settings for max temp disk space usage, both as a percentage of
total capacity and as an absolute number (whichever is smaller).

The default limit is MIN(10% of total disk capacity, 32GB).

Fixes #17663.
