### PR TITLE
server: allow eager idle replica campaigning on the bootstrapped node

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -380,6 +380,14 @@ func (n *Node) start(
 		return err
 	}
 
+	if n.initialBoot {
+		// The cluster was just bootstrapped by this node, explicitly notify the
+		// stores that they were bootstrapped.
+		for _, s := range stores {
+			s.NotifyBootstrapped()
+		}
+	}
+
 	if err := n.startStores(ctx, stores, n.stopper); err != nil {
 		return err
 	}

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -155,7 +155,8 @@ func createAndStartTestNode(
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := node.start(context.Background(), addr, bootstrappedEngines, newEngines, roachpb.Attributes{}, locality, cv); err != nil {
+	if err := node.start(context.Background(), addr, bootstrappedEngines, newEngines,
+		roachpb.Attributes{}, locality, cv); err != nil {
 		t.Fatal(err)
 	}
 	if err := WaitForInitialSplits(node.storeCfg.DB); err != nil {
@@ -393,7 +394,8 @@ func TestCorruptedClusterID(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := node.start(
-		context.Background(), serverAddr, bootstrappedEngines, newEngines, roachpb.Attributes{}, roachpb.Locality{}, cv,
+		context.Background(), serverAddr, bootstrappedEngines, newEngines,
+		roachpb.Attributes{}, roachpb.Locality{}, cv,
 	); !testutils.IsError(err, "unidentified store") {
 		t.Errorf("unexpected error %v", err)
 	}


### PR DESCRIPTION
Campaigning of idle replicas is allowed when sufficient time (a Raft
election cycle) has passed since the cluster has started. This
campaigning of an idle replica allows the replica to quickly be
rejuvenated when it is dormant. We also provide special handling for allowing
campaigning of idle replicas immediately if we just bootstrapped a
store. Unfortunately, this handling of bootstrapped stores had a hole:
when bootstrapping a cluster we first create a temporary store to
bootstrap on node 1 and then we create the real store and we were
failing to consider this real store bootstrapped. If we subsequently had
to campaign an idle replica we were forced to wait for the Raft election
timeout (3s) before campaigning. The hole is now plugged by explicitly
calling Store.NotifyBootstrapped() if the node has just performed
cluster bootstrapping.

Reduces the total running time for all tests by ~15% with the savings
coming from ccl/sqlccl (50s), sql (21s) and storage (7s).

Fixes #18246