### PR TITLE
cherrypick: storage: improve error log about passing no candidates to RemoveTarget

### DIFF
--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -344,6 +344,10 @@ func (rq *replicateQueue) processOneChange(
 		candidates := filterUnremovableReplicas(repl.RaftStatus(), desc.Replicas, lastReplAdded)
 		log.VEventf(ctx, 3, "filtered unremovable replicas from %v to get %v as candidates for removal",
 			desc.Replicas, candidates)
+		if len(candidates) == 0 {
+			return false, errors.Errorf("no removable replicas from range that needs a removal: %s",
+				rangeRaftProgress(repl.RaftStatus(), desc.Replicas))
+		}
 		removeReplica, details, err := rq.allocator.RemoveTarget(ctx, zone.Constraints, candidates, rangeInfo)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This wasn't actually causing problems because allocator.RemoveTarget
does a good job of verifying its inputs, but it's better form to handle
the error outside of RemoveTarget and to provide more information in the
error message than one RemoveTarget could -- its error message is
"must supply at least one candidate replica to allocator.RemoveTarget()"

This is low risk / low reward. I'm fine leaving it out, since the place I was seeing the annoying old message was just in a test, but sending out for a second opinion.