### PR TITLE
docs: Fix all broken links referring to RFCs

### DIFF
--- a/docs/RFCS/20151009_table_descriptor_lease.md
+++ b/docs/RFCS/20151009_table_descriptor_lease.md
@@ -19,7 +19,7 @@ latency.
 
 Table descriptors are currently distributed to every node in the
 cluster via gossipping of the system config (see
-[schema_gossip](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/schema_gossip.md)). Unfortunately,
+[schema_gossip](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20150720_schema_gossip.md)). Unfortunately,
 it is not safe to use these gossipped table descriptors in almost any
 circumstance. Consider the statements:
 

--- a/docs/RFCS/20151014_online_schema_change.md
+++ b/docs/RFCS/20151014_online_schema_change.md
@@ -25,7 +25,7 @@ from accessing the table and yet never leave table or index data in an
 invalid state.
 
 Online schema change will be built on top of [table descriptor
-leases](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/table_descriptor_lease.md)
+leases](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20151009_table_descriptor_lease.md)
 which describes the mechanism for asynchronously distributing
 modifications to table descriptors. This RFC is concerned with the
 actual steps of performing a schema change.

--- a/docs/RFCS/20160503_rebalancing_v2.md
+++ b/docs/RFCS/20160503_rebalancing_v2.md
@@ -61,7 +61,7 @@ offline. These are important problems that will be addressed in V3 or later.
 # Motivation
 
 To allocate replicas for ranges, we currently rely on distributed
-[stateless replica relocation](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/stateless_replica_relocation.md).
+[stateless replica relocation](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20150819_stateless_replica_relocation.md).
 
 Each range lease holder is responsible for replica allocation decisions (adding and removing replicas)
 for its respective range. This is a good, simple start. However, it is particularly susceptible to

--- a/docs/RFCS/20160624_sql_interleaved_tables.md
+++ b/docs/RFCS/20160624_sql_interleaved_tables.md
@@ -72,7 +72,7 @@ The keys for a sql table represented in the kv map are
     /<tableID>/1/<pkCol1>/<pkCol2>/<familyID>/<suffix>
 
 Where `pkColN` is the key encoding of the Nth primary index column, there is one
-row per [family of columns](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/sql_column_families.md),
+row per [family of columns](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20151214_sql_column_families.md),
 and `suffix` counts how many bytes are stripped off the end to determine where
 ranges can split. The 0 row is always present and acts as a sentinel for the
 existence of the row. The single `0` on the end is an optimization that reuses

--- a/docs/RFCS/20170117_enterprise.md
+++ b/docs/RFCS/20170117_enterprise.md
@@ -49,7 +49,7 @@ message License {
 ```
 
 The latest license will be stored as a gossiped [cluster
-setting](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/settings_table.md).
+setting](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20170317_settings_table.md).
 Once viewing historical settings is supported, it can be used to show historical
 licensing information. When nodes observe the setting change, the value is
 decoded to update an in-memory copy of the `License` struct.

--- a/docs/tech-notes/encoding.md
+++ b/docs/tech-notes/encoding.md
@@ -549,8 +549,8 @@ Example dump:
   [pkg/util/encoding/encoding.go]: https://github.com/cockroachdb/cockroach/blob/master/pkg/util/encoding/encoding.go
   [SQL in CockroachDB: Mapping Table Data to Key-Value Storage]: https://www.cockroachlabs.com/blog/sql-in-cockroachdb-mapping-table-data-to-key-value-storage/
   [Implementing Column Families in CockroachDB]: https://www.cockroachlabs.com/blog/sql-cockroachdb-column-families/
-  [column families RFC]: https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/sql_column_families.md
-  [interleaving RFC]: https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/sql_interleaved_tables.md
+  [column families RFC]: https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20151214_sql_column_families.md
+  [interleaving RFC]: https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20160624_sql_interleaved_tables.md
   [pkg/sql/sqlbase/structured.proto]: https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/sqlbase/structured.proto
   [pkg/sql/rowwriter.go]: https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/sqlbase/rowwriter.go
   [pkg/sql/sqlbase/rowfetcher.go]: https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/sqlbase/rowfetcher.go

--- a/docs/tech-notes/life_of_a_query.md
+++ b/docs/tech-notes/life_of_a_query.md
@@ -316,7 +316,7 @@ our execution planning more in the future).
    data source (usually a `scanNode`))
 2. normalization (e.g. `a = 1 + 1` -> `a = 2`, ` a not between b and c` -> `(a < b) or (a > c)`)
 3. type checking (see [the typing
-   RFC](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/typing.md)
+   RFC](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20160203_typing.md)
    for an in-depth discussion of Cockroach's typing system).
 
    1. constant folding (e.g. `1 + 2` becomes `3`): we perform exact


### PR DESCRIPTION
Unlike last time where I fixed some links I found, I was a bit more thorough this time. I did a regex search for `RFCS/[A-Za-z]` so hopefully these are the last of the broken links!