### PR TITLE
cherrypick-1.0: server: Close HTTP response body after reporting diagnostics

### DIFF
--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -310,6 +310,7 @@ func (s *Server) reportDiagnostics(runningTime time.Duration) {
 		}
 		return
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)


### PR DESCRIPTION
Most likely fixes #18126