### PR TITLE
cherrypick-1.1: distsql: fix serialization of negative ints

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_expr
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_expr
@@ -1,0 +1,14 @@
+# LogicTest: default distsql
+
+statement ok
+CREATE TABLE t (c int PRIMARY KEY);
+
+statement ok
+INSERT INTO t VALUES (1), (2), (3);
+
+# Verify we serialize the negative constant correctly (see #15617).
+query I rowsort
+SELECT c FROM t WHERE (c, c) > (2, -9223372036854775808);
+----
+2
+3

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -422,7 +422,16 @@ func (*DInt) AmbiguousFormat() bool { return true }
 
 // Format implements the NodeFormatter interface.
 func (d *DInt) Format(buf *bytes.Buffer, f FmtFlags) {
+	// If the number is negative, we need to use parens or the `:::INT` type hint
+	// will take precedence over the negation sign.
+	quote := f.disambiguateDatumTypes && *d < 0
+	if quote {
+		buf.WriteByte('(')
+	}
 	buf.WriteString(strconv.FormatInt(int64(*d), 10))
+	if quote {
+		buf.WriteByte(')')
+	}
 }
 
 // Size implements the Datum interface.

--- a/pkg/sql/parser/format_test.go
+++ b/pkg/sql/parser/format_test.go
@@ -148,6 +148,13 @@ func TestFormatExpr(t *testing.T) {
 		// {`ARRAY[e'j\x10k']`, FmtBareStrings,
 		//	 `ARRAY[j\x10k]`},
 
+		{`1`, FmtParsable, "1:::INT"},
+		{`9223372036854775807`, FmtParsable, "9223372036854775807:::INT"},
+		{`9223372036854775808`, FmtParsable, "9223372036854775808:::DECIMAL"},
+		{`-1`, FmtParsable, "(-1):::INT"},
+		{`-9223372036854775808`, FmtParsable, "(-9223372036854775808):::INT"},
+		{`-9223372036854775809`, FmtParsable, "-9223372036854775809:::DECIMAL"},
+
 		{`unique_rowid() + 123`, FmtParsable,
 			`unique_rowid() + 123:::INT`},
 		{`sqrt(123.0) + 456`, FmtParsable,


### PR DESCRIPTION
Cherry-pick of #18258.

Correcting the serialization of negative integers from `-5:::INT` to
`'-5':::INT`.

Fixes #15617.

CC @cockroachdb/release