### PR TITLE
cherrypick-1.1: server: de-flake TestDebugLogSpyBrokenConnection

### DIFF
--- a/pkg/server/debug_logspy_test.go
+++ b/pkg/server/debug_logspy_test.go
@@ -327,7 +327,7 @@ func TestDebugLogSpyBrokenConnection(t *testing.T) {
 		func() {
 			if err := spy.run(ctx, w, logSpyOptions{
 				Duration: durationAsString(time.Hour),
-				Count:    logSpyChanCap + 1,
+				Count:    logSpyChanCap - 1, // will definitely see that many entries
 			}); !testutils.IsError(err, test.failStr) {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
We were asking for cap+1 entries, but if all but the first `cap` were dropped,
spy.run() would end up waiting forever.

Fixes #18231.