### PR TITLE
cherrypick-1.0: server: Fix incorrect help text for server.remote_debugging.mode

### DIFF
--- a/pkg/server/debug.go
+++ b/pkg/server/debug.go
@@ -44,7 +44,7 @@ var debugServeMux = http.DefaultServeMux
 // TODO(arjun): use an Enum setting here.
 var debugRemote = settings.RegisterStringSetting(
 	"server.remote_debugging.mode",
-	"set to enable remote debugging, localhost-only or disable (all, local, false)",
+	"set to enable remote debugging, localhost-only or disable (any, local, off)",
 	"local")
 
 // handleDebug passes requests with the debugPathPrefix onto the default


### PR DESCRIPTION
Not a direct cherrypick, but this help message being incorrect is a pretty ugly wart for anyone who's trying to figure out how to debug their cluster. Including it in the next 1.0 branch release removes that wart at little-to-no cost.

@cockroachdb/release 