### PR TITLE
cherrypick-1.0: Redact hostnames in crash reports

### DIFF
--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -175,6 +175,10 @@ func sendCrashReport(ctx context.Context, r interface{}, depth int) {
 
 	ex := raven.NewException(err, raven.NewStacktrace(depth+1, contextLines, crdbPaths))
 	packet := raven.NewPacket(err.Error(), ex)
+	// Avoid leaking the machine's hostname by injecting the literal "<redacted>".
+	// Otherwise, raven.Client.Capture will see an empty ServerName field and
+	// automatically fill in the machine's hostname.
+	packet.ServerName = "<redacted>"
 	eventID, ch := raven.DefaultClient.Capture(packet, nil /* tags */)
 	select {
 	case <-ch:


### PR DESCRIPTION
For increased privacy, omit the hostnames that are by default included
in crash reports. Instead, construct a `server_id` tag that combines the
last eight characters of the cluster ID and the node ID.

See #16298 for details.