### PR TITLE
storage: Retry heartbeats in TestReplicaGCRace that can be dropped

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -2443,11 +2443,17 @@ func TestReplicaGCRace(t *testing.T) {
 	errChan := errorChannelTestHandler(make(chan *roachpb.Error, 1))
 	fromTransport.Listen(fromStore.StoreID(), errChan)
 
-	// Send the heartbeat. Boom. See
-	// https://github.com/cockroachdb/cockroach/issues/11591.
-	fromTransport.SendAsync(&hbReq)
+	// Send the heartbeat. Boom. See #11591.
+	// We have to send this multiple times to protect against
+	// dropped messages (see #18355).
+	if sent := fromTransport.SendAsync(&hbReq); !sent {
+		t.Fatal("failed to send heartbeat")
+	}
+	heartbeatsSent := 1
 
-	// The receiver of this message should return an error.
+	// The receiver of this message should return an error. If we don't get a
+	// quick response, assume that the message got dropped and try sending it
+	// again.
 	select {
 	case pErr := <-errChan:
 		switch pErr.GetDetail().(type) {
@@ -2456,7 +2462,13 @@ func TestReplicaGCRace(t *testing.T) {
 			t.Fatalf("unexpected error type %T: %s", pErr.GetDetail(), pErr)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("did not get expected error")
+		if heartbeatsSent >= 5 {
+			t.Fatal("did not get expected error")
+		}
+		heartbeatsSent++
+		if sent := fromTransport.SendAsync(&hbReq); !sent {
+			t.Fatal("failed to send heartbeat")
+		}
 	}
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3528,7 +3528,9 @@ func (s *Store) processRequestQueue(ctx context.Context, rangeID roachpb.RangeID
 		if pErr := s.processRaftRequest(info.respStream.Context(), info.req, IncomingSnapshot{}); pErr != nil {
 			// If we're unable to process the request, clear the request queue. This
 			// only happens if we couldn't create the replica because the request was
-			// targeted to a removed range.
+			// targeted to a removed range. This is also racy and could cause us to
+			// drop messages to the deleted range occasionally (#18355), but raft
+			// will just retry.
 			q.Lock()
 			if len(q.infos) == 0 {
 				s.replicaQueues.Delete(int64(rangeID))


### PR DESCRIPTION
This fixes TestReplicaGCRace, which was breaking because it relied on
getting a response to its request to a recently removed range. In
certain execution interleavings, that request could get dropped due to
this deletion of the request queue.

Not deleting the queue here means that a request to a GC'ed replica
will cause some memory to be allocated that may never be freed. I'm not
sure of a safe way to delete these while ensuring that all requests get
serviced due to the inherent races enabled by using separate
synchronization for the replicaQueues map itself and for queues stored
in said map.

The test could alternatively be made less flaky by resending the
request multiple times if we're really confident that no harm will come
from us occasionally silently dropping requests on the floor.

Fixes #17598 

I'm not a big fan of this fix given the potential for leaking memory over time, no matter how small that memory may be. If we are quite confident that dropping requests to a GC'ed replica is always ok, then modifying the test to send multiple heartbeats would be better. I'm just wary of leaving code in here that does allow for dropping requests given that the previous code (before #16896) doesn't look like it opened up such possibilities.