### PR TITLE
server: Fix DistSQL query plan debug API

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1101,7 +1101,7 @@ func (s *adminServer) QueryPlan(
 	}
 
 	explain := fmt.Sprintf(
-		"SELECT JSON FROM [EXPLAIN (distsql) %s]",
+		"SELECT \"JSON\" FROM [EXPLAIN (distsql) %s]",
 		strings.Trim(req.Query, ";"))
 	r, err := s.server.sqlExecutor.ExecuteStatementsBuffered(session, explain, nil, 1)
 	if err != nil {


### PR DESCRIPTION
The keyword JSON is not valid as a column, likely because of a change to
the YACC grammar, causing this query to error. This fixes that and adds
a smoke test to ensure the endpoint doesn't fail.