### PR TITLE
cherrypick-1.1: sql: don't rollback txn on missing table name; improve pg_table_is_visible

### DIFF
--- a/pkg/sql/parser/pg_builtins.go
+++ b/pkg/sql/parser/pg_builtins.go
@@ -316,7 +316,7 @@ var pgBuiltins = map[string][]Builtin{
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
 				oid := args[0]
 				t, err := ctx.Planner.QueryRow(ctx.Ctx(),
-					"SELECT nspname FROM pg_class c JOIN pg_namespace n ON c.relnamespace=n.oid "+
+					"SELECT nspname FROM pg_catalog.pg_class c JOIN pg_catalog.pg_namespace n ON c.relnamespace=n.oid "+
 						"WHERE c.oid=$1 AND nspname=ANY(current_schemas(true));", oid)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -38,6 +38,9 @@ import (
 // ID is a custom type for {Database,Table}Descriptor IDs.
 type ID parser.ID
 
+// InvalidID is the uninitialised descriptor id.
+const InvalidID ID = 0
+
 // IDs is a sortable list of IDs.
 type IDs []ID
 
@@ -82,7 +85,7 @@ const (
 	InterleavedFormatVersion
 )
 
-// MutationID is custom type for TableDescriptor mutations.
+// MutationID is a custom type for TableDescriptor mutations.
 type MutationID uint32
 
 // InvalidMutationID is the uninitialised mutation id.


### PR DESCRIPTION
Previously, a failure to find a table name in a database would cause an
internal rolled back transaction. This was unnecessary and was
misleading in traces. Now, the failure propagates without failing the
transaction.

Previously, `pg_table_is_visible` didn't qualify the database of the
tables `pg_namespace` and `pg_class` in an internal query, leading to
many pointless failed table lookups and potential bad behavior.