### PR TITLE
sqlccl: benchmark convertRecord on TPCH lineitem data

### DIFF
--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -1,0 +1,69 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package jobutils
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/kr/pretty"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+// VerifySystemJob checks that that job records are created as expected.
+func VerifySystemJob(
+	db *sqlutils.SQLRunner, offset int, expectedType jobs.Type, expected jobs.Record,
+) error {
+	var actual jobs.Record
+	var rawDescriptorIDs pq.Int64Array
+	var actualType string
+	var statusString string
+	// We have to query for the nth job created rather than filtering by ID,
+	// because job-generating SQL queries (e.g. BACKUP) do not currently return
+	// the job ID.
+	db.QueryRow(`
+		SELECT type, description, username, descriptor_ids, status
+		FROM crdb_internal.jobs ORDER BY created LIMIT 1 OFFSET $1`,
+		offset,
+	).Scan(
+		&actualType, &actual.Description, &actual.Username, &rawDescriptorIDs,
+		&statusString,
+	)
+
+	for _, id := range rawDescriptorIDs {
+		actual.DescriptorIDs = append(actual.DescriptorIDs, sqlbase.ID(id))
+	}
+	sort.Sort(actual.DescriptorIDs)
+	sort.Sort(expected.DescriptorIDs)
+	expected.Details = nil
+	if e, a := expected, actual; !reflect.DeepEqual(e, a) {
+		return errors.Errorf("job %d did not match:\n%s",
+			offset, strings.Join(pretty.Diff(e, a), "\n"))
+	}
+
+	if e, a := jobs.StatusSucceeded, jobs.Status(statusString); e != a {
+		return errors.Errorf("job %d: expected status %v, got %v", offset, e, a)
+	}
+	if e, a := expectedType.String(), actualType; e != a {
+		return errors.Errorf("job %d: expected type %v, got type %v", offset, e, a)
+	}
+
+	return nil
+}


### PR DESCRIPTION
```
name             time/op
ConvertRecord-8    10.7µs ± 7%

name             speed
ConvertRecord-8  11.2MB/s ± 7%

name             alloc/op
ConvertRecord-8    1.83kB ± 0%

name             allocs/op
ConvertRecord-8      93.0 ± 0%
```