### PR TITLE
distsql: refactor distributed aggregation to support arbitrary local aggregate inputs in final stage

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1372,39 +1372,51 @@ func (dsp *distSQLPlanner) addAggregators(
 		//
 		// Count the total number of aggregation in the local/final stages and keep
 		// track of whether any of them needs a final rendering.
-		numAgg := 0
+		nLocalAgg := 0
+		nFinalAgg := 0
 		needRender := false
 		for _, e := range aggregations {
 			info := distsqlplan.DistAggregationTable[e.Func]
-			numAgg += len(info.LocalStage)
+			nLocalAgg += len(info.LocalStage)
+			nFinalAgg += len(info.FinalStage)
 			if info.FinalRendering != nil {
 				needRender = true
 			}
 		}
 
-		localAgg := make([]distsqlrun.AggregatorSpec_Aggregation, numAgg, numAgg+len(groupCols))
-		intermediateTypes := make([]sqlbase.ColumnType, numAgg, numAgg+len(groupCols))
-		finalAgg := make([]distsqlrun.AggregatorSpec_Aggregation, numAgg)
+		localAgg := make([]distsqlrun.AggregatorSpec_Aggregation, nLocalAgg, nLocalAgg+len(groupCols))
+		intermediateTypes := make([]sqlbase.ColumnType, nLocalAgg, nLocalAgg+len(groupCols))
+		finalAgg := make([]distsqlrun.AggregatorSpec_Aggregation, nFinalAgg)
 		finalGroupCols := make([]uint32, len(groupCols))
 		var finalPreRenderTypes []sqlbase.ColumnType
 		if needRender {
-			finalPreRenderTypes = make([]sqlbase.ColumnType, numAgg)
+			finalPreRenderTypes = make([]sqlbase.ColumnType, nFinalAgg)
 		}
 
 		// Each aggregation can have multiple aggregations in the local/final
-		// stages. We concatenate all these into localAgg/finalAgg; aIdx is an index
-		// inside localAgg/finalAgg.
-		aIdx := 0
+		// stages. We concatenate all these into localAgg/finalAgg; localIdx is an index
+		// inside localAgg and finalIdx is an index inside finalAgg.
+		localIdx := 0
+		finalIdx := 0
 		for _, e := range aggregations {
 			info := distsqlplan.DistAggregationTable[e.Func]
-			for i, localFunc := range info.LocalStage {
-				localAgg[aIdx] = distsqlrun.AggregatorSpec_Aggregation{
+			// firstLocalIdxCurAgg points to the first local index in the current
+			// aggregation e.
+			// This is used when computing AggregatorSpec_Aggregation.ColIdx
+			// for FinalStage aggregators since their input column indices
+			// are specified as a relative offset to the first local aggregator's
+			// index.
+			// This is required since we append all localAggs and finalAggs across
+			// all aggregations for the given plan together.
+			firstLocalIdxCurAgg := uint32(localIdx)
+			// First prepare and spec local aggregations.
+			// Note the planNode first feeds the input (inputTypes) into the local aggregators.
+			for _, localFunc := range info.LocalStage {
+				localAgg[localIdx] = distsqlrun.AggregatorSpec_Aggregation{
 					Func:         localFunc,
 					ColIdx:       e.ColIdx,
 					FilterColIdx: e.FilterColIdx,
 				}
-
-				var localResultType sqlbase.ColumnType
 
 				argTypes := make([]sqlbase.ColumnType, len(e.ColIdx))
 				for i, c := range e.ColIdx {
@@ -1412,27 +1424,42 @@ func (dsp *distSQLPlanner) addAggregators(
 				}
 
 				var err error
-				_, localResultType, err = distsqlrun.GetAggregateInfo(localFunc, argTypes...)
+				_, intermediateTypes[localIdx], err = distsqlrun.GetAggregateInfo(localFunc, argTypes...)
 				if err != nil {
 					return err
 				}
-				intermediateTypes[aIdx] = localResultType
+				localIdx++
+			}
 
-				finalAgg[aIdx] = distsqlrun.AggregatorSpec_Aggregation{
-					Func: info.FinalStage[i],
-					// The input of final expression aIdx is the output of the
-					// local expression aIdx.
-					ColIdx: []uint32{uint32(aIdx)},
+			for _, finalInfo := range info.FinalStage {
+				// The input of the final aggregators are specified as the indices of the local aggregation
+				// values. We need to offset firstLocalIdxCurAgg by the relative indices specified in finalInfo.LocalIdxs.
+				argIdxs := make([]uint32, len(finalInfo.LocalIdxs))
+				for i, c := range finalInfo.LocalIdxs {
+					argIdxs[i] = c + firstLocalIdxCurAgg
 				}
+				finalAgg[finalIdx] = distsqlrun.AggregatorSpec_Aggregation{
+					Func:   finalInfo.Fn,
+					ColIdx: argIdxs,
+				}
+
 				if needRender {
-					_, finalPreRenderTypes[aIdx], err = distsqlrun.GetAggregateInfo(
-						info.FinalStage[i], localResultType,
+					argTypes := make([]sqlbase.ColumnType, len(finalInfo.LocalIdxs))
+					for i, c := range finalInfo.LocalIdxs {
+						// We want to access the corresponding local output type
+						// for the current aggregation e. c is the offset from
+						// the first local aggregator for the current aggregation e.
+						argTypes[i] = intermediateTypes[firstLocalIdxCurAgg+c]
+					}
+					var err error
+					_, finalPreRenderTypes[finalIdx], err = distsqlrun.GetAggregateInfo(
+						finalInfo.Fn, argTypes...,
 					)
 					if err != nil {
 						return err
 					}
 				}
-				aIdx++
+				finalIdx++
 			}
 		}
 
@@ -1481,21 +1508,21 @@ func (dsp *distSQLPlanner) addAggregators(
 			// Build rendering expressions.
 			renderExprs := make([]distsqlrun.Expression, len(aggregations))
 			h := distsqlplan.MakeTypeIndexedVarHelper(finalPreRenderTypes)
-			// aIdx is an index inside finalAgg. It is used to keep track of the
+			// finalIdx is an index inside finalAgg. It is used to keep track of the
 			// finalAgg results that correspond to each aggregation.
-			aIdx := 0
+			finalIdx := 0
 			for i, e := range aggregations {
 				info := distsqlplan.DistAggregationTable[e.Func]
 				if info.FinalRendering == nil {
-					renderExprs[i] = distsqlplan.MakeExpression(h.IndexedVar(aIdx), nil)
+					renderExprs[i] = distsqlplan.MakeExpression(h.IndexedVar(finalIdx), nil)
 				} else {
-					expr, err := info.FinalRendering(&h, aIdx)
+					expr, err := info.FinalRendering(&h, finalIdx)
 					if err != nil {
 						return err
 					}
 					renderExprs[i] = distsqlplan.MakeExpression(expr, nil)
 				}
-				aIdx += len(info.LocalStage)
+				finalIdx += len(info.FinalStage)
 			}
 			finalAggPost.RenderExprs = renderExprs
 		}

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -185,11 +185,11 @@ func checkDistAggregationInfo(
 		localAggregations[i] = distsqlrun.AggregatorSpec_Aggregation{Func: fn, ColIdx: []uint32{0}}
 	}
 	finalAggregations := make([]distsqlrun.AggregatorSpec_Aggregation, numIntermediary)
-	for i, fn := range info.FinalStage {
+	for i, finalInfo := range info.FinalStage {
 		// Each local aggregation feeds into a final aggregation.
 		finalAggregations[i] = distsqlrun.AggregatorSpec_Aggregation{
-			Func:   fn,
-			ColIdx: []uint32{uint32(i)},
+			Func:   finalInfo.Fn,
+			ColIdx: finalInfo.LocalIdxs,
 		}
 	}
 

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -298,15 +298,30 @@ func (ag *aggregator) accumulateRows(ctx context.Context) (err error) {
 					continue
 				}
 			}
-			var value parser.Datum
-			if len(a.ColIdx) != 0 {
-				c := a.ColIdx[0]
+			// Extract the corresponding arguments from the row to feed into the
+			// aggregate function.
+			// Most functions require at most one argument thus we separate
+			// the first argument and allocation of (if applicable) a variadic
+			// collection of arguments thereafter.
+			var firstArg parser.Datum
+			var otherArgs parser.Datums
+			if len(a.ColIdx) > 1 {
+				otherArgs = make(parser.Datums, len(a.ColIdx)-1)
+			}
+			isFirstArg := true
+			for j, c := range a.ColIdx {
 				if err := row[c].EnsureDecoded(&ag.datumAlloc); err != nil {
 					return err
 				}
-				value = row[c].Datum
+				if isFirstArg {
+					firstArg = row[c].Datum
+					isFirstArg = false
+					continue
+				}
+				otherArgs[j-1] = row[c].Datum
 			}
-			if err := ag.funcs[i].add(ctx, encoded, value); err != nil {
+
+			if err := ag.funcs[i].add(ctx, encoded, firstArg, otherArgs); err != nil {
 				return err
 			}
 		}
@@ -335,11 +350,20 @@ func (ag *aggregator) newAggregateFuncHolder(
 	}
 }
 
-func (a *aggregateFuncHolder) add(ctx context.Context, bucket []byte, d parser.Datum) error {
+func (a *aggregateFuncHolder) add(
+	ctx context.Context, bucket []byte, firstArg parser.Datum, otherArgs parser.Datums,
+) error {
 	if a.seen != nil {
-		encoded, err := sqlbase.EncodeDatum(bucket, d)
+		encoded, err := sqlbase.EncodeDatum(bucket, firstArg)
 		if err != nil {
 			return err
+		}
+		// Encode additional arguments if necessary.
+		if otherArgs != nil {
+			encoded, err = sqlbase.EncodeDatums(bucket, otherArgs)
+			if err != nil {
+				return err
+			}
 		}
 		if _, ok := a.seen[string(encoded)]; ok {
 			// skip
@@ -367,7 +391,7 @@ func (a *aggregateFuncHolder) add(ctx context.Context, bucket []byte, d parser.D
 		a.buckets[string(bucket)] = impl
 	}
 
-	return impl.Add(ctx, d)
+	return impl.Add(ctx, firstArg, otherArgs...)
 }
 
 func (a *aggregateFuncHolder) get(bucket string) (parser.Datum, error) {


### PR DESCRIPTION
In order to implement a distributed version of STDDEV and VARIANCE that is **numerically stable** (see #14351), we require the final stage aggregators to have access to multiple local (or intermediary) aggregate values (in the case of VARIANCE, we require the intermediary aggregate values "SQDIFF", "SUM", and "COUNT"; FYI see https://www.johndcook.com/blog/skewness_kurtosis/ and https://github.com/cockroachdb/cockroach/pull/17728/files).

This PR allows specifying the corresponding local indices in `LocalStage` that the `FinalStage` aggregator functions may use as inputs in [`DistAggregationTable`](https://github.com/cockroachdb/cockroach/compare/master...richardwu:stddev-var-local-final?expand=1#diff-ba0c6b6ad9127b4b373facbcc9ff48a0L75). 

There is no logical change to current aggregate functions.
- [x] I plan to verify (in a separate branch) that multiple intermediary values can indeed propagate e.g. in the case of distributed `VARIANCE` before merging this refactor.

cc: @vivekmenezes 