### PR TITLE
[DNM] sql: allow configuring rounding mode for decimals

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -778,6 +778,35 @@ SELECT round('inf'::decimal)
 query error invalid operation
 SELECT round(1::decimal, 3000)
 
+# Test rounding modes.
+
+statement error unknown rounding: blah
+SET decimal_round = 'blah'
+
+statement ok
+SET decimal_round = 'DOWN'
+
+query RRRR
+SELECT round(-2.5::decimal), round(-1.5::decimal), round(1.5::decimal), round(2.5::decimal)
+----
+-2  -1  1  2
+
+statement ok
+SET decimal_round = 'HALF_EVEN'
+
+query RRRR
+SELECT round(-2.5::decimal), round(-1.5::decimal), round(1.5::decimal), round(2.5::decimal)
+----
+-2  -2  2  2
+
+statement ok
+RESET decimal_round
+
+query RRRR
+SELECT round(-2.5::decimal), round(-1.5::decimal), round(1.5::decimal), round(2.5::decimal)
+----
+-3  -2  2  3
+
 query III
 SELECT sign(-2), sign(0), sign(2)
 ----

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1857,6 +1857,8 @@ type EvalContext struct {
 	// unqualified table name. Names in the search path are normalized already.
 	// This must not be modified (this is shared from the session).
 	SearchPath SearchPath
+	// RoundCtx is the decimal context used in round().
+	RoundCtx *apd.Context
 	// Ctx represents the context in which the expression is evaluated. This will
 	// point to the Session's context container.
 	// NOTE: seems a bit lazy to hold a pointer to the session's context here,

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -27,6 +27,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 
+	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -201,6 +202,8 @@ type Session struct {
 	DistSQLMode DistSQLExecMode
 	// Location indicates the current time zone.
 	Location *time.Location
+	// RoundCtx is the decimal context used in round().
+	RoundCtx *apd.Context
 	// SearchPath is a list of databases that will be searched for a table name
 	// before the database. Currently, this is used only for SELECTs.
 	// Names in the search path must have been normalized already.
@@ -681,6 +684,7 @@ func (s *Session) evalCtx() parser.EvalContext {
 		SearchPath: s.SearchPath,
 		Ctx:        s.Ctx,
 		Mon:        &s.TxnState.mon,
+		RoundCtx:   s.RoundCtx,
 	}
 }
 


### PR DESCRIPTION
This is a proof-of-concept to see if we think this is a good idea. It allows for users to configure how decimals work, since that's a feature we can provide. The unfortunate part about this is there's a really high amount of plumbing for a tiny benefit and pretty niche feature, so it barely seems worth it. We do the same thing for time zones and some other stuff, including copying all this stuff around into distsql (which this PR doesn't support yet).

Do we think these kinds of features are worth it?