### PR TITLE
cherrypick-1.1: clear Entry before reuse; improve snapshot sideloading error

### DIFF
--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -792,7 +792,7 @@ func TestRaftSSTableSideloadingSnapshot(t *testing.T) {
 		tc.store.raftEntryCache.clearTo(tc.repl.RangeID, sideloadedIndex+1)
 
 		mockSender := &mockSender{}
-		if err := sendSnapshot(
+		err = sendSnapshot(
 			ctx,
 			tc.store.cfg.Settings,
 			mockSender,
@@ -801,7 +801,8 @@ func TestRaftSSTableSideloadingSnapshot(t *testing.T) {
 			failingOS,
 			tc.repl.store.Engine().NewBatch,
 			func() {},
-		); errors.Cause(err) != errMustRetrySnapshotDueToTruncation {
+		)
+		if _, ok := errors.Cause(err).(*errMustRetrySnapshotDueToTruncation); !ok {
 			t.Fatal(err)
 		}
 	}()

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3411,6 +3411,7 @@ func sendSnapshot(
 	{
 		var ent raftpb.Entry
 		for i := range logEntries {
+			ent.Reset()
 			if err := ent.Unmarshal(logEntries[i]); err != nil {
 				return err
 			}


### PR DESCRIPTION
cc @cockroachdb/release 