### PR TITLE
cherrypick-1.1: storage: Retry heartbeats in TestReplicaGCRace that can be dropped

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3519,7 +3519,9 @@ func (s *Store) processRequestQueue(ctx context.Context, rangeID roachpb.RangeID
 		if pErr := s.processRaftRequest(info.respStream.Context(), info.req, IncomingSnapshot{}); pErr != nil {
 			// If we're unable to process the request, clear the request queue. This
 			// only happens if we couldn't create the replica because the request was
-			// targeted to a removed range.
+			// targeted to a removed range. This is also racy and could cause us to
+			// drop messages to the deleted range occasionally (#18355), but raft
+			// will just retry.
 			q.Lock()
 			if len(q.infos) == 0 {
 				s.replicaQueues.Delete(int64(rangeID))


### PR DESCRIPTION
This fixes TestReplicaGCRace, which was breaking because it relied on
getting a response to its request to a recently removed range. In
certain execution interleavings, that request could get dropped due to
the deletion of the request queue in store.processRaftRequest.

The race was introduced by 014148191297fdf828bfbdbab9c709b05761aa76, but
is benign as long as the raft client resends the dropped message.

Fixes #17598

cc @cockroachdb/release 