### PR TITLE
storage: immediately update target store write stats after rebalance

### DIFF
--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -572,7 +572,11 @@ func (rq *replicateQueue) addReplica(
 	if dryRun {
 		return nil
 	}
-	return repl.changeReplicas(ctx, roachpb.ADD_REPLICA, target, desc, priority, reason, details)
+	if err := repl.changeReplicas(ctx, roachpb.ADD_REPLICA, target, desc, priority, reason, details); err != nil {
+		return err
+	}
+	rq.allocator.storePool.updateLocalStoreAfterRebalance(target.StoreID, repl, roachpb.ADD_REPLICA)
+	return nil
 }
 
 func (rq *replicateQueue) removeReplica(
@@ -587,7 +591,11 @@ func (rq *replicateQueue) removeReplica(
 	if dryRun {
 		return nil
 	}
-	return repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, target, desc, reason, details)
+	if err := repl.ChangeReplicas(ctx, roachpb.REMOVE_REPLICA, target, desc, reason, details); err != nil {
+		return err
+	}
+	rq.allocator.storePool.updateLocalStoreAfterRebalance(target.StoreID, repl, roachpb.REMOVE_REPLICA)
+	return nil
 }
 
 func (rq *replicateQueue) canTransferLease() bool {

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -327,6 +327,38 @@ func (sp *StorePool) deadReplicasGossipUpdate(_ string, content roachpb.Value) {
 	detail.deadReplicas = deadReplicas
 }
 
+// updateLocalStoreAfterRebalance is used to update local copy of target store
+// after we make an rebalance immediately.
+func (sp *StorePool) updateLocalStoreAfterRebalance(
+	storeID roachpb.StoreID, repl *Replica, changeType roachpb.ReplicaChangeType,
+) {
+	sp.detailsMu.Lock()
+	defer sp.detailsMu.Unlock()
+	detail := *sp.getStoreDetailLocked(storeID)
+	switch changeType {
+	case roachpb.ADD_REPLICA:
+		detail.desc.Capacity.LogicalBytes += repl.GetMVCCStats().Total()
+		if qps, dur := repl.writeStats.avgQPS(); dur >= MinStatsDuration {
+			detail.desc.Capacity.WritesPerSecond += qps
+		}
+	case roachpb.REMOVE_REPLICA:
+		total := repl.GetMVCCStats().Total()
+		if detail.desc.Capacity.LogicalBytes <= total {
+			detail.desc.Capacity.LogicalBytes = 0
+		} else {
+			detail.desc.Capacity.LogicalBytes -= total
+		}
+		if qps, dur := repl.writeStats.avgQPS(); dur >= MinStatsDuration {
+			if detail.desc.Capacity.WritesPerSecond <= qps {
+				detail.desc.Capacity.WritesPerSecond = 0
+			} else {
+				detail.desc.Capacity.WritesPerSecond -= qps
+			}
+		}
+	}
+	sp.detailsMu.storeDetails[storeID] = &detail
+}
+
 // newStoreDetail makes a new storeDetail struct. It sets index to be -1 to
 // ensure that it will be processed by a queue immediately.
 func newStoreDetail() *storeDetail {


### PR DESCRIPTION
@a-robinson, Fixes #17970.

I just update the local copy for target store after the rebalance immediately.

still don't know how to add a test for it.

Please help me review it. Thank you very much.