### PR TITLE
storage : disable stats-based rebalancing when we use SCATTER

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -133,7 +133,6 @@ func makeInternalPlanner(
 		context:  ctx,
 		tables:   TableCollection{databaseCache: newDatabaseCache(config.SystemConfig{})},
 	}
-
 	s.mon = mon.MakeUnlimitedMonitor(ctx,
 		"internal-root",
 		mon.MemoryResource,

--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -226,7 +226,7 @@ func MakeAllocator(
 // supplied range, as governed by the supplied zone configuration. It
 // returns the required action that should be taken and a priority.
 func (a *Allocator) ComputeAction(
-	ctx context.Context, zone config.ZoneConfig, rangeInfo RangeInfo,
+	ctx context.Context, zone config.ZoneConfig, rangeInfo RangeInfo, disableStatsBasedRebalance bool,
 ) (AllocatorAction, float64) {
 	if a.storePool == nil {
 		// Do nothing if storePool is nil for some unittests.
@@ -284,6 +284,7 @@ func (a *Allocator) ComputeAction(
 				liveReplicas,
 				rangeInfo,
 				true, /* relaxConstraints */
+				disableStatsBasedRebalance,
 			); err == nil {
 				removeDead = true
 			}
@@ -340,6 +341,7 @@ func (a *Allocator) AllocateTarget(
 	existing []roachpb.ReplicaDescriptor,
 	rangeInfo RangeInfo,
 	relaxConstraints bool,
+	disableStatsBasedRebalance bool,
 ) (*roachpb.StoreDescriptor, string, error) {
 	sl, _, throttledStoreCount := a.storePool.getStoreList(rangeInfo.Desc.RangeID, storeFilterThrottled)
 
@@ -351,6 +353,7 @@ func (a *Allocator) AllocateTarget(
 		rangeInfo,
 		a.storePool.getLocalities(existing),
 		a.storePool.deterministic,
+		disableStatsBasedRebalance,
 	)
 	log.VEventf(ctx, 3, "allocate candidates: %s", candidates)
 	if target := candidates.selectGood(a.randGen); target != nil {
@@ -382,6 +385,7 @@ func (a Allocator) simulateRemoveTarget(
 	constraints config.Constraints,
 	candidates []roachpb.ReplicaDescriptor,
 	rangeInfo RangeInfo,
+	disableStatsBasedRebalance bool,
 ) (roachpb.ReplicaDescriptor, string, error) {
 	// Update statistics first
 	// TODO(a-robinson): This could theoretically interfere with decisions made by other goroutines,
@@ -392,7 +396,7 @@ func (a Allocator) simulateRemoveTarget(
 	defer func() {
 		a.storePool.updateLocalStoreAfterRebalance(targetStore, rangeInfo, roachpb.REMOVE_REPLICA)
 	}()
-	return a.RemoveTarget(ctx, constraints, candidates, rangeInfo)
+	return a.RemoveTarget(ctx, constraints, candidates, rangeInfo, disableStatsBasedRebalance)
 }
 
 // RemoveTarget returns a suitable replica to remove from the provided replica
@@ -405,6 +409,7 @@ func (a Allocator) RemoveTarget(
 	constraints config.Constraints,
 	candidates []roachpb.ReplicaDescriptor,
 	rangeInfo RangeInfo,
+	disableStatsBasedRebalance bool,
 ) (roachpb.ReplicaDescriptor, string, error) {
 	if len(candidates) == 0 {
 		return roachpb.ReplicaDescriptor{}, "", errors.Errorf("must supply at least one candidate replica to allocator.RemoveTarget()")
@@ -424,6 +429,7 @@ func (a Allocator) RemoveTarget(
 		rangeInfo,
 		a.storePool.getLocalities(rangeInfo.Desc.Replicas),
 		a.storePool.deterministic,
+		disableStatsBasedRebalance,
 	)
 	log.VEventf(ctx, 3, "remove candidates: %s", rankedCandidates)
 	if bad := rankedCandidates.selectBad(a.randGen); bad != nil {
@@ -470,6 +476,7 @@ func (a Allocator) RebalanceTarget(
 	raftStatus *raft.Status,
 	rangeInfo RangeInfo,
 	filter storeFilter,
+	disableStatsBasedRebalance bool,
 ) (*roachpb.StoreDescriptor, string) {
 	sl, _, _ := a.storePool.getStoreList(rangeInfo.Desc.RangeID, filter)
 
@@ -482,6 +489,7 @@ func (a Allocator) RebalanceTarget(
 		rangeInfo,
 		a.storePool.getLocalities(rangeInfo.Desc.Replicas),
 		a.storePool.deterministic,
+		disableStatsBasedRebalance,
 	)
 
 	// We're going to add another replica to the range which will change the
@@ -536,7 +544,7 @@ func (a Allocator) RebalanceTarget(
 
 		replicaCandidates := simulateFilterUnremovableReplicas(raftStatus, desc.Replicas, newReplica.ReplicaID)
 
-		removeReplica, _, err := a.simulateRemoveTarget(ctx, target.store.StoreID, constraints, replicaCandidates, rangeInfo)
+		removeReplica, _, err := a.simulateRemoveTarget(ctx, target.store.StoreID, constraints, replicaCandidates, rangeInfo, disableStatsBasedRebalance)
 		if err != nil {
 			log.Warningf(ctx, "simulating RemoveTarget failed: %s", err)
 			return nil, ""

--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -77,8 +77,8 @@ var statRebalanceThreshold = settings.RegisterNonNegativeFloatSetting(
 	0.20,
 )
 
-func statsBasedRebalancingEnabled(st *cluster.Settings) bool {
-	return EnableStatsBasedRebalancing.Get(&st.SV) && st.Version.IsActive(cluster.VersionStatsBasedRebalancing)
+func statsBasedRebalancingEnabled(st *cluster.Settings, disableStatsBasedRebalance bool) bool {
+	return EnableStatsBasedRebalancing.Get(&st.SV) && st.Version.IsActive(cluster.VersionStatsBasedRebalancing) && !disableStatsBasedRebalance
 }
 
 type balanceDimensions struct {
@@ -307,6 +307,7 @@ func allocateCandidates(
 	rangeInfo RangeInfo,
 	existingNodeLocalities map[roachpb.NodeID]roachpb.Locality,
 	deterministic bool,
+	disableStatsBasedRebalance bool,
 ) candidateList {
 	var candidates candidateList
 	for _, s := range sl.stores {
@@ -321,7 +322,7 @@ func allocateCandidates(
 			continue
 		}
 		diversityScore := diversityScore(s, existingNodeLocalities)
-		balanceScore := balanceScore(st, sl, s.Capacity, rangeInfo)
+		balanceScore := balanceScore(st, sl, s.Capacity, rangeInfo, disableStatsBasedRebalance)
 		candidates = append(candidates, candidate{
 			store:           s,
 			valid:           true,
@@ -349,6 +350,7 @@ func removeCandidates(
 	rangeInfo RangeInfo,
 	existingNodeLocalities map[roachpb.NodeID]roachpb.Locality,
 	deterministic bool,
+	disableStatsBasedRebalance bool,
 ) candidateList {
 	var candidates candidateList
 	for _, s := range sl.stores {
@@ -370,9 +372,9 @@ func removeCandidates(
 			continue
 		}
 		diversityScore := diversityRemovalScore(s.Node.NodeID, existingNodeLocalities)
-		balanceScore := balanceScore(st, sl, s.Capacity, rangeInfo)
+		balanceScore := balanceScore(st, sl, s.Capacity, rangeInfo, disableStatsBasedRebalance)
 		var convergesScore int
-		if !rebalanceFromConvergesOnMean(st, sl, s.Capacity, rangeInfo) {
+		if !rebalanceFromConvergesOnMean(st, sl, s.Capacity, rangeInfo, disableStatsBasedRebalance) {
 			// If removing this candidate replica does not converge the store
 			// stats to their means, we make it less attractive for removal by
 			// adding 1 to the constraint score. Note that when selecting a
@@ -411,6 +413,7 @@ func rebalanceCandidates(
 	rangeInfo RangeInfo,
 	existingNodeLocalities map[roachpb.NodeID]roachpb.Locality,
 	deterministic bool,
+	disableStatsBasedRebalance bool,
 ) (candidateList, candidateList) {
 	// Load the exiting storesIDs into a map to eliminate having to loop
 	// through the existing descriptors more than once.
@@ -446,7 +449,7 @@ func rebalanceCandidates(
 	if !rebalanceConstraintsCheck {
 		for _, store := range sl.stores {
 			if _, ok := existingStoreIDs[store.StoreID]; ok {
-				if shouldRebalance(ctx, st, store, constraintsOkStoreList, rangeInfo) {
+				if shouldRebalance(ctx, st, store, constraintsOkStoreList, rangeInfo, disableStatsBasedRebalance) {
 					shouldRebalanceCheck = true
 					break
 				}
@@ -484,9 +487,9 @@ func rebalanceCandidates(
 				continue
 			}
 			diversityScore := diversityRemovalScore(s.Node.NodeID, existingNodeLocalities)
-			balanceScore := balanceScore(st, sl, s.Capacity, rangeInfo)
+			balanceScore := balanceScore(st, sl, s.Capacity, rangeInfo, disableStatsBasedRebalance)
 			var convergesScore int
-			if !rebalanceFromConvergesOnMean(st, sl, s.Capacity, rangeInfo) {
+			if !rebalanceFromConvergesOnMean(st, sl, s.Capacity, rangeInfo, disableStatsBasedRebalance) {
 				// Similarly to in removeCandidates, any replica whose removal
 				// would not converge the range stats to their means is given a
 				// constraint score boost of 1 to make it less attractive for
@@ -506,9 +509,9 @@ func rebalanceCandidates(
 			if !storeInfo.ok || !maxCapacityOK {
 				continue
 			}
-			balanceScore := balanceScore(st, sl, s.Capacity, rangeInfo)
+			balanceScore := balanceScore(st, sl, s.Capacity, rangeInfo, disableStatsBasedRebalance)
 			var convergesScore int
-			if rebalanceToConvergesOnMean(st, sl, s.Capacity, rangeInfo) {
+			if rebalanceToConvergesOnMean(st, sl, s.Capacity, rangeInfo, disableStatsBasedRebalance) {
 				// This is the counterpart of !rebalanceFromConvergesOnMean from
 				// the existing candidates. Candidates whose addition would
 				// converge towards the range count mean are promoted.
@@ -552,6 +555,7 @@ func shouldRebalance(
 	store roachpb.StoreDescriptor,
 	sl StoreList,
 	rangeInfo RangeInfo,
+	disableStatsBasedRebalance bool,
 ) bool {
 	if store.Capacity.FractionUsed() >= maxFractionUsedThreshold {
 		log.VEventf(ctx, 2, "s%d: should-rebalance(disk-full): fraction-used=%.2f, capacity=(%v)",
@@ -559,12 +563,12 @@ func shouldRebalance(
 		return true
 	}
 
-	if !statsBasedRebalancingEnabled(st) {
+	if !statsBasedRebalancingEnabled(st, disableStatsBasedRebalance) {
 		return shouldRebalanceNoStats(ctx, st, store, sl)
 	}
 
 	// Rebalance if this store is full enough that the range is a bad fit.
-	score := balanceScore(st, sl, store.Capacity, rangeInfo)
+	score := balanceScore(st, sl, store.Capacity, rangeInfo, disableStatsBasedRebalance)
 	if rangeIsBadFit(score) {
 		log.VEventf(ctx, 2,
 			"s%d: should-rebalance(bad-fit): balanceScore=%s, capacity=(%v), rangeInfo=%+v, "+
@@ -579,7 +583,7 @@ func shouldRebalance(
 	// range and this store is a somewhat bad match for it.
 	if rangeIsPoorFit(score) {
 		for _, desc := range sl.stores {
-			otherScore := balanceScore(st, sl, desc.Capacity, rangeInfo)
+			otherScore := balanceScore(st, sl, desc.Capacity, rangeInfo, disableStatsBasedRebalance)
 			if !rangeIsGoodFit(otherScore) {
 				log.VEventf(ctx, 5,
 					"s%d is not a good enough fit to replace s%d: balanceScore=%s, capacity=(%v), rangeInfo=%+v, "+
@@ -618,7 +622,7 @@ func shouldRebalance(
 func shouldRebalanceNoStats(
 	ctx context.Context, st *cluster.Settings, store roachpb.StoreDescriptor, sl StoreList,
 ) bool {
-	overfullThreshold := int32(math.Ceil(overfullRangeThreshold(st, sl.candidateRanges.mean)))
+	overfullThreshold := int32(math.Ceil(overfullRangeThreshold(st, sl.candidateRanges.mean, true)))
 	if store.Capacity.RangeCount > overfullThreshold {
 		log.VEventf(ctx, 2,
 			"s%d: should-rebalance(ranges-overfull): rangeCount=%d, mean=%.2f, overfull-threshold=%d",
@@ -627,7 +631,7 @@ func shouldRebalanceNoStats(
 	}
 
 	if float64(store.Capacity.RangeCount) > sl.candidateRanges.mean {
-		underfullThreshold := int32(math.Floor(underfullRangeThreshold(st, sl.candidateRanges.mean)))
+		underfullThreshold := int32(math.Floor(underfullRangeThreshold(st, sl.candidateRanges.mean, true)))
 		for _, desc := range sl.stores {
 			if desc.Capacity.RangeCount < underfullThreshold {
 				log.VEventf(ctx, 2,
@@ -773,17 +777,21 @@ func oppositeStatus(rcs rangeCountStatus) rangeCountStatus {
 // stores where the range is a better fit based on various balance factors
 // like range count, disk usage, and QPS.
 func balanceScore(
-	st *cluster.Settings, sl StoreList, sc roachpb.StoreCapacity, rangeInfo RangeInfo,
+	st *cluster.Settings,
+	sl StoreList,
+	sc roachpb.StoreCapacity,
+	rangeInfo RangeInfo,
+	disableStatsBasedRebalance bool,
 ) balanceDimensions {
 	var dimensions balanceDimensions
-	if float64(sc.RangeCount) > overfullRangeThreshold(st, sl.candidateRanges.mean) {
+	if float64(sc.RangeCount) > overfullRangeThreshold(st, sl.candidateRanges.mean, disableStatsBasedRebalance) {
 		dimensions.ranges = overfull
-	} else if float64(sc.RangeCount) < underfullRangeThreshold(st, sl.candidateRanges.mean) {
+	} else if float64(sc.RangeCount) < underfullRangeThreshold(st, sl.candidateRanges.mean, disableStatsBasedRebalance) {
 		dimensions.ranges = underfull
 	} else {
 		dimensions.ranges = balanced
 	}
-	if statsBasedRebalancingEnabled(st) {
+	if statsBasedRebalancingEnabled(st, disableStatsBasedRebalance) {
 		dimensions.bytes = balanceContribution(
 			st,
 			dimensions.ranges,
@@ -913,15 +921,19 @@ func rangeIsPoorFit(bd balanceDimensions) bool {
 	return bd.totalScore() < -0.5
 }
 
-func overfullRangeThreshold(st *cluster.Settings, mean float64) float64 {
-	if !statsBasedRebalancingEnabled(st) {
+func overfullRangeThreshold(
+	st *cluster.Settings, mean float64, disableStatsBasedRebalance bool,
+) float64 {
+	if !statsBasedRebalancingEnabled(st, disableStatsBasedRebalance) {
 		return mean * (1 + rangeRebalanceThreshold.Get(&st.SV))
 	}
 	return math.Max(mean*(1+rangeRebalanceThreshold.Get(&st.SV)), mean+5)
 }
 
-func underfullRangeThreshold(st *cluster.Settings, mean float64) float64 {
-	if !statsBasedRebalancingEnabled(st) {
+func underfullRangeThreshold(
+	st *cluster.Settings, mean float64, disableStatsBasedRebalance bool,
+) float64 {
+	if !statsBasedRebalancingEnabled(st, disableStatsBasedRebalance) {
 		return mean * (1 - rangeRebalanceThreshold.Get(&st.SV))
 	}
 	return math.Min(mean*(1-rangeRebalanceThreshold.Get(&st.SV)), mean-5)
@@ -936,7 +948,11 @@ func underfullStatThreshold(st *cluster.Settings, mean float64) float64 {
 }
 
 func rebalanceFromConvergesOnMean(
-	st *cluster.Settings, sl StoreList, sc roachpb.StoreCapacity, rangeInfo RangeInfo,
+	st *cluster.Settings,
+	sl StoreList,
+	sc roachpb.StoreCapacity,
+	rangeInfo RangeInfo,
+	disableStatsBasedRebalance bool,
 ) bool {
 	return rebalanceConvergesOnMean(
 		st,
@@ -944,11 +960,16 @@ func rebalanceFromConvergesOnMean(
 		sc,
 		sc.RangeCount-1,
 		sc.LogicalBytes-rangeInfo.LogicalBytes,
-		sc.WritesPerSecond-rangeInfo.WritesPerSecond)
+		sc.WritesPerSecond-rangeInfo.WritesPerSecond,
+		disableStatsBasedRebalance)
 }
 
 func rebalanceToConvergesOnMean(
-	st *cluster.Settings, sl StoreList, sc roachpb.StoreCapacity, rangeInfo RangeInfo,
+	st *cluster.Settings,
+	sl StoreList,
+	sc roachpb.StoreCapacity,
+	rangeInfo RangeInfo,
+	disableStatsBasedRebalance bool,
 ) bool {
 	return rebalanceConvergesOnMean(
 		st,
@@ -956,7 +977,8 @@ func rebalanceToConvergesOnMean(
 		sc,
 		sc.RangeCount+1,
 		sc.LogicalBytes+rangeInfo.LogicalBytes,
-		sc.WritesPerSecond+rangeInfo.WritesPerSecond)
+		sc.WritesPerSecond+rangeInfo.WritesPerSecond,
+		disableStatsBasedRebalance)
 }
 
 func rebalanceConvergesOnMean(
@@ -966,8 +988,9 @@ func rebalanceConvergesOnMean(
 	newRangeCount int32,
 	newLogicalBytes int64,
 	newWritesPerSecond float64,
+	disableStatsBasedRebalance bool,
 ) bool {
-	if !statsBasedRebalancingEnabled(st) {
+	if !statsBasedRebalancingEnabled(st, disableStatsBasedRebalance) {
 		return convergesOnMean(float64(sc.RangeCount), float64(newRangeCount), sl.candidateRanges.mean)
 	}
 

--- a/pkg/storage/allocator_scorer_test.go
+++ b/pkg/storage/allocator_scorer_test.go
@@ -933,7 +933,7 @@ func TestBalanceScore(t *testing.T) {
 		{sRangesUnderfullBytesUnderfullWritesOverfull, rLowWrites, 3},
 	}
 	for i, tc := range testCases {
-		if a, e := balanceScore(st, storeList, tc.sc, tc.ri), tc.expected; a.totalScore() != e {
+		if a, e := balanceScore(st, storeList, tc.sc, tc.ri, false), tc.expected; a.totalScore() != e {
 			t.Errorf("%d: balanceScore(storeList, %+v, %+v) got %s; want %.2f", i, tc.sc, tc.ri, a, e)
 		}
 	}
@@ -1007,10 +1007,10 @@ func TestRebalanceConvergesOnMean(t *testing.T) {
 			RangeCount:      tc.rangeCount,
 			WritesPerSecond: tc.writesPerSecond,
 		}
-		if a, e := rebalanceToConvergesOnMean(st, storeList, sc, tc.ri), tc.toConverges; a != e {
+		if a, e := rebalanceToConvergesOnMean(st, storeList, sc, tc.ri, false), tc.toConverges; a != e {
 			t.Errorf("%d: rebalanceToConvergesOnMean(storeList, %+v, %+v) got %t; want %t", i, sc, tc.ri, a, e)
 		}
-		if a, e := rebalanceFromConvergesOnMean(st, storeList, sc, tc.ri), tc.fromConverges; a != e {
+		if a, e := rebalanceFromConvergesOnMean(st, storeList, sc, tc.ri, false), tc.fromConverges; a != e {
 			t.Errorf("%d: rebalanceFromConvergesOnMean(storeList, %+v, %+v) got %t; want %t", i, sc, tc.ri, a, e)
 		}
 	}

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -270,6 +270,7 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		false,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
@@ -304,6 +305,7 @@ func TestAllocatorCorruptReplica(t *testing.T) {
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		true,
+		false,
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -323,6 +325,7 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 		simpleZoneConfig.Constraints,
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
+		false,
 		false,
 	)
 	if result != nil {
@@ -346,6 +349,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		false,
+		false,
 	)
 	if err != nil {
 		t.Fatalf("Unable to perform allocation: %v", err)
@@ -358,6 +362,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 			StoreID: result1.StoreID,
 		}},
 		firstRangeInfo,
+		false,
 		false,
 	)
 	if err != nil {
@@ -383,6 +388,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 			},
 		},
 		firstRangeInfo,
+		false,
 		false,
 	)
 	if err == nil {
@@ -411,6 +417,7 @@ func TestAllocatorExistingReplica(t *testing.T) {
 			},
 		},
 		firstRangeInfo,
+		false,
 		false,
 	)
 	if err != nil {
@@ -586,6 +593,7 @@ func TestAllocatorRelaxConstraints(t *testing.T) {
 				existing,
 				firstRangeInfo,
 				false,
+				false,
 			)
 			if haveErr := (err != nil); haveErr != test.expErr {
 				t.Errorf("expected error %t; got %t: %s", test.expErr, haveErr, err)
@@ -661,6 +669,7 @@ func TestAllocatorRebalance(t *testing.T) {
 			nil,
 			testRangeInfo([]roachpb.ReplicaDescriptor{{StoreID: 3}}, firstRange),
 			storeFilterThrottled,
+			false,
 		)
 		if result == nil {
 			i-- // loop until we find 10 candidates
@@ -680,7 +689,7 @@ func TestAllocatorRebalance(t *testing.T) {
 			t.Fatalf("%d: unable to get store %d descriptor", i, store.StoreID)
 		}
 		sl, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)
-		result := shouldRebalance(ctx, st, desc, sl, firstRangeInfo)
+		result := shouldRebalance(ctx, st, desc, sl, firstRangeInfo, false)
 		if expResult := (i >= 2); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t; desc %+v; sl: %+v", i, expResult, result, desc, sl)
 		}
@@ -810,6 +819,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 			status,
 			rangeInfo,
 			storeFilterThrottled,
+			false,
 		)
 		if result != nil {
 			t.Errorf("expected no rebalance, but got %d.", result.StoreID)
@@ -886,7 +896,7 @@ func TestAllocatorRebalanceDeadNodes(t *testing.T) {
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			result, _ := a.RebalanceTarget(
-				ctx, config.Constraints{}, nil, testRangeInfo(c.existing, firstRange), storeFilterThrottled)
+				ctx, config.Constraints{}, nil, testRangeInfo(c.existing, firstRange), storeFilterThrottled, false)
 			if c.expected > 0 {
 				if result == nil {
 					t.Fatalf("expected %d, but found nil", c.expected)
@@ -1029,7 +1039,7 @@ func TestAllocatorRebalanceThrashing(t *testing.T) {
 				if !ok {
 					t.Fatalf("[store %d]: unable to get store %d descriptor", j, store.StoreID)
 				}
-				if a, e := shouldRebalance(context.Background(), st, desc, sl, firstRangeInfo), cluster[j].shouldRebalanceFrom; a != e {
+				if a, e := shouldRebalance(context.Background(), st, desc, sl, firstRangeInfo, false), cluster[j].shouldRebalanceFrom; a != e {
 					t.Errorf("[store %d]: shouldRebalance %t != expected %t", store.StoreID, a, e)
 				}
 			}
@@ -1084,6 +1094,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 			nil,
 			testRangeInfo([]roachpb.ReplicaDescriptor{{StoreID: stores[0].StoreID}}, firstRange),
 			storeFilterThrottled,
+			false,
 		)
 		if result != nil && result.StoreID != 4 {
 			t.Errorf("expected store 4; got %d", result.StoreID)
@@ -1097,7 +1108,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 			t.Fatalf("%d: unable to get store %d descriptor", i, store.StoreID)
 		}
 		sl, _, _ := a.storePool.getStoreList(firstRange, storeFilterThrottled)
-		result := shouldRebalance(ctx, st, desc, sl, firstRangeInfo)
+		result := shouldRebalance(ctx, st, desc, sl, firstRangeInfo, false)
 		if expResult := (i < 3); expResult != result {
 			t.Errorf("%d: expected rebalance %t; got %t", i, expResult, result)
 		}
@@ -1638,6 +1649,7 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 			config.Constraints{},
 			replicas,
 			testRangeInfo(replicas, firstRange),
+			false,
 		)
 		if err != nil {
 			t.Fatal(err)
@@ -2033,7 +2045,7 @@ func TestAllocatorComputeAction(t *testing.T) {
 
 	lastPriority := float64(999999999)
 	for i, tcase := range testCases {
-		action, priority := a.ComputeAction(ctx, tcase.zone, RangeInfo{Desc: &tcase.desc})
+		action, priority := a.ComputeAction(ctx, tcase.zone, RangeInfo{Desc: &tcase.desc}, false)
 		if tcase.expectedAction != action {
 			t.Errorf("Test case %d expected action %q, got action %q",
 				i, allocatorActionNames[tcase.expectedAction], allocatorActionNames[action])
@@ -2043,6 +2055,108 @@ func TestAllocatorComputeAction(t *testing.T) {
 			t.Errorf("Test cases should have descending priority. Case %d had priority %f, previous case had priority %f", i, priority, lastPriority)
 		}
 		lastPriority = priority
+	}
+}
+
+// TestAllocatorComputeActionDisableStatsRebalance is used to verify whether the cluster could balance out
+// if we disable stats-based-rebalance.
+func TestAllocatorRebalanceTargetDisableStatsRebalance(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	defer stopper.Stop(ctx)
+
+	st := a.storePool.st
+	EnableStatsBasedRebalancing.Override(&st.SV, true)
+	// Make sure the cluster's initial status is not balanced.
+	// store 1, 2, 3 has 200 replicas, store 4 has only 30 replicas.
+	// So obviously, if we want the replica is homogeneous within each store,
+	// we should rebalance some replicas from store 1, 2, 3 to store 4.
+	// However, we set the WritesPerSecond of store 4 is much bigger than other store,
+	// so if we enable stats-based rebalance, we couldn't spread out the replicas on store 1, 2, 3.
+	stores := []*roachpb.StoreDescriptor{
+		{
+			StoreID: 1,
+			Node:    roachpb.NodeDescriptor{NodeID: 1},
+			Capacity: roachpb.StoreCapacity{
+				RangeCount:      200,
+				WritesPerSecond: 30,
+			},
+		},
+		{
+			StoreID: 2,
+			Node:    roachpb.NodeDescriptor{NodeID: 2},
+			Capacity: roachpb.StoreCapacity{
+				RangeCount:      200,
+				WritesPerSecond: 30,
+			},
+		},
+		{
+			StoreID: 3,
+			Node:    roachpb.NodeDescriptor{NodeID: 3},
+			Capacity: roachpb.StoreCapacity{
+				RangeCount:      200,
+				WritesPerSecond: 30,
+			},
+		},
+		{
+			StoreID: 4,
+			Node:    roachpb.NodeDescriptor{NodeID: 4},
+			Capacity: roachpb.StoreCapacity{
+				RangeCount:      30,
+				WritesPerSecond: 100,
+			},
+		},
+	}
+	sg := gossiputil.NewStoreGossiper(g)
+	sg.GossipStores(stores, t)
+
+	desc := roachpb.RangeDescriptor{
+		RangeID: firstRange,
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				StoreID:   1,
+				NodeID:    1,
+				ReplicaID: 1,
+			},
+			{
+				StoreID:   2,
+				NodeID:    2,
+				ReplicaID: 2,
+			},
+			{
+				StoreID:   3,
+				NodeID:    3,
+				ReplicaID: 3,
+			},
+		},
+	}
+	for i := 0; i < 50; i++ {
+		target, _ := a.RebalanceTarget(
+			context.Background(),
+			config.Constraints{},
+			nil,
+			testRangeInfo(desc.Replicas, desc.RangeID),
+			storeFilterThrottled,
+			false, /* disableStatsBasedRebalance */
+		)
+		if target != nil {
+			t.Errorf("expected no balance, but got %d", target.StoreID)
+		}
+	}
+
+	for i := 0; i < 50; i++ {
+		target, _ := a.RebalanceTarget(
+			context.Background(),
+			config.Constraints{},
+			nil,
+			testRangeInfo(desc.Replicas, desc.RangeID),
+			storeFilterThrottled,
+			true, /* disableStatsBasedRebalance */
+		)
+		if expectedStore := roachpb.StoreID(4); target.StoreID != expectedStore {
+			t.Errorf("expected balance to %d, but got %d", expectedStore, target.StoreID)
+		}
 	}
 }
 
@@ -2123,7 +2237,7 @@ func TestAllocatorComputeActionRemoveDead(t *testing.T) {
 	for i, tcase := range testCases {
 		mockStorePool(sp, tcase.live, tcase.dead, nil, nil)
 
-		action, _ := a.ComputeAction(ctx, tcase.zone, RangeInfo{Desc: &tcase.desc})
+		action, _ := a.ComputeAction(ctx, tcase.zone, RangeInfo{Desc: &tcase.desc}, false)
 		if tcase.expectedAction != action {
 			t.Errorf("Test case %d expected action %d, got action %d", i, tcase.expectedAction, action)
 		}
@@ -2307,7 +2421,7 @@ func TestAllocatorComputeActionDecommission(t *testing.T) {
 	for i, tcase := range testCases {
 		mockStorePool(sp, tcase.live, tcase.dead, tcase.decommissioning, nil)
 
-		action, _ := a.ComputeAction(ctx, tcase.zone, RangeInfo{Desc: &tcase.desc})
+		action, _ := a.ComputeAction(ctx, tcase.zone, RangeInfo{Desc: &tcase.desc}, false)
 		if tcase.expectedAction != action {
 			t.Errorf("Test case %d expected action %d, got action %d", i, tcase.expectedAction, action)
 			continue
@@ -2321,7 +2435,7 @@ func TestAllocatorComputeActionNoStorePool(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	a := MakeAllocator(nil /* storePool */, nil /* rpcContext */)
-	action, priority := a.ComputeAction(context.Background(), config.ZoneConfig{}, RangeInfo{})
+	action, priority := a.ComputeAction(context.Background(), config.ZoneConfig{}, RangeInfo{}, false)
 	if action != AllocatorNoop {
 		t.Errorf("expected AllocatorNoop, but got %v", action)
 	}
@@ -2385,6 +2499,7 @@ func TestAllocatorThrottled(t *testing.T) {
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		false,
+		false,
 	)
 	if _, ok := err.(purgatoryError); !ok {
 		t.Fatalf("expected a purgatory error, got: %v", err)
@@ -2397,6 +2512,7 @@ func TestAllocatorThrottled(t *testing.T) {
 		simpleZoneConfig.Constraints,
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
+		false,
 		false,
 	)
 	if err != nil {
@@ -2420,6 +2536,7 @@ func TestAllocatorThrottled(t *testing.T) {
 		simpleZoneConfig.Constraints,
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
+		false,
 		false,
 	)
 	if _, ok := err.(purgatoryError); ok {
@@ -2688,6 +2805,7 @@ func TestAllocatorRebalanceAway(t *testing.T) {
 				nil,
 				testRangeInfo(existingReplicas, firstRange),
 				storeFilterThrottled,
+				false,
 			)
 
 			if tc.expected == nil && actual != nil {
@@ -2809,6 +2927,7 @@ func Example_rebalancing() {
 				nil,
 				testRangeInfo([]roachpb.ReplicaDescriptor{{NodeID: ts.Node.NodeID, StoreID: ts.StoreID}}, firstRange),
 				storeFilterThrottled,
+				false,
 			)
 			if target != nil {
 				log.Infof(context.TODO(), "rebalancing to %+v", target)

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -4119,7 +4119,7 @@ func (r *Replica) adminScatter(
 	var allowLeaseTransfer bool
 	canTransferLease := func() bool { return allowLeaseTransfer }
 	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
-		requeue, err := rq.processOneChange(ctx, r, sysCfg, canTransferLease, false /* dryRun */)
+		requeue, err := rq.processOneChange(ctx, r, sysCfg, canTransferLease, false /* dryRun */, true /* disableStatsBasedRebalance */)
 		if err != nil {
 			if IsSnapshotError(err) {
 				continue

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4310,7 +4310,7 @@ func (s *Store) AllocatorDryRun(
 	defer cancel()
 	canTransferLease := func() bool { return true }
 	_, err := s.replicateQueue.processOneChange(
-		ctx, repl, sysCfg, canTransferLease, true /* dryRun */)
+		ctx, repl, sysCfg, canTransferLease, true /* dryRun */, false /* disableStatsBasedRebalance */)
 	if err != nil {
 		log.Eventf(ctx, "error simulating allocator on replica %s: %s", repl, err)
 	}


### PR DESCRIPTION
@a-robinson , Fixes #17671.
I just disable stats-based rebalancing when we use SQL statement `ALTER TABLE ... SCATTER ...`
Still don't know how to add a test for it. Thank you for your guidance.
Please help me review this.