### PR TITLE
storage: Unskip TestLeaseInfoRequest

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1038,7 +1038,6 @@ func LeaseInfo(
 
 func TestLeaseInfoRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13503")
 	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,


### PR DESCRIPTION
It appears to not be flaky anymore. I stressed it for 20k runs over
15 minutes with no failures (after removing the t.Skip call, of course).

Fixes #13503