### PR TITLE
testutils: Unskip TestManualReplication

### DIFF
--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -35,7 +35,6 @@ import (
 
 func TestManualReplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13502")
 
 	tc := StartTestCluster(t, 3,
 		base.TestClusterArgs{


### PR DESCRIPTION
It appears to not be flaky anymore. I stressed it for 30k runs over
15 minutes with no failures (after removing the t.Skip call, of course).

Fixes #13502