### PR TITLE
sqlccl: don't split CSV files mid column family

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -524,9 +524,23 @@ func writeRocksDB(
 
 	var kv engine.MVCCKeyValue
 	kv.Key.Timestamp.WallTime = walltime
+	// firstKey is always the first key of the span. lastKey, if nil, means the
+	// current SST hasn't yet filled up. Once the SST has filled up, lastKey is
+	// set to the key at which to stop adding KVs. We have to do this because
+	// all column families for a row must be in one SST and the SST may have
+	// filled up with only some of the KVs from the column families being added.
 	var firstKey, lastKey roachpb.Key
 	var count int64
-	for it.Rewind(); ; it.Next() {
+
+	it.Rewind()
+	if ok, err := it.Valid(); err != nil {
+		return 0, err
+	} else if !ok {
+		return 0, errors.New("could not get first key")
+	}
+	firstKey = it.Key()
+
+	for ; ; it.Next() {
 		if ok, err := it.Valid(); err != nil {
 			return 0, err
 		} else if !ok {
@@ -534,34 +548,34 @@ func writeRocksDB(
 		}
 		count++
 
-		// Save the first key for the span.
-		if firstKey == nil {
-			firstKey = it.Key()
-
-			// Ensure the first key doesn't match the last key of the previous SST.
-			if firstKey.Equal(lastKey) {
-				return 0, errors.Errorf("duplicate key: %s", firstKey)
-			}
-		}
-
 		kv.Key.Key = it.UnsafeKey()
 		kv.Value = it.UnsafeValue()
+		if lastKey != nil {
+			if kv.Key.Key.Compare(lastKey) >= 0 {
+				if err := writeSST(firstKey, lastKey); err != nil {
+					return 0, err
+				}
+				firstKey = it.Key()
+				lastKey = nil
 
+				sst, err = engine.MakeRocksDBSstFileWriter()
+				if err != nil {
+					return 0, err
+				}
+				defer sst.Close()
+			}
+		}
 		if err := sst.Add(kv); err != nil {
 			return 0, errors.Wrapf(err, errSSTCreationMaybeDuplicateTemplate, kv.Key.Key)
 		}
-		if sst.DataSize > sstMaxSize {
-			if err := writeSST(firstKey, kv.Key.Key.Next()); err != nil {
-				return 0, err
-			}
-			firstKey = nil
-			lastKey = append([]byte(nil), kv.Key.Key...)
-
-			sst, err = engine.MakeRocksDBSstFileWriter()
+		if sst.DataSize > sstMaxSize && lastKey == nil {
+			// When we would like to split the file, proceed until we aren't in the
+			// middle of a row. Start by finding the next safe split key.
+			lastKey, err = keys.EnsureSafeSplitKey(kv.Key.Key)
 			if err != nil {
 				return 0, err
 			}
-			defer sst.Close()
+			lastKey = lastKey.PrefixEnd()
 		}
 	}
 	if sst.DataSize > 0 {

--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -310,6 +310,61 @@ N|N
 	}
 }
 
+// TestLoadCSVSplit ensures that a split cannot happen in the middle of a row.
+func TestLoadCSVSplit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tmp, tmpCleanup := testutils.TempDir(t)
+	defer tmpCleanup()
+	ctx := context.Background()
+
+	const (
+		tableName   = "t"
+		csvName     = tableName + ".dat"
+		tableCreate = `
+			CREATE TABLE ` + tableName + ` (
+				i int primary key,
+				s string,
+				b int,
+				c int,
+				index (s),
+				index (i, s),
+				family (i, b),
+				family (s, c)
+			)
+		`
+		tableCSV = `5,STRING,7,9`
+	)
+
+	tablePath := filepath.Join(tmp, tableName)
+	dataPath := filepath.Join(tmp, csvName)
+
+	if err := ioutil.WriteFile(tablePath, []byte(tableCreate), 0666); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(dataPath, []byte(tableCSV), 0666); err != nil {
+		t.Fatal(err)
+	}
+	// sstMaxSize = 1 should put each index (could be more than one KV due to
+	// column families) in its own SST.
+	csv, kv, sst, err := sqlccl.LoadCSV(ctx, tablePath, []string{dataPath}, tmp, 0 /* comma */, 0 /* comment */, nil /* nullif */, 1 /* sstMaxSize */, tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only a single input row.
+	if csv != 1 {
+		t.Fatalf("read %d rows, expected %d", csv, 1)
+	}
+	// Should produce 4 kvs: 2 families on PK + 2 indexes.
+	if kv != 4 {
+		t.Fatalf("created %d KVs, expected %d", kv, 4)
+	}
+	// But only 3 SSTs because the first 2 KVs should be in same SST.
+	if sst != 3 {
+		t.Fatalf("created %d SSTs, expected %d", sst, 3)
+	}
+}
+
 // TODO(dt): switch to a helper in sampledataccl.
 func makeCSVData(
 	t testing.TB, in string, numFiles, rowsPerFile int,


### PR DESCRIPTION
Previously, we would allow splitting between two KVs in the index of
different column families. This caused numerous odd errors, including
double-counting these rows during RESTORE. The select inconsistencies
mentioned in the fixed issues are also explained by this, I think,
because the system isn't quite sure what to do with these partial
rows and so does some weird stuff.

Fixes #18076