### PR TITLE
cliccl: add `load show` subcommand to display backup info

### DIFF
--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -9,13 +9,18 @@
 package cliccl
 
 import (
+	"fmt"
 	"os"
+	"strings"
+	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cli"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 
 	"github.com/pkg/errors"
@@ -68,6 +73,13 @@ Then the file could be converted and saved to /data/backup with:
 	flags.StringVar(&csvComment, "comment", "", "if specified, allows comment lines starting with this character")
 	flags.StringVar(&csvTempDir, "tempdir", os.TempDir(), "directory to store intermediate temp files")
 
+	loadShowCmd := &cobra.Command{
+		Use:   "show <basepath>",
+		Short: "show backups",
+		Long:  "Shows information about a SQL backup.",
+		RunE:  cli.MaybeDecorateGRPCError(runLoadShow),
+	}
+
 	loadCmds := &cobra.Command{
 		Use:   "load [command]",
 		Short: "loading commands",
@@ -78,6 +90,7 @@ Then the file could be converted and saved to /data/backup with:
 	}
 	cli.AddCmd(loadCmds)
 	loadCmds.AddCommand(loadCSVCmd)
+	loadCmds.AddCommand(loadShowCmd)
 }
 
 var (
@@ -138,5 +151,61 @@ func runLoadCSV(cmd *cobra.Command, args []string) error {
 	log.Infof(ctx, "KVs pairs created: %d", kv)
 	log.Infof(ctx, "SST files written: %d", sst)
 
+	return nil
+}
+
+func runLoadShow(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return errors.New("basepath argument is required")
+	}
+
+	ctx := context.Background()
+	basepath := args[0]
+	if !strings.Contains(basepath, "://") {
+		var err error
+		basepath, err = storageccl.MakeLocalStorageURI(basepath)
+		if err != nil {
+			return err
+		}
+	}
+	desc, err := sqlccl.ReadBackupDescriptorFromURI(ctx, basepath)
+	if err != nil {
+		return err
+	}
+	start := time.Unix(0, desc.StartTime.WallTime).UTC().Format(time.RFC3339Nano)
+	end := time.Unix(0, desc.EndTime.WallTime).UTC().Format(time.RFC3339Nano)
+	fmt.Printf("StartTime: %s (%s)\n", start, desc.StartTime)
+	fmt.Printf("EndTime: %s (%s)\n", end, desc.EndTime)
+	fmt.Printf("DataSize: %d (%s)\n", desc.EntryCounts.DataSize, humanizeutil.IBytes(desc.EntryCounts.DataSize))
+	fmt.Printf("Rows: %d\n", desc.EntryCounts.Rows)
+	fmt.Printf("IndexEntries: %d\n", desc.EntryCounts.IndexEntries)
+	fmt.Printf("SystemRecords: %d\n", desc.EntryCounts.SystemRecords)
+	fmt.Printf("FormatVersion: %d\n", desc.FormatVersion)
+	fmt.Printf("ClusterID: %s\n", desc.ClusterID)
+	fmt.Printf("NodeID: %s\n", desc.NodeID)
+	fmt.Printf("BuildInfo: %s\n", desc.BuildInfo.Short())
+	fmt.Printf("Spans:\n")
+	for _, s := range desc.Spans {
+		fmt.Printf("	%s\n", s)
+	}
+	fmt.Printf("Files:\n")
+	for _, f := range desc.Files {
+		fmt.Printf("	%s:\n", f.Path)
+		fmt.Printf("		Span: %s\n", f.Span)
+		fmt.Printf("		Sha512: %0128x\n", f.Sha512)
+		fmt.Printf("		DataSize: %d (%s)\n", f.EntryCounts.DataSize, humanizeutil.IBytes(f.EntryCounts.DataSize))
+		fmt.Printf("		Rows: %d\n", f.EntryCounts.Rows)
+		fmt.Printf("		IndexEntries: %d\n", f.EntryCounts.IndexEntries)
+		fmt.Printf("		SystemRecords: %d\n", f.EntryCounts.SystemRecords)
+	}
+	fmt.Printf("Descriptors:\n")
+	for _, d := range desc.Descriptors {
+		if desc := d.GetTable(); desc != nil {
+			fmt.Printf("	%d: %s (table)\n", d.GetID(), d.GetName())
+		}
+		if desc := d.GetDatabase(); desc != nil {
+			fmt.Printf("	%d: %s (database)\n", d.GetID(), d.GetName())
+		}
+	}
 	return nil
 }

--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -73,10 +73,10 @@ func exportStorageFromURI(ctx context.Context, uri string) (storageccl.ExportSto
 	return storageccl.MakeExportStorage(ctx, conf)
 }
 
-// readBackupDescriptorFromURI creates an export store from the given URI, then
+// ReadBackupDescriptorFromURI creates an export store from the given URI, then
 // reads and unmarshals a BackupDescriptor at the standard location in the
 // export storage.
-func readBackupDescriptorFromURI(ctx context.Context, uri string) (BackupDescriptor, error) {
+func ReadBackupDescriptorFromURI(ctx context.Context, uri string) (BackupDescriptor, error) {
 	exportStore, err := exportStorageFromURI(ctx, uri)
 	if err != nil {
 		return BackupDescriptor{}, err
@@ -122,7 +122,7 @@ func ValidatePreviousBackups(ctx context.Context, uris []string) (hlc.Timestamp,
 	}
 	backups := make([]BackupDescriptor, len(uris))
 	for i, uri := range uris {
-		desc, err := readBackupDescriptorFromURI(ctx, uri)
+		desc, err := ReadBackupDescriptorFromURI(ctx, uri)
 		if err != nil {
 			return hlc.Timestamp{}, err
 		}
@@ -838,7 +838,7 @@ func showBackupPlanHook(
 		if err != nil {
 			return err
 		}
-		desc, err := readBackupDescriptorFromURI(ctx, str)
+		desc, err := ReadBackupDescriptorFromURI(ctx, str)
 		if err != nil {
 			return err
 		}

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -56,7 +56,7 @@ func loadBackupDescs(ctx context.Context, uris []string) ([]BackupDescriptor, er
 	backupDescs := make([]BackupDescriptor, len(uris))
 
 	for i, uri := range uris {
-		desc, err := readBackupDescriptorFromURI(ctx, uri)
+		desc, err := ReadBackupDescriptorFromURI(ctx, uri)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read backup descriptor")
 		}


### PR DESCRIPTION
Makes output like:

```
$ ./cockroach load show ~/load-tbl/orders.sst
StartTime: 1969-12-31 19:00:00 -0500 EST (0.000000000,0)
EndTime: 2017-09-11 15:18:22.411692227 -0400 EDT (1505157502.411692227,0)
DataSize: 281537130
Rows: 0
IndexEntries: 0
SystemRecords: 0
FormatVersion: 0
ClusterID: 00000000-0000-0000-0000-000000000000
NodeID: 0
BuildInfo: CockroachDB   (, built , )
Spans:
        /Table/5{1-2}
Files:
        1.sst:
                Span: /Table/51/1/1{/0-335875}
                Sha512: 5237eab85bf185c00652a1591cba57f5bec8e44d231c1d2c266f104141659d663e22bdaddf945bc8c4f034a800f0a8bfa08a3f2a7fd2640721e5d55502c84a10
                DataSize: 0
                Rows: 0
                IndexEntries: 0
                SystemRecords: 0
        2.sst:
                Span: /Table/51/1/{1335875/0-2669511}
                Sha512: 614ab69357789438d0b8f53dd4830fb9d6526a35580ae0d0033c943c88cddb9d222364150a72353da9da36e020f661e522c28a8ae0e05bf302c5ee174d
                DataSize: 0
                Rows: 0
                IndexEntries: 0
                SystemRecords: 0
        3.sst:
                Span: /Table/51/1/{2669511/0-4003588}
                Sha512: a852d30f23d9ffc2185b5f0c188666460030fb27e08d7f6f340878c33dca76fb45a985926945fa4689f4b1c9285c8622857811a6a129f724c798b402d3
                DataSize: 0
                Rows: 0
                IndexEntries: 0
                SystemRecords: 0
        4.sst:
                Span: /Table/51/1/{4003588/0-5337991}
                Sha512: e7e244ec596880334c01b82063c4b10f731a521078fa8ad9da13d8181bd92bb3f4cabdba6a49e683a37685eea423686266dce95090bfed6a64dff7f399
                DataSize: 0
                Rows: 0
                IndexEntries: 0
                SystemRecords: 0
        5.sst:
                Span: /Table/51/{1/5337991/0-3/8367/3808196}
                Sha512: 198cbaadc460f81c555adeaf7357e75c1608a9146cb032a8c872423e35c87dacb2125f973fd8ca26b0848bbda0c381b0d612d38f57a44a5979dc101273
                DataSize: 0
                Rows: 0
                IndexEntries: 0
                SystemRecords: 0
        6.sst:
                Span: /Table/51/3/{8367/3849255/0-10440/5999872/0/NULL}
                Sha512: e79d9d4a390a7dab71d4fd706f818dc014b51e8e99347df3cf588091fb7c5b502b060ee3e807d98c53e78d4964927870b57ed6240865e6957104bc3bda
                DataSize: 0
                Rows: 0
                IndexEntries: 0
                SystemRecords: 0
Descriptors:
        51: orders
```