### PR TITLE
acceptance: fix schema change tests

### DIFF
--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -166,16 +166,16 @@ func (at *allocatorTest) Run(ctx context.Context, t *testing.T) {
 		log.Info(ctx, "running schema changes while cluster is rebalancing")
 		// These schema changes are over a table that is not actively
 		// being updated.
-		log.Info(ctx, "running schema changes over tpch.orders")
+		log.Info(ctx, "running schema changes over tpch.customer")
 		schemaChanges := []string{
-			"ALTER TABLE tpch.orders ADD COLUMN newcol INT DEFAULT (INT 23456)",
-			"CREATE INDEX foo ON tpch.orders (o_orderdate)",
+			"ALTER TABLE tpch.customer ADD COLUMN newcol INT DEFAULT 23456",
+			"CREATE INDEX foo ON tpch.customer (c_name)",
 		}
 		// All these return the same result.
 		validationQueries := []string{
-			"SELECT COUNT(*) FROM tpch.orders AS OF SYSTEM TIME %s",
-			"SELECT COUNT(newcol) FROM tpch.orders AS OF SYSTEM TIME %s",
-			"SELECT COUNT(o_orderdate) FROM tpch.orders@foo AS OF SYSTEM TIME %s",
+			"SELECT COUNT(*) FROM tpch.customer AS OF SYSTEM TIME %s",
+			"SELECT COUNT(newcol) FROM tpch.customer AS OF SYSTEM TIME %s",
+			"SELECT COUNT(c_name) FROM tpch.customer@foo AS OF SYSTEM TIME %s",
 		}
 		if err := at.runSchemaChanges(ctx, t, schemaChanges, validationQueries); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
use tpch.customer rather than tpch.orders because
the table is about the right size for this test to pass.

schema changes still slow

```
I170912 07:39:11.179688 710 acceptance/allocator_test.go:236  starting schema change: ALTER TABLE tpch.customer ADD COLUMN newcol INT DEFAULT 23456
I170912 07:39:11.179801 711 acceptance/allocator_test.go:236  starting schema change: CREATE INDEX foo ON tpch.customer (c_name)
I170912 07:48:58.573620 710 acceptance/allocator_test.go:241  completed schema change: ALTER TABLE tpch.customer ADD COLUMN newcol INT DEFAULT 23456, in 9m47.393964786s
I170912 07:49:24.717975 711 acceptance/allocator_test.go:241  completed schema change: CREATE INDEX foo ON tpch.customer (c_name), in 10m13.53847295s
I170912 07:49:24.718055 10 acceptance/allocator_test.go:253  validate applied schema changes
I170912 07:49:46.345819 10 acceptance/allocator_test.go:285  query: SELECT COUNT(*) FROM tpch.customer AS OF SYSTEM TIME 1505216964911283818.0000000046, found 1500000 rows
I170912 07:50:00.762523 10 acceptance/allocator_test.go:285  query: SELECT COUNT(newcol) FROM tpch.customer AS OF SYSTEM TIME 1505216964911283818.0000000046, found 1500000 rows
I170912 07:50:16.131358 10 acceptance/allocator_test.go:285  query: SELECT COUNT(c_name) FROM tpch.customer@foo AS OF SYSTEM TIME 1505216964911283818.0000000046, found 1500000 rows
I170912 07:50:16.131798 10 acceptance/allocator_test.go:188  running schema changes over datablocks.blocks
I170912 07:50:16.131935 655 acceptance/allocator_test.go:236  starting schema change: CREATE INDEX foo ON datablocks.blocks (block_id)
I170912 07:50:16.132240 654 acceptance/allocator_test.go:236  starting schema change: ALTER TABLE datablocks.blocks ADD COLUMN newcol DECIMAL DEFAULT (DECIMAL '1.4')
I170912 07:54:35.699794 654 acceptance/allocator_test.go:241  completed schema change: ALTER TABLE datablocks.blocks ADD COLUMN newcol DECIMAL DEFAULT (DECIMAL '1.4'), in 4m19.567524829s
I170912 08:03:19.413675 655 acceptance/allocator_test.go:241  completed schema change: CREATE INDEX foo ON datablocks.blocks (block_id), in 13m3.281745558s
I170912 08:03:19.413735 10 acceptance/allocator_test.go:253  validate applied schema changes
I170912 08:03:41.175988 10 acceptance/allocator_test.go:285  query: SELECT COUNT(*) FROM datablocks.blocks AS OF SYSTEM TIME 1505217800205359921.0000000000, found 752517 rows
I170912 08:04:09.333531 10 acceptance/allocator_test.go:285  query: SELECT COUNT(newcol) FROM datablocks.blocks AS OF SYSTEM TIME 1505217800205359921.0000000000, found 752517 rows
I170912 08:04:26.843892 10 acceptance/allocator_test.go:285  query: SELECT COUNT(block_id) FROM datablocks.blocks@foo AS OF SYSTEM TIME 1505217800205359921.0000000000, found 752517 rows
```