### PR TITLE
storage: cleanup updating of Replica.mu.lastTerm after snapshots

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -660,7 +660,7 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 			defer mtc.Stop()
 			mtc.Start(t, 3)
 			const stoppedStore = 1
-			repl, err := mtc.stores[0].GetReplica(1)
+			repl0, err := mtc.stores[0].GetReplica(1)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -693,7 +693,7 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 
 			mtc.waitForValues(key, []int64{incAB, incA, incAB})
 
-			index, err := repl.GetLastIndex()
+			index, err := repl0.GetLastIndex()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -770,6 +770,30 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 				mtc.restartStore(stoppedStore)
 			}
 			mtc.waitForValues(key, []int64{incAB, incAB, incAB})
+
+			// Verify that the cached index and term (Replica.mu.last{Index,Term}))
+			// on all of the replicas is the same. #18327 fixed an issue where the
+			// cached term was left unchanged after applying a snapshot leading to a
+			// persistently unavailable range.
+			repl0, err = mtc.stores[0].GetReplica(1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			expectedLastIndex, _ := repl0.GetLastIndex()
+			expectedLastTerm := repl0.GetCachedLastTerm()
+
+			for i := 1; i < len(mtc.stores); i++ {
+				repl1, err := mtc.stores[i].GetReplica(1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if lastIndex, _ := repl1.GetLastIndex(); expectedLastIndex != lastIndex {
+					t.Fatalf("%d: expected last index %d, but found %d", i, expectedLastIndex, lastIndex)
+				}
+				if lastTerm := repl1.GetCachedLastTerm(); expectedLastTerm != lastTerm {
+					t.Fatalf("%d: expected last term %d, but found %d", i, expectedLastTerm, lastTerm)
+				}
+			}
 		})
 	}
 }

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -339,14 +339,22 @@ func (r *Replica) GetTimestampCacheLowWater() hlc.Timestamp {
 
 // GetRaftLogSize returns the raft log size.
 func (r *Replica) GetRaftLogSize() int64 {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.mu.raftLogSize
 }
 
+// GetCachedLastTerm returns the cached last term value. May return
+// invalidLastTerm if the cache is not set.
+func (r *Replica) GetCachedLastTerm() uint64 {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.mu.lastTerm
+}
+
 func (r *Replica) IsRaftGroupInitialized() bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.mu.internalRaftGroup != nil
 }
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3250,14 +3250,14 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			return stats, err
 		}
 
-		// r.mu.lastIndex and r.mu.lastTerm were updated in applySnapshot, but
-		// we also want to make sure we reflect these changes in the local
-		// variables we're tracking here. We could pull these values from
-		// r.mu itself, but that would require us to grab a lock.
-		if lastIndex, err = r.raftMu.stateLoader.loadLastIndex(ctx, r.store.Engine()); err != nil {
-			return stats, err
-		}
-		lastTerm = invalidLastTerm
+		// r.mu.lastIndex, r.mu.lastTerm and r.mu.raftLogSize were updated in
+		// applySnapshot, but we also want to make sure we reflect these changes in
+		// the local variables we're tracking here.
+		r.mu.RLock()
+		lastIndex = r.mu.lastIndex
+		lastTerm = r.mu.lastTerm
+		raftLogSize = r.mu.raftLogSize
+		r.mu.RUnlock()
 
 		// We refresh pending commands after applying a snapshot because this
 		// replica may have been temporarily partitioned from the Raft group and

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -681,7 +681,6 @@ func (r *Replica) applySnapshot(
 	}
 
 	r.mu.RLock()
-	raftLogSize := r.mu.raftLogSize
 	replicaID := r.mu.replicaID
 	keyCount := r.mu.state.Stats.KeyCount
 	r.mu.RUnlock()
@@ -767,6 +766,7 @@ func (r *Replica) applySnapshot(
 	// If this replica doesn't know its ReplicaID yet, we're applying a
 	// preemptive snapshot. In this case, we're going to have to write the
 	// sideloaded proposals into the Raft log. Otherwise, sideload.
+	var raftLogSize int64
 	thinEntries := logEntries
 	if replicaID != 0 {
 		var err error
@@ -779,8 +779,9 @@ func (r *Replica) applySnapshot(
 	}
 
 	// Write the snapshot's Raft log into the range.
-	_, _, raftLogSize, err = r.append(
-		ctx, distinctBatch, 0, 0, raftLogSize, thinEntries,
+	var lastTerm uint64
+	_, lastTerm, raftLogSize, err = r.append(
+		ctx, distinctBatch, 0, invalidLastTerm, raftLogSize, thinEntries,
 	)
 	if err != nil {
 		return err
@@ -829,9 +830,7 @@ func (r *Replica) applySnapshot(
 	// feelings about this ever change, we can add a LastIndex field to
 	// raftpb.SnapshotMetadata.
 	r.mu.lastIndex = s.RaftAppliedIndex
-	// We could recompute and return the lastTerm in the snapshot, but instead we
-	// just set an invalid term and force a recomputation later.
-	r.mu.lastTerm = invalidLastTerm
+	r.mu.lastTerm = lastTerm
 	r.mu.raftLogSize = raftLogSize
 	// Update the range and store stats.
 	r.store.metrics.subtractMVCCStats(r.mu.state.Stats)


### PR DESCRIPTION
Cleanup the updating of `Replica.mu.lastTerm` after applying a
snapshot. `Replica.applySnapshot` updates
`Replica.mu.{lastTerm,lastIndex,raftLogSize}` and we need to copy those
udpates into local variables in
`Replica.handleRaftReadyRaftMuLocked`. Failure to do this updating
properly led to a bug in which a replica was persistently unavailable
because the cached last term was incorrect. Changed `applySnapshot` to
determine the actual last term and to verify this is updated correctly
in `TestSnapshotAfterTruncation`.

Fixes #18336