### PR TITLE
cherrypick-1.1: server: Deflake TestHealthAPI by disabling all liveness heartbeats

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1083,7 +1083,7 @@ func TestHealthAPI(t *testing.T) {
 	// Expire this node's liveness record by pausing heartbeats and advancing the
 	// server's clock.
 	ts := s.(*TestServer)
-	ts.nodeLiveness.PauseHeartbeat(true)
+	defer ts.nodeLiveness.DisableAllHeartbeatsForTest()()
 	self, err := ts.nodeLiveness.Self()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -370,6 +370,19 @@ func (nl *NodeLiveness) PauseHeartbeat(pause bool) {
 	}
 }
 
+// DisableAllHeartbeatsForTest disables all node liveness heartbeats, including
+// those triggered from outside the normal StartHeartbeat loop. Returns a
+// closure to call to re-enable heartbeats. Only safe for use in tests.
+func (nl *NodeLiveness) DisableAllHeartbeatsForTest() func() {
+	nl.PauseHeartbeat(true)
+	nl.selfSem <- struct{}{}
+	nl.otherSem <- struct{}{}
+	return func() {
+		<-nl.selfSem
+		<-nl.otherSem
+	}
+}
+
 var errNodeAlreadyLive = errors.New("node already live")
 
 // Heartbeat is called to update a node's expiration timestamp. This


### PR DESCRIPTION
PauseHeartbeat doesn't disable heartbeats triggered from outside the
NodeLiveness heartbeat loop, such as from requestLeaseAsync.
PauseHeartbeat can't be extended to block such heartbeats, though,
because they are relied upon by many of the node liveness tests.

Fixes #17771

@cockroachdb/release as requested on #18428 