### PR TITLE
cherrpick-1.1: storage: Unskip TestLeaseInfoRequest

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -1034,7 +1034,6 @@ func LeaseInfo(
 
 func TestLeaseInfoRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#13503")
 	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,


### PR DESCRIPTION
It appears to not be flaky anymore. I stressed it for 20k runs over
15 minutes with no failures (after removing the t.Skip call, of course).

I'm not sure that unskipping a test is cherrypick worthy, but requested by https://github.com/cockroachdb/cockroach/pull/18429#issuecomment-328890113