### PR TITLE
*: use proto.Unmarshal

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
@@ -106,7 +107,7 @@ func readBackupDescriptor(
 		return BackupDescriptor{}, err
 	}
 	var backupDesc BackupDescriptor
-	if err := backupDesc.Unmarshal(descBytes); err != nil {
+	if err := proto.Unmarshal(descBytes, &backupDesc); err != nil {
 		return BackupDescriptor{}, err
 	}
 	return backupDesc, err

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/kr/pretty"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
@@ -599,7 +600,7 @@ func TestBackupRestoreCheckpointing(t *testing.T) {
 			return errors.Errorf("%+v", err)
 		}
 		var checkpointDesc sqlccl.BackupDescriptor
-		if err := checkpointDesc.Unmarshal(checkpointDescBytes); err != nil {
+		if err := proto.Unmarshal(checkpointDescBytes, &checkpointDesc); err != nil {
 			return errors.Errorf("%+v", err)
 		}
 		if len(checkpointDesc.Files) == 0 {
@@ -620,7 +621,7 @@ func TestBackupRestoreCheckpointing(t *testing.T) {
 			return err
 		}
 		var payload jobs.Payload
-		if err := payload.Unmarshal(payloadBytes); err != nil {
+		if err := proto.Unmarshal(payloadBytes, &payload); err != nil {
 			return err
 		}
 		switch d := payload.Details.(type) {
@@ -748,7 +749,7 @@ func TestBackupRestoreResume(t *testing.T) {
 			t.Fatal(err)
 		}
 		var backupDescriptor sqlccl.BackupDescriptor
-		if err := backupDescriptor.Unmarshal(backupDescriptorBytes); err != nil {
+		if err := proto.Unmarshal(backupDescriptorBytes, &backupDescriptor); err != nil {
 			t.Fatal(err)
 		}
 		for _, file := range backupDescriptor.Files {
@@ -1630,7 +1631,7 @@ func TestBackupRestoreChecksum(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if err := backupDesc.Unmarshal(backupDescBytes); err != nil {
+		if err := proto.Unmarshal(backupDescBytes, &backupDesc); err != nil {
 			t.Fatalf("%+v", err)
 		}
 	}

--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -17,6 +17,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -81,7 +82,7 @@ func Load(
 		return BackupDescriptor{}, errors.Wrap(err, "fetch database descriptor")
 	}
 	var dbDescWrapper sqlbase.Descriptor
-	if err := dbDescWrapper.Unmarshal(dbDescBytes); err != nil {
+	if err := proto.Unmarshal(dbDescBytes, &dbDescWrapper); err != nil {
 		return BackupDescriptor{}, errors.Wrap(err, "unmarshal database descriptor")
 	}
 	dbDesc := dbDescWrapper.GetDatabase()

--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -62,7 +63,7 @@ func MakeKeyRewriter(rekeys []roachpb.ImportRequest_TableRekey) (*KeyRewriter, e
 	descs := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
 	for _, rekey := range rekeys {
 		var desc sqlbase.Descriptor
-		if err := desc.Unmarshal(rekey.NewDesc); err != nil {
+		if err := proto.Unmarshal(rekey.NewDesc, &desc); err != nil {
 			return nil, errors.Wrapf(err, "unmarshalling rekey descriptor for old table id %d", rekey.OldID)
 		}
 		table := desc.GetTable()

--- a/pkg/ccl/utilccl/licenseccl/license.go
+++ b/pkg/ccl/utilccl/licenseccl/license.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -45,7 +46,7 @@ func Decode(s string) (*License, error) {
 		return nil, errors.Wrap(err, "invalid license string")
 	}
 	var lic License
-	if err := lic.Unmarshal(data); err != nil {
+	if err := proto.Unmarshal(data, &lic); err != nil {
 		return nil, errors.Wrap(err, "invalid license string")
 	}
 	return &lic, nil

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1476,7 +1476,7 @@ func (s *adminServer) queryZone(
 	}
 
 	var zone config.ZoneConfig
-	if err := zone.Unmarshal(zoneBytes); err != nil {
+	if err := proto.Unmarshal(zoneBytes, &zone); err != nil {
 		return config.ZoneConfig{}, false, err
 	}
 	return zone, true, nil

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/gogo/protobuf/proto"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -366,7 +367,7 @@ func decodeSessionCookie(encodedCookie *http.Cookie) (*serverpb.SessionCookie, e
 		return nil, errors.Wrap(err, "session cookie could not be decoded")
 	}
 	var sessionCookieValue serverpb.SessionCookie
-	if err := sessionCookieValue.Unmarshal(cookieBytes); err != nil {
+	if err := proto.Unmarshal(cookieBytes, &sessionCookieValue); err != nil {
 		return nil, errors.Wrap(err, "session cookie could not be unmarshalled")
 	}
 	return &sessionCookieValue, nil

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -334,7 +335,7 @@ func makeMockRecorder(t *testing.T) *mockRecorder {
 		}
 		rec.last.rawReportBody = string(body)
 		// TODO(dt): switch on the request path to handle different request types.
-		if err := rec.last.DiagnosticReport.Unmarshal(body); err != nil {
+		if err := proto.Unmarshal(body, &rec.last.DiagnosticReport); err != nil {
 			panic(err)
 		}
 	}))

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -55,7 +56,7 @@ func (th *testClusterWithHelpers) getVersionFromSelect(i int) string {
 		th.Fatalf("%d: %s (%T)", i, err, err)
 	}
 	var v cluster.ClusterVersion
-	if err := v.Unmarshal([]byte(version)); err != nil {
+	if err := proto.Unmarshal([]byte(version), &v); err != nil {
 		th.Fatalf("%d: %s", i, err)
 	}
 	return v.MinimumVersion.String()

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -271,7 +272,7 @@ func versionTransformer(
 		}
 	}
 
-	if err := oldV.Unmarshal(curRawProto); err != nil {
+	if err := proto.Unmarshal(curRawProto, &oldV); err != nil {
 		return nil, nil, err
 	}
 	if versionBump == nil {

--- a/pkg/sql/jobs/jobs_test.go
+++ b/pkg/sql/jobs/jobs_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -60,7 +61,7 @@ func (expected *expectation) verify(id *int64, expectedStatus jobs.Status) error
 	}
 
 	var payload jobs.Payload
-	if err := payload.Unmarshal(payloadBytes); err != nil {
+	if err := proto.Unmarshal(payloadBytes, &payload); err != nil {
 		return err
 	}
 

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/gogo/protobuf/proto"
 )
 
 // Makes an IndexDescriptor with all columns being ascending.
@@ -1103,7 +1104,7 @@ func TestKeysPerRow(t *testing.T) {
 				`SELECT descriptor FROM system.descriptor ORDER BY id DESC LIMIT 1`)
 			row.Scan(&descBytes)
 			var desc Descriptor
-			if err := desc.Unmarshal(descBytes); err != nil {
+			if err := proto.Unmarshal(descBytes, &desc); err != nil {
 				t.Fatalf("%+v", err)
 			}
 

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -2282,15 +2283,15 @@ func (ncc *noConfChangeTestHandler) HandleRaftRequest(
 	for i, e := range req.Message.Entries {
 		if e.Type == raftpb.EntryConfChange {
 			var cc raftpb.ConfChange
-			if err := cc.Unmarshal(e.Data); err != nil {
+			if err := proto.Unmarshal(e.Data, &cc); err != nil {
 				panic(err)
 			}
 			var ccCtx storage.ConfChangeContext
-			if err := ccCtx.Unmarshal(cc.Context); err != nil {
+			if err := proto.Unmarshal(cc.Context, &ccCtx); err != nil {
 				panic(err)
 			}
 			var command storagebase.RaftCommand
-			if err := command.Unmarshal(ccCtx.Payload); err != nil {
+			if err := proto.Unmarshal(ccCtx.Payload, &command); err != nil {
 				panic(err)
 			}
 			if req.RangeID == ncc.rangeID {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -886,7 +886,7 @@ func (r *RocksDB) GetSSTables() SSTableInfos {
 func (r *RocksDB) getUserProperties() (enginepb.SSTUserPropertiesCollection, error) {
 	buf := cStringToGoBytes(C.DBGetUserProperties(r.rdb))
 	var ssts enginepb.SSTUserPropertiesCollection
-	if err := ssts.Unmarshal(buf); err != nil {
+	if err := proto.Unmarshal(buf, &ssts); err != nil {
 		return enginepb.SSTUserPropertiesCollection{}, err
 	}
 	if ssts.Error != "" {

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -760,7 +761,7 @@ func (r *Replica) applySnapshot(
 
 	logEntries := make([]raftpb.Entry, len(inSnap.LogEntries))
 	for i, bytes := range inSnap.LogEntries {
-		if err := logEntries[i].Unmarshal(bytes); err != nil {
+		if err := proto.Unmarshal(bytes, &logEntries[i]); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -152,7 +153,7 @@ func maybeSideloadEntriesImpl(
 				// Bad luck: we didn't have the proposal in-memory, so we'll
 				// have to unmarshal it.
 				log.Event(ctx, "proposal not already in memory; unmarshaling")
-				if err := strippedCmd.Unmarshal(data); err != nil {
+				if err := proto.Unmarshal(data, &strippedCmd); err != nil {
 					return nil, 0, err
 				}
 			}
@@ -232,7 +233,7 @@ func maybeInlineSideloadedRaftCommand(
 	ent.Data = nil // no reuse of potentially shared slice
 
 	var command storagebase.RaftCommand
-	if err := command.Unmarshal(data); err != nil {
+	if err := proto.Unmarshal(data, &command); err != nil {
 		return nil, err
 	}
 	sideloadedData, err := sideloaded.Get(ctx, ent.Index, ent.Term)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/gogo/protobuf/proto"
 	"github.com/google/btree"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -3437,8 +3438,7 @@ func sendSnapshot(
 	{
 		var ent raftpb.Entry
 		for i := range logEntries {
-			ent.Reset()
-			if err := ent.Unmarshal(logEntries[i]); err != nil {
+			if err := proto.Unmarshal(logEntries[i], &ent); err != nil {
 				return err
 			}
 			if !sniffSideloadedRaftCommand(ent.Data) {


### PR DESCRIPTION
`<proto>.Unmarshal` has surprising behavior in that it merges with the
existing data in the structure instead of over-writing it.

Add `TestProtoUnmarshal` linter.

Fixes #18407