### PR TITLE
all: require go 1.9

### DIFF
--- a/.go-version
+++ b/.go-version
@@ -1,1 +1,1 @@
-GOVERS = go1\.[89].*
+GOVERS = go1\.9.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Before you start contributing, review these [basic guidelines](https://www.cockr
    - A Go environment with a recent 64-bit version of the toolchain. Note that
     the Makefile enforces the specific version required, as it is updated
     frequently.
-   - Git 1.8+
+   - Git 1.9+
    - Bash (4+ is preferred)
    - GNU Make (3.81+ is known to work)
    - CMake 3.1+

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -101,17 +101,14 @@ RUN git clone --depth 1 https://github.com/tpoechtrager/osxcross.git \
  && mv osxcross/target /x-tools/x86_64-apple-darwin13 \
  && rm -rf osxcross
 
-# BEGIN https://github.com/docker-library/golang/blob/2a15dff/1.8/alpine3.5/Dockerfile
+# BEGIN https://github.com/docker-library/golang/blob/94e49ca/1.9/alpine3.6/Dockerfile
 
-COPY parallelbuilds-go1.8.patch /
-RUN curl -fsSL https://storage.googleapis.com/golang/go1.8.3.src.tar.gz -o golang.tar.gz \
- && echo '5f5dea2447e7dcfdc50fa6b94c512e58bfba5673c039259fd843f68829d99fa6  golang.tar.gz' | sha256sum -c - \
+RUN curl -fsSL https://storage.googleapis.com/golang/go1.9.src.tar.gz -o golang.tar.gz \
+ && echo 'a4ab229028ed167ba1986825751463605264e44868362ca8e7accc8be057e993  golang.tar.gz' | sha256sum -c - \
  && tar -C /usr/local -xzf golang.tar.gz \
  && rm golang.tar.gz \
  && cd /usr/local/go/src \
- && patch -p2 -i /parallelbuilds-go1.8.patch \
  && GOROOT_BOOTSTRAP=$(go env GOROOT) CC=clang CXX=clang++ ./make.bash \
- && rm -rf /*.patch \
  && apt-get autoremove -y golang
 
 ENV GOPATH /go
@@ -120,7 +117,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
-# END https://github.com/docker-library/golang/blob/2a15dff/1.8/alpine3.5/Dockerfile
+# END https://github.com/docker-library/golang/blob/94e49ca/1.9/alpine3.6/Dockerfile
 
 RUN chmod -R a+w $(go env GOTOOLDIR)
 

--- a/build/bootstrap/bootstrap-go.sh
+++ b/build/bootstrap/bootstrap-go.sh
@@ -4,7 +4,7 @@
 
 set -euxo pipefail
 
-GOVERSION=1.8
+GOVERSION=1.9
 
 sudo apt-get install -y gcc g++ make
 
@@ -14,10 +14,6 @@ rm -fr ~/go-bootstrap ~/${GOROOT}
 mkdir -p ~/go-bootstrap ~/${GOROOT} ~/go
 curl "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz" | tar -C ~/go-bootstrap -xz --strip=1
 curl "https://storage.googleapis.com/golang/go${GOVERSION}.src.tar.gz" | tar --strip-components=1 -C ~/${GOROOT} -xz
-
-# Apply the patch for the "major" go version (e.g. 1.6, 1.7).
-GOPATCHVER=$(echo ${GOVERSION} | grep -o "^[0-9]\+\.[0-9]\+")
-patch -p1 -d ~/${GOROOT} < "bootstrap/parallelbuilds-go${GOPATCHVER}.patch"
 
 (cd ~/${GOROOT}/src && GOROOT_BOOTSTRAP=~/go-bootstrap ./make.bash)
 

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20170706-162700
+version=20170913-074615
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")"


### PR DESCRIPTION
We will start using go 1.9 features (like `math/bits` or `testing.T.Helper()`)
soon.