### PR TITLE
sql: omit vars in replaced filter expressions

### DIFF
--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -237,6 +237,7 @@ func (p *planner) selectIndex(
 			s.filter = nil
 		}
 	}
+	s.filterVars.Rebind(s.filter, true, false)
 
 	s.reverse = c.reverse
 

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -182,3 +182,19 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT "name", age FROM a);
 3  scan    ·            ·             ("name"[omitted], age[omitted], rowid[hidden,omitted])  ·
 3  ·       table        a@primary     ·                                                       ·
 3  ·       spans        ALL           ·                                                       ·
+
+# Ensure that variables within filter conditions are omitted (not decoded) if
+# the filter condition is replaced by an index search.
+
+statement ok
+CREATE TABLE ab (a INT, b INT, PRIMARY KEY (a, b));
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT count(*) FROM ab WHERE a=1
+----
+0  group   ·            ·             ("count(*)")              ·
+0  ·       aggregate 0  count_rows()  ·                         ·
+1  render  ·            ·             ()                        ·
+2  scan    ·            ·             (a[omitted], b[omitted])  ·
+2  ·       table        ab@primary    ·                         ·
+2  ·       spans        /1-/2         ·                         ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -614,7 +614,7 @@ EXPLAIN (METADATA) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) O
 0  nosort  ·      ·            (b, c)                 +b,+c,key
 0  ·       order  +b,+c        ·                      ·
 1  render  ·      ·            (b, c, a[omitted])     =a,+b,+c,key
-2  scan    ·      ·            (a, b, c, d[omitted])  =a,+b,+c,key
+2  scan    ·      ·            (a[omitted], b, c, d[omitted])  =a,+b,+c,key
 2  ·       table  abc@primary  ·                      ·
 2  ·       spans  /1-/2        ·                      ·
 


### PR DESCRIPTION
Previously, when a filter expression is completely replaced by an index
constraint, the expression tree was not properly reanalyzed to see which
columns were necessary to decode during row fetching. This led to
unnecessary extra column decodes.

This patch makes sure that the filter expression is properly reanalyzed.
Removing these extra decodes gives a 15-20% performance improvement for
filtered `SELECT COUNT(*)` queries on an index prefix. For example:

```
CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b));

SELECT COUNT(*) FROM t WHERE a = 0;
```

Performance on the above query on a single node with 1000000 rows in the
table where `a = 0` improved by 18% on my machine.

cc @danhhz since we were talking about this