### PR TITLE
util: improvements to the union-find data structure

### DIFF
--- a/pkg/util/union_find.go
+++ b/pkg/util/union_find.go
@@ -14,6 +14,11 @@
 
 package util
 
+import (
+	"fmt"
+	"math"
+)
+
 // UnionFind implements the union find structure, with union by rank and path
 // compression heuristics. Find and Union operations are effectively constant
 // time. The data structure uses O(N) space where N is the largest element. It
@@ -27,28 +32,42 @@ type UnionFind struct {
 // are part of the same tree.
 type ufNode struct {
 	// parent is the parent node. All nodes in a tree are part of the same group;
-	// the representative of that group is the root node.
-	parent int32
+	// internally, the representative of that group is the root node. A tree root
+	// has itself as parent.
+	parent uint32
 	// the rank is the maximum depth of the subtree rooted at this node; only used
 	// for the root of each tree.
-	rank int32
+	rank uint32
+	// minimum element that is part of this group; only used for the root of each
+	// tree. This is the externally visible representative of the group; we do
+	// this to make the structure behave predictably and simplify things like
+	// checking equality of two structures.
+	minElement uint32
 }
 
-// Find returns the representative of the group that n is part of.
+// Find returns the representative of the group that n is part of; this is the
+// smallest element of that group.
 // Two elements a, b are in the same group iff Find(a) == Find(b).
-func (f *UnionFind) Find(n int32) int32 {
-	if int(n) >= len(f.nodes) {
+func (f *UnionFind) Find(n int) int {
+	_, minElem := f.findRoot(n)
+	return minElem
+}
+
+// findRoot returns the root of the subtree containing n and the smallest
+// element in this set.
+func (f *UnionFind) findRoot(n int) (subtreeRoot int, minElement int) {
+	if n >= len(f.nodes) {
 		// n was never touched by a Union call.
-		return n
+		return n, n
 	}
 
-	parent := f.nodes[n].parent
+	parent := f.nodes[uint32(n)].parent
 	grandparent := f.nodes[parent].parent
 
 	// Fast path if the element is connected directly to the root of the group (or
 	// is the root).
 	if grandparent == parent {
-		return parent
+		return int(parent), int(f.nodes[parent].minElement)
 	}
 
 	i := grandparent
@@ -62,35 +81,69 @@ func (f *UnionFind) Find(n int32) int32 {
 
 	// Compress the path.
 	root := i
-	for i := n; i != root; {
+	for i := uint32(n); i != root; {
 		i, f.nodes[i].parent = f.nodes[i].parent, root
 	}
-	return root
+	return int(root), int(f.nodes[root].minElement)
 }
 
 // Union joins the groups to which a and b belong.
-func (f *UnionFind) Union(a, b int32) {
+func (f *UnionFind) Union(a, b int) {
+	if a > math.MaxUint32 || a < 0 || b > math.MaxUint32 || b < 0 {
+		panic(fmt.Sprintf("invalid args %d, %d", a, b))
+	}
 	// Substitute a, b with the roots of the corresponding trees.
-	a = f.Find(a)
-	b = f.Find(b)
+	a, _ = f.findRoot(a)
+	b, _ = f.findRoot(b)
 	if a == b {
 		// Already part of the same group.
 		return
 	}
 	// Extend the slice with single-element groups as necessary.
-	for i := int32(len(f.nodes)); i <= a || i <= b; i++ {
-		f.nodes = append(f.nodes, ufNode{parent: i})
+	for i := len(f.nodes); i <= a || i <= b; i++ {
+		f.nodes = append(f.nodes, ufNode{parent: uint32(i), minElement: uint32(i)})
 	}
 	an := &f.nodes[a]
 	bn := &f.nodes[b]
 	if an.rank < bn.rank {
 		// A's tree is shallower than B's tree; choose B as the root.
-		an.parent = b
+		an.parent = uint32(b)
+		if an.minElement < bn.minElement {
+			bn.minElement = an.minElement
+		}
 	} else {
 		// Choose A as the root.
-		bn.parent = a
+		bn.parent = uint32(a)
 		if an.rank == bn.rank {
 			an.rank++
 		}
+		if bn.minElement < an.minElement {
+			an.minElement = bn.minElement
+		}
 	}
+}
+
+// Len returns the number of elements up to and including the last element that
+// is part of a multi-element group. In other words, if X is the largest value
+// which was passed to a Union operation, the length is X+1.
+func (f *UnionFind) Len() int {
+	return len(f.nodes)
+}
+
+// Copy returns a copy of the structure which can be modified independently.
+func (f *UnionFind) Copy() UnionFind {
+	return UnionFind{nodes: append([]ufNode(nil), f.nodes...)}
+}
+
+// Equals returns true if the two structures have the same sets.
+func (f *UnionFind) Equals(rhs UnionFind) bool {
+	if len(f.nodes) != len(rhs.nodes) {
+		return false
+	}
+	for i := range f.nodes {
+		if f.Find(i) != rhs.Find(i) {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/util/union_find_test.go
+++ b/pkg/util/union_find_test.go
@@ -22,15 +22,15 @@ import (
 
 func TestUnionFind(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
-	for _, n := range []int32{2, 3, 4, 10, 50, 100, 1000} {
+	for _, n := range []int{2, 3, 4, 10, 50, 100, 1000} {
 		group := make([]int, n)
 		for i := range group {
 			group[i] = i
 		}
 		uf := UnionFind{}
-		for i := int32(0); i < 100*n; i++ {
-			x := rng.Int31n(n)
-			y := rng.Int31n(n)
+		for i := 0; i < 100*n; i++ {
+			x := rng.Intn(n)
+			y := rng.Intn(n)
 			// 99% of the time we check if x and y are in the same group; 1% of
 			// the time we union them.
 			if rng.Intn(100) > 0 {
@@ -53,5 +53,37 @@ func TestUnionFind(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestUnionFindCopyEquals(t *testing.T) {
+	// Verify equality of two set groups that are equivalent but were generated
+	// with different operations.
+	var x UnionFind
+	x.Union(1, 2)
+	x.Union(2, 3)
+	x.Union(3, 4)
+	x.Union(6, 7)
+
+	var y UnionFind
+	y.Union(3, 1)
+	y.Union(2, 4)
+	y.Union(1, 2)
+	y.Union(6, 7)
+	if !x.Equals(y) || !y.Equals(x) {
+		t.Errorf("identical sets not equal")
+	}
+
+	y = x.Copy()
+	if !x.Equals(y) || !y.Equals(x) {
+		t.Errorf("identical sets not equal")
+	}
+	y.Union(1, 6)
+	if x.Equals(y) || y.Equals(x) {
+		t.Errorf("different sets equal")
+	}
+	x.Union(1, 6)
+	if !x.Equals(y) || !y.Equals(x) {
+		t.Errorf("identical sets not equal")
 	}
 }


### PR DESCRIPTION
I've been working on adding equivalency groups to `sql.orderingInfo` and some
shortcomings of the union-find implementation became apparent.

The group representative chosen by the structure depends on the set of union
operations; this complicates some things (like displaying information or
checking if two structures are equal). This change augments the structure to
keep track of the minimum element in each group and always return that as the
representative.

In addition, the interface is improved to operate on ints and eliminate uint32
casts; finally, we add Copy and Equals methods.