### PR TITLE
storage: fix two snapshot-related sideloading problems

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1121,14 +1121,24 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 	mtc.stores[0].ForceReplicationScanAndProcess()
 
 	// The range should become available on every node.
+	var r *storage.Replica // from the last store
 	testutils.SucceedsSoon(t, func() error {
+		rs := roachpb.RSpan{
+			Key: roachpb.RKey("a"), EndKey: roachpb.RKey("z"),
+		}
 		for _, s := range mtc.stores {
-			r := s.LookupReplica(roachpb.RKey("a"), roachpb.RKey("b"))
+			r = s.LookupReplica(rs.Key, rs.EndKey)
 			if r == nil {
-				return errors.Errorf("expected replica for keys \"a\" - \"b\"")
+				return errors.Errorf("expected replica for span %v", rs)
 			}
 			if n := s.ReservationCount(); n != 0 {
 				return errors.Errorf("expected 0 reservations, but found %d", n)
+			}
+			if len(r.Desc().Replicas) != 3 {
+				// This fails even after the preemptive snapshot has arrived and
+				// only goes through once the replica has properly caught up to
+				// the fully replicated descriptor.
+				return errors.Errorf("not fully initialized")
 			}
 		}
 		return nil
@@ -1152,6 +1162,23 @@ func TestStoreRangeUpReplicate(t *testing.T) {
 	}
 	if generated != preemptiveApplied {
 		t.Fatalf("expected %d preemptive snapshots, but found %d", generated, preemptiveApplied)
+	}
+
+	r.PutBogusSideloadedData()
+
+	againR, _, err := mtc.stores[2].GetOrCreateReplica(
+		context.Background(),
+		r.RangeID,
+		0,   // replicaID
+		nil, // fromReplica
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	againR.RaftUnlock()
+
+	if !againR.HasBogusSideloadedData() {
+		t.Fatalf("sideloaded storage changed after fake message to replicaID zero")
 	}
 }
 

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -176,6 +176,16 @@ func (s *Store) SetReplicaScannerActive(active bool) {
 	s.setScannerActive(active)
 }
 
+// GetOrCreateReplica passes through to its lowercase sibling.
+func (s *Store) GetOrCreateReplica(
+	ctx context.Context,
+	rangeID roachpb.RangeID,
+	replicaID roachpb.ReplicaID,
+	creatingReplica *roachpb.ReplicaDescriptor,
+) (*Replica, bool, error) {
+	return s.getOrCreateReplica(ctx, rangeID, replicaID, creatingReplica)
+}
+
 func (s *Store) SetRebalancesDisabled(v bool) {
 	var i int32
 	if v {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -814,7 +814,9 @@ func (r *Replica) handleReplicatedEvalResult(
 		// to and including the most recently truncated index.
 		r.store.raftEntryCache.clearTo(r.RangeID, newTruncState.Index+1)
 
-		// Truncate the sideloaded storage.
+		// Truncate the sideloaded storage. Note that this is safe only if the new truncated state
+		// is durably on disk (i.e.) synced. This is true at the time of writing but unfortunately
+		// could rot.
 		{
 			log.Eventf(ctx, "truncating sideloaded storage up to (and including) index %d", newTruncState.Index)
 			if err := r.raftMu.sideloaded.TruncateTo(ctx, newTruncState.Index+1); err != nil {

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -338,6 +338,11 @@ func TestRaftSSTableSideloadingInline(t *testing.T) {
 				ec.addEntries(rangeID, []raftpb.Entry{mkEnt(v2, 5, 6, &sstFat)})
 			}, expTrace: "using cache hit",
 		},
+		"v2-fat-without-file": {
+			thin: mkEnt(v2, 5, 6, &sstFat), fat: mkEnt(v2, 5, 6, &sstFat),
+			setup:    func(ec *raftEntryCache, ss sideloadStorage) {},
+			expTrace: "already inlined",
+		},
 	}
 
 	runOne := func(k string, test testCase) {


### PR DESCRIPTION
I'll cherry-pick these when they're in.

```
    storage: don't clobber sideloaded storage

    `tryGetOrCreateReplica` was using the incoming `replicaID` to create the
    sideloaded storage. This was incorrect because that `Replica` may already
    have had a replicaID in which case we were silently switching out the
    sideloaded storage. The particular instance in which this was observed as
    a problem was the following:

    1. Replica has nonzero replicaID
    1. it receives incoming preemptive snapshot message
    1. that message erroneously replaces the sideloaded storage with one for
       replicaID zero
    1. a sideloaded proposal applies; gets written to replicaID zero storage
    1. a regular Raft message arrives and again resets the sideload storage (to its
       correct replicaID)
    1. when this Replica attempts to send a snapshot, it won't find the sideloaded
       file for that log entry.

    Added a test that fails before, succeeds after.
```

```
    storage: handle inlined entries when inlining sideloaded data

    When a preemptive snapshot is applied, we (have to) write "fat" entries into the
    log because we don't have a sideloaded storage location yet (no replicaID).

    However, when that node itself later tries to create snapshot, it ends up in the
    situation in which an entry has the sideloading raft command version, but isn't
    actually on disk (but instead already inlined). We weren't handling that case
    correctly, resulting in (the first half of)
    https://github.com/cockroachdb/cockroach/issues/18324#issuecomment-328929342.

    Remedied that and updated TestRaftSSTableSideloadingInline so that it fails before
    the fix and passes after.
```