### PR TITLE
cherrypick-1.1: storage: Fix buggy comparison of lastAddedTime in replicate queue

### DIFF
--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -338,7 +338,7 @@ func (rq *replicateQueue) processOneChange(
 	case AllocatorRemove:
 		log.VEventf(ctx, 1, "removing a replica")
 		lastReplAdded, lastAddedTime := repl.LastReplicaAdded()
-		if timeutil.Since(lastAddedTime) < newReplicaGracePeriod {
+		if timeutil.Since(lastAddedTime) > newReplicaGracePeriod {
 			lastReplAdded = 0
 		}
 		candidates := filterUnremovableReplicas(repl.RaftStatus(), desc.Replicas, lastReplAdded)


### PR DESCRIPTION
Added by 54618ea5c874de8d646e8b814b79be693c7b7b86. This is what I get
for testing out the initial version of the PR but not the final version.

Fixes #18456 

@cockroachdb/release 