### PR TITLE
storage: preserve sideloaded files on replicaID bump

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"os"
 	"reflect"
 	"sort"
 	"sync/atomic"
@@ -847,18 +848,41 @@ func (r *Replica) setReplicaIDRaftMuLockedMuLocked(replicaID roachpb.ReplicaID) 
 	// 	// TODO(bdarnell): clean up previous raftGroup (update peers)
 	// }
 
-	// Initialize the new sideloaded storage.
-	{
-		var err error
-		if r.raftMu.sideloaded, err = newDiskSideloadStorage(
-			r.store.cfg.Settings, r.mu.state.Desc.RangeID, replicaID, r.store.Engine().GetAuxiliaryDir(),
-		); err != nil {
-			return errors.Wrap(err, "while initializing sideloaded storage")
+	// Initialize or update the sideloaded storage. If the sideloaded storage
+	// already exists (which is iff the previous replicaID was non-zero), then
+	// we have to move the contained files over (this corresponds to the case in
+	// which our replica is removed and re-added to the range, without having
+	// the replica GC'ed in the meantime).
+	//
+	// Note that we can't race with a concurrent replicaGC here because both that
+	// and this is under raftMu.
+	var prevSideloadedDir string
+	if ss := r.raftMu.sideloaded; ss != nil {
+		prevSideloadedDir = ss.Dir()
+	}
+	var err error
+	if r.raftMu.sideloaded, err = newDiskSideloadStorage(
+		r.store.cfg.Settings, r.mu.state.Desc.RangeID, replicaID, r.store.Engine().GetAuxiliaryDir(),
+	); err != nil {
+		return errors.Wrap(err, "while initializing sideloaded storage")
+	}
+	if prevSideloadedDir != "" {
+		if _, err := os.Stat(prevSideloadedDir); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+			// Old directory not found.
+		} else {
+			// Old directory found, so we have something to move over to the new one.
+			if err := os.Rename(prevSideloadedDir, r.raftMu.sideloaded.Dir()); err != nil {
+				return errors.Wrap(err, "while moving sideloaded directory")
+			}
 		}
 	}
 
 	previousReplicaID := r.mu.replicaID
 	r.mu.replicaID = replicaID
+
 	if replicaID >= r.mu.minReplicaID {
 		r.mu.minReplicaID = replicaID + 1
 	}

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -62,6 +62,9 @@ var errSideloadedFileNotFound = errors.New("sideloaded file not found")
 // sideloadStorage is the interface used for Raft SSTable sideloading.
 // Implementations do not need to be thread safe.
 type sideloadStorage interface {
+	// The directory in which the sideloaded files are stored. May or may not
+	// exist.
+	Dir() string
 	// Writes the given contents to the file specified by the given index and
 	// term. Does not perform the write if the file exists.
 	PutIfNotExists(_ context.Context, index, term uint64, contents []byte) error

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -58,6 +58,10 @@ func (ss *diskSideloadStorage) createDir() error {
 	return err
 }
 
+func (ss *diskSideloadStorage) Dir() string {
+	return ss.dir
+}
+
 func (ss *diskSideloadStorage) PutIfNotExists(
 	ctx context.Context, index, term uint64, contents []byte,
 ) error {

--- a/pkg/storage/replica_sideload_inmem.go
+++ b/pkg/storage/replica_sideload_inmem.go
@@ -51,8 +51,15 @@ func newInMemSideloadStorage(
 		m:      make(map[slKey][]byte),
 	}, nil
 }
+
 func (ss *inMemSideloadStorage) key(index, term uint64) slKey {
 	return slKey{index: index, term: term}
+}
+
+func (ss *inMemSideloadStorage) Dir() string {
+	// We could return ss.prefix but real code calling this would then take the
+	// result in look for it on the actual file system.
+	panic("unsupported")
 }
 
 func (ss *inMemSideloadStorage) PutIfNotExists(


### PR DESCRIPTION
If a replica gets removed from and subsequently re-added to a store without
being garbage collected in the meantime, its replicaID will change but it will
otherwise keep most of its state.

Before this commit, we would create a new sideloaded storage for the new
replicaID, effectively losing the old one. Now, the contents are moved along as
well.

Observed by @bdarnell in
https://github.com/cockroachdb/cockroach/pull/18462#issuecomment-329013272

I'll cherry-pick this into 1.1.