### PR TITLE
sql/logictest: print statement that caused error

### DIFF
--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -1435,7 +1435,7 @@ func (t *logicTest) execQuery(query logicQuery) error {
 		var buf bytes.Buffer
 		tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
 
-		fmt.Fprintf(&buf, "%s: \nexpected:\n", query.pos)
+		fmt.Fprintf(&buf, "%s: %s\nexpected:\n", query.pos, query.sql)
 		for _, expectedResultRaw := range query.expectedResultsRaw {
 			fmt.Fprintf(tw, "    %s\n", expectedResultRaw)
 		}


### PR DESCRIPTION
This improves TeamCity ergonomics. Previously a failure contained the
line with the statement that caused the failure, but not the statement
itself.