### PR TITLE
storage: deflake TestSnapshotAfterTruncation/differentTerm

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -772,29 +772,32 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 			}
 			mtc.waitForValues(key, []int64{incAB, incAB, incAB})
 
-			// Verify that the cached index and term (Replica.mu.last{Index,Term}))
-			// on all of the replicas is the same. #18327 fixed an issue where the
-			// cached term was left unchanged after applying a snapshot leading to a
-			// persistently unavailable range.
-			repl0, err = mtc.stores[0].GetReplica(1)
-			if err != nil {
-				t.Fatal(err)
-			}
-			expectedLastIndex, _ := repl0.GetLastIndex()
-			expectedLastTerm := repl0.GetCachedLastTerm()
-
-			for i := 1; i < len(mtc.stores); i++ {
-				repl1, err := mtc.stores[i].GetReplica(1)
+			testutils.SucceedsSoon(t, func() error {
+				// Verify that the cached index and term (Replica.mu.last{Index,Term}))
+				// on all of the replicas is the same. #18327 fixed an issue where the
+				// cached term was left unchanged after applying a snapshot leading to a
+				// persistently unavailable range.
+				repl0, err = mtc.stores[0].GetReplica(1)
 				if err != nil {
 					t.Fatal(err)
 				}
-				if lastIndex, _ := repl1.GetLastIndex(); expectedLastIndex != lastIndex {
-					t.Fatalf("%d: expected last index %d, but found %d", i, expectedLastIndex, lastIndex)
+				expectedLastIndex, _ := repl0.GetLastIndex()
+				expectedLastTerm := repl0.GetCachedLastTerm()
+
+				for i := 1; i < len(mtc.stores); i++ {
+					repl1, err := mtc.stores[i].GetReplica(1)
+					if err != nil {
+						return err
+					}
+					if lastIndex, _ := repl1.GetLastIndex(); expectedLastIndex != lastIndex {
+						return fmt.Errorf("%d: expected last index %d, but found %d", i, expectedLastIndex, lastIndex)
+					}
+					if lastTerm := repl1.GetCachedLastTerm(); expectedLastTerm != lastTerm {
+						return fmt.Errorf("%d: expected last term %d, but found %d", i, expectedLastTerm, lastTerm)
+					}
 				}
-				if lastTerm := repl1.GetCachedLastTerm(); expectedLastTerm != lastTerm {
-					t.Fatalf("%d: expected last term %d, but found %d", i, expectedLastTerm, lastTerm)
-				}
-			}
+				return nil
+			})
 		})
 	}
 }


### PR DESCRIPTION
Under stress, we might have additional leader elections even after the
snapshot occurs. Add a SucceedsSoon loop to wait for the term to
stabilize.

Fixes #18476