### PR TITLE
libroach: log estimated-pending-compaction-bytes

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -2025,11 +2025,14 @@ DBStatus DBImpl::GetStats(DBStatsResult* stats) {
   const rocksdb::Options &opts = rep->GetOptions();
   const std::shared_ptr<rocksdb::Statistics> &s = opts.statistics;
 
-  std::string memtable_total_size;
-  rep->GetProperty("rocksdb.cur-size-all-mem-tables", &memtable_total_size);
+  uint64_t memtable_total_size;
+  rep->GetIntProperty("rocksdb.cur-size-all-mem-tables", &memtable_total_size);
 
-  std::string table_readers_mem_estimate;
-  rep->GetProperty("rocksdb.estimate-table-readers-mem", &table_readers_mem_estimate);
+  uint64_t table_readers_mem_estimate;
+  rep->GetIntProperty("rocksdb.estimate-table-readers-mem", &table_readers_mem_estimate);
+
+  uint64_t pending_compaction_bytes_estimate;
+  rep->GetIntProperty("rocksdb.estimate-pending-compaction-bytes", &pending_compaction_bytes_estimate);
 
   stats->block_cache_hits = (int64_t)s->getTickerCount(rocksdb::BLOCK_CACHE_HIT);
   stats->block_cache_misses = (int64_t)s->getTickerCount(rocksdb::BLOCK_CACHE_MISS);
@@ -2041,10 +2044,11 @@ DBStatus DBImpl::GetStats(DBStatsResult* stats) {
     (int64_t)s->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_USEFUL);
   stats->memtable_hits = (int64_t)s->getTickerCount(rocksdb::MEMTABLE_HIT);
   stats->memtable_misses = (int64_t)s->getTickerCount(rocksdb::MEMTABLE_MISS);
-  stats->memtable_total_size = std::stoll(memtable_total_size);
+  stats->memtable_total_size = memtable_total_size;
   stats->flushes = (int64_t)event_listener->GetFlushes();
   stats->compactions = (int64_t)event_listener->GetCompactions();
-  stats->table_readers_mem_estimate = std::stoll(table_readers_mem_estimate);
+  stats->table_readers_mem_estimate = table_readers_mem_estimate;
+  stats->pending_compaction_bytes_estimate = pending_compaction_bytes_estimate;
   return kSuccess;
 }
 

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -235,6 +235,7 @@ typedef struct {
   int64_t flushes;
   int64_t compactions;
   int64_t table_readers_mem_estimate;
+  int64_t pending_compaction_bytes_estimate;
 } DBStatsResult;
 
 DBStatus DBGetStats(DBEngine* db, DBStatsResult* stats);

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -258,18 +258,19 @@ type Batch interface {
 // This is a good resource describing RocksDB's memory-related stats:
 // https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
 type Stats struct {
-	BlockCacheHits           int64
-	BlockCacheMisses         int64
-	BlockCacheUsage          int64
-	BlockCachePinnedUsage    int64
-	BloomFilterPrefixChecked int64
-	BloomFilterPrefixUseful  int64
-	MemtableHits             int64
-	MemtableMisses           int64
-	MemtableTotalSize        int64
-	Flushes                  int64
-	Compactions              int64
-	TableReadersMemEstimate  int64
+	BlockCacheHits                 int64
+	BlockCacheMisses               int64
+	BlockCacheUsage                int64
+	BlockCachePinnedUsage          int64
+	BloomFilterPrefixChecked       int64
+	BloomFilterPrefixUseful        int64
+	MemtableHits                   int64
+	MemtableMisses                 int64
+	MemtableTotalSize              int64
+	Flushes                        int64
+	Compactions                    int64
+	TableReadersMemEstimate        int64
+	PendingCompactionBytesEstimate int64
 }
 
 // PutProto sets the given key to the protobuf-serialized byte string

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -903,18 +903,19 @@ func (r *RocksDB) GetStats() (*Stats, error) {
 		return nil, err
 	}
 	return &Stats{
-		BlockCacheHits:           int64(s.block_cache_hits),
-		BlockCacheMisses:         int64(s.block_cache_misses),
-		BlockCacheUsage:          int64(s.block_cache_usage),
-		BlockCachePinnedUsage:    int64(s.block_cache_pinned_usage),
-		BloomFilterPrefixChecked: int64(s.bloom_filter_prefix_checked),
-		BloomFilterPrefixUseful:  int64(s.bloom_filter_prefix_useful),
-		MemtableHits:             int64(s.memtable_hits),
-		MemtableMisses:           int64(s.memtable_misses),
-		MemtableTotalSize:        int64(s.memtable_total_size),
-		Flushes:                  int64(s.flushes),
-		Compactions:              int64(s.compactions),
-		TableReadersMemEstimate:  int64(s.table_readers_mem_estimate),
+		BlockCacheHits:                 int64(s.block_cache_hits),
+		BlockCacheMisses:               int64(s.block_cache_misses),
+		BlockCacheUsage:                int64(s.block_cache_usage),
+		BlockCachePinnedUsage:          int64(s.block_cache_pinned_usage),
+		BloomFilterPrefixChecked:       int64(s.bloom_filter_prefix_checked),
+		BloomFilterPrefixUseful:        int64(s.bloom_filter_prefix_useful),
+		MemtableHits:                   int64(s.memtable_hits),
+		MemtableMisses:                 int64(s.memtable_misses),
+		MemtableTotalSize:              int64(s.memtable_total_size),
+		Flushes:                        int64(s.flushes),
+		Compactions:                    int64(s.compactions),
+		TableReadersMemEstimate:        int64(s.table_readers_mem_estimate),
+		PendingCompactionBytesEstimate: int64(s.pending_compaction_bytes_estimate),
 	}, nil
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4180,7 +4180,8 @@ func (s *Store) ComputeMetrics(ctx context.Context, tick int) error {
 		// Log this metric infrequently.
 		if tick%60 == 0 /* every 10m */ {
 			log.Infof(ctx, "sstables (read amplification = %d):\n%s", readAmp, sstables)
-			log.Info(ctx, rocksdb.GetCompactionStats())
+			log.Infof(ctx, "%s\nestimated_pending_compaction_bytes: %s",
+				rocksdb.GetCompactionStats(), humanizeutil.IBytes(stats.PendingCompactionBytesEstimate))
 		}
 	}
 	return nil


### PR DESCRIPTION
RocksDB will slow down writes when pending-compaction-bytes exceeds
64GB. This shouldn't happen under normal operation, but appears to be
happening during a restore.

See #17902