### PR TITLE
cherrypick-1.1: storage: preserve sideloaded files on replicaID bump

### DIFF
--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -61,6 +61,9 @@ var errSideloadedFileNotFound = errors.New("sideloaded file not found")
 // sideloadStorage is the interface used for Raft SSTable sideloading.
 // Implementations do not need to be thread safe.
 type sideloadStorage interface {
+	// The directory in which the sideloaded files are stored. May or may not
+	// exist.
+	Dir() string
 	// Writes the given contents to the file specified by the given index and
 	// term. Does not perform the write if the file exists.
 	PutIfNotExists(_ context.Context, index, term uint64, contents []byte) error

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -58,6 +58,10 @@ func (ss *diskSideloadStorage) createDir() error {
 	return err
 }
 
+func (ss *diskSideloadStorage) Dir() string {
+	return ss.dir
+}
+
 func (ss *diskSideloadStorage) PutIfNotExists(
 	ctx context.Context, index, term uint64, contents []byte,
 ) error {

--- a/pkg/storage/replica_sideload_inmem.go
+++ b/pkg/storage/replica_sideload_inmem.go
@@ -51,8 +51,15 @@ func newInMemSideloadStorage(
 		m:      make(map[slKey][]byte),
 	}, nil
 }
+
 func (ss *inMemSideloadStorage) key(index, term uint64) slKey {
 	return slKey{index: index, term: term}
+}
+
+func (ss *inMemSideloadStorage) Dir() string {
+	// We could return ss.prefix but real code calling this would then take the
+	// result in look for it on the actual file system.
+	panic("unsupported")
 }
 
 func (ss *inMemSideloadStorage) PutIfNotExists(

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"os"
 	"reflect"
 	"regexp"
 	"sort"
@@ -881,4 +882,55 @@ func TestRaftSSTableSideloadingTruncation(t *testing.T) {
 		t.Fatalf("expected all files to be cleaned up, but found %v", sideloadStrings)
 	}
 
+}
+
+func TestRaftSSTableSideloadingUpdatedReplicaID(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tc := testContext{}
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	tc.Start(t, stopper)
+	repl := tc.repl
+	ctx := context.Background()
+
+	const (
+		index = 123
+		term  = 456
+	)
+
+	val := []byte("foo")
+
+	repl.raftMu.Lock()
+	oldDir := repl.raftMu.sideloaded.Dir()
+	err := repl.raftMu.sideloaded.PutIfNotExists(ctx, index, term, val)
+	repl.raftMu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set the ReplicaID on the replica.
+	if err := repl.setReplicaID(2); err != nil {
+		t.Fatal(err)
+	}
+
+	newDir := repl.raftMu.sideloaded.Dir()
+
+	if oldDir == newDir {
+		t.Fatalf("old and new sideloaded directory are equal: %s", oldDir)
+	}
+
+	// We assert below that oldDir moved to newDir.
+
+	repl.raftMu.Lock()
+	_, err = repl.raftMu.sideloaded.Get(ctx, index, term)
+	repl.raftMu.Unlock()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(oldDir); !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
If a replica gets removed from and subsequently re-added to a store without
being garbage collected in the meantime, its replicaID will change but it will
otherwise keep most of its state.

Before this commit, we would create a new sideloaded storage for the new
replicaID, effectively losing the old one. Now, the contents are moved along as
well.

Observed by @bdarnell in
https://github.com/cockroachdb/cockroach/pull/18462#issuecomment-329013272

cc @cockroachdb/release 