### PR TITLE
storage: improve error message for failed splits

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -1433,7 +1433,8 @@ func TestChangeReplicasDescriptorInvariant(t *testing.T) {
 	before := mtc.stores[2].Metrics().RangeSnapshotsPreemptiveApplied.Count()
 	// Attempt to add replica to the third store with the original descriptor.
 	// This should fail because the descriptor is stale.
-	if err := addReplica(2, origDesc); !testutils.IsError(err, `change replicas of r\d+ failed`) {
+	expectedErr := `change replicas of r1 failed: descriptor changed: \[expected\]`
+	if err := addReplica(2, origDesc); !testutils.IsError(err, expectedErr) {
 		t.Fatalf("got unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
When a split fails because the underlying descriptor changed provide a
more informative error messages.

Before:

```
unexpected value:
raw_bytes:"I\205B\247\003\010\001\022\000\032\001a\"\006\010\001\020\001\030\001(\002"
timestamp:<wall_time:1505319352553640907 logical:0 >
```

After:

```
descriptor changed: r1:/M{in-ax} [(n1,s1):1, next=2] != r1:{/Min-a} [(n1,s1):1, next=2]
```

See #17180