### PR TITLE
sql/sqlbase: don't read idx key if not necessary.

### DIFF
--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -46,7 +46,7 @@ func (s *Server) refreshSettings() {
 		// First we need to decode the setting name field from the index key.
 		{
 			nameRow := []sqlbase.EncDatum{{Type: tbl.Columns[0].Type}}
-			_, matches, err := sqlbase.DecodeIndexKey(a, &tbl, tbl.PrimaryIndex.ID, nameRow, nil, kv.Key)
+			_, matches, err := sqlbase.DecodeIndexKey(a, &tbl, &tbl.PrimaryIndex, nameRow, nil, kv.Key)
 			if err != nil {
 				return errors.Wrap(err, "failed to decode key")
 			}

--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -31,7 +31,7 @@ import (
 
 // RefreshSettings starts a settings-changes listener.
 func (s *Server) refreshSettings() {
-	tbl := sqlbase.SettingsTable
+	tbl := &sqlbase.SettingsTable
 
 	a := &sqlbase.DatumAlloc{}
 	settingsTablePrefix := keys.MakeTablePrefix(uint32(tbl.ID))
@@ -46,7 +46,7 @@ func (s *Server) refreshSettings() {
 		// First we need to decode the setting name field from the index key.
 		{
 			nameRow := []sqlbase.EncDatum{{Type: tbl.Columns[0].Type}}
-			_, matches, err := sqlbase.DecodeIndexKey(a, &tbl, &tbl.PrimaryIndex, nameRow, nil, kv.Key)
+			_, matches, err := sqlbase.DecodeIndexKey(a, tbl, &tbl.PrimaryIndex, nameRow, nil, kv.Key)
 			if err != nil {
 				return errors.Wrap(err, "failed to decode key")
 			}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -278,7 +278,7 @@ func prettyEncDatums(vals []EncDatum) string {
 
 // ReadIndexKey decodes an index key for the fetcher's table.
 func (rf *RowFetcher) ReadIndexKey(k roachpb.Key) (remaining []byte, ok bool, err error) {
-	return DecodeIndexKey(rf.alloc, rf.desc, rf.index.ID, rf.keyVals,
+	return DecodeIndexKey(rf.alloc, rf.desc, rf.index, rf.keyVals,
 		rf.indexColumnDirs, k)
 }
 

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -61,6 +61,10 @@ type RowFetcher struct {
 	// The set of ColumnIDs that are required.
 	neededCols util.FastIntSet
 
+	// True if the index key must be decoded. This is only true if there are no
+	// needed columns and the table has no interleave children.
+	mustDecodeIndexKey bool
+
 	// Map used to get the index for columns in cols.
 	colIdxMap map[ColumnID]int
 
@@ -140,6 +144,19 @@ func (rf *RowFetcher) Init(
 				break
 			}
 		}
+	}
+
+	// If there are interleaves, we need to read the index key in order to
+	// determine whether this row is actually part of the index we're scanning.
+	// If we need to return any values from the row, we also have to read the
+	// index key to either get those values directly or determine the row's
+	// column family id to map the row values to their columns.
+	// Otherwise, we can completely avoid decoding the index key.
+	// TODO(jordan): Relax this restriction. Ideally we could skip doing key
+	// reading work if we need values from outside of the key, but not from
+	// inside of the key.
+	if !rf.neededCols.Empty() || len(rf.index.InterleavedBy) > 0 || len(rf.index.Interleave.Ancestors) > 0 {
+		rf.mustDecodeIndexKey = true
 	}
 
 	var indexColumnIDs []ColumnID
@@ -233,14 +250,18 @@ func (rf *RowFetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 			return true, nil
 		}
 
-		rf.keyRemainingBytes, ok, err = rf.ReadIndexKey(rf.kv.Key)
-		if err != nil {
-			return false, err
-		}
-		if !ok {
-			// The key did not match the descriptor, which means it's
-			// interleaved data from some other table or index.
-			continue
+		// See Init() for a detailed description of when we can get away with not
+		// reading the index key.
+		if rf.mustDecodeIndexKey {
+			rf.keyRemainingBytes, ok, err = rf.ReadIndexKey(rf.kv.Key)
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				// The key did not match the descriptor, which means it's
+				// interleaved data from some other table or index.
+				continue
+			}
 		}
 
 		// For unique secondary indexes, the index-key does not distinguish one row

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -726,7 +726,7 @@ func DecodeIndexKeyPrefix(
 func DecodeIndexKey(
 	a *DatumAlloc,
 	desc *TableDescriptor,
-	indexID IndexID,
+	index *IndexDescriptor,
 	vals []EncDatum,
 	colDirs []encoding.Direction,
 	key []byte,
@@ -735,7 +735,7 @@ func DecodeIndexKey(
 	var decodedIndexID IndexID
 	var err error
 
-	if index, err := desc.FindIndexByID(indexID); err == nil && len(index.Interleave.Ancestors) > 0 {
+	if len(index.Interleave.Ancestors) > 0 {
 		for _, ancestor := range index.Interleave.Ancestors {
 			key, decodedTableID, decodedIndexID, err = DecodeTableIDIndexID(key)
 			if err != nil {
@@ -765,7 +765,7 @@ func DecodeIndexKey(
 	if err != nil {
 		return nil, false, err
 	}
-	if decodedTableID != desc.ID || decodedIndexID != indexID {
+	if decodedTableID != desc.ID || decodedIndexID != index.ID {
 		return nil, false, nil
 	}
 
@@ -842,7 +842,7 @@ func ExtractIndexKey(
 		// find the index id so we can look up the descriptor, and once to extract
 		// the values. Only parse once.
 		var ok bool
-		_, ok, err = DecodeIndexKey(a, tableDesc, indexID, values, dirs, entry.Key)
+		_, ok, err = DecodeIndexKey(a, tableDesc, i, values, dirs, entry.Key)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -101,7 +101,7 @@ func decodeIndex(
 			return nil, err
 		}
 	}
-	_, ok, err := DecodeIndexKey(a, tableDesc, index.ID, values, colDirs, key)
+	_, ok, err := DecodeIndexKey(a, tableDesc, index, values, colDirs, key)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
During row fetching, if we don't need any of the columns contained
within the index key and the index is not interleaved, we can completely
skip reading and processing the index key.

This gives a nice speed boost for count(*) queries. I observe a ~10-15%
improvement on a million row dataset on a local 1 node cluster.

cc @nvanbenschoten on @knz's recommendation