### PR TITLE
cloud: Update kubernetes configs for v1.1

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -150,7 +150,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v1.0.5
+        image: cockroachdb/cockroach:v1.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257
@@ -168,7 +168,7 @@ spec:
           - |
             # The use of qualified `hostname -f` is crucial:
             # Other nodes aren't able to look up the unqualified hostname.
-            CRARGS=("start" "--logtostderr" "--certs-dir" "/cockroach/cockroach-certs" "--host" "$(hostname -f)" "--http-host" "0.0.0.0")
+            CRARGS=("start" "--logtostderr" "--certs-dir" "/cockroach/cockroach-certs" "--host" "$(hostname -f)" "--http-host" "0.0.0.0" "--cache" "25%" "--max-sql-memory" "25%")
             # We only want to initialize a new cluster (by omitting the join flag)
             # if we're sure that we're the first node (i.e. index 0) and that
             # there aren't any other nodes running as part of the cluster that

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -120,7 +120,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v1.0.5
+        image: cockroachdb/cockroach:v1.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257
@@ -136,7 +136,7 @@ spec:
           - |
             # The use of qualified `hostname -f` is crucial:
             # Other nodes aren't able to look up the unqualified hostname.
-            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)" "--http-host" "0.0.0.0")
+            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)" "--http-host" "0.0.0.0" "--cache" "25%" "--max-sql-memory" "25%")
             # We only want to initialize a new cluster (by omitting the join flag)
             # if we're sure that we're the first node (i.e. index 0) and that
             # there aren't any other nodes running as part of the cluster that


### PR DESCRIPTION
Being sure to add on the cache and max-sql-memory flags that are now
important for production-ready configs.

Sending out mostly so that I don't forget to update the cache flag. Not to be submitted until we actually have a usable v1.1.0 docker image.