### PR TITLE
server: Provide a more useful error if init is run more than once

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -873,7 +873,8 @@ func (l *DockerCluster) Hostname(i int) string {
 
 // ExecCLI runs ./cockroach <args> with sane defaults.
 func (l *DockerCluster) ExecCLI(ctx context.Context, i int, cmd []string) (string, string, error) {
-	cmd = append([]string{"--host", l.Hostname(i), "--certs-dir=/certs"}, cmd...)
+	cmd = append([]string{CockroachBinaryInContainer}, cmd...)
+	cmd = append(cmd, "--host", l.Hostname(i), "--certs-dir=/certs")
 	cfg := types.ExecConfig{
 		User:         "root",
 		Privileged:   true,

--- a/pkg/acceptance/init_test.go
+++ b/pkg/acceptance/init_test.go
@@ -116,6 +116,18 @@ func testInitModeNoneInner(
 	// --join address?)
 	lc.RunInitCommand(ctx, 0)
 
+	// Make sure that running init again returns the expected error message and
+	// does not break the cluster. We have to use ExecCLI rahter than OneShot in
+	// order to actually get the output from the command.
+	output, _, err := c.ExecCLI(ctx, 0, []string{"init"})
+	if err == nil {
+		t.Fatalf("expected error running init command on initialized cluster, got output: %s", output)
+	}
+	if !testutils.IsError(err, "cluster has already been initialized") {
+		t.Fatalf("got unexpected error when running init command on initialized cluster: %v\noutput: %s",
+			err, output)
+	}
+
 	// Once initialized, we can query each node.
 	testutils.SucceedsSoon(t, func() error {
 		for i, db := range dbs {

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -15,10 +15,12 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -48,10 +50,10 @@ func runInit(cmd *cobra.Command, args []string) error {
 	defer stopper.Stop(ctx)
 
 	if _, err = c.Bootstrap(ctx, &serverpb.BootstrapRequest{}); err != nil {
-		log.Error(ctx, err)
 		return err
 	}
 
+	fmt.Fprintln(os.Stdout, "Cluster successfully initialized")
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -341,6 +341,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.node = NewNode(storeCfg, s.recorder, s.registry, s.stopper, txnMetrics, sql.MakeEventLogger(s.leaseMgr))
 	roachpb.RegisterInternalServer(s.grpc, s.node)
 	storage.RegisterConsistencyServer(s.grpc, s.node.storesServer)
+	serverpb.RegisterInitServer(s.grpc, &noopInitServer{clusterID: s.ClusterID})
 
 	s.sessionRegistry = sql.MakeSessionRegistry()
 	s.jobRegistry = jobs.MakeRegistry(


### PR DESCRIPTION
It now prints confirmation of success when it succeeds and a more
digestible error when run on an already initialized cluster.

Also, fix the acceptance test framework as necessary to make the test function.

Fixes #18484.