### PR TITLE
cherrypick-1.1: sql/jobs: avoid race in TestRegistryResumeExpiredLease

### DIFF
--- a/pkg/sql/jobs/registry_external_test.go
+++ b/pkg/sql/jobs/registry_external_test.go
@@ -65,6 +65,7 @@ func TestRoundtripJob(t *testing.T) {
 
 func TestRegistryResumeExpiredLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer jobs.ResetResumeHooks()()
 
 	ctx := context.Background()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
@@ -122,7 +123,6 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 	resumeCounts := make(map[roachpb.NodeID]int)
 	resumeCalled := make(chan struct{})
 	var newJobs []*jobs.Job
-	defer jobs.ResetResumeHooks()()
 	jobs.AddResumeHook(func(_ jobs.Type) func(context.Context, *jobs.Job) error {
 		hookCallCount++
 		return func(_ context.Context, job *jobs.Job) error {


### PR DESCRIPTION
Resume hooks can't be modified while a server is adopting jobs or we'll
race with the registry adoption loop.

Original PR: #18464.