### PR TITLE
cli: fix pretty print alignment

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -523,7 +523,7 @@
   branch = "master"
   name = "github.com/lib/pq"
   packages = [".","oid"]
-  revision = "b609790bd85edf8e9ab7e0f8912750a786177bcf"
+  revision = "27ea5d92de30060e7121ddd543fe14e9a327e0cc"
 
 [[projects]]
   name = "github.com/lightstep/lightstep-tracer-go"

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -173,6 +173,7 @@ func runListCerts(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(os.Stdout, "Certificate directory: %s\n", baseCfg.SSLCertsDir)
 
 	certTableHeaders := []string{"Usage", "Certificate File", "Key File", "Expires", "Notes", "Error"}
+	alignment := "llllll"
 	var rows [][]string
 
 	addRow := func(ci *security.CertInfo, notes string) {
@@ -223,7 +224,7 @@ func runListCerts(cmd *cobra.Command, args []string) error {
 		addRow(cert, fmt.Sprintf("user: %s", user))
 	}
 
-	return printQueryOutput(os.Stdout, certTableHeaders, newRowSliceIter(rows))
+	return printQueryOutput(os.Stdout, certTableHeaders, newRowSliceIter(rows, alignment))
 }
 
 var certCmds = []*cobra.Command{

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1873,3 +1873,38 @@ func Example_in_memory() {
 	// 1
 	// # 1 row
 }
+
+func Example_pretty_print_numerical_strings() {
+	c := newCLITest(cliTestParams{})
+	defer c.cleanup()
+
+	// All strings in pretty-print output should be aligned to left regardless of their contents
+	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.t (s string, d string);"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'0', 'positive numerical string')"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'-1', 'negative numerical string')"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'1.0', 'decimal numerical string')"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'aaaaa', 'non-numerical string')"})
+	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "select * from t.t"})
+
+	// Output:
+	// sql -e create database t; create table t.t (s string, d string);
+	// CREATE TABLE
+	// sql -e insert into t.t values (e'0', 'positive numerical string')
+	// INSERT 1
+	// sql -e insert into t.t values (e'-1', 'negative numerical string')
+	// INSERT 1
+	// sql -e insert into t.t values (e'1.0', 'decimal numerical string')
+	// INSERT 1
+	// sql -e insert into t.t values (e'aaaaa', 'non-numerical string')
+	// INSERT 1
+	// sql --format=pretty -e select * from t.t
+	// +-------+---------------------------+
+	// |   s   |             d             |
+	// +-------+---------------------------+
+	// | 0     | positive numerical string |
+	// | -1    | negative numerical string |
+	// | 1.0   | decimal numerical string  |
+	// | aaaaa | non-numerical string      |
+	// +-------+---------------------------+
+	// (4 rows)
+}

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -319,7 +319,7 @@ func (c *cliState) handleSet(args []string, nextState, errState cliStateEnum) cl
 		}
 		err := printQueryOutput(os.Stdout,
 			[]string{"Option", "Value", "Description"},
-			newRowSliceIter(optData))
+			newRowSliceIter(optData, "lll" /*align*/))
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"reflect"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -348,7 +349,7 @@ func (c *sqlConn) Close() {
 }
 
 type sqlRowsI interface {
-	driver.Rows
+	driver.RowsColumnTypeScanType
 	Result() driver.Result
 	Tag() string
 
@@ -408,6 +409,10 @@ func (r *sqlRows) NextResultSet() (bool, error) {
 		return false, nil
 	}
 	return true, r.rows.NextResultSet()
+}
+
+func (r *sqlRows) ColumnTypeScanType(index int) reflect.Type {
+	return r.rows.ColumnTypeScanType(index)
 }
 
 func makeSQLConn(url string) *sqlConn {

--- a/pkg/sql/logictest/testdata/logic_test/snapshot_issue2861
+++ b/pkg/sql/logictest/testdata/logic_test/snapshot_issue2861
@@ -43,7 +43,7 @@ SELECT * FROM t
 
 user root
 
-query I
+query I rowsort
 SELECT * FROM t
 ----
 1


### PR DESCRIPTION
This patch modifies the `pretty` table format implementation so that
caller scan specify alignment of results inside the table. The
alignment directive supports "l", "r" and "c" for left, right and
center horizontal alignment, respectively.

Alignment in results printed by the `sql` client have alignment
decided automatically based on column type:

- strings and unicode: `left`
- ints and other numericals: `right`
- bools: `center`

This patch also adds proper alignment to `node ls` and other
"ad-hoc/non-table" queries.

Fixes #10042.

Release note (cli change): command-line utilities that print results
with the `pretty` format now use consistent horizontal alignment for
every row of the result.
