### PR TITLE
util: FastIntSet improvements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -635,9 +635,10 @@
   revision = "8be79e1e0910c292df4e79c241bb7e8f7e725959"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/tools"
-  packages = ["cmd/goimports","cmd/goyacc","cmd/stringer","cover","go/ast/astutil","go/buildutil","go/gcexportdata","go/gcimporter15","go/loader","go/types/typeutil","imports"]
-  revision = "bf4b54dc687c73b6ef63de8b8abf0ad3951e3edc"
+  packages = ["cmd/goimports","cmd/goyacc","cmd/stringer","container/intsets","cover","go/ast/astutil","go/buildutil","go/gcexportdata","go/gcimporter15","go/loader","go/types/typeutil","imports"]
+  revision = "68e087e2a5786de2c035ed544b1c5a42e31f1933"
 
 [[projects]]
   name = "google.golang.org/api"
@@ -673,6 +674,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "0c4cdc41e60e9405fc2dab5b883635e3c5b6f15afef358d81d488091edea9e40"
+  inputs-digest = "6f894a326b8459636d3168b14fda3ab490b310ec4394b997402e0b437756a92d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -206,7 +206,7 @@ func doExpandPlan(
 			n.columnsInOrder = make([]bool, len(planColumns(n.plan)))
 			for i := range n.columnsInOrder {
 				group := ordering.eqGroups.Find(i)
-				if ordering.constantCols.Contains(uint32(group)) {
+				if ordering.constantCols.Contains(group) {
 					n.columnsInOrder[i] = true
 					continue
 				}
@@ -504,13 +504,13 @@ func simplifyOrderings(plan planNode, usefulOrdering sqlbase.ColumnOrdering) pla
 			// the useful ordering. Check for this, ignoring any constant columns.
 			sortOrder := make(sqlbase.ColumnOrdering, 0, len(n.ordering))
 			for _, c := range n.ordering {
-				if !constantCols.Contains(uint32(c.ColIdx)) {
+				if !constantCols.Contains(c.ColIdx) {
 					sortOrder = append(sortOrder, c)
 				}
 			}
 			givenOrder := make(sqlbase.ColumnOrdering, 0, len(usefulOrdering))
 			for _, c := range usefulOrdering {
-				if !constantCols.Contains(uint32(c.ColIdx)) {
+				if !constantCols.Contains(c.ColIdx) {
 					givenOrder = append(givenOrder, c)
 				}
 			}

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -601,8 +601,8 @@ func (n *joinNode) joinOrdering() orderingInfo {
 	for i, leftIdx := range n.pred.leftEqualityIndices {
 		leftGroup := leftOrd.eqGroups.Find(leftIdx)
 		rightGroup := rightOrd.eqGroups.Find(n.pred.rightEqualityIndices[i])
-		if leftOrd.constantCols.Contains(uint32(leftGroup)) ||
-			rightOrd.constantCols.Contains(uint32(rightGroup)) {
+		if leftOrd.constantCols.Contains(leftGroup) ||
+			rightOrd.constantCols.Contains(rightGroup) {
 			info.addConstantColumn(leftCol(leftIdx))
 		}
 	}

--- a/pkg/sql/ordering_test.go
+++ b/pkg/sql/ordering_test.go
@@ -90,7 +90,7 @@ func makeOrdInfo(args ...interface{}) orderingInfo {
 		case constCols:
 			// Constant columns.
 			for _, i := range a {
-				ord.constantCols.Add(uint32(ord.eqGroups.Find(i)))
+				ord.constantCols.Add(ord.eqGroups.Find(i))
 			}
 		case isKeyType:
 			ord.isKey = true
@@ -368,15 +368,15 @@ func TestTrimOrderingGuarantee(t *testing.T) {
 									j = rng.Intn(10)
 								}
 								o.addConstantColumn(j)
-								used.Add(uint32(j))
+								used.Add(j)
 							}
 
 							for i := 0; i < numOrderCols; i++ {
 								for tries := 0; ; tries++ {
 									// Increase the range if we can't find a new valid id.
 									x := rng.Intn(10 + tries/10)
-									if o.eqGroups.Find(x) == x && !used.Contains(uint32(x)) {
-										used.Add(uint32(x))
+									if o.eqGroups.Find(x) == x && !used.Contains(x) {
+										used.Add(x)
 										o.addOrderColumn(x, genDir(rng))
 										break
 									}

--- a/pkg/sql/plan_ordering.go
+++ b/pkg/sql/plan_ordering.go
@@ -79,7 +79,7 @@ func sortOrdering(n *sortNode) orderingInfo {
 		ord.ordering = make(sqlbase.ColumnOrdering, 0, len(n.ordering))
 		for _, o := range n.ordering {
 			// Skip any constant columns (we preserve them below).
-			if !underlying.constantCols.Contains(uint32(o.ColIdx)) {
+			if !underlying.constantCols.Contains(o.ColIdx) {
 				ord.addOrderColumn(o.ColIdx, o.Direction)
 			}
 		}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -141,7 +141,7 @@ func (rf *RowFetcher) Init(
 		// corresponding ColumnID.
 		for col, idx := range colIdxMap {
 			if idx == i {
-				rf.neededCols.Add(uint32(col))
+				rf.neededCols.Add(int(col))
 				break
 			}
 		}
@@ -170,7 +170,7 @@ func (rf *RowFetcher) Init(
 
 	if isSecondaryIndex {
 		for i := range rf.cols {
-			if rf.neededCols.Contains(uint32(rf.cols[i].ID)) && !index.ContainsColumnID(rf.cols[i].ID) {
+			if rf.neededCols.Contains(int(rf.cols[i].ID)) && !index.ContainsColumnID(rf.cols[i].ID) {
 				return fmt.Errorf("requested column %s not in index", rf.cols[i].Name)
 			}
 		}
@@ -395,7 +395,7 @@ func (rf *RowFetcher) processKV(
 				return "", "", err
 			}
 			for i, id := range rf.index.ExtraColumnIDs {
-				if rf.neededCols.Contains(uint32(id)) {
+				if rf.neededCols.Contains(int(id)) {
 					rf.row[rf.colIdxMap[id]] = rf.extraVals[i]
 				}
 			}
@@ -452,7 +452,7 @@ func (rf *RowFetcher) processValueSingle(
 		return "", "", errors.Errorf("single entry value with no default column id")
 	}
 
-	if debugStrings || rf.neededCols.Contains(uint32(colID)) {
+	if debugStrings || rf.neededCols.Contains(int(colID)) {
 		if idx, ok := rf.colIdxMap[colID]; ok {
 			if debugStrings {
 				prettyKey = fmt.Sprintf("%s/%s", prettyKey, rf.desc.Columns[idx].Name)
@@ -510,7 +510,7 @@ func (rf *RowFetcher) processValueBytes(
 		}
 		colID := lastColID + ColumnID(colIDDiff)
 		lastColID = colID
-		if !rf.neededCols.Contains(uint32(colID)) {
+		if !rf.neededCols.Contains(int(colID)) {
 			// This column wasn't requested, so read its length and skip it.
 			_, len, err := encoding.PeekValueLength(valueBytes)
 			if err != nil {
@@ -620,7 +620,7 @@ func (rf *RowFetcher) NextRowDecoded(ctx context.Context, traceKV bool) (parser.
 func (rf *RowFetcher) finalizeRow() {
 	// Fill in any missing values with NULLs
 	for i := range rf.cols {
-		if rf.neededCols.Contains(uint32(rf.cols[i].ID)) && rf.row[i].IsUnset() {
+		if rf.neededCols.Contains(int(rf.cols[i].ID)) && rf.row[i].IsUnset() {
 			if !rf.cols[i].Nullable {
 				panic(fmt.Sprintf("Non-nullable column \"%s:%s\" with no value!",
 					rf.desc.Name, rf.cols[i].Name))

--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -17,61 +17,97 @@ package util
 import (
 	"bytes"
 	"fmt"
-	"math"
-	"sort"
+
+	"golang.org/x/tools/container/intsets"
 )
 
 // FastIntSet keeps track of a set of integers. It does not perform any
 // allocations when the values are small. It is not thread-safe.
 type FastIntSet struct {
-	smallVals uint64
-	largeVals map[uint32]struct{}
+	// We use a uint64 as long as all elements are between 0 and 63. If we add an
+	// element outside of this range, we switch to Sparse. We don't just use the
+	// latter directly because it's larger and can't be passed around by value.
+	small uint64
+	large *intsets.Sparse
 }
 
 // We store bits for values smaller than this cutoff.
-const smallValCutoff = 64
+const smallCutoff = 64
+
+func (s *FastIntSet) smallToLarge() *intsets.Sparse {
+	if s.large != nil {
+		panic("set already large")
+	}
+	large := new(intsets.Sparse)
+	for i, ok := s.Next(0); ok; i, ok = s.Next(i + 1) {
+		large.Insert(i)
+	}
+	return large
+}
+
+// Returns the bit encoded set from 0 to 63, and a flag that indicates whether
+// there are elements outside this range.
+func (s *FastIntSet) largeToSmall() (small uint64, otherValues bool) {
+	if s.large == nil {
+		panic("set not large")
+	}
+	for x := s.large.LowerBound(0); x < smallCutoff; x = s.large.LowerBound(x + 1) {
+		small |= (1 << uint64(x))
+	}
+	return small, s.large.Min() < 0 || s.large.Max() >= smallCutoff
+}
 
 // Add adds a value to the set. No-op if the value is already in the set.
-func (s *FastIntSet) Add(i uint32) {
-	if i < smallValCutoff {
-		s.smallVals |= (1 << uint64(i))
-	} else {
-		if s.largeVals == nil {
-			s.largeVals = make(map[uint32]struct{})
-		}
-		s.largeVals[i] = struct{}{}
+func (s *FastIntSet) Add(i int) {
+	if i >= 0 && i < smallCutoff && s.large == nil {
+		// Fast path.
+		s.small |= (1 << uint64(i))
+		return
 	}
+	if s.large == nil {
+		s.large = s.smallToLarge()
+		s.small = 0
+	}
+	s.large.Insert(i)
 }
 
 // Remove removes a value from the set. No-op if the value is not in the set.
-func (s *FastIntSet) Remove(i uint32) {
-	if i < smallValCutoff {
-		s.smallVals &= ^(1 << uint64(i))
+func (s *FastIntSet) Remove(i int) {
+	if s.large == nil {
+		if i >= 0 && i < smallCutoff {
+			s.small &= ^(1 << uint64(i))
+		}
 	} else {
-		delete(s.largeVals, i)
+		s.large.Remove(i)
 	}
 }
 
 // Contains returns true if the set contains the value.
-func (s *FastIntSet) Contains(i uint32) bool {
-	if i < smallValCutoff {
-		return (s.smallVals & (1 << uint64(i))) != 0
+func (s *FastIntSet) Contains(i int) bool {
+	if s.large != nil {
+		return s.large.Has(i)
 	}
-	_, ok := s.largeVals[i]
-	return ok
+	return i >= 0 && i < smallCutoff && (s.small&(1<<uint64(i))) != 0
 }
 
 // Empty returns true if the set is empty.
 func (s *FastIntSet) Empty() bool {
-	return s.smallVals == 0 && len(s.largeVals) == 0
+	return s.small == 0 && (s.large == nil || s.large.IsEmpty())
 }
 
 // Next returns the first value in the set which is >= startVal. If there is no
 // value, the second return value is false.
-// Note: this is efficient for small sets, but each call takes linear time for large sets.
-func (s *FastIntSet) Next(startVal uint32) (uint32, bool) {
-	if startVal < smallValCutoff {
-		for v := s.smallVals >> startVal; v > 0; {
+func (s *FastIntSet) Next(startVal int) (int, bool) {
+	if s.large != nil {
+		res := s.large.LowerBound(startVal)
+		return res, res != intsets.MaxInt
+	}
+	if startVal < smallCutoff {
+		if startVal < 0 {
+			startVal = 0
+		}
+
+		for v := s.small >> uint64(startVal); v > 0; {
 			// Skip 8 bits at a time when possible.
 			if v&0xFF == 0 {
 				startVal += 8
@@ -84,27 +120,19 @@ func (s *FastIntSet) Next(startVal uint32) (uint32, bool) {
 			startVal++
 			v >>= 1
 		}
-		startVal = smallValCutoff
 	}
-	if len(s.largeVals) > 0 {
-		found := false
-		min := uint32(0)
-		for k := range s.largeVals {
-			if k >= startVal && (!found || k < min) {
-				found = true
-				min = k
-			}
-		}
-		if found {
-			return min, true
-		}
-	}
-	return math.MaxUint32, false
+	return intsets.MaxInt, false
 }
 
-// ForEach calls a function for each value in the set (in arbitrary order).
-func (s *FastIntSet) ForEach(f func(i uint32)) {
-	for i, v := uint32(0), s.smallVals; v > 0; {
+// ForEach calls a function for each value in the set (in increasing order).
+func (s *FastIntSet) ForEach(f func(i int)) {
+	if s.large != nil {
+		for x := s.large.Min(); x != intsets.MaxInt; x = s.large.LowerBound(x + 1) {
+			f(x)
+		}
+		return
+	}
+	for i, v := 0, s.small; v > 0; {
 		// Skip 8 bits at a time when possible.
 		if v&0xFF == 0 {
 			i += 8
@@ -117,62 +145,85 @@ func (s *FastIntSet) ForEach(f func(i uint32)) {
 		i++
 		v >>= 1
 	}
-	for v := range s.largeVals {
-		f(v)
-	}
 }
 
-// Ordered returns a slice with all the integers in the set, in sorted order.
+// Ordered returns a slice with all the integers in the set, in increasing order.
 func (s *FastIntSet) Ordered() []int {
+	if s.large != nil {
+		return s.large.AppendTo([]int(nil))
+	}
 	// TODO(radu): when we switch to go1.9, use the new math/bits.OnesCount64 to
 	// calculate the correct length.
-	result := make([]int, 0, len(s.largeVals))
-	s.ForEach(func(i uint32) {
-		result = append(result, int(i))
+	result := make([]int, 0)
+	s.ForEach(func(i int) {
+		result = append(result, i)
 	})
-	if len(s.largeVals) > 0 {
-		sort.Ints(result)
-	}
 	return result
 }
 
 // Copy makes an copy of a FastIntSet which can be modified independently.
 func (s *FastIntSet) Copy() FastIntSet {
-	c := FastIntSet{smallVals: s.smallVals}
-	if len(s.largeVals) > 0 {
-		c.largeVals = make(map[uint32]struct{})
-		for v := range s.largeVals {
-			c.largeVals[v] = struct{}{}
-		}
+	var c FastIntSet
+	if s.large != nil {
+		c.large = new(intsets.Sparse)
+		c.large.Copy(s.large)
+	} else {
+		c.small = s.small
 	}
 	return c
 }
 
 // Equals returns true if the two sets are identical.
 func (s *FastIntSet) Equals(rhs FastIntSet) bool {
-	if s.smallVals != rhs.smallVals {
-		return false
+	if s.large == nil && rhs.large == nil {
+		return s.small == rhs.small
 	}
-	if len(s.largeVals) != len(rhs.largeVals) {
-		return false
+	if s.large != nil && rhs.large != nil {
+		return s.large.Equals(rhs.large)
 	}
-	if len(s.largeVals) > 0 {
-		s1 := s.Ordered()
-		s2 := rhs.Ordered()
-		for i := range s1 {
-			if s1[i] != s2[i] {
-				return false
-			}
+	// One set is "large" and one is "small". They might still be equal (the large
+	// set could have had a large element added and then removed).
+	var extraVals bool
+	s1 := s.small
+	s2 := rhs.small
+	if s.large != nil {
+		s1, extraVals = s.largeToSmall()
+	} else {
+		s2, extraVals = rhs.largeToSmall()
+	}
+	return !extraVals && s1 == s2
+}
+
+// SubsetOf returns true if rhs contains all the elements in s.
+func (s *FastIntSet) SubsetOf(rhs FastIntSet) bool {
+	if s.large == nil && rhs.large == nil {
+		return (s.small & rhs.small) == s.small
+	}
+	if s.large != nil && rhs.large != nil {
+		return s.large.SubsetOf(rhs.large)
+	}
+	// One set is "large" and one is "small".
+	s1 := s.small
+	s2 := rhs.small
+	if s.large != nil {
+		var extraVals bool
+		s1, extraVals = s.largeToSmall()
+		if extraVals {
+			// s has elements that rhs (which is small) can't have.
+			return false
 		}
+	} else {
+		// We don't care if rhs has extra values.
+		s2, _ = rhs.largeToSmall()
 	}
-	return true
+	return (s1 & s2) == s1
 }
 
 func (s *FastIntSet) String() string {
 	var buf bytes.Buffer
 	buf.WriteByte('(')
 	first := true
-	s.ForEach(func(i uint32) {
+	s.ForEach(func(i int) {
 		if first {
 			first = false
 		} else {

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -16,21 +16,25 @@ package util
 
 import (
 	"fmt"
-	"math/rand"
 	"reflect"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 func TestFastIntSet(t *testing.T) {
-	for _, m := range []uint32{1, 8, 30, smallValCutoff, 2 * smallValCutoff, 4 * smallValCutoff} {
+	for _, mVal := range []int{1, 8, 30, smallCutoff, 2 * smallCutoff, 4 * smallCutoff} {
+		m := mVal
 		t.Run(fmt.Sprintf("%d", m), func(t *testing.T) {
+			t.Parallel()
+			rng, _ := randutil.NewPseudoRand()
 			in := make([]bool, m)
 			forEachRes := make([]bool, m)
 
 			var s FastIntSet
 			for i := 0; i < 1000; i++ {
-				v := uint32(rand.Intn(int(m)))
-				if rand.Intn(2) == 0 {
+				v := rng.Intn(m)
+				if rng.Intn(2) == 0 {
 					in[v] = true
 					s.Add(v)
 				} else {
@@ -38,7 +42,7 @@ func TestFastIntSet(t *testing.T) {
 					s.Remove(v)
 				}
 				empty := true
-				for j := uint32(0); j < m; j++ {
+				for j := 0; j < m; j++ {
 					empty = empty && !in[j]
 					if in[j] != s.Contains(j) {
 						t.Fatalf("incorrect result for Contains(%d), expected %t", j, in[j])
@@ -51,10 +55,10 @@ func TestFastIntSet(t *testing.T) {
 				for j := range forEachRes {
 					forEachRes[j] = false
 				}
-				s.ForEach(func(j uint32) {
+				s.ForEach(func(j int) {
 					forEachRes[j] = true
 				})
-				for j := uint32(0); j < m; j++ {
+				for j := 0; j < m; j++ {
 					if in[j] != forEachRes[j] {
 						t.Fatalf("incorrect ForEachResult for %d (%t, expected %t)", j, forEachRes[j], in[j])
 					}
@@ -62,10 +66,10 @@ func TestFastIntSet(t *testing.T) {
 				// Cross-check Ordered and Next().
 				vals := make([]int, 0)
 				for i, ok := s.Next(0); ok; i, ok = s.Next(i + 1) {
-					vals = append(vals, int(i))
+					vals = append(vals, i)
 				}
 				if o := s.Ordered(); !reflect.DeepEqual(vals, o) {
-					t.Fatalf("set build with Next doesn't match Ordered: %v vs %v", vals, o)
+					t.Fatalf("set built with Next doesn't match Ordered: %v vs %v", vals, o)
 				}
 				s2 := s.Copy()
 				if !s.Equals(s2) || !s2.Equals(s) {
@@ -83,5 +87,67 @@ func TestFastIntSet(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestFastIntSetTwoSetOps(t *testing.T) {
+	rng, _ := randutil.NewPseudoRand()
+	// genSet creates a set of numElem values in [minVal, minVal + valRange)
+	// It also adds and then removes numRemoved elements.
+	genSet := func(numElem, numRemoved, minVal, valRange int) (FastIntSet, map[int]bool) {
+		var s FastIntSet
+		vals := rng.Perm(valRange)[:numElem+numRemoved]
+		used := make(map[int]bool, len(vals))
+		for _, i := range vals {
+			used[i] = true
+		}
+		for k := range used {
+			s.Add(k)
+		}
+		p := rng.Perm(len(vals))
+		for i := 0; i < numRemoved; i++ {
+			k := vals[p[i]]
+			s.Remove(k)
+			delete(used, k)
+		}
+		return s, used
+	}
+
+	// returns true if a is a subset of b
+	subset := func(a, b map[int]bool) bool {
+		for k := range a {
+			if !b[k] {
+				return false
+			}
+		}
+		return true
+	}
+
+	for _, minVal := range []int{-10, -1, 0, smallCutoff, 2 * smallCutoff} {
+		for _, valRange := range []int{0, 20, 200} {
+			for _, num1 := range []int{0, 1, 5, 10, 20} {
+				for _, removed1 := range []int{0, 1, 3, 8} {
+					s1, m1 := genSet(num1, removed1, minVal, num1+removed1+valRange)
+					for _, num2 := range []int{0, 1, 5, 10, 20} {
+						for _, removed2 := range []int{0, 1, 4, 10} {
+							s2, m2 := genSet(num2, removed2, minVal, num2+removed2+valRange)
+
+							subset1 := subset(m1, m2)
+							if subset1 != s1.SubsetOf(s2) {
+								t.Errorf("SubsetOf result incorrect: %s, %s", &s1, &s2)
+							}
+							subset2 := subset(m2, m1)
+							if subset2 != s2.SubsetOf(s1) {
+								t.Errorf("SubsetOf result incorrect: %s, %s", &s2, &s1)
+							}
+							eq := subset1 && subset2
+							if eq != s1.Equals(s2) || eq != s2.Equals(s1) {
+								t.Errorf("Equals result incorrect: %s, %s", &s1, &s2)
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
#### util: use intsets.Sparse in FastIntSet

Improving the code for FastIntSet to use a `intsets.Sparse` when we have
elements outside of the [0,64) range. We don't just use `Sparse` directly
because it's larger (56 bytes) and must be on the heap (we can't have slices of
`Sparse`).

Also improving the interface to use `int`s and adding a `SubsetOf` method.

#### util: improve FastIntSet with math/bits

Use the new `math/bits` primitives in `FastIntSet`.

#

Please ignore the first commit (separate PR). Note that I will be out for two weeks and don't plan to merge these PRs until I come back, so there is no rush to review.