### PR TITLE
sqlccl: add tests for CSV create table errors

### DIFF
--- a/pkg/ccl/sqlccl/csv_internal_test.go
+++ b/pkg/ccl/sqlccl/csv_internal_test.go
@@ -1,0 +1,80 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package sqlccl
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestMakeCSVTableDescriptorErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		stmt  string
+		error string
+	}{
+		{
+			stmt:  "create table if not exists a (i int)",
+			error: "unsupported IF NOT EXISTS",
+		},
+		{
+			stmt:  "create table a (i int) interleave in parent b (id)",
+			error: "interleaved not supported",
+		},
+		{
+			stmt:  "create table a as select 1",
+			error: "CREATE AS not supported",
+		},
+		{
+			stmt:  "create table a (i int references b (id))",
+			error: `foreign keys not supported: FOREIGN KEY \(i\) REFERENCES b \(id\)`,
+		},
+		{
+			stmt:  "create table a (i int, constraint a  foreign key (i) references c (id))",
+			error: `foreign keys not supported: CONSTRAINT a FOREIGN KEY \(i\) REFERENCES c \(id\)`,
+		},
+		{
+			stmt:  "create table a (i int default 0)",
+			error: "DEFAULT expressions not supported: i INT DEFAULT 0",
+		},
+		{
+			stmt: `create table a (
+				i int check (i > 0),
+				constraint a check (i < 0),
+				primary key (i),
+				unique index (i),
+				index (i),
+				family (i)
+			)`,
+		},
+	}
+	ctx := context.Background()
+	for _, tc := range tests {
+		t.Run(tc.stmt, func(t *testing.T) {
+			stmt, err := parser.ParseOne(tc.stmt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			create, ok := stmt.(*parser.CreateTable)
+			if !ok {
+				t.Fatal("expected CREATE TABLE statement in table file")
+			}
+			_, err = makeCSVTableDescriptor(ctx, create, defaultCSVParentID, defaultCSVTableID, 0)
+			if !testutils.IsError(err, tc.error) {
+				t.Fatalf("expected %v, got %+v", tc.error, err)
+			}
+		})
+	}
+}

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -525,7 +525,7 @@ func (p *planner) CreateTable(ctx context.Context, n *parser.CreateTable) (planN
 		return nil, err
 	}
 
-	hoistConstraints(n)
+	HoistConstraints(n)
 	for _, def := range n.Defs {
 		switch t := def.(type) {
 		case *parser.ForeignKeyConstraintTableDef:
@@ -559,12 +559,12 @@ func (p *planner) CreateTable(ctx context.Context, n *parser.CreateTable) (planN
 	return &createTableNode{n: n, dbDesc: dbDesc, sourcePlan: sourcePlan}, nil
 }
 
-// hoistConstraints finds column constraints defined inline with the columns
+// HoistConstraints finds column constraints defined inline with the columns
 // and moves them into n.Defs as constraints. For example, the foreign key
 // constraint in `CREATE TABLE foo (a INT REFERENCES bar(a))` gets pulled into
 // a top level fk constraint like
 // `CREATE TABLE foo (a int CONSTRAINT .. FOREIGN KEY(a) REFERENCES bar(a)`.
-func hoistConstraints(n *parser.CreateTable) {
+func HoistConstraints(n *parser.CreateTable) {
 	for _, d := range n.Defs {
 		if col, ok := d.(*parser.ColumnTableDef); ok {
 			for _, checkExpr := range col.CheckExprs {

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -171,11 +171,11 @@ func MakeColumnDefDescs(
 	}
 
 	if len(d.CheckExprs) > 0 {
-		// Should never happen since `hoistConstraints` moves these to table level
+		// Should never happen since `HoistConstraints` moves these to table level
 		return nil, nil, errors.New("unexpected column CHECK constraint")
 	}
 	if d.HasFKConstraint() {
-		// Should never happen since `hoistConstraints` moves these to table level
+		// Should never happen since `HoistConstraints` moves these to table level
 		return nil, nil, errors.New("unexpected column REFERENCED constraint")
 	}
 


### PR DESCRIPTION
makeCSVTableDescriptor now checks the create statement for more
failures. This is needed because otherwise sql.MakeTableDesc can panic
due to the nil EvalContext (like when processing DEFAULT expressions).