### PR TITLE
sql: store information about keys in orderingInfo, elide distinctNode

### DIFF
--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -199,6 +199,12 @@ func doExpandPlan(
 
 		ordering := planOrdering(n.plan)
 		if !ordering.isEmpty() {
+			// If any of the columns form a key, we already know that all rows are
+			// unique. Elide the distinctNode.
+			if len(ordering.keySets) > 0 {
+				return n.plan, nil
+			}
+
 			// The distinctNode can take advantage of any ordering. It only needs to
 			// know the set of columns S that contribute to the ordering (it keeps
 			// track of distinct elements within each group of rows with equal values

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -259,7 +259,7 @@ EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 0  ·       group by     @1-@1                  ·                               ·
 1  render  ·            ·                      ("k + v")                       ·
 1  ·       render 0     test.kv.k + test.kv.v  ·                               ·
-2  scan    ·            ·                      (k, v, w[omitted], s[omitted])  ·
+2  scan    ·            ·                      (k, v, w[omitted], s[omitted])  key(k)
 2  ·       table        kv@primary             ·                               ·
 2  ·       spans        ALL                    ·                               ·
 
@@ -286,10 +286,10 @@ EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 1  ·       aggregate 1  test.kv.k     ·                               ·
 1  ·       aggregate 2  test.kv.v     ·                               ·
 1  ·       group by     @1-@2         ·                               ·
-2  render  ·            ·             (k, v)                          ·
+2  render  ·            ·             (k, v)                          key(k)
 2  ·       render 0     test.kv.k     ·                               ·
 2  ·       render 1     test.kv.v     ·                               ·
-3  scan    ·            ·             (k, v, w[omitted], s[omitted])  ·
+3  scan    ·            ·             (k, v, w[omitted], s[omitted])  key(k)
 3  ·       table        kv@primary    ·                               ·
 3  ·       spans        ALL           ·                               ·
 
@@ -1153,7 +1153,7 @@ EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 1  render  ·            ·                                                               (v int, "k > 5" bool)                                          ·
 1  ·       render 0     (v)[int]                                                        ·                                                              ·
 1  ·       render 1     ((k)[int] > (5)[int])[bool]                                     ·                                                              ·
-2  scan    ·            ·                                                               (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)  ·
+2  scan    ·            ·                                                               (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)  key(rowid)
 2  ·       table        filter_test@primary                                             ·                                                              ·
 2  ·       spans        ALL                                                             ·                                                              ·
 
@@ -1225,7 +1225,7 @@ EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
 0  ·       aggregate 0  min(test.opt_test.v)  ·                ·
 1  render  ·            ·                     (v)              +v
 1  ·       render 0     test.opt_test.v       ·                ·
-2  scan    ·            ·                     (k[omitted], v)  +v
+2  scan    ·            ·                     (k[omitted], v)  key(k,v); +v
 2  ·       table        opt_test@v            ·                ·
 2  ·       spans        /#-                   ·                ·
 2  ·       limit        1                     ·                ·
@@ -1250,7 +1250,7 @@ EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
 0  ·       aggregate 0  min(test.opt_test.v)  ·           ·
 1  render  ·            ·                     (v)         +v
 1  ·       render 0     test.opt_test.v       ·           ·
-2  scan    ·            ·                     (k, v)      +v
+2  scan    ·            ·                     (k, v)      key(k,v); +v
 2  ·       table        opt_test@v            ·           ·
 2  ·       spans        /#-                   ·           ·
 2  ·       filter       k != 4                ·           ·
@@ -1270,7 +1270,7 @@ EXPLAIN (VERBOSE) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
 0  ·       aggregate 0  min(test.opt_test.v + 1)            ·               ·
 1  render  ·            ·                                   ("v + 1")       ·
 1  ·       render 0     test.opt_test.v + 1                 ·               ·
-2  scan    ·            ·                                   (k, v)          ·
+2  scan    ·            ·                                   (k, v)          key(k)
 2  ·       table        opt_test@primary                    ·               ·
 2  ·       spans        /#-                                 ·               ·
 2  ·       filter       (k != 4) AND ((v + 1) IS NOT NULL)  ·               ·
@@ -1282,7 +1282,7 @@ EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
 0  group  ·            ·                     ("min(v)")  ·
 0  ·      aggregate 0  min(test.opt_test.v)  ·           ·
 0  ·      group by     @1-@1                 ·           ·
-1  scan   ·            ·                     (k, v)      ·
+1  scan   ·            ·                     (k, v)      key(k)
 1  ·      table        opt_test@primary      ·           ·
 1  ·      spans        ALL                   ·           ·
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -638,9 +638,9 @@ EXPLAIN (METADATA) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 
 ----
 Level  Type    Field  Description  Columns               Ordering
 0      split   ·      ·            (key, pretty)         ·
-1      limit   ·      ·            (k1, k2)              +k1
-2      render  ·      ·            (k1, k2)              +k1
-3      scan    ·      ·            (k1, k2, v[omitted])  +k1
+1      limit   ·      ·            (k1, k2)              key(k1,k2); +k1
+2      render  ·      ·            (k1, k2)              key(k1,k2); +k1
+3      scan    ·      ·            (k1, k2, v[omitted])  key(k1,k2); +k1
 3      ·       table  s@primary    ·                     ·
 3      ·       spans  ALL          ·                     ·
 3      ·       limit  3            ·                     ·

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -195,3 +195,62 @@ query I
 SELECT COUNT(*) FROM (SELECT DISTINCT y FROM xyz)
 ----
 3
+
+
+query ITTTTT
+EXPLAIN (METADATA) SELECT DISTINCT x FROM xyz
+----
+0  render  ·      ·            (x)                          key(x)
+1  scan    ·      ·            (x, y[omitted], z[omitted])  key(x)
+1  ·       table  xyz@primary  ·                            ·
+1  ·       spans  ALL          ·                            ·
+
+query ITTTTT
+EXPLAIN (METADATA) SELECT DISTINCT x, y, z FROM xyz
+----
+0  scan  ·      ·            (x, y, z)  key(x)
+0  ·     table  xyz@primary  ·          ·
+0  ·     spans  ALL          ·          ·
+
+statement ok
+CREATE TABLE abcd (
+  a INT,
+  b INT,
+  c INT,
+  d INT,
+  PRIMARY KEY (a, b, c),
+  UNIQUE INDEX (d, b)
+)
+
+query ITTTTT
+EXPLAIN (METADATA) SELECT DISTINCT 1, d, b FROM abcd ORDER BY d, b
+----
+0  render  ·      ·                  ("1", d, b)                     "1"=CONST; key(d,b); +d,+b
+1  scan    ·      ·                  (a[omitted], b, c[omitted], d)  key(b,d); +d,+b
+1  ·       table  abcd@abcd_d_b_key  ·                               ·
+1  ·       spans  ALL                ·                               ·
+
+query ITTTTT
+EXPLAIN (METADATA) SELECT DISTINCT a, b FROM abcd
+----
+0  distinct  ·      ·             (a, b)                          +a,+b
+0  ·         key    a, b          ·                               ·
+1  render    ·      ·             (a, b)                          +a,+b
+2  scan      ·      ·             (a, b, c[omitted], d[omitted])  key(a,b,c); +a,+b
+2  ·         table  abcd@primary  ·                               ·
+2  ·         spans  ALL           ·                               ·
+
+query ITTTTT
+EXPLAIN (METADATA) SELECT DISTINCT a, b, c FROM abcd
+----
+0  render  ·      ·             (a, b, c)              key(a,b,c)
+1  scan    ·      ·             (a, b, c, d[omitted])  key(a,b,c)
+1  ·       table  abcd@primary  ·                      ·
+1  ·       spans  ALL           ·                      ·
+
+query ITTTTT
+EXPLAIN (METADATA) SELECT DISTINCT a, b, c, d FROM abcd
+----
+0  scan  ·      ·             (a, b, c, d)  key(a,b,c)
+0  ·     table  abcd@primary  ·             ·
+0  ·     spans  ALL           ·             ·

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -53,13 +53,13 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b
 2  render  ·               ·                  (a, b)                                                                              +a,+b
 2  ·       render 0        test.data.a        ·                                                                                   ·
 2  ·       render 1        test.data.b        ·                                                                                   ·
-3  scan    ·               ·                  (a, b, c[omitted], d[omitted])                                                      +a,+b
+3  scan    ·               ·                  (a, b, c[omitted], d[omitted])                                                      key(a,b,c,d); +a,+b
 3  ·       table           data@primary       ·                                                                                   ·
 3  ·       spans           ALL                ·                                                                                   ·
 2  render  ·               ·                  (a, b)                                                                              +a,+b
 2  ·       render 0        data2.a            ·                                                                                   ·
 2  ·       render 1        data2.b            ·                                                                                   ·
-3  scan    ·               ·                  (a, b, c[omitted], d[omitted])                                                      +a,+b
+3  scan    ·               ·                  (a, b, c[omitted], d[omitted])                                                      key(a,b,c,d); +a,+b
 3  ·       table           data@primary       ·                                                                                   ·
 3  ·       spans           ALL                ·                                                                                   ·
 
@@ -75,7 +75,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,
 1  render  ·               ·                  (a, b)                          +a,+b
 1  ·       render 0        data1.a            ·                               ·
 1  ·       render 1        data1.b            ·                               ·
-2  scan    ·               ·                  (a, b, c[omitted], d[omitted])  +a,+b
+2  scan    ·               ·                  (a, b, c[omitted], d[omitted])  key(a,b,c,d); +a,+b
 2  ·       table           data@primary       ·                               ·
 2  ·       spans           ALL                ·                               ·
 1  sort    ·               ·                  (c, d)                          +c,+d
@@ -83,7 +83,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,
 2  render  ·               ·                  (c, d)                          ·
 2  ·       render 0        data2.c            ·                               ·
 2  ·       render 1        data2.d            ·                               ·
-3  scan    ·               ·                  (a[omitted], b[omitted], c, d)  ·
+3  scan    ·               ·                  (a[omitted], b[omitted], c, d)  key(a,b,c,d)
 3  ·       table           data@primary       ·                               ·
 3  ·       spans           ALL                ·                               ·
 
@@ -104,7 +104,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,
 1  render  ·               ·                  (a, b)                          +a,+b
 1  ·       render 0        data1.a            ·                               ·
 1  ·       render 1        data1.b            ·                               ·
-2  scan    ·               ·                  (a, b, c[omitted], d[omitted])  +a,+b
+2  scan    ·               ·                  (a, b, c[omitted], d[omitted])  key(a,b,c,d); +a,+b
 2  ·       table           data@primary       ·                               ·
 2  ·       spans           ALL                ·                               ·
 1  sort    ·               ·                  (c, d)                          +c,+d
@@ -112,7 +112,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,
 2  render  ·               ·                  (c, d)                          ·
 2  ·       render 0        data2.c            ·                               ·
 2  ·       render 1        data2.d            ·                               ·
-3  scan    ·               ·                  (a[omitted], b[omitted], c, d)  ·
+3  scan    ·               ·                  (a[omitted], b[omitted], c, d)  key(a,b,c,d)
 3  ·       table           data@primary       ·                               ·
 3  ·       spans           ALL                ·                               ·
 
@@ -134,7 +134,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,
 2  render  ·               ·                  (a, b)                          +a,+b
 2  ·       render 0        data1.a            ·                               ·
 2  ·       render 1        data1.b            ·                               ·
-3  scan    ·               ·                  (a, b, c[omitted], d[omitted])  +a,+b
+3  scan    ·               ·                  (a, b, c[omitted], d[omitted])  key(a,b,c,d); +a,+b
 3  ·       table           data@primary       ·                               ·
 3  ·       spans           ALL                ·                               ·
 2  sort    ·               ·                  (c, d)                          +c,+d
@@ -142,7 +142,7 @@ EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,
 3  render  ·               ·                  (c, d)                          ·
 3  ·       render 0        data2.c            ·                               ·
 3  ·       render 1        data2.d            ·                               ·
-4  scan    ·               ·                  (a[omitted], b[omitted], c, d)  ·
+4  scan    ·               ·                  (a[omitted], b[omitted], c, d)  key(a,b,c,d)
 4  ·       table           data@primary       ·                               ·
 4  ·       spans           ALL                ·                               ·
 
@@ -168,7 +168,7 @@ EXPLAIN (VERBOSE) (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM 
 1  ·       type            inner                                ·                                                                                                                                                                                       ·
 1  ·       equality        (a, b, c, d) = (a, b, c, d)          ·                                                                                                                                                                                       ·
 1  ·       mergeJoinOrder  +"(a=a)",+"(b=b)",+"(c=c)",+"(d=d)"  ·                                                                                                                                                                                       ·
-2  scan    ·               ·                                    (a, b, c, d)                                                                                                                                                                            +a,+b,+c,+d; key
+2  scan    ·               ·                                    (a, b, c, d)                                                                                                                                                                            key(a,b,c,d); +a,+b,+c,+d
 2  ·       table           data@primary                         ·                                                                                                                                                                                       ·
 2  ·       spans           ALL                                  ·                                                                                                                                                                                       ·
 2  join    ·               ·                                    (a, b, c, d)                                                                                                                                                                            a=c; b=d; +a,+b
@@ -178,7 +178,7 @@ EXPLAIN (VERBOSE) (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM 
 3  render  ·               ·                                    (a, b)                                                                                                                                                                                  +a,+b
 3  ·       render 0        data1.a                              ·                                                                                                                                                                                       ·
 3  ·       render 1        data1.b                              ·                                                                                                                                                                                       ·
-4  scan    ·               ·                                    (a, b, c[omitted], d[omitted])                                                                                                                                                          +a,+b
+4  scan    ·               ·                                    (a, b, c[omitted], d[omitted])                                                                                                                                                          key(a,b,c,d); +a,+b
 4  ·       table           data@primary                         ·                                                                                                                                                                                       ·
 4  ·       spans           ALL                                  ·                                                                                                                                                                                       ·
 3  sort    ·               ·                                    (c, d)                                                                                                                                                                                  +c,+d
@@ -186,7 +186,7 @@ EXPLAIN (VERBOSE) (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM 
 4  render  ·               ·                                    (c, d)                                                                                                                                                                                  ·
 4  ·       render 0        data2.c                              ·                                                                                                                                                                                       ·
 4  ·       render 1        data2.d                              ·                                                                                                                                                                                       ·
-5  scan    ·               ·                                    (a[omitted], b[omitted], c, d)                                                                                                                                                          ·
+5  scan    ·               ·                                    (a[omitted], b[omitted], c, d)                                                                                                                                                          key(a,b,c,d)
 5  ·       table           data@primary                         ·                                                                                                                                                                                       ·
 5  ·       spans           ALL                                  ·                                                                                                                                                                                       ·
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -150,11 +150,11 @@ EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x 
 1  ·       type            inner                ·                                        ·
 1  ·       equality        (x) = (y)            ·                                        ·
 1  ·       mergeJoinOrder  +"(x=y)"             ·                                        ·
-2  scan    ·               ·                    (x, xsquared[omitted])                   +x; key
+2  scan    ·               ·                    (x, xsquared[omitted])                   key(x); +x
 2  ·       table           numtosquare@primary  ·                                        ·
 2  ·       spans           ALL                  ·                                        ·
 2  ·       filter          (x % 2) = 0          ·                                        ·
-2  scan    ·               ·                    (y, str)                                 +y; key
+2  scan    ·               ·                    (y, str)                                 key(y); +y
 2  ·       table           numtostr@primary     ·                                        ·
 2  ·       spans           ALL                  ·                                        ·
 

--- a/pkg/sql/logictest/testdata/logic_test/explain_plan
+++ b/pkg/sql/logictest/testdata/logic_test/explain_plan
@@ -76,41 +76,43 @@ EXPLAIN (EXPRS) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
 2  ·           limit   2
 
 query ITTT
-EXPLAIN SELECT DISTINCT * FROM t
+EXPLAIN SELECT DISTINCT v FROM t
 ----
 0  distinct  ·      ·
-0  ·         key    k
-1  scan      ·      ·
-1  ·         table  t@primary
-1  ·         spans  ALL
+1  render    ·      ·
+2  scan      ·      ·
+2  ·         table  t@primary
+2  ·         spans  ALL
 
 query ITTT
-EXPLAIN (EXPRS) SELECT DISTINCT * FROM t LIMIT 1 OFFSET 1
+EXPLAIN (EXPRS) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1
 ----
-0  limit     ·       ·
-0  ·         count   1
-0  ·         offset  1
-1  distinct  ·       ·
-1  ·         key     k
-2  scan      ·       ·
-2  ·         table   t@primary
-2  ·         spans   ALL
+0  limit     ·         ·
+0  ·         count     1
+0  ·         offset    1
+1  distinct  ·         ·
+2  render    ·         ·
+2  ·         render 0  v
+3  scan      ·         ·
+3  ·         table     t@primary
+3  ·         spans     ALL
 
 # Ensure EXPLAIN EXECUTE works properly
 
 statement ok
-PREPARE x AS SELECT DISTINCT * from t LIMIT $1
+PREPARE x AS SELECT DISTINCT v from t LIMIT $1
 
 query ITTT
 EXPLAIN (EXPRS) EXECUTE x(3)
 ----
-0  limit     ·      ·
-0  ·         count  3
-1  distinct  ·      ·
-1  ·         key    k
-2  scan      ·      ·
-2  ·         table  t@primary
-2  ·         spans  ALL
+0  limit     ·         ·
+0  ·         count     3
+1  distinct  ·         ·
+2  render    ·         ·
+2  ·         render 0  v
+3  scan      ·         ·
+3  ·         table     t@primary
+3  ·         spans     ALL
 
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))

--- a/pkg/sql/logictest/testdata/logic_test/explain_plan
+++ b/pkg/sql/logictest/testdata/logic_test/explain_plan
@@ -32,7 +32,7 @@ EXPLAIN SELECT * FROM t
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM t
 ----
-0  scan  ·      ·          (k, v)  ·
+0  scan  ·      ·          (k, v)  key(k)
 0  ·     table  t@primary  ·       ·
 0  ·     spans  ALL        ·       ·
 
@@ -46,7 +46,7 @@ EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----
-0  scan  ·       ·            (k, v)  ·
+0  scan  ·       ·            (k, v)  key(k)
 0  ·     table   t@primary    ·       ·
 0  ·     spans   ALL          ·       ·
 0  ·     filter  (k % 2) = 0  ·       ·
@@ -121,8 +121,8 @@ EXPLAIN (METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
 0  sort        ·      ·           (a, b)                                   a=CONST; +b
 0  ·           order  +b          ·                                        ·
 1  render      ·      ·           (a, b)                                   a=CONST
-2  index-join  ·      ·           (a, b, rowid[hidden,omitted])            a=CONST
-3  scan        ·      ·           (a[omitted], b[omitted], rowid[hidden])  a=CONST
+2  index-join  ·      ·           (a, b, rowid[hidden,omitted])            a=CONST; key(rowid)
+3  scan        ·      ·           (a[omitted], b[omitted], rowid[hidden])  a=CONST; key(rowid)
 3  ·           table  tc@c        ·                                        ·
 3  ·           spans  /10-/11     ·                                        ·
 3  scan        ·      ·           (a, b, rowid[hidden,omitted])            ·

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -30,25 +30,25 @@ EXPLAIN (TYPES) SELECT 42
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t
 ----
-0  scan  ·      ·          (k int, v int)  ·
+0  scan  ·      ·          (k int, v int)  key(k)
 0  ·     table  t@primary  ·               ·
 0  ·     spans  ALL        ·               ·
 
 query ITTTTT
 EXPLAIN (TYPES,SYMVARS) SELECT k FROM t
 ----
-0  render  ·         ·          (k int)                  ·
+0  render  ·         ·          (k int)                  key(k)
 0  ·       render 0  (@1)[int]  ·                        ·
-1  scan    ·         ·          (k int, v[omitted] int)  ·
+1  scan    ·         ·          (k int, v[omitted] int)  key(k)
 1  ·       table     t@primary  ·                        ·
 1  ·       spans     ALL        ·                        ·
 
 query ITTTTT
 EXPLAIN (TYPES,QUALIFY) SELECT k FROM t
 ----
-0  render  ·         ·                (k int)                  ·
+0  render  ·         ·                (k int)                  key(k)
 0  ·       render 0  (test.t.k)[int]  ·                        ·
-1  scan    ·         ·                (k int, v[omitted] int)  ·
+1  scan    ·         ·                (k int, v[omitted] int)  key(k)
 1  ·       table     t@primary        ·                        ·
 1  ·       spans     ALL              ·                        ·
 
@@ -65,7 +65,7 @@ EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-0  scan  ·       ·                              (k int, v int)  ·
+0  scan  ·       ·                              (k int, v int)  key(k)
 0  ·     table   t@primary                      ·               ·
 0  ·     spans   ALL                            ·               ·
 0  ·     filter  ((v)[int] > (123)[int])[bool]  ·               ·
@@ -139,9 +139,9 @@ EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
 0  delete  ·         ·                            ()              ·
 0  ·       from      t                            ·               ·
-1  render  ·         ·                            (k int)         ·
+1  render  ·         ·                            (k int)         key(k)
 1  ·       render 0  (k)[int]                     ·               ·
-2  scan    ·         ·                            (k int, v int)  ·
+2  scan    ·         ·                            (k int, v int)  key(k)
 2  ·       table     t@primary                    ·               ·
 2  ·       spans     ALL                          ·               ·
 2  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
@@ -152,11 +152,11 @@ EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 0  update  ·         ·                              ()                           ·
 0  ·       table     t                              ·                            ·
 0  ·       set       v                              ·                            ·
-1  render  ·         ·                              (k int, v int, "k + 1" int)  ·
+1  render  ·         ·                              (k int, v int, "k + 1" int)  key(k)
 1  ·       render 0  (k)[int]                       ·                            ·
 1  ·       render 1  (v)[int]                       ·                            ·
 1  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
-2  scan    ·         ·                              (k int, v int)               ·
+2  scan    ·         ·                              (k int, v int)               key(k)
 2  ·       table     t@primary                      ·                            ·
 2  ·       spans     ALL                            ·                            ·
 2  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
@@ -189,11 +189,11 @@ EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 query ITTTTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-0  distinct  ·         ·          (k int)                  +k; key
+0  distinct  ·         ·          (k int)                  key(k); +k
 0  ·         key       k          ·                        ·
-1  render    ·         ·          (k int)                  +k; key
+1  render    ·         ·          (k int)                  key(k); +k
 1  ·         render 0  (k)[int]   ·                        ·
-2  scan      ·         ·          (k int, v[omitted] int)  +k; key
+2  scan      ·         ·          (k int, v[omitted] int)  key(k); +k
 2  ·         table     t@primary  ·                        ·
 2  ·         spans     ALL        ·                        ·
 
@@ -213,7 +213,7 @@ EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 0  ·       order     +v         ·                        ·
 1  render  ·         ·          (v int)                  ·
 1  ·       render 0  (v)[int]   ·                        ·
-2  scan    ·         ·          (k[omitted] int, v int)  ·
+2  scan    ·         ·          (k[omitted] int, v int)  key(k)
 2  ·       table     t@primary  ·                        ·
 2  ·       spans     ALL        ·                        ·
 
@@ -234,7 +234,7 @@ EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 0  ·       count     (1)[int]   ·                        ·
 1  render  ·         ·          (v int)                  ·
 1  ·       render 0  (v)[int]   ·                        ·
-2  scan    ·         ·          (k[omitted] int, v int)  ·
+2  scan    ·         ·          (k[omitted] int, v int)  key(k)
 2  ·       table     t@primary  ·                        ·
 2  ·       spans     ALL        ·                        ·
 2  ·       limit     1          ·                        ·
@@ -258,8 +258,8 @@ EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 0  render      ·         ·                             (x int, y int)                                       ·
 0  ·           render 0  (x)[int]                      ·                                                    ·
 0  ·           render 1  (y)[int]                      ·                                                    ·
-1  index-join  ·         ·                             (x int, y int, rowid[hidden,omitted] int)            ·
-2  scan        ·         ·                             (x[omitted] int, y[omitted] int, rowid[hidden] int)  ·
+1  index-join  ·         ·                             (x int, y int, rowid[hidden,omitted] int)            key(x,rowid)
+2  scan        ·         ·                             (x[omitted] int, y[omitted] int, rowid[hidden] int)  key(x,rowid)
 2  ·           table     tt@a                          ·                                                    ·
 2  ·           spans     /#-/10                        ·                                                    ·
 2  scan        ·         ·                             (x int, y int, rowid[hidden,omitted] int)            ·

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -189,13 +189,11 @@ EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 query ITTTTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-0  distinct  ·         ·          (k int)                  key(k); +k
-0  ·         key       k          ·                        ·
-1  render    ·         ·          (k int)                  key(k); +k
-1  ·         render 0  (k)[int]   ·                        ·
-2  scan      ·         ·          (k int, v[omitted] int)  key(k); +k
-2  ·         table     t@primary  ·                        ·
-2  ·         spans     ALL        ·                        ·
+0  render  ·         ·          (k int)                  key(k)
+0  ·       render 0  (k)[int]   ·                        ·
+1  scan    ·         ·          (k int, v[omitted] int)  key(k)
+1  ·       table     t@primary  ·                        ·
+1  ·       spans     ALL        ·                        ·
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT DISTINCT k FROM t

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -626,10 +626,10 @@ EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 0  render  ·      ·                  (x, y)                                                                        ·
 1  join    ·      ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
 1  ·       type   cross              ·                                                                             ·
-2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                        ·
+2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                        key(rowid)
 2  ·       table  twocolumn@primary  ·                                                                             ·
 2  ·       spans  ALL                ·                                                                             ·
-2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                        ·
+2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                        key(rowid)
 2  ·       table  twocolumn@primary  ·                                                                             ·
 2  ·       spans  ALL                ·                                                                             ·
 
@@ -640,10 +640,10 @@ EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 1  join    ·         ·                  (x[omitted], x[hidden,omitted], y[omitted], rowid[hidden,omitted], x[hidden,omitted], y, rowid[hidden,omitted])  ·
 1  ·       type      inner              ·                                                                                                                ·
 1  ·       equality  (x) = (x)          ·                                                                                                                ·
-2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                                           ·
+2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                                           key(rowid)
 2  ·       table     twocolumn@primary  ·                                                                                                                ·
 2  ·       spans     ALL                ·                                                                                                                ·
-2  scan    ·         ·                  (x, y, rowid[hidden,omitted])                                                                                    ·
+2  scan    ·         ·                  (x, y, rowid[hidden,omitted])                                                                                    key(rowid)
 2  ·       table     twocolumn@primary  ·                                                                                                                ·
 2  ·       spans     ALL                ·                                                                                                                ·
 
@@ -654,10 +654,10 @@ EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = 
 1  join    ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
 1  ·       type      inner              ·                                                                                      ·
 1  ·       equality  (x) = (x)          ·                                                                                      ·
-2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 ·
+2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 key(rowid)
 2  ·       table     twocolumn@primary  ·                                                                                      ·
 2  ·       spans     ALL                ·                                                                                      ·
-2  scan    ·         ·                  (x, y, rowid[hidden,omitted])                                                          ·
+2  scan    ·         ·                  (x, y, rowid[hidden,omitted])                                                          key(rowid)
 2  ·       table     twocolumn@primary  ·                                                                                      ·
 2  ·       spans     ALL                ·                                                                                      ·
 
@@ -667,10 +667,10 @@ EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < 
 0  render  ·      ·                  (x)                                                                                    ·
 1  join    ·      ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
 1  ·       type   inner              ·                                                                                      ·
-2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                                 ·
+2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                                 key(rowid)
 2  ·       table  twocolumn@primary  ·                                                                                      ·
 2  ·       spans  ALL                ·                                                                                      ·
-2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                                 ·
+2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                                 key(rowid)
 2  ·       table  twocolumn@primary  ·                                                                                      ·
 2  ·       spans  ALL                ·                                                                                      ·
 
@@ -925,10 +925,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.s
 1  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
 1  ·       type      inner                                           ·                                     ·
 1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
-2  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         ·
+2  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         key(rowid)
 2  ·       table     pairs@primary                                   ·                                     ·
 2  ·       spans     ALL                                             ·                                     ·
-2  scan    ·         ·                                               (n, sq)                               ·
+2  scan    ·         ·                                               (n, sq)                               key(n)
 2  ·       table     square@primary                                  ·                                     ·
 2  ·       spans     ALL                                             ·                                     ·
 
@@ -960,10 +960,10 @@ EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM
 2  ·       render 4  test.square.sq               ·                                     ·
 3  join    ·         ·                            (a, b, rowid[hidden,omitted], n, sq)  ·
 3  ·       type      cross                        ·                                     ·
-4  scan    ·         ·                            (a, b, rowid[hidden,omitted])         ·
+4  scan    ·         ·                            (a, b, rowid[hidden,omitted])         key(rowid)
 4  ·       table     pairs@primary                ·                                     ·
 4  ·       spans     ALL                          ·                                     ·
-4  scan    ·         ·                            (n, sq)                               ·
+4  scan    ·         ·                            (n, sq)                               key(n)
 4  ·       table     square@primary               ·                                     ·
 4  ·       spans     ALL                          ·                                     ·
 
@@ -986,10 +986,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.
 1  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
 1  ·       type      full outer                                      ·                                     ·
 1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
-2  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         ·
+2  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         key(rowid)
 2  ·       table     pairs@primary                                   ·                                     ·
 2  ·       spans     ALL                                             ·                                     ·
-2  scan    ·         ·                                               (n, sq)                               ·
+2  scan    ·         ·                                               (n, sq)                               key(n)
 2  ·       table     square@primary                                  ·                                     ·
 2  ·       spans     ALL                                             ·                                     ·
 
@@ -1029,10 +1029,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.
 2  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
 2  ·       type      full outer                                      ·                                     ·
 2  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
-3  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         ·
+3  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         key(rowid)
 3  ·       table     pairs@primary                                   ·                                     ·
 3  ·       spans     ALL                                             ·                                     ·
-3  scan    ·         ·                                               (n, sq)                               ·
+3  scan    ·         ·                                               (n, sq)                               key(n)
 3  ·       table     square@primary                                  ·                                     ·
 3  ·       spans     ALL                                             ·                                     ·
 
@@ -1238,10 +1238,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = 
 0  ·     type            inner                  ·                         ·
 0  ·     equality        (a, b, c) = (a, b, c)  ·                         ·
 0  ·     mergeJoinOrder  +"(b=b)"               ·                         ·
-1  scan  ·               ·                      (a, b, c, d)              +b
+1  scan  ·               ·                      (a, b, c, d)              key(a,b); +b
 1  ·     table           pkba@primary           ·                         ·
 1  ·     spans           ALL                    ·                         ·
-1  scan  ·               ·                      (a, b, c, d)              +b
+1  scan  ·               ·                      (a, b, c, d)              key(b,c); +b
 1  ·     table           pkbc@primary           ·                         ·
 1  ·     spans           ALL                    ·                         ·
 
@@ -1257,10 +1257,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
 1  ·       type            inner                        ·                                                                                                                                                                     ·
 1  ·       equality        (a, b, c, d) = (a, b, c, d)  ·                                                                                                                                                                     ·
 1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(d=d)"   ·                                                                                                                                                                     ·
-2  scan    ·               ·                            (a, b, c, d)                                                                                                                                                          +b,+a; key
+2  scan    ·               ·                            (a, b, c, d)                                                                                                                                                          key(a,b); +b,+a
 2  ·       table           pkba@primary                 ·                                                                                                                                                                     ·
 2  ·       spans           ALL                          ·                                                                                                                                                                     ·
-2  scan    ·               ·                            (a, b, c, d)                                                                                                                                                          +b,+a,+d; key
+2  scan    ·               ·                            (a, b, c, d)                                                                                                                                                          key(a,b,d); +b,+a,+d
 2  ·       table           pkbad@primary                ·                                                                                                                                                                     ·
 2  ·       spans           ALL                          ·                                                                                                                                                                     ·
 
@@ -1277,10 +1277,10 @@ EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 1  ·       type            inner                       ·                                                                                                                                  ·
 1  ·       equality        (a, b, c) = (a, b, c)       ·                                                                                                                                  ·
 1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                                                                                                                                  ·
-2  scan    ·               ·                           (a, b, c, d)                                                                                                                       +b,+a,+c; key
+2  scan    ·               ·                           (a, b, c, d)                                                                                                                       key(a,b,c); +b,+a,+c
 2  ·       table           pkbac@primary               ·                                                                                                                                  ·
 2  ·       spans           ALL                         ·                                                                                                                                  ·
-2  scan    ·               ·                           (a, b, c, d)                                                                                                                       +b,+a,+c; key
+2  scan    ·               ·                           (a, b, c, d)                                                                                                                       key(a,b,c); +b,+a,+c
 2  ·       table           pkbac@primary               ·                                                                                                                                  ·
 2  ·       spans           ALL                         ·                                                                                                                                  ·
 
@@ -1291,9 +1291,9 @@ EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a 
 0  ·     type            inner                       ·                         ·
 0  ·     equality        (c, a, b) = (d, a, b)       ·                         ·
 0  ·     mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
-1  scan  ·               ·                           (a, b, c, d)              +b,+a,+c; key
+1  scan  ·               ·                           (a, b, c, d)              key(a,b,c); +b,+a,+c
 1  ·     table           pkbac@primary               ·                         ·
 1  ·     spans           ALL                         ·                         ·
-1  scan  ·               ·                           (a, b, c, d)              +b,+a,+d; key
+1  scan  ·               ·                           (a, b, c, d)              key(a,b,d); +b,+a,+d
 1  ·     table           pkbad@primary               ·                         ·
 1  ·     spans           ALL                         ·                         ·

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -61,10 +61,10 @@ query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
 ----
 Level  Type        Field   Description  Columns                      Ordering
-0      limit       ·       ·            (k, v, w)                    +v
+0      limit       ·       ·            (k, v, w)                    key(k,v); +v
 0      ·           count   2            ·                            ·
-1      index-join  ·       ·            (k, v, w)                    +v
-2      scan        ·       ·            (k, v[omitted], w[omitted])  +v
+1      index-join  ·       ·            (k, v, w)                    key(k,v); +v
+2      scan        ·       ·            (k, v[omitted], w[omitted])  key(k,v); +v
 2      ·           table   t@t_v_idx    ·                            ·
 2      ·           spans   /5-          ·                            ·
 2      scan        ·       ·            (k, v, w)                    ·

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -67,7 +67,7 @@ query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s) WITH ORDINALITY
 ----
 0  render      ·  ·  ("1")                       "1"=CONST
-1  ordinality  ·  ·  (s[omitted], "ordinality")  ·
+1  ordinality  ·  ·  (s[omitted], "ordinality")  key("ordinality")
 2  render      ·  ·  (s[omitted])                ·
 3  emptyrow    ·  ·  ()                          ·
 
@@ -109,7 +109,7 @@ query ITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM kv
 ----
 0  render  ·      ·           ("1")                     "1"=CONST
-1  scan    ·      ·           (k[omitted], v[omitted])  ·
+1  scan    ·      ·           (k[omitted], v[omitted])  key(k)
 1  ·       table  kv@primary  ·                         ·
 1  ·       spans  ALL         ·                         ·
 
@@ -119,7 +119,7 @@ EXPLAIN (METADATA) SELECT DISTINCT v FROM kv
 ----
 0  distinct  ·      ·           (v)              ·
 1  render    ·      ·           (v)              ·
-2  scan      ·      ·           (k[omitted], v)  ·
+2  scan      ·      ·           (k[omitted], v)  key(k)
 2  ·         table  kv@primary  ·                ·
 2  ·         spans  ALL         ·                ·
 
@@ -139,8 +139,8 @@ EXPLAIN (METADATA) DELETE FROM kv WHERE k = 3
 ----
 0  delete  ·      ·           ()               ·
 0  ·       from   kv          ·                ·
-1  render  ·      ·           (k)              ·
-2  scan    ·      ·           (k, v[omitted])  ·
+1  render  ·      ·           (k)              key(k)
+2  scan    ·      ·           (k, v[omitted])  key(k)
 2  ·       table  kv@primary  ·                ·
 2  ·       spans  /3-/4       ·                ·
 
@@ -163,7 +163,7 @@ EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT k+1 AS x, v-2 AS y FROM kv)
 ----
 0  render  ·         ·           ("1")                     "1"=CONST
 0  ·       render 0  1           ·                         ·
-1  scan    ·         ·           (k[omitted], v[omitted])  ·
+1  scan    ·         ·           (k[omitted], v[omitted])  key(k)
 1  ·       table     kv@primary  ·                         ·
 1  ·       spans     ALL         ·                         ·
 
@@ -179,7 +179,7 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT "name", age FROM a);
 2  render  ·            ·             ("name"[omitted], age[omitted])                         ·
 2  ·       render 0     NULL          ·                                                       ·
 2  ·       render 1     NULL          ·                                                       ·
-3  scan    ·            ·             ("name"[omitted], age[omitted], rowid[hidden,omitted])  ·
+3  scan    ·            ·             ("name"[omitted], age[omitted], rowid[hidden,omitted])  key(rowid)
 3  ·       table        a@primary     ·                                                       ·
 3  ·       spans        ALL           ·                                                       ·
 
@@ -195,6 +195,6 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM ab WHERE a=1
 0  group   ·            ·             ("count(*)")              ·
 0  ·       aggregate 0  count_rows()  ·                         ·
 1  render  ·            ·             ()                        ·
-2  scan    ·            ·             (a[omitted], b[omitted])  ·
+2  scan    ·            ·             (a[omitted], b[omitted])  key(a,b)
 2  ·       table        ab@primary    ·                         ·
 2  ·       spans        /1-/2         ·                         ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -198,7 +198,7 @@ EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, t.*)
 ----
 0  sort  ·      ·          (a, b, c)  +b,+a,+c
 0  ·     order  +b,+a,+c   ·          ·
-1  scan  ·      ·          (a, b, c)  ·
+1  scan  ·      ·          (a, b, c)  key(a)
 1  ·     table  t@primary  ·          ·
 1  ·     spans  ALL        ·          ·
 
@@ -207,7 +207,7 @@ EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, a), c
 ----
 0  sort  ·      ·          (a, b, c)  +b,+a,+c
 0  ·     order  +b,+a,+c   ·          ·
-1  scan  ·      ·          (a, b, c)  ·
+1  scan  ·      ·          (a, b, c)  key(a)
 1  ·     table  t@primary  ·          ·
 1  ·     spans  ALL        ·          ·
 
@@ -216,7 +216,7 @@ EXPLAIN(METADATA) SELECT * FROM t ORDER BY b, (a, c)
 ----
 0  sort  ·      ·          (a, b, c)  +b,+a,+c
 0  ·     order  +b,+a,+c   ·          ·
-1  scan  ·      ·          (a, b, c)  ·
+1  scan  ·      ·          (a, b, c)  key(a)
 1  ·     table  t@primary  ·          ·
 1  ·     spans  ALL        ·          ·
 
@@ -225,7 +225,7 @@ EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, (a, c))
 ----
 0  sort  ·      ·          (a, b, c)  +b,+a,+c
 0  ·     order  +b,+a,+c   ·          ·
-1  scan  ·      ·          (a, b, c)  ·
+1  scan  ·      ·          (a, b, c)  key(a)
 1  ·     table  t@primary  ·          ·
 1  ·     spans  ALL        ·          ·
 
@@ -377,7 +377,7 @@ EXPLAIN (METADATA) SELECT b+2 FROM t ORDER BY b+2
 0  sort    ·      ·          ("b + 2")                    +"b + 2"
 0  ·       order  +"b + 2"   ·                            ·
 1  render  ·      ·          ("b + 2")                    ·
-2  scan    ·      ·          (a[omitted], b, c[omitted])  ·
+2  scan    ·      ·          (a[omitted], b, c[omitted])  key(a)
 2  ·       table  t@primary  ·                            ·
 2  ·       spans  ALL        ·                            ·
 
@@ -388,7 +388,7 @@ EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY y
 0  sort    ·      ·          (y)                          +y
 0  ·       order  +y         ·                            ·
 1  render  ·      ·          (y)                          ·
-2  scan    ·      ·          (a[omitted], b, c[omitted])  ·
+2  scan    ·      ·          (a[omitted], b, c[omitted])  key(a)
 2  ·       table  t@primary  ·                            ·
 2  ·       spans  ALL        ·                            ·
 
@@ -399,7 +399,7 @@ EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
 0  sort    ·      ·          (y)                          +y
 0  ·       order  +y         ·                            ·
 1  render  ·      ·          (y)                          ·
-2  scan    ·      ·          (a[omitted], b, c[omitted])  ·
+2  scan    ·      ·          (a[omitted], b, c[omitted])  key(a)
 2  ·       table  t@primary  ·                            ·
 2  ·       spans  ALL        ·                            ·
 
@@ -510,11 +510,11 @@ EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
 0  nosort  ·         ·           (a, b)                 +b
 0  ·       order     +b,+c       ·                      ·
-1  render  ·         ·           (a, b, c)              +b,+c; key
+1  render  ·         ·           (a, b, c)              key(b,c); +b,+c
 1  ·       render 0  test.abc.a  ·                      ·
 1  ·       render 1  test.abc.b  ·                      ·
 1  ·       render 2  test.abc.c  ·                      ·
-2  scan    ·         ·           (a, b, c, d[omitted])  +b,+c; key
+2  scan    ·         ·           (a, b, c, d[omitted])  key(b,c); +b,+c
 2  ·       table     abc@bc      ·                      ·
 2  ·       spans     ALL         ·                      ·
 
@@ -611,10 +611,10 @@ EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-0  nosort  ·      ·            (b, c)                          +b,+c; key
+0  nosort  ·      ·            (b, c)                          key(b,c); +b,+c
 0  ·       order  +b,+c        ·                               ·
-1  render  ·      ·            (b, c, a[omitted])     a=CONST; +b,+c; key
-2  scan    ·      ·            (a[omitted], b, c, d[omitted])  a=CONST; +b,+c; key
+1  render  ·      ·            (b, c, a[omitted])              a=CONST; key(b,c); +b,+c
+2  scan    ·      ·            (a[omitted], b, c, d[omitted])  a=CONST; key(b,c); +b,+c
 2  ·       table  abc@primary  ·                               ·
 2  ·       spans  /1-/2        ·                               ·
 
@@ -627,7 +627,7 @@ INSERT INTO bar VALUES (0, NULL), (1, NULL)
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM bar ORDER BY baz, id
 ----
-0  scan  ·      ·          (id, baz)  +baz; key
+0  scan  ·      ·          (id, baz)  key(baz); +baz
 0  ·     table  bar@i_bar  ·          ·
 0  ·     spans  ALL        ·          ·
 
@@ -727,14 +727,14 @@ EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordi
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
-0  ordinality  ·     ·                 (x, "ordinality")  ·
+0  ordinality  ·     ·                 (x, "ordinality")  key("ordinality")
 1  values      ·     ·                 (x)                ·
 1  ·           size  1 column, 3 rows  ·                  ·
 
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
-0  ordinality  ·      ·                 (x, "ordinality")  ·
+0  ordinality  ·      ·                 (x, "ordinality")  key("ordinality")
 1  sort        ·      ·                 (x)                +x
 1  ·           order  +x                ·                  ·
 2  values      ·      ·                 (x)                ·
@@ -754,7 +754,7 @@ EXPLAIN (METADATA) DELETE FROM t WHERE a = 3 RETURNING b
 ----
 0  delete  ·      ·          (b)        ·
 0  ·       from   t          ·          ·
-1  scan    ·      ·          (a, b, c)  ·
+1  scan    ·      ·          (a, b, c)  key(a)
 1  ·       table  t@primary  ·          ·
 1  ·       spans  /3-/4      ·          ·
 
@@ -764,8 +764,8 @@ EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b
 0  update  ·      ·          (b)                ·
 0  ·       table  t          ·                  ·
 0  ·       set    c          ·                  ·
-1  render  ·      ·          (a, b, c, "true")  "true"=CONST
-2  scan    ·      ·          (a, b, c)          ·
+1  render  ·      ·          (a, b, c, "true")  "true"=CONST; key(a)
+2  scan    ·      ·          (a, b, c)          key(a)
 2  ·       table  t@primary  ·                  ·
 2  ·       spans  ALL        ·                  ·
 
@@ -787,7 +787,7 @@ query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
 0  render  ·      ·            (y, w, x)                                                             y=CONST; +w,+x
-1  scan    ·      ·            (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  y=CONST; +w,+x
+1  scan    ·      ·            (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  y=CONST; key(u,v,w,x,z,rowid); +w,+x
 1  ·       table  uvwxyz@ywxz  ·                                                                     ·
 1  ·       spans  /1-/2        ·                                                                     ·
 
@@ -806,9 +806,9 @@ CREATE TABLE blocks (
 query ITTTTT
 EXPLAIN (METADATA) SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
 ----
-0  limit   ·      ·               (block_id, writer_id, block_num, block_id)            block_id=block_id; +block_id,+writer_id,+block_num; key
-1  render  ·      ·               (block_id, writer_id, block_num, block_id)            block_id=block_id; +block_id,+writer_id,+block_num; key
-2  scan    ·      ·               (block_id, writer_id, block_num, raw_bytes[omitted])  +block_id,+writer_id,+block_num; key
+0  limit   ·      ·               (block_id, writer_id, block_num, block_id)            block_id=block_id; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+1  render  ·      ·               (block_id, writer_id, block_num, block_id)            block_id=block_id; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+2  scan    ·      ·               (block_id, writer_id, block_num, raw_bytes[omitted])  key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
 2  ·       table  blocks@primary  ·                                                     ·
 2  ·       spans  ALL             ·                                                     ·
 2  ·       limit  1               ·                                                     ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -8,8 +8,8 @@ EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv
 ----
 0  nosort  ·      ·           (v)     ·
 0  ·       order  +k          ·       ·
-1  render  ·      ·           (v, k)  +k; key
-2  scan    ·      ·           (k, v)  +k; key
+1  render  ·      ·           (v, k)  key(k); +k
+2  scan    ·      ·           (k, v)  key(k); +k
 2  ·       table  kv@primary  ·       ·
 2  ·       spans  ALL         ·       ·
 
@@ -18,8 +18,8 @@ EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
 ----
 0  nosort  ·      ·           (v)     ·
 0  ·       order  +k          ·       ·
-1  render  ·      ·           (v, k)  +k; key
-2  scan    ·      ·           (k, v)  +k; key
+1  render  ·      ·           (v, k)  key(k); +k
+2  scan    ·      ·           (k, v)  key(k); +k
 2  ·       table  kv@primary  ·       ·
 2  ·       spans  ALL         ·       ·
 
@@ -28,8 +28,8 @@ EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
 ----
 0  nosort   ·      ·           (v)     ·
 0  ·        order  -k          ·       ·
-1  render   ·      ·           (v, k)  -k; key
-2  revscan  ·      ·           (k, v)  -k; key
+1  render   ·      ·           (v, k)  key(k); -k
+2  revscan  ·      ·           (k, v)  key(k); -k
 2  ·        table  kv@primary  ·       ·
 2  ·        spans  ALL         ·       ·
 
@@ -38,8 +38,8 @@ EXPLAIN (METADATA) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
 ----
 0  sort     ·      ·               (k)              ·
 0  ·        order  +v,+k,+"v - 2"  ·                ·
-1  render   ·      ·               (k, v, "v - 2")  +v
-2  revscan  ·      ·               (k, v)           +v
+1  render   ·      ·               (k, v, "v - 2")  key(k,v); +v
+2  revscan  ·      ·               (k, v)           key(k,v); +v
 2  ·        table  kv@foo          ·                ·
 2  ·        spans  ALL             ·                ·
 
@@ -48,7 +48,7 @@ EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
 0  nosort  ·      ·       (k)     ·
 0  ·       order  -v      ·       ·
-1  scan    ·      ·       (k, v)  -v
+1  scan    ·      ·       (k, v)  key(k,v); -v
 1  ·       table  kv@foo  ·       ·
 1  ·       spans  ALL     ·       ·
 
@@ -57,7 +57,7 @@ EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
 0  nosort  ·      ·       (k)     ·
 0  ·       order  -v      ·       ·
-1  scan    ·      ·       (k, v)  -v
+1  scan    ·      ·       (k, v)  key(k,v); -v
 1  ·       table  kv@foo  ·       ·
 1  ·       spans  ALL     ·       ·
 
@@ -66,7 +66,7 @@ EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
 0  nosort   ·      ·       (k)     ·
 0  ·        order  +v      ·       ·
-1  revscan  ·      ·       (k, v)  +v
+1  revscan  ·      ·       (k, v)  key(k,v); +v
 1  ·        table  kv@foo  ·       ·
 1  ·        spans  ALL     ·       ·
 
@@ -75,7 +75,7 @@ EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
 0  nosort  ·      ·       (k)     ·
 0  ·       order  -v,+k   ·       ·
-1  scan    ·      ·       (k, v)  -v,+k; key
+1  scan    ·      ·       (k, v)  key(k,v); -v,+k
 1  ·       table  kv@foo  ·       ·
 1  ·       spans  ALL     ·       ·
 
@@ -94,7 +94,7 @@ EXPLAIN(METADATA) SELECT k FROM kv JOIN (VALUES (1,2)) AS z(a,b) ON kv.k = z.a O
 2  join    ·         ·                 (k, v, a[omitted], b[omitted])  ·
 2  ·       type      inner             ·                               ·
 2  ·       equality  (k) = (a)         ·                               ·
-3  scan    ·         ·                 (k, v)                          ·
+3  scan    ·         ·                 (k, v)                          key(k)
 3  ·       table     kv@primary        ·                               ·
 3  ·       spans     ALL               ·                               ·
 3  values  ·         ·                 (column1, column2[omitted])     ·
@@ -110,10 +110,10 @@ EXPLAIN(METADATA) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 2  ·       type            inner            ·                                                                                    ·
 2  ·       equality        (k, v) = (k, v)  ·                                                                                    ·
 2  ·       mergeJoinOrder  +"(k=k)"         ·                                                                                    ·
-3  scan    ·               ·                (k, v)                                                                               +k; key
+3  scan    ·               ·                (k, v)                                                                               key(k); +k
 3  ·       table           kv@primary       ·                                                                                    ·
 3  ·       spans           ALL              ·                                                                                    ·
-3  scan    ·               ·                (k, v)                                                                               +k; key
+3  scan    ·               ·                (k, v)                                                                               key(k); +k
 3  ·       table           kv@primary       ·                                                                                    ·
 3  ·       spans           ALL              ·                                                                                    ·
 
@@ -128,10 +128,10 @@ EXPLAIN(METADATA) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@f
 2  ·       type            inner              ·                                                                                    ·
 2  ·       equality        (k, v) = (k, v)    ·                                                                                    ·
 2  ·       mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                                                                                    ·
-3  scan    ·               ·                  (k, v)                                                                               -v,+k; key
+3  scan    ·               ·                  (k, v)                                                                               key(k,v); -v,+k
 3  ·       table           kv@foo             ·                                                                                    ·
 3  ·       spans           ALL                ·                                                                                    ·
-3  scan    ·               ·                  (k, v)                                                                               -v,+k; key
+3  scan    ·               ·                  (k, v)                                                                               key(k,v); -v,+k
 3  ·       table           kv@foo             ·                                                                                    ·
 3  ·       spans           ALL                ·                                                                                    ·
 

--- a/pkg/sql/logictest/testdata/logic_test/ordinal_references
+++ b/pkg/sql/logictest/testdata/logic_test/ordinal_references
@@ -55,7 +55,7 @@ EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @1
 1  render  ·         ·            (b, a)                         ·
 1  ·       render 0  test.foo.b   ·                              ·
 1  ·       render 1  test.foo.a   ·                              ·
-2  scan    ·         ·            (a, b, rowid[hidden,omitted])  ·
+2  scan    ·         ·            (a, b, rowid[hidden,omitted])  key(rowid)
 2  ·       table     foo@primary  ·                              ·
 2  ·       spans     ALL          ·                              ·
 
@@ -88,7 +88,7 @@ EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 0  ·       group by     @1-@1            ·                                       ·
 1  render  ·            ·                (a)                                     ·
 1  ·       render 0     test.foo.a       ·                                       ·
-2  scan    ·            ·                (a, b[omitted], rowid[hidden,omitted])  ·
+2  scan    ·            ·                (a, b[omitted], rowid[hidden,omitted])  key(rowid)
 2  ·       table        foo@primary      ·                                       ·
 2  ·       spans        ALL              ·                                       ·
 
@@ -101,7 +101,7 @@ EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 1  render  ·            ·                (b, a)                         ·
 1  ·       render 0     test.foo.b       ·                              ·
 1  ·       render 1     test.foo.a       ·                              ·
-2  scan    ·            ·                (a, b, rowid[hidden,omitted])  ·
+2  scan    ·            ·                (a, b, rowid[hidden,omitted])  key(rowid)
 2  ·       table        foo@primary      ·                              ·
 2  ·       spans        ALL              ·                              ·
 

--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -85,8 +85,8 @@ true
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
 ----
-0  ordinality  ·      ·            (x, "ordinality")  ·
-1  scan        ·      ·            (x)                ·
+0  ordinality  ·      ·            (x, "ordinality")  key(x); key("ordinality")
+1  scan        ·      ·            (x)                key(x)
 1  ·           table  foo@primary  ·                  ·
 1  ·           spans  /"a\x00"-    ·                  ·
 
@@ -95,8 +95,8 @@ EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALI
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
 ----
-0  filter      ·      ·            (x, "ordinality")  ·
-1  ordinality  ·      ·            (x, "ordinality")  ·
-2  scan        ·      ·            (x)                ·
+0  filter      ·      ·            (x, "ordinality")  key(x); key("ordinality")
+1  ordinality  ·      ·            (x, "ordinality")  key(x); key("ordinality")
+2  scan        ·      ·            (x)                key(x)
 2  ·           table  foo@primary  ·                  ·
 2  ·           spans  ALL          ·                  ·

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -114,9 +114,9 @@ EXPLAIN (METADATA) ALTER TABLE t SPLIT AT SELECT k1,k2 FROM t ORDER BY k1 LIMIT 
 ----
 Level  Type    Field  Description  Columns                           Ordering
 0      split   ·      ·            (key, pretty)                     ·
-1      limit   ·      ·            (k1, k2)                          +k1
-2      render  ·      ·            (k1, k2)                          +k1
-3      scan    ·      ·            (k1, k2, v[omitted], w[omitted])  +k1
+1      limit   ·      ·            (k1, k2)                          key(k1,k2); +k1
+2      render  ·      ·            (k1, k2)                          key(k1,k2); +k1
+3      scan    ·      ·            (k1, k2, v[omitted], w[omitted])  key(k1,k2); +k1
 3      ·       table  t@primary    ·                                 ·
 3      ·       spans  ALL          ·                                 ·
 3      ·       limit  3            ·                                 ·

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -523,9 +523,9 @@ CREATE TABLE tab0(
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
 ----
-0  render  ·         ·                                     (k)        ·
+0  render  ·         ·                                     (k)        key(k)
 0  ·       render 0  test.tab0.k                           ·          ·
-1  scan    ·         ·                                     (k, a, b)  ·
+1  scan    ·         ·                                     (k, a, b)  key(k)
 1  ·       table     tab0@primary                          ·          ·
 1  ·       spans     ALL                                   ·          ·
 1  ·       filter    ((a IN (6)) AND (a > 6)) OR (b >= 4)  ·          ·

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
@@ -72,8 +72,8 @@ SELECT * FROM t WHERE c = 7
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 ----
-0  index-join  ·      ·          (a, b, c, d)                             -c; key
-1  revscan     ·      ·          (a, b[omitted], c[omitted], d[omitted])  -c; key
+0  index-join  ·      ·          (a, b, c, d)                             key(c); -c
+1  revscan     ·      ·          (a, b[omitted], c[omitted], d[omitted])  key(c); -c
 1  ·           table  t@c        ·                                        ·
 1  ·           spans  /1-        ·                                        ·
 1  scan        ·      ·          (a, b, c, d)                             ·

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
@@ -136,8 +136,8 @@ EXPLAIN (VERBOSE) SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s !=
 ----
 0  render      ·         ·          (a)                                      ·
 0  ·           render 0  test.t.a   ·                                        ·
-1  index-join  ·         ·          (a, b[omitted], c[omitted], s[omitted])  ·
-2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  ·
+1  index-join  ·         ·          (a, b[omitted], c[omitted], s[omitted])  key(a,b,c)
+2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  key(a,b,c)
 2  ·           table     t@bc       ·                                        ·
 2  ·           spans     /2-/3      ·                                        ·
 2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  ·

--- a/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
+++ b/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
@@ -34,10 +34,10 @@ EXPLAIN(VERBOSE) SELECT COUNT(DISTINCT x.*) FROM a x, a y
 1  ·       render 0     (x.x, x.y)                  ·                                                                             ·
 2  join    ·            ·                           (x, y, rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
 2  ·       type         cross                       ·                                                                             ·
-3  scan    ·            ·                           (x, y, rowid[hidden,omitted])                                                 ·
+3  scan    ·            ·                           (x, y, rowid[hidden,omitted])                                                 key(rowid)
 3  ·       table        a@primary                   ·                                                                             ·
 3  ·       spans        ALL                         ·                                                                             ·
-3  scan    ·            ·                           (x[omitted], y[omitted], rowid[hidden,omitted])                               ·
+3  scan    ·            ·                           (x[omitted], y[omitted], rowid[hidden,omitted])                               key(rowid)
 3  ·       table        a@primary                   ·                                                                             ·
 3  ·       spans        ALL                         ·                                                                             ·
 

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -342,13 +342,13 @@ true
 query ITTTTT
 EXPLAIN (METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
 ----
-0  render  ·           ·            (x)                          ·
-1  scan    ·           ·            (x, y[omitted], z[omitted])  ·
+0  render  ·           ·            (x)                          key(x)
+1  scan    ·           ·            (x, y[omitted], z[omitted])  key(x)
 1  ·       table       xyz@primary  ·                            ·
 1  ·       spans       ALL          ·                            ·
 1  ·       subqueries  1            ·                            ·
-2  render  ·           ·            (x)                          ·
-3  scan    ·           ·            (x, y[omitted], z[omitted])  ·
+2  render  ·           ·            (x)                          key(x)
+3  scan    ·           ·            (x, y[omitted], z[omitted])  key(x)
 3  ·       table       xyz@primary  ·                            ·
 3  ·       spans       ALL          ·                            ·
 

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -349,8 +349,8 @@ EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (1, 2)
 0  update  ·      ·            ()                   ·
 0  ·       table  xyz          ·                    ·
 0  ·       set    x, y         ·                    ·
-1  render  ·      ·            (x, y, z, "1", "2")  "1"=CONST; "2"=CONST
-2  scan    ·      ·            (x, y, z)            ·
+1  render  ·      ·            (x, y, z, "1", "2")  "1"=CONST; "2"=CONST; key(x)
+2  scan    ·      ·            (x, y, z)            key(x)
 2  ·       table  xyz@primary  ·                    ·
 2  ·       spans  ALL          ·                    ·
 
@@ -360,7 +360,7 @@ EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (y, x)
 0  update  ·      ·            ()         ·
 0  ·       table  xyz          ·          ·
 0  ·       set    x, y         ·          ·
-1  scan    ·      ·            (x, y, z)  ·
+1  scan    ·      ·            (x, y, z)  key(x)
 1  ·       table  xyz@primary  ·          ·
 1  ·       spans  ALL          ·          ·
 
@@ -370,8 +370,8 @@ EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (2, 2)
 0  update  ·      ·            ()              ·
 0  ·       table  xyz          ·               ·
 0  ·       set    x, y         ·               ·
-1  render  ·      ·            (x, y, z, "2")  "2"=CONST
-2  scan    ·      ·            (x, y, z)       ·
+1  render  ·      ·            (x, y, z, "2")  "2"=CONST; key(x)
+2  scan    ·      ·            (x, y, z)       key(x)
 2  ·       table  xyz@primary  ·               ·
 2  ·       spans  ALL          ·               ·
 

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -522,12 +522,12 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) 
 1  ·       window 1  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
 1  ·       render 1  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
 1  ·       render 2  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
-2  render  ·         ·                                         (k int, d decimal, d decimal, v int)                                                             d=d
+2  render  ·         ·                                         (k int, d decimal, d decimal, v int)                                                             d=d; key(k)
 2  ·       render 0  (k)[int]                                  ·                                                                                                ·
 2  ·       render 1  (d)[decimal]                              ·                                                                                                ·
 2  ·       render 2  (d)[decimal]                              ·                                                                                                ·
 2  ·       render 3  (v)[int]                                  ·                                                                                                ·
-3  scan    ·         ·                                         (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  ·
+3  scan    ·         ·                                         (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  key(k)
 3  ·       table     kv@primary                                ·                                                                                                ·
 3  ·       spans     ALL                                       ·                                                                                                ·
 
@@ -541,14 +541,14 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY 
 1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                          ·
 1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                          ·
 1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                          ·
-2  render  ·         ·                                                                            (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                              d=d; "'a'"=CONST; "100"=CONST
+2  render  ·         ·                                                                            (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                              d=d; "'a'"=CONST; "100"=CONST; key(k)
 2  ·       render 0  (k)[int]                                                                     ·                                                                                                          ·
 2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                          ·
 2  ·       render 2  (d)[decimal]                                                                 ·                                                                                                          ·
 2  ·       render 3  (v)[int]                                                                     ·                                                                                                          ·
 2  ·       render 4  ('a')[string]                                                                ·                                                                                                          ·
 2  ·       render 5  (100)[int]                                                                   ·                                                                                                          ·
-3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)            ·
+3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)            key(k)
 3  ·       table     kv@primary                                                                   ·                                                                                                          ·
 3  ·       spans     ALL                                                                          ·                                                                                                          ·
 
@@ -560,12 +560,12 @@ EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM 
 1  window  ·         ·                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          ·
 1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
 1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
-2  render  ·         ·                                                                            (k int, d decimal, v int, "'a'" string)                                                          "'a'"=CONST
+2  render  ·         ·                                                                            (k int, d decimal, v int, "'a'" string)                                                          "'a'"=CONST; key(k)
 2  ·       render 0  (k)[int]                                                                     ·                                                                                                ·
 2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                ·
 2  ·       render 2  (v)[int]                                                                     ·                                                                                                ·
 2  ·       render 3  ('a')[string]                                                                ·                                                                                                ·
-3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  ·
+3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  key(k)
 3  ·       table     kv@primary                                                                   ·                                                                                                ·
 3  ·       spans     ALL                                                                          ·                                                                                                ·
 
@@ -579,14 +579,14 @@ EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER
 1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                              ·
 1  ·       render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                              ·
 1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                              ·
-2  render  ·         ·                                                                                                  (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                                  d=d; "'a'"=CONST; "100"=CONST
+2  render  ·         ·                                                                                                  (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                                  d=d; "'a'"=CONST; "100"=CONST; key(k)
 2  ·       render 0  (k)[int]                                                                                           ·                                                                                                              ·
 2  ·       render 1  (d)[decimal]                                                                                       ·                                                                                                              ·
 2  ·       render 2  (d)[decimal]                                                                                       ·                                                                                                              ·
 2  ·       render 3  (v)[int]                                                                                           ·                                                                                                              ·
 2  ·       render 4  ('a')[string]                                                                                      ·                                                                                                              ·
 2  ·       render 5  (100)[int]                                                                                         ·                                                                                                              ·
-3  scan    ·         ·                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                ·
+3  scan    ·         ·                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                key(k)
 3  ·       table     kv@primary                                                                                         ·                                                                                                              ·
 3  ·       spans     ALL                                                                                                ·                                                                                                              ·
 
@@ -613,11 +613,11 @@ EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FRO
 3  ·       aggregate 2  (d)[decimal]                                                                                                   ·                                                                                                                          ·
 3  ·       aggregate 3  (v)[int]                                                                                                       ·                                                                                                                          ·
 3  ·       group by     @1-@2                                                                                                          ·                                                                                                                          ·
-4  render  ·            ·                                                                                                              (d decimal, v int, k int)                                                                                                  ·
+4  render  ·            ·                                                                                                              (d decimal, v int, k int)                                                                                                  key(k)
 4  ·       render 0     (d)[decimal]                                                                                                   ·                                                                                                                          ·
 4  ·       render 1     (v)[int]                                                                                                       ·                                                                                                                          ·
 4  ·       render 2     (k)[int]                                                                                                       ·                                                                                                                          ·
-5  scan    ·            ·                                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                            ·
+5  scan    ·            ·                                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                            key(k)
 5  ·       table        kv@primary                                                                                                     ·                                                                                                                          ·
 5  ·       spans        ALL                                                                                                            ·                                                                                                                          ·
 
@@ -639,11 +639,11 @@ EXPLAIN (TYPES) SELECT MAX(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROU
 3  ·       aggregate 1  (d)[decimal]                                                                 ·                                                                                                ·
 3  ·       aggregate 2  (v)[int]                                                                     ·                                                                                                ·
 3  ·       group by     @1-@2                                                                        ·                                                                                                ·
-4  render  ·            ·                                                                            (d decimal, v int, k int)                                                                        ·
+4  render  ·            ·                                                                            (d decimal, v int, k int)                                                                        key(k)
 4  ·       render 0     (d)[decimal]                                                                 ·                                                                                                ·
 4  ·       render 1     (v)[int]                                                                     ·                                                                                                ·
 4  ·       render 2     (k)[int]                                                                     ·                                                                                                ·
-5  scan    ·            ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  ·
+5  scan    ·            ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  key(k)
 5  ·       table        kv@primary                                                                   ·                                                                                                ·
 5  ·       spans        ALL                                                                          ·                                                                                                ·
 

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
@@ -142,6 +143,9 @@ func (o *ordinalityNode) optimizeOrdering() {
 			ColIdx:    len(o.columns) - 1,
 			Direction: encoding.Ascending,
 		}}
-		o.ordering.isKey = true
 	}
+	// The ordinality column forms a key.
+	var k util.FastIntSet
+	k.Add(len(o.columns) - 1)
+	o.ordering.keySets = append(o.ordering.keySets, k)
 }

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -387,6 +387,7 @@ func (n *scanNode) computeOrdering(
 
 	columnIDs, dirs := index.FullColumnIDs()
 
+	var keySet util.FastIntSet
 	for i, colID := range columnIDs {
 		idx, ok := n.colIdxMap[colID]
 		if !ok {
@@ -401,11 +402,10 @@ func (n *scanNode) computeOrdering(
 			}
 			ordering.addOrderColumn(idx, dir)
 		}
+		keySet.Add(idx)
 	}
-	// We included any implicit columns, so the results are unique.
-	if len(ordering.ordering) > 0 {
-		ordering.isKey = true
-	}
+	// We included any implicit columns, so the columns form a key.
+	ordering.addKeySet(keySet)
 	return ordering
 }
 

--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -208,7 +208,7 @@ func (s *FastIntSet) SubsetOf(rhs FastIntSet) bool {
 	return (s1 & s2) == s1
 }
 
-func (s *FastIntSet) String() string {
+func (s FastIntSet) String() string {
 	var buf bytes.Buffer
 	buf.WriteByte('(')
 	first := true


### PR DESCRIPTION
#### sql: store information about keys in orderingInfo

We are now able to store information about column sets that form "keys", i.e.
all rows are distinct when projected on that set.

The existing structure had a very limited form of this, only keeping track if
the columns in the ordering form a key. Allowing arbitrary sets will enable more
optimizations.

#### sql: elide distinctNode if we have a key

An immediate application of the new key information is to elide distinct nodes
when possible.