### PR TITLE
sql/sqlbase: perf fix to fks on interleave parents

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -279,6 +279,9 @@ INSERT INTO orders
   (1, 1002, 80.00),
   (2, 1003, 70.00)
 
+statement error foreign key violation: value \[3\] not found in customers@primary \[id\]
+INSERT INTO orders VALUES (3, 1000, 100.0)
+
 query IIR
 SELECT * FROM orders WHERE customer = 1 AND id = 1000
 ----

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -374,12 +374,12 @@ func (f baseFKHelper) spanForValues(values parser.Datums) (roachpb.Span, error) 
 	} else {
 		key = roachpb.Key(f.searchPrefix)
 	}
-	return roachpb.Span{Key: key, EndKey: key.PrefixEnd()}, nil
+	return roachpb.Span{Key: key, EndKey: InterleaveEnd(key)}, nil
 }
 
 func (f baseFKHelper) span() roachpb.Span {
 	key := roachpb.Key(f.searchPrefix)
-	return roachpb.Span{Key: key, EndKey: key.PrefixEnd()}
+	return roachpb.Span{Key: key, EndKey: InterleaveEnd(key)}
 }
 
 // FkSpanCollector can collect the spans that foreign key validation will touch.

--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -485,7 +485,7 @@ func (*InterleaveDescriptor) ProtoMessage()               {}
 func (*InterleaveDescriptor) Descriptor() ([]byte, []int) { return fileDescriptorStructured, []int{4} }
 
 type InterleaveDescriptor_Ancestor struct {
-	// TableID the ID of the table being interleaved into.
+	// TableID is the ID of the table being interleaved into.
 	TableID ID `protobuf:"varint,1,opt,name=table_id,json=tableId,casttype=ID" json:"table_id"`
 	// IndexID is the ID of the parent index being interleaved into.
 	IndexID IndexID `protobuf:"varint,2,opt,name=index_id,json=indexId,casttype=IndexID" json:"index_id"`

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -154,7 +154,7 @@ message ColumnFamilyDescriptor {
 // grandparent) with shared lengths 2 and 1.
 message InterleaveDescriptor {
   message Ancestor {
-    // TableID the ID of the table being interleaved into.
+    // TableID is the ID of the table being interleaved into.
     optional uint32 table_id = 1 [(gogoproto.nullable) = false,
         (gogoproto.customname) = "TableID", (gogoproto.casttype) = "ID"];
     // IndexID is the ID of the parent index being interleaved into.

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -331,6 +331,13 @@ func EncodePartialIndexKey(
 	return key, containsNull, err
 }
 
+// InterleaveEnd returns the key at the end of the current interleave segment.
+// This is useful for constructing the end of the span over all keys for a single
+// row, without including any rows from tables interleaved into that row.
+func InterleaveEnd(key []byte) []byte {
+	return encoding.EncodeNotNullDescending(key)
+}
+
 type directions []IndexDescriptor_Direction
 
 func (d directions) get(i int) (encoding.Direction, error) {


### PR DESCRIPTION
The foreign key checker previously used an overly-wide span to scan to
check for foreign key existence that didn't take into account the fact
that there could tables interleaved into the foreign key table.

This patch tightens the span to include only those keys that are related
to the parent table's row.

For example, consider the following scenario:

```
CREATE TABLE t (a INT PRIMARY KEY);
CREATE TABLE u (a INT, b INT,
                FOREIGN KEY(a) REFERENCES parent(a),
                PRIMARY KEY (a, b))
               INTERLEAVE IN PARENT(t);
```

Inserts into `u` with, for example, `a = 2` need to check `t` to ensure
that a row with `a = 2` exists. Previously, this check was performed
with a scan over the span `.../2 -> .../3` where `...` represents the
index prefix for `t`. The size of this span increases as more rows are
added to `u`. This is not a problem for the actual scan performance in
this case, since the check will stop the scan after a key is found, but
it is a problem for the command queue, since it'll have dependencies
against other operations against keys in `u`.

This patch tightens the example span above to `.../2 -> .../2/<interleave sentinel>`.

This restores insert performance for TPCC to an acceptable level.