### PR TITLE
*: use production Raft settings in TestStoreConfig

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -55,6 +55,10 @@ const (
 	// defaultRaftTickInterval is the default resolution of the Raft timer.
 	defaultRaftTickInterval = 200 * time.Millisecond
 
+	// defaultRaftHeartbeatIntervalTicks is the default number of ticks between
+	// Raft heartbeats.
+	defaultRaftHeartbeatIntervalTicks = 5
+
 	// defaultRangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the
 	// leader lease active duration should be of the raft election timeout.
 	defaultRangeLeaseRaftElectionTimeoutMultiplier = 3
@@ -311,6 +315,14 @@ func (cfg *Config) GetHTTPClient() (http.Client, error) {
 	return cfg.httpClient.httpClient, cfg.httpClient.err
 }
 
+// TestFastRaftConfig are Raft config settings that speed up tests which
+// exercise Raft timeouts and failover.
+var TestFastRaftConfig = RaftConfig{
+	RaftElectionTimeoutTicks:   3,
+	RaftHeartbeatIntervalTicks: 1,
+	RaftTickInterval:           100 * time.Millisecond,
+}
+
 // RaftConfig holds raft tuning parameters.
 type RaftConfig struct {
 	// RaftTickInterval is the resolution of the Raft timer.
@@ -320,6 +332,10 @@ type RaftConfig struct {
 	// previous election expires. This value is inherited by individual stores
 	// unless overridden.
 	RaftElectionTimeoutTicks int
+
+	// RaftHeartbeatIntervalTicks is the number of ticks that pass between
+	// heartbeats.
+	RaftHeartbeatIntervalTicks int
 
 	// RangeLeaseRaftElectionTimeoutMultiplier specifies what multiple the leader
 	// lease active duration should be of the raft election timeout.
@@ -333,6 +349,9 @@ func (cfg *RaftConfig) SetDefaults() {
 	}
 	if cfg.RaftElectionTimeoutTicks == 0 {
 		cfg.RaftElectionTimeoutTicks = defaultRaftElectionTimeoutTicks
+	}
+	if cfg.RaftHeartbeatIntervalTicks == 0 {
+		cfg.RaftHeartbeatIntervalTicks = defaultRaftHeartbeatIntervalTicks
 	}
 	if cfg.RangeLeaseRaftElectionTimeoutMultiplier == 0 {
 		cfg.RangeLeaseRaftElectionTimeoutMultiplier = defaultRangeLeaseRaftElectionTimeoutMultiplier

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -57,6 +57,7 @@ func TestIndexBackfiller(t *testing.T) {
 			},
 		},
 	}
+	params.RaftConfig = base.TestFastRaftConfig
 
 	tc := serverutils.StartTestCluster(t, 3,
 		base.TestClusterArgs{

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -675,6 +675,7 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 					BootstrapVersion: cfg.bootstrapVersion,
 				},
 			},
+			RaftConfig: base.TestFastRaftConfig,
 		},
 		// For distributed SQL tests, we use the fake span resolver; it doesn't
 		// matter where the data really is.

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -192,6 +192,7 @@ func (t *parallelTest) setup(spec *parTestSpec) {
 					CheckStmtStringChange: true,
 				},
 			},
+			RaftConfig: base.TestFastRaftConfig,
 		},
 	}
 	t.cluster = serverutils.StartTestCluster(t, spec.ClusterSize, args)

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -307,7 +307,7 @@ func TestReplicateRange(t *testing.T) {
 func TestRestoreReplicas(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	// Disable periodic gossip activities. The periodic gossiping of the first
 	// range can cause spurious lease transfers which cause this test to fail.
 	sc.TestingKnobs.DisablePeriodicGossips = true
@@ -416,7 +416,7 @@ func TestFailedReplicaChange(t *testing.T) {
 	var runFilter atomic.Value
 	runFilter.Store(true)
 
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	sc.TestingKnobs.TestingEvalFilter = func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 		if runFilter.Load().(bool) {
 			if et, ok := filterArgs.Req.(*roachpb.EndTransactionRequest); ok && et.Commit {
@@ -657,7 +657,8 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 			name = "differentTerm"
 		}
 		t.Run(name, func(t *testing.T) {
-			mtc := &multiTestContext{}
+			sc := storage.TestFastRaftStoreConfig(nil)
+			mtc := &multiTestContext{storeConfig: &sc}
 			defer mtc.Stop()
 			mtc.Start(t, 3)
 			const stoppedStore = 1
@@ -857,7 +858,9 @@ func TestFailedSnapshotFillsReservation(t *testing.T) {
 // situation occurs when two replicas need snapshots at the same time.
 func TestConcurrentRaftSnapshots(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := &multiTestContext{}
+
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 5)
 	repl, err := mtc.stores[0].GetReplica(1)
@@ -917,7 +920,7 @@ func TestConcurrentRaftSnapshots(t *testing.T) {
 func TestReplicateAfterRemoveAndSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	// Disable the replica GC queue so that it doesn't accidentally pick up the
 	// removed replica and GC it. We'll explicitly enable it later in the test.
 	sc.TestingKnobs.DisableReplicaGCQueue = true
@@ -1014,7 +1017,7 @@ func TestRefreshPendingCommands(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
-			sc := storage.TestStoreConfig(nil)
+			sc := storage.TestFastRaftStoreConfig(nil)
 			sc.TestingKnobs = c
 			// Disable periodic gossip tasks which can move the range 1 lease
 			// unexpectedly.
@@ -1125,7 +1128,7 @@ func TestRefreshPendingCommands(t *testing.T) {
 func TestStoreRangeUpReplicate(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer storage.SetMockAddSSTable()()
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	// Prevent the split queue from creating additional ranges while we're
 	// waiting for replication.
 	sc.TestingKnobs.DisableSplitQueue = true
@@ -1219,7 +1222,7 @@ func TestStoreRangeCorruptionChangeReplicas(t *testing.T) {
 
 	ctx := context.Background()
 
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	sc.TestingKnobs.DisableReplicaRebalancing = true
 	var corrupt struct {
 		syncutil.Mutex
@@ -1366,7 +1369,8 @@ func getRangeMetadata(
 func TestUnreplicateFirstRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -1545,7 +1549,7 @@ func TestReplicateRestartAfterTruncation(t *testing.T) {
 }
 
 func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReAdd bool) {
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	// Don't timeout raft leaders or range leases (see the relation between
 	// RaftElectionTimeoutTicks and rangeLeaseActiveDuration). This test expects
 	// mtc.stores[0] to hold the range lease for range 1.
@@ -1627,7 +1631,7 @@ func runReplicateRestartAfterTruncation(t *testing.T, removeBeforeTruncateAndReA
 }
 
 func testReplicaAddRemove(t *testing.T, addFirst bool) {
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	// We're gonna want to validate the state of the store before and after the
 	// replica GC queue does its work, so we disable the replica gc queue here
 	// and run it manually when we're ready.
@@ -1904,7 +1908,8 @@ func TestQuotaPool(t *testing.T) {
 func TestRaftHeartbeats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -1942,7 +1947,8 @@ func TestRaftHeartbeats(t *testing.T) {
 func TestReportUnreachableHeartbeats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -1997,7 +2003,8 @@ func TestReportUnreachableHeartbeats(t *testing.T) {
 func TestReportUnreachableRemoveRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -2115,7 +2122,8 @@ func TestReplicaRemovalCampaign(t *testing.T) {
 
 	for i, td := range testData {
 		func() {
-			mtc := &multiTestContext{}
+			sc := storage.TestFastRaftStoreConfig(nil)
+			mtc := &multiTestContext{storeConfig: &sc}
 			defer mtc.Stop()
 			mtc.Start(t, 2)
 
@@ -2252,7 +2260,8 @@ func TestRaftAfterRemoveRange(t *testing.T) {
 // reproduce a race (see #1911 and #9037).
 func TestRaftRemoveRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 10)
 
@@ -2286,7 +2295,9 @@ func TestRaftRemoveRace(t *testing.T) {
 // placeholders.
 func TestRemovePlaceholderRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := &multiTestContext{}
+
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -2378,7 +2389,8 @@ func (ncc *noConfChangeTestHandler) HandleRaftResponse(
 func TestReplicaGCRace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -2819,7 +2831,8 @@ func (errorChannelTestHandler) HandleSnapshot(
 func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 4)
 
@@ -2943,7 +2956,7 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 func TestReplicaTooOldGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	sc.TestingKnobs.DisableScanner = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
@@ -3053,7 +3066,8 @@ func TestReplicaLazyLoad(t *testing.T) {
 func TestReplicateReAddAfterDown(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 
@@ -3103,7 +3117,8 @@ func TestReplicateReAddAfterDown(t *testing.T) {
 func TestLeaseHolderRemoveSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 2)
 
@@ -3132,7 +3147,8 @@ func TestLeaseHolderRemoveSelf(t *testing.T) {
 func TestRemovedReplicaError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 2)
 
@@ -3169,7 +3185,7 @@ func TestRemovedReplicaError(t *testing.T) {
 func TestRemoveRangeWithoutGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	sc.TestingKnobs.DisableReplicaGCQueue = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
@@ -3277,7 +3293,7 @@ func TestCheckConsistencyMultiStore(t *testing.T) {
 func TestCheckInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	mtc := &multiTestContext{storeConfig: &sc}
 	// Store 0 will report a diff with inconsistent key "e".
 	diffKey := []byte("e")
@@ -3480,7 +3496,8 @@ func TestTransferRaftLeadership(t *testing.T) {
 func TestFailedPreemptiveSnapshot(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 2)
 
@@ -3515,7 +3532,7 @@ func TestFailedPreemptiveSnapshot(t *testing.T) {
 func TestRaftBlockedReplica(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	sc.TestingKnobs.DisableScanner = true
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
@@ -3570,7 +3587,7 @@ func TestRaftBlockedReplica(t *testing.T) {
 func TestRangeQuiescence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	sc.TestingKnobs.DisableScanner = true
 	sc.TestingKnobs.DisablePeriodicGossips = true
 	mtc := &multiTestContext{storeConfig: &sc}
@@ -3702,7 +3719,7 @@ func TestFailedConfChange(t *testing.T) {
 	// Trigger errors at apply time so they happen on both leaders and
 	// followers.
 	var filterActive int32
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	sc.TestingKnobs.TestingApplyFilter = func(filterArgs storagebase.ApplyFilterArgs) *roachpb.Error {
 		if atomic.LoadInt32(&filterActive) == 1 && filterArgs.ChangeReplicas != nil {
 			return roachpb.NewErrorf("boom")

--- a/pkg/storage/client_replica_gc_test.go
+++ b/pkg/storage/client_replica_gc_test.go
@@ -114,7 +114,8 @@ func TestReplicaGCQueueDropReplicaDirect(t *testing.T) {
 func TestReplicaGCQueueDropReplicaGCOnScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 	// Disable the replica gc queue to prevent direct removal of replica.

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -465,7 +465,7 @@ func TestRangeLookupUseReverse(t *testing.T) {
 
 func TestRangeTransferLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cfg := storage.TestStoreConfig(nil)
+	cfg := storage.TestFastRaftStoreConfig(nil)
 	// Ensure the node liveness duration isn't too short. By default it is 900ms
 	// for TestStoreConfig().
 	cfg.RangeLeaseRaftElectionTimeoutMultiplier =
@@ -1168,7 +1168,9 @@ func TestErrorHandlingForNonKVCommand(t *testing.T) {
 
 func TestRangeInfo(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	mtc := &multiTestContext{}
+
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 2)
 

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1043,7 +1043,7 @@ func TestStoreRangeSystemSplits(t *testing.T) {
 func runSetupSplitSnapshotRace(
 	t *testing.T, testFn func(*multiTestContext, roachpb.Key, roachpb.Key),
 ) {
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	// We'll control replication by hand.
 	sc.TestingKnobs.DisableReplicateQueue = true
 	// Async intent resolution can sometimes lead to hangs when we stop
@@ -1462,6 +1462,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 	// or race tests never make any progress.
 	storeCfg.RaftTickInterval = 50 * time.Millisecond
 	storeCfg.RaftElectionTimeoutTicks = 2
+	storeCfg.RaftHeartbeatIntervalTicks = 1
 	currentTrigger := make(chan *roachpb.SplitTrigger, 1)
 	var seen struct {
 		syncutil.Mutex
@@ -1586,7 +1587,7 @@ func TestStoreRangeSplitRaceUninitializedRHS(t *testing.T) {
 // elects a leader without waiting for an election timeout.
 func TestLeaderAfterSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	storeConfig := storage.TestStoreConfig(nil)
+	storeConfig := storage.TestFastRaftStoreConfig(nil)
 	storeConfig.RaftElectionTimeoutTicks = 1000000
 	mtc := &multiTestContext{
 		storeConfig: &storeConfig,

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -29,7 +29,7 @@ import (
 // process ranges whose replicas are not all live.
 func TestConsistencyQueueRequiresLive(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	sc := storage.TestStoreConfig(nil)
+	sc := storage.TestFastRaftStoreConfig(nil)
 	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)

--- a/pkg/storage/gossip_test.go
+++ b/pkg/storage/gossip_test.go
@@ -148,9 +148,12 @@ func TestGossipHandlesReplacedNode(t *testing.T) {
 			InitialBackoff: 10 * time.Millisecond,
 			MaxBackoff:     50 * time.Millisecond,
 		},
+		RaftConfig: base.RaftConfig{
+			RaftTickInterval:           50 * time.Millisecond,
+			RaftElectionTimeoutTicks:   10,
+			RaftHeartbeatIntervalTicks: 1,
+		},
 	}
-	serverArgs.RaftTickInterval = 50 * time.Millisecond
-	serverArgs.RaftElectionTimeoutTicks = 10
 
 	tc := testcluster.StartTestCluster(t, 3,
 		base.TestClusterArgs{

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -721,7 +721,8 @@ func verifyNodeIsDecommissioning(t *testing.T, mtc *multiTestContext, nodeID roa
 }
 
 func testNodeLivenessSetDecommissioning(t *testing.T, decommissionNodeIdx int) {
-	mtc := &multiTestContext{}
+	sc := storage.TestFastRaftStoreConfig(nil)
+	mtc := &multiTestContext{storeConfig: &sc}
 	defer mtc.Stop()
 	mtc.Start(t, 3)
 	mtc.initGossipNetwork()

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -7655,7 +7655,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	var tc testContext
-	cfg := TestStoreConfig(nil)
+	cfg := TestFastRaftStoreConfig(nil)
 	// Disable ticks which would interfere with the manual ticking in this test.
 	cfg.RaftTickInterval = math.MaxInt32
 	stopper := stop.NewStopper()

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -186,7 +186,12 @@ func TestReplicateQueueDownReplicate(t *testing.T) {
 	// using the replicate queue, and to ensure that's the case, the test
 	// cluster needs to be kept in auto replication mode.
 	tc := testcluster.StartTestCluster(t, replicaCount+2,
-		base.TestClusterArgs{ReplicationMode: base.ReplicationAuto},
+		base.TestClusterArgs{
+			ReplicationMode: base.ReplicationAuto,
+			ServerArgs: base.TestServerArgs{
+				RaftConfig: base.TestFastRaftConfig,
+			},
+		},
 	)
 	defer tc.Stopper().Stop(context.Background())
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -64,8 +64,7 @@ import (
 
 const (
 	// rangeIDAllocCount is the number of Range IDs to allocate per allocation.
-	rangeIDAllocCount             = 10
-	defaultHeartbeatIntervalTicks = 5
+	rangeIDAllocCount = 10
 	// ttlStoreGossip is time-to-live for store-related info.
 	ttlStoreGossip = 2 * time.Minute
 
@@ -118,8 +117,7 @@ var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
 var enablePreVote = envutil.EnvOrDefaultBool(
 	"COCKROACH_ENABLE_PREVOTE", false)
 
-// TestStoreConfig has some fields initialized with values relevant in tests.
-func TestStoreConfig(clock *hlc.Clock) StoreConfig {
+func testStoreConfig(clock *hlc.Clock, raftConfig base.RaftConfig) StoreConfig {
 	if clock == nil {
 		clock = hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	}
@@ -127,21 +125,28 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 	sc := StoreConfig{
 		Settings:   st,
 		AmbientCtx: log.AmbientContext{Tracer: st.Tracer},
+		RaftConfig: raftConfig,
 		Clock:      clock,
 		CoalescedHeartbeatsInterval: 50 * time.Millisecond,
-		RaftHeartbeatIntervalTicks:  1,
 		ScanInterval:                10 * time.Minute,
 		MetricsSampleInterval:       metric.TestSampleInterval,
 		HistogramWindowInterval:     metric.TestSampleInterval,
 		EnableEpochRangeLeases:      true,
 	}
-
-	// Use shorter Raft tick settings in order to minimize start up and failover
-	// time in tests.
-	sc.RaftElectionTimeoutTicks = 3
-	sc.RaftTickInterval = 100 * time.Millisecond
 	sc.SetDefaults()
 	return sc
+}
+
+// TestStoreConfig has some fields initialized with values relevant in tests.
+func TestStoreConfig(clock *hlc.Clock) StoreConfig {
+	return testStoreConfig(clock, base.RaftConfig{})
+}
+
+// TestFastRaftStoreConfig overlays the TestStoreConfig settings with faster
+// Raft settings that speed up tests which exercise Raft timeouts and failover.
+func TestFastRaftStoreConfig(clock *hlc.Clock) StoreConfig {
+	// return TestStoreConfig(clock)
+	return testStoreConfig(clock, base.TestFastRaftConfig)
 }
 
 var (
@@ -588,9 +593,6 @@ type StoreConfig struct {
 	// the quiesce cadence.
 	CoalescedHeartbeatsInterval time.Duration
 
-	// RaftHeartbeatIntervalTicks is the number of ticks that pass between heartbeats.
-	RaftHeartbeatIntervalTicks int
-
 	// ScanInterval is the default value for the scan interval
 	ScanInterval time.Duration
 
@@ -790,9 +792,6 @@ func (sc *StoreConfig) SetDefaults() {
 
 	if sc.CoalescedHeartbeatsInterval == 0 {
 		sc.CoalescedHeartbeatsInterval = sc.RaftTickInterval / 2
-	}
-	if sc.RaftHeartbeatIntervalTicks == 0 {
-		sc.RaftHeartbeatIntervalTicks = defaultHeartbeatIntervalTicks
 	}
 	if sc.RaftEntryCacheSize == 0 {
 		sc.RaftEntryCacheSize = defaultRaftEntryCacheSize


### PR DESCRIPTION
Use the production Raft settings in most tests so that we can discover
and fix problems associated with them. Add storage.TestFastStoreConfig
and base.TestFastRaftConfig for tests which exercise Raft timeouts and
failover and thus want lower settings than used in production.

Fixes #18200