### PR TITLE
build: run vet and stringer from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,30 +284,21 @@ dupl: $(BOOTSTRAP_TARGET)
 	       -not -name '*.ir.go'     \
 	| dupl -files $(DUPLFLAGS)
 
-# All packages need to be installed before we can run (some) of the checks and
-# code generators reliably. More precisely, anything that uses x/tools/go/loader
-# is fragile (this includes stringer, vet and others). The blocking issue is
-# https://github.com/golang/go/issues/14120.
-
-# `go generate` uses stringer and so must depend on gotestdashi per the above
-# comment. See https://github.com/golang/go/issues/10249 for details.
 .PHONY: generate
 generate: ## Regenerate generated code.
-generate: gotestdashi
+generate: $(C_LIBS_CCL) $(CGO_FLAGS_FILES) $(BOOTSTRAP_TARGET)
 	$(GO) generate $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(PKG)
 
-# The style checks depend on `go vet` and so must depend on gotestdashi per the
-# above comment. See https://github.com/golang/go/issues/16086 for details.
 .PHONY: lint
 lint: ## Run all style checkers and linters.
 lint: override TAGS += lint
-lint: gotestdashi
+lint: $(C_LIBS_CCL) $(CGO_FLAGS_FILES) $(BOOTSTRAP_TARGET)
 	$(XGO) test ./build -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run 'TestStyle/$(TESTS)'
 
 .PHONY: lintshort
 lintshort: ## Run a fast subset of the style checkers and linters.
 lintshort: override TAGS += lint
-lintshort: gotestdashi
+lintshort: $(C_LIBS_CCL) $(CGO_FLAGS_FILES) $(BOOTSTRAP_TARGET)
 	$(XGO) test ./build -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -short -run 'TestStyle/$(TESTS)'
 
 .PHONY: clean

--- a/build/style_test.go
+++ b/build/style_test.go
@@ -469,7 +469,7 @@ func TestStyle(t *testing.T) {
 		t.Parallel()
 		// `go tool vet` is a special snowflake that emits all its output on
 		// `stderr.
-		cmd := exec.Command("go", "tool", "vet", "-all", "-shadow", "-printfuncs",
+		cmd := exec.Command("go", "tool", "vet", "-source", "-all", "-shadow", "-printfuncs",
 			strings.Join([]string{
 				"Info:1",
 				"Infof:1",


### PR DESCRIPTION
@RaduBerinde since you pulled the trigger on Go 1.9 figured I'd send this your way. Let me know if you'd rather I send this to someone else. (This is extracted from #16907.)

Prior to Go 1.9, Go static analysis tools, like `go vet` and `stringer`,
loaded packages using the `gcimporter`, which would extract type
information from installed artifacts. This was a colossally bad idea,
as type errors would appear or disappear after a `go install`.

Go 1.9 taught vet and stringer to instead use the `srcimporter`, which
ignores the installed artifacts and vets from the source code instead.
This means `make generate` and `make lint` no longer need to depend on
`gotestdashi`.