### PR TITLE
cherrypick: don't auto-retry if we've already sent results to the client

### DIFF
--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -407,6 +407,7 @@ func TestCommonMethods(t *testing.T) {
 		{txnType, "IsSerializableRestart"}:           {},
 		{txnType, "NewBatch"}:                        {},
 		{txnType, "Exec"}:                            {},
+		{txnType, "PrepareForRetry"}:                 {},
 		{txnType, "ResetDeadline"}:                   {},
 		{txnType, "Run"}:                             {},
 		{txnType, "Send"}:                            {},
@@ -427,6 +428,8 @@ func TestCommonMethods(t *testing.T) {
 		{txnType, "UserPriority"}:                    {},
 		{txnType, "AnchorKey"}:                       {},
 		{txnType, "ID"}:                              {},
+		{txnType, "IsAborted"}:                       {},
+		{txnType, "IsCommitted"}:                     {},
 	}
 
 	for b := range omittedChecks {

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -346,4 +346,4 @@ func (CopyDataBlock) StatementType() parser.StatementType { return parser.RowsAf
 
 // StatementTag returns a short string identifying the type of statement.
 func (CopyDataBlock) StatementTag() string { return "" }
-func (CopyDataBlock) String() string       { return "" }
+func (CopyDataBlock) String() string       { return "CopyDataBlock" }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -831,158 +831,23 @@ func (e *Executor) execParsed(
 		if txnState.State() == NoTxn {
 			panic("we failed to initialize a txn")
 		}
-		// Now actually run some statements.
-		var remainingStmts StatementList
-		origState := txnState.State()
 
-		// Track if we are retrying this query, so that we do not double count.
-		automaticRetryCount := 0
-
-		txnClosure := func(ctx context.Context) (transitionToOpen bool, _ error) {
-			defer func() { automaticRetryCount++ }()
-
-			if protoTS != nil {
-				txnState.mu.txn.SetFixedTimestamp(*protoTS)
-			}
-
-			// Some results may have been produced by a previous attempt.
-			txnState.txnResults.Reset(session.Ctx())
-			var err error
-			remainingStmts, transitionToOpen, err = runTxnAttempt(
-				e, session, stmtsToExec, pinfo, origState,
-				!inTxn /* txnPrefix */, avoidCachedDescriptors, automaticRetryCount, txnState.txnResults)
-
-			// TODO(andrei): Until #7881 fixed.
-			if err == nil && txnState.State() == Aborted {
-				doWarn := true
-				if len(stmtsToExec) > 0 {
-					if _, ok := stmtsToExec[0].AST.(*parser.ShowTransactionStatus); ok {
-						doWarn = false
-					}
-				}
-				if doWarn {
-					log.Errorf(ctx,
-						"7881: txnState is Aborted without an error propagating. stmtsToExec: %s, "+
-							"remainingStmts: %s, txnState: %+v", stmtsToExec, remainingStmts, txnState)
-				}
-			}
-
-			return transitionToOpen, err
-		}
-
-		// We now run the prefix of stmtsToExec that belong to the current
-		// transaction via txnClosure. We do this in a loop because we may want to
-		// do automatic retries, if possible. Whether or not we can do auto-retries
-		// depends on the state before we execute statements in the batch.
-		//
-		// TODO(andrei): It's unfortunate that we're keeping track of what the state
-		// was before running the statements. It'd be great if the state in which we
-		// find ourselves after running the statements told us if we can auto-retry.
-		// A way to do that is to introduce another state called AutoRestartWait,
-		// similar to RestartWait. We'd enter this state whenever we're in state
-		// AutoRetry and we get a retriable error.
-		txnCanBeAutoRetried := txnState.State() == AutoRetry
 		var err error
-		for {
-			// transitionToOpen will tell us if we need to transition from AutoRetry
-			// to Open after executing the statements.
-			var transitionToOpen bool
-
-			// Run some statements.
-			transitionToOpen, err = txnClosure(session.Ctx())
-
-			// Sanity checks.
-			if err != nil && txnState.TxnIsOpen() {
-				log.Fatalf(session.Ctx(), "statement(s) generated error but state is %s. err: %s",
-					txnState.State(), err)
-			} else {
-				state := txnState.State()
-				if err == nil && (state == Aborted || state == RestartWait) {
-					crash := true
-					if len(stmtsToExec) > 0 {
-						// SHOW TRANSACTION STATUS statements are always allowed regardless
-						// of the transaction state.
-						if _, ok := stmtsToExec[0].AST.(*parser.ShowTransactionStatus); ok {
-							crash = false
-						}
-					}
-					if crash {
-						log.Fatalf(session.Ctx(), "no error, but we're in error state: %s", state)
-					}
-				}
-			}
-
-			// Check if we need to auto-commit. If so, we end the transaction now; the
-			// transaction was only supposed to exist for the statement that we just
-			// ran.
-			if autoCommit {
-				if err == nil {
-					txn := txnState.mu.txn
-					if txn == nil {
-						log.Fatalf(session.Ctx(), "implicit txn returned with no error and yet "+
-							"the kv txn is gone. No state transition should have done that. State: %s",
-							txnState.State())
-					}
-
-					// We're were told to autoCommit. The KV txn might already be
-					// committed (planNodes are free to do that when running an implicit
-					// transaction, and some try to do it to take advantage of 1-PC txns).
-					// If it is, then there's nothing to do. If it isn't, then we commit
-					// it here.
-					//
-					// NOTE(andrei): It bothers me some that we're peeking at txn to
-					// figure out whether we committed or not, where SQL could already
-					// know that - individual statements could report this back.
-					if txn.IsAborted() {
-						// TODO(andrei): Until 7881 is fixed.
-						log.Fatalf(session.Ctx(), "#7881: the statement we just ran didn't generate an error "+
-							"but the txn proto is aborted. This should never happen. txn: %+v",
-							txn)
-					}
-
-					if !txn.IsCommitted() {
-						var skipCommit bool
-						if e.cfg.TestingKnobs.BeforeAutoCommit != nil {
-							err = e.cfg.TestingKnobs.BeforeAutoCommit(session.Ctx(), stmtsToExec[0].String())
-							skipCommit = err != nil
-						}
-						if !skipCommit {
-							err = txn.Commit(session.Ctx())
-						}
-						log.Eventf(session.Ctx(), "AutoCommit. err: %v\ntxn: %+v", err, txn.Proto())
-						if err != nil {
-							err = txnState.updateStateAndCleanupOnErr(err, e)
-						}
-					}
-				}
-
-				// After autoCommit, unless we're in RestartWait, we leave the
-				// transaction in NoTxn, regardless of whether we executed the query
-				// successfully or we encountered an error.
-				if txnState.State() != RestartWait {
-					txnState.resetStateAndTxn(NoTxn)
-				}
-			}
-
-			// If we've been told by runTxnAttempt that we should move to Open, do it
-			// now.
-			if err == nil && (txnState.State() == AutoRetry) && transitionToOpen {
-				txnState.SetState(Open)
-			}
-
-			if _, ok := err.(*roachpb.UnhandledRetryableError); ok {
-				// We sent transactional requests, so the TxnCoordSender was supposed to
-				// turn retryable errors into HandledRetryableTxnError.
-				log.Fatalf(session.Ctx(), "unexpected UnhandledRetryableError at the Executor level: %s", err)
-			}
-
-			shouldAutoRetry := txnState.State() == RestartWait && txnCanBeAutoRetried
-			if !shouldAutoRetry {
-				break
-			}
-			txnState.mu.txn.PrepareForRetry(session.Ctx(), err)
+		var remainingStmts StatementList
+		var transitionToOpen bool
+		remainingStmts, transitionToOpen, err = runWithAutoRetry(
+			e, session, stmtsToExec, !inTxn /* txnPrefix */, autoCommit,
+			protoTS, pinfo, avoidCachedDescriptors,
+		)
+		if autoCommit && txnState.State() != NoTxn {
+			log.Fatalf(session.Ctx(), "after an implicit txn, state should always be NoTxn, but found: %s",
+				txnState.State())
 		}
-		// We're now done with auto-retries.
+
+		// If we've been told that we should move to Open, do it now.
+		if err == nil && (txnState.State() == AutoRetry) && transitionToOpen {
+			txnState.SetState(Open)
+		}
 
 		if err != nil && (log.V(2) || logStatementsExecuteEnabled.Get(&e.cfg.Settings.SV)) {
 			log.Infof(session.Ctx(), "execParsed: error: %v. state: %s", err, txnState.State())
@@ -1071,6 +936,184 @@ func (e *Executor) execParsed(
 	}
 
 	return nil
+}
+
+// runWithAutoRetry runs a prefix of stmtsToExec corresponding to the current
+// transaction. It deals with auto-retries: when possible, the statements are
+// retried in case of retriable errors. It also deals with "autoCommit" - if the
+// current transaction only consists of a single statement (i.e. it's an
+// "implicit txn"), then this function deal with committing the transaction and
+// possibly retrying it if the commit gets a retriable error.
+//
+// Args:
+// stmtsToExec: A prefix of these will be executed. The remaining ones will be
+// returned as remainingStmts.
+// txnPrefix: Set if stmtsToExec corresponds to the start of the current
+// transaction. Used to trap nested BEGINs.
+// autoCommit: Set if the transction should be committed at the end of the
+// protoTS: If not nil, the transaction proto sets its Orig and Max timestamps
+// to it each retry.
+//
+// Returns:
+// remainingStmts: all the statements that were not executed.
+// transitionToOpen: specifies if the caller should move from state AutoRetry to
+// state Open. This will be false if the state is not AutoRetry when this
+// returns.
+// err: An error that occurred while executing the queries.
+func runWithAutoRetry(
+	e *Executor,
+	session *Session,
+	stmtsToExec StatementList,
+	txnPrefix bool,
+	autoCommit bool,
+	protoTS *hlc.Timestamp,
+	pinfo *parser.PlaceholderInfo,
+	avoidCachedDescriptors bool,
+) (remainingStmts StatementList, transitionToOpen bool, _ error) {
+
+	if autoCommit && !txnPrefix {
+		log.Fatal(session.Ctx(), "autoCommit implies txnPrefix. "+
+			"How could the transaction have been started before an implicit txn?")
+	}
+	if autoCommit && len(stmtsToExec) != 1 {
+		log.Fatal(session.Ctx(), "Only one statement should be executed when "+
+			"autoCommit is set. stmtsToExec: %s", stmtsToExec)
+	}
+
+	txnState := &session.TxnState
+	origState := txnState.State()
+
+	// Whether or not we can do auto-retries depends on the state before we
+	// execute statements in the batch.
+	//
+	// TODO(andrei): It's unfortunate that we're keeping track of what the state
+	// was before running the statements. It'd be great if the state in which we
+	// find ourselves after running the statements told us if we can auto-retry.
+	// A way to do that is to introduce another state called AutoRestartWait,
+	// similar to RestartWait. We'd enter this state whenever we're in state
+	// AutoRetry and we get a retriable error.
+	txnCanBeAutoRetried := txnState.State() == AutoRetry
+	if autoCommit && !txnCanBeAutoRetried {
+		log.Fatalf(session.Ctx(), "autoCommit is only supported in the AutoRetry state. "+
+			"Current state: %s", txnState.State())
+	}
+
+	// Track if we are retrying this query, so that we do not double count.
+	automaticRetryCount := 0
+
+	var err error
+	for {
+
+		if protoTS != nil {
+			txnState.mu.txn.SetFixedTimestamp(*protoTS)
+		}
+		// Some results may have been produced by a previous attempt.
+		txnState.txnResults.Reset(session.Ctx())
+
+		// Run some statements.
+		remainingStmts, transitionToOpen, err = runTxnAttempt(
+			e, session, stmtsToExec, pinfo, origState,
+			txnPrefix, avoidCachedDescriptors, automaticRetryCount, txnState.txnResults)
+
+		// Sanity checks.
+		if err != nil && txnState.TxnIsOpen() {
+			log.Fatalf(session.Ctx(), "statement(s) generated error but state is %s. err: %s",
+				txnState.State(), err)
+		} else {
+			state := txnState.State()
+			if err == nil && (state == Aborted || state == RestartWait) {
+				crash := true
+				// SHOW TRANSACTION STATUS statements are always allowed regardless of
+				// the transaction state.
+				if len(stmtsToExec) > 0 {
+					if _, ok := stmtsToExec[0].AST.(*parser.ShowTransactionStatus); ok {
+						crash = false
+					}
+				}
+				if crash {
+					log.Fatalf(session.Ctx(), "no error, but we're in error state: %s", state)
+				}
+			}
+		}
+
+		// Check if we need to auto-commit. If so, we end the transaction now; the
+		// transaction was only supposed to exist for the statement that we just
+		// ran.
+		if autoCommit {
+			if err == nil {
+				txn := txnState.mu.txn
+				if txn == nil {
+					log.Fatalf(session.Ctx(), "implicit txn returned with no error and yet "+
+						"the kv txn is gone. No state transition should have done that. State: %s",
+						txnState.State())
+				}
+
+				// We were told to autoCommit. The KV txn might already be committed
+				// (planNodes are free to do that when running an implicit transaction,
+				// and some try to do it to take advantage of 1-PC txns). If it is, then
+				// there's nothing to do. If it isn't, then we commit it here.
+				//
+				// NOTE(andrei): It bothers me some that we're peeking at txn to figure
+				// out whether we committed or not, where SQL could already know that -
+				// individual statements could report this back.
+				if txn.IsAborted() {
+					log.Fatalf(session.Ctx(), "#7881: the statement we just ran didn't generate an error "+
+						"but the txn proto is aborted. This should never happen. txn: %+v",
+						txn)
+				}
+
+				if !txn.IsCommitted() {
+					var skipCommit bool
+					if e.cfg.TestingKnobs.BeforeAutoCommit != nil {
+						err = e.cfg.TestingKnobs.BeforeAutoCommit(session.Ctx(), stmtsToExec[0].String())
+						skipCommit = err != nil
+					}
+					if !skipCommit {
+						err = txn.Commit(session.Ctx())
+					}
+					log.Eventf(session.Ctx(), "AutoCommit. err: %v\ntxn: %+v", err, txn.Proto())
+					if err != nil {
+						err = txnState.updateStateAndCleanupOnErr(err, e)
+					}
+				}
+			}
+
+			// After autoCommit, unless we're in RestartWait, we leave the transaction
+			// in NoTxn, regardless of whether we executed the query successfully or
+			// we encountered an error.
+			if txnState.State() != RestartWait {
+				txnState.resetStateAndTxn(NoTxn)
+			}
+		}
+
+		if _, ok := err.(*roachpb.UnhandledRetryableError); ok {
+			// We sent transactional requests, so the TxnCoordSender was supposed to
+			// turn retryable errors into HandledRetryableTxnError.
+			log.Fatalf(session.Ctx(), "unexpected UnhandledRetryableError at the Executor level: %s", err)
+		}
+
+		resultsSentToClient := txnState.txnResults.ResultsSentToClient()
+		shouldAutoRetry := txnState.State() == RestartWait && txnCanBeAutoRetried
+		if shouldAutoRetry && resultsSentToClient {
+			shouldAutoRetry = false
+			// We otherwise can and should auto-retry, but, alas, we've already sent
+			// some results to the client, so we can no longer auto-retry. We only
+			// stay in RestartWait if the client is doing client-directed retries.
+			// Otherwise, we move to Aborted.
+			if !txnState.retryIntent {
+				e.TxnAbortCount.Inc(1)
+				txnState.mu.txn.CleanupOnError(session.Ctx(), err)
+				txnState.resetStateAndTxn(Aborted)
+			}
+		}
+
+		if !shouldAutoRetry {
+			break
+		}
+		txnState.mu.txn.PrepareForRetry(session.Ctx(), err)
+		automaticRetryCount++
+	}
+	return remainingStmts, transitionToOpen, err
 }
 
 // runTxnAttempt takes in a batch of statements and executes a prefix of them

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1210,7 +1210,12 @@ func (e *Executor) execSingleStatement(
 // getTransactionState retrieves a text representation of the given state.
 func getTransactionState(txnState *txnState) string {
 	state := txnState.State()
-	if txnState.implicitTxn {
+	// If the statement reading the state is in an implicit transaction, then we
+	// want to tell NoTxn to the client.
+	// If implicitTxn is set, the state is supposed to be AutoRetry. However, we
+	// test the state too, just in case we have a state machine bug, in which case
+	// we don't want this code to hide a bug.
+	if txnState.implicitTxn && state == AutoRetry {
 		state = NoTxn
 	}
 	// For the purposes of representing the states to client, make the AutoRetry

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1186,9 +1186,16 @@ func (ts *txnState) finishSQLTxn(s *Session) {
 }
 
 // updateStateAndCleanupOnErr updates txnState based on the type of error that we
-// received. If it's a retriable error and we're going to retry the txn,
-// then the state moves to RestartWait. Otherwise, the state moves to Aborted
-// and the KV txn is cleaned up.
+// received. If it's a retriable error and it looks like we're going to retry
+// the txn (we're either in the AutoRetry state, meaning that we can do
+// auto-retries, or the client is doing client-directed retries), then the state
+// moves to RestartWait. Otherwise, the state moves to Aborted and the KV txn is
+// cleaned up.
+// Note that even if we move to RestartWait here, this doesn't automatically
+// mean that we're going to auto-retry. It might be the case, for example, that
+// we've already streamed results to the client and so we can't auto-retry for
+// that reason. It is the responsibility of higher layers to catch this and
+// terminate the transaction, if appropriate.
 //
 // This method always returns an error. Usually it's the input err, except that
 // a retriable error meant for another txn is replaced with a non-retriable

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -530,13 +530,13 @@ func (s *Session) Finish(e *Executor) {
 	// TODO(nvanbenschoten): Once we have better support for cancelling ongoing
 	// statement execution by the infrastructure added to support CancelRequest,
 	// we should try to actively drain this queue instead of passively waiting
-	// for it to drain.
+	// for it to drain. (andrei, 2017/09) - We now have support for statement
+	// cancellation. Now what?
 	_ = s.synchronizeParallelStmts(s.context)
 
 	// If we're inside a txn, roll it back.
 	if s.TxnState.State().kvTxnIsOpen() {
-		s.TxnState.updateStateAndCleanupOnErr(
-			errors.Errorf("session closing"), e)
+		_ = s.TxnState.updateStateAndCleanupOnErr(fmt.Errorf("session closing"), e)
 	}
 	if s.TxnState.State() != NoTxn {
 		s.TxnState.finishSQLTxn(s)
@@ -1135,7 +1135,7 @@ func (ts *txnState) resetStateAndTxn(state TxnStateEnum) {
 	}
 	if ts.mu.txn != nil && !ts.mu.txn.IsFinalized() {
 		panic(fmt.Sprintf(
-			"attempting to move SQL txn to state %v inconsistent with KV txn state: %s "+
+			"attempting to move SQL txn to state %s inconsistent with KV txn state: %s "+
 				"(finalized: false)", state, ts.mu.txn.Proto().Status))
 	}
 	ts.SetState(state)
@@ -1189,26 +1189,55 @@ func (ts *txnState) finishSQLTxn(s *Session) {
 // received. If it's a retriable error and we're going to retry the txn,
 // then the state moves to RestartWait. Otherwise, the state moves to Aborted
 // and the KV txn is cleaned up.
-func (ts *txnState) updateStateAndCleanupOnErr(err error, e *Executor) {
+//
+// This method always returns an error. Usually it's the input err, except that
+// a retriable error meant for another txn is replaced with a non-retriable
+// error because higher layers are not supposed to consider it retriable.
+func (ts *txnState) updateStateAndCleanupOnErr(err error, e *Executor) error {
 	if err == nil {
 		panic("updateStateAndCleanupOnErr called with no error")
 	}
+	if ts.mu.txn == nil {
+		panic(fmt.Sprintf(
+			"updateStateAndCleanupOnErr called in state with no KV txn. State: %s",
+			ts.State()))
+	}
 	if retErr, ok := err.(*roachpb.HandledRetryableTxnError); !ok ||
 		!ts.willBeRetried() ||
-		!ts.mu.txn.IsRetryableErrMeantForTxn(*retErr) {
+		!ts.mu.txn.IsRetryableErrMeantForTxn(*retErr) ||
+		// If we ran a COMMIT, then we can only do auto-retries, not client-directed
+		// retries.
+		(ts.commitSeen && ts.State() != AutoRetry) {
 
 		// We can't or don't want to retry this txn, so the txn is over.
 		e.TxnAbortCount.Inc(1)
+
+		// If we got a retriable error but it was meant for another txn, we'll
+		// return a non-retriable error instead further down. We need to identify
+		// this here, before the call to ts.resetStateAndTxn().
+		var retriableErrForAnotherTxn bool
+		txnID := ts.mu.txn.Proto().ID
+		if ok && !ts.mu.txn.IsRetryableErrMeantForTxn(*retErr) {
+			retriableErrForAnotherTxn = true
+		}
+
 		// This call rolls back a PENDING transaction and cleans up all its
 		// intents.
 		ts.mu.txn.CleanupOnError(ts.Ctx, err)
 		ts.resetStateAndTxn(Aborted)
+
+		if retriableErrForAnotherTxn {
+			return errors.Wrapf(
+				retErr,
+				"retryable error from another txn. Current txn ID: %v", txnID)
+		}
 	} else {
 		// If we got a retriable error, move the SQL txn to the RestartWait state.
 		// Note that TransactionAborted is also a retriable error, handled here;
 		// in this case cleanup for the txn has been done for us under the hood.
 		ts.SetState(RestartWait)
 	}
+	return err
 }
 
 func (ts *txnState) setIsolationLevel(isolation enginepb.IsolationType) error {

--- a/pkg/sql/session_test.go
+++ b/pkg/sql/session_test.go
@@ -16,13 +16,16 @@ package sql_test
 
 import (
 	"database/sql/driver"
+	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/lib/pq"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -174,5 +177,47 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 			}
 
 		})
+	}
+}
+
+// Test two things about non-retriable errors happening when the Executor does
+// an "autoCommit" (i.e. commits the KV txn after running an implicit
+// transaction):
+// 1) The error is reported to the client.
+// 2) The error doesn't leave the session in the Aborted state. After running
+// implicit transactions, the state should always be NoTxn, regardless of any
+// errors.
+func TestNonRetriableErrorOnAutoCommit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	query := "SELECT 42"
+
+	params := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				BeforeAutoCommit: func(ctx context.Context, stmt string) error {
+					if strings.Contains(stmt, query) {
+						return fmt.Errorf("injected autocommit error")
+					}
+					return nil
+				},
+			},
+		},
+	}
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	sqlDB.SetMaxOpenConns(1)
+
+	if _, err := sqlDB.Exec(query); !testutils.IsError(err, "injected") {
+		t.Fatalf("expected injected error, got: %v", err)
+	}
+
+	var state string
+	if err := sqlDB.QueryRow("SHOW TRANSACTION STATUS").Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if state != "NoTxn" {
+		t.Fatalf("expected state %s, got: %s", "NoTxn", state)
 	}
 }


### PR DESCRIPTION
Cherrypicking #18268 for 1.1.

Fixes #17592

Ever since results streaming, the condition about whether we can
auto-retry or not has become more complicated: we can't auto-retry if
we've previously streamed any results to the client. However, we were
ignoring this fact and retrying regardless. This patch adds this
condition.