### PR TITLE
distsql: increment DistSQL version

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -71,11 +71,11 @@ type DistSQLVersion uint32
 //
 // ATTENTION: When updating these fields, add to version_history.txt explaining
 // what changed.
-const Version DistSQLVersion = 5
+const Version DistSQLVersion = 6
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.
-const MinAcceptedVersion DistSQLVersion = 4
+const MinAcceptedVersion DistSQLVersion = 6
 
 var settingUseTempStorageSorts = settings.RegisterBoolSetting(
 	"sql.distsql.temp_storage.sorts",

--- a/pkg/sql/distsqlrun/version_history.txt
+++ b/pkg/sql/distsqlrun/version_history.txt
@@ -1,4 +1,4 @@
-- Verion: 6 (MinAcceptedVersion: 6)
+- Version: 6 (MinAcceptedVersion: 6)
   - The producer<->consumer (FlowStream RPC) protocol has changed: the
     consumer_signal.handshake field was introduced. The handshake messages are
     sent by the server-side of FlowStream informing the producer of the


### PR DESCRIPTION
As of #17767 I intended to update DistSQL Version and
MinAcceptedVersion, but I failed to do so. The code currently is lying
by claiming compatibility with a version it's not, in fact, compatible
with. This patch sets the correct version.

I'll cherry-pick this into 1.1.