### PR TITLE
cli/sql: use BSD's libedit for input.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ expect in your collaboration with the Cockroach Labs team.
      - Optional: NodeJS 6.x and Yarn 0.22.0+. Required when compiling protocol
        buffers.
 
-    Note that at least 4GB of RAM is required to build from source and run tests.
+   Note that at least 4GB of RAM is required to build from source and run tests.
 
 2. Get the CockroachDB code:
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -121,13 +121,6 @@
   version = "2017.04.17"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/chzyer/readline"
-  packages = ["."]
-  revision = "8ca065f6f7703ba76dfd61a8af7c3426b54e650e"
-  source = "https://github.com/cockroachdb/readline"
-
-[[projects]]
   name = "github.com/client9/misspell"
   packages = [".","cmd/misspell"]
   revision = "b5fc83876cd1bf9fbb4e39afa9e503c83edce3b5"
@@ -400,6 +393,12 @@
   name = "github.com/kisielk/gotool"
   packages = ["."]
   revision = "0de1eaf82fa3f583ce21fde859f1e7e0c5e9b220"
+
+[[projects]]
+  name = "github.com/knz/go-libedit"
+  packages = [".","common","other","unix"]
+  revision = "438167ad0c588fe6f2e87cb6ba8a4e9753e6d26e"
+  version = "v1.3"
 
 [[projects]]
   name = "github.com/knz/strtime"
@@ -695,6 +694,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2ebf48b7717b1b5dfa8b42088bb4c1673d32004c4a69acbfadbb8a493fa9c990"
+  inputs-digest = "44d910075a6ddad082ceae7c050336ca8fbe6b4fabdd108edee8a9f192b08fde"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,11 +45,6 @@ ignored = [
   revision = "8dd1f3ff407c300cff0a4bfedd969111ca5a7903"
 
 [[constraint]]
-  name = "github.com/chzyer/readline"
-  source = "https://github.com/cockroachdb/readline"
-  branch = "master"
-
-[[constraint]]
   name = "github.com/coreos/etcd"
   branch = "master"
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -72,6 +72,10 @@ func (e *cliError) Error() string { return e.cause.Error() }
 // to be captured.
 var stderr = log.OrigStderr
 
+// stdin aliases os.Stdin; we use an alias here so that tests in this
+// package can redirect the input of the CLI shell.
+var stdin = os.Stdin
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "output version information",

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -80,6 +80,15 @@ proc interrupt {} {
     sleep 0.4
 }
 
+# Convenience function that sends Ctrl+D to the monitored process.
+# Leaves some upfront delay to let the readline process the time
+# to initialize the key binding.
+proc send_eof {} {
+    report "EOF TO FOREGROUND PROCESS"
+    sleep 0.4
+    send "\004"
+}
+
 # Convenience functions to start/shutdown the server.
 # Preserves the invariant that the server's PID is saved
 # in `server_pid`.

--- a/pkg/cli/interactive_tests/test_history.tcl
+++ b/pkg/cli/interactive_tests/test_history.tcl
@@ -8,7 +8,7 @@ spawn $argv sql
 eexpect root@
 
 # Ensure the connection is up and working.
-send "select 1;\r"
+send "SELECT 1;\r"
 eexpect "1 row"
 eexpect root@
 
@@ -27,7 +27,7 @@ start_test "Test that we can recall a previous line with Ctrl+R"
 send "foo;\r"
 eexpect "syntax error"
 eexpect root@
-send "\022sel"
+send "\022SEL"
 eexpect "SELECT 1;"
 end_test
 
@@ -43,14 +43,14 @@ eexpect "SELECT 1;"
 end_test
 
 start_test "Test that client cannot terminate with Ctrl+D while cursor is on recalled line"
-send "\004"
+send_eof
 send "\r"
 eexpect "1 row"
 eexpect root@
 end_test
 
 start_test "Test that Ctrl+D does terminate client on empty line"
-send "\004"
+send_eof
 eexpect eof
 end_test
 
@@ -63,7 +63,7 @@ end_test
 
 start_test "Test that the client cannot terminate with Ctrl+C while cursor is on recalled line"
 interrupt
-send "\rselect 1;\r"
+send "\rSELECT 1;\r"
 eexpect "1 row"
 eexpect root@
 end_test
@@ -80,7 +80,7 @@ eexpect root@
 end_test
 
 start_test "Test that two statements on the same line can be recalled together."
-send "select 2; select 3;\r"
+send "SELECT 2; SELECT 3;\r"
 eexpect "1 row"
 eexpect "1 row"
 eexpect root@

--- a/pkg/cli/interactive_tests/test_history.tcl
+++ b/pkg/cli/interactive_tests/test_history.tcl
@@ -8,13 +8,13 @@ spawn $argv sql
 eexpect root@
 
 # Ensure the connection is up and working.
-send "SELECT 1;\r"
+send "select 1;\r"
 eexpect "1 row"
 eexpect root@
 
 start_test "Test that last line can be recalled with arrow-up"
 send "\033\[A"
-eexpect "SELECT 1;"
+eexpect "select 1;"
 end_test
 
 start_test "Test that recalled last line can be executed"
@@ -27,8 +27,8 @@ start_test "Test that we can recall a previous line with Ctrl+R"
 send "foo;\r"
 eexpect "syntax error"
 eexpect root@
-send "\022SEL"
-eexpect "SELECT 1;"
+send "\022sel"
+eexpect "select 1;"
 end_test
 
 start_test "Test that recalled previous line can be executed"
@@ -39,7 +39,7 @@ end_test
 
 start_test "Test that last recalled line becomes top of history"
 send "\033\[A"
-eexpect "SELECT 1;"
+eexpect "select 1;"
 end_test
 
 start_test "Test that client cannot terminate with Ctrl+D while cursor is on recalled line"
@@ -58,34 +58,23 @@ start_test "Test that history is preserved across runs"
 spawn $argv sql
 eexpect root@
 send "\033\[A"
-eexpect "SELECT 1;"
+eexpect "select 1;"
 end_test
 
 start_test "Test that the client cannot terminate with Ctrl+C while cursor is on recalled line"
 interrupt
-send "\rSELECT 1;\r"
-eexpect "1 row"
-eexpect root@
-end_test
-
-start_test "Test that ambiguous datum types are pretty-printed in a parsable form. #14484"
-send "SELECT INTERVAL '4' SECOND;\r"
-eexpect "1 row"
-eexpect root@
-send "\033\[A"
-eexpect "SELECT '4s':::INTERVAL;"
-send "\r"
+send "\rselect 1;\r"
 eexpect "1 row"
 eexpect root@
 end_test
 
 start_test "Test that two statements on the same line can be recalled together."
-send "SELECT 2; SELECT 3;\r"
+send "select 2; select 3;\r"
 eexpect "1 row"
 eexpect "1 row"
 eexpect root@
 send "\033\[A"
-eexpect "SELECT 2; SELECT 3;"
+eexpect "select 2; select 3;"
 send "\r"
 eexpect "1 row"
 eexpect "1 row"

--- a/pkg/cli/interactive_tests/test_last_statement.tcl
+++ b/pkg/cli/interactive_tests/test_last_statement.tcl
@@ -30,7 +30,7 @@ eexpect "CREATE TABLE"
 eexpect root@
 send "insert into t.foo(x) values (42)\r"
 eexpect " ->"
-send "\004"
+send_eof
 eexpect ":/# "
 
 send "$argv sql\r"

--- a/pkg/cli/interactive_tests/test_multiline_statements.tcl
+++ b/pkg/cli/interactive_tests/test_multiline_statements.tcl
@@ -16,7 +16,8 @@ eexpect "root@"
 
 # Send up-arrow.
 send "\033\[A"
-eexpect "SELECT e'foo\\\\nbar';"
+eexpect "select 'foo"
+eexpect "\rbar';"
 send "\r"
 eexpect "root@"
 
@@ -28,7 +29,9 @@ end_test
 
 start_test "Test that \show does what it says."
 send "\\show\r"
-eexpect "select 1,\r\n2, 3\r\n*->"
+eexpect "select 1,"
+eexpect "2, 3"
+eexpect " ->"
 end_test
 
 start_test "Test finishing the multi-line statement."
@@ -38,30 +41,32 @@ eexpect "root@"
 
 # Send up-arrow.
 send "\033\[A"
-eexpect "SELECT 1, 2, 3;"
+eexpect "select 1,"
+eexpect "2, 3"
+eexpect ";"
 end_test
 
 start_test "Test that Ctrl+C after the first line merely cancels the statement and presents the prompt."
 send "\r"
 eexpect root@
-send "SELECT\r"
+send "select\r"
 eexpect " ->"
 interrupt
 eexpect root@
 end_test
 
 start_test "Test that BEGIN .. without COMMIT begins a multi-line statement."
-send "BEGIN; SELECT 1;\r"
+send "begin; select 1;\r"
 eexpect " ->"
 end_test
 
 start_test "Test that \show does what it says."
 send "\\show\r"
-eexpect "BEGIN*;\r\nSELECT 1;\r\n*->"
+eexpect "begin; select 1;\r\n*->"
 end_test
 
 start_test "Test that a COMMIT is detected properly."
-send "COMMIT;\r"
+send "commit;\r"
 eexpect "1 row"
 eexpect "root@"
 end_test
@@ -69,28 +74,28 @@ end_test
 start_test "Test that BEGIN .. without COMMIT does not begin a multi-line statement in open txns. #16833"
 
 # trigger the error state
-send "BEGIN; SELECT nonexistent;\r\r"
+send "begin; select nonexistent;\r\r"
 eexpect "not found"
 eexpect ERROR
 
 # Try to send a txn prefix, expect no multiline entry
-send "BEGIN; SELECT 1;\r"
+send "begin; select 1;\r"
 eexpect "commands ignored"
 eexpect "root@"
 
 # clear status for next test
-send "COMMIT;\r"
+send "commit;\r"
 eexpect ROLLBACK
 eexpect "root@"
 end_test
 
 start_test "Test that an invalid statement inside a multi-line txn does not go to the server."
-send "BEGIN;\r"
+send "begin;\r"
 eexpect " ->"
-send "SELEC T1;\r"
+send "selec t1;\r"
 eexpect "invalid syntax"
 eexpect " ->"
-send "SELECT 1; COMMIT;\r"
+send "select 1; commit;\r"
 eexpect "1 row"
 eexpect root@
 end_test
@@ -106,7 +111,7 @@ eexpect "CREATE TABLE"
 eexpect root@
 eexpect OPEN
 
-send "SHOW ALL CLUSTER SETTINGS;\r"
+send "show all cluster settings;\r"
 eexpect "rows"
 eexpect root@
 eexpect OPEN

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -104,9 +104,6 @@ eexpect "Failed running \"sql\""
 # Check that history is scrubbed.
 send "$argv sql --certs-dir=$certs_dir\r"
 eexpect "root@"
-# Ctrl+R eisen
-send "\022eisen"
-eexpect "CREATE USER eisen WITH PASSWORD \\*\\*\\*\\*\\*;"
 interrupt
 end_test
 

--- a/pkg/cli/interactive_tests/test_url_login.tcl
+++ b/pkg/cli/interactive_tests/test_url_login.tcl
@@ -12,7 +12,7 @@ spawn $argv sql --url "postgresql://localhost:26257?sslmode=disable"
 eexpect @localhost
 end_test
 
-send "\004"
+send_eof
 eexpect eof
 
 stop_server $argv

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -29,13 +29,13 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/chzyer/readline"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	readline "github.com/knz/go-libedit"
 	"github.com/lib/pq"
 	"github.com/spf13/cobra"
 )
@@ -63,7 +63,7 @@ Open a sql shell running against a cockroach database.
 type cliState struct {
 	conn *sqlConn
 	// ins is used to read lines if isInteractive is true.
-	ins *readline.Instance
+	ins readline.EditLine
 	// buf is used to read lines if isInteractive is false.
 	buf *bufio.Reader
 
@@ -90,6 +90,8 @@ type cliState struct {
 	fullPrompt string
 	// The prompt on a continuation line in a multi-line entry.
 	continuePrompt string
+	// The current prompt, either fullPrompt or continuePrompt.
+	currentPrompt string
 
 	// State
 	//
@@ -192,7 +194,7 @@ Type:
 
 More documentation about our SQL dialect and the CLI shell is available online:
 %s
-%s`,
+%s\n`,
 		base.DocsURL("sql-statements.html"),
 		base.DocsURL("use-the-built-in-sql-client.html"),
 	)
@@ -205,15 +207,13 @@ func (c *cliState) addHistory(line string) {
 		return
 	}
 
-	// ins.SaveHistory will push command into memory and try to
-	// persist to disk (if ins's config.HistoryFile is set).  err can
+	// ins.AddHistory will push command into memory and try to
+	// persist to disk (if ins's history file is set). err can
 	// be not nil only if it got a IO error while trying to persist.
-	if err := c.ins.SaveHistory(line); err != nil {
+	if err := c.ins.AddHistory(line); err != nil {
 		log.Warningf(context.TODO(), "cannot save command-line history: %s", err)
 		log.Info(context.TODO(), "command-line history will not be saved in this session")
-		cfg := c.ins.Config.Clone()
-		cfg.HistoryFile = ""
-		c.ins.SetConfig(cfg)
+		c.ins.SetAutoSaveHistory("", false)
 	}
 }
 
@@ -578,16 +578,17 @@ func endsWithIncompleteTxn(stmts parser.StatementList) bool {
 	return txnStarted
 }
 
-var cmdHistFile = envutil.EnvOrDefaultString("COCKROACH_SQL_CLI_HISTORY", ".cockroachdb_history")
+var cmdHistFile = envutil.EnvOrDefaultString("COCKROACH_SQL_CLI_HISTORY", ".cockroachsql_history")
 
-// Do implements the readline.AutoCompleter interface.
-func (c *cliState) Do(line []rune, pos int) (newLine [][]rune, length int) {
+// GetCompletions implements the readline.CompletionGenerator interface.
+func (c *cliState) GetCompletions(_ string) []string {
+	sql, _ := c.ins.GetLineInfo()
 	var p parser.Parser
-	sql := string(line)
+
 	if !strings.HasSuffix(sql, "?") {
 		fmt.Fprintf(c.ins.Stdout(),
 			"\ntab completion not supported; append '?' and press tab for contextual help\n\n%s", sql)
-		return nil, 0
+		return nil
 	}
 
 	_, err := p.Parse(sql)
@@ -600,8 +601,14 @@ func (c *cliState) Do(line []rune, pos int) (newLine [][]rune, length int) {
 			fmt.Fprintf(c.ins.Stdout(), "\n%v\n", err)
 			maybeShowErrorDetails(c.ins.Stdout(), err, false)
 		}
+		fmt.Fprint(c.ins.Stdout(), c.currentPrompt, sql)
 	}
-	return nil, 0
+	return nil
+}
+
+// GetLeftPrompt implements the readline.LeftPromptGenerator interface.
+func (c *cliState) GetLeftPrompt() string {
+	return c.currentPrompt
 }
 
 func (c *cliState) doStart(nextState cliStateEnum) cliStateEnum {
@@ -609,32 +616,36 @@ func (c *cliState) doStart(nextState cliStateEnum) cliStateEnum {
 	c.partialLines = []string{}
 
 	if isInteractive {
-		c.promptPrefix, c.fullPrompt, c.continuePrompt = preparePrompts(c.conn.url)
-
-		// We only enable history management when the terminal is actually
-		// interactive. This saves on memory when e.g. piping a large SQL
-		// script through the command-line client.
-		homeDir, err := envutil.HomeDir()
-		if err != nil {
-			if log.V(2) {
-				log.Warningf(context.TODO(), "cannot retrieve user information: %v", err)
-				log.Info(context.TODO(), "cannot load or save the command-line history")
-			}
-		} else {
-			histFile := filepath.Join(homeDir, cmdHistFile)
-			cfg := c.ins.Config.Clone()
-			cfg.HistoryFile = histFile
-			cfg.HistorySearchFold = true
-			cfg.AutoComplete = c
-			c.ins.SetConfig(cfg)
-		}
-
-		fmt.Println("#\n# Enter \\? for a brief introduction.\n#")
-
 		c.checkSyntax = true
 		c.normalizeHistory = true
 		c.errExit = false
 		c.smartPrompt = true
+		c.promptPrefix, c.fullPrompt, c.continuePrompt = preparePrompts(c.conn.url)
+
+		c.ins.SetLeftPrompt(c)
+		c.ins.SetCompleter(c)
+		if err := c.ins.UseHistory(-1 /*maxEntries*/, true /*dedup*/); err != nil {
+			log.Warningf(context.TODO(), "cannot enable history: %v", err)
+		} else {
+			// We only enable history management when the terminal is actually
+			// interactive. This saves on memory when e.g. piping a large SQL
+			// script through the command-line client.
+			homeDir, err := envutil.HomeDir()
+			if err != nil {
+				log.Warningf(context.TODO(), "cannot retrieve user information: %v", err)
+				log.Warning(context.TODO(), "history will not be saved")
+			} else {
+				histFile := filepath.Join(homeDir, cmdHistFile)
+				err = c.ins.LoadHistory(histFile)
+				if err != nil {
+					log.Warningf(context.TODO(), "cannot load the command-line history (file corrupted?): %v", err)
+					log.Warning(context.TODO(), "the history file will be cleared upon first entry")
+				}
+				c.ins.SetAutoSaveHistory(histFile, true)
+			}
+		}
+
+		fmt.Println("#\n# Enter \\? for a brief introduction.\n#")
 	} else {
 		// When running non-interactive, by default we want errors to stop
 		// further processing and all syntax checking to be done
@@ -653,7 +664,7 @@ func (c *cliState) doStartLine(nextState cliStateEnum) cliStateEnum {
 	c.partialStmtsLen = 0
 
 	if isInteractive {
-		c.ins.SetPrompt(c.fullPrompt)
+		c.currentPrompt = c.fullPrompt
 	}
 
 	return nextState
@@ -663,7 +674,7 @@ func (c *cliState) doContinueLine(nextState cliStateEnum) cliStateEnum {
 	c.atEOF = false
 
 	if isInteractive {
-		c.ins.SetPrompt(c.continuePrompt)
+		c.currentPrompt = c.continuePrompt
 	}
 
 	return nextState
@@ -675,8 +686,16 @@ func (c *cliState) doContinueLine(nextState cliStateEnum) cliStateEnum {
 func (c *cliState) doReadLine(nextState cliStateEnum) cliStateEnum {
 	var l string
 	var err error
-	if c.ins != nil {
-		l, err = c.ins.Readline()
+	if c.buf == nil {
+		l, err = c.ins.GetLine()
+		if len(l) > 0 && l[len(l)-1] == '\n' {
+			// Strip the final newline.
+			l = l[:len(l)-1]
+		} else {
+			// There was no newline at the end of the input
+			// (e.g. Ctrl+C was entered). Force one.
+			fmt.Fprintln(c.ins.Stdout())
+		}
 	} else {
 		l, err = c.buf.ReadString('\n')
 		// bufio.ReadString() differs from readline.Readline in the handling of
@@ -699,7 +718,7 @@ func (c *cliState) doReadLine(nextState cliStateEnum) cliStateEnum {
 	case nil:
 		// Good to go.
 
-	case readline.ErrInterrupt:
+	case readline.ErrInterrupted:
 		if !isInteractive {
 			// Ctrl+C terminates non-interactive shells in all cases.
 			c.exitErr = err
@@ -1019,7 +1038,7 @@ func (c *cliState) doDecidePath() cliStateEnum {
 
 // runInteractive runs the SQL client interactively, presenting
 // a prompt to the user for each statement.
-func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
+func runInteractive(conn *sqlConn) (exitErr error) {
 	c := cliState{conn: conn}
 
 	state := cliStart
@@ -1040,16 +1059,18 @@ func runInteractive(conn *sqlConn, config *readline.Config) (exitErr error) {
 
 				// The readline initialization is not placed in
 				// the doStart() method because of the defer.
-				c.ins, c.exitErr = readline.NewEx(config)
+				c.ins, c.exitErr = readline.InitFiles("cockroach", stdin, os.Stdout, stderr)
 				if c.exitErr != nil {
 					return c.exitErr
 				}
-				defer func() { _ = c.ins.Close() }()
+				// If the user has used bind -v or bind -l in their ~/.editrc,
+				// this will reset the standard bindings. However we really
+				// want in this shell that Ctrl+C, tab, Ctrl+Z and Ctrl+R
+				// always have the same meaning.  So reload these bindings
+				// explicitly no matter what ~/.editrc may have changed.
+				c.ins.RebindControlKeys()
+				defer c.ins.Close()
 			} else {
-				stdin := config.Stdin
-				if stdin == nil {
-					stdin = os.Stdin
-				}
 				c.buf = bufio.NewReader(stdin)
 			}
 
@@ -1142,9 +1163,5 @@ func runTerm(cmd *cobra.Command, args []string) error {
 		// Single-line sql; run as simple as possible, without noise on stdout.
 		return runStatements(conn, sqlCtx.execStmts)
 	}
-	// Use the same as the default global readline config.
-	conf := readline.Config{
-		DisableAutoSaveHistory: true,
-	}
-	return runInteractive(conn, &conf)
+	return runInteractive(conn)
 }

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -15,11 +15,11 @@
 package cli
 
 import (
+	"io/ioutil"
 	"net/url"
-	"strings"
+	"os"
 	"testing"
 
-	"github.com/chzyer/readline"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -98,18 +98,48 @@ select '''
 		},
 	}
 
-	conf := readline.Config{
-		DisableAutoSaveHistory: true,
-		FuncOnWidthChanged:     func(func()) {},
-	}
-
 	// Some other tests (TestDumpRow) mess with this, so make sure it's set.
 	cliCtx.tableDisplayFormat = tableDisplayPretty
 
+	// We need a temporary file with a name guaranteed to be available.
+	// So open a dummy file.
+	f, err := ioutil.TempFile("", "input")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Get the name and close it.
+	fname := f.Name()
+	f.Close()
+
+	// At every point below, when t.Fatal is called we should ensure the
+	// file is closed and removed.
+	f = nil
+	defer func() {
+		if f != nil {
+			f.Close()
+		}
+		_ = os.Remove(fname)
+		stdin = os.Stdin
+	}()
+
 	for _, test := range tests {
-		conf.Stdin = strings.NewReader(test.in)
+		// Populate the test input.
+		if f, err = os.OpenFile(fname, os.O_WRONLY, 0666); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString(test.in); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+		// Make it available for reading.
+		if f, err = os.Open(fname); err != nil {
+			t.Fatal(err)
+		}
+		// Override the standard input for runInteractive().
+		stdin = f
+
 		out, err := captureOutput(func() {
-			err := runInteractive(conn, &conf)
+			err := runInteractive(conn)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
*Very many special thanks to @benesch and @bdarnell without whom this never could have been possible.*


Fixes #18192.
Fixes #16324.
Fixes #15460.
Fixes #14938.
Fixes #18909.

### cli/sql: use BSD's libedit for input.

This patch steps over to use http://github.com/knz/go-libedit,
a Go wrapper around BSD's
[editline](https://www.freebsd.org/cgi/man.cgi?query=editline&sektion=3)
library (`libedit`).

This supports:

- custom key bindings via `~/.editrc`
  See https://www.freebsd.org/cgi/man.cgi?query=editrc
  for details.
- proper entry across multiple lines.
- all terminal types supported by the system's terminfo library.

The name of the history file is changed from `~/.cockroachdb_history`
to `~/.cockroachsql_history` because the format is different. This
both avoids an error upon loading the previous format in the new
shell, and garbage history when trying to run an old shell over the
file using the new format.

### cli/sql: remove the option normalize_history

Prior to this patch, the CLI shell implemented logic to populate the
shell history using pretty-printed renderings of the AST of
parsed statements so far. The reason why this was done was a
combination of two factors:

- the readline input library was not able to handle multi-line
  entries.
- for UX it is desirable to have one "item" of SQL entry, that is,
  a full statement, as a single item of history so as to ease
  recollection of the history entry.

So to satisfy the 2nd point while dealing with the first, the shell
would concatenate the lines of a single statement, parse them,
then pretty-print the AST, because the pretty-print code guarantees
that the result contains a single line (significant newline characters
e.g. in string literals are escaped).

The second requirement still holds, but now the new readline library
*is* able to handle multi-line history entry.

So this patch simplifies the code to add multi-line statements
as one history entry, and removes the complexity associated with
normalization entirely.
