### PR TITLE
cherrypick: pgwire, cli/sql: support tables with no columns properly #17816

### DIFF
--- a/pkg/acceptance/reference_test.go
+++ b/pkg/acceptance/reference_test.go
@@ -68,24 +68,24 @@ $bin sql -e "CREATE DATABASE old"
 $bin sql -d old -e "CREATE TABLE testing_old (i int primary key, b bool, s string unique, d decimal, f float, t timestamp, v interval, index sb (s, b))"
 $bin sql -d old -e "INSERT INTO testing_old values (1, true, 'hello', decimal '3.14159', 3.14159, NOW(), interval '1h')"
 $bin sql -d old -e "INSERT INTO testing_old values (2, false, 'world', decimal '0.14159', 0.14159, NOW(), interval '234h45m2s234ms')"
-$bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > old.everything
+$bin sql -d old --format=records -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > old.everything
 $bin quit && wait # wait will block until all background jobs finish.
 
 bin=/cockroach/cockroach
 $bin start --certs-dir=/certs/ --background --logtostderr &> newout
 echo "Read data written by reference version using new binary"
-$bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > new.everything
+$bin sql -d old --format=records -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > new.everything
 # diff returns non-zero if different. With set -e above, that would exit here.
-diff new.everything old.everything
+diff -u new.everything old.everything
 
 $bin debug range ls
 
 echo "Add a row with the new binary and render the updated data before shutting down."
 $bin sql -d old -e "INSERT INTO testing_old values (3, false, '!', decimal '2.14159', 2.14159, NOW(), interval '3h')"
-$bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > new.everything
+$bin sql -d old --format=records -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > new.everything
 $bin sql -d old -e "CREATE TABLE testing_new (i int primary key, b bool, s string unique, d decimal, f float, t timestamp, v interval, index sb (s, b))"
 $bin sql -d old -e "INSERT INTO testing_new values (4, false, '!!', decimal '1.14159', 1.14159, NOW(), interval '4h')"
-$bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_new" >> new.everything
+$bin sql -d old --format=records -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_new" >> new.everything
 $bin quit
 # Let it close its listening sockets.
 sleep 1
@@ -116,10 +116,10 @@ trap finish EXIT
 export COCKROACH_CERTS_DIR=/certs/
 echo "TODO(marc): specify --certs-dir=/certs/ once the binary is upgraded"
 $bin start --background --logtostderr &> out
-$bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > old.everything
-$bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_new" >> old.everything
+$bin sql -d old --format=records -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > old.everything
+$bin sql -d old --format=records -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_new" >> old.everything
 # diff returns non-zero if different. With set -e above, that would exit here.
-diff new.everything old.everything
+diff -u new.everything old.everything
 $bin quit && wait
 `
 	runReadWriteReferenceTest(ctx, t, `bidirectional-reference-version`, backwardReferenceTest)
@@ -148,10 +148,10 @@ trap finish EXIT
 export COCKROACH_CERTS_DIR=/certs/
 echo "TODO(marc): specify --certs-dir=/certs/ once the binary is upgraded"
 $bin start --background --logtostderr &> out
-$bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > old.everything
-$bin sql -d old -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_new" >> old.everything
+$bin sql -d old --format=records -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_old" > old.everything
+$bin sql -d old --format=records -e "SELECT i, b, s, d, f, extract(epoch from (timestamp '1970-01-01 00:00:00' + v)) as v, extract(epoch FROM t) as e FROM testing_new" >> old.everything
 # diff returns non-zero if different. With set -e above, that would exit here.
-diff new.everything old.everything
+diff -u new.everything old.everything
 $bin quit && wait
 `
 	runReadWriteReferenceTest(ctx, t, `forward-reference-version`, backwardReferenceTest)

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -223,7 +223,7 @@ func runListCerts(cmd *cobra.Command, args []string) error {
 		addRow(cert, fmt.Sprintf("user: %s", user))
 	}
 
-	return printQueryOutput(os.Stdout, certTableHeaders, newRowSliceIter(rows), "")
+	return printQueryOutput(os.Stdout, certTableHeaders, newRowSliceIter(rows))
 }
 
 var certCmds = []*cobra.Command{

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -443,29 +443,29 @@ func Example_logging() {
 
 	// Output:
 	// sql --logtostderr=false -e select 1
-	// 1 row
 	// 1
 	// 1
+	// # 1 row
 	// sql --log-backtrace-at=foo.go:1 -e select 1
-	// 1 row
 	// 1
 	// 1
+	// # 1 row
 	// sql --log-dir= -e select 1
-	// 1 row
 	// 1
 	// 1
+	// # 1 row
 	// sql --logtostderr=true -e select 1
-	// 1 row
 	// 1
 	// 1
+	// # 1 row
 	// sql --verbosity=0 -e select 1
-	// 1 row
 	// 1
 	// 1
+	// # 1 row
 	// sql --vmodule=foo=1 -e select 1
-	// 1 row
 	// 1
 	// 1
+	// # 1 row
 }
 
 func Example_max_results() {
@@ -696,63 +696,63 @@ func Example_sql() {
 
 	// Output:
 	// sql -e show application_name
-	// 1 row
 	// application_name
 	// cockroach
+	// # 1 row
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
 	// INSERT 1
 	// sql -e delete from t.f
 	// pq: rejected: DELETE without WHERE clause (sql_safe_updates = true)
 	// sql -e select 3 -e select * from t.f
-	// 1 row
 	// 3
 	// 3
-	// 1 row
+	// # 1 row
 	// x	y
 	// 42	69
+	// # 1 row
 	// sql -e begin -e select 3 -e commit
 	// BEGIN
-	// 1 row
 	// 3
 	// 3
+	// # 1 row
 	// COMMIT
 	// sql -e select * from t.f
-	// 1 row
 	// x	y
 	// 42	69
+	// # 1 row
 	// sql --execute=show databases
-	// 5 rows
 	// Database
 	// crdb_internal
 	// information_schema
 	// pg_catalog
 	// system
 	// t
+	// # 5 rows
 	// sql -e select 1; select 2
-	// 1 row
 	// 1
 	// 1
-	// 1 row
+	// # 1 row
 	// 2
 	// 2
+	// # 1 row
 	// sql -e select 1; select 2 where false
-	// 1 row
 	// 1
 	// 1
-	// 0 rows
+	// # 1 row
 	// 2
+	// # 0 rows
 	// sql -d nonexistent -e select count(*) from pg_class limit 0
-	// 0 rows
 	// count(*)
+	// # 0 rows
 	// sql -d nonexistent -e create database nonexistent; create table foo(x int); select * from foo
-	// 0 rows
 	// x
+	// # 0 rows
 	// sql -e copy t.f from stdin
 	// woops! COPY has confused this client! Suggestion: use 'psql' for COPY
 	// user ls --echo-sql
 	// > SELECT username FROM system.users
-	// 0 rows
 	// username
+	// # 0 rows
 }
 
 func Example_sql_format() {
@@ -769,9 +769,9 @@ func Example_sql_format() {
 	// sql -e insert into t.times values ('2016-01-25 10:10:10', '2016-01-25 10:10:10-05:00')
 	// INSERT 1
 	// sql -e select * from t.times
-	// 1 row
 	// bare	withtz
 	// 2016-01-25 10:10:10+00:00	2016-01-25 15:10:10+00:00
+	// # 1 row
 }
 
 func Example_sql_column_labels() {
@@ -797,7 +797,6 @@ func Example_sql_column_labels() {
 	// sql -e insert into t.u values (0, 0, 0, 0, 0, 0)
 	// INSERT 1
 	// sql -e show columns from t.u
-	// 6 rows
 	// Field	Type	Null	Default	Indices
 	// """foo"	INT	true	NULL	{}
 	// \foo	INT	true	NULL	{}
@@ -806,10 +805,11 @@ func Example_sql_column_labels() {
 	// κόσμε	INT	true	NULL	{}
 	// a|b	INT	true	NULL	{}
 	// ܈85	INT	true	NULL	{}
+	// # 6 rows
 	// sql -e select * from t.u
-	// 1 row
 	// """foo"	\foo	"""foo\nbar"""	κόσμε	a|b	܈85
 	// 0	0	0	0	0	0
+	// # 1 row
 	// sql --format=pretty -e show columns from t.u
 	// +---------+------+------+---------+---------+
 	// |  Field  | Type | Null | Default | Indices |
@@ -831,13 +831,13 @@ func Example_sql_column_labels() {
 	// +------+------+------------+-------+-----+-----+
 	// (1 row)
 	// sql --format=tsv -e select * from t.u
-	// 1 row
 	// """foo"	\foo	"""foo\nbar"""	κόσμε	a|b	܈85
 	// 0	0	0	0	0	0
+	// # 1 row
 	// sql --format=csv -e select * from t.u
-	// 1 row
 	// """foo",\foo,"""foo\nbar""",κόσμε,a|b,܈85
 	// 0,0,0,0,0,0
+	// # 1 row
 	// sql --format=sql -e select * from t.u
 	// CREATE TABLE results (
 	//   """foo" STRING,
@@ -890,11 +890,11 @@ func Example_sql_empty_table() {
 	// +---+
 	// (0 rows)
 	// sql --format=tsv -e select * from t.norows
-	// 0 rows
 	// x
+	// # 0 rows
 	// sql --format=csv -e select * from t.norows
-	// 0 rows
 	// x
+	// # 0 rows
 	// sql --format=sql -e select * from t.norows
 	// CREATE TABLE results (
 	//   x STRING
@@ -913,17 +913,17 @@ func Example_sql_empty_table() {
 	// --
 	// (3 rows)
 	// sql --format=tsv -e select * from t.nocols
-	// 3 rows
 	// # no columns
 	// # empty
 	// # empty
 	// # empty
+	// # 3 rows
 	// sql --format=csv -e select * from t.nocols
-	// 3 rows
 	// # no columns
 	// # empty
 	// # empty
 	// # empty
+	// # 3 rows
 	// sql --format=sql -e select * from t.nocols
 	// CREATE TABLE results (
 	// );
@@ -952,11 +952,11 @@ func Example_sql_empty_table() {
 	// --
 	// (0 rows)
 	// sql --format=tsv -e select * from t.nocolsnorows
-	// 0 rows
 	// # no columns
+	// # 0 rows
 	// sql --format=csv -e select * from t.nocolsnorows
-	// 0 rows
 	// # no columns
+	// # 0 rows
 	// sql --format=sql -e select * from t.nocolsnorows
 	// CREATE TABLE results (
 	// );
@@ -1027,7 +1027,6 @@ func Example_sql_table() {
 	// sql -e insert into t.t values (e'a\tb\tc\n12\t123123213\t12313', 'tabs')
 	// INSERT 1
 	// sql -e select * from t.t
-	// 9 rows
 	// s	d
 	// foo	printable ASCII
 	// """foo"	printable ASCII with quotes
@@ -1040,6 +1039,7 @@ func Example_sql_table() {
 	// ܈85	UTF8 string with RTL char
 	// "a	b	c
 	// 12	123123213	12313"	tabs
+	// # 9 rows
 	// sql --format=pretty -e select * from t.t
 	// +--------------------------------+--------------------------------+
 	// |               s                |               d                |
@@ -1058,7 +1058,6 @@ func Example_sql_table() {
 	// +--------------------------------+--------------------------------+
 	// (9 rows)
 	// sql --format=tsv -e select * from t.t
-	// 9 rows
 	// s	d
 	// foo	printable ASCII
 	// """foo"	printable ASCII with quotes
@@ -1071,8 +1070,8 @@ func Example_sql_table() {
 	// ܈85	UTF8 string with RTL char
 	// "a	b	c
 	// 12	123123213	12313"	tabs
+	// # 9 rows
 	// sql --format=csv -e select * from t.t
-	// 9 rows
 	// s,d
 	// foo,printable ASCII
 	// """foo",printable ASCII with quotes
@@ -1085,6 +1084,7 @@ func Example_sql_table() {
 	// ܈85,UTF8 string with RTL char
 	// "a	b	c
 	// 12	123123213	12313",tabs
+	// # 9 rows
 	// sql --format=sql -e select * from t.t
 	// CREATE TABLE results (
 	//   s STRING,
@@ -1254,8 +1254,8 @@ func Example_user() {
 
 	// Output:
 	// user ls
-	// 0 rows
 	// username
+	// # 0 rows
 	// user ls --format=pretty
 	// +----------+
 	// | username |
@@ -1263,8 +1263,8 @@ func Example_user() {
 	// +----------+
 	// (0 rows)
 	// user ls --format=tsv
-	// 0 rows
 	// username
+	// # 0 rows
 	// user set FOO
 	// INSERT 1
 	// user set Foo
@@ -1463,9 +1463,9 @@ func Example_node() {
 
 	// Output:
 	// node ls
-	// 1 row
 	// id
 	// 1
+	// # 1 row
 	// node ls --format=pretty
 	// +----+
 	// | id |
@@ -1855,7 +1855,7 @@ func Example_in_memory() {
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
 	// INSERT 1
 	// node ls
-	// 1 row
 	// id
 	// 1
+	// # 1 row
 }

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -503,9 +503,9 @@ func TestDumpAsOf(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Last line is the timestamp.
+	// Last line is the row count, last-before-last is the timestamp.
 	fs := strings.Split(strings.TrimSpace(out), "\n")
-	ts := fs[len(fs)-1]
+	ts := fs[len(fs)-2]
 
 	dump1, err := c.RunWithCaptureArgs([]string{"dump", "d", "t"})
 	if err != nil {
@@ -757,12 +757,12 @@ SELECT * FROM c;
 SELECT * FROM a;
 SELECT * FROM c;
 
-1 row
 i
 1
-1 row
+# 1 row
 i
 1
+# 1 row
 `
 
 	if string(out) != expect {

--- a/pkg/cli/format_table.go
+++ b/pkg/cli/format_table.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
 )
 
 // rowStrIter is an iterator interface for the printQueryOutput function. It is
@@ -93,162 +94,342 @@ func newRowIter(rows *sqlRows, showMoreChars bool) *rowIter {
 	}
 }
 
-// printQueryOutput takes a list of column names and a list of row contents
-// writes a formatted table to 'w', or simply the tag if empty. Note that
-// printQueryOutput expects the tag to already be properly formatted.
-func printQueryOutput(w io.Writer, cols []string, allRows rowStrIter, tag string) error {
-	if len(cols) == 0 {
-		// This operation did not return rows, just show the tag.
-		fmt.Fprintln(w, tag)
+// rowReporter is used to render result sets.
+// - describe is called once in any case with the result column set.
+// - beforeFirstRow is called once upon the first row encountered.
+// - iter is called for every row, including the first (called after beforeFirstRowFn).
+// - doneRows is called once after the last row encountered (in case of no error).
+//   This can also be called when there were no rows, if the rowsAffectedHook
+//   passed to render() returns false.
+// - doneNoRows is called once when there were no rows and the rowsAffectedHook
+//   returns true.
+type rowReporter interface {
+	describe(w io.Writer, cols []string) error
+	beforeFirstRow(w io.Writer) error
+	iter(w io.Writer, rowIdx int, row []string) error
+	doneRows(w io.Writer, seenRows int) error
+	doneNoRows(w io.Writer) error
+}
+
+// render iterates using the rowReporter object.
+// The caller can pass a noRowsHook helper that will be called in the
+// case there were no result rows. The helper is guaranteed to be called
+// after the iteration through iter.Next(). Used in runQueryAndFormatResults.
+func render(
+	r rowReporter, w io.Writer, cols []string, iter rowStrIter, noRowsHook func() (bool, error),
+) error {
+	if err := r.describe(w, cols); err != nil {
+		return err
+	}
+	nRows := 0
+	for {
+		// Get a next row.
+		row, err := iter.Next()
+		if err == io.EOF {
+			// No more rows.
+			break
+		}
+		if err != nil {
+			// Error: don't call doneFn.
+			return err
+		}
+		if nRows == 0 {
+			// First row? Report.
+			if err := r.beforeFirstRow(w); err != nil {
+				return err
+			}
+		}
+
+		// Report every row including the first.
+		if err := r.iter(w, nRows, row); err != nil {
+			return err
+		}
+
+		nRows++
+	}
+
+	if nRows == 0 && noRowsHook != nil {
+		handled, err := noRowsHook()
+		if err != nil {
+			return err
+		}
+		if handled {
+			return r.doneNoRows(w)
+		}
+	}
+	return r.doneRows(w, nRows)
+}
+
+type prettyReporter struct {
+	cols  []string
+	table *tablewriter.Table
+}
+
+func (p *prettyReporter) describe(w io.Writer, cols []string) error {
+	p.cols = cols
+	if len(cols) > 0 {
+		// Initialize tablewriter and set column names as the header row.
+		p.table = tablewriter.NewWriter(w)
+		p.table.SetAutoFormatHeaders(false)
+		p.table.SetAutoWrapText(false)
+		p.table.SetHeader(p.cols)
+	}
+	return nil
+}
+
+func (p *prettyReporter) beforeFirstRow(w io.Writer) error { return nil }
+
+func (p *prettyReporter) iter(_ io.Writer, _ int, row []string) error {
+	if p.table == nil {
 		return nil
 	}
 
+	for i, r := range row {
+		row[i] = expandTabsAndNewLines(r)
+	}
+	p.table.Append(row)
+	return nil
+}
+
+func (p *prettyReporter) doneRows(w io.Writer, seenRows int) error {
+	if p.table != nil {
+		p.table.Render()
+	} else {
+		// A simple delimiter, like in psql.
+		fmt.Fprintln(w, "--")
+	}
+
+	fmt.Fprintf(w, "(%d row%s)\n", seenRows, util.Pluralize(int64(seenRows)))
+	return nil
+}
+
+func (p *prettyReporter) doneNoRows(_ io.Writer) error { return nil }
+
+type csvReporter struct {
+	cols    []string
+	allRows [][]string
+}
+
+func (p *csvReporter) describe(w io.Writer, cols []string) error {
+	p.cols = cols
+	return nil
+}
+
+func (p *csvReporter) iter(_ io.Writer, _ int, row []string) error {
+	if len(row) == 0 {
+		p.allRows = append(p.allRows, []string{"# empty"})
+	} else {
+		p.allRows = append(p.allRows, row)
+	}
+	return nil
+}
+
+func (p *csvReporter) beforeFirstRow(_ io.Writer) error { return nil }
+func (p *csvReporter) doneNoRows(_ io.Writer) error     { return nil }
+
+func (p *csvReporter) doneRows(w io.Writer, seenRows int) error {
+	fmt.Fprintf(w, "%d row%s\n", seenRows, util.Pluralize(int64(seenRows)))
+
+	csvWriter := csv.NewWriter(w)
+	if cliCtx.tableDisplayFormat == tableDisplayTSV {
+		csvWriter.Comma = '\t'
+	}
+	if len(p.cols) == 0 {
+		_ = csvWriter.Write([]string{"# no columns"})
+	} else {
+		_ = csvWriter.Write(p.cols)
+	}
+	_ = csvWriter.WriteAll(p.allRows)
+	return nil
+}
+
+type rawReporter struct{}
+
+func (p *rawReporter) describe(w io.Writer, cols []string) error {
+	fmt.Fprintf(w, "# %d column%s\n", len(cols),
+		util.Pluralize(int64(len(cols))))
+	return nil
+}
+
+func (p *rawReporter) iter(w io.Writer, rowIdx int, row []string) error {
+	fmt.Fprintf(w, "# row %d\n", rowIdx+1)
+	for _, r := range row {
+		fmt.Fprintf(w, "## %d\n%s\n", len(r), r)
+	}
+	return nil
+}
+
+func (p *rawReporter) beforeFirstRow(_ io.Writer) error { return nil }
+func (p *rawReporter) doneNoRows(_ io.Writer) error     { return nil }
+
+func (p *rawReporter) doneRows(w io.Writer, nRows int) error {
+	fmt.Fprintf(w, "# %d row%s\n", nRows, util.Pluralize(int64(nRows)))
+	return nil
+}
+
+type htmlReporter struct {
+	nCols int
+}
+
+func (p *htmlReporter) describe(w io.Writer, cols []string) error {
+	p.nCols = len(cols)
+	fmt.Fprint(w, "<table>\n<thead><tr>")
+	fmt.Fprint(w, "<th>row</th>")
+	for _, col := range cols {
+		fmt.Fprintf(w, "<th>%s</th>", html.EscapeString(col))
+	}
+	fmt.Fprintln(w, "</tr></head>")
+	return nil
+}
+
+func (p *htmlReporter) beforeFirstRow(w io.Writer) error {
+	fmt.Fprintln(w, "<tbody>")
+	return nil
+}
+
+func (p *htmlReporter) iter(w io.Writer, rowIdx int, row []string) error {
+	fmt.Fprintf(w, "<tr><td>%d</td>", rowIdx+1)
+	for _, r := range row {
+		fmt.Fprintf(w, "<td>%s</td>", strings.Replace(html.EscapeString(r), "\n", "<br/>", -1))
+	}
+	fmt.Fprintln(w, "</tr>")
+	return nil
+}
+
+func (p *htmlReporter) doneNoRows(w io.Writer) error {
+	fmt.Fprintln(w, "</table>")
+	return nil
+}
+
+func (p *htmlReporter) doneRows(w io.Writer, nRows int) error {
+	fmt.Fprintln(w, "</tbody>")
+	fmt.Fprintf(w, "<tfoot><tr><td colspan=%d>%d row%s</td></tr></tfoot></table>\n",
+		p.nCols+1, nRows, util.Pluralize(int64(nRows)))
+	return nil
+}
+
+type recordReporter struct {
+	cols        []string
+	maxColWidth int
+}
+
+func (p *recordReporter) describe(w io.Writer, cols []string) error {
+	p.cols = cols
+	for _, col := range cols {
+		colLen := utf8.RuneCountInString(col)
+		if colLen > p.maxColWidth {
+			p.maxColWidth = colLen
+		}
+	}
+	return nil
+}
+
+func (p *recordReporter) iter(w io.Writer, rowIdx int, row []string) error {
+	if len(p.cols) == 0 {
+		// No record details; a summary will be printed at the end.
+		return nil
+	}
+	fmt.Fprintf(w, "-[ RECORD %d ]\n", rowIdx+1)
+	for j, r := range row {
+		lines := strings.Split(r, "\n")
+		for l, line := range lines {
+			colLabel := p.cols[j]
+			if l > 0 {
+				colLabel = ""
+			}
+			// Note: special characters, including a vertical bar, in
+			// the colLabel are not escaped here. This is in accordance
+			// with the same behavior in PostgreSQL.
+			fmt.Fprintf(w, "%-*s | %s\n", p.maxColWidth, colLabel, line)
+		}
+	}
+	return nil
+}
+
+func (p *recordReporter) doneRows(w io.Writer, seenRows int) error {
+	if len(p.cols) == 0 {
+		fmt.Fprintf(w, "(%d row%s)\n", seenRows, util.Pluralize(int64(seenRows)))
+	}
+	return nil
+}
+
+func (p *recordReporter) beforeFirstRow(_ io.Writer) error { return nil }
+func (p *recordReporter) doneNoRows(_ io.Writer) error     { return nil }
+
+type sqlReporter struct {
+	noColumns bool
+}
+
+func (p *sqlReporter) describe(w io.Writer, cols []string) error {
+	fmt.Fprint(w, "CREATE TABLE results (\n")
+	for i, col := range cols {
+		s := parser.Name(col)
+		fmt.Fprintf(w, "  %s STRING", s.String())
+		if i < len(cols)-1 {
+			fmt.Fprint(w, ",")
+		}
+		fmt.Fprint(w, "\n")
+	}
+	fmt.Fprint(w, ");\n\n")
+	p.noColumns = (len(cols) == 0)
+	return nil
+}
+
+func (p *sqlReporter) iter(w io.Writer, _ int, row []string) error {
+	if p.noColumns {
+		fmt.Fprintln(w, "INSERT INTO results(rowid) VALUES (DEFAULT);")
+		return nil
+	}
+
+	fmt.Fprint(w, "INSERT INTO results VALUES (")
+	for i, r := range row {
+		s := parser.DString(r)
+		fmt.Fprintf(w, "%s", s.String())
+		if i < len(row)-1 {
+			fmt.Fprint(w, ", ")
+		}
+	}
+	fmt.Fprint(w, ");\n")
+	return nil
+}
+
+func (p *sqlReporter) beforeFirstRow(_ io.Writer) error  { return nil }
+func (p *sqlReporter) doneNoRows(_ io.Writer) error      { return nil }
+func (p *sqlReporter) doneRows(_ io.Writer, _ int) error { return nil }
+
+func makeReporter() (rowReporter, error) {
 	switch cliCtx.tableDisplayFormat {
 	case tableDisplayPretty:
-		// Initialize tablewriter and set column names as the header row.
-		table := tablewriter.NewWriter(w)
-		table.SetAutoFormatHeaders(false)
-		table.SetAutoWrapText(false)
-		table.SetHeader(cols)
-		nRows := 0
-		for {
-			row, err := allRows.Next()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return err
-			}
-			for i, r := range row {
-				row[i] = expandTabsAndNewLines(r)
-			}
-			table.Append(row)
-			nRows++
-		}
-		table.Render()
-		fmt.Fprintf(w, "(%d row%s)\n", nRows, util.Pluralize(int64(nRows)))
+		return &prettyReporter{}, nil
 
 	case tableDisplayTSV:
 		fallthrough
 	case tableDisplayCSV:
-		allRowsSlice, err := allRows.ToSlice()
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(w, "%d row%s\n", len(allRowsSlice),
-			util.Pluralize(int64(len(allRowsSlice))))
-
-		csvWriter := csv.NewWriter(w)
-		if cliCtx.tableDisplayFormat == tableDisplayTSV {
-			csvWriter.Comma = '\t'
-		}
-		_ = csvWriter.Write(cols)
-		_ = csvWriter.WriteAll(allRowsSlice)
+		return &csvReporter{}, nil
 
 	case tableDisplayRaw:
-		fmt.Fprintf(w, "# %d column%s\n", len(cols),
-			util.Pluralize(int64(len(cols))))
-		nRows := 0
-		for {
-			row, err := allRows.Next()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return err
-			}
-			nRows++
-			fmt.Fprintf(w, "# row %d\n", nRows)
-			for _, r := range row {
-				fmt.Fprintf(w, "## %d\n%s\n", len(r), r)
-			}
-		}
-		fmt.Fprintf(w, "# %d row%s\n", nRows, util.Pluralize(int64(nRows)))
+		return &rawReporter{}, nil
 
 	case tableDisplayHTML:
-		fmt.Fprint(w, "<table>\n<thead><tr>")
-		for _, col := range cols {
-			fmt.Fprintf(w, "<th>%s</th>", html.EscapeString(col))
-		}
-		fmt.Fprint(w, "</tr></head>\n<tbody>\n")
-		for {
-			row, err := allRows.Next()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return err
-			}
-			fmt.Fprint(w, "<tr>")
-			for _, r := range row {
-				fmt.Fprintf(w, "<td>%s</td>", strings.Replace(html.EscapeString(r), "\n", "<br/>", -1))
-			}
-			fmt.Fprint(w, "</tr>\n")
-		}
-		fmt.Fprint(w, "</tbody>\n</table>\n")
+		return &htmlReporter{}, nil
 
 	case tableDisplayRecords:
-		maxColWidth := 0
-		for _, col := range cols {
-			colLen := utf8.RuneCountInString(col)
-			if colLen > maxColWidth {
-				maxColWidth = colLen
-			}
-		}
-
-		for i := 0; ; i++ {
-			row, err := allRows.Next()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return err
-			}
-			fmt.Fprintf(w, "-[ RECORD %d ]\n", i+1)
-			for j, r := range row {
-				lines := strings.Split(r, "\n")
-				for l, line := range lines {
-					colLabel := cols[j]
-					if l > 0 {
-						colLabel = ""
-					}
-					// Note: special characters, including a vertical bar, in
-					// the colLabel are not escaped here. This is in accordance
-					// with the same behavior in PostgreSQL.
-					fmt.Fprintf(w, "%-*s | %s\n", maxColWidth, colLabel, line)
-				}
-			}
-		}
+		return &recordReporter{}, nil
 
 	case tableDisplaySQL:
-		fmt.Fprint(w, "CREATE TABLE results (\n")
-		for i, col := range cols {
-			s := parser.Name(col)
-			fmt.Fprintf(w, "  %s STRING", s.String())
-			if i < len(cols)-1 {
-				fmt.Fprint(w, ",")
-			}
-			fmt.Fprint(w, "\n")
-		}
-		fmt.Fprint(w, ");\n\n")
-		for {
-			row, err := allRows.Next()
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				return err
-			}
-			fmt.Fprint(w, "INSERT INTO results VALUES (")
-			for i, r := range row {
-				s := parser.DString(r)
-				fmt.Fprintf(w, "%s", s.String())
-				if i < len(row)-1 {
-					fmt.Fprint(w, ", ")
-				}
-			}
-			fmt.Fprint(w, ");\n")
-		}
+		return &sqlReporter{}, nil
+
+	default:
+		return nil, errors.Errorf("unhandled display format: %d", cliCtx.tableDisplayFormat)
 	}
-	return nil
+}
+
+// printQueryOutput takes a list of column names and a list of row
+// contents writes a formatted table to 'w'.
+func printQueryOutput(w io.Writer, cols []string, allRows rowStrIter) error {
+	reporter, err := makeReporter()
+	if err != nil {
+		return err
+	}
+	return render(reporter, w, cols, allRows, nil)
 }

--- a/pkg/cli/interactive_tests/test_last_statement.tcl
+++ b/pkg/cli/interactive_tests/test_last_statement.tcl
@@ -69,12 +69,12 @@ end_test
 
 start_test "Check that a final comment after a final statement does not cause an error message. #9482"
 send "printf 'select 1;-- final comment' | $argv sql\r"
-eexpect "1 row\r\n1\r\n1\r\n:/# "
+eexpect "1\r\n1\r\n# 1 row\r\n:/# "
 end_test
 
 start_test "Check that a final comment does not cause an error message. #9243"
 send "printf 'select 1;\\n-- final comment' | $argv sql\r"
-eexpect "1 row\r\n1\r\n1\r\n:/# "
+eexpect "1\r\n1\r\n# 1 row\r\n:/# "
 end_test
 
 # Finally terminate with Ctrl+C

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -36,8 +36,8 @@ end_test
 
 start_test "Check that \\| reads statements."
 send "\\| echo 'select '; echo '38 + 4;'\r"
-eexpect "1 row"
 eexpect 42
+eexpect "1 row"
 eexpect root@
 end_test
 
@@ -89,8 +89,8 @@ eexpect " ->"
 send "\\?\r"
 eexpect " ->"
 send "world';\r"
-eexpect "1 row"
 eexpect "hello\\\\nworld"
+eexpect "1 row"
 eexpect root@
 end_test
 

--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -18,7 +18,7 @@ end_test
 
 start_test "Check that tables are not pretty-printed when input is not a terminal and --format=pretty is not specified."
 send "echo begin; echo 'select 1;' | $argv sql\r"
-eexpect "begin\r\n1 row\r\n1\r\n1\r\n"
+eexpect "begin\r\n1\r\n1\r\n# 1 row\r\n"
 end_test
 
 start_test "Check that tables are pretty-printed when input is a terminal and --format=pretty is not specified."
@@ -34,7 +34,7 @@ start_test "Check that tables are not pretty-printed when input is a terminal an
 send "$argv sql --format=tsv\r"
 eexpect root@
 send "select 42; select 1;\r"
-eexpect "42\r\n1 row\r\n1\r\n1\r\n"
+eexpect "42\r\n# 1 row\r\n1\r\n1\r\n# 1 row\r\n"
 eexpect root@
 send "\\q\r"
 end_test

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -74,7 +74,7 @@ func runLsNodes(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	return printQueryOutput(os.Stdout, lsNodesColumnHeaders, newRowSliceIter(rows), "")
+	return printQueryOutput(os.Stdout, lsNodesColumnHeaders, newRowSliceIter(rows))
 }
 
 var baseNodeColumnHeaders = []string{
@@ -183,7 +183,7 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	return printQueryOutput(os.Stdout, getStatusNodeHeaders(), newRowSliceIter(nodeStatusesToRows(nodeStatuses, decommissionStatusResp)), "")
+	return printQueryOutput(os.Stdout, getStatusNodeHeaders(), newRowSliceIter(nodeStatusesToRows(nodeStatuses, decommissionStatusResp)))
 }
 
 func getStatusNodeHeaders() []string {
@@ -385,7 +385,7 @@ effect and the nodes will participate in the cluster as regular nodes.
 
 func printDecommissionStatus(resp serverpb.DecommissionStatusResponse) error {
 	return printQueryOutput(os.Stdout, decommissionNodesColumnHeaders,
-		newRowSliceIter(decommissionResponseValueToRows(resp.Status)), "")
+		newRowSliceIter(decommissionResponseValueToRows(resp.Status)))
 }
 
 func runRecommissionNode(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -302,8 +302,7 @@ func (c *cliState) handleSet(args []string, nextState, errState cliStateEnum) cl
 				{"normalize_history", strconv.FormatBool(c.normalizeHistory)},
 				{"show_times", strconv.FormatBool(cliCtx.showTimes)},
 				{"smart_prompt", strconv.FormatBool(c.smartPrompt)},
-			}),
-			"set")
+			}))
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/cli/sql_util_test.go
+++ b/pkg/cli/sql_util_test.go
@@ -117,7 +117,7 @@ SET
 	b.Reset()
 
 	// Use system database for sample query/output as they are fairly fixed.
-	cols, rows, _, err := runQuery(conn, makeQuery(`SHOW COLUMNS FROM system.namespace`), false)
+	cols, rows, err := runQuery(conn, makeQuery(`SHOW COLUMNS FROM system.namespace`), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -518,7 +518,7 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 		}
 
 		id := path[len(path)-1]
-		_, _, _, err = runQuery(conn, makeQuery(
+		_, _, err = runQuery(conn, makeQuery(
 			`UPSERT INTO system.zones (id, config) VALUES ($1, $2)`,
 			id, buf), false)
 		if err != nil {


### PR DESCRIPTION
Note for docs:

this also changes the CSV and TSV formats to print the row count at the end (instead of at the beginning). This is a user-facing change that may impact users who use an automated tool to parse/analyze the output produced by `cockroach sql`.