### PR TITLE
cherrypick-1.1: sql+cli: Fix UUID column dumping

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -459,6 +459,11 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, md tableMetadat
 						}
 					case "BYTES":
 						d = parser.NewDBytes(parser.DBytes(t))
+					case "UUID":
+						d, err = parser.ParseDUuidFromString(string(t))
+						if err != nil {
+							return err
+						}
 					default:
 						// STRING and DECIMAL types can have optional length
 						// suffixes, so only examine the prefix of the type.

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -53,6 +53,7 @@ func TestCopyNullInfNaN(t *testing.T) {
 			n INTERVAL NULL,
 			o BOOL NULL,
 			e DECIMAL NULL,
+			u UUID NULL,
 			tz TIMESTAMP WITH TIME ZONE NULL
 		);
 	`); err != nil {
@@ -70,10 +71,10 @@ func TestCopyNullInfNaN(t *testing.T) {
 	}
 
 	input := [][]interface{}{
-		{nil, nil, nil, nil, nil, nil, nil, nil, nil, nil},
-		{nil, math.Inf(1), nil, nil, nil, nil, nil, nil, nil, nil},
-		{nil, math.Inf(-1), nil, nil, nil, nil, nil, nil, nil, nil},
-		{nil, math.NaN(), nil, nil, nil, nil, nil, nil, nil, nil},
+		{nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil},
+		{nil, math.Inf(1), nil, nil, nil, nil, nil, nil, nil, nil, nil},
+		{nil, math.Inf(-1), nil, nil, nil, nil, nil, nil, nil, nil, nil},
+		{nil, math.NaN(), nil, nil, nil, nil, nil, nil, nil, nil, nil},
 	}
 
 	for _, in := range input {
@@ -143,6 +144,7 @@ func TestCopyRandom(t *testing.T) {
 			t TIMESTAMP,
 			s STRING,
 			b BYTES,
+			u UUID,
 			tz TIMESTAMP WITH TIME ZONE
 		);
 	`); err != nil {
@@ -154,7 +156,7 @@ func TestCopyRandom(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stmt, err := txn.Prepare(pq.CopyInSchema("d", "t", "id", "n", "o", "i", "f", "e", "t", "s", "b", "tz"))
+	stmt, err := txn.Prepare(pq.CopyInSchema("d", "t", "id", "n", "o", "i", "f", "e", "t", "s", "b", "u", "tz"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,6 +170,7 @@ func TestCopyRandom(t *testing.T) {
 		sqlbase.ColumnType_TIMESTAMP,
 		sqlbase.ColumnType_STRING,
 		sqlbase.ColumnType_BYTES,
+		sqlbase.ColumnType_UUID,
 		sqlbase.ColumnType_TIMESTAMPTZ,
 	}
 

--- a/pkg/sql/parser/col_types_test.go
+++ b/pkg/sql/parser/col_types_test.go
@@ -48,6 +48,7 @@ func TestParseColumnType(t *testing.T) {
 		{"NUMERIC", &DecimalColType{Name: "NUMERIC"}},
 		{"NUMERIC(8)", &DecimalColType{Name: "NUMERIC", Prec: 8}},
 		{"NUMERIC(9,10)", &DecimalColType{Name: "NUMERIC", Prec: 9, Scale: 10}},
+		{"UUID", &UUIDColType{}},
 		{"DATE", &DateColType{}},
 		{"TIMESTAMP", &TimestampColType{}},
 		{"TIMESTAMP WITH TIME ZONE", &TimestampTZColType{}},

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -1085,7 +1085,13 @@ func (*DUuid) AmbiguousFormat() bool { return false }
 
 // Format implements the NodeFormatter interface.
 func (d *DUuid) Format(buf *bytes.Buffer, f FmtFlags) {
-	encodeSQLString(buf, d.UUID.String())
+	if !f.bareStrings {
+		buf.WriteByte('\'')
+	}
+	buf.WriteString(d.UUID.String())
+	if !f.bareStrings {
+		buf.WriteByte('\'')
+	}
 }
 
 // Size implements the Datum interface.


### PR DESCRIPTION
Cherry picks #18505 for 1.1. Fixes #18501.

Previously, the UUID column was an unhandled case in the CLI dumping
which occurs when dumping to an SQL file.