### PR TITLE
distsql, storage: support user-specified temporary directories via CLI flag

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -53,11 +53,16 @@ type TestServerArgs struct {
 	// will be set to the the address of the cluster's first node.
 	JoinAddr string
 
-	// StoreSpecs define the stores for this server. If you want more than one
-	// store per node, populate this array with StoreSpecs each representing a
-	// store. If no StoreSpecs are provided than a single DefaultTestStoreSpec
-	// will be used.
+	// StoreSpecs define the stores for this server. If you want more than
+	// one store per node, populate this array with StoreSpecs each
+	// representing a store. If no StoreSpecs are provided then a single
+	// DefaultTestStoreSpec will be used.
 	StoreSpecs []StoreSpec
+
+	// TempStorageConfig defines parameters for the temp storage used as
+	// working memory for distributed operations and CSV importing.
+	// If not initialized, will default to DefaultTestTempStorageConfig.
+	TempStorageConfig TempStorageConfig
 
 	// Fields copied to the server.Config.
 	Insecure                 bool
@@ -111,11 +116,20 @@ type TestClusterArgs struct {
 	ServerArgsPerNode map[int]TestServerArgs
 }
 
-// DefaultTestStoreSpec is just a single in memory store of 100 MiB with no
-// special attributes.
-var DefaultTestStoreSpec = StoreSpec{
-	InMemory: true,
-}
+var (
+	// DefaultTestStoreSpec is just a single in memory store of 100 MiB
+	// with no special attributes.
+	DefaultTestStoreSpec = StoreSpec{
+		InMemory: true,
+	}
+	// DefaultTestTempStorageConfig is the associated temp storage for
+	// DefaultTestStoreSpec that is in-memory.
+	// It has a maximum size of 100MiB.
+	DefaultTestTempStorageConfig = TempStorageConfig{
+		InMemory:     true,
+		MaxSizeBytes: DefaultInMemTempStorageMaxSizeBytes,
+	}
+)
 
 // TestClusterReplicationMode represents the replication settings for a TestCluster.
 type TestClusterReplicationMode int

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -458,6 +458,24 @@ Also, if you use equal signs in the file path to a store, you must use the
 "path" field label.`,
 	}
 
+	TempDir = FlagInfo{
+		Name: "temp-dir",
+		Description: `
+The parent directory path where a temporary subdirectory will be created to be used for temporary files.
+This path must exist or the node will not start.
+The temporary subdirectory is used primarily as working memory for distributed computations
+and CSV importing.
+For example, the following will generate an arbitrary, temporary subdirectory
+"/mnt/ssd01/temp/cockroach-temp<NUMBER>":
+<PRE>
+
+  --temp-dir=/mnt/ssd01/temp
+
+</PRE>
+If this flag is unspecified, the temporary subdirectory will be located under
+the root of the first store.`,
+	}
+
 	URL = FlagInfo{
 		Name:   "url",
 		EnvVar: "COCKROACH_URL",

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -253,6 +253,7 @@ func init() {
 		// the stores flag has been parsed and the storage device that a percentage
 		// refers to becomes known.
 		varFlag(f, diskTempStorageSizeValue, cliflags.SQLTempStorage)
+		stringFlag(f, &serverCfg.TempStorageConfig.ParentDir, cliflags.TempDir, "")
 	}
 
 	for _, cmd := range certCmds {

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -17,7 +17,6 @@ package server
 import (
 	"os"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -199,41 +198,5 @@ func TestFilterGossipBootstrapResolvers(t *testing.T) {
 		t.Fatalf("expected one resolver; got %+v", filtered)
 	} else if filtered[0].Addr() != resolverSpecs[1] {
 		t.Fatalf("expected resolver to be %q; got %q", resolverSpecs[1], filtered[0].Addr())
-	}
-}
-
-func TestTempStoreDerivation(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	testCases := []struct {
-		firstStoreArg    string
-		expectedTempSpec base.StoreSpec
-	}{
-		{
-			firstStoreArg:    "type=mem,size=1GiB",
-			expectedTempSpec: base.StoreSpec{InMemory: true},
-		},
-		{
-			firstStoreArg:    "type=mem,size=1GiB,attrs=garbage:moregarbage",
-			expectedTempSpec: base.StoreSpec{InMemory: true},
-		},
-		{
-			firstStoreArg:    "path=/foo/bar",
-			expectedTempSpec: base.StoreSpec{Path: "/foo/bar/local"},
-		},
-	}
-
-	for i, tc := range testCases {
-		spec, err := base.NewStoreSpec(tc.firstStoreArg)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if e, a := tc.expectedTempSpec, MakeTempStoreSpecFromStoreSpec(spec); e.String() != a.String() {
-			t.Fatalf(
-				"%d: temp store spec did not match expected:\n%s",
-				i, strings.Join(pretty.Diff(e, a), "\n"),
-			)
-		}
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"bufio"
 	"compress/gzip"
 	"crypto/tls"
 	"fmt"
@@ -292,11 +293,56 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	rootSQLMemoryMonitor.Start(context.Background(), nil, mon.MakeStandaloneBudget(s.cfg.SQLMemoryPoolSize))
 
 	// Set up the DistSQL temp engine.
-	tempEngine, err := engine.NewTempEngine(ctx, s.cfg.TempStoreSpec)
+
+	// We first clean up abandoned temporary directories from the temporary
+	// directory record file.
+	firstStore := s.cfg.Stores.Specs[0]
+	// Record file can only exist if the first store is on-disk.
+	if !firstStore.InMemory {
+		if err := cleanupTempDirs(firstStore.Path); err != nil {
+			return nil, errors.Wrap(err, "could not cleanup temporary directories from record file")
+		}
+	}
+	// Create the temporary subdirectory for the temp engine.
+	var err error
+	if s.cfg.TempStorageConfig.Path, err = createTempDir(s.cfg.TempStorageConfig.ParentDir); err != nil {
+		return nil, errors.Wrap(err, "could not create temporary directory for temp storage")
+	}
+
+	// We record the new temporary directory in the record file (if it
+	// exists) for cleanup in case the node crashes.
+	if !firstStore.InMemory {
+		// Create the store dir, if it doesn't exist. The dir is required to exist
+		// by recordTempDir.
+		if err := os.MkdirAll(firstStore.Path, 0755); err != nil {
+			return nil, errors.Wrapf(err, "failed to create dir for first store: %s", firstStore.Path)
+		}
+		if err = recordTempDir(firstStore.Path, s.cfg.TempStorageConfig.Path); err != nil {
+			return nil, errors.Wrapf(
+				err,
+				"could not record temporary directory path to record file: %s",
+				filepath.Join(firstStore.Path, tempStorageDirsRecordFilename),
+			)
+		}
+	}
+	tempEngine, err := engine.NewTempEngine(s.cfg.TempStorageConfig)
 	if err != nil {
-		log.Fatalf(ctx, "could not create temporary store: %v", err)
+		return nil, errors.Wrap(err, "could not create temp storage")
 	}
 	s.stopper.AddCloser(tempEngine)
+	// Remove temporary directory linked to tempEngine after closing
+	// tempEngine.
+	s.stopper.AddCloser(stop.CloserFn(func() {
+		var err error
+		if firstStore.InMemory {
+			err = os.RemoveAll(s.cfg.TempStorageConfig.Path)
+		} else {
+			err = cleanupTempDirs(firstStore.Path)
+		}
+		if err != nil {
+			log.Errorf(context.TODO(), "could not remove temporary store directory: %v", err.Error())
+		}
+	}))
 
 	// Set up admin memory metrics for use by admin SQL executors.
 	s.adminMemMetrics = sql.MakeMemMetrics("admin", cfg.HistogramWindowInterval())
@@ -363,7 +409,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		NodeID:     &s.nodeIDContainer,
 
 		TempStorage:             tempEngine,
-		TempStorageMaxSizeBytes: s.cfg.TempStoreMaxSizeBytes,
+		TempStorageMaxSizeBytes: s.cfg.TempStorageConfig.MaxSizeBytes,
 
 		ParentMemoryMonitor: &rootSQLMemoryMonitor,
 
@@ -1334,4 +1380,76 @@ func officialAddr(
 	}
 
 	return util.NewUnresolvedAddr(lnAddr.Network(), net.JoinHostPort(host, port)), nil
+}
+
+// cleanupTempDirs should be invoked on startup (before creating any new
+// temporary directories) to clean up abandoned temporary directories from
+// previous startups.
+// It should also be invoked on shutdown when the server is closed.
+// It reads the temporary paths from the record file named
+// tempStorageDirsRecordFilename in recordDir and removes each directory.
+func cleanupTempDirs(recordDir string) error {
+	// Reading the entire file into memory shouldn't be a problem since
+	// it is extremely rare for this record file to contain more than a few
+	// entries.
+	f, err := os.OpenFile(filepath.Join(recordDir, tempStorageDirsRecordFilename), os.O_RDWR, 0644)
+	// There is no existing record file and thus nothing to clean up.
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	// Iterate through each temporary directory path and remove the
+	// directory.
+	for scanner.Scan() {
+		path := scanner.Text()
+		if path == "" {
+			continue
+		}
+		// If path/directory does not exist, error is nil.
+		if err := os.RemoveAll(path); err != nil {
+			return err
+		}
+	}
+
+	// Clear out the record file now that we're done.
+	if err = f.Truncate(0); err != nil {
+		return err
+	}
+	return f.Sync()
+}
+
+// createTempDir creates a temporary directory under the given parentDir and
+// returns the path of the temporary directory.  One should only create
+// temporary directories after calling cleanupTempDirs (see above).
+func createTempDir(parentDir string) (string, error) {
+	// We generate a unique temporary directory with the prefix defaultTempStorageDirPrefix.
+	tempPath, err := ioutil.TempDir(parentDir, defaultTempStorageDirPrefix)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Abs(tempPath)
+}
+
+// recordTempDir records tempPath to a record file named
+// tempStorageDirsRecordFilename in recordDir to facilitate deletion of the
+// temporary directory in case the node crashes.
+func recordTempDir(recordDir, tempPath string) error {
+	// If the file does not exist, create it, or append to the file.
+	f, err := os.OpenFile(filepath.Join(recordDir, tempStorageDirsRecordFilename), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Record tempPath to the record file.
+	if _, err = f.Write(append([]byte(tempPath), '\n')); err != nil {
+		return err
+	}
+	return f.Sync()
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -631,3 +631,155 @@ func TestHeartbeatCallbackForDecommissioning(t *testing.T) {
 		return nil
 	})
 }
+
+// TestCleanupTempDirs verifies that on server startup, abandoned temporary
+// directories in the record file are removed.
+func TestCleanupTempDirs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	storeDir, storeDirCleanup := testutils.TempDir(t)
+	defer storeDirCleanup()
+
+	// Create temporary directories and add them to the record file.
+	tempDir1, tempDir1Cleanup := tempStorageDir(t, storeDir)
+	defer tempDir1Cleanup()
+	tempDir2, tempDir2Cleanup := tempStorageDir(t, storeDir)
+	defer tempDir2Cleanup()
+	if err := recordTempDir(storeDir, tempDir1); err != nil {
+		t.Fatal(err)
+	}
+	if err := recordTempDir(storeDir, tempDir2); err != nil {
+		t.Fatal(err)
+	}
+
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		StoreSpecs: []base.StoreSpec{{Path: storeDir}},
+	})
+	defer s.Stopper().Stop(context.TODO())
+
+	// Verify that the temporary directories are removed after startup.
+	for i, tempDir := range []string{tempDir1, tempDir2} {
+		_, err := os.Stat(tempDir)
+		// os.Stat returns a nil err if the file exists, so we need to check
+		// the NOT of this condition instead of os.IsExist() (which returns
+		// false and misses this error).
+		if !os.IsNotExist(err) {
+			if err == nil {
+				t.Fatalf("temporary directory %d: %s not cleaned up after stopping server", i, tempDir)
+			} else {
+				// Unexpected error.
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+// TestTempStorage verifies that on server startup:
+// 1. A temporary directory is created.
+// 2. If store is on disk, The path of the temporary directory is recorded in
+// the store's path.
+// On server shutdown:
+// 3. The temporary directory is removed.
+func TestTempStorage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	storeDir, storeDirCleanup := testutils.TempDir(t)
+	defer storeDirCleanup()
+	for _, tc := range []struct {
+		name      string
+		storeSpec base.StoreSpec
+	}{
+		{
+			name:      "OnDiskStore",
+			storeSpec: base.StoreSpec{Path: storeDir},
+		},
+		{
+			name:      "InMemStore",
+			storeSpec: base.StoreSpec{InMemory: true},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, tempDirCleanup := testutils.TempDir(t)
+			defer tempDirCleanup()
+
+			// This will be cleaned up by tempDirCleanup.
+			tempStorage := base.TempStorageConfigFromEnv(tc.storeSpec, tempDir, base.DefaultTempStorageMaxSizeBytes)
+
+			s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+				StoreSpecs:        []base.StoreSpec{tc.storeSpec},
+				TempStorageConfig: tempStorage,
+			})
+
+			// 1. Verify temporary directory is created. Since
+			// starting a server generates an arbitrary temporary
+			// directory under tempDir, we need to retrieve that
+			// directory and check it exists.
+			files, err := ioutil.ReadDir(tempStorage.ParentDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(files) != 1 {
+				t.Fatalf("expected only one temporary file to be created during server startup: found %d files", len(files))
+			}
+			tempPath := filepath.Join(tempStorage.ParentDir, files[0].Name())
+
+			// 2. (If on-disk store) Verify that the temporary
+			// directory's path is recorded in the temporary
+			// directory record file under the store's path.
+			if !tc.storeSpec.InMemory {
+				expected := append([]byte(tempPath), '\n')
+				actual, err := ioutil.ReadFile(filepath.Join(storeDir, tempStorageDirsRecordFilename))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(expected, actual) {
+					t.Fatalf("record file not properly appended to.\nexpected: %s\nactual %s", expected, actual)
+				}
+			}
+
+			s.Stopper().Stop(context.TODO())
+
+			// 3. verify that the temporary directory is removed.
+			_, err = os.Stat(tempPath)
+			// os.Stat returns a nil err if the file exists, so we
+			// need to check the NOT of this condition instead of
+			// os.IsExist() (which returns false and misses this
+			// error).
+			if !os.IsNotExist(err) {
+				if err == nil {
+					t.Fatalf("temporary directory %s not cleaned up after stopping server", tempPath)
+				} else {
+					// Unexpected error.
+					t.Fatal(err)
+				}
+			}
+
+			// 4. (If on-disk store) Verify that the removed
+			// temporary directory's path is also removed
+			// from the record file.
+			if !tc.storeSpec.InMemory {
+				contents, err := ioutil.ReadFile(filepath.Join(storeDir, tempStorageDirsRecordFilename))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(contents) > 0 {
+					t.Fatalf("temporary directory path not removed from record file.\ncontents: %s", contents)
+				}
+
+			}
+		})
+	}
+}
+
+func tempStorageDir(t *testing.T, dir string) (string, func()) {
+	tempStoragePath, err := ioutil.TempDir(dir, "temp-engine-storage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanup := func() {
+		if err := os.RemoveAll(tempStoragePath); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return tempStoragePath, cleanup
+}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -67,8 +67,9 @@ func makeTestConfig(st *cluster.Settings) Config {
 	// Test servers start in secure mode by default.
 	cfg.Insecure = false
 
-	// Override the DistSQL local store with an in-memory store.
-	cfg.TempStoreSpec = base.DefaultTestStoreSpec
+	// Configure the default in-memory temp storage for all tests unless
+	// otherwise configured.
+	cfg.TempStorageConfig = base.DefaultTestTempStorageConfig
 
 	// Load test certs. In addition, the tests requiring certs
 	// need to call security.SetAssetLoader(securitytest.EmbeddedAssets)
@@ -182,8 +183,11 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		// the dir (and the test is then responsible for cleaning it up, not
 		// TestServer).
 	}
-	// Copy over the store specs.
 	cfg.Stores = base.StoreSpecList{Specs: params.StoreSpecs}
+	if params.TempStorageConfig != (base.TempStorageConfig{}) {
+		cfg.TempStorageConfig = params.TempStorageConfig
+	}
+
 	if cfg.TestingKnobs.Store == nil {
 		cfg.TestingKnobs.Store = &storage.StoreTestingKnobs{}
 	}

--- a/pkg/sql/distsqlrun/disk_row_container_test.go
+++ b/pkg/sql/distsqlrun/disk_row_container_test.go
@@ -61,7 +61,7 @@ func TestDiskRowContainer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	tempEngine, err := engine.NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +244,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	tempEngine, err := engine.NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -74,6 +74,8 @@ type FlowCtx struct {
 
 	// TempStorage is used by some DistSQL processors to store Rows when the
 	// working set is larger than can be stored in memory.
+	// This is not supposed to be used as a general engine.Engine and thus
+	// one should sparingly use the set of features offered by it.
 	TempStorage engine.Engine
 	// diskMonitor is used to monitor temporary storage disk usage.
 	diskMonitor *mon.BytesMonitor

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -507,7 +507,7 @@ func TestHashJoiner(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tempEngine, err := engine.NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -180,7 +180,7 @@ func TestSorter(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tempEngine, err := engine.NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -33,7 +33,7 @@ import (
 func TestRocksDBMap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	tempEngine, err := NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	tempEngine, err := NewTempEngine(base.DefaultTestTempStorageConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestRocksDBMap(t *testing.T) {
 func TestRocksDBMapSandbox(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	tempEngine, err := NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	tempEngine, err := NewTempEngine(base.DefaultTestTempStorageConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestRocksDBMapSandbox(t *testing.T) {
 func TestRocksDBStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	tempEngine, err := NewTempEngine(ctx, base.DefaultTestStoreSpec)
+	tempEngine, err := NewTempEngine(base.DefaultTestTempStorageConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -313,7 +313,7 @@ func BenchmarkRocksDBMapWrite(b *testing.B) {
 		}
 	}()
 	ctx := context.Background()
-	tempEngine, err := NewTempEngine(ctx, base.StoreSpec{Path: dir})
+	tempEngine, err := NewTempEngine(base.TempStorageConfig{ParentDir: dir})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -357,8 +357,7 @@ func BenchmarkRocksDBMapIteration(b *testing.B) {
 			b.Fatal(err)
 		}
 	}()
-	ctx := context.Background()
-	tempEngine, err := NewTempEngine(ctx, base.StoreSpec{Path: dir})
+	tempEngine, err := NewTempEngine(base.TempStorageConfig{ParentDir: dir})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/storage/engine/temp_engine.go
+++ b/pkg/storage/engine/temp_engine.go
@@ -15,36 +15,18 @@
 package engine
 
 import (
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"sync"
-
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // NewTempEngine creates a new engine for DistSQL processors to use when the
-// working set is larger than can be stored in memory. It returns nil if it
-// could not set up a temporary Engine. When closed, it destroys the
-// underlying data.
-func NewTempEngine(ctx context.Context, storeCfg base.StoreSpec) (Engine, error) {
-	if storeCfg.SizeInBytes != 0 {
-		return nil, errors.Errorf("spec.SizeInBytes specified for temp store. " +
-			"That's not allowed as the setting doesn't do anything.")
-	}
-
-	if storeCfg.InMemory {
+// working set is larger than can be stored in memory.
+func NewTempEngine(tempStorage base.TempStorageConfig) (Engine, error) {
+	if tempStorage.InMemory {
 		// TODO(arjun): Limit the size of the store once #16750 is addressed.
-		return NewInMem(storeCfg.Attributes, 0 /* cacheSize */), nil
-	}
-
-	if err := cleanupTempStorageDirs(ctx, storeCfg.Path, nil /* *WaitGroup */); err != nil {
-		return nil, err
+		// Technically we do not pass any attributes to temporary store.
+		return NewInMem(roachpb.Attributes{} /* attrs */, 0 /* cacheSize */), nil
 	}
 
 	// FIXME(tschottdorf): should be passed in.
@@ -53,73 +35,17 @@ func NewTempEngine(ctx context.Context, storeCfg base.StoreSpec) (Engine, error)
 	rocksDBCfg := RocksDBConfig{
 		Settings: st,
 		Attrs:    roachpb.Attributes{},
-		Dir:      storeCfg.Path,
-		// MaxSizeBytes doesn't matter for temp stores - it's not enforced in any way.
+		Dir:      tempStorage.Path,
+		// MaxSizeBytes doesn't matter for temp storage - it's not
+		// enforced in any way.
 		MaxSizeBytes: 0,
 		MaxOpenFiles: 128, // TODO(arjun): Revisit this.
 	}
 	rocksDBCache := NewRocksDBCache(0)
 	rocksdb, err := NewRocksDB(rocksDBCfg, rocksDBCache)
-	return &tempEngine{RocksDB: rocksdb}, err
-}
-
-type tempEngine struct {
-	*RocksDB
-}
-
-func (e *tempEngine) Close() {
-	e.RocksDB.Close()
-	dir := e.RocksDB.cfg.Dir
-	if dir == "" {
-		return
-	}
-	if err := os.RemoveAll(dir); err != nil {
-		log.Errorf(context.TODO(), "could not remove rocksdb dir: %v", err)
-	}
-}
-
-// wg is allowed to be nil, if the caller does not want to wait on the cleanup.
-func cleanupTempStorageDirs(ctx context.Context, path string, wg *sync.WaitGroup) error {
-	// Removing existing contents might be slow. Instead we rename it to a new
-	// name, and spawn a goroutine to clean it up asynchronously.
-	if err := os.MkdirAll(path, 0755); err != nil {
-		return err
-	}
-	deletionDir, err := ioutil.TempDir(path, "TO-DELETE-")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	filesToDelete, err := ioutil.ReadDir(path)
-	if err != nil {
-		return err
-	}
-
-	for _, fileToDelete := range filesToDelete {
-		toDeleteFull := filepath.Join(path, fileToDelete.Name())
-		if toDeleteFull != deletionDir {
-			if err := os.Rename(toDeleteFull, filepath.Join(deletionDir, fileToDelete.Name())); err != nil {
-				// Fall back to just removing the file if rename fails (e.g. due to #18994).
-				if rmErr := os.Remove(toDeleteFull); rmErr != nil {
-					return errors.Errorf("failed to remove file %q (%s) after failing to rename it (%s)",
-						toDeleteFull, rmErr, err)
-				}
-			}
-		}
-	}
-	if wg != nil {
-		wg.Add(1)
-	}
-	go func() {
-		if wg != nil {
-			defer wg.Done()
-		}
-		if err := os.RemoveAll(deletionDir); err != nil {
-			log.Warningf(ctx, "could not clear old TempEngine files: %v", err.Error())
-			// Even if this errors, this is safe since it's in the marked-for-deletion subdirectory.
-			return
-		}
-	}()
-
-	return nil
+	return rocksdb, nil
 }


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/17859

## Background 

Previously, the temporary store directory of a given node was defaulted as a subdirectory `local` under store 1's path. For example, if store 1's path is `/foo` (with potential other stores), then the temporary store for the node would be located at `/foo/local`.

We would like to allow the user to specify the temporary store's directory via a CLI flag `--temp-dir`. Note we should in the future also utilize this temporary directory for other temporary disk usage (as noted by @bdarnell), but for now this is primarily used as working memory for distributed operations.

## Changes

This PR introduces the `--temp-dir` flag which may specify the path where a temporary subdirectory will be created for temporary files. That is, `ioutil.TempDir()` is invoked with the `--temp-dir` path. The rationale behind this additional temporary subdirectory is to avoid file-naming conflicts with existing directory levels.

For example, if `--temp=dir=/foo/bar`, then some temporary subdirectory `/foo/bar/cockroach-temp<RANDOM-NUMBER>` will be created. At node termination, this subdirectory will be cleaned up. Note the directory tree path specified by `--temp-dir` must exist.

A significant change to permit this arbitrary temporary store is to how we cleanup these temporary stores. During normal node shutdown, the current temporary store may be cleaned up quite easily. However, during node crashes, SIGKILLs, or early node termination, these temporary stores may not be cleaned up properly.

We thus log the paths of all newly created temporary stores to a log file located on the node's first store. We synchronously delete each directory listed on this log file at node startup. If deleting these temporary directories fail, an error is propagated which may prevent node startup.

If the first store is in memory but a --temp-dir is specified, the temp storage will be on-disk. It will be cleaned up given that node shutdown goes smoothly, but if the node crashes then no guarantees are made for cleaning up the temp storage on startup (since no record file was created).

Note the directory tree path specified by `--temp-dir` must exist.

## Caveats

If the user swaps the order of stores for a given node (e.g. swapping store 1 with store 2), this shouldn't have any logical impact but the current implementation will not be able to check for the log file. One easy solution is to pass in all the stores' paths and check for the log file on every store.

## TODOS

- [x] test cluster behaves correctly with loadgen/kv and TPC-H
- [ ] update docs with new flag