### PR TITLE
build,sql,cli: reveal the CockroachDB version number

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -76,9 +76,15 @@ func init() {
 	}
 }
 
+// VersionedTag prefixes the tag with VersionPrefix.
+func (b Info) VersionedTag() string {
+	return VersionPrefix() + "-" + b.Tag
+}
+
 // Short returns a pretty printed build and version summary.
 func (b Info) Short() string {
-	return fmt.Sprintf("CockroachDB %s %s (%s, built %s, %s)", b.Distribution, b.Tag, b.Platform, b.Time, b.GoVersion)
+	return fmt.Sprintf("CockroachDB %s %s (%s, built %s, %s)",
+		b.Distribution, b.VersionedTag(), b.Platform, b.Time, b.GoVersion)
 }
 
 // Timestamp parses the utcTime string and returns the number of seconds since epoch.

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -149,7 +149,7 @@ func (c *sqlConn) checkServerMetadata() error {
 		// (`build.Info.Short()`). This is because we don't care if they're
 		// different platforms/build tools/timestamps. The important bit exposed by
 		// a version mismatch is the wire protocol and SQL dialect.
-		if client := build.GetInfo(); c.serverVersion != client.Tag {
+		if client := build.GetInfo(); c.serverVersion != client.VersionedTag() {
 			fmt.Println("# Client version:", client.Short())
 		} else {
 			isSame = " (same version as client)"

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -84,7 +84,7 @@ CREATE TABLE crdb_internal.node_build_info (
 			"ClusterID":    execCfg.ClusterID().String(),
 			"Organization": execCfg.Organization(),
 			"Build":        info.Short(),
-			"Version":      info.Tag,
+			"Version":      info.VersionedTag(),
 		} {
 			if err := addRow(
 				nodeID,


### PR DESCRIPTION
Previous to this patch, the vtable `crdb_internal.node_build_info`,
the built-in SQL function `version()` and the command-line utilities
would only print the build tag as a version number.

This patch augments this display by prefixing it by the
`VersionPrefix()`, computed after the current branch.

Before:

```
CockroachDB CCL 9fcb2f35e (freebsd amd64, built 2017/09/18 18:27:19, go1.9)
```

After:

```
CockroachDB CCL v1.1-9fcb2f35e (freebsd amd64, built 2017/09/18 18:27:19, go1.9)
```

cc @jordanlewis @justinj 