### PR TITLE
sql: fix SHOW [KV] TRACE on IPv6 systems

### DIFF
--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -284,8 +284,8 @@ SELECT timestamp,
        operation,
        span
   FROM (SELECT timestamp,
-               regexp_replace(message, e'^.*\\[[^]]*\\] ', '') AS message,
-               regexp_extract(message, e'^.*\\[[^]]*\\]') AS context,
+               regexp_replace(message, e'^\\[(?:[^][]|\\[[^]]*\\])*\\] ', '') AS message,
+               regexp_extract(message, e'^\\[(?:[^][]|\\[[^]]*\\])*\\]') AS context,
                first_value(operation) OVER (PARTITION BY txn_idx, span_idx ORDER BY message_idx) as operation,
                (txn_idx, span_idx) AS span
           FROM crdb_internal.session_trace)


### PR DESCRIPTION
The way SHOW [KV] TRACE works is that it runs the query with tracing
enabled then collects the tracing messages and *splits* them across
the two columns "message" and "context".

The context column is meant to contain the logging tag, the part
between square brackets at the beginning of a log/trace message.
Unfortunately the entire logging/tracing infrastructure only collect a
single string that combines the tag (context) and the message (as
opposed to a structured format that would collect them separately), so
SHOW TRACE has to split them after the fact. Moreover, the tag can
contain spaces, so that is not a good delimiter, can be of variable
length, and can contain most other punctuation in variable amount, so
punctuation cannot be used as a delimiter either. Therefore, when
implementing SHOW TRACE in the last iteration I made it use a regular
expression to extract "everything enclosed in square brackets" at the
beginning of a message as a context.
That is, using the regular expression `'^\[[^]*\] '`.

However, this regular expression is incorrect *if the tag itself
contains data enclosed in square brackets*. This happens to be a
rather common case on macOS, and indeed any system where IPv6 is
enabled, because a CockroachDB node when started with `--insecure` by
default will bind to the local IPv6 interface, ::1, which happens to
render textually in Go as "`[::1]`".

This in turn caused:

1. the context to be incorrectly extracted/stripped from the trace
   message, causing a messed up context column in the output of SHOW
   TRACE.
2. SHOW KV TRACE to fail to match entirely, i.e. empty KV traces.

This patch improves the behavior by supporting *a single level of extra
bracketing in the log tag*.

This patch is not a panacea, given that any additional (ab)use of
brackets in the future may break this feature again, and we don't have
a clear way to protect the codebase against that yet. However, the
stronger solution in the shape of introducing a little bit more
structure to the whole tracing/logging infrastructure is not exactly
trivial either. This is a 80% solution.