### PR TITLE
cherrypick: build,sql,cli: reveal the CockroachDB version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,8 +361,7 @@ $(ARCHIVE).tmp: .buildinfo/tag .buildinfo/rev .buildinfo/basebranch
 # For details, see the "Possible timestamp problems with diff-files?" thread on
 # the Git mailing list (http://marc.info/?l=git&m=131687596307197).
 .buildinfo/tag: | .buildinfo
-	@{ git describe --tags --exact-match 2> /dev/null || git rev-parse --short HEAD; } | tr -d \\n > $@
-	@git diff --quiet HEAD || echo -dirty >> $@
+	@{ git describe --tags --dirty 2> /dev/null || git rev-parse --short HEAD; } | tr -d \\n > $@
 
 .buildinfo/basebranch: | .buildinfo
 	@git describe --tags --abbrev=0 | tr -d \\n > $@

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -42,8 +42,8 @@ const TimeFormat = "2006/01/02 15:04:05"
 var (
 	// These variables are initialized via the linker -X flag in the
 	// top-level Makefile when compiling release binaries.
-	tag         = "unknown" // Tag of this build (git describe --exact-match)
-	baseBranch  = "unknown" // Base branch of this build (git describe)
+	tag         = "unknown" // Tag of this build (git describe --tags w/ optional '-dirty' suffix)
+	baseBranch  = "unknown" // Base branch of this build (git describe --tags --abbrev=0)
 	utcTime     string      // Build time in UTC (year/month/day hour:min:sec)
 	rev         string      // SHA-1 of this build (git rev-parse)
 	cgoCompiler = C.GoString(C.compilerVersion())


### PR DESCRIPTION
Previous to this patch, the vtable `crdb_internal.node_build_info`,
the built-in SQL function `version()` and the command-line utilities
would only print the build tag as a version number.

This patch augments this display by prefixing it by the
`VersionPrefix()`, computed after the current branch.

- for the branch `release-1.0`, where the last commit in the branch is
  exactly a tag, the tag string is exactly `v1.0.6`.
- for the branch `release-1.1`, where there were some commits since the
  last tag, the tag string is something like
  `v1.1-beta.20170907-95-gdcc6ca4c3`.
- for the master branch, once we have at least one 1.2 alpha release,
  the tag string will be something like
  `v1.2-alpha.2017MMDD-NN-SHAAAAAAA`.

cc @cockroachdb/release 