### PR TITLE
sql: fix problem with autoCommit leaving txn in wrong state

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -950,7 +950,12 @@ func (e *Executor) execParsed(
 // returned as remainingStmts.
 // txnPrefix: Set if stmtsToExec corresponds to the start of the current
 // transaction. Used to trap nested BEGINs.
-// autoCommit: Set if the transction should be committed at the end of the
+// autoCommit: If set, the transaction will be committed after running the
+//   statement. If set, stmtsToExec can only contain a single statement.
+//   If set, the transaction state will always be NoTxn when this function
+//   returns, regardless of errors.
+//   Errors encountered when committing are reported to the caller and are
+//   indistinguishable from errors encountered while running the query.
 // protoTS: If not nil, the transaction proto sets its Orig and Max timestamps
 // to it each retry.
 //
@@ -1103,7 +1108,12 @@ func runWithAutoRetry(
 			if !txnState.retryIntent {
 				e.TxnAbortCount.Inc(1)
 				txnState.mu.txn.CleanupOnError(session.Ctx(), err)
-				txnState.resetStateAndTxn(Aborted)
+				if autoCommit {
+					// autoCommit always leaves the transaction in NoTxn.
+					txnState.resetStateAndTxn(NoTxn)
+				} else {
+					txnState.resetStateAndTxn(Aborted)
+				}
 			}
 		}
 
@@ -1584,7 +1594,7 @@ func (e *Executor) execStmtInOpenTxn(
 			// Force an auto-retry by returning a retryable error to the higher
 			// levels.
 			err = roachpb.NewHandledRetryableTxnError(
-				"serializable transaction timestamp pushed (detected by sql Executor)",
+				"serializable transaction timestamp pushed (detected by SQL Executor)",
 				txnState.mu.txn.ID(),
 				// No updated transaction required; we've already manually updated our
 				// client.Txn.


### PR DESCRIPTION
When executing an implicit transaction, a certain layer in the Executor
code (runTxnAttempt()) is supposed to always leave the session in the
NoTxn state. In other words, it's supposed to always clean up the
transaction.
Before this patch, it was failing to do so in a particular case: if it
looked like we were going to auto-retry but at the last moment we
decided that we can't do that because we've already streamed results to
the client, we were leaving the session (and the transaction) in the
NoTxn state.
This patch fixes this by adding the missing cleanup.

I will cherry-pick this into 1.1