### PR TITLE
build,sql,cli: reveal the CockroachDB version number (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,8 +361,7 @@ $(ARCHIVE).tmp: .buildinfo/tag .buildinfo/rev .buildinfo/basebranch
 # For details, see the "Possible timestamp problems with diff-files?" thread on
 # the Git mailing list (http://marc.info/?l=git&m=131687596307197).
 .buildinfo/tag: | .buildinfo
-	@{ git describe --tags --exact-match 2> /dev/null || git rev-parse --short HEAD; } | tr -d \\n > $@
-	@git diff --quiet HEAD || echo -dirty >> $@
+	@{ git describe --tags --dirty 2> /dev/null || git rev-parse --short HEAD; } | tr -d \\n > $@
 
 .buildinfo/basebranch: | .buildinfo
 	@git describe --tags --abbrev=0 | tr -d \\n > $@

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -42,8 +42,8 @@ const TimeFormat = "2006/01/02 15:04:05"
 var (
 	// These variables are initialized via the linker -X flag in the
 	// top-level Makefile when compiling release binaries.
-	tag         = "unknown" // Tag of this build (git describe --exact-match)
-	baseBranch  = "unknown" // Base branch of this build (git describe)
+	tag         = "unknown" // Tag of this build (git describe --tags w/ optional '-dirty' suffix)
+	baseBranch  = "unknown" // Base branch of this build (git describe --tags --abbrev=0)
 	utcTime     string      // Build time in UTC (year/month/day hour:min:sec)
 	rev         string      // SHA-1 of this build (git rev-parse)
 	cgoCompiler = C.GoString(C.compilerVersion())
@@ -76,15 +76,10 @@ func init() {
 	}
 }
 
-// VersionedTag prefixes the tag with VersionPrefix.
-func (b Info) VersionedTag() string {
-	return VersionPrefix() + "-" + b.Tag
-}
-
 // Short returns a pretty printed build and version summary.
 func (b Info) Short() string {
 	return fmt.Sprintf("CockroachDB %s %s (%s, built %s, %s)",
-		b.Distribution, b.VersionedTag(), b.Platform, b.Time, b.GoVersion)
+		b.Distribution, b.Tag, b.Platform, b.Time, b.GoVersion)
 }
 
 // Timestamp parses the utcTime string and returns the number of seconds since epoch.

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -149,7 +149,7 @@ func (c *sqlConn) checkServerMetadata() error {
 		// (`build.Info.Short()`). This is because we don't care if they're
 		// different platforms/build tools/timestamps. The important bit exposed by
 		// a version mismatch is the wire protocol and SQL dialect.
-		if client := build.GetInfo(); c.serverVersion != client.VersionedTag() {
+		if client := build.GetInfo(); c.serverVersion != client.Tag {
 			fmt.Println("# Client version:", client.Short())
 		} else {
 			isSame = " (same version as client)"

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -84,7 +84,7 @@ CREATE TABLE crdb_internal.node_build_info (
 			"ClusterID":    execCfg.ClusterID().String(),
 			"Organization": execCfg.Organization(),
 			"Build":        info.Short(),
-			"Version":      info.VersionedTag(),
+			"Version":      info.Tag,
 		} {
 			if err := addRow(
 				nodeID,


### PR DESCRIPTION
Reverts/Supersedes #18556.

The previous patch was blindly concatenating the result of
`VersionPrefix()` with the build tag, to yield something like
`v1.1-abcdef`. However, as highlighted by @bdarnell, in the specific
case where the current tree is exactly a tagged version, then the
build tag becomes the (versioned) git tag, and the resulting visible
version number becomes `v1.1-v1.1`, which ... makes no sense.

This patch resolves this by removing the custom logic introduced by
the previous patch entirely, and using the output of `git describe`
instead of `git describe --exact-match` as buildinfo tag.

This gives us:

- for the branch `release-1.0`, where the last commit in the branch is
  exactly a tag, the tag string is exactly `v1.0.6`.
- for the branch `release-1.1`, where there were some commits since the
  last tag, the tag string is something like
  `v1.1-beta.20170907-95-gdcc6ca4c3`.
- for the master branch, once we have at least one 1.2 alpha release,
  the tag string will be something like
  `v1.2-alpha.2017MMDD-NN-SHAAAAAAA`.