### PR TITLE
cherrypick: sql: fix SHOW [KV] TRACE on IPv6 systems

### DIFF
--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -284,8 +284,8 @@ SELECT timestamp,
        operation,
        span
   FROM (SELECT timestamp,
-               regexp_replace(message, e'^.*\\[[^]]*\\] ', '') AS message,
-               regexp_extract(message, e'^.*\\[[^]]*\\]') AS context,
+               regexp_replace(message, e'^\\[(?:[^][]|\\[[^]]*\\])*\\] ', '') AS message,
+               regexp_extract(message, e'^\\[(?:[^][]|\\[[^]]*\\])*\\]') AS context,
                first_value(operation) OVER (PARTITION BY txn_idx, span_idx ORDER BY message_idx) as operation,
                (txn_idx, span_idx) AS span
           FROM crdb_internal.session_trace)

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -18,11 +18,13 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"sort"
+	"strings"
 	"testing"
 
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -258,5 +260,71 @@ func TestTrace(t *testing.T) {
 				})
 			}
 		})
+	}
+}
+
+func TestBracketInTracetags(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	query := "SELECT 42"
+
+	params := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLExecutor: &sql.ExecutorTestingKnobs{
+				BeforeExecute: func(ctx context.Context, stmt string, isParallel bool) {
+					if strings.Contains(stmt, query) {
+						taggedCtx := log.WithLogTag(ctx, "hello", "[::666]")
+						log.Event(taggedCtx, "world")
+					}
+				},
+			},
+		},
+	}
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	sqlDB.SetMaxOpenConns(1)
+
+	if _, err := sqlDB.Exec("SET tracing = ON"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqlDB.Exec(query); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := sqlDB.Exec("SET tracing = OFF"); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := sqlDB.Query(`SELECT message, context FROM [SHOW TRACE FOR SESSION];`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	ok := false
+	for rows.Next() {
+		var msg, ct []byte
+		if err := rows.Scan(&msg, &ct); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("received trace: %q // %q", msg, ct)
+		if len(ct) > 0 && ct[0] == '[' {
+			if ct[len(ct)-1] != ']' {
+				t.Errorf("context starts with open bracket but does not close it: %q", ct)
+			}
+		}
+		c1 := strings.Count(string(ct), "[")
+		c2 := strings.Count(string(ct), "]")
+		if c1 != c2 {
+			t.Errorf("mismatched brackets: %q", ct)
+		}
+		if string(msg) == "world" && strings.Contains(string(ct), "hello=[::666]") {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Fatal("expected message not found in trace")
 	}
 }


### PR DESCRIPTION
The way SHOW [KV] TRACE works is that it runs the query with tracing
enabled then collects the tracing messages and *splits* them across
the two columns "message" and "context".

The context column is meant to contain the logging tag, the part
between square brackets at the beginning of a log/trace message.
Unfortunately the entire logging/tracing infrastructure only collect a
single string that combines the tag (context) and the message (as
opposed to a structured format that would collect them separately), so
SHOW TRACE has to split them after the fact. Moreover, the tag can
contain spaces, so that is not a good delimiter, can be of variable
length, and can contain most other punctuation in variable amount, so
punctuation cannot be used as a delimiter either. Therefore, when
implementing SHOW TRACE in the last iteration I made it use a regular
expression to extract "everything enclosed in square brackets" at the
beginning of a message as a context.
That is, using the regular expression `'^\[[^]*\] '`.

However, this regular expression is incorrect *if the tag itself
contains data enclosed in square brackets*. This happens to be a
rather common case on macOS, and indeed any system where IPv6 is
enabled, because a CockroachDB node when started with `--insecure` by
default will bind to the local IPv6 interface, ::1, which happens to
render textually in Go as "`[::1]`".

This in turn caused:

1. the context to be incorrectly extracted/stripped from the trace
   message, causing a messed up context column in the output of SHOW
   TRACE.
2. SHOW KV TRACE to fail to match entirely, i.e. empty KV traces.

This patch improves the behavior by supporting *a single level of extra
bracketing in the log tag*.

This patch is not a panacea, given that any additional (ab)use of
brackets in the future may break this feature again, and we don't have
a clear way to protect the codebase against that yet. However, the
stronger solution in the shape of introducing a little bit more
structure to the whole tracing/logging infrastructure is not exactly
trivial either. This is a 80% solution.

cc @cockroachdb/release 