### PR TITLE
cherrypick: sql: fix problem with autoCommit leaving txn in wrong state

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -950,7 +950,12 @@ func (e *Executor) execParsed(
 // returned as remainingStmts.
 // txnPrefix: Set if stmtsToExec corresponds to the start of the current
 // transaction. Used to trap nested BEGINs.
-// autoCommit: Set if the transction should be committed at the end of the
+// autoCommit: If set, the transaction will be committed after running the
+//   statement. If set, stmtsToExec can only contain a single statement.
+//   If set, the transaction state will always be NoTxn when this function
+//   returns, regardless of errors.
+//   Errors encountered when committing are reported to the caller and are
+//   indistinguishable from errors encountered while running the query.
 // protoTS: If not nil, the transaction proto sets its Orig and Max timestamps
 // to it each retry.
 //
@@ -1103,7 +1108,12 @@ func runWithAutoRetry(
 			if !txnState.retryIntent {
 				e.TxnAbortCount.Inc(1)
 				txnState.mu.txn.CleanupOnError(session.Ctx(), err)
-				txnState.resetStateAndTxn(Aborted)
+				if autoCommit {
+					// autoCommit always leaves the transaction in NoTxn.
+					txnState.resetStateAndTxn(NoTxn)
+				} else {
+					txnState.resetStateAndTxn(Aborted)
+				}
 			}
 		}
 
@@ -1584,7 +1594,7 @@ func (e *Executor) execStmtInOpenTxn(
 			// Force an auto-retry by returning a retryable error to the higher
 			// levels.
 			err = roachpb.NewHandledRetryableTxnError(
-				"serializable transaction timestamp pushed (detected by sql Executor)",
+				"serializable transaction timestamp pushed (detected by SQL Executor)",
 				txnState.mu.txn.ID(),
 				// No updated transaction required; we've already manually updated our
 				// client.Txn.

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1740,16 +1740,19 @@ func TestTxnAutoRetriesDisabledAfterResultsHaveBeenSentToClient(t *testing.T) {
 	defer s.Stopper().Stop(context.TODO())
 
 	tests := []struct {
-		name                  string
-		clientDirectedRetries bool
+		name                              string
+		clientDirectedRetry               bool
+		expectedTxnStateAfterRetriableErr sql.TxnStateEnum
 	}{
 		{
-			name: "client_directed_retries",
-			clientDirectedRetries: true,
+			name:                              "client_directed_retries",
+			clientDirectedRetry:               true,
+			expectedTxnStateAfterRetriableErr: sql.RestartWait,
 		},
 		{
-			name: "no_client_directed_retries",
-			clientDirectedRetries: false,
+			name:                              "no_client_directed_retries",
+			clientDirectedRetry:               false,
+			expectedTxnStateAfterRetriableErr: sql.Aborted,
 		},
 	}
 	for _, tc := range tests {
@@ -1768,7 +1771,7 @@ func TestTxnAutoRetriesDisabledAfterResultsHaveBeenSentToClient(t *testing.T) {
 			}()
 
 			var savepoint string
-			if tc.clientDirectedRetries {
+			if tc.clientDirectedRetry {
 				savepoint = "SAVEPOINT cockroach_restart;"
 			}
 			// We'll run a statement that produces enough results to overflow the
@@ -1784,18 +1787,12 @@ func TestTxnAutoRetriesDisabledAfterResultsHaveBeenSentToClient(t *testing.T) {
 			if !isRetryableErr(err) {
 				t.Fatalf("expected retriable error, got: %v", err)
 			}
-			var expectedState string
-			if tc.clientDirectedRetries {
-				expectedState = "RestartWait"
-			} else {
-				expectedState = "Aborted"
-			}
 			var state string
 			if err := sqlDB.QueryRow("SHOW TRANSACTION STATUS").Scan(&state); err != nil {
 				t.Fatal(err)
 			}
-			if state != expectedState {
-				t.Fatalf("expected state %s, got: %s", expectedState, state)
+			if expStateStr := tc.expectedTxnStateAfterRetriableErr.String(); state != expStateStr {
+				t.Fatalf("expected state %s, got: %s", expStateStr, state)
 			}
 		})
 	}


### PR DESCRIPTION
Cherrypick of #18564 :

When executing an implicit transaction, a certain layer in the Executor
code (runTxnAttempt()) is supposed to always leave the session in the
NoTxn state. In other words, it's supposed to always clean up the
transaction.
Before this patch, it was failing to do so in a particular case: if it
looked like we were going to auto-retry but at the last moment we
decided that we can't do that because we've already streamed results to
the client, we were leaving the session (and the transaction) in the
NoTxn state.
This patch fixes this by adding the missing cleanup.

This PR also picks up and cherry-picks the test-only #18517 (to help the real cherry-pick).

cc @cockroachdb/release 