### PR TITLE
sql: restore the logical order of UNION

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -181,10 +181,10 @@ EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 0  union   ·              ·                (column1 int)  ·
 1  values  ·              ·                (column1 int)  ·
 1  ·       size           1 column, 1 row  ·              ·
-1  ·       row 0, expr 0  (1)[int]         ·              ·
+1  ·       row 0, expr 0  (2)[int]         ·              ·
 1  values  ·              ·                (column1 int)  ·
 1  ·       size           1 column, 1 row  ·              ·
-1  ·       row 0, expr 0  (2)[int]         ·              ·
+1  ·       row 0, expr 0  (1)[int]         ·              ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -587,11 +587,11 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR VALUES (1, 2), (1, 1), (1, 2), (2, 1), (2, 1) UNION VALUES (1, 3), (3, 4), (1, 1)]
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
 ----
+output row: [1 2]
+output row: [1 1]
+output row: [2 1]
 output row: [1 3]
 output row: [3 4]
-output row: [1 1]
-output row: [1 2]
-output row: [2 1]
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM abc EXCEPT SELECT * FROM abc WHERE b > 'p']
@@ -610,12 +610,12 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM ab WHERE a > 1 INTERSECT SELECT * FROM ab WHERE b > 1]
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
 ----
-fetched: /ab/primary/1/4 -> NULL
-fetched: /ab/primary/1/5 -> NULL
 fetched: /ab/primary/2/1 -> NULL
 fetched: /ab/primary/2/2 -> NULL
 fetched: /ab/primary/2/6 -> NULL
 fetched: /ab/primary/3/9 -> NULL
+fetched: /ab/primary/1/4 -> NULL
+fetched: /ab/primary/1/5 -> NULL
 fetched: /ab/primary/2/1 -> NULL
 fetched: /ab/primary/2/2 -> NULL
 output row: [2 2]

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -205,8 +205,8 @@ query ITTT
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
 0  union   ·     ·
+1  values  ·     ·
+1  ·       size  1 column, 1 row
 1  render  ·     ·
 2  values  ·     ·
 2  ·       size  3 columns, 5 rows
-1  values  ·     ·
-1  ·       size  1 column, 1 row

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -111,8 +111,10 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 	case *limitNode:
 		return getPlanColumns(n.plan, mut)
 	case *unionNode:
+		if n.inverted {
+			return getPlanColumns(n.right, mut)
+		}
 		return getPlanColumns(n.left, mut)
-
 	}
 
 	// Every other node has no columns in their results.

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1796,13 +1796,11 @@ func TestTxnAutoRetriesDisabledAfterResultsHaveBeenSentToClient(t *testing.T) {
 			// error is injected. We do this through a single statement (a UNION)
 			// instead of two separate statements in order to support the autoCommit
 			// test which needs a single statement.
-			// In the UNION we put the error first and the data second because,
-			// surprisingly, the order of the UNION results is <right operand>, <left
-			// operand>. TODO(knz): invert this once we invert the UNION results.
 			sql := fmt.Sprintf(`
 				%s
-				SELECT crdb_internal.force_retry('1s')
-				  UNION ALL SELECT generate_series(1, 10000);
+				SELECT generate_series(1, 10000)
+				UNION ALL
+				SELECT crdb_internal.force_retry('1s');
 				%s`,
 				prefix, suffix)
 			_, err := sqlDB.Exec(sql)

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -24,6 +24,61 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
+// unionNode is a planNode whose rows are the result of one of three set
+// operations (UNION, INTERSECT, or EXCEPT) on left and right. There are two
+// variations of each set operation: distinct, which always returns unique
+// results, and all, which does no uniqueing.
+//
+// Ordering of rows is expected to be handled externally to unionNode.
+// TODO(dan): In the long run, this is insufficient. If we know both left and
+// right are ordered the same way, we can do the set logic without the map
+// state. Additionally, if the unionNode has an ordering then we can hint it
+// down to left and right and force the condition for this first optimization.
+//
+// All six of the operations can be completed without cacheing rows by
+// iterating one side then the other and keeping counts of unique rows
+// in a map. The logic is common for all six. However, because EXCEPT
+// needs to iterate the right side first, the common code always reads
+// the right operand first. Meanwhile, we invert the operands for the
+// non-EXCEPT cases in order to preserve the appearance of the
+// original specified order.
+//
+// The emit logic for each op is represented by implementors of the
+// unionNodeEmit interface. The emitRight method is called for each row output
+// by the right side and passed a hashable representation of the row. If it
+// returns true, the row is emitted. After all right rows are examined, then
+// each left row is passed to emitLeft in the same way.
+//
+// An example: intersectNodeEmitAll
+// VALUES (1), (1), (1), (2), (2) INTERSECT ALL VALUES (1), (3), (1)
+// ----
+// 1
+// 1
+// There are three 1s on the left and two 1s on the right, so we emit 1, 1.
+// Nothing else is in both.
+//  emitRight: For each row, increment the map entry.
+//  emitLeft: For each row, if the row is not present in the map, it was not in
+//    both, don't emit. Otherwise, if the count for the row was > 0, emit and
+//    decrement the entry. Otherwise, the row was on the right, but we've
+//    already emitted as many as were on the right, don't emit.
+type unionNode struct {
+	// right and left are the data source operands.
+	// right is read first, to populate the `emit` field.
+	right, left planNode
+	// inverted, when true, indicates that the right plan corresponds to
+	// the left operand in the input SQL syntax, and vice-versa.
+	inverted bool
+	// emitAll is a performance optimization for UNION ALL. When set
+	// the union logic avoids the `emit` logic entirely.
+	emitAll bool
+	// emit contains the rows seen on the right so far and performs the
+	// selection/filtering logic.
+	emit unionNodeEmit
+	// scratch is a preallocated buffer for formatting the key of the
+	// current row on the right.
+	scratch []byte
+}
+
 // UnionClause constructs a planNode from a UNION/INTERSECT/EXCEPT expression.
 func (p *planner) UnionClause(
 	ctx context.Context, n *parser.UnionClause, desiredTypes []parser.Type,
@@ -82,55 +137,26 @@ func (p *planner) UnionClause(
 		}
 	}
 
+	inverted := false
+	if n.Type != parser.ExceptOp {
+		// The logic below reads the rows from the right operand first,
+		// because for EXCEPT in particular this is what we need to match.
+		// However for the other operators (UNION, INTERSECT) it is
+		// actually confusing to see the right values come up first in the
+		// results. So invert this here, to reduce surprise by users.
+		left, right = right, left
+		inverted = true
+	}
+
 	node := &unionNode{
-		right:   right,
-		left:    left,
-		emitAll: emitAll,
-		emit:    emit,
-		scratch: make([]byte, 0),
+		right:    right,
+		left:     left,
+		inverted: inverted,
+		emitAll:  emitAll,
+		emit:     emit,
+		scratch:  make([]byte, 0),
 	}
 	return node, nil
-}
-
-// unionNode is a planNode whose rows are the result of one of three set
-// operations (UNION, INTERSECT, or EXCEPT) on left and right. There are two
-// variations of each set operation: distinct, which always returns unique
-// results, and all, which does no uniqueing.
-//
-// Ordering of rows is expected to be handled externally to unionNode.
-// TODO(dan): In the long run, this is insufficient. If we know both left and
-// right are ordered the same way, we can do the set logic without the map
-// state. Additionally, if the unionNode has an ordering then we can hint it
-// down to left and right and force the condition for this first optimization.
-//
-// All six of the operations can be completed without cacheing rows by iterating
-// one side then the other and keeping counts of unique rows in a map. Because
-// EXCEPT needs to iterate the right side first, and the other two don't care,
-// we always read right before left.
-//
-// The emit logic for each op is represented by implementors of the
-// unionNodeEmit interface. The emitRight method is called for each row output
-// by the right side and passed a hashable representation of the row. If it
-// returns true, the row is emitted. After all right rows are examined, then
-// each left row is passed to emitLeft in the same way.
-//
-// An example: intersectNodeEmitAll
-// VALUES (1), (1), (1), (2), (2) INTERSECT ALL VALUES (1), (3), (1)
-// ----
-// 1
-// 1
-// There are three 1s on the left and two 1s on the right, so we emit 1, 1.
-// Nothing else is in both.
-//  emitRight: For each row, increment the map entry.
-//  emitLeft: For each row, if the row is not present in the map, it was not in
-//    both, don't emit. Otherwise, if the count for the row was > 0, emit and
-//    decrement the entry. Otherwise, the row was on the right, but we've
-//    already emitted as many as were on the right, don't emit.
-type unionNode struct {
-	right, left planNode
-	emitAll     bool // emitAll is a performance optimization for UNION ALL.
-	emit        unionNodeEmit
-	scratch     []byte
 }
 
 func (n *unionNode) Values() parser.Datums {


### PR DESCRIPTION
In order to compute EXCEPT properly, the code for
UNION/INTERSECT/EXCEPT needs to read its right operand first to
populate the map of known values. However in the non-EXCEPT case the
resulting output is non-intuitive, as a savvy user with a reasonable
order expectation would see the right operand being consumed first,
even when not necessary.

This patch restores the "natural" order.

This is not a user-facing change worth noting in docs: the ordering of
UNION's result has never been guaranteed without an ORDER BY clause.