### PR TITLE
sql: allow listing orphan dropped tables in crdb_internal.tables

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -743,6 +743,12 @@ func forEachTableDescWithTableLookupInternal(
 		if table, ok := desc.(*sqlbase.TableDescriptor); ok && !table.Dropped() {
 			dbName, ok := dbIDsToName[table.GetParentID()]
 			if !ok {
+				// Contrary to `crdb_internal.tables`, which for debugging
+				// purposes also displays dropped tables which miss a parent
+				// database (because the parent descriptor has already been
+				// deleted), information_schema.tables is specified to only
+				// report usable tables, so we exclude dropped tables and the
+				// parent database must always exist.
 				return errors.Errorf("no database with ID %d found", table.GetParentID())
 			}
 			dbTables := databases[dbName]

--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -22,6 +22,11 @@ DROP DATABASE "foo-bar" RESTRICT
 statement ok
 DROP DATABASE "foo-bar" CASCADE
 
+query TTT
+SELECT name, database_name, state FROM crdb_internal.tables WHERE name = 't'
+----
+t  [51]  DROP
+
 query T
 SHOW DATABASES
 ----


### PR DESCRIPTION
The virtual table `crdb_internal.tables` purposefully lists all table
descriptors, including dropped descriptors, for debugging purposes.

Prior to this patch, an error was emitted when a dropped descriptor
didn't have a valid parent database. The situation should not cause an
error, however, as a dropped table descriptor can exist with no
parent, e.g. as a consequence of DROP DATABASE CASCADE.

This patch fixes the issue by listing the parent ID of a dropped table
in numeric form if the database descriptor cannot be found.

Fixes #18432.