### PR TITLE
kv: clean up DistSender and RangeDescriptorCache testing

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -282,7 +282,7 @@ func (ds *DistSender) LeaseHolderCache() *LeaseHolderCache {
 // single inconsistent read only.
 func (ds *DistSender) RangeLookup(
 	ctx context.Context, key roachpb.RKey, desc *roachpb.RangeDescriptor, useReverseScan bool,
-) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
+) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	ba := roachpb.BatchRequest{}
 	ba.ReadConsistency = roachpb.INCONSISTENT
 	ba.Add(&roachpb.RangeLookupRequest{
@@ -298,10 +298,10 @@ func (ds *DistSender) RangeLookup(
 	shuffle.Shuffle(replicas)
 	br, err := ds.sendRPC(ctx, desc.RangeID, replicas, ba)
 	if err != nil {
-		return nil, nil, roachpb.NewError(err)
+		return nil, nil, err
 	}
 	if br.Error != nil {
-		return nil, nil, br.Error
+		return nil, nil, br.Error.GoError()
 	}
 	resp := br.Responses[0].GetInner().(*roachpb.RangeLookupResponse)
 	return resp.Ranges, resp.PrefetchedRanges, nil

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -45,50 +45,60 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
-var testMetaRangeDescriptor = roachpb.RangeDescriptor{
-	RangeID:  1,
-	StartKey: testutils.MakeKey(keys.Meta2Prefix, roachpb.RKey(roachpb.KeyMin)),
-	EndKey:   testutils.MakeKey(keys.Meta2Prefix, roachpb.RKey(roachpb.KeyMax)),
-	Replicas: []roachpb.ReplicaDescriptor{
-		{
-			NodeID:  1,
-			StoreID: 1,
+var (
+	//
+	// Meta RangeDescriptors
+	//
+	testMetaEndKey = roachpb.RKey(keys.SystemPrefix)
+	// single meta1 and meta2 range with one replica.
+	testMetaRangeDescriptor = roachpb.RangeDescriptor{
+		RangeID:  1,
+		StartKey: roachpb.RKeyMin,
+		EndKey:   testMetaEndKey,
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
 		},
-	},
-}
+	}
 
-var testRangeDescriptor = roachpb.RangeDescriptor{
-	RangeID:  2,
-	StartKey: roachpb.RKey("a"),
-	EndKey:   roachpb.RKey("z"),
-	Replicas: []roachpb.ReplicaDescriptor{
-		{
-			NodeID:  1,
-			StoreID: 1,
+	//
+	// User-Space RangeDescriptors
+	//
+	// single user-space descriptor with one replica.
+	testUserRangeDescriptor = roachpb.RangeDescriptor{
+		RangeID:  2,
+		StartKey: testMetaEndKey,
+		EndKey:   roachpb.RKeyMax,
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
 		},
-	},
-}
-
-// test descriptor using three replicas.
-var testRangeDescriptor2 = roachpb.RangeDescriptor{
-	RangeID:  2,
-	StartKey: roachpb.RKey("a"),
-	EndKey:   roachpb.RKey("z"),
-	Replicas: []roachpb.ReplicaDescriptor{
-		{
-			NodeID:  1,
-			StoreID: 1,
+	}
+	// single user-space descriptor with three replicas.
+	testUserRangeDescriptor3Replicas = roachpb.RangeDescriptor{
+		RangeID:  2,
+		StartKey: testMetaEndKey,
+		EndKey:   roachpb.RKeyMax,
+		Replicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:  1,
+				StoreID: 1,
+			},
+			{
+				NodeID:  2,
+				StoreID: 2,
+			},
+			{
+				NodeID:  3,
+				StoreID: 3,
+			},
 		},
-		{
-			NodeID:  2,
-			StoreID: 2,
-		},
-		{
-			NodeID:  3,
-			StoreID: 3,
-		},
-	},
-}
+	}
+)
 
 var testAddress = util.NewUnresolvedAddr("tcp", "node1")
 
@@ -100,6 +110,15 @@ type rpcSendFn func(
 	roachpb.BatchRequest,
 	*rpc.Context,
 ) (*roachpb.BatchResponse, error)
+
+// stubRPCSendFn is an rpcSendFn that simply creates a reply for the
+// BatchRequest without performing an RPC call or triggering any
+// test instrumentation.
+var stubRPCSendFn rpcSendFn = func(
+	_ context.Context, _ SendOptions, _ ReplicaSlice, args roachpb.BatchRequest, _ *rpc.Context,
+) (*roachpb.BatchResponse, error) {
+	return args.CreateReply(), nil
+}
 
 // adaptLegacyTransport converts the RPCSend functions used in these
 // tests to the newer transport interface.
@@ -265,7 +284,23 @@ func TestSendRPCOrder(t *testing.T) {
 		StartKey: roachpb.RKeyMin,
 		EndKey:   roachpb.RKeyMax,
 		RangeID:  rangeID,
-		Replicas: nil,
+	}
+	for i := int32(1); i <= 5; i++ {
+		addr := util.MakeUnresolvedAddr("tcp", fmt.Sprintf("node%d:1", i))
+		nd := &roachpb.NodeDescriptor{
+			NodeID:  roachpb.NodeID(i),
+			Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),
+			Attrs: roachpb.Attributes{
+				Attrs: nodeAttrs[i],
+			},
+		}
+		if err := g.AddInfoProto(gossip.MakeNodeIDKey(roachpb.NodeID(i)), nd, time.Hour); err != nil {
+			t.Fatal(err)
+		}
+		descriptor.Replicas = append(descriptor.Replicas, roachpb.ReplicaDescriptor{
+			NodeID:  roachpb.NodeID(i),
+			StoreID: roachpb.StoreID(i),
+		})
 	}
 
 	// Stub to be changed in each test case.
@@ -290,33 +325,13 @@ func TestSendRPCOrder(t *testing.T) {
 		TestingKnobs: DistSenderTestingKnobs{
 			TransportFactory: adaptLegacyTransport(testFn),
 		},
-		RangeDescriptorDB: MockRangeDescriptorDB(func(roachpb.RKey, bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-			return []roachpb.RangeDescriptor{descriptor}, nil, nil
-		}),
+		RangeDescriptorDB: mockRangeDescriptorDBForDescs(descriptor),
 	}
 
 	ds := NewDistSender(cfg, g)
 
 	for n, tc := range testCases {
 		verifyCall = makeVerifier(tc.expReplica)
-		descriptor.Replicas = nil // could do this once above, but more convenient here
-		for i := int32(1); i <= 5; i++ {
-			addr := util.MakeUnresolvedAddr("tcp", fmt.Sprintf("node%d:1", i))
-			nd := &roachpb.NodeDescriptor{
-				NodeID:  roachpb.NodeID(i),
-				Address: util.MakeUnresolvedAddr(addr.Network(), addr.String()),
-				Attrs: roachpb.Attributes{
-					Attrs: nodeAttrs[i],
-				},
-			}
-			if err := g.AddInfoProto(gossip.MakeNodeIDKey(roachpb.NodeID(i)), nd, time.Hour); err != nil {
-				t.Fatal(err)
-			}
-			descriptor.Replicas = append(descriptor.Replicas, roachpb.ReplicaDescriptor{
-				NodeID:  roachpb.NodeID(i),
-				StoreID: roachpb.StoreID(i),
-			})
-		}
 
 		{
 			// The local node needs to get its attributes during sendRPC.
@@ -370,9 +385,29 @@ func TestSendRPCOrder(t *testing.T) {
 type MockRangeDescriptorDB func(roachpb.RKey, bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error)
 
 func (mdb MockRangeDescriptorDB) RangeLookup(
-	_ context.Context, key roachpb.RKey, _ *roachpb.RangeDescriptor, useReverseScan bool,
+	ctx context.Context, key roachpb.RKey, desc *roachpb.RangeDescriptor, useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-	return mdb(keys.UserKey(key), useReverseScan)
+	descs, prefetched, err := mdb(keys.UserKey(key), useReverseScan)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// filterDescs filters the provided slice to only descriptors which would be
+	// stored within the bounds of the range this RangeLookup was sent to. This
+	// simulates how real RangeLookupRequests behave without needing to inform
+	// mdb about desc.
+	filterDescs := func(retDescs []roachpb.RangeDescriptor) []roachpb.RangeDescriptor {
+		var containedDescs []roachpb.RangeDescriptor
+		for _, retDesc := range retDescs {
+			if desc.ContainsKey(mustMeta(retDesc.EndKey)) {
+				containedDescs = append(containedDescs, retDesc)
+			} else {
+				log.Infof(ctx, "filtering descriptor %v from RangeLookup on range %v", retDesc, desc)
+			}
+		}
+		return containedDescs
+	}
+	return filterDescs(descs), filterDescs(prefetched), nil
 }
 
 func (mdb MockRangeDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) {
@@ -383,19 +418,37 @@ func (mdb MockRangeDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) 
 	return &rs[0], nil
 }
 
-var defaultMockRangeDescriptorDB = MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-	if bytes.HasPrefix(key, keys.Meta2Prefix) {
-		return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
-	}
-	return []roachpb.RangeDescriptor{testRangeDescriptor}, nil, nil
-})
+func mockRangeDescriptorDBForDescs(descs ...roachpb.RangeDescriptor) MockRangeDescriptorDB {
+	return MockRangeDescriptorDB(func(key roachpb.RKey, useReverseScan bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
+		var matchingDescs []roachpb.RangeDescriptor
+		for _, desc := range descs {
+			contains := desc.ContainsKey
+			if useReverseScan {
+				contains = desc.ContainsExclusiveEndKey
+			}
+			if contains(key) {
+				matchingDescs = append(matchingDescs, desc)
+			}
+		}
+		switch len(matchingDescs) {
+		case 0:
+			panic(fmt.Sprintf("found no matching descriptors for key %s", key))
+		case 1:
+			return matchingDescs, nil, nil
+		default:
+			panic(fmt.Sprintf("found multiple matching descriptors for key %s: %v", key, matchingDescs))
+		}
+	})
+}
 
-var threeReplicaMockRangeDescriptorDB = MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-	if bytes.HasPrefix(key, keys.Meta2Prefix) {
-		return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
-	}
-	return []roachpb.RangeDescriptor{testRangeDescriptor2}, nil, nil
-})
+var defaultMockRangeDescriptorDB = mockRangeDescriptorDBForDescs(
+	testMetaRangeDescriptor,
+	testUserRangeDescriptor,
+)
+var threeReplicaMockRangeDescriptorDB = mockRangeDescriptorDBForDescs(
+	testMetaRangeDescriptor,
+	testUserRangeDescriptor3Replicas,
+)
 
 func TestOwnNodeCertain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -574,15 +627,6 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
-	var testFn rpcSendFn = func(
-		_ context.Context,
-		_ SendOptions,
-		_ ReplicaSlice,
-		args roachpb.BatchRequest,
-		_ *rpc.Context,
-	) (*roachpb.BatchResponse, error) {
-		return args.CreateReply(), nil
-	}
 
 	errs := []error{
 		errors.New("boom"),
@@ -594,19 +638,21 @@ func TestRetryOnDescriptorLookupError(t *testing.T) {
 		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
 		Clock:      clock,
 		TestingKnobs: DistSenderTestingKnobs{
-			TransportFactory: adaptLegacyTransport(testFn),
+			TransportFactory: adaptLegacyTransport(stubRPCSendFn),
 		},
 		RangeDescriptorDB: MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-			// Return next error and truncate the prefix of the errors array.
-			var err error
-			if !key.Equal(roachpb.KeyMin) {
-				err = errs[0]
-				errs = errs[1:]
-				if bytes.HasPrefix(key, keys.Meta2Prefix) {
-					return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, err
-				}
+			// Don't return an error on the FirstRange lookup.
+			if key.Equal(roachpb.KeyMin) {
+				return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
 			}
-			return []roachpb.RangeDescriptor{testRangeDescriptor}, nil, err
+
+			// Return next error and truncate the prefix of the errors array.
+			err := errs[0]
+			errs = errs[1:]
+			if key.Less(testMetaRangeDescriptor.EndKey) {
+				return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, err
+			}
+			return []roachpb.RangeDescriptor{testUserRangeDescriptor}, nil, err
 		}),
 	}
 	ds := NewDistSender(cfg, g)
@@ -827,7 +873,7 @@ func TestEvictCacheOnUnknownLeaseHolder(t *testing.T) {
 
 	g, clock := makeGossip(t, stopper)
 
-	// Gossip the two nodes referred to in testRangeDescriptor2.
+	// Gossip the two nodes referred to in testUserRangeDescriptor3Replicas.
 	for i := 2; i <= 3; i++ {
 		addr := util.MakeUnresolvedAddr("tcp", fmt.Sprintf("node%d", i))
 		nd := &roachpb.NodeDescriptor{
@@ -891,13 +937,13 @@ func TestRetryOnWrongReplicaError(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
-	if err := g.AddInfoProto(gossip.KeyFirstRangeDescriptor, &testRangeDescriptor, time.Hour); err != nil {
+	if err := g.AddInfoProto(gossip.KeyFirstRangeDescriptor, &testUserRangeDescriptor, time.Hour); err != nil {
 		t.Fatal(err)
 	}
 
 	// Updated below, after it has first been returned.
 	badStartKey := roachpb.RKey("m")
-	newRangeDescriptor := testRangeDescriptor
+	newRangeDescriptor := testUserRangeDescriptor
 	goodStartKey := newRangeDescriptor.StartKey
 	newRangeDescriptor.StartKey = badStartKey
 	descStale := true
@@ -977,13 +1023,13 @@ func TestRetryOnWrongReplicaErrorWithSuggestion(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
-	if err := g.AddInfoProto(gossip.KeyFirstRangeDescriptor, &testRangeDescriptor, time.Hour); err != nil {
+	if err := g.AddInfoProto(gossip.KeyFirstRangeDescriptor, &testUserRangeDescriptor, time.Hour); err != nil {
 		t.Fatal(err)
 	}
 
 	// Updated below, after it has first been returned.
-	goodRangeDescriptor := testRangeDescriptor
-	badRangeDescriptor := testRangeDescriptor
+	goodRangeDescriptor := testUserRangeDescriptor
+	badRangeDescriptor := testUserRangeDescriptor
 	badRangeDescriptor.EndKey = roachpb.RKey("zBad")
 	badRangeDescriptor.RangeID++
 	firstLookup := true
@@ -1107,6 +1153,7 @@ func TestSendRPCRetry(t *testing.T) {
 	if err := g.SetNodeDescriptor(&roachpb.NodeDescriptor{NodeID: 1}); err != nil {
 		t.Fatal(err)
 	}
+
 	// Fill RangeDescriptor with 2 replicas.
 	var descriptor = roachpb.RangeDescriptor{
 		RangeID:  1,
@@ -1128,6 +1175,11 @@ func TestSendRPCRetry(t *testing.T) {
 			StoreID: roachpb.StoreID(i),
 		})
 	}
+	descDB := mockRangeDescriptorDBForDescs(
+		testMetaRangeDescriptor,
+		descriptor,
+	)
+
 	var testFn rpcSendFn = func(
 		_ context.Context,
 		_ SendOptions,
@@ -1147,12 +1199,7 @@ func TestSendRPCRetry(t *testing.T) {
 		TestingKnobs: DistSenderTestingKnobs{
 			TransportFactory: adaptLegacyTransport(testFn),
 		},
-		RangeDescriptorDB: MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-			if bytes.HasPrefix(key, keys.Meta2Prefix) {
-				return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
-			}
-			return []roachpb.RangeDescriptor{descriptor}, nil, nil
-		}),
+		RangeDescriptorDB: descDB,
 	}
 	ds := NewDistSender(cfg, g)
 	scan := roachpb.NewScan(roachpb.Key("a"), roachpb.Key("d"))
@@ -1291,7 +1338,7 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 	merged := false
 	// The stale first range descriptor which is unaware of the merge.
 	var firstRange = roachpb.RangeDescriptor{
-		RangeID:  1,
+		RangeID:  2,
 		StartKey: roachpb.RKey("a"),
 		EndKey:   roachpb.RKey("b"),
 		Replicas: []roachpb.ReplicaDescriptor{
@@ -1304,7 +1351,7 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 	// The merged descriptor, which will be looked up after having processed
 	// the stale range [a,b).
 	var mergedRange = roachpb.RangeDescriptor{
-		RangeID:  1,
+		RangeID:  2,
 		StartKey: roachpb.RKey("a"),
 		EndKey:   roachpb.RKeyMax,
 		Replicas: []roachpb.ReplicaDescriptor{
@@ -1353,7 +1400,7 @@ func TestMultiRangeMergeStaleDescriptor(t *testing.T) {
 			TransportFactory: adaptLegacyTransport(testFn),
 		},
 		RangeDescriptorDB: MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-			if bytes.HasPrefix(key, keys.Meta2Prefix) {
+			if key.Less(testMetaRangeDescriptor.EndKey) {
 				return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
 			}
 			if !merged {
@@ -1388,31 +1435,20 @@ func TestRangeLookupOptionOnReverseScan(t *testing.T) {
 	defer stopper.Stop(context.TODO())
 
 	g, clock := makeGossip(t, stopper)
-
-	var testFn rpcSendFn = func(
-		_ context.Context,
-		_ SendOptions,
-		_ ReplicaSlice,
-		args roachpb.BatchRequest,
-		_ *rpc.Context,
-	) (*roachpb.BatchResponse, error) {
-		return args.CreateReply(), nil
-	}
-
 	cfg := DistSenderConfig{
 		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
 		Clock:      clock,
 		TestingKnobs: DistSenderTestingKnobs{
-			TransportFactory: adaptLegacyTransport(testFn),
+			TransportFactory: adaptLegacyTransport(stubRPCSendFn),
 		},
 		RangeDescriptorDB: MockRangeDescriptorDB(func(key roachpb.RKey, useReverseScan bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 			if !key.Equal(roachpb.KeyMin) && !useReverseScan {
 				t.Fatalf("expected UseReverseScan to be set")
 			}
-			if bytes.HasPrefix(key, keys.Meta2Prefix) {
+			if key.Less(testMetaRangeDescriptor.EndKey) {
 				return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
 			}
-			return []roachpb.RangeDescriptor{testRangeDescriptor}, nil, nil
+			return []roachpb.RangeDescriptor{testUserRangeDescriptor}, nil, nil
 		}),
 	}
 	ds := NewDistSender(cfg, g)
@@ -1500,8 +1536,8 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 	// descriptor whose range is ["a", "c") and partially overlaps
 	// with the first descriptor's range.
 	var descriptor1 = roachpb.RangeDescriptor{
-		RangeID:  1,
-		StartKey: roachpb.RKeyMin,
+		RangeID:  2,
+		StartKey: testMetaEndKey,
 		EndKey:   roachpb.RKey("b"),
 		Replicas: []roachpb.ReplicaDescriptor{
 			{
@@ -1511,7 +1547,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 		},
 	}
 	var descriptor2 = roachpb.RangeDescriptor{
-		RangeID:  2,
+		RangeID:  3,
 		StartKey: roachpb.RKey("a"),
 		EndKey:   roachpb.RKey("c"),
 		Replicas: []roachpb.ReplicaDescriptor{
@@ -1522,7 +1558,7 @@ func TestTruncateWithSpanAndDescriptor(t *testing.T) {
 		},
 	}
 	descDB := MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-		if bytes.HasPrefix(key, keys.Meta2Prefix) {
+		if key.Less(testMetaRangeDescriptor.EndKey) {
 			return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
 		}
 		desc := descriptor1
@@ -1620,8 +1656,8 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 
 	// Fill MockRangeDescriptorDB with two descriptors.
 	var descriptor1 = roachpb.RangeDescriptor{
-		RangeID:  1,
-		StartKey: roachpb.RKeyMin,
+		RangeID:  2,
+		StartKey: testMetaEndKey,
 		EndKey:   roachpb.RKey("b"),
 		Replicas: []roachpb.ReplicaDescriptor{
 			{
@@ -1631,7 +1667,7 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 		},
 	}
 	var descriptor2 = roachpb.RangeDescriptor{
-		RangeID:  2,
+		RangeID:  3,
 		StartKey: roachpb.RKey("b"),
 		EndKey:   roachpb.RKey("c"),
 		Replicas: []roachpb.ReplicaDescriptor{
@@ -1642,7 +1678,7 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 		},
 	}
 	var descriptor3 = roachpb.RangeDescriptor{
-		RangeID:  3,
+		RangeID:  4,
 		StartKey: roachpb.RKey("c"),
 		EndKey:   roachpb.RKeyMax,
 		Replicas: []roachpb.ReplicaDescriptor{
@@ -1652,19 +1688,12 @@ func TestTruncateWithLocalSpanAndDescriptor(t *testing.T) {
 			},
 		},
 	}
-
-	descDB := MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-		switch {
-		case bytes.HasPrefix(key, keys.Meta2Prefix):
-			return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
-		case !key.Less(roachpb.RKey("c")):
-			return []roachpb.RangeDescriptor{descriptor3}, nil, nil
-		case !key.Less(roachpb.RKey("b")):
-			return []roachpb.RangeDescriptor{descriptor2}, nil, nil
-		default:
-			return []roachpb.RangeDescriptor{descriptor1}, nil, nil
-		}
-	})
+	descDB := mockRangeDescriptorDBForDescs(
+		testMetaRangeDescriptor,
+		descriptor1,
+		descriptor2,
+		descriptor3,
+	)
 
 	// Define our rpcSend stub which checks the span of the batch
 	// requests.
@@ -1821,8 +1850,8 @@ func TestSequenceUpdateOnMultiRangeQueryLoop(t *testing.T) {
 
 	// Fill MockRangeDescriptorDB with two descriptors.
 	var descriptor1 = roachpb.RangeDescriptor{
-		RangeID:  1,
-		StartKey: roachpb.RKeyMin,
+		RangeID:  2,
+		StartKey: testMetaEndKey,
 		EndKey:   roachpb.RKey("b"),
 		Replicas: []roachpb.ReplicaDescriptor{
 			{
@@ -1832,9 +1861,9 @@ func TestSequenceUpdateOnMultiRangeQueryLoop(t *testing.T) {
 		},
 	}
 	var descriptor2 = roachpb.RangeDescriptor{
-		RangeID:  2,
+		RangeID:  3,
 		StartKey: roachpb.RKey("b"),
-		EndKey:   roachpb.RKey("c"),
+		EndKey:   roachpb.RKeyMax,
 		Replicas: []roachpb.ReplicaDescriptor{
 			{
 				NodeID:  1,
@@ -1842,16 +1871,11 @@ func TestSequenceUpdateOnMultiRangeQueryLoop(t *testing.T) {
 			},
 		},
 	}
-	descDB := MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-		if bytes.HasPrefix(key, keys.Meta2Prefix) {
-			return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
-		}
-		desc := descriptor1
-		if key.Equal(roachpb.RKey("b")) {
-			desc = descriptor2
-		}
-		return []roachpb.RangeDescriptor{desc}, nil, nil
-	})
+	descDB := mockRangeDescriptorDBForDescs(
+		testMetaRangeDescriptor,
+		descriptor1,
+		descriptor2,
+	)
 
 	// Define our rpcSend stub which checks the span of the batch
 	// requests. Because of parallelization, the requests for the
@@ -1969,8 +1993,8 @@ func TestMultiRangeSplitEndTransaction(t *testing.T) {
 
 	// Fill MockRangeDescriptorDB with two descriptors.
 	var descriptor1 = roachpb.RangeDescriptor{
-		RangeID:  1,
-		StartKey: roachpb.RKeyMin,
+		RangeID:  2,
+		StartKey: testMetaEndKey,
 		EndKey:   roachpb.RKey("b"),
 		Replicas: []roachpb.ReplicaDescriptor{
 			{
@@ -1980,7 +2004,7 @@ func TestMultiRangeSplitEndTransaction(t *testing.T) {
 		},
 	}
 	var descriptor2 = roachpb.RangeDescriptor{
-		RangeID:  2,
+		RangeID:  3,
 		StartKey: roachpb.RKey("b"),
 		EndKey:   roachpb.RKeyMax,
 		Replicas: []roachpb.ReplicaDescriptor{
@@ -1990,16 +2014,11 @@ func TestMultiRangeSplitEndTransaction(t *testing.T) {
 			},
 		},
 	}
-	descDB := MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-		if bytes.HasPrefix(key, keys.Meta2Prefix) {
-			return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
-		}
-		desc := descriptor1
-		if !key.Less(roachpb.RKey("b")) {
-			desc = descriptor2
-		}
-		return []roachpb.RangeDescriptor{desc}, nil, nil
-	})
+	descDB := mockRangeDescriptorDBForDescs(
+		testMetaRangeDescriptor,
+		descriptor1,
+		descriptor2,
+	)
 
 	for i, test := range testCases {
 		var mu syncutil.Mutex
@@ -2063,7 +2082,7 @@ func TestCountRanges(t *testing.T) {
 	const firstKeyBoundary = 'a'
 	var descriptors [numDescriptors]roachpb.RangeDescriptor
 	for i := range descriptors {
-		startKey := roachpb.RKeyMin
+		startKey := testMetaEndKey
 		if i > 0 {
 			startKey = roachpb.RKey(string(firstKeyBoundary + i - 1))
 		}
@@ -2073,7 +2092,7 @@ func TestCountRanges(t *testing.T) {
 		}
 
 		descriptors[i] = roachpb.RangeDescriptor{
-			RangeID:  roachpb.RangeID(i + 1),
+			RangeID:  roachpb.RangeID(i + 2),
 			StartKey: startKey,
 			EndKey:   endKey,
 			Replicas: []roachpb.ReplicaDescriptor{
@@ -2086,31 +2105,12 @@ func TestCountRanges(t *testing.T) {
 	}
 
 	// Mock out descriptor DB and sender function.
-	descDB := MockRangeDescriptorDB(func(key roachpb.RKey, _ bool) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-		if bytes.HasPrefix(key, keys.Meta2Prefix) {
-			return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
-		}
-		for _, desc := range descriptors {
-			if key.Less(desc.EndKey) {
-				return []roachpb.RangeDescriptor{desc}, nil, nil
-			}
-		}
-		return []roachpb.RangeDescriptor{descriptors[len(descriptors)-1]}, nil, nil
-	})
-	var testFn rpcSendFn = func(
-		_ context.Context,
-		_ SendOptions,
-		_ ReplicaSlice,
-		ba roachpb.BatchRequest,
-		_ *rpc.Context,
-	) (*roachpb.BatchResponse, error) {
-		return ba.CreateReply(), nil
-	}
+	descDB := mockRangeDescriptorDBForDescs(append(descriptors[:], testMetaRangeDescriptor)...)
 	cfg := DistSenderConfig{
 		AmbientCtx: log.AmbientContext{Tracer: tracing.NewTracer()},
 		Clock:      clock,
 		TestingKnobs: DistSenderTestingKnobs{
-			TransportFactory: adaptLegacyTransport(testFn),
+			TransportFactory: adaptLegacyTransport(stubRPCSendFn),
 		},
 		RangeDescriptorDB: descDB,
 	}
@@ -2125,13 +2125,13 @@ func TestCountRanges(t *testing.T) {
 		endKey roachpb.RKey
 		count  int64
 	}{
-		{roachpb.RKeyMin, roachpb.RKey(string(firstKeyBoundary)), 1},
-		{roachpb.RKeyMin, keyIn(descriptors[0]), 1},
-		{roachpb.RKeyMin, descriptors[len(descriptors)-1].StartKey, numDescriptors - 1},
+		{testMetaEndKey, roachpb.RKey(string(firstKeyBoundary)), 1},
+		{testMetaEndKey, keyIn(descriptors[0]), 1},
+		{testMetaEndKey, descriptors[len(descriptors)-1].StartKey, numDescriptors - 1},
 		{descriptors[0].EndKey, roachpb.RKeyMax, numDescriptors - 1},
 		// Everything from the min key to a key within the last range.
-		{roachpb.RKeyMin, keyIn(descriptors[len(descriptors)-1]), numDescriptors},
-		{roachpb.RKeyMin, roachpb.RKeyMax, numDescriptors},
+		{testMetaEndKey, keyIn(descriptors[len(descriptors)-1]), numDescriptors},
+		{testMetaEndKey, roachpb.RKeyMax, numDescriptors},
 	}
 	for i, tc := range testcases {
 		count, pErr := ds.CountRanges(context.Background(), roachpb.RSpan{Key: tc.key, EndKey: tc.endKey})

--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -65,7 +65,7 @@ type RangeDescriptorDB interface {
 		key roachpb.RKey,
 		desc *roachpb.RangeDescriptor,
 		useReverseScan bool,
-	) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error)
+	) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error)
 	// FirstRange returns the descriptor for the first Range. This is the
 	// Range containing all meta1 entries.
 	FirstRange() (*roachpb.RangeDescriptor, error)
@@ -428,8 +428,7 @@ func (rdc *RangeDescriptorCache) performRangeLookup(
 	}
 	// Tag inner operations.
 	ctx = log.WithLogTag(ctx, "range-lookup", nil)
-	descs, prefetched, pErr := rdc.db.RangeLookup(ctx, metadataKey, desc, useReverseScan)
-	return descs, prefetched, pErr.GoError()
+	return rdc.db.RangeLookup(ctx, metadataKey, desc, useReverseScan)
 }
 
 // EvictCachedRangeDescriptor will evict any cached range descriptors

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -117,18 +117,7 @@ func (db *testDescriptorDB) RangeLookup(
 		return nil, nil, ctx.Err()
 	}
 	atomic.AddInt64(&db.lookupCount, 1)
-	return db.getDescriptors(stripMeta(key), useReverseScan)
-}
-
-func stripMeta(key roachpb.RKey) roachpb.RKey {
-	switch {
-	case bytes.HasPrefix(key, keys.Meta1Prefix):
-		return testutils.MakeKey(roachpb.RKey(keys.Meta2Prefix), key[len(keys.Meta1Prefix):])
-	case bytes.HasPrefix(key, keys.Meta2Prefix):
-		return key[len(keys.Meta2Prefix):]
-	}
-	// First range.
-	return nil
+	return db.getDescriptors(keys.UserKey(key), useReverseScan)
 }
 
 func (db *testDescriptorDB) splitRange(t *testing.T, key roachpb.RKey) {

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -60,7 +60,7 @@ func (a testDescriptorNode) Compare(b llrb.Comparable) int {
 
 func (db *testDescriptorDB) getDescriptors(
 	key roachpb.RKey, useReverseScan bool,
-) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
+) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	rs := make([]roachpb.RangeDescriptor, 0, 1)
 	preRs := make([]roachpb.RangeDescriptor, 0, 2)
 	for i := 0; i < 3; i++ {
@@ -110,11 +110,11 @@ func (db *testDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) {
 
 func (db *testDescriptorDB) RangeLookup(
 	ctx context.Context, key roachpb.RKey, _ *roachpb.RangeDescriptor, useReverseScan bool,
-) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
+) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	select {
 	case <-db.pauseChan:
 	case <-ctx.Done():
-		return nil, nil, roachpb.NewError(ctx.Err())
+		return nil, nil, ctx.Err()
 	}
 	atomic.AddInt64(&db.lookupCount, 1)
 	return db.getDescriptors(stripMeta(key), useReverseScan)

--- a/pkg/kv/range_iter_test.go
+++ b/pkg/kv/range_iter_test.go
@@ -31,11 +31,9 @@ import (
 
 var alphaRangeDescriptors []*roachpb.RangeDescriptor
 
-var alphaRangeDescriptorDB = MockRangeDescriptorDB(func(key roachpb.RKey, useReverseScan bool) (
-	[]roachpb.RangeDescriptor,
-	[]roachpb.RangeDescriptor,
-	*roachpb.Error,
-) {
+var alphaRangeDescriptorDB = MockRangeDescriptorDB(func(
+	key roachpb.RKey, useReverseScan bool,
+) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	if bytes.HasPrefix(key, keys.Meta2Prefix) {
 		return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
 	}

--- a/pkg/kv/range_iter_test.go
+++ b/pkg/kv/range_iter_test.go
@@ -38,7 +38,7 @@ var alphaRangeDescriptorDB = MockRangeDescriptorDB(func(
 		return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
 	}
 	var index int
-	if len(key) > 0 {
+	if !key.Equal(roachpb.KeyMin) {
 		if useReverseScan {
 			index = int(key[0] - byte('a'))
 		} else {

--- a/pkg/kv/range_iter_test.go
+++ b/pkg/kv/range_iter_test.go
@@ -15,13 +15,11 @@
 package kv
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -29,35 +27,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
-var alphaRangeDescriptors []*roachpb.RangeDescriptor
-
-var alphaRangeDescriptorDB = MockRangeDescriptorDB(func(
-	key roachpb.RKey, useReverseScan bool,
-) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
-	if bytes.HasPrefix(key, keys.Meta2Prefix) {
-		return []roachpb.RangeDescriptor{testMetaRangeDescriptor}, nil, nil
-	}
-	var index int
-	if !key.Equal(roachpb.KeyMin) {
-		if useReverseScan {
-			index = int(key[0] - byte('a'))
-		} else {
-			index = int(key[0] - byte('a') + 1)
-		}
-	}
-	if index < 0 {
-		index = 0
-	} else if index >= len(alphaRangeDescriptors) {
-		index = len(alphaRangeDescriptors) - 1
-	}
-	return []roachpb.RangeDescriptor{*alphaRangeDescriptors[index]}, nil, nil
-})
+var alphaRangeDescriptors []roachpb.RangeDescriptor
+var alphaRangeDescriptorDB MockRangeDescriptorDB
 
 func init() {
-	lastKey := roachpb.RKey(keys.MinKey)
+	lastKey := testMetaEndKey
 	for i, b := 0, byte('a'); b <= byte('z'); i, b = i+1, b+1 {
 		key := roachpb.RKey([]byte{b})
-		alphaRangeDescriptors = append(alphaRangeDescriptors, &roachpb.RangeDescriptor{
+		alphaRangeDescriptors = append(alphaRangeDescriptors, roachpb.RangeDescriptor{
 			RangeID:  roachpb.RangeID(i + 2),
 			StartKey: lastKey,
 			EndKey:   key,
@@ -70,6 +47,9 @@ func init() {
 		})
 		lastKey = key
 	}
+	alphaRangeDescriptorDB = mockRangeDescriptorDBForDescs(
+		append(alphaRangeDescriptors, testMetaRangeDescriptor)...,
+	)
 }
 
 func TestRangeIterForward(t *testing.T) {
@@ -89,11 +69,11 @@ func TestRangeIterForward(t *testing.T) {
 	ri := NewRangeIterator(ds)
 	i := 0
 	span := roachpb.RSpan{
-		Key:    roachpb.RKey(roachpb.KeyMin),
+		Key:    testMetaEndKey,
 		EndKey: roachpb.RKey([]byte("z")),
 	}
 	for ri.Seek(ctx, span.Key, Ascending); ri.Valid(); ri.Next(ctx) {
-		if !reflect.DeepEqual(alphaRangeDescriptors[i], ri.Desc()) {
+		if !reflect.DeepEqual(alphaRangeDescriptors[i], *ri.Desc()) {
 			t.Fatalf("%d: expected %v; got %v", i, alphaRangeDescriptors[i], ri.Desc())
 		}
 		i++
@@ -119,8 +99,8 @@ func TestRangeIterSeekForward(t *testing.T) {
 
 	ri := NewRangeIterator(ds)
 	i := 0
-	for ri.Seek(ctx, roachpb.RKey(roachpb.KeyMin), Ascending); ri.Valid(); {
-		if !reflect.DeepEqual(alphaRangeDescriptors[i], ri.Desc()) {
+	for ri.Seek(ctx, testMetaEndKey, Ascending); ri.Valid(); {
+		if !reflect.DeepEqual(alphaRangeDescriptors[i], *ri.Desc()) {
 			t.Fatalf("%d: expected %v; got %v", i, alphaRangeDescriptors[i], ri.Desc())
 		}
 		i += 2
@@ -154,11 +134,11 @@ func TestRangeIterReverse(t *testing.T) {
 	ri := NewRangeIterator(ds)
 	i := len(alphaRangeDescriptors) - 1
 	span := roachpb.RSpan{
-		Key:    roachpb.RKey(roachpb.KeyMin),
+		Key:    testMetaEndKey,
 		EndKey: roachpb.RKey([]byte{'z'}),
 	}
 	for ri.Seek(ctx, span.EndKey, Descending); ri.Valid(); ri.Next(ctx) {
-		if !reflect.DeepEqual(alphaRangeDescriptors[i], ri.Desc()) {
+		if !reflect.DeepEqual(alphaRangeDescriptors[i], *ri.Desc()) {
 			t.Fatalf("%d: expected %v; got %v", i, alphaRangeDescriptors[i], ri.Desc())
 		}
 		i--
@@ -185,7 +165,7 @@ func TestRangeIterSeekReverse(t *testing.T) {
 	ri := NewRangeIterator(ds)
 	i := len(alphaRangeDescriptors) - 1
 	for ri.Seek(ctx, roachpb.RKey([]byte{'z'}), Descending); ri.Valid(); {
-		if !reflect.DeepEqual(alphaRangeDescriptors[i], ri.Desc()) {
+		if !reflect.DeepEqual(alphaRangeDescriptors[i], *ri.Desc()) {
 			t.Fatalf("%d: expected %v; got %v", i, alphaRangeDescriptors[i], ri.Desc())
 		}
 		i -= 2

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -632,7 +632,7 @@ type mtcRangeDescriptorDB struct {
 
 func (mrdb mtcRangeDescriptorDB) RangeLookup(
 	ctx context.Context, key roachpb.RKey, desc *roachpb.RangeDescriptor, useReverseScan bool,
-) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, *roachpb.Error) {
+) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	return (*mrdb.ds).RangeLookup(ctx, key, desc, useReverseScan)
 }
 


### PR DESCRIPTION
This change performs a number of cleanup steps to make our `DistSender` and `RangeDescriptorCache` testing more manageable.
- `RangeDescriptorDB.RangeLookup` now returns an `error`, not a `*roachpb.Error`
- `stripMeta` was a half-baked `keys.UserKey`. It's now gone
- `MockRangeDescriptorDB` is a lot cleaner now and verifies that the descriptors it returns actually make sense
- The changes to `MockRangeDescriptorDB` forced us to fix problematic test `RangeDescriptors` throughout
- A new `stubRPCSendFn` variable was pulled out of tests for reuse