### PR TITLE
kv: remove obnoxious RangeDescriptorCache stringLocked logs

### DIFF
--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -274,9 +274,7 @@ func (rdc *RangeDescriptorCache) lookupRangeDescriptorInternal(
 		return desc, returnToken, nil
 	}
 
-	if log.V(3) {
-		log.Infof(ctx, "lookup range descriptor: key=%s\n%s", key, rdc.stringLocked())
-	} else if log.V(2) {
+	if log.V(2) {
 		log.Infof(ctx, "lookup range descriptor: key=%s", key)
 	}
 
@@ -464,10 +462,7 @@ func (rdc *RangeDescriptorCache) evictCachedRangeDescriptorLocked(
 	}
 
 	for {
-		if log.V(3) {
-			log.Infof(ctx, "evict cached descriptor: key=%s desc=%s\n%s",
-				descKey, cachedDesc, rdc.stringLocked())
-		} else if log.V(2) {
+		if log.V(2) {
 			log.Infof(ctx, "evict cached descriptor: key=%s desc=%s", descKey, cachedDesc)
 		}
 		rdc.rangeCache.cache.Del(rngKey)


### PR DESCRIPTION
This logs are very loud in logspy and aren't helpful. They print the
entire contents of the `RangeDescriptorCache`, which can grow up to
`1e6` entries in size on large clusters. Because it prints every range
descriptor in the cache, it is also picked up by a grep for any rangeId,
even those unrelated to the lookup/eviction.