### PR TITLE
sql: support casting strings to arrays

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -450,7 +450,7 @@ func convertRecord(
 	}
 
 	parse := parser.Parser{}
-	evalCtx := parser.EvalContext{}
+	evalCtx := parser.EvalContext{Location: &time.UTC}
 	// Although we don't yet support DEFAULT expressions on visible columns,
 	// we do on hidden columns (which is only the default _rowid one). This
 	// allows those expressions to run.
@@ -470,7 +470,7 @@ func convertRecord(
 				if nullif != nil && v == *nullif {
 					datums[i] = parser.DNull
 				} else {
-					datums[i], err = parser.ParseStringAs(col.Type.ToDatumType(), v, time.UTC)
+					datums[i], err = parser.ParseStringAs(col.Type.ToDatumType(), v, &evalCtx)
 					if err != nil {
 						return errors.Wrapf(err, "%s: row %d: parse %q as %s", batch.file, rowNum, col.Name, col.Type.SQLString())
 					}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -195,7 +195,8 @@ func (n *copyNode) addRow(ctx context.Context, line []byte) error {
 				return err
 			}
 		}
-		d, err := parser.ParseStringAs(n.resultColumns[i].Typ, s, n.session.Location)
+		evalCtx := n.session.evalCtx()
+		d, err := parser.ParseStringAs(n.resultColumns[i].Typ, s, &evalCtx)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -91,6 +91,33 @@ SELECT ARRAY[]:::int[]
 ----
 {}
 
+# casting strings to arrays
+
+query T
+SELECT '{1,2,3}'::INT[]
+----
+{1,2,3}
+
+query T
+SELECT '{hello,"hello"}'::STRING[]
+----
+{"hello","hello"}
+
+query T
+SELECT e'{he\\\\llo}'::STRING[]
+----
+{"he\\llo"}
+
+query T
+SELECT '{"abc\nxyz"}'::STRING[]
+----
+{"abcnxyz"}
+
+query T
+SELECT '{hello}'::VARCHAR(2)[]
+----
+{"he"}
+
 # array subscript access
 
 query T

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -2232,8 +2232,11 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		return d, nil
 	}
 	d = UnwrapDatum(d)
+	return performCast(ctx, d, expr.Type)
+}
 
-	switch typ := expr.Type.(type) {
+func performCast(ctx *EvalContext, d Datum, t CastTargetType) (Datum, error) {
+	switch typ := t.(type) {
 	case *BoolColType:
 		switch v := d.(type) {
 		case *DBool:
@@ -2426,7 +2429,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		case *DOid:
 			s = t.name
 		}
-		switch c := expr.Type.(type) {
+		switch c := t.(type) {
 		case *StringColType:
 			// If the CHAR type specifies a limit we truncate to that limit:
 			//   'hello'::CHAR(2) -> 'he'
@@ -2545,6 +2548,10 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		case *DInterval:
 			return d, nil
 		}
+	case *ArrayColType:
+		if s, ok := d.(*DString); ok {
+			return ParseDArrayFromString(ctx, string(*s), typ.ParamType)
+		}
 	case *OidColType:
 		switch v := d.(type) {
 		case *DOid:
@@ -2651,7 +2658,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 	}
 
 	return nil, pgerror.NewErrorf(
-		pgerror.CodeCannotCoerceError, "invalid cast: %s -> %s", d.ResolvedType(), expr.Type)
+		pgerror.CodeCannotCoerceError, "invalid cast: %s -> %s", d.ResolvedType(), t)
 }
 
 // Eval implements the TypedExpr interface.

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -1086,6 +1086,7 @@ var (
 	oidCastTypes       = []Type{TypeNull, TypeString, TypeCollatedString, TypeInt, TypeOid}
 	uuidCastTypes      = []Type{TypeNull, TypeString, TypeCollatedString, TypeBytes, TypeUUID}
 	inetCastTypes      = []Type{TypeNull, TypeString, TypeCollatedString, TypeINet}
+	arrayCastTypes     = []Type{TypeNull, TypeString}
 )
 
 // validCastTypes returns a set of types that can be cast into the provided type.
@@ -1121,7 +1122,7 @@ func validCastTypes(t Type) []Type {
 		if t.FamilyEqual(TypeCollatedString) {
 			return stringCastTypes
 		} else if t.FamilyEqual(TypeArray) {
-			return []Type{TypeNull}
+			return arrayCastTypes
 		}
 		return nil
 	}

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -210,7 +210,7 @@ func ParseType(sql string) (CastTargetType, error) {
 }
 
 // ParseStringAs parses s as type t.
-func ParseStringAs(t Type, s string, location *time.Location) (Datum, error) {
+func ParseStringAs(t Type, s string, evalCtx *EvalContext) (Datum, error) {
 	var d Datum
 	var err error
 	switch t {
@@ -219,7 +219,7 @@ func ParseStringAs(t Type, s string, location *time.Location) (Datum, error) {
 	case TypeBytes:
 		d = NewDBytes(DBytes(s))
 	case TypeDate:
-		d, err = ParseDDate(s, location)
+		d, err = ParseDDate(s, evalCtx.GetLocation())
 	case TypeDecimal:
 		d, err = ParseDDecimal(s)
 	case TypeFloat:
@@ -233,13 +233,24 @@ func ParseStringAs(t Type, s string, location *time.Location) (Datum, error) {
 	case TypeTimestamp:
 		d, err = ParseDTimestamp(s, time.Microsecond)
 	case TypeTimestampTZ:
-		d, err = ParseDTimestampTZ(s, location, time.Microsecond)
+		d, err = ParseDTimestampTZ(s, evalCtx.GetLocation(), time.Microsecond)
 	case TypeUUID:
 		d, err = ParseDUuidFromString(s)
 	case TypeINet:
 		d, err = ParseDIPAddrFromINetString(s)
 	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unknown type %s", t)
+		if a, ok := t.(TArray); ok {
+			typ, err := DatumTypeToColumnType(a.Typ)
+			if err != nil {
+				return nil, err
+			}
+			d, err = ParseDArrayFromString(evalCtx, s, typ)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unknown type %s", t)
+		}
 	}
 	return d, err
 }

--- a/pkg/sql/parser/parse_array.go
+++ b/pkg/sql/parser/parse_array.go
@@ -1,0 +1,189 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import (
+	"bytes"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+)
+
+var enclosingError = pgerror.NewErrorf(pgerror.CodeInvalidTextRepresentationError, "array must be enclosed in { and }")
+var extraTextError = pgerror.NewErrorf(pgerror.CodeInvalidTextRepresentationError, "extra text after closing right brace")
+var nestedArraysNotSupportedError = pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "nested arrays not supported")
+var malformedError = pgerror.NewErrorf(pgerror.CodeInvalidTextRepresentationError, "malformed array")
+
+var isQuoteChar = func(ch byte) bool {
+	return ch == '"'
+}
+
+var isControlChar = func(ch byte) bool {
+	return ch == '{' || ch == '}' || ch == ',' || ch == '"'
+}
+
+var isElementChar = func(r rune) bool {
+	return r != '{' && r != '}' && r != ','
+}
+
+// gobbleString advances the parser for the remainder of the current string
+// until it sees a non-escaped termination character, as specified by
+// isTerminatingChar, returning the resulting string, not including the
+// termination character.
+func (p *parseState) gobbleString(isTerminatingChar func(ch byte) bool) (out string, err error) {
+	var result bytes.Buffer
+	start := 0
+	i := 0
+	for i < len(p.s) && !isTerminatingChar(p.s[i]) {
+		i++
+		// In these strings, we just encode directly the character following a
+		// '\', even if it would normally be an escape sequence.
+		if i < len(p.s) && p.s[i] == '\\' {
+			result.WriteString(p.s[start:i])
+			i++
+			if i < len(p.s) {
+				result.WriteByte(p.s[i])
+				i++
+			}
+			start = i
+		}
+	}
+	if i >= len(p.s) {
+		return "", malformedError
+	}
+	result.WriteString(p.s[start:i])
+	p.s = p.s[i:]
+	return result.String(), nil
+}
+
+type parseState struct {
+	s       string
+	evalCtx *EvalContext
+	result  *DArray
+	t       ColumnType
+}
+
+func (p *parseState) advance() {
+	_, l := utf8.DecodeRuneInString(p.s)
+	p.s = p.s[l:]
+}
+
+func (p *parseState) eatWhitespace() {
+	for unicode.IsSpace(p.peek()) {
+		p.advance()
+	}
+}
+
+func (p *parseState) peek() rune {
+	r, _ := utf8.DecodeRuneInString(p.s)
+	return r
+}
+
+func (p *parseState) eof() bool {
+	return len(p.s) == 0
+}
+
+func (p *parseState) parseQuotedString() (string, error) {
+	return p.gobbleString(isQuoteChar)
+}
+
+func (p *parseState) parseUnquotedString() (string, error) {
+	out, err := p.gobbleString(isControlChar)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func (p *parseState) parseElement() error {
+	var next string
+	var err error
+	r := p.peek()
+	switch r {
+	case '{':
+		return nestedArraysNotSupportedError
+	case '"':
+		p.advance()
+		next, err = p.parseQuotedString()
+		if err != nil {
+			return err
+		}
+		p.advance()
+	default:
+		if !isElementChar(r) {
+			return malformedError
+		}
+		next, err = p.parseUnquotedString()
+		if err != nil {
+			return err
+		}
+		if strings.EqualFold(next, "null") {
+			return p.result.Append(DNull)
+		}
+	}
+
+	d, err := performCast(p.evalCtx, NewDString(next), p.t)
+	if err != nil {
+		return err
+	}
+	return p.result.Append(d)
+}
+
+// ParseDArrayFromString parses the string-form of constructing arrays, handling
+// cases such as `'{1,2,3}'::INT[]`.
+func ParseDArrayFromString(evalCtx *EvalContext, s string, t ColumnType) (*DArray, error) {
+	parser := parseState{
+		s:       s,
+		evalCtx: evalCtx,
+		result:  NewDArray(CastTargetToDatumType(t)),
+		t:       t,
+	}
+
+	parser.eatWhitespace()
+	if parser.peek() != '{' {
+		return nil, enclosingError
+	}
+	parser.advance()
+	parser.eatWhitespace()
+	if parser.peek() != '}' {
+		if err := parser.parseElement(); err != nil {
+			return nil, err
+		}
+		parser.eatWhitespace()
+		for parser.peek() == ',' {
+			parser.advance()
+			parser.eatWhitespace()
+			if err := parser.parseElement(); err != nil {
+				return nil, err
+			}
+		}
+	}
+	parser.eatWhitespace()
+	if parser.eof() {
+		return nil, enclosingError
+	}
+	if parser.peek() != '}' {
+		return nil, malformedError
+	}
+	parser.advance()
+	parser.eatWhitespace()
+	if !parser.eof() {
+		return nil, extraTextError
+	}
+
+	return parser.result, nil
+}

--- a/pkg/sql/parser/parse_array_test.go
+++ b/pkg/sql/parser/parse_array_test.go
@@ -1,0 +1,120 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import "testing"
+
+func TestParseArray(t *testing.T) {
+	testData := []struct {
+		str      string
+		typ      ColumnType
+		expected Datums
+	}{
+		{`{}`, intColTypeInt, Datums{}},
+		{`{1}`, intColTypeInt, Datums{NewDInt(1)}},
+		{`{1,2}`, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
+		{`   { 1    ,  2  }  `, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
+		{`   { 1    ,
+			"2"  }  `, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
+		{`{1,2,3}`, intColTypeInt, Datums{NewDInt(1), NewDInt(2), NewDInt(3)}},
+		{`{"1"}`, intColTypeInt, Datums{NewDInt(1)}},
+		{` { "1" , "2"}`, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
+		{` { "1" , 2}`, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
+		{`{1,NULL}`, intColTypeInt, Datums{NewDInt(1), DNull}},
+
+		{`{hello}`, stringColTypeString, Datums{NewDString("hello")}},
+		{`{hel
+lo}`, stringColTypeString, Datums{NewDString("hel\nlo")}},
+		{`{hel,
+lo}`, stringColTypeString, Datums{NewDString("hel"), NewDString("lo")}},
+		{`{hel,lo}`, stringColTypeString, Datums{NewDString("hel"), NewDString("lo")}},
+		{`{  he llo  }`, stringColTypeString, Datums{NewDString("he llo")}},
+		{"{hello,\u1680world}", stringColTypeString, Datums{NewDString("hello"), NewDString("world")}},
+		{`{hell\\o}`, stringColTypeString, Datums{NewDString("hell\\o")}},
+		{`{"hell\\o"}`, stringColTypeString, Datums{NewDString("hell\\o")}},
+		{`{NULL,"NULL"}`, stringColTypeString, Datums{DNull, NewDString("NULL")}},
+		{`{"hello"}`, stringColTypeString, Datums{NewDString("hello")}},
+		{`{" hello "}`, stringColTypeString, Datums{NewDString(" hello ")}},
+		{`{"hel,lo"}`, stringColTypeString, Datums{NewDString("hel,lo")}},
+		{`{"hel\"lo"}`, stringColTypeString, Datums{NewDString("hel\"lo")}},
+		{`{"h\"el\"lo"}`, stringColTypeString, Datums{NewDString("h\"el\"lo")}},
+		{`{"hel\nlo"}`, stringColTypeString, Datums{NewDString("helnlo")}},
+		{`{"hel\\lo"}`, stringColTypeString, Datums{NewDString("hel\\lo")}},
+		{`{"he\,l\}l\{o"}`, stringColTypeString, Datums{NewDString("he,l}l{o")}},
+
+		{`{日本語}`, stringColTypeString, Datums{NewDString("日本語")}},
+
+		// This can generate some strings with invalid UTF-8, but this isn't a
+		// problem, since the input would have had to be invalid UTF-8 for that to
+		// occur.
+		{string([]byte{'{', 'a', 200, '}'}), stringColTypeString, Datums{NewDString("a\xc8")}},
+		{string([]byte{'{', 'a', 200, 'a', '}'}), stringColTypeString, Datums{NewDString("a\xc8a")}},
+	}
+	for _, td := range testData {
+		t.Run(td.str, func(t *testing.T) {
+			expected := NewDArray(CastTargetToDatumType(td.typ))
+			for _, d := range td.expected {
+				if err := expected.Append(d); err != nil {
+					t.Fatal(err)
+				}
+			}
+			actual, err := ParseDArrayFromString(NewTestingEvalContext(), td.str, td.typ)
+			if err != nil {
+				t.Fatalf("ARRAY %s: got error %s, expected %s", td.str, err.Error(), expected)
+			}
+			if actual.Compare(NewTestingEvalContext(), expected) != 0 {
+				t.Fatalf("ARRAY %s: got %s, expected %s", td.str, actual, expected)
+			}
+		})
+	}
+}
+
+func TestParseArrayError(t *testing.T) {
+	testData := []struct {
+		str           string
+		typ           ColumnType
+		expectedError string
+	}{
+		{"", intColTypeInt, "array must be enclosed in { and }"},
+		{"1", intColTypeInt, "array must be enclosed in { and }"},
+		{"1,2", intColTypeInt, "array must be enclosed in { and }"},
+		{"{1,2", intColTypeInt, "malformed array"},
+		{"{1,2,", intColTypeInt, "malformed array"},
+		{"{", intColTypeInt, "malformed array"},
+		{"{,}", intColTypeInt, "malformed array"},
+		{"{}{}", intColTypeInt, "extra text after closing right brace"},
+		{"{} {}", intColTypeInt, "extra text after closing right brace"},
+		{"{{}}", intColTypeInt, "nested arrays not supported"},
+		{"{1, {1}}", intColTypeInt, "nested arrays not supported"},
+		{"{hello}", intColTypeInt, `could not parse "hello" as type int: strconv.ParseInt: parsing "hello": invalid syntax`},
+		{"{\"hello}", stringColTypeString, `malformed array`},
+		// It might be unnecessary to disallow this, but Postgres does.
+		{"{he\"lo}", stringColTypeString, "malformed array"},
+
+		{string([]byte{200}), stringColTypeString, "array must be enclosed in { and }"},
+		{string([]byte{'{', 'a', 200}), stringColTypeString, "malformed array"},
+	}
+	for _, td := range testData {
+		t.Run(td.str, func(t *testing.T) {
+			_, err := ParseDArrayFromString(NewTestingEvalContext(), td.str, td.typ)
+			if err == nil {
+				t.Fatalf("expected %#v to error with message %#v", td.str, td.expectedError)
+			}
+			if err.Error() != td.expectedError {
+				t.Fatalf("ARRAY %s: got error %s, expected error %s", td.str, err.Error(), td.expectedError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #18419.

Support expressions like '{1,2,3}'::INT[], or '{abc,"xyz"}'::STRING[].

More testing, incl. fuzzing might be necessary.
I'm also iffy on the current ad-hoc construction of an EvalContext for
the purposes of having a location.