### PR TITLE
sql/sqlbase: improve performance of fk checks

### DIFF
--- a/pkg/sql/bench_test.go
+++ b/pkg/sql/bench_test.go
@@ -272,12 +272,56 @@ func runBenchmarkInsert(b *testing.B, db *gosql.DB, count int) {
 
 }
 
+// runBenchmarkInsertFK benchmarks inserting count rows into a table with a
+// present foreign key into another table.
+func runBenchmarkInsertFK(b *testing.B, db *gosql.DB, count int) {
+	defer func() {
+		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.insert`); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := db.Exec(`DROP TABLE IF EXISTS bench.fk`); err != nil {
+			b.Fatal(err)
+		}
+	}()
+
+	if _, err := db.Exec(`CREATE TABLE bench.fk (k INT PRIMARY KEY)`); err != nil {
+		b.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO bench.fk VALUES(1), (2), (3)`); err != nil {
+		b.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE bench.insert (k INT PRIMARY KEY, r INT, foreign key (r) references bench.fk(k))`); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	var buf bytes.Buffer
+	val := 0
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		buf.WriteString(`INSERT INTO bench.insert VALUES `)
+		for j := 0; j < count; j++ {
+			if j > 0 {
+				buf.WriteString(", ")
+			}
+			fmt.Fprintf(&buf, "(%d, 1)", val)
+			val++
+		}
+		if _, err := db.Exec(buf.String()); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+
+}
+
 func BenchmarkSQL(b *testing.B) {
 	forEachDB(b, func(b *testing.B, db *gosql.DB) {
 		for _, runFn := range []func(*testing.B, *gosql.DB, int){
 			runBenchmarkDelete,
 			runBenchmarkInsert,
 			runBenchmarkInsertDistinct,
+			runBenchmarkInsertFK,
 			runBenchmarkInterleavedSelect,
 			runBenchmarkTrackChoices,
 			runBenchmarkUpdate,

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -236,7 +236,6 @@ func (rf *RowFetcher) StartScanFrom(ctx context.Context, f kvFetcher) error {
 
 // NextKey retrieves the next key/value and sets kv/kvEnd. Returns whether a row
 // has been completed.
-// TODO(andrei): change to return error
 func (rf *RowFetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 	var ok bool
 


### PR DESCRIPTION
There's no need to read or decode the full found fk row, or even decode
the found fk key. It's sufficient to just report whether there was any
key found in the span the fk should be in.

```
name                                 old time/op  new time/op  delta
SQL/Cockroach/InsertFK/count=1-8      451µs ± 1%   448µs ± 3%    ~     (p=0.684 n=10+10)
SQL/Cockroach/InsertFK/count=10-8    1.42ms ± 1%  1.40ms ± 2%  -1.42%  (p=0.015 n=8+9)
SQL/Cockroach/InsertFK/count=100-8   10.6ms ± 3%  10.3ms ± 3%  -2.74%  (p=0.001 n=10+9)
SQL/Cockroach/InsertFK/count=1000-8   105ms ± 3%   102ms ± 2%  -2.38%  (p=0.001 n=10+10)
```

This isn't a huge gain, but the larger the rows on the foreign table are, and the more column families they have, the larger the gain will be.