### PR TITLE
sqlccl: batch items in/out of convertRecord channels

### DIFF
--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -716,7 +716,7 @@ func BenchmarkConvertRecord(b *testing.B) {
 		b.Fatal(err)
 	}
 	recordCh := make(chan csvRecord)
-	kvCh := make(chan roachpb.KeyValue)
+	kvCh := make(chan []roachpb.KeyValue)
 	group := errgroup.Group{}
 
 	// no-op drain kvs channel.


### PR DESCRIPTION
```
name             old time/op    new time/op    delta
ConvertRecord-8    10.4µs ± 6%     5.0µs ± 6%   -51.82%        (p=0.000 n=10+10)

name             old speed      new speed      delta
ConvertRecord-8  11.6MB/s ± 6%  24.0MB/s ± 6%  +107.50%        (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
ConvertRecord-8    1.83kB ± 0%    3.63kB ± 0%   +97.93%        (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
ConvertRecord-8      93.0 ± 0%      93.0 ± 0%      ~     (all samples are equal)
```