### PR TITLE
kv: ForkCtxSpan in lookupRangeDescriptorInternal

### DIFF
--- a/build/style_test.go
+++ b/build/style_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -551,6 +552,26 @@ func TestStyle(t *testing.T) {
 
 	t.Run("TestForbiddenImports", func(t *testing.T) {
 		t.Parallel()
+
+		// forbiddenImportPkg -> permittedReplacementPkg
+		forbiddenImports := map[string]string{
+			"context": "golang.org/x/net/context",
+			"log":     "util/log",
+			"path":    "path/filepath",
+			"github.com/golang/protobuf/proto": "github.com/gogo/protobuf/proto",
+			"github.com/satori/go.uuid":        "util/uuid",
+			"golang.org/x/sync/singleflight":   "github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight",
+		}
+
+		// grepBuf creates a grep string that matches any forbidden import pkgs.
+		var grepBuf bytes.Buffer
+		grepBuf.WriteByte('(')
+		for forbiddenPkg := range forbiddenImports {
+			grepBuf.WriteByte('|')
+			grepBuf.WriteString(regexp.QuoteMeta(forbiddenPkg))
+		}
+		grepBuf.WriteString(")$")
+
 		filter := stream.FilterFunc(func(arg stream.Arg) error {
 			for _, useAllFiles := range []bool{false, true} {
 				buildContext := build.Default
@@ -587,8 +608,8 @@ func TestStyle(t *testing.T) {
 			filter,
 			stream.Sort(),
 			stream.Uniq(),
+			stream.Grep(`^`+settingsPkgPrefix+`: | `+grepBuf.String()),
 			stream.GrepNot(`cockroach/pkg/cmd/`),
-			stream.Grep(`^`+settingsPkgPrefix+`: | (github\.com/golang/protobuf/proto|github\.com/satori/go\.uuid|log|path|context|syscall)$`),
 			stream.GrepNot(`cockroach/pkg/(cli|security): syscall$`),
 			stream.GrepNot(`cockroach/pkg/(base|security|util/(log|randutil|stop)): log$`),
 			stream.GrepNot(`cockroach/pkg/(server/serverpb|ts/tspb): github\.com/golang/protobuf/proto$`),
@@ -596,22 +617,21 @@ func TestStyle(t *testing.T) {
 			stream.GrepNot(`cockroach/pkg/ccl/storageccl: path$`),
 			stream.GrepNot(`cockroach/pkg/util/uuid: github\.com/satori/go\.uuid$`),
 		), func(s string) {
-			switch {
-			case strings.HasSuffix(s, " path"):
-				t.Errorf(`%s <- please use "path/filepath" instead of "path"`, s)
-			case strings.HasSuffix(s, " log"):
-				t.Errorf(`%s <- please use "util/log" instead of "log"`, s)
-			case strings.HasSuffix(s, " github.com/golang/protobuf/proto"):
-				t.Errorf(`%s <- please use "github.com/gogo/protobuf/proto" instead of "github.com/golang/protobuf/proto"`, s)
-			case strings.HasSuffix(s, " github.com/satori/go.uuid"):
-				t.Errorf(`%s <- please use "util/uuid" instead of "github.com/satori/go.uuid"`, s)
-			case strings.HasSuffix(s, " context"):
-				t.Errorf(`%s <- please use "golang.org/x/net/context" instead of "context"`, s)
-			case strings.HasSuffix(s, " syscall"):
-				t.Errorf(`%s <- please use "golang.org/x/sys" instead of "syscall"`, s)
-			case strings.HasPrefix(s, settingsPkgPrefix+": github.com/cockroachdb/cockroach"):
-				if !strings.HasSuffix(s, "testutils") && !strings.HasSuffix(s, "humanizeutil") &&
-					!strings.HasSuffix(s, settingsPkgPrefix) {
+			pkgStr := strings.Split(s, ": ")
+			importingPkg, importedPkg := pkgStr[0], pkgStr[1]
+
+			// Test that a disallowed package is not imported.
+			if replPkg, ok := forbiddenImports[importedPkg]; ok {
+				t.Errorf(`%s <- please use %q instead of %q`, s, replPkg, importedPkg)
+			}
+
+			// Test that the settings package does not import CRDB dependencies.
+			if importingPkg == settingsPkgPrefix && strings.HasPrefix(importedPkg, cockroachDB) {
+				switch {
+				case strings.HasSuffix(s, "testutils"):
+				case strings.HasSuffix(s, "humanizeutil"):
+				case strings.HasSuffix(s, settingsPkgPrefix):
+				default:
 					t.Errorf("%s <- please don't add CRDB dependencies to settings pkg", s)
 				}
 			}

--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -24,13 +24,13 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
-	"golang.org/x/sync/singleflight"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
 )
 
 // rangeCacheKey is the key type used to store and sort values in the

--- a/pkg/testutils/storageutils/mocking.go
+++ b/pkg/testutils/storageutils/mocking.go
@@ -86,7 +86,7 @@ func (c *ReplayProtectionFilterWrapper) run(args storagebase.FilterArgs) *roachp
 	// We use the singleflight.Group to coalesce replayed raft commands onto the
 	// same filter call. This allows concurrent access to the filter for
 	// different raft commands.
-	resC := c.inFlight.DoChan(mapKey.String(), func() (interface{}, error) {
+	resC, _ := c.inFlight.DoChan(mapKey.String(), func() (interface{}, error) {
 		pErr := c.filter(args)
 
 		c.Lock()

--- a/pkg/testutils/storageutils/mocking.go
+++ b/pkg/testutils/storageutils/mocking.go
@@ -17,11 +17,10 @@ package storageutils
 import (
 	"fmt"
 
-	"golang.org/x/sync/singleflight"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
 )
 
 // raftCmdIDAndIndex identifies a batch and a command within it.

--- a/pkg/util/syncutil/singleflight/singleflight.go
+++ b/pkg/util/syncutil/singleflight/singleflight.go
@@ -1,0 +1,119 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// call is an in-flight or completed singleflight.Do call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu syncutil.Mutex   // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group) Do(
+	key string, fn func() (interface{}, error),
+) (v interface{}, shared bool, err error) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+		return c.val, true, c.err
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.dups > 0, c.err
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+func (g *Group) DoChan(key string, fn func() (interface{}, error)) <-chan Result {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call{chans: []chan<- Result{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	g.mu.Lock()
+	delete(g.m, key)
+	for _, ch := range c.chans {
+		ch <- Result{c.val, c.err, c.dups > 0}
+	}
+	g.mu.Unlock()
+}
+
+var _ = (*Group).Forget
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group) Forget(key string) {
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+}

--- a/pkg/util/syncutil/singleflight/singleflight_test.go
+++ b/pkg/util/syncutil/singleflight/singleflight_test.go
@@ -1,0 +1,87 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package singleflight
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDo(t *testing.T) {
+	var g Group
+	v, _, err := g.Do("key", func() (interface{}, error) {
+		return "bar", nil
+	})
+	if got, want := fmt.Sprintf("%v (%T)", v, v), "bar (string)"; got != want {
+		t.Errorf("Do = %v; want %v", got, want)
+	}
+	if err != nil {
+		t.Errorf("Do error = %v", err)
+	}
+}
+
+func TestDoErr(t *testing.T) {
+	var g Group
+	someErr := errors.New("Some error")
+	v, _, err := g.Do("key", func() (interface{}, error) {
+		return nil, someErr
+	})
+	if err != someErr {
+		t.Errorf("Do error = %v; want someErr %v", err, someErr)
+	}
+	if v != nil {
+		t.Errorf("unexpected non-nil value %#v", v)
+	}
+}
+
+func TestDoDupSuppress(t *testing.T) {
+	var g Group
+	var wg1, wg2 sync.WaitGroup
+	c := make(chan string, 1)
+	var calls int32
+	fn := func() (interface{}, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			// First invocation.
+			wg1.Done()
+		}
+		v := <-c
+		c <- v // pump; make available for any future calls
+
+		time.Sleep(10 * time.Millisecond) // let more goroutines enter Do
+
+		return v, nil
+	}
+
+	const n = 10
+	wg1.Add(1)
+	for i := 0; i < n; i++ {
+		wg1.Add(1)
+		wg2.Add(1)
+		go func() {
+			defer wg2.Done()
+			wg1.Done()
+			v, _, err := g.Do("key", fn)
+			if err != nil {
+				t.Errorf("Do error: %v", err)
+				return
+			}
+			if s, _ := v.(string); s != "bar" {
+				t.Errorf("Do = %T %v; want %q", v, v, "bar")
+			}
+		}()
+	}
+	wg1.Wait()
+	// At least one goroutine is in fn now and all of them have at
+	// least reached the line before the Do.
+	c <- "bar"
+	wg2.Wait()
+	if got := atomic.LoadInt32(&calls); got <= 0 || got >= n {
+		t.Errorf("number of calls = %d; want over 0 and less than %d", got, n)
+	}
+}


### PR DESCRIPTION
This change addresses a TODO in `lookupRangeDescriptorInternal` introduced
in #18197. We now simply fork the `ContextSpan` in `lookupRequests.DoChan`
as the leader of the coalesced `RangeLookupRequest`. This is permitted because
we no longer listen to context cancellation outside of `DoChan` as the lookup
leader. Instead, we guarantee that context cancellations are propagated
over the singleflight result channel, which assures that
`lookupRangeDescriptorInternal` never returns before `DoChan`. This
means that the parent span can never close before the child span is
forked, which was the issue that prompted the TODO.

We are able to do this because we now return whether a given call to
`DoChan` will lead a `Group` or not. In doing so, we also improve the
testing of `singleflight.Group`.

This, in turn, is all possible because the first two commits in this change
fork singleflight from `golang.org/x/sync/singleflight`.

cc. @petermattis @bdarnell who may remember why this TODO was introduced
in the first place.