### PR TITLE
sql: plumb traceKV into kvfetcher for scans

### DIFF
--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -186,7 +186,7 @@ func (cb *columnBackfiller) runChunk(
 		// populated and deleted by the OLTP commands but not otherwise
 		// read or used
 		if err := cb.fetcher.StartScan(
-			ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, chunkSize,
+			ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, chunkSize, false, /* traceKV */
 		); err != nil {
 			log.Errorf(ctx, "scan error: %s", err)
 			return err

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -144,7 +144,7 @@ func (ib *indexBackfiller) runChunk(
 		// populated and deleted by the OLTP commands but not otherwise
 		// read or used
 		if err := ib.fetcher.StartScan(
-			ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, chunkSize,
+			ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, chunkSize, false, /* traceKV */
 		); err != nil {
 			log.Errorf(ctx, "scan error: %s", err)
 			return nil, err

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -157,7 +157,7 @@ func (jr *joinReader) mainLoop(ctx context.Context) error {
 			})
 		}
 
-		err := jr.fetcher.StartScan(ctx, txn, spans, false /* no batch limits */, 0)
+		err := jr.fetcher.StartScan(ctx, txn, spans, false /* no batch limits */, 0, false /* traceKV */)
 		if err != nil {
 			log.Errorf(ctx, "scan error: %s", err)
 			return err

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -193,7 +193,7 @@ func (tr *tableReader) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 
 	if err := tr.fetcher.StartScan(
-		ctx, txn, tr.spans, true /* limit batches */, tr.limitHint,
+		ctx, txn, tr.spans, true /* limit batches */, tr.limitHint, false, /* traceKV */
 	); err != nil {
 		log.Errorf(ctx, "scan error: %s", err)
 		tr.out.output.Push(nil /* row */, ProducerMetadata{Err: err})

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -173,6 +173,7 @@ query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,3)]
 ----
 (0,2)  consuming rows    output row: []
+(0,0)  sql txn implicit  Scan /Table/52/1/{2-3}
 (0,0)  sql txn implicit  querying next range at /Table/52/1/2
 (0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
 (0,0)  sql txn implicit  CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/3
@@ -184,6 +185,7 @@ query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
 (0,2)  consuming rows    output row: []
+(0,0)  sql txn implicit  Scan /Table/52/1/{1-2}
 (0,0)  sql txn implicit  querying next range at /Table/52/1/1
 (0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
 (0,0)  sql txn implicit  fetched: /kv/primary/1/v -> /2
@@ -195,6 +197,7 @@ query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,2)]
 ----
 (0,2)  consuming rows    output row: []
+(0,0)  sql txn implicit  Scan /Table/52/1/{2-3}
 (0,0)  sql txn implicit  querying next range at /Table/52/1/2
 (0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
 (0,0)  sql txn implicit  fetched: /kv/primary/2/v -> /3
@@ -230,6 +233,7 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 
 (0,1)  starting plan  querying next range at /Table/3/1/1/2/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
 (0,1)  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+(0,1)  starting plan  Scan /Table/52/{1-2}
 (0,1)  starting plan  querying next range at /Table/52/1
 (0,1)  starting plan  r1: sending batch 1 Scan to (n1,s1):1
 (0,1)  starting plan  fetched: /kv/primary/1/v -> /2
@@ -243,6 +247,7 @@ query TTT
 SELECT span, operation, regexp_replace(message, '\d\d\d\d\d+', '...PK...') as message
   FROM [SHOW KV TRACE FOR UPDATE t.kv2 SET v = v + 2]
 ----
+(0,0)  sql txn implicit  Scan /Table/53/{1-2}
 (0,0)  sql txn implicit  querying next range at /Table/53/1
 (0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
 (0,0)  sql txn implicit  fetched: /kv2/primary/...PK.../k/v -> /1/2
@@ -257,6 +262,7 @@ SELECT span, operation, regexp_replace(message, '\d\d\d\d\d+', '...PK...') as me
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv2]
 ----
+(0,1)  starting plan   Scan /Table/53/{1-2}
 (0,1)  starting plan   querying next range at /Table/53/1
 (0,1)  starting plan   r1: sending batch 1 Scan to (n1,s1):1
 (0,1)  starting plan   DelRange /Table/53/1 - /Table/53/2
@@ -286,6 +292,7 @@ SELECT span, operation, regexp_replace(message, 'wall_time:\d+', 'wall_time:...'
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv]
 ----
+(0,0)  sql txn implicit  Scan /Table/52/{1-2}
 (0,0)  sql txn implicit  querying next range at /Table/52/1
 (0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
 (0,0)  sql txn implicit  fetched: /kv/primary/1/v -> /2

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -135,7 +135,7 @@ func (n *scanNode) Close(context.Context) {
 // initScan sets up the rowFetcher and starts a scan.
 func (n *scanNode) initScan(ctx context.Context) error {
 	limitHint := n.limitHint()
-	if err := n.fetcher.StartScan(ctx, n.p.txn, n.spans, !n.disableBatchLimits, limitHint); err != nil {
+	if err := n.fetcher.StartScan(ctx, n.p.txn, n.spans, !n.disableBatchLimits, limitHint, n.p.session.Tracing.KVTracingEnabled()); err != nil {
 		return err
 	}
 	n.scanInitialized = true

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -275,6 +275,8 @@ func ConvertBatchError(ctx context.Context, tableDesc *TableDescriptor, b *clien
 			return err
 		}
 		f := singleKVFetcher{kv: client.KeyValue{Key: key, Value: cErr.ActualValue}}
+		// Use the RowFetcher to decode the single kv pair above by passing in
+		// this singleKVFetcher implementation, which doesn't actually hit KV.
 		if err := rf.StartScanFrom(ctx, &f); err != nil {
 			return err
 		}

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // TableLookupsByID maps table IDs to looked up descriptors or, for tables that
@@ -359,10 +358,7 @@ func (f baseFKHelper) check(ctx context.Context, values parser.Datums, traceKV b
 	if err != nil {
 		return false, err
 	}
-	if traceKV {
-		log.VEventf(ctx, 2, "Scan %s -> %s", span.Key, span.EndKey)
-	}
-	err = f.rf.StartScan(ctx, f.txn, roachpb.Spans{span}, true /* limit batches */, 1)
+	err = f.rf.StartScan(ctx, f.txn, roachpb.Spans{span}, true /* limit batches */, 1, traceKV)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -199,7 +199,12 @@ func (rf *RowFetcher) Init(
 // StartScan initializes and starts the key-value scan. Can be used multiple
 // times.
 func (rf *RowFetcher) StartScan(
-	ctx context.Context, txn *client.Txn, spans roachpb.Spans, limitBatches bool, limitHint int64,
+	ctx context.Context,
+	txn *client.Txn,
+	spans roachpb.Spans,
+	limitBatches bool,
+	limitHint int64,
+	traceKV bool,
 ) error {
 	if len(spans) == 0 {
 		panic("no spans")
@@ -217,7 +222,7 @@ func (rf *RowFetcher) StartScan(
 		firstBatchLimit++
 	}
 
-	f, err := makeKVFetcher(txn, spans, rf.reverse, limitBatches, firstBatchLimit, rf.returnRangeInfo)
+	f, err := makeKVFetcher(txn, spans, rf.reverse, limitBatches, firstBatchLimit, rf.returnRangeInfo, traceKV)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -575,7 +575,7 @@ func (tu *tableUpserter) fetchExisting(ctx context.Context, traceKV bool) ([]par
 	}
 
 	// We don't limit batches here because the spans are unordered.
-	if err := tu.fetcher.StartScan(ctx, tu.txn, pkSpans, false /* no batch limits */, 0); err != nil {
+	if err := tu.fetcher.StartScan(ctx, tu.txn, pkSpans, false /* no batch limits */, 0, traceKV); err != nil {
 		return nil, err
 	}
 
@@ -820,7 +820,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 	if err != nil {
 		return resume, err
 	}
-	if err := rf.StartScan(ctx, td.txn, roachpb.Spans{resume}, true /* limit batches */, 0); err != nil {
+	if err := rf.StartScan(ctx, td.txn, roachpb.Spans{resume}, true /* limit batches */, 0, traceKV); err != nil {
 		return resume, err
 	}
 
@@ -908,7 +908,7 @@ func (td *tableDeleter) deleteIndexScan(
 	if err != nil {
 		return resume, err
 	}
-	if err := rf.StartScan(ctx, td.txn, roachpb.Spans{resume}, true /* limit batches */, 0); err != nil {
+	if err := rf.StartScan(ctx, td.txn, roachpb.Spans{resume}, true /* limit batches */, 0, traceKV); err != nil {
 		return resume, err
 	}
 


### PR DESCRIPTION
This commit plumbs traceKV into the kvfetcher and adds a new kv trace
output that describes a scan which is about to be performed, such as:

`Scan /Table/52/{1-2}`

This is useful to see because the row fetcher by itself currently only
shows the fetched rows, but not the span it is iterating over.