### PR TITLE
sql: add pg_catalog.pg_get_viewdef

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1592,6 +1592,42 @@ CREATE INDEX pg_indexdef_idx ON test.pg_indexdef_test (a ASC)
 query error pq: unknown signature: pg_get_indexdef\(int, int, bool\)
 SELECT pg_catalog.pg_get_indexdef(0, 0, true)
 
+query T
+SELECT pg_catalog.pg_get_viewdef(0)
+----
+NULL
+
+statement ok
+CREATE TABLE test.pg_viewdef_test (a int, b int, c int)
+
+statement ok
+CREATE VIEW test.pg_viewdef_view AS SELECT a, b FROM test.pg_viewdef_test
+
+query T
+SELECT pg_catalog.pg_get_viewdef('pg_viewdef_view'::regclass::oid)
+----
+SELECT a, b FROM test.pg_viewdef_test
+
+query T
+SELECT pg_catalog.pg_get_viewdef(0, true)
+----
+NULL
+
+query T
+SELECT pg_catalog.pg_get_viewdef(0, false)
+----
+NULL
+
+query T
+SELECT pg_catalog.pg_get_viewdef('pg_viewdef_view'::regclass::oid, true)
+----
+SELECT a, b FROM test.pg_viewdef_test
+
+query T
+SELECT pg_catalog.pg_get_viewdef('pg_viewdef_view'::regclass::oid, false)
+----
+SELECT a, b FROM test.pg_viewdef_test
+
 # These functions always return NULL since we don't support comments.
 query TTTT
 SELECT col_description('pg_class'::regclass::oid, 2),


### PR DESCRIPTION
@jordanlewis I wasn't able to re-use the SHOW CREATE VIEW code as it actually returns a different format than PostgreSQL pg_get_viewdef. Thus, I had to extract it from the pg_catalog.pg_views table.  Let me know if the SHOW CREATE VIEW format is indeed okay for this purpose in Cockroach and I can easily modify it to leverage that.  Also I couldn't tell the difference on the overloaded function with the boolean when setting up some fake data in PostgreSQL 9.6.  If you have a good example where true and false would yield different outputs I can update that portion of the PR as well. Thanks!