### PR TITLE
storage/engine: optimize MVCCFindSplitKey

### DIFF
--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -80,6 +80,14 @@ func BenchmarkMVCCComputeStats_RocksDB(b *testing.B) {
 	}
 }
 
+func BenchmarkMVCCFindSplitKey_RocksDB(b *testing.B) {
+	for _, valueSize := range []int{32} {
+		b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+			runMVCCFindSplitKey(setupMVCCRocksDB, valueSize, b)
+		})
+	}
+}
+
 func BenchmarkIterOnBatch_RocksDB(b *testing.B) {
 	for _, writes := range []int{10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("writes=%d", writes), func(b *testing.B) {

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -23,7 +23,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/dustin/go-humanize"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 
@@ -2292,12 +2291,7 @@ func IsValidSplitKey(key roachpb.Key) bool {
 // debugFn, if not nil, is used to print informational log messages about
 // the key finding process.
 func MVCCFindSplitKey(
-	ctx context.Context,
-	engine Reader,
-	rangeID roachpb.RangeID,
-	key,
-	endKey roachpb.RKey,
-	targetSize int64,
+	ctx context.Context, engine Reader, key, endKey roachpb.RKey, targetSize int64,
 ) (roachpb.Key, error) {
 	if key.Less(roachpb.RKey(keys.LocalMax)) {
 		key = roachpb.RKey(keys.LocalMax)
@@ -2306,33 +2300,29 @@ func MVCCFindSplitKey(
 	encStartKey := MakeMVCCMetadataKey(key.AsRawKey())
 	encEndKey := MakeMVCCMetadataKey(endKey.AsRawKey())
 
-	if log.V(2) {
-		log.Infof(ctx, "searching split key for %d [%s, %s)", rangeID, key, endKey)
-	}
-
-	// Get range size from stats.
-	ms, err := MVCCGetRangeStats(ctx, engine, rangeID)
-	if err != nil {
-		return nil, err
-	}
-
-	rangeSize := ms.KeyBytes + ms.ValBytes
-	if log.V(2) {
-		log.Infof(ctx, "range size: %s, targetSize %s",
-			humanize.IBytes(uint64(rangeSize)), humanize.IBytes(uint64(targetSize)))
-	}
-
 	sizeSoFar := int64(0)
 	bestSplitKey := encStartKey
 	bestSplitDiff := int64(math.MaxInt64)
 	var lastKey roachpb.Key
+	var lastKeyBuf []byte
+	var bestSplitKeyBuf []byte
 	var n int
 
-	if err := engine.Iterate(encStartKey, encEndKey, func(kv MVCCKeyValue) (bool, error) {
+	it := engine.NewIterator(false /* prefix */)
+	defer it.Close()
+
+	for it.Seek(encStartKey); ; it.Next() {
+		if ok, err := it.Valid(); err != nil {
+			return nil, err
+		} else if !ok || !it.Less(encEndKey) {
+			break
+		}
+		unsafeKey := it.UnsafeKey()
+
 		n++
 		// Is key within a legal key range? Note that we never choose the first key
 		// as the split key.
-		valid := n > 1 && IsValidSplitKey(kv.Key.Key)
+		valid := n > 1 && IsValidSplitKey(unsafeKey.Key)
 
 		// Determine if this key would make a better split than last "best" key.
 		diff := targetSize - sizeSoFar
@@ -2341,29 +2331,30 @@ func MVCCFindSplitKey(
 		}
 		if valid && diff < bestSplitDiff {
 			if log.V(2) {
-				log.Infof(ctx, "better split: diff %d at %s", diff, kv.Key)
+				log.Infof(ctx, "better split: diff %d at %s", diff, unsafeKey)
 			}
-			bestSplitKey = kv.Key
+			bestSplitKey = unsafeKey
+			bestSplitKey.Key = append(bestSplitKeyBuf, bestSplitKey.Key...)
+			bestSplitKeyBuf = bestSplitKey.Key[:0]
 			bestSplitDiff = diff
 		}
 
 		// Determine whether we've found best key and can exit iteration.
-		done := !bestSplitKey.Key.Equal(encStartKey.Key) && diff > bestSplitDiff
-		if done && log.V(2) {
-			log.Infof(ctx, "target size reached")
+		if !bestSplitKey.Key.Equal(encStartKey.Key) && diff > bestSplitDiff {
+			if log.V(2) {
+				log.Infof(ctx, "target size reached")
+			}
+			break
 		}
 
 		// Add this key/value to the size scanned so far.
-		if kv.Key.IsValue() && bytes.Equal(kv.Key.Key, lastKey) {
-			sizeSoFar += mvccVersionTimestampSize + int64(len(kv.Value))
+		if unsafeKey.IsValue() && bytes.Equal(unsafeKey.Key, lastKey) {
+			sizeSoFar += mvccVersionTimestampSize + int64(len(it.UnsafeValue()))
 		} else {
-			sizeSoFar += int64(kv.Key.EncodedSize() + len(kv.Value))
+			sizeSoFar += int64(unsafeKey.EncodedSize() + len(it.UnsafeValue()))
 		}
-		lastKey = kv.Key.Key
-
-		return done, nil
-	}); err != nil {
-		return nil, err
+		lastKey = append(lastKeyBuf, unsafeKey.Key...)
+		lastKeyBuf = lastKey[:0]
 	}
 
 	if bestSplitKey.Key.Equal(encStartKey.Key) {

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2660,12 +2660,10 @@ func (r *Replica) adminSplitWithDescriptor(
 		var foundSplitKey roachpb.Key
 		if len(args.SplitKey) == 0 {
 			// Find a key to split by size.
-			snap := r.store.engine.NewSnapshot()
-			defer snap.Close()
 			var err error
 			targetSize := r.GetMaxBytes() / 2
 			foundSplitKey, err = engine.MVCCFindSplitKey(
-				ctx, snap, desc.RangeID, desc.StartKey, desc.EndKey, targetSize)
+				ctx, r.store.engine, desc.StartKey, desc.EndKey, targetSize)
 			if err != nil {
 				return reply, false, roachpb.NewErrorf("unable to determine split key: %s", err)
 			}


### PR DESCRIPTION
Use an explicit iterator instead of Reader.Iterate() in order to reduce
allocations. Specifically, we can avoid 2 allocations per key/value.

Do not create a snapshot when calling MVCCFindSplitKey as internally it
uses a single iterator which has an implicit snapshot.

Remove the unused rangeID parameter to MVCCFindSplitKey. This parameter
was only being used to lookup the range stats to log them under V(2).

```
name                                     old time/op    new time/op    delta
MVCCFindSplitKey_RocksDB/valueSize=32-8     341ms ±23%     269ms ± 8%   -21.29%  (p=0.000 n=10+10)

name                                     old speed      new speed      delta
MVCCFindSplitKey_RocksDB/valueSize=32-8   198MB/s ±19%   250MB/s ± 8%   +26.34%  (p=0.000 n=10+10)

name                                     old alloc/op   new alloc/op   delta
MVCCFindSplitKey_RocksDB/valueSize=32-8    36.6MB ± 0%     0.0MB ± 0%  -100.00%  (p=0.000 n=9+10)

name                                     old allocs/op  new allocs/op  delta
MVCCFindSplitKey_RocksDB/valueSize=32-8     1.16M ± 0%     0.00M ± 0%  -100.00%  (p=0.000 n=9+10)
```

See #18646