### PR TITLE
distsql: don't plan on nodes that are not part of gossip

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -242,6 +242,13 @@ type Gossip struct {
 // The higher level manages the NodeIDContainer instance (which can be shared by
 // various server components). The ambient context is expected to already
 // contain the node ID.
+//
+// grpcServer: The server on which the new Gossip instance will register its RPC
+//   service. Can be nil, in which case the Gossip will not register the
+//   service.
+// rpcContext: The context used to connect to other nodes. Can be nil for tests
+//   that also specify a nil grpcServer and that plan on using the Gossip in a
+//   restricted way by populating it with data manually.
 func New(
 	ambient log.AmbientContext,
 	nodeID *base.NodeIDContainer,
@@ -281,12 +288,21 @@ func New(
 	g.mu.is.registerCallback(MakePrefixPattern(KeyStorePrefix), g.updateStoreMap)
 	g.mu.Unlock()
 
-	RegisterGossipServer(grpcServer, g.server)
+	if grpcServer != nil {
+		RegisterGossipServer(grpcServer, g.server)
+	}
 	return g
 }
 
 // NewTest is a simplified wrapper around New that creates the NodeIDContainer
 // internally. Used for testing.
+//
+// grpcServer: The server on which the new Gossip instance will register its RPC
+//   service. Can be nil, in which case the Gossip will not register the
+//   service.
+// rpcContext: The context used to connect to other nodes. Can be nil for tests
+//   that also specify a nil grpcServer and that plan on using the Gossip in a
+//   restricted way by populating it with data manually.
 func NewTest(
 	nodeID roachpb.NodeID,
 	rpcContext *rpc.Context,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -531,20 +531,36 @@ func (dsp *distSQLPlanner) partitionSpans(
 				addr, inAddrMap := planCtx.nodeAddresses[nodeID]
 				if !inAddrMap {
 					addr = replInfo.NodeDesc.Address.String()
-					var err error
-					if dsp.testingKnobs.OverrideHealthCheck != nil {
-						err = dsp.testingKnobs.OverrideHealthCheck(replInfo.NodeDesc.NodeID, addr)
-					} else {
-						err = dsp.rpcContext.ConnHealth(addr)
+					checkNodeHealth := func() error {
+						// Check if the node is still in gossip - i.e. if it hasn't been
+						// decommissioned or overridden by another node at the same address.
+						if _, err := dsp.gossip.GetNodeIDAddress(nodeID); err != nil {
+							log.VEventf(ctx, 1, "not using n%d because gossip doesn't know about it. "+
+								"It might have gone away from the cluster. Gossip said: %s.", nodeID, err)
+							return err
+						}
+
+						var err error
+						if dsp.testingKnobs.OverrideHealthCheck != nil {
+							err = dsp.testingKnobs.OverrideHealthCheck(replInfo.NodeDesc.NodeID, addr)
+						} else {
+							err = dsp.rpcContext.ConnHealth(addr)
+						}
+						if err != nil && err != rpc.ErrNotConnected && err != rpc.ErrNotHeartbeated {
+							// This host is known to be unhealthy. Don't use it (use the gateway
+							// instead). Note: this can never happen for our nodeID (which
+							// always has its address in the nodeMap).
+							log.VEventf(ctx, 1, "marking n%d as unhealthy for this plan: %v", nodeID, err)
+							return err
+						}
+						return nil
 					}
-					if err != nil && err != rpc.ErrNotConnected && err != rpc.ErrNotHeartbeated {
-						// This host is known to be unhealthy. Don't use it (use the gateway
-						// instead). Note: this can never happen for our nodeID (which
-						// always has its address in the nodeMap).
+					if err := checkNodeHealth(); err != nil {
 						addr = ""
-						log.VEventf(ctx, 1, "marking node %d as unhealthy for this plan: %v", nodeID, err)
 					}
-					planCtx.nodeAddresses[nodeID] = addr
+					if err == nil && addr != "" {
+						planCtx.nodeAddresses[nodeID] = addr
+					}
 				}
 				compat := true
 				if addr != "" {
@@ -603,15 +619,8 @@ func (dsp *distSQLPlanner) nodeVersionIsCompatible(
 	nodeID roachpb.NodeID, planVer distsqlrun.DistSQLVersion,
 ) bool {
 	var v distsqlrun.DistSQLVersionGossipInfo
-	if hook := dsp.testingKnobs.OverrideDistSQLVersionCheck; hook != nil {
-		var err error
-		if v, err = hook(nodeID); err != nil {
-			return false
-		}
-	} else {
-		if err := dsp.gossip.GetInfoProto(gossip.MakeDistSQLNodeVersionKey(nodeID), &v); err != nil {
-			return false
-		}
+	if err := dsp.gossip.GetInfoProto(gossip.MakeDistSQLNodeVersionKey(nodeID), &v); err != nil {
+		return false
 	}
 	return distsqlrun.FlowVerIsCompatible(dsp.planVersion, v.MinAcceptedVersion, v.Version)
 }

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -546,7 +546,7 @@ func (dsp *distSQLPlanner) partitionSpans(
 					}
 					planCtx.nodeAddresses[nodeID] = addr
 				}
-				var compat bool
+				compat := true
 				if addr != "" {
 					// Check if the node's DistSQL version is compatible with this plan.
 					// If it isn't, we'll use the gateway.

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
@@ -718,21 +719,45 @@ func TestPartitionSpans(t *testing.T) {
 		},
 	}
 
+	// We need a mock Gossip to contain addresses for the nodes. Otherwise the
+	// distSQLPlanner will not plan flows on them.
+	testStopper := stop.NewStopper()
+	defer testStopper.Stop(context.TODO())
+	mockGossip := gossip.NewTest(roachpb.NodeID(1), nil /* rpcContext */, nil, /* grpcServer */
+		testStopper, metric.NewRegistry())
+	var nodeDescs []*roachpb.NodeDescriptor
+	for i := 1; i <= 10; i++ {
+		nodeID := roachpb.NodeID(i)
+		desc := &roachpb.NodeDescriptor{
+			NodeID:  nodeID,
+			Address: util.UnresolvedAddr{AddressField: fmt.Sprintf("addr%d", i)},
+		}
+		if err := mockGossip.SetNodeDescriptor(desc); err != nil {
+			t.Fatal(err)
+		}
+		if err := mockGossip.AddInfoProto(
+			gossip.MakeDistSQLNodeVersionKey(nodeID),
+			&distsqlrun.DistSQLVersionGossipInfo{
+				MinAcceptedVersion: distsqlrun.MinAcceptedVersion,
+				Version:            distsqlrun.Version,
+			},
+			0, // ttl - no expiration
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		nodeDescs = append(nodeDescs, desc)
+	}
+
 	for testIdx, tc := range testCases {
 		t.Run(strconv.Itoa(testIdx), func(t *testing.T) {
 			stopper := stop.NewStopper()
 			defer stopper.Stop(context.TODO())
 
-			tsp := &testSpanResolver{}
-			for i := 1; i <= 10; i++ {
-				tsp.nodes = append(tsp.nodes, &roachpb.NodeDescriptor{
-					NodeID: roachpb.NodeID(i),
-					Address: util.UnresolvedAddr{
-						AddressField: fmt.Sprintf("addr%d", i),
-					},
-				})
+			tsp := &testSpanResolver{
+				nodes:  nodeDescs,
+				ranges: tc.ranges,
 			}
-			tsp.ranges = tc.ranges
 
 			dsp := distSQLPlanner{
 				planVersion:  distsqlrun.Version,
@@ -740,6 +765,7 @@ func TestPartitionSpans(t *testing.T) {
 				nodeDesc:     *tsp.nodes[tc.gatewayNode-1],
 				stopper:      stopper,
 				spanResolver: tsp,
+				gossip:       mockGossip,
 				testingKnobs: DistSQLPlannerTestingKnobs{
 					OverrideHealthCheck: func(node roachpb.NodeID, addr string) error {
 						for _, n := range tc.deadNodes {
@@ -748,15 +774,6 @@ func TestPartitionSpans(t *testing.T) {
 							}
 						}
 						return nil
-					},
-					OverrideDistSQLVersionCheck: func(
-						node roachpb.NodeID) (distsqlrun.DistSQLVersionGossipInfo, error,
-					) {
-						// Accept any version.
-						return distsqlrun.DistSQLVersionGossipInfo{
-							MinAcceptedVersion: 0,
-							Version:            1000000,
-						}, nil
 					},
 				},
 			}
@@ -814,9 +831,10 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 		// The versions accepted by each node.
 		nodeVersions map[roachpb.NodeID]distsqlrun.DistSQLVersionGossipInfo
 
-		// nodesNotInGossip is the set of nodes for which we're going to pretend
-		// that gossip returns an error when queried about the DistSQL version.
-		nodesNotInGossip map[roachpb.NodeID]struct{}
+		// nodesNotAdvertisingDistSQLVersion is the set of nodes for which gossip is
+		// not going to have information about the supported DistSQL version. This
+		// is to simulate CRDB 1.0 nodes which don't advertise this information.
+		nodesNotAdvertisingDistSQLVersion map[roachpb.NodeID]struct{}
 
 		// expected result: a map of node to list of spans.
 		partitions map[roachpb.NodeID][][2]string
@@ -871,7 +889,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 					Version:            3,
 				},
 			},
-			nodesNotInGossip: map[roachpb.NodeID]struct{}{
+			nodesNotAdvertisingDistSQLVersion: map[roachpb.NodeID]struct{}{
 				1: {},
 			},
 			partitions: map[roachpb.NodeID][][2]string{
@@ -879,22 +897,47 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
 			stopper := stop.NewStopper()
 			defer stopper.Stop(context.TODO())
 
-			tsp := &testSpanResolver{}
+			// We need a mock Gossip to contain addresses for the nodes. Otherwise the
+			// distSQLPlanner will not plan flows on them. This Gossip will also
+			// reflect tc.nodesNotAdvertisingDistSQLVersion.
+			testStopper := stop.NewStopper()
+			defer testStopper.Stop(context.TODO())
+			mockGossip := gossip.NewTest(roachpb.NodeID(1), nil /* rpcContext */, nil, /* grpcServer */
+				testStopper, metric.NewRegistry())
+			var nodeDescs []*roachpb.NodeDescriptor
 			for i := 1; i <= 2; i++ {
-				tsp.nodes = append(tsp.nodes, &roachpb.NodeDescriptor{
-					NodeID: roachpb.NodeID(i),
-					Address: util.UnresolvedAddr{
-						AddressField: fmt.Sprintf("addr%d", i),
-					},
-				})
+				nodeID := roachpb.NodeID(i)
+				desc := &roachpb.NodeDescriptor{
+					NodeID:  nodeID,
+					Address: util.UnresolvedAddr{AddressField: fmt.Sprintf("addr%d", i)},
+				}
+				if err := mockGossip.SetNodeDescriptor(desc); err != nil {
+					t.Fatal(err)
+				}
+				if _, ok := tc.nodesNotAdvertisingDistSQLVersion[nodeID]; !ok {
+					verInfo := tc.nodeVersions[nodeID]
+					if err := mockGossip.AddInfoProto(
+						gossip.MakeDistSQLNodeVersionKey(nodeID),
+						&verInfo,
+						0, // ttl - no expiration
+					); err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				nodeDescs = append(nodeDescs, desc)
 			}
-			tsp.ranges = ranges
+			tsp := &testSpanResolver{
+				nodes:  nodeDescs,
+				ranges: ranges,
+			}
 
 			dsp := distSQLPlanner{
 				planVersion:  tc.planVersion,
@@ -902,19 +945,11 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				nodeDesc:     *tsp.nodes[gatewayNode-1],
 				stopper:      stopper,
 				spanResolver: tsp,
+				gossip:       mockGossip,
 				testingKnobs: DistSQLPlannerTestingKnobs{
 					OverrideHealthCheck: func(node roachpb.NodeID, addr string) error {
 						// All the nodes are healthy.
 						return nil
-					},
-					OverrideDistSQLVersionCheck: func(
-						nodeID roachpb.NodeID) (distsqlrun.DistSQLVersionGossipInfo, error,
-					) {
-						if _, ok := tc.nodesNotInGossip[nodeID]; ok {
-							return distsqlrun.DistSQLVersionGossipInfo{},
-								gossip.NewKeyNotPresentError(gossip.MakeDistSQLNodeVersionKey(nodeID))
-						}
-						return tc.nodeVersions[nodeID], nil
 					},
 				},
 			}
@@ -941,5 +976,98 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				t.Errorf("expected partitions:\n  %v\ngot:\n  %v", tc.partitions, resMap)
 			}
 		})
+	}
+}
+
+// Test that a node whose descriptor info is not accessible through gossip is
+// not used. This is to simulate nodes that have been decomisioned and also
+// nodes that have been "replaced" by another node at the same address (which, I
+// guess, is also a type of decomissioning).
+func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// The spans that we're going to plan for.
+	span := roachpb.Span{Key: roachpb.Key("A"), EndKey: roachpb.Key("Z")}
+	gatewayNode := roachpb.NodeID(2)
+	ranges := []testSpanResolverRange{{"A", 1}, {"B", 2}, {"C", 1}}
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+
+	mockGossip := gossip.NewTest(roachpb.NodeID(1), nil /* rpcContext */, nil, /* grpcServer */
+		stopper, metric.NewRegistry())
+	var nodeDescs []*roachpb.NodeDescriptor
+	for i := 1; i <= 2; i++ {
+		nodeID := roachpb.NodeID(i)
+		desc := &roachpb.NodeDescriptor{
+			NodeID:  nodeID,
+			Address: util.UnresolvedAddr{AddressField: fmt.Sprintf("addr%d", i)},
+		}
+		if i == 2 {
+			if err := mockGossip.SetNodeDescriptor(desc); err != nil {
+				t.Fatal(err)
+			}
+		}
+		// All the nodes advertise their DistSQL versions. This is to simulate the
+		// "node overridden by another node at the same address" case mentioned in
+		// the test comment - for such a node, the descriptor would be taken out of
+		// the gossip data, but other datums it advertised are left in place.
+		if err := mockGossip.AddInfoProto(
+			gossip.MakeDistSQLNodeVersionKey(nodeID),
+			&distsqlrun.DistSQLVersionGossipInfo{
+				MinAcceptedVersion: distsqlrun.MinAcceptedVersion,
+				Version:            distsqlrun.Version,
+			},
+			0, // ttl - no expiration
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		nodeDescs = append(nodeDescs, desc)
+	}
+	tsp := &testSpanResolver{
+		nodes:  nodeDescs,
+		ranges: ranges,
+	}
+
+	dsp := distSQLPlanner{
+		planVersion:  distsqlrun.Version,
+		st:           cluster.MakeTestingClusterSettings(),
+		nodeDesc:     *tsp.nodes[gatewayNode-1],
+		stopper:      stopper,
+		spanResolver: tsp,
+		gossip:       mockGossip,
+		testingKnobs: DistSQLPlannerTestingKnobs{
+			OverrideHealthCheck: func(node roachpb.NodeID, addr string) error {
+				// All the nodes are healthy.
+				return nil
+			},
+		},
+	}
+
+	planCtx := dsp.NewPlanningCtx(context.Background(), nil /* txn */)
+	partitions, err := dsp.partitionSpans(&planCtx, roachpb.Spans{span})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resMap := make(map[roachpb.NodeID][][2]string)
+	for _, p := range partitions {
+		if _, ok := resMap[p.node]; ok {
+			t.Fatalf("node %d shows up in multiple partitions", p)
+		}
+		var spans [][2]string
+		for _, s := range p.spans {
+			spans = append(spans, [2]string{string(s.Key), string(s.EndKey)})
+		}
+		resMap[p.node] = spans
+	}
+
+	expectedPartitions :=
+		map[roachpb.NodeID][][2]string{
+			2: {{"A", "Z"}},
+		}
+	if !reflect.DeepEqual(resMap, expectedPartitions) {
+		t.Errorf("expected partitions:\n  %v\ngot:\n  %v", expectedPartitions, resMap)
 	}
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -117,7 +117,7 @@ func (dsp *distSQLPlanner) Run(
 		return err
 	}
 
-	flows := plan.GenerateFlowSpecs(dsp.nodeDesc.NodeID)
+	flows := plan.GenerateFlowSpecs(dsp.nodeDesc.NodeID /* gateway */)
 
 	if logPlanDiagram {
 		log.VEvent(ctx, 1, "creating plan diagram")

--- a/pkg/sql/distsqlplan/span_resolver.go
+++ b/pkg/sql/distsqlplan/span_resolver.go
@@ -320,6 +320,7 @@ func (it *spanResolverIterator) ReplicaInfo(ctx context.Context) (kv.ReplicaInfo
 				// Ignore the error; ask the oracle to pick another replica below.
 				log.VEventf(ctx, 2, "failed to resolve node %d: %s", nodeID, err)
 			} else {
+				repl.ReplicaDescriptor.NodeID = nodeID
 				repl.NodeDesc = nd
 				resolvedLH = true
 			}

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -164,11 +163,10 @@ func (fr *flowRegistry) RegisterFlow(
 	}()
 	entry := fr.getEntryLocked(id)
 	if entry.flow != nil {
-		return util.UnexpectedWithIssueErrorf(
-			12876,
+		return errors.Errorf(
 			"flow already registered: current node ID: %d flowID: %d.\n"+
-				"Current flow:%+v\nExisting flow:%+v",
-			fr.nodeID, f.spec, entry.flow.spec)
+				"Current flow: %+v\nExisting flow: %+v",
+			fr.nodeID, f.spec.FlowID, f.spec, entry.flow.spec)
 	}
 	// Take a reference that will be removed by UnregisterFlow.
 	entry.refCount++

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -365,13 +365,6 @@ type DistSQLPlannerTestingKnobs struct {
 	// If OverrideSQLHealthCheck is set, we use this callback to get the health of
 	// a node.
 	OverrideHealthCheck func(node roachpb.NodeID, addrString string) error
-	// If OverrideDistSQLVersionCheck is set, the distSQLPlanner uses this instead
-	// of gossip for figuring out a node's DistSQL version. The callback can
-	// return an error to simulate gossip not having any info for the node. If the
-	// test wants to simulate the node accepting any version, the callback can
-	// return a 0..+inf acceptable version range.
-	OverrideDistSQLVersionCheck func(
-		node roachpb.NodeID) (distsqlrun.DistSQLVersionGossipInfo, error)
 }
 
 // NewExecutor creates an Executor and registers a callback on the


### PR DESCRIPTION
Fixes #12876

This patch makes it so that the distSQLPlanner does not plan anything on
nodes whose descriptor is not available from gossip (on the gateway
node). Such nodes are not part of the cluster any more because either
they've been decomissioned or because they've been overridden in gossip
by another node with the same address. This latter case happens when you
start a node with a fresh data dir on a machine that was previously
running with another data dir. This could also be considered, I guess, a
type of decomissioning.
Note that gossip catches this case by not allowing two node descriptors
with the same address to be present in its data at any point.
Further note that the distSQLPlanner might be otherwise inclined to
use nodes not present in gossip because various caches told it that
there's ranges on those nodes. Our caches are not generally coherent
with gossip.

Before this patch, planning on two nodes with the same address resulted
in a panic. I will cherry-pick this into 1.1.

This patch includes some changes to the distSQLPlanner tests. They now
create a Gossip object and control the data in it, which replaces the
need for a gossip-related test hook we were previously using.