### PR TITLE
cli: Fix an IPAddr error in a flaky test

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -435,7 +435,7 @@ func TestDumpRandom(t *testing.T) {
 				string(s),
 				b,
 				[]byte(u.String()),
-				ip,
+				[]byte(ip.String()),
 			}
 			if err := conn.Exec("INSERT INTO d.t VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)", vals); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
There was an error when in a skipped test with how the IPAddr is encoded when randomly generated. This is fixed but is not the original reason for why the test is skipped.

cc: @justinj 