### PR TITLE
sql: elide 1-statement inserts/updates in transaction blocks contained in single batch

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -676,3 +676,37 @@ INSERT INTO bytes_t SELECT * FROM string_t
 
 query error value type bytes doesn't match type STRING of column "s"
 INSERT INTO string_t SELECT * FROM bytes_t
+
+# Test that only single-insert-statement, explicit transaction batches are
+# elided and executed as implicit transactions with 1PC.
+
+statement ok
+CREATE TABLE ab (
+  a STRING PRIMARY KEY,
+  b STRING
+)
+
+# 1 PC with one insert statement (final commit elided).
+query T
+SET TRACING=on;
+BEGIN; INSERT INTO ab VALUES ('foo1', 'bar1'); COMMIT;
+SET TRACING=off;
+SELECT message FROM [SHOW TRACE FOR SESSION]
+  WHERE MESSAGE LIKE 'executing _/_%';
+----
+executing 1/1: INSERT INTO ab VALUES ('foo1', 'bar1')
+executing 1/1: SET tracing = off
+
+# 2PC since there exists more than one statement.
+query T
+SET TRACING=on;
+BEGIN; INSERT INTO ab VALUES ('foo2', 'bar2'); INSERT INTO ab VALUES ('foo3', 'bar3'); COMMIT;
+SET TRACING=off;
+SELECT message FROM [SHOW TRACE FOR SESSION]
+  WHERE MESSAGE LIKE 'executing _/_%';
+----
+executing 1/6: BEGIN TRANSACTION
+executing 2/6: INSERT INTO ab VALUES ('foo2', 'bar2')
+executing 3/6: INSERT INTO ab VALUES ('foo3', 'bar3')
+executing 4/6: COMMIT TRANSACTION
+executing 1/1: SET tracing = off

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -432,3 +432,38 @@ SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM pks WHERE k1 = 2]
 fetched: /pks/primary/2/2 -> NULL
 fetched: /pks/primary/2/2/v -> 3
 output row: [2 2 3]
+
+
+# Test that only single-update-statement, explicit transaction batches are
+# elided and executed as implicit transactions with 1PC.
+
+statement ok
+CREATE TABLE ab (
+  a STRING PRIMARY KEY,
+  b STRING
+)
+
+# 1 PC with one update statement (final commit elided).
+query T
+SET TRACING=on;
+BEGIN; UPDATE ab SET a = '%s' WHERE b = '%s'; COMMIT;
+SET TRACING=off;
+SELECT message FROM [SHOW TRACE FOR SESSION]
+  WHERE MESSAGE LIKE 'executing _/_%';
+----
+executing 1/1: UPDATE ab SET a = '%s' WHERE b = '%s'
+executing 1/1: SET tracing = off
+
+# 2PC since there exists more than one statement.
+query T
+SET TRACING=on;
+BEGIN; UPDATE ab SET a = '%s' WHERE b = '%s'; UPDATE ab SET a = '%s' WHERE b = '%s'; COMMIT;
+SET TRACING=off;
+SELECT message FROM [SHOW TRACE FOR SESSION]
+  WHERE MESSAGE LIKE 'executing _/_%';
+----
+executing 1/6: BEGIN TRANSACTION
+executing 2/6: UPDATE ab SET a = '%s' WHERE b = '%s'
+executing 3/6: UPDATE ab SET a = '%s' WHERE b = '%s'
+executing 4/6: COMMIT TRANSACTION
+executing 1/1: SET tracing = off


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/cockroach/issues/17289

## Context

We have the notion of implicit and explicit transactions when the executor runs a batch of statements. Implicit transactions are singular statements that are not within a transaction block thus they are run as a transaction by itself. For example:
```
UPDATE foo SET data = 'bar' WHERE id = 1
```

Explicit transactions are transactions that have a `BEGIN (TRANSACTION)` and `END/COMMIT/ROLLBACK (TRANSACTION)`. For example, the equivalent explicit transaction for the above implicit transaction is:
```
BEGIN; UPDATE foo SET data = 'bar' WHERE id = 1; COMMIT;
```

## Problem

Implicit transactions are allowed to "auto commit" or 1-Phase-Commit (1PC); that is, instead of creating transaction intents when the write statement then sending an second commit statement (this has 2 phases or 2PC) it simply commits the statement (transaction) in 1-phase.

We do not currently recognize 1-statement transaction blocks as a transaction that can 1PC. This incurs a performance overhead.

## Fix

For a given "batch" of statements (in the perspective of the executor), we check whether or not a `BEGIN TRANSACTION` block contains one and only one write statement (currently `INSERT` or `UPDATE`) followed by a `COMMIT TRANSACTION` statement. If this is satisfied, the `BEGIN` and `COMMIT` are elided and `autoCommit` is set to true. In essence, 1-write-statement transaction blocks are converted into implicit transactions.

## Caveats

1. We whitelist the single-statements to either `INSERT`s or `UPDATE`s. This is because there exists transaction dependent statements (e.g. `SET TRANSACTION LEVEL xxx`) that most likely depend on transaction state set by `BEGIN` and `END`. Non-write statements like `SELECT` are more difficult to deal with since they may have sub-queries tht are dependent on `BEGIN` and `END`.
2. We cannot currently detect 1-statement transaction blocks between batches. For example, the following will not be elided since they are executed as separately 3 separate batches:
   ```
   BEGIN;

   UPDATE foo SET data = 'bar' WHERE id = 1;

   COMMIT;
   ```
   This brings up the point of buffering and combining batches whenever explicit transaction blocks 
   are involved, which is a separate issue.
3. We can probably do more intricate eliding of 2PC. Within an explicit transaction block, if the last statement in the block (before `COMMIT`) is to be committed and there has been no write statements  since `BEGIN`, then we can set `autoCommit` to true for the given statement. For example:
```
BEGIN; SELECT 1; SELECT 2; UPDATE foo SET data = 'bar' WHERE id = 1; COMMIT;
```
`SELECT 1;` and `SELECT 2` are non-write statements, thus the final `COMMIT` should be elided. This will obviously require some non-trivial refactor to maintain atomicity of transaction blocks while permitting auto-commit/1PC.

cc: @petermattis 