### PR TITLE
cherrypick-1.1: storage: short-circuit GC queue when context expires

### DIFF
--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -418,6 +418,11 @@ func (ir *intentResolver) resolveIntents(
 	if len(intents) == 0 {
 		return nil
 	}
+	// Avoid doing any work on behalf of expired contexts. See
+	// https://github.com/cockroachdb/cockroach/issues/15997.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	// We're doing async stuff below; those need new traces.
 	ctx, cleanup := tracing.EnsureContext(ctx, ir.store.Tracer(), "resolve intents")
 	defer cleanup()


### PR DESCRIPTION
Fallout from https://github.com/cockroachdb/cockroach/issues/18199 and corresponding
testing in https://github.com/cockroachdb/cockroach/issues/15997.

When the context is expired, there is no point in shooting off another gazillion requests.

cc @cockroachdb/release 