### PR TITLE
cherrypick-1.1: ui: remove Schema Change column from Database Tables page

### DIFF
--- a/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
@@ -99,10 +99,6 @@ class DatabaseSummaryTables extends DatabaseSummaryBase {
                         cell: (tableInfo) => tableInfo.numIndices,
                         sort: (tableInfo) => tableInfo.numIndices,
                       },
-                      {
-                        title: "Schema Change",
-                        cell: (_tableInfo) => "",
-                      },
                     ]} />
               }
             </div>


### PR DESCRIPTION
The Schema Change column never has any content.  This removes the
always-empty column.  Fixes #18594.