### PR TITLE
sql/pgwire,parser: render non-tz timestamp in its loc, set loc when c…

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -471,7 +471,17 @@ SELECT '2015-08-25 05:45:45.53453'::timestamptz
 query T
 SELECT '2015-08-25 05:45:45-01:00'::timestamp
 ----
-2015-08-25 06:45:45 +0000 +0000
+2015-08-25 05:45:45 +0000 +0000
+
+query T
+SELECT '2015-08-25 05:45:45-01:00'::timestamp::timestamptz
+----
+2015-08-25 05:45:45 +0100 +0100
+
+query T
+SELECT '2015-08-25 05:45:45-01:00'::timestamptz::timestamp
+----
+2015-08-25 07:45:45 +0000 +0000
 
 query T
 SELECT '2015-08-25 05:45:45-01:00'::timestamptz
@@ -504,7 +514,7 @@ SELECT '2015-08-24 23:45:45.53453 UTC'::timestamptz
 query T
 SELECT '2015-08-24 23:45:45.53453-02:00'::timestamp
 ----
-2015-08-25 01:45:45.53453 +0000 +0000
+2015-08-24 23:45:45.53453 +0000 +0000
 
 query T
 SELECT '2015-08-24 23:45:45.53453-02:00'::timestamptz
@@ -519,12 +529,38 @@ SELECT '2015-08-24 23:45:45.53453-05:00'::timestamptz
 query T
 SELECT '2015-08-24 23:45:45.534 -02:00'::timestamp
 ----
-2015-08-25 01:45:45.534 +0000 +0000
+2015-08-24 23:45:45.534 +0000 +0000
 
 query T
 SELECT '2015-08-24 23:45:45.534 -02:00'::timestamptz
 ----
 2015-08-24 20:45:45.534 -0500 -0500
+
+query T
+SELECT '2015-08-25 05:45:45-01:00'::timestamp::timestamptz
+----
+2015-08-25 05:45:45 -0500 -0500
+
+query T
+SELECT '2015-08-25 05:45:45-01:00'::timestamptz::timestamp
+----
+2015-08-25 01:45:45 +0000 +0000
+
+# using Eastern instead of fixed -5 should handle DST.
+statement ok
+SET TIME ZONE 'America/New_York'
+
+query T
+SELECT '2015-08-25 05:45:45-01:00'::timestamp::timestamptz
+----
+2015-08-25 05:45:45 -0400 -0400
+
+query T
+SELECT '2015-08-25 05:45:45-01:00'::timestamptz::timestamp
+----
+2015-08-25 02:45:45 +0000 +0000
+
+
 
 statement error cannot find time zone "foobar": timezone data cannot be found
 SET TIME ZONE 'foobar'

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -2510,7 +2510,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		case *DTimestamp:
 			return d, nil
 		case *DTimestampTZ:
-			return MakeDTimestamp(d.Time, time.Microsecond), nil
+			return MakeDTimestamp(d.Time.In(ctx.GetLocation()), time.Microsecond), nil
 		}
 
 	case *TimestampTZColType:
@@ -2523,7 +2523,9 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 		case *DDate:
 			return MakeDTimestampTZFromDate(ctx.GetLocation(), d), nil
 		case *DTimestamp:
-			return MakeDTimestampTZ(d.Time, time.Microsecond), nil
+			_, before := d.Time.Zone()
+			_, after := d.Time.In(ctx.GetLocation()).Zone()
+			return MakeDTimestampTZ(d.Time.Add(time.Duration(before-after)*time.Second), time.Microsecond), nil
 		case *DInt:
 			return MakeDTimestampTZ(time.Unix(int64(*d), 0).UTC(), time.Second), nil
 		case *DTimestampTZ:

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -412,9 +412,8 @@ func formatTs(t time.Time, offset *time.Location, tmp []byte) (b []byte) {
 	// Beware, "0000" in ISO is "1 BC", "-0001" is "2 BC" and so on
 	if offset != nil {
 		t = t.In(offset)
-	} else {
-		t = t.UTC()
 	}
+
 	bc := false
 	if t.Year() <= 0 {
 		// flip year sign, and add 1, e.g: "0" will be "1", and "-10" will be "11"


### PR DESCRIPTION
…asting

Updated logic test behaviors verified from postgres: when a timestamptz is cast to timestamp, the result renders a localized time, with no offset.

Fixes #16228.