### PR TITLE
log: allow log.Safe arguments in Fatal{f,}

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1713,10 +1713,10 @@ func (r *Replica) assertStateLocked(ctx context.Context, reader engine.Reader) {
 		// TODO(dt): expose properly once #15892 is addressed.
 		log.Errorf(ctx, "on-disk and in-memory state diverged:\n%s", pretty.Diff(diskState, r.mu.state))
 		r.mu.state.Desc, diskState.Desc = nil, nil
-		log.Fatal(ctx, log.Safe{
-			V: fmt.Sprintf("on-disk and in-memory state diverged: %s",
+		log.Fatal(ctx, log.Safe(
+			fmt.Sprintf("on-disk and in-memory state diverged: %s",
 				pretty.Diff(diskState, r.mu.state)),
-		})
+		))
 	}
 }
 

--- a/pkg/util/log/crash_reporting_test.go
+++ b/pkg/util/log/crash_reporting_test.go
@@ -15,25 +15,64 @@
 package log
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
-func TestCrashReportingFormatSave(t *testing.T) {
-	r1 := "i am hidden"
-	r2 := Safe{V: "i am public"}
-	r3 := Safe{V: &r2}
-	f1, f2, f3 := format(r1), format(r2), format(r3)
-	exp1, exp2 := "string", r2.V.(string)
-	exp3 := "&{V:i am public}"
-	if f1 != exp1 {
-		t.Errorf("wanted %s, got %s", exp1, f1)
+func TestCrashReportingSafeError(t *testing.T) {
+	type testCase struct {
+		format  string
+		rs      []interface{}
+		expType string
+		expErr  string
 	}
-	if f2 != exp2 {
-		t.Errorf("wanted %s, got %s", exp2, f2)
+
+	runtimeErr := &runtime.TypeAssertionError{}
+
+	testCases := []testCase{
+		{
+			// Intended result of panic(context.DeadlineExceeded).
+			format: "", rs: []interface{}{context.DeadlineExceeded},
+			expType: "*log.safeError", expErr: "?:0: <context.deadlineExceededError>",
+		},
+		{
+			// Intended result of panic(runtimeErr) which exhibits special case of known safe error.
+			format: "", rs: []interface{}{runtimeErr},
+			expType: "*runtime.TypeAssertionError", expErr: "interface conversion: interface is nil, not ",
+		},
+		{
+			// Special-casing switched off when format string present.
+			format: "%s", rs: []interface{}{runtimeErr},
+			expType: "*log.safeError", expErr: "?:0: %s | interface conversion: interface is nil, not ",
+		},
+		{
+			// Special-casing switched off when more than one reportable present.
+			format: "", rs: []interface{}{runtimeErr, "foo"},
+			expType: "*log.safeError", expErr: "?:0: interface conversion: interface is nil, not ; <string>",
+		},
+		{
+			format: "I like %s and %q and my pin code is %d", rs: []interface{}{Safe("A"), &SafeType{V: "B"}, 1234},
+			expType: "*log.safeError", expErr: "?:0: I like %s and %q and my pin code is %d | A; B; <int>",
+		},
 	}
-	if f3 != exp3 {
-		t.Errorf("wanted %s, got %s", exp3, f3)
+
+	for _, test := range testCases {
+		t.Run("", func(t *testing.T) {
+			err := reportablesToSafeError(0, test.format, test.rs)
+			if err == nil {
+				t.Fatal(err)
+			}
+			if typStr := fmt.Sprintf("%T", err); typStr != test.expType {
+				t.Errorf("expected %s, got %s", test.expType, typStr)
+			}
+			if errStr := err.Error(); errStr != test.expErr {
+				t.Errorf("expected %q, got %q", test.expErr, errStr)
+			}
+		})
 	}
 }
 

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -17,7 +17,6 @@ package log
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
 	"strconv"
 
 	"golang.org/x/net/context"
@@ -142,18 +141,10 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 	msg := MakeMessage(ctx, format, args)
 
 	if s == Severity_FATAL {
-		// we send the `format` str, not the formatted message, as args may be not
-		// be okay to share.
-		reportable := format
-		if reportable == "" && len(args) > 0 {
-			reportable = fmt.Sprintf("%T", args[0])
-		}
-		reportable = fmt.Sprintf("%s:%d %s", filepath.Base(file), line, reportable)
-
 		// We load the ReportingSettings from the a global singleton in this
 		// call path. See the singleton's comment for a rationale.
 		if sv, ok := (ReportingSettingsSingleton.Load()).(*settings.Values); ok {
-			sendCrashReport(ctx, sv, reportable, depth+1)
+			sendCrashReport(ctx, sv, depth+2, format, args)
 		}
 	}
 	// MakeMessage already added the tags when forming msg, we don't want


### PR DESCRIPTION
Principally allow the following idioms:

```
panic(err) // reported as %T unless it's a known whitelisted error
panic(log.Safe(err)) // reported as %+v
// String is reported
panic(log.Safe("I am just a const string so you can probably display me on sentry.io"))
// Reports roughly as "God knows what's in here %+v, %s | <*potentiallySensitive>"; OK
panic(fmt.Sprintf("God knows what's in here: %+v, %s", &potentiallySensitive, log.Safe("OK")))
log.Fatal(ctx, runtimeErr) // reported as a runtime error if it is one
log.Fatalf(ctx, "%s %s", log.Safe("x"), "y") // %s %s | x; <string>
```

See #18680 for first use case.