### PR TITLE
cherrypick-1.1: sql: deflake TestTrace

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -37,7 +37,10 @@ func TestTrace(t *testing.T) {
 	defer s.Close(t)
 
 	// These are always appended, even without the test specifying it.
-	alwaysOptionalSpans := []string{"[async] storage.pendingLeaseRequest: requesting lease"}
+	alwaysOptionalSpans := []string{
+		"[async] storage.pendingLeaseRequest: requesting lease",
+		"range lookup",
+	}
 
 	testData := []struct {
 		name          string


### PR DESCRIPTION
```
--- FAIL: TestTrace (4.62s)
	test_log_scope.go:78: test logs captured to: /tmp/logTestTrace323490533
	test_log_scope.go:61: use -show-logs to present logs inline
    --- FAIL: TestTrace/SessionDistSQL (0.22s)
        --- FAIL: TestTrace/SessionDistSQL/TracingOff (0.22s)
            --- FAIL: TestTrace/SessionDistSQL/TracingOff/node-0 (0.04s)
            	trace_test.go:270: expected span: "sql txn implicit", got: "range lookup"
```

Fixes #18648.

cc @cockroachdb/release 