### PR TITLE
cli,distsqlrun: Turn disk usage limits from cluster settings to flags

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -43,7 +43,10 @@ const MinimumStoreSize = 10 * 64 << 20
 // StoreSpec contains the details that can be specified in the cli pertaining
 // to the --store flag.
 type StoreSpec struct {
-	Path        string
+	Path string
+	// SizeInBytes is used for calculating free space and making rebalancing
+	// decisions. Zero indicates that there is no maximum size. This value is not
+	// actually used by the engine and thus not enforced.
 	SizeInBytes int64
 	SizePercent float64
 	InMemory    bool

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -114,8 +114,7 @@ type TestClusterArgs struct {
 // DefaultTestStoreSpec is just a single in memory store of 100 MiB with no
 // special attributes.
 var DefaultTestStoreSpec = StoreSpec{
-	SizeInBytes: 100 << 20,
-	InMemory:    true,
+	InMemory: true,
 }
 
 // TestClusterReplicationMode represents the replication settings for a TestCluster.

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -92,11 +92,36 @@ accept requests.`,
 	SQLMem = FlagInfo{
 		Name: "max-sql-memory",
 		Description: `
-Total size in bytes available for use to store temporary data for SQL
-clients, including prepared queries and intermediate data rows during
-query execution. Size suffixes are supported (e.g. 1GB and 1GiB). If
-left unspecified, defaults to 128MiB. A percentage of physical memory
-can also be specified (e.g. 25%).`,
+Maximum memory capacity available to store temporary data for SQL clients,
+including prepared queries and intermediate data rows during query execution.
+Accepts numbers interpreted as bytes, size suffixes (e.g. 1GB and 1GiB) or a
+percentage of physical memory (e.g. 25%).
+If left unspecified, defaults to 128MiB.
+`,
+	}
+
+	SQLTempStorage = FlagInfo{
+		Name: "max-disk-temp-storage",
+		Description: `
+Maximum storage capacity available to store temporary disk-based data for SQL
+queries that exceed the memory budget (e.g. join, sorts, etc are sometimes able
+to spill intermediate results to disk).
+Accepts numbers interpreted as bytes, size suffixes (e.g. 32GB and 32GiB) or a
+percentage of disk size (e.g. 10%).
+If left unspecified, defaults to 32GiB.
+
+The location of the temporary files is within the first store dir (see --store).
+If expressed as a percentage, --max-disk-temp-storage is interpreted relative to
+the size of the storage device on which the first store is placed. The temp
+space usage is never counted towards any store usage (although it does share the
+device with the first store) so, when configuring this, make sure that the size
+of this temp storage plus the size of the first store don't exceed the capacity
+of the storage device.
+If the first store is an in-memory one (i.e. type=mem), then this temporary "disk"
+data is also kept in-memory. A percentage value is interpreted as a percentage
+of the available internal memory. If not specified, the default shifts to 100MiB
+when the first store is in-memory.
+`,
 	}
 
 	Cache = FlagInfo{

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -249,6 +249,10 @@ func init() {
 		// Engine flags.
 		varFlag(f, cacheSizeValue, cliflags.Cache)
 		varFlag(f, sqlSizeValue, cliflags.SQLMem)
+		// N.B. diskTempStorageSizeValue.ResolvePercentage() will be called after
+		// the stores flag has been parsed and the storage device that a percentage
+		// refers to becomes known.
+		varFlag(f, diskTempStorageSizeValue, cliflags.SQLTempStorage)
 	}
 
 	for _, cmd := range certCmds {

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -1,0 +1,32 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+start_test "Check that --max-disk-temp-storage works."
+send "$argv start --insecure --store=path=mystore --max-disk-temp-storage=10GiB\r"
+eexpect "node starting"
+interrupt
+eexpect ":/# "
+end_test
+
+start_test "Check that --max-disk-temp-storage can be expressed as a percentage."
+send "$argv start --insecure --store=path=mystore --max-disk-temp-storage=10%\r"
+eexpect "node starting"
+interrupt
+eexpect ":/# "
+end_test
+
+start_test "Check that --max-disk-temp-storage percentage works when the store is in-memory."
+send "$argv start --insecure --store=type=mem,size=1GB --max-disk-temp-storage=10%\r"
+eexpect "node starting"
+interrupt
+eexpect ":/# "
+end_test
+
+send "exit 0\r"
+eexpect eof
+

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -27,7 +27,10 @@ system "grep -F 'log: exiting because of error: write /dev/stderr: broken pipe' 
 end_test
 
 start_test "Check that a broken log file prints a message to stderr."
-send "$argv start -s=path=/dev/null --insecure --logtostderr\r"
+# The path that we pass to the --log-dir will already exist as a file.
+system "mkdir -p logs"
+system "touch logs/broken"
+send "$argv start -s=path=logs/db --log-dir=logs/broken --insecure --logtostderr\r"
 eexpect "log: exiting because of error: log: cannot create log: open"
 eexpect "not a directory"
 eexpect ":/# "

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -322,7 +322,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	serverCfg.SSLCertsDir = startCtx.serverSSLCertsDir
 	serverCfg.User = security.NodeUser
 
-	serverCfg.TempStore = server.MakeTempStoreSpecFromStoreSpec(serverCfg.Stores.Specs[0])
+	serverCfg.TempStoreSpec = server.MakeTempStoreSpecFromStoreSpec(serverCfg.Stores.Specs[0])
 
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -33,6 +34,8 @@ import (
 	"text/tabwriter"
 	"time"
 
+	humanize "github.com/dustin/go-humanize"
+	"github.com/elastic/gosigar"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -258,34 +261,126 @@ func initBlockProfile() {
 	runtime.SetBlockProfileRate(int(d))
 }
 
+type percentResolverFunc func(percent int) (int64, error)
+
+// bytesOrPercentageValue is a flag that accepts an integer value, an integer
+// plus a unit (e.g. 32GB or 32GiB) or a percentage (e.g. 32%). In all these
+// cases, it transforms the string flag input into an int64 value.
+//
+// Since it accepts a percentage, instances need to be configured with
+// instructions on how to resolve a percentage to a number (i.e. the answer to
+// the question "a percentage of what?"). This is done by taking in a
+// percentResolverFunc. There are predefined ones: memoryPercentResolver and
+// diskPercentResolverFactory.
+//
+// bytesOrPercentageValue can be used in two ways:
+// 1. Upon flag parsing, it can write an int64 value through a pointer specified
+// by the caller.
+// 2. It can store the flag value as a string and only convert it to an int64 on
+// a subsequent Resolve() call. Input validation still happens at flag parsing
+// time.
+//
+// Option 2 is useful when percentages cannot be resolved at flag parsing time.
+// For example, we have flags that can be expressed as percentages of the
+// capacity of storage device. Which storage device is in question might only be
+// known once other flags are parsed (e.g. --max-disk-temp-storage=10% depends
+// on --store).
 type bytesOrPercentageValue struct {
 	val  *int64
 	bval *humanizeutil.BytesValue
+
+	origVal string
+
+	// percentResolver is used to turn a percent string into a value. See
+	// memoryPercentResolver() and diskPercentResolverFactory().
+	percentResolver percentResolverFunc
 }
 
-func newBytesOrPercentageValue(v *int64) *bytesOrPercentageValue {
+// memoryPercentResolver turns a percent into the respective fraction of the
+// system's internal memory.
+func memoryPercentResolver(percent int) (int64, error) {
+	sizeBytes, err := server.GetTotalMemory(context.TODO())
+	if err != nil {
+		return 0, err
+	}
+	return (sizeBytes * int64(percent)) / 100, nil
+}
+
+// diskPercentResolverFactory takes in a path and produces a percentResolverFunc
+// bound to the respective storage device.
+//
+// An error is returned if dir does not exist.
+func diskPercentResolverFactory(dir string) (percentResolverFunc, error) {
+	fileSystemUsage := gosigar.FileSystemUsage{}
+	if err := fileSystemUsage.Get(dir); err != nil {
+		return nil, err
+	}
+	if fileSystemUsage.Total > math.MaxInt64 {
+		return nil, fmt.Errorf("unsupported disk size %s, max supported size is %s",
+			humanize.IBytes(fileSystemUsage.Total), humanizeutil.IBytes(math.MaxInt64))
+	}
+	deviceCapacity := int64(fileSystemUsage.Total)
+
+	return func(percent int) (int64, error) {
+		return (deviceCapacity * int64(percent)) / 100, nil
+	}, nil
+}
+
+// newBytesOrPercentageValue creates a bytesOrPercentageValue.
+//
+// v and percentResolver can be nil (either they're both specified or they're
+// both nil). If they're nil, then Resolve() has to be called later to get the
+// passed-in value.
+func newBytesOrPercentageValue(
+	v *int64, percentResolver func(percent int) (int64, error),
+) *bytesOrPercentageValue {
+	if v == nil {
+		v = new(int64)
+	}
 	return &bytesOrPercentageValue{
-		val:  v,
-		bval: humanizeutil.NewBytesValue(v),
+		val:             v,
+		bval:            humanizeutil.NewBytesValue(v),
+		percentResolver: percentResolver,
 	}
 }
 
 func (b *bytesOrPercentageValue) Set(s string) error {
+	b.origVal = s
 	if strings.HasSuffix(s, "%") {
 		percent, err := strconv.Atoi(s[:len(s)-1])
 		if err != nil {
 			return err
 		}
 		if percent < 0 || percent > 99 {
-			return fmt.Errorf("percentage out of range")
+			return fmt.Errorf("percentage %s out of range 0%% - 99%%", s)
 		}
-		size, err := server.GetTotalMemory(context.Background())
+
+		if b.percentResolver == nil {
+			// percentResolver not set means that this flag is not yet supposed to set
+			// any value.
+			return nil
+		}
+
+		absVal, err := b.percentResolver(percent)
 		if err != nil {
 			return err
 		}
-		s = fmt.Sprint((size * int64(percent)) / 100)
+		s = fmt.Sprint(absVal)
 	}
 	return b.bval.Set(s)
+}
+
+// Resolve can be called to get the flag's value (if any). If the flag had been
+// previously set, *v will be written.
+func (b *bytesOrPercentageValue) Resolve(v *int64, percentResolver percentResolverFunc) error {
+	// The flag was not passed on the command line.
+	if b.origVal == "" {
+		return nil
+	}
+	b.percentResolver = percentResolver
+	b.val = v
+	b.bval = humanizeutil.NewBytesValue(v)
+	return b.Set(b.origVal)
 }
 
 func (b *bytesOrPercentageValue) Type() string {
@@ -300,8 +395,9 @@ func (b *bytesOrPercentageValue) IsSet() bool {
 	return b.bval.IsSet()
 }
 
-var cacheSizeValue = newBytesOrPercentageValue(&serverCfg.CacheSize)
-var sqlSizeValue = newBytesOrPercentageValue(&serverCfg.SQLMemoryPoolSize)
+var cacheSizeValue = newBytesOrPercentageValue(&serverCfg.CacheSize, memoryPercentResolver)
+var sqlSizeValue = newBytesOrPercentageValue(&serverCfg.SQLMemoryPoolSize, memoryPercentResolver)
+var diskTempStorageSizeValue = newBytesOrPercentageValue(nil /* v */, nil /* percentResolver */)
 
 // runStart starts the cockroach node using --store as the list of
 // storage devices ("stores") on this machine and --join as the list
@@ -315,6 +411,37 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	if ok, err := maybeRerunBackground(); ok {
 		return err
+	}
+
+	// Deal with flags that may depend on other flags.
+
+	// The temp store size can depend on the location of the first regular store
+	// (if it's expressed as a percentage), so we resolve that flag here.
+	var tempStorePercentageResolver percentResolverFunc
+	if !serverCfg.Stores.Specs[0].InMemory {
+		dir := serverCfg.Stores.Specs[0].Path
+		// Create the store dir, if it doesn't exist. The dir is required to exist
+		// by diskPercentResolverFactory.
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return errors.Wrapf(err, "failed to create dir for first store: %s", dir)
+		}
+		var err error
+		tempStorePercentageResolver, err = diskPercentResolverFactory(dir)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create resolver for: %s", dir)
+		}
+	} else {
+		tempStorePercentageResolver = memoryPercentResolver
+	}
+	if err := diskTempStorageSizeValue.Resolve(
+		&serverCfg.TempStoreMaxSizeBytes, tempStorePercentageResolver,
+	); err != nil {
+		return err
+	}
+	if serverCfg.Stores.Specs[0].InMemory && !diskTempStorageSizeValue.IsSet() {
+		// The default temp store size is different when the first store (and thus
+		// also the temp storage) is in memory.
+		serverCfg.TempStoreMaxSizeBytes = server.DefaultTempStoreMaxSizeBytesInMemStore
 	}
 
 	// Use the server-specific values for some flags and settings.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -123,8 +123,8 @@ type Config struct {
 	// Stores is specified to enable durable key-value storage.
 	Stores base.StoreSpecList
 
-	// TempStore is currently used to store local state when processing large queries.
-	TempStore base.StoreSpec
+	// TempStoreSpec is used to store ephemeral data when processing large queries.
+	TempStoreSpec base.StoreSpec
 
 	// Attrs specifies a colon-separated list of node topography or machine
 	// capabilities, used to match capabilities or location preferences specified
@@ -375,7 +375,7 @@ func MakeConfig(st *cluster.Settings) Config {
 		Stores: base.StoreSpecList{
 			Specs: []base.StoreSpec{storeSpec},
 		},
-		TempStore: MakeTempStoreSpecFromStoreSpec(storeSpec),
+		TempStoreSpec: MakeTempStoreSpecFromStoreSpec(storeSpec),
 	}
 	cfg.AmbientCtx.Tracer = st.Tracer
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -66,6 +66,10 @@ const (
 	defaultTempStoreRelativePath          = "local"
 	defaultEventLogEnabled                = true
 	defaultEnableWebSessionAuthentication = false
+	defaultTempStoreMaxSizeBytes          = 32 * 1024 * 1024 * 1024 /* 32GB */
+	// default size of the "disk" temp storage when the first store is in memory.
+	// In this case, the temp storage will also be in memory.
+	DefaultTempStoreMaxSizeBytesInMemStore = 100 * 1024 * 1024 /* 100MB */
 
 	maximumMaxClockOffset = 5 * time.Second
 
@@ -125,6 +129,11 @@ type Config struct {
 
 	// TempStoreSpec is used to store ephemeral data when processing large queries.
 	TempStoreSpec base.StoreSpec
+	// TempStoreMaxSizeBytes is the limit on the disk capacity to be used for temp
+	// storage. Note that TempStoreSpec.SizeInBytes is not used for this purpose;
+	// that spec setting is only used for regular stores for rebalancing purposes,
+	// and not particularly enforced, so we opt for our own setting.
+	TempStoreMaxSizeBytes int64
 
 	// Attrs specifies a colon-separated list of node topography or machine
 	// capabilities, used to match capabilities or location preferences specified
@@ -344,8 +353,6 @@ func SetOpenFileLimitForOneStore() (uint64, error) {
 func MakeTempStoreSpecFromStoreSpec(spec base.StoreSpec) base.StoreSpec {
 	if spec.InMemory {
 		return base.StoreSpec{
-			// TODO(arjun): Set the size in a principled fashion from the main store
-			// after #16750 is addressed.
 			InMemory: true,
 		}
 	}
@@ -375,7 +382,8 @@ func MakeConfig(st *cluster.Settings) Config {
 		Stores: base.StoreSpecList{
 			Specs: []base.StoreSpec{storeSpec},
 		},
-		TempStoreSpec: MakeTempStoreSpecFromStoreSpec(storeSpec),
+		TempStoreSpec:         MakeTempStoreSpecFromStoreSpec(storeSpec),
+		TempStoreMaxSizeBytes: defaultTempStoreMaxSizeBytes,
 	}
 	cfg.AmbientCtx.Tracer = st.Tracer
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -291,7 +291,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	rootSQLMemoryMonitor.Start(context.Background(), nil, mon.MakeStandaloneBudget(s.cfg.SQLMemoryPoolSize))
 
 	// Set up the DistSQL temp engine.
-	tempEngine, err := engine.NewTempEngine(ctx, s.cfg.TempStore)
+	tempEngine, err := engine.NewTempEngine(ctx, s.cfg.TempStoreSpec)
 	if err != nil {
 		log.Fatalf(ctx, "could not create temporary store: %v", err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -361,7 +361,8 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		Stopper:    s.stopper,
 		NodeID:     &s.nodeIDContainer,
 
-		TempStorage: tempEngine,
+		TempStorage:             tempEngine,
+		TempStorageMaxSizeBytes: s.cfg.TempStoreMaxSizeBytes,
 
 		ParentMemoryMonitor: &rootSQLMemoryMonitor,
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -68,7 +68,7 @@ func makeTestConfig(st *cluster.Settings) Config {
 	cfg.Insecure = false
 
 	// Override the DistSQL local store with an in-memory store.
-	cfg.TempStore = base.DefaultTestStoreSpec
+	cfg.TempStoreSpec = base.DefaultTestStoreSpec
 
 	// Load test certs. In addition, the tests requiring certs
 	// need to call security.SetAssetLoader(securitytest.EmbeddedAssets)

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -81,10 +81,8 @@ sql.defaults.distsql                               0              e     Default 
 sql.distsql.distribute_index_joins                 true           b     if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader
 sql.distsql.merge_joins.enabled                    true           b     if set, we plan merge joins when possible
 sql.distsql.temp_storage.joins                     true           b     set to true to enable use of disk for distributed sql joins
-sql.distsql.temp_storage.max_bytes                 32 GiB         z     maximum amount of disk space used for queries (in bytes; requires restart); also see sql.distsql.temp_storage.max_percent
-sql.distsql.temp_storage.max_percent               10             i     maximum amount of disk space used for queries (as a percentage of the total capacity; requires restart); also see sql.distsql.temp_storage.max_bytes
 sql.distsql.temp_storage.sorts                     true           b     set to true to enable use of disk for distributed sql sorts
-sql.distsql.temp_storage.workmem                   64 MiB         z     maximum amount of memory in bytes a processor can use before falling back to temp storage (requires restart)
+sql.distsql.temp_storage.workmem                   64 MiB         z     maximum amount of memory in bytes a processor can use before falling back to temp storage
 sql.metrics.statement_details.dump_to_logs         false          b     dump collected statement statistics to node logs when periodically cleared
 sql.metrics.statement_details.enabled              true           b     collect per-statement query statistics
 sql.metrics.statement_details.threshold            0s             d     minimum execution time to cause statistics to be collected

--- a/pkg/storage/engine/in_mem.go
+++ b/pkg/storage/engine/in_mem.go
@@ -32,7 +32,9 @@ func NewInMem(attrs roachpb.Attributes, cacheSize int64) InMem {
 	// from it adds another refcount, at which point we release one of them.
 	defer cache.Release()
 
-	rdb, err := newMemRocksDB(attrs, cache, 512<<20 /* 512 MB */)
+	// TODO(bdarnell): The hard-coded 512 MiB is wrong; see
+	// https://github.com/cockroachdb/cockroach/issues/16750
+	rdb, err := newMemRocksDB(attrs, cache, 512<<20 /* MaxSizeBytes: 512 MiB */)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Before this patch, the cluster setting sql.distsql.temp_storage.max_bytes and
sql.distsql.temp_storage.max_percentage were controlling how much
storage capacity could be used by distsql temp storage.
This didn't make sense: the settings should be per node, not per
cluster.

This patch replaces both settings with --max-disk-temp-storage flag. It
can take either a value or a percentage. One option briefly considered
was allowing the control over this temp storage through the --store
flag which already has an expressive language for specifying limits.
This option has the upside that it'd make it clear that the temp storage
is collocated with the first store and they share resources - in fact we
could easily prevent broken configuration where both the store and the
temp storage are configured to take the whole disk. However it's unclear
if tying temp storage to stores is a great idea thinking forward, and
also it's too late for me to explore that option more for 1.1.

This patch also changes the interpretation of the flag/cluster setting
when it's expressed as a percentage and the first store is type=mem.
Before, it used to be interpreted at p% of 512MB. Now, it will be
interpreted as p% of the internal memory.

The patch also has the effect that the dir for the first store will be
created earlier in the code path than it used to be, with permissions
0755. As far as I can tell, before the patch, the dir would have been
created later with the same permissions either when when initialized the
log dir or, if (--log_dir was specified) when we created the engine.

I'll cherry-pick this into 1.1 to remove the cluster settings before the
world gets wind of them.