### PR TITLE
cherry-pick 1.1: distsql: don't plan on nodes that are not part of gossip

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -240,6 +240,13 @@ type Gossip struct {
 // The higher level manages the NodeIDContainer instance (which can be shared by
 // various server components). The ambient context is expected to already
 // contain the node ID.
+//
+// grpcServer: The server on which the new Gossip instance will register its RPC
+//   service. Can be nil, in which case the Gossip will not register the
+//   service.
+// rpcContext: The context used to connect to other nodes. Can be nil for tests
+//   that also specify a nil grpcServer and that plan on using the Gossip in a
+//   restricted way by populating it with data manually.
 func New(
 	ambient log.AmbientContext,
 	nodeID *base.NodeIDContainer,
@@ -277,12 +284,21 @@ func New(
 	g.mu.is.registerCallback(MakePrefixPattern(KeyNodeIDPrefix), g.updateNodeAddress)
 	g.mu.Unlock()
 
-	RegisterGossipServer(grpcServer, g.server)
+	if grpcServer != nil {
+		RegisterGossipServer(grpcServer, g.server)
+	}
 	return g
 }
 
 // NewTest is a simplified wrapper around New that creates the NodeIDContainer
 // internally. Used for testing.
+//
+// grpcServer: The server on which the new Gossip instance will register its RPC
+//   service. Can be nil, in which case the Gossip will not register the
+//   service.
+// rpcContext: The context used to connect to other nodes. Can be nil for tests
+//   that also specify a nil grpcServer and that plan on using the Gossip in a
+//   restricted way by populating it with data manually.
 func NewTest(
 	nodeID roachpb.NodeID,
 	rpcContext *rpc.Context,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -532,20 +532,36 @@ func (dsp *distSQLPlanner) partitionSpans(
 				addr, inAddrMap := planCtx.nodeAddresses[nodeID]
 				if !inAddrMap {
 					addr = replInfo.NodeDesc.Address.String()
-					var err error
-					if dsp.testingKnobs.OverrideHealthCheck != nil {
-						err = dsp.testingKnobs.OverrideHealthCheck(replInfo.NodeDesc.NodeID, addr)
-					} else {
-						err = dsp.rpcContext.ConnHealth(addr)
+					checkNodeHealth := func() error {
+						// Check if the node is still in gossip - i.e. if it hasn't been
+						// decommissioned or overridden by another node at the same address.
+						if _, err := dsp.gossip.GetNodeIDAddress(nodeID); err != nil {
+							log.VEventf(ctx, 1, "not using n%d because gossip doesn't know about it. "+
+								"It might have gone away from the cluster. Gossip said: %s.", nodeID, err)
+							return err
+						}
+
+						var err error
+						if dsp.testingKnobs.OverrideHealthCheck != nil {
+							err = dsp.testingKnobs.OverrideHealthCheck(replInfo.NodeDesc.NodeID, addr)
+						} else {
+							err = dsp.rpcContext.ConnHealth(addr)
+						}
+						if err != nil && err != rpc.ErrNotConnected && err != rpc.ErrNotHeartbeated {
+							// This host is known to be unhealthy. Don't use it (use the gateway
+							// instead). Note: this can never happen for our nodeID (which
+							// always has its address in the nodeMap).
+							log.VEventf(ctx, 1, "marking n%d as unhealthy for this plan: %v", nodeID, err)
+							return err
+						}
+						return nil
 					}
-					if err != nil && err != rpc.ErrNotConnected && err != rpc.ErrNotHeartbeated {
-						// This host is known to be unhealthy. Don't use it (use the gateway
-						// instead). Note: this can never happen for our nodeID (which
-						// always has its address in the nodeMap).
+					if err := checkNodeHealth(); err != nil {
 						addr = ""
-						log.VEventf(ctx, 1, "marking node %d as unhealthy for this plan: %v", nodeID, err)
 					}
-					planCtx.nodeAddresses[nodeID] = addr
+					if err == nil && addr != "" {
+						planCtx.nodeAddresses[nodeID] = addr
+					}
 				}
 				compat := true
 				if addr != "" {
@@ -604,15 +620,8 @@ func (dsp *distSQLPlanner) nodeVersionIsCompatible(
 	nodeID roachpb.NodeID, planVer distsqlrun.DistSQLVersion,
 ) bool {
 	var v distsqlrun.DistSQLVersionGossipInfo
-	if hook := dsp.testingKnobs.OverrideDistSQLVersionCheck; hook != nil {
-		var err error
-		if v, err = hook(nodeID); err != nil {
-			return false
-		}
-	} else {
-		if err := dsp.gossip.GetInfoProto(gossip.MakeDistSQLNodeVersionKey(nodeID), &v); err != nil {
-			return false
-		}
+	if err := dsp.gossip.GetInfoProto(gossip.MakeDistSQLNodeVersionKey(nodeID), &v); err != nil {
+		return false
 	}
 	return distsqlrun.FlowVerIsCompatible(dsp.planVersion, v.MinAcceptedVersion, v.Version)
 }

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -547,7 +547,7 @@ func (dsp *distSQLPlanner) partitionSpans(
 					}
 					planCtx.nodeAddresses[nodeID] = addr
 				}
-				var compat bool
+				compat := true
 				if addr != "" {
 					// Check if the node's DistSQL version is compatible with this plan.
 					// If it isn't, we'll use the gateway.

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -117,7 +117,7 @@ func (dsp *distSQLPlanner) Run(
 		return err
 	}
 
-	flows := plan.GenerateFlowSpecs(dsp.nodeDesc.NodeID)
+	flows := plan.GenerateFlowSpecs(dsp.nodeDesc.NodeID /* gateway */)
 
 	if logPlanDiagram {
 		log.VEvent(ctx, 1, "creating plan diagram")

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -22,7 +22,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -164,11 +163,10 @@ func (fr *flowRegistry) RegisterFlow(
 	}()
 	entry := fr.getEntryLocked(id)
 	if entry.flow != nil {
-		return util.UnexpectedWithIssueErrorf(
-			12876,
+		return errors.Errorf(
 			"flow already registered: current node ID: %d flowID: %d.\n"+
-				"Current flow:%+v\nExisting flow:%+v",
-			fr.nodeID, f.spec, entry.flow.spec)
+				"Current flow: %+v\nExisting flow: %+v",
+			fr.nodeID, f.spec.FlowID, f.spec, entry.flow.spec)
 	}
 	// Take a reference that will be removed by UnregisterFlow.
 	entry.refCount++

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -365,13 +365,6 @@ type DistSQLPlannerTestingKnobs struct {
 	// If OverrideSQLHealthCheck is set, we use this callback to get the health of
 	// a node.
 	OverrideHealthCheck func(node roachpb.NodeID, addrString string) error
-	// If OverrideDistSQLVersionCheck is set, the distSQLPlanner uses this instead
-	// of gossip for figuring out a node's DistSQL version. The callback can
-	// return an error to simulate gossip not having any info for the node. If the
-	// test wants to simulate the node accepting any version, the callback can
-	// return a 0..+inf acceptable version range.
-	OverrideDistSQLVersionCheck func(
-		node roachpb.NodeID) (distsqlrun.DistSQLVersionGossipInfo, error)
 }
 
 // NewExecutor creates an Executor and registers a callback on the


### PR DESCRIPTION
Cherry-pick of #18651 (except one of the small cleanup commits that didn't apply cleanly and wasn't particularly needed).

cc @cockroachdb/release 


Fixes #12876

This patch makes it so that the distSQLPlanner does not plan anything on
nodes whose descriptor is not available from gossip (on the gateway
node). Such nodes are not part of the cluster any more because either
they've been decomissioned or because they've been overridden in gossip
by another node with the same address. This latter case happens when you
start a node with a fresh data dir on a machine that was previously
running with another data dir. This could also be considered, I guess, a
type of decomissioning.
Note that gossip catches this case by not allowing two node descriptors
with the same address to be present in its data at any point.
Further note that the distSQLPlanner might be otherwise inclined to
use nodes not present in gossip because various caches told it that
there's ranges on those nodes. Our caches are not generally coherent
with gossip.

Before this patch, planning on two nodes with the same address resulted
in a panic.

This patch includes some changes to the distSQLPlanner tests. They now
create a Gossip object and control the data in it, which replaces the
need for a gossip-related test hook we were previously using.