### PR TITLE
distsql: increase intermediate precision of decimal calculations in square difference calculations

### DIFF
--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -873,11 +873,6 @@ func (a *intSqrDiffAggregate) Count() *apd.Decimal {
 	return a.agg.Count()
 }
 
-// Ed is part of the decimalSqrDiff interface.
-func (a *intSqrDiffAggregate) Ed() *apd.ErrDecimal {
-	return a.agg.Ed()
-}
-
 // Tmp is part of the decimalSqrDiff interface.
 func (a *intSqrDiffAggregate) Tmp() *apd.Decimal {
 	return a.agg.Tmp()
@@ -964,15 +959,8 @@ type decimalSqrDiffAggregate struct {
 }
 
 func newDecimalSqrDiff() decimalSqrDiff {
-	// Use extra internal precision during squared difference to protect against
-	// order changes that can happen in dist SQL. The additional 3 here should
-	// allow for correctness up to 1000 more worst case inputs than non-worst
-	// case inputs. See #13689 for more analysis and other algorithms.
-	c := DecimalCtx.WithPrecision(DecimalCtx.Precision + 3)
-	ed := apd.MakeErrDecimal(c)
-	return &decimalSqrDiffAggregate{
-		ed: &ed,
-	}
+	ed := apd.MakeErrDecimal(IntermediateCtx)
+	return &decimalSqrDiffAggregate{ed: &ed}
 }
 
 func newDecimalSqrDiffAggregate(_ []Type, _ *EvalContext) AggregateFunc {
@@ -982,11 +970,6 @@ func newDecimalSqrDiffAggregate(_ []Type, _ *EvalContext) AggregateFunc {
 // Count is part of the decimalSqrDiff interface.
 func (a *decimalSqrDiffAggregate) Count() *apd.Decimal {
 	return &a.count
-}
-
-// Ed is part of the decimalSqrDiff interface.
-func (a *decimalSqrDiffAggregate) Ed() *apd.ErrDecimal {
-	return a.ed
 }
 
 // Tmp is part of the decimalSqrDiff interface.
@@ -1107,25 +1090,13 @@ type decimalSumSqrDiffsAggregate struct {
 }
 
 func newDecimalSumSqrDiffs() decimalSqrDiff {
-	// Use extra internal precision during squared difference to protect against
-	// order changes that can happen in dist SQL. The additional 3 here should
-	// allow for correctness up to 1000 more worst case inputs than non-worst
-	// case inputs. See #13689 for more analysis and other algorithms.
-	c := DecimalCtx.WithPrecision(DecimalCtx.Precision + 3)
-	ed := apd.MakeErrDecimal(c)
-	return &decimalSumSqrDiffsAggregate{
-		ed: &ed,
-	}
+	ed := apd.MakeErrDecimal(IntermediateCtx)
+	return &decimalSumSqrDiffsAggregate{ed: &ed}
 }
 
 // Count is part of the decimalSqrDiff interface.
 func (a *decimalSumSqrDiffsAggregate) Count() *apd.Decimal {
 	return &a.count
-}
-
-// Ed is part of the decimalSqrDiff interface.
-func (a *decimalSumSqrDiffsAggregate) Ed() *apd.ErrDecimal {
-	return a.ed
 }
 
 // Tmp is part of the decimalSumSqrDiffs interface.
@@ -1186,10 +1157,6 @@ func (a *decimalSumSqrDiffsAggregate) Result() (Datum, error) {
 		return DNull, nil
 	}
 	dd := &DDecimal{a.sqrDiff}
-	// Remove trailing zeros. Depending on the order in which the input
-	// is processed, some number of trailing zeros could be added to the
-	// output. Remove them so that the results are the same regardless of order.
-	dd.Decimal.Reduce(&dd.Decimal)
 	return dd, nil
 }
 
@@ -1204,7 +1171,6 @@ type floatSqrDiff interface {
 type decimalSqrDiff interface {
 	AggregateFunc
 	Count() *apd.Decimal
-	Ed() *apd.ErrDecimal
 	Tmp() *apd.Decimal
 }
 
@@ -1281,11 +1247,11 @@ func (a *decimalVarianceAggregate) Result() (Datum, error) {
 	if err != nil {
 		return nil, err
 	}
-	a.agg.Ed().Sub(a.agg.Tmp(), a.agg.Count(), decimalOne)
+	if _, err = IntermediateCtx.Sub(a.agg.Tmp(), a.agg.Count(), decimalOne); err != nil {
+		return nil, err
+	}
 	dd := &DDecimal{}
-	a.agg.Ed().Ctx = DecimalCtx
-	a.agg.Ed().Quo(&dd.Decimal, &sqrDiff.(*DDecimal).Decimal, a.agg.Tmp())
-	if err := a.agg.Ed().Err(); err != nil {
+	if _, err = DecimalCtx.Quo(&dd.Decimal, &sqrDiff.(*DDecimal).Decimal, a.agg.Tmp()); err != nil {
 		return nil, err
 	}
 	// Remove trailing zeros. Depending on the order in which the input is
@@ -1368,6 +1334,12 @@ func (a *floatStdDevAggregate) Result() (Datum, error) {
 
 // Result computes the square root of the variance aggregator.
 func (a *decimalStdDevAggregate) Result() (Datum, error) {
+	// TODO(richardwu): both decimalVarianceAggregate and
+	// finalDecimalVarianceAggregate return a decimal result with
+	// default DecimalCtx precision. We want to be able to specify that the
+	// varianceAggregate use IntermediateCtx (with the extra precision)
+	// since it is returning an intermediate value for stdDevAggregate (of
+	// which we take the Sqrt).
 	variance, err := a.agg.Result()
 	if err != nil {
 		return nil, err

--- a/pkg/sql/parser/decimal.go
+++ b/pkg/sql/parser/decimal.go
@@ -19,7 +19,7 @@ import "github.com/cockroachdb/apd"
 var (
 	// DecimalCtx is the default context for decimal operations. Any change
 	// in the exponent limits must still guarantee a safe conversion to the
-	// postegrs binary decimal format in the wire protocol, which uses an
+	// postgres binary decimal format in the wire protocol, which uses an
 	// int16. See pgwire/types.go.
 	DecimalCtx = &apd.Context{
 		Precision:   20,
@@ -32,6 +32,11 @@ var (
 	ExactCtx = DecimalCtx.WithPrecision(0)
 	// HighPrecisionCtx is a decimal context with high precision.
 	HighPrecisionCtx = DecimalCtx.WithPrecision(2000)
+	// IntermediateCtx is a decimal context with additional precision for
+	// intermediate calculations to protect against order changes that can
+	// happen in dist SQL. The additional 5 allows the stress test to pass.
+	// See #13689 for more analysis and other algorithms.
+	IntermediateCtx = DecimalCtx.WithPrecision(DecimalCtx.Precision + 5)
 	// RoundCtx is a decimal context with high precision and RoundHalfEven
 	// rounding.
 	RoundCtx = func() *apd.Context {


### PR DESCRIPTION
This PR increases the intermediate precision of our apd contexts for
intermediate calculations to address off by last-digit issues in our
final decimal results for STDDEV/VARIANCE.

The imprecision was introduced during
https://github.com/cockroachdb/cockroach/pull/18520 when STDDEV/VARIANCE
aggregations can now take advantage of local and final stage
aggregating. Since this architecture involves non-deterministic ordering
(which implies non-deterministic order of operations for our running
squared difference algorithm), there is a trivial discrepancy between
local and non-local results.

Fixes #18691, #18692, #18693, #18694.