### PR TITLE
cache: introduce OrderedCache Entry API

### DIFF
--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -162,8 +162,9 @@ func (rdc *RangeDescriptorCache) String() string {
 
 func (rdc *RangeDescriptorCache) stringLocked() string {
 	var buf bytes.Buffer
-	rdc.rangeCache.cache.Do(func(k, v interface{}) {
+	rdc.rangeCache.cache.Do(func(k, v interface{}) bool {
 		fmt.Fprintf(&buf, "key=%s desc=%+v\n", roachpb.Key(k.(rangeCacheKey)), v)
+		return false
 	})
 	return buf.String()
 }

--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -264,7 +264,7 @@ func (rdc *RangeDescriptorCache) lookupRangeDescriptorInternal(
 	defer doneWg()
 
 	rdc.rangeCache.RLock()
-	if _, desc, err := rdc.getCachedRangeDescriptorLocked(key, useReverseScan); err != nil {
+	if desc, _, err := rdc.getCachedRangeDescriptorLocked(key, useReverseScan); err != nil {
 		rdc.rangeCache.RUnlock()
 		return nil, nil, err
 	} else if desc != nil {
@@ -450,7 +450,7 @@ func (rdc *RangeDescriptorCache) EvictCachedRangeDescriptor(
 func (rdc *RangeDescriptorCache) evictCachedRangeDescriptorLocked(
 	ctx context.Context, descKey roachpb.RKey, seenDesc *roachpb.RangeDescriptor, inclusive bool,
 ) error {
-	rngKey, cachedDesc, err := rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
+	cachedDesc, entry, err := rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
 	if err != nil {
 		return err
 	}
@@ -467,7 +467,7 @@ func (rdc *RangeDescriptorCache) evictCachedRangeDescriptorLocked(
 		if log.V(2) {
 			log.Infof(ctx, "evict cached descriptor: key=%s desc=%s", descKey, cachedDesc)
 		}
-		rdc.rangeCache.cache.Del(rngKey)
+		rdc.rangeCache.cache.DelEntry(entry)
 
 		// Retrieve the metadata range key for the next level of metadata, and
 		// evict that key as well. This loop ends after the meta1 range, which
@@ -476,7 +476,7 @@ func (rdc *RangeDescriptorCache) evictCachedRangeDescriptorLocked(
 		if err != nil {
 			return err
 		}
-		rngKey, cachedDesc, err = rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
+		cachedDesc, entry, err = rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
 		if err != nil {
 			return err
 		}
@@ -502,18 +502,18 @@ func (rdc *RangeDescriptorCache) GetCachedRangeDescriptor(
 ) (*roachpb.RangeDescriptor, error) {
 	rdc.rangeCache.RLock()
 	defer rdc.rangeCache.RUnlock()
-	_, desc, err := rdc.getCachedRangeDescriptorLocked(key, inclusive)
+	desc, _, err := rdc.getCachedRangeDescriptorLocked(key, inclusive)
 	return desc, err
 }
 
-//  getCachedRangeDescriptorLocked is like GetCachedRangeDescriptor, but it
-//  assumes that the caller holds a read lock on rdc.rangeCache.
+// getCachedRangeDescriptorLocked is like GetCachedRangeDescriptor, but it
+// assumes that the caller holds a read lock on rdc.rangeCache.
 //
-//  In addition to GetCachedRangeDescriptor, it also returns an internal cache
-//  key that can be used to remove the cache entry.
+// In addition to GetCachedRangeDescriptor, it also returns an internal cache
+// Entry that can be used for descriptor eviction.
 func (rdc *RangeDescriptorCache) getCachedRangeDescriptorLocked(
 	key roachpb.RKey, inclusive bool,
-) (rangeCacheKey, *roachpb.RangeDescriptor, error) {
+) (*roachpb.RangeDescriptor, *cache.Entry, error) {
 	// The cache is indexed using the end-key of the range, but the
 	// end-key is non-inclusive by default.
 	var metaKey roachpb.RKey
@@ -527,12 +527,11 @@ func (rdc *RangeDescriptorCache) getCachedRangeDescriptorLocked(
 		return nil, nil, err
 	}
 
-	k, v, ok := rdc.rangeCache.cache.Ceil(rangeCacheKey(metaKey))
+	entry, ok := rdc.rangeCache.cache.CeilEntry(rangeCacheKey(metaKey))
 	if !ok {
 		return nil, nil, nil
 	}
-	metaEndKey := k.(rangeCacheKey)
-	rd := v.(*roachpb.RangeDescriptor)
+	desc := entry.Value.(*roachpb.RangeDescriptor)
 
 	containsFn := (*roachpb.RangeDescriptor).ContainsKey
 	if inclusive {
@@ -540,10 +539,10 @@ func (rdc *RangeDescriptorCache) getCachedRangeDescriptorLocked(
 	}
 
 	// Return nil if the key does not belong to the range.
-	if !containsFn(rd, key) {
+	if !containsFn(desc, key) {
 		return nil, nil, nil
 	}
-	return metaEndKey, rd, nil
+	return desc, entry, nil
 }
 
 // InsertRangeDescriptors inserts the provided descriptors in the cache.
@@ -605,18 +604,19 @@ func (rdc *RangeDescriptorCache) clearOverlappingCachedRangeDescriptors(
 	// Clear out any descriptors which subsume the key which we're going
 	// to cache. For example, if an existing KeyMin->KeyMax descriptor
 	// should be cleared out in favor of a KeyMin->"m" descriptor.
-	k, v, ok := rdc.rangeCache.cache.Ceil(rangeCacheKey(metaKey))
+	entry, ok := rdc.rangeCache.cache.CeilEntry(rangeCacheKey(metaKey))
 	if ok {
-		descriptor := v.(*roachpb.RangeDescriptor)
+		descriptor := entry.Value.(*roachpb.RangeDescriptor)
 		if descriptor.StartKey.Less(key) && !descriptor.EndKey.Less(key) {
 			if descriptor.Equal(*desc) {
 				// The descriptor is already in the cache. Nothing to do.
 				return false, nil
 			}
 			if log.V(2) {
-				log.Infof(ctx, "clearing overlapping descriptor: key=%s desc=%s", k, descriptor)
+				log.Infof(ctx, "clearing overlapping descriptor: key=%s desc=%s",
+					entry.Key, descriptor)
 			}
-			rdc.rangeCache.cache.Del(k.(rangeCacheKey))
+			rdc.rangeCache.cache.DelEntry(entry)
 		}
 	}
 
@@ -633,19 +633,18 @@ func (rdc *RangeDescriptorCache) clearOverlappingCachedRangeDescriptors(
 	// going to cache. This could happen on a merge (and also happens
 	// when there's a lot of concurrency). Iterate from the range meta key
 	// after RangeMetaKey(desc.StartKey) to the range meta key for desc.EndKey.
-	var keys []rangeCacheKey
-	rdc.rangeCache.cache.DoRange(func(k, v interface{}) bool {
+	var entries []*cache.Entry
+	rdc.rangeCache.cache.DoRangeEntry(func(e *cache.Entry) bool {
 		if log.V(2) {
 			log.Infof(ctx, "clearing subsumed descriptor: key=%s desc=%s",
-				k, v.(*roachpb.RangeDescriptor))
+				e.Key, e.Value.(*roachpb.RangeDescriptor))
 		}
-		keys = append(keys, k.(rangeCacheKey))
-
+		entries = append(entries, e)
 		return false
 	}, rangeCacheKey(startMeta.Next()), rangeCacheKey(endMeta))
 
-	for _, key := range keys {
-		rdc.rangeCache.cache.Del(key)
+	for _, e := range entries {
+		rdc.rangeCache.cache.DelEntry(e)
 	}
 	return true, nil
 }

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -932,7 +932,7 @@ func TestGetCachedRangeDescriptorInclusive(t *testing.T) {
 
 	for _, test := range testCases {
 		cache.rangeCache.RLock()
-		cacheKey, targetRange, err := cache.getCachedRangeDescriptorLocked(
+		targetRange, entry, err := cache.getCachedRangeDescriptorLocked(
 			test.queryKey, true /* inclusive */)
 		cache.rangeCache.RUnlock()
 		if err != nil {
@@ -940,6 +940,10 @@ func TestGetCachedRangeDescriptorInclusive(t *testing.T) {
 		}
 		if !reflect.DeepEqual(targetRange, test.rng) {
 			t.Fatalf("expect range %v, actual get %v", test.rng, targetRange)
+		}
+		var cacheKey rangeCacheKey
+		if entry != nil {
+			cacheKey = entry.Key.(rangeCacheKey)
 		}
 		if !reflect.DeepEqual(cacheKey, test.cacheKey) {
 			t.Fatalf("expect cache key %v, actual get %v", test.cacheKey, cacheKey)

--- a/pkg/storage/entry_cache.go
+++ b/pkg/storage/entry_cache.go
@@ -17,10 +17,11 @@ package storage
 
 import (
 	"github.com/biogo/store/llrb"
+	"github.com/coreos/etcd/raft/raftpb"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/coreos/etcd/raft/raftpb"
 )
 
 type entryCacheKey struct {
@@ -173,16 +174,16 @@ func (rec *raftEntryCache) delEntries(rangeID roachpb.RangeID, lo, hi uint64) {
 	if lo >= hi {
 		return
 	}
-	var keys []*entryCacheKey
+	var cacheEnts []*cache.Entry
 	rec.fromKey = entryCacheKey{RangeID: rangeID, Index: lo}
 	rec.toKey = entryCacheKey{RangeID: rangeID, Index: hi}
-	rec.cache.DoRange(func(k, v interface{}) bool {
-		keys = append(keys, k.(*entryCacheKey))
+	rec.cache.DoRangeEntry(func(e *cache.Entry) bool {
+		cacheEnts = append(cacheEnts, e)
 		return false
 	}, &rec.fromKey, &rec.toKey)
 
-	for _, k := range keys {
-		rec.cache.Del(k)
+	for _, e := range cacheEnts {
+		rec.cache.DelEntry(e)
 	}
 }
 

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -163,7 +163,7 @@ type cacheStore interface {
 	// add stores an entry.
 	add(e *Entry)
 	// del removes an entry.
-	del(key interface{})
+	del(e *Entry)
 	// len is number of items in store.
 	length() int
 }
@@ -282,7 +282,7 @@ func (bc *baseCache) access(e *Entry) {
 
 func (bc *baseCache) removeElement(e *Entry) {
 	bc.ll.remove(e)
-	bc.store.del(e.Key)
+	bc.store.del(e)
 	if bc.OnEvicted != nil {
 		bc.OnEvicted(e.Key, e.Value)
 	}
@@ -342,8 +342,8 @@ func (mc *UnorderedCache) get(key interface{}) *Entry {
 func (mc *UnorderedCache) add(e *Entry) {
 	mc.hmap[e.Key] = e
 }
-func (mc *UnorderedCache) del(key interface{}) {
-	delete(mc.hmap, key)
+func (mc *UnorderedCache) del(e *Entry) {
+	delete(mc.hmap, e.Key)
 }
 func (mc *UnorderedCache) length() int {
 	return len(mc.hmap)
@@ -385,8 +385,8 @@ func (oc *OrderedCache) get(key interface{}) *Entry {
 func (oc *OrderedCache) add(e *Entry) {
 	oc.llrb.Insert(e)
 }
-func (oc *OrderedCache) del(key interface{}) {
-	oc.llrb.Delete(&Entry{Key: key})
+func (oc *OrderedCache) del(e *Entry) {
+	oc.llrb.Delete(e)
 }
 func (oc *OrderedCache) length() int {
 	return oc.llrb.Len()
@@ -482,7 +482,6 @@ type IntervalCache struct {
 	// GetOverlaps.
 	getID      uintptr
 	getEntry   *Entry
-	tmpEntry   Entry
 	overlapKey IntervalKey
 	overlaps   []*Entry
 }
@@ -558,9 +557,8 @@ func (ic *IntervalCache) add(e *Entry) {
 	}
 }
 
-func (ic *IntervalCache) del(key interface{}) {
-	ic.tmpEntry.Key = key
-	if err := ic.tree.Delete(&ic.tmpEntry, false); err != nil {
+func (ic *IntervalCache) del(e *Entry) {
+	if err := ic.tree.Delete(e, false); err != nil {
 		log.Error(context.TODO(), err)
 	}
 }

--- a/pkg/util/cache/cache.go
+++ b/pkg/util/cache/cache.go
@@ -392,38 +392,75 @@ func (oc *OrderedCache) length() int {
 	return oc.llrb.Len()
 }
 
-// Ceil returns the smallest cache entry greater than or equal to key.
-func (oc *OrderedCache) Ceil(key interface{}) (interface{}, interface{}, bool) {
+// CeilEntry returns the smallest cache entry greater than or equal to key.
+func (oc *OrderedCache) CeilEntry(key interface{}) (*Entry, bool) {
 	if e, ok := oc.llrb.Ceil(&Entry{Key: key}).(*Entry); ok {
+		return e, true
+	}
+	return nil, false
+}
+
+// Ceil returns the smallest key-value pair greater than or equal to key.
+func (oc *OrderedCache) Ceil(key interface{}) (interface{}, interface{}, bool) {
+	if e, ok := oc.CeilEntry(key); ok {
 		return e.Key, e.Value, true
 	}
 	return nil, nil, false
 }
 
-// Floor returns the greatest cache entry less than or equal to key.
-func (oc *OrderedCache) Floor(key interface{}) (interface{}, interface{}, bool) {
+// FloorEntry returns the greatest cache entry less than or equal to key.
+func (oc *OrderedCache) FloorEntry(key interface{}) (*Entry, bool) {
 	if e, ok := oc.llrb.Floor(&Entry{Key: key}).(*Entry); ok {
+		return e, true
+	}
+	return nil, false
+}
+
+// Floor returns the greatest key-value pair less than or equal to key.
+func (oc *OrderedCache) Floor(key interface{}) (interface{}, interface{}, bool) {
+	if e, ok := oc.FloorEntry(key); ok {
 		return e.Key, e.Value, true
 	}
 	return nil, nil, false
 }
 
-// Do invokes f on all of the entries in the cache.
-func (oc *OrderedCache) Do(f func(k, v interface{})) {
-	oc.llrb.Do(func(e llrb.Comparable) (done bool) {
-		f(e.(*Entry).Key, e.(*Entry).Value)
-		return
+// DoEntry invokes f on all cache entries in the cache. f returns a boolean
+// indicating the traversal is done. If f returns true, the DoEntry loop will
+// exit; false, it will continue. DoEntry returns whether the iteration exited
+// early.
+func (oc *OrderedCache) DoEntry(f func(e *Entry) bool) bool {
+	return oc.llrb.Do(func(e llrb.Comparable) bool {
+		return f(e.(*Entry))
 	})
 }
 
-// DoRange invokes f on all cache entries in the range of from -> to.
-// f returns a boolean indicating the traversal is done. If f returns
-// true, the DoRange loop will exit; false, it will continue. DoRange
-// returns whether the iteration exited early.
-func (oc *OrderedCache) DoRange(f func(k, v interface{}) bool, from, to interface{}) bool {
+// Do invokes f on all key-value pairs in the cache. f returns a boolean
+// indicating the traversal is done. If f returns true, the Do loop will exit;
+// false, it will continue. Do returns whether the iteration exited early.
+func (oc *OrderedCache) Do(f func(k, v interface{}) bool) bool {
+	return oc.DoEntry(func(e *Entry) bool {
+		return f(e.Key, e.Value)
+	})
+}
+
+// DoRangeEntry invokes f on all cache entries in the range of from -> to. f
+// returns a boolean indicating the traversal is done. If f returns true, the
+// DoRangeEntry loop will exit; false, it will continue. DoRangeEntry returns
+// whether the iteration exited early.
+func (oc *OrderedCache) DoRangeEntry(f func(e *Entry) bool, from, to interface{}) bool {
 	return oc.llrb.DoRange(func(e llrb.Comparable) bool {
-		return f(e.(*Entry).Key, e.(*Entry).Value)
+		return f(e.(*Entry))
 	}, &Entry{Key: from}, &Entry{Key: to})
+}
+
+// DoRange invokes f on all key-value pairs in the range of from -> to. f
+// returns a boolean indicating the traversal is done. If f returns true, the
+// DoRange loop will exit; false, it will continue. DoRange returns whether the
+// iteration exited early.
+func (oc *OrderedCache) DoRange(f func(k, v interface{}) bool, from, to interface{}) bool {
+	return oc.DoRangeEntry(func(e *Entry) bool {
+		return f(e.Key, e.Value)
+	}, from, to)
 }
 
 // IntervalCache is a cache which supports querying of intervals which

--- a/pkg/util/cache/cache_test.go
+++ b/pkg/util/cache/cache_test.go
@@ -213,6 +213,35 @@ func TestOrderedCache(t *testing.T) {
 	if _, v, ok := oc.Floor(testKey("c")); !ok || v.(int) != 2 {
 		t.Error("expected fetch of key \"b\" for floor of maximum key")
 	}
+
+	// Test do over entire cache.
+	expKeys, collectKeys := []string{"a", "b"}, []string{}
+	expVals, collectVals := []int{1, 2}, []int{}
+	collect := func(k, v interface{}) bool {
+		collectKeys = append(collectKeys, string(k.(testKey)))
+		collectVals = append(collectVals, v.(int))
+		return false
+	}
+
+	oc.Do(collect)
+	if !reflect.DeepEqual(expKeys, collectKeys) {
+		t.Errorf("expected do to find keys %v, found %v", expKeys, collectKeys)
+	}
+	if !reflect.DeepEqual(expVals, collectVals) {
+		t.Errorf("expected do to find values %v, found %v", expVals, collectVals)
+	}
+
+	// Test doRange over range ["a","b").
+	expKeys, collectKeys = []string{"a"}, []string{}
+	expVals, collectVals = []int{1}, []int{}
+
+	oc.DoRange(collect, testKey("a"), testKey("b"))
+	if !reflect.DeepEqual(expKeys, collectKeys) {
+		t.Errorf("expected do to find keys %v, found %v", expKeys, collectKeys)
+	}
+	if !reflect.DeepEqual(expVals, collectVals) {
+		t.Errorf("expected do to find values %v, found %v", expVals, collectVals)
+	}
 }
 
 func TestOrderedCacheClear(t *testing.T) {


### PR DESCRIPTION
In 1a6ccc3 we introduced the `baseCache.DelEntry` method. This allows a
cache removal without requiring a lookup if the associated `cache.Entry`
has already been retrieved. This change exposes `...Entry` methods on
`OrderedCache` so that clients can use `DelEntry`.

The change then uses this new API in the `RangedescriptorCache` and
the `raftEntryCache`.