### PR TITLE
cherrypick-1.1: storage: expose site of error return

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3164,7 +3164,10 @@ type handleRaftReadyStats struct {
 // are ready to read, be saved to stable storage, committed or sent to other
 // peers. It takes a non-empty IncomingSnapshot to indicate that it is
 // about to process a snapshot.
-func (r *Replica) handleRaftReady(inSnap IncomingSnapshot) (handleRaftReadyStats, error) {
+//
+// The returned string is nonzero whenever an error is returned to give a
+// non-sensitive cue as to what happened.
+func (r *Replica) handleRaftReady(inSnap IncomingSnapshot) (handleRaftReadyStats, string, error) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	return r.handleRaftReadyRaftMuLocked(inSnap)
@@ -3172,9 +3175,12 @@ func (r *Replica) handleRaftReady(inSnap IncomingSnapshot) (handleRaftReadyStats
 
 // handleRaftReadyLocked is the same as handleRaftReady but requires that the
 // replica's raftMu be held.
+//
+// The returned string is nonzero whenever an error is returned to give a
+// non-sensitive cue as to what happened.
 func (r *Replica) handleRaftReadyRaftMuLocked(
 	inSnap IncomingSnapshot,
-) (handleRaftReadyStats, error) {
+) (handleRaftReadyStats, string, error) {
 	var stats handleRaftReadyStats
 
 	ctx := r.AnnotateCtx(context.TODO())
@@ -3217,11 +3223,12 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	})
 	r.mu.Unlock()
 	if err != nil {
-		return stats, err
+		const expl = "while checking raft group for Ready"
+		return stats, expl, errors.Wrap(err, expl)
 	}
 
 	if !hasReady {
-		return stats, nil
+		return stats, "", nil
 	}
 
 	logRaftReady(ctx, rd)
@@ -3247,7 +3254,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	if !raft.IsEmptySnap(rd.Snapshot) {
 		snapUUID, err := uuid.FromBytes(rd.Snapshot.Data)
 		if err != nil {
-			return stats, errors.Wrap(err, "invalid snapshot id")
+			const expl = "invalid snapshot id"
+			return stats, expl, errors.Wrap(err, expl)
 		}
 		if inSnap.SnapUUID == (uuid.UUID{}) {
 			log.Fatalf(ctx, "programming error: a snapshot application was attempted outside of the streaming snapshot codepath")
@@ -3257,7 +3265,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		}
 
 		if err := r.applySnapshot(ctx, inSnap, rd.Snapshot, rd.HardState); err != nil {
-			return stats, err
+			const expl = "while applying snapshot"
+			return stats, expl, errors.Wrap(err, expl)
 		}
 
 		if err := func() error {
@@ -3267,12 +3276,10 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			if r.store.removePlaceholderLocked(ctx, r.RangeID) {
 				atomic.AddInt32(&r.store.counts.filledPlaceholders, 1)
 			}
-			if err := r.store.processRangeDescriptorUpdateLocked(ctx, r); err != nil {
-				return errors.Wrap(err, "could not processRangeDescriptorUpdate after applySnapshot")
-			}
-			return nil
+			return r.store.processRangeDescriptorUpdateLocked(ctx, r)
 		}(); err != nil {
-			return stats, err
+			const expl = "could not processRangeDescriptorUpdate after applySnapshot"
+			return stats, expl, errors.Wrap(err, expl)
 		}
 
 		// r.mu.lastIndex and r.mu.lastTerm were updated in applySnapshot, but
@@ -3280,7 +3287,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		// variables we're tracking here. We could pull these values from
 		// r.mu itself, but that would require us to grab a lock.
 		if lastIndex, err = r.raftMu.stateLoader.loadLastIndex(ctx, r.store.Engine()); err != nil {
-			return stats, err
+			const expl = "loading last index"
+			return stats, expl, errors.Wrap(err, expl)
 		}
 		lastTerm = invalidLastTerm
 
@@ -3310,18 +3318,21 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		// last index.
 		thinEntries, sideLoadedEntriesSize, err := r.maybeSideloadEntriesRaftMuLocked(ctx, rd.Entries)
 		if err != nil {
-			return stats, err
+			const expl = "during sideloading"
+			return stats, expl, errors.Wrap(err, expl)
 		}
 		raftLogSize += sideLoadedEntriesSize
 		if lastIndex, lastTerm, raftLogSize, err = r.append(
 			ctx, writer, lastIndex, lastTerm, raftLogSize, thinEntries,
 		); err != nil {
-			return stats, err
+			const expl = "during append"
+			return stats, expl, errors.Wrap(err, expl)
 		}
 	}
 	if !raft.IsEmptyHardState(rd.HardState) {
 		if err := r.raftMu.stateLoader.setHardState(ctx, writer, rd.HardState); err != nil {
-			return stats, err
+			const expl = "during setHardState"
+			return stats, expl, errors.Wrap(err, expl)
 		}
 	}
 	writer.Close()
@@ -3340,7 +3351,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// infer the that entries are persisted on the node that sends a snapshot.
 	start := timeutil.Now()
 	if err := batch.Commit(syncRaftLog.Get(&r.store.cfg.Settings.SV) && rd.MustSync); err != nil {
-		return stats, err
+		const expl = "while committing batch"
+		return stats, expl, errors.Wrap(err, expl)
 	}
 	elapsed := timeutil.Since(start)
 	r.store.metrics.RaftLogCommitLatency.RecordValue(elapsed.Nanoseconds())
@@ -3357,7 +3369,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		for i := firstPurge; i <= lastPurge; i++ {
 			err := r.raftMu.sideloaded.Purge(ctx, i, purgeTerm)
 			if err != nil && errors.Cause(err) != errSideloadedFileNotFound {
-				return stats, errors.Wrapf(err, "while purging index %d", i)
+				const expl = "while purging index %d"
+				return stats, expl, errors.Wrapf(err, expl, i)
 			}
 		}
 	}
@@ -3428,7 +3441,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			if newEnt, err := maybeInlineSideloadedRaftCommand(
 				ctx, r.RangeID, e, r.raftMu.sideloaded, r.store.raftEntryCache,
 			); err != nil {
-				return stats, err
+				const expl = "maybeInlineSideloadedRaftCommand"
+				return stats, expl, errors.Wrap(err, expl)
 			} else if newEnt != nil {
 				e = *newEnt
 			}
@@ -3459,7 +3473,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 				if len(encodedCommand) == 0 {
 					commandID = ""
 				} else if err := command.Unmarshal(encodedCommand); err != nil {
-					return stats, err
+					const expl = "while unmarshalling entry"
+					return stats, expl, errors.Wrap(err, expl)
 				}
 			}
 
@@ -3486,15 +3501,18 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		case raftpb.EntryConfChange:
 			var cc raftpb.ConfChange
 			if err := cc.Unmarshal(e.Data); err != nil {
-				return stats, err
+				const expl = "while unmarshaling ConfChange"
+				return stats, expl, errors.Wrap(err, expl)
 			}
 			var ccCtx ConfChangeContext
 			if err := ccCtx.Unmarshal(cc.Context); err != nil {
-				return stats, err
+				const expl = "while unmarshaling ConfChangeContext"
+				return stats, expl, errors.Wrap(err, expl)
 			}
 			var command storagebase.RaftCommand
 			if err := command.Unmarshal(ccCtx.Payload); err != nil {
-				return stats, err
+				const expl = "while unmarshaling RaftCommand"
+				return stats, expl, errors.Wrap(err, expl)
 			}
 			commandID := storagebase.CmdIDKey(ccCtx.CommandID)
 			if changedRepl := r.processRaftCommand(
@@ -3518,7 +3536,8 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 				raftGroup.ApplyConfChange(cc)
 				return true, nil
 			}); err != nil {
-				return stats, err
+				const expl = "during ApplyConfChange"
+				return stats, expl, errors.Wrap(err, expl)
 			}
 		default:
 			log.Fatalf(ctx, "unexpected Raft entry: %v", e)
@@ -3533,10 +3552,14 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// TODO(bdarnell): need to check replica id and not Advance if it
 	// has changed. Or do we need more locking to guarantee that replica
 	// ID cannot change during handleRaftReady?
-	return stats, r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
+	const expl = "during advance"
+	if err := r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
 		raftGroup.Advance(rd)
 		return true, nil
-	})
+	}); err != nil {
+		return stats, expl, errors.Wrap(err, expl)
+	}
+	return stats, "", nil
 }
 
 // tick the Raft group, returning any error and true if the raft group exists

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1712,10 +1712,10 @@ func (r *Replica) assertStateLocked(ctx context.Context, reader engine.Reader) {
 		// TODO(dt): expose properly once #15892 is addressed.
 		log.Errorf(ctx, "on-disk and in-memory state diverged:\n%s", pretty.Diff(diskState, r.mu.state))
 		r.mu.state.Desc, diskState.Desc = nil, nil
-		log.Fatal(ctx, log.Safe{
-			V: fmt.Sprintf("on-disk and in-memory state diverged: %s",
+		log.Fatal(ctx, log.Safe(
+			fmt.Sprintf("on-disk and in-memory state diverged: %s",
 				pretty.Diff(diskState, r.mu.state)),
-		})
+		))
 	}
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6644,11 +6644,11 @@ func TestQuotaPoolAccessOnDestroyedReplica(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := repl.handleRaftReady(IncomingSnapshot{}); err != nil {
+	if _, _, err := repl.handleRaftReady(IncomingSnapshot{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := repl.handleRaftReady(IncomingSnapshot{}); err != nil {
+	if _, _, err := repl.handleRaftReady(IncomingSnapshot{}); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3179,9 +3179,9 @@ func (s *Store) processRaftRequest(
 		return roachpb.NewError(err)
 	}
 
-	if _, err := r.handleRaftReadyRaftMuLocked(inSnap); err != nil {
-		// mimic the behavior in processRaft.
-		log.Fatal(ctx, err)
+	if _, expl, err := r.handleRaftReadyRaftMuLocked(inSnap); err != nil {
+		// Mimic the behavior in processRaft.
+		log.Fatalf(ctx, "%s: %s", log.Safe(expl), err) // TODO(bdarnell)
 	}
 	removePlaceholder = false
 	return nil
@@ -3565,9 +3565,9 @@ func (s *Store) processReady(ctx context.Context, rangeID roachpb.RangeID) {
 
 	start := timeutil.Now()
 	r := (*Replica)(value)
-	stats, err := r.handleRaftReady(IncomingSnapshot{})
+	stats, expl, err := r.handleRaftReady(IncomingSnapshot{})
 	if err != nil {
-		log.Fatal(ctx, err) // TODO(bdarnell)
+		log.Fatalf(ctx, "%s: %s", log.Safe(expl), err) // TODO(bdarnell)
 	}
 	elapsed := timeutil.Since(start)
 	s.metrics.RaftWorkingDurationNanos.Inc(elapsed.Nanoseconds())

--- a/pkg/util/log/crash_reporting_test.go
+++ b/pkg/util/log/crash_reporting_test.go
@@ -15,25 +15,64 @@
 package log
 
 import (
+	"fmt"
+	"runtime"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
-func TestCrashReportingFormatSave(t *testing.T) {
-	r1 := "i am hidden"
-	r2 := Safe{V: "i am public"}
-	r3 := Safe{V: &r2}
-	f1, f2, f3 := format(r1), format(r2), format(r3)
-	exp1, exp2 := "string", r2.V.(string)
-	exp3 := "&{V:i am public}"
-	if f1 != exp1 {
-		t.Errorf("wanted %s, got %s", exp1, f1)
+func TestCrashReportingSafeError(t *testing.T) {
+	type testCase struct {
+		format  string
+		rs      []interface{}
+		expType string
+		expErr  string
 	}
-	if f2 != exp2 {
-		t.Errorf("wanted %s, got %s", exp2, f2)
+
+	runtimeErr := &runtime.TypeAssertionError{}
+
+	testCases := []testCase{
+		{
+			// Intended result of panic(context.DeadlineExceeded).
+			format: "", rs: []interface{}{context.DeadlineExceeded},
+			expType: "*log.safeError", expErr: "?:0: <context.deadlineExceededError>",
+		},
+		{
+			// Intended result of panic(runtimeErr) which exhibits special case of known safe error.
+			format: "", rs: []interface{}{runtimeErr},
+			expType: "*runtime.TypeAssertionError", expErr: "interface conversion: interface is nil, not ",
+		},
+		{
+			// Special-casing switched off when format string present.
+			format: "%s", rs: []interface{}{runtimeErr},
+			expType: "*log.safeError", expErr: "?:0: %s | interface conversion: interface is nil, not ",
+		},
+		{
+			// Special-casing switched off when more than one reportable present.
+			format: "", rs: []interface{}{runtimeErr, "foo"},
+			expType: "*log.safeError", expErr: "?:0: interface conversion: interface is nil, not ; <string>",
+		},
+		{
+			format: "I like %s and %q and my pin code is %d", rs: []interface{}{Safe("A"), &SafeType{V: "B"}, 1234},
+			expType: "*log.safeError", expErr: "?:0: I like %s and %q and my pin code is %d | A; B; <int>",
+		},
 	}
-	if f3 != exp3 {
-		t.Errorf("wanted %s, got %s", exp3, f3)
+
+	for _, test := range testCases {
+		t.Run("", func(t *testing.T) {
+			err := reportablesToSafeError(0, test.format, test.rs)
+			if err == nil {
+				t.Fatal(err)
+			}
+			if typStr := fmt.Sprintf("%T", err); typStr != test.expType {
+				t.Errorf("expected %s, got %s", test.expType, typStr)
+			}
+			if errStr := err.Error(); errStr != test.expErr {
+				t.Errorf("expected %q, got %q", test.expErr, errStr)
+			}
+		})
 	}
 }
 

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -17,7 +17,6 @@ package log
 import (
 	"bytes"
 	"fmt"
-	"path/filepath"
 	"strconv"
 
 	"golang.org/x/net/context"
@@ -142,18 +141,10 @@ func addStructured(ctx context.Context, s Severity, depth int, format string, ar
 	msg := MakeMessage(ctx, format, args)
 
 	if s == Severity_FATAL {
-		// we send the `format` str, not the formatted message, as args may be not
-		// be okay to share.
-		reportable := format
-		if reportable == "" && len(args) > 0 {
-			reportable = fmt.Sprintf("%T", args[0])
-		}
-		reportable = fmt.Sprintf("%s:%d %s", filepath.Base(file), line, reportable)
-
 		// We load the ReportingSettings from the a global singleton in this
 		// call path. See the singleton's comment for a rationale.
 		if sv, ok := (ReportingSettingsSingleton.Load()).(*settings.Values); ok {
-			sendCrashReport(ctx, sv, reportable, depth+1)
+			sendCrashReport(ctx, sv, depth+2, format, args)
 		}
 	}
 	// MakeMessage already added the tags when forming msg, we don't want


### PR DESCRIPTION
Slight conflicts in replica.go due to not having #18336 on release-1.1, but only very minor.

cc @cockroachdb/release