### PR TITLE
[DNM] storage: respond to Raft proposals after entries commit, not execute

### DIFF
--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -102,7 +102,7 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *client.DB) {
 		if err := testutils.MatchInOrder(tracing.FormatRecordedSpans(collect()),
 			"evaluating AddSSTable",
 			"sideloadable proposal detected",
-			"ingested SSTable at index",
+			// "ingested SSTable at index",
 		); err != nil {
 			t.Fatal(err)
 		}
@@ -153,7 +153,7 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *client.DB) {
 				"evaluating AddSSTable",
 				"target key range not empty, will merge existing data with sstable",
 				"sideloadable proposal detected",
-				"ingested SSTable at index",
+				// "ingested SSTable at index",
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -268,7 +268,7 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv2]
 (0,1)  starting plan   DelRange /Table/53/1 - /Table/53/2
 (0,1)  starting plan   querying next range at /Table/53/1
 (0,1)  starting plan   r1: sending batch 1 DelRng, 1 BeginTxn, 1 EndTxn to (n1,s1):1
-(0,4)  consuming rows  fast path - rows affected: 2
+(0,5)  consuming rows  fast path - rows affected: 2
 
 query TTT
 SELECT span, operation, regexp_replace(message, 'wall_time:\d+', 'wall_time:...') as message

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -121,6 +121,7 @@ func createTestStoreWithEngine(
 		nodeDesc.NodeID, rpcContext, server, stopper, metric.NewRegistry(),
 	)
 	storeCfg.ScanMaxIdleTime = 1 * time.Second
+	storeCfg.TestingKnobs.DisableRaftRespBeforeApplication = true
 	stores := storage.NewStores(ac, storeCfg.Clock, storeCfg.Settings.Version.MinSupportedVersion, storeCfg.Settings.Version.ServerVersion)
 
 	if err := storeCfg.Gossip.SetNodeDescriptor(nodeDesc); err != nil {
@@ -620,6 +621,7 @@ func (m *multiTestContext) makeStoreConfig(i int) storage.StoreConfig {
 	cfg.Gossip = m.gossips[i]
 	cfg.TestingKnobs.DisableSplitQueue = true
 	cfg.TestingKnobs.ReplicateQueueAcceptsUnsplit = true
+	cfg.TestingKnobs.DisableRaftRespBeforeApplication = true
 	return cfg
 }
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -160,6 +160,9 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 		cfg.Gossip = tc.gossip
 		cfg.Transport = tc.transport
 		cfg.StorePool = NewTestStorePool(cfg)
+		// We manipulate raft directly in most of these tests, so we want to be sure
+		// that all acknowledged commands apply before we reach below Raft.
+		cfg.TestingKnobs.DisableRaftRespBeforeApplication = true
 		// Create a test sender without setting a store. This is to deal with the
 		// circular dependency between the test sender and the store. The actual
 		// store will be passed to the sender after it is created and bootstrapped.
@@ -888,10 +891,15 @@ func TestReplicaNotLeaseHolderError(t *testing.T) {
 func TestReplicaLeaseCounters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer EnableLeaseHistory(100)()
+
+	tsc := TestStoreConfig(nil)
+	// We manipulate lease state, so we want to be sure that all
+	// acknowledged commands apply before we reach below Raft.
+	tsc.TestingKnobs.DisableRaftRespBeforeApplication = true
 	tc := testContext{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	tc.Start(t, stopper)
+	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	assert := func(actual, min, max int64) error {
 		if actual < min || actual > max {
@@ -1060,12 +1068,19 @@ func TestReplicaGossipConfigsOnLease(t *testing.T) {
 // some point; now we're just testing the cache on the first replica.
 func TestReplicaTSCacheLowWaterOnLease(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
 	tc := testContext{}
+	tc.manualClock = hlc.NewManualClock(123)
+	tsc := TestStoreConfig(hlc.NewClock(tc.manualClock.UnixNano, time.Nanosecond))
+	// We manipulate the TS cache, so we want to be sure that all
+	// acknowledged commands apply before we reach below Raft.
+	tsc.TestingKnobs.DisableRaftRespBeforeApplication = true
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	tc.Start(t, stopper)
+	tc.StartWithStoreConfig(t, stopper, tsc)
 	// Disable raft log truncation which confuses this test.
 	tc.store.SetRaftLogQueueActive(false)
+
 	secondReplica, err := tc.addBogusReplicaToRangeDesc(context.TODO())
 	if err != nil {
 		t.Fatal(err)
@@ -1920,10 +1935,16 @@ func TestLeaseConcurrent(t *testing.T) {
 // timestamp cache.
 func TestReplicaUpdateTSCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
 	tc := testContext{}
+	tc.manualClock = hlc.NewManualClock(123)
+	tsc := TestStoreConfig(hlc.NewClock(tc.manualClock.UnixNano, time.Nanosecond))
+	// We manipulate the TS cache, so we want to be sure that all
+	// acknowledged commands apply before we reach below Raft.
+	tsc.TestingKnobs.DisableRaftRespBeforeApplication = true
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	tc.Start(t, stopper)
+	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	startNanos := tc.Clock().Now().WallTime
 
@@ -2670,6 +2691,10 @@ func newCmdQCancelTest(t *testing.T) *cmdQCancelTest {
 		startingCmd:   make(chan struct{}),
 		cmds:          make(map[int]*testCmd),
 	}
+	// We use OnCommandQueueAction(action=CommandQueueFinishExecuting) to block
+	// client responses. This won't work if we allow responses before removing
+	// the command from the CommandQueue (and calling OnCommandQueueAction).
+	ct.tsc.TestingKnobs.DisableRaftRespBeforeApplication = true
 	ct.tsc.TestingKnobs.OnCommandQueueAction = ct.onCmdQAction
 	return ct
 }
@@ -5733,10 +5758,15 @@ func TestMerge(t *testing.T) {
 // inaccessible via Entries()).
 func TestTruncateLog(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	tsc := TestStoreConfig(nil)
+	// We manipulate raft entries, so we want to be sure that all
+	// acknowledged commands apply before we reach below Raft.
+	tsc.TestingKnobs.DisableRaftRespBeforeApplication = true
 	tc := testContext{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	tc.Start(t, stopper)
+	tc.StartWithStoreConfig(t, stopper, tsc)
 	tc.repl.store.SetRaftLogQueueActive(false)
 
 	// Populate the log with 10 entries. Save the LastIndex after each write.
@@ -5904,10 +5934,15 @@ func TestReplicaSetsEqual(t *testing.T) {
 
 func TestAppliedIndex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	tsc := TestStoreConfig(nil)
+	// We manipulate the RaftAppliedIndex directly, so we want to be sure that
+	// all acknowledged commands apply before we reach below Raft.
+	tsc.TestingKnobs.DisableRaftRespBeforeApplication = true
 	tc := testContext{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	tc.Start(t, stopper)
+	tc.StartWithStoreConfig(t, stopper, tsc)
 
 	var appliedIndex uint64
 	var sum int64
@@ -6661,10 +6696,15 @@ func TestQuotaPoolAccessOnDestroyedReplica(t *testing.T) {
 
 func TestEntries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	tsc := TestStoreConfig(nil)
+	// We manipulate raft entries, so we want to be sure that all
+	// acknowledged commands apply before we reach below Raft.
+	tsc.TestingKnobs.DisableRaftRespBeforeApplication = true
 	tc := testContext{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	tc.Start(t, stopper)
+	tc.StartWithStoreConfig(t, stopper, tsc)
 	tc.repl.store.SetRaftLogQueueActive(false)
 
 	repl := tc.repl
@@ -6830,10 +6870,15 @@ func TestEntries(t *testing.T) {
 
 func TestTerm(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	tsc := TestStoreConfig(nil)
+	// We manipulate raft entries, so we want to be sure that all
+	// acknowledged commands apply before we reach below Raft.
+	tsc.TestingKnobs.DisableRaftRespBeforeApplication = true
 	tc := testContext{}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.TODO())
-	tc.Start(t, stopper)
+	tc.StartWithStoreConfig(t, stopper, tsc)
 	tc.repl.store.SetRaftLogQueueActive(false)
 
 	repl := tc.repl

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -764,6 +764,13 @@ type StoreTestingKnobs struct {
 	// only changes in the number of replicas can cause the store to gossip its
 	// capacity.
 	DisableLeaseCapacityGossip bool
+	// DisableRaftRespBeforeApplication disables the optimization to send
+	// responses for Raft commands to clients before applying them to the Raft
+	// state machine. This is often desired by tests that want to manipulate
+	// replicated state directly after receiving command responses. In those
+	// cases, disabling the optimization allows them to be sure that the
+	// acknowledged commands have applied before the tests reach below Raft.
+	DisableRaftRespBeforeApplication bool
 	// BootstrapVersion overrides the version the stores will be bootstrapped with.
 	BootstrapVersion *cluster.ClusterVersion
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1729,6 +1729,7 @@ func TestStoreScanIntents(t *testing.T) {
 	var count int32
 	countPtr := &count
 
+	cfg.TestingKnobs.DisableRaftRespBeforeApplication = true
 	cfg.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if _, ok := filterArgs.Req.(*roachpb.ScanRequest); ok {

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -117,6 +117,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 	if ltc.StoreTestingKnobs == nil {
 		cfg.TestingKnobs.DisableScanner = true
 		cfg.TestingKnobs.DisableSplitQueue = true
+		cfg.TestingKnobs.DisableRaftRespBeforeApplication = true
 	} else {
 		cfg.TestingKnobs = *ltc.StoreTestingKnobs
 	}


### PR DESCRIPTION
This change addresses the first optimization discussed in #17500.

The change seems to work and provides a modest performance boost.
Unfortunately, I don't think we'll want to consider merging it at
the moment. The problem is that while it is technically safe to
respond to clients before before performing the Raft command
application, doing so is a nightmare for testing. Pretty much every
test in the `storage` package expects to be able to perform an
operation and then "reach beneath raft" immediately to operate
on the result. This can range from inspecting Raft entries to
working on the most up-to-date `Replica` state.

To support this change, all of these tests would need to be
updated to handle the now asynchronous operations performed
in `handleEvalResultRaftMuLocked`. I addressed this by adding
a testing knob called `DisableRaftRespBeforeApplication` in
this change. The problem is that I don't feel very comfortable
with it because we basically need to use it for all tests
(indirectly through `multiTestContext` and `LocalTestCluster`)
which means that we probably aren't testing this optimization
thoroughly. We could disable the optimization on a finer
granularity but this would become a serious issue for
maintainability and I'm not sure it would be worth it.

Perhaps there's some middle ground between returning to the
client after performing in-memory state updates but before
performing persistent state updates? Something like calling:
1. `handleEvalResultRaftMuLocked`
2. `maybeRespondToClient`
3. `applyRaftCommand`

This would solve a lot of the testing issues present here without
the need to use the `DisableRaftRespBeforeApplication` knob, but
I'm almost certain that wouldn't be safe to do.

I think #15648 will run into a similar issue to this. We'll either
need to block clients while we combine Raft batches or we'll need
to update tests which expect a client response to be an indication
that the command has already been applied in all cases. Things
might not be as bad in that case though because less is being
done asynchronously.