### PR TITLE
storage: remove /Local/RangeID/X/u/RaftLastIndex

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -194,6 +194,9 @@ func bootstrapCluster(
 	sender := kv.NewTxnCoordSender(cfg.AmbientCtx, cfg.Settings, stores, cfg.Clock, false, stopper, txnMetrics)
 	cfg.DB = client.NewDB(sender, cfg.Clock)
 	cfg.Transport = storage.NewDummyRaftTransport(cfg.Settings)
+	if err := cfg.Settings.InitializeVersion(bootstrapVersion); err != nil {
+		return uuid.UUID{}, errors.Wrap(err, "while initializing cluster version")
+	}
 	for i, eng := range engines {
 		sIdent := roachpb.StoreIdent{
 			ClusterID: clusterID,

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -108,13 +108,13 @@ func setupMixedCluster(
 	return testClusterWithHelpers{t, tc}
 }
 
-func TestClusterVersionUpgrade1_0To1_1(t *testing.T) {
+func TestClusterVersionUpgrade1_0To1_2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	// Four nodes that are all compatible with 1.0, but are really 1.1. This is
-	// what the official v1.1 binary will look like.
-	versions := [][2]string{{"1.0", "1.1"}, {"1.0", "1.1"}, {"1.0", "1.1"}, {"1.0", "1.1"}}
+	// Four nodes that are all compatible with 1.0, but are really 1.2. This is
+	// what the official v1.2 binary will look like.
+	versions := [][2]string{{"1.0", "1.2"}, {"1.0", "1.2"}, {"1.0", "1.2"}, {"1.0", "1.2"}}
 
 	// Start by running 1.0.
 	bootstrapVersion := cluster.ClusterVersion{
@@ -135,6 +135,7 @@ func TestClusterVersionUpgrade1_0To1_1(t *testing.T) {
 		bootstrapVersion.MinimumVersion, // v1.0
 		{Major: 1, Unstable: 500},
 		{Major: 1, Minor: 1},
+		{Major: 1, Minor: 2},
 	} {
 		curVersion := tc.getVersionFromSelect(0)
 		isNoopUpdate := curVersion == newVersion.String()

--- a/pkg/settings/cluster/cluster_version.go
+++ b/pkg/settings/cluster/cluster_version.go
@@ -24,7 +24,7 @@ var (
 	BinaryMinimumSupportedVersion = VersionBase
 
 	// BinaryServerVersion is the version of this binary.
-	BinaryServerVersion = VersionStatsBasedRebalancing
+	BinaryServerVersion = VersionRaftLastIndex
 )
 
 // List all historical versions here in reverse chronological order, with
@@ -33,6 +33,9 @@ var (
 // NB: when adding a version, don't forget to bump ServerVersion above (and
 // perhaps MinimumSupportedVersion, if necessary).
 var (
+	// VersionRaftLastIndex is https://github.com/cockroachdb/cockroach/pull/18717.
+	VersionRaftLastIndex = roachpb.Version{Major: 1, Minor: 1, Unstable: 1}
+
 	// VersionStatsBasedRebalancing is https://github.com/cockroachdb/cockroach/pull/16878.
 	VersionStatsBasedRebalancing = roachpb.Version{Major: 1, Minor: 0, Unstable: 3}
 
@@ -47,3 +50,9 @@ var (
 	// this version is used.
 	VersionBase = roachpb.Version{Major: 1}
 )
+
+// IsActive returns true if the features of the supplied version are active at
+// the running version.
+func (cv ClusterVersion) IsActive(v roachpb.Version) bool {
+	return !cv.UseVersion.Less(v)
+}

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -153,7 +153,7 @@ func (ecv *ExposedClusterVersion) BootstrapVersion() ClusterVersion {
 // IsActive returns true if the features of the supplied version are active at
 // the running version.
 func (ecv *ExposedClusterVersion) IsActive(v roachpb.Version) bool {
-	return !ecv.Version().UseVersion.Less(v)
+	return ecv.Version().IsActive(v)
 }
 
 // MakeTestingClusterSettings returns a Settings object that has had its version

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -94,7 +94,7 @@ sql.trace.txn.enable_threshold                     0s             d     duration
 trace.debug.enable                                 false          b     if set, traces for recent requests can be seen in the /debug page
 trace.lightstep.token                              ·              s     if set, traces go to Lightstep using this token
 trace.zipkin.collector                             ·              s     if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.
-version                                            1.0-3          m     set the active cluster version in the format '<major>.<minor>'.
+version                                            1.1-1          m     set the active cluster version in the format '<major>.<minor>'.
 
 query T colnames
 SELECT * FROM [SHOW SESSION_USER]

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -611,13 +611,11 @@ func declareKeysEndTransaction(
 				EndKey: rightRangeIDUnreplicatedPrefix.PrefixEnd(),
 			})
 
-			leftStateLoader := makeReplicaStateLoader(st.LeftDesc.RangeID)
 			spans.Add(SpanReadOnly, roachpb.Span{
-				Key: leftStateLoader.RangeLastReplicaGCTimestampKey(),
+				Key: keys.RangeLastReplicaGCTimestampKey(st.LeftDesc.RangeID),
 			})
-			rightStateLoader := makeReplicaStateLoader(st.RightDesc.RangeID)
 			spans.Add(SpanReadWrite, roachpb.Span{
-				Key: rightStateLoader.RangeLastReplicaGCTimestampKey(),
+				Key: keys.RangeLastReplicaGCTimestampKey(st.RightDesc.RangeID),
 			})
 
 			spans.Add(SpanReadOnly, roachpb.Span{
@@ -1518,7 +1516,7 @@ func evalGC(
 	}
 
 	var pd EvalResult
-	stateLoader := makeReplicaStateLoader(cArgs.EvalCtx.RangeID())
+	stateLoader := cArgs.EvalCtx.makeReplicaStateLoader()
 
 	// Don't write these keys unless we have to. We also don't declare these
 	// keys unless we have to (to allow the GC queue to batch requests more
@@ -1982,7 +1980,7 @@ func evalTruncateLog(
 	pd.Replicated.State.TruncatedState = tState
 	pd.Replicated.RaftLogDelta = &ms.SysBytes
 
-	return pd, makeReplicaStateLoader(cArgs.EvalCtx.RangeID()).setTruncatedState(ctx, batch, cArgs.Stats, tState)
+	return pd, cArgs.EvalCtx.makeReplicaStateLoader().setTruncatedState(ctx, batch, cArgs.Stats, tState)
 }
 
 func newFailedLeaseTrigger(isTransfer bool) EvalResult {
@@ -1999,8 +1997,7 @@ func newFailedLeaseTrigger(isTransfer bool) EvalResult {
 func declareKeysRequestLease(
 	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *SpanSet,
 ) {
-	loader := makeReplicaStateLoader(header.RangeID)
-	spans.Add(SpanReadWrite, roachpb.Span{Key: loader.RangeLeaseKey()})
+	spans.Add(SpanReadWrite, roachpb.Span{Key: keys.RangeLeaseKey(header.RangeID)})
 	spans.Add(SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})
 }
 
@@ -2150,7 +2147,7 @@ func evalNewLease(
 	}
 
 	// Store the lease to disk & in-memory.
-	if err := makeReplicaStateLoader(rec.RangeID()).setLease(ctx, batch, ms, lease); err != nil {
+	if err := rec.makeReplicaStateLoader().setLease(ctx, batch, ms, lease); err != nil {
 		return newFailedLeaseTrigger(isTransfer), err
 	}
 
@@ -3090,7 +3087,7 @@ func splitTrigger(
 		//
 		// TODO(tschottdorf): why would this use r.store.Engine() and not the
 		// batch?
-		leftLease, err := makeReplicaStateLoader(rec.RangeID()).loadLease(ctx, rec.Engine())
+		leftLease, err := rec.makeReplicaStateLoader().loadLease(ctx, rec.Engine())
 		if err != nil {
 			return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to load lease")
 		}
@@ -3108,7 +3105,7 @@ func splitTrigger(
 		rightLease := leftLease
 		rightLease.Replica = replica
 
-		gcThreshold, err := makeReplicaStateLoader(rec.RangeID()).loadGCThreshold(ctx, rec.Engine())
+		gcThreshold, err := rec.makeReplicaStateLoader().loadGCThreshold(ctx, rec.Engine())
 		if err != nil {
 			return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to load GCThreshold")
 		}
@@ -3116,7 +3113,7 @@ func splitTrigger(
 			log.VEventf(ctx, 1, "LHS's GCThreshold of split is not set")
 		}
 
-		txnSpanGCThreshold, err := makeReplicaStateLoader(rec.RangeID()).loadTxnSpanGCThreshold(ctx, rec.Engine())
+		txnSpanGCThreshold, err := rec.makeReplicaStateLoader().loadTxnSpanGCThreshold(ctx, rec.Engine())
 		if err != nil {
 			return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to load TxnSpanGCThreshold")
 		}
@@ -3154,7 +3151,8 @@ func splitTrigger(
 		// writeInitialReplicaState which essentially writes a ReplicaState
 		// only.
 		rightMS, err = writeInitialReplicaState(
-			ctx, batch, rightMS, split.RightDesc, rightLease, gcThreshold, txnSpanGCThreshold,
+			ctx, rec.ClusterSettings(), batch, rightMS, split.RightDesc,
+			rightLease, gcThreshold, txnSpanGCThreshold,
 		)
 		if err != nil {
 			return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to write initial Replica state")
@@ -3165,7 +3163,8 @@ func splitTrigger(
 			// clobber downstream simply because that's what 1.0 does and if we
 			// don't write it here, then a 1.0 version applying it as a follower
 			// won't write a HardState at all and is guaranteed to crash.
-			if err := makeReplicaStateLoader(split.RightDesc.RangeID).synthesizeRaftState(ctx, batch); err != nil {
+			rsl := makeReplicaStateLoader(rec.repl.store.cfg.Settings, split.RightDesc.RangeID)
+			if err := rsl.synthesizeRaftState(ctx, batch); err != nil {
 				return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to synthesize initial Raft state")
 			}
 		}
@@ -3387,7 +3386,7 @@ func mergeTrigger(
 	mergedMS.Add(msRange)
 
 	// Set stats for updated range.
-	if err := makeReplicaStateLoader(rec.RangeID()).setMVCCStats(ctx, batch, &mergedMS); err != nil {
+	if err := rec.makeReplicaStateLoader().setMVCCStats(ctx, batch, &mergedMS); err != nil {
 		return EvalResult{}, errors.Errorf("unable to write MVCC stats: %s", err)
 	}
 

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -738,8 +738,10 @@ func TestRaftSSTableSideloadingSnapshot(t *testing.T) {
 			if withSS {
 				ss = tc.repl.raftMu.sideloaded
 			}
+			rsl := makeReplicaStateLoader(tc.store.ClusterSettings(), tc.repl.RangeID)
 			entries, err := entries(
-				ctx, tc.store.Engine(), tc.repl.RangeID, tc.store.raftEntryCache, ss, sideloadedIndex, sideloadedIndex+1, 1<<20,
+				ctx, rsl, tc.store.Engine(), tc.repl.RangeID, tc.store.raftEntryCache,
+				ss, sideloadedIndex, sideloadedIndex+1, 1<<20,
 			)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -15,6 +15,9 @@
 package storage
 
 import (
+	"bytes"
+	"math"
+
 	"github.com/coreos/etcd/raft/raftpb"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -27,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -46,13 +50,16 @@ import (
 // struct with a mutex, and temporary loaders may be created when
 // locking is less desirable than an allocation.
 type replicaStateLoader struct {
+	st *cluster.Settings
 	keys.RangeIDPrefixBuf
 }
 
-func makeReplicaStateLoader(rangeID roachpb.RangeID) replicaStateLoader {
-	return replicaStateLoader{
+func makeReplicaStateLoader(st *cluster.Settings, rangeID roachpb.RangeID) replicaStateLoader {
+	rsl := replicaStateLoader{
+		st:               st,
 		RangeIDPrefixBuf: keys.MakeRangeIDPrefixBuf(rangeID),
 	}
+	return rsl
 }
 
 // loadState loads a ReplicaState from disk. The exception is the Desc field,
@@ -152,13 +159,6 @@ func (rsl replicaStateLoader) setLease(
 ) error {
 	return engine.MVCCPutProto(ctx, eng, ms, rsl.RangeLeaseKey(),
 		hlc.Timestamp{}, nil, &lease)
-}
-
-func loadAppliedIndex(
-	ctx context.Context, reader engine.Reader, rangeID roachpb.RangeID,
-) (uint64, uint64, error) {
-	rsl := makeReplicaStateLoader(rangeID)
-	return rsl.loadAppliedIndex(ctx, reader)
 }
 
 // loadAppliedIndex returns the Raft applied index and the lease applied index.
@@ -269,13 +269,6 @@ func (rsl replicaStateLoader) calcAppliedIndexSysBytes(
 		inlineValueIntEncodedSize(int64(leaseAppliedIndex)))
 }
 
-func loadTruncatedState(
-	ctx context.Context, reader engine.Reader, rangeID roachpb.RangeID,
-) (roachpb.RaftTruncatedState, error) {
-	rsl := makeReplicaStateLoader(rangeID)
-	return rsl.loadTruncatedState(ctx, reader)
-}
-
 func (rsl replicaStateLoader) loadTruncatedState(
 	ctx context.Context, reader engine.Reader,
 ) (roachpb.RaftTruncatedState, error) {
@@ -360,29 +353,27 @@ func (rsl replicaStateLoader) setMVCCStats(
 // with its TruncatedState) but are different in that they are not consistently
 // updated through Raft.
 
-func loadLastIndex(
-	ctx context.Context, reader engine.Reader, rangeID roachpb.RangeID,
-) (uint64, error) {
-	rsl := makeReplicaStateLoader(rangeID)
-	return rsl.loadLastIndex(ctx, reader)
-}
-
 func (rsl replicaStateLoader) loadLastIndex(
 	ctx context.Context, reader engine.Reader,
 ) (uint64, error) {
+	iter := reader.NewIterator(false)
+	defer iter.Close()
+
 	var lastIndex uint64
-	v, _, err := engine.MVCCGet(ctx, reader, rsl.RaftLastIndexKey(),
-		hlc.Timestamp{}, true /* consistent */, nil)
-	if err != nil {
-		return 0, err
-	}
-	if v != nil {
-		int64LastIndex, err := v.GetInt()
-		if err != nil {
-			return 0, err
+	iter.SeekReverse(engine.MakeMVCCMetadataKey(rsl.RaftLogKey(math.MaxUint64)))
+	if ok, _ := iter.Valid(); ok {
+		key := iter.Key()
+		prefix := rsl.RaftLogPrefix()
+		if bytes.HasPrefix(key.Key, prefix) {
+			var err error
+			_, lastIndex, err = encoding.DecodeUint64Ascending(key.Key[len(prefix):])
+			if err != nil {
+				log.Fatalf(ctx, "unable to decode Raft log index key: %s", key)
+			}
 		}
-		lastIndex = uint64(int64LastIndex)
-	} else {
+	}
+
+	if lastIndex == 0 {
 		// The log is empty, which means we are either starting from scratch
 		// or the entire log has been truncated away.
 		lastEnt, err := rsl.loadTruncatedState(ctx, reader)
@@ -397,6 +388,9 @@ func (rsl replicaStateLoader) loadLastIndex(
 func (rsl replicaStateLoader) setLastIndex(
 	ctx context.Context, eng engine.ReadWriter, lastIndex uint64,
 ) error {
+	if rsl.st.Version.IsActive(cluster.VersionRaftLastIndex) {
+		return nil
+	}
 	var value roachpb.Value
 	value.SetInt(int64(lastIndex))
 	return engine.MVCCPut(ctx, eng, nil, rsl.RaftLastIndexKey(),
@@ -428,13 +422,6 @@ func (rsl replicaStateLoader) setReplicaDestroyedError(
 ) error {
 	return engine.MVCCPutProto(ctx, eng, nil,
 		rsl.RangeReplicaDestroyedErrorKey(), hlc.Timestamp{}, nil /* txn */, err)
-}
-
-func loadHardState(
-	ctx context.Context, reader engine.Reader, rangeID roachpb.RangeID,
-) (raftpb.HardState, error) {
-	rsl := makeReplicaStateLoader(rangeID)
-	return rsl.loadHardState(ctx, reader)
 }
 
 func (rsl replicaStateLoader) loadHardState(
@@ -527,6 +514,7 @@ func (rsl replicaStateLoader) synthesizeHardState(
 // are returned.
 func writeInitialReplicaState(
 	ctx context.Context,
+	st *cluster.Settings,
 	eng engine.ReadWriter,
 	ms enginepb.MVCCStats,
 	desc roachpb.RangeDescriptor,
@@ -534,7 +522,7 @@ func writeInitialReplicaState(
 	gcThreshold hlc.Timestamp,
 	txnSpanGCThreshold hlc.Timestamp,
 ) (enginepb.MVCCStats, error) {
-	rsl := makeReplicaStateLoader(desc.RangeID)
+	rsl := makeReplicaStateLoader(st, desc.RangeID)
 
 	var s storagebase.ReplicaState
 	s.TruncatedState = &roachpb.RaftTruncatedState{
@@ -582,6 +570,7 @@ func writeInitialReplicaState(
 // state itself, and the updated stats are returned.
 func writeInitialState(
 	ctx context.Context,
+	st *cluster.Settings,
 	eng engine.ReadWriter,
 	ms enginepb.MVCCStats,
 	desc roachpb.RangeDescriptor,
@@ -589,11 +578,11 @@ func writeInitialState(
 	gcThreshold hlc.Timestamp,
 	txnSpanGCThreshold hlc.Timestamp,
 ) (enginepb.MVCCStats, error) {
-	newMS, err := writeInitialReplicaState(ctx, eng, ms, desc, lease, gcThreshold, txnSpanGCThreshold)
+	newMS, err := writeInitialReplicaState(ctx, st, eng, ms, desc, lease, gcThreshold, txnSpanGCThreshold)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
-	if err := makeReplicaStateLoader(desc.RangeID).synthesizeRaftState(ctx, eng); err != nil {
+	if err := makeReplicaStateLoader(st, desc.RangeID).synthesizeRaftState(ctx, eng); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 	return newMS, nil
@@ -611,6 +600,10 @@ type ReplicaEvalContext struct {
 // ClusterSettings returns the node's ClusterSettings.
 func (rec ReplicaEvalContext) ClusterSettings() *cluster.Settings {
 	return rec.repl.store.cfg.Settings
+}
+
+func (rec *ReplicaEvalContext) makeReplicaStateLoader() replicaStateLoader {
+	return makeReplicaStateLoader(rec.ClusterSettings(), rec.RangeID())
 }
 
 // In-memory state, immutable fields, and debugging methods are accessed directly.

--- a/pkg/storage/replica_state_test.go
+++ b/pkg/storage/replica_state_test.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -57,7 +58,7 @@ func TestSynthesizeHardState(t *testing.T) {
 		func() {
 			batch := eng.NewBatch()
 			defer batch.Close()
-			rsl := makeReplicaStateLoader(1)
+			rsl := makeReplicaStateLoader(cluster.MakeTestingClusterSettings(), 1)
 
 			if test.OldHS != nil {
 				if err := rsl.setHardState(context.Background(), batch, *test.OldHS); err != nil {

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -196,6 +196,7 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 			testDesc := testRangeDescriptor()
 			if _, err := writeInitialState(
 				ctx,
+				tc.store.ClusterSettings(),
 				tc.store.Engine(),
 				enginepb.MVCCStats{},
 				*testDesc,

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1009,7 +1009,8 @@ func splitTestRange(store *Store, key, splitKey roachpb.RKey, t *testing.T) *Rep
 	// Minimal amount of work to keep this deprecated machinery working: Write
 	// some required Raft keys.
 	if _, err := writeInitialState(
-		context.Background(), store.engine, enginepb.MVCCStats{}, *desc, roachpb.Lease{}, hlc.Timestamp{}, hlc.Timestamp{},
+		context.Background(), store.ClusterSettings(), store.engine, enginepb.MVCCStats{},
+		*desc, roachpb.Lease{}, hlc.Timestamp{}, hlc.Timestamp{},
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -2265,7 +2266,8 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 	}
 
 	if _, err := writeInitialState(
-		ctx, s.Engine(), enginepb.MVCCStats{}, *repl1.Desc(), roachpb.Lease{}, hlc.Timestamp{}, hlc.Timestamp{},
+		ctx, s.ClusterSettings(), s.Engine(), enginepb.MVCCStats{}, *repl1.Desc(),
+		roachpb.Lease{}, hlc.Timestamp{}, hlc.Timestamp{},
 	); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Replace /Local/RangeID/X/u/RaftLastIndex with a reverse scan of the Raft
log for the range to find the last index. This removes the writing of 1
key/value pair every time Raft tells us to append to the Raft log.

No attempt is to remove this key if it already exists on a replica, we
just stop using it. Since the key is unreplicated, as normal replica
rebalancing takes place the key will eventually get deleted.

See #18659