### PR TITLE
cherrypick 1.1: distsql: use ASCENDING encoding for comparisons

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -385,7 +385,7 @@ func (ag *aggregator) encode(
 	appendTo []byte, row sqlbase.EncDatumRow,
 ) (encoding []byte, err error) {
 	for _, colIdx := range ag.groupCols {
-		appendTo, err = row[colIdx].Encode(&ag.datumAlloc, sqlbase.DatumEncoding_VALUE, appendTo)
+		appendTo, err = row[colIdx].Encode(&ag.datumAlloc, sqlbase.DatumEncoding_ASCENDING_KEY, appendTo)
 		if err != nil {
 			return appendTo, err
 		}

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -175,10 +175,10 @@ func (d *distinct) encode(appendTo []byte, row sqlbase.EncDatumRow) ([]byte, err
 		// TODO(irfansharif): Different rows may come with different encodings,
 		// e.g. if they come from different streams that were merged, in which
 		// case the encodings don't match (despite having the same underlying
-		// datums). We instead opt to always choose sqlbase.DatumEncoding_VALUE
+		// datums). We instead opt to always choose sqlbase.DatumEncoding_ASCENDING_KEY
 		// but we may want to check the first row for what encodings are already
 		// available.
-		appendTo, err = datum.Encode(&d.datumAlloc, sqlbase.DatumEncoding_VALUE, appendTo)
+		appendTo, err = datum.Encode(&d.datumAlloc, sqlbase.DatumEncoding_ASCENDING_KEY, appendTo)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -528,3 +528,17 @@ query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM (VALUES (1, '222'), (2, '444')) t1(a,b) JOIN (VALUES (1, 100.0), (3, 32.0)) t2(a,b) ON t1.a = t2.a]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJykkDFrwzAQhff-CnNTAjfYTuggKJhOTYemdOhSNBjrapu6OqOToBD834ulIXVoWkI26e6-e-_eASwbeqo_SUC9QQEaYXTckAi7uZQGduYLVI7Q2zH4uawRGnYE6gC-9wOBgtd6CCSAYMjX_ZD2bbP7bFVmTRfsh6xBTwgc_HGJ-LolUPmEVwrdXit03B8sO0OOzEJCz-R_I7-4faile-Tekls6Hujdr6pifef6tosvQNgHr7KqwKrEaoPV9uwdxSWBvZCMbIVO7zmTkEYg01IKRTi4hp4dN1EmffeRiwVD4lO3TJ-dja1o8CdcXACXp3D5J7xZwPmkp5vvAAAA__-HZe5E
+
+statement ok
+CREATE TABLE nullables (a INT, b INT, c INT, PRIMARY KEY (a))
+
+statement ok
+INSERT INTO nullables VALUES (1,1,1)
+
+statement ok
+INSERT INTO nullables VALUES (2,NULL,1)
+
+query II
+SELECT c, COUNT(*) FROM nullables GROUP BY c;
+----
+1 2

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -212,7 +212,7 @@ func (ed *EncDatum) Encoding() (DatumEncoding, bool) {
 // a column ID so they should not be used to test for equality.
 func (ed *EncDatum) Encode(a *DatumAlloc, enc DatumEncoding, appendTo []byte) ([]byte, error) {
 	if ed.encoded != nil && enc == ed.encoding {
-		// We already have an encoding that matches
+		// We already have an encoding that matches that we can use.
 		return append(appendTo, ed.encoded...), nil
 	}
 	if err := ed.EnsureDecoded(a); err != nil {


### PR DESCRIPTION
Cherry-pick of #18702. 

As the comment on EncDatum.Encode indicates, using DatumEncoding_VALUE
encoding is not valid for comparisons, as the encoded datum can
contain a ColumnID prefix.
