### PR TITLE
sql,build: lint away (fmt|errors).Errorf in parser

### DIFF
--- a/build/style_test.go
+++ b/build/style_test.go
@@ -318,6 +318,31 @@ func TestStyle(t *testing.T) {
 		}
 	})
 
+	t.Run("TestPGErrors", func(t *testing.T) {
+		t.Parallel()
+		// TODO(justin): we should expand the packages this applies to as possible.
+		cmd, stderr, filter, err := dirCmd(pkg.Dir, "git", "grep", "-nE", `((fmt|errors).Errorf|errors.New)`, "--", "sql/parser/*.go")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := stream.ForEach(filter, func(s string) {
+			t.Errorf(`%s <- forbidden; use "pgerror.NewErrorf" instead`, s)
+		}); err != nil {
+			t.Error(err)
+		}
+
+		if err := cmd.Wait(); err != nil {
+			if out := stderr.String(); len(out) > 0 {
+				t.Fatalf("err=%s, stderr=%s", err, out)
+			}
+		}
+	})
+
 	t.Run("TestProtoClone", func(t *testing.T) {
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(

--- a/pkg/sql/parser/aggregate_builtins.go
+++ b/pkg/sql/parser/aggregate_builtins.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/mon"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
-	"github.com/pkg/errors"
 )
 
 func initAggregateBuiltins() {
@@ -1051,7 +1050,7 @@ func (a *floatSumSqrDiffsAggregate) Add(
 	// https://github.com/cockroachdb/cockroach/pull/17728.
 	totalCount, ok := addWithOverflow(a.count, count)
 	if !ok {
-		return errors.Errorf("number of values in aggregate exceed max count of %d", math.MaxInt64)
+		return pgerror.NewErrorf(pgerror.CodeNumericValueOutOfRangeError, "number of values in aggregate exceed max count of %d", math.MaxInt64)
 	}
 	// We are converting an int64 number (with 63-bit precision)
 	// to a float64 (with 52-bit precision), thus in the worst cases,


### PR DESCRIPTION
We should always be opting for pgerror.NewErrorf so that the resulting
errors have pg error codes. Parser currently does not have any `fmt` or
`errors` errors, so it's included here, but we should include the sql
package (and maybe others) ASAP.