### PR TITLE
rfcs: integrating PM concerns earlier on in RFC process

### DIFF
--- a/docs/RFCS/00000000_template.md
+++ b/docs/RFCS/00000000_template.md
@@ -30,7 +30,7 @@ Explain the proposal as if it was already included in the project and
 you were teaching it to another CockroachDB programmer. That generally means:
 
 - Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
+- Explaining the feature largely in terms of examples. Take into account that a product manager (PM) will want to connect back the work introduced by the RFC with user stories. Whenever practical, do ask PMs if they already have user stories that relate to the proposed work, and do approach PMs to attract user buy-in and mindshare if applicable.
 - Explaining how CockroachDB contributors and users should think about
   the feature, and how it should impact the way they use
   CockroachDB. It should explain the impact as concretely as possible.
@@ -51,6 +51,11 @@ This is the technical portion of the RFC. Explain the design in sufficient detai
 (You may replace the section title if the intent stays clear.)
 
 - Its interaction with other features is clear.
+- It covers where this feature may be surfaced in other areas of the product
+   - If the change influences a user-facing interface, make sure to preserve consistent user experience (UX). Prefer to avoid UX changes altogether unless the RFC also argues for a clear UX benefit to users. If UX has to change, then prefer changes that match the UX for related features, to give a clear impression to users of homogeneous CLI / GUI elements. Avoid UX surprises at all costs. If in doubt, ask for input from other engineers with past UX design experience and from your design department.
+- It considers how to monitor the success and quality of the feature.
+   - Your RFC must consider and propose a set of metrics to be collected, if applicable, and suggest which metrics would be useful to users and which need to be exposed in a public interface.
+   - Your RFC should outline how you propose to investigate when users run into related issues in production. If you propose new data structures, suggest how they should be checked for consistency. If you propose new asynchronous subsystems, suggest how a user can observe their state via tracing. In general, think about how your coworkers and users will gain access to the internals of the change after it has happened to either gain understanding during execution or troubleshoot problems.
 - It is reasonably clear how the feature would be implemented.
 - Corner cases are dissected by example.
 
@@ -74,6 +79,10 @@ other active RFCs.
 Why should we *not* do this?
 
 If applicable, list mitigating factors that may make each drawback acceptable.
+
+Investigate the consequences of the proposed change onto other areas of CockroachDB. If other features are impacted, especially UX, list this impact as a reason not to do the change. If possible, also investigate and suggest mitigating actions that would reduce the impact. You can for example consider additional validation testing, additional documentation or doc changes, new user research, etc.
+
+Also investigate the consequences of the proposed change on performance. Pay especially attention to the risk that introducing a possible performance improvement in one area can slow down another area in an unexpected way. Examine all the current "consumers" of the code path you are proposing to change and consider whether the performance of any of them may be negatively impacted by the proposed change. List all these consequences as possible drawbacks.
 
 ## Rationale and Alternatives
 


### PR DESCRIPTION
As Raphael suggested, there have been some top of mind issues on the product side that I think would be great to address in the RFC process. Namely, in addition to focusing on implementation, to also discuss the user experience. Otherwise, these discussions happen after implementation, when changes are more expensive. Also, introducing a more holistic view of how the RFC'd feature fits into the rest of the product -> again, this has happened in our current release cycle, where additional features like adding metrics to the admin UI were squeezed in after feature freeze. We should only consider a feature to be complete when it fits into the rest of the product cohesively. Finally, given our current focus on performance, we should identify some things we want to measure so that we don't introduce features that negatively impact the overall performance of the database.