### PR TITLE
sql,keys: bugfix to rowfetcher for COUNT(*)

### DIFF
--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -499,6 +499,16 @@ func TestEnsureSafeSplitKey(t *testing.T) {
 		if !d.expected.Equal(out) {
 			t.Fatalf("%d: %s: expected %s, but got %s", i, d.in, d.expected, out)
 		}
+
+		prefixLen, err := GetRowPrefixLength(d.in)
+		if err != nil {
+			t.Fatalf("%d: %s: unexpected error: %v", i, d.in, err)
+		}
+		suffix := d.in[prefixLen:]
+		expectedSuffix := d.in[len(d.expected):]
+		if !bytes.Equal(suffix, expectedSuffix) {
+			t.Fatalf("%d: %s: expected %s, but got %s", i, d.in, expectedSuffix, suffix)
+		}
 	}
 
 	errorData := []struct {

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -26,6 +26,9 @@ abcd  CREATE TABLE abcd (
       )
 
 statement ok
+CREATE INDEX d_idx ON abcd(d)
+
+statement ok
 INSERT INTO abcd VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 
 query IIII rowsort
@@ -33,6 +36,16 @@ SELECT * FROM abcd
 ----
 1 2 3 4
 5 6 7 8
+
+query I
+SELECT COUNT(*) FROM abcd
+----
+2
+
+query I
+SELECT COUNT(*) FROM abcd@d_idx
+----
+2
 
 statement ok
 UPDATE abcd SET b = 9, d = 10, c = NULL where c = 7
@@ -117,6 +130,7 @@ abcd  CREATE TABLE abcd (
       i INT NULL,
       j INT NULL,
       CONSTRAINT "primary" PRIMARY KEY (a ASC),
+      INDEX d_idx (d ASC),
       FAMILY f1 (a, b, e, f),
       FAMILY fam_1_c_d (c, d),
       FAMILY fam_2_g (g),

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -266,6 +267,14 @@ func (rf *RowFetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 				// interleaved data from some other table or index.
 				continue
 			}
+		} else {
+			// We still need to consume the key until the family id, so processKV can
+			// know whether we've finished a row or not.
+			prefixLen, err := keys.GetRowPrefixLength(rf.kv.Key)
+			if err != nil {
+				return false, err
+			}
+			rf.keyRemainingBytes = rf.kv.Key[prefixLen:]
 		}
 
 		// For unique secondary indexes, the index-key does not distinguish one row


### PR DESCRIPTION
d5c9932 introduced a critical bug to rowfetcher that prevented it from
correctly understanding tables with multiple column families when no
columns from the table were marked as needed, such as in the case of
`COUNT(*)`.

This commit fixes the bug by reusing the logic from EnsureSafeSplitKey
to advance the rowfetcher's key to the family id section as it must,
without needing to decode any of the prefix of the key.

Also add a test to ensure COUNT(*) and multiple column families interact
properly.

Fixes #18705.