### PR TITLE
server: fix gzipResponseWriter Flush, avoid all allocations

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1223,21 +1223,21 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case strings.Contains(ae, httputil.GzipEncoding):
 		w.Header().Set(httputil.ContentEncodingHeader, httputil.GzipEncoding)
 		gzw := newGzipResponseWriter(w)
-		defer gzw.Close()
+		defer func() {
+			if err := gzw.Close(); err != nil {
+				ctx := s.AnnotateCtx(r.Context())
+				log.Warningf(ctx, "error closing gzip response writer: %v", err)
+			}
+		}()
 		w = gzw
 	}
 	s.mux.ServeHTTP(w, r)
 }
 
 type gzipResponseWriter struct {
-	io.WriteCloser
+	gz *gzip.Writer
 	http.ResponseWriter
 }
-
-// Flush implements http.Flusher as required by grpc-gateway for clients
-// which access streaming endpoints (as exercised by the acceptance tests
-// at time of writing).
-func (*gzipResponseWriter) Flush() {}
 
 func newGzipResponseWriter(w http.ResponseWriter) *gzipResponseWriter {
 	var gz *gzip.Writer
@@ -1247,19 +1247,36 @@ func newGzipResponseWriter(w http.ResponseWriter) *gzipResponseWriter {
 		gz = gzI.(*gzip.Writer)
 		gz.Reset(w)
 	}
-	return &gzipResponseWriter{WriteCloser: gz, ResponseWriter: w}
+	return &gzipResponseWriter{gz: gz, ResponseWriter: w}
 }
 
 func (w *gzipResponseWriter) Write(b []byte) (int, error) {
-	return w.WriteCloser.Write(b)
+	return w.gz.Write(b)
 }
 
-func (w *gzipResponseWriter) Close() {
-	if w.WriteCloser != nil {
-		w.WriteCloser.Close()
-		gzipWriterPool.Put(w.WriteCloser)
-		w.WriteCloser = nil
+// Flush implements http.Flusher as required by grpc-gateway for clients
+// which access streaming endpoints (as exercised by the acceptance tests
+// at time of writing).
+func (w *gzipResponseWriter) Flush() {
+	// If Flush returns an error, we'll see it on the next call to Write or
+	// Close as well, so we can ignore it here.
+	if err := w.gz.Flush(); err == nil {
+		// Flush the wrapped ResponseWriter as well, if possible.
+		if f, ok := w.ResponseWriter.(http.Flusher); ok {
+			f.Flush()
+		}
 	}
+}
+
+func (w *gzipResponseWriter) Close() error {
+	if w.gz == nil {
+		return nil
+	}
+
+	err := w.gz.Close()
+	gzipWriterPool.Put(w.gz)
+	w.gz = nil
+	return err
 }
 
 func officialAddr(


### PR DESCRIPTION
This contains three small changes, some of which are being pulled out of
#18521:
- `gzipResponseWriter.Flush` was a no-op. We now properly
flush the `gzip.Writer` and underlying flusher if possible.
- properly return an error from the writer's `Close`
method.
- before we used a `sync.Pool` to avoid allocations for
`*gzip.Writers`. However, we always wrapped these writers in
a `gzipResponseWriter`, which we allocated for each connection.
We now embed the `gzip.Writer` in the `gzipResponseWriter` and
put `*gzipResponseWriter` objects in the `sync.Pool`.

@bdarnell since you already had some of this paged in from before. The answer to the question you had in https://github.com/cockroachdb/cockroach/pull/18521#issuecomment-330284385 is that `gzip.Writer.Reset` discards all of the writer's state, so it's safe to put back in the pool even if `Close` fails.