### PR TITLE
sql: note unimplemented errors raised after parsing as well

### DIFF
--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -978,6 +978,7 @@ func (c *v3Conn) sendInternalError(errToSend string) error {
 }
 
 func (c *v3Conn) sendError(err error) error {
+	c.executor.RecordError(err)
 	if c.doingExtendedQueryMessage {
 		c.ignoreTillSync = true
 	}


### PR DESCRIPTION
previously we were only recording unimplemented errors encountered during parsing, but we return them in some branches of evaluation as well.
I briefly started trying to add logging to execParsed, execRequest and looking for other possible paths.
That felt brittle and error prone though, as a new path could easily be missed, whereas the common pgwire helper handles all error responses.