### PR TITLE
cherrypick-1.1: build: Bump base for deploy image from debian 8.7 to 8.9

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8.7
+FROM debian:8.9
 
 MAINTAINER Tobias Schottdorf <tobias.schottdorf@gmail.com>
 


### PR DESCRIPTION
Just to pick up security/stability updates. This image was most recently
updated on Sept 13, 2017.

We could go further and switch to debian:jessie-slim to save some space
in the image, but that's a bigger change and I'm not a big fan of the
fact that the image maintainers will make bigger changes to what is
in the tag over time than for a more specific tag (like 8.7 or 8.9).
That could mean that, for example, cockroach v1.1.0 and v1.1.5 are
based on considerably different versions of debian jessie.

Cherrypicks #18748 into release-1.1

@cockroachdb/release 