### PR TITLE
engine: io limit RocksDBMap batch commits

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -530,7 +530,7 @@ func writeRocksDB(
 	writer := store.NewBatchWriter()
 	for kvBatch := range kvCh {
 		for _, kv := range kvBatch {
-			if err := writer.Put(kv.Key, kv.Value.RawBytes); err != nil {
+			if err := writer.Put(ctx, kv.Key, kv.Value.RawBytes); err != nil {
 				return 0, err
 			}
 		}
@@ -1291,7 +1291,7 @@ func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 					val = b
 				}
 			}
-			if err := batch.Put(key, val); err != nil {
+			if err := batch.Put(ctx, key, val); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/distsqlrun/disk_row_container.go
+++ b/pkg/sql/distsqlrun/disk_row_container.go
@@ -142,7 +142,7 @@ func (d *diskRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) 
 	if err := d.diskAcc.Grow(ctx, int64(len(d.scratchKey)+len(d.scratchVal))); err != nil {
 		return err
 	}
-	if err := d.bufferedRows.Put(d.scratchKey, d.scratchVal); err != nil {
+	if err := d.bufferedRows.Put(ctx, d.scratchKey, d.scratchVal); err != nil {
 		return err
 	}
 	d.scratchKey = d.scratchKey[:0]
@@ -203,7 +203,7 @@ type diskRowIterator struct {
 var _ rowIterator = diskRowIterator{}
 
 func (d *diskRowContainer) NewIterator(ctx context.Context) rowIterator {
-	if err := d.bufferedRows.Flush(); err != nil {
+	if err := d.bufferedRows.Flush(ctx); err != nil {
 		log.Fatal(ctx, err)
 	}
 	return diskRowIterator{rowContainer: d, SortedDiskMapIterator: d.diskMap.NewIterator()}

--- a/pkg/sql/distsqlrun/hash_row_container.go
+++ b/pkg/sql/distsqlrun/hash_row_container.go
@@ -490,7 +490,7 @@ func (i hashDiskRowBucketIterator) Mark(ctx context.Context, mark bool) error {
 	// These marks only matter when using a hashDiskRowIterator to iterate over
 	// unmarked rows. The writes are flushed when creating a NewIterator() in
 	// NewUnmarkedIterator().
-	return i.hashDiskRowContainer.bufferedRows.Put(i.Key(), rowVal)
+	return i.hashDiskRowContainer.bufferedRows.Put(ctx, i.Key(), rowVal)
 }
 
 // hashDiskRowIterator iterates over all unmarked rows in a

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -19,9 +19,16 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"runtime/debug"
+	"time"
 
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -497,4 +504,33 @@ func (r *RocksDBBatchReader) varstring() ([]byte, error) {
 		return nil, fmt.Errorf("expected %d bytes, but found %d", n, c)
 	}
 	return s, nil
+}
+
+const bulkIOWriteLimiterLongWait = 500 * time.Millisecond
+
+// LimitBulkIOWrite limits writes of size cost to the cluster
+// BulkIOWRiteLimiter settings.
+func LimitBulkIOWrite(ctx context.Context, st *cluster.Settings, cost int) {
+	// The limiter disallows anything greater than its burst (set to
+	// BulkIOWriteLimiterBurst), so cap the batch size if it would overflow.
+	//
+	// TODO(dan): This obviously means the limiter is no longer accounting for
+	// the full cost. I've tried calling WaitN in a loop to fully cover the
+	// cost, but that doesn't seem to be as smooth in practice (TPCH-10 restores
+	// on azure local disks), I think because the file is written all at once at
+	// the end. This could be fixed by writing the file in chunks, which also
+	// would likely help the overall smoothness, too.
+	if cost > cluster.BulkIOWriteLimiterBurst {
+		cost = cluster.BulkIOWriteLimiterBurst
+	}
+
+	begin := timeutil.Now()
+	if err := st.BulkIOWriteLimiter.WaitN(ctx, cost); err != nil {
+		log.Errorf(ctx, "error rate limiting bulk io write: %+v", err)
+	}
+
+	if d := timeutil.Since(begin); d > bulkIOWriteLimiterLongWait {
+		log.Warningf(ctx, "bulk io write limiter took %s (>%s):\n%s",
+			d, bulkIOWriteLimiterLongWait, debug.Stack())
+	}
 }

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -71,7 +71,7 @@ func TestRocksDBMap(t *testing.T) {
 				t.Fatalf("expected %v for value of key %v but got %v", v, k, b)
 			}
 		} else {
-			if err := batchWriter.Put(k, v); err != nil {
+			if err := batchWriter.Put(ctx, k, v); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -79,7 +79,7 @@ func TestRocksDBMap(t *testing.T) {
 
 	sort.StringSlice(keys).Sort()
 
-	if err := batchWriter.Flush(); err != nil {
+	if err := batchWriter.Flush(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -272,9 +272,9 @@ func TestRocksDBStore(t *testing.T) {
 			_ = diskStore.Put(k1, v1)
 			_ = diskStore.Put(k1, v1)
 			_ = diskStore.Put(k1, v2)
-			_ = batchWriter.Put(k1, v2)
-			_ = batchWriter.Put(k1, v1)
-			_ = batchWriter.Put(k1, v1)
+			_ = batchWriter.Put(ctx, k1, v2)
+			_ = batchWriter.Put(ctx, k1, v1)
+			_ = batchWriter.Put(ctx, k1, v1)
 			if err := batchWriter.Close(ctx); err != nil {
 				t.Fatal(err)
 			}
@@ -337,7 +337,7 @@ func BenchmarkRocksDBMapWrite(b *testing.B) {
 					for j := 0; j < inputSize; j++ {
 						k := fmt.Sprintf("%d", rng.Int())
 						v := fmt.Sprintf("%d", rng.Int())
-						if err := batchWriter.Put([]byte(k), []byte(v)); err != nil {
+						if err := batchWriter.Put(ctx, []byte(k), []byte(v)); err != nil {
 							b.Fatal(err)
 						}
 					}

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -579,7 +579,7 @@ func addSSTablePreApply(
 	}
 	path += ".ingested"
 
-	limitBulkIOWrite(ctx, st, len(sst.Data))
+	engine.LimitBulkIOWrite(ctx, st, len(sst.Data))
 
 	if inmem, ok := eng.(engine.InMem); ok {
 		path = fmt.Sprintf("%x", checksum)

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -15,48 +15,16 @@
 package storage
 
 import (
-	"runtime/debug"
-	"time"
-
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
-
-const bulkIOWriteLimiterLongWait = 500 * time.Millisecond
-
-func limitBulkIOWrite(ctx context.Context, st *cluster.Settings, cost int) {
-	// The limiter disallows anything greater than its burst (set to
-	// BulkIOWriteLimiterBurst), so cap the batch size if it would overflow.
-	//
-	// TODO(dan): This obviously means the limiter is no longer accounting for
-	// the full cost. I've tried calling WaitN in a loop to fully cover the
-	// cost, but that doesn't seem to be as smooth in practice (TPCH-10 restores
-	// on azure local disks), I think because the file is written all at once at
-	// the end. This could be fixed by writing the file in chunks, which also
-	// would likely help the overall smoothness, too.
-	if cost > cluster.BulkIOWriteLimiterBurst {
-		cost = cluster.BulkIOWriteLimiterBurst
-	}
-
-	begin := timeutil.Now()
-	if err := st.BulkIOWriteLimiter.WaitN(ctx, cost); err != nil {
-		log.Errorf(ctx, "error rate limiting bulk io write: %+v", err)
-	}
-
-	if d := timeutil.Since(begin); d > bulkIOWriteLimiterLongWait {
-		log.Warningf(ctx, "bulk io write limiter took %s (>%s):\n%s",
-			d, bulkIOWriteLimiterLongWait, debug.Stack())
-	}
-}
 
 var errSideloadedFileNotFound = errors.New("sideloaded file not found")
 

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/pkg/errors"
 )
 
@@ -65,7 +66,7 @@ func (ss *diskSideloadStorage) Dir() string {
 func (ss *diskSideloadStorage) PutIfNotExists(
 	ctx context.Context, index, term uint64, contents []byte,
 ) error {
-	limitBulkIOWrite(ctx, ss.st, len(contents))
+	engine.LimitBulkIOWrite(ctx, ss.st, len(contents))
 
 	filename := ss.filename(ctx, index, term)
 	if _, err := os.Stat(filename); err == nil {


### PR DESCRIPTION
Similar to raft sideloading, limit the IO of tempstore writes. These
happen during DistSQL work and CSV importing, both of which have caused
node liveness errors. Until those are solved, we need a way to limit
these writes for DistSQL and CSV import so that use of those features
on Azure (and possibly others) doesn't cause cluster instability.

To do that, we add a limiter to RocksDBMapBatchWriter that is
auto-populated from the underlying RocksDB instance. (Or, in the case
where it's something else, does not set a limiter at all.)

Fixes #15332