### PR TITLE
CODEOWNERS: split cluster jobs from sql-async-prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,7 +40,8 @@
 
 /pkg/sql/schema*             @cockroachdb/sql-async-prs
 /pkg/sql/lease*              @cockroachdb/sql-async-prs
-/pkg/sql/jobs/               @cockroachdb/sql-async-prs
+
+/pkg/sql/jobs/               @cockroachdb/cluster-jobs-prs
 
 /pkg/sql/distsql*.go         @cockroachdb/distsql-prs @cockroachdb/sql-planning-prs
 /pkg/sql/distsqlplan/        @cockroachdb/distsql-prs @cockroachdb/sql-planning-prs


### PR DESCRIPTION
sql/jobs isn't particularly related to schema changes or leases. Move
ownership the package to its own group, @cockroachdb/cluster-jobs-prs.