### PR TITLE
sql: remove the list of descriptor IDs from the output of SHOW JOBS.

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1032,10 +1032,10 @@ func (s *adminServer) Jobs(
 
 	q := makeSQLQuery()
 	q.Append(`
-			SELECT id, type, description, username, descriptor_ids, status,
-				created, started, finished, modified, fraction_completed, error
-			FROM [SHOW JOBS]
-			WHERE true
+      SELECT id, type, description, username, descriptor_ids, status,
+             created, started, finished, modified, fraction_completed, error
+        FROM crdb_internal.jobs
+       WHERE true
 	`)
 	if req.Status != "" {
 		q.Append(" AND status = $", parser.NewDString(req.Status))

--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -726,7 +726,10 @@ func RunAndWaitForTerminalState(
 		var status Status
 		var jobErr gosql.NullString
 		var fractionCompleted float64
-		err := sqlDB.QueryRow(`SELECT status, error, fraction_completed FROM [SHOW JOBS] WHERE id = $1`, jobID).Scan(
+		err := sqlDB.QueryRow(`
+       SELECT status, error, fraction_completed
+         FROM [SHOW JOBS]
+        WHERE id = $1`, jobID).Scan(
 			&status, &jobErr, &fractionCompleted,
 		)
 		if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -90,8 +90,9 @@ EXPLAIN DROP DATABASE foo
 query ITTT
 EXPLAIN SHOW JOBS
 ----
-0  values  ·     ·
-0  ·       size  13 columns, 0 rows
+0  render  ·     ·
+1  values  ·     ·
+1  ·       size  13 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -253,7 +253,7 @@ SELECT * FROM [SHOW TRACE FOR SELECT 1] LIMIT 0
 ----
 timestamp age message context operation span
 
-query ITTTTTTTTTRTI colnames
+query ITTTTTTTTRTI colnames
 SELECT * FROM [SHOW JOBS] LIMIT 0
 ----
-id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error  coordinator_id
+id  type  description  username  status  created  started  finished  modified  fraction_completed  error  coordinator_id

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -601,7 +601,11 @@ func (p *planner) ShowQueries(ctx context.Context, n *parser.ShowQueries) (planN
 // ShowJobs returns all the jobs.
 // Privileges: None.
 func (p *planner) ShowJobs(ctx context.Context, n *parser.ShowJobs) (planNode, error) {
-	return p.delegateQuery(ctx, "SHOW JOBS", "TABLE crdb_internal.jobs", nil, nil)
+	return p.delegateQuery(ctx, "SHOW JOBS",
+		`SELECT id, type, description, username, status, created, started, finished, modified,
+            fraction_completed, error, coordinator_id
+       FROM crdb_internal.jobs`,
+		nil, nil)
 }
 
 func (p *planner) ShowSessions(ctx context.Context, n *parser.ShowSessions) (planNode, error) {


### PR DESCRIPTION
Since descriptor IDs are not (yet) part of the public UI of
CockroachDB, they should not be printed out by documented statements
like SHOW.

Suggested in https://github.com/cockroachdb/docs/pull/1872#issuecomment-332006659.
Resolves the discussion on that issue.