### PR TITLE
sql: avoid a panic on SHOW CLUSTER [ QUERIES | SESSIONS ] when a node is down

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -818,6 +818,7 @@ func populateSessionsTable(
 				parser.DNull,
 				parser.DNull,
 				parser.DNull,
+				parser.DNull,
 			); err != nil {
 				return err
 			}


### PR DESCRIPTION
The code for SHOW CLUSTER QUERIES / SESSIONS populates a row of NULLs
when it doesn't get a response for a node on time. The code path for
that "error row" was wrong, which this patch corrects.

Fixes #18699.

@a-robinson  can you suggest a way to test this? Is there a way to spawn a cluster in a test and simulate that a node goes down exactly while the SHOW QUERIES/SESSIONS RPC is being processed on that node?