### PR TITLE
storage: Fix tracking of keys written in replica.writeStats

### DIFF
--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -498,3 +498,12 @@ func (r *RocksDBBatchReader) varstring() ([]byte, error) {
 	}
 	return s, nil
 }
+
+// RocksDBBatchCount provides an efficient way to get the count of mutations
+// in a RocksDB Batch representation.
+func RocksDBBatchCount(repr []byte) (int, error) {
+	if len(repr) < headerSize {
+		return 0, errors.Errorf("batch repr too small: %d < %d", len(repr), headerSize)
+	}
+	return int(binary.LittleEndian.Uint32(repr[countPos:headerSize])), nil
+}

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -244,8 +244,14 @@ func TestBatchRepr(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if count, expected := r.Count(), 3; count != expected {
-			t.Fatalf("bad count: expected %d, but found %d", expected, count)
+		const expectedCount = 3
+		if count := r.Count(); count != expectedCount {
+			t.Fatalf("bad count: RocksDBBatchReader.Count expected %d, but found %d", expectedCount, count)
+		}
+		if count, err := RocksDBBatchCount(repr); err != nil {
+			t.Fatal(err)
+		} else if count != expectedCount {
+			t.Fatalf("bad count: RocksDBBatchCount expected %d, but found %d", expectedCount, count)
 		}
 
 		var ops []string


### PR DESCRIPTION
Using the MVCCStats delta was incorrect, since it only counted inserts,
not updates or deletes.

Manually tested that updates to the same key now get reflected properly
in the writes per second row of the range debug page.

Fixes #18607