### PR TITLE
distsql: disallow arrays of tuples

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -287,6 +287,16 @@ CREATE TABLE badtable (b INT[] PRIMARY KEY)
 statement error column b is of type ARRAY and thus is not indexable
 CREATE TABLE a (b INT[] UNIQUE)
 
+
+# Regression test for #18745
+
+statement ok
+CREATE TABLE ident (x INT)
+
+query T
+SELECT ARRAY[ROW()] FROM ident
+----
+
 statement error column b is of type ARRAY and thus is not indexable
 CREATE TABLE a (
   b INT[],


### PR DESCRIPTION
Fixes #18745.

We correctly disallowed tuples, but when I made the change to allow
arrays, I neglected to disallow arrays of tuples. This commit corrects
that.