### PR TITLE
cherrypick 1.1: distsql,client: have DistSQL reads fill in the gateway field in BatchRequests

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -338,7 +338,10 @@ func makeBackupDescriptor(
 	db := p.ExecCfg().DB
 
 	{
-		txn := client.NewTxn(db)
+		// TODO(andrei): Plumb a gatewayNodeID in here and also find a way to
+		// express that whatever this txn does should not count towards lease
+		// placement stats.
+		txn := client.NewTxn(db, 0 /* gatewayNodeID */)
 		opt := client.TxnExecOptions{AutoRetry: true, AutoCommit: true}
 		err := txn.Exec(ctx, opt, func(ctx context.Context, txn *client.Txn, opt *client.TxnExecOptions) error {
 			var err error
@@ -744,7 +747,10 @@ func backupResumeHook(typ jobs.Type) func(context.Context, *jobs.Job) error {
 		var tables []*sqlbase.TableDescriptor
 
 		{
-			txn := client.NewTxn(job.DB())
+			// TODO(andrei): Plumb a gatewayNodeID in here and also find a way to
+			// express that whatever this txn does should not count towards lease
+			// placement stats.
+			txn := client.NewTxn(job.DB(), 0 /* gatewayNodeID */)
 			opt := client.TxnExecOptions{AutoRetry: true, AutoCommit: true}
 			if err := txn.Exec(ctx, opt, func(ctx context.Context, txn *client.Txn, opt *client.TxnExecOptions) error {
 				txn.SetFixedTimestamp(details.EndTime)

--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -952,7 +952,7 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	txn := client.NewTxn(db)
+	txn := client.NewTxn(db, 0 /* gatewayNodeID */)
 	opts := client.TxnExecOptions{
 		AutoRetry:  false,
 		AutoCommit: true,

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -497,7 +497,10 @@ func (db *DB) Txn(ctx context.Context, retryable func(context.Context, *Txn) err
 	// (https://github.com/cockroachdb/cockroach/issues/10511).
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	txn := NewTxn(db)
+	// TODO(andrei): Plumb a gatewayNodeID here. If we pass 0, then the gateway
+	// field will be filled in by the DistSender which will assume that the
+	// current node is the gateway.
+	txn := NewTxn(db, 0 /* gatewayNodeID */)
 	txn.SetDebugName("unnamed")
 	opts := TxnExecOptions{
 		AutoCommit: true,

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -153,7 +153,7 @@ func TestInitPut(t *testing.T) {
 		return br, nil
 	}), clock)
 
-	txn := NewTxn(db)
+	txn := NewTxn(db, 0 /* gatewayNodeID */)
 	if pErr := txn.InitPut(context.Background(), "a", "b", false); pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -192,7 +192,7 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 		return br, nil
 	}), clock)
 
-	txn := NewTxn(db)
+	txn := NewTxn(db, 0 /* gatewayNodeID */)
 
 	for testIdx = range testCases {
 		if _, pErr := txn.Send(context.Background(), ba); pErr != nil {
@@ -625,7 +625,7 @@ func TestTransactionStatus(t *testing.T) {
 	db := NewDB(newTestSender(nil), clock)
 	for _, write := range []bool{true, false} {
 		for _, commit := range []bool{true, false} {
-			txn := NewTxn(db)
+			txn := NewTxn(db, 0 /* gatewayNodeID */)
 
 			if _, pErr := txn.Get(context.Background(), "a"); pErr != nil {
 				t.Fatal(pErr)
@@ -658,10 +658,10 @@ func TestCommitInBatchWrongTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, 0)
 	db := NewDB(newTestSender(nil), clock)
-	txn := NewTxn(db)
+	txn := NewTxn(db, 0 /* gatewayNodeID */)
 
 	b1 := &Batch{}
-	txn2 := NewTxn(db)
+	txn2 := NewTxn(db, 0 /* gatewayNodeID */)
 	b2 := txn2.NewBatch()
 
 	for _, b := range []*Batch{b1, b2} {
@@ -678,7 +678,7 @@ func TestTimestampSelectionInOptions(t *testing.T) {
 	mc := hlc.NewManualClock(100)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
 	db := NewDB(newTestSender(nil), clock)
-	txn := NewTxn(db)
+	txn := NewTxn(db, 0 /* gatewayNodeID */)
 
 	refTimestamp := clock.Now()
 
@@ -720,7 +720,7 @@ func TestSetPriority(t *testing.T) {
 
 	// Verify the normal priority setting path.
 	expected = roachpb.NormalUserPriority
-	txn := NewTxn(db)
+	txn := NewTxn(db, 0 /* gatewayNodeID */)
 	if err := txn.SetUserPriority(expected); err != nil {
 		t.Fatal(err)
 	}
@@ -730,7 +730,7 @@ func TestSetPriority(t *testing.T) {
 
 	// Verify the internal (fixed value) priority setting path.
 	expected = roachpb.UserPriority(-13)
-	txn = NewTxn(db)
+	txn = NewTxn(db, 0 /* gatewayNodeID */)
 	txn.InternalSetPriority(13)
 	if _, pErr := txn.Send(context.Background(), roachpb.BatchRequest{}); pErr != nil {
 		t.Fatal(pErr)
@@ -765,7 +765,7 @@ func TestWrongTxnRetry(t *testing.T) {
 			return roachpb.NewHandledRetryableTxnError(
 				"test error", innerTxn.Proto().ID, *innerTxn.Proto())
 		}
-		innerTxn := NewTxn(db)
+		innerTxn := NewTxn(db, 0 /* gatewayNodeID */)
 		err := innerTxn.Exec(ctx, execOpt, innerClosure)
 		if !testutils.IsError(err, "test error") {
 			t.Fatalf("unexpected inner failure: %v", err)
@@ -798,7 +798,7 @@ func TestUpdateDeadlineMaybe(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, 0)
 	db := NewDB(newTestSender(nil), clock)
-	txn := NewTxn(db)
+	txn := NewTxn(db, 0 /* gatewayNodeID */)
 
 	if txn.deadline != nil {
 		t.Errorf("unexpected initial deadline: %s", txn.deadline)

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -26,6 +26,7 @@ import (
 )
 
 // NodeID is a custom type for a cockroach node ID. (not a raft node ID)
+// 0 is not a valid NodeID.
 type NodeID int32
 
 // String implements the fmt.Stringer interface.

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -131,7 +131,7 @@ func checkDistAggregationInfo(
 		}
 	}
 
-	txn := client.NewTxn(srv.KVClient().(*client.DB))
+	txn := client.NewTxn(srv.KVClient().(*client.DB), srv.NodeID())
 
 	// First run a flow that aggregates all the rows without any local stages.
 

--- a/pkg/sql/distsqlplan/fake_span_resolver_test.go
+++ b/pkg/sql/distsqlplan/fake_span_resolver_test.go
@@ -54,7 +54,7 @@ func TestFakeSpanResolver(t *testing.T) {
 
 	db := tc.Server(0).KVClient().(*client.DB)
 
-	txn := client.NewTxn(db)
+	txn := client.NewTxn(db, tc.Server(0).NodeID())
 	it := resolver.NewSpanResolverIterator(txn)
 
 	desc := sqlbase.GetTableDescriptor(db, "test", "t")

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -104,7 +104,7 @@ func TestJoinReader(t *testing.T) {
 				EvalCtx:  evalCtx,
 				Settings: cluster.MakeTestingClusterSettings(),
 				// Pass a DB without a TxnCoordSender.
-				txn: client.NewTxn(client.NewDB(s.DistSender(), s.Clock())),
+				txn: client.NewTxn(client.NewDB(s.DistSender(), s.Clock()), s.NodeID()),
 			}
 
 			in := &RowBuffer{}
@@ -176,7 +176,7 @@ func TestJoinReaderDrain(t *testing.T) {
 		EvalCtx:  evalCtx,
 		Settings: s.ClusterSettings(),
 		// Pass a DB without a TxnCoordSender.
-		txn: client.NewTxn(client.NewDB(s.DistSender(), s.Clock())),
+		txn: client.NewTxn(client.NewDB(s.DistSender(), s.Clock()), s.NodeID()),
 	}
 
 	encRow := make(sqlbase.EncDatumRow, 1)

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -251,7 +251,7 @@ func (ds *ServerImpl) setupFlow(
 	acc := monitor.MakeBoundAccount()
 
 	// The flow will run in a Txn that bypasses the local TxnCoordSender.
-	txn := client.NewTxnWithProto(ds.FlowDB, req.Txn)
+	txn := client.NewTxnWithProto(ds.FlowDB, req.Flow.Gateway, req.Txn)
 	// DistSQL transactions get retryable errors that would otherwise be handled
 	// by the TxnCoordSender.
 	txn.AcceptUnhandledRetryableErrors()

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -61,7 +61,7 @@ func TestServer(t *testing.T) {
 		OutputColumns: []uint32{0, 1}, // a
 	}
 
-	txn := client.NewTxn(kvDB)
+	txn := client.NewTxn(kvDB, s.NodeID())
 
 	req := &SetupFlowRequest{Version: Version, Txn: *txn.Proto()}
 	req.Flow = FlowSpec{

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -123,7 +123,7 @@ func TestTableReader(t *testing.T) {
 			EvalCtx:  evalCtx,
 			Settings: s.ClusterSettings(),
 			// Pass a DB without a TxnCoordSender.
-			txn:    client.NewTxn(client.NewDB(s.DistSender(), s.Clock())),
+			txn:    client.NewTxn(client.NewDB(s.DistSender(), s.Clock()), s.NodeID()),
 			nodeID: s.NodeID(),
 		}
 
@@ -187,12 +187,13 @@ ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3
 
 	evalCtx := parser.MakeTestingEvalContext()
 	defer evalCtx.Stop(context.Background())
+	nodeID := tc.Server(0).NodeID()
 	flowCtx := FlowCtx{
 		EvalCtx:  evalCtx,
 		Settings: tc.Server(0).ClusterSettings(),
 		// Pass a DB without a TxnCoordSender.
-		txn:    client.NewTxn(client.NewDB(tc.Server(0).DistSender(), tc.Server(0).Clock())),
-		nodeID: tc.Server(0).NodeID(),
+		txn:    client.NewTxn(client.NewDB(tc.Server(0).DistSender(), tc.Server(0).Clock()), nodeID),
+		nodeID: nodeID,
 	}
 	spec := TableReaderSpec{
 		Spans: []TableReaderSpan{{Span: td.PrimaryIndexSpan()}},

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -526,7 +526,7 @@ func (e *Executor) Prepare(
 		// TODO(vivek): perhaps we should be more consistent and update
 		// session.TxnState.mu.txn, but more thought needs to be put into whether that
 		// is really needed.
-		txn = client.NewTxn(e.cfg.DB)
+		txn = client.NewTxn(e.cfg.DB, e.cfg.NodeID.Get())
 		if err := txn.SetIsolation(session.DefaultIsolationLevel); err != nil {
 			panic(fmt.Errorf("cannot set up txn for prepare %q: %v", stmtStr, err))
 		}

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -313,7 +313,7 @@ func planQuery(
 	t *testing.T, s serverutils.TestServerInterface, sql string,
 ) (*planner, planNode, func()) {
 	kvDB := s.KVClient().(*client.DB)
-	txn := client.NewTxn(kvDB)
+	txn := client.NewTxn(kvDB, s.NodeID())
 	txn.Proto().OrigTimestamp = s.Clock().Now()
 	p := makeInternalPlanner("plan", txn, security.RootUser, &MemoryMetrics{})
 	p.session.tables.leaseMgr = s.LeaseManager().(*LeaseManager)

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1103,7 +1103,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	ts.mon.Start(ctx, &s.mon, mon.BoundAccount{})
 
 	ts.mu.Lock()
-	ts.mu.txn = client.NewTxn(e.cfg.DB)
+	ts.mu.txn = client.NewTxn(e.cfg.DB, e.cfg.NodeID.Get())
 	ts.mu.Unlock()
 	if ts.implicitTxn {
 		ts.mu.txn.SetDebugName(sqlImplicitTxnName)

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -817,7 +817,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		txn := client.NewTxn(kvDB)
+		txn := client.NewTxn(kvDB, s.NodeID())
 		if err := test.desc.validateCrossReferences(context.TODO(), txn); err == nil {
 			t.Errorf("%d: expected \"%s\", but found success: %+v", i, test.err, test.desc)
 		} else if test.err != err.Error() {

--- a/pkg/storage/addressing_test.go
+++ b/pkg/storage/addressing_test.go
@@ -155,7 +155,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 			store.testSender(), store.cfg.Clock,
 			false, stopper, kv.MakeTxnMetrics(time.Second))
 		db := client.NewDB(tcs, store.cfg.Clock)
-		txn := client.NewTxn(db)
+		txn := client.NewTxn(db, 0 /* gatewayNodeID */)
 		ctx := context.Background()
 		if err := txn.Run(ctx, b); err != nil {
 			t.Fatal(err)

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1299,7 +1299,7 @@ func TestStoreSplitTimestampCacheDifferentLeaseHolder(t *testing.T) {
 	ctx = tc.Server(0).Stopper().WithCancel(ctx)
 
 	// This transaction will try to write "under" a served read.
-	txnOld := client.NewTxn(db)
+	txnOld := client.NewTxn(db, 0 /* gatewayNodeID */)
 
 	// Do something with txnOld so that its timestamp gets set.
 	if _, err := txnOld.Scan(ctx, "a", "b", 0); err != nil {
@@ -1992,7 +1992,7 @@ func TestDistributedTxnCleanup(t *testing.T) {
 				// Run a distributed transaction involving the lhsKey and rhsKey.
 				var txnKey roachpb.Key
 				ctx := context.Background()
-				txn := client.NewTxn(store.DB())
+				txn := client.NewTxn(store.DB(), 0 /* gatewayNodeID */)
 				opts := client.TxnExecOptions{
 					AutoCommit: true,
 					AutoRetry:  false,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -650,6 +650,7 @@ type StoreTestingKnobs struct {
 	// ReplayProtectionFilterWrapper.
 	// TODO(bdarnell,tschottdorf): Migrate existing tests which use this
 	// to one of the other filters. See #10493
+	// TODO(andrei): Provide guidance on what to use instead for trapping reads.
 	TestingEvalFilter storagebase.ReplicaCommandFilter
 
 	// TestingApplyFilter is called before applying the results of a


### PR DESCRIPTION
cherry-pick of #18767
cc @cockroachdb/release 

Fixes #18700

Before this patch, the DistSender assumed that the gateway node was the
current node for all KV requests that it sent out. This isn't true for
requests produced by DistSQL flows.
This patch asks people creating client.Txns to be explicit about what
the gateway is, and DistSQL correctly identifies the true gateway.
client.Txn will then use that information to fill out all the requests
it sends.

I will cherry-pick this into 1.1