### PR TITLE
[DNM] storage: factor out evaluation of BatchRequest

### DIFF
--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -290,7 +290,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		}()
 
 		nowNanos += rng.Int63n(1e9)
-		cArgs := storage.CommandArgs{
+		cArgs := batcheval.CommandArgs{
 			Header: roachpb.Header{
 				Timestamp: hlc.Timestamp{WallTime: nowNanos},
 			},

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -98,8 +99,8 @@ func (r *rowCounter) count(key roachpb.Key) error {
 // evalExport dumps the requested keys into files of non-overlapping key ranges
 // in a format suitable for bulk ingest.
 func evalExport(
-	ctx context.Context, batch engine.ReadWriter, cArgs storage.CommandArgs, resp roachpb.Response,
-) (storage.EvalResult, error) {
+	ctx context.Context, batch engine.ReadWriter, cArgs batcheval.CommandArgs, resp roachpb.Response,
+) (batcheval.Result, error) {
 	args := cArgs.Args.(*roachpb.ExportRequest)
 	h := cArgs.Header
 	reply := resp.(*roachpb.ExportResponse)
@@ -114,29 +115,29 @@ func evalExport(
 	// deletions in the incremental backup.
 	gcThreshold, err := cArgs.EvalCtx.GCThreshold()
 	if err != nil {
-		return storage.EvalResult{}, err
+		return batcheval.Result{}, err
 	}
 	if args.StartTime != (hlc.Timestamp{}) {
 		if !gcThreshold.Less(args.StartTime) {
-			return storage.EvalResult{}, errors.Errorf("start timestamp %v must be after replica GC threshold %v", args.StartTime, gcThreshold)
+			return batcheval.Result{}, errors.Errorf("start timestamp %v must be after replica GC threshold %v", args.StartTime, gcThreshold)
 		}
 	}
 
 	if err := exportRequestLimiter.beginLimitedRequest(ctx); err != nil {
-		return storage.EvalResult{}, err
+		return batcheval.Result{}, err
 	}
 	defer exportRequestLimiter.endLimitedRequest()
 	log.Infof(ctx, "export [%s,%s)", args.Key, args.EndKey)
 
 	exportStore, err := MakeExportStorage(ctx, args.Storage)
 	if err != nil {
-		return storage.EvalResult{}, err
+		return batcheval.Result{}, err
 	}
 	defer exportStore.Close()
 
 	sst, err := engine.MakeRocksDBSstFileWriter()
 	if err != nil {
-		return storage.EvalResult{}, err
+		return batcheval.Result{}, err
 	}
 	defer sst.Close()
 
@@ -150,7 +151,7 @@ func evalExport(
 		if err != nil {
 			// The error may be a WriteIntentError. In which case, returning it will
 			// cause this command to be retried.
-			return storage.EvalResult{}, err
+			return batcheval.Result{}, err
 		}
 		if !ok || iter.UnsafeKey().Key.Compare(args.EndKey) >= 0 {
 			break
@@ -162,34 +163,34 @@ func evalExport(
 		}
 
 		if err := rows.count(iter.UnsafeKey().Key); err != nil {
-			return storage.EvalResult{}, errors.Wrapf(err, "decoding %s", iter.UnsafeKey())
+			return batcheval.Result{}, errors.Wrapf(err, "decoding %s", iter.UnsafeKey())
 		}
 		if err := sst.Add(engine.MVCCKeyValue{Key: iter.UnsafeKey(), Value: iter.UnsafeValue()}); err != nil {
-			return storage.EvalResult{}, errors.Wrapf(err, "adding key %s", iter.UnsafeKey())
+			return batcheval.Result{}, errors.Wrapf(err, "adding key %s", iter.UnsafeKey())
 		}
 	}
 
 	if sst.DataSize == 0 {
 		// Let the defer Close the sstable.
 		reply.Files = []roachpb.ExportResponse_File{}
-		return storage.EvalResult{}, nil
+		return batcheval.Result{}, nil
 	}
 	rows.BulkOpSummary.DataSize = sst.DataSize
 
 	sstContents, err := sst.Finish()
 	if err != nil {
-		return storage.EvalResult{}, err
+		return batcheval.Result{}, err
 	}
 
 	// Compute the checksum before we upload and remove the local file.
 	checksum, err := SHA512ChecksumData(sstContents)
 	if err != nil {
-		return storage.EvalResult{}, err
+		return batcheval.Result{}, err
 	}
 
 	filename := fmt.Sprintf("%d.sst", parser.GenerateUniqueInt(cArgs.EvalCtx.NodeID()))
 	if err := exportStore.WriteFile(ctx, filename, bytes.NewReader(sstContents)); err != nil {
-		return storage.EvalResult{}, err
+		return batcheval.Result{}, err
 	}
 
 	reply.Files = []roachpb.ExportResponse_File{{
@@ -199,7 +200,7 @@ func evalExport(
 		Sha512:   checksum,
 	}}
 
-	return storage.EvalResult{}, nil
+	return batcheval.Result{}, nil
 }
 
 // SHA512ChecksumData returns the SHA512 checksum of data.

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -203,7 +204,7 @@ func (b *sstBatcher) Close() {
 }
 
 // evalImport bulk loads key/value entries.
-func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.ImportResponse, error) {
+func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.ImportResponse, error) {
 	args := cArgs.Args.(*roachpb.ImportRequest)
 	db := cArgs.EvalCtx.DB()
 	kr, err := MakeKeyRewriter(args.Rekeys)

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -34,8 +35,8 @@ func init() {
 // data in the affected keyrange is first cleared (not tombstoned), which makes
 // this command idempotent.
 func evalWriteBatch(
-	ctx context.Context, batch engine.ReadWriter, cArgs storage.CommandArgs, _ roachpb.Response,
-) (storage.EvalResult, error) {
+	ctx context.Context, batch engine.ReadWriter, cArgs batcheval.CommandArgs, _ roachpb.Response,
+) (batcheval.Result, error) {
 
 	args := cArgs.Args.(*roachpb.WriteBatchRequest)
 	h := cArgs.Header
@@ -52,7 +53,7 @@ func evalWriteBatch(
 	if args.DataSpan.Key.Compare(args.Key) < 0 || args.DataSpan.EndKey.Compare(args.EndKey) > 0 {
 		// TODO(dan): Add a new field in roachpb.Error, so the client can catch
 		// this and retry.
-		return storage.EvalResult{}, errors.New("data spans multiple ranges")
+		return batcheval.Result{}, errors.New("data spans multiple ranges")
 	}
 
 	mvccStartKey := engine.MVCCKey{Key: args.Key}
@@ -62,7 +63,7 @@ func evalWriteBatch(
 	// request header.
 	msBatch, err := engineccl.VerifyBatchRepr(args.Data, mvccStartKey, mvccEndKey, h.Timestamp.WallTime)
 	if err != nil {
-		return storage.EvalResult{}, err
+		return batcheval.Result{}, err
 	}
 	ms.Add(msBatch)
 
@@ -70,14 +71,14 @@ func evalWriteBatch(
 	// adjust the MVCCStats) before applying the WriteBatch data.
 	existingStats, err := clearExistingData(ctx, batch, mvccStartKey, mvccEndKey, h.Timestamp.WallTime)
 	if err != nil {
-		return storage.EvalResult{}, errors.Wrap(err, "clearing existing data")
+		return batcheval.Result{}, errors.Wrap(err, "clearing existing data")
 	}
 	ms.Subtract(existingStats)
 
 	if err := batch.ApplyBatchRepr(args.Data, false /* !sync */); err != nil {
-		return storage.EvalResult{}, err
+		return batcheval.Result{}, err
 	}
-	return storage.EvalResult{}, nil
+	return batcheval.Result{}, nil
 }
 
 func clearExistingData(

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -133,7 +133,7 @@ func TestWriteBatchMVCCStats(t *testing.T) {
 		}
 	}
 
-	cArgs := storage.CommandArgs{
+	cArgs := batcheval.CommandArgs{
 		Args: &roachpb.WriteBatchRequest{
 			Span:     span,
 			DataSpan: span,

--- a/pkg/storage/abortcache/abort_cache.go
+++ b/pkg/storage/abortcache/abort_cache.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package storage
+package abortcache
 
 import (
 	"golang.org/x/net/context"
@@ -28,7 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-// The AbortCache sets markers for aborted transactions to provide
+// An Instance sets markers for aborted transactions to provide
 // protection against an aborted but active transaction not reading
 // values it wrote (due to its intents having been removed).
 //
@@ -36,7 +36,7 @@ import (
 // is cleared from a range, and is consulted before read commands are processed
 // on a range.
 //
-// The AbortCache stores responses in the underlying engine, using keys derived
+// The Instance stores responses in the underlying engine, using keys derived
 // from Range ID and txn ID.
 // Note that the epoch number is not used to query the cache: once aborted, even
 // higher epochs are prohibited from reading data. That's because, for better or
@@ -44,20 +44,20 @@ import (
 // than the txn meta used for clearing (see engine.MVCCResolveWriteIntent), and
 // this clearing can race with the new epoch laying intents.
 //
-// A AbortCache is not thread safe. Access to it is serialized
+// An Instance is not thread safe. Access to it is serialized
 // through Raft.
 //
 // TODO(tschottdorf): we seem to have made a half-hearted attempt at naming
 // this the "AbortSpan" instead, but large parts of the code still call this
-// "AbortCache". We should settle for one and rename everything post-yellow.
-type AbortCache struct {
+// "Instance". We should settle for one and rename everything post-yellow.
+type Instance struct {
 	rangeID roachpb.RangeID
 }
 
-// NewAbortCache returns a new abort cache. Every range replica
+// New returns a new abort cache. Every range replica
 // maintains an abort cache, not just the lease holder.
-func NewAbortCache(rangeID roachpb.RangeID) *AbortCache {
-	return &AbortCache{
+func New(rangeID roachpb.RangeID) *Instance {
+	return &Instance{
 		rangeID: rangeID,
 	}
 }
@@ -73,24 +73,26 @@ func fillUUID(b byte) uuid.UUID {
 var txnIDMin = fillUUID('\x00')
 var txnIDMax = fillUUID('\xff')
 
-func abortCacheMinKey(rangeID roachpb.RangeID) roachpb.Key {
+// MinKey returns the lower bound of the key span associated to an instance for the given RangeID.
+func MinKey(rangeID roachpb.RangeID) roachpb.Key {
 	return keys.AbortCacheKey(rangeID, txnIDMin)
 }
 
-func (sc *AbortCache) min() roachpb.Key {
-	return abortCacheMinKey(sc.rangeID)
+func (sc *Instance) min() roachpb.Key {
+	return MinKey(sc.rangeID)
 }
 
-func abortCacheMaxKey(rangeID roachpb.RangeID) roachpb.Key {
+// MaxKey returns the upper bound of the key span associated to an instance for the given RangeID.
+func MaxKey(rangeID roachpb.RangeID) roachpb.Key {
 	return keys.AbortCacheKey(rangeID, txnIDMax)
 }
 
-func (sc *AbortCache) max() roachpb.Key {
-	return abortCacheMaxKey(sc.rangeID)
+func (sc *Instance) max() roachpb.Key {
+	return MaxKey(sc.rangeID)
 }
 
 // ClearData removes all persisted items stored in the cache.
-func (sc *AbortCache) ClearData(e engine.Engine) error {
+func (sc *Instance) ClearData(e engine.Engine) error {
 	iter := e.NewIterator(false)
 	defer iter.Close()
 	b := e.NewWriteOnlyBatch()
@@ -105,7 +107,7 @@ func (sc *AbortCache) ClearData(e engine.Engine) error {
 
 // Get looks up an abort cache entry recorded for this transaction ID.
 // Returns whether an abort record was found and any error.
-func (sc *AbortCache) Get(
+func (sc *Instance) Get(
 	ctx context.Context, e engine.Reader, txnID uuid.UUID, entry *roachpb.AbortCacheEntry,
 ) (bool, error) {
 
@@ -119,7 +121,7 @@ func (sc *AbortCache) Get(
 // each unmarshaled entry with the key, the transaction ID and the decoded
 // entry.
 // TODO(tschottdorf): should not use a pointer to UUID.
-func (sc *AbortCache) Iterate(
+func (sc *Instance) Iterate(
 	ctx context.Context, e engine.Reader, f func([]byte, roachpb.AbortCacheEntry),
 ) {
 	_, _ = engine.MVCCIterate(ctx, e, sc.min(), sc.max(), hlc.Timestamp{},
@@ -185,7 +187,7 @@ func copySeqCache(
 // CopyInto copies all the results from this abort cache into the destRangeID
 // abort cache. Failures decoding individual cache entries return an error.
 // On success, returns the number of entries (key-value pairs) copied.
-func (sc *AbortCache) CopyInto(
+func (sc *Instance) CopyInto(
 	e engine.ReadWriter, ms *enginepb.MVCCStats, destRangeID roachpb.RangeID,
 ) (int, error) {
 	return copySeqCache(e, ms, sc.rangeID, destRangeID,
@@ -198,7 +200,7 @@ func (sc *AbortCache) CopyInto(
 // entries return an error. The copy is done directly using the engine
 // instead of interpreting values through MVCC for efficiency.
 // On success, returns the number of entries (key-value pairs) copied.
-func (sc *AbortCache) CopyFrom(
+func (sc *Instance) CopyFrom(
 	ctx context.Context, e engine.ReadWriter, ms *enginepb.MVCCStats, originRangeID roachpb.RangeID,
 ) (int, error) {
 	originMin := engine.MakeMVCCMetadataKey(keys.AbortCacheKey(originRangeID, txnIDMin))
@@ -207,7 +209,7 @@ func (sc *AbortCache) CopyFrom(
 }
 
 // Del removes all abort cache entries for the given transaction.
-func (sc *AbortCache) Del(
+func (sc *Instance) Del(
 	ctx context.Context, e engine.ReadWriter, ms *enginepb.MVCCStats, txnID uuid.UUID,
 ) error {
 	key := keys.AbortCacheKey(sc.rangeID, txnID)
@@ -215,7 +217,7 @@ func (sc *AbortCache) Del(
 }
 
 // Put writes an entry for the specified transaction ID.
-func (sc *AbortCache) Put(
+func (sc *Instance) Put(
 	ctx context.Context,
 	e engine.ReadWriter,
 	ms *enginepb.MVCCStats,

--- a/pkg/storage/batcheval/command_args.go
+++ b/pkg/storage/batcheval/command_args.go
@@ -1,0 +1,66 @@
+package batcheval
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/abortcache"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// ReplicaEvalContextI .
+type ReplicaEvalContextI interface {
+	ClusterSettings() *cluster.Settings
+	TxnSpanGCThreshold() (hlc.Timestamp, error)
+	GCThreshold() (hlc.Timestamp, error)
+	Desc() (*roachpb.RangeDescriptor, error)
+	//StoreTestingKnobs() StoreTestingKnobs
+	ContainsKey(roachpb.Key) (bool, error)
+	AbortCache() *abortcache.Instance
+	RangeID() roachpb.RangeID
+	FirstIndex() (uint64, error)
+	Term(uint64) (uint64, error)
+	GetLease() (roachpb.Lease, *roachpb.Lease, error)
+	Tracer() opentracing.Tracer
+	GetMVCCStats() (enginepb.MVCCStats, error)
+	GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error)
+	Engine() engine.Engine
+	IsFirstRange() bool
+
+	// Used from storageccl
+	NodeID() roachpb.NodeID
+	DB() *client.DB
+
+	MakeReplicaStateLoader() stateloader.Instance
+	//pushTxnQueue() *pushTxnQueue
+}
+
+// CommandArgs contains all the arguments to a command.
+// TODO(bdarnell): consider merging with storagebase.FilterArgs (which
+// would probably require removing the EvalCtx field due to import order
+// constraints).
+type CommandArgs struct {
+	EvalCtx ReplicaEvalContextI
+	Header  roachpb.Header
+	Args    roachpb.Request
+
+	// If MaxKeys is non-zero, span requests should limit themselves to
+	// that many keys. Commands using this feature should also set
+	// NumKeys and ResumeSpan in their responses.
+	MaxKeys int64
+
+	// *Stats should be mutated to reflect any writes made by the command.
+	Stats *enginepb.MVCCStats
+}
+
+// IntentsWithArg groups a slice of intents with the request which encountered them.
+type IntentsWithArg struct {
+	Args    roachpb.Request
+	Intents []roachpb.Intent
+}

--- a/pkg/storage/batcheval/eval_put.go
+++ b/pkg/storage/batcheval/eval_put.go
@@ -1,0 +1,50 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package batcheval
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// EvalPut sets the value for a specified key.
+func EvalPut(
+	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+) (Result, error) {
+	args := cArgs.Args.(*roachpb.PutRequest)
+	h := cArgs.Header
+	ms := cArgs.Stats
+
+	var ts hlc.Timestamp
+	if !args.Inline {
+		ts = h.Timestamp
+	}
+	if h.DistinctSpans {
+		if b, ok := batch.(engine.Batch); ok {
+			// Use the distinct batch for both blind and normal ops so that we don't
+			// accidentally flush mutations to make them visible to the distinct
+			// batch.
+			batch = b.Distinct()
+			defer batch.Close()
+		}
+	}
+	if args.Blind {
+		return Result{}, engine.MVCCBlindPut(ctx, batch, ms, args.Key, ts, args.Value, h.Txn)
+	}
+	return Result{}, engine.MVCCPut(ctx, batch, ms, args.Key, ts, args.Value, h.Txn)
+}

--- a/pkg/storage/batcheval/result.go
+++ b/pkg/storage/batcheval/result.go
@@ -1,0 +1,295 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package batcheval
+
+import (
+	"errors"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/kr/pretty"
+)
+
+// LocalResult is data belonging to an evaluated command that is only used on the node on which the
+// command was proposed. Note that the proposing node may die before the local results are
+// processed, so any side effects here are only best-effort.
+type LocalResult struct {
+	// The error resulting from the proposal. Most failing proposals will
+	// fail-fast, i.e. will return an error to the client above Raft. However,
+	// some proposals need to commit data even on error, and in that case we
+	// treat the proposal like a successful one, except that the error stored
+	// here will be sent to the client when the associated batch commits. In
+	// the common case, this field is nil.
+	Err   *roachpb.Error
+	Reply *roachpb.BatchResponse
+
+	// IntentsAlways stores any intents encountered but not conflicted with.
+	// They should be handed off to asynchronous intent processing on the
+	// proposer, so that an attempt to resolve them is made. In particular, this
+	// is the pathway used by EndTransaction to communicate its non-local
+	// intents up the stack.
+	//
+	// This is a pointer to allow the zero (and as an unwelcome side effect,
+	// all) values to be compared.
+	IntentsAlways *[]IntentsWithArg
+	// Like IntentsAlways, but specifies intents that must be left alone if the
+	// corresponding command/proposal didn't succeed. For example, resolving
+	// intents of a committing txn should not happen if the commit fails, or
+	// we may accidentally make uncommitted values live.
+	Intents *[]IntentsWithArg
+	// Whether we successfully or non-successfully requested a lease.
+	//
+	// TODO(tschottdorf): Update this counter correctly with prop-eval'ed KV
+	// in the following case:
+	// - proposal does not fail fast and goes through Raft
+	// - downstream-of-Raft logic identifies a conflict and returns an error
+	// The downstream-of-Raft logic does not exist at time of writing.
+	LeaseMetricsResult *storagebase.LeaseMetricsType
+
+	// When set (in which case we better be the first range), call
+	// gossipFirstRange if the Replica holds the lease.
+	GossipFirstRange bool
+	// Call maybeGossipSystemConfig.
+	MaybeGossipSystemConfig bool
+	// Call maybeAddToSplitQueue.
+	MaybeAddToSplitQueue bool
+	// Call maybeGossipNodeLiveness with the specified Span, if set.
+	MaybeGossipNodeLiveness *roachpb.Span
+
+	// Set when a transaction record is updated, after a call to
+	// EndTransaction or PushTxn.
+	UpdatedTxn *roachpb.Transaction
+}
+
+// DetachIntents returns (and removes) those intents from the LocalEvalResult
+// which are supposed to be handled. When hasError is false, returns all
+// intents. When it is true, returns only a subset of intents for which it is
+// known that it is safe to handle them even if the command that discovered them
+// has failed (e.g. omitting intents associated to a committing EndTransaction).
+func (lResult *LocalResult) DetachIntents(hasError bool) []IntentsWithArg {
+	if lResult == nil {
+		return nil
+	}
+	var r []IntentsWithArg
+	if !hasError && lResult.Intents != nil {
+		r = *lResult.Intents
+	}
+	if lResult.IntentsAlways != nil {
+		if r == nil {
+			r = *lResult.IntentsAlways
+		} else {
+			r = append(r, *lResult.IntentsAlways...)
+		}
+	}
+	lResult.Intents, lResult.IntentsAlways = nil, nil
+	return r
+}
+
+// Result is the result of evaluating a KV request. That is, the
+// proposer (which holds the lease, at least in the case in which the command
+// will complete successfully) has evaluated the request and is holding on to:
+//
+// a) changes to be written to disk when applying the command
+// b) changes to the state which may require special handling (i.e. code
+//    execution) on all Replicas
+// c) data which isn't sent to the followers but the proposer needs for tasks
+//    it must run when the command has applied (such as resolving intents).
+type Result struct {
+	Local      LocalResult
+	Replicated storagebase.ReplicatedEvalResult
+	WriteBatch *storagebase.WriteBatch
+}
+
+// IsZero reports whether p is the zero value.
+func (p *Result) IsZero() bool {
+	if p.Local != (LocalResult{}) {
+		return false
+	}
+	if !p.Replicated.Equal(storagebase.ReplicatedEvalResult{}) {
+		return false
+	}
+	if p.WriteBatch != nil {
+		return false
+	}
+	return true
+}
+
+// coalesceBool ORs rhs into lhs and then zeroes rhs.
+func coalesceBool(lhs *bool, rhs *bool) {
+	*lhs = *lhs || *rhs
+	*rhs = false
+}
+
+// MergeAndDestroy absorbs the supplied EvalResult while validating that the
+// resulting EvalResult makes sense. For example, it is forbidden to absorb
+// two lease updates or log truncations, or multiple splits and/or merges.
+//
+// The passed EvalResult must not be used once passed to Merge.
+func (p *Result) MergeAndDestroy(q Result) error {
+	if q.Replicated.State != nil {
+		if q.Replicated.State.RaftAppliedIndex != 0 {
+			return errors.New("must not specify RaftApplyIndex")
+		}
+		if q.Replicated.State.LeaseAppliedIndex != 0 {
+			return errors.New("must not specify RaftApplyIndex")
+		}
+		if p.Replicated.State == nil {
+			p.Replicated.State = &storagebase.ReplicaState{}
+		}
+		if p.Replicated.State.Desc == nil {
+			p.Replicated.State.Desc = q.Replicated.State.Desc
+		} else if q.Replicated.State.Desc != nil {
+			return errors.New("conflicting RangeDescriptor")
+		}
+		q.Replicated.State.Desc = nil
+
+		if p.Replicated.State.Lease == nil {
+			p.Replicated.State.Lease = q.Replicated.State.Lease
+		} else if q.Replicated.State.Lease != nil {
+			return errors.New("conflicting Lease")
+		}
+		q.Replicated.State.Lease = nil
+
+		if p.Replicated.State.TruncatedState == nil {
+			p.Replicated.State.TruncatedState = q.Replicated.State.TruncatedState
+		} else if q.Replicated.State.TruncatedState != nil {
+			return errors.New("conflicting TruncatedState")
+		}
+		q.Replicated.State.TruncatedState = nil
+
+		if q.Replicated.State.GCThreshold != nil {
+			if p.Replicated.State.GCThreshold == nil {
+				p.Replicated.State.GCThreshold = q.Replicated.State.GCThreshold
+			} else {
+				p.Replicated.State.GCThreshold.Forward(*q.Replicated.State.GCThreshold)
+			}
+			q.Replicated.State.GCThreshold = nil
+		}
+		if q.Replicated.State.TxnSpanGCThreshold != nil {
+			if p.Replicated.State.TxnSpanGCThreshold == nil {
+				p.Replicated.State.TxnSpanGCThreshold = q.Replicated.State.TxnSpanGCThreshold
+			} else {
+				p.Replicated.State.TxnSpanGCThreshold.Forward(*q.Replicated.State.TxnSpanGCThreshold)
+			}
+			q.Replicated.State.TxnSpanGCThreshold = nil
+		}
+
+		if q.Replicated.State.Stats != nil {
+			return errors.New("must not specify Stats")
+		}
+		if (*q.Replicated.State != storagebase.ReplicaState{}) {
+			log.Fatalf(context.TODO(), "unhandled EvalResult: %s",
+				pretty.Diff(*q.Replicated.State, storagebase.ReplicaState{}))
+		}
+		q.Replicated.State = nil
+	}
+
+	p.Replicated.BlockReads = p.Replicated.BlockReads || q.Replicated.BlockReads
+	q.Replicated.BlockReads = false
+
+	if p.Replicated.Split == nil {
+		p.Replicated.Split = q.Replicated.Split
+	} else if q.Replicated.Split != nil {
+		return errors.New("conflicting Split")
+	}
+	q.Replicated.Split = nil
+
+	if p.Replicated.Merge == nil {
+		p.Replicated.Merge = q.Replicated.Merge
+	} else if q.Replicated.Merge != nil {
+		return errors.New("conflicting Merge")
+	}
+	q.Replicated.Merge = nil
+
+	if p.Replicated.ChangeReplicas == nil {
+		p.Replicated.ChangeReplicas = q.Replicated.ChangeReplicas
+	} else if q.Replicated.ChangeReplicas != nil {
+		return errors.New("conflicting ChangeReplicas")
+	}
+	q.Replicated.ChangeReplicas = nil
+
+	if p.Replicated.ComputeChecksum == nil {
+		p.Replicated.ComputeChecksum = q.Replicated.ComputeChecksum
+	} else if q.Replicated.ComputeChecksum != nil {
+		return errors.New("conflicting ComputeChecksum")
+	}
+	q.Replicated.ComputeChecksum = nil
+
+	if p.Replicated.RaftLogDelta == 0 {
+		p.Replicated.RaftLogDelta = q.Replicated.RaftLogDelta
+	} else if q.Replicated.RaftLogDelta != 0 {
+		return errors.New("conflicting RaftLogDelta")
+	}
+	q.Replicated.RaftLogDelta = 0
+
+	if p.Replicated.AddSSTable == nil {
+		p.Replicated.AddSSTable = q.Replicated.AddSSTable
+	} else if q.Replicated.AddSSTable != nil {
+		return errors.New("conflicting AddSSTable")
+	}
+	q.Replicated.AddSSTable = nil
+
+	if q.Local.IntentsAlways != nil {
+		if p.Local.IntentsAlways == nil {
+			p.Local.IntentsAlways = q.Local.IntentsAlways
+		} else {
+			*p.Local.IntentsAlways = append(*p.Local.IntentsAlways, *q.Local.IntentsAlways...)
+		}
+	}
+	q.Local.IntentsAlways = nil
+
+	if q.Local.Intents != nil {
+		if p.Local.Intents == nil {
+			p.Local.Intents = q.Local.Intents
+		} else {
+			*p.Local.Intents = append(*p.Local.Intents, *q.Local.Intents...)
+		}
+	}
+	q.Local.Intents = nil
+
+	if p.Local.LeaseMetricsResult == nil {
+		p.Local.LeaseMetricsResult = q.Local.LeaseMetricsResult
+	} else if q.Local.LeaseMetricsResult != nil {
+		return errors.New("conflicting LeaseMetricsResult")
+	}
+	q.Local.LeaseMetricsResult = nil
+
+	if p.Local.MaybeGossipNodeLiveness == nil {
+		p.Local.MaybeGossipNodeLiveness = q.Local.MaybeGossipNodeLiveness
+	} else if q.Local.MaybeGossipNodeLiveness != nil {
+		return errors.New("conflicting maybeGossipNodeLiveness")
+	}
+	q.Local.MaybeGossipNodeLiveness = nil
+
+	coalesceBool(&p.Local.GossipFirstRange, &q.Local.GossipFirstRange)
+	coalesceBool(&p.Local.MaybeGossipSystemConfig, &q.Local.MaybeGossipSystemConfig)
+	coalesceBool(&p.Local.MaybeAddToSplitQueue, &q.Local.MaybeAddToSplitQueue)
+
+	if p.Local.UpdatedTxn == nil {
+		p.Local.UpdatedTxn = q.Local.UpdatedTxn
+	} else if q.Local.UpdatedTxn != nil {
+		return errors.New("conflicting updatedTxn")
+	}
+	q.Local.UpdatedTxn = nil
+
+	if !q.IsZero() {
+		log.Fatalf(context.TODO(), "unhandled EvalResult: %s", pretty.Diff(q, Result{}))
+	}
+
+	return nil
+}

--- a/pkg/storage/cclglue.go
+++ b/pkg/storage/cclglue.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/pkg/errors"
 )
@@ -29,16 +30,16 @@ func makeUnimplementedCommand(method roachpb.Method) Command {
 	return Command{
 		DeclareKeys: DefaultDeclareKeys,
 		Eval: func(
-			_ context.Context, _ engine.ReadWriter, _ CommandArgs, _ roachpb.Response,
-		) (EvalResult, error) {
-			return EvalResult{}, errors.Errorf("unimplemented command: %s", method.String())
+			_ context.Context, _ engine.ReadWriter, _ batcheval.CommandArgs, _ roachpb.Response,
+		) (batcheval.Result, error) {
+			return batcheval.Result{}, errors.Errorf("unimplemented command: %s", method.String())
 		}}
 }
 
 var writeBatchCmd = makeUnimplementedCommand(roachpb.WriteBatch)
 var addSSTableCmd = makeUnimplementedCommand(roachpb.AddSSTable)
 var exportCmd = makeUnimplementedCommand(roachpb.Export)
-var importCmdFn ImportCmdFunc = func(context.Context, CommandArgs) (*roachpb.ImportResponse, error) {
+var importCmdFn ImportCmdFunc = func(context.Context, batcheval.CommandArgs) (*roachpb.ImportResponse, error) {
 	return &roachpb.ImportResponse{}, errors.Errorf("unimplemented command: %s", roachpb.Import)
 }
 
@@ -65,7 +66,7 @@ func SetExportCmd(cmd Command) {
 
 // ImportCmdFunc is the type of the function that will be called as the
 // implementation of the Import command.
-type ImportCmdFunc func(context.Context, CommandArgs) (*roachpb.ImportResponse, error)
+type ImportCmdFunc func(context.Context, batcheval.CommandArgs) (*roachpb.ImportResponse, error)
 
 // SetImportCmd allows setting the function that will be called as the
 // implementation of the Import command. Only allowed to be called by Init.

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/abortcache"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -499,7 +500,7 @@ func processAbortCache(
 	pushTxn pushFunc,
 ) []roachpb.GCRequest_GCKey {
 	var gcKeys []roachpb.GCRequest_GCKey
-	abortCache := NewAbortCache(rangeID)
+	abortCache := abortcache.New(rangeID)
 	infoMu.Lock()
 	defer infoMu.Unlock()
 	abortCache.Iterate(ctx, snap, func(key []byte, v roachpb.AbortCacheEntry) {

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -465,12 +466,12 @@ func SetMockAddSSTable() (undo func()) {
 	// TODO(tschottdorf): this already does nontrivial work. Worth open-sourcing the relevant
 	// subparts of the real evalAddSSTable to make this test less likely to rot.
 	evalAddSSTable := func(
-		ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, _ roachpb.Response,
-	) (EvalResult, error) {
+		ctx context.Context, batch engine.ReadWriter, cArgs batcheval.CommandArgs, _ roachpb.Response,
+	) (batcheval.Result, error) {
 		log.Event(ctx, "evaluated testing-only AddSSTable mock")
 		args := cArgs.Args.(*roachpb.AddSSTableRequest)
 
-		return EvalResult{
+		return batcheval.Result{
 			Replicated: storagebase.ReplicatedEvalResult{
 				AddSSTable: &storagebase.ReplicatedEvalResult_AddSSTable{
 					Data:  args.Data,

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -261,7 +262,7 @@ func (ir *intentResolver) maybePushTransactions(
 // differently and would be better served by different entry points,
 // but combining them simplifies the plumbing necessary in Replica.
 func (ir *intentResolver) processIntentsAsync(
-	ctx context.Context, r *Replica, intents []intentsWithArg, allowSyncProcessing bool,
+	ctx context.Context, r *Replica, intents []batcheval.IntentsWithArg, allowSyncProcessing bool,
 ) {
 	if r.store.TestingKnobs().DisableAsyncIntentResolution {
 		return
@@ -291,7 +292,7 @@ func (ir *intentResolver) processIntentsAsync(
 }
 
 func (ir *intentResolver) processIntents(
-	ctx context.Context, r *Replica, item intentsWithArg, now hlc.Timestamp,
+	ctx context.Context, r *Replica, item batcheval.IntentsWithArg, now hlc.Timestamp,
 ) {
 	// Everything here is best effort; so give the context a timeout to avoid
 	// waiting too long. This may be a larger timeout than the context already
@@ -299,10 +300,10 @@ func (ir *intentResolver) processIntents(
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, intentResolverTimeout)
 	defer cancel()
 
-	if item.args.Method() != roachpb.EndTransaction {
+	if item.Args.Method() != roachpb.EndTransaction {
 		h := roachpb.Header{Timestamp: now}
 		resolveIntents, pushErr := ir.maybePushTransactions(ctxWithTimeout,
-			item.intents, h, roachpb.PUSH_TOUCH, true /* skipInFlight */)
+			item.Intents, h, roachpb.PUSH_TOUCH, true /* skipInFlight */)
 
 		// resolveIntents with poison=true because we're resolving
 		// intents outside of the context of an EndTransaction.
@@ -341,7 +342,7 @@ func (ir *intentResolver) processIntents(
 		// example, an attempt to explicitly rollback the transaction
 		// may succeed (triggering this code path), but the result may
 		// not make it back to the client.
-		if err := ir.resolveIntents(ctxWithTimeout, item.intents,
+		if err := ir.resolveIntents(ctxWithTimeout, item.Intents,
 			ResolveOptions{Wait: true, Poison: false}); err != nil {
 			log.Warningf(ctx, "%s: failed to resolve intents: %s", r, err)
 			return
@@ -350,7 +351,7 @@ func (ir *intentResolver) processIntents(
 		// We successfully resolved the intents, so we're able to GC from
 		// the txn span directly.
 		b := &client.Batch{}
-		txn := item.intents[0].Txn
+		txn := item.Intents[0].Txn
 		txnKey := keys.TransactionKey(txn.Key, txn.ID)
 
 		// This is pretty tricky. Transaction keys are range-local and

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -260,7 +261,7 @@ type Replica struct {
 
 		// Note that there are two replicaStateLoaders, in raftMu and mu,
 		// depending on which lock is being held.
-		stateLoader replicaStateLoader
+		stateLoader stateloader.Instance
 		// on-disk storage for sideloaded SSTables. nil when there's no ReplicaID.
 		sideloaded sideloadStorage
 	}
@@ -447,7 +448,7 @@ type Replica struct {
 
 		// Note that there are two replicaStateLoaders, in raftMu and mu,
 		// depending on which lock is being held.
-		stateLoader replicaStateLoader
+		stateLoader stateloader.Instance
 	}
 
 	unreachablesMu struct {
@@ -584,7 +585,7 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 		abortCache:     NewAbortCache(rangeID),
 		pushTxnQueue:   newPushTxnQueue(store),
 	}
-	r.mu.stateLoader = makeReplicaStateLoader(r.store.cfg.Settings, rangeID)
+	r.mu.stateLoader = stateloader.Make(r.store.cfg.Settings, rangeID)
 	if leaseHistoryMaxEntries > 0 {
 		r.leaseHistory = newLeaseHistory()
 	}
@@ -609,7 +610,7 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 		},
 	)
 	r.raftMu.timedMutex = makeTimedMutex(raftMuLogger)
-	r.raftMu.stateLoader = makeReplicaStateLoader(r.store.cfg.Settings, rangeID)
+	r.raftMu.stateLoader = stateloader.Make(r.store.cfg.Settings, rangeID)
 	return r
 }
 
@@ -666,18 +667,18 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(
 
 	var err error
 
-	if r.mu.state, err = r.mu.stateLoader.load(ctx, r.store.Engine(), desc); err != nil {
+	if r.mu.state, err = r.mu.stateLoader.Load(ctx, r.store.Engine(), desc); err != nil {
 		return err
 	}
 	r.rangeStr.store(0, r.mu.state.Desc)
 
-	r.mu.lastIndex, err = r.mu.stateLoader.loadLastIndex(ctx, r.store.Engine())
+	r.mu.lastIndex, err = r.mu.stateLoader.LoadLastIndex(ctx, r.store.Engine())
 	if err != nil {
 		return err
 	}
 	r.mu.lastTerm = invalidLastTerm
 
-	pErr, err := r.mu.stateLoader.loadReplicaDestroyedError(ctx, r.store.Engine())
+	pErr, err := r.mu.stateLoader.LoadReplicaDestroyedError(ctx, r.store.Engine())
 	if err != nil {
 		return err
 	}
@@ -1703,7 +1704,7 @@ func (r *Replica) State() storagebase.RangeInfo {
 //
 // TODO(tschottdorf): Consider future removal (for example, when #7224 is resolved).
 func (r *Replica) assertStateLocked(ctx context.Context, reader engine.Reader) {
-	diskState, err := r.mu.stateLoader.load(ctx, reader, r.mu.state.Desc)
+	diskState, err := r.mu.stateLoader.Load(ctx, reader, r.mu.state.Desc)
 	if err != nil {
 		log.Fatal(ctx, err)
 	}
@@ -3348,7 +3349,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		}
 	}
 	if !raft.IsEmptyHardState(rd.HardState) {
-		if err := r.raftMu.stateLoader.setHardState(ctx, writer, rd.HardState); err != nil {
+		if err := r.raftMu.stateLoader.SetHardState(ctx, writer, rd.HardState); err != nil {
 			const expl = "during setHardState"
 			return stats, expl, errors.Wrap(err, expl)
 		}
@@ -4603,19 +4604,19 @@ func (r *Replica) applyRaftCommand(
 	// reading the previous applied index keys on every write operation. This
 	// requires a little additional work in order maintain the MVCC stats.
 	var appliedIndexNewMS enginepb.MVCCStats
-	if err := r.raftMu.stateLoader.setAppliedIndexBlind(ctx, writer, &appliedIndexNewMS,
+	if err := r.raftMu.stateLoader.SetAppliedIndexBlind(ctx, writer, &appliedIndexNewMS,
 		raftAppliedIndex, leaseAppliedIndex); err != nil {
 		return enginepb.MVCCStats{}, roachpb.NewError(NewReplicaCorruptionError(
 			errors.Wrap(err, "unable to set applied index")))
 	}
 	rResult.Delta.SysBytes += appliedIndexNewMS.SysBytes -
-		r.raftMu.stateLoader.calcAppliedIndexSysBytes(oldRaftAppliedIndex, oldLeaseAppliedIndex)
+		r.raftMu.stateLoader.CalcAppliedIndexSysBytes(oldRaftAppliedIndex, oldLeaseAppliedIndex)
 
 	// Special-cased MVCC stats handling to exploit commutativity of stats
 	// delta upgrades. Thanks to commutativity, the command queue does not
 	// have to serialize on the stats key.
 	ms.Add(enginepb.MVCCStats(rResult.Delta))
-	if err := r.raftMu.stateLoader.setMVCCStats(ctx, writer, &ms); err != nil {
+	if err := r.raftMu.stateLoader.SetMVCCStats(ctx, writer, &ms); err != nil {
 		return enginepb.MVCCStats{}, roachpb.NewError(NewReplicaCorruptionError(
 			errors.Wrap(err, "unable to update MVCCStats")))
 	}
@@ -4630,8 +4631,8 @@ func (r *Replica) applyRaftCommand(
 
 	var assertHS *raftpb.HardState
 	if util.RaceEnabled && rResult.Split != nil && r.store.cfg.Settings.Version.IsActive(cluster.VersionSplitHardStateBelowRaft) {
-		rsl := makeReplicaStateLoader(r.store.cfg.Settings, rResult.Split.RightDesc.RangeID)
-		oldHS, err := rsl.loadHardState(ctx, r.store.Engine())
+		rsl := stateloader.Make(r.store.cfg.Settings, rResult.Split.RightDesc.RangeID)
+		oldHS, err := rsl.LoadHardState(ctx, r.store.Engine())
 		if err != nil {
 			log.Fatalf(ctx, "unable to load HardState: %s", err)
 		}
@@ -4644,8 +4645,8 @@ func (r *Replica) applyRaftCommand(
 
 	if assertHS != nil {
 		// Load the HardState that was just committed (if any).
-		rsl := makeReplicaStateLoader(r.store.cfg.Settings, rResult.Split.RightDesc.RangeID)
-		newHS, err := rsl.loadHardState(ctx, r.store.Engine())
+		rsl := stateloader.Make(r.store.cfg.Settings, rResult.Split.RightDesc.RangeID)
+		newHS, err := rsl.LoadHardState(ctx, r.store.Engine())
 		if err != nil {
 			log.Fatalf(ctx, "unable to load HardState: %s", err)
 		}
@@ -5365,7 +5366,7 @@ func (r *Replica) maybeSetCorrupt(ctx context.Context, pErr *roachpb.Error) *roa
 
 		// Try to persist the destroyed error message. If the underlying store is
 		// corrupted the error won't be processed and a panic will occur.
-		if err := r.mu.stateLoader.setReplicaDestroyedError(ctx, r.store.Engine(), pErr); err != nil {
+		if err := r.mu.stateLoader.SetReplicaDestroyedError(ctx, r.store.Engine(), pErr); err != nil {
 			cErr.Processed = false
 			return roachpb.NewError(cErr)
 		}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/abortcache"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
@@ -227,8 +228,8 @@ type Replica struct {
 	RangeID roachpb.RangeID // Should only be set by the constructor.
 
 	store        *Store
-	abortCache   *AbortCache   // Avoids anomalous reads after abort
-	pushTxnQueue *pushTxnQueue // Queues push txn attempts by txn ID
+	abortCache   *abortcache.Instance // Avoids anomalous reads after abort
+	pushTxnQueue *pushTxnQueue        // Queues push txn attempts by txn ID
 
 	// leaseholderStats tracks all incoming BatchRequests to the replica and which
 	// localities they come from in order to aid in lease rebalancing decisions.
@@ -582,7 +583,7 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 		AmbientContext: store.cfg.AmbientCtx,
 		RangeID:        rangeID,
 		store:          store,
-		abortCache:     NewAbortCache(rangeID),
+		abortCache:     abortcache.New(rangeID),
 		pushTxnQueue:   newPushTxnQueue(store),
 	}
 	r.mu.stateLoader = stateloader.Make(r.store.cfg.Settings, rangeID)

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -1525,14 +1526,14 @@ func evalGC(
 	pd.Replicated.State = &storagebase.ReplicaState{}
 	if newThreshold != (hlc.Timestamp{}) {
 		pd.Replicated.State.GCThreshold = &newThreshold
-		if err := stateLoader.setGCThreshold(ctx, batch, cArgs.Stats, &newThreshold); err != nil {
+		if err := stateLoader.SetGCThreshold(ctx, batch, cArgs.Stats, &newThreshold); err != nil {
 			return EvalResult{}, err
 		}
 	}
 
 	if newTxnSpanGCThreshold != (hlc.Timestamp{}) {
 		pd.Replicated.State.TxnSpanGCThreshold = &newTxnSpanGCThreshold
-		if err := stateLoader.setTxnSpanGCThreshold(ctx, batch, cArgs.Stats, &newTxnSpanGCThreshold); err != nil {
+		if err := stateLoader.SetTxnSpanGCThreshold(ctx, batch, cArgs.Stats, &newTxnSpanGCThreshold); err != nil {
 			return EvalResult{}, err
 		}
 	}
@@ -1983,7 +1984,7 @@ func evalTruncateLog(
 	}
 	pd.Replicated.RaftLogDelta = ms.SysBytes
 
-	return pd, cArgs.EvalCtx.makeReplicaStateLoader().setTruncatedState(ctx, batch, cArgs.Stats, tState)
+	return pd, cArgs.EvalCtx.makeReplicaStateLoader().SetTruncatedState(ctx, batch, cArgs.Stats, tState)
 }
 
 func newFailedLeaseTrigger(isTransfer bool) EvalResult {
@@ -2150,7 +2151,7 @@ func evalNewLease(
 	}
 
 	// Store the lease to disk & in-memory.
-	if err := rec.makeReplicaStateLoader().setLease(ctx, batch, ms, lease); err != nil {
+	if err := rec.makeReplicaStateLoader().SetLease(ctx, batch, ms, lease); err != nil {
 		return newFailedLeaseTrigger(isTransfer), err
 	}
 
@@ -3092,7 +3093,7 @@ func splitTrigger(
 		//
 		// TODO(tschottdorf): why would this use r.store.Engine() and not the
 		// batch?
-		leftLease, err := rec.makeReplicaStateLoader().loadLease(ctx, rec.Engine())
+		leftLease, err := rec.makeReplicaStateLoader().LoadLease(ctx, rec.Engine())
 		if err != nil {
 			return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to load lease")
 		}
@@ -3110,7 +3111,7 @@ func splitTrigger(
 		rightLease := leftLease
 		rightLease.Replica = replica
 
-		gcThreshold, err := rec.makeReplicaStateLoader().loadGCThreshold(ctx, rec.Engine())
+		gcThreshold, err := rec.makeReplicaStateLoader().LoadGCThreshold(ctx, rec.Engine())
 		if err != nil {
 			return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to load GCThreshold")
 		}
@@ -3118,7 +3119,7 @@ func splitTrigger(
 			log.VEventf(ctx, 1, "LHS's GCThreshold of split is not set")
 		}
 
-		txnSpanGCThreshold, err := rec.makeReplicaStateLoader().loadTxnSpanGCThreshold(ctx, rec.Engine())
+		txnSpanGCThreshold, err := rec.makeReplicaStateLoader().LoadTxnSpanGCThreshold(ctx, rec.Engine())
 		if err != nil {
 			return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to load TxnSpanGCThreshold")
 		}
@@ -3168,8 +3169,8 @@ func splitTrigger(
 			// clobber downstream simply because that's what 1.0 does and if we
 			// don't write it here, then a 1.0 version applying it as a follower
 			// won't write a HardState at all and is guaranteed to crash.
-			rsl := makeReplicaStateLoader(rec.repl.store.cfg.Settings, split.RightDesc.RangeID)
-			if err := rsl.synthesizeRaftState(ctx, batch); err != nil {
+			rsl := stateloader.Make(rec.repl.store.cfg.Settings, split.RightDesc.RangeID)
+			if err := rsl.SynthesizeRaftState(ctx, batch); err != nil {
 				return enginepb.MVCCStats{}, EvalResult{}, errors.Wrap(err, "unable to synthesize initial Raft state")
 			}
 		}
@@ -3391,7 +3392,7 @@ func mergeTrigger(
 	mergedMS.Add(msRange)
 
 	// Set stats for updated range.
-	if err := rec.makeReplicaStateLoader().setMVCCStats(ctx, batch, &mergedMS); err != nil {
+	if err := rec.makeReplicaStateLoader().SetMVCCStats(ctx, batch, &mergedMS); err != nil {
 		return EvalResult{}, errors.Errorf("unable to write MVCC stats: %s", err)
 	}
 

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/abortcache"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
@@ -620,8 +621,8 @@ func declareKeysEndTransaction(
 			})
 
 			spans.Add(SpanReadOnly, roachpb.Span{
-				Key:    abortCacheMinKey(header.RangeID),
-				EndKey: abortCacheMaxKey(header.RangeID)})
+				Key:    abortcache.MinKey(header.RangeID),
+				EndKey: abortcache.MaxKey(header.RangeID)})
 		}
 		if mt := et.InternalCommitTrigger.MergeTrigger; mt != nil {
 			// Merges write to the left side and delete and read from the right.

--- a/pkg/storage/replica_data_iter_test.go
+++ b/pkg/storage/replica_data_iter_test.go
@@ -56,10 +56,21 @@ func fakePrevKey(k []byte) roachpb.Key {
 	}, nil)
 }
 
+func uuidFromString(input string) uuid.UUID {
+	u, err := uuid.FromString(input)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
 // createRangeData creates sample range data in all possible areas of
 // the key space. Returns a slice of the encoded keys of all created
 // data.
 func createRangeData(t *testing.T, r *Replica) []engine.MVCCKey {
+	testTxnID := uuidFromString("0ce61c17-5eb4-4587-8c36-dcf4062ada4c")
+	testTxnID2 := uuidFromString("9855a1ef-8eb9-4c06-a106-cab1dda78a2b")
+
 	ts0 := hlc.Timestamp{}
 	ts := hlc.Timestamp{WallTime: 1}
 	desc := r.Desc()

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -725,7 +725,7 @@ func (r *Replica) handleReplicatedEvalResult(
 			r.mu.state.Stats.ContainsEstimates = false
 			stats := *r.mu.state.Stats
 			r.mu.Unlock()
-			if err := r.raftMu.stateLoader.setMVCCStats(ctx, r.store.Engine(), &stats); err != nil {
+			if err := r.raftMu.stateLoader.SetMVCCStats(ctx, r.store.Engine(), &stats); err != nil {
 				log.Fatal(ctx, errors.Wrap(err, "unable to write MVCC stats"))
 			}
 		}

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -36,17 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-)
-
-// leaseMetricsType is used to distinguish between various lease
-// operations and potentially outcomes.
-type leaseMetricsType int
-
-const (
-	leaseRequestSuccess leaseMetricsType = iota
-	leaseRequestError
-	leaseTransferSuccess
-	leaseTransferError
 )
 
 // ProposalData is data about a command which allows it to be
@@ -85,7 +75,7 @@ type ProposalData struct {
 	// Local contains the results of evaluating the request
 	// tying the upstream evaluation of the request to the
 	// downstream application of the command.
-	Local *LocalEvalResult
+	Local *batcheval.LocalResult
 
 	// Request is the client's original BatchRequest.
 	// TODO(tschottdorf): tests which use TestingCommandFilter use this.
@@ -121,276 +111,6 @@ func (proposal *ProposalData) finishRaftApplication(pr proposalResult) {
 	}
 	proposal.doneCh <- pr
 	close(proposal.doneCh)
-}
-
-// LocalEvalResult is data belonging to an evaluated command that is
-// only used on the node on which the command was proposed. Note that
-// the proposing node may die before the local results are processed,
-// so any side effects here are only best-effort.
-type LocalEvalResult struct {
-	// The error resulting from the proposal. Most failing proposals will
-	// fail-fast, i.e. will return an error to the client above Raft. However,
-	// some proposals need to commit data even on error, and in that case we
-	// treat the proposal like a successful one, except that the error stored
-	// here will be sent to the client when the associated batch commits. In
-	// the common case, this field is nil.
-	Err   *roachpb.Error
-	Reply *roachpb.BatchResponse
-
-	// intentsAlways stores any intents encountered but not conflicted with.
-	// They should be handed off to asynchronous intent processing on the
-	// proposer, so that an attempt to resolve them is made. In particular, this
-	// is the pathway used by EndTransaction to communicate its non-local
-	// intents up the stack.
-	//
-	// This is a pointer to allow the zero (and as an unwelcome side effect,
-	// all) values to be compared.
-	intentsAlways *[]intentsWithArg
-	// Like intentsAlways, but specifies intents that must be left alone if the
-	// corresponding command/proposal didn't succeed. For example, resolving
-	// intents of a committing txn should not happen if the commit fails, or
-	// we may accidentally make uncommitted values live.
-	intents *[]intentsWithArg
-	// Whether we successfully or non-successfully requested a lease.
-	//
-	// TODO(tschottdorf): Update this counter correctly with prop-eval'ed KV
-	// in the following case:
-	// - proposal does not fail fast and goes through Raft
-	// - downstream-of-Raft logic identifies a conflict and returns an error
-	// The downstream-of-Raft logic does not exist at time of writing.
-	leaseMetricsResult *leaseMetricsType
-
-	// When set (in which case we better be the first range), call
-	// gossipFirstRange if the Replica holds the lease.
-	gossipFirstRange bool
-	// Call maybeGossipSystemConfig.
-	maybeGossipSystemConfig bool
-	// Call maybeAddToSplitQueue.
-	maybeAddToSplitQueue bool
-	// Call maybeGossipNodeLiveness with the specified Span, if set.
-	maybeGossipNodeLiveness *roachpb.Span
-
-	// Set when a transaction record is updated, after a call to
-	// EndTransaction or PushTxn.
-	updatedTxn *roachpb.Transaction
-}
-
-// detachIntents returns (and removes) those intents from the LocalEvalResult
-// which are supposed to be handled. When hasError is false, returns all
-// intents. When it is true, returns only a subset of intents for which it is
-// known that it is safe to handle them even if the command that discovered them
-// has failed (e.g. omitting intents associated to a committing EndTransaction).
-func (lResult *LocalEvalResult) detachIntents(hasError bool) []intentsWithArg {
-	if lResult == nil {
-		return nil
-	}
-	var r []intentsWithArg
-	if !hasError && lResult.intents != nil {
-		r = *lResult.intents
-	}
-	if lResult.intentsAlways != nil {
-		if r == nil {
-			r = *lResult.intentsAlways
-		} else {
-			r = append(r, *lResult.intentsAlways...)
-		}
-	}
-	lResult.intents, lResult.intentsAlways = nil, nil
-	return r
-}
-
-// EvalResult is the result of evaluating a KV request. That is, the
-// proposer (which holds the lease, at least in the case in which the command
-// will complete successfully) has evaluated the request and is holding on to:
-//
-// a) changes to be written to disk when applying the command
-// b) changes to the state which may require special handling (i.e. code
-//    execution) on all Replicas
-// c) data which isn't sent to the followers but the proposer needs for tasks
-//    it must run when the command has applied (such as resolving intents).
-type EvalResult struct {
-	Local      LocalEvalResult
-	Replicated storagebase.ReplicatedEvalResult
-	WriteBatch *storagebase.WriteBatch
-}
-
-// IsZero reports whether p is the zero value.
-func (p *EvalResult) IsZero() bool {
-	if p.Local != (LocalEvalResult{}) {
-		return false
-	}
-	if !p.Replicated.Equal(storagebase.ReplicatedEvalResult{}) {
-		return false
-	}
-	if p.WriteBatch != nil {
-		return false
-	}
-	return true
-}
-
-// coalesceBool ORs rhs into lhs and then zeroes rhs.
-func coalesceBool(lhs *bool, rhs *bool) {
-	*lhs = *lhs || *rhs
-	*rhs = false
-}
-
-// MergeAndDestroy absorbs the supplied EvalResult while validating that the
-// resulting EvalResult makes sense. For example, it is forbidden to absorb
-// two lease updates or log truncations, or multiple splits and/or merges.
-//
-// The passed EvalResult must not be used once passed to Merge.
-func (p *EvalResult) MergeAndDestroy(q EvalResult) error {
-	if q.Replicated.State != nil {
-		if q.Replicated.State.RaftAppliedIndex != 0 {
-			return errors.New("must not specify RaftApplyIndex")
-		}
-		if q.Replicated.State.LeaseAppliedIndex != 0 {
-			return errors.New("must not specify RaftApplyIndex")
-		}
-		if p.Replicated.State == nil {
-			p.Replicated.State = &storagebase.ReplicaState{}
-		}
-		if p.Replicated.State.Desc == nil {
-			p.Replicated.State.Desc = q.Replicated.State.Desc
-		} else if q.Replicated.State.Desc != nil {
-			return errors.New("conflicting RangeDescriptor")
-		}
-		q.Replicated.State.Desc = nil
-
-		if p.Replicated.State.Lease == nil {
-			p.Replicated.State.Lease = q.Replicated.State.Lease
-		} else if q.Replicated.State.Lease != nil {
-			return errors.New("conflicting Lease")
-		}
-		q.Replicated.State.Lease = nil
-
-		if p.Replicated.State.TruncatedState == nil {
-			p.Replicated.State.TruncatedState = q.Replicated.State.TruncatedState
-		} else if q.Replicated.State.TruncatedState != nil {
-			return errors.New("conflicting TruncatedState")
-		}
-		q.Replicated.State.TruncatedState = nil
-
-		if q.Replicated.State.GCThreshold != nil {
-			if p.Replicated.State.GCThreshold == nil {
-				p.Replicated.State.GCThreshold = q.Replicated.State.GCThreshold
-			} else {
-				p.Replicated.State.GCThreshold.Forward(*q.Replicated.State.GCThreshold)
-			}
-			q.Replicated.State.GCThreshold = nil
-		}
-		if q.Replicated.State.TxnSpanGCThreshold != nil {
-			if p.Replicated.State.TxnSpanGCThreshold == nil {
-				p.Replicated.State.TxnSpanGCThreshold = q.Replicated.State.TxnSpanGCThreshold
-			} else {
-				p.Replicated.State.TxnSpanGCThreshold.Forward(*q.Replicated.State.TxnSpanGCThreshold)
-			}
-			q.Replicated.State.TxnSpanGCThreshold = nil
-		}
-
-		if q.Replicated.State.Stats != nil {
-			return errors.New("must not specify Stats")
-		}
-		if (*q.Replicated.State != storagebase.ReplicaState{}) {
-			log.Fatalf(context.TODO(), "unhandled EvalResult: %s",
-				pretty.Diff(*q.Replicated.State, storagebase.ReplicaState{}))
-		}
-		q.Replicated.State = nil
-	}
-
-	p.Replicated.BlockReads = p.Replicated.BlockReads || q.Replicated.BlockReads
-	q.Replicated.BlockReads = false
-
-	if p.Replicated.Split == nil {
-		p.Replicated.Split = q.Replicated.Split
-	} else if q.Replicated.Split != nil {
-		return errors.New("conflicting Split")
-	}
-	q.Replicated.Split = nil
-
-	if p.Replicated.Merge == nil {
-		p.Replicated.Merge = q.Replicated.Merge
-	} else if q.Replicated.Merge != nil {
-		return errors.New("conflicting Merge")
-	}
-	q.Replicated.Merge = nil
-
-	if p.Replicated.ChangeReplicas == nil {
-		p.Replicated.ChangeReplicas = q.Replicated.ChangeReplicas
-	} else if q.Replicated.ChangeReplicas != nil {
-		return errors.New("conflicting ChangeReplicas")
-	}
-	q.Replicated.ChangeReplicas = nil
-
-	if p.Replicated.ComputeChecksum == nil {
-		p.Replicated.ComputeChecksum = q.Replicated.ComputeChecksum
-	} else if q.Replicated.ComputeChecksum != nil {
-		return errors.New("conflicting ComputeChecksum")
-	}
-	q.Replicated.ComputeChecksum = nil
-
-	if p.Replicated.RaftLogDelta == 0 {
-		p.Replicated.RaftLogDelta = q.Replicated.RaftLogDelta
-	} else if q.Replicated.RaftLogDelta != 0 {
-		return errors.New("conflicting RaftLogDelta")
-	}
-	q.Replicated.RaftLogDelta = 0
-
-	if p.Replicated.AddSSTable == nil {
-		p.Replicated.AddSSTable = q.Replicated.AddSSTable
-	} else if q.Replicated.AddSSTable != nil {
-		return errors.New("conflicting AddSSTable")
-	}
-	q.Replicated.AddSSTable = nil
-
-	if q.Local.intentsAlways != nil {
-		if p.Local.intentsAlways == nil {
-			p.Local.intentsAlways = q.Local.intentsAlways
-		} else {
-			*p.Local.intentsAlways = append(*p.Local.intentsAlways, *q.Local.intentsAlways...)
-		}
-	}
-	q.Local.intentsAlways = nil
-
-	if q.Local.intents != nil {
-		if p.Local.intents == nil {
-			p.Local.intents = q.Local.intents
-		} else {
-			*p.Local.intents = append(*p.Local.intents, *q.Local.intents...)
-		}
-	}
-	q.Local.intents = nil
-
-	if p.Local.leaseMetricsResult == nil {
-		p.Local.leaseMetricsResult = q.Local.leaseMetricsResult
-	} else if q.Local.leaseMetricsResult != nil {
-		return errors.New("conflicting leaseMetricsResult")
-	}
-	q.Local.leaseMetricsResult = nil
-
-	if p.Local.maybeGossipNodeLiveness == nil {
-		p.Local.maybeGossipNodeLiveness = q.Local.maybeGossipNodeLiveness
-	} else if q.Local.maybeGossipNodeLiveness != nil {
-		return errors.New("conflicting maybeGossipNodeLiveness")
-	}
-	q.Local.maybeGossipNodeLiveness = nil
-
-	coalesceBool(&p.Local.gossipFirstRange, &q.Local.gossipFirstRange)
-	coalesceBool(&p.Local.maybeGossipSystemConfig, &q.Local.maybeGossipSystemConfig)
-	coalesceBool(&p.Local.maybeAddToSplitQueue, &q.Local.maybeAddToSplitQueue)
-
-	if p.Local.updatedTxn == nil {
-		p.Local.updatedTxn = q.Local.updatedTxn
-	} else if q.Local.updatedTxn != nil {
-		return errors.New("conflicting updatedTxn")
-	}
-	q.Local.updatedTxn = nil
-
-	if !q.IsZero() {
-		log.Fatalf(context.TODO(), "unhandled EvalResult: %s", pretty.Diff(q, EvalResult{}))
-	}
-
-	return nil
 }
 
 // TODO(tschottdorf): we should find new homes for the checksum, lease
@@ -920,7 +640,7 @@ func (r *Replica) handleReplicatedEvalResult(
 	return shouldAssert
 }
 
-func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult LocalEvalResult) {
+func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult batcheval.LocalResult) {
 	// Enqueue failed push transactions on the pushTxnQueue.
 	if !r.store.cfg.DontRetryPushTxnFailures {
 		if tpErr, ok := lResult.Err.GetDetail().(*roachpb.TransactionPushError); ok {
@@ -941,14 +661,14 @@ func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult LocalEvalRe
 	// ======================
 
 	// The caller is required to detach and handle intents.
-	if lResult.intentsAlways != nil {
-		log.Fatalf(ctx, "LocalEvalResult.intentsAlways should be nil: %+v", lResult.intentsAlways)
+	if lResult.IntentsAlways != nil {
+		log.Fatalf(ctx, "LocalEvalResult.IntentsAlways should be nil: %+v", lResult.IntentsAlways)
 	}
-	if lResult.intents != nil {
-		log.Fatalf(ctx, "LocalEvalResult.intents should be nil: %+v", lResult.intents)
+	if lResult.Intents != nil {
+		log.Fatalf(ctx, "LocalEvalResult.Intents should be nil: %+v", lResult.Intents)
 	}
 
-	if lResult.gossipFirstRange {
+	if lResult.GossipFirstRange {
 		// We need to run the gossip in an async task because gossiping requires
 		// the range lease and we'll deadlock if we try to acquire it while
 		// holding processRaftMu. Specifically, Replica.redirectOnOrAcquireLease
@@ -969,51 +689,50 @@ func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult LocalEvalRe
 			}); err != nil {
 			log.Infof(ctx, "unable to gossip first range: %s", err)
 		}
-		lResult.gossipFirstRange = false
+		lResult.GossipFirstRange = false
 	}
 
-	if lResult.maybeAddToSplitQueue {
+	if lResult.MaybeAddToSplitQueue {
 		r.store.splitQueue.MaybeAdd(r, r.store.Clock().Now())
-		lResult.maybeAddToSplitQueue = false
+		lResult.MaybeAddToSplitQueue = false
 	}
 
-	if lResult.maybeGossipSystemConfig {
+	if lResult.MaybeGossipSystemConfig {
 		if err := r.maybeGossipSystemConfig(ctx); err != nil {
 			log.Error(ctx, err)
 		}
-		lResult.maybeGossipSystemConfig = false
+		lResult.MaybeGossipSystemConfig = false
 	}
-	if lResult.maybeGossipNodeLiveness != nil {
-		if err := r.maybeGossipNodeLiveness(ctx, *lResult.maybeGossipNodeLiveness); err != nil {
+	if lResult.MaybeGossipNodeLiveness != nil {
+		if err := r.maybeGossipNodeLiveness(ctx, *lResult.MaybeGossipNodeLiveness); err != nil {
 			log.Error(ctx, err)
 		}
-		lResult.maybeGossipNodeLiveness = nil
+		lResult.MaybeGossipNodeLiveness = nil
 	}
 
-	if lResult.leaseMetricsResult != nil {
-		switch metric := *lResult.leaseMetricsResult; metric {
-		case leaseRequestSuccess, leaseRequestError:
-			r.store.metrics.leaseRequestComplete(metric == leaseRequestSuccess)
-		case leaseTransferSuccess, leaseTransferError:
-			r.store.metrics.leaseTransferComplete(metric == leaseTransferSuccess)
+	if lResult.LeaseMetricsResult != nil {
+		switch metric := *lResult.LeaseMetricsResult; metric {
+		case storagebase.LeaseRequestSuccess, storagebase.LeaseRequestError:
+			r.store.metrics.leaseRequestComplete(metric == storagebase.LeaseRequestSuccess)
+		case storagebase.LeaseTransferSuccess, storagebase.LeaseTransferError:
+			r.store.metrics.leaseTransferComplete(metric == storagebase.LeaseTransferSuccess)
 		}
-		lResult.leaseMetricsResult = nil
+		lResult.LeaseMetricsResult = nil
 	}
 
-	if lResult.updatedTxn != nil {
-		r.pushTxnQueue.UpdateTxn(ctx, lResult.updatedTxn)
-		lResult.updatedTxn = nil
+	if lResult.UpdatedTxn != nil {
+		r.pushTxnQueue.UpdateTxn(ctx, lResult.UpdatedTxn)
+		lResult.UpdatedTxn = nil
 	}
 
-	if (lResult != LocalEvalResult{}) {
-		log.Fatalf(ctx, "unhandled field in LocalEvalResult: %s", pretty.Diff(lResult, LocalEvalResult{}))
+	if (lResult != batcheval.LocalResult{}) {
+		log.Fatalf(ctx, "unhandled field in LocalEvalResult: %s", pretty.Diff(lResult, batcheval.LocalResult{}))
 	}
 }
 
 func (r *Replica) handleEvalResultRaftMuLocked(
 	ctx context.Context,
-	lResult *LocalEvalResult,
-	rResult storagebase.ReplicatedEvalResult,
+	lResult *batcheval.LocalResult, rResult storagebase.ReplicatedEvalResult,
 	raftAppliedIndex, leaseAppliedIndex uint64,
 ) {
 	shouldAssert := r.handleReplicatedEvalResult(ctx, rResult, raftAppliedIndex, leaseAppliedIndex)

--- a/pkg/storage/replica_proposal_test.go
+++ b/pkg/storage/replica_proposal_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -25,7 +26,7 @@ import (
 func TestEvalResultIsZero(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	var p EvalResult
+	var p batcheval.Result
 	if !p.IsZero() {
 		t.Fatalf("%v unexpectedly non-zero", p)
 	}
@@ -38,9 +39,9 @@ func TestEvalResultIsZero(t *testing.T) {
 				vf = vf.Addr()
 			}
 			switch f := vf.Interface().(type) {
-			case *LocalEvalResult:
-				f.gossipFirstRange = true
-				defer func() { f.gossipFirstRange = false }()
+			case *batcheval.LocalResult:
+				f.GossipFirstRange = true
+				defer func() { f.GossipFirstRange = false }()
 			case *storagebase.ReplicatedEvalResult:
 				f.IsLeaseRequest = true
 				defer func() { f.IsLeaseRequest = false }()

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -59,7 +60,7 @@ var _ raft.Storage = (*replicaRaftStorage)(nil)
 // InitialState requires that r.mu is held.
 func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState, error) {
 	ctx := r.AnnotateCtx(context.TODO())
-	hs, err := r.mu.stateLoader.loadHardState(ctx, r.store.Engine())
+	hs, err := r.mu.stateLoader.LoadHardState(ctx, r.store.Engine())
 	// For uninitialized ranges, membership is unknown at this point.
 	if raft.IsEmptyHardState(hs) || err != nil {
 		return raftpb.HardState{}, raftpb.ConfState{}, err
@@ -95,7 +96,7 @@ func (r *Replica) raftEntriesLocked(lo, hi, maxBytes uint64) ([]raftpb.Entry, er
 // loaded entries, and maxBytes will not be applied to the payloads.
 func entries(
 	ctx context.Context,
-	rsl replicaStateLoader,
+	rsl stateloader.Instance,
 	e engine.Reader,
 	rangeID roachpb.RangeID,
 	eCache *raftEntryCache,
@@ -188,7 +189,7 @@ func entries(
 		}
 
 		// Was the missing index after the last index?
-		lastIndex, err := rsl.loadLastIndex(ctx, e)
+		lastIndex, err := rsl.LoadLastIndex(ctx, e)
 		if err != nil {
 			return nil, err
 		}
@@ -201,7 +202,7 @@ func entries(
 	}
 
 	// No results, was it due to unavailability or truncation?
-	ts, err := rsl.loadTruncatedState(ctx, e)
+	ts, err := rsl.LoadTruncatedState(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +264,7 @@ func (r *Replica) raftTermRLocked(i uint64) (uint64, error) {
 
 func term(
 	ctx context.Context,
-	rsl replicaStateLoader,
+	rsl stateloader.Instance,
 	eng engine.Reader,
 	rangeID roachpb.RangeID,
 	eCache *raftEntryCache,
@@ -273,7 +274,7 @@ func term(
 	// sideloaded entries. We only need the term, so this is what we do.
 	ents, err := entries(ctx, rsl, eng, rangeID, eCache, nil /* sideloaded */, i, i+1, 0)
 	if err == raft.ErrCompacted {
-		ts, err := rsl.loadTruncatedState(ctx, eng)
+		ts, err := rsl.LoadTruncatedState(ctx, eng)
 		if err != nil {
 			return 0, err
 		}
@@ -310,7 +311,7 @@ func (r *Replica) raftTruncatedStateLocked(
 	if r.mu.state.TruncatedState != nil {
 		return *r.mu.state.TruncatedState, nil
 	}
-	ts, err := r.mu.stateLoader.loadTruncatedState(ctx, r.store.Engine())
+	ts, err := r.mu.stateLoader.LoadTruncatedState(ctx, r.store.Engine())
 	if err != nil {
 		return ts, err
 	}
@@ -417,7 +418,7 @@ func (r *Replica) GetSnapshot(
 	// to use Replica.mu.stateLoader. This call is not performance sensitive, so
 	// create a new state loader.
 	snapData, err := snapshot(
-		ctx, makeReplicaStateLoader(r.store.cfg.Settings, rangeID), snapType,
+		ctx, stateloader.Make(r.store.cfg.Settings, rangeID), snapType,
 		snap, rangeID, r.store.raftEntryCache, withSideloaded, startKey,
 	)
 	if err != nil {
@@ -470,7 +471,7 @@ type IncomingSnapshot struct {
 // given range. Note that snapshot() is called without Replica.raftMu held.
 func snapshot(
 	ctx context.Context,
-	rsl replicaStateLoader,
+	rsl stateloader.Instance,
 	snapType string,
 	snap engine.Reader,
 	rangeID roachpb.RangeID,
@@ -497,7 +498,7 @@ func snapshot(
 
 	// Read the range metadata from the snapshot instead of the members
 	// of the Range struct because they might be changed concurrently.
-	appliedIndex, _, err := rsl.loadAppliedIndex(ctx, snap)
+	appliedIndex, _, err := rsl.LoadAppliedIndex(ctx, snap)
 	if err != nil {
 		return OutgoingSnapshot{}, err
 	}
@@ -513,7 +514,7 @@ func snapshot(
 		return OutgoingSnapshot{}, errors.Errorf("failed to fetch term of %d: %s", appliedIndex, err)
 	}
 
-	state, err := rsl.load(ctx, snap, &desc)
+	state, err := rsl.Load(ctx, snap, &desc)
 	if err != nil {
 		return OutgoingSnapshot{}, err
 	}
@@ -597,7 +598,7 @@ func (r *Replica) append(
 		}
 	}
 
-	if err := r.raftMu.stateLoader.setLastIndex(ctx, batch, lastIndex); err != nil {
+	if err := r.raftMu.stateLoader.SetLastIndex(ctx, batch, lastIndex); err != nil {
 		return 0, 0, 0, err
 	}
 
@@ -810,7 +811,7 @@ func (r *Replica) applySnapshot(
 	// the HardState -- Raft wouldn't ask us to update the HardState in incorrect
 	// ways.
 	if !raft.IsEmptyHardState(hs) {
-		if err := r.raftMu.stateLoader.setHardState(ctx, distinctBatch, hs); err != nil {
+		if err := r.raftMu.stateLoader.SetHardState(ctx, distinctBatch, hs); err != nil {
 			return errors.Wrapf(err, "unable to persist HardState %+v", &hs)
 		}
 	}

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -738,7 +739,7 @@ func TestRaftSSTableSideloadingSnapshot(t *testing.T) {
 			if withSS {
 				ss = tc.repl.raftMu.sideloaded
 			}
-			rsl := makeReplicaStateLoader(tc.store.ClusterSettings(), tc.repl.RangeID)
+			rsl := stateloader.Make(tc.store.ClusterSettings(), tc.repl.RangeID)
 			entries, err := entries(
 				ctx, rsl, tc.store.Engine(), tc.repl.RangeID, tc.store.raftEntryCache,
 				ss, sideloadedIndex, sideloadedIndex+1, 1<<20,

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -124,6 +124,33 @@ type ReplicaEvalContext struct {
 	ss   *SpanSet
 }
 
+// ReplicaEvalContextI .
+type ReplicaEvalContextI interface {
+	ClusterSettings() *cluster.Settings
+	TxnSpanGCThreshold() (hlc.Timestamp, error)
+	GCThreshold() (hlc.Timestamp, error)
+	Desc() (*roachpb.RangeDescriptor, error)
+	StoreTestingKnobs() StoreTestingKnobs
+	ContainsKey(roachpb.Key) (bool, error)
+	AbortCache() *AbortCache
+	RangeID() roachpb.RangeID
+	FirstIndex() (uint64, error)
+	Term(uint64) (uint64, error)
+	GetLease() (roachpb.Lease, *roachpb.Lease, error)
+	Tracer() opentracing.Tracer
+	GetMVCCStats() (enginepb.MVCCStats, error)
+	GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error)
+	Engine() engine.Engine
+	IsFirstRange() bool
+
+	// Used from storageccl
+	NodeID() roachpb.NodeID
+	DB() *client.DB
+
+	makeReplicaStateLoader() replicaStateLoader
+	pushTxnQueue() *pushTxnQueue
+}
+
 // ClusterSettings returns the node's ClusterSettings.
 func (rec ReplicaEvalContext) ClusterSettings() *cluster.Settings {
 	return rec.repl.store.cfg.Settings
@@ -167,6 +194,8 @@ func (rec ReplicaEvalContext) StoreTestingKnobs() StoreTestingKnobs {
 }
 
 // Tracer returns the Replica's Tracer.
+//
+// TODO(tschottdorf): tracer is accessible from the settings.
 func (rec ReplicaEvalContext) Tracer() opentracing.Tracer {
 	return rec.repl.store.Tracer()
 }

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/abortcache"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
@@ -182,7 +183,7 @@ func (rec ReplicaEvalContext) Engine() engine.Engine {
 }
 
 // AbortCache returns the Replica's AbortCache.
-func (rec ReplicaEvalContext) AbortCache() *AbortCache {
+func (rec ReplicaEvalContext) AbortCache() *abortcache.Instance {
 	// Despite its name, the abort cache doesn't hold on-disk data in
 	// memory. It just provides methods that take a Batch, so SpanSet
 	// declarations are enforced there.

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -124,39 +124,13 @@ type ReplicaEvalContext struct {
 	ss   *SpanSet
 }
 
-// ReplicaEvalContextI .
-type ReplicaEvalContextI interface {
-	ClusterSettings() *cluster.Settings
-	TxnSpanGCThreshold() (hlc.Timestamp, error)
-	GCThreshold() (hlc.Timestamp, error)
-	Desc() (*roachpb.RangeDescriptor, error)
-	StoreTestingKnobs() StoreTestingKnobs
-	ContainsKey(roachpb.Key) (bool, error)
-	AbortCache() *AbortCache
-	RangeID() roachpb.RangeID
-	FirstIndex() (uint64, error)
-	Term(uint64) (uint64, error)
-	GetLease() (roachpb.Lease, *roachpb.Lease, error)
-	Tracer() opentracing.Tracer
-	GetMVCCStats() (enginepb.MVCCStats, error)
-	GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error)
-	Engine() engine.Engine
-	IsFirstRange() bool
-
-	// Used from storageccl
-	NodeID() roachpb.NodeID
-	DB() *client.DB
-
-	makeReplicaStateLoader() replicaStateLoader
-	pushTxnQueue() *pushTxnQueue
-}
-
 // ClusterSettings returns the node's ClusterSettings.
 func (rec ReplicaEvalContext) ClusterSettings() *cluster.Settings {
 	return rec.repl.store.cfg.Settings
 }
 
-func (rec *ReplicaEvalContext) makeReplicaStateLoader() stateloader.Instance {
+// MakeReplicaStateLoader makes a stateloader.Instance using the local RangeID().
+func (rec *ReplicaEvalContext) MakeReplicaStateLoader() stateloader.Instance {
 	return stateloader.Make(rec.ClusterSettings(), rec.RangeID())
 }
 

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -15,10 +15,6 @@
 package storage
 
 import (
-	"bytes"
-	"math"
-
-	"github.com/coreos/etcd/raft/raftpb"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -29,481 +25,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
-
-// replicaStateLoader contains accessor methods to read or write the
-// fields of storagebase.ReplicaState. It contains an internal buffer
-// which is reused to avoid an allocation on frequently-accessed code
-// paths.
-//
-// Because of this internal buffer, this struct is not safe for
-// concurrent use, and the return values of methods that return keys
-// are invalidated the next time any method is called.
-//
-// It is safe to have multiple replicaStateLoaders for the same
-// Replica. Reusable replicaStateLoaders are typically found in a
-// struct with a mutex, and temporary loaders may be created when
-// locking is less desirable than an allocation.
-type replicaStateLoader struct {
-	st *cluster.Settings
-	keys.RangeIDPrefixBuf
-}
-
-func makeReplicaStateLoader(st *cluster.Settings, rangeID roachpb.RangeID) replicaStateLoader {
-	rsl := replicaStateLoader{
-		st:               st,
-		RangeIDPrefixBuf: keys.MakeRangeIDPrefixBuf(rangeID),
-	}
-	return rsl
-}
-
-// loadState loads a ReplicaState from disk. The exception is the Desc field,
-// which is updated transactionally, and is populated from the supplied
-// RangeDescriptor under the convention that that is the latest committed
-// version.
-func (rsl replicaStateLoader) load(
-	ctx context.Context, reader engine.Reader, desc *roachpb.RangeDescriptor,
-) (storagebase.ReplicaState, error) {
-	var s storagebase.ReplicaState
-	// TODO(tschottdorf): figure out whether this is always synchronous with
-	// on-disk state (likely iffy during Split/ChangeReplica triggers).
-	s.Desc = protoutil.Clone(desc).(*roachpb.RangeDescriptor)
-	// Read the range lease.
-	lease, err := rsl.loadLease(ctx, reader)
-	if err != nil {
-		return storagebase.ReplicaState{}, err
-	}
-	s.Lease = &lease
-
-	if s.GCThreshold, err = rsl.loadGCThreshold(ctx, reader); err != nil {
-		return storagebase.ReplicaState{}, err
-	}
-
-	if s.TxnSpanGCThreshold, err = rsl.loadTxnSpanGCThreshold(ctx, reader); err != nil {
-		return storagebase.ReplicaState{}, err
-	}
-
-	if s.RaftAppliedIndex, s.LeaseAppliedIndex, err = rsl.loadAppliedIndex(ctx, reader); err != nil {
-		return storagebase.ReplicaState{}, err
-	}
-
-	if s.Stats, err = rsl.loadMVCCStats(ctx, reader); err != nil {
-		return storagebase.ReplicaState{}, err
-	}
-
-	// The truncated state should not be optional (i.e. the pointer is
-	// pointless), but it is and the migration is not worth it.
-	truncState, err := rsl.loadTruncatedState(ctx, reader)
-	if err != nil {
-		return storagebase.ReplicaState{}, err
-	}
-	s.TruncatedState = &truncState
-
-	return s, nil
-}
-
-// save persists the given ReplicaState to disk. It assumes that the contained
-// Stats are up-to-date and returns the stats which result from writing the
-// updated State.
-//
-// As an exception to the rule, the Desc field (whose on-disk state is special
-// in that it's a full MVCC value and updated transactionally) is only used for
-// its RangeID.
-//
-// TODO(tschottdorf): test and assert that none of the optional values are
-// missing whenever save is called. Optional values should be reserved
-// strictly for use in EvalResult. Do before merge.
-func (rsl replicaStateLoader) save(
-	ctx context.Context, eng engine.ReadWriter, state storagebase.ReplicaState,
-) (enginepb.MVCCStats, error) {
-	ms := state.Stats
-	if err := rsl.setLease(ctx, eng, ms, *state.Lease); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-	if err := rsl.setAppliedIndex(
-		ctx, eng, ms, state.RaftAppliedIndex, state.LeaseAppliedIndex,
-	); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-	if err := rsl.setGCThreshold(ctx, eng, ms, state.GCThreshold); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-	if err := rsl.setTxnSpanGCThreshold(ctx, eng, ms, state.TxnSpanGCThreshold); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-	if err := rsl.setTruncatedState(ctx, eng, ms, state.TruncatedState); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-	if err := rsl.setMVCCStats(ctx, eng, ms); err != nil {
-		return enginepb.MVCCStats{}, err
-	}
-	return *ms, nil
-}
-
-func (rsl replicaStateLoader) loadLease(
-	ctx context.Context, reader engine.Reader,
-) (roachpb.Lease, error) {
-	var lease roachpb.Lease
-	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeLeaseKey(),
-		hlc.Timestamp{}, true, nil, &lease)
-	return lease, err
-}
-
-func (rsl replicaStateLoader) setLease(
-	ctx context.Context, eng engine.ReadWriter, ms *enginepb.MVCCStats, lease roachpb.Lease,
-) error {
-	return engine.MVCCPutProto(ctx, eng, ms, rsl.RangeLeaseKey(),
-		hlc.Timestamp{}, nil, &lease)
-}
-
-// loadAppliedIndex returns the Raft applied index and the lease applied index.
-func (rsl replicaStateLoader) loadAppliedIndex(
-	ctx context.Context, reader engine.Reader,
-) (uint64, uint64, error) {
-	var appliedIndex uint64
-	v, _, err := engine.MVCCGet(ctx, reader, rsl.RaftAppliedIndexKey(),
-		hlc.Timestamp{}, true, nil)
-	if err != nil {
-		return 0, 0, err
-	}
-	if v != nil {
-		int64AppliedIndex, err := v.GetInt()
-		if err != nil {
-			return 0, 0, err
-		}
-		appliedIndex = uint64(int64AppliedIndex)
-	}
-	// TODO(tschottdorf): code duplication.
-	var leaseAppliedIndex uint64
-	v, _, err = engine.MVCCGet(ctx, reader, rsl.LeaseAppliedIndexKey(),
-		hlc.Timestamp{}, true, nil)
-	if err != nil {
-		return 0, 0, err
-	}
-	if v != nil {
-		int64LeaseAppliedIndex, err := v.GetInt()
-		if err != nil {
-			return 0, 0, err
-		}
-		leaseAppliedIndex = uint64(int64LeaseAppliedIndex)
-	}
-
-	return appliedIndex, leaseAppliedIndex, nil
-}
-
-// setAppliedIndex sets the {raft,lease} applied index values, properly
-// accounting for existing keys in the returned stats.
-func (rsl replicaStateLoader) setAppliedIndex(
-	ctx context.Context,
-	eng engine.ReadWriter,
-	ms *enginepb.MVCCStats,
-	appliedIndex,
-	leaseAppliedIndex uint64,
-) error {
-	var value roachpb.Value
-	value.SetInt(int64(appliedIndex))
-	if err := engine.MVCCPut(ctx, eng, ms,
-		rsl.RaftAppliedIndexKey(),
-		hlc.Timestamp{},
-		value,
-		nil /* txn */); err != nil {
-		return err
-	}
-	value.SetInt(int64(leaseAppliedIndex))
-	return engine.MVCCPut(ctx, eng, ms,
-		rsl.LeaseAppliedIndexKey(),
-		hlc.Timestamp{},
-		value,
-		nil /* txn */)
-}
-
-// setAppliedIndexBlind sets the {raft,lease} applied index values using a
-// "blind" put which ignores any existing keys. This is identical to
-// setAppliedIndex but is used to optimize the writing of the applied index
-// values during write operations where we definitively know the size of the
-// previous values.
-func (rsl replicaStateLoader) setAppliedIndexBlind(
-	ctx context.Context,
-	eng engine.ReadWriter,
-	ms *enginepb.MVCCStats,
-	appliedIndex,
-	leaseAppliedIndex uint64,
-) error {
-	var value roachpb.Value
-	value.SetInt(int64(appliedIndex))
-	if err := engine.MVCCBlindPut(ctx, eng, ms,
-		rsl.RaftAppliedIndexKey(),
-		hlc.Timestamp{},
-		value,
-		nil /* txn */); err != nil {
-		return err
-	}
-	value.SetInt(int64(leaseAppliedIndex))
-	return engine.MVCCBlindPut(ctx, eng, ms,
-		rsl.LeaseAppliedIndexKey(),
-		hlc.Timestamp{},
-		value,
-		nil /* txn */)
-}
-
-func inlineValueIntEncodedSize(v int64) int {
-	var value roachpb.Value
-	value.SetInt(v)
-	meta := enginepb.MVCCMetadata{RawBytes: value.RawBytes}
-	return meta.Size()
-}
-
-// Calculate the size (MVCCStats.SysBytes) of the {raft,lease} applied index
-// keys/values.
-func (rsl replicaStateLoader) calcAppliedIndexSysBytes(
-	appliedIndex, leaseAppliedIndex uint64,
-) int64 {
-	return int64(engine.MakeMVCCMetadataKey(rsl.RaftAppliedIndexKey()).EncodedSize() +
-		engine.MakeMVCCMetadataKey(rsl.LeaseAppliedIndexKey()).EncodedSize() +
-		inlineValueIntEncodedSize(int64(appliedIndex)) +
-		inlineValueIntEncodedSize(int64(leaseAppliedIndex)))
-}
-
-func (rsl replicaStateLoader) loadTruncatedState(
-	ctx context.Context, reader engine.Reader,
-) (roachpb.RaftTruncatedState, error) {
-	var truncState roachpb.RaftTruncatedState
-	if _, err := engine.MVCCGetProto(ctx, reader,
-		rsl.RaftTruncatedStateKey(), hlc.Timestamp{}, true,
-		nil, &truncState); err != nil {
-		return roachpb.RaftTruncatedState{}, err
-	}
-	return truncState, nil
-}
-
-func (rsl replicaStateLoader) setTruncatedState(
-	ctx context.Context,
-	eng engine.ReadWriter,
-	ms *enginepb.MVCCStats,
-	truncState *roachpb.RaftTruncatedState,
-) error {
-	if (*truncState == roachpb.RaftTruncatedState{}) {
-		return errors.New("cannot persist empty RaftTruncatedState")
-	}
-	return engine.MVCCPutProto(ctx, eng, ms,
-		rsl.RaftTruncatedStateKey(), hlc.Timestamp{}, nil, truncState)
-}
-
-func (rsl replicaStateLoader) loadGCThreshold(
-	ctx context.Context, reader engine.Reader,
-) (*hlc.Timestamp, error) {
-	var t hlc.Timestamp
-	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeLastGCKey(),
-		hlc.Timestamp{}, true, nil, &t)
-	return &t, err
-}
-
-func (rsl replicaStateLoader) setGCThreshold(
-	ctx context.Context, eng engine.ReadWriter, ms *enginepb.MVCCStats, threshold *hlc.Timestamp,
-) error {
-	if threshold == nil {
-		return errors.New("cannot persist nil GCThreshold")
-	}
-	return engine.MVCCPutProto(ctx, eng, ms,
-		rsl.RangeLastGCKey(), hlc.Timestamp{}, nil, threshold)
-}
-
-func (rsl replicaStateLoader) loadTxnSpanGCThreshold(
-	ctx context.Context, reader engine.Reader,
-) (*hlc.Timestamp, error) {
-	var t hlc.Timestamp
-	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeTxnSpanGCThresholdKey(),
-		hlc.Timestamp{}, true, nil, &t)
-	return &t, err
-}
-
-func (rsl replicaStateLoader) setTxnSpanGCThreshold(
-	ctx context.Context, eng engine.ReadWriter, ms *enginepb.MVCCStats, threshold *hlc.Timestamp,
-) error {
-	if threshold == nil {
-		return errors.New("cannot persist nil TxnSpanGCThreshold")
-	}
-
-	return engine.MVCCPutProto(ctx, eng, ms,
-		rsl.RangeTxnSpanGCThresholdKey(), hlc.Timestamp{}, nil, threshold)
-}
-
-func (rsl replicaStateLoader) loadMVCCStats(
-	ctx context.Context, reader engine.Reader,
-) (*enginepb.MVCCStats, error) {
-	var ms enginepb.MVCCStats
-	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeStatsKey(), hlc.Timestamp{}, true, nil, &ms)
-	return &ms, err
-}
-
-func (rsl replicaStateLoader) setMVCCStats(
-	ctx context.Context, eng engine.ReadWriter, newMS *enginepb.MVCCStats,
-) error {
-	return engine.MVCCPutProto(ctx, eng, nil, rsl.RangeStatsKey(), hlc.Timestamp{}, nil, newMS)
-}
-
-// The rest is not technically part of ReplicaState.
-// TODO(tschottdorf): more consolidation of ad-hoc structures: last index and
-// hard state. These are closely coupled with ReplicaState (and in particular
-// with its TruncatedState) but are different in that they are not consistently
-// updated through Raft.
-
-func (rsl replicaStateLoader) loadLastIndex(
-	ctx context.Context, reader engine.Reader,
-) (uint64, error) {
-	iter := reader.NewIterator(false)
-	defer iter.Close()
-
-	var lastIndex uint64
-	iter.SeekReverse(engine.MakeMVCCMetadataKey(rsl.RaftLogKey(math.MaxUint64)))
-	if ok, _ := iter.Valid(); ok {
-		key := iter.Key()
-		prefix := rsl.RaftLogPrefix()
-		if bytes.HasPrefix(key.Key, prefix) {
-			var err error
-			_, lastIndex, err = encoding.DecodeUint64Ascending(key.Key[len(prefix):])
-			if err != nil {
-				log.Fatalf(ctx, "unable to decode Raft log index key: %s", key)
-			}
-		}
-	}
-
-	if lastIndex == 0 {
-		// The log is empty, which means we are either starting from scratch
-		// or the entire log has been truncated away.
-		lastEnt, err := rsl.loadTruncatedState(ctx, reader)
-		if err != nil {
-			return 0, err
-		}
-		lastIndex = lastEnt.Index
-	}
-	return lastIndex, nil
-}
-
-func (rsl replicaStateLoader) setLastIndex(
-	ctx context.Context, eng engine.ReadWriter, lastIndex uint64,
-) error {
-	if rsl.st.Version.IsActive(cluster.VersionRaftLastIndex) {
-		return nil
-	}
-	var value roachpb.Value
-	value.SetInt(int64(lastIndex))
-	return engine.MVCCPut(ctx, eng, nil, rsl.RaftLastIndexKey(),
-		hlc.Timestamp{}, value, nil /* txn */)
-}
-
-// loadReplicaDestroyedError loads the replica destroyed error for the specified
-// range. If there is no error, nil is returned.
-func (rsl replicaStateLoader) loadReplicaDestroyedError(
-	ctx context.Context, reader engine.Reader,
-) (*roachpb.Error, error) {
-	var v roachpb.Error
-	found, err := engine.MVCCGetProto(ctx, reader,
-		rsl.RangeReplicaDestroyedErrorKey(),
-		hlc.Timestamp{}, true /* consistent */, nil, &v)
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, nil
-	}
-	return &v, nil
-}
-
-// setReplicaDestroyedError sets an error indicating that the replica has been
-// destroyed.
-func (rsl replicaStateLoader) setReplicaDestroyedError(
-	ctx context.Context, eng engine.ReadWriter, err *roachpb.Error,
-) error {
-	return engine.MVCCPutProto(ctx, eng, nil,
-		rsl.RangeReplicaDestroyedErrorKey(), hlc.Timestamp{}, nil /* txn */, err)
-}
-
-func (rsl replicaStateLoader) loadHardState(
-	ctx context.Context, reader engine.Reader,
-) (raftpb.HardState, error) {
-	var hs raftpb.HardState
-	found, err := engine.MVCCGetProto(ctx, reader,
-		rsl.RaftHardStateKey(),
-		hlc.Timestamp{}, true, nil, &hs)
-
-	if !found || err != nil {
-		return raftpb.HardState{}, err
-	}
-	return hs, nil
-}
-
-func (rsl replicaStateLoader) setHardState(
-	ctx context.Context, batch engine.ReadWriter, st raftpb.HardState,
-) error {
-	return engine.MVCCPutProto(ctx, batch, nil,
-		rsl.RaftHardStateKey(), hlc.Timestamp{}, nil, &st)
-}
-
-// synthesizeRaftState creates a Raft state which synthesizes both a HardState
-// and a lastIndex from pre-seeded data in the engine (typically created via
-// writeInitialReplicaState and, on a split, perhaps the activity of an
-// uninitialized Raft group)
-func (rsl replicaStateLoader) synthesizeRaftState(
-	ctx context.Context, eng engine.ReadWriter,
-) error {
-	hs, err := rsl.loadHardState(ctx, eng)
-	if err != nil {
-		return err
-	}
-	truncState, err := rsl.loadTruncatedState(ctx, eng)
-	if err != nil {
-		return err
-	}
-	raftAppliedIndex, _, err := rsl.loadAppliedIndex(ctx, eng)
-	if err != nil {
-		return err
-	}
-	if err := rsl.synthesizeHardState(ctx, eng, hs, truncState, raftAppliedIndex); err != nil {
-		return err
-	}
-	return rsl.setLastIndex(ctx, eng, truncState.Index)
-}
-
-// synthesizeHardState synthesizes an on-disk HardState from the given input,
-// taking care that a HardState compatible with the existing data is written.
-func (rsl replicaStateLoader) synthesizeHardState(
-	ctx context.Context,
-	eng engine.ReadWriter,
-	oldHS raftpb.HardState,
-	truncState roachpb.RaftTruncatedState,
-	raftAppliedIndex uint64,
-) error {
-	newHS := raftpb.HardState{
-		Term: truncState.Term,
-		// Note that when applying a Raft snapshot, the applied index is
-		// equal to the Commit index represented by the snapshot.
-		Commit: raftAppliedIndex,
-	}
-
-	if oldHS.Commit > newHS.Commit {
-		return errors.Errorf("can't decrease HardState.Commit from %d to %d",
-			oldHS.Commit, newHS.Commit)
-	}
-	if oldHS.Term > newHS.Term {
-		// The existing HardState is allowed to be ahead of us, which is
-		// relevant in practice for the split trigger. We already checked above
-		// that we're not rewinding the acknowledged index, and we haven't
-		// updated votes yet.
-		newHS.Term = oldHS.Term
-	}
-	// If the existing HardState voted in this term, remember that.
-	if oldHS.Term == newHS.Term {
-		newHS.Vote = oldHS.Vote
-	}
-	err := rsl.setHardState(ctx, eng, newHS)
-	return errors.Wrapf(err, "writing HardState %+v", &newHS)
-}
 
 // writeInitialReplicaState sets up a new Range, but without writing an
 // associated Raft state (which must be written separately via
@@ -522,7 +48,7 @@ func writeInitialReplicaState(
 	gcThreshold hlc.Timestamp,
 	txnSpanGCThreshold hlc.Timestamp,
 ) (enginepb.MVCCStats, error) {
-	rsl := makeReplicaStateLoader(st, desc.RangeID)
+	rsl := stateloader.Make(st, desc.RangeID)
 
 	var s storagebase.ReplicaState
 	s.TruncatedState = &roachpb.RaftTruncatedState{
@@ -538,25 +64,25 @@ func writeInitialReplicaState(
 	s.GCThreshold = &gcThreshold
 	s.TxnSpanGCThreshold = &txnSpanGCThreshold
 
-	if existingLease, err := rsl.loadLease(ctx, eng); err != nil {
+	if existingLease, err := rsl.LoadLease(ctx, eng); err != nil {
 		return enginepb.MVCCStats{}, errors.Wrap(err, "error reading lease")
 	} else if (existingLease != roachpb.Lease{}) {
 		log.Fatalf(ctx, "expected trivial lease, but found %+v", existingLease)
 	}
 
-	if existingGCThreshold, err := rsl.loadGCThreshold(ctx, eng); err != nil {
+	if existingGCThreshold, err := rsl.LoadGCThreshold(ctx, eng); err != nil {
 		return enginepb.MVCCStats{}, errors.Wrap(err, "error reading GCThreshold")
 	} else if (*existingGCThreshold != hlc.Timestamp{}) {
 		log.Fatalf(ctx, "expected trivial GChreshold, but found %+v", existingGCThreshold)
 	}
 
-	if existingTxnSpanGCThreshold, err := rsl.loadTxnSpanGCThreshold(ctx, eng); err != nil {
+	if existingTxnSpanGCThreshold, err := rsl.LoadTxnSpanGCThreshold(ctx, eng); err != nil {
 		return enginepb.MVCCStats{}, errors.Wrap(err, "error reading TxnSpanGCThreshold")
 	} else if (*existingTxnSpanGCThreshold != hlc.Timestamp{}) {
 		log.Fatalf(ctx, "expected trivial TxnSpanGCThreshold, but found %+v", existingTxnSpanGCThreshold)
 	}
 
-	newMS, err := rsl.save(ctx, eng, s)
+	newMS, err := rsl.Save(ctx, eng, s)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
@@ -582,7 +108,7 @@ func writeInitialState(
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
-	if err := makeReplicaStateLoader(st, desc.RangeID).synthesizeRaftState(ctx, eng); err != nil {
+	if err := stateloader.Make(st, desc.RangeID).SynthesizeRaftState(ctx, eng); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 	return newMS, nil
@@ -602,8 +128,8 @@ func (rec ReplicaEvalContext) ClusterSettings() *cluster.Settings {
 	return rec.repl.store.cfg.Settings
 }
 
-func (rec *ReplicaEvalContext) makeReplicaStateLoader() replicaStateLoader {
-	return makeReplicaStateLoader(rec.ClusterSettings(), rec.RangeID())
+func (rec *ReplicaEvalContext) makeReplicaStateLoader() stateloader.Instance {
+	return stateloader.Make(rec.ClusterSettings(), rec.RangeID())
 }
 
 // In-memory state, immutable fields, and debugging methods are accessed directly.

--- a/pkg/storage/replica_state_test.go
+++ b/pkg/storage/replica_state_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -58,20 +59,20 @@ func TestSynthesizeHardState(t *testing.T) {
 		func() {
 			batch := eng.NewBatch()
 			defer batch.Close()
-			rsl := makeReplicaStateLoader(cluster.MakeTestingClusterSettings(), 1)
+			rsl := stateloader.Make(cluster.MakeTestingClusterSettings(), 1)
 
 			if test.OldHS != nil {
-				if err := rsl.setHardState(context.Background(), batch, *test.OldHS); err != nil {
+				if err := rsl.SetHardState(context.Background(), batch, *test.OldHS); err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			oldHS, err := rsl.loadHardState(context.Background(), batch)
+			oldHS, err := rsl.LoadHardState(context.Background(), batch)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			err = rsl.synthesizeHardState(
+			err = rsl.SynthesizeHardState(
 				context.Background(), batch, oldHS, roachpb.RaftTruncatedState{Term: test.TruncTerm}, test.RaftAppliedIndex,
 			)
 			if !testutils.IsError(err, test.Err) {
@@ -81,7 +82,7 @@ func TestSynthesizeHardState(t *testing.T) {
 				return
 			}
 
-			hs, err := rsl.loadHardState(context.Background(), batch)
+			hs, err := rsl.LoadHardState(context.Background(), batch)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5983,7 +5983,7 @@ func TestReplicaCorruption(t *testing.T) {
 	}
 
 	// Verify destroyed error was persisted.
-	pErr, err = r.mu.stateLoader.loadReplicaDestroyedError(context.Background(), r.store.Engine())
+	pErr, err = r.mu.stateLoader.LoadReplicaDestroyedError(context.Background(), r.store.Engine())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -773,8 +774,8 @@ func TestReplicaLease(t *testing.T) {
 		{Start: start, Expiration: &hlc.Timestamp{}},
 	} {
 		if _, err := evalRequestLease(context.Background(), tc.store.Engine(),
-			CommandArgs{
-				EvalCtx: ReplicaEvalContext{tc.repl, nil},
+			batcheval.CommandArgs{
+				EvalCtx: &ReplicaEvalContext{tc.repl, nil},
 				Args: &roachpb.RequestLeaseRequest{
 					Lease: lease,
 				},
@@ -4544,7 +4545,7 @@ func TestEndTransactionDirectGC(t *testing.T) {
 			testutils.SucceedsSoon(t, func() error {
 				var gr roachpb.GetResponse
 				if _, err := evalGet(
-					ctx, tc.engine, CommandArgs{
+					ctx, tc.engine, batcheval.CommandArgs{
 						Args: &roachpb.GetRequest{Span: roachpb.Span{
 							Key: keys.TransactionKey(txn.Key, txn.ID),
 						}},
@@ -4951,7 +4952,7 @@ func TestAbortCacheError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rec := ReplicaEvalContext{tc.repl, nil}
+	rec := &ReplicaEvalContext{tc.repl, nil}
 	pErr := checkIfTxnAborted(context.Background(), rec, tc.engine, txn)
 	if _, ok := pErr.GetDetail().(*roachpb.TransactionAbortedError); ok {
 		expected := txn.Clone()
@@ -5234,20 +5235,20 @@ func TestResolveIntentPushTxnReplyTxn(t *testing.T) {
 
 	ctx := context.Background()
 	// Should not be able to push or resolve in a transaction.
-	if _, err := evalPushTxn(ctx, b, CommandArgs{Stats: &ms, Header: roachpb.Header{Txn: txn}, Args: &pa}, &roachpb.PushTxnResponse{}); !testutils.IsError(err, errTransactionUnsupported.Error()) {
+	if _, err := evalPushTxn(ctx, b, batcheval.CommandArgs{Stats: &ms, Header: roachpb.Header{Txn: txn}, Args: &pa}, &roachpb.PushTxnResponse{}); !testutils.IsError(err, errTransactionUnsupported.Error()) {
 		t.Fatalf("transactional PushTxn returned unexpected error: %v", err)
 	}
-	if _, err := evalResolveIntent(ctx, b, CommandArgs{Stats: &ms, Header: roachpb.Header{Txn: txn}, Args: &ra}, &roachpb.ResolveIntentResponse{}); !testutils.IsError(err, errTransactionUnsupported.Error()) {
+	if _, err := evalResolveIntent(ctx, b, batcheval.CommandArgs{Stats: &ms, Header: roachpb.Header{Txn: txn}, Args: &ra}, &roachpb.ResolveIntentResponse{}); !testutils.IsError(err, errTransactionUnsupported.Error()) {
 		t.Fatalf("transactional ResolveIntent returned unexpected error: %v", err)
 	}
-	if _, err := evalResolveIntentRange(ctx, b, CommandArgs{Stats: &ms, Header: roachpb.Header{Txn: txn}, Args: &rra}, &roachpb.ResolveIntentRangeResponse{}); !testutils.IsError(err, errTransactionUnsupported.Error()) {
+	if _, err := evalResolveIntentRange(ctx, b, batcheval.CommandArgs{Stats: &ms, Header: roachpb.Header{Txn: txn}, Args: &rra}, &roachpb.ResolveIntentRangeResponse{}); !testutils.IsError(err, errTransactionUnsupported.Error()) {
 		t.Fatalf("transactional ResolveIntentRange returned unexpected error: %v", err)
 	}
 
 	// Should not get a transaction back from PushTxn. It used to erroneously
 	// return args.PusherTxn.
 	var reply roachpb.PushTxnResponse
-	if _, err := evalPushTxn(ctx, b, CommandArgs{Stats: &ms, Args: &pa}, &reply); err != nil {
+	if _, err := evalPushTxn(ctx, b, batcheval.CommandArgs{Stats: &ms, Args: &pa}, &reply); err != nil {
 		t.Fatal(err)
 	} else if reply.Txn != nil {
 		t.Fatalf("expected nil response txn, but got %s", reply.Txn)
@@ -7129,7 +7130,7 @@ func TestComputeChecksumVersioning(t *testing.T) {
 	tc.Start(t, stopper)
 
 	if pct, _ := evalComputeChecksum(context.TODO(), nil,
-		CommandArgs{Args: &roachpb.ComputeChecksumRequest{
+		batcheval.CommandArgs{Args: &roachpb.ComputeChecksumRequest{
 			ChecksumID: uuid.MakeV4(),
 			Version:    replicaChecksumVersion,
 		}}, &roachpb.ComputeChecksumResponse{},
@@ -7138,7 +7139,7 @@ func TestComputeChecksumVersioning(t *testing.T) {
 	}
 
 	if pct, _ := evalComputeChecksum(context.TODO(), nil,
-		CommandArgs{Args: &roachpb.ComputeChecksumRequest{
+		batcheval.CommandArgs{Args: &roachpb.ComputeChecksumRequest{
 			ChecksumID: uuid.MakeV4(),
 			Version:    replicaChecksumVersion + 1,
 		}}, &roachpb.ComputeChecksumResponse{},
@@ -7991,9 +7992,9 @@ func TestGCWithoutThreshold(t *testing.T) {
 
 				var resp roachpb.GCResponse
 
-				if _, err := evalGC(ctx, rw, CommandArgs{
+				if _, err := evalGC(ctx, rw, batcheval.CommandArgs{
 					Args: &gc,
-					EvalCtx: ReplicaEvalContext{
+					EvalCtx: &ReplicaEvalContext{
 						repl: tc.repl,
 						ss:   &spans,
 					},

--- a/pkg/storage/stateloader/instance.go
+++ b/pkg/storage/stateloader/instance.go
@@ -1,0 +1,515 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// This file includes test-only helper methods added to types in
+// package storage. These methods are only linked in to tests in this
+// directory (but may be used from tests in both package storage and
+// package storage_test).
+
+package stateloader
+
+import (
+	"bytes"
+	"math"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/pkg/errors"
+)
+
+// Instance contains accessor methods to read or write the
+// fields of storagebase.ReplicaState. It contains an internal buffer
+// which is reused to avoid an allocation on frequently-accessed code
+// paths.
+//
+// Because of this internal buffer, this struct is not safe for
+// concurrent use, and the return values of methods that return keys
+// are invalidated the next time any method is called.
+//
+// It is safe to have multiple replicaStateLoaders for the same
+// Replica. Reusable replicaStateLoaders are typically found in a
+// struct with a mutex, and temporary loaders may be created when
+// locking is less desirable than an allocation.
+type Instance struct {
+	st *cluster.Settings
+	keys.RangeIDPrefixBuf
+}
+
+// Make creates in Instance.
+func Make(st *cluster.Settings, rangeID roachpb.RangeID) Instance {
+	rsl := Instance{
+		st:               st,
+		RangeIDPrefixBuf: keys.MakeRangeIDPrefixBuf(rangeID),
+	}
+	return rsl
+}
+
+// Load a ReplicaState from disk. The exception is the Desc field, which is
+// updated transactionally, and is populated from the supplied RangeDescriptor
+// under the convention that that is the latest committed version.
+func (rsl Instance) Load(
+	ctx context.Context, reader engine.Reader, desc *roachpb.RangeDescriptor,
+) (storagebase.ReplicaState, error) {
+	var s storagebase.ReplicaState
+	// TODO(tschottdorf): figure out whether this is always synchronous with
+	// on-disk state (likely iffy during Split/ChangeReplica triggers).
+	s.Desc = protoutil.Clone(desc).(*roachpb.RangeDescriptor)
+	// Read the range lease.
+	lease, err := rsl.LoadLease(ctx, reader)
+	if err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+	s.Lease = &lease
+
+	if s.GCThreshold, err = rsl.LoadGCThreshold(ctx, reader); err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+
+	if s.TxnSpanGCThreshold, err = rsl.LoadTxnSpanGCThreshold(ctx, reader); err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+
+	if s.RaftAppliedIndex, s.LeaseAppliedIndex, err = rsl.LoadAppliedIndex(ctx, reader); err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+
+	if s.Stats, err = rsl.LoadMVCCStats(ctx, reader); err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+
+	// The truncated state should not be optional (i.e. the pointer is
+	// pointless), but it is and the migration is not worth it.
+	truncState, err := rsl.LoadTruncatedState(ctx, reader)
+	if err != nil {
+		return storagebase.ReplicaState{}, err
+	}
+	s.TruncatedState = &truncState
+
+	return s, nil
+}
+
+// Save persists the given ReplicaState to disk. It assumes that the contained
+// Stats are up-to-date and returns the stats which result from writing the
+// updated State.
+//
+// As an exception to the rule, the Desc field (whose on-disk state is special
+// in that it's a full MVCC value and updated transactionally) is only used for
+// its RangeID.
+//
+// TODO(tschottdorf): test and assert that none of the optional values are
+// missing whenever save is called. Optional values should be reserved
+// strictly for use in EvalResult. Do before merge.
+func (rsl Instance) Save(
+	ctx context.Context, eng engine.ReadWriter, state storagebase.ReplicaState,
+) (enginepb.MVCCStats, error) {
+	ms := state.Stats
+	if err := rsl.SetLease(ctx, eng, ms, *state.Lease); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	if err := rsl.SetAppliedIndex(
+		ctx, eng, ms, state.RaftAppliedIndex, state.LeaseAppliedIndex,
+	); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	if err := rsl.SetGCThreshold(ctx, eng, ms, state.GCThreshold); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	if err := rsl.SetTxnSpanGCThreshold(ctx, eng, ms, state.TxnSpanGCThreshold); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	if err := rsl.SetTruncatedState(ctx, eng, ms, state.TruncatedState); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	if err := rsl.SetMVCCStats(ctx, eng, ms); err != nil {
+		return enginepb.MVCCStats{}, err
+	}
+	return *ms, nil
+}
+
+// LoadLease loads the lease.
+func (rsl Instance) LoadLease(ctx context.Context, reader engine.Reader) (roachpb.Lease, error) {
+	var lease roachpb.Lease
+	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeLeaseKey(),
+		hlc.Timestamp{}, true, nil, &lease)
+	return lease, err
+}
+
+// SetLease persists a lease.
+func (rsl Instance) SetLease(
+	ctx context.Context, eng engine.ReadWriter, ms *enginepb.MVCCStats, lease roachpb.Lease,
+) error {
+	return engine.MVCCPutProto(ctx, eng, ms, rsl.RangeLeaseKey(),
+		hlc.Timestamp{}, nil, &lease)
+}
+
+// LoadAppliedIndex returns the Raft applied index and the lease applied index.
+func (rsl Instance) LoadAppliedIndex(
+	ctx context.Context, reader engine.Reader,
+) (uint64, uint64, error) {
+	var appliedIndex uint64
+	v, _, err := engine.MVCCGet(ctx, reader, rsl.RaftAppliedIndexKey(),
+		hlc.Timestamp{}, true, nil)
+	if err != nil {
+		return 0, 0, err
+	}
+	if v != nil {
+		int64AppliedIndex, err := v.GetInt()
+		if err != nil {
+			return 0, 0, err
+		}
+		appliedIndex = uint64(int64AppliedIndex)
+	}
+	// TODO(tschottdorf): code duplication.
+	var leaseAppliedIndex uint64
+	v, _, err = engine.MVCCGet(ctx, reader, rsl.LeaseAppliedIndexKey(),
+		hlc.Timestamp{}, true, nil)
+	if err != nil {
+		return 0, 0, err
+	}
+	if v != nil {
+		int64LeaseAppliedIndex, err := v.GetInt()
+		if err != nil {
+			return 0, 0, err
+		}
+		leaseAppliedIndex = uint64(int64LeaseAppliedIndex)
+	}
+
+	return appliedIndex, leaseAppliedIndex, nil
+}
+
+// SetAppliedIndex sets the {raft,lease} applied index values, properly
+// accounting for existing keys in the returned stats.
+func (rsl Instance) SetAppliedIndex(
+	ctx context.Context,
+	eng engine.ReadWriter,
+	ms *enginepb.MVCCStats,
+	appliedIndex,
+	leaseAppliedIndex uint64,
+) error {
+	var value roachpb.Value
+	value.SetInt(int64(appliedIndex))
+	if err := engine.MVCCPut(ctx, eng, ms,
+		rsl.RaftAppliedIndexKey(),
+		hlc.Timestamp{},
+		value,
+		nil /* txn */); err != nil {
+		return err
+	}
+	value.SetInt(int64(leaseAppliedIndex))
+	return engine.MVCCPut(ctx, eng, ms,
+		rsl.LeaseAppliedIndexKey(),
+		hlc.Timestamp{},
+		value,
+		nil /* txn */)
+}
+
+// SetAppliedIndexBlind sets the {raft,lease} applied index values using a
+// "blind" put which ignores any existing keys. This is identical to
+// setAppliedIndex but is used to optimize the writing of the applied index
+// values during write operations where we definitively know the size of the
+// previous values.
+func (rsl Instance) SetAppliedIndexBlind(
+	ctx context.Context,
+	eng engine.ReadWriter,
+	ms *enginepb.MVCCStats,
+	appliedIndex,
+	leaseAppliedIndex uint64,
+) error {
+	var value roachpb.Value
+	value.SetInt(int64(appliedIndex))
+	if err := engine.MVCCBlindPut(ctx, eng, ms,
+		rsl.RaftAppliedIndexKey(),
+		hlc.Timestamp{},
+		value,
+		nil /* txn */); err != nil {
+		return err
+	}
+	value.SetInt(int64(leaseAppliedIndex))
+	return engine.MVCCBlindPut(ctx, eng, ms,
+		rsl.LeaseAppliedIndexKey(),
+		hlc.Timestamp{},
+		value,
+		nil /* txn */)
+}
+
+func inlineValueIntEncodedSize(v int64) int {
+	var value roachpb.Value
+	value.SetInt(v)
+	meta := enginepb.MVCCMetadata{RawBytes: value.RawBytes}
+	return meta.Size()
+}
+
+// CalcAppliedIndexSysBytes calculates the size (MVCCStats.SysBytes) of the {raft,lease} applied
+// index keys/values.
+func (rsl Instance) CalcAppliedIndexSysBytes(appliedIndex, leaseAppliedIndex uint64) int64 {
+	return int64(engine.MakeMVCCMetadataKey(rsl.RaftAppliedIndexKey()).EncodedSize() +
+		engine.MakeMVCCMetadataKey(rsl.LeaseAppliedIndexKey()).EncodedSize() +
+		inlineValueIntEncodedSize(int64(appliedIndex)) +
+		inlineValueIntEncodedSize(int64(leaseAppliedIndex)))
+}
+
+// LoadTruncatedState loads the truncated state.
+func (rsl Instance) LoadTruncatedState(
+	ctx context.Context, reader engine.Reader,
+) (roachpb.RaftTruncatedState, error) {
+	var truncState roachpb.RaftTruncatedState
+	if _, err := engine.MVCCGetProto(ctx, reader,
+		rsl.RaftTruncatedStateKey(), hlc.Timestamp{}, true,
+		nil, &truncState); err != nil {
+		return roachpb.RaftTruncatedState{}, err
+	}
+	return truncState, nil
+}
+
+// SetTruncatedState overwrites the truncated state.
+func (rsl Instance) SetTruncatedState(
+	ctx context.Context,
+	eng engine.ReadWriter,
+	ms *enginepb.MVCCStats,
+	truncState *roachpb.RaftTruncatedState,
+) error {
+	if (*truncState == roachpb.RaftTruncatedState{}) {
+		return errors.New("cannot persist empty RaftTruncatedState")
+	}
+	return engine.MVCCPutProto(ctx, eng, ms,
+		rsl.RaftTruncatedStateKey(), hlc.Timestamp{}, nil, truncState)
+}
+
+// LoadGCThreshold loads the GC threshold.
+func (rsl Instance) LoadGCThreshold(
+	ctx context.Context, reader engine.Reader,
+) (*hlc.Timestamp, error) {
+	var t hlc.Timestamp
+	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeLastGCKey(),
+		hlc.Timestamp{}, true, nil, &t)
+	return &t, err
+}
+
+// SetGCThreshold sets the GC threshold.
+func (rsl Instance) SetGCThreshold(
+	ctx context.Context, eng engine.ReadWriter, ms *enginepb.MVCCStats, threshold *hlc.Timestamp,
+) error {
+	if threshold == nil {
+		return errors.New("cannot persist nil GCThreshold")
+	}
+	return engine.MVCCPutProto(ctx, eng, ms,
+		rsl.RangeLastGCKey(), hlc.Timestamp{}, nil, threshold)
+}
+
+// LoadTxnSpanGCThreshold loads the transaction GC threshold.
+func (rsl Instance) LoadTxnSpanGCThreshold(
+	ctx context.Context, reader engine.Reader,
+) (*hlc.Timestamp, error) {
+	var t hlc.Timestamp
+	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeTxnSpanGCThresholdKey(),
+		hlc.Timestamp{}, true, nil, &t)
+	return &t, err
+}
+
+// SetTxnSpanGCThreshold overwrites the transaction GC threshold.
+func (rsl Instance) SetTxnSpanGCThreshold(
+	ctx context.Context, eng engine.ReadWriter, ms *enginepb.MVCCStats, threshold *hlc.Timestamp,
+) error {
+	if threshold == nil {
+		return errors.New("cannot persist nil TxnSpanGCThreshold")
+	}
+
+	return engine.MVCCPutProto(ctx, eng, ms,
+		rsl.RangeTxnSpanGCThresholdKey(), hlc.Timestamp{}, nil, threshold)
+}
+
+// LoadMVCCStats loads the MVCC stats.
+func (rsl Instance) LoadMVCCStats(
+	ctx context.Context, reader engine.Reader,
+) (*enginepb.MVCCStats, error) {
+	var ms enginepb.MVCCStats
+	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeStatsKey(), hlc.Timestamp{}, true, nil, &ms)
+	return &ms, err
+}
+
+// SetMVCCStats overwrites the MVCC stats.
+func (rsl Instance) SetMVCCStats(
+	ctx context.Context, eng engine.ReadWriter, newMS *enginepb.MVCCStats,
+) error {
+	return engine.MVCCPutProto(ctx, eng, nil, rsl.RangeStatsKey(), hlc.Timestamp{}, nil, newMS)
+}
+
+// The rest is not technically part of ReplicaState.
+// TODO(tschottdorf): more consolidation of ad-hoc structures: last index and
+// hard state. These are closely coupled with ReplicaState (and in particular
+// with its TruncatedState) but are different in that they are not consistently
+// updated through Raft.
+
+// LoadLastIndex loads the last index.
+func (rsl Instance) LoadLastIndex(ctx context.Context, reader engine.Reader) (uint64, error) {
+	iter := reader.NewIterator(false)
+	defer iter.Close()
+
+	var lastIndex uint64
+	iter.SeekReverse(engine.MakeMVCCMetadataKey(rsl.RaftLogKey(math.MaxUint64)))
+	if ok, _ := iter.Valid(); ok {
+		key := iter.Key()
+		prefix := rsl.RaftLogPrefix()
+		if bytes.HasPrefix(key.Key, prefix) {
+			var err error
+			_, lastIndex, err = encoding.DecodeUint64Ascending(key.Key[len(prefix):])
+			if err != nil {
+				log.Fatalf(ctx, "unable to decode Raft log index key: %s", key)
+			}
+		}
+	}
+
+	if lastIndex == 0 {
+		// The log is empty, which means we are either starting from scratch
+		// or the entire log has been truncated away.
+		lastEnt, err := rsl.LoadTruncatedState(ctx, reader)
+		if err != nil {
+			return 0, err
+		}
+		lastIndex = lastEnt.Index
+	}
+	return lastIndex, nil
+}
+
+// SetLastIndex overwrites the last index.
+func (rsl Instance) SetLastIndex(
+	ctx context.Context, eng engine.ReadWriter, lastIndex uint64,
+) error {
+	if rsl.st.Version.IsActive(cluster.VersionRaftLastIndex) {
+		return nil
+	}
+	var value roachpb.Value
+	value.SetInt(int64(lastIndex))
+	return engine.MVCCPut(ctx, eng, nil, rsl.RaftLastIndexKey(),
+		hlc.Timestamp{}, value, nil /* txn */)
+}
+
+// LoadReplicaDestroyedError loads the replica destroyed error for the specified
+// range. If there is no error, nil is returned.
+func (rsl Instance) LoadReplicaDestroyedError(
+	ctx context.Context, reader engine.Reader,
+) (*roachpb.Error, error) {
+	var v roachpb.Error
+	found, err := engine.MVCCGetProto(ctx, reader,
+		rsl.RangeReplicaDestroyedErrorKey(),
+		hlc.Timestamp{}, true /* consistent */, nil, &v)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+	return &v, nil
+}
+
+// SetReplicaDestroyedError sets an error indicating that the replica has been
+// destroyed.
+func (rsl Instance) SetReplicaDestroyedError(
+	ctx context.Context, eng engine.ReadWriter, err *roachpb.Error,
+) error {
+	return engine.MVCCPutProto(ctx, eng, nil,
+		rsl.RangeReplicaDestroyedErrorKey(), hlc.Timestamp{}, nil /* txn */, err)
+}
+
+// LoadHardState loads the HardState.
+func (rsl Instance) LoadHardState(
+	ctx context.Context, reader engine.Reader,
+) (raftpb.HardState, error) {
+	var hs raftpb.HardState
+	found, err := engine.MVCCGetProto(ctx, reader,
+		rsl.RaftHardStateKey(),
+		hlc.Timestamp{}, true, nil, &hs)
+
+	if !found || err != nil {
+		return raftpb.HardState{}, err
+	}
+	return hs, nil
+}
+
+// SetHardState overwrites the HardState.
+func (rsl Instance) SetHardState(
+	ctx context.Context, batch engine.ReadWriter, st raftpb.HardState,
+) error {
+	return engine.MVCCPutProto(ctx, batch, nil,
+		rsl.RaftHardStateKey(), hlc.Timestamp{}, nil, &st)
+}
+
+// SynthesizeRaftState creates a Raft state which synthesizes both a HardState
+// and a lastIndex from pre-seeded data in the engine (typically created via
+// writeInitialReplicaState and, on a split, perhaps the activity of an
+// uninitialized Raft group)
+func (rsl Instance) SynthesizeRaftState(ctx context.Context, eng engine.ReadWriter) error {
+	hs, err := rsl.LoadHardState(ctx, eng)
+	if err != nil {
+		return err
+	}
+	truncState, err := rsl.LoadTruncatedState(ctx, eng)
+	if err != nil {
+		return err
+	}
+	raftAppliedIndex, _, err := rsl.LoadAppliedIndex(ctx, eng)
+	if err != nil {
+		return err
+	}
+	if err := rsl.SynthesizeHardState(ctx, eng, hs, truncState, raftAppliedIndex); err != nil {
+		return err
+	}
+	return rsl.SetLastIndex(ctx, eng, truncState.Index)
+}
+
+// SynthesizeHardState synthesizes an on-disk HardState from the given input,
+// taking care that a HardState compatible with the existing data is written.
+func (rsl Instance) SynthesizeHardState(
+	ctx context.Context,
+	eng engine.ReadWriter,
+	oldHS raftpb.HardState,
+	truncState roachpb.RaftTruncatedState,
+	raftAppliedIndex uint64,
+) error {
+	newHS := raftpb.HardState{
+		Term: truncState.Term,
+		// Note that when applying a Raft snapshot, the applied index is
+		// equal to the Commit index represented by the snapshot.
+		Commit: raftAppliedIndex,
+	}
+
+	if oldHS.Commit > newHS.Commit {
+		return errors.Errorf("can't decrease HardState.Commit from %d to %d",
+			oldHS.Commit, newHS.Commit)
+	}
+	if oldHS.Term > newHS.Term {
+		// The existing HardState is allowed to be ahead of us, which is
+		// relevant in practice for the split trigger. We already checked above
+		// that we're not rewinding the acknowledged index, and we haven't
+		// updated votes yet.
+		newHS.Term = oldHS.Term
+	}
+	// If the existing HardState voted in this term, remember that.
+	if oldHS.Term == newHS.Term {
+		newHS.Vote = oldHS.Vote
+	}
+	err := rsl.SetHardState(ctx, eng, newHS)
+	return errors.Wrapf(err, "writing HardState %+v", &newHS)
+}

--- a/pkg/storage/storagebase/base.go
+++ b/pkg/storage/storagebase/base.go
@@ -82,3 +82,14 @@ const (
 	// has finished executing and will remove itself from the CommandQueue.
 	CommandQueueFinishExecuting
 )
+
+// LeaseMetricsType is used to distinguish between various lease
+// operations and potentially outcomes.
+type LeaseMetricsType int
+
+const (
+	LeaseRequestSuccess LeaseMetricsType = iota
+	LeaseRequestError
+	LeaseTransferSuccess
+	LeaseTransferError
+)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -1837,8 +1838,8 @@ func splitPostApply(
 		// committed the split Batch (which included the initialization of the
 		// ReplicaState). This will synthesize and persist the correct lastIndex and
 		// HardState.
-		rsl := makeReplicaStateLoader(r.store.cfg.Settings, split.RightDesc.RangeID)
-		if err := rsl.synthesizeRaftState(ctx, r.store.Engine()); err != nil {
+		rsl := stateloader.Make(r.store.cfg.Settings, split.RightDesc.RangeID)
+		if err := rsl.SynthesizeRaftState(ctx, r.store.Engine()); err != nil {
 			log.Fatal(ctx, err)
 		}
 	}
@@ -3121,7 +3122,7 @@ func (s *Store) processRaftRequest(
 		needTombstone := r.mu.state.Desc.NextReplicaID != 0
 		r.mu.Unlock()
 
-		appliedIndex, _, err := r.raftMu.stateLoader.loadAppliedIndex(ctx, r.store.Engine())
+		appliedIndex, _, err := r.raftMu.stateLoader.LoadAppliedIndex(ctx, r.store.Engine())
 		if err != nil {
 			return roachpb.NewError(err)
 		}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/abortcache"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -639,7 +640,7 @@ func TestProcessRangeDescriptorUpdate(t *testing.T) {
 	r := &Replica{
 		RangeID:    desc.RangeID,
 		store:      store,
-		abortCache: NewAbortCache(desc.RangeID),
+		abortCache: abortcache.New(desc.RangeID),
 	}
 	r.raftMu.timedMutex = makeTimedMutex(nil)
 	if err := r.init(desc, store.Clock(), 0); err != nil {

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2039,7 +2039,7 @@ func TestStoreGCThreshold(t *testing.T) {
 		}
 		repl.mu.Lock()
 		gcThreshold := *repl.mu.state.GCThreshold
-		pgcThreshold, err := repl.mu.stateLoader.loadGCThreshold(context.Background(), store.Engine())
+		pgcThreshold, err := repl.mu.stateLoader.LoadGCThreshold(context.Background(), store.Engine())
 		repl.mu.Unlock()
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/storage/track_raft_protos.go
+++ b/pkg/storage/track_raft_protos.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
@@ -45,7 +46,7 @@ func TrackRaftProtos() func() []reflect.Type {
 		funcName((*gossip.Gossip).AddInfoProto),
 		// Replica destroyed errors are written to disk, but they are
 		// deliberately per-replica values.
-		funcName((replicaStateLoader).setReplicaDestroyedError),
+		funcName((stateloader.Instance).SetReplicaDestroyedError),
 	}
 
 	belowRaftProtos := struct {


### PR DESCRIPTION
The first two commits are #18785.

----

See #18779.

This doesn't carry out all the work but does all the basic required
refactoring (mod cleanups).

I don't love that we're passing `ReplicaEvalContext` through an interface.
That should be avoidable and doing so should be instructive (I suspect
we'll trim some fat in the process):

Many methods roughly take the following form:

```go
// GetMVCCStats returns the Replica's MVCCStats. func (rec
ReplicaEvalContext) GetMVCCStats() enginepb.MVCCStats {
   r := rec.repl
   r.mu.RLock()
defer r.mu.RUnlock()
return *r.mu.state.Stats, nil
}
```

and to define this method inside of the `batcheval` package, we'd have
instead

```go
type ReplicaEvalContext {
   // ...
   state struct {
       *sync.Mutex
       *storagebase.ReplicaState
   }
}
```