### PR TITLE
cherrypick-1.1: sql: remove the list of descriptor IDs from the output of SHOW JOBS.

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1032,10 +1032,10 @@ func (s *adminServer) Jobs(
 
 	q := makeSQLQuery()
 	q.Append(`
-			SELECT id, type, description, username, descriptor_ids, status,
-				created, started, finished, modified, fraction_completed, error
-			FROM [SHOW JOBS]
-			WHERE true
+      SELECT id, type, description, username, descriptor_ids, status,
+             created, started, finished, modified, fraction_completed, error
+        FROM crdb_internal.jobs
+       WHERE true
 	`)
 	if req.Status != "" {
 		q.Append(" AND status = $", parser.NewDString(req.Status))

--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -726,7 +726,10 @@ func RunAndWaitForTerminalState(
 		var status Status
 		var jobErr gosql.NullString
 		var fractionCompleted float64
-		err := sqlDB.QueryRow(`SELECT status, error, fraction_completed FROM [SHOW JOBS] WHERE id = $1`, jobID).Scan(
+		err := sqlDB.QueryRow(`
+       SELECT status, error, fraction_completed
+         FROM [SHOW JOBS]
+        WHERE id = $1`, jobID).Scan(
 			&status, &jobErr, &fractionCompleted,
 		)
 		if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -90,8 +90,9 @@ EXPLAIN DROP DATABASE foo
 query ITTT
 EXPLAIN SHOW JOBS
 ----
-0  values  ·     ·
-0  ·       size  13 columns, 0 rows
+0  render  ·     ·
+1  values  ·     ·
+1  ·       size  13 columns, 0 rows
 
 statement ok
 CREATE INDEX a ON foo(x)

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -253,7 +253,7 @@ SELECT * FROM [SHOW TRACE FOR SELECT 1] LIMIT 0
 ----
 timestamp age message context operation span
 
-query ITTTTTTTTTRTI colnames
+query ITTTTTTTTRTI colnames
 SELECT * FROM [SHOW JOBS] LIMIT 0
 ----
-id  type  description  username  descriptor_ids  status  created  started  finished  modified  fraction_completed  error  coordinator_id
+id  type  description  username  status  created  started  finished  modified  fraction_completed  error  coordinator_id

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -601,7 +601,11 @@ func (p *planner) ShowQueries(ctx context.Context, n *parser.ShowQueries) (planN
 // ShowJobs returns all the jobs.
 // Privileges: None.
 func (p *planner) ShowJobs(ctx context.Context, n *parser.ShowJobs) (planNode, error) {
-	return p.delegateQuery(ctx, "SHOW JOBS", "TABLE crdb_internal.jobs", nil, nil)
+	return p.delegateQuery(ctx, "SHOW JOBS",
+		`SELECT id, type, description, username, status, created, started, finished, modified,
+            fraction_completed, error, coordinator_id
+       FROM crdb_internal.jobs`,
+		nil, nil)
 }
 
 func (p *planner) ShowSessions(ctx context.Context, n *parser.ShowSessions) (planNode, error) {

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -29,12 +29,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/kr/pretty"
-	"github.com/lib/pq"
 )
 
 func TestShowCreateTable(t *testing.T) {
@@ -464,8 +462,8 @@ func TestShowQueries(t *testing.T) {
 }
 
 // TestShowJobs manually inserts a row into system.jobs and checks that the
-// encoded protobuf payload is properly decoded and visible in both SHOW JOBS
-// and crdb_internal.jobs.
+// encoded protobuf payload is properly decoded and visible in
+// crdb_internal.jobs.
 func TestShowJobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -474,7 +472,7 @@ func TestShowJobs(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(t, rawSQLDB)
 	defer s.Stopper().Stop(context.TODO())
 
-	// row represents a row returned from crdb_internal.jobs or SHOW JOBS, but
+	// row represents a row returned from crdb_internal.jobs, but
 	// *not* a row in system.jobs.
 	type row struct {
 		id                int64
@@ -482,7 +480,6 @@ func TestShowJobs(t *testing.T) {
 		status            string
 		description       string
 		username          string
-		descriptorIDs     pq.Int64Array
 		err               string
 		created           time.Time
 		started           time.Time
@@ -493,13 +490,12 @@ func TestShowJobs(t *testing.T) {
 	}
 
 	in := row{
-		id:            42,
-		typ:           "SCHEMA CHANGE",
-		status:        "superfailed",
-		description:   "failjob",
-		username:      "failure",
-		descriptorIDs: pq.Int64Array{42},
-		err:           "boom",
+		id:          42,
+		typ:         "SCHEMA CHANGE",
+		status:      "superfailed",
+		description: "failjob",
+		username:    "failure",
+		err:         "boom",
 		// lib/pq returns time.Time objects with goofy locations, which breaks
 		// reflect.DeepEqual without this time.FixedZone song and dance.
 		// See: https://github.com/lib/pq/issues/329
@@ -520,13 +516,6 @@ func TestShowJobs(t *testing.T) {
 		ModifiedMicros:    in.modified.UnixNano() / time.Microsecond.Nanoseconds(),
 		FractionCompleted: in.fractionCompleted,
 		Username:          in.username,
-		DescriptorIDs: func() sqlbase.IDs {
-			var ids sqlbase.IDs
-			for _, id := range in.descriptorIDs {
-				ids = append(ids, sqlbase.ID(id))
-			}
-			return ids
-		}(),
 		Lease: &jobs.Lease{
 			NodeID: 7,
 		},
@@ -541,21 +530,17 @@ func TestShowJobs(t *testing.T) {
 		in.id, in.status, in.created, inPayload,
 	)
 
-	for _, source := range []string{"[SHOW JOBS]", "crdb_internal.jobs"} {
-		var out row
-		sqlDB.QueryRow(fmt.Sprintf(`
-			SELECT
-				id, type, status, created, description, started, finished, modified,
-				fraction_completed, username, descriptor_ids, error, coordinator_id
-			FROM %s`, source),
-		).Scan(
-			&out.id, &out.typ, &out.status, &out.created, &out.description, &out.started,
-			&out.finished, &out.modified, &out.fractionCompleted, &out.username, &out.descriptorIDs,
-			&out.err, &out.coordinatorID,
-		)
-		if !reflect.DeepEqual(in, out) {
-			diff := strings.Join(pretty.Diff(in, out), "\n")
-			t.Fatalf("in job did not match out job:\n%s", diff)
-		}
+	var out row
+	sqlDB.QueryRow(`
+      SELECT id, type, status, created, description, started, finished, modified,
+             fraction_completed, username, error, coordinator_id
+        FROM crdb_internal.jobs`).Scan(
+		&out.id, &out.typ, &out.status, &out.created, &out.description, &out.started,
+		&out.finished, &out.modified, &out.fractionCompleted, &out.username,
+		&out.err, &out.coordinatorID,
+	)
+	if !reflect.DeepEqual(in, out) {
+		diff := strings.Join(pretty.Diff(in, out), "\n")
+		t.Fatalf("in job did not match out job:\n%s", diff)
 	}
 }


### PR DESCRIPTION
Cherry-picks #18771.

Since descriptor IDs are not (yet) part of the public UI of
CockroachDB, they should not be printed out by documented statements
like SHOW.

Needed to complete the 1.1 docs.

cc @cockroachdb/release 