### PR TITLE
cherrypick-1.1: storage: Fix tracking of keys written in replica.writeStats

### DIFF
--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -498,3 +498,12 @@ func (r *RocksDBBatchReader) varstring() ([]byte, error) {
 	}
 	return s, nil
 }
+
+// RocksDBBatchCount provides an efficient way to get the count of mutations
+// in a RocksDB Batch representation.
+func RocksDBBatchCount(repr []byte) (int, error) {
+	if len(repr) < headerSize {
+		return 0, errors.Errorf("batch repr too small: %d < %d", len(repr), headerSize)
+	}
+	return int(binary.LittleEndian.Uint32(repr[countPos:headerSize])), nil
+}

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -244,8 +244,14 @@ func TestBatchRepr(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if count, expected := r.Count(), 3; count != expected {
-			t.Fatalf("bad count: expected %d, but found %d", expected, count)
+		const expectedCount = 3
+		if count := r.Count(); count != expectedCount {
+			t.Fatalf("bad count: RocksDBBatchReader.Count expected %d, but found %d", expectedCount, count)
+		}
+		if count, err := RocksDBBatchCount(repr); err != nil {
+			t.Fatal(err)
+		} else if count != expectedCount {
+			t.Fatalf("bad count: RocksDBBatchCount expected %d, but found %d", expectedCount, count)
 		}
 
 		var ops []string

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -590,6 +590,8 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 	if store.cfg.StorePool != nil {
 		r.leaseholderStats = newReplicaStats(store.Clock(), store.cfg.StorePool.getNodeLocalityString)
 	}
+	// Pass nil for the localityOracle because we intentionally don't track the
+	// origin locality of write load.
 	r.writeStats = newReplicaStats(store.Clock(), nil)
 
 	// Init rangeStr with the range ID.
@@ -4546,7 +4548,16 @@ func (r *Replica) applyRaftCommand(
 	if rResult.State.RaftAppliedIndex <= 0 {
 		log.Fatalf(ctx, "raft command index is <= 0")
 	}
-	r.writeStats.recordCount(math.Max(float64(rResult.Delta.KeyCount), 1), 0)
+	if writeBatch != nil && len(writeBatch.Data) > 0 {
+		// Record the write activity, passing a 0 nodeID because replica.writeStats
+		// intentionally doesn't track the origin of the writes.
+		mutationCount, err := engine.RocksDBBatchCount(writeBatch.Data)
+		if err != nil {
+			log.Errorf(ctx, "unable to read header of committed WriteBatch: %s", err)
+		} else {
+			r.writeStats.recordCount(float64(mutationCount), 0 /* nodeID */)
+		}
+	}
 
 	r.mu.Lock()
 	oldRaftAppliedIndex := r.mu.state.RaftAppliedIndex


### PR DESCRIPTION
Using the MVCCStats delta was incorrect, since it only counted inserts,
not updates or deletes.

Manually tested that updates to the same key now get reflected properly
in the writes per second row of the range debug page.

Fixes #18607 

@cockroachdb/release - seemingly worth cherrypicking because the count is completely broken and misleading in the "Keys Written per Second per Store" admin UI graph and our debug pages without this.