### PR TITLE
cherrypick-1.1: sql: avoid a panic on SHOW CLUSTER [ QUERIES | SESSIONS ] when a node is down

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -818,6 +818,7 @@ func populateSessionsTable(
 				parser.DNull,
 				parser.DNull,
 				parser.DNull,
+				parser.DNull,
 			); err != nil {
 				return err
 			}


### PR DESCRIPTION
The code for SHOW CLUSTER QUERIES / SESSIONS populates a row of NULLs
when it doesn't get a response for a node on time. The code path for
that "error row" was wrong, which this patch corrects.

See the discussion at https://github.com/cockroachdb/cockroach/pull/18772#pullrequestreview-65212533 and #18801 for the missing test. This patch at least ensures the panic goes away.

cc @cockroachdb/release 