### PR TITLE
storage: have serializable restarts take precedence over deadline expiration

### DIFF
--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -675,7 +675,16 @@ type EndTransactionRequest struct {
 	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// False to abort and rollback.
 	Commit bool `protobuf:"varint,2,opt,name=commit" json:"commit"`
-	// The deadline by which the transaction must commit, if present.
+	// If set, deadline represents the maximum timestamp at which the transaction
+	// can commit (i.e. the maximum timestamp for the txn's writes). If
+	// EndTransaction(Commit=true) finds that the txn's timestamp has been pushed
+	// above this deadline, an error will be returned and the client is supposed
+	// to rollback the txn.
+	// N.B. Assuming that the deadline was valid to begin with (i.e. it was higher
+	// than the txn's OrigTimestamp), only Snapshot transactions can get in
+	// trouble with the deadline check. A Serializable txn that has had its
+	// timestamp pushed has already lost before the deadline check: it will be
+	// forced to restart.
 	Deadline *cockroach_util_hlc.Timestamp `protobuf:"bytes,3,opt,name=deadline" json:"deadline,omitempty"`
 	// Optional commit triggers. Note that commit triggers are for
 	// internal use only and will cause an error if requested through the

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -295,7 +295,16 @@ message EndTransactionRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // False to abort and rollback.
   optional bool commit = 2 [(gogoproto.nullable) = false];
-  // The deadline by which the transaction must commit, if present.
+  // If set, deadline represents the maximum timestamp at which the transaction
+  // can commit (i.e. the maximum timestamp for the txn's writes). If
+  // EndTransaction(Commit=true) finds that the txn's timestamp has been pushed
+  // above this deadline, an error will be returned and the client is supposed
+  // to rollback the txn.
+  // N.B. Assuming that the deadline was valid to begin with (i.e. it was higher
+  // than the txn's OrigTimestamp), only Snapshot transactions can get in
+  // trouble with the deadline check. A Serializable txn that has had its
+  // timestamp pushed has already lost before the deadline check: it will be
+  // forced to restart.
   optional util.hlc.Timestamp deadline = 3;
   // Optional commit triggers. Note that commit triggers are for
   // internal use only and will cause an error if requested through the

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -853,16 +853,16 @@ func isEndTransactionTriggeringRetryError(
 
 	isTxnPushed := currentTxn.Timestamp != headerTxn.OrigTimestamp
 
-	// If pushing requires a retry and the transaction was pushed, retry.
-	if headerTxn.RetryOnPush && isTxnPushed {
-		return true, roachpb.RETRY_DELETE_RANGE
-	}
-
 	// If the isolation level is SERIALIZABLE, return a transaction
 	// retry error if the commit timestamp isn't equal to the txn
 	// timestamp.
 	if headerTxn.Isolation == enginepb.SERIALIZABLE && isTxnPushed {
 		return true, roachpb.RETRY_SERIALIZABLE
+	}
+
+	// If pushing requires a retry and the transaction was pushed, retry.
+	if headerTxn.RetryOnPush && isTxnPushed {
+		return true, roachpb.RETRY_DELETE_RANGE
 	}
 
 	return false, 0

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -764,23 +764,29 @@ func evalEndTransaction(
 	// a transaction is always set to the txn's original timestamp.
 	reply.Txn.Timestamp.Forward(h.Txn.Timestamp)
 
-	if isEndTransactionExceedingDeadline(reply.Txn.Timestamp, *args) {
-		// If the deadline has lapsed return an error and rely on the client
-		// issuing a Rollback() that aborts the transaction and cleans up
-		// intents. Unfortunately, we're returning an error and unable to
-		// write on error (see #1989): we can't write ABORTED into the master
-		// transaction record which remains PENDING, and thus rely on the
-		// client to issue a Rollback() for cleanup.
-		return EvalResult{}, roachpb.NewTransactionStatusError(
-			"transaction deadline exceeded")
-	}
-
 	// Set transaction status to COMMITTED or ABORTED as per the
 	// args.Commit parameter.
 	if args.Commit {
 		if retry, reason := isEndTransactionTriggeringRetryError(h.Txn, reply.Txn); retry {
 			return EvalResult{}, roachpb.NewTransactionRetryError(reason)
 		}
+
+		if isEndTransactionExceedingDeadline(reply.Txn.Timestamp, *args) {
+			// If the deadline has lapsed return an error and rely on the client
+			// issuing a Rollback() that aborts the transaction and cleans up
+			// intents. Unfortunately, we're returning an error and unable to
+			// write on error (see #1989): we can't write ABORTED into the master
+			// transaction record which remains PENDING, and thus rely on the
+			// client to issue a Rollback() for cleanup.
+			//
+			// N.B. This deadline test is expected to be a Noop for Serializable
+			// transactions; unless the client misconfigured the txn, the deadline can
+			// only be expired if the txn has been pushed, and pushed Serializable
+			// transactions are detected above.
+			return EvalResult{}, roachpb.NewTransactionStatusError(
+				"transaction deadline exceeded")
+		}
+
 		reply.Txn.Status = roachpb.COMMITTED
 	} else {
 		reply.Txn.Status = roachpb.ABORTED


### PR DESCRIPTION
Before this patch, if a Serializable txn was pushed and the push caused
the txn to exceed its deadline, the client would get a "deadline
exceeded" error back. What the client should have gotten is the
retriable error, as that would allow it to retry. This patch fixes this
by inverting the order of error generation. As a result, Serializable
txns shouldn't see "deadline exceeded" errors any more.

Touches #18684