### PR TITLE
sql: Include Range ID in the output of SHOW TESTING_RANGES

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -22,7 +22,7 @@ INSERT INTO data SELECT a, b, c, d FROM
 
 # Verify data placement.
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE data
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE data]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1
@@ -404,7 +404,7 @@ statement ok
 INSERT INTO two VALUES (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8,8), (9,9), (10,10)
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE one
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE one]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /0       {5}       5
@@ -412,7 +412,7 @@ NULL       /0       {5}       5
 /99        NULL     {5}       5
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE two
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE two]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /0       {5}       5

--- a/pkg/sql/logictest/testdata/logic_test/distsql_indexjoin
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_indexjoin
@@ -12,15 +12,15 @@ statement ok
 ALTER INDEX t@v TESTING_RELOCATE
   SELECT ARRAY[i+1], (i * 100)::int FROM GENERATE_SERIES(0, 4) AS g(i)
 
-query TTTI colnames
+query TTITI colnames
 SHOW TESTING_RANGES FROM INDEX t@v
 ----
-Start Key  End Key  Replicas  Lease Holder
-NULL       /100     {1}       1
-/100       /200     {2}       2
-/200       /300     {3}       3
-/300       /400     {4}       4
-/400       NULL     {5}       5
+Start Key  End Key  Range ID  Replicas  Lease Holder
+NULL       /100     1         {1}       1
+/100       /200     2         {2}       2
+/200       /300     3         {3}       3
+/300       /400     4         {4}       4
+/400       NULL     5         {5}       5
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM t WHERE v > 100]

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -21,20 +21,20 @@ INSERT INTO data SELECT a, b, c, d FROM
    GENERATE_SERIES(1, 10) AS D(d)
 
 # Verify data placement.
-query TTTI colnames
+query TTITI colnames
 SHOW TESTING_RANGES FROM TABLE data
 ----
-Start Key  End Key  Replicas  Lease Holder
-NULL       /1       {1}       1
-/1         /2       {2}       2
-/2         /3       {3}       3
-/3         /4       {4}       4
-/4         /5       {5}       5
-/5         /6       {1}       1
-/6         /7       {2}       2
-/7         /8       {3}       3
-/8         /9       {4}       4
-/9         NULL     {5}       5
+Start Key  End Key  Range ID  Replicas  Lease Holder
+NULL       /1       1         {1}       1
+/1         /2       2         {2}       2
+/2         /3       3         {3}       3
+/3         /4       4         {4}       4
+/4         /5       5         {5}       5
+/5         /6       6         {1}       1
+/6         /7       7         {2}       2
+/7         /8       8         {3}       3
+/8         /9       9         {4}       4
+/9         NULL     10        {5}       5
 
 # Ready to roll!
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -27,13 +27,13 @@ INSERT INTO NumToStr SELECT i, to_english(i) FROM GENERATE_SERIES(1, 100*100) AS
 
 # Verify data placement.
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE NumToSquare
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE NumToSquare]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       NULL     {1}       1
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE NumToStr
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE NumToStr]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /2000    {1}       1

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -3,39 +3,39 @@
 statement ok
 CREATE TABLE t (k1 INT, k2 INT, v INT, w INT, PRIMARY KEY (k1, k2))
 
-query TTTI colnames
+query TTITI colnames
 SHOW TESTING_RANGES FROM TABLE t
 ----
-Start Key  End Key  Replicas  Lease Holder
-NULL       NULL     {1}       1
+Start Key  End Key  Range ID  Replicas  Lease Holder
+NULL       NULL     1         {1}       1
 
 statement ok
 ALTER TABLE t SPLIT AT VALUES (1), (10)
 
-query TTTI colnames
+query TTITI colnames
 SHOW TESTING_RANGES FROM TABLE t
 ----
-Start Key  End Key  Replicas  Lease Holder
-NULL       /1       {1}       1
-/1         /10      {1}       1
-/10        NULL     {1}       1
+Start Key  End Key  Range ID  Replicas  Lease Holder
+NULL       /1       1         {1}       1
+/1         /10      2         {1}       1
+/10        NULL     3         {1}       1
 
 statement ok
 ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[4], 1, 12)
 
-query TTTI colnames
+query TTITI colnames
 SHOW TESTING_RANGES FROM TABLE t
 ----
-Start Key  End Key   Replicas  Lease Holder
-NULL       /1        {1}       1
-/1         /10       {4}       4
-/10        NULL      {1}       1
+Start Key  End Key   Range ID Replicas  Lease Holder
+NULL       /1        1        {1}       1
+/1         /10       2        {4}       4
+/10        NULL      3        {1}       1
 
 statement ok
 ALTER TABLE t SPLIT AT VALUES (5,1), (5,2), (5,3)
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE t
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1
@@ -52,7 +52,7 @@ statement ok
 ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[3,4], 4)
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE t
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1
@@ -66,7 +66,7 @@ statement ok
 CREATE INDEX idx ON t(v, w)
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM INDEX t@idx
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t@idx]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       NULL     {1}       1
@@ -75,7 +75,7 @@ statement ok
 ALTER INDEX t@idx SPLIT AT VALUES (100,1), (100,50)
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM INDEX t@idx
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t@idx]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /100/1   {1}       1
@@ -86,7 +86,7 @@ statement ok
 ALTER INDEX t@idx SPLIT AT VALUES (8), (9)
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM INDEX t@idx
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t@idx]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /8       {1}       1
@@ -99,7 +99,7 @@ statement ok
 ALTER INDEX t@idx TESTING_RELOCATE VALUES (ARRAY[5], 100, 10), (ARRAY[3], 100, 11)
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM INDEX t@idx
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t@idx]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /8       {1}       1
@@ -130,7 +130,7 @@ CREATE TABLE t0 (
 
 # We expect the splits for t0 to be the same as the splits for t.
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE t0
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t0]
 ----
 Start Key  End Key  Replicas  Lease Holder
 NULL       /1       {1}       1
@@ -144,7 +144,7 @@ statement ok
 ALTER TABLE t0 SPLIT AT VALUES (7, 8, 9)
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE t0
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t0]
 ----
 Start Key      End Key        Replicas  Lease Holder
 NULL           /1             {1}       1
@@ -159,7 +159,7 @@ statement ok
 ALTER TABLE t0 SPLIT AT VALUES (11)
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE t0
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t0]
 ----
 Start Key      End Key        Replicas  Lease Holder
 NULL           /1             {1}       1
@@ -172,7 +172,7 @@ NULL           /1             {1}       1
 /11            NULL           {1}       1
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM TABLE t
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM TABLE t]
 ----
 Start Key      End Key        Replicas  Lease Holder
 NULL           /1             {1}       1
@@ -192,7 +192,7 @@ CREATE INDEX idx on t1(v1,v2,v3) INTERLEAVE IN PARENT t(v1,v2)
 
 # We expect the splits for the index to be the same as the splits for t.
 query TTTI colnames
-SHOW TESTING_RANGES FROM INDEX t1@idx
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t1@idx]
 ----
 Start Key      End Key        Replicas  Lease Holder
 NULL           /1             {1}       1
@@ -208,7 +208,7 @@ statement ok
 ALTER INDEX t1@idx SPLIT AT VALUES (15,16)
 
 query TTTI colnames
-SHOW TESTING_RANGES FROM INDEX t1@idx
+SELECT "Start Key", "End Key", "Replicas", "Lease Holder" FROM [SHOW TESTING_RANGES FROM INDEX t1@idx]
 ----
 Start Key      End Key        Replicas  Lease Holder
 NULL           /1             {1}       1

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -231,17 +231,17 @@ username
 testuser
 
 
-query TTTI colnames
+query TTITI colnames
 SELECT * FROM [SHOW TESTING_RANGES FROM TABLE system.descriptor]
 ----
-Start Key  End Key  Replicas  Lease Holder
-NULL       NULL     {1}       1
+Start Key  End Key  Range ID  Replicas  Lease Holder
+NULL       NULL     1         {1}       1
 
-query TTTI colnames
+query TTITI colnames
 CREATE INDEX ix ON foo(x); SELECT * FROM [SHOW TESTING_RANGES FROM INDEX foo@ix]
 ----
-Start Key  End Key  Replicas  Lease Holder
-NULL       NULL     {1}       1
+Start Key  End Key  Range ID  Replicas  Lease Holder
+NULL       NULL     1         {1}       1
 
 query TTTTTT colnames
 SELECT * FROM [SHOW TRACE FOR SESSION]

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -72,6 +72,10 @@ var showRangesColumns = sqlbase.ResultColumns{
 		Typ:  parser.TypeString,
 	},
 	{
+		Name: "Range ID",
+		Typ:  parser.TypeInt,
+	},
+	{
 		Name: "Replicas",
 		// The INTs in the array are Store IDs.
 		Typ: parser.TArray{Typ: parser.TypeInt},
@@ -110,6 +114,8 @@ func (n *showRangesNode) Next(params runParams) (bool, error) {
 		n.values[1] = parser.NewDString(sqlbase.PrettyKey(desc.EndKey.AsRawKey(), 2))
 	}
 
+	n.values[2] = parser.NewDInt(parser.DInt(desc.RangeID))
+
 	var replicas []int
 	for _, rd := range desc.Replicas {
 		replicas = append(replicas, int(rd.StoreID))
@@ -121,7 +127,7 @@ func (n *showRangesNode) Next(params runParams) (bool, error) {
 	for i, r := range replicas {
 		replicaArr.Array[i] = parser.NewDInt(parser.DInt(r))
 	}
-	n.values[2] = replicaArr
+	n.values[3] = replicaArr
 
 	// Get the lease holder.
 	// TODO(radu): this will be slow if we have a lot of ranges; find a way to
@@ -136,7 +142,7 @@ func (n *showRangesNode) Next(params runParams) (bool, error) {
 		return false, errors.Wrap(err, "error getting lease info")
 	}
 	resp := b.RawResponse().Responses[0].GetInner().(*roachpb.LeaseInfoResponse)
-	n.values[3] = parser.NewDInt(parser.DInt(resp.Lease.Replica.StoreID))
+	n.values[4] = parser.NewDInt(parser.DInt(resp.Lease.Replica.StoreID))
 
 	n.rowIdx++
 	return true, nil

--- a/pkg/sql/split_at_test.go
+++ b/pkg/sql/split_at_test.go
@@ -166,10 +166,11 @@ func TestScatter(t *testing.T) {
 	// See showRangesColumns for the schema.
 	if cols, err := rows.Columns(); err != nil {
 		t.Fatal(err)
-	} else if len(cols) != 4 {
+	} else if len(cols) != 5 {
 		t.Fatalf("expected 4 columns, got %#v", cols)
 	}
 	vals := []interface{}{
+		new(interface{}),
 		new(interface{}),
 		new(interface{}),
 		new(interface{}),
@@ -181,7 +182,7 @@ func TestScatter(t *testing.T) {
 		if err := rows.Scan(vals...); err != nil {
 			t.Fatal(err)
 		}
-		leaseHolder := *vals[3].(*int)
+		leaseHolder := *vals[4].(*int)
 		if leaseHolder < 1 || leaseHolder > numHosts {
 			t.Fatalf("invalid lease holder value: %d", leaseHolder)
 		}


### PR DESCRIPTION
The new output looks like:

On multiple occasions when debugging I've wanted to be able to look up
debug pages for the ranges that are backing a particular table, but
figuring out the relevant range IDs is an awkward, indirect process.
There may be reasons for not wanting to expose this, so let me know
if you're aware of any. (cc @cockroachdb/core)

```
root@:26257/> show testing_ranges from table foo.bar;
+-----------+---------+----------+----------+--------------+
| Start Key | End Key | Range ID | Replicas | Lease Holder |
+-----------+---------+----------+----------+--------------+
| NULL      | /1      |       18 | {1}      |            1 |
| /1        | /2      |       19 | {1}      |            1 |
| /2        | /3      |       20 | {1}      |            1 |
| /3        | /4      |       21 | {1}      |            1 |
| /4        | NULL    |       22 | {1}      |            1 |
+-----------+---------+----------+----------+--------------+
```

I'll fix up the broken logic tests if you're open to this idea. It may make the logic tests require a little more maintenance unless we filter the output of some of the test cases to not return the Range ID.