### PR TITLE
distsql: de-duplicate equivalent local aggregations

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1346,8 +1346,8 @@ func (dsp *distSQLPlanner) addAggregators(
 		allDistinct = false
 	}
 
-	var finalAggSpec distsqlrun.AggregatorSpec
-	var finalAggPost distsqlrun.PostProcessSpec
+	var finalAggsSpec distsqlrun.AggregatorSpec
+	var finalAggsPost distsqlrun.PostProcessSpec
 
 	if !multiStage && allDistinct {
 		// We can't do local aggregation, but we can do local distinct processing
@@ -1388,17 +1388,19 @@ func (dsp *distSQLPlanner) addAggregators(
 	}
 
 	if !multiStage {
-		finalAggSpec = distsqlrun.AggregatorSpec{
+		finalAggsSpec = distsqlrun.AggregatorSpec{
 			Aggregations: aggregations,
 			GroupCols:    groupCols,
 		}
 	} else {
-		// Some aggregations might need multiple aggregation as part of their local
-		// and final stages (along with a final render expression to combine the
-		// multiple aggregations into a single result).
+		// Some aggregations might need multiple aggregation as part of
+		// their local and final stages (along with a final render
+		// expression to combine the multiple aggregations into a
+		// single result).
 		//
-		// Count the total number of aggregation in the local/final stages and keep
-		// track of whether any of them needs a final rendering.
+		// Count the total number of aggregation in the local/final
+		// stages and keep track of whether any of them needs a final
+		// rendering.
 		nLocalAgg := 0
 		nFinalAgg := 0
 		needRender := false
@@ -1411,72 +1413,107 @@ func (dsp *distSQLPlanner) addAggregators(
 			}
 		}
 
-		localAgg := make([]distsqlrun.AggregatorSpec_Aggregation, nLocalAgg, nLocalAgg+len(groupCols))
-		intermediateTypes := make([]sqlbase.ColumnType, nLocalAgg, nLocalAgg+len(groupCols))
-		finalAgg := make([]distsqlrun.AggregatorSpec_Aggregation, nFinalAgg)
+		// We alloc the maximum possible number of unique local
+		// aggregations but do not initialize any local aggregations
+		// since we can de-duplicate equivalent local aggregations.
+		localAggs := make([]distsqlrun.AggregatorSpec_Aggregation, 0, nLocalAgg+len(groupCols))
+		intermediateTypes := make([]sqlbase.ColumnType, 0, nLocalAgg+len(groupCols))
+		// TODO(richardwu): De-duplicate final aggregations similar to
+		// how we de-duplicate local aggregations.
+		finalAggs := make([]distsqlrun.AggregatorSpec_Aggregation, nFinalAgg)
 		finalGroupCols := make([]uint32, len(groupCols))
 		var finalPreRenderTypes []sqlbase.ColumnType
 		if needRender {
 			finalPreRenderTypes = make([]sqlbase.ColumnType, nFinalAgg)
 		}
 
-		// Each aggregation can have multiple aggregations in the local/final
-		// stages. We concatenate all these into localAgg/finalAgg; localIdx is an index
-		// inside localAgg and finalIdx is an index inside finalAgg.
-		localIdx := 0
+		// Each aggregation can have multiple aggregations in the
+		// local/final stages. We concatenate all these into
+		// localAggs/finalAggs.
+		// finalIdx is an index inside finalAggs.
 		finalIdx := 0
 		for _, e := range aggregations {
 			info := distsqlplan.DistAggregationTable[e.Func]
-			// firstLocalIdxCurAgg points to the first local index in the current
-			// aggregation e.
-			// This is used when computing AggregatorSpec_Aggregation.ColIdx
-			// for FinalStage aggregators since their input column indices
-			// are specified as a relative offset to the first local aggregator's
-			// index.
-			// This is required since we append all localAggs and finalAggs across
-			// all aggregations for the given plan together.
-			firstLocalIdxCurAgg := uint32(localIdx)
+
+			// relToAbsLocalIdx maps each local stage for the given
+			// aggregation e to its final index in localAggs.  This
+			// is necessary since we de-duplicate equivalent local
+			// aggregations and need to correspond the one copy of
+			// local aggregation required by the final stage to its
+			// input, which is specified as a relative local stage
+			// index (see `Aggregations` in aggregators_func.go).
+			// We use a slice here instead of a map because we have
+			// a small, bounded domain to map and runtime hash
+			// operations are relatively expensive.
+			relToAbsLocalIdx := make([]uint32, len(info.LocalStage))
 			// First prepare and spec local aggregations.
-			// Note the planNode first feeds the input (inputTypes) into the local aggregators.
-			for _, localFunc := range info.LocalStage {
-				localAgg[localIdx] = distsqlrun.AggregatorSpec_Aggregation{
+			// Note the planNode first feeds the input (inputTypes)
+			// into the local aggregators.
+			for i, localFunc := range info.LocalStage {
+				localAgg := distsqlrun.AggregatorSpec_Aggregation{
 					Func:         localFunc,
 					ColIdx:       e.ColIdx,
 					FilterColIdx: e.FilterColIdx,
 				}
 
-				argTypes := make([]sqlbase.ColumnType, len(e.ColIdx))
-				for i, c := range e.ColIdx {
-					argTypes[i] = inputTypes[c]
+				isNewAgg := true
+				for j, prevLocalAgg := range localAggs {
+					if localAgg.Equals(prevLocalAgg) {
+						// Map the relative index (i)
+						// for the current local stage
+						// to the absolute index (j) of
+						// the existing, equivalent
+						// local agg.
+						relToAbsLocalIdx[i] = uint32(j)
+						isNewAgg = false
+						break
+					}
 				}
 
-				var err error
-				_, intermediateTypes[localIdx], err = distsqlrun.GetAggregateInfo(localFunc, argTypes...)
-				if err != nil {
-					return err
+				if isNewAgg {
+					// Append the new local aggregation
+					// and map to its index in localAggs.
+					relToAbsLocalIdx[i] = uint32(len(localAggs))
+					localAggs = append(localAggs, localAgg)
+
+					argTypes := make([]sqlbase.ColumnType, len(e.ColIdx))
+					for j, c := range e.ColIdx {
+						argTypes[j] = inputTypes[c]
+					}
+					// Keep track of the new local
+					// aggregation's output type.
+					_, outputType, err := distsqlrun.GetAggregateInfo(localFunc, argTypes...)
+					if err != nil {
+						return err
+					}
+					intermediateTypes = append(intermediateTypes, outputType)
 				}
-				localIdx++
 			}
 
 			for _, finalInfo := range info.FinalStage {
-				// The input of the final aggregators are specified as the indices of the local aggregation
-				// values. We need to offset firstLocalIdxCurAgg by the relative indices specified in finalInfo.LocalIdxs.
+				// The input of the final aggregators are
+				// specified as the relative indices of the
+				// local aggregation values. We need to map
+				// these to the corresponding absolute indices
+				// in localAggs.
+				// argIdxs consists of the absolute indices
+				// in localAggs.
 				argIdxs := make([]uint32, len(finalInfo.LocalIdxs))
-				for i, c := range finalInfo.LocalIdxs {
-					argIdxs[i] = c + firstLocalIdxCurAgg
+				for i, relIdx := range finalInfo.LocalIdxs {
+					argIdxs[i] = relToAbsLocalIdx[relIdx]
 				}
-				finalAgg[finalIdx] = distsqlrun.AggregatorSpec_Aggregation{
+				finalAggs[finalIdx] = distsqlrun.AggregatorSpec_Aggregation{
 					Func:   finalInfo.Fn,
 					ColIdx: argIdxs,
 				}
 
 				if needRender {
 					argTypes := make([]sqlbase.ColumnType, len(finalInfo.LocalIdxs))
-					for i, c := range finalInfo.LocalIdxs {
-						// We want to access the corresponding local output type
-						// for the current aggregation e. c is the offset from
-						// the first local aggregator for the current aggregation e.
-						argTypes[i] = intermediateTypes[firstLocalIdxCurAgg+c]
+					for i := range finalInfo.LocalIdxs {
+						// Map the corresponding local
+						// aggregation output types for
+						// the current aggregation e.
+						argTypes[i] = intermediateTypes[argIdxs[i]]
 					}
 					var err error
 					_, finalPreRenderTypes[finalIdx], err = distsqlrun.GetAggregateInfo(
@@ -1490,8 +1527,9 @@ func (dsp *distSQLPlanner) addAggregators(
 			}
 		}
 
-		// Add IDENT expressions for the group columns; these need to be part of the
-		// output of the local stage because the final stage needs them.
+		// Add IDENT expressions for the group columns; these need to
+		// be part of the output of the local stage because the final
+		// stage needs them.
 		for i, groupColIdx := range groupCols {
 			agg := distsqlrun.AggregatorSpec_Aggregation{
 				Func:   distsqlrun.AggregatorSpec_IDENT,
@@ -1499,35 +1537,35 @@ func (dsp *distSQLPlanner) addAggregators(
 			}
 			// See if there already is an aggregation like the one we want to add.
 			idx := -1
-			for j := range localAgg {
-				if localAgg[j].Equals(agg) {
+			for j := range localAggs {
+				if localAggs[j].Equals(agg) {
 					idx = j
 					break
 				}
 			}
 			if idx == -1 {
 				// Not already there, add it.
-				idx = len(localAgg)
-				localAgg = append(localAgg, agg)
+				idx = len(localAggs)
+				localAggs = append(localAggs, agg)
 				intermediateTypes = append(intermediateTypes, inputTypes[groupColIdx])
 			}
 			finalGroupCols[i] = uint32(idx)
 		}
 
-		localAggSpec := distsqlrun.AggregatorSpec{
-			Aggregations: localAgg,
+		localAggsSpec := distsqlrun.AggregatorSpec{
+			Aggregations: localAggs,
 			GroupCols:    groupCols,
 		}
 
 		p.AddNoGroupingStage(
-			distsqlrun.ProcessorCoreUnion{Aggregator: &localAggSpec},
+			distsqlrun.ProcessorCoreUnion{Aggregator: &localAggsSpec},
 			distsqlrun.PostProcessSpec{},
 			intermediateTypes,
 			orderingTerminated, // The local aggregators don't guarantee any output ordering.
 		)
 
-		finalAggSpec = distsqlrun.AggregatorSpec{
-			Aggregations: finalAgg,
+		finalAggsSpec = distsqlrun.AggregatorSpec{
+			Aggregations: finalAggs,
 			GroupCols:    finalGroupCols,
 		}
 
@@ -1535,8 +1573,9 @@ func (dsp *distSQLPlanner) addAggregators(
 			// Build rendering expressions.
 			renderExprs := make([]distsqlrun.Expression, len(aggregations))
 			h := distsqlplan.MakeTypeIndexedVarHelper(finalPreRenderTypes)
-			// finalIdx is an index inside finalAgg. It is used to keep track of the
-			// finalAgg results that correspond to each aggregation.
+			// finalIdx is an index inside finalAggs. It is used to
+			// keep track of the finalAggs results that correspond
+			// to each aggregation.
 			finalIdx := 0
 			for i, e := range aggregations {
 				info := distsqlplan.DistAggregationTable[e.Func]
@@ -1551,7 +1590,7 @@ func (dsp *distSQLPlanner) addAggregators(
 				}
 				finalIdx += len(info.FinalStage)
 			}
-			finalAggPost.RenderExprs = renderExprs
+			finalAggsPost.RenderExprs = renderExprs
 		}
 	}
 
@@ -1570,7 +1609,7 @@ func (dsp *distSQLPlanner) addAggregators(
 		}
 	}
 
-	if len(finalAggSpec.GroupCols) == 0 || len(p.ResultRouters) == 1 {
+	if len(finalAggsSpec.GroupCols) == 0 || len(p.ResultRouters) == 1 {
 		// No GROUP BY, or we have a single stream. Use a single final aggregator.
 		// If the previous stage was all on a single node, put the final
 		// aggregator there. Otherwise, bring the results back on this node.
@@ -1580,8 +1619,8 @@ func (dsp *distSQLPlanner) addAggregators(
 		}
 		p.AddSingleGroupStage(
 			node,
-			distsqlrun.ProcessorCoreUnion{Aggregator: &finalAggSpec},
-			finalAggPost,
+			distsqlrun.ProcessorCoreUnion{Aggregator: &finalAggsSpec},
+			finalAggsPost,
 			finalOutTypes,
 		)
 	} else {
@@ -1591,7 +1630,7 @@ func (dsp *distSQLPlanner) addAggregators(
 		for _, resultProc := range p.ResultRouters {
 			p.Processors[resultProc].Spec.Output[0] = distsqlrun.OutputRouterSpec{
 				Type:        distsqlrun.OutputRouterSpec_BY_HASH,
-				HashColumns: finalAggSpec.GroupCols,
+				HashColumns: finalAggsSpec.GroupCols,
 			}
 		}
 
@@ -1609,8 +1648,8 @@ func (dsp *distSQLPlanner) addAggregators(
 						// The other fields will be filled in by mergeResultStreams.
 						ColumnTypes: p.ResultTypes,
 					}},
-					Core: distsqlrun.ProcessorCoreUnion{Aggregator: &finalAggSpec},
-					Post: finalAggPost,
+					Core: distsqlrun.ProcessorCoreUnion{Aggregator: &finalAggsSpec},
+					Post: finalAggsPost,
 					Output: []distsqlrun.OutputRouterSpec{{
 						Type: distsqlrun.OutputRouterSpec_PASS_THROUGH,
 					}},

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -500,7 +500,7 @@ func (a AggregatorSpec_Aggregation) Equals(b AggregatorSpec_Aggregation) bool {
 			return false
 		}
 	} else {
-		if a.FilterColIdx == nil || *a.FilterColIdx != *b.FilterColIdx {
+		if b.FilterColIdx == nil || *a.FilterColIdx != *b.FilterColIdx {
 			return false
 		}
 	}

--- a/pkg/sql/distsqlrun/processors.pb.go
+++ b/pkg/sql/distsqlrun/processors.pb.go
@@ -551,8 +551,10 @@ type AggregatorSpec_Aggregation struct {
 	Distinct bool `protobuf:"varint,2,opt,name=distinct" json:"distinct"`
 	// The column index specifies the argument(s) to the aggregator function.
 	//
-	// Currently no functions take more than one argument.
+	// Most aggregations take one argument
 	// COUNT_ROWS takes no arguments.
+	// FINAL_STDDEV and FINAL_VARIANCE take three arguments (SQRDIFF, SUM,
+	// COUNT).
 	ColIdx []uint32 `protobuf:"varint,5,rep,name=col_idx,json=colIdx" json:"col_idx,omitempty"`
 	// If set, this column index specifies a boolean argument; rows for which
 	// this value is not true don't contribute to this aggregation. This enables

--- a/pkg/sql/distsqlrun/processors.proto
+++ b/pkg/sql/distsqlrun/processors.proto
@@ -350,8 +350,10 @@ message AggregatorSpec {
 
     // The column index specifies the argument(s) to the aggregator function.
     //
-    // Currently no functions take more than one argument.
+    // Most aggregations take one argument
     // COUNT_ROWS takes no arguments.
+    // FINAL_STDDEV and FINAL_VARIANCE take three arguments (SQRDIFF, SUM,
+    // COUNT).
     repeated uint32 col_idx = 5;
 
     // If set, this column index specifies a boolean argument; rows for which

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -161,7 +161,7 @@ SELECT VARIANCE(a+b+c+d) FROM data
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), AVG(b), SUM(c), AVG(d), STDDEV(a), VARIANCE(b), SUM(a+b+c+d) FROM data]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzcVk-Lo04Qvf8-hdTJkIJJq_nnqcJkAsJvMrsmmcsig5suJJCxQ2tglyHffVF3NiqbdiGXkFt1Vz3fq3oF7QekSvIyfucM_G8gAMEBBBcQPEAYQoRw0GrLWaZ0UVIBAvkD_AHCLj0c8-I6QtgqzeB_QL7L9ww-rOPvew45lqwBQXIe7_YlyUHv3mP9k2Scx4AQcipZ-xYJtMhBi1y0yEPLtkn0yen1ye31yYPohKCO-Zkwy-OEwRcn_HdRsyTRnMS5amlabZ5tEj3AKnKK6PFls1z_jstb90_k1fJlvPoazoPFov4NUasRjRqng2fYu9isc7HZc4_HVGnJmmWjxeh05ThWm-e3oBDaGsOn5FrFqDgtguXs_7fVej5_erVpjDRBmp4Tr7MwmC0fn2wSAyQhkMR5AqLkaG7Gw-di0PCBRmjRGC2aoEXTi9NyG9MSt7ivHaLua1-dW3SgQ9R9OeDeogMdou7LAe8WHegQdV8OdPwihJwdVJpx6_X8-5cHxavKMuHqCc7UUW_5i1bbkqY6vpS48kJylldZUR2CtEoVAutgYQQ7DbBogx0zcwe1a0R7ZrB3je6hETwyM4-uYR4bwRMz8-Qa5qnZq0HHmpiXrM0dnf77FQAA__-t0YJ8
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzUVU-L4k4Qvf8-RahTggVjJ_FfTiXjCIHfOLtR57KEIWsXQXDS0omwy-B3X5I4q2bXzoIXvVV39av36nVBfUCmJM-Sd84h-AYCEFxA8ADBB4QexAhbrVac50qXT2pAKH9A0EVYZ9tdUV7HCCulGYIPKNbFhiGARfJ9wxEnkjUgSC6S9aYi2er1e6J_kkyKBBAiziTrwCKBFrlokYcW-WjZNokOuU6HPKdDPsR7BLUrjoR5kaQMgdjjv4sap6nmNClUQ9N8-WyTcADryC2jx5flbHGIq1vvd-Sf5Kt4_jWahNPpocYhI84yxzo952Iz7sVmjj3sMqUla5ZnLcT7K9udL5_fwlJ2o81PyScv-uVpGs7G_7_NF5PJ06tNAySBNDwmXsdROJ49Ptk0QnLxpKroOn98-8Pnr1Pvgfpo0QAtGqJFo4tWeWdWiVscxhZR9zWM7i063CLqvhz2btHhFlH35bB_iw63iLovh1v2b8T5VmU5N1bX3yt3y5XGMuV6_-Vqp1f8RatVRVMfXypcdSE5L-qsqA9hVqdKgadgYQS7Z2DRBLtm5hZqz4j2zWD_Gt09I7hvZu5fwzwwgodm5uE1zCPzX3VbxsQ8ZE3ueP_frwAAAP__rz1esg==
 
 query RRRRRRR
 SELECT SUM(a), AVG(b), SUM(c), AVG(d), STDDEV(a), VARIANCE(b), SUM(a+b+c+d) FROM data
@@ -177,6 +177,37 @@ query RIIIRRR
 SELECT SUM(a), MIN(b), MAX(c), COUNT(d), AVG(a+b+c+d), STDDEV(a+b), VARIANCE(c+d) FROM data
 ----
 55000 1 10 10000 22 4.0622223185119375800 16.50165016501650165
+
+# Verify that local aggregation is correctly shared and de-duplicated.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), STDDEV(a), AVG(a) FILTER (WHERE a > 5), COUNT(b), AVG(b), VARIANCE(b) FILTER (WHERE b < 8) FROM data]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzcVl2Lm0AUfe-vkPuUhQvrqElcnyZsEhC2bmvcfWllsc5FAlknjAotS_57UbdJtJuxNC8hD4HMmXvuOfcDxjfIpaAgeaUCvG_AAMECBBsQHEAYQ4ywVTKlopCqDmkJvvgJnomwzrdVWcMxQioVgfcG5brcEHgQJT82FFIiSAGCoDJZbxqRrVq_JuoXF0mZAEJIuSDlGZyhwdn3yjRtGnue5wcRGtyqfw2Yui0I8Q5BVuVBuSiTjMBjO_x3d7MsU5QlpeyZWz19HnF2Awirr-HcXy7fT_ePT0H056aNMZb-Q7QIDW4d33-E2nuW3clsH6KdQ0QH22c4Qk81wDrZgEPdVS6VIEWiU3a8-68WLf1g9vCyiubzxfOIW8gZHtXqvP978esKxp3TZB81_Rtv0z7PQn8W3C9G3EV-h5yZN_1tqZfDvuUOGnyMBp_c8ika3D3ZILvTIHbR-zvg7vr317ro8Qy4u_7x2Bc9ngF31z8e56LHM-Du-scz8HUSUrGVeUG9R_rjzGb9eJPIqH3pC1mplL4omTYy7fGx4TWAoKJsb1l78PP2qjZ4TGZastUhsz7Z0isPSNtatqMnO-f4HmvJE73y5BzlqZbs6pXdc5Tv9LMyB9ZEv2R97Xj36XcAAAD__9ZIsW0=
+
+query RRRIRR
+SELECT SUM(a), STDDEV(a), AVG(a) FILTER (WHERE a > 5), COUNT(b), AVG(b), VARIANCE(b) FILTER (WHERE b < 8) FROM data
+----
+55000 2.8724249481071304094 8 10000 5.5 4.0005715102157451064
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), AVG(DISTINCT a), VARIANCE(a) FILTER (WHERE a > 0) FROM data]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzMk8GKo0AQhu_7FPKfstAHW5M99EnJZhdh112Mk8uMhx67ECGxpbuFGYLvPqiHTEIyw5CLx66qz_9Dqo5otKJUHshCPIKDIQBDCIYlGFYoGFqjS7JWm2FkAhL1AuEz1E3buaFcMJTaEMQRrnZ7gkAun_eUkVRkwKDIyXo_hrSmPkjzGinpJBgyahQZ4UWceRF_6nw_JF8IkaQ5ip5Bd-4UYp2sCIL37IbIKb9rtFFkSJ2lF_0V1biqDFXS6QvT7cPfRcS_gyHe_V78TLZ5kq5zbyrt4iyJ0_VmmPB-JX_yTeZFwU3l4EyZz-XfBXMRCecispyLyCf3lZFtdWPpYr2vf9kf1p5URdONWN2Zkv4bXY4x0_PfyI0FRdZNXT49kmZsjYLvYf4h_OMM9i_h4J7k8B54eQ-8-hJc9N_eAgAA__-4kr3a
+
+query RRR
+SELECT SUM(a), AVG(DISTINCT a), VARIANCE(a) FILTER (WHERE a > 0) FROM data
+----
+55000 5.5 8.2508250825082508251
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT SUM(a), AVG(a), COUNT(a), STDDEV(a), VARIANCE(a) FROM data]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzElFFr2zAQx9_3Kcw9dXCwyHayzk8KTQOGLdmctC_DFC06jCG1jCTDRvF3H7YHrb1GHgup33w6__W7_524JyiUpI14JAPRd2CA4ANCAAghIMwhRSi1OpAxSje_dIJY_oRohpAXZWWb4xThoDRB9AQ2t0eCCPbix5ESEpI0IEiyIj-2kFLnj0L_4lJYAQjbykYeZ5DWCKqyzxcaKzKCiNX479BllmnKhFUD5u7uyxVn7wHhZnu32f_53n1LVvF63Uan8P5J_DO1KpSWpEn2oGn9XwX2vh7iplj_72gdb5afH3b71er2_ooHyBm-TNwvk3i5ubntpRIqJOmm2ehx_wMP0OMhenyOHl-cbEDQawCbYugj0EsP3Z_C8wj00p6DKTyPQC_tOZzC8wj0LRfaK_iETKkKQ4PF9vrNs2bhkcyo245GVfpAX7U6tJgu3La69kCSsV2WdUFcdKmmwJdi5hT7PTEbin03eQQdONWhWxyeU_fcKV64yYtzyB-d4ms3-foc8if3rGYjz8T9yIbstH73OwAA__-7q92w
+
+query RRIRR
+SELECT SUM(a), AVG(a), COUNT(a), STDDEV(a), VARIANCE(a) FROM data
+----
+55000 5.5 10000 2.8724249481071304094 8.2508250825082508251
 
 # planNode recursion figures out that DISTINCT can take advantage of orderings,
 # and so it retains the primary key ordering, which is why we don't need to
@@ -451,7 +482,7 @@ SELECT SUM(a), SUM(b), SUM(c) FROM data GROUP BY d HAVING SUM(a+b) > 10
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT AVG(a+b), c FROM data GROUP BY c, d HAVING c = d]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzcls9r2zAUx-_7K8w7tUxjlX9krWGgsR-QQ9ORNqdhhho9XENqGVmBlZL_fcg-OE5bvRb1kORmy_r4Pfnz5eFHqLXCmbzHFvI_wIFBDAwSYJACgwwKBo3RS2xbbdyWHpiqf5CfMajqZm3dcsFgqQ1C_gi2siuEHG7k7QrnKBUaYKDQymrVFWlMdS_Ng1DSSmDwq1pZNHkkkuhrJFzVOdaqX2GRSFkk-EcRQ7FhoNd2KNhaWSLkfMNe39S3sjRYSqt3ehKcCXfw6Y-fs5sTwU-H69hdXy8uT0Tirr5fLdxqcjraPW5uqHf7EN3J9u65YsVmOEP84hmGV61rbRQaVKOXdW95_1NeLy7_Tt16urUnOx3J-dy5yV4Uk7zvoWb6k252tj1fOB0V5vsYU6Kpg4gpP8aYxvuYFqKpg0hLfIxpSfYxLURTB5GW5BjTku5jWoimDiIt6TGmhfiTnWPb6LrFV_0RnblDoyqx_0KtXpsl_jZ62ZXpb686rltQ2Nr-Ke9vpnX_yDW4DfNdmG_D8Qjmb4MnIfBFCMyD-uaZn4693zvxw4lf1sRvK_XSmR_OQlT7YUK1HyZU-2FKNUETqichqr944XO_rPMQWX6YkOWHCVl-mJJF0ISsixBZnJii1BgNm6NhgzRskgaO0rBZyoOGKSemaUpIezJO3yTNT1PS_DQlzU-T0gickvZkqHqlFZsP_wMAAP__ALeCAg==
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzclk1r3DAQhu_9FWZOWarSyB_bxFBQ6QfsIZuyyZ6KKcpqcAwby8haaAj734vsg7NOoklQDmZvtuxHM_LzMvgBaq1wKe-whfwPcGAQA4MEGKTAIIOCQWP0BttWG_dKDyzUP8hPGVR1s7NuuWCw0QYhfwBb2S1CDtfyZosrlAoNMFBoZbXtijSmupPmXihpJTD4VW0tmjwSSfQ1Eq7qCmvVr7BIpCwS_KOIodgz0Ds7FGytLBFyvmevb-pbWRospdWjngRnwh188ePn8vpE8NlwHbvrq_XFiUjc1ffLtVtNZqOGhho399GtbG-fK1Dsh77jF_settrV2ig0qA4263Z5_5NdrS_-Ltx6Ohu9Pwj53PnIXpSRvO-hlvqTbkavPV84PSjMpxhNoqnJRpMfYzTjKSaEaGqyCYmPMSHJFBNCNDXZhCTHmJB0igkhmppsQtJjTAjxN7rCttF1i6_6wzl1h0ZVYv-FWr0zG_xt9KYr099edly3oLC1_VPe3yzq_pFr8DHMxzB_DMcHMH8bPA-Bz0NgHtQ3z_x07P3eiR9O_LLmflupl878cBai2g8Tqv0wodoPU6oJmlA9D1H9xQuf-WWdhcjyw4QsP0zI8sOULIImZJ2HyOLEFKXGaNgcDRukYZM0cJSGzVIeNEw5MU1TQtqTcfomaX6akuanKWl-mpRG4JS0J0PVK63Yf_gfAAD__y4VdLA=
 
 query RI rowsort
 SELECT AVG(a+b), c FROM data GROUP BY c, d HAVING c = d


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/18534

## Example
For the following contrived example
```
SELECT sum(a), avg(a), count(a), stddev(a), variance(a) FROM data
```
we de-duplicate __a ton__ of local aggregations
![image](https://user-images.githubusercontent.com/10563314/30886581-8a2d98b6-a2e5-11e7-8876-6d26afc0aa63.png)
where the [current state is in the left image](https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlVGLGjEQx9_7KZZ5sjBQs7t63j5FzhMWWm1X717KcqRmWARvI0kWWg6_e4lb8BRNyvkg-5bJ5J9f5p-BeYNaSZqJVzKQ_QQGCDEgJICQAsIASoStVisyRml3pBXk8jdkfYR1vW2s2y4RVkoTZG9g13ZDkMFS_NpQQUKSBgRJVqw3e8hWr1-F_sOlsAIQ5o3NIs6g3CGoxh4uNFZUBBnb4f9Dx1WlqRJWnTAXT996nH0GfLd6mD_NlmfWix_FJJ9OvefDZy6VE18s51BFUystSZM8KqLcfbzg-N_qJXfPS46i1EXTfDb--rJYTiaPzz0-QD5EfndIPI-LfDx7eOzxEfJ75KzvcgXVkrT7PYx4_IUnGPEUIz7AiA8vOpAcOcBu0UUBaNe6KL6FhwFo1zxMbuFhANo1D9NbeBiAds3DwIAryGxVbehkMpy_ue8mBsmK2vFiVKNX9F2r1R7ThvO9br8hydg2y9ogr9uUe-B7MfOK4yMxOxXHfnIAnXjVqV-cXvPugVc89JOH15DvvOKRnzy6hnzv_6t-oE38TXbKLnef_gYAAP__8k43jg==) and the [__improvement is in the right__](https://cockroachdb.github.io/distsqlplan/decode.html?eJzElFFr2zAQx9_3Kcw9dXCwyHayzk8KTQOGLdmctC_DFC06jCG1jCTDRvF3H7YHrb1GHgup33w6__W7_524JyiUpI14JAPRd2CA4ANCAAghIMwhRSi1OpAxSje_dIJY_oRohpAXZWWb4xThoDRB9AQ2t0eCCPbix5ESEpI0IEiyIj-2kFLnj0L_4lJYAQjbykYeZ5DWCKqyzxcaKzKCiNX479BllmnKhFUD5u7uyxVn7wHhZnu32f_53n1LVvF63Uan8P5J_DO1KpSWpEn2oGn9XwX2vh7iplj_72gdb5afH3b71er2_ooHyBm-TNwvk3i5ubntpRIqJOmm2ehx_wMP0OMhenyOHl-cbEDQawCbYugj0EsP3Z_C8wj00p6DKTyPQC_tOZzC8wj0LRfaK_iETKkKQ4PF9vrNs2bhkcyo245GVfpAX7U6tJgu3La69kCSsV2WdUFcdKmmwJdi5hT7PTEbin03eQQdONWhWxyeU_fcKV64yYtzyB-d4ms3-foc8if3rGYjz8T9yIbstH73OwAA__-7q92w). 

## Follow-up

We can do the same thing with final aggregations as well (before the rendering stage). 

cc: @RaduBerinde @vivekmenezes 