### PR TITLE
acceptance: refresh allocator test medium data sets

### DIFF
--- a/build/teamcity-nightly-acceptance.sh
+++ b/build/teamcity-nightly-acceptance.sh
@@ -47,11 +47,11 @@ case $TESTNAME in
     ;;
   TestSteady_6Medium)
     TESTTIMEOUT=24h
-    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 100'
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 960'
     ;;
   TestUpreplicate_1To6Medium)
     TESTTIMEOUT=18h
-    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 52'
+    COCKROACH_EXTRA_FLAGS+=' -tf.cockroach-env=COCKROACH_PREEMPTIVE_SNAPSHOT_RATE=8388608 -tf.cockroach-flags="--vmodule=allocator=5,allocator_scorer=5,replicate_queue=5" -at.std-dev 960'
     ;;
   TestContinuousLoad_BlockWriter)
     TESTTIMEOUT=6h

--- a/docs/cloud-resources.md
+++ b/docs/cloud-resources.md
@@ -20,14 +20,14 @@ hierarchy looks like this:
   * **backups/** — the output of `BACKUP... TO 'azure://roachfixtures/backups/FOO'`,
                    used to test `RESTORE` without manually running a backup.
     * **2tb/**
-    * **tpch{1,5,10}/**
+    * **tpch{1,5,10,100}/**
   * **store-dumps/** — gzipped tarballs of raw stores (i.e., `cockroach-data`
                        directories), used to test allocator rebalancing and
                        backups without manually inserting gigabytes of data.
     * **1node-17gb-841ranges/** - source: `RESTORE` of `tpch10`
-    * **1node-108gb-2065ranges/**
+    * **1node-113gb-9595ranges/** - source: `tpch100 IMPORT`
     * **3nodes-17gb-841ranges/** - source: `RESTORE` of `tpch10`
-    * **6nodes-56gb-1038ranges/**
+    * **6nodes-67gb-9588ranges/** - source: `RESTORE` of `tpch100`
     * **10nodes-2tb-50000ranges/**
   * **csvs/** — huge CSVs used to test distributed CSV import (`IMPORT...`).
 

--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -51,9 +51,9 @@ const (
 // Please keep /docs/cloud-resources.md up-to-date if you change these.
 const (
 	fixtureStore1s = "store-dumps/1node-17gb-841ranges"
-	fixtureStore1m = "store-dumps/1node-108gb-2065ranges"
+	fixtureStore1m = "store-dumps/1node-113gb-9595ranges"
 	fixtureStore3s = "store-dumps/3nodes-17gb-841ranges"
-	fixtureStore6m = "store-dumps/6nodes-56gb-1038ranges"
+	fixtureStore6m = "store-dumps/6nodes-67gb-9588ranges"
 )
 
 type allocatorTest struct {


### PR DESCRIPTION
The medium data sets have been regenerated using TPC-H scale factor 100
data. This results in a similar data size but an 8x increase in range
count, which is great for more thoroughly testing the allocator.

Helps unblock #15959