### PR TITLE
cherrypick-1.1: kv: avoid race when using Stopper.RunWorker

### DIFF
--- a/pkg/kv/transport_race.go
+++ b/pkg/kv/transport_race.go
@@ -59,53 +59,57 @@ func GRPCTransportFactory(
 	if atomic.AddInt32(&running, 1) <= 1 {
 		// NB: We can't use Stopper.RunWorker because doing so would race with
 		// calling Stopper.Stop.
-		rpcContext.Stopper.RunAsyncTask(context.TODO(), "transport racer", func(ctx context.Context) {
-			var iters int
-			var curIdx int
-			defer func() {
-				atomic.StoreInt32(&running, 0)
-				log.Infof(
-					ctx,
-					"transport race promotion: ran %d iterations on up to %d requests",
-					iters, curIdx+1,
-				)
-			}()
-			// Make a fixed-size slice of *BatchRequest. When full, entries
-			// are evicted in FIFO order.
-			const size = 1000
-			bas := make([]*roachpb.BatchRequest, size)
-			encoder := gob.NewEncoder(ioutil.Discard)
-			for {
-				iters++
-				start := timeutil.Now()
-				for _, ba := range bas {
-					if ba != nil {
-						if err := encoder.Encode(ba); err != nil {
-							panic(err)
+		if err := rpcContext.Stopper.RunAsyncTask(
+			context.TODO(), "transport racer", func(ctx context.Context) {
+				var iters int
+				var curIdx int
+				defer func() {
+					atomic.StoreInt32(&running, 0)
+					log.Infof(
+						ctx,
+						"transport race promotion: ran %d iterations on up to %d requests",
+						iters, curIdx+1,
+					)
+				}()
+				// Make a fixed-size slice of *BatchRequest. When full, entries
+				// are evicted in FIFO order.
+				const size = 1000
+				bas := make([]*roachpb.BatchRequest, size)
+				encoder := gob.NewEncoder(ioutil.Discard)
+				for {
+					iters++
+					start := timeutil.Now()
+					for _, ba := range bas {
+						if ba != nil {
+							if err := encoder.Encode(ba); err != nil {
+								panic(err)
+							}
 						}
 					}
-				}
-				// Prevent the goroutine from spinning too hot as this lets CI
-				// times skyrocket. Sleep on average for as long as we worked
-				// on the last iteration so we spend no more than half our CPU
-				// time on this task.
-				jittered := time.After(jitter(timeutil.Since(start)))
-				// Collect incoming requests until the jittered timer fires,
-				// then access everything we have.
-				for {
-					select {
-					case <-rpcContext.Stopper.ShouldQuiesce():
-						return
-					case ba := <-incoming:
-						bas[curIdx%size] = ba
-						curIdx++
-						continue
-					case <-jittered:
+					// Prevent the goroutine from spinning too hot as this lets CI
+					// times skyrocket. Sleep on average for as long as we worked
+					// on the last iteration so we spend no more than half our CPU
+					// time on this task.
+					jittered := time.After(jitter(timeutil.Since(start)))
+					// Collect incoming requests until the jittered timer fires,
+					// then access everything we have.
+					for {
+						select {
+						case <-rpcContext.Stopper.ShouldQuiesce():
+							return
+						case ba := <-incoming:
+							bas[curIdx%size] = ba
+							curIdx++
+							continue
+						case <-jittered:
+						}
+						break
 					}
-					break
 				}
-			}
-		})
+			}); err != nil {
+			// Failed to start async task, reset our state.
+			atomic.StoreInt32(&running, 0)
+		}
 	}
 	select {
 	// We have a shallow copy here and so the top level scalar fields can't


### PR DESCRIPTION
Fix #18815.