### PR TITLE
teamcity-reset-nightlies: clean up storage accounts too

### DIFF
--- a/build/teamcity-reset-nightlies.sh
+++ b/build/teamcity-reset-nightlies.sh
@@ -1,21 +1,40 @@
 #!/usr/bin/env bash
 
-# Deletes and recreates the cockroach-nightly resource group, which contains the
-# Azure VMs, virtual networks, IPs, etc. that are automatically created by
+# Deletes and recreates the nightlies resource group, which contains the Azure
+# VMs, virtual networks, IPs, disks etc. that are automatically created by
 # nightly tests. This is a big hammer, but the nightlies leak resources
 # constantly as `terraform destroy` is not particularly reliable.
 
 set -euo pipefail
 
-docker run --rm --interactive azuresdk/azure-cli-python:2.0.17 bash <<EOF
+docker run --rm --interactive \
+  --env=ARM_CLIENT_ID \
+  --env=ARM_CLIENT_SECRET \
+  --env=ARM_TENANT_ID \
+  --env=ARM_SUBSCRIPTION_ID \
+  azuresdk/azure-cli-python:2.0.17 bash <<'EOF'
   set -euo pipefail
+
+  resource_group=cockroach-nightly
+
+  declare -A storage_accounts=(
+    [cockroachnightlyeastvhd]=eastus
+    [cockroachnightlywestvhd]=westus
+  )
 
   az login --service-principal --username="$ARM_CLIENT_ID" --password="$ARM_CLIENT_SECRET" --tenant="$ARM_TENANT_ID"
   az account set --subscription="$ARM_SUBSCRIPTION_ID"
 
   # Simulate delete-if-exists behavior.
-  az group delete --yes --no-wait --name=cockroach-nightly || true
-  az group wait --deleted --timeout=$((60 * 10)) --name=cockroach-nightly
+  az group delete --yes --no-wait --name="$resource_group" || true
+  az group wait --deleted --timeout=$((60 * 10)) --name="$resource_group"
 
-  az group create --location=eastus --name=cockroach-nightly
+  az group create --location=eastus --name="$resource_group"
+
+  for account_name in "${!storage_accounts[@]}"
+  do
+    location="${storage_accounts[$account_name]}"
+    az storage account create --resource-group="$resource_group" --name="$account_name" --location="$location" --sku=Standard_LRS 
+    az storage container create --account-name="$account_name" --name=vhds
+  done
 EOF

--- a/pkg/acceptance/terraform/azure/variables.tf
+++ b/pkg/acceptance/terraform/azure/variables.tf
@@ -60,11 +60,14 @@ variable "azure_vhd_storage_account" {
   # Using a static storage account name also has the benefit of making it
   # easier to expunge leaked VHDs, which continue to occur as of 2017-08-09.
   # Only lowercase letters and numbers are allowed by Azure.
-  default = "cockroachnightlyvhd"
+  #
+  # N.B. Keep this in sync with build/teamcity-reset-nightlies.sh.
+  default = "cockroachnightlyeastvhd"
 }
 
 variable "vhd_storage_container" {
-  # Must belong to ${var.azure_vhd_storage_account}.
+  # Must belong to ${var.azure_vhd_storage_account}. Keep this in sync with
+  # build/teamcity-reset-nightlies.sh.
   default = "vhds"
 }
 

--- a/pkg/ccl/acceptanceccl/backup_test.go
+++ b/pkg/ccl/acceptanceccl/backup_test.go
@@ -84,7 +84,8 @@ func (bt *benchmarkTest) Start(ctx context.Context) {
 		// [0]: https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes
 		"-var", "azure_vm_size=Standard_L4s",
 		"-var", "azure_location=westus",
-		"-var", "azure_vhd_storage_account=cockroachnightlywestvhds",
+		// Keep this in sync with build/teamcity-reset-nightlies.sh.
+		"-var", "azure_vhd_storage_account=cockroachnightlywestvhd",
 	}
 
 	log.Infof(ctx, "creating cluster with %d node(s)", bt.nodes)


### PR DESCRIPTION
VM disks (VHDs) are backed by Azure storage accounts, which means the
VHDs leak whenever their VMs leak, which is frequently. Since the
storage accounts were previously associated with their own resource
group, deleting the cockroach-nightly resource group would not delete
the storage accounts. Prior to this commit, one of the storage accounts
had over 16TB worth of data.

Plug the leak by moving the storage accounts into the cockroach-nightly
resource group, so they get deleted when cockroach-nightly is deleted,
and teach teamcity-reset-nightlies to recreate them.