### PR TITLE
roachpb: fix lease equivalence after nullability refactor

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1118,10 +1118,19 @@ func (l Lease) Equivalent(ol Lease) bool {
 	// and then set to nil.
 	switch l.Type() {
 	case LeaseEpoch:
+		// Ignore expirations. This seems benign but since we changed the
+		// nullability of this field in the 1.2 cycle, it's crucial and
+		// tested in TestLeaseEquivalence.
+		l.Expiration, ol.Expiration = nil, nil
+
 		if ol.Epoch != nil && *l.Epoch == *ol.Epoch {
 			l.Epoch, ol.Epoch = nil, nil
 		}
 	case LeaseExpiration:
+		// See the comment above, though this field's nullability wasn't
+		// changed. We nil it out for completeness only.
+		l.Epoch, ol.Epoch = nil, nil
+
 		// For expiration-based leases, extensions are considered equivalent.
 		if !ol.GetExpiration().Less(l.GetExpiration()) {
 			l.Expiration, ol.Expiration = nil, nil

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4238,6 +4238,7 @@ func (r *Replica) checkForcedErrLocked(
 			forcedErr = roachpb.NewError(&roachpb.LeaseRejectedError{
 				Existing:  *r.mu.state.Lease,
 				Requested: requestedLease,
+				Message:   "proposed under invalid lease",
 			})
 		}
 	} else if isLeaseRequest {


### PR DESCRIPTION
In #18689, we changed the nullability of some fields from false to true to reduce the encoded size
of some protobufs, one of which was the `Lease` message.

This introduced a bug in which the "same" lease (but differing in nullability of one of the fields)
was considered non-equivalent.

This in turn lead to ranges that couldn't [get a new lease] and [replica divergence] through the
following mechanism:

- node 1 runs the nullable version, nodes 2 and 3 don't
- the lease has a zero (not nil!) Expiration
- node 2 sends a valid lease request
- all nodes update their in-memory state, but node 1 sees a zero field, 2 and 3 a nil one
- whenever node 1 sends a proposal under the "correct" lease, it sends a zero field
- whenever node 2 and 3 apply these commands, they discard them
- whenever node 1 applies these commands, well, it does!

I also saw the case of a range that had this message (in fact, this is where I got the scent):

```
on n3: command proposed from replica (n3,s3):69 with
repl=(n3,s3):69 start=1506492010.468037043,0 epo=138 pro=1506492010.468041892,0
incompatible to
repl=(n3,s3):69 start=1506492010.468037043,0 epo=138 pro=1506492010.468041892,0
```

(yes, this is `n3` deciding that its own lease isn't equivalent to itself). I think this basically
boils down to the fact that the lease request code doesn't verbatim pass the lease through but
unintentionally scrubs the nil fields:

```go
// ProposerLease will be the same as PrevLease, so with zero field
leaseReq = &roachpb.RequestLeaseRequest{
    Span:      reqSpan,
    Lease:     reqLease,
    PrevLease: status.Lease, // has the zero field
    // has no zero field
}
```

In effect this means that new versions that base their epoch leases off of a previous one will have
trouble (which is essentially all leases). This explains why the PM cluster ground to a halt.

PS: I'm pretty worried that we have more of those bugs lurking.

[get a new lease]: https://github.com/cockroachdb/cockroach/issues/18825#issuecomment-332563514
[replica divergence]: https://github.com/cockroachdb/cockroach/issues/18825#issue-261000347