### PR TITLE
sql: Fix TestLeaseRefreshedAutomatically race condition

### DIFF
--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -632,6 +632,14 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 			return errors.Errorf("expected at least 3 leases to be acquired, but only acquired %d times",
 				count)
 		}
+
+		// Stop the renewal goroutine before ending to prevent a race condition with
+		// recovering the constants modified during testing.
+		t := leaseManager.findTableState(tableDesc.ID, true)
+		t.mu.Lock()
+		t.mu.timer.Stop()
+		t.mu.Unlock()
+
 		return nil
 	})
 }


### PR DESCRIPTION
Fixes a race condition in a test that occurs when recovering testing
constants. In the test, table leases continue to get refreshed after the
test succeeds and this can cause a race condition with accessing the
constants.

In order to prevent this we stop the timer that fires and triggers this
asynchronous routine.

Fixes #18827.

cc: @a-robinson @vivekmenezes 
