### PR TITLE
distsql: pre-reserve memory needed to mark rows in HashJoiner build phase

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -569,16 +569,17 @@ func TestHashJoiner(t *testing.T) {
 		// Run tests with a probability of the run failing with a memory error.
 		// These verify that the hashJoiner falls back to disk correctly in all
 		// cases.
-		for i := 0; i < 5; i++ {
-			memFailPoint := buffer
-			t.Run(fmt.Sprintf("MemFailPoint=%s", memFailPoint), func(t *testing.T) {
-				if err := testFunc(t, func(h *hashJoiner) {
-					h.testingKnobMemFailPoint = memFailPoint
-					h.testingKnobFailProbability = 0.5
-				}); err != nil {
-					t.Fatal(err)
-				}
-			})
+		for _, memFailPoint := range []hashJoinPhase{buffer, build} {
+			for i := 0; i < 5; i++ {
+				t.Run(fmt.Sprintf("MemFailPoint=%s", memFailPoint), func(t *testing.T) {
+					if err := testFunc(t, func(h *hashJoiner) {
+						h.testingKnobMemFailPoint = memFailPoint
+						h.testingKnobFailProbability = 0.5
+					}); err != nil {
+						t.Fatal(err)
+					}
+				})
+			}
 		}
 
 		// Run test with a variety of memory limits.


### PR DESCRIPTION
A situation was uncovered by #18600, where the HashJoiner would run out
of memory in the probe phase. This was because we had made an assumption
that we wouldn't hit a memory limit if the buffer phase filled up at
most 2/3 of the limit with both streams , since the marking
infrastructure would take up only a fraction of 1/3 (the chosen stream).

This assumption failed to take into account other limits shared with
other processors. This change pre-reserves the memory needed for the
probe phase in the build phase so that we can keep a single point in the
code where we fall back to disk while not relying on any limit
assumptions.