### PR TITLE
cherrypick-1.1: server: add warning message for freezing at startup with --background

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -860,6 +860,24 @@ func (s *Server) Start(ctx context.Context) error {
 		return errors.Wrap(err, "inspecting engines")
 	}
 
+	defer time.AfterFunc(30*time.Second, func() {
+		serverVersion := s.cfg.Settings.Version.ServerVersion
+		// If the version is an unstable development version, treat it as the last
+		// stable version so that the docs link will exist (for example, 1.1-5
+		// becomes 1.1).
+		serverVersion.Unstable = 0
+		msg := `The server appears to be unable to contact the other nodes in the cluster. Please try
+
+- starting the other nodes, if you haven't already
+- double-checking that the '--join' and '--host' flags are set up correctly
+- not using the '--background' flag.
+
+If problems persist, please see https://www.cockroachlabs.com/docs/v` + serverVersion.String() + `/cluster-setup-troubleshooting.html.`
+
+		log.Shout(context.Background(), log.Severity_WARNING,
+			msg)
+	}).Stop()
+
 	// Now that we have a monotonic HLC wrt previous incarnations of the process,
 	// init all the replicas. At this point *some* store has been bootstrapped or
 	// we're joining an existing cluster for the first time.


### PR DESCRIPTION
Before if a user restarted a server with the --background flag the node
would freeze at startup waiting for another node for quorum.

Now the node will show a warning message if the server doesn't come up
within 30 seconds.

Closes: #15894