### PR TITLE
sql: table lease refresh done asynchronously 

### DIFF
--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -223,8 +223,10 @@ func TestLeaseManager(testingT *testing.T) {
 	// table and expiration.
 	l1, e1 := t.mustAcquire(1, descID)
 	l2, e2 := t.mustAcquire(1, descID)
-	if l1.ID != l2.ID || e1 != e2 {
+	if l1.ID != l2.ID {
 		t.Fatalf("expected same lease, but found %v != %v", l1, l2)
+	} else if e1 != e2 {
+		t.Fatalf("expected same lease timestamps, but found %v != %v", e1, e2)
 	}
 	t.expectLeases(descID, "/1/1")
 	// Node 2 never acquired a lease on descID, so we should expect an error.


### PR DESCRIPTION
This commit completes changes the lease refreshing flow from a periodic
renewal to renewing the lease asynchronously on table access if the
lease will expire soon (the first part was reverting the periodic
    renewal in ec9f73b).

Before, table lease acquisition was done through a routine which kept
renewing a lease indefinitely. This meant the routine to renew the lease
would not end after a table was truncated or otherwise discard.

This will continue to prevent consecutive accesses to the table lease
from blocking due to lease expiration as the previous flow did.

When we asynchronously attempt to acquire a lease we create a goroutine
which only lives for the length of the attempt. If it fails, the same
process will repeat until the existing lease expires, when the error
will become user-facing.

cc: @vivekmenezes @andreimatei 