### PR TITLE
cherrypick 1.1: storage: have serializable restarts take precedence over deadline expiration

### DIFF
--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -675,7 +675,16 @@ type EndTransactionRequest struct {
 	Span `protobuf:"bytes,1,opt,name=header,embedded=header" json:"header"`
 	// False to abort and rollback.
 	Commit bool `protobuf:"varint,2,opt,name=commit" json:"commit"`
-	// The deadline by which the transaction must commit, if present.
+	// If set, deadline represents the maximum timestamp at which the transaction
+	// can commit (i.e. the maximum timestamp for the txn's writes). If
+	// EndTransaction(Commit=true) finds that the txn's timestamp has been pushed
+	// above this deadline, an error will be returned and the client is supposed
+	// to rollback the txn.
+	// N.B. Assuming that the deadline was valid to begin with (i.e. it was higher
+	// than the txn's OrigTimestamp), only Snapshot transactions can get in
+	// trouble with the deadline check. A Serializable txn that has had its
+	// timestamp pushed has already lost before the deadline check: it will be
+	// forced to restart.
 	Deadline *cockroach_util_hlc.Timestamp `protobuf:"bytes,3,opt,name=deadline" json:"deadline,omitempty"`
 	// Optional commit triggers. Note that commit triggers are for
 	// internal use only and will cause an error if requested through the

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -295,7 +295,16 @@ message EndTransactionRequest {
   optional Span header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // False to abort and rollback.
   optional bool commit = 2 [(gogoproto.nullable) = false];
-  // The deadline by which the transaction must commit, if present.
+  // If set, deadline represents the maximum timestamp at which the transaction
+  // can commit (i.e. the maximum timestamp for the txn's writes). If
+  // EndTransaction(Commit=true) finds that the txn's timestamp has been pushed
+  // above this deadline, an error will be returned and the client is supposed
+  // to rollback the txn.
+  // N.B. Assuming that the deadline was valid to begin with (i.e. it was higher
+  // than the txn's OrigTimestamp), only Snapshot transactions can get in
+  // trouble with the deadline check. A Serializable txn that has had its
+  // timestamp pushed has already lost before the deadline check: it will be
+  // forced to restart.
   optional util.hlc.Timestamp deadline = 3;
   // Optional commit triggers. Note that commit triggers are for
   // internal use only and will cause an error if requested through the

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -766,23 +766,29 @@ func evalEndTransaction(
 	// a transaction is always set to the txn's original timestamp.
 	reply.Txn.Timestamp.Forward(h.Txn.Timestamp)
 
-	if isEndTransactionExceedingDeadline(reply.Txn.Timestamp, *args) {
-		// If the deadline has lapsed return an error and rely on the client
-		// issuing a Rollback() that aborts the transaction and cleans up
-		// intents. Unfortunately, we're returning an error and unable to
-		// write on error (see #1989): we can't write ABORTED into the master
-		// transaction record which remains PENDING, and thus rely on the
-		// client to issue a Rollback() for cleanup.
-		return EvalResult{}, roachpb.NewTransactionStatusError(
-			"transaction deadline exceeded")
-	}
-
 	// Set transaction status to COMMITTED or ABORTED as per the
 	// args.Commit parameter.
 	if args.Commit {
 		if retry, reason := isEndTransactionTriggeringRetryError(h.Txn, reply.Txn); retry {
 			return EvalResult{}, roachpb.NewTransactionRetryError(reason)
 		}
+
+		if isEndTransactionExceedingDeadline(reply.Txn.Timestamp, *args) {
+			// If the deadline has lapsed return an error and rely on the client
+			// issuing a Rollback() that aborts the transaction and cleans up
+			// intents. Unfortunately, we're returning an error and unable to
+			// write on error (see #1989): we can't write ABORTED into the master
+			// transaction record which remains PENDING, and thus rely on the
+			// client to issue a Rollback() for cleanup.
+			//
+			// N.B. This deadline test is expected to be a Noop for Serializable
+			// transactions; unless the client misconfigured the txn, the deadline can
+			// only be expired if the txn has been pushed, and pushed Serializable
+			// transactions are detected above.
+			return EvalResult{}, roachpb.NewTransactionStatusError(
+				"transaction deadline exceeded")
+		}
+
 		reply.Txn.Status = roachpb.COMMITTED
 	} else {
 		reply.Txn.Status = roachpb.ABORTED

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -855,16 +855,16 @@ func isEndTransactionTriggeringRetryError(
 
 	isTxnPushed := currentTxn.Timestamp != headerTxn.OrigTimestamp
 
-	// If pushing requires a retry and the transaction was pushed, retry.
-	if headerTxn.RetryOnPush && isTxnPushed {
-		return true, roachpb.RETRY_DELETE_RANGE
-	}
-
 	// If the isolation level is SERIALIZABLE, return a transaction
 	// retry error if the commit timestamp isn't equal to the txn
 	// timestamp.
 	if headerTxn.Isolation == enginepb.SERIALIZABLE && isTxnPushed {
 		return true, roachpb.RETRY_SERIALIZABLE
+	}
+
+	// If pushing requires a retry and the transaction was pushed, retry.
+	if headerTxn.RetryOnPush && isTxnPushed {
+		return true, roachpb.RETRY_DELETE_RANGE
 	}
 
 	return false, 0

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -3564,6 +3564,87 @@ func TestEndTransactionDeadline(t *testing.T) {
 	}
 }
 
+// Test that, when a pushed Snapshot txn would get a "deadline exceeded" error,
+// a Serializable one would get a serializable restart instead. In other words,
+// for Serializable transactions, regular push retriable errors take precedence
+// over the deadline check.
+func TestSerializableDeadline(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tc := testContext{}
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	tc.Start(t, stopper)
+
+	const expectedTransactionStatusError int = 1
+	const expectedTransactionRestartError int = 2
+
+	tests := []struct {
+		isoLevel        enginepb.IsolationType
+		expectedErrType int
+		expectedErrMsg  string
+	}{{
+		isoLevel:        enginepb.SNAPSHOT,
+		expectedErrType: expectedTransactionStatusError,
+		expectedErrMsg:  "TransactionStatusError: transaction deadline exceeded",
+	}, {
+		isoLevel:        enginepb.SERIALIZABLE,
+		expectedErrType: expectedTransactionRestartError,
+		expectedErrMsg:  "TransactionRetryError: retry txn \\(RETRY_SERIALIZABLE\\)",
+	}}
+	for i, test := range tests {
+		t.Run(test.isoLevel.String(), func(t *testing.T) {
+			key := roachpb.Key("key: " + strconv.Itoa(i))
+			// Start our txn. It will be pushed next.
+			txn := newTransaction("test txn", key, roachpb.MinUserPriority,
+				test.isoLevel, tc.Clock())
+			beginTxn, header := beginTxnArgs(key, txn)
+			if _, pErr := tc.SendWrappedWith(header, &beginTxn); pErr != nil {
+				t.Fatal(pErr.GoError())
+			}
+
+			tc.manualClock.Increment(100)
+			pusher := newTransaction(
+				"test pusher", key, roachpb.MaxUserPriority,
+				enginepb.SERIALIZABLE, tc.Clock())
+			pushReq := pushTxnArgs(pusher, txn, roachpb.PUSH_TIMESTAMP)
+			pushReq.Now = tc.Clock().Now()
+			resp, pErr := tc.SendWrapped(&pushReq)
+			if pErr != nil {
+				t.Fatal(pErr)
+			}
+			updatedPushee := resp.(*roachpb.PushTxnResponse).PusheeTxn
+			if updatedPushee.Status != roachpb.PENDING {
+				t.Fatalf("expected pushee to still be alive, but got %+v", updatedPushee)
+			}
+
+			// Send an EndTransaction with a deadline below the point where the txn
+			// has been pushed.
+			etArgs, etHeader := endTxnArgs(txn, true /* commit */)
+			deadline := updatedPushee.Timestamp
+			deadline.Logical--
+			etArgs.Deadline = &deadline
+			_, pErr = tc.SendWrappedWith(etHeader, &etArgs)
+			if pErr == nil {
+				t.Fatalf("expected %q, got: nil", test.expectedErrMsg)
+			}
+			err := pErr.GoError()
+			if test.expectedErrType == expectedTransactionStatusError {
+				if _, ok := err.(*roachpb.TransactionStatusError); !ok ||
+					!testutils.IsError(err, test.expectedErrMsg) {
+					t.Fatalf("expected %q, got: %s (%T)", test.expectedErrMsg,
+						err, err)
+				}
+			} else {
+				if _, ok := pErr.GetDetail().(*roachpb.TransactionRetryError); !ok ||
+					!testutils.IsError(err, test.expectedErrMsg) {
+					t.Fatalf("expected %q, got: %s (%T)", test.expectedErrMsg,
+						err, pErr.GetDetail())
+				}
+			}
+		})
+	}
+}
+
 // TestTxnSpanGCThreshold verifies that aborting transactions which haven't
 // written their initial txn record yet does not lead to anomalies. Precisely,
 // verify that if the GC queue could potentially have removed a txn record


### PR DESCRIPTION
Cherry-pick of #18804
cc @cockroachdb/release 

Before this patch, if a Serializable txn was pushed and the push caused
the txn to exceed its deadline, the client would get a "deadline
exceeded" error back. What the client should have gotten is the
retriable error, as that would allow it to retry. This patch fixes this
by inverting the order of error generation. As a result, Serializable
txns shouldn't see "deadline exceeded" errors any more.

Touches #18684