### PR TITLE
util/log: parse logs assuming UTC

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -344,7 +344,7 @@ func (d *EntryDecoder) Decode(entry *Entry) error {
 			continue
 		}
 		entry.Severity = Severity(strings.IndexByte(severityChar, m[1][0]) + 1)
-		t, err := time.ParseInLocation("060102 15:04:05.999999", string(m[2]), time.Local)
+		t, err := time.Parse("060102 15:04:05.999999", string(m[2]))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
72d005482 switched every `time.Unix` to `timeutil.Unix`, including the call in `formatLogEntry` thus changed the `time.Time` passed to `formatHeader` to have a UTC location instead of Local, meaning the log timestamps switched to being printed in UTC rather than the host's local TZ.

This is actually likely desireable in a distributed system, as it makes correlating events across nodes in a geographically diverse cluster easier, but it broke our parsing of the logs, which assumed local.

We probably shouldn't assume any particular offset anyway when reading a log file that might have been written with a different offset. We could add explicit offsets, to avoid assuming anything, but as mentioned above, just switching to UTC everywhere has other benefits too.