### PR TITLE
cherrypick-1.1: util/log: parse logs assuming UTC

### DIFF
--- a/build/style_test.go
+++ b/build/style_test.go
@@ -222,7 +222,7 @@ func TestStyle(t *testing.T) {
 
 		if err := stream.ForEach(stream.Sequence(
 			filter,
-			stream.GrepNot(`^util/(log|syncutil|timeutil|tracing)/\w+\.go\b`),
+			stream.GrepNot(`^util/(syncutil|timeutil|tracing)/\w+\.go\b`),
 		), func(s string) {
 			t.Errorf(`%s <- forbidden; use "timeutil" instead`, s)
 		}); err != nil {

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -13,6 +13,7 @@ build/builder.sh env \
 	github-pull-request-make
 
 build/builder.sh env \
+	TZ=America/New_York \
 	make test \
 	TESTFLAGS='-v' \
 	2>&1 \

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -344,7 +344,7 @@ func (d *EntryDecoder) Decode(entry *Entry) error {
 			continue
 		}
 		entry.Severity = Severity(strings.IndexByte(severityChar, m[1][0]) + 1)
-		t, err := time.ParseInLocation("060102 15:04:05.999999", string(m[2]), time.Local)
+		t, err := time.Parse("060102 15:04:05.999999", string(m[2]))
 		if err != nil {
 			return err
 		}

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -717,7 +717,7 @@ func (l *loggingT) putBuffer(b *buffer) {
 // are added to the entry before marshaling.
 func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string) {
 	// Set additional details in log entry.
-	now := time.Now()
+	now := timeutil.Now()
 	entry := MakeEntry(s, now.UnixNano(), file, line, msg)
 
 	if f, ok := l.interceptor.Load().(InterceptorFn); ok && f != nil {
@@ -878,7 +878,7 @@ func (sb *syncBuffer) Sync() error {
 
 func (sb *syncBuffer) Write(p []byte) (n int, err error) {
 	if sb.nbytes+int64(len(p)) >= atomic.LoadInt64(&LogFileMaxSize) {
-		if err := sb.rotateFile(time.Now()); err != nil {
+		if err := sb.rotateFile(timeutil.Now()); err != nil {
 			sb.logger.exit(err)
 		}
 	}
@@ -976,7 +976,7 @@ func (l *loggingT) closeFileLocked() error {
 // createFile creates the log file.
 // l.mu is held.
 func (l *loggingT) createFile() error {
-	now := time.Now()
+	now := timeutil.Now()
 	if l.file == nil {
 		sb := &syncBuffer{
 			logger: l,

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kr/pretty"
 
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 // Test that shortHostname works as advertised.
@@ -151,7 +152,7 @@ func TestEntryDecoder(t *testing.T) {
 		return buf.String()
 	}
 
-	t1 := time.Now().Round(time.Microsecond)
+	t1 := timeutil.Now().Round(time.Microsecond)
 	t2 := t1.Add(time.Microsecond)
 	t3 := t2.Add(time.Microsecond)
 	t4 := t3.Add(time.Microsecond)
@@ -776,7 +777,7 @@ func TestFileSeverityFilter(t *testing.T) {
 
 func BenchmarkHeader(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		buf := formatHeader(Severity_INFO, time.Now(), 200, "file.go", 100, nil)
+		buf := formatHeader(Severity_INFO, timeutil.Now(), 200, "file.go", 100, nil)
 		logging.putBuffer(buf)
 	}
 }

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 var (
@@ -63,7 +64,7 @@ var (
 
 	// startTime records when the process started so that crash reports can
 	// include the server's uptime as an extra tag.
-	startTime = time.Now()
+	startTime = timeutil.Now()
 )
 
 // TODO(dt): this should be split from the report interval.
@@ -284,7 +285,7 @@ func sendCrashReport(
 	// automatically fill in the machine's hostname.
 	packet.ServerName = "<redacted>"
 	tags := map[string]string{
-		"uptime": uptimeTag(time.Now()),
+		"uptime": uptimeTag(timeutil.Now()),
 	}
 	eventID, ch := raven.DefaultClient.Capture(packet, tags)
 	select {

--- a/pkg/util/log/file_test.go
+++ b/pkg/util/log/file_test.go
@@ -27,9 +27,9 @@ import (
 // advertised.
 func TestLogFilenameParsing(t *testing.T) {
 	testCases := []time.Time{
-		time.Now(),
-		time.Now().AddDate(-10, 0, 0),
-		time.Now().AddDate(0, 0, -1),
+		timeutil.Now(),
+		timeutil.Now().AddDate(-10, 0, 0),
+		timeutil.Now().AddDate(0, 0, -1),
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
72d005482 switched `formatLogEntry` to use `timeutil.Unix` and thus changed the `time.Time` passed to `formatHeader` to have a UTC location, meaning the log timestamps switched to being printed in UTC rather than the host's local TZ.

This is actually likely desireable in a distributed system, as it makes correlating events across nodes in a geographically diverse cluster easier, but it broke our parsing of the logs, which assumed local.

We probably shouldn't assume any particular offset anyway when reading a log file that might have been written with a different offset. We could add explicit offsets, to avoid assuming anything, but as mentioned above, just switching to UTC everywhere has other benefits too.# Please enter the commit message for your changes. Lines starting