### PR TITLE
storage: add TestProposalOverhead

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -174,8 +174,14 @@ func evaluateCommand(
 
 	// If a unittest filter was installed, check for an injected error; otherwise, continue.
 	if filter := rec.StoreTestingKnobs().TestingEvalFilter; filter != nil {
-		filterArgs := storagebase.FilterArgs{Ctx: ctx, CmdID: raftCmdID, Index: index,
-			Sid: rec.StoreID(), Req: args, Hdr: h}
+		filterArgs := storagebase.FilterArgs{
+			Ctx:   ctx,
+			CmdID: raftCmdID,
+			Index: index,
+			Sid:   rec.StoreID(),
+			Req:   args,
+			Hdr:   h,
+		}
 		if pErr := filter(filterArgs); pErr != nil {
 			log.Infof(ctx, "test injecting error: %s", pErr)
 			return EvalResult{}, pErr

--- a/pkg/storage/storagebase/base.go
+++ b/pkg/storage/storagebase/base.go
@@ -32,6 +32,14 @@ type FilterArgs struct {
 	Hdr   roachpb.Header
 }
 
+// ProposalFilterArgs groups the arguments to ReplicaProposalFilter.
+type ProposalFilterArgs struct {
+	Ctx   context.Context
+	Cmd   RaftCommand
+	CmdID CmdIDKey
+	Req   roachpb.BatchRequest
+}
+
 // ApplyFilterArgs groups the arguments to a ReplicaApplyFilter.
 type ApplyFilterArgs struct {
 	ReplicatedEvalResult
@@ -51,6 +59,10 @@ func (f *FilterArgs) InRaftCmd() bool {
 // nil to continue with regular processing or non-nil to terminate processing
 // with the returned error.
 type ReplicaCommandFilter func(args FilterArgs) *roachpb.Error
+
+// ReplicaProposalFilter can be used in testing to influence the error returned
+// from proposals after a request is evaluated but before it is proposed.
+type ReplicaProposalFilter func(args ProposalFilterArgs) *roachpb.Error
 
 // A ReplicaApplyFilter can be used in testing to influence the error returned
 // from proposals after they apply.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -644,7 +644,7 @@ type StoreConfig struct {
 // an error (which aborts all further processing for the command).
 type StoreTestingKnobs struct {
 	// TestingProposalFilter is called before proposing each command.
-	TestingProposalFilter storagebase.ReplicaCommandFilter
+	TestingProposalFilter storagebase.ReplicaProposalFilter
 
 	// TestingEvalFilter is called before evaluating each command. The
 	// number of times this callback is run depends on the propEvalKV


### PR DESCRIPTION
Rework StoreConfig.TestingProposalFilter to take a ProposalFilterArgs
which contains the actual proposal.

Fixes #18738