### PR TITLE
sql: fix handling of errors on Commit and Rollback 

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1402,7 +1402,13 @@ func (e *Executor) execStmtInAbortedTxn(
 	switch s := stmt.AST.(type) {
 	case *parser.CommitTransaction, *parser.RollbackTransaction:
 		if txnState.State() == RestartWait {
-			return rollbackSQLTransaction(txnState, res)
+			transition := rollbackSQLTransaction(txnState, res)
+			if transition.transitionDependentOnErrType {
+				log.Fatal(session.Ctx(), "transitionDependentOnErrType should not be "+
+					"returned by rollbackSQLTransaction")
+			}
+			txnState.resetStateAndTxn(transition.targetState)
+			return transition.err
 		}
 		// Reset the state to allow new transactions to start.
 		// The KV txn has already been rolled back when we entered the Aborted state.
@@ -1547,6 +1553,9 @@ func (e *Executor) execStmtInOpenTxn(
 
 	sessionEventf(session, "%s", stmt)
 
+	var explicitStateTransition bool
+	var transition stateTransition
+
 	// Do not double count automatically retried transactions.
 	if automaticRetryCount == 0 {
 		e.updateStmtCounts(stmt)
@@ -1554,7 +1563,28 @@ func (e *Executor) execStmtInOpenTxn(
 
 	// After the statement is executed, we might have to do state transitions.
 	defer func() {
-		if err != nil {
+		// There's two cases to handle, depending on the two categories of
+		// statements we have:
+		// - Some statements (COMMIT, ROLLBACK) explicitly decide what state
+		// transition they want. For them, explicitStateTransition is set and
+		// transition is filled in, and so we obey their instructions.
+		// - Most statements don't set explicitStateTransition. For them we do state
+		// transitions based on the error they returned (if any).
+
+		if explicitStateTransition {
+			if err != nil {
+				panic(fmt.Sprintf("unexpected return err when explicitStateTransition is set: %+v", err))
+			}
+			err = transition.err
+			if transition.transitionDependentOnErrType {
+				if err == nil {
+					panic(fmt.Sprintf("missing err when transitionDependentOnErrType is set"))
+				}
+				err = txnState.updateStateAndCleanupOnErr(err, e)
+			} else {
+				txnState.resetStateAndTxn(transition.targetState)
+			}
+		} else if err != nil {
 			if !txnState.TxnIsOpen() {
 				panic(fmt.Sprintf("unexpected txnState when cleaning up: %v", txnState.State()))
 			}
@@ -1563,9 +1593,17 @@ func (e *Executor) execStmtInOpenTxn(
 			if firstInTxn && isBegin(stmt) {
 				// A failed BEGIN statement that was starting a txn doesn't leave the
 				// txn in the Aborted state; we transition back to NoTxn.
+				//
+				// TODO(andrei): BEGIN should use the explicitStateTransition mechanism.
 				txnState.resetStateAndTxn(NoTxn)
 			}
-		} else if txnState.State() == AutoRetry && txnState.isSerializableRestart() {
+		}
+
+		if err != nil {
+			return
+		}
+
+		if txnState.State() == AutoRetry && txnState.isSerializableRestart() {
 			// If we just ran a statement synchronously, then the parallel queue
 			// would have been synchronized first, so this would be a no-op.
 			// However, if we just ran a statement asynchronously, then the
@@ -1630,7 +1668,9 @@ func (e *Executor) execStmtInOpenTxn(
 	case *parser.CommitTransaction:
 		// CommitTransaction is executed fully here; there's no planNode for it
 		// and a planner is not involved at all.
-		return commitSQLTransaction(txnState, commit, res)
+		transition = commitSQLTransaction(txnState, commit, res)
+		explicitStateTransition = true
+		return nil
 
 	case *parser.ReleaseSavepoint:
 		if err := parser.ValidateRestartCheckpoint(s.Savepoint); err != nil {
@@ -1638,7 +1678,9 @@ func (e *Executor) execStmtInOpenTxn(
 		}
 		// ReleaseSavepoint is executed fully here; there's no planNode for it
 		// and a planner is not involved at all.
-		return commitSQLTransaction(txnState, release, res)
+		transition = commitSQLTransaction(txnState, release, res)
+		explicitStateTransition = true
+		return nil
 
 	case *parser.RollbackTransaction:
 		// Turn off test verification of metadata changes made by the
@@ -1646,7 +1688,9 @@ func (e *Executor) execStmtInOpenTxn(
 		session.testingVerifyMetadataFn = nil
 		// RollbackTransaction is executed fully here; there's no planNode for it
 		// and a planner is not involved at all.
-		return rollbackSQLTransaction(txnState, res)
+		transition = rollbackSQLTransaction(txnState, res)
+		explicitStateTransition = true
+		return nil
 
 	case *parser.Savepoint:
 		if err := parser.ValidateRestartCheckpoint(s.Name); err != nil {
@@ -1789,12 +1833,35 @@ func stmtAllowedInImplicitTxn(stmt Statement) bool {
 	return false
 }
 
+// stateTransition allows statement execution to request state transitions as a
+// side-effect of their execution. Currently only specific statements use this
+// mechanism; the majority rely on the handling of the errors they return to
+// affect state transitions.
+type stateTransition struct {
+	// transitionDependentOnErrType, if set, means that the error should be
+	// interpreted to decide on the state transition (e.g. retriable errors may
+	// cause different transitions than non-retriable errors).
+	// If set, err must also be set, and targetSet is ignored.
+	transitionDependentOnErrType bool
+	// err is used by statements to inform that their execution encountered an
+	// error. The error will be eventually passed to pgwire, which serializes it
+	// to the client.
+	// The error can be a communication error (e.g. sending results to the client
+	// failed); these errors will be recognized by pgwire and the connection will
+	// be terminated.
+	err error
+
+	// targetState is the state to which we'll transition.
+	targetState TxnStateEnum
+}
+
 // rollbackSQLTransaction executes a ROLLBACK statement. The transaction is
 // rolled-back and the statement result is written to res.
 //
-// No matter what happens with the statement execution, the session state is
-// moved to NoTxn.
-func rollbackSQLTransaction(txnState *txnState, res StatementResult) error {
+// Returns the desired state transition. Since ROLLBACK is not concerned with
+// retriable errors, stateTransition.transitionDependentOnErrType is guaranteed
+// to be false.
+func rollbackSQLTransaction(txnState *txnState, res StatementResult) stateTransition {
 	if !txnState.TxnIsOpen() && txnState.State() != RestartWait {
 		panic(fmt.Sprintf("rollbackSQLTransaction called on txn in wrong state: %s (txn: %s)",
 			txnState.State(), txnState.mu.txn.Proto()))
@@ -1802,17 +1869,18 @@ func rollbackSQLTransaction(txnState *txnState, res StatementResult) error {
 	err := txnState.mu.txn.Rollback(txnState.Ctx)
 	if err != nil {
 		log.Warningf(txnState.Ctx, "txn rollback failed: %s", err)
-		txnState.resetStateAndTxn(NoTxn)
-		res.BeginResult((*parser.RollbackTransaction)(nil))
-		if closeErr := res.CloseResult(); closeErr != nil {
-			return closeErr
-		}
-		return err
 	}
 	// We're done with this txn.
-	txnState.resetStateAndTxn(NoTxn)
 	res.BeginResult((*parser.RollbackTransaction)(nil))
-	return res.CloseResult()
+	if closeErr := res.CloseResult(); closeErr != nil {
+		return stateTransition{
+			targetState: Aborted,
+			err:         closeErr,
+		}
+	}
+	return stateTransition{
+		targetState: NoTxn,
+	}
 }
 
 type commitType int
@@ -1822,9 +1890,12 @@ const (
 	release
 )
 
-// commitSqlTransaction executes a COMMIT or RELEASE SAVEPOINT statement. The
-// transaction is committed and results are writtern to res.
-func commitSQLTransaction(txnState *txnState, commitType commitType, res StatementResult) error {
+// commitSQLTransaction executes a COMMIT or RELEASE SAVEPOINT statement. The
+// transaction is committed and the statement result is written to res.
+func commitSQLTransaction(
+	txnState *txnState, commitType commitType, res StatementResult,
+) stateTransition {
+
 	if !txnState.TxnIsOpen() {
 		panic(fmt.Sprintf("commitSqlTransaction called on non-open txn: %+v", txnState.mu.txn))
 	}
@@ -1835,21 +1906,40 @@ func commitSQLTransaction(txnState *txnState, commitType commitType, res Stateme
 		// Errors on COMMIT need special handling: if the errors is not handled by
 		// auto-retry, COMMIT needs to finalize the transaction (it can't leave it
 		// in Aborted or RestartWait). Higher layers will handle this with the help
-		// of `txnState.commitSeen`, set above.
-		return err
+		// of `txnState.commitSeen`, set above. As far as the layer interpreting our
+		// stateTransition is concerned, transitionDependentOnErrType is the right
+		// thing to do without concern for the special nature of COMMIT.
+		return stateTransition{
+			transitionDependentOnErrType: true,
+			err: err,
+		}
 	}
 
+	var transition stateTransition
 	switch commitType {
 	case release:
 		// We'll now be waiting for a COMMIT.
-		txnState.resetStateAndTxn(CommitWait)
+		transition.targetState = CommitWait
 	case commit:
 		// We're done with this txn.
-		txnState.resetStateAndTxn(NoTxn)
+		transition.targetState = NoTxn
 	}
 
 	res.BeginResult((*parser.CommitTransaction)(nil))
-	return res.CloseResult()
+	if err := res.CloseResult(); err != nil {
+		transition = stateTransition{
+			err: err,
+			// The state after a communication error doesn't really matter, as the
+			// session will not receive more statements. We're using Aborted for
+			// consistency with most error code paths which don't have special
+			// handling for communication errors at the Executor level.
+			//
+			// TODO(andrei): Introduce a dedicated state to represent broken sessions
+			// that should not accept any statement anymore.
+			targetState: Aborted,
+		}
+	}
+	return transition
 }
 
 // exectDistSQL converts a classic plan to a distributed SQL physical plan and

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1689,9 +1689,6 @@ func (e *Executor) execStmtInOpenTxn(
 			txnState.mu.txn.Proto().Restart(
 				0 /* userPriority */, 0 /* upgradePriority */, hlc.Timestamp{})
 		}
-		if err != nil {
-			return err
-		}
 		return nil
 
 	case *parser.Prepare:
@@ -1793,7 +1790,10 @@ func stmtAllowedInImplicitTxn(stmt Statement) bool {
 }
 
 // rollbackSQLTransaction executes a ROLLBACK statement. The transaction is
-// rolled-back results are written to res. All errors are swallowed.
+// rolled-back and the statement result is written to res.
+//
+// No matter what happens with the statement execution, the session state is
+// moved to NoTxn.
 func rollbackSQLTransaction(txnState *txnState, res StatementResult) error {
 	if !txnState.TxnIsOpen() && txnState.State() != RestartWait {
 		panic(fmt.Sprintf("rollbackSQLTransaction called on txn in wrong state: %s (txn: %s)",

--- a/pkg/sql/session_test.go
+++ b/pkg/sql/session_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,8 +27,11 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -219,5 +223,80 @@ func TestNonRetriableErrorOnAutoCommit(t *testing.T) {
 	}
 	if state != "NoTxn" {
 		t.Fatalf("expected state %s, got: %s", "NoTxn", state)
+	}
+}
+
+// Test that, if a ROLLBACK statement encounters an error, the error is not
+// returned to the client and the session state is transitioned to NoTxn.
+func TestErrorOnRollback(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const targetKeyString string = "/Table/51/1/1/0"
+	var injectedErr int64
+
+	// We're going to inject an error into our EndTransaction.
+	params := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &storage.StoreTestingKnobs{
+				TestingProposalFilter: func(fArgs storagebase.ProposalFilterArgs) *roachpb.Error {
+					if !fArgs.Req.IsSingleRequest() {
+						return nil
+					}
+					req := fArgs.Req.Requests[0]
+					etReq, ok := req.GetInner().(*roachpb.EndTransactionRequest)
+					// We only inject the error once. Turns out that during the life of
+					// the test there's two EndTransactions being sent - one is the direct
+					// result of the test's call to tx.Rollback(), the second is sent by
+					// the TxnCoordSender - indirectly triggered by the fact that, on the
+					// server side, the transaction's context gets cancelled at the SQL
+					// layer.
+					if ok &&
+						etReq.Header().Key.String() == targetKeyString &&
+						atomic.LoadInt64(&injectedErr) == 0 {
+
+						atomic.StoreInt64(&injectedErr, 1)
+						return roachpb.NewErrorf("test injected error")
+					}
+					return nil
+				},
+			},
+		},
+	}
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Perform a write so that the EndTransaction we're going to send doesn't get
+	// elided.
+	if _, err := tx.Exec("INSERT INTO t.test(k, v) VALUES (1, 'abc')"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tx.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
+	var state string
+	if err := sqlDB.QueryRow("SHOW TRANSACTION STATUS").Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if state != "NoTxn" {
+		t.Fatalf("expected state %s, got: %s", "NoTxn", state)
+	}
+
+	if atomic.LoadInt64(&injectedErr) == 0 {
+		t.Fatal("test didn't inject the error; it must have failed to find " +
+			"the EndTransaction with the expected key")
 	}
 }


### PR DESCRIPTION
Fixes #18853

Ever since we've introduced results streaming, there's been great
ambiguity about the handling of errors that happen on commit and
rollback statements. The execution of these statements didn't use to
return any errors ever, but that has changed because result streaming
introduced the possibility of communication error happening during
statement execution, and these errors can never be swallowed (and so we
also stopped swallowing other errors at the time).
Because COMMIT and ROLLBACK do their own state transitions, the fact
that they started returning an error confused a higher layer
(execStmtInOpenTxn()) which also does state transitions when it sees
errors. That crashed.

This patch resolves the problem by establishing a protocol for state
transitions such that particular statements can coordinate with
execStmtInOpenTxn() around the needed transitions. COMMIT and ROLLBACK
use this mechanism to inform the higher layers that they have sometimes
taken care of all transitions.
Morally, this change is in the spirit of envisioned future changes to
the session state machine: state transitions should/will be centralized
into one level of the code, not sprinkled everywhere.