### PR TITLE
storage/engine: reduce allocations in RocksDBBatchReader

### DIFF
--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -52,11 +52,11 @@ func VerifyBatchRepr(
 		for r.Next() {
 			switch r.BatchType() {
 			case engine.BatchTypeValue:
-				mvccKey, err := engine.DecodeKey(r.UnsafeKey())
+				mvccKey, err := r.MVCCKey()
 				if err != nil {
 					return enginepb.MVCCStats{}, errors.Wrapf(err, "verifying key/value checksums")
 				}
-				v := roachpb.Value{RawBytes: r.UnsafeValue()}
+				v := roachpb.Value{RawBytes: r.Value()}
 				if err := v.Verify(mvccKey.Key); err != nil {
 					return enginepb.MVCCStats{}, err
 				}

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -261,12 +261,12 @@ func TestBatchRepr(t *testing.T) {
 			}
 			switch r.BatchType() {
 			case BatchTypeDeletion:
-				ops = append(ops, fmt.Sprintf("delete(%s)", string(r.UnsafeKey())))
+				ops = append(ops, fmt.Sprintf("delete(%s)", string(r.Key())))
 			case BatchTypeValue:
-				ops = append(ops, fmt.Sprintf("put(%s,%s)", string(r.UnsafeKey()), string(r.UnsafeValue())))
+				ops = append(ops, fmt.Sprintf("put(%s,%s)", string(r.Key()), string(r.Value())))
 			case BatchTypeMerge:
 				// The merge value is a protobuf and not easily displayable.
-				ops = append(ops, fmt.Sprintf("merge(%s)", string(r.UnsafeKey())))
+				ops = append(ops, fmt.Sprintf("merge(%s)", string(r.Key())))
 			}
 		}
 		if err != nil {
@@ -1140,7 +1140,7 @@ func TestDecodeKey(t *testing.T) {
 			if !r.Next() {
 				t.Fatalf("could not get the first entry: %+v", r.Error())
 			}
-			decodedKey, err := DecodeKey(r.UnsafeKey())
+			decodedKey, err := DecodeKey(r.Key())
 			if err != nil {
 				t.Fatalf("unexpected err: %+v", err)
 			}


### PR DESCRIPTION
Rather than use a bytes.Reader for reading the batch repr, read from a
[]byte. This allows us to return safe slices from
RocksDBBatchReader.{Key,Value} and removes the need to temporarily copy
the key and value.