### PR TITLE
sql/sqlbase: convert txnKVFetcher to use roachpb.KeyValue

### DIFF
--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -87,13 +87,11 @@ type spanKVFetcher struct {
 }
 
 // nextKV implements the kvFetcher interface.
-func (f *spanKVFetcher) nextKV(ctx context.Context) (bool, client.KeyValue, error) {
+func (f *spanKVFetcher) nextKV(ctx context.Context) (bool, roachpb.KeyValue, error) {
 	if len(f.kvs) == 0 {
-		return false, client.KeyValue{}, nil
+		return false, roachpb.KeyValue{}, nil
 	}
-	var kv client.KeyValue
-	kv.Key = f.kvs[0].Key
-	kv.Value = &f.kvs[0].Value
+	kv := f.kvs[0]
 	f.kvs = f.kvs[1:]
 	return true, kv, nil
 }

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1827,9 +1827,9 @@ func encodeArrayElement(b []byte, d parser.Datum) ([]byte, error) {
 // expected by the column. An error is returned if the value's type does not
 // match the column's type.
 func UnmarshalColumnValue(
-	a *DatumAlloc, typ ColumnType, value *roachpb.Value,
+	a *DatumAlloc, typ ColumnType, value roachpb.Value,
 ) (parser.Datum, error) {
-	if value == nil {
+	if value.RawBytes == nil {
 		return parser.DNull, nil
 	}
 


### PR DESCRIPTION
For historical reasons, txnKVFetcher was converting roachpb.KeyValue
into client.KeyValue. Switch to using roachpb.KeyValue to avoid the
conversion.

Switch to using the count of keys in the response header instead of
asking for the length of returned key/value pairs slice which results in
slightly simpler code.