### PR TITLE
build: adjust build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,9 @@ $(ARCHIVE).tmp: .buildinfo/tag .buildinfo/rev .buildinfo/basebranch
 # For details, see the "Possible timestamp problems with diff-files?" thread on
 # the Git mailing list (http://marc.info/?l=git&m=131687596307197).
 .buildinfo/tag: | .buildinfo
-	@{ git describe --tags --dirty 2> /dev/null || git rev-parse --short HEAD; } | tr -d \\n > $@
+	@{ git describe --tags --exact-match 2>/dev/null || \
+	  echo v1.x-unstable.$$(git show -s --date=format:'%Y%m%d' --format=%cd HEAD)-$$(git rev-parse --short HEAD); } | \
+	  tr -d \\n > $@
 
 .buildinfo/basebranch: | .buildinfo
 	@git describe --tags --abbrev=0 | tr -d \\n > $@


### PR DESCRIPTION
Current master reports the build tag as
`v1.1-alpha.20170817-1197-g081f0bab8`. This is quite confusing given
that the most recent 1.1 release is actually v1.1-beta.20170928. Switch
back to using `git describe --exact-match` and generate our own tag
format: `unstable-<date>-<sha>`. With this change, the build tag is
reported as: `unstable-20170929-081f0bab8`.