### PR TITLE
util: clear interval trees instead of remaking them

### DIFF
--- a/pkg/util/interval/btree_based_interval.go
+++ b/pkg/util/interval/btree_based_interval.go
@@ -915,3 +915,8 @@ func (t *btree) Iterator() TreeIterator {
 	}
 	return &ti
 }
+
+func (t *btree) Clear() {
+	t.root = nil
+	t.length = 0
+}

--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -205,5 +205,5 @@ func NewTree(overlapper Overlapper) Tree {
 	if useBTreeImpl {
 		return newBTree(overlapper)
 	}
-	return newLLBRTree(overlapper)
+	return newLLRBTree(overlapper)
 }

--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -187,6 +187,8 @@ type Tree interface {
 	// Iterator creates an iterator to iterate over all intervals stored in the
 	// tree, in-order.
 	Iterator() TreeIterator
+	// Clear this tree.
+	Clear()
 }
 
 // TreeIterator iterates over all intervals stored in the interval tree, in-order.

--- a/pkg/util/interval/llrb_based_interval.go
+++ b/pkg/util/interval/llrb_based_interval.go
@@ -652,3 +652,8 @@ func (t *llrbTree) Iterator() TreeIterator {
 	}
 	return &ti
 }
+
+func (t *llrbTree) Clear() {
+	t.Root = nil
+	t.Count = 0
+}

--- a/pkg/util/interval/llrb_based_interval.go
+++ b/pkg/util/interval/llrb_based_interval.go
@@ -37,8 +37,8 @@ type llrbTree struct {
 	Overlapper Overlapper
 }
 
-// newLLBRTree creates a new interval tree with the given overlapper function.
-func newLLBRTree(overlapper Overlapper) *llrbTree {
+// newLLRBTree creates a new interval tree with the given overlapper function.
+func newLLRBTree(overlapper Overlapper) *llrbTree {
 	return &llrbTree{Overlapper: overlapper}
 }
 

--- a/pkg/util/interval/range_group.go
+++ b/pkg/util/interval/range_group.go
@@ -439,7 +439,7 @@ func (rt *rangeTree) Sub(r Range) bool {
 
 // Clear implements RangeGroup. It clears all rangeKeys from the rangeTree.
 func (rt *rangeTree) Clear() {
-	rt.t = NewTree(InclusiveOverlapper)
+	rt.t.Clear()
 }
 
 // Overlaps implements RangeGroup. It returns whether the provided


### PR DESCRIPTION
getPrereqs was previously re-allocating a new interval tree on every
invocation, leading to a ton of unnecessary allocations. Instead, clear
the trees and reuse.

Before (single node, local cockroach on my laptop):

```
[11:44]% ./kv --read-percent=100 -duration=10s
_elapsed___errors__ops/sec(inst)___ops/sec(cum)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
      1s        0        17173.0        17172.3      0.7      2.4      5.2     21.0                                                                                 2s        0        16875.8        17024.4      0.7      2.4      5.0     14.2
      3s        0        17726.1        17258.2      0.7      2.5      4.7     21.0
      4s        0        18471.3        17561.4      0.7      2.1      4.1     23.1
      5s        0        18155.4        17680.2      0.7      2.2      4.1     19.9
      6s        0        17294.9        17615.8      0.7      2.5      4.7     14.7
      7s        0        17936.0        17661.4      0.7      2.4      4.5     18.9
      8s        0        18453.5        17760.5      0.7      2.2      4.2     21.0
      9s        0        18362.3        17827.3      0.7      2.2      4.1     14.2
     10s        0        17157.9        17760.2      0.7      2.6      4.7     22.0

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
   10.0s        0         177680        17760.0      0.9      0.7      2.4      4.5     23.1
```

After:

```
[11:44]% ./kv --read-percent=100 -duration=10s
_elapsed___errors__ops/sec(inst)___ops/sec(cum)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
      1s        0        18881.5        18880.9      0.7      2.0      3.5     12.1
      2s        0        18681.9        18781.8      0.7      2.0      4.5     11.5
      3s        0        18828.3        18797.3      0.7      2.0      4.2     18.9
      4s        0        18210.8        18650.5      0.7      2.2      4.5     15.2
      5s        0        18669.0        18654.2      0.7      2.0      4.2     21.0
      6s        0        18046.1        18552.9      0.7      2.2      4.5     18.9
      7s        0        18198.9        18502.4      0.7      2.2      4.1     17.8
      8s        0        18181.0        18462.2      0.7      2.2      4.2     19.9
      9s        0        17430.0        18347.5      0.7      2.4      4.7     15.7
     10s        0        17380.4        18250.8      0.7      2.4      4.7     25.2

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
   10.0s        0         182540        18250.9      0.9      0.7      2.2      4.5     25.2
```