### PR TITLE
*: add protoutil.MarshalTo

### DIFF
--- a/pkg/config/migration_test.go
+++ b/pkg/config/migration_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/gogo/protobuf/proto"
 )
 
@@ -26,7 +27,7 @@ func TestMigrateZoneConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testCases := []struct {
-		input, want proto.Message
+		input, want protoutil.Message
 	}{
 		{
 			&ZoneConfig{

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -848,7 +848,7 @@ func (g *Gossip) addInfoLocked(key string, val []byte, ttl time.Duration) error 
 
 // AddInfoProto adds or updates an info object. Returns an error if info
 // couldn't be added.
-func (g *Gossip) AddInfoProto(key string, msg proto.Message, ttl time.Duration) error {
+func (g *Gossip) AddInfoProto(key string, msg protoutil.Message, ttl time.Duration) error {
 	bytes, err := protoutil.Marshal(msg)
 	if err != nil {
 		return err

--- a/pkg/internal/client/util.go
+++ b/pkg/internal/client/util.go
@@ -19,11 +19,10 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
-
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
 // TODO(pmattis): The methods in this file needs tests.
@@ -83,7 +82,7 @@ func marshalValue(v interface{}) (roachpb.Value, error) {
 		err := r.SetDuration(t)
 		return r, err
 
-	case proto.Message:
+	case protoutil.Message:
 		err := r.SetProto(t)
 		return r, err
 

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -365,39 +365,21 @@ func (v *Value) SetInt(i int64) {
 // SetProto encodes the specified proto message into the bytes field of the
 // receiver and clears the checksum. If the proto message is an
 // InternalTimeSeriesData, the tag will be set to TIMESERIES rather than BYTES.
-func (v *Value) SetProto(msg proto.Message) error {
-	// Fast-path for when the proto implements MarshalTo and Size (i.e. all of
-	// our protos). The fast-path marshals directly into the Value.RawBytes field
-	// instead of allocating a separate []byte and copying.
-	type marshalTo interface {
-		MarshalTo(data []byte) (int, error)
-		Size() int
-	}
-	if m, ok := msg.(marshalTo); ok {
-		size := m.Size()
-		v.RawBytes = make([]byte, headerSize+size)
-		// NB: This call to protoutil.Interceptor would be more natural
-		// encapsulated in protoutil.MarshalTo, yet that approach imposes a
-		// significant (~30%) slowdown. It is unclear why. See
-		// BenchmarkValueSetProto.
-		protoutil.Interceptor(msg)
-		if _, err := m.MarshalTo(v.RawBytes[headerSize:]); err != nil {
-			return err
-		}
-		// Special handling for timeseries data.
-		if _, ok := msg.(*InternalTimeSeriesData); ok {
-			v.setTag(ValueType_TIMESERIES)
-		} else {
-			v.setTag(ValueType_BYTES)
-		}
-		return nil
-	}
-
-	data, err := protoutil.Marshal(msg)
-	if err != nil {
+func (v *Value) SetProto(msg protoutil.Message) error {
+	// All of the Cockroach protos implement MarshalTo and Size. So we marshal
+	// directly into the Value.RawBytes field instead of allocating a separate
+	// []byte and copying.
+	size := msg.Size()
+	v.RawBytes = make([]byte, headerSize+size)
+	if _, err := protoutil.MarshalTo(msg, v.RawBytes[headerSize:]); err != nil {
 		return err
 	}
-	v.SetBytes(data)
+	// Special handling for timeseries data.
+	if _, ok := msg.(*InternalTimeSeriesData); ok {
+		v.setTag(ValueType_TIMESERIES)
+	} else {
+		v.setTag(ValueType_BYTES)
+	}
 	return nil
 }
 

--- a/pkg/storage/below_raft_protos_test.go
+++ b/pkg/storage/below_raft_protos_test.go
@@ -98,7 +98,7 @@ func TestBelowRaftProtos(t *testing.T) {
 
 	slice := make([]byte, 1<<20)
 	for typ, fix := range belowRaftGoldenProtos {
-		if b, err := protoutil.Marshal(reflect.New(typ.Elem()).Interface().(proto.Message)); err != nil {
+		if b, err := protoutil.Marshal(reflect.New(typ.Elem()).Interface().(protoutil.Message)); err != nil {
 			t.Fatal(err)
 		} else if err := verifyHash(b, fix.emptySum); err != nil {
 			t.Errorf("%s (empty): %s\n", typ, err)

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -278,7 +278,9 @@ type Stats struct {
 // PutProto sets the given key to the protobuf-serialized byte string
 // of msg and the provided timestamp. Returns the length in bytes of
 // key and the value.
-func PutProto(engine Writer, key MVCCKey, msg proto.Message) (keyBytes, valBytes int64, err error) {
+func PutProto(
+	engine Writer, key MVCCKey, msg protoutil.Message,
+) (keyBytes, valBytes int64, err error) {
 	bytes, err := protoutil.Marshal(msg)
 	if err != nil {
 		return 0, 0, err

--- a/pkg/storage/engine/merge_test.go
+++ b/pkg/storage/engine/merge_test.go
@@ -46,7 +46,7 @@ func gibberishString(n int) string {
 	return string(b)
 }
 
-func mustMarshal(m proto.Message) []byte {
+func mustMarshal(m protoutil.Message) []byte {
 	b, err := protoutil.Marshal(m)
 	if err != nil {
 		panic(err)

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -452,7 +452,7 @@ func MVCCGetProto(
 	timestamp hlc.Timestamp,
 	consistent bool,
 	txn *roachpb.Transaction,
-	msg proto.Message,
+	msg protoutil.Message,
 ) (bool, error) {
 	// TODO(tschottdorf): Consider returning skipped intents to the caller.
 	value, _, mvccGetErr := MVCCGet(ctx, engine, key, timestamp, consistent, txn)
@@ -478,7 +478,7 @@ func MVCCPutProto(
 	key roachpb.Key,
 	timestamp hlc.Timestamp,
 	txn *roachpb.Transaction,
-	msg proto.Message,
+	msg protoutil.Message,
 ) error {
 	value := roachpb.Value{}
 	if err := value.SetProto(msg); err != nil {
@@ -847,8 +847,7 @@ func (b *putBuffer) marshalMeta(meta *enginepb.MVCCMetadata) (_ []byte, err erro
 	} else {
 		data = data[:size]
 	}
-	protoutil.Interceptor(meta)
-	n, err := meta.MarshalTo(data)
+	n, err := protoutil.MarshalTo(meta, data)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3322,15 +3322,6 @@ func TestFindBalancedSplitKeys(t *testing.T) {
 	}
 }
 
-// encodedSize returns the encoded size of the protobuf message.
-func encodedSize(msg proto.Message, t *testing.T) int64 {
-	data, err := protoutil.Marshal(msg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return int64(len(data))
-}
-
 func verifyStats(debug string, ms, expMS *enginepb.MVCCStats, t *testing.T) {
 	if ms.ContainsEstimates != expMS.ContainsEstimates {
 		t.Errorf("%s: mvcc contains estimates %t; expected %t", debug, ms.ContainsEstimates, expMS.ContainsEstimates)
@@ -3423,11 +3414,11 @@ func TestMVCCStatsBasic(t *testing.T) {
 	if err := MVCCDelete(context.Background(), engine, ms, key, ts2, txn); err != nil {
 		t.Fatal(err)
 	}
-	m2ValSize := encodedSize(&enginepb.MVCCMetadata{
+	m2ValSize := int64((&enginepb.MVCCMetadata{
 		Timestamp: enginepb.LegacyTimestamp(ts2),
 		Deleted:   true,
 		Txn:       &txn.TxnMeta,
-	}, t)
+	}).Size())
 	v2KeySize := mvccVersionTimestampSize
 	v2ValSize := int64(0)
 
@@ -3483,10 +3474,10 @@ func TestMVCCStatsBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 	mKey2Size := int64(mvccKey(key2).EncodedSize())
-	mVal2Size := encodedSize(&enginepb.MVCCMetadata{
+	mVal2Size := int64((&enginepb.MVCCMetadata{
 		Timestamp: enginepb.LegacyTimestamp(ts4),
 		Txn:       &txn.TxnMeta,
-	}, t)
+	}).Size())
 	vKey2Size := mvccVersionTimestampSize
 	vVal2Size := int64(len(value2.RawBytes))
 	expMS3 := enginepb.MVCCStats{
@@ -3587,7 +3578,7 @@ func TestMVCCStatsBasic(t *testing.T) {
 		t.Fatal(err)
 	}
 	txnKeySize := int64(mvccKey(txnKey).EncodedSize())
-	txnValSize := encodedSize(&enginepb.MVCCMetadata{RawBytes: txnVal.RawBytes}, t)
+	txnValSize := int64((&enginepb.MVCCMetadata{RawBytes: txnVal.RawBytes}).Size())
 	expMS6 := expMS5
 	expMS6.SysBytes += txnKeySize + txnValSize
 	expMS6.SysCount++

--- a/pkg/storage/track_raft_protos.go
+++ b/pkg/storage/track_raft_protos.go
@@ -20,8 +20,6 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/gogo/protobuf/proto"
-
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -56,7 +54,7 @@ func TrackRaftProtos() func() []reflect.Type {
 		inner: make(map[reflect.Type]struct{}),
 	}
 
-	protoutil.Interceptor = func(pb proto.Message) {
+	protoutil.Interceptor = func(pb protoutil.Message) {
 		t := reflect.TypeOf(pb)
 
 		// Special handling for MVCCMetadata: we expect MVCCMetadata to be
@@ -105,7 +103,7 @@ func TrackRaftProtos() func() []reflect.Type {
 	}
 
 	return func() []reflect.Type {
-		protoutil.Interceptor = func(_ proto.Message) {}
+		protoutil.Interceptor = func(_ protoutil.Message) {}
 
 		belowRaftProtos.Lock()
 		types := make([]reflect.Type, 0, len(belowRaftProtos.inner))

--- a/pkg/util/protoutil/marshaler.go
+++ b/pkg/util/protoutil/marshaler.go
@@ -37,7 +37,7 @@ func (*ProtoPb) ContentType() string {
 
 // Marshal implements gwruntime.Marshaler.
 func (*ProtoPb) Marshal(v interface{}) ([]byte, error) {
-	if p, ok := v.(proto.Message); ok {
+	if p, ok := v.(Message); ok {
 		return Marshal(p)
 	}
 	return nil, errors.Errorf("unexpected type %T does not implement %s", v, typeProtoMessage)
@@ -83,7 +83,7 @@ func (*ProtoPb) NewEncoder(w io.Writer) gwruntime.Encoder {
 
 // Encode implements gwruntime.Marshaler.
 func (e *protoEncoder) Encode(v interface{}) error {
-	if p, ok := v.(proto.Message); ok {
+	if p, ok := v.(Message); ok {
 		bytes, err := Marshal(p)
 		if err == nil {
 			_, err = e.w.Write(bytes)


### PR DESCRIPTION
Get rid of the few random calls to protoutil.Interceptor by using
protoutil.MarshalTo. Previously this had not been done because of an
observed slowdown in BenchmarkValueSetProto. This slow down was caused
by the additional interface conversions. Avoid such conversions by
adding protoutil.Message which extends proto.Message with MarshalTo and
Size methods. Note that justification for this change is the removal of
the random calls to protoutil.Interceptor, not the small performance
improvement.

name             old time/op  new time/op  delta
ValueSetProto-8  45.3ns ± 6%  38.0ns ± 3%  -15.94%  (p=0.000 n=10+9)