### PR TITLE
cherrypick 1.1: sql: fix stale txn deadline

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -345,7 +345,7 @@ func makeBackupDescriptor(
 		opt := client.TxnExecOptions{AutoRetry: true, AutoCommit: true}
 		err := txn.Exec(ctx, opt, func(ctx context.Context, txn *client.Txn, opt *client.TxnExecOptions) error {
 			var err error
-			txn.SetFixedTimestamp(endTime)
+			txn.SetFixedTimestamp(ctx, endTime)
 			sqlDescs, err = allSQLDescriptors(ctx, txn)
 			return err
 		})
@@ -753,7 +753,7 @@ func backupResumeHook(typ jobs.Type) func(context.Context, *jobs.Job) error {
 			txn := client.NewTxn(job.DB(), 0 /* gatewayNodeID */)
 			opt := client.TxnExecOptions{AutoRetry: true, AutoCommit: true}
 			if err := txn.Exec(ctx, opt, func(ctx context.Context, txn *client.Txn, opt *client.TxnExecOptions) error {
-				txn.SetFixedTimestamp(details.EndTime)
+				txn.SetFixedTimestamp(ctx, details.EndTime)
 				for _, sqlDescID := range job.Payload().DescriptorIDs {
 					desc := &sqlbase.Descriptor{}
 					descKey := sqlbase.MakeDescMetadataKey(sqlDescID)

--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
@@ -45,7 +44,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 // testUser has valid client certs.
@@ -941,7 +939,8 @@ func TestInconsistentReads(t *testing.T) {
 }
 
 // TestReadOnlyTxnObeysDeadline tests that read-only transactions obey the
-// deadline.
+// deadline. Read-only transactions have their EndTransaction elided, so the
+// enforcement of the deadline is done in the client.
 func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
@@ -953,16 +952,27 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	}
 
 	txn := client.NewTxn(db, 0 /* gatewayNodeID */)
+	// Only snapshot transactions can observe deadline errors; serializable ones
+	// get a restart error before the deadline check.
+	if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
+		t.Fatal(err)
+	}
 	opts := client.TxnExecOptions{
 		AutoRetry:  false,
 		AutoCommit: true,
 	}
-	if err := txn.Exec(context.TODO(), opts, func(ctx context.Context, txn *client.Txn, _ *client.TxnExecOptions) error {
-		// Set deadline to sometime in the past.
-		txn.UpdateDeadlineMaybe(hlc.Timestamp{WallTime: timeutil.Now().Add(-time.Second).UnixNano()})
-		_, err := txn.Get(ctx, "k")
-		return err
-	}); !testutils.IsError(err, "txn aborted") {
+	if err := txn.Exec(
+		context.TODO(), opts,
+		func(ctx context.Context, txn *client.Txn, _ *client.TxnExecOptions) error {
+			// Set a deadline, then set a higher commit timestamp for the txn.
+			txn.UpdateDeadlineMaybe(ctx, s.Clock().Now())
+			txn.Proto().Timestamp.Forward(s.Clock().Now())
+			_, err := txn.Get(ctx, "k")
+			return err
+		}); !testutils.IsError(err, "txn aborted") {
+		// We test for TransactionAbortedError. If this was not a read-only txn,
+		// the error returned by the server would have been different - a
+		// TransactionStatusError. This inconsistency is unfortunate.
 		t.Fatal(err)
 	}
 }

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -470,20 +470,20 @@ func TestTxnCoordSenderEndTxn(t *testing.T) {
 
 			case 1:
 				// Past deadline.
-				if !txn.UpdateDeadlineMaybe(pushedTimestamp.Prev()) {
+				if !txn.UpdateDeadlineMaybe(context.TODO(), pushedTimestamp.Prev()) {
 					t.Fatalf("did not update deadline")
 				}
 
 			case 2:
 				// Equal deadline.
-				if !txn.UpdateDeadlineMaybe(pushedTimestamp) {
+				if !txn.UpdateDeadlineMaybe(context.TODO(), pushedTimestamp) {
 					t.Fatalf("did not update deadline")
 				}
 
 			case 3:
 				// Future deadline.
 
-				if !txn.UpdateDeadlineMaybe(pushedTimestamp.Next()) {
+				if !txn.UpdateDeadlineMaybe(context.TODO(), pushedTimestamp.Next()) {
 					t.Fatalf("did not update deadline")
 				}
 			}

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -206,7 +206,7 @@ func (ib *indexBackfiller) runChunk(
 
 	var entries []sqlbase.IndexEntry
 	if err := ib.flowCtx.clientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		txn.SetFixedTimestamp(readAsOf)
+		txn.SetFixedTimestamp(ctx, readAsOf)
 
 		var err error
 		entries, err = buildIndexEntries(ctx, txn)

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -540,7 +540,7 @@ func (e *Executor) Prepare(
 
 	if protoTS != nil {
 		planner.avoidCachedDescriptors = true
-		txn.SetFixedTimestamp(*protoTS)
+		txn.SetFixedTimestamp(session.Ctx(), *protoTS)
 	}
 
 	if filter := e.cfg.TestingKnobs.BeforePrepare; filter != nil {
@@ -910,6 +910,9 @@ func (e *Executor) execParsed(
 				}
 			}
 
+			// Release any leases the transaction(s) may have used.
+			session.tables.releaseTables(session.Ctx())
+
 			// Exec the schema changers (if the txn rolled back, the schema changers
 			// will short-circuit because the corresponding descriptor mutation is not
 			// found).
@@ -1001,9 +1004,8 @@ func runWithAutoRetry(
 
 	var err error
 	for {
-
 		if protoTS != nil {
-			txnState.mu.txn.SetFixedTimestamp(*protoTS)
+			txnState.mu.txn.SetFixedTimestamp(session.Ctx(), *protoTS)
 		}
 		// Some results may have been produced by a previous attempt.
 		txnState.txnResults.Reset(session.Ctx())

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -419,7 +419,7 @@ func (s LeaseStore) getForExpiration(
 		descKey := sqlbase.MakeDescMetadataKey(id)
 		prevTimestamp := expiration
 		prevTimestamp.WallTime--
-		txn.SetFixedTimestamp(prevTimestamp)
+		txn.SetFixedTimestamp(ctx, prevTimestamp)
 		var desc sqlbase.Descriptor
 		if err := txn.GetProto(ctx, descKey, &desc); err != nil {
 			return err
@@ -1225,7 +1225,7 @@ func (m *LeaseManager) resolveName(
 	key := nameKey.Key()
 	id := sqlbase.InvalidID
 	if err := m.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		txn.SetFixedTimestamp(timestamp)
+		txn.SetFixedTimestamp(ctx, timestamp)
 		gr, err := txn.Get(ctx, key)
 		if err != nil {
 			return err

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -87,7 +87,8 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}
 
 	if !validExpirationTime(lease.ExpirationTime) {
-		t.Fatalf("invalid expiration time: %s", timeutil.Unix(0, lease.ExpirationTime))
+		t.Fatalf("invalid expiration time: %s. now: %s",
+			timeutil.Unix(0, lease.ExpirationTime), timeutil.Now())
 	}
 
 	// Acquiring another lease will fail.
@@ -152,7 +153,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 func validExpirationTime(expirationTime int64) bool {
 	now := timeutil.Now()
-	return expirationTime > now.Add(sql.LeaseDuration/2).UnixNano() && expirationTime < now.Add(sql.LeaseDuration*3/2).UnixNano()
+	return expirationTime > now.Add(sql.SchemaChangeLeaseDuration/2).UnixNano() && expirationTime < now.Add(sql.SchemaChangeLeaseDuration*3/2).UnixNano()
 }
 
 func TestSchemaChangeProcess(t *testing.T) {

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1243,6 +1243,7 @@ func (ts *txnState) updateStateAndCleanupOnErr(err error, e *Executor) error {
 		// Note that TransactionAborted is also a retriable error, handled here;
 		// in this case cleanup for the txn has been done for us under the hood.
 		ts.SetState(RestartWait)
+		ts.mu.txn.ResetDeadline()
 	}
 	return err
 }
@@ -1314,8 +1315,6 @@ func (scc *schemaChangerCollection) queueSchemaChanger(schemaChanger SchemaChang
 func (scc *schemaChangerCollection) execSchemaChanges(
 	ctx context.Context, e *Executor, session *Session,
 ) error {
-	// Release the leases once a transaction is complete.
-	session.tables.releaseTables(ctx)
 	if e.cfg.SchemaChangerTestingKnobs.SyncFilter != nil {
 		e.cfg.SchemaChangerTestingKnobs.SyncFilter(TestingSchemaChangerCollection{scc})
 	}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -268,7 +268,6 @@ type TableCollection struct {
 // of a transaction retry.
 func (tc *TableCollection) resetForTxnRetry(ctx context.Context, txn *client.Txn) {
 	if tc.timestamp != (hlc.Timestamp{}) && tc.timestamp != txn.OrigTimestamp() {
-		txn.ResetDeadline()
 		tc.releaseTables(ctx)
 	}
 }
@@ -369,7 +368,7 @@ func (tc *TableCollection) getTableVersion(
 
 	// If the table we just acquired expires before the txn's deadline, reduce
 	// the deadline.
-	txn.UpdateDeadlineMaybe(expiration)
+	txn.UpdateDeadlineMaybe(ctx, expiration)
 	return table, nil
 }
 
@@ -431,7 +430,7 @@ func (tc *TableCollection) getTableVersionByID(
 
 	// If the table we just acquired expires before the txn's deadline, reduce
 	// the deadline.
-	txn.UpdateDeadlineMaybe(expiration)
+	txn.UpdateDeadlineMaybe(ctx, expiration)
 	return table, nil
 }
 


### PR DESCRIPTION
cc @cockroachdb/release 

Touches #18684

Before this patch, we were relying on TableCollection to reset a txn's
deadline when it detected that the transaction had restarted and a new
set of descriptors needed to be acquired. However, there was a bug:
Executor.execSchemaChanges() would reset the TableCollection in a way
that prevented it from resetting the txn deadline in the future (the
idea is that tc.timestamp was being set to nil, which disarmed the txn
deadline reset code).
This meant that the txn continued with the old deadline after restarting
and so, if it ended up being pushed above the original deadline, it
couldn't commit.

This patch moves the deadline reset out of TableCollection, into the
Executor. The TableCollection's role in resetting the deadline was
questionable to begin with (as opposed to the TC's role in _updating_
the timestamp; that one is good). Now the reset is tied to a SQL
transaction restart.