### PR TITLE
build/deploy: install root CAs in docker image

### DIFF
--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -2,6 +2,13 @@ FROM debian:8.9
 
 MAINTAINER Tobias Schottdorf <tobias.schottdorf@gmail.com>
 
+# Install root CAs so we can make SSL connections to phone home and
+# do backups to GCE/AWS/Azure.
+RUN apt-get update && \
+	apt-get -y upgrade && \
+	apt-get install -y ca-certificates  && \
+	rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /cockroach
 COPY cockroach.sh cockroach /cockroach/
 # Set working directory so that relative paths


### PR DESCRIPTION
Fixes #18905