### PR TITLE
roachpb: {RSpan|RangeDescriptor}.ContainsExclusiveEndKey -> ContainsKeyInverted

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1019,7 +1019,7 @@ func (ds *DistSender) deduceRetryEarlyExitError(ctx context.Context) *roachpb.Er
 
 func includesFrontOfCurSpan(isReverse bool, rd *roachpb.RangeDescriptor, rs roachpb.RSpan) bool {
 	if isReverse {
-		return rd.ContainsExclusiveEndKey(rs.EndKey)
+		return rd.ContainsKeyInverted(rs.EndKey)
 	}
 	return rd.ContainsKey(rs.Key)
 }

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -424,7 +424,7 @@ func mockRangeDescriptorDBForDescs(descs ...roachpb.RangeDescriptor) MockRangeDe
 		for _, desc := range descs {
 			contains := desc.ContainsKey
 			if useReverseScan {
-				contains = desc.ContainsExclusiveEndKey
+				contains = desc.ContainsKeyInverted
 			}
 			if contains(key) {
 				matchingDescs = append(matchingDescs, desc)

--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -377,7 +377,7 @@ func (rdc *RangeDescriptorCache) lookupRangeDescriptorInternal(
 	if desc := lookupRes.desc; desc != nil {
 		containsFn := (*roachpb.RangeDescriptor).ContainsKey
 		if useReverseScan {
-			containsFn = (*roachpb.RangeDescriptor).ContainsExclusiveEndKey
+			containsFn = (*roachpb.RangeDescriptor).ContainsKeyInverted
 		}
 		if !containsFn(desc, key) {
 			return nil, evictToken, errors.Errorf("key %q not contained in range lookup's "+
@@ -535,7 +535,7 @@ func (rdc *RangeDescriptorCache) getCachedRangeDescriptorLocked(
 
 	containsFn := (*roachpb.RangeDescriptor).ContainsKey
 	if inclusive {
-		containsFn = (*roachpb.RangeDescriptor).ContainsExclusiveEndKey
+		containsFn = (*roachpb.RangeDescriptor).ContainsKeyInverted
 	}
 
 	// Return nil if the key does not belong to the range.

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -233,7 +233,7 @@ func doLookupWithToken(
 	if err != nil {
 		t.Fatal(err)
 	}
-	if (useReverseScan && !r.ContainsExclusiveEndKey(keyAddr)) || (!useReverseScan && !r.ContainsKey(keyAddr)) {
+	if (useReverseScan && !r.ContainsKeyInverted(keyAddr)) || (!useReverseScan && !r.ContainsKey(keyAddr)) {
 		t.Fatalf("Returned range did not contain key: %s-%s, %s", r.StartKey, r.EndKey, key)
 	}
 	return r, returnToken
@@ -683,7 +683,7 @@ func testRangeCacheHandleDoubleSplit(t *testing.T, useReverseScan bool) {
 				break
 			}
 			if useReverseScan {
-				if !desc.ContainsExclusiveEndKey(key) {
+				if !desc.ContainsKeyInverted(key) {
 					t.Errorf("desc %s does not contain exclusive end key %s", desc, key)
 				}
 			} else {

--- a/pkg/kv/range_iter.go
+++ b/pkg/kv/range_iter.go
@@ -192,7 +192,7 @@ func (ri *RangeIterator) Seek(ctx context.Context, key roachpb.RKey, scanDir Sca
 		// TODO: this code is subject to removal. See
 		// https://groups.google.com/d/msg/cockroach-db/DebjQEgU9r4/_OhMe7atFQAJ
 		reverse := ri.scanDir == Descending
-		if (reverse && !ri.desc.ContainsExclusiveEndKey(ri.key)) ||
+		if (reverse && !ri.desc.ContainsKeyInverted(ri.key)) ||
 			(!reverse && !ri.desc.ContainsKey(ri.key)) {
 			log.Eventf(ctx, "addressing error: %s does not include key %s", ri.desc, ri.key)
 			if err := ri.token.Evict(ctx); err != nil {

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1215,10 +1215,10 @@ func (rs RSpan) ContainsKey(key RKey) bool {
 	return bytes.Compare(key, rs.Key) >= 0 && bytes.Compare(key, rs.EndKey) < 0
 }
 
-// ContainsExclusiveEndKey returns whether this span contains the specified key.
-// A span is considered to include its EndKey (e.g., span ["a", b") contains
-// "b" according to this function, but does not contain "a").
-func (rs RSpan) ContainsExclusiveEndKey(key RKey) bool {
+// ContainsKeyInverted returns whether this span contains the specified key. The
+// receiver span is considered inverted, meaning that instead of containing the
+// range ["key","endKey"), it contains the range ("key","endKey"].
+func (rs RSpan) ContainsKeyInverted(key RKey) bool {
 	return bytes.Compare(key, rs.Key) > 0 && bytes.Compare(key, rs.EndKey) <= 0
 }
 

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -719,9 +719,9 @@ func TestRSpanContains(t *testing.T) {
 	}
 }
 
-// TestRSpanContainsExclusiveEndKey verifies ContainsExclusiveEndKey to check whether a key
-// or key range is contained within the span.
-func TestRSpanContainsExclusiveEndKey(t *testing.T) {
+// TestRSpanContainsKeyInverted verifies ContainsKeyInverted to check whether a key
+// is contained within the span.
+func TestRSpanContainsKeyInverted(t *testing.T) {
 	rs := RSpan{Key: []byte("b"), EndKey: []byte("c")}
 
 	testData := []struct {
@@ -736,7 +736,7 @@ func TestRSpanContainsExclusiveEndKey(t *testing.T) {
 		{RKey("c").Next(), false},
 	}
 	for i, test := range testData {
-		if rs.ContainsExclusiveEndKey(test.key) != test.contains {
+		if rs.ContainsKeyInverted(test.key) != test.contains {
 			t.Errorf("%d: expected key %q within range", i, test.key)
 		}
 	}

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -108,9 +108,10 @@ func (r RangeDescriptor) ContainsKey(key RKey) bool {
 	return r.RSpan().ContainsKey(key)
 }
 
-// ContainsExclusiveEndKey returns whether this RangeDescriptor contains the specified end key.
-func (r RangeDescriptor) ContainsExclusiveEndKey(key RKey) bool {
-	return r.RSpan().ContainsExclusiveEndKey(key)
+// ContainsKeyInverted returns whether this RangeDescriptor contains the
+// specified key using an inverted range. See RSpan.ContainsKeyInverted.
+func (r RangeDescriptor) ContainsKeyInverted(key RKey) bool {
+	return r.RSpan().ContainsKeyInverted(key)
 }
 
 // ContainsKeyRange returns whether this RangeDescriptor contains the specified

--- a/pkg/sql/distsqlplan/span_resolver.go
+++ b/pkg/sql/distsqlplan/span_resolver.go
@@ -268,7 +268,7 @@ func (it *spanResolverIterator) Seek(
 	if it.dir == oldDir && it.it.Valid() {
 		reverse := (it.dir == kv.Descending)
 		desc := it.it.Desc()
-		if (reverse && desc.ContainsExclusiveEndKey(seekKey)) ||
+		if (reverse && desc.ContainsKeyInverted(seekKey)) ||
 			(!reverse && desc.ContainsKey(seekKey)) {
 			if log.V(1) {
 				log.Infof(ctx, "not seeking (key=%s); existing descriptor %s", seekKey, desc)

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1291,7 +1291,7 @@ func evalRangeLookup(
 	userKey := keys.UserKey(key)
 	containsFn := roachpb.RangeDescriptor.ContainsKey
 	if args.Reverse {
-		containsFn = roachpb.RangeDescriptor.ContainsExclusiveEndKey
+		containsFn = roachpb.RangeDescriptor.ContainsKeyInverted
 	}
 
 	for _, kv := range kvs {


### PR DESCRIPTION
This was just straight up wrong. At the very least it should have been
`ContainsInclusiveEndKey` since that was the entire point, but even still,
that doesn't describe the inverted behavior of the range's start key.

```
gorename -from '"github.com/cockroachdb/cockroach/pkg/roachpb".RSpan.ContainsExclusiveEndKey' -to ContainsKeyInverted
gorename -from '"github.com/cockroachdb/cockroach/pkg/roachpb".RangeDescriptor.ContainsExclusiveEndKey' -to ContainsKeyInverted
```