### PR TITLE
*: add protoutil.Unmarshal

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
@@ -108,7 +107,7 @@ func readBackupDescriptor(
 		return BackupDescriptor{}, err
 	}
 	var backupDesc BackupDescriptor
-	if err := proto.Unmarshal(descBytes, &backupDesc); err != nil {
+	if err := protoutil.Unmarshal(descBytes, &backupDesc); err != nil {
 		return BackupDescriptor{}, err
 	}
 	return backupDesc, err

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -558,7 +557,7 @@ func TestBackupRestoreCheckpointing(t *testing.T) {
 			return errors.Errorf("%+v", err)
 		}
 		var checkpointDesc sqlccl.BackupDescriptor
-		if err := proto.Unmarshal(checkpointDescBytes, &checkpointDesc); err != nil {
+		if err := protoutil.Unmarshal(checkpointDescBytes, &checkpointDesc); err != nil {
 			return errors.Errorf("%+v", err)
 		}
 		if len(checkpointDesc.Files) == 0 {
@@ -579,7 +578,7 @@ func TestBackupRestoreCheckpointing(t *testing.T) {
 			return err
 		}
 		var payload jobs.Payload
-		if err := proto.Unmarshal(payloadBytes, &payload); err != nil {
+		if err := protoutil.Unmarshal(payloadBytes, &payload); err != nil {
 			return err
 		}
 		switch d := payload.Details.(type) {
@@ -707,7 +706,7 @@ func TestBackupRestoreResume(t *testing.T) {
 			t.Fatal(err)
 		}
 		var backupDescriptor sqlccl.BackupDescriptor
-		if err := proto.Unmarshal(backupDescriptorBytes, &backupDescriptor); err != nil {
+		if err := protoutil.Unmarshal(backupDescriptorBytes, &backupDescriptor); err != nil {
 			t.Fatal(err)
 		}
 		for _, file := range backupDescriptor.Files {
@@ -1589,7 +1588,7 @@ func TestBackupRestoreChecksum(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if err := proto.Unmarshal(backupDescBytes, &backupDesc); err != nil {
+		if err := protoutil.Unmarshal(backupDescBytes, &backupDesc); err != nil {
 			t.Fatalf("%+v", err)
 		}
 	}

--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -16,7 +16,6 @@ import (
 	"io"
 	"math/rand"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -83,7 +82,7 @@ func Load(
 		return BackupDescriptor{}, errors.Wrap(err, "fetch database descriptor")
 	}
 	var dbDescWrapper sqlbase.Descriptor
-	if err := proto.Unmarshal(dbDescBytes, &dbDescWrapper); err != nil {
+	if err := protoutil.Unmarshal(dbDescBytes, &dbDescWrapper); err != nil {
 		return BackupDescriptor{}, errors.Wrap(err, "unmarshal database descriptor")
 	}
 	dbDesc := dbDescWrapper.GetDatabase()

--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/pkg/errors"
 )
 
@@ -63,7 +63,7 @@ func MakeKeyRewriter(rekeys []roachpb.ImportRequest_TableRekey) (*KeyRewriter, e
 	descs := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
 	for _, rekey := range rekeys {
 		var desc sqlbase.Descriptor
-		if err := proto.Unmarshal(rekey.NewDesc, &desc); err != nil {
+		if err := protoutil.Unmarshal(rekey.NewDesc, &desc); err != nil {
 			return nil, errors.Wrapf(err, "unmarshalling rekey descriptor for old table id %d", rekey.OldID)
 		}
 		table := desc.GetTable()

--- a/pkg/ccl/utilccl/licenseccl/license.go
+++ b/pkg/ccl/utilccl/licenseccl/license.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -48,7 +47,7 @@ func Decode(s string) (*License, error) {
 		return nil, errors.Wrap(err, "invalid license string")
 	}
 	var lic License
-	if err := proto.Unmarshal(data, &lic); err != nil {
+	if err := protoutil.Unmarshal(data, &lic); err != nil {
 		return nil, errors.Wrap(err, "invalid license string")
 	}
 	return &lic, nil

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -23,7 +23,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
@@ -48,12 +47,12 @@ var specialZonesByID = map[sqlbase.ID]string{
 	keys.TimeseriesRangesID: timeseriesZoneName,
 }
 
-func unmarshalProto(val driver.Value, msg proto.Message) error {
+func unmarshalProto(val driver.Value, msg protoutil.Message) error {
 	raw, ok := val.([]byte)
 	if !ok {
 		return fmt.Errorf("unexpected value: %T", val)
 	}
-	return proto.Unmarshal(raw, msg)
+	return protoutil.Unmarshal(raw, msg)
 }
 
 func queryZones(conn *sqlConn) (map[sqlbase.ID]config.ZoneConfig, error) {

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -874,12 +874,12 @@ func (g *Gossip) GetInfo(key string) ([]byte, error) {
 
 // GetInfoProto returns an info value by key or KeyNotPresentError if specified
 // key does not exist or has expired.
-func (g *Gossip) GetInfoProto(key string, msg proto.Message) error {
+func (g *Gossip) GetInfoProto(key string, msg protoutil.Message) error {
 	bytes, err := g.GetInfo(key)
 	if err != nil {
 		return err
 	}
-	return proto.Unmarshal(bytes, msg)
+	return protoutil.Unmarshal(bytes, msg)
 }
 
 // InfoOriginatedHere returns true iff the latest info for the provided key

--- a/pkg/internal/client/batch.go
+++ b/pkg/internal/client/batch.go
@@ -368,7 +368,7 @@ func (b *Batch) put(key, value interface{}, inline bool) {
 // and Result.Err will indicate success or failure.
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc).
+// protoutil.Message or any Go primitive type (bool, int, etc).
 func (b *Batch) Put(key, value interface{}) {
 	b.put(key, value, false)
 }
@@ -382,7 +382,7 @@ func (b *Batch) Put(key, value interface{}) {
 // and Result.Err will indicate success or failure.
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc).
+// protoutil.Message or any Go primitive type (bool, int, etc).
 func (b *Batch) PutInline(key, value interface{}) {
 	b.put(key, value, true)
 }
@@ -396,7 +396,7 @@ func (b *Batch) PutInline(key, value interface{}) {
 // and Result.Err will indicate success or failure.
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc).
+// protoutil.Message or any Go primitive type (bool, int, etc).
 func (b *Batch) CPut(key, value, expValue interface{}) {
 	k, err := marshalKey(key)
 	if err != nil {
@@ -423,8 +423,8 @@ func (b *Batch) CPut(key, value, expValue interface{}) {
 // a ConditionFailedError just like a mismatched value.
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc). It is illegal to
-// set value to nil.
+// protoutil.Message or any Go primitive type (bool, int, etc). It is illegal
+// to set value to nil.
 func (b *Batch) InitPut(key, value interface{}, failOnTombstones bool) {
 	k, err := marshalKey(key)
 	if err != nil {

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
@@ -107,7 +107,7 @@ func (kv *KeyValue) ValueInt() int64 {
 }
 
 // ValueProto parses the byte slice value into msg.
-func (kv *KeyValue) ValueProto(msg proto.Message) error {
+func (kv *KeyValue) ValueProto(msg protoutil.Message) error {
 	if kv.Value == nil {
 		msg.Reset()
 		return nil
@@ -220,7 +220,7 @@ func (db *DB) Get(ctx context.Context, key interface{}) (KeyValue, error) {
 // message. If the key doesn't exist, the proto will simply be reset.
 //
 // key can be either a byte slice or a string.
-func (db *DB) GetProto(ctx context.Context, key interface{}, msg proto.Message) error {
+func (db *DB) GetProto(ctx context.Context, key interface{}, msg protoutil.Message) error {
 	r, err := db.Get(ctx, key)
 	if err != nil {
 		return err
@@ -231,7 +231,7 @@ func (db *DB) GetProto(ctx context.Context, key interface{}, msg proto.Message) 
 // Put sets the value for a key.
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc).
+// protoutil.Message or any Go primitive type (bool, int, etc).
 func (db *DB) Put(ctx context.Context, key, value interface{}) error {
 	b := &Batch{}
 	b.Put(key, value)
@@ -244,7 +244,7 @@ func (db *DB) Put(ctx context.Context, key, value interface{}) error {
 // with caution.
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc).
+// protoutil.Message or any Go primitive type (bool, int, etc).
 func (db *DB) PutInline(ctx context.Context, key, value interface{}) error {
 	b := &Batch{}
 	b.PutInline(key, value)
@@ -259,7 +259,7 @@ func (db *DB) PutInline(ctx context.Context, key, value interface{}) error {
 // Returns an error if the existing value is not equal to expValue.
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc).
+// protoutil.Message or any Go primitive type (bool, int, etc).
 func (db *DB) CPut(ctx context.Context, key, value, expValue interface{}) error {
 	b := &Batch{}
 	b.CPut(key, value, expValue)
@@ -272,7 +272,7 @@ func (db *DB) CPut(ctx context.Context, key, value, expValue interface{}) error 
 // mismatched values and will cause a ConditionFailedError.
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc). It is illegal to
+// protoutil.Message or any Go primitive type (bool, int, etc). It is illegal to
 // set value to nil.
 func (db *DB) InitPut(ctx context.Context, key, value interface{}, failOnTombstones bool) error {
 	b := &Batch{}

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -17,7 +17,6 @@ package client
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -27,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -365,7 +365,7 @@ func (txn *Txn) Get(ctx context.Context, key interface{}) (KeyValue, error) {
 // message. If the key doesn't exist, the proto will simply be reset.
 //
 // key can be either a byte slice or a string.
-func (txn *Txn) GetProto(ctx context.Context, key interface{}, msg proto.Message) error {
+func (txn *Txn) GetProto(ctx context.Context, key interface{}, msg protoutil.Message) error {
 	r, err := txn.Get(ctx, key)
 	if err != nil {
 		return err
@@ -376,7 +376,7 @@ func (txn *Txn) GetProto(ctx context.Context, key interface{}, msg proto.Message
 // Put sets the value for a key
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc).
+// protoutil.Message or any Go primitive type (bool, int, etc).
 func (txn *Txn) Put(ctx context.Context, key, value interface{}) error {
 	b := txn.NewBatch()
 	b.Put(key, value)
@@ -391,7 +391,7 @@ func (txn *Txn) Put(ctx context.Context, key, value interface{}) error {
 // Returns an error if the existing value is not equal to expValue.
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc).
+// protoutil.Message or any Go primitive type (bool, int, etc).
 func (txn *Txn) CPut(ctx context.Context, key, value, expValue interface{}) error {
 	b := txn.NewBatch()
 	b.CPut(key, value, expValue)
@@ -404,7 +404,7 @@ func (txn *Txn) CPut(ctx context.Context, key, value, expValue interface{}) erro
 // and will cause a ConditionFailedError.
 //
 // key can be either a byte slice or a string. value can be any key type, a
-// proto.Message or any Go primitive type (bool, int, etc). It is illegal to
+// protoutil.Message or any Go primitive type (bool, int, etc). It is illegal to
 // set value to nil.
 func (txn *Txn) InitPut(ctx context.Context, key, value interface{}, failOnTombstones bool) error {
 	b := txn.NewBatch()

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/rlmcpherson/s3gof3r"
+
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
 // UserPriority is a custom type for transaction's user priority.
@@ -119,7 +120,7 @@ func UpdatesTimestampCache(args Request) bool {
 
 // Request is an interface for RPC requests.
 type Request interface {
-	proto.Message
+	protoutil.Message
 	// Header returns the request header.
 	Header() Span
 	// SetHeader sets the request header.
@@ -152,7 +153,7 @@ func (tlr *TransferLeaseRequest) prevLease() Lease {
 
 // Response is an interface for RPC responses.
 type Response interface {
-	proto.Message
+	protoutil.Message
 	// Header returns the response header.
 	Header() ResponseHeader
 	// SetHeader sets the response header.

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -29,7 +29,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -486,7 +485,7 @@ func (v Value) GetInt() (int64, error) {
 // GetProto unmarshals the bytes field of the receiver into msg. If
 // unmarshalling fails or the tag is not BYTES, an error will be
 // returned.
-func (v Value) GetProto(msg proto.Message) error {
+func (v Value) GetProto(msg protoutil.Message) error {
 	expectedTag := ValueType_BYTES
 
 	// Special handling for ts data.
@@ -497,7 +496,7 @@ func (v Value) GetProto(msg proto.Message) error {
 	if tag := v.GetTag(); tag != expectedTag {
 		return fmt.Errorf("value type is not %s: %s", expectedTag, tag)
 	}
-	return proto.Unmarshal(v.dataBytes(), msg)
+	return protoutil.Unmarshal(v.dataBytes(), msg)
 }
 
 // GetTime decodes a time value from the bytes field of the receiver. If the

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -17,8 +17,9 @@ package security
 import (
 	"crypto/tls"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
 const (
@@ -54,16 +55,16 @@ type RequestWithUser interface {
 
 // ProtoAuthHook builds an authentication hook based on the security
 // mode and client certificate.
-// The proto.Message passed to the hook must implement RequestWithUser.
+// The protoutil.Message passed to the hook must implement RequestWithUser.
 func ProtoAuthHook(
 	insecureMode bool, tlsState *tls.ConnectionState,
-) (func(proto.Message, bool) error, error) {
+) (func(protoutil.Message, bool) error, error) {
 	userHook, err := UserAuthCertHook(insecureMode, tlsState)
 	if err != nil {
 		return nil, err
 	}
 
-	return func(request proto.Message, clientConnection bool) error {
+	return func(request protoutil.Message, clientConnection bool) error {
 		// RequestWithUser must be implemented.
 		requestWithUser, ok := request.(RequestWithUser)
 		if !ok {

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
 // Construct a fake tls.ConnectionState object with one peer certificate
@@ -91,7 +91,7 @@ func TestAuthenticationHook(t *testing.T) {
 	testCases := []struct {
 		insecure           bool
 		tls                *tls.ConnectionState
-		request            proto.Message
+		request            protoutil.Message
 		buildHookSuccess   bool
 		publicHookSuccess  bool
 		privateHookSuccess bool

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -48,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -113,7 +113,7 @@ func (s *adminServer) RegisterGateway(
 //
 // TODO(cdo): Make this work when we have an authentication scheme for the
 // API.
-func (s *adminServer) getUser(_ proto.Message) string {
+func (s *adminServer) getUser(_ protoutil.Message) string {
 	return security.RootUser
 }
 
@@ -1495,7 +1495,7 @@ func (s *adminServer) queryZone(
 	}
 
 	var zone config.ZoneConfig
-	if err := proto.Unmarshal(zoneBytes, &zone); err != nil {
+	if err := protoutil.Unmarshal(zoneBytes, &zone); err != nil {
 		return config.ZoneConfig{}, false, err
 	}
 	return zone, true, nil

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -56,13 +56,13 @@ import (
 )
 
 func getAdminJSONProto(
-	ts serverutils.TestServerInterface, path string, response proto.Message,
+	ts serverutils.TestServerInterface, path string, response protoutil.Message,
 ) error {
 	return serverutils.GetJSONProto(ts, adminPrefix+path, response)
 }
 
 func postAdminJSONProto(
-	ts serverutils.TestServerInterface, path string, request, response proto.Message,
+	ts serverutils.TestServerInterface, path string, request, response protoutil.Message,
 ) error {
 	return serverutils.PostJSONProto(ts, adminPrefix+path, request, response)
 }

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/gogo/protobuf/proto"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -368,7 +367,7 @@ func decodeSessionCookie(encodedCookie *http.Cookie) (*serverpb.SessionCookie, e
 		return nil, errors.Wrap(err, "session cookie could not be decoded")
 	}
 	var sessionCookieValue serverpb.SessionCookie
-	if err := proto.Unmarshal(cookieBytes, &sessionCookieValue); err != nil {
+	if err := protoutil.Unmarshal(cookieBytes, &sessionCookieValue); err != nil {
 		return nil, errors.Wrap(err, "session cookie could not be unmarshalled")
 	}
 	return &sessionCookieValue, nil

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -45,12 +44,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 func getStatusJSONProto(
-	ts serverutils.TestServerInterface, path string, response proto.Message,
+	ts serverutils.TestServerInterface, path string, response protoutil.Message,
 ) error {
 	return serverutils.GetJSONProto(ts, statusPrefix+path, response)
 }

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -38,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -348,7 +348,7 @@ func makeMockRecorder(t *testing.T) *mockRecorder {
 		}
 		rec.last.rawReportBody = string(body)
 		// TODO(dt): switch on the request path to handle different request types.
-		if err := proto.Unmarshal(body, &rec.last.DiagnosticReport); err != nil {
+		if err := protoutil.Unmarshal(body, &rec.last.DiagnosticReport); err != nil {
 			panic(err)
 		}
 	}))

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/pkg/errors"
 )
 
@@ -56,7 +56,7 @@ func (th *testClusterWithHelpers) getVersionFromSelect(i int) string {
 		th.Fatalf("%d: %s (%T)", i, err, err)
 	}
 	var v cluster.ClusterVersion
-	if err := proto.Unmarshal([]byte(version), &v); err != nil {
+	if err := protoutil.Unmarshal([]byte(version), &v); err != nil {
 		th.Fatalf("%d: %s", i, err)
 	}
 	return v.MinimumVersion.String()

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -273,7 +272,7 @@ func versionTransformer(
 		}
 	}
 
-	if err := proto.Unmarshal(curRawProto, &oldV); err != nil {
+	if err := protoutil.Unmarshal(curRawProto, &oldV); err != nil {
 		return nil, nil, err
 	}
 	if versionBump == nil {

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/pkg/errors"
 )
 
@@ -51,7 +51,20 @@ func (d *dummy) Marshal() ([]byte, error) {
 	return []byte(d.msg1 + "." + d.growsbyone), nil
 }
 
-// implement the proto.Message interface
+func (d *dummy) MarshalTo(data []byte) (int, error) {
+	encoded, err := d.Marshal()
+	if err != nil {
+		return 0, err
+	}
+	return copy(data, encoded), nil
+}
+
+func (d *dummy) Size() int {
+	encoded, _ := d.Marshal()
+	return len(encoded)
+}
+
+// implement the protoutil.Message interface
 func (d *dummy) ProtoMessage() {}
 func (d *dummy) Reset()        { *d = dummy{} }
 func (d *dummy) String() string {
@@ -71,7 +84,7 @@ var dummyTransformer = func(sv *settings.Values, old []byte, update *string) ([]
 			return nil, nil, err
 		}
 	}
-	if err := proto.Unmarshal(old, &oldD); err != nil {
+	if err := protoutil.Unmarshal(old, &oldD); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -34,8 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 // Returns an error if a zone config "exists" for the table id.
@@ -59,7 +58,7 @@ func zoneExists(sqlDB *gosql.DB, exists bool, id sqlbase.ID) error {
 			return errors.Errorf("e = %d, v = %d", id, storedID)
 		}
 		var cfg config.ZoneConfig
-		if err := proto.Unmarshal(val, &cfg); err != nil {
+		if err := protoutil.Unmarshal(val, &cfg); err != nil {
 			return err
 		}
 		if e := config.DefaultZoneConfig(); !reflect.DeepEqual(e, cfg) {

--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
@@ -33,8 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 // Job manages logging the progress of long-running system processes, like
@@ -646,7 +645,7 @@ func UnmarshalPayload(datum parser.Datum) (*Payload, error) {
 		return nil, errors.Errorf(
 			"Job: failed to unmarshal payload as DBytes (was %T)", bytes)
 	}
-	if err := proto.Unmarshal([]byte(*bytes), payload); err != nil {
+	if err := protoutil.Unmarshal([]byte(*bytes), payload); err != nil {
 		return nil, err
 	}
 	return payload, nil

--- a/pkg/sql/jobs/jobs_test.go
+++ b/pkg/sql/jobs/jobs_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -33,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/kr/pretty"
 )
@@ -61,7 +61,7 @@ func (expected *expectation) verify(id *int64, expectedStatus jobs.Status) error
 	}
 
 	var payload jobs.Payload
-	if err := proto.Unmarshal(payloadBytes, &payload); err != nil {
+	if err := protoutil.Unmarshal(payloadBytes, &payload); err != nil {
 		return err
 	}
 

--- a/pkg/sql/sqlbase/metadata.go
+++ b/pkg/sql/sqlbase/metadata.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
 var _ DescriptorProto = &DatabaseDescriptor{}
@@ -41,7 +41,7 @@ type DescriptorKey interface {
 // and TableDescriptor.
 // TODO(marc): this is getting rather large.
 type DescriptorProto interface {
-	proto.Message
+	protoutil.Message
 	GetPrivileges() *PrivilegeDescriptor
 	GetID() ID
 	SetID(ID)

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
 // Makes an IndexDescriptor with all columns being ascending.
@@ -1104,7 +1104,7 @@ func TestKeysPerRow(t *testing.T) {
 				`SELECT descriptor FROM system.descriptor ORDER BY id DESC LIMIT 1`)
 			row.Scan(&descBytes)
 			var desc Descriptor
-			if err := proto.Unmarshal(descBytes, &desc); err != nil {
+			if err := protoutil.Unmarshal(descBytes, &desc); err != nil {
 				t.Fatalf("%+v", err)
 			}
 

--- a/pkg/storage/abort_cache.go
+++ b/pkg/storage/abort_cache.go
@@ -17,7 +17,6 @@ package storage
 import (
 	"golang.org/x/net/context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -25,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -160,7 +160,7 @@ func copySeqCache(
 			key := keys.AbortCacheKey(dstID, txnID)
 			encKey := engine.MakeMVCCMetadataKey(key)
 			// Decode the MVCCMetadata value.
-			if err := proto.Unmarshal(kv.Value, &meta); err != nil {
+			if err := protoutil.Unmarshal(kv.Value, &meta); err != nil {
 				return false, errors.Errorf("could not decode mvcc metadata %s [% x]: %s", kv.Key, kv.Value, err)
 			}
 			value := engine.MakeValue(meta)

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -42,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -2338,15 +2338,15 @@ func (ncc *noConfChangeTestHandler) HandleRaftRequest(
 	for i, e := range req.Message.Entries {
 		if e.Type == raftpb.EntryConfChange {
 			var cc raftpb.ConfChange
-			if err := proto.Unmarshal(e.Data, &cc); err != nil {
+			if err := protoutil.Unmarshal(e.Data, &cc); err != nil {
 				panic(err)
 			}
 			var ccCtx storage.ConfChangeContext
-			if err := proto.Unmarshal(cc.Context, &ccCtx); err != nil {
+			if err := protoutil.Unmarshal(cc.Context, &ccCtx); err != nil {
 				panic(err)
 			}
 			var command storagebase.RaftCommand
-			if err := proto.Unmarshal(ccCtx.Payload, &command); err != nil {
+			if err := protoutil.Unmarshal(ccCtx.Payload, &command); err != nil {
 				panic(err)
 			}
 			if req.RangeID == ncc.rangeID {

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -404,10 +404,10 @@ func TestBatchGet(t *testing.T) {
 
 func compareMergedValues(t *testing.T, result, expected []byte) bool {
 	var resultV, expectedV enginepb.MVCCMetadata
-	if err := proto.Unmarshal(result, &resultV); err != nil {
+	if err := protoutil.Unmarshal(result, &resultV); err != nil {
 		t.Fatal(err)
 	}
-	if err := proto.Unmarshal(expected, &expectedV); err != nil {
+	if err := protoutil.Unmarshal(expected, &expectedV); err != nil {
 		t.Fatal(err)
 	}
 	return reflect.DeepEqual(resultV, expectedV)

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -15,7 +15,6 @@
 package engine
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -82,7 +81,7 @@ type Iterator interface {
 	Value() []byte
 	// ValueProto unmarshals the value the iterator is currently
 	// pointing to using a protobuf decoder.
-	ValueProto(msg proto.Message) error
+	ValueProto(msg protoutil.Message) error
 	// Less returns true if the key the iterator is currently positioned at is
 	// less than the specified key.
 	Less(key MVCCKey) bool
@@ -118,7 +117,7 @@ type Reader interface {
 	// using a protobuf decoder. Returns true on success or false if the
 	// key was not found. On success, returns the length in bytes of the
 	// key and the value.
-	GetProto(key MVCCKey, msg proto.Message) (ok bool, keyBytes, valBytes int64, err error)
+	GetProto(key MVCCKey, msg protoutil.Message) (ok bool, keyBytes, valBytes int64, err error)
 	// Iterate scans from start to end keys, visiting at most max
 	// key/value pairs. On each key value pair, the function f is
 	// invoked. If f returns an error or if the scan itself encounters

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -247,7 +247,7 @@ func TestEngineBatch(t *testing.T) {
 				t.Fatal(err)
 			}
 			var m enginepb.MVCCMetadata
-			if err := proto.Unmarshal(b, &m); err != nil {
+			if err := protoutil.Unmarshal(b, &m); err != nil {
 				t.Fatal(err)
 			}
 			if !m.IsInline() {
@@ -453,10 +453,10 @@ func TestEngineMerge(t *testing.T) {
 			}
 			result, _ := engine.Get(tc.testKey)
 			var resultV, expectedV enginepb.MVCCMetadata
-			if err := proto.Unmarshal(result, &resultV); err != nil {
+			if err := protoutil.Unmarshal(result, &resultV); err != nil {
 				t.Fatal(err)
 			}
-			if err := proto.Unmarshal(tc.expected, &expectedV); err != nil {
+			if err := protoutil.Unmarshal(tc.expected, &expectedV); err != nil {
 				t.Fatal(err)
 			}
 			if !reflect.DeepEqual(resultV, expectedV) {

--- a/pkg/storage/engine/merge.go
+++ b/pkg/storage/engine/merge.go
@@ -15,8 +15,6 @@
 package engine
 
 import (
-	"github.com/gogo/protobuf/proto"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -59,7 +57,7 @@ func MergeInternalTimeSeriesData(
 
 	// Unmarshal merged bytes and extract the time series value within.
 	var meta enginepb.MVCCMetadata
-	if err := proto.Unmarshal(mergedBytes, &meta); err != nil {
+	if err := protoutil.Unmarshal(mergedBytes, &meta); err != nil {
 		return roachpb.InternalTimeSeriesData{}, err
 	}
 	mergedTS, err := MakeValue(meta).GetTimeseries()

--- a/pkg/storage/engine/merge_test.go
+++ b/pkg/storage/engine/merge_test.go
@@ -163,10 +163,10 @@ func TestGoMerge(t *testing.T) {
 			continue
 		}
 		var resultV, expectedV enginepb.MVCCMetadata
-		if err := proto.Unmarshal(result, &resultV); err != nil {
+		if err := protoutil.Unmarshal(result, &resultV); err != nil {
 			t.Fatal(err)
 		}
-		if err := proto.Unmarshal(c.expected, &expectedV); err != nil {
+		if err := protoutil.Unmarshal(c.expected, &expectedV); err != nil {
 			t.Fatal(err)
 		}
 		if !reflect.DeepEqual(resultV, expectedV) {
@@ -294,7 +294,7 @@ func TestGoMerge(t *testing.T) {
 // a MVCCMetadata with an inline value.
 func unmarshalTimeSeries(t testing.TB, b []byte) roachpb.InternalTimeSeriesData {
 	var meta enginepb.MVCCMetadata
-	if err := proto.Unmarshal(b, &meta); err != nil {
+	if err := protoutil.Unmarshal(b, &meta); err != nil {
 		t.Fatalf("error unmarshalling time series in text: %s", err.Error())
 	}
 	valueTS, err := MakeValue(meta).GetTimeseries()

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -23,7 +23,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -2368,7 +2367,7 @@ func ComputeStatsGo(
 			first = true
 
 			if !implicitMeta {
-				if err := proto.Unmarshal(unsafeValue, meta); err != nil {
+				if err := protoutil.Unmarshal(unsafeValue, meta); err != nil {
 					return ms, errors.Wrap(err, "unable to decode MVCCMetadata")
 				}
 			}

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -36,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -770,7 +770,7 @@ func RunGC(
 		// If there's more than a single value for the key, possibly send for GC.
 		if len(keys) > 1 {
 			meta := &enginepb.MVCCMetadata{}
-			if err := proto.Unmarshal(vals[0], meta); err != nil {
+			if err := protoutil.Unmarshal(vals[0], meta); err != nil {
 				log.Errorf(ctx, "unable to unmarshal MVCC metadata for key %q: %s", keys[0], err)
 			} else {
 				// In the event that there's an active intent, send for

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -22,7 +22,6 @@ import (
 	"testing/quick"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -36,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -824,7 +824,7 @@ func TestGCQueueIntentResolution(t *testing.T) {
 	err := tc.store.Engine().Iterate(engine.MakeMVCCMetadataKey(roachpb.KeyMin),
 		engine.MakeMVCCMetadataKey(roachpb.KeyMax), func(kv engine.MVCCKeyValue) (bool, error) {
 			if !kv.Key.IsValue() {
-				if err := proto.Unmarshal(kv.Value, meta); err != nil {
+				if err := protoutil.Unmarshal(kv.Value, meta); err != nil {
 					return false, err
 				}
 				if meta.Txn != nil {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
-	"github.com/gogo/protobuf/proto"
 	"github.com/google/btree"
 	"github.com/kr/pretty"
 	"github.com/opentracing/opentracing-go"
@@ -3488,7 +3487,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 				// leader. Clear commandID so it's ignored for processing.
 				if len(encodedCommand) == 0 {
 					commandID = ""
-				} else if err := proto.Unmarshal(encodedCommand, &command); err != nil {
+				} else if err := protoutil.Unmarshal(encodedCommand, &command); err != nil {
 					const expl = "while unmarshalling entry"
 					return stats, expl, errors.Wrap(err, expl)
 				}
@@ -3516,18 +3515,18 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 
 		case raftpb.EntryConfChange:
 			var cc raftpb.ConfChange
-			if err := proto.Unmarshal(e.Data, &cc); err != nil {
+			if err := protoutil.Unmarshal(e.Data, &cc); err != nil {
 				const expl = "while unmarshaling ConfChange"
 				return stats, expl, errors.Wrap(err, expl)
 			}
 			var ccCtx ConfChangeContext
-			if err := proto.Unmarshal(cc.Context, &ccCtx); err != nil {
+			if err := protoutil.Unmarshal(cc.Context, &ccCtx); err != nil {
 				const expl = "while unmarshaling ConfChangeContext"
 				return stats, expl, errors.Wrap(err, expl)
 
 			}
 			var command storagebase.RaftCommand
-			if err := proto.Unmarshal(ccCtx.Payload, &command); err != nil {
+			if err := protoutil.Unmarshal(ccCtx.Payload, &command); err != nil {
 				const expl = "while unmarshaling RaftCommand"
 				return stats, expl, errors.Wrap(err, expl)
 			}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -770,7 +770,7 @@ func (r *Replica) applySnapshot(
 
 	logEntries := make([]raftpb.Entry, len(inSnap.LogEntries))
 	for i, bytes := range inSnap.LogEntries {
-		if err := proto.Unmarshal(bytes, &logEntries[i]); err != nil {
+		if err := protoutil.Unmarshal(bytes, &logEntries[i]); err != nil {
 			return err
 		}
 	}

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/coreos/etcd/raft/raftpb"
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -157,7 +156,7 @@ func maybeSideloadEntriesImpl(
 				// Bad luck: we didn't have the proposal in-memory, so we'll
 				// have to unmarshal it.
 				log.Event(ctx, "proposal not already in memory; unmarshaling")
-				if err := proto.Unmarshal(data, &strippedCmd); err != nil {
+				if err := protoutil.Unmarshal(data, &strippedCmd); err != nil {
 					return nil, 0, err
 				}
 			}
@@ -236,7 +235,7 @@ func maybeInlineSideloadedRaftCommand(
 	cmdID, data := DecodeRaftCommand(ent.Data)
 
 	var command storagebase.RaftCommand
-	if err := proto.Unmarshal(data, &command); err != nil {
+	if err := protoutil.Unmarshal(data, &command); err != nil {
 		return nil, err
 	}
 

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/coreos/etcd/raft/raftpb"
-	"github.com/gogo/protobuf/proto"
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
 )
@@ -54,10 +53,10 @@ func entryEq(l, r raftpb.Entry) error {
 	_, lData := DecodeRaftCommand(l.Data)
 	_, rData := DecodeRaftCommand(r.Data)
 	var lc, rc storagebase.RaftCommand
-	if err := proto.Unmarshal(lData, &lc); err != nil {
+	if err := protoutil.Unmarshal(lData, &lc); err != nil {
 		return errors.Wrap(err, "unmarshalling LHS")
 	}
-	if err := proto.Unmarshal(rData, &rc); err != nil {
+	if err := protoutil.Unmarshal(rData, &rc); err != nil {
 		return errors.Wrap(err, "unmarshalling RHS")
 	}
 	if !reflect.DeepEqual(lc, rc) {
@@ -762,12 +761,12 @@ func TestRaftSSTableSideloadingSnapshot(t *testing.T) {
 		var cmd storagebase.RaftCommand
 		var finalEnt raftpb.Entry
 		for _, entryBytes := range mockSender.logEntries {
-			if err := proto.Unmarshal(entryBytes, &ent); err != nil {
+			if err := protoutil.Unmarshal(entryBytes, &ent); err != nil {
 				t.Fatal(err)
 			}
 			if sniffSideloadedRaftCommand(ent.Data) {
 				_, cmdBytes := DecodeRaftCommand(ent.Data)
-				if err := proto.Unmarshal(cmdBytes, &cmd); err != nil {
+				if err := protoutil.Unmarshal(cmdBytes, &cmd); err != nil {
 					t.Fatal(err)
 				}
 				if as := cmd.ReplicatedEvalResult.AddSSTable; as == nil {

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1220,7 +1220,7 @@ func TestReplicaGossipFirstRange(t *testing.T) {
 		}
 		if key == gossip.KeyFirstRangeDescriptor {
 			var rangeDesc roachpb.RangeDescriptor
-			if err := proto.Unmarshal(bytes, &rangeDesc); err != nil {
+			if err := protoutil.Unmarshal(bytes, &rangeDesc); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/storage/span_set.go
+++ b/pkg/storage/span_set.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/gogo/protobuf/proto"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/pkg/errors"
 )
 
@@ -218,7 +218,7 @@ func (s *SpanSetIterator) Value() []byte {
 }
 
 // ValueProto implements engine.Iterator.
-func (s *SpanSetIterator) ValueProto(msg proto.Message) error {
+func (s *SpanSetIterator) ValueProto(msg protoutil.Message) error {
 	return s.i.ValueProto(msg)
 }
 
@@ -279,7 +279,9 @@ func (s spanSetReader) Get(key engine.MVCCKey) ([]byte, error) {
 	return s.r.Get(key)
 }
 
-func (s spanSetReader) GetProto(key engine.MVCCKey, msg proto.Message) (bool, int64, int64, error) {
+func (s spanSetReader) GetProto(
+	key engine.MVCCKey, msg protoutil.Message,
+) (bool, int64, int64, error) {
 	if err := s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
 		return false, 0, 0, err
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
-	"github.com/gogo/protobuf/proto"
 	"github.com/google/btree"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -3447,7 +3446,7 @@ func sendSnapshot(
 	{
 		var ent raftpb.Entry
 		for i := range logEntries {
-			if err := proto.Unmarshal(logEntries[i], &ent); err != nil {
+			if err := protoutil.Unmarshal(logEntries[i], &ent); err != nil {
 				return err
 			}
 			if !sniffSideloadedRaftCommand(ent.Data) {

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -27,8 +27,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
-
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -40,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
@@ -203,7 +202,7 @@ func StartServerRaw(args base.TestServerArgs) (TestServerInterface, error) {
 
 // GetJSONProto uses the supplied client to GET the URL specified by the parameters
 // and unmarshals the result into response.
-func GetJSONProto(ts TestServerInterface, path string, response proto.Message) error {
+func GetJSONProto(ts TestServerInterface, path string, response protoutil.Message) error {
 	httpClient, err := ts.GetAuthenticatedHTTPClient()
 	if err != nil {
 		return err
@@ -213,7 +212,7 @@ func GetJSONProto(ts TestServerInterface, path string, response proto.Message) e
 
 // PostJSONProto uses the supplied client to POST request to the URL specified by
 // the parameters and unmarshals the result into response.
-func PostJSONProto(ts TestServerInterface, path string, request, response proto.Message) error {
+func PostJSONProto(ts TestServerInterface, path string, request, response protoutil.Message) error {
 	httpClient, err := ts.GetAuthenticatedHTTPClient()
 	if err != nil {
 		return err

--- a/pkg/util/httputil/http.go
+++ b/pkg/util/httputil/http.go
@@ -21,8 +21,9 @@ import (
 	"strconv"
 
 	"github.com/gogo/protobuf/jsonpb"
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
 const (
@@ -50,7 +51,7 @@ const (
 
 // GetJSON uses the supplied client to GET the URL specified by the parameters
 // and unmarshals the result into response.
-func GetJSON(httpClient http.Client, path string, response proto.Message) error {
+func GetJSON(httpClient http.Client, path string, response protoutil.Message) error {
 	req, err := http.NewRequest("GET", path, nil)
 	if err != nil {
 		return err
@@ -61,7 +62,7 @@ func GetJSON(httpClient http.Client, path string, response proto.Message) error 
 
 // PostJSON uses the supplied client to POST request to the URL specified by
 // the parameters and unmarshals the result into response.
-func PostJSON(httpClient http.Client, path string, request, response proto.Message) error {
+func PostJSON(httpClient http.Client, path string, request, response protoutil.Message) error {
 	// Hack to avoid upsetting TestProtoMarshal().
 	marshalFn := (&jsonpb.Marshaler{}).Marshal
 
@@ -83,7 +84,7 @@ func PostJSON(httpClient http.Client, path string, request, response proto.Messa
 // The response is returned to the caller, though its body will have been
 // closed.
 func PostJSONWithRequest(
-	httpClient http.Client, path string, request, response proto.Message,
+	httpClient http.Client, path string, request, response protoutil.Message,
 ) (*http.Response, error) {
 	// Hack to avoid upsetting TestProtoMarshal().
 	marshalFn := (&jsonpb.Marshaler{}).Marshal
@@ -101,7 +102,7 @@ func PostJSONWithRequest(
 }
 
 func doJSONRequest(
-	httpClient http.Client, req *http.Request, response proto.Message,
+	httpClient http.Client, req *http.Request, response protoutil.Message,
 ) (*http.Response, error) {
 	if timeout := httpClient.Timeout; timeout > 0 {
 		req.Header.Set("Grpc-Timeout", strconv.FormatInt(timeout.Nanoseconds(), 10)+"n")

--- a/pkg/util/protoutil/clone.go
+++ b/pkg/util/protoutil/clone.go
@@ -40,7 +40,7 @@ func init() {
 	types.known = make(map[typeKey]reflect.Type)
 }
 
-func uncloneable(pb proto.Message) (reflect.Type, bool) {
+func uncloneable(pb Message) (reflect.Type, bool) {
 	for _, verbotenKind := range verbotenKinds {
 		if t := typeIsOrContainsVerboten(reflect.TypeOf(pb), verbotenKind); t != nil {
 			return t, true
@@ -62,11 +62,11 @@ func uncloneable(pb proto.Message) (reflect.Type, bool) {
 //
 // The concrete case against which this is currently guarding may be resolved
 // upstream, see https://github.com/gogo/protobuf/issues/147.
-func Clone(pb proto.Message) proto.Message {
+func Clone(pb Message) Message {
 	if t, ok := uncloneable(pb); ok {
 		panic(fmt.Sprintf("attempt to clone %T, which contains uncloneable field of type %s", pb, t))
 	}
-	return proto.Clone(pb)
+	return proto.Clone(pb).(Message)
 }
 
 func typeIsOrContainsVerboten(t reflect.Type, verboten reflect.Kind) reflect.Type {

--- a/pkg/util/protoutil/clone_test.go
+++ b/pkg/util/protoutil/clone_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestCloneProto(t *testing.T) {
 	testCases := []struct {
-		pb          proto.Message
+		pb          protoutil.Message
 		shouldPanic bool
 	}{
 		// Uncloneable types (all contain UUID fields).
@@ -54,7 +54,7 @@ func TestCloneProto(t *testing.T) {
 		{&roachpb.RangeDescriptor{}, false},
 	}
 	for _, tc := range testCases {
-		var clone proto.Message
+		var clone protoutil.Message
 		var panicObj interface{}
 		func() {
 			defer func() {

--- a/pkg/util/protoutil/jsonpb_marshal.go
+++ b/pkg/util/protoutil/jsonpb_marshal.go
@@ -22,23 +22,23 @@ import (
 	"reflect"
 
 	"github.com/gogo/protobuf/jsonpb"
-	"github.com/gogo/protobuf/proto"
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
-
-	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 )
 
 var _ gwruntime.Marshaler = (*JSONPb)(nil)
 
-var typeProtoMessage = reflect.TypeOf((*proto.Message)(nil)).Elem()
+var typeProtoMessage = reflect.TypeOf((*Message)(nil)).Elem()
 
 // JSONPb is a gwruntime.Marshaler that uses github.com/gogo/protobuf/jsonpb.
 type JSONPb jsonpb.Marshaler
 
 // ContentType implements gwruntime.Marshaler.
 func (*JSONPb) ContentType() string {
-	return httputil.JSONContentType
+	// NB: This is the same as httputil.JSONContentType which we can't use due to
+	// an import cycle.
+	const JSONContentType = "application/json"
+	return JSONContentType
 }
 
 // Marshal implements gwruntime.Marshaler.
@@ -49,7 +49,7 @@ func (j *JSONPb) Marshal(v interface{}) ([]byte, error) {
 // a lower-case version of marshal to allow for a call from
 // marshalNonProtoField without upsetting TestProtoMarshal().
 func (j *JSONPb) marshal(v interface{}) ([]byte, error) {
-	if pb, ok := v.(proto.Message); ok {
+	if pb, ok := v.(Message); ok {
 		var buf bytes.Buffer
 		marshalFn := (*jsonpb.Marshaler)(j).Marshal
 		if err := marshalFn(&buf, pb); err != nil {
@@ -98,7 +98,7 @@ func (j *JSONPb) marshalNonProtoField(v interface{}) ([]byte, error) {
 
 // Unmarshal implements gwruntime.Marshaler.
 func (j *JSONPb) Unmarshal(data []byte, v interface{}) error {
-	if pb, ok := v.(proto.Message); ok {
+	if pb, ok := v.(Message); ok {
 		return jsonpb.Unmarshal(bytes.NewReader(data), pb)
 	}
 	return errors.Errorf("unexpected type %T does not implement %s", v, typeProtoMessage)
@@ -107,7 +107,7 @@ func (j *JSONPb) Unmarshal(data []byte, v interface{}) error {
 // NewDecoder implements gwruntime.Marshaler.
 func (j *JSONPb) NewDecoder(r io.Reader) gwruntime.Decoder {
 	return gwruntime.DecoderFunc(func(v interface{}) error {
-		if pb, ok := v.(proto.Message); ok {
+		if pb, ok := v.(Message); ok {
 			return jsonpb.Unmarshal(r, pb)
 		}
 		return errors.Errorf("unexpected type %T does not implement %s", v, typeProtoMessage)
@@ -117,7 +117,7 @@ func (j *JSONPb) NewDecoder(r io.Reader) gwruntime.Decoder {
 // NewEncoder implements gwruntime.Marshaler.
 func (j *JSONPb) NewEncoder(w io.Writer) gwruntime.Encoder {
 	return gwruntime.EncoderFunc(func(v interface{}) error {
-		if pb, ok := v.(proto.Message); ok {
+		if pb, ok := v.(Message); ok {
 			marshalFn := (*jsonpb.Marshaler)(j).Marshal
 			return marshalFn(w, pb)
 		}

--- a/pkg/util/protoutil/marshal.go
+++ b/pkg/util/protoutil/marshal.go
@@ -25,6 +25,7 @@ import (
 type Message interface {
 	proto.Message
 	MarshalTo(data []byte) (int, error)
+	Unmarshal(data []byte) error
 	Size() int
 }
 
@@ -75,4 +76,15 @@ func Marshal(pb Message) ([]byte, error) {
 func MarshalToWithoutFuzzing(pb Message, dest []byte) (int, error) {
 	Interceptor(pb)
 	return pb.MarshalTo(dest)
+}
+
+// Unmarshal parses the protocol buffer representation in buf and places the
+// decoded result in pb. If the struct underlying pb does not match the data in
+// buf, the results can be unpredictable.
+//
+// Unmarshal resets pb before starting to unmarshal, so any existing data in pb
+// is always removed.
+func Unmarshal(data []byte, pb Message) error {
+	pb.Reset()
+	return pb.Unmarshal(data)
 }


### PR DESCRIPTION
Switch all remaining uses of proto.Message to protoutil.Message.

Changed the TestProtoUnmarshal lint to check for usage of
protoutil.Unmarshal instead of proto.Unmarshal. Added a TestProtoMessage
lint that checks for usage of proto.Message (bad) vs
protoutil.Message (good).