### PR TITLE
server: Fix --advertise-port

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1304,7 +1305,7 @@ func (w *gzipResponseWriter) Close() error {
 func officialAddr(
 	ctx context.Context, cfgAddr string, lnAddr net.Addr, osHostname func() (string, error),
 ) (*util.UnresolvedAddr, error) {
-	cfgHost, _, err := net.SplitHostPort(cfgAddr)
+	cfgHost, cfgPort, err := net.SplitHostPort(cfgAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -1331,5 +1332,11 @@ func officialAddr(
 		return nil, errors.Errorf("hostname %q did not resolve to any addresses; listener address: %s", host, lnHost)
 	}
 
-	return util.NewUnresolvedAddr(lnAddr.Network(), net.JoinHostPort(host, lnPort)), nil
+	// cfgPort may need to be used if --advertise-port was set on the command line.
+	port := lnPort
+	if i, err := strconv.Atoi(cfgPort); err == nil && i > 0 {
+		port = cfgPort
+	}
+
+	return util.NewUnresolvedAddr(lnAddr.Network(), net.JoinHostPort(host, port)), nil
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -451,8 +451,8 @@ func TestOfficializeAddr(t *testing.T) {
 				cfgAddr, lnAddr, expAddr string
 			}{
 				{"localhost:0", "127.0.0.1:1234", "localhost:1234"},
-				{"localhost:1234", "127.0.0.1:2345", "localhost:2345"},
-				{":1234", net.JoinHostPort(addrs[0], "2345"), net.JoinHostPort(host, "2345")},
+				{"localhost:1234", "127.0.0.1:2345", "localhost:1234"},
+				{":1234", net.JoinHostPort(addrs[0], "2345"), net.JoinHostPort(host, "1234")},
 				{":0", net.JoinHostPort(addrs[0], "2345"), net.JoinHostPort(host, "2345")},
 			} {
 				t.Run(tc.cfgAddr, func(t *testing.T) {


### PR DESCRIPTION
Previously we'd end up sticking the listening port the server bound to
into `unresolvedAdvertAddr` instead of the user-provided advertise-port,
which effectively made the --advertise-port not have any effect at all.
I'm not sure how it originally worked for Irfan's use case.

Tested manually by setting up a GCE firewall on all port 26257 traffic,
proxying local port 3000 to local port 26257, and starting a cockroach
process with advertise host set to the VM's external IP address (to go
through the firewall) and advertise port set to 3000. This setup works
after this commit, but fails when run on v1.1-beta.20170928.

Fixes #18932 

Thanks for helping find this, @tomholub!