### PR TITLE
keys: RangeMetaKey returns an RKey, not a Key

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -416,7 +416,7 @@ func (c *Cluster) TransferLease(nodeIdx int, r *rand.Rand, key roachpb.Key) (boo
 func (c *Cluster) lookupRange(nodeIdx int, key roachpb.Key) (*roachpb.RangeDescriptor, error) {
 	req := &roachpb.RangeLookupRequest{
 		Span: roachpb.Span{
-			Key: keys.RangeMetaKey(keys.MustAddr(key)),
+			Key: keys.RangeMetaKey(keys.MustAddr(key)).AsRawKey(),
 		},
 		MaxRanges: 1,
 	}

--- a/pkg/cli/range.go
+++ b/pkg/cli/range.go
@@ -64,7 +64,7 @@ func runLsRanges(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			panic(err)
 		}
-		startKey = keys.RangeMetaKey(rk)
+		startKey = keys.RangeMetaKey(rk).AsRawKey()
 	}
 	endKey := keys.Meta2Prefix.PrefixEnd()
 

--- a/pkg/internal/client/util.go
+++ b/pkg/internal/client/util.go
@@ -33,6 +33,10 @@ func marshalKey(k interface{}) (roachpb.Key, error) {
 		return *t, nil
 	case roachpb.Key:
 		return t, nil
+	case *roachpb.RKey:
+		return t.AsRawKey(), nil
+	case roachpb.RKey:
+		return t.AsRawKey(), nil
 	case string:
 		return roachpb.Key(t), nil
 	case []byte:

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -445,14 +445,14 @@ func AddrUpperBound(k roachpb.Key) (roachpb.RKey, error) {
 // - For a meta1 key, KeyMin is returned.
 // - For a meta2 key, a meta1 key is returned.
 // - For an ordinary key, a meta2 key is returned.
-func RangeMetaKey(key roachpb.RKey) roachpb.Key {
+func RangeMetaKey(key roachpb.RKey) roachpb.RKey {
 	if len(key) == 0 { // key.Equal(roachpb.RKeyMin)
-		return roachpb.KeyMin
+		return roachpb.RKeyMin
 	}
 	var prefix roachpb.Key
 	switch key[0] {
 	case meta1PrefixByte:
-		return roachpb.KeyMin
+		return roachpb.RKeyMin
 	case meta2PrefixByte:
 		prefix = Meta1Prefix
 		key = key[len(Meta2Prefix):]
@@ -460,7 +460,7 @@ func RangeMetaKey(key roachpb.RKey) roachpb.Key {
 		prefix = Meta2Prefix
 	}
 
-	buf := make(roachpb.Key, 0, len(prefix)+len(key))
+	buf := make(roachpb.RKey, 0, len(prefix)+len(key))
 	buf = append(buf, prefix...)
 	buf = append(buf, key...)
 	return buf

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -82,8 +82,8 @@ var (
 					if len(unq) == 0 {
 						return "", Meta1Prefix
 					}
-					return "", RangeMetaKey(MustAddr(RangeMetaKey(MustAddr(
-						roachpb.Key(unq)))))
+					return "", RangeMetaKey(RangeMetaKey(MustAddr(
+						roachpb.Key(unq)))).AsRawKey()
 				},
 			}},
 		},
@@ -98,7 +98,7 @@ var (
 					if len(unq) == 0 {
 						return "", Meta2Prefix
 					}
-					return "", RangeMetaKey(MustAddr(roachpb.Key(unq)))
+					return "", RangeMetaKey(MustAddr(roachpb.Key(unq))).AsRawKey()
 				},
 			}},
 		},

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -75,7 +75,7 @@ func TestPrettyPrint(t *testing.T) {
 		// system
 		{makeKey(Meta2Prefix, roachpb.Key("foo")), `/Meta2/"foo"`},
 		{makeKey(Meta1Prefix, roachpb.Key("foo")), `/Meta1/"foo"`},
-		{RangeMetaKey(roachpb.RKey("f")), `/Meta2/"f"`},
+		{RangeMetaKey(roachpb.RKey("f")).AsRawKey(), `/Meta2/"f"`},
 
 		{NodeLivenessKey(10033), "/System/NodeLiveness/10033"},
 		{NodeStatusKey(1111), "/System/StatusNode/1111"},
@@ -83,9 +83,9 @@ func TestPrettyPrint(t *testing.T) {
 		{SystemMax, "/System/Max"},
 
 		// key of key
-		{RangeMetaKey(roachpb.RKey(MakeRangeKeyPrefix(MakeTablePrefix(42)))), `/Meta2/Local/Range/Table/42`},
-		{RangeMetaKey(roachpb.RKey(makeKey(MakeTablePrefix(42), roachpb.RKey("foo")))), `/Meta2/Table/42/"foo"`},
-		{RangeMetaKey(roachpb.RKey(makeKey(Meta2Prefix, roachpb.Key("foo")))), `/Meta1/"foo"`},
+		{RangeMetaKey(roachpb.RKey(MakeRangeKeyPrefix(MakeTablePrefix(42)))).AsRawKey(), `/Meta2/Local/Range/Table/42`},
+		{RangeMetaKey(roachpb.RKey(makeKey(MakeTablePrefix(42), roachpb.RKey("foo")))).AsRawKey(), `/Meta2/Table/42/"foo"`},
+		{RangeMetaKey(roachpb.RKey(makeKey(Meta2Prefix, roachpb.Key("foo")))).AsRawKey(), `/Meta1/"foo"`},
 
 		// table
 		{SystemConfigSpan.Key, "/Table/SystemConfigSpan/Start"},

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -399,7 +399,7 @@ func (mdb MockRangeDescriptorDB) RangeLookup(
 	filterDescs := func(retDescs []roachpb.RangeDescriptor) []roachpb.RangeDescriptor {
 		var containedDescs []roachpb.RangeDescriptor
 		for _, retDesc := range retDescs {
-			if desc.ContainsKey(mustMeta(retDesc.EndKey)) {
+			if desc.ContainsKey(keys.RangeMetaKey(retDesc.EndKey)) {
 				containedDescs = append(containedDescs, retDesc)
 			} else {
 				log.Infof(ctx, "filtering descriptor %v from RangeLookup on range %v", retDesc, desc)

--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -47,10 +47,6 @@ func (a rangeCacheKey) Compare(b llrb.Comparable) int {
 	return bytes.Compare(a, b.(rangeCacheKey))
 }
 
-func meta(k roachpb.RKey) (roachpb.RKey, error) {
-	return keys.Addr(keys.RangeMetaKey(k))
-}
-
 // RangeDescriptorDB is a type which can query range descriptors from an
 // underlying datastore. This interface is used by rangeDescriptorCache to
 // initially retrieve information which will be cached.
@@ -394,10 +390,7 @@ func (rdc *RangeDescriptorCache) performRangeLookup(
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	// metadataKey is sent to RangeLookup to find the RangeDescriptor
 	// which contains key.
-	metadataKey, err := meta(key)
-	if err != nil {
-		return nil, nil, err
-	}
+	metadataKey := keys.RangeMetaKey(key)
 
 	// desc is the RangeDescriptor for the range which contains metadataKey.
 	var desc *roachpb.RangeDescriptor
@@ -472,10 +465,7 @@ func (rdc *RangeDescriptorCache) evictCachedRangeDescriptorLocked(
 		// Retrieve the metadata range key for the next level of metadata, and
 		// evict that key as well. This loop ends after the meta1 range, which
 		// returns KeyMin as its metadata key.
-		descKey, err = meta(descKey)
-		if err != nil {
-			return err
-		}
+		descKey = keys.RangeMetaKey(descKey)
 		cachedDesc, entry, err = rdc.getCachedRangeDescriptorLocked(descKey, inclusive)
 		if err != nil {
 			return err
@@ -517,14 +507,10 @@ func (rdc *RangeDescriptorCache) getCachedRangeDescriptorLocked(
 	// The cache is indexed using the end-key of the range, but the
 	// end-key is non-inclusive by default.
 	var metaKey roachpb.RKey
-	var err error
 	if !inclusive {
-		metaKey, err = meta(key.Next())
+		metaKey = keys.RangeMetaKey(key.Next())
 	} else {
-		metaKey, err = meta(key)
-	}
-	if err != nil {
-		return nil, nil, err
+		metaKey = keys.RangeMetaKey(key)
 	}
 
 	entry, ok := rdc.rangeCache.cache.CeilEntry(rangeCacheKey(metaKey))
@@ -572,10 +558,7 @@ func (rdc *RangeDescriptorCache) insertRangeDescriptorsLocked(
 		if err != nil || !continueWithInsert {
 			return err
 		}
-		rangeKey, err := meta(rs[i].EndKey)
-		if err != nil {
-			return err
-		}
+		rangeKey := keys.RangeMetaKey(rs[i].EndKey)
 		if log.V(2) {
 			log.Infof(ctx, "adding descriptor: key=%s desc=%s", rangeKey, &rs[i])
 		}
@@ -596,10 +579,7 @@ func (rdc *RangeDescriptorCache) clearOverlappingCachedRangeDescriptors(
 	ctx context.Context, desc *roachpb.RangeDescriptor,
 ) (bool, error) {
 	key := desc.EndKey
-	metaKey, err := meta(key)
-	if err != nil {
-		return false, err
-	}
+	metaKey := keys.RangeMetaKey(key)
 
 	// Clear out any descriptors which subsume the key which we're going
 	// to cache. For example, if an existing KeyMin->KeyMax descriptor
@@ -620,14 +600,8 @@ func (rdc *RangeDescriptorCache) clearOverlappingCachedRangeDescriptors(
 		}
 	}
 
-	startMeta, err := meta(desc.StartKey)
-	if err != nil {
-		return false, err
-	}
-	endMeta, err := meta(desc.EndKey)
-	if err != nil {
-		return false, err
-	}
+	startMeta := keys.RangeMetaKey(desc.StartKey)
+	endMeta := keys.RangeMetaKey(desc.EndKey)
 
 	// Also clear any descriptors which are subsumed by the one we're
 	// going to cache. This could happen on a merge (and also happens

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -32,14 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func mustMeta(k roachpb.RKey) roachpb.RKey {
-	m, err := meta(k)
-	if err != nil {
-		panic(err)
-	}
-	return m
-}
-
 type testDescriptorDB struct {
 	data            llrb.Tree
 	cache           *RangeDescriptorCache
@@ -176,7 +168,7 @@ func initTestDescriptorDB(t *testing.T) *testDescriptorDB {
 	for i, char := range "abcdefghijklmnopqrstuvwx" {
 		db.splitRange(t, roachpb.RKey(string(char)))
 		if i > 0 && i%6 == 0 {
-			db.splitRange(t, mustMeta(roachpb.RKey(string(char))))
+			db.splitRange(t, keys.RangeMetaKey(roachpb.RKey(string(char))))
 		}
 	}
 	db.cache = NewRangeDescriptorCache(db, staticSize(2<<10))
@@ -285,7 +277,7 @@ func TestDescriptorDBGetDescriptors(t *testing.T) {
 
 func TestRangeCacheAssumptions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	expKeyMin := mustMeta(mustMeta(mustMeta(roachpb.RKey("test"))))
+	expKeyMin := keys.RangeMetaKey(keys.RangeMetaKey(keys.RangeMetaKey(roachpb.RKey("test"))))
 	if !bytes.Equal(expKeyMin, roachpb.RKeyMin) {
 		t.Fatalf("RangeCache relies on RangeMetaKey returning KeyMin after two levels, but got %s", expKeyMin)
 	}
@@ -773,7 +765,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	if _, err := cache.clearOverlappingCachedRangeDescriptors(ctx, minToBDesc); err != nil {
 		t.Fatal(err)
 	}
-	cache.rangeCache.cache.Add(rangeCacheKey(mustMeta(roachpb.RKey("b"))), minToBDesc)
+	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKey("b"))), minToBDesc)
 	if desc, err := cache.GetCachedRangeDescriptor(roachpb.RKey("b"), false); err != nil {
 		t.Fatal(err)
 	} else if desc != nil {
@@ -782,7 +774,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	if _, err := cache.clearOverlappingCachedRangeDescriptors(ctx, bToMaxDesc); err != nil {
 		t.Fatal(err)
 	}
-	cache.rangeCache.cache.Add(rangeCacheKey(mustMeta(roachpb.RKeyMax)), bToMaxDesc)
+	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKeyMax)), bToMaxDesc)
 	if desc, err := cache.GetCachedRangeDescriptor(roachpb.RKey("b"), false); err != nil {
 		t.Fatal(err)
 	} else if desc != bToMaxDesc {
@@ -810,7 +802,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	if _, err := cache.clearOverlappingCachedRangeDescriptors(ctx, bToCDesc); err != nil {
 		t.Fatal(err)
 	}
-	cache.rangeCache.cache.Add(rangeCacheKey(mustMeta(roachpb.RKey("c"))), bToCDesc)
+	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKey("c"))), bToCDesc)
 	if desc, err := cache.GetCachedRangeDescriptor(roachpb.RKey("c"), true); err != nil {
 		t.Fatal(err)
 	} else if desc != bToCDesc {
@@ -824,7 +816,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	if _, err := cache.clearOverlappingCachedRangeDescriptors(ctx, aToBDesc); err != nil {
 		t.Fatal(err)
 	}
-	cache.rangeCache.cache.Add(rangeCacheKey(mustMeta(roachpb.RKey("b"))), aToBDesc)
+	cache.rangeCache.cache.Add(rangeCacheKey(keys.RangeMetaKey(roachpb.RKey("b"))), aToBDesc)
 	if desc, err := cache.GetCachedRangeDescriptor(roachpb.RKey("c"), true); err != nil {
 		t.Fatal(err)
 	} else if desc != bToCDesc {
@@ -863,7 +855,7 @@ func TestRangeCacheClearOverlappingMeta(t *testing.T) {
 	// Add new range, corresponding to splitting the first range at a meta key.
 	metaSplitDesc := &roachpb.RangeDescriptor{
 		StartKey: roachpb.RKeyMin,
-		EndKey:   mustMeta(roachpb.RKey("foo")),
+		EndKey:   keys.RangeMetaKey(roachpb.RKey("foo")),
 	}
 	func() {
 		defer func() {

--- a/pkg/kv/split_test.go
+++ b/pkg/kv/split_test.go
@@ -106,8 +106,8 @@ func TestRangeSplitMeta(t *testing.T) {
 	ctx := context.TODO()
 
 	// TODO(peter): revert when we allow meta2 splitting. See #16266.
-	// splitKeys := []roachpb.RKey{roachpb.RKey("G"), mustMeta(roachpb.RKey("F")),
-	// 	mustMeta(roachpb.RKey("K")), mustMeta(roachpb.RKey("H"))}
+	// splitKeys := []roachpb.RKey{roachpb.RKey("G"), keys.RangeMetaKey(roachpb.RKey("F")),
+	// 	keys.RangeMetaKey(roachpb.RKey("K")), keys.RangeMetaKey(roachpb.RKey("H"))}
 	splitKeys := []roachpb.RKey{roachpb.RKey("G"), roachpb.RKey("F"),
 		roachpb.RKey("K"), roachpb.RKey("H")}
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -570,7 +570,7 @@ func (ts *TestServer) GetFirstStoreID() roachpb.StoreID {
 func (ts *TestServer) LookupRange(key roachpb.Key) (roachpb.RangeDescriptor, error) {
 	rangeLookupReq := roachpb.RangeLookupRequest{
 		Span: roachpb.Span{
-			Key: keys.RangeMetaKey(keys.MustAddr(key)),
+			Key: keys.RangeMetaKey(keys.MustAddr(key)).AsRawKey(),
 		},
 		MaxRanges: 1,
 	}

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -167,7 +167,7 @@ func scanMetaKVs(
 	if err != nil {
 		return nil, err
 	}
-	if len(kvs) == 0 || !kvs[len(kvs)-1].Key.Equal(metaEnd) {
+	if len(kvs) == 0 || !kvs[len(kvs)-1].Key.Equal(metaEnd.AsRawKey()) {
 		// Normally we need to scan one more KV because the ranges are addressed by
 		// the end key.
 		extraKV, err := txn.Scan(ctx, metaEnd, keys.Meta2Prefix.PrefixEnd(), 1 /* one result */)

--- a/pkg/storage/addressing.go
+++ b/pkg/storage/addressing.go
@@ -89,7 +89,7 @@ func rangeAddressing(b *client.Batch, desc *roachpb.RangeDescriptor, action meta
 	//
 	// 3. the range ends with a normal user key, so we must update the
 	// relevant meta2 entry pointing to the end of this range.
-	action(b, keys.RangeMetaKey(desc.EndKey), desc)
+	action(b, keys.RangeMetaKey(desc.EndKey).AsRawKey(), desc)
 
 	if !bytes.HasPrefix(desc.EndKey, keys.Meta2Prefix) {
 		// 3a. the range starts with KeyMin or a meta2 addressing record,

--- a/pkg/storage/addressing_test.go
+++ b/pkg/storage/addressing_test.go
@@ -57,14 +57,6 @@ func meta2Key(key roachpb.RKey) []byte {
 	return testutils.MakeKey(keys.Meta2Prefix, key)
 }
 
-func metaKey(key roachpb.RKey) []byte {
-	rk, err := keys.Addr(keys.RangeMetaKey(key))
-	if err != nil {
-		panic(err)
-	}
-	return rk
-}
-
 // TestUpdateRangeAddressing verifies range addressing records are
 // correctly updated on creation of new range descriptors.
 func TestUpdateRangeAddressing(t *testing.T) {
@@ -95,25 +87,25 @@ func TestUpdateRangeAddressing(t *testing.T) {
 		{true, roachpb.RKey("a"), roachpb.RKey("m"), roachpb.RKey("m"), roachpb.RKey("z"),
 			[][]byte{meta2Key(roachpb.RKey("m"))}, [][]byte{meta2Key(roachpb.RKey("z"))}},
 		// Split KeyMin-"a" at meta2(m).
-		{true, roachpb.RKeyMin, metaKey(roachpb.RKey("m")), metaKey(roachpb.RKey("m")), roachpb.RKey("a"),
+		{true, roachpb.RKeyMin, keys.RangeMetaKey(roachpb.RKey("m")), keys.RangeMetaKey(roachpb.RKey("m")), roachpb.RKey("a"),
 			[][]byte{meta1Key(roachpb.RKey("m"))}, [][]byte{meta1Key(roachpb.RKeyMax), meta2Key(roachpb.RKey("a"))}},
 		// Split meta2(m)-"a" at meta2(z).
-		{true, metaKey(roachpb.RKey("m")), metaKey(roachpb.RKey("z")), metaKey(roachpb.RKey("z")), roachpb.RKey("a"),
+		{true, keys.RangeMetaKey(roachpb.RKey("m")), keys.RangeMetaKey(roachpb.RKey("z")), keys.RangeMetaKey(roachpb.RKey("z")), roachpb.RKey("a"),
 			[][]byte{meta1Key(roachpb.RKey("z"))}, [][]byte{meta1Key(roachpb.RKeyMax), meta2Key(roachpb.RKey("a"))}},
 		// Split meta2(m)-meta2(z) at meta2(r).
-		{true, metaKey(roachpb.RKey("m")), metaKey(roachpb.RKey("r")), metaKey(roachpb.RKey("r")), metaKey(roachpb.RKey("z")),
+		{true, keys.RangeMetaKey(roachpb.RKey("m")), keys.RangeMetaKey(roachpb.RKey("r")), keys.RangeMetaKey(roachpb.RKey("r")), keys.RangeMetaKey(roachpb.RKey("z")),
 			[][]byte{meta1Key(roachpb.RKey("r"))}, [][]byte{meta1Key(roachpb.RKey("z"))}},
 
 		// Now, merge all of our splits backwards...
 
 		// Merge meta2(m)-meta2(z).
-		{false, metaKey(roachpb.RKey("m")), metaKey(roachpb.RKey("r")), metaKey(roachpb.RKey("m")), metaKey(roachpb.RKey("z")),
+		{false, keys.RangeMetaKey(roachpb.RKey("m")), keys.RangeMetaKey(roachpb.RKey("r")), keys.RangeMetaKey(roachpb.RKey("m")), keys.RangeMetaKey(roachpb.RKey("z")),
 			[][]byte{meta1Key(roachpb.RKey("r"))}, [][]byte{meta1Key(roachpb.RKey("z"))}},
 		// Merge meta2(m)-"a".
-		{false, metaKey(roachpb.RKey("m")), metaKey(roachpb.RKey("z")), metaKey(roachpb.RKey("m")), roachpb.RKey("a"),
+		{false, keys.RangeMetaKey(roachpb.RKey("m")), keys.RangeMetaKey(roachpb.RKey("z")), keys.RangeMetaKey(roachpb.RKey("m")), roachpb.RKey("a"),
 			[][]byte{meta1Key(roachpb.RKey("z"))}, [][]byte{meta1Key(roachpb.RKeyMax), meta2Key(roachpb.RKey("a"))}},
 		// Merge KeyMin-"a".
-		{false, roachpb.RKeyMin, metaKey(roachpb.RKey("m")), roachpb.RKeyMin, roachpb.RKey("a"),
+		{false, roachpb.RKeyMin, keys.RangeMetaKey(roachpb.RKey("m")), roachpb.RKeyMin, roachpb.RKey("a"),
 			[][]byte{meta1Key(roachpb.RKey("m"))}, [][]byte{meta1Key(roachpb.RKeyMax), meta2Key(roachpb.RKey("a"))}},
 		// Merge "a"-"z".
 		{false, roachpb.RKey("a"), roachpb.RKey("m"), roachpb.RKey("a"), roachpb.RKey("z"),

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -266,14 +266,8 @@ func TestReplicateRange(t *testing.T) {
 	// Verify that in time, no intents remain on meta addressing
 	// keys, and that range descriptor on the meta records is correct.
 	testutils.SucceedsSoon(t, func() error {
-		meta2, err := keys.Addr(keys.RangeMetaKey(roachpb.RKeyMax))
-		if err != nil {
-			t.Fatal(err)
-		}
-		meta1, err := keys.Addr(keys.RangeMetaKey(meta2))
-		if err != nil {
-			t.Fatal(err)
-		}
+		meta2 := keys.RangeMetaKey(roachpb.RKeyMax)
+		meta1 := keys.RangeMetaKey(meta2)
 		for _, key := range []roachpb.RKey{meta2, meta1} {
 			metaDesc := roachpb.RangeDescriptor{}
 			if ok, err := engine.MVCCGetProto(context.Background(), mtc.stores[0].Engine(), key.AsRawKey(), mtc.stores[0].Clock().Now(), true, nil, &metaDesc); err != nil {
@@ -1342,7 +1336,7 @@ func getRangeMetadata(
 	b := &client.Batch{}
 	b.AddRawRequest(&roachpb.RangeLookupRequest{
 		Span: roachpb.Span{
-			Key: keys.RangeMetaKey(key),
+			Key: keys.RangeMetaKey(key).AsRawKey(),
 		},
 		MaxRanges: 1,
 	})

--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -354,8 +354,8 @@ func TestRangeLookupUseReverse(t *testing.T) {
 	// Resolve the intents.
 	scanArgs := roachpb.ScanRequest{
 		Span: roachpb.Span{
-			Key:    keys.RangeMetaKey(roachpb.RKeyMin.Next()),
-			EndKey: keys.RangeMetaKey(roachpb.RKeyMax),
+			Key:    keys.RangeMetaKey(roachpb.RKeyMin.Next()).AsRawKey(),
+			EndKey: keys.RangeMetaKey(roachpb.RKeyMax).AsRawKey(),
 		},
 	}
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1775,7 +1775,7 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 				log.Infof(context.TODO(), "allowing BeginTransaction to proceed after 20ms")
 			}
 		} else if filterArgs.Req.Method() == roachpb.Put &&
-			filterArgs.Req.Header().Key.Equal(keys.RangeMetaKey(splitKey)) {
+			filterArgs.Req.Header().Key.Equal(keys.RangeMetaKey(splitKey).AsRawKey()) {
 			select {
 			case wroteMeta2 <- struct{}{}:
 			default:
@@ -1837,7 +1837,7 @@ func TestStoreSplitBeginTxnPushMetaIntentRace(t *testing.T) {
 	// within a SucceedSoon in order to give the intents time to resolve.
 	testutils.SucceedsSoon(t, func() error {
 		val, intents, err := engine.MVCCGet(context.Background(), store.Engine(),
-			keys.RangeMetaKey(splitKey), hlc.MaxTimestamp, true, nil)
+			keys.RangeMetaKey(splitKey).AsRawKey(), hlc.MaxTimestamp, true, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1232,10 +1232,7 @@ func evalRangeLookup(
 			if err := v.GetProto(&rd); err != nil {
 				return nil, err
 			}
-			startKeyAddr, err := keys.Addr(keys.RangeMetaKey(rd.StartKey))
-			if err != nil {
-				return nil, err
-			}
+			startKeyAddr := keys.RangeMetaKey(rd.StartKey)
 			if !startKeyAddr.Less(key) {
 				// This is the case in which we've picked up an extra descriptor
 				// we don't want.

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -198,7 +198,7 @@ func (rgcq *replicaGCQueue) process(
 	b := &client.Batch{}
 	b.AddRawRequest(&roachpb.RangeLookupRequest{
 		Span: roachpb.Span{
-			Key: keys.RangeMetaKey(desc.StartKey),
+			Key: keys.RangeMetaKey(desc.StartKey).AsRawKey(),
 		},
 		MaxRanges: 1,
 	})

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6126,7 +6126,7 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 	// Get original meta2 descriptor.
 	rlArgs := &roachpb.RangeLookupRequest{
 		Span: roachpb.Span{
-			Key: keys.RangeMetaKey(roachpb.RKey(key)),
+			Key: keys.RangeMetaKey(roachpb.RKey(key)).AsRawKey(),
 		},
 		MaxRanges: 1,
 		Reverse:   isReverse,
@@ -6161,7 +6161,7 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 	// We send directly to Replica throughout this test, so there's no danger
 	// of the Store aborting this transaction (i.e. we don't have to set a high
 	// priority).
-	pArgs := putArgs(keys.RangeMetaKey(roachpb.RKey(key)), data)
+	pArgs := putArgs(keys.RangeMetaKey(roachpb.RKey(key)).AsRawKey(), data)
 	txn.Sequence++
 	if _, pErr = maybeWrapWithBeginTransaction(context.Background(), tc.Sender(), roachpb.Header{Txn: txn}, &pArgs); pErr != nil {
 		t.Fatal(pErr)
@@ -6170,7 +6170,7 @@ func testRangeDanglingMetaIntent(t *testing.T, isReverse bool) {
 	// Now lookup the range; should get the value. Since the lookup is
 	// inconsistent, there's no WriteIntentError.
 	// Note that 'A' < 'a'.
-	rlArgs.Key = keys.RangeMetaKey(roachpb.RKey{'A'})
+	rlArgs.Key = keys.RangeMetaKey(roachpb.RKey{'A'}).AsRawKey()
 
 	reply, pErr = tc.SendWrappedWith(roachpb.Header{
 		Timestamp:       tc.Clock().Now(),
@@ -6248,7 +6248,7 @@ func TestRangeLookupAsyncResolveIntent(t *testing.T) {
 	// Get original meta2 descriptor.
 	rlArgs := &roachpb.RangeLookupRequest{
 		Span: roachpb.Span{
-			Key: keys.RangeMetaKey(roachpb.RKey(key)),
+			Key: keys.RangeMetaKey(roachpb.RKey(key)).AsRawKey(),
 		},
 		MaxRanges: 1,
 	}
@@ -6282,7 +6282,7 @@ func TestRangeLookupAsyncResolveIntent(t *testing.T) {
 	// We send directly to Replica throughout this test, so there's no danger
 	// of the Store aborting this transaction (i.e. we don't have to set a high
 	// priority).
-	pArgs := putArgs(keys.RangeMetaKey(roachpb.RKey(key)), data)
+	pArgs := putArgs(keys.RangeMetaKey(roachpb.RKey(key)).AsRawKey(), data)
 	txn.Sequence++
 	if _, pErr = maybeWrapWithBeginTransaction(context.Background(), tc.Sender(), roachpb.Header{Txn: txn}, &pArgs); pErr != nil {
 		t.Fatal(pErr)
@@ -6294,7 +6294,7 @@ func TestRangeLookupAsyncResolveIntent(t *testing.T) {
 	// operation will block forever.
 	//
 	// Note that 'A' < 'a'.
-	rlArgs.Key = keys.RangeMetaKey(roachpb.RKey{'A'})
+	rlArgs.Key = keys.RangeMetaKey(roachpb.RKey{'A'}).AsRawKey()
 
 	reply, pErr = tc.SendWrappedWith(roachpb.Header{
 		Timestamp:       tc.Clock().Now(),
@@ -6355,7 +6355,7 @@ func TestReplicaLookupUseReverseScan(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			pArgs := putArgs(keys.RangeMetaKey(roachpb.RKey(r.EndKey)), data)
+			pArgs := putArgs(keys.RangeMetaKey(roachpb.RKey(r.EndKey)).AsRawKey(), data)
 
 			txn.Sequence++
 			if _, pErr := tc.SendWrappedWith(roachpb.Header{Txn: txn}, &pArgs); pErr != nil {
@@ -6366,8 +6366,8 @@ func TestReplicaLookupUseReverseScan(t *testing.T) {
 		// Resolve the intents.
 		rArgs := &roachpb.ResolveIntentRangeRequest{
 			Span: roachpb.Span{
-				Key:    keys.RangeMetaKey(roachpb.RKey("a")),
-				EndKey: keys.RangeMetaKey(roachpb.RKey("z")),
+				Key:    keys.RangeMetaKey(roachpb.RKey("a")).AsRawKey(),
+				EndKey: keys.RangeMetaKey(roachpb.RKey("z")).AsRawKey(),
 			},
 			IntentTxn: txn.TxnMeta,
 			Status:    roachpb.COMMITTED,
@@ -6387,7 +6387,7 @@ func TestReplicaLookupUseReverseScan(t *testing.T) {
 	// Test ReverseScan without intents.
 	for _, c := range testCases {
 		clonedRLArgs := *rlArgs
-		clonedRLArgs.Key = keys.RangeMetaKey(roachpb.RKey(c.key))
+		clonedRLArgs.Key = keys.RangeMetaKey(roachpb.RKey(c.key)).AsRawKey()
 		reply, pErr := tc.SendWrappedWith(roachpb.Header{
 			ReadConsistency: roachpb.INCONSISTENT,
 		}, &clonedRLArgs)
@@ -6409,7 +6409,7 @@ func TestReplicaLookupUseReverseScan(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		pArgs := putArgs(keys.RangeMetaKey(roachpb.RKey(r.EndKey)), data)
+		pArgs := putArgs(keys.RangeMetaKey(roachpb.RKey(r.EndKey)).AsRawKey(), data)
 
 		txn.Sequence++
 		if _, pErr := tc.SendWrappedWith(roachpb.Header{Txn: txn}, &pArgs); pErr != nil {
@@ -6420,7 +6420,7 @@ func TestReplicaLookupUseReverseScan(t *testing.T) {
 	// Test ReverseScan with intents.
 	for _, c := range testCases {
 		clonedRLArgs := *rlArgs
-		clonedRLArgs.Key = keys.RangeMetaKey(roachpb.RKey(c.key))
+		clonedRLArgs.Key = keys.RangeMetaKey(roachpb.RKey(c.key)).AsRawKey()
 		reply, pErr := tc.SendWrappedWith(roachpb.Header{
 			ReadConsistency: roachpb.INCONSISTENT,
 		}, &clonedRLArgs)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1716,16 +1716,12 @@ func (s *Store) BootstrapRange(
 	}
 	// Range addressing for meta2.
 	meta2Key := keys.RangeMetaKey(roachpb.RKeyMax)
-	if err := engine.MVCCPutProto(ctx, batch, ms, meta2Key, now, nil, desc); err != nil {
+	if err := engine.MVCCPutProto(ctx, batch, ms, meta2Key.AsRawKey(), now, nil, desc); err != nil {
 		return err
 	}
 	// Range addressing for meta1.
-	meta2KeyAddr, err := keys.Addr(meta2Key)
-	if err != nil {
-		return err
-	}
-	meta1Key := keys.RangeMetaKey(meta2KeyAddr)
-	if err := engine.MVCCPutProto(ctx, batch, ms, meta1Key, now, nil, desc); err != nil {
+	meta1Key := keys.RangeMetaKey(meta2Key)
+	if err := engine.MVCCPutProto(ctx, batch, ms, meta1Key.AsRawKey(), now, nil, desc); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The function takes an `RKey` as an argument and it's not possible
that the meta key for an `RKey` will be a local key. Because of this,
the function should have been returning an `RKey`.

Pulled out of #18970.