### PR TITLE
cherrypick-1.1: server: Fix --advertise-port

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -451,8 +451,8 @@ func TestOfficializeAddr(t *testing.T) {
 				cfgAddr, lnAddr, expAddr string
 			}{
 				{"localhost:0", "127.0.0.1:1234", "localhost:1234"},
-				{"localhost:1234", "127.0.0.1:2345", "localhost:2345"},
-				{":1234", net.JoinHostPort(addrs[0], "2345"), net.JoinHostPort(host, "2345")},
+				{"localhost:1234", "127.0.0.1:2345", "localhost:1234"},
+				{":1234", net.JoinHostPort(addrs[0], "2345"), net.JoinHostPort(host, "1234")},
 				{":0", net.JoinHostPort(addrs[0], "2345"), net.JoinHostPort(host, "2345")},
 			} {
 				t.Run(tc.cfgAddr, func(t *testing.T) {


### PR DESCRIPTION
The proposal by @petermattis this morning was to cherrypick this into 1.1.1, but not 1.1.0. It's only fixing a hidden flag, so it doesn't truly need to be cherrypicked at all, but is relevant to the use case described in #18932 of running multiple overlapping cockroach clusters on a set of machines with nginx proxying on different ports for the different processes. Opening for discussion, will wait until after 1.1.0 before considering a merge.

@cockroachdb/release 