### PR TITLE
build: also build terminfo libs as deps

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial-20170619
+FROM ubuntu:xenial-20170915
 
 MAINTAINER Tamir Duberstein <tamird@gmail.com>
 
@@ -79,14 +79,55 @@ RUN mkdir crosstool-ng \
  && rm -rf crosstool-ng
 
 COPY x86_64-unknown-linux-gnu.defconfig x86_64-unknown-linux-musl.defconfig x86_64-w64-mingw.defconfig ./
-RUN mkdir build src && cd build \
- && rm -rf * && DEFCONFIG=../x86_64-unknown-linux-gnu.defconfig  /usr/local/ct-ng/bin/ct-ng defconfig && /usr/local/ct-ng/bin/ct-ng build \
- && rm -rf * && DEFCONFIG=../x86_64-unknown-linux-musl.defconfig /usr/local/ct-ng/bin/ct-ng defconfig && /usr/local/ct-ng/bin/ct-ng build \
- && rm -rf * && DEFCONFIG=../x86_64-w64-mingw.defconfig          /usr/local/ct-ng/bin/ct-ng defconfig && /usr/local/ct-ng/bin/ct-ng build \
- && cd .. \
- && rm -rf build src
+RUN mkdir src \
+ && mkdir build && (cd build && DEFCONFIG=../x86_64-unknown-linux-gnu.defconfig  /usr/local/ct-ng/bin/ct-ng defconfig && /usr/local/ct-ng/bin/ct-ng build) && rm -rf build \
+ && mkdir build && (cd build && DEFCONFIG=../x86_64-unknown-linux-musl.defconfig /usr/local/ct-ng/bin/ct-ng defconfig && /usr/local/ct-ng/bin/ct-ng build) && rm -rf build \
+ && mkdir build && (cd build && DEFCONFIG=../x86_64-w64-mingw.defconfig          /usr/local/ct-ng/bin/ct-ng defconfig && /usr/local/ct-ng/bin/ct-ng build) && rm -rf build \
+ && rm -rf src
 
 RUN apt-get autoremove -y gcc g++
+
+# Build & install libtinfo (terminfo) for the linux targets.
+# (on BSD or BSD-derived like macOS it's already built-in; on windows we don't need it.)
+#
+# The patch is needed to work around a bug in Debian mawk, see
+# http://lists.gnu.org/archive/html/bug-ncurses/2015-08/msg00008.html
+COPY ncurses.patch ./
+#
+# Run the two builds.
+# As per the Debian rule file for ncurses, the two configure tests for
+# the type of bool and poll(2) are broken when cross-compiling, so we
+# need to feed the test results manually to configure via an environment
+# variable; see debian/rules on the Debian ncurses source package.
+#
+# The configure other settings in ncurses.conf are also sourced from the
+# Debian source package.
+#
+COPY ncurses.conf ./
+RUN mkdir ncurses \
+ && curl -fsSL http://ftp.gnu.org/gnu/ncurses/ncurses-6.0.tar.gz | tar --strip-components=1 -C ncurses -xz \
+ && cd ncurses \
+ && patch -p0 <../ncurses.patch \
+ && export cf_cv_type_of_bool='unsigned char' \
+ && export cf_cv_working_poll=yes \
+ && mkdir build-x86_64-unknown-linux-musl \
+ && (cd build-x86_64-unknown-linux-musl \
+    && CC=/x-tools/x86_64-unknown-linux-musl/bin/x86_64-unknown-linux-musl-cc \
+       CXX=/x-tools/x86_64-unknown-linux-musl/bin/x86_64-unknown-linux-musl-c++ \
+       ../configure --prefix=/x-tools/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/sysroot/usr \
+         --host=x86_64-unknown-linux-musl \
+         $(cat /ncurses.conf) --without-shared --without-dlsym \
+    && (cd ncurses && make all && make install.tinfo)) \
+ && mkdir build-x86_64-unknown-linux-gnu \
+ && (cd build-x86_64-unknown-linux-gnu \
+    && CC=/x-tools/x86_64-unknown-linux-gnu/bin/x86_64-unknown-linux-gnu-cc \
+       CXX=/x-tools/x86_64-unknown-linux-gnu/bin/x86_64-unknown-linux-gnu-c++ \
+       ../configure --prefix=/x-tools/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot/usr \
+         --host=x86_64-unknown-linux-gnu \
+         $(cat /ncurses.conf) \
+    && (cd ncurses && make all && make install.tinfo)) \
+ && cd .. \
+ && rm -rf ncurses ncurses.conf ncurses.patch
 
 # Build an msan-enabled build of libc++, following instructions from
 # https://github.com/google/sanitizers/wiki/MemorySanitizerLibcxxHowTo

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20171003-192752
+version=20171004-085709
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")"

--- a/build/ncurses.conf
+++ b/build/ncurses.conf
@@ -1,0 +1,21 @@
+--with-abi-version=5
+--with-shared
+--without-profile --without-debug
+--disable-rpath --enable-echo
+--enable-const
+--without-gpm
+--without-ada
+--without-tests
+--disable-macros
+--without-progs
+--enable-symlinks
+--disable-lp64
+--with-chtype=long
+--with-mmask-t=long
+--disable-termcap
+--with-default-terminfo-dir=/etc/terminfo
+--with-terminfo-dirs=/etc/terminfo:/lib/terminfo:/usr/share/terminfo
+--with-ticlib=tic
+--with-termlib=tinfo
+--without-versioned-syms
+--with-xterm-kbs=del

--- a/build/ncurses.patch
+++ b/build/ncurses.patch
@@ -1,0 +1,11 @@
+--- ncurses/base/MKlib_gen.sh   2015-08-07 00:48:24.000000000 +0000
++++ ncurses/base/MKlib_gen.sh   2017-10-03 07:12:40.873640729 +0000
+@@ -72,7 +72,7 @@
+ # appears in gcc 5.0 and (with modification) in 5.1, making it necessary to
+ # determine if we are using gcc, and if so, what version because the proposed
+ # solution uses a nonstandard option.
+-PRG=`echo "$1" | $AWK '{ sub(/^[[:space:]]*/,""); sub(/[[:space:]].*$/, ""); print; }' || exit 0`
++PRG=`echo "$1" | $AWK '{ sub(/^[ 	]*/,""); sub(/[ 	].*$/, ""); print; }' || exit 0`
+ FSF=`"$PRG" --version 2>/dev/null || exit 0 | fgrep "Free Software Foundation" | head -n 1`
+ ALL=`"$PRG" -dumpversion 2>/dev/null || exit 0`
+ ONE=`echo "$ALL" | sed -e 's/\..*$//'`


### PR DESCRIPTION
Needed for #18531.

I will update the PR with the docker.io image tag when I have checked locally that #18531 passes all tests with this. You can start looking at the general gist of the change in the mean time.