### PR TITLE
*: consistently use versioned URLs to docs

### DIFF
--- a/pkg/base/docs.go
+++ b/pkg/base/docs.go
@@ -1,0 +1,29 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package base
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/build"
+)
+
+// DocsURLBase is the root URL for the version of the docs associated with this
+// binary.
+var DocsURLBase = fmt.Sprintf("https://www.cockroachlabs.com/docs/%s/", build.VersionPrefix())
+
+// DocsURL generates the URL to pageName in the version of the docs associated
+// with this binary.
+func DocsURL(pageName string) string { return DocsURLBase + pageName }

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/chzyer/readline"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -177,7 +178,7 @@ const (
 
 // printCliHelp prints a short inline help about the CLI.
 func printCliHelp() {
-	fmt.Print(`You are using 'cockroach sql', CockroachDB's lightweight SQL client.
+	fmt.Printf(`You are using 'cockroach sql', CockroachDB's lightweight SQL client.
 Type:
   \q to exit        (Ctrl+C/Ctrl+D also supported)
   \! CMD            run an external command and print its results on standard output.
@@ -190,10 +191,11 @@ Type:
   \hf [NAME]        help on SQL built-in functions.
 
 More documentation about our SQL dialect and the CLI shell is available online:
-https://www.cockroachlabs.com/docs/stable/sql-statements.html
-https://www.cockroachlabs.com/docs/stable/use-the-built-in-sql-client.html
-
-`)
+%s
+%s`,
+		base.DocsURL("sql-statements.html"),
+		base.DocsURL("use-the-built-in-sql-client.html"),
+	)
 }
 
 // addHistory persists a line of input to the readline history

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -42,6 +42,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -780,7 +781,7 @@ func setupAndInitializeLoggingAndProfiling(ctx context.Context) (*stop.Stopper, 
 				"- Any user, even root, can log in without providing a password.\n"+
 				"- Any user, connecting as root, can read or write any data in your cluster.\n"+
 				"- There is no network encryption nor authentication, and thus no confidentiality.\n\n"+
-				"Check out how to secure your cluster: https://www.cockroachlabs.com/docs/stable/secure-a-cluster.html")
+				"Check out how to secure your cluster: "+base.DocsURL("secure-a-cluster.html"))
 	}
 
 	maybeWarnCacheSize()

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -75,8 +75,11 @@ const (
 
 	minimumNetworkFileDescriptors     = 256
 	recommendedNetworkFileDescriptors = 5000
+)
 
-	productionSettingsWebpage = "please see https://www.cockroachlabs.com/docs/stable/recommended-production-settings.html for more details"
+var productionSettingsWebpage = fmt.Sprintf(
+	"please see %s for more details",
+	base.DocsURL("recommended-production-settings.html"),
 )
 
 // MaxOffsetType stores the configured MaxOffset.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -862,18 +862,13 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 
 	defer time.AfterFunc(30*time.Second, func() {
-		serverVersion := s.cfg.Settings.Version.ServerVersion
-		// If the version is an unstable development version, treat it as the last
-		// stable version so that the docs link will exist (for example, 1.1-5
-		// becomes 1.1).
-		serverVersion.Unstable = 0
 		msg := `The server appears to be unable to contact the other nodes in the cluster. Please try
 
 - starting the other nodes, if you haven't already
 - double-checking that the '--join' and '--host' flags are set up correctly
 - not using the '--background' flag.
 
-If problems persist, please see https://www.cockroachlabs.com/docs/v` + serverVersion.String() + `/cluster-setup-troubleshooting.html.`
+If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.html") + "."
 
 		log.Shout(context.Background(), log.Severity_WARNING,
 			msg)

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/base"
 )
 
 // HelpMessage describes a contextual help message.
@@ -35,10 +35,6 @@ type HelpMessage struct {
 	// HelpMessageBody contains the details of the message.
 	HelpMessageBody
 }
-
-var docsURLBase = "https://www.cockroachlabs.com/docs/" + build.VersionPrefix()
-
-func docsURL(pageName string) string { return docsURLBase + "/" + pageName }
 
 // String implements the fmt.String interface.
 func (h *HelpMessage) String() string {
@@ -100,7 +96,7 @@ func helpWithFunction(sqllex sqlLexer, f ResolvableFunctionReference) int {
 		Function: f.String(),
 		HelpMessageBody: HelpMessageBody{
 			Category: "built-in functions",
-			SeeAlso:  docsURL("functions-and-operators.html"),
+			SeeAlso:  base.DocsURL("functions-and-operators.html"),
 		},
 	}
 
@@ -171,7 +167,7 @@ var HelpMessages = func(h map[string]HelpMessageBody) map[string]HelpMessageBody
 	reformatSeeAlso := func(seeAlso string) string {
 		return strings.Replace(
 			strings.Replace(seeAlso, ", ", "\n  ", -1),
-			"WEBDOCS", docsURLBase, -1)
+			"WEBDOCS", base.DocsURLBase, -1)
 	}
 	srcMsg := h["<SOURCE>"]
 	srcMsg.SeeAlso = reformatSeeAlso(strings.TrimSpace(srcMsg.SeeAlso))

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import _ from "lodash";
 
+import docsURL from "src/util/docs";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
@@ -87,7 +88,7 @@ export default function (props: GraphDashboardProps) {
                 Control this value per node with the
                   <code>
                   <a
-                    href="https://www.cockroachlabs.com/docs/stable/start-a-node.html#flags"
+                    href={docsURL("start-a-node.html#flags")}
                     target="_blank"
                   >
                     --store


### PR DESCRIPTION
Previously, some links to the docs website hardcoded the "stable"
version alias. Since the "stable" content is updated with every release,
the link points to increasingly irrelevant content for old binaries.
Instead, derive a docs "permalink" from the binary's version. (This
logic previously existed in sql/parser; this commit simply applies that
logic to docs URLs in other packages.)

Fix #18984.

@knz can you review? (The reviewers field is broken.)