### PR TITLE
cluster: streamline version handling

### DIFF
--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -118,8 +118,8 @@ func TestClusterVersionUpgrade1_0To1_2(t *testing.T) {
 
 	// Start by running 1.0.
 	bootstrapVersion := cluster.ClusterVersion{
-		UseVersion:     cluster.VersionBase,
-		MinimumVersion: cluster.VersionBase,
+		UseVersion:     cluster.VersionByKey(cluster.VersionBase),
+		MinimumVersion: cluster.VersionByKey(cluster.VersionBase),
 	}
 
 	tc := setupMixedCluster(t, bootstrapVersion, versions)
@@ -143,7 +143,7 @@ func TestClusterVersionUpgrade1_0To1_2(t *testing.T) {
 		for i := 0; i < tc.NumServers(); i++ {
 			v := tc.getVersionFromSetting(i)
 			wantActive := isNoopUpdate
-			if isActive := v.IsActive(newVersion); isActive != wantActive {
+			if isActive := v.Version().IsActiveVersion(newVersion); isActive != wantActive {
 				t.Fatalf("%d: v%s active=%t (wanted %t)", i, newVersion, isActive, wantActive)
 			}
 
@@ -255,8 +255,8 @@ func TestClusterVersionMixedVersionTooOld(t *testing.T) {
 
 	// Start by running 1.0.
 	bootstrapVersion := cluster.ClusterVersion{
-		UseVersion:     cluster.VersionBase,
-		MinimumVersion: cluster.VersionBase,
+		UseVersion:     cluster.VersionByKey(cluster.VersionBase),
+		MinimumVersion: cluster.VersionByKey(cluster.VersionBase),
 	}
 
 	tc := setupMixedCluster(t, bootstrapVersion, versions)

--- a/pkg/settings/cluster/cluster_version.go
+++ b/pkg/settings/cluster/cluster_version.go
@@ -14,57 +14,19 @@
 
 package cluster
 
-import "github.com/cockroachdb/cockroach/pkg/roachpb"
-
-var (
-	// BinaryMinimumSupportedVersion is the earliest version of data supported
-	// by this binary. If this binary is started using a store that has data
-	// marked with an earlier version than BinaryMinimumSupportedVersion, then
-	// the binary will exit with an error.
-	BinaryMinimumSupportedVersion = VersionBase
-
-	// BinaryServerVersion is the version of this binary.
-	//
-	// NB: This is the version that a new cluster will use when created.
-	BinaryServerVersion = VersionMVCCNetworkStats
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
-// List all historical versions here in reverse chronological order, with
-// comments describing what backwards-incompatible features were introduced.
-//
-// NB: when adding a version, don't forget to bump ServerVersion above (and
-// perhaps MinimumSupportedVersion, if necessary). Note that the version
-// upgrade process requires the versions as seen by a cluster to be
-// monotonic. Once we've added 1.1-2 (VersionMVCCNetworkStats), we can't go
-// back and add 1.0-4 (VersionFixSomeCriticalBug) because clusters running
-// 1.1-2 can't coordinate the switch over to the functionality added by
-// 1.0-4. Such clusters would need to be wiped. As a result, we recommend not
-// bumping to a new minor version until the prior 1.X.0 release has been
-// performed.
-var (
-	// VersionMVCCNetworkStats is https://github.com/cockroachdb/cockroach/pull/18828.
-	VersionMVCCNetworkStats = roachpb.Version{Major: 1, Minor: 1, Unstable: 2}
-
-	// VersionRaftLastIndex is https://github.com/cockroachdb/cockroach/pull/18717.
-	VersionRaftLastIndex = roachpb.Version{Major: 1, Minor: 1, Unstable: 1}
-
-	// VersionStatsBasedRebalancing is https://github.com/cockroachdb/cockroach/pull/16878.
-	VersionStatsBasedRebalancing = roachpb.Version{Major: 1, Minor: 0, Unstable: 3}
-
-	// VersionSplitHardStateBelowRaft is https://github.com/cockroachdb/cockroach/pull/17051.
-	VersionSplitHardStateBelowRaft = roachpb.Version{Major: 1, Minor: 0, Unstable: 2}
-
-	// VersionRaftLogTruncationBelowRaft is https://github.com/cockroachdb/cockroach/pull/16993.
-	VersionRaftLogTruncationBelowRaft = roachpb.Version{Major: 1, Minor: 0, Unstable: 1}
-
-	// VersionBase corresponds to any binary older than 1.0-1,
-	// though these binaries won't know anything about the mechanism in which
-	// this version is used.
-	VersionBase = roachpb.Version{Major: 1}
-)
+// IsActiveVersion returns true if the features of the supplied version are active at the running
+// version.
+func (cv ClusterVersion) IsActiveVersion(v roachpb.Version) bool {
+	return !cv.UseVersion.Less(v)
+}
 
 // IsActive returns true if the features of the supplied version are active at
 // the running version.
-func (cv ClusterVersion) IsActive(v roachpb.Version) bool {
-	return !cv.UseVersion.Less(v)
+func (cv ClusterVersion) IsActive(versionKey VersionKey) bool {
+	v := VersionByKey(versionKey)
+	return cv.IsActiveVersion(v)
 }

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -1,0 +1,103 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cluster
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// VersionKey is a unique identifier for a version of CockroachDB.
+type VersionKey int
+
+// Version constants. To add a version:
+// - add it at the end of this block
+// - add it at the end of the `Versions` block below
+// - (typically only applies to major and minor releases): bump BinaryMinimumSupportedVersion.
+//   For example, when introducing the `1.4` release, BinaryMinimumSupportedVersion would increase to `1.3`.
+const (
+	VersionBase VersionKey = iota
+	VersionRaftLogTruncationBelowRaft
+	VersionSplitHardStateBelowRaft
+	VersionStatsBasedRebalancing
+	VersionRaftLastIndex
+	VersionMVCCNetworkStats
+
+	// Add new versions here (step one of two)
+
+)
+
+// Versions lists all historical versions here in chronological order, with comments describing what
+// backwards-incompatible features were introduced.
+//
+// NB: The version upgrade process requires the versions as seen by a cluster to be monotonic. Once
+// we've added 1.1-2 (VersionMVCCNetworkStats), we can't go back and add 1.0-4
+// (VersionFixSomeCriticalBug) because clusters running 1.1-2 can't coordinate the switch over to
+// the functionality added by 1.0-4. Such clusters would need to be wiped. As a result, we recommend
+// not bumping to a new minor version until the prior 1.X.0 release has been performed.
+var versionsSingleton = keyedVersions([]keyedVersion{
+	{
+		// VersionBase corresponds to any binary older than 1.0-1, though these binaries won't know
+		// anything about the mechanism in which this version is used.
+		Key:     VersionBase,
+		Version: roachpb.Version{Major: 1},
+	},
+	{
+		// VersionRaftLogTruncationBelowRaft is https://github.com/cockroachdb/cockroach/pull/16993.
+		Key:     VersionRaftLogTruncationBelowRaft,
+		Version: roachpb.Version{Major: 1, Minor: 0, Unstable: 1},
+	},
+	{
+		// VersionSplitHardStateBelowRaft is https://github.com/cockroachdb/cockroach/pull/17051.
+		Key:     VersionSplitHardStateBelowRaft,
+		Version: roachpb.Version{Major: 1, Minor: 0, Unstable: 2},
+	},
+	{
+		// VersionStatsBasedRebalancing is https://github.com/cockroachdb/cockroach/pull/16878.
+		Key:     VersionStatsBasedRebalancing,
+		Version: roachpb.Version{Major: 1, Minor: 0, Unstable: 3},
+	},
+	{
+		// VersionRaftLastIndex is https://github.com/cockroachdb/cockroach/pull/18717.
+		Key:     VersionRaftLastIndex,
+		Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 1},
+	},
+	{
+		// VersionMVCCNetworkStats is https://github.com/cockroachdb/cockroach/pull/18828.
+		Key:     VersionMVCCNetworkStats,
+		Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 2},
+	},
+
+	// Add new versions here (step two of two).
+
+}).Validated()
+
+var (
+	// BinaryMinimumSupportedVersion is the earliest version of data supported
+	// by this binary. If this binary is started using a store that has data
+	// marked with an earlier version than BinaryMinimumSupportedVersion, then
+	// the binary will exit with an error.
+	BinaryMinimumSupportedVersion = VersionByKey(VersionBase)
+
+	// BinaryServerVersion is the version of this binary.
+	//
+	// This is the version that a new cluster will use when created.
+	BinaryServerVersion = versionsSingleton[len(versionsSingleton)-1].Version
+)
+
+// VersionByKey returns the roachpb.Version for a given key.
+// It is a fatal error to use an invalid key.
+func VersionByKey(key VersionKey) roachpb.Version {
+	return versionsSingleton.MustByKey(key)
+}

--- a/pkg/settings/cluster/keyed_versions.go
+++ b/pkg/settings/cluster/keyed_versions.go
@@ -1,0 +1,62 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cluster
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/kr/pretty"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// keyedVersion associates a key to a version.
+type keyedVersion struct {
+	Key VersionKey
+	roachpb.Version
+}
+
+// keyedVersions is a container for managing the versions of CockroachDB.
+type keyedVersions []keyedVersion
+
+// MustByKey asserts that the version specified by this key exists, and returns it.
+func (kv keyedVersions) MustByKey(k VersionKey) roachpb.Version {
+	key := int(k)
+	if key >= len(kv) || key < 0 {
+		log.Fatalf(context.Background(), "version with key %d does not exist, have:\n%s",
+			key, pretty.Sprint(kv))
+	}
+	return kv[key].Version
+}
+
+// Validated returns the receiver after asserting that versions are in chronological order
+// and that their keys correspond to their position in the list.
+func (kv keyedVersions) Validated() keyedVersions {
+	ctx := context.Background()
+	for i, namedVersion := range kv {
+		if int(namedVersion.Key) != i {
+			log.Fatalf(ctx, "version %s should have key %d but has %d",
+				namedVersion, i, namedVersion.Key)
+		}
+		if i > 0 {
+			prev := kv[i-1]
+			if !prev.Version.Less(namedVersion.Version) {
+				log.Fatalf(ctx, "version %s must be larger than %s", namedVersion, prev)
+			}
+		}
+	}
+	return kv
+}

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -149,10 +149,10 @@ func (ecv *ExposedClusterVersion) BootstrapVersion() ClusterVersion {
 	}
 }
 
-// IsActive returns true if the features of the supplied version are active at
-// the running version.
-func (ecv *ExposedClusterVersion) IsActive(v roachpb.Version) bool {
-	return ecv.Version().IsActive(v)
+// IsActive returns true if the features of the supplied version key are active at the running
+// version.
+func (ecv *ExposedClusterVersion) IsActive(versionKey VersionKey) bool {
+	return ecv.Version().IsActive(versionKey)
 }
 
 // MakeTestingClusterSettings returns a Settings object that has had its version

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -266,8 +266,8 @@ var logicTestConfigs = []testClusterConfig{
 	{name: "default", numNodes: 1, overrideDistSQLMode: "Off"},
 	{name: "default-v1.1@v1.0", numNodes: 1, overrideDistSQLMode: "Off",
 		bootstrapVersion: &cluster.ClusterVersion{
-			UseVersion:     cluster.VersionBase,
-			MinimumVersion: cluster.VersionBase,
+			UseVersion:     cluster.VersionByKey(cluster.VersionBase),
+			MinimumVersion: cluster.VersionByKey(cluster.VersionBase),
 		},
 		serverVersion: &roachpb.Version{Major: 1, Minor: 1},
 	},

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -432,7 +432,7 @@ func populateVersionSetting(ctx context.Context, r runner) error {
 	if v == (roachpb.Version{}) {
 		// The cluster was bootstrapped at v1.0 (or even earlier), so make that
 		// the version.
-		v = cluster.VersionBase
+		v = cluster.VersionByKey(cluster.VersionBase)
 	}
 
 	b, err := protoutil.Marshal(&cluster.ClusterVersion{

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1701,7 +1701,7 @@ func (s *Store) BootstrapRange(
 	// Bootstrap version information. We don't do this if this is v1.0, which is
 	// never going to be true in versions that have this code in production, but
 	// can be true in tests.
-	if bootstrapVersion != cluster.VersionBase {
+	if bootstrapVersion != cluster.VersionByKey(cluster.VersionBase) {
 		if err := engine.MVCCPutProto(ctx, batch, ms /* ms */, keys.BootstrapVersionKey, hlc.Timestamp{}, nil, &bootstrapVersion); err != nil {
 			return err
 		}

--- a/pkg/storage/stores.go
+++ b/pkg/storage/stores.go
@@ -384,10 +384,10 @@ func ReadVersionFromEngineOrDefault(
 	// These values should always exist in 1.1-initialized clusters, but may
 	// not on 1.0.x; we synthesize the missing version.
 	if cv.UseVersion == (roachpb.Version{}) {
-		cv.UseVersion = cluster.VersionBase
+		cv.UseVersion = cluster.VersionByKey(cluster.VersionBase)
 	}
 	if cv.MinimumVersion == (roachpb.Version{}) {
-		cv.MinimumVersion = cluster.VersionBase
+		cv.MinimumVersion = cluster.VersionByKey(cluster.VersionBase)
 	}
 	return cv, nil
 }

--- a/pkg/storage/stores_test.go
+++ b/pkg/storage/stores_test.go
@@ -431,7 +431,7 @@ func TestStoresClusterVersionWriteSynthesize(t *testing.T) {
 	makeStores := func() *Stores {
 		// Hard-code ServerVersion of 1.1 for this test.
 		// Hard-code MinSupportedVersion of 1.0 for this test.
-		ls := NewStores(log.AmbientContext{}, stores[0].Clock(), cluster.VersionBase, roachpb.Version{Major: 1, Minor: 1})
+		ls := NewStores(log.AmbientContext{}, stores[0].Clock(), cluster.VersionByKey(cluster.VersionBase), roachpb.Version{Major: 1, Minor: 1})
 		return ls
 	}
 
@@ -454,8 +454,8 @@ func TestStoresClusterVersionWriteSynthesize(t *testing.T) {
 			t.Fatal(err)
 		} else {
 			expCV := cluster.ClusterVersion{
-				MinimumVersion: cluster.VersionBase,
-				UseVersion:     cluster.VersionBase,
+				MinimumVersion: cluster.VersionByKey(cluster.VersionBase),
+				UseVersion:     cluster.VersionByKey(cluster.VersionBase),
 			}
 			if !reflect.DeepEqual(initialCV, expCV) {
 				t.Fatalf("expected %+v; got %+v", expCV, initialCV)
@@ -494,7 +494,7 @@ func TestStoresClusterVersionWriteSynthesize(t *testing.T) {
 
 		expCV := cluster.ClusterVersion{
 			MinimumVersion: versionA,
-			UseVersion:     cluster.VersionBase,
+			UseVersion:     cluster.VersionByKey(cluster.VersionBase),
 		}
 		if cv, err := ls01.SynthesizeClusterVersion(ctx); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Force (and verify) an ordering between versions and make it more straightforward to add a new one.