### PR TITLE
build: Build Docker images with the --no-cache flag

### DIFF
--- a/build/teamcity-publish-artifacts.sh
+++ b/build/teamcity-publish-artifacts.sh
@@ -16,7 +16,7 @@ if [[ "$TC_BUILD_BRANCH" != *-* ]] && [ "$TEAMCITY_BUILDCONF_NAME" == 'Publish R
   image=docker.io/cockroachdb/cockroach
 
   cp cockroach-linux-2.6.32-gnu-amd64 build/deploy/cockroach
-  docker build --tag=$image:{latest,"$TC_BUILD_BRANCH"} build/deploy
+  docker build --no-cache --tag=$image:{latest,"$TC_BUILD_BRANCH"} build/deploy
 
   TYPE=release-$(go env GOOS)
   case $TYPE in


### PR DESCRIPTION
To avoid ending up with old image components like CA certs.

Follow-up to a comment on #18959