### PR TITLE
distsql: add `distsql-disk` configuration to logic tests (incl. bigtest)

### DIFF
--- a/build/teamcity-sqllogictest.sh
+++ b/build/teamcity-sqllogictest.sh
@@ -9,7 +9,7 @@ mkdir -p artifacts
 # the all-on/all-off strategy BULIDER_HIDE_GOPATH_SRC gives us.
 export BUILDER_HIDE_GOPATH_SRC=0
 
-for config in default distsql; do
+for config in default distsql distsql-disk; do
     build/builder.sh env \
         make test TESTFLAGS="-v -bigtest -config ${config}" TESTTIMEOUT='24h' PKG='./pkg/sql/logictest' TESTS='^TestLogic$$' 2>&1 \
         | tee "artifacts/${config}.log" \

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -230,7 +230,7 @@ func TestSorter(t *testing.T) {
 				// Override the default memory limit. This will result in using
 				// a memory row container which will hit this limit and fall
 				// back to using a disk row container.
-				s.testingKnobMemLimit = memLimit
+				s.flowCtx.testingKnobs.MemoryLimitBytes = memLimit
 				s.Run(ctx, nil)
 				if !out.ProducerClosed {
 					t.Fatalf("output RowReceiver not closed")

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -276,6 +276,7 @@ var logicTestConfigs = []testClusterConfig{
 	{name: "distsql-disk", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "On", distSQLUseDisk: true},
 	{name: "5node", numNodes: 5, overrideDistSQLMode: "Off"},
 	{name: "5node-distsql", numNodes: 5, overrideDistSQLMode: "On"},
+	{name: "5node-distsql-disk", numNodes: 5, overrideDistSQLMode: "On", distSQLUseDisk: true},
 }
 
 // An index in the above slice.

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -275,6 +275,7 @@ var logicTestConfigs = []testClusterConfig{
 	{name: "distsql", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "On"},
 	{name: "distsql-disk", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "On", distSQLUseDisk: true},
 	{name: "5node", numNodes: 5, overrideDistSQLMode: "Off"},
+	{name: "5node-distsql", numNodes: 5, overrideDistSQLMode: "On"},
 }
 
 // An index in the above slice.

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 # English collation chart: http://www.unicode.org/cldr/charts/30/collation/en_US_POSIX.html
 

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 ##
 # Test a primary key with a collated string in first position (can get a key range).

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 ##
 # Test a primary key with a collated string in second position (cannot get a key range).

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 ##
 # Test a primary key with a collated string in first position (can get a key range).

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 ##
 # Test a primary key with a collated string in second position (cannot get a key range).

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 # The following tests have results equivalent to Postgres (differences
 # in string representation and number of decimals returned, but otherwise

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 statement ok
 CREATE TABLE xyz (

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql
+# LogicTest: 5node-distsql 5node-distsql-disk
 
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -1,4 +1,4 @@
-# LogicTest: 5node
+# LogicTest: 5node-distsql
 
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))
@@ -35,10 +35,6 @@ NULL       /1       {1}       1
 /7         /8       {3}       3
 /8         /9       {4}       4
 /9         NULL     {5}       5
-
-# Ready to roll!
-statement ok
-SET DISTSQL = ON
 
 # We hardcode the plan for the testcase that follows to make it easier to debug
 # errors caused by changing planning logic.

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -1,4 +1,4 @@
-# LogicTest: 5node
+# LogicTest: 5node-distsql
 
 statement ok
 CREATE TABLE data (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b, c, d))
@@ -35,10 +35,6 @@ NULL       /1       1         {1}       1
 /7         /8       8         {3}       3
 /8         /9       9         {4}       4
 /9         NULL     10        {5}       5
-
-# Ready to roll!
-statement ok
-SET DISTSQL = ON
 
 statement ok
 SET CLUSTER SETTING sql.distsql.merge_joins.enabled = true;

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -1,4 +1,4 @@
-# LogicTest: 5node
+# LogicTest: 5node-distsql
 
 # First, we set up two data tables:
 #   - NumToSquare maps integers from 1 to 100 to their squares
@@ -41,11 +41,6 @@ NULL       /2000    {1}       1
 /4000      /6000    {3}       3
 /6000      /8000    {4}       4
 /8000      NULL     {5}       5
-
-# Ready to roll!
-statement ok
-SET DISTSQL = ON
-
 
 #
 # -- Basic tests --

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql
+# LogicTest: 5node-distsql 5node-distsql-disk
 
 # First, we set up two data tables:
 #   - NumToSquare maps integers from 1 to 100 to their squares

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 # The join condition logic is tricky to get right with NULL
 # values. Simple implementations can deal well with NULLs on the first

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-disk
 
 query TT
 SELECT (1, 2, 'hello', NULL, NULL), (true, NULL, (false, 6.6, false))


### PR DESCRIPTION
Previously we only used the `distsql-disk` configuration in `postgresjoin`.