### PR TITLE
build: Use --no-cache when building the RHEL deploy docker image

### DIFF
--- a/build/deploy/rhel/build.sh
+++ b/build/deploy/rhel/build.sh
@@ -6,5 +6,5 @@ set -ux
 # them up afterwards) because docker build can't access resources
 # from parent directories.
 cp ../../../LICENSE ../../../APL.txt ../cockroach.sh ../cockroach ./
-docker build -t cockroachdb:${VERSION} .
+docker build --no-cache -t cockroachdb:${VERSION} .
 rm LICENSE APL.txt cockroach.sh cockroach


### PR DESCRIPTION
Not critical, but a nice-to-have as suggested by https://github.com/cockroachdb/cockroach/pull/18996#issuecomment-333965062