### PR TITLE
sql: bugfix to show trace for select count

### DIFF
--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -151,7 +151,7 @@ func (ib *indexBackfiller) runChunk(
 		}
 
 		for i := int64(0); i < chunkSize; i++ {
-			encRow, err := ib.fetcher.NextRow(ctx, false /* traceKV */)
+			encRow, err := ib.fetcher.NextRow(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -157,6 +157,7 @@ func (jr *joinReader) mainLoop(ctx context.Context) error {
 			})
 		}
 
+		// TODO(radu,andrei,knz): set the traceKV flag when requested by the session.
 		err := jr.fetcher.StartScan(ctx, txn, spans, false /* no batch limits */, 0, false /* traceKV */)
 		if err != nil {
 			log.Errorf(ctx, "scan error: %s", err)
@@ -167,8 +168,7 @@ func (jr *joinReader) mainLoop(ctx context.Context) error {
 		// the next batch. We could start the next batch early while we are
 		// outputting rows.
 		for {
-			// TODO(radu,andrei,knz): set the traceKV flag when requested by the session.
-			fetcherRow, err := jr.fetcher.NextRow(ctx, false /* traceKV */)
+			fetcherRow, err := jr.fetcher.NextRow(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -192,6 +192,7 @@ func (tr *tableReader) Run(ctx context.Context, wg *sync.WaitGroup) {
 		defer log.Infof(ctx, "exiting")
 	}
 
+	// TODO(radu,andrei,knz): set the traceKV flag when requested by the session.
 	if err := tr.fetcher.StartScan(
 		ctx, txn, tr.spans, true /* limit batches */, tr.limitHint, false, /* traceKV */
 	); err != nil {
@@ -202,8 +203,7 @@ func (tr *tableReader) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 
 	for {
-		// TODO(radu,andrei,knz): set the traceKV flag when requested by the session.
-		fetcherRow, err := tr.fetcher.NextRow(ctx, false /* traceKV */)
+		fetcherRow, err := tr.fetcher.NextRow(ctx)
 		if err != nil || fetcherRow == nil {
 			if err != nil {
 				tr.out.output.Push(nil /* row */, ProducerMetadata{Err: err})

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -574,6 +574,18 @@ CREATE TABLE ab (a INT, b INT, PRIMARY KEY(a, b))
 statement ok
 INSERT INTO ab VALUES (1, 4), (1, 5), (2, 1), (2, 2), (2, 6), (3, 9)
 
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT COUNT(*) FROM ab]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /ab/primary/1/4 -> NULL
+fetched: /ab/primary/1/5 -> NULL
+fetched: /ab/primary/2/1 -> NULL
+fetched: /ab/primary/2/2 -> NULL
+fetched: /ab/primary/2/6 -> NULL
+fetched: /ab/primary/3/9 -> NULL
+output row: [6]
+
 # Note: the output from GROUP BY is in random order; the example is constructed so
 # those rows are identical.
 query T


### PR DESCRIPTION
If tracing is on, we always have to decode the key component of every
fetched kv. There was a missing case, causing a panic.

Also, move the traceKV parameter into the rowFetcher struct to get rid
of a bunch of parameter plumbing. It's now initialized during StartScan.

Fixes #18990.