### PR TITLE
sql: don't enable "kv tracing" for SHOW TRACE FOR <stmt>

### DIFF
--- a/pkg/sql/bench_test.go
+++ b/pkg/sql/bench_test.go
@@ -1033,3 +1033,42 @@ func BenchmarkPlanning(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkIndexJoin measure an index-join with 1000 rows.
+func BenchmarkIndexJoin(b *testing.B) {
+	// The table will have an extra column not contained in the index to force a
+	// join with the PK.
+	create := `
+		 CREATE TABLE tidx (
+				 k INT NOT NULL,
+				 v INT NULL,
+				 extra STRING NULL,
+				 CONSTRAINT "primary" PRIMARY KEY (k ASC),
+				 INDEX idx (v ASC),
+				 FAMILY "primary" (k, v, extra)
+		 )
+		`
+	// We'll insert 1000 rows with random values below 1000 in the index. We'll
+	// then query the index with a query that retrieves all the data (but the
+	// optimizer doesn't know that).
+	insert := "insert into tidx(k,v) select generate_series(1,1000), (random()*1000)::int"
+	s, db, _ := serverutils.StartServer(b, base.TestServerArgs{UseDatabase: "bench"})
+	defer s.Stopper().Stop(context.TODO())
+
+	if _, err := db.Exec(`CREATE DATABASE bench`); err != nil {
+		b.Fatal(err)
+	}
+	if _, err := db.Exec(create); err != nil {
+		b.Fatal(err)
+	}
+	if _, err := db.Exec(insert); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := db.Exec("select * from tidx where v < 1000"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -31,7 +31,6 @@ SELECT span, message, operation FROM [SHOW TRACE FOR SELECT 1]
 (0,0)  === SPAN START: sql txn implicit ===  sql txn implicit
 (0,1)  === SPAN START: starting plan ===     starting plan
 (0,2)  === SPAN START: consuming rows ===    consuming rows
-(0,2)  output row: [1]                       consuming rows
 (0,2)  plan completed execution              consuming rows
 (0,2)  resources released, stopping trace    consuming rows
 
@@ -44,7 +43,6 @@ SELECT span, message, operation FROM [SHOW TRACE FOR EXECUTE x]
 (0,0)  === SPAN START: sql txn implicit ===  sql txn implicit
 (0,1)  === SPAN START: starting plan ===     starting plan
 (0,2)  === SPAN START: consuming rows ===    consuming rows
-(0,2)  output row: [1]                       consuming rows
 (0,2)  plan completed execution              consuming rows
 (0,2)  resources released, stopping trace    consuming rows
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1419,7 +1419,12 @@ type SessionTracing struct {
 // span that have already been created will not be traced).
 //
 // StopTracing() needs to be called to finish this trace.
-func (st *SessionTracing) StartTracing(recType tracing.RecordingType, traceKV bool) error {
+//
+// Args:
+// kvTracingEnabled: If set, the traces will also include "KV trace" messages -
+//   verbose messages around the interaction of SQL with KV. Some of the messages
+//   are per-row.
+func (st *SessionTracing) StartTracing(recType tracing.RecordingType, kvTracingEnabled bool) error {
 	if st.enabled {
 		return errors.Errorf("already tracing")
 	}
@@ -1433,7 +1438,7 @@ func (st *SessionTracing) StartTracing(recType tracing.RecordingType, traceKV bo
 
 	tracing.StartRecording(sp, recType)
 	st.enabled = true
-	st.kvTracingEnabled = traceKV
+	st.kvTracingEnabled = kvTracingEnabled
 	st.recordingType = recType
 	return nil
 }

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -334,7 +334,7 @@ WHERE message LIKE 'fetched: %'
 		plan.Close(ctx)
 		return nil, err
 	}
-	tracePlan, err := p.makeTraceNode(stmtPlan)
+	tracePlan, err := p.makeTraceNode(stmtPlan, n.OnlyKVTrace /* kvTracingEnabled */)
 	if err != nil {
 		plan.Close(ctx)
 		stmtPlan.Close(ctx)

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -235,21 +235,19 @@ func makeFKInsertHelper(
 	return h, nil
 }
 
-func (h fkInsertHelper) checkAll(ctx context.Context, row parser.Datums, traceKV bool) error {
+func (h fkInsertHelper) checkAll(ctx context.Context, row parser.Datums) error {
 	if len(h.fks) == 0 {
 		return nil
 	}
 	for idx := range h.fks {
-		if err := h.checkIdx(ctx, idx, row, traceKV); err != nil {
+		if err := h.checkIdx(ctx, idx, row); err != nil {
 			return err
 		}
 	}
 	return h.checker.runCheck(ctx, nil, row)
 }
 
-func (h fkInsertHelper) checkIdx(
-	ctx context.Context, idx IndexID, row parser.Datums, traceKV bool,
-) error {
+func (h fkInsertHelper) checkIdx(ctx context.Context, idx IndexID, row parser.Datums) error {
 	fks := h.fks
 	for i, fk := range fks[idx] {
 		nulls := true
@@ -322,21 +320,19 @@ func makeFKDeleteHelper(
 	return h, nil
 }
 
-func (h fkDeleteHelper) checkAll(ctx context.Context, row parser.Datums, traceKV bool) error {
+func (h fkDeleteHelper) checkAll(ctx context.Context, row parser.Datums) error {
 	if len(h.fks) == 0 {
 		return nil
 	}
 	for idx := range h.fks {
-		if err := h.checkIdx(ctx, idx, row, traceKV); err != nil {
+		if err := h.checkIdx(ctx, idx, row); err != nil {
 			return err
 		}
 	}
-	return h.checker.runCheck(ctx, row, nil)
+	return h.checker.runCheck(ctx, row, nil /* newRow */)
 }
 
-func (h fkDeleteHelper) checkIdx(
-	ctx context.Context, idx IndexID, row parser.Datums, traceKV bool,
-) error {
+func (h fkDeleteHelper) checkIdx(ctx context.Context, idx IndexID, row parser.Datums) error {
 	for i := range h.fks[idx] {
 		if err := h.checker.addCheck(row, &h.fks[idx][i]); err != nil {
 			return err
@@ -381,12 +377,12 @@ func makeFKUpdateHelper(
 }
 
 func (fks fkUpdateHelper) checkIdx(
-	ctx context.Context, idx IndexID, oldValues, newValues parser.Datums, traceKV bool,
+	ctx context.Context, idx IndexID, oldValues, newValues parser.Datums,
 ) error {
-	if err := fks.inbound.checkIdx(ctx, idx, oldValues, traceKV); err != nil {
+	if err := fks.inbound.checkIdx(ctx, idx, oldValues); err != nil {
 		return err
 	}
-	return fks.outbound.checkIdx(ctx, idx, newValues, traceKV)
+	return fks.outbound.checkIdx(ctx, idx, newValues)
 }
 
 // CollectSpans implements the FkSpanCollector interface.

--- a/pkg/sql/sqlbase/kvfetcher.go
+++ b/pkg/sql/sqlbase/kvfetcher.go
@@ -103,10 +103,6 @@ type txnKVFetcher struct {
 	// rangeInfos are deduped, so they're not ordered in any particular way and
 	// they don't map to kvFetcher.spans in any particular way.
 	rangeInfos []roachpb.RangeInfo
-
-	// traceKV determines whether or not to emit a log message every time a Scan
-	// is sent.
-	traceKV bool
 }
 
 func (f *txnKVFetcher) getRangesInfo() []roachpb.RangeInfo {
@@ -172,7 +168,6 @@ func makeKVFetcher(
 	useBatchLimit bool,
 	firstBatchLimit int64,
 	returnRangeInfo bool,
-	traceKV bool,
 ) (txnKVFetcher, error) {
 	if firstBatchLimit < 0 || (!useBatchLimit && firstBatchLimit != 0) {
 		return txnKVFetcher{}, errors.Errorf("invalid batch limit %d (useBatchLimit: %t)",
@@ -206,7 +201,6 @@ func makeKVFetcher(
 		useBatchLimit:   useBatchLimit,
 		firstBatchLimit: firstBatchLimit,
 		returnRangeInfo: returnRangeInfo,
-		traceKV:         traceKV,
 	}, nil
 }
 
@@ -230,16 +224,15 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 		}
 	}
 
-	if f.traceKV {
-		scanStr := "Scan "
+	if log.ExpensiveLogEnabled(ctx, 2) {
+		buf := bytes.NewBufferString("Scan ")
 		for i, span := range f.spans {
 			if i != 0 {
-				scanStr += ", "
+				buf.WriteString(", ")
 			}
-			scanStr += span.String()
+			buf.WriteString(span.String())
 		}
-
-		log.VEventf(ctx, 2, scanStr)
+		log.VEvent(ctx, 2, buf.String())
 	}
 
 	// Reset spans in preparation for adding resume-spans below.

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -229,7 +229,7 @@ func (rf *RowFetcher) StartScan(
 		firstBatchLimit++
 	}
 
-	f, err := makeKVFetcher(txn, spans, rf.reverse, limitBatches, firstBatchLimit, rf.returnRangeInfo, traceKV)
+	f, err := makeKVFetcher(txn, spans, rf.reverse, limitBatches, firstBatchLimit, rf.returnRangeInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -134,7 +134,9 @@ func (n *traceNode) Next(params runParams) (bool, error) {
 					}
 
 					values := n.plan.Values()
-					log.VEventf(consumeCtx, 2, "output row: %s", values)
+					if n.kvTracingEnabled {
+						log.VEventf(consumeCtx, 2, "output row: %s", values)
+					}
 				}
 			}
 			log.VEventf(consumeCtx, 2, "plan completed execution")

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/petermattis/goid"
 
 	"golang.org/x/net/context"
@@ -169,8 +171,45 @@ func FatalfDepth(ctx context.Context, depth int, format string, args ...interfac
 
 // V returns true if the logging verbosity is set to the specified level or
 // higher.
+//
+// See also ExpensiveLogEnabled().
+//
+// TODO(andrei): Audit uses of V() and see which ones should actually use the
+// newer ExpensiveLogEnabled().
 func V(level level) bool {
 	return VDepth(level, 1)
+}
+
+// ExpensiveLogEnabled is used to test whether effort should be used to produce
+// log messages whose construction has a measurable cost. It returns true if
+// either the current context is recording the trace, or if the caller's
+// verbosity is above level.
+//
+// NOTE: This doesn't take into consideration whether tracing is generally
+// enabled or whether a trace.EventLog or a trace.Trace (i.e. sp.netTr) is
+// attached to ctx. In particular, if some OpenTracing collection is enabled
+// (e.g. LightStep), that, by itself, does NOT cause the expensive messages to
+// be enabled. SHOW TRACE FOR <stmt> and friends, on the other hand, does cause
+// these messages to be enabled, as it shows that a user has expressed
+// particular interest in a trace.
+//
+// Usage:
+//
+// if ExpensiveLogEnabled(ctx, 2) {
+//   msg := constructExpensiveMessage()
+//   log.VEventf(ctx, 2, msg)
+// }
+//
+func ExpensiveLogEnabled(ctx context.Context, level level) bool {
+	if sp := opentracing.SpanFromContext(ctx); sp != nil {
+		if tracing.IsRecording(sp) {
+			return true
+		}
+	}
+	if VDepth(level, 1 /* depth */) {
+		return true
+	}
+	return false
 }
 
 // MakeEntry creates an Entry.

--- a/pkg/util/tracing/tracer_span.go
+++ b/pkg/util/tracing/tracer_span.go
@@ -117,6 +117,14 @@ func (s *span) isRecording() bool {
 	return atomic.LoadInt32(&s.recording) != 0
 }
 
+// IsRecording returns true if the span is recording its events.
+func IsRecording(s opentracing.Span) bool {
+	if _, noop := s.(*noopSpan); noop {
+		return false
+	}
+	return s.(*span).isRecording()
+}
+
 func (s *span) enableRecording(group *spanGroup, recType RecordingType) {
 	if group == nil {
 		panic("no spanGroup")


### PR DESCRIPTION
A "kv trace" is the a set of log messages around SQL<->KV interaction.
The concept is not very well defined at the moment, but it comprises two
categories of messages:
1. Details of KV requests being sent for execution, in particular
pretty-printed scan requests.
2. Per-row messages. In particular, every row that's being returned by
KV for processing by SQL.

These messages are the only ones that are returned as results of
SHOW _KV_ TRACE FOR <stmt>/SESSION.
The situation gets interesting for SHOW TRACE FOR ... (no KV specified).
In this case, before this patch, all the "kv trace" messages were
included in the results. This patch changes that and eliminates the
per-row messages. This is an improvement, per-row messages (as opposed
to per-RPC or higher level) is too verbose for most people that want
traces.

Tactically, a couple of "kv messages" that weren't per row are now
always logged (and hence traced) regardless of whether kv tracing is
enabled or not, and otherwise kv tracing is now no longer enabled for
SHOW TRACE FOR.

This was already the case before this patch, but now this comes to the
foreground: "kv tracing" means one thing externally (as in SHOW KV TRACE
FOR ...), versus internally, in the code, where "kvTracedEnabled" and
similarly-named members refer to "per-row" messages. A round of renames
is in order, but that's left for another day.

Benchstat - no difference
https://gist.github.com/andreimatei/c8ed8f850b59a9eec67b2fb190160108

This patch has no influence on the new index-join benchmark:
```
make bench PKG=./pkg/sql BENCHES=BenchmarkIndexJoin TESTFLAGS='-count 10'
make bench PKG=./pkg/sql BENCHES=BenchmarkIndexJoin TESTFLAGS='-test.benchmem -count 10'

[andrei:~/work/src/github.com/cockroachdb/cockroach] sql-kv-tracing+ ± benchstat /tmp/{before,after}
name         old time/op  new time/op  delta
IndexJoin-8  8.54ms ± 4%  8.54ms ± 1%   ~     (p=0.605 n=9+9)

[andrei:~/work/src/github.com/cockroachdb/cockroach] sql-kv-tracing+ ± benchstat /tmp/{before-mem,after-mem}
name         old time/op    new time/op    delta
IndexJoin-8    8.64ms ± 2%    8.59ms ± 6%    ~     (p=0.243 n=9+10)

name         old alloc/op   new alloc/op   delta
IndexJoin-8    3.62MB ± 0%    3.62MB ± 0%  -0.03%  (p=0.000 n=9+9)

name         old allocs/op  new allocs/op  delta
IndexJoin-8     11.6k ± 0%     11.6k ± 0%    ~     (p=0.314 n=10+10)
```