### PR TITLE
sql: allow fetching zone configs transactionally

### DIFF
--- a/pkg/sql/config.go
+++ b/pkg/sql/config.go
@@ -15,8 +15,12 @@
 package sql
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -26,10 +30,13 @@ func init() {
 	config.ZoneConfigHook = GetZoneConfig
 }
 
-// GetZoneConfig returns the zone config for the object with 'id'.
-func GetZoneConfig(cfg config.SystemConfig, id uint32) (config.ZoneConfig, bool, error) {
+func getZoneConfig(
+	id uint32, get func(roachpb.Key) (*roachpb.Value, error),
+) (config.ZoneConfig, bool, error) {
 	// Look in the zones table.
-	if zoneVal := cfg.GetValue(sqlbase.MakeZoneKey(sqlbase.ID(id))); zoneVal != nil {
+	if zoneVal, err := get(sqlbase.MakeZoneKey(sqlbase.ID(id))); err != nil {
+		return config.ZoneConfig{}, false, err
+	} else if zoneVal != nil {
 		// We're done.
 		zone, err := config.MigrateZoneConfig(zoneVal)
 		return zone, true, err
@@ -37,7 +44,9 @@ func GetZoneConfig(cfg config.SystemConfig, id uint32) (config.ZoneConfig, bool,
 
 	// No zone config for this ID. We need to figure out if it's a database
 	// or table. Lookup its descriptor.
-	if descVal := cfg.GetValue(sqlbase.MakeDescMetadataKey(sqlbase.ID(id))); descVal != nil {
+	if descVal, err := get(sqlbase.MakeDescMetadataKey(sqlbase.ID(id))); err != nil {
+		return config.ZoneConfig{}, false, err
+	} else if descVal != nil {
 		// Determine whether this is a database or table.
 		var desc sqlbase.Descriptor
 		if err := descVal.GetProto(&desc); err != nil {
@@ -45,18 +54,40 @@ func GetZoneConfig(cfg config.SystemConfig, id uint32) (config.ZoneConfig, bool,
 		}
 		if tableDesc := desc.GetTable(); tableDesc != nil {
 			// This is a table descriptor. Lookup its parent database zone config.
-			return GetZoneConfig(cfg, uint32(tableDesc.ParentID))
+			return getZoneConfig(uint32(tableDesc.ParentID), get)
 		}
 	}
 
 	// Retrieve the default zone config, but only as long as that wasn't the ID
 	// we were trying to retrieve (avoid infinite recursion).
 	if id != keys.RootNamespaceID {
-		return GetZoneConfig(cfg, keys.RootNamespaceID)
+		return getZoneConfig(keys.RootNamespaceID, get)
 	}
 
 	// No descriptor or not a table.
 	return config.ZoneConfig{}, false, nil
+}
+
+// GetZoneConfig returns the zone config for the object with 'id' using the
+// cached system config.
+func GetZoneConfig(cfg config.SystemConfig, id uint32) (config.ZoneConfig, bool, error) {
+	return getZoneConfig(id, func(key roachpb.Key) (*roachpb.Value, error) {
+		return cfg.GetValue(key), nil
+	})
+}
+
+// GetZoneConfigInTxn is like GetZoneConfig, but uses the provided transaction
+// to perform lookups instead of the cached system config.
+func GetZoneConfigInTxn(
+	ctx context.Context, txn *client.Txn, id uint32,
+) (config.ZoneConfig, bool, error) {
+	return getZoneConfig(id, func(key roachpb.Key) (*roachpb.Value, error) {
+		kv, err := txn.Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		return kv.Value, nil
+	})
 }
 
 // GetTableDesc returns the table descriptor for the table with 'id'.

--- a/pkg/sql/config_test.go
+++ b/pkg/sql/config_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -99,6 +99,42 @@ func TestGetZoneConfig(t *testing.T) {
 	defaultZoneConfig.RangeMaxBytes = 1 << 20
 	defaultZoneConfig.GC.TTLSeconds = 60
 
+	type testCase struct {
+		objectID uint32
+		zoneCfg  config.ZoneConfig
+	}
+	verifyZoneConfigs := func(testCases []testCase) {
+		cfg := forceNewConfig(t, s)
+
+		for tcNum, tc := range testCases {
+			// Verify SystemConfig.GetZoneConfigForKey.
+			{
+				zoneCfg, err := cfg.GetZoneConfigForKey(keys.MakeTablePrefix(tc.objectID))
+				if err != nil {
+					t.Fatalf("#%d: err=%s", tcNum, err)
+				}
+
+				if !proto.Equal(&zoneCfg, &tc.zoneCfg) {
+					t.Errorf("#%d: bad zone config.\nexpected: %+v\ngot: %+v", tcNum, &tc.zoneCfg, zoneCfg)
+				}
+			}
+
+			// Verify sql.GetZoneConfigInTxn.
+			if err := s.DB().Txn(context.Background(), func(ctx context.Context, txn *client.Txn) error {
+				if zoneCfg, found, err := sql.GetZoneConfigInTxn(ctx, txn, tc.objectID); err != nil {
+					return err
+				} else if !found {
+					t.Errorf("#%d: zone config missing", tcNum)
+				} else if !proto.Equal(&zoneCfg, &tc.zoneCfg) {
+					t.Errorf("#%d: bad zone config.\nexpected: %+v\ngot: %+v", tcNum, &tc.zoneCfg, zoneCfg)
+				}
+				return nil
+			}); err != nil {
+				t.Fatalf("#%d: err=%s", tcNum, err)
+			}
+		}
+	}
+
 	{
 		buf, err := protoutil.Marshal(&defaultZoneConfig)
 		if err != nil {
@@ -155,37 +191,18 @@ func TestGetZoneConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	{
-		cfg := forceNewConfig(t, s)
-
-		// We have no custom zone configs.
-		testCases := []struct {
-			key     roachpb.RKey
-			zoneCfg config.ZoneConfig
-		}{
-			{roachpb.RKeyMin, defaultZoneConfig},
-			{keys.MakeTablePrefix(0), defaultZoneConfig},
-			{keys.MakeTablePrefix(1), defaultZoneConfig},
-			{keys.MakeTablePrefix(keys.MaxReservedDescID), defaultZoneConfig},
-			{keys.MakeTablePrefix(db1), defaultZoneConfig},
-			{keys.MakeTablePrefix(db2), defaultZoneConfig},
-			{keys.MakeTablePrefix(tb11), defaultZoneConfig},
-			{keys.MakeTablePrefix(tb12), defaultZoneConfig},
-			{keys.MakeTablePrefix(tb21), defaultZoneConfig},
-			{keys.MakeTablePrefix(tb22), defaultZoneConfig},
-		}
-
-		for tcNum, tc := range testCases {
-			zoneCfg, err := cfg.GetZoneConfigForKey(tc.key)
-			if err != nil {
-				t.Fatalf("#%d: err=%s", tcNum, err)
-			}
-
-			if !proto.Equal(&zoneCfg, &tc.zoneCfg) {
-				t.Errorf("#%d: bad zone config.\nexpected: %+v\ngot: %+v", tcNum, tc.zoneCfg, zoneCfg)
-			}
-		}
-	}
+	// We have no custom zone configs.
+	verifyZoneConfigs([]testCase{
+		{0, defaultZoneConfig},
+		{1, defaultZoneConfig},
+		{keys.MaxReservedDescID, defaultZoneConfig},
+		{db1, defaultZoneConfig},
+		{db2, defaultZoneConfig},
+		{tb11, defaultZoneConfig},
+		{tb12, defaultZoneConfig},
+		{tb21, defaultZoneConfig},
+		{tb22, defaultZoneConfig},
+	})
 
 	// Now set some zone configs. We don't have a nice way of using table
 	// names for this, so we do raw puts.
@@ -222,36 +239,17 @@ func TestGetZoneConfig(t *testing.T) {
 		}
 	}
 
-	{
-		cfg := forceNewConfig(t, s)
-
-		testCases := []struct {
-			key     roachpb.RKey
-			zoneCfg config.ZoneConfig
-		}{
-			{roachpb.RKeyMin, defaultZoneConfig},
-			{keys.MakeTablePrefix(0), defaultZoneConfig},
-			{keys.MakeTablePrefix(1), defaultZoneConfig},
-			{keys.MakeTablePrefix(keys.MaxReservedDescID), defaultZoneConfig},
-			{keys.MakeTablePrefix(db1), db1Cfg},
-			{keys.MakeTablePrefix(db2), defaultZoneConfig},
-			{keys.MakeTablePrefix(tb11), tb11Cfg},
-			{keys.MakeTablePrefix(tb12), db1Cfg},
-			{keys.MakeTablePrefix(tb21), tb21Cfg},
-			{keys.MakeTablePrefix(tb22), defaultZoneConfig},
-		}
-
-		for tcNum, tc := range testCases {
-			zoneCfg, err := cfg.GetZoneConfigForKey(tc.key)
-			if err != nil {
-				t.Fatalf("#%d: err=%s", tcNum, err)
-			}
-
-			if !proto.Equal(&zoneCfg, &tc.zoneCfg) {
-				t.Errorf("#%d: bad zone config.\nexpected: %+v\ngot: %+v", tcNum, tc.zoneCfg, zoneCfg)
-			}
-		}
-	}
+	verifyZoneConfigs([]testCase{
+		{0, defaultZoneConfig},
+		{1, defaultZoneConfig},
+		{keys.MaxReservedDescID, defaultZoneConfig},
+		{db1, db1Cfg},
+		{db2, defaultZoneConfig},
+		{tb11, tb11Cfg},
+		{tb12, db1Cfg},
+		{tb21, tb21Cfg},
+		{tb22, defaultZoneConfig},
+	})
 }
 
 func BenchmarkGetZoneConfig(b *testing.B) {

--- a/pkg/sql/config_test.go
+++ b/pkg/sql/config_test.go
@@ -39,7 +39,7 @@ var configDescKey = sqlbase.MakeDescMetadataKey(keys.MaxReservedDescID)
 // forceNewConfig forces a system config update by writing a bogus descriptor with an
 // incremented value inside. It then repeatedly fetches the gossip config until the
 // just-written descriptor is found.
-func forceNewConfig(t *testing.T, s *server.TestServer) config.SystemConfig {
+func forceNewConfig(t testing.TB, s *server.TestServer) config.SystemConfig {
 	configID++
 	configDesc := &sqlbase.Descriptor{
 		Union: &sqlbase.Descriptor_Database{
@@ -63,7 +63,7 @@ func forceNewConfig(t *testing.T, s *server.TestServer) config.SystemConfig {
 	return waitForConfigChange(t, s)
 }
 
-func waitForConfigChange(t *testing.T, s *server.TestServer) config.SystemConfig {
+func waitForConfigChange(t testing.TB, s *server.TestServer) config.SystemConfig {
 	var foundDesc sqlbase.Descriptor
 	var cfg config.SystemConfig
 	testutils.SucceedsSoon(t, func() error {
@@ -252,4 +252,23 @@ func TestGetZoneConfig(t *testing.T) {
 			}
 		}
 	}
+}
+
+func BenchmarkGetZoneConfig(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+
+	params, _ := createTestServerParams()
+	srv, _, _ := serverutils.StartServer(b, params)
+	defer srv.Stopper().Stop(context.TODO())
+	s := srv.(*server.TestServer)
+	cfg := forceNewConfig(b, s)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := cfg.GetZoneConfigForKey(keys.MakeTablePrefix(keys.MaxReservedDescID + 1))
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
 }


### PR DESCRIPTION
sql.GetZoneConfig has useful logic for recursively looking up zone
configs (i.e., first check for a table config, then a database config,
then fall back to the default config), but can only use the cached
SystemConfig. Add a function sql.GetZoneConfigInTxn that uses the same
internal logic but performs consistent lookups using a client.Txn.

For upcoming geo-partitioning work. @mberhault can you take a look or suggest someone else who should?