### PR TITLE
ui: add explanatory comment to install link

### DIFF
--- a/pkg/ui/src/redux/alerts.ts
+++ b/pkg/ui/src/redux/alerts.ts
@@ -139,6 +139,9 @@ export const newVersionNotificationSelector = createSelector(
       level: AlertLevel.NOTIFICATION,
       title: "New Version Available",
       text: "A new version of CockroachDB is available.",
+      // Note that this explicitly does not use util/docs to create the link,
+      // since we want to link to the updated version, not the version currently
+      // running on the cluster.
       link: "https://www.cockroachlabs.com/docs/stable/install-cockroachdb.html",
       dismiss: (dispatch) => {
         const dismissedAt = moment();


### PR DESCRIPTION
I went back to check that #18986 had hit every docs link in `pkg/ui` and saw that this one wasn't using `util/docs`.  There's a good reason for that, but since it might not be immediately obvious to everyone in the future, I added a comment.