### PR TITLE
util: fix flaky TestFastIntSet

### DIFF
--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -137,6 +137,9 @@ func (s *FastIntSet) ForEach(f func(i int)) {
 
 // Ordered returns a slice with all the integers in the set, in increasing order.
 func (s *FastIntSet) Ordered() []int {
+	if s.Empty() {
+		return nil
+	}
 	if s.large != nil {
 		return s.large.AppendTo([]int(nil))
 	}

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -64,7 +64,7 @@ func TestFastIntSet(t *testing.T) {
 					}
 				}
 				// Cross-check Ordered and Next().
-				vals := make([]int, 0)
+				var vals []int
 				for i, ok := s.Next(0); ok; i, ok = s.Next(i + 1) {
 					vals = append(vals, i)
 				}


### PR DESCRIPTION
For an empty set, `Ordered` returns either a nil slice or a non-nil empty slice,
depending on the small vs large representation. Make it always be nil for
consistency.

Fixes #19017.