### PR TITLE
settings: require superuser to view settings

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -719,6 +719,12 @@ func (s *adminServer) Events(
 		if err := scanner.ScanIndex(row, 4, &event.Info); err != nil {
 			return nil, err
 		}
+		if event.EventType == string(sql.EventLogSetClusterSetting) {
+			if s.getUser(req) != security.RootUser {
+				// TODO(dt): unpack and selectively redact the setting value.
+				event.Info = ""
+			}
+		}
 		if err := scanner.ScanIndex(row, 5, &event.UniqueID); err != nil {
 			return nil, err
 		}

--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -305,6 +305,21 @@ func TestSettingsSetAndShow(t *testing.T) {
 	) {
 		t.Fatal(err)
 	}
+	if _, err := testuser.Exec(`SHOW CLUSTER SETTING foo`); !testutils.IsError(err,
+		`only root is allowed to SHOW CLUSTER SETTINGS`,
+	) {
+		t.Fatal(err)
+	}
+	if _, err := testuser.Exec(`SHOW ALL CLUSTER SETTINGS`); !testutils.IsError(err,
+		`only root is allowed to SHOW CLUSTER SETTINGS`,
+	) {
+		t.Fatal(err)
+	}
+	if _, err := testuser.Exec(`SELECT * FROM crdb_internal.cluster_settings`); !testutils.IsError(err,
+		`only root is allowed to read crdb_internal.cluster_settings`,
+	) {
+		t.Fatal(err)
+	}
 }
 
 func TestSettingsShowAll(t *testing.T) {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -587,6 +587,9 @@ CREATE TABLE crdb_internal.cluster_settings (
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
+		if err := p.RequireSuperUser("read crdb_internal.cluster_settings"); err != nil {
+			return err
+		}
 		for _, k := range settings.Keys() {
 			setting, _ := settings.Lookup(k)
 			if err := addRow(

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -49,6 +49,11 @@ func checkTableExists(ctx context.Context, p *planner, tn *parser.TableName) err
 func (p *planner) ShowClusterSetting(
 	ctx context.Context, n *parser.ShowClusterSetting,
 ) (planNode, error) {
+
+	if err := p.RequireSuperUser("SHOW CLUSTER SETTINGS"); err != nil {
+		return nil, err
+	}
+
 	name := strings.ToLower(n.Name)
 
 	if name == "all" {


### PR DESCRIPTION
The original system table only included grants for the root user, but our views
on top of it, in crdb_internal and SHOW opened up read access to non-superusers.

The majority of settings are probably safe to show to any user, but some may not
be. For example, an operator may wish to give users access to a cluster but
without disclosing a token or key for interacting with an external system (like
the lightstep token or proposed saved cloud storage credentials). Settings that
control behavior like which remote debugging interfaces are enabled could also
reveal information that could be misused.

For tokens or keys, we could build a separate secrets store, but that would
likely require much of the same infrastructure and plumbing as settings.
Alternatively we could mark individual settings as sensitive or add other fine-
grained access control.

Simply making all settings access limited to super-users though avoids needing
to build that, as well the more careful, case-by-case analysis of possible
issues when deciding which settings are or are not sensitive, and thus seems to
be a conservative default for now.