### PR TITLE
sql: add crdb_internal.ranges

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -200,6 +200,12 @@ node_id  component  field   value
 1        UI         Port    <port>
 1        UI         URI     /
 
+query ITTI colnames
+select * from crdb_internal.ranges
+----
+range_id  start_key  end_key  replicas
+1         /Min       /Max     1
+
 # Check that privileged builtins are only allowed for 'root'
 user testuser
 
@@ -217,3 +223,6 @@ select crdb_internal.set_vmodule('')
 
 query error pq: only root can access the node runtime information
 select * from crdb_internal.node_runtime_info
+
+query error pq: only root is allowed to read crdb_internal.ranges
+select * from crdb_internal.ranges

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -137,7 +137,7 @@ EXPLAIN SHOW TABLES
 1  render  ·      ·
 2  filter  ·      ·
 3  values  ·      ·
-3  ·       size   5 columns, 69 rows
+3  ·       size   5 columns, 70 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -194,7 +194,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·
-7  ·       size      13 columns, 581 rows
+7  ·       size      13 columns, 585 rows
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -220,6 +220,7 @@ crdb_internal       node_queries
 crdb_internal       node_runtime_info
 crdb_internal       node_sessions
 crdb_internal       node_statement_statistics
+crdb_internal       ranges
 crdb_internal       schema_changes
 crdb_internal       session_trace
 crdb_internal       session_variables
@@ -372,6 +373,7 @@ def            crdb_internal       node_queries               SYSTEM VIEW  1
 def            crdb_internal       node_runtime_info          SYSTEM VIEW  1
 def            crdb_internal       node_sessions              SYSTEM VIEW  1
 def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
+def            crdb_internal       ranges                     SYSTEM VIEW  1
 def            crdb_internal       schema_changes             SYSTEM VIEW  1
 def            crdb_internal       session_trace              SYSTEM VIEW  1
 def            crdb_internal       session_variables          SYSTEM VIEW  1


### PR DESCRIPTION
This is slightly different from SHOW TESTING_RANGES in that it:
is runnable only by root, shows all ranges, doesn't truncate table
IDs from the output, doesn't show lease holders. The bulkio team
has needed (and written) this many times to investigate various
split-related things.

Also sort that silly list.