### PR TITLE
sql/parser: Make extract() work with TimestampTZ

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -133,6 +133,10 @@ hour, minute, second, millisecond, microsecond, epoch</span>
 
 Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
 hour, minute, second, millisecond, microsecond, epoch</span>
+<code>extract(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Extracts `element` from `input`.
+
+Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
+hour, minute, second, millisecond, microsecond, epoch</span>
 <code>extract_duration(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Extracts `element` from `input`.
 Compatible elements: hour, minute, second, millisecond, microsecond.</span>
 <code>now() &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Returns the current transaction's timestamp.</span>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1039,6 +1039,106 @@ SELECT extract(epoch FROM '1970-01-02 00:00:01.000001'::timestamp)
 ----
 86401
 
+query I
+SELECT extract(milliseconds FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+306
+
+query I
+SELECT extract(millisecond FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+306
+
+query I
+SELECT extract(microseconds FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+306158
+
+query I
+SELECT extract(microsecond FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+306158
+
+query I
+SELECT extract(second FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+33
+
+query I
+SELECT extract(seconds FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+33
+
+query I
+SELECT extract(minute FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+46
+
+query I
+SELECT extract(minutes FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+46
+
+query I
+SELECT extract(hour FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+19
+
+query I
+SELECT extract(hour FROM '2016-02-10 19:46:33.306157519-04'::timestamptz)
+----
+19
+
+query I
+SELECT extract(hours FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+19
+
+query I
+SELECT extract(hours FROM '2016-02-10 19:46:33.306157519-04'::timestamptz)
+----
+19
+
+query I
+SELECT extract(day FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+10
+
+query I
+SELECT extract(days FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+10
+
+query I
+SELECT extract(month FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+2
+
+query I
+SELECT extract(months FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+2
+
+query I
+SELECT extract(year FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+2016
+
+query I
+SELECT extract(years FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+2016
+
+query I
+SELECT extract(epoch FROM '1970-01-02 00:00:01.000001'::timestamptz)
+----
+86401
+
+query I
+SELECT extract(epoch FROM '1970-01-02 00:00:01.000001-04'::timestamptz)
+----
+100801
+
 query B
 SELECT unique_rowid() < unique_rowid()
 ----

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1301,6 +1301,19 @@ CockroachDB supports the following flags:
 				"Compatible elements: year, quarter, month, week, dayofweek, dayofyear,\n" +
 				"hour, minute, second, millisecond, microsecond, epoch",
 		},
+		Builtin{
+			Types:      ArgTypes{{"element", TypeString}, {"input", TypeTimestampTZ}},
+			ReturnType: fixedReturnType(TypeInt),
+			category:   categoryDateAndTime,
+			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
+				fromTSTZ := args[1].(*DTimestampTZ)
+				timeSpan := strings.ToLower(string(MustBeDString(args[0])))
+				return extractStringFromTimestamp(ctx, fromTSTZ.Time, timeSpan)
+			},
+			Info: "Extracts `element` from `input`.\n\n" +
+				"Compatible elements: year, quarter, month, week, dayofweek, dayofyear,\n" +
+				"hour, minute, second, millisecond, microsecond, epoch",
+		},
 	},
 
 	"extract_duration": {


### PR DESCRIPTION
Update the SQL builtin function extract() to add an overload for the
TimestampTZ type.  Currently extract() only works for Timestamp and
Date types.