### PR TITLE
storage: avoid cacheRequest allocations for each request

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8615,67 +8615,67 @@ func TestMakeTimestampCacheRequest(t *testing.T) {
 		maxKeys  int64
 		req      roachpb.Request
 		resp     roachpb.Response
-		expected cacheRequest
+		expected *cacheRequest
 	}{
 		{
 			0,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{},
-			cacheRequest{reads: []roachpb.Span{ac}},
+			&cacheRequest{reads: []roachpb.Span{ac}},
 		},
 		{
 			0,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			cacheRequest{reads: []roachpb.Span{ac}},
+			&cacheRequest{reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{},
-			cacheRequest{reads: []roachpb.Span{ac}},
+			&cacheRequest{reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			cacheRequest{reads: []roachpb.Span{ac}},
+			&cacheRequest{reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{Rows: []roachpb.KeyValue{{Key: a}, {Key: b}}},
-			cacheRequest{reads: []roachpb.Span{{Key: a, EndKey: b.Next()}}},
+			&cacheRequest{reads: []roachpb.Span{{Key: a, EndKey: b.Next()}}},
 		},
 		{
 			0,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{},
-			cacheRequest{reads: []roachpb.Span{ac}},
+			&cacheRequest{reads: []roachpb.Span{ac}},
 		},
 		{
 			0,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			cacheRequest{reads: []roachpb.Span{ac}},
+			&cacheRequest{reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{},
-			cacheRequest{reads: []roachpb.Span{ac}},
+			&cacheRequest{reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			cacheRequest{reads: []roachpb.Span{ac}},
+			&cacheRequest{reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{Rows: []roachpb.KeyValue{{Key: c}, {Key: b}}},
-			cacheRequest{reads: []roachpb.Span{{Key: b, EndKey: c}}},
+			&cacheRequest{reads: []roachpb.Span{{Key: b, EndKey: c}}},
 		},
 	}
 	for _, c := range testCases {
@@ -8685,7 +8685,8 @@ func TestMakeTimestampCacheRequest(t *testing.T) {
 			ba.Header.MaxSpanRequestKeys = c.maxKeys
 			ba.Add(c.req)
 			br.Add(c.resp)
-			cr := makeCacheRequest(&ba, &br, roachpb.RSpan{})
+			ec := endCmds{ba: ba}
+			cr := ec.makeCacheRequest(&br, roachpb.RSpan{})
 			if !reflect.DeepEqual(c.expected, cr) {
 				t.Fatalf("%s", pretty.Diff(c.expected, cr))
 			}

--- a/pkg/storage/timestamp_cache.go
+++ b/pkg/storage/timestamp_cache.go
@@ -567,7 +567,7 @@ func (tc *timestampCache) add(
 }
 
 // AddRequest adds the specified request to the cache in an unexpanded state.
-func (tc *timestampCache) AddRequest(req cacheRequest) {
+func (tc *timestampCache) AddRequest(req *cacheRequest) {
 	if len(req.reads) == 0 && len(req.writes) == 0 && req.txn.Key == nil {
 		// The request didn't contain any spans for the timestamp cache.
 		return
@@ -580,7 +580,7 @@ func (tc *timestampCache) AddRequest(req cacheRequest) {
 
 	tc.reqIDAlloc++
 	req.uniqueID = tc.reqIDAlloc
-	tc.requests.ReplaceOrInsert(&req)
+	tc.requests.ReplaceOrInsert(req)
 	tc.reqSpans += req.numSpans()
 	tc.bytes += req.size()
 

--- a/pkg/storage/timestamp_cache_test.go
+++ b/pkg/storage/timestamp_cache_test.go
@@ -139,7 +139,7 @@ func TestTimestampCacheNoEviction(t *testing.T) {
 	manual.Increment(1)
 	aTS := clock.Now()
 	tc.add(roachpb.Key("a"), nil, aTS, uuid.UUID{}, true)
-	tc.AddRequest(cacheRequest{
+	tc.AddRequest(&cacheRequest{
 		reads:     []roachpb.Span{{Key: roachpb.Key("c")}},
 		timestamp: aTS,
 	})
@@ -147,7 +147,7 @@ func TestTimestampCacheNoEviction(t *testing.T) {
 	// Increment time by the MinTSCacheWindow and add another key.
 	manual.Increment(MinTSCacheWindow.Nanoseconds())
 	tc.add(roachpb.Key("b"), nil, clock.Now(), uuid.UUID{}, true)
-	tc.AddRequest(cacheRequest{
+	tc.AddRequest(&cacheRequest{
 		reads:     []roachpb.Span{{Key: roachpb.Key("d")}},
 		timestamp: clock.Now(),
 	})
@@ -171,7 +171,7 @@ func TestTimestampCacheExpandRequests(t *testing.T) {
 	// Increment time to the low water mark + 1.
 	start := clock.Now()
 	manual.Increment(1)
-	tc.AddRequest(cacheRequest{
+	tc.AddRequest(&cacheRequest{
 		span:      ab,
 		reads:     []roachpb.Span{{Key: roachpb.Key("a")}},
 		timestamp: clock.Now(),


### PR DESCRIPTION
We used to allocate a new `cacheRequest` and usually the `read` `[]Span`
that it contained for each request. These allocations happened often enough
that I was seeing them show up on TPCC heap profiles. We now batch the
`cacheRequest` allocation in with `endCmds`, which saves at least one
allocation per request.

I wasn't able to see any benchmarks movement because of this change, but
the allocations are no longer showing up in the profiles and it seems
like a clear win.