### PR TITLE
[experiment] bufalloc: create custom allocator for []roachpb.KeyValue

### DIFF
--- a/pkg/internal/client/batch.go
+++ b/pkg/internal/client/batch.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 )
 
 const (
@@ -209,6 +210,7 @@ func (b *Batch) fillResults() error {
 						dst.Key = src.Key
 						dst.Value = &src.Value
 					}
+					bufalloc.ReleaseKVSlice(t.Rows)
 				}
 			case *roachpb.ReverseScanRequest:
 				if result.Err == nil {
@@ -220,6 +222,7 @@ func (b *Batch) fillResults() error {
 						dst.Key = src.Key
 						dst.Value = &src.Value
 					}
+					bufalloc.ReleaseKVSlice(t.Rows)
 				}
 			case *roachpb.DeleteRequest:
 				row := &result.Rows[k]

--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -4230,6 +4230,8 @@ func (m *ScanResponse) MarshalTo(dAtA []byte) (int, error) {
 			}
 			i += n
 		}
+		// Would be nice to bufalloc.ReleaseKVSlice(m.Rows). Not easily possible
+		// in generated code.
 	}
 	return i, nil
 }
@@ -4294,6 +4296,8 @@ func (m *ReverseScanResponse) MarshalTo(dAtA []byte) (int, error) {
 			}
 			i += n
 		}
+		// Would be nice to bufalloc.ReleaseKVSlice(m.Rows). Not easily possible
+		// in generated code.
 	}
 	return i, nil
 }
@@ -11227,6 +11231,8 @@ func (m *ScanResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
+			// Would be nice to do m.Rows = bufalloc.AppendToKVSlice(m.Rows, KeyValue{}).
+			// Not easily possible in generated code.
 			m.Rows = append(m.Rows, KeyValue{})
 			if err := m.Rows[len(m.Rows)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
@@ -11418,6 +11424,8 @@ func (m *ReverseScanResponse) Unmarshal(dAtA []byte) error {
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
+			// Would be nice to do m.Rows = bufalloc.AppendToKVSlice(m.Rows, KeyValue{}).
+			// Not easily possible in generated code.
 			m.Rows = append(m.Rows, KeyValue{})
 			if err := m.Rows[len(m.Rows)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1565,7 +1565,7 @@ func mvccScanInternal(
 				}
 				return true, nil
 			}
-			res = append(res, kv)
+			res = bufalloc.AppendToKVSlice(res, kv)
 			return false, nil
 		})
 

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -1281,7 +1282,12 @@ func evalRangeLookup(
 		}
 
 		// Merge the results, the total ranges may be bigger than rangeCount.
+		oldKVs := kvs
 		kvs = append(kvs, revKVs...)
+		bufalloc.ReleaseKVSlice(revKVs)
+		if cap(oldKVs) != cap(kvs) {
+			bufalloc.ReleaseKVSlice(oldKVs)
+		}
 		intents = append(intents, revIntents...)
 	}
 
@@ -1307,6 +1313,7 @@ func evalRangeLookup(
 			}
 		}
 	}
+	bufalloc.ReleaseKVSlice(kvs)
 
 	// NOTE (subtle): dangling intents on meta records are peculiar: It's not
 	// clear whether the intent or the previous value point to the correct

--- a/pkg/util/bufalloc/kv_allocator.go
+++ b/pkg/util/bufalloc/kv_allocator.go
@@ -1,0 +1,153 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package bufalloc
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+const kvSliceMinExp = 4
+const kvSliceMin = 1 << kvSliceMinExp // 2^minExp
+
+const kvSliceAllocFactorLog = 2                       // log2(kvSliceAllocFactor)
+const kvSliceAllocFactor = 1 << kvSliceAllocFactorLog // re-alloc growth factor, 2^2 = 4
+
+const kvSliceAllocSize = 6
+
+var kvSliceAlloc [kvSliceAllocSize]sync.Pool
+
+func init() {
+	for i := range kvSliceAlloc {
+		idx := i
+		kvSliceAlloc[i] = sync.Pool{
+			New: func() interface{} {
+				return make([]roachpb.KeyValue, 0, indexToSize(idx))
+			},
+		}
+	}
+}
+
+func newKVSliceForIdx(idx int) []roachpb.KeyValue {
+	return kvSliceAlloc[idx].Get().([]roachpb.KeyValue)
+}
+
+func newKVSlice() []roachpb.KeyValue {
+	return newKVSliceForIdx(0)
+}
+
+// 16    -> 0
+// 64    -> 1
+// 256   -> 2
+// 1024  -> 3
+// 4096  -> 4
+// 16384 -> 5
+func sizeToIndex(size int) int {
+	size >>= kvSliceMinExp
+	idx := 0
+	for ; size > 1; idx++ {
+		size >>= kvSliceAllocFactorLog
+	}
+	return idx
+}
+
+// 0 -> 16
+// 1 -> 64
+// 2 -> 256
+// 3 -> 1024
+// 4 -> 4096
+// 5 -> 16384
+func indexToSize(idx int) int {
+	return kvSliceMin << (kvSliceAllocFactorLog * uint(idx))
+}
+
+// AppendToKVSlice behaves the same as: append(s, kv).
+//
+// This function allows us to catch append-induced reallocations and release the
+// original slice back into our allocator pools.
+func AppendToKVSlice(s []roachpb.KeyValue, kv roachpb.KeyValue) []roachpb.KeyValue {
+	c := cap(s)
+	if c == 0 {
+		s = newKVSlice()
+	} else if len(s) == c {
+		idx := sizeToIndex(c)
+		var realloc []roachpb.KeyValue
+		if idx+1 >= kvSliceAllocSize {
+			realloc = make([]roachpb.KeyValue, 0, kvSliceAllocFactor*c)
+		} else {
+			realloc = newKVSliceForIdx(idx + 1)
+		}
+		realloc = realloc[:c+1]
+		copy(realloc[:c], s)
+		realloc[c] = kv
+		ReleaseKVSlice(s)
+		return realloc
+	}
+	return append(s, kv)
+}
+
+// ReleaseKVSlice releases the KeyValue slice, allowing it to be re-used.
+func ReleaseKVSlice(s []roachpb.KeyValue) {
+	idx := sizeToIndex(cap(s))
+	switch {
+	case idx < kvSliceAllocSize:
+		kvSliceAlloc[idx].Put(s[:0])
+	case idx == kvSliceAllocSize:
+		splitAndReleaseAllSizes(s, idx)
+	case idx > kvSliceAllocSize:
+		splitAndRelease(s, idx)
+	}
+}
+
+// splitAndRelease splits s into kvSliceAllocFactor evenly sized chunks and
+// release each one.
+//
+// Ex:
+//  - len(s) == 64
+//  - kvSliceAllocFactor == 4
+//  - kvSliceMin = 16
+// the function will release 4 slices of cap 16.
+func splitAndRelease(s []roachpb.KeyValue, idx int) {
+	chunkSize := indexToSize(idx - 1)
+	for i := 0; i < kvSliceAllocFactor; i++ {
+		ReleaseKVSlice(s[:0:chunkSize])
+		s = s[chunkSize:]
+	}
+	if cap(s) != 0 {
+		panic("s should be empty")
+	}
+}
+
+// splitAndReleaseAllSizes splits s into kvSliceAllocFactor evenly sized chunks.
+// It releases kvSliceAllocFactor - 1 of those chunks immediately, and recurses
+// with the last chunk to release smaller chunks.
+//
+// Ex:
+//  - len(s) == 256
+//  - kvSliceAllocFactor == 4
+//  - kvSliceMin = 4
+// the function will release 3 slices of cap 64, 3 slices of cap 16, and 4
+// slices of cap 4.
+func splitAndReleaseAllSizes(s []roachpb.KeyValue, idx int) {
+	for ; idx > 1; idx-- {
+		chunkSize := indexToSize(idx - 1)
+		for i := 0; i < kvSliceAllocFactor-1; i++ {
+			kvSliceAlloc[idx-1].Put(s[:0:chunkSize])
+			s = s[chunkSize:]
+		}
+	}
+	splitAndRelease(s, idx)
+}


### PR DESCRIPTION
The [`[]roachpb.KeyValue` in `mvccScanInternal`](https://github.com/cockroachdb/cockroach/blob/16cb6dc42c23c0d8e73401217dd13c51874901ef/pkg/storage/engine/mvcc.go#L1568) was showing up as the
second largest culprit of allocations when running TPCC, just behind
[`bufalloc.ByteAllocator.Copy` in `MVCCIterate`](https://github.com/cockroachdb/cockroach/blob/16cb6dc42c23c0d8e73401217dd13c51874901ef/pkg/storage/engine/mvcc.go#L1708). This makes sense because
this slice will collect all KV pairs for `ScanRequests` and carry them
back to the client.

I figured that we could improve this by pooling slices, and that led to
the current design of pooling different capacity slices and managing
slice appends.

Over a series of 5 one-minute TPCC runs from before and after the change,
this approach has shown to decrease the `ns/op` metric from an average
of `73638065.2 ns/op` to an average of `63700720.2 ns/op`, a speedup of
**13.5%**.

The code is pretty rough here, but it's an interesting starting point
that demonstrates a clear target for optimization.