### PR TITLE
storageccl: remove index id during rekey of primary index

### DIFF
--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -11,6 +11,7 @@ package storageccl
 import (
 	"bytes"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -191,7 +192,9 @@ func (kr *KeyRewriter) RewriteKey(key []byte) ([]byte, bool, error) {
 }
 
 // RewriteSpan returns a new span with both Key and EndKey rewritten using
-// RewriteKey. An error is returned if either was not matched for rewrite.
+// RewriteKey. Span start keys for the primary index will be rewritten to
+// contain just the table ID. That is, /Table/51/1 -> /Table/51. An error
+// is returned if either was not matched for rewrite.
 func (kr *KeyRewriter) RewriteSpan(span roachpb.Span) (roachpb.Span, error) {
 	newKey, ok, err := kr.RewriteKey(append([]byte(nil), span.Key...))
 	if err != nil {
@@ -199,6 +202,15 @@ func (kr *KeyRewriter) RewriteSpan(span roachpb.Span) (roachpb.Span, error) {
 	}
 	if !ok {
 		return roachpb.Span{}, errors.Errorf("could not rewrite key: %s", span.Key)
+	}
+	// Modify all spans that begin at the primary index to instead begin at the
+	// start of the table. That is, change a span start key from /Table/51/1 to
+	// /Table/51. Otherwise a permanently empty span at /Table/51-/Table/51/1
+	// will be created.
+	if b, id, idx, err := sqlbase.DecodeTableIDIndexID(newKey); err != nil {
+		return roachpb.Span{}, errors.Wrapf(err, "could not rewrite key: %s", span.Key)
+	} else if idx == 1 && len(b) == 0 {
+		newKey = keys.MakeTablePrefix(uint32(id))
 	}
 	newEndKey, ok, err := kr.RewriteKey(append([]byte(nil), span.EndKey...))
 	if err != nil {


### PR DESCRIPTION
During backup, spans are created based on their index, so the first
span for a table would be something like /Table/52/1. During restore,
we would restore these spans as they are during backup, resulting in a
span from /Table/51/<whatever> - /Table/52/1. The next time the split
queue is run it would ensure a table is split at the correct place
(/Table/52), leaving a forever-empty range at /Table/52 - /Table/52/1.

To fix this, teach the rekey method to recognize primary index start
spans and have it move those to the start of the table span.

Fixes #16317