### PR TITLE
storage: Batch up handleRaftReady calls in processRequestQueue

### DIFF
--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2228,7 +2228,7 @@ func TestStoreRemovePlaceholderOnError(t *testing.T) {
 		IncomingSnapshot{
 			SnapUUID: uuid.MakeV4(),
 			State:    &storagebase.ReplicaState{Desc: repl1.Desc()},
-		}); !testutils.IsPError(err, expected) {
+		}, true /* handleRaftReady */); !testutils.IsPError(err, expected) {
 		t.Fatalf("expected %s, but found %v", expected, err)
 	}
 
@@ -2311,7 +2311,7 @@ func TestStoreRemovePlaceholderOnRaftIgnored(t *testing.T) {
 		IncomingSnapshot{
 			SnapUUID: uuid.MakeV4(),
 			State:    &storagebase.ReplicaState{Desc: repl1.Desc()},
-		}); err != nil {
+		}, true /* handleRaftReady */); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Previously we would call handleRaftReadyRaftMuLocked after processing
each request in the queue. Each call to handleRaftReadyRaftMuLocked will
sync any new raft log entries to disk. If the queue of requests has a
lot of requests with only one or two log entries each, this makes for a
lot of very small syncs to disk, one after another.

This boosts single-range write performance on the mostly uncontended
workload in #18657 on 3 GCE PD-SSDs from about 750 qps to about 2500
qps.

<img width="957" alt="screen shot 2017-10-05 at 9 16 07 am" src="https://user-images.githubusercontent.com/7085343/31230292-9ff495b4-a9b1-11e7-927c-2e516f7d2853.png">


I still think there's more improvements to be made on the workload in #18657, but this should help with any workloads that send a lot of requests to a small number of ranges.

