### PR TITLE
ui: Convert Metrics Query Thunk -> Redux Saga

### DIFF
--- a/pkg/ui/karma.conf.js
+++ b/pkg/ui/karma.conf.js
@@ -26,6 +26,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      "src/polyfills.ts",
       "src/**/*.spec.*",
     ],
 
@@ -48,7 +49,7 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
-      "src/**/*.spec.*": ["webpack", "sourcemap"],
+      "src/**": ["webpack", "sourcemap"],
     },
 
     // test results reporter to use

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -26,7 +26,9 @@
     "react-select": "^1.0.0-rc.4",
     "react-sticky": "^5.0.5",
     "redux": "^3.6.0",
+    "redux-saga": "^0.15.6",
     "redux-thunk": "^2.2.0",
+    "regenerator-runtime": "^0.11.0",
     "reselect": "^3.0.0",
     "webcola": "3.3.5",
     "whatwg-fetch": "^2.0.3"

--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -7,6 +7,8 @@ import "react-select/dist/react-select.css";
 import "styl/app.styl";
 import "src/js/sim/style.css";
 
+import "src/polyfills";
+
 import * as protobuf from "protobufjs/minimal";
 import Long from "long";
 

--- a/pkg/ui/src/polyfills.ts
+++ b/pkg/ui/src/polyfills.ts
@@ -1,0 +1,10 @@
+// This file imports polyfills necessary for both the unit tests and the
+// deployed bundle.
+//
+// If you're tempted to instead import babel-polyfill, which bundles the most
+// common polyfills, fair warning: babel-polyfill, jsdom, and Node 6 are
+// mutually incompatible.
+//
+// TODO(benesch): reevaluate babel-polyfill when we upgrade to Node 8.
+
+import "regenerator-runtime/runtime";

--- a/pkg/ui/src/redux/metrics.spec.ts
+++ b/pkg/ui/src/redux/metrics.spec.ts
@@ -1,11 +1,12 @@
 import { assert } from "chai";
 import _ from "lodash";
 import Long from "long";
-import { Action } from "redux";
-import fetchMock from "src/util/fetch-mock";
 
+import { delay } from "redux-saga";
+import { AllEffect, call, ForkEffect, put, take } from "redux-saga/effects";
+import { queryTimeSeries } from "src/util/api";
 import * as protos from "src/js/protos";
-import * as api from "src/util/api";
+
 import * as metrics from "./metrics";
 
 type TSRequest = protos.cockroach.ts.tspb.TimeSeriesQueryRequest;
@@ -147,11 +148,13 @@ describe("metrics reducer", function() {
     });
   });
 
-  describe("queryMetrics asynchronous action", function() {
+  describe("saga functions", function() {
     type timespan = [Long, Long];
+    const shortTimespan: timespan = [Long.fromNumber(400), Long.fromNumber(500)];
+    const longTimespan: timespan = [Long.fromNumber(0), Long.fromNumber(500)];
 
     // Helper function to generate metrics request.
-    const createRequest = function(ts: timespan, ...names: string[]): TSRequest {
+    function createRequest(ts: timespan, ...names: string[]): TSRequest {
       return new protos.cockroach.ts.tspb.TimeSeriesQueryRequest({
         start_nanos: ts[0],
         end_nanos: ts[1],
@@ -161,159 +164,152 @@ describe("metrics reducer", function() {
           };
         }),
       });
-    };
+    }
 
-    // Mock of metrics state.
-    let mockMetricsState: metrics.MetricsState;
-    const mockDispatch = <A extends Action>(action: A): A => {
-      mockMetricsState = metrics.metricsReducer(mockMetricsState, action);
-      return undefined;
-    };
-    const queryMetrics = function(id: string, request: TSRequest): Promise<void> {
-      return metrics.queryMetrics(id, request)(mockDispatch);
-    };
-
-    beforeEach(function () {
-      mockMetricsState = undefined;
-    });
-
-    afterEach(fetchMock.restore);
-
-    it ("correctly batches multiple calls", function () {
-      this.timeout(1000);
-
-      // Mock out fetch server; we are only expecting requests to /ts/query,
-      // which we simply reflect with an empty set of datapoints.
-      fetchMock.mock({
-        matcher: "ts/query",
-        method: "POST",
-        response: (_url: string, requestObj: RequestInit) => {
-          // Assert that metric store's "inFlight" is 1 or 2.
-          assert.isAtLeast(mockMetricsState.inFlight, 1);
-          assert.isAtMost(mockMetricsState.inFlight, 2);
-
-          const request = protos.cockroach.ts.tspb.TimeSeriesQueryRequest.decode(new Uint8Array(requestObj.body as ArrayBuffer));
-          const encodedResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse.encode({
-            results: _.map(request.queries, (q) => {
-              return {
-                query: q,
-                datapoints: [],
-              };
-            }),
-          }).finish();
-
+    function createResponse(queries: protos.cockroach.ts.tspb.TimeSeriesQueryResponse.Result$Properties[]) {
+      return new protos.cockroach.ts.tspb.TimeSeriesQueryResponse({
+        results: queries.map(q => {
           return {
-            body: api.toArrayBuffer(encodedResponse),
+            query: q,
+            datapoints: [],
           };
-        },
+        }),
+      });
+    }
+
+    describe("queryMetricsSaga", function() {
+      it("initially waits for incoming request objects", function () {
+        const saga = metrics.queryMetricsSaga();
+        assert.deepEqual(saga.next().value, take(metrics.REQUEST));
       });
 
-      // Dispatch several requests. Requests are divided among two timespans,
-      // which should result in two batches.
-      const shortTimespan: timespan = [Long.fromNumber(400), Long.fromNumber(500)];
-      const longTimespan: timespan = [Long.fromNumber(0), Long.fromNumber(500)];
-      queryMetrics("id.1", createRequest(shortTimespan, "short.1", "short.2"));
-      queryMetrics("id.2", createRequest(longTimespan, "long.1"));
-      queryMetrics("id.3", createRequest(shortTimespan, "short.3"));
-      queryMetrics("id.4", createRequest(shortTimespan, "short.4"));
-      const p1 = queryMetrics("id.5", createRequest(longTimespan, "long.2", "long.3"));
+      it("correctly accumulates batches", function () {
+        const requestAction = metrics.requestMetrics("id", createRequest(shortTimespan, "short.1"));
+        const saga = metrics.queryMetricsSaga();
+        saga.next();
 
-      // Queries should already be present, but unfulfilled.
-      assert.lengthOf(_.keys(mockMetricsState.queries), 5);
-      _.each(mockMetricsState.queries, (q) => {
-        assert.isDefined(q.nextRequest);
-        assert.isUndefined(q.data);
-        assert.isUndefined(q.request);
-      });
+        // Pass in a request, the generator should put the request to the
+        // redux store, fork "sendBatches" process, then await another request.
+        assert.deepEqual(saga.next(requestAction).value, put(requestAction));
+        const sendBatchesFork = saga.next().value as ForkEffect;
+        assert.isDefined(sendBatchesFork.FORK);
+        assert.deepEqual(saga.next().value, take(metrics.REQUEST));
 
-      // Dispatch an additional query for the short timespan, but in a
-      // setTimeout - this should result in a separate batch.
-      const p2 = new Promise<void>((resolve, _reject) => {
-        setTimeout(() => {
-          resolve(queryMetrics("id.6", createRequest(shortTimespan, "short.6")));
-        });
-      });
+        // Pass in two additional requests, the generator should not yield another
+        // fork.
+        for (let i = 0; i < 2; i++) {
+          assert.deepEqual(saga.next(requestAction).value, put(requestAction));
+          assert.deepEqual(saga.next().value, take(metrics.REQUEST));
+        }
 
-      return Promise.all([p1, p2]).then(() => {
-        // Assert that the server got the correct number of requests (2).
-        assert.lengthOf(fetchMock.calls("ts/query"), 3);
-        // Assert that the mock metrics state has 5 queries.
-        assert.lengthOf(_.keys(mockMetricsState.queries), 6);
-        _.each(mockMetricsState.queries, (q) => {
-          assert.isDefined(q.request);
-          assert.isUndefined(q.error);
-          assert.isDefined(q.data, "data not defined for query " + q.id);
-        });
-        // Assert that inFlight is 0.
-        assert.equal(mockMetricsState.inFlight, 0);
+        // Run the fork function. It should initially call delay (to defer to the
+        // event queue), then call sendRequestBatches with the currently
+        // accumulated batches, then complete.
+        const accumulateBatch = sendBatchesFork.FORK.fn() as IterableIterator<any>;
+        assert.deepEqual(accumulateBatch.next().value, call(delay, 0));
+        assert.deepEqual(
+          accumulateBatch.next().value,
+          call(
+            metrics.batchAndSendRequests,
+            [requestAction.payload, requestAction.payload, requestAction.payload],
+          ),
+        );
+        assert.isTrue(accumulateBatch.next().done);
+
+        // Pass in a request, the generator should again yield a "fork" followed
+        // by another take for request objects.
+        assert.deepEqual(saga.next(requestAction).value, put(requestAction));
+        assert.isDefined((saga.next().value as ForkEffect).FORK);
+        assert.deepEqual(saga.next().value, take(metrics.REQUEST));
       });
     });
 
-    it ("correctly responds to errors.", function () {
-      this.timeout(1000);
+    describe("batchAndSendRequests", function() {
+      it("sendBatches correctly batches multiple requests", function () {
+        const shortRequests = [
+          metrics.requestMetrics("id", createRequest(shortTimespan, "short.1")).payload,
+          metrics.requestMetrics("id", createRequest(shortTimespan, "short.2", "short.3")).payload,
+          metrics.requestMetrics("id", createRequest(shortTimespan, "short.4")).payload,
+        ];
+        const longRequests = [
+          metrics.requestMetrics("id", createRequest(longTimespan, "long.1")).payload,
+          metrics.requestMetrics("id", createRequest(longTimespan, "long.2", "long.3")).payload,
+          metrics.requestMetrics("id", createRequest(longTimespan, "long.4", "long.5")).payload,
+        ];
 
-      // Mock out fetch server; send a positive reply to the first request, and
-      // an error to the second request.
-      let successSent = false;
-      fetchMock.mock({
-        matcher: "ts/query",
-        method: "POST",
-        response: (_url: string, requestObj: RequestInit) => {
-          // Assert that metric store's "inFlight" is 1.
-          assert.equal(mockMetricsState.inFlight, 1);
+        // Mix the requests together and send the combined request set.
+        const mixedRequests = _.flatMap(shortRequests, (short, i) => [short, longRequests[i]]);
+        const sendBatches = metrics.batchAndSendRequests(mixedRequests);
 
-          if (successSent) {
-            return { throws: new Error() };
-          }
-          successSent = true;
+        // sendBatches next puts a "fetchMetrics" action into the store.
+        assert.deepEqual(sendBatches.next().value, put(metrics.fetchMetrics()));
 
-          const request = protos.cockroach.ts.tspb.TimeSeriesQueryRequest.decode(new Uint8Array(requestObj.body as ArrayBuffer));
-          const encodedResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse.encode({
-            results: _.map(request.queries, (q) => {
-              return {
-                query: q,
-                datapoints: [],
-              };
-            }),
-          }).finish();
+        // Next, sendBatches dispatches a "all" effect with a "call" for each
+        // batch; there should be two batches in total, one containing the
+        // short requests and one containing the long requests. The order
+        // of requests in each batch is maintained.
+        const allEffect = sendBatches.next().value as AllEffect;
+        assert.isArray(allEffect.ALL);
+        assert.deepEqual(allEffect.ALL, [
+          call(metrics.sendRequestBatch, shortRequests),
+          call(metrics.sendRequestBatch, longRequests),
+        ]);
 
-          return {
-            body: api.toArrayBuffer(encodedResponse),
-          };
-        },
+        // After completion, puts "fetchMetricsComplete" to store.
+        assert.deepEqual(sendBatches.next().value, put(metrics.fetchMetricsComplete()));
+        assert.isTrue(sendBatches.next().done);
+      });
+    });
+
+    describe("sendRequestBatch", function() {
+      const requests = [
+        metrics.requestMetrics("id1", createRequest(shortTimespan, "short.1")).payload,
+        metrics.requestMetrics("id2", createRequest(shortTimespan, "short.2", "short.3")).payload,
+        metrics.requestMetrics("id3", createRequest(shortTimespan, "short.4")).payload,
+      ];
+
+      it("correctly sends batch as single request, correctly handles valid response", function() {
+        const sendBatch = metrics.sendRequestBatch(requests);
+        const expectedRequest = createRequest(shortTimespan, "short.1", "short.2", "short.3", "short.4");
+        assert.deepEqual(sendBatch.next().value, call(queryTimeSeries, expectedRequest));
+
+        // Return a valid response.
+        const response = createResponse(expectedRequest.queries);
+
+        // Expect three puts to the underlying store.
+        const actualEffects = [
+          sendBatch.next(response).value,
+          sendBatch.next().value,
+          sendBatch.next().value,
+        ];
+        const expectedEffects = requests.map(req => put(metrics.receiveMetrics(
+          req.id,
+          req.data,
+          createResponse(req.data.queries),
+        )));
+        assert.deepEqual(actualEffects, expectedEffects);
+        assert.isTrue(sendBatch.next().done);
       });
 
-      // Dispatch several requests. Requests are divided among two timespans,
-      // which should result in two batches.
-      const shortTimespan: timespan = [Long.fromNumber(400), Long.fromNumber(500)];
-      const longTimespan: timespan = [Long.fromNumber(0), Long.fromNumber(500)];
-      queryMetrics("id.1", createRequest(shortTimespan, "short.1", "short.2"));
-      const p = queryMetrics("id.2", createRequest(longTimespan, "long.1"));
+      it("correctly handles error response", function() {
+        const sendBatch = metrics.sendRequestBatch(requests);
+        const expectedRequest = createRequest(shortTimespan, "short.1", "short.2", "short.3", "short.4");
+        assert.deepEqual(sendBatch.next().value, call(queryTimeSeries, expectedRequest));
 
-      // Queries should already be present, but unfulfilled.
-      assert.lengthOf(_.keys(mockMetricsState.queries), 2);
-      _.each(mockMetricsState.queries, (q) => {
-        assert.isDefined(q.nextRequest);
-        assert.isUndefined(q.data);
-      });
-
-      return p.then(() => {
-        // Assert that the server got the correct number of requests (2).
-        assert.lengthOf(fetchMock.calls("ts/query"), 2);
-        // Assert that the mock metrics state has 2 queries.
-        assert.lengthOf(_.keys(mockMetricsState.queries), 2);
-        // Assert query with id.1 has results.
-        const q1 = mockMetricsState.queries["id.1"];
-        assert.isDefined(q1);
-        assert.isDefined(q1.data);
-        assert.isUndefined(q1.error);
-        // Assert query with id.2 has an error.
-        const q2 = mockMetricsState.queries["id.2"];
-        assert.isDefined(q2);
-        assert.isDefined(q2.error);
-        assert.isUndefined(q2.data);
-        // Assert that inFlight is 0.
-        assert.equal(mockMetricsState.inFlight, 0);
+        // Throw an exception, a network error.  Expect three puts, which are
+        // are error responses.
+        const err = new Error("network error");
+        const actualEffects = [
+          sendBatch.throw(err).value,
+          sendBatch.next().value,
+          sendBatch.next().value,
+        ];
+        const expectedEffects = requests.map(req => put(metrics.errorMetrics(
+          req.id,
+          err,
+        )));
+        assert.deepEqual(actualEffects, expectedEffects);
+        assert.isTrue(sendBatch.next().done);
       });
     });
   });

--- a/pkg/ui/src/redux/metrics.ts
+++ b/pkg/ui/src/redux/metrics.ts
@@ -6,7 +6,9 @@
  */
 
 import _ from "lodash";
-import { Action, Dispatch } from "redux";
+import { Action } from "redux";
+import { delay } from "redux-saga";
+import { take, fork, call, all, put } from "redux-saga/effects";
 
 import * as protos from  "src/js/protos";
 import { PayloadAction } from "src/interfaces/action";
@@ -235,103 +237,96 @@ export function fetchMetricsComplete(): Action {
 }
 
 /**
- * queuedRequests is a list of requests that should be asynchronously sent to
- * the server. As a purely asynchronous concept, this lives outside of the redux
- * store.
- */
-let queuedRequests: WithID<TSRequest>[] = [];
-
-/**
- * queuePromise is a promise that will be resolved when the current batch of
- * queued requests has been been processed. This is returned by the queryMetrics
- * thunk method, for use in synchronizing in tests.
- */
-let queuePromise: Promise<void> = null;
-
-/**
- * queryMetrics action allows components to asynchronously request new metrics
- * from the server. Components provide their id and a request object for new
- * data.
+ * queryMetricsSaga is a redux saga which listens for REQUEST actions and sends
+ * those requests to the server asynchronously.
  *
- * Requests to queryMetrics may be batched when dispatching to the server;
+ * Metric queries can be batched when sending to the to the server -
  * specifically, queries which have the same time span can be handled by the
- * server in a single call.
+ * server in a single call. This saga will attempt to batch any requests which
+ * are dispatched as part of the same event (e.g. if a rendering page displays
+ * several graphs which need data).
  */
-export function queryMetrics<S>(id: string, query: TSRequest) {
-  return (dispatch: Dispatch<S>): Promise<void> => {
-    // Indicate that this request has been received and queued.
-    dispatch(requestMetrics(id, query));
-    queuedRequests.push({
-      id: id,
-      data: query,
-    });
+export function* queryMetricsSaga() {
+  let requests: WithID<TSRequest>[] = [];
 
-    // Only the first queued request is responsible for initiating the fetch
-    // process. The fetch process is "debounced" with a setTimeout, and thus
-    // multiple queryMetrics actions can be batched into a single fetch from the
-    // server.
-    if (queuedRequests.length > 1) {
-      // Return queuePromise, created by an earlier queueMetrics request.
-      return queuePromise;
+  while (true) {
+    const requestAction: PayloadAction<WithID<TSRequest>> = yield take((REQUEST));
+
+    // Dispatch action to underlying store.
+    yield put(requestAction);
+    requests.push(requestAction.payload);
+
+    // If no other requests are queued, fork a process which will send the
+    // request (and any other subsequent requests that are queued).
+    if (requests.length === 1) {
+      yield fork(sendRequestsAfterDelay);
     }
+  }
 
-    queuePromise = new Promise<void>((resolve, _reject) => {
-      setTimeout(() => {
-        // Increment in-flight counter.
-        dispatch(fetchMetrics());
+  function* sendRequestsAfterDelay() {
+    // Delay of zero will defer execution to the message queue, allowing the
+    // currently executing event (e.g. rendering a new page or a timespan change)
+    // to dispatch additional requests which can be batched.
+    yield call(delay, 0);
 
-        // Construct queryable batches from the set of queued queries. Queries can
-        // be dispatched in a batch if they are querying over the same timespan.
-        const batches = _.groupBy(queuedRequests, (qr) => timespanKey(qr.data));
-        queuedRequests = [];
+    const requestsToSend = requests;
+    requests = [];
+    yield call(batchAndSendRequests, requestsToSend);
+  }
+}
 
-        // Fetch data from the server for each batch.
-        const promises = _.map(batches, (batch) => {
-          // Flatten the individual queries from all requests in the batch into a
-          // single request.
-          // Lodash operations are split into two methods because the lodash
-          // typescript definition loses type information when chaining into
-          // flatten.
-          const unifiedRequest = _.clone(batch[0].data);
-          const toFlatten = _.map(batch, (req) => req.data.queries);
-          unifiedRequest.queries = _.flatten(toFlatten);
+/**
+ * batchAndSendRequests attempts to send the supplied requests in the
+ * smallest number of batches possible.
+ */
+export function* batchAndSendRequests(requests: WithID<TSRequest>[]) {
+  // Construct queryable batches from the set of queued queries. Queries can
+  // be dispatched in a batch if they are querying over the same timespan.
+  const batches = _.groupBy(requests, (qr) => timespanKey(qr.data));
+  requests = [];
 
-          return queryTimeSeries(unifiedRequest).then((response) => {
-            // The number of results should match the queries exactly, and should
-            // be in the exact order passed.
-            if (response.results.length !== unifiedRequest.queries.length) {
-              throw `mismatched count of results (${response.results.length}) and queries (${unifiedRequest.queries.length})`;
-            }
+  yield put(fetchMetrics());
+  yield all(_.map(batches, batch => call(sendRequestBatch, batch)));
+  yield put(fetchMetricsComplete());
+}
 
-            const results = response.results;
+/**
+ * sendRequestBatch sends the supplied requests in a single batch.
+ */
+export function* sendRequestBatch(requests: WithID<TSRequest>[]) {
+  // Flatten the queries from the batch into a single request.
+  const unifiedRequest = _.clone(requests[0].data);
+  unifiedRequest.queries = _.flatMap(requests, req => req.data.queries);
 
-            // Match each result in the response to its corresponding original
-            // query. Each request may have sent multiple queries in the batch.
-            _.each(batch, (request) => {
-              const numQueries = request.data.queries.length;
-              dispatch(receiveMetrics(request.id, request.data, new protos.cockroach.ts.tspb.TimeSeriesQueryResponse({
-                results: results.splice(0, numQueries),
-              })));
-            });
-          }).catch((e: Error) => {
-            // Dispatch the error to each individual MetricsQuery which was
-            // requesting data.
-            _.each(batch, (request) => {
-              dispatch(errorMetrics(request.id, e));
-            });
-          });
-        });
+  let response: protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
+  try {
+    response = yield call(queryTimeSeries, unifiedRequest);
+    // The number of results should match the queries exactly, and should
+    // be in the exact order passed.
+    if (response.results.length !== unifiedRequest.queries.length) {
+      throw `mismatched count of results (${response.results.length}) and queries (${unifiedRequest.queries.length})`;
+    }
+  } catch (e) {
+    // Dispatch the error to each individual MetricsQuery which was
+    // requesting data.
+    for (const request of requests) {
+      yield put(errorMetrics(request.id, e));
+    }
+    return;
+  }
 
-        // Wait for all promises to complete, then decrement in-flight counter
-        // and resolve queuePromise.
-        resolve(Promise.all(promises).then(() => {
-          dispatch(fetchMetricsComplete());
-        }));
-      });
-    });
-
-    return queuePromise;
-  };
+  // Match each result in the unified response to its corresponding original
+  // query. Each request may have sent multiple queries in the batch.
+  const results = response.results;
+  for (const request of requests) {
+    yield put(receiveMetrics(
+      request.id,
+      request.data,
+      new protos.cockroach.ts.tspb.TimeSeriesQueryResponse({
+        results: results.splice(0, request.data.queries.length),
+      }),
+    ));
+  }
 }
 
 interface SimpleTimespan {

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -2,11 +2,12 @@ import _ from "lodash";
 import { hashHistory } from "react-router";
 import { syncHistoryWithStore, routerReducer, RouterState } from "react-router-redux";
 import { createStore, combineReducers, applyMiddleware, compose, GenericStoreEnhancer } from "redux";
+import createSagaMiddleware from "redux-saga";
 import thunk from "redux-thunk";
 
 import { apiReducersReducer, APIReducersState } from "./apiReducers";
 import { localSettingsReducer, LocalSettingsState } from "./localsettings";
-import { metricsReducer, MetricsState } from "./metrics";
+import { metricsReducer, MetricsState, queryMetricsSaga } from "./metrics";
 import { timeWindowReducer, TimeWindowState } from "./timewindow";
 import { uiDataReducer, UIDataState } from "./uiData";
 
@@ -21,31 +22,38 @@ export interface AdminUIState {
 
 // createAdminUIStore is a function that returns a new store for the admin UI.
 // It's in a function so it can be recreated as necessary for testing.
-export const createAdminUIStore = () => createStore(
-  combineReducers<AdminUIState>({
-    cachedData: apiReducersReducer,
-    localSettings: localSettingsReducer,
-    metrics: metricsReducer,
-    routing: routerReducer,
-    timewindow: timeWindowReducer,
-    uiData: uiDataReducer,
-  }),
-  compose(
-    applyMiddleware(thunk),
-    // Support for redux dev tools
-    // https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd
-    (window as any).devToolsExtension ? (window as any).devToolsExtension({
-      // TODO(maxlang): implement {,de}serializeAction.
-      // TODO(maxlang): implement deserializeState.
-      serializeState: (_key: string, value: any): Object => {
-        if (value && value.toRaw) {
-          return value.toRaw();
-        }
-        return value;
-      },
-    }) : _.identity,
-  ) as GenericStoreEnhancer,
-);
+export function createAdminUIStore() {
+  const sagaMiddleware = createSagaMiddleware();
+
+  const store = createStore(
+    combineReducers<AdminUIState>({
+      cachedData: apiReducersReducer,
+      localSettings: localSettingsReducer,
+      metrics: metricsReducer,
+      routing: routerReducer,
+      timewindow: timeWindowReducer,
+      uiData: uiDataReducer,
+    }),
+    compose(
+      applyMiddleware(thunk, sagaMiddleware),
+      // Support for redux dev tools
+      // https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd
+      (window as any).devToolsExtension ? (window as any).devToolsExtension({
+        // TODO(maxlang): implement {,de}serializeAction.
+        // TODO(maxlang): implement deserializeState.
+        serializeState: (_key: string, value: any): Object => {
+          if (value && value.toRaw) {
+            return value.toRaw();
+          }
+          return value;
+        },
+      }) : _.identity,
+    ) as GenericStoreEnhancer,
+  );
+
+  sagaMiddleware.run(queryMetricsSaga);
+  return store;
+}
 
 export const store = createAdminUIStore();
 

--- a/pkg/ui/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/src/views/shared/containers/metricDataProvider/index.tsx
@@ -7,7 +7,7 @@ import moment from "moment";
 
 import * as protos from  "src/js/protos";
 import { AdminUIState } from "src/redux/state";
-import { queryMetrics, MetricsQuery } from "src/redux/metrics";
+import { requestMetrics, MetricsQuery } from "src/redux/metrics";
 import {
   Metric, MetricProps, MetricsDataComponentProps, QueryTimeInfo,
 } from "src/views/shared/components/metricQuery";
@@ -63,7 +63,7 @@ function queryFromProps(
 interface MetricsDataProviderConnectProps {
   metrics: MetricsQuery;
   timeInfo: QueryTimeInfo;
-  queryMetrics: typeof queryMetrics;
+  requestMetrics: typeof requestMetrics;
 }
 
 /**
@@ -141,10 +141,10 @@ class MetricsDataProvider extends React.Component<MetricsDataProviderProps, {}> 
     if (!request) {
       return;
     }
-    const { metrics, queryMetrics, id } = props;
+    const { metrics, requestMetrics, id } = props;
     const nextRequest = metrics && metrics.nextRequest;
     if (!nextRequest || !_.isEqual(nextRequest, request)) {
-      queryMetrics(id, request);
+      requestMetrics(id, request);
     }
   }
 
@@ -217,7 +217,7 @@ const metricsDataProviderConnected = connect(
     };
   },
   {
-    queryMetrics,
+    requestMetrics,
   },
 )(MetricsDataProvider);
 

--- a/pkg/ui/src/views/shared/containers/metricDataProvider/metricDataProvider.spec.tsx
+++ b/pkg/ui/src/views/shared/containers/metricDataProvider/metricDataProvider.spec.tsx
@@ -12,7 +12,7 @@ import {
 import {
   MetricsDataProviderUnconnected as MetricsDataProvider,
 } from "src/views/shared/containers/metricDataProvider";
-import { queryMetrics, MetricsQuery } from "src/redux/metrics";
+import { requestMetrics, MetricsQuery } from "src/redux/metrics";
 
 // TextGraph is a proof-of-concept component used to demonstrate that
 // MetricsDataProvider is working correctly. Used in tests.
@@ -34,9 +34,9 @@ function makeDataProvider(
   id: string,
   metrics: MetricsQuery,
   timeInfo: QueryTimeInfo,
-  qm: typeof queryMetrics,
+  rm: typeof requestMetrics,
 ) {
-  return shallow(<MetricsDataProvider id={id} metrics={metrics} timeInfo={timeInfo} queryMetrics={qm}>
+  return shallow(<MetricsDataProvider id={id} metrics={metrics} timeInfo={timeInfo} requestMetrics={rm}>
     <TextGraph>
       <Axis>
         <Metric name="test.metric.1" />
@@ -197,7 +197,7 @@ describe("<MetricsDataProvider>", function() {
           <MetricsDataProvider id="id"
                                metrics={null}
                                timeInfo={timespan1}
-                               queryMetrics={spy}>
+                               requestMetrics={spy}>
             <TextGraph>
               <Axis>
                 <Metric name="test.metrics.1" />

--- a/pkg/ui/webpack.config.js
+++ b/pkg/ui/webpack.config.js
@@ -24,7 +24,7 @@ class RemoveBrokenDependenciesPlugin {
 
 // tslint:disable:object-literal-sort-keys
 module.exports = {
-  entry: "./src/index.tsx",
+  entry: ["./src/index.tsx"],
   output: {
     filename: "bundle.js",
     path: __dirname + "/dist",

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -5252,6 +5252,10 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-saga@^0.15.6:
+  version "0.15.6"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.15.6.tgz#8638dc522de6c6c0a496fe8b2b5466287ac2dc4d"
+
 redux-thunk@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
@@ -5272,6 +5276,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz#8c4367a904b51ea62a908ac310bf99ff90a82a3e"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
 regenerator-transform@0.9.11:
   version "0.9.11"


### PR DESCRIPTION
Converts the redux thunk used to run metrics queries (for our time
series graphs) into a redux saga. Sagas are an alternative framework for
asynchronous actions which use generators instead of promises.

Metrics query was chosen as the first thunk to convert because it has
the most complex behavior (the transparent batching of requests from
different graphs). Other reducers which use metric queries still use
redux thunk.  In the interest of keeping this PR focused on the saga
conversion, I have not modified the reducer for metrics, or any other
component, in any significant way.

Advantages of this move:

+ Thunk has been broken up into three different generator functions
which call each other. Importantly, because these are saga generators,
the higher level functions can be tested in isolation without having to
invoke the lower-level functions; this allows us to put a strong focus
on each part of the process without needing complicated mocks or
orchestration in the tests.

In my opinion, the readability and focus of the new tests is enough to
justify the switch to saga on its own.

+ Sagas are executed as a long-running process loop which listens for
dispatched actions; this is in contrast to thunk, which dispatches
functions as actions. This allows us to have a significant amount of
control over parallel invocations while using locally-scoped variables
(as an alternative to package globals or redux store state).

This has a minor benefit for this particular method, but I anticipate
greater benefits for other sagas as they are written.

New Dependencies Required:
+ Redux Saga
+ Babel Polyfill

Polyfill has been hooked up in karma.conf.js and webpack.config.js. The
new dependencies are not a major contributor to package size.