### PR TITLE
cherrypick-1.1: sqlccl: correctly ignore dropped tables during backup

### DIFF
--- a/pkg/ccl/sqlccl/targets.go
+++ b/pkg/ccl/sqlccl/targets.go
@@ -90,6 +90,9 @@ func descriptorsMatchingTargets(
 
 	for _, desc := range descriptors {
 		if tableDesc := desc.GetTable(); tableDesc != nil {
+			if tableDesc.Dropped() {
+				continue
+			}
 			dbDesc, ok := databasesByID[tableDesc.ParentID]
 			if !ok {
 				return nil, errors.Errorf("unknown ParentID: %d", tableDesc.ParentID)


### PR DESCRIPTION
Dropping databases and tables failed in different ways, hence the
separate tests, but the fix is the same.

Fixes #19020 
Cherrypick of #19032