### PR TITLE
storageccl: combine stats and verify iteration

### DIFF
--- a/pkg/ccl/storageccl/add_sstable.go
+++ b/pkg/ccl/storageccl/add_sstable.go
@@ -86,32 +86,26 @@ func evalAddSSTable(
 func verifySSTable(
 	existingIter engine.SimpleIterator, data []byte, start, end engine.MVCCKey, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	dataIter, err := engineccl.NewMemSSTIterator(data)
+	// To verify every KV is a valid roachpb.KeyValue in the range [start, end)
+	// we a) pass a verify flag on the iterator so that as ComputeStatsGo calls
+	// Next, we're also verifying each KV pair. We explicitly check the first key
+	// is >= start and then that we do not find a key after end.
+	dataIter, err := engineccl.NewMemSSTIterator(data, true)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 	defer dataIter.Close()
 
+	// Check that the first key is in the expected range.
 	dataIter.Seek(engine.MVCCKey{Key: keys.MinKey})
 	ok, err := dataIter.Valid()
-	for ; ok; ok, err = dataIter.Valid() {
-		unsafeKey := dataIter.UnsafeKey()
-		if unsafeKey.Less(start) || !unsafeKey.Less(end) {
-			// TODO(dan): Add a new field in roachpb.Error, so the client can
-			// catch this and retry. It can happen if the range splits between
-			// when the client constructs the file and sends the request.
+	if err != nil {
+		return enginepb.MVCCStats{}, err
+	} else if ok {
+		if unsafeKey := dataIter.UnsafeKey(); unsafeKey.Less(start) {
 			return enginepb.MVCCStats{}, errors.Errorf("key %s not in request range [%s,%s)",
 				unsafeKey.Key, start.Key, end.Key)
 		}
-
-		v := roachpb.Value{RawBytes: dataIter.UnsafeValue()}
-		if err := v.Verify(unsafeKey.Key); err != nil {
-			return enginepb.MVCCStats{}, err
-		}
-		dataIter.Next()
-	}
-	if err != nil {
-		return enginepb.MVCCStats{}, err
 	}
 
 	// In the case that two iterators have an entry with the same key and
@@ -122,8 +116,20 @@ func verifySSTable(
 	mergedIter := engineccl.MakeMultiIterator([]engine.SimpleIterator{existingIter, dataIter})
 	defer mergedIter.Close()
 
-	// TODO(dan): This unnecessarily iterates the sstable a second time, see if
-	// combining this computation with the above checksum verification speeds
-	// anything up.
-	return engine.ComputeStatsGo(mergedIter, start, end, nowNanos)
+	stats, err := engine.ComputeStatsGo(mergedIter, start, end, nowNanos)
+	if err != nil {
+		return stats, err
+	}
+
+	dataIter.Seek(end)
+	ok, err = dataIter.Valid()
+	if err != nil {
+		return enginepb.MVCCStats{}, err
+	} else if ok {
+		if unsafeKey := dataIter.UnsafeKey(); !unsafeKey.Less(end) {
+			return enginepb.MVCCStats{}, errors.Errorf("key %s not in request range [%s,%s)",
+				unsafeKey.Key, start.Key, end.Key)
+		}
+	}
+	return stats, nil
 }

--- a/pkg/ccl/storageccl/engineccl/sst_iterator_test.go
+++ b/pkg/ccl/storageccl/engineccl/sst_iterator_test.go
@@ -100,7 +100,7 @@ func TestSSTIterator(t *testing.T) {
 		runTestSSTIterator(t, iter, allKVs)
 	})
 	t.Run("Mem", func(t *testing.T) {
-		iter, err := NewMemSSTIterator(data)
+		iter, err := NewMemSSTIterator(data, false)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -188,7 +188,7 @@ func evalImport(ctx context.Context, cArgs storage.CommandArgs) (*roachpb.Import
 			}
 		}
 
-		iter, err := engineccl.NewMemSSTIterator(fileContents)
+		iter, err := engineccl.NewMemSSTIterator(fileContents, false)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Avoid iterating dataIter twice -- once to verify and once for stats.
A flag in sstIterator enables verifing each KV in Next(). The dataIter is
combined with existing db iter and fed to stats calculation, during which we
call Next() and in doing so, verify all keys.

The range bounds are verified before/after with simple Seek()s.

```
name                            old time/op    new time/op    delta
AddSSTable/numEntries=100-4       2.57ms ±20%    2.42ms ± 7%   -6.11%  (p=0.025 n=19+17)
AddSSTable/numEntries=1000-4      7.85ms ±36%    6.92ms ±20%  -11.81%  (p=0.008 n=20+20)
AddSSTable/numEntries=10000-4     56.7ms ±58%    44.1ms ±15%  -22.24%  (p=0.006 n=30+26)
AddSSTable/numEntries=300000-4     1.02s ±17%     0.74s ± 8%  -27.39%  (p=0.003 n=7+5)

name                            old speed      new speed      delta
AddSSTable/numEntries=100-4     7.29MB/s ±17%  7.64MB/s ± 9%     ~     (p=0.080 n=19+17)
AddSSTable/numEntries=1000-4    22.3MB/s ±28%  25.1MB/s ±24%  +12.39%  (p=0.007 n=20+20)
AddSSTable/numEntries=10000-4   32.3MB/s ±55%  38.6MB/s ±14%  +19.45%  (p=0.007 n=30+27)
AddSSTable/numEntries=300000-4  50.9MB/s ±16%  69.5MB/s ± 8%  +36.64%  (p=0.003 n=7+5)

name                            old alloc/op   new alloc/op   delta
AddSSTable/numEntries=100-4        790kB ±12%     820kB ± 9%   +3.76%  (p=0.002 n=19+17)
AddSSTable/numEntries=1000-4      6.64MB ±29%    5.96MB ± 8%  -10.34%  (p=0.000 n=20+17)
AddSSTable/numEntries=10000-4     53.3MB ± 3%    49.4MB ± 4%   -7.36%  (p=0.000 n=23+25)
AddSSTable/numEntries=300000-4    2.31GB ± 4%    2.26GB ±11%     ~     (p=0.662 n=6+5)

name                            old allocs/op  new allocs/op  delta
AddSSTable/numEntries=100-4        1.10k ±56%     1.05k ±76%     ~     (p=0.659 n=20+20)
AddSSTable/numEntries=1000-4      4.49k ±220%     5.20k ±93%     ~     (p=0.495 n=20+20)
AddSSTable/numEntries=10000-4     17.0k ±201%    14.0k ±112%     ~     (p=0.792 n=29+30)
AddSSTable/numEntries=300000-4     21.5k ±10%     17.2k ±19%  -20.04%  (p=0.018 n=7+5)
```

Fixes #18883.