### PR TITLE
cli/sql: ensure a newline after \h's output

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -183,10 +183,11 @@ Type:
 
 More documentation about our SQL dialect and the CLI shell is available online:
 %s
-%s\n`,
+%s`,
 		base.DocsURL("sql-statements.html"),
 		base.DocsURL("use-the-built-in-sql-client.html"),
 	)
+	fmt.Println()
 }
 
 // addHistory persists a line of input to the readline history


### PR DESCRIPTION
Cleanup after #18531.