### PR TITLE
cli/sql: simplify history handling upon errors

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -865,10 +865,10 @@ func (c *cliState) doPrepareStatementLine(
 		return contState
 	}
 
+	// Complete input. Remember it in the history.
+	c.addHistory(c.concatLines)
+
 	if !c.checkSyntax {
-		// If syntax checking is not enabled, put the raw statement into
-		// history, then go and run it.
-		c.addHistory(c.concatLines)
 		return execState
 	}
 
@@ -893,12 +893,6 @@ func (c *cliState) doCheckStatement(startState, contState, execState cliStateEnu
 			}
 		}
 
-		// Even on failure, add the last (erroneous) lines as-is to the
-		// history, so that the user can recall them later to fix them.
-		for i := c.partialStmtsLen; i < len(c.partialLines); i++ {
-			c.addHistory(c.partialLines[i])
-		}
-
 		// Remove the erroneous lines from the buffered input,
 		// then try again.
 		c.partialLines = c.partialLines[:c.partialStmtsLen]
@@ -911,17 +905,6 @@ func (c *cliState) doCheckStatement(startState, contState, execState cliStateEnu
 	if !isInteractive {
 		return execState
 	}
-
-	// Add the last lines received to the history.
-	// Like above, this is one input chunk. However there may be
-	// sensitive newlines in string literals or SQL comments, so we
-	// can't blindly concatenate all the partial input into a single
-	// line. Leave them separate.
-	var lastInputChunk bytes.Buffer
-	for i := c.partialStmtsLen; i < len(c.partialLines); i++ {
-		fmt.Fprintln(&lastInputChunk, c.partialLines[i])
-	}
-	c.addHistory(lastInputChunk.String())
 
 	nextState := execState
 


### PR DESCRIPTION
Prior to this patch, the CLI shell would use different code paths
to register user input into the history file depending on whether
or not the input is valid. The separation existed because
until recently multi-line statements would be registered
as a single entry by pretty-printing the AST, which is only
possible if the syntax is valid, so there was another
code path able to register the individual lines of an erroneous
statement as separate history entries.

This previous code was actually the source of poor UX: when
a user enters a multi-line statement and makes a mistake they
probably want to recall the whole thing at once in order
to correct the mistake. Registering the individual lines as
separate history entries did impede this.

The new code simplifies by registering the multi-line input
in the history in all cases, using a common code path.
This reduces surprises and improves UX.

Simplifies after #18531.