### PR TITLE
build: separate out race logic tests

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export BUILDER_HIDE_GOPATH_SRC=1
+
+mkdir -p artifacts
+
+build/builder.sh env \
+	make testrace \
+  PKG=./pkg/sql/logictest
+	TESTFLAGS='-v' \
+	2>&1 \
+	| tee artifacts/testlogicrace.log \
+	| go-test-teamcity

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -13,6 +13,7 @@ build/builder.sh env \
 	github-pull-request-make
 
 build/builder.sh env \
+	COCKROACH_LOGIC_TESTS_SKIP=true \
 	make testrace \
 	TESTFLAGS='-v' \
 	2>&1 \


### PR DESCRIPTION
The testrace build is going over 20min lately, so pulling logic tests (~12-15min) into their own build should help a bit.
A follow up step might be to split `default` from the rest of the logic tests if testlogicrace is still the slowest build. This includes the env vars needed for that, so if/when we decide to do so, it could just be a TC change.