### PR TITLE
sql: remove some allocation-heavy closures

### DIFF
--- a/pkg/sql/parser/type_check_test.go
+++ b/pkg/sql/parser/type_check_test.go
@@ -130,6 +130,22 @@ func TestTypeCheck(t *testing.T) {
 	}
 }
 
+func BenchmarkTypeCheck(b *testing.B) {
+	// random example from TPCC
+	sql := `CASE 1 >= $1 + 10 WHEN true THEN 1-$1 ELSE (1-$1)+91 END`
+	expr, err := ParseExpr(sql)
+	if err != nil {
+		b.Fatalf("%s: %v", expr, err)
+	}
+	ctx := MakeSemaContext(false)
+	for i := 0; i < b.N; i++ {
+		_, err := TypeCheck(expr, &ctx, TypeInt)
+		if err != nil {
+			b.Fatalf("unexpected error: %s", err)
+		}
+	}
+}
+
 func TestTypeCheckNormalize(t *testing.T) {
 	testData := []struct {
 		expr     string


### PR DESCRIPTION
Previously multiSourceInfo.findColumn used a closure to do some commonly
repeated work. Allocating this closure accounted for around 2.5% of the
total allocations recorded during a short run of TPCC. It's totally
pointless to keep it around, so extract it into its own function.

Also, typeCheckSameTypedExprs used a lot of closures to do its work. Create a
state object to pass around the arguments to avoid this problem, similar
to the strategy employed by typeCheckOverloadedExprs.


```
name         old time/op    new time/op    delta
TypeCheck-8    15.1µs ± 1%    14.2µs ± 1%   -5.59%  (p=0.000 n=10+10)

name         old alloc/op   new alloc/op   delta
TypeCheck-8    1.26kB ± 0%    0.68kB ± 0%  -45.86%  (p=0.000 n=10+10)

name         old allocs/op  new allocs/op  delta
TypeCheck-8      38.0 ± 0%      32.0 ± 0%  -15.79%  (p=0.000 n=10+10)
```