### PR TITLE
sql: slim down nameResolutionVisitor

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -124,6 +124,12 @@ type dataSourceInfo struct {
 	// column but might be different if the statement renames
 	// them using AS.
 	sourceAliases sourceAliases
+
+	// colOffset is the offset of the first column in this dataSourceInfo in the
+	// multiSourceInfo array it is part of.
+	// The value is populated and used during name resolution, and shouldn't get
+	// touched by anything but the nameResolutionVisitor without care.
+	colOffset int
 }
 
 // planDataSource contains the data source information for data

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -35,7 +35,6 @@ const invalidColIdx = parser.InvalidColIdx
 type nameResolutionVisitor struct {
 	err        error
 	sources    multiSourceInfo
-	colOffsets []int
 	iVarHelper parser.IndexedVarHelper
 	searchPath parser.SearchPath
 
@@ -121,7 +120,7 @@ func (v *nameResolutionVisitor) VisitPre(expr parser.Expr) (recurse bool, newNod
 			v.err = err
 			return false, expr
 		}
-		ivar := v.iVarHelper.IndexedVar(v.colOffsets[srcIdx] + colIdx)
+		ivar := v.iVarHelper.IndexedVar(v.sources[srcIdx].colOffset + colIdx)
 		v.foundDependentVars = true
 		return true, ivar
 
@@ -219,14 +218,13 @@ func (p *planner) resolveNames(
 	*v = nameResolutionVisitor{
 		err:                nil,
 		sources:            sources,
-		colOffsets:         make([]int, len(sources)),
 		iVarHelper:         ivarHelper,
 		searchPath:         p.session.SearchPath,
 		foundDependentVars: false,
 	}
 	colOffset := 0
-	for i, s := range sources {
-		v.colOffsets[i] = colOffset
+	for _, s := range sources {
+		s.colOffset = colOffset
 		colOffset += len(s.sourceColumns)
 	}
 


### PR DESCRIPTION
nameResolutionVisitor previously allocated a slice of column offsets to
keep track of the number of columns that each data source was
responsible for. This showed up prominently in allocations profiles.

Instead, store the column offset right on the data source info.

@knz I think this is a little sketchy since there is some leaking abstraction, but I'm submitting it for discussion anyway. Perhaps we can think of a better idea.