### PR TITLE
sql: add equivalency groups from equality filters + related fixes

### DIFF
--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -30,6 +30,12 @@ type filterNode struct {
 	source     planDataSource
 	filter     parser.TypedExpr
 	ivarHelper parser.IndexedVarHelper
+	ordering   orderingInfo
+}
+
+func (f *filterNode) computeOrdering(evalCtx *parser.EvalContext) {
+	f.ordering = planOrdering(f.source.plan)
+	f.ordering.applyExpr(evalCtx, f.filter)
 }
 
 // IndexedVarEval implements the parser.IndexedVarContainer interface.

--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -189,8 +189,11 @@ func (p *planner) selectIndex(
 		}
 	}
 
-	if analyzeOrdering != nil {
-		for _, c := range candidates {
+	for _, c := range candidates {
+		// Compute the prefix of the index for which we have exact constraints. This
+		// prefix is inconsequential for ordering because the values are identical.
+		c.exactPrefix = c.constraints.exactPrefix(&s.p.evalCtx)
+		if analyzeOrdering != nil {
 			c.analyzeOrdering(ctx, s, analyzeOrdering, preferOrderMatching)
 		}
 	}
@@ -408,10 +411,6 @@ func (v *indexInfo) analyzeExprs(exprs []parser.TypedExprs) {
 func (v *indexInfo) analyzeOrdering(
 	ctx context.Context, scan *scanNode, analyzeOrdering analyzeOrderingFn, preferOrderMatching bool,
 ) {
-	// Compute the prefix of the index for which we have exact constraints. This
-	// prefix is inconsequential for ordering because the values are identical.
-	v.exactPrefix = v.constraints.exactPrefix(&scan.p.evalCtx)
-
 	// Analyze the ordering provided by the index (either forward or reverse).
 	fwdIndexOrdering := scan.computeOrdering(v.index, v.exactPrefix, false)
 	revIndexOrdering := scan.computeOrdering(v.index, v.exactPrefix, true)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -143,10 +143,10 @@ SELECT x, str FROM NumToSquare JOIN NumToStr ON y = xsquared
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
-0  render  ·               ·                    (x, str)                                 ·
+0  render  ·               ·                    (x, str)                                 key(x)
 0  ·       render 0        test.numtosquare.x   ·                                        ·
 0  ·       render 1        test.numtostr.str    ·                                        ·
-1  join    ·               ·                    (x, xsquared[omitted], y[omitted], str)  x=y
+1  join    ·               ·                    (x, xsquared[omitted], y[omitted], str)  x=y; key(x)
 1  ·       type            inner                ·                                        ·
 1  ·       equality        (x) = (y)            ·                                        ·
 1  ·       mergeJoinOrder  +"(x=y)"             ·                                        ·

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -950,7 +950,7 @@ EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM
 0  ·       render 1  b                            ·                                     ·
 0  ·       render 2  n                            ·                                     ·
 0  ·       render 3  sq                           ·                                     ·
-1  filter  ·         ·                            (a, b, sum, n, sq)                    ·
+1  filter  ·         ·                            (a, b, sum, n, sq)                    sum=sq
 1  ·       filter    sum = sq                     ·                                     ·
 2  render  ·         ·                            (a, b, sum, n, sq)                    ·
 2  ·       render 0  test.pairs.a                 ·                                     ·

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1234,7 +1234,7 @@ CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
-0  join  ·               ·                      (a, b, c, d, a, b, c, d)  a=a; b=b; c=c
+0  join  ·               ·                      (a, b, c, d, a, b, c, d)  a=a; b=b; c=c; key(a,b); key(b,c)
 0  ·     type            inner                  ·                         ·
 0  ·     equality        (a, b, c) = (a, b, c)  ·                         ·
 0  ·     mergeJoinOrder  +"(b=b)"               ·                         ·
@@ -1248,12 +1248,12 @@ EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = 
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
-0  render  ·               ·                            (a, b, c, d)                                                                                                                                                          ·
+0  render  ·               ·                            (a, b, c, d)                                                                                                                                                          key(a,b)
 0  ·       render 0        a                            ·                                                                                                                                                                     ·
 0  ·       render 1        b                            ·                                                                                                                                                                     ·
 0  ·       render 2        c                            ·                                                                                                                                                                     ·
 0  ·       render 3        d                            ·                                                                                                                                                                     ·
-1  join    ·               ·                            (a, b, c, d, a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d[hidden,omitted], a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d[hidden,omitted])  a=a=a; b=b=b; c=c=c; d=d=d
+1  join    ·               ·                            (a, b, c, d, a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d[hidden,omitted], a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d[hidden,omitted])  a=a=a; b=b=b; c=c=c; d=d=d; key(a,b)
 1  ·       type            inner                        ·                                                                                                                                                                     ·
 1  ·       equality        (a, b, c, d) = (a, b, c, d)  ·                                                                                                                                                                     ·
 1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(d=d)"   ·                                                                                                                                                                     ·
@@ -1267,13 +1267,13 @@ EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
-0  render  ·               ·                           (a, b, c, d, d)                                                                                                                    ·
+0  render  ·               ·                           (a, b, c, d, d)                                                                                                                    key(a,b,c)
 0  ·       render 0        a                           ·                                                                                                                                  ·
 0  ·       render 1        b                           ·                                                                                                                                  ·
 0  ·       render 2        c                           ·                                                                                                                                  ·
 0  ·       render 3        l.d                         ·                                                                                                                                  ·
 0  ·       render 4        r.d                         ·                                                                                                                                  ·
-1  join    ·               ·                           (a, b, c, a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d, a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d)  a=a=a; b=b=b; c=c=c
+1  join    ·               ·                           (a, b, c, a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d, a[hidden,omitted], b[hidden,omitted], c[hidden,omitted], d)  a=a=a; b=b=b; c=c=c; key(a,b,c)
 1  ·       type            inner                       ·                                                                                                                                  ·
 1  ·       equality        (a, b, c) = (a, b, c)       ·                                                                                                                                  ·
 1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                                                                                                                                  ·
@@ -1287,7 +1287,7 @@ EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
-0  join  ·               ·                           (a, b, c, d, a, b, c, d)  a=a; b=b; c=d
+0  join  ·               ·                           (a, b, c, d, a, b, c, d)  a=a; b=b; c=d; key(a,b,c)
 0  ·     type            inner                       ·                         ·
 0  ·     equality        (c, a, b) = (d, a, b)       ·                         ·
 0  ·     mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -139,8 +139,8 @@ EXPLAIN (METADATA) DELETE FROM kv WHERE k = 3
 ----
 0  delete  ·      ·           ()               ·
 0  ·       from   kv          ·                ·
-1  render  ·      ·           (k)              key(k)
-2  scan    ·      ·           (k, v[omitted])  key(k)
+1  render  ·      ·           (k)              k=CONST; key()
+2  scan    ·      ·           (k, v[omitted])  k=CONST; key()
 2  ·       table  kv@primary  ·                ·
 2  ·       spans  /3-/4       ·                ·
 
@@ -195,6 +195,6 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM ab WHERE a=1
 0  group   ·            ·             ("count(*)")              ·
 0  ·       aggregate 0  count_rows()  ·                         ·
 1  render  ·            ·             ()                        ·
-2  scan    ·            ·             (a[omitted], b[omitted])  key(a,b)
+2  scan    ·            ·             (a[omitted], b[omitted])  a=CONST; key(b)
 2  ·       table        ab@primary    ·                         ·
 2  ·       spans        /1-/2         ·                         ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -754,7 +754,7 @@ EXPLAIN (METADATA) DELETE FROM t WHERE a = 3 RETURNING b
 ----
 0  delete  ·      ·          (b)        ·
 0  ·       from   t          ·          ·
-1  scan    ·      ·          (a, b, c)  key(a)
+1  scan    ·      ·          (a, b, c)  a=CONST; key()
 1  ·       table  t@primary  ·          ·
 1  ·       spans  /3-/4      ·          ·
 

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -105,8 +105,8 @@ EXPLAIN(METADATA) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
 0  sort    ·               ·                (k)                                                                                  ·
 0  ·       order           -v               ·                                                                                    ·
-1  render  ·               ·                (k, v)                                                                               ·
-2  join    ·               ·                (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])  k=k=k; v=v=v
+1  render  ·               ·                (k, v)                                                                               key(k)
+2  join    ·               ·                (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])  k=k=k; v=v=v; key(k)
 2  ·       type            inner            ·                                                                                    ·
 2  ·       equality        (k, v) = (k, v)  ·                                                                                    ·
 2  ·       mergeJoinOrder  +"(k=k)"         ·                                                                                    ·
@@ -123,8 +123,8 @@ EXPLAIN(METADATA) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@f
 ----
 0  nosort  ·               ·                  (k)                                                                                  ·
 0  ·       order           -v                 ·                                                                                    ·
-1  render  ·               ·                  (k, v)                                                                               -v
-2  join    ·               ·                  (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])  k=k=k; v=v=v; -v
+1  render  ·               ·                  (k, v)                                                                               key(k,v); -v
+2  join    ·               ·                  (k, v[omitted], k[hidden,omitted], v[hidden,omitted], k[hidden,omitted], v[hidden])  k=k=k; v=v=v; key(k,v); -v
 2  ·       type            inner              ·                                                                                    ·
 2  ·       equality        (k, v) = (k, v)    ·                                                                                    ·
 2  ·       mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                                                                                    ·

--- a/pkg/sql/logictest/testdata/logic_test/physical_props
+++ b/pkg/sql/logictest/testdata/logic_test/physical_props
@@ -118,7 +118,7 @@ query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=e AND a=1 AND f=g
 ----
 Level  Type  Field           Description   Columns                Ordering
-0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST
+0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST; key()
 0      ·     type            inner         ·                      ·
 0      ·     equality        (a) = (e)     ·                      ·
 0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
@@ -129,3 +129,67 @@ Level  Type  Field           Description   Columns                Ordering
 1      ·     table           efg@primary   ·                      ·
 1      ·     spans           ALL           ·                      ·
 1      ·     filter          f = g         ·                      ·
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=e AND b=1 AND f=g
+----
+Level  Type  Field           Description   Columns                Ordering
+0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; b=CONST; key(a)
+0      ·     type            inner         ·                      ·
+0      ·     equality        (a) = (e)     ·                      ·
+0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
+1      scan  ·               ·             (a, b, c, d)           b=CONST; key(a); +a
+1      ·     table           abcd@primary  ·                      ·
+1      ·     spans           ALL           ·                      ·
+1      ·     filter          b = 1         ·                      ·
+1      scan  ·               ·             (e, f, g)              f=g; key(e); +e
+1      ·     table           efg@primary   ·                      ·
+1      ·     spans           ALL           ·                      ·
+1      ·     filter          f = g         ·                      ·
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=e
+----
+Level  Type  Field           Description   Columns                Ordering
+0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; key(a)
+0      ·     type            inner         ·                      ·
+0      ·     equality        (a) = (e)     ·                      ·
+0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
+1      scan  ·               ·             (a, b, c, d)           key(a); +a
+1      ·     table           abcd@primary  ·                      ·
+1      ·     spans           ALL           ·                      ·
+1      scan  ·               ·             (e, f, g)              key(e); +e
+1      ·     table           efg@primary   ·                      ·
+1      ·     spans           ALL           ·                      ·
+
+# Verify keys don't get propagated when not appropriate.
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=f
+----
+Level  Type  Field     Description   Columns                Ordering
+0      join  ·         ·             (a, b, c, d, e, f, g)  ·
+0      ·     type      inner         ·                      ·
+0      ·     equality  (a) = (f)     ·                      ·
+1      scan  ·         ·             (a, b, c, d)           key(a)
+1      ·     table     abcd@primary  ·                      ·
+1      ·     spans     ALL           ·                      ·
+1      scan  ·         ·             (e, f, g)              key(e)
+1      ·     table     efg@primary   ·                      ·
+1      ·     spans     ALL           ·                      ·
+
+# Verify we retain all keys when appropriate.
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN (SELECT * FROM efg WITH ORDINALITY) ON a=e
+----
+Level  Type        Field           Description   Columns                              Ordering
+0      join        ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; key(a); key("ordinality")
+0      ·           type            inner         ·                                    ·
+0      ·           equality        (a) = (e)     ·                                    ·
+0      ·           mergeJoinOrder  +"(a=e)"      ·                                    ·
+1      scan        ·               ·             (a, b, c, d)                         key(a); +a
+1      ·           table           abcd@primary  ·                                    ·
+1      ·           spans           ALL           ·                                    ·
+1      ordinality  ·               ·             (e, f, g, "ordinality")              key(e); key("ordinality"); +e
+2      scan        ·               ·             (e, f, g)                            key(e); +e
+2      ·           table           efg@primary   ·                                    ·
+2      ·           spans           ALL           ·                                    ·

--- a/pkg/sql/logictest/testdata/logic_test/physical_props
+++ b/pkg/sql/logictest/testdata/logic_test/physical_props
@@ -1,0 +1,85 @@
+# LogicTest: default
+
+statement ok
+CREATE TABLE abcd (a INT PRIMARY KEY, b INT, c INT, d INT)
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE b = c
+----
+Level  Type  Field   Description   Columns       Ordering
+0      scan  ·       ·             (a, b, c, d)  b=c; key(a)
+0      ·     table   abcd@primary  ·             ·
+0      ·     spans   ALL           ·             ·
+0      ·     filter  b = c         ·             ·
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = 1
+----
+Level  Type  Field  Description   Columns       Ordering
+0      scan  ·      ·             (a, b, c, d)  a=CONST; key()
+0      ·     table  abcd@primary  ·             ·
+0      ·     spans  /1-/2         ·             ·
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE b = 1
+----
+Level  Type  Field   Description   Columns       Ordering
+0      scan  ·       ·             (a, b, c, d)  b=CONST; key(a)
+0      ·     table   abcd@primary  ·             ·
+0      ·     spans   ALL           ·             ·
+0      ·     filter  b = 1         ·             ·
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = 1 AND b = 1
+----
+Level  Type  Field   Description   Columns       Ordering
+0      scan  ·       ·             (a, b, c, d)  a=CONST; b=CONST; key()
+0      ·     table   abcd@primary  ·             ·
+0      ·     spans   /1-/2         ·             ·
+0      ·     filter  b = 1         ·             ·
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = 1 AND b = d
+----
+Level  Type  Field   Description   Columns       Ordering
+0      scan  ·       ·             (a, b, c, d)  b=d; a=CONST; key()
+0      ·     table   abcd@primary  ·             ·
+0      ·     spans   /1-/2         ·             ·
+0      ·     filter  b = d         ·             ·
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = b AND b = c
+----
+Level  Type  Field   Description          Columns       Ordering
+0      scan  ·       ·                    (a, b, c, d)  a=b=c; key(a)
+0      ·     table   abcd@primary         ·             ·
+0      ·     spans   ALL                  ·             ·
+0      ·     filter  (a = b) AND (b = c)  ·             ·
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = b AND b = c AND c = 1
+----
+Level  Type  Field   Description                        Columns       Ordering
+0      scan  ·       ·                                  (a, b, c, d)  a=b=c; a=CONST; key()
+0      ·     table   abcd@primary                       ·             ·
+0      ·     spans   ALL                                ·             ·
+0      ·     filter  ((a = b) AND (b = c)) AND (c = 1)  ·             ·
+
+statement ok
+CREATE TABLE efg (e INT PRIMARY KEY, f INT, g INT)
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=e AND a=1 AND f=g
+----
+Level  Type  Field           Description   Columns                Ordering
+0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST
+0      ·     type            inner         ·                      ·
+0      ·     equality        (a) = (e)     ·                      ·
+0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
+1      scan  ·               ·             (a, b, c, d)           a=CONST; key()
+1      ·     table           abcd@primary  ·                      ·
+1      ·     spans           /1-/2         ·                      ·
+1      scan  ·               ·             (e, f, g)              f=g; key(e); +e
+1      ·     table           efg@primary   ·                      ·
+1      ·     spans           ALL           ·                      ·
+1      ·     filter          f = g         ·                      ·

--- a/pkg/sql/logictest/testdata/logic_test/physical_props
+++ b/pkg/sql/logictest/testdata/logic_test/physical_props
@@ -65,6 +65,52 @@ Level  Type  Field   Description                        Columns       Ordering
 0      ·     spans   ALL                                ·             ·
 0      ·     filter  ((a = b) AND (b = c)) AND (c = 1)  ·             ·
 
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE a = 1
+----
+Level  Type    Field          Description        Columns    Ordering
+0      filter  ·              ·                  (a, b, c)  a=CONST
+0      ·       filter         x.a = 1            ·          ·
+1      values  ·              ·                  (a, b, c)  ·
+1      ·       size           3 columns, 2 rows  ·          ·
+1      ·       row 0, expr 0  1                  ·          ·
+1      ·       row 0, expr 1  2                  ·          ·
+1      ·       row 0, expr 2  3                  ·          ·
+1      ·       row 1, expr 0  4                  ·          ·
+1      ·       row 1, expr 1  5                  ·          ·
+1      ·       row 1, expr 2  6                  ·          ·
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE a = b
+----
+Level  Type    Field          Description        Columns    Ordering
+0      filter  ·              ·                  (a, b, c)  a=b
+0      ·       filter         x.a = x.b          ·          ·
+1      values  ·              ·                  (a, b, c)  ·
+1      ·       size           3 columns, 2 rows  ·          ·
+1      ·       row 0, expr 0  1                  ·          ·
+1      ·       row 0, expr 1  2                  ·          ·
+1      ·       row 0, expr 2  3                  ·          ·
+1      ·       row 1, expr 0  4                  ·          ·
+1      ·       row 1, expr 1  5                  ·          ·
+1      ·       row 1, expr 2  6                  ·          ·
+
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE a = b AND b = 1
+----
+Level  Type    Field          Description                Columns    Ordering
+0      filter  ·              ·                          (a, b, c)  a=b; a=CONST
+0      ·       filter         (x.a = x.b) AND (x.b = 1)  ·          ·
+1      values  ·              ·                          (a, b, c)  ·
+1      ·       size           3 columns, 2 rows          ·          ·
+1      ·       row 0, expr 0  1                          ·          ·
+1      ·       row 0, expr 1  2                          ·          ·
+1      ·       row 0, expr 2  3                          ·          ·
+1      ·       row 1, expr 0  4                          ·          ·
+1      ·       row 1, expr 1  5                          ·          ·
+1      ·       row 1, expr 2  6                          ·          ·
+
+
 statement ok
 CREATE TABLE efg (e INT PRIMARY KEY, f INT, g INT)
 

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
@@ -136,8 +136,8 @@ EXPLAIN (VERBOSE) SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s !=
 ----
 0  render      ·         ·          (a)                                      ·
 0  ·           render 0  test.t.a   ·                                        ·
-1  index-join  ·         ·          (a, b[omitted], c[omitted], s[omitted])  key(a,b,c)
-2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  key(a,b,c)
+1  index-join  ·         ·          (a, b[omitted], c[omitted], s[omitted])  b=CONST; key(a,c)
+2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  b=CONST; key(a,c)
 2  ·           table     t@bc       ·                                        ·
 2  ·           spans     /2-/3      ·                                        ·
 2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  ·

--- a/pkg/sql/ordering.go
+++ b/pkg/sql/ordering.go
@@ -53,6 +53,8 @@ import (
 // A set of columns S forms a "key" if no two rows are equal when projected
 // on S. Such a property arises when we are scanning a unique index.
 //
+// An empty key set is valid: it indicates the results have a single row.
+//
 // We store a list of sets which form keys. In most cases there is at most one
 // key.
 //

--- a/pkg/sql/ordering.go
+++ b/pkg/sql/ordering.go
@@ -349,6 +349,16 @@ func (ord *orderingInfo) addEquivalency(colA, colB int) {
 }
 
 func (ord *orderingInfo) addKeySet(cols util.FastIntSet) {
+	// Remap column indices to equivalency group representatives.
+	var k util.FastIntSet
+	for c, ok := cols.Next(0); ok; c, ok = cols.Next(c + 1) {
+		group := ord.eqGroups.Find(c)
+		if !ord.constantCols.Contains(group) {
+			k.Add(ord.eqGroups.Find(c))
+		}
+	}
+	cols = k
+
 	// Check if the key set is redundant, or if it makes some existing
 	// key sets redundant.
 	// Note: we don't use range because we are modifying keySets.
@@ -365,15 +375,7 @@ func (ord *orderingInfo) addKeySet(cols util.FastIntSet) {
 			i--
 		}
 	}
-	// Remap column indices to equivalency group representatives.
-	var k util.FastIntSet
-	for c, ok := cols.Next(0); ok; c, ok = cols.Next(c + 1) {
-		group := ord.eqGroups.Find(c)
-		if !ord.constantCols.Contains(group) {
-			k.Add(ord.eqGroups.Find(c))
-		}
-	}
-	ord.keySets = append(ord.keySets, k)
+	ord.keySets = append(ord.keySets, cols)
 }
 
 func (ord *orderingInfo) addOrderColumn(colIdx int, dir encoding.Direction) {

--- a/pkg/sql/plan_ordering.go
+++ b/pkg/sql/plan_ordering.go
@@ -30,12 +30,13 @@ func planOrdering(plan planNode) orderingInfo {
 		return planOrdering(n.results)
 	case *distinctNode:
 		return planOrdering(n.plan)
-	case *filterNode:
-		return planOrdering(n.source.plan)
 	case *limitNode:
 		return planOrdering(n.plan)
 	case *indexJoinNode:
 		return planOrdering(n.index)
+
+	case *filterNode:
+		return n.ordering
 
 	case *groupNode:
 		// TODO(dt,knz,radu): aggregate buckets can be ordered if the source is

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -406,6 +406,7 @@ func (n *scanNode) computeOrdering(
 	}
 	// We included any implicit columns, so the columns form a key.
 	ordering.addKeySet(keySet)
+	ordering.applyExpr(&n.p.evalCtx, n.filter)
 	return ordering
 }
 


### PR DESCRIPTION
#### sql: fix a case where we aren't setting the constant columns correctly

If we have a scan without a preferred order, the current code fails to set
`exactPrefix` correctly. This results in not setting the constant columns for
the exact prefix. For example: `SELECT * FROM kv WHERE k = 1` should have k as a
constant column.

The fix is to always calculate exactPrefix.

#### sql: refine orderingInfo with equalities from scan filters

Look for equality expressions in filters and add constant columns and
equivalency groups accordingly.

#### sql: refine filterNode orderingInfo with the filter expression

Apply the same treatment we applied to the scan node.

#### sql: improve orderingInfo property propagation for joins

Propagate all constant columns (existing code was based on the incorrect
assumption that we can only propagate constant *equality* columns); and
propagate key property when the equality columns form keys on both sides.


```
name                                                             old time/op    new time/op    delta
Planning/SELECT_*_FROM_abc-4                                        211µs ± 3%     211µs ± 2%    ~     (p=0.971 n=10+10)
Planning/SELECT_*_FROM_abc_WHERE_a_>_5_ORDER_BY_a-4                 190µs ± 6%     187µs ± 4%    ~     (p=0.190 n=10+10)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5-4                            187µs ± 6%     188µs ± 7%    ~      (p=0.661 n=10+9)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5_ORDER_BY_a-4                 195µs ± 9%     196µs ± 7%    ~      (p=0.968 n=10+9)
Planning/SELECT_*_FROM_abc_WHERE_c_=_5-4                            188µs ± 5%     184µs ± 9%    ~     (p=0.280 n=10+10)
Planning/SELECT_*_FROM_abc_JOIN_abc_AS_abc2_ON_abc.a_=_abc2.a-4     298µs ± 1%     297µs ± 5%    ~     (p=0.684 n=10+10)

name                                                             old alloc/op   new alloc/op   delta
Planning/SELECT_*_FROM_abc-4                                       31.7kB ± 0%    31.7kB ± 0%    ~       (p=0.928 n=7+7)
Planning/SELECT_*_FROM_abc_WHERE_a_>_5_ORDER_BY_a-4                22.6kB ± 0%    22.8kB ± 0%  +0.85%    (p=0.000 n=9+8)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5-4                           23.5kB ± 0%    23.5kB ± 0%  +0.28%  (p=0.000 n=10+10)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5_ORDER_BY_a-4                24.4kB ± 0%    24.6kB ± 0%  +0.79%   (p=0.000 n=10+9)
Planning/SELECT_*_FROM_abc_WHERE_c_=_5-4                           23.4kB ± 0%    23.4kB ± 0%  +0.33%  (p=0.000 n=10+10)
Planning/SELECT_*_FROM_abc_JOIN_abc_AS_abc2_ON_abc.a_=_abc2.a-4    71.6kB ± 0%    71.6kB ± 0%  +0.02%  (p=0.000 n=10+10)

name                                                             old allocs/op  new allocs/op  delta
Planning/SELECT_*_FROM_abc-4                                          354 ± 0%       354 ± 0%    ~     (p=1.000 n=10+10)
Planning/SELECT_*_FROM_abc_WHERE_a_>_5_ORDER_BY_a-4                   370 ± 0%       376 ± 0%  +1.62%  (p=0.000 n=10+10)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5-4                              347 ± 0%       346 ± 0%  -0.29%  (p=0.000 n=10+10)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5_ORDER_BY_a-4                   397 ± 0%       403 ± 0%  +1.51%  (p=0.000 n=10+10)
Planning/SELECT_*_FROM_abc_WHERE_c_=_5-4                              343 ± 0%       342 ± 0%  -0.29%  (p=0.000 n=10+10)
Planning/SELECT_*_FROM_abc_JOIN_abc_AS_abc2_ON_abc.a_=_abc2.a-4       716 ± 0%       717 ± 0%  +0.14%  (p=0.000 n=10+10)
```