### PR TITLE
sql: don't search for fk index again

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -336,16 +336,15 @@ func (n *alterTableNode) Start(params runParams) error {
 					}
 				}
 			case sqlbase.ConstraintTypeFK:
-				for i, idx := range n.tableDesc.Indexes {
-					if idx.ForeignKey.Name == name {
-						if err := params.p.removeFKBackReference(params.ctx, n.tableDesc, idx); err != nil {
-							return err
-						}
-						n.tableDesc.Indexes[i].ForeignKey = sqlbase.ForeignKeyReference{}
-						descriptorChanged = true
-						break
-					}
+				idx, err := n.tableDesc.FindIndexByID(details.Index.ID)
+				if err != nil {
+					return err
 				}
+				if err := params.p.removeFKBackReference(params.ctx, n.tableDesc, *idx); err != nil {
+					return err
+				}
+				idx.ForeignKey = sqlbase.ForeignKeyReference{}
+				descriptorChanged = true
 			default:
 				return errors.Errorf("dropping %s constraint %q unsupported", details.Kind, t.Constraint)
 			}

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -132,6 +132,36 @@ statement ok
 INSERT INTO "user content"."customer reviews" (id, product, body) VALUES (2, '780', 'would not buy again')
 
 statement ok
+CREATE TABLE "user content".review_stats (
+  id INT PRIMARY KEY,
+  upvotes INT,
+  CONSTRAINT reviewfk FOREIGN KEY (id) REFERENCES "user content"."customer reviews"
+)
+
+query TTTTT
+SHOW CONSTRAINTS FROM "user content".review_stats
+----
+review_stats  primary   PRIMARY KEY  id  NULL
+review_stats  reviewfk  FOREIGN KEY  id  customer reviews.[id]
+
+statement error pgcode 23503 foreign key violation: value \[5\] not found in customer reviews@primary \[id\]
+INSERT INTO "user content".review_stats (id, upvotes) VALUES (5, 1)
+
+statement ok
+INSERT INTO "user content".review_stats (id, upvotes) VALUES (2, 1)
+
+statement error pgcode 23503 foreign key violation: values \[2\] in columns \[id\] referenced in table "review_stats"
+DELETE FROM "user content"."customer reviews" WHERE id = 2
+
+statement ok
+ALTER TABLE "user content".review_stats DROP CONSTRAINT reviewfk
+
+query TTTTT
+SHOW CONSTRAINTS FROM "user content".review_stats
+----
+review_stats  primary   PRIMARY KEY  id  NULL
+
+statement ok
 DELETE FROM "user content"."customer reviews"
 
 statement error pgcode 23503 foreign key violation: value \['790'\] not found in products@primary \[sku\]
@@ -701,25 +731,25 @@ DROP TABLE b
 # # A CREATE TABLE with a FK reference within a transaction.
 # statement ok
 # CREATE TABLE referee (id INT PRIMARY KEY);
-# 
+#
 # statement ok
 # BEGIN TRANSACTION
-# 
+#
 # statement ok
 # CREATE TABLE refers (
 #   a INT REFERENCES referee,
 #   b INT,
 #   INDEX b_idx (b)
 # )
-# 
+#
 # # Add some schema changes within the same transaction to verify that a
 # # table that isn't yet public can be modified.
 # statement ok
 # CREATE INDEX foo ON refers (a)
-# 
+#
 # statement ok
 # ALTER INDEX refers@b_idx RENAME TO another_idx
-# 
+#
 # query TT
 # SHOW CREATE TABLE refers
 # ----
@@ -731,23 +761,23 @@ DROP TABLE b
 #     INDEX refers_auto_index_fk_a_ref_referee (a ASC),
 #     FAMILY "primary" (a, b, rowid)
 # )
-# 
+#
 # statement ok
 # DROP INDEX refers@another_idx
-# 
+#
 # statement ok
 # COMMIT
-# 
+#
 # # CREATE AND DROP a table with a fk in the same transaction.
 # statement ok
 # BEGIN TRANSACTION
-# 
+#
 # statement ok
 # CREATE TABLE refers1 (a INT REFERENCES referee);
-# 
+#
 # statement ok
 # DROP TABLE refers1
-# 
+#
 # statement ok
 # COMMIT
 

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -2105,13 +2105,14 @@ func (desc TableDescriptor) collectConstraintInfo(
 			}
 			detail := ConstraintDetail{Kind: ConstraintTypeFK}
 			detail.Unvalidated = index.ForeignKey.Validity == ConstraintValidity_Unvalidated
+			numCols := len(index.ColumnIDs)
+			if index.ForeignKey.SharedPrefixLen > 0 {
+				numCols = int(index.ForeignKey.SharedPrefixLen)
+			}
+			detail.Columns = index.ColumnNames[:numCols]
+			detail.Index = index
+
 			if tableLookup != nil {
-				numCols := len(index.ColumnIDs)
-				if index.ForeignKey.SharedPrefixLen > 0 {
-					numCols = int(index.ForeignKey.SharedPrefixLen)
-				}
-				detail.Columns = index.ColumnNames[:numCols]
-				detail.Index = index
 				other, err := tableLookup(index.ForeignKey.Table)
 				if err != nil {
 					return nil, errors.Errorf("error resolving table %d referenced in foreign key",


### PR DESCRIPTION
Rather than searching all the indexes (and forgetting to look at the primary, whoops), just save which index the constraint came from in the constraint detail and use that.

Fixes #19084.