### PR TITLE
cherrypick-1.1: sql: don't search for fk index again

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -336,16 +336,15 @@ func (n *alterTableNode) Start(params runParams) error {
 					}
 				}
 			case sqlbase.ConstraintTypeFK:
-				for i, idx := range n.tableDesc.Indexes {
-					if idx.ForeignKey.Name == name {
-						if err := params.p.removeFKBackReference(params.ctx, n.tableDesc, idx); err != nil {
-							return err
-						}
-						n.tableDesc.Indexes[i].ForeignKey = sqlbase.ForeignKeyReference{}
-						descriptorChanged = true
-						break
-					}
+				idx, err := n.tableDesc.FindIndexByID(details.Index.ID)
+				if err != nil {
+					return err
 				}
+				if err := params.p.removeFKBackReference(params.ctx, n.tableDesc, *idx); err != nil {
+					return err
+				}
+				idx.ForeignKey = sqlbase.ForeignKeyReference{}
+				descriptorChanged = true
 			default:
 				return errors.Errorf("dropping %s constraint %q unsupported", details.Kind, t.Constraint)
 			}

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -132,6 +132,36 @@ statement ok
 INSERT INTO "user content"."customer reviews" (id, product, body) VALUES (2, '780', 'would not buy again')
 
 statement ok
+CREATE TABLE "user content".review_stats (
+  id INT PRIMARY KEY,
+  upvotes INT,
+  CONSTRAINT reviewfk FOREIGN KEY (id) REFERENCES "user content"."customer reviews"
+)
+
+query TTTTT
+SHOW CONSTRAINTS FROM "user content".review_stats
+----
+review_stats  primary   PRIMARY KEY  id  NULL
+review_stats  reviewfk  FOREIGN KEY  id  customer reviews.[id]
+
+statement error pgcode 23503 foreign key violation: value \[5\] not found in customer reviews@primary \[id\]
+INSERT INTO "user content".review_stats (id, upvotes) VALUES (5, 1)
+
+statement ok
+INSERT INTO "user content".review_stats (id, upvotes) VALUES (2, 1)
+
+statement error pgcode 23503 foreign key violation: values \[2\] in columns \[id\] referenced in table "review_stats"
+DELETE FROM "user content"."customer reviews" WHERE id = 2
+
+statement ok
+ALTER TABLE "user content".review_stats DROP CONSTRAINT reviewfk
+
+query TTTTT
+SHOW CONSTRAINTS FROM "user content".review_stats
+----
+review_stats  primary   PRIMARY KEY  id  NULL
+
+statement ok
 DELETE FROM "user content"."customer reviews"
 
 statement error pgcode 23503 foreign key violation: value \['790'\] not found in products@primary \[sku\]
@@ -748,7 +778,6 @@ DROP TABLE refers1
 
 statement ok
 COMMIT
-
 
 statement ok
 CREATE TABLE a (id BIGSERIAL NOT NULL, self_id INT, b_id INT UNIQUE NOT NULL, PRIMARY KEY (id));

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -2045,13 +2045,14 @@ func (desc TableDescriptor) collectConstraintInfo(
 			}
 			detail := ConstraintDetail{Kind: ConstraintTypeFK}
 			detail.Unvalidated = index.ForeignKey.Validity == ConstraintValidity_Unvalidated
+			numCols := len(index.ColumnIDs)
+			if index.ForeignKey.SharedPrefixLen > 0 {
+				numCols = int(index.ForeignKey.SharedPrefixLen)
+			}
+			detail.Columns = index.ColumnNames[:numCols]
+			detail.Index = index
+
 			if tableLookup != nil {
-				numCols := len(index.ColumnIDs)
-				if index.ForeignKey.SharedPrefixLen > 0 {
-					numCols = int(index.ForeignKey.SharedPrefixLen)
-				}
-				detail.Columns = index.ColumnNames[:numCols]
-				detail.Index = index
 				other, err := tableLookup(index.ForeignKey.Table)
 				if err != nil {
 					return nil, errors.Errorf("error resolving table %d referenced in foreign key",


### PR DESCRIPTION
rather than searching all the indexes (and forgetting to look at the primary, whoops), just use save which index the constraint came from in the constraint detail and use that.

Fixes #19084.