### PR TITLE
storage: prevent accidentally unpoisoning aborted txn

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1863,12 +1863,32 @@ func setAbortCache(
 	return rec.AbortCache().Put(ctx, batch, ms, txn.ID, &entry)
 }
 
-func declareKeysResolveIntent(
+func writeAbortCacheOnResolve(status roachpb.TransactionStatus) bool {
+	return status == roachpb.ABORTED
+}
+
+func declareKeysResolveIntentCombined(
 	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *SpanSet,
 ) {
 	DefaultDeclareKeys(desc, header, req, spans)
-	ri := req.(*roachpb.ResolveIntentRequest)
-	spans.Add(SpanReadWrite, roachpb.Span{Key: keys.AbortCacheKey(header.RangeID, ri.IntentTxn.ID)})
+	var args *roachpb.ResolveIntentRequest
+	switch t := req.(type) {
+	case *roachpb.ResolveIntentRequest:
+		args = t
+	case *roachpb.ResolveIntentRangeRequest:
+		// Ranged and point requests only differ in whether the header's EndKey
+		// is used, so we can convert them.
+		args = (*roachpb.ResolveIntentRequest)(t)
+	}
+	if writeAbortCacheOnResolve(args.Status) {
+		spans.Add(SpanReadWrite, roachpb.Span{Key: keys.AbortCacheKey(header.RangeID, args.IntentTxn.ID)})
+	}
+}
+
+func declareKeysResolveIntent(
+	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *SpanSet,
+) {
+	declareKeysResolveIntentCombined(desc, header, req, spans)
 }
 
 // evalResolveIntent resolves a write intent from the specified key
@@ -1892,7 +1912,7 @@ func evalResolveIntent(
 	if err := engine.MVCCResolveWriteIntent(ctx, batch, ms, intent); err != nil {
 		return EvalResult{}, err
 	}
-	if intent.Status == roachpb.ABORTED {
+	if writeAbortCacheOnResolve(args.Status) {
 		return EvalResult{}, setAbortCache(ctx, cArgs.EvalCtx, batch, ms, args.IntentTxn, args.Poison)
 	}
 	return EvalResult{}, nil
@@ -1901,9 +1921,7 @@ func evalResolveIntent(
 func declareKeysResolveIntentRange(
 	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *SpanSet,
 ) {
-	DefaultDeclareKeys(desc, header, req, spans)
-	ri := req.(*roachpb.ResolveIntentRangeRequest)
-	spans.Add(SpanReadWrite, roachpb.Span{Key: keys.AbortCacheKey(header.RangeID, ri.IntentTxn.ID)})
+	declareKeysResolveIntentCombined(desc, header, req, spans)
 }
 
 // evalResolveIntentRange resolves write intents in the specified
@@ -1928,7 +1946,7 @@ func evalResolveIntentRange(
 	if _, err := engine.MVCCResolveWriteIntentRange(ctx, batch, ms, intent, math.MaxInt64); err != nil {
 		return EvalResult{}, err
 	}
-	if intent.Status == roachpb.ABORTED {
+	if writeAbortCacheOnResolve(args.Status) {
 		return EvalResult{}, setAbortCache(ctx, cArgs.EvalCtx, batch, ms, args.IntentTxn, args.Poison)
 	}
 	return EvalResult{}, nil

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2448,7 +2448,7 @@ func TestReplicaCommandQueueCancellationLocal(t *testing.T) {
 	}
 
 	// Used only to block the other requests. Not a necessary part of the
-	// scenerio. See the comment on RunWithoutInitialSpan.
+	// scenario. See the comment on RunWithoutInitialSpan.
 	heartbeatBa := newBa(true /* withTxn */)
 	heartbeatBa.Add(&roachpb.HeartbeatTxnRequest{
 		Span: roachpb.Span{
@@ -2510,7 +2510,14 @@ func TestReplicaCommandQueueCancellationLocal(t *testing.T) {
 			Key: intentKey,
 		},
 		IntentTxn: txn.TxnMeta,
-		Status:    roachpb.PENDING,
+		// NB: This test originally used PENDING but the test requires the abort
+		// cache key to be declared here, and this is no more the case due to an
+		// optimization. Use an ABORTED resolve instead...
+		Status: roachpb.ABORTED,
+		// ... but with Poison=false which accesses the abort cache by *clearing*
+		// it. Poison=true would fail the test since the transaction would not be
+		// able to issue further commands.
+		Poison: false,
 	})
 
 	getKeyBa := newBa(true /* withTxn */)

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -4912,7 +4912,7 @@ func TestReplicaResolveIntentNoWait(t *testing.T) {
 			Span:   roachpb.Span{Key: key},
 			Txn:    txn.TxnMeta,
 			Status: txn.Status,
-		}}, ResolveOptions{Wait: false, Poison: false}); pErr != nil {
+		}}, ResolveOptions{Wait: false, Poison: true /* irrelevant */}); pErr != nil {
 		t.Fatal(pErr)
 	}
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/storage/span_set.go
+++ b/pkg/storage/span_set.go
@@ -16,6 +16,9 @@
 package storage
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -49,6 +52,19 @@ const (
 // separate local and global command queues).
 type SpanSet struct {
 	spans [numSpanAccess][numSpanScope][]roachpb.Span
+}
+
+// String prints a string representation of the span set.
+func (ss *SpanSet) String() string {
+	var buf bytes.Buffer
+	for i := SpanAccess(0); i < numSpanAccess; i++ {
+		for j := spanScope(0); j < numSpanScope; j++ {
+			for _, span := range ss.getSpans(i, j) {
+				fmt.Fprintf(&buf, "%d %d: %s\n", i, j, span)
+			}
+		}
+	}
+	return buf.String()
 }
 
 func (ss *SpanSet) len() int {


### PR DESCRIPTION
Discovered by @bdarnell in
https://github.com/cockroachdb/cockroach/pull/18635#issuecomment-333393480.
Making poisoning happen less often (to reduce contention) is planned but
requires more care.

Closes #18635.