### PR TITLE
cli: Improve help message for debug zip command

### DIFF
--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -18,7 +18,6 @@ package cli
 import (
 	"archive/zip"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -105,7 +104,7 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 	)
 
 	if len(args) != 1 {
-		return errors.New("exactly one argument is required")
+		return usageAndError(cmd)
 	}
 
 	conn, _, stopper, err := getClientGRPCConn()


### PR DESCRIPTION
Previously if you didn't provide a file argument, it would just print
out:

Error: exactly one argument is required
Failed running "debug"

Which doesn't indicate what argument is required and also kind of makes
it look like you were just running `cockroach debug`, not
`cockroach debug zip`.

Found by @dianasaur323 