### PR TITLE
[WIP] experimental cRPC protocol

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -161,6 +161,12 @@ type connMeta struct {
 	heartbeatErr atomic.Value
 }
 
+type crpcConnMeta struct {
+	sync.Once
+	conn    *CRPCClientConn
+	dialErr error
+}
+
 // Context contains the fields required by the rpc framework.
 type Context struct {
 	*base.Config
@@ -181,6 +187,8 @@ type Context struct {
 	localInternalServer roachpb.InternalServer
 
 	conns syncmap.Map
+
+	crpcConns syncmap.Map
 
 	// For unittesting.
 	BreakerFactory func() *circuit.Breaker
@@ -225,6 +233,23 @@ func NewContext(
 				}
 			})
 			ctx.removeConn(k.(string), meta)
+			return true
+		})
+
+		ctx.crpcConns.Range(func(k, v interface{}) bool {
+			meta := v.(*crpcConnMeta)
+			meta.Do(func() {
+				// Make sure initialization is not in progress when we're removing the
+				// conn. We need to set the error in case we win the race against the
+				// real initialization code.
+				if meta.dialErr == nil {
+					meta.dialErr = &roachpb.NodeUnavailableError{}
+				}
+			})
+			ctx.crpcConns.Delete(k)
+			if conn := meta.conn; conn != nil {
+				conn.Close()
+			}
 			return true
 		})
 	})
@@ -381,6 +406,26 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 		}
 	})
 
+	return meta.conn, meta.dialErr
+}
+
+// CRPCDial ...
+func (ctx *Context) CRPCDial(target string) (*CRPCClientConn, error) {
+	value, ok := ctx.crpcConns.Load(target)
+	if !ok {
+		meta := &crpcConnMeta{}
+		value, _ = ctx.crpcConns.LoadOrStore(target, meta)
+	}
+
+	meta := value.(*crpcConnMeta)
+	meta.Do(func() {
+		conn, err := net.Dial("tcp", target)
+		if err != nil {
+			meta.dialErr = err
+			return
+		}
+		meta.conn = newCRPCClientConn(conn)
+	})
 	return meta.conn, meta.dialErr
 }
 

--- a/pkg/rpc/crpc.go
+++ b/pkg/rpc/crpc.go
@@ -1,0 +1,344 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rpc
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"sync"
+
+	"golang.org/x/net/context"
+	"golang.org/x/net/http2"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+const crpcVersion = "CRPC 1.0\n"
+
+// CRPCMatch matches CRPC connections.
+func CRPCMatch(rd io.Reader) bool {
+	buf := make([]byte, len(crpcVersion))
+	if n, err := io.ReadFull(rd, buf); err != nil || n != len(buf) {
+		return false
+	}
+	return string(buf) == crpcVersion
+}
+
+type crpcServerResp struct {
+	streamID uint32
+	resp     protoutil.Message
+	err      error
+}
+
+type crpcParser func([]byte) (protoutil.Message, error)
+type crpcHandler func(protoutil.Message) (protoutil.Message, error)
+
+type crpcServerConn struct {
+	conn    net.Conn
+	rd      *bufio.Reader
+	wr      *bufio.Writer
+	fr      *http2.Framer
+	parser  crpcParser
+	handler crpcHandler
+
+	sender struct {
+		syncutil.Mutex
+		cond    sync.Cond
+		closed  bool
+		pending []crpcServerResp
+	}
+}
+
+func newCRPCServerConn(conn net.Conn, parser crpcParser, handler crpcHandler) *crpcServerConn {
+	c := &crpcServerConn{
+		conn:    conn,
+		rd:      bufio.NewReader(conn),
+		wr:      bufio.NewWriter(conn),
+		parser:  parser,
+		handler: handler,
+	}
+	c.fr = http2.NewFramer(c.wr, c.rd)
+	c.fr.SetReuseFrames()
+	c.sender.cond.L = &c.sender.Mutex
+	return c
+}
+
+func (c *crpcServerConn) readLoop() {
+	defer c.Close()
+
+	vers := make([]byte, len(crpcVersion))
+	if _, err := io.ReadFull(c.rd, vers); err != nil {
+		c.Close()
+		return
+	}
+
+	// Only start the write loop after we've parsed the version.
+	go c.writeLoop()
+	ctx := context.Background()
+
+	for {
+		frame, err := c.fr.ReadFrame()
+		if err != nil {
+			log.Error(ctx, err)
+			return
+		}
+
+		switch frame := frame.(type) {
+		case *http2.DataFrame:
+			req, err := c.parser(frame.Data())
+			go func(streamID uint32, req protoutil.Message, err error) {
+				var resp protoutil.Message
+				if err == nil {
+					resp, err = c.handler(req)
+				}
+				c.send(streamID, resp, err)
+			}(frame.StreamID, req, err)
+		default:
+			log.Fatalf(ctx, "unhandled frame type %T: %v", frame, frame)
+		}
+	}
+}
+
+func (c *crpcServerConn) writeLoop() {
+	defer c.Close()
+
+	ctx := context.Background()
+	s := &c.sender
+	var tmpbuf []byte
+
+	for {
+		s.Lock()
+		for len(s.pending) == 0 && !s.closed {
+			s.cond.Wait()
+		}
+		if s.closed {
+			s.Unlock()
+			return
+		}
+		pending := s.pending
+		s.pending = nil
+		s.Unlock()
+
+		for _, p := range pending {
+			if p.resp != nil {
+				size := p.resp.Size()
+				if cap(tmpbuf) < size {
+					tmpbuf = make([]byte, size)
+				}
+				tmpbuf = tmpbuf[:size]
+				if _, err := protoutil.MarshalToWithoutFuzzing(p.resp, tmpbuf); err != nil {
+					log.Warning(ctx, err)
+					continue
+				}
+			} else {
+				tmpbuf = tmpbuf[:0]
+			}
+			if err := c.fr.WriteData(p.streamID, true, tmpbuf); err != nil {
+				log.Warning(ctx, err)
+			}
+		}
+
+		if err := c.wr.Flush(); err != nil {
+			log.Warning(ctx, err)
+			return
+		}
+	}
+}
+
+func (c *crpcServerConn) send(streamID uint32, resp protoutil.Message, err error) {
+	s := &c.sender
+	s.Lock()
+	s.pending = append(s.pending, crpcServerResp{
+		streamID: streamID,
+		resp:     resp,
+		err:      err,
+	})
+	s.cond.Signal()
+	s.Unlock()
+}
+
+// Close ...
+func (c *crpcServerConn) Close() {
+	c.sender.Lock()
+	c.sender.closed = true
+	c.sender.cond.Signal()
+	c.sender.Unlock()
+	if err := c.conn.Close(); err != nil {
+		log.Warning(context.Background(), err)
+	}
+}
+
+// CRPCServe ...
+func CRPCServe(l net.Listener, parser crpcParser, handler crpcHandler) error {
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			return err
+		}
+		c := newCRPCServerConn(conn, parser, handler)
+		go c.readLoop()
+	}
+}
+
+type crpcClientReq struct {
+	streamID uint32
+	req      protoutil.Message
+	resp     protoutil.Message
+	err      error
+	wg       sync.WaitGroup
+}
+
+// CRPCClientConn ...
+type CRPCClientConn struct {
+	conn net.Conn
+	rd   *bufio.Reader
+	wr   *bufio.Writer
+	fr   *http2.Framer
+
+	sender struct {
+		syncutil.Mutex
+		cond    sync.Cond
+		closed  bool
+		pending []*crpcClientReq
+	}
+	receiver struct {
+		syncutil.Mutex
+		nextID  uint32
+		pending map[uint32]*crpcClientReq
+	}
+}
+
+func newCRPCClientConn(conn net.Conn) *CRPCClientConn {
+	c := &CRPCClientConn{
+		conn: conn,
+		rd:   bufio.NewReader(conn),
+		wr:   bufio.NewWriter(conn),
+	}
+	c.fr = http2.NewFramer(c.wr, c.rd)
+	c.fr.SetReuseFrames()
+	c.sender.cond.L = &c.sender.Mutex
+	c.receiver.nextID = 1
+	c.receiver.pending = make(map[uint32]*crpcClientReq)
+	go c.readLoop()
+	go c.writeLoop()
+	return c
+}
+
+func (c *CRPCClientConn) readLoop() {
+	defer c.Close()
+
+	r := &c.receiver
+	ctx := context.Background()
+
+	for {
+		frame, err := c.fr.ReadFrame()
+		if err != nil {
+			log.Error(ctx, err)
+			return
+		}
+
+		switch frame := frame.(type) {
+		case *http2.DataFrame:
+			r.Lock()
+			p := r.pending[frame.StreamID]
+			delete(r.pending, frame.StreamID)
+			r.Unlock()
+			p.err = protoutil.Unmarshal(frame.Data(), p.resp)
+			p.wg.Done()
+		default:
+			log.Fatalf(ctx, "unhandled frame type %v.", frame)
+		}
+	}
+}
+
+func (c *CRPCClientConn) writeLoop() {
+	defer c.Close()
+
+	if _, err := c.conn.Write([]byte(crpcVersion)); err != nil {
+		return
+	}
+
+	s := &c.sender
+	var tmpbuf []byte
+
+	for {
+		s.Lock()
+		for len(s.pending) == 0 && !s.closed {
+			s.cond.Wait()
+		}
+		if s.closed {
+			s.Unlock()
+			return
+		}
+		pending := s.pending
+		s.pending = nil
+		s.Unlock()
+
+		for _, p := range pending {
+			size := p.req.Size()
+			if cap(tmpbuf) < size {
+				tmpbuf = make([]byte, size)
+			}
+			tmpbuf = tmpbuf[:size]
+			if _, err := protoutil.MarshalToWithoutFuzzing(p.req, tmpbuf); err != nil {
+				p.err = err
+				p.wg.Done()
+				continue
+			}
+			if err := c.fr.WriteData(p.streamID, true, tmpbuf); err != nil {
+				return
+			}
+		}
+		if err := c.wr.Flush(); err != nil {
+			return
+		}
+	}
+}
+
+// Send ...
+func (c *CRPCClientConn) Send(req, resp protoutil.Message) error {
+	p := &crpcClientReq{req: req, resp: resp}
+	p.wg.Add(1)
+
+	r := &c.receiver
+	r.Lock()
+	p.streamID = r.nextID
+	r.nextID++
+	r.pending[p.streamID] = p
+	r.Unlock()
+
+	s := &c.sender
+	s.Lock()
+	s.pending = append(s.pending, p)
+	s.cond.Signal()
+	s.Unlock()
+
+	p.wg.Wait()
+	return p.err
+}
+
+// Close ...
+func (c *CRPCClientConn) Close() {
+	c.sender.Lock()
+	c.sender.closed = true
+	c.sender.cond.Signal()
+	c.sender.Unlock()
+	if err := c.conn.Close(); err != nil {
+		log.Warning(context.Background(), err)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -689,6 +689,7 @@ func (s *Server) Start(ctx context.Context) error {
 	})
 
 	pgL := m.Match(pgwire.Match)
+	crpcL := m.Match(rpc.CRPCMatch)
 	anyL := m.Match(cmux.Any())
 
 	httpLn, err := net.Listen("tcp", s.cfg.HTTPAddr)
@@ -751,6 +752,20 @@ func (s *Server) Start(ctx context.Context) error {
 			// A cmux can't gracefully shut down without Serve being called on it.
 			netutil.FatalIfUnexpected(m.Serve())
 		})
+	})
+
+	s.stopper.RunWorker(workersCtx, func(context.Context) {
+		netutil.FatalIfUnexpected(rpc.CRPCServe(crpcL,
+			func(data []byte) (protoutil.Message, error) {
+				req := &roachpb.BatchRequest{}
+				if err := protoutil.Unmarshal(data, req); err != nil {
+					return nil, err
+				}
+				return req, nil
+			},
+			func(req protoutil.Message) (protoutil.Message, error) {
+				return s.node.Batch(context.TODO(), req.(*roachpb.BatchRequest))
+			}))
 	})
 
 	s.stopper.RunWorker(workersCtx, func(context.Context) {


### PR DESCRIPTION
The cRPC protocol is built on top of http2 using only http2 data
frames. The core read and write loops are similar to gRPC, but trimmed
down to their essence. A ton of stuff is missing before this could
actually be used, such as context cancellation propagation, trace
propagation, chunking of large requests/responses into frames, and
proper error handling. This PR was done as a proof of concept to see
what performance impact replacing gRPC with something else could
achieve.

On a single-node cluster with the local server optimization disabled,
gRPC on a read-mostly workload shows:
```
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
   10.0s        0         111904        11189.4      1.4      1.2      3.0      5.8     18.9
```
cRPC:
```
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
   10.0s        0         183923        18389.3      0.9      0.7      1.8      3.7     62.9
```
Unfortunately, the effects on a multi-node cluster are less dramatic.

I think it would be possible to make cRPC wire compatible with
gRPC. This would require sending a headers frame with every RPC, but the
headers are small (7 bytes) and constant for this use case. We'd also
have to send a settings frame as the first frame on the connection, but
that is trivial.

See #17370.