### PR TITLE
pgwire,sql: add pg error codes

### DIFF
--- a/pkg/acceptance/node_test.go
+++ b/pkg/acceptance/node_test.go
@@ -84,6 +84,19 @@ function testSendInvalidUTF8(client) {
   });
 }
 
+function testSendNotEnoughParams(client) {
+  return new Promise(resolve => {
+    client.query({
+      text: 'SELECT 3',
+      values: ['foo']
+    }, function (err, results) {
+      let validationError = isError(err, /expected 0 arguments, got 1/, '08P01');
+      if (validationError) throw validationError;
+      resolve();
+    });
+  });
+}
+
 function runTests(client, ...tests) {
   if (tests.length === 0) {
     return Promise.resolve();
@@ -97,6 +110,7 @@ client.connect(function (err) {
 
   runTests(client,
     testSendInvalidUTF8,
+    testSendNotEnoughParams,
     testSelect
   ).then(result => {
     client.end(function (err) {


### PR DESCRIPTION
Remove v3conn.sendInternalError and uses of it. In addition, correct a
case where we were not sending an error back to the client before
terminating their connection.

I tested all of these against Postgres (sometimes there wasn't a clear analogue, though).
I think as far as testing goes,
all we really have is the integration tests for something like this, but
even then, most drivers that I've seen don't let you construct messages
that would trigger some of these (I had to mess with the guts of one
to test this).

I would rather if we had something a little more fine-grained, but I'm
not sure what that would look like necessarily. I'm still debating
putting together a new driver (or forking an old one) to better be able
to suit this purpose.