### PR TITLE
cli/sql: re-enable, then test, unicode input in interactive shells

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -397,8 +397,8 @@
 [[projects]]
   name = "github.com/knz/go-libedit"
   packages = [".","common","other","unix"]
-  revision = "438167ad0c588fe6f2e87cb6ba8a4e9753e6d26e"
-  version = "v1.3"
+  revision = "7577af3c24e9e2f3298da1358c4fa5e2329fd304"
+  version = "v1.4"
 
 [[projects]]
   name = "github.com/knz/strtime"

--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -26,11 +26,20 @@ send "$argv sql\r"
 eexpect root@
 send "select 1;\r"
 eexpect "+-*+\r\n*\r\n+-*+\r\n*1 row"
-send "\\q\r"
-eexpect ":/# "
+eexpect root@
+end_test
+
+start_test "Check that the shell supports unicode input and that results display unicode characters."
+send "select '☃';\r"
+eexpect "U00002603"
+eexpect "☃"
+eexpect "+-*+\r\n*1 row"
+eexpect root@
 end_test
 
 start_test "Check that tables are not pretty-printed when input is a terminal and --format=tsv is specified."
+send "\\q\r"
+eexpect ":/# "
 send "$argv sql --format=tsv\r"
 eexpect root@
 send "select 42; select 1;\r"

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1004,7 +1004,14 @@ func runInteractive(conn *sqlConn) (exitErr error) {
 
 				// The readline initialization is not placed in
 				// the doStart() method because of the defer.
-				c.ins, c.exitErr = readline.InitFiles("cockroach", stdin, os.Stdout, stderr)
+				c.ins, c.exitErr = readline.InitFiles("cockroach",
+					true, /* wideChars */
+					stdin, os.Stdout, stderr)
+				if c.exitErr == readline.ErrWidecharNotSupported {
+					log.Warning(context.TODO(), "wide character support disabled")
+					c.ins, c.exitErr = readline.InitFiles("cockroach",
+						false, stdin, os.Stdout, stderr)
+				}
 				if c.exitErr != nil {
 					return c.exitErr
 				}


### PR DESCRIPTION
The update to use go-libedit didn't include support for unicode input.
This patch bumps the dependency to v1.4, enables unicode, then adds a
test to ensure we don't see regressions in the future.

Fixes #19114.