### PR TITLE
distsql: add a basic infrastructure benchmark

### DIFF
--- a/pkg/sql/distsqlrun/stream_data_test.go
+++ b/pkg/sql/distsqlrun/stream_data_test.go
@@ -29,12 +29,12 @@ import (
 // The encoder/decoder don't maintain the ordering between rows and metadata
 // records.
 func testGetDecodedRows(
-	t *testing.T, sd *StreamDecoder, decodedRows sqlbase.EncDatumRows, metas []ProducerMetadata,
+	tb testing.TB, sd *StreamDecoder, decodedRows sqlbase.EncDatumRows, metas []ProducerMetadata,
 ) (sqlbase.EncDatumRows, []ProducerMetadata) {
 	for {
 		row, meta, err := sd.GetRow(nil /* rowBuf */)
 		if err != nil {
-			t.Fatal(err)
+			tb.Fatal(err)
 		}
 		if row == nil && meta.Empty() {
 			break
@@ -48,7 +48,7 @@ func testGetDecodedRows(
 	return decodedRows, metas
 }
 
-func testRowStream(t *testing.T, rng *rand.Rand, records []rowOrMeta) {
+func testRowStream(tb testing.TB, rng *rand.Rand, records []rowOrMeta) {
 	var se StreamEncoder
 	var sd StreamDecoder
 
@@ -61,7 +61,7 @@ func testRowStream(t *testing.T, rng *rand.Rand, records []rowOrMeta) {
 		if rowIdx < len(records) {
 			if records[rowIdx].row != nil {
 				if err := se.AddRow(records[rowIdx].row); err != nil {
-					t.Fatal(err)
+					tb.Fatal(err)
 				}
 				numRows++
 			} else {
@@ -77,16 +77,16 @@ func testRowStream(t *testing.T, rng *rand.Rand, records []rowOrMeta) {
 			msg.Data.RawBytes = append([]byte(nil), msg.Data.RawBytes...)
 			err := sd.AddMessage(msg)
 			if err != nil {
-				t.Fatal(err)
+				tb.Fatal(err)
 			}
-			decodedRows, metas = testGetDecodedRows(t, &sd, decodedRows, metas)
+			decodedRows, metas = testGetDecodedRows(tb, &sd, decodedRows, metas)
 		}
 	}
 	if len(metas) != numMeta {
-		t.Errorf("expected %d metadata records, got: %d", numMeta, len(metas))
+		tb.Errorf("expected %d metadata records, got: %d", numMeta, len(metas))
 	}
 	if len(decodedRows) != numRows {
-		t.Errorf("expected %d rows, got: %d", numRows, len(decodedRows))
+		tb.Errorf("expected %d rows, got: %d", numRows, len(decodedRows))
 	}
 }
 

--- a/pkg/sql/distsqlrun/stream_encoder.go
+++ b/pkg/sql/distsqlrun/stream_encoder.go
@@ -31,13 +31,10 @@ import (
 //          err := se.AddRow(...)
 //          ...
 //       }
-//       msg := se.FormMessage(false, nil)
+//       msg := se.FormMessage(nil)
 //       // Send out message.
 //       ...
 //   }
-//   msg := se.FormMessage(true, nil)
-//   // Send out final message
-//   ...
 type StreamEncoder struct {
 	// infos is initialized when the first row is received.
 	infos []DatumInfo


### PR DESCRIPTION
A benchmark that focuses on basic aspects of distsql infrastructure. It will be
useful when making improvements to the representation and movement of rows.

Results from a run:
```
Infrastructure/n1/r1-4       193µs
Infrastructure/n1/r100-4     468µs
Infrastructure/n1/r10000-4  17.8ms
Infrastructure/n3/r1-4       605µs
Infrastructure/n3/r100-4    1.23ms
Infrastructure/n3/r10000-4  58.3ms
```