### PR TITLE
cherry-pick 1.1: sql: don't enable "kv tracing" for SHOW TRACE FOR <stmt>

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -31,7 +31,6 @@ SELECT span, message, operation FROM [SHOW TRACE FOR SELECT 1]
 (0,0)  === SPAN START: sql txn implicit ===  sql txn implicit
 (0,1)  === SPAN START: starting plan ===     starting plan
 (0,2)  === SPAN START: consuming rows ===    consuming rows
-(0,2)  output row: [1]                       consuming rows
 (0,2)  plan completed execution              consuming rows
 (0,2)  resources released, stopping trace    consuming rows
 
@@ -44,7 +43,6 @@ SELECT span, message, operation FROM [SHOW TRACE FOR EXECUTE x]
 (0,0)  === SPAN START: sql txn implicit ===  sql txn implicit
 (0,1)  === SPAN START: starting plan ===     starting plan
 (0,2)  === SPAN START: consuming rows ===    consuming rows
-(0,2)  output row: [1]                       consuming rows
 (0,2)  plan completed execution              consuming rows
 (0,2)  resources released, stopping trace    consuming rows
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1419,7 +1419,12 @@ type SessionTracing struct {
 // span that have already been created will not be traced).
 //
 // StopTracing() needs to be called to finish this trace.
-func (st *SessionTracing) StartTracing(recType tracing.RecordingType, traceKV bool) error {
+//
+// Args:
+// kvTracingEnabled: If set, the traces will also include "KV trace" messages -
+//   verbose messages around the interaction of SQL with KV. Some of the messages
+//   are per-row.
+func (st *SessionTracing) StartTracing(recType tracing.RecordingType, kvTracingEnabled bool) error {
 	if st.enabled {
 		return errors.Errorf("already tracing")
 	}
@@ -1433,7 +1438,7 @@ func (st *SessionTracing) StartTracing(recType tracing.RecordingType, traceKV bo
 
 	tracing.StartRecording(sp, recType)
 	st.enabled = true
-	st.kvTracingEnabled = traceKV
+	st.kvTracingEnabled = kvTracingEnabled
 	st.recordingType = recType
 	return nil
 }

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -329,7 +329,7 @@ WHERE message LIKE 'fetched: %'
 		plan.Close(ctx)
 		return nil, err
 	}
-	tracePlan, err := p.makeTraceNode(stmtPlan)
+	tracePlan, err := p.makeTraceNode(stmtPlan, n.OnlyKVTrace /* kvTracingEnabled */)
 	if err != nil {
 		plan.Close(ctx)
 		stmtPlan.Close(ctx)

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -134,7 +134,9 @@ func (n *traceNode) Next(params runParams) (bool, error) {
 					}
 
 					values := n.plan.Values()
-					log.VEventf(consumeCtx, 2, "output row: %s", values)
+					if n.kvTracingEnabled {
+						log.VEventf(consumeCtx, 2, "output row: %s", values)
+					}
 				}
 			}
 			log.VEventf(consumeCtx, 2, "plan completed execution")


### PR DESCRIPTION
Cherry-pick of selections from #19008. The whole thing did not apply cleanly/was unnecessary because some of the logging messages it dealt with are not present on this branch.

CC @cockroachdb/release 

A "kv trace" is the a set of log messages around SQL<->KV interaction.
The concept is not very well defined at the moment, but it comprises two
categories of messages:
1. Details of KV requests being sent for execution, in particular
pretty-printed scan requests.
2. Per-row messages. In particular, every row that's being returned by
KV for processing by SQL.

These messages are the only ones that are returned as results of
SHOW _KV_ TRACE FOR <stmt>/SESSION.
The situation gets interesting for SHOW TRACE FOR ... (no KV specified).
In this case, before this patch, all the "kv trace" messages were
included in the results. This patch changes that and eliminates the
per-row messages. This is an improvement, per-row messages (as opposed
to per-RPC or higher level) is too verbose for most people that want
traces.

This was already the case before this patch, but now this comes to the
foreground: "kv tracing" means one thing externally (as in SHOW KV TRACE
FOR ...), versus internally, in the code, where "kvTracedEnabled" and
similarly-named members refer to "per-row" messages. A round of renames
is in order, but that's left for another day.

This patch also introduces log.ExpensiveLogEnabled(), a replacement for
log.V() which also takes tracing into consideration.