### PR TITLE
acceptance: add consistency checks for photos.photos

### DIFF
--- a/pkg/acceptance/terraform/azure/.rebal-3to5s-nauseousmeitner.tfstate.lock.info
+++ b/pkg/acceptance/terraform/azure/.rebal-3to5s-nauseousmeitner.tfstate.lock.info
@@ -1,0 +1,1 @@
+{"ID":"2fc0f2e4-2338-cdb6-f62c-7775719fc42c","Operation":"OperationTypeApply","Info":"","Who":"vivek@viveks-MacBook-Pro.local","Version":"0.10.4","Created":"2017-10-10T14:59:18.36229037Z","Path":"rebal-3to5s-nauseousmeitner.tfstate"}


### PR DESCRIPTION
So we can ensure that tables not undergoing schema changes are
consistent.