### PR TITLE
sql: avoid a panic with multi-valued SRFs

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -684,6 +684,9 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
+<tr><td><code>crdb_internal.unary_table() &rarr; setof tuple{}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing a single row with no values.</p>
+<p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
 <tr><td><code>format_type(type_oid: oid, typemod: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the SQL name of a data type that is identified by its type OID and possibly a type modifier. Currently, the type modifier is ignored.</p>
 </span></td></tr>
 <tr><td><code>generate_series(start: <a href="int.html">int</a>, end: <a href="int.html">int</a>) &rarr; setof tuple{int}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the integer values from <code>start</code> to <code>end</code>, inclusive.</p>

--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -259,3 +259,16 @@ query IITTT colnames
 SELECT a.*, b.*, c.* FROM generate_series(1,1) a, unnest(ARRAY[1]) b, pg_get_keywords() c LIMIT 0
 ----
 a  b  word  catcode  catdesc
+
+# Beware of multi-valued SRFs in render position (#19149)
+query TTT colnames
+SELECT 'a', pg_get_keywords(), 'c' LIMIT 1
+----
+'a'  pg_get_keywords              'c'
+a    ('action','U','unreserved')  c
+
+query TTT colnames
+SELECT 'a', pg_get_keywords() b, 'c' LIMIT 1
+----
+'a'  b                            'c'
+a    ('action','U','unreserved')  c

--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -272,3 +272,9 @@ SELECT 'a', pg_get_keywords() b, 'c' LIMIT 1
 ----
 'a'  b                            'c'
 a    ('action','U','unreserved')  c
+
+query TTT colnames
+SELECT 'a', crdb_internal.unary_table() b, 'c' LIMIT 1
+----
+'a'  b   'c'
+a    ()  c

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -354,6 +354,34 @@ func (r *renderNode) initTargets(
 	return nil
 }
 
+// makeTupleRender creates a new renderNode which makes a single tuple
+// columns from all the columns in its source. Used by
+// getDataSourceAsOneColumn().
+func (p *planner) makeTupleRender(
+	ctx context.Context, src planDataSource, name string,
+) (*renderNode, error) {
+	// Make a simple renderNode that renders all the columns in its
+	// source.
+	r := &renderNode{
+		planner:    p,
+		source:     src,
+		sourceInfo: multiSourceInfo{src.info},
+	}
+	r.ivarHelper = parser.MakeIndexedVarHelper(r, len(src.info.sourceColumns))
+
+	tExpr := &parser.Tuple{
+		Exprs: make(parser.Exprs, len(src.info.sourceColumns)),
+	}
+	for i := range src.info.sourceColumns {
+		tExpr.Exprs[i] = r.ivarHelper.IndexedVar(i)
+	}
+	if err := r.initTargets(ctx,
+		parser.SelectExprs{parser.SelectExpr{Expr: tExpr}}, nil); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
 // srfExtractionVisitor replaces the innermost set-returning function in an
 // expression with an IndexedVar that points at a new index at the end of the
 // ivarHelper. The extracted SRF is retained in the srf field.
@@ -427,7 +455,7 @@ func (r *renderNode) rewriteSRFs(
 
 	// We rewrote exactly one SRF; cross-join it with our sources and return the
 	// new render expression.
-	src, err := r.planner.getDataSource(ctx, v.srf, nil, publicColumns)
+	src, err := r.planner.getDataSourceAsOneColumn(ctx, v.srf)
 	if err != nil {
 		return target, err
 	}


### PR DESCRIPTION
This ensures that a multi-valued SRF in render position, e.g.
`SELECT pg_get_keywords()`, is rendered as a tuple, as in Postgres,
instead of crashing the server.

Fixes #19149.