### PR TITLE
docs: pre-generate func & op tables in HTML

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -287,6 +287,12 @@
   revision = "100ba4e885062801d56799d78530b73b178a78f3"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/golang-commonmark/markdown"
+  packages = [".","byteutil","html","linkify"]
+  revision = "11a7a839e723aa293cccdc353b394dbfce7c131e"
+
+[[projects]]
   name = "github.com/golang/dep"
   packages = [".","cmd/dep","internal/feedback","internal/fs","internal/gps","internal/gps/paths","internal/gps/pkgtree","internal/importers","internal/importers/base","internal/importers/glide","internal/importers/godep","internal/importers/govend","internal/importers/vndr"]
   revision = "83789e236d7ff64c82ee8392005455fc1ec1983b"
@@ -497,6 +503,12 @@
   version = "v1.0.0-rc0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/opennota/urlesc"
+  packages = ["."]
+  revision = "de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[projects]]
   name = "github.com/opentracing/opentracing-go"
   packages = [".","ext","log"]
   revision = "eaaf4e1eeb7a5373b38e70901270c83577dc6fb9"
@@ -694,6 +706,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "44d910075a6ddad082ceae7c050336ca8fbe6b4fabdd108edee8a9f192b08fde"
+  inputs-digest = "e29086ff86e8e28654fe1b81c4bb73495fee6bcdb64857c7d0970326221e09a8"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -1,59 +1,117 @@
-Function &rarr; Returns | Description
---- | ---
-<code>array_agg(arg1: anyelement) &rarr; anyelement</code> | <span class="funcdesc">Aggregates the selected values into an array.</span>
-<code>avg(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the average of the selected values.</span>
-<code>avg(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the average of the selected values.</span>
-<code>avg(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the average of the selected values.</span>
-<code>bool_and(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Calculates the boolean value of `AND`ing all selected values.</span>
-<code>bool_or(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Calculates the boolean value of `OR`ing all selected values.</span>
-<code>concat_agg(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Concatenates all selected values.</span>
-<code>concat_agg(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Concatenates all selected values.</span>
-<code>count(arg1: anyelement) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of selected elements.</span>
-<code>count_rows() &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of rows.</span>
-<code>final_stddev(arg1: <a href="decimal.html">decimal</a>, arg2: <a href="decimal.html">decimal</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the standard deviation from the selected locally-computed squared difference values.</span>
-<code>final_stddev(arg1: <a href="float.html">float</a>, arg2: <a href="float.html">float</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the standard deviation from the selected locally-computed squared difference values.</span>
-<code>final_variance(arg1: <a href="decimal.html">decimal</a>, arg2: <a href="decimal.html">decimal</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the variance from the selected locally-computed squared difference values.</span>
-<code>final_variance(arg1: <a href="float.html">float</a>, arg2: <a href="float.html">float</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the variance from the selected locally-computed squared difference values.</span>
-<code>max(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: inet) &rarr; inet</code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: oid) &rarr; oid</code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>max(arg1: uuid) &rarr; uuid</code> | <span class="funcdesc">Identifies the maximum selected value.</span>
-<code>min(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: inet) &rarr; inet</code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: oid) &rarr; oid</code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>min(arg1: uuid) &rarr; uuid</code> | <span class="funcdesc">Identifies the minimum selected value.</span>
-<code>sqrdiff(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the sum of squared differences from the mean of the selected values.</span>
-<code>sqrdiff(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the sum of squared differences from the mean of the selected values.</span>
-<code>sqrdiff(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the sum of squared differences from the mean of the selected values.</span>
-<code>stddev(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the standard deviation of the selected values.</span>
-<code>stddev(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the standard deviation of the selected values.</span>
-<code>stddev(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the standard deviation of the selected values.</span>
-<code>sum(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
-<code>sum(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
-<code>sum(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
-<code>sum(arg1: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
-<code>sum_int(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the sum of the selected values.</span>
-<code>variance(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the variance of the selected values.</span>
-<code>variance(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the variance of the selected values.</span>
-<code>variance(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the variance of the selected values.</span>
-<code>xor_agg(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Calculates the bitwise XOR of the selected values.</span>
-<code>xor_agg(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the bitwise XOR of the selected values.</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>array_agg(arg1: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>avg(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the average of the selected values.</p>
+</span></td></tr>
+<tr><td><code>avg(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the average of the selected values.</p>
+</span></td></tr>
+<tr><td><code>avg(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the average of the selected values.</p>
+</span></td></tr>
+<tr><td><code>bool_and(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Calculates the boolean value of <code>AND</code>ing all selected values.</p>
+</span></td></tr>
+<tr><td><code>bool_or(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Calculates the boolean value of <code>OR</code>ing all selected values.</p>
+</span></td></tr>
+<tr><td><code>concat_agg(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values.</p>
+</span></td></tr>
+<tr><td><code>concat_agg(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates all selected values.</p>
+</span></td></tr>
+<tr><td><code>count(arg1: anyelement) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of selected elements.</p>
+</span></td></tr>
+<tr><td><code>count_rows() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of rows.</p>
+</span></td></tr>
+<tr><td><code>final_stddev(arg1: <a href="decimal.html">decimal</a>, arg2: <a href="decimal.html">decimal</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation from the selected locally-computed squared difference values.</p>
+</span></td></tr>
+<tr><td><code>final_stddev(arg1: <a href="float.html">float</a>, arg2: <a href="float.html">float</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation from the selected locally-computed squared difference values.</p>
+</span></td></tr>
+<tr><td><code>final_variance(arg1: <a href="decimal.html">decimal</a>, arg2: <a href="decimal.html">decimal</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the variance from the selected locally-computed squared difference values.</p>
+</span></td></tr>
+<tr><td><code>final_variance(arg1: <a href="float.html">float</a>, arg2: <a href="float.html">float</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the variance from the selected locally-computed squared difference values.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>max(arg1: oid) &rarr; oid</code></td><td><span class="funcdesc"><p>Identifies the maximum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>min(arg1: oid) &rarr; oid</code></td><td><span class="funcdesc"><p>Identifies the minimum selected value.</p>
+</span></td></tr>
+<tr><td><code>sqrdiff(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the sum of squared differences from the mean of the selected values.</p>
+</span></td></tr>
+<tr><td><code>sqrdiff(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the sum of squared differences from the mean of the selected values.</p>
+</span></td></tr>
+<tr><td><code>sqrdiff(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the sum of squared differences from the mean of the selected values.</p>
+</span></td></tr>
+<tr><td><code>stddev(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation of the selected values.</p>
+</span></td></tr>
+<tr><td><code>stddev(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation of the selected values.</p>
+</span></td></tr>
+<tr><td><code>stddev(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation of the selected values.</p>
+</span></td></tr>
+<tr><td><code>sum(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the sum of the selected values.</p>
+</span></td></tr>
+<tr><td><code>sum(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the sum of the selected values.</p>
+</span></td></tr>
+<tr><td><code>sum(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the sum of the selected values.</p>
+</span></td></tr>
+<tr><td><code>sum(arg1: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a></code></td><td><span class="funcdesc"><p>Calculates the sum of the selected values.</p>
+</span></td></tr>
+<tr><td><code>sum_int(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the sum of the selected values.</p>
+</span></td></tr>
+<tr><td><code>variance(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the variance of the selected values.</p>
+</span></td></tr>
+<tr><td><code>variance(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the variance of the selected values.</p>
+</span></td></tr>
+<tr><td><code>variance(arg1: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the variance of the selected values.</p>
+</span></td></tr>
+<tr><td><code>xor_agg(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Calculates the bitwise XOR of the selected values.</p>
+</span></td></tr>
+<tr><td><code>xor_agg(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the bitwise XOR of the selected values.</p>
+</span></td></tr></tbody>
+</table>
 

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1,382 +1,700 @@
 ### Array Functions
 
-Function &rarr; Returns | Description
---- | ---
-<code>array_append(array: <a href="bool.html">bool</a>[], elem: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: <a href="bytes.html">bytes</a>[], elem: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: <a href="date.html">date</a>[], elem: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: <a href="decimal.html">decimal</a>[], elem: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: <a href="float.html">float</a>[], elem: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: <a href="int.html">int</a>[], elem: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: <a href="interval.html">interval</a>[], elem: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: <a href="string.html">string</a>[], elem: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: <a href="timestamp.html">timestamp</a>[], elem: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: <a href="timestamp.html">timestamptz</a>[], elem: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: inet[], elem: inet) &rarr; inet[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: oid[], elem: oid) &rarr; oid[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_append(array: uuid[], elem: uuid) &rarr; uuid[]</code> | <span class="funcdesc">Appends `elem` to `array`, returning the result.</span>
-<code>array_cat(left: <a href="bool.html">bool</a>[], right: <a href="bool.html">bool</a>[]) &rarr; <a href="bool.html">bool</a>[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: <a href="bytes.html">bytes</a>[], right: <a href="bytes.html">bytes</a>[]) &rarr; <a href="bytes.html">bytes</a>[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: <a href="date.html">date</a>[], right: <a href="date.html">date</a>[]) &rarr; <a href="date.html">date</a>[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: <a href="decimal.html">decimal</a>[], right: <a href="decimal.html">decimal</a>[]) &rarr; <a href="decimal.html">decimal</a>[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: <a href="float.html">float</a>[], right: <a href="float.html">float</a>[]) &rarr; <a href="float.html">float</a>[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: <a href="int.html">int</a>[], right: <a href="int.html">int</a>[]) &rarr; <a href="int.html">int</a>[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: <a href="interval.html">interval</a>[], right: <a href="interval.html">interval</a>[]) &rarr; <a href="interval.html">interval</a>[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: <a href="string.html">string</a>[], right: <a href="string.html">string</a>[]) &rarr; <a href="string.html">string</a>[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: <a href="timestamp.html">timestamp</a>[], right: <a href="timestamp.html">timestamp</a>[]) &rarr; <a href="timestamp.html">timestamp</a>[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: <a href="timestamp.html">timestamptz</a>[], right: <a href="timestamp.html">timestamptz</a>[]) &rarr; <a href="timestamp.html">timestamptz</a>[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: inet[], right: inet[]) &rarr; inet[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: oid[], right: oid[]) &rarr; oid[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_cat(left: uuid[], right: uuid[]) &rarr; uuid[]</code> | <span class="funcdesc">Appends two arrays.</span>
-<code>array_length(input: anyelement[], array_dimension: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the length of `input` on the provided `array_dimension`. However, because CockroachDB doesn't yet support multi-dimensional arrays, the only supported `array_dimension` is **1**.</span>
-<code>array_lower(input: anyelement[], array_dimension: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the minimum value of `input` on the provided `array_dimension`. However, because CockroachDB doesn't yet support multi-dimensional arrays, the only supported `array_dimension` is **1**.</span>
-<code>array_position(array: <a href="bool.html">bool</a>[], elem: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: <a href="bytes.html">bytes</a>[], elem: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: <a href="date.html">date</a>[], elem: <a href="date.html">date</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: <a href="decimal.html">decimal</a>[], elem: <a href="decimal.html">decimal</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: <a href="float.html">float</a>[], elem: <a href="float.html">float</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: <a href="int.html">int</a>[], elem: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: <a href="interval.html">interval</a>[], elem: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: <a href="string.html">string</a>[], elem: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: <a href="timestamp.html">timestamp</a>[], elem: <a href="timestamp.html">timestamp</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: <a href="timestamp.html">timestamptz</a>[], elem: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: inet[], elem: inet) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: oid[], elem: oid) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_position(array: uuid[], elem: uuid) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Return the index of the first occurrence of `elem` in `array`.</span>
-<code>array_positions(array: <a href="bool.html">bool</a>[], elem: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: <a href="bytes.html">bytes</a>[], elem: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: <a href="date.html">date</a>[], elem: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: <a href="decimal.html">decimal</a>[], elem: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: <a href="float.html">float</a>[], elem: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: <a href="int.html">int</a>[], elem: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: <a href="interval.html">interval</a>[], elem: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: <a href="string.html">string</a>[], elem: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: <a href="timestamp.html">timestamp</a>[], elem: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: <a href="timestamp.html">timestamptz</a>[], elem: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: inet[], elem: inet) &rarr; inet[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: oid[], elem: oid) &rarr; oid[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_positions(array: uuid[], elem: uuid) &rarr; uuid[]</code> | <span class="funcdesc">Returns and array of indexes of all occurrences of `elem` in `array`.</span>
-<code>array_prepend(elem: <a href="bool.html">bool</a>, array: <a href="bool.html">bool</a>[]) &rarr; <a href="bool.html">bool</a>[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: <a href="bytes.html">bytes</a>, array: <a href="bytes.html">bytes</a>[]) &rarr; <a href="bytes.html">bytes</a>[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: <a href="date.html">date</a>, array: <a href="date.html">date</a>[]) &rarr; <a href="date.html">date</a>[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: <a href="decimal.html">decimal</a>, array: <a href="decimal.html">decimal</a>[]) &rarr; <a href="decimal.html">decimal</a>[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: <a href="float.html">float</a>, array: <a href="float.html">float</a>[]) &rarr; <a href="float.html">float</a>[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: <a href="int.html">int</a>, array: <a href="int.html">int</a>[]) &rarr; <a href="int.html">int</a>[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: <a href="interval.html">interval</a>, array: <a href="interval.html">interval</a>[]) &rarr; <a href="interval.html">interval</a>[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: <a href="string.html">string</a>, array: <a href="string.html">string</a>[]) &rarr; <a href="string.html">string</a>[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: <a href="timestamp.html">timestamp</a>, array: <a href="timestamp.html">timestamp</a>[]) &rarr; <a href="timestamp.html">timestamp</a>[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: <a href="timestamp.html">timestamptz</a>, array: <a href="timestamp.html">timestamptz</a>[]) &rarr; <a href="timestamp.html">timestamptz</a>[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: inet, array: inet[]) &rarr; inet[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: oid, array: oid[]) &rarr; oid[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_prepend(elem: uuid, array: uuid[]) &rarr; uuid[]</code> | <span class="funcdesc">Prepends `elem` to `array`, returning the result.</span>
-<code>array_remove(array: <a href="bool.html">bool</a>[], elem: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: <a href="bytes.html">bytes</a>[], elem: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: <a href="date.html">date</a>[], elem: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: <a href="decimal.html">decimal</a>[], elem: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: <a href="float.html">float</a>[], elem: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: <a href="int.html">int</a>[], elem: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: <a href="interval.html">interval</a>[], elem: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: <a href="string.html">string</a>[], elem: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: <a href="timestamp.html">timestamp</a>[], elem: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: <a href="timestamp.html">timestamptz</a>[], elem: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: inet[], elem: inet) &rarr; inet[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: oid[], elem: oid) &rarr; oid[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_remove(array: uuid[], elem: uuid) &rarr; uuid[]</code> | <span class="funcdesc">Remove from `array` all elements equal to `elem`.</span>
-<code>array_replace(array: <a href="bool.html">bool</a>[], toreplace: <a href="bool.html">bool</a>, replacewith: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: <a href="bytes.html">bytes</a>[], toreplace: <a href="bytes.html">bytes</a>, replacewith: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: <a href="date.html">date</a>[], toreplace: <a href="date.html">date</a>, replacewith: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: <a href="decimal.html">decimal</a>[], toreplace: <a href="decimal.html">decimal</a>, replacewith: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: <a href="float.html">float</a>[], toreplace: <a href="float.html">float</a>, replacewith: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: <a href="int.html">int</a>[], toreplace: <a href="int.html">int</a>, replacewith: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: <a href="interval.html">interval</a>[], toreplace: <a href="interval.html">interval</a>, replacewith: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: <a href="string.html">string</a>[], toreplace: <a href="string.html">string</a>, replacewith: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: <a href="timestamp.html">timestamp</a>[], toreplace: <a href="timestamp.html">timestamp</a>, replacewith: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: <a href="timestamp.html">timestamptz</a>[], toreplace: <a href="timestamp.html">timestamptz</a>, replacewith: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: inet[], toreplace: inet, replacewith: inet) &rarr; inet[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: oid[], toreplace: oid, replacewith: oid) &rarr; oid[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_replace(array: uuid[], toreplace: uuid, replacewith: uuid) &rarr; uuid[]</code> | <span class="funcdesc">Replace all occurrences of `toreplace` in `array` with `replacewith`.</span>
-<code>array_upper(input: anyelement[], array_dimension: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the maximum value of `input` on the provided `array_dimension`. However, because CockroachDB doesn't yet support multi-dimensional arrays, the only supported `array_dimension` is **1**.</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>array_append(array: <a href="bool.html">bool</a>[], elem: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="bytes.html">bytes</a>[], elem: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="date.html">date</a>[], elem: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="decimal.html">decimal</a>[], elem: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="float.html">float</a>[], elem: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="inet.html">inet</a>[], elem: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="int.html">int</a>[], elem: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="interval.html">interval</a>[], elem: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="string.html">string</a>[], elem: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="timestamp.html">timestamp</a>[], elem: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="timestamp.html">timestamptz</a>[], elem: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: <a href="uuid.html">uuid</a>[], elem: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a>[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_append(array: oid[], elem: oid) &rarr; oid[]</code></td><td><span class="funcdesc"><p>Appends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="bool.html">bool</a>[], right: <a href="bool.html">bool</a>[]) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="bytes.html">bytes</a>[], right: <a href="bytes.html">bytes</a>[]) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="date.html">date</a>[], right: <a href="date.html">date</a>[]) &rarr; <a href="date.html">date</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="decimal.html">decimal</a>[], right: <a href="decimal.html">decimal</a>[]) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="float.html">float</a>[], right: <a href="float.html">float</a>[]) &rarr; <a href="float.html">float</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="inet.html">inet</a>[], right: <a href="inet.html">inet</a>[]) &rarr; <a href="inet.html">inet</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="int.html">int</a>[], right: <a href="int.html">int</a>[]) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="interval.html">interval</a>[], right: <a href="interval.html">interval</a>[]) &rarr; <a href="interval.html">interval</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="string.html">string</a>[], right: <a href="string.html">string</a>[]) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="timestamp.html">timestamp</a>[], right: <a href="timestamp.html">timestamp</a>[]) &rarr; <a href="timestamp.html">timestamp</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="timestamp.html">timestamptz</a>[], right: <a href="timestamp.html">timestamptz</a>[]) &rarr; <a href="timestamp.html">timestamptz</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: <a href="uuid.html">uuid</a>[], right: <a href="uuid.html">uuid</a>[]) &rarr; <a href="uuid.html">uuid</a>[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_cat(left: oid[], right: oid[]) &rarr; oid[]</code></td><td><span class="funcdesc"><p>Appends two arrays.</p>
+</span></td></tr>
+<tr><td><code>array_length(input: anyelement[], array_dimension: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the length of <code>input</code> on the provided <code>array_dimension</code>. However, because CockroachDB doesn’t yet support multi-dimensional arrays, the only supported <code>array_dimension</code> is <strong>1</strong>.</p>
+</span></td></tr>
+<tr><td><code>array_lower(input: anyelement[], array_dimension: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the minimum value of <code>input</code> on the provided <code>array_dimension</code>. However, because CockroachDB doesn’t yet support multi-dimensional arrays, the only supported <code>array_dimension</code> is <strong>1</strong>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="bool.html">bool</a>[], elem: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="bytes.html">bytes</a>[], elem: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="date.html">date</a>[], elem: <a href="date.html">date</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="decimal.html">decimal</a>[], elem: <a href="decimal.html">decimal</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="float.html">float</a>[], elem: <a href="float.html">float</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="inet.html">inet</a>[], elem: <a href="inet.html">inet</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="int.html">int</a>[], elem: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="interval.html">interval</a>[], elem: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="string.html">string</a>[], elem: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="timestamp.html">timestamp</a>[], elem: <a href="timestamp.html">timestamp</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="timestamp.html">timestamptz</a>[], elem: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: <a href="uuid.html">uuid</a>[], elem: <a href="uuid.html">uuid</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_position(array: oid[], elem: oid) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="bool.html">bool</a>[], elem: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="bytes.html">bytes</a>[], elem: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="date.html">date</a>[], elem: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="decimal.html">decimal</a>[], elem: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="float.html">float</a>[], elem: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="inet.html">inet</a>[], elem: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="int.html">int</a>[], elem: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="interval.html">interval</a>[], elem: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="string.html">string</a>[], elem: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="timestamp.html">timestamp</a>[], elem: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="timestamp.html">timestamptz</a>[], elem: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: <a href="uuid.html">uuid</a>[], elem: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_positions(array: oid[], elem: oid) &rarr; oid[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="bool.html">bool</a>, array: <a href="bool.html">bool</a>[]) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="bytes.html">bytes</a>, array: <a href="bytes.html">bytes</a>[]) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="date.html">date</a>, array: <a href="date.html">date</a>[]) &rarr; <a href="date.html">date</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="decimal.html">decimal</a>, array: <a href="decimal.html">decimal</a>[]) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="float.html">float</a>, array: <a href="float.html">float</a>[]) &rarr; <a href="float.html">float</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="inet.html">inet</a>, array: <a href="inet.html">inet</a>[]) &rarr; <a href="inet.html">inet</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="int.html">int</a>, array: <a href="int.html">int</a>[]) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="interval.html">interval</a>, array: <a href="interval.html">interval</a>[]) &rarr; <a href="interval.html">interval</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="string.html">string</a>, array: <a href="string.html">string</a>[]) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="timestamp.html">timestamp</a>, array: <a href="timestamp.html">timestamp</a>[]) &rarr; <a href="timestamp.html">timestamp</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="timestamp.html">timestamptz</a>, array: <a href="timestamp.html">timestamptz</a>[]) &rarr; <a href="timestamp.html">timestamptz</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: <a href="uuid.html">uuid</a>, array: <a href="uuid.html">uuid</a>[]) &rarr; <a href="uuid.html">uuid</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_prepend(elem: oid, array: oid[]) &rarr; oid[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="bool.html">bool</a>[], elem: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="bytes.html">bytes</a>[], elem: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="date.html">date</a>[], elem: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="decimal.html">decimal</a>[], elem: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="float.html">float</a>[], elem: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="inet.html">inet</a>[], elem: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="int.html">int</a>[], elem: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="interval.html">interval</a>[], elem: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="string.html">string</a>[], elem: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="timestamp.html">timestamp</a>[], elem: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="timestamp.html">timestamptz</a>[], elem: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: <a href="uuid.html">uuid</a>[], elem: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a>[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_remove(array: oid[], elem: oid) &rarr; oid[]</code></td><td><span class="funcdesc"><p>Remove from <code>array</code> all elements equal to <code>elem</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="bool.html">bool</a>[], toreplace: <a href="bool.html">bool</a>, replacewith: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="bytes.html">bytes</a>[], toreplace: <a href="bytes.html">bytes</a>, replacewith: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="date.html">date</a>[], toreplace: <a href="date.html">date</a>, replacewith: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="decimal.html">decimal</a>[], toreplace: <a href="decimal.html">decimal</a>, replacewith: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="float.html">float</a>[], toreplace: <a href="float.html">float</a>, replacewith: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="inet.html">inet</a>[], toreplace: <a href="inet.html">inet</a>, replacewith: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="int.html">int</a>[], toreplace: <a href="int.html">int</a>, replacewith: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="interval.html">interval</a>[], toreplace: <a href="interval.html">interval</a>, replacewith: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="string.html">string</a>[], toreplace: <a href="string.html">string</a>, replacewith: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="timestamp.html">timestamp</a>[], toreplace: <a href="timestamp.html">timestamp</a>, replacewith: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="timestamp.html">timestamptz</a>[], toreplace: <a href="timestamp.html">timestamptz</a>, replacewith: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: <a href="uuid.html">uuid</a>[], toreplace: <a href="uuid.html">uuid</a>, replacewith: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a>[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_replace(array: oid[], toreplace: oid, replacewith: oid) &rarr; oid[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
+</span></td></tr>
+<tr><td><code>array_upper(input: anyelement[], array_dimension: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the maximum value of <code>input</code> on the provided <code>array_dimension</code>. However, because CockroachDB doesn’t yet support multi-dimensional arrays, the only supported <code>array_dimension</code> is <strong>1</strong>.</p>
+</span></td></tr></tbody>
+</table>
 
 ### BOOL Functions
 
-Function &rarr; Returns | Description
---- | ---
-<code>inet_same_family(val: inet, val: inet) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Checks if two IP addresses are of the same IP family.</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>inet_same_family(val: <a href="inet.html">inet</a>, val: <a href="inet.html">inet</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Checks if two IP addresses are of the same IP family.</p>
+</span></td></tr></tbody>
+</table>
 
 ### Comparison Functions
 
-Function &rarr; Returns | Description
---- | ---
-<code>greatest(anyelement...) &rarr; anyelement</code> | <span class="funcdesc">Returns the element with the greatest value.</span>
-<code>least(anyelement...) &rarr; anyelement</code> | <span class="funcdesc">Returns the element with the lowest value.</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>greatest(anyelement...) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the element with the greatest value.</p>
+</span></td></tr>
+<tr><td><code>least(anyelement...) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the element with the lowest value.</p>
+</span></td></tr></tbody>
+</table>
 
 ### Date and Time Functions
 
-Function &rarr; Returns | Description
---- | ---
-<code>age(begin: <a href="timestamp.html">timestamptz</a>, end: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="interval.html">interval</a></code> | <span class="funcdesc">Calculates the interval between `begin` and `end`.</span>
-<code>age(val: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="interval.html">interval</a></code> | <span class="funcdesc">Calculates the interval between `val` and the current time.</span>
-<code>clock_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Returns the current wallclock time.</span>
-<code>clock_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Returns the current wallclock time.</span>
-<code>current_date() &rarr; <a href="date.html">date</a></code> | <span class="funcdesc">Returns the current date.</span>
-<code>current_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Returns the current transaction's timestamp.</span>
-<code>current_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Returns the current transaction's timestamp.</span>
-<code>experimental_strftime(input: <a href="date.html">date</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">From `input`, extracts and formats the time as identified in `extract_format` using standard `strftime` notation (though not all formatting is supported).</span>
-<code>experimental_strftime(input: <a href="timestamp.html">timestamp</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">From `input`, extracts and formats the time as identified in `extract_format` using standard `strftime` notation (though not all formatting is supported).</span>
-<code>experimental_strftime(input: <a href="timestamp.html">timestamptz</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">From `input`, extracts and formats the time as identified in `extract_format` using standard `strftime` notation (though not all formatting is supported).</span>
-<code>experimental_strptime(input: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Returns `input` as a timestamptz using `format` (which uses standard `strptime` formatting).</span>
-<code>extract(element: <a href="string.html">string</a>, input: <a href="date.html">date</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Extracts `element` from `input`.
-
-Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
-hour, minute, second, millisecond, microsecond, epoch</span>
-<code>extract(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamp</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Extracts `element` from `input`.
-
-Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
-hour, minute, second, millisecond, microsecond, epoch</span>
-<code>extract(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Extracts `element` from `input`.
-
-Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
-hour, minute, second, millisecond, microsecond, epoch</span>
-<code>extract_duration(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Extracts `element` from `input`.
-Compatible elements: hour, minute, second, millisecond, microsecond.</span>
-<code>now() &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Returns the current transaction's timestamp.</span>
-<code>now() &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Returns the current transaction's timestamp.</span>
-<code>statement_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Returns the current statement's timestamp.</span>
-<code>statement_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Returns the current statement's timestamp.</span>
-<code>transaction_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code> | <span class="funcdesc">Returns the current transaction's timestamp.</span>
-<code>transaction_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code> | <span class="funcdesc">Returns the current transaction's timestamp.</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>age(begin: <a href="timestamp.html">timestamptz</a>, end: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="interval.html">interval</a></code></td><td><span class="funcdesc"><p>Calculates the interval between <code>begin</code> and <code>end</code>.</p>
+</span></td></tr>
+<tr><td><code>age(val: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="interval.html">interval</a></code></td><td><span class="funcdesc"><p>Calculates the interval between <code>val</code> and the current time.</p>
+</span></td></tr>
+<tr><td><code>clock_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Returns the current wallclock time.</p>
+</span></td></tr>
+<tr><td><code>clock_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns the current wallclock time.</p>
+</span></td></tr>
+<tr><td><code>current_date() &rarr; <a href="date.html">date</a></code></td><td><span class="funcdesc"><p>Returns the current date.</p>
+</span></td></tr>
+<tr><td><code>current_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Returns the current transaction’s timestamp.</p>
+</span></td></tr>
+<tr><td><code>current_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns the current transaction’s timestamp.</p>
+</span></td></tr>
+<tr><td><code>experimental_strftime(input: <a href="date.html">date</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>From <code>input</code>, extracts and formats the time as identified in <code>extract_format</code> using standard <code>strftime</code> notation (though not all formatting is supported).</p>
+</span></td></tr>
+<tr><td><code>experimental_strftime(input: <a href="timestamp.html">timestamp</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>From <code>input</code>, extracts and formats the time as identified in <code>extract_format</code> using standard <code>strftime</code> notation (though not all formatting is supported).</p>
+</span></td></tr>
+<tr><td><code>experimental_strftime(input: <a href="timestamp.html">timestamptz</a>, extract_format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>From <code>input</code>, extracts and formats the time as identified in <code>extract_format</code> using standard <code>strftime</code> notation (though not all formatting is supported).</p>
+</span></td></tr>
+<tr><td><code>experimental_strptime(input: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns <code>input</code> as a timestamptz using <code>format</code> (which uses standard <code>strptime</code> formatting).</p>
+</span></td></tr>
+<tr><td><code>extract(element: <a href="string.html">string</a>, input: <a href="date.html">date</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
+<p>Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
+hour, minute, second, millisecond, microsecond, epoch</p>
+</span></td></tr>
+<tr><td><code>extract(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamp</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
+<p>Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
+hour, minute, second, millisecond, microsecond, epoch</p>
+</span></td></tr>
+<tr><td><code>extract(element: <a href="string.html">string</a>, input: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.</p>
+<p>Compatible elements: year, quarter, month, week, dayofweek, dayofyear,
+hour, minute, second, millisecond, microsecond, epoch</p>
+</span></td></tr>
+<tr><td><code>extract_duration(element: <a href="string.html">string</a>, input: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts <code>element</code> from <code>input</code>.
+Compatible elements: hour, minute, second, millisecond, microsecond.</p>
+</span></td></tr>
+<tr><td><code>now() &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Returns the current transaction’s timestamp.</p>
+</span></td></tr>
+<tr><td><code>now() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns the current transaction’s timestamp.</p>
+</span></td></tr>
+<tr><td><code>statement_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Returns the current statement’s timestamp.</p>
+</span></td></tr>
+<tr><td><code>statement_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns the current statement’s timestamp.</p>
+</span></td></tr>
+<tr><td><code>transaction_timestamp() &rarr; <a href="timestamp.html">timestamp</a></code></td><td><span class="funcdesc"><p>Returns the current transaction’s timestamp.</p>
+</span></td></tr>
+<tr><td><code>transaction_timestamp() &rarr; <a href="timestamp.html">timestamptz</a></code></td><td><span class="funcdesc"><p>Returns the current transaction’s timestamp.</p>
+</span></td></tr></tbody>
+</table>
 
 ### ID Generation Functions
 
-Function &rarr; Returns | Description
---- | ---
-<code>experimental_uuid_v4() &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Returns a UUID.</span>
-<code>unique_rowid() &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Returns a unique ID used by CockroachDB to generate unique row IDs if a Primary Key isn't defined for the table. The value is a combination of the  insert timestamp and the ID of the node executing the statement, which  guarantees this combination is globally unique.</span>
-<code>uuid_v4() &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Returns a UUID.</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>experimental_uuid_v4() &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns a UUID.</p>
+</span></td></tr>
+<tr><td><code>unique_rowid() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a unique ID used by CockroachDB to generate unique row IDs if a Primary Key isn’t defined for the table. The value is a combination of the  insert timestamp and the ID of the node executing the statement, which  guarantees this combination is globally unique.</p>
+</span></td></tr>
+<tr><td><code>uuid_v4() &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns a UUID.</p>
+</span></td></tr></tbody>
+</table>
 
 ### INET Functions
 
-Function &rarr; Returns | Description
---- | ---
-<code>abbrev(val: inet) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Converts the combined IP address and prefix length to an abbreviated display format as text.For INET types, this will omit the prefix length if it's not the default (32 or IPv4, 128 for IPv6)
-
-For example, `abbrev('192.168.1.2/24')` returns `'192.168.1.2/24'`</span>
-<code>broadcast(val: inet) &rarr; inet</code> | <span class="funcdesc">Gets the broadcast address for the network address represented by the value.
-
-For example, `broadcast('192.168.1.2/24')` returns `'192.168.1.255/24'`</span>
-<code>family(val: inet) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Extracts the IP family of the value; 4 for IPv4, 6 for IPv6.
-
-For example, `family('::1')` returns `6`</span>
-<code>host(val: inet) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Extracts the address part of the combined address/prefixlen value as text.
-
-For example, `host('192.168.1.2/16')` returns `'192.168.1.2'`</span>
-<code>hostmask(val: inet) &rarr; inet</code> | <span class="funcdesc">Creates an IP host mask corresponding to the prefix length in the value.
-
-For example, `hostmask('192.168.1.2/16')` returns `'0.0.255.255'`</span>
-<code>masklen(val: inet) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Retrieves the prefix length stored in the value.
-
-For example, `masklen('192.168.1.2/16')` returns `16`</span>
-<code>netmask(val: inet) &rarr; inet</code> | <span class="funcdesc">Creates an IP network mask corresponding to the prefix length in the value.
-
-For example, `netmask('192.168.1.2/16')` returns `'255.255.0.0'`</span>
-<code>set_masklen(val: inet, prefixlen: <a href="int.html">int</a>) &rarr; inet</code> | <span class="funcdesc">Sets the prefix length of `val` to `prefixlen`.
-
-For example, `set_masklen('192.168.1.2', 16)` returns `'192.168.1.2/16'`.</span>
-<code>text(val: inet) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Converts the IP address and prefix length to text.</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>abbrev(val: <a href="inet.html">inet</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts the combined IP address and prefix length to an abbreviated display format as text.For INET types, this will omit the prefix length if it’s not the default (32 or IPv4, 128 for IPv6)</p>
+<p>For example, <code>abbrev('192.168.1.2/24')</code> returns <code>'192.168.1.2/24'</code></p>
+</span></td></tr>
+<tr><td><code>broadcast(val: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a></code></td><td><span class="funcdesc"><p>Gets the broadcast address for the network address represented by the value.</p>
+<p>For example, <code>broadcast('192.168.1.2/24')</code> returns <code>'192.168.1.255/24'</code></p>
+</span></td></tr>
+<tr><td><code>family(val: <a href="inet.html">inet</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Extracts the IP family of the value; 4 for IPv4, 6 for IPv6.</p>
+<p>For example, <code>family('::1')</code> returns <code>6</code></p>
+</span></td></tr>
+<tr><td><code>host(val: <a href="inet.html">inet</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Extracts the address part of the combined address/prefixlen value as text.</p>
+<p>For example, <code>host('192.168.1.2/16')</code> returns <code>'192.168.1.2'</code></p>
+</span></td></tr>
+<tr><td><code>hostmask(val: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a></code></td><td><span class="funcdesc"><p>Creates an IP host mask corresponding to the prefix length in the value.</p>
+<p>For example, <code>hostmask('192.168.1.2/16')</code> returns <code>'0.0.255.255'</code></p>
+</span></td></tr>
+<tr><td><code>masklen(val: <a href="inet.html">inet</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Retrieves the prefix length stored in the value.</p>
+<p>For example, <code>masklen('192.168.1.2/16')</code> returns <code>16</code></p>
+</span></td></tr>
+<tr><td><code>netmask(val: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a></code></td><td><span class="funcdesc"><p>Creates an IP network mask corresponding to the prefix length in the value.</p>
+<p>For example, <code>netmask('192.168.1.2/16')</code> returns <code>'255.255.0.0'</code></p>
+</span></td></tr>
+<tr><td><code>set_masklen(val: <a href="inet.html">inet</a>, prefixlen: <a href="int.html">int</a>) &rarr; <a href="inet.html">inet</a></code></td><td><span class="funcdesc"><p>Sets the prefix length of <code>val</code> to <code>prefixlen</code>.</p>
+<p>For example, <code>set_masklen('192.168.1.2', 16)</code> returns <code>'192.168.1.2/16'</code>.</p>
+</span></td></tr>
+<tr><td><code>text(val: <a href="inet.html">inet</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts the IP address and prefix length to text.</p>
+</span></td></tr></tbody>
+</table>
 
 ### Math and Numeric Functions
 
-Function &rarr; Returns | Description
---- | ---
-<code>abs(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the absolute value of `val`.</span>
-<code>abs(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the absolute value of `val`.</span>
-<code>abs(val: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the absolute value of `val`.</span>
-<code>acos(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the inverse cosine of `val`.</span>
-<code>asin(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the inverse sine of `val`.</span>
-<code>atan(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the inverse tangent of `val`.</span>
-<code>atan2(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the inverse tangent of `x`/`y`.</span>
-<code>cbrt(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the cube root (∛) of `val`.</span>
-<code>cbrt(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the cube root (∛) of `val`.</span>
-<code>ceil(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the smallest integer greater than `val`.</span>
-<code>ceil(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the smallest integer greater than `val`.</span>
-<code>ceiling(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the smallest integer greater than `val`.</span>
-<code>ceiling(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the smallest integer greater than `val`.</span>
-<code>cos(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the cosine of `val`.</span>
-<code>cot(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the cotangent of `val`.</span>
-<code>crc32c(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the CRC-32 hash using the Castagnoli polynomial.</span>
-<code>crc32c(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the CRC-32 hash using the Castagnoli polynomial.</span>
-<code>crc32ieee(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the CRC-32 hash using the IEEE polynomial.</span>
-<code>crc32ieee(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the CRC-32 hash using the IEEE polynomial.</span>
-<code>degrees(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Converts `val` as a radian value to a degree value.</span>
-<code>div(x: <a href="decimal.html">decimal</a>, y: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the integer quotient of `x`/`y`.</span>
-<code>div(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the integer quotient of `x`/`y`.</span>
-<code>div(x: <a href="int.html">int</a>, y: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the integer quotient of `x`/`y`.</span>
-<code>exp(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates *e* ^ `val`.</span>
-<code>exp(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates *e* ^ `val`.</span>
-<code>floor(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the largest integer not greater than `val`.</span>
-<code>floor(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the largest integer not greater than `val`.</span>
-<code>fnv32(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the 32-bit FNV-1 hash value of a set of values.</span>
-<code>fnv32(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the 32-bit FNV-1 hash value of a set of values.</span>
-<code>fnv32a(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the 32-bit FNV-1a hash value of a set of values.</span>
-<code>fnv32a(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the 32-bit FNV-1a hash value of a set of values.</span>
-<code>fnv64(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the 64-bit FNV-1 hash value of a set of values.</span>
-<code>fnv64(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the 64-bit FNV-1 hash value of a set of values.</span>
-<code>fnv64a(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the 64-bit FNV-1a hash value of a set of values.</span>
-<code>fnv64a(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the 64-bit FNV-1a hash value of a set of values.</span>
-<code>isnan(val: <a href="decimal.html">decimal</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Returns true if `val` is NaN, false otherwise.</span>
-<code>isnan(val: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code> | <span class="funcdesc">Returns true if `val` is NaN, false otherwise.</span>
-<code>ln(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the natural log of `val`.</span>
-<code>ln(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the natural log of `val`.</span>
-<code>log(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the base 10 log of `val`.</span>
-<code>log(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the base 10 log of `val`.</span>
-<code>mod(x: <a href="decimal.html">decimal</a>, y: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates `x`%`y`.</span>
-<code>mod(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates `x`%`y`.</span>
-<code>mod(x: <a href="int.html">int</a>, y: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates `x`%`y`.</span>
-<code>pi() &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Returns the value for pi (3.141592653589793).</span>
-<code>pow(x: <a href="decimal.html">decimal</a>, y: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates `x`^`y`.</span>
-<code>pow(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates `x`^`y`.</span>
-<code>pow(x: <a href="int.html">int</a>, y: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates `x`^`y`.</span>
-<code>power(x: <a href="decimal.html">decimal</a>, y: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates `x`^`y`.</span>
-<code>power(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates `x`^`y`.</span>
-<code>power(x: <a href="int.html">int</a>, y: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates `x`^`y`.</span>
-<code>radians(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Converts `val` as a degree value to a radians value.</span>
-<code>random() &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Returns a random float between 0 and 1.</span>
-<code>round(input: <a href="decimal.html">decimal</a>, decimal_accuracy: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Keeps `decimal_accuracy` number of figures to the right of the zero position  in `input using half away from zero rounding. If `decimal_accuracy` is not in the range -2^31...(2^31-1), the results are undefined.</span>
-<code>round(input: <a href="float.html">float</a>, decimal_accuracy: <a href="int.html">int</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Keeps `decimal_accuracy` number of figures to the right of the zero position  in `input` using half to even (banker's) rounding.</span>
-<code>round(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Rounds `val` to the nearest integer, half away from zero: ROUND(+/-2.4) = +/-2, ROUND(+/-2.5) = +/-3.</span>
-<code>round(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Rounds `val` to the nearest integer using half to even (banker's) rounding.</span>
-<code>sign(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Determines the sign of `val`: **1** for positive; **0** for 0 values; **-1** for negative.</span>
-<code>sign(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Determines the sign of `val`: **1** for positive; **0** for 0 values; **-1** for negative.</span>
-<code>sign(val: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Determines the sign of `val`: **1** for positive; **0** for 0 values; **-1** for negative.</span>
-<code>sin(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the sine of `val`.</span>
-<code>sqrt(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Calculates the square root of `val`.</span>
-<code>sqrt(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the square root of `val`.</span>
-<code>tan(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Calculates the tangent of `val`.</span>
-<code>to_hex(val: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Converts `val` to its hexadecimal representation.</span>
-<code>trunc(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">Truncates the decimal values of `val`.</span>
-<code>trunc(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code> | <span class="funcdesc">Truncates the decimal values of `val`.</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>abs(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the absolute value of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>abs(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the absolute value of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>abs(val: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the absolute value of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>acos(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the inverse cosine of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>asin(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the inverse sine of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>atan(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the inverse tangent of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>atan2(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the inverse tangent of <code>x</code>/<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>cbrt(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the cube root (∛) of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>cbrt(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the cube root (∛) of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>ceil(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the smallest integer greater than <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>ceil(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the smallest integer greater than <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>ceiling(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the smallest integer greater than <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>ceiling(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the smallest integer greater than <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>cos(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the cosine of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>cot(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the cotangent of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>crc32c(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the CRC-32 hash using the Castagnoli polynomial.</p>
+</span></td></tr>
+<tr><td><code>crc32c(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the CRC-32 hash using the Castagnoli polynomial.</p>
+</span></td></tr>
+<tr><td><code>crc32ieee(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the CRC-32 hash using the IEEE polynomial.</p>
+</span></td></tr>
+<tr><td><code>crc32ieee(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the CRC-32 hash using the IEEE polynomial.</p>
+</span></td></tr>
+<tr><td><code>degrees(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Converts <code>val</code> as a radian value to a degree value.</p>
+</span></td></tr>
+<tr><td><code>div(x: <a href="decimal.html">decimal</a>, y: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the integer quotient of <code>x</code>/<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>div(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the integer quotient of <code>x</code>/<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>div(x: <a href="int.html">int</a>, y: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the integer quotient of <code>x</code>/<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>exp(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates <em>e</em> ^ <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>exp(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates <em>e</em> ^ <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>floor(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the largest integer not greater than <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>floor(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the largest integer not greater than <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>fnv32(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 32-bit FNV-1 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>fnv32(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 32-bit FNV-1 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>fnv32a(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 32-bit FNV-1a hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>fnv32a(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 32-bit FNV-1a hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>fnv64(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 64-bit FNV-1 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>fnv64(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 64-bit FNV-1 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>fnv64a(<a href="bytes.html">bytes</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 64-bit FNV-1a hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>fnv64a(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 64-bit FNV-1a hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>isnan(val: <a href="decimal.html">decimal</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if <code>val</code> is NaN, false otherwise.</p>
+</span></td></tr>
+<tr><td><code>isnan(val: <a href="float.html">float</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns true if <code>val</code> is NaN, false otherwise.</p>
+</span></td></tr>
+<tr><td><code>ln(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the natural log of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>ln(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the natural log of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>log(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the base 10 log of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>log(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the base 10 log of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>mod(x: <a href="decimal.html">decimal</a>, y: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates <code>x</code>%<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>mod(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates <code>x</code>%<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>mod(x: <a href="int.html">int</a>, y: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates <code>x</code>%<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>pi() &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns the value for pi (3.141592653589793).</p>
+</span></td></tr>
+<tr><td><code>pow(x: <a href="decimal.html">decimal</a>, y: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates <code>x</code>^<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>pow(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates <code>x</code>^<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>pow(x: <a href="int.html">int</a>, y: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates <code>x</code>^<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>power(x: <a href="decimal.html">decimal</a>, y: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates <code>x</code>^<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>power(x: <a href="float.html">float</a>, y: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates <code>x</code>^<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>power(x: <a href="int.html">int</a>, y: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates <code>x</code>^<code>y</code>.</p>
+</span></td></tr>
+<tr><td><code>radians(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Converts <code>val</code> as a degree value to a radians value.</p>
+</span></td></tr>
+<tr><td><code>random() &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns a random float between 0 and 1.</p>
+</span></td></tr>
+<tr><td><code>round(input: <a href="decimal.html">decimal</a>, decimal_accuracy: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Keeps <code>decimal_accuracy</code> number of figures to the right of the zero position  in <code>input using half away from zero rounding. If</code>decimal_accuracy` is not in the range -2^31…(2^31-1), the results are undefined.</p>
+</span></td></tr>
+<tr><td><code>round(input: <a href="float.html">float</a>, decimal_accuracy: <a href="int.html">int</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Keeps <code>decimal_accuracy</code> number of figures to the right of the zero position  in <code>input</code> using half to even (banker’s) rounding.</p>
+</span></td></tr>
+<tr><td><code>round(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Rounds <code>val</code> to the nearest integer, half away from zero: ROUND(+/-2.4) = +/-2, ROUND(+/-2.5) = +/-3.</p>
+</span></td></tr>
+<tr><td><code>round(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Rounds <code>val</code> to the nearest integer using half to even (banker’s) rounding.</p>
+</span></td></tr>
+<tr><td><code>sign(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Determines the sign of <code>val</code>: <strong>1</strong> for positive; <strong>0</strong> for 0 values; <strong>-1</strong> for negative.</p>
+</span></td></tr>
+<tr><td><code>sign(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Determines the sign of <code>val</code>: <strong>1</strong> for positive; <strong>0</strong> for 0 values; <strong>-1</strong> for negative.</p>
+</span></td></tr>
+<tr><td><code>sign(val: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Determines the sign of <code>val</code>: <strong>1</strong> for positive; <strong>0</strong> for 0 values; <strong>-1</strong> for negative.</p>
+</span></td></tr>
+<tr><td><code>sin(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the sine of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>sqrt(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the square root of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>sqrt(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the square root of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>tan(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the tangent of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>to_hex(val: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts <code>val</code> to its hexadecimal representation.</p>
+</span></td></tr>
+<tr><td><code>trunc(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Truncates the decimal values of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>trunc(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Truncates the decimal values of <code>val</code>.</p>
+</span></td></tr></tbody>
+</table>
 
 ### String and Byte Functions
 
-Function &rarr; Returns | Description
---- | ---
-<code>ascii(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the ASCII value for the first character in `val`.</span>
-<code>btrim(input: <a href="string.html">string</a>, trim_chars: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Removes any characters included in `trim_chars` from the beginning or end of `input` (applies recursively). 
-
-For example, `btrim('doggie', 'eod')` returns `ggi`.</span>
-<code>btrim(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Removes all spaces from the beginning and end of `val`.</span>
-<code>concat(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Concatenates a comma-separated list of strings.</span>
-<code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Uses the first argument as a separator between the concatenation of the subsequent arguments. 
-
-For example `concat_ws('!','wow','great')` returns `wow!great`.</span>
-<code>from_ip(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Converts the byte string representation of an IP to its character string representation.</span>
-<code>from_uuid(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Converts the byte string representation of a UUID to its character string representation.</span>
-<code>initcap(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Capitalizes the first letter of `val`.</span>
-<code>left(input: <a href="bytes.html">bytes</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Returns the first `return_set` bytes from `input`.</span>
-<code>left(input: <a href="string.html">string</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns the first `return_set` characters from `input`.</span>
-<code>length(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of bytes in `val`.</span>
-<code>length(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of characters in `val`.</span>
-<code>lower(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Converts all characters in `val` to their lower-case equivalents.</span>
-<code>ltrim(input: <a href="string.html">string</a>, trim_chars: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Removes any characters included in `trim_chars` from the beginning (left-hand side) of `input` (applies recursively). 
-
-For example, `ltrim('doggie', 'od')` returns `ggie`.</span>
-<code>ltrim(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Removes all spaces from the beginning (left-hand side) of `val`.</span>
-<code>md5(<a href="bytes.html">bytes</a>...) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Calculates the MD5 hash value of a set of values.</span>
-<code>md5(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Calculates the MD5 hash value of a set of values.</span>
-<code>octet_length(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of bytes in `val`.</span>
-<code>octet_length(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the number of bytes used to represent `val`.</span>
-<code>overlay(input: <a href="string.html">string</a>, overlay_val: <a href="string.html">string</a>, start_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Replaces characters in `input` with `overlay_val` starting at `start_pos` (begins at 1). 
-
-For example, `overlay('doggie', 'CAT', 2)` returns `dCATie`.</span>
-<code>overlay(input: <a href="string.html">string</a>, overlay_val: <a href="string.html">string</a>, start_pos: <a href="int.html">int</a>, end_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Deletes the characters in `input` between `start_pos` and `end_pos` (count starts at 1), and then insert `overlay_val` at `start_pos`.</span>
-<code>regexp_extract(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns the first match for the Regular Expression `regex` in `input`.</span>
-<code>regexp_replace(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>, replace: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Replaces matches for the Regular Expression `regex` in `input` with the Regular Expression `replace`.</span>
-<code>regexp_replace(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>, replace: <a href="string.html">string</a>, flags: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Replaces matches for the regular expression `regex` in `input` with the regular expression `replace` using `flags`.
-
-CockroachDB supports the following flags:
-
-| Flag           | Description                                                       |
-|----------------|-------------------------------------------------------------------|
-| **c**          | Case-sensitive matching                                           |
-| **i**          | Global matching (match each substring instead of only the first). |
-| **m** or **n** | Newline-sensitive (see below)                                     |
-| **p**          | Partial newline-sensitive matching (see below)                    |
-| **s**          | Newline-insensitive (default)                                     |
-| **w**          | Inverse partial newline-sensitive matching (see below)            |
-
-| Mode | `.` and `[^...]` match newlines | `^` and `$` match line boundaries|
-|------|----------------------------------|--------------------------------------|
-| s    | yes                              | no                                   |
-| w    | yes                              | yes                                  |
-| p    | no                               | no                                   |
-| m/n  | no                               | yes                                  |</span>
-<code>repeat(input: <a href="string.html">string</a>, repeat_counter: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Concatenates `input` `repeat_counter` number of times.
-
-For example, `repeat('dog', 2)` returns `dogdog`.</span>
-<code>replace(input: <a href="string.html">string</a>, find: <a href="string.html">string</a>, replace: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Replaces all occurrences of `find` with `replace` in `input`</span>
-<code>reverse(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Reverses the order of the string's characters.</span>
-<code>right(input: <a href="bytes.html">bytes</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Returns the last `return_set` bytes from `input`.</span>
-<code>right(input: <a href="string.html">string</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns the last `return_set` characters from `input`.</span>
-<code>rtrim(input: <a href="string.html">string</a>, trim_chars: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Removes any characters included in `trim_chars` from the end (right-hand side) of `input` (applies recursively). 
-
-For example, `rtrim('doggie', 'ei')` returns `dogg`.</span>
-<code>rtrim(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Removes all spaces from the end (right-hand side) of `val`.</span>
-<code>sha1(<a href="bytes.html">bytes</a>...) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Calculates the SHA1 hash value of a set of values.</span>
-<code>sha1(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Calculates the SHA1 hash value of a set of values.</span>
-<code>sha256(<a href="bytes.html">bytes</a>...) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Calculates the SHA256 hash value of a set of values.</span>
-<code>sha256(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Calculates the SHA256 hash value of a set of values.</span>
-<code>sha512(<a href="bytes.html">bytes</a>...) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Calculates the SHA512 hash value of a set of values.</span>
-<code>sha512(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Calculates the SHA512 hash value of a set of values.</span>
-<code>split_part(input: <a href="string.html">string</a>, delimiter: <a href="string.html">string</a>, return_index_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Splits `input` on `delimiter` and return the value in the `return_index_pos`  position (starting at 1). 
-
-For example, `split_part('123.456.789.0','.',3)`returns `789`.</span>
-<code>strpos(input: <a href="string.html">string</a>, find: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">Calculates the position where the string `find` begins in `input`. 
-
-For example, `strpos('doggie', 'gie')` returns `4`.</span>
-<code>substr(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns a substring of `input` that matches the regular expression `regex`.</span>
-<code>substr(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>, escape_char: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns a substring of `input` that matches the regular expression `regex` using `escape_char` as your escape character instead of `\`.</span>
-<code>substr(input: <a href="string.html">string</a>, start_pos: <a href="int.html">int</a>, end_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns a substring of `input` between `start_pos` and `end_pos` (count starts at 1).</span>
-<code>substr(input: <a href="string.html">string</a>, substr_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns a substring of `input` starting at `substr_pos` (count starts at 1).</span>
-<code>substring(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns a substring of `input` that matches the regular expression `regex`.</span>
-<code>substring(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>, escape_char: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns a substring of `input` that matches the regular expression `regex` using `escape_char` as your escape character instead of `\`.</span>
-<code>substring(input: <a href="string.html">string</a>, start_pos: <a href="int.html">int</a>, end_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns a substring of `input` between `start_pos` and `end_pos` (count starts at 1).</span>
-<code>substring(input: <a href="string.html">string</a>, substr_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns a substring of `input` starting at `substr_pos` (count starts at 1).</span>
-<code>to_english(val: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">This function enunciates the value of its argument using English cardinals.</span>
-<code>to_hex(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Converts `val` to its hexadecimal representation.</span>
-<code>to_ip(val: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Converts the character string representation of an IP to its byte string representation.</span>
-<code>to_uuid(val: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code> | <span class="funcdesc">Converts the character string representation of a UUID to its byte string representation.</span>
-<code>translate(input: <a href="string.html">string</a>, find: <a href="string.html">string</a>, replace: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">In `input`, replaces the first character from `find` with the first character in `replace`; repeat for each character in `find`. 
-
-For example, `translate('doggie', 'dog', '123');` returns `1233ie`.</span>
-<code>upper(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Converts all characters in `val` to their to their upper-case equivalents.</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>ascii(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the ASCII value for the first character in <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>btrim(input: <a href="string.html">string</a>, trim_chars: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes any characters included in <code>trim_chars</code> from the beginning or end of <code>input</code> (applies recursively).</p>
+<p>For example, <code>btrim('doggie', 'eod')</code> returns <code>ggi</code>.</p>
+</span></td></tr>
+<tr><td><code>btrim(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes all spaces from the beginning and end of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>concat(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates a comma-separated list of strings.</p>
+</span></td></tr>
+<tr><td><code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
+<p>For example <code>concat_ws('!','wow','great')</code> returns <code>wow!great</code>.</p>
+</span></td></tr>
+<tr><td><code>from_ip(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts the byte string representation of an IP to its character string representation.</p>
+</span></td></tr>
+<tr><td><code>from_uuid(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts the byte string representation of a UUID to its character string representation.</p>
+</span></td></tr>
+<tr><td><code>initcap(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Capitalizes the first letter of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>left(input: <a href="bytes.html">bytes</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the first <code>return_set</code> bytes from <code>input</code>.</p>
+</span></td></tr>
+<tr><td><code>left(input: <a href="string.html">string</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the first <code>return_set</code> characters from <code>input</code>.</p>
+</span></td></tr>
+<tr><td><code>length(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bytes in <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>length(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of characters in <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>lower(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts all characters in <code>val</code> to their lower-case equivalents.</p>
+</span></td></tr>
+<tr><td><code>ltrim(input: <a href="string.html">string</a>, trim_chars: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes any characters included in <code>trim_chars</code> from the beginning (left-hand side) of <code>input</code> (applies recursively).</p>
+<p>For example, <code>ltrim('doggie', 'od')</code> returns <code>ggie</code>.</p>
+</span></td></tr>
+<tr><td><code>ltrim(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes all spaces from the beginning (left-hand side) of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>md5(<a href="bytes.html">bytes</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Calculates the MD5 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>md5(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Calculates the MD5 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>octet_length(val: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bytes in <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>octet_length(val: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of bytes used to represent <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>overlay(input: <a href="string.html">string</a>, overlay_val: <a href="string.html">string</a>, start_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Replaces characters in <code>input</code> with <code>overlay_val</code> starting at <code>start_pos</code> (begins at 1).</p>
+<p>For example, <code>overlay('doggie', 'CAT', 2)</code> returns <code>dCATie</code>.</p>
+</span></td></tr>
+<tr><td><code>overlay(input: <a href="string.html">string</a>, overlay_val: <a href="string.html">string</a>, start_pos: <a href="int.html">int</a>, end_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Deletes the characters in <code>input</code> between <code>start_pos</code> and <code>end_pos</code> (count starts at 1), and then insert <code>overlay_val</code> at <code>start_pos</code>.</p>
+</span></td></tr>
+<tr><td><code>regexp_extract(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the first match for the Regular Expression <code>regex</code> in <code>input</code>.</p>
+</span></td></tr>
+<tr><td><code>regexp_replace(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>, replace: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Replaces matches for the Regular Expression <code>regex</code> in <code>input</code> with the Regular Expression <code>replace</code>.</p>
+</span></td></tr>
+<tr><td><code>regexp_replace(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>, replace: <a href="string.html">string</a>, flags: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Replaces matches for the regular expression <code>regex</code> in <code>input</code> with the regular expression <code>replace</code> using <code>flags</code>.</p>
+<p>CockroachDB supports the following flags:</p>
+<table>
+<thead>
+<tr>
+<th>Flag</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>c</strong></td>
+<td>Case-sensitive matching</td>
+</tr>
+<tr>
+<td><strong>i</strong></td>
+<td>Global matching (match each substring instead of only the first).</td>
+</tr>
+<tr>
+<td><strong>m</strong> or <strong>n</strong></td>
+<td>Newline-sensitive (see below)</td>
+</tr>
+<tr>
+<td><strong>p</strong></td>
+<td>Partial newline-sensitive matching (see below)</td>
+</tr>
+<tr>
+<td><strong>s</strong></td>
+<td>Newline-insensitive (default)</td>
+</tr>
+<tr>
+<td><strong>w</strong></td>
+<td>Inverse partial newline-sensitive matching (see below)</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>Mode</th>
+<th><code>.</code> and <code>[^...]</code> match newlines</th>
+<th><code>^</code> and <code>$</code> match line boundaries</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>s</td>
+<td>yes</td>
+<td>no</td>
+</tr>
+<tr>
+<td>w</td>
+<td>yes</td>
+<td>yes</td>
+</tr>
+<tr>
+<td>p</td>
+<td>no</td>
+<td>no</td>
+</tr>
+<tr>
+<td>m/n</td>
+<td>no</td>
+<td>yes</td>
+</tr>
+</tbody>
+</table>
+</span></td></tr>
+<tr><td><code>repeat(input: <a href="string.html">string</a>, repeat_counter: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates <code>input</code> <code>repeat_counter</code> number of times.</p>
+<p>For example, <code>repeat('dog', 2)</code> returns <code>dogdog</code>.</p>
+</span></td></tr>
+<tr><td><code>replace(input: <a href="string.html">string</a>, find: <a href="string.html">string</a>, replace: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Replaces all occurrences of <code>find</code> with <code>replace</code> in <code>input</code></p>
+</span></td></tr>
+<tr><td><code>reverse(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Reverses the order of the string’s characters.</p>
+</span></td></tr>
+<tr><td><code>right(input: <a href="bytes.html">bytes</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the last <code>return_set</code> bytes from <code>input</code>.</p>
+</span></td></tr>
+<tr><td><code>right(input: <a href="string.html">string</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the last <code>return_set</code> characters from <code>input</code>.</p>
+</span></td></tr>
+<tr><td><code>rtrim(input: <a href="string.html">string</a>, trim_chars: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes any characters included in <code>trim_chars</code> from the end (right-hand side) of <code>input</code> (applies recursively).</p>
+<p>For example, <code>rtrim('doggie', 'ei')</code> returns <code>dogg</code>.</p>
+</span></td></tr>
+<tr><td><code>rtrim(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes all spaces from the end (right-hand side) of <code>val</code>.</p>
+</span></td></tr>
+<tr><td><code>sha1(<a href="bytes.html">bytes</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Calculates the SHA1 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>sha1(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Calculates the SHA1 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>sha256(<a href="bytes.html">bytes</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Calculates the SHA256 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>sha256(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Calculates the SHA256 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>sha512(<a href="bytes.html">bytes</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Calculates the SHA512 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>sha512(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Calculates the SHA512 hash value of a set of values.</p>
+</span></td></tr>
+<tr><td><code>split_part(input: <a href="string.html">string</a>, delimiter: <a href="string.html">string</a>, return_index_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Splits <code>input</code> on <code>delimiter</code> and return the value in the <code>return_index_pos</code>  position (starting at 1).</p>
+<p>For example, <code>split_part('123.456.789.0','.',3)</code>returns <code>789</code>.</p>
+</span></td></tr>
+<tr><td><code>strpos(input: <a href="string.html">string</a>, find: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the position where the string <code>find</code> begins in <code>input</code>.</p>
+<p>For example, <code>strpos('doggie', 'gie')</code> returns <code>4</code>.</p>
+</span></td></tr>
+<tr><td><code>substr(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a substring of <code>input</code> that matches the regular expression <code>regex</code>.</p>
+</span></td></tr>
+<tr><td><code>substr(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>, escape_char: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a substring of <code>input</code> that matches the regular expression <code>regex</code> using <code>escape_char</code> as your escape character instead of <code>\</code>.</p>
+</span></td></tr>
+<tr><td><code>substr(input: <a href="string.html">string</a>, start_pos: <a href="int.html">int</a>, end_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a substring of <code>input</code> between <code>start_pos</code> and <code>end_pos</code> (count starts at 1).</p>
+</span></td></tr>
+<tr><td><code>substr(input: <a href="string.html">string</a>, substr_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a substring of <code>input</code> starting at <code>substr_pos</code> (count starts at 1).</p>
+</span></td></tr>
+<tr><td><code>substring(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a substring of <code>input</code> that matches the regular expression <code>regex</code>.</p>
+</span></td></tr>
+<tr><td><code>substring(input: <a href="string.html">string</a>, regex: <a href="string.html">string</a>, escape_char: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a substring of <code>input</code> that matches the regular expression <code>regex</code> using <code>escape_char</code> as your escape character instead of <code>\</code>.</p>
+</span></td></tr>
+<tr><td><code>substring(input: <a href="string.html">string</a>, start_pos: <a href="int.html">int</a>, end_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a substring of <code>input</code> between <code>start_pos</code> and <code>end_pos</code> (count starts at 1).</p>
+</span></td></tr>
+<tr><td><code>substring(input: <a href="string.html">string</a>, substr_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a substring of <code>input</code> starting at <code>substr_pos</code> (count starts at 1).</p>
+</span></td></tr>
+<tr><td><code>to_english(val: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>This function enunciates the value of its argument using English cardinals.</p>
+</span></td></tr>
+<tr><td><code>to_hex(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts <code>val</code> to its hexadecimal representation.</p>
+</span></td></tr>
+<tr><td><code>to_ip(val: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Converts the character string representation of an IP to its byte string representation.</p>
+</span></td></tr>
+<tr><td><code>to_uuid(val: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Converts the character string representation of a UUID to its byte string representation.</p>
+</span></td></tr>
+<tr><td><code>translate(input: <a href="string.html">string</a>, find: <a href="string.html">string</a>, replace: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>In <code>input</code>, replaces the first character from <code>find</code> with the first character in <code>replace</code>; repeat for each character in <code>find</code>.</p>
+<p>For example, <code>translate('doggie', 'dog', '123');</code> returns <code>1233ie</code>.</p>
+</span></td></tr>
+<tr><td><code>upper(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts all characters in <code>val</code> to their to their upper-case equivalents.</p>
+</span></td></tr></tbody>
+</table>
 
 ### System Info Functions
 
-Function &rarr; Returns | Description
---- | ---
-<code>cluster_logical_timestamp() &rarr; <a href="decimal.html">decimal</a></code> | <span class="funcdesc">This function is used only by CockroachDB's developers for testing purposes.</span>
-<code>crdb_internal.cluster_id() &rarr; uuid</code> | <span class="funcdesc">Returns the cluster ID.</span>
-<code>crdb_internal.force_error(errorCode: <a href="string.html">string</a>, msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">This function is used only by CockroachDB's developers for testing purposes.</span>
-<code>crdb_internal.force_log_fatal(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">This function is used only by CockroachDB's developers for testing purposes.</span>
-<code>crdb_internal.force_panic(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">This function is used only by CockroachDB's developers for testing purposes.</span>
-<code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">This function is used only by CockroachDB's developers for testing purposes.</span>
-<code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>, txnID: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">This function is used only by CockroachDB's developers for testing purposes.</span>
-<code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code> | <span class="funcdesc">This function is used only by CockroachDB's developers for testing purposes.</span>
-<code>crdb_internal.set_vmodule(vmodule_string: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code> | <span class="funcdesc">This function is used for internal debugging purposes. Incorrect use can severely impact performance.</span>
-<code>current_database() &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns the current database.</span>
-<code>current_schema() &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns the current schema. This function is provided for compatibility with PostgreSQL. For a new CockroachDB application, consider using current_database() instead.</span>
-<code>current_schemas(include_pg_catalog: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a>[]</code> | <span class="funcdesc">Returns the current search path for unqualified names.</span>
-<code>current_user() &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns the current user. This function is provided for compatibility with PostgreSQL.</span>
-<code>version() &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns the node's version of CockroachDB.</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>cluster_logical_timestamp() &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.cluster_id() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Returns the cluster ID.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.force_error(errorCode: <a href="string.html">string</a>, msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.force_log_fatal(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.force_panic(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>, txnID: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.set_vmodule(vmodule_string: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used for internal debugging purposes. Incorrect use can severely impact performance.</p>
+</span></td></tr>
+<tr><td><code>current_database() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current database.</p>
+</span></td></tr>
+<tr><td><code>current_schema() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current schema. This function is provided for compatibility with PostgreSQL. For a new CockroachDB application, consider using current_database() instead.</p>
+</span></td></tr>
+<tr><td><code>current_schemas(include_pg_catalog: <a href="bool.html">bool</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Returns the current search path for unqualified names.</p>
+</span></td></tr>
+<tr><td><code>current_user() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current user. This function is provided for compatibility with PostgreSQL.</p>
+</span></td></tr>
+<tr><td><code>version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the node’s version of CockroachDB.</p>
+</span></td></tr></tbody>
+</table>
 
 ### Compatibility Functions
 
-Function &rarr; Returns | Description
---- | ---
-<code>format_type(type_oid: oid, typemod: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code> | <span class="funcdesc">Returns the SQL name of a data type that is identified by its type OID and possibly a type modifier. Currently, the type modifier is ignored.</span>
-<code>generate_series(start: <a href="int.html">int</a>, end: <a href="int.html">int</a>) &rarr; setof tuple{int}</code> | <span class="funcdesc">Produces a virtual table containing the integer values from `start` to `end`, inclusive.</span>
-<code>generate_series(start: <a href="int.html">int</a>, end: <a href="int.html">int</a>, step: <a href="int.html">int</a>) &rarr; setof tuple{int}</code> | <span class="funcdesc">Produces a virtual table containing the integer values from `start` to `end`, inclusive, by increment of `step`.</span>
-<code>oid(int: <a href="int.html">int</a>) &rarr; oid</code> | <span class="funcdesc">Converts an integer to an OID.</span>
-<code>pg_get_keywords() &rarr; setof tuple{<a href="string.html">string</a>, <a href="string.html">string</a>, string}</code> | <span class="funcdesc">Produces a virtual table containing the keywords known to the SQL parser.</span>
-<code>unnest(input: anyelement[]) &rarr; anyelement</code> | <span class="funcdesc">Returns the input array as a set of rows</span>
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>format_type(type_oid: oid, typemod: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the SQL name of a data type that is identified by its type OID and possibly a type modifier. Currently, the type modifier is ignored.</p>
+</span></td></tr>
+<tr><td><code>generate_series(start: <a href="int.html">int</a>, end: <a href="int.html">int</a>) &rarr; setof tuple{int}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the integer values from <code>start</code> to <code>end</code>, inclusive.</p>
+</span></td></tr>
+<tr><td><code>generate_series(start: <a href="int.html">int</a>, end: <a href="int.html">int</a>, step: <a href="int.html">int</a>) &rarr; setof tuple{int}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the integer values from <code>start</code> to <code>end</code>, inclusive, by increment of <code>step</code>.</p>
+</span></td></tr>
+<tr><td><code>oid(int: <a href="int.html">int</a>) &rarr; oid</code></td><td><span class="funcdesc"><p>Converts an integer to an OID.</p>
+</span></td></tr>
+<tr><td><code>pg_get_keywords() &rarr; setof tuple{<a href="string.html">string</a>, <a href="string.html">string</a>, string}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the keywords known to the SQL parser.</p>
+</span></td></tr>
+<tr><td><code>unnest(input: anyelement[]) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows</p>
+</span></td></tr></tbody>
+</table>
 

--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -98,7 +98,7 @@
 </thead><tbody>
 <tr><td><a href="bool.html">bool</a> <code><</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code><</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>collatedstring{} <code><</code> collatedstring{}</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="collatedstring.html">collatedstring</a> <code><</code> <a href="collatedstring.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -108,7 +108,7 @@
 <tr><td><a href="float.html">float</a> <code><</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="float.html">float</a> <code><</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="float.html">float</a> <code><</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>inet <code><</code> inet</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="inet.html">inet</a> <code><</code> <a href="inet.html">inet</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="int.html">int</a> <code><</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="int.html">int</a> <code><</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="int.html">int</a> <code><</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -121,7 +121,7 @@
 <tr><td><a href="timestamp.html">timestamptz</a> <code><</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="timestamp.html">timestamptz</a> <code><</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>tuple <code><</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>uuid <code><</code> uuid</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="uuid.html">uuid</a> <code><</code> <a href="uuid.html">uuid</a></td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>
 <table><thead>
 <tr><td><code><<</code></td><td>Return</td></tr>
@@ -133,7 +133,7 @@
 </thead><tbody>
 <tr><td><a href="bool.html">bool</a> <code><=</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code><=</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>collatedstring{} <code><=</code> collatedstring{}</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="collatedstring.html">collatedstring</a> <code><=</code> <a href="collatedstring.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code><=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -143,7 +143,7 @@
 <tr><td><a href="float.html">float</a> <code><=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="float.html">float</a> <code><=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="float.html">float</a> <code><=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>inet <code><=</code> inet</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="inet.html">inet</a> <code><=</code> <a href="inet.html">inet</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="int.html">int</a> <code><=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="int.html">int</a> <code><=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="int.html">int</a> <code><=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -156,51 +156,51 @@
 <tr><td><a href="timestamp.html">timestamptz</a> <code><=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="timestamp.html">timestamptz</a> <code><=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>tuple <code><=</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>uuid <code><=</code> uuid</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="uuid.html">uuid</a> <code><=</code> <a href="uuid.html">uuid</a></td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>
 <table><thead>
 <tr><td><code>=</code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td><a href="bool.html">bool</a> <code>=</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>bool[] <code>=</code> bool[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="bool.html">bool[]</a> <code>=</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>=</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>bytes[] <code>=</code> bytes[]</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>collatedstring{} <code>=</code> collatedstring{}</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="bytes.html">bytes[]</a> <code>=</code> <a href="bytes.html">bytes[]</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="collatedstring.html">collatedstring</a> <code>=</code> <a href="collatedstring.html">collatedstring</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>date[] <code>=</code> date[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="date.html">date[]</a> <code>=</code> <a href="date.html">date[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>decimal[] <code>=</code> decimal[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="decimal.html">decimal[]</a> <code>=</code> <a href="decimal.html">decimal[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="float.html">float</a> <code>=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="float.html">float</a> <code>=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="float.html">float</a> <code>=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>float[] <code>=</code> float[]</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>inet <code>=</code> inet</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>inet[] <code>=</code> inet[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="float.html">float[]</a> <code>=</code> <a href="float.html">float[]</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="inet.html">inet</a> <code>=</code> <a href="inet.html">inet</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="inet.html">inet[]</a> <code>=</code> <a href="inet.html">inet[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>=</code> <a href="decimal.html">decimal</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>=</code> <a href="float.html">float</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>=</code> <a href="int.html">int</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>int[] <code>=</code> int[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="int.html">int[]</a> <code>=</code> <a href="int.html">int[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>=</code> <a href="interval.html">interval</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>interval[] <code>=</code> interval[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="interval.html">interval[]</a> <code>=</code> <a href="interval.html">interval[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>oid <code>=</code> oid</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>oid[] <code>=</code> oid[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>oid <code>=</code> oid</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>=</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>string[] <code>=</code> string[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="string.html">string[]</a> <code>=</code> <a href="string.html">string[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="timestamp.html">timestamp</a> <code>=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="timestamp.html">timestamp</a> <code>=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="timestamp.html">timestamp</a> <code>=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>timestamp[] <code>=</code> timestamp[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp[]</a> <code>=</code> <a href="timestamp.html">timestamp[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="timestamp.html">timestamptz</a> <code>=</code> <a href="date.html">date</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="timestamp.html">timestamptz</a> <code>=</code> <a href="timestamp.html">timestamp</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="timestamp.html">timestamptz</a> <code>=</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>timestamptz[] <code>=</code> timestamptz[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>timestamptz <code>=</code> timestamptz</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>tuple <code>=</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>uuid <code>=</code> uuid</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>uuid[] <code>=</code> uuid[]</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="uuid.html">uuid</a> <code>=</code> <a href="uuid.html">uuid</a></td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="uuid.html">uuid[]</a> <code>=</code> <a href="uuid.html">uuid[]</a></td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>
 <table><thead>
 <tr><td><code>>></code></td><td>Return</td></tr>
@@ -217,11 +217,11 @@
 </thead><tbody>
 <tr><td><a href="bool.html">bool</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>collatedstring{} <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="collatedstring.html">collatedstring</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="date.html">date</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="float.html">float</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>inet <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="inet.html">inet</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>oid <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
@@ -229,7 +229,7 @@
 <tr><td><a href="timestamp.html">timestamp</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="timestamp.html">timestamptz</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>tuple <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>uuid <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td><a href="uuid.html">uuid</a> <code>IN</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>
 <table><thead>
 <tr><td><code>LIKE</code></td><td>Return</td></tr>
@@ -258,47 +258,47 @@
 <table><thead>
 <tr><td><code>||</code></td><td>Return</td></tr>
 </thead><tbody>
-<tr><td><a href="bool.html">bool</a> <code>||</code> bool[]</td><td>bool[]</td></tr>
-<tr><td>bool[] <code>||</code> <a href="bool.html">bool</a></td><td>bool[]</td></tr>
-<tr><td>bool[] <code>||</code> bool[]</td><td>bool[]</td></tr>
+<tr><td><a href="bool.html">bool</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
+<tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool[]</a></td></tr>
+<tr><td><a href="bool.html">bool[]</a> <code>||</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool[]</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>||</code> <a href="bytes.html">bytes</a></td><td><a href="bytes.html">bytes</a></td></tr>
-<tr><td><a href="bytes.html">bytes</a> <code>||</code> bytes[]</td><td>bytes[]</td></tr>
-<tr><td>bytes[] <code>||</code> <a href="bytes.html">bytes</a></td><td>bytes[]</td></tr>
-<tr><td>bytes[] <code>||</code> bytes[]</td><td>bytes[]</td></tr>
-<tr><td><a href="date.html">date</a> <code>||</code> date[]</td><td>date[]</td></tr>
-<tr><td>date[] <code>||</code> <a href="date.html">date</a></td><td>date[]</td></tr>
-<tr><td>date[] <code>||</code> date[]</td><td>date[]</td></tr>
-<tr><td><a href="decimal.html">decimal</a> <code>||</code> decimal[]</td><td>decimal[]</td></tr>
-<tr><td>decimal[] <code>||</code> <a href="decimal.html">decimal</a></td><td>decimal[]</td></tr>
-<tr><td>decimal[] <code>||</code> decimal[]</td><td>decimal[]</td></tr>
-<tr><td><a href="float.html">float</a> <code>||</code> float[]</td><td>float[]</td></tr>
-<tr><td>float[] <code>||</code> <a href="float.html">float</a></td><td>float[]</td></tr>
-<tr><td>float[] <code>||</code> float[]</td><td>float[]</td></tr>
-<tr><td>inet <code>||</code> inet[]</td><td>inet[]</td></tr>
-<tr><td>inet[] <code>||</code> inet</td><td>inet[]</td></tr>
-<tr><td>inet[] <code>||</code> inet[]</td><td>inet[]</td></tr>
-<tr><td><a href="int.html">int</a> <code>||</code> int[]</td><td>int[]</td></tr>
-<tr><td>int[] <code>||</code> <a href="int.html">int</a></td><td>int[]</td></tr>
-<tr><td>int[] <code>||</code> int[]</td><td>int[]</td></tr>
-<tr><td><a href="interval.html">interval</a> <code>||</code> interval[]</td><td>interval[]</td></tr>
-<tr><td>interval[] <code>||</code> <a href="interval.html">interval</a></td><td>interval[]</td></tr>
-<tr><td>interval[] <code>||</code> interval[]</td><td>interval[]</td></tr>
-<tr><td>oid <code>||</code> oid[]</td><td>oid[]</td></tr>
-<tr><td>oid[] <code>||</code> oid</td><td>oid[]</td></tr>
-<tr><td>oid[] <code>||</code> oid[]</td><td>oid[]</td></tr>
+<tr><td><a href="bytes.html">bytes</a> <code>||</code> <a href="bytes.html">bytes[]</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
+<tr><td><a href="bytes.html">bytes[]</a> <code>||</code> <a href="bytes.html">bytes</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
+<tr><td><a href="bytes.html">bytes[]</a> <code>||</code> <a href="bytes.html">bytes[]</a></td><td><a href="bytes.html">bytes[]</a></td></tr>
+<tr><td><a href="date.html">date</a> <code>||</code> <a href="date.html">date[]</a></td><td><a href="date.html">date[]</a></td></tr>
+<tr><td><a href="date.html">date[]</a> <code>||</code> <a href="date.html">date</a></td><td><a href="date.html">date[]</a></td></tr>
+<tr><td><a href="date.html">date[]</a> <code>||</code> <a href="date.html">date[]</a></td><td><a href="date.html">date[]</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>||</code> <a href="decimal.html">decimal[]</a></td><td><a href="decimal.html">decimal[]</a></td></tr>
+<tr><td><a href="decimal.html">decimal[]</a> <code>||</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal[]</a></td></tr>
+<tr><td><a href="decimal.html">decimal[]</a> <code>||</code> <a href="decimal.html">decimal[]</a></td><td><a href="decimal.html">decimal[]</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>||</code> <a href="float.html">float[]</a></td><td><a href="float.html">float[]</a></td></tr>
+<tr><td><a href="float.html">float[]</a> <code>||</code> <a href="float.html">float</a></td><td><a href="float.html">float[]</a></td></tr>
+<tr><td><a href="float.html">float[]</a> <code>||</code> <a href="float.html">float[]</a></td><td><a href="float.html">float[]</a></td></tr>
+<tr><td><a href="inet.html">inet</a> <code>||</code> <a href="inet.html">inet[]</a></td><td><a href="inet.html">inet[]</a></td></tr>
+<tr><td><a href="inet.html">inet[]</a> <code>||</code> <a href="inet.html">inet</a></td><td><a href="inet.html">inet[]</a></td></tr>
+<tr><td><a href="inet.html">inet[]</a> <code>||</code> <a href="inet.html">inet[]</a></td><td><a href="inet.html">inet[]</a></td></tr>
+<tr><td><a href="int.html">int</a> <code>||</code> <a href="int.html">int[]</a></td><td><a href="int.html">int[]</a></td></tr>
+<tr><td><a href="int.html">int[]</a> <code>||</code> <a href="int.html">int</a></td><td><a href="int.html">int[]</a></td></tr>
+<tr><td><a href="int.html">int[]</a> <code>||</code> <a href="int.html">int[]</a></td><td><a href="int.html">int[]</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>||</code> <a href="interval.html">interval[]</a></td><td><a href="interval.html">interval[]</a></td></tr>
+<tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval[]</a></td></tr>
+<tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval[]</a></td><td><a href="interval.html">interval[]</a></td></tr>
+<tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
+<tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
+<tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
-<tr><td><a href="string.html">string</a> <code>||</code> string[]</td><td>string[]</td></tr>
-<tr><td>string[] <code>||</code> <a href="string.html">string</a></td><td>string[]</td></tr>
-<tr><td>string[] <code>||</code> string[]</td><td>string[]</td></tr>
-<tr><td><a href="timestamp.html">timestamp</a> <code>||</code> timestamp[]</td><td>timestamp[]</td></tr>
-<tr><td>timestamp[] <code>||</code> <a href="timestamp.html">timestamp</a></td><td>timestamp[]</td></tr>
-<tr><td>timestamp[] <code>||</code> timestamp[]</td><td>timestamp[]</td></tr>
-<tr><td><a href="timestamp.html">timestamptz</a> <code>||</code> timestamptz[]</td><td>timestamptz[]</td></tr>
-<tr><td>timestamptz[] <code>||</code> <a href="timestamp.html">timestamptz</a></td><td>timestamptz[]</td></tr>
-<tr><td>timestamptz[] <code>||</code> timestamptz[]</td><td>timestamptz[]</td></tr>
-<tr><td>uuid <code>||</code> uuid[]</td><td>uuid[]</td></tr>
-<tr><td>uuid[] <code>||</code> uuid</td><td>uuid[]</td></tr>
-<tr><td>uuid[] <code>||</code> uuid[]</td><td>uuid[]</td></tr>
+<tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string[]</a></td><td><a href="string.html">string[]</a></td></tr>
+<tr><td><a href="string.html">string[]</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string[]</a></td></tr>
+<tr><td><a href="string.html">string[]</a> <code>||</code> <a href="string.html">string[]</a></td><td><a href="string.html">string[]</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp</a> <code>||</code> <a href="timestamp.html">timestamp[]</a></td><td><a href="timestamp.html">timestamp[]</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp[]</a> <code>||</code> <a href="timestamp.html">timestamp</a></td><td><a href="timestamp.html">timestamp[]</a></td></tr>
+<tr><td><a href="timestamp.html">timestamp[]</a> <code>||</code> <a href="timestamp.html">timestamp[]</a></td><td><a href="timestamp.html">timestamp[]</a></td></tr>
+<tr><td><a href="timestamp.html">timestamptz</a> <code>||</code> timestamptz</td><td>timestamptz</td></tr>
+<tr><td>timestamptz <code>||</code> <a href="timestamp.html">timestamptz</a></td><td>timestamptz</td></tr>
+<tr><td>timestamptz <code>||</code> timestamptz</td><td>timestamptz</td></tr>
+<tr><td><a href="uuid.html">uuid</a> <code>||</code> <a href="uuid.html">uuid[]</a></td><td><a href="uuid.html">uuid[]</a></td></tr>
+<tr><td><a href="uuid.html">uuid[]</a> <code>||</code> <a href="uuid.html">uuid</a></td><td><a href="uuid.html">uuid[]</a></td></tr>
+<tr><td><a href="uuid.html">uuid[]</a> <code>||</code> <a href="uuid.html">uuid[]</a></td><td><a href="uuid.html">uuid[]</a></td></tr>
 </tbody></table>
 <table><thead>
 <tr><td><code>~</code></td><td>Return</td></tr>

--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	markdown "github.com/golang-commonmark/markdown"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -164,6 +165,7 @@ const notUsableInfo = "Not usable; exposed only for compatibility with PostgreSQ
 func generateFunctions(from map[string][]parser.Builtin, categorize bool) []byte {
 	functions := make(map[string][]string)
 	seen := make(map[string]struct{})
+	md := markdown.New(markdown.XHTMLOutput(true), markdown.Nofollow(true))
 	for name, fns := range from {
 		// NB: funcs can appear more than once i.e. upper/lowercase varients for
 		// faster lookups, so normalize to lowercase and de-dupe using a set.
@@ -190,9 +192,14 @@ func generateFunctions(from map[string][]parser.Builtin, categorize bool) []byte
 			}
 			extra := ""
 			if fn.Info != "" {
-				extra = fmt.Sprintf("<span class=\"funcdesc\">%s</span>", fn.Info)
+				// Render the info field to HTML upfront, because Markdown
+				// won't do it automatically in a table context.
+				// Boo Markdown, bad Markdown.
+				// TODO(knz): Do not use Markdown.
+				info := md.RenderToString([]byte(fn.Info))
+				extra = fmt.Sprintf("<span class=\"funcdesc\">%s</span>", info)
 			}
-			s := fmt.Sprintf("<code>%s(%s) &rarr; %s</code> | %s", name, linkArguments(args), linkArguments(ret), extra)
+			s := fmt.Sprintf("<tr><td><code>%s(%s) &rarr; %s</code></td><td>%s</td></tr>", name, linkArguments(args), linkArguments(ret), extra)
 			functions[cat] = append(functions[cat], s)
 		}
 	}
@@ -216,10 +223,10 @@ func generateFunctions(from map[string][]parser.Builtin, categorize bool) []byte
 		if categorize {
 			fmt.Fprintf(b, "### %s Functions\n\n", cat)
 		}
-		b.WriteString("Function &rarr; Returns | Description\n")
-		b.WriteString("--- | ---\n")
+		b.WriteString("<table>\n<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>\n")
+		b.WriteString("<tbody>\n")
 		b.WriteString(strings.Join(functions[cat], "\n"))
-		b.WriteString("\n\n")
+		b.WriteString("</tbody>\n</table>\n\n")
 	}
 	return b.Bytes()
 }
@@ -239,13 +246,16 @@ func linkArguments(t string) string {
 }
 
 func linkTypeName(s string) string {
+	s = strings.TrimSuffix(s, "{}")
 	name := s
 	switch s {
 	case "timestamptz":
 		s = "timestamp"
 	}
+	s = strings.TrimSuffix(s, "[]")
 	switch s {
-	case "int", "decimal", "float", "bool", "date", "timestamp", "interval", "string", "bytes":
+	case "int", "decimal", "float", "bool", "date", "timestamp", "interval", "string", "bytes",
+		"inet", "uuid", "collatedstring":
 		s = fmt.Sprintf("<a href=\"%s.html\">%s</a>", s, name)
 	}
 	return s


### PR DESCRIPTION
Markdown is a terrible markup format which is unable to process
markup inside table cells.

Instead pre-process each table cell as an individual Markdown
document and embed the resulting HTML in the output.

This patch incidentally also fixes hyperlinks for array arguments and
`collatedstring`.

Fixes #18647.