### PR TITLE
sql: Add TableDescriptor validation for duplicate indexes

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -689,7 +689,7 @@ func restoreTableDescs(
 		}
 
 		for _, table := range tables {
-			if err := table.Validate(ctx, txn); err != nil {
+			if err := table.Validate(ctx, txn, false /* newOrModifiedTable */); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -438,7 +438,7 @@ func (n *createViewNode) Start(params runParams) error {
 		return err
 	}
 
-	if err = desc.ValidateTable(); err != nil {
+	if err = desc.ValidateTable(true /* newOrModifiedTable */); err != nil {
 		return err
 	}
 
@@ -471,7 +471,7 @@ func (n *createViewNode) Start(params runParams) error {
 	if desc.Adding() {
 		n.p.notifySchemaChange(&desc, sqlbase.InvalidMutationID)
 	}
-	if err := desc.Validate(params.ctx, n.p.txn); err != nil {
+	if err := desc.Validate(params.ctx, n.p.txn, true /* newOrModifiedTable */); err != nil {
 		return err
 	}
 
@@ -633,7 +633,7 @@ func (n *createTableNode) Start(params runParams) error {
 	// We need to validate again after adding the FKs.
 	// Only validate the table because backreferences aren't created yet.
 	// Everything is validated below.
-	err = desc.ValidateTable()
+	err = desc.ValidateTable(true /* newOrModifiedTable */)
 	if err != nil {
 		return err
 	}
@@ -659,7 +659,7 @@ func (n *createTableNode) Start(params runParams) error {
 		}
 	}
 
-	if err := desc.Validate(params.ctx, params.p.txn); err != nil {
+	if err := desc.Validate(params.ctx, params.p.txn, true /* newOrModifiedTable */); err != nil {
 		return err
 	}
 
@@ -987,7 +987,7 @@ func (p *planner) saveNonmutationAndNotify(ctx context.Context, td *sqlbase.Tabl
 	if err := td.SetUpVersion(); err != nil {
 		return err
 	}
-	if err := td.ValidateTable(); err != nil {
+	if err := td.ValidateTable(true /* newOrModifiedTable */); err != nil {
 		return err
 	}
 	if err := p.writeTableDesc(ctx, td); err != nil {

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -206,7 +206,7 @@ func getDescriptorByID(
 		// but it's worth it to avoid having to do the upgrade every time the
 		// descriptor is fetched. Our current test for this enforces compatibility
 		// backward and forward, so that'll have to be extended before this is done.
-		if err := table.Validate(ctx, txn); err != nil {
+		if err := table.Validate(ctx, txn, false /* newOrModifiedTable */); err != nil {
 			return false, err
 		}
 		*t = *table

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -82,7 +82,7 @@ func (mt mutationTest) makeMutationsActive() {
 		}
 	}
 	mt.tableDesc.Mutations = nil
-	if err := mt.tableDesc.ValidateTable(); err != nil {
+	if err := mt.tableDesc.ValidateTable(true /* newOrModifiedTable */); err != nil {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
@@ -137,7 +137,7 @@ func (mt mutationTest) writeMutation(m sqlbase.DescriptorMutation) {
 		}
 	}
 	mt.tableDesc.Mutations = append(mt.tableDesc.Mutations, m)
-	if err := mt.tableDesc.ValidateTable(); err != nil {
+	if err := mt.tableDesc.ValidateTable(true /* newOrModifiedTable */); err != nil {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
@@ -342,21 +342,21 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, i CHAR DEFAULT 'i', FAMILY (k),
 	// Check that a mutation can only be inserted with an explicit mutation state, and direction.
 	tableDesc = mTest.tableDesc
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{}}
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, and no column/index descriptor") {
+	if err := tableDesc.ValidateTable(true /* newOrModifiedTable */); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, and no column/index descriptor") {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{Descriptor_: &sqlbase.DescriptorMutation_Column{Column: &tableDesc.Columns[len(tableDesc.Columns)-1]}}}
 	tableDesc.Columns = tableDesc.Columns[:len(tableDesc.Columns)-1]
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state UNKNOWN, direction NONE, col "i", id 3`) {
+	if err := tableDesc.ValidateTable(true /* newOrModifiedTable */); !testutils.IsError(err, `mutation in state UNKNOWN, direction NONE, col "i", id 3`) {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = sqlbase.DescriptorMutation_DELETE_ONLY
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state DELETE_ONLY, direction NONE, col "i", id 3`) {
+	if err := tableDesc.ValidateTable(true /* newOrModifiedTable */); !testutils.IsError(err, `mutation in state DELETE_ONLY, direction NONE, col "i", id 3`) {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = sqlbase.DescriptorMutation_UNKNOWN
 	tableDesc.Mutations[0].Direction = sqlbase.DescriptorMutation_DROP
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state UNKNOWN, direction DROP, col "i", id 3`) {
+	if err := tableDesc.ValidateTable(true /* newOrModifiedTable */); !testutils.IsError(err, `mutation in state UNKNOWN, direction DROP, col "i", id 3`) {
 		t.Fatal(err)
 	}
 }
@@ -519,7 +519,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v));
 	tableDesc = mTest.tableDesc
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{Descriptor_: &sqlbase.DescriptorMutation_Index{Index: &tableDesc.Indexes[len(tableDesc.Indexes)-1]}}}
 	tableDesc.Indexes = tableDesc.Indexes[:len(tableDesc.Indexes)-1]
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, index foo, id 2") {
+	if err := tableDesc.ValidateTable(true /* newOrModifiedTable */); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, index foo, id 2") {
 		t.Fatal(err)
 	}
 }

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -371,7 +371,7 @@ func (p *planner) dropIndexByName(
 		return fmt.Errorf("index %q in the middle of being added, try again later", idxName)
 	}
 
-	if err := tableDesc.Validate(ctx, p.txn); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, false /* newOrModifiedTable */); err != nil {
 		return err
 	}
 	mutationID, err := p.createSchemaChangeJob(ctx, tableDesc, jobDesc)

--- a/pkg/sql/grant.go
+++ b/pkg/sql/grant.go
@@ -48,7 +48,7 @@ func (p *planner) changePrivileges(
 				return nil, err
 			}
 		case *sqlbase.TableDescriptor:
-			if err := d.Validate(ctx, p.txn); err != nil {
+			if err := d.Validate(ctx, p.txn, false /* newOrModifiedTable */); err != nil {
 				return nil, err
 			}
 			if err := d.SetUpVersion(); err != nil {

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -160,7 +160,7 @@ func (s LeaseStore) acquire(
 
 		// ValidateTable instead of Validate, even though we have a txn available,
 		// so we don't block reads waiting for this table version.
-		if err := table.ValidateTable(); err != nil {
+		if err := table.ValidateTable(false /* newOrModifiedTable */); err != nil {
 			return err
 		}
 
@@ -340,7 +340,7 @@ func (s LeaseStore) Publish(
 			tableDesc.ModificationTime = modTime
 			log.Infof(ctx, "publish: descID=%d (%s) version=%d mtime=%s",
 				tableDesc.ID, tableDesc.Name, tableDesc.Version, modTime.GoTime())
-			if err := tableDesc.ValidateTable(); err != nil {
+			if err := tableDesc.ValidateTable(false /* newOrModifiedTable */); err != nil {
 				return err
 			}
 
@@ -1366,7 +1366,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 					case *sqlbase.Descriptor_Table:
 						table := union.Table
 						table.MaybeUpgradeFormatVersion()
-						if err := table.ValidateTable(); err != nil {
+						if err := table.ValidateTable(false /* newOrModifiedTable */); err != nil {
 							log.Errorf(ctx, "%s: received invalid table descriptor: %v", kv.Key, table)
 							continue
 						}

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -48,7 +48,7 @@ CREATE TABLE c (
   foo INT,
   bar INT,
   INDEX c_foo_idx (foo),
-  INDEX (foo),
+  INDEX (foo DESC),
   INDEX c_foo_bar_idx (foo ASC, bar DESC),
   UNIQUE (bar)
 )
@@ -60,7 +60,7 @@ Table  Name           Unique  Seq  Column  Direction  Storing  Implicit
 c      primary        true    1    id      ASC        false    false
 c      c_foo_idx      false   1    foo     ASC        false    false
 c      c_foo_idx      false   2    id      ASC        false    true
-c      c_foo_idx1     false   1    foo     ASC        false    false
+c      c_foo_idx1     false   1    foo     DESC       false    false
 c      c_foo_idx1     false   2    id      ASC        false    true
 c      c_foo_bar_idx  false   1    foo     ASC        false    false
 c      c_foo_bar_idx  false   2    bar     DESC       false    false

--- a/pkg/sql/rename.go
+++ b/pkg/sql/rename.go
@@ -200,7 +200,7 @@ func (p *planner) RenameTable(ctx context.Context, n *parser.RenameTable) (planN
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
 	newTbKey := tableKey{targetDbDesc.ID, newTn.Table()}.Key()
 
-	if err := tableDesc.Validate(ctx, p.txn); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, false /* newOrModifiedTable */); err != nil {
 		return nil, err
 	}
 
@@ -306,7 +306,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *parser.RenameIndex) (planN
 		return nil, err
 	}
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
-	if err := tableDesc.Validate(ctx, p.txn); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, false /* newOrModifiedTable */); err != nil {
 		return nil, err
 	}
 	if err := p.txn.Put(ctx, descKey, sqlbase.WrapDescriptor(tableDesc)); err != nil {
@@ -417,7 +417,7 @@ func (p *planner) RenameColumn(ctx context.Context, n *parser.RenameColumn) (pla
 	}
 
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
-	if err := tableDesc.Validate(ctx, p.txn); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, false /* newOrModifiedTable */); err != nil {
 		return nil, err
 	}
 	if err := p.txn.Put(ctx, descKey, sqlbase.WrapDescriptor(tableDesc)); err != nil {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1009,7 +1009,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					case *sqlbase.Descriptor_Table:
 						table := union.Table
 						table.MaybeUpgradeFormatVersion()
-						if err := table.ValidateTable(); err != nil {
+						if err := table.ValidateTable(false /* newOrModifiedTable */); err != nil {
 							log.Errorf(ctx, "%s: received invalid table descriptor: %v", kv.Key, table)
 							continue
 						}

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -528,6 +528,191 @@ func TestValidateTableDesc(t *testing.T) {
 				NextFamilyID: 1,
 				NextIndexID:  2,
 			}},
+		{`index "secondidx" is a duplicate index of index "primaryidx"`,
+			TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: FamilyFormatVersion,
+				Columns: []ColumnDescriptor{
+					{ID: 1, Name: "bar"},
+				},
+				Families: []ColumnFamilyDescriptor{
+					{ID: 0, Name: "primary", ColumnIDs: []ColumnID{1}, ColumnNames: []string{"bar"}},
+				},
+				PrimaryIndex: IndexDescriptor{ID: 1, Name: "primaryidx", ColumnIDs: []ColumnID{1},
+					ColumnNames:      []string{"bar"},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+				},
+				Indexes: []IndexDescriptor{
+					{ID: 2, Name: "secondidx", ColumnIDs: []ColumnID{1},
+						ColumnNames:      []string{"bar"},
+						ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+					},
+				},
+				NextColumnID: 2,
+				NextFamilyID: 1,
+				NextIndexID:  3,
+			}},
+		// Test no index error is thrown for indexes that are similar but with
+		// different directions.
+		// A privilege error is thrown, as we've gotten past the index checks.
+		{`user root does not have privileges`,
+			TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: FamilyFormatVersion,
+				Columns: []ColumnDescriptor{
+					{ID: 1, Name: "bar"},
+				},
+				Families: []ColumnFamilyDescriptor{
+					{ID: 0, Name: "primary", ColumnIDs: []ColumnID{1}, ColumnNames: []string{"bar"}},
+				},
+				PrimaryIndex: IndexDescriptor{ID: 1, Name: "primaryidx", ColumnIDs: []ColumnID{1},
+					ColumnNames:      []string{"bar"},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+				},
+				Indexes: []IndexDescriptor{
+					{ID: 2, Name: "secondidx", ColumnIDs: []ColumnID{1},
+						ColumnNames:      []string{"bar"},
+						ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_DESC},
+					},
+				},
+				NextColumnID: 2,
+				NextFamilyID: 1,
+				NextIndexID:  3,
+				Privileges:   &PrivilegeDescriptor{},
+			}},
+		// Test no index error is thrown for indexes that are similar but have
+		// different uniqueness.
+		// A privilege error is thrown, as we've gotten past the index checks.
+		{`user root does not have privileges`,
+			TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: FamilyFormatVersion,
+				Columns: []ColumnDescriptor{
+					{ID: 1, Name: "bar"},
+				},
+				Families: []ColumnFamilyDescriptor{
+					{ID: 0, Name: "primary", ColumnIDs: []ColumnID{1}, ColumnNames: []string{"bar"}},
+				},
+				PrimaryIndex: IndexDescriptor{ID: 1, Name: "primaryidx", ColumnIDs: []ColumnID{1},
+					ColumnNames:      []string{"bar"},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+				},
+				Indexes: []IndexDescriptor{
+					{ID: 2, Name: "secondidx", ColumnIDs: []ColumnID{1},
+						ColumnNames:      []string{"bar"},
+						ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_DESC},
+					},
+				},
+				NextColumnID: 2,
+				NextFamilyID: 1,
+				NextIndexID:  3,
+				Privileges:   &PrivilegeDescriptor{},
+			}},
+		// Test no index error is thrown for similar compound indexes where only
+		// some directions are the same.
+		// A privilege error is thrown, as we've gotten past the index checks.
+		{`user root does not have privileges`,
+			TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: FamilyFormatVersion,
+				Columns: []ColumnDescriptor{
+					{ID: 1, Name: "one"},
+					{ID: 2, Name: "two"},
+					{ID: 3, Name: "three"},
+				},
+				Families: []ColumnFamilyDescriptor{
+					{ID: 0, Name: "primary", ColumnIDs: []ColumnID{1, 2, 3}, ColumnNames: []string{"one", "two", "three"}},
+				},
+				PrimaryIndex: IndexDescriptor{ID: 1, Name: "primaryidx", ColumnIDs: []ColumnID{1},
+					ColumnNames:      []string{"one"},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+				},
+				Indexes: []IndexDescriptor{
+					{ID: 2, Name: "foo", ColumnIDs: []ColumnID{1, 2, 3},
+						ColumnNames:      []string{"one", "two", "three"},
+						ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC, IndexDescriptor_DESC, IndexDescriptor_ASC},
+					},
+					{ID: 3, Name: "bar", ColumnIDs: []ColumnID{1, 2, 3},
+						ColumnNames:      []string{"one", "two", "three"},
+						ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC, IndexDescriptor_ASC, IndexDescriptor_ASC},
+					},
+				},
+				NextColumnID: 4,
+				NextFamilyID: 1,
+				NextIndexID:  4,
+				Privileges:   &PrivilegeDescriptor{},
+			}},
+		{`index "bar" is a duplicate index of index "foo"`,
+			TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: FamilyFormatVersion,
+				Columns: []ColumnDescriptor{
+					{ID: 1, Name: "one"},
+					{ID: 2, Name: "two"},
+					{ID: 3, Name: "three"},
+				},
+				Families: []ColumnFamilyDescriptor{
+					{ID: 0, Name: "primary", ColumnIDs: []ColumnID{1, 2, 3}, ColumnNames: []string{"one", "two", "three"}},
+				},
+				PrimaryIndex: IndexDescriptor{ID: 1, Name: "primaryidx", ColumnIDs: []ColumnID{1},
+					ColumnNames:      []string{"one"},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+				},
+				Indexes: []IndexDescriptor{
+					{ID: 2, Name: "foo", ColumnIDs: []ColumnID{1, 2, 3},
+						ColumnNames:      []string{"one", "two", "three"},
+						ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC, IndexDescriptor_ASC, IndexDescriptor_ASC},
+					},
+					{ID: 3, Name: "bar", ColumnIDs: []ColumnID{1, 2, 3},
+						ColumnNames:      []string{"one", "two", "three"},
+						ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC, IndexDescriptor_ASC, IndexDescriptor_ASC},
+					},
+				},
+				NextColumnID: 4,
+				NextFamilyID: 1,
+				NextIndexID:  4,
+			}},
+		{`index "bar" is a duplicate index of index "foo"`,
+			TableDescriptor{
+				ID:            2,
+				ParentID:      1,
+				Name:          "foo",
+				FormatVersion: FamilyFormatVersion,
+				Columns: []ColumnDescriptor{
+					{ID: 1, Name: "bar"},
+					{ID: 2, Name: "second"},
+				},
+				Families: []ColumnFamilyDescriptor{
+					{ID: 0, Name: "primary", ColumnIDs: []ColumnID{1, 2}, ColumnNames: []string{"bar", "second"}},
+				},
+				PrimaryIndex: IndexDescriptor{ID: 1, Name: "primaryidx", ColumnIDs: []ColumnID{1},
+					ColumnNames:      []string{"bar"},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+				},
+				Indexes: []IndexDescriptor{
+					{ID: 2, Name: "foo", ColumnIDs: []ColumnID{2},
+						ColumnNames:      []string{"second"},
+						ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+					},
+					{ID: 3, Name: "bar", ColumnIDs: []ColumnID{2},
+						ColumnNames:      []string{"second"},
+						ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+					},
+				},
+				NextColumnID: 3,
+				NextFamilyID: 1,
+				NextIndexID:  4,
+			}},
 		{`index "bar" column "bar" should have ID 1, but found ID 2`,
 			TableDescriptor{
 				ID:            2,
@@ -589,8 +774,10 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 	}
 	for i, d := range testData {
-		if err := d.desc.ValidateTable(); err == nil {
+		if err := d.desc.ValidateTable(true /* newOrModifiedTable */); err == nil && d.err != "" {
 			t.Errorf("%d: expected \"%s\", but found success: %+v", i, d.err, d.desc)
+		} else if d.err == "" {
+			t.Errorf("%d: expected no error, but found \"%+v\"", i, err)
 		} else if d.err != err.Error() {
 			t.Errorf("%d: expected \"%s\", but found \"%+v\"", i, d.err, err)
 		}

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -260,7 +260,7 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 	}
 	desc.PrimaryIndex = sqlbase.IndexDescriptor{}
 
-	err = desc.ValidateTable()
+	err = desc.ValidateTable(true /* newOrModifiedTable */)
 	if !testutils.IsError(err, sqlbase.ErrMissingPrimaryKey.Error()) {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
Previously we didn't check if an index was a duplicate when running
TableDescriptor.Validate.

This is now checked. NB: Adding this check will be a breaking change if
a duplicate index already exists, as an error will now be thrown.