### PR TITLE
sql: revert the default behavior of DROP DATABASE to CASCADE

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -161,7 +161,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
 	}
 
-	if _, err := sqlDB.Exec(`DROP DATABASE t`); !testutils.IsError(err,
+	if _, err := sqlDB.Exec(`DROP DATABASE t RESTRICT`); !testutils.IsError(err,
 		`database "t" is not empty`) {
 		t.Fatal(err)
 	}
@@ -285,7 +285,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
 	}
 
-	if _, err := sqlDB.Exec(`DROP DATABASE t`); !testutils.IsError(err,
+	if _, err := sqlDB.Exec(`DROP DATABASE t RESTRICT`); !testutils.IsError(err,
 		`database "t" is not empty`) {
 		t.Fatal(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -99,7 +99,7 @@ SELECT * FROM b.a
 7
 
 statement error database "b" is not empty
-DROP DATABASE b
+DROP DATABASE b RESTRICT
 
 statement ok
 DROP DATABASE b CASCADE

--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -16,7 +16,7 @@ test
 statement ok
 CREATE TABLE "foo-bar".t(x INT)
 
-statement error database.*is not empty and CASCADE was not specified
+statement error database.*is not empty and RESTRICT was specified
 DROP DATABASE "foo-bar" RESTRICT
 
 statement ok
@@ -225,3 +225,17 @@ test
 
 query error database "constraint_db" does not exist
 SELECT * FROM constraint_db.t1
+
+# Check that the default option is CASCADE, but that safe_updates blocks it
+
+statement ok
+CREATE DATABASE foo; CREATE TABLE foo.bar(x INT);
+
+statement ok
+SET sql_safe_updates = TRUE;
+
+statement error DROP DATABASE on non-empty database without explicit CASCADE
+DROP DATABASE foo
+
+statement ok
+SET sql_safe_updates = FALSE; DROP DATABASE foo


### PR DESCRIPTION
... because that's what DROP DATABASE does in postgres, and schema
migration tools expect it to work this way.

However, in order to avoid unpleasant surprises by user, make
DROP DATABASE *without* behavior specifier also error out
when the session variable `sql_safe_updates` is set. This is
the case e.g. in interactive shells by default. For example:

```
root@:26257/> drop database t;
pq: rejected: DROP DATABASE on non-empty database without explicit CASCADE (sql_safe_updates = true)
```

Fixes #19145.

cc @tlvenn @bdarnell 