### PR TITLE
ui: reducer and redux state file cleanup.

### DIFF
--- a/pkg/ui/src/redux/alerts.ts
+++ b/pkg/ui/src/redux/alerts.ts
@@ -11,7 +11,7 @@ import { ThunkAction } from "redux-thunk";
 
 import { LocalSetting } from "./localsettings";
 import {
-  saveUIData, VERSION_DISMISSED_KEY, loadUIData, isInFlight, UIDataSet,
+  saveUIData, VERSION_DISMISSED_KEY, loadUIData, isInFlight, UIDataState,
 } from "./uiData";
 import { refreshCluster, refreshNodes, refreshVersion, refreshHealth } from "./apiReducers";
 import { nodeStatusesSelector } from "./nodes";
@@ -237,7 +237,7 @@ export function alertDataSync(store: Store<AdminUIState>) {
 
   // Memoizers to prevent unnecessary dispatches of alertDataSync if store
   // hasn't changed in an interesting way.
-  let lastUIData: UIDataSet;
+  let lastUIData: UIDataState;
 
   return () => {
     const state: AdminUIState = store.getState();

--- a/pkg/ui/src/redux/apiReducers.ts
+++ b/pkg/ui/src/redux/apiReducers.ts
@@ -123,7 +123,7 @@ export interface APIReducersState {
   commandQueue: CachedDataReducerState<api.CommandQueueResponseMessage>;
 }
 
-export default combineReducers<APIReducersState>({
+export const apiReducersReducer = combineReducers<APIReducersState>({
   [clusterReducerObj.actionNamespace]: clusterReducerObj.reducer,
   [eventsReducerObj.actionNamespace]: eventsReducerObj.reducer,
   [healthReducerObj.actionNamespace]: healthReducerObj.reducer,

--- a/pkg/ui/src/redux/localsettings.spec.ts
+++ b/pkg/ui/src/redux/localsettings.spec.ts
@@ -1,6 +1,7 @@
 import { Action } from "redux";
-import reducer, {
-  LocalSettingData, LocalSetting, setLocalSetting, LocalSettingsState,
+import {
+  LocalSettingData, LocalSetting, setLocalSetting,
+  LocalSettingsState, localSettingsReducer,
 } from "./localsettings";
 import { assert } from "chai";
 
@@ -22,7 +23,7 @@ describe("Local Settings", function() {
   describe("reducer", function() {
     it("should have the correct default value.", function() {
       assert.deepEqual(
-        reducer(undefined, { type: "unknown" }),
+        localSettingsReducer(undefined, { type: "unknown" }),
         {},
       );
     });
@@ -34,12 +35,12 @@ describe("Local Settings", function() {
         const expected: LocalSettingsState = {
           [key]: value,
         };
-        let actual = reducer(undefined, setLocalSetting(key, value));
+        let actual = localSettingsReducer(undefined, setLocalSetting(key, value));
         assert.deepEqual(actual, expected);
 
         const key2 = "another-setting";
         expected[key2] = value;
-        actual = reducer(actual, setLocalSetting(key2, value));
+        actual = localSettingsReducer(actual, setLocalSetting(key2, value));
         assert.deepEqual(actual, expected);
       });
 
@@ -53,7 +54,7 @@ describe("Local Settings", function() {
           [key]: "oldvalue",
         };
         assert.deepEqual(
-          reducer(initial, setLocalSetting(key, value)),
+          localSettingsReducer(initial, setLocalSetting(key, value)),
           expected,
         );
       });
@@ -64,7 +65,7 @@ describe("Local Settings", function() {
     let topLevelState: { localSettings: LocalSettingsState};
     const dispatch = function(action: Action) {
       topLevelState = {
-        localSettings: reducer(topLevelState.localSettings, action),
+        localSettings: localSettingsReducer(topLevelState.localSettings, action),
       };
     };
 

--- a/pkg/ui/src/redux/localsettings.spec.ts
+++ b/pkg/ui/src/redux/localsettings.spec.ts
@@ -1,6 +1,6 @@
 import { Action } from "redux";
 import reducer, {
-  LocalSettingData, LocalSetting, setLocalSetting, LocalSettingsDict,
+  LocalSettingData, LocalSetting, setLocalSetting, LocalSettingsState,
 } from "./localsettings";
 import { assert } from "chai";
 
@@ -31,7 +31,7 @@ describe("Local Settings", function() {
       it("should correctly set UI values by key.", function() {
         const key = "test-setting";
         const value = "test-value";
-        const expected: LocalSettingsDict = {
+        const expected: LocalSettingsState = {
           [key]: value,
         };
         let actual = reducer(undefined, setLocalSetting(key, value));
@@ -46,10 +46,10 @@ describe("Local Settings", function() {
       it("should correctly overwrite previous values.", function() {
         const key = "test-setting";
         const value = "test-value";
-        const expected: LocalSettingsDict = {
+        const expected: LocalSettingsState = {
           [key]: value,
         };
-        const initial: LocalSettingsDict = {
+        const initial: LocalSettingsState = {
           [key]: "oldvalue",
         };
         assert.deepEqual(
@@ -61,7 +61,7 @@ describe("Local Settings", function() {
   });
 
   describe("LocalSetting helper class", function() {
-    let topLevelState: { localSettings: LocalSettingsDict};
+    let topLevelState: { localSettings: LocalSettingsState};
     const dispatch = function(action: Action) {
       topLevelState = {
         localSettings: reducer(topLevelState.localSettings, action),

--- a/pkg/ui/src/redux/localsettings.ts
+++ b/pkg/ui/src/redux/localsettings.ts
@@ -24,14 +24,14 @@ export interface LocalSettingData {
 /**
  * Local settings are stored in a simple string-keyed dictionary.
  */
-export interface LocalSettingsDict {
+export interface LocalSettingsState {
   [key: string]: any;
 }
 
 /**
  * reducer function which handles local settings, storing them in a dictionary.
  */
-export default function reducer(state: LocalSettingsDict = {}, action: Action): LocalSettingsDict {
+export default function reducer(state: LocalSettingsState = {}, action: Action): LocalSettingsState {
   if (_.isNil(action)) {
     return state;
   }
@@ -77,7 +77,7 @@ export class LocalSetting<S, T> {
   }
 
   /**
-   * Selector which retrieves this setting from the LocalSettingsDict
+   * Selector which retrieves this setting from the LocalSettingsState
    * @param state The current top-level redux state of the application.
    */
   selector = (state: S) => {
@@ -87,12 +87,12 @@ export class LocalSetting<S, T> {
   /**
    * Construct a new LocalSetting manager.
    * @param key The unique key of the setting.
-   * @param innerSelector A selector which retrieves the LocalSettingsDict from
+   * @param innerSelector A selector which retrieves the LocalSettingsState from
    * the top-level redux state of the application.
    * @param defaultValue Optional default value of the setting when it has not
    * yet been set.
    */
-  constructor(public key: string, innerSelector: Selector<S, LocalSettingsDict>, defaultValue?: T) {
+  constructor(public key: string, innerSelector: Selector<S, LocalSettingsState>, defaultValue?: T) {
     this._value = createSelector(
       innerSelector,
       (uiSettings) => {

--- a/pkg/ui/src/redux/localsettings.ts
+++ b/pkg/ui/src/redux/localsettings.ts
@@ -31,7 +31,7 @@ export interface LocalSettingsState {
 /**
  * reducer function which handles local settings, storing them in a dictionary.
  */
-export default function reducer(state: LocalSettingsState = {}, action: Action): LocalSettingsState {
+export function localSettingsReducer(state: LocalSettingsState = {}, action: Action): LocalSettingsState {
   if (_.isNil(action)) {
     return state;
   }

--- a/pkg/ui/src/redux/metrics.spec.ts
+++ b/pkg/ui/src/redux/metrics.spec.ts
@@ -7,7 +7,6 @@ import fetchMock from "src/util/fetch-mock";
 import * as protos from "src/js/protos";
 import * as api from "src/util/api";
 import * as metrics from "./metrics";
-import reducer from "./metrics";
 
 type TSRequest = protos.cockroach.ts.tspb.TimeSeriesQueryRequest;
 
@@ -39,7 +38,7 @@ describe("metrics reducer", function() {
     let state: metrics.MetricQueryState;
 
     beforeEach(() => {
-      state = reducer(undefined, { type: "unknown" });
+      state = metrics.metricsReducer(undefined, { type: "unknown" });
     });
 
     it("should have the correct default value.", function() {
@@ -63,7 +62,7 @@ describe("metrics reducer", function() {
           },
         ],
       });
-      state = reducer(state, metrics.requestMetrics(componentID, request));
+      state = metrics.metricsReducer(state, metrics.requestMetrics(componentID, request));
       assert.isDefined(state.queries);
       assert.isDefined(state.queries[componentID]);
       assert.lengthOf(_.keys(state.queries), 1);
@@ -89,7 +88,7 @@ describe("metrics reducer", function() {
           },
         ],
       });
-      state = reducer(state, metrics.receiveMetrics(componentID, request, response));
+      state = metrics.metricsReducer(state, metrics.receiveMetrics(componentID, request, response));
       assert.isDefined(state.queries);
       assert.isDefined(state.queries[componentID]);
       assert.lengthOf(_.keys(state.queries), 1);
@@ -117,8 +116,8 @@ describe("metrics reducer", function() {
         ],
       });
       // populate nextRequest
-      state = reducer(state, metrics.requestMetrics(componentID, request));
-      state = reducer(state, metrics.receiveMetrics(componentID, request, response));
+      state = metrics.metricsReducer(state, metrics.requestMetrics(componentID, request));
+      state = metrics.metricsReducer(state, metrics.receiveMetrics(componentID, request, response));
       assert.isDefined(state.queries);
       assert.isDefined(state.queries[componentID]);
       assert.lengthOf(_.keys(state.queries), 1);
@@ -129,7 +128,7 @@ describe("metrics reducer", function() {
 
     it("should correctly dispatch errorMetrics", function() {
       const error: Error = new Error("An error occurred");
-      state = reducer(state, metrics.errorMetrics(componentID, error));
+      state = metrics.metricsReducer(state, metrics.errorMetrics(componentID, error));
       assert.isDefined(state.queries);
       assert.isDefined(state.queries[componentID]);
       assert.lengthOf(_.keys(state.queries), 1);
@@ -139,11 +138,11 @@ describe("metrics reducer", function() {
     });
 
     it("should correctly dispatch fetchMetrics and fetchMetricsComplete", function() {
-      state = reducer(state, metrics.fetchMetrics());
+      state = metrics.metricsReducer(state, metrics.fetchMetrics());
       assert.equal(state.inFlight, 1);
-      state = reducer(state, metrics.fetchMetrics());
+      state = metrics.metricsReducer(state, metrics.fetchMetrics());
       assert.equal(state.inFlight, 2);
-      state = reducer(state, metrics.fetchMetricsComplete());
+      state = metrics.metricsReducer(state, metrics.fetchMetricsComplete());
       assert.equal(state.inFlight, 1);
     });
   });
@@ -167,7 +166,7 @@ describe("metrics reducer", function() {
     // Mock of metrics state.
     let mockMetricsState: metrics.MetricQueryState;
     const mockDispatch = <A extends Action>(action: A): A => {
-      mockMetricsState = reducer(mockMetricsState, action);
+      mockMetricsState = metrics.metricsReducer(mockMetricsState, action);
       return undefined;
     };
     const queryMetrics = function(id: string, request: TSRequest): Promise<void> {

--- a/pkg/ui/src/redux/metrics.spec.ts
+++ b/pkg/ui/src/redux/metrics.spec.ts
@@ -35,7 +35,7 @@ describe("metrics reducer", function() {
 
   describe("reducer", function() {
     const componentID = "test-component";
-    let state: metrics.MetricQueryState;
+    let state: metrics.MetricsState;
 
     beforeEach(() => {
       state = metrics.metricsReducer(undefined, { type: "unknown" });
@@ -164,7 +164,7 @@ describe("metrics reducer", function() {
     };
 
     // Mock of metrics state.
-    let mockMetricsState: metrics.MetricQueryState;
+    let mockMetricsState: metrics.MetricsState;
     const mockDispatch = <A extends Action>(action: A): A => {
       mockMetricsState = metrics.metricsReducer(mockMetricsState, action);
       return undefined;

--- a/pkg/ui/src/redux/metrics.ts
+++ b/pkg/ui/src/redux/metrics.ts
@@ -144,7 +144,7 @@ export class MetricQueryState {
  * dispatching them based on ID. It also accepts actions which indicate the
  * state of the connection to the server.
  */
-export default function reducer(state: MetricQueryState = new MetricQueryState(), action: Action): MetricQueryState {
+export function metricsReducer(state: MetricQueryState = new MetricQueryState(), action: Action): MetricQueryState {
   switch (action.type) {
     // A new fetch request to the server is now in flight.
     case FETCH:

--- a/pkg/ui/src/redux/metrics.ts
+++ b/pkg/ui/src/redux/metrics.ts
@@ -129,10 +129,10 @@ export function metricQuerySetReducer(state: MetricQuerySet = {}, action: Action
 }
 
 /**
- * MetricQueryState maintains a MetricQuerySet collection, along with some
+ * MetricsState maintains a MetricQuerySet collection, along with some
  * metadata relevant to server queries.
  */
-export class MetricQueryState {
+export class MetricsState {
   // A count of the number of in-flight fetch requests.
   inFlight = 0;
   // The collection of MetricQuery objects.
@@ -144,7 +144,7 @@ export class MetricQueryState {
  * dispatching them based on ID. It also accepts actions which indicate the
  * state of the connection to the server.
  */
-export function metricsReducer(state: MetricQueryState = new MetricQueryState(), action: Action): MetricQueryState {
+export function metricsReducer(state: MetricsState = new MetricsState(), action: Action): MetricsState {
   switch (action.type) {
     // A new fetch request to the server is now in flight.
     case FETCH:

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -19,7 +19,7 @@ export interface AdminUIState {
     routing: RouterState;
     localSettings: localSettings.LocalSettingsState;
     uiData: uiData.UIDataState;
-    metrics: metrics.MetricQueryState;
+    metrics: metrics.MetricsState;
     timewindow: timewindow.TimeWindowState;
     cachedData: apiReducers.APIReducersState;
 }

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -18,7 +18,7 @@ import * as apiReducers from "./apiReducers";
 export interface AdminUIState {
     routing: RouterState;
     localSettings: localSettings.LocalSettingsState;
-    uiData: uiData.UIDataSet;
+    uiData: uiData.UIDataState;
     metrics: metrics.MetricQueryState;
     timewindow: timewindow.TimeWindowState;
     cachedData: apiReducers.APIReducersState;

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -4,15 +4,15 @@ import { hashHistory } from "react-router";
 import { syncHistoryWithStore, routerReducer, RouterState } from "react-router-redux";
 import thunk from "redux-thunk";
 
-import localSettingsReducer from "./localsettings";
+import { localSettingsReducer } from "./localsettings";
 import * as localSettings from "./localsettings";
-import uiDataReducer from "./uiData";
+import { uiDataReducer } from "./uiData";
 import * as uiData from "./uiData";
-import metricsReducer from "./metrics";
+import { metricsReducer } from "./metrics";
 import * as metrics from "./metrics";
-import timeWindowReducer from "./timewindow";
+import { timeWindowReducer } from "./timewindow";
 import * as timewindow from "./timewindow";
-import apiReducersReducer from "./apiReducers";
+import { apiReducersReducer } from "./apiReducers";
 import * as apiReducers from "./apiReducers";
 
 export interface AdminUIState {

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -17,7 +17,7 @@ import * as apiReducers from "./apiReducers";
 
 export interface AdminUIState {
     routing: RouterState;
-    localSettings: localSettings.LocalSettingsDict;
+    localSettings: localSettings.LocalSettingsState;
     uiData: uiData.UIDataSet;
     metrics: metrics.MetricQueryState;
     timewindow: timewindow.TimeWindowState;

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -1,34 +1,34 @@
 import _ from "lodash";
-import { createStore, combineReducers, applyMiddleware, compose, GenericStoreEnhancer } from "redux";
 import { hashHistory } from "react-router";
 import { syncHistoryWithStore, routerReducer, RouterState } from "react-router-redux";
+import { createStore, combineReducers, applyMiddleware, compose, GenericStoreEnhancer } from "redux";
 import thunk from "redux-thunk";
 
+import { apiReducersReducer, APIReducersState } from "./apiReducers";
 import { localSettingsReducer, LocalSettingsState } from "./localsettings";
-import { uiDataReducer, UIDataState } from "./uiData";
 import { metricsReducer, MetricsState } from "./metrics";
 import { timeWindowReducer, TimeWindowState } from "./timewindow";
-import { apiReducersReducer, APIReducersState } from "./apiReducers";
+import { uiDataReducer, UIDataState } from "./uiData";
 
 export interface AdminUIState {
-    routing: RouterState;
-    localSettings: LocalSettingsState;
-    uiData: UIDataState;
-    metrics: MetricsState;
-    timewindow: TimeWindowState;
     cachedData: APIReducersState;
+    localSettings: LocalSettingsState;
+    metrics: MetricsState;
+    routing: RouterState;
+    timewindow: TimeWindowState;
+    uiData: UIDataState;
 }
 
 // createAdminUIStore is a function that returns a new store for the admin UI.
 // It's in a function so it can be recreated as necessary for testing.
 export const createAdminUIStore = () => createStore(
   combineReducers<AdminUIState>({
-    routing: routerReducer,
-    localSettings: localSettingsReducer,
-    uiData: uiDataReducer,
-    metrics: metricsReducer,
-    timewindow: timeWindowReducer,
     cachedData: apiReducersReducer,
+    localSettings: localSettingsReducer,
+    metrics: metricsReducer,
+    routing: routerReducer,
+    timewindow: timeWindowReducer,
+    uiData: uiDataReducer,
   }),
   compose(
     applyMiddleware(thunk),

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -4,24 +4,19 @@ import { hashHistory } from "react-router";
 import { syncHistoryWithStore, routerReducer, RouterState } from "react-router-redux";
 import thunk from "redux-thunk";
 
-import { localSettingsReducer } from "./localsettings";
-import * as localSettings from "./localsettings";
-import { uiDataReducer } from "./uiData";
-import * as uiData from "./uiData";
-import { metricsReducer } from "./metrics";
-import * as metrics from "./metrics";
-import { timeWindowReducer } from "./timewindow";
-import * as timewindow from "./timewindow";
-import { apiReducersReducer } from "./apiReducers";
-import * as apiReducers from "./apiReducers";
+import { localSettingsReducer, LocalSettingsState } from "./localsettings";
+import { uiDataReducer, UIDataState } from "./uiData";
+import { metricsReducer, MetricsState } from "./metrics";
+import { timeWindowReducer, TimeWindowState } from "./timewindow";
+import { apiReducersReducer, APIReducersState } from "./apiReducers";
 
 export interface AdminUIState {
     routing: RouterState;
-    localSettings: localSettings.LocalSettingsState;
-    uiData: uiData.UIDataState;
-    metrics: metrics.MetricsState;
-    timewindow: timewindow.TimeWindowState;
-    cachedData: apiReducers.APIReducersState;
+    localSettings: LocalSettingsState;
+    uiData: UIDataState;
+    metrics: MetricsState;
+    timewindow: TimeWindowState;
+    cachedData: APIReducersState;
 }
 
 // createAdminUIStore is a function that returns a new store for the admin UI.

--- a/pkg/ui/src/redux/timewindow.spec.ts
+++ b/pkg/ui/src/redux/timewindow.spec.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import reducer, * as timewindow from "./timewindow";
+import * as timewindow from "./timewindow";
 import moment from "moment";
 
 describe("time window reducer", function() {
@@ -35,7 +35,7 @@ describe("time window reducer", function() {
   describe("reducer", () => {
     it("should have the correct default value.", () => {
       assert.deepEqual(
-        reducer(undefined, { type: "unknown" }),
+        timewindow.timeWindowReducer(undefined, { type: "unknown" }),
         new timewindow.TimeWindowState(),
       );
       assert.deepEqual(
@@ -55,7 +55,7 @@ describe("time window reducer", function() {
         };
         expected.scaleChanged = false;
         assert.deepEqual(
-          reducer(undefined, timewindow.setTimeWindow({ start, end })),
+          timewindow.timeWindowReducer(undefined, timewindow.setTimeWindow({ start, end })),
           expected,
         );
       });
@@ -74,7 +74,7 @@ describe("time window reducer", function() {
         };
         expected.scaleChanged = true;
         assert.deepEqual(
-          reducer(undefined, timewindow.setTimeScale({
+          timewindow.timeWindowReducer(undefined, timewindow.setTimeScale({
             windowSize: newSize,
             windowValid: newValid,
             sampleSize: newSample,

--- a/pkg/ui/src/redux/timewindow.ts
+++ b/pkg/ui/src/redux/timewindow.ts
@@ -105,7 +105,7 @@ export class TimeWindowState {
   }
 }
 
-export default function(state = new TimeWindowState(), action: Action): TimeWindowState {
+export function timeWindowReducer(state = new TimeWindowState(), action: Action): TimeWindowState {
   switch (action.type) {
     case SET_WINDOW:
       const { payload: tw } = action as PayloadAction<TimeWindow>;

--- a/pkg/ui/src/redux/uiData.spec.ts
+++ b/pkg/ui/src/redux/uiData.spec.ts
@@ -195,7 +195,7 @@ describe("UIData reducer", function() {
   });
 
   describe("reducer", function() {
-    let state: uidata.UIDataSet;
+    let state: uidata.UIDataState;
 
     beforeEach(function () {
       state = reducer(undefined, { type: "unknown" });
@@ -229,18 +229,18 @@ describe("UIData reducer", function() {
 
       assert.lengthOf(_.keys(state), 3);
       assert.equal(state[objKey].data, obj);
-      assert.equal(state[objKey].state, uidata.UIDataState.VALID);
+      assert.equal(state[objKey].status, uidata.UIDataStatus.VALID);
       assert.equal(state[boolKey].data, bool);
-      assert.equal(state[boolKey].state, uidata.UIDataState.VALID);
+      assert.equal(state[boolKey].status, uidata.UIDataStatus.VALID);
       assert.equal(state[numKey].data, num);
-      assert.equal(state[numKey].state, uidata.UIDataState.VALID);
+      assert.equal(state[numKey].status, uidata.UIDataStatus.VALID);
 
       // validate overwrite.
       const obj2 = { value: 2 };
       dispatch(uidata.setUIDataKey(objKey, obj2));
       assert.lengthOf(_.keys(state), 3);
       assert.equal(state[objKey].data, obj2);
-      assert.equal(state[objKey].state, uidata.UIDataState.VALID);
+      assert.equal(state[objKey].status, uidata.UIDataStatus.VALID);
     });
 
     it("should correctly dispatch loadErrorUIData.", function () {
@@ -248,11 +248,11 @@ describe("UIData reducer", function() {
       const err = new Error("an error.");
       assert.isUndefined(state[key1]);
       dispatch(uidata.loadErrorUIData(key1, err));
-      assert.equal(state[key1].state, uidata.UIDataState.LOAD_ERROR);
+      assert.equal(state[key1].status, uidata.UIDataStatus.LOAD_ERROR);
       assert.equal(state[key1].error, err);
 
       dispatch(uidata.setUIDataKey(key1, 4));
-      assert.equal(state[key1].state, uidata.UIDataState.VALID);
+      assert.equal(state[key1].status, uidata.UIDataStatus.VALID);
       assert.isNull(state[key1].error);
     });
 
@@ -261,11 +261,11 @@ describe("UIData reducer", function() {
       const err = new Error("an error.");
       assert.isUndefined(state[key1]);
       dispatch(uidata.saveErrorUIData(key1, err));
-      assert.equal(state[key1].state, uidata.UIDataState.SAVE_ERROR);
+      assert.equal(state[key1].status, uidata.UIDataStatus.SAVE_ERROR);
       assert.equal(state[key1].error, err);
 
       dispatch(uidata.setUIDataKey(key1, 4));
-      assert.equal(state[key1].state, uidata.UIDataState.VALID);
+      assert.equal(state[key1].status, uidata.UIDataStatus.VALID);
       assert.isNull(state[key1].error);
     });
 
@@ -275,12 +275,12 @@ describe("UIData reducer", function() {
       const keys = [key1, key2];
       dispatch(uidata.beginSaveUIData(keys));
       assert.lengthOf(_.keys(state), 2);
-      assert.equal(state[key1].state, uidata.UIDataState.SAVING);
-      assert.equal(state[key2].state, uidata.UIDataState.SAVING);
+      assert.equal(state[key1].status, uidata.UIDataStatus.SAVING);
+      assert.equal(state[key2].status, uidata.UIDataStatus.SAVING);
       dispatch(uidata.setUIDataKey(key1, "value1"));
       dispatch(uidata.setUIDataKey(key2, "value2"));
-      assert.equal(state[key1].state, uidata.UIDataState.VALID);
-      assert.equal(state[key2].state, uidata.UIDataState.VALID);
+      assert.equal(state[key1].status, uidata.UIDataStatus.VALID);
+      assert.equal(state[key2].status, uidata.UIDataStatus.VALID);
     });
 
     it("should correctly dispatch beginLoadUIData", function () {
@@ -289,17 +289,17 @@ describe("UIData reducer", function() {
       const keys = [key1, key2];
       dispatch(uidata.beginLoadUIData(keys));
       assert.lengthOf(_.keys(state), 2);
-      assert.equal(state[key1].state, uidata.UIDataState.LOADING);
-      assert.equal(state[key2].state, uidata.UIDataState.LOADING);
+      assert.equal(state[key1].status, uidata.UIDataStatus.LOADING);
+      assert.equal(state[key2].status, uidata.UIDataStatus.LOADING);
       dispatch(uidata.setUIDataKey(key1, "value1"));
       dispatch(uidata.setUIDataKey(key2, "value2"));
-      assert.equal(state[key1].state, uidata.UIDataState.VALID);
-      assert.equal(state[key2].state, uidata.UIDataState.VALID);
+      assert.equal(state[key1].status, uidata.UIDataStatus.VALID);
+      assert.equal(state[key2].status, uidata.UIDataStatus.VALID);
     });
   });
 
   describe("asynchronous actions", function() {
-    let state: uidata.UIDataSet;
+    let state: uidata.UIDataState;
 
     const dispatch = (action: Action) => {
       state = reducer(state, action);
@@ -333,8 +333,8 @@ describe("UIData reducer", function() {
         matcher: `${api.API_PREFIX}/uidata`,
         method: "POST",
         response: (_url: string, requestObj: RequestInit) => {
-          assert.equal(state[uiKey1].state, uidata.UIDataState.SAVING);
-          assert.equal(state[uiKey2].state, uidata.UIDataState.SAVING);
+          assert.equal(state[uiKey1].status, uidata.UIDataStatus.SAVING);
+          assert.equal(state[uiKey2].status, uidata.UIDataStatus.SAVING);
 
           const kvs = protos.cockroach.server.serverpb.SetUIDataRequest.decode(new Uint8Array(requestObj.body as ArrayBuffer)).key_values;
 
@@ -372,8 +372,8 @@ describe("UIData reducer", function() {
         assert.equal(state[uiKey2].data, uiObj2);
         assert.isNull(state[uiKey1].error);
         assert.isNull(state[uiKey2].error);
-        assert.equal(state[uiKey1].state, uidata.UIDataState.VALID);
-        assert.equal(state[uiKey2].state, uidata.UIDataState.VALID);
+        assert.equal(state[uiKey1].status, uidata.UIDataStatus.VALID);
+        assert.equal(state[uiKey2].status, uidata.UIDataStatus.VALID);
       });
     });
 
@@ -395,8 +395,8 @@ describe("UIData reducer", function() {
       p.then(() => {
         assert.lengthOf(fetchMock.calls(`${api.API_PREFIX}/uidata`), 1);
         assert.lengthOf(_.keys(state), 2);
-        assert.equal(state[uiKey1].state, uidata.UIDataState.SAVING);
-        assert.equal(state[uiKey2].state, uidata.UIDataState.SAVING);
+        assert.equal(state[uiKey1].status, uidata.UIDataStatus.SAVING);
+        assert.equal(state[uiKey2].status, uidata.UIDataStatus.SAVING);
         assert.isUndefined(state[uiKey1].data);
         assert.isUndefined(state[uiKey2].data);
         assert.notProperty(state[uiKey1], "data");
@@ -405,8 +405,8 @@ describe("UIData reducer", function() {
         assert.isUndefined(state[uiKey2].error);
         setTimeout(
           () => {
-            assert.equal(state[uiKey1].state, uidata.UIDataState.SAVE_ERROR);
-            assert.equal(state[uiKey2].state, uidata.UIDataState.SAVE_ERROR);
+            assert.equal(state[uiKey1].status, uidata.UIDataStatus.SAVE_ERROR);
+            assert.equal(state[uiKey2].status, uidata.UIDataStatus.SAVE_ERROR);
             assert.instanceOf(state[uiKey1].error, Error);
             assert.instanceOf(state[uiKey2].error, Error);
             done();
@@ -425,8 +425,8 @@ describe("UIData reducer", function() {
         response: () => {
           // FetchMock URL must match the above string exactly, requesting both
           // keys.
-          assert.equal(state[uiKey1].state, uidata.UIDataState.LOADING);
-          assert.equal(state[uiKey2].state, uidata.UIDataState.LOADING);
+          assert.equal(state[uiKey1].status, uidata.UIDataStatus.LOADING);
+          assert.equal(state[uiKey2].status, uidata.UIDataStatus.LOADING);
 
           const response: protos.cockroach.server.serverpb.GetUIDataResponse$Properties = {
             key_values: {},
@@ -457,8 +457,8 @@ describe("UIData reducer", function() {
         assert.deepEqual(state[uiKey2].data, uiObj2);
         assert.isNull(state[uiKey1].error);
         assert.isNull(state[uiKey2].error);
-        assert.equal(state[uiKey1].state, uidata.UIDataState.VALID);
-        assert.equal(state[uiKey2].state, uidata.UIDataState.VALID);
+        assert.equal(state[uiKey1].status, uidata.UIDataStatus.VALID);
+        assert.equal(state[uiKey2].status, uidata.UIDataStatus.VALID);
       });
     });
 
@@ -479,8 +479,8 @@ describe("UIData reducer", function() {
       p.then(() => {
         assert.lengthOf(fetchMock.calls(uidataPrefixMatcher), 1);
         assert.lengthOf(_.keys(state), 2);
-        assert.equal(state[uiKey1].state, uidata.UIDataState.LOADING);
-        assert.equal(state[uiKey2].state, uidata.UIDataState.LOADING);
+        assert.equal(state[uiKey1].status, uidata.UIDataStatus.LOADING);
+        assert.equal(state[uiKey2].status, uidata.UIDataStatus.LOADING);
         assert.isUndefined(state[uiKey1].data);
         assert.isUndefined(state[uiKey2].data);
         assert.notProperty(state[uiKey1], "data");
@@ -489,8 +489,8 @@ describe("UIData reducer", function() {
         assert.isUndefined(state[uiKey2].error);
         setTimeout(
           () => {
-            assert.equal(state[uiKey1].state, uidata.UIDataState.LOAD_ERROR);
-            assert.equal(state[uiKey2].state, uidata.UIDataState.LOAD_ERROR);
+            assert.equal(state[uiKey1].status, uidata.UIDataStatus.LOAD_ERROR);
+            assert.equal(state[uiKey2].status, uidata.UIDataStatus.LOAD_ERROR);
             assert.instanceOf(state[uiKey1].error, Error);
             assert.instanceOf(state[uiKey2].error, Error);
             done();
@@ -508,7 +508,7 @@ describe("UIData reducer", function() {
       fetchMock.mock({
         matcher: expectedURL,
         response: () => {
-          assert.equal(state[missingKey].state, uidata.UIDataState.LOADING);
+          assert.equal(state[missingKey].status, uidata.UIDataStatus.LOADING);
 
           const encodedResponse = protos.cockroach.server.serverpb.GetUIDataResponse.encode({}).finish();
           return {
@@ -524,7 +524,7 @@ describe("UIData reducer", function() {
         assert.lengthOf(_.keys(state), 1);
         assert.equal(state[missingKey].data, undefined);
         assert.property(state[missingKey], "data");
-        assert.equal(state[missingKey].state, uidata.UIDataState.VALID);
+        assert.equal(state[missingKey].status, uidata.UIDataStatus.VALID);
         assert.isNull(state[missingKey].error);
       });
     });

--- a/pkg/ui/src/redux/uiData.spec.ts
+++ b/pkg/ui/src/redux/uiData.spec.ts
@@ -6,7 +6,6 @@ import fetchMock from "src/util/fetch-mock";
 
 import * as protos from "src/js/protos";
 import * as api from "src/util/api";
-import reducer from "./uiData";
 import * as uidata from "./uiData";
 
 describe("UIData reducer", function() {
@@ -36,11 +35,11 @@ describe("UIData reducer", function() {
     let state: any;
 
     beforeEach(function () {
-      state = { uiData: reducer(undefined, { type: "unknown" }) };
+      state = { uiData: uidata.uiDataReducer(undefined, { type: "unknown" }) };
     });
 
     const dispatch = (action: Action) => {
-      state = { uiData: reducer(state.uiData, action) };
+      state = { uiData: uidata.uiDataReducer(state.uiData, action) };
     };
 
     it("isValid", function () {
@@ -198,11 +197,11 @@ describe("UIData reducer", function() {
     let state: uidata.UIDataState;
 
     beforeEach(function () {
-      state = reducer(undefined, { type: "unknown" });
+      state = uidata.uiDataReducer(undefined, { type: "unknown" });
     });
 
     const dispatch = (action: Action) => {
-      state = reducer(state, action);
+      state = uidata.uiDataReducer(state, action);
     };
 
     it("should have the correct default value.", function() {
@@ -302,7 +301,7 @@ describe("UIData reducer", function() {
     let state: uidata.UIDataState;
 
     const dispatch = (action: Action) => {
-      state = reducer(state, action);
+      state = uidata.uiDataReducer(state, action);
     };
 
     const uiKey1 = "a_key";
@@ -323,7 +322,7 @@ describe("UIData reducer", function() {
     };
 
     beforeEach(function () {
-      state = reducer(undefined, { type: "unknown" });
+      state = uidata.uiDataReducer(undefined, { type: "unknown" });
     });
 
     afterEach(fetchMock.restore);

--- a/pkg/ui/src/redux/uiData.ts
+++ b/pkg/ui/src/redux/uiData.ts
@@ -45,7 +45,7 @@ export class OptInAttributes {
 // VERSION_DISMISSED_KEY is the uiData key on the server that tracks when the outdated banner was last dismissed.
 export const VERSION_DISMISSED_KEY = "version_dismissed";
 
-export enum UIDataState {
+export enum UIDataStatus {
   UNINITIALIZED, // Data has not been loaded yet.
   LOADING,
   LOADING_LOAD_ERROR, // Loading with an existing load error
@@ -56,24 +56,24 @@ export enum UIDataState {
 }
 
 export class UIData {
-  state: UIDataState = UIDataState.UNINITIALIZED;
+  status: UIDataStatus = UIDataStatus.UNINITIALIZED;
   error: Error;
   data: any;
 }
 
 /**
- * UIDataSet maintains the current values of fields that are persisted to the
+ * UIDataState maintains the current values of fields that are persisted to the
  * server as UIData. Fields are maintained in this collection as untyped
  * objects.
  */
-export class UIDataSet {
+export class UIDataState {
   [key: string]: UIData;
 }
 
 /**
- * Reducer which modifies a UIDataSet.
+ * Reducer which modifies a UIDataState.
  */
-export default function (state = new UIDataSet(), action: Action): UIDataSet {
+export default function (state = new UIDataState(), action: Action): UIDataState {
   if (_.isNil(action)) {
     return state;
   }
@@ -83,7 +83,7 @@ export default function (state = new UIDataSet(), action: Action): UIDataSet {
       const { key, value } = (action as PayloadAction<KeyValue>).payload;
       state = _.clone(state);
       state[key] = _.clone(state[key]) || new UIData();
-      state[key].state = UIDataState.VALID;
+      state[key].status = UIDataStatus.VALID;
       state[key].data = value;
       state[key].error = null;
       return state;
@@ -93,7 +93,7 @@ export default function (state = new UIDataSet(), action: Action): UIDataSet {
       state = _.clone(state);
       _.each(keys, (k) => {
         state[k] = _.clone(state[k]) || new UIData();
-        state[k].state = UIDataState.SAVING;
+        state[k].status = UIDataStatus.SAVING;
       });
       return state;
     }
@@ -104,7 +104,7 @@ export default function (state = new UIDataSet(), action: Action): UIDataSet {
       const { key: saveErrorKey, error: saveError } = (action as PayloadAction<KeyedError>).payload;
       state = _.clone(state);
       state[saveErrorKey] = _.clone(state[saveErrorKey]) || new UIData();
-      state[saveErrorKey].state = UIDataState.SAVE_ERROR;
+      state[saveErrorKey].status = UIDataStatus.SAVE_ERROR;
       state[saveErrorKey].error = saveError;
       return state;
     }
@@ -113,7 +113,7 @@ export default function (state = new UIDataSet(), action: Action): UIDataSet {
       state = _.clone(state);
       _.each(keys, (k) => {
         state[k] = _.clone(state[k]) || new UIData();
-        state[k].state = UIDataState.LOADING;
+        state[k].status = UIDataStatus.LOADING;
       });
       return state;
     }
@@ -124,7 +124,7 @@ export default function (state = new UIDataSet(), action: Action): UIDataSet {
       const { key: loadErrorKey, error: loadError } = (action as PayloadAction<KeyedError>).payload;
       state = _.clone(state);
       state[loadErrorKey] = _.clone(state[loadErrorKey]) || new UIData();
-      state[loadErrorKey].state = UIDataState.LOAD_ERROR;
+      state[loadErrorKey].status = UIDataStatus.LOAD_ERROR;
       state[loadErrorKey].error = loadError;
       return state;
     }
@@ -205,7 +205,7 @@ export interface KeyedError {
 
 // Returns true if the key exists and the data is valid.
 export function isValid(state: AdminUIState, key: string) {
-  return state.uiData[key] && (state.uiData[key].state === UIDataState.VALID) || false;
+  return state.uiData[key] && (state.uiData[key].status === UIDataStatus.VALID) || false;
 }
 
 // Returns contents of the data field if the key is valid, undefined otherwise.
@@ -215,35 +215,35 @@ export function getData(state: AdminUIState, key: string) {
 
 // Returns true if the given key exists and is in the SAVING state.
 export function isSaving(state: AdminUIState, key: string) {
-  return state.uiData[key] && (state.uiData[key].state === UIDataState.SAVING) || false;
+  return state.uiData[key] && (state.uiData[key].status === UIDataStatus.SAVING) || false;
 }
 
 // Returns true if the given key exists and is in the SAVING state.
 export function isLoading(state: AdminUIState, key: string) {
-  return state.uiData[key] && (state.uiData[key].state === UIDataState.LOADING) || false;
+  return state.uiData[key] && (state.uiData[key].status === UIDataStatus.LOADING) || false;
 }
 
 // Returns true if the key exists and is in either the SAVING or LOADING state.
 export function isInFlight(state: AdminUIState, key: string) {
-  return state.uiData[key] && ((state.uiData[key].state === UIDataState.SAVING) || (state.uiData[key].state === UIDataState.LOADING)) || false;
+  return state.uiData[key] && ((state.uiData[key].status === UIDataStatus.SAVING) || (state.uiData[key].status === UIDataStatus.LOADING)) || false;
 }
 
 // Returns the error field if the key exists and is in the SAVE_ERROR state.
 // Returns null otherwise.
 export function getSaveError(state: AdminUIState, key: string): Error {
-  return (state.uiData[key] && (state.uiData[key].state === UIDataState.SAVE_ERROR || state.uiData[key].state === UIDataState.SAVING)) ? state.uiData[key].error : null;
+  return (state.uiData[key] && (state.uiData[key].status === UIDataStatus.SAVE_ERROR || state.uiData[key].status === UIDataStatus.SAVING)) ? state.uiData[key].error : null;
 }
 
 // Returns the error field if the key exists and is in the LOAD_ERROR state.
 // Returns null otherwise.
 export function getLoadError(state: AdminUIState, key: string): Error {
-  return (state.uiData[key] && (state.uiData[key].state === UIDataState.LOAD_ERROR || state.uiData[key].state === UIDataState.LOADING)) ? state.uiData[key].error : null;
+  return (state.uiData[key] && (state.uiData[key].status === UIDataStatus.LOAD_ERROR || state.uiData[key].status === UIDataStatus.LOADING)) ? state.uiData[key].error : null;
 }
 
 /**
  * saveUIData saves the value one (or more) UIData objects to the server. After
  * the values have been successfully persisted to the server, they are updated
- * in the local UIDataSet store.
+ * in the local UIDataState store.
  */
 export function saveUIData(...values: KeyValue[]) {
   return (dispatch: Dispatch<AdminUIState>, getState: () => AdminUIState): Promise<void> => {

--- a/pkg/ui/src/redux/uiData.ts
+++ b/pkg/ui/src/redux/uiData.ts
@@ -73,7 +73,7 @@ export class UIDataState {
 /**
  * Reducer which modifies a UIDataState.
  */
-export default function (state = new UIDataState(), action: Action): UIDataState {
+export function uiDataReducer(state = new UIDataState(), action: Action): UIDataState {
   if (_.isNil(action)) {
     return state;
   }


### PR DESCRIPTION
This is a few little renames/export changes to the reducers to try to make everything nice and consistent.  I'm happy to bikeshed the details, getting them consistent and not using a default export are the goals.

I'm not a big fan of `apiReducersReducer`, but left it as-is for consistency.  I'm sure there's a better name for that one (maybe `cachedDataReducer` to match the state key?).