### PR TITLE
config: fix comment on ZoneConfig proto

### DIFF
--- a/pkg/config/config.pb.go
+++ b/pkg/config/config.pb.go
@@ -118,8 +118,7 @@ func (m *Constraints) String() string            { return proto.CompactTextStrin
 func (*Constraints) ProtoMessage()               {}
 func (*Constraints) Descriptor() ([]byte, []int) { return fileDescriptorConfig, []int{2} }
 
-// ZoneConfig holds configuration that is needed for a range of KV pairs. This
-// and the conversion methods must stay in sync with ZoneConfigHuman.
+// ZoneConfig holds configuration that applies to one or more ranges.
 type ZoneConfig struct {
 	// TODO(d4l3k): Remove replica_attrs after a sufficient amount of time has passed.
 	ReplicaAttrs  []cockroach_roachpb.Attributes `protobuf:"bytes,1,rep,name=replica_attrs,json=replicaAttrs" json:"replica_attrs" yaml:",omitempty"`

--- a/pkg/config/config.proto
+++ b/pkg/config/config.proto
@@ -58,8 +58,7 @@ message Constraints {
   repeated Constraint constraints = 6 [(gogoproto.nullable) = false];
 }
 
-// ZoneConfig holds configuration that is needed for a range of KV pairs. This
-// and the conversion methods must stay in sync with ZoneConfigHuman.
+// ZoneConfig holds configuration that applies to one or more ranges.
 message ZoneConfig {
   // TODO(d4l3k): Remove replica_attrs after a sufficient amount of time has passed.
   repeated roachpb.Attributes replica_attrs = 1 [deprecated = true, (gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\",omitempty\""];


### PR DESCRIPTION
`ZoneConfigHuman` is not and never was. (It was excised from the PR that
added the comment during code review.) Also take the opportunity to
clarify usage of the word "range."