### PR TITLE
sqlbase: fix comment about interleaved bookkeeping

### DIFF
--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -495,8 +495,8 @@ type InterleaveDescriptor_Ancestor struct {
 	// SharedPrefixLen is how many fields are shared between a parent and child
 	// being interleaved, excluding any fields shared between parent and
 	// grandparent. Thus, the sum of SharedPrefixLens in the components of an
-	// InterleaveDescriptor is always strictly less than the number of fields
-	// in the index being interleaved.
+	// InterleaveDescriptor is never more than the number of fields in the index
+	// being interleaved.
 	SharedPrefixLen uint32 `protobuf:"varint,3,opt,name=shared_prefix_len,json=sharedPrefixLen" json:"shared_prefix_len"`
 }
 

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -164,8 +164,8 @@ message InterleaveDescriptor {
     // SharedPrefixLen is how many fields are shared between a parent and child
     // being interleaved, excluding any fields shared between parent and
     // grandparent. Thus, the sum of SharedPrefixLens in the components of an
-    // InterleaveDescriptor is always strictly less than the number of fields
-    // in the index being interleaved.
+    // InterleaveDescriptor is never more than the number of fields in the index
+    // being interleaved.
     optional uint32 shared_prefix_len = 3 [(gogoproto.nullable) = false,
         (gogoproto.customname) = "SharedPrefixLen"];
   }


### PR DESCRIPTION
The sum of `SharedPrefixLens` is not strictly less than the components in
the index being interleaved, but less than or equal to. (E.g., a child
that interleaves all the fields in the parent index will have a
`SharedPrefixLen` equal to the number of fields in the index.)