### PR TITLE
kv: implement dist sender optimizations

### DIFF
--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -1043,15 +1043,15 @@ func TestBadRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := db.Scan(ctx, "a", "a", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
+	if _, err := db.Scan(ctx, "a", "a", 0); !testutils.IsError(err, "must be greater than start") {
 		t.Fatalf("unexpected error on scan with startkey == endkey: %v", err)
 	}
 
-	if _, err := db.ReverseScan(ctx, "a", "a", 0); !testutils.IsError(err, "truncation resulted in empty batch") {
+	if _, err := db.ReverseScan(ctx, "a", "a", 0); !testutils.IsError(err, "must be greater than start") {
 		t.Fatalf("unexpected error on reverse scan with startkey == endkey: %v", err)
 	}
 
-	if err := db.DelRange(ctx, "x", "a"); !testutils.IsError(err, "truncation resulted in empty batch") {
+	if err := db.DelRange(ctx, "x", "a"); !testutils.IsError(err, "must be greater than start") {
 		t.Fatalf("unexpected error on deletion on [x, a): %v", err)
 	}
 

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -46,20 +46,6 @@ func (n Node) Batch(
 	return &roachpb.BatchResponse{}, nil
 }
 
-func TestInvalidAddrLength(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	// The provided replicas is nil, so its length will be always less than the
-	// specified response number
-	ds := &DistSender{}
-	ret, err := ds.sendToReplicas(context.Background(), SendOptions{}, 0, nil, roachpb.BatchRequest{}, nil)
-
-	// the expected return is nil and SendError
-	if _, ok := err.(*roachpb.SendError); !ok || ret != nil {
-		t.Fatalf("Shorter replicas should return nil and SendError.")
-	}
-}
-
 // TestSendToOneClient verifies that Send correctly sends a request
 // to one server using the heartbeat RPC.
 func TestSendToOneClient(t *testing.T) {

--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -185,7 +185,16 @@ func (gt *grpcTransport) maybeResurrectRetryables() bool {
 func (gt *grpcTransport) SendNext(ctx context.Context, done chan<- BatchCall) {
 	client := gt.orderedClients[gt.clientIndex]
 	gt.clientIndex++
+
 	gt.setState(client.args.Replica, true /* pending */, false /* retryable */)
+
+	// Fast path for case of a single replica; don't set cancellation
+	// on context or launch in a goroutine.
+	if len(gt.orderedClients) == 1 {
+		reply, err := gt.send(ctx, client)
+		done <- BatchCall{Reply: reply, Err: err}
+		return
+	}
 
 	{
 		var cancel func()
@@ -199,54 +208,51 @@ func (gt *grpcTransport) SendNext(ctx context.Context, done chan<- BatchCall) {
 	gt.closeWG.Add(1)
 	go func() {
 		defer gt.closeWG.Done()
-		gt.opts.metrics.SentCount.Inc(1)
-		reply, err := func() (*roachpb.BatchResponse, error) {
-			if localServer := gt.rpcContext.GetLocalInternalServerForAddr(client.remoteAddr); localServer != nil {
-				log.VEvent(ctx, 2, "sending request to local server")
-
-				// Clone the request. At the time of writing, Replica may mutate it
-				// during command execution which can lead to data races.
-				//
-				// TODO(tamird): we should clone all of client.args.Header, but the
-				// assertions in protoutil.Clone fire and there seems to be no
-				// reasonable workaround.
-				origTxn := client.args.Txn
-				if origTxn != nil {
-					clonedTxn := origTxn.Clone()
-					client.args.Txn = &clonedTxn
-				}
-
-				// Create a new context from the existing one with the "local request" field set.
-				// This tells the handler that this is an in-procress request, bypassing ctx.Peer checks.
-				localCtx := grpcutil.NewLocalRequestContext(ctx)
-
-				gt.opts.metrics.LocalSentCount.Inc(1)
-				return localServer.Batch(localCtx, &client.args)
-			}
-
-			log.VEventf(ctx, 2, "sending request to %s", client.remoteAddr)
-			reply, err := client.client.Batch(ctx, &client.args)
-			if reply != nil {
-				for i := range reply.Responses {
-					if err := reply.Responses[i].GetInner().Verify(client.args.Requests[i].GetInner()); err != nil {
-						log.Error(ctx, err)
-					}
-				}
-			}
-			return reply, err
-		}()
-		// NotLeaseHolderErrors can be retried.
-		var retryable bool
-		if reply != nil && reply.Error != nil {
-			// TODO(spencer): pass the lease expiration when setting the state
-			// to set a more efficient deadline for retrying this replica.
-			if _, ok := reply.Error.GetDetail().(*roachpb.NotLeaseHolderError); ok {
-				retryable = true
-			}
-		}
-		gt.setState(client.args.Replica, false /* pending */, retryable)
+		reply, err := gt.send(ctx, client)
 		done <- BatchCall{Reply: reply, Err: err}
 	}()
+}
+
+func (gt *grpcTransport) send(
+	ctx context.Context, client batchClient,
+) (*roachpb.BatchResponse, error) {
+	reply, err := func() (*roachpb.BatchResponse, error) {
+		gt.opts.metrics.SentCount.Inc(1)
+		if localServer := gt.rpcContext.GetLocalInternalServerForAddr(client.remoteAddr); localServer != nil {
+			log.VEvent(ctx, 2, "sending request to local server")
+
+			// Create a new context from the existing one with the "local request" field set.
+			// This tells the handler that this is an in-procress request, bypassing ctx.Peer checks.
+			localCtx := grpcutil.NewLocalRequestContext(ctx)
+
+			gt.opts.metrics.LocalSentCount.Inc(1)
+			return localServer.Batch(localCtx, &client.args)
+		}
+
+		log.VEventf(ctx, 2, "sending request to %s", client.remoteAddr)
+		reply, err := client.client.Batch(ctx, &client.args)
+		if reply != nil {
+			for i := range reply.Responses {
+				if err := reply.Responses[i].GetInner().Verify(client.args.Requests[i].GetInner()); err != nil {
+					log.Error(ctx, err)
+				}
+			}
+		}
+		return reply, err
+	}()
+
+	// NotLeaseHolderErrors can be retried.
+	var retryable bool
+	if reply != nil && reply.Error != nil {
+		// TODO(spencer): pass the lease expiration when setting the state
+		// to set a more efficient deadline for retrying this replica.
+		if _, ok := reply.Error.GetDetail().(*roachpb.NotLeaseHolderError); ok {
+			retryable = true
+		}
+	}
+	gt.setState(client.args.Replica, false /* pending */, retryable)
+
+	return reply, err
 }
 
 func (gt *grpcTransport) NextReplica() roachpb.ReplicaDescriptor {

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -525,7 +525,7 @@ func TestTxnCoordSenderAddIntentOnError(t *testing.T) {
 	s, sender := createTestDB(t)
 	defer s.Stop()
 
-	// Create a transaction with intent at "a".
+	// Create a transaction with intent at "x".
 	key := roachpb.Key("x")
 	txn := client.NewTxn(s.DB, 0 /* gatewayNodeID */)
 	// Write so that the coordinator begins tracking this txn.

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -92,7 +92,7 @@ func TestAmbiguousCommit(t *testing.T) {
 						sendNext: func(ctx context.Context, done chan<- kv.BatchCall) {
 							if ambiguousSuccess {
 								interceptDone := make(chan kv.BatchCall)
-								transport.SendNext(ctx, interceptDone)
+								go transport.SendNext(ctx, interceptDone)
 								call := <-interceptDone
 								// During shutdown, we may get responses that
 								// have call.Err set and all we have to do is


### PR DESCRIPTION
- Fast path at start of `divideAndSendBatchToRanges` for case where
  all the key span is contained within a single range.
- Avoid batch truncation in fast path in `sendPartialBatch`.
- Fast path in `grpcTransport` for case of a single replica - send
  syncrhonously instead of via goroutine.
- Remove `DistSender.sendRPC`'s `context.WithCancel` as cancellation should
  properly be done in the transport, which is the component which understands
  if cancellation is necessary. gRPCTransport already has a cancellation
  mechanism, so we were doing this twice unnecessarily. In the case of the
  dist sender fast path (added to this commit) which prevents launching a
  goroutine in the event of a single replica, this means the transport can
  avoid starting any cancelable context.
- Remove unnecessary transaction clone from grpcTransport for local
  server case because after code audit, determined that there are no
  cases where `ba.Txn` is modified at `Store.Send` and below without
  first doing a similar shallow copy of `ba.Txn`.

I removed the shallow clone of the batch's transaction.  This is no
longer needed, based on a code audit. There is nowhere in the Store ->
Replica -> Raft evaluation path where we modify the batch's Txn
without first making a shallow copy of it.