### PR TITLE
storage: fix bug for the testrace of TestSystemZoneConfigs

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -526,7 +526,11 @@ func (a Allocator) RebalanceTarget(
 			StoreID:   target.store.StoreID,
 			ReplicaID: rangeInfo.Desc.NextReplicaID,
 		}
+
+		// Deep-copy the Replicas slice since we'll mutate it.
 		desc := *rangeInfo.Desc
+		desc.Replicas = append([]roachpb.ReplicaDescriptor(nil), desc.Replicas...)
+
 		desc.Replicas = append(desc.Replicas, newReplica)
 		rangeInfo.Desc = &desc
 


### PR DESCRIPTION
Fixes #19180. 
Fixes #19207.

@a-robinson. PLAT.

I have run `make testrace` for this test about 10 times, and it seems ok.

The main problem I think is when we try to update `desc.Replicas = append(desc.Replicas, newReplica)`, it will race with other goroutines, so I make a copy for `rangeInfo.Desc.Replicas`.