### PR TITLE
release-1.1: cluster: properly introduce cluster version v1.1

### DIFF
--- a/pkg/settings/cluster/cluster_version.go
+++ b/pkg/settings/cluster/cluster_version.go
@@ -24,7 +24,7 @@ var (
 	BinaryMinimumSupportedVersion = VersionBase
 
 	// BinaryServerVersion is the version of this binary.
-	BinaryServerVersion = VersionStatsBasedRebalancing
+	BinaryServerVersion = Version1_1_0
 )
 
 // List all historical versions here in reverse chronological order, with
@@ -33,6 +33,8 @@ var (
 // NB: when adding a version, don't forget to bump ServerVersion above (and
 // perhaps MinimumSupportedVersion, if necessary).
 var (
+	// CockroachDB v1.1.0.
+	Version1_1_0 = roachpb.Version{Major: 1, Minor: 1}
 	// VersionStatsBasedRebalancing is https://github.com/cockroachdb/cockroach/pull/16878.
 	VersionStatsBasedRebalancing = roachpb.Version{Major: 1, Minor: 0, Unstable: 3}
 

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -92,7 +92,7 @@ sql.trace.txn.enable_threshold                     0s             d     duration
 trace.debug.enable                                 false          b     if set, traces for recent requests can be seen in the /debug page
 trace.lightstep.token                              ·              s     if set, traces go to Lightstep using this token
 trace.zipkin.collector                             ·              s     if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.
-version                                            1.0-3          m     set the active cluster version in the format '<major>.<minor>'.
+version                                            1.1            m     set the active cluster version in the format '<major>.<minor>'.
 
 query T colnames
 SELECT * FROM [SHOW SESSION_USER]


### PR DESCRIPTION
We forgot to introduce a proper version for v1.1.0. As a result, clusters
running our v1.1 release identify as v1.0-3, which in turn means that the
upgrade instructions do not work:

https://www.cockroachlabs.com/docs/v1.1/upgrade-cockroach-version.html

(1.1 needs to be replaced by 1.0-3).

We've already released v1.1.0 so unless we decide that we want to yank the relase
(don't think it's necessary) this will only become active in v1.1.1 (before
the release of which we should add another version, v1.1.1). We should think
about linting this or at least making its verification a part of the release
checklist, too.

cc @bdarnell @jseldess