### PR TITLE
sql: introduce MultiRowFetcher for one-pass row fetches for multiple (interleaved) tables

### DIFF
--- a/pkg/sql/sqlbase/multirowfetcher.go
+++ b/pkg/sql/sqlbase/multirowfetcher.go
@@ -1,0 +1,879 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+type tableInfo struct {
+	// -- Fields initialized once --
+
+	desc             *TableDescriptor
+	index            *IndexDescriptor
+	isSecondaryIndex bool
+	indexColumnDirs  []encoding.Direction
+	// equivSignature is an equivalence class for each unique table-index
+	// pair. It allows us to check if an index key belongs to a given
+	// table-index.
+	equivSignature []byte
+
+	// The table columns to use for fetching, possibly including ones currently in
+	// schema changes.
+	cols []ColumnDescriptor
+
+	// The set of ColumnIDs that are required.
+	neededCols util.FastIntSet
+
+	// Map used to get the index for columns in cols.
+	colIdxMap map[ColumnID]int
+
+	// One value per column that is part of the key; each value is a column
+	// index (into cols).
+	indexColIdx []int
+
+	// -- Fields updated during a scan --
+
+	keyValTypes []ColumnType
+	extraTypes  []ColumnType
+	keyVals     []EncDatum
+	extraVals   []EncDatum
+	row         EncDatumRow
+	decodedRow  parser.Datums
+}
+
+// RowResponse is returned when NextRow is invoked. It contains the
+// EncDatumRow as well as the table and index descriptors for the corresponding
+// table/index.
+type RowResponse struct {
+	Row   EncDatumRow
+	Desc  *TableDescriptor
+	Index *IndexDescriptor
+}
+
+// DecodedRowResponse returns the decoded Row in terms of Datums as well as the
+// table and index descriptors for the corresponding table/index.
+type DecodedRowResponse struct {
+	Datums parser.Datums
+	Desc   *TableDescriptor
+	Index  *IndexDescriptor
+}
+
+// MultiRowFetcherTableArgs are the arguments passed to MultiRowFetcher.Init
+// for a given table that includes descriptors and row information
+type MultiRowFetcherTableArgs struct {
+	Desc             *TableDescriptor
+	Index            *IndexDescriptor
+	ColIdxMap        map[ColumnID]int
+	IsSecondaryIndex bool
+	Cols             []ColumnDescriptor
+	ValNeededForCol  []bool
+}
+
+// MultiRowFetcher handles fetching kvs and forming table rows for an
+// arbitrary number of tables.
+// MultiRowFetcher should be used in lieu of RowFetcher if for a given
+// set of spans, rows from multiple tables are interleaved (i.e. interleaved
+// tables).
+// Usage:
+//   var mrf MultiRowFetcher
+//   err := mrf.Init(..)
+//   // Handle err
+//   err := mrf.StartScan(..)
+//   // Handle err
+//   for {
+//      res, err := mrf.NextRow()
+//      // Handle err
+//      if res.row == nil {
+//         // Done
+//         break
+//      }
+//      // Process res.row
+//   }
+type MultiRowFetcher struct {
+	// tables is a slice of all the tables and their descriptors for which
+	// rows are returned.
+	tables []tableInfo
+
+	// allEquivSignatures is a map used for checking if an equivalence
+	// signature belongs to any table or table's ancestor. It also maps the
+	// string representation of every table's and every table's ancestors'
+	// signature to the table's index in 'tables' for lookup during decoding.
+	// If 2+ tables share the same ancestor signature, allEquivSignatures
+	// will map the signature to the largest 'tables' index.
+	// The full signature for a given table in 'tables' will always map to
+	// its own index in 'tables'.
+	allEquivSignatures map[string]int
+
+	// reverse denotes whether or not the spans should be read in reverse
+	// or not when StartScan is invoked.
+	reverse bool
+
+	// maxKeysPerRow memoizes the maximum number of keys per row
+	// out of all the tables. This is used to calculate the kvFetcher's
+	// firstBatchLimit.
+	maxKeysPerRow int
+
+	// True if the index key must be decoded.
+	// If there is more than one table, the index key must always be decoded.
+	// This is only false if there are no needed columns and the (single)
+	// table has no interleave children.
+	mustDecodeIndexKey bool
+
+	// returnRangeInfo, if set, causes the underlying kvFetcher to return
+	// information about the ranges descriptors/leases uses in servicing the
+	// requests. This has some cost, so it's only enabled by DistSQL when this
+	// info is actually useful for correcting the plan (e.g. not for the PK-side
+	// of an index-join).
+	// If set, GetRangeInfo() can be used to retrieve the accumulated info.
+	returnRangeInfo bool
+
+	// traceKV indicates whether or not session tracing is enabled. It is set
+	// when beginning a new scan.
+	traceKV bool
+
+	// -- Fields updated during a scan --
+
+	kvFetcher      kvFetcher
+	indexKey       []byte // the index key of the current row
+	prettyValueBuf *bytes.Buffer
+
+	rowReadyTable *tableInfo // the table for which a row was fully decoded and ready for output
+	currentTable  *tableInfo // the most recent table for which a key was decoded
+	keySigBuf     []byte     // buffer for the index key's signature
+	keyRestBuf    []byte     // buffer for the rest of the index key that is not part of the signature
+
+	// The current key/value, unless kvEnd is true.
+	kv                roachpb.KeyValue
+	keyRemainingBytes []byte
+	kvEnd             bool
+
+	// Buffered allocation of decoded datums.
+	alloc *DatumAlloc
+}
+
+// Init sets up a MultiRowFetcher for a given table and index. If we are using a
+// non-primary index, valNeededForCol can only be true for the columns in the
+// index.
+func (mrf *MultiRowFetcher) Init(
+	tables []MultiRowFetcherTableArgs, reverse bool, returnRangeInfo bool, alloc *DatumAlloc,
+) error {
+	if len(tables) == 0 {
+		panic("no tables to fetch from")
+	}
+
+	mrf.reverse = reverse
+	mrf.returnRangeInfo = returnRangeInfo
+	mrf.alloc = alloc
+	mrf.allEquivSignatures = make(map[string]int, len(tables))
+
+	// We must always decode the index key if we need to distinguish between
+	// rows from more than one table.
+	mrf.mustDecodeIndexKey = len(tables) >= 2
+
+	mrf.tables = make([]tableInfo, 0, len(tables))
+	for tableIdx, tableArgs := range tables {
+		table := tableInfo{
+			desc:             tableArgs.Desc,
+			colIdxMap:        tableArgs.ColIdxMap,
+			index:            tableArgs.Index,
+			isSecondaryIndex: tableArgs.IsSecondaryIndex,
+			cols:             tableArgs.Cols,
+			row:              make([]EncDatum, len(tableArgs.Cols)),
+			decodedRow:       make([]parser.Datum, len(tableArgs.Cols)),
+		}
+
+		// We produce references to every signature's reference.
+		equivSignatures, err := TableEquivSignatures(table.desc, table.index)
+		if err != nil {
+			return err
+		}
+		for i, sig := range equivSignatures {
+			// We always map the table's equivalence signature (last
+			// 'sig' in 'equivSignatures') to its tableIdx.
+			// This allows us to overwrite previous "ancestor
+			// signatures" (see below).
+			if i == len(equivSignatures)-1 {
+				mrf.allEquivSignatures[string(sig)] = tableIdx
+				break
+			}
+			// Map each table's ancestors' signatures to -1 so
+			// we know during ReadIndexKey if the parsed index
+			// key belongs to ancestor or one of our tables.
+			// We must check if the signature has already been set
+			// since it's possible for a later 'table' to have an
+			// ancestor that is a previous 'table', and we do not
+			// want to overwrite the previous table's tableIdx.
+			if _, exists := mrf.allEquivSignatures[string(sig)]; !exists {
+				mrf.allEquivSignatures[string(sig)] = -1
+			}
+		}
+		// The last signature is the given table's equivalence signature.
+		table.equivSignature = equivSignatures[len(equivSignatures)-1]
+
+		for i, v := range tableArgs.ValNeededForCol {
+			if !v {
+				continue
+			}
+			// The i-th column is required. Search the colIdxMap to find the
+			// corresponding ColumnID.
+			for col, idx := range table.colIdxMap {
+				if idx == i {
+					table.neededCols.Add(int(col))
+					break
+				}
+			}
+		}
+
+		// If there is more than one table, we have to decode the index key to
+		// figure out which table the row belongs to.
+		// If there are interleaves, we need to read the index key in order to
+		// determine whether this row is actually part of the index we're scanning.
+		// If we need to return any values from the row, we also have to read the
+		// index key to either get those values directly or determine the row's
+		// column family id to map the row values to their columns.
+		// Otherwise, we can completely avoid decoding the index key.
+		// TODO(jordan): Relax this restriction. Ideally we could skip doing key
+		// reading work if we need values from outside of the key, but not from
+		// inside of the key.
+		if !mrf.mustDecodeIndexKey && (!table.neededCols.Empty() || len(table.index.InterleavedBy) > 0 || len(table.index.Interleave.Ancestors) > 0) {
+			mrf.mustDecodeIndexKey = true
+		}
+
+		var indexColumnIDs []ColumnID
+		indexColumnIDs, table.indexColumnDirs = table.index.FullColumnIDs()
+
+		table.indexColIdx = make([]int, len(indexColumnIDs))
+		for i, id := range indexColumnIDs {
+			table.indexColIdx[i] = table.colIdxMap[id]
+		}
+
+		if table.isSecondaryIndex {
+			for i := range table.cols {
+				if table.neededCols.Contains(int(table.cols[i].ID)) && !table.index.ContainsColumnID(table.cols[i].ID) {
+					return fmt.Errorf("requested column %s not in index", table.cols[i].Name)
+				}
+			}
+		}
+
+		// Prepare our index key vals slice.
+		table.keyValTypes, err = GetColumnTypes(table.desc, indexColumnIDs)
+		if err != nil {
+			return err
+		}
+		table.keyVals = make([]EncDatum, len(indexColumnIDs))
+
+		if hasExtraCols(&table) {
+			// Unique secondary indexes have a value that is the
+			// primary index key.
+			// Primary indexes only contain ascendingly-encoded
+			// values. If this ever changes, we'll probably have to
+			// figure out the directions here too.
+			table.extraTypes, err = GetColumnTypes(table.desc, table.index.ExtraColumnIDs)
+			table.extraVals = make([]EncDatum, len(table.index.ExtraColumnIDs))
+			if err != nil {
+				return err
+			}
+		}
+
+		// Keep track of the maximum keys per row to accommodate a
+		// limitHint when StartScan is invoked.
+		if keysPerRow := table.desc.KeysPerRow(table.index.ID); keysPerRow > mrf.maxKeysPerRow {
+			mrf.maxKeysPerRow = keysPerRow
+		}
+
+		mrf.tables = append(mrf.tables, table)
+	}
+
+	if len(tables) == 1 {
+		// If there is more than one table, currentTable will be
+		// updated every time NextKey is invoked and rowReadyTable
+		// will be updated when a row is fully decoded.
+		mrf.currentTable = &(mrf.tables[0])
+		mrf.rowReadyTable = &(mrf.tables[0])
+	}
+
+	return nil
+}
+
+// StartScan initializes and starts the key-value scan. Can be used multiple
+// times.
+func (mrf *MultiRowFetcher) StartScan(
+	ctx context.Context,
+	txn *client.Txn,
+	spans roachpb.Spans,
+	limitBatches bool,
+	limitHint int64,
+	traceKV bool,
+) error {
+	if len(spans) == 0 {
+		panic("no spans")
+	}
+
+	mrf.traceKV = traceKV
+
+	// If we have a limit hint, we limit the first batch size. Subsequent
+	// batches get larger to avoid making things too slow (e.g. in case we have
+	// a very restrictive filter and actually have to retrieve a lot of rows).
+	firstBatchLimit := limitHint
+	if firstBatchLimit != 0 {
+		// The limitHint is a row limit, but each row could be made up
+		// of more than one key. We take the maximum possible keys
+		// per row out of all the table rows we could potentially
+		// scan over.
+		firstBatchLimit = limitHint * int64(mrf.maxKeysPerRow)
+		// We need an extra key to make sure we form the last row.
+		firstBatchLimit++
+	}
+
+	f, err := makeKVFetcher(txn, spans, mrf.reverse, limitBatches, firstBatchLimit, mrf.returnRangeInfo)
+	if err != nil {
+		return err
+	}
+	return mrf.StartScanFrom(ctx, &f)
+}
+
+// StartScanFrom initializes and starts a scan from the given kvFetcher. Can be
+// used multiple times.
+func (mrf *MultiRowFetcher) StartScanFrom(ctx context.Context, f kvFetcher) error {
+	mrf.indexKey = nil
+	mrf.kvFetcher = f
+	// Retrieve the first key.
+	_, err := mrf.NextKey(ctx)
+	return err
+}
+
+// NextKey retrieves the next key/value and sets kv/kvEnd. Returns whether a row
+// has been completed.
+func (mrf *MultiRowFetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
+	var ok bool
+
+	for {
+		ok, mrf.kv, err = mrf.kvFetcher.nextKV(ctx)
+		if err != nil {
+			return false, err
+		}
+		mrf.kvEnd = !ok
+		if mrf.kvEnd {
+			// No more keys in the scan. We need to transition
+			// mrf.rowReadyTable to mrf.currentTable for the last
+			// row.
+			mrf.rowReadyTable = mrf.currentTable
+			return true, nil
+		}
+
+		// See Init() for a detailed description of when we can get away with not
+		// reading the index key.
+		if mrf.mustDecodeIndexKey || mrf.traceKV {
+			mrf.keyRemainingBytes, ok, err = mrf.ReadIndexKey(mrf.kv.Key)
+			if err != nil {
+				return false, err
+			}
+			if !ok {
+				// The key did not match any of the table
+				// descriptors, which means it's interleaved
+				// data from some other table or index.
+				continue
+			}
+		} else {
+			// We still need to consume the key until the family
+			// id, so processKV can know whether we've finished a
+			// row or not.
+			prefixLen, err := keys.GetRowPrefixLength(mrf.kv.Key)
+			if err != nil {
+				return false, err
+			}
+			mrf.keyRemainingBytes = mrf.kv.Key[prefixLen:]
+		}
+
+		// For unique secondary indexes, the index-key does not distinguish one row
+		// from the next if both rows contain identical values along with a NULL.
+		// Consider the keys:
+		//
+		//   /test/unique_idx/NULL/0
+		//   /test/unique_idx/NULL/1
+		//
+		// The index-key extracted from the above keys is /test/unique_idx/NULL. The
+		// trailing /0 and /1 are the primary key used to unique-ify the keys when a
+		// NULL is present. Currently we don't detect NULLs on decoding. If we did
+		// we could detect this case and enlarge the index-key. A simpler fix for
+		// this problem is to simply always output a row for each key scanned from a
+		// secondary index as secondary indexes have only one key per row.
+		// If mrf.rowReadyTable differs from mrf.currentTable, this denotes
+		// a row is ready for output.
+		if mrf.indexKey != nil && (mrf.currentTable.isSecondaryIndex || !bytes.HasPrefix(mrf.kv.Key, mrf.indexKey) || mrf.rowReadyTable != mrf.currentTable) {
+			// The current key belongs to a new row. Output the
+			// current row.
+			mrf.indexKey = nil
+			return true, nil
+		}
+
+		return false, nil
+	}
+}
+
+func (mrf *MultiRowFetcher) prettyEncDatums(types []ColumnType, vals []EncDatum) string {
+	var buf bytes.Buffer
+	for i, v := range vals {
+		if err := v.EnsureDecoded(&types[i], mrf.alloc); err != nil {
+			fmt.Fprintf(&buf, "error decoding: %v", err)
+		}
+		fmt.Fprintf(&buf, "/%v", v.Datum)
+	}
+	return buf.String()
+}
+
+// ReadIndexKey decodes an index key for a given table.
+// It returns whether or not the key is for any of the tables initialized
+// in MultiRowFetcher, and the remaining part of the key if it is.
+func (mrf *MultiRowFetcher) ReadIndexKey(key roachpb.Key) (remaining []byte, ok bool, err error) {
+	// If there is only one table to check keys for, there is no need
+	// to go through the equivalence signature checks.
+	if len(mrf.tables) == 1 {
+		return DecodeIndexKey(
+			mrf.currentTable.desc,
+			mrf.currentTable.index,
+			mrf.currentTable.keyValTypes,
+			mrf.currentTable.keyVals,
+			mrf.currentTable.indexColumnDirs,
+			key,
+		)
+	}
+
+	// key now contains the bytes in the key (if match) that are not part
+	// of the signature in order.
+	tableIdx, key, match, err := IndexKeyEquivSignature(key, mrf.allEquivSignatures, mrf.keySigBuf, mrf.keyRestBuf)
+	if err != nil {
+		return nil, false, err
+	}
+	// The index key does not belong to our table because either:
+	// !match:	    part of the index key's signature did not match any of
+	//		    mrf.allEquivSignatures.
+	// tableIdx == -1:  index key belongs to an ancestor.
+	if !match || tableIdx == -1 {
+		return nil, false, nil
+	}
+
+	// Either a new table is encountered or the rowReadyTable differs from
+	// the currentTable (the rowReadyTable was outputted in the previous
+	// read). We transition the references.
+	if &mrf.tables[tableIdx] != mrf.currentTable || mrf.rowReadyTable != mrf.currentTable {
+		mrf.rowReadyTable = mrf.currentTable
+		mrf.currentTable = &mrf.tables[tableIdx]
+
+		// mrf.rowReadyTable is nil if this is the very first key.
+		// We want to ensure this does not differ from mrf.currentTable
+		// to prevent another transition.
+		if mrf.rowReadyTable == nil {
+			mrf.rowReadyTable = mrf.currentTable
+		}
+	}
+
+	// We can simply decode all the column values we retrieved
+	// when processing the index key. The column values are at the
+	// front of the key.
+	if key, err = DecodeKeyVals(
+		mrf.currentTable.keyValTypes,
+		mrf.currentTable.keyVals,
+		mrf.currentTable.indexColumnDirs,
+		key,
+	); err != nil {
+		return nil, false, err
+	}
+
+	return key, true, nil
+}
+
+// processKV processes the given key/value, setting values in the row
+// accordingly. If debugStrings is true, returns pretty printed key and value
+// information in prettyKey/prettyValue (otherwise they are empty strings).
+func (mrf *MultiRowFetcher) processKV(
+	ctx context.Context, kv roachpb.KeyValue,
+) (prettyKey string, prettyValue string, err error) {
+	table := mrf.currentTable
+
+	if mrf.traceKV {
+		prettyKey = fmt.Sprintf(
+			"/%s/%s%s",
+			table.desc.Name,
+			table.index.Name,
+			mrf.prettyEncDatums(table.keyValTypes, table.keyVals),
+		)
+	}
+
+	// Either this is the first key of the fetch or the first key of a new
+	// row.
+	if mrf.indexKey == nil {
+		// This is the first key for the row.
+		mrf.indexKey = []byte(kv.Key[:len(kv.Key)-len(mrf.keyRemainingBytes)])
+
+		// Reset the row to nil; it will get filled in with the column
+		// values as we decode the key-value pairs for the row.
+		for i := range table.row {
+			table.row[i].UnsetDatum()
+		}
+
+		// Fill in the column values that are part of the index key.
+		for i, v := range table.keyVals {
+			table.row[table.indexColIdx[i]] = v
+		}
+	}
+
+	if table.neededCols.Empty() {
+		// We don't need to decode any values.
+		if mrf.traceKV {
+			prettyValue = parser.DNull.String()
+		}
+		return prettyKey, prettyValue, nil
+	}
+
+	if !table.isSecondaryIndex && len(mrf.keyRemainingBytes) > 0 {
+		_, familyID, err := encoding.DecodeUvarintAscending(mrf.keyRemainingBytes)
+		if err != nil {
+			return "", "", err
+		}
+
+		family, err := table.desc.FindFamilyByID(FamilyID(familyID))
+		if err != nil {
+			return "", "", err
+		}
+
+		// If familyID is 0, kv.Value contains values for composite key columns.
+		// These columns already have a table.row value assigned above, but that value
+		// (obtained from the key encoding) might not be correct (e.g. for decimals,
+		// it might not contain the right number of trailing 0s; for collated
+		// strings, it is one of potentially many strings with the same collation
+		// key).
+		//
+		// In these cases, the correct value will be present in family 0 and the
+		// table.row value gets overwritten.
+
+		switch kv.Value.GetTag() {
+		case roachpb.ValueType_TUPLE:
+			prettyKey, prettyValue, err = mrf.processValueTuple(ctx, table, kv, prettyKey)
+		default:
+			prettyKey, prettyValue, err = mrf.processValueSingle(ctx, table, family, kv, prettyKey)
+		}
+		if err != nil {
+			return "", "", err
+		}
+	} else {
+		valueBytes, err := kv.Value.GetBytes()
+		if err != nil {
+			return "", "", err
+		}
+
+		if hasExtraCols(table) {
+			// This is a unique secondary index; decode the extra
+			// column values from the value.
+			var err error
+			valueBytes, err = DecodeKeyVals(
+				table.extraTypes,
+				table.extraVals,
+				nil,
+				valueBytes,
+			)
+			if err != nil {
+				return "", "", err
+			}
+			for i, id := range table.index.ExtraColumnIDs {
+				if table.neededCols.Contains(int(id)) {
+					table.row[table.colIdxMap[id]] = table.extraVals[i]
+				}
+			}
+			if mrf.traceKV {
+				prettyValue = mrf.prettyEncDatums(table.extraTypes, table.extraVals)
+			}
+		}
+
+		if debugRowFetch {
+			if hasExtraCols(table) {
+				log.Infof(ctx, "Scan %s -> %s", kv.Key, mrf.prettyEncDatums(table.extraTypes, table.extraVals))
+			} else {
+				log.Infof(ctx, "Scan %s", kv.Key)
+			}
+		}
+
+		if len(valueBytes) > 0 {
+			prettyKey, prettyValue, err = mrf.processValueBytes(
+				ctx, table, kv, valueBytes, prettyKey,
+			)
+			if err != nil {
+				return "", "", err
+			}
+		}
+	}
+
+	if mrf.traceKV && prettyValue == "" {
+		prettyValue = parser.DNull.String()
+	}
+
+	return prettyKey, prettyValue, nil
+}
+
+// processValueSingle processes the given value (of column
+// family.DefaultColumnID), setting values in table.row accordingly. The key is
+// only used for logging.
+func (mrf *MultiRowFetcher) processValueSingle(
+	ctx context.Context,
+	table *tableInfo,
+	family *ColumnFamilyDescriptor,
+	kv roachpb.KeyValue,
+	prettyKeyPrefix string,
+) (prettyKey string, prettyValue string, err error) {
+	prettyKey = prettyKeyPrefix
+
+	// If this is the row sentinel (in the legacy pre-family format),
+	// a value is not expected, so we're done.
+	if family.ID == 0 {
+		return "", "", nil
+	}
+
+	colID := family.DefaultColumnID
+	if colID == 0 {
+		return "", "", errors.Errorf("single entry value with no default column id")
+	}
+
+	if mrf.traceKV || table.neededCols.Contains(int(colID)) {
+		if idx, ok := table.colIdxMap[colID]; ok {
+			if mrf.traceKV {
+				prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.Columns[idx].Name)
+			}
+			typ := table.cols[idx].Type
+			// TODO(arjun): The value is a directly marshaled single value, so we
+			// unmarshal it eagerly here. This can potentially be optimized out,
+			// although that would require changing UnmarshalColumnValue to operate
+			// on bytes, and for Encode/DecodeTableValue to operate on marshaled
+			// single values.
+			value, err := UnmarshalColumnValue(mrf.alloc, typ, kv.Value)
+			if err != nil {
+				return "", "", err
+			}
+			if mrf.traceKV {
+				prettyValue = value.String()
+			}
+			table.row[idx] = DatumToEncDatum(typ, value)
+			if debugRowFetch {
+				log.Infof(ctx, "Scan %s -> %v", kv.Key, value)
+			}
+			return prettyKey, prettyValue, nil
+		}
+	}
+
+	// No need to unmarshal the column value. Either the column was part of
+	// the index key or it isn't needed.
+	if debugRowFetch {
+		log.Infof(ctx, "Scan %s -> [%d] (skipped)", kv.Key, colID)
+	}
+	return prettyKey, prettyValue, nil
+}
+
+func (mrf *MultiRowFetcher) processValueBytes(
+	ctx context.Context,
+	table *tableInfo,
+	kv roachpb.KeyValue,
+	valueBytes []byte,
+	prettyKeyPrefix string,
+) (prettyKey string, prettyValue string, err error) {
+	prettyKey = prettyKeyPrefix
+	if mrf.traceKV {
+		if mrf.prettyValueBuf == nil {
+			mrf.prettyValueBuf = &bytes.Buffer{}
+		}
+		mrf.prettyValueBuf.Reset()
+	}
+
+	var colIDDiff uint32
+	var lastColID ColumnID
+	for len(valueBytes) > 0 {
+		_, _, colIDDiff, _, err = encoding.DecodeValueTag(valueBytes)
+		if err != nil {
+			return "", "", err
+		}
+		colID := lastColID + ColumnID(colIDDiff)
+		lastColID = colID
+		if !table.neededCols.Contains(int(colID)) {
+			// This column wasn't requested, so read its length and skip it.
+			_, len, err := encoding.PeekValueLength(valueBytes)
+			if err != nil {
+				return "", "", err
+			}
+			valueBytes = valueBytes[len:]
+			if debugRowFetch {
+				log.Infof(ctx, "Scan %s -> [%d] (skipped)", kv.Key, colID)
+			}
+			continue
+		}
+		idx := table.colIdxMap[colID]
+
+		if mrf.traceKV {
+			prettyKey = fmt.Sprintf("%s/%s", prettyKey, table.desc.Columns[idx].Name)
+		}
+
+		var encValue EncDatum
+		encValue, valueBytes, err =
+			EncDatumFromBuffer(&table.cols[idx].Type, DatumEncoding_VALUE, valueBytes)
+		if err != nil {
+			return "", "", err
+		}
+		if mrf.traceKV {
+			err := encValue.EnsureDecoded(&table.cols[idx].Type, mrf.alloc)
+			if err != nil {
+				return "", "", err
+			}
+			fmt.Fprintf(mrf.prettyValueBuf, "/%v", encValue.Datum)
+		}
+		table.row[idx] = encValue
+		if debugRowFetch {
+			log.Infof(ctx, "Scan %d -> %v", idx, encValue)
+		}
+	}
+	if mrf.traceKV {
+		prettyValue = mrf.prettyValueBuf.String()
+	}
+	return prettyKey, prettyValue, nil
+}
+
+// processValueTuple processes the given values (of columns family.ColumnIDs),
+// setting values in the mrf.row accordingly. The key is only used for logging.
+func (mrf *MultiRowFetcher) processValueTuple(
+	ctx context.Context, table *tableInfo, kv roachpb.KeyValue, prettyKeyPrefix string,
+) (prettyKey string, prettyValue string, err error) {
+	tupleBytes, err := kv.Value.GetTuple()
+	if err != nil {
+		return "", "", err
+	}
+	return mrf.processValueBytes(ctx, table, kv, tupleBytes, prettyKeyPrefix)
+}
+
+// NextRow processes keys until we complete one row, which is returned as an
+// EncDatumRow. The row contains one value per table column, regardless of the
+// index used; values that are not needed (as per valNeededForCol) are nil. The
+// EncDatumRow should not be modified and is only valid until the next call.
+// The
+// When there are no more rows, the EncDatumRow is nil.
+func (mrf *MultiRowFetcher) NextRow(ctx context.Context) (RowResponse, error) {
+	if mrf.kvEnd {
+		return RowResponse{}, nil
+	}
+
+	// All of the columns for a particular row will be grouped together. We
+	// loop over the key/value pairs and decode the key to extract the
+	// columns encoded within the key and the column ID. We use the column
+	// ID to lookup the column and decode the value. All of these values go
+	// into a map keyed by column name. When the index key changes we
+	// output a row containing the current values.
+	for {
+		prettyKey, prettyVal, err := mrf.processKV(ctx, mrf.kv)
+		if err != nil {
+			return RowResponse{}, err
+		}
+		if mrf.traceKV {
+			log.VEventf(ctx, 2, "fetched: %s -> %s", prettyKey, prettyVal)
+		}
+		rowDone, err := mrf.NextKey(ctx)
+		if err != nil {
+			return RowResponse{}, err
+		}
+		if rowDone {
+			mrf.finalizeRow()
+			return RowResponse{
+				Row:   mrf.rowReadyTable.row,
+				Desc:  mrf.rowReadyTable.desc,
+				Index: mrf.rowReadyTable.index,
+			}, nil
+		}
+	}
+}
+
+// NextRowDecoded calls NextRow and decodes the EncDatumRow into a Datums.
+// The Datums should not be modified and is only valid until the next call.
+// When there are no more rows, the Datums is nil.
+func (mrf *MultiRowFetcher) NextRowDecoded(
+	ctx context.Context, traceKV bool,
+) (DecodedRowResponse, error) {
+	resp, err := mrf.NextRow(ctx)
+	if err != nil {
+		return DecodedRowResponse{}, err
+	}
+	if resp.Row == nil {
+		return DecodedRowResponse{}, nil
+	}
+
+	for i, encDatum := range resp.Row {
+		if encDatum.IsUnset() {
+			mrf.rowReadyTable.decodedRow[i] = parser.DNull
+			continue
+		}
+		if err := encDatum.EnsureDecoded(&mrf.rowReadyTable.cols[i].Type, mrf.alloc); err != nil {
+			return DecodedRowResponse{}, err
+		}
+		mrf.rowReadyTable.decodedRow[i] = encDatum.Datum
+	}
+
+	return DecodedRowResponse{
+		Datums: mrf.rowReadyTable.decodedRow,
+		Desc:   resp.Desc,
+		Index:  resp.Index,
+	}, nil
+}
+
+func (mrf *MultiRowFetcher) finalizeRow() {
+	table := mrf.rowReadyTable
+	// Fill in any missing values with NULLs
+	for i := range table.cols {
+		if table.neededCols.Contains(int(table.cols[i].ID)) && table.row[i].IsUnset() {
+			if !table.cols[i].Nullable {
+				panic(fmt.Sprintf("Non-nullable column \"%s:%s\" with no value!",
+					table.desc.Name, table.cols[i].Name))
+			}
+			table.row[i] = EncDatum{
+				Datum: parser.DNull,
+			}
+		}
+	}
+}
+
+// Key returns the next key (the key that follows the last returned row).
+// Key returns nil when there are no more rows.
+// TODO(richardwu): uncomment this when RowFetcher refactored to MultiRowFetcher.
+// func (mrf *MultiRowFetcher) Key() roachpb.Key {
+// 	return mrf.kv.Key
+// }
+
+// GetRangeInfo returns information about the ranges where the rows came from.
+// The RangeInfo's are deduped and not ordered.
+// TODO(richardwu): uncomment this when RowFetcher refactored to MultiRowFetcher.
+// func (mrf *MultiRowFetcher) GetRangeInfo() []roachpb.RangeInfo {
+// 	return mrf.kvFetcher.getRangesInfo()
+// }
+
+// Only unique secondary indexes have extra columns to decode (namely the
+// primary index columns).
+func hasExtraCols(table *tableInfo) bool {
+	return table.isSecondaryIndex && table.index.Unique
+}

--- a/pkg/sql/sqlbase/multirowfetcher_test.go
+++ b/pkg/sql/sqlbase/multirowfetcher_test.go
@@ -1,0 +1,796 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"golang.org/x/net/context"
+)
+
+const testDB = "test"
+
+type initFetcherArgs struct {
+	tableDesc       *TableDescriptor
+	indexIdx        int
+	valNeededForCol []bool
+}
+
+func initFetcher(
+	entries []initFetcherArgs, reverseScan bool, alloc *DatumAlloc,
+) (fetcher *MultiRowFetcher, err error) {
+	fetcher = &MultiRowFetcher{}
+
+	fetcherArgs := make([]MultiRowFetcherTableArgs, len(entries))
+
+	for i, entry := range entries {
+		var index *IndexDescriptor
+		var isSecondaryIndex bool
+
+		if entry.indexIdx > 0 {
+			index = &entry.tableDesc.Indexes[entry.indexIdx-1]
+			isSecondaryIndex = true
+		} else {
+			index = &entry.tableDesc.PrimaryIndex
+		}
+
+		colIdxMap := make(map[ColumnID]int)
+		for i, c := range entry.tableDesc.Columns {
+			colIdxMap[c.ID] = i
+		}
+
+		fetcherArgs[i] = MultiRowFetcherTableArgs{
+			Desc:             entry.tableDesc,
+			Index:            index,
+			ColIdxMap:        colIdxMap,
+			IsSecondaryIndex: isSecondaryIndex,
+			Cols:             entry.tableDesc.Columns,
+			ValNeededForCol:  entry.valNeededForCol,
+		}
+	}
+
+	if err := fetcher.Init(fetcherArgs, reverseScan, false, alloc); err != nil {
+		return nil, err
+	}
+
+	return fetcher, nil
+}
+
+type fetcherEntryArgs struct {
+	tableName        string
+	indexName        string // Specify if this entry is an index
+	indexIdx         int    // 0 for primary index (default)
+	modFactor        int    // Useful modulo to apply for value columns
+	schema           string
+	interleaveSchema string // Specify if this entry is to be interleaved into another table
+	indexSchema      string // Specify if this entry is to be created as an index
+	nRows            int
+	nCols            int // Number of columns in the table
+	nVals            int // Number of values requested from scan
+	valNeededForCol  []bool
+	genValue         sqlutils.GenRowFn
+}
+
+func TestNextRowSingle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	tables := map[string]fetcherEntryArgs{
+		"t1": {
+			modFactor: 42,
+			nRows:     1337,
+			nCols:     2,
+		},
+		"t2": {
+			modFactor: 13,
+			nRows:     2014,
+			nCols:     2,
+		},
+		"norows": {
+			modFactor: 10,
+			nRows:     0,
+			nCols:     2,
+		},
+		"onerow": {
+			modFactor: 10,
+			nRows:     1,
+			nCols:     2,
+		},
+	}
+
+	// Initialize tables first.
+	var maxCols int
+	for tableName, table := range tables {
+		sqlutils.CreateTable(
+			t, sqlDB, tableName,
+			"k INT PRIMARY KEY, v INT",
+			table.nRows,
+			sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowModuloFn(table.modFactor)),
+		)
+		if table.nCols > maxCols {
+			maxCols = table.nCols
+		}
+	}
+
+	alloc := &DatumAlloc{}
+
+	// Backing slice for specifying which column values should be returned.
+	// By default, we want all the columns.
+	valNeededForCol := make([]bool, maxCols)
+	for i := range valNeededForCol {
+		valNeededForCol[i] = true
+	}
+
+	// We try to read rows from each table.
+	for tableName, table := range tables {
+		t.Run(tableName, func(t *testing.T) {
+			tableDesc := GetTableDescriptor(kvDB, testDB, tableName)
+			args := []initFetcherArgs{
+				{
+					tableDesc:       tableDesc,
+					indexIdx:        0,
+					valNeededForCol: valNeededForCol[:table.nCols],
+				},
+			}
+
+			mrf, err := initFetcher(args, false /*reverseScan*/, alloc)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := mrf.StartScan(
+				context.TODO(),
+				client.NewTxn(kvDB, 0),
+				roachpb.Spans{tableDesc.TableSpan()},
+				false, /*limitBatches*/
+				0,     /*limitHint*/
+				false, /*traceKV*/
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			count := 0
+
+			expectedVals := [2]int64{1, 1}
+			for {
+				resp, err := mrf.NextRowDecoded(context.TODO(), false /*traceKV*/)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if resp.Datums == nil {
+					break
+				}
+
+				count++
+
+				if resp.Desc.ID != tableDesc.ID || resp.Index.ID != tableDesc.PrimaryIndex.ID {
+					t.Fatalf(
+						"unexpected row retrieved from fetcher.\nnexpected:  table %s - index %s\nactual: table %s - index %s",
+						tableDesc.Name, tableDesc.PrimaryIndex.Name,
+						resp.Desc.Name, resp.Index.Name,
+					)
+				}
+
+				if table.nCols != len(resp.Datums) {
+					t.Fatalf("expected %d columns, got %d columns", table.nCols, len(resp.Datums))
+				}
+
+				for i, expected := range expectedVals {
+					actual := int64(*resp.Datums[i].(*parser.DInt))
+					if expected != actual {
+						t.Fatalf("unexpected value for row %d, col %d.\nexpected: %d\nactual: %d", count, i, expected, actual)
+					}
+				}
+
+				expectedVals[0]++
+				expectedVals[1]++
+				// Value column is in terms of a modulo.
+				expectedVals[1] %= int64(table.modFactor)
+			}
+
+			if table.nRows != count {
+				t.Fatalf("expected %d rows, got %d rows", table.nRows, count)
+			}
+		})
+	}
+}
+
+// Secondary indexes contain extra values (the primary key of the primary index
+// as well as STORING columns).
+func TestNextRowSecondaryIndex(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	// Modulo to use for s1, s2 storing columns.
+	storingMods := [2]int{7, 13}
+	// Number of NULL secondary index values.
+	nNulls := 20
+
+	tables := map[string]*fetcherEntryArgs{
+		"nonunique": {
+			modFactor:       20,
+			schema:          "p INT PRIMARY KEY, idx INT, s1 INT, s2 INT, INDEX i1 (idx)",
+			nRows:           422,
+			nCols:           4,
+			nVals:           2,
+			valNeededForCol: []bool{true, true, false, false},
+		},
+		"unique": {
+			// Must be > nRows since this value must be unique.
+			modFactor:       1000,
+			schema:          "p INT PRIMARY KEY, idx INT, s1 INT, s2 INT, UNIQUE INDEX i1 (idx)",
+			nRows:           123,
+			nCols:           4,
+			nVals:           2,
+			valNeededForCol: []bool{true, true, false, false},
+		},
+		"nonuniquestoring": {
+			modFactor: 42,
+			schema:    "p INT PRIMARY KEY, idx INT, s1 INT, s2 INT, INDEX i1 (idx) STORING (s1, s2)",
+			nRows:     654,
+			nCols:     4,
+			nVals:     4,
+		},
+		"uniquestoring": {
+			// Must be > nRows since this value must be unique.
+			modFactor: 1000,
+			nRows:     555,
+			schema:    "p INT PRIMARY KEY, idx INT, s1 INT, s2 INT, UNIQUE INDEX i1 (idx) STORING (s1, s2)",
+			nCols:     4,
+			nVals:     4,
+		},
+	}
+
+	// Initialize the generate value functions.
+	tables["nonunique"].genValue = sqlutils.ToRowFn(
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tables["nonunique"].modFactor),
+	)
+	tables["unique"].genValue = sqlutils.ToRowFn(
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tables["unique"].modFactor),
+	)
+	tables["nonuniquestoring"].genValue = sqlutils.ToRowFn(
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tables["nonuniquestoring"].modFactor),
+		sqlutils.RowModuloFn(storingMods[0]),
+		sqlutils.RowModuloFn(storingMods[1]),
+	)
+	tables["uniquestoring"].genValue = sqlutils.ToRowFn(
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tables["uniquestoring"].modFactor),
+		sqlutils.RowModuloFn(storingMods[0]),
+		sqlutils.RowModuloFn(storingMods[1]),
+	)
+
+	r := sqlutils.MakeSQLRunner(t, sqlDB)
+	// Initialize tables first.
+	var maxCols int
+	for tableName, table := range tables {
+		sqlutils.CreateTable(
+			t, sqlDB, tableName,
+			table.schema,
+			table.nRows,
+			table.genValue,
+		)
+		if table.nCols > maxCols {
+			maxCols = table.nCols
+		}
+
+		// Insert nNulls NULL secondary index values (this tests if
+		// we're properly decoding (UNIQUE) secondary index keys
+		// properly).
+		for i := 1; i <= nNulls; i++ {
+			r.Exec(fmt.Sprintf(
+				`INSERT INTO test.%s VALUES (%d, NULL, %d, %d);`,
+				tableName,
+				table.nRows+i,
+				(table.nRows+i)%storingMods[0],
+				(table.nRows+i)%storingMods[1],
+			))
+		}
+		table.nRows += nNulls
+	}
+
+	alloc := &DatumAlloc{}
+
+	// Backing slice for specifying which column values should be returned.
+	// By default, we want all the columns.
+	valNeededForCol := make([]bool, maxCols)
+	for i := range valNeededForCol {
+		valNeededForCol[i] = true
+	}
+
+	// We try to read rows from each index.
+	for tableName, table := range tables {
+		t.Run(tableName, func(t *testing.T) {
+			tableDesc := GetTableDescriptor(kvDB, testDB, tableName)
+
+			colsNeeded := valNeededForCol[:table.nCols]
+			if table.valNeededForCol != nil {
+				colsNeeded = table.valNeededForCol
+			}
+			args := []initFetcherArgs{
+				{
+					tableDesc: tableDesc,
+					// We scan from the first secondary index.
+					indexIdx:        1,
+					valNeededForCol: colsNeeded,
+				},
+			}
+
+			mrf, err := initFetcher(args, false /*reverseScan*/, alloc)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := mrf.StartScan(
+				context.TODO(),
+				client.NewTxn(kvDB, 0),
+				roachpb.Spans{tableDesc.TableSpan()},
+				false, /*limitBatches*/
+				0,     /*limitHint*/
+				false, /*traceKV*/
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			count := 0
+			nullCount := 0
+			var prevIdxVal int64
+			for {
+				resp, err := mrf.NextRowDecoded(context.TODO(), false /*traceKV*/)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if resp.Datums == nil {
+					break
+				}
+
+				count++
+
+				if resp.Desc.ID != tableDesc.ID || resp.Index.ID != tableDesc.Indexes[0].ID {
+					t.Fatalf(
+						"unexpected row retrieved from fetcher.\nnexpected:  table %s - index %s\nactual: table %s - index %s",
+						tableDesc.Name, tableDesc.Indexes[0].Name,
+						resp.Desc.Name, resp.Index.Name,
+					)
+				}
+
+				if table.nCols != len(resp.Datums) {
+					t.Fatalf("expected %d columns, got %d columns", table.nCols, len(resp.Datums))
+				}
+
+				// Verify that the correct # of values are returned.
+				numVals := 0
+				for _, datum := range resp.Datums {
+					if datum != parser.DNull {
+						numVals++
+					}
+				}
+
+				// Some secondary index values can be NULL. We keep track
+				// of how many we encounter.
+				idxNull := resp.Datums[1] == parser.DNull
+				if idxNull {
+					nullCount++
+					// It is okay to bump this up by one since we know
+					// this index value is suppose to be NULL.
+					numVals++
+				}
+
+				if table.nVals != numVals {
+					t.Fatalf("expected %d non-NULL values, got %d", table.nVals, numVals)
+				}
+
+				id := int64(*resp.Datums[0].(*parser.DInt))
+				// Verify the value in the value column is
+				// correct (if it is not NULL).
+				if !idxNull {
+					idx := int64(*resp.Datums[1].(*parser.DInt))
+					if id%int64(table.modFactor) != idx {
+						t.Fatalf("for row id %d, expected %d value, got %d", id, id%int64(table.modFactor), idx)
+					}
+
+					// Index values must be fetched in
+					// non-decreasing order.
+					if prevIdxVal > idx {
+						t.Fatalf("index value unexpectedly decreased from %d to %d", prevIdxVal, idx)
+					}
+					prevIdxVal = idx
+				}
+
+				// We verify that the storing values are
+				// decoded correctly.
+				if tableName == "nonuniquestoring" || tableName == "uniquestoring" {
+					s1 := int64(*resp.Datums[2].(*parser.DInt))
+					s2 := int64(*resp.Datums[3].(*parser.DInt))
+
+					if id%int64(storingMods[0]) != s1 {
+						t.Fatalf("for row id %d, expected %d for s1 value, got %d", id, id%int64(storingMods[0]), s1)
+					}
+					if id%int64(storingMods[1]) != s2 {
+						t.Fatalf("for row id %d, expected %d for s2 value, got %d", id, id%int64(storingMods[1]), s2)
+					}
+				}
+			}
+
+			if table.nRows != count {
+				t.Fatalf("expected %d rows, got %d rows", table.nRows, count)
+			}
+		})
+	}
+}
+
+// Appends all non-empty subsets of indices in [0, maxIdx).
+func generateIdxSubsets(maxIdx int, subsets [][]int) [][]int {
+	if maxIdx < 0 {
+		return subsets
+	}
+	subsets = generateIdxSubsets(maxIdx-1, subsets)
+	curLength := len(subsets)
+	for i := 0; i < curLength; i++ {
+		// Keep original subsets by duplicating them.
+		dupe := make([]int, len(subsets[i]))
+		copy(dupe, subsets[i])
+		subsets = append(subsets, dupe)
+		// Generate new subsets with the current index.
+		subsets[i] = append(subsets[i], maxIdx)
+	}
+	return append(subsets, []int{maxIdx})
+}
+
+// We test reading rows from six tables in a database that contains two
+// interleave hierarchies.
+// The tables are structured as follows:
+// parent1
+// parent2
+//   child1
+//      grandchild1
+//	  grandgrandchild1
+//   child2
+//   grandgrandchild1@ggc1_unique_idx
+// parent3
+// We test reading rows from every non-empty subset for completeness.
+func TestNextRowInterleave(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	tableArgs := map[string]*fetcherEntryArgs{
+		"parent1": {
+			tableName: "parent1",
+			modFactor: 12,
+			schema:    "p1 INT PRIMARY KEY, v INT",
+			nRows:     100,
+			nCols:     2,
+			nVals:     2,
+		},
+		"parent2": {
+			tableName: "parent2",
+			modFactor: 3,
+			schema:    "p2 INT PRIMARY KEY, v INT",
+			nRows:     400,
+			nCols:     2,
+			nVals:     2,
+		},
+		"child1": {
+			tableName:        "child1",
+			modFactor:        5,
+			schema:           "p2 INT, c1 INT, v INT, PRIMARY KEY (p2, c1)",
+			interleaveSchema: "test.parent2 (p2)",
+			// child1 has more rows than parent2, thus some parent2
+			// rows will have multiple child1.
+			nRows: 500,
+			nCols: 3,
+			nVals: 3,
+		},
+		"grandchild1": {
+			tableName:        "grandchild1",
+			modFactor:        7,
+			schema:           "p2 INT, c1 INT, gc1 INT, v INT, PRIMARY KEY (p2, c1, gc1)",
+			interleaveSchema: "test.child1 (p2, c1)",
+			nRows:            2000,
+			nCols:            4,
+			nVals:            4,
+		},
+		"grandgrandchild1": {
+			tableName:        "grandgrandchild1",
+			modFactor:        12,
+			schema:           "p2 INT, c1 INT, gc1 INT, ggc1 INT, v INT, PRIMARY KEY (p2, c1, gc1, ggc1)",
+			interleaveSchema: "test.grandchild1 (p2, c1, gc1)",
+			nRows:            350,
+			nCols:            5,
+			nVals:            5,
+		},
+		"child2": {
+			tableName:        "child2",
+			modFactor:        42,
+			schema:           "p2 INT, c2 INT, v INT, PRIMARY KEY (p2, c2)",
+			interleaveSchema: "test.parent2 (p2)",
+			// child2 has less rows than parent2, thus not all
+			// parent2 rows will have a nested child2 row.
+			nRows: 100,
+			nCols: 3,
+			nVals: 3,
+		},
+		"parent3": {
+			tableName: "parent3",
+			modFactor: 42,
+			schema:    "p3 INT PRIMARY KEY, v INT",
+			nRows:     1,
+			nCols:     2,
+			nVals:     2,
+		},
+	}
+
+	// Initialize generating value functions for each table.
+	tableArgs["parent1"].genValue = sqlutils.ToRowFn(
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tableArgs["parent1"].modFactor),
+	)
+
+	tableArgs["parent2"].genValue = sqlutils.ToRowFn(
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tableArgs["parent2"].modFactor),
+	)
+
+	tableArgs["child1"].genValue = sqlutils.ToRowFn(
+		// Foreign key needs a shifted modulo.
+		sqlutils.RowModuloShiftedFn(tableArgs["parent2"].nRows),
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tableArgs["child1"].modFactor),
+	)
+
+	tableArgs["grandchild1"].genValue = sqlutils.ToRowFn(
+		// Foreign keys need a shifted modulo.
+		sqlutils.RowModuloShiftedFn(
+			tableArgs["child1"].nRows,
+			tableArgs["parent2"].nRows,
+		),
+		sqlutils.RowModuloShiftedFn(tableArgs["child1"].nRows),
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tableArgs["grandchild1"].modFactor),
+	)
+
+	tableArgs["grandgrandchild1"].genValue = sqlutils.ToRowFn(
+		// Foreign keys need a shifted modulo.
+		sqlutils.RowModuloShiftedFn(
+			tableArgs["grandchild1"].nRows,
+			tableArgs["child1"].nRows,
+			tableArgs["parent2"].nRows,
+		),
+		sqlutils.RowModuloShiftedFn(
+			tableArgs["grandchild1"].nRows,
+			tableArgs["child1"].nRows,
+		),
+		sqlutils.RowModuloShiftedFn(tableArgs["grandchild1"].nRows),
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tableArgs["grandgrandchild1"].modFactor),
+	)
+
+	tableArgs["child2"].genValue = sqlutils.ToRowFn(
+		// Foreign key needs a shifted modulo.
+		sqlutils.RowModuloShiftedFn(tableArgs["parent2"].nRows),
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tableArgs["child2"].modFactor),
+	)
+
+	tableArgs["parent3"].genValue = sqlutils.ToRowFn(
+		sqlutils.RowIdxFn,
+		sqlutils.RowModuloFn(tableArgs["parent3"].modFactor),
+	)
+
+	ggc1idx := *tableArgs["grandgrandchild1"]
+	// This is only possible since nrows(ggc1) < nrows(p2) thus c1 is
+	// unique.
+	ggc1idx.indexSchema = `CREATE UNIQUE INDEX ggc1_unique_idx ON test.grandgrandchild1 (p2) INTERLEAVE IN PARENT test.parent2 (p2);`
+	ggc1idx.indexName = "ggc1_unique_idx"
+	ggc1idx.indexIdx = 1
+	// Last column v is not stored in this index.
+	ggc1idx.valNeededForCol = []bool{true, true, true, true, false}
+	ggc1idx.nVals = 4
+
+	// We need an ordering of the tables in order to execute the interleave
+	// DDL statements.
+	interleaveEntries := []fetcherEntryArgs{
+		*tableArgs["parent1"],
+		*tableArgs["parent2"],
+		*tableArgs["child1"],
+		*tableArgs["grandchild1"],
+		*tableArgs["grandgrandchild1"],
+		*tableArgs["child2"],
+		ggc1idx,
+		*tableArgs["parent3"],
+	}
+
+	var maxCols int
+	for _, table := range interleaveEntries {
+		if table.indexSchema != "" {
+			// Create interleaved secondary indexes.
+			r := sqlutils.MakeSQLRunner(t, sqlDB)
+			r.Exec(table.indexSchema)
+		} else {
+			// Create tables (primary indexes).
+			sqlutils.CreateTableInterleave(
+				t, sqlDB, table.tableName,
+				table.schema,
+				table.interleaveSchema,
+				table.nRows,
+				table.genValue,
+			)
+		}
+
+		if table.nCols > maxCols {
+			maxCols = table.nCols
+		}
+
+	}
+
+	alloc := &DatumAlloc{}
+	// Backing slice for specifying which column values should be returned.
+	// By default, we want all the columns.
+	valNeededForCol := make([]bool, maxCols)
+	for i := range valNeededForCol {
+		valNeededForCol[i] = true
+	}
+
+	// Retrieve rows from every non-empty subset of the tables/indexes.
+	for _, idxs := range generateIdxSubsets(len(interleaveEntries)-1, nil) {
+		// Initialize our subset of tables/indexes.
+		entries := make([]*fetcherEntryArgs, len(idxs))
+		testNames := make([]string, len(entries))
+		for i, idx := range idxs {
+			entries[i] = &interleaveEntries[idx]
+			testNames[i] = entries[i].tableName
+			// Use the index name instead if we're scanning an index.
+			if entries[i].indexName != "" {
+				testNames[i] = entries[i].indexName
+			}
+		}
+
+		testName := strings.Join(testNames, "-")
+
+		t.Run(testName, func(t *testing.T) {
+			// Initialize the MultiRowFetcher.
+			args := make([]initFetcherArgs, len(entries))
+			lookupSpans := make([]roachpb.Span, len(entries))
+			// Used during NextRow to see if tableID << 32 |
+			// indexID (key) are with what we initialize
+			// MultiRowFetcher.
+			idLookups := make(map[uint64]*fetcherEntryArgs, len(entries))
+			for i, entry := range entries {
+				tableDesc := GetTableDescriptor(kvDB, testDB, entry.tableName)
+				var indexID IndexID
+				if entry.indexIdx == 0 {
+					indexID = tableDesc.PrimaryIndex.ID
+				} else {
+					indexID = tableDesc.Indexes[entry.indexIdx-1].ID
+				}
+				idLookups[idLookupKey(tableDesc.ID, indexID)] = entry
+
+				colsNeeded := valNeededForCol[:entry.nCols]
+				if entry.valNeededForCol != nil {
+					colsNeeded = entry.valNeededForCol
+				}
+
+				args[i] = initFetcherArgs{
+					tableDesc:       tableDesc,
+					indexIdx:        entry.indexIdx,
+					valNeededForCol: colsNeeded,
+				}
+
+				// We take every entry's index span (primary or
+				// secondary) and use it to start our scan.
+				lookupSpans[i] = tableDesc.IndexSpan(indexID)
+			}
+
+			lookupSpans, _ = roachpb.MergeSpans(lookupSpans)
+
+			mrf, err := initFetcher(args, false /*reverseScan*/, alloc)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := mrf.StartScan(
+				context.TODO(),
+				client.NewTxn(kvDB, 0),
+				lookupSpans,
+				false, /*limitBatches*/
+				0,     /*limitHint*/
+				false, /*traceKV*/
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			// Running count of rows processed for each table-index.
+			count := make(map[string]int, len(entries))
+
+			for {
+				resp, err := mrf.NextRowDecoded(context.TODO(), false /*traceKV*/)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if resp.Datums == nil {
+					break
+				}
+
+				entry, found := idLookups[idLookupKey(resp.Desc.ID, resp.Index.ID)]
+				if !found {
+					t.Fatalf(
+						"unexpected row from table %s - index %s",
+						resp.Desc.Name, resp.Index.Name,
+					)
+				}
+
+				tableIdxName := fmt.Sprintf("%s@%s", entry.tableName, entry.indexName)
+				count[tableIdxName]++
+
+				// Check that the correct # of columns is returned.
+				if entry.nCols != len(resp.Datums) {
+					t.Fatalf("for table %s expected %d columns, got %d columns", tableIdxName, entry.nCols, len(resp.Datums))
+				}
+
+				// Verify that the correct # of values are returned.
+				numVals := 0
+				for _, datum := range resp.Datums {
+					if datum != parser.DNull {
+						numVals++
+					}
+				}
+				if entry.nVals != numVals {
+					t.Fatalf("for table %s expected %d non-NULL values, got %d", tableIdxName, entry.nVals, numVals)
+				}
+
+				// Verify the value in the value column is
+				// correct if it is requested.
+				if entry.nVals == entry.nCols {
+					id := int64(*resp.Datums[entry.nCols-2].(*parser.DInt))
+					val := int64(*resp.Datums[entry.nCols-1].(*parser.DInt))
+
+					if id%int64(entry.modFactor) != val {
+						t.Fatalf("for table %s row id %d, expected %d value, got %d", tableIdxName, id, id%int64(entry.modFactor), val)
+					}
+				}
+			}
+
+			for tableIdxName, actual := range count {
+				// tableIdxName is formatted as tableName@indexName.
+				tableName := strings.Split(tableIdxName, "@")[0]
+				if tableArgs[tableName].nRows != actual {
+					t.Fatalf("for table %s expected %d rows, got %d rows", tableName, tableArgs[tableName].nRows, actual)
+				}
+			}
+		})
+	}
+}
+
+func idLookupKey(tableID ID, indexID IndexID) uint64 {
+	return (uint64(tableID) << 32) | uint64(indexID)
+}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -62,7 +62,7 @@ type RowFetcher struct {
 	// The set of ColumnIDs that are required.
 	neededCols util.FastIntSet
 
-	// True if the index key must be decoded. This is only true if there are no
+	// True if the index key must be decoded. This is only false if there are no
 	// needed columns and the table has no interleave children.
 	mustDecodeIndexKey bool
 
@@ -312,7 +312,7 @@ func (rf *RowFetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 func (rf *RowFetcher) prettyEncDatums(types []ColumnType, vals []EncDatum) string {
 	var buf bytes.Buffer
 	for i, v := range vals {
-		if err := v.EnsureDecoded(&types[i], &DatumAlloc{}); err != nil {
+		if err := v.EnsureDecoded(&types[i], rf.alloc); err != nil {
 			fmt.Fprintf(&buf, "error decoding: %v", err)
 		}
 		fmt.Fprintf(&buf, "/%v", v.Datum)

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 type indexKeyTest struct {
+	tableID              ID
 	primaryInterleaves   []ID
 	secondaryInterleaves []ID
 	primaryValues        []parser.Datum // len must be at least primaryInterleaveComponents+1
@@ -60,7 +61,7 @@ func makeTableDescForTest(test indexKeyTest) (TableDescriptor, map[ColumnID]int)
 		for j, ancestorTableID := range ancestorTableIDs {
 			interleave.Ancestors[j] = InterleaveDescriptor_Ancestor{
 				TableID:         ancestorTableID,
-				IndexID:         IndexID(ancestorTableID + 1),
+				IndexID:         1,
 				SharedPrefixLen: 1,
 			}
 		}
@@ -68,7 +69,7 @@ func makeTableDescForTest(test indexKeyTest) (TableDescriptor, map[ColumnID]int)
 	}
 
 	tableDesc := TableDescriptor{
-		ID:      50,
+		ID:      test.tableID,
 		Columns: columns,
 		PrimaryIndex: IndexDescriptor{
 			ID:               1,
@@ -130,31 +131,31 @@ func TestIndexKey(t *testing.T) {
 	var a DatumAlloc
 
 	tests := []indexKeyTest{
-		{nil, nil,
+		{50, nil, nil,
 			[]parser.Datum{parser.NewDInt(10)},
 			[]parser.Datum{parser.NewDInt(20)},
 		},
-		{[]ID{100}, nil,
+		{50, []ID{100}, nil,
 			[]parser.Datum{parser.NewDInt(10), parser.NewDInt(11)},
 			[]parser.Datum{parser.NewDInt(20)},
 		},
-		{[]ID{100, 200}, nil,
+		{50, []ID{100, 200}, nil,
 			[]parser.Datum{parser.NewDInt(10), parser.NewDInt(11), parser.NewDInt(12)},
 			[]parser.Datum{parser.NewDInt(20)},
 		},
-		{nil, []ID{100},
+		{50, nil, []ID{100},
 			[]parser.Datum{parser.NewDInt(10)},
 			[]parser.Datum{parser.NewDInt(20), parser.NewDInt(21)},
 		},
-		{[]ID{100}, []ID{100},
+		{50, []ID{100}, []ID{100},
 			[]parser.Datum{parser.NewDInt(10), parser.NewDInt(11)},
 			[]parser.Datum{parser.NewDInt(20), parser.NewDInt(21)},
 		},
-		{[]ID{100}, []ID{200},
+		{50, []ID{100}, []ID{200},
 			[]parser.Datum{parser.NewDInt(10), parser.NewDInt(11)},
 			[]parser.Datum{parser.NewDInt(20), parser.NewDInt(21)},
 		},
-		{[]ID{100, 200}, []ID{100, 300},
+		{50, []ID{100, 200}, []ID{100, 300},
 			[]parser.Datum{parser.NewDInt(10), parser.NewDInt(11), parser.NewDInt(12)},
 			[]parser.Datum{parser.NewDInt(20), parser.NewDInt(21), parser.NewDInt(22)},
 		},
@@ -480,5 +481,312 @@ func TestMarshalColumnValue(t *testing.T) {
 		} else if !reflect.DeepEqual(actual, testCase.exp) {
 			t.Errorf("%d: MarshalColumnValue() got %s, expected %v", i, actual, testCase.exp)
 		}
+	}
+}
+
+type interleaveTableArgs struct {
+	indexKeyArgs indexKeyTest
+	values       []parser.Datum
+}
+
+type interleaveInfo struct {
+	tableID  uint64
+	values   []parser.Datum
+	equivSig []byte
+	children map[string]*interleaveInfo
+}
+
+func createHierarchy() map[string]*interleaveInfo {
+	return map[string]*interleaveInfo{
+		"t1": {
+			tableID: 50,
+			values:  []parser.Datum{parser.NewDInt(10)},
+			children: map[string]*interleaveInfo{
+				"t2": {
+					tableID: 100,
+					values:  []parser.Datum{parser.NewDInt(10), parser.NewDInt(15)},
+				},
+				"t3": {
+					tableID: 150,
+					values:  []parser.Datum{parser.NewDInt(10), parser.NewDInt(20)},
+					children: map[string]*interleaveInfo{
+						"t4": {
+							tableID: 20,
+							values:  []parser.Datum{parser.NewDInt(10), parser.NewDInt(30)},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+type equivSigTestCases struct {
+	name     string
+	table    interleaveTableArgs
+	expected [][]byte
+}
+
+func createEquivTCs(hierarchy map[string]*interleaveInfo) []equivSigTestCases {
+	return []equivSigTestCases{
+		{
+			name: "NoAncestors",
+			table: interleaveTableArgs{
+				indexKeyArgs: indexKeyTest{tableID: 50},
+				values:       []parser.Datum{parser.NewDInt(10)},
+			},
+			expected: [][]byte{hierarchy["t1"].equivSig},
+		},
+
+		{
+			name: "OneAncestor",
+			table: interleaveTableArgs{
+				indexKeyArgs: indexKeyTest{tableID: 100, primaryInterleaves: []ID{50}},
+				values:       []parser.Datum{parser.NewDInt(10), parser.NewDInt(20)},
+			},
+			expected: [][]byte{hierarchy["t1"].equivSig, hierarchy["t1"].children["t2"].equivSig},
+		},
+
+		{
+			name: "TwoAncestors",
+			table: interleaveTableArgs{
+				indexKeyArgs: indexKeyTest{tableID: 20, primaryInterleaves: []ID{50, 150}},
+				values:       []parser.Datum{parser.NewDInt(10), parser.NewDInt(20), parser.NewDInt(30)},
+			},
+			expected: [][]byte{hierarchy["t1"].equivSig, hierarchy["t1"].children["t3"].equivSig, hierarchy["t1"].children["t3"].children["t4"].equivSig},
+		},
+	}
+}
+
+// equivSignatures annotates the hierarchy with the equivalence signatures
+// for each table and returns an in-order depth-first traversal of the
+// equivalence signatures.
+func equivSignatures(
+	hierarchy map[string]*interleaveInfo, parent []byte, signatures [][]byte,
+) [][]byte {
+	for _, info := range hierarchy {
+		// Reset the reference to the parent for every child.
+		curParent := parent
+		curParent = encoding.EncodeUvarintAscending(curParent, info.tableID)
+		// Primary ID is always 1
+		curParent = encoding.EncodeUvarintAscending(curParent, 1)
+		info.equivSig = make([]byte, len(curParent))
+		copy(info.equivSig, curParent)
+		signatures = append(signatures, info.equivSig)
+		if len(info.children) > 0 {
+			curParent = encoding.EncodeNotNullDescending(curParent)
+			signatures = equivSignatures(info.children, curParent, signatures)
+		}
+	}
+	return signatures
+}
+
+func TestIndexKeyEquivSignature(t *testing.T) {
+	hierarchy := createHierarchy()
+	hierarchySigs := equivSignatures(hierarchy, nil /*parent*/, nil /*signatures*/)
+	// validEquivSigs is necessary for IndexKeyEquivSignatures.
+	validEquivSigs := make(map[string]int)
+	for i, sig := range hierarchySigs {
+		validEquivSigs[string(sig)] = i
+	}
+
+	// Required buffers when extracting the index key's equivalence signature.
+	var keySigBuf, keyRestBuf []byte
+
+	for _, tc := range createEquivTCs(hierarchy) {
+		t.Run(tc.name, func(t *testing.T) {
+			// We need to initialize this for makeTableDescForTest.
+			tc.table.indexKeyArgs.primaryValues = tc.table.values
+			// Setup descriptors and form an index key.
+			desc, colMap := makeTableDescForTest(tc.table.indexKeyArgs)
+			primaryKeyPrefix := MakeIndexKeyPrefix(&desc, desc.PrimaryIndex.ID)
+			primaryKey, _, err := EncodeIndexKey(
+				&desc, &desc.PrimaryIndex, colMap, tc.table.values, primaryKeyPrefix)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			tableIdx, restKey, match, err := IndexKeyEquivSignature(primaryKey, validEquivSigs, keySigBuf, keyRestBuf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !match {
+				t.Fatalf("expected to extract equivalence signature from index key, instead false returned")
+			}
+
+			tableSig := tc.expected[len(tc.expected)-1]
+			expectedTableIdx := validEquivSigs[string(tableSig)]
+			if expectedTableIdx != tableIdx {
+				t.Fatalf("table index returned does not match table index from validEquivSigs.\nexpected %d\nactual %d", expectedTableIdx, tableIdx)
+			}
+
+			// Column values should be at the beginning of the
+			// remaining bytes of the key.
+			colVals, null, err := EncodeColumns(desc.PrimaryIndex.ColumnIDs, desc.PrimaryIndex.ColumnDirections, colMap, tc.table.values, nil /*key*/)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if null {
+				t.Fatalf("unexpected null values when encoding expected column values")
+			}
+
+			if !bytes.Equal(colVals, restKey[:len(colVals)]) {
+				t.Fatalf("missing column values from rest of key.\nexpected %v\nactual %v", colVals, restKey[:len(colVals)])
+			}
+
+			// The remaining bytes of the key should be the same
+			// length as the primary key minus the equivalence
+			// signature bytes.
+			if len(primaryKey)-len(tableSig) != len(restKey) {
+				t.Fatalf("unexpected rest of key length, expected %d, actual %d", len(primaryKey)-len(tableSig), len(restKey))
+			}
+		})
+	}
+}
+
+// TestTableEquivSignatures verifies that TableEquivSignatures returns a slice
+// of slice references to a table's interleave ancestors' equivalence
+// signatures.
+func TestTableEquivSignatures(t *testing.T) {
+	hierarchy := createHierarchy()
+	equivSignatures(hierarchy, nil /*parent*/, nil /*signatures*/)
+
+	for _, tc := range createEquivTCs(hierarchy) {
+		t.Run(tc.name, func(t *testing.T) {
+			// We need to initialize this for makeTableDescForTest.
+			tc.table.indexKeyArgs.primaryValues = tc.table.values
+			// Setup descriptors and form an index key.
+			desc, _ := makeTableDescForTest(tc.table.indexKeyArgs)
+			equivSigs, err := TableEquivSignatures(&desc, &desc.PrimaryIndex)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(equivSigs) != len(tc.expected) {
+				t.Fatalf("expected %d equivalence signatures from TableEquivSignatures, actual %d", len(tc.expected), len(equivSigs))
+			}
+			for i, sig := range equivSigs {
+				if !bytes.Equal(sig, tc.expected[i]) {
+					t.Fatalf("equivalence signatures at index %d do not match.\nexpected\t%v\nactual\t%v", i, tc.expected[i], sig)
+				}
+			}
+		})
+	}
+}
+
+// TestEquivSignature verifies that invoking IndexKeyEquivSignature for an encoded index key
+// for a given table-index pair returns the equivalent equivalence signature as
+// that of the table-index from invoking TableEquivSignatures.
+// It also checks that the equivalence signature is not equivalent to any other
+// tables' equivalence signatures.
+func TestEquivSignature(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		tables []interleaveTableArgs
+	}{
+		{
+			name: "Simple",
+			tables: []interleaveTableArgs{
+				{
+					indexKeyArgs: indexKeyTest{tableID: 50},
+					values:       []parser.Datum{parser.NewDInt(10)},
+				},
+				{
+					indexKeyArgs: indexKeyTest{tableID: 51},
+					values:       []parser.Datum{parser.NewDInt(20)},
+				},
+			},
+		},
+
+		{
+			name: "ParentAndChild",
+			tables: []interleaveTableArgs{
+				{
+					indexKeyArgs: indexKeyTest{tableID: 50},
+					values:       []parser.Datum{parser.NewDInt(10)},
+				},
+				{
+					indexKeyArgs: indexKeyTest{tableID: 51, primaryInterleaves: []ID{50}},
+					values:       []parser.Datum{parser.NewDInt(10), parser.NewDInt(20)},
+				},
+			},
+		},
+
+		{
+			name: "Siblings",
+			tables: []interleaveTableArgs{
+				{
+					indexKeyArgs: indexKeyTest{tableID: 50},
+					values:       []parser.Datum{parser.NewDInt(10)},
+				},
+				{
+					indexKeyArgs: indexKeyTest{tableID: 51, primaryInterleaves: []ID{50}},
+					values:       []parser.Datum{parser.NewDInt(10), parser.NewDInt(20)},
+				},
+				{
+					indexKeyArgs: indexKeyTest{tableID: 52, primaryInterleaves: []ID{50}},
+					values:       []parser.Datum{parser.NewDInt(30), parser.NewDInt(40)},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			keyEquivSigs := make([][]byte, len(tc.tables))
+			tableEquivSigs := make([][]byte, len(tc.tables))
+
+			for i, table := range tc.tables {
+				// We need to initialize this for makeTableDescForTest.
+				table.indexKeyArgs.primaryValues = table.values
+
+				// Setup descriptors and form an index key.
+				desc, colMap := makeTableDescForTest(table.indexKeyArgs)
+				primaryKeyPrefix := MakeIndexKeyPrefix(&desc, desc.PrimaryIndex.ID)
+				primaryKey, _, err := EncodeIndexKey(
+					&desc, &desc.PrimaryIndex, colMap, table.values, primaryKeyPrefix)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Extract out the table's equivalence signature.
+				tempEquivSigs, err := TableEquivSignatures(&desc, &desc.PrimaryIndex)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// The last signature is this table's.
+				tableEquivSigs[i] = tempEquivSigs[len(tempEquivSigs)-1]
+
+				validEquivSigs := make(map[string]int)
+				for i, sig := range tempEquivSigs {
+					validEquivSigs[string(sig)] = i
+				}
+				// Extract out the corresponding table index
+				// of the index key's signature.
+				tableIdx, _, _, err := IndexKeyEquivSignature(primaryKey, validEquivSigs, nil /*keySigBuf*/, nil /*keyRestBuf*/)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// Map the table index back to the signature.
+				keyEquivSigs[i] = tempEquivSigs[tableIdx]
+			}
+
+			for i, keySig := range keyEquivSigs {
+				for j, tableSig := range tableEquivSigs {
+					if i == j {
+						// The corresponding table should have the same
+						// equivalence signature as the one derived from the key.
+						if !bytes.Equal(keySig, tableSig) {
+							t.Fatalf("IndexKeyEquivSignature differs from equivalence signature for its table.\nKeySignature: %v\nTableSignature: %v", keySig, tableSig)
+						}
+					} else {
+						// A different table should not have
+						// the same equivalence signature.
+						if bytes.Equal(keySig, tableSig) {
+							t.Fatalf("IndexKeyEquivSignature produces equivalent signature for a different table.\nKeySignature: %v\nTableSignature: %v", keySig, tableSig)
+						}
+					}
+				}
+			}
+
+		})
 	}
 }

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -72,12 +72,12 @@ const (
 
 	// IntMin is chosen such that the range of int tags does not overlap the
 	// ascii character set that is frequently used in testing.
-	IntMin      = 0x80
+	IntMin      = 0x80 // 128
 	intMaxWidth = 8
-	intZero     = IntMin + intMaxWidth
+	intZero     = IntMin + intMaxWidth           // 136
 	intSmall    = IntMax - intZero - intMaxWidth // 109
 	// IntMax is the maximum int tag value.
-	IntMax = 0xfd
+	IntMax = 0xfd // 253
 
 	// Nulls come last when encoded descendingly.
 	encodedNotNullDesc = 0xfe


### PR DESCRIPTION
This PR introduces `MultiRowFetcher` which generalizees `RowFetcher` to
respond to and return rows from multiple tables from the same set of
spans.

`MultiRowFetcher` is initialized with a slice of `MultiRowFetcherArgs`
which encapsulates the arguments for one table in `RowFetcher`.

One key point is that the `reverse bool` argument that exists in
`RowFetcher` can only be enabled on a per-fetcher basis: one cannot scan
in arbitrary directions on a per-table basis (since row kvfetcher works
by scanning KV pairs sequentially).

`MultiRowFetcher` is necessary in order to fetch interleaved tables
efficiently in one-pass. See the RFC for interleaved tables here
https://github.com/cockroachdb/cockroach/pull/19028.

There are no tests yet since I wanted to get some comments on this approach. `MultiRowFetcher`
is backwards compatible with `RowFetcher`: only the `Init` parameters and the response from `NextRow/NextRowDecoded` differs slightly.

cc: @vivekmenezes 