### PR TITLE
cli: use closure for better caller

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1162,7 +1162,12 @@ func (s *adminServer) Drain(req *serverpb.DrainRequest, stream serverpb.Admin_Dr
 	s.server.grpc.Stop()
 
 	ctx := stream.Context()
-	go s.server.stopper.Stop(ctx)
+	go func() {
+		// The explicit closure here allows callers.Lookup() to return something
+		// sensible referring to this file (otherwise it ends up in runtime
+		// internals).
+		s.server.stopper.Stop(ctx)
+	}()
 
 	select {
 	case <-s.server.stopper.IsStopped():


### PR DESCRIPTION
This avoids the unhelpful caller in this server log message during `./cockroach
quit`:

> I171013 12:32:26.868578 216 util/stop/stopper.go:402 stop has been called from
> /usr/local/Cellar/go/1.9/libexec/src/runtime/asm_amd64.s:2337, stopping or
> quiescing all running tasks

Observed in #19231.