### PR TITLE
sql: cache anonymized stmt str for prepared stmts

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -506,6 +506,8 @@ func (e *Executor) Prepare(
 	}
 
 	prepared.Statement = stmt.AST
+	prepared.AnonymizedStr = session.appStats.getStrForStmt(stmt)
+
 	if err := placeholderHints.ProcessPlaceholderAnnotations(stmt.AST); err != nil {
 		return nil, err
 	}
@@ -678,6 +680,7 @@ func (e *Executor) execPrepared(
 		stmts = StatementList{{
 			AST:           stmt.Statement,
 			ExpectedTypes: stmt.Columns,
+			AnonymizedStr: stmt.AnonymizedStr,
 		}}
 	}
 	// Send the Request for SQL execution and set the application-level error
@@ -1757,6 +1760,7 @@ func (e *Executor) execStmtInOpenTxn(
 		pinfo = newPInfo
 		stmt.AST = ps.Statement
 		stmt.ExpectedTypes = ps.Columns
+		stmt.AnonymizedStr = ps.AnonymizedStr
 	}
 
 	var p *planner

--- a/pkg/sql/prepare.go
+++ b/pkg/sql/prepare.go
@@ -36,6 +36,9 @@ type PreparedStatement struct {
 	// the future to present a contextual error message based on location
 	// information.
 	Str string
+	// AnonymizedStr is the anonymized statement string suitable for recording
+	// in statement statistics.
+	AnonymizedStr string
 	// Statement is the parsed, prepared SQL statement. It may be nil if the
 	// prepared statement is empty.
 	Statement parser.Statement
@@ -67,6 +70,7 @@ func (p *PreparedStatement) close(ctx context.Context, s *Session) {
 type Statement struct {
 	AST           parser.Statement
 	ExpectedTypes sqlbase.ResultColumns
+	AnonymizedStr string
 	queryID       uint128.Uint128
 	queryMeta     *queryMeta
 }


### PR DESCRIPTION
Previously, executing a prepared statement would always compute the
anonymized statement string for insertion into the statement statistics
map. This is unnecessary since a prepared statement always has the same
"query shape" - we can reuse the same anonymized statement string every
time.

Now, the anonymized statement string is computed during the query
preparation stage and reused during execution.

`recordStatementSummary` used to take up about 10% of the time of
`execStmt` in a simple `kv` workload - now it takes less than 2%.