### PR TITLE
build: introduce packer template for TeamCity agent

### DIFF
--- a/build/packer/README.md
+++ b/build/packer/README.md
@@ -1,0 +1,19 @@
+# build/packer
+
+This directory contains [Packer] templates that automate building VM images.
+To use, install Packer, then run:
+
+```
+$ packer build VM-TEMPLATE.json
+```
+
+The location of the created VM image will be printed when the build completes.
+
+At present, the only VM template available builds TeamCity agents. You'll need
+`DIGITALOCEAN_API_TOKEN` set in your environment. Employees can find the token
+in customenv.mk. You'll also need to use [Nikhil's fork of
+Packer][benesch-packer] until [packer#5527] lands.
+
+[Packer]: https://www.packer.io
+[benesch-packer]: https://github.com/benesch/packer/tree/digitalocean
+[packer#5527]: https://github.com/hashicorp/packer/pull/5527

--- a/build/packer/teamcity-agent.json
+++ b/build/packer/teamcity-agent.json
@@ -1,0 +1,25 @@
+{
+  "variables": {
+    "image_id": "teamcity-agent-{{timestamp}}"
+  },
+
+  "builders": [{
+      "type": "digitalocean",
+      "image": "ubuntu-16-04-x64",
+      "region": "nyc1",
+      "size": "c-16",
+      "snapshot_name": "{{user `image_id`}}",
+      "snapshot_regions": ["nyc1"],
+      "ssh_username": "root",
+      "volumes": [{
+        "size": 25,
+        "snapshot_name": "{{user `image_id`}}-vol"
+      }]
+  }],
+
+  "provisioners": [{
+    "type": "shell",
+    "environment_vars": ["DIGITAL_OCEAN_IMAGE_ID={{user `image_id`}}"],
+    "script": "teamcity-agent.sh"
+  }]
+}

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+write_teamcity_config() {
+  sudo -u agent tee /home/agent/conf/buildAgent.properties <<EOF
+serverUrl=https://teamcity.cockroachdb.com
+name=
+workDir=../work
+tempDir=../temp
+systemDir=../system
+digitalocean-cloud.image.id=$DIGITAL_OCEAN_IMAGE_ID
+EOF
+}
+
+# Avoid saving any Bash history.
+HISTSIZE=0
+
+# High CPU instances only have 20GiB of local SSD, so mount a block storage
+# volume to hold Docker's data.
+[[ -e /dev/sda ]] || { echo "no volume attached, exiting" >&2; exit 1; }
+mkfs.ext4 /dev/sda
+mkdir -p /var/lib/docker
+echo '/dev/sda /var/lib/docker ext4 discard 0 2' >> /etc/fstab
+mount -a
+
+# Add third-party APT repositories.
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0EBFCD88
+cat > /etc/apt/sources.list.d/docker.list <<EOF
+deb https://download.docker.com/linux/ubuntu xenial stable
+EOF
+apt-add-repository ppa:webupd8team/java
+add-apt-repository ppa:gophers/archive
+apt-get update --yes
+
+# Auto-accept the Oracle Java license agreement.
+debconf-set-selections <<< "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true"
+
+# Install the necessary dependencies. Keep this list small!
+apt-get install --yes \
+  docker-ce \
+  golang-1.9 \
+  oracle-java8-installer \
+  unzip
+
+# Link Go into the PATH; the PPA installs it into /usr/lib/go-1.x/bin.
+ln -s /usr/lib/go-1.9/bin/go /usr/bin/go
+
+# Add a user for the TeamCity agent with Docker rights.
+adduser agent --disabled-password
+adduser agent docker
+
+# Download the TeamCity agent code and install its configuration.
+# N.B.: This must be done as the agent user.
+su - agent <<'EOF'
+set -euxo pipefail
+
+echo 'export GOPATH="$HOME"/work/.go' >> .profile && source .profile
+
+wget https://teamcity.cockroachdb.com/update/buildAgent.zip
+unzip buildAgent.zip
+rm buildAgent.zip
+
+# Cache the current version of the main Cockroach repository on the agent to
+# speed up the first build. As of 2017-10-13, the main repository is 450MB (!).
+# The other repositories we run CI on are small enough not to be worth caching,
+# but feel free to add them if it becomes necessary.
+#
+# WARNING: This uses undocumented implementation details of TeamCity's Git
+# alternate system.
+git clone --bare https://github.com/cockroachdb/cockroach system/git/cockroach.git
+cat > system/git/map <<EOS
+https://github.com/cockroachdb/cockroach = cockroach.git
+EOS
+
+# For master and the last two release, download the builder and postgres-test
+# containers.
+repo="$GOPATH"/src/github.com/cockroachdb/cockroach
+git clone --shared system/git/cockroach.git "$repo"
+cd "$repo"
+for branch in $(git branch --all --list --sort=-committerdate 'origin/release-*' | head -n1) master
+do
+  git checkout "$branch"
+  build/builder.sh make gotestdashi
+  # TODO(benesch): store the postgres-test version somewhere more accessible.
+  docker pull $(git grep cockroachdb/postgres-test -- '*.go' | sed -E 's/.*"([^"]*).*"/\1/') || true
+done
+cd -
+EOF
+write_teamcity_config
+
+# Configure the Teamcity agent to start when the server starts.
+#
+# systemd will nuke the auto-upgrade process unless we mark the service as
+# "oneshot". This has the unfortunate side-effect of making `systemctl start
+# teamcity-agent` hang forever when run manually, but it at least works when the
+# system starts the service at bootup.
+#
+# TODO(benesch): see if we can fix this with Type=forking, KillMode=process.
+cat > /etc/systemd/system/teamcity-agent.service <<EOF
+[Unit]
+Description=TeamCity Build Agent
+After=network.target
+Requires=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+User=agent
+PIDFile=/home/agent/logs/buildAgent.pid
+ExecStart=/home/agent/bin/agent.sh start
+ExecStop=/home/agent/bin/agent.sh stop
+SuccessExitStatus=0 143
+
+[Install]
+WantedBy=multi-user.target
+EOF
+systemctl enable teamcity-agent.service
+
+# Boot the TeamCity agent so it can be upgraded by the server (i.e., download
+# and install whatever plugins the server has installed) before we bake the
+# image.
+#
+# WARNING: There seems to be no clean way to check when the upgrade is complete.
+# As a hack, the string below seems to appear in the logs iff the upgrade is
+# successful.
+systemctl start teamcity-agent.service
+until grep -q 'Updating agent parameters on the server' /home/agent/logs/teamcity-agent.log
+do
+  echo .
+  sleep 5
+done
+
+# Re-write the TeamCity config to discard the name and authorization token
+# assigned by the TeamCity server; otherwise, agents created from this image
+# might look like unauthorized duplicates to the TeamCity server.
+systemctl stop teamcity-agent.service
+write_teamcity_config
+
+# Prepare for imaging by removing unnecessary files.
+rm -rf /home/agent/logs
+apt-get clean
+sync

--- a/build/teamcity-rebuild-agent.sh
+++ b/build/teamcity-rebuild-agent.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+export BUILDER_HIDE_GOPATH_SRC=1
+
+docker run \
+  --rm --interactive --tty \
+  --env=DIGITALOCEAN_API_TOKEN \
+  --volume="$PWD/build/packer:/packer" \
+  --workdir=/packer \
+  hashicorp/packer:1.1.0 \
+  build teamcity-agent.json


### PR DESCRIPTION
Teach Packer to completely automate the process of building a new
TeamCity agent. The whole shebang takes less than ten minutes.