### PR TITLE
sql: don't run db.Txn when getting cached db descs

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -112,7 +112,11 @@ func getTableID(ctx context.Context, p *planner, tn *parser.TableName) (sqlbase.
 		return virtual.GetID(), nil
 	}
 
-	dbID, err := p.session.tables.databaseCache.getDatabaseID(ctx, p.txn, p.getVirtualTabler(), tn.Database())
+	txnRunner := func(ctx context.Context, retryable func(ctx context.Context, txn *client.Txn) error) error {
+		return retryable(ctx, p.txn)
+	}
+
+	dbID, err := p.session.tables.databaseCache.getDatabaseID(ctx, txnRunner, p.getVirtualTabler(), tn.Database())
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -318,14 +318,8 @@ func (tc *TableCollection) getTableVersion(
 	if dbID == 0 {
 		// Resolve the database from the database cache when the transaction
 		// hasn't modified the database.
-		if err := tc.leaseMgr.LeaseStore.db.Txn(
-			ctx,
-			func(ctx context.Context, txn *client.Txn) error {
-				var err error
-				dbID, err = tc.databaseCache.getDatabaseID(ctx, txn, vt, tn.Database())
-				return err
-			},
-		); err != nil {
+		dbID, err = tc.databaseCache.getDatabaseID(ctx, tc.leaseMgr.LeaseStore.db.Txn, vt, tn.Database())
+		if err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Previously, when fetching the database ID from the database cache
(something that happens once per SQL transaction), we would always run
`db.Txn` regardless of whether the database ID was already in the cache
or not. `db.Txn` is fairly heavy-weight and shouldn't be invoked unless
necessary.

Now, we pass a function that invokes `db.Txn` into the cache, permitting
it to only make a new transaction when the database descriptor isn't
present.

I noticed this because we were spending about 5% of the whole execStmt
flow running `db.Txn`s pointlessly, since the vast majority of the time
we have the database descriptor cached. That 5% was attributed to
planning, since the database and table resolution happens during
planning. After this change, planning takes up 35% instead of 40% of the
execStmt flow.