### PR TITLE
sqlbase: remove ColumnType from EncDatum

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -1386,6 +1386,7 @@ func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 		// able to do this in memory, but requires that rows added to it be done
 		// in order. Thus, we first need to fetch all rows and sort them. We use
 		// NewRocksDBMap to write the rows, then fetch them in order using an iterator.
+		types := sp.input.Types()
 		input := distsqlrun.MakeNoMetadataRowSource(sp.input, sp.output)
 		alloc := &sqlbase.DatumAlloc{}
 		store := engine.NewRocksDBMultiMap(sp.tempStorage)
@@ -1404,7 +1405,7 @@ func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 				return errors.Errorf("expected 2 datums, got %d", len(row))
 			}
 			for i, ed := range row {
-				if err := ed.EnsureDecoded(alloc); err != nil {
+				if err := ed.EnsureDecoded(&types[i], alloc); err != nil {
 					return err
 				}
 				datum := ed.Datum.(*parser.DBytes)

--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -45,15 +45,16 @@ func (s *Server) refreshSettings() {
 		var k, v, t string
 		// First we need to decode the setting name field from the index key.
 		{
-			nameRow := []sqlbase.EncDatum{{Type: tbl.Columns[0].Type}}
-			_, matches, err := sqlbase.DecodeIndexKey(a, tbl, &tbl.PrimaryIndex, nameRow, nil, kv.Key)
+			types := []sqlbase.ColumnType{tbl.Columns[0].Type}
+			nameRow := make([]sqlbase.EncDatum, 1)
+			_, matches, err := sqlbase.DecodeIndexKey(tbl, &tbl.PrimaryIndex, types, nameRow, nil, kv.Key)
 			if err != nil {
 				return errors.Wrap(err, "failed to decode key")
 			}
 			if !matches {
 				return errors.Errorf("unexpected non-settings KV with settings prefix: %v", kv.Key)
 			}
-			if err := nameRow[0].EnsureDecoded(a); err != nil {
+			if err := nameRow[0].EnsureDecoded(&types[0], a); err != nil {
 				return err
 			}
 			k = string(parser.MustBeDString(nameRow[0].Datum))

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -545,7 +545,7 @@ func (sc *SchemaChanger) distBackfill(
 			// them.
 			recv, err := makeDistSQLReceiver(
 				ctx,
-				nil, /* sink */
+				nil, /* resultWriter */
 				nil, /* rangeCache */
 				nil, /* leaseCache */
 				nil, /* txn - the flow does not run wholly in a txn */

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2305,7 +2305,7 @@ func (dsp *distSQLPlanner) createPlanForValues(
 		for j := range n.columns {
 			var err error
 			datum := sqlbase.DatumToEncDatum(types[j], datums[j])
-			buf, err = datum.Encode(&a, s.Columns[j].Encoding, buf)
+			buf, err = datum.Encode(&types[j], &a, s.Columns[j].Encoding, buf)
 			if err != nil {
 				return physicalPlan{}, err
 			}

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -339,8 +339,8 @@ func checkDistAggregationInfo(
 			default:
 				// For all other types, a simple string
 				// representation comparison will suffice.
-				strDist = rowDist.String()
-				strNonDist = rowNonDist.String()
+				strDist = rowDist.Datum.String()
+				strNonDist = rowNonDist.Datum.String()
 				equiv = strDist == strNonDist
 			}
 			if !equiv {

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -52,9 +52,11 @@ func TestAggregator(t *testing.T) {
 	colPtr := func(idx uint32) *uint32 { return &idx }
 
 	testCases := []struct {
-		spec     AggregatorSpec
-		input    sqlbase.EncDatumRows
-		expected sqlbase.EncDatumRows
+		spec        AggregatorSpec
+		inputTypes  []sqlbase.ColumnType
+		input       sqlbase.EncDatumRows
+		outputTypes []sqlbase.ColumnType
+		expected    sqlbase.EncDatumRows
 	}{
 		{
 			// SELECT MIN(@0), MAX(@0), COUNT(@0), AVG(@0), SUM(@0), STDDEV(@0),
@@ -91,7 +93,17 @@ func TestAggregator(t *testing.T) {
 					},
 				},
 			},
-			input: sqlbase.EncDatumRows{},
+			inputTypes: oneIntCol,
+			input:      sqlbase.EncDatumRows{},
+			outputTypes: []sqlbase.ColumnType{
+				intType, // MIN
+				intType, // MAX
+				intType, // COUNT
+				decType, // AVG
+				decType, // SUM
+				decType, // STDDEV
+				decType, // VARIANCE
+			},
 			expected: sqlbase.EncDatumRows{
 				{null, null, v[0], null, null, null, null},
 			},
@@ -111,6 +123,7 @@ func TestAggregator(t *testing.T) {
 					},
 				},
 			},
+			inputTypes: twoIntCols,
 			input: sqlbase.EncDatumRows{
 				{v[1], v[2]},
 				{v[3], null},
@@ -118,6 +131,7 @@ func TestAggregator(t *testing.T) {
 				{v[7], v[2]},
 				{v[8], v[4]},
 			},
+			outputTypes: twoIntCols,
 			expected: sqlbase.EncDatumRows{
 				{null, v[1]},
 				{v[4], v[1]},
@@ -139,6 +153,7 @@ func TestAggregator(t *testing.T) {
 					},
 				},
 			},
+			inputTypes: twoIntCols,
 			input: sqlbase.EncDatumRows{
 				{v[1], v[2]},
 				{v[3], v[4]},
@@ -146,11 +161,13 @@ func TestAggregator(t *testing.T) {
 				{v[7], v[2]},
 				{v[8], v[4]},
 			},
+			outputTypes: twoIntCols,
 			expected: sqlbase.EncDatumRows{
 				{v[4], v[2]},
 				{v[2], v[3]},
 			},
-		}, {
+		},
+		{
 			// SELECT @2, SUM(@1), GROUP BY @2.
 			spec: AggregatorSpec{
 				GroupCols: []uint32{1},
@@ -165,6 +182,7 @@ func TestAggregator(t *testing.T) {
 					},
 				},
 			},
+			inputTypes: twoIntCols,
 			input: sqlbase.EncDatumRows{
 				{v[1], v[2]},
 				{v[3], v[4]},
@@ -172,11 +190,16 @@ func TestAggregator(t *testing.T) {
 				{v[7], v[2]},
 				{v[8], v[4]},
 			},
+			outputTypes: []sqlbase.ColumnType{
+				intType, // IDENT
+				decType, // SUM
+			},
 			expected: sqlbase.EncDatumRows{
 				{v[2], v[14]},
 				{v[4], v[11]},
 			},
-		}, {
+		},
+		{
 			// SELECT COUNT(@1), SUM(@1), GROUP BY [] (empty group key).
 			spec: AggregatorSpec{
 				Aggregations: []AggregatorSpec_Aggregation{
@@ -190,12 +213,17 @@ func TestAggregator(t *testing.T) {
 					},
 				},
 			},
+			inputTypes: twoIntCols,
 			input: sqlbase.EncDatumRows{
 				{v[1], v[2]},
 				{v[1], v[4]},
 				{v[3], v[2]},
 				{v[4], v[2]},
 				{v[5], v[4]},
+			},
+			outputTypes: []sqlbase.ColumnType{
+				intType, // COUNT
+				decType, // SUM
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[5], v[14]},
@@ -212,6 +240,7 @@ func TestAggregator(t *testing.T) {
 					},
 				},
 			},
+			inputTypes: oneIntCol,
 			input: sqlbase.EncDatumRows{
 				{v[2]},
 				{v[4]},
@@ -219,6 +248,7 @@ func TestAggregator(t *testing.T) {
 				{v[2]},
 				{v[4]},
 			},
+			outputTypes: []sqlbase.ColumnType{decType},
 			expected: sqlbase.EncDatumRows{
 				{v[6]},
 			},
@@ -233,15 +263,18 @@ func TestAggregator(t *testing.T) {
 					},
 				},
 			},
+			inputTypes: oneIntCol,
 			input: sqlbase.EncDatumRows{
 				{v[1]},
 				{v[1]},
 				{v[1]},
 			},
+			outputTypes: oneIntCol,
 			expected: sqlbase.EncDatumRows{
 				{v[1]},
 			},
-		}, {
+		},
+		{
 			// SELECT MAX(@1), MIN(@2), COUNT(@2), COUNT DISTINCT (@2), GROUP BY [] (empty group key).
 			spec: AggregatorSpec{
 				Aggregations: []AggregatorSpec_Aggregation{
@@ -264,6 +297,7 @@ func TestAggregator(t *testing.T) {
 					},
 				},
 			},
+			inputTypes: twoIntCols,
 			input: sqlbase.EncDatumRows{
 				{v[2], v[2]},
 				{v[1], v[4]},
@@ -271,10 +305,12 @@ func TestAggregator(t *testing.T) {
 				{v[4], v[2]},
 				{v[5], v[4]},
 			},
+			outputTypes: []sqlbase.ColumnType{intType, intType, intType, intType},
 			expected: sqlbase.EncDatumRows{
 				{v[5], v[2], v[5], v[2]},
 			},
-		}, {
+		},
+		{
 			// SELECT MAX(@1) FILTER @2, COUNT(@3) FILTER @4, COUNT_ROWS FILTER @4
 			spec: AggregatorSpec{
 				Aggregations: []AggregatorSpec_Aggregation{
@@ -294,6 +330,7 @@ func TestAggregator(t *testing.T) {
 					},
 				},
 			},
+			inputTypes: []sqlbase.ColumnType{intType, boolType, intType, boolType},
 			input: sqlbase.EncDatumRows{
 				{v[1], boolTrue, v[1], boolTrue},
 				{v[5], boolFalse, v[1], boolFalse},
@@ -301,6 +338,7 @@ func TestAggregator(t *testing.T) {
 				{v[3], boolNULL, v[1], boolTrue},
 				{v[2], boolTrue, v[1], boolTrue},
 			},
+			outputTypes: threeIntCols,
 			expected: sqlbase.EncDatumRows{
 				{v[2], v[3], v[3]},
 			},
@@ -311,12 +349,8 @@ func TestAggregator(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			ags := c.spec
 
-			var types []sqlbase.ColumnType
-			if len(c.input) == 0 {
-				types = []sqlbase.ColumnType{columnTypeInt}
-			}
-			in := NewRowBuffer(types, c.input, RowBufferArgs{})
-			out := &RowBuffer{}
+			in := NewRowBuffer(c.inputTypes, c.input, RowBufferArgs{})
+			out := NewRowBuffer(c.outputTypes, nil /* rows */, RowBufferArgs{})
 			evalCtx := parser.MakeTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -367,7 +367,7 @@ func TestAggregator(t *testing.T) {
 
 			var expected []string
 			for _, row := range c.expected {
-				expected = append(expected, row.String())
+				expected = append(expected, row.String(c.outputTypes))
 			}
 			sort.Strings(expected)
 			expStr := strings.Join(expected, "")
@@ -381,7 +381,7 @@ func TestAggregator(t *testing.T) {
 				if row == nil {
 					break
 				}
-				rets = append(rets, row.String())
+				rets = append(rets, row.String(c.outputTypes))
 			}
 			sort.Strings(rets)
 			retStr := strings.Join(rets, "")

--- a/pkg/sql/distsqlrun/algebraic_set_op_test.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op_test.go
@@ -80,10 +80,10 @@ func initTestData() testInputs {
 }
 
 func runProcessors(tc testCase) (sqlbase.EncDatumRows, error) {
-	types := []sqlbase.ColumnType{intType, intType}
+	types := twoIntCols
 	inL := NewRowBuffer(types, tc.inputLeft, RowBufferArgs{})
 	inR := NewRowBuffer(types, tc.inputRight, RowBufferArgs{})
-	out := &RowBuffer{}
+	out := NewRowBuffer(types, nil /* rows */, RowBufferArgs{})
 
 	flowCtx := FlowCtx{Settings: cluster.MakeTestingClusterSettings()}
 
@@ -109,8 +109,8 @@ func runProcessors(tc testCase) (sqlbase.EncDatumRows, error) {
 		res = append(res, row)
 	}
 
-	if result := res.String(); result != tc.expected.String() {
-		return nil, errors.Errorf("invalid results: %s, expected %s'", result, tc.expected.String())
+	if result, exp := res.String(types), tc.expected.String(types); result != exp {
+		return nil, errors.Errorf("invalid results: %s, expected %s'", result, exp)
 	}
 
 	return res, nil
@@ -193,8 +193,8 @@ func TestExceptAll(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if result := outRows.String(); result != tc.expected.String() {
-			t.Errorf("invalid result index %d: %s, expected %s'", i, result, tc.expected.String())
+		if result, exp := outRows.String(twoIntCols), tc.expected.String(twoIntCols); result != exp {
+			t.Errorf("invalid result index %d: %s, expected %s'", i, result, exp)
 		}
 	}
 }

--- a/pkg/sql/distsqlrun/algebraic_set_op_test.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op_test.go
@@ -42,8 +42,7 @@ type testInputs struct {
 func initTestData() testInputs {
 	v := [15]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT},
-			parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(intType, parser.NewDInt(parser.DInt(i)))
 	}
 
 	inputUnordered := sqlbase.EncDatumRows{
@@ -81,8 +80,9 @@ func initTestData() testInputs {
 }
 
 func runProcessors(tc testCase) (sqlbase.EncDatumRows, error) {
-	inL := NewRowBuffer(nil, tc.inputLeft, RowBufferArgs{})
-	inR := NewRowBuffer(nil, tc.inputRight, RowBufferArgs{})
+	types := []sqlbase.ColumnType{intType, intType}
+	inL := NewRowBuffer(types, tc.inputLeft, RowBufferArgs{})
+	inR := NewRowBuffer(types, tc.inputRight, RowBufferArgs{})
 	out := &RowBuffer{}
 
 	flowCtx := FlowCtx{Settings: cluster.MakeTestingClusterSettings()}

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -171,7 +171,8 @@ func DrainAndForwardMetadata(ctx context.Context, src RowSource, dst RowReceiver
 		}
 		if row != nil {
 			log.Fatalf(
-				ctx, "both row data and metadata in the same record. row: %s meta: %+v", row, meta,
+				ctx, "both row data and metadata in the same record. row: %s meta: %+v",
+				row.String(src.Types()), meta,
 			)
 		}
 
@@ -242,6 +243,11 @@ type NoMetadataRowSource struct {
 // MakeNoMetadataRowSource builds a NoMetadataRowSource.
 func MakeNoMetadataRowSource(src RowSource, sink RowReceiver) NoMetadataRowSource {
 	return NoMetadataRowSource{src: src, metadataSink: sink}
+}
+
+// Types returns the source types.
+func (rs *NoMetadataRowSource) Types() []sqlbase.ColumnType {
+	return rs.src.Types()
 }
 
 // NextRow is analogous to RowSource.Next. If the producer sends an error, we

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -517,24 +517,19 @@ type RowBufferArgs struct {
 	OnNext func(*RowBuffer) (sqlbase.EncDatumRow, ProducerMetadata)
 }
 
-// NewRowBuffer creates a RowBuffer with the given schema and initial rows. The
-// types are optional if there is at least one row.
+// NewRowBuffer creates a RowBuffer with the given schema and initial rows.
 func NewRowBuffer(
 	types []sqlbase.ColumnType, rows sqlbase.EncDatumRows, hooks RowBufferArgs,
 ) *RowBuffer {
+	if types == nil {
+		panic("types required")
+	}
 	wrappedRows := make([]BufferedRecord, len(rows))
 	for i, row := range rows {
 		wrappedRows[i].Row = row
 	}
 	rb := &RowBuffer{types: types, args: hooks}
 	rb.mu.records = wrappedRows
-
-	if len(rb.mu.records) > 0 && rb.types == nil {
-		rb.types = make([]sqlbase.ColumnType, len(rb.mu.records[0].Row))
-		for i, d := range rb.mu.records[0].Row {
-			rb.types[i] = d.Type
-		}
-	}
 	return rb
 }
 
@@ -578,7 +573,7 @@ func (rb *RowBuffer) ProducerDone() {
 // Types is part of the RowSource interface.
 func (rb *RowBuffer) Types() []sqlbase.ColumnType {
 	if rb.types == nil {
-		panic("not initialized with types")
+		panic("not initialized")
 	}
 	return rb.types
 }

--- a/pkg/sql/distsqlrun/disk_row_container.go
+++ b/pkg/sql/distsqlrun/disk_row_container.go
@@ -122,15 +122,16 @@ func (d *diskRowContainer) AddRow(ctx context.Context, row sqlbase.EncDatumRow) 
 	}
 
 	for i, orderInfo := range d.ordering {
+		col := orderInfo.ColIdx
 		var err error
-		d.scratchKey, err = row[orderInfo.ColIdx].Encode(&d.datumAlloc, d.encodings[i], d.scratchKey)
+		d.scratchKey, err = row[col].Encode(&d.types[col], &d.datumAlloc, d.encodings[i], d.scratchKey)
 		if err != nil {
 			return err
 		}
 	}
 	for _, i := range d.valueIdxs {
 		var err error
-		d.scratchVal, err = row[i].Encode(&d.datumAlloc, sqlbase.DatumEncoding_VALUE, d.scratchVal)
+		d.scratchVal, err = row[i].Encode(&d.types[i], &d.datumAlloc, sqlbase.DatumEncoding_VALUE, d.scratchVal)
 		if err != nil {
 			return err
 		}
@@ -179,14 +180,15 @@ func (d *diskRowContainer) keyValToRow(k []byte, v []byte) (sqlbase.EncDatumRow,
 			continue
 		}
 		var err error
-		d.scratchEncRow[orderInfo.ColIdx], k, err = sqlbase.EncDatumFromBuffer(d.types[orderInfo.ColIdx], d.encodings[i], k)
+		col := orderInfo.ColIdx
+		d.scratchEncRow[col], k, err = sqlbase.EncDatumFromBuffer(&d.types[col], d.encodings[i], k)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to decode row")
 		}
 	}
 	for _, i := range d.valueIdxs {
 		var err error
-		d.scratchEncRow[i], v, err = sqlbase.EncDatumFromBuffer(d.types[i], sqlbase.DatumEncoding_VALUE, v)
+		d.scratchEncRow[i], v, err = sqlbase.EncDatumFromBuffer(&d.types[i], sqlbase.DatumEncoding_VALUE, v)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to decode row")
 		}

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -166,8 +166,8 @@ func TestDistinct(t *testing.T) {
 				res = append(res, row)
 			}
 
-			if result := res.String(); result != c.expected.String() {
-				t.Errorf("invalid results: %s, expected %s'", result, c.expected.String())
+			if result := res.String(twoIntCols); result != c.expected.String(twoIntCols) {
+				t.Errorf("invalid results: %s, expected %s'", result, c.expected.String(twoIntCols))
 			}
 		})
 	}

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -135,7 +135,7 @@ func TestDistinct(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			ds := c.spec
 
-			in := NewRowBuffer(nil /* types */, c.input, RowBufferArgs{})
+			in := NewRowBuffer(twoIntCols, c.input, RowBufferArgs{})
 			out := &RowBuffer{}
 
 			evalCtx := parser.MakeTestingEvalContext()

--- a/pkg/sql/distsqlrun/expr.go
+++ b/pkg/sql/distsqlrun/expr.go
@@ -109,7 +109,7 @@ func (eh *exprHelper) IndexedVarResolvedType(idx int) parser.Type {
 
 // IndexedVarEval is part of the parser.IndexedVarContainer interface.
 func (eh *exprHelper) IndexedVarEval(idx int, ctx *parser.EvalContext) (parser.Datum, error) {
-	err := eh.row[idx].EnsureDecoded(&eh.datumAlloc)
+	err := eh.row[idx].EnsureDecoded(&eh.types[idx], &eh.datumAlloc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -277,11 +277,14 @@ func (f *Flow) makeProcessor(ps *ProcessorSpec, inputs []RowSource) (Processor, 
 	if err != nil {
 		return nil, err
 	}
-	// Initialize any routers (the setupRouter case above).
+	// Initialize any routers (the setupRouter case above) and outboxes.
 	types := proc.OutputTypes()
 	for _, o := range outputs {
-		if r, ok := o.(router); ok {
-			r.init(&f.FlowCtx, types)
+		switch o := o.(type) {
+		case router:
+			o.init(&f.FlowCtx, types)
+		case *outbox:
+			o.init(types)
 		}
 	}
 	return proc, nil

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -644,9 +644,14 @@ func (h *hashJoiner) probePhase(
 // If the row contains any NULLs and encodeNull is false, hasNull is true and
 // no encoding is returned. If encodeNull is true, hasNull is never set.
 func encodeColumnsOfRow(
-	da *sqlbase.DatumAlloc, appendTo []byte, row sqlbase.EncDatumRow, cols columns, encodeNull bool,
+	da *sqlbase.DatumAlloc,
+	appendTo []byte,
+	row sqlbase.EncDatumRow,
+	cols columns,
+	colTypes []sqlbase.ColumnType,
+	encodeNull bool,
 ) (encoding []byte, hasNull bool, err error) {
-	for _, colIdx := range cols {
+	for i, colIdx := range cols {
 		if row[colIdx].IsNull() && !encodeNull {
 			return nil, true, nil
 		}
@@ -655,7 +660,7 @@ func encodeColumnsOfRow(
 		// TODO(radu): we should figure out what encoding is readily available and
 		// use that (though it needs to be consistent across all rows). We could add
 		// functionality to compare VALUE encodings ignoring the column ID.
-		appendTo, err = row[colIdx].Encode(da, sqlbase.DatumEncoding_ASCENDING_KEY, appendTo)
+		appendTo, err = row[colIdx].Encode(&colTypes[i], da, sqlbase.DatumEncoding_ASCENDING_KEY, appendTo)
 		if err != nil {
 			return appendTo, false, err
 		}

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -45,10 +45,13 @@ func TestHashJoiner(t *testing.T) {
 	null := sqlbase.EncDatum{Datum: parser.DNull}
 
 	testCases := []struct {
-		spec     HashJoinerSpec
-		outCols  []uint32
-		inputs   []sqlbase.EncDatumRows
-		expected sqlbase.EncDatumRows
+		spec       HashJoinerSpec
+		outCols    []uint32
+		leftTypes  []sqlbase.ColumnType
+		leftInput  sqlbase.EncDatumRows
+		rightTypes []sqlbase.ColumnType
+		rightInput sqlbase.EncDatumRows
+		expected   sqlbase.EncDatumRows
 	}{
 		{
 			spec: HashJoinerSpec{
@@ -57,21 +60,21 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_INNER,
 				// Implicit @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[1], v[4]},
-					{v[2], v[4]},
-					{v[3], v[1]},
-					{v[4], v[5]},
-					{v[5], v[5]},
-				},
-				{
-					{v[1], v[0], v[4]},
-					{v[3], v[4], v[1]},
-					{v[4], v[4], v[5]},
-				},
+			outCols:   []uint32{0, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], v[4]},
+				{v[2], v[4]},
+				{v[3], v[1]},
+				{v[4], v[5]},
+				{v[5], v[5]},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[1], v[0], v[4]},
+				{v[3], v[4], v[1]},
+				{v[4], v[4], v[5]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[1], v[0], v[4]},
@@ -86,19 +89,19 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_INNER,
 				// Implicit @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 1, 3},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[0], v[1]},
-				},
-				{
-					{v[0], v[4]},
-					{v[0], v[1]},
-					{v[0], v[0]},
-					{v[0], v[5]},
-					{v[0], v[4]},
-				},
+			outCols:   []uint32{0, 1, 3},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[0], v[1]},
+			},
+			rightTypes: twoIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[4]},
+				{v[0], v[1]},
+				{v[0], v[0]},
+				{v[0], v[5]},
+				{v[0], v[4]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], v[0], v[4]},
@@ -122,26 +125,26 @@ func TestHashJoiner(t *testing.T) {
 				OnExpr:         Expression{Expr: "@4 >= 4"},
 				// Implicit AND @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 1, 3},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[0], v[1]},
-					{v[1], v[0]},
-					{v[1], v[1]},
-				},
-				{
-					{v[0], v[4]},
-					{v[0], v[1]},
-					{v[0], v[0]},
-					{v[0], v[5]},
-					{v[0], v[4]},
-					{v[1], v[4]},
-					{v[1], v[1]},
-					{v[1], v[0]},
-					{v[1], v[5]},
-					{v[1], v[4]},
-				},
+			outCols:   []uint32{0, 1, 3},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[0], v[1]},
+				{v[1], v[0]},
+				{v[1], v[1]},
+			},
+			rightTypes: twoIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[4]},
+				{v[0], v[1]},
+				{v[0], v[0]},
+				{v[0], v[5]},
+				{v[0], v[4]},
+				{v[1], v[4]},
+				{v[1], v[1]},
+				{v[1], v[0]},
+				{v[1], v[5]},
+				{v[1], v[4]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], v[0], v[4]},
@@ -165,21 +168,21 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_LEFT_OUTER,
 				// Implicit @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[1], v[4]},
-					{v[2], v[4]},
-					{v[3], v[1]},
-					{v[4], v[5]},
-					{v[5], v[5]},
-				},
-				{
-					{v[1], v[0], v[4]},
-					{v[3], v[4], v[1]},
-					{v[4], v[4], v[5]},
-				},
+			outCols:   []uint32{0, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], v[4]},
+				{v[2], v[4]},
+				{v[3], v[1]},
+				{v[4], v[5]},
+				{v[5], v[5]},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[1], v[0], v[4]},
+				{v[3], v[4], v[1]},
+				{v[4], v[4], v[5]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], null, null},
@@ -197,21 +200,21 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_RIGHT_OUTER,
 				// Implicit @1 = @4 constraint.
 			},
-			outCols: []uint32{3, 1, 2},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[1], v[0], v[4]},
-					{v[3], v[4], v[1]},
-					{v[4], v[4], v[5]},
-				},
-				{
-					{v[0], v[0]},
-					{v[1], v[4]},
-					{v[2], v[4]},
-					{v[3], v[1]},
-					{v[4], v[5]},
-					{v[5], v[5]},
-				},
+			outCols:   []uint32{3, 1, 2},
+			leftTypes: threeIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[1], v[0], v[4]},
+				{v[3], v[4], v[1]},
+				{v[4], v[4], v[5]},
+			},
+			rightTypes: twoIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], v[4]},
+				{v[2], v[4]},
+				{v[3], v[1]},
+				{v[4], v[5]},
+				{v[5], v[5]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], null, null},
@@ -229,21 +232,21 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_FULL_OUTER,
 				// Implicit @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[1], v[4]},
-					{v[2], v[4]},
-					{v[3], v[1]},
-					{v[4], v[5]},
-				},
-				{
-					{v[1], v[0], v[4]},
-					{v[3], v[4], v[1]},
-					{v[4], v[4], v[5]},
-					{v[5], v[5], v[1]},
-				},
+			outCols:   []uint32{0, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], v[4]},
+				{v[2], v[4]},
+				{v[3], v[1]},
+				{v[4], v[5]},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[1], v[0], v[4]},
+				{v[3], v[4], v[1]},
+				{v[4], v[4], v[5]},
+				{v[5], v[5], v[1]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], null, null},
@@ -261,20 +264,20 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_INNER,
 				// Implicit @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[2], v[4]},
-					{v[3], v[1]},
-					{v[4], v[5]},
-					{v[5], v[5]},
-				},
-				{
-					{v[1], v[0], v[4]},
-					{v[3], v[4], v[1]},
-					{v[4], v[4], v[5]},
-				},
+			outCols:   []uint32{0, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[2], v[4]},
+				{v[3], v[1]},
+				{v[4], v[5]},
+				{v[5], v[5]},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[1], v[0], v[4]},
+				{v[3], v[4], v[1]},
+				{v[4], v[4], v[5]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[3], v[4], v[1]},
@@ -289,33 +292,33 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_LEFT_OUTER,
 				OnExpr:         Expression{Expr: "@3 = 9"},
 			},
-			outCols: []uint32{0, 1},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[1]},
-					{v[2]},
-					{v[3]},
-					{v[5]},
-					{v[6]},
-					{v[7]},
-				},
-				{
-					{v[2], v[8]},
-					{v[3], v[9]},
-					{v[4], v[9]},
+			outCols:   []uint32{0, 1},
+			leftTypes: oneIntCol,
+			leftInput: sqlbase.EncDatumRows{
+				{v[1]},
+				{v[2]},
+				{v[3]},
+				{v[5]},
+				{v[6]},
+				{v[7]},
+			},
+			rightTypes: twoIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[2], v[8]},
+				{v[3], v[9]},
+				{v[4], v[9]},
 
-					// Rows that match v[5].
-					{v[5], v[9]},
-					{v[5], v[9]},
+				// Rows that match v[5].
+				{v[5], v[9]},
+				{v[5], v[9]},
 
-					// Rows that match v[6] but the ON condition fails.
-					{v[6], v[8]},
-					{v[6], v[8]},
+				// Rows that match v[6] but the ON condition fails.
+				{v[6], v[8]},
+				{v[6], v[8]},
 
-					// Rows that match v[7], ON condition fails for one.
-					{v[7], v[8]},
-					{v[7], v[9]},
-				},
+				// Rows that match v[7], ON condition fails for one.
+				{v[7], v[8]},
+				{v[7], v[9]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[1], null},
@@ -335,18 +338,18 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_RIGHT_OUTER,
 				OnExpr:         Expression{Expr: "@2 > 1"},
 			},
-			outCols: []uint32{0, 1},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0]},
-					{v[1]},
-					{v[2]},
-				},
-				{
-					{v[1]},
-					{v[2]},
-					{v[3]},
-				},
+			outCols:   []uint32{0, 1},
+			leftTypes: oneIntCol,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0]},
+				{v[1]},
+				{v[2]},
+			},
+			rightTypes: oneIntCol,
+			rightInput: sqlbase.EncDatumRows{
+				{v[1]},
+				{v[2]},
+				{v[3]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{null, v[1]},
@@ -362,18 +365,18 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_FULL_OUTER,
 				OnExpr:         Expression{Expr: "@2 > 1"},
 			},
-			outCols: []uint32{0, 1},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0]},
-					{v[1]},
-					{v[2]},
-				},
-				{
-					{v[1]},
-					{v[2]},
-					{v[3]},
-				},
+			outCols:   []uint32{0, 1},
+			leftTypes: oneIntCol,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0]},
+				{v[1]},
+				{v[2]},
+			},
+			rightTypes: oneIntCol,
+			rightInput: sqlbase.EncDatumRows{
+				{v[1]},
+				{v[2]},
+				{v[3]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], null},
@@ -392,20 +395,20 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_INNER,
 				// Implicit @1,@2 = @3,@4 constraint.
 			},
-			outCols: []uint32{0, 1, 2, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[1], null},
-					{null, v[2]},
-					{null, null},
-				},
-				{
-					{v[0], v[0], v[4]},
-					{v[1], null, v[5]},
-					{null, v[2], v[6]},
-					{null, null, v[7]},
-				},
+			outCols:   []uint32{0, 1, 2, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], null},
+				{null, v[2]},
+				{null, null},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[0], v[4]},
+				{v[1], null, v[5]},
+				{null, v[2], v[6]},
+				{null, null, v[7]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], v[0], v[0], v[0], v[4]},
@@ -419,20 +422,20 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_LEFT_OUTER,
 				// Implicit @1,@2 = @3,@4 constraint.
 			},
-			outCols: []uint32{0, 1, 2, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[1], null},
-					{null, v[2]},
-					{null, null},
-				},
-				{
-					{v[0], v[0], v[4]},
-					{v[1], null, v[5]},
-					{null, v[2], v[6]},
-					{null, null, v[7]},
-				},
+			outCols:   []uint32{0, 1, 2, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], null},
+				{null, v[2]},
+				{null, null},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[0], v[4]},
+				{v[1], null, v[5]},
+				{null, v[2], v[6]},
+				{null, null, v[7]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], v[0], v[0], v[0], v[4]},
@@ -449,20 +452,20 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_RIGHT_OUTER,
 				// Implicit @1,@2 = @3,@4 constraint.
 			},
-			outCols: []uint32{0, 1, 2, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[1], null},
-					{null, v[2]},
-					{null, null},
-				},
-				{
-					{v[0], v[0], v[4]},
-					{v[1], null, v[5]},
-					{null, v[2], v[6]},
-					{null, null, v[7]},
-				},
+			outCols:   []uint32{0, 1, 2, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], null},
+				{null, v[2]},
+				{null, null},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[0], v[4]},
+				{v[1], null, v[5]},
+				{null, v[2], v[6]},
+				{null, null, v[7]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], v[0], v[0], v[0], v[4]},
@@ -479,20 +482,20 @@ func TestHashJoiner(t *testing.T) {
 				Type:           JoinType_FULL_OUTER,
 				// Implicit @1,@2 = @3,@4 constraint.
 			},
-			outCols: []uint32{0, 1, 2, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[1], null},
-					{null, v[2]},
-					{null, null},
-				},
-				{
-					{v[0], v[0], v[4]},
-					{v[1], null, v[5]},
-					{null, v[2], v[6]},
-					{null, null, v[7]},
-				},
+			outCols:   []uint32{0, 1, 2, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], null},
+				{null, v[2]},
+				{null, null},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[0], v[4]},
+				{v[1], null, v[5]},
+				{null, v[2], v[6]},
+				{null, null, v[7]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], v[0], v[0], v[0], v[4]},
@@ -530,8 +533,8 @@ func TestHashJoiner(t *testing.T) {
 		// testFunc is a helper function that runs a hashJoin with the current
 		// test case after running the provided setup function.
 		testFunc := func(t *testing.T, setup func(h *hashJoiner)) error {
-			leftInput := NewRowBuffer(nil /* types */, c.inputs[0], RowBufferArgs{})
-			rightInput := NewRowBuffer(nil /* types */, c.inputs[1], RowBufferArgs{})
+			leftInput := NewRowBuffer(c.leftTypes, c.leftInput, RowBufferArgs{})
+			rightInput := NewRowBuffer(c.rightTypes, c.rightInput, RowBufferArgs{})
 			out := &RowBuffer{}
 			flowCtx := FlowCtx{
 				Settings:    cluster.MakeTestingClusterSettings(),
@@ -673,13 +676,16 @@ func TestHashJoinerDrain(t *testing.T) {
 		leftInputDrainNotification <- nil
 	}
 	leftInput := NewRowBuffer(
-		nil, /* types */
+		oneIntCol,
 		inputs[0],
-		RowBufferArgs{OnConsumerDone: leftInputConsumerDone})
-	rightInput := NewRowBuffer(nil /* types */, inputs[1], RowBufferArgs{})
+		RowBufferArgs{OnConsumerDone: leftInputConsumerDone},
+	)
+	rightInput := NewRowBuffer(oneIntCol, inputs[1], RowBufferArgs{})
 	out := NewRowBuffer(
-		nil /* types */, nil, /* rows */
-		RowBufferArgs{AccumulateRowsWhileDraining: true})
+		oneIntCol,
+		nil, /* rows */
+		RowBufferArgs{AccumulateRowsWhileDraining: true},
+	)
 	evalCtx := parser.MakeTestingEvalContext()
 	ctx := context.Background()
 	defer evalCtx.Stop(ctx)
@@ -788,17 +794,23 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 		return nil, ProducerMetadata{}
 	}
 	leftInput := NewRowBuffer(
-		nil, /* types */
+		oneIntCol,
 		inputs[0],
-		RowBufferArgs{OnConsumerDone: leftInputConsumerDone})
+		RowBufferArgs{OnConsumerDone: leftInputConsumerDone},
+	)
 	rightInput := NewRowBuffer(
-		nil /* types */, inputs[1],
+		oneIntCol,
+		inputs[1],
 		RowBufferArgs{
 			OnConsumerDone: rightInputConsumerDone,
-			OnNext:         rightInputNext})
+			OnNext:         rightInputNext,
+		},
+	)
 	out := NewRowBuffer(
-		nil /* types */, nil, /* rows */
-		RowBufferArgs{})
+		oneIntCol,
+		nil, /* rows */
+		RowBufferArgs{},
+	)
 	evalCtx := parser.MakeTestingEvalContext()
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{Settings: cluster.MakeTestingClusterSettings(), EvalCtx: evalCtx}

--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -94,6 +94,7 @@ func processInboundStreamHelper(
 		if err != nil {
 			return errors.Wrap(err, log.MakeMessage(ctx, "decoding error", nil /* args */))
 		}
+		var types []sqlbase.ColumnType
 		for {
 			row, meta, err := sd.GetRow(nil /* rowBuf */)
 			if err != nil {
@@ -105,7 +106,10 @@ func processInboundStreamHelper(
 			}
 
 			if log.V(3) {
-				log.Infof(ctx, "inbound stream pushing row %s", row)
+				if types == nil {
+					types = sd.Types()
+				}
+				log.Infof(ctx, "inbound stream pushing row %s", row.String(types))
 			}
 			if draining && meta.Empty() {
 				// Don't forward data rows when we're draining.

--- a/pkg/sql/distsqlrun/input_sync_test.go
+++ b/pkg/sql/distsqlrun/input_sync_test.go
@@ -130,8 +130,8 @@ func TestOrderedSync(t *testing.T) {
 			}
 			retRows = append(retRows, row)
 		}
-		expStr := c.expected.String()
-		retStr := retRows.String()
+		expStr := c.expected.String(threeIntCols)
+		retStr := retRows.String(threeIntCols)
 		if expStr != retStr {
 			t.Errorf("invalid results for case %d; expected:\n   %s\ngot:\n   %s",
 				testIdx, expStr, retStr)
@@ -176,7 +176,7 @@ func TestUnorderedSync(t *testing.T) {
 		for _, row := range retRows {
 			if int(parser.MustBeDInt(row[0].Datum)) == i {
 				if int(parser.MustBeDInt(row[1].Datum)) != j {
-					t.Errorf("Expected [%d %d], got %s", i, j, row)
+					t.Errorf("Expected [%d %d], got %s", i, j, row.String(twoIntCols))
 				}
 				j++
 			}

--- a/pkg/sql/distsqlrun/input_sync_test.go
+++ b/pkg/sql/distsqlrun/input_sync_test.go
@@ -110,7 +110,7 @@ func TestOrderedSync(t *testing.T) {
 	for testIdx, c := range testCases {
 		var sources []RowSource
 		for _, srcRows := range c.sources {
-			rowBuf := NewRowBuffer(nil /* types */, srcRows, RowBufferArgs{})
+			rowBuf := NewRowBuffer(threeIntCols, srcRows, RowBufferArgs{})
 			sources = append(sources, rowBuf)
 		}
 		evalCtx := parser.NewTestingEvalContext()

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -37,10 +37,13 @@ func TestMergeJoiner(t *testing.T) {
 	null := sqlbase.EncDatum{Datum: parser.DNull}
 
 	testCases := []struct {
-		spec     MergeJoinerSpec
-		outCols  []uint32
-		inputs   []sqlbase.EncDatumRows
-		expected sqlbase.EncDatumRows
+		spec       MergeJoinerSpec
+		outCols    []uint32
+		leftTypes  []sqlbase.ColumnType
+		leftInput  sqlbase.EncDatumRows
+		rightTypes []sqlbase.ColumnType
+		rightInput sqlbase.EncDatumRows
+		expected   sqlbase.EncDatumRows
 	}{
 		{
 			spec: MergeJoinerSpec{
@@ -55,21 +58,21 @@ func TestMergeJoiner(t *testing.T) {
 				Type: JoinType_INNER,
 				// Implicit @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[1], v[4]},
-					{v[2], v[4]},
-					{v[3], v[1]},
-					{v[4], v[5]},
-					{v[5], v[5]},
-				},
-				{
-					{v[1], v[0], v[4]},
-					{v[3], v[4], v[1]},
-					{v[4], v[4], v[5]},
-				},
+			outCols:   []uint32{0, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], v[4]},
+				{v[2], v[4]},
+				{v[3], v[1]},
+				{v[4], v[5]},
+				{v[5], v[5]},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[1], v[0], v[4]},
+				{v[3], v[4], v[1]},
+				{v[4], v[4], v[5]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[1], v[0], v[4]},
@@ -90,19 +93,19 @@ func TestMergeJoiner(t *testing.T) {
 				Type: JoinType_INNER,
 				// Implicit @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 1, 3},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[0], v[1]},
-				},
-				{
-					{v[0], v[4]},
-					{v[0], v[1]},
-					{v[0], v[0]},
-					{v[0], v[5]},
-					{v[0], v[4]},
-				},
+			outCols:   []uint32{0, 1, 3},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[0], v[1]},
+			},
+			rightTypes: twoIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[4]},
+				{v[0], v[1]},
+				{v[0], v[0]},
+				{v[0], v[5]},
+				{v[0], v[4]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], v[0], v[4]},
@@ -131,26 +134,26 @@ func TestMergeJoiner(t *testing.T) {
 				OnExpr: Expression{Expr: "@4 >= 4"},
 				// Implicit AND @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 1, 3},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[0], v[1]},
-					{v[1], v[0]},
-					{v[1], v[1]},
-				},
-				{
-					{v[0], v[4]},
-					{v[0], v[1]},
-					{v[0], v[0]},
-					{v[0], v[5]},
-					{v[0], v[4]},
-					{v[1], v[4]},
-					{v[1], v[1]},
-					{v[1], v[0]},
-					{v[1], v[5]},
-					{v[1], v[4]},
-				},
+			outCols:   []uint32{0, 1, 3},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[0], v[1]},
+				{v[1], v[0]},
+				{v[1], v[1]},
+			},
+			rightTypes: twoIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[4]},
+				{v[0], v[1]},
+				{v[0], v[0]},
+				{v[0], v[5]},
+				{v[0], v[4]},
+				{v[1], v[4]},
+				{v[1], v[1]},
+				{v[1], v[0]},
+				{v[1], v[5]},
+				{v[1], v[4]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], v[0], v[4]},
@@ -181,35 +184,35 @@ func TestMergeJoiner(t *testing.T) {
 				OnExpr: Expression{Expr: "@2 >= @4"},
 				// Implicit AND @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 1, 3},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[0], v[0]},
+			outCols:   []uint32{0, 1, 3},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[0], v[0]},
 
-					{v[1], v[5]},
+				{v[1], v[5]},
 
-					{v[2], v[0]},
-					{v[2], v[8]},
+				{v[2], v[0]},
+				{v[2], v[8]},
 
-					{v[3], v[5]},
+				{v[3], v[5]},
 
-					{v[6], v[0]},
-				},
-				{
-					{v[0], v[5]},
-					{v[0], v[5]},
+				{v[6], v[0]},
+			},
+			rightTypes: twoIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[5]},
+				{v[0], v[5]},
 
-					{v[1], v[0]},
-					{v[1], v[8]},
+				{v[1], v[0]},
+				{v[1], v[8]},
 
-					{v[2], v[5]},
+				{v[2], v[5]},
 
-					{v[3], v[0]},
-					{v[3], v[0]},
+				{v[3], v[0]},
+				{v[3], v[0]},
 
-					{v[5], v[0]},
-				},
+				{v[5], v[0]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], v[0], null},
@@ -244,21 +247,21 @@ func TestMergeJoiner(t *testing.T) {
 				Type: JoinType_LEFT_OUTER,
 				// Implicit @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[1], v[4]},
-					{v[2], v[4]},
-					{v[3], v[1]},
-					{v[4], v[5]},
-					{v[5], v[5]},
-				},
-				{
-					{v[1], v[0], v[4]},
-					{v[3], v[4], v[1]},
-					{v[4], v[4], v[5]},
-				},
+			outCols:   []uint32{0, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], v[4]},
+				{v[2], v[4]},
+				{v[3], v[1]},
+				{v[4], v[5]},
+				{v[5], v[5]},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[1], v[0], v[4]},
+				{v[3], v[4], v[1]},
+				{v[4], v[4], v[5]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], null, null},
@@ -282,21 +285,21 @@ func TestMergeJoiner(t *testing.T) {
 				Type: JoinType_RIGHT_OUTER,
 				// Implicit @1 = @3 constraint.
 			},
-			outCols: []uint32{3, 1, 2},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[1], v[0], v[4]},
-					{v[3], v[4], v[1]},
-					{v[4], v[4], v[5]},
-				},
-				{
-					{v[0], v[0]},
-					{v[1], v[4]},
-					{v[2], v[4]},
-					{v[3], v[1]},
-					{v[4], v[5]},
-					{v[5], v[5]},
-				},
+			outCols:   []uint32{3, 1, 2},
+			leftTypes: threeIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[1], v[0], v[4]},
+				{v[3], v[4], v[1]},
+				{v[4], v[4], v[5]},
+			},
+			rightTypes: twoIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], v[4]},
+				{v[2], v[4]},
+				{v[3], v[1]},
+				{v[4], v[5]},
+				{v[5], v[5]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], null, null},
@@ -320,21 +323,21 @@ func TestMergeJoiner(t *testing.T) {
 				Type: JoinType_FULL_OUTER,
 				// Implicit @1 = @3 constraint.
 			},
-			outCols: []uint32{0, 3, 4},
-			inputs: []sqlbase.EncDatumRows{
-				{
-					{v[0], v[0]},
-					{v[1], v[4]},
-					{v[2], v[4]},
-					{v[3], v[1]},
-					{v[4], v[5]},
-				},
-				{
-					{v[1], v[0], v[4]},
-					{v[3], v[4], v[1]},
-					{v[4], v[4], v[5]},
-					{v[5], v[5], v[1]},
-				},
+			outCols:   []uint32{0, 3, 4},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[0]},
+				{v[1], v[4]},
+				{v[2], v[4]},
+				{v[3], v[1]},
+				{v[4], v[5]},
+			},
+			rightTypes: threeIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[1], v[0], v[4]},
+				{v[3], v[4], v[1]},
+				{v[4], v[4], v[5]},
+				{v[5], v[5], v[1]},
 			},
 			expected: sqlbase.EncDatumRows{
 				{v[0], null, null},
@@ -350,8 +353,8 @@ func TestMergeJoiner(t *testing.T) {
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			ms := c.spec
-			leftInput := NewRowBuffer(nil /* types */, c.inputs[0], RowBufferArgs{})
-			rightInput := NewRowBuffer(nil /* types */, c.inputs[1], RowBufferArgs{})
+			leftInput := NewRowBuffer(c.leftTypes, c.leftInput, RowBufferArgs{})
+			rightInput := NewRowBuffer(c.rightTypes, c.rightInput, RowBufferArgs{})
 			out := &RowBuffer{}
 			evalCtx := parser.MakeTestingEvalContext()
 			defer evalCtx.Stop(context.Background())

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -386,8 +386,8 @@ func TestMergeJoiner(t *testing.T) {
 				}
 				retRows = append(retRows, row)
 			}
-			expStr := c.expected.String()
-			retStr := retRows.String()
+			expStr := c.expected.String(threeIntCols)
+			retStr := retRows.String(threeIntCols)
 			if expStr != retStr {
 				t.Errorf("invalid results; expected:\n   %s\ngot:\n   %s",
 					expStr, retStr)

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -205,8 +205,7 @@ func emitHelper(
 	var consumerStatus ConsumerStatus
 	if !meta.Empty() {
 		if row != nil {
-			log.Fatalf(ctx, "both row data and metadata in the same emitHelper call. "+
-				"row: %s. meta: %+v", row, meta)
+			panic("both row data and metadata in the same emitHelper call")
 		}
 		// Bypass EmitRow() and send directly to output.output.
 		consumerStatus = output.output.Push(nil /* row */, meta)
@@ -264,7 +263,7 @@ func (h *ProcOutputHelper) EmitRow(
 		}
 		if !passes {
 			if log.V(3) {
-				log.Infof(ctx, "filtered out row %s", row)
+				log.Infof(ctx, "filtered out row %s", row.String(h.filter.types))
 			}
 			return NeedMoreRows, nil
 		}

--- a/pkg/sql/distsqlrun/processors_test.go
+++ b/pkg/sql/distsqlrun/processors_test.go
@@ -50,11 +50,13 @@ func TestPostProcess(t *testing.T) {
 
 	testCases := []struct {
 		post          PostProcessSpec
+		outputTypes   []sqlbase.ColumnType
 		expNeededCols []int
 		expected      string
 	}{
 		{
 			post:          PostProcessSpec{},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 1 2] [0 1 3] [0 1 4] [0 2 3] [0 2 4] [0 3 4] [1 2 3] [1 2 4] [1 3 4] [2 3 4]]",
 		},
@@ -64,6 +66,7 @@ func TestPostProcess(t *testing.T) {
 			post: PostProcessSpec{
 				Filter: Expression{Expr: "@1 = 1"},
 			},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[1 2 3] [1 2 4] [1 3 4]]",
 		},
@@ -74,6 +77,7 @@ func TestPostProcess(t *testing.T) {
 				Projection:    true,
 				OutputColumns: []uint32{0, 2},
 			},
+			outputTypes:   twoIntCols,
 			expNeededCols: []int{0, 2},
 			expected:      "[[0 2] [0 3] [0 4] [0 3] [0 4] [0 4] [1 3] [1 4] [1 4] [2 4]]",
 		},
@@ -85,6 +89,7 @@ func TestPostProcess(t *testing.T) {
 				Projection:    true,
 				OutputColumns: []uint32{0, 2},
 			},
+			outputTypes:   twoIntCols,
 			expNeededCols: []int{0, 2},
 			expected:      "[[1 3] [1 4] [1 4]]",
 		},
@@ -96,6 +101,7 @@ func TestPostProcess(t *testing.T) {
 				Projection:    true,
 				OutputColumns: []uint32{0, 2},
 			},
+			outputTypes:   twoIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 3] [0 4] [1 3] [1 4]]",
 		},
@@ -105,6 +111,7 @@ func TestPostProcess(t *testing.T) {
 			post: PostProcessSpec{
 				RenderExprs: []Expression{{Expr: "@1"}, {Expr: "@2"}, {Expr: "@1 + @2"}},
 			},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1},
 			expected:      "[[0 1 1] [0 1 1] [0 1 1] [0 2 2] [0 2 2] [0 3 3] [1 2 3] [1 2 3] [1 3 4] [2 3 5]]",
 		},
@@ -115,6 +122,7 @@ func TestPostProcess(t *testing.T) {
 				Filter:      Expression{Expr: "@2 = 2"},
 				RenderExprs: []Expression{{Expr: "@1"}, {Expr: "@2"}, {Expr: "@1 + @2"}},
 			},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1},
 			expected:      "[[0 2 2] [0 2 2] [1 2 3] [1 2 3]]",
 		},
@@ -125,6 +133,7 @@ func TestPostProcess(t *testing.T) {
 				Filter:      Expression{Expr: "@3 = 4"},
 				RenderExprs: []Expression{{Expr: "@1"}, {Expr: "@2"}, {Expr: "@1 + @2"}},
 			},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 1 1] [0 2 2] [0 3 3] [1 2 3] [1 3 4] [2 3 5]]",
 		},
@@ -141,6 +150,7 @@ func TestPostProcess(t *testing.T) {
 					{Expr: "@1 = @2 - 1 AND @1 = @3 - 2"},
 				},
 			},
+			outputTypes:   []sqlbase.ColumnType{intType, intType, boolType, boolType, boolType, boolType},
 			expNeededCols: []int{0, 1, 2},
 			expected: "[" + strings.Join([]string{
 				/* 0 1 2 */ "[-1 2 false true true true]",
@@ -159,6 +169,7 @@ func TestPostProcess(t *testing.T) {
 		// Offset.
 		{
 			post:          PostProcessSpec{Offset: 3},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 2 3] [0 2 4] [0 3 4] [1 2 3] [1 2 4] [1 3 4] [2 3 4]]",
 		},
@@ -166,21 +177,25 @@ func TestPostProcess(t *testing.T) {
 		// Limit.
 		{
 			post:          PostProcessSpec{Limit: 3},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 1 2] [0 1 3] [0 1 4]]",
 		},
 		{
 			post:          PostProcessSpec{Limit: 9},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 1 2] [0 1 3] [0 1 4] [0 2 3] [0 2 4] [0 3 4] [1 2 3] [1 2 4] [1 3 4]]",
 		},
 		{
 			post:          PostProcessSpec{Limit: 10},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 1 2] [0 1 3] [0 1 4] [0 2 3] [0 2 4] [0 3 4] [1 2 3] [1 2 4] [1 3 4] [2 3 4]]",
 		},
 		{
 			post:          PostProcessSpec{Limit: 11},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 1 2] [0 1 3] [0 1 4] [0 2 3] [0 2 4] [0 3 4] [1 2 3] [1 2 4] [1 3 4] [2 3 4]]",
 		},
@@ -188,21 +203,25 @@ func TestPostProcess(t *testing.T) {
 		// Offset + limit.
 		{
 			post:          PostProcessSpec{Offset: 3, Limit: 2},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 2 3] [0 2 4]]",
 		},
 		{
 			post:          PostProcessSpec{Offset: 3, Limit: 6},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 2 3] [0 2 4] [0 3 4] [1 2 3] [1 2 4] [1 3 4]]",
 		},
 		{
 			post:          PostProcessSpec{Offset: 3, Limit: 7},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 2 3] [0 2 4] [0 3 4] [1 2 3] [1 2 4] [1 3 4] [2 3 4]]",
 		},
 		{
 			post:          PostProcessSpec{Offset: 3, Limit: 8},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[0 2 3] [0 2 4] [0 3 4] [1 2 3] [1 2 4] [1 3 4] [2 3 4]]",
 		},
@@ -213,6 +232,7 @@ func TestPostProcess(t *testing.T) {
 				Filter: Expression{Expr: "@1 = 1"},
 				Offset: 1,
 			},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[1 2 4] [1 3 4]]",
 		},
@@ -223,6 +243,7 @@ func TestPostProcess(t *testing.T) {
 				Filter: Expression{Expr: "@1 = 1"},
 				Limit:  2,
 			},
+			outputTypes:   threeIntCols,
 			expNeededCols: []int{0, 1, 2},
 			expected:      "[[1 2 3] [1 2 4]]",
 		},
@@ -277,7 +298,7 @@ func TestPostProcess(t *testing.T) {
 				res = append(res, row)
 			}
 
-			if str := res.String(); str != tc.expected {
+			if str := res.String(tc.outputTypes); str != tc.expected {
 				t.Errorf("expected output:\n    %s\ngot:\n    %s\n", tc.expected, str)
 			}
 		})

--- a/pkg/sql/distsqlrun/processors_test.go
+++ b/pkg/sql/distsqlrun/processors_test.go
@@ -29,10 +29,9 @@ import (
 func TestPostProcess(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	columnTypeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
 	v := [10]sqlbase.EncDatum{}
 	for i := range v {
-		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, parser.NewDInt(parser.DInt(i)))
+		v[i] = sqlbase.DatumToEncDatum(intType, parser.NewDInt(parser.DInt(i)))
 	}
 
 	// We run the same input rows through various PostProcessSpecs.
@@ -231,7 +230,7 @@ func TestPostProcess(t *testing.T) {
 
 	for tcIdx, tc := range testCases {
 		t.Run(strconv.Itoa(tcIdx), func(t *testing.T) {
-			inBuf := NewRowBuffer(nil /* types */, input, RowBufferArgs{})
+			inBuf := NewRowBuffer(threeIntCols, input, RowBufferArgs{})
 			outBuf := &RowBuffer{}
 
 			var out ProcOutputHelper

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -104,7 +104,7 @@ func TestServer(t *testing.T) {
 	if len(metas) != 0 {
 		t.Errorf("unexpected metadata: %v", metas)
 	}
-	str := rows.String()
+	str := rows.String(twoIntCols)
 	expected := "[[1 10] [3 30]]"
 	if str != expected {
 		t.Errorf("invalid results: %s, expected %s'", str, expected)

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -218,7 +218,7 @@ func TestSorter(t *testing.T) {
 			t.Run(fmt.Sprintf("%sMemLimit=%d", c.name, memLimit), func(t *testing.T) {
 				types := make([]sqlbase.ColumnType, len(c.input[0]))
 				for i := range types {
-					types[i] = c.input[0][i].Type
+					types[i] = intType
 				}
 				in := NewRowBuffer(types, c.input, RowBufferArgs{})
 				out := &RowBuffer{}

--- a/pkg/sql/distsqlrun/stream_data_test.go
+++ b/pkg/sql/distsqlrun/stream_data_test.go
@@ -48,7 +48,7 @@ func testGetDecodedRows(
 	return decodedRows, metas
 }
 
-func testRowStream(tb testing.TB, rng *rand.Rand, records []rowOrMeta) {
+func testRowStream(tb testing.TB, rng *rand.Rand, types []sqlbase.ColumnType, records []rowOrMeta) {
 	var se StreamEncoder
 	var sd StreamDecoder
 
@@ -56,6 +56,8 @@ func testRowStream(tb testing.TB, rng *rand.Rand, records []rowOrMeta) {
 	var metas []ProducerMetadata
 	numRows := 0
 	numMeta := 0
+
+	se.init(types)
 
 	for rowIdx := 0; rowIdx <= len(records); rowIdx++ {
 		if rowIdx < len(records) {
@@ -102,9 +104,10 @@ func TestStreamEncodeDecode(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
 	for test := 0; test < 100; test++ {
 		rowLen := rng.Intn(20)
+		types := sqlbase.RandColumnTypes(rng, rowLen)
 		info := make([]DatumInfo, rowLen)
 		for i := range info {
-			info[i].Type = sqlbase.RandColumnType(rng)
+			info[i].Type = types[i]
 			info[i].Encoding = sqlbase.RandDatumEncoding(rng)
 		}
 		numRows := rng.Intn(100)
@@ -120,7 +123,7 @@ func TestStreamEncodeDecode(t *testing.T) {
 				rows[i].meta.Err = fmt.Errorf("test error %d", i)
 			}
 		}
-		testRowStream(t, rng, rows)
+		testRowStream(t, rng, types, rows)
 	}
 }
 

--- a/pkg/sql/distsqlrun/stream_decoder.go
+++ b/pkg/sql/distsqlrun/stream_decoder.go
@@ -156,7 +156,7 @@ func (sd *StreamDecoder) GetRow(
 	for i := range rowBuf {
 		var err error
 		rowBuf[i], sd.data, err = sqlbase.EncDatumFromBuffer(
-			sd.typing[i].Type, sd.typing[i].Encoding, sd.data,
+			&sd.typing[i].Type, sd.typing[i].Encoding, sd.data,
 		)
 		if err != nil {
 			// Reset sd because it is no longer usable.
@@ -165,4 +165,17 @@ func (sd *StreamDecoder) GetRow(
 		}
 	}
 	return rowBuf, ProducerMetadata{}, nil
+}
+
+// Types returns the types of the columns; can only be used after we received at
+// least one row.
+func (sd *StreamDecoder) Types() []sqlbase.ColumnType {
+	if !sd.typingReceived {
+		panic("no typing info received yet")
+	}
+	types := make([]sqlbase.ColumnType, len(sd.typing))
+	for i := range types {
+		types[i] = sd.typing[i].Type
+	}
+	return types
 }

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -149,7 +149,7 @@ func TestTableReader(t *testing.T) {
 			res = append(res, row)
 		}
 
-		if result := res.String(); result != c.expected {
+		if result := res.String(tr.OutputTypes()); result != c.expected {
 			t.Errorf("invalid results: %s, expected %s'", result, c.expected)
 		}
 	}
@@ -227,7 +227,7 @@ ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3
 		res = append(res, row)
 	}
 	if len(res) != 3 {
-		t.Fatalf("expected 3 rows, got: %s", res)
+		t.Fatalf("expected 3 rows, got: %d", len(res))
 	}
 	if len(metas) != 1 {
 		t.Fatalf("expected one meta with misplanned ranges, got: %+v", metas)

--- a/pkg/sql/distsqlrun/testutils.go
+++ b/pkg/sql/distsqlrun/testutils.go
@@ -34,15 +34,10 @@ var _ RowSource = &RepeatableRowSource{}
 func NewRepeatableRowSource(
 	types []sqlbase.ColumnType, rows sqlbase.EncDatumRows,
 ) *RepeatableRowSource {
-	r := &RepeatableRowSource{rows: rows, types: types}
-	if len(r.rows) > 0 && r.types == nil {
-		inferredTypes := make([]sqlbase.ColumnType, len(r.rows[0]))
-		for i, d := range r.rows[0] {
-			inferredTypes[i] = d.Type
-		}
-		r.types = inferredTypes
+	if types == nil {
+		panic("types required")
 	}
-	return r
+	return &RepeatableRowSource{rows: rows, types: types}
 }
 
 // Types is part of the RowSource interface.

--- a/pkg/sql/distsqlrun/util_test.go
+++ b/pkg/sql/distsqlrun/util_test.go
@@ -39,6 +39,7 @@ import (
 var intType = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
 var boolType = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BOOL}
 var decType = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_DECIMAL}
+var strType = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_STRING}
 var oneIntCol = []sqlbase.ColumnType{intType}
 var twoIntCols = []sqlbase.ColumnType{intType, intType}
 var threeIntCols = []sqlbase.ColumnType{intType, intType, intType}

--- a/pkg/sql/distsqlrun/util_test.go
+++ b/pkg/sql/distsqlrun/util_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -34,6 +35,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
+
+var intType = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
+var boolType = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BOOL}
+var decType = sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_DECIMAL}
+var oneIntCol = []sqlbase.ColumnType{intType}
+var twoIntCols = []sqlbase.ColumnType{intType, intType}
+var threeIntCols = []sqlbase.ColumnType{intType, intType, intType}
 
 // startMockDistSQLServer starts a MockDistSQLServer and returns the address on
 // which it's listening.

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -17,6 +17,7 @@ package sqlbase
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -40,7 +41,8 @@ func EncodingDirToDatumEncoding(dir encoding.Direction) DatumEncoding {
 // parser.Datum. It allows "passing through" a Datum without decoding and
 // reencoding.
 type EncDatum struct {
-	Type ColumnType
+	// Temporary, used just for sanity checking this change.
+	typeDeprecated ColumnType
 
 	// Encoding type. Valid only if encoded is not nil.
 	encoding DatumEncoding
@@ -52,7 +54,17 @@ type EncDatum struct {
 	Datum parser.Datum
 }
 
-func (ed *EncDatum) stringWithAlloc(a *DatumAlloc) string {
+func (ed *EncDatum) checkType(typ *ColumnType) {
+	if reflect.DeepEqual(ed.typeDeprecated, ColumnType{}) {
+		// Allow uninitialized types.
+		return
+	}
+	if ed.typeDeprecated.SemanticType != typ.SemanticType {
+		panic(fmt.Sprintf("expected type %+v, got %+v", ed.typeDeprecated, *typ))
+	}
+}
+
+func (ed *EncDatum) stringWithAlloc(typ *ColumnType, a *DatumAlloc) string {
 	if ed.Datum == nil {
 		if ed.encoded == nil {
 			return "<unset>"
@@ -60,7 +72,7 @@ func (ed *EncDatum) stringWithAlloc(a *DatumAlloc) string {
 		if a == nil {
 			a = &DatumAlloc{}
 		}
-		err := ed.EnsureDecoded(a)
+		err := ed.EnsureDecoded(typ, a)
 		if err != nil {
 			return fmt.Sprintf("<error: %v>", err)
 		}
@@ -68,23 +80,23 @@ func (ed *EncDatum) stringWithAlloc(a *DatumAlloc) string {
 	return ed.Datum.String()
 }
 
-func (ed *EncDatum) String() string {
-	return ed.stringWithAlloc(nil)
+func (ed *EncDatum) String(typ *ColumnType) string {
+	return ed.stringWithAlloc(typ, nil)
 }
 
 // EncDatumFromEncoded initializes an EncDatum with the given encoded
 // value. The encoded value is stored as a shallow copy, so the caller must
 // make sure the slice is not modified for the lifetime of the EncDatum.
 // SetEncoded wipes the underlying Datum.
-func EncDatumFromEncoded(typ ColumnType, enc DatumEncoding, encoded []byte) EncDatum {
+func EncDatumFromEncoded(typ *ColumnType, enc DatumEncoding, encoded []byte) EncDatum {
 	if len(encoded) == 0 {
-		panic("empty encoded value")
+		panic(fmt.Sprintf("empty encoded value"))
 	}
 	return EncDatum{
-		Type:     typ,
-		encoding: enc,
-		encoded:  encoded,
-		Datum:    nil,
+		typeDeprecated: *typ,
+		encoding:       enc,
+		encoded:        encoded,
+		Datum:          nil,
 	}
 }
 
@@ -92,7 +104,7 @@ func EncDatumFromEncoded(typ ColumnType, enc DatumEncoding, encoded []byte) EncD
 // possibly followed by other data. Similar to EncDatumFromEncoded,
 // except that this function figures out where the encoding stops and returns a
 // slice for the rest of the buffer.
-func EncDatumFromBuffer(typ ColumnType, enc DatumEncoding, buf []byte) (EncDatum, []byte, error) {
+func EncDatumFromBuffer(typ *ColumnType, enc DatumEncoding, buf []byte) (EncDatum, []byte, error) {
 	switch enc {
 	case DatumEncoding_ASCENDING_KEY, DatumEncoding_DESCENDING_KEY:
 		encLen, err := encoding.PeekLength(buf)
@@ -123,8 +135,8 @@ func DatumToEncDatum(ctyp ColumnType, d parser.Datum) EncDatum {
 			d.ResolvedType(), ptyp))
 	}
 	return EncDatum{
-		Type:  ctyp,
-		Datum: d,
+		typeDeprecated: ctyp,
+		Datum:          d,
 	}
 }
 
@@ -167,14 +179,15 @@ func (ed *EncDatum) IsNull() bool {
 }
 
 // EnsureDecoded ensures that the Datum field is set (decoding if it is not).
-func (ed *EncDatum) EnsureDecoded(a *DatumAlloc) error {
+func (ed *EncDatum) EnsureDecoded(typ *ColumnType, a *DatumAlloc) error {
+	ed.checkType(typ)
 	if ed.Datum != nil {
 		return nil
 	}
 	if ed.encoded == nil {
 		panic("decoding unset EncDatum")
 	}
-	datType := ed.Type.ToDatumType()
+	datType := typ.ToDatumType()
 	var err error
 	var rem []byte
 	switch ed.encoding {
@@ -210,12 +223,15 @@ func (ed *EncDatum) Encoding() (DatumEncoding, bool) {
 // encoding.
 // Note: DatumEncoding_VALUE encodings are not unique because they can contain
 // a column ID so they should not be used to test for equality.
-func (ed *EncDatum) Encode(a *DatumAlloc, enc DatumEncoding, appendTo []byte) ([]byte, error) {
+func (ed *EncDatum) Encode(
+	typ *ColumnType, a *DatumAlloc, enc DatumEncoding, appendTo []byte,
+) ([]byte, error) {
+	ed.checkType(typ)
 	if ed.encoded != nil && enc == ed.encoding {
 		// We already have an encoding that matches that we can use.
 		return append(appendTo, ed.encoded...), nil
 	}
-	if err := ed.EnsureDecoded(a); err != nil {
+	if err := ed.EnsureDecoded(typ, a); err != nil {
 		return nil, err
 	}
 	switch enc {
@@ -235,8 +251,9 @@ func (ed *EncDatum) Encode(a *DatumAlloc, enc DatumEncoding, appendTo []byte) ([
 //    0  if the receiver is equal to rhs,
 //    +1 if the receiver is greater than rhs.
 func (ed *EncDatum) Compare(
-	a *DatumAlloc, evalCtx *parser.EvalContext, rhs *EncDatum,
+	typ *ColumnType, a *DatumAlloc, evalCtx *parser.EvalContext, rhs *EncDatum,
 ) (int, error) {
+	ed.checkType(typ)
 	// TODO(radu): if we have both the Datum and a key encoding available, which
 	// one would be faster to use?
 	if ed.encoding == rhs.encoding && ed.encoded != nil && rhs.encoded != nil {
@@ -247,10 +264,10 @@ func (ed *EncDatum) Compare(
 			return bytes.Compare(rhs.encoded, ed.encoded), nil
 		}
 	}
-	if err := ed.EnsureDecoded(a); err != nil {
+	if err := ed.EnsureDecoded(typ, a); err != nil {
 		return 0, err
 	}
-	if err := rhs.EnsureDecoded(a); err != nil {
+	if err := rhs.EnsureDecoded(typ, a); err != nil {
 		return 0, err
 	}
 	return ed.Datum.Compare(evalCtx, rhs.Datum), nil
@@ -259,25 +276,33 @@ func (ed *EncDatum) Compare(
 // EncDatumRow is a row of EncDatums.
 type EncDatumRow []EncDatum
 
-func (r EncDatumRow) stringToBuf(a *DatumAlloc, b *bytes.Buffer) {
+func (r EncDatumRow) stringToBuf(types []ColumnType, a *DatumAlloc, b *bytes.Buffer) {
+	if len(types) != len(r) {
+		panic(fmt.Sprintf("mismatched types (%v) and row (%v)", types, r))
+	}
 	b.WriteString("[")
 	for i := range r {
 		if i > 0 {
 			b.WriteString(" ")
 		}
-		b.WriteString(r[i].stringWithAlloc(a))
+		b.WriteString(r[i].stringWithAlloc(&types[i], a))
 	}
 	b.WriteString("]")
 }
 
-func (r EncDatumRow) String() string {
+func (r EncDatumRow) String(types []ColumnType) string {
 	var b bytes.Buffer
-	r.stringToBuf(&DatumAlloc{}, &b)
+	r.stringToBuf(types, &DatumAlloc{}, &b)
 	return b.String()
 }
 
 // EncDatumRowToDatums converts a given EncDatumRow to a Datums.
-func EncDatumRowToDatums(datums parser.Datums, row EncDatumRow, da *DatumAlloc) error {
+func EncDatumRowToDatums(
+	types []ColumnType, datums parser.Datums, row EncDatumRow, da *DatumAlloc,
+) error {
+	if len(types) != len(row) {
+		panic(fmt.Sprintf("mismatched types (%v) and row (%v)", types, row))
+	}
 	if len(row) != len(datums) {
 		return errors.Errorf(
 			"Length mismatch (%d and %d) between datums and row", len(datums), len(row))
@@ -287,7 +312,7 @@ func EncDatumRowToDatums(datums parser.Datums, row EncDatumRow, da *DatumAlloc) 
 			datums[i] = parser.DNull
 			continue
 		}
-		err := encDatum.EnsureDecoded(da)
+		err := encDatum.EnsureDecoded(&types[i], da)
 		if err != nil {
 			return err
 		}
@@ -308,10 +333,17 @@ func EncDatumRowToDatums(datums parser.Datums, row EncDatumRow, da *DatumAlloc) 
 // {{0, asc}, {1, asc}} (i.e. ordered by first column and then by second
 // column).
 func (r EncDatumRow) Compare(
-	a *DatumAlloc, ordering ColumnOrdering, evalCtx *parser.EvalContext, rhs EncDatumRow,
+	types []ColumnType,
+	a *DatumAlloc,
+	ordering ColumnOrdering,
+	evalCtx *parser.EvalContext,
+	rhs EncDatumRow,
 ) (int, error) {
+	if len(r) != len(types) || len(rhs) != len(types) {
+		panic(fmt.Sprintf("length mismatch: %d types, %d lhs, %d rhs\n%+v\n%+v\n%+v", len(types), len(r), len(rhs), types, r, rhs))
+	}
 	for _, c := range ordering {
-		cmp, err := r[c.ColIdx].Compare(a, evalCtx, &rhs[c.ColIdx])
+		cmp, err := r[c.ColIdx].Compare(&types[c.ColIdx], a, evalCtx, &rhs[c.ColIdx])
 		if err != nil {
 			return 0, err
 		}
@@ -327,10 +359,14 @@ func (r EncDatumRow) Compare(
 
 // CompareToDatums is a version of Compare which compares against decoded Datums.
 func (r EncDatumRow) CompareToDatums(
-	a *DatumAlloc, ordering ColumnOrdering, evalCtx *parser.EvalContext, rhs parser.Datums,
+	types []ColumnType,
+	a *DatumAlloc,
+	ordering ColumnOrdering,
+	evalCtx *parser.EvalContext,
+	rhs parser.Datums,
 ) (int, error) {
 	for _, c := range ordering {
-		if err := r[c.ColIdx].EnsureDecoded(a); err != nil {
+		if err := r[c.ColIdx].EnsureDecoded(&types[c.ColIdx], a); err != nil {
 			return 0, err
 		}
 		cmp := r[c.ColIdx].Datum.Compare(evalCtx, rhs[c.ColIdx])
@@ -344,10 +380,10 @@ func (r EncDatumRow) CompareToDatums(
 	return 0, nil
 }
 
-// EncDatumRows is a slice of EncDatumRows.
+// EncDatumRows is a slice of EncDatumRows having the same schema.
 type EncDatumRows []EncDatumRow
 
-func (r EncDatumRows) String() string {
+func (r EncDatumRows) String(types []ColumnType) string {
 	var a DatumAlloc
 	var b bytes.Buffer
 	b.WriteString("[")
@@ -355,7 +391,7 @@ func (r EncDatumRows) String() string {
 		if i > 0 {
 			b.WriteString(" ")
 		}
-		r.stringToBuf(&a, &b)
+		r.stringToBuf(types, &a, &b)
 	}
 	b.WriteString("]")
 	return b.String()

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -245,13 +245,12 @@ func ConvertBatchError(ctx context.Context, tableDesc *TableDescriptor, b *clien
 		panic(fmt.Sprintf("index %d outside of results: %+v", j, b.Results))
 	}
 	result := b.Results[j]
-	var alloc DatumAlloc
 	if cErr, ok := origPErr.GetDetail().(*roachpb.ConditionFailedError); ok && len(result.Rows) > 0 {
 		key := result.Rows[0].Key
 		// TODO(dan): There's too much internal knowledge of the sql table
 		// encoding here (and this callsite is the only reason
 		// DecodeIndexKeyPrefix is exported). Refactor this bit out.
-		indexID, _, err := DecodeIndexKeyPrefix(&alloc, tableDesc, key)
+		indexID, _, err := DecodeIndexKeyPrefix(tableDesc, key)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -88,9 +88,11 @@ type RowFetcher struct {
 	// -- Fields updated during a scan --
 
 	kvFetcher      kvFetcher
-	keyVals        []EncDatum  // the index key values for the current row
+	keyVals        []EncDatum // the index key values for the current row
+	keyValTypes    []ColumnType
 	extraVals      EncDatumRow // the extra column values for unique indexes
-	indexKey       []byte      // the index key of the current row
+	extraTypes     []ColumnType
+	indexKey       []byte // the index key of the current row
 	row            EncDatumRow
 	decodedRow     parser.Datums
 	prettyValueBuf *bytes.Buffer
@@ -180,9 +182,10 @@ func (rf *RowFetcher) Init(
 		}
 	}
 
-	var err error
 	// Prepare our index key vals slice.
-	rf.keyVals, err = MakeEncodedKeyVals(rf.desc, indexColumnIDs)
+	rf.keyVals = make([]EncDatum, len(indexColumnIDs))
+	var err error
+	rf.keyValTypes, err = GetColumnTypes(desc, indexColumnIDs)
 	if err != nil {
 		return err
 	}
@@ -192,7 +195,8 @@ func (rf *RowFetcher) Init(
 		// key. Prepare extraVals for use in decoding this value.
 		// Primary indexes only contain ascendingly-encoded values. If this
 		// ever changes, we'll probably have to figure out the directions here too.
-		rf.extraVals, err = MakeEncodedKeyVals(desc, index.ExtraColumnIDs)
+		rf.extraVals = make([]EncDatum, len(index.ExtraColumnIDs))
+		rf.extraTypes, err = GetColumnTypes(desc, index.ExtraColumnIDs)
 		if err != nil {
 			return err
 		}
@@ -305,10 +309,10 @@ func (rf *RowFetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 	}
 }
 
-func prettyEncDatums(vals []EncDatum) string {
+func (rf *RowFetcher) prettyEncDatums(types []ColumnType, vals []EncDatum) string {
 	var buf bytes.Buffer
-	for _, v := range vals {
-		if err := v.EnsureDecoded(&DatumAlloc{}); err != nil {
+	for i, v := range vals {
+		if err := v.EnsureDecoded(&types[i], &DatumAlloc{}); err != nil {
 			fmt.Fprintf(&buf, "error decoding: %v", err)
 		}
 		fmt.Fprintf(&buf, "/%v", v.Datum)
@@ -318,8 +322,7 @@ func prettyEncDatums(vals []EncDatum) string {
 
 // ReadIndexKey decodes an index key for the fetcher's table.
 func (rf *RowFetcher) ReadIndexKey(k roachpb.Key) (remaining []byte, ok bool, err error) {
-	return DecodeIndexKey(rf.alloc, rf.desc, rf.index, rf.keyVals,
-		rf.indexColumnDirs, k)
+	return DecodeIndexKey(rf.desc, rf.index, rf.keyValTypes, rf.keyVals, rf.indexColumnDirs, k)
 }
 
 // processKV processes the given key/value, setting values in the row
@@ -329,7 +332,9 @@ func (rf *RowFetcher) processKV(
 	ctx context.Context, kv roachpb.KeyValue,
 ) (prettyKey string, prettyValue string, err error) {
 	if rf.traceKV {
-		prettyKey = fmt.Sprintf("/%s/%s%s", rf.desc.Name, rf.index.Name, prettyEncDatums(rf.keyVals))
+		prettyKey = fmt.Sprintf(
+			"/%s/%s%s", rf.desc.Name, rf.index.Name, rf.prettyEncDatums(rf.keyValTypes, rf.keyVals),
+		)
 	}
 
 	if rf.indexKey == nil {
@@ -395,7 +400,7 @@ func (rf *RowFetcher) processKV(
 			// This is a unique index; decode the extra column values from
 			// the value.
 			var err error
-			valueBytes, err = DecodeKeyVals(rf.extraVals, nil, valueBytes)
+			valueBytes, err = DecodeKeyVals(rf.extraTypes, rf.extraVals, nil, valueBytes)
 			if err != nil {
 				return "", "", err
 			}
@@ -405,13 +410,13 @@ func (rf *RowFetcher) processKV(
 				}
 			}
 			if rf.traceKV {
-				prettyValue = prettyEncDatums(rf.extraVals)
+				prettyValue = rf.prettyEncDatums(rf.extraTypes, rf.extraVals)
 			}
 		}
 
 		if debugRowFetch {
 			if rf.extraVals != nil {
-				log.Infof(ctx, "Scan %s -> %s", kv.Key, prettyEncDatums(rf.extraVals))
+				log.Infof(ctx, "Scan %s -> %s", kv.Key, rf.prettyEncDatums(rf.extraTypes, rf.extraVals))
 			} else {
 				log.Infof(ctx, "Scan %s", kv.Key)
 			}
@@ -527,12 +532,12 @@ func (rf *RowFetcher) processValueBytes(
 
 		var encValue EncDatum
 		encValue, valueBytes, err =
-			EncDatumFromBuffer(rf.cols[idx].Type, DatumEncoding_VALUE, valueBytes)
+			EncDatumFromBuffer(&rf.cols[idx].Type, DatumEncoding_VALUE, valueBytes)
 		if err != nil {
 			return "", "", err
 		}
 		if rf.traceKV {
-			err := encValue.EnsureDecoded(rf.alloc)
+			err := encValue.EnsureDecoded(&rf.cols[idx].Type, rf.alloc)
 			if err != nil {
 				return "", "", err
 			}
@@ -607,10 +612,18 @@ func (rf *RowFetcher) NextRowDecoded(ctx context.Context, traceKV bool) (parser.
 	if encRow == nil {
 		return nil, nil
 	}
-	err = EncDatumRowToDatums(rf.decodedRow, encRow, rf.alloc)
-	if err != nil {
-		return nil, err
+
+	for i, encDatum := range encRow {
+		if encDatum.IsUnset() {
+			rf.decodedRow[i] = parser.DNull
+			continue
+		}
+		if err := encDatum.EnsureDecoded(&rf.cols[i].Type, rf.alloc); err != nil {
+			return nil, err
+		}
+		rf.decodedRow[i] = encDatum.Datum
 	}
+
 	return rf.decodedRow, nil
 }
 
@@ -623,8 +636,8 @@ func (rf *RowFetcher) finalizeRow() {
 					rf.desc.Name, rf.cols[i].Name))
 			}
 			rf.row[i] = EncDatum{
-				Type:  rf.cols[i].Type,
-				Datum: parser.DNull,
+				typeDeprecated: rf.cols[i].Type,
+				Datum:          parser.DNull,
 			}
 		}
 	}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -635,10 +635,7 @@ func (rf *RowFetcher) finalizeRow() {
 				panic(fmt.Sprintf("Non-nullable column \"%s:%s\" with no value!",
 					rf.desc.Name, rf.cols[i].Name))
 			}
-			rf.row[i] = EncDatum{
-				typeDeprecated: rf.cols[i].Type,
-				Datum:          parser.DNull,
-			}
+			rf.row[i] = EncDatum{Datum: parser.DNull}
 		}
 	}
 }

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -380,7 +380,11 @@ func EncodeColumns(
 }
 
 func appendEncDatumsToKey(
-	key roachpb.Key, values EncDatumRow, dirs []IndexDescriptor_Direction, alloc *DatumAlloc,
+	key roachpb.Key,
+	types []ColumnType,
+	values EncDatumRow,
+	dirs []IndexDescriptor_Direction,
+	alloc *DatumAlloc,
 ) (roachpb.Key, error) {
 	for i, val := range values {
 		encoding := DatumEncoding_ASCENDING_KEY
@@ -388,7 +392,7 @@ func appendEncDatumsToKey(
 			encoding = DatumEncoding_DESCENDING_KEY
 		}
 		var err error
-		key, err = val.Encode(alloc, encoding, key)
+		key, err = val.Encode(&types[i], alloc, encoding, key)
 		if err != nil {
 			return nil, err
 		}
@@ -408,6 +412,7 @@ func appendEncDatumsToKey(
 // Note that ExtraColumnIDs are not encoded, so the result isn't always a
 // full index key.
 func MakeKeyFromEncDatums(
+	types []ColumnType,
 	values EncDatumRow,
 	tableDesc *TableDescriptor,
 	index *IndexDescriptor,
@@ -417,6 +422,9 @@ func MakeKeyFromEncDatums(
 	dirs := index.ColumnDirections
 	if len(values) != len(dirs) {
 		return nil, errors.Errorf("%d values, %d directions", len(values), len(dirs))
+	}
+	if len(values) != len(types) {
+		return nil, errors.Errorf("%d values, %d types", len(values), len(types))
 	}
 	// We know we will append to the key which will cause the capacity to grow
 	// so make it bigger from the get-go.
@@ -433,11 +441,11 @@ func MakeKeyFromEncDatums(
 
 			length := int(ancestor.SharedPrefixLen)
 			var err error
-			key, err = appendEncDatumsToKey(key, values[:length], dirs[:length], alloc)
+			key, err = appendEncDatumsToKey(key, types[:length], values[:length], dirs[:length], alloc)
 			if err != nil {
 				return nil, err
 			}
-			values, dirs = values[length:], dirs[length:]
+			types, values, dirs = types[length:], values[length:], dirs[length:]
 
 			// We reuse NotNullDescending (0xfe) as the interleave sentinel.
 			key = encoding.EncodeNotNullDescending(key)
@@ -446,7 +454,7 @@ func MakeKeyFromEncDatums(
 		key = encoding.EncodeUvarintAscending(key, uint64(tableDesc.ID))
 		key = encoding.EncodeUvarintAscending(key, uint64(index.ID))
 	}
-	return appendEncDatumsToKey(key, values, dirs, alloc)
+	return appendEncDatumsToKey(key, types, values, dirs, alloc)
 }
 
 // EncodeDatum encodes a datum (order-preserving encoding, suitable for keys).
@@ -634,18 +642,17 @@ func EncodeTableValue(
 	return nil, errors.Errorf("unable to encode table value: %T", val)
 }
 
-// MakeEncodedKeyVals returns a slice of EncDatums with the correct types for
-// the given columns.
-func MakeEncodedKeyVals(desc *TableDescriptor, columnIDs []ColumnID) ([]EncDatum, error) {
-	keyVals := make([]EncDatum, len(columnIDs))
+// GetColumnTypes returns the types of the columns with the given IDs.
+func GetColumnTypes(desc *TableDescriptor, columnIDs []ColumnID) ([]ColumnType, error) {
+	types := make([]ColumnType, len(columnIDs))
 	for i, id := range columnIDs {
 		col, err := desc.FindActiveColumnByID(id)
 		if err != nil {
 			return nil, err
 		}
-		keyVals[i].Type = col.Type
+		types[i] = col.Type
 	}
-	return keyVals, nil
+	return types, nil
 }
 
 // DecodeTableIDIndexID decodes a table id followed by an index id.
@@ -671,7 +678,7 @@ func DecodeTableIDIndexID(key []byte) ([]byte, ID, IndexID, error) {
 //
 // Don't use this function in the scan "hot path".
 func DecodeIndexKeyPrefix(
-	a *DatumAlloc, desc *TableDescriptor, key []byte,
+	desc *TableDescriptor, key []byte,
 ) (indexID IndexID, remaining []byte, err error) {
 	// TODO(dan): This whole operation is n^2 because of the interleaves
 	// bookkeeping. We could improve it to n with a prefix tree of components.
@@ -728,19 +735,21 @@ func DecodeIndexKeyPrefix(
 }
 
 // DecodeIndexKey decodes the values that are a part of the specified index
-// key. ValTypes is a slice returned from makeKeyVals. The remaining bytes in the
-// index key are returned which will either be an encoded column ID for the
-// primary key index, the primary key suffix for non-unique secondary indexes
-// or unique secondary indexes containing NULL or empty. If the given descriptor
-// does not match the key, false is returned with no error.
+// key (setting vals).
+//
+// The remaining bytes in the index key are returned which will either be an
+// encoded column ID for the primary key index, the primary key suffix for
+// non-unique secondary indexes or unique secondary indexes containing NULL or
+// empty. If the given descriptor does not match the key, false is returned with
+// no error.
 func DecodeIndexKey(
-	a *DatumAlloc,
 	desc *TableDescriptor,
 	index *IndexDescriptor,
+	types []ColumnType,
 	vals []EncDatum,
 	colDirs []encoding.Direction,
 	key []byte,
-) ([]byte, bool, error) {
+) (remainingKey []byte, matches bool, _ error) {
 	var decodedTableID ID
 	var decodedIndexID IndexID
 	var err error
@@ -756,11 +765,11 @@ func DecodeIndexKey(
 			}
 
 			length := int(ancestor.SharedPrefixLen)
-			key, err = DecodeKeyVals(vals[:length], colDirs[:length], key)
+			key, err = DecodeKeyVals(types[:length], vals[:length], colDirs[:length], key)
 			if err != nil {
 				return nil, false, err
 			}
-			vals, colDirs = vals[length:], colDirs[length:]
+			types, vals, colDirs = types[length:], vals[length:], colDirs[length:]
 
 			// We reuse NotNullDescending as the interleave sentinel, consume it.
 			var ok bool
@@ -779,7 +788,7 @@ func DecodeIndexKey(
 		return nil, false, nil
 	}
 
-	key, err = DecodeKeyVals(vals, colDirs, key)
+	key, err = DecodeKeyVals(types, vals, colDirs, key)
 	if err != nil {
 		return nil, false, err
 	}
@@ -796,9 +805,11 @@ func DecodeIndexKey(
 // DecodeKeyVals decodes the values that are part of the key. The decoded
 // values are stored in the vals. If this slice is nil, the direction
 // used will default to encoding.Ascending.
-func DecodeKeyVals(vals []EncDatum, directions []encoding.Direction, key []byte) ([]byte, error) {
+func DecodeKeyVals(
+	types []ColumnType, vals []EncDatum, directions []encoding.Direction, key []byte,
+) ([]byte, error) {
 	if directions != nil && len(directions) != len(vals) {
-		return nil, errors.Errorf("encoding directions doesn't parallel val: %d vs %d.",
+		return nil, errors.Errorf("encoding directions doesn't parallel vals: %d vs %d.",
 			len(directions), len(vals))
 	}
 	for j := range vals {
@@ -807,7 +818,7 @@ func DecodeKeyVals(vals []EncDatum, directions []encoding.Direction, key []byte)
 			enc = DatumEncoding_DESCENDING_KEY
 		}
 		var err error
-		vals[j], key, err = EncDatumFromBuffer(vals[j].Type, enc, key)
+		vals[j], key, err = EncDatumFromBuffer(&types[j], enc, key)
 		if err != nil {
 			return nil, err
 		}
@@ -822,7 +833,7 @@ func DecodeKeyVals(vals []EncDatum, directions []encoding.Direction, key []byte)
 func ExtractIndexKey(
 	a *DatumAlloc, tableDesc *TableDescriptor, entry client.KeyValue,
 ) (roachpb.Key, error) {
-	indexID, key, err := DecodeIndexKeyPrefix(a, tableDesc, entry.Key)
+	indexID, key, err := DecodeIndexKeyPrefix(tableDesc, entry.Key)
 	if err != nil {
 		return nil, err
 	}
@@ -836,10 +847,11 @@ func ExtractIndexKey(
 	}
 
 	// Extract the values for index.ColumnIDs.
-	values, err := MakeEncodedKeyVals(tableDesc, index.ColumnIDs)
+	indexTypes, err := GetColumnTypes(tableDesc, index.ColumnIDs)
 	if err != nil {
 		return nil, err
 	}
+	values := make([]EncDatum, len(index.ColumnIDs))
 	dirs := make([]encoding.Direction, len(index.ColumnIDs))
 	for i, dir := range index.ColumnDirections {
 		dirs[i], err = dir.ToEncodingDirection()
@@ -847,12 +859,12 @@ func ExtractIndexKey(
 			return nil, err
 		}
 	}
-	if i, err := tableDesc.FindIndexByID(indexID); err == nil && len(i.Interleave.Ancestors) > 0 {
+	if len(index.Interleave.Ancestors) > 0 {
 		// TODO(dan): In the interleaved index case, we parse the key twice; once to
 		// find the index id so we can look up the descriptor, and once to extract
 		// the values. Only parse once.
 		var ok bool
-		_, ok, err = DecodeIndexKey(a, tableDesc, i, values, dirs, entry.Key)
+		_, ok, err = DecodeIndexKey(tableDesc, index, indexTypes, values, dirs, entry.Key)
 		if err != nil {
 			return nil, err
 		}
@@ -860,17 +872,18 @@ func ExtractIndexKey(
 			return nil, errors.Errorf("descriptor did not match key")
 		}
 	} else {
-		key, err = DecodeKeyVals(values, dirs, key)
+		key, err = DecodeKeyVals(indexTypes, values, dirs, key)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// Extract the values for index.ExtraColumnIDs
-	extraValues, err := MakeEncodedKeyVals(tableDesc, index.ExtraColumnIDs)
+	extraTypes, err := GetColumnTypes(tableDesc, index.ExtraColumnIDs)
 	if err != nil {
 		return nil, err
 	}
+	extraValues := make([]EncDatum, len(index.ExtraColumnIDs))
 	dirs = make([]encoding.Direction, len(index.ExtraColumnIDs))
 	for i := range index.ExtraColumnIDs {
 		// Implicit columns are always encoded Ascending.
@@ -883,13 +896,12 @@ func ExtractIndexKey(
 			return nil, err
 		}
 	}
-	_, err = DecodeKeyVals(extraValues, dirs, extraKey)
+	_, err = DecodeKeyVals(extraTypes, extraValues, dirs, extraKey)
 	if err != nil {
 		return nil, err
 	}
 
 	// Encode the index key from its components.
-	values = append(values, extraValues...)
 	colMap := make(map[ColumnID]int)
 	for i, columnID := range index.ColumnIDs {
 		colMap[columnID] = i
@@ -898,14 +910,21 @@ func ExtractIndexKey(
 		colMap[columnID] = i + len(index.ColumnIDs)
 	}
 	indexKeyPrefix := MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
-	decodedValues := make([]parser.Datum, len(values))
-	var da DatumAlloc
+
+	decodedValues := make([]parser.Datum, len(values)+len(extraValues))
 	for i, value := range values {
-		err := value.EnsureDecoded(&da)
+		err := value.EnsureDecoded(&indexTypes[i], a)
 		if err != nil {
 			return nil, err
 		}
 		decodedValues[i] = value.Datum
+	}
+	for i, value := range extraValues {
+		err := value.EnsureDecoded(&extraTypes[i], a)
+		if err != nil {
+			return nil, err
+		}
+		decodedValues[len(values)+i] = value.Datum
 	}
 	indexKey, _, err := EncodeIndexKey(
 		tableDesc, &tableDesc.PrimaryIndex, colMap, decodedValues, indexKeyPrefix)

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -90,12 +90,13 @@ func makeTableDescForTest(test indexKeyTest) (TableDescriptor, map[ColumnID]int)
 }
 
 func decodeIndex(
-	a *DatumAlloc, tableDesc *TableDescriptor, index *IndexDescriptor, key []byte,
+	tableDesc *TableDescriptor, index *IndexDescriptor, key []byte,
 ) ([]parser.Datum, error) {
-	values, err := MakeEncodedKeyVals(tableDesc, index.ColumnIDs)
+	types, err := GetColumnTypes(tableDesc, index.ColumnIDs)
 	if err != nil {
 		return nil, err
 	}
+	values := make([]EncDatum, len(index.ColumnIDs))
 	colDirs := make([]encoding.Direction, len(index.ColumnDirections))
 	for i, dir := range index.ColumnDirections {
 		colDirs[i], err = dir.ToEncodingDirection()
@@ -103,7 +104,7 @@ func decodeIndex(
 			return nil, err
 		}
 	}
-	_, ok, err := DecodeIndexKey(a, tableDesc, index, values, colDirs, key)
+	_, ok, err := DecodeIndexKey(tableDesc, index, types, values, colDirs, key)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +115,7 @@ func decodeIndex(
 	decodedValues := make([]parser.Datum, len(values))
 	var da DatumAlloc
 	for i, value := range values {
-		err := value.EnsureDecoded(&da)
+		err := value.EnsureDecoded(&types[i], &da)
 		if err != nil {
 			return nil, err
 		}
@@ -211,7 +212,7 @@ func TestIndexKey(t *testing.T) {
 		}
 
 		checkEntry := func(index *IndexDescriptor, entry client.KeyValue) {
-			values, err := decodeIndex(&a, &tableDesc, index, entry.Key)
+			values, err := decodeIndex(&tableDesc, index, entry.Key)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -223,7 +224,7 @@ func TestIndexKey(t *testing.T) {
 				}
 			}
 
-			indexID, _, err := DecodeIndexKeyPrefix(&a, &tableDesc, entry.Key)
+			indexID, _, err := DecodeIndexKeyPrefix(&tableDesc, entry.Key)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
#### distsqlrun: require types for RowBuffer

Curretly the RowBuffer (used mainly in tests) relies on the types in the
`EncDatum`s (unless it is an empty buffer). To prepare for a removing the type
information from `EncDatum`, requires the types in all cases.

#### sqlbase: remove ColumnType from EncDatum

We carry around the entire `ColumnType` with every `EncDatum`. Initially
`ColumnType` was just a 32-bit value (it used memory that is otherwise lost to
padding). But in time this type grew much bigger.

This change modifies the EncDatum interface to require the type information to
be passed in. We leave the type as a deprecated field and assert that the type
matches. In a subsequent commit, this type will be removed.

In addition to the immediate performance improvement, these changes should help
facilitate switching to a more efficient representation of rows or row groups
(which would definitely require the type information to be passed in).

#### sqlbase: remove the deprecated type from EncDatum

Infrastructure benchmarks for this group of changes:

```
name                        old time/op    new time/op    delta
Infrastructure/n1/r1-4         186µs ± 4%     187µs ±10%     ~       (p=0.959 n=8+8)
Infrastructure/n1/r100-4       395µs ±29%     345µs ±12%  -12.51%    (p=0.019 n=9+9)
Infrastructure/n1/r10000-4    16.9ms ±24%    14.1ms ±44%     ~     (p=0.052 n=10+10)
Infrastructure/n3/r1-4         598µs ± 2%     580µs ± 5%   -3.02%   (p=0.043 n=7+10)
Infrastructure/n3/r100-4      1.30ms ± 6%    1.15ms ± 3%  -12.09%   (p=0.000 n=9+10)
Infrastructure/n3/r10000-4    56.9ms ±14%    45.6ms ± 4%  -19.79%   (p=0.000 n=10+9)

name                        old alloc/op   new alloc/op   delta
Infrastructure/n1/r1-4        37.3kB ± 0%    33.0kB ± 0%  -11.63%   (p=0.000 n=10+9)
Infrastructure/n1/r100-4       187kB ± 0%     123kB ± 0%  -34.51%  (p=0.000 n=10+10)
Infrastructure/n1/r10000-4    15.8MB ± 0%     9.6MB ± 0%  -39.25%  (p=0.000 n=10+10)
Infrastructure/n3/r1-4         129kB ± 2%     117kB ± 2%   -9.18%  (p=0.000 n=10+10)
Infrastructure/n3/r100-4       725kB ± 1%     489kB ± 1%  -32.50%  (p=0.000 n=10+10)
Infrastructure/n3/r10000-4    61.3MB ± 0%    39.1MB ± 0%  -36.16%  (p=0.000 n=10+10)

name                        old allocs/op  new allocs/op  delta
Infrastructure/n1/r1-4           214 ± 0%       217 ± 0%   +1.59%   (p=0.000 n=8+10)
Infrastructure/n1/r100-4         326 ± 0%       328 ± 0%   +0.61%    (p=0.002 n=6+6)
Infrastructure/n1/r10000-4     10.2k ± 0%     10.1k ± 0%   -0.69%   (p=0.000 n=10+9)
Infrastructure/n3/r1-4           935 ± 0%       937 ± 0%   +0.26%   (p=0.000 n=10+8)
Infrastructure/n3/r100-4       1.71k ± 0%     1.71k ± 0%     ~     (p=0.346 n=10+10)
Infrastructure/n3/r10000-4     76.6k ± 0%     76.4k ± 0%   -0.19%  (p=0.000 n=10+10)
```

CC @knz