### PR TITLE
sql: handle arrays properly in pgwire

### DIFF
--- a/pkg/acceptance/node_test.go
+++ b/pkg/acceptance/node_test.go
@@ -97,6 +97,28 @@ function testSendNotEnoughParams(client) {
   });
 }
 
+function testInsertArray(client) {
+  return new Promise(resolve => {
+    client.query({
+      text: 'CREATE DATABASE d',
+    }, (err) => {
+      if (err) throw err;
+      client.query({
+        text: 'CREATE TABLE d.x (y FLOAT[])',
+      }, (err) => {
+        if (err) throw err;
+        client.query({
+          text: 'INSERT INTO d.x VALUES ($1)',
+          values: [[1, 2, 3]],
+        }, (err) => {
+          if (err) throw err;
+          resolve();
+        });
+      });
+    });
+  });
+}
+
 function runTests(client, ...tests) {
   if (tests.length === 0) {
     return Promise.resolve();
@@ -111,12 +133,14 @@ client.connect(function (err) {
   runTests(client,
     testSendInvalidUTF8,
     testSendNotEnoughParams,
+    testInsertArray,
     testSelect
   ).then(result => {
     client.end(function (err) {
       if (err) throw err;
     });
   }).catch(err => {
+    client.end()
     throw err;
   });
 });

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -675,15 +675,28 @@ oid   typname       typnamespace  typowner  typlen  typbyval  typtype
 700   float4        1782195457    NULL      8       true      b
 701   float8        1782195457    NULL      8       true      b
 869   inet          1782195457    NULL      24      true      b
+1000  _bool         1782195457    NULL      -1      false     b
+1001  _bytea        1782195457    NULL      -1      false     b
+1003  _name         1782195457    NULL      -1      false     b
 1005  _int2         1782195457    NULL      -1      false     b
 1007  _int4         1782195457    NULL      -1      false     b
 1009  _text         1782195457    NULL      -1      false     b
+1015  _varchar      1782195457    NULL      -1      false     b
 1016  _int8         1782195457    NULL      -1      false     b
+1021  _float4       1782195457    NULL      -1      false     b
+1022  _float8       1782195457    NULL      -1      false     b
+1028  _oid          1782195457    NULL      -1      false     b
+1041  _inet         1782195457    NULL      -1      false     b
 1043  varchar       1782195457    NULL      -1      false     b
 1082  date          1782195457    NULL      8       true      b
 1114  timestamp     1782195457    NULL      24      true      b
+1115  _timestamp    1782195457    NULL      -1      false     b
+1182  _date         1782195457    NULL      -1      false     b
 1184  timestamptz   1782195457    NULL      24      true      b
+1185  _timestamptz  1782195457    NULL      -1      false     b
 1186  interval      1782195457    NULL      24      true      b
+1187  _interval     1782195457    NULL      -1      false     b
+1231  _numeric      1782195457    NULL      -1      false     b
 1700  numeric       1782195457    NULL      -1      false     b
 2202  regprocedure  1782195457    NULL      8       true      b
 2205  regclass      1782195457    NULL      8       true      b
@@ -691,6 +704,7 @@ oid   typname       typnamespace  typowner  typlen  typbyval  typtype
 2249  record        1782195457    NULL      0       true      b
 2283  anyelement    1782195457    NULL      -1      false     b
 2950  uuid          1782195457    NULL      16      true      b
+2951  _uuid         1782195457    NULL      -1      false     b
 4089  regnamespace  1782195457    NULL      8       true      b
 
 query OTTBBTOOO colnames
@@ -699,35 +713,49 @@ FROM pg_catalog.pg_type
 ORDER BY oid
 ----
 oid   typname       typcategory  typispreferred  typisdefined  typdelim  typrelid  typelem  typarray
-16    bool          B            false           true          ,         0         0        0
-17    bytea         U            false           true          ,         0         0        0
-19    name          S            false           true          ,         0         0        0
-20    int8          N            false           true          ,         0         0        0
-21    int2          N            false           true          ,         0         0        0
+16    bool          B            false           true          ,         0         0        1000
+17    bytea         U            false           true          ,         0         0        1001
+19    name          S            false           true          ,         0         0        1003
+20    int8          N            false           true          ,         0         0        1016
+21    int2          N            false           true          ,         0         0        1005
 22    int2vector    A            false           true          ,         0         21       0
-23    int4          N            false           true          ,         0         0        0
+23    int4          N            false           true          ,         0         0        1007
 24    regproc       N            false           true          ,         0         0        0
-25    text          S            false           true          ,         0         0        0
-26    oid           N            false           true          ,         0         0        0
-700   float4        N            false           true          ,         0         0        0
-701   float8        N            false           true          ,         0         0        0
-869   inet          I            false           true          ,         0         0        0
+25    text          S            false           true          ,         0         0        1009
+26    oid           N            false           true          ,         0         0        1028
+700   float4        N            false           true          ,         0         0        1021
+701   float8        N            false           true          ,         0         0        1022
+869   inet          I            false           true          ,         0         0        1041
+1000  _bool         A            false           true          ,         0         16       0
+1001  _bytea        A            false           true          ,         0         17       0
+1003  _name         A            false           true          ,         0         19       0
 1005  _int2         A            false           true          ,         0         21       0
 1007  _int4         A            false           true          ,         0         23       0
 1009  _text         A            false           true          ,         0         25       0
+1015  _varchar      A            false           true          ,         0         1043     0
 1016  _int8         A            false           true          ,         0         20       0
-1043  varchar       S            false           true          ,         0         0        0
-1082  date          D            false           true          ,         0         0        0
-1114  timestamp     D            false           true          ,         0         0        0
-1184  timestamptz   D            false           true          ,         0         0        0
-1186  interval      T            false           true          ,         0         0        0
-1700  numeric       N            false           true          ,         0         0        0
+1021  _float4       A            false           true          ,         0         700      0
+1022  _float8       A            false           true          ,         0         701      0
+1028  _oid          A            false           true          ,         0         26       0
+1041  _inet         A            false           true          ,         0         869      0
+1043  varchar       S            false           true          ,         0         0        1015
+1082  date          D            false           true          ,         0         0        1182
+1114  timestamp     D            false           true          ,         0         0        1115
+1115  _timestamp    A            false           true          ,         0         1114     0
+1182  _date         A            false           true          ,         0         1082     0
+1184  timestamptz   D            false           true          ,         0         0        1185
+1185  _timestamptz  A            false           true          ,         0         1184     0
+1186  interval      T            false           true          ,         0         0        1187
+1187  _interval     A            false           true          ,         0         1186     0
+1231  _numeric      A            false           true          ,         0         1700     0
+1700  numeric       N            false           true          ,         0         0        1231
 2202  regprocedure  N            false           true          ,         0         0        0
 2205  regclass      N            false           true          ,         0         0        0
 2206  regtype       N            false           true          ,         0         0        0
 2249  record        P            false           true          ,         0         0        0
 2283  anyelement    P            false           true          ,         0         0        0
-2950  uuid          U            false           true          ,         0         0        0
+2950  uuid          U            false           true          ,         0         0        2951
+2951  _uuid         A            false           true          ,         0         2950     0
 4089  regnamespace  N            false           true          ,         0         0        0
 
 query OTOOOOOOO colnames
@@ -749,15 +777,28 @@ oid   typname       typinput        typoutput        typreceive        typsend  
 700   float4        float4in        float4out        float4recv        float4send        0         0          0
 701   float8        float8in        float8out        float8recv        float8send        0         0          0
 869   inet          inetin          inetout          inetrecv          inetsend          0         0          0
+1000  _bool         array_in        array_out        array_recv        array_send        0         0          0
+1001  _bytea        array_in        array_out        array_recv        array_send        0         0          0
+1003  _name         array_in        array_out        array_recv        array_send        0         0          0
 1005  _int2         array_in        array_out        array_recv        array_send        0         0          0
 1007  _int4         array_in        array_out        array_recv        array_send        0         0          0
 1009  _text         array_in        array_out        array_recv        array_send        0         0          0
+1015  _varchar      array_in        array_out        array_recv        array_send        0         0          0
 1016  _int8         array_in        array_out        array_recv        array_send        0         0          0
+1021  _float4       array_in        array_out        array_recv        array_send        0         0          0
+1022  _float8       array_in        array_out        array_recv        array_send        0         0          0
+1028  _oid          array_in        array_out        array_recv        array_send        0         0          0
+1041  _inet         array_in        array_out        array_recv        array_send        0         0          0
 1043  varchar       varcharin       varcharout       varcharrecv       varcharsend       0         0          0
 1082  date          date_in         date_out         date_recv         date_send         0         0          0
 1114  timestamp     timestamp_in    timestamp_out    timestamp_recv    timestamp_send    0         0          0
+1115  _timestamp    array_in        array_out        array_recv        array_send        0         0          0
+1182  _date         array_in        array_out        array_recv        array_send        0         0          0
 1184  timestamptz   timestamptz_in  timestamptz_out  timestamptz_recv  timestamptz_send  0         0          0
+1185  _timestamptz  array_in        array_out        array_recv        array_send        0         0          0
 1186  interval      interval_in     interval_out     interval_recv     interval_send     0         0          0
+1187  _interval     array_in        array_out        array_recv        array_send        0         0          0
+1231  _numeric      array_in        array_out        array_recv        array_send        0         0          0
 1700  numeric       numeric_in      numeric_out      numeric_recv      numeric_send      0         0          0
 2202  regprocedure  regprocedurein  regprocedureout  regprocedurerecv  regproceduresend  0         0          0
 2205  regclass      regclassin      regclassout      regclassrecv      regclasssend      0         0          0
@@ -765,6 +806,7 @@ oid   typname       typinput        typoutput        typreceive        typsend  
 2249  record        record_in       record_out       record_recv       record_send       0         0          0
 2283  anyelement    anyelement_in   anyelement_out   anyelement_recv   anyelement_send   0         0          0
 2950  uuid          uuid_in         uuid_out         uuid_recv         uuid_send         0         0          0
+2951  _uuid         array_in        array_out        array_recv        array_send        0         0          0
 4089  regnamespace  regnamespacein  regnamespaceout  regnamespacerecv  regnamespacesend  0         0          0
 
 query OTTTBOI colnames
@@ -786,15 +828,28 @@ oid   typname       typalign  typstorage  typnotnull  typbasetype  typtypmod
 700   float4        NULL      NULL        false       0            -1
 701   float8        NULL      NULL        false       0            -1
 869   inet          NULL      NULL        false       0            -1
+1000  _bool         NULL      NULL        false       0            -1
+1001  _bytea        NULL      NULL        false       0            -1
+1003  _name         NULL      NULL        false       0            -1
 1005  _int2         NULL      NULL        false       0            -1
 1007  _int4         NULL      NULL        false       0            -1
 1009  _text         NULL      NULL        false       0            -1
+1015  _varchar      NULL      NULL        false       0            -1
 1016  _int8         NULL      NULL        false       0            -1
+1021  _float4       NULL      NULL        false       0            -1
+1022  _float8       NULL      NULL        false       0            -1
+1028  _oid          NULL      NULL        false       0            -1
+1041  _inet         NULL      NULL        false       0            -1
 1043  varchar       NULL      NULL        false       0            -1
 1082  date          NULL      NULL        false       0            -1
 1114  timestamp     NULL      NULL        false       0            -1
+1115  _timestamp    NULL      NULL        false       0            -1
+1182  _date         NULL      NULL        false       0            -1
 1184  timestamptz   NULL      NULL        false       0            -1
+1185  _timestamptz  NULL      NULL        false       0            -1
 1186  interval      NULL      NULL        false       0            -1
+1187  _interval     NULL      NULL        false       0            -1
+1231  _numeric      NULL      NULL        false       0            -1
 1700  numeric       NULL      NULL        false       0            -1
 2202  regprocedure  NULL      NULL        false       0            -1
 2205  regclass      NULL      NULL        false       0            -1
@@ -802,6 +857,7 @@ oid   typname       typalign  typstorage  typnotnull  typbasetype  typtypmod
 2249  record        NULL      NULL        false       0            -1
 2283  anyelement    NULL      NULL        false       0            -1
 2950  uuid          NULL      NULL        false       0            -1
+2951  _uuid         NULL      NULL        false       0            -1
 4089  regnamespace  NULL      NULL        false       0            -1
 
 query OTIOTTT colnames
@@ -823,15 +879,28 @@ oid   typname       typndims  typcollation  typdefaultbin  typdefault  typacl
 700   float4        0         0             NULL           NULL        NULL
 701   float8        0         0             NULL           NULL        NULL
 869   inet          0         0             NULL           NULL        NULL
+1000  _bool         0         0             NULL           NULL        NULL
+1001  _bytea        0         0             NULL           NULL        NULL
+1003  _name         0         1661428263    NULL           NULL        NULL
 1005  _int2         0         0             NULL           NULL        NULL
 1007  _int4         0         0             NULL           NULL        NULL
 1009  _text         0         1661428263    NULL           NULL        NULL
+1015  _varchar      0         1661428263    NULL           NULL        NULL
 1016  _int8         0         0             NULL           NULL        NULL
+1021  _float4       0         0             NULL           NULL        NULL
+1022  _float8       0         0             NULL           NULL        NULL
+1028  _oid          0         0             NULL           NULL        NULL
+1041  _inet         0         0             NULL           NULL        NULL
 1043  varchar       0         1661428263    NULL           NULL        NULL
 1082  date          0         0             NULL           NULL        NULL
 1114  timestamp     0         0             NULL           NULL        NULL
+1115  _timestamp    0         0             NULL           NULL        NULL
+1182  _date         0         0             NULL           NULL        NULL
 1184  timestamptz   0         0             NULL           NULL        NULL
+1185  _timestamptz  0         0             NULL           NULL        NULL
 1186  interval      0         0             NULL           NULL        NULL
+1187  _interval     0         0             NULL           NULL        NULL
+1231  _numeric      0         0             NULL           NULL        NULL
 1700  numeric       0         0             NULL           NULL        NULL
 2202  regprocedure  0         0             NULL           NULL        NULL
 2205  regclass      0         0             NULL           NULL        NULL
@@ -839,6 +908,7 @@ oid   typname       typndims  typcollation  typdefaultbin  typdefault  typacl
 2249  record        0         0             NULL           NULL        NULL
 2283  anyelement    0         0             NULL           NULL        NULL
 2950  uuid          0         0             NULL           NULL        NULL
+2951  _uuid         0         0             NULL           NULL        NULL
 4089  regnamespace  0         0             NULL           NULL        NULL
 
 ## pg_catalog.pg_proc

--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -163,18 +163,27 @@ var (
 var OidToType = map[oid.Oid]Type{
 	oid.T_anyelement:   TypeAny,
 	oid.T_bool:         TypeBool,
+	oid.T__bool:        TArray{TypeBool},
 	oid.T_bytea:        TypeBytes,
+	oid.T__bytea:       TArray{TypeBytes},
 	oid.T_date:         TypeDate,
+	oid.T__date:        TArray{TypeDate},
 	oid.T_float4:       typeFloat4,
+	oid.T__float4:      TArray{typeFloat4},
 	oid.T_float8:       TypeFloat,
+	oid.T__float8:      TArray{TypeFloat},
 	oid.T_int2:         typeInt2,
 	oid.T_int4:         typeInt4,
 	oid.T_int8:         TypeInt,
 	oid.T_int2vector:   TypeIntVector,
 	oid.T_interval:     TypeInterval,
+	oid.T__interval:    TArray{TypeInterval},
 	oid.T_name:         TypeName,
+	oid.T__name:        TArray{TypeName},
 	oid.T_numeric:      TypeDecimal,
+	oid.T__numeric:     TArray{TypeDecimal},
 	oid.T_oid:          TypeOid,
+	oid.T__oid:         TArray{TypeOid},
 	oid.T_regclass:     TypeRegClass,
 	oid.T_regnamespace: TypeRegNamespace,
 	oid.T_regproc:      TypeRegProc,
@@ -187,10 +196,15 @@ var OidToType = map[oid.Oid]Type{
 	oid.T_record:       TypeTuple,
 	oid.T_text:         TypeString,
 	oid.T_timestamp:    TypeTimestamp,
+	oid.T__timestamp:   TArray{TypeTimestamp},
 	oid.T_timestamptz:  TypeTimestampTZ,
+	oid.T__timestamptz: TArray{TypeTimestampTZ},
 	oid.T_uuid:         TypeUUID,
+	oid.T__uuid:        TArray{TypeUUID},
 	oid.T_inet:         TypeINet,
+	oid.T__inet:        TArray{TypeINet},
 	oid.T_varchar:      typeVarChar,
+	oid.T__varchar:     TArray{typeVarChar},
 }
 
 // AliasedOidToName maps Postgres object IDs to type names for those OIDs that map to
@@ -213,6 +227,21 @@ var aliasedOidToName = map[oid.Oid]string{
 	oid.T__int4:      "_int4",
 	oid.T__int8:      "_int8",
 	oid.T__text:      "_text",
+	// TODO(justin): find a better solution to this than mapping every array type.
+	oid.T__float4:      "_float4",
+	oid.T__float8:      "_float8",
+	oid.T__bool:        "_bool",
+	oid.T__bytea:       "_bytea",
+	oid.T__date:        "_date",
+	oid.T__interval:    "_interval",
+	oid.T__name:        "_name",
+	oid.T__numeric:     "_numeric",
+	oid.T__oid:         "_oid",
+	oid.T__timestamp:   "_timestamp",
+	oid.T__timestamptz: "_timestamptz",
+	oid.T__uuid:        "_uuid",
+	oid.T__inet:        "_inet",
+	oid.T__varchar:     "_varchar",
 }
 
 // PGDisplayName returns the Postgres display name for a given type.
@@ -542,11 +571,35 @@ func (TArray) Size() (uintptr, bool) {
 
 // oidToArrayOid maps scalar type Oids to their corresponding array type Oid.
 var oidToArrayOid = map[oid.Oid]oid.Oid{
-	oid.T_int2: oid.T__int2,
-	oid.T_int4: oid.T__int4,
-	oid.T_int8: oid.T__int8,
-	oid.T_text: oid.T__text,
-	oid.T_name: oid.T__name,
+	oid.T_bool:        oid.T__bool,
+	oid.T_bytea:       oid.T__bytea,
+	oid.T_name:        oid.T__name,
+	oid.T_int8:        oid.T__int8,
+	oid.T_int2:        oid.T__int2,
+	oid.T_int4:        oid.T__int4,
+	oid.T_text:        oid.T__text,
+	oid.T_oid:         oid.T__oid,
+	oid.T_float4:      oid.T__float4,
+	oid.T_float8:      oid.T__float8,
+	oid.T_inet:        oid.T__inet,
+	oid.T_varchar:     oid.T__varchar,
+	oid.T_date:        oid.T__date,
+	oid.T_timestamp:   oid.T__timestamp,
+	oid.T_timestamptz: oid.T__timestamptz,
+	oid.T_interval:    oid.T__interval,
+	oid.T_numeric:     oid.T__numeric,
+	oid.T_uuid:        oid.T__uuid,
+}
+
+const noArrayType = 0
+
+// ArrayOids is a set of all oids which correspond to an array type.
+var ArrayOids = map[oid.Oid]struct{}{}
+
+func init() {
+	for _, v := range oidToArrayOid {
+		ArrayOids[v] = struct{}{}
+	}
 }
 
 // Oid implements the Type interface.
@@ -554,7 +607,7 @@ func (a TArray) Oid() oid.Oid {
 	if o, ok := oidToArrayOid[a.Typ.Oid()]; ok {
 		return o
 	}
-	return oid.T_anyarray
+	return noArrayType
 }
 
 // SQLName implements the Type interface.

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1448,6 +1448,7 @@ CREATE TABLE pg_catalog.pg_type (
 		for o, typ := range parser.OidToType {
 			cat := typCategory(typ)
 			typElem := oidZero
+			typArray := oidZero
 			builtinPrefix := parser.PGIOBuiltinPrefix(typ)
 			if cat == typCategoryArray {
 				if typ == parser.TypeIntVector {
@@ -1462,6 +1463,8 @@ CREATE TABLE pg_catalog.pg_type (
 					builtinPrefix = "array_"
 					typElem = parser.NewDOid(parser.DInt(parser.UnwrapType(typ).(parser.TArray).Typ.Oid()))
 				}
+			} else {
+				typArray = parser.NewDOid(parser.DInt(parser.TArray{Typ: typ}.Oid()))
 			}
 			typname := parser.PGDisplayName(typ)
 
@@ -1479,7 +1482,7 @@ CREATE TABLE pg_catalog.pg_type (
 				typDelim,                // typdelim
 				oidZero,                 // typrelid
 				typElem,                 // typelem
-				oidZero,                 // typarray
+				typArray,                // typarray
 
 				// regproc references
 				h.RegProc(builtinPrefix+"in"),   // typinput

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -858,6 +858,18 @@ func TestPGPreparedQuery(t *testing.T) {
 		"SELECT $1::INET": {
 			baseTest.SetArgs("192.168.0.1/32").Results("192.168.0.1"),
 		},
+		"SELECT $1:::FLOAT[]": {
+			baseTest.SetArgs("{}").Results("{}"),
+			baseTest.SetArgs("{1.0,2.0,3.0}").Results("{1.0,2.0,3.0}"),
+		},
+		"SELECT $1:::DECIMAL[]": {
+			baseTest.SetArgs("{1.000}").Results("{1.000}"),
+		},
+		"SELECT $1:::STRING[]": {
+			baseTest.SetArgs(`{aaa}`).Results(`{"aaa"}`),
+			baseTest.SetArgs(`{"aaa"}`).Results(`{"aaa"}`),
+			baseTest.SetArgs(`{aaa,bbb,ccc}`).Results(`{"aaa","bbb","ccc"}`),
+		},
 
 		// TODO(jordan): blocked on #13651
 		//"SELECT $1::INT[]": {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -621,11 +621,6 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 				}
 			}
 			return out, nil
-		case oid.T_anyarray:
-			if err := validateStringBytes(b); err != nil {
-				return nil, err
-			}
-			return parser.NewDString(string(b)), nil
 		case oid.T__text, oid.T__name:
 			var arr pq.StringArray
 			if err := (&arr).Scan(b); err != nil {
@@ -645,6 +640,14 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 				}
 			}
 			return out, nil
+		}
+		if _, ok := parser.ArrayOids[id]; ok {
+			// Arrays come in in their string form, so we parse them as such and later
+			// convert them to their actual datum form.
+			if err := validateStringBytes(b); err != nil {
+				return nil, err
+			}
+			return parser.NewDString(string(b)), nil
 		}
 	case formatBinary:
 		switch id {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -621,6 +621,11 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 				}
 			}
 			return out, nil
+		case oid.T_anyarray:
+			if err := validateStringBytes(b); err != nil {
+				return nil, err
+			}
+			return parser.NewDString(string(b)), nil
 		case oid.T__text, oid.T__name:
 			var arr pq.StringArray
 			if err := (&arr).Scan(b); err != nil {


### PR DESCRIPTION
Fixes #19251.

I messed and neglected to test drivers exhaustively interacting with arrays.

These two commits fix use of arrays with jdbc, node-postgres, and lib/pq.

I think these, alongside the string->array parsing commit should be cherry-picked for 1.1.1 or 1.1.2.