### PR TITLE
server: allow more than one lease in TestRange[s]Response

### DIFF
--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -446,8 +446,8 @@ func TestRangesResponse(t *testing.T) {
 		if ri.State.LastIndex == 0 {
 			t.Error("expected positive LastIndex")
 		}
-		if e, a := 1, len(ri.LeaseHistory); e != a {
-			t.Errorf("expected a lease history length of %d, actual %d\n%+v", e, a, ri)
+		if len(ri.LeaseHistory) == 0 {
+			t.Error("expected at least one lease history entry")
 		}
 	}
 }
@@ -707,7 +707,7 @@ func TestRangeResponse(t *testing.T) {
 		t.Error("expected positive LastIndex")
 	}
 
-	if e, a := 1, len(info.LeaseHistory); e != a {
-		t.Errorf("expected a lease history length of %d, actual %d\n%+v", e, a, info)
+	if len(info.LeaseHistory) == 0 {
+		t.Error("expected at least one lease history entry")
 	}
 }


### PR DESCRIPTION
If the server is slow to boot, leases might be renewed and generate additional history entries. Loosen the assertion of the number of history entries in TestRangeResponse and TestRangesResponse from "exactly one history entry" to "at least one history entry."

From Slack:

> `TestRangeResponse` has gotten super flaky since the switch to Digital Ocean. Soliciting ideas as to why. https://teamcity.cockroachdb.com/project.html?projectId=Cockroach_UnitTests&testNameId=8602514234779675364&tab=testDetails
>
> So, the test is expecting one lease, but there are two:
>```
>LeaseHistory:[
>    repl=(n1,s1):1 start=0.000000000,0 exp=1508082713.438572783,0 pro=1508082704.438676184,0
>    repl=(n1,s1):1 start=0.000000000,0 exp=1508082718.218974280,0 pro=1508082709.219027001,0
>  ]```
>
> ...is it possible that DO is just _slower_ and therefore the lease is extended once before the assertion is made?

Injecting a `test.Sleep(5 * time.Second)` into `TestRangeResponse` after booting the server generates exactly the same failure as on our new Digital Ocean build agents, so the theory is confirmed. Whether this is expected behavior is out of my depth, but seems reasonable that a lease renewal would add a new history entry.

Fixes #19264.
Fixes #19258.