### PR TITLE
storage: prevent DisableOnePhaseCommit from wedging a cluster

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -196,7 +196,7 @@ func TestAsOfRetry(t *testing.T) {
 
 	params, cmdFilters := createTestServerParams()
 	// Disable one phase commits because they cannot be restarted.
-	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
+	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOptional1PC = true
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -446,7 +446,7 @@ func TestTxnAutoRetry(t *testing.T) {
 	params, cmdFilters := createTestServerParams()
 	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	// Disable one phase commits because they cannot be restarted.
-	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
+	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOptional1PC = true
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 	{
@@ -610,7 +610,7 @@ func TestTxnAutoRetryParallelStmts(t *testing.T) {
 
 	params, cmdFilters := createTestServerParams()
 	// Disable one phase commits because they cannot be restarted.
-	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
+	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOptional1PC = true
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 	sqlDB.SetMaxOpenConns(1)
@@ -752,7 +752,7 @@ func TestAbortedTxnOnlyRetriedOnce(t *testing.T) {
 	params, _ := createTestServerParams()
 	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	// Disable one phase commits because they cannot be restarted.
-	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOnePhaseCommits = true
+	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOptional1PC = true
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 	{

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -385,7 +385,7 @@ func TestIsOnePhaseCommit(t *testing.T) {
 				ba.Txn.Isolation = enginepb.SERIALIZABLE
 			}
 		}
-		if is1PC := isOnePhaseCommit(ba); is1PC != c.exp1PC {
+		if is1PC := isOnePhaseCommit(ba, &StoreTestingKnobs{}); is1PC != c.exp1PC {
 			t.Errorf("%d: expected 1pc=%t; got %t", i, c.exp1PC, is1PC)
 		}
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -679,8 +679,11 @@ type StoreTestingKnobs struct {
 	// If non-nil, BadChecksumReportDiff is called by CheckConsistency() on a
 	// checksum mismatch to report the diff between snapshots.
 	BadChecksumReportDiff func(roachpb.StoreIdent, []ReplicaSnapshotDiff)
-	// Disables the use of one phase commits.
-	DisableOnePhaseCommits bool
+	// Disables the use of optional one phase commits. Even when enabled, requests
+	// that set the Require1PC flag are permitted to use one phase commits. This
+	// prevents wedging node liveness, which requires one phase commits during
+	// liveness updates.
+	DisableOptional1PC bool
 	// A hack to manipulate the clock before sending a batch request to a replica.
 	// TODO(kaneda): This hook is not encouraged to use. Get rid of it once
 	// we make TestServer take a ManualClock.


### PR DESCRIPTION
If one phase commit is disabled, node liveness is unable to update any
livenesses. This effectively halts all transactions from proceeding once
the epoch-based lease system is bootstrapped. Since TestAsOfRetry
disables one phase commit, if it's run with a slow enough race detector,
epoch-based leases will be up and running before it completes and it
will hang forever.

Prevent the DisableOnePhaseCommit testing knob from applying to
BatchRequests that set the Require1PC flag, like node liveness. Tests
that use the knob still get the desired effect of preventing one phase
commits on the BatchRequests they generate, as those obviously do not
set the Require1PC flag.