### PR TITLE
cherry-pick 1.1: handle arrays in pgwire properly

### DIFF
--- a/pkg/acceptance/node_test.go
+++ b/pkg/acceptance/node_test.go
@@ -84,19 +84,6 @@ function testSendInvalidUTF8(client) {
   });
 }
 
-function testSendNotEnoughParams(client) {
-  return new Promise(resolve => {
-    client.query({
-      text: 'SELECT 3',
-      values: ['foo']
-    }, function (err, results) {
-      let validationError = isError(err, /expected 0 arguments, got 1/, '08P01');
-      if (validationError) throw validationError;
-      resolve();
-    });
-  });
-}
-
 function testInsertArray(client) {
   return new Promise(resolve => {
     client.query({
@@ -132,7 +119,6 @@ client.connect(function (err) {
 
   runTests(client,
     testSendInvalidUTF8,
-    testSendNotEnoughParams,
     testInsertArray,
     testSelect
   ).then(result => {

--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -435,7 +435,7 @@ func convertRecord(
 	}
 
 	parse := parser.Parser{}
-	evalCtx := parser.EvalContext{}
+	evalCtx := parser.EvalContext{Location: &time.UTC}
 	// Although we don't yet support DEFAULT expressions on visible columns,
 	// we do on hidden columns (which is only the default _rowid one). This
 	// allows those expressions to run.
@@ -451,7 +451,7 @@ func convertRecord(
 			if nullif != nil && r == *nullif {
 				datums[i] = parser.DNull
 			} else {
-				datums[i], err = parser.ParseStringAs(visibleCols[i].Type.ToDatumType(), r, time.UTC)
+				datums[i], err = parser.ParseStringAs(visibleCols[i].Type.ToDatumType(), r, &evalCtx)
 				if err != nil {
 					return errors.Wrapf(err, "%s: row %d: parse %q as %s", record.file, record.row, visibleCols[i].Name, visibleCols[i].Type.SQLString())
 				}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -194,7 +194,8 @@ func (n *copyNode) addRow(ctx context.Context, line []byte) error {
 				return err
 			}
 		}
-		d, err := parser.ParseStringAs(n.resultColumns[i].Typ, s, n.session.Location)
+		evalCtx := n.session.evalCtx()
+		d, err := parser.ParseStringAs(n.resultColumns[i].Typ, s, &evalCtx)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -91,6 +91,33 @@ SELECT ARRAY[]:::int[]
 ----
 {}
 
+# casting strings to arrays
+
+query T
+SELECT '{1,2,3}'::INT[]
+----
+{1,2,3}
+
+query T
+SELECT '{hello,"hello"}'::STRING[]
+----
+{"hello","hello"}
+
+query T
+SELECT e'{he\\\\llo}'::STRING[]
+----
+{"he\\llo"}
+
+query T
+SELECT '{"abc\nxyz"}'::STRING[]
+----
+{"abcnxyz"}
+
+query T
+SELECT '{hello}'::VARCHAR(2)[]
+----
+{"he"}
+
 # array subscript access
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -665,15 +665,27 @@ oid   typname       typnamespace  typowner  typlen  typbyval  typtype
 26    oid           1782195457    NULL      8       true      b
 700   float4        1782195457    NULL      8       true      b
 701   float8        1782195457    NULL      8       true      b
+1000  _bool         1782195457    NULL      -1      false     b
+1001  _bytea        1782195457    NULL      -1      false     b
+1003  _name         1782195457    NULL      -1      false     b
 1005  _int2         1782195457    NULL      -1      false     b
 1007  _int4         1782195457    NULL      -1      false     b
 1009  _text         1782195457    NULL      -1      false     b
+1015  _varchar      1782195457    NULL      -1      false     b
 1016  _int8         1782195457    NULL      -1      false     b
+1021  _float4       1782195457    NULL      -1      false     b
+1022  _float8       1782195457    NULL      -1      false     b
+1028  _oid          1782195457    NULL      -1      false     b
 1043  varchar       1782195457    NULL      -1      false     b
 1082  date          1782195457    NULL      8       true      b
 1114  timestamp     1782195457    NULL      24      true      b
+1115  _timestamp    1782195457    NULL      -1      false     b
+1182  _date         1782195457    NULL      -1      false     b
 1184  timestamptz   1782195457    NULL      24      true      b
+1185  _timestamptz  1782195457    NULL      -1      false     b
 1186  interval      1782195457    NULL      24      true      b
+1187  _interval     1782195457    NULL      -1      false     b
+1231  _numeric      1782195457    NULL      -1      false     b
 1700  numeric       1782195457    NULL      -1      false     b
 2202  regprocedure  1782195457    NULL      8       true      b
 2205  regclass      1782195457    NULL      8       true      b
@@ -681,6 +693,7 @@ oid   typname       typnamespace  typowner  typlen  typbyval  typtype
 2249  record        1782195457    NULL      0       true      b
 2283  anyelement    1782195457    NULL      -1      false     b
 2950  uuid          1782195457    NULL      16      true      b
+2951  _uuid         1782195457    NULL      -1      false     b
 4089  regnamespace  1782195457    NULL      8       true      b
 
 query OTTBBTOOO colnames
@@ -689,34 +702,47 @@ FROM pg_catalog.pg_type
 ORDER BY oid
 ----
 oid   typname       typcategory  typispreferred  typisdefined  typdelim  typrelid  typelem  typarray
-16    bool          B            false           true          ,         0         0        0
-17    bytea         U            false           true          ,         0         0        0
-19    name          S            false           true          ,         0         0        0
-20    int8          N            false           true          ,         0         0        0
-21    int2          N            false           true          ,         0         0        0
+16    bool          B            false           true          ,         0         0        1000
+17    bytea         U            false           true          ,         0         0        1001
+19    name          S            false           true          ,         0         0        1003
+20    int8          N            false           true          ,         0         0        1016
+21    int2          N            false           true          ,         0         0        1005
 22    int2vector    A            false           true          ,         0         21       0
-23    int4          N            false           true          ,         0         0        0
+23    int4          N            false           true          ,         0         0        1007
 24    regproc       N            false           true          ,         0         0        0
-25    text          S            false           true          ,         0         0        0
-26    oid           N            false           true          ,         0         0        0
-700   float4        N            false           true          ,         0         0        0
-701   float8        N            false           true          ,         0         0        0
+25    text          S            false           true          ,         0         0        1009
+26    oid           N            false           true          ,         0         0        1028
+700   float4        N            false           true          ,         0         0        1021
+701   float8        N            false           true          ,         0         0        1022
+1000  _bool         A            false           true          ,         0         16       0
+1001  _bytea        A            false           true          ,         0         17       0
+1003  _name         A            false           true          ,         0         19       0
 1005  _int2         A            false           true          ,         0         21       0
 1007  _int4         A            false           true          ,         0         23       0
 1009  _text         A            false           true          ,         0         25       0
+1015  _varchar      A            false           true          ,         0         1043     0
 1016  _int8         A            false           true          ,         0         20       0
-1043  varchar       S            false           true          ,         0         0        0
-1082  date          D            false           true          ,         0         0        0
-1114  timestamp     D            false           true          ,         0         0        0
-1184  timestamptz   D            false           true          ,         0         0        0
-1186  interval      T            false           true          ,         0         0        0
-1700  numeric       N            false           true          ,         0         0        0
+1021  _float4       A            false           true          ,         0         700      0
+1022  _float8       A            false           true          ,         0         701      0
+1028  _oid          A            false           true          ,         0         26       0
+1043  varchar       S            false           true          ,         0         0        1015
+1082  date          D            false           true          ,         0         0        1182
+1114  timestamp     D            false           true          ,         0         0        1115
+1115  _timestamp    A            false           true          ,         0         1114     0
+1182  _date         A            false           true          ,         0         1082     0
+1184  timestamptz   D            false           true          ,         0         0        1185
+1185  _timestamptz  A            false           true          ,         0         1184     0
+1186  interval      T            false           true          ,         0         0        1187
+1187  _interval     A            false           true          ,         0         1186     0
+1231  _numeric      A            false           true          ,         0         1700     0
+1700  numeric       N            false           true          ,         0         0        1231
 2202  regprocedure  N            false           true          ,         0         0        0
 2205  regclass      N            false           true          ,         0         0        0
 2206  regtype       N            false           true          ,         0         0        0
 2249  record        P            false           true          ,         0         0        0
 2283  anyelement    P            false           true          ,         0         0        0
-2950  uuid          U            false           true          ,         0         0        0
+2950  uuid          U            false           true          ,         0         0        2951
+2951  _uuid         A            false           true          ,         0         2950     0
 4089  regnamespace  N            false           true          ,         0         0        0
 
 query OTOOOOOOO colnames
@@ -737,15 +763,27 @@ oid   typname       typinput        typoutput        typreceive        typsend  
 26    oid           oidin           oidout           oidrecv           oidsend           0         0          0
 700   float4        float4in        float4out        float4recv        float4send        0         0          0
 701   float8        float8in        float8out        float8recv        float8send        0         0          0
+1000  _bool         array_in        array_out        array_recv        array_send        0         0          0
+1001  _bytea        array_in        array_out        array_recv        array_send        0         0          0
+1003  _name         array_in        array_out        array_recv        array_send        0         0          0
 1005  _int2         array_in        array_out        array_recv        array_send        0         0          0
 1007  _int4         array_in        array_out        array_recv        array_send        0         0          0
 1009  _text         array_in        array_out        array_recv        array_send        0         0          0
+1015  _varchar      array_in        array_out        array_recv        array_send        0         0          0
 1016  _int8         array_in        array_out        array_recv        array_send        0         0          0
+1021  _float4       array_in        array_out        array_recv        array_send        0         0          0
+1022  _float8       array_in        array_out        array_recv        array_send        0         0          0
+1028  _oid          array_in        array_out        array_recv        array_send        0         0          0
 1043  varchar       varcharin       varcharout       varcharrecv       varcharsend       0         0          0
 1082  date          date_in         date_out         date_recv         date_send         0         0          0
 1114  timestamp     timestamp_in    timestamp_out    timestamp_recv    timestamp_send    0         0          0
+1115  _timestamp    array_in        array_out        array_recv        array_send        0         0          0
+1182  _date         array_in        array_out        array_recv        array_send        0         0          0
 1184  timestamptz   timestamptz_in  timestamptz_out  timestamptz_recv  timestamptz_send  0         0          0
+1185  _timestamptz  array_in        array_out        array_recv        array_send        0         0          0
 1186  interval      interval_in     interval_out     interval_recv     interval_send     0         0          0
+1187  _interval     array_in        array_out        array_recv        array_send        0         0          0
+1231  _numeric      array_in        array_out        array_recv        array_send        0         0          0
 1700  numeric       numeric_in      numeric_out      numeric_recv      numeric_send      0         0          0
 2202  regprocedure  regprocedurein  regprocedureout  regprocedurerecv  regproceduresend  0         0          0
 2205  regclass      regclassin      regclassout      regclassrecv      regclasssend      0         0          0
@@ -753,6 +791,7 @@ oid   typname       typinput        typoutput        typreceive        typsend  
 2249  record        record_in       record_out       record_recv       record_send       0         0          0
 2283  anyelement    anyelement_in   anyelement_out   anyelement_recv   anyelement_send   0         0          0
 2950  uuid          uuid_in         uuid_out         uuid_recv         uuid_send         0         0          0
+2951  _uuid         array_in        array_out        array_recv        array_send        0         0          0
 4089  regnamespace  regnamespacein  regnamespaceout  regnamespacerecv  regnamespacesend  0         0          0
 
 query OTTTBOI colnames
@@ -773,15 +812,27 @@ oid   typname       typalign  typstorage  typnotnull  typbasetype  typtypmod
 26    oid           NULL      NULL        false       0            -1
 700   float4        NULL      NULL        false       0            -1
 701   float8        NULL      NULL        false       0            -1
+1000  _bool         NULL      NULL        false       0            -1
+1001  _bytea        NULL      NULL        false       0            -1
+1003  _name         NULL      NULL        false       0            -1
 1005  _int2         NULL      NULL        false       0            -1
 1007  _int4         NULL      NULL        false       0            -1
 1009  _text         NULL      NULL        false       0            -1
+1015  _varchar      NULL      NULL        false       0            -1
 1016  _int8         NULL      NULL        false       0            -1
+1021  _float4       NULL      NULL        false       0            -1
+1022  _float8       NULL      NULL        false       0            -1
+1028  _oid          NULL      NULL        false       0            -1
 1043  varchar       NULL      NULL        false       0            -1
 1082  date          NULL      NULL        false       0            -1
 1114  timestamp     NULL      NULL        false       0            -1
+1115  _timestamp    NULL      NULL        false       0            -1
+1182  _date         NULL      NULL        false       0            -1
 1184  timestamptz   NULL      NULL        false       0            -1
+1185  _timestamptz  NULL      NULL        false       0            -1
 1186  interval      NULL      NULL        false       0            -1
+1187  _interval     NULL      NULL        false       0            -1
+1231  _numeric      NULL      NULL        false       0            -1
 1700  numeric       NULL      NULL        false       0            -1
 2202  regprocedure  NULL      NULL        false       0            -1
 2205  regclass      NULL      NULL        false       0            -1
@@ -789,6 +840,7 @@ oid   typname       typalign  typstorage  typnotnull  typbasetype  typtypmod
 2249  record        NULL      NULL        false       0            -1
 2283  anyelement    NULL      NULL        false       0            -1
 2950  uuid          NULL      NULL        false       0            -1
+2951  _uuid         NULL      NULL        false       0            -1
 4089  regnamespace  NULL      NULL        false       0            -1
 
 query OTIOTTT colnames
@@ -809,15 +861,27 @@ oid   typname       typndims  typcollation  typdefaultbin  typdefault  typacl
 26    oid           0         0             NULL           NULL        NULL
 700   float4        0         0             NULL           NULL        NULL
 701   float8        0         0             NULL           NULL        NULL
+1000  _bool         0         0             NULL           NULL        NULL
+1001  _bytea        0         0             NULL           NULL        NULL
+1003  _name         0         1661428263    NULL           NULL        NULL
 1005  _int2         0         0             NULL           NULL        NULL
 1007  _int4         0         0             NULL           NULL        NULL
 1009  _text         0         1661428263    NULL           NULL        NULL
+1015  _varchar      0         1661428263    NULL           NULL        NULL
 1016  _int8         0         0             NULL           NULL        NULL
+1021  _float4       0         0             NULL           NULL        NULL
+1022  _float8       0         0             NULL           NULL        NULL
+1028  _oid          0         0             NULL           NULL        NULL
 1043  varchar       0         1661428263    NULL           NULL        NULL
 1082  date          0         0             NULL           NULL        NULL
 1114  timestamp     0         0             NULL           NULL        NULL
+1115  _timestamp    0         0             NULL           NULL        NULL
+1182  _date         0         0             NULL           NULL        NULL
 1184  timestamptz   0         0             NULL           NULL        NULL
+1185  _timestamptz  0         0             NULL           NULL        NULL
 1186  interval      0         0             NULL           NULL        NULL
+1187  _interval     0         0             NULL           NULL        NULL
+1231  _numeric      0         0             NULL           NULL        NULL
 1700  numeric       0         0             NULL           NULL        NULL
 2202  regprocedure  0         0             NULL           NULL        NULL
 2205  regclass      0         0             NULL           NULL        NULL
@@ -825,6 +889,7 @@ oid   typname       typndims  typcollation  typdefaultbin  typdefault  typacl
 2249  record        0         0             NULL           NULL        NULL
 2283  anyelement    0         0             NULL           NULL        NULL
 2950  uuid          0         0             NULL           NULL        NULL
+2951  _uuid         0         0             NULL           NULL        NULL
 4089  regnamespace  0         0             NULL           NULL        NULL
 
 ## pg_catalog.pg_proc

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -1085,6 +1085,7 @@ var (
 	intervalCastTypes  = []Type{TypeNull, TypeString, TypeCollatedString, TypeInt, TypeInterval}
 	oidCastTypes       = []Type{TypeNull, TypeString, TypeCollatedString, TypeInt, TypeOid}
 	uuidCastTypes      = []Type{TypeNull, TypeString, TypeCollatedString, TypeBytes, TypeUUID}
+	arrayCastTypes     = []Type{TypeNull, TypeString}
 )
 
 // validCastTypes returns a set of types that can be cast into the provided type.
@@ -1118,7 +1119,7 @@ func validCastTypes(t Type) []Type {
 		if t.FamilyEqual(TypeCollatedString) {
 			return stringCastTypes
 		} else if t.FamilyEqual(TypeArray) {
-			return []Type{TypeNull}
+			return arrayCastTypes
 		}
 		return nil
 	}

--- a/pkg/sql/parser/parse_array.go
+++ b/pkg/sql/parser/parse_array.go
@@ -1,0 +1,189 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import (
+	"bytes"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+)
+
+var enclosingError = pgerror.NewErrorf(pgerror.CodeInvalidTextRepresentationError, "array must be enclosed in { and }")
+var extraTextError = pgerror.NewErrorf(pgerror.CodeInvalidTextRepresentationError, "extra text after closing right brace")
+var nestedArraysNotSupportedError = pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "nested arrays not supported")
+var malformedError = pgerror.NewErrorf(pgerror.CodeInvalidTextRepresentationError, "malformed array")
+
+var isQuoteChar = func(ch byte) bool {
+	return ch == '"'
+}
+
+var isControlChar = func(ch byte) bool {
+	return ch == '{' || ch == '}' || ch == ',' || ch == '"'
+}
+
+var isElementChar = func(r rune) bool {
+	return r != '{' && r != '}' && r != ','
+}
+
+// gobbleString advances the parser for the remainder of the current string
+// until it sees a non-escaped termination character, as specified by
+// isTerminatingChar, returning the resulting string, not including the
+// termination character.
+func (p *parseState) gobbleString(isTerminatingChar func(ch byte) bool) (out string, err error) {
+	var result bytes.Buffer
+	start := 0
+	i := 0
+	for i < len(p.s) && !isTerminatingChar(p.s[i]) {
+		i++
+		// In these strings, we just encode directly the character following a
+		// '\', even if it would normally be an escape sequence.
+		if i < len(p.s) && p.s[i] == '\\' {
+			result.WriteString(p.s[start:i])
+			i++
+			if i < len(p.s) {
+				result.WriteByte(p.s[i])
+				i++
+			}
+			start = i
+		}
+	}
+	if i >= len(p.s) {
+		return "", malformedError
+	}
+	result.WriteString(p.s[start:i])
+	p.s = p.s[i:]
+	return result.String(), nil
+}
+
+type parseState struct {
+	s       string
+	evalCtx *EvalContext
+	result  *DArray
+	t       ColumnType
+}
+
+func (p *parseState) advance() {
+	_, l := utf8.DecodeRuneInString(p.s)
+	p.s = p.s[l:]
+}
+
+func (p *parseState) eatWhitespace() {
+	for unicode.IsSpace(p.peek()) {
+		p.advance()
+	}
+}
+
+func (p *parseState) peek() rune {
+	r, _ := utf8.DecodeRuneInString(p.s)
+	return r
+}
+
+func (p *parseState) eof() bool {
+	return len(p.s) == 0
+}
+
+func (p *parseState) parseQuotedString() (string, error) {
+	return p.gobbleString(isQuoteChar)
+}
+
+func (p *parseState) parseUnquotedString() (string, error) {
+	out, err := p.gobbleString(isControlChar)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func (p *parseState) parseElement() error {
+	var next string
+	var err error
+	r := p.peek()
+	switch r {
+	case '{':
+		return nestedArraysNotSupportedError
+	case '"':
+		p.advance()
+		next, err = p.parseQuotedString()
+		if err != nil {
+			return err
+		}
+		p.advance()
+	default:
+		if !isElementChar(r) {
+			return malformedError
+		}
+		next, err = p.parseUnquotedString()
+		if err != nil {
+			return err
+		}
+		if strings.EqualFold(next, "null") {
+			return p.result.Append(DNull)
+		}
+	}
+
+	d, err := performCast(p.evalCtx, NewDString(next), p.t)
+	if err != nil {
+		return err
+	}
+	return p.result.Append(d)
+}
+
+// ParseDArrayFromString parses the string-form of constructing arrays, handling
+// cases such as `'{1,2,3}'::INT[]`.
+func ParseDArrayFromString(evalCtx *EvalContext, s string, t ColumnType) (*DArray, error) {
+	parser := parseState{
+		s:       s,
+		evalCtx: evalCtx,
+		result:  NewDArray(CastTargetToDatumType(t)),
+		t:       t,
+	}
+
+	parser.eatWhitespace()
+	if parser.peek() != '{' {
+		return nil, enclosingError
+	}
+	parser.advance()
+	parser.eatWhitespace()
+	if parser.peek() != '}' {
+		if err := parser.parseElement(); err != nil {
+			return nil, err
+		}
+		parser.eatWhitespace()
+		for parser.peek() == ',' {
+			parser.advance()
+			parser.eatWhitespace()
+			if err := parser.parseElement(); err != nil {
+				return nil, err
+			}
+		}
+	}
+	parser.eatWhitespace()
+	if parser.eof() {
+		return nil, enclosingError
+	}
+	if parser.peek() != '}' {
+		return nil, malformedError
+	}
+	parser.advance()
+	parser.eatWhitespace()
+	if !parser.eof() {
+		return nil, extraTextError
+	}
+
+	return parser.result, nil
+}

--- a/pkg/sql/parser/parse_array_test.go
+++ b/pkg/sql/parser/parse_array_test.go
@@ -1,0 +1,120 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import "testing"
+
+func TestParseArray(t *testing.T) {
+	testData := []struct {
+		str      string
+		typ      ColumnType
+		expected Datums
+	}{
+		{`{}`, intColTypeInt, Datums{}},
+		{`{1}`, intColTypeInt, Datums{NewDInt(1)}},
+		{`{1,2}`, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
+		{`   { 1    ,  2  }  `, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
+		{`   { 1    ,
+			"2"  }  `, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
+		{`{1,2,3}`, intColTypeInt, Datums{NewDInt(1), NewDInt(2), NewDInt(3)}},
+		{`{"1"}`, intColTypeInt, Datums{NewDInt(1)}},
+		{` { "1" , "2"}`, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
+		{` { "1" , 2}`, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
+		{`{1,NULL}`, intColTypeInt, Datums{NewDInt(1), DNull}},
+
+		{`{hello}`, stringColTypeString, Datums{NewDString("hello")}},
+		{`{hel
+lo}`, stringColTypeString, Datums{NewDString("hel\nlo")}},
+		{`{hel,
+lo}`, stringColTypeString, Datums{NewDString("hel"), NewDString("lo")}},
+		{`{hel,lo}`, stringColTypeString, Datums{NewDString("hel"), NewDString("lo")}},
+		{`{  he llo  }`, stringColTypeString, Datums{NewDString("he llo")}},
+		{"{hello,\u1680world}", stringColTypeString, Datums{NewDString("hello"), NewDString("world")}},
+		{`{hell\\o}`, stringColTypeString, Datums{NewDString("hell\\o")}},
+		{`{"hell\\o"}`, stringColTypeString, Datums{NewDString("hell\\o")}},
+		{`{NULL,"NULL"}`, stringColTypeString, Datums{DNull, NewDString("NULL")}},
+		{`{"hello"}`, stringColTypeString, Datums{NewDString("hello")}},
+		{`{" hello "}`, stringColTypeString, Datums{NewDString(" hello ")}},
+		{`{"hel,lo"}`, stringColTypeString, Datums{NewDString("hel,lo")}},
+		{`{"hel\"lo"}`, stringColTypeString, Datums{NewDString("hel\"lo")}},
+		{`{"h\"el\"lo"}`, stringColTypeString, Datums{NewDString("h\"el\"lo")}},
+		{`{"hel\nlo"}`, stringColTypeString, Datums{NewDString("helnlo")}},
+		{`{"hel\\lo"}`, stringColTypeString, Datums{NewDString("hel\\lo")}},
+		{`{"he\,l\}l\{o"}`, stringColTypeString, Datums{NewDString("he,l}l{o")}},
+
+		{`{日本語}`, stringColTypeString, Datums{NewDString("日本語")}},
+
+		// This can generate some strings with invalid UTF-8, but this isn't a
+		// problem, since the input would have had to be invalid UTF-8 for that to
+		// occur.
+		{string([]byte{'{', 'a', 200, '}'}), stringColTypeString, Datums{NewDString("a\xc8")}},
+		{string([]byte{'{', 'a', 200, 'a', '}'}), stringColTypeString, Datums{NewDString("a\xc8a")}},
+	}
+	for _, td := range testData {
+		t.Run(td.str, func(t *testing.T) {
+			expected := NewDArray(CastTargetToDatumType(td.typ))
+			for _, d := range td.expected {
+				if err := expected.Append(d); err != nil {
+					t.Fatal(err)
+				}
+			}
+			actual, err := ParseDArrayFromString(NewTestingEvalContext(), td.str, td.typ)
+			if err != nil {
+				t.Fatalf("ARRAY %s: got error %s, expected %s", td.str, err.Error(), expected)
+			}
+			if actual.Compare(NewTestingEvalContext(), expected) != 0 {
+				t.Fatalf("ARRAY %s: got %s, expected %s", td.str, actual, expected)
+			}
+		})
+	}
+}
+
+func TestParseArrayError(t *testing.T) {
+	testData := []struct {
+		str           string
+		typ           ColumnType
+		expectedError string
+	}{
+		{"", intColTypeInt, "array must be enclosed in { and }"},
+		{"1", intColTypeInt, "array must be enclosed in { and }"},
+		{"1,2", intColTypeInt, "array must be enclosed in { and }"},
+		{"{1,2", intColTypeInt, "malformed array"},
+		{"{1,2,", intColTypeInt, "malformed array"},
+		{"{", intColTypeInt, "malformed array"},
+		{"{,}", intColTypeInt, "malformed array"},
+		{"{}{}", intColTypeInt, "extra text after closing right brace"},
+		{"{} {}", intColTypeInt, "extra text after closing right brace"},
+		{"{{}}", intColTypeInt, "nested arrays not supported"},
+		{"{1, {1}}", intColTypeInt, "nested arrays not supported"},
+		{"{hello}", intColTypeInt, `could not parse "hello" as type int: strconv.ParseInt: parsing "hello": invalid syntax`},
+		{"{\"hello}", stringColTypeString, `malformed array`},
+		// It might be unnecessary to disallow this, but Postgres does.
+		{"{he\"lo}", stringColTypeString, "malformed array"},
+
+		{string([]byte{200}), stringColTypeString, "array must be enclosed in { and }"},
+		{string([]byte{'{', 'a', 200}), stringColTypeString, "malformed array"},
+	}
+	for _, td := range testData {
+		t.Run(td.str, func(t *testing.T) {
+			_, err := ParseDArrayFromString(NewTestingEvalContext(), td.str, td.typ)
+			if err == nil {
+				t.Fatalf("expected %#v to error with message %#v", td.str, td.expectedError)
+			}
+			if err.Error() != td.expectedError {
+				t.Fatalf("ARRAY %s: got error %s, expected error %s", td.str, err.Error(), td.expectedError)
+			}
+		})
+	}
+}

--- a/pkg/sql/parser/type.go
+++ b/pkg/sql/parser/type.go
@@ -160,18 +160,27 @@ var (
 var OidToType = map[oid.Oid]Type{
 	oid.T_anyelement:   TypeAny,
 	oid.T_bool:         TypeBool,
+	oid.T__bool:        TArray{TypeBool},
 	oid.T_bytea:        TypeBytes,
+	oid.T__bytea:       TArray{TypeBytes},
 	oid.T_date:         TypeDate,
+	oid.T__date:        TArray{TypeDate},
 	oid.T_float4:       typeFloat4,
+	oid.T__float4:      TArray{typeFloat4},
 	oid.T_float8:       TypeFloat,
+	oid.T__float8:      TArray{TypeFloat},
 	oid.T_int2:         typeInt2,
 	oid.T_int4:         typeInt4,
 	oid.T_int8:         TypeInt,
 	oid.T_int2vector:   TypeIntVector,
 	oid.T_interval:     TypeInterval,
+	oid.T__interval:    TArray{TypeInterval},
 	oid.T_name:         TypeName,
+	oid.T__name:        TArray{TypeName},
 	oid.T_numeric:      TypeDecimal,
+	oid.T__numeric:     TArray{TypeDecimal},
 	oid.T_oid:          TypeOid,
+	oid.T__oid:         TArray{TypeOid},
 	oid.T_regclass:     TypeRegClass,
 	oid.T_regnamespace: TypeRegNamespace,
 	oid.T_regproc:      TypeRegProc,
@@ -184,9 +193,13 @@ var OidToType = map[oid.Oid]Type{
 	oid.T_record:       TypeTuple,
 	oid.T_text:         TypeString,
 	oid.T_timestamp:    TypeTimestamp,
+	oid.T__timestamp:   TArray{TypeTimestamp},
 	oid.T_timestamptz:  TypeTimestampTZ,
+	oid.T__timestamptz: TArray{TypeTimestampTZ},
 	oid.T_uuid:         TypeUUID,
+	oid.T__uuid:        TArray{TypeUUID},
 	oid.T_varchar:      typeVarChar,
+	oid.T__varchar:     TArray{typeVarChar},
 }
 
 // AliasedOidToName maps Postgres object IDs to type names for those OIDs that map to
@@ -209,6 +222,21 @@ var aliasedOidToName = map[oid.Oid]string{
 	oid.T__int4:      "_int4",
 	oid.T__int8:      "_int8",
 	oid.T__text:      "_text",
+	// TODO(justin): find a better solution to this than mapping every array type.
+	oid.T__float4:      "_float4",
+	oid.T__float8:      "_float8",
+	oid.T__bool:        "_bool",
+	oid.T__bytea:       "_bytea",
+	oid.T__date:        "_date",
+	oid.T__interval:    "_interval",
+	oid.T__name:        "_name",
+	oid.T__numeric:     "_numeric",
+	oid.T__oid:         "_oid",
+	oid.T__timestamp:   "_timestamp",
+	oid.T__timestamptz: "_timestamptz",
+	oid.T__uuid:        "_uuid",
+	oid.T__inet:        "_inet",
+	oid.T__varchar:     "_varchar",
 }
 
 // PGDisplayName returns the Postgres display name for a given type.
@@ -528,11 +556,34 @@ func (TArray) Size() (uintptr, bool) {
 
 // oidToArrayOid maps scalar type Oids to their corresponding array type Oid.
 var oidToArrayOid = map[oid.Oid]oid.Oid{
-	oid.T_int2: oid.T__int2,
-	oid.T_int4: oid.T__int4,
-	oid.T_int8: oid.T__int8,
-	oid.T_text: oid.T__text,
-	oid.T_name: oid.T__name,
+	oid.T_bool:        oid.T__bool,
+	oid.T_bytea:       oid.T__bytea,
+	oid.T_name:        oid.T__name,
+	oid.T_int8:        oid.T__int8,
+	oid.T_int2:        oid.T__int2,
+	oid.T_int4:        oid.T__int4,
+	oid.T_text:        oid.T__text,
+	oid.T_oid:         oid.T__oid,
+	oid.T_float4:      oid.T__float4,
+	oid.T_float8:      oid.T__float8,
+	oid.T_varchar:     oid.T__varchar,
+	oid.T_date:        oid.T__date,
+	oid.T_timestamp:   oid.T__timestamp,
+	oid.T_timestamptz: oid.T__timestamptz,
+	oid.T_interval:    oid.T__interval,
+	oid.T_numeric:     oid.T__numeric,
+	oid.T_uuid:        oid.T__uuid,
+}
+
+const noArrayType = 0
+
+// ArrayOids is a set of all oids which correspond to an array type.
+var ArrayOids = map[oid.Oid]struct{}{}
+
+func init() {
+	for _, v := range oidToArrayOid {
+		ArrayOids[v] = struct{}{}
+	}
 }
 
 // Oid implements the Type interface.
@@ -540,7 +591,7 @@ func (a TArray) Oid() oid.Oid {
 	if o, ok := oidToArrayOid[a.Typ.Oid()]; ok {
 		return o
 	}
-	return oid.T_anyarray
+	return noArrayType
 }
 
 // SQLName implements the Type interface.

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1424,6 +1424,7 @@ CREATE TABLE pg_catalog.pg_type (
 		for o, typ := range parser.OidToType {
 			cat := typCategory(typ)
 			typElem := oidZero
+			typArray := oidZero
 			builtinPrefix := parser.PGIOBuiltinPrefix(typ)
 			if cat == typCategoryArray {
 				if typ == parser.TypeIntVector {
@@ -1438,6 +1439,8 @@ CREATE TABLE pg_catalog.pg_type (
 					builtinPrefix = "array_"
 					typElem = parser.NewDOid(parser.DInt(parser.UnwrapType(typ).(parser.TArray).Typ.Oid()))
 				}
+			} else {
+				typArray = parser.NewDOid(parser.DInt(parser.TArray{Typ: typ}.Oid()))
 			}
 			typname := parser.PGDisplayName(typ)
 
@@ -1455,7 +1458,7 @@ CREATE TABLE pg_catalog.pg_type (
 				typDelim,                // typdelim
 				oidZero,                 // typrelid
 				typElem,                 // typelem
-				oidZero,                 // typarray
+				typArray,                // typarray
 
 				// regproc references
 				h.RegProc(builtinPrefix+"in"),   // typinput

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -855,9 +855,6 @@ func TestPGPreparedQuery(t *testing.T) {
 		"SELECT $1::UUID": {
 			baseTest.SetArgs("63616665-6630-3064-6465-616462656562").Results("63616665-6630-3064-6465-616462656562"),
 		},
-		"SELECT $1::INET": {
-			baseTest.SetArgs("192.168.0.1/32").Results("192.168.0.1"),
-		},
 		"SELECT $1:::FLOAT[]": {
 			baseTest.SetArgs("{}").Results("{}"),
 			baseTest.SetArgs("{1.0,2.0,3.0}").Results("{1.0,2.0,3.0}"),

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -855,6 +855,21 @@ func TestPGPreparedQuery(t *testing.T) {
 		"SELECT $1::UUID": {
 			baseTest.SetArgs("63616665-6630-3064-6465-616462656562").Results("63616665-6630-3064-6465-616462656562"),
 		},
+		"SELECT $1::INET": {
+			baseTest.SetArgs("192.168.0.1/32").Results("192.168.0.1"),
+		},
+		"SELECT $1:::FLOAT[]": {
+			baseTest.SetArgs("{}").Results("{}"),
+			baseTest.SetArgs("{1.0,2.0,3.0}").Results("{1.0,2.0,3.0}"),
+		},
+		"SELECT $1:::DECIMAL[]": {
+			baseTest.SetArgs("{1.000}").Results("{1.000}"),
+		},
+		"SELECT $1:::STRING[]": {
+			baseTest.SetArgs(`{aaa}`).Results(`{"aaa"}`),
+			baseTest.SetArgs(`{"aaa"}`).Results(`{"aaa"}`),
+			baseTest.SetArgs(`{aaa,bbb,ccc}`).Results(`{"aaa","bbb","ccc"}`),
+		},
 
 		// TODO(jordan): blocked on #13651
 		//"SELECT $1::INT[]": {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -529,6 +529,11 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 				}
 			}
 			return out, nil
+		case oid.T_anyarray:
+			if err := validateStringBytes(b); err != nil {
+				return nil, err
+			}
+			return parser.NewDString(string(b)), nil
 		case oid.T__text, oid.T__name:
 			var arr pq.StringArray
 			if err := (&arr).Scan(b); err != nil {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -529,11 +529,6 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 				}
 			}
 			return out, nil
-		case oid.T_anyarray:
-			if err := validateStringBytes(b); err != nil {
-				return nil, err
-			}
-			return parser.NewDString(string(b)), nil
 		case oid.T__text, oid.T__name:
 			var arr pq.StringArray
 			if err := (&arr).Scan(b); err != nil {
@@ -553,6 +548,14 @@ func decodeOidDatum(id oid.Oid, code formatCode, b []byte) (parser.Datum, error)
 				}
 			}
 			return out, nil
+		}
+		if _, ok := parser.ArrayOids[id]; ok {
+			// Arrays come in in their string form, so we parse them as such and later
+			// convert them to their actual datum form.
+			if err := validateStringBytes(b); err != nil {
+				return nil, err
+			}
+			return parser.NewDString(string(b)), nil
 		}
 	case formatBinary:
 		switch id {


### PR DESCRIPTION
The hiccup in this cherry-pick is that since inet wasn't in 1.1 I had to remove it. Also includes the array-string parsing commit.