### PR TITLE
storage: less clobbering and better readability in NodeLiveness

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -706,20 +706,23 @@ func shouldReplaceLiveness(old, new Liveness) bool {
 		return true
 	}
 
-	if old.Expiration == new.Expiration && old.Epoch == new.Epoch {
-		// Assume that the update is newer when its draining or
-		// decommissioning field changed.
-		//
-		// This has false positives (in which case we're clobbering the
-		// liveness). A better way to handle liveness updates in general is
-		// to add a sequence number.
-		//
-		// See #18219.
-		return old.Draining != new.Draining || old.Decommissioning != new.Decommissioning
+	// Compare first Epoch, and no change there, Expiration.
+	if old.Epoch != new.Epoch {
+		return old.Epoch < new.Epoch
+	}
+	if old.Expiration != new.Expiration {
+		return old.Expiration.Less(new.Expiration)
 	}
 
-	// Accept an update if it moves either expiration or epoch forward.
-	return old.Expiration.Less(new.Expiration) || old.Epoch < new.Epoch
+	// If Epoch and Expiration are unchanged, assume that the update is newer
+	// when its draining or decommissioning field changed.
+	//
+	// This has false positives (in which case we're clobbering the liveness). A
+	// better way to handle liveness updates in general is to add a sequence
+	// number.
+	//
+	// See #18219.
+	return old.Draining != new.Draining || old.Decommissioning != new.Decommissioning
 }
 
 // livenessGossipUpdate is the gossip callback used to keep the
@@ -771,25 +774,25 @@ func (nl *NodeLiveness) numLiveNodes() int64 {
 		return 0
 	}
 
-	self, err := nl.Self()
+	now := nl.clock.Now()
+	maxOffset := nl.clock.MaxOffset()
+
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+
+	self, err := nl.getLivenessLocked(selfID)
 	if err == ErrNoLivenessRecord {
 		return 0
 	}
 	if err != nil {
 		log.Warningf(ctx, "looking up own liveness: %s", err)
+		return 0
 	}
-
-	now := nl.clock.Now()
-	maxOffset := nl.clock.MaxOffset()
-
 	// If this node isn't live, we don't want to report its view of node liveness
 	// because it's more likely to be inaccurate than the view of a live node.
 	if !self.IsLive(now, maxOffset) {
 		return 0
 	}
-
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
 	var liveNodes int64
 	for _, l := range nl.mu.nodes {
 		if l.IsLive(now, maxOffset) {

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -720,6 +720,27 @@ func (nl *NodeLiveness) updateLivenessAttempt(
 	return nil
 }
 
+func shouldReplaceLiveness(old, new Liveness) bool {
+	if (old == Liveness{}) {
+		return true
+	}
+
+	if old.Expiration == new.Expiration && old.Epoch == new.Epoch {
+		// Assume that the update is newer when its draining or
+		// decommissioning field changed.
+		//
+		// This has false positives (in which case we're clobbering the
+		// liveness). A better way to handle liveness updates in general is
+		// to add a sequence number.
+		//
+		// See #18219.
+		return old.Draining != new.Draining || old.Decommissioning != new.Decommissioning
+	}
+
+	// Accept an update if it moves either expiration or epoch forward.
+	return old.Expiration.Less(new.Expiration) || old.Epoch < new.Epoch
+}
+
 // livenessGossipUpdate is the gossip callback used to keep the
 // in-memory liveness info up to date.
 func (nl *NodeLiveness) livenessGossipUpdate(key string, content roachpb.Value) {
@@ -734,16 +755,12 @@ func (nl *NodeLiveness) livenessGossipUpdate(key string, content roachpb.Value) 
 	// expiration or epoch was advanced, or the draining state changed.
 	var callbacks []IsLiveCallback
 	nl.mu.Lock()
-	exLiveness, ok := nl.mu.nodes[liveness.NodeID]
-	apply := !ok ||
-		exLiveness.Expiration.Less(liveness.Expiration) ||
-		exLiveness.Epoch < liveness.Epoch ||
-		exLiveness.Draining != liveness.Draining ||
-		exLiveness.Decommissioning != liveness.Decommissioning
-	if apply {
+	exLiveness := nl.mu.nodes[liveness.NodeID]
+	if shouldReplaceLiveness(exLiveness, liveness) {
 		nl.mu.nodes[liveness.NodeID] = liveness
 
 		// If isLive status is now true, but previously false, invoke any registered callbacks.
+		// Note that this works fine even if exLiveness is empty.
 		now, offset := nl.clock.Now(), nl.clock.MaxOffset()
 		if !exLiveness.IsLive(now, offset) && liveness.IsLive(now, offset) {
 			callbacks = append(callbacks, nl.mu.callbacks...)

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -492,7 +492,14 @@ func (nl *NodeLiveness) Self() (*Liveness, error) {
 
 func (nl *NodeLiveness) setSelf(liveness Liveness) {
 	nl.mu.Lock()
-	nl.mu.self = liveness
+	// NB: shouldReplaceLiveness should always be true
+	// since setSelf is only ever called for non-overlapping
+	// liveness updated serialized through a single semaphore.
+	//
+	// We call it for symmetry with the nodes map.
+	if shouldReplaceLiveness(nl.mu.self, liveness) {
+		nl.mu.self = liveness
+	}
 	nl.mu.Unlock()
 }
 

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -370,9 +370,14 @@ func TestNodeLivenessRestart(t *testing.T) {
 	})
 }
 
-// TestNodeLivenessSelf verifies that a node keeps its own most
-// recent liveness heartbeat info in preference to anything which
-// might be received belatedly through gossip.
+// TestNodeLivenessSelf verifies that a node keeps its own most recent liveness
+// heartbeat info in preference to anything which might be received belatedly
+// through gossip.
+//
+// Note that this test originally injected a Gossip update with a higher Epoch
+// and semantics have since changed to make the "self" record less special. It
+// is updated like any other node's record, with appropriate safeguards against
+// clobbering in place.
 func TestNodeLivenessSelf(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	mtc := &multiTestContext{}
@@ -395,10 +400,10 @@ func TestNodeLivenessSelf(t *testing.T) {
 		atomic.AddInt32(&count, 1)
 	})
 	testutils.SucceedsSoon(t, func() error {
-		if err := g.AddInfoProto(key, &storage.Liveness{
-			NodeID: 1,
-			Epoch:  2,
-		}, 0); err != nil {
+		fakeBehindLiveness := *liveness
+		fakeBehindLiveness.Epoch-- // almost certainly results in zero
+
+		if err := g.AddInfoProto(key, &fakeBehindLiveness, 0); err != nil {
 			t.Fatal(err)
 		}
 		if atomic.LoadInt32(&count) < 2 {
@@ -407,7 +412,7 @@ func TestNodeLivenessSelf(t *testing.T) {
 		return nil
 	})
 
-	// Self should not see new epoch.
+	// Self should not see the fake liveness, but have kept the real one.
 	l := mtc.nodeLivenesses[0]
 	lGet, err := l.GetLiveness(g.NodeID.Get())
 	if err != nil {

--- a/pkg/storage/node_liveness_unit_test.go
+++ b/pkg/storage/node_liveness_unit_test.go
@@ -1,0 +1,94 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestShouldReplaceLiveness(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	l := func(epo int64, expiration hlc.Timestamp, draining, decom bool) Liveness {
+		return Liveness{
+			Epoch:           epo,
+			Expiration:      hlc.LegacyTimestamp(expiration),
+			Draining:        draining,
+			Decommissioning: decom,
+		}
+	}
+	const (
+		no  = false
+		yes = true
+	)
+	now := hlc.Timestamp{WallTime: 12345}
+
+	for _, test := range []struct {
+		old, new Liveness
+		exp      bool
+	}{
+		{
+			// Epoch update only.
+			Liveness{},
+			l(1, hlc.Timestamp{}, false, false),
+			yes,
+		},
+		{
+			// No Epoch update, but Expiration update.
+			l(1, now, false, false),
+			l(1, now.Add(0, 1), false, false),
+			yes,
+		},
+		{
+			// No update.
+			l(1, now, false, false),
+			l(1, now, false, false),
+			no,
+		},
+		{
+			// Only Decommissioning changes.
+			l(1, now, false, false),
+			l(1, now, false, true),
+			yes,
+		},
+		{
+			// Only Draining changes.
+			l(1, now, false, false),
+			l(1, now, true, false),
+			yes,
+		},
+		{
+			// Decommissioning changes, but Epoch moves backwards.
+			l(10, now, true, true),
+			l(9, now, true, false),
+			no,
+		},
+		{
+			// Draining changes, but Expiration moves backwards..
+			l(10, now, false, false),
+			l(10, now.Add(-1, 0), true, false),
+			no,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			if act := shouldReplaceLiveness(test.old, test.new); act != test.exp {
+				t.Errorf("unexpected update: %+v", test)
+			}
+		})
+	}
+}


### PR DESCRIPTION
See #18219 for context. Needs testing, but I wanted to get this out for review as
I'm hoping that it can go into 1.1.2. or 1.1.3.

----

Investigated the decommissioning problems some users have faced, which are essentially
that sometimes `NodeLiveness` gets stuck with a liveness record that doesn't have
`Decommissioning == true` even though `./cockroach debug gossip-values` indicates that
Gossip did receive the correct record. This appears to be happening mostly (always?)
when the target node is dead.

Unfortunately, I couldn't come up with a conclusive scenario since the users presumably
initiated these commands long after the target node was dead (and so `IncrementEpoch`
*should* not be directed at this node, though perhaps it is?) but I decided to simplify
and harden the code against some of the known issues. Precisely,

1. Update the stored liveness when setting the decommissioning status. This alone would
   prevent the decommissioning command from getting stuck (since the wrong state would be
   expunged).
2. Pass all code which updates any cached liveness through a method which decides whether
   to update, namely when the epoch or expiration are newer (or, if neither has
   changed, update if there are any other changes). This should do the "right
   thing" for Epoch/Expiration, but may clobber for `Draining/Decommissioning`,
   though that problem should have gotten less frequent in this change since we
   previously didn't use this criterion for more than breaking ties.
3. Remove `(NodeLiveness).mu.self`. It was odd to have both that and an entry in `mu.nodes`,
   and the original motivation (avoiding late gossip updates to "wind back" the
   state) does not seem to apply any more. This change is logically disconnected from the
   initial issue, but clarifying the code to make it easier to reason about seemed like a
   clear win.

I'm mildly nervous that something here might introduce a silly bug, but if it did and we
don't discover it in review, it's a signal that we should introduce a sequence number as
described in #18219.