### PR TITLE
cherrypick-1.1: sqlccl: pass needed spans to prev backup checks

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -2093,3 +2093,23 @@ func TestBackupRestoreDropTable(t *testing.T) {
 	expected := sqlDB.QueryStr(`SELECT * FROM data.bank`)
 	sqlDB.CheckQueryResults(`SELECT * FROM data2.bank`, expected)
 }
+
+func TestBackupRestoreIncrementalNewTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const numAccounts = 1
+	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
+	defer cleanupFn()
+	sqlDB.Exec(`CREATE TABLE data.bank2 (i int)`)
+
+	full := filepath.Join(dir, "full")
+	inc := filepath.Join(dir, "inc")
+
+	sqlDB.Exec(`BACKUP DATABASE data TO $1`, full)
+
+	sqlDB.Exec(`CREATE TABLE data.bank3 (i int)`)
+	_, err := sqlDB.DB.Exec("BACKUP DATABASE data TO $1 INCREMENTAL FROM $2", inc, full)
+	if !testutils.IsError(err, "a new full backup may be required") {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Previously we validated previous backups were well-formed and ordered.
We did not, however, pass the spans which needed to be covered, the way we do
when running the matching check in RESTORE, meaning that we'd accept a set of
previous backups that didn't actually cover the spans being backed up.

Re-ordering the steps in the backup plan slightly computes the matching tables
and spans before validating the prior backups (and setting the start time), thus
catching that case where the set of tables (and thus the spans for which we need
complete history in order to restore) has changed.

Another potential approach would be to automatically change the startTime for
the spans for which we are missing history, effectiely de-incrementalizing those
tables. This opens up significant additional complexity though. A simple error
at BACKUP time should at least indicate there is an issue right away, rather
than letting an operator believe they are making usable BACKUPs that cannot
actually be RESTOREd.