### PR TITLE
Revert "sql: remove unnecessary DatumAlloc parameter from index key methods"

### DIFF
--- a/pkg/server/settingsworker.go
+++ b/pkg/server/settingsworker.go
@@ -46,7 +46,7 @@ func (s *Server) refreshSettings() {
 		// First we need to decode the setting name field from the index key.
 		{
 			nameRow := []sqlbase.EncDatum{{Type: tbl.Columns[0].Type}}
-			_, matches, err := sqlbase.DecodeIndexKey(tbl, &tbl.PrimaryIndex, nameRow, nil, kv.Key)
+			_, matches, err := sqlbase.DecodeIndexKey(a, tbl, &tbl.PrimaryIndex, nameRow, nil, kv.Key)
 			if err != nil {
 				return errors.Wrap(err, "failed to decode key")
 			}

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -245,12 +245,13 @@ func ConvertBatchError(ctx context.Context, tableDesc *TableDescriptor, b *clien
 		panic(fmt.Sprintf("index %d outside of results: %+v", j, b.Results))
 	}
 	result := b.Results[j]
+	var alloc DatumAlloc
 	if cErr, ok := origPErr.GetDetail().(*roachpb.ConditionFailedError); ok && len(result.Rows) > 0 {
 		key := result.Rows[0].Key
 		// TODO(dan): There's too much internal knowledge of the sql table
 		// encoding here (and this callsite is the only reason
 		// DecodeIndexKeyPrefix is exported). Refactor this bit out.
-		indexID, _, err := DecodeIndexKeyPrefix(tableDesc, key)
+		indexID, _, err := DecodeIndexKeyPrefix(&alloc, tableDesc, key)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -318,7 +318,7 @@ func prettyEncDatums(vals []EncDatum) string {
 
 // ReadIndexKey decodes an index key for the fetcher's table.
 func (rf *RowFetcher) ReadIndexKey(k roachpb.Key) (remaining []byte, ok bool, err error) {
-	return DecodeIndexKey(rf.desc, rf.index, rf.keyVals,
+	return DecodeIndexKey(rf.alloc, rf.desc, rf.index, rf.keyVals,
 		rf.indexColumnDirs, k)
 }
 

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -671,7 +671,7 @@ func DecodeTableIDIndexID(key []byte) ([]byte, ID, IndexID, error) {
 //
 // Don't use this function in the scan "hot path".
 func DecodeIndexKeyPrefix(
-	desc *TableDescriptor, key []byte,
+	a *DatumAlloc, desc *TableDescriptor, key []byte,
 ) (indexID IndexID, remaining []byte, err error) {
 	// TODO(dan): This whole operation is n^2 because of the interleaves
 	// bookkeeping. We could improve it to n with a prefix tree of components.
@@ -734,6 +734,7 @@ func DecodeIndexKeyPrefix(
 // or unique secondary indexes containing NULL or empty. If the given descriptor
 // does not match the key, false is returned with no error.
 func DecodeIndexKey(
+	a *DatumAlloc,
 	desc *TableDescriptor,
 	index *IndexDescriptor,
 	vals []EncDatum,
@@ -818,8 +819,10 @@ func DecodeKeyVals(vals []EncDatum, directions []encoding.Direction, key []byte)
 // key/value entry, including secondary indexes.
 //
 // Don't use this function in the scan "hot path".
-func ExtractIndexKey(tableDesc *TableDescriptor, entry client.KeyValue) (roachpb.Key, error) {
-	indexID, key, err := DecodeIndexKeyPrefix(tableDesc, entry.Key)
+func ExtractIndexKey(
+	a *DatumAlloc, tableDesc *TableDescriptor, entry client.KeyValue,
+) (roachpb.Key, error) {
+	indexID, key, err := DecodeIndexKeyPrefix(a, tableDesc, entry.Key)
 	if err != nil {
 		return nil, err
 	}
@@ -849,7 +852,7 @@ func ExtractIndexKey(tableDesc *TableDescriptor, entry client.KeyValue) (roachpb
 		// find the index id so we can look up the descriptor, and once to extract
 		// the values. Only parse once.
 		var ok bool
-		_, ok, err = DecodeIndexKey(tableDesc, i, values, dirs, entry.Key)
+		_, ok, err = DecodeIndexKey(a, tableDesc, i, values, dirs, entry.Key)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -90,7 +90,7 @@ func makeTableDescForTest(test indexKeyTest) (TableDescriptor, map[ColumnID]int)
 }
 
 func decodeIndex(
-	tableDesc *TableDescriptor, index *IndexDescriptor, key []byte,
+	a *DatumAlloc, tableDesc *TableDescriptor, index *IndexDescriptor, key []byte,
 ) ([]parser.Datum, error) {
 	values, err := MakeEncodedKeyVals(tableDesc, index.ColumnIDs)
 	if err != nil {
@@ -103,7 +103,7 @@ func decodeIndex(
 			return nil, err
 		}
 	}
-	_, ok, err := DecodeIndexKey(tableDesc, index, values, colDirs, key)
+	_, ok, err := DecodeIndexKey(a, tableDesc, index, values, colDirs, key)
 	if err != nil {
 		return nil, err
 	}
@@ -126,6 +126,7 @@ func decodeIndex(
 
 func TestIndexKey(t *testing.T) {
 	rng, _ := randutil.NewPseudoRand()
+	var a DatumAlloc
 
 	tests := []indexKeyTest{
 		{nil, nil,
@@ -210,7 +211,7 @@ func TestIndexKey(t *testing.T) {
 		}
 
 		checkEntry := func(index *IndexDescriptor, entry client.KeyValue) {
-			values, err := decodeIndex(&tableDesc, index, entry.Key)
+			values, err := decodeIndex(&a, &tableDesc, index, entry.Key)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -222,7 +223,7 @@ func TestIndexKey(t *testing.T) {
 				}
 			}
 
-			indexID, _, err := DecodeIndexKeyPrefix(&tableDesc, entry.Key)
+			indexID, _, err := DecodeIndexKeyPrefix(&a, &tableDesc, entry.Key)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -230,7 +231,7 @@ func TestIndexKey(t *testing.T) {
 				t.Errorf("%d", i)
 			}
 
-			extracted, err := ExtractIndexKey(&tableDesc, entry)
+			extracted, err := ExtractIndexKey(&a, &tableDesc, entry)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -532,7 +532,7 @@ func (tu *tableUpserter) upsertRowPKs(ctx context.Context, traceKV bool) ([]roac
 			if result.Rows[0].Value == nil {
 				upsertRowPKs[i] = nil
 			} else {
-				upsertRowPK, err := sqlbase.ExtractIndexKey(tableDesc, result.Rows[0])
+				upsertRowPK, err := sqlbase.ExtractIndexKey(tu.alloc, tableDesc, result.Rows[0])
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Reverts cockroachdb/cockroach#19278

We actually need the `DatumAlloc` in `ExtractIndexKey` [here](https://github.com/cockroachdb/cockroach/blob/407057955ddbf182e2ac12a7fbf40f6afd4e6922/pkg/sql/sqlbase/table.go#L901); we currently incorrectly allocate a new one. PR #19246 fixes this.