### PR TITLE
sql/parser: Fix extract() for quarter

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1046,6 +1046,26 @@ SELECT extract(months FROM '2016-02-10 19:46:33.306157519'::timestamp)
 2
 
 query I
+SELECT extract(quarter FROM '2016-02-10 19:46:33.306157519'::timestamp)
+----
+1
+
+query I
+SELECT extract(quarter FROM '2016-05-10 19:46:33.306157519'::timestamp)
+----
+2
+
+query I
+SELECT extract(quarter FROM '2016-09-09 19:46:33.306157519'::timestamp)
+----
+3
+
+query I
+SELECT extract(quarter FROM '2016-10-10 19:46:33.306157519'::timestamp)
+----
+4
+
+query I
 SELECT extract(year FROM '2016-02-10 19:46:33.306157519'::timestamp)
 ----
 2016
@@ -1139,6 +1159,26 @@ query I
 SELECT extract(months FROM '2016-02-10 19:46:33.306157519'::timestamptz)
 ----
 2
+
+query I
+SELECT extract(quarter FROM '2016-02-10 19:46:33.306157519'::timestamptz)
+----
+1
+
+query I
+SELECT extract(quarter FROM '2016-05-10 19:46:33.306157519'::timestamptz)
+----
+2
+
+query I
+SELECT extract(quarter FROM '2016-09-09 19:46:33.306157519'::timestamptz)
+----
+3
+
+query I
+SELECT extract(quarter FROM '2016-10-10 19:46:33.306157519'::timestamptz)
+----
+4
 
 query I
 SELECT extract(year FROM '2016-02-10 19:46:33.306157519'::timestamptz)

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -2975,7 +2975,7 @@ func extractStringFromTimestamp(
 		return NewDInt(DInt(fromTime.Year())), nil
 
 	case "quarter":
-		return NewDInt(DInt(fromTime.Month()/4 + 1)), nil
+		return NewDInt(DInt((fromTime.Month()-1)/3 + 1)), nil
 
 	case "month", "months":
 		return NewDInt(DInt(fromTime.Month())), nil


### PR DESCRIPTION
The builtin SQL function extract() has incorrect
logic for extracting the quarter from dates and timestamps.
Fix extract() so it returns 1 for Jan-Mar, 2 for Apr-Jun,
3 for Jul-Sep, and 4 for Oct-Dec.