### PR TITLE
cli: fix broken output of special characters in queries

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -589,7 +589,7 @@
   branch = "master"
   name = "github.com/olekukonko/tablewriter"
   packages = ["."]
-  revision = "a7a4c189eb47ed33ce7b35f2880070a0c82a67d4"
+  revision = "b8a9be070da40449e501c3c4730a889e42d87a9e"
 
 [[projects]]
   name = "github.com/opencontainers/go-digest"

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -754,92 +755,139 @@ func Example_sql_column_labels() {
 	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
-	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.u (\"\"\"foo\" int, \"\\foo\" int, \"foo\nbar\" int, \"κόσμε\" int, \"a|b\" int, \"܈85\" int)"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.u values (0, 0, 0, 0, 0, 0)"})
+	testData := []string{
+		`f"oo`,
+		`f'oo`,
+		`f\oo`,
+		`foo
+bar`,
+		`κόσμε`,
+		`a|b`,
+		`܈85`,
+	}
+
+	tdef := make([]string, len(testData))
+	var vals bytes.Buffer
+	for i, col := range testData {
+		tdef[i] = tree.NameString(col) + " int"
+		if i > 0 {
+			vals.WriteString(", ")
+		}
+		vals.WriteByte('0')
+	}
+	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.u (" + strings.Join(tdef, ", ") + ")"})
+	c.RunWithArgs([]string{"sql", "-e", "insert into t.u values (" + vals.String() + ")"})
 	c.RunWithArgs([]string{"sql", "-e", "show columns from t.u"})
 	c.RunWithArgs([]string{"sql", "-e", "select * from t.u"})
 	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "show columns from t.u"})
 	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "select * from t.u"})
-	c.RunWithArgs([]string{"sql", "--format=tsv", "-e", "select * from t.u"})
-	c.RunWithArgs([]string{"sql", "--format=csv", "-e", "select * from t.u"})
-	c.RunWithArgs([]string{"sql", "--format=sql", "-e", "select * from t.u"})
-	c.RunWithArgs([]string{"sql", "--format=html", "-e", "select * from t.u"})
-	c.RunWithArgs([]string{"sql", "--format=records", "-e", "select * from t.u"})
+	for i := tableDisplayFormat(0); i < tableDisplayLastFormat; i++ {
+		c.RunWithArgs([]string{"sql", "--format=" + i.String(), "-e", "select * from t.u"})
+	}
 
 	// Output:
-	// sql -e create database t; create table t.u ("""foo" int, "\foo" int, "foo
-	// bar" int, "κόσμε" int, "a|b" int, "܈85" int)
+	// sql -e create database t; create table t.u ("f""oo" int, "f'oo" int, "f\oo" int, "foo
+	// bar" int, "κόσμε" int, "a|b" int, ܈85 int)
 	// CREATE TABLE
-	// sql -e insert into t.u values (0, 0, 0, 0, 0, 0)
+	// sql -e insert into t.u values (0, 0, 0, 0, 0, 0, 0)
 	// INSERT 1
 	// sql -e show columns from t.u
 	// Field	Type	Null	Default	Indices
-	// """foo"	INT	true	NULL	{}
-	// \foo	INT	true	NULL	{}
+	// "f""oo"	INT	true	NULL	{}
+	// f'oo	INT	true	NULL	{}
+	// f\oo	INT	true	NULL	{}
 	// "foo
 	// bar"	INT	true	NULL	{}
 	// κόσμε	INT	true	NULL	{}
 	// a|b	INT	true	NULL	{}
 	// ܈85	INT	true	NULL	{}
-	// # 6 rows
+	// # 7 rows
 	// sql -e select * from t.u
-	// """foo"	\foo	foo\nbar	κόσμε	a|b	܈85
-	// 0	0	0	0	0	0
+	// "f""oo"	f'oo	f\oo	foo\nbar	κόσμε	a|b	܈85
+	// 0	0	0	0	0	0	0
 	// # 1 row
 	// sql --format=pretty -e show columns from t.u
 	// +---------+------+------+---------+---------+
 	// |  Field  | Type | Null | Default | Indices |
 	// +---------+------+------+---------+---------+
-	// | "foo    | INT  | true | NULL    | {}      |
-	// | \foo    | INT  | true | NULL    | {}      |
+	// | f"oo    | INT  | true | NULL    | {}      |
+	// | f'oo    | INT  | true | NULL    | {}      |
+	// | f\oo    | INT  | true | NULL    | {}      |
 	// | foo␤    | INT  | true | NULL    | {}      |
 	// | bar     |      |      |         |         |
 	// | κόσμε   | INT  | true | NULL    | {}      |
 	// | a|b     | INT  | true | NULL    | {}      |
 	// | ܈85     | INT  | true | NULL    | {}      |
 	// +---------+------+------+---------+---------+
-	// (6 rows)
+	// (7 rows)
 	// sql --format=pretty -e select * from t.u
-	// +------+------+----------+-------+-----+-----+
-	// | "foo | \foo | foo\nbar | κόσμε | a|b | ܈85 |
-	// +------+------+----------+-------+-----+-----+
-	// |    0 |    0 |        0 |     0 |   0 |   0 |
-	// +------+------+----------+-------+-----+-----+
+	// +------+------+------+----------+-------+-----+-----+
+	// | f"oo | f'oo | f\oo | foo\nbar | κόσμε | a|b | ܈85 |
+	// +------+------+------+----------+-------+-----+-----+
+	// |    0 |    0 |    0 |        0 |     0 |   0 |   0 |
+	// +------+------+------+----------+-------+-----+-----+
 	// (1 row)
 	// sql --format=tsv -e select * from t.u
-	// """foo"	\foo	foo\nbar	κόσμε	a|b	܈85
-	// 0	0	0	0	0	0
+	// "f""oo"	f'oo	f\oo	foo\nbar	κόσμε	a|b	܈85
+	// 0	0	0	0	0	0	0
 	// # 1 row
 	// sql --format=csv -e select * from t.u
-	// """foo",\foo,foo\nbar,κόσμε,a|b,܈85
-	// 0,0,0,0,0,0
+	// "f""oo",f'oo,f\oo,foo\nbar,κόσμε,a|b,܈85
+	// 0,0,0,0,0,0,0
 	// # 1 row
+	// sql --format=pretty -e select * from t.u
+	// +------+------+------+----------+-------+-----+-----+
+	// | f"oo | f'oo | f\oo | foo\nbar | κόσμε | a|b | ܈85 |
+	// +------+------+------+----------+-------+-----+-----+
+	// |    0 |    0 |    0 |        0 |     0 |   0 |   0 |
+	// +------+------+------+----------+-------+-----+-----+
+	// (1 row)
+	// sql --format=records -e select * from t.u
+	// -[ RECORD 1 ]
+	// f"oo     | 0
+	// f'oo     | 0
+	// f\oo     | 0
+	// foo\nbar | 0
+	// κόσμε    | 0
+	// a|b      | 0
+	// ܈85      | 0
 	// sql --format=sql -e select * from t.u
 	// CREATE TABLE results (
-	//   """foo" STRING,
-	//   "\foo" STRING,
+	//   "f""oo" STRING,
+	//   "f'oo" STRING,
+	//   "f\oo" STRING,
 	//   "foo\nbar" STRING,
 	//   "κόσμε" STRING,
 	//   "a|b" STRING,
 	//   ܈85 STRING
 	// );
 	//
-	// INSERT INTO results VALUES ('0', '0', '0', '0', '0', '0');
+	// INSERT INTO results VALUES ('0', '0', '0', '0', '0', '0', '0');
 	// sql --format=html -e select * from t.u
 	// <table>
-	// <thead><tr><th>row</th><th>&#34;foo</th><th>\foo</th><th>foo\nbar</th><th>κόσμε</th><th>a|b</th><th>܈85</th></tr></head>
+	// <thead><tr><th>row</th><th>f&#34;oo</th><th>f&#39;oo</th><th>f\oo</th><th>foo\nbar</th><th>κόσμε</th><th>a|b</th><th>܈85</th></tr></head>
 	// <tbody>
-	// <tr><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+	// <tr><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 	// </tbody>
-	// <tfoot><tr><td colspan=7>1 row</td></tr></tfoot></table>
-	// sql --format=records -e select * from t.u
-	// -[ RECORD 1 ]
-	// "foo     | 0
-	// \foo     | 0
-	// foo\nbar | 0
-	// κόσμε    | 0
-	// a|b      | 0
-	// ܈85      | 0
+	// <tfoot><tr><td colspan=8>1 row</td></tr></tfoot></table>
+	// sql --format=raw -e select * from t.u
+	// # 7 columns
+	// # row 1
+	// ## 1
+	// 0
+	// ## 1
+	// 0
+	// ## 1
+	// 0
+	// ## 1
+	// 0
+	// ## 1
+	// 0
+	// ## 1
+	// 0
+	// ## 1
+	// 0
+	// # 1 row
 }
 
 func Example_sql_empty_table() {
@@ -851,26 +899,27 @@ func Example_sql_empty_table() {
 		"create table t.nocolsnorows();" +
 		"create table t.nocols(); insert into t.nocols(rowid) values (1),(2),(3);"})
 	for _, table := range []string{"norows", "nocols", "nocolsnorows"} {
-		for _, format := range []string{"pretty", "tsv", "csv", "sql", "html", "raw", "records"} {
-			c.RunWithArgs([]string{"sql", "--format=" + format, "-e", "select * from t." + table})
+		for format := tableDisplayFormat(0); format < tableDisplayLastFormat; format++ {
+			c.RunWithArgs([]string{"sql", "--format=" + format.String(), "-e", "select * from t." + table})
 		}
 	}
 
 	// Output:
 	// sql -e create database t;create table t.norows(x int);create table t.nocolsnorows();create table t.nocols(); insert into t.nocols(rowid) values (1),(2),(3);
 	// INSERT 3
-	// sql --format=pretty -e select * from t.norows
-	// +---+
-	// | x |
-	// +---+
-	// +---+
-	// (0 rows)
 	// sql --format=tsv -e select * from t.norows
 	// x
 	// # 0 rows
 	// sql --format=csv -e select * from t.norows
 	// x
 	// # 0 rows
+	// sql --format=pretty -e select * from t.norows
+	// +---+
+	// | x |
+	// +---+
+	// +---+
+	// (0 rows)
+	// sql --format=records -e select * from t.norows
 	// sql --format=sql -e select * from t.norows
 	// CREATE TABLE results (
 	//   x STRING
@@ -884,10 +933,6 @@ func Example_sql_empty_table() {
 	// sql --format=raw -e select * from t.norows
 	// # 1 column
 	// # 0 rows
-	// sql --format=records -e select * from t.norows
-	// sql --format=pretty -e select * from t.nocols
-	// --
-	// (3 rows)
 	// sql --format=tsv -e select * from t.nocols
 	// # no columns
 	// # empty
@@ -900,6 +945,11 @@ func Example_sql_empty_table() {
 	// # empty
 	// # empty
 	// # 3 rows
+	// sql --format=pretty -e select * from t.nocols
+	// --
+	// (3 rows)
+	// sql --format=records -e select * from t.nocols
+	// (3 rows)
 	// sql --format=sql -e select * from t.nocols
 	// CREATE TABLE results (
 	// );
@@ -922,17 +972,17 @@ func Example_sql_empty_table() {
 	// # row 2
 	// # row 3
 	// # 3 rows
-	// sql --format=records -e select * from t.nocols
-	// (3 rows)
-	// sql --format=pretty -e select * from t.nocolsnorows
-	// --
-	// (0 rows)
 	// sql --format=tsv -e select * from t.nocolsnorows
 	// # no columns
 	// # 0 rows
 	// sql --format=csv -e select * from t.nocolsnorows
 	// # no columns
 	// # 0 rows
+	// sql --format=pretty -e select * from t.nocolsnorows
+	// --
+	// (0 rows)
+	// sql --format=records -e select * from t.nocolsnorows
+	// (0 rows)
 	// sql --format=sql -e select * from t.nocolsnorows
 	// CREATE TABLE results (
 	// );
@@ -945,8 +995,6 @@ func Example_sql_empty_table() {
 	// sql --format=raw -e select * from t.nocolsnorows
 	// # 0 columns
 	// # 0 rows
-	// sql --format=records -e select * from t.nocolsnorows
-	// (0 rows)
 }
 
 func Example_csv_tsv_quoting() {
@@ -957,9 +1005,13 @@ func Example_csv_tsv_quoting() {
 		`ab`,
 		`a b`,
 		`a
-b`,
+bc
+def`,
 		`a, b`,
 		`"a", "b"`,
+		`'a', 'b'`,
+		`a\,b`,
+		`a	b`,
 	}
 
 	for _, sqlStr := range testData {
@@ -986,17 +1038,21 @@ b`,
 	// s	t
 	// a b	a b
 	// # 1 row
-	// sql --format=csv -e select e'a\nb' as s, e'a\nb' as t
+	// sql --format=csv -e select e'a\nbc\ndef' as s, e'a\nbc\ndef' as t
 	// s,t
 	// "a
-	// b","a
-	// b"
+	// bc
+	// def","a
+	// bc
+	// def"
 	// # 1 row
-	// sql --format=tsv -e select e'a\nb' as s, e'a\nb' as t
+	// sql --format=tsv -e select e'a\nbc\ndef' as s, e'a\nbc\ndef' as t
 	// s	t
 	// "a
-	// b"	"a
-	// b"
+	// bc
+	// def"	"a
+	// bc
+	// def"
 	// # 1 row
 	// sql --format=csv -e select 'a, b' as s, 'a, b' as t
 	// s,t
@@ -1014,33 +1070,59 @@ b`,
 	// s	t
 	// """a"", ""b"""	"""a"", ""b"""
 	// # 1 row
+	// sql --format=csv -e select e'\'a\', \'b\'' as s, e'\'a\', \'b\'' as t
+	// s,t
+	// "'a', 'b'","'a', 'b'"
+	// # 1 row
+	// sql --format=tsv -e select e'\'a\', \'b\'' as s, e'\'a\', \'b\'' as t
+	// s	t
+	// 'a', 'b'	'a', 'b'
+	// # 1 row
+	// sql --format=csv -e select e'a\\,b' as s, e'a\\,b' as t
+	// s,t
+	// "a\,b","a\,b"
+	// # 1 row
+	// sql --format=tsv -e select e'a\\,b' as s, e'a\\,b' as t
+	// s	t
+	// a\,b	a\,b
+	// # 1 row
+	// sql --format=csv -e select e'a\tb' as s, e'a\tb' as t
+	// s,t
+	// a	b,a	b
+	// # 1 row
+	// sql --format=tsv -e select e'a\tb' as s, e'a\tb' as t
+	// s	t
+	// "a	b"	"a	b"
+	// # 1 row
 }
 
 func Example_sql_table() {
 	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
 
+	testData := []struct {
+		str, desc string
+	}{
+		{"e'foo'", "printable ASCII"},
+		{"e'\"foo'", "printable ASCII with quotes"},
+		{"e'\\\\foo'", "printable ASCII with backslash"},
+		{"e'foo\\x0abar'", "non-printable ASCII"},
+		{"'κόσμε'", "printable UTF8"},
+		{"e'\\xc3\\xb1'", "printable UTF8 using escapes"},
+		{"e'\\x01'", "non-printable UTF8 string"},
+		{"e'\\xdc\\x88\\x38\\x35'", "UTF8 string with RTL char"},
+		{"e'a\\tb\\tc\\n12\\t123123213\\t12313'", "tabs"},
+		{"e'\\xc3\\x28'", "non-UTF8 string"}, // This expects an insert error.
+	}
+
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.t (s string, d string);"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'foo', 'printable ASCII')"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\"foo', 'printable ASCII with quotes')"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\\\\foo', 'printable ASCII with backslash')"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'foo\\x0abar', 'non-printable ASCII')"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values ('κόσμε', 'printable UTF8')"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\\xc3\\xb1', 'printable UTF8 using escapes')"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\\x01', 'non-printable UTF8 string')"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\\xdc\\x88\\x38\\x35', 'UTF8 string with RTL char')"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'\\xc3\\x28', 'non-UTF8 string')"})
-	c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (e'a\\tb\\tc\\n12\\t123123213\\t12313', 'tabs')"})
+	for _, t := range testData {
+		c.RunWithArgs([]string{"sql", "-e", "insert into t.t values (" + t.str + ", '" + t.desc + "')"})
+	}
 	c.RunWithArgs([]string{"sql", "-e", "select * from t.t"})
-	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "select * from t.t"})
-	c.RunWithArgs([]string{"sql", "--format=tsv", "-e", "select * from t.t"})
-	c.RunWithArgs([]string{"sql", "--format=csv", "-e", "select * from t.t"})
-	c.RunWithArgs([]string{"sql", "--format=sql", "-e", "select * from t.t"})
-	c.RunWithArgs([]string{"sql", "--format=html", "-e", "select * from t.t"})
-	c.RunWithArgs([]string{"sql", "--format=raw", "-e", "select * from t.t"})
-	c.RunWithArgs([]string{"sql", "--format=records", "-e", "select * from t.t"})
-	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "select '  hai' as x"})
-	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "explain select s from t.t union all select s from t.t"})
+	for format := tableDisplayFormat(0); format < tableDisplayLastFormat; format++ {
+		c.RunWithArgs([]string{"sql", "--format=" + format.String(), "-e", "select * from t.t"})
+	}
 
 	// Output:
 	// sql -e create database t; create table t.t (s string, d string);
@@ -1061,14 +1143,14 @@ func Example_sql_table() {
 	// INSERT 1
 	// sql -e insert into t.t values (e'\xdc\x88\x38\x35', 'UTF8 string with RTL char')
 	// INSERT 1
+	// sql -e insert into t.t values (e'a\tb\tc\n12\t123123213\t12313', 'tabs')
+	// INSERT 1
 	// sql -e insert into t.t values (e'\xc3\x28', 'non-UTF8 string')
 	// pq: invalid UTF-8 byte sequence
 	// DETAIL: source SQL:
 	// insert into t.t values (e'\xc3\x28', 'non-UTF8 string')
 	//                         ^
 	// HINT: try \h VALUES
-	// sql -e insert into t.t values (e'a\tb\tc\n12\t123123213\t12313', 'tabs')
-	// INSERT 1
 	// sql -e select * from t.t
 	// s	d
 	// foo	printable ASCII
@@ -1083,23 +1165,6 @@ func Example_sql_table() {
 	// "a	b	c
 	// 12	123123213	12313"	tabs
 	// # 9 rows
-	// sql --format=pretty -e select * from t.t
-	// +--------------------------------+--------------------------------+
-	// |               s                |               d                |
-	// +--------------------------------+--------------------------------+
-	// | foo                            | printable ASCII                |
-	// | "foo                           | printable ASCII with quotes    |
-	// | \foo                           | printable ASCII with backslash |
-	// | foo␤                           | non-printable ASCII            |
-	// | bar                            |                                |
-	// | κόσμε                          | printable UTF8                 |
-	// | ñ                              | printable UTF8 using escapes   |
-	// | \x01                           | non-printable UTF8 string      |
-	// | ܈85                            | UTF8 string with RTL char      |
-	// | a   b         c␤               | tabs                           |
-	// | 12  123123213 12313            |                                |
-	// +--------------------------------+--------------------------------+
-	// (9 rows)
 	// sql --format=tsv -e select * from t.t
 	// s	d
 	// foo	printable ASCII
@@ -1128,6 +1193,53 @@ func Example_sql_table() {
 	// "a	b	c
 	// 12	123123213	12313",tabs
 	// # 9 rows
+	// sql --format=pretty -e select * from t.t
+	// +--------------------------------+--------------------------------+
+	// |               s                |               d                |
+	// +--------------------------------+--------------------------------+
+	// | foo                            | printable ASCII                |
+	// | "foo                           | printable ASCII with quotes    |
+	// | \foo                           | printable ASCII with backslash |
+	// | foo␤                           | non-printable ASCII            |
+	// | bar                            |                                |
+	// | κόσμε                          | printable UTF8                 |
+	// | ñ                              | printable UTF8 using escapes   |
+	// | \x01                           | non-printable UTF8 string      |
+	// | ܈85                            | UTF8 string with RTL char      |
+	// | a   b         c␤               | tabs                           |
+	// | 12  123123213 12313            |                                |
+	// +--------------------------------+--------------------------------+
+	// (9 rows)
+	// sql --format=records -e select * from t.t
+	// -[ RECORD 1 ]
+	// s | foo
+	// d | printable ASCII
+	// -[ RECORD 2 ]
+	// s | "foo
+	// d | printable ASCII with quotes
+	// -[ RECORD 3 ]
+	// s | \foo
+	// d | printable ASCII with backslash
+	// -[ RECORD 4 ]
+	// s | foo
+	//   | bar
+	// d | non-printable ASCII
+	// -[ RECORD 5 ]
+	// s | κόσμε
+	// d | printable UTF8
+	// -[ RECORD 6 ]
+	// s | ñ
+	// d | printable UTF8 using escapes
+	// -[ RECORD 7 ]
+	// s | \x01
+	// d | non-printable UTF8 string
+	// -[ RECORD 8 ]
+	// s | ܈85
+	// d | UTF8 string with RTL char
+	// -[ RECORD 9 ]
+	// s | a	b	c
+	//   | 12	123123213	12313
+	// d | tabs
 	// sql --format=sql -e select * from t.t
 	// CREATE TABLE results (
 	//   s STRING,
@@ -1208,36 +1320,19 @@ func Example_sql_table() {
 	// ## 4
 	// tabs
 	// # 9 rows
-	// sql --format=records -e select * from t.t
-	// -[ RECORD 1 ]
-	// s | foo
-	// d | printable ASCII
-	// -[ RECORD 2 ]
-	// s | "foo
-	// d | printable ASCII with quotes
-	// -[ RECORD 3 ]
-	// s | \foo
-	// d | printable ASCII with backslash
-	// -[ RECORD 4 ]
-	// s | foo
-	//   | bar
-	// d | non-printable ASCII
-	// -[ RECORD 5 ]
-	// s | κόσμε
-	// d | printable UTF8
-	// -[ RECORD 6 ]
-	// s | ñ
-	// d | printable UTF8 using escapes
-	// -[ RECORD 7 ]
-	// s | \x01
-	// d | non-printable UTF8 string
-	// -[ RECORD 8 ]
-	// s | ܈85
-	// d | UTF8 string with RTL char
-	// -[ RECORD 9 ]
-	// s | a	b	c
-	//   | 12	123123213	12313
-	// d | tabs
+}
+
+func Example_misc_pretty() {
+	c := newCLITest(cliTestParams{})
+	defer c.cleanup()
+
+	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.t (s string, d string);"})
+	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "select '  hai' as x"})
+	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "explain select s from t.t union all select s from t.t"})
+
+	// Output:
+	// sql -e create database t; create table t.t (s string, d string);
+	// CREATE TABLE
 	// sql --format=pretty -e select '  hai' as x
 	// +-------+
 	// |   x   |

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -759,8 +759,11 @@ func Example_sql_column_labels() {
 		`f"oo`,
 		`f'oo`,
 		`f\oo`,
-		`foo
-bar`,
+		`short
+very very long
+not much`,
+		`very very long
+thenshort`,
 		`κόσμε`,
 		`a|b`,
 		`܈85`,
@@ -786,93 +789,124 @@ bar`,
 	}
 
 	// Output:
-	// sql -e create database t; create table t.u ("f""oo" int, "f'oo" int, "f\oo" int, "foo
-	// bar" int, "κόσμε" int, "a|b" int, ܈85 int)
+	// sql -e create database t; create table t.u ("f""oo" int, "f'oo" int, "f\oo" int, "short
+	// very very long
+	// not much" int, "very very long
+	// thenshort" int, "κόσμε" int, "a|b" int, ܈85 int)
 	// CREATE TABLE
-	// sql -e insert into t.u values (0, 0, 0, 0, 0, 0, 0)
+	// sql -e insert into t.u values (0, 0, 0, 0, 0, 0, 0, 0)
 	// INSERT 1
 	// sql -e show columns from t.u
 	// Field	Type	Null	Default	Indices
 	// "f""oo"	INT	true	NULL	{}
 	// f'oo	INT	true	NULL	{}
 	// f\oo	INT	true	NULL	{}
-	// "foo
-	// bar"	INT	true	NULL	{}
+	// "short
+	// very very long
+	// not much"	INT	true	NULL	{}
+	// "very very long
+	// thenshort"	INT	true	NULL	{}
 	// κόσμε	INT	true	NULL	{}
 	// a|b	INT	true	NULL	{}
 	// ܈85	INT	true	NULL	{}
-	// # 7 rows
+	// # 8 rows
 	// sql -e select * from t.u
-	// "f""oo"	f'oo	f\oo	foo\nbar	κόσμε	a|b	܈85
-	// 0	0	0	0	0	0	0
+	// "f""oo"	f'oo	f\oo	"short
+	// very very long
+	// not much"	"very very long
+	// thenshort"	κόσμε	a|b	܈85
+	// 0	0	0	0	0	0	0	0
 	// # 1 row
 	// sql --format=pretty -e show columns from t.u
-	// +---------+------+------+---------+---------+
-	// |  Field  | Type | Null | Default | Indices |
-	// +---------+------+------+---------+---------+
-	// | f"oo    | INT  | true | NULL    | {}      |
-	// | f'oo    | INT  | true | NULL    | {}      |
-	// | f\oo    | INT  | true | NULL    | {}      |
-	// | foo␤    | INT  | true | NULL    | {}      |
-	// | bar     |      |      |         |         |
-	// | κόσμε   | INT  | true | NULL    | {}      |
-	// | a|b     | INT  | true | NULL    | {}      |
-	// | ܈85     | INT  | true | NULL    | {}      |
-	// +---------+------+------+---------+---------+
-	// (7 rows)
+	// +-----------------+------+------+---------+---------+
+	// |      Field      | Type | Null | Default | Indices |
+	// +-----------------+------+------+---------+---------+
+	// | f"oo            | INT  | true | NULL    | {}      |
+	// | f'oo            | INT  | true | NULL    | {}      |
+	// | f\oo            | INT  | true | NULL    | {}      |
+	// | short␤          | INT  | true | NULL    | {}      |
+	// | very very long␤ |      |      |         |         |
+	// | not much        |      |      |         |         |
+	// | very very long␤ | INT  | true | NULL    | {}      |
+	// | thenshort       |      |      |         |         |
+	// | κόσμε           | INT  | true | NULL    | {}      |
+	// | a|b             | INT  | true | NULL    | {}      |
+	// | ܈85             | INT  | true | NULL    | {}      |
+	// +-----------------+------+------+---------+---------+
+	// (8 rows)
 	// sql --format=pretty -e select * from t.u
-	// +------+------+------+----------+-------+-----+-----+
-	// | f"oo | f'oo | f\oo | foo\nbar | κόσμε | a|b | ܈85 |
-	// +------+------+------+----------+-------+-----+-----+
-	// |    0 |    0 |    0 |        0 |     0 |   0 |   0 |
-	// +------+------+------+----------+-------+-----+-----+
+	// +------+------+------+----------------+----------------+-------+-----+-----+
+	// | f"oo | f'oo | f\oo |     short      | very very long | κόσμε | a|b | ܈85 |
+	// |      |      |      | very very long |   thenshort    |       |     |     |
+	// |      |      |      |    not much    |                |       |     |     |
+	// +------+------+------+----------------+----------------+-------+-----+-----+
+	// |    0 |    0 |    0 |              0 |              0 |     0 |   0 |   0 |
+	// +------+------+------+----------------+----------------+-------+-----+-----+
 	// (1 row)
 	// sql --format=tsv -e select * from t.u
-	// "f""oo"	f'oo	f\oo	foo\nbar	κόσμε	a|b	܈85
-	// 0	0	0	0	0	0	0
+	// "f""oo"	f'oo	f\oo	"short
+	// very very long
+	// not much"	"very very long
+	// thenshort"	κόσμε	a|b	܈85
+	// 0	0	0	0	0	0	0	0
 	// # 1 row
 	// sql --format=csv -e select * from t.u
-	// "f""oo",f'oo,f\oo,foo\nbar,κόσμε,a|b,܈85
-	// 0,0,0,0,0,0,0
+	// "f""oo",f'oo,f\oo,"short
+	// very very long
+	// not much","very very long
+	// thenshort",κόσμε,a|b,܈85
+	// 0,0,0,0,0,0,0,0
 	// # 1 row
 	// sql --format=pretty -e select * from t.u
-	// +------+------+------+----------+-------+-----+-----+
-	// | f"oo | f'oo | f\oo | foo\nbar | κόσμε | a|b | ܈85 |
-	// +------+------+------+----------+-------+-----+-----+
-	// |    0 |    0 |    0 |        0 |     0 |   0 |   0 |
-	// +------+------+------+----------+-------+-----+-----+
+	// +------+------+------+----------------+----------------+-------+-----+-----+
+	// | f"oo | f'oo | f\oo |     short      | very very long | κόσμε | a|b | ܈85 |
+	// |      |      |      | very very long |   thenshort    |       |     |     |
+	// |      |      |      |    not much    |                |       |     |     |
+	// +------+------+------+----------------+----------------+-------+-----+-----+
+	// |    0 |    0 |    0 |              0 |              0 |     0 |   0 |   0 |
+	// +------+------+------+----------------+----------------+-------+-----+-----+
 	// (1 row)
 	// sql --format=records -e select * from t.u
 	// -[ RECORD 1 ]
-	// f"oo     | 0
-	// f'oo     | 0
-	// f\oo     | 0
-	// foo\nbar | 0
-	// κόσμε    | 0
-	// a|b      | 0
-	// ܈85      | 0
+	// f"oo           | 0
+	// f'oo           | 0
+	// f\oo           | 0
+	// short         +| 0
+	// very very long+|
+	// not much       |
+	// very very long+| 0
+	// thenshort      |
+	// κόσμε          | 0
+	// a|b            | 0
+	// ܈85            | 0
 	// sql --format=sql -e select * from t.u
 	// CREATE TABLE results (
 	//   "f""oo" STRING,
 	//   "f'oo" STRING,
 	//   "f\oo" STRING,
-	//   "foo\nbar" STRING,
+	//   "short
+	// very very long
+	// not much" STRING,
+	//   "very very long
+	// thenshort" STRING,
 	//   "κόσμε" STRING,
 	//   "a|b" STRING,
 	//   ܈85 STRING
 	// );
 	//
-	// INSERT INTO results VALUES ('0', '0', '0', '0', '0', '0', '0');
+	// INSERT INTO results VALUES ('0', '0', '0', '0', '0', '0', '0', '0');
 	// sql --format=html -e select * from t.u
 	// <table>
-	// <thead><tr><th>row</th><th>f&#34;oo</th><th>f&#39;oo</th><th>f\oo</th><th>foo\nbar</th><th>κόσμε</th><th>a|b</th><th>܈85</th></tr></head>
+	// <thead><tr><th>row</th><th>f&#34;oo</th><th>f&#39;oo</th><th>f\oo</th><th>short<br/>very very long<br/>not much</th><th>very very long<br/>thenshort</th><th>κόσμε</th><th>a|b</th><th>܈85</th></tr></head>
 	// <tbody>
-	// <tr><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
+	// <tr><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 	// </tbody>
-	// <tfoot><tr><td colspan=8>1 row</td></tr></tfoot></table>
+	// <tfoot><tr><td colspan=9>1 row</td></tr></tfoot></table>
 	// sql --format=raw -e select * from t.u
-	// # 7 columns
+	// # 8 columns
 	// # row 1
+	// ## 1
+	// 0
 	// ## 1
 	// 0
 	// ## 1
@@ -1021,6 +1055,14 @@ def`,
 		c.RunWithArgs([]string{"sql", "--format=tsv", "-e", sql})
 	}
 
+	for _, identStr := range testData {
+		escaped1 := tree.NameString(identStr + "1")
+		escaped2 := tree.NameString(identStr + "2")
+		sql := "select 1 as " + escaped1 + ", 2 as " + escaped2
+		c.RunWithArgs([]string{"sql", "--format=csv", "-e", sql})
+		c.RunWithArgs([]string{"sql", "--format=tsv", "-e", sql})
+	}
+
 	// Output:
 	// sql --format=csv -e select 'ab' as s, 'ab' as t
 	// s,t
@@ -1093,6 +1135,86 @@ def`,
 	// sql --format=tsv -e select e'a\tb' as s, e'a\tb' as t
 	// s	t
 	// "a	b"	"a	b"
+	// # 1 row
+	// sql --format=csv -e select 1 as ab1, 2 as ab2
+	// ab1,ab2
+	// 1,2
+	// # 1 row
+	// sql --format=tsv -e select 1 as ab1, 2 as ab2
+	// ab1	ab2
+	// 1	2
+	// # 1 row
+	// sql --format=csv -e select 1 as "a b1", 2 as "a b2"
+	// a b1,a b2
+	// 1,2
+	// # 1 row
+	// sql --format=tsv -e select 1 as "a b1", 2 as "a b2"
+	// a b1	a b2
+	// 1	2
+	// # 1 row
+	// sql --format=csv -e select 1 as "a
+	// bc
+	// def1", 2 as "a
+	// bc
+	// def2"
+	// "a
+	// bc
+	// def1","a
+	// bc
+	// def2"
+	// 1,2
+	// # 1 row
+	// sql --format=tsv -e select 1 as "a
+	// bc
+	// def1", 2 as "a
+	// bc
+	// def2"
+	// "a
+	// bc
+	// def1"	"a
+	// bc
+	// def2"
+	// 1	2
+	// # 1 row
+	// sql --format=csv -e select 1 as "a, b1", 2 as "a, b2"
+	// "a, b1","a, b2"
+	// 1,2
+	// # 1 row
+	// sql --format=tsv -e select 1 as "a, b1", 2 as "a, b2"
+	// a, b1	a, b2
+	// 1	2
+	// # 1 row
+	// sql --format=csv -e select 1 as """a"", ""b""1", 2 as """a"", ""b""2"
+	// """a"", ""b""1","""a"", ""b""2"
+	// 1,2
+	// # 1 row
+	// sql --format=tsv -e select 1 as """a"", ""b""1", 2 as """a"", ""b""2"
+	// """a"", ""b""1"	"""a"", ""b""2"
+	// 1	2
+	// # 1 row
+	// sql --format=csv -e select 1 as "'a', 'b'1", 2 as "'a', 'b'2"
+	// "'a', 'b'1","'a', 'b'2"
+	// 1,2
+	// # 1 row
+	// sql --format=tsv -e select 1 as "'a', 'b'1", 2 as "'a', 'b'2"
+	// 'a', 'b'1	'a', 'b'2
+	// 1	2
+	// # 1 row
+	// sql --format=csv -e select 1 as "a\,b1", 2 as "a\,b2"
+	// "a\,b1","a\,b2"
+	// 1,2
+	// # 1 row
+	// sql --format=tsv -e select 1 as "a\,b1", 2 as "a\,b2"
+	// a\,b1	a\,b2
+	// 1	2
+	// # 1 row
+	// sql --format=csv -e select 1 as "a	b1", 2 as "a	b2"
+	// a	b1,a	b2
+	// 1,2
+	// # 1 row
+	// sql --format=tsv -e select 1 as "a	b1", 2 as "a	b2"
+	// "a	b1"	"a	b2"
+	// 1	2
 	// # 1 row
 }
 
@@ -1194,21 +1316,21 @@ func Example_sql_table() {
 	// 12	123123213	12313",tabs
 	// # 9 rows
 	// sql --format=pretty -e select * from t.t
-	// +--------------------------------+--------------------------------+
-	// |               s                |               d                |
-	// +--------------------------------+--------------------------------+
-	// | foo                            | printable ASCII                |
-	// | "foo                           | printable ASCII with quotes    |
-	// | \foo                           | printable ASCII with backslash |
-	// | foo␤                           | non-printable ASCII            |
-	// | bar                            |                                |
-	// | κόσμε                          | printable UTF8                 |
-	// | ñ                              | printable UTF8 using escapes   |
-	// | \x01                           | non-printable UTF8 string      |
-	// | ܈85                            | UTF8 string with RTL char      |
-	// | a   b         c␤               | tabs                           |
-	// | 12  123123213 12313            |                                |
-	// +--------------------------------+--------------------------------+
+	// +---------------------+--------------------------------+
+	// |          s          |               d                |
+	// +---------------------+--------------------------------+
+	// | foo                 | printable ASCII                |
+	// | "foo                | printable ASCII with quotes    |
+	// | \foo                | printable ASCII with backslash |
+	// | foo␤                | non-printable ASCII            |
+	// | bar                 |                                |
+	// | κόσμε               | printable UTF8                 |
+	// | ñ                   | printable UTF8 using escapes   |
+	// | \x01                | non-printable UTF8 string      |
+	// | ܈85                 | UTF8 string with RTL char      |
+	// | a   b         c␤    | tabs                           |
+	// | 12  123123213 12313 |                                |
+	// +---------------------+--------------------------------+
 	// (9 rows)
 	// sql --format=records -e select * from t.t
 	// -[ RECORD 1 ]

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -782,7 +783,7 @@ func Example_sql_column_labels() {
 	// ܈85	INT	true	NULL	{}
 	// # 6 rows
 	// sql -e select * from t.u
-	// """foo"	\foo	"""foo\nbar"""	κόσμε	a|b	܈85
+	// """foo"	\foo	foo\nbar	κόσμε	a|b	܈85
 	// 0	0	0	0	0	0
 	// # 1 row
 	// sql --format=pretty -e show columns from t.u
@@ -799,25 +800,25 @@ func Example_sql_column_labels() {
 	// +---------+------+------+---------+---------+
 	// (6 rows)
 	// sql --format=pretty -e select * from t.u
-	// +------+------+------------+-------+-----+-----+
-	// | "foo | \foo | "foo\nbar" | κόσμε | a|b | ܈85 |
-	// +------+------+------------+-------+-----+-----+
-	// |    0 |    0 |          0 |     0 |   0 |   0 |
-	// +------+------+------------+-------+-----+-----+
+	// +------+------+----------+-------+-----+-----+
+	// | "foo | \foo | foo\nbar | κόσμε | a|b | ܈85 |
+	// +------+------+----------+-------+-----+-----+
+	// |    0 |    0 |        0 |     0 |   0 |   0 |
+	// +------+------+----------+-------+-----+-----+
 	// (1 row)
 	// sql --format=tsv -e select * from t.u
-	// """foo"	\foo	"""foo\nbar"""	κόσμε	a|b	܈85
+	// """foo"	\foo	foo\nbar	κόσμε	a|b	܈85
 	// 0	0	0	0	0	0
 	// # 1 row
 	// sql --format=csv -e select * from t.u
-	// """foo",\foo,"""foo\nbar""",κόσμε,a|b,܈85
+	// """foo",\foo,foo\nbar,κόσμε,a|b,܈85
 	// 0,0,0,0,0,0
 	// # 1 row
 	// sql --format=sql -e select * from t.u
 	// CREATE TABLE results (
 	//   """foo" STRING,
 	//   "\foo" STRING,
-	//   """foo\nbar""" STRING,
+	//   "foo\nbar" STRING,
 	//   "κόσμε" STRING,
 	//   "a|b" STRING,
 	//   ܈85 STRING
@@ -826,19 +827,19 @@ func Example_sql_column_labels() {
 	// INSERT INTO results VALUES ('0', '0', '0', '0', '0', '0');
 	// sql --format=html -e select * from t.u
 	// <table>
-	// <thead><tr><th>row</th><th>&#34;foo</th><th>\foo</th><th>&#34;foo\nbar&#34;</th><th>κόσμε</th><th>a|b</th><th>܈85</th></tr></head>
+	// <thead><tr><th>row</th><th>&#34;foo</th><th>\foo</th><th>foo\nbar</th><th>κόσμε</th><th>a|b</th><th>܈85</th></tr></head>
 	// <tbody>
 	// <tr><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td></tr>
 	// </tbody>
 	// <tfoot><tr><td colspan=7>1 row</td></tr></tfoot></table>
 	// sql --format=records -e select * from t.u
 	// -[ RECORD 1 ]
-	// "foo       | 0
-	// \foo       | 0
-	// "foo\nbar" | 0
-	// κόσμε      | 0
-	// a|b        | 0
-	// ܈85        | 0
+	// "foo     | 0
+	// \foo     | 0
+	// foo\nbar | 0
+	// κόσμε    | 0
+	// a|b      | 0
+	// ܈85      | 0
 }
 
 func Example_sql_empty_table() {
@@ -948,6 +949,73 @@ func Example_sql_empty_table() {
 	// (0 rows)
 }
 
+func Example_csv_tsv_quoting() {
+	c := newCLITest(cliTestParams{})
+	defer c.cleanup()
+
+	testData := []string{
+		`ab`,
+		`a b`,
+		`a
+b`,
+		`a, b`,
+		`"a", "b"`,
+	}
+
+	for _, sqlStr := range testData {
+		escaped := lex.EscapeSQLString(sqlStr)
+		sql := "select " + escaped + " as s, " + escaped + " as t"
+		c.RunWithArgs([]string{"sql", "--format=csv", "-e", sql})
+		c.RunWithArgs([]string{"sql", "--format=tsv", "-e", sql})
+	}
+
+	// Output:
+	// sql --format=csv -e select 'ab' as s, 'ab' as t
+	// s,t
+	// ab,ab
+	// # 1 row
+	// sql --format=tsv -e select 'ab' as s, 'ab' as t
+	// s	t
+	// ab	ab
+	// # 1 row
+	// sql --format=csv -e select 'a b' as s, 'a b' as t
+	// s,t
+	// a b,a b
+	// # 1 row
+	// sql --format=tsv -e select 'a b' as s, 'a b' as t
+	// s	t
+	// a b	a b
+	// # 1 row
+	// sql --format=csv -e select e'a\nb' as s, e'a\nb' as t
+	// s,t
+	// "a
+	// b","a
+	// b"
+	// # 1 row
+	// sql --format=tsv -e select e'a\nb' as s, e'a\nb' as t
+	// s	t
+	// "a
+	// b"	"a
+	// b"
+	// # 1 row
+	// sql --format=csv -e select 'a, b' as s, 'a, b' as t
+	// s,t
+	// "a, b","a, b"
+	// # 1 row
+	// sql --format=tsv -e select 'a, b' as s, 'a, b' as t
+	// s	t
+	// a, b	a, b
+	// # 1 row
+	// sql --format=csv -e select '"a", "b"' as s, '"a", "b"' as t
+	// s,t
+	// """a"", ""b""","""a"", ""b"""
+	// # 1 row
+	// sql --format=tsv -e select '"a", "b"' as s, '"a", "b"' as t
+	// s	t
+	// """a"", ""b"""	"""a"", ""b"""
+	// # 1 row
+}
+
 func Example_sql_table() {
 	c := newCLITest(cliTestParams{})
 	defer c.cleanup()
@@ -1010,7 +1078,7 @@ func Example_sql_table() {
 	// bar"	non-printable ASCII
 	// κόσμε	printable UTF8
 	// ñ	printable UTF8 using escapes
-	// """\x01"""	non-printable UTF8 string
+	// \x01	non-printable UTF8 string
 	// ܈85	UTF8 string with RTL char
 	// "a	b	c
 	// 12	123123213	12313"	tabs
@@ -1026,7 +1094,7 @@ func Example_sql_table() {
 	// | bar                            |                                |
 	// | κόσμε                          | printable UTF8                 |
 	// | ñ                              | printable UTF8 using escapes   |
-	// | "\x01"                         | non-printable UTF8 string      |
+	// | \x01                           | non-printable UTF8 string      |
 	// | ܈85                            | UTF8 string with RTL char      |
 	// | a   b         c␤               | tabs                           |
 	// | 12  123123213 12313            |                                |
@@ -1041,7 +1109,7 @@ func Example_sql_table() {
 	// bar"	non-printable ASCII
 	// κόσμε	printable UTF8
 	// ñ	printable UTF8 using escapes
-	// """\x01"""	non-printable UTF8 string
+	// \x01	non-printable UTF8 string
 	// ܈85	UTF8 string with RTL char
 	// "a	b	c
 	// 12	123123213	12313"	tabs
@@ -1055,7 +1123,7 @@ func Example_sql_table() {
 	// bar",non-printable ASCII
 	// κόσμε,printable UTF8
 	// ñ,printable UTF8 using escapes
-	// """\x01""",non-printable UTF8 string
+	// \x01,non-printable UTF8 string
 	// ܈85,UTF8 string with RTL char
 	// "a	b	c
 	// 12	123123213	12313",tabs
@@ -1072,7 +1140,7 @@ func Example_sql_table() {
 	// INSERT INTO results VALUES (e'foo\nbar', 'non-printable ASCII');
 	// INSERT INTO results VALUES (e'\u03BA\U00001F79\u03C3\u03BC\u03B5', 'printable UTF8');
 	// INSERT INTO results VALUES (e'\u00F1', 'printable UTF8 using escapes');
-	// INSERT INTO results VALUES (e'"\\x01"', 'non-printable UTF8 string');
+	// INSERT INTO results VALUES (e'\\x01', 'non-printable UTF8 string');
 	// INSERT INTO results VALUES (e'\u070885', 'UTF8 string with RTL char');
 	// INSERT INTO results VALUES (e'a\tb\tc\n12\t123123213\t12313', 'tabs');
 	// sql --format=html -e select * from t.t
@@ -1085,7 +1153,7 @@ func Example_sql_table() {
 	// <tr><td>4</td><td>foo<br/>bar</td><td>non-printable ASCII</td></tr>
 	// <tr><td>5</td><td>κόσμε</td><td>printable UTF8</td></tr>
 	// <tr><td>6</td><td>ñ</td><td>printable UTF8 using escapes</td></tr>
-	// <tr><td>7</td><td>&#34;\x01&#34;</td><td>non-printable UTF8 string</td></tr>
+	// <tr><td>7</td><td>\x01</td><td>non-printable UTF8 string</td></tr>
 	// <tr><td>8</td><td>܈85</td><td>UTF8 string with RTL char</td></tr>
 	// <tr><td>9</td><td>a	b	c<br/>12	123123213	12313</td><td>tabs</td></tr>
 	// </tbody>
@@ -1124,8 +1192,8 @@ func Example_sql_table() {
 	// ## 28
 	// printable UTF8 using escapes
 	// # row 7
-	// ## 6
-	// "\x01"
+	// ## 4
+	// \x01
 	// ## 25
 	// non-printable UTF8 string
 	// # row 8
@@ -1161,7 +1229,7 @@ func Example_sql_table() {
 	// s | ñ
 	// d | printable UTF8 using escapes
 	// -[ RECORD 7 ]
-	// s | "\x01"
+	// s | \x01
 	// d | non-printable UTF8 string
 	// -[ RECORD 8 ]
 	// s | ܈85

--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -236,6 +236,7 @@ const (
 	tableDisplaySQL
 	tableDisplayHTML
 	tableDisplayRaw
+	tableDisplayLastFormat
 )
 
 // Type implements the pflag.Value interface.

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -726,7 +726,10 @@ func formatVal(val driver.Value, showPrintableUnicode bool, showNewLinesAndTabs 
 				return t
 			}
 		}
-		return fmt.Sprintf("%+q", t)
+		s := fmt.Sprintf("%+q", t)
+		// Strip the start and final quotes. The surrounding display
+		// format (e.g. CSV/TSV) will add its own quotes.
+		return s[1 : len(s)-1]
 
 	case []byte:
 		if showPrintableUnicode {
@@ -742,7 +745,10 @@ func formatVal(val driver.Value, showPrintableUnicode bool, showNewLinesAndTabs 
 				return string(t)
 			}
 		}
-		return fmt.Sprintf("%+q", t)
+		// Strip the start and final quotes. The surrounding display
+		// format (e.g. CSV/TSV) will add its own quotes.
+		s := fmt.Sprintf("%+q", t)
+		return s[1 : len(s)-1]
 
 	case time.Time:
 		return t.Format(tree.TimestampOutputFormat)

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -595,7 +595,7 @@ func runQueryAndFormatResults(conn *sqlConn, w io.Writer, fn queryFunc) error {
 			return false, nil
 		}
 
-		cols := getColumnStrings(rows)
+		cols := getColumnStrings(rows, true)
 		reporter, err := makeReporter()
 		if err != nil {
 			return err
@@ -624,14 +624,14 @@ func runQueryAndFormatResults(conn *sqlConn, w io.Writer, fn queryFunc) error {
 }
 
 // sqlRowsToStrings turns 'rows' into a list of rows, each of which
-// is a  list of column values.
+// is a list of column values.
 // 'rows' should be closed by the caller.
 // It returns the header row followed by all data rows.
 // If both the header row and list of rows are empty, it means no row
 // information was returned (eg: statement was not a query).
 // If showMoreChars is true, then more characters are not escaped.
 func sqlRowsToStrings(rows *sqlRows, showMoreChars bool) ([]string, [][]string, error) {
-	cols := getColumnStrings(rows)
+	cols := getColumnStrings(rows, showMoreChars)
 	allRows, err := getAllRowStrings(rows, showMoreChars)
 	if err != nil {
 		return nil, nil, err
@@ -639,11 +639,11 @@ func sqlRowsToStrings(rows *sqlRows, showMoreChars bool) ([]string, [][]string, 
 	return cols, allRows, nil
 }
 
-func getColumnStrings(rows *sqlRows) []string {
+func getColumnStrings(rows *sqlRows, showMoreChars bool) []string {
 	srcCols := rows.Columns()
 	cols := make([]string, len(srcCols))
 	for i, c := range srcCols {
-		cols[i] = formatVal(c, true, false)
+		cols[i] = formatVal(c, showMoreChars, showMoreChars)
 	}
 	return cols
 }

--- a/pkg/cli/sql_util_test.go
+++ b/pkg/cli/sql_util_test.go
@@ -127,8 +127,8 @@ SET
 	}
 
 	expectedRows := [][]string{
-		{`parentID`, `INT`, `false`, `NULL`, `"{\"primary\"}"`},
-		{`name`, `STRING`, `false`, `NULL`, `"{\"primary\"}"`},
+		{`parentID`, `INT`, `false`, `NULL`, `{\"primary\"}`},
+		{`name`, `STRING`, `false`, `NULL`, `{\"primary\"}`},
 		{`id`, `INT`, `true`, `NULL`, `{}`},
 	}
 	if !reflect.DeepEqual(expectedRows, rows) {


### PR DESCRIPTION
(This is the bug fix prefix to #18576. Pulling as separate PR since the other PR is likely to iterate longer.)

Fixes #19307.
Fixes #20848.

Prior to this patch, the CLI tools that display SQL rows (namely,
`sql`, `user`, `zone`) would make an effort to display anything with
the Unicode graphical property, and all whitespace, unchanged.

As this is the most common case, a bug slipped through: when a
character is neither graphical nor whitespace, it would erroneously
get processed two times for escape: a first one by the low-level value
formatter, and a second time by the table formatter.

For example:

```
> cockroach sql -e "select e'\x01' as x"
x
"""\x01"""
(1 row)
```

The triple quotes in the output were because first the ASCII 1 byte
would be escaped to the string `"\x01"` (first layer of quoting), then
the TSV formatter would introduce the additional necessary CSV escapes
by tripling them.

The error was that although the content of the string must be escaped
by the first-level formatter, that formatter should not introduce
boundary quotes -- the boundary quoting is under the responsibility of
the table formatter.

With this patch   :

```
> cockroach sql -e "select e'\x01' as x"
x
\x01
(1 row)
```

Note that although this patch addresses the most egregious
consequences of the original bug, the approach is arguably not yet
complete: we probably would like the SQL formatter to insert values
that are *equivalent* to those received from the server; this means
that *whether to quote or not should be decided by the formatter*.
Note that only the `raw` and `sql` formatters may be interested in
this change; the more common `pretty`, `tsv`, `csv` and `records`
formatter are fine as-is. A subsequent commit can introduce the
corresponding necessary plumbing.