### PR TITLE
cli/sql: fix multiline stmts with smart_prompt disabled

### DIFF
--- a/pkg/cli/interactive_tests/test_multiline_statements.tcl
+++ b/pkg/cli/interactive_tests/test_multiline_statements.tcl
@@ -71,6 +71,20 @@ eexpect "1 row"
 eexpect "root@"
 end_test
 
+start_test "Test that BEGIN .. without COMMIT also begins a multi-line statement with smart_prompt disabled."
+# Issue #19219.
+send "\\unset smart_prompt\r"
+send "begin; select 1;\r"
+eexpect " ->"
+send "commit;\r"
+eexpect root@
+send "begin; select 1;\r"
+eexpect " ->"
+send "commit;\r"
+eexpect "root@"
+send "\\set smart_prompt\r"
+end_test
+
 start_test "Test that BEGIN .. without COMMIT does not begin a multi-line statement in open txns. #16833"
 
 # trigger the error state

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -458,6 +458,8 @@ func (c *cliState) doRefreshPrompts(nextState cliStateEnum) cliStateEnum {
 		}
 
 		c.fullPrompt += dbStr + c.lastKnownTxnStatus
+	} else {
+		c.lastKnownTxnStatus = ""
 	}
 
 	c.continuePrompt = strings.Repeat(" ", len(c.fullPrompt)-1) + "-> "


### PR DESCRIPTION
Fixes #19219.