### PR TITLE
cli/sql: accept semicolons after client-local commands

### DIFF
--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -171,6 +171,16 @@ eexpect "with no argument"
 eexpect root@
 end_test
 
+start_test "Check that commands are also recognized with a final semicolon."
+send "\\set;\r"
+eexpect "display_format"
+eexpect root@
+send "\\h select;\r"
+eexpect SELECT
+eexpect Description
+eexpect root@
+end_test
+
 # Finally terminate with Ctrl+C.
 interrupt
 eexpect eof

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -783,7 +783,11 @@ func (c *cliState) doHandleCliCmd(loopState, nextState cliStateEnum) cliStateEnu
 	// to handle it as a statement, so save the history.
 	c.addHistory(c.lastInputLine)
 
-	cmd := strings.Fields(c.lastInputLine)
+	// As a convenience to the user, we strip the final semicolon, if
+	// any, in all cases.
+	line := strings.TrimRight(c.lastInputLine, "; ")
+
+	cmd := strings.Fields(line)
 	switch cmd[0] {
 	case `\q`, `\quit`, `\exit`:
 		return cliStop


### PR DESCRIPTION
Fixes #19022.