### PR TITLE
build: Make sure to base RHEL Docker images off the latest base

### DIFF
--- a/build/deploy/rhel/Dockerfile
+++ b/build/deploy/rhel/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel-atomic
+FROM registry.access.redhat.com/rhel-atomic:latest
 
 MAINTAINER Alex Robinson <alex@cockroachlabs.com>
 

--- a/build/deploy/rhel/build.sh
+++ b/build/deploy/rhel/build.sh
@@ -6,5 +6,5 @@ set -ux
 # them up afterwards) because docker build can't access resources
 # from parent directories.
 cp ../../../LICENSE ../../../APL.txt ../cockroach.sh ../cockroach ./
-docker build --no-cache -t cockroachdb:${VERSION} .
+docker build --no-cache --pull -t cockroachdb:${VERSION} .
 rm LICENSE APL.txt cockroach.sh cockroach


### PR DESCRIPTION
To make sure that we're always using the latest base image, particularly
when doing rebuilds to handle security issues in the base image.