### PR TITLE
engine: Fix splitting to work on ranges with a very large first row

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -222,7 +222,7 @@ typedef struct {
 MVCCStatsResult MVCCComputeStats(DBIterator* iter, DBKey start, DBKey end, int64_t now_nanos);
 
 bool MVCCIsValidSplitKey(DBSlice key, bool allow_meta2_splits);
-DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, 
+DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_split,
                           int64_t target_size, bool allow_meta2_splits, DBString* split_key);
 
 // DBStatsResult contains various runtime stats for RocksDB.

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -100,7 +100,7 @@ type Iterator interface {
 	// allowMeta2Splits is false.
 	//
 	// TODO: remove allowMeta2Splits in version 1.3.
-	FindSplitKey(start, end MVCCKey, targetSize int64, allowMeta2Splits bool) (MVCCKey, error)
+	FindSplitKey(start, end, minSplitKey MVCCKey, targetSize int64, allowMeta2Splits bool) (MVCCKey, error)
 }
 
 // Reader is the read interface to an engine's data.

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/zerofields"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -3129,11 +3130,30 @@ func TestFindSplitKey(t *testing.T) {
 // they avoid splits through invalid key ranges.
 func TestFindValidSplitKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	// Manually creates rows corresponding to the schema:
+	// CREATE TABLE t (id STRING PRIMARY KEY, col INT)
+	encodeTableKey := func(rowVal string, colFam uint32) roachpb.Key {
+		tableKey := keys.MakeTablePrefix(keys.MaxReservedDescID + 1)
+		rowKey := roachpb.Key(encoding.EncodeVarintAscending(append([]byte(nil), tableKey...), 1))
+		rowKey = encoding.EncodeStringAscending(encoding.EncodeVarintAscending(rowKey, 1), rowVal)
+		colKey := keys.MakeFamilyKey(append([]byte(nil), rowKey...), colFam)
+		return colKey
+	}
+	splitKeyFromTableKey := func(tableKey roachpb.Key) roachpb.Key {
+		splitKey, err := keys.EnsureSafeSplitKey(tableKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return splitKey
+	}
+
 	rangeID := roachpb.RangeID(1)
 	testCases := []struct {
-		keys     []roachpb.Key
-		expSplit roachpb.Key
-		expError bool
+		keys       []roachpb.Key
+		rangeStart roachpb.Key // optional
+		expSplit   roachpb.Key
+		expError   bool
 	}{
 		// All m1 cannot be split.
 		{
@@ -3212,6 +3232,53 @@ func TestFindValidSplitKeys(t *testing.T) {
 			expSplit: nil,
 			expError: false,
 		},
+		// Some example table data. Make sure we don't split in the middle of a row
+		// or return the start key of the range.
+		{
+			keys: []roachpb.Key{
+				encodeTableKey("a", 1),
+				encodeTableKey("a", 2),
+				encodeTableKey("a", 3),
+				encodeTableKey("a", 4),
+				encodeTableKey("a", 5),
+				encodeTableKey("b", 1),
+				encodeTableKey("c", 1),
+			},
+			rangeStart: splitKeyFromTableKey(encodeTableKey("a", 1)),
+			expSplit:   splitKeyFromTableKey(encodeTableKey("b", 1)),
+			expError:   false,
+		},
+		// More example table data. Make sure ranges at the start of a table can
+		// be split properly - this checks that the minSplitKey logic doesn't
+		// break for such ranges.
+		{
+			keys: []roachpb.Key{
+				encodeTableKey("a", 1),
+				encodeTableKey("b", 1),
+				encodeTableKey("c", 1),
+				encodeTableKey("d", 1),
+			},
+			rangeStart: keys.MakeTablePrefix(keys.MaxReservedDescID + 1),
+			expSplit:   splitKeyFromTableKey(encodeTableKey("c", 1)),
+			expError:   false,
+		},
+		// More example table data. Make sure ranges at the start of a table can
+		// be split properly (even if "properly" means creating an empty LHS,
+		// splitting here will at least allow the resulting RHS to split again).
+		{
+			keys: []roachpb.Key{
+				encodeTableKey("a", 1),
+				encodeTableKey("a", 2),
+				encodeTableKey("a", 3),
+				encodeTableKey("a", 4),
+				encodeTableKey("a", 5),
+				encodeTableKey("b", 1),
+				encodeTableKey("c", 1),
+			},
+			rangeStart: keys.MakeTablePrefix(keys.MaxReservedDescID + 1),
+			expSplit:   splitKeyFromTableKey(encodeTableKey("a", 1)),
+			expError:   false,
+		},
 	}
 
 	for i, test := range testCases {
@@ -3231,6 +3298,9 @@ func TestFindValidSplitKeys(t *testing.T) {
 				t.Fatal(err)
 			}
 			rangeStart := test.keys[0]
+			if len(test.rangeStart) > 0 {
+				rangeStart = test.rangeStart
+			}
 			rangeEnd := test.keys[len(test.keys)-1].Next()
 			rangeStartAddr, err := keys.Addr(rangeStart)
 			if err != nil {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1145,10 +1145,10 @@ func (r *rocksDBBatchIterator) ComputeStats(
 }
 
 func (r *rocksDBBatchIterator) FindSplitKey(
-	start, end MVCCKey, targetSize int64, allowMeta2Splits bool,
+	start, end, minSplitKey MVCCKey, targetSize int64, allowMeta2Splits bool,
 ) (MVCCKey, error) {
 	r.batch.flushMutations()
-	return r.iter.FindSplitKey(start, end, targetSize, allowMeta2Splits)
+	return r.iter.FindSplitKey(start, end, minSplitKey, targetSize, allowMeta2Splits)
 }
 
 func (r *rocksDBBatchIterator) Key() MVCCKey {
@@ -1748,10 +1748,10 @@ func (r *rocksDBIterator) ComputeStats(
 }
 
 func (r *rocksDBIterator) FindSplitKey(
-	start, end MVCCKey, targetSize int64, allowMeta2Splits bool,
+	start, end, minSplitKey MVCCKey, targetSize int64, allowMeta2Splits bool,
 ) (MVCCKey, error) {
 	var splitKey C.DBString
-	status := C.MVCCFindSplitKey(r.iter, goToCKey(start), goToCKey(end),
+	status := C.MVCCFindSplitKey(r.iter, goToCKey(start), goToCKey(end), goToCKey(minSplitKey),
 		C.int64_t(targetSize), C.bool(allowMeta2Splits), &splitKey)
 	if err := statusToError(status); err != nil {
 		return MVCCKey{}, err

--- a/pkg/storage/span_set.go
+++ b/pkg/storage/span_set.go
@@ -265,12 +265,12 @@ func (s *SpanSetIterator) ComputeStats(
 
 // FindSplitKey implements engine.Iterator.
 func (s *SpanSetIterator) FindSplitKey(
-	start, end engine.MVCCKey, targetSize int64, allowMeta2Splits bool,
+	start, end, minSplitKey engine.MVCCKey, targetSize int64, allowMeta2Splits bool,
 ) (engine.MVCCKey, error) {
 	if err := s.spans.checkAllowed(SpanReadOnly, roachpb.Span{Key: start.Key, EndKey: end.Key}); err != nil {
 		return engine.MVCCKey{}, err
 	}
-	return s.i.FindSplitKey(start, end, targetSize, allowMeta2Splits)
+	return s.i.FindSplitKey(start, end, minSplitKey, targetSize, allowMeta2Splits)
 }
 
 type spanSetReader struct {

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 const (
@@ -118,7 +119,9 @@ func (sq *splitQueue) process(ctx context.Context, r *Replica, sysCfg config.Sys
 			// If we couldn't find a split key, set the max-bytes for the range to
 			// double its current size to prevent future attempts to split the range
 			// until it grows again.
-			r.SetMaxBytes(size * 2)
+			newMaxBytes := size * 2
+			r.SetMaxBytes(newMaxBytes)
+			log.VEventf(ctx, 2, "couldn't find valid split key, growing max bytes to %d", newMaxBytes)
 		} else {
 			// We successfully split the range, reset max-bytes to the zone setting.
 			zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)


### PR DESCRIPTION
Previously, if the target split point was contained within the first SQL
row of a range, MVCCFindSplitKey would return a key within that first
row, which would prevent a split from happening because we only split on
row boundaries (and don't want to split on the first key in a range).
Now, we'll continue iterating until we find the first key that isn't
part of the first row in such ranges.

Fixes #19296 

Thanks to @jordanlewis for helping me figure out how to create keys to test this with.