### PR TITLE
acceptance: respect logDir in local clusters

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -293,6 +293,10 @@ func (c *Cluster) makeNode(ctx context.Context, nodeIdx int, cfg NodeConfig) (*N
 		fmt.Sprintf("--cache=256MiB"),
 	}
 
+	if n.Cfg.LogDir != "" {
+		args = append(args, fmt.Sprintf("--log-dir=%s", n.Cfg.LogDir))
+	}
+
 	n.Cfg.ExtraArgs = append(args, cfg.ExtraArgs...)
 
 	if err := os.MkdirAll(n.logDir(), 0755); err != nil {


### PR DESCRIPTION
Previously, local clusters would not respect the `-l` flag and always log
into their data directories (which are not saved in CI).