### PR TITLE
util/grpcutil: deflake TestShouldPrint

### DIFF
--- a/pkg/util/grpcutil/log_test.go
+++ b/pkg/util/grpcutil/log_test.go
@@ -21,6 +21,9 @@ import (
 	"regexp"
 	"testing"
 	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/petermattis/goid"
 )
 
 func TestShouldPrint(t *testing.T) {
@@ -78,9 +81,12 @@ func TestShouldPrint(t *testing.T) {
 						}
 					}
 
-					// Should print after sleep.
 					if !alwaysPrint {
-						time.Sleep(duration)
+						// Force printing by pretending the previous output was well in the
+						// past.
+						spamMu.Lock()
+						spamMu.gids[goid.Get()] = timeutil.Now().Add(-time.Hour)
+						spamMu.Unlock()
 					}
 					if !curriedShouldPrint() {
 						t.Error("expected third call to print")


### PR DESCRIPTION
An inopportune backwards time jump could cause a failure to print. Avoid
this by replacing a time.Sleep with whacking an older timestamp into
the `spamMu.gids` map.

Fixes #19335