### PR TITLE
config: learn to read subzones 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -162,7 +162,9 @@ const (
 	minRangeMaxBytes = 64 << 10 // 64 KB
 )
 
-type zoneConfigHook func(SystemConfig, uint32) (ZoneConfig, bool, error)
+type zoneConfigHook func(
+	sysCfg SystemConfig, objectID uint32, keySuffix []byte,
+) (zoneCfg ZoneConfig, found bool, err error)
 
 var (
 	// defaultZoneConfig is the default zone configuration used when no custom
@@ -184,8 +186,9 @@ var (
 		},
 	}
 
-	// ZoneConfigHook is a function used to lookup a zone config given a table
-	// or database ID.
+	// ZoneConfigHook is a function used to lookup a zone config given a table or
+	// database ID and the post-ID suffix of a key within that table or database.
+	//
 	// This is also used by testing to simplify fake configs.
 	ZoneConfigHook zoneConfigHook
 
@@ -304,19 +307,35 @@ func (z ZoneConfig) Validate() error {
 	return nil
 }
 
-// ObjectIDForKey returns the object ID (table or database) for 'key',
-// or (_, false) if not within the structured key space.
-func ObjectIDForKey(key roachpb.RKey) (uint32, bool) {
+// GetSubzoneForKeySuffix returns the ZoneConfig for the subzone that contains
+// keySuffix, if it exists.
+func (z ZoneConfig) GetSubzoneForKeySuffix(keySuffix []byte) (ZoneConfig, bool) {
+	// TODO(benesch): Use binary search instead.
+	for _, s := range z.SubzoneSpans {
+		// The span's Key is stored with the prefix removed, so we can compare
+		// directly to keySuffix. An unset EndKey implies Key.PrefixEnd().
+		if (s.Key.Compare(keySuffix) <= 0) &&
+			((s.EndKey == nil && bytes.HasPrefix(keySuffix, s.Key)) || s.EndKey.Compare(keySuffix) > 0) {
+			return z.Subzones[s.SubzoneIndex].Config, true
+		}
+	}
+	return ZoneConfig{}, false
+}
+
+// DecodeObjectID decodes the object ID from the front of key. It returns the
+// decoded object ID, the remainder of the key, and whether the result is valid
+// (i.e., whether the key was within the structured key space).
+func DecodeObjectID(key roachpb.RKey) (uint32, []byte, bool) {
 	if key.Equal(roachpb.RKeyMax) {
-		return 0, false
+		return 0, nil, false
 	}
 	if encoding.PeekType(key) != encoding.Int {
 		// TODO(marc): this should eventually return SystemDatabaseID.
-		return 0, false
+		return 0, nil, false
 	}
 	// Consume first encoded int.
-	_, id64, err := encoding.DecodeUvarintAscending(key)
-	return uint32(id64), err == nil
+	rem, id64, err := encoding.DecodeUvarintAscending(key)
+	return uint32(id64), rem, err == nil
 }
 
 // Equal checks for equality.
@@ -477,7 +496,7 @@ func (s SystemConfig) GetLargestObjectID(maxID uint32) (uint32, error) {
 // GetZoneConfigForKey looks up the zone config for the range containing 'key'.
 // It is the caller's responsibility to ensure that the range does not need to be split.
 func (s SystemConfig) GetZoneConfigForKey(key roachpb.RKey) (ZoneConfig, error) {
-	objectID, ok := ObjectIDForKey(key)
+	objectID, keySuffix, ok := DecodeObjectID(key)
 	if !ok {
 		// Not in the structured data namespace.
 		objectID = keys.RootNamespaceID
@@ -498,16 +517,16 @@ func (s SystemConfig) GetZoneConfigForKey(key roachpb.RKey) (ZoneConfig, error) 
 		objectID = keys.SystemRangesID
 	}
 
-	return s.getZoneConfigForID(objectID)
+	return s.getZoneConfigForID(objectID, keySuffix)
 }
 
 // getZoneConfigForID looks up the zone config for the object (table or database)
 // with 'id'.
-func (s SystemConfig) getZoneConfigForID(id uint32) (ZoneConfig, error) {
+func (s SystemConfig) getZoneConfigForID(id uint32, keySuffix []byte) (ZoneConfig, error) {
 	testingLock.Lock()
 	hook := ZoneConfigHook
 	testingLock.Unlock()
-	if cfg, found, err := hook(s, id); err != nil || found {
+	if cfg, found, err := hook(s, id, keySuffix); err != nil || found {
 		return cfg, err
 	}
 	return DefaultZoneConfig(), nil
@@ -581,7 +600,7 @@ func (s SystemConfig) ComputeSplitKey(startKey, endKey roachpb.RKey) roachpb.RKe
 
 	// If the above iteration over the static split points didn't decide anything,
 	// the key range must be somewhere in the SQL table part of the keyspace.
-	startID, ok := ObjectIDForKey(startKey)
+	startID, _, ok := DecodeObjectID(startKey)
 	if !ok || startID <= keys.MaxSystemConfigDescID {
 		// The start key is either:
 		// - not part of the structured data span

--- a/pkg/config/config.proto
+++ b/pkg/config/config.proto
@@ -27,6 +27,8 @@ import "gogoproto/gogo.proto";
 //   as well as whether there's an intersection between max values
 //   and TTL or a union.
 message GCPolicy {
+  option (gogoproto.equal) = true;
+
   // TTLSeconds specifies the maximum age of a value before it's
   // garbage collected. Only older versions of values are garbage
   // collected. Specifying <=0 mean older versions are never GC'd.
@@ -35,6 +37,7 @@ message GCPolicy {
 
 // Constraint constrains the stores a replica can be stored on.
 message Constraint {
+  option (gogoproto.equal) = true;
   option (gogoproto.goproto_stringer) = false;
 
   enum Type {
@@ -55,11 +58,15 @@ message Constraint {
 
 // Constraints is a collection of constraints.
 message Constraints {
+  option (gogoproto.equal) = true;
+
   repeated Constraint constraints = 6 [(gogoproto.nullable) = false];
 }
 
 // ZoneConfig holds configuration that applies to one or more ranges.
 message ZoneConfig {
+  option (gogoproto.equal) = true;
+
   reserved 1;
   optional int64 range_min_bytes = 2 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_min_bytes\""];
   optional int64 range_max_bytes = 3 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"range_max_bytes\""];
@@ -72,6 +79,56 @@ message ZoneConfig {
   // order in which the constraints are stored is arbitrary and may change.
   // https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20160706_expressive_zone_config.md#constraint-system
   optional Constraints constraints = 6 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"constraints,flow\""];
+
+  // Subzones stores config overrides for "subzones", each of which represents
+  // either a SQL table index or a partition of a SQL table index. Subzones are
+  // not applicable when the zone does not represent a SQL table (i.e., when the
+  // zone represents a database, a special system range, or is itself a
+  // subzone.)
+  repeated Subzone subzones = 8 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"-\""];
+
+  // SubzoneSpans maps each key span in a subzone to the slice index of an entry
+  // in SubzoneConfig. Spans are non-overlapping and sorted by start key to
+  // allow binary searching. SubzoneSpans can be easily derived from a
+  // TableDescriptor, but are denormalized here to make GetZoneConfigForKey
+  // lookups efficient.
+  repeated SubzoneSpan subzone_spans = 7 [(gogoproto.nullable) = false, (gogoproto.moretags) = "yaml:\"-\""];
+}
+
+message Subzone {
+  option (gogoproto.equal) = true;
+
+  // IndexID is the ID of the SQL table index that the subzone represents.
+  optional uint32 index_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "IndexID"];
+
+  // PartitionName is the partition of the SQL table index that the subzone
+  // represents. It is empty when the subzone represents the entire index.
+  optional string partition_name = 2 [(gogoproto.nullable) = false];
+
+  // Config stores the ZoneConfig that applies to this Subzone. It never
+  // contains nested subzones.
+  optional ZoneConfig config = 3 [(gogoproto.nullable) = false];
+}
+
+message SubzoneSpan {
+  option (gogoproto.equal) = true;
+
+  // Key stores a key suffix that represents the inclusive lower bound for this
+  // span. The SQL table prefix, like /Table/51/, is omitted.
+  //
+  // Both Key and EndKey, below, are cast to roachpb.Key for convenience, but
+  // there's no technical restriction that prevents switching them to []byte or
+  // another type that communicates their missing prefix.
+  optional bytes key = 1 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+
+  // EndKey stores a key suffix that represents the exclusive upper bound for
+  // this span. Like with Key, the SQL table prefix is omitted. If EndKey is
+  // empty, it is assumed to be Key.PrefixEnd().
+  optional bytes end_key = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+
+  // SubzoneIndex is the slice index of the Subzone this span belongs to in the
+  // parent ZoneConfig's Subzones field.
+  optional int32 subzone_index = 3 [(gogoproto.nullable) = false];
 }
 
 message SystemConfig {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -15,6 +15,7 @@
 package config_test
 
 import (
+	"bytes"
 	"fmt"
 	"sort"
 	"testing"
@@ -54,34 +55,38 @@ func kv(k, v []byte) roachpb.KeyValue {
 	}
 }
 
-func TestObjectIDForKey(t *testing.T) {
+func TestDecodeObjectID(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testCases := []struct {
-		key     roachpb.RKey
-		success bool
-		id      uint32
+		key       roachpb.RKey
+		keySuffix []byte
+		success   bool
+		id        uint32
 	}{
 		// Before the structured span.
-		{roachpb.RKeyMin, false, 0},
+		{roachpb.RKeyMin, nil, false, 0},
 
 		// Boundaries of structured span.
-		{roachpb.RKeyMax, false, 0},
+		{roachpb.RKeyMax, nil, false, 0},
 
 		// Valid, even if there are things after the ID.
-		{testutils.MakeKey(keys.MakeTablePrefix(42), roachpb.RKey("\xff")), true, 42},
-		{keys.MakeTablePrefix(0), true, 0},
-		{keys.MakeTablePrefix(999), true, 999},
+		{testutils.MakeKey(keys.MakeTablePrefix(42), roachpb.RKey("\xff")), []byte{'\xff'}, true, 42},
+		{keys.MakeTablePrefix(0), []byte{}, true, 0},
+		{keys.MakeTablePrefix(999), []byte{}, true, 999},
 	}
 
 	for tcNum, tc := range testCases {
-		id, success := config.ObjectIDForKey(tc.key)
+		id, keySuffix, success := config.DecodeObjectID(tc.key)
 		if success != tc.success {
 			t.Errorf("#%d: expected success=%t", tcNum, tc.success)
 			continue
 		}
 		if id != tc.id {
 			t.Errorf("#%d: expected id=%d, got %d", tcNum, tc.id, id)
+		}
+		if !bytes.Equal(keySuffix, tc.keySuffix) {
+			t.Errorf("#%d: expected suffix=%q, got %q", tcNum, tc.keySuffix, keySuffix)
 		}
 	}
 }
@@ -413,7 +418,7 @@ func TestGetZoneConfigForKey(t *testing.T) {
 	}
 	for tcNum, tc := range testCases {
 		var objectID uint32
-		config.ZoneConfigHook = func(_ config.SystemConfig, id uint32) (config.ZoneConfig, bool, error) {
+		config.ZoneConfigHook = func(_ config.SystemConfig, id uint32, _ []byte) (config.ZoneConfig, bool, error) {
 			objectID = id
 			return config.ZoneConfig{}, false, nil
 		}

--- a/pkg/config/testutil.go
+++ b/pkg/config/testutil.go
@@ -79,7 +79,7 @@ func TestingSetZoneConfig(id uint32, zone ZoneConfig) {
 	testingZoneConfig[id] = zone
 }
 
-func testingZoneConfigHook(_ SystemConfig, id uint32) (ZoneConfig, bool, error) {
+func testingZoneConfigHook(_ SystemConfig, id uint32, _ []byte) (ZoneConfig, bool, error) {
 	testingLock.Lock()
 	defer testingLock.Unlock()
 	if zone, ok := testingZoneConfig[id]; ok {

--- a/pkg/sql/config.go
+++ b/pkg/sql/config.go
@@ -38,16 +38,28 @@ var errNoZoneConfigApplies = errors.New("no zone config applies")
 //
 // This function must be kept in sync with ascendZoneSpecifier.
 func getZoneConfig(
-	id uint32, get func(roachpb.Key) (*roachpb.Value, error),
+	id uint32, keySuffix []byte, get func(roachpb.Key) (*roachpb.Value, error),
 ) (config.ZoneConfig, uint32, error) {
 	// Look in the zones table.
 	if zoneVal, err := get(sqlbase.MakeZoneKey(sqlbase.ID(id))); err != nil {
 		return config.ZoneConfig{}, 0, err
 	} else if zoneVal != nil {
-		// We're done.
+		// We found a matching entry.
 		var zone config.ZoneConfig
-		err := zoneVal.GetProto(&zone)
-		return zone, id, err
+		if err := zoneVal.GetProto(&zone); err != nil {
+			return config.ZoneConfig{}, 0, err
+		}
+		if subzone, found := zone.GetSubzoneForKeySuffix(keySuffix); found {
+			// The ZoneConfig has a more-specific index or partition subzone; use
+			// that.
+			return subzone, id, nil
+		}
+		// No subzone matched. If the parent zone specifies zero replicas, it
+		// existed only as a home for subzones, and we should keep recursing up the
+		// hierarchy. Otherwise, return the parent zone.
+		if zone.NumReplicas != 0 {
+			return zone, id, nil
+		}
 	}
 
 	// No zone config for this ID. We need to figure out if it's a table, so we
@@ -61,14 +73,15 @@ func getZoneConfig(
 		}
 		if tableDesc := desc.GetTable(); tableDesc != nil {
 			// This is a table descriptor. Look up its parent database zone config.
-			return getZoneConfig(uint32(tableDesc.ParentID), get)
+			// Don't forward keySuffix, because only tables can have subzones.
+			return getZoneConfig(uint32(tableDesc.ParentID), nil, get)
 		}
 	}
 
 	// Retrieve the default zone config, but only as long as that wasn't the ID
 	// we were trying to retrieve (avoid infinite recursion).
 	if id != keys.RootNamespaceID {
-		return getZoneConfig(keys.RootNamespaceID, get)
+		return getZoneConfig(keys.RootNamespaceID, nil, get)
 	}
 
 	// No descriptor or not a table.
@@ -77,8 +90,10 @@ func getZoneConfig(
 
 // GetZoneConfig returns the zone config for the object with 'id' using the
 // cached system config.
-func GetZoneConfig(cfg config.SystemConfig, id uint32) (config.ZoneConfig, bool, error) {
-	zone, _, err := getZoneConfig(id, func(key roachpb.Key) (*roachpb.Value, error) {
+func GetZoneConfig(
+	cfg config.SystemConfig, id uint32, keySuffix []byte,
+) (config.ZoneConfig, bool, error) {
+	zone, _, err := getZoneConfig(id, keySuffix, func(key roachpb.Key) (*roachpb.Value, error) {
 		return cfg.GetValue(key), nil
 	})
 	if err == errNoZoneConfigApplies {
@@ -91,9 +106,9 @@ func GetZoneConfig(cfg config.SystemConfig, id uint32) (config.ZoneConfig, bool,
 // GetZoneConfigInTxn is like GetZoneConfig, but uses the provided transaction
 // to perform lookups instead of the cached system config.
 func GetZoneConfigInTxn(
-	ctx context.Context, txn *client.Txn, id uint32,
+	ctx context.Context, txn *client.Txn, id uint32, keySuffix []byte,
 ) (config.ZoneConfig, uint32, error) {
-	return getZoneConfig(id, func(key roachpb.Key) (*roachpb.Value, error) {
+	return getZoneConfig(id, keySuffix, func(key roachpb.Key) (*roachpb.Value, error) {
 		kv, err := txn.Get(ctx, key)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/config_test.go
+++ b/pkg/sql/config_test.go
@@ -17,7 +17,6 @@ package sql_test
 import (
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -100,8 +99,9 @@ func TestGetZoneConfig(t *testing.T) {
 	defaultZoneConfig.GC.TTLSeconds = 60
 
 	type testCase struct {
-		objectID uint32
-		zoneCfg  config.ZoneConfig
+		objectID  uint32
+		keySuffix []byte
+		zoneCfg   config.ZoneConfig
 	}
 	verifyZoneConfigs := func(testCases []testCase) {
 		cfg := forceNewConfig(t, s)
@@ -109,22 +109,23 @@ func TestGetZoneConfig(t *testing.T) {
 		for tcNum, tc := range testCases {
 			// Verify SystemConfig.GetZoneConfigForKey.
 			{
-				zoneCfg, err := cfg.GetZoneConfigForKey(keys.MakeTablePrefix(tc.objectID))
+				key := append(keys.MakeTablePrefix(tc.objectID), tc.keySuffix...)
+				zoneCfg, err := cfg.GetZoneConfigForKey(key)
 				if err != nil {
 					t.Fatalf("#%d: err=%s", tcNum, err)
 				}
 
-				if !proto.Equal(&zoneCfg, &tc.zoneCfg) {
-					t.Errorf("#%d: bad zone config.\nexpected: %+v\ngot: %+v", tcNum, &tc.zoneCfg, zoneCfg)
+				if !tc.zoneCfg.Equal(zoneCfg) {
+					t.Errorf("#%d: bad zone config.\nexpected: %+v\ngot: %+v", tcNum, tc.zoneCfg, zoneCfg)
 				}
 			}
 
 			// Verify sql.GetZoneConfigInTxn.
 			if err := s.DB().Txn(context.Background(), func(ctx context.Context, txn *client.Txn) error {
-				if zoneCfg, _, err := sql.GetZoneConfigInTxn(ctx, txn, tc.objectID); err != nil {
+				if zoneCfg, _, err := sql.GetZoneConfigInTxn(ctx, txn, tc.objectID, tc.keySuffix); err != nil {
 					return err
-				} else if !proto.Equal(&zoneCfg, &tc.zoneCfg) {
-					t.Errorf("#%d: bad zone config.\nexpected: %+v\ngot: %+v", tcNum, &tc.zoneCfg, zoneCfg)
+				} else if !tc.zoneCfg.Equal(zoneCfg) {
+					t.Errorf("#%d: bad zone config.\nexpected: %+v\ngot: %+v", tcNum, tc.zoneCfg, zoneCfg)
 				}
 				return nil
 			}); err != nil {
@@ -191,26 +192,32 @@ func TestGetZoneConfig(t *testing.T) {
 
 	// We have no custom zone configs.
 	verifyZoneConfigs([]testCase{
-		{0, defaultZoneConfig},
-		{1, defaultZoneConfig},
-		{keys.MaxReservedDescID, defaultZoneConfig},
-		{db1, defaultZoneConfig},
-		{db2, defaultZoneConfig},
-		{tb11, defaultZoneConfig},
-		{tb12, defaultZoneConfig},
-		{tb21, defaultZoneConfig},
-		{tb22, defaultZoneConfig},
+		{0, nil, defaultZoneConfig},
+		{1, nil, defaultZoneConfig},
+		{keys.MaxReservedDescID, nil, defaultZoneConfig},
+		{db1, nil, defaultZoneConfig},
+		{db2, nil, defaultZoneConfig},
+		{tb11, nil, defaultZoneConfig},
+		{tb11, []byte{42}, defaultZoneConfig},
+		{tb12, nil, defaultZoneConfig},
+		{tb12, []byte{42}, defaultZoneConfig},
+		{tb21, nil, defaultZoneConfig},
+		{tb22, nil, defaultZoneConfig},
 	})
 
 	// Now set some zone configs. We don't have a nice way of using table
 	// names for this, so we do raw puts.
-	// Here is the list of dbs/tables and whether they have a custom zone config:
+	// Here is the list of dbs/tables/partitions and whether they have a custom
+	// zone config:
 	// db1: true
 	//   tb1: true
 	//   tb2: false
-	// db1: false
+	// db2: false
 	//   tb1: true
+	//     p1: true [1, 2), [6, 7)
+	//     p2: true [3, 5)
 	//   tb2: false
+	//     p1: true  [1, 255)
 	db1Cfg := config.ZoneConfig{
 		NumReplicas: 1,
 		Constraints: config.Constraints{Constraints: []config.Constraint{{Value: "db1"}}},
@@ -219,14 +226,40 @@ func TestGetZoneConfig(t *testing.T) {
 		NumReplicas: 1,
 		Constraints: config.Constraints{Constraints: []config.Constraint{{Value: "db1.tb1"}}},
 	}
+	p211Cfg := config.ZoneConfig{
+		NumReplicas: 1,
+		Constraints: config.Constraints{Constraints: []config.Constraint{{Value: "db2.tb1.p1"}}},
+	}
+	p212Cfg := config.ZoneConfig{
+		NumReplicas: 1,
+		Constraints: config.Constraints{Constraints: []config.Constraint{{Value: "db2.tb1.p2"}}},
+	}
 	tb21Cfg := config.ZoneConfig{
 		NumReplicas: 1,
 		Constraints: config.Constraints{Constraints: []config.Constraint{{Value: "db2.tb1"}}},
+		Subzones:    []config.Subzone{{Config: p211Cfg}, {Config: p212Cfg}},
+		SubzoneSpans: []config.SubzoneSpan{
+			{SubzoneIndex: 0, Key: []byte{1}},
+			{SubzoneIndex: 1, Key: []byte{3}, EndKey: []byte{5}},
+			{SubzoneIndex: 0, Key: []byte{6}},
+		},
+	}
+	p221Cfg := config.ZoneConfig{
+		NumReplicas: 1,
+		Constraints: config.Constraints{Constraints: []config.Constraint{{Value: "db2.tb2.p1"}}},
+	}
+	tb22Cfg := config.ZoneConfig{
+		NumReplicas: 0,
+		Subzones:    []config.Subzone{{Config: p221Cfg}},
+		SubzoneSpans: []config.SubzoneSpan{
+			{SubzoneIndex: 0, Key: []byte{1}, EndKey: []byte{255}},
+		},
 	}
 	for objID, objZone := range map[uint32]config.ZoneConfig{
 		db1:  db1Cfg,
 		tb11: tb11Cfg,
 		tb21: tb21Cfg,
+		tb22: tb22Cfg,
 	} {
 		buf, err := protoutil.Marshal(&objZone)
 		if err != nil {
@@ -238,15 +271,29 @@ func TestGetZoneConfig(t *testing.T) {
 	}
 
 	verifyZoneConfigs([]testCase{
-		{0, defaultZoneConfig},
-		{1, defaultZoneConfig},
-		{keys.MaxReservedDescID, defaultZoneConfig},
-		{db1, db1Cfg},
-		{db2, defaultZoneConfig},
-		{tb11, tb11Cfg},
-		{tb12, db1Cfg},
-		{tb21, tb21Cfg},
-		{tb22, defaultZoneConfig},
+		{0, nil, defaultZoneConfig},
+		{1, nil, defaultZoneConfig},
+		{keys.MaxReservedDescID, nil, defaultZoneConfig},
+		{db1, nil, db1Cfg},
+		{db2, nil, defaultZoneConfig},
+		{tb11, nil, tb11Cfg},
+		{tb11, []byte{42}, tb11Cfg},
+		{tb12, nil, db1Cfg},
+		{tb12, []byte{42}, db1Cfg},
+		{tb21, nil, tb21Cfg},
+		{tb21, []byte{}, tb21Cfg},
+		{tb21, []byte{0}, tb21Cfg},
+		{tb21, []byte{1}, p211Cfg},
+		{tb21, []byte{1, 255}, p211Cfg},
+		{tb21, []byte{2}, tb21Cfg},
+		{tb21, []byte{3}, p212Cfg},
+		{tb21, []byte{4}, p212Cfg},
+		{tb21, []byte{5}, tb21Cfg},
+		{tb21, []byte{6}, p211Cfg},
+		{tb22, nil, defaultZoneConfig},
+		{tb22, []byte{0}, defaultZoneConfig},
+		{tb22, []byte{1}, p221Cfg},
+		{tb22, []byte{255}, defaultZoneConfig},
 	})
 }
 

--- a/pkg/sql/zone.go
+++ b/pkg/sql/zone.go
@@ -159,7 +159,10 @@ func (n *setZoneConfigNode) Start(params runParams) error {
 		return err
 	}
 
-	proto, _, err := GetZoneConfigInTxn(params.ctx, params.p.txn, uint32(targetID))
+	// TODO(benesch): pass in a proper key suffix to support index/partition
+	// zone configs.
+	var keySuffix []byte
+	proto, _, err := GetZoneConfigInTxn(params.ctx, params.p.txn, uint32(targetID), keySuffix)
 	if err == errNoZoneConfigApplies {
 		// TODO(benesch): This shouldn't be the caller's responsibility;
 		// GetZoneConfigInTxn should just return the default zone config if no zone
@@ -234,7 +237,10 @@ func (n *showZoneConfigNode) Start(params runParams) error {
 	if err != nil {
 		return err
 	}
-	proto, zoneID, err := GetZoneConfigInTxn(params.ctx, params.p.txn, uint32(targetID))
+	// TODO(benesch): pass in a proper key suffix to support index/partition
+	// zone configs.
+	var keySuffix []byte
+	proto, zoneID, err := GetZoneConfigInTxn(params.ctx, params.p.txn, uint32(targetID), keySuffix)
 	if err == errNoZoneConfigApplies {
 		// TODO(benesch): This shouldn't be the caller's responsibility;
 		// GetZoneConfigInTxn should just return the default zone config if no zone


### PR DESCRIPTION
Ignore the first four commits; those are in #19315.

----

As described in the partitioning RFC, teach the config package how to
interpret subzones stored in a ZoneConfig. In the interest of minimizing
review burden, this commit does not introduce any codepaths outside of
tests that create ZoneConfigs with subzones.