### PR TITLE
util/interval: bucket multiple Ranges in single rangeList node

### DIFF
--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -59,6 +59,10 @@ type inclusiveOverlapper struct{}
 
 // Overlap checks where a and b overlap in the inclusive way.
 func (overlapper inclusiveOverlapper) Overlap(a Range, b Range) bool {
+	return overlapsInclusive(a, b)
+}
+
+func overlapsInclusive(a Range, b Range) bool {
 	return a.Start.Compare(b.End) <= 0 && b.Start.Compare(a.End) <= 0
 }
 
@@ -70,6 +74,10 @@ type exclusiveOverlapper struct{}
 
 // Overlap checks where a and b overlap in the exclusive way.
 func (overlapper exclusiveOverlapper) Overlap(a Range, b Range) bool {
+	return overlapsExclusive(a, b)
+}
+
+func overlapsExclusive(a Range, b Range) bool {
 	return a.Start.Compare(b.End) < 0 && b.Start.Compare(a.End) < 0
 }
 

--- a/pkg/util/interval/range_group_test.go
+++ b/pkg/util/interval/range_group_test.go
@@ -24,813 +24,722 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/util/log" // for flags
 )
 
-func TestRangeListAddSingleRangeAndClear(t *testing.T) {
-	testRangeGroupAddSingleRangeAndClear(t, NewRangeList())
-}
-
-func TestRangeTreeAddSingleRangeAndClear(t *testing.T) {
-	testRangeGroupAddSingleRangeAndClear(t, NewRangeTree())
-}
-
-func testRangeGroupAddSingleRangeAndClear(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-
-	if l := rg.Len(); l != 1 {
-		t.Errorf("added 1 range to range group, wanted len = 1; got len = %d", l)
-	}
-
-	rg.Clear()
-	if l := rg.Len(); l != 0 {
-		t.Errorf("cleared range group, wanted len = 0; got len = %d", l)
+func forEachRangeGroupImpl(t *testing.T, fn func(t *testing.T, rg RangeGroup)) {
+	for _, constr := range []func() RangeGroup{
+		NewRangeList,
+		NewRangeTree,
+	} {
+		rg := constr()
+		name := reflect.TypeOf(rg).Elem().Name()
+		t.Run(name, func(t *testing.T) {
+			fn(t, rg)
+		})
 	}
 }
 
-func TestRangeListAddTwoRangesBefore(t *testing.T) {
-	testRangeGroupAddTwoRangesBefore(t, NewRangeList())
-}
+func TestRangeGroupAddSingleRangeAndClear(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
 
-func TestRangeTreeAddTwoRangesBefore(t *testing.T) {
-	testRangeGroupAddTwoRangesBefore(t, NewRangeTree())
-}
+		if l := rg.Len(); l != 1 {
+			t.Errorf("added 1 range to range group, wanted len = 1; got len = %d", l)
+		}
 
-func testRangeGroupAddTwoRangesBefore(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-
-	if l := rg.Len(); l != 2 {
-		t.Errorf("added 2 disjoint ranges to range group, wanted len = 2; got len = %d", l)
-	}
-}
-
-func TestRangeListAddTwoRangesAfter(t *testing.T) {
-	testRangeGroupAddTwoRangesAfter(t, NewRangeList())
-}
-
-func TestRangeTreeAddTwoRangesAfter(t *testing.T) {
-	testRangeGroupAddTwoRangesAfter(t, NewRangeTree())
-}
-
-func testRangeGroupAddTwoRangesAfter(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-
-	if l := rg.Len(); l != 2 {
-		t.Errorf("added 2 disjoint ranges to range group, wanted len = 2; got len = %d", l)
-	}
-}
-
-func TestRangeListAddTwoRangesMergeForward(t *testing.T) {
-	testRangeGroupAddTwoRangesMergeForward(t, NewRangeList())
-}
-
-func TestRangeTreeAddTwoRangesMergeForward(t *testing.T) {
-	testRangeGroupAddTwoRangesMergeForward(t, NewRangeTree())
-}
-
-func testRangeGroupAddTwoRangesMergeForward(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-
-	if l := rg.Len(); l != 1 {
-		t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
-	}
-}
-
-func TestRangeListAddTwoRangesMergeBackwards(t *testing.T) {
-	testRangeGroupAddTwoRangesMergeBackwards(t, NewRangeList())
-}
-
-func TestRangeTreeAddTwoRangesMergeBackwards(t *testing.T) {
-	testRangeGroupAddTwoRangesMergeBackwards(t, NewRangeTree())
-}
-
-func testRangeGroupAddTwoRangesMergeBackwards(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-
-	if l := rg.Len(); l != 1 {
-		t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
-	}
-}
-
-func TestRangeListAddTwoRangesWithin(t *testing.T) {
-	testRangeGroupAddTwoRangesWithin(t, NewRangeList())
-}
-
-func TestRangeTreeAddTwoRangesWithin(t *testing.T) {
-	testRangeGroupAddTwoRangesWithin(t, NewRangeTree())
-}
-
-func testRangeGroupAddTwoRangesWithin(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x04}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x02}, End: []byte{0x03}}); added {
-		t.Errorf("added fully contained range to range group, wanted false added flag; got true")
-	}
-
-	if l := rg.Len(); l != 1 {
-		t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
-	}
-}
-
-func TestRangeListAddTwoRangesSurround(t *testing.T) {
-	testRangeGroupAddTwoRangesSurround(t, NewRangeList())
-}
-
-func TestRangeTreeAddTwoRangesSurround(t *testing.T) {
-	testRangeGroupAddTwoRangesSurround(t, NewRangeTree())
-}
-
-func testRangeGroupAddTwoRangesSurround(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x02}, End: []byte{0x03}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x04}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-
-	if l := rg.Len(); l != 1 {
-		t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
-	}
-}
-
-func TestRangeListAddThreeRangesMergeInOrder(t *testing.T) {
-	testRangeGroupAddThreeRangesMergeInOrder(t, NewRangeList())
-}
-
-func TestRangeTreeAddThreeRangesMergeInOrder(t *testing.T) {
-	testRangeGroupAddThreeRangesMergeInOrder(t, NewRangeTree())
-}
-
-func testRangeGroupAddThreeRangesMergeInOrder(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-
-	if l := rg.Len(); l != 1 {
-		t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
-	}
-}
-
-func TestRangeListAddThreeRangesMergeOutOfOrder(t *testing.T) {
-	testRangeGroupAddThreeRangesMergeOutOfOrder(t, NewRangeList())
-}
-
-func TestRangeTreeAddThreeRangesMergeOutOfOrder(t *testing.T) {
-	testRangeGroupAddThreeRangesMergeOutOfOrder(t, NewRangeTree())
-}
-
-func testRangeGroupAddThreeRangesMergeOutOfOrder(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-
-	if l := rg.Len(); l != 1 {
-		t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
-	}
-}
-
-func TestRangeListAddThreeRangesMergeReverseOrder(t *testing.T) {
-	testRangeGroupAddThreeRangesMergeReverseOrder(t, NewRangeList())
-}
-
-func TestRangeTreeAddThreeRangesMergeReverseOrder(t *testing.T) {
-	testRangeGroupAddThreeRangesMergeReverseOrder(t, NewRangeTree())
-}
-
-func testRangeGroupAddThreeRangesMergeReverseOrder(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-
-	if l := rg.Len(); l != 1 {
-		t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
-	}
-}
-
-func TestRangeListAddThreeRangesSuperset(t *testing.T) {
-	testRangeGroupAddThreeRangesSuperset(t, NewRangeList())
-}
-
-func TestRangeTreeAddThreeRangesSuperset(t *testing.T) {
-	testRangeGroupAddThreeRangesSuperset(t, NewRangeTree())
-}
-
-func testRangeGroupAddThreeRangesSuperset(t *testing.T, rg RangeGroup) {
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-	if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x06}}); !added {
-		t.Errorf("added new range to range group, wanted true added flag; got false")
-	}
-
-	if l := rg.Len(); l != 1 {
-		t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
-	}
-}
-
-func TestRangeListSubRanges(t *testing.T) {
-	testRangeGroupSubRanges(t, NewRangeList())
-}
-
-func TestRangeTreeSubRanges(t *testing.T) {
-	testRangeGroupSubRanges(t, NewRangeTree())
-}
-
-func testRangeGroupSubRanges(t *testing.T, rg RangeGroup) {
-	oneRange := []Range{{Start: []byte{0x01}, End: []byte{0x05}}}
-	twoRanges := []Range{
-		{Start: []byte{0x01}, End: []byte{0x05}},
-		{Start: []byte{0x07}, End: []byte{0x0f}},
-	}
-
-	tests := []struct {
-		add []Range
-		sub Range
-		rem bool
-		res []Range
-	}{
-		{
-			add: []Range{},
-			sub: Range{Start: []byte{0x10}, End: []byte{0x11}},
-			rem: false,
-			res: []Range{},
-		},
-		{
-			add: oneRange,
-			sub: Range{Start: []byte{0x10}, End: []byte{0x11}},
-			rem: false,
-			res: []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
-		},
-		{
-			add: oneRange,
-			sub: Range{Start: []byte{0x01}, End: []byte{0x05}},
-			rem: true,
-			res: []Range{},
-		},
-		{
-			add: oneRange,
-			sub: Range{Start: []byte{0x00}, End: []byte{0x06}},
-			rem: true,
-			res: []Range{},
-		},
-		{
-			add: oneRange,
-			sub: Range{Start: []byte{0x04}, End: []byte{0x06}},
-			rem: true,
-			res: []Range{{Start: []byte{0x01}, End: []byte{0x04}}},
-		},
-		{
-			add: oneRange,
-			sub: Range{Start: []byte{0x05}, End: []byte{0x06}},
-			rem: false,
-			res: []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
-		},
-		{
-			add: oneRange,
-			sub: Range{Start: []byte{0x01}, End: []byte{0x03}},
-			rem: true,
-			res: []Range{{Start: []byte{0x03}, End: []byte{0x05}}},
-		},
-		{
-			add: oneRange,
-			sub: Range{Start: []byte{0x02}, End: []byte{0x04}},
-			rem: true,
-			res: []Range{
-				{Start: []byte{0x01}, End: []byte{0x02}},
-				{Start: []byte{0x04}, End: []byte{0x05}},
-			},
-		},
-		{
-			add: twoRanges,
-			sub: Range{Start: []byte{0x10}, End: []byte{0x11}},
-			rem: false,
-			res: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x07}, End: []byte{0x0f}},
-			},
-		},
-		{
-			add: twoRanges,
-			sub: Range{Start: []byte{0x01}, End: []byte{0x04}},
-			rem: true,
-			res: []Range{
-				{Start: []byte{0x04}, End: []byte{0x05}},
-				{Start: []byte{0x07}, End: []byte{0x0f}},
-			},
-		},
-		{
-			add: twoRanges,
-			sub: Range{Start: []byte{0x01}, End: []byte{0x05}},
-			rem: true,
-			res: []Range{{Start: []byte{0x07}, End: []byte{0x0f}}},
-		},
-		{
-			add: twoRanges,
-			sub: Range{Start: []byte{0x03}, End: []byte{0x09}},
-			rem: true,
-			res: []Range{
-				{Start: []byte{0x01}, End: []byte{0x03}},
-				{Start: []byte{0x09}, End: []byte{0x0f}},
-			},
-		},
-		{
-			add: twoRanges,
-			sub: Range{Start: []byte{0x03}, End: []byte{0xff}},
-			rem: true,
-			res: []Range{
-				{Start: []byte{0x01}, End: []byte{0x03}},
-			},
-		},
-		{
-			add: twoRanges,
-			sub: Range{Start: []byte{0x00}, End: []byte{0x09}},
-			rem: true,
-			res: []Range{
-				{Start: []byte{0x09}, End: []byte{0x0f}},
-			},
-		},
-	}
-
-	for _, test := range tests {
 		rg.Clear()
+		if l := rg.Len(); l != 0 {
+			t.Errorf("cleared range group, wanted len = 0; got len = %d", l)
+		}
+	})
+}
 
-		for _, r := range test.add {
+func TestRangeGroupAddTwoRangesBefore(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+
+		if l := rg.Len(); l != 2 {
+			t.Errorf("added 2 disjoint ranges to range group, wanted len = 2; got len = %d", l)
+		}
+	})
+}
+
+func TestRangeGroupAddTwoRangesAfter(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+
+		if l := rg.Len(); l != 2 {
+			t.Errorf("added 2 disjoint ranges to range group, wanted len = 2; got len = %d", l)
+		}
+	})
+}
+
+func TestRangeGroupAddTwoRangesMergeForward(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+
+		if l := rg.Len(); l != 1 {
+			t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
+		}
+	})
+}
+
+func TestRangeGroupAddTwoRangesMergeBackwards(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+
+		if l := rg.Len(); l != 1 {
+			t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
+		}
+	})
+}
+
+func TestRangeGroupAddTwoRangesWithin(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x04}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x02}, End: []byte{0x03}}); added {
+			t.Errorf("added fully contained range to range group, wanted false added flag; got true")
+		}
+
+		if l := rg.Len(); l != 1 {
+			t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
+		}
+	})
+}
+
+func TestRangeGroupAddTwoRangesSurround(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x02}, End: []byte{0x03}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x04}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+
+		if l := rg.Len(); l != 1 {
+			t.Errorf("added 2 overlapping ranges to range group, wanted len = 1; got len = %d", l)
+		}
+	})
+}
+
+func TestRangeGroupAddThreeRangesMergeInOrder(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+
+		if l := rg.Len(); l != 1 {
+			t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
+		}
+	})
+}
+
+func TestRangeGroupAddThreeRangesMergeOutOfOrder(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+
+		if l := rg.Len(); l != 1 {
+			t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
+		}
+	})
+}
+
+func TestRangeGroupAddThreeRangesMergeReverseOrder(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x03}, End: []byte{0x04}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x03}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+
+		if l := rg.Len(); l != 1 {
+			t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
+		}
+	})
+}
+
+func TestRangeGroupAddThreeRangesSuperset(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x02}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x04}, End: []byte{0x06}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+		if added := rg.Add(Range{Start: []byte{0x01}, End: []byte{0x06}}); !added {
+			t.Errorf("added new range to range group, wanted true added flag; got false")
+		}
+
+		if l := rg.Len(); l != 1 {
+			t.Errorf("added three overlapping ranges to range group, wanted len = 1; got len = %d", l)
+		}
+	})
+}
+
+func TestRangeGroupSubRanges(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		oneRange := []Range{{Start: []byte{0x01}, End: []byte{0x05}}}
+		twoRanges := []Range{
+			{Start: []byte{0x01}, End: []byte{0x05}},
+			{Start: []byte{0x07}, End: []byte{0x0f}},
+		}
+
+		tests := []struct {
+			add []Range
+			sub Range
+			rem bool
+			res []Range
+		}{
+			{
+				add: []Range{},
+				sub: Range{Start: []byte{0x10}, End: []byte{0x11}},
+				rem: false,
+				res: []Range{},
+			},
+			{
+				add: oneRange,
+				sub: Range{Start: []byte{0x10}, End: []byte{0x11}},
+				rem: false,
+				res: []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+			},
+			{
+				add: oneRange,
+				sub: Range{Start: []byte{0x01}, End: []byte{0x05}},
+				rem: true,
+				res: []Range{},
+			},
+			{
+				add: oneRange,
+				sub: Range{Start: []byte{0x00}, End: []byte{0x06}},
+				rem: true,
+				res: []Range{},
+			},
+			{
+				add: oneRange,
+				sub: Range{Start: []byte{0x04}, End: []byte{0x06}},
+				rem: true,
+				res: []Range{{Start: []byte{0x01}, End: []byte{0x04}}},
+			},
+			{
+				add: oneRange,
+				sub: Range{Start: []byte{0x05}, End: []byte{0x06}},
+				rem: false,
+				res: []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+			},
+			{
+				add: oneRange,
+				sub: Range{Start: []byte{0x01}, End: []byte{0x03}},
+				rem: true,
+				res: []Range{{Start: []byte{0x03}, End: []byte{0x05}}},
+			},
+			{
+				add: oneRange,
+				sub: Range{Start: []byte{0x02}, End: []byte{0x04}},
+				rem: true,
+				res: []Range{
+					{Start: []byte{0x01}, End: []byte{0x02}},
+					{Start: []byte{0x04}, End: []byte{0x05}},
+				},
+			},
+			{
+				add: twoRanges,
+				sub: Range{Start: []byte{0x10}, End: []byte{0x11}},
+				rem: false,
+				res: []Range{
+					{Start: []byte{0x01}, End: []byte{0x05}},
+					{Start: []byte{0x07}, End: []byte{0x0f}},
+				},
+			},
+			{
+				add: twoRanges,
+				sub: Range{Start: []byte{0x01}, End: []byte{0x04}},
+				rem: true,
+				res: []Range{
+					{Start: []byte{0x04}, End: []byte{0x05}},
+					{Start: []byte{0x07}, End: []byte{0x0f}},
+				},
+			},
+			{
+				add: twoRanges,
+				sub: Range{Start: []byte{0x01}, End: []byte{0x05}},
+				rem: true,
+				res: []Range{{Start: []byte{0x07}, End: []byte{0x0f}}},
+			},
+			{
+				add: twoRanges,
+				sub: Range{Start: []byte{0x03}, End: []byte{0x09}},
+				rem: true,
+				res: []Range{
+					{Start: []byte{0x01}, End: []byte{0x03}},
+					{Start: []byte{0x09}, End: []byte{0x0f}},
+				},
+			},
+			{
+				add: twoRanges,
+				sub: Range{Start: []byte{0x03}, End: []byte{0xff}},
+				rem: true,
+				res: []Range{
+					{Start: []byte{0x01}, End: []byte{0x03}},
+				},
+			},
+			{
+				add: twoRanges,
+				sub: Range{Start: []byte{0x00}, End: []byte{0x09}},
+				rem: true,
+				res: []Range{
+					{Start: []byte{0x09}, End: []byte{0x0f}},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			rg.Clear()
+
+			for _, r := range test.add {
+				if added := rg.Add(r); !added {
+					t.Errorf("added new range %v to empty range group, wanted true added flag; got false", r)
+				}
+			}
+			str := rg.String()
+
+			if rem := rg.Sub(test.sub); rem != test.rem {
+				t.Errorf("subtracted %v from range group %s, wanted %t removed flag; got %t", test.sub, str, test.rem, rem)
+			}
+
+			if l, el := rg.Len(), len(test.res); l != el {
+				t.Errorf("subtracted %v from range group %s, wanted %b remaining ranges; got %b", test.sub, str, el, l)
+			} else {
+				ranges := make([]Range, 0, l)
+				if err := rg.ForEach(func(r Range) error {
+					ranges = append(ranges, r)
+					return nil
+				}); err != nil {
+					t.Fatal(err)
+				}
+
+				if !reflect.DeepEqual(ranges, test.res) {
+					t.Errorf("subtracted %v from range group %s, wanted the remaining ranges %v; got %v", test.sub, str, test.res, ranges)
+				}
+			}
+		}
+	})
+}
+
+func TestRangeGroupOverlapsRange(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		for _, r := range []Range{
+			{Start: []byte{0x01}, End: []byte{0x05}},
+			{Start: []byte{0x07}, End: []byte{0x0f}},
+		} {
 			if added := rg.Add(r); !added {
 				t.Errorf("added new range %v to empty range group, wanted true added flag; got false", r)
 			}
 		}
-		str := rg.String()
 
-		if rem := rg.Sub(test.sub); rem != test.rem {
-			t.Errorf("subtracted %v from range group %s, wanted %t removed flag; got %t", test.sub, str, test.rem, rem)
+		tests := []struct {
+			r    Range
+			want bool
+		}{
+			{
+				r:    Range{Start: []byte{0x0a}, End: []byte{0x0b}},
+				want: true,
+			},
+			{
+				r:    Range{Start: []byte{0x01}, End: []byte{0x04}},
+				want: true,
+			},
+			{
+				r:    Range{Start: []byte{0x04}, End: []byte{0x07}},
+				want: true,
+			},
+			{
+				r:    Range{Start: []byte{0x06}, End: []byte{0x07}},
+				want: false,
+			},
+			{
+				r:    Range{Start: []byte{0x05}, End: []byte{0x07}},
+				want: false,
+			},
+			{
+				r:    Range{Start: []byte{0x05}, End: []byte{0x06}},
+				want: false,
+			},
+			{
+				r:    Range{Start: []byte{0x05}, End: []byte{0x08}},
+				want: true,
+			},
+			{
+				r:    Range{Start: []byte{0x01}, End: []byte{0x0f}},
+				want: true,
+			},
+			{
+				r:    Range{Start: []byte{0x10}, End: []byte{0x11}},
+				want: false,
+			},
 		}
 
-		if l, el := rg.Len(), len(test.res); l != el {
-			t.Errorf("subtracted %v from range group %s, wanted %b remaining ranges; got %b", test.sub, str, el, l)
-		} else {
-			ranges := make([]Range, 0, l)
-			if err := rg.ForEach(func(r Range) error {
-				ranges = append(ranges, r)
+		for _, test := range tests {
+			if enc := rg.Overlaps(test.r); enc != test.want {
+				t.Errorf("testing if range group %v overlaps range %v, wanted %t; got %t", rg, test.r, test.want, enc)
+			}
+		}
+	})
+}
+
+func TestRangeGroupEnclosesRange(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		for _, r := range []Range{
+			{Start: []byte{0x01}, End: []byte{0x05}},
+			{Start: []byte{0x07}, End: []byte{0x0f}},
+		} {
+			if added := rg.Add(r); !added {
+				t.Errorf("added new range %v to empty range group, wanted true added flag; got false", r)
+			}
+		}
+
+		tests := []struct {
+			r    Range
+			want bool
+		}{
+			{
+				r:    Range{Start: []byte{0x10}, End: []byte{0x11}},
+				want: false,
+			},
+			{
+				r:    Range{Start: []byte{0x01}, End: []byte{0x04}},
+				want: true,
+			},
+			{
+				r:    Range{Start: []byte{0x01}, End: []byte{0x05}},
+				want: true,
+			},
+			{
+				r:    Range{Start: []byte{0x01}, End: []byte{0x0f}},
+				want: false,
+			},
+			{
+				r:    Range{Start: []byte{0x07}, End: []byte{0x0f}},
+				want: true,
+			},
+		}
+
+		for _, test := range tests {
+			if enc := rg.Encloses(test.r); enc != test.want {
+				t.Errorf("testing if range group %v encloses range %v, wanted %t; got %t", rg, test.r, test.want, enc)
+			}
+		}
+	})
+}
+
+func TestRangeGroupForEach(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		errToThrow := errors.New("this error should be thrown")
+		dontErr := -1
+		tests := []struct {
+			rngs     []Range
+			errAfter int // after this many iterations, throw error. -1 to ignore.
+		}{
+			{
+				rngs:     []Range{},
+				errAfter: dontErr,
+			},
+			{
+				rngs:     []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+				errAfter: dontErr,
+			},
+			{
+				rngs: []Range{
+					{Start: []byte{0x01}, End: []byte{0x05}},
+					{Start: []byte{0x09}, End: []byte{0xff}},
+				},
+				errAfter: dontErr,
+			},
+			{
+				rngs: []Range{
+					{Start: []byte{0x01}, End: []byte{0x05}},
+					{Start: []byte{0x09}, End: []byte{0x10}},
+					{Start: []byte{0x1a}, End: []byte{0x1c}},
+					{Start: []byte{0x44}, End: []byte{0xf0}},
+					{Start: []byte{0xf1}, End: []byte{0xff}},
+				},
+				errAfter: dontErr,
+			},
+			{
+				rngs: []Range{
+					{Start: []byte{0x01}, End: []byte{0x05}},
+					{Start: []byte{0x09}, End: []byte{0x10}},
+					{Start: []byte{0x1a}, End: []byte{0x1c}},
+					{Start: []byte{0x44}, End: []byte{0xf0}},
+					{Start: []byte{0xf1}, End: []byte{0xff}},
+				},
+				errAfter: 1,
+			},
+		}
+
+		for _, test := range tests {
+			rg.Clear()
+			for _, r := range test.rngs {
+				rg.Add(r)
+			}
+
+			n := 0
+			acc := []Range{}
+			throwingErr := test.errAfter != -1
+			errSaw := rg.ForEach(func(r Range) error {
+				if throwingErr && n >= test.errAfter {
+					return errToThrow
+				}
+				n++
+				acc = append(acc, r)
 				return nil
-			}); err != nil {
-				t.Fatal(err)
+			})
+
+			expRngs := test.rngs
+			if throwingErr {
+				expRngs = test.rngs[:test.errAfter]
+				if errSaw != errToThrow {
+					t.Errorf("expected error %v from RangeGroup.ForEach, found %v", errToThrow, errSaw)
+				}
+			} else {
+				if errSaw != nil {
+					t.Errorf("no error expected from RangeGroup.ForEach, found %v", errSaw)
+				}
+			}
+			if !reflect.DeepEqual(acc, expRngs) {
+				t.Errorf("expected to accumulate Ranges %v, found %v", expRngs, acc)
+			}
+		}
+	})
+}
+
+func TestRangeGroupIterator(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		tests := []struct {
+			rngs []Range
+		}{
+			{
+				rngs: []Range{},
+			},
+			{
+				rngs: []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+			},
+			{
+				rngs: []Range{
+					{Start: []byte{0x01}, End: []byte{0x05}},
+					{Start: []byte{0x09}, End: []byte{0xff}},
+				},
+			},
+			{
+				rngs: []Range{
+					{Start: []byte{0x01}, End: []byte{0x05}},
+					{Start: []byte{0x09}, End: []byte{0x10}},
+					{Start: []byte{0x1a}, End: []byte{0x1c}},
+					{Start: []byte{0x44}, End: []byte{0xf0}},
+					{Start: []byte{0xf1}, End: []byte{0xff}},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			rg.Clear()
+			for _, r := range test.rngs {
+				rg.Add(r)
 			}
 
-			if !reflect.DeepEqual(ranges, test.res) {
-				t.Errorf("subtracted %v from range group %s, wanted the remaining ranges %v; got %v", test.sub, str, test.res, ranges)
+			acc := []Range{}
+			it := rg.Iterator()
+			for r, ok := it.Next(); ok; r, ok = it.Next() {
+				acc = append(acc, r)
+			}
+
+			if !reflect.DeepEqual(acc, test.rngs) {
+				t.Errorf("expected to accumulate Ranges %v, found %v", test.rngs, acc)
 			}
 		}
-	}
+	})
 }
 
-func TestRangeListOverlapsRange(t *testing.T) {
-	testRangeGroupOverlapsRange(t, NewRangeList())
-}
-
-func TestRangeTreeOverlapsRange(t *testing.T) {
-	testRangeGroupOverlapsRange(t, NewRangeTree())
-}
-
-func testRangeGroupOverlapsRange(t *testing.T, rg RangeGroup) {
-	rg.Clear()
-	for _, r := range []Range{
-		{Start: []byte{0x01}, End: []byte{0x05}},
-		{Start: []byte{0x07}, End: []byte{0x0f}},
-	} {
-		if added := rg.Add(r); !added {
-			t.Errorf("added new range %v to empty range group, wanted true added flag; got false", r)
-		}
-	}
-
-	tests := []struct {
-		r    Range
-		want bool
-	}{
-		{
-			r:    Range{Start: []byte{0x0a}, End: []byte{0x0b}},
-			want: true,
-		},
-		{
-			r:    Range{Start: []byte{0x01}, End: []byte{0x04}},
-			want: true,
-		},
-		{
-			r:    Range{Start: []byte{0x04}, End: []byte{0x07}},
-			want: true,
-		},
-		{
-			r:    Range{Start: []byte{0x05}, End: []byte{0x07}},
-			want: false,
-		},
-		{
-			r:    Range{Start: []byte{0x05}, End: []byte{0x08}},
-			want: true,
-		},
-		{
-			r:    Range{Start: []byte{0x01}, End: []byte{0x0f}},
-			want: true,
-		},
-		{
-			r:    Range{Start: []byte{0x10}, End: []byte{0x11}},
-			want: false,
-		},
-	}
-
-	for _, test := range tests {
-		if enc := rg.Overlaps(test.r); enc != test.want {
-			t.Errorf("testing if range group %v overlaps range %v, wanted %t; got %t", rg, test.r, test.want, enc)
-		}
-	}
-}
-
-func TestRangeListEnclosesRange(t *testing.T) {
-	testRangeGroupEnclosesRange(t, NewRangeList())
-}
-
-func TestRangeTreeEnclosesRange(t *testing.T) {
-	testRangeGroupEnclosesRange(t, NewRangeTree())
-}
-
-func testRangeGroupEnclosesRange(t *testing.T, rg RangeGroup) {
-	rg.Clear()
-	for _, r := range []Range{
-		{Start: []byte{0x01}, End: []byte{0x05}},
-		{Start: []byte{0x07}, End: []byte{0x0f}},
-	} {
-		if added := rg.Add(r); !added {
-			t.Errorf("added new range %v to empty range group, wanted true added flag; got false", r)
-		}
-	}
-
-	tests := []struct {
-		r    Range
-		want bool
-	}{
-		{
-			r:    Range{Start: []byte{0x10}, End: []byte{0x11}},
-			want: false,
-		},
-		{
-			r:    Range{Start: []byte{0x01}, End: []byte{0x04}},
-			want: true,
-		},
-		{
-			r:    Range{Start: []byte{0x01}, End: []byte{0x05}},
-			want: true,
-		},
-		{
-			r:    Range{Start: []byte{0x01}, End: []byte{0x0f}},
-			want: false,
-		},
-		{
-			r:    Range{Start: []byte{0x07}, End: []byte{0x0f}},
-			want: true,
-		},
-	}
-
-	for _, test := range tests {
-		if enc := rg.Encloses(test.r); enc != test.want {
-			t.Errorf("testing if range group %v encloses range %v, wanted %t; got %t", rg, test.r, test.want, enc)
-		}
-	}
-}
-
-func TestRangeListForEach(t *testing.T) {
-	testRangeGroupForEach(t, NewRangeList())
-}
-
-func TestRangeTreeForEach(t *testing.T) {
-	testRangeGroupForEach(t, NewRangeTree())
-}
-
-func testRangeGroupForEach(t *testing.T, rg RangeGroup) {
-	errToThrow := errors.New("this error should be thrown")
-	dontErr := -1
-	tests := []struct {
-		rngs     []Range
-		errAfter int // after this many iterations, throw error. -1 to ignore.
-	}{
-		{
-			rngs:     []Range{},
-			errAfter: dontErr,
-		},
-		{
-			rngs:     []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
-			errAfter: dontErr,
-		},
-		{
-			rngs: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0xff}},
+func TestRangeGroupStringer(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg RangeGroup) {
+		tests := []struct {
+			rngs []Range
+			str  string
+		}{
+			{
+				rngs: []Range{},
+				str:  "[]",
 			},
-			errAfter: dontErr,
-		},
-		{
-			rngs: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0x10}},
-				{Start: []byte{0x1a}, End: []byte{0x1c}},
-				{Start: []byte{0x44}, End: []byte{0xf0}},
-				{Start: []byte{0xf1}, End: []byte{0xff}},
+			{
+				rngs: []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+				str:  "[{01-05}]",
 			},
-			errAfter: dontErr,
-		},
-		{
-			rngs: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0x10}},
-				{Start: []byte{0x1a}, End: []byte{0x1c}},
-				{Start: []byte{0x44}, End: []byte{0xf0}},
-				{Start: []byte{0xf1}, End: []byte{0xff}},
+			{
+				rngs: []Range{
+					{Start: []byte{0x01}, End: []byte{0x05}},
+					{Start: []byte{0x09}, End: []byte{0xff}},
+				},
+				str: "[{01-05} {09-ff}]",
 			},
-			errAfter: 1,
-		},
-	}
-
-	for _, test := range tests {
-		rg.Clear()
-		for _, r := range test.rngs {
-			rg.Add(r)
+			{
+				rngs: []Range{
+					{Start: []byte{0x01}, End: []byte{0x05}},
+					{Start: []byte{0x09}, End: []byte{0xf0}},
+					{Start: []byte{0xf1}, End: []byte{0xff}},
+				},
+				str: "[{01-05} {09-f0} {f1-ff}]",
+			},
 		}
 
-		n := 0
-		acc := []Range{}
-		throwingErr := test.errAfter != -1
-		errSaw := rg.ForEach(func(r Range) error {
-			if throwingErr && n >= test.errAfter {
-				return errToThrow
+		for _, test := range tests {
+			rg.Clear()
+			for _, r := range test.rngs {
+				rg.Add(r)
 			}
-			n++
-			acc = append(acc, r)
-			return nil
+			if str := rg.String(); str != test.str {
+				t.Errorf("added new ranges %v to range group, wanted string value %s; got %s", test.rngs, test.str, str)
+			}
+		}
+	})
+}
+
+func TestRangeGroupsOverlap(t *testing.T) {
+	forEachRangeGroupImpl(t, func(t *testing.T, rg1 RangeGroup) {
+		forEachRangeGroupImpl(t, func(t *testing.T, rg2 RangeGroup) {
+			tests := []struct {
+				rngs1   []Range
+				rngs2   []Range
+				overlap bool
+			}{
+				{
+					rngs1:   []Range{},
+					rngs2:   []Range{},
+					overlap: false,
+				},
+				{
+					rngs1:   []Range{},
+					rngs2:   []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+					overlap: false,
+				},
+				{
+					rngs1:   []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+					rngs2:   []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+					overlap: true,
+				},
+				{
+					rngs1:   []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+					rngs2:   []Range{{Start: []byte{0x05}, End: []byte{0x08}}},
+					overlap: false,
+				},
+				{
+					rngs1:   []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
+					rngs2:   []Range{{Start: []byte{0x04}, End: []byte{0x08}}},
+					overlap: true,
+				},
+				{
+					rngs1: []Range{
+						{Start: []byte{0x01}, End: []byte{0x05}},
+						{Start: []byte{0x09}, End: []byte{0xf0}},
+					},
+					rngs2:   []Range{{Start: []byte{0xf1}, End: []byte{0xff}}},
+					overlap: false,
+				},
+				{
+					rngs1: []Range{
+						{Start: []byte{0x01}, End: []byte{0x05}},
+						{Start: []byte{0x09}, End: []byte{0xf0}},
+					},
+					rngs2:   []Range{{Start: []byte{0xe0}, End: []byte{0xff}}},
+					overlap: true,
+				},
+				{
+					rngs1: []Range{
+						{Start: []byte{0x01}, End: []byte{0x05}},
+						{Start: []byte{0x09}, End: []byte{0x10}},
+						{Start: []byte{0x1a}, End: []byte{0x1c}},
+						{Start: []byte{0x44}, End: []byte{0xf0}},
+						{Start: []byte{0xf1}, End: []byte{0xff}},
+					},
+					rngs2:   []Range{{Start: []byte{0x11}, End: []byte{0x19}}},
+					overlap: false,
+				},
+				{
+					rngs1: []Range{
+						{Start: []byte{0x01}, End: []byte{0x05}},
+						{Start: []byte{0x09}, End: []byte{0x10}},
+						{Start: []byte{0x1a}, End: []byte{0x1c}},
+						{Start: []byte{0x44}, End: []byte{0xf0}},
+						{Start: []byte{0xf1}, End: []byte{0xff}},
+					},
+					rngs2:   []Range{{Start: []byte{0x11}, End: []byte{0xff}}},
+					overlap: true,
+				},
+			}
+
+			for _, test := range tests {
+				for _, swap := range []bool{false, true} {
+					rg1.Clear()
+					rg2.Clear()
+
+					rngs1, rngs2 := test.rngs1, test.rngs2
+					if swap {
+						rngs1, rngs2 = rngs2, rngs1
+					}
+
+					for _, r := range rngs1 {
+						rg1.Add(r)
+					}
+					for _, r := range rngs2 {
+						rg2.Add(r)
+					}
+
+					overlap := RangeGroupsOverlap(rg1, rg2)
+					if e, a := test.overlap, overlap; a != e {
+						t.Errorf("expected RangeGroupsOverlap(%s, %s) = %t, found %t", rg1, rg2, e, a)
+					}
+				}
+			}
 		})
-
-		expRngs := test.rngs
-		if throwingErr {
-			expRngs = test.rngs[:test.errAfter]
-			if errSaw != errToThrow {
-				t.Errorf("expected error %v from RangeGroup.ForEach, found %v", errToThrow, errSaw)
-			}
-		} else {
-			if errSaw != nil {
-				t.Errorf("no error expected from RangeGroup.ForEach, found %v", errSaw)
-			}
-		}
-		if !reflect.DeepEqual(acc, expRngs) {
-			t.Errorf("expected to accumulate Ranges %v, found %v", expRngs, acc)
-		}
-	}
-}
-
-func TestRangeListIterator(t *testing.T) {
-	testRangeGroupIterator(t, NewRangeList())
-}
-
-func TestRangeTreeIterator(t *testing.T) {
-	testRangeGroupIterator(t, NewRangeTree())
-}
-
-func testRangeGroupIterator(t *testing.T, rg RangeGroup) {
-	tests := []struct {
-		rngs []Range
-	}{
-		{
-			rngs: []Range{},
-		},
-		{
-			rngs: []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
-		},
-		{
-			rngs: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0xff}},
-			},
-		},
-		{
-			rngs: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0x10}},
-				{Start: []byte{0x1a}, End: []byte{0x1c}},
-				{Start: []byte{0x44}, End: []byte{0xf0}},
-				{Start: []byte{0xf1}, End: []byte{0xff}},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		rg.Clear()
-		for _, r := range test.rngs {
-			rg.Add(r)
-		}
-
-		acc := []Range{}
-		it := rg.Iterator()
-		for r, ok := it.Next(); ok; r, ok = it.Next() {
-			acc = append(acc, r)
-		}
-
-		if !reflect.DeepEqual(acc, test.rngs) {
-			t.Errorf("expected to accumulate Ranges %v, found %v", test.rngs, acc)
-		}
-	}
-}
-
-func TestRangeListStringer(t *testing.T) {
-	testRangeGroupStringer(t, NewRangeList())
-}
-
-func TestRangeTreeStringer(t *testing.T) {
-	testRangeGroupStringer(t, NewRangeTree())
-}
-
-func testRangeGroupStringer(t *testing.T, rg RangeGroup) {
-	tests := []struct {
-		rngs []Range
-		str  string
-	}{
-		{
-			rngs: []Range{},
-			str:  "[]",
-		},
-		{
-			rngs: []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
-			str:  "[{01-05}]",
-		},
-		{
-			rngs: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0xff}},
-			},
-			str: "[{01-05} {09-ff}]",
-		},
-		{
-			rngs: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0xf0}},
-				{Start: []byte{0xf1}, End: []byte{0xff}},
-			},
-			str: "[{01-05} {09-f0} {f1-ff}]",
-		},
-	}
-
-	for _, test := range tests {
-		rg.Clear()
-		for _, r := range test.rngs {
-			rg.Add(r)
-		}
-		if str := rg.String(); str != test.str {
-			t.Errorf("added new ranges %v to range group, wanted string value %s; got %s", test.rngs, test.str, str)
-		}
-	}
-}
-
-func TestRangeListsOverlap(t *testing.T) {
-	testRangeGroupsOverlap(t, NewRangeList(), NewRangeList())
-}
-
-func TestRangeTreesIterator(t *testing.T) {
-	testRangeGroupsOverlap(t, NewRangeTree(), NewRangeTree())
-}
-
-func TestRangeListAndRangeTreeOverlap(t *testing.T) {
-	testRangeGroupsOverlap(t, NewRangeList(), NewRangeTree())
-}
-
-func testRangeGroupsOverlap(t *testing.T, rg1, rg2 RangeGroup) {
-	tests := []struct {
-		rngs1   []Range
-		rngs2   []Range
-		overlap bool
-	}{
-		{
-			rngs1:   []Range{},
-			rngs2:   []Range{},
-			overlap: false,
-		},
-		{
-			rngs1:   []Range{},
-			rngs2:   []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
-			overlap: false,
-		},
-		{
-			rngs1:   []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
-			rngs2:   []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
-			overlap: true,
-		},
-		{
-			rngs1:   []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
-			rngs2:   []Range{{Start: []byte{0x05}, End: []byte{0x08}}},
-			overlap: false,
-		},
-		{
-			rngs1:   []Range{{Start: []byte{0x01}, End: []byte{0x05}}},
-			rngs2:   []Range{{Start: []byte{0x04}, End: []byte{0x08}}},
-			overlap: true,
-		},
-		{
-			rngs1: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0xf0}},
-			},
-			rngs2:   []Range{{Start: []byte{0xf1}, End: []byte{0xff}}},
-			overlap: false,
-		},
-		{
-			rngs1: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0xf0}},
-			},
-			rngs2:   []Range{{Start: []byte{0xe0}, End: []byte{0xff}}},
-			overlap: true,
-		},
-		{
-			rngs1: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0x10}},
-				{Start: []byte{0x1a}, End: []byte{0x1c}},
-				{Start: []byte{0x44}, End: []byte{0xf0}},
-				{Start: []byte{0xf1}, End: []byte{0xff}},
-			},
-			rngs2:   []Range{{Start: []byte{0x11}, End: []byte{0x19}}},
-			overlap: false,
-		},
-		{
-			rngs1: []Range{
-				{Start: []byte{0x01}, End: []byte{0x05}},
-				{Start: []byte{0x09}, End: []byte{0x10}},
-				{Start: []byte{0x1a}, End: []byte{0x1c}},
-				{Start: []byte{0x44}, End: []byte{0xf0}},
-				{Start: []byte{0xf1}, End: []byte{0xff}},
-			},
-			rngs2:   []Range{{Start: []byte{0x11}, End: []byte{0xff}}},
-			overlap: true,
-		},
-	}
-
-	for _, test := range tests {
-		for _, swap := range []bool{false, true} {
-			rg1.Clear()
-			rg2.Clear()
-
-			rngs1, rngs2 := test.rngs1, test.rngs2
-			if swap {
-				rngs1, rngs2 = rngs2, rngs1
-			}
-
-			for _, r := range rngs1 {
-				rg1.Add(r)
-			}
-			for _, r := range rngs2 {
-				rg2.Add(r)
-			}
-
-			overlap := RangeGroupsOverlap(rg1, rg2)
-			if e, a := test.overlap, overlap; a != e {
-				t.Errorf("expected RangeGroupsOverlap(%s, %s) = %t, found %t", rg1, rg2, e, a)
-			}
-		}
-	}
+	})
 }
 
 func TestRangeListAndRangeGroupIdentical(t *testing.T) {
@@ -879,7 +788,7 @@ func TestRangeListAndRangeGroupIdentical(t *testing.T) {
 			listLen := rl.Len()
 			treeLen := rt.Len()
 			if listLen != treeLen {
-				t.Errorf("expected RangeList and RangeTree to have the same length; got %d from RangeList and %d from RangeTree", listLen, treeLen)
+				t.Fatalf("expected RangeList and RangeTree to have the same length; got %d from RangeList and %d from RangeTree", listLen, treeLen)
 			}
 
 			listRngs := make([]Range, 0, rl.Len())
@@ -898,7 +807,7 @@ func TestRangeListAndRangeGroupIdentical(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(listRngs, treeRngs) {
-				t.Fatalf(`expected RangeList and RangeTree to contain the same ranges; started with %s, added %v, and subtracted %v to get %v for RangeList and %v for RangeTree`, lStr, ar, sr, rl, rt)
+				t.Fatalf("expected RangeList and RangeTree to contain the same ranges:\nstarted with %s\nadded %v\nsubtracted %v\n\ngot:\nRangeList: %v\nRangeTree: %v", lStr, ar, sr, rl, rt)
 			}
 		}
 	}


### PR DESCRIPTION
Related to #19345.

Previously, the linked list implementation version of `RangeGroup` would
store a single `Range` in each list `Element`. This was pretty heavy on
allocations because it required a new list `Element` every time we
inserted a `Range` that couldn't be merged with existing ranges. Is also
required us to compare against every `Range` in the group when searching,
which was a big deal because searching for an overlapping `Range` is the
first step of almost all `RangeGroup` operations.

The implementation now buckets a constant number of `Ranges` in each
linked list node. This has two benefits. First, it reduces allocations
by a factor of `rangeListNodeBucketSize` because each list node can now
store up to `rangeListNodeBucketSize` ranges. Second, it allows us to
scan through the `rangeList` faster when searching for a certain range
by comparing only against the largest `Range` in each node as we scan
forward, until we find one that is larger than our desired `Range`. This
technique is similar in spirit to a two-layer skip list.

At the time of testing, a `rangeListNodeBucketSize` of `8` seemed to strike
the best balance between fewer list nodes and larger list nodes based on
benchmarking results.

```
name         old time/op    new time/op    delta
RangeList-4    1.30µs ± 3%    0.84µs ± 2%  -35.11%  (p=0.000 n=9+10)

name         old alloc/op   new alloc/op   delta
RangeList-4      444B ± 0%       12B ± 0%  -97.30%  (p=0.000 n=10+10)

name         old allocs/op  new allocs/op  delta
RangeList-4      21.0 ± 0%      12.0 ± 0%  -42.86%  (p=0.000 n=10+10)
```

The first commit is much smaller than what the diff is claiming..