### PR TITLE
cli/sql: help users who enter a single '?' further

### DIFF
--- a/pkg/cli/interactive_tests/test_contextual_help.tcl
+++ b/pkg/cli/interactive_tests/test_contextual_help.tcl
@@ -62,6 +62,18 @@ eexpect "See also"
 eexpect root@
 end_test
 
+start_test "Check that a useful reminder is given if the user mistakenly uses a single ?."
+send "select ?\r"
+eexpect "Note:"
+eexpect JSON
+eexpect "use '??'"
+eexpect " ->"
+# restore the normal state
+send ";\r"
+eexpect HINT
+eexpect root@
+end_test
+
 
 start_test "Check that ??-tab works."
 send "select ??\t"

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -190,10 +190,11 @@ func TestIsEndOfStatement(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		isEmpty, isEnd := isEndOfStatement(test.in)
+		isEmpty, lastTok := checkTokens(test.in)
 		if isEmpty != test.isEmpty {
 			t.Errorf("%q: isEmpty expected %v, got %v", test.in, test.isEmpty, isEmpty)
 		}
+		isEnd := isEndOfStatement(lastTok)
 		if isEnd != test.isEnd {
 			t.Errorf("%q: isEnd expected %v, got %v", test.in, test.isEnd, isEnd)
 		}


### PR DESCRIPTION
With the advent of JSON in CockroachDB, the single '?' token has
become a JSON operator. Since CockroachDB also supports contextual
help, the contextual help token has become '??'. However users may not
know this.

This patch ensures that if a user ends a line with a single '?' token,
a note is printed to the screen before the user is invited to complete
the statement (as the final ? may be part of a JSON expression
continued in the next line).  For example:

```
root@:26257/> select 1 ?
Note: a single '?' is a JSON operator. If you want contextual help, use '??'.
           -> 2;
pq: unsupported comparison operator: <int> ? <int>
root@:26257/>
```

cc @jseldess 