### PR TITLE
sql: remove unnecessary call to SetSystemConfig in index truncation

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -290,11 +290,6 @@ func (sc *SchemaChanger) truncateIndexes(
 					defer sc.testingKnobs.RunAfterBackfillChunk()
 				}
 
-				// TODO(vivek): See comment in backfillIndexesChunk.
-				if err := txn.SetSystemConfigTrigger(); err != nil {
-					return err
-				}
-
 				tc := &TableCollection{leaseMgr: sc.leaseMgr}
 				defer tc.releaseTables(ctx)
 				tableDesc, err := sc.getTableVersion(ctx, txn, tc, version)


### PR DESCRIPTION
It was originally needed because the ResumeSpan was added to the TableDescriptor. With the
move of ResumeSpan to the Jobs table, it is no longer needed.

cc: @vivekmenezes 