### PR TITLE
storage: Avoid proposing commands if context is canceled

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2880,6 +2880,14 @@ func (r *Replica) propose(
 		return nil, nil, noop, roachpb.NewError(err)
 	}
 
+	// Checking the context just before proposing can help avoid ambiguous errors.
+	if err := ctx.Err(); err != nil {
+		errStr := fmt.Sprintf("%s before proposing: %s", err, ba.Summary())
+		log.Warning(ctx, errStr)
+		log.ErrEvent(ctx, errStr)
+		return nil, nil, noop, roachpb.NewError(err)
+	}
+
 	// Must check that the request is in bounds at proposal time in
 	// addition to application time because some evaluation functions
 	// (especially EndTransaction with SplitTrigger) fail (with a


### PR DESCRIPTION
This seems like a good practice in general, but was motivated mainly by
the "context cancellation after 0.0s of attempting command RequestLease"
that pop up way more often than it seems like they should. This will
still log them, but will avoid the ambiguous errors.

Also, this means that #17014 apparently didn't completely fix #16911,
since I've been seeing these errors while running against master.