### PR TITLE
build: use baked-in deps for java acceptance tests

### DIFF
--- a/pkg/acceptance/java_test.go
+++ b/pkg/acceptance/java_test.go
@@ -38,5 +38,6 @@ cd /testdata/java
 # See: https://basildoncoder.com/blog/postgresql-jdbc-client-certificates.html
 openssl pkcs8 -topk8 -inform PEM -outform DER -in /certs/node.key -out key.pk8 -nocrypt
 
-mvn %v
+mvn %v -o
+rm -rf target
 `

--- a/pkg/acceptance/node_test.go
+++ b/pkg/acceptance/node_test.go
@@ -34,7 +34,8 @@ func TestDockerNodeJS(t *testing.T) {
 
 const nodeJS = `
 const fs     = require('fs');
-const pg     = require('pg');
+// Gross, will be removed in follow-up.
+const pg     = require('/usr/lib/node_modules/pg');
 const assert = require('assert');
 
 const config = {

--- a/pkg/acceptance/testdata/java/pom.xml
+++ b/pkg/acceptance/testdata/java/pom.xml
@@ -24,6 +24,6 @@
     </dependencies>
 
     <build>
-        <testSourceDirectory>src/main</testSourceDirectory>
+      <testSourceDirectory>src/main</testSourceDirectory>
     </build>
 </project>

--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -60,7 +60,7 @@ func testDockerSuccess(ctx context.Context, t *testing.T, name string, cmd []str
 const (
 	// Iterating against a locally built version of the docker image can be done
 	// by changing postgresTestImage to the hash of the container.
-	postgresTestImage = "docker.io/cockroachdb/postgres-test:20171018-1158"
+	postgresTestImage = "docker.io/cockroachdb/postgres-test:20171019-1337"
 )
 
 func testDocker(


### PR DESCRIPTION
In addition, remove the `target` directory after testing so we don't
leave files sitting around. We could do `mvn clean` but that requires a
plugin I didn't add to the pom.xml and I don't want to eat another
dockerhub run. I'll add it the next time I need to modify the Dockerfile
(which I suspect will be soon).