### PR TITLE
contextutil: add cancellation info log

### DIFF
--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -369,7 +370,7 @@ func (f *Flow) Start(ctx context.Context, doneFn func()) error {
 	)
 	f.status = FlowRunning
 
-	f.ctx, f.ctxCancel = context.WithCancel(ctx)
+	f.ctx, f.ctxCancel = contextutil.WithCancel(ctx)
 
 	// Once we call RegisterFlow, the inbound streams become accessible; we must
 	// set up the WaitGroup counter before.

--- a/pkg/sql/distsqlrun/outbox.go
+++ b/pkg/sql/distsqlrun/outbox.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -214,7 +215,7 @@ func (m *outbox) mainLoop(ctx context.Context) error {
 	// producer to drain). Perhaps what we want is a way to tell when all the rows
 	// corresponding to the first KV batch have been sent and only start the
 	// goroutine if more batches are needed to satisfy the query.
-	listenToConsumerCtx, cancel := context.WithCancel(ctx)
+	listenToConsumerCtx, cancel := contextutil.WithCancel(ctx)
 	drainCh, err := m.listenForDrainSignalFromConsumer(listenToConsumerCtx)
 	defer cancel()
 	if err != nil {

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -336,7 +337,7 @@ func (ds *ServerImpl) RunSyncFlow(stream DistSQL_RunSyncFlowServer) error {
 	mbox.setFlowCtx(&f.FlowCtx)
 
 	if err := ds.Stopper.RunTask(ctx, "distsqlrun.ServerImpl: sync flow", func(ctx context.Context) {
-		ctx, ctxCancel := context.WithCancel(ctx)
+		ctx, ctxCancel := contextutil.WithCancel(ctx)
 		defer ctxCancel()
 		mbox.start(ctx, &f.waitGroup, ctxCancel)
 		if err := f.Start(ctx, func() {}); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -10,7 +10,7 @@ SET tracing = on; BEGIN; SELECT 1; COMMIT; SELECT 2; SET tracing = off;
 # This also checks that the span column properly reports separate
 # SQL transactions.
 query TTT
-SELECT span, message, operation FROM [SHOW TRACE FOR SESSION] WHERE message NOT LIKE e'%\n%'
+SELECT span, message, operation FROM [SHOW TRACE FOR SESSION] WHERE message NOT LIKE e'%\n%' AND message NOT LIKE '%canceling context'
 ----
 (0,0)  === SPAN START: sql txn implicit ===  sql txn implicit
 (1,0)  === SPAN START: sql txn ===           sql txn implicit

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -314,7 +315,7 @@ func (s *Server) ServeConn(ctx context.Context, conn net.Conn) error {
 	draining := s.mu.draining
 	if !draining {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithCancel(ctx)
+		ctx, cancel = contextutil.WithCancel(ctx)
 		done := make(chan struct{})
 		s.mu.connCancelMap[done] = cancel
 		defer func() {

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -491,7 +492,7 @@ func NewSession(
 	if traceSessionEventLogEnabled.Get(&e.cfg.Settings.SV) {
 		s.eventLog = trace.NewEventLog(fmt.Sprintf("sql [%s]", args.User), remoteStr)
 	}
-	s.context, s.cancel = context.WithCancel(ctx)
+	s.context, s.cancel = contextutil.WithCancel(ctx)
 
 	e.cfg.SessionRegistry.register(s)
 
@@ -1096,7 +1097,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	}
 
 	ts.sp = sp
-	ts.Ctx, ts.cancel = context.WithCancel(ctx)
+	ts.Ctx, ts.cancel = contextutil.WithCancel(ctx)
 	ts.SetState(AutoRetry)
 	s.Tracing.onNewSQLTxn(ts.sp)
 

--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -1,0 +1,39 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package contextutil
+
+import (
+	"runtime/debug"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// WithCancel adds an info log to context.WithCancel's CancelFunc.
+func WithCancel(parent context.Context) (context.Context, context.CancelFunc) {
+	return wrap(context.WithCancel(parent))
+}
+
+func wrap(ctx context.Context, cancel context.CancelFunc) (context.Context, context.CancelFunc) {
+	return ctx, func() {
+		if log.V(1) {
+			log.InfofDepth(ctx, 1, "canceling context:\n%s", debug.Stack())
+		} else {
+			log.InfofDepth(ctx, 1, "canceling context")
+		}
+		cancel()
+	}
+}


### PR DESCRIPTION
We are currently attempting to track down various errors with context
cancelled messages (see #18652, #15332, #19199). In order to assist
in this debugging, add a contextutil package that wraps calls to
cancel with an info Log that prints the line that caused the cancel
to execute.

For now only selectively add this to suspect locations. Adding it to
all cancel funcs produces a huge amount of log spam.