### PR TITLE
storage: deflake TestNodeHeartbeatCallback

### DIFF
--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -244,6 +244,9 @@ func TestNodeHeartbeatCallback(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	// NB: since the heartbeat callback is invoked synchronously in
+	// `Heartbeat()` which this goroutine invoked, we don't need to wrap this in
+	// a retry.
 	if err := verifyUptimes(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The node could become live by observing the Gossip update (triggered by its
heartbeat write) before getting to the point in `heartbeatInternal` at which
it would invoke the heartbeat callback. As a result, one location in this
test needs to be prepared to wait for a split second.

Flaky in the hundreds before, now not flaky with 2k+ iterations.

Fixes #19362.