### PR TITLE
kv: increase max gossip cycles in TestGetFirstRangeDescriptor

### DIFF
--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -1148,7 +1148,7 @@ func TestGetFirstRangeDescriptor(t *testing.T) {
 	if err := n.Nodes[1].Gossip.AddInfoProto(gossip.KeyFirstRangeDescriptor, expectedDesc, time.Hour); err != nil {
 		t.Fatal(err)
 	}
-	maxCycles := 10
+	const maxCycles = 25
 	n.SimulateNetwork(func(cycle int, network *simulation.Network) bool {
 		desc, err := ds.FirstRange()
 		if err != nil {


### PR DESCRIPTION
Fixes #19257.

I was never actually able to reproduce the flake, but since gossip is
all probabilistic, it will always be possible. This change bumps up the
max gossip cycles from 10 to 25. The only other place where we fail a
test after a certain number of cycles is in `TestGossipStorage`, where
we wait for 1000 cycles.