### PR TITLE
sql: Fix DROP INDEX IF EXISTS failure with 'idx' syntax

### DIFF
--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -242,8 +242,11 @@ type fullIndexName struct {
 //   Notes: postgres allows only the index owner to DROP an index.
 //          mysql requires the INDEX privilege on the table.
 func (p *planner) DropIndex(ctx context.Context, n *parser.DropIndex) (planNode, error) {
-	idxNames := make([]fullIndexName, len(n.IndexList))
-	for i, index := range n.IndexList {
+	// Keep a track of the indexes that exist to check. When the IF EXISTS
+	// options are provided, we will simply not include any indexes that
+	// don't exist and continue execution.
+	idxNames := make([]fullIndexName, 0, len(n.IndexList))
+	for _, index := range n.IndexList {
 		tn, err := p.expandIndexName(ctx, index, false /* requireTable */)
 		if err != nil {
 			return nil, err
@@ -251,8 +254,8 @@ func (p *planner) DropIndex(ctx context.Context, n *parser.DropIndex) (planNode,
 			// Only index names of the form "idx" throw an error here if they
 			// don't exist.
 			if n.IfExists {
-				// Noop.
-				return &zeroNode{}, nil
+				// Skip this index and don't return an error.
+				continue
 			}
 			// Index does not exist, but we want it to error out.
 			return nil, fmt.Errorf("index %q not found", index.Index)
@@ -267,8 +270,7 @@ func (p *planner) DropIndex(ctx context.Context, n *parser.DropIndex) (planNode,
 			return nil, err
 		}
 
-		idxNames[i].tn = tn
-		idxNames[i].idxName = index.Index
+		idxNames = append(idxNames, fullIndexName{tn: tn, idxName: index.Index})
 	}
 	return &dropIndexNode{n: n, idxNames: idxNames}, nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -57,8 +57,10 @@ users  foo      false   2    id      ASC        false    true
 users  bar      true    1    id      ASC        false    false
 users  bar      true    2    name    ASC        false    false
 
+# Also test that dropping with a non-existing index still drops 'foo'.
+
 statement ok
-DROP INDEX IF EXISTS users@foo
+DROP INDEX IF EXISTS users@foo, users@zap
 
 query TTBITTBB colnames
 SHOW INDEXES FROM users
@@ -178,8 +180,10 @@ users
 statement ok
 CREATE INDEX baz ON users (name)
 
+# Also test that dropping with a non-existing index still drops 'baz'.
+
 statement ok
-DROP INDEX IF EXISTS baz
+DROP INDEX IF EXISTS baz, zap
 
 query TTBITTBB colnames
 SHOW INDEXES FROM users
@@ -187,7 +191,7 @@ SHOW INDEXES FROM users
 Table  Name     Unique  Seq  Column  Direction  Storing  Implicit
 users  primary  true    1    id      ASC        false    false
 
-# Test that it still succeeds without an index.
+# Test that it still succeeds when an index does not exist.
 
 statement ok
 DROP INDEX IF EXISTS baz

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -19,6 +19,9 @@ CREATE TABLE othertable (
 statement error index name "baw" is ambiguous
 DROP INDEX baw
 
+statement error index name "baw" is ambiguous
+DROP INDEX IF EXISTS baw
+
 statement ok
 DROP TABLE othertable
 
@@ -38,11 +41,11 @@ users  foo      false   2    id      ASC        false    true
 users  bar      true    1    id      ASC        false    false
 users  bar      true    2    name    ASC        false    false
 
-statement error index "ffo" does not exist
-DROP INDEX users@ffo
+statement error index "zap" does not exist
+DROP INDEX users@zap
 
 statement ok
-DROP INDEX IF EXISTS users@ffo
+DROP INDEX IF EXISTS users@zap
 
 query TTBITTBB colnames
 SHOW INDEXES FROM users
@@ -169,3 +172,22 @@ query T
 SHOW TABLES
 ----
 users
+
+# Test the syntax without a '@'
+
+statement ok
+CREATE INDEX baz ON users (name)
+
+statement ok
+DROP INDEX IF EXISTS baz
+
+query TTBITTBB colnames
+SHOW INDEXES FROM users
+----
+Table  Name     Unique  Seq  Column  Direction  Storing  Implicit
+users  primary  true    1    id      ASC        false    false
+
+# Test that it still succeeds without an index.
+
+statement ok
+DROP INDEX IF EXISTS baz

--- a/pkg/sql/rename.go
+++ b/pkg/sql/rename.go
@@ -252,7 +252,7 @@ func (p *planner) RenameTable(ctx context.Context, n *parser.RenameTable) (planN
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) RenameIndex(ctx context.Context, n *parser.RenameIndex) (planNode, error) {
-	tn, err := p.expandIndexName(ctx, n.Index)
+	tn, err := p.expandIndexName(ctx, n.Index, true /* requireTable */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -744,12 +744,18 @@ func (p *planner) getQualifiedTableName(
 	return tbName.String(), nil
 }
 
-// findTableContainingIndex returns the name of the table containing
-// an index of the given name. An error is returned if the index is
-// not found or if the index name is ambiguous (i.e. exists in
-// multiple tables).
+// findTableContainingIndex returns the name of the table containing an
+// index of the given name. An error is returned if the index name is
+// ambiguous (i.e. exists in multiple tables). If no table is found and
+// requireTable is true, an error will be returned, otherwise the
+// TableName returned will be nil.
 func (p *planner) findTableContainingIndex(
-	ctx context.Context, txn *client.Txn, vt VirtualTabler, dbName parser.Name, idxName parser.Name,
+	ctx context.Context,
+	txn *client.Txn,
+	vt VirtualTabler,
+	dbName parser.Name,
+	idxName parser.Name,
+	requireTable bool,
 ) (result *parser.TableName, err error) {
 	dbDesc, err := MustGetDatabaseDesc(ctx, txn, vt, string(dbName))
 	if err != nil {
@@ -780,17 +786,19 @@ func (p *planner) findTableContainingIndex(
 		}
 		result = tn
 	}
-	if result == nil {
+	if result == nil && requireTable {
 		return nil, fmt.Errorf("index %q not in any of the tables %v", idxName, tns)
 	}
 	return result, nil
 }
 
-// expandIndexName ensures that the index name is qualified with a
-// table name, and searches the table name if not yet specified. It returns
-// the TableName of the underlying table for convenience.
+// expandIndexName ensures that the index name is qualified with a table
+// name, and searches the table name if not yet specified. It returns
+// the TableName of the underlying table for convenience. If no table is
+// found and requireTable is true an error will be returned, otherwise
+// the TableName returned will be nil.
 func (p *planner) expandIndexName(
-	ctx context.Context, index *parser.TableNameWithIndex,
+	ctx context.Context, index *parser.TableNameWithIndex, requireTable bool,
 ) (*parser.TableName, error) {
 	tn, err := index.Table.NormalizeWithDatabaseName(p.session.Database)
 	if err != nil {
@@ -807,9 +815,19 @@ func (p *planner) expandIndexName(
 		if index.Index == "" {
 			index.Index = tn.TableName
 		}
-		realTableName, err := p.findTableContainingIndex(ctx, p.txn, p.getVirtualTabler(), tn.DatabaseName, index.Index)
+		realTableName, err := p.findTableContainingIndex(
+			ctx,
+			p.txn, p.getVirtualTabler(),
+			tn.DatabaseName,
+			index.Index,
+			requireTable,
+		)
 		if err != nil {
 			return nil, err
+		} else if realTableName == nil {
+			// NB: realTableName is nil here if and only if requireTable is
+			// false, otherwise err would be non-nil.
+			return nil, nil
 		}
 		index.Table.TableNameReference = realTableName
 		tn = realTableName
@@ -835,7 +853,7 @@ func (p *planner) getTableAndIndex(
 		tn, err = table.NormalizeWithDatabaseName(p.session.Database)
 	} else {
 		// Variant: ALTER INDEX
-		tn, err = p.expandIndexName(ctx, tableWithIndex)
+		tn, err = p.expandIndexName(ctx, tableWithIndex, true /* requireTable */)
 	}
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Previously, if you don't use the `table@idx` syntax but instead use
`idx` then `DROP INDEX IF EXISTS` behaves like `DROP INDEX`, and it
throws an error if the index doesn't exist.

---
WIP note that the tests are expected to fail due to the unresolved comments below.