### PR TITLE
acceptance/cluster: don't run containers as root

### DIFF
--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -15,6 +15,7 @@
 package acceptance
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,8 +23,8 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/docker/docker/api/types/container"
 )
 
 const testGlob = "../cli/interactive_tests/test*.tcl"
@@ -40,10 +41,9 @@ func TestDockerCLI(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)
 
-	containerConfig := container.Config{
-		Image: acceptanceImage,
-		Cmd:   []string{"stat", cluster.CockroachBinaryInContainer},
-	}
+	containerConfig := defaultContainerConfig()
+	containerConfig.Cmd = []string{"stat", cluster.CockroachBinaryInContainer}
+	containerConfig.Env = []string{fmt.Sprintf("PGUSER=%s", security.RootUser)}
 	ctx := context.Background()
 	if err := testDockerOneShot(ctx, t, "cli_test", containerConfig); err != nil {
 		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)
@@ -94,10 +94,8 @@ func TestDockerStartFlags(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)
 
-	containerConfig := container.Config{
-		Image: acceptanceImage,
-		Cmd:   []string{"stat", cluster.CockroachBinaryInContainer},
-	}
+	containerConfig := defaultContainerConfig()
+	containerConfig.Cmd = []string{"stat", cluster.CockroachBinaryInContainer}
 	ctx := context.Background()
 	if err := testDockerOneShot(ctx, t, "start_flags_test", containerConfig); err != nil {
 		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -101,8 +101,8 @@ func nodeStr(l *DockerCluster, i int) string {
 	return fmt.Sprintf("roach-%s-%d", l.clusterID, i)
 }
 
-func dataStr(node, store int) string {
-	return fmt.Sprintf("/data%d.%d", node, store)
+func storeStr(node, store int) string {
+	return fmt.Sprintf("data%d.%d", node, store)
 }
 
 // The various event types.
@@ -118,9 +118,9 @@ type Event struct {
 }
 
 type testStore struct {
-	index   int
-	dataStr string
-	config  StoreConfig
+	index  int
+	dir    string
+	config StoreConfig
 }
 
 type testNode struct {
@@ -150,16 +150,17 @@ type DockerCluster struct {
 	clusterID            string
 	networkID            string
 	networkName          string
-	logDir               string // no logging if empty
-	logDirRemovable      bool   // if true, the log directory can be removed after use
+	// Careful! volumesDir will be emptied during cluster cleanup.
+	volumesDir string
 }
 
 // CreateDocker creates a Docker-based cockroach cluster. The stopper is used to
 // gracefully shutdown the channel (e.g. when a signal arrives). The cluster
-// must be started before being used and keeps logs in the specified logDir, if
-// supplied.
+// must be started before being used and keeps container volumes in the
+// specified volumesDir, including logs and cockroach stores. If volumesDir is
+// empty, a temporary directory is created.
 func CreateDocker(
-	ctx context.Context, cfg TestConfig, logDir string, stopper *stop.Stopper,
+	ctx context.Context, cfg TestConfig, volumesDir string, stopper *stop.Stopper,
 ) *DockerCluster {
 	select {
 	case <-stopper.ShouldStop():
@@ -179,32 +180,30 @@ func CreateDocker(
 
 	clusterID := uuid.MakeV4()
 	clusterIDS := clusterID.Short()
-	// Only pass a nonzero logDir down to DockerCluster when instructed to keep
-	// logs.
-	var uniqueLogDir string
-	logDirRemovable := false
-	if logDir != "" {
+
+	if volumesDir == "" {
+		volumesDir, err = ioutil.TempDir("", fmt.Sprintf("cockroach-acceptance-%s", clusterIDS))
+		maybePanic(err)
+	} else {
+		volumesDir = filepath.Join(volumesDir, clusterIDS)
+	}
+	if !filepath.IsAbs(volumesDir) {
 		pwd, err := os.Getwd()
 		maybePanic(err)
-
-		uniqueLogDir = fmt.Sprintf("%s-%s", logDir, clusterIDS)
-		if !filepath.IsAbs(uniqueLogDir) {
-			uniqueLogDir = filepath.Join(pwd, uniqueLogDir)
-		}
-		ensureLogDirExists(uniqueLogDir)
-		logDirRemovable = true
-		log.Infof(ctx, "local cluster log directory: %s", uniqueLogDir)
+		volumesDir = filepath.Join(pwd, volumesDir)
 	}
+	maybePanic(os.MkdirAll(volumesDir, 0755))
+	log.Infof(ctx, "cluster volume directory: %s", volumesDir)
+
 	return &DockerCluster{
 		clusterID: clusterIDS,
 		client:    resilientDockerClient{APIClient: cli},
 		config:    cfg,
 		stopper:   stopper,
 		// TODO(tschottdorf): deadlocks will occur if these channels fill up.
-		events:          make(chan Event, 1000),
-		expectedEvents:  make(chan Event, 1000),
-		logDir:          uniqueLogDir,
-		logDirRemovable: logDirRemovable,
+		events:         make(chan Event, 1000),
+		expectedEvents: make(chan Event, 1000),
+		volumesDir:     volumesDir,
 	}
 }
 
@@ -343,11 +342,9 @@ func (l *DockerCluster) initCluster(ctx context.Context) {
 	binds := []string{
 		l.CertsDir + ":/certs",
 		filepath.Join(pwd, "..") + ":/go/src/github.com/cockroachdb/cockroach",
+		filepath.Join(l.volumesDir, "logs") + ":/logs",
 	}
 
-	if l.logDir != "" {
-		binds = append(binds, l.logDir+":/logs")
-	}
 	if *cockroachImage == defaultImage {
 		path, err := filepath.Abs(*CockroachBinary)
 		maybePanic(err)
@@ -355,7 +352,6 @@ func (l *DockerCluster) initCluster(ctx context.Context) {
 	}
 
 	l.Nodes = []*testNode{}
-	vols := map[string]struct{}{}
 	// Expand the cluster configuration into nodes and stores per node.
 	for i, nc := range l.config.Nodes {
 		newTestNode := &testNode{
@@ -364,12 +360,14 @@ func (l *DockerCluster) initCluster(ctx context.Context) {
 			nodeStr: nodeStr(l, i),
 		}
 		for j, sc := range nc.Stores {
-			vols[dataStr(i, j)] = struct{}{}
+			hostDir := filepath.Join(l.volumesDir, storeStr(i, j))
+			containerDir := "/" + storeStr(i, j)
+			binds = append(binds, hostDir+":"+containerDir)
 			newTestNode.stores = append(newTestNode.stores,
 				testStore{
-					config:  sc,
-					index:   j,
-					dataStr: dataStr(i, j),
+					config: sc,
+					index:  j,
+					dir:    containerDir,
 				})
 		}
 		l.Nodes = append(l.Nodes, newTestNode)
@@ -383,7 +381,6 @@ func (l *DockerCluster) initCluster(ctx context.Context) {
 		l,
 		container.Config{
 			Image:      *cockroachImage,
-			Volumes:    vols,
 			Entrypoint: []string{"/bin/true"},
 		}, container.HostConfig{
 			Binds:           binds,
@@ -497,7 +494,7 @@ func (l *DockerCluster) startNode(ctx context.Context, node *testNode) {
 
 	for _, store := range node.stores {
 		storeSpec := base.StoreSpec{
-			Path:        store.dataStr,
+			Path:        store.dir,
 			SizeInBytes: int64(store.config.MaxRanges) * maxRangeBytes,
 		}
 		cmd = append(cmd, fmt.Sprintf("--store=%s", storeSpec))
@@ -507,18 +504,12 @@ func (l *DockerCluster) startNode(ctx context.Context, node *testNode) {
 		cmd = append(cmd, "--join="+net.JoinHostPort(l.Nodes[0].nodeStr, base.DefaultPort))
 	}
 
-	var localLogDir string
-	if len(l.logDir) > 0 {
-		dockerLogDir := "/logs/" + node.nodeStr
-		localLogDir = filepath.Join(l.logDir, node.nodeStr)
-		ensureLogDirExists(localLogDir)
-		cmd = append(
-			cmd,
-			"--logtostderr=ERROR",
-			"--log-dir="+dockerLogDir)
-	} else {
-		cmd = append(cmd, "--logtostderr=INFO")
-	}
+	dockerLogDir := "/logs/" + node.nodeStr
+	localLogDir := filepath.Join(l.volumesDir, "logs", node.nodeStr)
+	cmd = append(
+		cmd,
+		"--logtostderr=ERROR",
+		"--log-dir="+dockerLogDir)
 	env := []string{
 		"COCKROACH_SCAN_MAX_IDLE_TIME=200ms",
 		"COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE=true",
@@ -781,7 +772,6 @@ func (l *DockerCluster) stop(ctx context.Context) {
 		_ = os.RemoveAll(l.CertsDir)
 		l.CertsDir = ""
 	}
-	outputLogDir := l.logDir
 	for i, n := range l.Nodes {
 		if n.Container == nil {
 			continue
@@ -789,28 +779,19 @@ func (l *DockerCluster) stop(ctx context.Context) {
 		ci, err := n.Inspect(ctx)
 		crashed := err != nil || (!ci.State.Running && ci.State.ExitCode != 0)
 		maybePanic(n.Kill(ctx))
-		if crashed && outputLogDir == "" {
-			outputLogDir, err = ioutil.TempDir("", "crashed_nodes")
-			if err != nil {
-				panic(err)
-			}
-		}
-		if crashed || l.logDir != "" {
-			// TODO(bdarnell): make these filenames more consistent with
-			// structured logs?
-			file := filepath.Join(outputLogDir, nodeStr(l, i),
-				fmt.Sprintf("stderr.%s.log", strings.Replace(
-					timeutil.Now().Format(time.RFC3339), ":", "_", -1)))
-
-			maybePanic(os.MkdirAll(filepath.Dir(file), 0777))
-			w, err := os.Create(file)
-			maybePanic(err)
-			defer w.Close()
-			maybePanic(n.Logs(ctx, w))
-			log.Infof(ctx, "node %d: stderr at %s", i, file)
-			if crashed {
-				log.Infof(ctx, "~~~ node %d CRASHED ~~~~", i)
-			}
+		// TODO(bdarnell): make these filenames more consistent with structured
+		// logs?
+		file := filepath.Join(l.volumesDir, "logs", nodeStr(l, i),
+			fmt.Sprintf("stderr.%s.log", strings.Replace(
+				timeutil.Now().Format(time.RFC3339), ":", "_", -1)))
+		maybePanic(os.MkdirAll(filepath.Dir(file), 0755))
+		w, err := os.Create(file)
+		maybePanic(err)
+		defer w.Close()
+		maybePanic(n.Logs(ctx, w))
+		log.Infof(ctx, "node %d: stderr at %s", i, file)
+		if crashed {
+			log.Infof(ctx, "~~~ node %d CRASHED ~~~~", i)
 		}
 		maybePanic(n.Remove(ctx))
 	}
@@ -907,8 +888,6 @@ func (l *DockerCluster) ExecCLI(ctx context.Context, i int, cmd []string) (strin
 	cmd = append([]string{CockroachBinaryInContainer}, cmd...)
 	cmd = append(cmd, "--host", l.Hostname(i), "--certs-dir=/certs")
 	cfg := types.ExecConfig{
-		User:         "root",
-		Privileged:   true,
 		Cmd:          cmd,
 		AttachStderr: true,
 		AttachStdout: true,
@@ -950,23 +929,19 @@ func (l *DockerCluster) ExecCLI(ctx context.Context, i int, cmd []string) (strin
 	return outputStream.String(), errorStream.String(), nil
 }
 
-func ensureLogDirExists(logDir string) {
-	// Ensure that the path exists, with all its parents.
-	// If we don't make sure the directory exists, Docker will and then we
-	// may run into ownership issues (think Docker running as root, but us
-	// running as a regular Joe as it happens on CircleCI).
-	maybePanic(os.MkdirAll(logDir, 0755))
-	// Now make the last component, and just the last one, writable by
-	// anyone, and set the gid and uid bit so that the owner is
-	// propagated to sub-directories.
-	maybePanic(os.Chmod(logDir, 0777|os.ModeSetuid|os.ModeSetgid))
-}
-
-// Cleanup removes the log directory if it was initially created
-// by this DockerCluster.
-func (l *DockerCluster) Cleanup(ctx context.Context) {
-	if l.logDir != "" && l.logDirRemovable {
-		if err := os.RemoveAll(l.logDir); err != nil {
+// Cleanup removes the cluster's volumes directory, optionally preserving the
+// logs directory.
+func (l *DockerCluster) Cleanup(ctx context.Context, preserveLogs bool) {
+	volumes, err := ioutil.ReadDir(l.volumesDir)
+	if err != nil {
+		log.Warning(ctx, err)
+		return
+	}
+	for _, v := range volumes {
+		if preserveLogs && v.Name() == "logs" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(l.volumesDir, v.Name())); err != nil {
 			log.Warning(ctx, err)
 		}
 	}

--- a/pkg/acceptance/csharp_test.go
+++ b/pkg/acceptance/csharp_test.go
@@ -35,7 +35,7 @@ func TestDockerCSharp(t *testing.T) {
 const csharp = `
 set -euxo pipefail
 
-cd /testdata/csharp
+cd /mnt/data/csharp
 
 # In dotnet, to get a cert with a private key, we have to use a pfx file.
 # See:

--- a/pkg/acceptance/java_test.go
+++ b/pkg/acceptance/java_test.go
@@ -34,7 +34,7 @@ func TestDockerJava(t *testing.T) {
 
 const java = `
 set -e
-cd /testdata/java
+cd /mnt/data/java
 # See: https://basildoncoder.com/blog/postgresql-jdbc-client-certificates.html
 openssl pkcs8 -topk8 -inform PEM -outform DER -in /certs/node.key -out key.pk8 -nocrypt
 

--- a/pkg/acceptance/node_test.go
+++ b/pkg/acceptance/node_test.go
@@ -34,7 +34,7 @@ func TestDockerNodeJS(t *testing.T) {
 
 const nodeJS = `
 set -e
-cd /testdata/node
+cd /mnt/data/node
 
 export SHOULD_FAIL=%v
 # Get access to globally installed node modules.

--- a/pkg/acceptance/php_test.go
+++ b/pkg/acceptance/php_test.go
@@ -45,7 +45,7 @@ $result = pg_query_params('SELECT 1, 2 > $1, $1', [%v])
 $arr = pg_fetch_row($result);
 ($arr === ['1', 'f', '3']) or kill('Unexpected: ' . print_r($arr, true));
 
-$dbh = new PDO('pgsql:','', null, array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION));
+$dbh = new PDO('pgsql:','root', null, array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION));
 $dbh->exec('CREATE database bank');
 $dbh->exec('CREATE table bank.accounts (id INT PRIMARY KEY, balance INT)');
 $dbh->exec('INSERT INTO bank.accounts (id, balance) VALUES (1, 1000), (2, 250)');

--- a/pkg/acceptance/reference_test.go
+++ b/pkg/acceptance/reference_test.go
@@ -22,14 +22,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/docker/docker/api/types/container"
 )
 
 func runReferenceTestWithScript(ctx context.Context, t *testing.T, script string) {
-	containerConfig := container.Config{
-		Image: acceptanceImage,
-		Cmd:   []string{"stat", cluster.CockroachBinaryInContainer},
-	}
+	containerConfig := defaultContainerConfig()
+	containerConfig.Cmd = []string{"stat", cluster.CockroachBinaryInContainer}
 	if err := testDockerOneShot(ctx, t, "reference", containerConfig); err != nil {
 		t.Skipf(`TODO(dt): No binary in one-shot container, see #6086: %s`, err)
 	}
@@ -45,8 +42,8 @@ func runReadWriteReferenceTest(
 ) {
 	referenceTestScript := fmt.Sprintf(`
 set -xe
-mkdir /old
-cd /old
+mkdir old
+cd old
 
 touch oldout newout
 function finish() {

--- a/pkg/acceptance/testdata/Dockerfile
+++ b/pkg/acceptance/testdata/Dockerfile
@@ -71,6 +71,9 @@ RUN curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg > /etc/apt/trusted.gpg.d
     xmlstarlet \
     yarn
 
+RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.0.0/autouseradd-1.0.0-amd64.tar.gz \
+    | tar xz -C /usr --strip-components 1
+
 # When system packages are not available for a language's PostgreSQL driver,
 # fall back to using that language's package manager. The high-level process
 # looks like this:
@@ -117,4 +120,4 @@ RUN (cd /testdata/node && yarn install && mv node_modules /usr/lib/node) \
 RUN apt-get purge --yes \
     curl \
     xmlstarlet \
- && rm -rf /var/lib/apt/lists/* /testdata
+ && rm -rf /tmp/* /var/lib/apt/lists/* /testdata

--- a/pkg/acceptance/testdata/csharp/Program.cs
+++ b/pkg/acceptance/testdata/csharp/Program.cs
@@ -13,6 +13,7 @@ namespace CockroachDrivers
             var connStringBuilder = new NpgsqlConnectionStringBuilder();
             connStringBuilder.Port = int.Parse(Environment.GetEnvironmentVariable("PGPORT"));
             connStringBuilder.Host = Environment.GetEnvironmentVariable("PGHOST");
+            connStringBuilder.Username = Environment.GetEnvironmentVariable("PGUSER");
             connStringBuilder.SslMode = SslMode.Require;
             connStringBuilder.TrustServerCertificate = true;
             Simple(connStringBuilder.ConnectionString);

--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 )
@@ -32,10 +33,12 @@ func defaultContainerConfig() container.Config {
 	return container.Config{
 		Image: acceptanceImage,
 		Env: []string{
+			fmt.Sprintf("PGUSER=%s", security.RootUser),
 			fmt.Sprintf("PGPORT=%s", base.DefaultPort),
 			"PGSSLCERT=/certs/node.crt",
 			"PGSSLKEY=/certs/node.key",
 		},
+		Entrypoint: []string{"autouseradd", "-u", "roach", "-C", "/home/roach", "--"},
 	}
 }
 
@@ -60,7 +63,7 @@ func testDockerSuccess(ctx context.Context, t *testing.T, name string, cmd []str
 const (
 	// Iterating against a locally built version of the docker image can be done
 	// by changing acceptanceImage to the hash of the container.
-	acceptanceImage = "docker.io/cockroachdb/acceptance:20171108-172143"
+	acceptanceImage = "docker.io/cockroachdb/acceptance:20171109-044311"
 )
 
 func testDocker(
@@ -88,15 +91,13 @@ func testDocker(
 		}
 		hostConfig := container.HostConfig{
 			NetworkMode: "host",
-			Binds:       []string{filepath.Join(pwd, "testdata") + ":/testdata"},
+			Binds:       []string{filepath.Join(pwd, "testdata") + ":/mnt/data"},
 		}
 		err = l.OneShot(
 			ctx, acceptanceImage, types.ImagePullOptions{}, containerConfig, hostConfig, "docker-"+name,
 		)
-		if err == nil {
-			// Clean up the log files if the run was successful.
-			l.Cleanup(ctx)
-		}
+		preserveLogs := err != nil
+		l.Cleanup(ctx, preserveLogs)
 	})
 	return err
 }

--- a/pkg/cli/interactive_tests/test_extern_dir.tcl
+++ b/pkg/cli/interactive_tests/test_extern_dir.tcl
@@ -37,7 +37,7 @@ end_test
 start_test "Check implicit external I/O dir under store dir"
 
 send "$argv start --insecure --store=$storedir\r"
-eexpect "external I/O path:   /mystore/extern"
+eexpect "external I/O path:   $env(HOME)/$storedir/extern"
 interrupt
 eexpect "shutdown completed"
 


### PR DESCRIPTION
Root containers leak root files and directories everywhere, which brick
TeamCity agents unless one is very, very careful. Run the containers as
the invoking user instead.

This requires replacing all volumes with bind mounts, as volumes are
always root-owned and thus unwriteable by the new container user. Bind
mounts, by contrast, inherit the permissions of the file or directory on
the host. (Under the hood, volumes are just automatically-managed bind
mounts to somewhere in /var/lib/docker/, so there's no performance cost
to this.)

