### PR TITLE
cherrypick-1.1: cli: simplify and improve dump performance

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -855,3 +855,43 @@ CREATE VIEW bar ("1") AS SELECT 1;
 		t.Fatalf("expected: %s\ngot: %s", expect, out)
 	}
 }
+
+// TestDumpPrimaryKeyConstraint tests that a primary key with a non-default
+// name works.
+func TestDumpPrimaryKeyConstraint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest(cliTestParams{t: t})
+	defer c.cleanup()
+
+	const create = `
+	CREATE DATABASE d;
+	CREATE TABLE d.t (
+		i int,
+		CONSTRAINT pk_name PRIMARY KEY (i)
+	);
+	INSERT INTO d.t VALUES (1);
+`
+
+	c.RunWithArgs([]string{"sql", "-e", create})
+
+	out, err := c.RunWithCapture("dump d t")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const expect = `dump d t
+CREATE TABLE t (
+	i INT NOT NULL,
+	CONSTRAINT pk_name PRIMARY KEY (i ASC),
+	FAMILY "primary" (i)
+);
+
+INSERT INTO t (i) VALUES
+	(1);
+`
+
+	if string(out) != expect {
+		t.Fatalf("expected: %s\ngot: %s", expect, out)
+	}
+}


### PR DESCRIPTION
Cherrypick #18472 and #19325.

#18472 was initially not included in 1.1 because it was thought to only be a performance increase, and the release cycle was late enough that it wasn't worth the risk to include it. However #18500 showed that the 1.1 branch had a known bug, so now it may be important enough to include here.

We could have alternatively made a from-scratch change to just fix the bug in 1.1, but I think it's better to cherrypick a more thought out and tested solution instead.

Our other option is to not accept the risk of the code changes here, and document the bug as a known limitation. However I think the change is safe enough to include, and comes with a hefty performance improvement to boot.

Fixes #18500 