### PR TITLE
sql: Add server_version_num session variable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -145,7 +145,7 @@ EXPLAIN SHOW DATABASE
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 20 rows
+2  ·       size  2 columns, 21 rows
 
 query ITTT
 EXPLAIN SHOW TIME ZONE
@@ -153,7 +153,7 @@ EXPLAIN SHOW TIME ZONE
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 20 rows
+2  ·       size  2 columns, 21 rows
 
 query ITTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -161,7 +161,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 20 rows
+2  ·       size  2 columns, 21 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -169,7 +169,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 20 rows
+2  ·       size  2 columns, 21 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -177,7 +177,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 20 rows
+2  ·       size  2 columns, 21 rows
 
 query ITTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1043,6 +1043,7 @@ max_index_keys                 32            NULL      NULL        NULL        s
 node_id                        1             NULL      NULL        NULL        string
 search_path                    ·             NULL      NULL        NULL        string
 server_version                 9.5.0         NULL      NULL        NULL        string
+server_version_num             90500         NULL      NULL        NULL        string
 session_user                   root          NULL      NULL        NULL        string
 sql_safe_updates               false         NULL      NULL        NULL        string
 standard_conforming_strings    on            NULL      NULL        NULL        string
@@ -1068,6 +1069,7 @@ max_index_keys                 32            NULL  user     NULL      32        
 node_id                        1             NULL  user     NULL      1             1
 search_path                    ·             NULL  user     NULL      ·             ·
 server_version                 9.5.0         NULL  user     NULL      9.5.0         9.5.0
+server_version_num             90500         NULL  user     NULL      90500         90500
 session_user                   root          NULL  user     NULL      root          root
 sql_safe_updates               false         NULL  user     NULL      false         false
 standard_conforming_strings    on            NULL  user     NULL      on            on
@@ -1093,6 +1095,7 @@ max_index_keys                 NULL    NULL     NULL     NULL        NULL
 node_id                        NULL    NULL     NULL     NULL        NULL
 search_path                    NULL    NULL     NULL     NULL        NULL
 server_version                 NULL    NULL     NULL     NULL        NULL
+server_version_num             NULL    NULL     NULL     NULL        NULL
 session_user                   NULL    NULL     NULL     NULL        NULL
 sql_safe_updates               NULL    NULL     NULL     NULL        NULL
 standard_conforming_strings    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/reset
+++ b/pkg/sql/logictest/testdata/logic_test/reset
@@ -22,6 +22,9 @@ SHOW SEARCH_PATH
 statement error variable "server_version" cannot be reset
 RESET SERVER_VERSION
 
+statement error variable "server_version_num" cannot be reset
+RESET SERVER_VERSION_NUM
+
 # Lower case
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -89,6 +89,7 @@ max_index_keys                 32
 node_id                        1
 search_path                    ·
 server_version                 9.5.0
+server_version_num             90500
 session_user                   root
 sql_safe_updates               false
 standard_conforming_strings    on
@@ -176,6 +177,12 @@ SHOW SERVER_VERSION
 ----
 server_version
 9.5.0
+
+query T colnames
+SHOW SERVER_VERSION_NUM
+----
+server_version_num
+90500
 
 # Test read-only variables
 statement error variable "max_index_keys" cannot be changed

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -34,6 +34,7 @@ max_index_keys                 32
 node_id                        1
 search_path                    ·
 server_version                 9.5.0
+server_version_num             90500
 session_user                   root
 sql_safe_updates               false
 standard_conforming_strings    on

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -33,6 +33,8 @@ import (
 const (
 	// PgServerVersion is the latest version of postgres that we claim to support.
 	PgServerVersion = "9.5.0"
+	// PgServerVersionNum is the latest version of postgres that we claim to support in the numeric format of "server_version_num".
+	PgServerVersionNum = "90500"
 )
 
 // sessionVar provides a unified interface for performing operations on
@@ -265,6 +267,11 @@ var varGen = map[string]sessionVar{
 	`server_version`: {
 		Get: func(*Session) string { return PgServerVersion },
 	},
+
+	`server_version_num`: {
+		Get: func(*Session) string { return PgServerVersionNum },
+	},
+
 	`session_user`: {
 		Get: func(session *Session) string { return session.User },
 	},


### PR DESCRIPTION
I've come across an ORM that is using this session vaiable to detect
postgres version. Seems ok to support this since server_version
is already present. This can make life easier when porting an app from
postgres to cockroachdb.

Not sure about the type of the var being string type, but I can see
other vars that are integers in postgres that are represented as strings
here (max_index_keys for example).

The specific ORM I've come across is "dat" for Go: https://github.com/mgutz/dat

My guess is that other ORMs/frameworks would use this variable too to check
postgres version > some version.