### PR TITLE
storage: improve TestPushTxnQueueCancel

### DIFF
--- a/pkg/storage/push_txn_queue_test.go
+++ b/pkg/storage/push_txn_queue_test.go
@@ -259,6 +259,11 @@ func TestPushTxnQueueCancel(t *testing.T) {
 	}()
 
 	testutils.SucceedsSoon(t, func() error {
+		select {
+		case rwe := <-retCh:
+			t.Fatalf("MaybeWaitForPush terminated prematurely: %+v", rwe)
+		default:
+		}
 		expDeps := []uuid.UUID{pusher.ID}
 		if deps := ptq.GetDependents(txn.ID); !reflect.DeepEqual(deps, expDeps) {
 			return errors.Errorf("expected GetDependents %+v; got %+v", expDeps, deps)


### PR DESCRIPTION
I was unable to reproduce

https://github.com/cockroachdb/cockroach/issues/19333

in >25k iterations, but I suspect an error was returned and the
test never got to check it. With these changes, the next time it
flakes we will have more intel.

Closes #19333.