### PR TITLE
sql: extract not-null constraints from filters

### DIFF
--- a/pkg/sql/expr_filter_test.go
+++ b/pkg/sql/expr_filter_test.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -159,6 +160,60 @@ func TestSplitFilter(t *testing.T) {
 			if exprStr != expr.String() {
 				t.Errorf("Expression changed after splitFilter; before: `%s` after: `%s`",
 					exprStr, expr.String())
+			}
+		})
+	}
+}
+
+func TestExtractNotNullConstraints(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Note: see testTableDesc for the variable schema.
+	testCases := []struct {
+		expr        string
+		notNullVars []int
+	}{
+		{`c`, []int{2}},
+		{`NOT c`, []int{2}},
+		{`a = 1`, []int{0}},
+		{`a IS NULL`, []int{}},
+		{`a IS NOT NULL`, []int{0}},
+		{`NOT (a = 1)`, []int{0}},
+		{`NOT (a IS NULL)`, []int{}}, // We could do better here.
+		{`NOT (a IS NOT NULL)`, []int{}},
+		{`(a IS NOT NULL) AND (b IS NOT NULL)`, []int{0, 1}},
+		{`(a IS NOT NULL) OR (b IS NOT NULL)`, []int{}},
+		{`(a IS NOT NULL) OR (a IS NULL)`, []int{}},
+		{`a > b`, []int{0, 1}},
+		{`a = b`, []int{0, 1}},
+		{`a + b > 1`, []int{0, 1}},
+		{`c OR d`, []int{}}, // `NULL OR true` and `true OR NULL` are true.
+		{`a = 1 AND b = 2`, []int{0, 1}},
+		{`a = 1 OR b = 2`, []int{}},
+		{`(a = 1 AND b = 2) OR (b = 3 AND j = 4)`, []int{1}},
+		{`(a, b) = (1, 2)`, []int{0, 1}},
+		{`(a, b) > (1, 2)`, []int{0, 1}},
+		{`a IN (b,j)`, []int{0}},
+		{`(a, b) IN ((1,j))`, []int{0, 1}},
+		{`a NOT IN (b,j)`, []int{0}},
+		{`(a, b) NOT IN ((1,j))`, []int{0, 1}},
+		{`(a + b, 1 + j) IN ((1, 2), (3, 4))`, []int{0, 1, 9}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expr, func(t *testing.T) {
+			evalCtx := parser.NewTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
+
+			sel := makeSelectNode(t)
+			expr := parseAndNormalizeExpr(t, evalCtx, tc.expr, sel)
+			result := extractNotNullConstraints(expr)
+			var expected util.FastIntSet
+			for _, v := range tc.notNullVars {
+				expected.Add(v)
+			}
+			if !result.Equals(expected) {
+				t.Errorf("expected %s, got %s", &expected, result)
 			}
 		})
 	}

--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -224,6 +224,7 @@ func (p *planner) selectIndex(
 		return &zeroNode{}, nil
 	}
 
+	s.origFilter = s.filter
 	s.filter = applyIndexConstraints(&p.evalCtx, s.filter, c.constraints)
 	if s.filter != nil {
 		// Constraint propagation may have produced new constant sub-expressions.

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1223,9 +1223,9 @@ EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
 ----
 0  group   ·            ·                     ("min(v)")       ·
 0  ·       aggregate 0  min(test.opt_test.v)  ·                ·
-1  render  ·            ·                     (v)              +v
+1  render  ·            ·                     (v)              v!=NULL; +v
 1  ·       render 0     test.opt_test.v       ·                ·
-2  scan    ·            ·                     (k[omitted], v)  k!=NULL; weak-key(k,v); +v
+2  scan    ·            ·                     (k[omitted], v)  k!=NULL; v!=NULL; key(k,v); +v
 2  ·       table        opt_test@v            ·                ·
 2  ·       spans        /#-                   ·                ·
 2  ·       limit        1                     ·                ·
@@ -1248,9 +1248,9 @@ EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
 ----
 0  group   ·            ·                     ("min(v)")  ·
 0  ·       aggregate 0  min(test.opt_test.v)  ·           ·
-1  render  ·            ·                     (v)         +v
+1  render  ·            ·                     (v)         v!=NULL; +v
 1  ·       render 0     test.opt_test.v       ·           ·
-2  scan    ·            ·                     (k, v)      k!=NULL; weak-key(k,v); +v
+2  scan    ·            ·                     (k, v)      k!=NULL; v!=NULL; key(k,v); +v
 2  ·       table        opt_test@v            ·           ·
 2  ·       spans        /#-                   ·           ·
 2  ·       filter       k != 4                ·           ·
@@ -1270,7 +1270,7 @@ EXPLAIN (VERBOSE) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
 0  ·       aggregate 0  min(test.opt_test.v + 1)            ·               ·
 1  render  ·            ·                                   ("v + 1")       ·
 1  ·       render 0     test.opt_test.v + 1                 ·               ·
-2  scan    ·            ·                                   (k, v)          k!=NULL; key(k)
+2  scan    ·            ·                                   (k, v)          k!=NULL; v!=NULL; key(k)
 2  ·       table        opt_test@primary                    ·               ·
 2  ·       spans        /#-                                 ·               ·
 2  ·       filter       (k != 4) AND ((v + 1) IS NOT NULL)  ·               ·

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -301,6 +301,24 @@ NULL
 2
 5
 
+# Here we can infer that v is not-NULL so eliding the node is correct.
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx WHERE v > 0
+----
+Level  Type    Field     Description  Columns          Ordering
+0      render  ·         ·            (v)              v!=NULL; key(v)
+0      ·       render 0  test.kv.v    ·                ·
+1      scan    ·         ·            (k[omitted], v)  v!=NULL; key(v)
+1      ·       table     kv@idx       ·                ·
+1      ·       spans     /1-          ·                ·
+
+query I rowsort
+SELECT DISTINCT v FROM kv@idx WHERE v > 0
+----
+1
+2
+5
+
 statement ok
 CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
 

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -65,7 +65,7 @@ EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-0  scan  ·       ·                              (k int, v int)  k!=NULL; key(k)
+0  scan  ·       ·                              (k int, v int)  k!=NULL; v!=NULL; key(k)
 0  ·     table   t@primary                      ·               ·
 0  ·     spans   ALL                            ·               ·
 0  ·     filter  ((v)[int] > (123)[int])[bool]  ·               ·
@@ -110,7 +110,7 @@ EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v
 0  render  ·            ·                                     (z int, v int)                                  ·
 0  ·       render 0     ((2)[int] * ("count(k)")[int])[int]   ·                                               ·
 0  ·       render 1     (v)[int]                              ·                                               ·
-1  filter  ·            ·                                     (v int, "count(k)" int, "count(k)" int, v int)  ·
+1  filter  ·            ·                                     (v int, "count(k)" int, "count(k)" int, v int)  "count(k)"!=NULL
 1  ·       filter       (("count(k)")[int] > (1)[int])[bool]  ·                                               ·
 2  group   ·            ·                                     (v int, "count(k)" int, "count(k)" int, v int)  ·
 2  ·       aggregate 0  (v)[int]                              ·                                               ·
@@ -141,7 +141,7 @@ EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 0  ·       from      t                            ·               ·
 1  render  ·         ·                            (k int)         k!=NULL; key(k)
 1  ·       render 0  (k)[int]                     ·               ·
-2  scan    ·         ·                            (k int, v int)  k!=NULL; key(k)
+2  scan    ·         ·                            (k int, v int)  k!=NULL; v!=NULL; key(k)
 2  ·       table     t@primary                    ·               ·
 2  ·       spans     ALL                          ·               ·
 2  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
@@ -152,11 +152,11 @@ EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 0  update  ·         ·                              ()                           ·
 0  ·       table     t                              ·                            ·
 0  ·       set       v                              ·                            ·
-1  render  ·         ·                              (k int, v int, "k + 1" int)  k!=NULL; key(k)
+1  render  ·         ·                              (k int, v int, "k + 1" int)  k!=NULL; v!=NULL; key(k)
 1  ·       render 0  (k)[int]                       ·                            ·
 1  ·       render 1  (v)[int]                       ·                            ·
 1  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
-2  scan    ·         ·                              (k int, v int)               k!=NULL; key(k)
+2  scan    ·         ·                              (k int, v int)               k!=NULL; v!=NULL; key(k)
 2  ·       table     t@primary                      ·                            ·
 2  ·       spans     ALL                            ·                            ·
 2  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
@@ -253,11 +253,11 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query ITTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0  render      ·         ·                             (x int, y int)                                       ·
+0  render      ·         ·                             (x int, y int)                                       x!=NULL; y!=NULL
 0  ·           render 0  (x)[int]                      ·                                                    ·
 0  ·           render 1  (y)[int]                      ·                                                    ·
-1  index-join  ·         ·                             (x int, y int, rowid[hidden,omitted] int)            rowid!=NULL; weak-key(x,rowid)
-2  scan        ·         ·                             (x[omitted] int, y[omitted] int, rowid[hidden] int)  rowid!=NULL; weak-key(x,rowid)
+1  index-join  ·         ·                             (x int, y int, rowid[hidden,omitted] int)            x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
+2  scan        ·         ·                             (x[omitted] int, y[omitted] int, rowid[hidden] int)  x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
 2  ·           table     tt@a                          ·                                                    ·
 2  ·           spans     /#-/10                        ·                                                    ·
 2  scan        ·         ·                             (x int, y int, rowid[hidden,omitted] int)            ·

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -945,12 +945,12 @@ SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
 ----
-0  render  ·         ·                            (a, b, n, sq)                         ·
+0  render  ·         ·                            (a, b, n, sq)                         sq!=NULL
 0  ·       render 0  a                            ·                                     ·
 0  ·       render 1  b                            ·                                     ·
 0  ·       render 2  n                            ·                                     ·
 0  ·       render 3  sq                           ·                                     ·
-1  filter  ·         ·                            (a, b, sum, n, sq)                    sum=sq
+1  filter  ·         ·                            (a, b, sum, n, sq)                    sum=sq; sum!=NULL; sq!=NULL
 1  ·       filter    sum = sq                     ·                                     ·
 2  render  ·         ·                            (a, b, sum, n, sq)                    ·
 2  ·       render 0  test.pairs.a                 ·                                     ·
@@ -1019,12 +1019,12 @@ NULL  NULL  6     36
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
-0  render  ·         ·                                               (a, b, n, sq)                         ·
+0  render  ·         ·                                               (a, b, n, sq)                         b!=NULL; sq!=NULL
 0  ·       render 0  test.pairs.a                                    ·                                     ·
 0  ·       render 1  test.pairs.b                                    ·                                     ·
 0  ·       render 2  test.square.n                                   ·                                     ·
 0  ·       render 3  test.square.sq                                  ·                                     ·
-1  filter  ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
+1  filter  ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  b!=NULL; sq!=NULL
 1  ·       filter    (test.pairs.b % 2) != (test.square.sq % 2)      ·                                     ·
 2  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
 2  ·       type      full outer                                      ·                                     ·

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -61,10 +61,10 @@ query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
 ----
 Level  Type        Field   Description  Columns                      Ordering
-0      limit       ·       ·            (k, v, w)                    k!=NULL; weak-key(k,v); +v
+0      limit       ·       ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
 0      ·           count   2            ·                            ·
-1      index-join  ·       ·            (k, v, w)                    k!=NULL; weak-key(k,v); +v
-2      scan        ·       ·            (k, v[omitted], w[omitted])  k!=NULL; weak-key(k,v); +v
+1      index-join  ·       ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+2      scan        ·       ·            (k, v[omitted], w[omitted])  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
 2      ·           table   t@t_v_idx    ·                            ·
 2      ·           spans   /5-          ·                            ·
 2      scan        ·       ·            (k, v, w)                    ·

--- a/pkg/sql/logictest/testdata/logic_test/physical_props
+++ b/pkg/sql/logictest/testdata/logic_test/physical_props
@@ -7,7 +7,7 @@ query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE b = c
 ----
 Level  Type  Field   Description   Columns       Ordering
-0      scan  ·       ·             (a, b, c, d)  b=c; a!=NULL; key(a)
+0      scan  ·       ·             (a, b, c, d)  b=c; a!=NULL; b!=NULL; c!=NULL; key(a)
 0      ·     table   abcd@primary  ·             ·
 0      ·     spans   ALL           ·             ·
 0      ·     filter  b = c         ·             ·
@@ -42,7 +42,7 @@ query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = 1 AND b = d
 ----
 Level  Type  Field   Description   Columns       Ordering
-0      scan  ·       ·             (a, b, c, d)  b=d; a=CONST; key()
+0      scan  ·       ·             (a, b, c, d)  b=d; a=CONST; b!=NULL; d!=NULL; key()
 0      ·     table   abcd@primary  ·             ·
 0      ·     spans   /1-/2         ·             ·
 0      ·     filter  b = d         ·             ·
@@ -51,7 +51,7 @@ query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = b AND b = c
 ----
 Level  Type  Field   Description          Columns       Ordering
-0      scan  ·       ·                    (a, b, c, d)  a=b=c; a!=NULL; key(a)
+0      scan  ·       ·                    (a, b, c, d)  a=b=c; a!=NULL; b!=NULL; c!=NULL; key(a)
 0      ·     table   abcd@primary         ·             ·
 0      ·     spans   ALL                  ·             ·
 0      ·     filter  (a = b) AND (b = c)  ·             ·
@@ -60,7 +60,7 @@ query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = b AND b = c AND c = 1
 ----
 Level  Type  Field   Description                        Columns       Ordering
-0      scan  ·       ·                                  (a, b, c, d)  a=b=c; a=CONST; key()
+0      scan  ·       ·                                  (a, b, c, d)  a=b=c; a=CONST; b!=NULL; c!=NULL; key()
 0      ·     table   abcd@primary                       ·             ·
 0      ·     spans   ALL                                ·             ·
 0      ·     filter  ((a = b) AND (b = c)) AND (c = 1)  ·             ·
@@ -84,7 +84,7 @@ query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE a = b
 ----
 Level  Type    Field          Description        Columns    Ordering
-0      filter  ·              ·                  (a, b, c)  a=b
+0      filter  ·              ·                  (a, b, c)  a=b; a!=NULL; b!=NULL
 0      ·       filter         x.a = x.b          ·          ·
 1      values  ·              ·                  (a, b, c)  ·
 1      ·       size           3 columns, 2 rows  ·          ·
@@ -99,7 +99,7 @@ query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE a = b AND b = 1
 ----
 Level  Type    Field          Description                Columns    Ordering
-0      filter  ·              ·                          (a, b, c)  a=b; a=CONST
+0      filter  ·              ·                          (a, b, c)  a=b; a=CONST; b!=NULL
 0      ·       filter         (x.a = x.b) AND (x.b = 1)  ·          ·
 1      values  ·              ·                          (a, b, c)  ·
 1      ·       size           3 columns, 2 rows          ·          ·
@@ -125,7 +125,7 @@ Level  Type  Field           Description   Columns                Ordering
 1      scan  ·               ·             (a, b, c, d)           a=CONST; key()
 1      ·     table           abcd@primary  ·                      ·
 1      ·     spans           /1-/2         ·                      ·
-1      scan  ·               ·             (e, f, g)              f=g; e!=NULL; key(e); +e
+1      scan  ·               ·             (e, f, g)              f=g; e!=NULL; f!=NULL; g!=NULL; key(e); +e
 1      ·     table           efg@primary   ·                      ·
 1      ·     spans           ALL           ·                      ·
 1      ·     filter          f = g         ·                      ·
@@ -142,7 +142,7 @@ Level  Type  Field           Description   Columns                Ordering
 1      ·     table           abcd@primary  ·                      ·
 1      ·     spans           ALL           ·                      ·
 1      ·     filter          b = 1         ·                      ·
-1      scan  ·               ·             (e, f, g)              f=g; e!=NULL; key(e); +e
+1      scan  ·               ·             (e, f, g)              f=g; e!=NULL; f!=NULL; g!=NULL; key(e); +e
 1      ·     table           efg@primary   ·                      ·
 1      ·     spans           ALL           ·                      ·
 1      ·     filter          f = g         ·                      ·

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
@@ -72,8 +72,8 @@ SELECT * FROM t WHERE c = 7
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 ----
-0  index-join  ·      ·          (a, b, c, d)                             weak-key(c); -c
-1  revscan     ·      ·          (a, b[omitted], c[omitted], d[omitted])  weak-key(c); -c
+0  index-join  ·      ·          (a, b, c, d)                             c!=NULL; key(c); -c
+1  revscan     ·      ·          (a, b[omitted], c[omitted], d[omitted])  c!=NULL; key(c); -c
 1  ·           table  t@c        ·                                        ·
 1  ·           spans  /1-        ·                                        ·
 1  scan        ·      ·          (a, b, c, d)                             ·

--- a/pkg/sql/physical_props.go
+++ b/pkg/sql/physical_props.go
@@ -669,6 +669,8 @@ func (pp *physicalProps) applyExpr(evalCtx *parser.EvalContext, expr parser.Type
 		}
 		// TODO(radu): look for tuple equalities like (a, b) = (c, d)
 	}
+	// Infer not-null columns.
+	pp.notNullCols.UnionWith(extractNotNullConstraints(expr))
 }
 
 // computeMergeJoinOrdering determines if merge-join can be used to perform a join.

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -81,6 +81,12 @@ type scanNode struct {
 	filter     parser.TypedExpr
 	filterVars parser.IndexedVarHelper
 
+	// origFilter is the original filtering expression, which might have gotten
+	// simplified during index selection. For example "k > 0" is converted to a
+	// span and the filter is nil. But we still want to deduce not-null columns
+	// from the original filter.
+	origFilter parser.TypedExpr
+
 	scanInitialized bool
 	fetcher         sqlbase.RowFetcher
 
@@ -411,7 +417,7 @@ func (n *scanNode) computePhysicalProps(
 	// We included any implicit columns, so the columns form a (possibly weak)
 	// key.
 	pp.addWeakKey(keySet)
-	pp.applyExpr(&n.p.evalCtx, n.filter)
+	pp.applyExpr(&n.p.evalCtx, n.origFilter)
 	return pp
 }
 

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -144,6 +144,45 @@ func TestFastIntSetTwoSetOps(t *testing.T) {
 							if eq != s1.Equals(s2) || eq != s2.Equals(s1) {
 								t.Errorf("Equals result incorrect: %s, %s", &s1, &s2)
 							}
+
+							// Test union.
+
+							u := s1.Copy()
+							u.UnionWith(s2)
+							// Verify all elements from m1 and m2 are in u.
+							for _, m := range []map[int]bool{m1, m2} {
+								for x := range m {
+									if !u.Contains(x) {
+										t.Errorf("incorrect union result %s union %s = %s", &s1, &s2, &u)
+										break
+									}
+								}
+							}
+							// Verify all elements from u are in m2 or m1.
+							for x, ok := u.Next(minVal); ok; x, ok = u.Next(x + 1) {
+								if !(m1[x] || m2[x]) {
+									t.Errorf("incorrect union result %s union %s = %s", &s1, &s2, &u)
+									break
+								}
+							}
+
+							// Test intersection.
+							u = s1.Copy()
+							u.IntersectionWith(s2)
+							// Verify all elements from m1 and m2 are in u.
+							for x := range m1 {
+								if m2[x] && !u.Contains(x) {
+									t.Errorf("incorrect intersection result %s union %s = %s  x=%d", &s1, &s2, &u, x)
+									break
+								}
+							}
+							// Verify all elements from u are in m2 and m1.
+							for x, ok := u.Next(minVal); ok; x, ok = u.Next(x + 1) {
+								if !(m1[x] && m2[x]) {
+									t.Errorf("incorrect intersection result %s intersect %s = %s", &s1, &s2, &u)
+									break
+								}
+							}
 						}
 					}
 				}


### PR DESCRIPTION
#### util: add union and intersection to FastIntSet


#### sql: infrastructure to infer not-null constraints

Adding functions that infer not-null variable constraints from filters. These
will be used to improve the not-null column info in physicalProps.

#### sql: extract not-null constraints from filters

Extract not-null column information from filter expressions (applies to scanNode
and filterNode).

Discussed in #19343.
