### PR TITLE
[WIP] storage: clone Spans before adding them to tscache.Request and use sync.Pool

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/tscache"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -1931,29 +1932,93 @@ func makeTSCacheRequest(
 	ba *roachpb.BatchRequest, br *roachpb.BatchResponse, span roachpb.RSpan,
 ) tscache.Request {
 	cr := tscache.Request{
-		Span:      span,
 		Timestamp: ba.Timestamp,
 	}
 	if ba.Txn != nil {
 		cr.TxnID = ba.Txn.ID
 	}
 
+	// Copy all keys necessary for the TimestampCache Request into a single byte
+	// slice. This has been shown to dramatically reduce the GC time spent
+	// scanning TimestampCache-related memory. Before doing so, add up the
+	// length of all keys we'll need to copy so we can allocate exactly the
+	// buffer size we'll need. While doing so, we can also count how large the
+	// read and write span slices need to be.
+	var readCount, writeCount int
+	keysSize := bufalloc.RSpanSize(span)
 	for i, union := range ba.Requests {
 		args := union.GetInner()
 		if roachpb.UpdatesTimestampCache(args) {
 			header := args.Header()
+
+			// Count key sizes and read or write requests. This should be kept
+			// in-sync with the type switch below.
+			switch args.(type) {
+			case *roachpb.DeleteRangeRequest:
+				writeCount++
+				keysSize += bufalloc.SpanSize(header)
+			case *roachpb.EndTransactionRequest:
+				keysSize += bufalloc.SpanSize(header)
+			case *roachpb.ScanRequest:
+				readCount++
+				keysSize += len(header.Key)
+				resp := br.Responses[i].GetInner().(*roachpb.ScanResponse)
+				if ba.Header.MaxSpanRequestKeys != 0 &&
+					ba.Header.MaxSpanRequestKeys == int64(len(resp.Rows)) {
+					// See below. +1 because we call Next on this key.
+					keysSize += len(resp.Rows[len(resp.Rows)-1].Key) + 1
+				} else {
+					keysSize += len(header.EndKey)
+				}
+			case *roachpb.ReverseScanRequest:
+				readCount++
+				keysSize += len(header.EndKey)
+				resp := br.Responses[i].GetInner().(*roachpb.ReverseScanResponse)
+				if ba.Header.MaxSpanRequestKeys != 0 &&
+					ba.Header.MaxSpanRequestKeys == int64(len(resp.Rows)) {
+					// See below.
+					keysSize += len(resp.Rows[len(resp.Rows)-1].Key)
+				} else {
+					keysSize += len(header.Key)
+				}
+			default:
+				readCount++
+				keysSize += bufalloc.SpanSize(header)
+			}
+		}
+	}
+
+	if readCount > 0 {
+		cr.Reads = make([]roachpb.Span, 0, readCount)
+	}
+	if writeCount > 0 {
+		cr.Writes = make([]roachpb.Span, 0, writeCount)
+	}
+
+	// Create a ByteAllocator with exactly the number of bytes we'll need for
+	// all keys in the CacheRequest. It should never need to re-alloc.
+	alloc := bufalloc.ByteAllocator(make([]byte, 0, keysSize))
+	alloc, cr.Span = alloc.CopyRSpan(span)
+
+	for i, union := range ba.Requests {
+		args := union.GetInner()
+		if roachpb.UpdatesTimestampCache(args) {
+			header := args.Header()
+			var headerCopy roachpb.Span
 			switch args.(type) {
 			case *roachpb.DeleteRangeRequest:
 				// DeleteRange adds to the write timestamp cache to prevent
 				// subsequent writes from rewriting history.
-				cr.Writes = append(cr.Writes, header)
+				alloc, headerCopy = alloc.CopySpan(header)
+				cr.Writes = append(cr.Writes, headerCopy)
 			case *roachpb.EndTransactionRequest:
 				// EndTransaction adds to the write timestamp cache to ensure replays
 				// create a transaction record with WriteTooOld set.
 				//
 				// Note that TimestampCache.ExpandRequests lazily creates the
 				// transaction key from the request key.
-				cr.Txn = roachpb.Span{Key: header.Key}
+				alloc, headerCopy = alloc.CopySpan(header)
+				cr.Txn = headerCopy
 			case *roachpb.ScanRequest:
 				resp := br.Responses[i].GetInner().(*roachpb.ScanResponse)
 				if ba.Header.MaxSpanRequestKeys != 0 &&
@@ -1967,17 +2032,10 @@ func makeTSCacheRequest(
 					// to prevent phantom read anomalies. That means we can only
 					// perform this truncate if the scan requested a limited number of
 					// results and we hit that limit.
-
-					// Make a copy of the key to avoid holding on to the large buffer the
-					// key was allocated from for the response.
-					src := resp.Rows[len(resp.Rows)-1].Key
-					// Size the new key to be exactly what we need for key.Next() to not
-					// allocate.
-					key := make(roachpb.Key, len(src), len(src)+1)
-					copy(key, src)
-					header.EndKey = key.Next()
+					header.EndKey = resp.Rows[len(resp.Rows)-1].Key.Next()
 				}
-				cr.Reads = append(cr.Reads, header)
+				alloc, headerCopy = alloc.CopySpan(header)
+				cr.Reads = append(cr.Reads, headerCopy)
 			case *roachpb.ReverseScanRequest:
 				resp := br.Responses[i].GetInner().(*roachpb.ReverseScanResponse)
 				if ba.Header.MaxSpanRequestKeys != 0 &&
@@ -1985,17 +2043,13 @@ func makeTSCacheRequest(
 					// See comment in the ScanRequest case. For revert scans, results
 					// are returned in reverse order and we truncate the start key of
 					// the span.
-
-					// Make a copy of the key to avoid holding on to the large buffer the
-					// key was allocated from for the response.
-					src := resp.Rows[len(resp.Rows)-1].Key
-					key := make(roachpb.Key, len(src))
-					copy(key, src)
-					header.Key = key
+					header.Key = resp.Rows[len(resp.Rows)-1].Key
 				}
-				cr.Reads = append(cr.Reads, header)
+				alloc, headerCopy = alloc.CopySpan(header)
+				cr.Reads = append(cr.Reads, headerCopy)
 			default:
-				cr.Reads = append(cr.Reads, header)
+				alloc, headerCopy = alloc.CopySpan(header)
+				cr.Reads = append(cr.Reads, headerCopy)
 			}
 		}
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8621,67 +8621,67 @@ func TestMakeTimestampCacheRequest(t *testing.T) {
 		maxKeys  int64
 		req      roachpb.Request
 		resp     roachpb.Response
-		expected tscache.Request
+		expected *tscache.Request
 	}{
 		{
 			0,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{},
-			tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Reads: []roachpb.Span{ac}},
 		},
 		{
 			0,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{},
-			tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{Rows: []roachpb.KeyValue{{Key: a}, {Key: b}}},
-			tscache.Request{Reads: []roachpb.Span{{Key: a, EndKey: b.Next()}}},
+			&tscache.Request{Reads: []roachpb.Span{{Key: a, EndKey: b.Next()}}},
 		},
 		{
 			0,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{},
-			tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Reads: []roachpb.Span{ac}},
 		},
 		{
 			0,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{},
-			tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{Rows: []roachpb.KeyValue{{Key: c}, {Key: b}}},
-			tscache.Request{Reads: []roachpb.Span{{Key: b, EndKey: c}}},
+			&tscache.Request{Reads: []roachpb.Span{{Key: b, EndKey: c}}},
 		},
 	}
 	for _, c := range testCases {

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -42,7 +42,7 @@ import (
 // to the current system time plus the maximum clock offset.
 type Cache interface {
 	// AddRequest adds the specified request to the cache in an unexpanded state.
-	AddRequest(req Request)
+	AddRequest(req *Request)
 	// ExpandRequests expands any request that overlaps the specified span and
 	// which is newer than the specified timestamp.
 	ExpandRequests(span roachpb.RSpan, timestamp hlc.Timestamp)

--- a/pkg/storage/tscache/cache_impl_test.go
+++ b/pkg/storage/tscache/cache_impl_test.go
@@ -64,7 +64,7 @@ func TestTimestampCacheImplNoEviction(t *testing.T) {
 	manual.Increment(1)
 	aTS := clock.Now()
 	tc.add(roachpb.Key("a"), nil, aTS, uuid.UUID{}, true)
-	tc.AddRequest(Request{
+	tc.AddRequest(&Request{
 		Reads:     []roachpb.Span{{Key: roachpb.Key("c")}},
 		Timestamp: aTS,
 	})
@@ -72,7 +72,7 @@ func TestTimestampCacheImplNoEviction(t *testing.T) {
 	// Increment time by the MinTSCacheWindow and add another key.
 	manual.Increment(MinTSCacheWindow.Nanoseconds())
 	tc.add(roachpb.Key("b"), nil, clock.Now(), uuid.UUID{}, true)
-	tc.AddRequest(Request{
+	tc.AddRequest(&Request{
 		Reads:     []roachpb.Span{{Key: roachpb.Key("d")}},
 		Timestamp: clock.Now(),
 	})
@@ -96,7 +96,7 @@ func TestTimestampCacheImplExpandRequests(t *testing.T) {
 	// Increment time to the low water mark + 1.
 	start := clock.Now()
 	manual.Increment(1)
-	tc.AddRequest(Request{
+	tc.AddRequest(&Request{
 		Span:      ab,
 		Reads:     []roachpb.Span{{Key: roachpb.Key("a")}},
 		Timestamp: clock.Now(),

--- a/pkg/util/bufalloc/byte_allocator.go
+++ b/pkg/util/bufalloc/byte_allocator.go
@@ -14,6 +14,10 @@
 
 package bufalloc
 
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
 // ByteAllocator provides chunk allocation of []byte, amortizing the overhead
 // of each allocation. Because the underlying storage for the slices is shared,
 // they should share a similar lifetime in order to avoid pinning large amounts
@@ -60,4 +64,53 @@ func (a ByteAllocator) Copy(src []byte, extraCap int) (ByteAllocator, []byte) {
 	a, alloc = a.Alloc(len(src), extraCap)
 	copy(alloc, src)
 	return a, alloc
+}
+
+// CopySpan performs a deep copy of the provided Span. The returned Span
+// should be treated as immutable.
+func (a ByteAllocator) CopySpan(src roachpb.Span) (ByteAllocator, roachpb.Span) {
+	if len(src.Key) == 0 {
+		return a, roachpb.Span{}
+	}
+	var dst roachpb.Span
+	extraCap := 0
+	if len(src.EndKey) > 0 {
+		a, dst.EndKey = a.Copy(src.EndKey, 0)
+	} else {
+		// In a few places including in the TimestampCache we translate
+		// [Key, nil) -> [Key, Key.Next()). If the start key has enough
+		// extra capacity, the Next call does not need to allocate and
+		// can instead share the same memory with the start key.
+		extraCap = 1
+	}
+	a, dst.Key = a.Copy(src.Key, extraCap)
+	return a, dst
+}
+
+// CopyRSpan performs a deep copy of the provided RSpan. The returned RSpan
+// should be treated as immutable.
+func (a ByteAllocator) CopyRSpan(src roachpb.RSpan) (ByteAllocator, roachpb.RSpan) {
+	var dst roachpb.Span
+	a, dst = a.CopySpan(src.AsRawSpanWithNoLocals())
+	return a, roachpb.RSpan{
+		Key:    roachpb.RKey(dst.Key),
+		EndKey: roachpb.RKey(dst.EndKey),
+	}
+}
+
+// SpanSize returns the amount of memory required to copy the provided Span.
+func SpanSize(src roachpb.Span) int {
+	if len(src.Key) == 0 {
+		return 0
+	}
+	endSize := 1
+	if len(src.EndKey) > 0 {
+		endSize = len(src.EndKey)
+	}
+	return len(src.Key) + endSize
+}
+
+// RSpanSize returns the amount of memory required to copy the provided RSpan.
+func RSpanSize(src roachpb.RSpan) int {
+	return SpanSize(src.AsRawSpanWithNoLocals())
 }


### PR DESCRIPTION
Related to #16796.

This PR makes two related changes:
- it clones all Spans before adding them to a `tscache.Request`
- it adds `*tscache.Request` to a `sync.Pool`

Both of these were done to reduce GC time. Using GCTrace on my linux machine (since
it seems to be broken on Darwin) a read-only workload originally showed a consistent 
**7%** of time spent in GC. This was when running:
```
kv --read-percent 100 --concurrency 16 --splits 100 --write-seq 100000
```

After the first change, this time dropped to **3%**. After the second change, it dropped
again to **2%**. 

The second change is pretty straightforward. The first is more interesting, especially in
light of the experimentation done in #16796. If I individually deep copy the `Spans` by
adding a `Clone` method to `roachpb.Span`, I don't see the same effect as I do here. I
had originally thought that the old GC time was in-part due to scanning the corresponding
`BatchRequest` and `endCmds` structs, which were for some reason being referenced and
therefore unable to be GCed. This proves that that was not the case. This leads me to believe
that the GC cost reduction is due to the single slab of memory being allocated for all keys in
a `BatchRequest`. This theory is fairly unsubstantiated though. I'm curious if anyone has any
other ideas as to why we're seeing such a big difference.

In addition to the GC impact, the two commits also has a fairly large impact on `kv`
performance as a whole. The following are the results from three 1 minute `kv` runs
before and after the changes. As would be expected from a GC related change like this,
we see the impact on the tail latencies. Specifically, it reduces 99th percentile latency by
about **33%**. It also increases throughput by about **7%**.

### Before
```
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s        0        1985392        33089.4      0.5      0.4      0.9      2.6     30.4

BenchmarkLoadgenKV/readPercent=100/splits=100/concurrency=16/duration=1m0s	 1985395	     30221 ns/op

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s        0        1979390        32989.3      0.5      0.4      0.9      2.8     27.3

BenchmarkLoadgenKV/readPercent=100/splits=100/concurrency=16/duration=1m0s	 1979390	     30312 ns/op

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s        0        1986851        33113.6      0.5      0.4      0.9      2.8     27.3

BenchmarkLoadgenKV/readPercent=100/splits=100/concurrency=16/duration=1m0s	 1986852	     30199 ns/op
```

### After
```
_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s        0        2121080        35350.8      0.5      0.4      0.9      1.8     23.1

BenchmarkLoadgenKV/readPercent=100/splits=100/concurrency=16/duration=1m0s	 2121080	     28287 ns/op

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s        0        2128153        35468.7      0.5      0.4      0.8      1.8     27.3

BenchmarkLoadgenKV/readPercent=100/splits=100/concurrency=16/duration=1m0s	 2128153	     28193 ns/op

_elapsed___errors_____ops(total)___ops/sec(cum)__avg(ms)__p50(ms)__p95(ms)__p99(ms)_pMax(ms)
   60.0s        0        2123837        35396.8      0.5      0.4      0.8      1.8     26.2

BenchmarkLoadgenKV/readPercent=100/splits=100/concurrency=16/duration=1m0s	 2123847	     28251 ns/op
```