### PR TITLE
cherry-pick 1.1: sql: don't set isKey if columns are nullable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -627,15 +627,13 @@ INSERT INTO bar VALUES (0, NULL), (1, NULL)
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM bar ORDER BY baz, id
 ----
-0  scan  ·      ·          (id, baz)  +baz,key
-0  ·     table  bar@i_bar  ·          ·
-0  ·     spans  ALL        ·          ·
+0  sort  ·      ·          (id, baz)  +baz,+id
+0  ·     order  +baz,+id   ·          ·
+1  scan  ·      ·          (id, baz)  +baz
+1  ·     table  bar@i_bar  ·          ·
+1  ·     spans  ALL        ·          ·
 
-# Here rowsort is needed because the ORDER BY clause does not guarantee any
-# relative ordering between rows where baz is NULL. As we see above, because
-# this is a unique index, the ordering `+baz,+id` is deemed equivalent to just
-# `+baz`.
-query IT rowsort
+query IT
 SELECT * FROM bar ORDER BY baz, id
 ----
 0 NULL

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -75,7 +75,7 @@ EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
 0  nosort  ·      ·       (k)     ·
 0  ·       order  -v,+k   ·       ·
-1  scan    ·      ·       (k, v)  -v,+k,key
+1  scan    ·      ·       (k, v)  -v,+k
 1  ·       table  kv@foo  ·       ·
 1  ·       spans  ALL     ·       ·
 
@@ -128,10 +128,10 @@ EXPLAIN(METADATA) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@f
 2  ·       type            inner              ·                                                                                    ·
 2  ·       equality        (k, v) = (k, v)    ·                                                                                    ·
 2  ·       mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                                                                                    ·
-3  scan    ·               ·                  (k, v)                                                                               -v,+k,key
+3  scan    ·               ·                  (k, v)                                                                               -v,+k
 3  ·       table           kv@foo             ·                                                                                    ·
 3  ·       spans           ALL                ·                                                                                    ·
-3  scan    ·               ·                  (k, v)                                                                               -v,+k,key
+3  scan    ·               ·                  (k, v)                                                                               -v,+k
 3  ·       table           kv@foo             ·                                                                                    ·
 3  ·       spans           ALL                ·                                                                                    ·
 
@@ -154,3 +154,40 @@ PREPARE a AS (TABLE kv) ORDER BY PRIMARY KEY kv
 
 statement error ORDER BY INDEX in window definition is not supported
 SELECT avg(k) OVER (ORDER BY PRIMARY KEY kv) FROM kv
+
+statement ok
+CREATE TABLE abcd (a INT PRIMARY KEY, b INT, c INT, d INT, UNIQUE INDEX (b, c) STORING (d))
+
+statement ok
+INSERT INTO abcd VALUES (1, 1, NULL, 4), (2, 1, NULL, 3), (3, NULL, 3, 2), (4, NULL, 3, 1)
+
+# Verify we don't incorrectly elide the sort node (#19343).
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd ORDER BY b, c, d
+----
+Level  Type  Field  Description        Columns       Ordering
+0      sort  ·      ·                  (a, b, c, d)  +b,+c,+d
+0      ·     order  +b,+c,+d           ·             ·
+1      scan  ·      ·                  (a, b, c, d)  +b,+c
+1      ·     table  abcd@abcd_b_c_key  ·             ·
+1      ·     spans  ALL                ·             ·
+
+query IIII
+SELECT * FROM abcd ORDER BY b, c, d
+----
+4  NULL  3     1
+3  NULL  3     2
+2  1     NULL  3
+1  1     NULL  4
+
+statement ok
+CREATE TABLE abcd2 (a INT PRIMARY KEY, b INT NOT NULL, c INT NOT NULL, d INT, UNIQUE INDEX (b, c) STORING (d))
+
+# In this case it is correct to elide the sort node.
+query ITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM abcd2 ORDER BY b, c, d
+----
+Level  Type  Field  Description          Columns       Ordering
+0      scan  ·      ·                    (a, b, c, d)  +b,+c,key
+0      ·     table  abcd2@abcd2_b_c_key  ·             ·
+0      ·     spans  ALL                  ·             ·

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
@@ -72,8 +72,8 @@ SELECT * FROM t WHERE c = 7
 query ITTTTT
 EXPLAIN (METADATA) SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 ----
-0  index-join  ·      ·          (a, b, c, d)                             -c,key
-1  revscan     ·      ·          (a, b[omitted], c[omitted], d[omitted])  -c,key
+0  index-join  ·      ·          (a, b, c, d)                             -c
+1  revscan     ·      ·          (a, b[omitted], c[omitted], d[omitted])  -c
 1  ·           table  t@c        ·                                        ·
 1  ·           spans  /1-        ·                                        ·
 1  scan        ·      ·          (a, b, c, d)                             ·


### PR DESCRIPTION
We assume that the columns of an index form a "key" but that is only correct if
the columns are not null.

Fixes #19343.

This is not really a cherry-pick since this code has changed a lot; it's a fully reworked fix.

CC @cockroachdb/release
