### PR TITLE
cherrypick-1.1: less clobbering in node liveness

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -43,9 +43,9 @@ var (
 
 	errChangeDecommissioningFailed = errors.New("failed to change the decommissioning status")
 
-	// errSkippedHeartbeat is returned when a heartbeat request fails because
+	// ErrEpochIncremented is returned when a heartbeat request fails because
 	// the underlying liveness record has had its epoch incremented.
-	errSkippedHeartbeat = errors.New("heartbeat failed on epoch increment")
+	ErrEpochIncremented = errors.New("heartbeat failed on epoch increment")
 )
 
 type errRetryLiveness struct {
@@ -335,7 +335,7 @@ func (nl *NodeLiveness) StartHeartbeat(
 							log.Errorf(ctx, "unexpected error getting liveness: %v", err)
 						}
 						if err := nl.heartbeatInternal(ctx, liveness, incrementEpoch); err != nil {
-							if err == errSkippedHeartbeat {
+							if err == ErrEpochIncremented {
 								log.Infof(ctx, "%s; retrying", err)
 								continue
 							}
@@ -446,7 +446,7 @@ func (nl *NodeLiveness) heartbeatInternal(
 			return errNodeAlreadyLive
 		}
 		// Otherwise, return error.
-		return errSkippedHeartbeat
+		return ErrEpochIncremented
 	}); err != nil {
 		if err == errNodeAlreadyLive {
 			nl.metrics.HeartbeatSuccesses.Inc(1)

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -689,20 +689,23 @@ func shouldReplaceLiveness(old, new Liveness) bool {
 		return true
 	}
 
-	if old.Expiration == new.Expiration && old.Epoch == new.Epoch {
-		// Assume that the update is newer when its draining or
-		// decommissioning field changed.
-		//
-		// This has false positives (in which case we're clobbering the
-		// liveness). A better way to handle liveness updates in general is
-		// to add a sequence number.
-		//
-		// See #18219.
-		return old.Draining != new.Draining || old.Decommissioning != new.Decommissioning
+	// Compare first Epoch, and no change there, Expiration.
+	if old.Epoch != new.Epoch {
+		return old.Epoch < new.Epoch
+	}
+	if old.Expiration != new.Expiration {
+		return old.Expiration.Less(new.Expiration)
 	}
 
-	// Accept an update if it moves either expiration or epoch forward.
-	return old.Expiration.Less(new.Expiration) || old.Epoch < new.Epoch
+	// If Epoch and Expiration are unchanged, assume that the update is newer
+	// when its draining or decommissioning field changed.
+	//
+	// This has false positives (in which case we're clobbering the liveness). A
+	// better way to handle liveness updates in general is to add a sequence
+	// number.
+	//
+	// See #18219.
+	return old.Draining != new.Draining || old.Decommissioning != new.Decommissioning
 }
 
 // livenessGossipUpdate is the gossip callback used to keep the
@@ -754,25 +757,25 @@ func (nl *NodeLiveness) numLiveNodes() int64 {
 		return 0
 	}
 
-	self, err := nl.Self()
+	now := nl.clock.Now()
+	maxOffset := nl.clock.MaxOffset()
+
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+
+	self, err := nl.getLivenessLocked(selfID)
 	if err == ErrNoLivenessRecord {
 		return 0
 	}
 	if err != nil {
 		log.Warningf(ctx, "looking up own liveness: %s", err)
+		return 0
 	}
-
-	now := nl.clock.Now()
-	maxOffset := nl.clock.MaxOffset()
-
 	// If this node isn't live, we don't want to report its view of node liveness
 	// because it's more likely to be inaccurate than the view of a live node.
 	if !self.IsLive(now, maxOffset) {
 		return 0
 	}
-
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
 	var liveNodes int64
 	for _, l := range nl.mu.nodes {
 		if l.IsLive(now, maxOffset) {

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -475,7 +475,14 @@ func (nl *NodeLiveness) Self() (*Liveness, error) {
 
 func (nl *NodeLiveness) setSelf(liveness Liveness) {
 	nl.mu.Lock()
-	nl.mu.self = liveness
+	// NB: shouldReplaceLiveness should always be true
+	// since setSelf is only ever called for non-overlapping
+	// liveness updated serialized through a single semaphore.
+	//
+	// We call it for symmetry with the nodes map.
+	if shouldReplaceLiveness(nl.mu.self, liveness) {
+		nl.mu.self = liveness
+	}
 	nl.mu.Unlock()
 }
 

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -559,17 +559,22 @@ func (nl *NodeLiveness) IncrementEpoch(ctx context.Context, liveness *Liveness) 
 	}
 	newLiveness := *liveness
 	newLiveness.Epoch++
-	update := func(l Liveness) {
+	maybeUpdate := func(l Liveness) {
 		nl.mu.Lock()
 		defer nl.mu.Unlock()
+
 		if nodeID := nl.gossip.NodeID.Get(); nodeID == l.NodeID {
-			nl.mu.self = l
+			if shouldReplaceLiveness(nl.mu.self, l) {
+				nl.mu.self = l
+			}
 		} else {
-			nl.mu.nodes[l.NodeID] = l
+			if shouldReplaceLiveness(nl.mu.nodes[l.NodeID], l) {
+				nl.mu.nodes[l.NodeID] = l
+			}
 		}
 	}
 	if err := nl.updateLiveness(ctx, &newLiveness, liveness, func(actual Liveness) error {
-		defer update(actual)
+		defer maybeUpdate(actual)
 		if actual.Epoch > liveness.Epoch {
 			return errEpochAlreadyIncremented
 		} else if actual.Epoch < liveness.Epoch {
@@ -585,7 +590,7 @@ func (nl *NodeLiveness) IncrementEpoch(ctx context.Context, liveness *Liveness) 
 
 	log.VEventf(ctx, 1, "incremented node %d liveness epoch to %d",
 		newLiveness.NodeID, newLiveness.Epoch)
-	update(newLiveness)
+	maybeUpdate(newLiveness)
 	nl.metrics.EpochIncrements.Inc(1)
 	return nil
 }

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -125,7 +125,6 @@ type NodeLiveness struct {
 
 	mu struct {
 		syncutil.Mutex
-		self              Liveness
 		callbacks         []IsLiveCallback
 		nodes             map[roachpb.NodeID]Liveness
 		heartbeatCallback HeartbeatCallback
@@ -237,7 +236,7 @@ func (nl *NodeLiveness) setDrainingInternal(
 	}
 	newLiveness.Draining = drain
 	if err := nl.updateLiveness(ctx, &newLiveness, liveness, func(actual Liveness) error {
-		nl.setSelf(actual)
+		nl.maybeUpdate(actual)
 		if actual.Draining == newLiveness.Draining {
 			return errNodeDrainingSet
 		}
@@ -248,7 +247,7 @@ func (nl *NodeLiveness) setDrainingInternal(
 		}
 		return err
 	}
-	nl.setSelf(newLiveness)
+	nl.maybeUpdate(newLiveness)
 	return nil
 }
 
@@ -438,7 +437,7 @@ func (nl *NodeLiveness) heartbeatInternal(
 	}
 	if err := nl.updateLiveness(ctx, &newLiveness, liveness, func(actual Liveness) error {
 		// Update liveness to actual value on mismatch.
-		nl.setSelf(actual)
+		nl.maybeUpdate(actual)
 		// If the actual liveness is different than expected, but is
 		// considered live, treat the heartbeat as a success. This can
 		// happen when the periodic heartbeater races with a concurrent
@@ -458,7 +457,7 @@ func (nl *NodeLiveness) heartbeatInternal(
 	}
 
 	log.VEventf(ctx, 1, "heartbeat %+v", newLiveness.Expiration)
-	nl.setSelf(newLiveness)
+	nl.maybeUpdate(newLiveness)
 	nl.metrics.HeartbeatSuccesses.Inc(1)
 	return nil
 }
@@ -473,19 +472,6 @@ func (nl *NodeLiveness) Self() (*Liveness, error) {
 	return nl.getLivenessLocked(nl.gossip.NodeID.Get())
 }
 
-func (nl *NodeLiveness) setSelf(liveness Liveness) {
-	nl.mu.Lock()
-	// NB: shouldReplaceLiveness should always be true
-	// since setSelf is only ever called for non-overlapping
-	// liveness updated serialized through a single semaphore.
-	//
-	// We call it for symmetry with the nodes map.
-	if shouldReplaceLiveness(nl.mu.self, liveness) {
-		nl.mu.self = liveness
-	}
-	nl.mu.Unlock()
-}
-
 // GetIsLiveMap returns a map of nodeID to boolean liveness status of
 // each node.
 func (nl *NodeLiveness) GetIsLiveMap() map[roachpb.NodeID]bool {
@@ -495,11 +481,7 @@ func (nl *NodeLiveness) GetIsLiveMap() map[roachpb.NodeID]bool {
 	now := nl.clock.Now()
 	maxOffset := nl.clock.MaxOffset()
 	for nID, l := range nl.mu.nodes {
-		if nID == nl.mu.self.NodeID {
-			lMap[nID] = nl.mu.self.IsLive(now, maxOffset)
-		} else {
-			lMap[nID] = l.IsLive(now, maxOffset)
-		}
+		lMap[nID] = l.IsLive(now, maxOffset)
 	}
 	return lMap
 }
@@ -511,11 +493,7 @@ func (nl *NodeLiveness) GetLivenesses() []Liveness {
 	defer nl.mu.Unlock()
 	livenesses := make([]Liveness, 0, len(nl.mu.nodes))
 	for _, l := range nl.mu.nodes {
-		if l.NodeID == nl.mu.self.NodeID {
-			livenesses = append(livenesses, nl.mu.self)
-		} else {
-			livenesses = append(livenesses, l)
-		}
+		livenesses = append(livenesses, l)
 	}
 	return livenesses
 }
@@ -530,10 +508,6 @@ func (nl *NodeLiveness) GetLiveness(nodeID roachpb.NodeID) (*Liveness, error) {
 }
 
 func (nl *NodeLiveness) getLivenessLocked(nodeID roachpb.NodeID) (*Liveness, error) {
-	if nodeID != 0 && nodeID == nl.mu.self.NodeID {
-		copySelf := nl.mu.self
-		return &copySelf, nil
-	}
 	if l, ok := nl.mu.nodes[nodeID]; ok {
 		return &l, nil
 	}
@@ -566,22 +540,8 @@ func (nl *NodeLiveness) IncrementEpoch(ctx context.Context, liveness *Liveness) 
 	}
 	newLiveness := *liveness
 	newLiveness.Epoch++
-	maybeUpdate := func(l Liveness) {
-		nl.mu.Lock()
-		defer nl.mu.Unlock()
-
-		if nodeID := nl.gossip.NodeID.Get(); nodeID == l.NodeID {
-			if shouldReplaceLiveness(nl.mu.self, l) {
-				nl.mu.self = l
-			}
-		} else {
-			if shouldReplaceLiveness(nl.mu.nodes[l.NodeID], l) {
-				nl.mu.nodes[l.NodeID] = l
-			}
-		}
-	}
 	if err := nl.updateLiveness(ctx, &newLiveness, liveness, func(actual Liveness) error {
-		defer maybeUpdate(actual)
+		defer nl.maybeUpdate(actual)
 		if actual.Epoch > liveness.Epoch {
 			return errEpochAlreadyIncremented
 		} else if actual.Epoch < liveness.Epoch {
@@ -597,7 +557,7 @@ func (nl *NodeLiveness) IncrementEpoch(ctx context.Context, liveness *Liveness) 
 
 	log.VEventf(ctx, 1, "incremented node %d liveness epoch to %d",
 		newLiveness.NodeID, newLiveness.Epoch)
-	maybeUpdate(newLiveness)
+	nl.maybeUpdate(newLiveness)
 	nl.metrics.EpochIncrements.Inc(1)
 	return nil
 }
@@ -715,6 +675,15 @@ func (nl *NodeLiveness) updateLivenessAttempt(
 	return nil
 }
 
+func (nl *NodeLiveness) maybeUpdate(new Liveness) {
+	nl.mu.Lock()
+	old := nl.mu.nodes[new.NodeID]
+	if shouldReplaceLiveness(old, new) {
+		nl.mu.nodes[new.NodeID] = new
+	}
+	nl.mu.Unlock()
+}
+
 func shouldReplaceLiveness(old, new Liveness) bool {
 	if (old == Liveness{}) {
 		return true
@@ -778,22 +747,32 @@ func (nl *NodeLiveness) livenessGossipUpdate(key string, content roachpb.Value) 
 // nodes reporting the metric, so it's simplest to just have all live nodes
 // report it.
 func (nl *NodeLiveness) numLiveNodes() int64 {
+	ctx := nl.ambientCtx.AnnotateCtx(context.Background())
+
 	selfID := nl.gossip.NodeID.Get()
 	if selfID == 0 {
 		return 0
 	}
 
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
+	self, err := nl.Self()
+	if err == ErrNoLivenessRecord {
+		return 0
+	}
+	if err != nil {
+		log.Warningf(ctx, "looking up own liveness: %s", err)
+	}
+
+	now := nl.clock.Now()
+	maxOffset := nl.clock.MaxOffset()
 
 	// If this node isn't live, we don't want to report its view of node liveness
 	// because it's more likely to be inaccurate than the view of a live node.
-	now := nl.clock.Now()
-	maxOffset := nl.clock.MaxOffset()
-	if !nl.mu.self.IsLive(now, maxOffset) {
+	if !self.IsLive(now, maxOffset) {
 		return 0
 	}
 
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
 	var liveNodes int64
 	for _, l := range nl.mu.nodes {
 		if l.IsLive(now, maxOffset) {

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -92,7 +93,16 @@ func TestNodeLiveness(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := nl.Heartbeat(context.Background(), l); err != nil {
+		for {
+			err := nl.Heartbeat(context.Background(), l)
+			if err == nil {
+				break
+			}
+			if err == storage.ErrEpochIncremented {
+				log.Warningf(context.Background(), "retrying after %s", err)
+				continue
+			}
+
 			t.Fatal(err)
 		}
 	}

--- a/pkg/storage/node_liveness_test.go
+++ b/pkg/storage/node_liveness_test.go
@@ -234,6 +234,9 @@ func TestNodeHeartbeatCallback(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	// NB: since the heartbeat callback is invoked synchronously in
+	// `Heartbeat()` which this goroutine invoked, we don't need to wrap this in
+	// a retry.
 	if err := verifyUptimes(); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/node_liveness_unit_test.go
+++ b/pkg/storage/node_liveness_unit_test.go
@@ -1,0 +1,94 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestShouldReplaceLiveness(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	l := func(epo int64, expiration hlc.Timestamp, draining, decom bool) Liveness {
+		return Liveness{
+			Epoch:           epo,
+			Expiration:      hlc.Timestamp(expiration),
+			Draining:        draining,
+			Decommissioning: decom,
+		}
+	}
+	const (
+		no  = false
+		yes = true
+	)
+	now := hlc.Timestamp{WallTime: 12345}
+
+	for _, test := range []struct {
+		old, new Liveness
+		exp      bool
+	}{
+		{
+			// Epoch update only.
+			Liveness{},
+			l(1, hlc.Timestamp{}, false, false),
+			yes,
+		},
+		{
+			// No Epoch update, but Expiration update.
+			l(1, now, false, false),
+			l(1, now.Add(0, 1), false, false),
+			yes,
+		},
+		{
+			// No update.
+			l(1, now, false, false),
+			l(1, now, false, false),
+			no,
+		},
+		{
+			// Only Decommissioning changes.
+			l(1, now, false, false),
+			l(1, now, false, true),
+			yes,
+		},
+		{
+			// Only Draining changes.
+			l(1, now, false, false),
+			l(1, now, true, false),
+			yes,
+		},
+		{
+			// Decommissioning changes, but Epoch moves backwards.
+			l(10, now, true, true),
+			l(9, now, true, false),
+			no,
+		},
+		{
+			// Draining changes, but Expiration moves backwards..
+			l(10, now, false, false),
+			l(10, now.Add(-1, 0), true, false),
+			no,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			if act := shouldReplaceLiveness(test.old, test.new); act != test.exp {
+				t.Errorf("unexpected update: %+v", test)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Combination of #19386, #19215, #19279, #19348.

cc @cockroachdb/release 