### PR TITLE
sql: convert placeholders to leaf values

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -330,11 +330,12 @@ func makeCSVTableDescriptor(
 			return nil, errors.Errorf("unsupported table definition: %s", parser.AsString(def))
 		}
 	}
+	semaCtx := parser.SemaContext{}
+	evalCtx := parser.EvalContext{}
 	tableDesc, err := sql.MakeTableDesc(
 		ctx,
 		nil, /* txn */
 		sql.NilVirtualTabler,
-		parser.SearchPath{},
 		create,
 		parentID,
 		tableID,
@@ -342,7 +343,8 @@ func makeCSVTableDescriptor(
 		sqlbase.NewDefaultPrivilegeDescriptor(),
 		nil, /* affected */
 		"",  /* sessionDB */
-		nil, /* EvalContext */
+		&semaCtx,
+		&evalCtx,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -150,7 +150,7 @@ func Load(
 			// only uses txn for resolving FKs and interleaved tables, neither of which
 			// are present here.
 			var txn *client.Txn
-			desc, err := sql.MakeTableDesc(ctx, txn, sql.NilVirtualTabler, parser.SearchPath{}, s, dbDesc.ID, 0 /* table ID */, ts, privs, affected, dbDesc.Name, &evalCtx)
+			desc, err := sql.MakeTableDesc(ctx, txn, sql.NilVirtualTabler, s, dbDesc.ID, 0 /* table ID */, ts, privs, affected, dbDesc.Name, nil, &evalCtx)
 			if err != nil {
 				return BackupDescriptor{}, errors.Wrap(err, "make table desc")
 			}

--- a/pkg/sql/analyze.go
+++ b/pkg/sql/analyze.go
@@ -1677,7 +1677,6 @@ func makeIsNotNull(left parser.TypedExpr) parser.TypedExpr {
 // analyzeExpr performs semantic analysis of an expression, including:
 // - replacing sub-queries by a sql.subquery node;
 // - resolving names (optional);
-// - replacing placeholders by their value;
 // - type checking (with optional type enforcement);
 // - normalization.
 // The parameters sources and IndexedVars, if both are non-nil, indicate

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -552,7 +552,7 @@ func (sc *SchemaChanger) distBackfill(
 			if err != nil {
 				return err
 			}
-			planCtx := sc.distSQLPlanner.newPlanningCtx(ctx, txn)
+			planCtx := sc.distSQLPlanner.newPlanningCtx(ctx, &evalCtx, txn)
 			plan, err := sc.distSQLPlanner.createBackfiller(
 				&planCtx, backfillType, *tableDesc, duration, chunkSize, spans, otherTableDescs, sc.readAsOf,
 			)

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -779,7 +779,7 @@ func TestPartitionSpans(t *testing.T) {
 				},
 			}
 
-			planCtx := dsp.newPlanningCtx(context.Background(), nil /* txn */)
+			planCtx := dsp.newPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */)
 			var spans []roachpb.Span
 			for _, s := range tc.spans {
 				spans = append(spans, roachpb.Span{Key: roachpb.Key(s[0]), EndKey: roachpb.Key(s[1])})
@@ -955,7 +955,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				},
 			}
 
-			planCtx := dsp.newPlanningCtx(context.Background(), nil /* txn */)
+			planCtx := dsp.newPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */)
 			partitions, err := dsp.partitionSpans(&planCtx, roachpb.Spans{span})
 			if err != nil {
 				t.Fatal(err)
@@ -1046,7 +1046,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		},
 	}
 
-	planCtx := dsp.newPlanningCtx(context.Background(), nil /* txn */)
+	planCtx := dsp.newPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */)
 	partitions, err := dsp.partitionSpans(&planCtx, roachpb.Spans{span})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -439,7 +439,7 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 	recv *distSQLReceiver,
 	evalCtx parser.EvalContext,
 ) error {
-	planCtx := dsp.newPlanningCtx(ctx, txn)
+	planCtx := dsp.newPlanningCtx(ctx, &evalCtx, txn)
 
 	log.VEvent(ctx, 1, "creating DistSQL plan")
 

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -289,7 +289,7 @@ func checkDistAggregationInfo(
 		if err != nil {
 			t.Fatal(err)
 		}
-		finalProc.Post.RenderExprs = []distsqlrun.Expression{MakeExpression(expr, nil)}
+		finalProc.Post.RenderExprs = []distsqlrun.Expression{MakeExpression(expr, nil, nil)}
 	}
 
 	procs = append(procs, finalProc)

--- a/pkg/sql/distsqlplan/expression.go
+++ b/pkg/sql/distsqlplan/expression.go
@@ -28,23 +28,30 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
-// exprFmtFlagsBase are FmtFlags used for serializing expressions; a proper
-// IndexedVar formatting function needs to be added on.
-var exprFmtFlagsBase = parser.FmtStarDatumFormat(
-	parser.FmtParsable,
-	func(buf *bytes.Buffer, _ parser.FmtFlags) {
-		fmt.Fprintf(buf, "0")
-	},
-)
+// exprFmtFlagsBase produced FmtFlags used for serializing expressions; a proper
+// IndexedVar formatting function needs to be added on. It replaces placeholders
+// with their values.
+func exprFmtFlagsBase(evalCtx *parser.EvalContext) parser.FmtFlags {
+	return parser.FmtPlaceholderFormat(
+		parser.FmtParsable,
+		func(buf *bytes.Buffer, flags parser.FmtFlags, p *parser.Placeholder) {
+			d, err := p.Eval(evalCtx)
+			if err != nil {
+				panic(fmt.Sprintf("failed to serialize placeholder: %s", err))
+			}
+			d.Format(buf, flags)
+		})
+}
 
-// exprFmtFlagsNoMap are FmtFlags used for serializing expressions that don't
-// need to remap IndexedVars.
-var exprFmtFlagsNoMap = parser.FmtIndexedVarFormat(
-	exprFmtFlagsBase,
-	func(buf *bytes.Buffer, _ parser.FmtFlags, _ parser.IndexedVarContainer, idx int) {
-		fmt.Fprintf(buf, "@%d", idx+1)
-	},
-)
+// exprFmtFlagsNoMap produces FmtFlags used for serializing expressions that
+// don't need to remap IndexedVars.
+func exprFmtFlagsNoMap(evalCtx *parser.EvalContext) parser.FmtFlags {
+	return parser.FmtIndexedVarFormat(
+		exprFmtFlagsBase(evalCtx),
+		func(buf *bytes.Buffer, _ parser.FmtFlags, _ parser.IndexedVarContainer, idx int) {
+			fmt.Fprintf(buf, "@%d", idx+1)
+		})
+}
 
 // MakeExpression creates a distsqlrun.Expression.
 //
@@ -54,18 +61,20 @@ var exprFmtFlagsNoMap = parser.FmtIndexedVarFormat(
 // The expr uses IndexedVars to refer to columns. The caller can optionally
 // remap these columns by passing an indexVarMap: an IndexedVar with index i
 // becomes column indexVarMap[i].
-func MakeExpression(expr parser.TypedExpr, indexVarMap []int) distsqlrun.Expression {
+func MakeExpression(
+	expr parser.TypedExpr, evalCtx *parser.EvalContext, indexVarMap []int,
+) distsqlrun.Expression {
 	if expr == nil {
 		return distsqlrun.Expression{}
 	}
 
-	// We format the expression using the IndexedVar and StarDatum formatting interceptors.
+	// We format the expression using the IndexedVar and Placeholder formatting interceptors.
 	var f parser.FmtFlags
 	if indexVarMap == nil {
-		f = exprFmtFlagsNoMap
+		f = exprFmtFlagsNoMap(evalCtx)
 	} else {
 		f = parser.FmtIndexedVarFormat(
-			exprFmtFlagsBase,
+			exprFmtFlagsBase(evalCtx),
 			func(buf *bytes.Buffer, _ parser.FmtFlags, _ parser.IndexedVarContainer, idx int) {
 				remappedIdx := indexVarMap[idx]
 				if remappedIdx < 0 {

--- a/pkg/sql/distsqlplan/physical_plan_test.go
+++ b/pkg/sql/distsqlplan/physical_plan_test.go
@@ -206,6 +206,7 @@ func TestProjectionAndRendering(t *testing.T) {
 						&parser.IndexedVar{Idx: 12},
 						&parser.IndexedVar{Idx: 13},
 					},
+					nil,
 					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3},
 					[]sqlbase.ColumnType{strToType("A"), strToType("B"), strToType("C"), strToType("D")},
 				)
@@ -227,6 +228,7 @@ func TestProjectionAndRendering(t *testing.T) {
 						&parser.IndexedVar{Idx: 13},
 						&parser.IndexedVar{Idx: 12},
 					},
+					nil,
 					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3},
 					[]sqlbase.ColumnType{strToType("B"), strToType("D"), strToType("C")},
 				)
@@ -254,6 +256,7 @@ func TestProjectionAndRendering(t *testing.T) {
 							Right:    &parser.IndexedVar{Idx: 2},
 						},
 					},
+					nil,
 					[]int{0, 1, 2},
 					[]sqlbase.ColumnType{strToType("X")},
 				)
@@ -285,6 +288,7 @@ func TestProjectionAndRendering(t *testing.T) {
 						},
 						&parser.IndexedVar{Idx: 10},
 					},
+					nil,
 					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2},
 					[]sqlbase.ColumnType{strToType("X"), strToType("A")},
 				)

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1771,6 +1771,7 @@ func (e *Executor) execStmtInOpenTxn(
 	p.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
 	p.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
 	p.semaCtx.Placeholders.Assign(pinfo)
+	p.evalCtx.Placeholders = &p.semaCtx.Placeholders
 	p.avoidCachedDescriptors = avoidCachedDescriptors
 	p.phaseTimes[plannerStartExecStmt] = timeutil.Now()
 	p.stmt = &stmt

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -143,7 +143,7 @@ func (p *planner) Explain(ctx context.Context, n *parser.Explain) (planNode, err
 		// We may want to show placeholder types, so ensure no values
 		// are missing.
 		p.semaCtx.Placeholders.FillUnassigned()
-		return p.makeExplainPlanNode(explainer, expanded, optimized, plan), nil
+		return p.makeExplainPlanNode(explainer, expanded, optimized, n.Statement, plan), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported EXPLAIN mode: %d", mode)

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -187,7 +187,7 @@ func (n *explainDistSQLNode) Start(params runParams) error {
 		return err
 	}
 
-	planCtx := n.distSQLPlanner.newPlanningCtx(params.ctx, n.txn)
+	planCtx := n.distSQLPlanner.newPlanningCtx(params.ctx, &params.p.evalCtx, n.txn)
 	plan, err := n.distSQLPlanner.createPlanForNode(&planCtx, n.plan)
 	if err != nil {
 		return err

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -272,7 +272,7 @@ func (d *DBool) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DBool)
+	v, ok := UnwrapDatum(ctx, other).(*DBool)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -382,7 +382,7 @@ func (d *DInt) Compare(ctx *EvalContext, other Datum) int {
 		return 1
 	}
 	var v DInt
-	switch t := UnwrapDatum(other).(type) {
+	switch t := UnwrapDatum(ctx, other).(type) {
 	case *DInt:
 		v = *t
 	case *DFloat, *DDecimal:
@@ -485,7 +485,7 @@ func (d *DFloat) Compare(ctx *EvalContext, other Datum) int {
 		return 1
 	}
 	var v DFloat
-	switch t := UnwrapDatum(other).(type) {
+	switch t := UnwrapDatum(ctx, other).(type) {
 	case *DFloat:
 		v = *t
 	case *DInt:
@@ -646,7 +646,7 @@ func (d *DDecimal) Compare(ctx *EvalContext, other Datum) int {
 		return 1
 	}
 	v := ctx.getTmpDec()
-	switch t := UnwrapDatum(other).(type) {
+	switch t := UnwrapDatum(ctx, other).(type) {
 	case *DDecimal:
 		v = &t.Decimal
 	case *DInt:
@@ -790,14 +790,14 @@ func (d *DString) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := AsDString(other)
+	v, ok := UnwrapDatum(ctx, other).(*DString)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
-	if *d < v {
+	if *d < *v {
 		return -1
 	}
-	if *d > v {
+	if *d > *v {
 		return 1
 	}
 	return 0
@@ -928,7 +928,7 @@ func (d *DCollatedString) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DCollatedString)
+	v, ok := UnwrapDatum(ctx, other).(*DCollatedString)
 	if !ok || d.Locale != v.Locale {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -996,7 +996,7 @@ func (d *DBytes) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DBytes)
+	v, ok := UnwrapDatum(ctx, other).(*DBytes)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -1081,7 +1081,7 @@ func (d *DUuid) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DUuid)
+	v, ok := UnwrapDatum(ctx, other).(*DUuid)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -1195,7 +1195,7 @@ func (d *DIPAddr) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DIPAddr)
+	v, ok := UnwrapDatum(ctx, other).(*DIPAddr)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -1348,7 +1348,7 @@ func (d *DDate) Compare(ctx *EvalContext, other Datum) int {
 		return 1
 	}
 	var v DDate
-	switch t := other.(type) {
+	switch t := UnwrapDatum(ctx, other).(type) {
 	case *DDate:
 		v = *t
 	case *DTimestamp, *DTimestampTZ:
@@ -1557,6 +1557,7 @@ func (*DTimestamp) ResolvedType() Type {
 }
 
 func timeFromDatum(ctx *EvalContext, d Datum) (time.Time, bool) {
+	d = UnwrapDatum(ctx, d)
 	switch t := d.(type) {
 	case *DDate:
 		return MakeDTimestampTZFromDate(ctx.GetLocation(), t).Time, true
@@ -1877,7 +1878,7 @@ func (d *DInterval) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DInterval)
+	v, ok := UnwrapDatum(ctx, other).(*DInterval)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -2002,7 +2003,7 @@ func (d *DJSON) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DJSON)
+	v, ok := UnwrapDatum(ctx, other).(*DJSON)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -2202,7 +2203,7 @@ func (d *DTuple) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DTuple)
+	v, ok := UnwrapDatum(ctx, other).(*DTuple)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -2532,7 +2533,7 @@ func (d *DArray) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := AsDArray(other)
+	v, ok := UnwrapDatum(ctx, other).(*DArray)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -2763,7 +2764,7 @@ func (d *DOid) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DOid)
+	v, ok := UnwrapDatum(ctx, other).(*DOid)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -2875,9 +2876,19 @@ func wrapWithOid(d Datum, oid oid.Oid) Datum {
 // UnwrapDatum returns the base Datum type for a provided datum, stripping
 // an *DOidWrapper if present. This is useful for cases like type switches,
 // where type aliases should be ignored.
-func UnwrapDatum(d Datum) Datum {
+func UnwrapDatum(evalCtx *EvalContext, d Datum) Datum {
 	if w, ok := d.(*DOidWrapper); ok {
 		return w.Wrapped
+	}
+	if p, ok := d.(*Placeholder); ok && evalCtx != nil && evalCtx.HasPlaceholders() {
+		ret, err := p.Eval(evalCtx)
+		if err != nil {
+			// If we fail to evaluate the placeholder, it's because we don't have
+			// a placeholder available. Just return the placeholder and someone else
+			// will handle this problem.
+			return d
+		}
+		return ret
 	}
 	return d
 }
@@ -2947,6 +2958,63 @@ func (d *DOidWrapper) Format(buf *bytes.Buffer, f FmtFlags) {
 // Size implements the Datum interface.
 func (d *DOidWrapper) Size() uintptr {
 	return unsafe.Sizeof(*d) + d.Wrapped.Size()
+}
+
+// AmbiguousFormat implements the Datum interface.
+func (d *Placeholder) AmbiguousFormat() bool {
+	return true
+}
+
+func (d *Placeholder) mustGetValue(ctx *EvalContext) Datum {
+	e, ok := ctx.Placeholders.Value(d.Name)
+	if !ok {
+		panic("fail")
+	}
+	out, err := e.Eval(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("fail %s", err))
+	}
+	return out
+}
+
+// Compare implements the Datum interface.
+func (d *Placeholder) Compare(ctx *EvalContext, other Datum) int {
+	return d.mustGetValue(ctx).Compare(ctx, other)
+}
+
+// Prev implements the Datum interface.
+func (d *Placeholder) Prev(ctx *EvalContext) (Datum, bool) {
+	return d.mustGetValue(ctx).Prev(ctx)
+}
+
+// IsMin implements the Datum interface.
+func (d *Placeholder) IsMin(ctx *EvalContext) bool {
+	return d.mustGetValue(ctx).IsMin(ctx)
+}
+
+// Next implements the Datum interface.
+func (d *Placeholder) Next(ctx *EvalContext) (Datum, bool) {
+	return d.mustGetValue(ctx).Next(ctx)
+}
+
+// IsMax implements the Datum interface.
+func (d *Placeholder) IsMax(ctx *EvalContext) bool {
+	return d.mustGetValue(ctx).IsMax(ctx)
+}
+
+// max implements the Datum interface.
+func (d *Placeholder) max(ctx *EvalContext) (Datum, bool) {
+	return d.mustGetValue(ctx).max(ctx)
+}
+
+// min implements the Datum interface.
+func (d *Placeholder) min(ctx *EvalContext) (Datum, bool) {
+	return d.mustGetValue(ctx).min(ctx)
+}
+
+// Size implements the Datum interface.
+func (d *Placeholder) Size() uintptr {
+	panic("shouldn't get called")
 }
 
 // NewDNameFromDString is a helper routine to create a *DName (implemented as

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1886,6 +1886,9 @@ type EvalContext struct {
 	// This must not be modified (this is shared from the session).
 	SearchPath SearchPath
 
+	// Placeholders relates placeholder names to their type and, later, value.
+	Placeholders *PlaceholderInfo
+
 	// CtxProvider holds the context in which the expression is evaluated. This
 	// will point to the session, which is itself a provider of contexts.
 	// NOTE: seems a bit lazy to hold a pointer to the session's context here,
@@ -1987,6 +1990,12 @@ func (ctx *EvalContext) GetClusterTimestampRaw() hlc.Timestamp {
 		panic("zero cluster timestamp in EvalContext")
 	}
 	return ctx.clusterTimestamp
+}
+
+// HasPlaceholders returns true if this EvalContext's placeholders have been
+// assigned. Will be false during Prepare.
+func (ctx *EvalContext) HasPlaceholders() bool {
+	return ctx.Placeholders != nil
 }
 
 // TimestampToDecimal converts the logical timestamp into a decimal
@@ -2249,7 +2258,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 	if d == DNull {
 		return d, nil
 	}
-	d = UnwrapDatum(d)
+	d = UnwrapDatum(ctx, d)
 	return performCast(ctx, d, expr.Type)
 }
 
@@ -2731,7 +2740,7 @@ func (expr *CollateExpr) Eval(ctx *EvalContext) (Datum, error) {
 	if err != nil {
 		return DNull, err
 	}
-	switch d := UnwrapDatum(d).(type) {
+	switch d := UnwrapDatum(ctx, d).(type) {
 	case *DString:
 		return NewDCollatedString(string(*d), expr.Locale, &ctx.collationEnv), nil
 	case *DCollatedString:
@@ -3173,9 +3182,37 @@ func (t *DOidWrapper) Eval(_ *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
-func (node *Placeholder) Eval(_ *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(
-		pgerror.CodeUndefinedParameterError, "no value provided for placeholder: $%s", node.Name)
+func (t *Placeholder) Eval(ctx *EvalContext) (Datum, error) {
+	if !ctx.HasPlaceholders() {
+		// While preparing a query, there will be no available placeholders. A
+		// placeholder evaluates to itself at this point.
+		return t, nil
+	}
+	e, ok := ctx.Placeholders.Value(t.Name)
+	if !ok {
+		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "missing value for placeholder %s", t.Name)
+	}
+	// Placeholder expressions cannot contain other placeholders, so we do
+	// not need to recurse.
+	typ, typed := ctx.Placeholders.Type(t.Name, false)
+	if !typed {
+		// All placeholders should be typed at this point.
+		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "missing type for placeholder %s", t.Name)
+	}
+	if !e.ResolvedType().Equivalent(typ) {
+		// This happens when we overrode the placeholder's type during type
+		// checking, since the placeholder's type hint didn't match the desired
+		// type for the placeholder. In this case, we cast the expression to
+		// the desired type.
+		// TODO(jordan): introduce a restriction on what casts are allowed here.
+		colType, err := DatumTypeToColumnType(typ)
+		if err != nil {
+			return nil, err
+		}
+		cast := &CastExpr{Expr: e, Type: colType}
+		return cast.Eval(ctx)
+	}
+	return e.Eval(ctx)
 }
 
 // Eval implements the TypedExpr interface.

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -645,6 +645,10 @@ func (*Placeholder) Variable() {}
 
 // Format implements the NodeFormatter interface.
 func (node *Placeholder) Format(buf *bytes.Buffer, f FmtFlags) {
+	if f.placeholderFormat != nil {
+		f.placeholderFormat(buf, f, node)
+		return
+	}
 	buf.WriteByte('$')
 	buf.WriteString(node.Name)
 }

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -626,8 +626,6 @@ func (node DefaultVal) Format(buf *bytes.Buffer, f FmtFlags) {
 // ResolvedType implements the TypedExpr interface.
 func (DefaultVal) ResolvedType() Type { return nil }
 
-var _ VariableExpr = &Placeholder{}
-
 // Placeholder represents a named placeholder.
 type Placeholder struct {
 	Name string
@@ -639,9 +637,6 @@ type Placeholder struct {
 func NewPlaceholder(name string) *Placeholder {
 	return &Placeholder{Name: name}
 }
-
-// Variable implements the VariableExpr interface.
-func (*Placeholder) Variable() {}
 
 // Format implements the NodeFormatter interface.
 func (node *Placeholder) Format(buf *bytes.Buffer, f FmtFlags) {

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -31,9 +31,9 @@ type fmtFlags struct {
 	// IndexedVarContainer.IndexedVarFormat calls; it can be used to
 	// customize the formatting of IndexedVars.
 	indexedVarFormat func(buf *bytes.Buffer, f FmtFlags, c IndexedVarContainer, idx int)
-	// starDatumFormat is an optional interceptor for StarDatum.Format calls,
-	// can be used to customize the formatting of StarDatums.
-	starDatumFormat func(buf *bytes.Buffer, f FmtFlags)
+	// placeholderFormat is an optional interceptor for Placeholder.Format calls;
+	// it can be used to format placeholders differently than normal.
+	placeholderFormat func(buf *bytes.Buffer, f FmtFlags, p *Placeholder)
 	// If true, non-function names are replaced by underscores.
 	anonymize bool
 	// If true, strings will be rendered without wrapping quotes if they
@@ -146,11 +146,13 @@ func FmtIndexedVarFormat(
 	return &f
 }
 
-// FmtStarDatumFormat returns FmtFlags that customizes the printing of
+// FmtPlaceholderFormat returns FmtFlags that customizes the printing of
 // StarDatums using the provided function.
-func FmtStarDatumFormat(base FmtFlags, fn func(buf *bytes.Buffer, f FmtFlags)) FmtFlags {
+func FmtPlaceholderFormat(
+	base FmtFlags, placeholderFn func(buf *bytes.Buffer, f FmtFlags, p *Placeholder),
+) FmtFlags {
 	f := *base
-	f.starDatumFormat = fn
+	f.placeholderFormat = placeholderFn
 	return &f
 }
 

--- a/pkg/sql/parser/hide_constants.go
+++ b/pkg/sql/parser/hide_constants.go
@@ -34,6 +34,9 @@ func formatNodeOrHideConstants(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
 					return
 				}
 			}
+		case *Placeholder:
+			// Placeholders should be printed as placeholder markers.
+			// Deliberately empty so we format as normal.
 		case Datum, Constant:
 			buf.WriteByte('_')
 			return

--- a/pkg/sql/parser/normalize.go
+++ b/pkg/sql/parser/normalize.go
@@ -95,7 +95,7 @@ func (expr *UnaryExpr) normalize(v *normalizeVisitor) TypedExpr {
 		return val
 	case UnaryMinus:
 		// -0 -> 0 (except for float which has negative zero)
-		if val.ResolvedType() != TypeFloat && IsNumericZero(val) {
+		if val.ResolvedType() != TypeFloat && v.isNumericZero(val) {
 			return val
 		}
 		switch b := val.(type) {
@@ -134,25 +134,25 @@ func (expr *BinaryExpr) normalize(v *normalizeVisitor) TypedExpr {
 
 	switch expr.Operator {
 	case Plus:
-		if IsNumericZero(right) {
+		if v.isNumericZero(right) {
 			final, v.err = ReType(left, expectedType)
 			break
 		}
-		if IsNumericZero(left) {
+		if v.isNumericZero(left) {
 			final, v.err = ReType(right, expectedType)
 			break
 		}
 	case Minus:
-		if IsNumericZero(right) {
+		if v.isNumericZero(right) {
 			final, v.err = ReType(left, expectedType)
 			break
 		}
 	case Mult:
-		if IsNumericOne(right) {
+		if v.isNumericOne(right) {
 			final, v.err = ReType(left, expectedType)
 			break
 		}
-		if IsNumericOne(left) {
+		if v.isNumericOne(left) {
 			final, v.err = ReType(right, expectedType)
 			break
 		}
@@ -160,7 +160,7 @@ func (expr *BinaryExpr) normalize(v *normalizeVisitor) TypedExpr {
 		// because if the other operand is NULL during evaluation
 		// the result must be NULL.
 	case Div, FloorDiv:
-		if IsNumericOne(right) {
+		if v.isNumericOne(right) {
 			final, v.err = ReType(left, expectedType)
 			break
 		}
@@ -357,7 +357,7 @@ func (expr *ComparisonExpr) normalize(v *normalizeVisitor) TypedExpr {
 				expr.Left = left.Left
 				expr.Right = newRightExpr
 				expr.memoizeFn()
-				if !isVar(expr.Left) {
+				if !isVar(v.ctx, expr.Left) {
 					// Continue as long as the left side of the comparison is not a
 					// variable.
 					continue
@@ -411,7 +411,7 @@ func (expr *ComparisonExpr) normalize(v *normalizeVisitor) TypedExpr {
 				expr.Left = left.Right
 				expr.Right = newRightExpr
 				expr.memoizeFn()
-				if !isVar(expr.Left) {
+				if !isVar(v.ctx, expr.Left) {
 					// Continue as long as the left side of the comparison is not a
 					// variable.
 					continue
@@ -593,6 +593,28 @@ func (expr *RangeCond) normalize(v *normalizeVisitor) TypedExpr {
 	return makeOpExpr(newLeft, newRight).normalize(v)
 }
 
+func (expr *Tuple) normalize(v *normalizeVisitor) TypedExpr {
+	// A Tuple should be directly evaluated into a DTuple if it's either fully
+	// constant or contains only constants and top-level Placeholders.
+	isConst := true
+	for _, subExpr := range expr.Exprs {
+		if !v.isConst(subExpr) {
+			if _, ok := subExpr.(*Placeholder); !ok {
+				isConst = false
+				break
+			}
+		}
+	}
+	if !isConst {
+		return expr
+	}
+	e, err := expr.Eval(v.ctx)
+	if err != nil {
+		v.err = err
+	}
+	return e
+}
+
 // NormalizeExpr normalizes a typed expression, simplifying where possible,
 // but guaranteeing that the result of evaluating the expression is
 // unchanged and that resulting expression tree is still well-typed.
@@ -604,7 +626,7 @@ func (expr *RangeCond) normalize(v *normalizeVisitor) TypedExpr {
 //   a BETWEEN b AND c     -> (a >= b) AND (a <= c)
 //   a NOT BETWEEN b AND c -> (a < b) OR (a > c)
 func (ctx *EvalContext) NormalizeExpr(typedExpr TypedExpr) (TypedExpr, error) {
-	v := normalizeVisitor{ctx: ctx}
+	v := makeNormalizeVisitor(ctx)
 	expr, _ := WalkExpr(&v, typedExpr)
 	if v.err != nil {
 		return nil, v.err
@@ -620,6 +642,11 @@ type normalizeVisitor struct {
 }
 
 var _ Visitor = &normalizeVisitor{}
+
+// makeNormalizeVisistor creates a normalizeVisistor instance.
+func makeNormalizeVisitor(ctx *EvalContext) normalizeVisitor {
+	return normalizeVisitor{ctx: ctx, isConstVisitor: isConstVisitor{ctx: ctx}}
+}
 
 func (v *normalizeVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	if v.err != nil {
@@ -656,6 +683,9 @@ func (v *normalizeVisitor) VisitPost(expr Expr) Expr {
 
 	// Evaluate all constant expressions.
 	if v.isConst(expr) {
+		if _, ok := expr.(*Placeholder); ok {
+			return expr
+		}
 		newExpr, err := expr.(TypedExpr).Eval(v.ctx)
 		if err != nil {
 			return expr
@@ -667,6 +697,38 @@ func (v *normalizeVisitor) VisitPost(expr Expr) Expr {
 
 func (v *normalizeVisitor) isConst(expr Expr) bool {
 	return v.isConstVisitor.run(expr)
+}
+
+// isNumericZero returns true if the datum is a number and equal to
+// zero.
+func (v *normalizeVisitor) isNumericZero(expr TypedExpr) bool {
+	if d, ok := expr.(Datum); ok {
+		switch t := UnwrapDatum(v.ctx, d).(type) {
+		case *DDecimal:
+			return t.Decimal.Sign() == 0
+		case *DFloat:
+			return *t == 0
+		case *DInt:
+			return *t == 0
+		}
+	}
+	return false
+}
+
+// isNumericOne returns true if the datum is a number and equal to
+// one.
+func (v *normalizeVisitor) isNumericOne(expr TypedExpr) bool {
+	if d, ok := expr.(Datum); ok {
+		switch t := UnwrapDatum(v.ctx, d).(type) {
+		case *DDecimal:
+			return t.Decimal.Cmp(&DecimalOne.Decimal) == 0
+		case *DFloat:
+			return *t == 1.0
+		case *DInt:
+			return *t == 1
+		}
+	}
+	return false
 }
 
 func invertComparisonOp(op ComparisonOperator) (ComparisonOperator, error) {
@@ -687,6 +749,7 @@ func invertComparisonOp(op ComparisonOperator) (ComparisonOperator, error) {
 }
 
 type isConstVisitor struct {
+	ctx     *EvalContext
 	isConst bool
 }
 
@@ -694,7 +757,7 @@ var _ Visitor = &isConstVisitor{}
 
 func (v *isConstVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	if v.isConst {
-		if isVar(expr) {
+		if isVar(v.ctx, expr) {
 			v.isConst = false
 			return false, expr
 		}
@@ -718,19 +781,25 @@ func (v *isConstVisitor) run(expr Expr) bool {
 	return v.isConst
 }
 
-func isVar(expr Expr) bool {
-	_, ok := expr.(VariableExpr)
-	return ok
+func isVar(evalCtx *EvalContext, expr Expr) bool {
+	switch expr.(type) {
+	case VariableExpr:
+		return true
+	case *Placeholder:
+		return evalCtx != nil && (!evalCtx.HasPlaceholders() || evalCtx.Placeholders.IsUnresolvedPlaceholder(expr))
+	}
+	return false
 }
 
 type containsVarsVisitor struct {
+	evalCtx      *EvalContext
 	containsVars bool
 }
 
 var _ Visitor = &containsVarsVisitor{}
 
 func (v *containsVarsVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
-	if !v.containsVars && isVar(expr) {
+	if !v.containsVars && isVar(v.evalCtx, expr) {
 		v.containsVars = true
 	}
 	if v.containsVars {
@@ -743,8 +812,8 @@ func (*containsVarsVisitor) VisitPost(expr Expr) Expr { return expr }
 
 // ContainsVars returns true if the expression contains any variables.
 // (variables = sub-expressions, placeholders, indexed vars, etc.)
-func ContainsVars(expr Expr) bool {
-	v := containsVarsVisitor{containsVars: false}
+func ContainsVars(evalCtx *EvalContext, expr Expr) bool {
+	v := containsVarsVisitor{evalCtx: evalCtx, containsVars: false}
 	WalkExprConst(&v, expr)
 	return v.containsVars
 }
@@ -754,38 +823,6 @@ var DecimalOne DDecimal
 
 func init() {
 	DecimalOne.SetCoefficient(1)
-}
-
-// IsNumericZero returns true if the datum is a number and equal to
-// zero.
-func IsNumericZero(expr TypedExpr) bool {
-	if d, ok := expr.(Datum); ok {
-		switch t := UnwrapDatum(d).(type) {
-		case *DDecimal:
-			return t.Decimal.Sign() == 0
-		case *DFloat:
-			return *t == 0
-		case *DInt:
-			return *t == 0
-		}
-	}
-	return false
-}
-
-// IsNumericOne returns true if the datum is a number and equal to
-// one.
-func IsNumericOne(expr TypedExpr) bool {
-	if d, ok := expr.(Datum); ok {
-		switch t := UnwrapDatum(d).(type) {
-		case *DDecimal:
-			return t.Decimal.Cmp(&DecimalOne.Decimal) == 0
-		case *DFloat:
-			return *t == 1.0
-		case *DInt:
-			return *t == 1
-		}
-	}
-	return false
 }
 
 // ReType ensures that the given numeric expression evaluates

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -86,12 +86,7 @@ func TypeCheck(expr Expr, ctx *SemaContext, desired Type) (TypedExpr, error) {
 		panic("the desired type for parser.TypeCheck cannot be nil, use TypeAny instead")
 	}
 
-	expr, err := replacePlaceholders(expr, ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	expr, err = foldConstantLiterals(expr)
+	expr, err := foldConstantLiterals(expr)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +115,7 @@ func (p *Parser) NormalizeExpr(ctx *EvalContext, typedExpr TypedExpr) (TypedExpr
 	if ctx.SkipNormalize {
 		return typedExpr, nil
 	}
-	p.normalizeVisitor = normalizeVisitor{ctx: ctx}
+	p.normalizeVisitor = makeNormalizeVisitor(ctx)
 	expr, _ := WalkExpr(&p.normalizeVisitor, typedExpr)
 	if err := p.normalizeVisitor.err; err != nil {
 		return nil, err

--- a/pkg/sql/parser/placeholders.go
+++ b/pkg/sql/parser/placeholders.go
@@ -67,7 +67,7 @@ func (p *PlaceholderInfo) Assign(src *PlaceholderInfo) {
 	}
 }
 
-// FillUnassigned sets all unsassigned placeholders to NULL.
+// FillUnassigned sets all unassigned placeholders to NULL.
 func (p *PlaceholderInfo) FillUnassigned() {
 	for pn := range p.Types {
 		if _, ok := p.Values[pn]; !ok {
@@ -135,7 +135,14 @@ func (p *PlaceholderInfo) SetValue(name string, val Datum) {
 func (p *PlaceholderInfo) SetType(name string, typ Type) error {
 	t, ok := p.Types[name]
 	if ok && !typ.Equivalent(t) {
-		return pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError, "placeholder %s already has type %s, cannot assign %s", name, t, typ)
+		// If we already have a *value* for this expression, then we're good to go.
+		// This can happen when we're running statements with placeholders from the
+		// internal executor, which directly assigns placeholder values and types.
+		// If the directly-assigned placeholder value is null, then the type
+		// assigned will be NULL. We should set it properly rather than fail.
+		if _, ok := p.Value(name); !ok {
+			return pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError, "placeholder %s already has type %s, cannot assign %s", name, t, typ)
+		}
 	}
 	p.Types[name] = typ
 	if _, ok := p.TypeHints[name]; !ok {
@@ -171,64 +178,4 @@ func (p *PlaceholderInfo) IsUnresolvedPlaceholder(expr Expr) bool {
 		return !res
 	}
 	return false
-}
-
-// placeholdersVisitor is a Visitor implementation used to
-// replace placeholders with their supplied values.
-type placeholdersVisitor struct {
-	placeholders PlaceholderInfo
-	err          error
-}
-
-var _ Visitor = &placeholdersVisitor{}
-
-func (v *placeholdersVisitor) VisitPre(expr Expr) (recurse bool, newNode Expr) {
-	switch t := expr.(type) {
-	case *Placeholder:
-		if e, ok := v.placeholders.Value(t.Name); ok {
-			// Placeholder expressions cannot contain other placeholders, so we do
-			// not need to recurse.
-			typ, typed := v.placeholders.Type(t.Name, false)
-			if !typed {
-				// All placeholders should be typed at this point.
-				v.err = pgerror.NewErrorf(pgerror.CodeInternalError, "missing type for placeholder %s", t.Name)
-				return false, e
-			}
-			if !e.ResolvedType().Equivalent(typ) {
-				// This happens when we overrode the placeholder's type during type
-				// checking, since the placeholder's type hint didn't match the desired
-				// type for the placeholder. In this case, we cast the expression to
-				// the desired type.
-				// TODO(jordan): introduce a restriction on what casts are allowed here.
-				colType, err := DatumTypeToColumnType(typ)
-				if err != nil {
-					v.err = err
-					return false, e
-				}
-				return false, &CastExpr{Expr: e, Type: colType}
-			}
-			return false, e
-		}
-	}
-	return true, expr
-}
-
-func (*placeholdersVisitor) VisitPost(expr Expr) Expr { return expr }
-
-// replacePlaceholders replaces all placeholders in the input expression with
-// their supplied values in the SemaContext's Placeholders map. If there is no
-// available value for a placeholder, it is left alone. A nil ctx makes
-// this a no-op and is supported for tests only.
-func replacePlaceholders(expr Expr, ctx *SemaContext) (Expr, error) {
-	// We don't need to recurse through the input if there are no values to
-	// replace, since the walk above will do no work in that case. This happens
-	// during typechecking during the prepare phase. Missing placeholder values
-	// during execute are detected before this step.
-	if ctx == nil || len(ctx.Placeholders.Values) == 0 {
-		return expr, nil
-	}
-	v := &placeholdersVisitor{placeholders: ctx.Placeholders}
-
-	expr, _ = WalkExpr(v, expr)
-	return expr, v.err
 }

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -104,7 +104,7 @@ func (b *writeBuffer) writeTextDatum(
 		b.putInt32(-1)
 		return
 	}
-	switch v := parser.UnwrapDatum(d).(type) {
+	switch v := parser.UnwrapDatum(nil, d).(type) {
 	case *parser.DBool:
 		b.putInt32(1)
 		if *v {
@@ -231,7 +231,7 @@ func (b *writeBuffer) writeBinaryDatum(
 		b.putInt32(-1)
 		return
 	}
-	switch v := parser.UnwrapDatum(d).(type) {
+	switch v := parser.UnwrapDatum(nil, d).(type) {
 	case *parser.DBool:
 		b.putInt32(1)
 		if *v {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -164,6 +164,8 @@ func makeInternalPlanner(
 		p.evalCtx.SetStmtTimestamp(ts)
 	}
 
+	p.evalCtx.Placeholders = &p.semaCtx.Placeholders
+
 	return p
 }
 
@@ -229,6 +231,7 @@ func (p *planner) query(ctx context.Context, sql string, args ...interface{}) (p
 		return nil, err
 	}
 	golangFillQueryArguments(&p.semaCtx.Placeholders, args)
+	p.evalCtx.Placeholders = &p.semaCtx.Placeholders
 	return p.makePlan(ctx, Statement{AST: stmt})
 }
 

--- a/pkg/sql/prepare.go
+++ b/pkg/sql/prepare.go
@@ -353,7 +353,7 @@ func getPreparedStatementForExecute(
 	var p parser.Parser
 	for i, e := range s.Params {
 		idx := strconv.Itoa(i + 1)
-		typedExpr, err := sqlbase.SanitizeVarFreeExpr(e, prepared.TypeHints[idx], "EXECUTE parameter", session.SearchPath)
+		typedExpr, err := sqlbase.SanitizeVarFreeExpr(e, prepared.TypeHints[idx], "EXECUTE parameter", nil /* semaCtx */, nil /* evalCtx */)
 		if err != nil {
 			return ps, pInfo, pgerror.NewError(pgerror.CodeWrongObjectTypeError, err.Error())
 		}
@@ -389,6 +389,7 @@ func (p *planner) Execute(ctx context.Context, n *parser.Execute) (planNode, err
 		return nil, err
 	}
 	p.semaCtx.Placeholders.Assign(newPInfo)
+	p.evalCtx.Placeholders = &p.semaCtx.Placeholders
 
 	return p.newPlan(ctx, ps.Statement, nil)
 }

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -621,6 +621,35 @@ func (s *Session) Ctx() context.Context {
 	return s.context
 }
 
+type evalPlanner struct {
+	p *planner
+}
+
+// QueryRow implements parser.EvalPlanner. Its special function is to preserve
+// the placeholder map of the outer planner, which would otherwise be
+// overwritten by planner.QueryRow.
+func (ep *evalPlanner) QueryRow(
+	ctx context.Context, sql string, args ...interface{},
+) (parser.Datums, error) {
+	placeholders := ep.p.semaCtx.Placeholders
+	defer func() {
+		ep.p.semaCtx.Placeholders = placeholders
+		ep.p.evalCtx.Placeholders = &ep.p.semaCtx.Placeholders
+	}()
+	ep.p.semaCtx.Placeholders = parser.PlaceholderInfo{}
+	ep.p.evalCtx.Placeholders = &ep.p.semaCtx.Placeholders
+	return ep.p.QueryRow(ctx, sql, args...)
+}
+
+// QualifyWithDatabase implements parser.EvalPlanner.
+func (ep *evalPlanner) QualifyWithDatabase(
+	ctx context.Context, t *parser.NormalizableTableName,
+) (*parser.TableName, error) {
+	return ep.p.QualifyWithDatabase(ctx, t)
+}
+
+var _ parser.EvalPlanner = &evalPlanner{}
+
 func (s *Session) resetPlanner(p *planner, e *Executor, txn *client.Txn) {
 	p.session = s
 	// phaseTimes is an array, not a slice, so this performs a copy-by-value.
@@ -633,7 +662,7 @@ func (s *Session) resetPlanner(p *planner, e *Executor, txn *client.Txn) {
 	p.semaCtx.SearchPath = s.SearchPath
 
 	p.evalCtx = s.evalCtx()
-	p.evalCtx.Planner = p
+	p.evalCtx.Planner = &evalPlanner{p: p}
 	if e != nil {
 		p.evalCtx.ClusterID = e.cfg.ClusterID()
 		p.evalCtx.NodeID = e.cfg.NodeID.Get()

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -396,7 +396,7 @@ func setTimeZone(_ context.Context, session *Session, values []parser.TypedExpr)
 
 	var loc *time.Location
 	var offset int64
-	switch v := parser.UnwrapDatum(d).(type) {
+	switch v := parser.UnwrapDatum(&evalCtx, d).(type) {
 	case *parser.DString:
 		location := string(*v)
 		loc, err = timeutil.LoadLocation(location)

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -103,6 +103,13 @@ func (p *planner) SetVar(ctx context.Context, n *parser.SetVar) (planNode, error
 
 func (n *setNode) Start(params runParams) error {
 	if n.typedValues != nil {
+		for i, v := range n.typedValues {
+			d, err := v.Eval(&params.p.evalCtx)
+			if err != nil {
+				return err
+			}
+			n.typedValues[i] = d
+		}
 		return n.v.Set(params.ctx, params.p.session, n.typedValues)
 	}
 	return n.v.Reset(params.p.session)

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -63,13 +63,16 @@ func incompatibleExprTypeError(
 // type and contains no variable expressions. It returns the type-checked and
 // constant-folded expression.
 func SanitizeVarFreeExpr(
-	expr parser.Expr, expectedType parser.Type, context string, searchPath parser.SearchPath,
+	expr parser.Expr,
+	expectedType parser.Type,
+	context string,
+	semaCtx *parser.SemaContext,
+	evalCtx *parser.EvalContext,
 ) (parser.TypedExpr, error) {
-	if parser.ContainsVars(expr) {
+	if parser.ContainsVars(evalCtx, expr) {
 		return nil, exprContainsVarsError(context, expr)
 	}
-	ctx := parser.SemaContext{SearchPath: searchPath}
-	typedExpr, err := parser.TypeCheck(expr, &ctx, expectedType)
+	typedExpr, err := parser.TypeCheck(expr, semaCtx, expectedType)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +89,7 @@ func SanitizeVarFreeExpr(
 // index descriptor if the column is a primary key or unique.
 // The search path is used for name resolution for DEFAULT expressions.
 func MakeColumnDefDescs(
-	d *parser.ColumnTableDef, searchPath parser.SearchPath, evalCtx *parser.EvalContext,
+	d *parser.ColumnTableDef, semaCtx *parser.SemaContext, evalCtx *parser.EvalContext,
 ) (*ColumnDescriptor, *IndexDescriptor, error) {
 	col := &ColumnDescriptor{
 		Name:     string(d.Name),
@@ -151,8 +154,7 @@ func MakeColumnDefDescs(
 		col.Type.Width = int32(t.N)
 	case *parser.ArrayColType:
 		for i, e := range t.BoundsExprs {
-			ctx := parser.SemaContext{SearchPath: searchPath}
-			te, err := parser.TypeCheckAndRequire(e, &ctx, parser.TypeInt, "array bounds")
+			te, err := parser.TypeCheckAndRequire(e, semaCtx, parser.TypeInt, "array bounds")
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "couldn't get bound %d", i)
 			}
@@ -184,19 +186,19 @@ func MakeColumnDefDescs(
 	if d.HasDefaultExpr() {
 		// Verify the default expression type is compatible with the column type.
 		if _, err := SanitizeVarFreeExpr(
-			d.DefaultExpr.Expr, colDatumType, "DEFAULT", searchPath,
+			d.DefaultExpr.Expr, colDatumType, "DEFAULT", semaCtx, evalCtx,
 		); err != nil {
 			return nil, nil, err
 		}
 		var p parser.Parser
 		if err := p.AssertNoAggregationOrWindowing(
-			d.DefaultExpr.Expr, "DEFAULT expressions", searchPath,
+			d.DefaultExpr.Expr, "DEFAULT expressions", semaCtx.SearchPath,
 		); err != nil {
 			return nil, nil, err
 		}
 
 		// Type check and simplify: this performs constant folding and reduces the expression.
-		typedExpr, err := parser.TypeCheck(d.DefaultExpr.Expr, nil, col.Type.ToDatumType())
+		typedExpr, err := parser.TypeCheck(d.DefaultExpr.Expr, semaCtx, col.Type.ToDatumType())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -492,7 +494,7 @@ func EncodeTableKey(b []byte, val parser.Datum, dir encoding.Direction) ([]byte,
 		return encoding.EncodeNullDescending(b), nil
 	}
 
-	switch t := parser.UnwrapDatum(val).(type) {
+	switch t := parser.UnwrapDatum(nil, val).(type) {
 	case *parser.DBool:
 		var x int64
 		if *t {
@@ -603,7 +605,7 @@ func EncodeTableValue(
 	if val == parser.DNull {
 		return encoding.EncodeNullValue(appendTo, uint32(colID)), nil
 	}
-	switch t := parser.UnwrapDatum(val).(type) {
+	switch t := parser.UnwrapDatum(nil, val).(type) {
 	case *parser.DBool:
 		return encoding.EncodeBoolValue(appendTo, uint32(colID), bool(*t)), nil
 	case *parser.DInt:


### PR DESCRIPTION
Previously, the `Placeholder` expression type was merely a marker that
was replaced during type checking with an actual Datum value by a tree
traversal.

This was inefficient - every query with placeholders would end up
getting path-copied during that replacement step. Additionally, it was
an obstacle to optimizations like plan caching that requires that
expression trees retain their meaning after type checking.

Now, a `Placeholder` is a fully fledged `Expr` that can be evaluated.
Evaluating a `Placeholder` returns the `Datum` that it points to in the
`PlaceholderInfo` map.

This transformation required a lot of plumbing, which makes up the bulk
of this patch. `EvalContext` had to be augmented to include a
`PlaceholderInfo` map so that the placeholder values can be known at
`Placeholder.Eval()` time. `EvalContext`s and `SemaContext`s also needed
to be plumbed to every place that needs to check for constant
expressions, since checking for constant expressions now requires that
placeholder values be known (placeholders without values are not
constant expressions; placeholders with values are).

**n.b.:**
after this patch alone, we still end up path copying all placeholders because of
`NormalizeVisitor`, which traverses expression trees and `Eval()`s all constant
subexpressions, which `Placeholder` now counts as.

I think the right solution here is to actually have `Placeholder` implement `Datum`
(and plumb `EvalContext` into all `Datum` methods). That way `Placeholder` can
simply forward its methods to its underlying `Datum` and we get the behavior that
we want (no path copying) without changing all of the index selection and analysis
code that expects `Datum` objects in specific parts of the tree.