### PR TITLE
cli/sql: bump the go-libedit dependency to fix signal handling on darwin

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -456,8 +456,8 @@
 [[projects]]
   name = "github.com/knz/go-libedit"
   packages = [".","common","other","unix"]
-  revision = "7577af3c24e9e2f3298da1358c4fa5e2329fd304"
-  version = "v1.4"
+  revision = "aafda877029e573c3bc5e352d000a41076e3d973"
+  version = "v1.6.1"
 
 [[projects]]
   branch = "master"

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -595,11 +595,6 @@ func (c *cliState) GetCompletions(_ string) []string {
 	return nil
 }
 
-// GetLeftPrompt implements the readline.LeftPromptGenerator interface.
-func (c *cliState) GetLeftPrompt() string {
-	return c.currentPrompt
-}
-
 func (c *cliState) doStart(nextState cliStateEnum) cliStateEnum {
 	// Common initialization.
 	c.partialLines = []string{}
@@ -610,7 +605,6 @@ func (c *cliState) doStart(nextState cliStateEnum) cliStateEnum {
 		c.smartPrompt = true
 		c.promptPrefix, c.fullPrompt, c.continuePrompt = preparePrompts(c.conn.url)
 
-		c.ins.SetLeftPrompt(c)
 		c.ins.SetCompleter(c)
 		if err := c.ins.UseHistory(-1 /*maxEntries*/, true /*dedup*/); err != nil {
 			log.Warningf(context.TODO(), "cannot enable history: %v", err)
@@ -653,6 +647,7 @@ func (c *cliState) doStartLine(nextState cliStateEnum) cliStateEnum {
 
 	if isInteractive {
 		c.currentPrompt = c.fullPrompt
+		c.ins.SetLeftPrompt(c.currentPrompt)
 	}
 
 	return nextState
@@ -663,6 +658,7 @@ func (c *cliState) doContinueLine(nextState cliStateEnum) cliStateEnum {
 
 	if isInteractive {
 		c.currentPrompt = c.continuePrompt
+		c.ins.SetLeftPrompt(c.currentPrompt)
 	}
 
 	return nextState


### PR DESCRIPTION
The details of the story can be found here:

https://github.com/knz/go-libedit/commit/5ffa3044c44237e9fc907fd3fc17e4cf604a2f12
(failed attempt: https://github.com/knz/go-libedit/commit/3b0f69cb0f672aad6a49ee224c3a801ae576a6e9)

This patch also tweaks the handling of the prompts, since go-libedit
1.5 doesn't do Go callbacks any more.

Fixes #19132.