### PR TITLE
CONTRIBUTING.md: document the tinfo dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,9 @@ new engineers.
      - A C++ compiler that supports C++11. Note that GCC prior to 6.0 doesn't
        work due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891
      - The standard C/C++ development headers on your system.
+     - On GNU/Linux, the terminfo development libraries, which may be
+       part of a ncurses development package (e.g. `libtinfo-dev` on
+       Debian/Ubuntu, but `ncurses-devel` on CentOS).
      - A Go environment with a recent 64-bit version of the toolchain. Note that
        the Makefile enforces the specific version required, as it is updated
        frequently.


### PR DESCRIPTION
Fixes #19116.

The root cause of the issue, as determined by @mberhault [here](https://github.com/cockroachdb/cockroach/issues/19116#issuecomment-337908428), is that although libtinfo is part of the base system on every gnu/linux distro (because it's part of the LSB) the linker will look at a file name called `libtinfo.so` *without a version number*, and fish the version number to use as the real run-time dependency from that file. That file is a symlink, typically only installed by the ncurses/terminfo dev package.