### PR TITLE
storage: harden node liveness mechanism

### DIFF
--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -56,6 +56,10 @@ const (
 	// KeyNodeLivenessPrefix is the key prefix for gossiping node liveness info.
 	KeyNodeLivenessPrefix = "liveness"
 
+	// KeyNodeLivenessSelfReportedPrefix is the key prefix for nodes
+	// optimistically gossiping their expected node liveness info.
+	KeyNodeLivenessSelfReportedPrefix = "self-liveness"
+
 	// KeySentinel is a key for gossip which must not expire or
 	// else the node considers itself partitioned and will retry with
 	// bootstrap hosts.  The sentinel is gossiped by the node that holds
@@ -121,6 +125,12 @@ func NodeIDFromKey(key string) (roachpb.NodeID, error) {
 // MakeNodeLivenessKey returns the gossip key for node liveness info.
 func MakeNodeLivenessKey(nodeID roachpb.NodeID) string {
 	return MakeKey(KeyNodeLivenessPrefix, nodeID.String())
+}
+
+// MakeNodeLivenessSelfReportedKey returns the gossip key for
+// self-reported node liveness info.
+func MakeNodeLivenessSelfReportedKey(nodeID roachpb.NodeID) string {
+	return MakeKey(KeyNodeLivenessSelfReportedPrefix, nodeID.String())
 }
 
 // MakeStoreKey returns the gossip key for the given store.


### PR DESCRIPTION
- Introduce a new gossip key for self-report node liveness info. Each node
  optimistically gossips node liveness in advance of heartbeats. Nodes
  receiving self-reported gossip trust them, as long as they're not the node's
  own self-reported value. In other words, nodes trust other nodes' self
  reported liveness values and give them the benefit of the doubt before
  attempting to increment their epochs, but will only trust the official liveness
  range's gossip of liveness values when considering whether it is itself live.

- Don't increment the epoch of another node if current node is not live. This
  just seems like good policy.