### PR TITLE
ui: Add Query Manager Reducer

### DIFF
--- a/pkg/ui/src/redux/queryManager/reducer.spec.ts
+++ b/pkg/ui/src/redux/queryManager/reducer.spec.ts
@@ -1,0 +1,114 @@
+import { assert } from "chai";
+import moment from "moment";
+
+import {
+  managedQueryReducer,
+  ManagedQueryState,
+  queryBegin,
+  queryComplete,
+  queryError,
+  queryManagerReducer,
+  QueryManagerState,
+} from "./reducer";
+
+describe("Query Manager State", function () {
+  describe("managed query reducer", function () {
+    const testMoment = moment();
+    const testError = new Error("err");
+    let state: ManagedQueryState;
+
+    beforeEach(function() {
+      state = managedQueryReducer(undefined, {} as any);
+    });
+
+    it("has the correct initial state", function () {
+      assert.deepEqual(state, new ManagedQueryState());
+    });
+
+    it("dispatches queryBegin correctly", function () {
+      // We expect "isRunning" to be true and all other fields to be null.
+      const expected = new ManagedQueryState();
+      expected.isRunning = true;
+      expected.lastError = null;
+      expected.completedAt = null;
+
+      state = managedQueryReducer(state, queryBegin("ID"));
+      assert.deepEqual(state, expected);
+    });
+
+    it("dispatches queryError correctly", function () {
+      // We expect "isRunning" to be false; both the error field and completedAt
+      // should be populated with the supplied information from the action.
+      const expected = new ManagedQueryState();
+      expected.isRunning = false;
+      expected.lastError = testError;
+      expected.completedAt = testMoment;
+
+      state = managedQueryReducer(state, queryBegin("ID"));
+      state = managedQueryReducer(state, queryError("ID", testError, testMoment));
+      assert.deepEqual(state, expected);
+    });
+
+    it("dispatches queryComplete correctly", function () {
+      // We expect "isRunning" to be false, completedAt to be populated, and
+      // the error field to be null.
+      const expected = new ManagedQueryState();
+      expected.isRunning = false;
+      expected.lastError = null;
+      expected.completedAt = testMoment;
+
+      state = managedQueryReducer(state, queryBegin("ID"));
+      state = managedQueryReducer(state, queryComplete("ID", testMoment));
+      assert.deepEqual(state, expected);
+    });
+
+    it("clears error on queryBegin", function () {
+      const expected = new ManagedQueryState();
+      expected.isRunning = true;
+      expected.lastError = null;
+      expected.completedAt = null;
+
+      state = managedQueryReducer(state, queryError("ID", testError, testMoment));
+      state = managedQueryReducer(state, queryBegin("ID"));
+      assert.deepEqual(state, expected);
+    });
+
+    it("ignores unrecognized actions", function () {
+      const origState = state;
+      state = managedQueryReducer(state, { type: "unsupported" } as any);
+      assert.equal(state, origState);
+    });
+  });
+
+  describe("query manager reducer", function () {
+    const testMoment = moment();
+    const testError = new Error("err");
+    let state: QueryManagerState;
+
+    beforeEach(function() {
+      state = queryManagerReducer(undefined, {} as any);
+    });
+
+    it("has the correct initial value", function () {
+      assert.deepEqual(state, {});
+    });
+
+    it("correctly dispatches based on ID", function () {
+      const expected = {
+        "1": managedQueryReducer(undefined, queryBegin("1")),
+        "2": managedQueryReducer(undefined, queryError("2", testError, testMoment)),
+        "3": managedQueryReducer(undefined, queryComplete("3", testMoment)),
+      };
+
+      state = queryManagerReducer(state, queryBegin("1"));
+      state = queryManagerReducer(state, queryBegin("2"));
+      state = queryManagerReducer(state, queryBegin("3"));
+      state = queryManagerReducer(state, queryError("2", testError, testMoment));
+      state = queryManagerReducer(state, queryError("3", testError, testMoment));
+      state = queryManagerReducer(state, queryBegin("3"));
+      state = queryManagerReducer(state, queryComplete("3", testMoment));
+
+      assert.deepEqual(state, expected);
+    });
+  });
+});

--- a/pkg/ui/src/redux/queryManager/reducer.ts
+++ b/pkg/ui/src/redux/queryManager/reducer.ts
@@ -1,0 +1,149 @@
+import moment from "moment";
+import { Action } from "redux";
+
+import nextState from "src/util/nextState";
+
+const QUERY_BEGIN = "cockroachui/queries/QUERY_BEGIN";
+const QUERY_ERROR = "cockroachui/queries/QUERY_ERROR";
+const QUERY_COMPLETE = "cockroachui/queries/QUERY_COMPLETE";
+
+interface QueryBeginAction extends Action {
+    type: typeof QUERY_BEGIN;
+    payload: {
+        id: string;
+    };
+}
+
+interface QueryErrorAction extends Action {
+    type: typeof QUERY_ERROR;
+    payload: {
+        id: string;
+        error: Error;
+        timestamp: moment.Moment;
+    };
+}
+
+interface QueryCompleteAction extends Action {
+    type: typeof QUERY_COMPLETE;
+    payload: {
+        id: string;
+        timestamp: moment.Moment;
+    };
+}
+
+type QueryAction = QueryBeginAction | QueryErrorAction | QueryCompleteAction;
+
+/**
+ * queryBegin is dispatched by the query manager whenever the query with the
+ * given ID has started execution.
+ */
+export function queryBegin(id: string): QueryBeginAction {
+    return {
+        type: QUERY_BEGIN,
+        payload: {
+            id,
+        },
+    };
+}
+
+/**
+ * queryError is dispatched by the query manager whenever the query with the
+ * given ID has stopped due to an error condition. This action contains the
+ * returned error, along with the timestamp when the error was received.
+ */
+export function queryError(id: string, error: Error, timestamp: moment.Moment): QueryErrorAction {
+    return {
+        type: QUERY_ERROR,
+        payload: {
+            id,
+            error,
+            timestamp,
+        },
+    };
+}
+
+/**
+ * queryComplete is dispatched by the query manager whenever the query with the
+ * given ID has completed successfully. It includes the timestamp when the query
+ * was completed.
+ */
+export function queryComplete(id: string, timestamp: moment.Moment): QueryCompleteAction {
+    return {
+        type: QUERY_COMPLETE,
+        payload: {
+            id,
+            timestamp,
+        },
+    };
+}
+
+/**
+ * ManagedQueryState maintains the current state for a single managed query.
+ */
+export class ManagedQueryState {
+    // True if this query is currently running asynchronously.
+    isRunning = false;
+    // If the previous attempt to run this query ended with an error, this field
+    // contains that error.
+    lastError: Error = null;
+    // Contains the timestamp when the query last compeleted, regardless of
+    // whether it succeeded or encountered an error.
+    completedAt: moment.Moment = null;
+}
+
+/**
+ * managedQueryReducer reduces actions for a single managed query.
+ */
+export function managedQueryReducer(
+    state = new ManagedQueryState(), action: QueryAction,
+): ManagedQueryState {
+    switch (action.type) {
+        case QUERY_BEGIN:
+            return nextState(state, {
+                isRunning: true,
+                lastError: null,
+                completedAt: null,
+            });
+        case QUERY_ERROR:
+            return nextState(state, {
+                isRunning: false,
+                lastError: action.payload.error,
+                completedAt: action.payload.timestamp,
+            });
+        case QUERY_COMPLETE:
+            return nextState(state, {
+                isRunning: false,
+                lastError: null,
+                completedAt: action.payload.timestamp,
+            });
+        default:
+            return state;
+    }
+}
+
+/**
+ * QueryManagerState maintains the state for all queries being managed.
+ */
+export interface QueryManagerState {
+    [id: string]: ManagedQueryState;
+}
+
+/**
+ * queryManagerReducer reduces actions for a query collection, multiplexing
+ * incoming actions to individual query reducers by ID.
+ */
+export function queryManagerReducer(
+    state: QueryManagerState = {}, action: QueryAction,
+): QueryManagerState {
+    switch (action.type) {
+        case QUERY_BEGIN:
+        case QUERY_ERROR:
+        case QUERY_COMPLETE:
+            return {
+                ...state,
+                [action.payload.id]: managedQueryReducer(state[action.payload.id], action),
+            };
+        default:
+            return state;
+    }
+}

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -8,6 +8,7 @@ import thunk from "redux-thunk";
 import { apiReducersReducer, APIReducersState } from "./apiReducers";
 import { localSettingsReducer, LocalSettingsState } from "./localsettings";
 import { metricsReducer, MetricsState, queryMetricsSaga } from "./metrics";
+import { queryManagerReducer, QueryManagerState } from "./queryManager/reducer";
 import { timeWindowReducer, TimeWindowState } from "./timewindow";
 import { uiDataReducer, UIDataState } from "./uiData";
 
@@ -15,6 +16,7 @@ export interface AdminUIState {
     cachedData: APIReducersState;
     localSettings: LocalSettingsState;
     metrics: MetricsState;
+    queryManager: QueryManagerState;
     routing: RouterState;
     timewindow: TimeWindowState;
     uiData: UIDataState;
@@ -30,6 +32,7 @@ export function createAdminUIStore() {
       cachedData: apiReducersReducer,
       localSettings: localSettingsReducer,
       metrics: metricsReducer,
+      queryManager: queryManagerReducer,
       routing: routerReducer,
       timewindow: timeWindowReducer,
       uiData: uiDataReducer,

--- a/pkg/ui/src/util/nextState.ts
+++ b/pkg/ui/src/util/nextState.ts
@@ -1,0 +1,30 @@
+import _ from "lodash";
+
+/**
+ * nextState is a utility function that allows type-safe replacement of fields
+ * when generating a new state in a redux reducer. This is an alternative to
+ * using the spread operator; e.g. instead of:
+ *
+ * return {
+ *   ...state,
+ *   prop1: "newValue",
+ * }
+ *
+ * nextState can be used instead:
+ *
+ * return nextState(state, {
+ *   prop1: "newValue",
+ * });
+ *
+ * The advantage is the explicit requirement that replacement values are
+ * overwriting fields that exist on the type of state. In the examples above,
+ * using the spread operator would compile even if "prop1" was not a field of
+ * state's type. This is an explicit design choice of typescript.
+ *
+ * @param lastState An object representing the previous state of a reducer.
+ * @param changes A set of new properties which should replace properties of the
+ * previous object.
+ */
+export default function nextState<T extends Object>(lastState: T, changes: Partial<T>): T {
+    return _.assign({}, lastState, changes);
+}


### PR DESCRIPTION
Adds the Query Manager Reducer, which is designed to to hold metadata
state for asynchronous queries. For each query, this state includes:
+ Whether the query is currently running.
+ If the last attempt to run the query encountered an error.
+ The time at which the query was last attempted.

Currently, this metadata is being stored in the Admin UI right alongside
the data itself, and each query is responsible for managing its own
execution and metadata. This commit does not change this, but creates a
reducer that will be used to store it after further refactoring - the
next step will be to create a Saga that executes queries, using this
reducer to store query metadata.