### PR TITLE
storage: factor out replicaStateLoader

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -722,7 +722,7 @@ func (r *Replica) handleReplicatedEvalResult(
 			r.mu.state.Stats.ContainsEstimates = false
 			stats := *r.mu.state.Stats
 			r.mu.Unlock()
-			if err := r.raftMu.stateLoader.setMVCCStats(ctx, r.store.Engine(), &stats); err != nil {
+			if err := r.raftMu.stateLoader.SetMVCCStats(ctx, r.store.Engine(), &stats); err != nil {
 				log.Fatal(ctx, errors.Wrap(err, "unable to write MVCC stats"))
 			}
 		}

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -802,7 +802,7 @@ func TestRaftSSTableSideloadingSnapshot(t *testing.T) {
 			if withSS {
 				ss = tc.repl.raftMu.sideloaded
 			}
-			rsl := makeReplicaStateLoader(tc.store.ClusterSettings(), tc.repl.RangeID)
+			rsl := MakeStateLoader(tc.store.ClusterSettings(), tc.repl.RangeID)
 			entries, err := entries(
 				ctx, rsl, tc.store.Engine(), tc.repl.RangeID, tc.store.raftEntryCache,
 				ss, sideloadedIndex, sideloadedIndex+1, 1<<20,

--- a/pkg/storage/replica_state_test.go
+++ b/pkg/storage/replica_state_test.go
@@ -58,20 +58,20 @@ func TestSynthesizeHardState(t *testing.T) {
 		func() {
 			batch := eng.NewBatch()
 			defer batch.Close()
-			rsl := makeReplicaStateLoader(cluster.MakeTestingClusterSettings(), 1)
+			rsl := MakeStateLoader(cluster.MakeTestingClusterSettings(), 1)
 
 			if test.OldHS != nil {
-				if err := rsl.setHardState(context.Background(), batch, *test.OldHS); err != nil {
+				if err := rsl.SetHardState(context.Background(), batch, *test.OldHS); err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			oldHS, err := rsl.loadHardState(context.Background(), batch)
+			oldHS, err := rsl.LoadHardState(context.Background(), batch)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			err = rsl.synthesizeHardState(
+			err = rsl.SynthesizeHardState(
 				context.Background(), batch, oldHS, roachpb.RaftTruncatedState{Term: test.TruncTerm}, test.RaftAppliedIndex,
 			)
 			if !testutils.IsError(err, test.Err) {
@@ -81,7 +81,7 @@ func TestSynthesizeHardState(t *testing.T) {
 				return
 			}
 
-			hs, err := rsl.loadHardState(context.Background(), batch)
+			hs, err := rsl.LoadHardState(context.Background(), batch)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -6107,7 +6107,7 @@ func TestReplicaCorruption(t *testing.T) {
 	}
 
 	// Verify destroyed error was persisted.
-	pErr, err = r.mu.stateLoader.loadReplicaDestroyedError(context.Background(), r.store.Engine())
+	pErr, err = r.mu.stateLoader.LoadReplicaDestroyedError(context.Background(), r.store.Engine())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1838,8 +1838,8 @@ func splitPostApply(
 		// committed the split Batch (which included the initialization of the
 		// ReplicaState). This will synthesize and persist the correct lastIndex and
 		// HardState.
-		rsl := makeReplicaStateLoader(r.store.cfg.Settings, split.RightDesc.RangeID)
-		if err := rsl.synthesizeRaftState(ctx, r.store.Engine()); err != nil {
+		rsl := MakeStateLoader(r.store.cfg.Settings, split.RightDesc.RangeID)
+		if err := rsl.SynthesizeRaftState(ctx, r.store.Engine()); err != nil {
 			log.Fatal(ctx, err)
 		}
 	}
@@ -3173,7 +3173,7 @@ func (s *Store) processRaftSnapshotRequest(
 			needTombstone := r.mu.state.Desc.NextReplicaID != 0
 			r.mu.Unlock()
 
-			appliedIndex, _, err := r.raftMu.stateLoader.loadAppliedIndex(ctx, r.store.Engine())
+			appliedIndex, _, err := r.raftMu.stateLoader.LoadAppliedIndex(ctx, r.store.Engine())
 			if err != nil {
 				return roachpb.NewError(err)
 			}

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2044,7 +2044,7 @@ func TestStoreGCThreshold(t *testing.T) {
 		}
 		repl.mu.Lock()
 		gcThreshold := *repl.mu.state.GCThreshold
-		pgcThreshold, err := repl.mu.stateLoader.loadGCThreshold(context.Background(), store.Engine())
+		pgcThreshold, err := repl.mu.stateLoader.LoadGCThreshold(context.Background(), store.Engine())
 		repl.mu.Unlock()
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/storage/track_raft_protos.go
+++ b/pkg/storage/track_raft_protos.go
@@ -45,7 +45,7 @@ func TrackRaftProtos() func() []reflect.Type {
 		funcName((*gossip.Gossip).AddInfoProto),
 		// Replica destroyed errors are written to disk, but they are
 		// deliberately per-replica values.
-		funcName((replicaStateLoader).setReplicaDestroyedError),
+		funcName((StateLoader).SetReplicaDestroyedError),
 	}
 
 	belowRaftProtos := struct {


### PR DESCRIPTION
This is one of the self-contained threads to unravel for #18784.

The resulting code allows the `StateLoader` struct to be moved into
its own package (but since moves rot quickly, I'm going to merge this
first and then execute the move separately).