### PR TITLE
cherry-pick 1.1: sql: fix repeated escapes in array parsing

### DIFF
--- a/pkg/sql/parser/parse_array.go
+++ b/pkg/sql/parser/parse_array.go
@@ -47,9 +47,8 @@ var isElementChar = func(r rune) bool {
 func (p *parseState) gobbleString(isTerminatingChar func(ch byte) bool) (out string, err error) {
 	var result bytes.Buffer
 	start := 0
-	i := -1
-	for i < len(p.s) && (i < 0 || !isTerminatingChar(p.s[i])) {
-		i++
+	i := 0
+	for i < len(p.s) && !isTerminatingChar(p.s[i]) {
 		// In these strings, we just encode directly the character following a
 		// '\', even if it would normally be an escape sequence.
 		if i < len(p.s) && p.s[i] == '\\' {
@@ -60,6 +59,8 @@ func (p *parseState) gobbleString(isTerminatingChar func(ch byte) bool) (out str
 				i++
 			}
 			start = i
+		} else {
+			i++
 		}
 	}
 	if i >= len(p.s) {

--- a/pkg/sql/parser/parse_array_test.go
+++ b/pkg/sql/parser/parse_array_test.go
@@ -14,7 +14,11 @@
 
 package parser
 
-import "testing"
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
 
 func TestParseArray(t *testing.T) {
 	testData := []struct {
@@ -34,28 +38,39 @@ func TestParseArray(t *testing.T) {
 		{` { "1" , 2}`, intColTypeInt, Datums{NewDInt(1), NewDInt(2)}},
 		{`{1,NULL}`, intColTypeInt, Datums{NewDInt(1), DNull}},
 
-		{`{hello}`, stringColTypeString, Datums{NewDString("hello")}},
+		{`{hello}`, stringColTypeString, Datums{NewDString(`hello`)}},
 		{`{hel
-lo}`, stringColTypeString, Datums{NewDString("hel\nlo")}},
+lo}`, stringColTypeString, Datums{NewDString(`hel
+lo`)}},
 		{`{hel,
-lo}`, stringColTypeString, Datums{NewDString("hel"), NewDString("lo")}},
-		{`{hel,lo}`, stringColTypeString, Datums{NewDString("hel"), NewDString("lo")}},
-		{`{  he llo  }`, stringColTypeString, Datums{NewDString("he llo")}},
-		{"{hello,\u1680world}", stringColTypeString, Datums{NewDString("hello"), NewDString("world")}},
-		{`{hell\\o}`, stringColTypeString, Datums{NewDString("hell\\o")}},
-		{`{"hell\\o"}`, stringColTypeString, Datums{NewDString("hell\\o")}},
-		{`{NULL,"NULL"}`, stringColTypeString, Datums{DNull, NewDString("NULL")}},
-		{`{"hello"}`, stringColTypeString, Datums{NewDString("hello")}},
-		{`{" hello "}`, stringColTypeString, Datums{NewDString(" hello ")}},
-		{`{"hel,lo"}`, stringColTypeString, Datums{NewDString("hel,lo")}},
-		{`{"hel\"lo"}`, stringColTypeString, Datums{NewDString("hel\"lo")}},
-		{`{"h\"el\"lo"}`, stringColTypeString, Datums{NewDString("h\"el\"lo")}},
-		{`{"\"hello"}`, stringColTypeString, Datums{NewDString("\"hello")}},
-		{`{"hel\nlo"}`, stringColTypeString, Datums{NewDString("helnlo")}},
-		{`{"hel\\lo"}`, stringColTypeString, Datums{NewDString("hel\\lo")}},
-		{`{"he\,l\}l\{o"}`, stringColTypeString, Datums{NewDString("he,l}l{o")}},
+lo}`, stringColTypeString, Datums{NewDString(`hel`), NewDString(`lo`)}},
+		{`{hel,lo}`, stringColTypeString, Datums{NewDString(`hel`), NewDString(`lo`)}},
+		{`{  he llo  }`, stringColTypeString, Datums{NewDString(`he llo`)}},
+		{"{hello,\u1680world}", stringColTypeString, Datums{NewDString(`hello`), NewDString(`world`)}},
+		{`{hell\\o}`, stringColTypeString, Datums{NewDString(`hell\o`)}},
+		{`{"hell\\o"}`, stringColTypeString, Datums{NewDString(`hell\o`)}},
+		{`{NULL,"NULL"}`, stringColTypeString, Datums{DNull, NewDString(`NULL`)}},
+		{`{"hello"}`, stringColTypeString, Datums{NewDString(`hello`)}},
+		{`{" hello "}`, stringColTypeString, Datums{NewDString(` hello `)}},
+		{`{"hel,lo"}`, stringColTypeString, Datums{NewDString(`hel,lo`)}},
+		{`{"hel\"lo"}`, stringColTypeString, Datums{NewDString(`hel"lo`)}},
+		{`{"h\"el\"lo"}`, stringColTypeString, Datums{NewDString(`h"el"lo`)}},
+		{`{"\"hello"}`, stringColTypeString, Datums{NewDString(`"hello`)}},
+		{`{"hello\""}`, stringColTypeString, Datums{NewDString(`hello"`)}},
+		{`{"hel\nlo"}`, stringColTypeString, Datums{NewDString(`helnlo`)}},
+		{`{"hel\\lo"}`, stringColTypeString, Datums{NewDString(`hel\lo`)}},
+		{`{"hel\\\"lo"}`, stringColTypeString, Datums{NewDString(`hel\"lo`)}},
+		{`{"hel\\\\lo"}`, stringColTypeString, Datums{NewDString(`hel\\lo`)}},
+		{`{"hel\\\\\\lo"}`, stringColTypeString, Datums{NewDString(`hel\\\lo`)}},
+		{`{"\\"}`, stringColTypeString, Datums{NewDString(`\`)}},
+		{`{"\\\\"}`, stringColTypeString, Datums{NewDString(`\\`)}},
+		{`{"\\\\\\"}`, stringColTypeString, Datums{NewDString(`\\\`)}},
+		{`{"he\,l\}l\{o"}`, stringColTypeString, Datums{NewDString(`he,l}l{o`)}},
+		// There is no way to input non-printing characters (without having used an escape string previously).
+		{`{\\x07}`, stringColTypeString, Datums{NewDString(`\x07`)}},
+		{`{\x07}`, stringColTypeString, Datums{NewDString(`x07`)}},
 
-		{`{日本語}`, stringColTypeString, Datums{NewDString("日本語")}},
+		{`{日本語}`, stringColTypeString, Datums{NewDString(`日本語`)}},
 
 		// This can generate some strings with invalid UTF-8, but this isn't a
 		// problem, since the input would have had to be invalid UTF-8 for that to
@@ -82,27 +97,78 @@ lo}`, stringColTypeString, Datums{NewDString("hel"), NewDString("lo")}},
 	}
 }
 
+const randomArrayIterations = 10000
+const randomArrayMaxLength = 10
+const randomStringMaxLength = 1000
+
+func TestParseArrayRandomParseArray(t *testing.T) {
+	for i := 0; i < randomArrayIterations; i++ {
+		numElems := rand.Intn(randomArrayMaxLength)
+		ary := make([][]byte, numElems)
+		for aryIdx := range ary {
+			len := rand.Intn(randomStringMaxLength)
+			str := make([]byte, len)
+			for strIdx := 0; strIdx < len; strIdx++ {
+				str[strIdx] = byte(rand.Intn(256))
+			}
+			ary[aryIdx] = str
+		}
+
+		var buf bytes.Buffer
+		buf.WriteByte('{')
+		for j, b := range ary {
+			if j > 0 {
+				buf.WriteByte(',')
+			}
+			buf.WriteByte('"')
+			// The input format for this doesn't support regular escaping, any
+			// character can be preceded by a backslash to encode it directly (this
+			// means that there's no printable way to encode non-printing characters,
+			// users must use `e` prefixed strings).
+			for _, c := range b {
+				if c == '"' || c == '\\' || rand.Intn(10) == 0 {
+					buf.WriteByte('\\')
+				}
+				buf.WriteByte(c)
+			}
+			buf.WriteByte('"')
+		}
+		buf.WriteByte('}')
+
+		parsed, err := ParseDArrayFromString(NewTestingEvalContext(), buf.String(), stringColTypeString)
+		if err != nil {
+			t.Fatalf(`got error: "%s" for elem "%s"`, err, buf.String())
+		}
+		for aryIdx := range ary {
+			value := MustBeDString(parsed.Array[aryIdx])
+			if string(value) != string(ary[aryIdx]) {
+				t.Fatalf(`iteration %d: array "%s", got %#v, expected %#v`, i, buf.String(), value, string(ary[aryIdx]))
+			}
+		}
+	}
+}
+
 func TestParseArrayError(t *testing.T) {
 	testData := []struct {
 		str           string
 		typ           ColumnType
 		expectedError string
 	}{
-		{"", intColTypeInt, "array must be enclosed in { and }"},
-		{"1", intColTypeInt, "array must be enclosed in { and }"},
-		{"1,2", intColTypeInt, "array must be enclosed in { and }"},
-		{"{1,2", intColTypeInt, "malformed array"},
-		{"{1,2,", intColTypeInt, "malformed array"},
-		{"{", intColTypeInt, "malformed array"},
-		{"{,}", intColTypeInt, "malformed array"},
-		{"{}{}", intColTypeInt, "extra text after closing right brace"},
-		{"{} {}", intColTypeInt, "extra text after closing right brace"},
-		{"{{}}", intColTypeInt, "nested arrays not supported"},
-		{"{1, {1}}", intColTypeInt, "nested arrays not supported"},
-		{"{hello}", intColTypeInt, `could not parse "hello" as type int: strconv.ParseInt: parsing "hello": invalid syntax`},
-		{"{\"hello}", stringColTypeString, `malformed array`},
+		{``, intColTypeInt, "array must be enclosed in { and }"},
+		{`1`, intColTypeInt, "array must be enclosed in { and }"},
+		{`1,2`, intColTypeInt, "array must be enclosed in { and }"},
+		{`{1,2`, intColTypeInt, "malformed array"},
+		{`{1,2,`, intColTypeInt, "malformed array"},
+		{`{`, intColTypeInt, "malformed array"},
+		{`{,}`, intColTypeInt, "malformed array"},
+		{`{}{}`, intColTypeInt, "extra text after closing right brace"},
+		{`{} {}`, intColTypeInt, "extra text after closing right brace"},
+		{`{{}}`, intColTypeInt, "nested arrays not supported"},
+		{`{1, {1}}`, intColTypeInt, "nested arrays not supported"},
+		{`{hello}`, intColTypeInt, `could not parse "hello" as type int: strconv.ParseInt: parsing "hello": invalid syntax`},
+		{`{"hello}`, stringColTypeString, `malformed array`},
 		// It might be unnecessary to disallow this, but Postgres does.
-		{"{he\"lo}", stringColTypeString, "malformed array"},
+		{`{he"lo}`, stringColTypeString, "malformed array"},
 
 		{string([]byte{200}), stringColTypeString, "array must be enclosed in { and }"},
 		{string([]byte{'{', 'a', 200}), stringColTypeString, "malformed array"},


### PR DESCRIPTION
Previously, we wouldn't parse properly arrays containing strings with
multiple escapes in a row. This commit fixes that.

Also added a random generator, which catches the errors we had before.

Going to cherry-pick for 1.1.2.