### PR TITLE
ui: refactor updateLinkedGuidelines to put hover state in the store

### DIFF
--- a/pkg/ui/src/redux/hover.ts
+++ b/pkg/ui/src/redux/hover.ts
@@ -1,0 +1,63 @@
+/**
+ * Monitors the currently hovered chart and point in time.
+ */
+
+import moment from "moment";
+import { Action } from "redux";
+
+import { PayloadAction } from "src/interfaces/action";
+import { AdminUIState } from "src/redux/state";
+
+export const HOVER_ON = "cockroachui/hover/HOVER_ON";
+export const HOVER_OFF = "cockroachui/hover/HOVER_OFF";
+
+/**
+ * HoverInfo is conveys the current hover position to the state.
+ */
+export interface HoverInfo {
+  hoverChart: string;
+  hoverTime: moment.Moment;
+}
+
+export class HoverState {
+  // Are we currently hovering over a chart?
+  currentlyHovering = false;
+  // Which chart are we hovering over?
+  hoverChart: string;
+  // What point in time are we hovering over?
+  hoverTime: moment.Moment;
+}
+
+export function hoverReducer(state = new HoverState(), action: Action): HoverState {
+  switch (action.type) {
+    case HOVER_ON:
+      const { payload: hi } = action as PayloadAction<HoverInfo>;
+      return {
+        currentlyHovering: true,
+        hoverChart: hi.hoverChart,
+        hoverTime: hi.hoverTime,
+      };
+    case HOVER_OFF:
+      return new HoverState();
+    default:
+      return state;
+  }
+}
+
+export function hoverOn(hi: HoverInfo): PayloadAction<HoverInfo> {
+  return {
+    type: HOVER_ON,
+    payload: hi,
+  };
+}
+
+export function hoverOff(): Action {
+  return {
+    type: HOVER_OFF,
+  };
+}
+
+/**
+ * Are we currently hovering, and if so, which chart and when?
+ */
+export const hoverStateSelector = (state: AdminUIState) => state.hover;

--- a/pkg/ui/src/redux/state.ts
+++ b/pkg/ui/src/redux/state.ts
@@ -6,6 +6,7 @@ import createSagaMiddleware from "redux-saga";
 import thunk from "redux-thunk";
 
 import { apiReducersReducer, APIReducersState } from "./apiReducers";
+import { hoverReducer, HoverState } from "./hover";
 import { localSettingsReducer, LocalSettingsState } from "./localsettings";
 import { metricsReducer, MetricsState, queryMetricsSaga } from "./metrics";
 import { queryManagerReducer, QueryManagerState } from "./queryManager/reducer";
@@ -14,6 +15,7 @@ import { uiDataReducer, UIDataState } from "./uiData";
 
 export interface AdminUIState {
     cachedData: APIReducersState;
+    hover: HoverState;
     localSettings: LocalSettingsState;
     metrics: MetricsState;
     queryManager: QueryManagerState;
@@ -30,6 +32,7 @@ export function createAdminUIStore() {
   const store = createStore(
     combineReducers<AdminUIState>({
       cachedData: apiReducersReducer,
+      hover: hoverReducer,
       localSettings: localSettingsReducer,
       metrics: metricsReducer,
       queryManager: queryManagerReducer,

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -16,6 +16,7 @@ import ClusterSummaryBar from "./summaryBar";
 
 import { AdminUIState } from "src/redux/state";
 import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
+import { hoverStateSelector, HoverState, hoverOn, hoverOff } from "src/redux/hover";
 import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
 import Alerts from "src/views/shared/containers/alerts";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
@@ -62,9 +63,12 @@ const dashboardDropdownOptions = _.map(dashboards, (dashboard, key) => {
 interface NodeGraphsOwnProps {
   refreshNodes: typeof refreshNodes;
   refreshLiveness: typeof refreshLiveness;
+  hoverOn: typeof hoverOn;
+  hoverOff: typeof hoverOff;
   nodesQueryValid: boolean;
   livenessQueryValid: boolean;
   nodesSummary: NodesSummary;
+  hoverState: HoverState;
 }
 
 type NodeGraphsProps = NodeGraphsOwnProps & RouterState;
@@ -137,7 +141,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
   }
 
   render() {
-    const { params, nodesSummary } = this.props;
+    const { params, nodesSummary, hoverState, hoverOn, hoverOff } = this.props;
     const selectedDashboard = params[dashboardNameAttr];
     const dashboard = _.has(dashboards, selectedDashboard)
       ? selectedDashboard
@@ -180,7 +184,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
       return (
         <div key={key}>
           <MetricsDataProvider id={key}>
-            {graph}
+            { React.cloneElement(graph, { hoverOn, hoverOff, hoverState }) }
           </MetricsDataProvider>
         </div>
       );
@@ -229,10 +233,13 @@ export default connect(
       nodesSummary: nodesSummarySelector(state),
       nodesQueryValid: state.cachedData.nodes.valid,
       livenessQueryValid: state.cachedData.nodes.valid,
+      hoverState: hoverStateSelector(state),
     };
   },
   {
     refreshNodes,
     refreshLiveness,
+    hoverOn,
+    hoverOff,
   },
 )(NodeGraphs);

--- a/pkg/ui/src/views/devtools/containers/raftMessages/index.tsx
+++ b/pkg/ui/src/views/devtools/containers/raftMessages/index.tsx
@@ -6,6 +6,7 @@ import { InjectedRouter, RouterState } from "react-router";
 import { createSelector } from "reselect";
 
 import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
+import { hoverStateSelector, HoverState, hoverOn, hoverOff } from "src/redux/hover";
 import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import { nodeIDAttr } from "src/util/constants";
@@ -23,9 +24,12 @@ import messagesDashboard from "./messages";
 interface NodeGraphsOwnProps {
   refreshNodes: typeof refreshNodes;
   refreshLiveness: typeof refreshLiveness;
+  hoverOn: typeof hoverOn;
+  hoverOff: typeof hoverOff;
   nodesQueryValid: boolean;
   livenessQueryValid: boolean;
   nodesSummary: NodesSummary;
+  hoverState: HoverState;
 }
 
 type NodeGraphsProps = NodeGraphsOwnProps & RouterState;
@@ -94,7 +98,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
   }
 
   render() {
-    const { params, nodesSummary } = this.props;
+    const { params, nodesSummary, hoverState, hoverOn, hoverOff } = this.props;
 
     const selectedNode = params[nodeIDAttr] || "";
     const nodeSources = (selectedNode !== "") ? [selectedNode] : null;
@@ -133,7 +137,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
       return (
         <div key={key}>
           <MetricsDataProvider id={key}>
-            {graph}
+            { React.cloneElement(graph, { hoverOn, hoverOff, hoverState }) }
           </MetricsDataProvider>
         </div>
       );
@@ -169,10 +173,13 @@ function mapStateToProps(state: AdminUIState) {
     nodesSummary: nodesSummarySelector(state),
     nodesQueryValid: state.cachedData.nodes.valid,
     livenessQueryValid: state.cachedData.nodes.valid,
+    hoverState: hoverStateSelector(state),
   };
 }
 const actions = {
   refreshNodes,
   refreshLiveness,
+  hoverOn,
+  hoverOff,
 };
 export default connect(mapStateToProps, actions)(NodeGraphs);


### PR DESCRIPTION
Rather than imperatively updating the linked guidelines on mouse move,
keep the hover state in the Redux store and declaratively update the
linked guidelines when rendering charts.

This is a refactor to support the upcoming work replacing NVD3 with
vanilla D3 charting.