### PR TITLE
log: special-case Wrap(safe, "foo")

### DIFF
--- a/pkg/util/log/crash_reporting_test.go
+++ b/pkg/util/log/crash_reporting_test.go
@@ -50,6 +50,11 @@ func TestCrashReportingSafeError(t *testing.T) {
 			expType: "*runtime.TypeAssertionError", expErr: "interface conversion: interface is nil, not ",
 		},
 		{
+			// Same as last, but skipping through to the cause: panic(errors.Wrap(safeErr, "gibberish")).
+			format: "", rs: []interface{}{errors.Wrap(runtimeErr, "unseen")},
+			expType: "*runtime.TypeAssertionError", expErr: "interface conversion: interface is nil, not ",
+		},
+		{
 			// Special-casing switched off when format string present.
 			format: "%s", rs: []interface{}{runtimeErr},
 			expType: "*log.safeError", expErr: "?:0: %s | <*runtime.TypeAssertionError>: interface conversion: interface is nil, not ",


### PR DESCRIPTION
Extend the previous special case to allow reporting a wrapped
error verbatim if it is the only argument.

This should allow the changes in #19447 to *actually* report the wrapped
error including its type (before the string would be reported, but losing
the wrapped type).