### PR TITLE
storage: avoid unnecessary clock updates and access to clock mutex

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -135,7 +135,7 @@ func TestRejectFutureCommand(t *testing.T) {
 
 	// Once the accumulated offset reaches MaxOffset, commands will be rejected.
 	_, pErr := client.SendWrappedWith(context.Background(), rg1(mtc.stores[0]), roachpb.Header{Timestamp: ts1.Add(clock.MaxOffset().Nanoseconds()+1, 0)}, incArgs)
-	if !testutils.IsPError(pErr, "rejecting command with timestamp in the future") {
+	if !testutils.IsPError(pErr, "remote wall time is too far ahead") {
 		t.Fatalf("unexpected error %v", pErr)
 	}
 

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -973,7 +973,7 @@ func TestStoreSendWithClockOffset(t *testing.T) {
 	// Set args timestamp to exceed max offset.
 	reqTS := store.cfg.Clock.Now().Add(store.cfg.Clock.MaxOffset().Nanoseconds()+1, 0)
 	_, pErr := client.SendWrappedWith(context.Background(), store.testSender(), roachpb.Header{Timestamp: reqTS}, &args)
-	if !testutils.IsPError(pErr, "rejecting command with timestamp in the future") {
+	if !testutils.IsPError(pErr, "remote wall time is too far ahead") {
 		t.Errorf("unexpected error: %v", pErr)
 	}
 }


### PR DESCRIPTION
Because `Clock.Update` already has code in it to verify that the clock isn't
being updated to a time more recent than the current physical wall clock time
plus the max offset, add a new method, `Clock.UpdateAndCheckMaxOffset` to
combine the update and check into a single lock.

Also, in `Store.Send`, only update the clock in the event that the
`BatchResponse.Timestamp` has been forwarded from `BatchRequest.Timestamp`.

For single node requests generated via loadgen/kv and resent to
Store.Send, this improves performance by ~7.5%.