### PR TITLE
deps: constrain go-ole to master to fix Windows builds

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -298,10 +298,10 @@
   version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/go-ole/go-ole"
   packages = [".","oleutil"]
-  revision = "0e87ea779d9deb219633b828a023b32e1244dd57"
-  version = "v1.2.0"
+  revision = "2ecd927eaf828c4fc088fae349b28eed1480ff56"
 
 [[projects]]
   branch = "master"
@@ -809,6 +809,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "034ab7fa506a52f7a2062b0f3bfe1b8ff8a231ab399ea77fff073a95507e4d41"
+  inputs-digest = "edb05186c8fb63ca299ffbe69311bf1583f8be70607b26aa668827caf75c69c9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -106,3 +106,9 @@ ignored = [
 [[override]]
   name = "github.com/docker/distribution"
   branch = "master"
+
+# go-ole has not made a release in over two years, but go-sigar requires
+# features introduced in the last two years.
+[[override]]
+ name = "github.com/go-ole/go-ole"
+ branch = "master"


### PR DESCRIPTION
The last release of go-ole, v1.2, was two years ago. go-sigar, via
StackExchange/wmi, understandably depends on features added in the last
two years when compiling for Windows.

Fix the Windows build by forcing `dep` to vendor go-ole's master branch
instead of v1.2.