### PR TITLE
storage: create RangeMatchingPred function, use for tscache accesses

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -672,13 +672,24 @@ func EnsureSafeSplitKey(key roachpb.Key) (roachpb.Key, error) {
 	return key[:idx], nil
 }
 
-// Range returns a key range encompassing all the keys in the Batch.
+// Range returns a key range encompassing the key ranges of all requests in the
+// Batch.
 func Range(ba roachpb.BatchRequest) (roachpb.RSpan, error) {
+	return RangeMatchingPred(ba, nil)
+}
+
+// RangeMatchingPred returns a key range encompassing the key ranges of all
+// requests in the Batch that match the provided predicate. If no predicate
+// is provided, no filtering will be performed on the requests in the Batch.
+func RangeMatchingPred(
+	ba roachpb.BatchRequest, pred func(roachpb.Request) bool,
+) (roachpb.RSpan, error) {
 	from := roachpb.RKeyMax
 	to := roachpb.RKeyMin
 	for _, arg := range ba.Requests {
 		req := arg.GetInner()
-		if _, ok := req.(*roachpb.NoopRequest); ok {
+		_, noop := req.(*roachpb.NoopRequest)
+		if noop || (pred != nil && !pred(req)) {
 			continue
 		}
 		h := req.Header()

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8617,6 +8617,7 @@ func TestMakeTimestampCacheRequest(t *testing.T) {
 	b := roachpb.Key("b")
 	c := roachpb.Key("c")
 	ac := roachpb.Span{Key: a, EndKey: c}
+	acR := roachpb.RSpan{Key: roachpb.RKey(a), EndKey: roachpb.RKey(c)}
 	testCases := []struct {
 		maxKeys  int64
 		req      roachpb.Request
@@ -8627,61 +8628,61 @@ func TestMakeTimestampCacheRequest(t *testing.T) {
 			0,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{},
-			&tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Span: acR, Reads: []roachpb.Span{ac}},
 		},
 		{
 			0,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			&tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Span: acR, Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{},
-			&tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Span: acR, Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			&tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Span: acR, Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ScanRequest{Span: ac},
 			&roachpb.ScanResponse{Rows: []roachpb.KeyValue{{Key: a}, {Key: b}}},
-			&tscache.Request{Reads: []roachpb.Span{{Key: a, EndKey: b.Next()}}},
+			&tscache.Request{Span: acR, Reads: []roachpb.Span{{Key: a, EndKey: b.Next()}}},
 		},
 		{
 			0,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{},
-			&tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Span: acR, Reads: []roachpb.Span{ac}},
 		},
 		{
 			0,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			&tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Span: acR, Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{},
-			&tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Span: acR, Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{Rows: []roachpb.KeyValue{{Key: a}}},
-			&tscache.Request{Reads: []roachpb.Span{ac}},
+			&tscache.Request{Span: acR, Reads: []roachpb.Span{ac}},
 		},
 		{
 			2,
 			&roachpb.ReverseScanRequest{Span: ac},
 			&roachpb.ReverseScanResponse{Rows: []roachpb.KeyValue{{Key: c}, {Key: b}}},
-			&tscache.Request{Reads: []roachpb.Span{{Key: b, EndKey: c}}},
+			&tscache.Request{Span: acR, Reads: []roachpb.Span{{Key: b, EndKey: c}}},
 		},
 	}
 	for _, c := range testCases {
@@ -8691,7 +8692,7 @@ func TestMakeTimestampCacheRequest(t *testing.T) {
 			ba.Header.MaxSpanRequestKeys = c.maxKeys
 			ba.Add(c.req)
 			br.Add(c.resp)
-			cr := makeTSCacheRequest(&ba, &br, roachpb.RSpan{})
+			cr := makeTSCacheRequest(&ba, &br)
 			if !reflect.DeepEqual(c.expected, cr) {
 				t.Fatalf("%s", pretty.Diff(c.expected, cr))
 			}


### PR DESCRIPTION
This change specializes the `keys.Range` functions that `Replica` uses
to determine the influence spans when adding and expanding
`tscache.Requests`. It restricts the `Range` function to
`roachpb.Requests` that update the `TimestampCache` when adding a
request and restricts the `Range` function to `roachpb.Requests` that
consult the `TimestampCache` for expanding requests. This means that
fewer unnecessary `tscache.Requests` will be expanded because unrelated
`roachpb.Requests` in a `BatchRequest` will no longer expand the
influence spans passed to the `tscache` methods.

This wasn't inspired by any particular workload, but it seemed like the
right thing to do. I also think the change makes purpose of the
`RSpan` passed to `AddRequest` and `ExpandRequests` more self-explanatory.