### PR TITLE
storage: make average diversity score for diversityRemovalScore

### DIFF
--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -321,7 +321,7 @@ func allocateCandidates(
 		if !maxCapacityCheck(s) {
 			continue
 		}
-		diversityScore := diversityScore(s, existingNodeLocalities)
+		diversityScore := diversityAllocateScore(s, existingNodeLocalities)
 		balanceScore := balanceScore(sl, s.Capacity, rangeInfo, options)
 		candidates = append(candidates, candidate{
 			store:           s,
@@ -519,7 +519,7 @@ func rebalanceCandidates(
 					s, rangeInfo, balanceScore, sl)
 				continue
 			}
-			diversityScore := rebalanceToDiversityScore(s, existingNodeLocalities)
+			diversityScore := diversityRebalanceScore(s, existingNodeLocalities)
 			candidates = append(candidates, candidate{
 				store:           s,
 				valid:           true,
@@ -697,63 +697,93 @@ func constraintCheck(store roachpb.StoreDescriptor, constraints config.Constrain
 	return true, positive
 }
 
-// diversityScore returns a score between 1 and 0 where higher scores are stores
-// with the fewest locality tiers in common with already existing replicas.
-func diversityScore(
+// diversityAllocateScore returns a value between 1 and 0. It is only used for allocateCandidates.
+// A much higher score just means the store may be a better fit for allocating target.
+func diversityAllocateScore(
 	store roachpb.StoreDescriptor, existingNodeLocalities map[roachpb.NodeID]roachpb.Locality,
 ) float64 {
-	minScore := roachpb.MaxDiversityScore
+	var sumScore float64
+	var numSamples int
+	// We don't need to calculate the overall diversityScore for the range, because the original overall diversityScore
+	// of this range is always the same.
 	for _, locality := range existingNodeLocalities {
-		if newScore := store.Node.Locality.DiversityScore(locality); newScore < minScore {
-			minScore = newScore
-		}
+		newScore := store.Node.Locality.DiversityScore(locality)
+		sumScore += newScore
+		numSamples++
 	}
-	return minScore
+	// When this range has no replica, it means any node will be a perfect fit for this range.
+	if numSamples == 0 {
+		return 1.0
+	}
+	return sumScore / float64(numSamples)
 }
 
-// diversityRemovalScore is the same as diversityScore, but for a node that's
-// already present in existingNodeLocalities. It works by calculating the
-// diversityScore for nodeID as if nodeID didn't already have a replica.
-// As with diversityScore, a higher score indicates that the node is a better
-// fit for the range (i.e. keeping it around is good for diversity).
+// diversityRemovalScore calculates the average diversityScore if we try to remove the replica from this node.
+// It will also return a value between 0 and 1. A higher score indicates that the node is a better fit for the range.
+// (i.e. keeping it around is good for diversity).
 func diversityRemovalScore(
 	nodeID roachpb.NodeID, existingNodeLocalities map[roachpb.NodeID]roachpb.Locality,
 ) float64 {
-	minScore := roachpb.MaxDiversityScore
+	var sumScore float64
+	var numSamples int
 	locality := existingNodeLocalities[nodeID]
+	// We don't need to calculate the overall diversityScore for the range, because the original overall diversityScore
+	// of this range is always the same.
 	for otherNodeID, otherLocality := range existingNodeLocalities {
 		if otherNodeID == nodeID {
 			continue
 		}
-		if newScore := otherLocality.DiversityScore(locality); newScore < minScore {
-			minScore = newScore
-		}
+		newScore := locality.DiversityScore(otherLocality)
+		sumScore += newScore
+		numSamples++
 	}
-	return minScore
+	if numSamples == 0 {
+		return 1.0
+	}
+	return sumScore / float64(numSamples)
 }
 
-// rebalanceToDiversityScore is like diversityScore, but it returns what
-// the diversity score would be if the given store was added and one of the
-// existing stores was removed. This is equivalent to the second lowest score.
-//
-// This is useful for considering rebalancing a range that already has enough
-// replicas - it's perfectly fine to add a replica in the same locality as an
-// existing replica in such cases.
-func rebalanceToDiversityScore(
+// diversityRebalanceScore calculates what range's average diversityScore would be
+// if we rebalance to the target store. We don't exactly know which replica being removed is better,
+// so we just choose each replica as the potential replica to be removed, and see the diversityScore
+// we can get for this range. It will also return a value between 1 and 0.
+// A much higher score means the rebalance target store is a better fit for the range.
+func diversityRebalanceScore(
 	store roachpb.StoreDescriptor, existingNodeLocalities map[roachpb.NodeID]roachpb.Locality,
 ) float64 {
-	minScore := roachpb.MaxDiversityScore
-	nextMinScore := roachpb.MaxDiversityScore
-	for _, locality := range existingNodeLocalities {
-		newScore := store.Node.Locality.DiversityScore(locality)
-		if newScore < minScore {
-			nextMinScore = minScore
-			minScore = newScore
-		} else if newScore < nextMinScore {
-			nextMinScore = newScore
+	var numSamples int
+	var maxDiversityScore float64
+	for nodeID := range existingNodeLocalities {
+		numSamples = 0
+		var sumScore float64
+		// Now, we choose nodeID as the replica we are going to remove and calculates the overall diversityScore
+		// if we rebalance to store.
+		for otherNodeID, otherLocality := range existingNodeLocalities {
+			if otherNodeID == nodeID {
+				continue
+			}
+			newScore := store.Node.Locality.DiversityScore(otherLocality)
+			sumScore += newScore
+			numSamples++
+			for anotherNodeID, anotherLocality := range existingNodeLocalities {
+				if anotherNodeID == otherNodeID || anotherNodeID == nodeID {
+					continue
+				}
+				newScore := otherLocality.DiversityScore(anotherLocality)
+				sumScore += newScore
+				numSamples++
+			}
+		}
+		if maxDiversityScore < sumScore {
+			maxDiversityScore = sumScore
 		}
 	}
-	return nextMinScore
+	// When this range has no replica, it means any node will be a perfect fit for this range.
+	// (it will never happen in the normal case).
+	if numSamples == 0 {
+		return 1.0
+	}
+	return maxDiversityScore / float64(numSamples)
 }
 
 type rangeCountStatus int

--- a/pkg/storage/allocator_scorer_test.go
+++ b/pkg/storage/allocator_scorer_test.go
@@ -29,6 +29,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
+type storeScore struct {
+	storeID roachpb.StoreID
+	score   float64
+}
+
+type storeScores []storeScore
+
+func (s storeScores) Len() int           { return len(s) }
+func (s storeScores) Less(i, j int) bool { return s[i].score < s[j].score }
+func (s storeScores) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
 func TestOnlyValid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -488,72 +499,60 @@ func TestConstraintCheck(t *testing.T) {
 	}
 }
 
-func TestDiversityScore(t *testing.T) {
+func TestAllocateDiversityScore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testCases := []struct {
 		name     string
-		existing []roachpb.NodeID
-		expected map[roachpb.StoreID]float64
+		stores   map[roachpb.StoreID]struct{}
+		expected []roachpb.StoreID
 	}{
 		{
-			name: "no existing replicas",
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     1,
-				testStoreUSa15Dupe: 1,
-				testStoreUSa1:      1,
-				testStoreUSb:       1,
-				testStoreEurope:    1,
-			},
+			name:     "no existing replicas",
+			expected: []roachpb.StoreID{testStoreUSa15, testStoreUSa15Dupe, testStoreUSa1, testStoreUSb, testStoreEurope},
 		},
 		{
-			name: "one existing replica",
-			existing: []roachpb.NodeID{
-				roachpb.NodeID(testStoreUSa15),
+			name: "one existing replicas",
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15: {},
 			},
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     0,
-				testStoreUSa15Dupe: 0,
-				testStoreUSa1:      1.0 / 4.0,
-				testStoreUSb:       1.0 / 2.0,
-				testStoreEurope:    1,
-			},
+			expected: []roachpb.StoreID{testStoreEurope, testStoreUSb, testStoreUSa1, testStoreUSa15Dupe},
 		},
 		{
 			name: "two existing replicas",
-			existing: []roachpb.NodeID{
-				roachpb.NodeID(testStoreUSa15),
-				roachpb.NodeID(testStoreEurope),
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15:  {},
+				testStoreEurope: {},
 			},
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     0,
-				testStoreUSa15Dupe: 0,
-				testStoreUSa1:      1.0 / 4.0,
-				testStoreUSb:       1.0 / 2.0,
-				testStoreEurope:    0,
-			},
+			expected: []roachpb.StoreID{testStoreUSb, testStoreUSa1, testStoreUSa15Dupe},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			existingNodeLocalities := make(map[roachpb.NodeID]roachpb.Locality)
-			for _, nodeID := range tc.existing {
-				for _, s := range testStores {
-					if s.Node.NodeID == nodeID {
-						existingNodeLocalities[s.Node.NodeID] = s.Node.Locality
-					}
+			for _, s := range testStores {
+				if _, ok := tc.stores[s.StoreID]; ok {
+					existingNodeLocalities[s.Node.NodeID] = s.Node.Locality
 				}
 			}
+			var scores storeScores
 			for _, s := range testStores {
-				actualScore := diversityScore(s, existingNodeLocalities)
-				expectedScore, ok := tc.expected[s.StoreID]
-				if !ok {
-					t.Fatalf("no expected score found for storeID %d", s.StoreID)
+				if _, ok := tc.stores[s.StoreID]; ok {
+					continue
 				}
-				if actualScore != expectedScore {
-					t.Errorf("store %d expected diversity score: %.2f, actual %.2f", s.StoreID, expectedScore, actualScore)
+				var score storeScore
+				actualScore := diversityAllocateScore(s, existingNodeLocalities)
+				score.storeID = s.StoreID
+				score.score = actualScore
+				scores = append(scores, score)
+			}
+			sort.Sort(sort.Reverse(scores))
+			for i := 0; i < len(scores); {
+				if scores[i].storeID != tc.expected[i] {
+					t.Fatalf("expected the result store order is %v, but got %v", tc.expected, scores)
 				}
+				i++
 			}
 		})
 	}
@@ -563,191 +562,169 @@ func TestRebalanceToDiversityScore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testCases := []struct {
-		name     string
-		existing []roachpb.NodeID
-		expected map[roachpb.StoreID]float64
+		name          string
+		stores        map[roachpb.StoreID]struct{}
+		removedTarget roachpb.StoreDescriptor
+		expected      []roachpb.StoreID
 	}{
 		{
-			name: "no existing replicas",
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     1,
-				testStoreUSa15Dupe: 1,
-				testStoreUSa1:      1,
-				testStoreUSb:       1,
-				testStoreEurope:    1,
-			},
+			name:     "no existing replicas",
+			expected: []roachpb.StoreID{testStoreUSa15, testStoreUSa15Dupe, testStoreUSa1, testStoreUSb, testStoreEurope},
 		},
 		{
 			name: "one existing replica",
-			existing: []roachpb.NodeID{
-				roachpb.NodeID(testStoreUSa15),
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15: {},
 			},
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     1,
-				testStoreUSa15Dupe: 1,
-				testStoreUSa1:      1,
-				testStoreUSb:       1,
-				testStoreEurope:    1,
-			},
+			removedTarget: testStores[int(testStoreUSa15)-1],
+			expected:      []roachpb.StoreID{testStoreUSa15Dupe, testStoreUSa1, testStoreUSb, testStoreEurope},
 		},
 		{
 			name: "two existing replicas",
-			existing: []roachpb.NodeID{
-				roachpb.NodeID(testStoreUSa15),
-				roachpb.NodeID(testStoreUSa1),
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15: {},
+				testStoreUSa1:  {},
 			},
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     1.0 / 4.0,
-				testStoreUSa15Dupe: 1.0 / 4.0,
-				testStoreUSa1:      1.0 / 4.0,
-				testStoreUSb:       1.0 / 2.0,
-				testStoreEurope:    1,
-			},
+			removedTarget: testStores[int(testStoreUSa15)-1],
+			expected:      []roachpb.StoreID{testStoreEurope, testStoreUSb, testStoreUSa15Dupe},
 		},
 		{
 			name: "three existing replicas",
-			existing: []roachpb.NodeID{
-				roachpb.NodeID(testStoreUSa15),
-				roachpb.NodeID(testStoreUSa1),
-				roachpb.NodeID(testStoreEurope),
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15:  {},
+				testStoreUSa1:   {},
+				testStoreEurope: {},
 			},
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     1.0 / 4.0,
-				testStoreUSa15Dupe: 1.0 / 4.0,
-				testStoreUSa1:      1.0 / 4.0,
-				testStoreUSb:       1.0 / 2.0,
-				testStoreEurope:    1.0,
-			},
+			removedTarget: testStores[int(testStoreUSa15)-1],
+			expected:      []roachpb.StoreID{testStoreUSb, testStoreUSa15Dupe},
 		},
 		{
 			name: "three existing replicas with duplicate",
-			existing: []roachpb.NodeID{
-				roachpb.NodeID(testStoreUSa15),
-				roachpb.NodeID(testStoreUSa15Dupe),
-				roachpb.NodeID(testStoreUSa1),
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15:     {},
+				testStoreUSa15Dupe: {},
+				testStoreUSa1:      {},
 			},
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     0,
-				testStoreUSa15Dupe: 0,
-				testStoreUSa1:      1.0 / 4.0,
-				testStoreUSb:       1.0 / 2.0,
-				testStoreEurope:    1.0,
-			},
+			removedTarget: testStores[int(testStoreUSa15)-1],
+			expected:      []roachpb.StoreID{testStoreEurope, testStoreUSb},
 		},
 		{
 			name: "four existing replicas",
-			existing: []roachpb.NodeID{
-				roachpb.NodeID(testStoreUSa15),
-				roachpb.NodeID(testStoreUSa1),
-				roachpb.NodeID(testStoreUSb),
-				roachpb.NodeID(testStoreEurope),
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15:  {},
+				testStoreUSa1:   {},
+				testStoreUSb:    {},
+				testStoreEurope: {},
 			},
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     1.0 / 4.0,
-				testStoreUSa15Dupe: 1.0 / 4.0,
-				testStoreUSa1:      1.0 / 4.0,
-				testStoreUSb:       1.0 / 2.0,
-				testStoreEurope:    1.0,
-			},
+			removedTarget: testStores[int(testStoreUSa15)-1],
+			expected:      []roachpb.StoreID{testStoreUSa15Dupe},
 		},
 		{
 			name: "four existing replicas with duplicate",
-			existing: []roachpb.NodeID{
-				roachpb.NodeID(testStoreUSa15),
-				roachpb.NodeID(testStoreUSa15Dupe),
-				roachpb.NodeID(testStoreUSa1),
-				roachpb.NodeID(testStoreUSb),
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15:     {},
+				testStoreUSa15Dupe: {},
+				testStoreUSa1:      {},
+				testStoreUSb:       {},
 			},
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     0,
-				testStoreUSa15Dupe: 0,
-				testStoreUSa1:      1.0 / 4.0,
-				testStoreUSb:       1.0 / 2.0,
-				testStoreEurope:    1.0,
-			},
+			removedTarget: testStores[int(testStoreUSa15)-1],
+			expected:      []roachpb.StoreID{testStoreEurope},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			existingNodeLocalities := make(map[roachpb.NodeID]roachpb.Locality)
-			for _, nodeID := range tc.existing {
-				for _, s := range testStores {
-					if s.Node.NodeID == nodeID {
-						existingNodeLocalities[s.Node.NodeID] = s.Node.Locality
-					}
+			for _, s := range testStores {
+				if _, ok := tc.stores[s.StoreID]; ok {
+					existingNodeLocalities[s.Node.NodeID] = s.Node.Locality
 				}
 			}
+			var scores storeScores
 			for _, s := range testStores {
-				actualScore := rebalanceToDiversityScore(s, existingNodeLocalities)
-				expectedScore, ok := tc.expected[s.StoreID]
-				if !ok {
-					t.Fatalf("no expected score found for storeID %d", s.StoreID)
+				if _, ok := tc.stores[s.StoreID]; ok {
+					continue
 				}
-				if actualScore != expectedScore {
-					t.Errorf("store %d expected diversity score: %.2f, actual %.2f", s.StoreID, expectedScore, actualScore)
+				var score storeScore
+				actualScore := diversityRebalanceScore(s, existingNodeLocalities)
+				score.storeID = s.StoreID
+				score.score = actualScore
+				scores = append(scores, score)
+			}
+			sort.Sort(sort.Reverse(scores))
+			for i := 0; i < len(scores); {
+				if scores[i].storeID != tc.expected[i] {
+					t.Fatalf("expected the result store order is %v, but got %v", tc.expected, scores)
 				}
+				i++
 			}
 		})
 	}
 }
 
-func TestDiversityRemovalScore(t *testing.T) {
+func TestRemovalDiversityScore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testCases := []struct {
 		name     string
-		expected map[roachpb.StoreID]float64
+		stores   map[roachpb.StoreID]struct{}
+		expected []roachpb.StoreID
 	}{
 		{
 			name: "four existing replicas",
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:  1.0 / 4.0,
-				testStoreUSa1:   1.0 / 4.0,
-				testStoreUSb:    1.0 / 2.0,
-				testStoreEurope: 1,
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15:  {},
+				testStoreUSa1:   {},
+				testStoreUSb:    {},
+				testStoreEurope: {},
 			},
+			expected: []roachpb.StoreID{testStoreEurope, testStoreUSb, testStoreUSa15, testStoreUSa1},
 		},
 		{
 			name: "four existing replicas with duplicate",
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:     0,
-				testStoreUSa15Dupe: 0,
-				testStoreUSb:       1.0 / 2.0,
-				testStoreEurope:    1,
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15:     {},
+				testStoreUSa15Dupe: {},
+				testStoreUSb:       {},
+				testStoreEurope:    {},
 			},
+			expected: []roachpb.StoreID{testStoreEurope, testStoreUSb, testStoreUSa15, testStoreUSa15Dupe},
 		},
 		{
 			name: "three existing replicas - excluding testStoreUSa15",
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa1:   1.0 / 2.0,
-				testStoreUSb:    1.0 / 2.0,
-				testStoreEurope: 1,
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa1:   {},
+				testStoreUSb:    {},
+				testStoreEurope: {},
 			},
+			expected: []roachpb.StoreID{testStoreEurope, testStoreUSa1, testStoreUSb},
 		},
 		{
 			name: "three existing replicas - excluding testStoreUSa1",
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:  1.0 / 2.0,
-				testStoreUSb:    1.0 / 2.0,
-				testStoreEurope: 1,
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15:  {},
+				testStoreUSb:    {},
+				testStoreEurope: {},
 			},
+			expected: []roachpb.StoreID{testStoreEurope, testStoreUSa15, testStoreUSb},
 		},
 		{
 			name: "three existing replicas - excluding testStoreUSb",
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15:  1.0 / 4.0,
-				testStoreUSa1:   1.0 / 4.0,
-				testStoreEurope: 1.0,
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15:  {},
+				testStoreUSa1:   {},
+				testStoreEurope: {},
 			},
+			expected: []roachpb.StoreID{testStoreEurope, testStoreUSa15, testStoreUSa1},
 		},
 		{
 			name: "three existing replicas - excluding testStoreEurope",
-			expected: map[roachpb.StoreID]float64{
-				testStoreUSa15: 1.0 / 4.0,
-				testStoreUSa1:  1.0 / 4.0,
-				testStoreUSb:   1.0 / 2.0,
+			stores: map[roachpb.StoreID]struct{}{
+				testStoreUSa15: {},
+				testStoreUSa1:  {},
+				testStoreUSb:   {},
 			},
+			expected: []roachpb.StoreID{testStoreUSb, testStoreUSa15, testStoreUSa1},
 		},
 	}
 
@@ -755,22 +732,31 @@ func TestDiversityRemovalScore(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			existingNodeLocalities := make(map[roachpb.NodeID]roachpb.Locality)
 			for _, s := range testStores {
-				if _, ok := tc.expected[s.StoreID]; ok {
+				if _, ok := tc.stores[s.StoreID]; ok {
 					existingNodeLocalities[s.Node.NodeID] = s.Node.Locality
 				}
 			}
+			var scores storeScores
 			for _, s := range testStores {
-				if _, ok := tc.expected[s.StoreID]; !ok {
+				if _, ok := tc.stores[s.StoreID]; !ok {
 					continue
 				}
+				var score storeScore
 				actualScore := diversityRemovalScore(s.Node.NodeID, existingNodeLocalities)
-				expectedScore, ok := tc.expected[s.StoreID]
+				_, ok := tc.stores[s.StoreID]
 				if !ok {
 					t.Fatalf("no expected score found for storeID %d", s.StoreID)
 				}
-				if actualScore != expectedScore {
-					t.Errorf("store %d expected diversity removal score: %.2f, actual %.2f", s.StoreID, expectedScore, actualScore)
+				score.storeID = s.StoreID
+				score.score = actualScore
+				scores = append(scores, score)
+			}
+			sort.Sort(sort.Reverse(scores))
+			for i := 0; i < len(scores); {
+				if scores[i].storeID != tc.expected[i] {
+					t.Fatalf("expected the result store order is %v, but got %v", tc.expected, scores)
 				}
+				i++
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #17479.

@a-robinson, I didn't use `diversityRemovalAverageScore` to replace `diversityRemovalScore` in `rebalanceCandidates`.

If I replace it, it will fail in the test `TestReplicateQueueRebalance`.