### PR TITLE
storage: Switch an occasionally spammy log.Infof to log.VEventf

### DIFF
--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -620,7 +620,7 @@ func shouldRebalanceNoStats(
 ) bool {
 	overfullThreshold := int32(math.Ceil(overfullRangeThreshold(st, sl.candidateRanges.mean)))
 	if store.Capacity.RangeCount > overfullThreshold {
-		log.Infof(ctx,
+		log.VEventf(ctx, 2,
 			"s%d: should-rebalance(ranges-overfull): rangeCount=%d, mean=%.2f, overfull-threshold=%d",
 			store.StoreID, store.Capacity.RangeCount, sl.candidateRanges.mean, overfullThreshold)
 		return true
@@ -630,7 +630,7 @@ func shouldRebalanceNoStats(
 		underfullThreshold := int32(math.Floor(underfullRangeThreshold(st, sl.candidateRanges.mean)))
 		for _, desc := range sl.stores {
 			if desc.Capacity.RangeCount < underfullThreshold {
-				log.Infof(ctx,
+				log.VEventf(ctx, 2,
 					"s%d: should-rebalance(better-fit-ranges=s%d): rangeCount=%d, otherRangeCount=%d, "+
 						"mean=%.2f, underfull-threshold=%d",
 					store.StoreID, desc.StoreID, store.Capacity.RangeCount, desc.Capacity.RangeCount,


### PR DESCRIPTION
These were never meant to be log.Infof -- I must have removed the
log.V(2) wrapper from around them and forgetten to switch them to
log.VEventf. This can create a bunch of log message when a cluster
becomes unbalanced, such as when a new node joins.

I'd like to see this cherry-picked back to 1.1 to avoid confusing people with log messages that are pretty unclear to anyone unfamiliar with our code, but would understand if you think it's too insignificant. cc @bdarnell 