### PR TITLE
server: rework Gossip bootstrap sequence

### DIFF
--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -93,7 +93,7 @@ func (at *allocatorTest) Run(ctx context.Context, t *testing.T) {
 	if err := at.f.Resize(at.StartNodes); err != nil {
 		t.Fatal(err)
 	}
-	if err := CheckGossip(ctx, at.f, longWaitTime, HasPeers(at.StartNodes)); err != nil {
+	if err := CheckGossip(ctx, at.f, waitTime, HasPeers(at.StartNodes)); err != nil {
 		t.Fatal(err)
 	}
 	at.f.Assert(ctx, t)
@@ -152,7 +152,7 @@ func (at *allocatorTest) Run(ctx context.Context, t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := CheckGossip(ctx, at.f, longWaitTime, HasPeers(at.EndNodes)); err != nil {
+	if err := CheckGossip(ctx, at.f, waitTime, HasPeers(at.EndNodes)); err != nil {
 		t.Fatal(err)
 	}
 	at.f.Assert(ctx, t)

--- a/pkg/acceptance/continuous_load_test.go
+++ b/pkg/acceptance/continuous_load_test.go
@@ -56,6 +56,8 @@ type continuousLoadTest struct {
 	Process string
 }
 
+const longWaitTime = 2 * time.Minute
+
 // queryCount returns the total SQL queries executed by the cluster.
 func (cl continuousLoadTest) queryCount(f *terrafarm.Farmer) (float64, error) {
 	var client http.Client

--- a/pkg/acceptance/gossip_peerings_test.go
+++ b/pkg/acceptance/gossip_peerings_test.go
@@ -15,7 +15,9 @@
 package acceptance
 
 import (
+	"io/ioutil"
 	"math/rand"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -24,12 +26,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/acceptance/localcluster"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
 )
 
-const longWaitTime = 2 * time.Minute
-const shortWaitTime = 20 * time.Second
+const waitTime = 2 * time.Minute
 
 func TestGossipPeerings(t *testing.T) {
 	s := log.Scope(t)
@@ -46,11 +49,6 @@ func testGossipPeeringsInner(
 	num := c.NumNodes()
 
 	deadline := timeutil.Now().Add(cfg.Duration)
-
-	waitTime := longWaitTime
-	if cfg.Duration < waitTime {
-		waitTime = shortWaitTime
-	}
 
 	for timeutil.Now().Before(deadline) {
 		if err := CheckGossip(ctx, c, waitTime, HasPeers(num)); err != nil {
@@ -91,11 +89,6 @@ func TestGossipRestart(t *testing.T) {
 	ctx := context.Background()
 	cfg := readConfigFromFlags()
 	RunLocal(t, func(t *testing.T) {
-		// TODO(tschottdorf): https://github.com/cockroachdb/cockroach/issues/18027.
-		// When that is addressed, use the standard runner again.
-		if len(cfg.Nodes) > 3 {
-			cfg.Nodes = cfg.Nodes[:3]
-		}
 		c := StartCluster(ctx, t, cfg)
 		defer c.AssertAndStop(ctx, t)
 
@@ -115,11 +108,6 @@ func testGossipRestartInner(
 	num := c.NumNodes()
 
 	deadline := timeutil.Now().Add(cfg.Duration)
-
-	waitTime := longWaitTime
-	if cfg.Duration < waitTime {
-		waitTime = shortWaitTime
-	}
 
 	for timeutil.Now().Before(deadline) {
 		log.Infof(ctx, "waiting for initial gossip connections")
@@ -156,37 +144,148 @@ func testGossipRestartInner(
 			t.FailNow()
 		}
 
-		log.Infof(ctx, "waiting for gossip to be connected")
-		if err := CheckGossip(ctx, c, waitTime, HasPeers(num)); err != nil {
-			t.Fatal(err)
-		}
-		if err := CheckGossip(ctx, c, waitTime, hasClusterID); err != nil {
-			t.Fatal(err)
-		}
-		if err := CheckGossip(ctx, c, waitTime, hasSentinel); err != nil {
-			t.Fatal(err)
-		}
+		testClusterConnectedAndFunctional(ctx, t, c)
+	}
+}
 
-		for i := 0; i < num; i++ {
-			db, err := c.NewClient(ctx, i)
-			if err != nil {
+func testClusterConnectedAndFunctional(ctx context.Context, t *testing.T, c cluster.Cluster) {
+	num := c.NumNodes()
+
+	log.Infof(ctx, "waiting for gossip to be connected")
+	if err := CheckGossip(ctx, c, waitTime, HasPeers(num)); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckGossip(ctx, c, waitTime, hasClusterID); err != nil {
+		t.Fatal(err)
+	}
+	if err := CheckGossip(ctx, c, waitTime, hasSentinel); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < num; i++ {
+		db, err := c.NewClient(ctx, i)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i == 0 {
+			if err := db.Del(ctx, "count"); err != nil {
 				t.Fatal(err)
 			}
-			if i == 0 {
-				if err := db.Del(ctx, "count"); err != nil {
-					t.Fatal(err)
-				}
-			}
-			var kv client.KeyValue
-			if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-				var err error
-				kv, err = txn.Inc(ctx, "count", 1)
-				return err
-			}); err != nil {
-				t.Fatal(err)
-			} else if v := kv.ValueInt(); v != int64(i+1) {
-				t.Fatalf("unexpected value %d for write #%d (expected %d)", v, i, i+1)
-			}
+		}
+		var kv client.KeyValue
+		if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+			var err error
+			kv, err = txn.Inc(ctx, "count", 1)
+			return err
+		}); err != nil {
+			t.Fatal(err)
+		} else if v := kv.ValueInt(); v != int64(i+1) {
+			t.Fatalf("unexpected value %d for write #%d (expected %d)", v, i, i+1)
 		}
 	}
+}
+
+// This test verifies that when the first node is restarted and has no valid
+// join flags or persisted Gossip bootstrap records (achieved through restarting
+// the other nodes and thus randomizing their ports), it will still be able to
+// accept incoming Gossip connections and manages to bootstrap that way.
+//
+// See https://github.com/cockroachdb/cockroach/issues/18027.
+func TestGossipRestartFirstNodeNeedsIncoming(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	ctx := context.Background()
+	cfg := readConfigFromFlags()
+	RunLocal(t, func(t *testing.T) {
+		c := StartCluster(ctx, t, cfg)
+		defer c.AssertAndStop(ctx, t)
+
+		testGossipRestartFirstNodeNeedsIncomingInner(ctx, t, c, cfg)
+	})
+}
+
+func testGossipRestartFirstNodeNeedsIncomingInner(
+	ctx context.Context, t *testing.T, c cluster.Cluster, cfg cluster.TestConfig,
+) {
+	num := c.NumNodes()
+
+	if err := c.Kill(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure the first node to repel all replicas.
+
+	lc := c.(*localcluster.LocalCluster)
+	lc.Nodes[0].Cfg.ExtraArgs = append(lc.Nodes[0].Cfg.ExtraArgs, "--attrs", "empty")
+
+	if err := c.Restart(ctx, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	const zoneCfg = "constraints: [-empty]"
+	zoneFile := filepath.Join(lc.Nodes[0].Cfg.DataDir, ".customzone")
+
+	if err := ioutil.WriteFile(zoneFile, []byte(zoneCfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := c.ExecCLI(ctx, 0, []string{"zone", "set", ".default", "-f", zoneFile}); err != nil {
+		t.Fatal(err)
+	}
+
+	db := makePGClient(t, c.PGUrl(ctx, 0))
+	defer db.Close()
+
+	testutils.SucceedsSoon(t, func() error {
+		const query = "SELECT COUNT(replicas) FROM crdb_internal.ranges WHERE ARRAY_POSITION(replicas, 1) IS NOT NULL"
+		var count int
+		if err := db.QueryRow(query).Scan(&count); err != nil {
+			t.Fatal(err)
+		}
+		if count > 0 {
+			err := errors.Errorf("first node still has %d replicas", count)
+			log.Info(ctx, err)
+			return err
+		}
+		return nil
+	})
+
+	log.Infof(ctx, "killing all nodes")
+	for i := 0; i < num; i++ {
+		if err := c.Kill(ctx, i); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	log.Infof(ctx, "restarting only first node so that it writes its advertised address")
+
+	// Note that at this point, the first node has no join flags and no useful
+	// persisted Gossip info (since all other nodes are down and they'll get new
+	// ports when they respawn).
+	chs := []<-chan error{lc.RestartAsync(ctx, 0)}
+
+	testutils.SucceedsSoon(t, func() error {
+		if lc.Nodes[0].AdvertiseAddr() != "" {
+			return nil
+		}
+		return errors.New("no advertised addr yet")
+	})
+
+	// The other nodes will be joined to the first node, so they can
+	// reach out to it (and in fact they will, since that's the only
+	// reachable peer they have -- their persisted info is outdated, too!)
+	log.Infof(ctx, "restarting the other nodes")
+	for i := 1; i < num; i++ {
+		chs = append(chs, lc.RestartAsync(ctx, i))
+	}
+
+	log.Infof(ctx, "waiting for healthy cluster")
+	for i, ch := range chs {
+		if err := <-ch; err != nil {
+			t.Errorf("error restarting node %d: %s", i, err)
+		}
+	}
+
+	testClusterConnectedAndFunctional(ctx, t, c)
 }

--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -41,20 +41,6 @@ func TestVersionUpgrade(t *testing.T) {
 }
 
 func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfig) {
-	// TODO(tschottdorf): this test is flaky when run with four (or more) nodes.
-	// I'm not 100% sure why, but the node started first may sometimes not be
-	// able to connect to Gossip. That node is special in that it gets started
-	// without join flags, but even though it is passed as a peer to all of the
-	// other nodes, either none of them bothers to actually use it, or the node
-	// does not profit from incoming connections sufficiently. For some reason,
-	// it works with three nodes (I've done dozens of iterations; with four nodes
-	// it usually craps out after only a handful).
-	//
-	// See https://github.com/cockroachdb/cockroach/issues/18027.
-	if len(cfg.Nodes) > 3 {
-		cfg.Nodes = cfg.Nodes[:3]
-	}
-
 	for i := range cfg.Nodes {
 		// Leave the field blank for all but the first node so that they use the
 		// version we're testing in this run.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,8 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/cockroachdb/cmux"
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -132,6 +134,8 @@ type Server struct {
 	engines            Engines
 	internalMemMetrics sql.MemoryMetrics
 	adminMemMetrics    sql.MemoryMetrics
+
+	serveNonGossip int32 // atomically updated
 }
 
 // NewServer creates a Server from a server.Context.
@@ -190,7 +194,24 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			log.Fatal(ctx, err)
 		}
 	}
-	s.grpc = rpc.NewServer(s.rpcContext)
+
+	{
+		var earlyRPCWhiteList = map[string]struct{}{
+			"/cockroach.rpc.Heartbeat/Ping":   {},
+			"/cockroach.gossip.Gossip/Gossip": {},
+		}
+		s.grpc = rpc.NewServerWithInterceptor(s.rpcContext, func(fullName string) error {
+			if atomic.LoadInt32(&s.serveNonGossip) != 0 {
+				return nil
+			}
+			if _, allowed := earlyRPCWhiteList[fullName]; !allowed {
+				return grpcstatus.Errorf(
+					codes.Unavailable, "node waiting for gossip network; %s not available", fullName,
+				)
+			}
+			return nil
+		})
+	}
 
 	s.gossip = gossip.New(
 		s.cfg.AmbientCtx,
@@ -597,7 +618,20 @@ func (s *singleListener) Addr() net.Addr {
 }
 
 // Start starts the server on the specified port, starts gossip and initializes
-// the node using the engines from the server's context.
+// the node using the engines from the server's context. This is complex since
+// it sets up the listeners and the associated port muxing, but especially since
+// it has to solve the "bootstrapping problem": nodes need to connect to Gossip
+// fairly early, but what drives Gossip connectivity are the first range
+// replicas in the kv store. This in turn suggests opening the Gossip server
+// early. However, naively doing so also serves most other services prematurely,
+// which exposes a large surface of potentially underinitialized services. This
+// is avoided with some additional complexity that can be summarized as follows:
+//
+// - before blocking trying to connect to the Gossip network, we already open
+//   the admin UI (so that its diagnostics are available)
+// - we also allow our Gossip and our connection health Ping service
+// - everything else returns Unavailable errors (which are retryable)
+// - once the node has started, unlock all RPCs.
 //
 // The passed context can be used to trace the server startup. The context
 // should represent the general startup operation.
@@ -784,31 +818,11 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}
 
-	pgCtx := s.pgServer.AmbientCtx.AnnotateCtx(context.Background())
-	s.stopper.RunWorker(pgCtx, func(pgCtx context.Context) {
-		select {
-		case <-serveSQL:
-		case <-s.stopper.ShouldQuiesce():
-			return
-		}
-		netutil.FatalIfUnexpected(httpServer.ServeWith(pgCtx, s.stopper, pgL, func(conn net.Conn) {
-			connCtx := log.WithLogTagStr(pgCtx, "client", conn.RemoteAddr().String())
-			setTCPKeepAlive(connCtx, conn)
-
-			if err := s.pgServer.ServeConn(connCtx, conn); err != nil && !netutil.IsClosedConnection(err) {
-				// Report the error on this connection's context, so that we
-				// know which remote client caused the error when looking at
-				// the logs.
-				log.Error(connCtx, err)
-			}
-		}))
-	})
-
-	// Enable the debug endpoints first to provide an earlier window
-	// into what's going on with the node in advance of exporting node
-	// functionality.
-	// TODO(marc): when cookie-based authentication exists,
-	// apply it for all web endpoints.
+	// Enable the debug endpoints first to provide an earlier window into what's
+	// going on with the node in advance of exporting node functionality.
+	//
+	// TODO(marc): when cookie-based authentication exists, apply it to all web
+	// endpoints.
 	s.mux.Handle(debugEndpoint, authorizedHandler(http.HandlerFunc(handleDebug)))
 
 	// Filter the gossip bootstrap resolvers based on the listen and
@@ -903,6 +917,13 @@ func (s *Server) Start(ctx context.Context) error {
 		atomic.StoreInt32(&initLActive, 0)
 	}
 
+	// This opens the main listener.
+	s.stopper.RunWorker(workersCtx, func(context.Context) {
+		serveOnMux.Do(func() {
+			netutil.FatalIfUnexpected(m.Serve())
+		})
+	})
+
 	// We ran this before, but might've bootstrapped in the meantime. This time
 	// we'll get the actual list of bootstrapped and empty engines.
 	bootstrappedEngines, emptyEngines, cv, err := inspectEngines(ctx, s.engines, s.cfg.Settings.Version.MinSupportedVersion, s.cfg.Settings.Version.ServerVersion)
@@ -922,154 +943,6 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 		log.Shout(context.Background(), log.Severity_WARNING,
 			msg)
 	}).Stop()
-
-	// Now that we have a monotonic HLC wrt previous incarnations of the process,
-	// init all the replicas. At this point *some* store has been bootstrapped or
-	// we're joining an existing cluster for the first time.
-	if err := s.node.start(
-		ctx,
-		unresolvedAdvertAddr,
-		bootstrappedEngines, emptyEngines,
-		s.cfg.NodeAttributes,
-		s.cfg.Locality,
-		cv,
-	); err != nil {
-		return err
-	}
-	log.Event(ctx, "started node")
-
-	s.refreshSettings()
-
-	raven.SetTagsContext(map[string]string{
-		"cluster":   s.ClusterID().String(),
-		"node":      s.NodeID().String(),
-		"server_id": fmt.Sprintf("%s-%s", s.ClusterID().Short(), s.NodeID()),
-	})
-
-	// We can now add the node registry.
-	s.recorder.AddNode(s.registry, s.node.Descriptor, s.node.startedAt, s.cfg.AdvertiseAddr, s.cfg.HTTPAddr)
-
-	// Begin recording runtime statistics.
-	s.startSampleEnvironment(s.cfg.MetricsSampleInterval)
-
-	// Begin recording time series data collected by the status monitor.
-	s.tsDB.PollSource(
-		s.cfg.AmbientCtx, s.recorder, s.cfg.MetricsSampleInterval, ts.Resolution10s, s.stopper,
-	)
-
-	// Begin recording status summaries.
-	s.node.startWriteSummaries(s.cfg.MetricsSampleInterval)
-
-	// Create and start the schema change manager only after a NodeID
-	// has been assigned.
-	var testingKnobs *sql.SchemaChangerTestingKnobs
-	if s.cfg.TestingKnobs.SQLSchemaChanger != nil {
-		testingKnobs = s.cfg.TestingKnobs.SQLSchemaChanger.(*sql.SchemaChangerTestingKnobs)
-	} else {
-		testingKnobs = new(sql.SchemaChangerTestingKnobs)
-	}
-	sql.NewSchemaChangeManager(
-		s.st,
-		testingKnobs,
-		*s.db,
-		s.node.Descriptor,
-		s.rpcContext,
-		s.distSQLServer,
-		s.distSender,
-		s.gossip,
-		s.leaseMgr,
-		s.clock,
-		s.jobRegistry,
-	).Start(s.stopper)
-
-	s.sqlExecutor.Start(ctx, &s.adminMemMetrics, s.node.Descriptor)
-	s.distSQLServer.Start()
-
-	log.Infof(ctx, "starting %s server at %s", s.cfg.HTTPRequestScheme(), unresolvedHTTPAddr)
-	log.Infof(ctx, "starting grpc/postgres server at %s", unresolvedListenAddr)
-	log.Infof(ctx, "advertising CockroachDB node at %s", unresolvedAdvertAddr)
-	s.stopper.RunWorker(workersCtx, func(context.Context) {
-		serveOnMux.Do(func() {
-			netutil.FatalIfUnexpected(m.Serve())
-		})
-	})
-
-	if len(s.cfg.SocketFile) != 0 {
-		log.Infof(ctx, "starting postgres server at unix:%s", s.cfg.SocketFile)
-
-		// Unix socket enabled: postgres protocol only.
-		unixLn, err := net.Listen("unix", s.cfg.SocketFile)
-		if err != nil {
-			return err
-		}
-
-		s.stopper.RunWorker(workersCtx, func(workersCtx context.Context) {
-			<-s.stopper.ShouldQuiesce()
-			if err := unixLn.Close(); err != nil {
-				log.Fatal(workersCtx, err)
-			}
-		})
-
-		pgCtx := s.pgServer.AmbientCtx.AnnotateCtx(context.Background())
-		s.stopper.RunWorker(pgCtx, func(pgCtx context.Context) {
-			select {
-			case <-serveSQL:
-			case <-s.stopper.ShouldQuiesce():
-				return
-			}
-			netutil.FatalIfUnexpected(httpServer.ServeWith(pgCtx, s.stopper, unixLn, func(conn net.Conn) {
-				connCtx := log.WithLogTagStr(pgCtx, "client", conn.RemoteAddr().String())
-				if err := s.pgServer.ServeConn(connCtx, conn); err != nil &&
-					!netutil.IsClosedConnection(err) {
-					// Report the error on this connection's context, so that we
-					// know which remote client caused the error when looking at
-					// the logs.
-					log.Error(connCtx, err)
-				}
-			}))
-		})
-	}
-
-	log.Event(ctx, "accepting connections")
-
-	// Begin the node liveness heartbeat. Add a callback which
-	// 1. records the local store "last up" timestamp for every store whenever the
-	//    liveness record is updated.
-	// 2. sets Draining if Decommissioning is set in the liveness record
-	decommissionSem := make(chan struct{}, 1)
-	s.nodeLiveness.StartHeartbeat(ctx, s.stopper, func(ctx context.Context) {
-		now := s.clock.Now()
-		if err := s.node.stores.VisitStores(func(s *storage.Store) error {
-			return s.WriteLastUpTimestamp(ctx, now)
-		}); err != nil {
-			log.Warning(ctx, errors.Wrap(err, "writing last up timestamp"))
-		}
-
-		if liveness, err := s.nodeLiveness.Self(); err != nil && err != storage.ErrNoLivenessRecord {
-			log.Warning(ctx, errors.Wrap(err, "retrieving own liveness record"))
-		} else if liveness != nil && liveness.Decommissioning && !liveness.Draining {
-			select {
-			case decommissionSem <- struct{}{}:
-				s.stopper.RunWorker(ctx, func(context.Context) {
-					defer func() {
-						<-decommissionSem
-					}()
-					if _, err := s.Drain(GracefulDrainModes); err != nil {
-						log.Warningf(ctx, "failed to set Draining when Decommissioning: %v", err)
-					}
-				})
-			default:
-				// Already have an active goroutine trying to drain; don't add a
-				// second one.
-			}
-		}
-	})
-
-	if err := s.jobRegistry.Start(
-		ctx, s.stopper, s.nodeLiveness, jobs.DefaultCancelInterval, jobs.DefaultAdoptInterval,
-	); err != nil {
-		return err
-	}
 
 	// Initialize grpc-gateway mux and context.
 	jsonpb := &protoutil.JSONPb{
@@ -1155,6 +1028,116 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	s.mux.Handle(statusVars, http.HandlerFunc(s.status.handleVars))
 	log.Event(ctx, "added http endpoints")
 
+	// Now that we have a monotonic HLC wrt previous incarnations of the process,
+	// init all the replicas. At this point *some* store has been bootstrapped or
+	// we're joining an existing cluster for the first time.
+	if err := s.node.start(
+		ctx,
+		unresolvedAdvertAddr,
+		bootstrappedEngines, emptyEngines,
+		s.cfg.NodeAttributes,
+		s.cfg.Locality,
+		cv,
+	); err != nil {
+		return err
+	}
+	log.Event(ctx, "started node")
+
+	s.refreshSettings()
+
+	raven.SetTagsContext(map[string]string{
+		"cluster":   s.ClusterID().String(),
+		"node":      s.NodeID().String(),
+		"server_id": fmt.Sprintf("%s-%s", s.ClusterID().Short(), s.NodeID()),
+	})
+
+	// We can now add the node registry.
+	s.recorder.AddNode(s.registry, s.node.Descriptor, s.node.startedAt, s.cfg.AdvertiseAddr, s.cfg.HTTPAddr)
+
+	// Begin recording runtime statistics.
+	s.startSampleEnvironment(s.cfg.MetricsSampleInterval)
+
+	// Begin recording time series data collected by the status monitor.
+	s.tsDB.PollSource(
+		s.cfg.AmbientCtx, s.recorder, s.cfg.MetricsSampleInterval, ts.Resolution10s, s.stopper,
+	)
+
+	// Begin recording status summaries.
+	s.node.startWriteSummaries(s.cfg.MetricsSampleInterval)
+
+	// Create and start the schema change manager only after a NodeID
+	// has been assigned.
+	var testingKnobs *sql.SchemaChangerTestingKnobs
+	if s.cfg.TestingKnobs.SQLSchemaChanger != nil {
+		testingKnobs = s.cfg.TestingKnobs.SQLSchemaChanger.(*sql.SchemaChangerTestingKnobs)
+	} else {
+		testingKnobs = new(sql.SchemaChangerTestingKnobs)
+	}
+
+	sql.NewSchemaChangeManager(
+		s.st,
+		testingKnobs,
+		*s.db,
+		s.node.Descriptor,
+		s.rpcContext,
+		s.distSQLServer,
+		s.distSender,
+		s.gossip,
+		s.leaseMgr,
+		s.clock,
+		s.jobRegistry,
+	).Start(s.stopper)
+
+	s.sqlExecutor.Start(ctx, &s.adminMemMetrics, s.node.Descriptor)
+	s.distSQLServer.Start()
+
+	atomic.StoreInt32(&s.serveNonGossip, 1)
+
+	log.Infof(ctx, "starting %s server at %s", s.cfg.HTTPRequestScheme(), unresolvedHTTPAddr)
+	log.Infof(ctx, "starting grpc/postgres server at %s", unresolvedListenAddr)
+	log.Infof(ctx, "advertising CockroachDB node at %s", unresolvedAdvertAddr)
+
+	log.Event(ctx, "accepting connections")
+
+	// Begin the node liveness heartbeat. Add a callback which
+	// 1. records the local store "last up" timestamp for every store whenever the
+	//    liveness record is updated.
+	// 2. sets Draining if Decommissioning is set in the liveness record
+	decommissionSem := make(chan struct{}, 1)
+	s.nodeLiveness.StartHeartbeat(ctx, s.stopper, func(ctx context.Context) {
+		now := s.clock.Now()
+		if err := s.node.stores.VisitStores(func(s *storage.Store) error {
+			return s.WriteLastUpTimestamp(ctx, now)
+		}); err != nil {
+			log.Warning(ctx, errors.Wrap(err, "writing last up timestamp"))
+		}
+
+		if liveness, err := s.nodeLiveness.Self(); err != nil && err != storage.ErrNoLivenessRecord {
+			log.Warning(ctx, errors.Wrap(err, "retrieving own liveness record"))
+		} else if liveness != nil && liveness.Decommissioning && !liveness.Draining {
+			select {
+			case decommissionSem <- struct{}{}:
+				s.stopper.RunWorker(ctx, func(context.Context) {
+					defer func() {
+						<-decommissionSem
+					}()
+					if _, err := s.Drain(GracefulDrainModes); err != nil {
+						log.Warningf(ctx, "failed to set Draining when Decommissioning: %v", err)
+					}
+				})
+			default:
+				// Already have an active goroutine trying to drain; don't add a
+				// second one.
+			}
+		}
+	})
+
+	if err := s.jobRegistry.Start(
+		ctx, s.stopper, s.nodeLiveness, jobs.DefaultCancelInterval, jobs.DefaultAdoptInterval,
+	); err != nil {
+		return err
+	}
+
 	// Before serving SQL requests, we have to make sure the database is
 	// in an acceptable form for this version of the software.
 	// We have to do this after actually starting up the server to be able to
@@ -1166,7 +1149,63 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	}
 	log.Infof(ctx, "done ensuring all necessary migrations have run")
 	close(serveSQL)
+
 	log.Info(ctx, "serving sql connections")
+	// Start servicing SQL connections.
+
+	pgCtx := s.pgServer.AmbientCtx.AnnotateCtx(context.Background())
+	s.stopper.RunWorker(pgCtx, func(pgCtx context.Context) {
+		select {
+		case <-serveSQL:
+		case <-s.stopper.ShouldQuiesce():
+			return
+		}
+		netutil.FatalIfUnexpected(httpServer.ServeWith(pgCtx, s.stopper, pgL, func(conn net.Conn) {
+			connCtx := log.WithLogTagStr(pgCtx, "client", conn.RemoteAddr().String())
+			setTCPKeepAlive(connCtx, conn)
+
+			if err := s.pgServer.ServeConn(connCtx, conn); err != nil && !netutil.IsClosedConnection(err) {
+				// Report the error on this connection's context, so that we
+				// know which remote client caused the error when looking at
+				// the logs.
+				log.Error(connCtx, err)
+			}
+		}))
+	})
+	if len(s.cfg.SocketFile) != 0 {
+		log.Infof(ctx, "starting postgres server at unix:%s", s.cfg.SocketFile)
+
+		// Unix socket enabled: postgres protocol only.
+		unixLn, err := net.Listen("unix", s.cfg.SocketFile)
+		if err != nil {
+			return err
+		}
+
+		s.stopper.RunWorker(workersCtx, func(workersCtx context.Context) {
+			<-s.stopper.ShouldQuiesce()
+			if err := unixLn.Close(); err != nil {
+				log.Fatal(workersCtx, err)
+			}
+		})
+
+		s.stopper.RunWorker(pgCtx, func(pgCtx context.Context) {
+			select {
+			case <-serveSQL:
+			case <-s.stopper.ShouldQuiesce():
+				return
+			}
+			netutil.FatalIfUnexpected(httpServer.ServeWith(pgCtx, s.stopper, unixLn, func(conn net.Conn) {
+				connCtx := log.WithLogTagStr(pgCtx, "client", conn.RemoteAddr().String())
+				if err := s.pgServer.ServeConn(connCtx, conn); err != nil &&
+					!netutil.IsClosedConnection(err) {
+					// Report the error on this connection's context, so that we
+					// know which remote client caused the error when looking at
+					// the logs.
+					log.Error(connCtx, err)
+				}
+			}))
+		})
+	}
 
 	// Record that this node joined the cluster in the event log. Since this
 	// executes a SQL query, this must be done after the SQL layer is ready.


### PR DESCRIPTION
This is a WIP because I want to add the script from #19427, which reproduces
this problem with 100% accuracy, as an acceptance test.

----

A long time ago, in #5441, we changed the server startup sequence so that we
would only open the main listener at the very end of the startup sequence. The
impetus was that by opening the listener early, various services could receive
requests when they weren't actually ready, which resulted in unexpected errors
during tests.

What we missed at the time was that this isn't actually a good idea because it
also robs the node of the ability to accept incoming Gossip connections. As a
result, if a node didn't manage to talk to Gossip peers (perhaps it was started
without a join flag and had nothing reasonable persisted), it would never get
its Gossip connected and would never leave `(*Node).start` which has to wait for
Gossip.

These deadlocks worsened the impact of some of our other insufficiently
streamlined aspects of the startup sequence, namely the choice of `--join`
flags, and were generally hard to debug especially since the HTTP endpoints, and
thus many debugging facilities, weren't available.

This commit reworks the sequence so that

- the HTTP endpoint opens early (so that the debug endpoints are accessible)
- opens the main cmux listener early
    - but delays opening the Postgres sublistener
    - but fails all non-Gossip and non-Ping gRPC traffic retryably

Fixes #18027.
Fixes #13027.