### PR TITLE
sql: Fix schema change event logging

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -59,6 +59,9 @@ const (
 	// EventLogFinishSchemaChange is recorded when a previously initiated schema
 	// change has completed.
 	EventLogFinishSchemaChange EventLogType = "finish_schema_change"
+	// EventLogFinishSchemaRollback is recorded when a previously
+	// initiated schema change rollback has completed.
+	EventLogFinishSchemaRollback EventLogType = "finish_schema_change_rollback"
 
 	// EventLogNodeJoin is recorded when a node joins the cluster.
 	EventLogNodeJoin EventLogType = "node_join"

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -122,11 +122,17 @@ SELECT "targetID", "reportingID" FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
 51 1
-51 1
 
 query II rowsort
 SELECT "targetID", "reportingID" FROM system.eventlog
 WHERE "eventType" = 'reverse_schema_change'
+----
+51 1
+
+
+query II rowsort
+SELECT "targetID", "reportingID" FROM system.eventlog
+WHERE "eventType" = 'finish_schema_change_rollback'
 ----
 51 1
 
@@ -149,7 +155,6 @@ WHERE "eventType" = 'finish_schema_change'
 ----
 51 1
 51 1
-51 1
 
 # Drop the index
 #################
@@ -168,7 +173,6 @@ query II rowsort
 SELECT "targetID", "reportingID" FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
-51 1
 51 1
 51 1
 51 1

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -441,7 +441,7 @@ func (sc *SchemaChanger) exec(
 	// but we're no longer responsible for taking care of that.
 
 	// Run through mutation state machine and backfill.
-	err = sc.runStateMachineAndBackfill(ctx, &lease, evalCtx)
+	err = sc.runStateMachineAndBackfill(ctx, &lease, evalCtx, false /* isRollback */)
 
 	// Purge the mutations if the application of the mutations failed due to
 	// a permanent error. All other errors are transient errors that are
@@ -473,7 +473,7 @@ func (sc *SchemaChanger) rollbackSchemaChange(
 
 	// After this point the schema change has been reversed and any retry
 	// of the schema change will act upon the reversed schema change.
-	if errPurge := sc.runStateMachineAndBackfill(ctx, lease, evalCtx); errPurge != nil {
+	if errPurge := sc.runStateMachineAndBackfill(ctx, lease, evalCtx, true /* isRollback */); errPurge != nil {
 		// Don't return this error because we do want the caller to know
 		// that an integrity constraint was violated with the original
 		// schema change. The reversed schema change will be
@@ -576,7 +576,7 @@ func (sc *SchemaChanger) waitToUpdateLeases(ctx context.Context, tableID sqlbase
 // It ensures that all nodes are on the current (pre-update) version of the
 // schema.
 // Returns the updated of the descriptor.
-func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.Descriptor, error) {
+func (sc *SchemaChanger) done(ctx context.Context, isRollback bool) (*sqlbase.Descriptor, error) {
 	return sc.leaseMgr.Publish(ctx, sc.tableID, func(desc *sqlbase.TableDescriptor) error {
 		i := 0
 		for _, mutation := range desc.Mutations {
@@ -607,15 +607,22 @@ func (sc *SchemaChanger) done(ctx context.Context) (*sqlbase.Descriptor, error) 
 	}, func(txn *client.Txn) error {
 		if err := sc.job.WithTxn(txn).Succeeded(ctx); err != nil {
 			log.Warningf(ctx, "schema change ignoring error while marking job %d as successful: %+v",
-				sc.job.ID(), err)
+				*sc.job.ID(), err)
 		}
-		// Log "Finish Schema Change" event. Only the table ID and mutation ID
-		// are logged; this can be correlated with the DDL statement that
-		// initiated the change using the mutation id.
+
+		schemaChangeEventType := EventLogFinishSchemaChange
+		if isRollback {
+			schemaChangeEventType = EventLogFinishSchemaRollback
+		}
+
+		// Log "Finish Schema Change" or "Finish Schema Change Rollback"
+		// event. Only the table ID and mutation ID are logged; this can
+		// be correlated with the DDL statement that initiated the change
+		// using the mutation id.
 		return MakeEventLogger(sc.leaseMgr).InsertEventRecord(
 			ctx,
 			txn,
-			EventLogFinishSchemaChange,
+			schemaChangeEventType,
 			int32(sc.tableID),
 			int32(sc.nodeID),
 			struct {
@@ -649,7 +656,10 @@ func (sc *SchemaChanger) notFirstInLine(ctx context.Context) (bool, error) {
 // runStateMachineAndBackfill runs the schema change state machine followed by
 // the backfill.
 func (sc *SchemaChanger) runStateMachineAndBackfill(
-	ctx context.Context, lease *sqlbase.TableDescriptor_SchemaChangeLease, evalCtx parser.EvalContext,
+	ctx context.Context,
+	lease *sqlbase.TableDescriptor_SchemaChangeLease,
+	evalCtx parser.EvalContext,
+	isRollback bool,
 ) error {
 	if fn := sc.testingKnobs.RunBeforePublishWriteAndDelete; fn != nil {
 		fn()
@@ -661,7 +671,7 @@ func (sc *SchemaChanger) runStateMachineAndBackfill(
 
 	if err := sc.job.Progressed(ctx, .1, jobs.Noop); err != nil {
 		log.Warningf(ctx, "failed to log progress on job %v after completing state machine: %v",
-			sc.job.ID(), err)
+			*sc.job.ID(), err)
 	}
 
 	// Run backfill(s).
@@ -670,7 +680,7 @@ func (sc *SchemaChanger) runStateMachineAndBackfill(
 	}
 
 	// Mark the mutations as completed.
-	_, err := sc.done(ctx)
+	_, err := sc.done(ctx, isRollback)
 	return err
 }
 

--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -29,6 +29,8 @@ export const DROP_VIEW = "drop_view";
 export const REVERSE_SCHEMA_CHANGE = "reverse_schema_change";
 // Recorded when a previously initiated schema change has completed.
 export const FINISH_SCHEMA_CHANGE = "finish_schema_change";
+// Recorded when a schema change rollback has completed.
+export const FINISH_SCHEMA_CHANGE_ROLLBACK = "finish_schema_change_rollback";
 // Recorded when a node joins the cluster.
 export const NODE_JOIN = "node_join";
 // Recorded when an existing node rejoins the cluster after being offline.
@@ -43,8 +45,11 @@ export const SET_CLUSTER_SETTING = "set_cluster_setting";
 // Node Event Types
 export const nodeEvents = [NODE_JOIN, NODE_RESTART, NODE_DECOMMISSIONED, NODE_RECOMMISSIONED];
 export const databaseEvents = [CREATE_DATABASE, DROP_DATABASE];
-export const tableEvents = [CREATE_TABLE, DROP_TABLE, ALTER_TABLE, CREATE_INDEX,
-  DROP_INDEX, CREATE_VIEW, DROP_VIEW, REVERSE_SCHEMA_CHANGE, FINISH_SCHEMA_CHANGE];
+export const tableEvents = [
+  CREATE_TABLE, DROP_TABLE, ALTER_TABLE, CREATE_INDEX,
+  DROP_INDEX, CREATE_VIEW, DROP_VIEW, REVERSE_SCHEMA_CHANGE, FINISH_SCHEMA_CHANGE,
+  FINISH_SCHEMA_CHANGE_ROLLBACK,
+];
 export const settingsEvents = [SET_CLUSTER_SETTING];
 export const allEvents = [...nodeEvents, ...databaseEvents, ...tableEvents, ...settingsEvents];
 

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -101,7 +101,10 @@ export function getEventInfo(e: Event$Properties): SimplifiedEvent {
       content = <span>Schema Change Reversed: Schema change with ID {info.MutationID} was reversed.</span>;
       break;
     case eventTypes.FINISH_SCHEMA_CHANGE:
-      content = <span>Schema Change Finished: Schema Change Completed: Schema change with ID {info.MutationID} was completed.</span>;
+      content = <span>Schema Change Completed: Schema change with ID {info.MutationID} was completed.</span>;
+      break;
+    case eventTypes.FINISH_SCHEMA_CHANGE_ROLLBACK:
+      content = <span>Schema Change Rollback Completed: Rollback of schema change with ID {info.MutationID} was completed.</span>;
       break;
     case eventTypes.NODE_JOIN:
       content = <span>Node Joined: Node {targetId} joined the cluster</span>;


### PR DESCRIPTION
Previously, the schema change completion message had repetition. Also a
new message for the completion of a schema change rollback has also
been added, as there was no event indicating when it completed.