### PR TITLE
sql,cli: support arrays in dump

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -59,11 +59,12 @@ func TestDumpRow(t *testing.T) {
 		e decimal,
 		u uuid,
 		ip inet,
+		ary string[],
 		tz timestamptz,
 		e1 decimal(2),
 		e2 decimal(2, 1),
 		s1 string(1),
-		FAMILY "primary" (i, f, d, t, n, o, u, ip, tz, e1, e2, s1, rowid),
+		FAMILY "primary" (i, f, d, t, n, o, u, ip, ary, tz, e1, e2, s1, rowid),
 		FAMILY fam_1_s (s),
 		FAMILY fam_2_b (b),
 		FAMILY fam_3_e (e)
@@ -78,6 +79,7 @@ func TestDumpRow(t *testing.T) {
 		1.2345,
 		'e9716c74-2638-443d-90ed-ffde7bea7d1d',
 		'192.168.0.1',
+		ARRAY['hello','world'],
 		'2016-01-25 10:10:10',
 		3.4,
 		4.5,
@@ -113,22 +115,23 @@ CREATE TABLE t (
 	e DECIMAL NULL,
 	u UUID NULL,
 	ip INET NULL,
+	ary STRING[] NULL,
 	tz TIMESTAMP WITH TIME ZONE NULL,
 	e1 DECIMAL(2) NULL,
 	e2 DECIMAL(2,1) NULL,
 	s1 STRING(1) NULL,
-	FAMILY "primary" (i, f, d, t, n, o, u, ip, tz, e1, e2, s1, rowid),
+	FAMILY "primary" (i, f, d, t, n, o, u, ip, ary, tz, e1, e2, s1, rowid),
 	FAMILY fam_1_s (s),
 	FAMILY fam_2_b (b),
 	FAMILY fam_3_e (e)
 );
 
-INSERT INTO t (i, f, s, b, d, t, n, o, e, u, ip, tz, e1, e2, s1) VALUES
-	(1, 2.3, 'striiing', '\x613162326333', '2016-03-26', '2016-01-25 10:10:10+00:00', '2h30m30s', true, 1.2345, 'e9716c74-2638-443d-90ed-ffde7bea7d1d', '192.168.0.1', '2016-01-25 10:10:10+00:00', 3, 4.5, 's'),
-	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
-	(NULL, '+Inf', NULL, NULL, NULL, NULL, NULL, NULL, 'Infinity', NULL, NULL, NULL, NULL, NULL, NULL),
-	(NULL, '-Inf', NULL, NULL, NULL, NULL, NULL, NULL, '-Infinity', NULL, NULL, NULL, NULL, NULL, NULL),
-	(NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL);
+INSERT INTO t (i, f, s, b, d, t, n, o, e, u, ip, ary, tz, e1, e2, s1) VALUES
+	(1, 2.3, 'striiing', '\x613162326333', '2016-03-26', '2016-01-25 10:10:10+00:00', '2h30m30s', true, 1.2345, 'e9716c74-2638-443d-90ed-ffde7bea7d1d', '192.168.0.1', ARRAY['hello':::STRING,'world':::STRING], '2016-01-25 10:10:10+00:00', 3, 4.5, 's'),
+	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, '+Inf', NULL, NULL, NULL, NULL, NULL, NULL, 'Infinity', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, '-Inf', NULL, NULL, NULL, NULL, NULL, NULL, '-Infinity', NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 `
 
 	if out != expect {

--- a/pkg/sql/parser/parse_array.go
+++ b/pkg/sql/parser/parse_array.go
@@ -144,6 +144,41 @@ func (p *parseState) parseElement() error {
 	return p.result.Append(d)
 }
 
+// StringToColType returns a column type given a string representation of the
+// type. Used by dump.
+func StringToColType(s string) (ColumnType, error) {
+	switch s {
+	case "BOOL":
+		return boolColTypeBool, nil
+	case "INT":
+		return intColTypeInt, nil
+	case "FLOAT":
+		return floatColTypeFloat, nil
+	case "DECIMAL":
+		return decimalColTypeDecimal, nil
+	case "TIMESTAMP":
+		return timestampColTypeTimestamp, nil
+	case "TIMESTAMPTZ", "TIMESTAMP WITH TIME ZONE":
+		return timestampTzColTypeTimestampWithTZ, nil
+	case "INTERVAL":
+		return intervalColTypeInterval, nil
+	case "UUID":
+		return uuidColTypeUUID, nil
+	case "INET":
+		return ipnetColTypeINet, nil
+	case "DATE":
+		return dateColTypeDate, nil
+	case "STRING":
+		return stringColTypeString, nil
+	case "NAME":
+		return nameColTypeName, nil
+	case "BYTES":
+		return bytesColTypeBytes, nil
+	default:
+		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected column type %s", s)
+	}
+}
+
 // ParseDArrayFromString parses the string-form of constructing arrays, handling
 // cases such as `'{1,2,3}'::INT[]`.
 func ParseDArrayFromString(evalCtx *EvalContext, s string, t ColumnType) (*DArray, error) {

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1780,11 +1780,7 @@ func parserTypeToEncodingType(t parser.Type) (encoding.Type, error) {
 		return encoding.Float, nil
 	case parser.TypeDecimal:
 		return encoding.Decimal, nil
-	case parser.TypeBytes:
-		return encoding.Bytes, nil
-	case parser.TypeString:
-		return encoding.Bytes, nil
-	case parser.TypeBytes:
+	case parser.TypeBytes, parser.TypeString, parser.TypeName:
 		return encoding.Bytes, nil
 	case parser.TypeTimestamp, parser.TypeTimestampTZ, parser.TypeDate:
 		return encoding.Time, nil


### PR DESCRIPTION
Fixes #19487.

I neglected to add the array handling case to dump. This commit adds it.
Added an `EachColType` function that will hopefully be able to kept up
to date which can be used to make tests which will continue to test
new column types as more get added.