### PR TITLE
sql: propagate column properties to elements

### DIFF
--- a/pkg/acceptance/testdata/java/src/main/java/MainTest.java
+++ b/pkg/acceptance/testdata/java/src/main/java/MainTest.java
@@ -160,6 +160,21 @@ public class MainTest extends CockroachDBTest {
     }
 
     @Test
+    public void testArrayWithProps() throws Exception {
+        PreparedStatement stmt = conn.prepareStatement("CREATE TABLE x (a SMALLINT[])");
+        stmt.execute();
+        stmt = conn.prepareStatement("INSERT INTO x VALUES (ARRAY[123])");
+        stmt.execute();
+        stmt = conn.prepareStatement("SELECT a FROM x");
+        ResultSet rs = stmt.executeQuery();
+        rs.next();
+
+        Array ar = rs.getArray(1);
+        Long[] fs = (Long[]) ar.getArray();
+        Assert.assertArrayEquals(new Long[]{123L}, fs);
+    }
+
+    @Test
     public void testStringArray() throws Exception {
         PreparedStatement stmt = conn.prepareStatement("SELECT '{123,\"hello\",\"\\\"hello\\\"\"}'::STRING[]");
         ResultSet rs = stmt.executeQuery();

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -462,7 +462,7 @@ func GenerateInsertRow(
 
 	// Ensure that the values honor the specified column widths.
 	for i := range rowVals {
-		if err := sqlbase.CheckValueWidth(insertCols[i], rowVals[i]); err != nil {
+		if err := sqlbase.CheckValueWidth(insertCols[i].Type, rowVals[i], insertCols[i].Name); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -379,6 +379,17 @@ statement ok
 DELETE FROM a
 
 statement ok
+INSERT INTO a VALUES (NULL)
+
+query T
+SELECT b FROM a
+----
+NULL
+
+statement ok
+DELETE FROM a
+
+statement ok
 INSERT INTO a VALUES (ARRAY[])
 
 query T
@@ -461,6 +472,25 @@ query T
 SELECT * FROM a
 ----
 {1,2,3,4,5,6,7,8,NULL}
+
+statement ok
+DROP TABLE a
+
+# Ensure that additional type info stays when used as an array.
+
+statement ok
+CREATE TABLE a (b SMALLINT[])
+
+query TT
+SHOW CREATE TABLE a
+----
+a  CREATE TABLE a (
+    b SMALLINT[] NULL,
+    FAMILY "primary" (b, rowid)
+  )
+
+statement error integer out of range for type SMALLINT \(column "b"\)
+INSERT INTO a VALUES (ARRAY[100000])
 
 statement ok
 DROP TABLE a

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2068,8 +2068,19 @@ func ColumnsSelectors(cols []ColumnDescriptor) tree.SelectExprs {
 	return exprs
 }
 
-func colTypeSQLString(c *ColumnType, semType ColumnType_SemanticType) string {
-	switch semType {
+func (c *ColumnType) elementColumnType() *ColumnType {
+	if c.SemanticType != ColumnType_ARRAY {
+		return nil
+	}
+	result := *c
+	result.SemanticType = *c.ArrayContents
+	result.ArrayContents = nil
+	return &result
+}
+
+// SQLString returns the SQL string corresponding to the type.
+func (c *ColumnType) SQLString() string {
+	switch c.SemanticType {
 	case ColumnType_INT:
 		if c.Width > 0 && c.VisibleType == ColumnType_BIT {
 			// A non-zero width indicates a bit array. The syntax "INT(N)"
@@ -2078,11 +2089,11 @@ func colTypeSQLString(c *ColumnType, semType ColumnType_SemanticType) string {
 		}
 	case ColumnType_STRING:
 		if c.Width > 0 {
-			return fmt.Sprintf("%s(%d)", semType.String(), c.Width)
+			return fmt.Sprintf("%s(%d)", c.SemanticType.String(), c.Width)
 		}
 	case ColumnType_FLOAT:
 		if c.Precision > 0 {
-			return fmt.Sprintf("%s(%d)", semType.String(), c.Precision)
+			return fmt.Sprintf("%s(%d)", c.SemanticType.String(), c.Precision)
 		}
 		if c.VisibleType == ColumnType_DOUBLE_PRECISON {
 			return "DOUBLE PRECISION"
@@ -2090,9 +2101,9 @@ func colTypeSQLString(c *ColumnType, semType ColumnType_SemanticType) string {
 	case ColumnType_DECIMAL:
 		if c.Precision > 0 {
 			if c.Width > 0 {
-				return fmt.Sprintf("%s(%d,%d)", semType.String(), c.Precision, c.Width)
+				return fmt.Sprintf("%s(%d,%d)", c.SemanticType.String(), c.Precision, c.Width)
 			}
-			return fmt.Sprintf("%s(%d)", semType.String(), c.Precision)
+			return fmt.Sprintf("%s(%d)", c.SemanticType.String(), c.Precision)
 		}
 	case ColumnType_TIMESTAMPTZ:
 		return "TIMESTAMP WITH TIME ZONE"
@@ -2105,17 +2116,12 @@ func colTypeSQLString(c *ColumnType, semType ColumnType_SemanticType) string {
 		}
 		return fmt.Sprintf("%s COLLATE %s", ColumnType_STRING.String(), *c.Locale)
 	case ColumnType_ARRAY:
-		return colTypeSQLString(c, *c.ArrayContents) + "[]"
+		return c.elementColumnType().SQLString() + "[]"
 	}
 	if c.VisibleType != ColumnType_NONE {
 		return c.VisibleType.String()
 	}
-	return semType.String()
-}
-
-// SQLString returns the SQL string corresponding to the type.
-func (c *ColumnType) SQLString() string {
-	return colTypeSQLString(c, c.SemanticType)
+	return c.SemanticType.String()
 }
 
 // MaxCharacterLength returns the declared maximum length of characters if the

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -439,7 +439,7 @@ func (u *updateNode) Next(params runParams) (bool, error) {
 
 	// Ensure that the values honor the specified column widths.
 	for i := range updateValues {
-		if err := sqlbase.CheckValueWidth(u.tw.ru.UpdateCols[i], updateValues[i]); err != nil {
+		if err := sqlbase.CheckValueWidth(u.tw.ru.UpdateCols[i].Type, updateValues[i], u.tw.ru.UpdateCols[i].Name); err != nil {
 			return false, err
 		}
 	}


### PR DESCRIPTION
Release notes: Fix interaction with  modified column types such as
length-limited strings in arrays.

Previously we would throw away any column modifiers when a type was used
with an array. This change addresses this problem.

Fixes #19237.