### PR TITLE
util/contextutil: silence overly verbose log message

### DIFF
--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -28,10 +28,13 @@ func WithCancel(parent context.Context) (context.Context, context.CancelFunc) {
 }
 
 func wrap(ctx context.Context, cancel context.CancelFunc) (context.Context, context.CancelFunc) {
+	if !log.V(1) {
+		return ctx, cancel
+	}
 	return ctx, func() {
-		if log.V(1) {
+		if log.V(2) {
 			log.InfofDepth(ctx, 1, "canceling context:\n%s", debug.Stack())
-		} else {
+		} else if log.V(1) {
 			log.InfofDepth(ctx, 1, "canceling context")
 		}
 		cancel()


### PR DESCRIPTION
Logging "canceling context" every time a context is cancelled is overly
verbose and a measurable performance hit. Only wrap the cancellation
closure if log.V(1) or higher is specified.