### PR TITLE
tscache: introduce skiplist-backed TimestampCache

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -640,13 +640,11 @@ func TestRangeTransferLease(t *testing.T) {
 
 		// We'd like to verify the timestamp cache's low water mark, but this is
 		// impossible to determine precisely in all cases because it may have
-		// been subsumed by future tscache accesses. However, we know that there
-		// were no tscache accesses since we executed the transfer lease
-		// request, which means that the low water mark will still be equal to
-		// the high water mark. So instead of checking the low water mark, we
-		// make sure that the high water mark is set to the new lease start
-		// time, which is less than the previous lease's expiration time.
-		if highWater := replica1.GetTSCacheHighWater(); highWater != replica1Lease.Start {
+		// been subsumed by future tscache accesses. So instead of checking the
+		// low water mark, we make sure that the high water mark is equal to or
+		// greater than the new lease start time, which is less than the
+		// previous lease's expiration time.
+		if highWater := replica1.GetTSCacheHighWater(); highWater.Less(replica1Lease.Start) {
 			t.Fatalf("expected timestamp cache high water %s, but found %s",
 				replica1Lease.Start, highWater)
 		}

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -209,11 +209,15 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 		// lease's expiration but instead use the new lease's start to initialize
 		// the timestamp cache low water.
 		desc := r.Desc()
-		r.store.tsCacheMu.Lock()
+		if !r.store.tsCacheMu.cache.ThreadSafe() {
+			r.store.tsCacheMu.Lock()
+		}
 		for _, keyRange := range makeReplicatedKeyRanges(desc) {
 			r.store.tsCacheMu.cache.SetLowWater(keyRange.start.Key, keyRange.end.Key, newLease.Start)
 		}
-		r.store.tsCacheMu.Unlock()
+		if !r.store.tsCacheMu.cache.ThreadSafe() {
+			r.store.tsCacheMu.Unlock()
+		}
 
 		// Reset the request counts used to make lease placement decisions whenever
 		// starting a new lease.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1963,8 +1963,10 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 		t.Error(pErr)
 	}
 	// Verify the timestamp cache has rTS=1s and wTS=0s for "a".
-	tc.repl.store.tsCacheMu.Lock()
-	defer tc.repl.store.tsCacheMu.Unlock()
+	if !tc.repl.store.tsCacheMu.cache.ThreadSafe() {
+		tc.repl.store.tsCacheMu.Lock()
+		defer tc.repl.store.tsCacheMu.Unlock()
+	}
 	tc.repl.store.tsCacheMu.cache.ExpandRequests(tc.repl.Desc().RSpan(), hlc.Timestamp{})
 	noID := uuid.UUID{}
 	rTS, rTxnID := tc.repl.store.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -55,12 +55,9 @@ type Cache interface {
 	// ExpandRequests expands any request that overlaps the specified span and
 	// which is newer than the specified timestamp.
 	ExpandRequests(span roachpb.RSpan, timestamp hlc.Timestamp)
-
 	// SetLowWater sets the low water mark of the cache for the specified span
 	// to the provided timestamp.
 	SetLowWater(start, end roachpb.Key, timestamp hlc.Timestamp)
-	// GlobalLowWater returns the low water mark for the entire cache.
-	GlobalLowWater() hlc.Timestamp
 
 	// GetMaxRead returns the maximum read timestamp which overlaps the interval
 	// spanning from start to end. If that maximum timestamp belongs to a single
@@ -78,9 +75,11 @@ type Cache interface {
 	//
 	// add the specified timestamp to the cache covering the range of keys from
 	// start to end.
-	add(start, end roachpb.Key, timestamp hlc.Timestamp, txnID uuid.UUID, readTSCache bool)
+	add(start, end roachpb.Key, ts hlc.Timestamp, txnID uuid.UUID, readCache bool)
 	// clear clears the cache and resets the low-water mark.
 	clear(lowWater hlc.Timestamp)
+	// getLowWater return the low water mark for the specified cache.
+	getLowWater(readCache bool) hlc.Timestamp
 }
 
 // New returns a new timestamp cache with the supplied hybrid clock.

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -50,7 +51,24 @@ const MinRetentionWindow = 10 * time.Second
 // instead to determine read-write conflicts. The low water mark is initialized
 // to the current system time plus the maximum clock offset.
 type Cache interface {
+	// ThreadSafe returns whether the Cache implementation is thread-safe and
+	// therefore does not need external locking.
+	//
+	// TODO(nvanbenschoten): We expose this while the treeImpl is still being
+	// used because finer grained locking internally in each method would hurt
+	// performance. Once we switch to the sklImpl by default, we can give
+	// treeImpl its own lock and let it do its own locking.
+	ThreadSafe() bool
+
 	// AddRequest adds the specified request to the cache in an unexpanded state.
+	//
+	// TODO(nvanbenschoten): once we switch to using the sklImpl by default, we
+	// should trim this interface. We can remove AddRequest and  ExpandRequests,
+	// and export Add directly, because we no longer need to group operations
+	// into a single synchronized access. Doing so will hurt the performance of
+	// treeImpl but improve performance of sklImpl. Because of this tradeoff, we
+	// don't want to do this until we switch from using treeImpl by default to
+	// using sklImpl by default.
 	AddRequest(req *Request)
 	// ExpandRequests expands any request that overlaps the specified span and
 	// which is newer than the specified timestamp.
@@ -84,6 +102,9 @@ type Cache interface {
 
 // New returns a new timestamp cache with the supplied hybrid clock.
 func New(clock *hlc.Clock) Cache {
+	if envutil.EnvOrDefaultBool("COCKROACH_USE_SKL_TSCACHE", false) {
+		return newSklImpl(clock)
+	}
 	return newTreeImpl(clock)
 }
 

--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -15,24 +15,37 @@
 package tscache
 
 import (
+	"bytes"
 	"fmt"
+	"math/rand"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
+
+var cacheImplConstrs = []func(clock *hlc.Clock) Cache{
+	func(clock *hlc.Clock) Cache { return newTreeImpl(clock) },
+	func(clock *hlc.Clock) Cache { return newSklImpl(clock) },
+}
 
 func forEachCacheImpl(
 	t *testing.T, fn func(t *testing.T, tc Cache, clock *hlc.Clock, manual *hlc.ManualClock),
 ) {
-	for _, constr := range []func(*hlc.Clock) Cache{
-		func(clock *hlc.Clock) Cache { return newTreeImpl(clock) },
-	} {
+	for _, constr := range cacheImplConstrs {
 		const baseTS = 100
 		manual := hlc.NewManualClock(baseTS)
 		clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
@@ -444,14 +457,259 @@ func TestTimestampCacheEqualTimestamps(t *testing.T) {
 	})
 }
 
+// lockedCache wraps non-thread safe Cache implementations in Mutex to make them
+// thread safe.
+//
+// TODO(nvanbenschoten): remove when we remove Cache.ThreadSafe.
+type lockedCache struct {
+	syncutil.Mutex
+	c Cache
+}
+
+func makeThreadSafe(c Cache) Cache {
+	if !c.ThreadSafe() {
+		return &lockedCache{c: c}
+	}
+	return c
+}
+
+func unwrapCache(c Cache) Cache {
+	if lc, ok := c.(*lockedCache); ok {
+		return unwrapCache(lc.c)
+	}
+	return c
+}
+
+func (lc *lockedCache) ThreadSafe() bool { return true }
+func (lc *lockedCache) GetMaxRead(start, end roachpb.Key) (hlc.Timestamp, uuid.UUID) {
+	lc.Lock()
+	defer lc.Unlock()
+	return lc.c.GetMaxRead(start, end)
+}
+func (lc *lockedCache) add(
+	start, end roachpb.Key, ts hlc.Timestamp, txnID uuid.UUID, readCache bool,
+) {
+	lc.Lock()
+	lc.c.add(start, end, ts, txnID, readCache)
+	lc.Unlock()
+}
+func (lc *lockedCache) clear(lowWater hlc.Timestamp) {
+	lc.Lock()
+	lc.c.clear(lowWater)
+	lc.Unlock()
+}
+
+// Implement if needed.
+func (*lockedCache) AddRequest(_ *Request)                                   { panic("unimplemented") }
+func (*lockedCache) ExpandRequests(_ roachpb.RSpan, _ hlc.Timestamp)         { panic("unimplemented") }
+func (*lockedCache) SetLowWater(_, _ roachpb.Key, _ hlc.Timestamp)           { panic("unimplemented") }
+func (*lockedCache) GetMaxWrite(_, _ roachpb.Key) (hlc.Timestamp, uuid.UUID) { panic("unimplemented") }
+func (*lockedCache) getLowWater(_ bool) hlc.Timestamp                        { panic("unimplemented") }
+
+// TestTimestampCacheImplsIdentical verifies that all timestamp cache
+// implementations return the same results for the same inputs, even under
+// concurrent load.
+func TestTimestampCacheImplsIdentical(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Run one subtest using a real clock to generate timestamps and one subtest
+	// using a fake clock to generate timestamps. The former is good for
+	// simulating real conditions while the latter is good for testing timestamp
+	// collisions.
+	testutils.RunTrueAndFalse(t, "useClock", func(t *testing.T, useClock bool) {
+		clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+		caches := make([]Cache, len(cacheImplConstrs))
+		start := clock.Now()
+		for i, constr := range cacheImplConstrs {
+			c := makeThreadSafe(constr(clock))
+			c.clear(start) // set low water mark
+			caches[i] = c
+		}
+
+		// Context cancellations are used to shutdown goroutines and prevent
+		// deadlocks once any test failures are found. errgroup.WithContext will
+		// cancel the context either when any goroutine returns an error or when
+		// all goroutines finish and Wait returns.
+		doneWG, ctx := errgroup.WithContext(context.Background())
+
+		// We run a goroutine for each slot. Goroutines insert new value over
+		// random intervals, but verify that the value in their slot always
+		// ratchets.
+		slots := 4 * runtime.NumCPU()
+		if util.RaceEnabled {
+			// We add in a lot of preemption points when race detection
+			// is enabled, so things will already be very slow. Reduce
+			// the concurrency to that we don't time out.
+			slots /= 2
+		}
+
+		// semC and retC force all goroutines to work in lockstep, first adding
+		// intervals to all caches together, then reading from all caches
+		// together.
+		semC, retC := make(chan struct{}), make(chan struct{})
+		go func() {
+			populate := func() {
+				for i := 0; i < slots; i++ {
+					select {
+					case semC <- struct{}{}:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+			populate()
+
+			left := slots
+			for {
+				select {
+				case <-retC:
+					left--
+					if left == 0 {
+						// Reset left count and populate.
+						left = slots
+						populate()
+					}
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+
+		for i := 0; i < slots; i++ {
+			i := i
+			doneWG.Go(func() error {
+				rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+				slotKey := []byte(fmt.Sprintf("%05d", i))
+				txnID := uuid.MakeV4()
+				maxVal := cacheValue{}
+
+				const n = 1000
+				for j := 0; j < n; j++ {
+					t.Logf("goroutine %d at iter %d", i, j)
+
+					// Wait for all goroutines to synchronize.
+					select {
+					case <-semC:
+					case <-ctx.Done():
+						return nil
+					}
+
+					// Add the same random range to each cache.
+					from, middle, to := randRange(rng, slots+1)
+					if bytes.Equal(from, to) {
+						to = nil
+					}
+
+					ts := start.Add(int64(j), 100)
+					if useClock {
+						ts = clock.Now()
+					}
+
+					newVal := cacheValue{ts: ts, txnID: txnID}
+					for _, c := range caches {
+						t.Logf("adding (%T) [%s,%s) = %s", unwrapCache(c), string(from), string(to), newVal)
+						c.add(from, to, ts, txnID, true /* readCache */)
+					}
+
+					// Return semaphore.
+					select {
+					case retC <- struct{}{}:
+					case <-ctx.Done():
+						return nil
+					}
+
+					// Wait for all goroutines to synchronize.
+					select {
+					case <-semC:
+					case <-ctx.Done():
+						return nil
+					}
+
+					// Check the value for the newly added interval. Should be
+					// equal across all caches and be a ratcheted version of the
+					// interval added above.
+					var err error
+					if _, err = identicalAndRatcheted(caches, from, to, newVal); err != nil {
+						return errors.Wrapf(err, "interval=[%s,%s)", string(from), string(to))
+					}
+
+					// Check the value for the start key of the newly added
+					// interval. Should be equal across all caches and be a
+					// ratcheted version of the interval added above.
+					if _, err = identicalAndRatcheted(caches, from, nil, newVal); err != nil {
+						return errors.Wrapf(err, "startKey=%s", string(from))
+					}
+
+					// Check the value right after the start key of the newly
+					// added interval, if possible. Should be equal across all
+					// caches and be a ratcheted version of the interval added
+					// above.
+					if middle != nil {
+						if _, err = identicalAndRatcheted(caches, middle, nil, newVal); err != nil {
+							return errors.Wrapf(err, "middleKey=%s", string(middle))
+						}
+					}
+
+					// Check the value for the goroutine's slot. Should be equal
+					// across all caches and be a ratcheted version of the
+					// maximum value we've seen in the slot.
+					if maxVal, err = identicalAndRatcheted(caches, slotKey, nil, maxVal); err != nil {
+						return errors.Wrapf(err, "slotKey=%s", string(slotKey))
+					}
+
+					// Return semaphore.
+					select {
+					case retC <- struct{}{}:
+					case <-ctx.Done():
+						return nil
+					}
+				}
+				return nil
+			})
+		}
+		if err := doneWG.Wait(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+// identicalAndRatcheted asserts that all caches have identical values for the
+// specified range and that the value is a ratcheted version of previous value.
+// It returns an error if the assertion fails and the value found if it doesn't.
+func identicalAndRatcheted(
+	caches []Cache, from, to roachpb.Key, prevVal cacheValue,
+) (cacheValue, error) {
+	var vals []cacheValue
+	for _, c := range caches {
+		keyTS, keyTxnID := c.GetMaxRead(from, to)
+		vals = append(vals, cacheValue{ts: keyTS, txnID: keyTxnID})
+	}
+
+	// Assert same values for each cache.
+	firstVal := vals[0]
+	firstCache := unwrapCache(caches[0])
+	for i := 1; i < len(caches); i++ {
+		if !reflect.DeepEqual(firstVal, vals[i]) {
+			return firstVal, errors.Errorf("expected %s (%T) and %s (%T) to be equal",
+				firstVal, firstCache, vals[i], unwrapCache(caches[i]))
+		}
+	}
+
+	// Assert that the value is a ratcheted version of prevVal.
+	// See assertRatchet.
+	if _, ratchet := ratchetValue(firstVal, prevVal); ratchet {
+		return firstVal, errors.Errorf("ratchet inversion from %s to %s", prevVal, firstVal)
+	}
+
+	return firstVal, nil
+}
+
 func BenchmarkTimestampCacheInsertion(b *testing.B) {
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
 	tc := New(clock)
 
 	for i := 0; i < b.N; i++ {
-		tc.clear(clock.Now())
-
 		cdTS := clock.Now()
 		tc.add(roachpb.Key("c"), roachpb.Key("d"), cdTS, noTxnID, true)
 

--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -232,7 +232,7 @@ var layeredIntervalTestCase3 = layeredIntervalTestCase{
 
 		assertTS(t, tc, roachpb.Key("a"), nil, acTx.ts, acTx.id)
 		assertTS(t, tc, roachpb.Key("b"), nil, bcTx.ts, zeroIfSimul(txns, bcTx.id))
-		assertTS(t, tc, roachpb.Key("c"), nil, tc.GlobalLowWater(), noTxnID)
+		assertTS(t, tc, roachpb.Key("c"), nil, tc.getLowWater(true /* readCache */), noTxnID)
 		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("c"), bcTx.ts, zeroIfSimul(txns, bcTx.id))
 		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("b"), acTx.ts, acTx.id)
 		assertTS(t, tc, roachpb.Key("b"), roachpb.Key("c"), bcTx.ts, zeroIfSimul(txns, bcTx.id))
@@ -256,7 +256,7 @@ var layeredIntervalTestCase4 = layeredIntervalTestCase{
 
 		assertTS(t, tc, roachpb.Key("a"), nil, abTx.ts, zeroIfSimul(txns, abTx.id))
 		assertTS(t, tc, roachpb.Key("b"), nil, acTx.ts, acTx.id)
-		assertTS(t, tc, roachpb.Key("c"), nil, tc.GlobalLowWater(), noTxnID)
+		assertTS(t, tc, roachpb.Key("c"), nil, tc.getLowWater(true /* readCache */), noTxnID)
 		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("c"), abTx.ts, zeroIfSimul(txns, abTx.id))
 		assertTS(t, tc, roachpb.Key("a"), roachpb.Key("b"), abTx.ts, zeroIfSimul(txns, abTx.id))
 		assertTS(t, tc, roachpb.Key("b"), roachpb.Key("c"), acTx.ts, acTx.id)

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -459,6 +459,13 @@ func (s *intervalSkl) LookupTimestampRange(from, to []byte, opt rangeOptions) ca
 	return val
 }
 
+// FloorTS returns the receiver's floor timestamp.
+func (s *intervalSkl) FloorTS() hlc.Timestamp {
+	s.rotMutex.RLock()
+	defer s.rotMutex.RUnlock()
+	return s.floorTS
+}
+
 // sklPage maintains a skiplist based on a fixed-size arena. When the arena has
 // filled up, it returns arenaskl.ErrArenaFull. At that point, a new fixed page
 // must be allocated and used instead.

--- a/pkg/storage/tscache/skl_impl.go
+++ b/pkg/storage/tscache/skl_impl.go
@@ -1,0 +1,150 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tscache
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+// sklPageSize is the size of each page in the sklImpl's read and write
+// intervalSkl.
+const sklPageSize = 32 << 20 // 32 MB
+
+// sklImpl implements the Cache interface. It maintains a pair of skiplists
+// containing keys or key ranges and the timestamps at which they were most
+// recently read or written. If a timestamp was read or written by a
+// transaction, the txn ID is stored with the timestamp to avoid advancing
+// timestamps on successive requests from the same transaction.
+//
+// sklImpl is safe for concurrent use by multiple goroutines.
+//
+// TODO(nvanbenschoten): We should export some metrics from here, including:
+// - page rotations/min (rCache & wCache)
+// - page count         (rCache & wCache)
+type sklImpl struct {
+	rCache, wCache *intervalSkl
+	clock          *hlc.Clock
+}
+
+var _ Cache = &sklImpl{}
+
+// newSklImpl returns a new treeImpl with the supplied hybrid clock.
+func newSklImpl(clock *hlc.Clock) *sklImpl {
+	tc := sklImpl{clock: clock}
+	tc.clear(clock.Now())
+	return &tc
+}
+
+// ThreadSafe implements the Cache interface.
+func (*sklImpl) ThreadSafe() bool { return true }
+
+// clear clears the cache and resets the low-water mark.
+func (tc *sklImpl) clear(lowWater hlc.Timestamp) {
+	tc.rCache = newIntervalSkl(tc.clock, MinRetentionWindow, sklPageSize)
+	tc.wCache = newIntervalSkl(tc.clock, MinRetentionWindow, sklPageSize)
+	tc.rCache.floorTS = lowWater
+	tc.wCache.floorTS = lowWater
+}
+
+// getSkl returns either the read or write intervalSkl.
+func (tc *sklImpl) getSkl(readCache bool) *intervalSkl {
+	if readCache {
+		return tc.rCache
+	}
+	return tc.wCache
+}
+
+// add the specified timestamp to the cache covering the range of keys from
+// start to end. If end is nil, the range covers the start key only. txnID is
+// nil for no transaction. readCache specifies whether the command adding this
+// timestamp should update the read timestamp; false to update the write
+// timestamp cache.
+func (tc *sklImpl) add(start, end roachpb.Key, ts hlc.Timestamp, txnID uuid.UUID, readCache bool) {
+	skl := tc.getSkl(readCache)
+
+	val := cacheValue{ts: ts, txnID: txnID}
+	if len(end) == 0 {
+		skl.Add(nonNil(start), val)
+	} else {
+		skl.AddRange(nonNil(start), end, excludeTo, val)
+	}
+}
+
+// AddRequest implements the Cache interface.
+func (tc *sklImpl) AddRequest(req *Request) {
+	for _, sp := range req.Reads {
+		tc.add(sp.Key, sp.EndKey, req.Timestamp, req.TxnID, true /* readCache */)
+	}
+	for _, sp := range req.Writes {
+		tc.add(sp.Key, sp.EndKey, req.Timestamp, req.TxnID, false /* readCache */)
+	}
+	if req.Txn.Key != nil {
+		// Make the transaction key from the request key. We're guaranteed
+		// req.TxnID != nil because we only hit this code path for
+		// EndTransactionRequests.
+		key := keys.TransactionKey(req.Txn.Key, req.TxnID)
+		tc.add(key, nil, req.Timestamp, req.TxnID, false /* readCache */)
+	}
+}
+
+// ExpandRequests implements the Cache interface.
+func (tc *sklImpl) ExpandRequests(span roachpb.RSpan, ts hlc.Timestamp) { /* no-op */ }
+
+// SetLowWater implements the Cache interface.
+func (tc *sklImpl) SetLowWater(start, end roachpb.Key, ts hlc.Timestamp) {
+	tc.add(start, end, ts, noTxnID, false /* readCache */)
+	tc.add(start, end, ts, noTxnID, true /* readCache */)
+}
+
+// getLowWater implements the Cache interface.
+func (tc *sklImpl) getLowWater(readCache bool) hlc.Timestamp {
+	return tc.getSkl(readCache).FloorTS()
+}
+
+// GetMaxRead implements the Cache interface.
+func (tc *sklImpl) GetMaxRead(start, end roachpb.Key) (hlc.Timestamp, uuid.UUID) {
+	return tc.getMax(start, end, true /* readCache */)
+}
+
+// GetMaxWrite implements the Cache interface.
+func (tc *sklImpl) GetMaxWrite(start, end roachpb.Key) (hlc.Timestamp, uuid.UUID) {
+	return tc.getMax(start, end, false /* readCache */)
+}
+
+func (tc *sklImpl) getMax(start, end roachpb.Key, readCache bool) (hlc.Timestamp, uuid.UUID) {
+	skl := tc.getSkl(readCache)
+
+	var val cacheValue
+	if len(end) == 0 {
+		val = skl.LookupTimestamp(nonNil(start))
+	} else {
+		val = skl.LookupTimestampRange(nonNil(start), end, excludeTo)
+	}
+	return val.ts, val.txnID
+}
+
+// intervalSkl doesn't handle nil keys the same way as empty keys. Cockroach's
+// KV API layer doesn't make a distinction.
+var emptyStartKey = []byte("")
+
+func nonNil(b []byte) []byte {
+	if b == nil {
+		return emptyStartKey
+	}
+	return b
+}

--- a/pkg/storage/tscache/tree_impl.go
+++ b/pkg/storage/tscache/tree_impl.go
@@ -125,11 +125,11 @@ func (tc *treeImpl) len() int {
 
 // add the specified timestamp to the cache covering the range of keys from
 // start to end. If end is nil, the range covers the start key only. txnID is
-// nil for no transaction. readTSCache specifies whether the command adding this
+// nil for no transaction. readCache specifies whether the command adding this
 // timestamp should update the read timestamp; false to update the write
 // timestamp cache.
 func (tc *treeImpl) add(
-	start, end roachpb.Key, timestamp hlc.Timestamp, txnID uuid.UUID, readTSCache bool,
+	start, end roachpb.Key, timestamp hlc.Timestamp, txnID uuid.UUID, readCache bool,
 ) {
 	// This gives us a memory-efficient end key if end is empty.
 	if len(end) == 0 {
@@ -141,7 +141,7 @@ func (tc *treeImpl) add(
 	// low water mark.
 	if tc.lowWater.Less(timestamp) {
 		tcache := tc.wCache
-		if readTSCache {
+		if readCache {
 			tcache = tc.rCache
 		}
 
@@ -552,18 +552,18 @@ func (tc *treeImpl) ExpandRequests(span roachpb.RSpan, timestamp hlc.Timestamp) 
 		tc.bytes -= reqSize
 		for i := range req.Reads {
 			sp := &req.Reads[i]
-			tc.add(sp.Key, sp.EndKey, req.Timestamp, req.TxnID, true /* readTSCache */)
+			tc.add(sp.Key, sp.EndKey, req.Timestamp, req.TxnID, true /* readCache */)
 		}
 		for i := range req.Writes {
 			sp := &req.Writes[i]
-			tc.add(sp.Key, sp.EndKey, req.Timestamp, req.TxnID, false /* readTSCache */)
+			tc.add(sp.Key, sp.EndKey, req.Timestamp, req.TxnID, false /* readCache */)
 		}
 		if req.Txn.Key != nil {
 			// Make the transaction key from the request key. We're guaranteed
 			// req.TxnID != nil because we only hit this code path for
 			// EndTransactionRequests.
 			key := keys.TransactionKey(req.Txn.Key, req.TxnID)
-			tc.add(key, nil, req.Timestamp, req.TxnID, false /* readTSCache */)
+			tc.add(key, nil, req.Timestamp, req.TxnID, false /* readCache */)
 		}
 		req.release()
 	}
@@ -575,8 +575,10 @@ func (tc *treeImpl) SetLowWater(start, end roachpb.Key, timestamp hlc.Timestamp)
 	tc.add(start, end, timestamp, noTxnID, true)
 }
 
-// GlobalLowWater implements the Cache interface.
-func (tc *treeImpl) GlobalLowWater() hlc.Timestamp {
+// getLowWater implements the Cache interface.
+func (tc *treeImpl) getLowWater(readCache bool) hlc.Timestamp {
+	// The lowWater timestamp is shared between the read and write caches, so
+	// ignore the readCache argument.
 	return tc.lowWater
 }
 
@@ -590,14 +592,14 @@ func (tc *treeImpl) GetMaxWrite(start, end roachpb.Key) (hlc.Timestamp, uuid.UUI
 	return tc.getMax(start, end, false)
 }
 
-func (tc *treeImpl) getMax(start, end roachpb.Key, readTSCache bool) (hlc.Timestamp, uuid.UUID) {
+func (tc *treeImpl) getMax(start, end roachpb.Key, readCache bool) (hlc.Timestamp, uuid.UUID) {
 	if len(end) == 0 {
 		end = start.Next()
 	}
 	maxTS := tc.lowWater
 	maxTxnID := noTxnID
 	cache := tc.wCache
-	if readTSCache {
+	if readCache {
 		cache = tc.rCache
 	}
 	for _, o := range cache.GetOverlaps(start, end) {


### PR DESCRIPTION
This is still a major work in progress, but I wanted to publish it in-case others wanted
to play around with it as well. I'm going to continue experimenting with this over the
next few days.

The change creates a new implementation of `tscache.Cache` that's backed by a concurrent
skiplist. It uses a fork of https://github.com/andy-kimball/tscache, which contains a similar
timestamp cache built on top of an arena-based skiplist (https://github.com/andy-kimball/arenaskl).
A couple of important modifications were performed to make the structure usable in CockroachDB, which are located over in https://github.com/nvanbenschoten/tscache. The actual changes here
are minimal, and amount to creating a wrapper type around the library and ripping out now-unnecessary locking.

Nothing here is polished, but that wasn't the intention for now. The important part is that all tests pass with the new `tscache.Cache` implementation plugged in!

Preliminary benchmarking shows impressive results. Here, the effect of the arena allocator is obvious. The properties of the skiplist also allow us to avoid a `request` interval map like we have in the current code, which I predict is also contributing to speedup. The following lists some (hastily gathered) performance diffs:

#### kv, 100% reads
`kv --read-percent 100 --concurrency 16 --splits 100 --write-seq 100000`
- GCTrace time dropped from **7%** to **0%**
- Throughput increased by **14%**
- 99th percentile latency dropped by **40-60%**

#### kv, 80% reads
`kv --read-percent 80 --concurrency 16 --splits 100 --write-seq 100000`
- Throughput increased by **11%**
- 99th percentile latency dropped by **20%**

#### tpcc
`default settings`
- Throughput increased by **30%**
- 99th percentile latency dropped by **50-60%**

cc. @petermattis @spencerkimball @andy-kimball