### PR TITLE
Makefile: avoid broken find invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,8 +315,8 @@ clean: ## Remove build artifacts.
 clean: clean-c-deps
 	$(MAKE) -C $(ORG_ROOT) -f cockroach/build/protobuf.mk clean
 	$(GO) clean $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -i github.com/cockroachdb/...
-	$(FIND_RELEVANT) -type f \( -name 'zcgo_flags*.go' -o -name '*.test' \) -delete
-	$(FIND_RELEVANT) -type f -depth 1 -name 'cockroach*' -delete
+	$(FIND_RELEVANT) -type f \( -name 'zcgo_flags*.go' -o -name '*.test' \) -exec rm {} +
+	for f in cockroach*; do [ -f "$$f" ] && rm -f "$$f"; done
 	rm -rf artifacts $(LOCAL_BIN) $(ARCHIVE)
 
 .PHONY: maintainer-clean


### PR DESCRIPTION
format=-delete and -prune are incompatible with GNU find, but not with BSD
find.  Use `-exec rm {} +`, which works on both operating systems.
Additionally, replace `-depth 1` (which was meant to be `-maxdepth 1`
anyway) with a shell for loop instead, since `-maxdepth` is not POSIX.
