### PR TITLE
all: make all comments for false constants match the style guide

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -420,7 +420,7 @@ func (c *Cluster) TransferLease(nodeIdx int, r *rand.Rand, key roachpb.Key) (boo
 func (c *Cluster) lookupRange(nodeIdx int, key roachpb.Key) (*roachpb.RangeDescriptor, error) {
 	sender := c.Client(nodeIdx).GetSender()
 	rs, _, err := client.RangeLookup(context.Background(), sender, key,
-		roachpb.CONSISTENT, 0 /* prefetchNum */, false /* !reverse */)
+		roachpb.CONSISTENT, 0 /* prefetchNum */, false /* prefetchReverse */)
 	if err != nil {
 		return nil, errors.Errorf("%s: lookup range: %s", key, err)
 	}

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -88,7 +88,7 @@ func loadTestData(
 		if scaled := len(keys) / numBatches; (i % scaled) == 0 {
 			if i > 0 {
 				log.Infof(ctx, "committing (%d/~%d)", i/scaled, numBatches)
-				if err := batch.Commit(false /* !sync */); err != nil {
+				if err := batch.Commit(false /* sync */); err != nil {
 					return nil, err
 				}
 				batch.Close()
@@ -106,7 +106,7 @@ func loadTestData(
 			return nil, err
 		}
 	}
-	if err := batch.Commit(false /* !sync */); err != nil {
+	if err := batch.Commit(false /* sync */); err != nil {
 		return nil, err
 	}
 	batch.Close()

--- a/pkg/ccl/storageccl/writebatch.go
+++ b/pkg/ccl/storageccl/writebatch.go
@@ -74,7 +74,7 @@ func evalWriteBatch(
 	}
 	ms.Subtract(existingStats)
 
-	if err := batch.ApplyBatchRepr(args.Data, false /* !sync */); err != nil {
+	if err := batch.ApplyBatchRepr(args.Data, false /* sync */); err != nil {
 		return storage.EvalResult{}, err
 	}
 	return storage.EvalResult{}, nil

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -540,8 +540,8 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	var descs []roachpb.RangeDescriptor
 
 	if _, err := engine.MVCCIterate(context.Background(), db, start, end, hlc.MaxTimestamp,
-		false /* !consistent */, nil, /* txn */
-		false /* !reverse */, func(kv roachpb.KeyValue) (bool, error) {
+		false /* consistent */, nil, /* txn */
+		false /* reverse */, func(kv roachpb.KeyValue) (bool, error) {
 			var desc roachpb.RangeDescriptor
 			_, suffix, _, err := keys.DecodeRangeKey(kv.Key)
 			if err != nil {
@@ -626,8 +626,8 @@ func runDebugCheckStoreCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	if _, err := engine.MVCCIterate(context.Background(), db, start, end, hlc.MaxTimestamp,
-		false /* !consistent */, nil, /* txn */
-		false /* !reverse */, func(kv roachpb.KeyValue) (bool, error) {
+		false /* consistent */, nil, /* txn */
+		false /* reverse */, func(kv roachpb.KeyValue) (bool, error) {
 			rangeID, _, suffix, detail, err := keys.DecodeRangeIDKey(kv.Key)
 			if err != nil {
 				return false, err

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -870,7 +870,7 @@ func (ds *DistSender) sendPartialBatchAsync(
 ) bool {
 	if err := ds.rpcContext.Stopper.RunLimitedAsyncTask(
 		ctx, "kv.DistSender: sending partial batch",
-		ds.asyncSenderSem, false, /* !wait */
+		ds.asyncSenderSem, false, /* wait */
 		func(ctx context.Context) {
 			atomic.AddInt32(&ds.asyncSenderCount, 1)
 			responseCh <- ds.sendPartialBatch(ctx, ba, rs, desc, evictToken, batchIdx, true /* needsTruncate */)

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -867,7 +867,7 @@ func TestEvictCacheOnError(t *testing.T) {
 		if _, ok := ds.leaseHolderCache.Lookup(context.TODO(), 1); ok != !tc.shouldClearLeaseHolder {
 			t.Errorf("%d: lease holder cache eviction: shouldClearLeaseHolder=%t, but value is %t", i, tc.shouldClearLeaseHolder, ok)
 		}
-		if cachedDesc, err := ds.rangeCache.GetCachedRangeDescriptor(roachpb.RKey(key), false /* !inverted */); err != nil {
+		if cachedDesc, err := ds.rangeCache.GetCachedRangeDescriptor(roachpb.RKey(key), false /* inverted */); err != nil {
 			t.Error(err)
 		} else if cachedDesc == nil != tc.shouldClearReplica {
 			t.Errorf("%d: unexpected second replica lookup behaviour: wanted=%t", i, tc.shouldClearReplica)

--- a/pkg/kv/local_test_cluster_util.go
+++ b/pkg/kv/local_test_cluster_util.go
@@ -89,7 +89,7 @@ func InitSenderForLocalTestCluster(
 		st,
 		distSender,
 		clock,
-		false, /* !linearizable */
+		false, /* linearizable */
 		stopper,
 		MakeTxnMetrics(metric.TestSampleInterval),
 	)

--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -557,7 +557,7 @@ func (rdc *RangeDescriptorCache) evictCachedRangeDescriptorLocked(
 			break
 		}
 
-		cachedDesc, entry, err = rdc.getCachedRangeDescriptorLocked(descKey, false /* !inverted */)
+		cachedDesc, entry, err = rdc.getCachedRangeDescriptorLocked(descKey, false /* inverted */)
 		if err != nil || cachedDesc == nil {
 			return err
 		}

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -98,7 +98,7 @@ func (db *testDescriptorDB) getDescriptors(
 }
 
 func (db *testDescriptorDB) FirstRange() (*roachpb.RangeDescriptor, error) {
-	rs, _, err := db.getDescriptors(roachpb.RKeyMin, false /* !useReverseScan */)
+	rs, _, err := db.getDescriptors(roachpb.RKeyMin, false /* useReverseScan */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -651,7 +651,7 @@ func (ts *TestServer) SplitRange(
 			return desc, err
 		}
 
-		rightRangeDesc, err = scanMeta(splitRKey, false /* !reverse */)
+		rightRangeDesc, err = scanMeta(splitRKey, false /* reverse */)
 		if err != nil {
 			wrappedMsg = "could not look up right-hand side descriptor"
 			return err

--- a/pkg/sql/limit_opt.go
+++ b/pkg/sql/limit_opt.go
@@ -94,7 +94,7 @@ func applyLimit(plan planNode, numRows int64, soft bool) {
 		if n.needOnlyOneRow {
 			// We have a single MIN/MAX function and the underlying plan's
 			// ordering matches the function. We only need to retrieve one row.
-			applyLimit(n.plan, 1, false /* !soft */)
+			applyLimit(n.plan, 1, false /* soft */)
 		} else {
 			setUnlimited(n.plan)
 		}

--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1159,7 +1159,7 @@ CockroachDB supports the following flags:
 			nullableArgs: true,
 			category:     categoryComparison,
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {
-				return pickFromTuple(ctx, false /* !greatest */, args)
+				return pickFromTuple(ctx, false /* greatest */, args)
 			},
 			Info: "Returns the element with the lowest value.",
 		},

--- a/pkg/storage/abortspan/abortspan.go
+++ b/pkg/storage/abortspan/abortspan.go
@@ -89,7 +89,7 @@ func (sc *AbortSpan) ClearData(e engine.Engine) error {
 	if err != nil {
 		return err
 	}
-	return b.Commit(false /* !sync */)
+	return b.Commit(false /* sync */)
 }
 
 // Get looks up an AbortSpan entry recorded for this transaction ID.
@@ -112,7 +112,7 @@ func (sc *AbortSpan) Iterate(
 	ctx context.Context, e engine.Reader, f func([]byte, roachpb.AbortSpanEntry),
 ) {
 	_, _ = engine.MVCCIterate(ctx, e, sc.min(), sc.max(), hlc.Timestamp{},
-		true /* consistent */, nil /* txn */, false, /* !reverse */
+		true /* consistent */, nil /* txn */, false, /* reverse */
 		func(kv roachpb.KeyValue) (bool, error) {
 			var entry roachpb.AbortSpanEntry
 			if _, err := keys.DecodeAbortSpanKey(kv.Key, nil); err != nil {

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -1158,7 +1158,7 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 				nil, /* replicaStats */
 				c.check,
 				true,  /* checkCandidateFullness */
-				false, /* !alwaysAllowDecisionWithoutStats */
+				false, /* alwaysAllowDecisionWithoutStats */
 			)
 			if c.expected != target.StoreID {
 				t.Fatalf("expected %d, but found %d", c.expected, target.StoreID)
@@ -1212,7 +1212,7 @@ func TestAllocatorTransferLeaseTargetMultiStore(t *testing.T) {
 				nil, /* replicaStats */
 				c.check,
 				true,  /* checkCandidateFullness */
-				false, /* !alwaysAllowDecisionWithoutStats */
+				false, /* alwaysAllowDecisionWithoutStats */
 			)
 			if c.expected != target.StoreID {
 				t.Fatalf("expected %d, but found %d", c.expected, target.StoreID)
@@ -1441,7 +1441,7 @@ func TestAllocatorTransferLeaseTargetLoadBased(t *testing.T) {
 				c.stats,
 				c.check,
 				true,  /* checkCandidateFullness */
-				false, /* !alwaysAllowDecisionWithoutStats */
+				false, /* alwaysAllowDecisionWithoutStats */
 			)
 			if c.expected != target.StoreID {
 				t.Errorf("expected %d, got %d", c.expected, target.StoreID)

--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -297,13 +297,13 @@ func (cq *CommandQueue) expand(c *cmd, isInserted bool) bool {
 
 	tree := cq.tree(c)
 	if isInserted {
-		if err := tree.Delete(c, false /* !fast */); err != nil {
+		if err := tree.Delete(c, false /* fast */); err != nil {
 			panic(err)
 		}
 	}
 	for i := range c.children {
 		child := &c.children[i]
-		if err := tree.Insert(child, false /* !fast */); err != nil {
+		if err := tree.Insert(child, false /* fast */); err != nil {
 			panic(err)
 		}
 	}
@@ -705,11 +705,11 @@ func (cq *CommandQueue) add(
 func (cq *CommandQueue) insertIntoTree(cmd *cmd) {
 	if cq.coveringOptimization || len(cmd.children) == 0 {
 		tree := cq.tree(cmd)
-		if err := tree.Insert(cmd, false /* !fast */); err != nil {
+		if err := tree.Insert(cmd, false /* fast */); err != nil {
 			panic(err)
 		}
 	} else {
-		cq.expand(cmd, false /* !isInserted */)
+		cq.expand(cmd, false /* isInserted */)
 	}
 }
 
@@ -746,7 +746,7 @@ func (cq *CommandQueue) remove(cmd *cmd) {
 	tree := cq.tree(cmd)
 	if !cmd.expanded {
 		n := tree.Len()
-		if err := tree.Delete(cmd, false /* !fast */); err != nil {
+		if err := tree.Delete(cmd, false /* fast */); err != nil {
 			panic(err)
 		}
 		if d := n - tree.Len(); d != 1 {
@@ -759,7 +759,7 @@ func (cq *CommandQueue) remove(cmd *cmd) {
 		for i := range cmd.children {
 			child := &cmd.children[i]
 			n := tree.Len()
-			if err := tree.Delete(child, false /* !fast */); err != nil {
+			if err := tree.Delete(child, false /* fast */); err != nil {
 				panic(err)
 			}
 			if d := n - tree.Len(); d != 1 {

--- a/pkg/storage/command_queue_test.go
+++ b/pkg/storage/command_queue_test.go
@@ -110,7 +110,7 @@ func TestCommandQueueWriteWaitForNonAdjacentRead(t *testing.T) {
 
 	// A write should have to wait for **both** reads, not only the second
 	// one.
-	prereqs := getPrereqs(cq, key, nil, false /* !readOnly */)
+	prereqs := getPrereqs(cq, key, nil, false /* readOnly */)
 
 	// Certainly blocks now.
 	if !checkCmdDoesNotFinish(prereqs) {
@@ -285,7 +285,7 @@ func TestCommandQueueCoveringOptimization(t *testing.T) {
 
 func TestCommandQueueWithoutCoveringOptimization(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	cq := NewCommandQueue(false /* !coveringOptimization */)
+	cq := NewCommandQueue(false /* coveringOptimization */)
 
 	a := roachpb.Span{Key: roachpb.Key("a")}
 	b := roachpb.Span{Key: roachpb.Key("b")}

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -130,7 +130,7 @@ func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Batch
 func TestBatchBasics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	testBatchBasics(t, false /* writeOnly */, func(e Engine, b Batch) error {
-		return b.Commit(false /* !sync */)
+		return b.Commit(false /* sync */)
 	})
 }
 
@@ -283,14 +283,14 @@ func TestBatchRepr(t *testing.T) {
 			t.Fatalf("expected %v, but found %v", expOps, ops)
 		}
 
-		return e.ApplyBatchRepr(repr, false /* !sync */)
+		return e.ApplyBatchRepr(repr, false /* sync */)
 	})
 }
 
 func TestWriteBatchBasics(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	testBatchBasics(t, true /* writeOnly */, func(e Engine, b Batch) error {
-		return b.Commit(false /* !sync */)
+		return b.Commit(false /* sync */)
 	})
 }
 
@@ -316,7 +316,7 @@ func TestApplyBatchRepr(t *testing.T) {
 
 		b2 := e.NewBatch()
 		defer b2.Close()
-		if err := b2.ApplyBatchRepr(repr1, false /* !sync */); err != nil {
+		if err := b2.ApplyBatchRepr(repr1, false /* sync */); err != nil {
 			t.Fatal(err)
 		}
 		repr2 := b2.Repr()
@@ -342,11 +342,11 @@ func TestApplyBatchRepr(t *testing.T) {
 
 		b4 := e.NewBatch()
 		defer b4.Close()
-		if err := b4.ApplyBatchRepr(repr, false /* !sync */); err != nil {
+		if err := b4.ApplyBatchRepr(repr, false /* sync */); err != nil {
 			t.Fatal(err)
 		}
 		// Intentionally don't call Repr() because the expected user wouldn't.
-		if err := b4.Commit(false /* !sync */); err != nil {
+		if err := b4.Commit(false /* sync */); err != nil {
 			t.Fatal(err)
 		}
 
@@ -508,7 +508,7 @@ func TestBatchProto(t *testing.T) {
 		t.Fatalf("expected GetProto to fail ok=%t: %s", ok, err)
 	}
 	// Commit and verify the proto can be read directly from the engine.
-	if err := b.Commit(false /* !sync */); err != nil {
+	if err := b.Commit(false /* sync */); err != nil {
 		t.Fatal(err)
 	}
 	if ok, _, _, err := e.GetProto(mvccKey("proto"), getVal); !ok || err != nil {
@@ -597,7 +597,7 @@ func TestBatchScan(t *testing.T) {
 	}
 
 	// Now, commit batch and re-scan using engine direct to compare results.
-	if err := b.Commit(false /* !sync */); err != nil {
+	if err := b.Commit(false /* sync */); err != nil {
 		t.Fatal(err)
 	}
 	for i, scan := range scans {

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -108,7 +108,7 @@ func setupMVCCData(
 		// sstables.
 		if scaled := len(order) / 20; i > 0 && (i%scaled) == 0 {
 			log.Infof(context.Background(), "committing (%d/~%d)", i/scaled, 20)
-			if err := batch.Commit(false /* !sync */); err != nil {
+			if err := batch.Commit(false /* sync */); err != nil {
 				b.Fatal(err)
 			}
 			batch.Close()
@@ -127,7 +127,7 @@ func setupMVCCData(
 			b.Fatal(err)
 		}
 	}
-	if err := batch.Commit(false /* !sync */); err != nil {
+	if err := batch.Commit(false /* sync */); err != nil {
 		b.Fatal(err)
 	}
 	batch.Close()
@@ -380,7 +380,7 @@ func runMVCCBatchPut(emk engineMaker, valueSize, batchSize int, b *testing.B) {
 			}
 		}
 
-		if err := batch.Commit(false /* !sync */); err != nil {
+		if err := batch.Commit(false /* sync */); err != nil {
 			b.Fatal(err)
 		}
 
@@ -431,7 +431,7 @@ func runMVCCBatchTimeSeries(emk engineMaker, batchSize int, b *testing.B) {
 			}
 		}
 
-		if err := batch.Commit(false /* !sync */); err != nil {
+		if err := batch.Commit(false /* sync */); err != nil {
 			b.Fatal(err)
 		}
 		batch.Close()
@@ -646,7 +646,7 @@ func runBatchApplyBatchRepr(
 		} else {
 			batch = eng.NewBatch()
 		}
-		if err := batch.ApplyBatchRepr(repr, false /* !sync */); err != nil {
+		if err := batch.ApplyBatchRepr(repr, false /* sync */); err != nil {
 			b.Fatal(err)
 		}
 		batch.Close()

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -112,7 +112,7 @@ func TestEngineBatchCommit(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		if err := batch.Commit(false /* !sync */); err != nil {
+		if err := batch.Commit(false /* sync */); err != nil {
 			t.Fatal(err)
 		}
 		close(writesDone)
@@ -319,7 +319,7 @@ func TestEngineBatch(t *testing.T) {
 			}
 			iter.Close()
 			// Commit the batch and try getting the value from the engine.
-			if err := b.Commit(false /* !sync */); err != nil {
+			if err := b.Commit(false /* sync */); err != nil {
 				t.Errorf("%d: %v", i, err)
 				continue
 			}

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1589,7 +1589,7 @@ func MVCCScan(
 	txn *roachpb.Transaction,
 ) ([]roachpb.KeyValue, *roachpb.Span, []roachpb.Intent, error) {
 	return mvccScanInternal(ctx, engine, key, endKey, max, timestamp,
-		consistent, txn, false /* !reverse */)
+		consistent, txn, false /* reverse */)
 }
 
 // MVCCReverseScan scans the key range [start,end) key up to some maximum

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3028,7 +3028,7 @@ func TestValidSplitKeys(t *testing.T) {
 		key   roachpb.Key
 		valid bool
 	}{
-		false /* !allowMeta2Splits */ : {
+		false /* allowMeta2Splits */ : {
 			{roachpb.Key("\x02"), false},
 			{roachpb.Key("\x02\x00"), false},
 			{roachpb.Key("\x02\xff"), false},

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1666,12 +1666,12 @@ func (r *rocksDBIterator) Valid() (bool, error) {
 
 func (r *rocksDBIterator) Next() {
 	r.checkEngineOpen()
-	r.setState(C.DBIterNext(r.iter, false /* !skip_current_key_versions */))
+	r.setState(C.DBIterNext(r.iter, false /* skip_current_key_versions */))
 }
 
 func (r *rocksDBIterator) Prev() {
 	r.checkEngineOpen()
-	r.setState(C.DBIterPrev(r.iter, false /* !skip_current_key_versions */))
+	r.setState(C.DBIterPrev(r.iter, false /* skip_current_key_versions */))
 }
 
 func (r *rocksDBIterator) NextKey() {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -80,7 +80,7 @@ func TestBatchIterReadOwnWrite(t *testing.T) {
 		t.Fatal("uncommitted write seen by non-batch iter")
 	}
 
-	if err := b.Commit(false /* !sync */); err != nil {
+	if err := b.Commit(false /* sync */); err != nil {
 		t.Fatal(err)
 	}
 
@@ -420,7 +420,7 @@ func TestConcurrentBatch(t *testing.T) {
 	// Concurrently write all the batches.
 	for _, batch := range batches {
 		go func(batch Batch) {
-			errChan <- batch.Commit(false /* !sync */)
+			errChan <- batch.Commit(false /* sync */)
 		}(batch)
 	}
 

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -476,7 +476,7 @@ func processLocalKeyRange(
 
 	_, err := engine.MVCCIterate(ctx, snap, startKey, endKey,
 		hlc.Timestamp{}, true /* consistent */, nil, /* txn */
-		false /* !reverse */, func(kv roachpb.KeyValue) (bool, error) {
+		false /* reverse */, func(kv roachpb.KeyValue) (bool, error) {
 			return false, handleOne(kv)
 		})
 	return gcKeys, err

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -652,7 +652,7 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(
 
 	r.cmdQMu.Lock()
 	r.cmdQMu.queues[spanGlobal] = NewCommandQueue(true /* optimizeOverlap */)
-	r.cmdQMu.queues[spanLocal] = NewCommandQueue(false /* !optimizeOverlap */)
+	r.cmdQMu.queues[spanLocal] = NewCommandQueue(false /* optimizeOverlap */)
 	r.cmdQMu.Unlock()
 
 	r.mu.proposals = map[storagebase.CmdIDKey]*ProposalData{}
@@ -3165,7 +3165,7 @@ func defaultSubmitProposalLocked(r *Replica, p *ProposalData) error {
 			// We're proposing a command here so there is no need to wake the
 			// leader if we were quiesced.
 			r.unquiesceLocked()
-			return false, /* !unquiesceAndWakeLeader */
+			return false, /* unquiesceAndWakeLeader */
 				raftGroup.ProposeConfChange(raftpb.ConfChange{
 					Type:    changeTypeInternalToRaft[crt.ChangeType],
 					NodeID:  uint64(crt.Replica.ReplicaID),
@@ -3191,7 +3191,7 @@ func defaultSubmitProposalLocked(r *Replica, p *ProposalData) error {
 		// We're proposing a command so there is no need to wake the leader if we
 		// were quiesced.
 		r.unquiesceLocked()
-		return false /* !unquiesceAndWakeLeader */, raftGroup.Propose(encode(p.idKey, data))
+		return false /* unquiesceAndWakeLeader */, raftGroup.Propose(encode(p.idKey, data))
 	})
 }
 
@@ -3253,7 +3253,7 @@ func (r *Replica) stepRaftGroup(req *RaftMessageRequest) error {
 		if req.Message.Type == raftpb.MsgApp {
 			r.setEstimatedCommitIndexLocked(req.Message.Commit)
 		}
-		return false, /* !unquiesceAndWakeLeader */
+		return false, /* unquiesceAndWakeLeader */
 			raftGroup.Step(req.Message)
 	})
 }
@@ -5540,7 +5540,7 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (config.SystemConfig, er
 	if pErr != nil {
 		return config.SystemConfig{}, pErr.GoError()
 	}
-	if intents := result.Local.detachIntents(false /* !hasError */); len(intents) > 0 {
+	if intents := result.Local.detachIntents(false /* hasError */); len(intents) > 0 {
 		// There were intents, so what we read may not be consistent. Attempt
 		// to nudge the intents in case they're expired; next time around we'll
 		// hopefully have more luck.

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -885,7 +885,7 @@ func evalEndTransaction(
 	// We specify alwaysReturn==false because if the commit fails below Raft, we
 	// don't want the intents to be up for resolution. That should happen only
 	// if the commit actually happens; otherwise, we risk losing writes.
-	intentsResult := intentsToEvalResult(externalIntents, args, false /* !alwaysReturn */)
+	intentsResult := intentsToEvalResult(externalIntents, args, false /* alwaysReturn */)
 	intentsResult.Local.updatedTxn = reply.Txn
 	if err := pd.MergeAndDestroy(intentsResult); err != nil {
 		return EvalResult{}, err
@@ -2030,7 +2030,7 @@ func evalTruncateLog(
 		//
 		// Note that any sideloaded payloads that may be removed by this truncation
 		// don't matter; they're not tracked in the raft log delta.
-		iter := batch.NewIterator(false /* !prefix */)
+		iter := batch.NewIterator(false /* prefix */)
 		defer iter.Close()
 		// We can pass zero as nowNanos because we're only interested in SysBytes.
 		var err error

--- a/pkg/storage/replica_data_iter_test.go
+++ b/pkg/storage/replica_data_iter_test.go
@@ -135,7 +135,7 @@ func TestReplicaDataIteratorEmptyRange(t *testing.T) {
 	newDesc := *tc.repl.Desc()
 	newDesc.RangeID = 125125125
 
-	iter := NewReplicaDataIterator(&newDesc, tc.repl.store.Engine(), false /* !replicatedOnly */)
+	iter := NewReplicaDataIterator(&newDesc, tc.repl.store.Engine(), false /* replicatedOnly */)
 	defer iter.Close()
 	for ; ; iter.Next() {
 		if ok, err := iter.Valid(); err != nil {
@@ -189,7 +189,7 @@ func TestReplicaDataIterator(t *testing.T) {
 	postKeys := createRangeData(t, postRng)
 
 	// Verify the contents of the "b"-"c" range.
-	iter := NewReplicaDataIterator(tc.repl.Desc(), tc.repl.store.Engine(), false /* !replicatedOnly */)
+	iter := NewReplicaDataIterator(tc.repl.Desc(), tc.repl.store.Engine(), false /* replicatedOnly */)
 	defer iter.Close()
 	i := 0
 	for ; ; iter.Next() {
@@ -231,7 +231,7 @@ func TestReplicaDataIterator(t *testing.T) {
 	if err := tc.store.removeReplicaImpl(context.Background(), tc.repl, *tc.repl.Desc(), true); err != nil {
 		t.Fatal(err)
 	}
-	iter = NewReplicaDataIterator(tc.repl.Desc(), tc.repl.store.Engine(), false /* !replicatedOnly */)
+	iter = NewReplicaDataIterator(tc.repl.Desc(), tc.repl.store.Engine(), false /* replicatedOnly */)
 	defer iter.Close()
 	if ok, err := iter.Valid(); err != nil {
 		t.Fatal(err)
@@ -260,7 +260,7 @@ func TestReplicaDataIterator(t *testing.T) {
 		{preRng, preKeys},
 		{postRng, postKeys},
 	} {
-		iter = NewReplicaDataIterator(test.r.Desc(), test.r.store.Engine(), false /* !replicatedOnly */)
+		iter = NewReplicaDataIterator(test.r.Desc(), test.r.store.Engine(), false /* replicatedOnly */)
 		defer iter.Close()
 		i = 0
 		for ; ; iter.Next() {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -795,7 +795,7 @@ func (r *Replica) handleReplicatedEvalResult(
 				end := engine.MakeMVCCMetadataKey(
 					keys.RaftLogKey(r.RangeID, newTruncState.Index).PrefixEnd(),
 				)
-				iter := r.store.Engine().NewIterator(false /* !prefix */)
+				iter := r.store.Engine().NewIterator(false /* prefix */)
 				// Clear the log entries. Intentionally don't use range deletion
 				// tombstones (ClearRange()) due to performance concerns connected
 				// to having many range deletion tombstones. There is a chance that

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -229,7 +229,7 @@ func iterateEntries(
 		hlc.Timestamp{},
 		true,  /* consistent */
 		nil,   /* txn */
-		false, /* !reverse */
+		false, /* reverse */
 		scanFunc,
 	)
 	return err
@@ -484,7 +484,7 @@ func snapshot(
 	// know they cannot be committed yet; operations that modify range
 	// descriptors resolve their own intents when they commit.
 	ok, err := engine.MVCCGetProto(ctx, snap, keys.RangeDescriptorKey(startKey),
-		hlc.MaxTimestamp, false /* !consistent */, nil, &desc)
+		hlc.MaxTimestamp, false /* consistent */, nil, &desc)
 	if err != nil {
 		return OutgoingSnapshot{}, errors.Errorf("failed to get desc: %s", err)
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -707,7 +707,7 @@ func TestLeaseReplicaNotInDesc(t *testing.T) {
 	}
 	tc.repl.mu.Lock()
 	_, _, pErr := tc.repl.checkForcedErrLocked(
-		context.Background(), makeIDKey(), raftCmd, nil /* proposal */, false, /* !proposedLocally */
+		context.Background(), makeIDKey(), raftCmd, nil /* proposal */, false, /* proposedLocally */
 	)
 	tc.repl.mu.Unlock()
 	if _, isErr := pErr.GetDetail().(*roachpb.LeaseRejectedError); !isErr {

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -542,7 +542,7 @@ func (rq *replicateQueue) transferLease(
 		repl.leaseholderStats,
 		opts.checkTransferLeaseSource,
 		opts.checkCandidateFullness,
-		false, /* !alwaysAllowDecisionWithoutStats */
+		false, /* alwaysAllowDecisionWithoutStats */
 	); target != (roachpb.ReplicaDescriptor{}) {
 		rq.metrics.TransferLeaseCount.Inc(1)
 		log.VEventf(ctx, 1, "transferring lease to s%d", target.StoreID)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1046,8 +1046,8 @@ func IterateRangeDescriptors(
 		return fn(desc)
 	}
 
-	_, err := engine.MVCCIterate(ctx, eng, start, end, hlc.MaxTimestamp, false /* !consistent */, nil, /* txn */
-		false /* !reverse */, kvToDesc)
+	_, err := engine.MVCCIterate(ctx, eng, start, end, hlc.MaxTimestamp, false /* consistent */, nil, /* txn */
+		false /* reverse */, kvToDesc)
 	log.Eventf(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
 		allCount, matchCount, bySuffix)
 	return err

--- a/pkg/storage/tscache/cache_impl.go
+++ b/pkg/storage/tscache/cache_impl.go
@@ -587,7 +587,7 @@ func (tc *cacheImpl) ExpandRequests(span roachpb.RSpan, timestamp hlc.Timestamp)
 		}
 		for i := range req.Writes {
 			sp := &req.Writes[i]
-			tc.add(sp.Key, sp.EndKey, req.Timestamp, req.TxnID, false /* !readTSCache */)
+			tc.add(sp.Key, sp.EndKey, req.Timestamp, req.TxnID, false /* readTSCache */)
 		}
 		if req.Txn.Key != nil {
 			// Make the transaction key from the request key. We're guaranteed
@@ -595,7 +595,7 @@ func (tc *cacheImpl) ExpandRequests(span roachpb.RSpan, timestamp hlc.Timestamp)
 			// EndTransactionRequests.
 			key := keys.TransactionKey(req.Txn.Key, req.TxnID)
 			// We set txnID=nil because we want hits for same txn ID.
-			tc.add(key, nil, req.Timestamp, uuid.UUID{}, false /* !readTSCache */)
+			tc.add(key, nil, req.Timestamp, uuid.UUID{}, false /* readTSCache */)
 		}
 		req.release()
 	}

--- a/pkg/util/interval/range_group.go
+++ b/pkg/util/interval/range_group.go
@@ -359,7 +359,7 @@ func (rt *rangeTree) Add(r Range) bool {
 	overlaps := rt.t.Get(r)
 	if len(overlaps) == 0 {
 		key := rt.makeKey(r)
-		if err := rt.t.Insert(&key, false /* !fast */); err != nil {
+		if err := rt.t.Insert(&key, false /* fast */); err != nil {
 			panic(err)
 		}
 		return true

--- a/pkg/util/tracing/shadow.go
+++ b/pkg/util/tracing/shadow.go
@@ -132,7 +132,7 @@ func createZipkinTracer(collectorAddr string) (shadowTracerManager, opentracing.
 	}
 
 	// Create our recorder.
-	recorder := zipkin.NewRecorder(collector, false /* !debug */, "0.0.0.0:0", "cockroach")
+	recorder := zipkin.NewRecorder(collector, false /* debug */, "0.0.0.0:0", "cockroach")
 
 	// Create our tracer.
 	zipkinTr, err := zipkin.NewTracer(recorder)

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -589,7 +589,7 @@ func ChildSpan(ctx context.Context, opName string) (context.Context, opentracing
 		ns := &tr.(*Tracer).noopSpan
 		return opentracing.ContextWithSpan(ctx, ns), ns
 	}
-	newSpan := StartChildSpan(opName, span, false /* !separateRecording */)
+	newSpan := StartChildSpan(opName, span, false /* separateRecording */)
 	return opentracing.ContextWithSpan(ctx, newSpan), newSpan
 }
 


### PR DESCRIPTION
Changing all the f(false /* !foo */) to f(false /* foo */). The inline
comment is supposed to be the name of the argument.