### PR TITLE
server,sql: Refactor distSQLPlanner to only be initialized once

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -552,8 +552,8 @@ func (sc *SchemaChanger) distBackfill(
 			if err != nil {
 				return err
 			}
-			planCtx := sc.distSQLPlanner.NewPlanningCtx(ctx, txn)
-			plan, err := sc.distSQLPlanner.CreateBackfiller(
+			planCtx := sc.distSQLPlanner.newPlanningCtx(ctx, txn)
+			plan, err := sc.distSQLPlanner.createBackfiller(
 				&planCtx, backfillType, *tableDesc, duration, chunkSize, spans, otherTableDescs, sc.readAsOf,
 			)
 			if err != nil {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -836,10 +836,10 @@ func initBackfillerSpec(
 	return ret, nil
 }
 
-// CreateBackfiller generates a plan consisting of index/column backfiller
+// createBackfiller generates a plan consisting of index/column backfiller
 // processors, one for each node that has spans that we are reading. The plan is
 // finalized.
-func (dsp *DistSQLPlanner) CreateBackfiller(
+func (dsp *DistSQLPlanner) createBackfiller(
 	planCtx *planningCtx,
 	backfillType backfillType,
 	desc sqlbase.TableDescriptor,
@@ -1012,7 +1012,7 @@ func (l *DistLoader) LoadCSV(
 	rowContainer := sqlbase.NewRowContainer(*evalCtx.ActiveMemAcc, ci, 0)
 	rowResultWriter := NewRowResultWriter(parser.Rows, rowContainer)
 
-	planCtx := l.distSQLPlanner.NewPlanningCtx(ctx, nil)
+	planCtx := l.distSQLPlanner.newPlanningCtx(ctx, nil)
 	// Because we're not going through the normal pathways, we have to set up
 	// the nodeID -> nodeAddress map ourselves.
 	for _, node := range nodes {
@@ -2376,7 +2376,7 @@ func (dsp *DistSQLPlanner) createPlanForDistinct(
 	return plan, nil
 }
 
-func (dsp *DistSQLPlanner) NewPlanningCtx(ctx context.Context, txn *client.Txn) planningCtx {
+func (dsp *DistSQLPlanner) newPlanningCtx(ctx context.Context, txn *client.Txn) planningCtx {
 	planCtx := planningCtx{
 		ctx:           ctx,
 		spanIter:      dsp.spanResolver.NewSpanResolverIterator(txn),

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -108,7 +108,9 @@ var planMergeJoins = settings.RegisterBoolSetting(
 	true,
 )
 
-func newDistSQLPlanner(
+// NewDistSQLPlanner initializes a DistSQLPlanner
+func NewDistSQLPlanner(
+	ctx context.Context,
 	planVersion distsqlrun.DistSQLVersion,
 	st *cluster.Settings,
 	nodeDesc roachpb.NodeDescriptor,
@@ -119,6 +121,7 @@ func newDistSQLPlanner(
 	stopper *stop.Stopper,
 	testingKnobs DistSQLPlannerTestingKnobs,
 ) *DistSQLPlanner {
+	log.Infof(ctx, "creating DistSQLPlanner with address %s", nodeDesc.Address)
 	dsp := &DistSQLPlanner{
 		planVersion:  planVersion,
 		st:           st,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -44,8 +44,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-//
-// A rough overview of the process:
+// DistSQLPlanner is used to generate distributed plans from logical
+// plans. A rough overview of the process:
 //
 //  - the plan is based on a planNode tree (in the future it will be based on an
 //    intermediate representation tree). Only a subset of the possible trees is
@@ -63,7 +63,7 @@ import (
 //  - for each an internal planNode we start with the plan of the child node(s)
 //    and add processing stages (connected to the result routers of the children
 //    node).
-type distSQLPlanner struct {
+type DistSQLPlanner struct {
 	// planVersion is the version of DistSQL targeted by the plan we're building.
 	// This is currently only assigned to the node's current DistSQL version and
 	// is used to skip incompatible nodes when mapping spans.
@@ -118,8 +118,8 @@ func newDistSQLPlanner(
 	gossip *gossip.Gossip,
 	stopper *stop.Stopper,
 	testingKnobs DistSQLPlannerTestingKnobs,
-) *distSQLPlanner {
-	dsp := &distSQLPlanner{
+) *DistSQLPlanner {
+	dsp := &DistSQLPlanner{
 		planVersion:  planVersion,
 		st:           st,
 		nodeDesc:     nodeDesc,
@@ -135,8 +135,8 @@ func newDistSQLPlanner(
 }
 
 // setSpanResolver switches to a different SpanResolver. It is the caller's
-// responsibility to make sure the distSQLPlanner is not in use.
-func (dsp *distSQLPlanner) setSpanResolver(spanResolver distsqlplan.SpanResolver) {
+// responsibility to make sure the DistSQLPlanner is not in use.
+func (dsp *DistSQLPlanner) setSpanResolver(spanResolver distsqlplan.SpanResolver) {
 	dsp.spanResolver = spanResolver
 }
 
@@ -170,7 +170,7 @@ func (v *distSQLExprCheckVisitor) VisitPost(expr parser.Expr) parser.Expr { retu
 
 // checkExpr verifies that an expression doesn't contain things that are not yet
 // supported by distSQL, like subqueries.
-func (dsp *distSQLPlanner) checkExpr(expr parser.Expr) error {
+func (dsp *DistSQLPlanner) checkExpr(expr parser.Expr) error {
 	if expr == nil {
 		return nil
 	}
@@ -183,7 +183,7 @@ func (dsp *distSQLPlanner) checkExpr(expr parser.Expr) error {
 //  - whether DistSQL is equipped to handle the query (if not, an error is
 //    returned).
 //  - whether it is recommended that the query be run with DistSQL.
-func (dsp *distSQLPlanner) CheckSupport(node planNode) (bool, error) {
+func (dsp *DistSQLPlanner) CheckSupport(node planNode) (bool, error) {
 	rec, err := dsp.checkSupportForNode(node)
 	if err != nil {
 		return false, err
@@ -251,7 +251,7 @@ func leafType(t parser.Type) parser.Type {
 // checkSupportForNode returns a distRecommendation (as described above) or an
 // error if the plan subtree is not supported by DistSQL.
 // TODO(radu): add tests for this.
-func (dsp *distSQLPlanner) checkSupportForNode(node planNode) (distRecommendation, error) {
+func (dsp *DistSQLPlanner) checkSupportForNode(node planNode) (distRecommendation, error) {
 	switch n := node.(type) {
 	case *filterNode:
 		if err := dsp.checkExpr(n.filter); err != nil {
@@ -485,7 +485,7 @@ type spanPartition struct {
 // partitionSpans does its best to not assign ranges on nodes that are known to
 // either be unhealthy or running an incompatible version. The ranges owned by
 // such nodes are assigned to the gateway.
-func (dsp *distSQLPlanner) partitionSpans(
+func (dsp *DistSQLPlanner) partitionSpans(
 	planCtx *planningCtx, spans roachpb.Spans,
 ) ([]spanPartition, error) {
 	if len(spans) == 0 {
@@ -634,7 +634,7 @@ func (dsp *distSQLPlanner) partitionSpans(
 // nodeVersionIsCompatible decides whether a particular node's DistSQL version
 // is compatible with planVer. It uses gossip to find out the node's version
 // range.
-func (dsp *distSQLPlanner) nodeVersionIsCompatible(
+func (dsp *DistSQLPlanner) nodeVersionIsCompatible(
 	nodeID roachpb.NodeID, planVer distsqlrun.DistSQLVersion,
 ) bool {
 	var v distsqlrun.DistSQLVersionGossipInfo
@@ -704,7 +704,7 @@ func getOutputColumnsFromScanNode(n *scanNode) []uint32 {
 
 // convertOrdering maps the columns in ord.ordering to the output columns of a
 // processor.
-func (dsp *distSQLPlanner) convertOrdering(
+func (dsp *DistSQLPlanner) convertOrdering(
 	props physicalProps, planToStreamColMap []int,
 ) distsqlrun.Ordering {
 	if len(props.ordering) == 0 {
@@ -742,7 +742,7 @@ func (dsp *distSQLPlanner) convertOrdering(
 // createTableReaders generates a plan consisting of table reader processors,
 // one for each node that has spans that we are reading.
 // overridesResultColumns is optional.
-func (dsp *distSQLPlanner) createTableReaders(
+func (dsp *DistSQLPlanner) createTableReaders(
 	planCtx *planningCtx, n *scanNode, overrideResultColumns []uint32,
 ) (physicalPlan, error) {
 	spec, post, err := initTableReaderSpec(n)
@@ -839,7 +839,7 @@ func initBackfillerSpec(
 // CreateBackfiller generates a plan consisting of index/column backfiller
 // processors, one for each node that has spans that we are reading. The plan is
 // finalized.
-func (dsp *distSQLPlanner) CreateBackfiller(
+func (dsp *DistSQLPlanner) CreateBackfiller(
 	planCtx *planningCtx,
 	backfillType backfillType,
 	desc sqlbase.TableDescriptor,
@@ -887,7 +887,7 @@ func (dsp *distSQLPlanner) CreateBackfiller(
 // DistLoader uses DistSQL to convert external data formats (csv, etc) into
 // sstables of our mvcc-format key values.
 type DistLoader struct {
-	distSQLPlanner *distSQLPlanner
+	distSQLPlanner *DistSQLPlanner
 }
 
 // RowResultWriter is a thin wrapper around a RowContainer.
@@ -1198,7 +1198,7 @@ func (l *DistLoader) LoadCSV(
 // the select data source (a n.source) and updates it to produce results
 // corresponding to the render node itself. An evaluator stage is added if the
 // render node has any expressions which are not just simple column references.
-func (dsp *distSQLPlanner) selectRenders(p *physicalPlan, n *renderNode) {
+func (dsp *DistSQLPlanner) selectRenders(p *physicalPlan, n *renderNode) {
 	p.AddRendering(n.render, p.planToStreamColMap, getTypesForPlanResult(n, nil))
 
 	// Update p.planToStreamColMap; we will have a simple 1-to-1 mapping of
@@ -1209,7 +1209,7 @@ func (dsp *distSQLPlanner) selectRenders(p *physicalPlan, n *renderNode) {
 
 // addSorters adds sorters corresponding to a sortNode and updates the plan to
 // reflect the sort node.
-func (dsp *distSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
+func (dsp *DistSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
 
 	matchLen := planPhysicalProps(n.plan).computeMatch(n.ordering)
 
@@ -1278,7 +1278,7 @@ func (dsp *distSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
 //        therefore k just passes through unchanged.
 //    All other expressions simply pass through unchanged, for e.g. '1' in
 //    'SELECT 1 GROUP BY k'.
-func (dsp *distSQLPlanner) addAggregators(
+func (dsp *DistSQLPlanner) addAggregators(
 	planCtx *planningCtx, p *physicalPlan, n *groupNode,
 ) error {
 	aggregations := make([]distsqlrun.AggregatorSpec_Aggregation, len(n.funcs))
@@ -1760,7 +1760,7 @@ func (dsp *distSQLPlanner) addAggregators(
 	return nil
 }
 
-func (dsp *distSQLPlanner) createPlanForIndexJoin(
+func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 	planCtx *planningCtx, n *indexJoinNode,
 ) (physicalPlan, error) {
 	priCols := make([]uint32, len(n.index.desc.PrimaryIndex.ColumnIDs))
@@ -1864,7 +1864,7 @@ func getTypesForPlanResult(node planNode, planToStreamColMap []int) []sqlbase.Co
 	return types
 }
 
-func (dsp *distSQLPlanner) createPlanForJoin(
+func (dsp *DistSQLPlanner) createPlanForJoin(
 	planCtx *planningCtx, n *joinNode,
 ) (physicalPlan, error) {
 
@@ -2187,7 +2187,7 @@ func (dsp *distSQLPlanner) createPlanForJoin(
 	return p, nil
 }
 
-func (dsp *distSQLPlanner) createPlanForNode(
+func (dsp *DistSQLPlanner) createPlanForNode(
 	planCtx *planningCtx, node planNode,
 ) (physicalPlan, error) {
 	switch n := node.(type) {
@@ -2264,7 +2264,7 @@ func (dsp *distSQLPlanner) createPlanForNode(
 	}
 }
 
-func (dsp *distSQLPlanner) createPlanForValues(
+func (dsp *DistSQLPlanner) createPlanForValues(
 	planCtx *planningCtx, n *valuesNode,
 ) (physicalPlan, error) {
 	columns := len(n.columns)
@@ -2332,7 +2332,7 @@ func (dsp *distSQLPlanner) createPlanForValues(
 	}, nil
 }
 
-func (dsp *distSQLPlanner) createPlanForDistinct(
+func (dsp *DistSQLPlanner) createPlanForDistinct(
 	planCtx *planningCtx, n *distinctNode,
 ) (physicalPlan, error) {
 	plan, err := dsp.createPlanForNode(planCtx, n.plan)
@@ -2376,7 +2376,7 @@ func (dsp *distSQLPlanner) createPlanForDistinct(
 	return plan, nil
 }
 
-func (dsp *distSQLPlanner) NewPlanningCtx(ctx context.Context, txn *client.Txn) planningCtx {
+func (dsp *DistSQLPlanner) NewPlanningCtx(ctx context.Context, txn *client.Txn) planningCtx {
 	planCtx := planningCtx{
 		ctx:           ctx,
 		spanIter:      dsp.spanResolver.NewSpanResolverIterator(txn),
@@ -2388,7 +2388,7 @@ func (dsp *distSQLPlanner) NewPlanningCtx(ctx context.Context, txn *client.Txn) 
 
 // FinalizePlan adds a final "result" stage if necessary and populates the
 // endpoints of the plan.
-func (dsp *distSQLPlanner) FinalizePlan(planCtx *planningCtx, plan *physicalPlan) {
+func (dsp *DistSQLPlanner) FinalizePlan(planCtx *planningCtx, plan *physicalPlan) {
 	thisNodeID := dsp.nodeDesc.NodeID
 	// If we don't already have a single result router on this node, add a final
 	// stage.

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -721,7 +721,7 @@ func TestPartitionSpans(t *testing.T) {
 	}
 
 	// We need a mock Gossip to contain addresses for the nodes. Otherwise the
-	// distSQLPlanner will not plan flows on them.
+	// DistSQLPlanner will not plan flows on them.
 	testStopper := stop.NewStopper()
 	defer testStopper.Stop(context.TODO())
 	mockGossip := gossip.NewTest(roachpb.NodeID(1), nil /* rpcContext */, nil, /* grpcServer */
@@ -760,7 +760,7 @@ func TestPartitionSpans(t *testing.T) {
 				ranges: tc.ranges,
 			}
 
-			dsp := distSQLPlanner{
+			dsp := DistSQLPlanner{
 				planVersion:  distsqlrun.Version,
 				st:           cluster.MakeTestingClusterSettings(),
 				nodeDesc:     *tsp.nodes[tc.gatewayNode-1],
@@ -906,7 +906,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 			defer stopper.Stop(context.TODO())
 
 			// We need a mock Gossip to contain addresses for the nodes. Otherwise the
-			// distSQLPlanner will not plan flows on them. This Gossip will also
+			// DistSQLPlanner will not plan flows on them. This Gossip will also
 			// reflect tc.nodesNotAdvertisingDistSQLVersion.
 			testStopper := stop.NewStopper()
 			defer testStopper.Stop(context.TODO())
@@ -940,7 +940,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				ranges: ranges,
 			}
 
-			dsp := distSQLPlanner{
+			dsp := DistSQLPlanner{
 				planVersion:  tc.planVersion,
 				st:           cluster.MakeTestingClusterSettings(),
 				nodeDesc:     *tsp.nodes[gatewayNode-1],
@@ -1031,7 +1031,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		ranges: ranges,
 	}
 
-	dsp := distSQLPlanner{
+	dsp := DistSQLPlanner{
 		planVersion:  distsqlrun.Version,
 		st:           cluster.MakeTestingClusterSettings(),
 		nodeDesc:     *tsp.nodes[gatewayNode-1],

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -779,7 +779,7 @@ func TestPartitionSpans(t *testing.T) {
 				},
 			}
 
-			planCtx := dsp.NewPlanningCtx(context.Background(), nil /* txn */)
+			planCtx := dsp.newPlanningCtx(context.Background(), nil /* txn */)
 			var spans []roachpb.Span
 			for _, s := range tc.spans {
 				spans = append(spans, roachpb.Span{Key: roachpb.Key(s[0]), EndKey: roachpb.Key(s[1])})
@@ -955,7 +955,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				},
 			}
 
-			planCtx := dsp.NewPlanningCtx(context.Background(), nil /* txn */)
+			planCtx := dsp.newPlanningCtx(context.Background(), nil /* txn */)
 			partitions, err := dsp.partitionSpans(&planCtx, roachpb.Spans{span})
 			if err != nil {
 				t.Fatal(err)
@@ -1046,7 +1046,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		},
 	}
 
-	planCtx := dsp.NewPlanningCtx(context.Background(), nil /* txn */)
+	planCtx := dsp.newPlanningCtx(context.Background(), nil /* txn */)
 	partitions, err := dsp.partitionSpans(&planCtx, roachpb.Spans{span})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -439,7 +439,7 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 	recv *distSQLReceiver,
 	evalCtx parser.EvalContext,
 ) error {
-	planCtx := dsp.NewPlanningCtx(ctx, txn)
+	planCtx := dsp.newPlanningCtx(ctx, txn)
 
 	log.VEvent(ctx, 1, "creating DistSQL plan")
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -74,7 +74,7 @@ func (req runnerRequest) run() {
 	req.resultChan <- res
 }
 
-func (dsp *distSQLPlanner) initRunners() {
+func (dsp *DistSQLPlanner) initRunners() {
 	// This channel has to be unbuffered because we want to only be able to send
 	// requests if a worker is actually there to receive them.
 	dsp.runnerChan = make(chan runnerRequest)
@@ -104,7 +104,7 @@ func (dsp *distSQLPlanner) initRunners() {
 // reported to recv instead of being returned (see the flow.Start() call for the
 // local flow). Perhaps we should push all errors to recv and have this function
 // not return anything.
-func (dsp *distSQLPlanner) Run(
+func (dsp *DistSQLPlanner) Run(
 	planCtx *planningCtx,
 	txn *client.Txn,
 	plan *physicalPlan,
@@ -432,7 +432,7 @@ func (r *distSQLReceiver) updateCaches(ctx context.Context, ranges []roachpb.Ran
 //
 // Note that errors that happen while actually running the flow are reported to
 // recv, not returned by this function.
-func (dsp *distSQLPlanner) PlanAndRun(
+func (dsp *DistSQLPlanner) PlanAndRun(
 	ctx context.Context,
 	txn *client.Txn,
 	tree planNode,

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -400,23 +400,12 @@ func NewExecutor(cfg ExecutorConfig, stopper *stop.Stopper) *Executor {
 	}
 }
 
-// Start starts workers for the executor and initializes the DistSQLPlanner.
+// Start starts workers for the executor.
 func (e *Executor) Start(
-	ctx context.Context, startupMemMetrics *MemoryMetrics, nodeDesc roachpb.NodeDescriptor,
+	ctx context.Context, startupMemMetrics *MemoryMetrics, dsp *DistSQLPlanner,
 ) {
 	ctx = e.AnnotateCtx(ctx)
-	log.Infof(ctx, "creating DistSQLPlanner with address %s", nodeDesc.Address)
-	e.distSQLPlanner = newDistSQLPlanner(
-		distsqlrun.Version,
-		e.cfg.Settings,
-		nodeDesc,
-		e.cfg.RPCContext,
-		e.cfg.DistSQLSrv,
-		e.cfg.DistSender,
-		e.cfg.Gossip,
-		e.stopper,
-		e.cfg.TestingKnobs.DistSQLPlannerKnobs,
-	)
+	e.distSQLPlanner = dsp
 
 	e.databaseCache.Store(newDatabaseCache(e.systemConfig))
 	e.systemConfigCond = sync.NewCond(&e.systemConfigMu)

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -238,7 +238,7 @@ type Executor struct {
 	systemConfigMu   syncutil.Mutex
 	systemConfigCond *sync.Cond
 
-	distSQLPlanner *distSQLPlanner
+	distSQLPlanner *DistSQLPlanner
 
 	// Application-level SQL statistics
 	sqlStats sqlStats
@@ -342,7 +342,7 @@ type ExecutorTestingKnobs struct {
 	// execution so there'll be nothing left to abort by the time the filter runs.
 	DisableAutoCommit bool
 
-	// DistSQLPlannerKnobs are testing knobs for distSQLPlanner.
+	// DistSQLPlannerKnobs are testing knobs for DistSQLPlanner.
 	DistSQLPlannerKnobs DistSQLPlannerTestingKnobs
 
 	// BeforeAutoCommit is called when the Executor is about to commit the KV
@@ -359,7 +359,7 @@ type ExecutorTestingKnobs struct {
 	BeforeAutoCommit func(ctx context.Context, stmt string) error
 }
 
-// DistSQLPlannerTestingKnobs is used to control internals of the distSQLPlanner
+// DistSQLPlannerTestingKnobs is used to control internals of the DistSQLPlanner
 // for testing purposes.
 type DistSQLPlannerTestingKnobs struct {
 	// If OverrideSQLHealthCheck is set, we use this callback to get the health of
@@ -400,12 +400,12 @@ func NewExecutor(cfg ExecutorConfig, stopper *stop.Stopper) *Executor {
 	}
 }
 
-// Start starts workers for the executor and initializes the distSQLPlanner.
+// Start starts workers for the executor and initializes the DistSQLPlanner.
 func (e *Executor) Start(
 	ctx context.Context, startupMemMetrics *MemoryMetrics, nodeDesc roachpb.NodeDescriptor,
 ) {
 	ctx = e.AnnotateCtx(ctx)
-	log.Infof(ctx, "creating distSQLPlanner with address %s", nodeDesc.Address)
+	log.Infof(ctx, "creating DistSQLPlanner with address %s", nodeDesc.Address)
 	e.distSQLPlanner = newDistSQLPlanner(
 		distsqlrun.Version,
 		e.cfg.Settings,

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -156,7 +156,7 @@ type explainDistSQLNode struct {
 	optColumnsSlot
 
 	plan           planNode
-	distSQLPlanner *distSQLPlanner
+	distSQLPlanner *DistSQLPlanner
 
 	// txn is the current transaction (used for the fake span resolver).
 	txn *client.Txn

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -187,7 +187,7 @@ func (n *explainDistSQLNode) Start(params runParams) error {
 		return err
 	}
 
-	planCtx := n.distSQLPlanner.NewPlanningCtx(params.ctx, n.txn)
+	planCtx := n.distSQLPlanner.newPlanningCtx(params.ctx, n.txn)
 	plan, err := n.distSQLPlanner.createPlanForNode(&planCtx, n.plan)
 	if err != nil {
 		return err

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -191,7 +191,7 @@ func (p *planner) EvalContext() parser.EvalContext {
 }
 
 // TODO(dan): This is here to implement PlanHookState, but it's not clear that
-// this is the right abstraction. We could also export distSQLPlanner, for
+// this is the right abstraction. We could also export DistSQLPlanner, for
 // example. Revisit.
 func (p *planner) DistLoader() *DistLoader {
 	return &DistLoader{distSQLPlanner: p.session.distSQLPlanner}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -919,6 +919,7 @@ func NewSchemaChangeManager(
 	leaseMgr *LeaseManager,
 	clock *hlc.Clock,
 	jobRegistry *jobs.Registry,
+	dsp *DistSQLPlanner,
 ) *SchemaChangeManager {
 	return &SchemaChangeManager{
 		db:             db,
@@ -926,21 +927,9 @@ func NewSchemaChangeManager(
 		leaseMgr:       leaseMgr,
 		testingKnobs:   testingKnobs,
 		schemaChangers: make(map[sqlbase.ID]SchemaChanger),
-		// TODO(radu): investigate using the same distSQLPlanner from the executor.
-		distSQLPlanner: newDistSQLPlanner(
-			distsqlrun.Version,
-			st,
-			nodeDesc,
-			rpcContext,
-			distSQLServ,
-			distSender,
-			gossip,
-			leaseMgr.stopper,
-			// TODO(radu): pass these knobs
-			DistSQLPlannerTestingKnobs{},
-		),
-		jobRegistry: jobRegistry,
-		clock:       clock,
+		distSQLPlanner: dsp,
+		jobRegistry:    jobRegistry,
+		clock:          clock,
 	}
 }
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -63,7 +63,7 @@ type SchemaChanger struct {
 	execAfter      time.Time
 	readAsOf       hlc.Timestamp
 	testingKnobs   *SchemaChangerTestingKnobs
-	distSQLPlanner *distSQLPlanner
+	distSQLPlanner *DistSQLPlanner
 	jobRegistry    *jobs.Registry
 	job            *jobs.Job
 }
@@ -901,7 +901,7 @@ type SchemaChangeManager struct {
 	testingKnobs *SchemaChangerTestingKnobs
 	// Create a schema changer for every outstanding schema change seen.
 	schemaChangers map[sqlbase.ID]SchemaChanger
-	distSQLPlanner *distSQLPlanner
+	distSQLPlanner *DistSQLPlanner
 	clock          *hlc.Clock
 	jobRegistry    *jobs.Registry
 }

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -256,7 +256,7 @@ type Session struct {
 	execCfg *ExecutorConfig
 	// distSQLPlanner is in charge of distSQL physical planning and running
 	// logic.
-	distSQLPlanner *distSQLPlanner
+	distSQLPlanner *DistSQLPlanner
 	// context is the Session's base context, to be used for all
 	// SQL-related logging. See Ctx().
 	context context.Context


### PR DESCRIPTION
This changes DistSQLPlanner to be exported. This will let us initialize a single DistSQLPlanner in pkg/server.

Note that a few methods on DistSQLPlanner were unexported as they don't escape pkg/sql. These exported methods are used outside of the file they're defined, but not out of the packaged.


This also refactors distSQLPlanner to only be initialized once. This moves distSQLPlanner initialization out from the SchemaChangeManager and Executor to instead use a shared instance initialized in Server.Start.

---
The first commit just renames things. @RaduBerinde thoughts on this? I'm not about our export/non-exported conventions as this does unexport a few functions that are called outside the definition file.