### PR TITLE
storage: use RangeList instead of RangeTree in CommandQueue

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -240,8 +240,8 @@ func NewCommandQueue(coveringOptimization bool) *CommandQueue {
 		readsBuffer:          make(map[*cmd]struct{}),
 		reads:                interval.NewTree(interval.ExclusiveOverlapper),
 		writes:               interval.NewTree(interval.ExclusiveOverlapper),
-		wRg:                  interval.NewRangeTree(),
-		rwRg:                 interval.NewRangeTree(),
+		wRg:                  interval.NewRangeList(),
+		rwRg:                 interval.NewRangeList(),
 		coveringOptimization: coveringOptimization,
 	}
 	return cq


### PR DESCRIPTION
Closes #19345.
Extracted from #19361.

This needs more experimentation, but I've done some testing on `kv` and
`tpcc`. I wasn't able to see the `RangeGroup` on profiles before or
after on `tpcc`.

On `kv` with `cycle-length=5` the change seemed to improve average latency
by about 4%. Again though, I wasn't able to reproduce the `RangeCache`
blowup on profiles for the before or after testing.

I'd like to see the effect it has on the Premier benchmarks.

cc. @asubiotto 