### PR TITLE
config: split subzones

### DIFF
--- a/pkg/config/system_test.go
+++ b/pkg/config/system_test.go
@@ -176,17 +176,11 @@ func TestGetLargestID(t *testing.T) {
 func TestStaticSplits(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	for i := range config.StaticSplits {
-		if config.StaticSplits[i].SplitKey.Less(config.StaticSplits[i].SplitPoint) {
-			t.Errorf("SplitKey %q should not be less than SplitPoint %q",
-				config.StaticSplits[i].SplitKey, config.StaticSplits[i].SplitPoint)
-		}
-		if i == 0 {
-			continue
-		}
-		if !config.StaticSplits[i-1].SplitKey.Less(config.StaticSplits[i].SplitPoint) {
+	splits := config.StaticSplits()
+	for i := 1; i < len(splits); i++ {
+		if !splits[i-1].Less(splits[i]) {
 			t.Errorf("previous SplitKey %q should be less than next SplitPoint %q",
-				config.StaticSplits[i-1].SplitKey, config.StaticSplits[i].SplitPoint)
+				splits[i-1], splits[i])
 		}
 	}
 }


### PR DESCRIPTION
As described in the partitioning RFC, teach the config package how to
split subzones stored in a ZoneConfig. In the interest of minimizing
review burden, this commit does not introduce any codepaths outside of
tests that create ZoneConfigs with subzones.

Also do some cleanup work while I'm in the area.