### PR TITLE
sql: remove traceKV from RowFetcher.NextRowDecoded

### DIFF
--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -197,7 +197,7 @@ func (cb *columnBackfiller) runChunk(
 		b := txn.NewBatch()
 		rowLength := 0
 		for i := int64(0); i < chunkSize; i++ {
-			row, err := cb.fetcher.NextRowDecoded(ctx, false /* traceKV */)
+			row, err := cb.fetcher.NextRowDecoded(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -177,7 +177,7 @@ func (n *scanNode) Next(params runParams) (bool, error) {
 	// We fetch one row at a time until we find one that passes the filter.
 	for n.hardLimit == 0 || n.rowIndex < n.hardLimit {
 		var err error
-		n.row, err = n.fetcher.NextRowDecoded(params.ctx, n.p.session.Tracing.KVTracingEnabled())
+		n.row, err = n.fetcher.NextRowDecoded(params.ctx)
 		if err != nil || n.row == nil {
 			return false, err
 		}

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -285,7 +285,7 @@ func ConvertBatchError(ctx context.Context, tableDesc *TableDescriptor, b *clien
 		if err := rf.StartScanFrom(ctx, &f); err != nil {
 			return err
 		}
-		decodedVals, err := rf.NextRowDecoded(ctx, false /* traceKV */)
+		decodedVals, err := rf.NextRowDecoded(ctx)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -604,7 +604,7 @@ func (rf *RowFetcher) NextRow(ctx context.Context) (EncDatumRow, error) {
 // NextRowDecoded calls NextRow and decodes the EncDatumRow into a Datums.
 // The Datums should not be modified and is only valid until the next call.
 // When there are no more rows, the Datums is nil.
-func (rf *RowFetcher) NextRowDecoded(ctx context.Context, traceKV bool) (parser.Datums, error) {
+func (rf *RowFetcher) NextRowDecoded(ctx context.Context) (parser.Datums, error) {
 	encRow, err := rf.NextRow(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -581,7 +581,7 @@ func (tu *tableUpserter) fetchExisting(ctx context.Context, traceKV bool) ([]par
 
 	rows := make([]parser.Datums, len(primaryKeys))
 	for {
-		row, err := tu.fetcher.NextRowDecoded(ctx, traceKV)
+		row, err := tu.fetcher.NextRowDecoded(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -822,7 +822,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 	}
 
 	for i := int64(0); i < limit; i++ {
-		row, err := rf.NextRowDecoded(ctx, traceKV)
+		row, err := rf.NextRowDecoded(ctx)
 		if err != nil {
 			return resume, err
 		}
@@ -910,7 +910,7 @@ func (td *tableDeleter) deleteIndexScan(
 	}
 
 	for i := int64(0); i < limit; i++ {
-		row, err := rf.NextRowDecoded(ctx, traceKV)
+		row, err := rf.NextRowDecoded(ctx)
 		if err != nil {
 			return resume, err
 		}


### PR DESCRIPTION
This is unused in the function, and is non-idiomatic since traceKV is
set when initializing RowFetcher.