### PR TITLE
sql: fresh planners for queries run by virt tbls

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -374,6 +374,8 @@ CREATE TABLE crdb_internal.jobs (
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...parser.Datum) error) error {
+		p = makeInternalPlanner("jobs", p.txn, p.evalCtx.User, p.session.memMetrics)
+		defer finishInternalPlanner(p)
 		rows, err := p.queryRows(ctx, `SELECT id, status, created, payload FROM system.jobs`)
 		if err != nil {
 			return err
@@ -1442,6 +1444,8 @@ CREATE TABLE crdb_internal.zones (
 			return 0, "", fmt.Errorf("object with ID %d does not exist", id)
 		}
 
+		p = makeInternalPlanner("zones", p.txn, p.evalCtx.User, p.session.memMetrics)
+		defer finishInternalPlanner(p)
 		rows, err := p.queryRows(ctx, `SELECT id, config FROM system.zones`)
 		if err != nil {
 			return err

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -866,8 +866,10 @@ func forEachColumnInIndex(
 	return nil
 }
 
-func forEachUser(ctx context.Context, p *planner, fn func(username string) error) error {
+func forEachUser(ctx context.Context, origPlanner *planner, fn func(username string) error) error {
 	query := `SELECT username FROM system.users`
+	p := makeInternalPlanner("for-each-user", origPlanner.txn, security.RootUser, origPlanner.session.memMetrics)
+	defer finishInternalPlanner(p)
 	plan, err := p.query(ctx, query)
 	if err != nil {
 		return nil


### PR DESCRIPTION
forEachUser, crdb_internal.zones and crdb_internal.jobs previously ran
their `SELECT` statements using the planner that invoked it. This is
dangerous, since running plans can modify their associated planners.

Switch to creating a fresh internal planner for the queries, which is the
pattern that we use almost everywhere else for internal queries.