### PR TITLE
sqlccl: cleanup failed or canceled RESTORE data

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -1153,6 +1153,56 @@ func doRestorePlan(
 	return nil
 }
 
+func loadBackupSQLDescs(
+	ctx context.Context, details jobs.RestoreDetails, settings *cluster.Settings,
+) ([]BackupDescriptor, []sqlbase.Descriptor, error) {
+	backupDescs, err := loadBackupDescs(ctx, details.URIs, settings)
+	if err != nil {
+		return nil, nil, err
+	}
+	lastBackupDesc := backupDescs[len(backupDescs)-1]
+
+	var sqlDescs []sqlbase.Descriptor
+	for _, desc := range lastBackupDesc.Descriptors {
+		if _, ok := details.TableRewrites[desc.GetID()]; ok {
+			sqlDescs = append(sqlDescs, desc)
+		}
+	}
+	return backupDescs, sqlDescs, nil
+}
+
+// restoreFailHook removes KV data that has been committed from a restore that
+// has failed or been canceled. It does this by adding the table descriptors
+// in DROP state, which causes the schema change stuff to delete the keys
+// in the background.
+func restoreFailHook(
+	ctx context.Context, txn *client.Txn, settings *cluster.Settings, details *jobs.RestoreDetails,
+) error {
+	// Needed to trigger the schema change manager.
+	if err := txn.SetSystemConfigTrigger(); err != nil {
+		return err
+	}
+	_, sqlDescs, err := loadBackupSQLDescs(ctx, *details, settings)
+	if err != nil {
+		return err
+	}
+	var tables []*sqlbase.TableDescriptor
+	for _, desc := range sqlDescs {
+		if tableDesc := desc.GetTable(); tableDesc != nil {
+			tableDesc.State = sqlbase.TableDescriptor_DROP
+			tables = append(tables, tableDesc)
+		}
+	}
+	if err := rewriteTableDescs(tables, details.TableRewrites); err != nil {
+		return err
+	}
+	b := txn.NewBatch()
+	for _, desc := range tables {
+		b.CPut(sqlbase.MakeDescMetadataKey(desc.ID), sqlbase.WrapDescriptor(desc), nil)
+	}
+	return txn.Run(ctx, b)
+}
+
 func restoreResumeHook(
 	typ jobs.Type, settings *cluster.Settings,
 ) func(ctx context.Context, job *jobs.Job) error {
@@ -1163,17 +1213,9 @@ func restoreResumeHook(
 	return func(ctx context.Context, job *jobs.Job) error {
 		details := job.Record.Details.(jobs.RestoreDetails)
 
-		backupDescs, err := loadBackupDescs(ctx, details.URIs, settings)
+		backupDescs, sqlDescs, err := loadBackupSQLDescs(ctx, details, settings)
 		if err != nil {
 			return err
-		}
-		lastBackupDesc := backupDescs[len(backupDescs)-1]
-
-		var sqlDescs []sqlbase.Descriptor
-		for _, desc := range lastBackupDesc.Descriptors {
-			if _, ok := details.TableRewrites[desc.GetID()]; ok {
-				sqlDescs = append(sqlDescs, desc)
-			}
 		}
 
 		_, err = restore(
@@ -1193,4 +1235,5 @@ func restoreResumeHook(
 func init() {
 	sql.AddPlanHook(restorePlanHook)
 	jobs.AddResumeHook(restoreResumeHook)
+	jobs.RestoreFailHook = restoreFailHook
 }

--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -154,7 +155,7 @@ func (j *Job) Created(ctx context.Context, cancelFn func()) error {
 
 // Started marks the tracked job as started.
 func (j *Job) Started(ctx context.Context) error {
-	return j.update(ctx, func(status *Status, payload *Payload) (bool, error) {
+	return j.update(ctx, func(_ *client.Txn, status *Status, payload *Payload) (bool, error) {
 		if *status != StatusPending {
 			// Already started - do nothing.
 			return false, nil
@@ -187,7 +188,7 @@ func (j *Job) Progressed(
 			fractionCompleted, j.id,
 		)
 	}
-	return j.update(ctx, func(status *Status, payload *Payload) (bool, error) {
+	return j.update(ctx, func(_ *client.Txn, status *Status, payload *Payload) (bool, error) {
 		if *status != StatusRunning {
 			return false, &InvalidStatusError{*j.id, *status, "update progress on"}
 		}
@@ -224,7 +225,7 @@ func isControllable(p *Payload, op string) error {
 // pause the job; instead, it expects the job to call job.Progressed soon,
 // observe a "job is paused" error, and abort further work.
 func (j *Job) Paused(ctx context.Context) error {
-	return j.update(ctx, func(status *Status, payload *Payload) (bool, error) {
+	return j.update(ctx, func(_ *client.Txn, status *Status, payload *Payload) (bool, error) {
 		if err := isControllable(payload, "PAUSE"); err != nil {
 			return false, err
 		}
@@ -244,7 +245,7 @@ func (j *Job) Paused(ctx context.Context) error {
 // currently paused. It does not directly resume the job; rather, it expires the
 // job's lease so that a Registry adoption loop detects it and resumes it.
 func (j *Job) Resumed(ctx context.Context) error {
-	return j.update(ctx, func(status *Status, payload *Payload) (bool, error) {
+	return j.update(ctx, func(_ *client.Txn, status *Status, payload *Payload) (bool, error) {
 		if *status == StatusRunning {
 			// Already resumed - do nothing.
 			return false, nil
@@ -264,7 +265,7 @@ func (j *Job) Resumed(ctx context.Context) error {
 // cancel the job; like job.Paused, it expects the job to call job.Progressed
 // soon, observe a "job is canceled" error, and abort further work.
 func (j *Job) Canceled(ctx context.Context) error {
-	return j.update(ctx, func(status *Status, payload *Payload) (bool, error) {
+	return j.update(ctx, func(txn *client.Txn, status *Status, payload *Payload) (bool, error) {
 		if err := isControllable(payload, "CANCEL"); err != nil {
 			return false, err
 		}
@@ -276,6 +277,11 @@ func (j *Job) Canceled(ctx context.Context) error {
 			return false, fmt.Errorf("job with status %s cannot be canceled", *status)
 		}
 		*status = StatusCanceled
+		if onfail, ok := payload.Details.(onFailer); ok {
+			if err := onfail.onFail(ctx, txn, j); err != nil {
+				return false, err
+			}
+		}
 		payload.FinishedMicros = timeutil.ToUnixMicros(timeutil.Now())
 		return true, nil
 	})
@@ -291,12 +297,17 @@ func (j *Job) Failed(ctx context.Context, err error) {
 	if j.id == nil {
 		return
 	}
-	internalErr := j.update(ctx, func(status *Status, payload *Payload) (bool, error) {
+	internalErr := j.update(ctx, func(txn *client.Txn, status *Status, payload *Payload) (bool, error) {
 		if status.Terminal() {
 			// Already done - do nothing.
 			return false, nil
 		}
 		*status = StatusFailed
+		if onfail, ok := payload.Details.(onFailer); ok {
+			if err := onfail.onFail(ctx, txn, j); err != nil {
+				return false, err
+			}
+		}
 		payload.Error = err.Error()
 		payload.FinishedMicros = timeutil.ToUnixMicros(timeutil.Now())
 		return true, nil
@@ -308,11 +319,30 @@ func (j *Job) Failed(ctx context.Context, err error) {
 	j.registry.unregister(*j.id)
 }
 
+type onFailer interface {
+	onFail(context.Context, *client.Txn, *Job) error
+}
+
+var _ onFailer = &Payload_Restore{}
+
+// RestoreFailHook is the func that is run when a RESTORE job has failed.
+var RestoreFailHook func(context.Context, *client.Txn, *cluster.Settings, *RestoreDetails) error
+
+func (r *Payload_Restore) onFail(ctx context.Context, txn *client.Txn, job *Job) error {
+	// This is set in the CCL package if RESTOREs are enabled, and so should
+	// always be non-nil. However the jobs tests exercise this without importing
+	// the CCL package, so we do need the test.
+	if RestoreFailHook != nil {
+		return RestoreFailHook(ctx, txn, job.registry.settings, r.Restore)
+	}
+	return nil
+}
+
 // Succeeded marks the tracked job as having succeeded and sets its fraction
 // completed to 1.0.
 func (j *Job) Succeeded(ctx context.Context) error {
 	defer j.registry.unregister(*j.id)
-	return j.update(ctx, func(status *Status, payload *Payload) (bool, error) {
+	return j.update(ctx, func(_ *client.Txn, status *Status, payload *Payload) (bool, error) {
 		if status.Terminal() {
 			// Already done - do nothing.
 			return false, nil
@@ -380,7 +410,7 @@ func (j *Job) FinishedWith(ctx context.Context, err error) error {
 
 // SetDetails sets the details field of the currently running tracked job.
 func (j *Job) SetDetails(ctx context.Context, details interface{}) error {
-	return j.update(ctx, func(_ *Status, payload *Payload) (bool, error) {
+	return j.update(ctx, func(_ *client.Txn, _ *Status, payload *Payload) (bool, error) {
 		payload.Details = WrapPayloadDetails(details)
 		return true, nil
 	})
@@ -494,7 +524,7 @@ func (j *Job) insert(ctx context.Context, payload *Payload) error {
 }
 
 func (j *Job) update(
-	ctx context.Context, updateFn func(*Status, *Payload) (doUpdate bool, err error),
+	ctx context.Context, updateFn func(*client.Txn, *Status, *Payload) (doUpdate bool, err error),
 ) error {
 	if j.id == nil {
 		return errors.New("Job: cannot update: job not created")
@@ -517,7 +547,7 @@ func (j *Job) update(
 			return err
 		}
 
-		doUpdate, err := updateFn(&status, payload)
+		doUpdate, err := updateFn(txn, &status, payload)
 		if err != nil {
 			return err
 		}
@@ -554,7 +584,7 @@ func (j *Job) update(
 }
 
 func (j *Job) adopt(ctx context.Context, oldLease *Lease) error {
-	return j.update(ctx, func(status *Status, payload *Payload) (bool, error) {
+	return j.update(ctx, func(_ *client.Txn, status *Status, payload *Payload) (bool, error) {
 		if *status != StatusRunning {
 			return false, errors.Errorf("job %d no longer running", *j.id)
 		}


### PR DESCRIPTION
Previously, if a RESTORE failed or was manually canceled, any data
it had committed would have been orphaned, and forever taken up
space. Since there was no table descriptor, nothing would have been
able to see or delete it.

Add optional callbacks in jobs code to allow for specific jobs
to implement an onFail method. Add the job's client.Txn to the
update method and this onFail callback to allow for a job to be
transactionally failed and cleaned up.

Release note: Cleanup partially restored data when a RESTORE fails
or is canceled.

Fixes #19398
Fixes #17123

@vivekmenezes could you review the table drop stuff in restore.go?