### PR TITLE
scripts: fix gceworker

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -19,6 +19,6 @@ echo '. ~/.bashrc_go' >> ~/.bashrc
 
 mkdir -p "$GOPATH/src/github.com/cockroachdb"
 
-git clone https://github.com/cockroachdb/cockroach.git "$GOPATH/src/github.com/cockroachdb/cockroach"
+git clone --recursive https://github.com/cockroachdb/cockroach.git "$GOPATH/src/github.com/cockroachdb/cockroach"
 
 . bootstrap/bootstrap-go.sh


### PR DESCRIPTION
bootstrap-debian.sh does not build cockroach out of the box without a
git submodule update --init. Fix the git clone to recursively clone
submodules so that make works after running bootstrap-debian.sh.