### PR TITLE
acceptance: test rapid restarts and early queries

### DIFF
--- a/pkg/acceptance/cluster/testconfig.proto
+++ b/pkg/acceptance/cluster/testconfig.proto
@@ -53,6 +53,4 @@ message TestConfig {
   // tests such as TestPut that will run indefinitely.
   optional int64 duration = 3 [(gogoproto.nullable) = false, (gogoproto.casttype) = "time.Duration"];
   optional InitMode init_mode = 4 [(gogoproto.nullable) = false];
-
-  // TODO(bram): #4559 once defined, add in a collection of chaos agents here.
 }

--- a/pkg/acceptance/localcluster/localcluster.go
+++ b/pkg/acceptance/localcluster/localcluster.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"os/exec"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -73,7 +74,7 @@ func (b *LocalCluster) AssertAndStop(ctx context.Context, t testing.TB) {
 
 // ExecCLI implements cluster.Cluster.
 func (b *LocalCluster) ExecCLI(ctx context.Context, i int, cmd []string) (string, string, error) {
-	cmd = append([]string{b.cfg.Binary}, cmd...)
+	cmd = append([]string{b.Cfg.Binary}, cmd...)
 	cmd = append(cmd, "--insecure", "--port", b.Port(ctx, i))
 	c := exec.CommandContext(ctx, cmd[0], cmd[1:]...)
 	var o, e bytes.Buffer
@@ -95,7 +96,37 @@ func (b *LocalCluster) Kill(ctx context.Context, i int) error {
 // once the node is successfully connected to the cluster and serving, nil.
 func (b *LocalCluster) RestartAsync(ctx context.Context, i int) <-chan error {
 	b.Nodes[i].Kill()
-	return b.Nodes[i].StartAsync(ctx, b.joins()...)
+	joins := b.joins()
+	ch := b.Nodes[i].StartAsync(ctx, joins...)
+	if len(joins) == 0 && len(b.Nodes) > 1 {
+		// This blocking loop in is counter-intuitive but is essential in allowing
+		// restarts of whole clusters. Roughly the following happens:
+		//
+		// 1. The whole cluster gets killed.
+		// 2. A node restarts.
+		// 3. It will *block* here until it has written down the file which contains
+		//    enough information to link other nodes.
+		// 4. When restarting other nodes, and `.joins()` is passed in, these nodes
+		//    can connect (at least) to the first node.
+		// 5. the cluster can become healthy after restart.
+		//
+		// If we didn't block here, we'd start all nodes up with join addresses that
+		// don't make any sense, and the cluster would likely not become connected.
+		//
+		// An additional difficulty is that older versions (pre 1.1) don't write
+		// this file. That's why we let *every* node do this (you could try to make
+		// only the first one wait, but if that one is 1.0, bad luck).
+		// Short-circuiting the wait in the case that the listening URL file is
+		// written (i.e. isServing closes) makes restarts work with 1.0 servers for
+		// the most part.
+		for {
+			if gossipAddr := b.Nodes[i].AdvertiseAddr(); gossipAddr != "" {
+				return ch
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	return ch
 }
 
 // Restart implements cluster.Cluster.
@@ -105,12 +136,16 @@ func (b *LocalCluster) Restart(ctx context.Context, i int) error {
 
 // URL implements cluster.Cluster.
 func (b *LocalCluster) URL(ctx context.Context, i int) string {
-	return "http://" + b.Addr(ctx, i, b.HTTPPort(i))
+	rest := b.Nodes[i].HTTPAddr()
+	if rest == "" {
+		return ""
+	}
+	return "http://" + rest
 }
 
 // Addr implements cluster.Cluster.
 func (b *LocalCluster) Addr(ctx context.Context, i int, port string) string {
-	return net.JoinHostPort(b.IPAddr(i), port)
+	return net.JoinHostPort(b.Nodes[i].AdvertiseAddr(), port)
 }
 
 // Hostname implements cluster.Cluster.

--- a/pkg/acceptance/rapid_restart_test.go
+++ b/pkg/acceptance/rapid_restart_test.go
@@ -1,0 +1,158 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package acceptance
+
+import (
+	"math/rand"
+	"net/http"
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
+	"github.com/cockroachdb/cockroach/pkg/acceptance/localcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func TestRapidRestarts(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	ctx := context.Background()
+	cfg := readConfigFromFlags()
+	RunLocal(t, func(t *testing.T) {
+		deadline := timeutil.Now().Add(cfg.Duration)
+		// In a loop, bootstrap a new node and immediately kill it. This is more
+		// effective at finding problems that restarting an existing node since
+		// there are more moving parts the first time around. Since there could be
+		// future issues that only occur on a restart, each invocation of the test
+		// also restart-kills the existing node once.
+		for timeutil.Now().Before(deadline) {
+			testRapidRestartSingle(ctx, t, cfg)
+		}
+	})
+}
+
+func unexpectedExitCode(exitErr *exec.ExitError) error {
+	if exitErr == nil {
+		// Server shut down cleanly. Note that returning `err` here would create
+		// an error interface wrapping a nil *ExitError, which is *not* nil
+		// itself.
+		return nil
+	}
+	// NB: the docs suggest[1] that there are platform-independent types, but an
+	// inspection shows that at the time of writing, everything seems to return a
+	// syscall.WaitStatus.
+	//
+	// [1]: https://golang.org/pkg/os/#ProcessState.Sys
+	s, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return errors.Wrapf(exitErr, "unsupported architecture: %T", exitErr.Sys())
+	}
+	status := s.ExitStatus()
+	switch status {
+	case -1:
+		// Received SIGINT before setting up our own signal handlers.
+	case 1:
+		// Exit code from a SIGINT received by our signal handlers.
+	default:
+		return errors.Wrapf(exitErr, "unexpected exit status %d", status)
+	}
+	return nil
+}
+
+func testRapidRestartSingle(ctx context.Context, t *testing.T, cfg cluster.TestConfig) {
+	// Make this a single-node cluster which unlocks optimizations in
+	// LocalCluster that skip all the waiting so that we get to kill the process
+	// early in its boot sequence.
+	cfg.Nodes = cfg.Nodes[:1]
+
+	c := StartCluster(ctx, t, cfg)
+	defer c.AssertAndStop(ctx, t)
+
+	lc := c.(*localcluster.LocalCluster)
+
+	interrupt := func() {
+		t.Helper()
+		time.Sleep(time.Duration(rand.Int63n(int64(time.Second))))
+		lc.Nodes[0].Signal(os.Interrupt)
+	}
+
+	check := func() {
+		t.Helper()
+		if err := unexpectedExitCode(lc.Nodes[0].Wait()); err != nil {
+			lc.Cfg.Ephemeral = false // keep log dir
+			t.Fatalf("node did not terminate cleanly: %v", err)
+		}
+	}
+
+	const count = 2
+	// NB: the use of Group makes no sense with count=2, but this way you can
+	// bump it and the whole thing still works.
+	var g errgroup.Group
+
+	getVars := func(ch <-chan error) func() error {
+		return func() error {
+			for {
+				base := c.URL(ctx, 0)
+				if base != "" {
+					// Torture the prometheus endpoint to prevent regression of #19559.
+					const varsEndpoint = "/_status/vars"
+					resp, err := cluster.HTTPClient.Get(base + varsEndpoint)
+					if err == nil {
+						if resp.StatusCode != http.StatusNotFound && resp.StatusCode != http.StatusOK {
+							return errors.Errorf("unexpected status code from %s: %d", varsEndpoint, resp.StatusCode)
+						}
+					}
+				}
+				select {
+				case err := <-ch:
+					return err
+				default:
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}
+	}
+	closedCh := make(chan error)
+	close(closedCh)
+
+	for i := 0; i < count; i++ {
+		g.Go(getVars(closedCh))
+
+		if i > 0 {
+			ch := lc.RestartAsync(ctx, 0)
+			g.Go(getVars(ch))
+		}
+
+		log.Info(ctx, "interrupting node")
+		interrupt()
+
+		log.Info(ctx, "waiting for exit code")
+		check()
+	}
+
+	if err := g.Wait(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/acceptance/status_server_test.go
+++ b/pkg/acceptance/status_server_test.go
@@ -98,6 +98,8 @@ func checkNode(
 		get(ctx, t, c.URL(ctx, i), fmt.Sprintf("/_status/logs/%s", urlID))
 		get(ctx, t, c.URL(ctx, i), fmt.Sprintf("/_status/stacks/%s", urlID))
 	}
+
+	get(ctx, t, c.URL(ctx, i), "/_status/vars")
 }
 
 // TestStatusServer starts up an N node cluster and tests the status server on

--- a/pkg/acceptance/util_cluster.go
+++ b/pkg/acceptance/util_cluster.go
@@ -187,7 +187,9 @@ func StartCluster(ctx context.Context, t *testing.T, cfg cluster.TestConfig) (c 
 		}
 	}
 
-	if cfg.InitMode != cluster.INIT_NONE {
+	// Don't bother waiting for a single-node cluster. This is useful for
+	// TestRapidRestarts which wants to kill the process early.
+	if len(cfg.Nodes) > 1 && cfg.InitMode != cluster.INIT_NONE {
 		wantedReplicas := 3
 		if numNodes := c.NumNodes(); numNodes < wantedReplicas {
 			wantedReplicas = numNodes
@@ -196,7 +198,6 @@ func StartCluster(ctx context.Context, t *testing.T, cfg cluster.TestConfig) (c 
 		// Looks silly, but we actually start zero-node clusters in the
 		// reference tests.
 		if wantedReplicas > 0 {
-
 			log.Infof(ctx, "waiting for first range to have %d replicas", wantedReplicas)
 
 			testutils.SucceedsSoon(t, func() error {

--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -66,6 +66,7 @@ func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfi
 
 	// Verify that the nodes are *really* at the versions configured. This
 	// tests the CI harness.
+	log.Info(ctx, "verifying that configured versions are actual versions")
 	for i := 0; i < c.NumNodes(); i++ {
 		db, err := gosql.Open("postgres", c.PGUrl(ctx, i))
 		if err != nil {
@@ -110,11 +111,11 @@ func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfi
 	}
 
 	lc := c.(*localcluster.LocalCluster)
-	// Upgrade the first node's binary to match the other nodes (i.e. the testing binary).
+	log.Info(ctx, "upgrading the first node's binary to match the other nodes (i.e. the testing binary)")
 	lc.Nodes[0].Cfg.ExtraArgs[0] = lc.Nodes[1].Cfg.ExtraArgs[0]
 
 	var chs []<-chan error
-	// Restart the nodes asynchronously.
+	log.Info(ctx, "restarting the nodes asynchronously")
 	for i := 0; i < c.NumNodes(); i++ {
 		chs = append(chs, lc.RestartAsync(ctx, i))
 	}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -653,6 +653,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	var returnErr error
 
+	stopWithoutDrain := make(chan struct{}) // closed if interrupted very early
+
 	// Block until one of the signals above is received or the stopper
 	// is stopped externally (for example, via the quit endpoint).
 	select {
@@ -693,12 +695,18 @@ func runStart(cmd *cobra.Command, args []string) error {
 			serverStatusMu.draining = true
 			drainingIsSafe := serverStatusMu.started
 			serverStatusMu.Unlock()
-			if drainingIsSafe {
-				if _, err := s.Drain(server.GracefulDrainModes); err != nil {
-					// Don't use shutdownCtx because this is in a goroutine that may
-					// still be running after shutdownCtx's span has been finished.
-					log.Warning(context.Background(), err)
-				}
+
+			// drainingIsSafe may have been set in the meantime, but that's ok.
+			// In the worst case, we're not draining a Server that has *just*
+			// started. Not desirable, but not terrible either.
+			if !drainingIsSafe {
+				close(stopWithoutDrain)
+				return
+			}
+			if _, err := s.Drain(server.GracefulDrainModes); err != nil {
+				// Don't use shutdownCtx because this is in a goroutine that may
+				// still be running after shutdownCtx's span has been finished.
+				log.Warning(context.Background(), err)
 			}
 			stopper.Stop(context.Background())
 		}()
@@ -716,6 +724,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 			case <-ticker.C:
 				log.Infof(context.Background(), "%d running tasks", stopper.NumTasks())
 			case <-stopper.ShouldStop():
+				return
+			case <-stopWithoutDrain:
 				return
 			}
 		}
@@ -742,6 +752,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 		// NB: we do not return here to go through log.Flush below.
 	case <-stopper.IsStopped():
 		const msgDone = "server drained and shutdown completed"
+		log.Infof(shutdownCtx, msgDone)
+		fmt.Fprintln(os.Stdout, msgDone)
+	case <-stopWithoutDrain:
+		const msgDone = "too early to drain; used hard shutdown instead"
 		log.Infof(shutdownCtx, msgDone)
 		fmt.Fprintln(os.Stdout, msgDone)
 	}


### PR DESCRIPTION
See #19559, #19579, #19571 for issues touched by this test (all of which
it reproduced before the preceding commits fixed them).

The changes here (outside of the test) ensure that a single-node instance starts
as quickly as possible, without waiting for ports to be ready or for replication
to have occurred. This was done to remove any additional delay in
`TestRapidRestarts` that could otherwise obscur bugs (for example, consider that
going through `./cockroach quit` was not able to tickle any of the bugs).

I was also tempted to "bump" the version upgrade tests to use 1.1 instead of 1.0
since that would have removed a bunch of cruft (since 1.0 doesn't write its
listener files), but I decided against that. As a result, some of the new
accessors look a little unclean, but they should straighten themselves out once
we only rely on listener files.