### PR TITLE
sql: introduce MakeJSON

### DIFF
--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -1953,6 +1953,22 @@ func ParseDJSON(s string) (Datum, error) {
 	return &DJSON{j}, nil
 }
 
+// MakeDJSON returns a JSON value given a Go-style representation of JSON.
+// * JSON null is Go `nil`,
+// * JSON true is Go `true`,
+// * JSON false is Go `false`,
+// * JSON numbers are json.Number | int | int64 | float64,
+// * JSON string is a Go string,
+// * JSON array is a Go []interface{},
+// * JSON object is a Go map[string]interface{}.
+func MakeDJSON(d interface{}) (Datum, error) {
+	j, err := json.MakeJSON(d)
+	if err != nil {
+		return nil, err
+	}
+	return &DJSON{j}, nil
+}
+
 // ResolvedType implements the TypedExpr interface.
 func (*DJSON) ResolvedType() Type {
 	return TypeJSON

--- a/pkg/sql/parser/datum_test.go
+++ b/pkg/sql/parser/datum_test.go
@@ -451,3 +451,17 @@ func TestParseDTimestamp(t *testing.T) {
 		}
 	}
 }
+
+func TestMakeDJSON(t *testing.T) {
+	j1, err := MakeDJSON(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	j2, err := MakeDJSON(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j1.Compare(NewTestingEvalContext(), j2) != -1 {
+		t.Fatal("expected JSON 1 < 2")
+	}
+}

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -15,6 +15,7 @@
 package json
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -195,6 +196,40 @@ func TestJSONSize(t *testing.T) {
 			}
 			if j.Size() != tc.size {
 				t.Fatalf("expected %v to have size %d, but had size %d", j, tc.size, j.Size())
+			}
+		})
+	}
+}
+
+func TestMakeJSON(t *testing.T) {
+	testCases := []struct {
+		input    interface{}
+		expected string
+	}{
+		// These tests are limited because they only really need to exercise the
+		// parts not exercised by the ParseJSON tests - that is, those involving
+		// int/int64/float64.
+		{json.Number("1.00"), "1.00"},
+		{1, "1"},
+		{int64(1), "1"},
+		{1.4, "1.4"},
+		{map[string]interface{}{"foo": 4}, `{"foo": 4}`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.expected, func(t *testing.T) {
+			result, err := MakeJSON(tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expectedResult, err := ParseJSON(tc.expected)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if result.Compare(expectedResult) != 0 {
+				t.Fatalf("expected %v to equal %v", result, expectedResult)
 			}
 		})
 	}


### PR DESCRIPTION
It occurred to me today that people using JSON for various purposes
within Cockroach will need a way to construct JSON objects, and it will
be a pain to construct the structs literally because 1. the object keys
need to be sorted, and 2. we want to be able to change the
representation (at least for the time being).

This commit adjusts interpretDJSON to rename it to MakeDJSON, export it
from the parser package, have a more usable API, and include tests.