### PR TITLE
 storage: minor tweaks to temporary disabling of incoming preemptive snapshots

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -918,8 +918,8 @@ func (m *multiTestContext) restartStoreWithoutHeartbeat(i int) {
 
 	// Normally, the newly restarted store would not be able to accept rebalances
 	// until the election timeout passed. But we're using a manual clock which
-	// won't advance the time properly, so manually enable rebalances.
-	m.stores[i].SetRebalancesDisabled(false)
+	// won't advance the time properly, so manually enable incoming rebalances.
+	m.stores[i].SetIncomingRebalancesDisabled(false)
 }
 
 // restartStore restarts a store previously stopped with StopStore.

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -186,12 +186,12 @@ func (s *Store) GetOrCreateReplica(
 	return s.getOrCreateReplica(ctx, rangeID, replicaID, creatingReplica)
 }
 
-func (s *Store) SetRebalancesDisabled(v bool) {
+func (s *Store) SetIncomingRebalancesDisabled(v bool) {
 	var i int32
 	if v {
 		i = 1
 	}
-	atomic.StoreInt32(&s.rebalancesDisabled, i)
+	atomic.StoreInt32(&s.incomingRebalancesDisabled, i)
 }
 
 // EnqueueRaftUpdateCheck enqueues the replica for a Raft update check, forcing

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1096,6 +1096,10 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 // getEstimatedBehindCountRLocked returns an estimate of how far this replica is
 // behind. A return value of 0 indicates that the replica is up to date.
 func (r *Replica) getEstimatedBehindCountRLocked(raftStatus *raft.Status) int64 {
+	if !r.isInitializedRLocked() || r.mu.replicaID == 0 || r.mu.destroyed != nil {
+		// The range is either not fully initialized or has been destroyed.
+		return 0
+	}
 	if r.mu.quiescent {
 		// The range is quiescent, so it is up to date.
 		return 0

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -622,7 +622,7 @@ func (rq *replicateQueue) purgatoryChan() <-chan struct{} {
 // the replicas.
 func rangeRaftProgress(raftStatus *raft.Status, replicas []roachpb.ReplicaDescriptor) string {
 	if raftStatus == nil || len(raftStatus.Progress) == 0 {
-		return ""
+		return "[raft progress unknown]"
 	}
 	var buf bytes.Buffer
 	buf.WriteString("[")


### PR DESCRIPTION
Also do a minor rename to make the variable/log message clearer. Intended to help debug #19010. The failures I'm seeing on my gceworker are very different from what teamcity has been running into lately, so try to get a little more info out of the teamcity runs.

The second commit *might* be a fix for #19010, but it's hard to say without being able to reproduce it locally.

The third commit is only tangentially related in that I ran into it while debugging the same problem. It just makes certain log messages more understandable without needing to refer back to the source code.