### PR TITLE
sqlccl: fix RESTORE of INCREMENTAL after dropping a table

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -543,12 +543,12 @@ rangeLoop:
 				}
 			}
 		}
-		if ts != maxEndTime {
-			return nil, hlc.Timestamp{}, errors.Errorf(
-				"no backup covers time [%s,%s) for range [%s,%s) (or backups out of order)",
-				ts, maxEndTime, roachpb.Key(importRange.Start), roachpb.Key(importRange.End))
-		}
 		if needed {
+			if ts != maxEndTime {
+				return nil, hlc.Timestamp{}, errors.Errorf(
+					"no backup covers time [%s,%s) for range [%s,%s) (or backups out of order)",
+					ts, maxEndTime, roachpb.Key(importRange.Start), roachpb.Key(importRange.End))
+			}
 			// If needed is false, we have data backed up that is not necessary
 			// for this restore. Skip it.
 			requestEntries = append(requestEntries, importEntry{


### PR DESCRIPTION
This adds tests for the DROP and TRUNCATE cases.

Also, extend the handling of dropped tables during restore:

If a table was dropped between t1 and t2, it isn’t actually required that a backup of the state at time t2 include the span for that table.

However our checking of the span coverage was requiring that all spans in the backup match the desired time bounds, even those that were not required by the requested restore. This changes that enforcement to be limited to required spans.

This error would only occur when attempting to RESTORE that backup or in later attempts to create additional incremental backups on top of it : the initial backup, that stops including the span, would succeed, as it validates its _previous_ backups.

NB: for ’revision_history’ backups, this is still broken — unlike a latest backup, which is free to not include the span of the dropped table, a ‘revision_history’ backup *does* need to include that span,
to allow time travel to before the DROP. Tracked in #19600.