### PR TITLE
[DO NOT MERGE] storage: benchmark difference between purego and cgo iteration

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1110,6 +1110,11 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	s.sqlExecutor.Start(ctx, &s.adminMemMetrics, distSQLPlanner)
 	s.distSQLServer.Start()
 
+	if len(s.engines) > 1 {
+		panic("use only one engine")
+	}
+	s.distSQLServer.ServerConfig.Engine = s.engines[0]
+
 	atomic.StoreInt32(&s.serveNonGossip, 1)
 
 	log.Infof(ctx, "starting %s server at %s", s.cfg.HTTPRequestScheme(), unresolvedHTTPAddr)

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -53,6 +53,9 @@ type FlowCtx struct {
 
 	Settings *cluster.Settings
 
+	// Used for testing.
+	Engine engine.Engine
+
 	stopper *stop.Stopper
 
 	// id is a unique identifier for a flow.

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -97,6 +97,8 @@ var settingWorkMemBytes = settings.RegisterByteSizeSetting(
 
 var noteworthyMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NOTEWORTHY_DISTSQL_MEMORY_USAGE", 1024*1024 /* 1MB */)
 
+var scanLayer = settings.RegisterStringSetting("scan_layer", "rocksdb, kvfetcher, or rowfetcher", "")
+
 // ServerConfig encompasses the configuration required to create a
 // DistSQLServer.
 type ServerConfig struct {
@@ -136,6 +138,8 @@ type ServerConfig struct {
 
 	// A handle to gossip used to broadcast the node's DistSQL version.
 	Gossip *gossip.Gossip
+
+	Engine engine.Engine
 }
 
 // ServerImpl implements the server for the distributed SQL APIs.
@@ -279,6 +283,7 @@ func (ds *ServerImpl) setupFlow(
 	// txnProto).
 	flowCtx := FlowCtx{
 		Settings:       ds.Settings,
+		Engine:         ds.ServerConfig.Engine,
 		AmbientContext: ds.AmbientContext,
 		stopper:        ds.Stopper,
 		id:             req.Flow.FlowID,

--- a/pkg/sql/sqlbase/kvfetcher.go
+++ b/pkg/sql/sqlbase/kvfetcher.go
@@ -238,6 +238,7 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	// Reset spans in preparation for adding resume-spans below.
 	f.spans = f.spans[:0]
 
+	// Here we send a BatchRequest.
 	br, err := f.txn.Send(ctx, ba)
 	if err != nil {
 		return err.GoError()
@@ -280,6 +281,10 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	// call to fetch(). We can use a pool of workers to issue the KV ops which will also limit the
 	// total number of fetches that happen in parallel (and thus the amount of resources we use).
 	return nil
+}
+
+func (f *txnKVFetcher) NextKV(ctx context.Context) (bool, roachpb.KeyValue, error) {
+	return f.nextKV(ctx)
 }
 
 // nextKV returns the next key/value (initiating fetches as necessary). When

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -102,6 +102,9 @@ type RowFetcher struct {
 	keyRemainingBytes []byte
 	kvEnd             bool
 
+	Debug             bool
+	DebugBytesFetched int
+
 	// Buffered allocation of decoded datums.
 	alloc *DatumAlloc
 }
@@ -263,6 +266,10 @@ func (rf *RowFetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 		rf.kvEnd = !ok
 		if rf.kvEnd {
 			return true, nil
+		}
+
+		if rf.Debug {
+			rf.DebugBytesFetched += len(rf.kv.Key) + len(rf.kv.Value.RawBytes)
 		}
 
 		// See Init() for a detailed description of when we can get away with not
@@ -644,6 +651,10 @@ func (rf *RowFetcher) finalizeRow() {
 // Key returns nil when there are no more rows.
 func (rf *RowFetcher) Key() roachpb.Key {
 	return rf.kv.Key
+}
+
+func (rf *RowFetcher) KVFetcher() *txnKVFetcher {
+	return rf.kvFetcher.(*txnKVFetcher)
 }
 
 // GetRangeInfo returns information about the ranges where the rows came from.


### PR DESCRIPTION
NOTE: All numbers collected on a one-node cluster running on my laptop.

While investigating `COUNT(*)` performance (https://github.com/cockroachdb/cockroach/issues/19288), the throughput of various layers was measured (fb05b62) while performing `SELECT COUNT(*) FROM tpch.lineitem`. The throughput found for the `rocksdb` layer (which is simple iteration over the keys/values in `tpch.lineitem`) reported `~95MB/s`. This was a long way off from the `~500MB/s` measured through [`BenchmarkMVCCComputeStats_RocksDB`](https://github.com/cockroachdb/cockroach/blob/03a829c5f069a75a351edef36fe255055e73a6b1/pkg/storage/engine/bench_rocksdb_test.go#L75). The difference between these two iterations is that for the first one, we cross the cgo boundary once for every key/value pair while we only cross the cgo boundary once while computing stats, as the iteration is done in C++.

This warranted further investigation, so we set about measuring the cgo overhead by ingesting a `tpch.lineitem` sst and reading it with a `leveldb` pure go iteration and our normal `rocksdb` iteration (included in this PR), and got a pretty noticeable difference (the size of a key/value pair is `~200` bytes):
```
$ benchstat cgo purego
name             old time/op    new time/op     delta
MVCCIteration-8     511ms ± 4%      139ms ± 2%   -72.84%  (p=0.000 n=19+18)

name             old speed      new speed       delta
MVCCIteration-8  47.8MB/s ± 4%  176.2MB/s ± 2%  +268.82%  (p=0.000 n=20+18)
```
Although the purego iteration doesn't hit the `500MB/s` number, the throughput really depends on the size of the keys so is not comparable (for example, here is a run with an sst file where each key/value was `~700 bytes`):
```
BenchmarkMVCCIteration/Cgo-4         30      38456904 ns/op    1093.95 MB/s
BenchmarkMVCCIteration/Purego-4      50      27323478 ns/op    1539.69 MB/s
```
By moving our iteration at the MVCCScan level into C++, we could reduce our cgo overhead for scans and increase the throughput by a significant amount.
@arjunravinarayan @petermattis @jordanlewis @bdarnell @nvanbenschoten 