### PR TITLE
build: check out submodules before `go install`

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -19,6 +19,6 @@ echo '. ~/.bashrc_go' >> ~/.bashrc
 
 mkdir -p "$GOPATH/src/github.com/cockroachdb"
 
-git clone --recursive https://github.com/cockroachdb/cockroach.git "$GOPATH/src/github.com/cockroachdb/cockroach"
+git clone https://github.com/cockroachdb/cockroach.git "$GOPATH/src/github.com/cockroachdb/cockroach"
 
 . bootstrap/bootstrap-go.sh

--- a/build/common.mk
+++ b/build/common.mk
@@ -168,10 +168,7 @@ BOOTSTRAP_TARGET := $(LOCAL_BIN)/.bootstrap
 
 # Update the git hooks and install commands from dependencies whenever they
 # change.
-$(BOOTSTRAP_TARGET): $(GITHOOKS) $(REPO_ROOT)/Gopkg.lock $(LOCAL_BIN)/returncheck
-ifneq ($(GIT_DIR),)
-	git submodule update --init
-endif
+$(BOOTSTRAP_TARGET): $(GITHOOKS) $(REPO_ROOT)/Gopkg.lock $(LOCAL_BIN)/returncheck | submodules
 	@$(GO_INSTALL) -v \
 		$(REPO_ROOT)/vendor/github.com/golang/dep/cmd/dep \
 		$(REPO_ROOT)/vendor/github.com/client9/misspell/cmd/misspell \
@@ -190,6 +187,12 @@ endif
 		$(REPO_ROOT)/vendor/golang.org/x/tools/cmd/goyacc \
 		$(REPO_ROOT)/vendor/golang.org/x/tools/cmd/stringer
 	touch $@
+
+.PHONY: submodules
+submodules:
+ifneq ($(GIT_DIR),)
+	git submodule update --init
+endif
 
 # Make doesn't expose a list of the variables declared in a given file, so we
 # resort to sed magic. Roughly, this sed command prints VARIABLE in lines of the
@@ -469,5 +472,5 @@ unsafe-clean-c-deps:
 	git -C $(SNAPPY_SRC_DIR)   clean -dxf
 
 .SECONDEXPANSION:
-$(LOCAL_BIN)/%: $$(shell find $(PKG_ROOT)/cmd/$$*)
+$(LOCAL_BIN)/%: $$(shell find $(PKG_ROOT)/cmd/$$*) | submodules
 	@$(GO_INSTALL) -v $(PKG_ROOT)/cmd/$*


### PR DESCRIPTION
I accidentally broke this ordering in #19527: submodules must be checked
out before we run `go install`. Fixing this eliminates the need for a
recursive clone in bootstrap-debian, which was added by #19581 as a
workaround. (Avoiding the recursive clone in bootstrap-debian means
someone will realize if the Makefile breaks again.)