### PR TITLE
distsql: omit unused renders during planning

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_expr
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_expr
@@ -1,14 +1,17 @@
 # LogicTest: default distsql
 
 statement ok
-CREATE TABLE t (c int PRIMARY KEY);
+CREATE TABLE t (c int PRIMARY KEY)
 
 statement ok
-INSERT INTO t VALUES (1), (2), (3);
+INSERT INTO t VALUES (1), (2), (3)
 
 # Verify we serialize the negative constant correctly (see #15617).
 query I rowsort
-SELECT c FROM t WHERE (c, c) > (2, -9223372036854775808);
+SELECT c FROM t WHERE (c, c) > (2, -9223372036854775808)
 ----
 2
 3
+
+statement ok
+CREATE TABLE ab (a int PRIMARY KEY, b int)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -271,3 +271,23 @@ SELECT y, str, REPEAT('test', y) FROM NumToStr ORDER BY str
 # Verify we use the "top K" strategy and thus don't hit OOM as above.
 statement ok
 SELECT y, str, REPEAT('test', y) FROM NumToStr ORDER BY str LIMIT 10
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumToSquare)
+----
+0  render  ·         ·                    (x)                                      x!=NULL; key(x)
+0  ·       render 0  x                    ·                                        ·
+1  render  ·         ·                    (x, "2 * x"[omitted], "x + 1"[omitted])  x!=NULL; key(x)
+1  ·       render 0  test.numtosquare.x   ·                                        ·
+1  ·       render 1  NULL                 ·                                        ·
+1  ·       render 2  NULL                 ·                                        ·
+2  scan    ·         ·                    (x, xsquared[omitted])                   x!=NULL; key(x)
+2  ·       table     numtosquare@primary  ·                                        ·
+2  ·       spans     ALL                  ·                                        ·
+
+# Verifies that unused renders don't cause us to do rendering instead of a
+# simple projection.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumToSquare)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJyMj7FqAzEQRPt8RZhaha9V5dZNHEy6cIVyGszBnfayu4IEo38PPhUhRcDlzEjvsTcUyXxJKw3xHQPGgE1lopnoveoPTvkL8RAwl636vR4DJlEi3uCzL0TEW_pYeGHKVARkepqXHbrpvCb9Ppa6uthnTUoEnKvH5-OAsQVI9V-ueboScWjhcfeFtkkx_hH_Rz60MYD5yn6fSdWJryrTrunxvP_bi0zzvg49nEqf2tiefgIAAP__QLRrHw==


### PR DESCRIPTION
Omitting unused renders when doing distsql planning for renderNodes.

In practice, the unused renders usually get projected out; but having them
there initially causes the planning process to use renders instead of a
projection. For example, without this change the plan for the new test case
shows `Render: @1` instead of `Out: @1`.