### PR TITLE
cli: add "debug synctest" command

### DIFF
--- a/c-deps/libroach/batch.cc
+++ b/c-deps/libroach/batch.cc
@@ -411,6 +411,7 @@ class DBBatchInserter : public rocksdb::WriteBatch::Handler {
     }
     return rocksdb::Status::InvalidArgument("DeleteRangeCF not implemented");
   }
+  virtual void LogData(const rocksdb::Slice& blob) { batch_->PutLogData(blob); }
 
  private:
   rocksdb::WriteBatchBase* const batch_;

--- a/pkg/cli/synctest/synctest.go
+++ b/pkg/cli/synctest/synctest.go
@@ -1,0 +1,224 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package synctest
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/signal"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/codahale/hdrhistogram"
+)
+
+var numOps uint64
+var numBytes uint64
+
+const (
+	minLatency = 100 * time.Microsecond
+	maxLatency = 10 * time.Second
+)
+
+func clampLatency(d, min, max time.Duration) time.Duration {
+	if d < min {
+		return min
+	}
+	if d > max {
+		return max
+	}
+	return d
+}
+
+type worker struct {
+	db      *engine.RocksDB
+	latency struct {
+		syncutil.Mutex
+		*hdrhistogram.WindowedHistogram
+	}
+	logOnly bool
+}
+
+func newWorker(db *engine.RocksDB) *worker {
+	w := &worker{db: db}
+	w.latency.WindowedHistogram = hdrhistogram.NewWindowed(1,
+		minLatency.Nanoseconds(), maxLatency.Nanoseconds(), 1)
+	return w
+}
+
+func (w *worker) run(wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	ctx := context.Background()
+	rand := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	var buf []byte
+
+	randBlock := func(min, max int) []byte {
+		data := make([]byte, rand.Intn(max-min)+min)
+		for i := range data {
+			data[i] = byte(rand.Int() & 0xff)
+		}
+		return data
+	}
+
+	for {
+		start := timeutil.Now()
+		b := w.db.NewBatch()
+		if w.logOnly {
+			block := randBlock(300, 400)
+			if err := b.LogData(block); err != nil {
+				log.Fatal(ctx, err)
+			}
+		} else {
+			for j := 0; j < 5; j++ {
+				block := randBlock(60, 80)
+				key := encoding.EncodeUint32Ascending(buf, rand.Uint32())
+				if err := b.Put(engine.MakeMVCCMetadataKey(key), block); err != nil {
+					log.Fatal(ctx, err)
+				}
+				buf = key[:0]
+			}
+		}
+		bytes := uint64(len(b.Repr()))
+		if err := b.Commit(true); err != nil {
+			log.Fatal(ctx, err)
+		}
+		atomic.AddUint64(&numOps, 1)
+		atomic.AddUint64(&numBytes, bytes)
+		elapsed := clampLatency(timeutil.Since(start), minLatency, maxLatency)
+		w.latency.Lock()
+		if err := w.latency.Current.RecordValue(elapsed.Nanoseconds()); err != nil {
+			log.Fatal(ctx, err)
+		}
+		w.latency.Unlock()
+	}
+}
+
+// Options holds parameters for the test.
+type Options struct {
+	Dir         string
+	Concurrency int
+	Duration    time.Duration
+	LogOnly     bool
+}
+
+// Run a test of writing synchronously to the RocksDB WAL.
+func Run(opts Options) error {
+	fmt.Printf("writing to %s\n", opts.Dir)
+
+	db, err := engine.NewRocksDB(
+		engine.RocksDBConfig{
+			Settings: cluster.MakeTestingClusterSettings(),
+			Dir:      opts.Dir,
+		},
+		engine.RocksDBCache{})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = os.RemoveAll(opts.Dir)
+	}()
+
+	workers := make([]*worker, opts.Concurrency)
+
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		workers[i] = newWorker(db)
+		workers[i].logOnly = opts.LogOnly
+		go workers[i].run(&wg)
+	}
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	done := make(chan os.Signal, 3)
+	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		wg.Wait()
+		done <- syscall.Signal(0)
+	}()
+
+	if opts.Duration > 0 {
+		go func() {
+			time.Sleep(opts.Duration)
+			done <- syscall.Signal(0)
+		}()
+	}
+
+	start := timeutil.Now()
+	lastNow := start
+	var lastOps uint64
+	var lastBytes uint64
+
+	for i := 0; ; i++ {
+		select {
+		case <-ticker.C:
+			var h *hdrhistogram.Histogram
+			for _, w := range workers {
+				w.latency.Lock()
+				m := w.latency.Merge()
+				w.latency.Rotate()
+				w.latency.Unlock()
+				if h == nil {
+					h = m
+				} else {
+					h.Merge(m)
+				}
+			}
+
+			p50 := h.ValueAtQuantile(50)
+			p95 := h.ValueAtQuantile(95)
+			p99 := h.ValueAtQuantile(99)
+			pMax := h.ValueAtQuantile(100)
+
+			now := timeutil.Now()
+			elapsed := now.Sub(lastNow)
+			ops := atomic.LoadUint64(&numOps)
+			bytes := atomic.LoadUint64(&numBytes)
+
+			if i%20 == 0 {
+				fmt.Println("_elapsed____ops/sec___mb/sec__p50(ms)__p95(ms)__p99(ms)_pMax(ms)")
+			}
+			fmt.Printf("%8s %10.1f %8.1f %8.1f %8.1f %8.1f %8.1f\n",
+				time.Duration(timeutil.Since(start).Seconds()+0.5)*time.Second,
+				float64(ops-lastOps)/elapsed.Seconds(),
+				float64(bytes-lastBytes)/(1024.0*1024.0)/elapsed.Seconds(),
+				time.Duration(p50).Seconds()*1000,
+				time.Duration(p95).Seconds()*1000,
+				time.Duration(p99).Seconds()*1000,
+				time.Duration(pMax).Seconds()*1000,
+			)
+			lastNow = now
+			lastOps = ops
+			lastBytes = bytes
+
+		case <-done:
+			return nil
+		}
+	}
+}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -198,6 +198,11 @@ type Writer interface {
 	Merge(key MVCCKey, value []byte) error
 	// Put sets the given key to the value provided.
 	Put(key MVCCKey, value []byte) error
+	// LogData adds the specified data to the RocksDB WAL. The data is
+	// uninterpreted by RocksDB (i.e. not added to the memtable or
+	// sstables). Currently only used for performance testing of appending to the
+	// RocksDB WAL.
+	LogData(data []byte) error
 }
 
 // ReadWriter is the read/write interface to an engine's data.

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -719,6 +719,11 @@ func (r *RocksDB) Merge(key MVCCKey, value []byte) error {
 	return dbMerge(r.rdb, key, value)
 }
 
+// LogData is part of the Writer interface.
+func (r *RocksDB) LogData(data []byte) error {
+	panic("unimplemented")
+}
+
 // ApplyBatchRepr atomically applies a set of batched updates. Created by
 // calling Repr() on a batch. Using this method is equivalent to constructing
 // and committing a batch whose Repr() equals repr.
@@ -1010,6 +1015,10 @@ func (r *rocksDBReadOnly) Put(key MVCCKey, value []byte) error {
 	panic("not implemented")
 }
 
+func (r *rocksDBReadOnly) LogData(data []byte) error {
+	panic("not implemented")
+}
+
 // NewBatch returns a new batch wrapping this rocksdb engine.
 func (r *RocksDB) NewBatch() Batch {
 	return newRocksDBBatch(r, false /* writeOnly */)
@@ -1231,6 +1240,11 @@ func (r *distinctBatch) Merge(key MVCCKey, value []byte) error {
 	return nil
 }
 
+func (r *distinctBatch) LogData(data []byte) error {
+	r.builder.LogData(data)
+	return nil
+}
+
 func (r *distinctBatch) Clear(key MVCCKey) error {
 	r.builder.Clear(key)
 	return nil
@@ -1445,6 +1459,15 @@ func (r *rocksDBBatch) Merge(key MVCCKey, value []byte) error {
 	}
 	r.distinctNeedsFlush = true
 	r.builder.Merge(key, value)
+	return nil
+}
+
+func (r *rocksDBBatch) LogData(data []byte) error {
+	if r.distinctOpen {
+		panic("distinct batch open")
+	}
+	r.distinctNeedsFlush = true
+	r.builder.LogData(data)
 	return nil
 }
 
@@ -1684,12 +1707,12 @@ func (r *rocksDBBatch) commitInternal(sync bool) error {
 		}
 		r.batch = nil
 		count, size = r.flushedCount, r.flushedSize
-	} else if r.builder.count > 0 {
+	} else if len(r.builder.repr) > 0 {
 		count, size = r.builder.count, len(r.builder.repr)
 
 		// Fast-path which avoids flushing mutations to the C++ batch. Instead, we
 		// directly apply the mutations to the database.
-		if err := r.parent.ApplyBatchRepr(r.builder.Finish(), sync); err != nil {
+		if err := dbApplyBatchRepr(r.parent.rdb, r.builder.Finish(), sync); err != nil {
 			return err
 		}
 		if r.batch != nil {

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -288,6 +288,10 @@ func (s spanSetWriter) Put(key engine.MVCCKey, value []byte) error {
 	return s.w.Put(key, value)
 }
 
+func (s spanSetWriter) LogData(data []byte) error {
+	return s.w.LogData(data)
+}
+
 type spanSetReadWriter struct {
 	spanSetReader
 	spanSetWriter


### PR DESCRIPTION
Expose the RocksDB LogData functionality which allows adding data to the
RocksDB WAL which is uninterpreted by RocksDB (i.e. not added to the
memtable or sstables). This is used by "debug synctest" to isolate
performance of appending to the WAL vs appending to the WAL and
inserting into the memtable.