### PR TITLE
storage: interface *Replica to ReplicaEvalContext

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -112,7 +112,7 @@ func evalExport(
 	// threshold. If it's not, the mvcc tombstones could have been deleted and
 	// the resulting RocksDB tombstones compacted, which means we'd miss
 	// deletions in the incremental backup.
-	gcThreshold, err := cArgs.EvalCtx.GCThreshold()
+	gcThreshold, err := cArgs.EvalCtx.GetGCThreshold()
 	if err != nil {
 		return storage.EvalResult{}, err
 	}

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -246,22 +246,6 @@ func (r *Replica) DescLocked() *roachpb.RangeDescriptor {
 	return r.mu.state.Desc
 }
 
-// GetGCThreshold returns the range's GCThreshold, acquiring a replica lock in
-// the process.
-func (r *Replica) GetGCThreshold() hlc.Timestamp {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return *r.mu.state.GCThreshold
-}
-
-// GetTxnSpanGCThreshold returns the range's TxnSpanGCThreshold, acquiring a replica lock in
-// the process.
-func (r *Replica) GetTxnSpanGCThreshold() hlc.Timestamp {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return *r.mu.state.TxnSpanGCThreshold
-}
-
 func (r *Replica) AssertState(ctx context.Context, reader engine.Reader) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
@@ -284,13 +268,6 @@ func (r *Replica) GetLastIndex() (uint64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.raftLastIndexLocked()
-}
-
-// GetLease exposes replica.getLease for tests.
-// If you just need information about the lease holder, consider issuing a
-// LeaseInfoRequest instead of using this internal method.
-func (r *Replica) GetLease() (roachpb.Lease, *roachpb.Lease) {
-	return r.getLease()
 }
 
 // SetQuotaPool allows the caller to set a replica's quota pool initialized to

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -366,7 +366,7 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now hlc.Timestamp) {
 	if bq.needsLease {
 		// Check to see if either we own the lease or do not know who the lease
 		// holder is.
-		if lease, _ := repl.getLease(); repl.IsLeaseValid(lease, now) &&
+		if lease, _ := repl.GetLease(); repl.IsLeaseValid(lease, now) &&
 			!lease.OwnedBy(repl.store.StoreID()) {
 			if log.V(1) {
 				log.Infof(ctx, "needs lease; not adding: %+v", lease)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -230,7 +230,7 @@ type Replica struct {
 
 	store        *Store
 	abortSpan    *abortspan.AbortSpan // Avoids anomalous reads after abort
-	pushTxnQueue *pushTxnQueue        // Queues push txn attempts by txn ID
+	pushTxnQueue *PushTxnQueue        // Queues push txn attempts by txn ID
 
 	// leaseholderStats tracks all incoming BatchRequests to the replica and which
 	// localities they come from in order to aid in lease rebalancing decisions.
@@ -458,6 +458,8 @@ type Replica struct {
 		remotes map[roachpb.ReplicaID]struct{}
 	}
 }
+
+var _ ReplicaI = &Replica{}
 
 // KeyRange is an interface type for the replicasByKey BTree, to compare
 // Replica and ReplicaPlaceholder.
@@ -1156,9 +1158,8 @@ func (r *Replica) IsDestroyed() error {
 	return r.mu.destroyed
 }
 
-// getLease returns the current lease, and the tentative next one, if a lease
-// request initiated by this replica is in progress.
-func (r *Replica) getLease() (roachpb.Lease, *roachpb.Lease) {
+// GetLease returns the lease and, if available, the proposed next lease.
+func (r *Replica) GetLease() (roachpb.Lease, *roachpb.Lease) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return r.getLeaseRLocked()
@@ -1435,7 +1436,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 							var err error
 							if _, descErr := r.GetReplicaDescriptor(); descErr != nil {
 								err = descErr
-							} else if lease, _ := r.getLease(); !r.IsLeaseValid(lease, r.store.Clock().Now()) {
+							} else if lease, _ := r.GetLease(); !r.IsLeaseValid(lease, r.store.Clock().Now()) {
 								err = newNotLeaseHolderError(nil, r.store.StoreID(), r.Desc())
 							} else {
 								err = newNotLeaseHolderError(&lease, r.store.StoreID(), r.Desc())
@@ -1631,9 +1632,9 @@ func containsKeyRange(desc roachpb.RangeDescriptor, start, end roachpb.Key) bool
 	return desc.ContainsKeyRange(startKeyAddr, endKeyAddr)
 }
 
-// getLastReplicaGCTimestamp reads the timestamp at which the replica was
+// GetLastReplicaGCTimestamp reads the timestamp at which the replica was
 // last checked for removal by the replica gc queue.
-func (r *Replica) getLastReplicaGCTimestamp(ctx context.Context) (hlc.Timestamp, error) {
+func (r *Replica) GetLastReplicaGCTimestamp(ctx context.Context) (hlc.Timestamp, error) {
 	key := keys.RangeLastReplicaGCTimestampKey(r.RangeID)
 	var timestamp hlc.Timestamp
 	_, err := engine.MVCCGetProto(ctx, r.store.Engine(), key, hlc.Timestamp{}, true, nil, &timestamp)
@@ -1858,7 +1859,7 @@ func (r *Replica) requestCanProceed(rspan roachpb.RSpan, ts hlc.Timestamp) error
 			// Only return the correct range descriptor as a hint
 			// if we know the current lease holder for that range, which
 			// indicates that our knowledge is not stale.
-			if lease, _ := repl.getLease(); repl.IsLeaseValid(lease, r.store.Clock().Now()) {
+			if lease, _ := repl.GetLease(); repl.IsLeaseValid(lease, r.store.Clock().Now()) {
 				mismatchErr.SuggestedRange = repl.Desc()
 			}
 		}

--- a/pkg/storage/replica_accessors.go
+++ b/pkg/storage/replica_accessors.go
@@ -1,0 +1,62 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"fmt"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// ReplicaI is the glue between a ReplicaEvalContext and a *Replica
+// to avoid a direct dependency.
+type ReplicaI interface {
+	fmt.Stringer
+	ClusterSettings() *cluster.Settings
+	StoreTestingKnobs() StoreTestingKnobs
+
+	// TODO(tschottdorf): available through ClusterSettings().
+	Tracer() opentracing.Tracer
+
+	Engine() engine.Engine
+	DB() *client.DB
+	AbortSpan() *abortspan.AbortSpan
+	GetPushTxnQueue() *PushTxnQueue
+
+	NodeID() roachpb.NodeID
+	StoreID() roachpb.StoreID
+	GetRangeID() roachpb.RangeID
+
+	IsFirstRange() bool
+	GetFirstIndex() (uint64, error)
+	GetTerm(uint64) (uint64, error)
+
+	Desc() *roachpb.RangeDescriptor
+
+	GetMVCCStats() enginepb.MVCCStats
+	GetGCThreshold() hlc.Timestamp
+	GetTxnSpanGCThreshold() hlc.Timestamp
+	GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error)
+	GetLease() (roachpb.Lease, *roachpb.Lease)
+}

--- a/pkg/storage/replica_command_test.go
+++ b/pkg/storage/replica_command_test.go
@@ -100,7 +100,7 @@ func TestDeclareKeysResolveIntent(t *testing.T) {
 					h.RangeID = desc.RangeID
 
 					cArgs := CommandArgs{Header: h}
-					cArgs.EvalCtx.repl = &Replica{abortSpan: ac}
+					cArgs.EvalCtx.i = &Replica{abortSpan: ac}
 
 					if !ranged {
 						cArgs.Args = &ri

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -114,7 +114,7 @@ func newReplicaGCQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *repl
 func (rgcq *replicaGCQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, _ config.SystemConfig,
 ) (bool, float64) {
-	lastCheck, err := repl.getLastReplicaGCTimestamp(ctx)
+	lastCheck, err := repl.GetLastReplicaGCTimestamp(ctx)
 	if err != nil {
 		log.Errorf(ctx, "could not read last replica GC timestamp: %s", err)
 		return false, 0
@@ -128,7 +128,7 @@ func (rgcq *replicaGCQueue) shouldQueue(
 		WallTime: repl.store.startedAt,
 	}
 
-	if lease, _ := repl.getLease(); lease.ProposedTS != nil {
+	if lease, _ := repl.GetLease(); lease.ProposedTS != nil {
 		lastActivity.Forward(*lease.ProposedTS)
 	}
 

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -103,7 +103,7 @@ const (
 // Replica may hold is expired. It is more precise than LeaseExpiration
 // in that it returns the minimal duration necessary.
 func leaseExpiry(repl *Replica) int64 {
-	l, _ := repl.getLease()
+	l, _ := repl.GetLease()
 	if l.Type() != roachpb.LeaseExpiration {
 		panic("leaseExpiry only valid for expiration-based leases")
 	}
@@ -429,7 +429,7 @@ func sendLeaseRequest(r *Replica, l *roachpb.Lease) error {
 	ba := roachpb.BatchRequest{}
 	ba.Timestamp = r.store.Clock().Now()
 	ba.Add(&roachpb.RequestLeaseRequest{Lease: *l})
-	exLease, _ := r.getLease()
+	exLease, _ := r.GetLease()
 	ch, _, _, pErr := r.propose(context.TODO(), exLease, ba, nil, nil)
 	if pErr == nil {
 		// Next if the command was committed, wait for the range to apply it.
@@ -1160,7 +1160,7 @@ func TestReplicaLeaseRejectUnknownRaftNodeID(t *testing.T) {
 			StoreID:   2,
 		},
 	}
-	exLease, _ := tc.repl.getLease()
+	exLease, _ := tc.repl.GetLease()
 	ba := roachpb.BatchRequest{}
 	ba.Timestamp = tc.repl.store.Clock().Now()
 	ba.Add(&roachpb.RequestLeaseRequest{Lease: *lease})
@@ -1351,7 +1351,7 @@ func TestReplicaNoGossipFromNonLeader(t *testing.T) {
 
 	// Increment the clock's timestamp to expire the range lease.
 	tc.manualClock.Set(leaseExpiry(tc.repl))
-	lease, _ := tc.repl.getLease()
+	lease, _ := tc.repl.GetLease()
 	if tc.repl.leaseStatus(lease, tc.Clock().Now(), hlc.Timestamp{}).State != LeaseState_EXPIRED {
 		t.Fatal("range lease should have been expired")
 	}
@@ -1774,7 +1774,7 @@ func TestAcquireLease(t *testing.T) {
 			// the start of a lease as far as possible, and since there is an auto-
 			// matic lease for us at the beginning, we'll basically create a lease from
 			// then on.
-			lease, _ := tc.repl.getLease()
+			lease, _ := tc.repl.GetLease()
 			expStart := lease.Start
 			tc.manualClock.Set(leaseExpiry(tc.repl))
 
@@ -1785,7 +1785,7 @@ func TestAcquireLease(t *testing.T) {
 			if held, expired := hasLease(tc.repl, ts); !held || expired {
 				t.Errorf("expected lease acquisition")
 			}
-			lease, _ = tc.repl.getLease()
+			lease, _ = tc.repl.GetLease()
 			if lease.Start != expStart {
 				t.Errorf("unexpected lease start: %s; expected %s", lease.Start, expStart)
 			}
@@ -1805,7 +1805,7 @@ func TestAcquireLease(t *testing.T) {
 			// Since the command we sent above does not get blocked on the lease
 			// extension, we need to wait for it to go through.
 			testutils.SucceedsSoon(t, func() error {
-				newLease, _ := tc.repl.getLease()
+				newLease, _ := tc.repl.GetLease()
 				if !lease.Expiration.Less(*newLease.Expiration) {
 					return errors.Errorf("lease did not get extended: %+v to %+v", lease, newLease)
 				}
@@ -4292,7 +4292,7 @@ func TestRaftRetryProtectionInTxn(t *testing.T) {
 		// Reach in and manually send to raft (to simulate Raft retry) and
 		// also avoid updating the timestamp cache.
 		ba.Timestamp = txn.OrigTimestamp
-		lease, _ := tc.repl.getLease()
+		lease, _ := tc.repl.GetLease()
 		ch, _, _, err := tc.repl.propose(context.Background(), lease, ba, nil, nil)
 		if err != nil {
 			t.Fatalf("%d: unexpected error: %s", i, err)
@@ -7651,7 +7651,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 			ba.Timestamp = tc.Clock().Now()
 			ba.Add(&roachpb.PutRequest{Span: roachpb.Span{
 				Key: roachpb.Key(fmt.Sprintf("k%d", i))}})
-			lease, _ := repl.getLease()
+			lease, _ := repl.GetLease()
 			proposal, pErr := repl.requestToProposal(context.Background(), makeIDKey(), ba, nil, nil)
 			if pErr != nil {
 				t.Fatal(pErr)
@@ -7847,7 +7847,7 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 		var ba roachpb.BatchRequest
 		ba.Timestamp = tc.Clock().Now()
 		ba.Add(&roachpb.PutRequest{Span: roachpb.Span{Key: roachpb.Key(id)}})
-		lease, _ := r.getLease()
+		lease, _ := r.GetLease()
 		cmd, pErr := r.requestToProposal(context.Background(), storagebase.CmdIDKey(id), ba, nil, nil)
 		if pErr != nil {
 			t.Fatal(pErr)
@@ -8126,8 +8126,8 @@ func TestGCWithoutThreshold(t *testing.T) {
 				if _, err := evalGC(ctx, rw, CommandArgs{
 					Args: &gc,
 					EvalCtx: ReplicaEvalContext{
-						repl: tc.repl,
-						ss:   &spans,
+						i:  tc.repl,
+						ss: &spans,
 					},
 				}, &resp); err != nil {
 					t.Fatalf("at (%s,%s): %s", keyThresh, txnThresh, err)
@@ -8788,7 +8788,7 @@ func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	exLease, _ := repl.getLease()
+	exLease, _ := repl.GetLease()
 	ch, _, _, pErr := repl.propose(
 		context.Background(), exLease, ba, nil /* endCmds */, nil, /* spans */
 	)

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -193,7 +193,7 @@ func (rq *replicateQueue) shouldQueue(
 	}
 
 	// If the lease is valid, check to see if we should transfer it.
-	if lease, _ := repl.getLease(); repl.IsLeaseValid(lease, now) {
+	if lease, _ := repl.GetLease(); repl.IsLeaseValid(lease, now) {
 		if rq.canTransferLease() &&
 			rq.allocator.ShouldTransferLease(
 				ctx, zone.Constraints, desc.Replicas, lease.Replica.StoreID, desc.RangeID, repl.leaseholderStats) {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -4038,7 +4038,7 @@ func (s *Store) canApplySnapshotLocked(
 				if r.RaftStatus() == nil {
 					return true
 				}
-				lease, pendingLease := r.getLease()
+				lease, pendingLease := r.GetLease()
 				now := s.Clock().Now()
 				return !r.IsLeaseValid(lease, now) &&
 					(pendingLease == nil || !r.IsLeaseValid(*pendingLease, now))


### PR DESCRIPTION
Introduce an interface implemented by `*Replica` and used by
`ReplicaEvalContext` to prepare the way for moving `ReplicaEvalContext` into a
subpackage of `storage`.

See #18779.