### PR TITLE
cherrypick-1.1: ui: exclude decommissioned nodes from staggered version warning

### DIFF
--- a/pkg/ui/src/redux/alerts.ts
+++ b/pkg/ui/src/redux/alerts.ts
@@ -14,7 +14,7 @@ import {
   saveUIData, VERSION_DISMISSED_KEY, loadUIData, isInFlight, UIDataSet,
 } from "./uiData";
 import { refreshCluster, refreshNodes, refreshVersion, refreshHealth } from "./apiReducers";
-import { nodeStatusesSelector } from "./nodes";
+import { nodeStatusesSelector, livenessByNodeIDSelector } from "./nodes";
 import { AdminUIState } from "./state";
 
 export enum AlertLevel {
@@ -51,11 +51,24 @@ export const staggeredVersionDismissedSetting = new LocalSetting(
 
 export const versionsSelector = createSelector(
   nodeStatusesSelector,
-  (nodeStatuses) => nodeStatuses && _.uniq(_.map(nodeStatuses, (status) => status.build_info && status.build_info.tag)),
+  livenessByNodeIDSelector,
+  (nodeStatuses, livenessStatusByNodeID) =>
+    _.chain(nodeStatuses)
+      // Ignore nodes for which we don't have any build info.
+      .filter((status) => !!status.build_info )
+      // Exclude this node if it's known to be decommissioning.
+      .filter((status) => !status.desc ||
+                          !livenessStatusByNodeID[status.desc.node_id] ||
+                          !livenessStatusByNodeID[status.desc.node_id].decommissioning)
+      // Collect the surviving nodes' build tags.
+      .map((status) => status.build_info.tag)
+      .uniq()
+      .value(),
 );
 
 /**
  * Warning when multiple versions of CockroachDB are detected on the cluster.
+ * This excludes decommissioned nodes.
  */
 export const staggeredVersionWarningSelector = createSelector(
   versionsSelector,

--- a/pkg/ui/src/redux/apiReducers.ts
+++ b/pkg/ui/src/redux/apiReducers.ts
@@ -65,7 +65,7 @@ export const refreshTableStats = tableStatsReducerObj.refresh;
 const logsReducerObj = new CachedDataReducer(api.getLogs, "logs", moment.duration(10, "s"));
 export const refreshLogs = logsReducerObj.refresh;
 
-const livenessReducerObj = new CachedDataReducer(api.getLiveness, "liveness", moment.duration(10, "s"));
+export const livenessReducerObj = new CachedDataReducer(api.getLiveness, "liveness", moment.duration(10, "s"));
 export const refreshLiveness = livenessReducerObj.refresh;
 
 export const jobsKey = (status: string, type: protos.cockroach.sql.jobs.Type, limit: number) =>

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -61,7 +61,7 @@ const livenessCheckedAtSelector = (state: AdminUIState) => state.cachedData.live
  * livenessByNodeIDSelector returns a map from NodeID to the Liveness record for
  * that node.
  */
-const livenessByNodeIDSelector = createSelector(
+export const livenessByNodeIDSelector = createSelector(
   livenessesSelector,
   (livenesses) => {
     if (livenesses) {


### PR DESCRIPTION
Fixes #15534.

cc @cockroachdb/release 