### PR TITLE
sql: add <@, @> JSON operators

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -192,6 +192,11 @@
 <tr><td><a href="uuid.html">uuid</a> <code><=</code> <a href="uuid.html">uuid</a></td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>
 <table><thead>
+<tr><td><code><@</code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td>jsonb <code><@</code> jsonb</td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>
+<table><thead>
 <tr><td><code>=</code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td><a href="bool.html">bool</a> <code>=</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -258,6 +263,11 @@
 <tr><td><code>?|</code></td><td>Return</td></tr>
 </thead><tbody>
 <tr><td>jsonb <code>?|</code> <a href="string.html">string[]</a></td><td><a href="bool.html">bool</a></td></tr>
+</tbody></table>
+<table><thead>
+<tr><td><code>@></code></td><td>Return</td></tr>
+</thead><tbody>
+<tr><td>jsonb <code>@></code> jsonb</td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>
 <table><thead>
 <tr><td><code>ILIKE</code></td><td>Return</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -336,3 +336,23 @@ SELECT '3'::JSONB - 'b'
 
 statement error pgcode 22023 cannot delete from object using integer index
 SELECT '{}'::JSONB - 1
+
+query B
+SELECT '[1, 2, 3]'::JSONB <@ '[1, 2]'::JSONB
+----
+false
+
+query B
+SELECT '[1, 2]'::JSONB <@ '[1, 2, 3]'::JSONB
+----
+true
+
+query B
+SELECT '[1, 2]'::JSONB @> '[1, 2, 3]'::JSONB
+----
+false
+
+query B
+SELECT '[1, 2, 3]'::JSONB @> '[1, 2]'::JSONB
+----
+true

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1895,6 +1895,26 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 			},
 		},
 	},
+
+	Contains: {
+		CmpOp{
+			LeftType:  types.JSON,
+			RightType: types.JSON,
+			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+				return MakeDBool(DBool(json.Contains(left.(*DJSON).JSON, right.(*DJSON).JSON))), nil
+			},
+		},
+	},
+
+	ContainedBy: {
+		CmpOp{
+			LeftType:  types.JSON,
+			RightType: types.JSON,
+			fn: func(ctx *EvalContext, left Datum, right Datum) (Datum, error) {
+				return MakeDBool(DBool(json.Contains(right.(*DJSON).JSON, left.(*DJSON).JSON))), nil
+			},
+		},
+	},
 }
 
 func boolFromCmp(cmp int, op ComparisonOperator) *DBool {

--- a/pkg/util/json/contains.go
+++ b/pkg/util/json/contains.go
@@ -1,0 +1,188 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package json
+
+import "sort"
+
+// Contains returns true if a contains b. This implements the @>, <@ operators.
+// See the Postgres docs for the expected semantics of Contains.
+// https://www.postgresql.org/docs/10/static/datatype-json.html#JSON-CONTAINMENT
+// The naive approach to doing array containment would be to do an O(n^2)
+// nested loop through the arrays to check if one is contained in the
+// other.  We're out of luck when the arrays contain other arrays or
+// objects (there might actually be something fancy we can do, but there's nothing
+// obvious).
+// When the arrays contain scalars however, we can optimize this by
+// pre-sorting both arrays and iterating through them in lockstep.
+// To this end, we preprocess the JSON document to sort all of its arrays so
+// that when we perform contains we can extract the scalars sorted, and then
+// also the arrays and objects in separate arrays, so that we can do the fast
+// thing for the subset of the arrays which are scalars.
+func Contains(a, b JSON) bool {
+	preA := a.preprocessForContains()
+	preB := b.preprocessForContains()
+	return preA.contains(preB)
+}
+
+// containsable is an interface used internally for the implementation of @>.
+type containsable interface {
+	contains(other containsable) bool
+}
+
+// containsableScalar is a preprocessed JSON scalar. The JSON it holds will
+// never be a JSON object or a JSON array.
+type containsableScalar struct{ JSON }
+
+// containsableArray is a preprocessed JSON array.
+// * scalars will always be scalars and will always be sorted,
+// * arrays will only contain containsableArrays,
+// * objects will only contain containsableObjects
+// (the last two are stored interfaces for reuse, though)
+type containsableArray struct {
+	scalars []containsableScalar
+	arrays  []containsable
+	objects []containsable
+}
+
+type containsableKeyValuePair struct {
+	k jsonString
+	v containsable
+}
+
+// containsableObject is a preprocessed JSON object.
+// Same as a jsonObject, it is stored as a sorted-by-key list of key-value
+// pairs.
+type containsableObject []containsableKeyValuePair
+
+func (j jsonNull) preprocessForContains() containsable   { return containsableScalar{j} }
+func (j jsonFalse) preprocessForContains() containsable  { return containsableScalar{j} }
+func (j jsonTrue) preprocessForContains() containsable   { return containsableScalar{j} }
+func (j jsonNumber) preprocessForContains() containsable { return containsableScalar{j} }
+func (j jsonString) preprocessForContains() containsable { return containsableScalar{j} }
+
+func (j jsonArray) preprocessForContains() containsable {
+	result := containsableArray{}
+	for _, e := range j {
+		switch v := e.(type) {
+		case jsonArray:
+			result.arrays = append(result.arrays, v.preprocessForContains())
+		case jsonObject:
+			result.objects = append(result.objects, v.preprocessForContains())
+		default:
+			result.scalars = append(result.scalars, e.preprocessForContains().(containsableScalar))
+		}
+	}
+
+	sort.Slice(result.scalars, func(i, j int) bool {
+		return result.scalars[i].JSON.Compare(result.scalars[j].JSON) == -1
+	})
+
+	return result
+}
+
+func (j jsonObject) preprocessForContains() containsable {
+	preprocessed := make(containsableObject, len(j))
+
+	for i := range preprocessed {
+		preprocessed[i].k = j[i].k
+		preprocessed[i].v = j[i].v.preprocessForContains()
+	}
+
+	return preprocessed
+}
+
+func (j containsableScalar) contains(other containsable) bool {
+	if o, ok := other.(containsableScalar); ok {
+		return j.JSON.Compare(o.JSON) == 0
+	}
+	return false
+}
+
+func (j containsableArray) contains(other containsable) bool {
+	// This is a unique case of contains (and is described as such in the
+	// Postgres docs) - an array contains a scalar which is an element of it.
+	// This contradicts the general rule of contains that the contained object
+	// must have the same "shape" as the containing object.
+	if o, ok := other.(containsableScalar); ok {
+		found := sort.Search(len(j.scalars), func(i int) bool {
+			return j.scalars[i].JSON.Compare(o.JSON) >= 0
+		})
+		return found < len(j.scalars) && j.scalars[found].JSON.Compare(o.JSON) == 0
+	}
+
+	if contained, ok := other.(containsableArray); ok {
+		// Since both slices of scalars are sorted via the preprocessing, we can
+		// step through them together via binary search.
+		remainingScalars := j.scalars[:]
+		for _, val := range contained.scalars {
+			found := sort.Search(len(remainingScalars), func(i int) bool {
+				return remainingScalars[i].JSON.Compare(val.JSON) >= 0
+			})
+			if found == len(remainingScalars) || remainingScalars[found].JSON.Compare(val.JSON) != 0 {
+				return false
+			}
+			remainingScalars = remainingScalars[found:]
+		}
+
+		// TODO(justin): there's possibly(?) something fancier we can do with the
+		// objects and arrays, but for now just do the quadratic check.
+		if !quadraticJSONArrayContains(j.objects, contained.objects) ||
+			!quadraticJSONArrayContains(j.arrays, contained.arrays) {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+// quadraticJSONArrayContains does an O(n^2) check to see if every value in
+// `other` is contained within a value in `container`. `container` and `other`
+// should not contain scalars.
+func quadraticJSONArrayContains(container, other []containsable) bool {
+	for _, otherVal := range other {
+		found := false
+		for _, containerVal := range container {
+			if containerVal.contains(otherVal) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func (j containsableObject) contains(other containsable) bool {
+	if contained, ok := other.(containsableObject); ok {
+		// We can iterate through the keys of `other` and scan through to find the
+		// corresponding keys in `j` since they're both sorted.
+		objIdx := 0
+		for _, rightEntry := range contained {
+			for objIdx < len(j) && j[objIdx].k < rightEntry.k {
+				objIdx++
+			}
+			if objIdx >= len(j) ||
+				j[objIdx].k != rightEntry.k ||
+				!j[objIdx].v.contains(rightEntry.v) {
+				return false
+			}
+			objIdx++
+		}
+		return true
+	}
+	return false
+}

--- a/pkg/util/json/contains_testers.go
+++ b/pkg/util/json/contains_testers.go
@@ -1,0 +1,122 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// This file contains (ha!) helpers to test @>.
+
+package json
+
+import (
+	"math/rand"
+)
+
+type containsTester interface {
+	// slowContains is a slower but simpler implementation of contains to check
+	// against the substantially more complex actual implementation.
+	slowContains(other JSON) bool
+
+	// subdocument returns a JSON document which is contained by this one.
+	subdocument(isRoot bool, rng *rand.Rand) JSON
+}
+
+func (j jsonNull) slowContains(other JSON) bool   { return j.Compare(other) == 0 }
+func (j jsonTrue) slowContains(other JSON) bool   { return j.Compare(other) == 0 }
+func (j jsonFalse) slowContains(other JSON) bool  { return j.Compare(other) == 0 }
+func (j jsonNumber) slowContains(other JSON) bool { return j.Compare(other) == 0 }
+func (j jsonString) slowContains(other JSON) bool { return j.Compare(other) == 0 }
+
+func (j jsonArray) slowContains(other JSON) bool {
+	if other.isScalar() {
+		for i := 0; i < len(j); i++ {
+			if j[i].Compare(other) == 0 {
+				return true
+			}
+		}
+	}
+
+	if ary, ok := other.(jsonArray); ok {
+		for i := 0; i < len(ary); i++ {
+			found := false
+			for k := 0; k < len(j); k++ {
+				if j[k].jsonType() == ary[i].jsonType() && j[k].(containsTester).slowContains(ary[i]) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func (j jsonObject) slowContains(other JSON) bool {
+	if obj, ok := other.(jsonObject); ok {
+		for i := 0; i < len(obj); i++ {
+			leftVal := j.FetchValKey(string(obj[i].k))
+			if leftVal == nil || !leftVal.(containsTester).slowContains(obj[i].v) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func (j jsonNull) subdocument(_ bool, _ *rand.Rand) JSON   { return j }
+func (j jsonTrue) subdocument(_ bool, _ *rand.Rand) JSON   { return j }
+func (j jsonFalse) subdocument(_ bool, _ *rand.Rand) JSON  { return j }
+func (j jsonNumber) subdocument(_ bool, _ *rand.Rand) JSON { return j }
+func (j jsonString) subdocument(_ bool, _ *rand.Rand) JSON { return j }
+
+func (j jsonArray) subdocument(isRoot bool, rng *rand.Rand) JSON {
+	// Root arrays contain their scalar elements.
+	if isRoot && rng.Intn(5) == 0 {
+		idx := rng.Intn(len(j))
+		if j[idx].isScalar() {
+			return j[idx]
+		}
+	}
+	result := make(jsonArray, 0)
+	i := 0
+	for i < len(j) {
+		if rng.Intn(2) == 0 {
+			result = append(result, j[i].(containsTester).subdocument(false /* isRoot */, rng))
+		}
+		if rng.Intn(2) == 0 {
+			i++
+		}
+	}
+	// Shuffle the slice.
+	for i := range result {
+		j := rng.Intn(i + 1)
+		result[i], result[j] = result[j], result[i]
+	}
+
+	return result
+}
+
+func (j jsonObject) subdocument(_ bool, rng *rand.Rand) JSON {
+	result := make(jsonObject, 0)
+	for _, e := range j {
+		if rng.Intn(2) == 0 {
+			result = append(result, jsonKeyValuePair{
+				k: e.k,
+				v: e.v.(containsTester).subdocument(false /* isRoot */, rng),
+			})
+		}
+	}
+	return result
+}

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -78,6 +78,14 @@ type JSON interface {
 
 	// Exists implements the `?` operator.
 	Exists(string) bool
+
+	// isScalar returns whether the JSON document is null, true, false, a string,
+	// or a number.
+	isScalar() bool
+
+	// preprocessForContains converts a JSON document to an internal interface
+	// which is used to efficiently implement the @> operator.
+	preprocessForContains() containsable
 }
 
 type jsonTrue struct{}
@@ -104,6 +112,9 @@ type jsonKeyValuePair struct {
 	k jsonString
 	v JSON
 }
+
+// jsonObject represents a JSON object as a sorted-by-key list of key-value
+// pairs, which are unique by key.
 type jsonObject []jsonKeyValuePair
 
 func (jsonNull) jsonType() jsonType   { return nullJSONType }
@@ -426,7 +437,7 @@ func MakeJSON(d interface{}) (JSON, error) {
 			}
 		}
 		return jsonObject(result), nil
-		// The below are not used by ParseDJSON, but are provided for ease-of-use when
+		// The below are not used by ParseJSON, but are provided for ease-of-use when
 		// constructing Datums.
 	case int:
 		dec := apd.Decimal{}
@@ -588,3 +599,11 @@ func (j jsonArray) Exists(s string) bool {
 func (j jsonObject) Exists(s string) bool {
 	return j.FetchValKey(s) != nil
 }
+
+func (jsonNull) isScalar() bool   { return true }
+func (jsonFalse) isScalar() bool  { return true }
+func (jsonTrue) isScalar() bool   { return true }
+func (jsonNumber) isScalar() bool { return true }
+func (jsonString) isScalar() bool { return true }
+func (jsonArray) isScalar() bool  { return false }
+func (jsonObject) isScalar() bool { return false }


### PR DESCRIPTION
The behaviour of this operator is described at
https://www.postgresql.org/docs/9.5/static/datatype-json.html#JSON-CONTAINMENT

This will probably have to change a bit once we have an encoding, but I
wanted to implement it now for the simpler case.

I debated first going with a simpler but always O(n^2) implementation of jsonArrayContains, it looked like this:

```go
func jsonArrayContains(ctx *EvalContext, ary DJSON, other DJSON) bool {
	for _, v := range other.arrayVal {
		found := false
		for _, c := range ary.arrayVal {
			if c.typ == v.typ && c.contains(ctx, v) {
				found = true
				break
			}
		}
		if !found {
			return false
		}
	}
	return true
}
```

The current implementation is quite a bit more complex, but significantly faster.
On this benchmark:

```go
func BenchmarkJSONArrayContains(b *testing.B) {
	ctx := NewTestingEvalContext()
	for arySize := 0; arySize <= 20; arySize += 5 {
		b.Run(fmt.Sprintf("JSON array of size %d", arySize), func(b *testing.B) {
			var buf bytes.Buffer
			buf.WriteByte('[')
			for i := 0; i < arySize; i++ {
				if i > 0 {
					buf.WriteByte(',')
				}
				buf.WriteString(fmt.Sprintf("%d", i))
			}
			buf.WriteByte(']')
			j, _ := ParseDJSON(buf.String())
			ary := *j.(*DJSON)

			// ary is now an array of the form [0, 1, 2, ...].
			b.ResetTimer()
			for i := 0; i < b.N; i++ {
				jsonArrayContains(ctx, ary, ary)
			}
			b.StopTimer()
		})
	}
}
```

The original implementation:
```
BenchmarkJSONArrayContains/JSON_array_of_size_0-8          200000000          9.30 ns/op
BenchmarkJSONArrayContains/JSON_array_of_size_5-8            500000       3274 ns/op
BenchmarkJSONArrayContains/JSON_array_of_size_10-8           100000      11784 ns/op
BenchmarkJSONArrayContains/JSON_array_of_size_15-8            50000      25897 ns/op
BenchmarkJSONArrayContains/JSON_array_of_size_20-8            30000      45286 ns/op
```

The current implementation:
```
BenchmarkJSONArrayContains/JSON_array_of_size_0-8           5000000        285 ns/op
BenchmarkJSONArrayContains/JSON_array_of_size_5-8           1000000       2088 ns/op
BenchmarkJSONArrayContains/JSON_array_of_size_10-8           300000       3756 ns/op
BenchmarkJSONArrayContains/JSON_array_of_size_15-8           200000       6238 ns/op
BenchmarkJSONArrayContains/JSON_array_of_size_20-8           200000       8365 ns/op
```

Re: the second TODO on `preprocessJSONArrayForContains`,
We could maybe transform
```
a @> b
```
into
```
PREPROCESS(a) @>' PREPROCESS(b)
```
where @>' assumes its arguments are preprocessed, and then the constant folding code
would take care of this. cc @knz for thoughts on this?