### PR TITLE
storage: Don't ignore quiesceLocked's return value

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3924,7 +3924,9 @@ func (r *Replica) quiesceAndNotifyLocked(ctx context.Context, status *raft.Statu
 		return false
 	}
 
-	r.quiesceLocked()
+	if !r.quiesceLocked() {
+		return false
+	}
 	for id := range status.Progress {
 		if roachpb.ReplicaID(id) == r.mu.replicaID {
 			continue


### PR DESCRIPTION
This doesn't look like it was a real correctness issue, but it
certainly seems wasteful to send quiesce messages to all followers
if the leader didn't actually quiesce itself.