### PR TITLE
sql: fix panic in prepare

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -355,3 +355,8 @@ PREPARE sets(string) AS SET CLUSTER SETTING cluster.organization = $1
 
 statement
 EXECUTE sets('hello')
+
+# #19597
+
+statement error could not determine data type of placeholder
+PREPARE x19597 AS SELECT $1 IN ($2, null);

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -1265,11 +1265,7 @@ func typeCheckSameTypedExprs(
 			case len(constIdxs) > 0:
 				return typeCheckConstsAndPlaceholdersWithDesired(s, desired)
 			case len(placeholderIdxs) > 0:
-				err := typeCheckSameTypedPlaceholders(s, nil)
-				if err == nil {
-					panic("type checking parameters without a type should throw an error")
-				}
-				return nil, nil, err
+				return nil, nil, placeholderTypeAmbiguityError{s.exprs[placeholderIdxs[0]].(*Placeholder)}
 			default:
 				return typedExprs, TypeNull, nil
 			}
@@ -1299,8 +1295,7 @@ func typeCheckSameTypedExprs(
 	}
 }
 
-// Used to set placeholders to the desired typ. If the typ is not provided or is
-// nil, an error will be thrown.
+// Used to set placeholders to the desired typ.
 func typeCheckSameTypedPlaceholders(s typeCheckExprsState, typ Type) error {
 	for _, i := range s.placeholderIdxs {
 		typedExpr, err := typeCheckAndRequire(s.ctx, s.exprs[i], typ, "placeholder")


### PR DESCRIPTION
Fixes #19597.

Looking at the comment above typeCheckSameTypedPlaceholders, the
contract of this function is that nil is a valid argument, but it should
throw an error if passed to it.

This statement successfully prepares in Postgres, but this seems like a
clear change here that I think making it prepare in Cockroach is out of
scope for this change.