### PR TITLE
bootstrap-debian: install NodeJS and Yarn

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -5,9 +5,22 @@
 
 set -euxo pipefail
 
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | sudo apt-key add -
+echo "deb https://deb.nodesource.com/node_6.x xenial main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+
+curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+
 sudo apt-get update
 sudo apt-get dist-upgrade -y
-sudo apt-get install -y --no-install-recommends docker.io git autoconf cmake
+sudo apt-get install -y --no-install-recommends \
+  autoconf \
+  cmake \
+  docker.io \
+  libtinfo-dev \
+  git \
+  nodejs \
+  yarn
 
 sudo adduser "${USER}" docker
 


### PR DESCRIPTION
Since removing embedded.go (99b35b3), Node and Yarn are required to
build CockroachDB from its Git repository. Teach bootstrap-debian.sh to
install these new dependencies so that GCE/Azure workers can actually
build the latest tip of master.