### PR TITLE
sqlccl: add a function from tabledesc -> spans for zone configs

### DIFF
--- a/pkg/ccl/sqlccl/zone.go
+++ b/pkg/ccl/sqlccl/zone.go
@@ -1,0 +1,258 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package sqlccl
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/intervalccl"
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/pkg/errors"
+)
+
+// GenerateSubzoneSpans constructs from a TableDescriptor the entries mapping
+// zone config spans to subzones for use in the SubzoneSpans field of
+// config.ZoneConfig. SubzoneSpans controls which splits are created, so only
+// the spans corresponding to entries in subzones are returned.
+//
+// Zone configs target indexes and partitions via `subzones`, which are attached
+// to a table-scoped row in `system.zones`. Each subzone represents one index
+// (primary or secondary) or one partition (or subpartition) and contains the
+// usual zone config constraints. They are saved to `system.zones` sparsely
+// (only when set by a user) and are the most specific entry in the normal
+// cluster-default/database/table/subzone config hierarchy.
+//
+// Each non-interleaved index and partition can be mapped to spans in the
+// keyspace. Indexes and range partitions each map to one span, while each list
+// partition maps to one or more spans. Each partition span is contained by some
+// index span and each subpartition span is contained by one of its parent
+// partition's spans. The spans for a given level of a range partitioning
+// (corresponding to one `PARTITION BY` in sql or one `PartitionDescriptor`) are
+// disjoint, but the spans for a given level of a list partitioning may overlap
+// if DEFAULT is used. A list partitioning which includes both (1, DEFAULT) and
+// (1, 2) will overlap with the latter getting precedence in the zone config
+// hierarchy. NB: In a valid PartitionDescriptor, no partitions with the same
+// number of DEFAULTs will overlap (this property is used by
+// `indexCoveringsForPartitioning`).
+//
+// These subzone spans are kept denormalized to the relevant `system.zone` row
+// for performance. Given a TableDescriptor, the spans for every
+// index/partition/subpartition are created, filtered out if they don't have a
+// config set for them, and precedence applied (via `OverlapCoveringMerge`) to
+// produce a set of non-overlapping spans, which each map to a subzone. There
+// may be "holes" (uncovered spans) in this set.
+//
+// The returned spans are returned in exactly the format required by
+// `system.zones`. They must be sorted and non-overlapping. Each contains an
+// IndexID, which maps to one of the input `subzones` by indexing into the
+// slice. As space optimizations, all `Key`s and `EndKey`s of `SubzoneSpan` omit
+// the common prefix (the encoded table ID) and if `EndKey` is equal to
+// `Key.PrefixEnd()` it is omitted.
+func GenerateSubzoneSpans(
+	tableDesc *sqlbase.TableDescriptor, subzones []config.Subzone,
+) ([]config.SubzoneSpan, error) {
+	a := &sqlbase.DatumAlloc{}
+
+	subzoneIndexByIndexID := make(map[sqlbase.IndexID]int32)
+	subzoneIndexByPartition := make(map[string]int32)
+	for i, subzone := range subzones {
+		if len(subzone.PartitionName) > 0 {
+			subzoneIndexByPartition[subzone.PartitionName] = int32(i)
+		} else {
+			subzoneIndexByIndexID[sqlbase.IndexID(subzone.IndexID)] = int32(i)
+		}
+	}
+
+	var indexCovering intervalccl.Covering
+	var partitionCoverings []intervalccl.Covering
+	if err := tableDesc.ForeachNonDropIndex(func(idxDesc *sqlbase.IndexDescriptor) error {
+		_, indexSubzoneExists := subzoneIndexByIndexID[idxDesc.ID]
+		if indexSubzoneExists {
+			idxSpan := tableDesc.IndexSpan(idxDesc.ID)
+			// Each index starts with a unique prefix, so (from a precedence
+			// perspective) it's safe to append them all together.
+			indexCovering = append(indexCovering, intervalccl.Range{
+				Start: idxSpan.Key, End: idxSpan.EndKey,
+				Payload: config.Subzone{IndexID: uint32(idxDesc.ID)},
+			})
+		}
+
+		var emptyPrefix []parser.Datum
+		indexPartitionCoverings, err := indexCoveringsForPartitioning(
+			a, tableDesc, idxDesc, &idxDesc.Partitioning, subzoneIndexByPartition, emptyPrefix)
+		if err != nil {
+			return err
+		}
+		// The returned indexPartitionCoverings are sorted with highest
+		// precedence first. They all start with the index prefix, so cannot
+		// overlap with the partition coverings for any other index, so (from a
+		// precedence perspective) it's safe to append them all together.
+		partitionCoverings = append(partitionCoverings, indexPartitionCoverings...)
+
+		// TODO(dan): A bunch of this logic is easier if we disallow setting
+		// zone configs on indexes that are interleaved into another index.
+		// InterleavedBy is fine, so using the root of the interleave hierarchy
+		// will work. It is expected that this is sufficient for real-world use
+		// cases. Revisit this restriction if that expectation is wrong.
+		indexUsed := indexSubzoneExists || len(indexPartitionCoverings) > 0
+		if indexUsed && len(idxDesc.Interleave.Ancestors) > 0 {
+			return errors.Errorf("cannot set a zone config for interleaved index %s; "+
+				"set it on the root of the interleaved hierarchy instead", idxDesc.Name)
+		}
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// OverlapCoveringMerge returns the payloads for any coverings that overlap
+	// in the same order they were input. So, we require that they be ordered
+	// with highest precedence first, so the first payload of each range is the
+	// one we need.
+	ranges := intervalccl.OverlapCoveringMerge(append(partitionCoverings, indexCovering))
+
+	// NB: This assumes that none of the indexes are interleaved, which is
+	// checked above.
+	sharedPrefix := keys.MakeTablePrefix(uint32(tableDesc.ID))
+
+	var subzoneSpans []config.SubzoneSpan
+	for _, r := range ranges {
+		payloads := r.Payload.([]interface{})
+		if len(payloads) == 0 {
+			continue
+		}
+		subzoneSpan := config.SubzoneSpan{
+			Key:    bytes.TrimPrefix(r.Start, sharedPrefix),
+			EndKey: bytes.TrimPrefix(r.End, sharedPrefix),
+		}
+		var ok bool
+		if subzone := payloads[0].(config.Subzone); len(subzone.PartitionName) > 0 {
+			subzoneSpan.SubzoneIndex, ok = subzoneIndexByPartition[subzone.PartitionName]
+		} else {
+			subzoneSpan.SubzoneIndex, ok = subzoneIndexByIndexID[sqlbase.IndexID(subzone.IndexID)]
+		}
+		if !ok {
+			continue
+		}
+		if bytes.Equal(subzoneSpan.Key.PrefixEnd(), subzoneSpan.EndKey) {
+			subzoneSpan.EndKey = nil
+		}
+		subzoneSpans = append(subzoneSpans, subzoneSpan)
+	}
+	return subzoneSpans, nil
+}
+
+// indexCoveringsForPartitioning returns span coverings representing the
+// partitions in partDesc (including subpartitions). They are sorted with
+// highest precedence first and the intervalccl.Range payloads are each a
+// `config.Subzone` with the PartitionName set.
+func indexCoveringsForPartitioning(
+	a *sqlbase.DatumAlloc,
+	tableDesc *sqlbase.TableDescriptor,
+	idxDesc *sqlbase.IndexDescriptor,
+	partDesc *sqlbase.PartitioningDescriptor,
+	relevantPartitions map[string]int32,
+	prefixDatums []parser.Datum,
+) ([]intervalccl.Covering, error) {
+	if partDesc.NumColumns == 0 {
+		return nil, nil
+	}
+
+	var coverings []intervalccl.Covering
+	var descendentCoverings []intervalccl.Covering
+
+	if len(partDesc.List) > 0 {
+		// The returned spans are required to be ordered with highest precedence
+		// first. The span for (1, DEFAULT) overlaps with (1, 2) and needs to be
+		// returned at a lower precedence. Luckily, because of the partitioning
+		// validation, we're guaranteed that all entries in a list partitioning
+		// with the same number of DEFAULTs are non-overlapping. So, bucket the
+		// `intervalccl.Range`s by the number of non-DEFAULT columns and return
+		// them ordered from least # of DEFAULTs to most.
+		listCoverings := make([]intervalccl.Covering, int(partDesc.NumColumns)+1)
+		for _, p := range partDesc.List {
+			for _, valueEncBuf := range p.Values {
+				datums, keyPrefix, err := sqlbase.TranslateValueEncodingToSpan(
+					a, tableDesc, idxDesc, partDesc, valueEncBuf, prefixDatums)
+				if err != nil {
+					return nil, err
+				}
+				if _, ok := relevantPartitions[p.Name]; ok {
+					listCoverings[len(datums)] = append(listCoverings[len(datums)], intervalccl.Range{
+						Start: keyPrefix, End: roachpb.Key(keyPrefix).PrefixEnd(),
+						Payload: config.Subzone{PartitionName: p.Name},
+					})
+				}
+				newPrefixDatums := append(prefixDatums, datums...)
+				subpartitionCoverings, err := indexCoveringsForPartitioning(
+					a, tableDesc, idxDesc, &p.Subpartitioning, relevantPartitions, newPrefixDatums)
+				if err != nil {
+					return nil, err
+				}
+				descendentCoverings = append(descendentCoverings, subpartitionCoverings...)
+			}
+		}
+		for i := range listCoverings {
+			if covering := listCoverings[len(listCoverings)-i-1]; len(covering) > 0 {
+				coverings = append(coverings, covering)
+			}
+		}
+	}
+
+	if len(partDesc.Range) > 0 {
+		lastEndKey := sqlbase.MakeIndexKeyPrefix(tableDesc, idxDesc.ID)
+		if len(prefixDatums) > 0 {
+			colMap := make(map[sqlbase.ColumnID]int, len(prefixDatums))
+			for i := range prefixDatums {
+				colMap[idxDesc.ColumnIDs[i]] = i
+			}
+
+			var err error
+			lastEndKey, _, err = sqlbase.EncodePartialIndexKey(
+				tableDesc, idxDesc, len(prefixDatums), colMap, prefixDatums, lastEndKey)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		for _, p := range partDesc.Range {
+			if _, ok := relevantPartitions[p.Name]; !ok {
+				continue
+			}
+			datums, endKey, err := sqlbase.TranslateValueEncodingToSpan(
+				a, tableDesc, idxDesc, partDesc, p.UpperBound, prefixDatums)
+			if err != nil {
+				return nil, err
+			}
+			if _, ok := relevantPartitions[p.Name]; ok {
+				coverings = append(coverings, intervalccl.Covering{{
+					Start: lastEndKey, End: endKey,
+					Payload: config.Subzone{PartitionName: p.Name},
+				}})
+				lastEndKey = endKey
+			}
+			newPrefixDatums := append(prefixDatums, datums...)
+			subpartitionCoverings, err := indexCoveringsForPartitioning(
+				a, tableDesc, idxDesc, &p.Subpartitioning, relevantPartitions, newPrefixDatums)
+			if err != nil {
+				return nil, err
+			}
+			descendentCoverings = append(descendentCoverings, subpartitionCoverings...)
+		}
+	}
+
+	// descendentCoverings are from subpartitions and so get precedence; append
+	// them to the front.
+	return append(descendentCoverings, coverings...), nil
+}

--- a/pkg/ccl/sqlccl/zone_test.go
+++ b/pkg/ccl/sqlccl/zone_test.go
@@ -1,0 +1,401 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package sqlccl
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"golang.org/x/net/context"
+)
+
+func TestGenerateSubzoneSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	prettyTrimmedKey := func(key []byte) string {
+		untrimmedKey := append(keys.MakeTablePrefix(0), key...)
+		return strings.TrimPrefix(roachpb.Key(untrimmedKey).String(), "/Table/0")
+	}
+
+	tests := []struct {
+		name   string
+		schema string
+
+		// subzones are 1:1 to the `subzones` input of GenerateSubzoneSpans,
+		// each formatted as `@index_name` or `.partition_name`
+		subzones []string
+
+		// expected are 1:1 to the output of GenerateSubzoneSpans, each
+		// formatted as `{subzone} {start}-{end}` (e.g. `@primary /1-/2`), where
+		// {subzone} is formatted identically to the test shorthand above, and
+		// {start} and {end} are formatted using our key pretty printer, but
+		// with the table removed. The end key is always specified in tests
+		// (though GenerateSubzoneSpans may omit it to save space).
+		expected []string
+	}{
+		{
+			name:   `no subzones`,
+			schema: `CREATE TABLE t (a INT PRIMARY KEY)`,
+		},
+
+		{
+			name:     `all indexes`,
+			schema:   `CREATE TABLE t (a INT PRIMARY KEY, b INT, INDEX idx1 (b), INDEX idx2 (b))`,
+			subzones: []string{`@primary`, `@idx1`, `@idx2`},
+			expected: []string{`@primary /1-/2`, `@idx1 /2-/3`, `@idx2 /3-/4`},
+		},
+		{
+			name:     `all indexes - shuffled`,
+			schema:   `CREATE TABLE t (a INT PRIMARY KEY, b INT, INDEX idx1 (b), INDEX idx2 (b))`,
+			subzones: []string{`@idx2`, `@primary`, `@idx1`},
+			expected: []string{`@primary /1-/2`, `@idx1 /2-/3`, `@idx2 /3-/4`},
+		},
+		{
+			name:     `some indexes`,
+			schema:   `CREATE TABLE t (a INT PRIMARY KEY, b INT, INDEX idx1 (b), INDEX idx2 (b))`,
+			subzones: []string{`@primary`, `@idx2`},
+			expected: []string{`@primary /1-/2`, `@idx2 /3-/4`},
+		},
+
+		{
+			name: `single col list partitioning`,
+			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY LIST (a) (
+				PARTITION p3 VALUES (3),
+				PARTITION p4 VALUES (4)
+			)`,
+			subzones: []string{`@primary`, `.p3`, `.p4`},
+			expected: []string{
+				`@primary /1-/1/3`,
+				`     .p3 /1/3-/1/4`,
+				`     .p4 /1/4-/1/5`,
+				`@primary /1/5-/2`,
+			},
+		},
+		{
+			name: `single col list partitioning - DEFAULT`,
+			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY LIST (a) (
+				PARTITION p3 VALUES (3),
+				PARTITION p4 VALUES (4),
+				PARTITION pd VALUES (DEFAULT)
+			)`,
+			subzones: []string{`@primary`, `.p3`, `.p4`, `.pd`},
+			expected: []string{
+				`.pd /1-/1/3`,
+				`.p3 /1/3-/1/4`,
+				`.p4 /1/4-/1/5`,
+				`.pd /1/5-/2`,
+			},
+		},
+		{
+			name: `multi col list partitioning`,
+			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
+				PARTITION p34 VALUES (3, 4),
+				PARTITION p56 VALUES (5, 6),
+				PARTITION p57 VALUES (5, 7)
+			)`,
+			subzones: []string{`@primary`, `.p34`, `.p56`, `.p57`},
+			expected: []string{
+				`@primary /1-/1/3/4`,
+				`    .p34 /1/3/4-/1/3/5`,
+				`@primary /1/3/5-/1/5/6`,
+				`    .p56 /1/5/6-/1/5/7`,
+				`    .p57 /1/5/7-/1/5/8`,
+				`@primary /1/5/8-/2`,
+			},
+		},
+		{
+			name: `multi col list partitioning - DEFAULT`,
+			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
+				PARTITION p34 VALUES (3, 4),
+				PARTITION p56 VALUES (5, 6),
+				PARTITION p57 VALUES (5, 7),
+				PARTITION p5d VALUES (5, DEFAULT),
+				PARTITION pd VALUES (DEFAULT, DEFAULT)
+			)`,
+			subzones: []string{`@primary`, `.p34`, `.p56`, `.p57`, `.p5d`, `.pd`},
+			expected: []string{
+				` .pd /1-/1/3/4`,
+				`.p34 /1/3/4-/1/3/5`,
+				` .pd /1/3/5-/1/5`,
+				`.p5d /1/5-/1/5/6`,
+				`.p56 /1/5/6-/1/5/7`,
+				`.p57 /1/5/7-/1/5/8`,
+				`.p5d /1/5/8-/1/6`,
+				` .pd /1/6-/2`,
+			},
+		},
+
+		{
+			name: `single col range partitioning`,
+			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY RANGE (a) (
+				PARTITION p3 VALUES LESS THAN (3),
+				PARTITION p4 VALUES LESS THAN (4)
+			)`,
+			subzones: []string{`@primary`, `.p3`, `.p4`},
+			expected: []string{
+				`     .p3 /1-/1/3`,
+				`     .p4 /1/3-/1/4`,
+				`@primary /1/4-/2`,
+			},
+		},
+		{
+			name: `single col range partitioning - MAXVALUE`,
+			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY RANGE (a) (
+				PARTITION p3 VALUES LESS THAN (3),
+				PARTITION p4 VALUES LESS THAN (4),
+				PARTITION pm VALUES LESS THAN (MAXVALUE)
+			)`,
+			subzones: []string{`@primary`, `.p3`, `.p4`, `.pm`},
+			expected: []string{
+				`.p3 /1-/1/3`,
+				`.p4 /1/3-/1/4`,
+				`.pm /1/4-/2`,
+			},
+		},
+		{
+			name: `multi col range partitioning`,
+			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
+				PARTITION p34 VALUES LESS THAN (3, 4),
+				PARTITION p56 VALUES LESS THAN (5, 6),
+				PARTITION p57 VALUES LESS THAN (5, 7)
+			)`,
+			subzones: []string{`@primary`, `.p34`, `.p56`, `.p57`},
+			expected: []string{
+				`    .p34 /1-/1/3/4`,
+				`    .p56 /1/3/4-/1/5/6`,
+				`    .p57 /1/5/6-/1/5/7`,
+				`@primary /1/5/7-/2`,
+			},
+		},
+		{
+			name: `multi col range partitioning - MAXVALUE`,
+			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
+				PARTITION p34 VALUES LESS THAN (3, 4),
+				PARTITION p3m VALUES LESS THAN (3, MAXVALUE),
+				PARTITION p56 VALUES LESS THAN (5, 6),
+				PARTITION p57 VALUES LESS THAN (5, 7),
+				PARTITION pm VALUES LESS THAN (MAXVALUE, MAXVALUE)
+			)`,
+			subzones: []string{`@primary`, `.p34`, `.p3m`, `.p56`, `.p57`, `.pm`},
+			expected: []string{
+				`.p34 /1-/1/3/4`,
+				`.p3m /1/3/4-/1/4`,
+				`.p56 /1/4-/1/5/6`,
+				`.p57 /1/5/6-/1/5/7`,
+				` .pm /1/5/7-/2`,
+			},
+		},
+
+		{
+			name: `list-list partitioning`,
+			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+				PARTITION p3 VALUES (3) PARTITION BY LIST (b) (
+					PARTITION p34 VALUES (4)
+				),
+				PARTITION p5 VALUES (5) PARTITION BY LIST (b) (
+					PARTITION p56 VALUES (6),
+					PARTITION p5d VALUES (DEFAULT)
+				),
+				PARTITION pd VALUES (DEFAULT)
+			)`,
+			subzones: []string{`@primary`, `.p3`, `.p34`, `.p5`, `.p56`, `.p5d`, `.pd`},
+			expected: []string{
+				` .pd /1-/1/3`,
+				` .p3 /1/3-/1/3/4`,
+				`.p34 /1/3/4-/1/3/5`,
+				` .p3 /1/3/5-/1/4`,
+				` .pd /1/4-/1/5`,
+				`.p5d /1/5-/1/5/6`,
+				`.p56 /1/5/6-/1/5/7`,
+				`.p5d /1/5/7-/1/6`,
+				` .pd /1/6-/2`,
+			},
+		},
+		{
+			name: `list-range partitioning`,
+			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+				PARTITION p3 VALUES (3) PARTITION BY RANGE (b) (
+					PARTITION p34 VALUES LESS THAN (4)
+				),
+				PARTITION p5 VALUES (5) PARTITION BY RANGE (b) (
+					PARTITION p56 VALUES LESS THAN (6),
+					PARTITION p5d VALUES LESS THAN (MAXVALUE)
+				),
+				PARTITION pd VALUES (DEFAULT)
+			)`,
+			subzones: []string{`@primary`, `.p3`, `.p34`, `.p5`, `.p56`, `.p5d`, `.pd`},
+			expected: []string{
+				` .pd /1-/1/3`,
+				`.p34 /1/3-/1/3/4`,
+				` .p3 /1/3/4-/1/4`,
+				` .pd /1/4-/1/5`,
+				`.p56 /1/5-/1/5/6`,
+				`.p5d /1/5/6-/1/6`,
+				` .pd /1/6-/2`,
+			},
+		},
+
+		{
+			name: `inheritance - index`,
+			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY LIST (a) (
+				PARTITION pd VALUES (DEFAULT)
+			)`,
+			subzones: []string{`@primary`},
+			expected: []string{`@primary /1-/2`},
+		},
+		{
+			name: `inheritance - single col default`,
+			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY LIST (a) (
+				PARTITION p3 VALUES (3),
+				PARTITION pd VALUES (DEFAULT)
+			)`,
+			subzones: []string{`@primary`, `.pd`},
+			expected: []string{`.pd /1-/2`},
+		},
+		{
+			name: `inheritance - multi col default`,
+			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
+				PARTITION p34 VALUES (3, 4),
+				PARTITION p3d VALUES (3, DEFAULT),
+				PARTITION p56 VALUES (5, 6),
+				PARTITION p5d VALUES (5, DEFAULT)
+			)`,
+			subzones: []string{`@primary`, `.p3d`, `.p56`},
+			expected: []string{
+				`@primary /1-/1/3`,
+				`    .p3d /1/3-/1/4`,
+				`@primary /1/4-/1/5/6`,
+				`    .p56 /1/5/6-/1/5/7`,
+				`@primary /1/5/7-/2`,
+			},
+		},
+		{
+			name: `inheritance - subpartitioning`,
+			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+				PARTITION p3 VALUES (3) PARTITION BY LIST (b) (
+					PARTITION p34 VALUES (4),
+					PARTITION p3d VALUES (DEFAULT)
+				),
+				PARTITION p5 VALUES (5) PARTITION BY LIST (b) (
+					PARTITION p56 VALUES (6),
+					PARTITION p5d VALUES (DEFAULT)
+				),
+				PARTITION p7 VALUES (7) PARTITION BY LIST (b) (
+					PARTITION p78 VALUES (8),
+					PARTITION p7d VALUES (DEFAULT)
+				)
+			)`,
+			subzones: []string{`@primary`, `.p3d`, `.p56`, `.p7`},
+			expected: []string{
+				`@primary /1-/1/3`,
+				`    .p3d /1/3-/1/4`,
+				`@primary /1/4-/1/5/6`,
+				`    .p56 /1/5/6-/1/5/7`,
+				`@primary /1/5/7-/1/7`,
+				`     .p7 /1/7-/1/8`,
+				`@primary /1/8-/2`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var tableDesc *sqlbase.TableDescriptor
+			{
+				stmt, err := parser.ParseOne(test.schema)
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				createTable, ok := stmt.(*parser.CreateTable)
+				if !ok {
+					t.Fatalf("expected *parser.CreateTable got %T", stmt)
+				}
+				const parentID, tableID = keys.MaxReservedDescID + 1, keys.MaxReservedDescID + 2
+				tableDesc, err = makeCSVTableDescriptor(
+					ctx, createTable, parentID, tableID, hlc.UnixNano())
+				if err != nil {
+					t.Fatalf("%+v", err)
+				}
+				if err := tableDesc.ValidateTable(); err != nil {
+					t.Fatalf("%+v", err)
+				}
+			}
+
+			var subzones []config.Subzone
+			for _, subzoneShort := range test.subzones {
+				if strings.HasPrefix(subzoneShort, "@") {
+					idxDesc, _, err := tableDesc.FindIndexByName(subzoneShort[1:])
+					if err != nil {
+						log.Info(ctx, tableDesc)
+						t.Fatalf("could not find index %s: %+v", subzoneShort, err)
+					}
+					subzones = append(subzones, config.Subzone{IndexID: uint32(idxDesc.ID)})
+				} else if strings.HasPrefix(subzoneShort, ".") {
+					// TODO(dan): decide if config.Subzone needs to have IndexID
+					// set when PartitionName is non-empty. The proto comment
+					// doesn't specify.
+					subzones = append(subzones, config.Subzone{PartitionName: subzoneShort[1:]})
+				}
+			}
+			spans, err := GenerateSubzoneSpans(tableDesc, subzones)
+			if err != nil {
+				t.Fatalf("generating subzone spans: %+v", err)
+			}
+
+			var actual []string
+			for _, span := range spans {
+				// Verify that we're always doing the space savings when we can.
+				if span.Key.PrefixEnd().Equal(span.EndKey) {
+					t.Errorf("endKey should be omitted when equal to key.PrefixEnd [%s, %s)",
+						prettyTrimmedKey(span.Key), prettyTrimmedKey(span.EndKey))
+				}
+				if len(span.EndKey) == 0 {
+					span.EndKey = span.Key.PrefixEnd()
+				}
+
+				// TODO(dan): Check that spans are sorted.
+
+				var subzoneShort string
+				if subzone := subzones[span.SubzoneIndex]; len(subzone.PartitionName) > 0 {
+					subzoneShort = "." + subzone.PartitionName
+				} else {
+					idxDesc, err := tableDesc.FindIndexByID(sqlbase.IndexID(subzone.IndexID))
+					if err != nil {
+						t.Fatalf("could not find index with ID %d: %+v", subzone.IndexID, err)
+					}
+					subzoneShort = "@" + idxDesc.Name
+				}
+				actual = append(actual, fmt.Sprintf("%s %s-%s", subzoneShort,
+					prettyTrimmedKey(span.Key), prettyTrimmedKey(span.EndKey),
+				))
+			}
+
+			if len(actual) != len(test.expected) {
+				t.Fatalf("got \n    %v\n expected \n    %v", actual, test.expected)
+			}
+			for i := range actual {
+				if expected := strings.TrimSpace(test.expected[i]); actual[i] != expected {
+					t.Errorf("%d: got [%s] expected [%s]", i, actual[i], expected)
+				}
+			}
+		})
+	}
+}

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -1140,7 +1140,7 @@ func valueEncodeTuple(
 	cols []sqlbase.ColumnDescriptor,
 ) ([]byte, error) {
 	if len(tuple.Exprs) != len(cols) {
-		return nil, errors.Errorf("partition has %d column(s) but %d value(s) were supplied",
+		return nil, errors.Errorf("partition has %d columns but %d values were supplied",
 			len(cols), len(tuple.Exprs))
 	}
 	var value, scratch []byte
@@ -1223,7 +1223,7 @@ func addPartitionedBy(
 		for _, tuple := range l.Tuples {
 			encodedTuple, err := valueEncodeTuple(parser.PartitionByList, evalCtx, tuple, cols)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "PARTITION %s", p.Name)
 			}
 			p.Values = append(p.Values, encodedTuple)
 		}
@@ -1243,7 +1243,7 @@ func addPartitionedBy(
 		}
 		encodedTuple, err := valueEncodeTuple(parser.PartitionByRange, evalCtx, r.Tuple, cols)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "PARTITION %s", p.Name)
 		}
 		if r.Subpartition != nil {
 			newColOffset := colOffset + int(partDesc.NumColumns)

--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -46,31 +46,31 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     )
 )
 
-statement error partition name p1 must be unique
+statement error PARTITION p1: name must be unique
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES (1),
     PARTITION p1 VALUES (2)
 )
 
-statement error partition name p1 must be unique
+statement error PARTITION p1: name must be unique
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES (1),
     PARTITION P1 VALUES (2)
 )
 
-statement error partition name p1 must be unique
+statement error  PARTITION p1: name must be unique
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES (1) PARTITION BY LIST (b) (
         PARTITION p1 VALUES (2)
     )
 )
 
-statement error partition has 1 column\(s\) but 2 value\(s\) were supplied
+statement error PARTITION p1: partition has 1 columns but 2 values were supplied
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES (0, 1)
 )
 
-statement error partition has 2 column\(s\) but 1 value\(s\) were supplied
+statement error PARTITION p1: partition has 2 columns but 1 values were supplied
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
     PARTITION p1 VALUES (0)
 )
@@ -187,12 +187,12 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     )
 )
 
-statement error MAXVALUE cannot be used with PARTITION BY LIST
+statement error PARTITION p1: MAXVALUE cannot be used with PARTITION BY LIST
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES (MAXVALUE)
 )
 
-statement error DEFAULT cannot be used with PARTITION BY RANGE
+statement error PARTITION p1: DEFAULT cannot be used with PARTITION BY RANGE
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
     PARTITION p1 VALUES LESS THAN (DEFAULT)
 )
@@ -257,7 +257,7 @@ CREATE TABLE ok7 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a
 )
 
 statement ok
-CREATE TABLE ok8 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a) (
+CREATE TABLE ok9 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES (1) PARTITION BY LIST (b) (
         PARTITION p1_1 VALUES (3),
         PARTITION p1_2 VALUES (4)
@@ -265,7 +265,8 @@ CREATE TABLE ok8 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST 
     PARTITION p2 VALUES (6) PARTITION BY RANGE (b) (
         PARTITION p2_1 VALUES LESS THAN (7) PARTITION BY LIST (c) (
             PARTITION p2_1_1 VALUES (8)
-        )
+        ),
+        PARTITION p2_2 VALUES LESS THAN (MAXVALUE)
     )
 )
 

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1233,29 +1233,55 @@ func (desc *TableDescriptor) validateTableIndexes(
 	return nil
 }
 
-// translateValueEncodingToKey parses columns encoded with the "value" encoding
-// and returns them reencoded using the "key ascending" encoding. The parsed
-// datums are also returned. If DEFAULT or MAXVALUE is encountered, the returned
-// row (both reencoded and parsed datums) will be shorter then len(colIDs);
-// specifically it will contain all the values up to but not including the
-// special one.
+// TranslateValueEncodingToSpan parses columns (which are a prefix of the
+// columns of `idxDesc`) encoded with the "value" encoding and returns the
+// parsed datums. It also reencodes them into a key as they would be for
+// `idxDesc` (accounting for index dirs, interleaves, subpartitioning, etc).
 //
-// TODO(dan): The upcoming PR that translates a TableDescriptor into spans for a
-// zone config will make this return the relevant key prefix (this is currently
-// implicit between this method and validatePartitioningDescriptor). At that
-// time, add documentation for how this logic works and lots of tests.
-func translateValueEncodingToKey(
-	typ parser.PartitionByType,
+// For a list partitioning, this returned key can be used as a prefix scan to
+// select all rows that have the given columns as a prefix (this is true even if
+// the list partitioning contains DEFAULT).
+//
+// Examples of the key returned for a list partitioning:
+// - (1, 2) -> /table/index/1/2
+// - (1, DEFAULT) -> /table/index/1
+// - (DEFAULT, DEFAULT) -> /table/index
+//
+// For a range partitioning, this returned key can be used as a exclusive end
+// key to select all rows strictly less than ones with the given columns as a
+// prefix (this is true even if the range partitioning contains MAXVALUE).
+//
+// Examples of the key returned for a range partitioning:
+// - (1, 2) -> /table/index/1/3
+// - (1, MAXVALUE) -> /table/index/2
+// - (DEFAULT, DEFAULT) -> (/table/index).PrefixEnd()
+//
+// If DEFAULT or MAXVALUE is encountered, the returned row (both reencoded and
+// parsed datums) will be shorter then len(colIDs); specifically it will contain
+// all the values up to but not including the special one.
+//
+// NB: It is required elsewhere and assumed here that if an entry for a list
+// partitioning contains DEFAULT, everything in that entry "after" also has to
+// be DEFAULT. So, (1, 2, DEFAULT) is valid but (1, DEFAULT, 2) is not.
+// Similarly for range partitioning and MAXVALUE.
+func TranslateValueEncodingToSpan(
 	a *DatumAlloc,
-	desc *TableDescriptor,
+	tableDesc *TableDescriptor,
+	idxDesc *IndexDescriptor,
+	partDesc *PartitioningDescriptor,
 	valueEncBuf []byte,
-	colIDs []ColumnID,
+	prefixDatums []parser.Datum,
 ) (parser.Datums, []byte, error) {
-	datums := make(parser.Datums, len(colIDs))
-	var keyEncBuf []byte
+	if len(prefixDatums)+int(partDesc.NumColumns) > len(idxDesc.ColumnIDs) {
+		return nil, nil, fmt.Errorf("not enough columns in index for this partitioning")
+	}
+
+	datums := make(parser.Datums, int(partDesc.NumColumns))
 	specialIdx := -1
+
+	colIDs := idxDesc.ColumnIDs[len(prefixDatums) : len(prefixDatums)+int(partDesc.NumColumns)]
 	for i, colID := range colIDs {
-		col, err := desc.FindActiveColumnByID(colID)
+		col, err := tableDesc.FindColumnByID(colID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1273,23 +1299,15 @@ func translateValueEncodingToKey(
 			return nil, nil, errors.Wrap(err, "decoding")
 		}
 		if specialIdx != -1 {
-			switch typ {
-			case parser.PartitionByList:
-				return nil, nil, errors.Errorf("non-DEFAULT value (%s) not allowed after DEFAULT",
-					datums[i])
-			case parser.PartitionByRange:
-				return nil, nil, errors.Errorf("non-MAXVALUE value (%s) not allowed after MAXVALUE",
-					datums[i])
-			default:
-				return nil, nil, errors.Errorf("unknown partition type: %s", typ)
+			if len(partDesc.List) > 0 && len(partDesc.Range) == 0 {
+				return nil, nil, errors.Errorf(
+					"non-DEFAULT value (%s) not allowed after DEFAULT", datums[i])
+			} else if len(partDesc.Range) > 0 && len(partDesc.List) == 0 {
+				return nil, nil, errors.Errorf(
+					"non-MAXVALUE value (%s) not allowed after MAXVALUE", datums[i])
+			} else {
+				return nil, nil, errors.Errorf("unknown partition type")
 			}
-		}
-		// TODO(dan): One we start using this method to fill in zone configs,
-		// this encoding has to match the index direction (instead of always
-		// being ascending).
-		keyEncBuf, err = EncodeTableKey(keyEncBuf, datums[i], encoding.Ascending)
-		if err != nil {
-			return nil, nil, err
 		}
 	}
 	if len(valueEncBuf) > 0 {
@@ -1298,7 +1316,35 @@ func translateValueEncodingToKey(
 	if specialIdx != -1 {
 		datums = datums[:specialIdx]
 	}
-	return datums, keyEncBuf, nil
+
+	allDatums := append(prefixDatums, datums...)
+	colMap := make(map[ColumnID]int, len(allDatums))
+	for i := range allDatums {
+		colMap[idxDesc.ColumnIDs[i]] = i
+	}
+
+	indexKeyPrefix := MakeIndexKeyPrefix(tableDesc, idxDesc.ID)
+	key, _, err := EncodePartialIndexKey(
+		tableDesc, idxDesc, len(allDatums), colMap, allDatums, indexKeyPrefix)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Currently, key looks something like `/table/index/1`. Given a range
+	// partitioning of (1), we're done. This can be used as the exclusive end
+	// key of a scan to fetch all rows strictly less than (1).
+	//
+	// If `specialIdx` is not the sentinel, then we're actually in a case like
+	// `(1, MAXVALUE, ..., MAXVALUE)`. Since this index could have a descending
+	// nullable column, we can't rely on `/table/index/1/0xff` to be _strictly_
+	// larger than everything it should match. Instead, we need `PrefixEnd()`.
+	// This also intuitively makes sense; we're essentially a key that is
+	// guaranteed to be less than `(2, MINVALUE, ..., MINVALUE)`.
+	if specialIdx != -1 && len(partDesc.Range) > 0 {
+		key = roachpb.Key(key).PrefixEnd()
+	}
+
+	return datums, key, nil
 }
 
 func printPartitioningPrefix(datums []parser.Datum, s string) string {
@@ -1332,10 +1378,16 @@ func (desc *TableDescriptor) validatePartitioningDescriptor(
 	if partDesc.NumColumns == 0 {
 		return nil
 	}
-	if colOffset+int(partDesc.NumColumns) > len(idxDesc.ColumnIDs) {
-		return fmt.Errorf("not enough columns in index for this partitioning")
+
+	// We don't need real prefixes in the TranslateValueEncodingToSpan calls
+	// because we're only using it to look for collisions and the prefix would
+	// be the same for all of them. Faking them out with DNull allows us to make
+	// O(list partition) calls to TranslateValueEncodingToSpan instead of O(list
+	// partition entry).
+	fakePrefixDatums := make([]parser.Datum, colOffset)
+	for i := range fakePrefixDatums {
+		fakePrefixDatums[i] = parser.DNull
 	}
-	colIDs := idxDesc.ColumnIDs[colOffset : colOffset+int(partDesc.NumColumns)]
 
 	if len(partDesc.List) == 0 && len(partDesc.Range) == 0 {
 		return fmt.Errorf("at least one of LIST or RANGE partitioning must be used")
@@ -1348,34 +1400,33 @@ func (desc *TableDescriptor) validatePartitioningDescriptor(
 		listValues := make(map[string]struct{}, len(partDesc.List))
 		for _, p := range partDesc.List {
 			if len(p.Name) == 0 {
-				return fmt.Errorf("partition name must be non-empty")
+				return fmt.Errorf("PARTITION name must be non-empty")
 			}
 			if _, exists := partitionNames[p.Name]; exists {
-				return fmt.Errorf("partition name %s must be unique", p.Name)
+				return fmt.Errorf("PARTITION %s: name must be unique", p.Name)
 			}
 			partitionNames[p.Name] = struct{}{}
 
 			if len(p.Values) == 0 {
-				return fmt.Errorf("partition %s must contain values", p.Name)
+				return fmt.Errorf("PARTITION %s: must contain values", p.Name)
 			}
 			// NB: key encoding is used to check uniqueness because it has
 			// to match the behavior of the value when indexed.
 			for _, valueEncBuf := range p.Values {
-				datums, keyEncBuf, err := translateValueEncodingToKey(
-					parser.PartitionByList, a, desc, valueEncBuf, colIDs,
-				)
+				datums, keyPrefix, err := TranslateValueEncodingToSpan(
+					a, desc, idxDesc, partDesc, valueEncBuf, fakePrefixDatums)
 				if err != nil {
 					return fmt.Errorf("PARTITION %s: %v", p.Name, err)
 				}
-				if _, exists := listValues[string(keyEncBuf)]; exists {
-					if len(datums) != len(colIDs) {
+				if _, exists := listValues[string(keyPrefix)]; exists {
+					if len(datums) != int(partDesc.NumColumns) {
 						return fmt.Errorf("prefix (%s) cannot be present in more than one partition",
 							printPartitioningPrefix(datums, "DEFAULT"))
 					}
 					return fmt.Errorf("%s cannot be present in more than one partition",
 						parser.AsString(datums))
 				}
-				listValues[string(keyEncBuf)] = struct{}{}
+				listValues[string(keyPrefix)] = struct{}{}
 			}
 
 			newColOffset := colOffset + int(partDesc.NumColumns)
@@ -1388,7 +1439,7 @@ func (desc *TableDescriptor) validatePartitioningDescriptor(
 	}
 
 	if len(partDesc.Range) > 0 {
-		var lastValue []byte
+		var lastEndKey []byte
 		rangeValues := make(map[string]struct{}, len(partDesc.Range))
 		for _, p := range partDesc.Range {
 			if len(p.Name) == 0 {
@@ -1402,19 +1453,13 @@ func (desc *TableDescriptor) validatePartitioningDescriptor(
 			// NB: key encoding is used to check sortedness and uniqueness
 			// because it has to match the behavior of the value when
 			// indexed.
-			datums, keyEncBuf, err := translateValueEncodingToKey(
-				parser.PartitionByRange, a, desc, p.UpperBound, colIDs,
-			)
+			datums, endKey, err := TranslateValueEncodingToSpan(
+				a, desc, idxDesc, partDesc, p.UpperBound, fakePrefixDatums)
 			if err != nil {
 				return fmt.Errorf("PARTITION %s: %v", p.Name, err)
 			}
-			if len(datums) < len(colIDs) {
-				// MAXVALUE, so encode something that always sorts higher than
-				// any possible value for this column.
-				keyEncBuf = roachpb.Key(keyEncBuf).PrefixEnd()
-			}
-			if _, exists := rangeValues[string(keyEncBuf)]; exists {
-				if len(datums) != len(colIDs) {
+			if _, exists := rangeValues[string(endKey)]; exists {
+				if len(datums) != int(partDesc.NumColumns) {
 					return fmt.Errorf("prefix (%s) cannot be present in more than one partition",
 						printPartitioningPrefix(datums, "MAXVALUE"))
 				}
@@ -1422,11 +1467,11 @@ func (desc *TableDescriptor) validatePartitioningDescriptor(
 					parser.AsString(datums))
 			}
 
-			rangeValues[string(keyEncBuf)] = struct{}{}
-			if bytes.Compare(lastValue, keyEncBuf) >= 0 {
-				return fmt.Errorf("values must be strictly increasing")
+			rangeValues[string(endKey)] = struct{}{}
+			if bytes.Compare(lastEndKey, endKey) >= 0 {
+				return fmt.Errorf("values must be strictly increasing: %s vs %s", roachpb.Key(lastEndKey), roachpb.Key(endKey))
 			}
-			lastValue = keyEncBuf
+			lastEndKey = endKey
 
 			newColOffset := colOffset + int(partDesc.NumColumns)
 			if err := desc.validatePartitioningDescriptor(
@@ -1785,6 +1830,9 @@ func (desc *TableDescriptor) FindFamilyByID(id FamilyID) (*ColumnFamilyDescripto
 // FindIndexByName finds the index with the specified name in the active
 // list or the mutations list. It returns true if the index is being dropped.
 func (desc *TableDescriptor) FindIndexByName(name string) (IndexDescriptor, bool, error) {
+	if desc.IsPhysicalTable() && desc.PrimaryIndex.Name == name {
+		return desc.PrimaryIndex, false, nil
+	}
 	for i, idx := range desc.Indexes {
 		if idx.Name == name {
 			return desc.Indexes[i], false, nil

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -865,41 +865,31 @@ func TestValidatePartitioning(t *testing.T) {
 		err  string
 		desc TableDescriptor
 	}{
-		{"not enough columns in index for this partitioning",
-			TableDescriptor{
-				PrimaryIndex: IndexDescriptor{
-					Partitioning: PartitioningDescriptor{
-						NumColumns: 1,
-					},
-				},
-			},
-		},
-		{"not enough columns in index for this partitioning",
-			TableDescriptor{
-				Columns: []ColumnDescriptor{{ID: 1, Type: ColumnType{SemanticType: ColumnType_INT}}},
-				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1},
-					Partitioning: PartitioningDescriptor{
-						NumColumns: 1,
-						List: []PartitioningDescriptor_List{
-							{
-								Name:   "p1",
-								Values: [][]byte{{0x03, 0x02}},
-								Subpartitioning: PartitioningDescriptor{
-									NumColumns: 1,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
 		{"at least one of LIST or RANGE partitioning must be used",
 			TableDescriptor{
 				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1},
 					Partitioning: PartitioningDescriptor{
 						NumColumns: 1,
+					},
+				},
+			},
+		},
+		{"PARTITION p1: must contain values",
+			TableDescriptor{
+				PrimaryIndex: IndexDescriptor{
+					Partitioning: PartitioningDescriptor{
+						NumColumns: 1,
+						List:       []PartitioningDescriptor_List{{Name: "p1"}},
+					},
+				},
+			},
+		},
+		{"not enough columns in index for this partitioning",
+			TableDescriptor{
+				PrimaryIndex: IndexDescriptor{
+					Partitioning: PartitioningDescriptor{
+						NumColumns: 1,
+						List:       []PartitioningDescriptor_List{{Name: "p1", Values: [][]byte{{}}}},
 					},
 				},
 			},
@@ -907,43 +897,38 @@ func TestValidatePartitioning(t *testing.T) {
 		{"only one LIST or RANGE partitioning may used",
 			TableDescriptor{
 				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1},
+					ColumnIDs:        []ColumnID{1},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 					Partitioning: PartitioningDescriptor{
 						NumColumns: 1,
-						List: []PartitioningDescriptor_List{
-							{},
-						},
-						Range: []PartitioningDescriptor_Range{
-							{},
-						},
+						List:       []PartitioningDescriptor_List{{}},
+						Range:      []PartitioningDescriptor_Range{{}},
 					},
 				},
 			},
 		},
-		{"partition name must be non-empty",
+		{"PARTITION name must be non-empty",
 			TableDescriptor{
 				Columns: []ColumnDescriptor{{ID: 1, Type: ColumnType{SemanticType: ColumnType_INT}}},
 				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1},
+					ColumnIDs:        []ColumnID{1},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 					Partitioning: PartitioningDescriptor{
 						NumColumns: 1,
-						List: []PartitioningDescriptor_List{
-							{},
-						},
+						List:       []PartitioningDescriptor_List{{}},
 					},
 				},
 			},
 		},
-		{"partition p1 must contain values",
+		{"PARTITION p1: must contain values",
 			TableDescriptor{
 				Columns: []ColumnDescriptor{{ID: 1, Type: ColumnType{SemanticType: ColumnType_INT}}},
 				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1},
+					ColumnIDs:        []ColumnID{1},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 					Partitioning: PartitioningDescriptor{
 						NumColumns: 1,
-						List: []PartitioningDescriptor_List{
-							{Name: "p1"},
-						},
+						List:       []PartitioningDescriptor_List{{Name: "p1"}},
 					},
 				},
 			},
@@ -952,12 +937,13 @@ func TestValidatePartitioning(t *testing.T) {
 			TableDescriptor{
 				Columns: []ColumnDescriptor{{ID: 1, Type: ColumnType{SemanticType: ColumnType_INT}}},
 				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1},
+					ColumnIDs:        []ColumnID{1},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 					Partitioning: PartitioningDescriptor{
 						NumColumns: 1,
-						List: []PartitioningDescriptor_List{
-							{Name: "p1", Values: [][]byte{{}}},
-						},
+						List: []PartitioningDescriptor_List{{
+							Name: "p1", Values: [][]byte{{}},
+						}},
 					},
 				},
 			},
@@ -966,7 +952,8 @@ func TestValidatePartitioning(t *testing.T) {
 			TableDescriptor{
 				Columns: []ColumnDescriptor{{ID: 1, Type: ColumnType{SemanticType: ColumnType_INT}}},
 				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1},
+					ColumnIDs:        []ColumnID{1},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 					Partitioning: PartitioningDescriptor{
 						NumColumns: 1,
 						List: []PartitioningDescriptor_List{
@@ -980,7 +967,8 @@ func TestValidatePartitioning(t *testing.T) {
 			TableDescriptor{
 				Columns: []ColumnDescriptor{{ID: 1, Type: ColumnType{SemanticType: ColumnType_INT}}},
 				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1},
+					ColumnIDs:        []ColumnID{1},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 					Partitioning: PartitioningDescriptor{
 						NumColumns: 1,
 						List: []PartitioningDescriptor_List{
@@ -994,7 +982,8 @@ func TestValidatePartitioning(t *testing.T) {
 			TableDescriptor{
 				Columns: []ColumnDescriptor{{ID: 1, Type: ColumnType{SemanticType: ColumnType_INT}}},
 				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1, 1},
+					ColumnIDs:        []ColumnID{1, 1},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC, IndexDescriptor_ASC},
 					Partitioning: PartitioningDescriptor{
 						NumColumns: 1,
 						Range: []PartitioningDescriptor_Range{
@@ -1005,11 +994,12 @@ func TestValidatePartitioning(t *testing.T) {
 				},
 			},
 		},
-		{"partition name p1 must be unique",
+		{"PARTITION p1: name must be unique",
 			TableDescriptor{
 				Columns: []ColumnDescriptor{{ID: 1, Type: ColumnType{SemanticType: ColumnType_INT}}},
 				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1},
+					ColumnIDs:        []ColumnID{1},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
 					Partitioning: PartitioningDescriptor{
 						NumColumns: 1,
 						List: []PartitioningDescriptor_List{
@@ -1020,11 +1010,32 @@ func TestValidatePartitioning(t *testing.T) {
 				},
 			},
 		},
-		{"partition name p1 must be unique",
+		{"not enough columns in index for this partitioning",
 			TableDescriptor{
 				Columns: []ColumnDescriptor{{ID: 1, Type: ColumnType{SemanticType: ColumnType_INT}}},
 				PrimaryIndex: IndexDescriptor{
-					ColumnIDs: []ColumnID{1, 1},
+					ColumnIDs:        []ColumnID{1},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC},
+					Partitioning: PartitioningDescriptor{
+						NumColumns: 1,
+						List: []PartitioningDescriptor_List{{
+							Name:   "p1",
+							Values: [][]byte{{0x03, 0x02}},
+							Subpartitioning: PartitioningDescriptor{
+								NumColumns: 1,
+								List:       []PartitioningDescriptor_List{{Name: "p1_1", Values: [][]byte{{}}}},
+							},
+						}},
+					},
+				},
+			},
+		},
+		{"PARTITION p1: name must be unique",
+			TableDescriptor{
+				Columns: []ColumnDescriptor{{ID: 1, Type: ColumnType{SemanticType: ColumnType_INT}}},
+				PrimaryIndex: IndexDescriptor{
+					ColumnIDs:        []ColumnID{1, 1},
+					ColumnDirections: []IndexDescriptor_Direction{IndexDescriptor_ASC, IndexDescriptor_ASC},
 					Partitioning: PartitioningDescriptor{
 						NumColumns: 1,
 						List: []PartitioningDescriptor_List{


### PR DESCRIPTION
GenerateSubzoneSpans constructs from a TableDescriptor the entries mapping
zone config spans to subzones for use in the SubzoneSpans field of
config.ZoneConfig. SubzoneSpans controls which splits are created, so only
the spans corresponding to entries in subzones are returned.

Zone configs target indexes and partitions via `subzones`, which are attached
to a table-scoped row in `system.zones`. Each subzone represents one index
(primary or secondary) or one partition (or subpartition) and contains the
usual zone config constraints. They are saved to `system.zones` sparsely
(only when set by a user) and are the most specific entry in the normal
cluster-default/database/table/subzone config hierarchy.

Each non-interleaved index and partition can be mapped to spans in the
keyspace. Indexes and range partitions each map to one span, while each list
partition maps to one or more spans. Each partition span is contained by some
index span and each subpartition span is contained by one of its parent
partition's spans. The spans for a given level of a range partitioning
(corresponding to one `PARTITION BY` in sql or one `PartitionDescriptor`) are
disjoint, but the spans for a given level of a list partitioning may overlap
if DEFAULT is used. A list partitioning which includes both (1, DEFAULT) and
(1, 2) will overlap with the latter getting precedence in the zone config
hierarchy. NB: In a valid PartitionDescriptor, no partitions with the same
number of DEFAULTs will overlap (this property is used by
`indexCoveringsForPartitioning`).

These subzone spans are kept denormalized to the relevant `system.zone` row
for performance. Given a TableDescriptor, the spans for every
index/partition/subpartition are created, filtered out if they don't have a
config set for them, and precedence applied (via `OverlapCoveringMerge`) to
produce a set of non-overlapping spans, which each map to a subzone. There
may be "holes" (uncovered spans) in this set.

The returned spans are returned in exactly the format required by
`system.zones`. They must be sorted and non-overlapping. Each contains an
IndexID, which maps to one of the input `subzones` by indexing into the
slice. As space optimizations, all `Key`s and `EndKey`s of `SubzoneSpan` omit
the common prefix (the encoded table ID) and if `EndKey` is equal to
`Key.PrefixEnd()` it is omitted.

Release Note: none