### PR TITLE
ui: cluster overview

### DIFF
--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -34,6 +34,7 @@ import TableDetails from "src/views/databases/containers/tableDetails";
 
 import JobsPage from "src/views/jobs";
 
+import ClusterOverview from "src/views/cluster/containers/clusterOverview";
 import NodesOverview from "src/views/cluster/containers/nodesOverview";
 import NodeOverview from "src/views/cluster/containers/nodeOverview";
 import NodeGraphs from "src/views/cluster/containers/nodeGraphs";
@@ -67,7 +68,10 @@ ReactDOM.render(
   <Provider store={store}>
     <Router history={history}>
       <Route path="/" component={Layout}>
-        <IndexRedirect to="cluster" />
+        <IndexRedirect to="overview" />
+        <Route path="overview">
+          <IndexRoute component={ClusterOverview} />
+        </Route>
         <Route path="cluster">
           <IndexRedirect to="all/overview" />
           <Route path={`all/:${dashboardNameAttr}`} component={NodeGraphs} />

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -140,6 +140,8 @@ const nodeSumsSelector = createSelector(
       capacityTotal: 0,
       usedBytes: 0,
       usedMem: 0,
+      totalRanges: 0,
+      underReplicatedRanges: 0,
       unavailableRanges: 0,
       replicas: 0,
     };
@@ -170,6 +172,8 @@ const nodeSumsSelector = createSelector(
           result.capacityTotal += n.metrics[MetricConstants.capacity];
           result.usedBytes += BytesUsed(n);
           result.usedMem += n.metrics[MetricConstants.rss];
+          result.totalRanges += n.metrics[MetricConstants.ranges];
+          result.underReplicatedRanges += n.metrics[MetricConstants.underReplicatedRanges];
           result.unavailableRanges += n.metrics[MetricConstants.unavailableRanges];
           result.replicas += n.metrics[MetricConstants.replicas];
         }

--- a/pkg/ui/src/util/format.ts
+++ b/pkg/ui/src/util/format.ts
@@ -24,11 +24,25 @@ export function ComputePrefixExponent(value: number, prefixMultiple: number, pre
   return prefixScale;
 }
 
-export function BytesToUnitValue(bytes: number): UnitValue {
+/**
+ * ComputeByteScale calculates the appropriate scale factor and unit to use to
+ * display a given byte value, without actually converting the value.
+ *
+ * This is used to prescale byte values before passing them to a d3-axis.
+ */
+export function ComputeByteScale(bytes: number): UnitValue {
   const scale = ComputePrefixExponent(bytes, kibi, byteUnits);
   return {
-    value: bytes / Math.pow(kibi, scale),
+    value: Math.pow(kibi, scale),
     units: byteUnits[scale],
+  };
+}
+
+export function BytesToUnitValue(bytes: number): UnitValue {
+  const scale = ComputeByteScale(bytes);
+  return {
+    value: bytes / scale.value,
+    units: scale.units,
   };
 }
 

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -44,7 +44,8 @@ export default class extends React.Component<{}, {}> {
   render() {
     return <nav className="navigation-bar">
       <ul className="navigation-bar__list">
-        <IconLink to="/cluster" icon={Icons.clusterIcon} title="Cluster" />
+        <IconLink to="/overview" icon={Icons.clusterIcon} title="Overview" />
+        <IconLink to="/cluster" icon={Icons.nodesIcon} title="Cluster" />
         <IconLink to="/databases" icon={Icons.databaseIcon} title="Databases"/>
         <IconLink to="/jobs" icon={Icons.jobsIcon} title="Jobs"/>
       </ul>

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/capacity.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/capacity.tsx
@@ -1,0 +1,107 @@
+import d3 from "d3";
+
+import { ComputeByteScale } from "src/util/format";
+
+interface CapacityChartProps {
+  used: number;
+  usable: number;
+}
+
+/**
+ * capacityChart is the small bar chart showing capacity usage displayed on the
+ * cluster summary panel of the cluster overview page.
+ */
+function capacityChart() {
+  const size = {
+    width: 250,
+    height: 20,
+  };
+
+  const margin = {
+    top: 12,
+    right: 35,
+    bottom: 25,
+    left: 20,
+  };
+
+  const TICK_SIZE = 6;
+  const AXIS_MARGIN = 4;
+
+  const scale = d3.scale.linear()
+    .range([0, size.width]);
+
+  const axis = d3.svg.axis()
+    .scale(scale)
+    .tickSize(TICK_SIZE)
+    .ticks(5);
+
+  function recomputeScale(capacity: CapacityChartProps) {
+    // Compute the appropriate scale factor for a value slightly smaller than the
+    // usable capacity, so that if the usable capacity is exactly 1 {MiB,GiB,etc}
+    // we show the scale in the next-smaller unit.
+    const byteScale = ComputeByteScale(capacity.usable - 1);
+
+    const scaled = {
+      used: capacity.used / byteScale.value,
+      usable: capacity.usable / byteScale.value,
+    };
+
+    axis.tickFormat(function (d) {
+      return d + " " + byteScale.units;
+    });
+    scale.domain([0, scaled.usable]);
+
+    return scaled;
+  }
+
+  return function chart(svg: d3.Selection<CapacityChartProps>) {
+    svg
+      .attr("width", size.width + margin.left + margin.right)
+      .attr("height", size.height + margin.top + margin.bottom);
+
+    const el = svg.selectAll(".main")
+      .data((d: CapacityChartProps) => [recomputeScale(d)]);
+
+    el.enter()
+      .append("g")
+      .attr("class", "main")
+      .attr("transform", `translate(${margin.left},${margin.top})`);
+
+    const axisGroup = el.selectAll("g.axis")
+      .data(() => [0]);
+
+    axisGroup.enter()
+      .append("g")
+      .attr("class", "axis")
+      .attr("transform", `translate(0,${size.height + AXIS_MARGIN})`);
+
+    axisGroup.call(axis);
+    axisGroup.selectAll("text").attr("y", AXIS_MARGIN + TICK_SIZE);
+
+    const bg = el.selectAll(".bg")
+      .data((d: CapacityChartProps) => [d]);
+
+    bg.enter()
+      .append("rect")
+      .attr("class", "bg");
+
+    bg
+      .attr("width", size.width)
+      .attr("height", size.height);
+
+    const bar = el.selectAll(".bar")
+      .data((d: CapacityChartProps) => [d]);
+
+    bar.enter()
+      .append("rect")
+      .attr("class", "bar")
+      .attr("height", 10)
+      .attr("y", 5);
+
+    bar
+      .attr("width", (d: CapacityChartProps) => scale(d.used));
+
+  };
+}
+
+export default capacityChart;

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -1,0 +1,150 @@
+@require "~styl/base/palette.styl"
+@require "~styl/layout/layout.styl"
+
+.cluster-overview
+  /* TODO(couchand): Update the layout styles to get rid of this hack. */
+  margin-top -1 * $page-padding-top
+  border-bottom 1px solid $table-border-color
+
+  .cluster-ticker
+    padding-top 0
+    padding-bottom 0
+
+  .cluster-summary
+    background-color white
+    padding-top $page-padding-top
+    padding-bottom $page-padding-top
+    padding-left 20px
+    color gray
+    display grid
+    align-items end
+    grid-template-columns 0.8fr 3fr 1fr 1fr 1fr 1fr 0.5fr 1fr 1.2fr 1fr 0.5fr
+    grid-template-rows repeat(3, auto)
+    grid-template-areas "cap-t cap-t . live-t live-t live-t . rep-t rep-t rep-t ." "cap-m cap-c . live-a live-b live-c . rep-a rep-b rep-c ." "cap-a cap-a . live-1 live-2 live-3 . rep-1 rep-2 rep-3 ."
+
+    &__section
+      display contents
+
+      &.capacity-usage
+        .cluster-summary__title
+            grid-area cap-t
+
+        .cluster-summary__chart
+            grid-area cap-c
+
+        .cluster-summary__metric
+            grid-area cap-m
+
+        .cluster-summary__aside
+            grid-area cap-a
+
+      &.node-liveness
+        .cluster-summary__title
+            grid-area live-t
+
+        .cluster-summary__metric.live-nodes
+            grid-area live-a
+
+        .cluster-summary__metric.suspect-nodes
+            grid-area live-b
+
+        .cluster-summary__metric.dead-nodes
+            grid-area live-c
+
+        .cluster-summary__label.live-nodes
+            grid-area live-1
+
+        .cluster-summary__label.suspect-nodes
+            grid-area live-2
+
+        .cluster-summary__label.dead-nodes
+            grid-area live-3
+
+      &.replication-status
+        .cluster-summary__title
+            grid-area rep-t
+
+        .cluster-summary__metric.total-ranges
+            grid-area rep-a
+
+        .cluster-summary__metric.under-replicated-ranges
+            grid-area rep-b
+
+        .cluster-summary__metric.unavailable-ranges
+            grid-area rep-c
+
+        .cluster-summary__label.total-ranges
+            grid-area rep-1
+
+        .cluster-summary__label.under-replicated-ranges
+            grid-area rep-2
+
+        .cluster-summary__label.unavailable-ranges
+            grid-area rep-3
+
+    &__title
+      font-weight 400
+      margin-bottom 20px
+
+    &__metric
+      align-self start
+      font-size 30px
+      line-height 48px
+      color $link-color
+
+
+      &.warning
+        color $warning-color
+
+      &.alert
+        color $alert-color
+
+    &__label
+      font-size 11px
+      line-height 14px
+      padding-top 7px
+      text-transform uppercase
+
+    &__aside
+      .label
+        text-transform uppercase
+        margin-right 14px
+
+      .value
+        color $link-color
+
+      .label, .value
+        font-size 11px
+
+  .capacity-usage .cluster-summary__chart
+    align-self start
+    position relative
+
+    svg
+      position absolute
+      shape-rendering crispEdges
+
+    .axis path
+      fill none
+      stroke none
+
+    .axis line
+      fill none
+      stroke gray
+      shape-rendering crispEdges
+
+    .axis text
+      font-size 12px
+      fill gray
+
+    .axis .tick:nth-child(2n) text
+      display none
+
+    rect
+      shape-rendering crispEdges
+
+      &.bg
+        fill lightgray
+
+      &.bar
+        fill $link-color

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -1,0 +1,174 @@
+import d3 from "d3";
+import React from "react";
+import { connect } from "react-redux";
+import { createSelector } from "reselect";
+
+import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
+import { Bytes as formatBytes } from "src/util/format";
+import { NodesOverview } from "src/views/cluster/containers/nodesOverview";
+import createChartComponent from "src/views/shared/util/d3-react";
+import capacityChart from "./capacity";
+
+import "./cluster.styl";
+
+// tslint:disable-next-line:variable-name
+const CapacityChart = createChartComponent(capacityChart);
+
+class ClusterTicker extends React.Component<{}, {}> {
+  render() {
+    return (
+      <section className="section cluster-ticker">
+        <h2>Cluster Overview</h2>
+      </section>
+    );
+  }
+}
+
+interface CapacityUsageProps {
+  usedCapacity: number;
+  usableCapacity: number;
+}
+
+const formatPercentage = d3.format("0.1%");
+
+class CapacityUsage extends React.Component<CapacityUsageProps, {}> {
+  render() {
+    const { usedCapacity, usableCapacity } = this.props;
+    const usedPercentage = usableCapacity !== 0 ? usedCapacity / usableCapacity : 0;
+    return (
+      <div className="cluster-summary__section capacity-usage">
+        <h3 className="cluster-summary__title">Capacity Usage</h3>
+        <div className="cluster-summary__metric">{ formatPercentage(usedPercentage) }</div>
+        <div className="cluster-summary__chart">
+          <CapacityChart used={usedCapacity} usable={usableCapacity} />
+        </div>
+        <div className="cluster-summary__aside">
+          <span className="label">Current Usage</span>
+          <span className="value">{ formatBytes(usedCapacity) }</span>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToCapacityUsageProps = createSelector(
+  nodesSummarySelector,
+  function (nodesSummary: NodesSummary) {
+    const { capacityAvailable, capacityUsed } = nodesSummary.nodeSums;
+    const usableCapacity = capacityAvailable + capacityUsed;
+    return {
+      usedCapacity: capacityUsed,
+      usableCapacity: usableCapacity,
+    };
+  },
+);
+
+// tslint:disable-next-line:variable-name
+const CapacityUsageConnected = connect(mapStateToCapacityUsageProps)(CapacityUsage);
+
+interface NodeLivenessProps {
+  liveNodes: number;
+  suspectNodes: number;
+  deadNodes: number;
+}
+
+class NodeLiveness extends React.Component<NodeLivenessProps, {}> {
+  render() {
+    const { liveNodes, suspectNodes, deadNodes } = this.props;
+    return (
+      <div className="cluster-summary__section node-liveness">
+        <h3 className="cluster-summary__title">Node Liveness</h3>
+        <div className="cluster-summary__metric live-nodes">{ liveNodes }</div>
+        <div className="cluster-summary__label live-nodes">Live<br />Nodes</div>
+        <div className={ "cluster-summary__metric suspect-nodes" + (suspectNodes ? " warning" : "") }>{ suspectNodes }</div>
+        <div className="cluster-summary__label suspect-nodes">Suspect<br />Nodes</div>
+        <div className={ "cluster-summary__metric dead-nodes" + (deadNodes ? " alert" : "") }>{ deadNodes }</div>
+        <div className="cluster-summary__label dead-nodes">Dead<br />Nodes</div>
+      </div>
+    );
+  }
+}
+
+const mapStateToNodeLivenessProps = createSelector(
+  nodesSummarySelector,
+  function (nodesSummary: NodesSummary) {
+    const { nodeCounts } = nodesSummary.nodeSums;
+    return {
+      liveNodes: nodeCounts.healthy,
+      suspectNodes: nodeCounts.suspect,
+      deadNodes: nodeCounts.dead,
+    };
+  },
+);
+
+// tslint:disable-next-line:variable-name
+const NodeLivenessConnected = connect(mapStateToNodeLivenessProps)(NodeLiveness);
+
+interface ReplicationStatusProps {
+  totalRanges: number;
+  underReplicatedRanges: number;
+  unavailableRanges: number;
+}
+
+class ReplicationStatus extends React.Component<ReplicationStatusProps, {}> {
+  render() {
+    const { totalRanges, underReplicatedRanges, unavailableRanges } = this.props;
+    return (
+      <div className="cluster-summary__section replication-status">
+        <h3 className="cluster-summary__title">Replication Status</h3>
+        <div className="cluster-summary__metric total-ranges">{ totalRanges }</div>
+        <div className="cluster-summary__label total-ranges">Total<br />Ranges</div>
+        <div className={ "cluster-summary__metric under-replicated-ranges" + (underReplicatedRanges ? " warning" : "") }>{ underReplicatedRanges }</div>
+        <div className="cluster-summary__label under-replicated-ranges">Under-replicated<br />Ranges</div>
+        <div className={ "cluster-summary__metric unavailable-ranges" + (unavailableRanges ? " alert" : "") }>{ unavailableRanges }</div>
+        <div className="cluster-summary__label unavailable-ranges">Unavailable<br />Ranges</div>
+      </div>
+    );
+  }
+}
+
+const mapStateToReplicationStatusProps = createSelector(
+  nodesSummarySelector,
+  function (nodesSummary: NodesSummary) {
+    const { totalRanges, underReplicatedRanges, unavailableRanges } = nodesSummary.nodeSums;
+    return {
+      totalRanges: totalRanges,
+      underReplicatedRanges: underReplicatedRanges,
+      unavailableRanges: unavailableRanges,
+    };
+  },
+);
+
+// tslint:disable-next-line:variable-name
+const ReplicationStatusConnected = connect(mapStateToReplicationStatusProps)(ReplicationStatus);
+
+class ClusterSummary extends React.Component<{}, {}> {
+  render() {
+    return (
+      <section className="cluster-summary">
+        <CapacityUsageConnected />
+        <NodeLivenessConnected />
+        <ReplicationStatusConnected />
+      </section>
+    );
+  }
+}
+
+/**
+ * Renders the main content of the cluster visualization page.
+ */
+class ClusterOverview extends React.Component<{}, {}> {
+  render() {
+    return (
+      <div>
+        <div className="cluster-overview">
+          <ClusterTicker />
+          <ClusterSummary />
+        </div>
+        <NodesOverview />
+      </div>
+    );
+  }
+}
+
+export { ClusterOverview as default };

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -342,9 +342,6 @@ class NodesMain extends React.Component<NodesMainProps, {}> {
 
   render() {
     return <div>
-      <section className="section parent-link">
-        <Link to="/cluster">&lt; Back to Cluster</Link>
-      </section>
       <LiveNodesConnected />
       <DeadNodesConnected />
       <DecommissionedNodesConnected />
@@ -353,9 +350,10 @@ class NodesMain extends React.Component<NodesMainProps, {}> {
 }
 
 /**
- * nodesMainConnected is a redux-connected HOC of NodesMain.
+ * NodesMainConnected is a redux-connected HOC of NodesMain.
  */
-const nodesMainConnected = connect(
+// tslint:disable-next-line:variable-name
+const NodesMainConnected = connect(
   (state: AdminUIState) => {
     return {
       statusesValid: nodeQueryValid(state),
@@ -367,4 +365,19 @@ const nodesMainConnected = connect(
   },
 )(NodesMain);
 
-export { nodesMainConnected as default };
+/**
+ * Renders the main content of the nodes page, which is primarily a data table
+ * of all nodes.
+ */
+function NodesPage() {
+  return (
+    <div>
+      <section className="section parent-link">
+        <Link to="/cluster">&lt; Back to Cluster</Link>
+      </section>
+      <NodesMainConnected />
+    </div>
+  );
+}
+
+export { NodesPage as default, NodesMainConnected as NodesOverview };

--- a/pkg/ui/src/views/shared/util/d3-react.tsx
+++ b/pkg/ui/src/views/shared/util/d3-react.tsx
@@ -1,0 +1,34 @@
+import d3 from "d3";
+import React from "react";
+
+type Chart<T> = (sel: d3.Selection<T>) => void;
+type Charter<T> = () => Chart<T>;
+
+/**
+ * createChartComponent wraps a D3 reusable chart in a React component.
+ * See https://bost.ocks.org/mike/chart/
+ */
+export default function createChartComponent<T>(chart: Charter<T>) {
+  return class WrappedChart extends React.Component<T, {}> {
+    svgEl: SVGElement;
+    chart = chart();
+
+    componentDidMount() {
+      d3.select(this.svgEl)
+        .datum(this.props)
+        .call(this.chart);
+    }
+
+    shouldComponentUpdate(props: T) {
+      d3.select(this.svgEl)
+        .datum(props)
+        .call(this.chart);
+
+      return false;
+    }
+
+    render() {
+      return <svg ref={(el) => this.svgEl = el} />;
+    }
+  };
+}

--- a/pkg/ui/styl/layout/layout.styl
+++ b/pkg/ui/styl/layout/layout.styl
@@ -15,6 +15,7 @@ permissions and limitations under the License.
 */
 
 $subnav-background  = $background-color
+$page-padding-top   = 20px
 
 .page
   position relative
@@ -23,7 +24,7 @@ $subnav-background  = $background-color
   height 100vh
   min-width 100%
   padding-left $nav-width
-  padding-top 20px
+  padding-top $page-padding-top
 
   &:after
     content ""


### PR DESCRIPTION
Part of the initial steps of making a homepage for the admin UI with the cluster viz as the main attraction, here is some work towards a structure for the page and the overview on the top.  Clearly lots of work to do here, but I thought I'd get it up so we could get some eyes on it early.

![screen shot 2017-10-30 at 5 28 14 pm](https://user-images.githubusercontent.com/793969/32196723-f4d079fa-bd97-11e7-8982-0d23194efa8b.png)

Contributes to #19512.
See #19643 regarding naming things.