### PR TITLE
storage: factor out PushTxnQueue

### DIFF
--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -1931,9 +1931,9 @@ func TestStoreRangeGossipOnSplits(t *testing.T) {
 	}
 }
 
-// TestStorePushTxnQueueEnabledOnSplit verifies that the PushTxnQueue for
+// TestStoreTxnWaitQueueEnabledOnSplit verifies that the TxnWaitQueue for
 // the right hand side of the split range is enabled after a split.
-func TestStorePushTxnQueueEnabledOnSplit(t *testing.T) {
+func TestStoreTxnWaitQueueEnabledOnSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := storage.TestStoreConfig(nil)
 	storeCfg.TestingKnobs.DisableSplitQueue = true
@@ -1948,7 +1948,7 @@ func TestStorePushTxnQueueEnabledOnSplit(t *testing.T) {
 	}
 
 	rhsRepl := store.LookupReplica(roachpb.RKey(keys.UserTableDataMin), nil)
-	if !rhsRepl.IsPushTxnQueueEnabled() {
+	if !rhsRepl.IsTxnWaitQueueEnabled() {
 		t.Errorf("expected RHS replica's push txn queue to be enabled post-split")
 	}
 }
@@ -2116,11 +2116,11 @@ func TestUnsplittableRange(t *testing.T) {
 	})
 }
 
-// TestPushTxnQueueDependencyCycleWithRangeSplit verifies that a range
+// TestTxnWaitQueueDependencyCycleWithRangeSplit verifies that a range
 // split which occurs while a dependency cycle is partially underway
 // will cause the pending push txns to be retried such that they
 // relocate to the appropriate new range.
-func TestPushTxnQueueDependencyCycleWithRangeSplit(t *testing.T) {
+func TestTxnWaitQueueDependencyCycleWithRangeSplit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	for _, read2ndPass := range []bool{false, true} {

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -473,8 +473,8 @@ func (r *Replica) IsQuiescent() bool {
 	return r.mu.quiescent
 }
 
-func (r *Replica) IsPushTxnQueueEnabled() bool {
-	return r.pushTxnQueue.isEnabled()
+func (r *Replica) IsTxnWaitQueueEnabled() bool {
+	return r.txnWaitQueue.IsEnabled()
 }
 
 // GetQueueLastProcessed returns the last processed timestamp for the

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -48,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/tscache"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -230,7 +231,7 @@ type Replica struct {
 
 	store        *Store
 	abortSpan    *abortspan.AbortSpan // Avoids anomalous reads after abort
-	pushTxnQueue *PushTxnQueue        // Queues push txn attempts by txn ID
+	txnWaitQueue *txnwait.Queue       // Queues push txn attempts by txn ID
 
 	// leaseholderStats tracks all incoming BatchRequests to the replica and which
 	// localities they come from in order to aid in lease rebalancing decisions.
@@ -587,7 +588,7 @@ func newReplica(rangeID roachpb.RangeID, store *Store) *Replica {
 		RangeID:        rangeID,
 		store:          store,
 		abortSpan:      abortspan.New(rangeID),
-		pushTxnQueue:   newPushTxnQueue(store),
+		txnWaitQueue:   txnwait.NewQueue(store),
 	}
 	r.mu.stateLoader = stateloader.Make(r.store.cfg.Settings, rangeID)
 	if leaseHistoryMaxEntries > 0 {

--- a/pkg/storage/replica_accessors.go
+++ b/pkg/storage/replica_accessors.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -42,7 +43,7 @@ type ReplicaI interface {
 	Engine() engine.Engine
 	DB() *client.DB
 	AbortSpan() *abortspan.AbortSpan
-	GetPushTxnQueue() *PushTxnQueue
+	GetTxnWaitQueue() *txnwait.Queue
 
 	NodeID() roachpb.NodeID
 	StoreID() roachpb.StoreID

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -1749,7 +1750,7 @@ func evalPushTxn(
 	var reason string
 
 	switch {
-	case isExpired(args.Now, &reply.PusheeTxn):
+	case txnwait.IsExpired(args.Now, &reply.PusheeTxn):
 		reason = "pushee is expired"
 		// When cleaning up, actually clean up (as opposed to simply pushing
 		// the garbage in the path of future writers).
@@ -1847,7 +1848,7 @@ func evalQueryTxn(
 		return EvalResult{}, err
 	}
 	// Get the list of txns waiting on this txn.
-	reply.WaitingTxns = cArgs.EvalCtx.GetPushTxnQueue().GetDependents(args.Txn.ID)
+	reply.WaitingTxns = cArgs.EvalCtx.GetTxnWaitQueue().GetDependents(args.Txn.ID)
 	return EvalResult{}, nil
 }
 

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -199,14 +200,14 @@ func (r *Replica) AbortSpan() *abortspan.AbortSpan {
 	return r.abortSpan
 }
 
-// GetPushTxnQueue returns the PushTxnQueue.
-func (rec *ReplicaEvalContext) GetPushTxnQueue() *PushTxnQueue {
-	return rec.i.GetPushTxnQueue()
+// GetTxnWaitQueue returns the txnwait.Queue.
+func (rec *ReplicaEvalContext) GetTxnWaitQueue() *txnwait.Queue {
+	return rec.i.GetTxnWaitQueue()
 }
 
-// GetPushTxnQueue returns the Replica's pushTxnQueue.
-func (r *Replica) GetPushTxnQueue() *PushTxnQueue {
-	return r.pushTxnQueue
+// GetTxnWaitQueue returns the Replica's txnwait.Queue.
+func (r *Replica) GetTxnWaitQueue() *txnwait.Queue {
+	return r.txnWaitQueue
 }
 
 // GetTerm returns the term for the given index in the Raft log.

--- a/pkg/storage/txnwait/queue_test.go
+++ b/pkg/storage/txnwait/queue_test.go
@@ -1,0 +1,122 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package txnwait
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestShouldPushImmediately(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testCases := []struct {
+		typ        roachpb.PushTxnType
+		pusherPri  int32
+		pusheePri  int32
+		shouldPush bool
+	}{
+		{roachpb.PUSH_ABORT, roachpb.MinTxnPriority, roachpb.MinTxnPriority, false},
+		{roachpb.PUSH_ABORT, roachpb.MinTxnPriority, 1, false},
+		{roachpb.PUSH_ABORT, roachpb.MinTxnPriority, roachpb.MaxTxnPriority, false},
+		{roachpb.PUSH_ABORT, 1, roachpb.MinTxnPriority, true},
+		{roachpb.PUSH_ABORT, 1, 1, false},
+		{roachpb.PUSH_ABORT, 1, roachpb.MaxTxnPriority, false},
+		{roachpb.PUSH_ABORT, roachpb.MaxTxnPriority, roachpb.MinTxnPriority, true},
+		{roachpb.PUSH_ABORT, roachpb.MaxTxnPriority, 1, true},
+		{roachpb.PUSH_ABORT, roachpb.MaxTxnPriority, roachpb.MaxTxnPriority, false},
+		{roachpb.PUSH_TIMESTAMP, roachpb.MinTxnPriority, roachpb.MinTxnPriority, false},
+		{roachpb.PUSH_TIMESTAMP, roachpb.MinTxnPriority, 1, false},
+		{roachpb.PUSH_TIMESTAMP, roachpb.MinTxnPriority, roachpb.MaxTxnPriority, false},
+		{roachpb.PUSH_TIMESTAMP, 1, roachpb.MinTxnPriority, true},
+		{roachpb.PUSH_TIMESTAMP, 1, 1, false},
+		{roachpb.PUSH_TIMESTAMP, 1, roachpb.MaxTxnPriority, false},
+		{roachpb.PUSH_TIMESTAMP, roachpb.MaxTxnPriority, roachpb.MinTxnPriority, true},
+		{roachpb.PUSH_TIMESTAMP, roachpb.MaxTxnPriority, 1, true},
+		{roachpb.PUSH_TIMESTAMP, roachpb.MaxTxnPriority, roachpb.MaxTxnPriority, false},
+		{roachpb.PUSH_TOUCH, roachpb.MinTxnPriority, roachpb.MinTxnPriority, true},
+		{roachpb.PUSH_TOUCH, roachpb.MinTxnPriority, 1, true},
+		{roachpb.PUSH_TOUCH, roachpb.MinTxnPriority, roachpb.MaxTxnPriority, true},
+		{roachpb.PUSH_TOUCH, 1, roachpb.MinTxnPriority, true},
+		{roachpb.PUSH_TOUCH, 1, 1, true},
+		{roachpb.PUSH_TOUCH, 1, roachpb.MaxTxnPriority, true},
+		{roachpb.PUSH_TOUCH, roachpb.MaxTxnPriority, roachpb.MinTxnPriority, true},
+		{roachpb.PUSH_TOUCH, roachpb.MaxTxnPriority, 1, true},
+		{roachpb.PUSH_TOUCH, roachpb.MaxTxnPriority, roachpb.MaxTxnPriority, true},
+	}
+	for _, test := range testCases {
+		t.Run("", func(t *testing.T) {
+			req := roachpb.PushTxnRequest{
+				PushType: test.typ,
+				PusherTxn: roachpb.Transaction{
+					TxnMeta: enginepb.TxnMeta{
+						Priority: test.pusherPri,
+					},
+				},
+				PusheeTxn: enginepb.TxnMeta{
+					Priority: test.pusheePri,
+				},
+			}
+			if shouldPush := ShouldPushImmediately(&req); shouldPush != test.shouldPush {
+				t.Errorf("expected %t; got %t", test.shouldPush, shouldPush)
+			}
+		})
+	}
+}
+
+func makeTS(w int64, l int32) hlc.Timestamp {
+	return hlc.Timestamp{WallTime: w, Logical: l}
+}
+
+func TestIsPushed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testCases := []struct {
+		typ          roachpb.PushTxnType
+		pushTo       hlc.Timestamp
+		txnStatus    roachpb.TransactionStatus
+		txnTimestamp hlc.Timestamp
+		isPushed     bool
+	}{
+		{roachpb.PUSH_ABORT, hlc.Timestamp{}, roachpb.PENDING, hlc.Timestamp{}, false},
+		{roachpb.PUSH_ABORT, hlc.Timestamp{}, roachpb.ABORTED, hlc.Timestamp{}, true},
+		{roachpb.PUSH_ABORT, hlc.Timestamp{}, roachpb.COMMITTED, hlc.Timestamp{}, true},
+		{roachpb.PUSH_TIMESTAMP, makeTS(10, 1), roachpb.PENDING, hlc.Timestamp{}, false},
+		{roachpb.PUSH_TIMESTAMP, makeTS(10, 1), roachpb.ABORTED, hlc.Timestamp{}, true},
+		{roachpb.PUSH_TIMESTAMP, makeTS(10, 1), roachpb.COMMITTED, hlc.Timestamp{}, true},
+		{roachpb.PUSH_TIMESTAMP, makeTS(10, 1), roachpb.PENDING, makeTS(10, 0), false},
+		{roachpb.PUSH_TIMESTAMP, makeTS(10, 1), roachpb.PENDING, makeTS(10, 1), false},
+		{roachpb.PUSH_TIMESTAMP, makeTS(10, 1), roachpb.PENDING, makeTS(10, 2), true},
+	}
+	for _, test := range testCases {
+		t.Run("", func(t *testing.T) {
+			req := roachpb.PushTxnRequest{
+				PushType: test.typ,
+				PushTo:   test.pushTo,
+			}
+			txn := roachpb.Transaction{
+				Status: test.txnStatus,
+				TxnMeta: enginepb.TxnMeta{
+					Timestamp: test.txnTimestamp,
+				},
+			}
+			if isPushed := isPushed(&req, &txn); isPushed != test.isPushed {
+				t.Errorf("expected %t; got %t", test.isPushed, isPushed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This removes one more roadblock for moving command evaluation outside of the
storage package since `PushTxnQueue` is returned from `ReplicaEvalContext`
(moving into its own package wasn't necessary, we could've just used an
interface -- but this seems nicer).

I spent some time trying to move the tests as well, but they're very tightly
coupled to the execution machinery, to the point where what they are really
testing is not a concern of the new `pushtxnq` package specifically