### PR TITLE
tscache: introduce intervalSkl, a skiplist-backed interval-ratcheting data structure

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -82,6 +82,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/andy-kimball/arenaskl"
+  packages = ["."]
+  revision = "1b13f9a73da39445e8106e6cdc1af59f06ea6c20"
+
+[[projects]]
+  branch = "master"
   name = "github.com/andybalholm/cascadia"
   packages = ["."]
   revision = "349dd0209470eabd9514242c688c403c0926d266"
@@ -640,6 +646,12 @@
   version = "1.0.0"
 
 [[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
@@ -710,6 +722,12 @@
   packages = ["."]
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = ["assert","require"]
+  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
+  version = "v1.1.4"
 
 [[projects]]
   name = "github.com/tebeka/go2xunit"
@@ -815,6 +833,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "107aefc02632222ca74fa3741b47c2e237af328f83854dc521a119664b361ce6"
+  inputs-digest = "36eccb7ec47b760d2085ed99aa6e1fa05883335b24d13dc639ea0b87ed66dfd9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -113,3 +113,27 @@ var lowWaterTxnIDMarker = func() uuid.UUID {
 	}
 	return u
 }()
+
+// ratchetValue returns the cacheValue that results from ratcheting the provided
+// old and new cacheValues. It also returns flags reflecting whether the value
+// was updated.
+//
+// This ratcheting policy is shared across all Cache implementations, even if
+// they do not use this function directly.
+func ratchetValue(old, new cacheValue) (cacheValue, bool) {
+	if old.ts.Less(new.ts) {
+		// Ratchet to new value.
+		return new, true
+	} else if new.ts.Less(old.ts) {
+		// Nothing to update.
+		return old, false
+	} else if new.txnID != old.txnID {
+		// old.ts == new.ts but the values have different txnIDs. Remove the
+		// transaction ID from the value so that it is no longer owned by any
+		// transaction.
+		new.txnID = noTxnID
+		return new, old.txnID != noTxnID
+	}
+	// old == new.
+	return old, false
+}

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -15,6 +15,7 @@
 package tscache
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -113,6 +114,19 @@ var lowWaterTxnIDMarker = func() uuid.UUID {
 	}
 	return u
 }()
+
+func (v cacheValue) String() string {
+	var txnIDStr string
+	switch v.txnID {
+	case noTxnID:
+		txnIDStr = "none"
+	case lowWaterTxnIDMarker:
+		txnIDStr = "low water"
+	default:
+		txnIDStr = v.txnID.String()
+	}
+	return fmt.Sprintf("{ts: %s, txnID: %s}", v.ts, txnIDStr)
+}
 
 // ratchetValue returns the cacheValue that results from ratcheting the provided
 // old and new cacheValues. It also returns flags reflecting whether the value

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -24,6 +24,7 @@ import (
 	"github.com/andy-kimball/arenaskl"
 
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -164,7 +165,8 @@ func (s *intervalSkl) Add(key []byte, val cacheValue) {
 // be passed as the "from" key, in which case only the end key will be added.
 // nil can also be passed as the "to" key, in which case an open range will be
 // added spanning [from, infinity). However, it is illegal to pass nil for both
-// "from" and "to".
+// "from" and "to". It is also illegal for "from" > "to", which would be an
+// inverted range.
 //
 // If some or all of the range was previously read at a higher timestamp, then
 // the range is split into sub-ranges that are each marked with the maximum read
@@ -183,8 +185,8 @@ func (s *intervalSkl) AddRange(from, to []byte, opt rangeOptions, val cacheValue
 
 		switch {
 		case cmp > 0:
-			// Starting key is after ending key, so range is zero length.
-			return
+			// Starting key is after ending key. This shouldn't happen.
+			panic(interval.ErrInvertedRange)
 		case cmp == 0:
 			// Starting key is same as ending key, so just add single node.
 			if opt == (excludeFrom | excludeTo) {
@@ -343,6 +345,8 @@ func (s *intervalSkl) LookupTimestampRange(from, to []byte, opt rangeOptions) ca
 	if s.earlier != nil {
 		// If later page timestamp is greater than the max timestamp in the
 		// earlier page, then no need to do lookup at all.
+		//
+		// TODO(nvanbenschoten): test this when val.ts == maxTs.
 		maxTs := hlc.Timestamp{WallTime: atomic.LoadInt64(&s.earlier.maxWallTime)}
 		if val.ts.Less(maxTs) {
 			val2 := s.earlier.lookupTimestampRange(from, to, opt)

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -36,7 +36,7 @@ type rangeOptions int
 
 const (
 	// excludeFrom indicates that the range does not include the starting key.
-	excludeFrom = 1 << iota
+	excludeFrom = rangeOptions(1 << iota)
 
 	// excludeTo indicates that the range does not include the ending key.
 	excludeTo
@@ -435,7 +435,13 @@ func (p *sklPage) addNode(
 		// would not be updated with the new value, then there is no need to add
 		// another node, since its timestamp would be the same as the gap
 		// timestamp and its txnID would be the same as the gap txnID.
-		prevVal := p.scanForTimestamp(it, key, key, 0, false)
+		//
+		// NB: We pass excludeTo here because another thread may race and add a
+		// node at the key while we're scanning for the previous value. We don't
+		// want to consider this new key here because even if it has a larger
+		// key value that indicates that we can take this fast path, it may have
+		// a smaller gap value that we need to ratchet below.
+		prevVal := p.scanForTimestamp(it, key, key, excludeTo, false)
 		if _, update := ratchetValue(prevVal, val); !update {
 			return nil
 		}

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -1,0 +1,699 @@
+// Copyright (C) 2017 Andy Kimball
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tscache
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/andy-kimball/arenaskl"
+
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// rangeOptions are passed to AddRange to indicate the bounds of the range. By
+// default, the "from" and "to" keys are inclusive. Setting these bit flags
+// indicates that one or both is exclusive instead.
+type rangeOptions int
+
+const (
+	// excludeFrom indicates that the range does not include the starting key.
+	excludeFrom = 1 << iota
+
+	// excludeTo indicates that the range does not include the ending key.
+	excludeTo
+)
+
+// nodeOptions are meta tags on skiplist nodes that indicate the status and role
+// of that node in the intervalSkl. The options are bit flags that can be
+// independently added and removed.
+//
+// Each node in the intervalSkl holds a key and, optionally, the latest read
+// timestamp for that key. In addition, the node optionally holds the latest
+// read timestamp for the range of keys between itself and the next key that is
+// present in the skiplist. This space between keys is called the "gap", and the
+// timestamp for that range is called the "gap timestamp". Here is a simplified
+// representation that would result after these ranges were added to an empty
+// intervalSkl:
+//   ["apple", "orange") = 200
+//   ["kiwi", "raspberry"] = 100
+//
+//   "apple"    "orange"   "raspberry"
+//   keyts=200  keyts=100  keyts=100
+//   gapts=200  gapts=100  gapts=0
+//
+// That is, the range from apple (inclusive) to orange (exclusive) has a read
+// timestamp of 200. The range from orange (inclusive) to raspberry (inclusive)
+// has a read timestamp of 100. All other keys have a read timestamp of 0.
+type nodeOptions int
+
+const (
+	// initializing indicates that the node has been created, but is still in a
+	// provisional state. Any key and gap timestamps are not final values, and
+	// should not be used until initialization is complete.
+	initializing = 1 << iota
+
+	// hasKey indicates that the node has an associated key timestamp. If this
+	// is not set, then the key timestamp is assumed to be zero.
+	hasKey
+
+	// hasGap indicates that the node has an associated gap timestamp. If this
+	// is not set, then the gap timestamp is assumed to be zero.
+	hasGap
+
+	// useMaxTs indicates that the intervalSkl's max value should be used in
+	// place of the node's gap and key timestamps. This is used when the
+	// structure has filled up and the value can no longer be set (but meta
+	// can).
+	useMaxTs
+)
+
+const (
+	encodedTsSize = 12
+)
+
+// intervalSkl efficiently tracks the latest logical time at which any key or
+// range of keys has been accessed. Keys are binary values of any length, and
+// times are represented as hybrid logical timestamps (see hlc package). The
+// data structure guarantees that the read timestamp of any given key or range
+// will never decrease. In other words, if a lookup returns timestamp A and
+// repeating the same lookup returns timestamp B, then B >= A.
+//
+// Add and lookup operations do not block or interfere with one another, which
+// enables predictable operation latencies. Also, the impact of the structure on
+// the GC is virtually nothing, even when the structure is very large. These
+// properties are enabled by employing a lock-free skiplist implementation that
+// uses an arena allocator. Skiplist nodes refer to one another by offset into
+// the arena rather than by pointer, so the GC has very few objects to track.
+//
+//
+// The data structure can conceptually be thought of as being parameterized over
+// a key and a value type, such that the key implements a Comparable interface
+// (see interval.Comparable) and the value implements a Ratchetable interface:
+//
+//   type Ratchetable interface {
+//     Ratchet(other Ratchetable) (changed bool)
+//   }
+//
+// In other words, if Go supported zero-cost abstractions, this type might look
+// like:
+//
+//   type intervalSkl<K: Comparable, V: Ratchetable>
+//
+type intervalSkl struct {
+	// Maximum size of the data structure in bytes. When the data structure
+	// fills, older entries are discarded.
+	size uint32
+
+	// rotMutex synchronizes page rotation with all other operations. The read
+	// lock is acquired by the Add and Lookup operations. The write lock is
+	// acquired only when the pages are rotated. Since that is very rare, the
+	// vast majority of operations can proceed without blocking.
+	rotMutex syncutil.RWMutex
+
+	// The structure maintains two fixed-size skiplist pages. When the later
+	// page fills, it becomes the earlier page, and the previous earlier page is
+	// discarded. In order to ensure that timestamps never decrease, intervalSkl
+	// maintains a floor timestamp, which is the minimum read timestamp that can
+	// be returned by the lookup operations. When the earlier page is discarded,
+	// its current maximum read timestamp becomes the new floor timestamp for
+	// the overall intervalSkl.
+	later   *sklPage
+	earlier *sklPage
+	floorTs hlc.Timestamp
+}
+
+// newIntervalSkl creates a new interval skiplist with the given maximum size.
+func newIntervalSkl(size uint32) *intervalSkl {
+	// The earlier and later fixed pages are each 1/2 the size of the larger
+	// page.
+	return &intervalSkl{size: size, later: newSklPage(size / 2)}
+}
+
+// Add marks the a single key as having been read at the given timestamp. Once
+// Add completes, future lookups of this key are guaranteed to return an equal
+// or greater timestamp.
+func (s *intervalSkl) Add(key []byte, ts hlc.Timestamp) {
+	s.AddRange(key, key, 0, ts)
+}
+
+// AddRange marks the given range of keys (from, to) as having been read at the
+// given timestamp. If some or all of the range was previously read at a higher
+// timestamp, then the range is split into sub-ranges that are each marked with
+// the maximum read timestamp for that sub-range. The starting and ending points
+// of the range are inclusive by default, but can be excluded by passing the
+// applicable range options. Once AddRange completes, future lookups at any point
+// in the range are guaranteed to return an equal or greater timestamp.
+func (s *intervalSkl) AddRange(from, to []byte, opt rangeOptions, ts hlc.Timestamp) {
+	if from == nil {
+		panic("from key cannot be nil")
+	}
+
+	if to != nil {
+		cmp := bytes.Compare(from, to)
+		if cmp > 0 {
+			// Starting key is after ending key, so range is zero length.
+			return
+		}
+
+		if cmp == 0 {
+			// Starting key is same as ending key, so just add single node.
+			if opt == (excludeFrom | excludeTo) {
+				// Both from and to keys are excluded, so range is zero length.
+				return
+			}
+
+			// Just add the ending key.
+			from = nil
+			opt = 0
+		}
+	}
+
+	for {
+		// Try to add the range to the later page.
+		filledPage := s.addRange(from, to, opt, ts)
+		if filledPage == nil {
+			break
+		}
+
+		// The page was filled up, so rotate the pages and then try again.
+		s.rotatePages(filledPage)
+	}
+}
+
+// addRange marks the given range of keys (from, to) as having been read at the
+// given timestamp. It returns nil if the operation was successful, or a pointer
+// to an sklPage if the operation failed because that page was full.
+func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, ts hlc.Timestamp) *sklPage {
+	// Acquire the rotation mutex read lock so that the page will not be rotated
+	// while add or lookup operations are in progress.
+	s.rotMutex.RLock()
+	defer s.rotMutex.RUnlock()
+
+	// If floor ts is >= requested timestamp, then no need to perform a search
+	// or add any records.
+	if !s.floorTs.Less(ts) {
+		return nil
+	}
+
+	var it arenaskl.Iterator
+	it.Init(s.later.list)
+
+	// Start by ensuring that the ending node has been created (unless "to" is
+	// nil, in which case the range extends indefinitely). Do this before creating
+	// the start node, so that the range won't extend past the end point during
+	// the period between creating the two endpoints.
+	var err error
+	if to != nil {
+		if (opt & excludeTo) == 0 {
+			err = s.later.addNode(&it, to, ts, hasKey)
+		} else {
+			err = s.later.addNode(&it, to, ts, 0)
+		}
+
+		if err == arenaskl.ErrArenaFull {
+			return s.later
+		}
+	}
+
+	// If from is nil, then the "range" is just a single key.
+	if from == nil {
+		return nil
+	}
+
+	// Ensure that the starting node has been created.
+	if (opt & excludeFrom) == 0 {
+		err = s.later.addNode(&it, from, ts, hasKey|hasGap)
+	} else {
+		err = s.later.addNode(&it, from, ts, hasGap)
+	}
+
+	if err == arenaskl.ErrArenaFull {
+		return s.later
+	}
+
+	// Seek to the node immediately after the "from" node.
+	if !it.Valid() || !bytes.Equal(it.Key(), from) {
+		if it.Seek(from) {
+			it.Next()
+		}
+	} else {
+		it.Next()
+	}
+
+	// Now iterate forwards and ensure that all nodes between the start and
+	// end (exclusive) have timestamps that are >= the range timestamp.
+	if !s.later.ensureFloorTs(&it, to, ts) {
+		// Page is filled up, so rotate pages and try again.
+		return s.later
+	}
+
+	return nil
+}
+
+// rotatePages makes the later page the earlier page, and then discards the
+// earlier page. The max timestamp of the earlier page becomes the new floor
+// timestamp, in order to guarantee that timestamp lookups never return decreasing
+// values.
+func (s *intervalSkl) rotatePages(filledPage *sklPage) {
+	// Acquire the rotation mutex write lock to lock the entire intervalSkl.
+	s.rotMutex.Lock()
+	defer s.rotMutex.Unlock()
+
+	if filledPage != s.later {
+		// Another thread already rotated the pages, so don't do anything more.
+		return
+	}
+
+	// Max timestamp of the earlier page becomes the new floor timestamp.
+	if s.earlier != nil {
+		newFloorTs := hlc.Timestamp{WallTime: atomic.LoadInt64(&s.earlier.maxWallTime)}
+		s.floorTs.Forward(newFloorTs)
+	}
+
+	// Make the later page the earlier page.
+	s.earlier = s.later
+	s.later = newSklPage(s.size / 2)
+}
+
+// LookupTimestamp returns the latest timestamp at which the given key was read.
+// If this operation is repeated with the same key, it will always result in an
+// equal or greater timestamp.
+func (s *intervalSkl) LookupTimestamp(key []byte) hlc.Timestamp {
+	// Acquire the rotation mutex read lock so that the page will not be rotated
+	// while add or lookup operations are in progress.
+	s.rotMutex.RLock()
+	defer s.rotMutex.RUnlock()
+
+	// First perform lookup on the later page.
+	ts := s.later.lookupTimestamp(key)
+
+	// Now perform same lookup on the earlier page.
+	if s.earlier != nil {
+		// If later page timestamp is greater than the max timestamp in the
+		// earlier page, then no need to do lookup at all.
+		maxTs := hlc.Timestamp{WallTime: atomic.LoadInt64(&s.earlier.maxWallTime)}
+		if ts.Less(maxTs) {
+			ts2 := s.earlier.lookupTimestamp(key)
+			if ts.Less(ts2) {
+				ts = ts2
+			}
+		}
+	}
+
+	// Return the higher timestamp from the two lookups.
+	if ts.Less(s.floorTs) {
+		ts = s.floorTs
+	}
+
+	return ts
+}
+
+// sklPage maintains a skiplist based on a fixed-size arena. When the arena has
+// filled up, it returns arenaskl.ErrArenaFull. At that point, a new fixed page
+// must be allocated and used instead.
+type sklPage struct {
+	list        *arenaskl.Skiplist
+	maxWallTime int64 // accessed atomically
+	isFull      int32 // accessed atomically
+}
+
+func newSklPage(size uint32) *sklPage {
+	return &sklPage{list: arenaskl.NewSkiplist(arenaskl.NewArena(size))}
+}
+
+func (p *sklPage) lookupTimestamp(key []byte) hlc.Timestamp {
+	var it arenaskl.Iterator
+	it.Init(p.list)
+
+	if !it.SeekForPrev(key) {
+		// Key not found, so scan previous nodes to find the gap timestamp.
+		return p.scanForTimestamp(&it, key, false)
+	}
+
+	if (it.Meta() & initializing) != 0 {
+		// Node is not yet initialized, so scan previous nodes to find the
+		// gap timestamp needed to initialize this node.
+		return p.scanForTimestamp(&it, key, true)
+	}
+
+	keyTs, _ := p.decodeTimestampSet(it.Value(), it.Meta())
+	return keyTs
+}
+
+func (p *sklPage) addNode(
+	it *arenaskl.Iterator, key []byte, ts hlc.Timestamp, opt nodeOptions,
+) error {
+	var arr [encodedTsSize * 2]byte
+	var keyTs, gapTs hlc.Timestamp
+
+	if (opt & hasKey) != 0 {
+		keyTs = ts
+	}
+
+	if (opt & hasGap) != 0 {
+		gapTs = ts
+	}
+
+	if !it.SeekForPrev(key) {
+		// If the previous node has a gap timestamp that is >= than the new
+		// timestamp, then there is no need to add another node, since its
+		// timestamp would be the same as the gap timestamp.
+		prevTs := p.scanForTimestamp(it, key, false)
+		if !prevTs.Less(ts) {
+			return nil
+		}
+
+		// Ratchet max timestamp before adding the node.
+		p.ratchetMaxTimestamp(ts)
+
+		// Ensure that a new node is created. It needs to stay in the
+		// initializing state until the gap timestamp of its preceding node
+		// has been found and used to ratchet this node's timestamps. During
+		// the search for the gap timestamp, this node acts as a sentinel
+		// for other ongoing operations - when they see this node they're
+		// forced to stop and help complete its initialization before they
+		// can continue.
+		b, meta := p.encodeTimestampSet(arr[:0], keyTs, gapTs)
+		err := it.Add(key, b, meta|initializing)
+		if err == arenaskl.ErrArenaFull {
+			atomic.StoreInt32(&p.isFull, 1)
+			return err
+		}
+
+		if err == nil {
+			// Add was successful, so finish initialization by scanning for
+			// gap timestamp and using it to ratchet the new nodes' timestamps.
+			p.scanForTimestamp(it, key, true)
+			return nil
+		}
+
+		// Another thread raced and added the node, so just ratchet its
+		// timestamps instead.
+	} else {
+		if opt == 0 {
+			// Don't need to set either key or gap ts, so done.
+			return nil
+		}
+	}
+
+	// Ratchet up the timestamps on the existing node, but don't clear the
+	// initializing bit, since we don't have the gap timestamp from the previous
+	// node. Leave finishing initialization to the thread that added the node, or
+	// to a lookup thread that requires it.
+	p.ratchetTimestampSet(it, keyTs, gapTs, false)
+
+	return nil
+}
+
+func (p *sklPage) ensureFloorTs(it *arenaskl.Iterator, to []byte, ts hlc.Timestamp) bool {
+	for it.Valid() {
+		if to != nil && bytes.Compare(it.Key(), to) >= 0 {
+			break
+		}
+
+		if atomic.LoadInt32(&p.isFull) == 1 {
+			// Page is full, so stop iterating. The caller will then be able to
+			// release the read lock and rotate the pages. Not doing this could
+			// result in forcing all other operations to wait for this thread to
+			// completely finish iteration. That could take a long time if this
+			// range is very large.
+			return false
+		}
+
+		// Don't clear the initialization bit, since we don't have the gap
+		// timestamp from the previous node, and don't need an initialized node
+		// for this operation anyway.
+		p.ratchetTimestampSet(it, ts, ts, false)
+
+		it.Next()
+	}
+
+	return true
+}
+
+func (p *sklPage) ratchetMaxTimestamp(ts hlc.Timestamp) {
+	// Cheat and just use the max wall time portion of the timestamp, since it's
+	// fine for the max timestamp to be a bit too large.
+	new := ts.WallTime
+	if ts.Logical > 0 {
+		new++
+	}
+
+	for {
+		old := atomic.LoadInt64(&p.maxWallTime)
+		if new <= old {
+			break
+		}
+
+		if atomic.CompareAndSwapInt64(&p.maxWallTime, old, new) {
+			break
+		}
+	}
+}
+
+// ratchetTimestampSet will update the current node's key and gap timestamps to
+// the maximum of their current values or the given values. If clearInit is true,
+// then the initializing bit will be cleared, indicating that the node is now
+// fully initialized and its timestamps can now be relied upon.
+func (p *sklPage) ratchetTimestampSet(
+	it *arenaskl.Iterator, keyTs, gapTs hlc.Timestamp, clearInit bool,
+) {
+	var arr [encodedTsSize * 2]byte
+
+	for {
+		meta := it.Meta()
+		oldKeyTs, oldGapTs := p.decodeTimestampSet(it.Value(), meta)
+
+		greater := false
+		if oldKeyTs.Less(keyTs) {
+			greater = true
+		} else {
+			keyTs = oldKeyTs
+		}
+
+		if oldGapTs.Less(gapTs) {
+			greater = true
+		} else {
+			gapTs = oldGapTs
+		}
+
+		var initMeta uint16
+		if clearInit {
+			initMeta = 0
+		} else {
+			initMeta = meta & initializing
+		}
+
+		// Check whether it's necessary to make an update.
+		var err error
+		if !greater {
+			if !clearInit || (meta&initializing) == 0 {
+				// No update necessary because the init bit doesn't need to be
+				// cleared or it's already cleared.
+				return
+			}
+
+			// Clear the initializing bit, but no need to update the timestamps.
+			err = it.SetMeta(meta & ^uint16(initializing))
+		} else {
+			// Ratchet the max timestamp.
+			if gapTs.Less(keyTs) {
+				p.ratchetMaxTimestamp(keyTs)
+			} else {
+				p.ratchetMaxTimestamp(gapTs)
+			}
+
+			// Update the timestamps, possibly preserving the init bit.
+			b, newMeta := p.encodeTimestampSet(arr[:0], keyTs, gapTs)
+			err = it.Set(b, newMeta|initMeta)
+		}
+
+		switch err {
+		case nil:
+			return
+
+		case arenaskl.ErrArenaFull:
+			atomic.StoreInt32(&p.isFull, 1)
+
+			// Arena full, so ratchet the timestamps to the max timestamp.
+			err = it.SetMeta(uint16(useMaxTs) | initMeta)
+			if err == arenaskl.ErrRecordUpdated {
+				continue
+			}
+
+			return
+
+		case arenaskl.ErrRecordUpdated:
+			// Record was updated by another thread, so restart ratchet attempt.
+			continue
+
+		default:
+			panic(fmt.Sprintf("unexpected error: %v", err))
+		}
+	}
+}
+
+// scanForTimestamp scans backwards for the first initialized node and uses its
+// gap timestamp as the initial candidate. It then scans forwards until it
+// reaches the termination key, ratcheting any uninitialized nodes it encounters,
+// and updating the candidate gap timestamp as it goes. The timestamp of the
+// termination key is returned.
+//
+// Iterating backwards and then forwards solves potential race conditions with
+// other threads. During iteration backwards, other nodes can be inserting new
+// nodes between the previous node and the lookup node, which could change the
+// correct value of the gap timestamp. The solution is two-fold:
+//
+// 1. Add new nodes in two phases - initializing and then initialized. Nodes in
+//    the initializing state act as a synchronization point between goroutines
+//    that are adding a particular node and goroutines that are scanning for gap
+//    timestamps. Scanning goroutines encounter the initializing nodes and are
+//    forced to deal with them before continuing.
+//
+// 2. After the gap timestamp of the previous node has been found, the scanning
+//    goroutine will scan forwards until it reaches the original key. It will
+//    complete initialization of any nodes along the way and inherit the gap
+//    timestamp of initialized nodes as it goes. By the time it reaches the
+//    original key, it has a valid gap timestamp value.
+//
+// During forward iteration, if another goroutine inserts a new gap node in the
+// interval between the previous node and the original key, then either:
+//
+// 1. The forward iteration finds it and looks up its gap timestamp. That node
+//    now becomes the new "previous node", and iteration continues.
+//
+// 2. The new node is created after the iterator has move past its position. As
+//    part of node creation, the creator had to scan backwards to find the gap
+//    timestamp of the previous node. It is guaranteed to find a gap timestamp
+//    that is >= the gap timestamp found by the original goroutine.
+//
+// This means that no matter what gets inserted, or when it gets inserted, the
+// scanning goroutine is guaranteed to end up with a timestamp value that will
+// never decrease on future lookups, which is the critical invariant.
+func (p *sklPage) scanForTimestamp(it *arenaskl.Iterator, key []byte, onKey bool) hlc.Timestamp {
+	clone := *it
+
+	if onKey {
+		// The iterator is currently positioned on the key node, so need to
+		// iterate backwards from there in order to find the gap timestamp.
+		clone.Prev()
+	}
+
+	// First iterate backwards, looking for an already initialized node which
+	// will supply the initial candidate gap timestamp.
+	var gapTs hlc.Timestamp
+	for {
+		if !clone.Valid() {
+			// No more previous nodes, so use the zero timestamp and begin
+			// forward iteration from the first node.
+			clone.SeekToFirst()
+			break
+		}
+
+		meta := clone.Meta()
+		if (meta & initializing) == 0 {
+			// Found the gap timestamp for an initialized node.
+			_, gapTs = p.decodeTimestampSet(clone.Value(), meta)
+			clone.Next()
+			break
+		}
+
+		clone.Prev()
+	}
+
+	// Now iterate forwards until "key" is reached, update any uninitialized
+	// nodes along the way, and update the gap timestamp.
+	for {
+		if !clone.Valid() {
+			return gapTs
+		}
+
+		if (clone.Meta() & initializing) != 0 {
+			// Finish initializing the node with the gap timestamp.
+			p.ratchetTimestampSet(&clone, gapTs, gapTs, true)
+		}
+
+		cmp := bytes.Compare(clone.Key(), key)
+		if cmp > 0 {
+			// Past the lookup key, so use the gap timestamp.
+			return gapTs
+		}
+
+		var keyTs hlc.Timestamp
+		keyTs, gapTs = p.decodeTimestampSet(clone.Value(), clone.Meta())
+
+		if cmp == 0 {
+			// On the lookup key, so use the key timestamp.
+			return keyTs
+		}
+
+		// Haven't yet reached the lookup key, so keep iterating.
+		clone.Next()
+	}
+}
+
+func (p *sklPage) decodeTimestampSet(b []byte, meta uint16) (keyTs, gapTs hlc.Timestamp) {
+	if (meta & useMaxTs) != 0 {
+		ts := hlc.Timestamp{WallTime: atomic.LoadInt64(&p.maxWallTime)}
+		return ts, ts
+	}
+
+	if (meta & hasKey) != 0 {
+		b, keyTs = decodeTimestamp(b)
+	}
+
+	if (meta & hasGap) != 0 {
+		_, gapTs = decodeTimestamp(b)
+	}
+
+	return
+}
+
+func (p *sklPage) encodeTimestampSet(
+	b []byte, keyTs, gapTs hlc.Timestamp,
+) (ret []byte, meta uint16) {
+	if keyTs.WallTime != 0 || keyTs.Logical != 0 {
+		b = encodeTimestamp(b, keyTs)
+		meta |= hasKey
+	}
+
+	if gapTs.WallTime != 0 || gapTs.Logical != 0 {
+		b = encodeTimestamp(b, gapTs)
+		meta |= hasGap
+	}
+
+	ret = b
+	return
+}
+
+func decodeTimestamp(b []byte) (ret []byte, ts hlc.Timestamp) {
+	wallTime := binary.BigEndian.Uint64(b)
+	logical := binary.BigEndian.Uint32(b[8:])
+	ts = hlc.Timestamp{WallTime: int64(wallTime), Logical: int32(logical)}
+	ret = b[encodedTsSize:]
+	return
+}
+
+func encodeTimestamp(b []byte, ts hlc.Timestamp) []byte {
+	l := len(b)
+	b = b[:l+encodedTsSize]
+	binary.BigEndian.PutUint64(b[l:], uint64(ts.WallTime))
+	binary.BigEndian.PutUint32(b[l+8:], uint32(ts.Logical))
+	return b
+}

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -155,29 +155,37 @@ func newIntervalSkl(size uint32) *intervalSkl {
 // Add completes, future lookups of this key are guaranteed to return an equal
 // or greater timestamp.
 func (s *intervalSkl) Add(key []byte, val cacheValue) {
-	s.AddRange(key, key, 0, val)
+	s.AddRange(nil, key, 0, val)
 }
 
-// AddRange marks the given range of keys (from, to) as having been read at the
-// given timestamp. If some or all of the range was previously read at a higher
-// timestamp, then the range is split into sub-ranges that are each marked with
-// the maximum read timestamp for that sub-range. The starting and ending points
-// of the range are inclusive by default, but can be excluded by passing the
-// applicable range options. Once AddRange completes, future lookups at any point
-// in the range are guaranteed to return an equal or greater timestamp.
+// AddRange marks the given range of keys [from, to] as having been read at the
+// given timestamp. The starting and ending points of the range are inclusive by
+// default, but can be excluded by passing the applicable range options. nil can
+// be passed as the "from" key, in which case only the end key will be added.
+// nil can also be passed as the "to" key, in which case an open range will be
+// added spanning [from, infinity). However, it is illegal to pass nil for both
+// "from" and "to".
+//
+// If some or all of the range was previously read at a higher timestamp, then
+// the range is split into sub-ranges that are each marked with the maximum read
+// timestamp for that sub-range.  Once AddRange completes, future lookups at any
+// point in the range are guaranteed to return an equal or greater timestamp.
 func (s *intervalSkl) AddRange(from, to []byte, opt rangeOptions, val cacheValue) {
-	if from == nil {
-		panic("from key cannot be nil")
+	if from == nil && to == nil {
+		panic("from and to keys cannot be nil")
 	}
 
 	if to != nil {
-		cmp := bytes.Compare(from, to)
-		if cmp > 0 {
-			// Starting key is after ending key, so range is zero length.
-			return
+		cmp := 0
+		if from != nil {
+			cmp = bytes.Compare(from, to)
 		}
 
-		if cmp == 0 {
+		switch {
+		case cmp > 0:
+			// Starting key is after ending key, so range is zero length.
+			return
+		case cmp == 0:
 			// Starting key is same as ending key, so just add single node.
 			if opt == (excludeFrom | excludeTo) {
 				// Both from and to keys are excluded, so range is zero length.
@@ -202,9 +210,12 @@ func (s *intervalSkl) AddRange(from, to []byte, opt rangeOptions, val cacheValue
 	}
 }
 
-// addRange marks the given range of keys (from, to) as having been read at the
-// given timestamp. It returns nil if the operation was successful, or a pointer
-// to an sklPage if the operation failed because that page was full.
+// addRange marks the given range of keys [from, to] as having been read at the
+// given timestamp. The key range and the rangeOptions observe the same behavior
+// as is specified for AddRange above. Notably, addRange treats nil "from" and
+// "to" arguments in accordance with AddRange's contract. It returns nil if the
+// operation was successful, or a pointer to an sklPage if the operation failed
+// because that page was full.
 func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, val cacheValue) *sklPage {
 	// Acquire the rotation mutex read lock so that the page will not be rotated
 	// while add or lookup operations are in progress.
@@ -237,7 +248,8 @@ func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, val cacheValue
 		}
 	}
 
-	// If from is nil, then the "range" is just a single key.
+	// If from is nil, then the "range" is just a single key. We already
+	// asserted above that if from == nil then to != nil.
 	if from == nil {
 		return nil
 	}
@@ -312,7 +324,7 @@ func (s *intervalSkl) rotatePages(filledPage *sklPage) {
 // read. If this operation is repeated with the same key, it will always result
 // in an equal or greater timestamp.
 func (s *intervalSkl) LookupTimestamp(key []byte) cacheValue {
-	return s.LookupTimestampRange(key, key, 0)
+	return s.LookupTimestampRange(nil, key, 0)
 }
 
 // LookupTimestampRange returns the latest timestamp value of any key within the
@@ -361,7 +373,11 @@ func newSklPage(size uint32) *sklPage {
 
 func (p *sklPage) lookupTimestampRange(from, to []byte, opt rangeOptions) cacheValue {
 	if to != nil {
-		cmp := bytes.Compare(from, to)
+		cmp := 0
+		if from != nil {
+			cmp = bytes.Compare(from, to)
+		}
+
 		if cmp > 0 {
 			// Starting key is after ending key, so range is zero length.
 			return cacheValue{}
@@ -372,6 +388,9 @@ func (p *sklPage) lookupTimestampRange(from, to []byte, opt rangeOptions) cacheV
 				// Both from and to keys are excluded, so range is zero length.
 				return cacheValue{}
 			}
+
+			// Scan over a single key.
+			from = to
 			opt = 0
 		}
 	}

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -346,18 +346,26 @@ func (s *intervalSkl) LookupTimestampRange(from, to []byte, opt rangeOptions) ca
 		// If later page timestamp is greater than the max timestamp in the
 		// earlier page, then no need to do lookup at all.
 		//
-		// TODO(nvanbenschoten): test this when val.ts == maxTs.
+		// NB: if the max timestamp of the earlier page is equal to the later
+		// page timestamp, then we still need to perform the lookup. This is
+		// because the earlier page's max timestamp _may_ (if the hlc.Timestamp
+		// ceil operation in sklPage.ratchetMaxTimestamp was a no-op) correspond
+		// to a real range's timestamp, and this range _may_ overlap with our
+		// lookup range. If that is the case and that other range has a
+		// different txnID than our current cacheValue result (val), then we
+		// need to remove the txnID from our result, per the ratcheting policy
+		// for cacheValues. This is tested in TestIntervalSklMaxPageTS.
 		maxTs := hlc.Timestamp{WallTime: atomic.LoadInt64(&s.earlier.maxWallTime)}
-		if val.ts.Less(maxTs) {
+		if !maxTs.Less(val.ts) {
 			val2 := s.earlier.lookupTimestampRange(from, to, opt)
 			val, _ = ratchetValue(val, val2)
 		}
 	}
 
-	// Return the higher timestamp from the two lookups.
-	if val.ts.Less(s.floorTs) {
-		val = cacheValue{ts: s.floorTs, txnID: noTxnID}
-	}
+	// Return the higher value from the the page lookups and the floor
+	// timestamp.
+	floorVal := cacheValue{ts: s.floorTs, txnID: noTxnID}
+	val, _ = ratchetValue(val, floorVal)
 
 	return val
 }

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -19,11 +19,13 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/andy-kimball/arenaskl"
 
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 // rangeOptions are passed to AddRange to indicate the bounds of the range. By
@@ -68,23 +70,27 @@ const (
 	// should not be used until initialization is complete.
 	initializing = 1 << iota
 
-	// hasKey indicates that the node has an associated key timestamp. If this
-	// is not set, then the key timestamp is assumed to be zero.
+	// hasKey indicates that the node has an associated key value. If this is
+	// not set, then the key timestamp is assumed to be zero and the key is
+	// assumed to not have a corresponding txnID.
 	hasKey
 
-	// hasGap indicates that the node has an associated gap timestamp. If this
-	// is not set, then the gap timestamp is assumed to be zero.
+	// hasGap indicates that the node has an associated gap value. If this is
+	// not set, then the gap timestamp is assumed to be zero and the gep is
+	// assumed to not have a corresponding txnID.
 	hasGap
 
-	// useMaxTs indicates that the intervalSkl's max value should be used in
+	// useMaxVal indicates that the intervalSkl's max value should be used in
 	// place of the node's gap and key timestamps. This is used when the
 	// structure has filled up and the value can no longer be set (but meta
 	// can).
-	useMaxTs
+	useMaxVal
 )
 
 const (
-	encodedTsSize = 12
+	encodedTsSize    = int(unsafe.Sizeof(hlc.Timestamp{}))
+	encodedTxnIDSize = int(unsafe.Sizeof(uuid.UUID{}))
+	encodedValSize   = encodedTsSize + encodedTxnIDSize
 )
 
 // intervalSkl efficiently tracks the latest logical time at which any key or
@@ -148,8 +154,8 @@ func newIntervalSkl(size uint32) *intervalSkl {
 // Add marks the a single key as having been read at the given timestamp. Once
 // Add completes, future lookups of this key are guaranteed to return an equal
 // or greater timestamp.
-func (s *intervalSkl) Add(key []byte, ts hlc.Timestamp) {
-	s.AddRange(key, key, 0, ts)
+func (s *intervalSkl) Add(key []byte, val cacheValue) {
+	s.AddRange(key, key, 0, val)
 }
 
 // AddRange marks the given range of keys (from, to) as having been read at the
@@ -159,7 +165,7 @@ func (s *intervalSkl) Add(key []byte, ts hlc.Timestamp) {
 // of the range are inclusive by default, but can be excluded by passing the
 // applicable range options. Once AddRange completes, future lookups at any point
 // in the range are guaranteed to return an equal or greater timestamp.
-func (s *intervalSkl) AddRange(from, to []byte, opt rangeOptions, ts hlc.Timestamp) {
+func (s *intervalSkl) AddRange(from, to []byte, opt rangeOptions, val cacheValue) {
 	if from == nil {
 		panic("from key cannot be nil")
 	}
@@ -186,7 +192,7 @@ func (s *intervalSkl) AddRange(from, to []byte, opt rangeOptions, ts hlc.Timesta
 
 	for {
 		// Try to add the range to the later page.
-		filledPage := s.addRange(from, to, opt, ts)
+		filledPage := s.addRange(from, to, opt, val)
 		if filledPage == nil {
 			break
 		}
@@ -199,7 +205,7 @@ func (s *intervalSkl) AddRange(from, to []byte, opt rangeOptions, ts hlc.Timesta
 // addRange marks the given range of keys (from, to) as having been read at the
 // given timestamp. It returns nil if the operation was successful, or a pointer
 // to an sklPage if the operation failed because that page was full.
-func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, ts hlc.Timestamp) *sklPage {
+func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, val cacheValue) *sklPage {
 	// Acquire the rotation mutex read lock so that the page will not be rotated
 	// while add or lookup operations are in progress.
 	s.rotMutex.RLock()
@@ -207,7 +213,7 @@ func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, ts hlc.Timesta
 
 	// If floor ts is >= requested timestamp, then no need to perform a search
 	// or add any records.
-	if !s.floorTs.Less(ts) {
+	if !s.floorTs.Less(val.ts) {
 		return nil
 	}
 
@@ -221,9 +227,9 @@ func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, ts hlc.Timesta
 	var err error
 	if to != nil {
 		if (opt & excludeTo) == 0 {
-			err = s.later.addNode(&it, to, ts, hasKey)
+			err = s.later.addNode(&it, to, val, hasKey)
 		} else {
-			err = s.later.addNode(&it, to, ts, 0)
+			err = s.later.addNode(&it, to, val, 0)
 		}
 
 		if err == arenaskl.ErrArenaFull {
@@ -238,9 +244,9 @@ func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, ts hlc.Timesta
 
 	// Ensure that the starting node has been created.
 	if (opt & excludeFrom) == 0 {
-		err = s.later.addNode(&it, from, ts, hasKey|hasGap)
+		err = s.later.addNode(&it, from, val, hasKey|hasGap)
 	} else {
-		err = s.later.addNode(&it, from, ts, hasGap)
+		err = s.later.addNode(&it, from, val, hasGap)
 	}
 
 	if err == arenaskl.ErrArenaFull {
@@ -248,7 +254,18 @@ func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, ts hlc.Timesta
 	}
 
 	// Seek to the node immediately after the "from" node.
+	//
+	// If there are no nodes after the "from" node (only possible if to == nil),
+	// then ensureFloorValue below will be a no-op because no other nodes need
+	// to be adjusted.
 	if !it.Valid() || !bytes.Equal(it.Key(), from) {
+		// We will only reach this state if we didn't need to add a node at
+		// "from" due to the previous gap value being larger than val. The fast
+		// path for this case is in sklPage.addNode. For all other times, adding
+		// the new node will have positioned the iterator at "from".
+		//
+		// If Seek returns false then we're already at the following node, so
+		// there's no need to call Next.
 		if it.Seek(from) {
 			it.Next()
 		}
@@ -258,7 +275,7 @@ func (s *intervalSkl) addRange(from, to []byte, opt rangeOptions, ts hlc.Timesta
 
 	// Now iterate forwards and ensure that all nodes between the start and
 	// end (exclusive) have timestamps that are >= the range timestamp.
-	if !s.later.ensureFloorTs(&it, to, ts) {
+	if !s.later.ensureFloorValue(&it, to, val) {
 		// Page is filled up, so rotate pages and try again.
 		return s.later
 	}
@@ -291,37 +308,35 @@ func (s *intervalSkl) rotatePages(filledPage *sklPage) {
 	s.later = newSklPage(s.size / 2)
 }
 
-// LookupTimestamp returns the latest timestamp at which the given key was read.
-// If this operation is repeated with the same key, it will always result in an
-// equal or greater timestamp.
-func (s *intervalSkl) LookupTimestamp(key []byte) hlc.Timestamp {
+// LookupTimestamp returns the latest timestamp value at which the given key was
+// read. If this operation is repeated with the same key, it will always result
+// in an equal or greater timestamp.
+func (s *intervalSkl) LookupTimestamp(key []byte) cacheValue {
 	// Acquire the rotation mutex read lock so that the page will not be rotated
 	// while add or lookup operations are in progress.
 	s.rotMutex.RLock()
 	defer s.rotMutex.RUnlock()
 
 	// First perform lookup on the later page.
-	ts := s.later.lookupTimestamp(key)
+	val := s.later.lookupTimestamp(key)
 
 	// Now perform same lookup on the earlier page.
 	if s.earlier != nil {
 		// If later page timestamp is greater than the max timestamp in the
 		// earlier page, then no need to do lookup at all.
 		maxTs := hlc.Timestamp{WallTime: atomic.LoadInt64(&s.earlier.maxWallTime)}
-		if ts.Less(maxTs) {
-			ts2 := s.earlier.lookupTimestamp(key)
-			if ts.Less(ts2) {
-				ts = ts2
-			}
+		if val.ts.Less(maxTs) {
+			val2 := s.earlier.lookupTimestamp(key)
+			val, _ = ratchetValue(val, val2)
 		}
 	}
 
 	// Return the higher timestamp from the two lookups.
-	if ts.Less(s.floorTs) {
-		ts = s.floorTs
+	if val.ts.Less(s.floorTs) {
+		val = cacheValue{ts: s.floorTs, txnID: noTxnID}
 	}
 
-	return ts
+	return val
 }
 
 // sklPage maintains a skiplist based on a fixed-size arena. When the arena has
@@ -337,7 +352,7 @@ func newSklPage(size uint32) *sklPage {
 	return &sklPage{list: arenaskl.NewSkiplist(arenaskl.NewArena(size))}
 }
 
-func (p *sklPage) lookupTimestamp(key []byte) hlc.Timestamp {
+func (p *sklPage) lookupTimestamp(key []byte) cacheValue {
 	var it arenaskl.Iterator
 	it.Init(p.list)
 
@@ -352,35 +367,37 @@ func (p *sklPage) lookupTimestamp(key []byte) hlc.Timestamp {
 		return p.scanForTimestamp(&it, key, true)
 	}
 
-	keyTs, _ := p.decodeTimestampSet(it.Value(), it.Meta())
-	return keyTs
+	keyVal, _ := p.decodeValueSet(it.Value(), it.Meta())
+	return keyVal
 }
 
 func (p *sklPage) addNode(
-	it *arenaskl.Iterator, key []byte, ts hlc.Timestamp, opt nodeOptions,
+	it *arenaskl.Iterator, key []byte, val cacheValue, opt nodeOptions,
 ) error {
-	var arr [encodedTsSize * 2]byte
-	var keyTs, gapTs hlc.Timestamp
+	// Array with constant size will remain on the stack.
+	var arr [encodedValSize * 2]byte
+	var keyVal, gapVal cacheValue
 
 	if (opt & hasKey) != 0 {
-		keyTs = ts
+		keyVal = val
 	}
 
 	if (opt & hasGap) != 0 {
-		gapTs = ts
+		gapVal = val
 	}
 
 	if !it.SeekForPrev(key) {
-		// If the previous node has a gap timestamp that is >= than the new
-		// timestamp, then there is no need to add another node, since its
-		// timestamp would be the same as the gap timestamp.
-		prevTs := p.scanForTimestamp(it, key, false)
-		if !prevTs.Less(ts) {
+		// If the previous node has a gap value that would not be updated with
+		// the new value, then there is no need to add another node, since its
+		// timestamp would be the same as the gap timestamp and its txnID would
+		// be the same as the gap txnID.
+		prevVal := p.scanForTimestamp(it, key, false)
+		if _, update := ratchetValue(prevVal, val); !update {
 			return nil
 		}
 
 		// Ratchet max timestamp before adding the node.
-		p.ratchetMaxTimestamp(ts)
+		p.ratchetMaxTimestamp(val.ts)
 
 		// Ensure that a new node is created. It needs to stay in the
 		// initializing state until the gap timestamp of its preceding node
@@ -389,7 +406,7 @@ func (p *sklPage) addNode(
 		// for other ongoing operations - when they see this node they're
 		// forced to stop and help complete its initialization before they
 		// can continue.
-		b, meta := p.encodeTimestampSet(arr[:0], keyTs, gapTs)
+		b, meta := p.encodeValueSet(arr[:0], keyVal, gapVal)
 		err := it.Add(key, b, meta|initializing)
 		if err == arenaskl.ErrArenaFull {
 			atomic.StoreInt32(&p.isFull, 1)
@@ -416,12 +433,12 @@ func (p *sklPage) addNode(
 	// initializing bit, since we don't have the gap timestamp from the previous
 	// node. Leave finishing initialization to the thread that added the node, or
 	// to a lookup thread that requires it.
-	p.ratchetTimestampSet(it, keyTs, gapTs, false)
+	p.ratchetValueSet(it, keyVal, gapVal, false)
 
 	return nil
 }
 
-func (p *sklPage) ensureFloorTs(it *arenaskl.Iterator, to []byte, ts hlc.Timestamp) bool {
+func (p *sklPage) ensureFloorValue(it *arenaskl.Iterator, to []byte, val cacheValue) bool {
 	for it.Valid() {
 		if to != nil && bytes.Compare(it.Key(), to) >= 0 {
 			break
@@ -439,7 +456,7 @@ func (p *sklPage) ensureFloorTs(it *arenaskl.Iterator, to []byte, ts hlc.Timesta
 		// Don't clear the initialization bit, since we don't have the gap
 		// timestamp from the previous node, and don't need an initialized node
 		// for this operation anyway.
-		p.ratchetTimestampSet(it, ts, ts, false)
+		p.ratchetValueSet(it, val, val, false)
 
 		it.Next()
 	}
@@ -449,7 +466,18 @@ func (p *sklPage) ensureFloorTs(it *arenaskl.Iterator, to []byte, ts hlc.Timesta
 
 func (p *sklPage) ratchetMaxTimestamp(ts hlc.Timestamp) {
 	// Cheat and just use the max wall time portion of the timestamp, since it's
-	// fine for the max timestamp to be a bit too large.
+	// fine for the max timestamp to be a bit too large. This is the case
+	// because it's always safe to increase the timestamp in a range. It's also
+	// always safe to remove the transaction ID from a range. Either of these
+	// changes may force a transaction to lose "ownership" over a range of keys,
+	// but they'll never allow a transaction to gain "ownership" over a range of
+	// keys that it wouldn't otherwise have. In other words, it's ok for the
+	// intervalSkl to produce false negatives but never ok for it to produce
+	// false positives.
+	//
+	// We could use an atomic.Value to store a "MaxValue" cacheValue for a given
+	// page, but this would be more expensive and it's not clear that it would
+	// be worth it.
 	new := ts.WallTime
 	if ts.Logical > 0 {
 		new++
@@ -467,31 +495,24 @@ func (p *sklPage) ratchetMaxTimestamp(ts hlc.Timestamp) {
 	}
 }
 
-// ratchetTimestampSet will update the current node's key and gap timestamps to
-// the maximum of their current values or the given values. If clearInit is true,
+// ratchetValueSet will update the current node's key and gap timestamps to the
+// maximum of their current values or the given values. If clearInit is true,
 // then the initializing bit will be cleared, indicating that the node is now
 // fully initialized and its timestamps can now be relied upon.
-func (p *sklPage) ratchetTimestampSet(
-	it *arenaskl.Iterator, keyTs, gapTs hlc.Timestamp, clearInit bool,
+func (p *sklPage) ratchetValueSet(
+	it *arenaskl.Iterator, keyVal, gapVal cacheValue, clearInit bool,
 ) {
-	var arr [encodedTsSize * 2]byte
+	// Array with constant size will remain on the stack.
+	var arr [encodedValSize * 2]byte
 
 	for {
 		meta := it.Meta()
-		oldKeyTs, oldGapTs := p.decodeTimestampSet(it.Value(), meta)
+		oldKeyVal, oldGapVal := p.decodeValueSet(it.Value(), meta)
 
-		greater := false
-		if oldKeyTs.Less(keyTs) {
-			greater = true
-		} else {
-			keyTs = oldKeyTs
-		}
-
-		if oldGapTs.Less(gapTs) {
-			greater = true
-		} else {
-			gapTs = oldGapTs
-		}
+		var keyValUpdate, gapValUpdate bool
+		keyVal, keyValUpdate = ratchetValue(oldKeyVal, keyVal)
+		gapVal, gapValUpdate = ratchetValue(oldGapVal, gapVal)
+		update := keyValUpdate || gapValUpdate
 
 		var initMeta uint16
 		if clearInit {
@@ -502,7 +523,7 @@ func (p *sklPage) ratchetTimestampSet(
 
 		// Check whether it's necessary to make an update.
 		var err error
-		if !greater {
+		if !update {
 			if !clearInit || (meta&initializing) == 0 {
 				// No update necessary because the init bit doesn't need to be
 				// cleared or it's already cleared.
@@ -513,6 +534,7 @@ func (p *sklPage) ratchetTimestampSet(
 			err = it.SetMeta(meta & ^uint16(initializing))
 		} else {
 			// Ratchet the max timestamp.
+			keyTs, gapTs := keyVal.ts, gapVal.ts
 			if gapTs.Less(keyTs) {
 				p.ratchetMaxTimestamp(keyTs)
 			} else {
@@ -520,7 +542,7 @@ func (p *sklPage) ratchetTimestampSet(
 			}
 
 			// Update the timestamps, possibly preserving the init bit.
-			b, newMeta := p.encodeTimestampSet(arr[:0], keyTs, gapTs)
+			b, newMeta := p.encodeValueSet(arr[:0], keyVal, gapVal)
 			err = it.Set(b, newMeta|initMeta)
 		}
 
@@ -532,7 +554,7 @@ func (p *sklPage) ratchetTimestampSet(
 			atomic.StoreInt32(&p.isFull, 1)
 
 			// Arena full, so ratchet the timestamps to the max timestamp.
-			err = it.SetMeta(uint16(useMaxTs) | initMeta)
+			err = it.SetMeta(uint16(useMaxVal) | initMeta)
 			if err == arenaskl.ErrRecordUpdated {
 				continue
 			}
@@ -586,7 +608,7 @@ func (p *sklPage) ratchetTimestampSet(
 // This means that no matter what gets inserted, or when it gets inserted, the
 // scanning goroutine is guaranteed to end up with a timestamp value that will
 // never decrease on future lookups, which is the critical invariant.
-func (p *sklPage) scanForTimestamp(it *arenaskl.Iterator, key []byte, onKey bool) hlc.Timestamp {
+func (p *sklPage) scanForTimestamp(it *arenaskl.Iterator, key []byte, onKey bool) cacheValue {
 	clone := *it
 
 	if onKey {
@@ -597,7 +619,7 @@ func (p *sklPage) scanForTimestamp(it *arenaskl.Iterator, key []byte, onKey bool
 
 	// First iterate backwards, looking for an already initialized node which
 	// will supply the initial candidate gap timestamp.
-	var gapTs hlc.Timestamp
+	var gapVal cacheValue
 	for {
 		if !clone.Valid() {
 			// No more previous nodes, so use the zero timestamp and begin
@@ -609,7 +631,7 @@ func (p *sklPage) scanForTimestamp(it *arenaskl.Iterator, key []byte, onKey bool
 		meta := clone.Meta()
 		if (meta & initializing) == 0 {
 			// Found the gap timestamp for an initialized node.
-			_, gapTs = p.decodeTimestampSet(clone.Value(), meta)
+			_, gapVal = p.decodeValueSet(clone.Value(), meta)
 			clone.Next()
 			break
 		}
@@ -621,26 +643,26 @@ func (p *sklPage) scanForTimestamp(it *arenaskl.Iterator, key []byte, onKey bool
 	// nodes along the way, and update the gap timestamp.
 	for {
 		if !clone.Valid() {
-			return gapTs
+			return gapVal
 		}
 
 		if (clone.Meta() & initializing) != 0 {
 			// Finish initializing the node with the gap timestamp.
-			p.ratchetTimestampSet(&clone, gapTs, gapTs, true)
+			p.ratchetValueSet(&clone, gapVal, gapVal, true)
 		}
 
 		cmp := bytes.Compare(clone.Key(), key)
 		if cmp > 0 {
 			// Past the lookup key, so use the gap timestamp.
-			return gapTs
+			return gapVal
 		}
 
-		var keyTs hlc.Timestamp
-		keyTs, gapTs = p.decodeTimestampSet(clone.Value(), clone.Meta())
+		var keyVal cacheValue
+		keyVal, gapVal = p.decodeValueSet(clone.Value(), clone.Meta())
 
 		if cmp == 0 {
 			// On the lookup key, so use the key timestamp.
-			return keyTs
+			return keyVal
 		}
 
 		// Haven't yet reached the lookup key, so keep iterating.
@@ -648,33 +670,32 @@ func (p *sklPage) scanForTimestamp(it *arenaskl.Iterator, key []byte, onKey bool
 	}
 }
 
-func (p *sklPage) decodeTimestampSet(b []byte, meta uint16) (keyTs, gapTs hlc.Timestamp) {
-	if (meta & useMaxTs) != 0 {
+func (p *sklPage) decodeValueSet(b []byte, meta uint16) (keyVal, gapVal cacheValue) {
+	if (meta & useMaxVal) != 0 {
 		ts := hlc.Timestamp{WallTime: atomic.LoadInt64(&p.maxWallTime)}
-		return ts, ts
+		maxVal := cacheValue{ts: ts, txnID: noTxnID}
+		return maxVal, maxVal
 	}
 
 	if (meta & hasKey) != 0 {
-		b, keyTs = decodeTimestamp(b)
+		b, keyVal = decodeValue(b)
 	}
 
 	if (meta & hasGap) != 0 {
-		_, gapTs = decodeTimestamp(b)
+		_, gapVal = decodeValue(b)
 	}
 
 	return
 }
 
-func (p *sklPage) encodeTimestampSet(
-	b []byte, keyTs, gapTs hlc.Timestamp,
-) (ret []byte, meta uint16) {
-	if keyTs.WallTime != 0 || keyTs.Logical != 0 {
-		b = encodeTimestamp(b, keyTs)
+func (p *sklPage) encodeValueSet(b []byte, keyVal, gapVal cacheValue) (ret []byte, meta uint16) {
+	if keyVal.ts.WallTime != 0 || keyVal.ts.Logical != 0 {
+		b = encodeValue(b, keyVal)
 		meta |= hasKey
 	}
 
-	if gapTs.WallTime != 0 || gapTs.Logical != 0 {
-		b = encodeTimestamp(b, gapTs)
+	if gapVal.ts.WallTime != 0 || gapVal.ts.Logical != 0 {
+		b = encodeValue(b, gapVal)
 		meta |= hasGap
 	}
 
@@ -682,18 +703,24 @@ func (p *sklPage) encodeTimestampSet(
 	return
 }
 
-func decodeTimestamp(b []byte) (ret []byte, ts hlc.Timestamp) {
-	wallTime := binary.BigEndian.Uint64(b)
-	logical := binary.BigEndian.Uint32(b[8:])
-	ts = hlc.Timestamp{WallTime: int64(wallTime), Logical: int32(logical)}
-	ret = b[encodedTsSize:]
+func decodeValue(b []byte) (ret []byte, val cacheValue) {
+	val.ts.WallTime = int64(binary.BigEndian.Uint64(b))
+	val.ts.Logical = int32(binary.BigEndian.Uint32(b[8:]))
+	var err error
+	if val.txnID, err = uuid.FromBytes(b[encodedTsSize:encodedValSize]); err != nil {
+		panic(err)
+	}
+	ret = b[encodedValSize:]
 	return
 }
 
-func encodeTimestamp(b []byte, ts hlc.Timestamp) []byte {
+func encodeValue(b []byte, val cacheValue) []byte {
 	l := len(b)
-	b = b[:l+encodedTsSize]
-	binary.BigEndian.PutUint64(b[l:], uint64(ts.WallTime))
-	binary.BigEndian.PutUint32(b[l+8:], uint32(ts.Logical))
+	b = b[:l+encodedValSize]
+	binary.BigEndian.PutUint64(b[l:], uint64(val.ts.WallTime))
+	binary.BigEndian.PutUint32(b[l+8:], uint32(val.ts.Logical))
+	if _, err := val.txnID.MarshalTo(b[l+encodedTsSize:]); err != nil {
+		panic(err)
+	}
 	return b
 }

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -250,8 +250,8 @@ func TestIntervalSklBoundaryRange(t *testing.T) {
 	// Don't allow nil from and to keys.
 	require.Panics(t, func() { s.AddRange([]byte(nil), []byte(nil), excludeFrom, val1) })
 
-	// If from key is greater than to key, then range is zero-length.
-	s.AddRange([]byte("kiwi"), []byte("apple"), 0, val1)
+	// Don't allow inverted ranges.
+	require.Panics(t, func() { s.AddRange([]byte("kiwi"), []byte("apple"), 0, val1) })
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("banana")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("kiwi")))

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -25,241 +25,339 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-const arenaSize = 64 * 1024 * 1024
+const arenaSize = 64 * 1024 * 1024 // 64 MB
+
+var (
+	emptyVal = cacheValue{}
+	floorTs  = makeTS(100, 0)
+	floorVal = makeValWithoutID(floorTs)
+)
 
 func makeTS(walltime int64, logical int32) hlc.Timestamp {
-	return hlc.Timestamp{
-		WallTime: walltime,
-		Logical:  logical,
+	return hlc.Timestamp{WallTime: walltime, Logical: logical}
+}
+
+func makeValWithoutID(ts hlc.Timestamp) cacheValue {
+	return cacheValue{ts: ts, txnID: noTxnID}
+}
+
+func makeVal(ts hlc.Timestamp, txnIDStr string) cacheValue {
+	txnIDBytes := []byte(txnIDStr)
+	if len(txnIDBytes) < 16 {
+		// If too short, pad front with zeros.
+		oldTxnIDBytes := txnIDBytes
+		txnIDBytes = make([]byte, 16)
+		copy(txnIDBytes[16-len(oldTxnIDBytes):], oldTxnIDBytes)
 	}
+	txnID, err := uuid.FromBytes(txnIDBytes)
+	if err != nil {
+		panic(err)
+	}
+	return cacheValue{ts: ts, txnID: txnID}
 }
 
 func TestIntervalSklAdd(t *testing.T) {
-	ts1 := makeTS(100, 100)
-	ts2 := makeTS(200, 201)
+	val1 := makeVal(makeTS(100, 100), "1")
+	val2 := makeVal(makeTS(200, 201), "2")
 
 	s := newIntervalSkl(arenaSize)
 
-	s.Add([]byte("apricot"), ts1)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("apricot")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("banana")))
+	s.Add([]byte("apricot"), val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("banana")))
 
-	s.Add([]byte("banana"), ts2)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("apricot")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("cherry")))
+	s.Add([]byte("banana"), val2)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("cherry")))
 }
 
 func TestIntervalSklSingleRange(t *testing.T) {
-	ts1 := makeTS(100, 100)
-	ts2 := makeTS(200, 50)
+	val1 := makeVal(makeTS(100, 100), "1")
+	val2 := makeVal(makeTS(200, 50), "2")
 
 	s := newIntervalSkl(arenaSize)
 
-	s.AddRange([]byte("apricot"), []byte("orange"), 0, ts1)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("apricot")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("orange")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("raspberry")))
+	s.AddRange([]byte("apricot"), []byte("orange"), 0, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("raspberry")))
 
 	// Try again and make sure it's a no-op.
-	s.AddRange([]byte("apricot"), []byte("orange"), 0, ts1)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("apricot")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("orange")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("raspberry")))
+	s.AddRange([]byte("apricot"), []byte("orange"), 0, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("raspberry")))
 
 	// Ratchet up the timestamps.
-	s.AddRange([]byte("apricot"), []byte("orange"), 0, ts2)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("apricot")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("orange")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("raspberry")))
+	s.AddRange([]byte("apricot"), []byte("orange"), 0, val2)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("raspberry")))
 
 	// Add disjoint range.
-	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, ts1)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("peach")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("pear")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("raspberry")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("tomato")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("watermelon")))
+	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("peach")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("watermelon")))
 
 	// Try again and make sure it's a no-op.
-	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, ts1)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("peach")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("pear")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("raspberry")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("tomato")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("watermelon")))
+	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("peach")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("watermelon")))
 
 	// Ratchet up the timestamps.
-	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, ts2)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("peach")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("pear")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("raspberry")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("tomato")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("watermelon")))
+	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, val2)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("peach")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("watermelon")))
 }
 
 func TestIntervalSklOpenRanges(t *testing.T) {
-	floorTs := makeTS(100, 0)
-	ts1 := makeTS(200, 200)
-	ts2 := makeTS(200, 201)
+	val1 := makeVal(makeTS(200, 200), "1")
+	val2 := makeVal(makeTS(200, 201), "2")
 
 	s := newIntervalSkl(arenaSize)
 	s.floorTs = floorTs
 
-	s.AddRange([]byte("banana"), nil, excludeFrom, ts1)
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("orange")))
+	s.AddRange([]byte("banana"), nil, excludeFrom, val1)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("orange")))
 
-	s.AddRange([]byte(""), []byte("kiwi"), 0, ts2)
-	require.Equal(t, ts2, s.LookupTimestamp(nil))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("orange")))
+	s.AddRange([]byte(""), []byte("kiwi"), 0, val2)
+	require.Equal(t, val2, s.LookupTimestamp(nil))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("orange")))
 }
 
 func TestIntervalSklSupersetRange(t *testing.T) {
-	floorTs := makeTS(100, 0)
-	ts1 := makeTS(200, 1)
-	ts2 := makeTS(201, 0)
-	ts3 := makeTS(300, 0)
+	val1 := makeVal(makeTS(200, 1), "1")
+	val2 := makeVal(makeTS(201, 0), "2")
+	val3 := makeVal(makeTS(300, 0), "3")
 
 	s := newIntervalSkl(arenaSize)
 	s.floorTs = floorTs
 
 	// Same range.
-	s.AddRange([]byte("kiwi"), []byte("orange"), 0, ts1)
-	s.AddRange([]byte("kiwi"), []byte("orange"), 0, ts2)
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("mango")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("orange")))
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("raspberry")))
+	s.AddRange([]byte("kiwi"), []byte("orange"), 0, val1)
+	s.AddRange([]byte("kiwi"), []byte("orange"), 0, val2)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("mango")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("raspberry")))
 
 	// Superset range, but with lower timestamp.
-	s.AddRange([]byte("grape"), []byte("pear"), 0, ts1)
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("grape")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("orange")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("pear")))
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("watermelon")))
+	s.AddRange([]byte("grape"), []byte("pear"), 0, val1)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("watermelon")))
 
 	// Superset range, but with higher timestamp.
-	s.AddRange([]byte("banana"), []byte("raspberry"), 0, ts3)
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("grape")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("orange")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("pear")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("raspberry")))
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("watermelon")))
+	s.AddRange([]byte("banana"), []byte("raspberry"), 0, val3)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("watermelon")))
 }
 
 func TestIntervalSklContiguousRanges(t *testing.T) {
-	floorTs := makeTS(100, 0)
-	ts1 := makeTS(200, 1)
-	ts2 := makeTS(201, 0)
+	val1 := makeVal(makeTS(200, 1), "1")
+	val2 := makeVal(makeTS(201, 0), "2")
 
 	s := newIntervalSkl(arenaSize)
 	s.floorTs = floorTs
 
-	s.AddRange([]byte("banana"), []byte("kiwi"), excludeTo, ts1)
-	s.AddRange([]byte("kiwi"), []byte("orange"), excludeTo, ts2)
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("orange")))
+	s.AddRange([]byte("banana"), []byte("kiwi"), excludeTo, val1)
+	s.AddRange([]byte("kiwi"), []byte("orange"), excludeTo, val2)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("orange")))
 }
 
 func TestIntervalSklOverlappingRanges(t *testing.T) {
-	floorTs := makeTS(100, 0)
-	ts1 := makeTS(200, 1)
-	ts2 := makeTS(201, 0)
-	ts3 := makeTS(300, 0)
-	ts4 := makeTS(400, 0)
+	val1 := makeVal(makeTS(200, 1), "1")
+	val2 := makeVal(makeTS(201, 0), "2")
+	val3 := makeVal(makeTS(300, 0), "3")
+	val4 := makeVal(makeTS(400, 0), "4")
 
 	s := newIntervalSkl(arenaSize)
 	s.floorTs = floorTs
 
-	s.AddRange([]byte("banana"), []byte("kiwi"), 0, ts1)
-	s.AddRange([]byte("grape"), []byte("raspberry"), excludeTo, ts2)
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("grape")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("raspberry")))
+	s.AddRange([]byte("banana"), []byte("kiwi"), 0, val1)
+	s.AddRange([]byte("grape"), []byte("raspberry"), excludeTo, val2)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("raspberry")))
 
-	s.AddRange([]byte("apricot"), []byte("orange"), 0, ts3)
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("apricot")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("grape")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("orange")))
-	require.Equal(t, ts2, s.LookupTimestamp([]byte("pear")))
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("raspberry")))
+	s.AddRange([]byte("apricot"), []byte("orange"), 0, val3)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("raspberry")))
 
-	s.AddRange([]byte("kiwi"), []byte(nil), excludeFrom, ts4)
-	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("apricot")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("grape")))
-	require.Equal(t, ts3, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, ts4, s.LookupTimestamp([]byte("orange")))
-	require.Equal(t, ts4, s.LookupTimestamp([]byte("pear")))
-	require.Equal(t, ts4, s.LookupTimestamp([]byte("raspberry")))
+	s.AddRange([]byte("kiwi"), []byte(nil), excludeFrom, val4)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("raspberry")))
 }
 
 func TestIntervalSklBoundaryRange(t *testing.T) {
-	ts1 := makeTS(100, 100)
+	val1 := makeVal(makeTS(100, 100), "1")
 
 	s := newIntervalSkl(arenaSize)
 
 	// Don't allow nil from key.
-	require.Panics(t, func() { s.AddRange([]byte(nil), []byte(nil), excludeFrom, ts1) })
+	require.Panics(t, func() { s.AddRange([]byte(nil), []byte(nil), excludeFrom, val1) })
 
 	// If from key is greater than to key, then range is zero-length.
-	s.AddRange([]byte("kiwi"), []byte("apple"), 0, ts1)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("raspberry")))
+	s.AddRange([]byte("kiwi"), []byte("apple"), 0, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("raspberry")))
 
 	// If from key is same as to key, and both are excluded, then range is
 	// zero-length.
-	s.AddRange([]byte("banana"), []byte("banana"), excludeFrom|excludeTo, ts1)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("kiwi")))
+	s.AddRange([]byte("banana"), []byte("banana"), excludeFrom|excludeTo, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("kiwi")))
 
 	// If from key is same as to key, then range has length one.
-	s.AddRange([]byte("mango"), []byte("mango"), 0, ts1)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("mango")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("orange")))
+	s.AddRange([]byte("mango"), []byte("mango"), 0, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("mango")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("orange")))
 
 	// If from key is same as to key, then range has length one.
-	s.AddRange([]byte("banana"), []byte("banana"), excludeTo, ts1)
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, ts1, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("cherry")))
+	s.AddRange([]byte("banana"), []byte("banana"), excludeTo, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("cherry")))
+}
+
+func TestIntervalSklRatchetTxnIDs(t *testing.T) {
+	ts1 := makeTS(100, 100)
+	ts2 := makeTS(250, 50)
+	ts3 := makeTS(350, 50)
+
+	val1 := makeVal(ts1, "1")
+	val2 := makeVal(ts1, "2")
+	val2WithoutID := makeValWithoutID(ts1)
+	val3 := makeVal(ts2, "2") // same txn ID as tsVal2
+	val4 := makeVal(ts2, "3")
+	val4WithoutID := makeValWithoutID(ts2)
+	val5 := makeVal(ts3, "4")
+	val6 := makeVal(ts3, "5")
+	val6WithoutID := makeValWithoutID(ts3)
+
+	s := newIntervalSkl(arenaSize)
+
+	s.AddRange([]byte("apricot"), []byte("raspberry"), 0, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("tomato")))
+
+	// Ratchet up the txnID with the same timestamp; txnID should be removed.
+	s.AddRange([]byte("apricot"), []byte("tomato"), 0, val2)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val2WithoutID, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val2WithoutID, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val2WithoutID, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("watermelon")))
+
+	// Ratchet up the timestamp with the same txnID.
+	s.AddRange([]byte("apricot"), []byte("orange"), 0, val3)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val2WithoutID, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("watermelon")))
+
+	// Ratchet up the txnID with the same timestamp; txnID should be removed.
+	s.AddRange([]byte("apricot"), []byte("banana"), 0, val4)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val4WithoutID, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val4WithoutID, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val2WithoutID, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("watermelon")))
+
+	// Ratchet up the timestamp with a new txnID using excludeTo.
+	s.AddRange([]byte("apricot"), []byte("orange"), excludeTo, val5)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val5, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val5, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val2WithoutID, s.LookupTimestamp([]byte("raspberry")))
+
+	// Ratchet up the txnID with the same timestamp using excludeTo; txnID should be removed.
+	s.AddRange([]byte("apricot"), []byte("banana"), excludeTo, val6)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val6WithoutID, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val5, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val2WithoutID, s.LookupTimestamp([]byte("raspberry")))
+
+	// Ratchet up the txnID with the same timestamp using excludeFrom; txnID should be removed.
+	s.AddRange([]byte("banana"), []byte(nil), excludeFrom, val6)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val6WithoutID, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, val5, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val6, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val6, s.LookupTimestamp([]byte("raspberry")))
 }
 
 func TestIntervalSklFill(t *testing.T) {
 	const n = 200
+	const txnID = "123"
 
 	// Use constant seed so that skiplist towers will be of predictable size.
 	rand.Seed(0)
@@ -268,32 +366,34 @@ func TestIntervalSklFill(t *testing.T) {
 
 	for i := 0; i < n; i++ {
 		key := []byte(fmt.Sprintf("%05d", i))
-		s.AddRange(key, key, 0, makeTS(int64(100+i), int32(i)))
+		s.AddRange(key, key, 0, makeVal(makeTS(int64(100+i), int32(i)), txnID))
 	}
 
 	floorTs := s.floorTs
 	require.True(t, makeTS(100, 0).Less(floorTs))
 
 	lastKey := []byte(fmt.Sprintf("%05d", n-1))
-	require.Equal(t, makeTS(int64(100+n-1), int32(n-1)), s.LookupTimestamp(lastKey))
+	expVal := makeVal(makeTS(int64(100+n-1), int32(n-1)), txnID)
+	require.Equal(t, expVal, s.LookupTimestamp(lastKey))
 
 	for i := 0; i < n; i++ {
 		key := []byte(fmt.Sprintf("%05d", i))
-		require.False(t, s.LookupTimestamp(key).Less(floorTs))
+		require.False(t, s.LookupTimestamp(key).ts.Less(floorTs))
 	}
 }
 
 // Repeatedly fill the structure and make sure timestamp lookups always increase.
 func TestIntervalSklFill2(t *testing.T) {
 	const n = 10000
+	const txnID = "123"
 
 	s := newIntervalSkl(997)
 	key := []byte("some key")
 
 	for i := 0; i < n; i++ {
-		ts := makeTS(int64(i), int32(i))
-		s.Add(key, ts)
-		require.True(t, !s.LookupTimestamp(key).Less(ts))
+		val := makeVal(makeTS(int64(i), int32(i)), txnID)
+		s.Add(key, val)
+		require.True(t, !s.LookupTimestamp(key).ts.Less(val.ts))
 	}
 }
 
@@ -326,7 +426,7 @@ func TestIntervalSklConcurrency(t *testing.T) {
 
 					rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 					key := []byte(fmt.Sprintf("%05d", i))
-					maxTs := hlc.Timestamp{}
+					maxVal := cacheValue{}
 
 					for j := 0; j < n; j++ {
 						fromNum := rng.Intn(slots)
@@ -342,17 +442,18 @@ func TestIntervalSklConcurrency(t *testing.T) {
 						to := []byte(fmt.Sprintf("%05d", toNum))
 
 						now := clock.Now()
-						s.AddRange(from, to, 0, now)
+						nowVal := makeValWithoutID(now)
+						s.AddRange(from, to, 0, nowVal)
 
-						ts := s.LookupTimestamp(from)
-						require.False(t, ts.Less(now))
+						val := s.LookupTimestamp(from)
+						require.False(t, val.ts.Less(now))
 
-						ts = s.LookupTimestamp(to)
-						require.False(t, ts.Less(now))
+						val = s.LookupTimestamp(to)
+						require.False(t, val.ts.Less(now))
 
-						ts = s.LookupTimestamp(key)
-						require.False(t, ts.Less(maxTs))
-						maxTs = ts
+						val = s.LookupTimestamp(key)
+						require.False(t, val.ts.Less(maxVal.ts))
+						maxVal = val
 					}
 				}(i)
 			}
@@ -364,6 +465,7 @@ func TestIntervalSklConcurrency(t *testing.T) {
 
 func BenchmarkIntervalSklAdd(b *testing.B) {
 	const max = 500000000
+	const txnID = "123"
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Millisecond)
 	s := newIntervalSkl(64 * 1024 * 1024)
@@ -376,7 +478,7 @@ func BenchmarkIntervalSklAdd(b *testing.B) {
 				rnd := int64(rng.Int31n(max))
 				from := []byte(fmt.Sprintf("%020d", rnd))
 				to := []byte(fmt.Sprintf("%020d", rnd+int64(size-1)))
-				s.AddRange(from, to, 0, clock.Now())
+				s.AddRange(from, to, 0, makeVal(clock.Now(), txnID))
 			}
 		})
 
@@ -388,6 +490,7 @@ func BenchmarkIntervalSklAddAndLookup(b *testing.B) {
 	const parallel = 1
 	const max = 1000000000
 	const data = 500000
+	const txnID = "123"
 
 	s := newIntervalSkl(arenaSize)
 	clock := hlc.NewClock(hlc.UnixNano, time.Millisecond)
@@ -395,7 +498,8 @@ func BenchmarkIntervalSklAddAndLookup(b *testing.B) {
 
 	for i := 0; i < data; i++ {
 		from, to := makeRange(rng.Int31n(max))
-		s.AddRange(from, to, excludeFrom|excludeTo, clock.Now())
+		nowVal := makeVal(clock.Now(), txnID)
+		s.AddRange(from, to, excludeFrom|excludeTo, nowVal)
 	}
 
 	for i := 0; i <= 10; i++ {
@@ -419,7 +523,8 @@ func BenchmarkIntervalSklAddAndLookup(b *testing.B) {
 							s.LookupTimestamp(key)
 						} else {
 							from, to := makeRange(keyNum)
-							s.AddRange(from, to, excludeFrom|excludeTo, clock.Now())
+							nowVal := makeVal(clock.Now(), txnID)
+							s.AddRange(from, to, excludeFrom|excludeTo, nowVal)
 						}
 					}
 				}(i)

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -1,0 +1,452 @@
+// Copyright (C) 2017 Andy Kimball
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tscache
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+const arenaSize = 64 * 1024 * 1024
+
+func makeTS(walltime int64, logical int32) hlc.Timestamp {
+	return hlc.Timestamp{
+		WallTime: walltime,
+		Logical:  logical,
+	}
+}
+
+func TestIntervalSklAdd(t *testing.T) {
+	ts1 := makeTS(100, 100)
+	ts2 := makeTS(200, 201)
+
+	s := newIntervalSkl(arenaSize)
+
+	s.Add([]byte("apricot"), ts1)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("banana")))
+
+	s.Add([]byte("banana"), ts2)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("cherry")))
+}
+
+func TestIntervalSklSingleRange(t *testing.T) {
+	ts1 := makeTS(100, 100)
+	ts2 := makeTS(200, 50)
+
+	s := newIntervalSkl(arenaSize)
+
+	s.AddRange([]byte("apricot"), []byte("orange"), 0, ts1)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("raspberry")))
+
+	// Try again and make sure it's a no-op.
+	s.AddRange([]byte("apricot"), []byte("orange"), 0, ts1)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("raspberry")))
+
+	// Ratchet up the timestamps.
+	s.AddRange([]byte("apricot"), []byte("orange"), 0, ts2)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("raspberry")))
+
+	// Add disjoint range.
+	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, ts1)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("peach")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("watermelon")))
+
+	// Try again and make sure it's a no-op.
+	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, ts1)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("peach")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("watermelon")))
+
+	// Ratchet up the timestamps.
+	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, ts2)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("peach")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("watermelon")))
+}
+
+func TestIntervalSklOpenRanges(t *testing.T) {
+	floorTs := makeTS(100, 0)
+	ts1 := makeTS(200, 200)
+	ts2 := makeTS(200, 201)
+
+	s := newIntervalSkl(arenaSize)
+	s.floorTs = floorTs
+
+	s.AddRange([]byte("banana"), nil, excludeFrom, ts1)
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("orange")))
+
+	s.AddRange([]byte(""), []byte("kiwi"), 0, ts2)
+	require.Equal(t, ts2, s.LookupTimestamp(nil))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("orange")))
+}
+
+func TestIntervalSklSupersetRange(t *testing.T) {
+	floorTs := makeTS(100, 0)
+	ts1 := makeTS(200, 1)
+	ts2 := makeTS(201, 0)
+	ts3 := makeTS(300, 0)
+
+	s := newIntervalSkl(arenaSize)
+	s.floorTs = floorTs
+
+	// Same range.
+	s.AddRange([]byte("kiwi"), []byte("orange"), 0, ts1)
+	s.AddRange([]byte("kiwi"), []byte("orange"), 0, ts2)
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("mango")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("raspberry")))
+
+	// Superset range, but with lower timestamp.
+	s.AddRange([]byte("grape"), []byte("pear"), 0, ts1)
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("watermelon")))
+
+	// Superset range, but with higher timestamp.
+	s.AddRange([]byte("banana"), []byte("raspberry"), 0, ts3)
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("watermelon")))
+}
+
+func TestIntervalSklContiguousRanges(t *testing.T) {
+	floorTs := makeTS(100, 0)
+	ts1 := makeTS(200, 1)
+	ts2 := makeTS(201, 0)
+
+	s := newIntervalSkl(arenaSize)
+	s.floorTs = floorTs
+
+	s.AddRange([]byte("banana"), []byte("kiwi"), excludeTo, ts1)
+	s.AddRange([]byte("kiwi"), []byte("orange"), excludeTo, ts2)
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("orange")))
+}
+
+func TestIntervalSklOverlappingRanges(t *testing.T) {
+	floorTs := makeTS(100, 0)
+	ts1 := makeTS(200, 1)
+	ts2 := makeTS(201, 0)
+	ts3 := makeTS(300, 0)
+	ts4 := makeTS(400, 0)
+
+	s := newIntervalSkl(arenaSize)
+	s.floorTs = floorTs
+
+	s.AddRange([]byte("banana"), []byte("kiwi"), 0, ts1)
+	s.AddRange([]byte("grape"), []byte("raspberry"), excludeTo, ts2)
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("raspberry")))
+
+	s.AddRange([]byte("apricot"), []byte("orange"), 0, ts3)
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, ts2, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("raspberry")))
+
+	s.AddRange([]byte("kiwi"), []byte(nil), excludeFrom, ts4)
+	require.Equal(t, floorTs, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("apricot")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, ts3, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, ts4, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, ts4, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, ts4, s.LookupTimestamp([]byte("raspberry")))
+}
+
+func TestIntervalSklBoundaryRange(t *testing.T) {
+	ts1 := makeTS(100, 100)
+
+	s := newIntervalSkl(arenaSize)
+
+	// Don't allow nil from key.
+	require.Panics(t, func() { s.AddRange([]byte(nil), []byte(nil), excludeFrom, ts1) })
+
+	// If from key is greater than to key, then range is zero-length.
+	s.AddRange([]byte("kiwi"), []byte("apple"), 0, ts1)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("raspberry")))
+
+	// If from key is same as to key, and both are excluded, then range is
+	// zero-length.
+	s.AddRange([]byte("banana"), []byte("banana"), excludeFrom|excludeTo, ts1)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("kiwi")))
+
+	// If from key is same as to key, then range has length one.
+	s.AddRange([]byte("mango"), []byte("mango"), 0, ts1)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("mango")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("orange")))
+
+	// If from key is same as to key, then range has length one.
+	s.AddRange([]byte("banana"), []byte("banana"), excludeTo, ts1)
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, ts1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, hlc.Timestamp{}, s.LookupTimestamp([]byte("cherry")))
+}
+
+func TestIntervalSklFill(t *testing.T) {
+	const n = 200
+
+	// Use constant seed so that skiplist towers will be of predictable size.
+	rand.Seed(0)
+
+	s := newIntervalSkl(3000)
+
+	for i := 0; i < n; i++ {
+		key := []byte(fmt.Sprintf("%05d", i))
+		s.AddRange(key, key, 0, makeTS(int64(100+i), int32(i)))
+	}
+
+	floorTs := s.floorTs
+	require.True(t, makeTS(100, 0).Less(floorTs))
+
+	lastKey := []byte(fmt.Sprintf("%05d", n-1))
+	require.Equal(t, makeTS(int64(100+n-1), int32(n-1)), s.LookupTimestamp(lastKey))
+
+	for i := 0; i < n; i++ {
+		key := []byte(fmt.Sprintf("%05d", i))
+		require.False(t, s.LookupTimestamp(key).Less(floorTs))
+	}
+}
+
+// Repeatedly fill the structure and make sure timestamp lookups always increase.
+func TestIntervalSklFill2(t *testing.T) {
+	const n = 10000
+
+	s := newIntervalSkl(997)
+	key := []byte("some key")
+
+	for i := 0; i < n; i++ {
+		ts := makeTS(int64(i), int32(i))
+		s.Add(key, ts)
+		require.True(t, !s.LookupTimestamp(key).Less(ts))
+	}
+}
+
+func TestIntervalSklConcurrency(t *testing.T) {
+	testCases := []struct {
+		name string
+		size uint32
+	}{
+		// Test concurrency with a small page size in order to force lots of
+		// page rotations.
+		{name: "Rotates", size: 2048},
+		// Test concurrency with a larger page size in order to test slot
+		// concurrency without the added complication of page rotations.
+		{name: "Slots", size: arenaSize},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			const n = 10000
+			const slots = 20
+
+			var wg sync.WaitGroup
+			clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+			s := newIntervalSkl(tc.size)
+
+			for i := 0; i < slots; i++ {
+				wg.Add(1)
+
+				go func(i int) {
+					defer wg.Done()
+
+					rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+					key := []byte(fmt.Sprintf("%05d", i))
+					maxTs := hlc.Timestamp{}
+
+					for j := 0; j < n; j++ {
+						fromNum := rng.Intn(slots)
+						toNum := rng.Intn(slots)
+
+						if fromNum > toNum {
+							fromNum, toNum = toNum, fromNum
+						} else if fromNum == toNum {
+							toNum++
+						}
+
+						from := []byte(fmt.Sprintf("%05d", fromNum))
+						to := []byte(fmt.Sprintf("%05d", toNum))
+
+						now := clock.Now()
+						s.AddRange(from, to, 0, now)
+
+						ts := s.LookupTimestamp(from)
+						require.False(t, ts.Less(now))
+
+						ts = s.LookupTimestamp(to)
+						require.False(t, ts.Less(now))
+
+						ts = s.LookupTimestamp(key)
+						require.False(t, ts.Less(maxTs))
+						maxTs = ts
+					}
+				}(i)
+			}
+
+			wg.Wait()
+		})
+	}
+}
+
+func BenchmarkIntervalSklAdd(b *testing.B) {
+	const max = 500000000
+
+	clock := hlc.NewClock(hlc.UnixNano, time.Millisecond)
+	s := newIntervalSkl(64 * 1024 * 1024)
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	size := 1
+	for i := 0; i < 9; i++ {
+		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			for iter := 0; iter < b.N; iter++ {
+				rnd := int64(rng.Int31n(max))
+				from := []byte(fmt.Sprintf("%020d", rnd))
+				to := []byte(fmt.Sprintf("%020d", rnd+int64(size-1)))
+				s.AddRange(from, to, 0, clock.Now())
+			}
+		})
+
+		size *= 10
+	}
+}
+
+func BenchmarkIntervalSklAddAndLookup(b *testing.B) {
+	const parallel = 1
+	const max = 1000000000
+	const data = 500000
+
+	s := newIntervalSkl(arenaSize)
+	clock := hlc.NewClock(hlc.UnixNano, time.Millisecond)
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	for i := 0; i < data; i++ {
+		from, to := makeRange(rng.Int31n(max))
+		s.AddRange(from, to, excludeFrom|excludeTo, clock.Now())
+	}
+
+	for i := 0; i <= 10; i++ {
+		b.Run(fmt.Sprintf("frac_%d", i), func(b *testing.B) {
+			var wg sync.WaitGroup
+
+			for p := 0; p < parallel; p++ {
+				wg.Add(1)
+
+				go func(i int) {
+					defer wg.Done()
+
+					rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+					for n := 0; n < b.N/parallel; n++ {
+						readFrac := rng.Int31()
+						keyNum := rng.Int31n(max)
+
+						if (readFrac % 10) < int32(i) {
+							key := []byte(fmt.Sprintf("%020d", keyNum))
+							s.LookupTimestamp(key)
+						} else {
+							from, to := makeRange(keyNum)
+							s.AddRange(from, to, excludeFrom|excludeTo, clock.Now())
+						}
+					}
+				}(i)
+			}
+
+			wg.Wait()
+		})
+	}
+}
+
+func makeRange(start int32) (from, to []byte) {
+	var end int32
+
+	rem := start % 100
+	if rem < 80 {
+		end = start + 0
+	} else if rem < 90 {
+		end = start + 100
+	} else if rem < 95 {
+		end = start + 10000
+	} else if rem < 99 {
+		end = start + 1000000
+	} else {
+		end = start + 100000000
+	}
+
+	from = []byte(fmt.Sprintf("%020d", start))
+	to = []byte(fmt.Sprintf("%020d", end))
+	return
+}

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -17,6 +17,7 @@ package tscache
 import (
 	"fmt"
 	"math/rand"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -827,12 +828,12 @@ func TestIntervalSklConcurrency(t *testing.T) {
 			// for testing timestamp collisions.
 			testutils.RunTrueAndFalse(t, "useClock", func(t *testing.T, useClock bool) {
 				const n = 10000
-				const slots = 20
 
 				var wg sync.WaitGroup
 				clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 				s := newIntervalSkl(tc.size)
 
+				slots := 5 * runtime.NumCPU()
 				for i := 0; i < slots; i++ {
 					wg.Add(1)
 

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -247,7 +247,7 @@ func TestIntervalSklBoundaryRange(t *testing.T) {
 
 	s := newIntervalSkl(arenaSize)
 
-	// Don't allow nil from key.
+	// Don't allow nil from and to keys.
 	require.Panics(t, func() { s.AddRange([]byte(nil), []byte(nil), excludeFrom, val1) })
 
 	// If from key is greater than to key, then range is zero-length.

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -355,6 +355,174 @@ func TestIntervalSklRatchetTxnIDs(t *testing.T) {
 	require.Equal(t, val6, s.LookupTimestamp([]byte("raspberry")))
 }
 
+func TestIntervalSklLookupRange(t *testing.T) {
+	ts1 := makeTS(100, 100)
+	ts2 := makeTS(200, 201)
+	ts3 := makeTS(300, 201)
+	ts4 := makeTS(400, 0)
+
+	val1 := makeVal(ts1, "1")
+	val2 := makeVal(ts2, "2")
+	val3 := makeVal(ts2, "3")
+	val3WithoutID := makeValWithoutID(ts2)
+	val4 := makeVal(ts3, "4")
+	val5 := makeVal(ts3, "5")
+	val5WithoutID := makeValWithoutID(ts3)
+	val6 := makeVal(ts4, "6")
+
+	s := newIntervalSkl(arenaSize)
+
+	// Perform range lookups over a single key.
+	s.Add([]byte("apricot"), val1)
+	require.Equal(t, val1, s.LookupTimestampRange([]byte(""), []byte(nil), 0))
+	require.Equal(t, val1, s.LookupTimestampRange([]byte(""), []byte(nil), excludeFrom))
+	require.Equal(t, val1, s.LookupTimestampRange([]byte(""), []byte(nil), excludeTo))
+	require.Equal(t, val1, s.LookupTimestampRange([]byte(""), []byte(nil), (excludeFrom|excludeTo)))
+
+	require.Equal(t, emptyVal, s.LookupTimestampRange([]byte("apple"), []byte("apple"), 0))
+	require.Equal(t, val1, s.LookupTimestampRange([]byte("apple"), []byte("apricot"), 0))
+	require.Equal(t, val1, s.LookupTimestampRange([]byte("apple"), []byte("apricot"), excludeFrom))
+	require.Equal(t, emptyVal, s.LookupTimestampRange([]byte("apple"), []byte("apricot"), excludeTo))
+
+	require.Equal(t, val1, s.LookupTimestampRange([]byte("apricot"), []byte("apricot"), 0))
+	require.Equal(t, val1, s.LookupTimestampRange([]byte("apricot"), []byte("apricot"), excludeFrom))
+	require.Equal(t, val1, s.LookupTimestampRange([]byte("apricot"), []byte("apricot"), excludeTo))
+	require.Equal(t, emptyVal, s.LookupTimestampRange([]byte("apricot"), []byte("apricot"), (excludeFrom|excludeTo)))
+
+	// Perform range lookups over a series of keys.
+	s.Add([]byte("banana"), val2)
+	s.Add([]byte("cherry"), val3)
+	require.Equal(t, val2, s.LookupTimestampRange([]byte("apricot"), []byte("banana"), 0))
+	require.Equal(t, val2, s.LookupTimestampRange([]byte("apricot"), []byte("banana"), excludeFrom))
+	require.Equal(t, val1, s.LookupTimestampRange([]byte("apricot"), []byte("banana"), excludeTo))
+	require.Equal(t, emptyVal, s.LookupTimestampRange([]byte("apricot"), []byte("banana"), (excludeFrom|excludeTo)))
+
+	require.Equal(t, val3WithoutID, s.LookupTimestampRange([]byte("apricot"), []byte("cherry"), 0))
+	require.Equal(t, val3WithoutID, s.LookupTimestampRange([]byte("apricot"), []byte("cherry"), excludeFrom))
+	require.Equal(t, val2, s.LookupTimestampRange([]byte("apricot"), []byte("cherry"), excludeTo))
+	require.Equal(t, val2, s.LookupTimestampRange([]byte("apricot"), []byte("cherry"), (excludeFrom|excludeTo)))
+
+	require.Equal(t, val3WithoutID, s.LookupTimestampRange([]byte("banana"), []byte("cherry"), 0))
+	require.Equal(t, val3, s.LookupTimestampRange([]byte("banana"), []byte("cherry"), excludeFrom))
+	require.Equal(t, val2, s.LookupTimestampRange([]byte("banana"), []byte("cherry"), excludeTo))
+	require.Equal(t, emptyVal, s.LookupTimestampRange([]byte("banana"), []byte("cherry"), (excludeFrom|excludeTo)))
+
+	// Open ranges should scan until the last key.
+	require.Equal(t, val3WithoutID, s.LookupTimestampRange([]byte("apricot"), []byte(nil), 0))
+	require.Equal(t, val3WithoutID, s.LookupTimestampRange([]byte("banana"), []byte(nil), 0))
+	require.Equal(t, val3, s.LookupTimestampRange([]byte("cherry"), []byte(nil), 0))
+	require.Equal(t, emptyVal, s.LookupTimestampRange([]byte("tomato"), []byte(nil), 0))
+
+	// Range with multiple identical timestamps should return no txnID.
+	s.AddRange([]byte("apple"), []byte("kiwi"), excludeTo, val4)
+	s.AddRange([]byte("kiwi"), []byte("tomato"), excludeTo, val5)
+	require.Equal(t, val4, s.LookupTimestampRange([]byte("apple"), []byte("kiwi"), excludeTo))
+	require.Equal(t, val5, s.LookupTimestampRange([]byte("kiwi"), []byte("tomato"), excludeTo))
+	require.Equal(t, val5WithoutID, s.LookupTimestampRange([]byte("apple"), []byte("tomato"), excludeTo))
+
+	// Subset lookup range.
+	s.AddRange([]byte("apple"), []byte("cherry"), excludeTo, val6)
+	require.Equal(t, val6, s.LookupTimestampRange([]byte("apple"), []byte("berry"), 0))
+	require.Equal(t, val6, s.LookupTimestampRange([]byte("apple"), []byte("berry"), excludeFrom))
+	require.Equal(t, val6, s.LookupTimestampRange([]byte("berry"), []byte("blueberry"), 0))
+	require.Equal(t, val6, s.LookupTimestampRange([]byte("berry"), []byte("cherry"), 0))
+	require.Equal(t, val6, s.LookupTimestampRange([]byte("berry"), []byte("cherry"), excludeTo))
+}
+
+func TestIntervalSklLookupRangeSingleKeyRanges(t *testing.T) {
+	ts1 := makeTS(100, 100)
+	ts2 := makeTS(200, 201)
+
+	val1 := makeVal(ts1, "1")
+	val2 := makeVal(ts2, "2")
+	val3 := makeVal(ts2, "3")
+	val3WithoutID := makeValWithoutID(ts2)
+
+	key1 := []byte("a")
+	key2 := append(key1, 0x0)
+	key3 := append(key2, 0x0)
+	key4 := append(key3, 0x0)
+
+	// Perform range lookups over [key, key.Next()) ranges.
+	t.Run("[key, key.Next())", func(t *testing.T) {
+		s := newIntervalSkl(arenaSize)
+
+		s.AddRange(key1, key2, excludeTo, val1)
+		s.AddRange(key2, key3, excludeTo, val2)
+		s.AddRange(key3, key4, excludeTo, val3)
+
+		require.Equal(t, val1, s.LookupTimestampRange([]byte(""), key1, 0))
+		require.Equal(t, emptyVal, s.LookupTimestampRange([]byte(""), key1, excludeTo))
+		require.Equal(t, val2, s.LookupTimestampRange([]byte(""), key2, 0))
+		require.Equal(t, val1, s.LookupTimestampRange([]byte(""), key2, excludeTo))
+
+		require.Equal(t, val2, s.LookupTimestampRange(key1, key2, 0))
+		require.Equal(t, val2, s.LookupTimestampRange(key1, key2, excludeFrom))
+		require.Equal(t, val1, s.LookupTimestampRange(key1, key2, excludeTo))
+		// This may be surprising. We actually return the gapVal of the first range
+		// even though there isn't a discrete byte value between key1 and key2 (this
+		// is a feature, not a bug!). It demonstrates the difference between the
+		// first two options (which behave exactly the same) and the third:
+		// a) Add(key, val)
+		// b) AddRange(key, key, 0, val)
+		// c) AddRange(key, key.Next(), excludeTo, val)
+		//
+		// NB: If the behavior is not needed, it's better to use one of the
+		// first two options because they allow us to avoid storing a gap value.
+		require.Equal(t, val1, s.LookupTimestampRange(key1, key2, (excludeFrom|excludeTo)))
+
+		require.Equal(t, val3WithoutID, s.LookupTimestampRange(key1, key3, 0))
+		require.Equal(t, val3WithoutID, s.LookupTimestampRange(key1, key3, excludeFrom))
+		require.Equal(t, val2, s.LookupTimestampRange(key1, key3, excludeTo))
+		require.Equal(t, val2, s.LookupTimestampRange(key1, key3, (excludeFrom|excludeTo)))
+
+		require.Equal(t, val3WithoutID, s.LookupTimestampRange(key2, key3, 0))
+		// Again, this may be surprising. The logic is the same as above.
+		require.Equal(t, val3WithoutID, s.LookupTimestampRange(key2, key3, excludeFrom))
+		require.Equal(t, val2, s.LookupTimestampRange(key2, key3, excludeTo))
+		require.Equal(t, val2, s.LookupTimestampRange(key2, key3, (excludeFrom|excludeTo)))
+
+		require.Equal(t, val3, s.LookupTimestampRange(key3, []byte(nil), 0))
+		require.Equal(t, val3, s.LookupTimestampRange(key3, []byte(nil), excludeFrom))
+	})
+
+	// Perform the same lookups, but this time use single key ranges.
+	t.Run("[key, key]", func(t *testing.T) {
+		s := newIntervalSkl(arenaSize)
+
+		s.AddRange(key1, key1, 0, val1) // same as Add(key1, val1)
+		s.AddRange(key2, key2, 0, val2) //   ...   Add(key2, val2)
+		s.AddRange(key3, key3, 0, val3) //   ...   Add(key3, val3)
+
+		require.Equal(t, val1, s.LookupTimestampRange([]byte(""), key1, 0))
+		require.Equal(t, emptyVal, s.LookupTimestampRange([]byte(""), key1, excludeTo))
+		require.Equal(t, val2, s.LookupTimestampRange([]byte(""), key2, 0))
+		require.Equal(t, val1, s.LookupTimestampRange([]byte(""), key2, excludeTo))
+
+		require.Equal(t, val2, s.LookupTimestampRange(key1, key2, 0))
+		require.Equal(t, val2, s.LookupTimestampRange(key1, key2, excludeFrom))
+		require.Equal(t, val1, s.LookupTimestampRange(key1, key2, excludeTo))
+		// DIFFERENT!
+		require.Equal(t, emptyVal, s.LookupTimestampRange(key1, key2, (excludeFrom|excludeTo)))
+
+		require.Equal(t, val3WithoutID, s.LookupTimestampRange(key1, key3, 0))
+		require.Equal(t, val3WithoutID, s.LookupTimestampRange(key1, key3, excludeFrom))
+		require.Equal(t, val2, s.LookupTimestampRange(key1, key3, excludeTo))
+		require.Equal(t, val2, s.LookupTimestampRange(key1, key3, (excludeFrom|excludeTo)))
+
+		require.Equal(t, val3WithoutID, s.LookupTimestampRange(key2, key3, 0))
+		// DIFFERENT!
+		require.Equal(t, val3, s.LookupTimestampRange(key2, key3, excludeFrom))
+		require.Equal(t, val2, s.LookupTimestampRange(key2, key3, excludeTo))
+		// DIFFERENT!
+		require.Equal(t, emptyVal, s.LookupTimestampRange(key2, key3, (excludeFrom|excludeTo)))
+
+		require.Equal(t, val3, s.LookupTimestampRange(key3, []byte(nil), 0))
+		// DIFFERENT!
+		require.Equal(t, emptyVal, s.LookupTimestampRange(key3, []byte(nil), excludeFrom))
+	})
+}
+
 func TestIntervalSklFill(t *testing.T) {
 	const n = 200
 	const txnID = "123"
@@ -431,11 +599,8 @@ func TestIntervalSklConcurrency(t *testing.T) {
 					for j := 0; j < n; j++ {
 						fromNum := rng.Intn(slots)
 						toNum := rng.Intn(slots)
-
 						if fromNum > toNum {
 							fromNum, toNum = toNum, fromNum
-						} else if fromNum == toNum {
-							toNum++
 						}
 
 						from := []byte(fmt.Sprintf("%05d", fromNum))
@@ -449,6 +614,9 @@ func TestIntervalSklConcurrency(t *testing.T) {
 						require.False(t, val.ts.Less(now))
 
 						val = s.LookupTimestamp(to)
+						require.False(t, val.ts.Less(now))
+
+						val = s.LookupTimestampRange(from, to, 0)
 						require.False(t, val.ts.Less(now))
 
 						val = s.LookupTimestamp(key)

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -34,8 +34,8 @@ const arenaSize = 64 * 1024 * 1024 // 64 MB
 
 var (
 	emptyVal = cacheValue{}
-	floorTs  = makeTS(100, 0)
-	floorVal = makeValWithoutID(floorTs)
+	floorTS  = makeTS(100, 0)
+	floorVal = makeValWithoutID(floorTS)
 )
 
 func makeTS(walltime int64, logical int32) hlc.Timestamp {
@@ -62,17 +62,23 @@ func makeVal(ts hlc.Timestamp, txnIDStr string) cacheValue {
 }
 
 func TestIntervalSklAdd(t *testing.T) {
-	val1 := makeVal(makeTS(100, 100), "1")
-	val2 := makeVal(makeTS(200, 201), "2")
+	ts1 := makeTS(200, 0)
+	ts2 := makeTS(200, 201)
+	ts3Ceil := makeTS(201, 0)
+
+	val1 := makeVal(ts1, "1")
+	val2 := makeVal(ts2, "2")
 
 	s := newIntervalSkl(arenaSize)
 
 	s.Add([]byte("apricot"), val1)
+	require.Equal(t, ts1.WallTime, s.later.maxWallTime)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val1, s.LookupTimestamp([]byte("apricot")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("banana")))
 
 	s.Add([]byte("banana"), val2)
+	require.Equal(t, ts3Ceil.WallTime, s.later.maxWallTime)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val1, s.LookupTimestamp([]byte("apricot")))
 	require.Equal(t, val2, s.LookupTimestamp([]byte("banana")))
@@ -80,11 +86,14 @@ func TestIntervalSklAdd(t *testing.T) {
 }
 
 func TestIntervalSklSingleRange(t *testing.T) {
-	val1 := makeVal(makeTS(100, 100), "1")
+	val1 := makeVal(makeTS(100, 10), "1")
 	val2 := makeVal(makeTS(200, 50), "2")
+	val3 := makeVal(makeTS(300, 50), "3")
+	val4 := makeVal(makeTS(400, 50), "4")
 
 	s := newIntervalSkl(arenaSize)
 
+	// val1:  [a--------------o]
 	s.AddRange([]byte("apricot"), []byte("orange"), 0, val1)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val1, s.LookupTimestamp([]byte("apricot")))
@@ -93,6 +102,7 @@ func TestIntervalSklSingleRange(t *testing.T) {
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("raspberry")))
 
 	// Try again and make sure it's a no-op.
+	// val1:  [a--------------o]
 	s.AddRange([]byte("apricot"), []byte("orange"), 0, val1)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val1, s.LookupTimestamp([]byte("apricot")))
@@ -101,6 +111,8 @@ func TestIntervalSklSingleRange(t *testing.T) {
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("raspberry")))
 
 	// Ratchet up the timestamps.
+	// val1:  [a--------------o]
+	// val2:  [a--------------o]
 	s.AddRange([]byte("apricot"), []byte("orange"), 0, val2)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val2, s.LookupTimestamp([]byte("apricot")))
@@ -108,7 +120,9 @@ func TestIntervalSklSingleRange(t *testing.T) {
 	require.Equal(t, val2, s.LookupTimestamp([]byte("orange")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("raspberry")))
 
-	// Add disjoint range.
+	// Add disjoint open range.
+	// val1:  [a--------------o]  (p--------------t)
+	// val2:  [a--------------o]
 	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, val1)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("peach")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("pear")))
@@ -117,6 +131,8 @@ func TestIntervalSklSingleRange(t *testing.T) {
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("watermelon")))
 
 	// Try again and make sure it's a no-op.
+	// val1:  [a--------------o]  (p--------------t)
+	// val2:  [a--------------o]
 	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, val1)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("peach")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("pear")))
@@ -125,43 +141,99 @@ func TestIntervalSklSingleRange(t *testing.T) {
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("watermelon")))
 
 	// Ratchet up the timestamps.
+	// val1:  [a--------------o]  (p--------------t)
+	// val2:  [a--------------o]  (p--------------t)
 	s.AddRange([]byte("pear"), []byte("tomato"), excludeFrom|excludeTo, val2)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("peach")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("pear")))
 	require.Equal(t, val2, s.LookupTimestamp([]byte("raspberry")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("tomato")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("watermelon")))
+
+	// Add disjoint left-open range.
+	// val1:  [a--------------o]  (p--------------t)
+	// val2:  [a--------------o]  (p--------------t)
+	// val3:                                     (t--------------w]
+	s.AddRange([]byte("tomato"), []byte("watermelon"), excludeFrom, val3)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("peach")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("watermelon")))
+
+	// Add disjoint right-open range.
+	// val1:  [a--------------o]      (p--------------t)
+	// val2:  [a--------------o]      (p--------------t)
+	// val3:                                         (t--------------w]
+	// val4:                      [p--p)
+	s.AddRange([]byte("peach"), []byte("pear"), excludeTo, val4)
+	require.Equal(t, val4, s.LookupTimestamp([]byte("peach")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("tomato")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("watermelon")))
 }
 
 func TestIntervalSklOpenRanges(t *testing.T) {
 	val1 := makeVal(makeTS(200, 200), "1")
 	val2 := makeVal(makeTS(200, 201), "2")
+	val3 := makeVal(makeTS(300, 0), "3")
+	val4 := makeVal(makeTS(400, 0), "4")
 
 	s := newIntervalSkl(arenaSize)
-	s.floorTs = floorTs
+	s.floorTS = floorTS
 
-	s.AddRange([]byte("banana"), nil, excludeFrom, val1)
+	// Range extending to infinity. excludeTo doesn't make a difference.
+	// val1:  [b----------->
+	s.AddRange([]byte("banana"), nil, 0, val1)
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
-	require.Equal(t, floorVal, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("banana")))
 	require.Equal(t, val1, s.LookupTimestamp([]byte("orange")))
 
-	s.AddRange([]byte(""), []byte("kiwi"), 0, val2)
-	require.Equal(t, val2, s.LookupTimestamp(nil))
-	require.Equal(t, val2, s.LookupTimestamp([]byte("")))
+	// val1:  [b----------->
+	// val2:  [b----------->
+	s.AddRange([]byte("banana"), nil, excludeTo, val2)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val2, s.LookupTimestamp([]byte("banana")))
-	require.Equal(t, val2, s.LookupTimestamp([]byte("kiwi")))
-	require.Equal(t, val1, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("orange")))
+
+	// Range starting at the minimum key. excludeFrom doesn't make a difference.
+	// val1:       [b----------->
+	// val2:       [b----------->
+	// val3:  <----------k]
+	s.AddRange([]byte(""), []byte("kiwi"), 0, val3)
+	require.Equal(t, val3, s.LookupTimestamp(nil))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("orange")))
+
+	// val1:       [b----------->
+	// val2:       [b----------->
+	// val3:  <----------k]
+	// val4:  <----------k]
+	s.AddRange([]byte(""), []byte("kiwi"), excludeFrom, val4)
+	require.Equal(t, val4, s.LookupTimestamp(nil))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("orange")))
 }
 
 func TestIntervalSklSupersetRange(t *testing.T) {
 	val1 := makeVal(makeTS(200, 1), "1")
 	val2 := makeVal(makeTS(201, 0), "2")
 	val3 := makeVal(makeTS(300, 0), "3")
+	val4 := makeVal(makeTS(400, 0), "4")
+	val5 := makeVal(makeTS(500, 0), "5")
+	val6 := makeVal(makeTS(600, 0), "6")
 
 	s := newIntervalSkl(arenaSize)
-	s.floorTs = floorTs
+	s.floorTS = floorTS
 
 	// Same range.
+	// val1:  [k---------o]
+	// val2:  [k---------o]
 	s.AddRange([]byte("kiwi"), []byte("orange"), 0, val1)
 	s.AddRange([]byte("kiwi"), []byte("orange"), 0, val2)
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
@@ -171,6 +243,8 @@ func TestIntervalSklSupersetRange(t *testing.T) {
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("raspberry")))
 
 	// Superset range, but with lower timestamp.
+	// val1:  [g--------------p]
+	// val2:    [k---------o]
 	s.AddRange([]byte("grape"), []byte("pear"), 0, val1)
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val1, s.LookupTimestamp([]byte("grape")))
@@ -180,6 +254,9 @@ func TestIntervalSklSupersetRange(t *testing.T) {
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("watermelon")))
 
 	// Superset range, but with higher timestamp.
+	// val1:    [g--------------p]
+	// val2:      [k---------o]
+	// val3: [b-------------------r]
 	s.AddRange([]byte("banana"), []byte("raspberry"), 0, val3)
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val3, s.LookupTimestamp([]byte("banana")))
@@ -188,6 +265,54 @@ func TestIntervalSklSupersetRange(t *testing.T) {
 	require.Equal(t, val3, s.LookupTimestamp([]byte("orange")))
 	require.Equal(t, val3, s.LookupTimestamp([]byte("pear")))
 	require.Equal(t, val3, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("watermelon")))
+
+	// Equal range but left-open.
+	// val1:    [g--------------p]
+	// val2:      [k---------o]
+	// val3: [b-------------------r]
+	// val4: (b-------------------r]
+	s.AddRange([]byte("banana"), []byte("raspberry"), excludeFrom, val4)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val3, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("watermelon")))
+
+	// Equal range but right-open.
+	// val1:    [g--------------p]
+	// val2:      [k---------o]
+	// val3: [b-------------------r]
+	// val4: (b-------------------r]
+	// val5: [b-------------------r)
+	s.AddRange([]byte("banana"), []byte("raspberry"), excludeTo, val5)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val5, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val5, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, val5, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val5, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val5, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("raspberry")))
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("watermelon")))
+
+	// Equal range but fully-open.
+	// val1:    [g--------------p]
+	// val2:      [k---------o]
+	// val3: [b-------------------r]
+	// val4: (b-------------------r]
+	// val5: [b-------------------r)
+	// val6: (b-------------------r)
+	s.AddRange([]byte("banana"), []byte("raspberry"), (excludeFrom | excludeTo), val6)
+	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
+	require.Equal(t, val5, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val6, s.LookupTimestamp([]byte("grape")))
+	require.Equal(t, val6, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val6, s.LookupTimestamp([]byte("orange")))
+	require.Equal(t, val6, s.LookupTimestamp([]byte("pear")))
+	require.Equal(t, val4, s.LookupTimestamp([]byte("raspberry")))
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("watermelon")))
 }
 
@@ -199,8 +324,10 @@ func TestIntervalSklContiguousRanges(t *testing.T) {
 	val2WithoutID := makeValWithoutID(ts1)
 
 	s := newIntervalSkl(arenaSize)
-	s.floorTs = floorTs
+	s.floorTS = floorTS
 
+	// val1:  [b---------k)
+	// val2:            [k---------o)
 	s.AddRange([]byte("banana"), []byte("kiwi"), excludeTo, val1)
 	s.AddRange([]byte("kiwi"), []byte("orange"), excludeTo, val2)
 
@@ -208,6 +335,7 @@ func TestIntervalSklContiguousRanges(t *testing.T) {
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val1, s.LookupTimestamp([]byte("banana")))
 	require.Equal(t, val2, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val2, s.LookupTimestamp([]byte("mango")))
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("orange")))
 
 	// Test range lookups over the contiguous range.
@@ -230,8 +358,10 @@ func TestIntervalSklOverlappingRanges(t *testing.T) {
 	val4 := makeVal(makeTS(400, 0), "4")
 
 	s := newIntervalSkl(arenaSize)
-	s.floorTs = floorTs
+	s.floorTS = floorTS
 
+	// val1:  [b---------k]
+	// val2:        [g------------r)
 	s.AddRange([]byte("banana"), []byte("kiwi"), 0, val1)
 	s.AddRange([]byte("grape"), []byte("raspberry"), excludeTo, val2)
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
@@ -240,6 +370,9 @@ func TestIntervalSklOverlappingRanges(t *testing.T) {
 	require.Equal(t, val2, s.LookupTimestamp([]byte("kiwi")))
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("raspberry")))
 
+	// val1:    [b---------k]
+	// val2:         [g------------r)
+	// val3:  [a---------------o]
 	s.AddRange([]byte("apricot"), []byte("orange"), 0, val3)
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val3, s.LookupTimestamp([]byte("apricot")))
@@ -250,6 +383,10 @@ func TestIntervalSklOverlappingRanges(t *testing.T) {
 	require.Equal(t, val2, s.LookupTimestamp([]byte("pear")))
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("raspberry")))
 
+	// val1:    [b---------k]
+	// val2:          [g------------r)
+	// val3:  [a---------------o]
+	// val4:              (k------------->
 	s.AddRange([]byte("kiwi"), []byte(nil), excludeFrom, val4)
 	require.Equal(t, floorVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, val3, s.LookupTimestamp([]byte("apricot")))
@@ -267,33 +404,48 @@ func TestIntervalSklBoundaryRange(t *testing.T) {
 	s := newIntervalSkl(arenaSize)
 
 	// Don't allow nil from and to keys.
+	require.Panics(t, func() { s.AddRange([]byte(nil), []byte(nil), 0, val1) })
 	require.Panics(t, func() { s.AddRange([]byte(nil), []byte(nil), excludeFrom, val1) })
+	require.Panics(t, func() { s.AddRange([]byte(nil), []byte(nil), excludeTo, val1) })
+	require.Panics(t, func() { s.AddRange([]byte(nil), []byte(nil), excludeFrom|excludeTo, val1) })
 
 	// Don't allow inverted ranges.
 	require.Panics(t, func() { s.AddRange([]byte("kiwi"), []byte("apple"), 0, val1) })
+	require.Equal(t, int64(0), s.later.maxWallTime)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("banana")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("kiwi")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("raspberry")))
 
-	// If from key is same as to key, and both are excluded, then range is
+	// If from key is same as to key and both are excluded, then range is
 	// zero-length.
 	s.AddRange([]byte("banana"), []byte("banana"), excludeFrom|excludeTo, val1)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("banana")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("kiwi")))
 
-	// If from key is same as to key, then range has length one.
+	// If from key is same as to key and at least one endpoint is included, then
+	// range has length one.
 	s.AddRange([]byte("mango"), []byte("mango"), 0, val1)
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("kiwi")))
 	require.Equal(t, val1, s.LookupTimestamp([]byte("mango")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("cherry")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("orange")))
 
-	// If from key is same as to key, then range has length one.
-	s.AddRange([]byte("banana"), []byte("banana"), excludeTo, val1)
-	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("apple")))
+	s.AddRange([]byte("banana"), []byte("banana"), excludeFrom, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("mango")))
 	require.Equal(t, val1, s.LookupTimestamp([]byte("banana")))
 	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("cherry")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("orange")))
+
+	s.AddRange([]byte("cherry"), []byte("cherry"), excludeTo, val1)
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("kiwi")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("mango")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("banana")))
+	require.Equal(t, val1, s.LookupTimestamp([]byte("cherry")))
+	require.Equal(t, emptyVal, s.LookupTimestamp([]byte("orange")))
 }
 
 func TestIntervalSklRatchetTxnIDs(t *testing.T) {
@@ -391,6 +543,7 @@ func TestIntervalSklLookupRange(t *testing.T) {
 
 	// Perform range lookups over a single key.
 	s.Add([]byte("apricot"), val1)
+	// from = "" and to = nil means that we're scanning over all keys.
 	require.Equal(t, val1, s.LookupTimestampRange([]byte(""), []byte(nil), 0))
 	require.Equal(t, val1, s.LookupTimestampRange([]byte(""), []byte(nil), excludeFrom))
 	require.Equal(t, val1, s.LookupTimestampRange([]byte(""), []byte(nil), excludeTo))
@@ -487,6 +640,9 @@ func TestIntervalSklLookupRangeSingleKeyRanges(t *testing.T) {
 		// first two options because they allow us to avoid storing a gap value.
 		require.Equal(t, val1, s.LookupTimestampRange(key1, key2, (excludeFrom|excludeTo)))
 
+		// val1 and val2 both have the same timestamp but have different IDs, so
+		// the cacheValue ratcheting policy enforces that the result of scanning
+		// over both should be a value with their timestamp but with no txnID.
 		require.Equal(t, val3WithoutID, s.LookupTimestampRange(key1, key3, 0))
 		require.Equal(t, val3WithoutID, s.LookupTimestampRange(key1, key3, excludeFrom))
 		require.Equal(t, val2, s.LookupTimestampRange(key1, key3, excludeTo))
@@ -552,7 +708,7 @@ func TestIntervalSklLookupEqualsEarlierMaxWallTime(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "tsWithLogicalPart", func(t *testing.T, logicalPart bool) {
 		s := newIntervalSkl(arenaSize)
-		s.floorTs = floorTs
+		s.floorTS = floorTS
 
 		// Insert an initial value into intervalSkl.
 		initTS := ts1
@@ -575,7 +731,7 @@ func TestIntervalSklLookupEqualsEarlierMaxWallTime(t *testing.T) {
 		// Write to overlapping and non-overlapping parts of the new page with
 		// the values that have the same timestamp as the maxWallTime of the
 		// earlier page. One value has the same txnID as the previous write in
-		// the earlier page and one has a different txnID..
+		// the earlier page and one has a different txnID.
 		valSameID := makeVal(expMaxTS, txnID1)
 		valDiffID := makeVal(expMaxTS, txnID2)
 		valNoID := makeValWithoutID(expMaxTS)
@@ -611,9 +767,6 @@ func TestIntervalSklFill(t *testing.T) {
 	const n = 200
 	const txnID = "123"
 
-	// Use constant seed so that skiplist towers will be of predictable size.
-	rand.Seed(0)
-
 	s := newIntervalSkl(3000)
 
 	for i := 0; i < n; i++ {
@@ -621,16 +774,20 @@ func TestIntervalSklFill(t *testing.T) {
 		s.AddRange(key, key, 0, makeVal(makeTS(int64(100+i), int32(i)), txnID))
 	}
 
-	floorTs := s.floorTs
-	require.True(t, makeTS(100, 0).Less(floorTs))
+	floorTS := s.floorTS
+	require.True(t, makeTS(100, 0).Less(floorTS))
 
+	// Verify that the last key inserted is still in the intervalSkl and has not
+	// been rotated out.
 	lastKey := []byte(fmt.Sprintf("%05d", n-1))
 	expVal := makeVal(makeTS(int64(100+n-1), int32(n-1)), txnID)
 	require.Equal(t, expVal, s.LookupTimestamp(lastKey))
 
+	// Verify that all keys inserted are either still in the intervalSkl or have
+	// been rotated out and used to ratchet the floorTS.
 	for i := 0; i < n; i++ {
 		key := []byte(fmt.Sprintf("%05d", i))
-		require.False(t, s.LookupTimestamp(key).ts.Less(floorTs))
+		require.False(t, s.LookupTimestamp(key).ts.Less(floorTS))
 	}
 }
 
@@ -639,6 +796,7 @@ func TestIntervalSklFill2(t *testing.T) {
 	const n = 10000
 	const txnID = "123"
 
+	// n >> 997 so the intervalSkl will be filled.
 	s := newIntervalSkl(997)
 	key := []byte("some key")
 
@@ -765,7 +923,7 @@ func assertRatchet(t *testing.T, before, after cacheValue) {
 }
 
 func BenchmarkIntervalSklAdd(b *testing.B) {
-	const max = 500000000
+	const max = 500000000 // max size of range
 	const txnID = "123"
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Millisecond)
@@ -789,8 +947,8 @@ func BenchmarkIntervalSklAdd(b *testing.B) {
 
 func BenchmarkIntervalSklAddAndLookup(b *testing.B) {
 	const parallel = 1
-	const max = 1000000000
-	const data = 500000
+	const max = 1000000000 // max size of range
+	const data = 500000    // number of ranges
 	const txnID = "123"
 
 	s := newIntervalSkl(arenaSize)
@@ -836,9 +994,14 @@ func BenchmarkIntervalSklAddAndLookup(b *testing.B) {
 	}
 }
 
+// makeRange creates a key range from the provided input. The range will start
+// at the provided key and will have an end key that is a determinstic function
+// of the provided key. This means that for a given input, the function will
+// always produce the same range.
 func makeRange(start int32) (from, to []byte) {
 	var end int32
 
+	// Most ranges are small. Larger ranges are less and less likely.
 	rem := start % 100
 	if rem < 80 {
 		end = start + 0

--- a/pkg/util/race_off.go
+++ b/pkg/util/race_off.go
@@ -19,3 +19,8 @@ package util
 
 // RaceEnabled is true if CockroachDB was built with the race build tag.
 const RaceEnabled = false
+
+// RacePreempt adds a goroutine preemption point if CockroachDB was built with
+// the race build tag. The function is a no-op (and should be optimized out
+// through dead code elimination) if the race build tag was not used.
+func RacePreempt() {}

--- a/pkg/util/race_on.go
+++ b/pkg/util/race_on.go
@@ -17,5 +17,14 @@
 
 package util
 
+import "runtime"
+
 // RaceEnabled is true if CockroachDB was built with the race build tag.
 const RaceEnabled = true
+
+// RacePreempt adds a goroutine preemption point if CockroachDB was built with
+// the race build tag. The function is a no-op (and should be optimized out
+// through dead code elimination) if the race build tag was not used.
+func RacePreempt() {
+	runtime.Gosched()
+}


### PR DESCRIPTION
This change introduces the primary data structure necessary for #19508.
However, the change does not yet add the `Cache` implementation that will
be backed by this data structure (`sklImpl`). That will be added in a separate
change (probably after a few more adjustments here) so that we can focus on
its integration into Cockroach carefully.

`intervalSkl` efficiently tracks the latest logical time at which any key or
range of keys has been accessed. Keys are binary values of any length, and
times are represented as hybrid logical timestamps (see `hlc` package). The
data structure guarantees that the read timestamp of any given key or range
will never decrease. In other words, if a lookup returns timestamp A and
repeating the same lookup returns timestamp B, then B >= A.

Add and lookup operations do not block or interfere with one another, which
enables predictable operation latencies. Also, the impact of the structure on
the GC is virtually nothing, even when the structure is very large. These
properties are enabled by employing a lock-free skiplist implementation that
uses an arena allocator. Skiplist nodes refer to one another by offset into
the arena rather than by pointer, so the GC has very few objects to track.

The data structure can conceptually be thought of as being parameterized over
a key and a value type, such that the key implements a `Comparable` interface
(see `interval.Comparable`) and the value implements a `Ratchetable` interface:

```
type Ratchetable interface {
    Ratchet(other Ratchetable) (changed bool)
}
```

In other words, if Go supported zero-cost abstractions, this structure might look
like:

```
type intervalSkl<K: Comparable, V: Ratchetable>
```

As described in #19508, this structure began as a fork of
https://github.com/andy-kimball/tscache, which is built on top of an arena-based
skiplist (https://github.com/andy-kimball/arenaskl). It was then adapted for
Cockroach's codebase. Finally, two changes were added on top of it:
- the value type was changed from an `hlc.Timestamp` to a `tscache.cacheValue`,
  which includes a timestamp and a transaction ID. The ratcheting policy was
  adjusted for this new value type to reflect the transactional ownership property
  that the current `cacheImpl` exhibits.
- support for range lookups was added to complement the existing support for
  point lookups. This means the structure now supports scanning for the largest
  `cacheValue` within a given range of keys.