### PR TITLE
sql: rework join filter propagation

### DIFF
--- a/pkg/sql/filter_opt.go
+++ b/pkg/sql/filter_opt.go
@@ -196,18 +196,7 @@ func (p *planner) propagateFilters(
 		return p.addRenderFilter(ctx, n, extraFilter)
 
 	case *joinNode:
-		switch n.joinType {
-		case joinTypeInner, joinTypeLeftOuter, joinTypeRightOuter:
-			return p.addJoinFilter(ctx, n, extraFilter)
-		default:
-			// There's nothing we can do for full outer joins; simply
-			// trigger filter optimization in the sub-nodes.
-			var err error
-			if n.left.plan, err = p.triggerFilterPropagation(ctx, n.left.plan); err == nil {
-				n.right.plan, err = p.triggerFilterPropagation(ctx, n.right.plan)
-			}
-			return n, extraFilter, err
-		}
+		return p.addJoinFilter(ctx, n, extraFilter)
 
 	case *indexJoinNode:
 		panic("filter optimization must occur before index selection")
@@ -526,80 +515,124 @@ func (p *planner) addRenderFilter(
 	return s, extraFilter, nil
 }
 
-// openJoinFilter changes a filter that may refer to merged columns
-// (results of USING/NATURAL) to a filter that uses only the left and right columns.
-// leftBegin is the logical index of the first column after
-// the merged columns.
-// rightBegin is the logical index of the first column in
-// the right data source.
-func openJoinFilter(
-	n *joinNode, leftBegin, rightBegin int, extraFilter parser.TypedExpr,
-) parser.TypedExpr {
-	if leftBegin == 0 || isFilterTrue(extraFilter) {
-		// No merged columns, or definitely no reference to them in the
-		// filter: nothing to do.
-		return extraFilter
+// expandOnCond infers constraints (on equality columns) for one side of the
+// join from constraints for the other side.
+//
+// The ON condition (which for inner joins includes any filters) can constrain
+// equality columns from one side, and we want to push down those constraints
+// to both sides.
+//
+// For example, for
+//   SELECT * FROM a INNER JOIN b ON a.x = b.x AND a.x > 10
+// we infer the condition b.x > 10, resulting in
+//   SELECT * FROM a INNER JOIN b ON a.x = b.x AND a.x > 10 AND b.x > 10
+//
+// A common situation where we can get something like this is when using a
+// merged column, which for inner joins is treated as an alias for the left
+// column:
+//   SELECT * FROM a INNER JOIN b USING(x) WHERE x > 10
+// In this case `x > 10` becomes an additional `a.x > 10` ON condition; this
+// function will add `b.x > 10`.
+//
+// The expanded expression can then be split as necessary.
+func expandOnCond(n *joinNode, cond parser.TypedExpr) parser.TypedExpr {
+	if isFilterTrue(cond) || len(n.pred.leftEqualityIndices) == 0 {
+		return cond
 	}
+	numLeft := len(n.left.info.sourceColumns)
 
-	// There are merged columns, and the incoming extra filter may be
-	// referring to them.
-	// To understand what's going on below consider the query:
+	// We can't use splitFilter directly because that function removes all the
+	// constraints we were able to use from the expression. We could use it
+	// without using the remainder result, but we need to have some other way of
+	// not keeping redundant constraints.
 	//
-	// SELECT * FROM a JOIN b USING(x) WHERE f(a,b) AND g(a) AND g(b) AND h(x)
+	// We split the condition into conjuncts and use splitFilter on each
+	// conjunct to convert it to constraints for each side (as much as
+	// possible); if the constraint is consumed completely by either splitFilter
+	// call, we remove the original conjunct and just keep the splitFilter
+	// results.  Otherwise, we keep all three.
 	//
-	// What we want at the end (below) is this:
-	//    SELECT x, ... FROM
-	//          (SELECT * FROM a WHERE g(a) AND h(a.x))
-	//     JOIN (SELECT * FROM b WHERE g(b) AND h(b.x))
-	//       ON a.x = b.x AND f(a,b)
+	// Some examples (assuming left.x = right.x, left.y = right.y):
 	//
-	// So we need to replace h(x) which refers to the merged USING
-	// column by h(x) on the source tables. But we can't simply
-	// replace it by a single reference to *either* of the two source
-	// tables (say, via h(a.x) in the example), because if we did then
-	// the filter propagation would push it towards that source table
-	// only (a in the example) -- and we want it propagated on both
-	// sides!
+	//      conjunct:           left.x > 10
+	//      splitFilter left:   left.x > 10
+	//      splitFilter right:  right.x > 10
+	//      result:             left.x > 10 AND right.x > 10
 	//
-	// So what we do instead:
-	// - we first split the expression to extract those expressions that
-	//   refer to merged columns (notUsingMerged // perhapsUsingMerged):
-	//   "f(a,b) AND g(a) AND g(b)" // "h(x)"
-	// - we replace the part that refers to merged column by an AND
-	//   of its substitution by references to the left and righ sources:
-	//     "h(x)" -> "h(a.x) AND h(b.x)"
-	// - we recombine all of them:
-	//     f(a,b) AND g(a) AND g(b) AND h(a.x) AND h(b.x)
-	// Then the rest of the optimization below can go forward, and
-	// will take care of splitting the expressions among the left and
-	// right operands.
-	noMergedVars := func(expr parser.VariableExpr) (bool, parser.Expr) {
-		if iv, ok := expr.(*parser.IndexedVar); ok && iv.Idx >= leftBegin {
-			return true, expr
+	//      conjunct:           left.x > right.v
+	//      splitFilter left:   <empty>
+	//      splitFilter right:  right.x > right.v
+	//      result:             right.x > right.v
+	//
+	//      conjunct:           left.x = 10 OR right.x = 20
+	//      splitFilter left:   left.x = 10 OR left.x = 20
+	//      splitFilter right:  right.x = 10 OR right.x = 20
+	//      result:             (left.x = 10 OR left.x = 20) AND (right.x = 10 OR right.x = 20)
+	//
+	//      conjunct:           left.v > right.w
+	//      splitFilter left:   <empty>
+	//      splitFilter right:  <empty>
+	//      result:             left.v > right.w
+	//
+	//      conjunct:           left.x > right.y
+	//      splitFilter left:   left.x > right.y
+	//      splitFilter right   right.x > right.y
+	//      result:             left.x > right.y AND right.x > right.y
+	//
+	// The final result is obtained by merging all the results for each
+	// conjunction.
+
+	var result parser.TypedExpr = parser.DBoolTrue
+
+	andExprs := splitAndExpr(&n.planner.evalCtx, cond, nil)
+	for _, e := range andExprs {
+		convLeft := func(expr parser.VariableExpr) (bool, parser.Expr) {
+			iv, ok := expr.(*parser.IndexedVar)
+			if !ok {
+				return false, expr
+			}
+			if iv.Idx < numLeft {
+				// Variable from the left side.
+				return true, expr
+			}
+			// Variable from the right side; see if it is an equality column.
+			for i, c := range n.pred.rightEqualityIndices {
+				if c == iv.Idx-numLeft {
+					return true, n.pred.iVarHelper.IndexedVar(n.pred.leftEqualityIndices[i])
+				}
+			}
+			return false, expr
 		}
-		return false, expr
+		leftFilter, leftRemainder := splitFilter(e, convLeft)
+
+		convRight := func(expr parser.VariableExpr) (bool, parser.Expr) {
+			iv, ok := expr.(*parser.IndexedVar)
+			if !ok {
+				return false, expr
+			}
+			if iv.Idx >= numLeft {
+				// Variable from the right side.
+				return true, expr
+			}
+			// Variable from the left side; see if it is an equality column.
+			for i, c := range n.pred.leftEqualityIndices {
+				if c == iv.Idx {
+					return true, n.pred.iVarHelper.IndexedVar(numLeft + n.pred.rightEqualityIndices[i])
+				}
+			}
+			return false, expr
+		}
+		rightFilter, rightRemainder := splitFilter(e, convRight)
+
+		result = mergeConj(result, leftFilter)
+		result = mergeConj(result, rightFilter)
+		// Also retain the original expression, unless one of the splitFilter
+		// calls consumed it completely.
+		if !isFilterTrue(leftRemainder) && !isFilterTrue(rightRemainder) {
+			result = mergeConj(result, e)
+		}
 	}
-	// Note: we use a negative condition here because splitFilter()
-	// doesn't guarantee that its right return value doesn't contain
-	// sub-expressions where the conversion function returns true.
-	notUsingMerged, perhapsUsingMerged := splitFilter(extraFilter, noMergedVars)
-	leftFilter := exprConvertVars(perhapsUsingMerged,
-		func(expr parser.VariableExpr) (bool, parser.Expr) {
-			if iv, ok := expr.(*parser.IndexedVar); ok && iv.Idx < leftBegin {
-				newIv := n.pred.iVarHelper.IndexedVar(leftBegin + n.pred.leftEqualityIndices[iv.Idx])
-				return true, newIv
-			}
-			return true, expr
-		})
-	rightFilter := exprConvertVars(perhapsUsingMerged,
-		func(expr parser.VariableExpr) (bool, parser.Expr) {
-			if iv, ok := expr.(*parser.IndexedVar); ok && iv.Idx < leftBegin {
-				newIv := n.pred.iVarHelper.IndexedVar(rightBegin + n.pred.rightEqualityIndices[iv.Idx])
-				return true, newIv
-			}
-			return true, expr
-		})
-	return mergeConj(notUsingMerged, mergeConj(leftFilter, rightFilter))
+	return result
 }
 
 // splitJoinFilter splits a predicate over both sides of the join into
@@ -608,32 +641,30 @@ func openJoinFilter(
 // In this process we shift the IndexedVars in the left and right
 // filter expressions so that they are numbered starting from 0
 // relative to their respective operand.
-// leftBegin is the logical index of the first column after
-// the merged columns.
 // rightBegin is the logical index of the first column in
 // the right data source.
 func splitJoinFilter(
-	n *joinNode, leftBegin, rightBegin int, initialPred parser.TypedExpr,
+	n *joinNode, rightBegin int, initialPred parser.TypedExpr,
 ) (parser.TypedExpr, parser.TypedExpr, parser.TypedExpr) {
-	leftExpr, remainder := splitJoinFilterLeft(n, leftBegin, rightBegin, initialPred)
-	rightExpr, combinedExpr := splitJoinFilterRight(n, leftBegin, rightBegin, remainder)
+	leftExpr, remainder := splitJoinFilterLeft(n, rightBegin, initialPred)
+	rightExpr, combinedExpr := splitJoinFilterRight(n, rightBegin, remainder)
 	return leftExpr, rightExpr, combinedExpr
 }
 
 func splitJoinFilterLeft(
-	n *joinNode, leftBegin, rightBegin int, initialPred parser.TypedExpr,
+	n *joinNode, rightBegin int, initialPred parser.TypedExpr,
 ) (parser.TypedExpr, parser.TypedExpr) {
 	return splitFilter(initialPred,
 		func(expr parser.VariableExpr) (bool, parser.Expr) {
 			if iv, ok := expr.(*parser.IndexedVar); ok && iv.Idx < rightBegin {
-				return true, n.pred.iVarHelper.IndexedVar(iv.Idx - leftBegin)
+				return true, expr
 			}
 			return false, expr
 		})
 }
 
 func splitJoinFilterRight(
-	n *joinNode, leftBegin, rightBegin int, initialPred parser.TypedExpr,
+	n *joinNode, rightBegin int, initialPred parser.TypedExpr,
 ) (parser.TypedExpr, parser.TypedExpr) {
 	return splitFilter(initialPred,
 		func(expr parser.VariableExpr) (bool, parser.Expr) {
@@ -648,39 +679,42 @@ func splitJoinFilterRight(
 func (p *planner) addJoinFilter(
 	ctx context.Context, n *joinNode, extraFilter parser.TypedExpr,
 ) (planNode, parser.TypedExpr, error) {
+
 	// There are four steps to the transformation below:
-	//
-	// 1. if there are merged columns (i.e. USING/NATURAL), since the
-	//    incoming extra filter may refer to them, transform the
-	//    extra filter to only use the left and right columns.
-	// 2. split the predicate into the left, right and on parts.
-	// 3. propagate the left and right part to the left and right join operands.
-	// 4. compute the new ON predicate from the remaining part(s),
-	//    possibly detecting new equality columns.
+	//  1. For inner joins, incorporate the extra filter into the ON condition.
+	//  2. Extract any join equality constraints from the ON condition.
+	//  3. "Expand" the remaining ON condition with new constraints inferred based
+	//     on the equality columns (see expandOnCond).
+	//  4. Propagate the filter and ON condition depending on the join type.
+	numLeft := len(n.left.info.sourceColumns)
+	extraFilter = n.pred.iVarHelper.Rebind(extraFilter, true, false)
 
-	// Reminder: the layout of the virtual data values for a join is:
-	// [ merged columns ] [ columns from left ] [ columns from right]
-	//
-	// The merged columns result from USING or NATURAL; for example
-	//      SELECT * FROM a JOIN b USING(x)
-	// has columns: x (merged), a.*, b.*
+	onAndExprs := splitAndExpr(&p.evalCtx, n.pred.onCond, nil)
 
-	// leftBegin is the logical index of the first column in the left data source.
-	leftBegin := 0
-	// rightBegin is the logical index of the first column in
-	// the right data source.
-	rightBegin := leftBegin + len(n.left.info.sourceColumns)
+	// Step 1: for inner joins, incorporate the filter into the ON condition.
+	if n.joinType == joinTypeInner {
+		onAndExprs = splitAndExpr(&p.evalCtx, extraFilter, onAndExprs)
+		extraFilter = nil
+	}
 
-	// Step 1: remove references to the merged columns.
-	// TODO(radu): we don't have merged columns at this level anymore; rewrite
-	// this function to "transfer" equalities for equality columns between sides
-	// (if the join type allows it).
-	extraFilter = openJoinFilter(n, leftBegin, rightBegin, extraFilter)
-	extraFilter = n.pred.iVarHelper.Rebind(extraFilter, false, false)
+	// Step 2: harvest any equality columns. We want to do this before the
+	// expandOnCond call below, which uses the equality columns information.
+	onCond := parser.TypedExpr(parser.DBoolTrue)
+	for _, e := range onAndExprs {
+		if e != parser.DBoolTrue && !n.pred.tryAddEqualityFilter(e, n.left.info, n.right.info) {
+			onCond = mergeConj(onCond, e)
+		}
+	}
 
-	// Step 2: split the filters.
-	var propagateLeft, propagateRight, onRemainder, filterRemainder parser.TypedExpr
+	// Step 3: expand the ON condition, in the hope that new inferred
+	// constraints can be pushed down. This is not useful for FULL OUTER
+	// joins, where nothing can be pushed down.
+	if n.joinType != joinTypeFullOuter {
+		onCond = expandOnCond(n, onCond)
+	}
 
+	// Step 4: propagate the filter and ON conditions as allowed by the join type.
+	var propagateLeft, propagateRight, filterRemainder parser.TypedExpr
 	switch n.joinType {
 	case joinTypeInner:
 		// We transform:
@@ -693,28 +727,7 @@ func (p *planner) addJoinFilter(
 		//          JOIN
 		//          (SELECT * from r WHERE (onRight AND filterRight)
 		//          ON (onCombined AND filterCombined)
-
-		// First we merge the existing ON predicate with the extra filter.
-		// (onAll AND filterAll).
-		//
-		// We don't need to reset the helper here, as this will be done
-		// later for the final predicate below.
-		//
-		// Note: we assume here that neither extraFilter nor n.pred.onCond
-		// can refer to the merged columns any more. For extraFilter
-		// that's guaranteed by the code above. For n.pred.onCond, that's
-		// proven by induction on the following two observations:
-		// - initially, onCond cannot refer to merged columns because
-		//   in SQL the USING/NATURAL syntax is mutually exclusive with ON
-		// - at every subsequent round of filter optimization, changes to
-		//   n.pred.onCond have been processed by the code above.
-		initialPred := mergeConj(extraFilter, n.pred.onCond)
-
-		// Now split the combined predicate.
-		propagateLeft, propagateRight, onRemainder = splitJoinFilter(
-			n, leftBegin, rightBegin, initialPred,
-		)
-		// There is no remainder filter: everything has been absorbed.
+		propagateLeft, propagateRight, onCond = splitJoinFilter(n, numLeft, onCond)
 
 	case joinTypeLeftOuter:
 		// We transform:
@@ -731,10 +744,10 @@ func (p *planner) addJoinFilter(
 
 		// Extract filterLeft towards propagation on the left.
 		// filterRemainder = filterRight AND filterCombined.
-		propagateLeft, filterRemainder = splitJoinFilterLeft(n, leftBegin, rightBegin, extraFilter)
+		propagateLeft, filterRemainder = splitJoinFilterLeft(n, numLeft, extraFilter)
 		// Extract onRight towards propagation on the right.
-		// onRemainder = onLeft AND onCombined.
-		propagateRight, onRemainder = splitJoinFilterRight(n, leftBegin, rightBegin, n.pred.onCond)
+		// onCond = onLeft AND onCombined.
+		propagateRight, onCond = splitJoinFilterRight(n, numLeft, onCond)
 
 	case joinTypeRightOuter:
 		// We transform:
@@ -751,18 +764,20 @@ func (p *planner) addJoinFilter(
 
 		// Extract filterRight towards propagation on the right.
 		// filterRemainder = filterLeft AND filterCombined.
-		propagateRight, filterRemainder = splitJoinFilterRight(n, leftBegin, rightBegin, extraFilter)
+		propagateRight, filterRemainder = splitJoinFilterRight(n, numLeft, extraFilter)
 		// Extract onLeft towards propagation on the left.
-		// onRemainder = onRight AND onCombined.
-		propagateLeft, onRemainder = splitJoinFilterLeft(n, leftBegin, rightBegin, n.pred.onCond)
+		// onCond = onRight AND onCombined.
+		propagateLeft, onCond = splitJoinFilterLeft(n, numLeft, onCond)
 
-	default:
+	case joinTypeFullOuter:
+		// Not much we can do for full outer joins.
+		filterRemainder = extraFilter
 	}
 
-	// Step 3: propagate the left and right predicates to the left and
-	// right sides of the join. The predicates must first be "shifted"
-	// i.e. their IndexedVars which are relative to the join columns
-	// must be modified to become relative to the operand's columns.
+	// Propagate the left and right predicates to the left and right sides of the
+	// join. The predicates must first be "shifted" i.e. their IndexedVars which
+	// are relative to the join columns must be modified to become relative to the
+	// operand's columns.
 	propagate := func(ctx context.Context, pred parser.TypedExpr, side *planDataSource) error {
 		newPlan, err := p.propagateOrWrapFilters(ctx, side.plan, side.info, pred)
 		if err != nil {
@@ -777,19 +792,7 @@ func (p *planner) addJoinFilter(
 	if err := propagate(ctx, propagateRight, &n.right); err != nil {
 		return n, extraFilter, err
 	}
-
-	// Step 4: extract possibly new equality columns from the combined ON
-	// predicate, and use the rest as new ON condition.
-	var newCombinedExpr parser.TypedExpr = parser.DBoolTrue
-	for _, e := range splitAndExpr(&p.evalCtx, onRemainder, nil) {
-		if e == parser.DBoolTrue {
-			continue
-		}
-		if !n.pred.tryAddEqualityFilter(e, n.left.info, n.right.info) {
-			newCombinedExpr = mergeConj(newCombinedExpr, e)
-		}
-	}
-	n.pred.onCond = n.pred.iVarHelper.Rebind(newCombinedExpr, true, false)
+	n.pred.onCond = onCond
 
 	return n, filterRemainder, nil
 }

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -130,7 +130,10 @@ func (p *joinPredicate) tryAddEqualityFilter(filter parser.Expr, left, right *da
 		// invalid. We could simply avoid the optimization but this is
 		// really a bug in the built-in semantics so we want to complain
 		// loudly.
-		panic(fmt.Errorf("predicate %s is valid, but '%T = %T' cannot be type checked", c, lhs, rhs))
+		panic(fmt.Errorf(
+			"predicate %s is valid, but '%s = %s' cannot be type checked",
+			c, lhs.ResolvedType(), rhs.ResolvedType(),
+		))
 	}
 	p.cmpFunctions = append(p.cmpFunctions, fn)
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -157,11 +157,12 @@ EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x 
 2  scan    ·               ·                    (y, str)                                 y!=NULL; key(y); +y
 2  ·       table           numtostr@primary     ·                                        ·
 2  ·       spans           ALL                  ·                                        ·
+2  ·       filter          (y % 2) = 0          ·                                        ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzclUFr2zAUx-_7FObBoKUaWLKzLIKCT4MMlo7S2_DBjd4Sg2N5kgwrJd992NpI42RSjHYIvsWxfn7v_3ug9wq1FLgqdqiBfwcKBBgQSIBACgRmkBNolFyj1lJ1RyywFL-AxwTKumlN93dOYC0VAn8FU5oKgcNT8VzhIxYCFRAQaIqy6os0qtwV6iWr252R-mdbKAQCn8vKoOLRTUaj9xHjnC9XT7fRfRTbn0DgoTU8yijkewKyNX9KHyo-v0TbQm-Pq_XncwLaFBsETvfkv0cw6tAcyVhQf-yf_R2-09ZSCVQojr6Ud-TfI-cOQEbvbK1hzq-oNvhFlvUwZ4U_zE1G727vVbnZ2p9vsyaDrIccSUCOMx2u5AfZDOOeLZweFaZXPmA6kQGzK_fMJuI5uXLPyUQ8p1fuOZ2IZ88CfkTdyFrjRTd_3CVAsUErRctWrfGbkuu-jH186Ln-3hWojX3L7MOytq-6Bi-HZyHwPARehMCUumk6whgbB89C4HkIvAiBB8ZOaDak47d04tadOGF67Dse0mnIsNywZ1hu2DMsN-wZlhv2DWsWMqyPIbrdsEe3G_bodsMe3W7Yp3seovtTiG437NHthj263bBHtxv26V6E6KZjluXpHTpmW46lfZf_mH05lvY5pyfbwyk937_7HQAA__8EY8gd
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzclkFr2zAUx-_7FObBoKUaWLKzLIKCT4MMlo7S2_DBjd8Sg2N5kgwrJd992NpI42RShHaJb3asn5_e72_08gqNKHFV7FAB_w4UCDAgkACBFAjMICfQSrFGpYTslxhgWf4CHhOomrbT_c85gbWQCPwVdKVrBA5PxXONj1iUKIFAibqo6qFIK6tdIV-ypttpoX52hUQg8LmqNUoe3WQ0eh8xzvly9XQb3UexuQQCD53mUUYh3xMQnf5T-lDx-SXaFmp7XG1YnxNQutggcLon_70FLb32TzIW1AL7ZwuH93SNkCVKLI_elPfk3yXnFkBG70ytsYqvKDf4RVTNWEWNP_RNRu9u72W12ZrLt70mo14PfSQBfZzZ4Up8EO243bOF06PC9Pq_ATqRb4BdfxRsIlEk1x9FMpEo0uuPIp1IFI7_C4-oWtEovGgKxX0HWG7QSFGik2v8JsV6KGNuHwZuOOBLVNo8ZeZm2ZhH_QYvh2ch8DwEXoTAlNpp6mGM-cGzEHgeAi9C4JGxE5qN6fgtndh1J1aYHvuOx3QaEpYddoRlhx1h2WFHWHbYFdYsJKyPIbrtsEO3HXbotsMO3XbYpXseovtTiG477NBthx267bBDtx126V6E6KY-w_L0DPWZlr606_D3mZe-tMs5PZkeVun5_t3vAAAA__8hZ_Il
 
 # Save the result of the following statement to a label.
 query IT rowsort label-sq-2-str

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1149,11 +1149,10 @@ SELECT *
 1  join    ·         ·
 1  ·       type      inner
 1  ·       equality  (b) = (sq)
-1  ·       pred      (test.pairs.a IS NULL) OR (test.pairs.a < test.square.sq)
 2  scan    ·         ·
 2  ·       table     pairs@primary
 2  ·       spans     ALL
-2  ·       filter    ((a IS NULL) OR (a > 2)) AND (a > 1)
+2  ·       filter    ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
 2  scan    ·         ·
 2  ·       table     square@primary
 2  ·       spans     /2-/6
@@ -1535,3 +1534,245 @@ EXPLAIN (VERBOSE) SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 3  scan    ·               ·                                 (a, s)                                                                              a!=NULL; key(a); +a
 3  ·       table           str2@primary                      ·                                                                                   ·
 3  ·       spans           ALL                               ·                                                                                   ·
+
+
+statement ok
+CREATE TABLE xyu (x INT, y INT, u INT, PRIMARY KEY(x,y,u))
+
+statement ok
+INSERT INTO xyu VALUES (0, 0, 0), (1, 1, 1), (3, 1, 31), (3, 2, 32), (4, 4, 44)
+
+statement ok
+CREATE TABLE xyv (x INT, y INT, v INT, PRIMARY KEY(x,y,v))
+
+statement ok
+INSERT INTO xyv VALUES (1, 1, 1), (2, 2, 2), (3, 1, 31), (3, 3, 33), (5, 5, 55)
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
+----
+0  render  ·               ·                  (x, y, u, v)                                                                              x!=NULL; y!=NULL
+0  ·       render 0        x                  ·                                                                                         ·
+0  ·       render 1        y                  ·                                                                                         ·
+0  ·       render 2        test.xyu.u         ·                                                                                         ·
+0  ·       render 3        test.xyv.v         ·                                                                                         ·
+1  render  ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  x!=NULL; y!=NULL
+1  ·       render 0        test.xyu.x         ·                                                                                         ·
+1  ·       render 1        test.xyu.y         ·                                                                                         ·
+1  ·       render 2        NULL               ·                                                                                         ·
+1  ·       render 3        NULL               ·                                                                                         ·
+1  ·       render 4        test.xyu.u         ·                                                                                         ·
+1  ·       render 5        NULL               ·                                                                                         ·
+1  ·       render 6        NULL               ·                                                                                         ·
+1  ·       render 7        test.xyv.v         ·                                                                                         ·
+2  join    ·               ·                  (x, y, u, x[omitted], y[omitted], v)                                                      x=x; y=y; x!=NULL; y!=NULL
+2  ·       type            inner              ·                                                                                         ·
+2  ·       equality        (x, y) = (x, y)    ·                                                                                         ·
+2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                                                         ·
+3  scan    ·               ·                  (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+3  ·       table           xyu@primary        ·                                                                                         ·
+3  ·       spans           /3-                ·                                                                                         ·
+3  scan    ·               ·                  (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+3  ·       table           xyv@primary        ·                                                                                         ·
+3  ·       spans           /3-                ·                                                                                         ·
+
+query IIII
+SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
+----
+3  1  31  31
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
+----
+0  render  ·               ·                  (x, y, u, v)                                                                              ·
+0  ·       render 0        x                  ·                                                                                         ·
+0  ·       render 1        y                  ·                                                                                         ·
+0  ·       render 2        test.xyu.u         ·                                                                                         ·
+0  ·       render 3        test.xyv.v         ·                                                                                         ·
+1  render  ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
+1  ·       render 0        test.xyu.x         ·                                                                                         ·
+1  ·       render 1        test.xyu.y         ·                                                                                         ·
+1  ·       render 2        NULL               ·                                                                                         ·
+1  ·       render 3        NULL               ·                                                                                         ·
+1  ·       render 4        test.xyu.u         ·                                                                                         ·
+1  ·       render 5        NULL               ·                                                                                         ·
+1  ·       render 6        NULL               ·                                                                                         ·
+1  ·       render 7        test.xyv.v         ·                                                                                         ·
+2  join    ·               ·                  (x, y, u, x[omitted], y[omitted], v)                                                      ·
+2  ·       type            left outer         ·                                                                                         ·
+2  ·       equality        (x, y) = (x, y)    ·                                                                                         ·
+2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                                                         ·
+3  scan    ·               ·                  (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+3  ·       table           xyu@primary        ·                                                                                         ·
+3  ·       spans           /3-                ·                                                                                         ·
+3  scan    ·               ·                  (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+3  ·       table           xyv@primary        ·                                                                                         ·
+3  ·       spans           ALL                ·                                                                                         ·
+
+query IIII rowsort
+SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
+----
+3  1  31  31
+3  2  32  NULL
+4  4  44  NULL
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
+----
+0  render  ·               ·                  (x, y, u, v)                                                                              ·
+0  ·       render 0        x                  ·                                                                                         ·
+0  ·       render 1        y                  ·                                                                                         ·
+0  ·       render 2        test.xyu.u         ·                                                                                         ·
+0  ·       render 3        test.xyv.v         ·                                                                                         ·
+1  render  ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
+1  ·       render 0        test.xyv.x         ·                                                                                         ·
+1  ·       render 1        test.xyv.y         ·                                                                                         ·
+1  ·       render 2        NULL               ·                                                                                         ·
+1  ·       render 3        NULL               ·                                                                                         ·
+1  ·       render 4        test.xyu.u         ·                                                                                         ·
+1  ·       render 5        NULL               ·                                                                                         ·
+1  ·       render 6        NULL               ·                                                                                         ·
+1  ·       render 7        test.xyv.v         ·                                                                                         ·
+2  join    ·               ·                  (x[omitted], y[omitted], u, x, y, v)                                                      ·
+2  ·       type            right outer        ·                                                                                         ·
+2  ·       equality        (x, y) = (x, y)    ·                                                                                         ·
+2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                                                         ·
+3  scan    ·               ·                  (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+3  ·       table           xyu@primary        ·                                                                                         ·
+3  ·       spans           ALL                ·                                                                                         ·
+3  scan    ·               ·                  (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+3  ·       table           xyv@primary        ·                                                                                         ·
+3  ·       spans           /3-                ·                                                                                         ·
+
+query IIII rowsort
+SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
+----
+3  1  31    31
+3  3  NULL  33
+5  5  NULL  55
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
+----
+0  render  ·               ·                               (x, y, u, v)                                                                              x!=NULL
+0  ·       render 0        x                               ·                                                                                         ·
+0  ·       render 1        y                               ·                                                                                         ·
+0  ·       render 2        test.xyu.u                      ·                                                                                         ·
+0  ·       render 3        test.xyv.v                      ·                                                                                         ·
+1  filter  ·               ·                               (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  x!=NULL
+1  ·       filter          x > 2                           ·                                                                                         ·
+2  render  ·               ·                               (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
+2  ·       render 0        IFNULL(test.xyu.x, test.xyv.x)  ·                                                                                         ·
+2  ·       render 1        IFNULL(test.xyu.y, test.xyv.y)  ·                                                                                         ·
+2  ·       render 2        NULL                            ·                                                                                         ·
+2  ·       render 3        NULL                            ·                                                                                         ·
+2  ·       render 4        test.xyu.u                      ·                                                                                         ·
+2  ·       render 5        NULL                            ·                                                                                         ·
+2  ·       render 6        NULL                            ·                                                                                         ·
+2  ·       render 7        test.xyv.v                      ·                                                                                         ·
+3  join    ·               ·                               (x, y, u, x, y, v)                                                                        ·
+3  ·       type            full outer                      ·                                                                                         ·
+3  ·       equality        (x, y) = (x, y)                 ·                                                                                         ·
+3  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"               ·                                                                                         ·
+4  scan    ·               ·                               (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+4  ·       table           xyu@primary                     ·                                                                                         ·
+4  ·       spans           ALL                             ·                                                                                         ·
+4  scan    ·               ·                               (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+4  ·       table           xyv@primary                     ·                                                                                         ·
+4  ·       spans           ALL                             ·                                                                                         ·
+
+query IIII rowsort
+SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
+----
+3  1  31    31
+3  2  32    NULL
+4  4  44    NULL
+3  3  NULL  33
+5  5  NULL  55
+
+# Verify that we transfer constraints between the two sides.
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
+----
+0  join  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+0  ·     type            inner              ·                   ·
+0  ·     equality        (x, y) = (x, y)    ·                   ·
+0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+1  scan  ·               ·                  (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
+1  ·     table           xyu@primary        ·                   ·
+1  ·     spans           /1/#-/1/10         ·                   ·
+1  scan  ·               ·                  (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
+1  ·     table           xyv@primary        ·                   ·
+1  ·     spans           /1/#-/1/10         ·                   ·
+
+query IIIIII
+SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
+----
+1  1  1  1  1  1
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+0  join  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+0  ·     type            inner              ·                   ·
+0  ·     equality        (x, y) = (x, y)    ·                   ·
+0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+1  scan  ·               ·                  (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
+1  ·     table           xyu@primary        ·                   ·
+1  ·     spans           /1/#-/1/10         ·                   ·
+1  scan  ·               ·                  (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
+1  ·     table           xyv@primary        ·                   ·
+1  ·     spans           /1/#-/1/10         ·                   ·
+
+query IIIIII
+SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+1  1  1  1  1  1
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+0  join  ·               ·                                       (x, y, u, x, y, v)  ·
+0  ·     type            left outer                              ·                   ·
+0  ·     equality        (x, y) = (x, y)                         ·                   ·
+0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"                       ·                   ·
+0  ·     pred            (test.xyu.x = 1) AND (test.xyu.y < 10)  ·                   ·
+1  scan  ·               ·                                       (x, y, u)           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+1  ·     table           xyu@primary                             ·                   ·
+1  ·     spans           ALL                                     ·                   ·
+1  scan  ·               ·                                       (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
+1  ·     table           xyv@primary                             ·                   ·
+1  ·     spans           /1/#-/1/10                              ·                   ·
+
+query IIIIII rowsort
+SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+0  0  0   NULL  NULL  NULL
+1  1  1   1     1     1
+3  1  31  NULL  NULL  NULL
+3  2  32  NULL  NULL  NULL
+4  4  44  NULL  NULL  NULL
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+0  join  ·               ·                                       (x, y, u, x, y, v)  ·
+0  ·     type            right outer                             ·                   ·
+0  ·     equality        (x, y) = (x, y)                         ·                   ·
+0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"                       ·                   ·
+0  ·     pred            (test.xyv.x = 1) AND (test.xyv.y < 10)  ·                   ·
+1  scan  ·               ·                                       (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
+1  ·     table           xyu@primary                             ·                   ·
+1  ·     spans           /1/#-/1/10                              ·                   ·
+1  scan  ·               ·                                       (x, y, v)           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+1  ·     table           xyv@primary                             ·                   ·
+1  ·     spans           ALL                                     ·                   ·
+
+query IIIIII rowsort
+SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+1     1     1     1  1  1
+NULL  NULL  NULL  3  1  31
+NULL  NULL  NULL  3  3  33
+NULL  NULL  NULL  5  5  55
+NULL  NULL  NULL  2  2  2

--- a/pkg/sql/logictest/testdata/logic_test/physical_props
+++ b/pkg/sql/logictest/testdata/logic_test/physical_props
@@ -125,9 +125,9 @@ Level  Type  Field           Description   Columns                Ordering
 1      scan  ·               ·             (a, b, c, d)           a=CONST; key()
 1      ·     table           abcd@primary  ·                      ·
 1      ·     spans           /1-/2         ·                      ·
-1      scan  ·               ·             (e, f, g)              f=g; e!=NULL; f!=NULL; g!=NULL; key(e); +e
+1      scan  ·               ·             (e, f, g)              f=g; e=CONST; f!=NULL; g!=NULL; key()
 1      ·     table           efg@primary   ·                      ·
-1      ·     spans           ALL           ·                      ·
+1      ·     spans           /1-/2         ·                      ·
 1      ·     filter          f = g         ·                      ·
 
 query ITTTTT colnames

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -145,20 +145,24 @@ output row: [2]
 query ITTT
 EXPLAIN SELECT * FROM t x JOIN t y USING(b) WHERE x.b < '3'
 ----
-0  render      ·         ·
-1  render      ·         ·
-2  join        ·         ·
-2  ·           type      inner
-2  ·           equality  (b) = (b)
-3  index-join  ·         ·
-4  scan        ·         ·
-4  ·           table     t@bc
-4  ·           spans     /#-/"3"
-4  scan        ·         ·
-4  ·           table     t@primary
-3  scan        ·         ·
-3  ·           table     t@primary
-3  ·           spans     ALL
+0  render      ·               ·
+1  render      ·               ·
+2  join        ·               ·
+2  ·           type            inner
+2  ·           equality        (b) = (b)
+2  ·           mergeJoinOrder  +"(b=b)"
+3  index-join  ·               ·
+4  scan        ·               ·
+4  ·           table           t@bc
+4  ·           spans           /#-/"3"
+4  scan        ·               ·
+4  ·           table           t@primary
+3  index-join  ·               ·
+4  scan        ·               ·
+4  ·           table           t@bc
+4  ·           spans           /#-/"3"
+4  scan        ·               ·
+4  ·           table           t@primary
 
 statement ok
 TRUNCATE TABLE t


### PR DESCRIPTION
With the previous change of removing the merged columns, we can no longer
map constraints on merged columns to constraints on the left and right side.

Instead, we implement a more general mechanism that "transfers" constraints from
one side to the other. This handles more cases well: e.g.
`SELECT FROM a JOIN b USING (x) WHERE a.x > 1` will push down `x > 1` on both
`a` and `b`.

For inner and left outer joins, merged columns are aliases for the corresponding
left side column, so any constraints on them end up being propagated through the
renderNode and then to both sides of the join. For right outer joins, merged
columns are aliases for the corresponding right side column (except for collated
strings and the like).

Updates #19640.