### PR TITLE
sql: Plumb RangeDescriptorCache and LeaseHolderCache to distSQLBackfill

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1099,6 +1099,8 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 		s.clock,
 		s.jobRegistry,
 		distSQLPlanner,
+		s.distSender.RangeDescriptorCache(),
+		s.distSender.LeaseHolderCache(),
 	).Start(s.stopper)
 
 	s.sqlExecutor.Start(ctx, &s.adminMemMetrics, distSQLPlanner)

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -536,18 +536,15 @@ func (sc *SchemaChanger) distBackfill(
 					otherTableDescs = append(otherTableDescs, *table)
 				}
 			}
-			// TODO(andrei): pass the right caches. I think this will crash without
-			// them.
 			recv, err := makeDistSQLReceiver(
 				ctx,
 				nil, /* resultWriter */
-				nil, /* rangeCache */
-				nil, /* leaseCache */
+				sc.rangeDescriptorCache,
+				sc.leaseHolderCache,
 				nil, /* txn - the flow does not run wholly in a txn */
-				// updateClock - the flow will not generate errors with time signal.
-				// TODO(andrei): plumb a clock update handler here regardless of whether
-				// it will actually be used or not.
-				nil,
+				func(ts hlc.Timestamp) {
+					_ = sc.clock.Update(ts)
+				},
 			)
 			if err != nil {
 				return err

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -615,11 +615,14 @@ func (p *planner) notifySchemaChange(
 	tableDesc *sqlbase.TableDescriptor, mutationID sqlbase.MutationID,
 ) {
 	sc := SchemaChanger{
-		tableID:     tableDesc.GetID(),
-		mutationID:  mutationID,
-		nodeID:      p.evalCtx.NodeID,
-		leaseMgr:    p.LeaseMgr(),
-		jobRegistry: p.ExecCfg().JobRegistry,
+		tableID:              tableDesc.GetID(),
+		mutationID:           mutationID,
+		nodeID:               p.evalCtx.NodeID,
+		leaseMgr:             p.LeaseMgr(),
+		jobRegistry:          p.ExecCfg().JobRegistry,
+		leaseHolderCache:     p.ExecCfg().LeaseHolderCache,
+		rangeDescriptorCache: p.ExecCfg().RangeDescriptorCache,
+		clock:                p.ExecCfg().Clock,
 	}
 	p.session.TxnState.schemaChangers.queueSchemaChanger(sc)
 }


### PR DESCRIPTION
This plumbs through caches to the distSQLReceiver initialized during
schema change backfilling. These caches are updated during distSQL
execution.

This will prevent a panic if the spans during distSQL execution
do not match the planned spans. It is not currently known if this was a
problem, but panics are happening on another code path where a
distSQLReceiver is initialized during query execution (on #19586).