### PR TITLE
config,sql: prepare to support zone configs on indices and partitions

### DIFF
--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -262,12 +262,12 @@ func TestingSetDefaultZoneConfig(cfg ZoneConfig) func() {
 	}
 }
 
-// Validate verifies some ZoneConfig fields.
-// This should be used to validate user input when setting a new zone config.
-func (z ZoneConfig) Validate() error {
+// Validate returns an error if the ZoneConfig specifies a known-dangerous
+// configuration.
+func (z *ZoneConfig) Validate() error {
 	switch z.NumReplicas {
 	case 0:
-		return fmt.Errorf("attributes for at least one replica must be specified in zone config")
+		return fmt.Errorf("at least one replica is required")
 	case 2:
 		return fmt.Errorf("at least 3 replicas are required for multi-replica configurations")
 	}

--- a/pkg/config/zone_test.go
+++ b/pkg/config/zone_test.go
@@ -72,6 +72,68 @@ func TestZoneConfigValidate(t *testing.T) {
 	}
 }
 
+func TestZoneConfigSubzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	zone := config.DefaultZoneConfig()
+	subzoneAInvalid := config.Subzone{IndexID: 1, PartitionName: "a", Config: config.ZoneConfig{}}
+	subzoneA := config.Subzone{IndexID: 1, PartitionName: "a", Config: config.DefaultZoneConfig()}
+	subzoneB := config.Subzone{IndexID: 1, PartitionName: "b", Config: config.DefaultZoneConfig()}
+
+	if zone.IsSubzonePlaceholder() {
+		t.Errorf("default zone config should not be considered a subzone placeholder")
+	}
+
+	zone.SetSubzone(subzoneAInvalid)
+	zone.SetSubzone(subzoneB)
+	if err := zone.Validate(); !testutils.IsError(err, "at least one replica is required") {
+		t.Errorf("expected 'at least one replica is required' validation error, but got %v", err)
+	}
+
+	zone.SetSubzone(subzoneA)
+	if err := zone.Validate(); err != nil {
+		t.Errorf("expected zone validation to succeed, but got %s", err)
+	}
+	if subzone := zone.GetSubzone(1, "a"); !subzoneA.Equal(subzone) {
+		t.Errorf("expected subzone to equal %+v, but got %+v", &subzoneA, subzone)
+	}
+	if subzone := zone.GetSubzone(1, "b"); !subzoneB.Equal(subzone) {
+		t.Errorf("expected subzone to equal %+v, but got %+v", &subzoneB, subzone)
+	}
+	if subzone := zone.GetSubzone(1, "c"); subzone != nil {
+		t.Errorf("expected nil subzone, but got %+v", subzone)
+	}
+	if subzone := zone.GetSubzone(2, "a"); subzone != nil {
+		t.Errorf("expected nil subzone, but got %+v", subzone)
+	}
+	if zone.IsSubzonePlaceholder() {
+		t.Errorf("zone with its own config should not be considered a subzone placeholder")
+	}
+
+	zone.DeleteTableConfig()
+	if e := (config.ZoneConfig{
+		Subzones: []config.Subzone{subzoneA, subzoneB},
+	}); !e.Equal(zone) {
+		t.Errorf("expected zone after clearing to equal %+v, but got %+v", e, zone)
+	}
+	if !zone.IsSubzonePlaceholder() {
+		t.Errorf("expected cleared zone config to be considered a subzone placeholder")
+	}
+
+	if didDelete := zone.DeleteSubzone(1, "c"); didDelete {
+		t.Errorf("deletion claims to have succeeded on non-existent subzone")
+	}
+	if didDelete := zone.DeleteSubzone(1, "b"); !didDelete {
+		t.Errorf("valid deletion claims to have failed")
+	}
+	if subzone := zone.GetSubzone(1, "b"); subzone != nil {
+		t.Errorf("expected deleted subzone to be nil when retrieved, but got %+v", subzone)
+	}
+	if subzone := zone.GetSubzone(1, "a"); !subzoneA.Equal(subzone) {
+		t.Errorf("expected non-deleted subzone to equal %+v, but got %+v", &subzoneA, subzone)
+	}
+}
+
 // TestZoneConfigMarshalYAML makes sure that ZoneConfig is correctly marshaled
 // to YAML and back.
 func TestZoneConfigMarshalYAML(t *testing.T) {

--- a/pkg/config/zone_test.go
+++ b/pkg/config/zone_test.go
@@ -34,7 +34,7 @@ func TestZoneConfigValidate(t *testing.T) {
 	}{
 		{
 			config.ZoneConfig{},
-			"attributes for at least one replica must be specified in zone config",
+			"at least one replica is required",
 		},
 		{
 			config.ZoneConfig{

--- a/pkg/sql/config.go
+++ b/pkg/sql/config.go
@@ -49,15 +49,15 @@ func getZoneConfig(
 		if err := zoneVal.GetProto(&zone); err != nil {
 			return config.ZoneConfig{}, 0, err
 		}
-		if subzone, found := zone.GetSubzoneForKeySuffix(keySuffix); found {
+		if subzone := zone.GetSubzoneForKeySuffix(keySuffix); subzone != nil {
 			// The ZoneConfig has a more-specific index or partition subzone; use
 			// that.
-			return subzone, id, nil
+			return subzone.Config, id, nil
 		}
-		// No subzone matched. If the parent zone specifies zero replicas, it
-		// existed only as a home for subzones, and we should keep recursing up the
-		// hierarchy. Otherwise, return the parent zone.
-		if zone.NumReplicas != 0 {
+		// No subzone matched. Return the parent zone, unless it was just a
+		// placeholder for subzones, in which case we need to keep recursing up the
+		// hierarchy.
+		if !zone.IsSubzonePlaceholder() {
 			return zone, id, nil
 		}
 	}

--- a/pkg/sql/zone.go
+++ b/pkg/sql/zone.go
@@ -41,7 +41,7 @@ func zoneSpecifierNotFoundError(zs parser.ZoneSpecifier) error {
 	}
 }
 
-func resolveZoneSpecifier(
+func resolveZone(
 	ctx context.Context, txn *client.Txn, zs parser.ZoneSpecifier,
 ) (sqlbase.ID, error) {
 	errMissingKey := errors.New("missing key")
@@ -136,7 +136,7 @@ func (n *setZoneConfigNode) Start(params runParams) error {
 		}
 	}
 
-	targetID, err := resolveZoneSpecifier(params.ctx, params.p.txn, n.zoneSpecifier)
+	targetID, err := resolveZone(params.ctx, params.p.txn, n.zoneSpecifier)
 	if err != nil {
 		return err
 	}
@@ -233,7 +233,7 @@ func (p *planner) ShowZoneConfig(ctx context.Context, n *parser.ShowZoneConfig) 
 }
 
 func (n *showZoneConfigNode) Start(params runParams) error {
-	targetID, err := resolveZoneSpecifier(params.ctx, params.p.txn, n.zoneSpecifier)
+	targetID, err := resolveZone(params.ctx, params.p.txn, n.zoneSpecifier)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/zone.go
+++ b/pkg/sql/zone.go
@@ -162,22 +162,22 @@ func (n *setZoneConfigNode) Start(params runParams) error {
 	// TODO(benesch): pass in a proper key suffix to support index/partition
 	// zone configs.
 	var keySuffix []byte
-	proto, _, err := GetZoneConfigInTxn(params.ctx, params.p.txn, uint32(targetID), keySuffix)
+	zone, _, err := GetZoneConfigInTxn(params.ctx, params.p.txn, uint32(targetID), keySuffix)
 	if err == errNoZoneConfigApplies {
 		// TODO(benesch): This shouldn't be the caller's responsibility;
 		// GetZoneConfigInTxn should just return the default zone config if no zone
 		// config applies.
-		proto = config.DefaultZoneConfig()
+		zone = config.DefaultZoneConfig()
 	} else if err != nil {
 		return err
 	}
-	if err := yaml.UnmarshalStrict([]byte(*yamlConfig), &proto); err != nil {
+	if err := yaml.UnmarshalStrict([]byte(*yamlConfig), &zone); err != nil {
 		return fmt.Errorf("could not parse zone config: %s", err)
 	}
-	if err := proto.Validate(); err != nil {
+	if err := zone.Validate(); err != nil {
 		return fmt.Errorf("could not parse zone config: %s", err)
 	}
-	buf, err := protoutil.Marshal(&proto)
+	buf, err := protoutil.Marshal(&zone)
 	if err != nil {
 		return fmt.Errorf("could not marshal zone config: %s", err)
 	}
@@ -240,12 +240,12 @@ func (n *showZoneConfigNode) Start(params runParams) error {
 	// TODO(benesch): pass in a proper key suffix to support index/partition
 	// zone configs.
 	var keySuffix []byte
-	proto, zoneID, err := GetZoneConfigInTxn(params.ctx, params.p.txn, uint32(targetID), keySuffix)
+	zone, zoneID, err := GetZoneConfigInTxn(params.ctx, params.p.txn, uint32(targetID), keySuffix)
 	if err == errNoZoneConfigApplies {
 		// TODO(benesch): This shouldn't be the caller's responsibility;
 		// GetZoneConfigInTxn should just return the default zone config if no zone
 		// config applies.
-		proto = config.DefaultZoneConfig()
+		zone = config.DefaultZoneConfig()
 		zoneID = keys.RootNamespaceID
 	} else if err != nil {
 		return err
@@ -260,11 +260,11 @@ func (n *showZoneConfigNode) Start(params runParams) error {
 	}
 	n.cliSpecifier = config.CLIZoneSpecifier(zs)
 
-	n.protoConfig, err = protoutil.Marshal(&proto)
+	n.protoConfig, err = protoutil.Marshal(&zone)
 	if err != nil {
 		return err
 	}
-	n.yamlConfig, err = yaml.Marshal(proto)
+	n.yamlConfig, err = yaml.Marshal(zone)
 	return err
 }
 


### PR DESCRIPTION
Some helpers that prepare for upcoming work to allow specifying zone configs on indices and partitions of indices, as described in the partitioning RFC.