### PR TITLE
Change New Version alert link to upgrade doc

### DIFF
--- a/pkg/ui/src/redux/alerts.ts
+++ b/pkg/ui/src/redux/alerts.ts
@@ -155,7 +155,7 @@ export const newVersionNotificationSelector = createSelector(
       // Note that this explicitly does not use util/docs to create the link,
       // since we want to link to the updated version, not the version currently
       // running on the cluster.
-      link: "https://www.cockroachlabs.com/docs/stable/install-cockroachdb.html",
+      link: "https://www.cockroachlabs.com/docs/stable/upgrade-cockroach-version.html",
       dismiss: (dispatch) => {
         const dismissedAt = moment();
         // Dismiss locally.


### PR DESCRIPTION
Instead of linking to the install doc when we detect a cluster's running an old version of `cockroach`, we should link to the doc that shows them how to upgrade. 

This should ultimately link to a version that you know you can upgrade to, but because we're avoiding dealing with the Gordian knot of versions, I suggest we just improving the current behavior by leaving this as a link to `stable`.