### PR TITLE
sql: fix recursive use of prepare and execute

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -334,7 +334,7 @@ query error pq: job with ID 123 does not exist
 EXECUTE p6(123)
 
 # Ensure that SET / SET CLUSTER SETTING know about placeholders
-statement
+statement ok
 PREPARE setp(string) AS SET application_name = $1
 
 query T
@@ -350,13 +350,28 @@ hello
 # Note: we can't check the result of SET CLUSTER SETTING synchronously
 # because it doesn't propagate immediately.
 
-statement
+statement ok
 PREPARE sets(string) AS SET CLUSTER SETTING cluster.organization = $1
 
-statement
+statement ok
 EXECUTE sets('hello')
 
 # #19597
 
 statement error could not determine data type of placeholder
 PREPARE x19597 AS SELECT $1 IN ($2, null);
+
+# Regression for #19716: ensure that placeholders for EXECUTE statements inside
+# of PREPARE statements are properly segregated from those of the outer
+# statement.
+
+statement ok
+PREPARE innerStmt AS SELECT $1:::int i, 'foo' t
+
+statement ok
+PREPARE outerStmt AS SELECT * FROM [EXECUTE innerStmt(3)] WHERE t = $1
+
+query IT
+EXECUTE outerStmt('foo')
+----
+3 foo

--- a/pkg/sql/prepare.go
+++ b/pkg/sql/prepare.go
@@ -388,7 +388,13 @@ func (p *planner) Execute(ctx context.Context, n *parser.Execute) (planNode, err
 	if err != nil {
 		return nil, err
 	}
-	p.semaCtx.Placeholders.Assign(newPInfo)
 
-	return p.newPlan(ctx, ps.Statement, nil)
+	// We need to make a fresh planner here, so that writing the placeholders
+	// into the SemaContext doesn't overwrite the outer placeholder values if
+	// there are any.
+	innerPlanner := &planner{}
+	*innerPlanner = *p
+	innerPlanner.semaCtx.Placeholders.Assign(newPInfo)
+
+	return innerPlanner.newPlan(ctx, ps.Statement, nil)
 }


### PR DESCRIPTION
Previously, calling `PREPARE` on a statement that included an `EXECUTE`
in a statement datasource (the `SELECT * FROM [...]` syntax) was buggy.
It did not properly segregate the placeholders from the inner statement
from those of the outer statement.

Fixes #19716.