### PR TITLE
sql: pre-evaluate arguments to set

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -203,3 +203,7 @@ query T
 SHOW "time zone"
 ----
 UTC
+
+# Regression test for #19727 - invalid EvalContext used to evaluate arguments to set.
+statement ok
+SET APPLICATION_NAME = current_timestamp()::string

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -103,6 +103,13 @@ func (p *planner) SetVar(ctx context.Context, n *parser.SetVar) (planNode, error
 
 func (n *setNode) Start(params runParams) error {
 	if n.typedValues != nil {
+		for i, v := range n.typedValues {
+			d, err := v.Eval(&params.p.evalCtx)
+			if err != nil {
+				return err
+			}
+			n.typedValues[i] = d
+		}
 		return n.v.Set(params.ctx, params.p.session, n.typedValues)
 	}
 	return n.v.Reset(params.p.session)


### PR DESCRIPTION
Run Eval() on all arguments passed to Set before beginning the Set plan.
This is necessary because the implementations of all of the different
variable setters don't get passed the proper EvalContext, and therefore
won't be able to properly resolve Placeholders once they become leaf
values.

This wouldn't be necessary if the Set implementations were able to get
the correct EvalContext, but doing that properly would require a larger
refactor.

Release note: fix a rare panic in `SET`.
Fixes #19727.

I'd like to cherrypick this into 1.1.