### PR TITLE
Add 'uuid_generate_v4' alias for 'uuid_v4' builtin.

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1138,6 +1138,7 @@ CockroachDB supports the following flags:
 	},
 
 	"experimental_uuid_v4": {uuidV4Impl},
+	"uuid_generate_v4":     {uuidV4Impl},
 	"uuid_v4":              {uuidV4Impl},
 
 	"greatest": {


### PR DESCRIPTION
This is a very small changeset which adds `uuid_generate_v4()` as an alias for the `uuid_v4()` builtin. This improves compatibility with PostgreSQL's equivalent function in the `uuid-ossp` module: https://www.postgresql.org/docs/9.4/static/uuid-ossp.html