### PR TITLE
Add category to release note commit guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,13 +150,26 @@ See our separate [style guide](STYLE.md) document.
     to indicate their reach.
   - We publish detailed [release notes](https://www.cockroachlabs.com/docs/releases/)
     describing most non-test changes. To facilitate this, at least one commit in every
-    PR (possibly the PR message/merge commit) should contain a brief description of
+    PR (preferably the PR message/merge commit) should contain a brief description of
     the change in terms that a user would recognize. This description should be prefixed
-    with "Release note:". For example, a commit like ["distsql: pre-reserve memory needed
+    with "Release note (category):", where the "category" is one of the following:
+    - cli change
+    - sql change
+    - web ui change
+    - performance improvement
+    - bug fix
+    - general change (e.g., change of required Go version)
+    - build change (e.g., compatibility with older CPUs)
+    - enterprise change (e.g., change to backup/restore)
+    - backwards-incompatible change
+
+    For example, a commit like ["distsql: pre-reserve memory needed
     to mark rows in HashJoiner build phase"](https://github.com/cockroachdb/cockroach/pull/18975)
-    might say "Release note: Fixed a panic in queries with `JOIN` using the
+    might say, "Release note (bug fix): Fixed a panic in queries with `JOIN` using the
     distributed SQL engine."
 
+    When a commit falls into more than one category, choose the category that matches best
+    or is most affected from a user's perspective.
 
 - Run the linters, code generators, and unit test suites locally:
 


### PR DESCRIPTION
To make it even easier for a single non-Ben person to pull together release notes, it'd be great to call out the category of change in the release note commit message. 