### PR TITLE
sql: some cleanup to planner-internal queries

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -258,6 +258,9 @@ func (p *planner) QueryRow(
 func (p *planner) queryRows(
 	ctx context.Context, sql string, args ...interface{},
 ) ([]parser.Datums, error) {
+	oldPlaceholders := p.semaCtx.Placeholders
+	defer func() { p.semaCtx.Placeholders = oldPlaceholders }()
+
 	plan, err := p.makeInternalPlan(ctx, sql, args...)
 	if err != nil {
 		return nil, err
@@ -286,6 +289,8 @@ func (p *planner) queryRows(
 // exec executes a SQL query string and returns the number of rows
 // affected.
 func (p *planner) exec(ctx context.Context, sql string, args ...interface{}) (int, error) {
+	oldPlaceholders := p.semaCtx.Placeholders
+	defer func() { p.semaCtx.Placeholders = oldPlaceholders }()
 	plan, err := p.makeInternalPlan(ctx, sql, args...)
 	if err != nil {
 		return 0, err

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -212,12 +212,16 @@ func (p *planner) setTxn(txn *client.Txn) {
 	}
 }
 
-// query initializes a planNode from a SQL statement string. Close() must be
-// called on the returned planNode after use.
+// makeInternalPlan initializes a planNode from a SQL statement string.
+// Close() must be called on the returned planNode after use.
+// This function changes the planner's placeholder map. It is the caller's
+// responsibility to save and restore the old map if desired.
 // This function is not suitable for use in the planNode constructors directly:
 // the returned planNode has already been optimized.
 // Consider also (*planner).delegateQuery(...).
-func (p *planner) query(ctx context.Context, sql string, args ...interface{}) (planNode, error) {
+func (p *planner) makeInternalPlan(
+	ctx context.Context, sql string, args ...interface{},
+) (planNode, error) {
 	if log.V(2) {
 		log.Infof(ctx, "internal query: %s", sql)
 		if len(args) > 0 {
@@ -254,7 +258,7 @@ func (p *planner) QueryRow(
 func (p *planner) queryRows(
 	ctx context.Context, sql string, args ...interface{},
 ) ([]parser.Datums, error) {
-	plan, err := p.query(ctx, sql, args...)
+	plan, err := p.makeInternalPlan(ctx, sql, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +286,7 @@ func (p *planner) queryRows(
 // exec executes a SQL query string and returns the number of rows
 // affected.
 func (p *planner) exec(ctx context.Context, sql string, args ...interface{}) (int, error) {
-	plan, err := p.query(ctx, sql, args...)
+	plan, err := p.makeInternalPlan(ctx, sql, args...)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
- remove usages of `planner.query` from outside of the planner
- rename `planner.query` to `makeInternalPlan`
- restore placeholders after executing internal queries