### PR TITLE
build: preserve publish-script acceptance logs

### DIFF
--- a/build/teamcity-publish-artifacts.sh
+++ b/build/teamcity-publish-artifacts.sh
@@ -28,7 +28,7 @@ if [[ "$TC_BUILD_BRANCH" != *-* ]] && [ "$TEAMCITY_BUILDCONF_NAME" == 'Publish R
   # For the acceptance tests that run without Docker.
   ln -s cockroach-linux-2.6.32-gnu-amd64 cockroach
   build/builder.sh make TYPE=$TYPE testbuild TAGS=acceptance PKG=./pkg/acceptance
-  (cd pkg/acceptance && ./acceptance.test -i $image -b /cockroach/cockroach -nodes 4 -test.v -test.timeout -5m)
+  (cd pkg/acceptance && ./acceptance.test -l ./artifacts -i $image -b /cockroach/cockroach -nodes 4 -test.v -test.timeout -5m) &> ./artifacts/publish-acceptance.log
 
   sed "s/<EMAIL>/$DOCKER_EMAIL/;s/<AUTH>/$DOCKER_AUTH/" < build/.dockercfg.in > ~/.dockercfg
   docker push "$image:latest"


### PR DESCRIPTION
Saw a hung build while preparing the release today, but without the node logs
there is little to be done about it.