### PR TITLE
sql: fix panic when UPDATE ran after ALTER ADD COLUMN on table with index on all columns

### DIFF
--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -800,6 +800,11 @@ func (v *indexInfo) isCoveringIndex(scan *scanNode) bool {
 	}
 
 	for i, needed := range scan.valNeededForCol {
+		// This is possible during a schema change when we have
+		// additional columns.
+		if i >= len(v.desc.Columns) {
+			return false
+		}
 		if needed {
 			colID := v.desc.Columns[i].ID
 			if !v.index.ContainsColumnID(colID) {


### PR DESCRIPTION
I discovered this nasty bug during https://github.com/cockroachdb/cockroach/pull/19701.

## Replication steps

1. Create a table
2. Create an index on that table on all the columns
3. Run an `ADD COLUMN` schema change, then run a DML statement (i.e. `UPDATE`) concurrently with the schema change (one can accomplish this interactively by creating a table with a large .# of rows, then quickly switching to another console to run the DML query)

## Example

```sql
CREATE TABLE kv (k INT, v INT);

CREATE INDEX allidx ON kv (k, v);   # important

# Generate enough rows to cause schema change to take O(seconds) for running DML concurrently
INSERT INTO kv (kv) SELECT k, v FROM
  GENERATE_SERIES(1,1000) AS K(k),
  GENERATE_SERIES(1,100) AS V(v);

ALTER TABLE kv ADD COLUMN x DECIMAL DEFAULT (DECIMAL '1.4');
# The following should be run concurrently with the above schema change
UPDATE kv SET v = 1337 WHERE k = 123;
```

## Cause

1. [`isCoveringIndex` is invoked](https://github.com/cockroachdb/cockroach/blob/4c420daeefedfd5b14249ffdd4b4f12797d89d13/pkg/sql/index_selection.go#L802-L809) to figure out which index to use for `UPDATE` 
2. During schema changes, `valNeededForCol` is [initialized with all columns (including mutations)](https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/scan.go#L370-L373). From my understanding of schema changes, certain delete/write/read capabilities are granted after each stage. I'm assuming this is correct behavior to initialize this with all columns in case those capabilities are granted during execution.

## Fix

We check if the index exceeds the current columns in the descriptor during index selection. I've also added a regression test that fails without the fix.