### PR TITLE
teamcity-assert-clean: clean when `git status` fails

### DIFF
--- a/build/teamcity-assert-clean.sh
+++ b/build/teamcity-assert-clean.sh
@@ -3,8 +3,11 @@ set -exuo pipefail
 
 export BUILDER_HIDE_GOPATH_SRC=1
 
-if ! build/builder.sh /bin/bash -c '! git status --porcelain | read || (git status; git diff -a 1>&2; exit 1)';
-then
-  docker run --volume="$(cd "$(dirname "$0")/.." && pwd):/nuke" --workdir="/nuke" golang:stretch git clean -fdx
+# The workspace is clean iff `git status --porcelain` produces no output. Any
+# output is either an error message or a listing of an untracked/dirty file.
+if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
+  git status >&2 || true
+  git diff -a >&2 || true
+  docker run --volume="$(cd "$(dirname "$0")/.." && pwd):/nuke" --workdir="/nuke" golang:stretch git clean -fdx >&2
   exit 1
 fi


### PR DESCRIPTION
An acceptance test build recently littered root-owned files in the
working tree after it timed out. teamcity-assert-clean failed to clean
up the mess because `git status` failed:

    fatal: 'git status --porcelain' failed in submodule c-deps/protobuf

We should probably figure out why `git status` failed, but, in the
meantime, teach teamcity-assert-clean to clean up even if `git status`
produces an error message.

Doing this required unpacking the logic of the "is workspace dirty?"
one-liner onto multiple lines.