### PR TITLE
distsqlrun: fix a double close of the merge joiner output

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -298,8 +298,9 @@ func (h *hashJoiner) receiveRow(
 			return row, false, nil
 		}
 
-		if !h.maybeEmitUnmatchedRow(ctx, row, side) {
-			return nil, true, nil
+		needMoreRows, err := h.maybeEmitUnmatchedRow(ctx, row, side)
+		if !needMoreRows || err != nil {
+			return nil, true, err
 		}
 	}
 }
@@ -555,8 +556,11 @@ func (h *hashJoiner) probeRow(
 		}
 	}
 
-	if !probeMatched && !h.maybeEmitUnmatchedRow(ctx, row, otherSide(h.storedSide)) {
-		return true, nil
+	if !probeMatched {
+		needMoreRows, err := h.maybeEmitUnmatchedRow(ctx, row, otherSide(h.storedSide))
+		if !needMoreRows || err != nil {
+			return true, err
+		}
 	}
 	return false, nil
 }
@@ -628,8 +632,9 @@ func (h *hashJoiner) probePhase(
 			if err != nil {
 				return false, err
 			}
-			if !h.maybeEmitUnmatchedRow(ctx, row, h.storedSide) {
-				return true, nil
+			needMoreRows, err := h.maybeEmitUnmatchedRow(ctx, row, h.storedSide)
+			if !needMoreRows || err != nil {
+				return true, err
 			}
 		}
 	}

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -133,8 +133,9 @@ func (m *mergeJoiner) outputBatch(
 				if matchedRight != nil {
 					matchedRight[rIdx] = true
 				}
-				if !emitHelper(ctx, &m.out, renderedRow, ProducerMetadata{}) {
-					return false, nil
+				consumerStatus, err := m.out.EmitRow(ctx, renderedRow)
+				if err != nil || consumerStatus != NeedMoreRows {
+					return false, err
 				}
 			}
 		}

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -139,16 +139,22 @@ func (m *mergeJoiner) outputBatch(
 				}
 			}
 		}
-		if !matched && !m.maybeEmitUnmatchedRow(ctx, lrow, leftSide) {
-			return false, nil
+		if !matched {
+			needMoreRows, err := m.maybeEmitUnmatchedRow(ctx, lrow, leftSide)
+			if !needMoreRows || err != nil {
+				return false, err
+			}
 		}
 	}
 
 	if matchedRight != nil {
 		// Produce results for unmatched right rows (for RIGHT OUTER or FULL OUTER).
 		for rIdx, rrow := range rightRows {
-			if !matchedRight[rIdx] && !m.maybeEmitUnmatchedRow(ctx, rrow, rightSide) {
-				return false, nil
+			if !matchedRight[rIdx] {
+				needMoreRows, err := m.maybeEmitUnmatchedRow(ctx, rrow, rightSide)
+				if !needMoreRows || err != nil {
+					return false, err
+				}
 			}
 		}
 	}

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -366,7 +366,7 @@ func TestMergeJoiner(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.Run(context.Background(), nil)
+			m.Run(context.Background(), nil /* wg */)
 
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
@@ -391,6 +391,96 @@ func TestMergeJoiner(t *testing.T) {
 			if expStr != retStr {
 				t.Errorf("invalid results; expected:\n   %s\ngot:\n   %s",
 					expStr, retStr)
+			}
+		})
+	}
+}
+
+// Test that the joiner shuts down fine if the consumer is closed prematurely.
+func TestConsumerClosed(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	columnTypeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
+	v := [10]sqlbase.EncDatum{}
+	for i := range v {
+		v[i] = sqlbase.DatumToEncDatum(columnTypeInt, parser.NewDInt(parser.DInt(i)))
+	}
+
+	spec := MergeJoinerSpec{
+		LeftOrdering: convertToSpecOrdering(
+			sqlbase.ColumnOrdering{
+				{ColIdx: 0, Direction: encoding.Ascending},
+			}),
+		RightOrdering: convertToSpecOrdering(
+			sqlbase.ColumnOrdering{
+				{ColIdx: 0, Direction: encoding.Ascending},
+			}),
+		Type: JoinType_INNER,
+		// Implicit @1 = @2 constraint.
+	}
+	outCols := []uint32{0}
+	leftTypes := oneIntCol
+	rightTypes := oneIntCol
+
+	testCases := []struct {
+		typ       JoinType
+		leftRows  sqlbase.EncDatumRows
+		rightRows sqlbase.EncDatumRows
+	}{
+		{
+			typ: JoinType_INNER,
+			// Implicit @1 = @2 constraint.
+			leftRows: sqlbase.EncDatumRows{
+				{v[0]},
+			},
+			rightRows: sqlbase.EncDatumRows{
+				{v[0]},
+			},
+		},
+		{
+			typ: JoinType_LEFT_OUTER,
+			// Implicit @1 = @2 constraint.
+			leftRows: sqlbase.EncDatumRows{
+				{v[0]},
+			},
+			rightRows: sqlbase.EncDatumRows{},
+		},
+		{
+			typ: JoinType_RIGHT_OUTER,
+			// Implicit @1 = @2 constraint.
+			leftRows: sqlbase.EncDatumRows{},
+			rightRows: sqlbase.EncDatumRows{
+				{v[0]},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.typ.String() /* name */, func(t *testing.T) {
+			leftInput := NewRowBuffer(leftTypes, tc.leftRows, RowBufferArgs{})
+			rightInput := NewRowBuffer(rightTypes, tc.rightRows, RowBufferArgs{})
+
+			// Create a consumer and close it immediately. The mergeJoiner should find out
+			// about this closer the first time it attempts to push a row.
+			out := &RowBuffer{}
+			out.ConsumerDone()
+
+			evalCtx := parser.MakeTestingEvalContext()
+			defer evalCtx.Stop(context.Background())
+			flowCtx := FlowCtx{
+				Settings: cluster.MakeTestingClusterSettings(),
+				EvalCtx:  evalCtx,
+			}
+			post := PostProcessSpec{Projection: true, OutputColumns: outCols}
+			m, err := newMergeJoiner(&flowCtx, &spec, leftInput, rightInput, &post, out)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			m.Run(context.TODO(), nil /* wg */)
+
+			if !out.ProducerClosed {
+				t.Fatalf("output RowReceiver not closed")
 			}
 		})
 	}

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -246,7 +246,8 @@ func emitHelper(
 //
 // It returns the consumer's status that was observed when pushing this row. If
 // an error is returned, it's coming from the ProcOutputHelper's filtering or
-// rendering processing; the output has not been closed.
+// rendering processing; the output has not been closed and it's the caller's
+// responsibility to push the error to the output.
 //
 // Note: check out emitHelper() for a useful wrapper.
 func (h *ProcOutputHelper) EmitRow(


### PR DESCRIPTION
This patch fixes a bug that caused us to call ProducerDone() twice on
the output of a mergeJoiner in case outputting a matched row encountered
an error or a closed consumer. This was a panic.