### PR TITLE
sql: convert placeholders to leaf values

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -330,11 +330,12 @@ func makeCSVTableDescriptor(
 			return nil, errors.Errorf("unsupported table definition: %s", parser.AsString(def))
 		}
 	}
+	semaCtx := parser.SemaContext{}
+	evalCtx := parser.EvalContext{}
 	tableDesc, err := sql.MakeTableDesc(
 		ctx,
 		nil, /* txn */
 		sql.NilVirtualTabler,
-		parser.SearchPath{},
 		create,
 		parentID,
 		tableID,
@@ -342,7 +343,8 @@ func makeCSVTableDescriptor(
 		sqlbase.NewDefaultPrivilegeDescriptor(),
 		nil, /* affected */
 		"",  /* sessionDB */
-		nil, /* EvalContext */
+		&semaCtx,
+		&evalCtx,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -150,7 +150,7 @@ func Load(
 			// only uses txn for resolving FKs and interleaved tables, neither of which
 			// are present here.
 			var txn *client.Txn
-			desc, err := sql.MakeTableDesc(ctx, txn, sql.NilVirtualTabler, parser.SearchPath{}, s, dbDesc.ID, 0 /* table ID */, ts, privs, affected, dbDesc.Name, &evalCtx)
+			desc, err := sql.MakeTableDesc(ctx, txn, sql.NilVirtualTabler, s, dbDesc.ID, 0 /* table ID */, ts, privs, affected, dbDesc.Name, nil, &evalCtx)
 			if err != nil {
 				return BackupDescriptor{}, errors.Wrap(err, "make table desc")
 			}

--- a/pkg/sql/analyze.go
+++ b/pkg/sql/analyze.go
@@ -1677,7 +1677,6 @@ func makeIsNotNull(left parser.TypedExpr) parser.TypedExpr {
 // analyzeExpr performs semantic analysis of an expression, including:
 // - replacing sub-queries by a sql.subquery node;
 // - resolving names (optional);
-// - replacing placeholders by their value;
 // - type checking (with optional type enforcement);
 // - normalization.
 // The parameters sources and IndexedVars, if both are non-nil, indicate

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -549,7 +549,7 @@ func (sc *SchemaChanger) distBackfill(
 			if err != nil {
 				return err
 			}
-			planCtx := sc.distSQLPlanner.newPlanningCtx(ctx, txn)
+			planCtx := sc.distSQLPlanner.newPlanningCtx(ctx, &evalCtx, txn)
 			plan, err := sc.distSQLPlanner.createBackfiller(
 				&planCtx, backfillType, *tableDesc, duration, chunkSize, spans, otherTableDescs, sc.readAsOf,
 			)

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -736,7 +736,7 @@ func (n *createTableNode) Start(params runParams) error {
 	var affected map[sqlbase.ID]*sqlbase.TableDescriptor
 	creationTime := params.p.txn.OrigTimestamp()
 	if n.n.As() {
-		desc, err = makeTableDescIfAs(n.n, n.dbDesc.ID, id, creationTime, planColumns(n.sourcePlan), privs, &params.p.evalCtx)
+		desc, err = makeTableDescIfAs(n.n, n.dbDesc.ID, id, creationTime, planColumns(n.sourcePlan), privs, &params.p.semaCtx, &params.p.evalCtx)
 	} else {
 		affected = make(map[sqlbase.ID]*sqlbase.TableDescriptor)
 		desc, err = params.p.makeTableDesc(params.ctx, n.n, n.dbDesc.ID, id, creationTime, privs, affected)
@@ -1429,8 +1429,7 @@ func (n *createViewNode) makeViewTableDesc(
 		if len(columnNames) > i {
 			columnTableDef.Name = columnNames[i]
 		}
-		// We pass an empty search path here because there are no names to resolve.
-		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, parser.SearchPath{}, evalCtx)
+		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, &n.p.semaCtx, evalCtx)
 		if err != nil {
 			return desc, err
 		}
@@ -1448,6 +1447,7 @@ func makeTableDescIfAs(
 	creationTime hlc.Timestamp,
 	resultColumns []sqlbase.ResultColumn,
 	privileges *sqlbase.PrivilegeDescriptor,
+	semaCtx *parser.SemaContext,
 	evalCtx *parser.EvalContext,
 ) (desc sqlbase.TableDescriptor, err error) {
 	tableName, err := p.Table.Normalize()
@@ -1465,8 +1465,7 @@ func makeTableDescIfAs(
 		if len(p.AsColumnNames) > i {
 			columnTableDef.Name = p.AsColumnNames[i]
 		}
-		// We pass an empty search path here because we do not have any expressions to resolve.
-		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, parser.SearchPath{}, evalCtx)
+		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, semaCtx, evalCtx)
 		if err != nil {
 			return desc, err
 		}
@@ -1481,13 +1480,13 @@ func MakeTableDesc(
 	ctx context.Context,
 	txn *client.Txn,
 	vt VirtualTabler,
-	searchPath parser.SearchPath,
 	n *parser.CreateTable,
 	parentID, id sqlbase.ID,
 	creationTime hlc.Timestamp,
 	privileges *sqlbase.PrivilegeDescriptor,
 	affected map[sqlbase.ID]*sqlbase.TableDescriptor,
 	sessionDB string,
+	semaCtx *parser.SemaContext,
 	evalCtx *parser.EvalContext,
 ) (sqlbase.TableDescriptor, error) {
 	tableName, err := n.Table.Normalize()
@@ -1506,7 +1505,7 @@ func MakeTableDesc(
 					)
 				}
 			}
-			col, idx, err := sqlbase.MakeColumnDefDescs(d, searchPath, evalCtx)
+			col, idx, err := sqlbase.MakeColumnDefDescs(d, semaCtx, evalCtx)
 			if err != nil {
 				return desc, err
 			}
@@ -1633,7 +1632,7 @@ func MakeTableDesc(
 			// pass, handled above.
 
 		case *parser.CheckConstraintTableDef:
-			ck, err := makeCheckConstraint(desc, d, generatedNames, searchPath)
+			ck, err := makeCheckConstraint(desc, d, generatedNames, semaCtx, evalCtx)
 			if err != nil {
 				return desc, err
 			}
@@ -1683,7 +1682,6 @@ func (p *planner) makeTableDesc(
 		ctx,
 		p.txn,
 		&p.session.virtualSchemas,
-		p.session.SearchPath,
 		n,
 		parentID,
 		id,
@@ -1691,6 +1689,7 @@ func (p *planner) makeTableDesc(
 		privileges,
 		affected,
 		p.session.Database,
+		&p.semaCtx,
 		&p.evalCtx,
 	)
 }
@@ -1737,7 +1736,8 @@ func makeCheckConstraint(
 	desc sqlbase.TableDescriptor,
 	d *parser.CheckConstraintTableDef,
 	inuseNames map[string]struct{},
-	searchPath parser.SearchPath,
+	semaCtx *parser.SemaContext,
+	evalCtx *parser.EvalContext,
 ) (*sqlbase.TableDescriptor_CheckConstraint, error) {
 	// CHECK expressions seem to vary across databases. Wikipedia's entry on
 	// Check_constraint (https://en.wikipedia.org/wiki/Check_constraint) says
@@ -1791,11 +1791,13 @@ func makeCheckConstraint(
 	}
 
 	var p parser.Parser
-	if err := p.AssertNoAggregationOrWindowing(expr, "CHECK expressions", searchPath); err != nil {
+	if err := p.AssertNoAggregationOrWindowing(expr, "CHECK expressions", semaCtx.SearchPath); err != nil {
 		return nil, err
 	}
 
-	if _, err := sqlbase.SanitizeVarFreeExpr(expr, parser.TypeBool, "CHECK", searchPath); err != nil {
+	if _, err := sqlbase.SanitizeVarFreeExpr(
+		expr, parser.TypeBool, "CHECK", semaCtx, evalCtx,
+	); err != nil {
 		return nil, err
 	}
 	if generateName {

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -779,7 +779,7 @@ func TestPartitionSpans(t *testing.T) {
 				},
 			}
 
-			planCtx := dsp.newPlanningCtx(context.Background(), nil /* txn */)
+			planCtx := dsp.newPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */)
 			var spans []roachpb.Span
 			for _, s := range tc.spans {
 				spans = append(spans, roachpb.Span{Key: roachpb.Key(s[0]), EndKey: roachpb.Key(s[1])})
@@ -955,7 +955,7 @@ func TestPartitionSpansSkipsIncompatibleNodes(t *testing.T) {
 				},
 			}
 
-			planCtx := dsp.newPlanningCtx(context.Background(), nil /* txn */)
+			planCtx := dsp.newPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */)
 			partitions, err := dsp.partitionSpans(&planCtx, roachpb.Spans{span})
 			if err != nil {
 				t.Fatal(err)
@@ -1046,7 +1046,7 @@ func TestPartitionSpansSkipsNodesNotInGossip(t *testing.T) {
 		},
 	}
 
-	planCtx := dsp.newPlanningCtx(context.Background(), nil /* txn */)
+	planCtx := dsp.newPlanningCtx(context.Background(), nil /* evalCtx */, nil /* txn */)
 	partitions, err := dsp.partitionSpans(&planCtx, roachpb.Spans{span})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -439,7 +439,7 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 	recv *distSQLReceiver,
 	evalCtx parser.EvalContext,
 ) error {
-	planCtx := dsp.newPlanningCtx(ctx, txn)
+	planCtx := dsp.newPlanningCtx(ctx, &evalCtx, txn)
 
 	log.VEvent(ctx, 1, "creating DistSQL plan")
 

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -289,7 +289,7 @@ func checkDistAggregationInfo(
 		if err != nil {
 			t.Fatal(err)
 		}
-		finalProc.Post.RenderExprs = []distsqlrun.Expression{MakeExpression(expr, nil)}
+		finalProc.Post.RenderExprs = []distsqlrun.Expression{MakeExpression(expr, nil, nil)}
 	}
 
 	procs = append(procs, finalProc)

--- a/pkg/sql/distsqlplan/physical_plan_test.go
+++ b/pkg/sql/distsqlplan/physical_plan_test.go
@@ -206,6 +206,7 @@ func TestProjectionAndRendering(t *testing.T) {
 						&parser.IndexedVar{Idx: 12},
 						&parser.IndexedVar{Idx: 13},
 					},
+					nil,
 					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3},
 					[]sqlbase.ColumnType{strToType("A"), strToType("B"), strToType("C"), strToType("D")},
 				)
@@ -227,6 +228,7 @@ func TestProjectionAndRendering(t *testing.T) {
 						&parser.IndexedVar{Idx: 13},
 						&parser.IndexedVar{Idx: 12},
 					},
+					nil,
 					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3},
 					[]sqlbase.ColumnType{strToType("B"), strToType("D"), strToType("C")},
 				)
@@ -254,6 +256,7 @@ func TestProjectionAndRendering(t *testing.T) {
 							Right:    &parser.IndexedVar{Idx: 2},
 						},
 					},
+					nil,
 					[]int{0, 1, 2},
 					[]sqlbase.ColumnType{strToType("X")},
 				)
@@ -285,6 +288,7 @@ func TestProjectionAndRendering(t *testing.T) {
 						},
 						&parser.IndexedVar{Idx: 10},
 					},
+					nil,
 					[]int{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2},
 					[]sqlbase.ColumnType{strToType("X"), strToType("A")},
 				)

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1771,6 +1771,7 @@ func (e *Executor) execStmtInOpenTxn(
 	p.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
 	p.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
 	p.semaCtx.Placeholders.Assign(pinfo)
+	p.evalCtx.Placeholders = &p.semaCtx.Placeholders
 	p.avoidCachedDescriptors = avoidCachedDescriptors
 	p.phaseTimes[plannerStartExecStmt] = timeutil.Now()
 	p.stmt = &stmt

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -142,8 +142,8 @@ func (p *planner) Explain(ctx context.Context, n *parser.Explain) (planNode, err
 	case explainPlan:
 		// We may want to show placeholder types, so ensure no values
 		// are missing.
-		p.semaCtx.Placeholders.FillUnassigned()
-		return p.makeExplainPlanNode(explainer, expanded, optimized, plan), nil
+		p.semaCtx.Placeholders.PermitUnassigned()
+		return p.makeExplainPlanNode(explainer, expanded, optimized, n.Statement, plan), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported EXPLAIN mode: %d", mode)

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -187,7 +187,7 @@ func (n *explainDistSQLNode) Start(params runParams) error {
 		return err
 	}
 
-	planCtx := n.distSQLPlanner.newPlanningCtx(params.ctx, n.txn)
+	planCtx := n.distSQLPlanner.newPlanningCtx(params.ctx, &params.p.evalCtx, n.txn)
 	plan, err := n.distSQLPlanner.createPlanForNode(&planCtx, n.plan)
 	if err != nil {
 		return err

--- a/pkg/sql/logictest/testdata/logic_test/explain_plan
+++ b/pkg/sql/logictest/testdata/logic_test/explain_plan
@@ -114,6 +114,18 @@ EXPLAIN (EXPRS) EXECUTE x(3)
 3  ·         table     t@primary
 3  ·         spans     ALL
 
+query ITTT
+EXPLAIN (EXPRS) SELECT * FROM [EXECUTE x(3)]
+----
+0  limit     ·         ·
+0  ·         count     3
+1  distinct  ·         ·
+2  render    ·         ·
+2  ·         render 0  v
+3  scan      ·         ·
+3  ·         table     t@primary
+3  ·         spans     ALL
+
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))
 

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -369,3 +369,19 @@ PREPARE outerStmt AS SELECT * FROM [EXECUTE innerStmt(3)] WHERE t = $1
 
 query error can't have more than 1 EXECUTE per statement
 SELECT * FROM [EXECUTE innerStmt(1)] CROSS JOIN [EXECUTE x]
+
+statement ok
+PREPARE selectin AS SELECT 1 in ($1, $2)
+
+statement ok
+PREPARE selectin2 AS SELECT $1::int in ($2, $3)
+
+query B
+EXECUTE selectin(5, 1)
+----
+true
+
+query B
+EXECUTE selectin2(1, 5, 1)
+----
+true

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -274,7 +274,7 @@ func (d *DBool) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DBool)
+	v, ok := UnwrapDatum(ctx, other).(*DBool)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -384,7 +384,7 @@ func (d *DInt) Compare(ctx *EvalContext, other Datum) int {
 		return 1
 	}
 	var v DInt
-	switch t := UnwrapDatum(other).(type) {
+	switch t := UnwrapDatum(ctx, other).(type) {
 	case *DInt:
 		v = *t
 	case *DFloat, *DDecimal:
@@ -487,7 +487,7 @@ func (d *DFloat) Compare(ctx *EvalContext, other Datum) int {
 		return 1
 	}
 	var v DFloat
-	switch t := UnwrapDatum(other).(type) {
+	switch t := UnwrapDatum(ctx, other).(type) {
 	case *DFloat:
 		v = *t
 	case *DInt:
@@ -640,7 +640,7 @@ func (d *DDecimal) Compare(ctx *EvalContext, other Datum) int {
 		return 1
 	}
 	v := ctx.getTmpDec()
-	switch t := UnwrapDatum(other).(type) {
+	switch t := UnwrapDatum(ctx, other).(type) {
 	case *DDecimal:
 		v = &t.Decimal
 	case *DInt:
@@ -780,14 +780,14 @@ func (d *DString) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := AsDString(other)
+	v, ok := UnwrapDatum(ctx, other).(*DString)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
-	if *d < v {
+	if *d < *v {
 		return -1
 	}
-	if *d > v {
+	if *d > *v {
 		return 1
 	}
 	return 0
@@ -918,7 +918,7 @@ func (d *DCollatedString) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DCollatedString)
+	v, ok := UnwrapDatum(ctx, other).(*DCollatedString)
 	if !ok || d.Locale != v.Locale {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -986,7 +986,7 @@ func (d *DBytes) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DBytes)
+	v, ok := UnwrapDatum(ctx, other).(*DBytes)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -1071,7 +1071,7 @@ func (d *DUuid) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DUuid)
+	v, ok := UnwrapDatum(ctx, other).(*DUuid)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -1185,7 +1185,7 @@ func (d *DIPAddr) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DIPAddr)
+	v, ok := UnwrapDatum(ctx, other).(*DIPAddr)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -1338,7 +1338,7 @@ func (d *DDate) Compare(ctx *EvalContext, other Datum) int {
 		return 1
 	}
 	var v DDate
-	switch t := other.(type) {
+	switch t := UnwrapDatum(ctx, other).(type) {
 	case *DDate:
 		v = *t
 	case *DTimestamp, *DTimestampTZ:
@@ -1547,6 +1547,7 @@ func (*DTimestamp) ResolvedType() Type {
 }
 
 func timeFromDatum(ctx *EvalContext, d Datum) (time.Time, bool) {
+	d = UnwrapDatum(ctx, d)
 	switch t := d.(type) {
 	case *DDate:
 		return MakeDTimestampTZFromDate(ctx.GetLocation(), t).Time, true
@@ -1867,7 +1868,7 @@ func (d *DInterval) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DInterval)
+	v, ok := UnwrapDatum(ctx, other).(*DInterval)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -1980,7 +1981,7 @@ func (d *DJSON) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DJSON)
+	v, ok := UnwrapDatum(ctx, other).(*DJSON)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -2084,7 +2085,7 @@ func (d *DTuple) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DTuple)
+	v, ok := UnwrapDatum(ctx, other).(*DTuple)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -2414,7 +2415,7 @@ func (d *DArray) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := AsDArray(other)
+	v, ok := UnwrapDatum(ctx, other).(*DArray)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -2645,7 +2646,7 @@ func (d *DOid) Compare(ctx *EvalContext, other Datum) int {
 		// NULL is less than any non-NULL value.
 		return 1
 	}
-	v, ok := other.(*DOid)
+	v, ok := UnwrapDatum(ctx, other).(*DOid)
 	if !ok {
 		panic(makeUnsupportedComparisonMessage(d, other))
 	}
@@ -2757,9 +2758,19 @@ func wrapWithOid(d Datum, oid oid.Oid) Datum {
 // UnwrapDatum returns the base Datum type for a provided datum, stripping
 // an *DOidWrapper if present. This is useful for cases like type switches,
 // where type aliases should be ignored.
-func UnwrapDatum(d Datum) Datum {
+func UnwrapDatum(evalCtx *EvalContext, d Datum) Datum {
 	if w, ok := d.(*DOidWrapper); ok {
 		return w.Wrapped
+	}
+	if p, ok := d.(*Placeholder); ok && evalCtx != nil && evalCtx.HasPlaceholders() {
+		ret, err := p.Eval(evalCtx)
+		if err != nil {
+			// If we fail to evaluate the placeholder, it's because we don't have
+			// a placeholder available. Just return the placeholder and someone else
+			// will handle this problem.
+			return d
+		}
+		return ret
 	}
 	return d
 }
@@ -2829,6 +2840,63 @@ func (d *DOidWrapper) Format(buf *bytes.Buffer, f FmtFlags) {
 // Size implements the Datum interface.
 func (d *DOidWrapper) Size() uintptr {
 	return unsafe.Sizeof(*d) + d.Wrapped.Size()
+}
+
+// AmbiguousFormat implements the Datum interface.
+func (d *Placeholder) AmbiguousFormat() bool {
+	return true
+}
+
+func (d *Placeholder) mustGetValue(ctx *EvalContext) Datum {
+	e, ok := ctx.Placeholders.Value(d.Name)
+	if !ok {
+		panic("fail")
+	}
+	out, err := e.Eval(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("fail %s", err))
+	}
+	return out
+}
+
+// Compare implements the Datum interface.
+func (d *Placeholder) Compare(ctx *EvalContext, other Datum) int {
+	return d.mustGetValue(ctx).Compare(ctx, other)
+}
+
+// Prev implements the Datum interface.
+func (d *Placeholder) Prev(ctx *EvalContext) (Datum, bool) {
+	return d.mustGetValue(ctx).Prev(ctx)
+}
+
+// IsMin implements the Datum interface.
+func (d *Placeholder) IsMin(ctx *EvalContext) bool {
+	return d.mustGetValue(ctx).IsMin(ctx)
+}
+
+// Next implements the Datum interface.
+func (d *Placeholder) Next(ctx *EvalContext) (Datum, bool) {
+	return d.mustGetValue(ctx).Next(ctx)
+}
+
+// IsMax implements the Datum interface.
+func (d *Placeholder) IsMax(ctx *EvalContext) bool {
+	return d.mustGetValue(ctx).IsMax(ctx)
+}
+
+// max implements the Datum interface.
+func (d *Placeholder) max(ctx *EvalContext) (Datum, bool) {
+	return d.mustGetValue(ctx).max(ctx)
+}
+
+// min implements the Datum interface.
+func (d *Placeholder) min(ctx *EvalContext) (Datum, bool) {
+	return d.mustGetValue(ctx).min(ctx)
+}
+
+// Size implements the Datum interface.
+func (d *Placeholder) Size() uintptr {
+	panic("shouldn't get called")
 }
 
 // NewDNameFromDString is a helper routine to create a *DName (implemented as

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -2425,7 +2425,7 @@ func (expr *CastExpr) Eval(ctx *EvalContext) (Datum, error) {
 	if d == DNull {
 		return d, nil
 	}
-	d = UnwrapDatum(d)
+	d = UnwrapDatum(ctx, d)
 	return performCast(ctx, d, expr.Type)
 }
 
@@ -2907,7 +2907,7 @@ func (expr *CollateExpr) Eval(ctx *EvalContext) (Datum, error) {
 	if err != nil {
 		return DNull, err
 	}
-	switch d := UnwrapDatum(d).(type) {
+	switch d := UnwrapDatum(ctx, d).(type) {
 	case *DString:
 		return NewDCollatedString(string(*d), expr.Locale, &ctx.collationEnv), nil
 	case *DCollatedString:
@@ -3349,9 +3349,37 @@ func (t *DOidWrapper) Eval(_ *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
-func (node *Placeholder) Eval(_ *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(
-		pgerror.CodeUndefinedParameterError, "no value provided for placeholder: $%s", node.Name)
+func (t *Placeholder) Eval(ctx *EvalContext) (Datum, error) {
+	if !ctx.HasPlaceholders() {
+		// While preparing a query, there will be no available placeholders. A
+		// placeholder evaluates to itself at this point.
+		return t, nil
+	}
+	e, ok := ctx.Placeholders.Value(t.Name)
+	if !ok {
+		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "missing value for placeholder %s", t.Name)
+	}
+	// Placeholder expressions cannot contain other placeholders, so we do
+	// not need to recurse.
+	typ, typed := ctx.Placeholders.Type(t.Name, false)
+	if !typed {
+		// All placeholders should be typed at this point.
+		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "missing type for placeholder %s", t.Name)
+	}
+	if !e.ResolvedType().Equivalent(typ) {
+		// This happens when we overrode the placeholder's type during type
+		// checking, since the placeholder's type hint didn't match the desired
+		// type for the placeholder. In this case, we cast the expression to
+		// the desired type.
+		// TODO(jordan): introduce a restriction on what casts are allowed here.
+		colType, err := DatumTypeToColumnType(typ)
+		if err != nil {
+			return nil, err
+		}
+		cast := &CastExpr{Expr: e, Type: colType}
+		return cast.Eval(ctx)
+	}
+	return e.Eval(ctx)
 }
 
 // Eval implements the TypedExpr interface.

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -2049,6 +2049,13 @@ type EvalContext struct {
 	// This must not be modified (this is shared from the session).
 	SearchPath SearchPath
 
+	// Placeholders relates placeholder names to their type and, later, value.
+	// This pointer should always be set to the location of the PlaceholderInfo
+	// in the corresponding SemaContext during normal execution. Placeholders are
+	// available during Eval to permit lookup of a particular placeholder's
+	// underlying datum, if available.
+	Placeholders *PlaceholderInfo
+
 	// CtxProvider holds the context in which the expression is evaluated. This
 	// will point to the session, which is itself a provider of contexts.
 	// NOTE: seems a bit lazy to hold a pointer to the session's context here,
@@ -2150,6 +2157,12 @@ func (ctx *EvalContext) GetClusterTimestampRaw() hlc.Timestamp {
 		panic("zero cluster timestamp in EvalContext")
 	}
 	return ctx.clusterTimestamp
+}
+
+// HasPlaceholders returns true if this EvalContext's placeholders have been
+// assigned. Will be false during Prepare.
+func (ctx *EvalContext) HasPlaceholders() bool {
+	return ctx.Placeholders != nil
 }
 
 // TimestampToDecimal converts the logical timestamp into a decimal

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -624,8 +624,6 @@ func (node DefaultVal) Format(buf *bytes.Buffer, f FmtFlags) {
 // ResolvedType implements the TypedExpr interface.
 func (DefaultVal) ResolvedType() Type { return nil }
 
-var _ VariableExpr = &Placeholder{}
-
 // Placeholder represents a named placeholder.
 type Placeholder struct {
 	Name string
@@ -637,9 +635,6 @@ type Placeholder struct {
 func NewPlaceholder(name string) *Placeholder {
 	return &Placeholder{Name: name}
 }
-
-// Variable implements the VariableExpr interface.
-func (*Placeholder) Variable() {}
 
 // Format implements the NodeFormatter interface.
 func (node *Placeholder) Format(buf *bytes.Buffer, f FmtFlags) {

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -643,6 +643,10 @@ func (*Placeholder) Variable() {}
 
 // Format implements the NodeFormatter interface.
 func (node *Placeholder) Format(buf *bytes.Buffer, f FmtFlags) {
+	if f.placeholderFormat != nil {
+		f.placeholderFormat(buf, f, node)
+		return
+	}
 	buf.WriteByte('$')
 	buf.WriteString(node.Name)
 }

--- a/pkg/sql/parser/format.go
+++ b/pkg/sql/parser/format.go
@@ -31,9 +31,9 @@ type fmtFlags struct {
 	// IndexedVarContainer.IndexedVarFormat calls; it can be used to
 	// customize the formatting of IndexedVars.
 	indexedVarFormat func(buf *bytes.Buffer, f FmtFlags, c IndexedVarContainer, idx int)
-	// starDatumFormat is an optional interceptor for StarDatum.Format calls,
-	// can be used to customize the formatting of StarDatums.
-	starDatumFormat func(buf *bytes.Buffer, f FmtFlags)
+	// placeholderFormat is an optional interceptor for Placeholder.Format calls;
+	// it can be used to format placeholders differently than normal.
+	placeholderFormat func(buf *bytes.Buffer, f FmtFlags, p *Placeholder)
 	// If true, non-function names are replaced by underscores.
 	anonymize bool
 	// If true, strings will be rendered without wrapping quotes if they
@@ -148,11 +148,13 @@ func FmtIndexedVarFormat(
 	return &f
 }
 
-// FmtStarDatumFormat returns FmtFlags that customizes the printing of
+// FmtPlaceholderFormat returns FmtFlags that customizes the printing of
 // StarDatums using the provided function.
-func FmtStarDatumFormat(base FmtFlags, fn func(buf *bytes.Buffer, f FmtFlags)) FmtFlags {
+func FmtPlaceholderFormat(
+	base FmtFlags, placeholderFn func(buf *bytes.Buffer, f FmtFlags, p *Placeholder),
+) FmtFlags {
 	f := *base
-	f.starDatumFormat = fn
+	f.placeholderFormat = placeholderFn
 	return &f
 }
 

--- a/pkg/sql/parser/hide_constants.go
+++ b/pkg/sql/parser/hide_constants.go
@@ -34,6 +34,9 @@ func formatNodeOrHideConstants(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
 					return
 				}
 			}
+		case *Placeholder:
+			// Placeholders should be printed as placeholder markers.
+			// Deliberately empty so we format as normal.
 		case Datum, Constant:
 			buf.WriteByte('_')
 			return

--- a/pkg/sql/parser/normalize.go
+++ b/pkg/sql/parser/normalize.go
@@ -95,7 +95,7 @@ func (expr *UnaryExpr) normalize(v *normalizeVisitor) TypedExpr {
 		return val
 	case UnaryMinus:
 		// -0 -> 0 (except for float which has negative zero)
-		if val.ResolvedType() != TypeFloat && IsNumericZero(val) {
+		if val.ResolvedType() != TypeFloat && v.isNumericZero(val) {
 			return val
 		}
 		switch b := val.(type) {
@@ -134,25 +134,25 @@ func (expr *BinaryExpr) normalize(v *normalizeVisitor) TypedExpr {
 
 	switch expr.Operator {
 	case Plus:
-		if IsNumericZero(right) {
+		if v.isNumericZero(right) {
 			final, v.err = ReType(left, expectedType)
 			break
 		}
-		if IsNumericZero(left) {
+		if v.isNumericZero(left) {
 			final, v.err = ReType(right, expectedType)
 			break
 		}
 	case Minus:
-		if IsNumericZero(right) {
+		if v.isNumericZero(right) {
 			final, v.err = ReType(left, expectedType)
 			break
 		}
 	case Mult:
-		if IsNumericOne(right) {
+		if v.isNumericOne(right) {
 			final, v.err = ReType(left, expectedType)
 			break
 		}
-		if IsNumericOne(left) {
+		if v.isNumericOne(left) {
 			final, v.err = ReType(right, expectedType)
 			break
 		}
@@ -160,7 +160,7 @@ func (expr *BinaryExpr) normalize(v *normalizeVisitor) TypedExpr {
 		// because if the other operand is NULL during evaluation
 		// the result must be NULL.
 	case Div, FloorDiv:
-		if IsNumericOne(right) {
+		if v.isNumericOne(right) {
 			final, v.err = ReType(left, expectedType)
 			break
 		}
@@ -357,7 +357,7 @@ func (expr *ComparisonExpr) normalize(v *normalizeVisitor) TypedExpr {
 				expr.Left = left.Left
 				expr.Right = newRightExpr
 				expr.memoizeFn()
-				if !isVar(expr.Left) {
+				if !isVar(v.ctx, expr.Left) {
 					// Continue as long as the left side of the comparison is not a
 					// variable.
 					continue
@@ -411,7 +411,7 @@ func (expr *ComparisonExpr) normalize(v *normalizeVisitor) TypedExpr {
 				expr.Left = left.Right
 				expr.Right = newRightExpr
 				expr.memoizeFn()
-				if !isVar(expr.Left) {
+				if !isVar(v.ctx, expr.Left) {
 					// Continue as long as the left side of the comparison is not a
 					// variable.
 					continue
@@ -593,6 +593,26 @@ func (expr *RangeCond) normalize(v *normalizeVisitor) TypedExpr {
 	return makeOpExpr(newLeft, newRight).normalize(v)
 }
 
+func (expr *Tuple) normalize(v *normalizeVisitor) TypedExpr {
+	// A Tuple should be directly evaluated into a DTuple if it's either fully
+	// constant or contains only constants and top-level Placeholders.
+	isConst := true
+	for _, subExpr := range expr.Exprs {
+		if !v.isConst(subExpr) {
+			isConst = false
+			break
+		}
+	}
+	if !isConst {
+		return expr
+	}
+	e, err := expr.Eval(v.ctx)
+	if err != nil {
+		v.err = err
+	}
+	return e
+}
+
 // NormalizeExpr normalizes a typed expression, simplifying where possible,
 // but guaranteeing that the result of evaluating the expression is
 // unchanged and that resulting expression tree is still well-typed.
@@ -604,7 +624,7 @@ func (expr *RangeCond) normalize(v *normalizeVisitor) TypedExpr {
 //   a BETWEEN b AND c     -> (a >= b) AND (a <= c)
 //   a NOT BETWEEN b AND c -> (a < b) OR (a > c)
 func (ctx *EvalContext) NormalizeExpr(typedExpr TypedExpr) (TypedExpr, error) {
-	v := normalizeVisitor{ctx: ctx}
+	v := makeNormalizeVisitor(ctx)
 	expr, _ := WalkExpr(&v, typedExpr)
 	if v.err != nil {
 		return nil, v.err
@@ -620,6 +640,11 @@ type normalizeVisitor struct {
 }
 
 var _ Visitor = &normalizeVisitor{}
+
+// makeNormalizeVisistor creates a normalizeVisistor instance.
+func makeNormalizeVisitor(ctx *EvalContext) normalizeVisitor {
+	return normalizeVisitor{ctx: ctx, isConstVisitor: isConstVisitor{ctx: ctx}}
+}
 
 func (v *normalizeVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	if v.err != nil {
@@ -656,6 +681,9 @@ func (v *normalizeVisitor) VisitPost(expr Expr) Expr {
 
 	// Evaluate all constant expressions.
 	if v.isConst(expr) {
+		if _, ok := expr.(*Placeholder); ok {
+			return expr
+		}
 		newExpr, err := expr.(TypedExpr).Eval(v.ctx)
 		if err != nil {
 			return expr
@@ -667,6 +695,38 @@ func (v *normalizeVisitor) VisitPost(expr Expr) Expr {
 
 func (v *normalizeVisitor) isConst(expr Expr) bool {
 	return v.isConstVisitor.run(expr)
+}
+
+// isNumericZero returns true if the datum is a number and equal to
+// zero.
+func (v *normalizeVisitor) isNumericZero(expr TypedExpr) bool {
+	if d, ok := expr.(Datum); ok {
+		switch t := UnwrapDatum(v.ctx, d).(type) {
+		case *DDecimal:
+			return t.Decimal.Sign() == 0
+		case *DFloat:
+			return *t == 0
+		case *DInt:
+			return *t == 0
+		}
+	}
+	return false
+}
+
+// isNumericOne returns true if the datum is a number and equal to
+// one.
+func (v *normalizeVisitor) isNumericOne(expr TypedExpr) bool {
+	if d, ok := expr.(Datum); ok {
+		switch t := UnwrapDatum(v.ctx, d).(type) {
+		case *DDecimal:
+			return t.Decimal.Cmp(&DecimalOne.Decimal) == 0
+		case *DFloat:
+			return *t == 1.0
+		case *DInt:
+			return *t == 1
+		}
+	}
+	return false
 }
 
 func invertComparisonOp(op ComparisonOperator) (ComparisonOperator, error) {
@@ -687,6 +747,7 @@ func invertComparisonOp(op ComparisonOperator) (ComparisonOperator, error) {
 }
 
 type isConstVisitor struct {
+	ctx     *EvalContext
 	isConst bool
 }
 
@@ -694,7 +755,7 @@ var _ Visitor = &isConstVisitor{}
 
 func (v *isConstVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	if v.isConst {
-		if isVar(expr) {
+		if isVar(v.ctx, expr) {
 			v.isConst = false
 			return false, expr
 		}
@@ -718,19 +779,27 @@ func (v *isConstVisitor) run(expr Expr) bool {
 	return v.isConst
 }
 
-func isVar(expr Expr) bool {
-	_, ok := expr.(VariableExpr)
-	return ok
+// isVar returns true if the expression's value can vary during plan
+// execution.
+func isVar(evalCtx *EvalContext, expr Expr) bool {
+	switch expr.(type) {
+	case VariableExpr:
+		return true
+	case *Placeholder:
+		return evalCtx != nil && (!evalCtx.HasPlaceholders() || evalCtx.Placeholders.IsUnresolvedPlaceholder(expr))
+	}
+	return false
 }
 
 type containsVarsVisitor struct {
+	evalCtx      *EvalContext
 	containsVars bool
 }
 
 var _ Visitor = &containsVarsVisitor{}
 
 func (v *containsVarsVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
-	if !v.containsVars && isVar(expr) {
+	if !v.containsVars && isVar(v.evalCtx, expr) {
 		v.containsVars = true
 	}
 	if v.containsVars {
@@ -743,8 +812,8 @@ func (*containsVarsVisitor) VisitPost(expr Expr) Expr { return expr }
 
 // ContainsVars returns true if the expression contains any variables.
 // (variables = sub-expressions, placeholders, indexed vars, etc.)
-func ContainsVars(expr Expr) bool {
-	v := containsVarsVisitor{containsVars: false}
+func ContainsVars(evalCtx *EvalContext, expr Expr) bool {
+	v := containsVarsVisitor{evalCtx: evalCtx, containsVars: false}
 	WalkExprConst(&v, expr)
 	return v.containsVars
 }
@@ -754,38 +823,6 @@ var DecimalOne DDecimal
 
 func init() {
 	DecimalOne.SetCoefficient(1)
-}
-
-// IsNumericZero returns true if the datum is a number and equal to
-// zero.
-func IsNumericZero(expr TypedExpr) bool {
-	if d, ok := expr.(Datum); ok {
-		switch t := UnwrapDatum(d).(type) {
-		case *DDecimal:
-			return t.Decimal.Sign() == 0
-		case *DFloat:
-			return *t == 0
-		case *DInt:
-			return *t == 0
-		}
-	}
-	return false
-}
-
-// IsNumericOne returns true if the datum is a number and equal to
-// one.
-func IsNumericOne(expr TypedExpr) bool {
-	if d, ok := expr.(Datum); ok {
-		switch t := UnwrapDatum(d).(type) {
-		case *DDecimal:
-			return t.Decimal.Cmp(&DecimalOne.Decimal) == 0
-		case *DFloat:
-			return *t == 1.0
-		case *DInt:
-			return *t == 1
-		}
-	}
-	return false
 }
 
 // ReType ensures that the given numeric expression evaluates

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -86,12 +86,7 @@ func TypeCheck(expr Expr, ctx *SemaContext, desired Type) (TypedExpr, error) {
 		panic("the desired type for parser.TypeCheck cannot be nil, use TypeAny instead")
 	}
 
-	expr, err := replacePlaceholders(expr, ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	expr, err = foldConstantLiterals(expr)
+	expr, err := foldConstantLiterals(expr)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +115,7 @@ func (p *Parser) NormalizeExpr(ctx *EvalContext, typedExpr TypedExpr) (TypedExpr
 	if ctx.SkipNormalize {
 		return typedExpr, nil
 	}
-	p.normalizeVisitor = normalizeVisitor{ctx: ctx}
+	p.normalizeVisitor = makeNormalizeVisitor(ctx)
 	expr, _ := WalkExpr(&p.normalizeVisitor, typedExpr)
 	if err := p.normalizeVisitor.err; err != nil {
 		return nil, err

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -104,7 +104,7 @@ func (b *writeBuffer) writeTextDatum(
 		b.putInt32(-1)
 		return
 	}
-	switch v := parser.UnwrapDatum(d).(type) {
+	switch v := parser.UnwrapDatum(nil, d).(type) {
 	case *parser.DBool:
 		b.putInt32(1)
 		if *v {
@@ -231,7 +231,7 @@ func (b *writeBuffer) writeBinaryDatum(
 		b.putInt32(-1)
 		return
 	}
-	switch v := parser.UnwrapDatum(d).(type) {
+	switch v := parser.UnwrapDatum(nil, d).(type) {
 	case *parser.DBool:
 		b.putInt32(1)
 		if *v {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -168,6 +168,8 @@ func makeInternalPlanner(
 		p.evalCtx.SetStmtTimestamp(ts)
 	}
 
+	p.evalCtx.Placeholders = &p.semaCtx.Placeholders
+
 	return p
 }
 
@@ -237,6 +239,7 @@ func (p *planner) makeInternalPlan(
 		return nil, err
 	}
 	golangFillQueryArguments(&p.semaCtx.Placeholders, args)
+	p.evalCtx.Placeholders = &p.semaCtx.Placeholders
 	return p.makePlan(ctx, Statement{AST: stmt})
 }
 

--- a/pkg/sql/prepare.go
+++ b/pkg/sql/prepare.go
@@ -353,7 +353,7 @@ func getPreparedStatementForExecute(
 	var p parser.Parser
 	for i, e := range s.Params {
 		idx := strconv.Itoa(i + 1)
-		typedExpr, err := sqlbase.SanitizeVarFreeExpr(e, prepared.TypeHints[idx], "EXECUTE parameter", session.SearchPath)
+		typedExpr, err := sqlbase.SanitizeVarFreeExpr(e, prepared.TypeHints[idx], "EXECUTE parameter", nil /* semaCtx */, nil /* evalCtx */)
 		if err != nil {
 			return ps, pInfo, pgerror.NewError(pgerror.CodeWrongObjectTypeError, err.Error())
 		}

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -396,7 +396,7 @@ func setTimeZone(_ context.Context, session *Session, values []parser.TypedExpr)
 
 	var loc *time.Location
 	var offset int64
-	switch v := parser.UnwrapDatum(d).(type) {
+	switch v := parser.UnwrapDatum(&evalCtx, d).(type) {
 	case *parser.DString:
 		location := string(*v)
 		loc, err = timeutil.LoadLocation(location)

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -63,13 +63,16 @@ func incompatibleExprTypeError(
 // type and contains no variable expressions. It returns the type-checked and
 // constant-folded expression.
 func SanitizeVarFreeExpr(
-	expr parser.Expr, expectedType parser.Type, context string, searchPath parser.SearchPath,
+	expr parser.Expr,
+	expectedType parser.Type,
+	context string,
+	semaCtx *parser.SemaContext,
+	evalCtx *parser.EvalContext,
 ) (parser.TypedExpr, error) {
-	if parser.ContainsVars(expr) {
+	if parser.ContainsVars(evalCtx, expr) {
 		return nil, exprContainsVarsError(context, expr)
 	}
-	ctx := parser.SemaContext{SearchPath: searchPath}
-	typedExpr, err := parser.TypeCheck(expr, &ctx, expectedType)
+	typedExpr, err := parser.TypeCheck(expr, semaCtx, expectedType)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +89,7 @@ func SanitizeVarFreeExpr(
 // index descriptor if the column is a primary key or unique.
 // The search path is used for name resolution for DEFAULT expressions.
 func MakeColumnDefDescs(
-	d *parser.ColumnTableDef, searchPath parser.SearchPath, evalCtx *parser.EvalContext,
+	d *parser.ColumnTableDef, semaCtx *parser.SemaContext, evalCtx *parser.EvalContext,
 ) (*ColumnDescriptor, *IndexDescriptor, error) {
 	col := &ColumnDescriptor{
 		Name:     string(d.Name),
@@ -151,8 +154,7 @@ func MakeColumnDefDescs(
 		col.Type.Width = int32(t.N)
 	case *parser.ArrayColType:
 		for i, e := range t.BoundsExprs {
-			ctx := parser.SemaContext{SearchPath: searchPath}
-			te, err := parser.TypeCheckAndRequire(e, &ctx, parser.TypeInt, "array bounds")
+			te, err := parser.TypeCheckAndRequire(e, semaCtx, parser.TypeInt, "array bounds")
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "couldn't get bound %d", i)
 			}
@@ -184,19 +186,19 @@ func MakeColumnDefDescs(
 	if d.HasDefaultExpr() {
 		// Verify the default expression type is compatible with the column type.
 		if _, err := SanitizeVarFreeExpr(
-			d.DefaultExpr.Expr, colDatumType, "DEFAULT", searchPath,
+			d.DefaultExpr.Expr, colDatumType, "DEFAULT", semaCtx, evalCtx,
 		); err != nil {
 			return nil, nil, err
 		}
 		var p parser.Parser
 		if err := p.AssertNoAggregationOrWindowing(
-			d.DefaultExpr.Expr, "DEFAULT expressions", searchPath,
+			d.DefaultExpr.Expr, "DEFAULT expressions", semaCtx.SearchPath,
 		); err != nil {
 			return nil, nil, err
 		}
 
 		// Type check and simplify: this performs constant folding and reduces the expression.
-		typedExpr, err := parser.TypeCheck(d.DefaultExpr.Expr, nil, col.Type.ToDatumType())
+		typedExpr, err := parser.TypeCheck(d.DefaultExpr.Expr, semaCtx, col.Type.ToDatumType())
 		if err != nil {
 			return nil, nil, err
 		}
@@ -492,7 +494,7 @@ func EncodeTableKey(b []byte, val parser.Datum, dir encoding.Direction) ([]byte,
 		return encoding.EncodeNullDescending(b), nil
 	}
 
-	switch t := parser.UnwrapDatum(val).(type) {
+	switch t := parser.UnwrapDatum(nil, val).(type) {
 	case *parser.DBool:
 		var x int64
 		if *t {
@@ -603,7 +605,7 @@ func EncodeTableValue(
 	if val == parser.DNull {
 		return encoding.EncodeNullValue(appendTo, uint32(colID)), nil
 	}
-	switch t := parser.UnwrapDatum(val).(type) {
+	switch t := parser.UnwrapDatum(nil, val).(type) {
 	case *parser.DBool:
 		return encoding.EncodeBoolValue(appendTo, uint32(colID), bool(*t)), nil
 	case *parser.DInt:


### PR DESCRIPTION
Had to recreate this - apparently, you can't re-open a PR (#19424) if you force pushed to it while it was closed. I resolved all the comments from the previous PR.

Previously, the Placeholder expression type was merely a marker that
was replaced during type checking with an actual Datum value by a tree
traversal.

This was inefficient - every query with placeholders would end up
getting path-copied during that replacement step. Additionally, it was
an obstacle to optimizations like plan caching that requires that
expression trees retain their meaning after type checking.

Now, a Placeholder is a fully-fledged Datum that can be evaluated.
Evaluating a Placeholder returns the Datum that it points to in the
PlaceholderInfo map.

This transformation required a lot of plumbing, which makes up the bulk
of this patch. EvalContext had to be augmented to include a
PlaceholderInfo map so that the placeholder values can be known at
Placeholder.Eval() time. EvalContexts and SemaContexts also needed
to be plumbed to every place that needs to check for constant
expressions, since checking for constant expressions now requires that
placeholder values be known (placeholders without values are not
constant expressions; placeholders with values are).