### PR TITLE
sql: restrict when EXECUTE can be used

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -361,17 +361,11 @@ EXECUTE sets('hello')
 statement error could not determine data type of placeholder
 PREPARE x19597 AS SELECT $1 IN ($2, null);
 
-# Regression for #19716: ensure that placeholders for EXECUTE statements inside
-# of PREPARE statements are properly segregated from those of the outer
-# statement.
-
 statement ok
 PREPARE innerStmt AS SELECT $1:::int i, 'foo' t
 
-statement ok
+statement error can't prepare an EXECUTE statement
 PREPARE outerStmt AS SELECT * FROM [EXECUTE innerStmt(3)] WHERE t = $1
 
-query IT
-EXECUTE outerStmt('foo')
-----
-3 foo
+query error can't have more than 1 EXECUTE per statement
+SELECT * FROM [EXECUTE innerStmt(1)] CROSS JOIN [EXECUTE x]

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -473,6 +473,7 @@ func (p *planner) prepare(ctx context.Context, stmt parser.Statement) (planNode,
 	if plan, err := p.maybePlanHook(ctx, stmt); plan != nil || err != nil {
 		return plan, err
 	}
+	p.isPreparing = true
 
 	switch n := stmt.(type) {
 	case *parser.AlterUserSetPassword:

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -97,6 +97,10 @@ type planner struct {
 	// hasSubqueries collects whether any subqueries expansion has
 	// occurred during logical plan construction.
 	hasSubqueries bool
+	// isPreparing is true if this planner is currently preparing.
+	isPreparing bool
+	// plannedExecute is true if this planner has planned an EXECUTE statement.
+	plannedExecute bool
 
 	// Avoid allocations by embedding commonly used objects and visitors.
 	parser                parser.Parser


### PR DESCRIPTION
This commit prevents users from using `EXECUTE` inside of `PREPARE`
statements and alongside other `EXECUTE` statements, both of which are
made possible by the `... FROM [<stmt>]` syntax.

For example, `PREPARE x AS SELECT * FROM [EXECUTE y]` is no longer
permitted. Nor is `SELECT * FROM [EXECUTE x] CROSS JOIN [execute y]`.

It's difficult to properly support this, because special care must be
taken all over the place to maintain a proper stack of prepared
statement parameters. It's also currently buggy, despite the effort made
in #19720. The problem is `EXPLAIN` statements - since `EXECUTE`
statements don't get their own plan nodes, the `EXPLAIN` plan walker has
no ability to maintain a prepared statement argument stack, since
there's no marker inside of a plan tree for where an `EXECUTE` with
parameters begins. There's no technical reason why a new plan node for
`EXECUTE` couldn't be added, but it seems like extra complexity for no
reason at the moment.

Reverts #19720.