### PR TITLE
build: ensure libroach expresses dependency on protobufs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,10 +337,6 @@ unsafe-clean: maintainer-clean unsafe-clean-c-deps
 protobuf: ## Regenerate generated code for protobuf definitions.
 	$(MAKE) -C $(ORG_ROOT) -f cockroach/build/protobuf.mk
 
-.PHONY: ui
-ui: libprotobuf
-	$(MAKE) -C $(UI_ROOT) generate
-
 # pre-push locally runs most of the checks CI will run. Notably, it doesn't run
 # the acceptance tests.
 .PHONY: pre-push

--- a/build/common.mk
+++ b/build/common.mk
@@ -125,6 +125,10 @@ $(foreach v,$(filter-out $(strip $(VALID_VARS)),$(.VARIABLES)),\
 .ALWAYS_REBUILD:
 .PHONY: .ALWAYS_REBUILD
 
+.PHONY: ui
+ui: libprotobuf
+	$(MAKE) -C $(UI_ROOT) generate
+
 ifneq ($(GIT_DIR),)
 # If we're in a git worktree, the git hooks directory may not be in our root,
 # so we ask git for the location.
@@ -449,8 +453,13 @@ libsnappy: $(SNAPPY_DIR)/Makefile
 librocksdb: $(ROCKSDB_DIR)/Makefile
 	@$(MAKE) --no-print-directory -C $(ROCKSDB_DIR) rocksdb
 
+# libroach depends on ui because generating the UI indirectly updates the
+# timestamps on the generated C++ protobufs that libroach depends on.
+#
+# TODO(benesch): merge the protobuf, UI, and top-level Makefile so this
+# dependency can be clearly expressed.
 .PHONY: libroach
-libroach: $(LIBROACH_DIR)/Makefile
+libroach: $(LIBROACH_DIR)/Makefile | ui
 	@$(MAKE) --no-print-directory -C $(LIBROACH_DIR) roach
 
 .PHONY: libroachccl


### PR DESCRIPTION
libroach currently has an implicit dependency on the generated C++
protobufs; make it explicit to avoid unnecessary rebuilds when
timestamps on the generated files are updated after libroach has
finished building.