### PR TITLE
build: fail if TESTS specified without PKG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,15 @@
 # `help` target. They look a bit awkward in the variable declarations below
 # since any whitespace added would become part of the variable's default value.
 
+ifeq ($(PKG),)
+ifneq ($(TESTS),)
+$(error TESTS must be specified with PKG (e.g. PKG=./pkg/sql/))
+endif
+ifneq ($(BENCHES),)
+$(error BENCHES must be specified with PKG (e.g. PKG=./pkg/sql/))
+endif
+endif
+
 PKG          := ./pkg/...## Which package to run tests against, e.g. "./pkg/storage".
 TAGS         :=
 


### PR DESCRIPTION
A common error is to try to run a named test or benchmark with TESTS= or
BENCHES= without remembering to specify the package that the test is in
with PKG=. Doing this is always(?) a waste of time and requires a ctrl-c
and re-run. Prevent this failure mode by failing in this case.

Users that really want to run a named test against all packages can
specify PKG=./... to get that behavior.