### PR TITLE
sql: allow arrays to be cast to their own type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -125,6 +125,23 @@ SELECT '{hello}'::VARCHAR(2)[]
 ----
 {"he"}
 
+# array casting
+
+query T
+SELECT ARRAY[1,2,3]::INT[]
+----
+{1,2,3}
+
+query error invalid cast: int[] -> UUID[]
+SELECT ARRAY[1,2,3]::UUID[]
+
+query error invalid cast: inet[] -> INT[]
+SELECT ARRAY['8.8.8.8'::INET, '8.8.4.4'::INET]::INT[]
+
+# this _should_ be valid, but isn't, yet
+query error invalid cast: int[] -> TEXT[]
+SELECT ARRAY[1,2,3]::TEXT[]
+
 # array subscript access
 
 query T

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2740,8 +2740,13 @@ func performCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 			return v, nil
 		}
 	case *coltypes.TArray:
-		if s, ok := d.(*DString); ok {
-			return ParseDArrayFromString(ctx, string(*s), typ.ParamType)
+		switch v := d.(type) {
+		case *DString:
+			return ParseDArrayFromString(ctx, string(*v), typ.ParamType)
+		case *DArray:
+			if (*v).ParamTyp == coltypes.CastTargetToDatumType((*typ).ParamType) {
+				return d, nil
+			}
 		}
 	case *coltypes.TOid:
 		switch v := d.(type) {

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1210,7 +1210,10 @@ func validCastTypes(t types.T) []types.T {
 		if t.FamilyEqual(types.FamCollatedString) {
 			return stringCastTypes
 		} else if t.FamilyEqual(types.FamArray) {
-			return arrayCastTypes
+			ret := make([]types.T, len(arrayCastTypes)+1)
+			copy(ret, arrayCastTypes)
+			ret[len(ret)-1] = t
+			return ret
 		}
 		return nil
 	}


### PR DESCRIPTION
@jordanlewis 

I ran into #13651 while trying to use epgsql against cockroach, which [runs some queries under the hood](https://github.com/epgsql/epgsql/blob/3652aa9c0a7cb58beb4736cdbdfa0dc4f7eafa20/src/epgsql.erl#L181) that contain array casts.

#13651 mentions that there's a test for this, here: https://github.com/cockroachdb/cockroach/blob/0c8b4d9370caedce43caacd339d99f5993ece257/pkg/sql/pgwire/pgwire_test.go#L879

Unfortunately the test doesn't pass; with this patch the error changes from the previous "invalid cast: int[] -> INT[]", to the following:

```
--- FAIL: TestPGPreparedQuery (0.34s)
    --- FAIL: TestPGPreparedQuery/exec (0.11s)
        --- FAIL: TestPGPreparedQuery/exec/SELECT_$1::INT[] (0.00s)
            --- FAIL: TestPGPreparedQuery/exec/SELECT_$1::INT[]/0 (0.00s)
                pgwire_test.go:945: sql: Scan error on column index 0: pq: destination <nil> is not a pointer to array or slice
                pgwire_test.go:951: SELECT $1::INT[]: [{[10]}]: expected [{[10]}], got [{<nil>}]
    --- FAIL: TestPGPreparedQuery/prepare (0.04s)
        --- FAIL: TestPGPreparedQuery/prepare/SELECT_$1::INT[] (0.00s)
            --- FAIL: TestPGPreparedQuery/prepare/SELECT_$1::INT[]/0 (0.00s)
                pgwire_test.go:945: sql: Scan error on column index 0: pq: destination <nil> is not a pointer to array or slice
                pgwire_test.go:951: SELECT $1::INT[]: [{[10]}]: expected [{[10]}], got [{<nil>}]
```

having stared at the referenced code for a bit, I think the test framework in there has troubles with arrays, but my go skills are insufficient at this point to sort it out. So I left that test commented out, and included another test of the fix in sql/logictest/testdata/logic_test/array; hopefully that's sufficient.

Do let me know if there's anything more I can do, here.