### PR TITLE
sql: ensure that DELETE on the fast path is still a valid data source

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -132,8 +132,7 @@ func (d *deleteNode) Start(params runParams) error {
 	}
 	if scan, ok := maybeScan.(*scanNode); ok && canDeleteWithoutScan(params.ctx, d.n, scan, &d.tw) {
 		d.run.fastPath = true
-		err := d.fastDelete(params.ctx, scan)
-		return err
+		return d.fastDelete(params.ctx, scan)
 	}
 
 	return d.run.tw.init(d.p.txn)
@@ -154,6 +153,10 @@ func (d *deleteNode) FastPathResults() (int, bool) {
 }
 
 func (d *deleteNode) Next(params runParams) (bool, error) {
+	if d.run.fastPath {
+		return false, nil
+	}
+
 	traceKV := d.p.session.Tracing.KVTracingEnabled()
 
 	next, err := d.run.rows.Next(params)

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -242,3 +242,10 @@ EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 3  ·           limit  10
 3  scan        ·      ·
 3  ·           table  indexed@primary
+
+# Ensure that if the fast path is selected, DELETE is still a valid
+# data source (#19805).
+query I
+INSERT INTO indexed(id,value) VALUES (1,2); SELECT 1 FROM [DELETE FROM indexed]
+----
+1

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -112,7 +112,8 @@ type planNode interface {
 	// See executor.go: forEachRow() for an example.
 	//
 	// Available after Start(). It is illegal to call Next() after it returns
-	// false.
+	// false. It is legal to call Next() even if the node implements
+	// planNodeFastPath and the FastPathResults() method returns true.
 	Next(params runParams) (bool, error)
 
 	// Values returns the values at the current row. The result is only valid
@@ -134,6 +135,8 @@ type planNode interface {
 type planNodeFastPath interface {
 	// FastPathResults returns the affected row count and true if the
 	// node has no result set and has already executed when Start() completes.
+	// Note that Next() must still be valid even if this method returns
+	// true, although it may have nothing left to do.
 	FastPathResults() (int, bool)
 }
 


### PR DESCRIPTION
Prior to this patch, the DELETE statement without WHERE and RETURNING
would use the "fast path", that is, all the work being done in Start().

The code for this would however violate the `planNode` interface
contract: after the fast path is taken, the code would panic if the
`Next()` method is called. `planNode` specifies that `Next()` is
always callable after `Start()`, although perhaps it has nothing to
do.

Fixes #19805.