### PR TITLE
sql: extract zone config test helpers

### DIFF
--- a/pkg/sql/zone_test.go
+++ b/pkg/sql/zone_test.go
@@ -15,21 +15,17 @@
 package sql_test
 
 import (
-	gosql "database/sql"
 	"fmt"
 	"testing"
 
 	"golang.org/x/net/context"
-	yaml "gopkg.in/yaml.v2"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 )
 
 func TestValidSetShowZones(t *testing.T) {
@@ -42,170 +38,140 @@ func TestValidSetShowZones(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(t, db)
 	sqlDB.Exec(`CREATE DATABASE d; USE d; CREATE TABLE t ();`)
 
-	type zoneRow struct {
-		id           uint32
-		cliSpecifier string
-		config       config.ZoneConfig
-	}
-
-	rowToString := func(row zoneRow) []string {
-		configProto, err := protoutil.Marshal(&row.config)
-		if err != nil {
-			t.Fatal(err)
-		}
-		configYAML, err := yaml.Marshal(row.config)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return []string{
-			fmt.Sprintf("%d", row.id),
-			row.cliSpecifier,
-			string(configYAML),
-			string(configProto),
-		}
-	}
-
-	deleteZoneConfig := func(target string) {
-		t.Helper()
-		sqlDB.Exec(fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE NULL", target))
-	}
-
-	setZoneConfig := func(target string, config string) {
-		t.Helper()
-		sqlDB.Exec(fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE %s",
-			target, parser.EscapeSQLString(config)))
-	}
-
-	txnSetZoneConfig := func(txn *gosql.Tx, target string, config string) {
-		t.Helper()
-		_, err := txn.Exec(fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE %s",
-			target, parser.EscapeSQLString(config)))
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	verifyZoneConfig := func(target string, row zoneRow) {
-		t.Helper()
-		sqlDB.CheckQueryResults(fmt.Sprintf("EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s", target),
-			[][]string{rowToString(row)})
-	}
-
-	verifyZoneConfigs := func(rows ...zoneRow) {
-		t.Helper()
-		expected := make([][]string, len(rows))
-		for i, row := range rows {
-			expected[i] = rowToString(row)
-		}
-		sqlDB.CheckQueryResults("EXPERIMENTAL SHOW ALL ZONE CONFIGURATIONS", expected)
-	}
-
 	yamlDefault := fmt.Sprintf("gc: {ttlseconds: %d}", config.DefaultZoneConfig().GC.TTLSeconds)
 	yamlOverride := "gc: {ttlseconds: 42}"
 	zoneOverride := config.DefaultZoneConfig()
 	zoneOverride.GC.TTLSeconds = 42
 
-	defaultRow := zoneRow{keys.RootNamespaceID, ".default", config.DefaultZoneConfig()}
-	defaultOverrideRow := zoneRow{keys.RootNamespaceID, ".default", zoneOverride}
-	metaRow := zoneRow{keys.MetaRangesID, ".meta", zoneOverride}
-	systemRow := zoneRow{keys.SystemDatabaseID, "system", zoneOverride}
-	jobsRow := zoneRow{keys.JobsTableID, "system.jobs", zoneOverride}
-	dbRow := zoneRow{keys.MaxReservedDescID + 1, "d", zoneOverride}
-	tableRow := zoneRow{keys.MaxReservedDescID + 2, "d.t", zoneOverride}
+	defaultRow := sqlutils.ZoneRow{
+		ID:           keys.RootNamespaceID,
+		CLISpecifier: ".default",
+		Config:       config.DefaultZoneConfig(),
+	}
+	defaultOverrideRow := sqlutils.ZoneRow{
+		ID:           keys.RootNamespaceID,
+		CLISpecifier: ".default",
+		Config:       zoneOverride,
+	}
+	metaRow := sqlutils.ZoneRow{
+		ID:           keys.MetaRangesID,
+		CLISpecifier: ".meta",
+		Config:       zoneOverride,
+	}
+	systemRow := sqlutils.ZoneRow{
+		ID:           keys.SystemDatabaseID,
+		CLISpecifier: "system",
+		Config:       zoneOverride,
+	}
+	jobsRow := sqlutils.ZoneRow{
+		ID:           keys.JobsTableID,
+		CLISpecifier: "system.jobs",
+		Config:       zoneOverride,
+	}
+	dbRow := sqlutils.ZoneRow{
+		ID:           keys.MaxReservedDescID + 1,
+		CLISpecifier: "d",
+		Config:       zoneOverride,
+	}
+	tableRow := sqlutils.ZoneRow{
+		ID:           keys.MaxReservedDescID + 2,
+		CLISpecifier: "d.t",
+		Config:       zoneOverride,
+	}
 
 	// Ensure the default is reported for all zones at first.
-	verifyZoneConfigs(defaultRow)
-	verifyZoneConfig("RANGE default", defaultRow)
-	verifyZoneConfig("RANGE meta", defaultRow)
-	verifyZoneConfig("DATABASE system", defaultRow)
-	verifyZoneConfig("TABLE system.lease", defaultRow)
-	verifyZoneConfig("DATABASE d", defaultRow)
-	verifyZoneConfig("TABLE d.t", defaultRow)
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE default", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE meta", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE system", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE system.lease", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", defaultRow)
 
 	// Ensure a database zone config applies to that database and its tables, and
 	// no other zones.
-	setZoneConfig("DATABASE d", yamlOverride)
-	verifyZoneConfigs(defaultRow, dbRow)
-	verifyZoneConfig("RANGE meta", defaultRow)
-	verifyZoneConfig("DATABASE system", defaultRow)
-	verifyZoneConfig("TABLE system.lease", defaultRow)
-	verifyZoneConfig("DATABASE d", dbRow)
-	verifyZoneConfig("TABLE d.t", dbRow)
+	sqlutils.SetZoneConfig(sqlDB, "DATABASE d", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow, dbRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE meta", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE system", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE system.lease", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", dbRow)
 
 	// Ensure a table zone config applies to that table and no others.
-	setZoneConfig("TABLE d.t", yamlOverride)
-	verifyZoneConfigs(defaultRow, dbRow, tableRow)
-	verifyZoneConfig("RANGE meta", defaultRow)
-	verifyZoneConfig("DATABASE system", defaultRow)
-	verifyZoneConfig("TABLE system.lease", defaultRow)
-	verifyZoneConfig("DATABASE d", dbRow)
-	verifyZoneConfig("TABLE d.t", tableRow)
+	sqlutils.SetZoneConfig(sqlDB, "TABLE d.t", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow, dbRow, tableRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE meta", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE system", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE system.lease", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", tableRow)
 
 	// Ensure a named zone config applies to that named zone and no others.
-	setZoneConfig("RANGE meta", yamlOverride)
-	verifyZoneConfigs(defaultRow, metaRow, dbRow, tableRow)
-	verifyZoneConfig("RANGE meta", metaRow)
-	verifyZoneConfig("DATABASE system", defaultRow)
-	verifyZoneConfig("TABLE system.lease", defaultRow)
-	verifyZoneConfig("DATABASE d", dbRow)
-	verifyZoneConfig("TABLE d.t", tableRow)
+	sqlutils.SetZoneConfig(sqlDB, "RANGE meta", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow, metaRow, dbRow, tableRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE meta", metaRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE system", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE system.lease", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", tableRow)
 
 	// Ensure updating the default zone propagates to zones without an override,
 	// but not to those with overrides.
-	setZoneConfig("RANGE default", yamlOverride)
-	verifyZoneConfigs(defaultOverrideRow, metaRow, dbRow, tableRow)
-	verifyZoneConfig("RANGE meta", metaRow)
-	verifyZoneConfig("DATABASE system", defaultOverrideRow)
-	verifyZoneConfig("TABLE system.lease", defaultOverrideRow)
-	verifyZoneConfig("DATABASE d", dbRow)
-	verifyZoneConfig("TABLE d.t", tableRow)
+	sqlutils.SetZoneConfig(sqlDB, "RANGE default", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultOverrideRow, metaRow, dbRow, tableRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE meta", metaRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE system", defaultOverrideRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE system.lease", defaultOverrideRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", tableRow)
 
 	// Ensure deleting a database deletes only the database zone, and not the
 	// table zone.
-	deleteZoneConfig("DATABASE d")
-	verifyZoneConfigs(defaultOverrideRow, metaRow, tableRow)
-	verifyZoneConfig("DATABASE d", defaultOverrideRow)
-	verifyZoneConfig("TABLE d.t", tableRow)
+	sqlutils.DeleteZoneConfig(sqlDB, "DATABASE d")
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultOverrideRow, metaRow, tableRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", defaultOverrideRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", tableRow)
 
 	// Ensure deleting a table zone works.
-	deleteZoneConfig("TABLE d.t")
-	verifyZoneConfigs(defaultOverrideRow, metaRow)
-	verifyZoneConfig("TABLE d.t", defaultOverrideRow)
+	sqlutils.DeleteZoneConfig(sqlDB, "TABLE d.t")
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultOverrideRow, metaRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", defaultOverrideRow)
 
 	// Ensure deleting a named zone works.
-	deleteZoneConfig("RANGE meta")
-	verifyZoneConfigs(defaultOverrideRow)
-	verifyZoneConfig("RANGE meta", defaultOverrideRow)
+	sqlutils.DeleteZoneConfig(sqlDB, "RANGE meta")
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultOverrideRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE meta", defaultOverrideRow)
 
 	// Ensure deleting non-overridden zones is not an error.
-	deleteZoneConfig("RANGE meta")
-	deleteZoneConfig("DATABASE d")
-	deleteZoneConfig("TABLE d.t")
+	sqlutils.DeleteZoneConfig(sqlDB, "RANGE meta")
+	sqlutils.DeleteZoneConfig(sqlDB, "DATABASE d")
+	sqlutils.DeleteZoneConfig(sqlDB, "TABLE d.t")
 
 	// Ensure updating the default zone config applies to zones that have had
 	// overrides added and removed.
-	setZoneConfig("RANGE default", yamlDefault)
-	verifyZoneConfigs(defaultRow)
-	verifyZoneConfig("RANGE default", defaultRow)
-	verifyZoneConfig("RANGE meta", defaultRow)
-	verifyZoneConfig("DATABASE system", defaultRow)
-	verifyZoneConfig("TABLE system.lease", defaultRow)
-	verifyZoneConfig("DATABASE d", defaultRow)
-	verifyZoneConfig("TABLE d.t", defaultRow)
+	sqlutils.SetZoneConfig(sqlDB, "RANGE default", yamlDefault)
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE default", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE meta", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE system", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE system.lease", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", defaultRow)
 
 	// Ensure the system database zone can be configured, even though zones on
 	// config tables are disallowed.
-	setZoneConfig("DATABASE system", yamlOverride)
-	verifyZoneConfigs(defaultRow, systemRow)
-	verifyZoneConfig("DATABASE system", systemRow)
-	verifyZoneConfig("TABLE system.namespace", systemRow)
-	verifyZoneConfig("TABLE system.jobs", systemRow)
+	sqlutils.SetZoneConfig(sqlDB, "DATABASE system", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow, systemRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE system", systemRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE system.namespace", systemRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE system.jobs", systemRow)
 
 	// Ensure zones for non-config tables in the system database can be
 	// configured.
-	setZoneConfig("TABLE system.jobs", yamlOverride)
-	verifyZoneConfigs(defaultRow, systemRow, jobsRow)
-	verifyZoneConfig("TABLE system.jobs", jobsRow)
+	sqlutils.SetZoneConfig(sqlDB, "TABLE system.jobs", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow, systemRow, jobsRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE system.jobs", jobsRow)
 
 	// Ensure zone configs are read transactionally instead of from the cached
 	// system config.
@@ -213,12 +179,12 @@ func TestValidSetShowZones(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	txnSetZoneConfig(txn, "RANGE default", yamlOverride)
-	txnSetZoneConfig(txn, "TABLE d.t", "") // this should pick up the overridden default config
+	sqlutils.TxnSetZoneConfig(sqlDB, txn, "RANGE default", yamlOverride)
+	sqlutils.TxnSetZoneConfig(sqlDB, txn, "TABLE d.t", "") // this should pick up the overridden default config
 	if err := txn.Commit(); err != nil {
 		t.Fatal(err)
 	}
-	verifyZoneConfig("TABLE d.t", tableRow)
+	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", tableRow)
 }
 
 func TestInvalidSetShowZones(t *testing.T) {

--- a/pkg/testutils/sqlutils/zone.go
+++ b/pkg/testutils/sqlutils/zone.go
@@ -1,0 +1,101 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlutils
+
+import (
+	gosql "database/sql"
+	"fmt"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+)
+
+// ZoneRow represents a row returned by EXPERIMENTAL SHOW ZONE CONFIGURATION.
+type ZoneRow struct {
+	ID           uint32
+	CLISpecifier string
+	Config       config.ZoneConfig
+}
+
+func (row ZoneRow) sqlRowString() ([]string, error) {
+	configProto, err := protoutil.Marshal(&row.Config)
+	if err != nil {
+		return nil, err
+	}
+	configYAML, err := yaml.Marshal(row.Config)
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		fmt.Sprintf("%d", row.ID),
+		row.CLISpecifier,
+		string(configYAML),
+		string(configProto),
+	}, nil
+}
+
+// DeleteZoneConfig deletes the specified zone config through the SQL interface.
+func DeleteZoneConfig(sqlDB *SQLRunner, target string) {
+	sqlDB.Helper()
+	sqlDB.Exec(fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE NULL", target))
+}
+
+// SetZoneConfig updates the specified zone config through the SQL interface.
+func SetZoneConfig(sqlDB *SQLRunner, target string, config string) {
+	sqlDB.Helper()
+	sqlDB.Exec(fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE %s",
+		target, parser.EscapeSQLString(config)))
+}
+
+// TxnSetZoneConfig updates the specified zone config through the SQL interface
+// using the provided transaction.
+func TxnSetZoneConfig(sqlDB *SQLRunner, txn *gosql.Tx, target string, config string) {
+	sqlDB.Helper()
+	_, err := txn.Exec(fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE %s",
+		target, parser.EscapeSQLString(config)))
+	if err != nil {
+		sqlDB.Fatal(err)
+	}
+}
+
+// VerifyZoneConfigForTarget verifies that the specified zone matches the specified
+// ZoneRow.
+func VerifyZoneConfigForTarget(sqlDB *SQLRunner, target string, row ZoneRow) {
+	sqlDB.Helper()
+	sqlRow, err := row.sqlRowString()
+	if err != nil {
+		sqlDB.Fatal(err)
+	}
+	sqlDB.CheckQueryResults(fmt.Sprintf("EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s", target),
+		[][]string{sqlRow})
+}
+
+// VerifyAllZoneConfigs verifies that the specified ZoneRows exactly match the
+// list of active zone configs.
+func VerifyAllZoneConfigs(sqlDB *SQLRunner, rows ...ZoneRow) {
+	sqlDB.Helper()
+	expected := make([][]string, len(rows))
+	for i, row := range rows {
+		var err error
+		expected[i], err = row.sqlRowString()
+		if err != nil {
+			sqlDB.Fatal(err)
+		}
+	}
+	sqlDB.CheckQueryResults("EXPERIMENTAL SHOW ALL ZONE CONFIGURATIONS", expected)
+}


### PR DESCRIPTION
Setting zone configs on indexes and partitions will be CCL-only. Extract
helpers from TestValidSetShowZones so we can write a similar test for
index/partition zones in CCL code.