### PR TITLE
cherry-pick 1.1: distsqlrun: fix a double close of the merge joiner output

### DIFF
--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -133,8 +133,9 @@ func (m *mergeJoiner) outputBatch(
 				if matchedRight != nil {
 					matchedRight[rIdx] = true
 				}
-				if !emitHelper(ctx, &m.out, renderedRow, ProducerMetadata{}) {
-					return false, nil
+				consumerStatus, err := m.out.EmitRow(ctx, renderedRow)
+				if err != nil || consumerStatus != NeedMoreRows {
+					return false, err
 				}
 			}
 		}


### PR DESCRIPTION
Cherry-pick first commit from #19794
cc @cockroachdb/release 

This patch fixes a bug that caused us to call ProducerDone() twice on
the output of a mergeJoiner in case outputting a matched row encountered
an error or a closed consumer. This was a panic.