### PR TITLE
storage: make ReplicaEvalContext the interface

### DIFF
--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -112,10 +112,7 @@ func evalExport(
 	// threshold. If it's not, the mvcc tombstones could have been deleted and
 	// the resulting RocksDB tombstones compacted, which means we'd miss
 	// deletions in the incremental backup.
-	gcThreshold, err := cArgs.EvalCtx.GetGCThreshold()
-	if err != nil {
-		return storage.EvalResult{}, err
-	}
+	gcThreshold := cArgs.EvalCtx.GetGCThreshold()
 	if args.StartTime != (hlc.Timestamp{}) {
 		if !gcThreshold.Less(args.StartTime) {
 			return storage.EvalResult{}, errors.Errorf("start timestamp %v must be after replica GC threshold %v", args.StartTime, gcThreshold)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -460,7 +460,7 @@ type Replica struct {
 	}
 }
 
-var _ ReplicaI = &Replica{}
+var _ ReplicaEvalContext = &Replica{}
 
 // KeyRange is an interface type for the replicasByKey BTree, to compare
 // Replica and ReplicaPlaceholder.
@@ -2438,7 +2438,7 @@ func (r *Replica) executeAdminBatch(
 
 	case *roachpb.ImportRequest:
 		cArgs := CommandArgs{
-			EvalCtx: ReplicaEvalContext{r, nil},
+			EvalCtx: NewReplicaEvalContext(r, &SpanSet{}),
 			Header:  ba.Header,
 			Args:    args,
 		}
@@ -2519,7 +2519,7 @@ func (r *Replica) executeReadOnlyBatch(
 	// that holding readOnlyCmdMu throughout is important to avoid reads from the
 	// "wrong" key range being served after the range has been split.
 	var result EvalResult
-	rec := ReplicaEvalContext{r, spans}
+	rec := NewReplicaEvalContext(r, spans)
 	readOnly := r.store.Engine().NewReadOnly()
 	defer readOnly.Close()
 	br, result, pErr = evaluateBatch(ctx, storagebase.CmdIDKey(""), readOnly, rec, nil, ba)
@@ -4983,7 +4983,7 @@ func (r *Replica) evaluateTxnWriteBatch(
 		if util.RaceEnabled && spans != nil {
 			batch = makeSpanSetBatch(batch, spans)
 		}
-		rec := ReplicaEvalContext{r, spans}
+		rec := NewReplicaEvalContext(r, spans)
 		br, result, pErr := evaluateBatch(ctx, idKey, batch, rec, &ms, strippedBa)
 		if pErr == nil && ba.Timestamp == br.Timestamp {
 			clonedTxn := ba.Txn.Clone()
@@ -5035,7 +5035,7 @@ func (r *Replica) evaluateTxnWriteBatch(
 	if util.RaceEnabled && spans != nil {
 		batch = makeSpanSetBatch(batch, spans)
 	}
-	rec := ReplicaEvalContext{r, spans}
+	rec := NewReplicaEvalContext(r, spans)
 	br, result, pErr := evaluateBatch(ctx, idKey, batch, rec, &ms, ba)
 	return batch, ms, br, result, pErr
 }
@@ -5492,7 +5492,7 @@ func (r *Replica) maybeGossipNodeLiveness(ctx context.Context, span roachpb.Span
 	ba.Timestamp = r.store.Clock().Now()
 	ba.Add(&roachpb.ScanRequest{Span: span})
 	// Call evaluateBatch instead of Send to avoid command queue reentrance.
-	rec := ReplicaEvalContext{r, nil}
+	rec := NewReplicaEvalContext(r, todoSpanSet)
 	br, result, pErr :=
 		evaluateBatch(ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, ba)
 	if pErr != nil {
@@ -5572,7 +5572,7 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (config.SystemConfig, er
 	ba.Timestamp = r.store.Clock().Now()
 	ba.Add(&roachpb.ScanRequest{Span: keys.SystemConfigSpan})
 	// Call evaluateBatch instead of Send to avoid command queue reentrance.
-	rec := ReplicaEvalContext{r, nil}
+	rec := NewReplicaEvalContext(r, todoSpanSet)
 	br, result, pErr := evaluateBatch(
 		ctx, storagebase.CmdIDKey(""), r.store.Engine(), rec, nil, ba,
 	)

--- a/pkg/storage/replica_command_test.go
+++ b/pkg/storage/replica_command_test.go
@@ -100,7 +100,7 @@ func TestDeclareKeysResolveIntent(t *testing.T) {
 				h.RangeID = desc.RangeID
 
 				cArgs := CommandArgs{Header: h}
-				cArgs.EvalCtx.i = &Replica{abortSpan: ac}
+				cArgs.EvalCtx = &Replica{abortSpan: ac}
 
 				if !ranged {
 					cArgs.Args = &ri

--- a/pkg/storage/replica_eval_context_span.go
+++ b/pkg/storage/replica_eval_context_span.go
@@ -1,0 +1,176 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	opentracing "github.com/opentracing/opentracing-go"
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// SpanSetReplicaEvalContext is a testing-only implementation of
+// ReplicaEvalContext which verifies that access to state is registered in the
+// SpanSet if one is given.
+type SpanSetReplicaEvalContext struct {
+	i  ReplicaEvalContext
+	ss SpanSet
+}
+
+var _ ReplicaEvalContext = &SpanSetReplicaEvalContext{}
+
+// AbortSpan returns the abort span.
+func (rec *SpanSetReplicaEvalContext) AbortSpan() *abortspan.AbortSpan {
+	return rec.i.AbortSpan()
+}
+
+// StoreTestingKnobs returns the StoreTestingKnobs.
+func (rec *SpanSetReplicaEvalContext) StoreTestingKnobs() StoreTestingKnobs {
+	return rec.i.StoreTestingKnobs()
+}
+
+// StoreID returns the StoreID.
+func (rec *SpanSetReplicaEvalContext) StoreID() roachpb.StoreID {
+	return rec.i.StoreID()
+}
+
+// GetRangeID returns the RangeID.
+func (rec *SpanSetReplicaEvalContext) GetRangeID() roachpb.RangeID {
+	return rec.i.GetRangeID()
+}
+
+// ClusterSettings returns the cluster settings.
+func (rec *SpanSetReplicaEvalContext) ClusterSettings() *cluster.Settings {
+	return rec.i.ClusterSettings()
+}
+
+// DB returns the Replica's client DB.
+func (rec *SpanSetReplicaEvalContext) DB() *client.DB {
+	return rec.i.DB()
+}
+
+// GetTxnWaitQueue returns the txnwait.Queue.
+func (rec *SpanSetReplicaEvalContext) GetTxnWaitQueue() *txnwait.Queue {
+	return rec.i.GetTxnWaitQueue()
+}
+
+// NodeID returns the NodeID.
+func (rec *SpanSetReplicaEvalContext) NodeID() roachpb.NodeID {
+	return rec.i.NodeID()
+}
+
+// Tracer returns the tracer.
+func (rec *SpanSetReplicaEvalContext) Tracer() opentracing.Tracer {
+	return rec.i.Tracer()
+}
+
+// Engine returns the engine.
+func (rec *SpanSetReplicaEvalContext) Engine() engine.Engine {
+	return rec.i.Engine()
+}
+
+// GetFirstIndex returns the first index.
+func (rec *SpanSetReplicaEvalContext) GetFirstIndex() (uint64, error) {
+	return rec.i.GetFirstIndex()
+}
+
+// GetTerm returns the term for the given index in the Raft log.
+func (rec *SpanSetReplicaEvalContext) GetTerm(i uint64) (uint64, error) {
+	return rec.i.GetTerm(i)
+}
+
+// IsFirstRange returns true iff the replica belongs to the first range.
+func (rec *SpanSetReplicaEvalContext) IsFirstRange() bool {
+	return rec.i.IsFirstRange()
+}
+
+// Desc returns the Replica's RangeDescriptor.
+func (rec SpanSetReplicaEvalContext) Desc() *roachpb.RangeDescriptor {
+	desc := rec.i.Desc()
+	rec.ss.assertAllowed(SpanReadOnly,
+		roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)},
+	)
+	return desc
+}
+
+// ContainsKey returns true if the given key is within the Replica's range.
+//
+// TODO(bdarnell): Replace this method with one on Desc(). See comment
+// on Replica.ContainsKey.
+func (rec SpanSetReplicaEvalContext) ContainsKey(key roachpb.Key) bool {
+	desc := rec.Desc() // already asserts
+	return containsKey(*desc, key)
+}
+
+// GetMVCCStats returns the Replica's MVCCStats.
+func (rec SpanSetReplicaEvalContext) GetMVCCStats() enginepb.MVCCStats {
+	rec.ss.assertAllowed(SpanReadOnly,
+		roachpb.Span{Key: keys.RangeStatsKey(rec.GetRangeID())},
+	)
+	return rec.i.GetMVCCStats()
+}
+
+// GetGCThreshold returns the GC threshold of the Range, typically updated when
+// keys are garbage collected. Reads and writes at timestamps <= this time will
+// not be served.
+func (rec SpanSetReplicaEvalContext) GetGCThreshold() hlc.Timestamp {
+	rec.ss.assertAllowed(SpanReadOnly,
+		roachpb.Span{Key: keys.RangeLastGCKey(rec.GetRangeID())},
+	)
+	return rec.i.GetGCThreshold()
+}
+
+// GetTxnSpanGCThreshold returns the time of the Replica's last
+// transaction span GC.
+func (rec SpanSetReplicaEvalContext) GetTxnSpanGCThreshold() hlc.Timestamp {
+	rec.ss.assertAllowed(SpanReadOnly,
+		roachpb.Span{Key: keys.RangeTxnSpanGCThresholdKey(rec.GetRangeID())},
+	)
+	return rec.i.GetTxnSpanGCThreshold()
+}
+
+// String implements Stringer.
+func (rec SpanSetReplicaEvalContext) String() string {
+	return rec.i.String()
+}
+
+// GetLastReplicaGCTimestamp returns the last time the Replica was
+// considered for GC.
+func (rec SpanSetReplicaEvalContext) GetLastReplicaGCTimestamp(
+	ctx context.Context,
+) (hlc.Timestamp, error) {
+	if err := rec.ss.checkAllowed(SpanReadOnly,
+		roachpb.Span{Key: keys.RangeLastReplicaGCTimestampKey(rec.GetRangeID())},
+	); err != nil {
+		return hlc.Timestamp{}, err
+	}
+	return rec.i.GetLastReplicaGCTimestamp(ctx)
+}
+
+// GetLease returns the Replica's current and next lease (if any).
+func (rec SpanSetReplicaEvalContext) GetLease() (roachpb.Lease, *roachpb.Lease) {
+	rec.ss.assertAllowed(SpanReadOnly,
+		roachpb.Span{Key: keys.RangeLeaseKey(rec.GetRangeID())},
+	)
+	return rec.i.GetLease()
+}

--- a/pkg/storage/replica_state.go
+++ b/pkg/storage/replica_state.go
@@ -20,7 +20,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
@@ -116,46 +115,12 @@ func writeInitialState(
 	return newMS, nil
 }
 
-// ReplicaEvalContext is the interface through which command
-// evaluation accesses the in-memory state of a Replica. Any state
-// that corresponds to (mutable) on-disk data must be registered in
-// the SpanSet if one is given.
-type ReplicaEvalContext struct {
-	i  ReplicaI
-	ss *SpanSet
-}
-
-// AbortSpan returns the abort span.
-func (rec *ReplicaEvalContext) AbortSpan() *abortspan.AbortSpan {
-	return rec.i.AbortSpan()
-}
-
-// StoreTestingKnobs returns the StoreTestingKnobs.
-func (rec *ReplicaEvalContext) StoreTestingKnobs() StoreTestingKnobs {
-	return rec.i.StoreTestingKnobs()
-}
-
-// StoreID returns the StoreID.
-func (rec *ReplicaEvalContext) StoreID() roachpb.StoreID {
-	return rec.i.StoreID()
-}
-
-// GetRangeID returns the RangeID.
-func (rec *ReplicaEvalContext) GetRangeID() roachpb.RangeID {
-	return rec.i.GetRangeID()
-}
-
-// ClusterSettings returns the cluster settings.
-func (rec *ReplicaEvalContext) ClusterSettings() *cluster.Settings {
-	return rec.i.ClusterSettings()
-}
-
 // ClusterSettings returns the node's ClusterSettings.
 func (r *Replica) ClusterSettings() *cluster.Settings {
 	return r.store.cfg.Settings
 }
 
-func (rec *ReplicaEvalContext) makeReplicaStateLoader() stateloader.StateLoader {
+func makeReplicaStateLoader(rec ReplicaEvalContext) stateloader.StateLoader {
 	return stateloader.Make(rec.ClusterSettings(), rec.GetRangeID())
 }
 
@@ -177,11 +142,6 @@ func (r *Replica) Tracer() opentracing.Tracer {
 }
 
 // DB returns the Replica's client DB.
-func (rec *ReplicaEvalContext) DB() *client.DB {
-	return rec.i.DB()
-}
-
-// DB returns the Replica's client DB.
 func (r *Replica) DB() *client.DB {
 	return r.store.DB()
 }
@@ -200,19 +160,9 @@ func (r *Replica) AbortSpan() *abortspan.AbortSpan {
 	return r.abortSpan
 }
 
-// GetTxnWaitQueue returns the txnwait.Queue.
-func (rec *ReplicaEvalContext) GetTxnWaitQueue() *txnwait.Queue {
-	return rec.i.GetTxnWaitQueue()
-}
-
 // GetTxnWaitQueue returns the Replica's txnwait.Queue.
 func (r *Replica) GetTxnWaitQueue() *txnwait.Queue {
 	return r.txnWaitQueue
-}
-
-// GetTerm returns the term for the given index in the Raft log.
-func (rec *ReplicaEvalContext) GetTerm(i uint64) (uint64, error) {
-	return rec.i.GetTerm(i)
 }
 
 // GetTerm returns the term of the given index in the raft log.
@@ -222,91 +172,9 @@ func (r *Replica) GetTerm(i uint64) (uint64, error) {
 	return r.raftTermRLocked(i)
 }
 
-// NodeID returns the NodeID.
-func (rec *ReplicaEvalContext) NodeID() roachpb.NodeID {
-	return rec.i.NodeID()
-}
-
-// Tracer returns the tracer.
-func (rec *ReplicaEvalContext) Tracer() opentracing.Tracer {
-	return rec.i.Tracer()
-}
-
-// Engine returns the engine.
-func (rec *ReplicaEvalContext) Engine() engine.Engine {
-	return rec.i.Engine()
-}
-
-// GetFirstIndex returns the first index.
-func (rec *ReplicaEvalContext) GetFirstIndex() (uint64, error) {
-	return rec.i.GetFirstIndex()
-}
-
-// IsFirstRange returns true iff the replica belongs to the first range.
-func (rec *ReplicaEvalContext) IsFirstRange() bool {
-	return rec.i.IsFirstRange()
-}
-
-// Fields backed by on-disk data must be registered in the SpanSet.
-
-// Desc returns the Replica's RangeDescriptor.
-func (rec ReplicaEvalContext) Desc() (*roachpb.RangeDescriptor, error) {
-	desc := rec.i.Desc()
-	if rec.ss != nil {
-		if err := rec.ss.checkAllowed(SpanReadOnly,
-			roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)},
-		); err != nil {
-			return nil, err
-		}
-	}
-	return desc, nil
-}
-
 // GetRangeID returns the Range ID.
 func (r *Replica) GetRangeID() roachpb.RangeID {
 	return r.RangeID
-}
-
-// ContainsKey returns true if the given key is within the Replica's range.
-//
-// TODO(bdarnell): Replace this method with one on Desc(). See comment
-// on Replica.ContainsKey.
-func (rec ReplicaEvalContext) ContainsKey(key roachpb.Key) (bool, error) {
-	desc := rec.i.Desc()
-	if rec.ss != nil {
-		if err := rec.ss.checkAllowed(SpanReadOnly,
-			roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)},
-		); err != nil {
-			return false, err
-		}
-	}
-	return containsKey(*desc, key), nil
-}
-
-// GetMVCCStats returns the Replica's MVCCStats.
-func (rec ReplicaEvalContext) GetMVCCStats() (enginepb.MVCCStats, error) {
-	if rec.ss != nil {
-		if err := rec.ss.checkAllowed(SpanReadOnly,
-			roachpb.Span{Key: keys.RangeStatsKey(rec.GetRangeID())},
-		); err != nil {
-			return enginepb.MVCCStats{}, err
-		}
-	}
-	return rec.i.GetMVCCStats(), nil
-}
-
-// GetGCThreshold returns the GC threshold of the Range, typically updated when
-// keys are garbage collected. Reads and writes at timestamps <= this time will
-// not be served.
-func (rec ReplicaEvalContext) GetGCThreshold() (hlc.Timestamp, error) {
-	if rec.ss != nil {
-		if err := rec.ss.checkAllowed(SpanReadOnly,
-			roachpb.Span{Key: keys.RangeLastGCKey(rec.GetRangeID())},
-		); err != nil {
-			return hlc.Timestamp{}, err
-		}
-	}
-	return rec.i.GetGCThreshold(), nil
 }
 
 // GetGCThreshold returns the GC threshold.
@@ -316,51 +184,10 @@ func (r *Replica) GetGCThreshold() hlc.Timestamp {
 	return *r.mu.state.GCThreshold
 }
 
-// GetTxnSpanGCThreshold returns the time of the Replica's last
-// transaction span GC.
-func (rec ReplicaEvalContext) GetTxnSpanGCThreshold() (hlc.Timestamp, error) {
-	if rec.ss != nil {
-		if err := rec.ss.checkAllowed(SpanReadOnly,
-			roachpb.Span{Key: keys.RangeTxnSpanGCThresholdKey(rec.GetRangeID())},
-		); err != nil {
-			return hlc.Timestamp{}, err
-		}
-	}
-	return rec.i.GetTxnSpanGCThreshold(), nil
-}
-
 // GetTxnSpanGCThreshold returns the time of the replica's last transaction span
 // GC.
 func (r *Replica) GetTxnSpanGCThreshold() hlc.Timestamp {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return *r.mu.state.TxnSpanGCThreshold
-}
-
-// GetLastReplicaGCTimestamp returns the last time the Replica was
-// considered for GC.
-func (rec ReplicaEvalContext) GetLastReplicaGCTimestamp(
-	ctx context.Context,
-) (hlc.Timestamp, error) {
-	if rec.ss != nil {
-		if err := rec.ss.checkAllowed(SpanReadOnly,
-			roachpb.Span{Key: keys.RangeLastReplicaGCTimestampKey(rec.GetRangeID())},
-		); err != nil {
-			return hlc.Timestamp{}, err
-		}
-	}
-	return rec.i.GetLastReplicaGCTimestamp(ctx)
-}
-
-// GetLease returns the Replica's current and next lease (if any).
-func (rec ReplicaEvalContext) GetLease() (roachpb.Lease, *roachpb.Lease, error) {
-	if rec.ss != nil {
-		if err := rec.ss.checkAllowed(SpanReadOnly,
-			roachpb.Span{Key: keys.RangeLeaseKey(rec.GetRangeID())},
-		); err != nil {
-			return roachpb.Lease{}, nil, err
-		}
-	}
-	lease, nextLease := rec.i.GetLease()
-	return lease, nextLease, nil
 }

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -480,7 +480,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	}
 
 	if _, _, _, pErr := repl1.propose(
-		context.Background(), lease, roachpb.BatchRequest{}, nil, nil,
+		context.Background(), lease, roachpb.BatchRequest{}, nil, &allSpans,
 	); !pErr.Equal(expErr) {
 		t.Fatalf("expected error %s, but got %v", expErr, pErr)
 	}


### PR DESCRIPTION
As suggested by @bdarnell, this makes ReplicaEvalContext an interface
(previously `ReplicaI`) and in turn has it implemented by `*Replica` and
`SpanSetReplicaEvalContext` (formerly `ReplicaEvalContext`).

As fallout, some methods that previously returned errors due to assertions will
now Fatal. This was deemed more ergonomic than returning `nil` errors from
various `*Replica` accessors.

Introduce a second implementation, `*SpanSetReplicaEvalContext`, which is the
one we use in race-enabled builds (where we want to assert span accesses).

As a side effect, this also removes an oversight: we were previously passing the
`SpanSet` to the `ReplicaEvalContext` even when that wasn't desired (i.e.
outside of race builds).