### PR TITLE
acceptance: skip TestDockerCSharp

### DIFF
--- a/pkg/acceptance/csharp_test.go
+++ b/pkg/acceptance/csharp_test.go
@@ -27,6 +27,8 @@ func TestDockerCSharp(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)
 
+	t.Skip("#19841")
+
 	ctx := context.Background()
 	testDockerSuccess(ctx, t, "csharp", []string{"/bin/sh", "-c", strings.Replace(csharp, "%v", "test", 1)})
 	testDockerFail(ctx, t, "csharp", []string{"/bin/sh", "-c", strings.Replace(csharp, "%v", "other", 1)})


### PR DESCRIPTION
It calls a remote web API which at the time of writing is
unavailable.

See #19841.