### PR TITLE
build/packer: run agents in nyc3, not nyc1

### DIFF
--- a/build/packer/teamcity-agent.json
+++ b/build/packer/teamcity-agent.json
@@ -9,7 +9,6 @@
       "region": "nyc1",
       "size": "c-16",
       "snapshot_name": "{{user `image_id`}}",
-      "snapshot_regions": ["nyc1"],
       "ssh_username": "root",
       "volumes": [{
         "size": 25,

--- a/build/packer/teamcity-agent.json
+++ b/build/packer/teamcity-agent.json
@@ -6,7 +6,7 @@
   "builders": [{
       "type": "digitalocean",
       "image": "ubuntu-16-04-x64",
-      "region": "nyc1",
+      "region": "nyc3",
       "size": "c-16",
       "snapshot_name": "{{user `image_id`}}",
       "ssh_username": "root",


### PR DESCRIPTION
nyc3 appears to have more high CPU capacity than nyc1.