### PR TITLE
sql, distsql: planning for interleave joins between ancestor and descendant

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1247,6 +1247,11 @@ func (s Span) EqualValue(o Span) bool {
 
 // Overlaps returns whether the two spans overlap.
 func (s Span) Overlaps(o Span) bool {
+	// Spans must be valid.
+	if !s.Valid() || !o.Valid() {
+		return false
+	}
+
 	if len(s.EndKey) == 0 && len(o.EndKey) == 0 {
 		return s.Key.Equal(o.Key)
 	} else if len(s.EndKey) == 0 {
@@ -1259,6 +1264,11 @@ func (s Span) Overlaps(o Span) bool {
 
 // Contains returns whether the receiver contains the given span.
 func (s Span) Contains(o Span) bool {
+	// Spans must be valid.
+	if !s.Valid() || !o.Valid() {
+		return false
+	}
+
 	if len(s.EndKey) == 0 && len(o.EndKey) == 0 {
 		return s.Key.Equal(o.Key)
 	} else if len(s.EndKey) == 0 {
@@ -1291,6 +1301,42 @@ func (s Span) AsRange() interval.Range {
 func (s Span) String() string {
 	const maxChars = math.MaxInt32
 	return PrettyPrintRange(s.Key, s.EndKey, maxChars)
+}
+
+// SplitOnKey returns two spans where the left span has EndKey
+// and right span has start Key of the split key.
+// If the split key lies outside the span, the original
+// span is returned on the left (and right is an invalid span
+// with empty keys).
+func (s Span) SplitOnKey(key Key) (left Span, right Span) {
+	// Cannot split on or before start key or on or after end key.
+	if bytes.Compare(key, s.Key) <= 0 || bytes.Compare(key, s.EndKey) >= 0 {
+		return s, Span{}
+	}
+
+	return Span{Key: s.Key, EndKey: key}, Span{Key: key, EndKey: s.EndKey}
+}
+
+// Valid returns whether or not the span is a "valid span".
+// A valid span cannot have an empty start and end key and must satisfy either:
+// 1. The end key is empty.
+// 2. The start key is lexicographically-ordered before the end key.
+func (s Span) Valid() bool {
+	// s.Key can be empty if it is KeyMin.
+	// Can't have both KeyMin start and end keys.
+	if len(s.Key) == 0 && len(s.EndKey) == 0 {
+		return false
+	}
+
+	if len(s.EndKey) == 0 {
+		return true
+	}
+
+	if bytes.Compare(s.Key, s.EndKey) >= 0 {
+		return false
+	}
+
+	return true
 }
 
 // Spans is a slice of spans.

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1245,9 +1245,13 @@ func (s Span) EqualValue(o Span) bool {
 	return s.Key.Equal(o.Key) && s.EndKey.Equal(o.EndKey)
 }
 
-// Overlaps returns whether the two spans overlap.
+// Overlaps returns true WLOG for span A and B iff:
+// 1. Both spans contain one key (just the start key) and they are equal; or
+// 2. The span with only one key is contained inside the other span; or
+// 3. The end key of span A is strictly greater than the start key of span B
+//    and the end key of span B is strictly greater than the start key of span
+//    A.
 func (s Span) Overlaps(o Span) bool {
-	// Spans must be valid.
 	if !s.Valid() || !o.Valid() {
 		return false
 	}
@@ -1264,7 +1268,6 @@ func (s Span) Overlaps(o Span) bool {
 
 // Contains returns whether the receiver contains the given span.
 func (s Span) Contains(o Span) bool {
-	// Spans must be valid.
 	if !s.Valid() || !o.Valid() {
 		return false
 	}
@@ -1303,11 +1306,10 @@ func (s Span) String() string {
 	return PrettyPrintRange(s.Key, s.EndKey, maxChars)
 }
 
-// SplitOnKey returns two spans where the left span has EndKey
-// and right span has start Key of the split key.
-// If the split key lies outside the span, the original
-// span is returned on the left (and right is an invalid span
-// with empty keys).
+// SplitOnKey returns two spans where the left span has EndKey and right span
+// has start Key of the split key, respectively.
+// If the split key lies outside the span, the original span is returned on the
+// left (and right is an invalid span with empty keys).
 func (s Span) SplitOnKey(key Key) (left Span, right Span) {
 	// Cannot split on or before start key or on or after end key.
 	if bytes.Compare(key, s.Key) <= 0 || bytes.Compare(key, s.EndKey) >= 0 {

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -20,6 +20,7 @@ import (
 	"math/rand"
 	"reflect"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -707,6 +708,9 @@ func TestSpanOverlaps(t *testing.T) {
 	sD := Span{Key: []byte("d")}
 	sAtoC := Span{Key: []byte("a"), EndKey: []byte("c")}
 	sBtoD := Span{Key: []byte("b"), EndKey: []byte("d")}
+	// Invalid spans.
+	sCtoA := Span{Key: []byte("c"), EndKey: []byte("a")}
+	sDtoB := Span{Key: []byte("d"), EndKey: []byte("b")}
 
 	testData := []struct {
 		s1, s2   Span
@@ -723,6 +727,11 @@ func TestSpanOverlaps(t *testing.T) {
 		{sAtoC, sAtoC, true},
 		{sAtoC, sBtoD, true},
 		{sBtoD, sAtoC, true},
+		// Invalid spans.
+		{sAtoC, sDtoB, false},
+		{sDtoB, sAtoC, false},
+		{sBtoD, sCtoA, false},
+		{sCtoA, sBtoD, false},
 	}
 	for i, test := range testData {
 		if o := test.s1.Overlaps(test.s2); o != test.overlaps {
@@ -755,13 +764,87 @@ func TestSpanContains(t *testing.T) {
 		{[]byte("b"), []byte("bb"), false},
 		{[]byte("0"), []byte("bb"), false},
 		{[]byte("aa"), []byte("bb"), false},
-		// TODO(bdarnell): check for invalid ranges in Span.Contains?
-		//{[]byte("b"), []byte("a"), false},
+		{[]byte("b"), []byte("a"), false},
 	}
 	for i, test := range testData {
 		if s.Contains(Span{test.start, test.end}) != test.contains {
 			t.Errorf("%d: expected span %q-%q within range to be %v",
 				i, test.start, test.end, test.contains)
+		}
+	}
+}
+
+func TestSpanSplitOnKey(t *testing.T) {
+	s := Span{Key: []byte("b"), EndKey: []byte("c")}
+
+	testData := []struct {
+		split []byte
+		left  Span
+		right Span
+	}{
+		// Split on start/end key should fail.
+		{
+			[]byte("b"),
+			s,
+			Span{},
+		},
+		{
+			[]byte("c"),
+			s,
+			Span{},
+		},
+
+		// Before start key.
+		{
+			[]byte("a"),
+			s,
+			Span{},
+		},
+		// After end key.
+		{
+			[]byte("d"),
+			s,
+			Span{},
+		},
+
+		// Simple split.
+		{
+			[]byte("bb"),
+			Span{[]byte("b"), []byte("bb")},
+			Span{[]byte("bb"), []byte("c")},
+		},
+	}
+	for testIdx, test := range testData {
+		t.Run(strconv.Itoa(testIdx), func(t *testing.T) {
+			actualL, actualR := s.SplitOnKey(test.split)
+			if !test.left.EqualValue(actualL) {
+				t.Fatalf("expected left span after split to be %v, got %v", test.left, actualL)
+			}
+
+			if !test.right.EqualValue(actualR) {
+				t.Fatalf("expected right span after split to be %v, got %v", test.right, actualL)
+			}
+		})
+	}
+}
+
+func TestSpanValid(t *testing.T) {
+	testData := []struct {
+		start, end []byte
+		valid      bool
+	}{
+		{[]byte("a"), nil, true},
+		{[]byte("a"), []byte("b"), true},
+		{[]byte(""), []byte(""), false},
+		{[]byte(""), []byte("a"), true},
+		{[]byte("a"), []byte("a"), false},
+		{[]byte("b"), []byte("aa"), false},
+	}
+	for i, test := range testData {
+		s := Span{test.start, test.end}
+		if test.valid != s.Valid() {
+			t.Errorf("%d: expected span %q-%q to return %t for Valid, instead got %t",
+				i, test.start, test.end, test.valid, s.Valid())
 		}
 	}
 }

--- a/pkg/roachpb/merge_spans.go
+++ b/pkg/roachpb/merge_spans.go
@@ -39,6 +39,7 @@ func (s sortedSpans) Len() int {
 
 // MergeSpans sorts the incoming spans and merges overlapping spans. Returns
 // true iff all of the spans are distinct.
+// The input spans are not safe for re-use.
 func MergeSpans(spans []Span) ([]Span, bool) {
 	if len(spans) == 0 {
 		return spans, true

--- a/pkg/roachpb/merge_spans_test.go
+++ b/pkg/roachpb/merge_spans_test.go
@@ -20,24 +20,25 @@ import (
 	"testing"
 )
 
-func TestMergeSpans(t *testing.T) {
-	makeSpan := func(s string) Span {
-		parts := strings.Split(s, "-")
-		if len(parts) == 2 {
-			return Span{Key: Key(parts[0]), EndKey: Key(parts[1])}
-		}
-		return Span{Key: Key(s)}
+func makeSpan(s string) Span {
+	parts := strings.Split(s, "-")
+	if len(parts) == 2 {
+		return Span{Key: Key(parts[0]), EndKey: Key(parts[1])}
 	}
-	makeSpans := func(s string) []Span {
-		var spans []Span
-		if len(s) > 0 {
-			for _, p := range strings.Split(s, ",") {
-				spans = append(spans, makeSpan(p))
-			}
-		}
-		return spans
-	}
+	return Span{Key: Key(s)}
+}
 
+func makeSpans(s string) []Span {
+	var spans []Span
+	if len(s) > 0 {
+		for _, p := range strings.Split(s, ",") {
+			spans = append(spans, makeSpan(p))
+		}
+	}
+	return spans
+}
+
+func TestMergeSpans(t *testing.T) {
 	testCases := []struct {
 		spans    string
 		expected string

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -480,11 +480,11 @@ type spanPartition struct {
 	spans roachpb.Spans
 }
 
-// partitionSpans finds out which nodes are owners for ranges touching the given
-// spans, and splits the spans according to owning nodes. The result is a set of
-// spanPartitions (one for each relevant node), which form a partitioning of the
-// spans (i.e. they are non-overlapping and their union is exactly the original
-// set of spans).
+// partitionSpans finds out which nodes are owners for ranges touching the
+// given spans, and splits the spans according to owning nodes. The result is a
+// set of spanPartitions (guaranteed one for each relevant node), which form a
+// partitioning of the spans (i.e. they are non-overlapping and their union is
+// exactly the original set of spans).
 //
 // partitionSpans does its best to not assign ranges on nodes that are known to
 // either be unhealthy or running an incompatible version. The ranges owned by
@@ -504,6 +504,7 @@ func (dsp *DistSQLPlanner) partitionSpans(
 	nodeVerCompatMap := make(map[roachpb.NodeID]bool)
 	it := planCtx.spanIter
 	for _, span := range spans {
+		// rspan is the span we are currently partitioning.
 		var rspan roachpb.RSpan
 		var err error
 		if rspan.Key, err = keys.Addr(span.Key); err != nil {
@@ -519,6 +520,9 @@ func (dsp *DistSQLPlanner) partitionSpans(
 		if log.V(1) {
 			log.Infof(ctx, "partitioning span %s", span)
 		}
+		// We break up rspan into its individual ranges (which may or
+		// may not be on separate nodes). We then create "partitioned
+		// spans" using the end keys of these individual ranges.
 		for it.Seek(ctx, span, kv.Ascending); ; it.Next(ctx) {
 			if !it.Valid() {
 				return nil, it.Error()
@@ -704,7 +708,7 @@ func getOutputColumnsFromScanNode(n *scanNode) []uint32 {
 	return outputColumns
 }
 
-// convertOrdering maps the columns in ord.ordering to the output columns of a
+// convertOrdering maps the columns in props.ordering to the output columns of a
 // processor.
 func (dsp *DistSQLPlanner) convertOrdering(
 	props physicalProps, planToStreamColMap []int,
@@ -761,13 +765,11 @@ func (dsp *DistSQLPlanner) createTableReaders(
 	stageID := p.NewStageID()
 
 	p.ResultRouters = make([]distsqlplan.ProcessorIdx, len(spanPartitions))
+
 	for i, sp := range spanPartitions {
 		tr := &distsqlrun.TableReaderSpec{}
 		*tr = spec
-		tr.Spans = make([]distsqlrun.TableReaderSpan, len(sp.spans))
-		for j := range sp.spans {
-			tr.Spans[j].Span = sp.spans[j]
-		}
+		tr.Spans = makeTableReaderSpans(sp.spans)
 
 		proc := distsqlplan.Processor{
 			Node: sp.node,
@@ -1497,6 +1499,23 @@ func getTypesForPlanResult(node planNode, planToStreamColMap []int) []sqlbase.Co
 func (dsp *DistSQLPlanner) createPlanForJoin(
 	planCtx *planningCtx, n *joinNode,
 ) (physicalPlan, error) {
+	// See if we can create an interleave join plan.
+	if planInterleavedJoins.Get(&dsp.st.SV) && n.joinType == joinTypeInner {
+		// TODO(richardwu): We currently only do an interleave join on
+		// all equality columns. This can be relaxed once a hybrid
+		// hash-merge join is implemented (see comment below for merge
+		// joins).
+		if len(n.mergeJoinOrdering) == len(n.pred.leftEqualityIndices) {
+			plan, ok, err := dsp.tryCreatePlanForInterleavedJoin(planCtx, n)
+			if err != nil {
+				return physicalPlan{}, err
+			}
+			// An interleave join plan could be used. Return it.
+			if ok {
+				return plan, nil
+			}
+		}
+	}
 
 	// Outline of the planning process for joins:
 	//
@@ -1532,15 +1551,12 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 		&leftPlan.PhysicalPlan, &rightPlan.PhysicalPlan,
 	)
 
-	joinToStreamColMap := makePlanToStreamColMap(len(n.columns))
-
 	// Nodes where we will run the join processors.
 	var nodes []roachpb.NodeID
 
 	// We initialize these properties of the joiner. They will then be used to
 	// fill in the processor spec. See descriptions for HashJoinerSpec.
 	var joinType distsqlrun.JoinType
-	var onExpr distsqlrun.Expression
 	var leftEqCols, rightEqCols []uint32
 	var leftMergeOrd, rightMergeOrd distsqlrun.Ordering
 
@@ -1582,14 +1598,9 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 		}
 
 		// Set up the equality columns.
-		leftEqCols = make([]uint32, numEq)
-		for i, leftPlanCol := range n.pred.leftEqualityIndices {
-			leftEqCols[i] = uint32(leftPlan.planToStreamColMap[leftPlanCol])
-		}
-		rightEqCols = make([]uint32, numEq)
-		for i, rightPlanCol := range n.pred.rightEqualityIndices {
-			rightEqCols[i] = uint32(rightPlan.planToStreamColMap[rightPlanCol])
-		}
+		leftEqCols = eqCols(n.pred.leftEqualityIndices, leftPlan.planToStreamColMap)
+		rightEqCols = eqCols(n.pred.rightEqualityIndices, rightPlan.planToStreamColMap)
+
 		if planMergeJoins.Get(&dsp.st.SV) && len(n.mergeJoinOrdering) > 0 {
 			// TODO(radu): we currently only use merge joins when we have an ordering on
 			// all equality columns. We should relax this by either:
@@ -1599,18 +1610,8 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 			//  - or: adding a sort processor to complete the order
 			if len(n.mergeJoinOrdering) == len(n.pred.leftEqualityIndices) {
 				// Excellent! We can use the merge joiner.
-				leftMergeOrd.Columns = make([]distsqlrun.Ordering_Column, len(n.mergeJoinOrdering))
-				rightMergeOrd.Columns = make([]distsqlrun.Ordering_Column, len(n.mergeJoinOrdering))
-				for i, c := range n.mergeJoinOrdering {
-					leftMergeOrd.Columns[i].ColIdx = leftEqCols[c.ColIdx]
-					rightMergeOrd.Columns[i].ColIdx = rightEqCols[c.ColIdx]
-					dir := distsqlrun.Ordering_Column_ASC
-					if c.Direction == encoding.Descending {
-						dir = distsqlrun.Ordering_Column_DESC
-					}
-					leftMergeOrd.Columns[i].Direction = dir
-					rightMergeOrd.Columns[i].Direction = dir
-				}
+				leftMergeOrd = distsqlOrdering(n.mergeJoinOrdering, leftEqCols)
+				rightMergeOrd = distsqlOrdering(n.mergeJoinOrdering, rightEqCols)
 			}
 		}
 	} else {
@@ -1627,54 +1628,8 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 		}
 	}
 
-	post := distsqlrun.PostProcessSpec{
-		Projection: true,
-	}
-	// addOutCol appends to post.OutputColumns and returns the index
-	// in the slice of the added column.
-	addOutCol := func(col uint32) int {
-		idx := len(post.OutputColumns)
-		post.OutputColumns = append(post.OutputColumns, col)
-		return idx
-	}
-
-	// The join columns are in two groups:
-	//  - the columns on the left side (numLeftCols)
-	//  - the columns on the right side (numRightCols)
-	joinCol := 0
-
-	for i := 0; i < n.pred.numLeftCols; i++ {
-		if !n.columns[joinCol].Omitted {
-			joinToStreamColMap[joinCol] = addOutCol(uint32(leftPlan.planToStreamColMap[i]))
-		}
-		joinCol++
-	}
-	for i := 0; i < n.pred.numRightCols; i++ {
-		if !n.columns[joinCol].Omitted {
-			joinToStreamColMap[joinCol] = addOutCol(
-				uint32(rightPlan.planToStreamColMap[i] + len(leftTypes)),
-			)
-		}
-		joinCol++
-	}
-
-	if n.pred.onCond != nil {
-		// We have to remap ordinal references in the on condition (which refer to
-		// the join columns as described above) to values that make sense in the
-		// joiner (0 to N-1 for the left input columns, N to N+M-1 for the right
-		// input columns).
-		joinColMap := make([]int, len(n.columns))
-		idx := 0
-		for i := 0; i < n.pred.numLeftCols; i++ {
-			joinColMap[idx] = leftPlan.planToStreamColMap[i]
-			idx++
-		}
-		for i := 0; i < n.pred.numRightCols; i++ {
-			joinColMap[idx] = rightPlan.planToStreamColMap[i] + len(leftTypes)
-			idx++
-		}
-		onExpr = distsqlplan.MakeExpression(n.pred.onCond, planCtx.evalCtx, joinColMap)
-	}
+	post, joinToStreamColMap := joinOutColumns(n, leftPlan, rightPlan)
+	onExpr := remapOnExpr(planCtx.evalCtx, n, leftPlan, rightPlan)
 
 	// Create the Core spec.
 	var core distsqlrun.ProcessorCoreUnion
@@ -1697,9 +1652,10 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 	pIdxStart := distsqlplan.ProcessorIdx(len(p.Processors))
 	stageID := p.NewStageID()
 
-	if len(nodes) == 1 {
+	// Each node has a join processor.
+	for _, n := range nodes {
 		proc := distsqlplan.Processor{
-			Node: nodes[0],
+			Node: n,
 			Spec: distsqlrun.ProcessorSpec{
 				Input: []distsqlrun.InputSyncSpec{
 					{ColumnTypes: leftTypes},
@@ -1712,27 +1668,11 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 			},
 		}
 		p.Processors = append(p.Processors, proc)
-	} else {
-		// Parallel hash join: we distribute rows (by hash of equality columns) to
-		// len(nodes) join processors.
+	}
 
-		// Each node has a join processor.
-		for _, n := range nodes {
-			proc := distsqlplan.Processor{
-				Node: n,
-				Spec: distsqlrun.ProcessorSpec{
-					Input: []distsqlrun.InputSyncSpec{
-						{ColumnTypes: leftTypes},
-						{ColumnTypes: rightTypes},
-					},
-					Core:    core,
-					Post:    post,
-					Output:  []distsqlrun.OutputRouterSpec{{Type: distsqlrun.OutputRouterSpec_PASS_THROUGH}},
-					StageID: stageID,
-				},
-			}
-			p.Processors = append(p.Processors, proc)
-		}
+	if len(nodes) > 1 {
+		// Parallel hash or merge join: we distribute rows (by hash of
+		// equality columns) to len(nodes) join processors.
 
 		// Set up the left routers.
 		for _, resultProc := range leftRouters {
@@ -2008,4 +1948,13 @@ func (dsp *DistSQLPlanner) FinalizePlan(planCtx *planningCtx, plan *physicalPlan
 	finalOut.Streams = append(finalOut.Streams, distsqlrun.StreamEndpointSpec{
 		Type: distsqlrun.StreamEndpointSpec_SYNC_RESPONSE,
 	})
+}
+
+func makeTableReaderSpans(spans roachpb.Spans) []distsqlrun.TableReaderSpan {
+	trSpans := make([]distsqlrun.TableReaderSpan, len(spans))
+	for i, span := range spans {
+		trSpans[i].Span = span
+	}
+
+	return trSpans
 }

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -1,0 +1,779 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"bytes"
+	"math"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+var planInterleavedJoins = settings.RegisterBoolSetting(
+	"sql.distsql.interleaved_joins.enabled",
+	"if set we plan interleaved table joins instead of merge joins when possible",
+	true,
+)
+
+func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
+	planCtx *planningCtx, n *joinNode,
+) (plan physicalPlan, ok bool, err error) {
+	if !useInterleavedJoin(n) {
+		return physicalPlan{}, false, nil
+	}
+
+	leftScan, leftOk := n.left.plan.(*scanNode)
+	rightScan, rightOk := n.right.plan.(*scanNode)
+
+	// We know they are scan nodes from useInterleaveJoin, but we add
+	// this check to prevent future panics.
+	if !leftOk || !rightOk {
+		return physicalPlan{}, false, pgerror.NewErrorf(
+			pgerror.CodeInternalError,
+			"left and right children of join node must be scan nodes to execute an interleaved join",
+		)
+	}
+
+	// We iterate through each table and collate their metadata for
+	// the InterleavedReaderJoinerSpec.
+	tables := make([]distsqlrun.InterleavedReaderJoinerSpec_Table, 2)
+	plans := make([]physicalPlan, 2)
+	var totalLimitHint int64
+	for i, t := range []struct {
+		scan      *scanNode
+		eqIndices []int
+	}{
+		{
+			scan:      leftScan,
+			eqIndices: n.pred.leftEqualityIndices,
+		},
+		{
+			scan:      rightScan,
+			eqIndices: n.pred.rightEqualityIndices,
+		},
+	} {
+		// We don't really need to initialize a full-on plan to
+		// retrieve the metadata for each table reader, but this turns
+		// out to be very useful for computing ordering and remapping the
+		// onCond and columns.
+		var err error
+		if plans[i], err = dsp.createTableReaders(planCtx, t.scan, nil); err != nil {
+			return physicalPlan{}, false, err
+		}
+
+		eqCols := eqCols(t.eqIndices, plans[i].planToStreamColMap)
+		ordering := distsqlOrdering(n.mergeJoinOrdering, eqCols)
+
+		// Doesn't matter which processor we choose since the metadata
+		// for TableReader is independent of node/processor instance.
+		tr := plans[i].Processors[0].Spec.Core.TableReader
+
+		tables[i] = distsqlrun.InterleavedReaderJoinerSpec_Table{
+			Desc:     tr.Table,
+			IndexIdx: tr.IndexIdx,
+			Post:     plans[i].GetLastStagePost(),
+			Ordering: ordering,
+		}
+
+		// We will set the limit hint of the final
+		// InterleavedReaderJoiner as the sum of the individual tables'
+		// limit hints.
+		// This is because the InterleavedReaderJoiner reads rows from
+		// all tables at the same time and so the hint applies to the
+		// total number of rows read from all tables.
+		if totalLimitHint >= math.MaxInt64-tr.LimitHint {
+			totalLimitHint = math.MaxInt64
+		} else {
+			totalLimitHint += tr.LimitHint
+		}
+	}
+
+	var joinType distsqlrun.JoinType
+	switch n.joinType {
+	case joinTypeInner:
+		joinType = distsqlrun.JoinType_INNER
+	default:
+		return physicalPlan{}, false, pgerror.NewErrorf(
+			pgerror.CodeInternalError,
+			"can only plan inner joins with interleaved joins",
+		)
+	}
+
+	post, joinToStreamColMap := joinOutColumns(n, plans[0], plans[1])
+	onExpr := remapOnExpr(planCtx.evalCtx, n, plans[0], plans[1])
+
+	ancestor, descendant := n.interleavedNodes()
+
+	// We partition each set of spans to their respective nodes.
+	ancsPartitions, err := dsp.partitionSpans(planCtx, ancestor.spans)
+	if err != nil {
+		return physicalPlan{}, false, err
+	}
+	descPartitions, err := dsp.partitionSpans(planCtx, descendant.spans)
+	if err != nil {
+		return physicalPlan{}, false, err
+	}
+
+	// We want to ensure that all child spans with a given interleave
+	// prefix value (which also happens to be our equality join columns)
+	// are read on the same node as the corresponding ancestor rows.
+	// We map all descendant spans in their partitions to the corresponding
+	// nodes of the ascendant spans.
+	//
+	// Example:
+	// Let PK1 and (PK1, PK2) be the primary keys of parent and child,
+	// respectively. PK1 is the interleave prefix.
+	// The filter WHERE PK1 = 1 AND PK2 IN (5, 7) will produce the
+	// parent and child spans
+	//   parent:  /1 - /2    (technically /1 - /1/#/8)
+	//   child:   /1/#/5 - /1/#/6, /1/#/7 - /1/#/8
+	// If the parent span is partitioned to node 1 and the child spans are
+	// partitioned to node 2 and 3, then we need to move the child spans
+	// to node 1 where the PK1 = 1 parent row is read.
+	if descPartitions, err = alignInterleavedSpans(n, ancsPartitions, descPartitions); err != nil {
+		return physicalPlan{}, false, err
+	}
+
+	// Figure out which nodes we need to schedule a processor on.
+	seen := make(map[roachpb.NodeID]struct{})
+	var nodes []roachpb.NodeID
+	for _, partitions := range [][]spanPartition{ancsPartitions, descPartitions} {
+		for _, part := range partitions {
+			if _, ok := seen[part.node]; !ok {
+				seen[part.node] = struct{}{}
+				nodes = append(nodes, part.node)
+			}
+		}
+	}
+
+	var ancsIdx, descIdx int
+	// The left table is in the 0th index, right table in the 1st index.
+	if leftScan == ancestor {
+		ancsIdx, descIdx = 0, 1
+	} else {
+		ancsIdx, descIdx = 1, 0
+	}
+
+	stageID := plan.NewStageID()
+
+	// We provision a separate InterleavedReaderJoiner per node that has
+	// rows from either table.
+	for _, nodeID := range nodes {
+		// Find the relevant span from each table for this node.
+		// Note it is possible that either set of spans can be empty
+		// (but not both).
+		var ancsSpans, descSpans roachpb.Spans
+		for _, part := range ancsPartitions {
+			if part.node == nodeID {
+				ancsSpans = part.spans
+				break
+			}
+		}
+		for _, part := range descPartitions {
+			if part.node == nodeID {
+				descSpans = part.spans
+				break
+			}
+		}
+		if len(ancsSpans) == 0 && len(descSpans) == 0 {
+			panic("cannot have empty set of spans for both tables for a given node")
+		}
+
+		// Make a copy of our spec for each table.
+		processorTables := make([]distsqlrun.InterleavedReaderJoinerSpec_Table, len(tables))
+		copy(processorTables, tables)
+		// We set the set of spans for each table to be read by the
+		// processor.
+		processorTables[ancsIdx].Spans = makeTableReaderSpans(ancsSpans)
+		processorTables[descIdx].Spans = makeTableReaderSpans(descSpans)
+
+		irj := &distsqlrun.InterleavedReaderJoinerSpec{
+			Tables: processorTables,
+			// We previously checked that both scans are in the
+			// same direction (useInterleavedJoin).
+			Reverse:   ancestor.reverse,
+			LimitHint: totalLimitHint,
+			OnExpr:    onExpr,
+			Type:      joinType,
+		}
+
+		proc := distsqlplan.Processor{
+			Node: nodeID,
+			Spec: distsqlrun.ProcessorSpec{
+				Core:    distsqlrun.ProcessorCoreUnion{InterleavedReaderJoiner: irj},
+				Post:    post,
+				Output:  []distsqlrun.OutputRouterSpec{{Type: distsqlrun.OutputRouterSpec_PASS_THROUGH}},
+				StageID: stageID,
+			},
+		}
+
+		plan.Processors = append(plan.Processors, proc)
+	}
+
+	// Each result router correspond to each of the processors we appended.
+	plan.ResultRouters = make([]distsqlplan.ProcessorIdx, len(nodes))
+	for i := 0; i < len(nodes); i++ {
+		plan.ResultRouters[i] = distsqlplan.ProcessorIdx(i)
+	}
+
+	plan.planToStreamColMap = joinToStreamColMap
+	plan.ResultTypes = getTypesForPlanResult(n, joinToStreamColMap)
+
+	plan.SetMergeOrdering(dsp.convertOrdering(n.props, plan.planToStreamColMap))
+	return plan, true, nil
+}
+
+func joinOutColumns(
+	n *joinNode, leftPlan, rightPlan physicalPlan,
+) (post distsqlrun.PostProcessSpec, joinToStreamColMap []int) {
+	joinToStreamColMap = makePlanToStreamColMap(len(n.columns))
+	post.Projection = true
+
+	// addOutCol appends to post.OutputColumns and returns the index
+	// in the slice of the added column.
+	addOutCol := func(col uint32) int {
+		idx := len(post.OutputColumns)
+		post.OutputColumns = append(post.OutputColumns, col)
+		return idx
+	}
+
+	// The join columns are in two groups:
+	//  - the columns on the left side (numLeftCols)
+	//  - the columns on the right side (numRightCols)
+	joinCol := 0
+	for i := 0; i < n.pred.numLeftCols; i++ {
+		if !n.columns[joinCol].Omitted {
+			joinToStreamColMap[joinCol] = addOutCol(uint32(leftPlan.planToStreamColMap[i]))
+		}
+		joinCol++
+	}
+	for i := 0; i < n.pred.numRightCols; i++ {
+		if !n.columns[joinCol].Omitted {
+			joinToStreamColMap[joinCol] = addOutCol(
+				uint32(rightPlan.planToStreamColMap[i] + len(leftPlan.ResultTypes)),
+			)
+		}
+		joinCol++
+	}
+
+	return post, joinToStreamColMap
+}
+
+// remapOnExpr remaps ordinal references in the on condition (which refer to the
+// join columns as described above) to values that make sense in the joiner (0
+// to N-1 for the left input columns, N to N+M-1 for the right input columns).
+func remapOnExpr(
+	evalCtx *tree.EvalContext, n *joinNode, leftPlan, rightPlan physicalPlan,
+) distsqlrun.Expression {
+	if n.pred.onCond == nil {
+		return distsqlrun.Expression{}
+	}
+
+	joinColMap := make([]int, len(n.columns))
+	idx := 0
+	for i := 0; i < n.pred.numLeftCols; i++ {
+		joinColMap[idx] = leftPlan.planToStreamColMap[i]
+		idx++
+	}
+	for i := 0; i < n.pred.numRightCols; i++ {
+		joinColMap[idx] = rightPlan.planToStreamColMap[i] + len(leftPlan.ResultTypes)
+		idx++
+	}
+
+	return distsqlplan.MakeExpression(n.pred.onCond, evalCtx, joinColMap)
+}
+
+// eqCols produces a slice of ordinal references for the plan columns specified
+// in eqIndices using planToColMap.
+// That is: eqIndices contains a slice of plan column indexes and planToColMap
+// maps the plan column indexes to the ordinal references (index of the
+// intermediate row produced).
+func eqCols(eqIndices, planToColMap []int) []uint32 {
+	eqCols := make([]uint32, len(eqIndices))
+	for i, planCol := range eqIndices {
+		eqCols[i] = uint32(planToColMap[planCol])
+	}
+
+	return eqCols
+}
+
+// distsqlOrdering converts the ordering specified by mergeJoinOrdering in
+// terms of the index of eqCols to the ordinal references provided by eqCols.
+func distsqlOrdering(
+	mergeJoinOrdering sqlbase.ColumnOrdering, eqCols []uint32,
+) distsqlrun.Ordering {
+	var ord distsqlrun.Ordering
+	ord.Columns = make([]distsqlrun.Ordering_Column, len(mergeJoinOrdering))
+	for i, c := range mergeJoinOrdering {
+		ord.Columns[i].ColIdx = eqCols[c.ColIdx]
+		dir := distsqlrun.Ordering_Column_ASC
+		if c.Direction == encoding.Descending {
+			dir = distsqlrun.Ordering_Column_DESC
+		}
+		ord.Columns[i].Direction = dir
+	}
+
+	return ord
+}
+
+func useInterleavedJoin(n *joinNode) bool {
+	if len(n.mergeJoinOrdering) == 0 {
+		return false
+	}
+
+	ancestor, descendant := n.interleavedNodes()
+
+	// There is no interleaved ancestor/descendant scan node and thus no
+	// interleaved relation.
+	if ancestor == nil || descendant == nil {
+		return false
+	}
+
+	// We cannot do an interleaved join if the tables require scanning in
+	// opposite directions.
+	if ancestor.reverse != descendant.reverse {
+		return false
+	}
+
+	var ancestorEqIndices []int
+	// We are guaranteed that both of the sources are scan nodes from
+	// n.interleavedNodes().
+	if ancestor == n.left.plan.(*scanNode) {
+		ancestorEqIndices = n.pred.leftEqualityIndices
+	} else {
+		ancestorEqIndices = n.pred.rightEqualityIndices
+	}
+
+	// We want full 1-1 correspondence between our join columns and the
+	// primary index of the ancestor.
+	//  TODO(richardwu): We can relax this once we implement a hybrid
+	//  hash/merge for interleaved joins after forming merge groups with the
+	//  interleave prefix (or when the merge join logic is combined with
+	//  the interleaved join logic).
+	if len(n.mergeJoinOrdering) != len(ancestor.index.ColumnIDs) {
+		return false
+	}
+
+	// We iterate through the ordering given by n.mergeJoinOrdering and check
+	// if the columns have a 1-1 correspondence to the interleaved
+	// ancestor's primary index columns (i.e. interleave prefix).  We
+	// naively return false if any part of the ordering does not
+	// correspond.
+	for i, info := range n.mergeJoinOrdering {
+		colID := ancestor.index.ColumnIDs[i]
+		// info.ColIdx refers to i in ancestorEqIndices[i], which refers
+		// to the index of the source row. This corresponds to
+		// the index in scanNode.resultColumns. To convert the colID
+		// from the index descriptor, we can use the map provided by
+		// colIdxMap.
+		if ancestorEqIndices[info.ColIdx] != ancestor.colIdxMap[colID] {
+			// The column in the ordering does not correspond to
+			// the column in the interleave prefix.
+			// We should not try to do an interleaved join.
+			return false
+		}
+	}
+
+	// The columns in n.mergeJoinOrdering has a 1-1 correspondence with the
+	// columns in the interleaved ancestor's primary index. We can indeed
+	// hint at the possibility of an interleaved join.
+	return true
+}
+
+// maximalJoinPrefix takes the common ancestor scanNode that the join is
+// defined on, the target scanNode that the index key belongs to and the index
+// key itself, and returns the maximal prefix of the key which is also a prefix
+// of all keys that need to be joined together.
+//
+// Let's denote a child key interleaved into a parent key in the following.
+// format:
+//   /table/index/<parent-pk1>/.../<parent-pkN>/#/<child-pk1>/.../<child-pkN>
+//
+// In the following examples, the ancestor is parent and the target is child.
+//
+// Let M be the longest prefix of the parent PK which is (equality) constrained
+// by the join. The maximal join prefix is:
+//   /table/index/<parent-pk1>/.../<parent-pkM>
+//
+// Examples (/table/index suppressed from keys):
+//  1. Full interleave (prefix) join:
+//
+//    1a. Parent table PK1
+//        Child table (PK1, PK2)
+//        Join on PK1
+//        For child key /5/#/42, the maximal join prefix is /5
+//
+//    1b. Parent table (PK1, PK2)
+//        Child table (PK1, PK2, PK3)
+//        Join on PK1, PK2
+//        for child key /5/6/#/42, the maximal join prefix is /5/6
+//
+//  2. Prefix joins:
+//        Parent table (PK1, PK2)
+//        Child table (PK1, PK2, PK3)
+//        Join on PK1 (this is a prefix of the parent PKs).
+//        For child key /5/6/#/42, the maximal join prefix is /5
+//
+//  3. Subest joins:
+//        Parent table (PK1, PK2, PK3)
+//        Child table (PK1, PK2, PK3, PK4)
+//        Join on PK1, PK3
+//        For child key /5/6/7/#/32, the maximal join prefix is /5
+//
+// This logic can also be extended in the general case to joins between sibling
+// joins with a common ancestor: the maximal join prefix will be applied to
+// both tables where each sibling scan is passed as the target scanNode.
+func maximalJoinPrefix(
+	ancestor *scanNode, target *scanNode, key roachpb.Key,
+) (roachpb.Key, bool, error) {
+	// To calculate how long this prefix is, we take a look at the actual
+	// encoding of an interleaved table's key
+	//   /table/index/<parent-pk1>/.../<parent-pkN>/#/.../table/index/<child-pk1>/.../<child-pkN>
+	// For each ancestor (including parent), we have
+	//   table, index, '#' (interleaved sentinel)
+	// or 3 values to peek at.
+	// We truncate up to the key M which is the last column in our join.
+	//   /table/index/<parent-pk1>/.../<parent-pkM>
+	// For the full interleaved join case, we need to count the number of
+	// columns in the shared interleave prefix (pk1 to pkM). We traverse the
+	// InterleaveDescriptor and add up SharedPrefixLen.
+	// We finally subtract 1 since we do not want to include the last
+	// interleaved sentinel '#'.
+	// Thus we need to peek (encoding.PeekLength())
+	//    3 * count(interleaved ancestors) + sum(SharedPrefixLen) - 1
+	// times to get the actual byte length of the prefix.
+	//
+	// Example:
+	//
+	// Given the following interleaved hierarchy (where their primary keys
+	// are in parentheses)
+	//   parent	      (pid1)
+	//     child	      (pid1, cid1, cid2)
+	//        grandchild  (pid1, cid1, cid2, gcid1)
+	//
+	// Let our join be defined on (pid1, cid1, cid2) and we want to join
+	// the child and grandchild tables.
+	//
+	// A grandchild key could be (pid1=5, cid1=6, cid2=7, gcid1=8)
+	//    /<parent-id>/1/5/#/<child-id>/1/6/7/#/<gchild-id>/1/8
+	//
+	// We'd like to take the prefix up to and including <cid2> or
+	//    /<parent-id>/1/5/#/<child-id>/1/6/7
+	//
+	// We must call encoding.PeekLength() 8 times or
+	//   3 * nAncestors + sum(SharedPrefixLen) - 1 = 3 * 2 + (1 + 2) - 1 = 8
+	// where the ancestor is child.
+	//
+	// TODO(richardwu): this formula works only for full interleaved joins.
+	// For prefix/subset joins, instead of adding the SharedPrefixLen of
+	// the ancestor the join is defined on, we would add the number of
+	// prefix columns in our interleave prefix that we are joining on.
+	nAncestors := 0
+	sharedPrefixLen := 0
+	for _, targetAncs := range target.index.Interleave.Ancestors {
+		nAncestors++
+		sharedPrefixLen += int(targetAncs.SharedPrefixLen)
+		if targetAncs.TableID == ancestor.desc.ID && targetAncs.IndexID == ancestor.index.ID {
+			break
+		}
+	}
+
+	initialKey := key
+	prefixLen := 0
+	for i := 0; i < 3*nAncestors+sharedPrefixLen-1; i++ {
+		// It's possible for the span key to not contain the full join
+		// prefix (a key might refer to an ancestor further up the
+		// interleaved hierarchy).
+		if len(key) == 0 {
+			break
+		}
+		valLen, err := encoding.PeekLength(key)
+		if err != nil {
+			return nil, false, err
+		}
+		prefixLen += valLen
+		key = key[valLen:]
+	}
+
+	if len(key) > 0 {
+		// There are remaining bytes in the key: we truncate it and
+		// return true.
+		return initialKey[:prefixLen], true, nil
+	}
+
+	// The loop terminated early because the key is shorter than the
+	// full join prefix.
+	// We return false to denote that this key was not truncated to
+	// form the join prefix.
+	return initialKey, false, nil
+}
+
+// sortedSpanPartitions implements sort.Interface. Sorting is defined on the
+// node ID of each partition.
+type sortedSpanPartitions []spanPartition
+
+func (s sortedSpanPartitions) Len() int           { return len(s) }
+func (s sortedSpanPartitions) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s sortedSpanPartitions) Less(i, j int) bool { return s[i].node < s[j].node }
+
+// alignInterleavedSpans takes the partitioned spans from both the parent
+// (parentSpans) and (not necessarily direct) child (childSpans), "aligns" them
+// and returns childSpans such that all child keys that need to be joined with
+// their corresponding parent keys are mapped to the parent keys' partition.
+// This ensures that we correctly join all parent-child rows within the
+// node-contained InterleavedReaderJoiner.
+//
+// For each parentSpan, a "join span" is computed.
+// The "join span" is a span that includes all child rows that need to be
+// joined with parent rows in the span.
+//
+// With the "join span" of each parent span, we can find any child spans that
+// need to be remapped to the same node as the parent span.
+//
+// We iterate through each child span and see which parent join span overlaps.
+//
+// If there is no overlap with any join span, there can't possibly be any join
+// results from this child span. We still need to keep it for outer joins, but
+// it doesn't need to be remapped.
+//
+// If there is overlap with some parent join span, there exist "some" child
+// keys in the span that need to be mapped to the parent span. The sections of
+// the child span that do not overlap need to be split off and potentially
+// remapped to other parent join spans.
+//
+// The child span gets split as necessary on the join span's boundaries. The
+// split that overlaps the join span is (re-)mapped to the parent span. Any
+// remaining splits are considered separately with the same logic.
+func alignInterleavedSpans(
+	n *joinNode, parentSpans []spanPartition, childSpans []spanPartition,
+) ([]spanPartition, error) {
+	mappedSpans := make(map[roachpb.NodeID]roachpb.Spans)
+
+	// Map parent spans to their join span.
+	joinSpans, err := joinSpans(n, parentSpans)
+	if err != nil {
+		return nil, err
+	}
+
+	// mapAndSplit takes a childSpan and finds the parentJoinSpan that has
+	// the parent row(s) with which the child row(s) are suppose to join.
+	// It does this by finding overlaps between childSpan and
+	// parentJoinSpan.
+	// It splits off the non-overlapping parts and appends them to
+	// the passed in nonOverlaps slice for repeated application.
+	mapAndSplit := func(curNodeID roachpb.NodeID, childSpan roachpb.Span, nonOverlaps roachpb.Spans) roachpb.Spans {
+		// TODO(richardwu): Instead of doing a linear search for each
+		// child span, we can make this O(logn) with binary search
+		// after pre-sorting the parent join spans.
+		for _, parentPart := range joinSpans {
+			for _, parentJoinSpan := range parentPart.spans {
+				if parentJoinSpan.Overlaps(childSpan) {
+					// Initialize the overlap region
+					// as the entire childSpan.
+					overlap := childSpan
+					var nonOverlap roachpb.Span
+
+					// Check non-overlapping region
+					// before start key.
+					//	    |----parentJoinSpan----...
+					//  |----childSpan----...
+					if bytes.Compare(parentJoinSpan.Key, childSpan.Key) > 0 {
+						nonOverlap, overlap = overlap.SplitOnKey(parentJoinSpan.Key)
+						nonOverlaps = append(nonOverlaps, nonOverlap)
+					}
+
+					// Check non-overlapping region
+					// before end key.
+					//  ...----parentJoinSpan----|
+					//		  ...----childSpan----|
+					if bytes.Compare(parentJoinSpan.EndKey, childSpan.EndKey) < 0 {
+						overlap, nonOverlap = overlap.SplitOnKey(parentJoinSpan.EndKey)
+						nonOverlaps = append(nonOverlaps, nonOverlap)
+					}
+
+					// Map the overlap region to the
+					// partition/node of the
+					// parentJoinSpan.
+					mappedSpans[parentPart.node] = append(mappedSpans[parentPart.node], overlap)
+
+					return nonOverlaps
+				}
+			}
+		}
+
+		// There was no corresponding parentJoinSpan for this
+		// childSpan.  We simply map childSpan back to its current
+		// partition/node.
+		mappedSpans[curNodeID] = append(mappedSpans[curNodeID], childSpan)
+
+		return nonOverlaps
+	}
+
+	// Buffer to store spans that still need to be mapped.
+	// It is initialized with the initial childSpan and may be populated
+	// with non-overlapping sub-spans as mapAndSplit is invoked.
+	// Note this is unbounded since a mapAndSplit of one childSpan can
+	// cause two non-overlapping spans to be generated.
+	// We recurse on the non-overlapping spans until none are left before
+	// moving on to the next childSpan.
+	spansLeft := make(roachpb.Spans, 0, 2)
+	for _, childPart := range childSpans {
+		for _, childSpan := range childPart.spans {
+			spansLeft = append(spansLeft, childSpan)
+			for len(spansLeft) > 0 {
+				// Copy out the last span in spansLeft to
+				// mapAndSplit.
+				spanToMap := spansLeft[len(spansLeft)-1]
+				// Discard the element from spansLeft and
+				// reclaim one buffer space.
+				spansLeft = spansLeft[:len(spansLeft)-1]
+				// We map every child span to its
+				// corresponding parent span.
+				// Splitting the child span may be
+				// necessary which may produce up to two
+				// non-overlapping sub-spans that are
+				// appended to spansLeft.
+				spansLeft = mapAndSplit(childPart.node, spanToMap, spansLeft)
+			}
+		}
+	}
+
+	// It's possible from the mapAndSplit logic that we end up with
+	// adjacent spans on the same node. We want to clean this up by
+	// merging them.
+	alignedDescSpans := make(sortedSpanPartitions, 0, len(mappedSpans))
+	for nodeID, spans := range mappedSpans {
+		spans, _ = roachpb.MergeSpans(spans)
+		alignedDescSpans = append(
+			alignedDescSpans,
+			spanPartition{
+				node:  nodeID,
+				spans: spans,
+			},
+		)
+	}
+
+	sort.Sort(alignedDescSpans)
+
+	return alignedDescSpans, nil
+}
+
+// The derivation of the "join span" for a parent span is as follows (see
+// comment above alignInterleaveSpans for why this is needed):
+//
+//   1. Start key of join span (the first parent key in parentSpan)
+//
+//      Take the maximalJoinPrefix (MJP) of parentSpan.Key. If the MJP Is
+//      the same with parentSpan.Key (no truncation occurred), then it is also
+//      the join span start key (examples A, B above).
+//      Otherwise, the parentSpan.Key contains more than parent keys, and
+//      because child rows come after parent rows, the join span start key is
+//      the PrefixEnd() of the MJP (examples C, D).
+//
+//   2. End key of the join span: the next parent key after the last parent key
+//      in parentSpan (it needs to be the next key because child rows come after
+//      the parent rows).
+//
+//      Take the maximalJoinPrefix (MJP) of parentSpan.EndKey. If the MJP
+//      is the same with parentSpan.EndKey (no truncation occurred), then it is
+//      also the join span end key (examples A, C).
+//      Otherwise, parentSpan.EndKey contains more than parent keys and needs to
+//      be extended to include all child rows for the last parent row; the join
+//      span end key is the PrefixEnd() of the MJP (examples B, D).
+//
+// To illustrate, we'll use some examples of parent spans (/table/index omitted
+// from keys):
+//   A. /1 - /3
+//      This span contains parent rows with primary keys 1, 2, and all
+//      corresponding child rows. The join span is the same: /1 - /3.
+//
+//   B. /1 - /3/#/1
+//      This span contains parent rows with primary key 1, 2, 3 and all child
+//      rows corresponding to 1, 2 (note that /3/#/1 comes after all the parent
+//      rows with 3 but before all corresponding child rows). The join span is:
+//      /1 - /4.
+//
+//   C. /1/#/1 - /4
+//      This span contains parent rows with primary key 2, 3 and all child rows
+//      corresponding to 1, 2, 3. The join span is: /2 - /4.
+//
+//   D. /1/#/1 - /2/#/1
+//      This span contains the parent row with primary key 2 and all child rows
+//      corresponding to 1, 2. The join span is: /2 - /3.
+//
+// The corresponding joinSpans for a set of parentSpans is disjoint if and only
+// if the parentSpans are disjoint in terms of the parent rows.
+// That is, as long as only 1 node reads a given parent row for all parent
+// rows, the joinSpans are guaranteed to be non-overlapping.
+// End keys are only pushed forward to the next parent row if the span contains
+// the previous parent row.
+// Since the previous row is read on that one node, it is not possible for the
+// subsequent span on a different node to contain the previous row.
+// The start key will be pushed forward to at least the next row, which
+// maintains the disjoint property.
+func joinSpans(n *joinNode, parentSpans []spanPartition) ([]spanPartition, error) {
+	joinSpans := make([]spanPartition, len(parentSpans))
+
+	parent, child := n.interleavedNodes()
+
+	// Compute the join span for every parent span.
+	for i, parentPart := range parentSpans {
+		joinSpans[i].node = parentPart.node
+		joinSpans[i].spans = make(roachpb.Spans, len(parentPart.spans))
+
+		for j, parentSpan := range parentPart.spans {
+			// Step 1: start key.
+			joinSpanStartKey, startTruncated, err := maximalJoinPrefix(parent, child, parentSpan.Key)
+			if err != nil {
+				return nil, err
+			}
+			if startTruncated {
+				// parentSpan.Key is a child key.
+				// Example C and D.
+				joinSpanStartKey = joinSpanStartKey.PrefixEnd()
+			}
+
+			// Step 2: end key.
+			joinSpanEndKey, endTruncated, err := maximalJoinPrefix(parent, child, parentSpan.EndKey)
+			if err != nil {
+				return nil, err
+			}
+
+			if endTruncated {
+				// parentSpan.EndKey is a child key.
+				// Example B and D.
+				joinSpanEndKey = joinSpanEndKey.PrefixEnd()
+			}
+
+			// We don't need to check if joinSpanStartKey <
+			// joinSpanEndKey since the invalid spans will be
+			// ignored during Span.Overlaps.
+			joinSpans[i].spans[j] = roachpb.Span{
+				Key:    joinSpanStartKey,
+				EndKey: joinSpanEndKey,
+			}
+		}
+	}
+
+	return joinSpans, nil
+}

--- a/pkg/sql/distsql_plan_join_test.go
+++ b/pkg/sql/distsql_plan_join_test.go
@@ -1,0 +1,724 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+func setTestEqCols(n *joinNode, colNames []string) error {
+	left := n.left.plan.(*scanNode)
+	right := n.right.plan.(*scanNode)
+
+	n.pred = &joinPredicate{}
+	n.mergeJoinOrdering = nil
+
+	for _, colName := range colNames {
+		if colName == "" {
+			continue
+		}
+
+		colFound := false
+		for i, leftCol := range left.cols {
+			if colName == leftCol.Name {
+				n.pred.leftEqualityIndices = append(
+					n.pred.leftEqualityIndices,
+					i,
+				)
+				colFound = true
+				break
+			}
+		}
+		if !colFound {
+			return errors.Errorf("column %s not found in %s", colName, left.desc.Name)
+		}
+
+		colFound = false
+		for i, rightCol := range right.cols {
+			if colName == rightCol.Name {
+				n.pred.rightEqualityIndices = append(
+					n.pred.rightEqualityIndices,
+					i,
+				)
+				colFound = true
+				break
+			}
+		}
+		if !colFound {
+			return errors.Errorf("column %s not found in %s", colName, right.desc.Name)
+		}
+	}
+
+	n.mergeJoinOrdering = computeMergeJoinOrdering(
+		planPhysicalProps(n.left.plan),
+		planPhysicalProps(n.right.plan),
+		n.pred.leftEqualityIndices,
+		n.pred.rightEqualityIndices,
+	)
+
+	return nil
+}
+
+func genPermutations(slice []string) [][]string {
+	if len(slice) == 0 {
+		return [][]string{{}}
+	}
+
+	var out [][]string
+	for i, str := range slice {
+		recurse := append([]string{}, slice[:i]...)
+		recurse = append(recurse, slice[i+1:]...)
+		for _, subperms := range genPermutations(recurse) {
+			out = append(out, append([]string{str}, subperms...))
+		}
+	}
+
+	return out
+}
+
+var tableNames = map[string]bool{
+	"parent1":     true,
+	"child1":      true,
+	"grandchild1": true,
+	"child2":      true,
+	"parent2":     true,
+}
+
+// Format for any key:
+//   <table-name>/<index-id>/<index-col1>/.../#/<table-name>/<index-id>/....
+func encodeTestKey(kvDB *client.DB, keyStr string) (roachpb.Key, error) {
+	var key []byte
+	tokens := strings.Split(keyStr, "/")
+
+	for _, tok := range tokens {
+		// Encode the table ID if the token is a table name.
+		if tableNames[tok] {
+			desc := sqlbase.GetTableDescriptor(kvDB, sqlutils.TestDB, tok)
+			key = encoding.EncodeUvarintAscending(key, uint64(desc.ID))
+			continue
+		}
+
+		// Interleaved sentinel.
+		if tok == "#" {
+			key = encoding.EncodeNotNullDescending(key)
+			continue
+		}
+
+		// Assume any other value is an unsigned integer.
+		tokInt, err := strconv.ParseUint(tok, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		key = encoding.EncodeUvarintAscending(key, tokInt)
+	}
+
+	return key, nil
+}
+
+func decodeTestKey(kvDB *client.DB, key roachpb.Key) (string, error) {
+	var out []byte
+
+	keyStr := roachpb.PrettyPrintKey(nil /* valDirs */, key)
+	tokens := strings.Split(keyStr, "/")[1:]
+
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+		// We know for certain the next token is the table ID. Need
+		// to convert into a table name.
+		if tok == "Table" || tok == "#" {
+			if tok == "#" {
+				out = append(out, []byte("#/")...)
+			}
+
+			descID, err := strconv.ParseUint(tokens[i+1], 10, 64)
+			if err != nil {
+				return "", err
+			}
+
+			if err := kvDB.Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
+				desc, err := sqlbase.GetTableDescFromID(context.TODO(), txn, sqlbase.ID(descID))
+				if err != nil {
+					return err
+				}
+
+				out = append(out, []byte(desc.Name)...)
+				return nil
+			}); err != nil {
+				return "", err
+			}
+
+			// We read an extra token for the table ID.
+			i++
+		} else {
+			// Encode anything else as is.
+			out = append(out, []byte(tok)...)
+		}
+
+		out = append(out, '/')
+	}
+
+	// Omit the last '/'.
+	return string(out[:len(out)-1]), nil
+}
+
+// See CreateTestInterleavedHierarchy for the longest chain used for the short
+// format.
+var shortFormTables = [3]string{"parent1", "child1", "grandchild1"}
+
+// shortToLongKey converts the short key format preferred in test cases
+//    /1/#/3/4
+// to its long form required by parseTestkey
+//    parent1/1/1/#/child1/1/3/4
+func shortToLongKey(short string) string {
+	tableOrder := shortFormTables
+	curTableIdx := 0
+
+	var long []byte
+	tokens := strings.Split(short, "/")
+	// Verify short format starts with '/'.
+	if tokens[0] != "" {
+		panic("missing '/' token at the beginning of short format")
+	}
+	// Skip the first element since short format has starting '/'.
+	tokens = tokens[1:]
+
+	// Always append parent1.
+	long = append(long, []byte(fmt.Sprintf("%s/1/", tableOrder[curTableIdx]))...)
+	curTableIdx++
+
+	for _, tok := range tokens {
+		// New interleaved table and primary keys follow.
+		if tok == "#" {
+			if curTableIdx >= len(tableOrder) {
+				panic("too many '#' tokens specified in short format (max 2 for child1 and grandchild1)")
+			}
+
+			long = append(long, []byte(fmt.Sprintf("#/%s/1/", tableOrder[curTableIdx]))...)
+			curTableIdx++
+
+			continue
+		}
+
+		long = append(long, []byte(fmt.Sprintf("%s/", tok))...)
+	}
+
+	// Remove the last '/'.
+	return string(long[:len(long)-1])
+}
+
+func TestUseInterleavedJoin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	sqlutils.CreateTestInterleavedHierarchy(t, sqlDB)
+
+	// Only test cases on the full interleave prefix between the two
+	// tables should return false.
+	for _, tc := range []struct {
+		table1   string
+		table2   string
+		eqCols   string
+		expected bool
+	}{
+		// Refer to comment above CreateTestInterleavedHierarchy for
+		// table schemas.
+
+		// Simple parent-child case.
+		// parent1-child1 share interleave prefix (pid1).
+		{"parent1", "child1", "pid1", true},
+		{"parent1", "child1", "pid1,v", true},
+		{"parent1", "child1", "", false},
+		{"parent1", "child1", "v", false},
+		// Parent-grandchild case.
+		// parent1-grandchild1 share interleave prefix (pid1).
+		{"parent1", "grandchild1", "pid1", true},
+		{"parent1", "grandchild1", "pid1,v", true},
+		{"parent1", "grandchild1", "", false},
+		{"parent1", "grandchild1", "v", false},
+		// Multiple-column interleave prefix.
+		// child1-grandchild1 share interleave prefix (pid1, cid1,
+		// cid2).
+		{"child1", "grandchild1", "pid1,cid1,cid2", true},
+		{"child1", "grandchild1", "pid1,cid1,cid2,v", true},
+		{"child1", "grandchild1", "", false},
+		{"child1", "grandchild1", "v", false},
+		// TODO(richardwu): update these once prefix/subset of
+		// interleave prefixes are permitted.
+		{"child1", "grandchild1", "cid1", false},
+		{"child1", "grandchild1", "cid2", false},
+		{"child1", "grandchild1", "cid1,v", false},
+		{"child1", "grandchild1", "cid2,v", false},
+		{"child1", "grandchild1", "cid1,cid2", false},
+		{"child1", "grandchild1", "cid1,cid2,v", false},
+		{"child1", "grandchild1", "pid1,cid1", false},
+		{"child1", "grandchild1", "pid1,cid2", false},
+		{"child1", "grandchild1", "pid1,cid1,v", false},
+		{"child1", "grandchild1", "pid1,cid2,v", false},
+		// Common ancestor example.
+		{"child1", "child2", "", false},
+		// TODO(richardwu): update this when common ancestor
+		// interleaved joins are possible.
+		{"child1", "child2", "pid1", false},
+	} {
+		// Run the subtests with the tables in both positions (left and
+		// right).
+		for i := 0; i < 2; i++ {
+			// Run every permutation of the equality columns (just
+			// to ensure mergeJoinOrdering is invariant since we
+			// rely on it to correspond with the primary index of
+			// the ancestor).
+			eqCols := strings.Split(tc.eqCols, ",")
+			for _, colNames := range genPermutations(eqCols) {
+				testName := fmt.Sprintf("%s-%s-%s", tc.table1, tc.table2, strings.Join(colNames, ","))
+				t.Run(testName, func(t *testing.T) {
+					join, err := newTestJoinNode(kvDB, tc.table1, tc.table2)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if err := setTestEqCols(join, colNames); err != nil {
+						t.Fatal(err)
+					}
+
+					actual := useInterleavedJoin(join)
+
+					if tc.expected != actual {
+						t.Errorf("expected useInterleaveJoin to return %t, actual %t", tc.expected, actual)
+					}
+				})
+			}
+			// Rerun the same subtests but flip the tables
+			tc.table1, tc.table2 = tc.table2, tc.table1
+		}
+	}
+}
+
+func TestMaximalJoinPrefix(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	sqlutils.CreateTestInterleavedHierarchy(t, sqlDB)
+
+	testCases := []struct {
+		table1    string
+		table2    string
+		input     string
+		expected  string
+		truncated bool
+	}{
+		// Key is already an ancestor prefix.
+		{"parent1", "child1", "/2", "/2", false},
+
+		// Key of descendant child1.
+		{"parent1", "child1", "/2/#/3/4", "/2", true},
+
+		// Partial key of descendant child1 (only cid1, missing cid2).
+		{"parent1", "child1", "/2/#/1/3", "/2", true},
+
+		// Key of descendant grandchild1.
+		{"parent1", "grandchild1", "/2/#/3/4/#/5", "/2", true},
+
+		// Key of some descendant child1 is still a descendant key
+		// of parent1.
+		{"parent1", "grandchild1", "/2/#/3/4", "/2", true},
+
+		// Key is already an ancestor prefix of child1.
+		{"child1", "grandchild1", "/2/#/3/4", "/2/#/3/4", false},
+
+		// Key of descendant grandchild1 with ancestor child1:
+		// prefix of parent1 retained.
+		{"child1", "grandchild1", "/2/#/3/4/#/5", "/2/#/3/4", true},
+
+		// TODO(richardwu): prefix/subset joins and sibiling joins.
+	}
+
+	for testIdx, tc := range testCases {
+		t.Run(strconv.Itoa(testIdx), func(t *testing.T) {
+			join, err := newTestJoinNode(kvDB, tc.table1, tc.table2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			input, err := encodeTestKey(kvDB, shortToLongKey(tc.input))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ancestor, descendant := join.interleavedNodes()
+
+			// Compute maximal join prefix.
+			actualKey, truncated, err := maximalJoinPrefix(ancestor, descendant, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual, err := decodeTestKey(kvDB, actualKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected := shortToLongKey(tc.expected)
+
+			if expected != actual {
+				t.Errorf("unexpected maximal join prefix.\nexpected:\t%s\nactual:\t%s", expected, actual)
+			}
+
+			if tc.truncated != truncated {
+				t.Errorf("expected maximalJoinPrefix to return %t for truncated, got %t", tc.truncated, truncated)
+			}
+		})
+	}
+}
+
+type testPartition struct {
+	node  roachpb.NodeID
+	spans [][2]string
+}
+
+func makeSpanPartitions(kvDB *client.DB, testParts []testPartition) ([]spanPartition, error) {
+	spanParts := make([]spanPartition, len(testParts))
+
+	for i, testPart := range testParts {
+		spanParts[i].node = testPart.node
+		for _, span := range testPart.spans {
+			start, err := encodeTestKey(kvDB, shortToLongKey(span[0]))
+			if err != nil {
+				return nil, err
+			}
+
+			end, err := encodeTestKey(kvDB, shortToLongKey(span[1]))
+			if err != nil {
+				return nil, err
+			}
+
+			spanParts[i].spans = append(
+				spanParts[i].spans,
+				roachpb.Span{Key: start, EndKey: end},
+			)
+		}
+	}
+
+	return spanParts, nil
+}
+
+func TestAlignInterleavedSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	sqlutils.CreateTestInterleavedHierarchy(t, sqlDB)
+
+	testCases := []struct {
+		table1 string
+		table2 string
+
+		ancsParts []testPartition
+		descParts []testPartition
+		expected  []testPartition
+	}{
+		// Test that child1 spans get mapped to their corresponding
+		// parent1 spans and the descendant span is recursively split
+		// to satisfaction.
+		{
+			table1: "parent1", table2: "child1",
+
+			ancsParts: []testPartition{
+				// Test that the next parent row after the
+				// last is computed properly if the end key
+				// is not a parent1 key.
+				{1, [][2]string{{"/1", "/2/#/5"}}},
+				// End key is a parent1 key.
+				{2, [][2]string{{"/3", "/4"}}},
+				{3, [][2]string{{"/4", "/5"}}},
+			},
+
+			descParts: []testPartition{
+				{4, [][2]string{{"/1/#/7", "/4/#/8"}}},
+			},
+
+			expected: []testPartition{
+				{1, [][2]string{{"/1/#/7", "/3"}}},
+				{2, [][2]string{{"/3", "/4"}}},
+				{3, [][2]string{{"/4", "/4/#/8"}}},
+			},
+		},
+
+		// Test that child spans do not get remapped if they're already
+		// on the correct node.
+		{
+			table1: "parent1", table2: "child1",
+
+			ancsParts: []testPartition{
+				{1, [][2]string{{"/1", "/3"}}},
+			},
+
+			descParts: []testPartition{
+				{1, [][2]string{{"/1/#/7", "/2/#/8"}}},
+			},
+
+			expected: []testPartition{
+				{1, [][2]string{{"/1/#/7", "/2/#/8"}}},
+			},
+		},
+
+		// Test that even if the parent1 span does not entirely contain
+		// the child1 span, it gets mapped to the relevant parent row
+		// correctly.
+		{
+			table1: "parent1", table2: "child1",
+
+			ancsParts: []testPartition{
+				{1, [][2]string{{"/1", "/1/#/5"}}},
+			},
+
+			descParts: []testPartition{
+				{2, [][2]string{{"/1/#/7", "/1/#/8"}}},
+			},
+
+			expected: []testPartition{
+				{1, [][2]string{{"/1/#/7", "/1/#/8"}}},
+			},
+		},
+
+		// Test that multiple child spans mapped to the same nodes
+		// are merged and properly ordered.
+		{
+			table1: "parent1", table2: "child1",
+
+			ancsParts: []testPartition{
+				// Multiple spans within each partition.
+				{1, [][2]string{
+					{"/1", "/1/#/1"},
+					{"/1/#/1", "/2"},
+				}},
+				{2, [][2]string{
+					{"/2", "/2/#/1/1/#/8"},
+					{"/2/#/1/1/#/8", "/2/#/3/5"},
+					{"/2/#/3/5", "/3"},
+				}},
+			},
+
+			descParts: []testPartition{
+				{1, [][2]string{
+					// pid1=1 rows should map to node 1.
+					{"/1/#/1", "/1/#/2"},
+					{"/1/#/7", "/1/#/9"},
+					// pid1=2 rows should map to node 2.
+					{"/2/#/1", "/2/#/2"},
+					{"/2/#/5", "/2/#/8"},
+				}},
+				{2, [][2]string{
+					// pid1=1 rows should map to node 1.
+					{"/1/#/2", "/1/#/7"},
+					// pid1=2 rows should map to node 2.
+					// Overlaps with previous spans in node
+					// 1.
+					{"/2/#/2", "/2/#/6"},
+				}},
+				{3, [][2]string{
+					// pid1=1 rows should map to node 1.
+					{"/1/#/11", "/1/#/13"},
+					// pid1=2 rows should map to node 2.
+					{"/2/#/11", "/2/#/15"},
+				}},
+				// pid1=1 and pid=2 rows in a span.
+				{4, [][2]string{{"/1/#/15", "/2/#/0/7/#/1"}}},
+			},
+
+			expected: []testPartition{
+				{1, [][2]string{
+					{"/1/#/1", "/1/#/9"},
+					{"/1/#/11", "/1/#/13"},
+					{"/1/#/15", "/2"},
+				}},
+				{2, [][2]string{
+					{"/2", "/2/#/0/7/#/1"},
+					{"/2/#/1", "/2/#/8"},
+					{"/2/#/11", "/2/#/15"},
+				}},
+			},
+		},
+
+		// Test with child1 spans having parent1 keys split points.
+		{
+			table1: "parent1", table2: "child1",
+
+			ancsParts: []testPartition{
+				{1, [][2]string{{"/1", "/2"}}},
+				{2, [][2]string{{"/2", "/3"}}},
+				{3, [][2]string{{"/3", "/4"}}},
+			},
+
+			descParts: []testPartition{
+				{1, [][2]string{{"/2", "/3"}}},
+				// Technically not possible for two partitions
+				// to have the same span.
+				{3, [][2]string{{"/1", "/2"}}},
+				{6, [][2]string{{"/1", "/2"}}},
+			},
+
+			expected: []testPartition{
+				{1, [][2]string{{"/1", "/2"}}},
+				{2, [][2]string{{"/2", "/3"}}},
+			},
+		},
+
+		// Test child1 span that do not need to be remapped are still
+		// split by the next parent1 row after the last.
+		{
+			table1: "parent1", table2: "child1",
+
+			ancsParts: []testPartition{
+				{1, [][2]string{{"/1", "/2"}}},
+				{2, [][2]string{{"/2", "/3"}}},
+			},
+
+			descParts: []testPartition{
+				{1, [][2]string{{"/1", "/3"}}},
+			},
+
+			expected: []testPartition{
+				{1, [][2]string{{"/1", "/2"}}},
+				{2, [][2]string{{"/2", "/3"}}},
+			},
+		},
+
+		// Test that child1 spans that have no corresponding parent1
+		// span are not remapped.
+		{
+			table1: "parent1", table2: "child1",
+
+			ancsParts: []testPartition{
+				{1, [][2]string{{"/1", "/2"}}},
+				{2, [][2]string{{"/2", "/3"}}},
+			},
+
+			descParts: []testPartition{
+				// No corresponding parent span: not remapped.
+				{1, [][2]string{{"/4", "/5"}}},
+				// Partially no corresponding parent span.
+				{2, [][2]string{{"/2", "/4"}}},
+			},
+
+			expected: []testPartition{
+				{1, [][2]string{{"/4", "/5"}}},
+				{2, [][2]string{{"/2", "/4"}}},
+			},
+		},
+
+		// Test parent-grandchild example.
+		{
+			table1: "parent1", table2: "grandchild1",
+
+			ancsParts: []testPartition{
+				{1, [][2]string{{"/1", "/2/#/1/1/#/5"}}},
+				{2, [][2]string{{"/3", "/4"}}},
+				{3, [][2]string{{"/4", "/5"}}},
+			},
+
+			descParts: []testPartition{
+				{4, [][2]string{{"/1/#/42/37/#/5", "/2/#/1/1/#/5"}}},
+				// Partial child1 key (instead of grandchild1).
+				{5, [][2]string{{"/3/#/1", "/4/#/1/1/#/5"}}},
+			},
+
+			expected: []testPartition{
+				{1, [][2]string{{"/1/#/42/37/#/5", "/2/#/1/1/#/5"}}},
+				{2, [][2]string{{"/3/#/1", "/4"}}},
+				{3, [][2]string{{"/4", "/4/#/1/1/#/5"}}},
+			},
+		},
+
+		// Test child-grandchild example.
+		{
+			table1: "child1", table2: "grandchild1",
+
+			ancsParts: []testPartition{
+				{1, [][2]string{{"/1/#/2/3", "/2"}}},
+				{2, [][2]string{{"/2/#/2/3", "/2/#/5/2"}}},
+				{3, [][2]string{{"/4", "/5"}}},
+				{4, [][2]string{{"/2/#/5/2", "/2/#/6"}}},
+			},
+
+			descParts: []testPartition{
+				// Starts before any of the child1 spans.
+				{5, [][2]string{{"/1", "/1/#/5/6"}}},
+				// Starts in between the first and second
+				// child1 spans.
+				{6, [][2]string{{"/2/#/1/2", "/2/#/5/2/#/7"}}},
+			},
+
+			expected: []testPartition{
+				{1, [][2]string{{"/1/#/2/3", "/1/#/5/6"}}},
+				{2, [][2]string{{"/2/#/2/3", "/2/#/5/2"}}},
+				{4, [][2]string{{"/2/#/5/2", "/2/#/5/2/#/7"}}},
+				{5, [][2]string{{"/1", "/1/#/2/3"}}},
+				{6, [][2]string{{"/2/#/1/2", "/2/#/2/3"}}},
+			},
+		},
+	}
+
+	for testIdx, tc := range testCases {
+		t.Run(strconv.Itoa(testIdx), func(t *testing.T) {
+			join, err := newTestJoinNode(kvDB, tc.table1, tc.table2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ancsParts, err := makeSpanPartitions(kvDB, tc.ancsParts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			descParts, err := makeSpanPartitions(kvDB, tc.descParts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			actual, err := alignInterleavedSpans(join, ancsParts, descParts)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			expected, err := makeSpanPartitions(kvDB, tc.expected)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(expected, actual) {
+				t.Errorf("unexpected partition results after aligning.\nexpected:\t%v\nactual:\t%v", expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -476,6 +476,14 @@ func newProcessor(
 			flowCtx, core.MergeJoiner, inputs[0], inputs[1], post, outputs[0],
 		)
 	}
+	if core.InterleavedReaderJoiner != nil {
+		if err := checkNumInOut(inputs, outputs, 0, 1); err != nil {
+			return nil, err
+		}
+		return newInterleavedReaderJoiner(
+			flowCtx, core.InterleavedReaderJoiner, post, outputs[0],
+		)
+	}
 	if core.HashJoiner != nil {
 		if err := checkNumInOut(inputs, outputs, 2, 1); err != nil {
 			return nil, err

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -817,3 +817,57 @@ func (n *joinNode) joinOrdering() physicalProps {
 	info.ordering = info.reduce(info.ordering)
 	return info
 }
+
+// interleavedNodes returns the ancestor on which an interleaved join is
+// defined as well as the descendants of this ancestor which participate in
+// the join. One of the left/right scan nodes is the ancestor and the other
+// descendant. Nils are returned if there is no interleaved relationship.
+// TODO(richardwu): For sibling joins, both left and right tables are
+// "descendants" while the ancestor is some common ancestor. We will need to
+// probably return descendants as a slice.
+//
+// An interleaved join has an equality on some columns of the interleave prefix.
+// The "interleaved join ancestor" is the ancestor which contains all these
+// join columns in its primary key.
+// TODO(richardwu): For prefix/subset joins, this ancestor will be the furthest
+// ancestor down the interleaved hierarchy which contains all the columns of
+// the maximal join prefix (see maximalJoinPrefix in distsql_join.go).
+func (n *joinNode) interleavedNodes() (ancestor *scanNode, descendant *scanNode) {
+	leftScan, leftOk := n.left.plan.(*scanNode)
+	rightScan, rightOk := n.right.plan.(*scanNode)
+
+	if !leftOk || !rightOk {
+		return nil, nil
+	}
+
+	leftAncestors := leftScan.index.Interleave.Ancestors
+	rightAncestors := rightScan.index.Interleave.Ancestors
+
+	// A join between an ancestor and descendant: the descendant of the two
+	// tables must have have more interleaved ancestors than the other,
+	// which makes the other node the potential interleaved ancestor.
+	// TODO(richardwu): The general case where we can have a join
+	// on a common ancestor's primary key requires traversing both
+	// ancestor slices.
+	if len(leftAncestors) > len(rightAncestors) {
+		ancestor = rightScan
+		descendant = leftScan
+	} else {
+		ancestor = leftScan
+		descendant = rightScan
+	}
+
+	// We check the ancestors of the potential descendant to see if any of
+	// them match the potential ancestor.
+	for _, descAncestor := range descendant.index.Interleave.Ancestors {
+		if descAncestor.TableID == ancestor.desc.ID && descAncestor.IndexID == ancestor.index.ID {
+			// If the tables are indeed interleaved, then we return
+			// the potentials as confirmed ancestor-descendant.
+			return ancestor, descendant
+		}
+	}
+
+	// We could not establish an ancestor-descendant relationship so we
+	// return nils for both.
+	return nil, nil
+}

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -1,0 +1,122 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"golang.org/x/net/context"
+)
+
+func newTestScanNode(kvDB *client.DB, tableName string) (*scanNode, error) {
+	desc := sqlbase.GetTableDescriptor(kvDB, sqlutils.TestDB, tableName)
+
+	p := planner{}
+	scan := p.Scan()
+	scan.desc = desc
+	err := scan.initDescDefaults(p.planDeps, publicColumns, nil)
+	if err != nil {
+		return nil, err
+	}
+	scan.initOrdering(0, &p.evalCtx)
+	return scan, nil
+}
+
+func newTestJoinNode(kvDB *client.DB, leftName, rightName string) (*joinNode, error) {
+	left, err := newTestScanNode(kvDB, leftName)
+	if err != nil {
+		return nil, err
+	}
+	right, err := newTestScanNode(kvDB, rightName)
+	if err != nil {
+		return nil, err
+	}
+	return &joinNode{
+		left:  planDataSource{plan: left},
+		right: planDataSource{plan: right},
+	}, nil
+}
+
+func TestInterleavedNodes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	sqlutils.CreateTestInterleavedHierarchy(t, sqlDB)
+
+	for _, tc := range []struct {
+		table1     string
+		table2     string
+		ancestor   string
+		descendant string
+	}{
+		// Refer to comment above CreateTestInterleavedHierarchy for
+		// table schemas.
+
+		{"parent1", "child1", "parent1", "child1"},
+		{"parent1", "child2", "parent1", "child2"},
+		{"parent1", "grandchild1", "parent1", "grandchild1"},
+		{"child1", "child2", "", ""},
+		{"child1", "grandchild1", "child1", "grandchild1"},
+		{"child2", "grandchild1", "", ""},
+		{"parent1", "parent2", "", ""},
+		{"parent2", "child1", "", ""},
+		{"parent2", "grandchild1", "", ""},
+		{"parent2", "child2", "", ""},
+	} {
+		// Run the subtests with the tables in both positions (left
+		// and right).
+		for i := 0; i < 2; i++ {
+			testName := fmt.Sprintf("%s-%s", tc.table1, tc.table2)
+			t.Run(testName, func(t *testing.T) {
+				join, err := newTestJoinNode(kvDB, tc.table1, tc.table2)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				ancestor, descendant := join.interleavedNodes()
+
+				if tc.ancestor == tc.descendant && tc.ancestor == "" {
+					if ancestor != nil || descendant != nil {
+						t.Errorf("expected ancestor and descendant to both be nil")
+					}
+					return
+				}
+
+				if ancestor == nil || descendant == nil {
+					t.Fatalf("expected ancestor and descendant to not be nil")
+				}
+
+				if tc.ancestor != ancestor.desc.Name || tc.descendant != descendant.desc.Name {
+					t.Errorf(
+						"unexpected ancestor and descendant nodes.\nexpected: %s (ancestor), %s (descendant)\nactual: %s (ancestor), %s (descendant)",
+						tc.ancestor, tc.descendant,
+						ancestor.desc.Name, descendant.desc.Name,
+					)
+				}
+			})
+			// Rerun the same subtests but flip the tables
+			tc.table1, tc.table2 = tc.table2, tc.table1
+		}
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -1,0 +1,648 @@
+# LogicTest: 5node-distsql
+
+# The following tables form the interleaved hierarchy:
+#   name:             primary key:                # rows:   'a' = id mod X :
+#   parent1           (pid1)                      40        8
+#     child1          (pid1, cid1)                150       66
+#       grandchild1   (pid1, cid1, gcid1)         410       201
+#     child2          (pid1, cid2, cid3)          15        7
+#       grandchild2   (pid1, cid2, cid3, gcid1)   51        13
+#   parent2           (pid2)                      5         2
+#
+# All IDs belonging to a table (pid1 --> parent1, cid1 --> child1, cid2,cid3
+# --> child2, etc.) start from 1 up to (# rows).
+# Foreign keys are modded by their ancestor's (# rows). For example, for child1
+# row with cid1=500, we take ((cid1-1) % 200 + 1) = 100 as pid1.
+# One exception is cid3, which is taken as cid2 % 15.
+# There's a column 'a' that's modded by a factor.
+#
+# This allows us to test the following edge cases (in order of tests):
+#   - one-to-many (parent1 - child1)
+#   - one-to-one and one-to-none (parent1 - child2)
+#   - parent-grandchild (parent1 - grandchild1)
+#   - multiple interleaved columns (child2 - grandchild2)
+#   - additional ancestor above (child2 - grandchild2)
+#   - no interleaved relationship (parent1 - parent2, parent2 - child1)
+#   - TODO(richardwu): sibling-sibling (child1 - child2)
+
+#################
+# Create tables #
+#################
+
+statement ok
+CREATE TABLE parent1 (pid1 INT PRIMARY KEY, pa1 INT)
+
+statement ok
+CREATE TABLE parent2 (pid2 INT PRIMARY KEY, pa2 INT)
+
+statement ok
+CREATE TABLE child1 (
+  pid1 INT,
+  cid1 INT,
+  ca1 INT,
+  PRIMARY KEY(pid1, cid1),
+  FOREIGN KEY (pid1) REFERENCES parent1
+)
+INTERLEAVE IN PARENT parent1 (pid1)
+
+statement ok
+CREATE TABLE child2 (
+  pid1 INT,
+  cid2 INT,
+  cid3 INT,
+  ca2 INT,
+  PRIMARY KEY(pid1, cid2, cid3),
+  FOREIGN KEY (pid1) REFERENCES parent1
+)
+INTERLEAVE IN PARENT parent1 (pid1)
+
+statement ok
+CREATE TABLE grandchild1 (
+  pid1 INT,
+  cid1 INT,
+  gcid1 INT,
+  gca1 INT,
+  PRIMARY KEY(pid1, cid1, gcid1),
+  FOREIGN KEY (pid1, cid1) REFERENCES child1
+)
+INTERLEAVE IN PARENT child1 (pid1, cid1)
+
+# No foreign key since we are permitting the rows to overflow out of child2
+# for pid1 > 15.
+statement ok
+CREATE TABLE grandchild2 (
+  pid1 INT,
+  cid2 INT,
+  cid3 INT,
+  gcid2 INT,
+  gca2 INT,
+  PRIMARY KEY(pid1, cid2, cid3, gcid2)
+)
+INTERLEAVE IN PARENT child2 (pid1, cid2, cid3)
+
+####################
+# Insert some rows #
+####################
+
+statement ok
+INSERT INTO parent1 SELECT
+  pid,
+  mod(pid, 8)
+FROM
+  GENERATE_SERIES(1, 40) AS ID(pid)
+
+statement ok
+INSERT INTO parent2 SELECT
+  pid,
+  mod(pid, 2)
+FROM
+  GENERATE_SERIES(1, 5) AS ID(pid)
+
+# child1 has more rows than parent1.
+statement ok
+INSERT INTO child1 SELECT
+  mod(cid-1, 40) + 1,
+  cid,
+  mod(cid, 66)
+FROM
+  GENERATE_SERIES(1, 150) AS ID(cid)
+
+# child2 has fewer rows than parent1.
+statement ok
+INSERT INTO child2 SELECT
+  mod(cid-1, 40) + 1,
+  cid,
+  mod(cid, 14),
+  mod(cid, 7)
+FROM
+  GENERATE_SERIES(1, 15) AS ID(cid)
+
+statement ok
+INSERT INTO grandchild1 SELECT
+  mod(mod(gcid-1, 150), 40) + 1,
+  mod(gcid-1, 150) + 1,
+  gcid,
+  mod(gcid, 201)
+FROM
+  GENERATE_SERIES(1, 410) AS ID(gcid)
+
+# We let grandchild2.pid1 exceed child2.pid1 (one of the interleaved keys).
+# So instead of
+#     (gcid1 - 1) % 15 % 40 + 1
+# we choose to only mod by 40 (nrows of parent1) instead of first modding
+# by 15 (nrows of child2).
+statement ok
+INSERT INTO grandchild2 SELECT
+  mod(gcid-1, 40) + 1,
+  mod(gcid-1, 15) + 1,
+  mod(mod(gcid-1, 15) + 1, 14),
+  gcid,
+  mod(gcid, 13)
+FROM
+  GENERATE_SERIES(1, 51) AS ID(gcid)
+
+####################
+# Split our ranges #
+####################
+
+# Split at parent1 key into five parts.
+statement ok
+ALTER TABLE parent1 SPLIT AT SELECT i FROM GENERATE_SERIES(8, 32, 8) AS g(i)
+
+# Split at child1 keys in between parent1 parts (total 10 parts).
+statement ok
+ALTER TABLE child1 SPLIT AT SELECT pid1, pid1 + 40 FROM
+GENERATE_SERIES(4, 36, 8) AS g(pid1)
+
+# Split at grandchild2 keys in between the 10 parts (total 20 parts).
+statement ok
+ALTER TABLE grandchild2 SPLIT AT SELECT pid1, pid1 + 40, pid1, pid1 FROM
+GENERATE_SERIES(2, 38, 4) AS g(pid1)
+
+# Relocate the twenty parts to the five nodes.
+statement ok
+ALTER TABLE grandchild2 TESTING_RELOCATE
+  SELECT ARRAY[((i-1)/2)::INT%5+1], i, i+20, i, i FROM GENERATE_SERIES(1, 39, 2) AS g(i)
+
+# Verify data placement.
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE parent1
+----
+Start Key                   End Key                     Range ID  Replicas  Lease Holder
+NULL                        /2/#/54/1/42/2/#/56/1/2     1         {1}       1
+/2/#/54/1/42/2/#/56/1/2     /4/#/53/1/44                11        {2}       2
+/4/#/53/1/44                /6/#/54/1/46/6/#/56/1/6     6         {3}       3
+/6/#/54/1/46/6/#/56/1/6     /8                          12        {4}       4
+/8                          /10/#/54/1/50/10/#/56/1/10  2         {5}       5
+/10/#/54/1/50/10/#/56/1/10  /12/#/53/1/52               13        {1}       1
+/12/#/53/1/52               /14/#/54/1/54/14/#/56/1/14  7         {2}       2
+/14/#/54/1/54/14/#/56/1/14  /16                         14        {3}       3
+/16                         /18/#/54/1/58/18/#/56/1/18  3         {4}       4
+/18/#/54/1/58/18/#/56/1/18  /20/#/53/1/60               15        {5}       5
+/20/#/53/1/60               /22/#/54/1/62/22/#/56/1/22  8         {1}       1
+/22/#/54/1/62/22/#/56/1/22  /24                         16        {2}       2
+/24                         /26/#/54/1/66/26/#/56/1/26  4         {3}       3
+/26/#/54/1/66/26/#/56/1/26  /28/#/53/1/68               17        {4}       4
+/28/#/53/1/68               /30/#/54/1/70/30/#/56/1/30  9         {5}       5
+/30/#/54/1/70/30/#/56/1/30  /32                         18        {1}       1
+/32                         /34/#/54/1/74/34/#/56/1/34  5         {2}       2
+/34/#/54/1/74/34/#/56/1/34  /36/#/53/1/76               19        {3}       3
+/36/#/53/1/76               /38/#/54/1/78/38/#/56/1/38  10        {4}       4
+/38/#/54/1/78/38/#/56/1/38  NULL                        20        {5}       5
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE child1
+----
+Start Key                   End Key                     Range ID  Replicas  Lease Holder
+NULL                        /2/#/54/1/42/2/#/56/1/2     1         {1}       1
+/2/#/54/1/42/2/#/56/1/2     /4/#/53/1/44                11        {2}       2
+/4/#/53/1/44                /6/#/54/1/46/6/#/56/1/6     6         {3}       3
+/6/#/54/1/46/6/#/56/1/6     /8                          12        {4}       4
+/8                          /10/#/54/1/50/10/#/56/1/10  2         {5}       5
+/10/#/54/1/50/10/#/56/1/10  /12/#/53/1/52               13        {1}       1
+/12/#/53/1/52               /14/#/54/1/54/14/#/56/1/14  7         {2}       2
+/14/#/54/1/54/14/#/56/1/14  /16                         14        {3}       3
+/16                         /18/#/54/1/58/18/#/56/1/18  3         {4}       4
+/18/#/54/1/58/18/#/56/1/18  /20/#/53/1/60               15        {5}       5
+/20/#/53/1/60               /22/#/54/1/62/22/#/56/1/22  8         {1}       1
+/22/#/54/1/62/22/#/56/1/22  /24                         16        {2}       2
+/24                         /26/#/54/1/66/26/#/56/1/26  4         {3}       3
+/26/#/54/1/66/26/#/56/1/26  /28/#/53/1/68               17        {4}       4
+/28/#/53/1/68               /30/#/54/1/70/30/#/56/1/30  9         {5}       5
+/30/#/54/1/70/30/#/56/1/30  /32                         18        {1}       1
+/32                         /34/#/54/1/74/34/#/56/1/34  5         {2}       2
+/34/#/54/1/74/34/#/56/1/34  /36/#/53/1/76               19        {3}       3
+/36/#/53/1/76               /38/#/54/1/78/38/#/56/1/38  10        {4}       4
+/38/#/54/1/78/38/#/56/1/38  NULL                        20        {5}       5
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE grandchild1
+----
+Start Key                   End Key                     Range ID  Replicas  Lease Holder
+NULL                        /2/#/54/1/42/2/#/56/1/2     1         {1}       1
+/2/#/54/1/42/2/#/56/1/2     /4/#/53/1/44                11        {2}       2
+/4/#/53/1/44                /6/#/54/1/46/6/#/56/1/6     6         {3}       3
+/6/#/54/1/46/6/#/56/1/6     /8                          12        {4}       4
+/8                          /10/#/54/1/50/10/#/56/1/10  2         {5}       5
+/10/#/54/1/50/10/#/56/1/10  /12/#/53/1/52               13        {1}       1
+/12/#/53/1/52               /14/#/54/1/54/14/#/56/1/14  7         {2}       2
+/14/#/54/1/54/14/#/56/1/14  /16                         14        {3}       3
+/16                         /18/#/54/1/58/18/#/56/1/18  3         {4}       4
+/18/#/54/1/58/18/#/56/1/18  /20/#/53/1/60               15        {5}       5
+/20/#/53/1/60               /22/#/54/1/62/22/#/56/1/22  8         {1}       1
+/22/#/54/1/62/22/#/56/1/22  /24                         16        {2}       2
+/24                         /26/#/54/1/66/26/#/56/1/26  4         {3}       3
+/26/#/54/1/66/26/#/56/1/26  /28/#/53/1/68               17        {4}       4
+/28/#/53/1/68               /30/#/54/1/70/30/#/56/1/30  9         {5}       5
+/30/#/54/1/70/30/#/56/1/30  /32                         18        {1}       1
+/32                         /34/#/54/1/74/34/#/56/1/34  5         {2}       2
+/34/#/54/1/74/34/#/56/1/34  /36/#/53/1/76               19        {3}       3
+/36/#/53/1/76               /38/#/54/1/78/38/#/56/1/38  10        {4}       4
+/38/#/54/1/78/38/#/56/1/38  NULL                        20        {5}       5
+
+statement ok
+SET CLUSTER SETTING sql.distsql.interleaved_joins.enabled = true;
+
+#####################
+# Interleaved joins #
+#####################
+
+# Select over two ranges for parent/child with split at children key.
+# Returns:
+#   pid1    pa1         cid1      ca1
+#           (pid1 % 8)           (cid1 % 66)
+query IIII rowsort,colnames
+SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5
+----
+pid1  pa1  cid1  ca1
+3     3    3     3
+3     3    43    43
+3     3    83    17
+3     3    123   57
+4     4    4     4
+4     4    44    44
+4     4    84    18
+4     4    124   58
+5     5    5     5
+5     5    45    45
+5     5    85    19
+5     5    125   59
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzkkk9r6zAQxO_vU4Q5vcfbguW0F0PB15SSlFyLD8LaJAJHMiu5tJR89yKrf5zQhvbcm6X5zY5H7DOcN7zUew6o7qFAKEGYoyH04lsOwUuSMrgwj6gKgnX9EPN1tLFjVBicF8PCBgTDUdsu6c2hIbReGNUHuvQXvj_BCH6Ir0MbQoh6y6jKA02C1ST4k7ELF1k61g-8Zm1Ybrx1LEc5uOVNRKpm91qe6l4Lu5haJ2G2GmI1qxXV6Q3Wdrubsu3Odka9CROW6jkI72kdb-LfWv3_dy0JHD9BmPKXVF_hq87qqHP5CzsX5zuvOfTeBf7WBhVpAdlsOW9r8IO0fCe-HWPycTX6xgvDIWZ1ng8Ll6X0g1OzOmsujszq1Fz-yNwc_rwEAAD__xw2LG0=
+
+# Swap parent1 and child1 tables.
+
+query IIII rowsort,colnames
+SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5
+----
+pid1  cid1  ca1  pa1
+3     3     3    3
+3     43    43   3
+3     83    17   3
+3     123   57   3
+4     4     4    4
+4     44    44   4
+4     84    18   4
+4     124   58   4
+5     5     5    5
+5     45    45   5
+5     85    19   5
+5     125   59   5
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzkUk1r4zAUvO-vCHPaZd-C5bAXQ8HXlJKUXIsPwnpJBI5knuTSUvLfi6x-2KEN7bk3vTczbzQwT3De8FofOaC6gwKhBGGJhtCLbzkELwnKxJV5QFUQrOuHmNfRxo5RYXBeDAsbEAxHbbuEN6eG0HphVO_Utf_n-zMawQ_x5WhDCFHvGVV5oomxmhh_cHblIkvH-p63rA3LtbeOZeaDG95FpGj2qOWxbg-2Myl02i82Q6wWtaK6pHoJwtbuD1N2r4VdVK_IhA_Cm1vHu_i7Vn__XElijU8QZsep_o_PMqtZ5vIHZi4uZ95y6L0L_KUGFamAbPac2xr8IC3fim9HmzxuRt24MBxiRpd5WLkMpQ9OxeqiuJiJ1bm4_Ja4Of16DgAA___peSxr
+
+# Select over two ranges for parent/child with split at grandchild key.
+# Also, rows with pid1 <= 30 should have 4 rows whereas pid1 > 30 should
+# have 3 rows.
+# Returns:
+#   parent1.pid1 pa1          child1.pid1     cid1        ca1
+#                (pid1 % 8)                             (cid1 % 66)
+query IIIII colnames
+SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1
+----
+pid1 pa1 pid1 cid1 ca1
+29    5    29    29    29
+29    5    29    69    3
+29    5    29    109   43
+29    5    29    149   17
+30    6    30    30    30
+30    6    30    70    4
+30    6    30    110   44
+30    6    30    150   18
+31    7    31    31    31
+31    7    31    71    5
+31    7    31    111   45
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzskcFq8zAQhO__U4Q5_SVbiJLmYijomlKSkmvxQVibROBIRpJLS_C7F8m0sUtS2ntv1s4Mn2f3BOs0r9WRA4pnCBCWKAmNdxWH4Hwa96aVfkUxIxjbtDGNS0LlPKM4IZpYMwqsbGRfs3rhLSvN_sEZyx4EzVGZOjMeeReRCOao_JtslGcbEzgJk00bi4kUJOcgbM3-MPRWB1Nr8SEMvCQXIHzSat7F_1JMb-59MuZPEEZ-kncklyg7gmvjuVKIas8oREdXap_bOq_Zsx7Xk2KKsruwm7W7dc3Ie409H7HF38ov1N5yaJwN_KOFztI9WO-5v19wra_4ybsqY_rnJufyQHOIvSr6x8pmKf_gMCy-DS9G4dnX8PxX5LL79x4AAP__HMEtCA==
+
+# parent-child where pid1 <= 15 have one joined row and pid1 > 15 have no
+# joined rows (since child2 only has 15 rows up to pid1 = 15).
+# Returns:
+#   pid1    pa1           cid2      cid3              ca2
+#           (pid1 % 8)              (cid2 % 14)       (cid2 % 7)
+query IIIII rowsort,colnames
+SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12
+----
+pid1 pa1 cid2 cid3 ca2
+12  4  12  12  5
+13  5  13  13  6
+14  6  14  0   0
+15  7  15  1   1
+
+# Note this spans all 5 nodes, which makes sense since we want to read all
+# parent rows even if child rows are non-existent (so we can support OUTER
+# joins).
+# TODO(richardwu): we can remove nodes reading from just one table for INNER
+# joins or LEFT/RIGHT joins.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzklE9r4zAUxO_7KcKcdslbiGwnB8OCrllKUnItPhjrJTE4lpHk0hL83YtkSOzS9A85-ibpzY95o8OcUWvFm_zEFukTBAgRCDEICQhLZITG6IKt1cZLemCtXpAuCGXdtM4_Z4RCG0Z6hitdxUixrh2bivNn3nGu2PzXZc0GBMUuL6vg98B7B-9QnnLzKpvccO38En4w27YunUlB0q-0Kw_HobY4lpW6DAZakjFJv_zFsOK9-y3F_M8_47XhCMIQSUguSa6QdQTdumsq6_IDIxUd3Uh-DayNYsNqnFCKObLug-_Z6L-6GWlveUcjbzHZX48mmzyebPJkssm_aNcd20bXlr_VIAtfQKwO3BeW1a0p-NHoItj0123gwoNi6_qp6C_rOozCgkNYfAqvRvDiPRzd4xzfAyf3wMsfwVn36y0AAP__pYpV_Q==
+
+# Single gateway node query (node 1).
+# Returns:
+#   pid1    pa1           cid2      cid3              ca2
+#           (pid1 % 8)              (cid2 % 14)       (cid2 % 7)
+# Note pid=21, 31 has no joined rows since child2 only has pid1 <= 15.
+query IIIII rowsort,colnames
+SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31)
+----
+pid1  pa1  cid2  cid3  ca2
+1     1    1     1     1
+11    3    11    11    4
+
+# These rows are all on the same node 1 (gateway).
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJyMkEFLAzEQhe_-ivJOinNotHoICLlWxEqvsoewmW4D22RJZkUp-99lE6jrQfCWee-bebycEaLjV3viDP0OhYYwpNhyzjHNUgW27hN6TfBhGGWWG0IbE0OfIV56hsY2CKee7Qfv2TpOz9EHTiA4Fuv7cv-FD4I5wZ9s-jKDTRxEgYqx2o2iV0aRuQNh77vjkm2PvncXY8GSuSezAeES2PNBro26vXlKM1ueICxXNmQeyDyimQhxlJ9WWWzH0Gqi_zffcx5iyPyr61-X11NDYNdx_d0cx9TyW4ptianjruwVwXGW6qo6bEO1pma6-g4AAP__vKCOyQ==
+
+# Parent-grandchild.
+# Returns:
+#   pid1    pa2           cid2    cid3          gcid2       gca2
+#           (pid1 % 8)            (cid2 % 14)               (gcid2 % 13)
+# Where clause is on ranges that overlap children, grandchildren, and parent
+# key splits, respectively.
+# Rows with pid >= 11 have only one joined row since there are only 51
+# granchild2 rows.
+query IIIIII rowsort,colnames
+SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
+  pid1 >= 11 AND pid1 <= 13
+  OR pid1 >= 19 AND pid1 <= 21
+  OR pid1 >= 31 AND pid1 <= 33
+----
+pid1  pa1  cid2  cid3  gcid2  gca2
+11    3    6     6     51     12
+11    3    11    11    11     11
+12    4    12    12    12     12
+13    5    13    13    13     0
+19    3    4     4     19     6
+20    4    5     5     20     7
+21    5    6     6     21     8
+31    7    1     1     31     5
+32    0    2     2     32     6
+33    1    3     3     33     7
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
+    pid1 >= 11 AND pid1 <= 13
+    OR pid1 >= 19 AND pid1 <= 21
+    OR pid1 >= 31 AND pid1 <= 33
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzslNGL1DAQxt_9K8I87eIITXunGFiIIMKK7Mrim_YhNHN7gV5SklSUo_-7pPW626Mriigc9K3JN1-_mfbH3IN1mnbqjgKIz8ABIQeEaygRGu8qCsH5JA2FW_0NRIZgbNPGdF0iVM4TiHuIJtYEArY2kq9JfaUDKU3-vTOWPCBoisrUfc4HuomQEsyd8t9lozzZmMKTwN6ZOpIXbLVaSc6-tFlW0IZxLoTY7j6t2ZvdWzYq1Ybx4qeyZvsDm5peXzLlD6-bcRUXo4ox6qHZfRsFkxxl-m4Hc7w9H-zoldXVran1qD6Z6YZuT-OhLFBeobwGhPGf1nQTV5I_X298Ku8fAeHclSwoX6J8BWWH4Np4YidEdSQQvMMLfJ2waq3zmjzpCUllN0Pgzr1wzaOy-eB8EswXsBew_yHY-cLXwtd_WpwzfB0oNM4G-q3NmKXFSvpIwxYOrvUVffSu6mOG47739ReaQhxUPhy2tpf6Bs_N_Jfmq4k5e2zO_ya5-CNz2T37EQAA__-LHJN8
+
+query ITTT
+EXPLAIN SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
+  pid1 >= 11 AND pid1 <= 13
+  OR pid1 >= 19 AND pid1 <= 21
+  OR pid1 >= 31 AND pid1 <= 33
+----
+0  render  ·               ·
+1  join    ·               ·
+1  ·       type            inner
+1  ·       equality        (pid1) = (pid1)
+1  ·       mergeJoinOrder  +"(pid1=pid1)"
+2  scan    ·               ·
+2  ·       table           parent1@primary
+2  ·       spans           /11-/13/# /19-/21/# /31-/33/#
+2  scan    ·               ·
+2  ·       table           grandchild2@primary
+2  ·       spans           /11/#/54/1-/13/#/54/2 /19/#/54/1-/21/#/54/2 /31/#/54/1-/33/#/54/2
+
+# Swap parent1 and grandchild2 positions.
+query IIIIII rowsort,colnames
+SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
+  pid1 >= 11 AND pid1 <= 13
+  OR pid1 >= 19 AND pid1 <= 21
+  OR pid1 >= 31 AND pid1 <= 33
+----
+pid1  cid2  cid3  gcid2  gca2 pa1
+11    6     6     51     12   3
+11    11    11    11     11   3
+12    12    12    12     12   4
+13    13    13    13     0    5
+19    4     4     19     6    3
+20    5     5     20     7    4
+21    6     6     21     8    5
+31    1     1     31     5    7
+32    2     2     32     6    0
+33    3     3     33     7    1
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
+    pid1 >= 11 AND pid1 <= 13
+    OR pid1 >= 19 AND pid1 <= 21
+    OR pid1 >= 31 AND pid1 <= 33
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzslNGL1DAQxt_9K8I87eIITXuHGFiIIMKKdKX4pn0IzVwv0EtKkopy9H-Xtu7udemKIgpC35p88_WbaX_MI1inKVcPFEB8Ag4IKSDcQonQeldRCM4P0lS4119BJAjGtl0crkuEynkC8QjRxIZAwN5G8g2pL1SQ0uTfOWPJA4KmqEwz5rynuwhDgnlQ_pusvbK6ujeNHsIHkb01TSQv2GazkZx97pIkox3jXAixzz9u2ev8DTsp1Y7x7IeyZYeCzU2vrpnS4-sWXNnVqOwUdWz20EXBJEeZosxQ3qC8BYTC1PdPp2yVJxv5UflvRpy6Pc8ICKd_2tBd3Ej-fLvzQ9X4CAgLHwTlSyh7BNfFMzshqppA8B6v8HXGqrPOa_KkZySV_QKBuXvh2ouy5eB0FsxXsFew_yLY6crXytc_WpwLfBUUWmcD_dJmTIbFSrqmaQsH1_mKPnhXjTHT8TD6xgtNIU4qnw57O0pjg0_N_Kfmm5k5uTSnf5Kc_Za57J99DwAA__-nJ5Nz
+
+query ITTT
+EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
+  pid1 >= 11 AND pid1 <= 13
+  OR pid1 >= 19 AND pid1 <= 21
+  OR pid1 >= 31 AND pid1 <= 33
+----
+0  render  ·               ·
+1  join    ·               ·
+1  ·       type            inner
+1  ·       equality        (pid1) = (pid1)
+1  ·       mergeJoinOrder  +"(pid1=pid1)"
+2  scan    ·               ·
+2  ·       table           grandchild2@primary
+2  ·       spans           /11/#/54/1-/13/#/54/2 /19/#/54/1-/21/#/54/2 /31/#/54/1-/33/#/54/2
+2  scan    ·               ·
+2  ·       table           parent1@primary
+2  ·       spans           /11-/13/# /19-/21/# /31-/33/#
+
+# Join on multiple interleaved columns with an overarching ancestor (parent1).
+# Returns:
+#   child2.pid1   gc2.pid1        child2.cid2   gc2.cid2  child2.cid3   gc2.cid3      child2.ca2        gcid2         gca2
+#                 (gcid2 % 40)                            (cid2 % 14)                                                 (gcid2 % 13)
+query IIIIIIIII colnames,rowsort
+SELECT * FROM child2 JOIN grandchild2 ON
+  child2.pid1=grandchild2.pid1
+  AND child2.cid2=grandchild2.cid2
+  AND child2.cid3=grandchild2.cid3
+WHERE
+  child2.pid1 >= 5 AND child2.pid1 <= 7
+  OR child2.cid2 >= 12 AND child2.cid2 <= 14
+  OR gcid2 >= 49 AND gcid2 <= 51
+----
+pid1  cid2  cid3  ca2  pid1  cid2  cid3  gcid2  gca2
+2     2     2     2    2     12    12    42     3
+2     2     2     2    11    6     6     51     12
+3     3     3     3    3     13    13    43     4
+4     4     4     4    4     14    0     44     5
+5     5     5     5    5     5     5     5      5
+5     5     5     5    5     15    1     45     6
+5     5     5     5    6     1     1     46     7
+6     6     6     6    6     6     6     6      6
+7     7     7     0    7     7     7     7      7
+7     7     7     0    27    12    12    27     1
+8     8     8     1    9     4     4     49     10
+9     9     9     2    10    5     5     50     11
+10    10    10    3    28    13    13    28     2
+10    10    10    3    29    14    0     29     3
+12    12    12    5    12    12    12    12     12
+13    13    13    6    13    13    13    13     0
+14    14    0     0    14    14    0     14     1
+
+# Note there are 5 nodes because the filter cid2 >= 12 AND cid2 <= 14
+# creates a giant parent span which requires reading from all rows.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM child2 JOIN grandchild2 ON
+    child2.pid1=grandchild2.pid1
+    AND child2.cid2=grandchild2.cid2
+    AND child2.cid3=grandchild2.cid3
+  WHERE
+    child2.pid1 >= 5 AND child2.pid1 <= 7
+    OR child2.cid2 >= 12 AND child2.cid2 <= 14
+    OR gcid2 >= 49 AND gcid2 <= 51
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzsls-K2zAQh-99CjEnh0zBku3driCgQimklKSE3lofjDWbNXitIMmlZcm7F9mNdh3Sf-QWctSMvvwm_gTSE3RG06p6JAfyC3BAEICQAUIOCAWUCDtranLO2LBlBJb6O8gUoel2vQ_lEqE2lkA-gW98SyBh2XmyLVXfaEOVJvvBNB1ZQNDkq6Yd8j7SvYeQ0DxW9oeqH5pWh_xQZ-veS6Y4KoEqQxXm2TTbh5fA1ladjtTQZe-b1pOVLEkSxdnXPk0zWrBCSrlcfZ6xt6t3LDbqBbv91Zix9YYliRIR4WLKiMjw_AAdqDxS-d2UyiNV8AMVZz3-i6gKQIhfqqV7nyg-RyXmqLL5bGEDNikBwolfQXWD6hbVG1R3UO4RTO-fVTlfbQkk3-NvdD5b7DtjNVnSE3Hl_oTwlXltdkfbTgeLSTC_nqNLOkfiqvOSdGZXnZekM7_qvCSdf3mDbcjtTOfon27lNFzqpLc0vgCc6W1Nn6yph5hxuR64oaDJ-bHLx8WyG1rDgC9h_kf4ZgKnx7A4Jzk7B87PgYv_gsv9q58BAAD__5XeUlM=
+
+query ITTT
+EXPLAIN
+  SELECT * FROM child2 JOIN grandchild2 ON
+    child2.pid1=grandchild2.pid1
+    AND child2.cid2=grandchild2.cid2
+    AND child2.cid3=grandchild2.cid3
+  WHERE
+    child2.pid1 >= 5 AND child2.pid1 <= 7
+    OR child2.cid2 >= 12 AND child2.cid2 <= 14
+    OR gcid2 >= 49 AND gcid2 <= 51
+----
+0  join  ·               ·
+0  ·     type            inner
+0  ·     equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
+0  ·     mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
+1  scan  ·               ·
+1  ·     table           child2@primary
+1  ·     spans           ALL
+1  scan  ·               ·
+1  ·     table           grandchild2@primary
+1  ·     spans           ALL
+
+# Aggregation over parent and child keys.
+# There are 4 rows for each 10 <= pid1 <= 30 and 3 rows for each 30 < pid1 <=
+# 39.
+# We thus have 3 arithmetic series of 10 + ... + 39 and 1 arithmetic series
+# of 10 + ... + 30 or
+#     SUM(pid1) = 3 * (39 - 10 + 1) * (10 + 39)/2 + (30 - 10 + 1) * (10 + 30)/2 = 2625
+# For SUM(cid1), we notice that pid1 = cid1 % 40, thus for every additional
+# round of rows under a pid1, cid1 is increased by 40.
+# For each additional round up to the 3rd (2 rounds after the first where 50 <= cid1 <= 79,
+# 90 <= cid1 <= 119) , we have an additional
+#     40 * (1 + 2) * (39 - 10 + 1) = 3600
+# For the 4th round, we have 150 - 130 + 1 = 21 rows (130 <= cid1 <= 150) each
+# additional row adds 120, thus
+#     SUM(cid1) = SUM(pid1) + 3600 + 21 * 120 = 8745
+# For each
+query RR
+SELECT SUM(parent1.pid1), SUM(child1.cid1) FROM parent1 JOIN child1 USING(pid1) WHERE
+  pid1 >= 10 AND pid1 <= 39
+----
+2625 8745
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL)
+  SELECT SUM(parent1.pid1), SUM(child1.cid1) FROM parent1 JOIN child1 USING(pid1) WHERE
+    pid1 >= 10 AND pid1 <= 39
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzklc9q4zAQxu_7FGFOCatDZDvZrKHgHlPapqT0VHwQ1sQxOJKR5NIS_O5FNs0fk8iFJCffLM18_s03I6QtCMnxmW1QQ_gOFAh4QMAHAgEQmEBMoFAyQa2lsimNYM4_IRwTyERRGrsdE0ikQgi3YDKTI4QwFwZVjuwDl8g4qgeZCVRAgKNhWV7zHnFlwBKyDVNfUcEUCmOLsIHBojThILLLZZauDxOTdZbzXeAnkUS29h0nx5UZRvTv6E7ZrPoTCOySfYgrArI0ew_asBQhpBX5vc_7NFWYMiNb3l7fnoYRtcT6yxudxXlncXtKKaTiqJAfQeLqJgX5RwXRnsy5w-e15-z1pK0dPq_dVr8nbe3wee22Bj1pa4fPW172J3BL1IUUGluX_uk_j-1jgDzF5uXQslQJviiZ1Jhmuah19QZHbZoobRZz0YRsgYdi6hR7R2LaFntucgfad6oDtzi4pO6JUzx1k6eXkP85xTM3eXYJ-b97VuOOY-I-ZG12XP35DgAA__84h19b
+
+########################
+# Non-interleaved joins #
+########################
+
+# Join on siblings uses merge joiner.
+# TODO(richardwu): Update this once sibling joins are implemented.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN child2 USING(pid1)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzclsFq20AQhu99ijCnlmzBK8lOLSjomkKTEnorOijW1BYoWrG7gobgdy-yCq4lZ8ZiZDC-WdZ-u_-sP_D_BpXJ8SF7QQfxL9CgIAAFISiIQMEcUgW1NSt0zth2SQfc538gnikoqrrx7depgpWxCPEb-MKXCDH8zJ5LfMIsRwsKcvRZUe4OqW3xktnXZLUpyrw98bHx8U2iVRKoJIR0q8A0_t_G-_2eX282mdsc7pVoSLepAuezNUKst2rqgEE_oEoiUcbg3Yz7fYzN0WLe3-e2PfikVUfG_Y52jd9MUfXHLfG3_5jo209fbbHedB-HQ89VslDJXW_0_VjhCWM11bHIR9M-mM-m7i07fnB0cLC-dCknCXhmKfV1ShlcuhuTBDyzG8F1uhFeuhuTBDyzG-F1uhFduhuTBDyzG9F1usF0zCd0takcntRkZu00mK-xuyNnGrvCH9asdsd0j487bvcXnaPz3duge7ivuldtwNPhhQReSmAtyq3nNK1HXFkwDl5I4KUE1qLcvSsb0EGfnv1Ph_R9hySsD-9s1qcjieA0zAhOw4zgNMwJztCM4HOJ4DTMCE7DjOA0zAnO0IzgC4ngdxJFaZhRlIYZRWmYU5ShGUW_SBSlYUZRGmYUpWFOUYZmFF1KFNWinsDQjKQMzVjK0JymHM51BVlZkLUFWV0Q9gVZYdCixqAHlWGUrTTN2UrTnK00zdrK4JytY8rS8Dcb05bG0pyto_rSaJyzdVAeSFvT7Ye_AQAA___QTz1Q
+
+# Join on non-interleaved tables (with key) uses merge joiner.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN parent2 ON pid1=pid2]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzclsFq3DAQhu99ijCnlqiwkp3t1lDwNYUmJfRWfFCsqdfgWEaSoSH43YvtgGuTaNYoB2dvcaxvZv5vltU-Qa0V3sgHtJD8Bg4MBDCIgEEMDK4gY9AYnaO12vRHRuBa_YVkx6Csm9b1_84Y5NogJE_gSlchJPBL3ld4h1KhAQYKnSyroUljygdpHtNGGqxd3_K2dclFylkqIOsY6NY9l52q3T9eHKU9ziulHLIuY2CdLBAS3rFXxpvqaKPQoFrWuewbT6fa-qVzQ69lzB9oCvyuy3oZs8I_7mPKLz99M2VxHP-cZWVpxNJ4kXhKE52QZsWcN_qzbhbHXm4czxrzbW-Zn9WWxbZli7OSHW1bdnRWsuNty36b8cTbjSdeHe_9fxaIHw53aBtdWzzpstr1OVAVOKqxujU5_jQ6H9qMj7cDN9wVCq0b3z4_XNfjq37A0-E4BN6HwIcQmBOh-ZLe_U8LPyy8MJ_TuyUdhSzLDxPL8sPEsvwwsSwiMxE6DlnWVYhuP0zo9sOEbj9M6CYyE6H3Ibq_hOj2w4RuP0zo9sOEbiIzEfoQovtriG4_TOj2w4RuP0zoJjJT3_xrLkuxko6D6H0QfQiiORV83Y2ZdR_-BQAA___LXMBP
+
+# Join on non-interleaved column uses hash joiner.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON pa1 = ca1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzclkFr20wQhu_frwhzSmA_8EqyWwsKOjY9JCX0VnRQpKklULRidwUNwf-9SCq4kt2ZiKnB-Chrn9131g_ofYPGFPiQvaCD-DtoUBCAghAURKBgDamC1pocnTO2XzIC98VPiFcKqqbtfP9zqiA3FiF-A1_5GiGGb9lzjU-YFWhBQYE-q-rhkNZWL5l9TdrMYuP7Ix87H98kWiUBpHsFpvO_tz3s9vx6U2aunO40rE8VOJ_tEGK9V_8wXl5WdTFNp5JwYcBwEjD4a8DDPl1jbIEWi8lOaU9yS05M-Tlz5RdTNfMha_zhb5Pg7pOtdqW_TcK7-aAqiVSyno17GCUUjHIi54P537TziU8eHE0O1pftoDTe2R3U1-NgcNkqSOOdXYXgelQIL1sFabyzqxBejwrRZasgjXd2FaLrUYEphE_oWtM4fFcLWfVzYLHD8V6c6WyOX63Jh2PGx8eBG76xBTo_vg3Gh_tmfNUHfD-8kcBbCaxFufWapvWCKwuWwRsJvJXAWpR7dmVHdDCnV3_SIX3fIQnr6Z2t5nQkEZyGGcFpmBGchjnBGZoRfC0RnIYZwWmYEZyGOcEZmhF8IxH8g0RRGmYUpWFGURrmFGVoRtGPEkVpmFGUhhlFaZhTlKEZRbcSRbWoJzA0IylDM5YyNKcph3NdQVYWZG1BVheEfUFWGLSoMeijyrDIVprmbKVpzlaaZm1lcM7WJWXp-D9b0paW0pyti_rSYpyz9ag8kLam-_9-BQAA__9NTjLn
+
+# Prefix join on interleaved columns uses merge joiner.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid2)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzklsFq20AQhu99ijCnlmzBK8lOLCjomkKTEnorOijaqSxQtGIlQUPwuxdJAdeyMmMxwWB8lKVv59_xd_hfobQG75NnrCH8DRoUeKDABwUBKFhCrKByNsW6tq77ZADuzF8IFwrysmqb7udYQWodQvgKTd4UCCH8Sp4KfMTEoAMFBpskL_ohlcufE_cSpZu8MN20h7YJryKtIk9FvooCiLcKbNu8nb078unlapPUm_3jehDibaygbpIMIdRb9YExM5eU5t2sKlpK43rvxt0dZZ1Bh2Z81LWKvOtu_tFfTmzgB7oMv9u8HG-gwD_N5zf0yzeXZ5vd4-QqblR0q6L1aCG7m_pH3LQtp24wGfzefrXV6LPpwcHeYH0e4kpjnlhcfTHieufhjzTmif3xLsYf_zz8kcY8sT_-xfgTnIc_0pgn9ie4GH-YRvyIdWXLGo9qVovuYmgyHNZW29al-NPZtB8zPD70XN8QDNbN8NYbHu7K4VUX8Hh4JYHXEliLcuslTesZK_PmwSsJvJbAWpR7tLID2hvTi_9pn963T8J6f2eLMR1IBKdhRnAaZgSnYU5whmYEX0oEp2FGcBpmBKdhTnCGZgRfSQS_kShKw4yiNMwoSsOcogzNKHorUZSGGUVpmFGUhjlFGZpRdC1RVIt6AkMzkjI0YylDc5pyONcVZGVB1hZkdUHYF2SFQYsagz6oDLNspWnOVprmbKVp1lYG52ydU5YO_7M5bWkuzdk6qy_NxjlbD8oDaWu8_fQvAAD__3QUZvQ=
+
+# Subset join on interleaved columns uses hash joiner.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid3)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzclsFq20AQhu99ijCnFrbglWQ3FhR0bHpISuit6KBop5ZA0YpdCRqC371IanEsOzMREwz2cS19u_-sP9D_DLU1eJs9oof4F2hQEICCEBREoGAJqYLG2Ry9t65_ZQRuzB-IFwrKuuna_udUQW4dQvwMbdlWCDH8zB4qvMfMoAMFBtusrIZDGlc-Zu4pyYuyMv1pd10bXyVaJYFKQpVEkG4V2K79t_duy4enqyLzxf52PRhCuk0V-DbbIMR6q94x5sZltXk1q0qW0rjBq3F3W3W1dQYdmr3N0p7kXjky87fMF99tWU9HrvB3-3EI-OmrKzfF_8XLucNh9EglK5Vcq2Q9mX43VigY60jmW_vZNtPpjx4c7R2sz8NSacwTW6ov09LgPGSRxjyxLMFlyhKehyzSmCeWJbxMWaLzkEUa88SyRJcpC1NZ79E3tvb4pja06GdCs8HxjrztXI4_nM2HY8bl3cANX3WDvh2fBuPiph4f9QHfDq8k8FoCa1FuvaRpPePKgnnwSgKvJbAW5Z5c2QEdTOnFSzqk7zskYb1_Z4spHUkEp2FGcBpmBKdhTnCGZgRfSgSnYUZwGmYEp2FOcIZmBF9JBP8iUZSGGUVpmFGUhjlFGZpR9FqiKA0zitIwoygNc4oyNKPoWqKoFvUEhmYkZWjGUobmNOVwrivIyoKsLcjqgrAvyAqDFjUGfVAZZtlK05ytNM3ZStOsrQzO2TqnLB3-Z3Pa0lyas3VWX5qNc7YelAfS1nT74W8AAAD__1x4Wc8=
+
+# Sort node in between join and child nodes produces hash joiner.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING(pid1)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzclsFq20AQhu99ijCnlm7Bu5IdR1DQsekhKWlvRQfF2toCRytWa2gIfvciqWAkOftn2BiMb3XtTzM7-01-vVBlCn2XP-mGkt8kSZAiQREJiknQnDJBtTUr3TTGtj_pgdviLyUzQWVV71z735mglbGakhdypdtqSuhX_rjVDzovtCVBhXZ5ue2K1LZ8yu1zWudWV64teb9zyVUqRaoo2wsyO_f_sYenPT5fbfJmM3xSKinbZ4Ial681JXIv3rG91abcFsPuRBqNGjwUV5ziP41147qp-hx0-ujVBg7P2VXGFtrqYvCkrCXRT46c4lvebL6bshqfZKv_uI-p_PTVlutN96_RFGORzl8dZBxwjiNN3pkvph4f92jh-aCwPG-7Q9sLshsUP73d8kLsVuctWWh7QZKB4qeXTF2IZNF5SxbaXpBkoPjpJYsuRLL4vCULbS9IMlD89JLFFyIZeKt-0E1tqka_6W1v1h5CF2vdD6UxO7vSP6xZdWX6j_cd171uFLpx_bdR_-G26r9qG3w7vAyBpQqiFyG0mvlpOaZnA3oAz8awYgxc8eBlCDwaOJdehNCjgU_oyDvw2H9bsf-2pP-65iH74YfBfvhhtB-ABvvhp9F-LLwTv_YP_DpkP_ww2A8_jPYD0GA__DTaj2XIftyEGO6HgeF-GBkOaGC4n4YJMAmQwcQl-KMiJwnCkRzQwHJAI80RDjwHOBJdTnKEY7qc5AhHdUAD1wGNZEc4sB3gUHd_hso50J0TotM756Qol4a6s3KUi0Pd_UmKdOdEKZdGurPClI0j3VlxOsX9eSpvgO6cRJ3eOSdSuTTUnRWqXBzprvypOtY923_4FwAA__9byzFW
+
+query ITTT
+EXPLAIN SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING (pid1)
+----
+ 0  render  ·         ·
+ 1  join    ·         ·
+ 1  ·       type      inner
+ 1  ·       equality  (pid1) = (pid1)
+ 2  scan    ·         ·
+ 2  ·       table     parent1@primary
+ 2  ·       spans     ALL
+ 2  sort    ·         ·
+ 2  ·       order     +cid1
+ 3  scan    ·         ·
+ 3  ·       table     child1@primary
+ 3  ·       spans     ALL
+
+# Multi-table staggered join uses interleaved joiner on the bottom join
+# and a merge joiner.
+query T
+SELECT "URL" FROM[EXPLAIN (DISTSQL)
+  SELECT * FROM grandchild1
+  JOIN child1 USING (pid1, cid1)
+  JOIN parent1 USING (pid1)
+ORDER BY pid1
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzsl1-L2kwUh-_fTyHn6i1OwUnUrYFCbi3tbpHelVzMOmc1kM3IZCxdFr97GbOrRt05CedCEC9j8uT8mSfw8xVKo_FePWMFyW-QICACATEIGIKAEWQCVtbMsaqM9Y_UwFT_hWQgIC9Xa-d_zgTMjUVIXsHlrkBIYFo6tAWqPzhDpdF-M3mJFgRodCovtvW-45MDXyF_VvYlXVhV6vkyL7RvxN_sPaxd0kulSCORxiL1Tc3yxfKQ2gHbG00CBOzqFvjk_k9lX6RR_9NX6x_eXYKA40oivYNsI8Cs3duQ-9keX3pLVS2bw6QSsk0moHJqgZDIjWi_rF_qsXjbU_Ol70OulMXSyUafrPaiD9vbv8dYjRb18Xv6vnCrp85M-gPtAs-58H48B0dz_lhGpyezHyvmjXWm4Xvz2awaz35Ue9ioLW-fR_vPg1jWpT8PeZ2fR3RTtL2ixLIurWh0nYrGN0XbK0os69KKxtep6PCmaHtFiWVdWtHhdSpK_PuYYbUyZYWtUu7AT4N6gfWOKrO2c_xpzXxbpr582HLb3KSxcvXdqL6YlvUt32B7eMyBJxxYsvqWozAtO6ws6gaPOfCEA0tW30crO6GjY3pwSMfhfcdBWDZ3NjimhxzBwzAheBgmBA_DlOAETQg-4ggehgnBwzAheBimBCdoQvAxR_A7jqJhmFA0DBOKhmFKUYImFP3CUTQME4qGYULRMEwpStCEohOOopKVEwiakJSgCUsJmtKUwqmswAsLvLTAiwvMvMALDJKVGORJZOhka5imbA3TlK1hmrSVwClbu4Sl0zPrkpa60pStnfJSZ5yy9SQ8BG3NNv_9CwAA__93EwUl
+
+# Multi-table join with parent1 and child1 at the bottom uses interleaved
+# joiner but induces a hash joiner on the higher join.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM parent1
+  JOIN child1 USING (pid1)
+  JOIN grandchild1 USING (pid1, cid1)
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzsl0GL2kAUx-_9FPJOLZ2Ck0R3DRRyrKXsFumt5DBr3mogm5HJWLosfvdljK5GzTzDu4h422zml3nvzW_g7xuUOsMH9YIVxH9BgoAABIQgIAIBA0gFLIyeYlVp45bUwDj7D3FfQF4ultb9OxUw1QYhfgOb2wIhhnFp0RSo_uEEVYbmp85LNCAgQ6vyYr3fL3y24HbIX5R5TRbKYGldEe5F73Fp414iReJKmuSz-f7a6TwvMrl9sbdWJK76j90KfLafE_n1y3fjFq7_BAH76yORDCBdCdBLu-ln18bTa2-uqnmzbgeGkK5SAZVVM4RYrsT5o_mjnorNVJrf3TY3M6rMPjps9CaSqHutQaPWoLXW3aeWpTYZGswaH0sdSS050fAPVc1Pnf_mcEQS7o5HJEHjgMLtGd2J5P6g9V1PIaOnEwU_6G96cdj6yY2jxsbydifa7gQxmou6E_IK70RwU7NNTWI0F6VmcIVqhjc129QkRnNRaoZXqGZ0U7NNTWI0F6VmdIVqEj8yJlgtdFnhWSm27xrCbIb1gCq9NFP8bfR0vU39-Ljm1uEow8rWb4P6YVzWr1yB58NDDjziwJJVtxz4adlhZEE3eMiBRxxYsuo-GNkRHRzS_X069M879MKyObP-IR1xBPfDhOB-mBDcD1OCEzQh-IAjuB8mBPfDhOB-mBKcoAnBhxzB7ziK-mFCUT9MKOqHKUUJmlD0nqOoHyYU9cOEon6YUpSgCUVHHEUlKycQNCEpQROWEjSlKYVTWYEXFnhpgRcXmHmBFxgkKzHIo8jQyVY_Tdnqpylb_TRpK4FTtnYJS8dn1iUtdaUpWzvlpc44ZetRePDamq4-vQcAAP__14cC7g==

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -83,6 +83,7 @@ server.time_until_store_dead                       5m0s           d     the time
 server.web_session_timeout                         168h0m0s       d     the duration that a newly created web session will be valid
 sql.defaults.distsql                               0              e     Default distributed SQL execution mode [off = 0, auto = 1, on = 2]
 sql.distsql.distribute_index_joins                 true           b     if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader
+sql.distsql.interleaved_joins.enabled              true           b     if set we plan interleaved table joins instead of merge joins when possible
 sql.distsql.merge_joins.enabled                    true           b     if set, we plan merge joins when possible
 sql.distsql.temp_storage.joins                     true           b     set to true to enable use of disk for distributed sql joins
 sql.distsql.temp_storage.sorts                     true           b     set to true to enable use of disk for distributed sql sorts

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -686,7 +686,8 @@ func (p *planner) addJoinFilter(
 
 	// There are four steps to the transformation below:
 	//  1. For inner joins, incorporate the extra filter into the ON condition.
-	//  2. Extract any join equality constraints from the ON condition.
+	//  2. Extract any join equality constraints from the ON condition and
+	//     append it to the equality indices of the join predicate.
 	//  3. "Expand" the remaining ON condition with new constraints inferred based
 	//     on the equality columns (see expandOnCond).
 	//  4. Propagate the filter and ON condition depending on the join type.

--- a/pkg/sql/sqlbase/multirowfetcher_test.go
+++ b/pkg/sql/sqlbase/multirowfetcher_test.go
@@ -30,8 +30,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-const testDB = "test"
-
 type initFetcherArgs struct {
 	tableDesc       *TableDescriptor
 	indexIdx        int
@@ -140,10 +138,11 @@ func TestNextRowSingle(t *testing.T) {
 	// We try to read rows from each table.
 	for tableName, table := range tables {
 		t.Run(tableName, func(t *testing.T) {
-			tableDesc := GetTableDescriptor(kvDB, testDB, tableName)
+			tableDesc := GetTableDescriptor(kvDB, sqlutils.TestDB, tableName)
 
 			var valNeededForCol util.FastIntSet
 			valNeededForCol.AddRange(0, table.nCols-1)
+
 			args := []initFetcherArgs{
 				{
 					tableDesc:       tableDesc,
@@ -297,7 +296,8 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 		// properly).
 		for i := 1; i <= nNulls; i++ {
 			r.Exec(t, fmt.Sprintf(
-				`INSERT INTO test.%s VALUES (%d, NULL, %d, %d);`,
+				`INSERT INTO %s.%s VALUES (%d, NULL, %d, %d);`,
+				sqlutils.TestDB,
 				tableName,
 				table.nRows+i,
 				(table.nRows+i)%storingMods[0],
@@ -311,7 +311,7 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 	// We try to read rows from each index.
 	for tableName, table := range tables {
 		t.Run(tableName, func(t *testing.T) {
-			tableDesc := GetTableDescriptor(kvDB, testDB, tableName)
+			tableDesc := GetTableDescriptor(kvDB, sqlutils.TestDB, tableName)
 
 			var valNeededForCol util.FastIntSet
 			valNeededForCol.AddRange(0, table.nVals-1)
@@ -458,7 +458,7 @@ func generateIdxSubsets(maxIdx int, subsets [][]int) [][]int {
 //   grandgrandchild1@ggc1_unique_idx
 // parent3
 // We test reading rows from every non-empty subset for completeness.
-func TestNextRowInterleave(t *testing.T) {
+func TestNextRowInterleaved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
@@ -485,7 +485,7 @@ func TestNextRowInterleave(t *testing.T) {
 			tableName:        "child1",
 			modFactor:        5,
 			schema:           "p2 INT, c1 INT, v INT, PRIMARY KEY (p2, c1)",
-			interleaveSchema: "test.parent2 (p2)",
+			interleaveSchema: "parent2 (p2)",
 			// child1 has more rows than parent2, thus some parent2
 			// rows will have multiple child1.
 			nRows: 500,
@@ -496,7 +496,7 @@ func TestNextRowInterleave(t *testing.T) {
 			tableName:        "grandchild1",
 			modFactor:        7,
 			schema:           "p2 INT, c1 INT, gc1 INT, v INT, PRIMARY KEY (p2, c1, gc1)",
-			interleaveSchema: "test.child1 (p2, c1)",
+			interleaveSchema: "child1 (p2, c1)",
 			nRows:            2000,
 			nCols:            4,
 			nVals:            4,
@@ -505,7 +505,7 @@ func TestNextRowInterleave(t *testing.T) {
 			tableName:        "grandgrandchild1",
 			modFactor:        12,
 			schema:           "p2 INT, c1 INT, gc1 INT, ggc1 INT, v INT, PRIMARY KEY (p2, c1, gc1, ggc1)",
-			interleaveSchema: "test.grandchild1 (p2, c1, gc1)",
+			interleaveSchema: "grandchild1 (p2, c1, gc1)",
 			nRows:            350,
 			nCols:            5,
 			nVals:            5,
@@ -514,7 +514,7 @@ func TestNextRowInterleave(t *testing.T) {
 			tableName:        "child2",
 			modFactor:        42,
 			schema:           "p2 INT, c2 INT, v INT, PRIMARY KEY (p2, c2)",
-			interleaveSchema: "test.parent2 (p2)",
+			interleaveSchema: "parent2 (p2)",
 			// child2 has less rows than parent2, thus not all
 			// parent2 rows will have a nested child2 row.
 			nRows: 100,
@@ -595,7 +595,11 @@ func TestNextRowInterleave(t *testing.T) {
 	ggc1idx := *tableArgs["grandgrandchild1"]
 	// This is only possible since nrows(ggc1) < nrows(p2) thus c1 is
 	// unique.
-	ggc1idx.indexSchema = `CREATE UNIQUE INDEX ggc1_unique_idx ON test.grandgrandchild1 (p2) INTERLEAVE IN PARENT test.parent2 (p2);`
+	ggc1idx.indexSchema = fmt.Sprintf(
+		`CREATE UNIQUE INDEX ggc1_unique_idx ON %s.grandgrandchild1 (p2) INTERLEAVE IN PARENT %s.parent2 (p2);`,
+		sqlutils.TestDB,
+		sqlutils.TestDB,
+	)
 	ggc1idx.indexName = "ggc1_unique_idx"
 	ggc1idx.indexIdx = 1
 	// Last column v (idx 4) is not stored in this index.
@@ -658,7 +662,7 @@ func TestNextRowInterleave(t *testing.T) {
 			// MultiRowFetcher.
 			idLookups := make(map[uint64]*fetcherEntryArgs, len(entries))
 			for i, entry := range entries {
-				tableDesc := GetTableDescriptor(kvDB, testDB, entry.tableName)
+				tableDesc := GetTableDescriptor(kvDB, sqlutils.TestDB, entry.tableName)
 				var indexID IndexID
 				if entry.indexIdx == 0 {
 					indexID = tableDesc.PrimaryIndex.ID

--- a/pkg/testutils/sqlutils/table_gen.go
+++ b/pkg/testutils/sqlutils/table_gen.go
@@ -71,7 +71,7 @@ func CreateTableInterleaved(
 	}
 
 	r := MakeSQLRunner(sqlDB)
-	stmt := `CREATE DATABASE IF NOT EXISTS test;`
+	stmt := fmt.Sprintf(`CREATE DATABASE IF NOT EXISTS %s;`, TestDB)
 	stmt += fmt.Sprintf(`CREATE TABLE %s.%s (%s) %s;`, TestDB, tableName, schema, interleaveSchema)
 	r.Exec(tb, stmt)
 	for i := 1; i <= numRows; {


### PR DESCRIPTION
For two tables `parent` and `child`
```sql
CREATE TABLE parent (pid1 INT, pid2 INT, v INT, PRIMARY KEY (pid1, pid2));

CREATE TABLE child (pid1 INT, pid2 INT, cid1 INT, v INT, PRIMARY KEY (pid1, pid2, cid1)) INTERLEAVE IN PARENT parent (pid1, pid2);
```

A query on the full interleave prefix
```sql
SELECT * FROM parent JOIN child USING (pid1, pid2)
```
[uses the `InterleaveReaderJoiner`](https://cockroachdb.github.io/distsqlplan/decode.html?eJyMjzFLPDEUxPv_p_gzlXKvuD1BISCkXQtPrpUtwmZcA2uyJG9FOPLd5TbFYSFYzm-SmXlnxOT57D5YYF7RYRAsOY0sJeULag96_wWzF4S4rHrBg2BMmTBnaNCZMOijMs90nzzReeanFCIzBJ7qwrzlz3zTG9vtxB52t485TO9XCcFxVfPfdmIPYu_E3ot9wFAFadVrb1E3Eaar8vdtJ5YlxcIfa35L3tdBQD-x3V_Smke-5DRuNU0et38b8Cza3K6JPjarDvXfdwAAAP__72hxmQ==).

A query on just a subset of the interleave prefix will simply [default back to a `MergeJoiner`](https://cockroachdb.github.io/distsqlplan/decode.html?eJyskc9KxDAQh-8-hcxJcQ7b1j8QEHJdQVcWb9JDbMZuoJuUSQLK0neXJod161ZZ8NbMzDcfv-kOrNP0pLbkQbxCATVCz64h7x2PpTyw1B8gFgjG9jGM5RqhcUwgdhBM6AgEvKi3jtakNDEgaArKdGlpz2ar-FP2iskGQFjFIM5lgbJEWUE9ILgY9ot9UC2BKAb8R3mzMZ2eulFez-rLWf3eGq1jTUz6wFmP5F8jRzI8Erf04IydZujoPVzI4urynk27yZ8_o9ygvEV5NxuoOuWea_K9s56mwY5uXoxpSLeUr-Nd5Iae2TVJk5-rxKWCJh9yt8yPpU2t9MO_w8UJcDmFy1_h6gBeDPVw9hUAAP__kk3-zw==).
```sql
SELECT * FROM parent JOIN child USING (pid1)
```

Fixes #18948