### PR TITLE
sql: only claim 1/10 done after sampling csv

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1090,7 +1090,7 @@ func (l *DistLoader) LoadCSV(
 	}
 
 	log.VEventf(ctx, 1, "generated %d splits; begin routing for job %s", len(spans), job.Record.Description)
-	if err := job.Progressed(ctx, 1.0/3.0, jobs.Noop); err != nil {
+	if err := job.Progressed(ctx, 1.0/10.0, jobs.Noop); err != nil {
 		log.Warningf(ctx, "failed to update job progress: %s", err)
 	}
 


### PR DESCRIPTION
1/3 was pulled out of thin air and is wildly inaccurate.
1/10 is too, but hopefully closer, and at least not overpromising quite as badly.