### PR TITLE
sql: fix panic with IN expressions and subqueries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -158,3 +158,24 @@ query B
 SELECT IFNULL('true', false)
 ----
 true
+
+# Regression tests for #19770
+
+query B
+SELECT 1 in (SELECT 1)
+----
+true
+
+statement error unsupported comparison operator: <int> IN <tuple{string}>
+SELECT 1 IN (SELECT 'a')
+
+statement error unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>
+SELECT 1 IN (SELECT (1, 2))
+
+query B
+SELECT (1, 2) IN (SELECT 1, 2)
+----
+true
+
+statement error subquery must return 2 columns, found 1
+SELECT (1, 2) IN (SELECT (1, 2))

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -1091,6 +1091,30 @@ func subOpCompError(leftType, rightType Type, subOp, op ComparisonOperator) *pge
 	return pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, sig)
 }
 
+// typeCheckSubqueryWithIn checks the case where the right side of an IN
+// expression is a subquery.
+func typeCheckSubqueryWithIn(left, right Type) error {
+	if rTuple, ok := right.(TTuple); ok {
+		if lTuple, ok := left.(TTuple); ok {
+			if len(lTuple) != len(rTuple) {
+				return pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, fmt.Sprintf(compSignatureFmt, left, In, right))
+			}
+			for i := range rTuple {
+				if rTuple[i] != lTuple[i] {
+					return pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, fmt.Sprintf(compSignatureFmt, left, In, right))
+				}
+			}
+		} else {
+			// Subqueries returning a single column come through as a tuple{T}, so
+			// T IN tuple{T} should be accepted.
+			if len(rTuple) != 1 || rTuple[0] != left {
+				return pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, fmt.Sprintf(compSignatureFmt, left, In, right))
+			}
+		}
+	}
+	return nil
+}
+
 func typeCheckComparisonOp(
 	ctx *SemaContext, op ComparisonOperator, left, right Expr,
 ) (TypedExpr, TypedExpr, CmpOp, error) {
@@ -1162,6 +1186,12 @@ func typeCheckComparisonOp(
 	}
 	leftReturn := leftExpr.ResolvedType()
 	rightReturn := rightExpr.ResolvedType()
+
+	if foldedOp == In {
+		if err := typeCheckSubqueryWithIn(leftReturn, rightReturn); err != nil {
+			return nil, nil, CmpOp{}, err
+		}
+	}
 
 	// Return early if at least one overload is possible and NULL is an argument.
 	// Callers can handle returning NULL, if necessary.


### PR DESCRIPTION
Fixes #19770.

Previously, an IN expression with a subquery on the RHS was not
type-checked for if the column value matched the LHS, which would lead
to a panic in some cases.

This commit introduces a check in the case of an IN expression that the
type matches.

There is already such a check for explicit tuples, but these cannot be
folded into the same check, as the typechecking of the tuple case has
some specialized logic for inferring its types.