### PR TITLE
storageccl,sqlccl: make nodelocal paths relative to external-io-dir

### DIFF
--- a/pkg/ccl/sqlccl/backup_cloud_test.go
+++ b/pkg/ccl/sqlccl/backup_cloud_test.go
@@ -55,7 +55,7 @@ func TestCloudBackupRestoreS3(t *testing.T) {
 	defer sql.TestDisableTableLeases()()
 	const numAccounts = 1000
 
-	ctx, _, tc, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, initNone)
+	ctx, tc, _, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, initNone)
 	defer cleanupFn()
 	prefix := fmt.Sprintf("TestBackupRestoreS3-%d", timeutil.Now().UnixNano())
 	uri := url.URL{Scheme: "s3", Host: bucket, Path: prefix}
@@ -88,7 +88,7 @@ func TestCloudBackupRestoreGoogleCloudStorage(t *testing.T) {
 	}(http.DefaultTransport.(*http.Transport).DisableKeepAlives)
 	http.DefaultTransport.(*http.Transport).DisableKeepAlives = true
 
-	ctx, _, tc, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, initNone)
+	ctx, tc, _, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, initNone)
 	defer cleanupFn()
 	prefix := fmt.Sprintf("TestBackupRestoreGoogleCloudStorage-%d", timeutil.Now().UnixNano())
 	uri := url.URL{Scheme: "gs", Host: bucket, Path: prefix}
@@ -120,7 +120,7 @@ func TestCloudBackupRestoreAzure(t *testing.T) {
 	}(http.DefaultTransport.(*http.Transport).DisableKeepAlives)
 	http.DefaultTransport.(*http.Transport).DisableKeepAlives = true
 
-	ctx, _, tc, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, initNone)
+	ctx, tc, _, _, cleanupFn := backupRestoreTestSetup(t, 1, numAccounts, initNone)
 	defer cleanupFn()
 	prefix := fmt.Sprintf("TestBackupRestoreAzure-%d", timeutil.Now().UnixNano())
 	uri := url.URL{Scheme: "azure", Host: bucket, Path: prefix}

--- a/pkg/ccl/sqlccl/bench_test.go
+++ b/pkg/ccl/sqlccl/bench_test.go
@@ -40,7 +40,7 @@ func BenchmarkClusterBackup(b *testing.B) {
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
 
-	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(b, multiNode, 0, initNone)
+	_, _, sqlDB, dir, cleanupFn := backupRestoreTestSetup(b, multiNode, 0, initNone)
 	defer cleanupFn()
 	sqlDB.Exec(`DROP TABLE data.bank`)
 
@@ -73,7 +73,7 @@ func BenchmarkClusterRestore(b *testing.B) {
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
 
-	_, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0, initNone)
+	_, _, sqlDB, dir, cleanup := backupRestoreTestSetup(b, multiNode, 0, initNone)
 	defer cleanup()
 	sqlDB.Exec(`DROP TABLE data.bank`)
 
@@ -94,7 +94,7 @@ func BenchmarkLoadRestore(b *testing.B) {
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
 
-	ctx, dir, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0, initNone)
+	ctx, _, sqlDB, dir, cleanup := backupRestoreTestSetup(b, multiNode, 0, initNone)
 	defer cleanup()
 	sqlDB.Exec(`DROP TABLE data.bank`)
 
@@ -113,7 +113,7 @@ func BenchmarkLoadSQL(b *testing.B) {
 	// NB: This benchmark takes liberties in how b.N is used compared to the go
 	// documentation's description. We're getting useful information out of it,
 	// but this is not a pattern to cargo-cult.
-	_, _, _, sqlDB, cleanup := backupRestoreTestSetup(b, multiNode, 0, initNone)
+	_, _, sqlDB, _, cleanup := backupRestoreTestSetup(b, multiNode, 0, initNone)
 	defer cleanup()
 	sqlDB.Exec(`DROP TABLE data.bank`)
 
@@ -140,11 +140,11 @@ func BenchmarkLoadSQL(b *testing.B) {
 func BenchmarkClusterEmptyIncrementalBackup(b *testing.B) {
 	const numStatements = 100000
 
-	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(b, multiNode, 0, initNone)
+	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(b, multiNode, 0, initNone)
 	defer cleanupFn()
 
-	restoreDir := filepath.Join(dir, "restore")
-	fullDir := filepath.Join(dir, "full")
+	restoreDir := filepath.Join(localFoo, "restore")
+	fullDir := filepath.Join(localFoo, "full")
 
 	bankData := sampledataccl.BankRows(numStatements)
 	_, err := sampledataccl.ToBackup(b, bankData, restoreDir)
@@ -165,7 +165,7 @@ func BenchmarkClusterEmptyIncrementalBackup(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		incrementalDir := filepath.Join(dir, fmt.Sprintf("incremental%d", i))
+		incrementalDir := filepath.Join(localFoo, fmt.Sprintf("incremental%d", i))
 		sqlDB.Exec(`BACKUP DATABASE data TO $1 INCREMENTAL FROM $2`, incrementalDir, fullDir)
 	}
 	b.StopTimer()

--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -199,7 +199,8 @@ var (
 )
 
 type localFileStorage struct {
-	base string
+	rawBase string // un-prefixed base -- DO NOT use for I/O ops.
+	base    string // the prefixed base, for I/O ops on this node.
 }
 
 var _ ExportStorage = &localFileStorage{}
@@ -219,25 +220,27 @@ func makeLocalStorage(base string, settings *cluster.Settings) (ExportStorage, e
 		return nil, errors.Errorf("Local storage requested but path not provided")
 	}
 
+	localBase := base
 	// In non-server execution we have no settings and no restriction on local IO.
 	if settings != nil {
 		if settings.ExternalIODir == "" {
 			return nil, errors.Errorf("local file access is disabled")
 		}
-		// TODO(dt): base = filepath.Join(settings.ExternalIODir, base)
-		base = filepath.Clean(base)
-		if !strings.HasPrefix(base, settings.ExternalIODir) {
+		// we prefix with the IO dir
+		localBase = filepath.Clean(filepath.Join(settings.ExternalIODir, localBase))
+		// ... and make sure we didn't ../ our way back out.
+		if !strings.HasPrefix(localBase, settings.ExternalIODir) {
 			return nil, errors.Errorf("local file access to paths outside of external-io-dir is not allowed")
 		}
 	}
-	return &localFileStorage{base: base}, nil
+	return &localFileStorage{base: localBase, rawBase: base}, nil
 }
 
 func (l *localFileStorage) Conf() roachpb.ExportStorage {
 	return roachpb.ExportStorage{
 		Provider: roachpb.ExportStorageProvider_LocalFile,
 		LocalFile: roachpb.ExportStorage_LocalFilePath{
-			Path: l.base,
+			Path: l.rawBase,
 		},
 	}
 }

--- a/pkg/ccl/storageccl/export_storage_test.go
+++ b/pkg/ccl/storageccl/export_storage_test.go
@@ -230,11 +230,8 @@ func TestLocalIOLimits(t *testing.T) {
 	const allowed = "/allowed"
 	testSettings.ExternalIODir = allowed
 
-	for dest, expected := range map[string]string{allowed: "", "/blah": "not allowed"} {
-		u, err := MakeLocalStorageURI(dest)
-		if err != nil {
-			t.Fatal(err)
-		}
+	for dest, expected := range map[string]string{allowed: "", "/../../blah": "not allowed"} {
+		u := fmt.Sprintf("nodelocal://%s", dest)
 
 		conf, err := ExportStorageConfFromURI(u)
 		if err != nil {

--- a/pkg/ccl/storageccl/export_test.go
+++ b/pkg/ccl/storageccl/export_test.go
@@ -46,7 +46,7 @@ func TestExportCmd(t *testing.T) {
 			StartTime: start,
 			Storage: roachpb.ExportStorage{
 				Provider:  roachpb.ExportStorageProvider_LocalFile,
-				LocalFile: roachpb.ExportStorage_LocalFilePath{Path: dir},
+				LocalFile: roachpb.ExportStorage_LocalFilePath{Path: "/foo"},
 			},
 			MVCCFilter: mvccFilter,
 		}
@@ -67,7 +67,7 @@ func TestExportCmd(t *testing.T) {
 			sst := engine.MakeRocksDBSstFileReader()
 			defer sst.Close()
 
-			fileContents, err := ioutil.ReadFile(filepath.Join(dir, file.Path))
+			fileContents, err := ioutil.ReadFile(filepath.Join(dir, "foo", file.Path))
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}

--- a/pkg/ccl/storageccl/import_test.go
+++ b/pkg/ccl/storageccl/import_test.go
@@ -11,6 +11,7 @@ package storageccl
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -150,6 +151,10 @@ func runTestImport(t *testing.T, init func(*cluster.Settings)) {
 	dir, dirCleanupFn := testutils.TempDir(t)
 	defer dirCleanupFn()
 
+	if err := os.Mkdir(filepath.Join(dir, "foo"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
 	writeSST := func(keys ...[]byte) string {
 		path := strconv.FormatInt(hlc.UnixNano(), 10)
 
@@ -172,7 +177,7 @@ func runTestImport(t *testing.T, init func(*cluster.Settings)) {
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if err := ioutil.WriteFile(filepath.Join(dir, path), sstContents, 0644); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(dir, "foo", path), sstContents, 0644); err != nil {
 			t.Fatalf("%+v", err)
 		}
 		return path
@@ -255,7 +260,7 @@ func runTestImport(t *testing.T, init func(*cluster.Settings)) {
 
 	init(s.ClusterSettings())
 
-	storage, err := ExportStorageConfFromURI("nodelocal://" + dir)
+	storage, err := ExportStorageConfFromURI("nodelocal:///foo")
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}
@@ -273,7 +278,7 @@ func runTestImport(t *testing.T, init func(*cluster.Settings)) {
 			for _, f := range files[:i] {
 				req.Files = append(req.Files, roachpb.ImportRequest_File{Dir: storage, Path: f})
 			}
-			expectedKVs := slurpSSTablesLatestKey(t, dir, files[:i], kr)
+			expectedKVs := slurpSSTablesLatestKey(t, filepath.Join(dir, "foo"), files[:i], kr)
 
 			// Import may be retried by DistSender if it takes too long to return, so
 			// make sure it's idempotent.

--- a/pkg/ccl/utilccl/sampledataccl/bankdata_test.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata_test.go
@@ -128,9 +128,9 @@ func TestToBackup(t *testing.T) {
 	for _, rows := range []int{1, 10} {
 		for _, chunkBytes := range chunkBytesSizes {
 			t.Run(fmt.Sprintf("rows=%d/chunk=%d", rows, chunkBytes), func(t *testing.T) {
-				dir := filepath.Join(outerDir, fmt.Sprintf("%d-%d", rows, chunkBytes))
+				dir := fmt.Sprintf("%d-%d", rows, chunkBytes)
 				data := Bank(rows, payloadBytes, bankConfigDefault)
-				backup, err := toBackup(t, data, dir, chunkBytes)
+				backup, err := toBackup(t, data, filepath.Join(outerDir, dir), chunkBytes)
 				if err != nil {
 					t.Fatalf("%+v", err)
 				}
@@ -139,7 +139,7 @@ func TestToBackup(t *testing.T) {
 					sqlDB := sqlutils.MakeSQLRunner(t, db)
 					sqlDB.Exec(`DROP DATABASE IF EXISTS data CASCADE`)
 					sqlDB.Exec(`CREATE DATABASE data`)
-					sqlDB.Exec(`RESTORE data.* FROM $1`, `nodelocal://`+dir)
+					sqlDB.Exec(`RESTORE data.* FROM $1`, `nodelocal:///`+dir)
 
 					var rowCount int
 					sqlDB.QueryRow(fmt.Sprintf(`SELECT COUNT(*) FROM %s`, data.Name())).Scan(&rowCount)


### PR DESCRIPTION
This prefixes local file access paths specified with `nodelocal` URLs
with the external-io-dir, meaning that the paths are relative to that
path. Additionally, after cleaning (collapsing ../) the resolved local
path must still begin with the IO dir or an error is returned.

This is a small code change and a very large test change, as many of our tests,
instead of sending the full temp dir in each command now set it as their
IO dir and then just send a placeholder, e.g. "foo".