### PR TITLE
cherrypick-1.1: sql: fix KV TRACE crash with COUNT(*)

### DIFF
--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -318,7 +318,11 @@ func (rf *RowFetcher) processKV(
 	ctx context.Context, kv client.KeyValue, debugStrings bool,
 ) (prettyKey string, prettyValue string, err error) {
 	if debugStrings {
-		prettyKey = fmt.Sprintf("/%s/%s%s", rf.desc.Name, rf.index.Name, prettyEncDatums(rf.keyVals))
+		if rf.mustDecodeIndexKey {
+			prettyKey = fmt.Sprintf("/%s/%s%s", rf.desc.Name, rf.index.Name, prettyEncDatums(rf.keyVals))
+		} else {
+			prettyKey = fmt.Sprintf("/%s/%s/{not-decoded}", rf.desc.Name, rf.index.Name)
+		}
 	}
 
 	if rf.indexKey == nil {


### PR DESCRIPTION
Also adding a test.

Fixes #19846.

This is not really a cherrypick since this is no longer a problem on master. I will open a PR to add just the test.
CC @cockroachdb/release 