### PR TITLE
ui: label byte axes with the measure name and unit symbol

### DIFF
--- a/pkg/ui/src/util/format.ts
+++ b/pkg/ui/src/util/format.ts
@@ -24,11 +24,25 @@ export function ComputePrefixExponent(value: number, prefixMultiple: number, pre
   return prefixScale;
 }
 
-export function BytesToUnitValue(bytes: number): UnitValue {
+/**
+ * ComputeByteScale calculates the appropriate scale factor and unit to use to
+ * display a given byte value, without actually converting the value.
+ *
+ * This is used to prescale byte values before passing them to a d3-axis.
+ */
+export function ComputeByteScale(bytes: number): UnitValue {
   const scale = ComputePrefixExponent(bytes, kibi, byteUnits);
   return {
-    value: bytes / Math.pow(kibi, scale),
+    value: Math.pow(kibi, scale),
     units: byteUnits[scale],
+  };
+}
+
+export function BytesToUnitValue(bytes: number): UnitValue {
+  const scale = ComputeByteScale(bytes);
+  return {
+    value: bytes / scale.value,
+    units: scale.units,
   };
 }
 

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -105,8 +105,8 @@ export default function (props: GraphDashboardProps) {
         </div>
       )}
     >
-      <Axis units={AxisUnits.Bytes}>
-        <Metric name="cr.store.capacity" title="Capacity" />
+      <Axis units={AxisUnits.Bytes} label="capacity">
+        <Metric name="cr.store.capacity" title="capacity" />
         <Metric name="cr.store.capacity.available" title="Available" />
         <Metric name="cr.store.capacity.used" title="Used" />
       </Axis>

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -58,7 +58,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph title="Logical Bytes per Store" tooltip={`The number of logical bytes of data on each store.`}>
-      <Axis units={AxisUnits.Bytes}>
+      <Axis units={AxisUnits.Bytes} label="logical store size">
         {
           _.map(nodeIDs, (nid) => (
             <Metric

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -36,7 +36,7 @@ export default function (props: GraphDashboardProps) {
         </div>
       )}
     >
-      <Axis units={AxisUnits.Bytes}>
+      <Axis units={AxisUnits.Bytes} label="memory usage">
         <Metric name="cr.node.sys.rss" title="Total memory (RSS)" />
         <Metric name="cr.node.sys.go.allocbytes" title="Go Allocated" />
         <Metric name="cr.node.sys.go.totalbytes" title="Go Total" />

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -27,7 +27,7 @@ export default function (props: GraphDashboardProps) {
         `The total amount of SQL client network traffic in bytes per second ${tooltipSelection}.`
       }
     >
-      <Axis units={AxisUnits.Bytes}>
+      <Axis units={AxisUnits.Bytes} label="byte traffic">
         <Metric name="cr.node.sql.bytesin" title="Bytes In" nonNegativeRate />
         <Metric name="cr.node.sql.bytesout" title="Bytes Out" nonNegativeRate />
       </Axis>

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -30,7 +30,7 @@ export default function (props: GraphDashboardProps) {
            CockroachDB system ${tooltipSelection}. This excludes historical and deleted data.`
       }
     >
-      <Axis units={AxisUnits.Bytes}>
+      <Axis units={AxisUnits.Bytes} label="live bytes">
         <Metric name="cr.store.livebytes" title="Live" />
         <Metric name="cr.store.sysbytes" title="System" />
       </Axis>

--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -110,7 +110,6 @@
     font-size 11px
 
   .nv-axislabel
-    text-transform lowercase
     font-family Lato-Regular
     fill $button-border-color
 


### PR DESCRIPTION
Previously, byte axes were mislabeled with the SI unit names, even though they were actually showing IEC units.  The tooltip correctly shows that the units are IEC.  This change switches the axis labels to use the IEC units.  In the interest of avoiding the kinds of surprise expressed in #4735, this change uses the unit symbol instead of the full name.  To fill out the space along the axis, the measure name is listed first, with the unit symbol in parentheses (e.g., "capacity (GiB)").

Closes #18949.

![screen shot 2017-11-07 at 11 43 15 am](https://user-images.githubusercontent.com/793969/32505707-e34e9a44-c3b0-11e7-9eee-4869b2e223a1.png)
