### PR TITLE
build: Improve error logging in teamcity-post-failures

### DIFF
--- a/build/teamcity-jepsen-run-one.sh
+++ b/build/teamcity-jepsen-run-one.sh
@@ -84,7 +84,8 @@ if timeout 20m ssh "${SSH_OPTIONS[@]}" "ubuntu@${controller}" "${testcmd}" \
 
     # Test passed. grab just the results file.
     progress "Test passed. Grabbing minimal logs..."
-    scp "${SSH_OPTIONS[@]}" -C -r \
+    # TODO(bdarnell): remove -v's
+    scp "${SSH_OPTIONS[@]}" -C -r -v -v -v \
         "ubuntu@${controller}:jepsen/cockroachdb/store/latest/{test.fressian,results.edn,latency-quantiles.png,latency-raw.png,rate.png}" \
         "${artifacts_dir}"
 

--- a/build/teamcity-post-failures.py
+++ b/build/teamcity-post-failures.py
@@ -85,7 +85,14 @@ def post_issue(issue):
         'https://api.github.com/repos/cockroachdb/cockroach/issues',
         data=json.dumps(issue).encode('utf-8'),
         headers={'Authorization': 'token {0}'.format(os.environ['GITHUB_API_TOKEN'])})
-    opener.open(req).read()
+    try:
+        opener.open(req).read()
+    except urllib.error.HTTPError as e:
+        # Github's error response bodies include useful information, so print them.
+        print('Posting to github failed with error code {0}'.format(e.code))
+        print('Error response body: {0}'.format(e.read()))
+        print('Request body: {0}'.format(issue))
+        raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This failed last night for jepsen tests with a `422 Unprocessable
Entity` error response from github (which should indicate a problem
like a missing field in the input, although the input structure is the
same between jepsen and other modes, which appear to be working).
Include more information to figure out what's going on.