### PR TITLE
cherry-pick 1.1: sql: fix panic with IN expressions and subqueries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -158,3 +158,24 @@ query B
 SELECT IFNULL('true', false)
 ----
 true
+
+# Regression tests for #19770
+
+query B
+SELECT 1 in (SELECT 1)
+----
+true
+
+statement error unsupported comparison operator: <int> IN <tuple{string}>
+SELECT 1 IN (SELECT 'a')
+
+statement error unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>
+SELECT 1 IN (SELECT (1, 2))
+
+query B
+SELECT (1, 2) IN (SELECT 1, 2)
+----
+true
+
+statement error subquery must return 2 columns, found 1
+SELECT (1, 2) IN (SELECT (1, 2))


### PR DESCRIPTION
Fixes #19770.

Previously, an IN expression with a subquery on the RHS was not
type-checked for if the column value matched the LHS, which would lead
to a panic in some cases.

This commit introduces a check in the case of an IN expression that the
type matches.

There is already such a check for explicit tuples, but these cannot be
folded into the same check, as the typechecking of the tuple case has
some specialized logic for inferring its types.