### PR TITLE
Makefile: allow `make test TESTS=-`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@
 
 ifeq ($(PKG),)
 ifneq ($(TESTS),)
+ifneq ($(TESTS),-)
 $(error TESTS must be specified with PKG (e.g. PKG=./pkg/sql/))
+endif
 endif
 ifneq ($(BENCHES),)
 $(error BENCHES must be specified with PKG (e.g. PKG=./pkg/sql/))


### PR DESCRIPTION
This is useful as it compiles all tests and serves as a quick
sanity check during refactors.