### PR TITLE
sql : add functions to encode JSON paths as binary

### DIFF
--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -660,6 +660,21 @@ func EncodeNotNullAscending(b []byte) []byte {
 	return append(b, encodedNotNull)
 }
 
+// EncodeArrayAscending encodes a value used to signify membership of an array for JSON objects.
+func EncodeArrayAscending(b []byte) []byte {
+	return append(b, byte(Array))
+}
+
+// EncodeTrueAscending encodes the boolean value true for use with JSON inverted indexes.
+func EncodeTrueAscending(b []byte) []byte {
+	return append(b, byte(True))
+}
+
+// EncodeFalseAscending encodes the boolean value false for use with JSON inverted indexes.
+func EncodeFalseAscending(b []byte) []byte {
+	return append(b, byte(False))
+}
+
 // EncodeNotNullDescending is the descending equivalent of EncodeNotNullAscending.
 func EncodeNotNullDescending(b []byte) []byte {
 	return append(b, encodedNotNullDesc)

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
 type jsonType int
@@ -53,6 +54,10 @@ type JSON interface {
 	Format(buf *bytes.Buffer)
 	// Size returns the size of the JSON document in bytes.
 	Size() uintptr
+
+	// EncodeInvertedIndexKeys takes in a key prefix and returns a slice of inverted index keys,
+	// one per path through the receiver.
+	EncodeInvertedIndexKeys(b []byte) [][]byte
 
 	// FetchValKey implements the `->` operator for strings, returning nil if the
 	// key is not found.
@@ -368,6 +373,51 @@ func ParseJSON(s string) (JSON, error) {
 		return nil, errTrailingCharacters
 	}
 	return MakeJSON(result)
+}
+
+func (j jsonNull) EncodeInvertedIndexKeys(b []byte) [][]byte {
+	return [][]byte{encoding.EncodeNullAscending(b)}
+}
+func (jsonTrue) EncodeInvertedIndexKeys(b []byte) [][]byte {
+	return [][]byte{encoding.EncodeTrueAscending(b)}
+}
+func (jsonFalse) EncodeInvertedIndexKeys(b []byte) [][]byte {
+	return [][]byte{encoding.EncodeFalseAscending(b)}
+}
+func (j jsonString) EncodeInvertedIndexKeys(b []byte) [][]byte {
+	return [][]byte{encoding.EncodeStringAscending(b, string(j))}
+}
+func (j jsonNumber) EncodeInvertedIndexKeys(b []byte) [][]byte {
+	var dec = apd.Decimal(j)
+	return [][]byte{encoding.EncodeDecimalAscending(b, &dec)}
+}
+func (j jsonArray) EncodeInvertedIndexKeys(b []byte) [][]byte {
+	var outKeys [][]byte
+
+	for i := range j {
+		for _, childBytes := range j[i].EncodeInvertedIndexKeys(nil) {
+			encodedKey := bytes.Join([][]byte{b, encoding.EncodeArrayAscending(nil), childBytes}, nil)
+			outKeys = append(outKeys, encodedKey)
+		}
+	}
+
+	return outKeys
+}
+
+func (j jsonObject) EncodeInvertedIndexKeys(b []byte) [][]byte {
+	var outKeys [][]byte
+	for i := range j {
+		for _, childBytes := range j[i].v.EncodeInvertedIndexKeys(nil) {
+			encodedKey := bytes.Join([][]byte{b,
+				encoding.EncodeNotNullAscending(nil),
+				encoding.EncodeStringAscending(nil, string(j[i].k)),
+				childBytes}, nil)
+
+			outKeys = append(outKeys, encodedKey)
+		}
+	}
+
+	return outKeys
 }
 
 // MakeJSON returns a JSON value given a Go-style representation of JSON.

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -21,7 +21,10 @@ import (
 	"strings"
 	"testing"
 
+	"bytes"
+	"github.com/cockroachdb/apd"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -552,6 +555,82 @@ func TestJSONRemoveIndex(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func getApdEncoding(num float64) *apd.Decimal {
+	dec := &apd.Decimal{}
+	dec, _ = dec.SetFloat64(num)
+	return dec
+}
+
+func arraySeparator(b []byte) []byte {
+	return encoding.EncodeArrayAscending(b)
+}
+
+func keyPrefix(b []byte) []byte {
+	return encoding.EncodeNotNullAscending(b)
+}
+
+func TestEncodeDecodeJSONInvertedIndex(t *testing.T) {
+	bytePrefix := make([]byte, 1, 100)
+	bytePrefix[0] = 0x0f
+
+	testCases := []struct {
+		value  string
+		expEnc [][]byte
+	}{
+		{`{"a":"b"}`, [][]byte{bytes.Join([][]byte{keyPrefix(bytePrefix),
+			encoding.EncodeStringAscending(nil, "a"), encoding.EncodeStringAscending(nil, "b")}, nil)}},
+		{`["a", "b"]`, [][]byte{bytes.Join([][]byte{arraySeparator(bytePrefix),
+			encoding.EncodeStringAscending(nil, "a")}, nil),
+			bytes.Join([][]byte{arraySeparator(bytePrefix),
+				encoding.EncodeStringAscending(nil, "b")}, nil)}},
+		{`null`, [][]byte{encoding.EncodeNullAscending(bytePrefix)}},
+		{`false`, [][]byte{encoding.EncodeFalseAscending(bytePrefix)}},
+		{`true`, [][]byte{encoding.EncodeTrueAscending(bytePrefix)}},
+		{`1.23`, [][]byte{encoding.EncodeDecimalAscending(bytePrefix, getApdEncoding(1.23))}},
+		{`"a"`, [][]byte{encoding.EncodeStringAscending(bytePrefix, "a")}},
+		{`["c", {"a":"b"}]`, [][]byte{bytes.Join([][]byte{arraySeparator(bytePrefix),
+			encoding.EncodeStringAscending(nil, "c")}, nil),
+			bytes.Join([][]byte{arraySeparator(bytePrefix),
+				keyPrefix(nil),
+				encoding.EncodeStringAscending(nil, "a"),
+				encoding.EncodeStringAscending(nil, "b")}, nil)}},
+		{`["c", {"a":["c","d"]}]`, [][]byte{bytes.Join([][]byte{
+			arraySeparator(bytePrefix),
+			encoding.EncodeStringAscending(nil, "c")}, nil),
+
+			bytes.Join([][]byte{arraySeparator(bytePrefix),
+				keyPrefix(nil),
+				encoding.EncodeStringAscending(nil, "a"),
+				arraySeparator(nil),
+				encoding.EncodeStringAscending(nil, "c")}, nil),
+
+			bytes.Join([][]byte{arraySeparator(bytePrefix),
+				keyPrefix(nil),
+				encoding.EncodeStringAscending(nil, "a"),
+				arraySeparator(nil),
+				encoding.EncodeStringAscending(nil, "d")}, nil)}},
+
+		{`{"a":"b","e":"f"}`, [][]byte{
+			bytes.Join([][]byte{keyPrefix(bytePrefix),
+				encoding.EncodeStringAscending(nil, "a"), encoding.EncodeStringAscending(nil, "b")}, nil),
+
+			bytes.Join([][]byte{keyPrefix(bytePrefix),
+				encoding.EncodeStringAscending(nil, "e"), encoding.EncodeStringAscending(nil, "f")}, nil),
+		}},
+	}
+
+	for _, c := range testCases {
+		enc := jsonTestShorthand(c.value).EncodeInvertedIndexKeys(bytePrefix)
+		for j, path := range enc {
+			if !bytes.Equal(path, c.expEnc[j]) {
+				t.Errorf("unexpected encoding mismatch for %v. expected [%#v], got [%#v]",
+					c.value, c.expEnc[j], path)
+			}
+		}
+
 	}
 }
 


### PR DESCRIPTION
These functions will allow us to generate inverted index keys from a JSON interface.