### PR TITLE
ui: flatten cluster summary sections

### DIFF
--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -22,65 +22,62 @@
     grid-template-rows repeat(3, auto)
     grid-template-areas "cap-t cap-t . live-t live-t live-t . rep-t rep-t rep-t ." "cap-m cap-c . live-a live-b live-c . rep-a rep-b rep-c ." "cap-a cap-a . live-1 live-2 live-3 . rep-1 rep-2 rep-3 ."
 
-    &__section
-      display contents
+    .capacity-usage
+      &.cluster-summary__title
+          grid-area cap-t
 
-      &.capacity-usage
-        .cluster-summary__title
-            grid-area cap-t
+      &.cluster-summary__chart
+          grid-area cap-c
 
-        .cluster-summary__chart
-            grid-area cap-c
+      &.cluster-summary__metric
+          grid-area cap-m
 
-        .cluster-summary__metric
-            grid-area cap-m
+      &.cluster-summary__aside
+          grid-area cap-a
 
-        .cluster-summary__aside
-            grid-area cap-a
+    .node-liveness
+      &.cluster-summary__title
+          grid-area live-t
 
-      &.node-liveness
-        .cluster-summary__title
-            grid-area live-t
+      &.cluster-summary__metric.live-nodes
+          grid-area live-a
 
-        .cluster-summary__metric.live-nodes
-            grid-area live-a
+      &.cluster-summary__metric.suspect-nodes
+          grid-area live-b
 
-        .cluster-summary__metric.suspect-nodes
-            grid-area live-b
+      &.cluster-summary__metric.dead-nodes
+          grid-area live-c
 
-        .cluster-summary__metric.dead-nodes
-            grid-area live-c
+      &.cluster-summary__label.live-nodes
+          grid-area live-1
 
-        .cluster-summary__label.live-nodes
-            grid-area live-1
+      &.cluster-summary__label.suspect-nodes
+          grid-area live-2
 
-        .cluster-summary__label.suspect-nodes
-            grid-area live-2
+      &.cluster-summary__label.dead-nodes
+          grid-area live-3
 
-        .cluster-summary__label.dead-nodes
-            grid-area live-3
+    .replication-status
+      &.cluster-summary__title
+          grid-area rep-t
 
-      &.replication-status
-        .cluster-summary__title
-            grid-area rep-t
+      &.cluster-summary__metric.total-ranges
+          grid-area rep-a
 
-        .cluster-summary__metric.total-ranges
-            grid-area rep-a
+      &.cluster-summary__metric.under-replicated-ranges
+          grid-area rep-b
 
-        .cluster-summary__metric.under-replicated-ranges
-            grid-area rep-b
+      &.cluster-summary__metric.unavailable-ranges
+          grid-area rep-c
 
-        .cluster-summary__metric.unavailable-ranges
-            grid-area rep-c
+      &.cluster-summary__label.total-ranges
+          grid-area rep-1
 
-        .cluster-summary__label.total-ranges
-            grid-area rep-1
+      &.cluster-summary__label.under-replicated-ranges
+          grid-area rep-2
 
-        .cluster-summary__label.under-replicated-ranges
-            grid-area rep-2
-
-        .cluster-summary__label.unavailable-ranges
-            grid-area rep-3
+      &.cluster-summary__label.unavailable-ranges
+          grid-area rep-3
 
     &__title
       font-weight 400
@@ -116,7 +113,7 @@
       .label, .value
         font-size 11px
 
-  .capacity-usage .cluster-summary__chart
+  .capacity-usage.cluster-summary__chart
     align-self start
     position relative
 

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { createSelector } from "reselect";
 
+import { AdminUIState } from "src/redux/state";
 import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
 import { Bytes as formatBytes } from "src/util/format";
 import { NodesOverview } from "src/views/cluster/containers/nodesOverview";
@@ -31,24 +32,20 @@ interface CapacityUsageProps {
 
 const formatPercentage = d3.format("0.1%");
 
-class CapacityUsage extends React.Component<CapacityUsageProps, {}> {
-  render() {
-    const { usedCapacity, usableCapacity } = this.props;
-    const usedPercentage = usableCapacity !== 0 ? usedCapacity / usableCapacity : 0;
-    return (
-      <div className="cluster-summary__section capacity-usage">
-        <h3 className="cluster-summary__title">Capacity Usage</h3>
-        <div className="cluster-summary__metric">{ formatPercentage(usedPercentage) }</div>
-        <div className="cluster-summary__chart">
-          <CapacityChart used={usedCapacity} usable={usableCapacity} />
-        </div>
-        <div className="cluster-summary__aside">
-          <span className="label">Current Usage</span>
-          <span className="value">{ formatBytes(usedCapacity) }</span>
-        </div>
-      </div>
-    );
-  }
+function renderCapacityUsage(props: CapacityUsageProps) {
+  const { usedCapacity, usableCapacity } = props;
+  const usedPercentage = usableCapacity !== 0 ? usedCapacity / usableCapacity : 0;
+  return [
+    <h3 className="capacity-usage cluster-summary__title">Capacity Usage</h3>,
+    <div className="capacity-usage cluster-summary__metric">{ formatPercentage(usedPercentage) }</div>,
+    <div className="capacity-usage cluster-summary__chart">
+      <CapacityChart used={usedCapacity} usable={usableCapacity} />
+    </div>,
+    <div className="capacity-usage cluster-summary__aside">
+      <span className="label">Current Usage</span>
+      <span className="value">{ formatBytes(usedCapacity) }</span>
+    </div>,
+  ];
 }
 
 const mapStateToCapacityUsageProps = createSelector(
@@ -63,30 +60,23 @@ const mapStateToCapacityUsageProps = createSelector(
   },
 );
 
-// tslint:disable-next-line:variable-name
-const CapacityUsageConnected = connect(mapStateToCapacityUsageProps)(CapacityUsage);
-
 interface NodeLivenessProps {
   liveNodes: number;
   suspectNodes: number;
   deadNodes: number;
 }
 
-class NodeLiveness extends React.Component<NodeLivenessProps, {}> {
-  render() {
-    const { liveNodes, suspectNodes, deadNodes } = this.props;
-    return (
-      <div className="cluster-summary__section node-liveness">
-        <h3 className="cluster-summary__title">Node Liveness</h3>
-        <div className="cluster-summary__metric live-nodes">{ liveNodes }</div>
-        <div className="cluster-summary__label live-nodes">Live<br />Nodes</div>
-        <div className={ "cluster-summary__metric suspect-nodes" + (suspectNodes ? " warning" : "") }>{ suspectNodes }</div>
-        <div className="cluster-summary__label suspect-nodes">Suspect<br />Nodes</div>
-        <div className={ "cluster-summary__metric dead-nodes" + (deadNodes ? " alert" : "") }>{ deadNodes }</div>
-        <div className="cluster-summary__label dead-nodes">Dead<br />Nodes</div>
-      </div>
-    );
-  }
+function renderNodeLiveness(props: NodeLivenessProps) {
+  const { liveNodes, suspectNodes, deadNodes } = props;
+  return [
+    <h3 className="node-liveness cluster-summary__title">Node Liveness</h3>,
+    <div className="node-liveness cluster-summary__metric live-nodes">{ liveNodes }</div>,
+    <div className="node-liveness cluster-summary__label live-nodes">Live<br />Nodes</div>,
+    <div className={ "node-liveness cluster-summary__metric suspect-nodes" + (suspectNodes ? " warning" : "") }>{ suspectNodes }</div>,
+    <div className="node-liveness cluster-summary__label suspect-nodes">Suspect<br />Nodes</div>,
+    <div className={ "node-liveness cluster-summary__metric dead-nodes" + (deadNodes ? " alert" : "") }>{ deadNodes }</div>,
+    <div className="node-liveness cluster-summary__label dead-nodes">Dead<br />Nodes</div>,
+  ];
 }
 
 const mapStateToNodeLivenessProps = createSelector(
@@ -101,30 +91,23 @@ const mapStateToNodeLivenessProps = createSelector(
   },
 );
 
-// tslint:disable-next-line:variable-name
-const NodeLivenessConnected = connect(mapStateToNodeLivenessProps)(NodeLiveness);
-
 interface ReplicationStatusProps {
   totalRanges: number;
   underReplicatedRanges: number;
   unavailableRanges: number;
 }
 
-class ReplicationStatus extends React.Component<ReplicationStatusProps, {}> {
-  render() {
-    const { totalRanges, underReplicatedRanges, unavailableRanges } = this.props;
-    return (
-      <div className="cluster-summary__section replication-status">
-        <h3 className="cluster-summary__title">Replication Status</h3>
-        <div className="cluster-summary__metric total-ranges">{ totalRanges }</div>
-        <div className="cluster-summary__label total-ranges">Total<br />Ranges</div>
-        <div className={ "cluster-summary__metric under-replicated-ranges" + (underReplicatedRanges ? " warning" : "") }>{ underReplicatedRanges }</div>
-        <div className="cluster-summary__label under-replicated-ranges">Under-replicated<br />Ranges</div>
-        <div className={ "cluster-summary__metric unavailable-ranges" + (unavailableRanges ? " alert" : "") }>{ unavailableRanges }</div>
-        <div className="cluster-summary__label unavailable-ranges">Unavailable<br />Ranges</div>
-      </div>
-    );
-  }
+function renderReplicationStatus(props: ReplicationStatusProps) {
+  const { totalRanges, underReplicatedRanges, unavailableRanges } = props;
+  return [
+    <h3 className="replication-status cluster-summary__title">Replication Status</h3>,
+    <div className="replication-status cluster-summary__metric total-ranges">{ totalRanges }</div>,
+    <div className="replication-status cluster-summary__label total-ranges">Total<br />Ranges</div>,
+    <div className={ "replication-status cluster-summary__metric under-replicated-ranges" + (underReplicatedRanges ? " warning" : "") }>{ underReplicatedRanges }</div>,
+    <div className="replication-status cluster-summary__label under-replicated-ranges">Under-replicated<br />Ranges</div>,
+    <div className={ "replication-status cluster-summary__metric unavailable-ranges" + (unavailableRanges ? " alert" : "") }>{ unavailableRanges }</div>,
+    <div className="replication-status cluster-summary__label unavailable-ranges">Unavailable<br />Ranges</div>,
+  ];
 }
 
 const mapStateToReplicationStatusProps = createSelector(
@@ -139,20 +122,33 @@ const mapStateToReplicationStatusProps = createSelector(
   },
 );
 
-// tslint:disable-next-line:variable-name
-const ReplicationStatusConnected = connect(mapStateToReplicationStatusProps)(ReplicationStatus);
+interface ClusterSummaryProps {
+  capacityUsage: CapacityUsageProps;
+  nodeLiveness: NodeLivenessProps;
+  replicationStatus: ReplicationStatusProps;
+}
 
-class ClusterSummary extends React.Component<{}, {}> {
+class ClusterSummary extends React.Component<ClusterSummaryProps, {}> {
   render() {
-    return (
-      <section className="cluster-summary">
-        <CapacityUsageConnected />
-        <NodeLivenessConnected />
-        <ReplicationStatusConnected />
-      </section>
-    );
+    const children = [
+      ...renderCapacityUsage(this.props.capacityUsage),
+      ...renderNodeLiveness(this.props.nodeLiveness),
+      ...renderReplicationStatus(this.props.replicationStatus),
+    ];
+    return <section className="cluster-summary" children={children} />;
   }
 }
+
+function mapStateToClusterSummaryProps (state: AdminUIState) {
+  return {
+    capacityUsage: mapStateToCapacityUsageProps(state),
+    nodeLiveness: mapStateToNodeLivenessProps(state),
+    replicationStatus: mapStateToReplicationStatusProps(state),
+  };
+}
+
+// tslint:disable-next-line:variable-name
+const ClusterSummaryConnected = connect(mapStateToClusterSummaryProps)(ClusterSummary);
 
 /**
  * Renders the main content of the cluster visualization page.
@@ -163,7 +159,7 @@ class ClusterOverview extends React.Component<{}, {}> {
       <div>
         <div className="cluster-overview">
           <ClusterTicker />
-          <ClusterSummary />
+          <ClusterSummaryConnected />
         </div>
         <NodesOverview />
       </div>


### PR DESCRIPTION
Because Chrome's support for display: contents is still behind a flag,
we can't rely on it to handle flattening the markup for the cluster
overview.  This is uglier than it would be otherwise, because we're not
on React 16 yet, so we can't just have each section's component return
the arrays of elements.

Fixes #19902.