### PR TITLE
build: Expand jepsen test coverage

### DIFF
--- a/build/jepsen-common.sh
+++ b/build/jepsen-common.sh
@@ -38,22 +38,26 @@ function progress {
 }
 
 nemeses=(
-    # big-skews disabled since they assume an eth0 interface.
-    #"--nemesis big-skews"
     "--nemesis majority-ring"
-    "--nemesis start-stop-2"
+    "--nemesis split"
     "--nemesis start-kill-2"
-    #"--nemesis majority-ring --nemesis2 big-skews"
-    #"--nemesis big-skews --nemesis2 start-kill-2"
+    "--nemesis start-stop-2"
+    "--nemesis strobe-skews"
+    "--nemesis subcritical-skews"
+    "--nemesis majority-ring --nemesis2 subcritical-skews"
+    "--nemesis subcritical-skews --nemesis2 start-kill-2"
     "--nemesis majority-ring --nemesis2 start-kill-2"
     "--nemesis parts --nemesis2 start-kill-2"
 )
 
 tests=(
     "bank"
-    "comments"
-    "register"
+    "bank-multitable"
+    # The comments test is expected to fail because it requires linearizability.
+    #"comments"
+    "g2"
     "monotonic"
-    "sets"
+    "register"
     "sequential"
+    "sets"
 )

--- a/build/teamcity-jepsen-run-one.sh
+++ b/build/teamcity-jepsen-run-one.sh
@@ -26,7 +26,7 @@ testcmd="cd jepsen/cockroachdb && set -eo pipefail && \
    --ssh-private-key ~/.ssh/id_rsa \
    --nodes-file ~/nodes \
    --os ubuntu \
-   --time-limit 360 \
+   --time-limit 300 \
    --concurrency 30 \
    --recovery-time 25 \
    --test-count 1 \


### PR DESCRIPTION
Enable more nemeses: subcritical-skews, strobe-skews, split
Enable more tests: bank-mulittable, g2

Updates #19697