### PR TITLE
log: report hostname when COCKROACH_REPORT_SENSITIVE_DETAILS=true

### DIFF
--- a/pkg/util/log/crash_reporting_packet_test.go
+++ b/pkg/util/log/crash_reporting_packet_test.go
@@ -108,8 +108,11 @@ func TestCrashReportingPacket(t *testing.T) {
 		p := packets[0]
 		packets = packets[1:]
 		t.Run("", func(t *testing.T) {
-			if e, a := "<redacted>", p.ServerName; e != a {
-				t.Errorf("expected ServerName to be '<redacted>', but got '%s'", a)
+			if !log.ReportSensitiveDetails {
+				e, a := "<redacted>", p.ServerName
+				if e != a {
+					t.Errorf("expected ServerName to be '<redacted>', but got '%s'", a)
+				}
 			}
 
 			tags := make(map[string]string, len(p.Tags))


### PR DESCRIPTION
This environment variable will be set on our internal clusters and nightly test clusters
to allow easier identification.