### PR TITLE
sqlccl: fix TestBackupRestoreDropDB flake

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -2264,12 +2264,10 @@ func TestBackupRestoreDropDB(t *testing.T) {
 	_, dir, _, sqlDB, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
 	defer cleanupFn()
 
-	sqlDB.Exec(`DROP DATABASE data CASCADE`)
-	sqlDB.Exec(`
-		CREATE DATABASE data;
-		CREATE TABLE data.bank (i int);
-		INSERT INTO data.bank VALUES (1);
-	`)
+	sqlDB.Exec(`DROP DATABASE data`)
+	sqlDB.Exec(`CREATE DATABASE data`)
+	sqlDB.Exec(`CREATE TABLE data.bank (i int)`)
+	sqlDB.Exec(`INSERT INTO data.bank VALUES (1)`)
 
 	sqlDB.Exec("BACKUP DATABASE data TO $1", dir)
 	sqlDB.Exec("CREATE DATABASE data2")


### PR DESCRIPTION
For an unknown reason these statements need to be executed separately
otherwise a rare failure will occur where the INSERT can't see the
created table.

Fixes #19735