### PR TITLE
cli,cliccl: add tests for setting index/partition zone configs

### DIFF
--- a/pkg/ccl/cliccl/cli_test.go
+++ b/pkg/ccl/cliccl/cli_test.go
@@ -1,0 +1,199 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/LICENSE
+
+package cliccl
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/cli"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"golang.org/x/net/context"
+)
+
+// cliTest is a stripped-down version of package cli's cliTest. It's currently
+// easier to reimplement the pieces we need than it is to export cli.cliTest, as
+// cli's tests frequently mutate internal package variables. We may need to
+// revisit this decision if this package's tests become more complex.
+type cliTest struct {
+	*server.TestServer
+	connArgs []string
+}
+
+func newCLITest() cliTest {
+	s, err := serverutils.StartServerRaw(base.TestServerArgs{Insecure: true})
+	if err != nil {
+		panic(err)
+	}
+	host, port, err := net.SplitHostPort(s.ServingAddr())
+	if err != nil {
+		panic(err)
+	}
+	return cliTest{
+		TestServer: s.(*server.TestServer),
+		connArgs:   []string{"--insecure", "--host=" + host, "--port=" + port},
+	}
+}
+
+func (c *cliTest) close() {
+	c.Stopper().Stop(context.Background())
+}
+
+func (c *cliTest) run(line string) {
+	c.runWithArgs(strings.Fields(line))
+}
+
+func (c *cliTest) runWithArgs(args []string) {
+	fmt.Println(strings.Join(args, " "))
+	cli.TestingReset()
+	if err := cli.Run(append(args, c.connArgs...)); err != nil {
+		fmt.Println(err)
+	}
+}
+
+func Example_cclzone() {
+	c := newCLITest()
+	defer c.close()
+
+	c.runWithArgs([]string{"sql", "-e", "CREATE DATABASE db"})
+	c.runWithArgs([]string{"sql", "-e", `CREATE TABLE db.t (
+  c1 STRING PRIMARY KEY,
+  c2 STRING
+) PARTITION BY LIST (c1) (
+  PARTITION p0 VALUES ('a'),
+  PARTITION p1 VALUES (DEFAULT)
+)`})
+	c.runWithArgs([]string{"sql", "-e", "CREATE INDEX ON db.t (c2)"})
+	c.run("zone set db.t@nonexistent --file=./../../cli/testdata/zone_attrs.yaml")
+	c.run("zone set db.t.nonexistent --file=./../../cli/testdata/zone_attrs.yaml")
+	c.run("zone set db.t.p0@t_c2_idx --file=./../../cli/testdata/zone_attrs.yaml")
+	c.run("zone set db.t@primary --file=./../../cli/testdata/zone_attrs.yaml")
+	c.run("zone get db.t.p0")
+	c.run("zone get db.t")
+	c.run("zone get db.t@t_c2_idx")
+	c.run("zone set db.t.p1 --file=./../../cli/testdata/zone_range_max_bytes.yaml")
+	c.run("zone get db.t.p1")
+	c.run("zone get db.t.p0")
+	c.run("zone ls")
+	c.run("zone rm db.t@primary")
+	c.run("zone get db.t.p0")
+	c.run("zone get db.t.p1")
+	c.run("zone ls")
+	c.run("zone rm db.t.p0")
+	c.run("zone rm db.t.p1")
+	c.run("zone ls")
+
+	// Output:
+	// sql -e CREATE DATABASE db
+	// CREATE DATABASE
+	// sql -e CREATE TABLE db.t (
+	//   c1 STRING PRIMARY KEY,
+	//   c2 STRING
+	// ) PARTITION BY LIST (c1) (
+	//   PARTITION p0 VALUES ('a'),
+	//   PARTITION p1 VALUES (DEFAULT)
+	// )
+	// CREATE TABLE
+	// sql -e CREATE INDEX ON db.t (c2)
+	// CREATE INDEX
+	// zone set db.t@nonexistent --file=./../../cli/testdata/zone_attrs.yaml
+	// pq: index "nonexistent" does not exist
+	// zone set db.t.nonexistent --file=./../../cli/testdata/zone_attrs.yaml
+	// pq: partition "nonexistent" does not exist
+	// zone set db.t.p0@t_c2_idx --file=./../../cli/testdata/zone_attrs.yaml
+	// index and partition cannot be specified simultaneously: "db.t.p0@t_c2_idx"
+	// zone set db.t@primary --file=./../../cli/testdata/zone_attrs.yaml
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 1
+	// constraints: [us-east-1a, ssd]
+	// zone get db.t.p0
+	// db.t@primary
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 1
+	// constraints: [us-east-1a, ssd]
+	// zone get db.t
+	// .default
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 1
+	// constraints: []
+	// zone get db.t@t_c2_idx
+	// .default
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 1
+	// constraints: []
+	// zone set db.t.p1 --file=./../../cli/testdata/zone_range_max_bytes.yaml
+	// range_min_bytes: 1048576
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 3
+	// constraints: [us-east-1a, ssd]
+	// zone get db.t.p1
+	// db.t.p1
+	// range_min_bytes: 1048576
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 3
+	// constraints: [us-east-1a, ssd]
+	// zone get db.t.p0
+	// db.t@primary
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 1
+	// constraints: [us-east-1a, ssd]
+	// zone ls
+	// .default
+	// db.t.p1
+	// db.t@primary
+	// zone rm db.t@primary
+	// CONFIGURE ZONE 1
+	// zone get db.t.p0
+	// .default
+	// range_min_bytes: 1048576
+	// range_max_bytes: 67108864
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 1
+	// constraints: []
+	// zone get db.t.p1
+	// db.t.p1
+	// range_min_bytes: 1048576
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 3
+	// constraints: [us-east-1a, ssd]
+	// zone ls
+	// .default
+	// db.t.p1
+	// zone rm db.t.p0
+	// CONFIGURE ZONE 0
+	// zone rm db.t.p1
+	// CONFIGURE ZONE 1
+	// zone ls
+	// .default
+}

--- a/pkg/ccl/cliccl/main_test.go
+++ b/pkg/ccl/cliccl/main_test.go
@@ -1,0 +1,30 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cliccl_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+)
+
+func TestMain(m *testing.M) {
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -82,12 +82,6 @@ func newCLITest(params cliTestParams) cliTest {
 	}
 	c.certsDir = certsDir
 
-	// Reset the client context for each test. We don't reset the
-	// pointer (because they are tied into the flags), but instead
-	// overwrite the existing struct's values.
-	baseCfg.InitDefaults()
-	InitCLIDefaults()
-
 	if c.t != nil {
 		c.logScope = log.Scope(c.t)
 	}
@@ -261,9 +255,7 @@ func captureOutput(f func()) (out string, err error) {
 }
 
 func (c cliTest) RunWithArgs(origArgs []string) {
-	sqlCtx.execStmts = nil
-	zoneCtx.zoneConfig = ""
-	zoneCtx.zoneDisableReplication = false
+	TestingReset()
 
 	if err := func() error {
 		args := append([]string(nil), origArgs[:1]...)
@@ -293,9 +285,7 @@ func (c cliTest) RunWithArgs(origArgs []string) {
 }
 
 func (c cliTest) RunWithCAArgs(origArgs []string) {
-	sqlCtx.execStmts = nil
-	zoneCtx.zoneConfig = ""
-	zoneCtx.zoneDisableReplication = false
+	TestingReset()
 
 	if err := func() error {
 		args := append([]string(nil), origArgs[:1]...)
@@ -528,6 +518,7 @@ func Example_zone() {
 	c.Run("zone rm .meta")
 	c.Run("zone rm .system")
 	c.Run("zone rm .timeseries")
+	c.Run("zone set system.jobs@primary --file=./testdata/zone_attrs.yaml")
 
 	// Output:
 	// zone ls
@@ -668,6 +659,8 @@ func Example_zone() {
 	// CONFIGURE ZONE 0
 	// zone rm .timeseries
 	// CONFIGURE ZONE 0
+	// zone set system.jobs@primary --file=./testdata/zone_attrs.yaml
+	// pq: setting zone configs on indexes or partitions requires a CCL binary
 }
 
 func Example_sql() {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -43,15 +43,6 @@ var clientConnHost, clientConnPort string
 var tempDir string
 var externalIODir string
 
-// InitCLIDefaults is used for testing.
-func InitCLIDefaults() {
-	cliCtx.tableDisplayFormat = tableDisplayTSV
-	cliCtx.showTimes = false
-	dumpCtx.dumpMode = dumpBoth
-	dumpCtx.asOf = ""
-	sqlCtx.echo = false
-}
-
 const usageIndentation = 8
 const wrapWidth = 79 - usageIndentation
 

--- a/pkg/cli/testutils.go
+++ b/pkg/cli/testutils.go
@@ -1,0 +1,32 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cli
+
+// TestingReset resets global mutable state so that Run can be called multiple
+// times from the same test process. It is public for cliccl.
+func TestingReset() {
+	// Reset the client context for each test. We don't reset the
+	// pointers (because they are tied into the flags), but instead
+	// overwrite the existing structs' values.
+	baseCfg.InitDefaults()
+	cliCtx.tableDisplayFormat = tableDisplayTSV
+	cliCtx.showTimes = false
+	dumpCtx.dumpMode = dumpBoth
+	dumpCtx.asOf = ""
+	sqlCtx.echo = false
+	sqlCtx.execStmts = nil
+	zoneCtx.zoneConfig = ""
+	zoneCtx.zoneDisableReplication = false
+}

--- a/scripts/diff-example.sh
+++ b/scripts/diff-example.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Diff a failed Go example [0] against its expected output.
+#
+# By default, when an example fails, Go prints "got:", followed by the
+# actual output, then prints "want:", followed by the expected output. When the
+# output grows beyond several lines, as it often does, it's virtually impossible
+# to visually parse where the output differs, especially when whitespace is
+# involved. This script parses the output and prints it as a unified diff to
+# make the difference obvious.
+#
+# If this script produces no output, it means the actual and expected output
+# matched.
+#
+# Sample usage:
+#
+#     $ make test PKG=./pkg/cli TESTS=Example_zone | scripts/diff-example.sh
+#
+# [0]: https://golang.org/pkg/testing/#hdr-Examples
+
+set -euo pipefail
+
+do_diff() {
+  if [ -x "$(command -v colordiff)" ]; then
+    colordiff "$@"
+  else
+    diff "$@"
+  fi
+}
+
+cd $(mktemp -d)
+trap 'rm -rf $PWD' EXIT
+
+cat >in
+
+# The actual output is everything after "got:" but before "want:".
+<in sed -n  "
+ /^got:$/,/^want:$/{
+   //d
+   p
+}" >got
+
+# The desired output is everything after "want:", excluding the status about
+# whether the test passed or failed.
+<in sed "1,/^want:$/d" | grep -Ev "^(PASS|FAIL)" >want
+
+do_diff -u want got


### PR DESCRIPTION
The underlying support for index/partition zone configs landed in #19854.
This commit merely adds tests that setting these zone configs from the
CLI works as expected.