### PR TITLE
sql,sql/parser: update partitioning syntax per RFC

### DIFF
--- a/pkg/ccl/sqlccl/zone_test.go
+++ b/pkg/ccl/sqlccl/zone_test.go
@@ -40,8 +40,8 @@ func TestValidIndexPartitionSetShowZones(t *testing.T) {
 		CREATE DATABASE d;
 		USE d;
 		CREATE TABLE t (c STRING PRIMARY KEY) PARTITION BY LIST (c) (
-			PARTITION p0 VALUES ('a'),
-			PARTITION p1 VALUES (DEFAULT)
+			PARTITION p0 VALUES IN ('a'),
+			PARTITION p1 VALUES IN (DEFAULT)
 		)`)
 
 	yamlDefault := fmt.Sprintf("gc: {ttlseconds: %d}", config.DefaultZoneConfig().GC.TTLSeconds)
@@ -280,8 +280,8 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `single col list partitioning`,
 			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY LIST (a) (
-				PARTITION p3 VALUES (3),
-				PARTITION p4 VALUES (4)
+				PARTITION p3 VALUES IN (3),
+				PARTITION p4 VALUES IN (4)
 			)`,
 			subzones: []string{`@primary`, `.p3`, `.p4`},
 			expected: []string{
@@ -294,9 +294,9 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `single col list partitioning - DEFAULT`,
 			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY LIST (a) (
-				PARTITION p3 VALUES (3),
-				PARTITION p4 VALUES (4),
-				PARTITION pd VALUES (DEFAULT)
+				PARTITION p3 VALUES IN (3),
+				PARTITION p4 VALUES IN (4),
+				PARTITION pd VALUES IN (DEFAULT)
 			)`,
 			subzones: []string{`@primary`, `.p3`, `.p4`, `.pd`},
 			expected: []string{
@@ -309,9 +309,9 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `multi col list partitioning`,
 			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
-				PARTITION p34 VALUES (3, 4),
-				PARTITION p56 VALUES (5, 6),
-				PARTITION p57 VALUES (5, 7)
+				PARTITION p34 VALUES IN ((3, 4)),
+				PARTITION p56 VALUES IN ((5, 6)),
+				PARTITION p57 VALUES IN ((5, 7))
 			)`,
 			subzones: []string{`@primary`, `.p34`, `.p56`, `.p57`},
 			expected: []string{
@@ -326,11 +326,11 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `multi col list partitioning - DEFAULT`,
 			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
-				PARTITION p34 VALUES (3, 4),
-				PARTITION p56 VALUES (5, 6),
-				PARTITION p57 VALUES (5, 7),
-				PARTITION p5d VALUES (5, DEFAULT),
-				PARTITION pd VALUES (DEFAULT, DEFAULT)
+				PARTITION p34 VALUES IN ((3, 4)),
+				PARTITION p56 VALUES IN ((5, 6)),
+				PARTITION p57 VALUES IN ((5, 7)),
+				PARTITION p5d VALUES IN ((5, DEFAULT)),
+				PARTITION pd VALUES IN ((DEFAULT, DEFAULT))
 			)`,
 			subzones: []string{`@primary`, `.p34`, `.p56`, `.p57`, `.p5d`, `.pd`},
 			expected: []string{
@@ -348,8 +348,8 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `single col range partitioning`,
 			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY RANGE (a) (
-				PARTITION p3 VALUES LESS THAN (3),
-				PARTITION p4 VALUES LESS THAN (4)
+				PARTITION p3 VALUES < 3,
+				PARTITION p4 VALUES < 4
 			)`,
 			subzones: []string{`@primary`, `.p3`, `.p4`},
 			expected: []string{
@@ -361,9 +361,9 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `single col range partitioning - MAXVALUE`,
 			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY RANGE (a) (
-				PARTITION p3 VALUES LESS THAN (3),
-				PARTITION p4 VALUES LESS THAN (4),
-				PARTITION pm VALUES LESS THAN (MAXVALUE)
+				PARTITION p3 VALUES < 3,
+				PARTITION p4 VALUES < 4,
+				PARTITION pm VALUES < MAXVALUE
 			)`,
 			subzones: []string{`@primary`, `.p3`, `.p4`, `.pm`},
 			expected: []string{
@@ -375,9 +375,9 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `multi col range partitioning`,
 			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
-				PARTITION p34 VALUES LESS THAN (3, 4),
-				PARTITION p56 VALUES LESS THAN (5, 6),
-				PARTITION p57 VALUES LESS THAN (5, 7)
+				PARTITION p34 VALUES < (3, 4),
+				PARTITION p56 VALUES < (5, 6),
+				PARTITION p57 VALUES < (5, 7)
 			)`,
 			subzones: []string{`@primary`, `.p34`, `.p56`, `.p57`},
 			expected: []string{
@@ -390,11 +390,11 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `multi col range partitioning - MAXVALUE`,
 			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
-				PARTITION p34 VALUES LESS THAN (3, 4),
-				PARTITION p3m VALUES LESS THAN (3, MAXVALUE),
-				PARTITION p56 VALUES LESS THAN (5, 6),
-				PARTITION p57 VALUES LESS THAN (5, 7),
-				PARTITION pm VALUES LESS THAN (MAXVALUE, MAXVALUE)
+				PARTITION p34 VALUES < (3, 4),
+				PARTITION p3m VALUES < (3, MAXVALUE),
+				PARTITION p56 VALUES < (5, 6),
+				PARTITION p57 VALUES < (5, 7),
+				PARTITION pm VALUES < (MAXVALUE, MAXVALUE)
 			)`,
 			subzones: []string{`@primary`, `.p34`, `.p3m`, `.p56`, `.p57`, `.pm`},
 			expected: []string{
@@ -409,14 +409,14 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `list-list partitioning`,
 			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-				PARTITION p3 VALUES (3) PARTITION BY LIST (b) (
-					PARTITION p34 VALUES (4)
+				PARTITION p3 VALUES IN (3) PARTITION BY LIST (b) (
+					PARTITION p34 VALUES IN (4)
 				),
-				PARTITION p5 VALUES (5) PARTITION BY LIST (b) (
-					PARTITION p56 VALUES (6),
-					PARTITION p5d VALUES (DEFAULT)
+				PARTITION p5 VALUES IN (5) PARTITION BY LIST (b) (
+					PARTITION p56 VALUES IN (6),
+					PARTITION p5d VALUES IN (DEFAULT)
 				),
-				PARTITION pd VALUES (DEFAULT)
+				PARTITION pd VALUES IN (DEFAULT)
 			)`,
 			subzones: []string{`@primary`, `.p3`, `.p34`, `.p5`, `.p56`, `.p5d`, `.pd`},
 			expected: []string{
@@ -434,14 +434,14 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `list-range partitioning`,
 			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-				PARTITION p3 VALUES (3) PARTITION BY RANGE (b) (
-					PARTITION p34 VALUES LESS THAN (4)
+				PARTITION p3 VALUES IN (3) PARTITION BY RANGE (b) (
+					PARTITION p34 VALUES < 4
 				),
-				PARTITION p5 VALUES (5) PARTITION BY RANGE (b) (
-					PARTITION p56 VALUES LESS THAN (6),
-					PARTITION p5d VALUES LESS THAN (MAXVALUE)
+				PARTITION p5 VALUES IN (5) PARTITION BY RANGE (b) (
+					PARTITION p56 VALUES < 6,
+					PARTITION p5d VALUES < MAXVALUE
 				),
-				PARTITION pd VALUES (DEFAULT)
+				PARTITION pd VALUES IN (DEFAULT)
 			)`,
 			subzones: []string{`@primary`, `.p3`, `.p34`, `.p5`, `.p56`, `.p5d`, `.pd`},
 			expected: []string{
@@ -458,7 +458,7 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `inheritance - index`,
 			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY LIST (a) (
-				PARTITION pd VALUES (DEFAULT)
+				PARTITION pd VALUES IN (DEFAULT)
 			)`,
 			subzones: []string{`@primary`},
 			expected: []string{`@primary /1-/2`},
@@ -466,8 +466,8 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `inheritance - single col default`,
 			schema: `CREATE TABLE t (a INT PRIMARY KEY) PARTITION BY LIST (a) (
-				PARTITION p3 VALUES (3),
-				PARTITION pd VALUES (DEFAULT)
+				PARTITION p3 VALUES IN (3),
+				PARTITION pd VALUES IN (DEFAULT)
 			)`,
 			subzones: []string{`@primary`, `.pd`},
 			expected: []string{`.pd /1-/2`},
@@ -475,10 +475,10 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `inheritance - multi col default`,
 			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
-				PARTITION p34 VALUES (3, 4),
-				PARTITION p3d VALUES (3, DEFAULT),
-				PARTITION p56 VALUES (5, 6),
-				PARTITION p5d VALUES (5, DEFAULT)
+				PARTITION p34 VALUES IN ((3, 4)),
+				PARTITION p3d VALUES IN ((3, DEFAULT)),
+				PARTITION p56 VALUES IN ((5, 6)),
+				PARTITION p5d VALUES IN ((5, DEFAULT))
 			)`,
 			subzones: []string{`@primary`, `.p3d`, `.p56`},
 			expected: []string{
@@ -492,17 +492,17 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 		{
 			name: `inheritance - subpartitioning`,
 			schema: `CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-				PARTITION p3 VALUES (3) PARTITION BY LIST (b) (
-					PARTITION p34 VALUES (4),
-					PARTITION p3d VALUES (DEFAULT)
+				PARTITION p3 VALUES IN (3) PARTITION BY LIST (b) (
+					PARTITION p34 VALUES IN (4),
+					PARTITION p3d VALUES IN (DEFAULT)
 				),
-				PARTITION p5 VALUES (5) PARTITION BY LIST (b) (
-					PARTITION p56 VALUES (6),
-					PARTITION p5d VALUES (DEFAULT)
+				PARTITION p5 VALUES IN (5) PARTITION BY LIST (b) (
+					PARTITION p56 VALUES IN (6),
+					PARTITION p5d VALUES IN (DEFAULT)
 				),
-				PARTITION p7 VALUES (7) PARTITION BY LIST (b) (
-					PARTITION p78 VALUES (8),
-					PARTITION p7d VALUES (DEFAULT)
+				PARTITION p7 VALUES IN (7) PARTITION BY LIST (b) (
+					PARTITION p78 VALUES IN (8),
+					PARTITION p7d VALUES IN (DEFAULT)
 				)
 			)`,
 			subzones: []string{`@primary`, `.p3d`, `.p56`, `.p7`},

--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -8,73 +8,73 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
 
 statement error syntax
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES ()
+    PARTITION p1 VALUES IN ()
 )
 
 # NB: This table gets the automatic, hidden unique_rowid PK, so `a` is not a prefix.
 statement error declared partition columns must match index being partitioned
 CREATE TABLE t (a INT, b INT, c INT) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (0)
+    PARTITION p1 VALUES IN (0)
 )
 
 statement error declared partition columns must match index being partitioned
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b, c) (
-    PARTITION p1 VALUES (0)
+    PARTITION p1 VALUES IN (0)
 )
 
 statement error declared partition columns must match index being partitioned
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (b) (
-    PARTITION p1 VALUES (0)
+    PARTITION p1 VALUES IN (0)
 )
 
 statement error declared partition columns must match index being partitioned
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (c) (
-    PARTITION p1 VALUES (0)
+    PARTITION p1 VALUES IN (0)
 )
 
 statement error declared partition columns must match index being partitioned
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (0) PARTITION BY LIST (a) (
-        PARTITION p1_1 VALUES (0)
+    PARTITION p1 VALUES IN (0) PARTITION BY LIST (a) (
+        PARTITION p1_1 VALUES IN (0)
     )
 )
 
 statement error declared partition columns must match index being partitioned
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (0) PARTITION BY LIST (c) (
-        PARTITION p1_1 VALUES (0)
+    PARTITION p1 VALUES IN (0) PARTITION BY LIST (c) (
+        PARTITION p1_1 VALUES IN (0)
     )
 )
 
 statement error PARTITION p1: name must be unique
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (1),
-    PARTITION p1 VALUES (2)
+    PARTITION p1 VALUES IN (1),
+    PARTITION p1 VALUES IN (2)
 )
 
 statement error PARTITION p1: name must be unique
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (1),
-    PARTITION P1 VALUES (2)
+    PARTITION p1 VALUES IN (1),
+    PARTITION P1 VALUES IN (2)
 )
 
 statement error PARTITION p1: name must be unique
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (1) PARTITION BY LIST (b) (
-        PARTITION p1 VALUES (2)
+    PARTITION p1 VALUES IN (1) PARTITION BY LIST (b) (
+        PARTITION p1 VALUES IN (2)
     )
 )
 
 statement error PARTITION p1: cannot subpartition a range partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN (1) PARTITION BY LIST (b) (
-        PARTITION p2 VALUES (2)
+    PARTITION p1 VALUES < 1 PARTITION BY LIST (b) (
+        PARTITION p2 VALUES IN (2)
     )
 )
 
 statement ok
 CREATE TABLE interleave_root (a INT PRIMARY KEY) PARTITION BY LIST (a) (
-    PARTITION p0 VALUES (0)
+    PARTITION p0 VALUES IN (0)
 )
 
 statement ok
@@ -82,211 +82,245 @@ CREATE TABLE interleave_child (a INT PRIMARY KEY) INTERLEAVE IN PARENT interleav
 
 statement error cannot set a zone config for interleaved index primary; set it on the root of the interleaved hierarchy instead
 CREATE TABLE t (a INT PRIMARY KEY) INTERLEAVE IN PARENT interleave_root (a) PARTITION BY LIST (a) (
-    PARTITION p0 VALUES (0)
+    PARTITION p0 VALUES IN (0)
 )
 
 statement error PARTITION p1: partition has 1 columns but 2 values were supplied
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (0, 1)
+    PARTITION p1 VALUES IN ((0, 1))
 )
 
 statement error PARTITION p1: partition has 2 columns but 1 values were supplied
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
-    PARTITION p1 VALUES (0)
+    PARTITION p1 VALUES IN (0)
 )
 
 statement error \(1\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (1),
-    PARTITION p2 VALUES (1)
+    PARTITION p1 VALUES IN (1),
+    PARTITION p2 VALUES IN (1)
 )
 
 statement error prefix \(DEFAULT\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (DEFAULT),
-    PARTITION p2 VALUES (DEFAULT)
+    PARTITION p1 VALUES IN (DEFAULT),
+    PARTITION p2 VALUES IN (DEFAULT)
 )
 
 statement error prefix \(1, 2, DEFAULT\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a, b, c) (
-    PARTITION p1 VALUES (1, 2, DEFAULT),
-    PARTITION p2 VALUES (1, 2, DEFAULT)
+    PARTITION p1 VALUES IN ((1, 2, DEFAULT)),
+    PARTITION p2 VALUES IN ((1, 2, DEFAULT))
 )
 
 statement error prefix \(1, DEFAULT\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a, b, c) (
-    PARTITION p1 VALUES (1, DEFAULT, DEFAULT),
-    PARTITION p2 VALUES (1, DEFAULT, DEFAULT)
+    PARTITION p1 VALUES IN ((1, DEFAULT, DEFAULT)),
+    PARTITION p2 VALUES IN ((1, DEFAULT, DEFAULT))
 )
 
 statement error \(1.000\) cannot be present in more than one partition
 CREATE TABLE t (a DECIMAL PRIMARY KEY) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (1.0:::decimal),
-    PARTITION p2 VALUES (1.000:::decimal)
+    PARTITION p1 VALUES IN (1.0:::decimal),
+    PARTITION p2 VALUES IN (1.000:::decimal)
 )
 
 statement error PARTITION p1: non-DEFAULT value \(1\) not allowed after DEFAULT
 CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
-    PARTITION p1 VALUES (DEFAULT, 1)
+    PARTITION p1 VALUES IN ((DEFAULT, 1))
 )
 
 statement error values must be strictly increasing
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN (2),
-    PARTITION p2 VALUES LESS THAN (1)
+    PARTITION p1 VALUES < 2,
+    PARTITION p2 VALUES < 1
 )
 
 statement error values must be strictly increasing
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN (MAXVALUE),
-    PARTITION p2 VALUES LESS THAN (1)
+    PARTITION p1 VALUES < MAXVALUE,
+    PARTITION p2 VALUES < 1
 )
 
 statement error \(1\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN (1),
-    PARTITION p2 VALUES LESS THAN (1)
+    PARTITION p1 VALUES < 1,
+    PARTITION p2 VALUES < 1
 )
 
 statement error prefix \(1, 2, MAXVALUE\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY RANGE (a, b, c) (
-    PARTITION p1 VALUES LESS THAN (1, 2, MAXVALUE),
-    PARTITION p2 VALUES LESS THAN (1, 2, MAXVALUE)
+    PARTITION p1 VALUES < (1, 2, MAXVALUE),
+    PARTITION p2 VALUES < (1, 2, MAXVALUE)
 )
 
 statement error prefix \(1, MAXVALUE\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY RANGE (a, b, c) (
-    PARTITION p1 VALUES LESS THAN (1, MAXVALUE, MAXVALUE),
-    PARTITION p2 VALUES LESS THAN (1, MAXVALUE, MAXVALUE)
+    PARTITION p1 VALUES < (1, MAXVALUE, MAXVALUE),
+    PARTITION p2 VALUES < (1, MAXVALUE, MAXVALUE)
 )
 
 statement error \(1.000\) cannot be present in more than one partition
 CREATE TABLE t (a DECIMAL PRIMARY KEY) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN (1.0:::decimal),
-    PARTITION p2 VALUES LESS THAN (1.000:::decimal)
+    PARTITION p1 VALUES < 1.0:::decimal,
+    PARTITION p2 VALUES < 1.000:::decimal
 )
 
 statement error PARTITION p1: non-MAXVALUE value \(1\) not allowed after MAXVALUE
 CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
-    PARTITION p1 VALUES LESS THAN (MAXVALUE, 1)
+    PARTITION p1 VALUES < (MAXVALUE, 1)
 )
 
 statement error values must be strictly increasing
 CREATE TABLE t (a STRING COLLATE da PRIMARY KEY) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN ('ü' COLLATE da),
-    PARTITION p2 VALUES LESS THAN ('x' COLLATE da)
+    PARTITION p1 VALUES < ('ü' COLLATE da),
+    PARTITION p2 VALUES < ('x' COLLATE da)
 )
 
 statement ok
 CREATE TABLE collate_da (a STRING COLLATE da PRIMARY KEY) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN ('x' COLLATE da),
-    PARTITION p2 VALUES LESS THAN ('ü' COLLATE da)
+    PARTITION p1 VALUES < ('x' COLLATE da),
+    PARTITION p2 VALUES < ('ü' COLLATE da)
 )
 
 statement error values must be strictly increasing
 CREATE TABLE t (a STRING COLLATE de PRIMARY KEY) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN ('x' COLLATE de),
-    PARTITION p2 VALUES LESS THAN ('ü' COLLATE de)
+    PARTITION p1 VALUES < ('x' COLLATE de),
+    PARTITION p2 VALUES < ('ü' COLLATE de)
 )
 
 statement ok
 CREATE TABLE collate_de (a STRING COLLATE de PRIMARY KEY) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN ('ü' COLLATE de),
-    PARTITION p2 VALUES LESS THAN ('x' COLLATE de)
+    PARTITION p1 VALUES < ('ü' COLLATE de),
+    PARTITION p2 VALUES < ('x' COLLATE de)
 )
 
 statement error value type decimal doesn't match type INT of column "a"
 CREATE TABLE foo (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (1.2)
+    PARTITION p1 VALUES IN (1.2)
 )
 
 statement error value type decimal doesn't match type INT of column "b"
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (0) PARTITION BY LIST (b) (
-        PARTITION p1_1 VALUES (1.2)
+    PARTITION p1 VALUES IN (0) PARTITION BY LIST (b) (
+        PARTITION p1_1 VALUES IN (1.2)
     )
 )
 
 statement error PARTITION p1: MAXVALUE cannot be used with PARTITION BY LIST
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (MAXVALUE)
+    PARTITION p1 VALUES IN (MAXVALUE)
+)
+
+statement error PARTITION p1: MAXVALUE cannot be used with PARTITION BY LIST
+CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN (((MAXVALUE)))
 )
 
 statement error PARTITION p1: DEFAULT cannot be used with PARTITION BY RANGE
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN (DEFAULT)
+    PARTITION p1 VALUES < DEFAULT
+)
+
+statement error PARTITION p1: DEFAULT cannot be used with PARTITION BY RANGE
+CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
+    PARTITION p1 VALUES < (DEFAULT)
+)
+
+statement error PARTITION p1: DEFAULT cannot be used with PARTITION BY RANGE
+CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
+    PARTITION p1 VALUES < (((DEFAULT)))
 )
 
 statement error unimplemented: placeholders are not supported in PARTITION BY
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES ($1)
+    PARTITION p1 VALUES IN ($1)
 )
 
 statement ok
 CREATE TABLE ok1 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (1),
-    PARTITION p2 VALUES (2)
+    PARTITION p1 VALUES IN (1),
+    PARTITION p2 VALUES IN (2)
 )
 
 statement ok
 CREATE TABLE ok2 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (1),
-    PARTITION p2 VALUES (DEFAULT)
+    PARTITION p1 VALUES IN ((1)),
+    PARTITION p2 VALUES IN (((2)))
 )
 
 statement ok
-CREATE TABLE ok3 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
-    PARTITION p1 VALUES (1, 1),
-    PARTITION p2 VALUES (1, DEFAULT),
-    PARTITION p3 VALUES (2, 3),
-    PARTITION p4 VALUES (DEFAULT, DEFAULT)
+CREATE TABLE ok3 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN (1),
+    PARTITION p2 VALUES IN (DEFAULT)
 )
 
 statement ok
-CREATE TABLE ok4 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (1) PARTITION BY LIST (b) (
-        PARTITION p1_1 VALUES (1),
-        PARTITION p1_2 VALUES (DEFAULT)
+CREATE TABLE ok4 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
+    PARTITION p1 VALUES IN ((1, 1)),
+    PARTITION p2 VALUES IN ((1, DEFAULT)),
+    PARTITION p3 VALUES IN ((2, 3)),
+    PARTITION p4 VALUES IN ((DEFAULT, DEFAULT))
+)
+
+statement ok
+CREATE TABLE ok5 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN (1) PARTITION BY LIST (b) (
+        PARTITION p1_1 VALUES IN (1),
+        PARTITION p1_2 VALUES IN (DEFAULT)
     ),
-    PARTITION p2 VALUES (2) PARTITION BY LIST (b) (
-        PARTITION p2_1 VALUES (3)
+    PARTITION p2 VALUES IN (2) PARTITION BY LIST (b) (
+        PARTITION p2_1 VALUES IN (3)
     ),
-    PARTITION p3 VALUES (DEFAULT)
-)
-
-statement ok
-CREATE TABLE ok5 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN (1),
-    PARTITION p2 VALUES LESS THAN (2)
+    PARTITION p3 VALUES IN (DEFAULT)
 )
 
 statement ok
 CREATE TABLE ok6 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
-    PARTITION p1 VALUES LESS THAN (1),
-    PARTITION p2 VALUES LESS THAN (2),
-    PARTITION p3 VALUES LESS THAN (MAXVALUE)
+    PARTITION p1 VALUES < 1,
+    PARTITION p2 VALUES < 2
 )
 
 statement ok
-CREATE TABLE ok7 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
-    PARTITION p1 VALUES LESS THAN (1, 1),
-    PARTITION p2 VALUES LESS THAN (1, MAXVALUE),
-    PARTITION p3 VALUES LESS THAN (2, MAXVALUE),
-    PARTITION p4 VALUES LESS THAN (3, 4),
-    PARTITION p5 VALUES LESS THAN (MAXVALUE, MAXVALUE)
+CREATE TABLE ok7 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
+    PARTITION p1 VALUES < ((1)),
+    PARTITION p2 VALUES < (((2)))
 )
 
 statement ok
-CREATE TABLE ok9 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES (1) PARTITION BY LIST (b) (
-        PARTITION p1_1 VALUES (3) PARTITION BY LIST (c) (
-            PARTITION p1_1_1 VALUES (8)
+CREATE TABLE ok8 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
+    PARTITION p1 VALUES < 1,
+    PARTITION p2 VALUES < 2,
+    PARTITION p3 VALUES < MAXVALUE
+)
+
+statement ok
+CREATE TABLE ok9 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
+    PARTITION p1 VALUES < (1),
+    PARTITION p2 VALUES < (2),
+    PARTITION p3 VALUES < (MAXVALUE)
+)
+
+statement ok
+CREATE TABLE ok10 (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a, b) (
+    PARTITION p1 VALUES < (1, 1),
+    PARTITION p2 VALUES < (1, MAXVALUE),
+    PARTITION p3 VALUES < (2, MAXVALUE),
+    PARTITION p4 VALUES < (3, 4),
+    PARTITION p5 VALUES < (MAXVALUE, MAXVALUE)
+)
+
+statement ok
+CREATE TABLE ok11 (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN (1) PARTITION BY LIST (b) (
+        PARTITION p1_1 VALUES IN (3) PARTITION BY LIST (c) (
+            PARTITION p1_1_1 VALUES IN (8)
         ),
-        PARTITION p1_2 VALUES (4)
+        PARTITION p1_2 VALUES IN (4)
     ),
-    PARTITION p2 VALUES (6) PARTITION BY RANGE (b) (
-        PARTITION p2_1 VALUES LESS THAN (7),
-        PARTITION p2_2 VALUES LESS THAN (MAXVALUE)
+    PARTITION p2 VALUES IN (6) PARTITION BY RANGE (b) (
+        PARTITION p2_1 VALUES < 7,
+        PARTITION p2_2 VALUES < MAXVALUE
     )
 )
 

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -3378,16 +3378,6 @@ func (t *Placeholder) Eval(ctx *EvalContext) (Datum, error) {
 	return e.Eval(ctx)
 }
 
-// Eval implements the TypedExpr interface.
-func (expr PartitionDefault) Eval(ctx *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
-}
-
-// Eval implements the TypedExpr interface.
-func (expr PartitionMaxValue) Eval(ctx *EvalContext) (Datum, error) {
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
-}
-
 func evalComparison(ctx *EvalContext, op ComparisonOperator, left, right Datum) (Datum, error) {
 	if left == DNull || right == DNull {
 		return DNull, nil

--- a/pkg/sql/parser/expr.go
+++ b/pkg/sql/parser/expr.go
@@ -628,6 +628,14 @@ func (node DefaultVal) Format(buf *bytes.Buffer, f FmtFlags) {
 // ResolvedType implements the TypedExpr interface.
 func (DefaultVal) ResolvedType() types.T { return nil }
 
+// MaxVal represents the MAXVALUE expression.
+type MaxVal struct{}
+
+// Format implements the NodeFormatter interface.
+func (node MaxVal) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("MAXVALUE")
+}
+
 // Placeholder represents a named placeholder.
 type Placeholder struct {
 	Name string
@@ -1299,8 +1307,7 @@ func (node *Tuple) String() string            { return AsString(node) }
 func (node *AnnotateTypeExpr) String() string { return AsString(node) }
 func (node *UnaryExpr) String() string        { return AsString(node) }
 func (node DefaultVal) String() string        { return AsString(node) }
+func (node MaxVal) String() string            { return AsString(node) }
 func (node *Placeholder) String() string      { return AsString(node) }
 func (node dNull) String() string             { return AsString(node) }
 func (list NameList) String() string          { return AsString(list) }
-func (node PartitionDefault) String() string  { return AsString(node) }
-func (node PartitionMaxValue) String() string { return AsString(node) }

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -176,18 +176,18 @@ func TestParse(t *testing.T) {
 		{`CREATE TABLE a.b (b INT)`},
 		{`CREATE TABLE IF NOT EXISTS a (b INT)`},
 
-		{`CREATE TABLE a (b INT) PARTITION BY LIST (b) (PARTITION p1 VALUES (1, DEFAULT), PARTITION p2 VALUES (2), (3))`},
-		{`CREATE TABLE a (b INT) PARTITION BY RANGE (b) (PARTITION p1 VALUES LESS THAN (1), PARTITION p2 VALUES LESS THAN (2, 3), PARTITION p3 VALUES LESS THAN (MAXVALUE))`},
-		// This montrosity was added on the assumption that it's more readable
+		{`CREATE TABLE a (b INT) PARTITION BY LIST (b) (PARTITION p1 VALUES IN (1, DEFAULT), PARTITION p2 VALUES IN ((1, 2), (3, 4)))`},
+		{`CREATE TABLE a (b INT) PARTITION BY RANGE (b) (PARTITION p1 VALUES < 1, PARTITION p2 VALUES < (2, MAXVALUE), PARTITION p3 VALUES < MAXVALUE)`},
+		// This monstrosity was added on the assumption that it's more readable
 		// than all on one line. Feel free to rip it out if you come across it
 		// and disagree.
 		{regexp.MustCompile(`\n\s*`).ReplaceAllLiteralString(
 			`CREATE TABLE a (b INT, c INT, d INT) PARTITION BY LIST (b) (
-				PARTITION p1 VALUES (1) PARTITION BY LIST (c) (
-					PARTITION p1_1 VALUES (3), PARTITION p1_2 VALUES (4, 5)
-				), PARTITION p2 VALUES (6) PARTITION BY RANGE (c) (
-					PARTITION p2_1 VALUES LESS THAN (7) PARTITION BY LIST (d) (
-						PARTITION p2_1_1 VALUES (8)
+				PARTITION p1 VALUES IN (1) PARTITION BY LIST (c) (
+					PARTITION p1_1 VALUES IN (3), PARTITION p1_2 VALUES IN (4, 5)
+				), PARTITION p2 VALUES IN (6) PARTITION BY RANGE (c) (
+					PARTITION p2_1 VALUES < 7 PARTITION BY LIST (d) (
+						PARTITION p2_1_1 VALUES IN (8)
 					)
 				)
 			)`, ``),

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -331,8 +331,14 @@ func (u *sqlSymUnion) interleave() *InterleaveDef {
 func (u *sqlSymUnion) partitionBy() *PartitionBy {
     return u.val.(*PartitionBy)
 }
+func (u *sqlSymUnion) listPartition() ListPartition {
+    return u.val.(ListPartition)
+}
 func (u *sqlSymUnion) listPartitions() []ListPartition {
     return u.val.([]ListPartition)
+}
+func (u *sqlSymUnion) rangePartition() RangePartition {
+    return u.val.(RangePartition)
 }
 func (u *sqlSymUnion) rangePartitions() []RangePartition {
     return u.val.([]RangePartition)
@@ -691,11 +697,10 @@ func (u *sqlSymUnion) scrubOption() ScrubOption {
 %type <*InterleaveDef> opt_interleave
 %type <*PartitionBy> opt_partition_by partition_by
 %type <str> partition opt_partition
+%type <ListPartition> list_partition
 %type <[]ListPartition> list_partitions
+%type <RangePartition> range_partition
 %type <[]RangePartition> range_partitions
-%type <[]*Tuple> list_partition_values
-%type <Exprs> partition_exprs
-%type <Expr> partition_expr
 %type <empty> opt_all_clause
 %type <bool> distinct_clause
 %type <NameList> opt_column_list
@@ -2834,80 +2839,43 @@ partition_by:
   }
 
 list_partitions:
-  partition VALUES list_partition_values ',' list_partitions
+  list_partition
   {
-    $$.val = append([]ListPartition{{
-      Name: UnrestrictedName($1),
-      Tuples: $3.tuples(),
-    }}, $5.listPartitions()...)
+    $$.val = []ListPartition{$1.listPartition()}
   }
-| partition VALUES list_partition_values partition_by ',' list_partitions
+| list_partitions ',' list_partition
   {
-    $$.val = append([]ListPartition{{
-      Name: UnrestrictedName($1),
-      Tuples: $3.tuples(),
-      Subpartition: $4.partitionBy(),
-    }}, $6.listPartitions()...)
-  }
-| partition VALUES list_partition_values opt_partition_by
-  {
-    $$.val = []ListPartition{{
-      Name: UnrestrictedName($1),
-      Tuples: $3.tuples(),
-      Subpartition: $4.partitionBy(),
-    }}
+    $$.val = append($1.listPartitions(), $3.listPartition())
   }
 
-list_partition_values:
-  '(' partition_exprs ')'
+list_partition:
+  partition VALUES IN '(' expr_list ')' opt_partition_by
   {
-    $$.val = []*Tuple{{Exprs: $2.exprs()}}
-  }
-| list_partition_values ',' '(' partition_exprs ')'
-  {
-    $$.val = append($1.tuples(), &Tuple{Exprs: $4.exprs()})
-  }
-
-partition_exprs:
-  partition_expr
-  {
-    $$.val = Exprs{$1.expr()}
-  }
-| partition_exprs ',' partition_expr
-  {
-    $$.val = append($1.exprs(), $3.expr())
-  }
-
-partition_expr:
-  a_expr
-| MAXVALUE
-  {
-    $$.val = PartitionMaxValue{}
+    $$.val = ListPartition{
+      Name: UnrestrictedName($1),
+      Exprs: $5.exprs(),
+      Subpartition: $7.partitionBy(),
+    }
   }
 
 range_partitions:
-  partition VALUES LESS THAN '(' partition_exprs ')' ',' range_partitions
+  range_partition
   {
-    $$.val = append([]RangePartition{{
-      Name: UnrestrictedName($1),
-      Tuple: &Tuple{Exprs: $6.exprs()},
-    }}, $9.rangePartitions()...)
+    $$.val = []RangePartition{$1.rangePartition()}
   }
-| partition VALUES LESS THAN '(' partition_exprs ')' partition_by ',' range_partitions
+| range_partitions ',' range_partition
   {
-    $$.val = append([]RangePartition{{
-      Name: UnrestrictedName($1),
-      Tuple: &Tuple{Exprs: $6.exprs()},
-      Subpartition: $8.partitionBy(),
-    }}, $10.rangePartitions()...)
+    $$.val = append($1.rangePartitions(), $3.rangePartition())
   }
-| partition VALUES LESS THAN '(' partition_exprs ')' opt_partition_by
+
+range_partition:
+  partition VALUES '<' a_expr opt_partition_by
   {
-    $$.val = []RangePartition{{
+    $$.val = RangePartition{
       Name: UnrestrictedName($1),
-      Tuple: &Tuple{Exprs: $6.exprs()},
-      Subpartition: $8.partitionBy(),
-    }}
+      Expr: $4.expr(),
+      Subpartition: $5.partitionBy(),
+    }
   }
 
 column_def:
@@ -5529,6 +5497,10 @@ a_expr:
 | DEFAULT
   {
     $$.val = DefaultVal{}
+  }
+| MAXVALUE
+  {
+    $$.val = MaxVal{}
   }
 // | UNIQUE select_with_parens { return unimplemented(sqllex) }
 

--- a/pkg/sql/parser/type_check.go
+++ b/pkg/sql/parser/type_check.go
@@ -445,6 +445,7 @@ var (
 	errFilterWithinWindow   = pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "FILTER within a window function call is not yet supported")
 	errStarNotAllowed       = pgerror.NewError(pgerror.CodeSyntaxError, "cannot use \"*\" in this context")
 	errInvalidDefaultUsage  = pgerror.NewError(pgerror.CodeSyntaxError, "DEFAULT can only appear in a VALUES list within INSERT or on the right side of a SET")
+	errInvalidMaxUsage      = pgerror.NewError(pgerror.CodeSyntaxError, "MAXVALUE can only appear within a range partition expression")
 )
 
 // TypeCheck implements the Expr interface.
@@ -768,6 +769,11 @@ func (expr DefaultVal) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, er
 }
 
 // TypeCheck implements the Expr interface.
+func (expr MaxVal) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, error) {
+	return nil, errInvalidMaxUsage
+}
+
+// TypeCheck implements the Expr interface.
 func (expr *NumVal) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, error) {
 	return typeCheckConstant(expr, ctx, desired)
 }
@@ -958,16 +964,6 @@ func (d *DOidWrapper) TypeCheck(_ *SemaContext, _ types.T) (TypedExpr, error) { 
 // TypeCheck implements the Expr interface. It is implemented as an idempotent
 // identity function for Datum.
 func (d dNull) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, error) { return d, nil }
-
-// TypeCheck implements the Expr interface.
-func (expr PartitionDefault) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, error) {
-	return expr, nil
-}
-
-// TypeCheck implements the Expr interface.
-func (expr PartitionMaxValue) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, error) {
-	return expr, nil
-}
 
 // typeCheckAndRequireTupleElems asserts that all elements in the Tuple
 // can be typed as required and are equivalent to required. Note that one would invoke

--- a/pkg/sql/parser/walk.go
+++ b/pkg/sql/parser/walk.go
@@ -502,6 +502,9 @@ func (expr *ColumnItem) Walk(_ Visitor) Expr {
 func (expr DefaultVal) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
+func (expr MaxVal) Walk(_ Visitor) Expr { return expr }
+
+// Walk implements the Expr interface.
 func (expr *NumVal) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
@@ -569,12 +572,6 @@ func (expr *DOid) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
 func (expr *DOidWrapper) Walk(_ Visitor) Expr { return expr }
-
-// Walk implements the Expr interface.
-func (expr PartitionDefault) Walk(_ Visitor) Expr { return expr }
-
-// Walk implements the Expr interface.
-func (expr PartitionMaxValue) Walk(_ Visitor) Expr { return expr }
 
 // WalkExpr traverses the nodes in an expression.
 //


### PR DESCRIPTION
Adjust the partitioning syntax per the latest update to the RFC. In
summary, list partitioning syntax is changed from

    CREATE TABLE ... PARTITION BY LIST (<cols>) VALUES (<exprs>) [, (<exprs>)...]

to

    CREATE TABLE ... PARTITION BY LIST (<cols>) VALUES IN (<expr>...)

and range partitioning syntax is changed from

    CREATE TABLE ... PARTITION BY RANGE (<cols>) VALUES LESS THAN (<expr>...)

to

    CREATE TABLE ... PARTITION BY RANGE (<cols>) VALUES < <expr>.

In the new syntax, <expr> must be a tuple whenever <cols> has more than
one column. When <cols> has only column, single exprs are automatically
promoted to 1-tuples.

As discussed in the RFC, this requires making DEFAULT and MAXVALUE part
of a_expr. (One could theoretically create a parallel expression
hierarchy without DEFAULT and MAXVALUE, but that would cause a
combinatorial explosion of the number of expression types.) The change
to move DEFAULT into a_expr already landed, so this commit only moves
MAXVALUE into a_expr.