### PR TITLE
kv: combine IntentRows in {Reverse}ScanResponse combinable implementation

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -190,6 +190,7 @@ func (sr *ScanResponse) combine(c combinable) error {
 	otherSR := c.(*ScanResponse)
 	if sr != nil {
 		sr.Rows = append(sr.Rows, otherSR.Rows...)
+		sr.IntentRows = append(sr.IntentRows, otherSR.IntentRows...)
 		if err := sr.ResponseHeader.combine(otherSR.Header()); err != nil {
 			return err
 		}
@@ -204,10 +205,10 @@ func (sr *ReverseScanResponse) combine(c combinable) error {
 	otherSR := c.(*ReverseScanResponse)
 	if sr != nil {
 		sr.Rows = append(sr.Rows, otherSR.Rows...)
+		sr.IntentRows = append(sr.IntentRows, otherSR.IntentRows...)
 		if err := sr.ResponseHeader.combine(otherSR.Header()); err != nil {
 			return err
 		}
-
 	}
 	return nil
 }

--- a/pkg/roachpb/api_test.go
+++ b/pkg/roachpb/api_test.go
@@ -33,6 +33,9 @@ func TestCombinable(t *testing.T) {
 		Rows: []KeyValue{
 			{Key: Key("A"), Value: MakeValueFromString("V")},
 		},
+		IntentRows: []KeyValue{
+			{Key: Key("Ai"), Value: MakeValueFromString("X")},
+		},
 	}
 
 	if _, ok := interface{}(sr1).(combinable); !ok {
@@ -43,10 +46,14 @@ func TestCombinable(t *testing.T) {
 		Rows: []KeyValue{
 			{Key: Key("B"), Value: MakeValueFromString("W")},
 		},
+		IntentRows: []KeyValue{
+			{Key: Key("Bi"), Value: MakeValueFromString("Z")},
+		},
 	}
 
 	wantedSR := &ScanResponse{
-		Rows: append(append([]KeyValue(nil), sr1.Rows...), sr2.Rows...),
+		Rows:       append(append([]KeyValue(nil), sr1.Rows...), sr2.Rows...),
+		IntentRows: append(append([]KeyValue(nil), sr1.IntentRows...), sr2.IntentRows...),
 	}
 
 	if err := sr1.combine(sr2); err != nil {


### PR DESCRIPTION
Discussed in #19147.

The `ReturnIntents` option was added to `ScanRequest` and `ReverseScanRequest`
in 4fb751c. This options makes these scans return the intent KVs they run into
as well.

This change makes the `ScanRequest` and `ReverseScanRequest` combinable
implementations combine the intent KVs across different responses.