### PR TITLE
sql: add transaction_read_only variable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -145,7 +145,7 @@ EXPLAIN SHOW DATABASE
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 21 rows
+2  ·       size  2 columns, 22 rows
 
 query ITTT
 EXPLAIN SHOW TIME ZONE
@@ -153,7 +153,7 @@ EXPLAIN SHOW TIME ZONE
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 21 rows
+2  ·       size  2 columns, 22 rows
 
 query ITTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -161,7 +161,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 21 rows
+2  ·       size  2 columns, 22 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -169,7 +169,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 21 rows
+2  ·       size  2 columns, 22 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -177,7 +177,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 21 rows
+2  ·       size  2 columns, 22 rows
 
 query ITTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1057,6 +1057,7 @@ tracing                        off           NULL      NULL        NULL        s
 transaction isolation level    SERIALIZABLE  NULL      NULL        NULL        string
 transaction priority           NORMAL        NULL      NULL        NULL        string
 transaction status             NoTxn         NULL      NULL        NULL        string
+transaction_read_only          false         NULL      NULL        NULL        string
 
 query TTTTTTT colnames
 SELECT name, setting, unit, context, enumvals, boot_val, reset_val FROM pg_catalog.pg_settings
@@ -1083,6 +1084,7 @@ tracing                        off           NULL  user     NULL      off       
 transaction isolation level    SERIALIZABLE  NULL  user     NULL      SERIALIZABLE  SERIALIZABLE
 transaction priority           NORMAL        NULL  user     NULL      NORMAL        NORMAL
 transaction status             NoTxn         NULL  user     NULL      NoTxn         NoTxn
+transaction_read_only          false         NULL  user     NULL      false         false
 
 query TTTTTT colnames
 SELECT name, source, min_val, max_val, sourcefile, sourceline FROM pg_catalog.pg_settings
@@ -1109,7 +1111,7 @@ tracing                        NULL    NULL     NULL     NULL        NULL
 transaction isolation level    NULL    NULL     NULL     NULL        NULL
 transaction priority           NULL    NULL     NULL     NULL        NULL
 transaction status             NULL    NULL     NULL     NULL        NULL
-
+transaction_read_only          NULL    NULL     NULL     NULL        NULL
 
 # Verify proper functionality of system information functions.
 

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -98,6 +98,7 @@ tracing                        off
 transaction isolation level    SERIALIZABLE
 transaction priority           NORMAL
 transaction status             NoTxn
+transaction_read_only          false
 
 # SESSION_USER is a special keyword, check that SHOW knows about it.
 query T

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -43,6 +43,7 @@ tracing                        off
 transaction isolation level    SERIALIZABLE
 transaction priority           NORMAL
 transaction status             NoTxn
+transaction_read_only          false
 
 query I colnames
 SELECT * FROM [SHOW CLUSTER SETTING sql.defaults.distsql]

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -335,6 +335,12 @@ var varGen = map[string]sessionVar{
 		Get: func(session *Session) string { return getTransactionState(&session.TxnState) },
 	},
 
+	`transaction_read_only`: {
+		// Supported for PG driver compatibility only. We don't support setting it
+		// in any way.
+		Get: func(*Session) string { return "false" },
+	},
+
 	`tracing`: {
 		Get: func(session *Session) string {
 			if session.Tracing.Enabled() {


### PR DESCRIPTION
Closes #19911. @justinj this should address adding the read-only transaction_read_only variable.