### PR TITLE
cloud: Add config for running cockroach commands in secure k8 clusters

### DIFF
--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -189,7 +189,7 @@ kubectl create -f cockroachdb-client-secure.yaml
 Check and approve the CSR for the pod as described above, and then get a shell to the pod and run:
 
 ```shell
-kubectl exec -it <pod name> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+kubectl exec -it cockroachdb-client-secure -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
 ```
 
 You can see example SQL statements for inserting and querying data in the

--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -172,14 +172,25 @@ Along with our StatefulSet configuration, we expose a standard Kubernetes servic
 that offers a load-balanced virtual IP for clients to access the database
 with. In our example, we've called this service `cockroachdb-public`.
 
-Start up a client pod and open up an interactive, (mostly) Postgres-flavor
-SQL shell using:
+In insecure mode, start up a client pod and open up an interactive, (mostly) Postgres-flavor
+SQL shell:
 
-```console
-$ kubectl run -it --rm cockroach-client --image=cockroachdb/cockroach --restart=Never --command -- ./cockroach sql --host cockroachdb-public
+```shell
+$ kubectl run cockroachdb -it --image=cockroachdb/cockroach --rm --restart=Never \
+    -- sql --insecure --host=cockroachdb-public
 ```
 
-**WARNING**: there is no secure mode equivalent of doing this (yet).
+In secure mode, use our `cockroachdb-client-secure.yaml` config to launch a pod that runs indefinitely with the `cockroach` binary inside it:
+
+```shell
+kubectl create -f cockroachdb-client-secure.yaml
+```
+
+Check and approve the CSR for the pod as described above, and then get a shell to the pod and run:
+
+```shell
+kubectl exec -it <pod name> -- ./cockroach sql --certs-dir=/cockroach-certs --host=cockroachdb-public
+```
 
 You can see example SQL statements for inserting and querying data in the
 included [demo script](demo.sh), but can use almost any Postgres-style SQL

--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -73,12 +73,7 @@ which will lead to a lot of trouble.
 
 ### Secure mode
 
-Secure mode currently works by requesting node/client certificates from the kubernetes
-controller at pod initialization time.
-
-This means that rescheduled pods will go through the CSR process, requiring manual involvement.
-A future improvement for node/client certificates will use kubernetes secrets, simplifying
-deployment and maintenance.
+Secure mode currently works by requesting node/client certificates from the kubernetes controller at pod initialization time.
 
 ## Creating your kubernetes cluster
 

--- a/cloud/kubernetes/cockroachdb-client-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-client-secure.yaml
@@ -1,51 +1,45 @@
-apiVersion: apps/v1beta1
-kind: Deployment
+apiVersion: v1
+kind: Pod
 metadata:
   name: cockroachdb-client-secure
+  labels:
+    app: cockroachdb
 spec:
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: cockroachdb
-    spec:
-      volumes:
-      - name: client-certs
-        emptyDir: {}
-
-      initContainers:
-      # The init-certs container sends a certificate signing request to the
-      # kubernetes cluster.
-      # You can see pending requests using: kubectl get csr
-      # CSRs can be approved using:         kubectl certificate approve <csr name>
-      #
-      # In addition to the client certificate and key, the init-certs entrypoint will symlink
-      # the cluster CA to the certs directory.
-      - name: init-certs
-        image: cockroachdb/cockroach-k8s-request-cert:0.2
-        imagePullPolicy: IfNotPresent
-        command:
-        - "/bin/ash"
-        - "-ecx"
-        - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=client -user=root -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        volumeMounts:
-        - name: client-certs
-          mountPath: /cockroach-certs
-
-      containers:
-      - name: cockroachdb-client
-        image: cockroachdb/cockroach:v1.1.2
-        imagePullPolicy: IfNotPresent
-        volumeMounts:
-        - name: client-certs
-          mountPath: /cockroach-certs
-        # Keep a pod open indefinitely so kubectl exec can be used to get a shell to it
-        # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
-        command:
-        - sleep
-        - "99999999999999"
+  initContainers:
+  # The init-certs container sends a certificate signing request to the
+  # kubernetes cluster.
+  # You can see pending requests using: kubectl get csr
+  # CSRs can be approved using:         kubectl certificate approve <csr name>
+  #
+  # In addition to the client certificate and key, the init-certs entrypoint will symlink
+  # the cluster CA to the certs directory.
+  - name: init-certs
+    image: cockroachdb/cockroach-k8s-request-cert:0.2
+    imagePullPolicy: IfNotPresent
+    command:
+    - "/bin/ash"
+    - "-ecx"
+    - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=client -user=root -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    env:
+    - name: POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    volumeMounts:
+    - name: client-certs
+      mountPath: /cockroach-certs
+  containers:
+  - name: cockroachdb-client
+    image: cockroachdb/cockroach:v1.1.2
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - name: client-certs
+      mountPath: /cockroach-certs
+    # Keep a pod open indefinitely so kubectl exec can be used to get a shell to it
+    # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
+    command:
+    - sleep
+    - "2147483648" # 2^31
+  volumes:
+  - name: client-certs
+    emptyDir: {}

--- a/cloud/kubernetes/cockroachdb-client-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-client-secure.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: cockroachdb-client-secure
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cockroachdb
+    spec:
+      volumes:
+      - name: client-certs
+        emptyDir: {}
+
+      initContainers:
+      # The init-certs container sends a certificate signing request to the
+      # kubernetes cluster.
+      # You can see pending requests using: kubectl get csr
+      # CSRs can be approved using:         kubectl certificate approve <csr name>
+      #
+      # In addition to the client certificate and key, the init-certs entrypoint will symlink
+      # the cluster CA to the certs directory.
+      - name: init-certs
+        image: cockroachdb/cockroach-k8s-request-cert:0.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - "/bin/ash"
+        - "-ecx"
+        - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=client -user=root -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+
+      containers:
+      - name: cockroachdb-client
+        image: cockroachdb/cockroach:v1.1.2
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+        # Keep a pod open indefinitely so kubectl exec can be used to get a shell to it
+        # and run cockroach client commands, such as cockroach sql, cockroach node status, etc.
+        command:
+        - sleep
+        - "99999999999999"


### PR DESCRIPTION
- Add deployment config for cockroach client commands in secure k8 clusters
- Remove limitation about rescheduled pods needing to go through the CSR approval process
- Update instructions for accessing the sql shell from k8