### PR TITLE
cloud: Update Kubernetes configs to use the init command

### DIFF
--- a/cloud/kubernetes/cluster_init_secure.yaml
+++ b/cloud/kubernetes/cluster_init_secure.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cluster-init-secure
+  labels:
+    app: cockroachdb
+spec:
+  template:
+    spec:
+      initContainers:
+      # The init-certs container sends a certificate signing request to the
+      # kubernetes cluster.
+      # You can see pending requests using: kubectl get csr
+      # CSRs can be approved using:         kubectl certificate approve <csr name>
+      #
+      # In addition to the client certificate and key, the init-certs entrypoint will symlink
+      # the cluster CA to the certs directory.
+      - name: init-certs
+        image: cockroachdb/cockroach-k8s-request-cert:0.2
+        imagePullPolicy: IfNotPresent
+        command:
+        - "/bin/ash"
+        - "-ecx"
+        - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=client -user=root -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+      containers:
+      - name: cluster-init
+        image: cockroachdb/cockroach:v1.1.2
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: client-certs
+          mountPath: /cockroach-certs
+        command:
+          - "/cockroach/cockroach"
+          - "init"
+          - "--certs-dir=/cockroach-certs"
+          - "--host=cockroachdb-0.cockroachdb"
+      restartPolicy: OnFailure
+      volumes:
+      - name: client-certs
+        emptyDir: {}

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -82,31 +82,6 @@ spec:
       # it's started up for the first time. It has to exit successfully
       # before the pod's main containers are allowed to start.
       initContainers:
-      # This particular init container does a DNS lookup for other pods in
-      # the set to help determine whether or not a cluster already exists.
-      # If any other pods exist, it creates a file in the cockroach-data
-      # directory to pass that information along to the primary container that
-      # has to decide what command-line flags to use when starting CockroachDB.
-      # This only matters when a pod's persistent volume is empty - if it has
-      # data from a previous execution, that data will always be used.
-      #
-      # If your Kubernetes cluster uses a custom DNS domain, you will have
-      # to add an additional arg to this pod: "-domain=<your-custom-domain>"
-      - name: bootstrap
-        image: cockroachdb/cockroach-k8s-init:0.2
-        imagePullPolicy: IfNotPresent
-        args:
-        - "-on-start=/on-start.sh"
-        - "-service=cockroachdb"
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        volumeMounts:
-        - name: datadir
-          mountPath: /cockroach/cockroach-data
-
       # The init-certs container sends a certificate signing request to the
       # kubernetes cluster.
       # You can see pending requests using: kubectl get csr
@@ -122,7 +97,7 @@ spec:
         command:
         - "/bin/ash"
         - "-ecx"
-        - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=node -addresses=localhost,127.0.0.1,${POD_IP},$(hostname -f),cockroachdb-public -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+        - "/request-cert -namespace=${POD_NAMESPACE} -certs-dir=/cockroach-certs -type=node -addresses=localhost,127.0.0.1,${POD_IP},$(hostname -f),$(hostname -f|cut -f 1-2 -d '.'),cockroachdb-public -symlink-ca-from=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
         env:
         - name: POD_IP
           valueFrom:
@@ -165,26 +140,9 @@ spec:
         command:
           - "/bin/bash"
           - "-ecx"
-          - |
-            # The use of qualified `hostname -f` is crucial:
-            # Other nodes aren't able to look up the unqualified hostname.
-            CRARGS=("start" "--logtostderr" "--certs-dir" "/cockroach/cockroach-certs" "--host" "$(hostname -f)" "--http-host" "0.0.0.0" "--cache" "25%" "--max-sql-memory" "25%")
-            # We only want to initialize a new cluster (by omitting the join flag)
-            # if we're sure that we're the first node (i.e. index 0) and that
-            # there aren't any other nodes running as part of the cluster that
-            # this is supposed to be a part of (which indicates that a cluster
-            # already exists and we should make sure not to create a new one).
-            # It's fine to run without --join on a restart if there aren't any
-            # other nodes.
-            if [ ! "$(hostname)" == "cockroachdb-0" ] || \
-               [ -e "/cockroach/cockroach-data/cluster_exists_marker" ]
-            then
-              # We don't join cockroachdb in order to avoid a node attempting
-              # to join itself, which currently doesn't work
-              # (https://github.com/cockroachdb/cockroach/issues/9625).
-              CRARGS+=("--join" "cockroachdb-public")
-            fi
-            exec /cockroach/cockroach ${CRARGS[*]}
+          # The use of qualified `hostname -f` is crucial:
+          # Other nodes aren't able to look up the unqualified hostname.
+          - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --host $(hostname -f) --http-host 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -78,34 +78,6 @@ spec:
       labels:
         app: cockroachdb
     spec:
-      # Init containers are run only once in the lifetime of a pod, before
-      # it's started up for the first time. It has to exit successfully
-      # before the pod's main containers are allowed to start.
-      # This particular init container does a DNS lookup for other pods in
-      # the set to help determine whether or not a cluster already exists.
-      # If any other pods exist, it creates a file in the cockroach-data
-      # directory to pass that information along to the primary container that
-      # has to decide what command-line flags to use when starting CockroachDB.
-      # This only matters when a pod's persistent volume is empty - if it has
-      # data from a previous execution, that data will always be used.
-      #
-      # If your Kubernetes cluster uses a custom DNS domain, you will have
-      # to add an additional arg to this pod: "-domain=<your-custom-domain>"
-      initContainers:
-      - name: bootstrap
-        image: cockroachdb/cockroach-k8s-init:0.2
-        imagePullPolicy: IfNotPresent
-        args:
-        - "-on-start=/on-start.sh"
-        - "-service=cockroachdb"
-        env:
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        volumeMounts:
-        - name: datadir
-          mountPath: /cockroach/cockroach-data
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -133,26 +105,9 @@ spec:
         command:
           - "/bin/bash"
           - "-ecx"
-          - |
-            # The use of qualified `hostname -f` is crucial:
-            # Other nodes aren't able to look up the unqualified hostname.
-            CRARGS=("start" "--logtostderr" "--insecure" "--host" "$(hostname -f)" "--http-host" "0.0.0.0" "--cache" "25%" "--max-sql-memory" "25%")
-            # We only want to initialize a new cluster (by omitting the join flag)
-            # if we're sure that we're the first node (i.e. index 0) and that
-            # there aren't any other nodes running as part of the cluster that
-            # this is supposed to be a part of (which indicates that a cluster
-            # already exists and we should make sure not to create a new one).
-            # It's fine to run without --join on a restart if there aren't any
-            # other nodes.
-            if [ ! "$(hostname)" == "cockroachdb-0" ] || \
-               [ -e "/cockroach/cockroach-data/cluster_exists_marker" ]
-            then
-              # We don't join cockroachdb in order to avoid a node attempting
-              # to join itself, which currently doesn't work
-              # (https://github.com/cockroachdb/cockroach/issues/9625).
-              CRARGS+=("--join" "cockroachdb-public")
-            fi
-            exec /cockroach/cockroach ${CRARGS[*]}
+          # The use of qualified `hostname -f` is crucial:
+          # Other nodes aren't able to look up the unqualified hostname.
+          - "exec /cockroach/cockroach start --logtostderr --insecure --host $(hostname -f) --http-host 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60


### PR DESCRIPTION
This removes a (very rare) potential edge case where a cluster could
end up in split brain if all pods went down, cockroachdb-0 lost its
disk, and the other pods didn't.

The docs will need to be updated in lockstep with this change.

Fixes #19954