### PR TITLE
tscache: remove lowWaterTxnIDMarker, GetMaxRead/GetMaxWrite returns no flag

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -638,12 +638,17 @@ func TestRangeTransferLease(t *testing.T) {
 
 		replica1Lease, _ := replica1.GetLease()
 
-		// Verify the timestamp cache low water. Because we executed a transfer lease
-		// request, the low water should be set to the new lease start time which is
-		// less than the previous lease's expiration time.
-		if lowWater := replica1.GetTimestampCacheLowWater(); lowWater != replica1Lease.Start {
-			t.Fatalf("expected timestamp cache low water %s, but found %s",
-				replica1Lease.Start, lowWater)
+		// We'd like to verify the timestamp cache's low water mark, but this is
+		// impossible to determine precisely in all cases because it may have
+		// been subsumed by future tscache accesses. However, we know that there
+		// were no tscache accesses since we executed the transfer lease
+		// request, which means that the low water mark will still be equal to
+		// the high water mark. So instead of checking the low water mark, we
+		// make sure that the high water mark is set to the new lease start
+		// time, which is less than the previous lease's expiration time.
+		if highWater := replica1.GetTSCacheHighWater(); highWater != replica1Lease.Start {
+			t.Fatalf("expected timestamp cache high water %s, but found %s",
+				replica1Lease.Start, highWater)
 		}
 	})
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2366,35 +2366,36 @@ func (r *Replica) applyTimestampCache(
 			// has already been finalized, in which case this is a replay.
 			if _, ok := args.(*roachpb.BeginTransactionRequest); ok {
 				key := keys.TransactionKey(header.Key, ba.Txn.ID)
-				wTS, wTxnID, wOK := r.store.tsCacheMu.cache.GetMaxWrite(key, nil)
-				if wOK {
-					// GetMaxWrite will only find a timestamp interval with an
-					// associated txnID on the TransactionKey if an EndTxnReq
-					// has been processed. All other timestamp intervals will
-					// have no associated txnID and will be due to the low-water
-					// mark.
-					if wTxnID != ba.Txn.ID {
-						log.Fatalf(ctx, "unexpected tscache interval (%s,%s) on TxnKey %s",
-							wTS, wTxnID, key)
-					}
+				wTS, wTxnID := r.store.tsCacheMu.cache.GetMaxWrite(key, nil)
+				// GetMaxWrite will only find a timestamp interval with an
+				// associated txnID on the TransactionKey if an EndTxnReq has
+				// been processed. All other timestamp intervals will have no
+				// associated txnID and will be due to the low-water mark.
+				switch wTxnID {
+				case ba.Txn.ID:
 					return bumped, roachpb.NewError(roachpb.NewTransactionReplayError())
-				} else if !wTS.Less(ba.Txn.Timestamp) {
-					// This is a crucial bit of code. The timestamp cache is
-					// reset with the current time as the low-water
-					// mark, so if this replica recently obtained the lease,
-					// this case will be true for new txns, even if they're not
-					// a replay. We move the timestamp forward and return retry.
-					// If it's really a replay, it won't retry.
-					txn := ba.Txn.Clone()
-					bumped = txn.Timestamp.Forward(wTS.Next()) || bumped
-					err = roachpb.NewTransactionRetryError(roachpb.RETRY_POSSIBLE_REPLAY)
-					return bumped, roachpb.NewErrorWithTxn(err, &txn)
+				case uuid.UUID{} /* noTxnID */ :
+					if !wTS.Less(ba.Txn.Timestamp) {
+						// This is a crucial bit of code. The timestamp cache is
+						// reset with the current time as the low-water mark, so
+						// if this replica recently obtained the lease, this
+						// case will be true for new txns, even if they're not a
+						// replay. We move the timestamp forward and return
+						// retry. If it's really a replay, it won't retry.
+						txn := ba.Txn.Clone()
+						bumped = txn.Timestamp.Forward(wTS.Next()) || bumped
+						err = roachpb.NewTransactionRetryError(roachpb.RETRY_POSSIBLE_REPLAY)
+						return bumped, roachpb.NewErrorWithTxn(err, &txn)
+					}
+				default:
+					log.Fatalf(ctx, "unexpected tscache interval (%s,%s) on TxnKey %s",
+						wTS, wTxnID, key)
 				}
 				continue
 			}
 
 			// Forward the timestamp if there's been a more recent read (by someone else).
-			rTS, rTxnID, _ := r.store.tsCacheMu.cache.GetMaxRead(header.Key, header.EndKey)
+			rTS, rTxnID := r.store.tsCacheMu.cache.GetMaxRead(header.Key, header.EndKey)
 			if ba.Txn != nil {
 				if ba.Txn.ID != rTxnID {
 					nextTS := rTS.Next()
@@ -2412,7 +2413,7 @@ func (r *Replica) applyTimestampCache(
 			// write too old boolean for transactions. Note that currently
 			// only EndTransaction and DeleteRange requests update the
 			// write timestamp cache.
-			wTS, wTxnID, _ := r.store.tsCacheMu.cache.GetMaxWrite(header.Key, header.EndKey)
+			wTS, wTxnID := r.store.tsCacheMu.cache.GetMaxWrite(header.Key, header.EndKey)
 			if ba.Txn != nil {
 				if ba.Txn.ID != wTxnID {
 					if !wTS.Less(ba.Txn.Timestamp) {

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1973,13 +1973,13 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 	tc.repl.store.tsCacheMu.cache.ExpandRequests(tc.repl.Desc().RSpan(), hlc.Timestamp{})
 	rTS, _, rOK := tc.repl.store.tsCacheMu.cache.GetMaxRead(roachpb.Key("a"), nil)
 	wTS, _, wOK := tc.repl.store.tsCacheMu.cache.GetMaxWrite(roachpb.Key("a"), nil)
-	if rTS.WallTime != t0.Nanoseconds() || wTS.WallTime != startNanos || !rOK || wOK {
+	if rTS.WallTime != t0.Nanoseconds() || wTS.WallTime != startNanos || rOK || wOK {
 		t.Errorf("expected rTS=1s and wTS=0s, but got %s, %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}
 	// Verify the timestamp cache has rTS=0s and wTS=2s for "b".
 	rTS, _, rOK = tc.repl.store.tsCacheMu.cache.GetMaxRead(roachpb.Key("b"), nil)
 	wTS, _, wOK = tc.repl.store.tsCacheMu.cache.GetMaxWrite(roachpb.Key("b"), nil)
-	if rTS.WallTime != startNanos || wTS.WallTime != t1.Nanoseconds() || rOK || !wOK {
+	if rTS.WallTime != startNanos || wTS.WallTime != t1.Nanoseconds() || rOK || wOK {
 		t.Errorf("expected rTS=0s and wTS=2s, but got %s, %s; rOK=%t, wOK=%t", rTS, wTS, rOK, wOK)
 	}
 	// Verify another key ("c") has 0sec in timestamp cache.

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -63,19 +63,16 @@ type Cache interface {
 	GlobalLowWater() hlc.Timestamp
 
 	// GetMaxRead returns the maximum read timestamp which overlaps the interval
-	// spanning from start to end. If that timestamp belongs to a single
-	// transaction, that transaction's ID is returned. If no part of the
-	// specified range is overlapped by timestamps from different transactions
-	// in the cache, the low water timestamp is returned for the read
-	// timestamps. Also returns an "ok" bool, indicating whether the overlapping
-	// interval had a distinct (non-empty) txnID.
-	//
-	// DURING REVIEW: Don't worry about the bool semantics since no-one uses
-	// them anymore, just proving that this is safe between commits.
-	GetMaxRead(start, end roachpb.Key) (hlc.Timestamp, uuid.UUID, bool)
+	// spanning from start to end. If that maximum timestamp belongs to a single
+	// transaction, that transaction's ID is returned. Otherwise, if that
+	// maximum is shared between multiple transactions, no transaction ID is
+	// returned. Finally, if no part of the specified range is overlapped by
+	// timestamp intervals from any transactions in the cache, the low water
+	// timestamp is returned for the read timestamps.
+	GetMaxRead(start, end roachpb.Key) (hlc.Timestamp, uuid.UUID)
 	// GetMaxWrite behaves like GetMaxRead, but returns the maximum write
 	// timestamp which overlaps the interval spanning from start to end.
-	GetMaxWrite(start, end roachpb.Key) (hlc.Timestamp, uuid.UUID, bool)
+	GetMaxWrite(start, end roachpb.Key) (hlc.Timestamp, uuid.UUID)
 
 	// The following methods are used for testing within this package:
 	//

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -67,9 +67,11 @@ type Cache interface {
 	// transaction, that transaction's ID is returned. If no part of the
 	// specified range is overlapped by timestamps from different transactions
 	// in the cache, the low water timestamp is returned for the read
-	// timestamps. Also returns an "ok" bool, indicating whether an explicit
-	// match of the interval was found in the cache (as opposed to using the
-	// low-water mark).
+	// timestamps. Also returns an "ok" bool, indicating whether the overlapping
+	// interval had a distinct (non-empty) txnID.
+	//
+	// DURING REVIEW: Don't worry about the bool semantics since no-one uses
+	// them anymore, just proving that this is safe between commits.
 	GetMaxRead(start, end roachpb.Key) (hlc.Timestamp, uuid.UUID, bool)
 	// GetMaxWrite behaves like GetMaxRead, but returns the maximum write
 	// timestamp which overlaps the interval spanning from start to end.
@@ -99,29 +101,11 @@ type cacheValue struct {
 // noTxnID is used when a cacheValue has no corresponding TxnID.
 var noTxnID uuid.UUID
 
-// lowWaterTxnIDMarker is a special txn ID that identifies a cache entry as a
-// low water mark. It is specified when a lease is acquired to clear the
-// timestamp cache for a range. Also see Cache.getMax where this txn ID is
-// checked in order to return whether the max read/write timestamp came from a
-// regular entry or one of these low water mark entries.
-var lowWaterTxnIDMarker = func() uuid.UUID {
-	// The specific txn ID used here isn't important. We use something that is:
-	// a) non-zero
-	// b) obvious
-	u, err := uuid.FromString("11111111-1111-1111-1111-111111111111")
-	if err != nil {
-		panic(err)
-	}
-	return u
-}()
-
 func (v cacheValue) String() string {
 	var txnIDStr string
 	switch v.txnID {
 	case noTxnID:
 		txnIDStr = "none"
-	case lowWaterTxnIDMarker:
-		txnIDStr = "low water"
 	default:
 		txnIDStr = v.txnID.String()
 	}

--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -75,34 +75,34 @@ func TestTimestampCache(t *testing.T) {
 		tc.add(roachpb.Key("b"), roachpb.Key("c"), ts, noTxnID, true)
 
 		// Verify all permutations of direct and range access.
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("b"), nil); rTS != ts || !ok {
+		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("b"), nil); rTS != ts || ok {
 			t.Errorf("expected current time for key \"b\"; got %s; ok=%t", rTS, ok)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bb"), nil); rTS != ts || !ok {
+		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bb"), nil); rTS != ts || ok {
 			t.Errorf("expected current time for key \"bb\"; ok=%t", ok)
 		}
 		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("c"), nil); rTS.WallTime != baseTS || ok {
 			t.Errorf("expected baseTS for key \"c\"; ok=%t", ok)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("b"), roachpb.Key("c")); rTS != ts || !ok {
+		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("b"), roachpb.Key("c")); rTS != ts || ok {
 			t.Errorf("expected current time for key \"b\"-\"c\"; ok=%t", ok)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bb"), roachpb.Key("bz")); rTS != ts || !ok {
+		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bb"), roachpb.Key("bz")); rTS != ts || ok {
 			t.Errorf("expected current time for key \"bb\"-\"bz\"; ok=%t", ok)
 		}
 		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("b")); rTS.WallTime != baseTS || ok {
 			t.Errorf("expected baseTS for key \"a\"-\"b\"; ok=%t", ok)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("bb")); rTS != ts || !ok {
+		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("bb")); rTS != ts || ok {
 			t.Errorf("expected current time for key \"a\"-\"bb\"; ok=%t", ok)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("d")); rTS != ts || !ok {
+		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("d")); rTS != ts || ok {
 			t.Errorf("expected current time for key \"a\"-\"d\"; ok=%t", ok)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bz"), roachpb.Key("c")); rTS != ts || !ok {
+		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bz"), roachpb.Key("c")); rTS != ts || ok {
 			t.Errorf("expected current time for key \"bz\"-\"c\"; ok=%t", ok)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bz"), roachpb.Key("d")); rTS != ts || !ok {
+		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bz"), roachpb.Key("d")); rTS != ts || ok {
 			t.Errorf("expected current time for key \"bz\"-\"d\"; ok=%t", ok)
 		}
 		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("c"), roachpb.Key("d")); rTS.WallTime != baseTS || ok {

--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -54,20 +54,20 @@ func TestTimestampCache(t *testing.T) {
 		// First simulate a read of just "a" at time 50.
 		tc.add(roachpb.Key("a"), nil, hlc.Timestamp{WallTime: 50}, noTxnID, true)
 		// Verify GetMax returns the lowWater mark.
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("a"), nil); rTS.WallTime != baseTS || ok {
-			t.Errorf("expected baseTS for key \"a\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("a"), nil); rTS.WallTime != baseTS || rTxnID != noTxnID {
+			t.Errorf("expected baseTS for key \"a\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("notincache"), nil); rTS.WallTime != baseTS || ok {
-			t.Errorf("expected baseTS for key \"notincache\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("notincache"), nil); rTS.WallTime != baseTS || rTxnID != noTxnID {
+			t.Errorf("expected baseTS for key \"notincache\"; txnID=%s", rTxnID)
 		}
 
 		// Advance the clock and verify same low water mark.
 		manual.Increment(100)
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("a"), nil); rTS.WallTime != baseTS || ok {
-			t.Errorf("expected baseTS for key \"a\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("a"), nil); rTS.WallTime != baseTS || rTxnID != noTxnID {
+			t.Errorf("expected baseTS for key \"a\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("notincache"), nil); rTS.WallTime != baseTS || ok {
-			t.Errorf("expected baseTS for key \"notincache\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("notincache"), nil); rTS.WallTime != baseTS || rTxnID != noTxnID {
+			t.Errorf("expected baseTS for key \"notincache\"; txnID=%s", rTxnID)
 		}
 
 		// Sim a read of "b"-"c" at a time above the low-water mark.
@@ -75,38 +75,38 @@ func TestTimestampCache(t *testing.T) {
 		tc.add(roachpb.Key("b"), roachpb.Key("c"), ts, noTxnID, true)
 
 		// Verify all permutations of direct and range access.
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("b"), nil); rTS != ts || ok {
-			t.Errorf("expected current time for key \"b\"; got %s; ok=%t", rTS, ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("b"), nil); rTS != ts || rTxnID != noTxnID {
+			t.Errorf("expected current time for key \"b\"; got %s; txnID=%s", rTS, rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bb"), nil); rTS != ts || ok {
-			t.Errorf("expected current time for key \"bb\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("bb"), nil); rTS != ts || rTxnID != noTxnID {
+			t.Errorf("expected current time for key \"bb\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("c"), nil); rTS.WallTime != baseTS || ok {
-			t.Errorf("expected baseTS for key \"c\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("c"), nil); rTS.WallTime != baseTS || rTxnID != noTxnID {
+			t.Errorf("expected baseTS for key \"c\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("b"), roachpb.Key("c")); rTS != ts || ok {
-			t.Errorf("expected current time for key \"b\"-\"c\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("b"), roachpb.Key("c")); rTS != ts || rTxnID != noTxnID {
+			t.Errorf("expected current time for key \"b\"-\"c\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bb"), roachpb.Key("bz")); rTS != ts || ok {
-			t.Errorf("expected current time for key \"bb\"-\"bz\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("bb"), roachpb.Key("bz")); rTS != ts || rTxnID != noTxnID {
+			t.Errorf("expected current time for key \"bb\"-\"bz\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("b")); rTS.WallTime != baseTS || ok {
-			t.Errorf("expected baseTS for key \"a\"-\"b\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("b")); rTS.WallTime != baseTS || rTxnID != noTxnID {
+			t.Errorf("expected baseTS for key \"a\"-\"b\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("bb")); rTS != ts || ok {
-			t.Errorf("expected current time for key \"a\"-\"bb\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("bb")); rTS != ts || rTxnID != noTxnID {
+			t.Errorf("expected current time for key \"a\"-\"bb\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("d")); rTS != ts || ok {
-			t.Errorf("expected current time for key \"a\"-\"d\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("d")); rTS != ts || rTxnID != noTxnID {
+			t.Errorf("expected current time for key \"a\"-\"d\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bz"), roachpb.Key("c")); rTS != ts || ok {
-			t.Errorf("expected current time for key \"bz\"-\"c\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("bz"), roachpb.Key("c")); rTS != ts || rTxnID != noTxnID {
+			t.Errorf("expected current time for key \"bz\"-\"c\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("bz"), roachpb.Key("d")); rTS != ts || ok {
-			t.Errorf("expected current time for key \"bz\"-\"d\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("bz"), roachpb.Key("d")); rTS != ts || rTxnID != noTxnID {
+			t.Errorf("expected current time for key \"bz\"-\"d\"; txnID=%s", rTxnID)
 		}
-		if rTS, _, ok := tc.GetMaxRead(roachpb.Key("c"), roachpb.Key("d")); rTS.WallTime != baseTS || ok {
-			t.Errorf("expected baseTS for key \"c\"-\"d\"; ok=%t", ok)
+		if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("c"), roachpb.Key("d")); rTS.WallTime != baseTS || rTxnID != noTxnID {
+			t.Errorf("expected baseTS for key \"c\"-\"d\"; txnID=%s", rTxnID)
 		}
 	})
 }
@@ -134,7 +134,7 @@ func assertTS(
 	} else {
 		keys = fmt.Sprintf("%q-%q", start, end)
 	}
-	ts, txnID, _ := tc.GetMaxRead(start, end)
+	ts, txnID := tc.GetMaxRead(start, end)
 	if ts != expectedTS {
 		t.Errorf("expected %s to have timestamp %v, found %v", keys, expectedTS, ts)
 	}
@@ -372,8 +372,8 @@ func TestTimestampCacheClear(t *testing.T) {
 		tc.clear(expTS)
 
 		// Fetching any keys should give current time.
-		if rTS, _, ok := tc.GetMaxRead(key, nil); ok {
-			t.Errorf("expected %s to have cleared timestamp", key)
+		if rTS, rTxnID := tc.GetMaxRead(key, nil); rTxnID != noTxnID {
+			t.Errorf("%s unexpectedly associated to txn %s", key, rTxnID)
 		} else if rTS != expTS {
 			t.Errorf("expected %s, got %s", rTS, expTS)
 		}
@@ -398,10 +398,11 @@ func TestTimestampCacheReadVsWrite(t *testing.T) {
 		ts3 := clock.Now()
 		tc.add(roachpb.Key("a"), nil, ts3, txn2ID, false)
 
-		rTS, _, rOK := tc.GetMaxRead(roachpb.Key("a"), nil)
-		wTS, _, wOK := tc.GetMaxWrite(roachpb.Key("a"), nil)
-		if rTS != ts2 || wTS != ts3 || !rOK || !wOK {
-			t.Errorf("expected %s %s; got %s %s; rOK=%t, wOK=%t", ts2, ts3, rTS, wTS, rOK, wOK)
+		rTS, rTxnID := tc.GetMaxRead(roachpb.Key("a"), nil)
+		wTS, wTxnID := tc.GetMaxWrite(roachpb.Key("a"), nil)
+		if rTS != ts2 || wTS != ts3 || rTxnID != txn1ID || wTxnID != txn2ID {
+			t.Errorf("expected (%s,%s) and (%s,%s); got (%s,%s) and (%s,%s)",
+				ts2, txn1ID, ts3, txn2ID, rTS, rTxnID, wTS, wTxnID)
 		}
 	})
 }
@@ -422,12 +423,12 @@ func TestTimestampCacheEqualTimestamps(t *testing.T) {
 		tc.add(roachpb.Key("b"), roachpb.Key("c"), ts1, txn2, true)
 
 		// When querying either side separately, the transaction ID is returned.
-		if ts, txn, _ := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("b")); ts != ts1 {
+		if ts, txn := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("b")); ts != ts1 {
 			t.Errorf("expected 'a'-'b' to have timestamp %s, but found %s", ts1, ts)
 		} else if txn != txn1 {
 			t.Errorf("expected 'a'-'b' to have txn id %s, but found %s", txn1, txn)
 		}
-		if ts, txn, _ := tc.GetMaxRead(roachpb.Key("b"), roachpb.Key("c")); ts != ts1 {
+		if ts, txn := tc.GetMaxRead(roachpb.Key("b"), roachpb.Key("c")); ts != ts1 {
 			t.Errorf("expected 'b'-'c' to have timestamp %s, but found %s", ts1, ts)
 		} else if txn != txn2 {
 			t.Errorf("expected 'b'-'c' to have txn id %s, but found %s", txn2, txn)
@@ -435,7 +436,7 @@ func TestTimestampCacheEqualTimestamps(t *testing.T) {
 
 		// Querying a span that overlaps both returns a nil txn ID; neither
 		// can proceed here.
-		if ts, txn, _ := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("c")); ts != ts1 {
+		if ts, txn := tc.GetMaxRead(roachpb.Key("a"), roachpb.Key("c")); ts != ts1 {
 			t.Errorf("expected 'a'-'c' to have timestamp %s, but found %s", ts1, ts)
 		} else if txn != (noTxnID) {
 			t.Errorf("expected 'a'-'c' to have zero txn id, but found %s", txn)

--- a/pkg/storage/tscache/tree_impl.go
+++ b/pkg/storage/tscache/tree_impl.go
@@ -563,8 +563,7 @@ func (tc *treeImpl) ExpandRequests(span roachpb.RSpan, timestamp hlc.Timestamp) 
 			// req.TxnID != nil because we only hit this code path for
 			// EndTransactionRequests.
 			key := keys.TransactionKey(req.Txn.Key, req.TxnID)
-			// We set txnID=nil because we want hits for same txn ID.
-			tc.add(key, nil, req.Timestamp, noTxnID, false /* readTSCache */)
+			tc.add(key, nil, req.Timestamp, req.TxnID, false /* readTSCache */)
 		}
 		req.release()
 	}
@@ -572,8 +571,8 @@ func (tc *treeImpl) ExpandRequests(span roachpb.RSpan, timestamp hlc.Timestamp) 
 
 // SetLowWater implements the Cache interface.
 func (tc *treeImpl) SetLowWater(start, end roachpb.Key, timestamp hlc.Timestamp) {
-	tc.add(start, end, timestamp, lowWaterTxnIDMarker, false)
-	tc.add(start, end, timestamp, lowWaterTxnIDMarker, true)
+	tc.add(start, end, timestamp, noTxnID, false)
+	tc.add(start, end, timestamp, noTxnID, true)
 }
 
 // GlobalLowWater implements the Cache interface.
@@ -614,7 +613,7 @@ func (tc *treeImpl) getMax(
 			maxTxnID = noTxnID
 		}
 	}
-	if maxTxnID == lowWaterTxnIDMarker {
+	if maxTxnID == noTxnID {
 		ok = false
 	}
 	return maxTS, maxTxnID, ok

--- a/pkg/storage/tscache/tree_impl_test.go
+++ b/pkg/storage/tscache/tree_impl_test.go
@@ -44,8 +44,8 @@ func TestTreeImplEviction(t *testing.T) {
 	tc.add(roachpb.Key("b"), nil, clock.Now(), noTxnID, true)
 
 	// Verify looking up key "c" returns the new low water mark ("a"'s timestamp).
-	if rTS, _, ok := tc.GetMaxRead(roachpb.Key("c"), nil); rTS != aTS || ok {
-		t.Errorf("expected low water mark %s, got %s; ok=%t", aTS, rTS, ok)
+	if rTS, rTxnID := tc.GetMaxRead(roachpb.Key("c"), nil); rTS != aTS || rTxnID != noTxnID {
+		t.Errorf("expected low water mark %s, got %s; txnID=%s", aTS, rTS, rTxnID)
 	}
 }
 


### PR DESCRIPTION
Refactoring that simplifies #19508.

This is subtle, but I'm pretty confident it's correct. I split the change into
two commits, each of which I found easier to convince myself about in isolation.

The first of two changes removes `lowWaterTxnIDMarker` and uses `noTxnID` in its
place. To do this, it changes the semantics of the flag returned from
`GetMaxRead/GetMaxWrite` from returning whether the interval found is "not the
low-water mark" to returning whether the interval found "has a non-empty txnID".
This is ok, because the only difference between an interval having an empty
txnID and an interval being part of the low-water mark is that an interval with
an empty txnID could have also been created by two requests with different
txnIDs conflicting at the same timestamp or a request with no txnID to begin
with. However, the only consumer of this flag was looking at `TransactionKeys`,
which should only ever be accessed by a single txnID. This means that in the
only case where the flag was used, the two semantics are equivalent.However, to
take advantage of this, the change needed to give the `TransactionKey` timestamp
interval its `TxnID`, something we had not done before for historical reasons
(`GetMaxRead/GetMaxWrite` used to take a `TxnID` that it should ignore).

The next change takes advantage of the previous simplification to remove the
flag returned from `GetMaxRead/GetMaxWrite` completely. This removes a major
subtlety in the interface and makes it easier to implement.