### PR TITLE
sqlccl: don’t include system tables in all BACKUPs

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -66,14 +66,6 @@ var backupOptionExpectValues = map[string]bool{
 // to durable storage.
 var BackupCheckpointInterval = time.Minute
 
-// BackupImplicitSQLDescriptors are descriptors for tables that are implicitly
-// included in every backup, plus their parent database descriptors.
-var BackupImplicitSQLDescriptors = []sqlbase.Descriptor{
-	*sqlbase.WrapDescriptor(&sqlbase.SystemDB),
-	*sqlbase.WrapDescriptor(&sqlbase.DescriptorTable),
-	*sqlbase.WrapDescriptor(&sqlbase.UsersTable),
-}
-
 // exportStorageFromURI returns an ExportStorage for the given URI.
 func exportStorageFromURI(
 	ctx context.Context, uri string, settings *cluster.Settings,
@@ -368,8 +360,6 @@ func resolveTargetsToDescriptors(
 	if sqlDescs, _, err = descriptorsMatchingTargets(sessionDatabase, sqlDescs, targets); err != nil {
 		return nil, err
 	}
-
-	sqlDescs = append(sqlDescs, BackupImplicitSQLDescriptors...)
 
 	// Dedupe. Duplicate descriptors will cause restore to fail.
 	{

--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -407,9 +407,6 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 			sanitizedIncDir, sanitizedFullDir,
 		),
 		DescriptorIDs: sqlbase.IDs{
-			keys.SystemDatabaseID,
-			keys.DescriptorTableID,
-			keys.UsersTableID,
 			sqlbase.ID(backupDatabaseID),
 			sqlbase.ID(backupTableID),
 		},
@@ -1869,7 +1866,7 @@ func TestTimestampMismatch(t *testing.T) {
 func TestBackupLevelDB(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	_, _, sqlDB, rawDir, cleanupFn := backupRestoreTestSetup(t, singleNode, 0, initNone)
+	_, _, sqlDB, rawDir, cleanupFn := backupRestoreTestSetup(t, singleNode, 1, initNone)
 	defer cleanupFn()
 
 	_ = sqlDB.Exec(`BACKUP DATABASE data TO $1`, localFoo)


### PR DESCRIPTION
This removes the automatic inclusion of the system.users and system.descriptors table in all backups.

Prior to this change, these tables were implicitly included in all backups, with the hope that if RESTORE later learned to use them for something (like restoring users and grants), they’d be available. 

However including them in their entirety could surprise a user: if they make a backup of some table or db, they may assume that the backup only includes information about that table or DB and, if they were to share it with someone else, and could be unpleasantly surprised to find it included all their table schemas and all cluster users with their hashed passwords.

These tables _can_ be easily included in their entirety in a backup if desired, simply by including e.g. `system.users` in the BACKUP command, which should also make clearer what data ends up in the resulting backup.


Release Note: BACKUPs no longer automatically include the system.users and system.descriptor table.