### PR TITLE
server: turn off more tracebacks during tests

### DIFF
--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -245,6 +245,10 @@ func TestClusterVersionMixedVersionTooOld(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
+	// Prevent node crashes from generating several megabytes of stacks when
+	// GOTRACEBACK=all, as it is on CI.
+	defer log.DisableTracebacks()()
+
 	exits := make(chan int, 100)
 
 	log.SetExitFunc(func(i int) { exits <- i })
@@ -292,11 +296,11 @@ func TestClusterVersionMixedVersionTooNew(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	exits := make(chan int, 100)
-
 	// Prevent node crashes from generating several megabytes of stacks when
 	// GOTRACEBACK=all, as it is on CI.
 	defer log.DisableTracebacks()()
+
+	exits := make(chan int, 100)
 
 	log.SetExitFunc(func(i int) { exits <- i })
 	defer log.SetExitFunc(os.Exit)


### PR DESCRIPTION
43045a54 turned off stack traces in
TestClusterVersionMixedVersionTooNew, but forgot to turn them off in
TestClusterVersionMixedVersionTooOld, which suffers from the same
problem.

Also shuffle some code in TestClusterVersionMixedVersionTooNew to avoid
separating the declaration of exits from its first use.