### PR TITLE
gitattributes: remove non-versioned sql/parser files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
 *.ir.* -diff
 *.pb.* -diff
 pkg/sql/ir/parser/irgen/irgen.go -diff
-pkg/sql/parser/help_messages.go -diff
-pkg/sql/parser/sql.go -diff


### PR DESCRIPTION
Since #19964, generated code in sql/parser is no longer checked into
version control. Remove the relevant files from .gitattributes.