### PR TITLE
sql: silence monotonic insert test on CI

### DIFF
--- a/pkg/sql/tests/monotonic_insert_test.go
+++ b/pkg/sql/tests/monotonic_insert_test.go
@@ -79,6 +79,8 @@ type mtClient struct {
 //   https://github.com/jepsen-io/jepsen/blob/master/cockroachdb/src/jepsen/cockroach/monotonic.clj
 func TestMonotonicInserts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	s := log.Scope(t)
+	defer s.Close(t)
 
 	for _, distSQLMode := range []sql.DistSQLExecMode{sql.DistSQLOff, sql.DistSQLOn} {
 		t.Run(fmt.Sprintf("distsql=%s", distSQLMode), func(t *testing.T) {


### PR DESCRIPTION
This test generates 2MB of logs. Silence it unless logging verbosely.

@tschottdorf @jordanlewis mentioned that, at some point in the past, we wanted this test to be verbose by default to debug failures. It seems _much_ more reliable these days, so is it safe to suppress its two megs of output?