### PR TITLE
build: remove MAINTAINERs from Dockerfiles

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:xenial-20170915
 
-MAINTAINER Tamir Duberstein <tamird@gmail.com>
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-transport-https \
     ca-certificates \

--- a/build/deploy/Dockerfile
+++ b/build/deploy/Dockerfile
@@ -1,7 +1,5 @@
 FROM debian:8.9
 
-MAINTAINER Tobias Schottdorf <tobias.schottdorf@gmail.com>
-
 # Install root CAs so we can make SSL connections to phone home and
 # do backups to GCE/AWS/Azure.
 RUN apt-get update && \

--- a/build/deploy/rhel/Dockerfile
+++ b/build/deploy/rhel/Dockerfile
@@ -1,7 +1,5 @@
 FROM registry.access.redhat.com/rhel-atomic:latest
 
-MAINTAINER Alex Robinson <alex@cockroachlabs.com>
-
 LABEL name="cockroachdb/cockroach" \
       vendor="Cockroach Labs" \
       version="1.1.2" \


### PR DESCRIPTION
MAINTAINERs are deprecated in favor of `LABEL maintainer`, but they seem
pretty useless, so just remove them entirely.