### PR TITLE
Makefile: fix syntax error in `make lint` warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ generate: ## Regenerate generated code.
 .PHONY: lint
 lint: override TAGS += lint
 lint: ## Run all style checkers and linters.
-	@if [ -t 1 ]; then DO echo $(shell tput setaf 6 2>/dev/null)NOTE: make lint is very slow! perhaps try make lintshort$(shell tput sgr0 2>/dev/null); fi
+	@if [ -t 1 ]; then tput setaf 3 2>/dev/null; echo 'NOTE: `make lint` is very slow! Perhaps `make lintshort`?'; tput sgr0 2>/dev/null; fi
 	$(XGO) test ./build -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run 'TestStyle/$(TESTS)'
 
 .PHONY: lintshort


### PR DESCRIPTION
`DO` is not a Bash keyword. (Well, at least not where it appears here.)
Fix it up. Also take the opportunity to make the warning consistent with
other diagnostics printed by our Makefile.