### PR TITLE
sql: IndexedVars no longer need a container ptr

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -1212,7 +1212,7 @@ func newReadCSVProcessor(
 		output:     output,
 		settings:   flowCtx.Settings,
 	}
-	if err := cp.out.Init(&distsqlrun.PostProcessSpec{}, csvOutputTypes, &flowCtx.EvalCtx, output); err != nil {
+	if err := cp.out.Init(&distsqlrun.PostProcessSpec{}, csvOutputTypes, flowCtx.NewEvalCtx(), output); err != nil {
 		return nil, err
 	}
 	return cp, nil
@@ -1367,7 +1367,7 @@ func newSSTWriterProcessor(
 		tempStorage:   flowCtx.TempStorage,
 		settings:      flowCtx.Settings,
 	}
-	if err := sp.out.Init(&distsqlrun.PostProcessSpec{}, sstOutputTypes, &flowCtx.EvalCtx, output); err != nil {
+	if err := sp.out.Init(&distsqlrun.PostProcessSpec{}, sstOutputTypes, flowCtx.NewEvalCtx(), output); err != nil {
 		return nil, err
 	}
 	return sp, nil

--- a/pkg/sql/analyze.go
+++ b/pkg/sql/analyze.go
@@ -1715,12 +1715,14 @@ func (p *planner) analyzeExpr(
 
 	// Type check.
 	var typedExpr tree.TypedExpr
+	p.semaCtx.IVarHelper = &iVarHelper
 	if requireType {
 		typedExpr, err = tree.TypeCheckAndRequire(resolved, &p.semaCtx,
 			expectedType, typingContext)
 	} else {
 		typedExpr, err = tree.TypeCheck(resolved, &p.semaCtx, expectedType)
 	}
+	p.semaCtx.IVarHelper = nil
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -935,21 +935,32 @@ func (src *dataSourceInfo) findTableAlias(colIdx int) (tree.TableName, bool) {
 	return anonymousTable, false
 }
 
-func (src *dataSourceInfo) FormatVar(buf *bytes.Buffer, f tree.FmtFlags, colIdx int) {
-	if f.ShowTableAliases {
-		tableAlias, found := src.findTableAlias(colIdx)
-		if found {
-			if tableAlias.TableName != "" {
-				if tableAlias.DatabaseName != "" {
-					tree.FormatNode(buf, f, tableAlias.DatabaseName)
-					buf.WriteByte('.')
-				}
-				tree.FormatNode(buf, f, tableAlias.TableName)
-				buf.WriteByte('.')
-			}
-		} else {
-			buf.WriteString("_.")
+type varFormatter struct {
+	TableName  tree.TableName
+	ColumnName tree.Name
+}
+
+// Format implements the NodeFormatter interface.
+func (c *varFormatter) Format(buf *bytes.Buffer, f tree.FmtFlags) {
+	if f.ShowTableAliases && c.TableName.TableName != "" {
+		if c.TableName.DatabaseName != "" {
+			tree.FormatNode(buf, f, c.TableName.DatabaseName)
+			buf.WriteByte('.')
 		}
+
+		tree.FormatNode(buf, f, c.TableName.TableName)
+		buf.WriteByte('.')
 	}
-	tree.Name(src.sourceColumns[colIdx].Name).Format(buf, f)
+	tree.FormatNode(buf, f, c.ColumnName)
+}
+
+// NodeFormatter returns a tree.NodeFormatter that, when formatted,
+// represents the object at the input column index.
+func (src *dataSourceInfo) NodeFormatter(colIdx int) tree.NodeFormatter {
+	var ret varFormatter
+	ret.ColumnName = tree.Name(src.sourceColumns[colIdx].Name)
+	if tableAlias, found := src.findTableAlias(colIdx); found {
+		ret.TableName = tableAlias
+	}
+	return &ret
 }

--- a/pkg/sql/distsqlplan/aggregator_funcs.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs.go
@@ -15,7 +15,6 @@
 package distsqlplan
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
@@ -226,7 +225,8 @@ var DistAggregationTable = map[distsqlrun.AggregatorSpec_Func]DistAggregationInf
 					Type: coltypes.NewFloat(0 /* prec */, false /* precSpecified */),
 				}
 			}
-			return expr.TypeCheck(nil, types.Any)
+			ctx := &tree.SemaContext{IVarHelper: h}
+			return expr.TypeCheck(ctx, types.Any)
 		},
 	},
 
@@ -294,8 +294,8 @@ func (tc *typeContainer) IndexedVarResolvedType(idx int) types.T {
 	return tc.types[idx].ToDatumType()
 }
 
-func (tc *typeContainer) IndexedVarFormat(buf *bytes.Buffer, f tree.FmtFlags, idx int) {
-	fmt.Fprintf(buf, "@%d", idx+1)
+func (tc *typeContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
+	return tree.Name(fmt.Sprintf("$%d", idx+1))
 }
 
 // MakeTypeIndexedVarHelper returns an IndexedVarHelper which creates IndexedVars

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -165,7 +165,7 @@ func newAggregator(
 
 		ag.outputTypes[i] = retType
 	}
-	if err := ag.out.Init(post, ag.outputTypes, &flowCtx.EvalCtx, output); err != nil {
+	if err := ag.init(post, ag.outputTypes, flowCtx, output); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/distsqlrun/algebraic_set_op.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op.go
@@ -76,7 +76,7 @@ func newAlgebraicSetOp(
 	}
 
 	e.types = lt
-	err := e.out.Init(post, e.types, &flowCtx.EvalCtx, output)
+	err := e.init(post, e.types, flowCtx, output)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -87,7 +87,7 @@ func (cb *columnBackfiller) init() error {
 		}
 	}
 	defaultExprs, err := sqlbase.MakeDefaultExprs(
-		cb.added, &transform.ExprTransformContext{}, &cb.flowCtx.EvalCtx,
+		cb.added, &transform.ExprTransformContext{}, cb.flowCtx.NewEvalCtx(),
 	)
 	if err != nil {
 		return err
@@ -210,7 +210,7 @@ func (cb *columnBackfiller) runChunk(
 			// Evaluate the new values. This must be done separately for
 			// each row so as to handle impure functions correctly.
 			for j, e := range cb.updateExprs {
-				val, err := e.Eval(&cb.flowCtx.EvalCtx)
+				val, err := e.Eval(cb.flowCtx.NewEvalCtx())
 				if err != nil {
 					return sqlbase.NewInvalidSchemaDefinitionError(err)
 				}

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -58,7 +58,7 @@ func newDistinct(
 	}
 
 	d.types = input.Types()
-	if err := d.out.Init(post, d.types, &flowCtx.EvalCtx, output); err != nil {
+	if err := d.init(post, d.types, flowCtx, output); err != nil {
 		return nil, err
 	}
 
@@ -152,9 +152,10 @@ func (d *distinct) matchLastGroupKey(row sqlbase.EncDatumRow) (bool, error) {
 	if d.lastGroupKey == nil {
 		return false, nil
 	}
+	evalCtx := d.flowCtx.NewEvalCtx()
 	for colIdx := range d.orderedCols {
 		res, err := d.lastGroupKey[colIdx].Compare(
-			&d.types[colIdx], &d.datumAlloc, &d.flowCtx.EvalCtx, &row[colIdx],
+			&d.types[colIdx], &d.datumAlloc, evalCtx, &row[colIdx],
 		)
 		if res != 0 || err != nil {
 			return false, err

--- a/pkg/sql/distsqlrun/expr_test.go
+++ b/pkg/sql/distsqlrun/expr_test.go
@@ -15,7 +15,6 @@
 package distsqlrun
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 
@@ -34,8 +33,8 @@ func (d testVarContainer) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.D
 	return nil, nil
 }
 
-func (d testVarContainer) IndexedVarFormat(buf *bytes.Buffer, _ tree.FmtFlags, idx int) {
-	fmt.Fprintf(buf, "var%d", idx)
+func (d testVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
+	return tree.Name(fmt.Sprintf("var%d", idx))
 }
 
 func TestProcessExpression(t *testing.T) {

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -58,6 +58,9 @@ type FlowCtx struct {
 	// id is a unique identifier for a flow.
 	id FlowID
 	// EvalCtx is used by all the processors in the flow to evaluate expressions.
+	// Processors that intend to evaluate expressions with this EvalCtx should
+	// get a copy with NewEvalCtx instead of storing a pointer to this one
+	// directly.
 	EvalCtx tree.EvalContext
 	// rpcCtx is used by the Outboxes that may be present in the flow for
 	// connecting to other nodes.
@@ -83,6 +86,18 @@ type FlowCtx struct {
 
 	// JobRegistry is used during backfill to load jobs which keep state.
 	JobRegistry *jobs.Registry
+}
+
+// NewEvalCtx returns a modifiable copy of the FlowCtx's EvalContext.
+// Processors should use this method any time they need to store a pointer to
+// the EvalContext, since processors may mutate the EvalContext. Specifically,
+// every processor that runs ProcOutputHelper.Init must pass in a modifiable
+// EvalContext, since it stores that EvalContext in its exprHelpers and mutates
+// them at runtime to ensure expressions are evaluated with the correct indexed
+// var context.
+func (ctx *FlowCtx) NewEvalCtx() *tree.EvalContext {
+	evalCtx := ctx.EvalCtx
+	return &evalCtx
 }
 
 type flowStatus int

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -185,8 +185,9 @@ func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 		rowContainerMon = &limitedMon
 	}
 
-	h.rows[leftSide].initWithMon(nil /* ordering */, h.leftSource.Types(), &h.flowCtx.EvalCtx, rowContainerMon)
-	h.rows[rightSide].initWithMon(nil /* ordering */, h.rightSource.Types(), &h.flowCtx.EvalCtx, rowContainerMon)
+	evalCtx := h.flowCtx.NewEvalCtx()
+	h.rows[leftSide].initWithMon(nil /* ordering */, h.leftSource.Types(), evalCtx, rowContainerMon)
+	h.rows[rightSide].initWithMon(nil /* ordering */, h.rightSource.Types(), evalCtx, rowContainerMon)
 	defer h.rows[leftSide].Close(ctx)
 	defer h.rows[rightSide].Close(ctx)
 

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -91,10 +91,11 @@ func (jb *joinerBase) init(
 	types = append(types, leftTypes...)
 	types = append(types, rightTypes...)
 
-	if err := jb.onCond.init(onExpr, types, &flowCtx.EvalCtx); err != nil {
+	evalCtx := flowCtx.NewEvalCtx()
+	if err := jb.onCond.init(onExpr, types, evalCtx); err != nil {
 		return err
 	}
-	return jb.out.Init(post, types, &flowCtx.EvalCtx, output)
+	return jb.out.Init(post, types, evalCtx, output)
 }
 
 type joinSide uint8

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -187,9 +187,11 @@ func (jb *joinerBase) render(lrow, rrow sqlbase.EncDatumRow) (sqlbase.EncDatumRo
 	}
 	jb.combinedRow = append(jb.combinedRow, lrow...)
 	jb.combinedRow = append(jb.combinedRow, rrow...)
-	res, err := jb.onCond.evalFilter(jb.combinedRow)
-	if !res || err != nil {
-		return nil, err
+	if jb.onCond.expr != nil {
+		res, err := jb.onCond.evalFilter(jb.combinedRow)
+		if !res || err != nil {
+			return nil, err
+		}
 	}
 	return jb.combinedRow, nil
 }

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -72,7 +72,7 @@ func newJoinReader(
 		types[i] = spec.Table.Columns[i].Type
 	}
 
-	if err := jr.out.Init(post, types, &flowCtx.EvalCtx, output); err != nil {
+	if err := jr.init(post, types, flowCtx, output); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -322,6 +322,12 @@ func (pb *processorBase) OutputTypes() []sqlbase.ColumnType {
 	return pb.out.outputTypes
 }
 
+func (pb *processorBase) init(
+	post *PostProcessSpec, types []sqlbase.ColumnType, flowCtx *FlowCtx, output RowReceiver,
+) error {
+	return pb.out.Init(post, types, flowCtx.NewEvalCtx(), output)
+}
+
 // noopProcessor is a processor that simply passes rows through from the
 // synchronizer to the post-processing stage. It can be useful for its
 // post-processing or in the last stage of a computation, where we may only
@@ -339,7 +345,7 @@ func newNoopProcessor(
 	flowCtx *FlowCtx, input RowSource, post *PostProcessSpec, output RowReceiver,
 ) (*noopProcessor, error) {
 	n := &noopProcessor{flowCtx: flowCtx, input: input}
-	if err := n.out.Init(post, input.Types(), &flowCtx.EvalCtx, output); err != nil {
+	if err := n.init(post, input.Types(), flowCtx, output); err != nil {
 		return nil, err
 	}
 	return n, nil

--- a/pkg/sql/distsqlrun/routers.go
+++ b/pkg/sql/distsqlrun/routers.go
@@ -193,7 +193,7 @@ func (rb *routerBase) init(flowCtx *FlowCtx, types []sqlbase.ColumnType) {
 	for i := range rb.outputs {
 		// This method must be called before we start() so we don't need
 		// to take the mutex.
-		rb.outputs[i].mu.rowContainer.init(nil /* ordering */, types, &flowCtx.EvalCtx)
+		rb.outputs[i].mu.rowContainer.init(nil /* ordering */, types, flowCtx.NewEvalCtx())
 		// Initialize any outboxes.
 		if o, ok := rb.outputs[i].stream.(*outbox); ok {
 			o.init(types)

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -106,7 +106,7 @@ func newSamplerProcessor(
 	outTypes = append(outTypes, sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BYTES})
 	s.outTypes = outTypes
 
-	if err := s.out.Init(post, outTypes, &flowCtx.EvalCtx, output); err != nil {
+	if err := s.init(post, outTypes, flowCtx, output); err != nil {
 		return nil, err
 	}
 	return s, nil

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -69,7 +69,7 @@ func newSorter(
 		count:       count,
 		tempStorage: flowCtx.TempStorage,
 	}
-	if err := s.out.Init(post, input.Types(), &flowCtx.EvalCtx, output); err != nil {
+	if err := s.init(post, input.Types(), flowCtx, output); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -114,7 +114,7 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 		rowContainerMon = &limitedMon
 	}
-	sv.initWithMon(s.ordering, s.rawInput.Types(), &s.flowCtx.EvalCtx, rowContainerMon)
+	sv.initWithMon(s.ordering, s.rawInput.Types(), s.flowCtx.NewEvalCtx(), rowContainerMon)
 	// Construct the optimal sorterStrategy.
 	var ss sorterStrategy
 	if s.matchLen == 0 {

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -95,7 +95,7 @@ func newTableReader(
 	for i := range types {
 		types[i] = spec.Table.Columns[i].Type
 	}
-	if err := tr.out.Init(post, types, &flowCtx.EvalCtx, output); err != nil {
+	if err := tr.init(post, types, flowCtx, output); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -47,7 +47,7 @@ func newValuesProcessor(
 	for i := range v.columns {
 		types[i] = v.columns[i].Type
 	}
-	if err := v.out.Init(post, types, &flowCtx.EvalCtx, output); err != nil {
+	if err := v.init(post, types, flowCtx, output); err != nil {
 		return nil, err
 	}
 	return v, nil

--- a/pkg/sql/expr_filter_test.go
+++ b/pkg/sql/expr_filter_test.go
@@ -122,7 +122,7 @@ func TestSplitFilter(t *testing.T) {
 		t.Run(fmt.Sprintf("%s~(%s, %s)", d.expr, d.expectedRes, d.expectedRem), func(t *testing.T) {
 			evalCtx := tree.NewTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
-			sel := makeSelectNode(t)
+			sel := makeSelectNode(t, evalCtx)
 			// A function that "converts" only vars in the list.
 			conv := func(expr tree.VariableExpr) (bool, tree.Expr) {
 				iv := expr.(*tree.IndexedVar)
@@ -205,7 +205,7 @@ func TestExtractNotNullConstraints(t *testing.T) {
 			evalCtx := tree.NewTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
 
-			sel := makeSelectNode(t)
+			sel := makeSelectNode(t, evalCtx)
 			expr := parseAndNormalizeExpr(t, evalCtx, tc.expr, sel)
 			result := extractNotNullConstraints(expr)
 			var expected util.FastIntSet

--- a/pkg/sql/group_test.go
+++ b/pkg/sql/group_test.go
@@ -50,8 +50,8 @@ func TestDesiredAggregateOrder(t *testing.T) {
 	for _, d := range testData {
 		evalCtx := tree.NewTestingEvalContext()
 		defer evalCtx.Stop(context.Background())
-		sel := makeSelectNode(t)
-		expr := parseAndNormalizeExpr(t, &p.evalCtx, d.expr, sel)
+		sel := makeSelectNode(t, evalCtx)
+		expr := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
 		group := &groupNode{planner: p}
 		render := &renderNode{planner: p}
 		postRender := &renderNode{planner: p}

--- a/pkg/sql/index_selection_test.go
+++ b/pkg/sql/index_selection_test.go
@@ -326,7 +326,7 @@ func TestMakeConstraints(t *testing.T) {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
 			evalCtx := tree.NewTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
-			sel := makeSelectNode(t)
+			sel := makeSelectNode(t, evalCtx)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, _ := makeConstraints(t, evalCtx, d.expr, desc, index, sel)
 			if s := constraints.String(); d.expected != s {
@@ -534,7 +534,7 @@ func TestMakeSpans(t *testing.T) {
 			t.Run(d.expr+"~"+expected, func(t *testing.T) {
 				evalCtx := tree.NewTestingEvalContext()
 				defer evalCtx.Stop(context.Background())
-				sel := makeSelectNode(t)
+				sel := makeSelectNode(t, evalCtx)
 				columns := strings.Split(d.columns, ",")
 				dirs := make([]encoding.Direction, 0, len(columns))
 				for range columns {
@@ -583,7 +583,7 @@ func TestMakeSpans(t *testing.T) {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
 			evalCtx := tree.NewTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
-			sel := makeSelectNode(t)
+			sel := makeSelectNode(t, evalCtx)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, _ := makeConstraints(t, evalCtx, d.expr, desc, index, sel)
 			spans, err := makeSpans(evalCtx, constraints, desc, index)
@@ -674,7 +674,7 @@ func TestExactPrefix(t *testing.T) {
 		t.Run(fmt.Sprintf("%s~%d", d.expr, d.expected), func(t *testing.T) {
 			evalCtx := tree.NewTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
-			sel := makeSelectNode(t)
+			sel := makeSelectNode(t, evalCtx)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, _ := makeConstraints(t, evalCtx, d.expr, desc, index, sel)
 			prefix := constraints.exactPrefix(evalCtx)
@@ -751,7 +751,7 @@ func TestApplyConstraints(t *testing.T) {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
 			evalCtx := tree.NewTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
-			sel := makeSelectNode(t)
+			sel := makeSelectNode(t, evalCtx)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, expr := makeConstraints(t, evalCtx, d.expr, desc, index, sel)
 			expr2 := applyIndexConstraints(evalCtx, expr, constraints)

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -394,7 +394,9 @@ func (p *planner) makeJoin(
 				},
 			}
 			var err error
+			p.semaCtx.IVarHelper = &r.ivarHelper
 			expr, err = c.TypeCheck(&p.semaCtx, types.Any)
+			p.semaCtx.IVarHelper = nil
 			if err != nil {
 				return planDataSource{}, err
 			}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -15,7 +15,6 @@
 package sql
 
 import (
-	"bytes"
 	"fmt"
 	"sync"
 
@@ -185,6 +184,7 @@ func (n *scanNode) Next(params runParams) (bool, error) {
 		if err != nil || n.row == nil {
 			return false, err
 		}
+		n.p.evalCtx.IVarHelper = &n.filterVars
 		passesFilter, err := sqlbase.RunFilter(n.filter, &n.p.evalCtx)
 		if err != nil {
 			return false, err
@@ -436,8 +436,8 @@ func (n *scanNode) IndexedVarResolvedType(idx int) types.T {
 	return n.resultColumns[idx].Typ
 }
 
-func (n *scanNode) IndexedVarFormat(buf *bytes.Buffer, f tree.FmtFlags, idx int) {
-	tree.Name(n.resultColumns[idx].Name).Format(buf, f)
+func (n *scanNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
+	return tree.Name(n.resultColumns[idx].Name)
 }
 
 // scanVisibility represents which table columns should be included in a scan.

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -28,8 +28,7 @@ import (
 const invalidSrcIdx = -1
 
 // invalidColIdx is the colIdx value returned by findColumn() when there is no match.
-// We reuse the value from tree.InvalidColIdx because its meaning is the same.
-const invalidColIdx = tree.InvalidColIdx
+const invalidColIdx = -1
 
 // nameResolutionVisitor is a tree.Visitor implementation used to
 // resolve the column names in an expression.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2068,6 +2068,8 @@ type EvalContext struct {
 	// underlying datum, if available.
 	Placeholders *PlaceholderInfo
 
+	IVarHelper *IndexedVarHelper
+
 	// CtxProvider holds the context in which the expression is evaluated. This
 	// will point to the session, which is itself a provider of contexts.
 	// NOTE: seems a bit lazy to hold a pointer to the session's context here,

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -34,7 +34,7 @@ type fmtFlags struct {
 	// indexedVarFormat is an optional interceptor for
 	// IndexedVarContainer.IndexedVarFormat calls; it can be used to
 	// customize the formatting of IndexedVars.
-	indexedVarFormat func(buf *bytes.Buffer, f FmtFlags, c IndexedVarContainer, idx int)
+	indexedVarFormat func(buf *bytes.Buffer, idx int)
 	// placeholderFormat is an optional interceptor for Placeholder.Format calls;
 	// it can be used to format placeholders differently than normal.
 	placeholderFormat func(buf *bytes.Buffer, f FmtFlags, p *Placeholder)
@@ -145,9 +145,7 @@ func FmtExpr(base FmtFlags, showTypes bool, symbolicVars bool, showTableAliases 
 
 // FmtIndexedVarFormat returns FmtFlags that customizes the printing of
 // IndexedVars using the provided function.
-func FmtIndexedVarFormat(
-	base FmtFlags, fn func(buf *bytes.Buffer, f FmtFlags, c IndexedVarContainer, idx int),
-) FmtFlags {
+func FmtIndexedVarFormat(base FmtFlags, fn func(buf *bytes.Buffer, idx int)) FmtFlags {
 	f := *base
 	f.indexedVarFormat = fn
 	return &f

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -33,6 +33,8 @@ type SemaContext struct {
 	// Placeholders relates placeholder names to their type and, later, value.
 	Placeholders PlaceholderInfo
 
+	IVarHelper *IndexedVarHelper
+
 	// Location references the *Location on the current Session.
 	Location **time.Location
 

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -208,7 +208,7 @@ func (p *planner) orderBy(
 			}
 
 			// ORDER BY (a, b) -> ORDER BY a, b
-			cols, exprs = flattenTuples(cols, exprs)
+			cols, exprs = flattenTuples(cols, exprs, &s.ivarHelper)
 
 			colIdxs := s.addOrReuseRenders(cols, exprs, true)
 			for i := 0; i < len(colIdxs)-1; i++ {
@@ -243,7 +243,7 @@ func (p *planner) orderBy(
 
 // flattenTuples extracts the members of tuples into a list of columns.
 func flattenTuples(
-	cols sqlbase.ResultColumns, exprs []tree.TypedExpr,
+	cols sqlbase.ResultColumns, exprs []tree.TypedExpr, ivarHelper *tree.IndexedVarHelper,
 ) (sqlbase.ResultColumns, []tree.TypedExpr) {
 	// We want to avoid allocating new slices unless strictly necessary.
 	var newExprs []tree.TypedExpr
@@ -258,7 +258,7 @@ func flattenTuples(
 				copy(newCols, cols[:i])
 			}
 
-			newCols, newExprs = flattenTuple(t, newCols, newExprs)
+			newCols, newExprs = flattenTuple(t, newCols, newExprs, ivarHelper)
 		} else if newExprs != nil {
 			newExprs = append(newExprs, e)
 			newCols = append(newCols, cols[i])
@@ -272,16 +272,19 @@ func flattenTuples(
 
 // flattenTuple extracts the members of one tuple into a list of columns.
 func flattenTuple(
-	t *tree.Tuple, cols sqlbase.ResultColumns, exprs []tree.TypedExpr,
+	t *tree.Tuple,
+	cols sqlbase.ResultColumns,
+	exprs []tree.TypedExpr,
+	ivarHelper *tree.IndexedVarHelper,
 ) (sqlbase.ResultColumns, []tree.TypedExpr) {
 	for _, e := range t.Exprs {
 		if eT, ok := e.(*tree.Tuple); ok {
-			cols, exprs = flattenTuple(eT, cols, exprs)
+			cols, exprs = flattenTuple(eT, cols, exprs, ivarHelper)
 		} else {
 			expr := e.(tree.TypedExpr)
 			exprs = append(exprs, expr)
 			cols = append(cols, sqlbase.ResultColumn{
-				Name: e.String(),
+				Name: expr.String(),
 				Typ:  expr.ResolvedType(),
 			})
 		}

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -39,7 +39,7 @@ func (p *planner) computeRender(
 	// column name, we determine the name before we perform any manipulations to
 	// the expression.
 	if outputName == autoGenerateRenderOutputName {
-		if outputName, err = getRenderColName(p.session.SearchPath, target); err != nil {
+		if outputName, err = getRenderColName(p.session.SearchPath, target, &ivarHelper); err != nil {
 			return sqlbase.ResultColumn{}, nil, err
 		}
 	}

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -332,6 +332,7 @@ func (n *windowNode) replaceIndexVarsAndAggFuncs(s *renderNode) {
 		sourceInfo:              s.sourceInfo[0],
 	}
 	ivarHelper := tree.MakeIndexedVarHelper(&n.colContainer, s.ivarHelper.NumVars())
+	n.ivarHelper = &ivarHelper
 
 	n.aggContainer = windowNodeAggContainer{
 		windowNodeIvarContainer: makeWindowNodeIvarContainer(n),
@@ -352,7 +353,10 @@ func (n *windowNode) replaceIndexVarsAndAggFuncs(s *renderNode) {
 			case *tree.IndexedVar:
 				// We add a new render to the source renderNode for each new IndexedVar we
 				// see. We also register this mapping in the idxMap.
-				col := sqlbase.ResultColumn{Name: t.String(), Typ: t.ResolvedType()}
+				col := sqlbase.ResultColumn{
+					Name: t.String(),
+					Typ:  t.ResolvedType(),
+				}
 				colIdx := s.addOrReuseRender(col, t, true)
 				n.colContainer.idxMap[t.Idx] = colIdx
 				return nil, false, ivarHelper.IndexedVar(t.Idx)
@@ -456,6 +460,7 @@ type windowNode struct {
 	// to migrate IndexedVars and aggregate functions below the windowing level.
 	colContainer windowNodeColContainer
 	aggContainer windowNodeAggContainer
+	ivarHelper   *tree.IndexedVarHelper
 
 	windowsAcc WrappableMemoryAccount
 }
@@ -762,7 +767,9 @@ func (n *windowNode) populateValues(ctx context.Context) error {
 				}
 				// Instead, we evaluate the current window render, which depends on at least
 				// one window function, at the given row.
+				n.planner.evalCtx.IVarHelper = n.ivarHelper
 				res, err := curWindowRender.Eval(&n.planner.evalCtx)
+				n.planner.evalCtx.IVarHelper = nil
 				if err != nil {
 					return err
 				}
@@ -977,9 +984,10 @@ func (cc *windowNodeColContainer) IndexedVarResolvedType(idx int) types.T {
 	return cc.sourceInfo.sourceColumns[idx].Typ
 }
 
-// IndexedVarString implements the tree.IndexedVarContainer interface.
-func (cc *windowNodeColContainer) IndexedVarFormat(buf *bytes.Buffer, f tree.FmtFlags, idx int) {
-	cc.sourceInfo.FormatVar(buf, f, idx)
+// IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
+func (cc *windowNodeColContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
+	// Avoid duplicating the type annotation by calling .Format directly.
+	return cc.sourceInfo.NodeFormatter(idx)
 }
 
 // windowNodeAggContainer is a IndexedVarContainer providing indirection for
@@ -996,8 +1004,8 @@ func (ac *windowNodeAggContainer) IndexedVarResolvedType(idx int) types.T {
 	return ac.aggFuncs[idx].ResolvedType()
 }
 
-// IndexedVarString implements the tree.IndexedVarContainer interface.
-func (ac *windowNodeAggContainer) IndexedVarFormat(buf *bytes.Buffer, f tree.FmtFlags, idx int) {
+// IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
+func (ac *windowNodeAggContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	// Avoid duplicating the type annotation by calling .Format directly.
-	ac.aggFuncs[idx].Format(buf, f)
+	return ac.aggFuncs[idx]
 }


### PR DESCRIPTION
Previously, an `IndexedVar` stored a pointer to the
`IndexedVarContainer` that begat it. This is a troublesome violation of
the principle that expression types should be immutable. The trouble
manifests itself during projects that involve copying and modifying
plans, such as plan caching - changing plan nodes that implement the
`IndexedVarContainer` interface is impossible without a full expression
tree walk to reparent the `IndexedVars` onto the new container.

This patch:
- removes the container pointer from `IndexedVar`
- adds a `NodeFormatter` pointer to `IndexedVar`
- adds an `IndexedVarHelper` pointer to `SemaContext`
- adds an `IndexedVarHelper` pointer to `EvalContext`

Callers of `Eval` and `TypeCheck` now have the responsibility of passing
the correct `IndexedVarHelper` via the respective context.

Callers of `Format` don't have to pass an `IndexedVarHelper` because the
`IndexedVar` now carries an AST node from its creation time that can be
`Format`'d to produce its string representation. This was done because
there are too many callsites of `NodeFormatter.Format` to plumb
`IndexedVarHelper` instances to, mainly all of the places where errors
containing expressions are created.

Also, a couple of minor changes to distsql to facilitate this:

- don't bother trying to evaluate a join condition filter if it doesn't exist
- make copies of the `EvalContext` from `FlowCtx` instead of sharing one

cc @nvanbenschoten 