### PR TITLE
cloud: Improve kubernetes pod disruption budget

### DIFF
--- a/cloud/kubernetes/cockroachdb-client-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-client-secure.yaml
@@ -3,7 +3,7 @@ kind: Pod
 metadata:
   name: cockroachdb-client-secure
   labels:
-    app: cockroachdb
+    app: cockroachdb-client
 spec:
   initContainers:
   # The init-certs container sends a certificate signing request to the

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -64,7 +64,7 @@ spec:
   selector:
     matchLabels:
       app: cockroachdb
-  minAvailable: 67%
+  maxUnavailable: 1
 ---
 apiVersion: apps/v1beta1
 kind: StatefulSet

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -64,7 +64,7 @@ spec:
   selector:
     matchLabels:
       app: cockroachdb
-  minAvailable: 67%
+  maxUnavailable: 1
 ---
 apiVersion: apps/v1beta1
 kind: StatefulSet


### PR DESCRIPTION
Ensure that Kubernetes will try to make sure only one pod gets brought
down at a time regardless of how many pods are in the cluster. This
wasn't an option in the original release of PodDisruptionBudgets, but
has been an option for multiple releases now and more clearly reflects
our intent.

Change the label on the secure client pod to be different from the label
used by the cockroachdb nodes because otherwise it messes with the
enforcement of the disruption budget.