### PR TITLE
Makefile: suppress errors when tput fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ generate: ## Regenerate generated code.
 .PHONY: lint
 lint: override TAGS += lint
 lint: ## Run all style checkers and linters.
-	@if [ -t 1 ]; then tput setaf 3 2>/dev/null; echo 'NOTE: `make lint` is very slow! Perhaps `make lintshort`?'; tput sgr0 2>/dev/null; fi
+	@if [ -t 1 ]; then echo $$(tput setaf 3 2>/dev/null)'NOTE: `make lint` is very slow! Perhaps `make lintshort`?'$$(tput sgr0 2>/dev/null); fi
 	$(XGO) test ./build -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run 'TestStyle/$(TESTS)'
 
 .PHONY: lintshort


### PR DESCRIPTION
Some platforms only accept the termcap capability names, not the
terminfo ones. Rather than trying to find a compatible invocation, just
suppress errors when tput fails by using command substitution instead of
a command list.

Fix #19993.