### PR TITLE
Makefile: don't run benches during test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 PKG          := ./pkg/...## Which package to run tests against, e.g. "./pkg/storage".
 TAGS         :=
 TESTS        := .## Tests to run for use with `make test`.
-BENCHES      := -## Benchmarks to run for use with `make bench`.
+BENCHES      :=## Benchmarks to run for use with `make bench`.
 FILES        :=## Space delimited list of logic test files to run, for make testlogic.
 TESTTIMEOUT  := 4m## Test timeout to use for regular tests.
 RACETIMEOUT  := 25m## Test timeout to use for race tests.


### PR DESCRIPTION
`make testrace` got nearly twice as slow after 508aa37 landed. My
working hypothesis: specifying `-bench -` means `go test` has to run
every benchmark to look for matching subbenchmarks. This is arguably a
bug in `go test`, but it's easy enough not to pass the `-bench` flag at
all when we're not meaning to run benchmarks.