### PR TITLE
kv: fix local server optimization with --advertise-addr

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -293,7 +293,7 @@ func NewContext(
 // GetLocalInternalServerForAddr returns the context's internal batch server
 // for target, if it exists.
 func (ctx *Context) GetLocalInternalServerForAddr(target string) roachpb.InternalServer {
-	if target == ctx.Addr {
+	if target == ctx.AdvertiseAddr {
 		return ctx.localInternalServer
 	}
 	return nil


### PR DESCRIPTION
We were using `Addr` to match against our local addr, but should have been using AdvertiseAddr.

Fixes #19991.