### PR TITLE
build: Disable sshguard for jepsen tests

### DIFF
--- a/build/jepsen/terraform/main.tf
+++ b/build/jepsen/terraform/main.tf
@@ -178,6 +178,9 @@ resource "null_resource" "cockroach-runner" {
       "sudo apt-get -qqy upgrade -o Dpkg::Options::='--force-confold' >/dev/null",
       # Allow access to the cockroach instances from the Jepsen controller.
       "sudo cp ~/.ssh/authorized_keys2 /root/.ssh/authorized_keys2",
+      # The Jepsen controller does a lot of separate ssh commands which can
+      # trigger sshguard. Disable it.
+      "sudo service sshguard stop",
       # Download cockroach binary, zip so that Jepsen understands it
       "mkdir -p /tmp/cockroach",
       "[ $(stat --format=%s cockroach) -ne 0 ] || curl -sfSL https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.${var.cockroach_sha} -o cockroach",

--- a/build/teamcity-jepsen-run-one.sh
+++ b/build/teamcity-jepsen-run-one.sh
@@ -84,8 +84,7 @@ if timeout 20m ssh "${SSH_OPTIONS[@]}" "ubuntu@${controller}" "${testcmd}" \
 
     # Test passed. grab just the results file.
     progress "Test passed. Grabbing minimal logs..."
-    # TODO(bdarnell): remove -v's
-    scp "${SSH_OPTIONS[@]}" -C -r -v -v -v \
+    scp "${SSH_OPTIONS[@]}" -C -r \
         "ubuntu@${controller}:jepsen/cockroachdb/store/latest/{test.fressian,results.edn,latency-quantiles.png,latency-raw.png,rate.png}" \
         "${artifacts_dir}"
 


### PR DESCRIPTION
Jepsen does a lot of separate ssh commands (especially now that the
skew nemesis is enabled), which sometimes triggers sshguard.

Fixes #19994