### PR TITLE
Revert "sql: Support SELECT FOR UPDATE SQL syntax"

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -150,8 +150,7 @@ func (p *planner) validateCheckExpr(
 	// use the tableDesc we have, but this is a rare operation and be benefit
 	// would be marginal compared to the work of the actual query, so the added
 	// complexity seems unjustified.
-	rows, err := p.SelectClause(ctx, sel, nil /* orderBy */, lim, false, /* lockForUpdate */
-		nil /* desiredTypes */, publicColumns)
+	rows, err := p.SelectClause(ctx, sel, nil, lim, nil, publicColumns)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -96,8 +96,7 @@ func (p *planner) Delete(
 		Exprs: sqlbase.ColumnsSelectors(rd.FetchCols),
 		From:  &tree.From{Tables: []tree.TableExpr{n.Table}},
 		Where: n.Where,
-	}, nil /* orderBy */, n.Limit, false, /* lockForUpdate */
-		nil /* desiredTypes */, publicAndNonPublicColumns)
+	}, nil, n.Limit, nil, publicAndNonPublicColumns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -315,9 +315,6 @@ func (dsp *DistSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 			// ranges at a time.
 			rec = shouldNotDistribute
 		}
-		if n.lockForUpdate {
-			return 0, newQueryNotSupportedError("explicit locking with FOR UPDATE is not yet supported")
-		}
 		// We recommend running scans distributed if we have a filtering
 		// expression or if we have a full table scan.
 		if n.filter != nil {

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -120,8 +120,8 @@ func (cb *columnBackfiller) init() error {
 		colIdxMap[c.ID] = i
 	}
 	return cb.fetcher.Init(
-		&desc, colIdxMap, &desc.PrimaryIndex, false /* reverse */, false, /* lockForUpdate */
-		false /* isSecondaryIndex */, desc.Columns, valNeededForCol, false /* returnRangeInfo */, &cb.alloc,
+		&desc, colIdxMap, &desc.PrimaryIndex, false, false, desc.Columns,
+		valNeededForCol, false, &cb.alloc,
 	)
 }
 

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -107,8 +107,8 @@ func (ib *indexBackfiller) init() error {
 	}
 
 	return ib.fetcher.Init(
-		&desc, ib.colIdxMap, &desc.PrimaryIndex, false /* reverse */, false, /* lockForUpdate */
-		false /* isSecondaryIndex */, cols, valNeededForCol, false /* returnRangeInfo */, &ib.alloc,
+		&desc, ib.colIdxMap, &desc.PrimaryIndex, false, false, cols,
+		valNeededForCol, false, &ib.alloc,
 	)
 }
 

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -140,7 +140,7 @@ func initRowFetcher(
 		colIdxMap[c.ID] = i
 	}
 	if err := fetcher.Init(
-		desc, colIdxMap, index, reverseScan, false /* lockForUpdate */, isSecondaryIndex,
+		desc, colIdxMap, index, reverseScan, isSecondaryIndex,
 		desc.Columns, valNeededForCol, true /* returnRangeInfo */, alloc,
 	); err != nil {
 		return nil, false, err

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -122,7 +122,6 @@ func (p *planner) makeIndexJoin(
 	// Create a new scanNode that will be used with the primary index.
 	table := p.Scan()
 	table.desc = origScan.desc
-	table.lockForUpdate = origScan.lockForUpdate
 	// Note: initDescDefaults can only error out if its 2nd argument is not nil.
 	_ = table.initDescDefaults(origScan.scanVisibility, nil)
 	table.initOrdering(0)

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -270,18 +270,6 @@ query IIII
 SELECT * FROM (SELECT * FROM xyzw LIMIT 5) OFFSET 5
 ----
 
-query error pq: explicit locking with FOR UPDATE is not yet supported
-SELECT * FROM xyzw FOR UPDATE
-
-query error pq: explicit locking with FOR UPDATE is not yet supported
-SELECT * FROM xyzw LIMIT 1 FOR UPDATE
-
-query error pq: explicit locking with FOR UPDATE is not yet supported
-SELECT * FROM xyzw FOR UPDATE LIMIT 1 OFFSET 1
-
-query error pq: explicit locking with FOR UPDATE is not yet supported
-SELECT * FROM (SELECT x FROM xyzw FOR UPDATE) LIMIT 1 OFFSET 1
-
 query II rowsort
 SELECT z, y FROM xyzw@foo
 ----

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -678,8 +678,6 @@ func TestParse(t *testing.T) {
 		{`SELECT a FROM t LIMIT a`},
 		{`SELECT a FROM t OFFSET b`},
 		{`SELECT a FROM t LIMIT a OFFSET b`},
-		{`SELECT a FROM t FOR UPDATE`},
-		{`SELECT a FROM t LIMIT a OFFSET b FOR UPDATE`},
 		{`SELECT DISTINCT * FROM t`},
 		{`SELECT DISTINCT a, b FROM t`},
 		{`SET a = 3`},
@@ -989,9 +987,6 @@ func TestParse2(t *testing.T) {
 		// We allow OFFSET before LIMIT, but always output LIMIT first.
 		{`SELECT a FROM t OFFSET a LIMIT b`,
 			`SELECT a FROM t LIMIT b OFFSET a`},
-		// We allow FOR UPDATE before LIMIT, but always output LIMIT first.
-		{`SELECT a FROM t FOR UPDATE LIMIT b`,
-			`SELECT a FROM t LIMIT b FOR UPDATE`},
 		// FETCH FIRST ... is alternative syntax for LIMIT.
 		{`SELECT a FROM t FETCH FIRST 3 ROWS ONLY`,
 			`SELECT a FROM t LIMIT 3`},

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -402,7 +402,7 @@ func (p *planner) newPlan(
 	case *tree.Select:
 		return p.Select(ctx, n, desiredTypes)
 	case *tree.SelectClause:
-		return p.SelectClause(ctx, n, nil /* orderBy */, nil /* limit */, false, /* lockForUpdate */
+		return p.SelectClause(ctx, n, nil /* orderBy */, nil, /* limit */
 			desiredTypes, publicColumns)
 	case *tree.SetClusterSetting:
 		return p.SetClusterSetting(ctx, n)
@@ -504,7 +504,7 @@ func (p *planner) prepare(ctx context.Context, stmt tree.Statement) (planNode, e
 	case *tree.Select:
 		return p.Select(ctx, n, nil)
 	case *tree.SelectClause:
-		return p.SelectClause(ctx, n, nil /* orderBy */, nil /* limit */, false, /* lockForUpdate */
+		return p.SelectClause(ctx, n, nil /* orderBy */, nil, /* limit */
 			nil /* desiredTypes */, publicColumns)
 	case *tree.SetClusterSetting:
 		return p.SetClusterSetting(ctx, n)

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -73,7 +73,6 @@ type scanNode struct {
 	spans            []roachpb.Span
 	isSecondaryIndex bool
 	reverse          bool
-	lockForUpdate    bool
 	props            physicalProps
 
 	rowIndex int64 // the index of the current row
@@ -133,8 +132,8 @@ func (n *scanNode) disableBatchLimit() {
 }
 
 func (n *scanNode) Start(runParams) error {
-	return n.fetcher.Init(n.desc, n.colIdxMap, n.index, n.reverse, n.lockForUpdate, n.isSecondaryIndex,
-		n.cols, n.valNeededForCol, false /* returnRangeInfo */, &n.p.alloc)
+	return n.fetcher.Init(n.desc, n.colIdxMap, n.index, n.reverse, n.isSecondaryIndex, n.cols,
+		n.valNeededForCol, false /* returnRangeInfo */, &n.p.alloc)
 }
 
 func (n *scanNode) Close(context.Context) {

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -38,10 +38,9 @@ func (*ValuesClause) selectStatement() {}
 
 // Select represents a SelectStatement with an ORDER and/or LIMIT.
 type Select struct {
-	Select        SelectStatement
-	OrderBy       OrderBy
-	Limit         *Limit
-	LockForUpdate bool
+	Select  SelectStatement
+	OrderBy OrderBy
+	Limit   *Limit
 }
 
 // Format implements the NodeFormatter interface.
@@ -49,9 +48,6 @@ func (node *Select) Format(buf *bytes.Buffer, f FmtFlags) {
 	FormatNode(buf, f, node.Select)
 	FormatNode(buf, f, node.OrderBy)
 	FormatNode(buf, f, node.Limit)
-	if node.LockForUpdate {
-		buf.WriteString(" FOR UPDATE")
-	}
 }
 
 // ParenSelect represents a parenthesized SELECT/UNION/VALUES statement.

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -271,7 +271,7 @@ func ConvertBatchError(ctx context.Context, tableDesc *TableDescriptor, b *clien
 			cols[i] = *col
 			valNeededForCol[i] = true
 		}
-		if err := rf.Init(tableDesc, colIdxMap, index, false /* reverse */, false, /* lockForUpdate */
+		if err := rf.Init(tableDesc, colIdxMap, index, false, /* reverse */
 			indexID != tableDesc.PrimaryIndex.ID /* isSecondaryIndex */, cols, valNeededForCol,
 			false /* returnRangeInfo */, &DatumAlloc{}); err != nil {
 			return err

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -441,7 +441,7 @@ func makeBaseFKHelper(
 	ids := ColIDtoRowIndexFromCols(b.searchTable.Columns)
 	isSecondary := b.searchTable.PrimaryIndex.ID != searchIdx.ID
 	err = b.rf.Init(b.searchTable, ids, searchIdx, false, /* reverse */
-		false /* lockForUpdate */, isSecondary, b.searchTable.Columns, nil, /* valNeededForCol */
+		isSecondary, b.searchTable.Columns, nil,
 		false /* returnRangeInfo */, alloc)
 	if err != nil {
 		return b, err

--- a/pkg/sql/sqlbase/kvfetcher.go
+++ b/pkg/sql/sqlbase/kvfetcher.go
@@ -88,7 +88,6 @@ type txnKVFetcher struct {
 	firstBatchLimit int64
 	useBatchLimit   bool
 	reverse         bool
-	lockForUpdate   bool
 	// returnRangeInfo, if set, causes the kvFetcher to populate rangeInfos.
 	// See also rowFetcher.returnRangeInfo.
 	returnRangeInfo bool
@@ -166,7 +165,6 @@ func makeKVFetcher(
 	txn *client.Txn,
 	spans roachpb.Spans,
 	reverse bool,
-	lockForUpdate bool,
 	useBatchLimit bool,
 	firstBatchLimit int64,
 	returnRangeInfo bool,
@@ -200,7 +198,6 @@ func makeKVFetcher(
 		txn:             txn,
 		spans:           copySpans,
 		reverse:         reverse,
-		lockForUpdate:   lockForUpdate,
 		useBatchLimit:   useBatchLimit,
 		firstBatchLimit: firstBatchLimit,
 		returnRangeInfo: returnRangeInfo,
@@ -213,10 +210,6 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	ba.Header.MaxSpanRequestKeys = f.getBatchSize()
 	ba.Header.ReturnRangeInfo = f.returnRangeInfo
 	ba.Requests = make([]roachpb.RequestUnion, len(f.spans))
-	if f.lockForUpdate {
-		return errors.Errorf("explicit locking with FOR UPDATE is not yet supported")
-	}
-
 	if f.reverse {
 		scans := make([]roachpb.ReverseScanRequest, len(f.spans))
 		for i := range f.spans {

--- a/pkg/sql/sqlbase/multirowfetcher.go
+++ b/pkg/sql/sqlbase/multirowfetcher.go
@@ -133,8 +133,6 @@ type MultiRowFetcher struct {
 	// or not when StartScan is invoked.
 	reverse bool
 
-	lockForUpdate bool
-
 	// maxKeysPerRow memoizes the maximum number of keys per row
 	// out of all the tables. This is used to calculate the kvFetcher's
 	// firstBatchLimit.
@@ -182,16 +180,13 @@ type MultiRowFetcher struct {
 // non-primary index, valNeededForCol can only be true for the columns in the
 // index.
 func (mrf *MultiRowFetcher) Init(
-	tables []MultiRowFetcherTableArgs,
-	reverse, lockForUpdate, returnRangeInfo bool,
-	alloc *DatumAlloc,
+	tables []MultiRowFetcherTableArgs, reverse, returnRangeInfo bool, alloc *DatumAlloc,
 ) error {
 	if len(tables) == 0 {
 		panic("no tables to fetch from")
 	}
 
 	mrf.reverse = reverse
-	mrf.lockForUpdate = lockForUpdate
 	mrf.returnRangeInfo = returnRangeInfo
 	mrf.alloc = alloc
 	mrf.allEquivSignatures = make(map[string]int, len(tables))
@@ -355,7 +350,7 @@ func (mrf *MultiRowFetcher) StartScan(
 		firstBatchLimit++
 	}
 
-	f, err := makeKVFetcher(txn, spans, mrf.reverse, mrf.lockForUpdate, limitBatches, firstBatchLimit, mrf.returnRangeInfo)
+	f, err := makeKVFetcher(txn, spans, mrf.reverse, limitBatches, firstBatchLimit, mrf.returnRangeInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/sqlbase/multirowfetcher_test.go
+++ b/pkg/sql/sqlbase/multirowfetcher_test.go
@@ -70,7 +70,7 @@ func initFetcher(
 		}
 	}
 
-	if err := fetcher.Init(fetcherArgs, reverseScan, false /*reverse*/, false /*lockForUpdate*/, alloc); err != nil {
+	if err := fetcher.Init(fetcherArgs, reverseScan, false /*reverse*/, alloc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -52,7 +52,6 @@ type RowFetcher struct {
 	desc             *TableDescriptor
 	index            *IndexDescriptor
 	reverse          bool
-	lockForUpdate    bool
 	isSecondaryIndex bool
 	indexColumnDirs  []encoding.Direction
 
@@ -123,7 +122,7 @@ func (rf *RowFetcher) Init(
 	desc *TableDescriptor,
 	colIdxMap map[ColumnID]int,
 	index *IndexDescriptor,
-	reverse, lockForUpdate, isSecondaryIndex bool,
+	reverse, isSecondaryIndex bool,
 	cols []ColumnDescriptor,
 	valNeededForCol []bool,
 	returnRangeInfo bool,
@@ -133,7 +132,6 @@ func (rf *RowFetcher) Init(
 	rf.colIdxMap = colIdxMap
 	rf.index = index
 	rf.reverse = reverse
-	rf.lockForUpdate = lockForUpdate
 	rf.isSecondaryIndex = isSecondaryIndex
 	rf.cols = cols
 	rf.returnRangeInfo = returnRangeInfo
@@ -235,7 +233,7 @@ func (rf *RowFetcher) StartScan(
 		firstBatchLimit++
 	}
 
-	f, err := makeKVFetcher(txn, spans, rf.reverse, rf.lockForUpdate, limitBatches, firstBatchLimit, rf.returnRangeInfo)
+	f, err := makeKVFetcher(txn, spans, rf.reverse, limitBatches, firstBatchLimit, rf.returnRangeInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -343,7 +343,7 @@ func (tu *tableUpserter) init(txn *client.Txn) error {
 
 	return tu.fetcher.Init(
 		tableDesc, tu.fetchColIDtoRowIndex, &tableDesc.PrimaryIndex,
-		false /* reverse */, false /* lockForUpdate */, false, /* isSecondaryIndex */
+		false /* reverse */, false, /* isSecondaryIndex */
 		tu.fetchCols, valNeededForCol, false /*returnRangeInfo*/, tu.alloc)
 }
 
@@ -812,7 +812,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 	var rf sqlbase.RowFetcher
 	err := rf.Init(
 		td.rd.Helper.TableDesc, td.rd.FetchColIDtoRowIndex, &td.rd.Helper.TableDesc.PrimaryIndex,
-		false /* reverse */, false /* lockForUpdate */, false, /* isSecondaryIndex */
+		false /*reverse*/, false, /*isSecondaryIndex*/
 		td.rd.FetchCols, valNeededForCol, false /* returnRangeInfo */, td.alloc)
 	if err != nil {
 		return resume, err
@@ -900,7 +900,7 @@ func (td *tableDeleter) deleteIndexScan(
 	var rf sqlbase.RowFetcher
 	err := rf.Init(
 		td.rd.Helper.TableDesc, td.rd.FetchColIDtoRowIndex, &td.rd.Helper.TableDesc.PrimaryIndex,
-		false /* reverse */, false /* lockForUpdate */, false, /* isSecondaryIndex */
+		false /* reverse */, false, /*isSecondaryIndex */
 		td.rd.FetchCols, valNeededForCol, false /* returnRangeInfo */, td.alloc)
 	if err != nil {
 		return resume, err

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -274,8 +274,7 @@ func (p *planner) Update(
 		Exprs: sqlbase.ColumnsSelectors(ru.FetchCols),
 		From:  &tree.From{Tables: []tree.TableExpr{n.Table}},
 		Where: n.Where,
-	}, nil /* orderBy */, nil /* limit */, false, /* lockForUpdate */
-		nil /* desiredTypes */, publicAndNonPublicColumns)
+	}, nil, nil, nil, publicAndNonPublicColumns)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This reverts commit 04fbeb9e76f9488073966f7ef4d00167aa20997b.

It was decided in PR #19577 that we would postpone the `SELECT FOR UPDATE` functionality, so revert changes from PR #19650, which was premature.  Also revert changes from PR #19690 involving the `lockForUpdate` flag (cc @richardwu, fyi).