### PR TITLE
client: avoid filling results for "raw" Batch requests

### DIFF
--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -455,16 +455,11 @@ func sendAndFill(ctx context.Context, send SenderFunc, b *Batch) error {
 	ba.Requests = b.reqs
 	ba.Header = b.Header
 	b.response, b.pErr = send(ctx, ba)
-	if b.pErr != nil {
-		// Discard errors from fillResults.
-		_ = b.fillResults(ctx)
-		return b.pErr.GoError()
+	b.fillResults(ctx)
+	if b.pErr == nil {
+		b.pErr = roachpb.NewError(b.resultErr())
 	}
-	if err := b.fillResults(ctx); err != nil {
-		b.pErr = roachpb.NewError(err)
-		return err
-	}
-	return nil
+	return b.pErr.GoError()
 }
 
 // Run executes the operations queued up within a batch. Before executing any

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -571,7 +571,8 @@ func (txn *Txn) CommitInBatch(ctx context.Context, b *Batch) error {
 	if txn != b.txn {
 		return errors.Errorf("a batch b can only be committed by b.txn")
 	}
-	b.AddRawRequest(endTxnReq(true /* commit */, txn.deadline, txn.systemConfigTrigger))
+	b.appendReqs(endTxnReq(true /* commit */, txn.deadline, txn.systemConfigTrigger))
+	b.initResult(1 /* calls */, 0, b.raw, nil)
 	return txn.Run(ctx, b)
 }
 


### PR DESCRIPTION
While I don't think we'll ever actually want to merge #19050, it revealed that
there were cases where `fillResults` was being called twice for `client.Batches`.
The times when this could happen were where a batch was being used initially as
a "raw" batch (such as in `TxnCoordSender.resendWithTxn`). This in turn revealed
that we were actually always performing a lot of unnecessary bookkeeping on "raw"
requests in both `Batch.initResult` and `Batch.fillResults`, including lots of
`[]KeyValue` allocations. This change avoids all of this extra work.