### PR TITLE
sql: don't evaluate DEFAULT expressions on table creation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -663,3 +663,22 @@ query I
 SELECT COUNT(*) FROM crdb_internal.jobs WHERE status = 'pending' OR status = 'started'
 ----
 0
+
+# Verify that ALTER TABLE statements are rolled back properly when a DEFAULT expression returns
+# an error.
+
+statement ok
+CREATE TABLE default_err_test (foo text)
+
+statement ok
+INSERT INTO default_err_test VALUES ('foo'), ('bar'), ('baz')
+
+statement error some_msg
+ALTER TABLE default_err_test ADD COLUMN id int DEFAULT crdb_internal.force_error('foo', 'some_msg')
+
+query T
+SELECT * from default_err_test
+----
+foo
+bar
+baz

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -172,9 +172,8 @@ INSERT INTO blog_posts (title) values ('foo')
 statement ok
 INSERT INTO blog_posts (title) values ('bar')
 
-# TODO(vilterp) change this to [1, 2] once initial-evaluation bug has been fixed
 query I
 SELECT id FROM blog_posts ORDER BY id
 ----
+1
 2
-3

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -213,13 +213,6 @@ func MakeColumnDefDescs(
 		if typedExpr, err = t.NormalizeExpr(evalCtx, typedExpr); err != nil {
 			return nil, nil, err
 		}
-		// Try to evaluate once. If it is aimed to succeed during a
-		// backfill, it must succeed here too. This tries to ensure that
-		// we don't end up failing the evaluation during the schema change
-		// proper.
-		if _, err := typedExpr.Eval(evalCtx); err != nil {
-			return nil, nil, err
-		}
 		d.DefaultExpr.Expr = typedExpr
 
 		s := tree.Serialize(d.DefaultExpr.Expr)


### PR DESCRIPTION
Not sure what this would catch, and it throws off sequences (see #19664) -- if you create a table with a column that uses a sequence it its DEFAULT expression, it'll increment the sequence at table creation time, before a row has been inserted into the table.

tracking issue: #19723