### PR TITLE
sql: never use Datum.Next when computing spans

### DIFF
--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -150,7 +150,10 @@ func TestPrettyPrint(t *testing.T) {
 		{makeKey([]byte("")), "/Min"},
 		{Meta1KeyMax, "/Meta1/Max"},
 		{Meta2KeyMax, "/Meta2/Max"},
-		{makeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0x12, 'a', 0x00, 0x02})), "/Table/42/???"},
+		{makeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0xf6})), `/Table/42/109/PrefixEnd`},
+		{makeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0xf7})), `/Table/42/???`},
+		{makeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0x12, 'a', 0x00, 0x02})), `/Table/42/"a"/PrefixEnd`},
+		{makeKey(MakeTablePrefix(42), roachpb.RKey([]byte{0x12, 'a', 0x00, 0x03})), `/Table/42/???`},
 	}
 	for i, test := range testCases {
 		keyInfo := MassagePrettyPrintedSpanForTest(PrettyPrint(test.key), nil)

--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -1138,20 +1138,6 @@ func spanFromLogicalSpan(
 			break
 		}
 	}
-	// Since the end of a span is exclusive, if the last constraint is an
-	// inclusive one, we might need to make the key exclusive by applying a
-	// PrefixEnd(). We normally avoid doing this by transforming "a = x" to "a =
-	// x±1" for the last end constraint, depending on the encoding direction
-	// (since this keeps the key nice and pretty-printable). However, we might not
-	// be able to do the ±1.
-	if n := len(ls.end); n > 0 && ls.end[n-1].inclusive {
-		last := &ls.end[n-1]
-		nextVal, hasNext := nextInDirection(evalCtx, last.val, last.dir)
-		if hasNext {
-			last.val = nextVal
-			last.inclusive = false
-		}
-	}
 	for i := 0; ; i++ {
 		s.EndKey = append(s.EndKey, interstices[i]...)
 		if i >= len(ls.end) {
@@ -1188,21 +1174,6 @@ func encodeLogicalKeyPart(
 		return nil, err
 	}
 	return sqlbase.EncodeTableKey(b, d, part.dir)
-}
-
-func nextInDirection(
-	evalCtx *tree.EvalContext, val tree.Datum, dir encoding.Direction,
-) (tree.Datum, bool) {
-	if dir == encoding.Ascending {
-		if val.IsMax(evalCtx) {
-			return nil, false
-		}
-		return val.Next(evalCtx)
-	}
-	if val.IsMin(evalCtx) {
-		return nil, false
-	}
-	return val.Prev(evalCtx)
 }
 
 // mergeAndSortSpans is used to merge a set of potentially overlapping spans

--- a/pkg/sql/index_selection_test.go
+++ b/pkg/sql/index_selection_test.go
@@ -563,7 +563,7 @@ func TestMakeSpans(t *testing.T) {
 			`/7/3/0-/7/3/1 /7/2/0-/7/2/1 /7/1/0-/7/1/1`},
 		// Test different directions for te columns inside a tuple.
 		{`(a,b,j) IN ((1,2,3), (4,5,6))`, `a-,b,j-`, `/4/5/6-/4/5/5 /1/2/3-/1/2/2`},
-		{`k = b'\xff'`, `k`, `/"\xff"-/"\xff\x00"`},
+		{`k = b'\xff'`, `k`, `/"\xff"-/"\xff"/PrefixEnd`},
 		// Test that limits on bytes work correctly: when encoding a descending limit for bytes,
 		// we need to go outside the bytes encoding.
 		// "\xaa" is encoded as [bytesDescMarker, ^0xaa, <term escape sequence>]

--- a/pkg/sql/index_selection_test.go
+++ b/pkg/sql/index_selection_test.go
@@ -506,15 +506,12 @@ func TestMakeSpans(t *testing.T) {
 		{`(a = 5) OR (a, b) IN ((1, 1), (3, 3))`, `a,b`,
 			`/1/1-/1/2 /3/3-/3/4 /5-/6`, `/5-/4 /3/3-/3/2 /1/1-/1/0`},
 
-		// When encoding an end constraint for a maximal datum, we use
-		// bytes.PrefixEnd() to go beyond the normal encodings of that datatype.
-		// This is the reason for the "???" suffix of the pretty-printed spans.
 		{fmt.Sprintf(`a = %d`, math.MaxInt64), `a`,
-			`/9223372036854775807-/???`,
+			`/9223372036854775807-/9223372036854775807/PrefixEnd`,
 			`/9223372036854775807-/9223372036854775806`},
 		{fmt.Sprintf(`a = %d`, math.MinInt64), `a`,
 			`/-9223372036854775808-/-9223372036854775807`,
-			`/-9223372036854775808-/???`},
+			`/-9223372036854775808-/-9223372036854775808/PrefixEnd`},
 
 		{`(a, b) >= (1, 4)`, `a,b`, `/1/4-`, `-/1/3`},
 		{`(a, b) > (1, 4)`, `a,b`, `/1/5-`, `-/1/4`},

--- a/pkg/sql/logictest/testdata/logic_test/deep_interleaving
+++ b/pkg/sql/logictest/testdata/logic_test/deep_interleaving
@@ -102,12 +102,16 @@ SELECT * FROM level4
 3  30  200
 3  30  300
 
+# The span below ends at the end of the first index of table 53, and is not
+# constraining the value of k2 or k3. This is confusing on first glance because
+# the second interleave in the hierarchy doesn't contain any new primary key
+# columns on top of the first interleave.
 query ITTT
 EXPLAIN SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 ----
 0  scan  ·      ·
 0  ·     table  level4@primary
-0  ·     spans  /2/#/52/1/#/53/1-/3
+0  ·     spans  /2/#/52/1/#/53/1-/2/#/52/1/#/53/2
 
 query III rowsort
 SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
@@ -141,7 +145,7 @@ EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
 ----
 0  scan  ·      ·
 0  ·     table  level4@primary
-0  ·     spans  /2/#/52/1/#/53/1/20/101/#/54/1-/2/#/52/1/#/53/1/20/300
+0  ·     spans  /2/#/52/1/#/53/1/20/101/#/54/1-/2/#/52/1/#/53/1/20/299/#/54/2
 
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
@@ -153,7 +157,7 @@ EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
 ----
 0  scan  ·      ·
 0  ·     table  level4@primary
-0  ·     spans  /2/#/52/1/#/53/1/20/200/#/54/1-/2/#/52/1/#/53/1/20/201
+0  ·     spans  /2/#/52/1/#/53/1/20/200/#/54/1-/2/#/52/1/#/53/1/20/200/#/54/2
 
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200

--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -24,7 +24,7 @@ EXPLAIN SELECT * FROM p WHERE f IS NaN
 0  render  ·      ·
 1  scan    ·      ·
 1  ·       table  p@p_f_key
-1  ·       spans  /NaN-/-Inf
+1  ·       spans  /NaN-/NaN/PrefixEnd
 
 query ITTT
 EXPLAIN SELECT * FROM p WHERE f = 'NaN'
@@ -32,7 +32,7 @@ EXPLAIN SELECT * FROM p WHERE f = 'NaN'
 0  render  ·      ·
 1  scan    ·      ·
 1  ·       table  p@p_f_key
-1  ·       spans  /NaN-/-Inf
+1  ·       spans  /NaN-/NaN/PrefixEnd
 
 query ITTT
 EXPLAIN SELECT * FROM p WHERE isnan(f)

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -619,7 +619,7 @@ EXPLAIN SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20
 1  index-join  ·      ·
 2  revscan     ·      ·
 2  ·           table  test2@test2_k_key
-2  ·           spans  /#-/"100\x00"
+2  ·           spans  /#-/"100"/PrefixEnd
 2  ·           limit  20
 2  scan        ·      ·
 2  ·           table  test2@primary
@@ -726,7 +726,7 @@ ORDER BY total DESC
 2  render  ·         ·
 3  scan    ·         ·
 3  ·       table     favourites@favourites_glob_fav_idx
-3  ·       spans     /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts\x00" /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2\x00" /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3\x00"
+3  ·       spans     /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"/PrefixEnd
 
 query TI rowsort
 SELECT

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -961,17 +961,30 @@ func PeekLength(b []byte) (int, error) {
 // PrettyPrintValue returns the string representation of all contiguous decodable
 // values in the provided byte slice, separated by a provided separator.
 func PrettyPrintValue(b []byte, sep string) string {
+	s1, allDecoded := prettyPrintValueImpl(b, sep)
+	if allDecoded {
+		return s1
+	}
+	if s2, allDecoded := prettyPrintValueImpl(UndoPrefixEnd(b), sep); allDecoded {
+		return s2 + sep + "PrefixEnd"
+	}
+	return s1
+}
+
+func prettyPrintValueImpl(b []byte, sep string) (string, bool) {
+	allDecoded := true
 	var buf bytes.Buffer
 	for len(b) > 0 {
 		bb, s, err := prettyPrintFirstValue(b)
 		if err != nil {
+			allDecoded = false
 			fmt.Fprintf(&buf, "%s???", sep)
 		} else {
 			fmt.Fprintf(&buf, "%s%s", sep, s)
 		}
 		b = bb
 	}
-	return buf.String()
+	return buf.String(), allDecoded
 }
 
 // prettyPrintFirstValue returns a string representation of the first decodable
@@ -1039,6 +1052,41 @@ func prettyPrintFirstValue(b []byte) ([]byte, string, error) {
 		// This shouldn't ever happen, but if it does, return an empty slice.
 		return nil, strconv.Quote(string(b)), nil
 	}
+}
+
+// UndoPrefixEnd is a partial inverse for roachpb.Key.PrefixEnd.
+//
+// Specifically, calling UndoPrefixEnd will reverse the effects of calling a
+// PrefixEnd on a byte sequence, except when the byte sequence represents a
+// maximal prefix (i.e., 0xff...). This is because PrefixEnd is a lossy
+// operation: PrefixEnd(0xff) returns 0xff rather than wrapping around to the
+// minimal prefix 0x00. For consistency, UndoPrefixEnd is also lossy:
+// UndoPrefixEnd(0x00) returns 0x00 rather than wrapping around to the maximal
+// prefix 0xff.
+//
+// Formally:
+//
+//     PrefixEnd(UndoPrefixEnd(p)) = p for all non-minimal prefixes p
+//     UndoPrefixEnd(PrefixEnd(p)) = p for all non-maximal prefixes p
+//
+// A minimal prefix is any prefix that consists only of one or more 0x00 bytes;
+// analogously, a maximal prefix is any prefix that consists only of one or more
+// 0xff bytes.
+//
+// UndoPrefixEnd is implemented here to avoid a circular dependency on roachpb,
+// but arguably belongs in a byte-manipulation utility package.
+func UndoPrefixEnd(b []byte) []byte {
+	out := append([]byte(nil), b...)
+	for i := len(out) - 1; i >= 0; i-- {
+		out[i] = out[i] - 1
+		if out[i] != 0xff {
+			return out
+		}
+	}
+	// At this point, out has wrapped around to the maximal possible prefix. That
+	// means we were provided a minimal prefix (i.e., all zero bytes), so return
+	// it unchanged.
+	return b
 }
 
 // NonsortingVarintMaxLen is the maximum length of an EncodeNonsortingVarint

--- a/pkg/util/encoding/printer_test.go
+++ b/pkg/util/encoding/printer_test.go
@@ -1,0 +1,59 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package encoding_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+func TestUndoPrefixEnd(t *testing.T) {
+	for _, tc := range []struct {
+		in  []byte
+		out []byte
+	}{
+		{[]byte{0x00}, []byte{0x00}},
+		{[]byte{0x00, 0x00}, []byte{0x00, 0x00}},
+		{[]byte{0x00, 0x01}, []byte{0x00, 0x00}},
+		{[]byte{0x01, 0x00, 0x00, 0x00}, []byte{0x00, 0xff, 0xff, 0xff}},
+		{[]byte{0xff, 0xff}, []byte{0xff, 0xfe}},
+	} {
+		t.Run(fmt.Sprintf("undo-prefix/key=%q", tc.in), func(t *testing.T) {
+			if e, a := tc.out, encoding.UndoPrefixEnd(tc.in); !bytes.Equal(e, a) {
+				t.Errorf("expected %q but got %q", e, a)
+			}
+		})
+	}
+
+	for _, k := range [][]byte{
+		{0x00},
+		{0x00, 0x00},
+		{0x00, 0x01},
+		{0x00, 0xff, 0xff, 0xff},
+		{0x01, 0x00, 0x00, 0x00},
+		// Maximal byte sequences (repeated 0xff bytes) do not roundtrip.
+	} {
+		t.Run(fmt.Sprintf("roundtrip/key=%q", k), func(t *testing.T) {
+			if r := encoding.UndoPrefixEnd(roachpb.Key(k).PrefixEnd()); !bytes.Equal(k, r) {
+				t.Errorf("roundtripping resulted in %q", r)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
tl;dr avoid computing overwide spans in SQL that cause multiple partitions to be scanned when the SQL query is constrained to one region.

For example, this query should only hit one range

```sql
CREATE TABLE db.users (country STRING PRIMARY KEY, name STRING) PARTITION BY LIST (users) (
    PARTITION us VALUES IN ('us'),
    PARTITION ca VALUES IN ('ca')
);
ALTER TABLE db.users PARTITION us EXPERIMENTAL CONFIGURE ZONE '{gc: {ttlseconds: 60}}';
INSERT INTO db.users VALUES ('us', 'nikhil'), ('ca', 'justin')
SELECT * FROM db.users WHERE country = 'us';
```

but without this patch it hits two.

Full details in the commit messages:

```
keys: check if undoing PrefixEnd makes keys pretty printable
Calling PrefixEnd can result in semantically invalid keys. Suppose we
have the following key:

    b2          12             61    00 01
    /Table/42   bytes marker   "a"   term marker

Calling PrefixEnd will blindly increment the last byte, resulting in:

    b2 12 61 00 02

This key has no semantic meaning, as the byte sequence termination
marker has been destroyed. The pretty printer currently has no choice
but to display this key with a bunch of ???s:

    /Table/42/???

We can do better than this by checking whether undoing a PrefixEnd
operation results in a printable key. Now, the pretty printer can
display the above key as:

    /Table/42/"a"/PrefixEnd

Note that the pretty printer will never append "/PrefixEnd" to a
semantically valid key. For example, "/Table/42/1".PrefixEnd() will be
printed as "/Table/42/2" because, in this case, PrefixEnd results in a
semantically valid key.
```

```
sql: never use Datum.Next when computing spans
The SQL layer must translate inclusive upper bounds into exclusive upper
bounds, as KV scans always use exclusive upper bounds. The PrefixEnd key
operation is provided for exactly this purpose, but it can result in
semantically-invalid keys that the pretty printer could not handle
before 8fea154.

As a workaround, span computation would call Datum.Next instead of
Key.PrefixEnd whenever the datum was not already the maximum value. This
kept spans "nice and pretty-printable" at the cost of making them too
wide.

For example, the key /Table/42/"a" is encoded as:

        b2          12             61    00 01
        /Table/42   bytes marker   "a"   term marker

Calling PrefixEnd increments only the last byte

        b2          12             61    00 02
        /Table/42   bytes marker   "a"   term marker

whereas calling Datum.Next appends a null byte to the bytes sequence
within the key, which results in a much greater key:

        b2          12             61 ff     00 02
        /Table/42   bytes marker   "a\x00"   term marker

Up until now, using Datum.Next instead of PrefixEnd had largely no
effect, as the SQL layer prevents any "in-between" keys, like b2 12 61
01, from ever appearing. With partitioning, however, it's possible to
introduce a split at the PrefixEnd of any key (e.g., at b2 12 61 00 02),
which means that the span computed by `SELECT * FROM t WHERE pk = 'a'`,
which extends to b2 12 61 ff 00 02, would be too wide and bleed into the
next range.

Now that PrefixEnd keys can always be pretty-printed, just remove the
special casing from SQL span generation and always use PrefixEnd. This
guarantees that the tightest possible span is computed.

(We could have instead taught partitioning to call Datum.Next instead of
PrefixEnd in exactly the cases where SQL span computation did, but that
seemed like furthering a hack that existed only to work around a
limitation in the pretty printer.)
```

This is kind of a scary change; please suggest additional reviewers!