### PR TITLE
sql: fix span generation with IN

### DIFF
--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -990,9 +990,17 @@ func applyInConstraint(
 		}
 		for _, s := range existingSpans {
 			if c.start != nil {
+				// Don't append directly to the existing slice, or we
+				// may introduce unwanted aliasing (see #20035).
+				old := s.start
+				s.start = make([]logicalKeyPart, 0, len(old)+len(parts))
+				s.start = append(s.start, old...)
 				s.start = append(s.start, parts...)
 			}
 			if c.end != nil {
+				old := s.end
+				s.end = make([]logicalKeyPart, 0, len(old)+len(parts))
+				s.end = append(s.end, old...)
 				s.end = append(s.end, parts...)
 			}
 			spans = append(spans, s)

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -675,3 +675,73 @@ fetched: /test2/primary/...PK.../k/v -> /'014'/42
 fetched: /test2/primary/...PK.../k/v -> /'013'/42
 fetched: /test2/primary/...PK.../k/v -> /'012'/42
 fetched: /test2/primary/...PK.../k/v -> /'011'/42
+
+# Regression test for #20035.
+statement ok
+CREATE TABLE favourites (
+  id INT NOT NULL DEFAULT unique_rowid(),
+  resource_type STRING(30) NOT NULL,
+  resource_key STRING(255) NOT NULL,
+  device_group STRING(30) NOT NULL,
+  customerid INT NOT NULL,
+  jurisdiction STRING(2) NOT NULL,
+  brand STRING(255) NOT NULL,
+  created_ts TIMESTAMP NULL,
+  guid_id STRING(100) NOT NULL,
+  locale STRING(10) NOT NULL DEFAULT NULL,
+  CONSTRAINT "primary" PRIMARY KEY (id ASC),
+  UNIQUE INDEX favourites_idx (resource_type ASC, device_group ASC, resource_key ASC, customerid ASC),
+  INDEX favourites_guid_idx (guid_id ASC),
+  INDEX favourites_glob_fav_idx (resource_type ASC, device_group ASC, jurisdiction ASC, brand ASC, locale ASC, resource_key ASC),
+  FAMILY "primary" (id, resource_type, resource_key, device_group, customerid, jurisdiction, brand, created_ts, guid_id, locale)
+)
+
+statement ok
+INSERT INTO favourites (customerid, guid_id, resource_type, device_group, jurisdiction, brand, locale, resource_key)
+  VALUES (1, '1', 'GAME', 'web', 'MT', 'xxx', 'en_GB', 'tp'),
+         (2, '2', 'GAME', 'web', 'MT', 'xxx', 'en_GB', 'ts'),
+         (3, '3', 'GAME', 'web', 'MT', 'xxx', 'en_GB', 'ts1'),
+         (4, '4', 'GAME', 'web', 'MT', 'xxx', 'en_GB', 'ts2'),
+         (5, '5', 'GAME', 'web', 'MT', 'xxx', 'en_GB', 'ts3'),
+         (6, '6', 'GAME', 'web', 'MT', 'xxx', 'en_GB', 'ts4')
+
+query ITTT
+EXPLAIN SELECT
+  resource_key,
+  count(resource_key) total
+FROM favourites f1
+WHERE f1.jurisdiction   = 'MT'
+AND   f1.brand          = 'xxx'
+AND   f1.resource_type  = 'GAME'
+AND   f1.device_group   = 'web'
+AND   f1.locale         = 'en_GB'
+AND   f1.resource_key IN ('ts', 'ts2', 'ts3')
+GROUP BY resource_key
+ORDER BY total DESC
+----
+0  sort    ·         ·
+0  ·       order     -total
+1  group   ·         ·
+1  ·       group by  @1-@1
+2  render  ·         ·
+3  scan    ·         ·
+3  ·       table     favourites@favourites_glob_fav_idx
+3  ·       spans     /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts\x00" /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2\x00" /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3\x00"
+
+query TI rowsort
+SELECT
+  resource_key,
+  count(resource_key) total
+FROM favourites f1
+WHERE f1.jurisdiction   = 'MT'
+AND   f1.brand          = 'xxx'
+AND   f1.resource_type  = 'GAME'
+AND   f1.device_group   = 'web'
+AND   f1.locale         = 'en_GB'
+AND   f1.resource_key IN ('ts', 'ts2', 'ts3')
+GROUP BY resource_key
+ORDER BY total DESC
+----
+ts 1
+ts2 1
+ts3 1


### PR DESCRIPTION
Issue #20035 exposes a bug in span generation. We have an IN with three values
and we only see one span.

The root cause is that we are appending to the same slices for each IN value,
which means that if the slice has some extra capacity, we overwrite the previous
value. The result is that we get multiple spans that are identical (which get
merged later into a single span).

Fixes #20035.

Release Note: Fixed a bug leading to incorrect results for queries with IN
constraints (in some cases).