### PR TITLE
sql: do not leak traces in lease renewal

### DIFF
--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -1251,7 +1251,9 @@ func (m *LeaseManager) AcquireByName(
 					// Start the renewal. When it finishes, it will reset t.renewalInProgress.
 					if err := t.stopper.RunAsyncTask(context.Background(),
 						"lease renewal", func(ctx context.Context) {
-							ctx, _ = tracing.EnsureContext(ctx, m.ambientCtx.Tracer, "lease renewal")
+							var cleanup func()
+							ctx, cleanup = tracing.EnsureContext(ctx, m.ambientCtx.Tracer, "lease renewal")
+							defer cleanup()
 							t.startLeaseRenewal(ctx, m, tableVersion)
 						}); err != nil {
 						return &tableVersion.TableDescriptor, tableVersion.expiration, err


### PR DESCRIPTION
Found while investigating an unrelated problem via the /debug/requests endpoint.