### PR TITLE
sql/sqlbase: When deleting rows, check to see if the value of the fk is `null`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -871,3 +871,18 @@ pkref_b  CREATE TABLE pkref_b (
         CONSTRAINT fk_b_ref_pkref_a FOREIGN KEY (b) REFERENCES pkref_a (a) ON DELETE RESTRICT,
         FAMILY "primary" (b)
 )
+
+# See https://github.com/cockroachdb/cockroach/issues/20045
+statement ok
+CREATE TABLE self_x2 (
+  x STRING PRIMARY KEY
+ ,y STRING UNIQUE REFERENCES self_x2(x)
+ ,z STRING REFERENCES self_x2(y)
+ ,INDEX(z)
+);
+
+statement ok
+INSERT INTO self_x2 (x, y, z) VALUES ('pk1', NULL, NULL);
+
+statement ok
+DELETE FROM self_x2 WHERE x = 'pk1';


### PR DESCRIPTION
When deleting rows, there were no existing checks for null values when verifying foreign key relationships.
This fixes that and merges the update and delete checks as the code was just repeated.

Note that this bug doesn't have to be in a self-referencing table, but it is an convenient way to reproduce with it. All it requires is a chain of 2 foreign key references.
Also, this has to take into account composite foreign keys, which is why we have to check for all nulls instead of just a single lookup.  This was already done in the insert check.

Release Notes: Fixed a bug so deleting chains of 2 or more foreign key references is now possible.

Fixes #20045.