### PR TITLE
RFCS: minor update to statistics rfc

### DIFF
--- a/docs/RFCS/20170908_sql_optimizer_statistics.md
+++ b/docs/RFCS/20170908_sql_optimizer_statistics.md
@@ -91,18 +91,10 @@ which is focused on the collection of basic statistics.
   reservoir sampling), sorting it and then using the one-pass
   algorithm on the sorted data.
 
-* Density: defined as 1 / "number of distinct values".
+* Cardinality: the number of distinct values (on a single column, or
+  on a group of columns).
 
-* Density vector: stores density information for column groups; used
-  to estimate the output of "GROUP BY" operations or to estimate
-  selectivity of equality predicates where a value is unknown (as in
-  the case of prepared queries). The density vector contains density
-  information for all prefixes of a group of columns. For example, for
-  a column group A,B,C the density vector allows us to estimate the
-  number of distinct values of A, the number of distinct pairs (A,B),
-  and the number of distinct tuples (A,B,C).
-
-* Sketch: Used in density estimation. Algorithms such as
+* Sketch: Used for cardinality estimation. Algorithms such as
   [HyperLogLog](http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf)
   use a hash of the value to estimate the number of distinct values.
   Sketches can be merged allowing for parallel computation. For
@@ -124,7 +116,7 @@ which is focused on the collection of basic statistics.
 
 * The desired statistics to collect are:
     - a histogram for a given column
-    - a density vector for a given set of columns
+    - a cardinality for a given set of columns
 
 * The count of distinct values for a column or group of columns can be
   computed using a sketch algorithm such as
@@ -185,9 +177,9 @@ CREATE TABLE system.table_statistics (
   statistic_id INT,
   column_ids []INT,
   created_at TIMESTAMP,
-  rows INT,
-  density []FLOAT,
-  null_fraction FLOAT,
+  row_count INT,
+  cardinality INT,
+  null_values INT,
   histogram BYTES,
   PRIMARY KEY (table_id, statistic_id)
 )
@@ -203,14 +195,12 @@ corresponding to the histograms maintained for the table.
   is generated.
 * `created_at` is the time at which the statistic was generated.
 * `row_count` is the total number of rows in the table.
-* `density` is the density vector, with one value for each prefix of
-  `column_ids`. E.g. if the statistic is on columns A,B,C there are
-  three density values - one for A, one for (A,B), and one for
-  (A,B,C). Only set if the
-* `null_fraction` is the fraction of the rows that have a NULL on the
-  first column (`column_ids[0]`).
-* `histogram` for `column_ids[0]` (optional). It encodes a proto
-  defined as:
+* `cardinality` is the estimated cardinality (on all columns).
+* `null_values` is the number of rows that have a NULL on any
+  of the columns in `column_ids`; these rows don't contribute
+  to the cardinality.
+* `histogram` is optional and can only be set if there is a single
+  column; it encodes a proto defined as:
 
 ```
 message HistogramData {


### PR DESCRIPTION
Changing to "cardinality" from "density" and removing the density vector stuff. I realized it's more flexible if each statistic has a single cardinality; we can have multiple entries as necessary (and we're not constrained on which groups to include).