### PR TITLE
server/status: Don't log every 10 seconds about nodes without an address

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -293,7 +293,9 @@ func (mr *MetricsRecorder) getNetworkActivity(
 		for nodeID, alive := range isLiveMap {
 			address, err := mr.gossip.GetNodeIDAddress(nodeID)
 			if err != nil {
-				log.Warning(ctx, err.Error())
+				if alive {
+					log.Warning(ctx, err.Error())
+				}
 				continue
 			}
 			na := NodeStatus_NetworkActivity{}


### PR DESCRIPTION
On the PM cluster, this is being logged every 10 seconds on every node
because one of the nodes in the cluster has been dead for hours.