### PR TITLE
sql: Adds ON DELETE CASCADE for foreign key references

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -527,7 +527,9 @@ func (sc *SchemaChanger) distBackfill(
 			// backfiller processor.
 			var otherTableDescs []sqlbase.TableDescriptor
 			if backfillType == columnBackfill {
-				fkTables := sqlbase.TablesNeededForFKs(*tableDesc, sqlbase.CheckUpdates)
+				fkTables, _ := sqlbase.TablesNeededForFKs(
+					ctx, *tableDesc, sqlbase.CheckUpdates, sqlbase.NoLookup, sqlbase.NoCheckPrivilege,
+				)
 				for k := range fkTables {
 					table, err := tc.getTableVersionByID(ctx, txn, k)
 					if err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -441,7 +441,8 @@ func resolveFK(
 	}
 
 	if d.Actions.Delete != tree.NoAction &&
-		d.Actions.Delete != tree.Restrict {
+		d.Actions.Delete != tree.Restrict &&
+		d.Actions.Delete != tree.Cascade {
 		feature := fmt.Sprintf("unsupported: ON DELETE %s", d.Actions.Delete)
 		return pgerror.Unimplemented(feature, feature)
 	}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -70,8 +70,10 @@ func (p *planner) Delete(
 		requestedCols = en.tableDesc.Columns
 	}
 
-	fkTables := sqlbase.TablesNeededForFKs(*en.tableDesc, sqlbase.CheckDeletes)
-	if err := p.fillFKTableMap(ctx, fkTables); err != nil {
+	fkTables, err := sqlbase.TablesNeededForFKs(
+		ctx, *en.tableDesc, sqlbase.CheckDeletes, p.lookupFKTable, p.CheckPrivilege,
+	)
+	if err != nil {
 		return nil, err
 	}
 	rd, err := sqlbase.MakeRowDeleter(p.txn, en.tableDesc, fkTables, requestedCols,

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -150,7 +150,9 @@ func (cb *columnBackfiller) runChunk(
 			defer cb.flowCtx.testingKnobs.RunAfterBackfillChunk()
 		}
 
-		fkTables := sqlbase.TablesNeededForFKs(tableDesc, sqlbase.CheckUpdates)
+		fkTables, _ := sqlbase.TablesNeededForFKs(
+			ctx, tableDesc, sqlbase.CheckUpdates, sqlbase.NoLookup, sqlbase.NoCheckPrivilege,
+		)
 		for _, fkTableDesc := range cb.spec.OtherTables {
 			found, ok := fkTables[fkTableDesc.ID]
 			if !ok {

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -155,8 +155,10 @@ func (p *planner) Insert(
 		}
 	}
 
-	fkTables := sqlbase.TablesNeededForFKs(*en.tableDesc, sqlbase.CheckInserts)
-	if err := p.fillFKTableMap(ctx, fkTables); err != nil {
+	fkTables, err := sqlbase.TablesNeededForFKs(
+		ctx, *en.tableDesc, sqlbase.CheckInserts, p.lookupFKTable, p.CheckPrivilege,
+	)
+	if err != nil {
 		return nil, err
 	}
 	ri, err := sqlbase.MakeRowInserter(p.txn, en.tableDesc, fkTables, cols,
@@ -218,8 +220,10 @@ func (p *planner) Insert(
 				return nil, err
 			}
 
-			fkTables := sqlbase.TablesNeededForFKs(*en.tableDesc, sqlbase.CheckUpdates)
-			if err := p.fillFKTableMap(ctx, fkTables); err != nil {
+			fkTables, err := sqlbase.TablesNeededForFKs(
+				ctx, *en.tableDesc, sqlbase.CheckUpdates, p.lookupFKTable, p.CheckPrivilege,
+			)
+			if err != nil {
 				return nil, err
 			}
 			tu := tableUpserterPool.Get().(*tableUpserter)

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1,0 +1,823 @@
+# LogicTest: default parallel-stmts distsql
+
+subtest DeleteCascade_Basic
+### Basic Delete Cascade
+#     a
+#    / \
+#   b1 b2
+#  / \
+# c1  c2
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES b1 ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES b1 ON DELETE CASCADE
+);
+
+statement ok
+INSERT INTO a VALUES ('a-pk1');
+
+statement ok
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1');
+
+statement ok
+INSERT INTO b1 VALUES ('b1-pk2', 'a-pk1');
+
+statement ok
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1');
+
+statement ok
+INSERT INTO b2 VALUES ('b2-pk2', 'a-pk1');
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk1-b1-pk1', 'b1-pk1');
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk2-b1-pk1', 'b1-pk1');
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk3-b1-pk2', 'b1-pk2');
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk4-b1-pk2', 'b1-pk2');
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk1-b1-pk1', 'b1-pk1');
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk2-b1-pk1', 'b1-pk1');
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk3-b1-pk2', 'b1-pk2');
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk4-b1-pk2', 'b1-pk2');
+
+# ON DELETE CASCADE
+statement ok
+DELETE FROM a WHERE id = 'a-pk1';
+
+# Clean up after the test.
+statement ok
+DROP TABLE c2;
+
+statement ok
+DROP TABLE c1;
+
+statement ok
+DROP TABLE b2;
+
+statement ok
+DROP TABLE b1;
+
+statement ok
+DROP TABLE a;
+
+subtest DeleteCascade_PrimaryKeys
+### Basic Delete Cascade using primary keys
+#     a
+#    / \
+#   b1 b2
+#  / \
+# c1  c2
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY REFERENCES a ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY REFERENCES a ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY REFERENCES b1 ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY REFERENCES b1 ON DELETE CASCADE
+);
+
+statement ok
+INSERT INTO a VALUES ('pk1');
+
+statement ok
+INSERT INTO b1 VALUES ('pk1');
+
+statement ok
+INSERT INTO b2 VALUES ('pk1');
+
+statement ok
+INSERT INTO c1 VALUES ('pk1');
+
+statement ok
+INSERT INTO c2 VALUES ('pk1');
+
+# ON DELETE CASCADE
+statement ok
+DELETE FROM a WHERE id = 'pk1';
+
+# Clean up after the test.
+statement ok
+DROP TABLE c2;
+
+statement ok
+DROP TABLE c1;
+
+statement ok
+DROP TABLE b2;
+
+statement ok
+DROP TABLE b1;
+
+statement ok
+DROP TABLE a;
+
+subtest DeleteCascade_CompositeFKs
+### Basic Delete Cascade with composite FKs
+#     a
+#    / \
+#   b1 b2
+#  / \
+# c1  c2
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+ ,x INT
+ ,UNIQUE (id, x)
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,a_id STRING
+ ,x INT
+ ,y INT
+ ,INDEX (a_id, x, y)
+ ,FOREIGN KEY (a_id, x) REFERENCES a (id, x) ON DELETE CASCADE
+ ,UNIQUE (id, x)
+);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,a_id STRING
+ ,x INT
+ ,y INT
+ ,INDEX (a_id, x, y)
+ ,FOREIGN KEY (a_id, x) REFERENCES a (id, x) ON DELETE CASCADE
+ ,UNIQUE (id, x)
+);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,b_id STRING
+ ,x INT
+ ,FOREIGN KEY (b_id, x) REFERENCES b1 (id, x) ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,b_id STRING
+ ,x INT
+ ,FOREIGN KEY (b_id, x) REFERENCES b1 (id, x) ON DELETE CASCADE
+);
+
+statement ok
+INSERT INTO a VALUES ('a-pk1', 1);
+
+statement ok
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1', 1, 1);
+
+statement ok
+INSERT INTO b1 VALUES ('b1-pk2', 'a-pk1', 1, 2);
+
+statement ok
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1', 1, 1);
+
+statement ok
+INSERT INTO b2 VALUES ('b2-pk2', 'a-pk1', 1, 2);
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk1-b1-pk1', 'b1-pk1', 1);
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk2-b1-pk1', 'b1-pk1', 1);
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk3-b1-pk2', 'b1-pk2', 1);
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk4-b1-pk2', 'b1-pk2', 1);
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk1-b1-pk1', 'b1-pk1', 1);
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk2-b1-pk1', 'b1-pk1', 1);
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk3-b1-pk2', 'b1-pk2', 1);
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk4-b1-pk2', 'b1-pk2', 1);
+
+# ON DELETE CASCADE
+statement ok
+DELETE FROM a WHERE id = 'a-pk1';
+
+# Clean up after the test.
+statement ok
+DROP TABLE c2;
+
+statement ok
+DROP TABLE c1;
+
+statement ok
+DROP TABLE b2;
+
+statement ok
+DROP TABLE b1;
+
+statement ok
+DROP TABLE a;
+
+subtest DeleteCascade_Restrict
+### Basic Delete Cascade with Restrict
+#     a
+#    / \
+#   b1 b2
+#  / \
+# c1  c2
+#     |
+#     d
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES b1 ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES b1 ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE d (
+  id STRING PRIMARY KEY
+ ,delete_restrict STRING NOT NULL REFERENCES c2 ON DELETE RESTRICT
+);
+
+statement ok
+INSERT INTO a VALUES ('a-pk1');
+
+statement ok
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1');
+
+statement ok
+INSERT INTO b1 VALUES ('b1-pk2', 'a-pk1');
+
+statement ok
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1');
+
+statement ok
+INSERT INTO b2 VALUES ('b2-pk2', 'a-pk1');
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk1-b1-pk1', 'b1-pk1');
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk2-b1-pk1', 'b1-pk1');
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk3-b1-pk2', 'b1-pk2');
+
+statement ok
+INSERT INTO c1 VALUES ('c1-pk4-b1-pk2', 'b1-pk2');
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk1-b1-pk1', 'b1-pk1');
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk2-b1-pk1', 'b1-pk1');
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk3-b1-pk2', 'b1-pk2');
+
+statement ok
+INSERT INTO c2 VALUES ('c2-pk4-b1-pk2', 'b1-pk2');
+
+statement ok
+INSERT INTO d VALUES ('d-pk1-c2-pk4-b1-pk2', 'c2-pk4-b1-pk2');
+
+# ON DELETE CASCADE
+statement error pq: foreign key violation: values \['c2-pk4-b1-pk2'\] in columns \[id\] referenced in table "d"
+DELETE FROM a WHERE id = 'a-pk1';
+
+# Clean up after the test.
+statement ok
+DROP TABLE d;
+
+statement ok
+DROP TABLE c2;
+
+statement ok
+DROP TABLE c1;
+
+statement ok
+DROP TABLE b2;
+
+statement ok
+DROP TABLE b1;
+
+statement ok
+DROP TABLE a;
+
+subtest DeleteCascade_Interleaved
+### Basic Delete Cascade with Interleaved Tables
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY REFERENCES a ON DELETE CASCADE
+) INTERLEAVE IN PARENT a (id);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY REFERENCES a ON DELETE CASCADE
+) INTERLEAVE IN PARENT a (id);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY REFERENCES b1 ON DELETE CASCADE
+) INTERLEAVE IN PARENT b1 (id);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY REFERENCES b1 ON DELETE CASCADE
+) INTERLEAVE IN PARENT b1 (id);
+
+statement ok
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY REFERENCES b2 ON DELETE CASCADE
+) INTERLEAVE IN PARENT b2 (id);
+
+statement ok
+INSERT INTO a VALUES ('pk1'), ('pk2');
+
+statement ok
+INSERT INTO b1 VALUES ('pk1'), ('pk2');
+
+statement ok
+INSERT INTO b2 VALUES ('pk1'), ('pk2');
+
+statement ok
+INSERT INTO c1 VALUES ('pk1'), ('pk2');
+
+statement ok
+INSERT INTO c2 VALUES ('pk1'), ('pk2');
+
+statement ok
+INSERT INTO c3 VALUES ('pk1'), ('pk2');
+
+# ON DELETE CASCADE from b1 downward
+statement ok
+DELETE FROM b1 WHERE id = 'pk2';
+
+# ON DELETE CASCADE
+statement ok
+DELETE FROM a WHERE id = 'pk1';
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3;
+
+statement ok
+DROP TABLE c2;
+
+statement ok
+DROP TABLE c1;
+
+statement ok
+DROP TABLE b2;
+
+statement ok
+DROP TABLE b1;
+
+statement ok
+DROP TABLE a;
+
+subtest DeleteCascade_InterleavedRestrict
+### Basic Delete Cascade with Interleaved Tables To Restrict
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+#
+# In this test, c3 is restricted, so deleting from a should fail, but from b1
+# should be ok.
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY REFERENCES a ON DELETE CASCADE
+) INTERLEAVE IN PARENT a (id);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY REFERENCES a ON DELETE CASCADE
+) INTERLEAVE IN PARENT a (id);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY REFERENCES b1 ON DELETE CASCADE
+) INTERLEAVE IN PARENT b1 (id);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY REFERENCES b1 ON DELETE CASCADE
+) INTERLEAVE IN PARENT b1 (id);
+
+statement ok
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY REFERENCES b2 ON DELETE RESTRICT
+) INTERLEAVE IN PARENT b2 (id);
+
+statement ok
+INSERT INTO a VALUES ('pk1'), ('pk2');
+
+statement ok
+INSERT INTO b1 VALUES ('pk1'), ('pk2');
+
+statement ok
+INSERT INTO b2 VALUES ('pk1'), ('pk2');
+
+statement ok
+INSERT INTO c1 VALUES ('pk1'), ('pk2');
+
+statement ok
+INSERT INTO c2 VALUES ('pk1'), ('pk2');
+
+statement ok
+INSERT INTO c3 VALUES ('pk1'), ('pk2');
+
+# ON DELETE CASCADE from b1 downward
+statement ok
+DELETE FROM b1 WHERE id = 'pk2';
+
+# ON DELETE CASCADE
+statement error pq: foreign key violation: values \['pk1'\] in columns \[id\] referenced in table "c3"
+DELETE FROM a WHERE id = 'pk1';
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3;
+
+statement ok
+DROP TABLE c2;
+
+statement ok
+DROP TABLE c1;
+
+statement ok
+DROP TABLE b2;
+
+statement ok
+DROP TABLE b1;
+
+statement ok
+DROP TABLE a;
+
+subtest DeleteCascade_SelfReference
+### Self Reference Delete Cascade
+# self <- self
+
+statement ok
+CREATE TABLE self (
+  id INT PRIMARY KEY
+ ,other_id INT REFERENCES self ON DELETE CASCADE
+);
+
+statement ok
+INSERT INTO self VALUES (1, NULL);
+
+statement ok
+INSERT INTO self VALUES (2, 1);
+
+statement ok
+INSERT INTO self VALUES (3, 2);
+
+statement ok
+INSERT INTO self VALUES (4, 3);
+
+statement ok
+DELETE FROM self WHERE id = 1;
+
+# Clean up after the test.
+statement ok
+DROP TABLE self CASCADE;
+
+subtest DeleteCascade_SelfReferenceCycle
+### Self Reference Delete Cascade Cycle
+# self <- self
+
+statement ok
+CREATE TABLE self (
+  id INT PRIMARY KEY
+ ,other_id INT REFERENCES self ON DELETE CASCADE
+);
+
+statement ok
+INSERT INTO self VALUES (1, NULL);
+
+statement ok
+INSERT INTO self VALUES (2, 1);
+
+statement ok
+INSERT INTO self VALUES (3, 2);
+
+statement ok
+INSERT INTO self VALUES (4, 3);
+
+statement ok
+UPDATE self SET other_id = 4 WHERE id = 1;
+
+statement ok
+DELETE FROM self WHERE id = 1;
+
+# Clean up after the test.
+statement ok
+DROP TABLE self CASCADE;
+
+subtest DeleteCascade_TwoTableLoop
+### Delete cascade loop between two tables
+# loop_a <- loop_b
+# loop_b <- loop_a
+
+statement ok
+CREATE TABLE loop_a (
+  id STRING PRIMARY KEY
+ ,cascade_delete STRING
+ ,INDEX(cascade_delete)
+);
+
+statement ok
+CREATE TABLE loop_b (
+  id STRING PRIMARY KEY
+ ,cascade_delete STRING REFERENCES loop_a ON DELETE CASCADE
+);
+
+statement ok
+ALTER TABLE loop_a ADD CONSTRAINT cascade_delete_constraint
+  FOREIGN KEY (cascade_delete) REFERENCES loop_b (id)
+  ON DELETE CASCADE;
+
+statement ok
+INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk1', NULL);
+
+statement ok
+INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk1', 'loop_a-pk1');
+
+statement ok
+INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk2', 'loop_b-pk1');
+
+statement ok
+INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk2', 'loop_a-pk2');
+
+statement ok
+INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk3', 'loop_b-pk2');
+
+statement ok
+INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk3', 'loop_a-pk3');
+
+statement ok
+UPDATE loop_a SET cascade_delete = 'loop_b-pk3' WHERE id = 'loop_a-pk1';
+
+statement ok
+DELETE FROM loop_a WHERE id = 'loop_a-pk1';
+
+# Clean up after the test.
+statement ok
+DROP TABLE loop_a CASCADE;
+
+statement ok
+DROP TABLE loop_b;
+
+subtest DeleteCascade_TwoTableLoopCycle
+### Delete cascade loop between two tables with cycle
+# loop_a <- loop_b
+# loop_b <- loop_a
+
+statement ok
+CREATE TABLE loop_a (
+  id STRING PRIMARY KEY
+ ,cascade_delete STRING
+ ,INDEX(cascade_delete)
+);
+
+statement ok
+CREATE TABLE loop_b (
+  id STRING PRIMARY KEY
+ ,cascade_delete STRING REFERENCES loop_a ON DELETE CASCADE
+);
+
+statement ok
+ALTER TABLE loop_a ADD CONSTRAINT cascade_delete_constraint
+  FOREIGN KEY (cascade_delete) REFERENCES loop_b (id)
+  ON DELETE CASCADE;
+
+statement ok
+INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk1', NULL);
+
+statement ok
+INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk1', 'loop_a-pk1');
+
+statement ok
+INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk2', 'loop_b-pk1');
+
+statement ok
+INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk2', 'loop_a-pk2');
+
+statement ok
+INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk3', 'loop_b-pk2');
+
+statement ok
+INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk3', 'loop_a-pk3');
+
+statement ok
+DELETE FROM loop_a WHERE id = 'loop_a-pk1';
+
+# Clean up after the test.
+statement ok
+DROP TABLE loop_a CASCADE;
+
+statement ok
+DROP TABLE loop_b;
+
+subtest DeleteCascade_DoubleSelfReference
+### Delete cascade double self reference
+# self_x2 (x) <- (y)
+# self_x2 (y) <- (z)
+
+statement ok
+CREATE TABLE self_x2 (
+  x STRING PRIMARY KEY
+ ,y STRING UNIQUE REFERENCES self_x2(x) ON DELETE CASCADE
+ ,z STRING REFERENCES self_x2(y) ON DELETE CASCADE
+ ,INDEX(z)
+);
+
+statement ok
+INSERT INTO self_x2 (x, y, z) VALUES ('pk1', NULL, NULL);
+
+statement ok
+INSERT INTO self_x2 (x, y, z) VALUES ('pk2', 'pk1', NULL);
+
+statement ok
+INSERT INTO self_x2 (x, y, z) VALUES ('pk3', 'pk2', 'pk1');
+
+statement ok
+DELETE FROM self_x2 WHERE x = 'pk1';
+
+# Clean up after the test.
+statement ok
+DROP TABLE self_x2;
+
+## Delete cascade race
+#         a
+#        / \
+#       b   c
+#       |   |
+#       |   d
+#        \ /
+#         e
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b (
+  id STRING PRIMARY KEY
+ ,a_id STRING REFERENCES a ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE c (
+  id STRING PRIMARY KEY
+ ,a_id STRING REFERENCES a ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE d (
+  id STRING PRIMARY KEY
+ ,c_id STRING REFERENCES c ON DELETE CASCADE
+);
+
+statement ok
+CREATE TABLE e (
+  id STRING PRIMARY KEY
+ ,b_id STRING REFERENCES b ON DELETE CASCADE
+ ,d_id STRING REFERENCES d ON DELETE CASCADE
+);
+
+statement ok
+INSERT INTO a (id) VALUES ('a1');
+
+statement ok
+INSERT INTO b (id, a_id) VALUES ('b1', 'a1');
+
+statement ok
+INSERT INTO c (id, a_id) VALUES ('c1', 'a1');
+
+statement ok
+INSERT INTO d (id, c_id) VALUES ('d1', 'c1');
+
+statement ok
+INSERT INTO e (id, b_id, d_id) VALUES ('e1', 'b1', 'd1');
+
+statement ok
+DELETE FROM a WHERE id = 'a1';
+
+# Clean up after the test.
+statement ok
+DROP TABLE e;
+
+statement ok
+DROP TABLE d;
+
+statement ok
+DROP TABLE c;
+
+statement ok
+DROP TABLE b;
+
+statement ok
+DROP TABLE a;

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -77,8 +77,11 @@ ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON UPDATE NO AC
 statement ok
 ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
 
-statement error pq: unsupported: ON DELETE CASCADE
+statement ok
 ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON DELETE CASCADE
+
+statement ok
+ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
 
 statement error pq: unsupported: ON UPDATE CASCADE
 ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON UPDATE CASCADE
@@ -919,3 +922,62 @@ DELETE FROM test20045 WHERE x = 'pk2';
 
 statement ok
 DELETE FROM test20045 WHERE x = 'pk1';
+
+## Delete cascade without privileges
+
+statement ok
+CREATE DATABASE d;
+
+statement ok
+CREATE TABLE d.a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE d.b (
+  id STRING PRIMARY KEY
+ ,a_id STRING REFERENCES d.a ON DELETE CASCADE
+);
+
+statement ok
+INSERT INTO d.a VALUES ('a1');
+
+statement ok
+INSERT INTO d.b VALUES ('b1', 'a1');
+
+statement ok
+GRANT ALL ON DATABASE d TO testuser;
+
+statement ok
+GRANT ALL ON d.a TO testuser;
+
+user testuser
+
+statement error user testuser does not have SELECT privilege on relation b
+DELETE FROM d.a WHERE id = 'a1';
+
+user root
+
+statement ok
+GRANT SELECT ON d.b TO testuser;
+
+user testuser
+
+statement error user testuser does not have DELETE privilege on relation b
+DELETE FROM d.a WHERE id = 'a1';
+
+user root
+
+statement ok
+GRANT DELETE ON d.b TO testuser;
+
+user testuser
+
+statement ok
+DELETE FROM d.a WHERE id = 'a1';
+
+user root
+
+# Clean up after the test.
+statement ok
+DROP DATABASE d CASCADE;

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -343,19 +343,17 @@ func (p *planner) exec(ctx context.Context, sql string, args ...interface{}) (in
 	return countRowsAffected(params, plan)
 }
 
-func (p *planner) fillFKTableMap(ctx context.Context, m sqlbase.TableLookupsByID) error {
-	for tableID := range m {
-		table, err := p.session.tables.getTableVersionByID(ctx, p.txn, tableID)
+func (p *planner) lookupFKTable(
+	ctx context.Context, tableID sqlbase.ID,
+) (sqlbase.TableLookup, error) {
+	table, err := p.session.tables.getTableVersionByID(ctx, p.txn, tableID)
+	if err != nil {
 		if err == errTableAdding {
-			m[tableID] = sqlbase.TableLookup{IsAdding: true}
-			continue
+			return sqlbase.TableLookup{IsAdding: true}, nil
 		}
-		if err != nil {
-			return err
-		}
-		m[tableID] = sqlbase.TableLookup{Table: table}
+		return sqlbase.TableLookup{}, err
 	}
-	return nil
+	return sqlbase.TableLookup{Table: table}, nil
 }
 
 // isDatabaseVisible returns true if the given database is visible

--- a/pkg/sql/sqlbase/cascader.go
+++ b/pkg/sql/sqlbase/cascader.go
@@ -1,0 +1,475 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// cascader is used to handle all referential integrity cascading actions.
+type cascader struct {
+	txn                *client.Txn
+	tablesByID         TableLookupsByID                   // TablesDescriptors by Table ID
+	indexRowFetchers   map[ID]map[IndexID]MultiRowFetcher // RowFetchers by Table ID and Index ID
+	rowDeleters        map[ID]RowDeleter                  // RowDeleters by Table ID
+	deleterRowFetchers map[ID]MultiRowFetcher             // RowFetchers for rowDeleters by Table ID
+	// TODO(Bram): replace rowsToCheck's datums with row_containers for memory
+	// monitoring.
+	rowsToCheck map[ID][]tree.Datums // Rows that have been deleted by Table ID
+	alloc       *DatumAlloc
+}
+
+func makeCascader(txn *client.Txn, tablesByID TableLookupsByID, alloc *DatumAlloc) *cascader {
+	return &cascader{
+		txn:                txn,
+		tablesByID:         tablesByID,
+		indexRowFetchers:   make(map[ID]map[IndexID]MultiRowFetcher),
+		rowDeleters:        make(map[ID]RowDeleter),
+		deleterRowFetchers: make(map[ID]MultiRowFetcher),
+		rowsToCheck:        make(map[ID][]tree.Datums),
+		alloc:              alloc,
+	}
+}
+
+// spanForIndexValues creates a span against an index to extract the primary
+// keys needed for cascading.
+func spanForIndexValues(
+	table *TableDescriptor,
+	index *IndexDescriptor,
+	prefixLen int,
+	indexColIDs map[ColumnID]int,
+	values []tree.Datum,
+	keyPrefix []byte,
+) (roachpb.Span, error) {
+	keyBytes, _, err := EncodePartialIndexKey(table, index, prefixLen, indexColIDs, values, keyPrefix)
+	if err != nil {
+		return roachpb.Span{}, err
+	}
+	key := roachpb.Key(keyBytes)
+	if index.ID == table.PrimaryIndex.ID {
+		return roachpb.Span{Key: key, EndKey: encoding.EncodeInterleavedSentinel(key)}, nil
+	}
+	return roachpb.Span{Key: key, EndKey: key.PrefixEnd()}, nil
+}
+
+// batchRequestForIndexValues creates a batch request against an index to
+// extract the primary keys needed for cascading.
+func batchRequestForIndexValues(
+	referencedIndex *IndexDescriptor,
+	referencingTable *TableDescriptor,
+	referencingIndex *IndexDescriptor,
+	values []tree.Datums,
+	colIDtoRowIndex map[ColumnID]int,
+) (roachpb.BatchRequest, error) {
+
+	//TODO(bram): consider caching some of these values
+	keyPrefix := MakeIndexKeyPrefix(referencingTable, referencingIndex.ID)
+	prefixLen := len(referencingIndex.ColumnIDs)
+	if len(referencedIndex.ColumnIDs) < prefixLen {
+		prefixLen = len(referencedIndex.ColumnIDs)
+	}
+	indexColIDs := make(map[ColumnID]int, len(referencedIndex.ColumnIDs))
+	for i, referencedColID := range referencedIndex.ColumnIDs[:prefixLen] {
+		if found, ok := colIDtoRowIndex[referencedColID]; ok {
+			indexColIDs[referencingIndex.ColumnIDs[i]] = found
+		} else {
+			return roachpb.BatchRequest{}, errors.Errorf(
+				"missing value for column %q in multi-part foreign key", referencedIndex.ColumnNames[i],
+			)
+		}
+	}
+
+	var req roachpb.BatchRequest
+	for _, value := range values {
+		span, err := spanForIndexValues(
+			referencingTable, referencingIndex, prefixLen, indexColIDs, value, keyPrefix,
+		)
+		if err != nil {
+			return roachpb.BatchRequest{}, err
+		}
+		req.Add(&roachpb.ScanRequest{Span: span})
+	}
+	return req, nil
+}
+
+// spanForPKValues creates a span against the primary index of a table and is
+// used to fetch rows for cascading.
+func spanForPKValues(
+	table *TableDescriptor, fetchColIDtoRowIndex map[ColumnID]int, values tree.Datums,
+) (roachpb.Span, error) {
+	return spanForIndexValues(
+		table,
+		&table.PrimaryIndex,
+		len(table.PrimaryIndex.ColumnIDs),
+		fetchColIDtoRowIndex,
+		values,
+		MakeIndexKeyPrefix(table, table.PrimaryIndex.ID),
+	)
+}
+
+// batchRequestForPKValues creates a batch request against the primary index of
+// a table and is used to fetch rows for cascading.
+func batchRequestForPKValues(
+	table *TableDescriptor, fetchColIDtoRowIndex map[ColumnID]int, values []tree.Datums,
+) (roachpb.BatchRequest, error) {
+	var req roachpb.BatchRequest
+	for _, value := range values {
+		span, err := spanForPKValues(table, fetchColIDtoRowIndex, value)
+		if err != nil {
+			return roachpb.BatchRequest{}, err
+		}
+		req.Add(&roachpb.ScanRequest{Span: span})
+	}
+	return req, nil
+}
+
+// addIndexRowFetch will create or load a cached row fetcher on an index to
+// fetch the primary keys of the rows that will be affected by a cascading
+// action.
+func (c *cascader) addIndexRowFetcher(
+	table *TableDescriptor, index *IndexDescriptor,
+) (MultiRowFetcher, error) {
+	// Is there a cached row fetcher?
+	rowFetchersForTable, exists := c.indexRowFetchers[table.ID]
+	if exists {
+		rowFetcher, exists := rowFetchersForTable[index.ID]
+		if exists {
+			return rowFetcher, nil
+		}
+	} else {
+		c.indexRowFetchers[table.ID] = make(map[IndexID]MultiRowFetcher)
+	}
+
+	// Create a new row fetcher. Only the primary key columns are required.
+	var colDesc []ColumnDescriptor
+	for _, id := range table.PrimaryIndex.ColumnIDs {
+		cDesc, err := table.FindColumnByID(id)
+		if err != nil {
+			return MultiRowFetcher{}, err
+		}
+		colDesc = append(colDesc, *cDesc)
+	}
+	var valNeededForCol util.FastIntSet
+	valNeededForCol.AddRange(0, len(colDesc)-1)
+	isSecondary := table.PrimaryIndex.ID != index.ID
+	var rowFetcher MultiRowFetcher
+	if err := rowFetcher.Init(
+		false, /* reverse */
+		false, /* returnRangeInfo */
+		false, /* isCheck */
+		c.alloc,
+		MultiRowFetcherTableArgs{
+			Desc:             table,
+			Index:            index,
+			ColIdxMap:        ColIDtoRowIndexFromCols(colDesc),
+			IsSecondaryIndex: isSecondary,
+			Cols:             colDesc,
+			ValNeededForCol:  valNeededForCol,
+		},
+	); err != nil {
+		return MultiRowFetcher{}, err
+	}
+	// Cache the row fetcher.
+	c.indexRowFetchers[table.ID][index.ID] = rowFetcher
+	return rowFetcher, nil
+}
+
+// addRowDeleter creates the row deleter and primary index row fetcher.
+func (c *cascader) addRowDeleter(table *TableDescriptor) (RowDeleter, MultiRowFetcher, error) {
+	// Is there a cached row fetcher and deleter?
+	if rowDeleter, exists := c.rowDeleters[table.ID]; exists {
+		return rowDeleter, c.deleterRowFetchers[table.ID], nil
+	}
+
+	// Create the row deleter. The row deleter is needed prior to the row fetcher
+	// as it will dictate what columns are required in the row fetcher.
+	rowDeleter, err := MakeRowDeleter(
+		c.txn,
+		table,
+		c.tablesByID,
+		nil,  /* requestedCol */
+		true, /* checkFKs */
+		c.alloc,
+	)
+	if err != nil {
+		return RowDeleter{}, MultiRowFetcher{}, err
+	}
+
+	// Create the row fetcher that will retrive the rows and columns needed for
+	// deletion.
+	var valNeededForCol util.FastIntSet
+	valNeededForCol.AddRange(0, len(rowDeleter.FetchCols)-1)
+	tableArgs := MultiRowFetcherTableArgs{
+		Desc:             table,
+		Index:            &table.PrimaryIndex,
+		ColIdxMap:        rowDeleter.FetchColIDtoRowIndex,
+		IsSecondaryIndex: false,
+		Cols:             rowDeleter.FetchCols,
+		ValNeededForCol:  valNeededForCol,
+	}
+	var rowFetcher MultiRowFetcher
+	if err := rowFetcher.Init(
+		false, /* reverse */
+		false, /* returnRangeInfo */
+		false, /* isCheck */
+		c.alloc,
+		tableArgs,
+	); err != nil {
+		return RowDeleter{}, MultiRowFetcher{}, err
+	}
+
+	// Cache both the fetcher and deleter.
+	c.rowDeleters[table.ID] = rowDeleter
+	c.deleterRowFetchers[table.ID] = rowFetcher
+	return rowDeleter, rowFetcher, nil
+}
+
+// deleteRow performs row deletions on a single table for all rows that match
+// the values. Returns the values of the rows that were deleted. This deletion
+// happens in a single batch.
+func (c *cascader) deleteRow(
+	ctx context.Context,
+	referencedIndex *IndexDescriptor,
+	referencingTable *TableDescriptor,
+	referencingIndex *IndexDescriptor,
+	values []tree.Datums,
+	colIDtoRowIndex map[ColumnID]int,
+	traceKV bool,
+) ([]tree.Datums, map[ColumnID]int, error) {
+	// Create the span to search for index values.
+	// TODO(bram): This initial index lookup can be skipped if the index is the
+	// primary index.
+	if traceKV {
+		log.VEventf(ctx, 2,
+			"cascading delete from refIndex:%s, into table:%s, using index:%s for values:%+v",
+			referencedIndex.Name, referencingTable.Name, referencingIndex.Name, values,
+		)
+	}
+	req, err := batchRequestForIndexValues(
+		referencedIndex, referencingTable, referencingIndex, values, colIDtoRowIndex,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	br, roachErr := c.txn.Send(ctx, req)
+	if roachErr != nil {
+		return nil, nil, roachErr.GoError()
+	}
+
+	// Create or retrieve the index row fetcher.
+	indexRowFetcher, err := c.addIndexRowFetcher(referencingTable, referencingIndex)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Fetch all the primary keys that need to be deleted.
+	// TODO(Bram): use a row container here and consider chunking this into n,
+	// primary keys, perhaps 100, at time.
+	var primaryKeysToDel []tree.Datums
+	for _, resp := range br.Responses {
+		fetcher := spanKVFetcher{
+			kvs: resp.GetInner().(*roachpb.ScanResponse).Rows,
+		}
+		if err := indexRowFetcher.StartScanFrom(ctx, &fetcher); err != nil {
+			return nil, nil, err
+		}
+		for !indexRowFetcher.kvEnd {
+			primaryKey, _, _, err := indexRowFetcher.NextRowDecoded(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
+			// Make a copy of the primary key because the datum struct is reused in
+			// the row fetcher.
+			primaryKey = append(tree.Datums(nil), primaryKey...)
+			primaryKeysToDel = append(primaryKeysToDel, primaryKey)
+		}
+	}
+
+	// Early exit if no rows need to be deleted.
+	if len(primaryKeysToDel) == 0 {
+		return nil, nil, nil
+	}
+
+	// Create or retrieve the row deleter and primary index row fetcher.
+	rowDeleter, pkRowFetcher, err := c.addRowDeleter(referencingTable)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Create a batch request to get all the spans of the primary keys that need
+	// to be deleted.
+	pkLookupReq, err := batchRequestForPKValues(
+		referencingTable, rowDeleter.FetchColIDtoRowIndex, primaryKeysToDel,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	pkResp, roachErr := c.txn.Send(ctx, pkLookupReq)
+	if roachErr != nil {
+		return nil, nil, roachErr.GoError()
+	}
+
+	// Fetch the rows for deletion.
+	// TODO(Bram): use a row container here too for rowsToDelete.
+	var rowsToDelete []tree.Datums
+	for _, resp := range pkResp.Responses {
+		fetcher := spanKVFetcher{
+			kvs: resp.GetInner().(*roachpb.ScanResponse).Rows,
+		}
+		if err := pkRowFetcher.StartScanFrom(ctx, &fetcher); err != nil {
+			return nil, nil, err
+		}
+		for !pkRowFetcher.kvEnd {
+			rowToDelete, _, _, err := pkRowFetcher.NextRowDecoded(ctx)
+			if err != nil {
+				return nil, nil, err
+			}
+			// Make a copy of the rowToDelete because the datum struct is reused in
+			// the row fetcher.
+			rowToDelete = append(tree.Datums(nil), rowToDelete...)
+			rowsToDelete = append(rowsToDelete, rowToDelete)
+		}
+	}
+
+	// Delete the rows in a new batch.
+	// TODO(bram): Can we move this batch out of this function?  Might not work
+	// when dealing with updates.
+	deleteBatch := c.txn.NewBatch()
+	for _, row := range rowsToDelete {
+		if err := rowDeleter.deleteRowNoCascade(ctx, deleteBatch, row, traceKV); err != nil {
+			return nil, nil, err
+		}
+	}
+	if err := c.txn.Run(ctx, deleteBatch); err != nil {
+		return nil, nil, err
+	}
+
+	// Add the values to be checked for consistency after all cascading changes
+	// have finished.
+	c.rowsToCheck[referencingTable.ID] = append(c.rowsToCheck[referencingTable.ID], rowsToDelete...)
+	return rowsToDelete, rowDeleter.FetchColIDtoRowIndex, nil
+}
+
+type cascadeQueueElement struct {
+	table *TableDescriptor
+	// TODO(Bram): replace values' datums with row_containers for memory
+	// monitoring.
+	values          []tree.Datums
+	colIDtoRowIndex map[ColumnID]int
+}
+
+// cascadeQueue is used for a breadth first walk of the referential integrity
+// graph.
+type cascadeQueue []cascadeQueueElement
+
+func (q *cascadeQueue) enqueue(elem cascadeQueueElement) {
+	*q = append((*q), elem)
+}
+
+func (q *cascadeQueue) dequeue() (cascadeQueueElement, bool) {
+	if len(*q) == 0 {
+		return cascadeQueueElement{}, false
+	}
+	elem := (*q)[0]
+	*q = (*q)[1:]
+	return elem, true
+}
+
+// cascadeAll performs all required cascading operations, then checks all the
+// remaining indexes to ensure that no orphans were created.
+func (c *cascader) cascadeAll(
+	ctx context.Context,
+	table *TableDescriptor,
+	originalValues tree.Datums,
+	colIDtoRowIndex map[ColumnID]int,
+	traceKV bool,
+) error {
+	// Perform all the required cascading operations.
+	var cascadeQ cascadeQueue
+	cascadeQ.enqueue(cascadeQueueElement{table, []tree.Datums{originalValues}, colIDtoRowIndex})
+	for {
+		select {
+		case <-ctx.Done():
+			return NewQueryCanceledError()
+		default:
+		}
+		elem, exists := cascadeQ.dequeue()
+		if !exists {
+			break
+		}
+		if traceKV {
+			log.VEventf(ctx, 2, "cascading into %s for values:%s", elem.table.Name, elem.values)
+		}
+		for _, referencedIndex := range elem.table.AllNonDropIndexes() {
+			for _, ref := range referencedIndex.ReferencedBy {
+				referencingTable, ok := c.tablesByID[ref.Table]
+				if !ok {
+					return errors.Errorf("Could not find table:%d in table descriptor map", ref.Table)
+				}
+				if referencingTable.IsAdding {
+					// We can assume that a table being added but not yet public is empty,
+					// and thus does not need to be checked for cascading.
+					continue
+				}
+				referencingIndex, err := referencingTable.Table.FindIndexByID(ref.Index)
+				if err != nil {
+					return err
+				}
+				if referencingIndex.ForeignKey.OnDelete == ForeignKeyReference_CASCADE {
+					returnedValues, colIDtoRowIndex, err := c.deleteRow(
+						ctx, &referencedIndex, referencingTable.Table, referencingIndex, elem.values, elem.colIDtoRowIndex, traceKV,
+					)
+					if err != nil {
+						return err
+					}
+					if len(returnedValues) > 0 {
+						// If a row was deleted, add the table to the queue.
+						cascadeQ.enqueue(cascadeQueueElement{
+							table:           referencingTable.Table,
+							values:          returnedValues,
+							colIDtoRowIndex: colIDtoRowIndex,
+						})
+					}
+				}
+			}
+		}
+	}
+
+	// Check all values to ensure there are no orphans.
+	for tableID, removedValues := range c.rowsToCheck {
+		if len(removedValues) == 0 {
+			continue
+		}
+		rowDeleter, exists := c.rowDeleters[tableID]
+		if !exists {
+			return errors.Errorf("programming error: could not find row deleter for table %d", tableID)
+		}
+		for _, removedValue := range removedValues {
+			if err := rowDeleter.Fks.checkAll(ctx, removedValue); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -39,44 +40,205 @@ type TableLookup struct {
 	IsAdding bool
 }
 
+// TableLookupFunction is the function type used by TablesNeededForFKs that will
+// perform the actual lookup.
+type TableLookupFunction func(context.Context, ID) (TableLookup, error)
+
+// NoLookup can be used to not perform any lookups during a TablesNeededForFKs
+// function call.
+func NoLookup(_ context.Context, _ ID) (TableLookup, error) {
+	return TableLookup{}, nil
+}
+
+// CheckPrivilegeFunction is the function type used by TablesNeededForFKs that will
+// check the privileges of the current user to access specific tables.
+type CheckPrivilegeFunction func(DescriptorProto, privilege.Kind) error
+
+// NoCheckPrivilege can be used to not perform any privilege checks during a
+// TablesNeededForFKs function call.
+func NoCheckPrivilege(_ DescriptorProto, _ privilege.Kind) error {
+	return nil
+}
+
 // FKCheck indicates a kind of FK check (delete, insert, or both).
 type FKCheck int
 
 const (
 	// CheckDeletes checks if rows reference a changed value.
-	CheckDeletes FKCheck = iota
-	// CheckInserts checks if a new/changed value references an existing row.
+	CheckDeletes = iota
+	// CheckInserts checks if a new value references an existing row.
 	CheckInserts
 	// CheckUpdates checks all references (CheckDeletes+CheckInserts).
 	CheckUpdates
 )
 
-// TablesNeededForFKs calculates the IDs of the additional TableDescriptors that
-// will be needed for FK checking delete and/or insert operations on `table`.
-//
-// NB: the returned map's values are *not* set -- higher level calling code, eg
-// in planner, should fill the map's values by acquiring leases. This function
-// is essentially just returning a slice of IDs, but the empty map can be filled
-// in place and reused, avoiding a second allocation.
-func TablesNeededForFKs(table TableDescriptor, usage FKCheck) TableLookupsByID {
-	var ret TableLookupsByID
-	for _, idx := range table.AllNonDropIndexes() {
-		if usage != CheckDeletes && idx.ForeignKey.IsSet() {
-			if ret == nil {
-				ret = make(TableLookupsByID)
-			}
-			ret[idx.ForeignKey.Table] = TableLookup{}
+type tableLookupQueueElement struct {
+	tableLookup TableLookup
+	usage       FKCheck
+}
+
+type tableLookupQueue struct {
+	queue          []tableLookupQueueElement
+	alreadyChecked map[ID]map[FKCheck]struct{}
+	tableLookups   TableLookupsByID
+	lookup         TableLookupFunction
+	checkPrivilege CheckPrivilegeFunction
+}
+
+func (q *tableLookupQueue) getTable(ctx context.Context, tableID ID) (TableLookup, error) {
+	if tableLookup, exists := q.tableLookups[tableID]; exists {
+		return tableLookup, nil
+	}
+	tableLookup, err := q.lookup(ctx, tableID)
+	if err != nil {
+		return TableLookup{}, err
+	}
+	if !tableLookup.IsAdding && tableLookup.Table != nil {
+		if err := q.checkPrivilege(tableLookup.Table, privilege.SELECT); err != nil {
+			return TableLookup{}, err
 		}
-		if usage != CheckInserts {
-			for _, ref := range idx.ReferencedBy {
-				if ret == nil {
-					ret = make(TableLookupsByID)
+	}
+	q.tableLookups[tableID] = tableLookup
+	return tableLookup, nil
+}
+
+func (q *tableLookupQueue) enqueue(ctx context.Context, tableID ID, usage FKCheck) error {
+	// Lookup the table.
+	tableLookup, err := q.getTable(ctx, tableID)
+	if err != nil {
+		return err
+	}
+	// Don't enqueue if lookup returns an empty tableLookup. This just means that
+	// there is no need to walk any further.
+	if tableLookup.Table == nil {
+		return nil
+	}
+	// Only enqueue checks that haven't been performed yet.
+	if alreadyCheckByTableID, exists := q.alreadyChecked[tableID]; exists {
+		if _, existsInner := alreadyCheckByTableID[usage]; existsInner {
+			return nil
+		}
+	} else {
+		q.alreadyChecked[tableID] = make(map[FKCheck]struct{})
+	}
+	q.alreadyChecked[tableID][usage] = struct{}{}
+	// If the table is being added, there's no need to check it.
+	if tableLookup.IsAdding {
+		return nil
+	}
+	switch usage {
+	// Insert has already been checked when the table is fetched.
+	case CheckDeletes:
+		if err := q.checkPrivilege(tableLookup.Table, privilege.DELETE); err != nil {
+			return err
+		}
+	case CheckUpdates:
+		if err := q.checkPrivilege(tableLookup.Table, privilege.UPDATE); err != nil {
+			return err
+		}
+	}
+	(*q).queue = append((*q).queue, tableLookupQueueElement{tableLookup: tableLookup, usage: usage})
+	return nil
+}
+
+func (q *tableLookupQueue) dequeue() (TableLookup, FKCheck, bool) {
+	if len((*q).queue) == 0 {
+		return TableLookup{}, 0, false
+	}
+	elem := (*q).queue[0]
+	(*q).queue = (*q).queue[1:]
+	return elem.tableLookup, elem.usage, true
+}
+
+// TablesNeededForFKs populates a map of TableLookupsByID for all the
+// TableDescriptors that might be needed when performing FK checking for delete
+// and/or insert operations. It uses the passed in lookup function to perform
+// the actual lookup.
+func TablesNeededForFKs(
+	ctx context.Context,
+	table TableDescriptor,
+	usage FKCheck,
+	lookup TableLookupFunction,
+	checkPrivilege CheckPrivilegeFunction,
+) (TableLookupsByID, error) {
+	queue := tableLookupQueue{
+		tableLookups:   make(TableLookupsByID),
+		alreadyChecked: make(map[ID]map[FKCheck]struct{}),
+		lookup:         lookup,
+		checkPrivilege: checkPrivilege,
+	}
+	// Add the passed in table descriptor to the table lookup.
+	queue.tableLookups[table.ID] = TableLookup{Table: &table}
+	if err := queue.enqueue(ctx, table.ID, usage); err != nil {
+		return nil, err
+	}
+	for {
+		tableLookup, curUsage, exists := queue.dequeue()
+		if !exists {
+			return queue.tableLookups, nil
+		}
+		// If the table descriptor is nil it means that there was no actual lookup
+		// performed. Meaning there is no need to walk any secondary relationships
+		// and the table descriptor lookup will happen later.
+		if tableLookup.IsAdding || tableLookup.Table == nil {
+			continue
+		}
+		for _, idx := range tableLookup.Table.AllNonDropIndexes() {
+			if curUsage == CheckInserts || curUsage == CheckUpdates {
+				if idx.ForeignKey.IsSet() {
+					if _, err := queue.getTable(ctx, idx.ForeignKey.Table); err != nil {
+						return nil, err
+					}
 				}
-				ret[ref.Table] = TableLookup{}
+			}
+			if curUsage == CheckDeletes || curUsage == CheckUpdates {
+				for _, ref := range idx.ReferencedBy {
+					// The table being referenced is required to know the relationship, so
+					// fetch it here.
+					referencedTableLookup, err := queue.getTable(ctx, ref.Table)
+					if err != nil {
+						return nil, err
+					}
+					// Again here if the table descriptor is nil it means that there was
+					// no actual lookup performed. Meaning there is no need to walk any
+					// secondary relationships.
+					if referencedTableLookup.IsAdding || referencedTableLookup.Table == nil {
+						continue
+					}
+					referencedIdx, err := referencedTableLookup.Table.FindIndexByID(ref.Index)
+					if err != nil {
+						return nil, err
+					}
+					if curUsage == CheckDeletes {
+						var nextUsage FKCheck
+						switch referencedIdx.ForeignKey.OnDelete {
+						case ForeignKeyReference_CASCADE:
+							nextUsage = CheckDeletes
+						case ForeignKeyReference_SET_DEFAULT, ForeignKeyReference_SET_NULL:
+							nextUsage = CheckUpdates
+						default:
+							// There is no need to check any other relationships.
+							continue
+						}
+						if err := queue.enqueue(ctx, referencedTableLookup.Table.ID, nextUsage); err != nil {
+							return nil, err
+						}
+					} else {
+						// curUsage == CheckUpdates
+						if referencedIdx.ForeignKey.OnUpdate == ForeignKeyReference_CASCADE ||
+							referencedIdx.ForeignKey.OnUpdate == ForeignKeyReference_SET_DEFAULT ||
+							referencedIdx.ForeignKey.OnUpdate == ForeignKeyReference_SET_NULL {
+							if err := queue.enqueue(
+								ctx, referencedTableLookup.Table.ID, CheckUpdates,
+							); err != nil {
+								return nil, err
+							}
+						}
+					}
+				}
 			}
 		}
 	}
-	return ret
 }
 
 // spanKVFetcher is an kvFetcher that returns a set slice of kvs.
@@ -151,7 +313,6 @@ func (f *fkBatchChecker) runCheck(
 	fetcher := spanKVFetcher{}
 	for i, resp := range br.Responses {
 		fk := f.batchIdxToFk[i]
-
 		fetcher.kvs = resp.GetInner().(*roachpb.ScanResponse).Rows
 		if err := fk.rf.StartScanFrom(ctx, &fetcher); err != nil {
 			return err
@@ -285,7 +446,9 @@ func checkIdx(
 }
 
 type fkDeleteHelper struct {
-	fks map[IndexID][]baseFKHelper
+	fks         map[IndexID][]baseFKHelper
+	otherTables TableLookupsByID
+	alloc       *DatumAlloc
 
 	checker *fkBatchChecker
 }
@@ -298,6 +461,8 @@ func makeFKDeleteHelper(
 	alloc *DatumAlloc,
 ) (fkDeleteHelper, error) {
 	h := fkDeleteHelper{
+		otherTables: otherTables,
+		alloc:       alloc,
 		checker: &fkBatchChecker{
 			txn: txn,
 		},
@@ -314,7 +479,7 @@ func makeFKDeleteHelper(
 				continue
 			}
 			if err != nil {
-				return h, err
+				return fkDeleteHelper{}, err
 			}
 			if h.fks == nil {
 				h.fks = make(map[IndexID][]baseFKHelper)

--- a/pkg/sql/sqlbase/fk_test.go
+++ b/pkg/sql/sqlbase/fk_test.go
@@ -1,0 +1,205 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/kr/pretty"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+)
+
+type testTables struct {
+	nextID       ID
+	tablesByID   map[ID]*TableDescriptor
+	tablesByName map[string]*TableDescriptor
+}
+
+func (t *testTables) createTestTable(name string) ID {
+	table := &TableDescriptor{
+		Name:        name,
+		ID:          t.nextID,
+		NextIndexID: IndexID(1), // This must be 1 to avoid clashing with a primary index.
+	}
+	t.tablesByID[table.ID] = table
+	t.tablesByName[table.Name] = table
+	t.nextID++
+	return table.ID
+}
+
+func (t *testTables) createForeignKeyReference(
+	referencingID ID,
+	referencedID ID,
+	onDelete ForeignKeyReference_Action,
+	onUpdate ForeignKeyReference_Action,
+) error {
+	// Get the tables
+	referencing, exists := t.tablesByID[referencingID]
+	if !exists {
+		return errors.Errorf("Can't find table with ID:%d", referencingID)
+	}
+	referenced, exists := t.tablesByID[referencedID]
+	if !exists {
+		return errors.Errorf("Can't find table with ID:%d", referencedID)
+	}
+	// Create an index on both tables.
+	referencedIndexID := referenced.NextIndexID
+	referencingIndexID := referencing.NextIndexID
+	referencedIndex := IndexDescriptor{
+		ID: referencedIndexID,
+		ReferencedBy: []ForeignKeyReference{
+			{
+				Table: referencingID,
+				Index: referencingIndexID,
+			},
+		},
+	}
+	referenced.Indexes = append(referenced.Indexes, referencedIndex)
+
+	referencingIndex := IndexDescriptor{
+		ID: referencingIndexID,
+		ForeignKey: ForeignKeyReference{
+			Table:    referencedID,
+			OnDelete: onDelete,
+			OnUpdate: onUpdate,
+			Index:    referencedIndexID,
+		},
+	}
+	referencing.Indexes = append(referencing.Indexes, referencingIndex)
+
+	referenced.NextIndexID++
+	referencing.NextIndexID++
+	return nil
+}
+
+// TestTablesNeededForFKs creates an artificial set of tables to test the graph
+// walking algorithm used in the function.
+func TestTablesNeededForFKs(t *testing.T) {
+	tables := testTables{
+		nextID:       ID(1),
+		tablesByID:   make(map[ID]*TableDescriptor),
+		tablesByName: make(map[string]*TableDescriptor),
+	}
+
+	// First setup the table we will be testing against.
+	xID := tables.createTestTable("X")
+
+	expectedInsertIDs := []ID{xID}
+	expectedUpdateIDs := []ID{xID}
+	expectedDeleteIDs := []ID{xID}
+
+	// For all possible combinations of relationships for foreign keys, create a
+	// table that X references, and one that references X.
+	for deleteNum, deleteName := range ForeignKeyReference_Action_name {
+		for updateNum, updateName := range ForeignKeyReference_Action_name {
+			subName := fmt.Sprintf("OnDelete%s OnUpdate%s", deleteName, updateName)
+			referencedByX := tables.createTestTable(fmt.Sprintf("X Referenced - %s", subName))
+			if err := tables.createForeignKeyReference(
+				xID, referencedByX, ForeignKeyReference_Action(deleteNum), ForeignKeyReference_Action(updateNum),
+			); err != nil {
+				t.Fatalf("could not add index: %s", err)
+			}
+
+			referencingX := tables.createTestTable(fmt.Sprintf("Referencing X - %s", subName))
+			if err := tables.createForeignKeyReference(
+				referencingX, xID, ForeignKeyReference_Action(deleteNum), ForeignKeyReference_Action(updateNum),
+			); err != nil {
+				t.Fatalf("could not add index: %s", err)
+			}
+
+			expectedInsertIDs = append(expectedInsertIDs, referencedByX)
+			expectedUpdateIDs = append(expectedUpdateIDs, referencedByX)
+			expectedUpdateIDs = append(expectedUpdateIDs, referencingX)
+			expectedDeleteIDs = append(expectedDeleteIDs, referencingX)
+
+			// To go even further, create another set of tables for all possible
+			// foreign key relationships that reference the table that is referencing
+			// X. This will ensure that we bound the tree walking algorithm correctly.
+			for deleteNum2, deleteName2 := range ForeignKeyReference_Action_name {
+				for updateNum2, updateName2 := range ForeignKeyReference_Action_name {
+					//if deleteNum2 != int32(ForeignKeyReference_CASCADE) || updateNum2 != int32(ForeignKeyReference_CASCADE) {
+					//	continue
+					//}
+					subName2 := fmt.Sprintf("Referencing %d - OnDelete%s OnUpdated%s", referencingX, deleteName2, updateName2)
+					referencing2 := tables.createTestTable(subName2)
+					if err := tables.createForeignKeyReference(
+						referencing2, referencingX, ForeignKeyReference_Action(deleteNum2), ForeignKeyReference_Action(updateNum2),
+					); err != nil {
+						t.Fatalf("could not add index: %s", err)
+					}
+
+					// Only fetch the next level of tables if a cascade can occur through
+					// the first level.
+					if deleteNum == int32(ForeignKeyReference_CASCADE) ||
+						deleteNum == int32(ForeignKeyReference_SET_DEFAULT) ||
+						deleteNum == int32(ForeignKeyReference_SET_NULL) {
+						expectedDeleteIDs = append(expectedDeleteIDs, referencing2)
+					}
+					if updateNum == int32(ForeignKeyReference_CASCADE) ||
+						updateNum == int32(ForeignKeyReference_SET_DEFAULT) ||
+						updateNum == int32(ForeignKeyReference_SET_NULL) {
+						expectedUpdateIDs = append(expectedUpdateIDs, referencing2)
+					}
+				}
+			}
+		}
+	}
+
+	sort.Slice(expectedInsertIDs, func(i, j int) bool { return expectedInsertIDs[i] < expectedInsertIDs[j] })
+	sort.Slice(expectedUpdateIDs, func(i, j int) bool { return expectedUpdateIDs[i] < expectedUpdateIDs[j] })
+	sort.Slice(expectedDeleteIDs, func(i, j int) bool { return expectedDeleteIDs[i] < expectedDeleteIDs[j] })
+
+	xDesc, exists := tables.tablesByID[xID]
+	if !exists {
+		t.Fatalf("Could not find table:%d", xID)
+	}
+
+	lookup := func(ctx context.Context, tableID ID) (TableLookup, error) {
+		table, exists := tables.tablesByID[tableID]
+		if !exists {
+			return TableLookup{}, errors.Errorf("Could not lookup table:%d", tableID)
+		}
+		return TableLookup{Table: table}, nil
+	}
+
+	test := func(t *testing.T, usage FKCheck, expectedIDs []ID) {
+		tableLookups, err := TablesNeededForFKs(context.TODO(), *xDesc, usage, lookup, NoCheckPrivilege)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var actualIDs []ID
+		for id := range tableLookups {
+			actualIDs = append(actualIDs, id)
+		}
+		sort.Slice(actualIDs, func(i, j int) bool { return actualIDs[i] < actualIDs[j] })
+		if a, e := actualIDs, expectedIDs; !reflect.DeepEqual(a, e) {
+			t.Errorf("insert's expected table IDs did not match actual IDs diff:\n %v", pretty.Diff(e, a))
+		}
+	}
+
+	t.Run("Inserts", func(t *testing.T) {
+		test(t, CheckInserts, expectedInsertIDs)
+	})
+	t.Run("Updates", func(t *testing.T) {
+		test(t, CheckUpdates, expectedUpdateIDs)
+	})
+	t.Run("Deletes", func(t *testing.T) {
+		test(t, CheckDeletes, expectedDeleteIDs)
+	})
+}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -104,8 +104,10 @@ func (p *planner) Update(
 		requestedCols = en.tableDesc.Columns
 	}
 
-	fkTables := sqlbase.TablesNeededForFKs(*en.tableDesc, sqlbase.CheckUpdates)
-	if err := p.fillFKTableMap(ctx, fkTables); err != nil {
+	fkTables, err := sqlbase.TablesNeededForFKs(
+		ctx, *en.tableDesc, sqlbase.CheckUpdates, p.lookupFKTable, p.CheckPrivilege,
+	)
+	if err != nil {
 		return nil, err
 	}
 	ru, err := sqlbase.MakeRowUpdater(p.txn, en.tableDesc, fkTables, updateCols,


### PR DESCRIPTION
This is still a work in progress, but I wanted to put it out there to start to get some early feedback.
Major things left to do before this can be considered mergeable:
- Tighten up the TablesNeededForFKs to not just be a full transitive closure.
- Add a depth limit to the recursive calls to row deleter so we don't panic.
- More testing.
- Remove extra logging debug statements.

---

Commit message follows...
- Enables the addition of the ON DELETE CASCADE action for foreign keys references.
- Augments the TablesNeededForFKs function to fetch all tables that might be needed.
- Adds a cascade helper to the fkDeleteHelper.
- DeleteRow now calls cascadeAll before attempting to delete the row.
- Adds a new cascade logic test specifically for testing the convoluted cascade scenarios.

There are a ton of improvements and additions that should happen here. This is just a MVP implementation.