### PR TITLE
sql: make UPDATE and DELETE symmetric with INSERT/UPSERT

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -96,7 +96,7 @@ func (p *planner) Delete(
 		Exprs: sqlbase.ColumnsSelectors(rd.FetchCols),
 		From:  &tree.From{Tables: []tree.TableExpr{n.Table}},
 		Where: n.Where,
-	}, nil, n.Limit, nil, publicAndNonPublicColumns)
+	}, n.OrderBy, n.Limit, nil, publicAndNonPublicColumns)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -174,6 +174,34 @@ CREATE TABLE indexed (id int primary key, value int, other int, index (value))
 statement ok
 DELETE FROM indexed WHERE value = 5
 
+# Check DELETE with ORDER BY clause (MySQL extension)
+
+statement ok
+INSERT INTO unindexed VALUES (1, 9), (8, 2), (3, 7), (6, 4)
+
+query ITTT
+EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v
+----
+0  delete  ·      ·
+0  ·       from   unindexed
+1  nosort  ·      ·
+1  ·       order  +v
+2  scan    ·      ·
+2  ·       table  unindexed@primary
+2  ·       spans  ALL
+
+query II
+DELETE FROM unindexed WHERE k > 1 AND v < 7 ORDER BY v DESC RETURNING v,k
+----
+4  6
+2  8
+
+query II
+DELETE FROM unindexed ORDER BY v RETURNING k,v
+----
+3  7
+1  9
+
 # Check DELETE with LIMIT clause (MySQL extension)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -578,27 +578,66 @@ INSERT INTO kv (k.*) VALUES ('hello')
 statement error compound types not supported yet: "k.v"
 INSERT INTO kv (k.v) VALUES ('hello')
 
-# Test INSERT INTO ... SELECT FROM ... LIMIT 1
-statement ok
-CREATE TABLE insert_t (x INT,v INT,PRIMARY KEY (x))
+
 
 statement ok
-CREATE TABLE select_t (x INT,v INT,PRIMARY KEY (x))
+CREATE TABLE insert_t (x INT, v INT)
 
 statement ok
-INSERT INTO select_t VALUES(1, 2),(2,3),(3,4)
+CREATE TABLE select_t (x INT, v INT)
+
+statement ok
+INSERT INTO select_t VALUES (1, 9), (8, 2), (3, 7), (6, 4)
+
+# Check that INSERT supports ORDER BY (MySQL extension)
+
+query ITTT
+EXPLAIN (PLAN,EXPRS) INSERT INTO insert_t TABLE select_t ORDER BY v DESC
+----
+0  insert  ·          ·
+0  ·       into       insert_t(x, v, rowid)
+0  ·       default 0  NULL
+0  ·       default 1  NULL
+0  ·       default 2  unique_rowid()
+1  sort    ·          ·
+1  ·       order      -v
+2  render  ·          ·
+2  ·       render 0   x
+2  ·       render 1   v
+3  scan    ·          ·
+3  ·       table      select_t@primary
+3  ·       spans      ALL
+
+query II
+INSERT INTO insert_t TABLE select_t ORDER BY v DESC RETURNING x, v
+----
+1  9
+3  7
+6  4
+8  2
+
+# Check that INSERT supports LIMIT (MySQL extension)
+
+statement ok
+TRUNCATE TABLE insert_t
 
 query ITTT
 EXPLAIN (PLAN,EXPRS) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 ----
-0  insert  ·      ·
-0  ·       into   insert_t(x, v)
-1  limit   ·      ·
-1  ·       count  1
-2  scan    ·      ·
-2  ·       table  select_t@primary
-2  ·       spans  ALL
-2  ·       limit  1
+0  insert  ·          ·
+0  ·       into       insert_t(x, v, rowid)
+0  ·       default 0  NULL
+0  ·       default 1  NULL
+0  ·       default 2  unique_rowid()
+1  limit   ·          ·
+1  ·       count      1
+2  render  ·          ·
+2  ·       render 0   x
+2  ·       render 1   v
+3  scan    ·          ·
+3  ·       table      select_t@primary
+3  ·       spans      ALL
+3  ·       limit      1
 
 statement ok
 INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
@@ -606,7 +645,7 @@ INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 query II
 SELECT * FROM insert_t
 ----
-1  2
+1  9
 
 statement ok
 TRUNCATE TABLE insert_t
@@ -617,43 +656,68 @@ INSERT INTO insert_t (SELECT * FROM select_t LIMIT 1)
 query II
 SELECT * FROM insert_t
 ----
-1  2
+1  9
+
+# Check the grouping of LIMIT and ORDER BY
 
 query ITTT
-EXPLAIN (PLAN) INSERT INTO insert_t VALUES(1,1),(2,2) LIMIT 1
+EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) LIMIT 1
 ----
 0  insert  ·     ·
-0  ·       into  insert_t(x, v)
+0  ·       into  insert_t(x, v, rowid)
 1  limit   ·     ·
 2  values  ·     ·
 2  ·       size  2 columns, 2 rows
 
 query ITTT
-EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,1),(2,2)) LIMIT 1
+EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1
 ----
-0  insert  ·     ·
-0  ·       into  insert_t(x, v)
-1  limit   ·     ·
-2  values  ·     ·
-2  ·       size  2 columns, 2 rows
+0  insert  ·         ·
+0  ·       into      insert_t(x, v, rowid)
+1  limit   ·         ·
+2  sort    ·         ·
+2  ·       order     +column2
+2  ·       strategy  top 1
+3  values  ·         ·
+3  ·       size      2 columns, 2 rows
 
 query ITTT
-EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,1),(2,2) LIMIT 1)
+EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2) LIMIT 1
 ----
-0  insert  ·     ·
-0  ·       into  insert_t(x, v)
-1  limit   ·     ·
-2  values  ·     ·
-2  ·       size  2 columns, 2 rows
+0  insert  ·         ·
+0  ·       into      insert_t(x, v, rowid)
+1  limit   ·         ·
+2  sort    ·         ·
+2  ·       order     +column2
+2  ·       strategy  top 1
+3  values  ·         ·
+3  ·       size      2 columns, 2 rows
+
+query ITTT
+EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1)
+----
+0  insert  ·         ·
+0  ·       into      insert_t(x, v, rowid)
+1  limit   ·         ·
+2  sort    ·         ·
+2  ·       order     +column2
+2  ·       strategy  top 1
+3  values  ·         ·
+3  ·       size      2 columns, 2 rows
 
 statement error pq: multiple LIMIT clauses not allowed
-EXPLAIN (PLAN) INSERT INTO insert_t (VALUES(1,1),(2,2) LIMIT 1) LIMIT 1
+EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) LIMIT 1) LIMIT 1
+
+statement error pq: multiple ORDER BY clauses not allowed
+EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2) ORDER BY 2
 
 statement error DEFAULT can only appear in a VALUES list within INSERT or on the right side of a SET
-INSERT INTO insert_t (VALUES(1, DEFAULT),(2,'BBB') LIMIT 1)
+INSERT INTO insert_t (VALUES (1, DEFAULT), (2,'BBB') LIMIT 1)
 
 statement error DEFAULT can only appear in a VALUES list within INSERT or on the right side of a SET
-INSERT INTO insert_t (VALUES(1, DEFAULT),(2,'BBB')) LIMIT 1
+INSERT INTO insert_t (VALUES (1, DEFAULT), (2,'BBB')) LIMIT 1
+
+# Check string/bytes type conflicts during insertions.
 
 statement ok
 CREATE TABLE bytes_t (

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -432,3 +432,70 @@ SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM pks WHERE k1 = 2]
 fetched: /pks/primary/2/2 -> NULL
 fetched: /pks/primary/2/2/v -> 3
 output row: [2 2 3]
+
+# Check that UPDATE properly supports ORDER BY (MySQL extension)
+
+statement ok
+TRUNCATE kv
+
+statement ok
+INSERT INTO kv VALUES (1, 9), (8, 2), (3, 7), (6, 4)
+
+query ITTT
+EXPLAIN UPDATE kv SET v = v + 1 ORDER BY v DESC
+----
+0  update  ·      ·
+0  ·       table  kv
+0  ·       set    v
+1  render  ·      ·
+2  sort    ·      ·
+2  ·       order  -v
+3  scan    ·      ·
+3  ·       table  kv@primary
+3  ·       spans  ALL
+
+query II
+UPDATE kv SET v = v + 1 ORDER BY v DESC RETURNING k,v
+----
+1  10
+3  8
+6  5
+8  3
+
+# Use case for UPDATE ... ORDER BY: renumbering a PK without unique violation.
+
+statement error duplicate key value \(k\)=\(6\) violates unique constraint "primary"
+UPDATE kv SET k = k * 2
+
+statement ok
+UPDATE kv SET k = k * 2 ORDER BY k DESC
+
+# Check that UPDATE properly supports LIMIT (MySQL extension)
+
+statement ok
+TRUNCATE kv; INSERT INTO kv VALUES (1, 2), (2, 3), (3, 4)
+
+query ITTT
+EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
+----
+0  update  ·      ·
+0  ·       table  kv
+0  ·       set    v
+1  render  ·      ·
+2  limit   ·      ·
+3  scan    ·      ·
+3  ·       table  kv@primary
+3  ·       spans  /#-/3
+3  ·       limit  1
+
+query II
+UPDATE kv SET v = v - 1 WHERE k < 10 ORDER BY k LIMIT 1 RETURNING k, v
+----
+1  1
+
+query II
+SELECT * FROM kv
+----
+1  1
+2  3
+3  4

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -734,10 +734,14 @@ func TestParse(t *testing.T) {
 		{`UPDATE a SET (b, c) = (3, DEFAULT)`},
 		{`UPDATE a SET (b, c) = (SELECT 3, 4)`},
 		{`UPDATE a SET b = 3 WHERE a = b`},
+		{`UPDATE a SET b = 3 WHERE a = b LIMIT c`},
+		{`UPDATE a SET b = 3 WHERE a = b ORDER BY c`},
+		{`UPDATE a SET b = 3 WHERE a = b ORDER BY c LIMIT d`},
 		{`UPDATE a SET b = 3 WHERE a = b RETURNING a`},
 		{`UPDATE a SET b = 3 WHERE a = b RETURNING 1, 2`},
 		{`UPDATE a SET b = 3 WHERE a = b RETURNING a, a + b`},
 		{`UPDATE a SET b = 3 WHERE a = b RETURNING NOTHING`},
+		{`UPDATE a SET b = 3 WHERE a = b ORDER BY c LIMIT d RETURNING e`},
 
 		{`UPDATE t AS "0" SET k = ''`},                 // "0" lost its quotes
 		{`SELECT * FROM "0" JOIN "0" USING (id, "0")`}, // last "0" lost its quotes.

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -225,10 +225,13 @@ func TestParse(t *testing.T) {
 		{`DELETE FROM a.b`},
 		{`DELETE FROM a WHERE a = b`},
 		{`DELETE FROM a WHERE a = b LIMIT c`},
+		{`DELETE FROM a WHERE a = b ORDER BY c`},
+		{`DELETE FROM a WHERE a = b ORDER BY c LIMIT d`},
 		{`DELETE FROM a WHERE a = b RETURNING a, b`},
 		{`DELETE FROM a WHERE a = b RETURNING 1, 2`},
 		{`DELETE FROM a WHERE a = b RETURNING a + b`},
 		{`DELETE FROM a WHERE a = b RETURNING NOTHING`},
+		{`DELETE FROM a WHERE a = b ORDER BY c LIMIT d RETURNING e`},
 
 		{`DISCARD ALL`},
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3758,13 +3758,26 @@ returning_clause:
 
 // %Help: UPDATE - update rows of a table
 // %Category: DML
-// %Text: UPDATE <tablename> [[AS] <name>] SET ... [WHERE <expr>] [RETURNING <exprs...>]
+// %Text:
+// UPDATE <tablename> [[AS] <name>]
+//        SET ...
+//        [WHERE <expr>]
+//        [ORDER BY <exprs...>]
+//        [LIMIT <expr>]
+//        [RETURNING <exprs...>]
 // %SeeAlso: INSERT, UPSERT, DELETE, WEBDOCS/update.html
 update_stmt:
   opt_with_clause UPDATE relation_expr_opt_alias
-    SET set_clause_list update_from_clause where_clause returning_clause
+    SET set_clause_list update_from_clause where_clause opt_sort_clause opt_limit_clause returning_clause
   {
-    $$.val = &tree.Update{Table: $3.tblExpr(), Exprs: $5.updateExprs(), Where: tree.NewWhere(tree.AstWhere, $7.expr()), Returning: $8.retClause()}
+    $$.val = &tree.Update{
+      Table: $3.tblExpr(),
+      Exprs: $5.updateExprs(),
+      Where: tree.NewWhere(tree.AstWhere, $7.expr()),
+      OrderBy: $8.orderBy(),
+      Limit: $9.limit(),
+      Returning: $10.retClause(),
+    }
   }
 | opt_with_clause UPDATE error // SHOW HELP: UPDATE
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1567,17 +1567,19 @@ create_ddl_stmt:
 // %Help: DELETE - delete rows from a table
 // %Category: DML
 // %Text: DELETE FROM <tablename> [WHERE <expr>]
+//               [ORDER BY <exprs...>]
 //               [LIMIT <expr>]
 //               [RETURNING <exprs...>]
 // %SeeAlso: WEBDOCS/delete.html
 delete_stmt:
-  opt_with_clause DELETE FROM relation_expr_opt_alias where_clause opt_limit_clause returning_clause
+  opt_with_clause DELETE FROM relation_expr_opt_alias where_clause opt_sort_clause opt_limit_clause returning_clause
   {
     $$.val = &tree.Delete{
       Table: $4.tblExpr(),
       Where: tree.NewWhere(tree.AstWhere, $5.expr()),
-      Limit: $6.limit(),
-      Returning: $7.retClause(),
+      OrderBy: $6.orderBy(),
+      Limit: $7.limit(),
+      Returning: $8.retClause(),
     }
   }
 | opt_with_clause DELETE error // SHOW HELP: DELETE

--- a/pkg/sql/sem/tree/delete.go
+++ b/pkg/sql/sem/tree/delete.go
@@ -26,6 +26,7 @@ import "bytes"
 type Delete struct {
 	Table     TableExpr
 	Where     *Where
+	OrderBy   OrderBy
 	Limit     *Limit
 	Returning ReturningClause
 }
@@ -35,6 +36,7 @@ func (node *Delete) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("DELETE FROM ")
 	FormatNode(buf, f, node.Table)
 	FormatNode(buf, f, node.Where)
+	FormatNode(buf, f, node.OrderBy)
 	FormatNode(buf, f, node.Limit)
 	FormatNode(buf, f, node.Returning)
 }

--- a/pkg/sql/sem/tree/update.go
+++ b/pkg/sql/sem/tree/update.go
@@ -27,6 +27,8 @@ type Update struct {
 	Table     TableExpr
 	Exprs     UpdateExprs
 	Where     *Where
+	OrderBy   OrderBy
+	Limit     *Limit
 	Returning ReturningClause
 }
 
@@ -37,6 +39,8 @@ func (node *Update) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString(" SET ")
 	FormatNode(buf, f, node.Exprs)
 	FormatNode(buf, f, node.Where)
+	FormatNode(buf, f, node.OrderBy)
+	FormatNode(buf, f, node.Limit)
 	FormatNode(buf, f, node.Returning)
 }
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -274,7 +274,7 @@ func (p *planner) Update(
 		Exprs: sqlbase.ColumnsSelectors(ru.FetchCols),
 		From:  &tree.From{Tables: []tree.TableExpr{n.Table}},
 		Where: n.Where,
-	}, nil, nil, nil, publicAndNonPublicColumns)
+	}, n.OrderBy, n.Limit, nil /*desiredTypes*/, publicAndNonPublicColumns)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +285,21 @@ func (p *planner) Update(
 	// currentUpdateIdx is the index of the first column descriptor in updateCols
 	// that is assigned to by the current setExpr.
 	currentUpdateIdx := 0
-	render := rows.(*renderNode)
+
+	// We need to add renders below, for the RHS of each
+	// assignment. Where can we do this? If we already have a
+	// renderNode, then use that. Otherwise, add one.
+	var render *renderNode
+	if r, ok := rows.(*renderNode); ok {
+		render = r
+	} else {
+		render, err = p.insertRender(ctx, rows, tn)
+		if err != nil {
+			return nil, err
+		}
+		// The new renderNode is also the new data source for the update.
+		rows = render
+	}
 
 	for _, setExpr := range setExprs {
 		if setExpr.Tuple {
@@ -350,9 +364,8 @@ func (p *planner) Update(
 	// types are inferred. For the simpler case ("SET a = $1"), populate them
 	// using checkColumnType. This step also verifies that the expression
 	// types match the column types.
-	sel := rows.(*renderNode)
 	for _, sourceSlot := range sourceSlots {
-		if err := sourceSlot.checkColumnTypes(sel.render, &p.semaCtx.Placeholders); err != nil {
+		if err := sourceSlot.checkColumnTypes(render.render, &p.semaCtx.Placeholders); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
### sql: make DELETE support ORDER BY

This is for symmetry with INSERT/UPSERT that also supports it,
and is complementary to LIMIT (the effects of LIMIT are
non-deterministic without ORDER BY).

Both DELETE ... LIMIT (introduced previously) and
DELETE ... ORDER BY (introduced in this patch) are MySQL
extensions.

Release note (sql change): the DELETE statement now also supports
an ORDER BY clause, which constrains the deletion order,
the output of its LIMIT clause (if any) and the result order
of its RETURNING clause (if any).

### sql: support ORDER BY and LIMIT in UPDATE

This is a MySQL extension.

This patch introduces this feature:

1) for symmetry with INSERT/UPSERT/DELETE that also support these
   clauses.

2) to enable renumbering the PK of a table reliably without duplicate
   key violations (ORDER BY).

3) to limit the size of write transactions (LIMIT).

Regarding point 2. For example, consider a table contains PK values 0,
1, 2, 3, ...  Without this feature, one cannot renumber to 1, 2, 3
... (starting from 1 instead of 0), because the change from 0 to 1
would violate the existing row with PK 1. With an ORDER BY clause this
becomes possible: `UPDATE ... SET k = k + 1 ORDER BY k DESC` (starting
from the end).

Release note (sql change): the UPDATE statement now supports an ORDER
BY and LIMIT clause. This is a MySQL extension that can help with
updating the PK of a table (ORDER BY) and control the maximum size of
write transactions (LIMIT).

cc @bdarnell 