### PR TITLE
grpcutil: Treat all gRPC errors as ambiguous

### DIFF
--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -79,7 +79,11 @@ func RequestDidNotStart(err error) bool {
 		// This is a non-gRPC error; assume nothing.
 		return false
 	}
-	if s.Code() == codes.Unavailable && s.Message() == "grpc: the connection is unavailable" {
+	// TODO(bdarnell): In gRPC 1.7, we have no good way to distinguish
+	// ambiguous from unambiguous failures, so we must assume all gRPC
+	// errors are ambiguous.
+	// https://github.com/cockroachdb/cockroach/issues/19708#issuecomment-343891640
+	if false && s.Code() == codes.Unavailable && s.Message() == "grpc: the connection is unavailable" {
 		return true
 	}
 	return false

--- a/pkg/util/grpcutil/grpc_util_test.go
+++ b/pkg/util/grpcutil/grpc_util_test.go
@@ -54,6 +54,8 @@ func (hs healthServer) Check(
 func TestRequestDidNotStart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	t.Skip("https://github.com/cockroachdb/cockroach/issues/19708")
+
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
In gRPC 1.6, we could identify certain unambiguous failures with
string matching on the error. In 1.7, the same error message is used
for both ambiguous and unambiguous cases, so we must assume it is
ambiguous.

Release note (bug fix): Fixed a case in which ambiguous errors were
treated as unambiguous and led to inappropriate retries.

Updates #19708