### PR TITLE
 build: Only post issues for master and release branches

### DIFF
--- a/build/teamcity-post-failures.py
+++ b/build/teamcity-post-failures.py
@@ -96,8 +96,10 @@ def post_issue(issue):
 
 
 if __name__ == '__main__':
-    build_id = os.environ['TC_BUILD_ID']
-    failed_tests = list(collect_build_results(build_id))
-    if failed_tests:
-        issue = create_issue(build_id, failed_tests)
-        post_issue(issue)
+    branch = os.environ['TC_BUILD_BRANCH']
+    if branch == 'master' or branch.startswith('release-'):
+        build_id = os.environ['TC_BUILD_ID']
+        failed_tests = list(collect_build_results(build_id))
+        if failed_tests:
+            issue = create_issue(build_id, failed_tests)
+            post_issue(issue)


### PR DESCRIPTION
This is handled in teamcity configs in some cases, but the jepsen
tests run this script regardless of branch, and fixing it here
is simpler than adding additional conditional logic in teamcity.

Release notes: None

~~The second commit in this PR will be removed before merging.~~ (the now-removed second commit was testing an upgrade of the `tc-nightly` branch of our jepsen fork to the upstream master. It passed in a few configurations, so I'll update that branch for tonight's run). 