### PR TITLE
kv: collect traces from RPCs returning errors

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -17,7 +17,6 @@ package client
 import (
 	"fmt"
 
-	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -1015,17 +1014,6 @@ func (txn *Txn) Send(
 		}
 		if br.Txn != nil && br.Txn.ID != txn.mu.Proto.ID {
 			return nil, roachpb.NewError(&roachpb.TxnPrevAttemptError{})
-		}
-		if len(br.CollectedSpans) != 0 {
-			span := opentracing.SpanFromContext(ctx)
-			if span == nil {
-				return nil, roachpb.NewErrorf(
-					"trying to ingest remote spans but there is no recording span set up",
-				)
-			}
-			if err := tracing.ImportRemoteSpans(span, br.CollectedSpans); err != nil {
-				return nil, roachpb.NewErrorf("error ingesting remote spans: %s", err)
-			}
 		}
 
 		// Only successful requests can carry an updated Txn in their response


### PR DESCRIPTION
Release note: Fix SHOW TRACE FOR <query> missing some trace data.

Before this patch, if an RPC returned an error (e.g.
NotLeaseHolderError) and the RPC is retried by the DistSender, then the
spans collected on the server-side (and returned to the client through
batchResponse.CollectedSpans) were not imported into the client's trace.
This patch fixes that by moving the place where the import happens: from
the high-level txn.Send() to the low-level grpcTransport.send().

Fixes #20032