### PR TITLE
cherrypick-1.1: storage: do not GC large transactions

### DIFF
--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -374,6 +374,8 @@ func processLocalKeyRange(
 
 	var gcKeys []roachpb.GCRequest_GCKey
 
+	const maxIntentHack = 800
+
 	handleOneTransaction := func(kv roachpb.KeyValue) error {
 		var txn roachpb.Transaction
 		if err := kv.Value.GetProto(&txn); err != nil {
@@ -406,6 +408,11 @@ func processLocalKeyRange(
 			// persisted, though they still might exist in the system.
 			infoMu.TransactionSpanGCAborted++
 			if err := func() error {
+				// Simply don't resolve these intents. We don't have to and don't want to get bogged down
+				// trying to do so.
+				if len(txn.Intents) > maxIntentHack {
+					return nil
+				}
 				infoMu.Unlock() // intentional
 				defer infoMu.Lock()
 				return resolveIntents(roachpb.AsIntents(txn.Intents, &txn),
@@ -424,6 +431,11 @@ func processLocalKeyRange(
 			if err := func() error {
 				infoMu.Unlock() // intentional
 				defer infoMu.Lock()
+
+				if len(txn.Intents) > maxIntentHack {
+					// Return an error so that we leave this transaction alone. Don't try to resolve its intents.
+					return errors.Errorf("cannot GC transaction with %d intents", len(txn.Intents))
+				}
 				return resolveIntents(roachpb.AsIntents(txn.Intents, &txn), ResolveOptions{Wait: true, Poison: false})
 			}(); err != nil {
 				// Returning the error here would abort the whole GC run, and


### PR DESCRIPTION
Cherry-pick of #19538.

Release notes (temporary workaround): avoid overloading the system during
cleanup of large transactions.

cc @cockroachdb/release