### PR TITLE
distsqlrun: close orderedSynchronizer sources that were neglected

### DIFF
--- a/pkg/sql/distsqlrun/input_sync.go
+++ b/pkg/sql/distsqlrun/input_sync.go
@@ -131,17 +131,31 @@ func (s *orderedSynchronizer) Pop() interface{} {
 	return nil
 }
 
-// initHeap grabs a row from each source and initializes the heap.
+// initHeap grabs a row from each source and initializes the heap. Any given
+// source will be on the heap (even if an error was encountered while reading
+// from it) unless there are no more rows to read from it.
+// If an error is returned, heap.Init() has not been called, so s.heap is not
+// an actual heap. In this case, all members of the heap need to be drained.
 func (s *orderedSynchronizer) initHeap() error {
+	// consumeErr is the last error encountered while consuming metadata.
+	var consumeErr error
 	for i := range s.sources {
 		src := &s.sources[i]
-		if err := s.consumeMetadata(src, stopOnRowOrError); err != nil {
-			return err
+		err := s.consumeMetadata(src, stopOnRowOrError)
+		if err != nil {
+			consumeErr = err
 		}
-		if src.row != nil {
+		// We add the source to the heap either if we have received a row from
+		// it or there was an error reading from this source. We still add to
+		// the heap in case of error so that these sources can be drained in
+		// `drainSources`.
+		if src.row != nil || err != nil {
 			// Add to the heap array (it won't be a heap until we call heap.Init).
 			s.heap = append(s.heap, srcIdx(i))
 		}
+	}
+	if consumeErr != nil {
+		return consumeErr
 	}
 	heap.Init(s)
 	// heap operations might set s.err (see Less)
@@ -292,35 +306,36 @@ func (s *orderedSynchronizer) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 func (s *orderedSynchronizer) ConsumerDone() {
 	// We're entering draining mode. Only metadata will be forwarded from now on.
 	if s.state != draining {
-		s.state = draining
-		s.consumerStatusChanged(RowSource.ConsumerDone)
+		s.consumerStatusChanged(draining, RowSource.ConsumerDone)
 	}
 }
 
 // ConsumerClosed is part of the RowSource interface.
 func (s *orderedSynchronizer) ConsumerClosed() {
-	// The state should matter, as no further methods should be called, but we'll
-	// set it to something other than the default.
-	s.state = drainBuffered
-	s.consumerStatusChanged(RowSource.ConsumerClosed)
+	// The state shouldn't matter, as no further methods should be called, but
+	// we'll set it to something other than the default.
+	s.consumerStatusChanged(drainBuffered, RowSource.ConsumerClosed)
 }
 
 // consumerStatusChanged calls a RowSource method on all the non-exhausted
 // sources.
-func (s *orderedSynchronizer) consumerStatusChanged(f func(RowSource)) {
+func (s *orderedSynchronizer) consumerStatusChanged(
+	newState orderedSynchronizerState, f func(RowSource),
+) {
 	if s.state == notInitialized {
 		for i := range s.sources {
 			f(s.sources[i].src)
 		}
 	} else {
-		// The sources that are not in the heap have been consumed already. It would
-		// be ok to call ConsumerDone()/ConsumerClosed() on them too, but avoiding
-		// the call may be a bit faster (in most cases there should be no sources
-		// left).
+		// The sources that are not in the heap have been consumed already. It
+		// would be ok to call ConsumerDone()/ConsumerClosed() on them too, but
+		// avoiding the call may be a bit faster (in most cases there should be
+		// no sources left).
 		for _, sIdx := range s.heap {
 			f(s.sources[sIdx].src)
 		}
 	}
+	s.state = newState
 }
 
 func makeOrderedSync(

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -17,6 +17,8 @@ package sql_test
 import (
 	gosql "database/sql"
 	"errors"
+	"fmt"
+	"math/rand"
 	"strings"
 	"testing"
 	"time"
@@ -26,9 +28,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 func TestCancelSelectQuery(t *testing.T) {
@@ -175,15 +179,20 @@ func TestCancelParallelQuery(t *testing.T) {
 	}
 }
 
-// Cancel a distSQL query pre-execution (before any streams have been established)
+// TestCancelDistSQLQuery runs a distsql query and cancels it randomly at
+// various points of execution.
 func TestCancelDistSQLQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	const queryToCancel = "SELECT * FROM nums ORDER BY num DESC"
+	const queryToCancel = "SELECT * FROM nums ORDER BY num"
+	cancelQuery := fmt.Sprintf("CANCEL QUERY (SELECT query_id FROM [SHOW CLUSTER QUERIES] WHERE query = '%s')", queryToCancel)
 
 	// conn1 is used for the query above. conn2 is solely for the CANCEL statement.
 	var conn1 *gosql.DB
 	var conn2 *gosql.DB
 
+	var queryLatency *time.Duration
+	sem := make(chan struct{}, 1)
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 	tc := serverutils.StartTestCluster(t, 2, /* numNodes */
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
@@ -191,14 +200,15 @@ func TestCancelDistSQLQuery(t *testing.T) {
 				UseDatabase: "test",
 				Knobs: base.TestingKnobs{
 					SQLExecutor: &sql.ExecutorTestingKnobs{
-						BeforeExecute: func(ctx context.Context, stmt string, _ /* isParallel */ bool) {
-							// if queryToCancel
-							if strings.Contains(stmt, "ORDER BY num") {
-								// Cancel it
-								const cancelQuery = "CANCEL QUERY (SELECT query_id FROM [SHOW CLUSTER QUERIES] WHERE node_id = 1)"
-								if _, err := conn2.Exec(cancelQuery); err != nil {
-									t.Fatal(err)
-								}
+						BeforeExecute: func(_ context.Context, stmt string, _ /* isParallel */ bool) {
+							if strings.HasPrefix(stmt, queryToCancel) {
+								// Wait for the race to start.
+								<-sem
+							} else if strings.HasPrefix(stmt, cancelQuery) {
+								// Signal to start the race.
+								sleepTime := time.Duration(rng.Int63n(int64(*queryLatency)))
+								sem <- struct{}{}
+								time.Sleep(sleepTime)
 							}
 						},
 					},
@@ -211,15 +221,47 @@ func TestCancelDistSQLQuery(t *testing.T) {
 	conn2 = tc.ServerConn(1)
 
 	sqlutils.CreateTable(t, conn1, "nums", "num INT", 0, nil)
-	_, err := conn1.Exec("INSERT INTO nums SELECT generate_series(1,10)")
-	if err != nil {
+	if _, err := conn1.Exec("INSERT INTO nums SELECT generate_series(1,100)"); err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = conn1.Exec(queryToCancel)
-	if err != nil && !sqlbase.IsQueryCanceledError(err) {
+	if _, err := conn1.Exec("ALTER TABLE nums SPLIT AT VALUES (50)"); err != nil {
 		t.Fatal(err)
-	} else if err == nil {
-		t.Fatal("didn't get an error from query that should have been canceled")
+	}
+	// Make the second node the leaseholder for the first range to distribute
+	// the query.
+	if _, err := conn1.Exec(fmt.Sprintf(
+		"ALTER TABLE nums TESTING_RELOCATE VALUES (ARRAY[%d], 1)",
+		tc.Server(1).GetFirstStoreID(),
+	)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run queryToCancel to be able to get an estimate of how long it should
+	// take. The goroutine in charge of cancellation will sleep a random
+	// amount of time within this bound. Signal sem so that it can run
+	// unhindered.
+	sem <- struct{}{}
+	start := timeutil.Now()
+	if _, err := conn1.Exec(queryToCancel); err != nil {
+		t.Fatal(err)
+	}
+	execTime := timeutil.Since(start)
+	queryLatency = &execTime
+
+	errChan := make(chan error)
+	go func() {
+		_, err := conn1.Exec(queryToCancel)
+		errChan <- err
+	}()
+	_, err := conn2.Exec(cancelQuery)
+	if err != nil && !testutils.IsError(err, "query ID") {
+		t.Fatal(err)
+	}
+	// Successful cancellation.
+	// Note the err != nil check. It exists because a successful cancellation
+	// does not imply that the query was canceled.
+	if err := <-errChan; err != nil && !sqlbase.IsQueryCanceledError(err) {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
These sources were neglected because they were not added to the heap
when a heap initialization error happened. The ordered synchronizer
would then go into a draining phase, but it would only close sources
that were added to the heap.

Fixes #19951

This commit also improves the testing of distsql query cancellation. The
issue that this commit fixes is caught by stress testing the new test.

Another oddity was uncovered by this: an ORDER BY DESC run after a SPLIT AT results in an ordering issue. I'll file an issue tomorrow morning and verify the minimum steps to reproduce.

I will also add orderedSynchronizer unit tests probably in another PR. Should this be cherrypicked into 1.1? I think so.

Release note (bug fix): fix a race condition that would result in some queries hanging after cancellation