### PR TITLE
distsqlrun: Fix MergeJoiner correctness issue with NULL values

### DIFF
--- a/pkg/sql/distsqlrun/stream_merger.go
+++ b/pkg/sql/distsqlrun/stream_merger.go
@@ -106,6 +106,13 @@ func CompareEncDatumRowForMerge(
 	for i, ord := range leftOrdering {
 		lIdx := ord.ColIdx
 		rIdx := rightOrdering[i].ColIdx
+		// If both datums are NULL, we need to follow SQL semantics where
+		// they are not equal. This differs from our datum semantics where
+		// they are equal.
+		if lhs[lIdx].IsNull() && rhs[rIdx].IsNull() {
+			// We can return either -1 or 1, it does not change the behavior.
+			return -1, nil
+		}
 		cmp, err := lhs[lIdx].Compare(&lhsTypes[lIdx], da, evalCtx, &rhs[rIdx])
 		if err != nil {
 			return 0, err

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -194,3 +194,48 @@ query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d)))]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzsmE1v4kgQhu_7K6I67Sq9Et02H0FaydesNMkoM7cRBwf3ECRCo7aRJory30dAZhi7Sb1U2kECcQT8uKor7cdv-pnmrrA3-aMtafiNNCkypCghRSkp6tJI0cK7sS1L51eXbIDr4gcNO4qm88WyWn09UjR23tLwmappNbM0pK_5_cze2bywnhQVtsqns3WRhZ8-5v4pK_IqJ0W3y2p4kWmVGZUlKktp9KLILavXO29veP908ZCXD_Wb1cGRorLKJ5aG-kV9ZKvvaLLWnvm49nbMcFs3kdT94nzVLJnpS5WZy9j1p2_2sb2V84X1tniz_t5X7ljaJ-sn9n83nTfXN7Pfq79f0X_-89PJw_bjh23WbuQ0VJZcqiwVTOUP4r3T-XWLxpR-f809L9ul9_ZY-nK-ayk7O79x_7pF47Ldhfu1wvp4XNZ6q-26rNX2BC4DdQ_mMn12WdQ0TsZl5niU0nqr7Sql1fYESgF1D6YUc1ZK1DRORinJ8Sil9VbbVUqr7QmUAuoeTCnJWSlR0zgZpaTHo5TWW21XKa22J1AKqHswpaRnpURN42SUAk4V72y5cPPS7nVK01mtzBYTu5lj6ZZ-bD97N16X2Xy8XXPr_zULW1abX7ubD9fzzU-rBveHtYmiBzG0SWPopMPTmqVBaR7WOorux9AmiaKveNo06U5t5DW404QTwcSNDG5MXEr3Y-jGxKX0FU-ngmdbCDeebSk9iKEN-HPzdOPZDuguu017_B7v8Xtc85u8H-NiHkYuBjRwMU8jF_M0cvEgxsU8jFwMaOBinkYuBjRw8RW7T3WH36eaf3uCxxPQSMcIBz4GOBIywoGRNf8KBUoGNHIywoGUAY6sDHCkZc3HB-Blzb9IgVoBjdyKcCBXgCO7AhxGXf5tioqDHIDCLsBR2gU5AsVdgAPHaj5J6B6QbJAlRJLlaShZgCPJ8jiULMCRZCU5SkpDyYqSlBSHkhVlqRAPUoVIskGqEEmWp6FkAY4ky-NQsjyOJGskgUpKI8kiHEgW4EiyCEeHCkGqqO1YY3jJmiBVSCQLaCRZhAPJAhxJFuFAskaSqKQ0kizCgWQBjiQLcCRZE8QKiWRNkCokkgU0kizCgWQBjiQLcChZSaCS0lCyokAlxaFkRYEqxINUUZfsAEhWckQTPi6iMxoxjiQrOqUR40iykkQlpaFkRYlKikPJihJVeHAexApWsqOXv34GAAD___sgIII=
+
+
+# Test that the distSQL MergeJoiner follows SQL NULL semantics for ON predicate equivilance.
+# The use of sorts here force
+
+statement ok
+CREATE TABLE distsql_mj_test (k INT, v INT)
+
+statement ok
+INSERT INTO distsql_mj_test VALUES (0, NULL), (0, 1), (2, 4), (NULL, 4)
+
+# If SQL NULL semantics are not followed, NULL = NULL is truthy. This makes the rows with NULL also appear in the inner join.
+
+query IIII rowsort
+SELECT l.k, l.v, r.k, r.v FROM (SELECT * FROM distsql_mj_test ORDER BY k, v) l INNER JOIN (SELECT * FROM distsql_mj_test ORDER BY k, v) r ON l.k = r.k AND l.v = r.v
+----
+0  1  0  1
+2  4  2  4
+
+statement ok
+DELETE FROM distsql_mj_test WHERE TRUE;
+
+statement ok
+INSERT INTO distsql_mj_test VALUES (0, NULL), (1, NULL), (2, NULL)
+
+# We should not have any results for values with NULLs
+query IIII rowsort
+SELECT l.k, l.v, r.k, r.v FROM (SELECT * FROM distsql_mj_test ORDER BY k, v) l INNER JOIN (SELECT * FROM distsql_mj_test ORDER BY k, v) r ON l.k = r.k AND l.v = r.v
+----
+
+statement ok
+DELETE FROM distsql_mj_test WHERE TRUE;
+
+statement ok
+INSERT INTO distsql_mj_test VALUES (NULL)
+
+# We shouldn't expect a row of (NULL, NULL), otherwise NULL = NULL was joined.
+query II rowsort
+SELECT l.k, r.k FROM (SELECT * FROM distsql_mj_test ORDER BY k) l INNER JOIN (SELECT * FROM distsql_mj_test ORDER BY k) r ON l.k = r.k
+----
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT l.k, r.k FROM (SELECT * FROM distsql_mj_test ORDER BY k) l INNER JOIN (SELECT * FROM distsql_mj_test ORDER BY k) r ON l.k = r.k)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzEkkFr4zAQhe_7K5Y57RIVIifOwVDwNYUmJe2thOBaU1fF8bijMbSE_Pdi65DE1EpzKL1Jo_nemydmBxUZXGRbdJA8ggYFMawV1Ew5Okfcln3T3LxDMlZgq7qRtrxWkBMjJDsQKyVCAgu6ohoUGJTMll3TXgE1ckCcZAVCMturI1kdln3InkpcYWaQT8ShZrvN-CM11ol7Kzfb142gE1CwbCT5m2oY8teX-N8TS9861aNB8eiXw01-Mtx0UPyg2VTEBhlNfxfOt3wx4S1ygTdkq_6YJT7Lv1SP_l-zLV788fA9Ko0GQ8QnIc5s9QpdTZXDby32uE2ApkD_I44azvGOKe9s_HXZcV3BoBP_OvOXeeWf2gGPYR2EozAcBeH4BNZ9eBKEp2Hn6QXOUR-Og_C457ze__kMAAD__4m9mGY=


### PR DESCRIPTION
Previously, when a distSQL merge join was being executed the comparison
check was using Datum.Compare while processing the incoming streams we
are joining on.

This is problematic when both sides of the stream have a NULL value,
because this comparison is considered equal which is a violation of the
semantics of equals (=) with SQL NULLs.

Unfortunately, this bug was present before distSQL merge joins were
being planned (#17214) and so it exists in 1.1.0.