### PR TITLE
util: add more primitives to FastIntSet

### DIFF
--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -357,18 +357,42 @@ func (s *FastIntSet) Shift(delta int) FastIntSet {
 	return result
 }
 
+// String returns a list representation of elements. Sequential runs of positive
+// numbers are shown as ranges. For example, for the set {0, 1, 2, 5, 6, 10},
+// the output is "(0-2,5,6,10)".
 func (s FastIntSet) String() string {
 	var buf bytes.Buffer
 	buf.WriteByte('(')
-	first := true
-	s.ForEach(func(i int) {
-		if first {
-			first = false
-		} else {
+	appendRange := func(start, end int) {
+		if buf.Len() > 1 {
 			buf.WriteByte(',')
 		}
-		fmt.Fprintf(&buf, "%d", i)
+		if start == end {
+			fmt.Fprintf(&buf, "%d", start)
+		} else if start+1 == end {
+			fmt.Fprintf(&buf, "%d,%d", start, end)
+		} else {
+			fmt.Fprintf(&buf, "%d-%d", start, end)
+		}
+	}
+	rangeStart, rangeEnd := -1, -1
+	s.ForEach(func(i int) {
+		if i < 0 {
+			appendRange(i, i)
+			return
+		}
+		if rangeStart != -1 && rangeEnd == i-1 {
+			rangeEnd = i
+		} else {
+			if rangeStart != -1 {
+				appendRange(rangeStart, rangeEnd)
+			}
+			rangeStart, rangeEnd = i, i
+		}
 	})
+	if rangeStart != -1 {
+		appendRange(rangeStart, rangeEnd)
+	}
 	buf.WriteByte(')')
 	return buf.String()
 }

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -265,3 +265,31 @@ func TestFastIntSetAddRange(t *testing.T) {
 		}
 	}
 }
+
+func TestFastIntSetString(t *testing.T) {
+	testCases := []struct {
+		vals []int
+		exp  string
+	}{
+		{
+			vals: []int{},
+			exp:  "()",
+		},
+		{
+			vals: []int{-5, -3, -2, -1, 0, 1, 2, 3, 4, 5},
+			exp:  "(-5,-3,-2,-1,0-5)",
+		},
+		{
+			vals: []int{0, 1, 3, 4, 5},
+			exp:  "(0,1,3-5)",
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			s := MakeFastIntSet(tc.vals...)
+			if str := s.String(); str != tc.exp {
+				t.Errorf("expected %s, got %s", tc.exp, str)
+			}
+		})
+	}
+}

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -162,6 +162,10 @@ func TestFastIntSetTwoSetOps(t *testing.T) {
 
 							u := s1.Copy()
 							u.UnionWith(s2)
+
+							if !u.Equals(s1.Union(s2)) {
+								t.Errorf("inconsistency between UnionWith and Union on %s %s\n", s1, s2)
+							}
 							// Verify all elements from m1 and m2 are in u.
 							for _, m := range []map[int]bool{m1, m2} {
 								for x := range m {
@@ -182,6 +186,13 @@ func TestFastIntSetTwoSetOps(t *testing.T) {
 							// Test intersection.
 							u = s1.Copy()
 							u.IntersectionWith(s2)
+							if s1.Intersects(s2) != !u.Empty() ||
+								s2.Intersects(s1) != !u.Empty() {
+								t.Errorf("inconsistency between IntersectionWith and Intersect on %s %s\n", s1, s2)
+							}
+							if !u.Equals(s1.Intersection(s2)) {
+								t.Errorf("inconsistency between IntersectionWith and Intersection on %s %s\n", s1, s2)
+							}
 							// Verify all elements from m1 and m2 are in u.
 							for x := range m1 {
 								if m2[x] && !u.Contains(x) {
@@ -193,6 +204,29 @@ func TestFastIntSetTwoSetOps(t *testing.T) {
 							for x, ok := u.Next(minVal); ok; x, ok = u.Next(x + 1) {
 								if !(m1[x] && m2[x]) {
 									t.Errorf("incorrect intersection result %s intersect %s = %s", &s1, &s2, &u)
+									break
+								}
+							}
+
+							// Test difference.
+							u = s1.Copy()
+							u.DifferenceWith(s2)
+
+							if !u.Equals(s1.Difference(s2)) {
+								t.Errorf("inconsistency between DifferenceWith and Difference on %s %s\n", s1, s2)
+							}
+
+							// Verify all elements in m1 but not in m2 are in u.
+							for x := range m1 {
+								if !m2[x] && !u.Contains(x) {
+									t.Errorf("incorrect difference result %s \\ %s = %s  x=%d", &s1, &s2, &u, x)
+									break
+								}
+							}
+							// Verify all elements from u are in m1.
+							for x, ok := u.Next(minVal); ok; x, ok = u.Next(x + 1) {
+								if !m1[x] {
+									t.Errorf("incorrect difference result %s \\ %s = %s", &s1, &s2, &u)
 									break
 								}
 							}


### PR DESCRIPTION
 - Intersects
 - DifferenceWith
 - non-mutating variants of union/diff/intersect
 - Len
 - changing some methods to non-pointer receiver (so they can be used
   on sets returned from function calls)

Release note: none