### PR TITLE
tests: pass testing.T in individual calls

### DIFF
--- a/pkg/ccl/sqlccl/partition_test.go
+++ b/pkg/ccl/sqlccl/partition_test.go
@@ -150,12 +150,12 @@ func TestPartitioning(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			sqlDB := sqlutils.MakeSQLRunner(t, tc.Conns[0])
+			sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 			tableName := fmt.Sprintf("data.%q", testCase.name)
-			sqlDB.Exec(fmt.Sprintf(testCase.table, tableName))
-			sqlDB.Exec(fmt.Sprintf(
+			sqlDB.Exec(t, fmt.Sprintf(testCase.table, tableName))
+			sqlDB.Exec(t, fmt.Sprintf(
 				`ALTER TABLE %s PARTITION dc1 EXPERIMENTAL CONFIGURE ZONE 'constraints: [+dc1]'`, tableName))
-			sqlDB.Exec(fmt.Sprintf(
+			sqlDB.Exec(t, fmt.Sprintf(
 				`ALTER TABLE %s PARTITION dc2 EXPERIMENTAL CONFIGURE ZONE 'constraints: [+dc2]'`, tableName))
 			testutils.SucceedsSoon(t, func() error {
 				for _, scan := range testCase.scans {

--- a/pkg/ccl/sqlccl/zone_test.go
+++ b/pkg/ccl/sqlccl/zone_test.go
@@ -36,8 +36,8 @@ func TestValidIndexPartitionSetShowZones(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
 
-	sqlDB := sqlutils.MakeSQLRunner(t, db)
-	sqlDB.Exec(`
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	sqlDB.Exec(t, `
 		CREATE DATABASE d;
 		USE d;
 		CREATE TABLE t (c STRING PRIMARY KEY) PARTITION BY LIST (c) (
@@ -87,119 +87,119 @@ func TestValidIndexPartitionSetShowZones(t *testing.T) {
 	}
 
 	// Ensure the default is reported for all zones at first.
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE default", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "INDEX d.t@primary", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p1", defaultRow)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE default", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "INDEX d.t@primary", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p1", defaultRow)
 
 	// Ensure a database zone config applies to that database, its tables, and its
 	// tables' indices and partitions.
-	sqlutils.SetZoneConfig(sqlDB, "DATABASE d", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow, dbRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", dbRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", dbRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "INDEX d.t@primary", dbRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", dbRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p1", dbRow)
+	sqlutils.SetZoneConfig(t, sqlDB, "DATABASE d", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow, dbRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "INDEX d.t@primary", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p1", dbRow)
 
 	// Ensure a table zone config applies to that table and its indices and
 	// partitions, but no other zones.
-	sqlutils.SetZoneConfig(sqlDB, "TABLE d.t", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow, dbRow, tableRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", dbRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", tableRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "INDEX d.t@primary", tableRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", tableRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p1", tableRow)
+	sqlutils.SetZoneConfig(t, sqlDB, "TABLE d.t", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow, dbRow, tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "INDEX d.t@primary", tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p1", tableRow)
 
 	// Ensure an index zone config applies to that index and its partitions, but
 	// no other zones.
-	sqlutils.SetZoneConfig(sqlDB, "INDEX d.t@primary", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow, dbRow, tableRow, primaryRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", dbRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", tableRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "INDEX d.t@primary", primaryRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", primaryRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p1", primaryRow)
+	sqlutils.SetZoneConfig(t, sqlDB, "INDEX d.t@primary", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow, dbRow, tableRow, primaryRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "INDEX d.t@primary", primaryRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", primaryRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p1", primaryRow)
 
 	// Ensure a partition zone config applies to that partition, but no other
 	// zones.
-	sqlutils.SetZoneConfig(sqlDB, "TABLE d.t PARTITION p0", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow, dbRow, tableRow, primaryRow, p0Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", dbRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", tableRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "INDEX d.t@primary", primaryRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", p0Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p1", primaryRow)
+	sqlutils.SetZoneConfig(t, sqlDB, "TABLE d.t PARTITION p0", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow, dbRow, tableRow, primaryRow, p0Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "INDEX d.t@primary", primaryRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", p0Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p1", primaryRow)
 
 	// Ensure updating the default zone propagates to zones without an override,
 	// but not to those with overrides.
-	sqlutils.SetZoneConfig(sqlDB, "RANGE default", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultOverrideRow, dbRow, tableRow, primaryRow, p0Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", dbRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", tableRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "INDEX d.t@primary", primaryRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", p0Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p1", primaryRow)
+	sqlutils.SetZoneConfig(t, sqlDB, "RANGE default", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultOverrideRow, dbRow, tableRow, primaryRow, p0Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", dbRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "INDEX d.t@primary", primaryRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", p0Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p1", primaryRow)
 
 	// Ensure deleting a database zone leaves child overrides in place.
-	sqlutils.DeleteZoneConfig(sqlDB, "DATABASE d")
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultOverrideRow, tableRow, primaryRow, p0Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", defaultOverrideRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", tableRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "INDEX d.t@primary", primaryRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", p0Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p1", primaryRow)
+	sqlutils.DeleteZoneConfig(t, sqlDB, "DATABASE d")
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultOverrideRow, tableRow, primaryRow, p0Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", defaultOverrideRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", tableRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "INDEX d.t@primary", primaryRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", p0Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p1", primaryRow)
 
 	// Ensure deleting a table zone leaves child overrides in place.
-	sqlutils.DeleteZoneConfig(sqlDB, "TABLE d.t")
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultOverrideRow, primaryRow, p0Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", defaultOverrideRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "INDEX d.t@primary", primaryRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", p0Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p1", primaryRow)
+	sqlutils.DeleteZoneConfig(t, sqlDB, "TABLE d.t")
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultOverrideRow, primaryRow, p0Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", defaultOverrideRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "INDEX d.t@primary", primaryRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", p0Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p1", primaryRow)
 
 	// Ensure deleting an index zone leaves child overrides in place.
-	sqlutils.DeleteZoneConfig(sqlDB, "INDEX d.t@primary")
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultOverrideRow, p0Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "INDEX d.t@primary", defaultOverrideRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", p0Row)
+	sqlutils.DeleteZoneConfig(t, sqlDB, "INDEX d.t@primary")
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultOverrideRow, p0Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "INDEX d.t@primary", defaultOverrideRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", p0Row)
 
 	// Ensure deleting a partition zone works.
-	sqlutils.DeleteZoneConfig(sqlDB, "TABLE d.t PARTITION p0")
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultOverrideRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", defaultOverrideRow)
+	sqlutils.DeleteZoneConfig(t, sqlDB, "TABLE d.t PARTITION p0")
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultOverrideRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", defaultOverrideRow)
 
 	// Ensure deleting non-overridden zones is not an error.
-	sqlutils.DeleteZoneConfig(sqlDB, "DATABASE d")
-	sqlutils.DeleteZoneConfig(sqlDB, "TABLE d.t")
-	sqlutils.DeleteZoneConfig(sqlDB, "TABLE d.t PARTITION p1")
+	sqlutils.DeleteZoneConfig(t, sqlDB, "DATABASE d")
+	sqlutils.DeleteZoneConfig(t, sqlDB, "TABLE d.t")
+	sqlutils.DeleteZoneConfig(t, sqlDB, "TABLE d.t PARTITION p1")
 
 	// Ensure updating the default zone config applies to zones that have had
 	// overrides added and removed.
-	sqlutils.SetZoneConfig(sqlDB, "RANGE default", yamlDefault)
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "RANGE default", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "DATABASE d", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "INDEX d.t@primary", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p1", defaultRow)
+	sqlutils.SetZoneConfig(t, sqlDB, "RANGE default", yamlDefault)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "RANGE default", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "DATABASE d", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "INDEX d.t@primary", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p1", defaultRow)
 
 	// Ensure subzones can be created even when no table zone exists.
-	sqlutils.SetZoneConfig(sqlDB, "TABLE d.t PARTITION p0", yamlOverride)
-	sqlutils.SetZoneConfig(sqlDB, "TABLE d.t PARTITION p1", yamlOverride)
-	sqlutils.VerifyAllZoneConfigs(sqlDB, defaultRow, p0Row, p1Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t", defaultRow)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p0", p0Row)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, "TABLE d.t PARTITION p1", p1Row)
+	sqlutils.SetZoneConfig(t, sqlDB, "TABLE d.t PARTITION p0", yamlOverride)
+	sqlutils.SetZoneConfig(t, sqlDB, "TABLE d.t PARTITION p1", yamlOverride)
+	sqlutils.VerifyAllZoneConfigs(t, sqlDB, defaultRow, p0Row, p1Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t", defaultRow)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p0", p0Row)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, "TABLE d.t PARTITION p1", p1Row)
 
 	// Ensure the shorthand index syntax works.
-	sqlutils.SetZoneConfig(sqlDB, `INDEX "primary"`, yamlOverride)
-	sqlutils.VerifyZoneConfigForTarget(sqlDB, `INDEX "primary"`, primaryRow)
+	sqlutils.SetZoneConfig(t, sqlDB, `INDEX "primary"`, yamlOverride)
+	sqlutils.VerifyZoneConfigForTarget(t, sqlDB, `INDEX "primary"`, primaryRow)
 }
 
 func TestInvalidIndexPartitionSetShowZones(t *testing.T) {

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1117,7 +1117,7 @@ func TestAdminAPIJobs(t *testing.T) {
 
 	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
-	sqlDB := sqlutils.MakeSQLRunner(t, conn)
+	sqlDB := sqlutils.MakeSQLRunner(conn)
 
 	testJobs := []struct {
 		id      int64
@@ -1134,7 +1134,7 @@ func TestAdminAPIJobs(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		sqlDB.Exec(
+		sqlDB.Exec(t,
 			`INSERT INTO system.jobs (id, status, payload) VALUES ($1, $2, $3)`,
 			job.id, job.status, payloadBytes,
 		)
@@ -1177,11 +1177,11 @@ func TestAdminAPIQueryPlan(t *testing.T) {
 
 	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
-	sqlDB := sqlutils.MakeSQLRunner(t, conn)
+	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(`CREATE DATABASE api_test`)
-	sqlDB.Exec(`CREATE TABLE api_test.t1 (id int primary key, name string)`)
-	sqlDB.Exec(`CREATE TABLE api_test.t2 (id int primary key, name string)`)
+	sqlDB.Exec(t, `CREATE DATABASE api_test`)
+	sqlDB.Exec(t, `CREATE TABLE api_test.t1 (id int primary key, name string)`)
+	sqlDB.Exec(t, `CREATE TABLE api_test.t2 (id int primary key, name string)`)
 
 	testCases := []struct {
 		query string

--- a/pkg/sql/bench_test.go
+++ b/pkg/sql/bench_test.go
@@ -1013,9 +1013,9 @@ func BenchmarkPlanning(b *testing.B) {
 	s, db, _ := serverutils.StartServer(b, base.TestServerArgs{UseDatabase: "bench"})
 	defer s.Stopper().Stop(context.TODO())
 
-	sr := sqlutils.MakeSQLRunner(b, db)
-	sr.Exec(`CREATE DATABASE bench`)
-	sr.Exec(`CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX(b), UNIQUE INDEX(c))`)
+	sr := sqlutils.MakeSQLRunner(db)
+	sr.Exec(b, `CREATE DATABASE bench`)
+	sr.Exec(b, `CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, INDEX(b), UNIQUE INDEX(c))`)
 
 	queries := []string{
 		`SELECT * FROM abc`,
@@ -1028,7 +1028,7 @@ func BenchmarkPlanning(b *testing.B) {
 	for _, q := range queries {
 		b.Run(q, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				sr.Exec(q)
+				sr.Exec(b, q)
 			}
 		})
 	}

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -262,14 +262,14 @@ func TestDistBackfill(t *testing.T) {
 		SplitTable(t, tc, descNumToStr, i, n*n/numNodes*i)
 	}
 
-	r := sqlutils.MakeSQLRunner(t, tc.ServerConn(0))
+	r := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	r.DB.SetMaxOpenConns(1)
-	r.Exec("SET DISTSQL = OFF")
+	r.Exec(t, "SET DISTSQL = OFF")
 	if _, err := tc.ServerConn(0).Exec(`CREATE INDEX foo ON numtostr (str)`); err != nil {
 		t.Fatal(err)
 	}
-	r.Exec("SET DISTSQL = ALWAYS")
-	res := r.QueryStr(`SELECT str FROM numtostr@foo`)
+	r.Exec(t, "SET DISTSQL = ALWAYS")
+	res := r.QueryStr(t, `SELECT str FROM numtostr@foo`)
 	if len(res) != n*n {
 		t.Errorf("expected %d entries, got %d", n*n, len(res))
 	}
@@ -468,26 +468,26 @@ func TestDistSQLDeadHosts(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(context.TODO())
 
-	r := sqlutils.MakeSQLRunner(t, tc.ServerConn(0))
+	r := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 	r.DB.SetMaxOpenConns(1)
-	r.Exec("CREATE DATABASE test")
+	r.Exec(t, "CREATE DATABASE test")
 
-	r.Exec("CREATE TABLE t (x INT PRIMARY KEY, xsquared INT)")
+	r.Exec(t, "CREATE TABLE t (x INT PRIMARY KEY, xsquared INT)")
 
 	for i := 0; i < numNodes; i++ {
-		r.Exec(fmt.Sprintf("ALTER TABLE t SPLIT AT VALUES (%d)", n*i/5))
+		r.Exec(t, fmt.Sprintf("ALTER TABLE t SPLIT AT VALUES (%d)", n*i/5))
 	}
 
 	for i := 0; i < numNodes; i++ {
-		r.Exec(fmt.Sprintf(
+		r.Exec(t, fmt.Sprintf(
 			"ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[%d,%d,%d], %d)",
 			i+1, (i+1)%5+1, (i+2)%5+1, n*i/5,
 		))
 	}
 
-	r.Exec(fmt.Sprintf("INSERT INTO t SELECT i, i*i FROM GENERATE_SERIES(1, %d) AS g(i)", n))
+	r.Exec(t, fmt.Sprintf("INSERT INTO t SELECT i, i*i FROM GENERATE_SERIES(1, %d) AS g(i)", n))
 
-	r.Exec("SET DISTSQL = ON")
+	r.Exec(t, "SET DISTSQL = ON")
 
 	// Run a query that uses the entire table and is easy to verify.
 	runQuery := func() error {
@@ -507,7 +507,7 @@ func TestDistSQLDeadHosts(t *testing.T) {
 	}
 
 	// Verify the plan (should include all 5 nodes).
-	r.CheckQueryResults(
+	r.CheckQueryResults(t,
 		"SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM(xsquared) FROM t]",
 		[][]string{{"https://cockroachdb.github.io/distsqlplan/decode.html?eJy8k09LwzAYxu9-CnlOCu9h7bo5e5rHHXQy9SQ91OalFLamJCkoo99d1iDaIskgo8f8-T2_PG1yRC0FP-UH1kjfEYEQgzAHIQFhgYzQKFmw1lKdtlhgIz6RzghV3bTmNJ0RCqkY6RGmMntGitf8Y887zgUrEASbvNr3kkZVh1x9rQ0I29ak1-sYWUeQrflJ6-h8z0NZKi5zI0eal7fHm3V0e3b0b2JbSyVYsRgEZt2F5dFE38_jCakQT1TB4wmpMJ-ogscTUiGZqILHc6mH-E_0jnUja82jBznMywgsSrZvWctWFfysZNGH2-G2391PCNbGrkZ2sKnt0ulYf-HICccDOBrDsdvsUc-ddOKGk5BzL5zw0m1ehpjvnPDKbV6FmO_d_2rmuSbuSzZ2Z93VdwAAAP__XTV6BQ=="}},
 	)
@@ -517,7 +517,7 @@ func TestDistSQLDeadHosts(t *testing.T) {
 
 	testutils.SucceedsSoon(t, runQuery)
 
-	r.CheckQueryResults(
+	r.CheckQueryResults(t,
 		"SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM(xsquared) FROM t]",
 		[][]string{{"https://cockroachdb.github.io/distsqlplan/decode.html?eJy8k8FK7DAYhff3KS5npZCF6dRx7KouZ6Ejo64ki9j8lEKnKUkKytB3lzaItkg60qHL5M93vpySHlFpRQ_yQBbJKzgYIjCswBBDMNRGZ2StNt3YH96qdyRXDEVVN67bFgyZNoTkCFe4kpDgWb6VtCepyIBBkZNF2QtqUxyk-UgdGHaNS_6nEUTLoBv3lday0z13eW4ol06PNE8v9xcpvzw5-juxqbRRZEgNAkV7Zjlf6PtNeOZUiBaqMOGZU2G1UIUJz7le8S_Re7K1riyNXvMwTzCQysn_CFY3JqNHo7M-3C93_el-Q5F1fsr9Ylv5UXetnzAPwtEA5mM4CsK3YfMqCMdhOJ5z7esgvA6b13PMN0F4EzZv_mQW7b_PAAAA__-DuA-E"}},
 	)
@@ -527,7 +527,7 @@ func TestDistSQLDeadHosts(t *testing.T) {
 
 	testutils.SucceedsSoon(t, runQuery)
 
-	r.CheckQueryResults(
+	r.CheckQueryResults(t,
 		"SELECT URL FROM [EXPLAIN (DISTSQL) SELECT SUM(xsquared) FROM t]",
 		[][]string{{"https://cockroachdb.github.io/distsqlplan/decode.html?eJy8kkFLwzAUx-9-CvmfFHIwXZ3QUz3uoJOpJ8khNo9S6JrykoIy-t2lDaItkk02dkxe_r_fe-Ht0FhDj3pLDtkbJAQWEEihBFq2BTlneSiFhyvzgexGoGrazg_XSqCwTMh28JWvCRle9HtNG9KGGAKGvK7qEd5ytdX8mXsIrDufXeYJVC9gO_9N68XhnvuyZCq1tzPN8-vDVS6vD0b_ELvGsiEmMwGq_sRyeab_2-M5ZoTkTCPs8ZxqBf5Ab8i1tnE0W4UpTwmQKSlskbMdF_TEthjh4bgeX48XhpwPVRkOqyaUhrZ-h2U0nEzCch5OouG7uHkRDafxcHpM27fR8DJuXv7LrPqLrwAAAP__vMyldA=="}},
 	)

--- a/pkg/sql/distsqlrun/server_test.go
+++ b/pkg/sql/distsqlrun/server_test.go
@@ -41,11 +41,11 @@ func TestServer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := sqlutils.MakeSQLRunner(t, sqlDB)
+	r := sqlutils.MakeSQLRunner(sqlDB)
 
-	r.Exec(`CREATE DATABASE test`)
-	r.Exec(`CREATE TABLE test.t (a INT PRIMARY KEY, b INT)`)
-	r.Exec(`INSERT INTO test.t VALUES (1, 10), (2, 20), (3, 30)`)
+	r.Exec(t, `CREATE DATABASE test`)
+	r.Exec(t, `CREATE TABLE test.t (a INT PRIMARY KEY, b INT)`)
+	r.Exec(t, `INSERT INTO test.t VALUES (1, 10), (2, 20), (3, 30)`)
 
 	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 

--- a/pkg/sql/impure_builtin_test.go
+++ b/pkg/sql/impure_builtin_test.go
@@ -36,9 +36,9 @@ func TestClusterID(t *testing.T) {
 	defer tc.Stopper().Stop(context.TODO())
 
 	for i := 0; i < 3; i++ {
-		db := sqlutils.MakeSQLRunner(t, tc.Conns[i])
+		db := sqlutils.MakeSQLRunner(tc.Conns[i])
 		var clusterID uuid.UUID
-		db.QueryRow("SELECT crdb_internal.cluster_id()").Scan(&clusterID)
+		db.QueryRow(t, "SELECT crdb_internal.cluster_id()").Scan(&clusterID)
 		if id := tc.Servers[0].ClusterID(); id != clusterID {
 			t.Fatalf("expected %v, got %v", id, clusterID)
 		}

--- a/pkg/sql/jobs/registry_external_test.go
+++ b/pkg/sql/jobs/registry_external_test.go
@@ -204,7 +204,7 @@ func TestRegistryResumeActiveLease(t *testing.T) {
 	}
 
 	var id int64
-	sqlutils.MakeSQLRunner(t, sqlDB).QueryRow(
+	sqlutils.MakeSQLRunner(sqlDB).QueryRow(t,
 		`INSERT INTO system.jobs (status, payload) VALUES ($1, $2) RETURNING id`,
 		jobs.StatusRunning, payload).Scan(&id)
 

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -97,7 +97,7 @@ func (t *parallelTest) getClient(nodeIdx, clientIdx int) *gosql.DB {
 		if err != nil {
 			t.Fatal(err)
 		}
-		sqlutils.MakeSQLRunner(t, db).Exec("SET DATABASE = test")
+		sqlutils.MakeSQLRunner(db).Exec(t, "SET DATABASE = test")
 		t.cluster.Stopper().AddCloser(
 			stop.CloserFn(func() {
 				_ = db.Close()
@@ -207,7 +207,7 @@ func (t *parallelTest) setup(spec *parTestSpec) {
 	for i := range t.clients {
 		t.clients[i] = append(t.clients[i], t.cluster.ServerConn(i))
 	}
-	r0 := sqlutils.MakeSQLRunner(t, t.clients[0][0])
+	r0 := sqlutils.MakeSQLRunner(t.clients[0][0])
 
 	if spec.RangeSplitSize != 0 {
 		if testing.Verbose() || log.V(1) {
@@ -221,16 +221,16 @@ func (t *parallelTest) setup(spec *parTestSpec) {
 			t.Fatal(err)
 		}
 		objID := keys.RootNamespaceID
-		r0.Exec(`UPDATE system.zones SET config = $2 WHERE id = $1`, objID, buf)
+		r0.Exec(t, `UPDATE system.zones SET config = $2 WHERE id = $1`, objID, buf)
 	}
 
 	if testing.Verbose() || log.V(1) {
 		log.Infof(t.ctx, "Creating database")
 	}
 
-	r0.Exec("CREATE DATABASE test")
+	r0.Exec(t, "CREATE DATABASE test")
 	for i := range t.clients {
-		sqlutils.MakeSQLRunner(t, t.clients[i][0]).Exec("SET DATABASE = test")
+		sqlutils.MakeSQLRunner(t.clients[i][0]).Exec(t, "SET DATABASE = test")
 	}
 
 	if testing.Verbose() || log.V(1) {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -368,7 +368,7 @@ CREATE INDEX foo ON t.test (v)
 	// Ensure that the indexes have been created.
 	mTest := makeMutationTest(t, kvDB, sqlDB, tableDesc)
 	indexQuery := `SELECT v FROM t.test@foo`
-	mTest.CheckQueryResults(indexQuery, [][]string{{"b"}, {"d"}})
+	mTest.CheckQueryResults(t, indexQuery, [][]string{{"b"}, {"d"}})
 
 	// Ensure that the version has been incremented.
 	tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "test")
@@ -380,7 +380,7 @@ CREATE INDEX foo ON t.test (v)
 	// Apply a schema change that only sets the UpVersion bit.
 	expectedVersion = newVersion + 1
 
-	mTest.Exec(`ALTER INDEX t.test@foo RENAME TO ufo`)
+	mTest.Exec(t, `ALTER INDEX t.test@foo RENAME TO ufo`)
 
 	for r := retry.Start(retryOpts); r.Next(); {
 		// Ensure that the version gets incremented.
@@ -399,7 +399,7 @@ CREATE INDEX foo ON t.test (v)
 	// that they all get executed.
 	count := 5
 	for i := 0; i < count; i++ {
-		mTest.Exec(fmt.Sprintf(`CREATE INDEX foo%d ON t.test (v)`, i))
+		mTest.Exec(t, fmt.Sprintf(`CREATE INDEX foo%d ON t.test (v)`, i))
 	}
 	// Wait until indexes are created.
 	for r := retry.Start(retryOpts); r.Next(); {
@@ -410,7 +410,7 @@ CREATE INDEX foo ON t.test (v)
 	}
 	for i := 0; i < count; i++ {
 		indexQuery := fmt.Sprintf(`SELECT v FROM t.test@foo%d`, i)
-		mTest.CheckQueryResults(indexQuery, [][]string{{"b"}, {"d"}})
+		mTest.CheckQueryResults(t, indexQuery, [][]string{{"b"}, {"d"}})
 	}
 }
 

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -471,7 +471,7 @@ func TestShowJobs(t *testing.T) {
 
 	params, _ := createTestServerParams()
 	s, rawSQLDB, _ := serverutils.StartServer(t, params)
-	sqlDB := sqlutils.MakeSQLRunner(t, rawSQLDB)
+	sqlDB := sqlutils.MakeSQLRunner(rawSQLDB)
 	defer s.Stopper().Stop(context.TODO())
 
 	// row represents a row returned from crdb_internal.jobs, but
@@ -527,13 +527,13 @@ func TestShowJobs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	sqlDB.Exec(
+	sqlDB.Exec(t,
 		`INSERT INTO system.jobs (id, status, created, payload) VALUES ($1, $2, $3, $4)`,
 		in.id, in.status, in.created, inPayload,
 	)
 
 	var out row
-	sqlDB.QueryRow(`
+	sqlDB.QueryRow(t, `
       SELECT id, type, status, created, description, started, finished, modified,
              fraction_completed, username, error, coordinator_id
         FROM crdb_internal.jobs`).Scan(

--- a/pkg/sql/sqlbase/multirowfetcher_test.go
+++ b/pkg/sql/sqlbase/multirowfetcher_test.go
@@ -279,7 +279,7 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 		sqlutils.RowModuloFn(storingMods[1]),
 	)
 
-	r := sqlutils.MakeSQLRunner(t, sqlDB)
+	r := sqlutils.MakeSQLRunner(sqlDB)
 	// Initialize tables first.
 	for tableName, table := range tables {
 		sqlutils.CreateTable(
@@ -293,7 +293,7 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 		// we're properly decoding (UNIQUE) secondary index keys
 		// properly).
 		for i := 1; i <= nNulls; i++ {
-			r.Exec(fmt.Sprintf(
+			r.Exec(t, fmt.Sprintf(
 				`INSERT INTO test.%s VALUES (%d, NULL, %d, %d);`,
 				tableName,
 				table.nRows+i,
@@ -615,8 +615,8 @@ func TestNextRowInterleave(t *testing.T) {
 	for _, table := range interleaveEntries {
 		if table.indexSchema != "" {
 			// Create interleaved secondary indexes.
-			r := sqlutils.MakeSQLRunner(t, sqlDB)
-			r.Exec(table.indexSchema)
+			r := sqlutils.MakeSQLRunner(sqlDB)
+			r.Exec(t, table.indexSchema)
 		} else {
 			// Create tables (primary indexes).
 			sqlutils.CreateTableInterleave(

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -1326,13 +1326,13 @@ func TestKeysPerRow(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%s - %d", test.createTable, test.indexID), func(t *testing.T) {
-			sqlDB := sqlutils.MakeSQLRunner(t, conn)
+			sqlDB := sqlutils.MakeSQLRunner(conn)
 			tableName := fmt.Sprintf("t%d", i)
-			sqlDB.Exec(fmt.Sprintf(`CREATE TABLE d.%s %s`, tableName, test.createTable))
+			sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE d.%s %s`, tableName, test.createTable))
 
 			var descBytes []byte
 			// Grab the most recently created descriptor.
-			row := sqlDB.QueryRow(
+			row := sqlDB.QueryRow(t,
 				`SELECT descriptor FROM system.descriptor ORDER BY id DESC LIMIT 1`)
 			row.Scan(&descBytes)
 			var desc Descriptor

--- a/pkg/sql/table_split_test.go
+++ b/pkg/sql/table_split_test.go
@@ -38,9 +38,9 @@ func TestSplitAtTableBoundary(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 3, testClusterArgs)
 	defer tc.Stopper().Stop(context.TODO())
 
-	runner := sqlutils.MakeSQLRunner(t, tc.Conns[0])
-	runner.Exec(`CREATE DATABASE test`)
-	runner.Exec(`CREATE TABLE test.t (k SERIAL PRIMARY KEY, v INT)`)
+	runner := sqlutils.MakeSQLRunner(tc.Conns[0])
+	runner.Exec(t, `CREATE DATABASE test`)
+	runner.Exec(t, `CREATE TABLE test.t (k SERIAL PRIMARY KEY, v INT)`)
 
 	const tableIDQuery = `
 SELECT tables.id FROM system.namespace tables
@@ -48,7 +48,7 @@ SELECT tables.id FROM system.namespace tables
   WHERE dbs.name = $1 AND tables.name = $2
 `
 	var tableID uint32
-	runner.QueryRow(tableIDQuery, "test", "t").Scan(&tableID)
+	runner.QueryRow(t, tableIDQuery, "test", "t").Scan(&tableID)
 	tableStartKey := keys.MakeTablePrefix(tableID)
 
 	// Wait for new table to split.

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -359,9 +359,9 @@ func TestKVTraceWithCountStar(t *testing.T) {
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
 
-	r := sqlutils.MakeSQLRunner(t, db)
-	r.Exec("CREATE DATABASE test")
-	r.Exec("CREATE TABLE test.a (a INT PRIMARY KEY, b INT)")
-	r.Exec("INSERT INTO test.a VALUES (1,1), (2,2)")
-	r.Exec("SHOW KV TRACE FOR SELECT COUNT(*) FROM test.a")
+	r := sqlutils.MakeSQLRunner(db)
+	r.Exec(t, "CREATE DATABASE test")
+	r.Exec(t, "CREATE TABLE test.a (a INT PRIMARY KEY, b INT)")
+	r.Exec(t, "INSERT INTO test.a VALUES (1,1), (2,2)")
+	r.Exec(t, "SHOW KV TRACE FOR SELECT COUNT(*) FROM test.a")
 }

--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -60,14 +60,14 @@ func TestUpsertFastPath(t *testing.T) {
 		}},
 	})
 	defer s.Stopper().Stop(context.TODO())
-	sqlDB := sqlutils.MakeSQLRunner(t, conn)
-	sqlDB.Exec(`CREATE DATABASE d`)
-	sqlDB.Exec(`CREATE TABLE d.kv (k INT PRIMARY KEY, v INT)`)
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, `CREATE TABLE d.kv (k INT PRIMARY KEY, v INT)`)
 
 	// This should hit the fast path.
 	atomic.StoreUint64(&scans, 0)
 	atomic.StoreUint64(&beginTxn, 0)
-	sqlDB.Exec(`UPSERT INTO d.kv VALUES (1, 1)`)
+	sqlDB.Exec(t, `UPSERT INTO d.kv VALUES (1, 1)`)
 	if s := atomic.LoadUint64(&scans); s != 0 {
 		t.Errorf("expected no scans (the upsert fast path) but got %d", s)
 	}
@@ -78,7 +78,7 @@ func TestUpsertFastPath(t *testing.T) {
 	// This could hit the fast path, but doesn't right now because of #14482.
 	atomic.StoreUint64(&scans, 0)
 	atomic.StoreUint64(&beginTxn, 0)
-	sqlDB.Exec(`INSERT INTO d.kv VALUES (1, 1) ON CONFLICT (k) DO UPDATE SET v=excluded.v`)
+	sqlDB.Exec(t, `INSERT INTO d.kv VALUES (1, 1) ON CONFLICT (k) DO UPDATE SET v=excluded.v`)
 	if s := atomic.LoadUint64(&scans); s != 1 {
 		t.Errorf("expected 1 scans (no upsert fast path) but got %d", s)
 	}
@@ -89,7 +89,7 @@ func TestUpsertFastPath(t *testing.T) {
 	// This should not hit the fast path because it doesn't set every column.
 	atomic.StoreUint64(&scans, 0)
 	atomic.StoreUint64(&beginTxn, 0)
-	sqlDB.Exec(`UPSERT INTO d.kv (k) VALUES (1)`)
+	sqlDB.Exec(t, `UPSERT INTO d.kv (k) VALUES (1)`)
 	if s := atomic.LoadUint64(&scans); s != 1 {
 		t.Errorf("expected 1 scans (no upsert fast path) but got %d", s)
 	}
@@ -119,10 +119,10 @@ func TestUpsertFastPath(t *testing.T) {
 	}
 
 	// This should not hit the fast path because kv has a secondary index.
-	sqlDB.Exec(`CREATE INDEX vidx ON d.kv (v)`)
+	sqlDB.Exec(t, `CREATE INDEX vidx ON d.kv (v)`)
 	atomic.StoreUint64(&scans, 0)
 	atomic.StoreUint64(&beginTxn, 0)
-	sqlDB.Exec(`UPSERT INTO d.kv VALUES (1, 1)`)
+	sqlDB.Exec(t, `UPSERT INTO d.kv VALUES (1, 1)`)
 	if s := atomic.LoadUint64(&scans); s != 1 {
 		t.Errorf("expected 1 scans (no upsert fast path) but got %d", s)
 	}
@@ -136,11 +136,11 @@ func TestConcurrentUpsertWithSnapshotIsolation(t *testing.T) {
 
 	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
-	sqlDB := sqlutils.MakeSQLRunner(t, conn)
+	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(`CREATE DATABASE d`)
-	sqlDB.Exec(`CREATE TABLE d.t (a INT PRIMARY KEY, b INT, INDEX b_idx (b))`)
-	sqlDB.Exec(`SET DEFAULT_TRANSACTION_ISOLATION TO SNAPSHOT`)
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+	sqlDB.Exec(t, `CREATE TABLE d.t (a INT PRIMARY KEY, b INT, INDEX b_idx (b))`)
+	sqlDB.Exec(t, `SET DEFAULT_TRANSACTION_ISOLATION TO SNAPSHOT`)
 
 	testCases := []struct {
 		name       string
@@ -181,8 +181,8 @@ SELECT * FROM d.t@primary = %s
 SELECT * FROM d.t@b_idx   = %s
 `,
 					err,
-					sqlDB.QueryStr(`SELECT * FROM d.t@primary`),
-					sqlDB.QueryStr(`SELECT * FROM d.t@b_idx`),
+					sqlDB.QueryStr(t, `SELECT * FROM d.t@primary`),
+					sqlDB.QueryStr(t, `SELECT * FROM d.t@b_idx`),
 				)
 			}
 		})

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -29,7 +30,7 @@ import (
 
 // VerifySystemJob checks that that job records are created as expected.
 func VerifySystemJob(
-	db *sqlutils.SQLRunner, offset int, expectedType jobs.Type, expected jobs.Record,
+	t testing.TB, db *sqlutils.SQLRunner, offset int, expectedType jobs.Type, expected jobs.Record,
 ) error {
 	var actual jobs.Record
 	var rawDescriptorIDs pq.Int64Array
@@ -38,7 +39,7 @@ func VerifySystemJob(
 	// We have to query for the nth job created rather than filtering by ID,
 	// because job-generating SQL queries (e.g. BACKUP) do not currently return
 	// the job ID.
-	db.QueryRow(`
+	db.QueryRow(t, `
 		SELECT type, description, username, descriptor_ids, status
 		FROM crdb_internal.jobs ORDER BY created LIMIT 1 OFFSET $1`,
 		offset,

--- a/pkg/testutils/sqlutils/table_gen.go
+++ b/pkg/testutils/sqlutils/table_gen.go
@@ -67,10 +67,10 @@ func CreateTableInterleave(
 		interleaveSchema = fmt.Sprintf(`INTERLEAVE IN PARENT %s`, interleaveSchema)
 	}
 
-	r := MakeSQLRunner(tb, sqlDB)
+	r := MakeSQLRunner(sqlDB)
 	stmt := `CREATE DATABASE IF NOT EXISTS test;`
 	stmt += fmt.Sprintf(`CREATE TABLE test.%s (%s) %s;`, tableName, schema, interleaveSchema)
-	r.Exec(stmt)
+	r.Exec(tb, stmt)
 	for i := 1; i <= numRows; {
 		var buf bytes.Buffer
 		fmt.Fprintf(&buf, `INSERT INTO test.%s VALUES `, tableName)
@@ -80,7 +80,7 @@ func CreateTableInterleave(
 		}
 		genValues(&buf, i, batchEnd, fn)
 
-		r.Exec(buf.String())
+		r.Exec(tb, buf.String())
 		i = batchEnd + 1
 	}
 }

--- a/pkg/testutils/sqlutils/zone.go
+++ b/pkg/testutils/sqlutils/zone.go
@@ -17,6 +17,7 @@ package sqlutils
 import (
 	gosql "database/sql"
 	"fmt"
+	"testing"
 
 	yaml "gopkg.in/yaml.v2"
 
@@ -50,52 +51,52 @@ func (row ZoneRow) sqlRowString() ([]string, error) {
 }
 
 // DeleteZoneConfig deletes the specified zone config through the SQL interface.
-func DeleteZoneConfig(sqlDB *SQLRunner, target string) {
-	sqlDB.Helper()
-	sqlDB.Exec(fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE NULL", target))
+func DeleteZoneConfig(t testing.TB, sqlDB *SQLRunner, target string) {
+	t.Helper()
+	sqlDB.Exec(t, fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE NULL", target))
 }
 
 // SetZoneConfig updates the specified zone config through the SQL interface.
-func SetZoneConfig(sqlDB *SQLRunner, target string, config string) {
-	sqlDB.Helper()
-	sqlDB.Exec(fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE %s",
+func SetZoneConfig(t testing.TB, sqlDB *SQLRunner, target string, config string) {
+	t.Helper()
+	sqlDB.Exec(t, fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE %s",
 		target, lex.EscapeSQLString(config)))
 }
 
 // TxnSetZoneConfig updates the specified zone config through the SQL interface
 // using the provided transaction.
-func TxnSetZoneConfig(sqlDB *SQLRunner, txn *gosql.Tx, target string, config string) {
-	sqlDB.Helper()
+func TxnSetZoneConfig(t testing.TB, sqlDB *SQLRunner, txn *gosql.Tx, target string, config string) {
+	t.Helper()
 	_, err := txn.Exec(fmt.Sprintf("ALTER %s EXPERIMENTAL CONFIGURE ZONE %s",
 		target, lex.EscapeSQLString(config)))
 	if err != nil {
-		sqlDB.Fatal(err)
+		t.Fatal(err)
 	}
 }
 
 // VerifyZoneConfigForTarget verifies that the specified zone matches the specified
 // ZoneRow.
-func VerifyZoneConfigForTarget(sqlDB *SQLRunner, target string, row ZoneRow) {
-	sqlDB.Helper()
+func VerifyZoneConfigForTarget(t testing.TB, sqlDB *SQLRunner, target string, row ZoneRow) {
+	t.Helper()
 	sqlRow, err := row.sqlRowString()
 	if err != nil {
-		sqlDB.Fatal(err)
+		t.Fatal(err)
 	}
-	sqlDB.CheckQueryResults(fmt.Sprintf("EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s", target),
+	sqlDB.CheckQueryResults(t, fmt.Sprintf("EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s", target),
 		[][]string{sqlRow})
 }
 
 // VerifyAllZoneConfigs verifies that the specified ZoneRows exactly match the
 // list of active zone configs.
-func VerifyAllZoneConfigs(sqlDB *SQLRunner, rows ...ZoneRow) {
-	sqlDB.Helper()
+func VerifyAllZoneConfigs(t testing.TB, sqlDB *SQLRunner, rows ...ZoneRow) {
+	t.Helper()
 	expected := make([][]string, len(rows))
 	for i, row := range rows {
 		var err error
 		expected[i], err = row.sqlRowString()
 		if err != nil {
-			sqlDB.Fatal(err)
+			t.Fatal(err)
 		}
 	}
-	sqlDB.CheckQueryResults("EXPERIMENTAL SHOW ALL ZONE CONFIGURATIONS", expected)
+	sqlDB.CheckQueryResults(t, "EXPERIMENTAL SHOW ALL ZONE CONFIGURATIONS", expected)
 }

--- a/pkg/testutils/testcluster/testcluster_test.go
+++ b/pkg/testutils/testcluster/testcluster_test.go
@@ -45,21 +45,21 @@ func TestManualReplication(t *testing.T) {
 		})
 	defer tc.Stopper().Stop(context.TODO())
 
-	s0 := sqlutils.MakeSQLRunner(t, tc.Conns[0])
-	s1 := sqlutils.MakeSQLRunner(t, tc.Conns[1])
-	s2 := sqlutils.MakeSQLRunner(t, tc.Conns[2])
+	s0 := sqlutils.MakeSQLRunner(tc.Conns[0])
+	s1 := sqlutils.MakeSQLRunner(tc.Conns[1])
+	s2 := sqlutils.MakeSQLRunner(tc.Conns[2])
 
-	s0.Exec(`CREATE DATABASE t`)
-	s0.Exec(`CREATE TABLE test (k INT PRIMARY KEY, v INT)`)
-	s0.Exec(`INSERT INTO test VALUES (5, 1), (4, 2), (1, 2)`)
+	s0.Exec(t, `CREATE DATABASE t`)
+	s0.Exec(t, `CREATE TABLE test (k INT PRIMARY KEY, v INT)`)
+	s0.Exec(t, `INSERT INTO test VALUES (5, 1), (4, 2), (1, 2)`)
 
-	if r := s1.Query(`SELECT * FROM test WHERE k = 5`); !r.Next() {
+	if r := s1.Query(t, `SELECT * FROM test WHERE k = 5`); !r.Next() {
 		t.Fatal("no rows")
 	} else {
 		r.Close()
 	}
 
-	s2.ExecRowsAffected(3, `DELETE FROM test`)
+	s2.ExecRowsAffected(t, 3, `DELETE FROM test`)
 
 	// Split the table to a new range.
 	kvDB := tc.Servers[0].DB()


### PR DESCRIPTION
With our increased use of subtests, we often have multiple `testing.T`s
floating around in tests. When we close over one of them in a struct
like SQLRunner that then gets used elsewhere, we often end up calling
methods on the wrong `testing.TB`, leading to confusing and
uninformative errors rather than actual failue message / location. Since
these are usually only called when something breaks, this may be long
after the change introducing the subtest, and thus harder to recognize
what's wrong.

Instead, we should treat testing.T more like context -- always passed in
at individual callsites and not stored in stucts that may be passed
between scopes or goroutines.

There are probably a few places that, after this change, no longer
benefit as much from SQLRunner or could be cleaned up,  however I tried
to keep this change as simple and mechanical as possible given its
breadth.