### PR TITLE
kv: simplify next() and truncate()

### DIFF
--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -60,7 +60,7 @@ func truncate(ba roachpb.BatchRequest, rs roachpb.RSpan) (roachpb.BatchRequest, 
 		if err != nil {
 			return false, emptySpan, err
 		}
-		if l, r := !keyAddr.Equal(header.Key), !endKeyAddr.Equal(header.EndKey); l || r {
+		if l, r := keys.IsLocal(header.Key), keys.IsLocal(header.EndKey); l || r {
 			if !l || !r {
 				return false, emptySpan, errors.Errorf("local key mixed with global key in range")
 			}
@@ -219,6 +219,10 @@ func next(ba roachpb.BatchRequest, k roachpb.RKey) (roachpb.RKey, error) {
 			return nil, err
 		}
 		if addr.Less(k) {
+			if len(h.EndKey) == 0 {
+				// `h` affects only `[KeyMin,k)`, all of which is less than `k`.
+				continue
+			}
 			eAddr, err := keys.AddrUpperBound(h.EndKey)
 			if err != nil {
 				return nil, err
@@ -227,7 +231,7 @@ func next(ba roachpb.BatchRequest, k roachpb.RKey) (roachpb.RKey, error) {
 				// Starts below k, but continues beyond. Need to stay at k.
 				return k, nil
 			}
-			// Affects only [KeyMin,k).
+			// `h` affects only `[KeyMin,k)`, all of which is less than `k`.
 			continue
 		}
 		// We want the smallest of the surviving candidates.


### PR DESCRIPTION
The old code was correct, but this is slightly more efficient and
also gives the reader less to think about.

Release notes: none.

Closes #18395.