### PR TITLE
storage: report stringified RocksDB error code

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -24,6 +24,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -441,7 +442,7 @@ func (r *RocksDB) open() error {
 			max_open_files:  C.int(maxOpenFiles),
 		})
 	if err := statusToError(status); err != nil {
-		return errors.Errorf("could not open rocksdb instance: %s", err)
+		return errors.Wrap(err, "could not open rocksdb instance")
 	}
 
 	// Update or add the version file if needed.
@@ -1873,11 +1874,35 @@ func goToCTimestamp(ts hlc.Timestamp) C.DBTimestamp {
 	}
 }
 
+// A RocksDBError wraps an error returned from a RocksDB operation.
+type RocksDBError struct {
+	msg string
+}
+
+var _ log.SafeMessager = (*RocksDBError)(nil)
+
+// Error implements the error interface.
+func (err *RocksDBError) Error() string {
+	return err.msg
+}
+
+// SafeMessage implements log.SafeMessager.
+func (err *RocksDBError) SafeMessage() string {
+	// RocksDB errors are of format
+	// <Error Type>: [<Suberror type>] [State]
+	// We extract only the `<Error Type>` part.
+	ps := strings.SplitN(err.msg, ":", 2)
+	if len(ps) < 2 {
+		return "<unknown>"
+	}
+	return ps[0]
+}
+
 func statusToError(s C.DBStatus) error {
 	if s.data == nil {
 		return nil
 	}
-	return errors.New(cStringToGoString(s))
+	return &RocksDBError{msg: cStringToGoString(s)}
 }
 
 // goMerge takes existing and update byte slices that are expected to

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
 )
 
 const testCacheSize = 1 << 30 // 1 GB
@@ -567,6 +568,44 @@ func BenchmarkRocksDBSstFileReader(b *testing.B) {
 		if count >= b.N {
 			break
 		}
+	}
+}
+
+// TestRocksDBErrorSafeMessage verifies that RocksDB errors have a chance of
+// being reported safely.
+func TestRocksDBErrorSafeMessage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	dir, dirCleanup := testutils.TempDir(t)
+	defer dirCleanup()
+
+	open := func() (*RocksDB, error) {
+		return NewRocksDB(
+			RocksDBConfig{
+				Settings: cluster.MakeTestingClusterSettings(),
+				Dir:      dir,
+			},
+			RocksDBCache{},
+		)
+	}
+
+	// Provoke a RocksDB error by opening two instances for the same directory.
+	r1, err := open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r1.Close()
+	r2, err := open()
+	if err == nil {
+		defer r2.Close()
+		t.Fatal("expected error")
+	}
+	rErr, ok := errors.Cause(err).(*RocksDBError)
+	if !ok {
+		t.Fatalf("unexpected error of cause %T: %s", errors.Cause(err), err)
+	}
+	const exp = "IO error" // from `rocksdb::Status::ToString()`
+	if act := rErr.SafeMessage(); act != exp {
+		t.Fatalf("expected %q, got %q", exp, act)
 	}
 }
 


### PR DESCRIPTION
We are now seeing first error reports that have a RocksDB-originating error at their root,
so next it would be nice to see what classes of errors we see. We hope to see "IO error"
a lot, as that usually means out of disk.

See https://github.com/facebook/rocksdb/blob/master/include/rocksdb/status.h for a list
of status code messages that we can expect to see.

Release note: none