### PR TITLE
cherrypick-1.1: storage: report stringified RocksDB error code

### DIFF
--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
 )
 
 const testCacheSize = 1 << 30 // 1 GB
@@ -567,6 +568,44 @@ func BenchmarkRocksDBSstFileReader(b *testing.B) {
 		if count >= b.N {
 			break
 		}
+	}
+}
+
+// TestRocksDBErrorSafeMessage verifies that RocksDB errors have a chance of
+// being reported safely.
+func TestRocksDBErrorSafeMessage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	dir, dirCleanup := testutils.TempDir(t)
+	defer dirCleanup()
+
+	open := func() (*RocksDB, error) {
+		return NewRocksDB(
+			RocksDBConfig{
+				Settings: cluster.MakeTestingClusterSettings(),
+				Dir:      dir,
+			},
+			RocksDBCache{},
+		)
+	}
+
+	// Provoke a RocksDB error by opening two instances for the same directory.
+	r1, err := open()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r1.Close()
+	r2, err := open()
+	if err == nil {
+		defer r2.Close()
+		t.Fatal("expected error")
+	}
+	rErr, ok := errors.Cause(err).(*RocksDBError)
+	if !ok {
+		t.Fatalf("unexpected error of cause %T: %s", errors.Cause(err), err)
+	}
+	const exp = "IO error" // from `rocksdb::Status::ToString()`
+	if act := rErr.SafeMessage(); act != exp {
+		t.Fatalf("expected %q, got %q", exp, act)
 	}
 }
 

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -84,11 +84,23 @@ func RecoverAndReportPanic(ctx context.Context, sv *settings.Values) {
 	}
 }
 
+// SafeMessager is implemented by objects which have a way of representing
+// themselves suitably redacted for anonymized reporting.
+type SafeMessager interface {
+	SafeMessage() string
+}
+
 // A SafeType panic can be reported verbatim, i.e. does not leak information.
-//
-// TODO(dt): flesh out, see #15892.
+// A nil `*SafeType` is not valid for use and may cause panics.
 type SafeType struct {
 	V interface{}
+}
+
+var _ SafeMessager = SafeType{}
+
+// SafeMessage implements SafeMessager.
+func (st SafeType) SafeMessage() string {
+	return fmt.Sprintf("%v", st.V)
 }
 
 // Safe constructs a SafeType.
@@ -184,9 +196,6 @@ func (e *safeError) Error() string {
 // redact returns a redacted version of the supplied item that is safe to use in
 // anonymized reporting.
 func redact(r interface{}) string {
-	handleSafeType := func(v *SafeType) string {
-		return fmt.Sprintf("%+v", v.V)
-	}
 	typAnd := func(i interface{}, text string) string {
 		type stackTracer interface {
 			StackTrace() errors.StackTrace
@@ -213,10 +222,8 @@ func redact(r interface{}) string {
 
 	handle := func(r interface{}) string {
 		switch t := r.(type) {
-		case *SafeType:
-			return handleSafeType(t)
-		case SafeType:
-			return handleSafeType(&t)
+		case SafeMessager:
+			return t.SafeMessage()
 		case error:
 			// continue below
 		default:


### PR DESCRIPTION
We are now seeing first error reports that have a RocksDB-originating error at their root,
so next it would be nice to see what classes of errors we see. We hope to see "IO error"
a lot, as that usually means out of disk.

See https://github.com/facebook/rocksdb/blob/master/include/rocksdb/status.h for a list
of status code messages that we can expect to see.

Release note: none

cc @cockroachdb/release 