### PR TITLE
sql: information_schema.sequences and pg_catalog.pg_sequence

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -137,7 +137,7 @@ EXPLAIN SHOW TABLES
 1  render  ·      ·
 2  filter  ·      ·
 3  values  ·      ·
-3  ·       size   5 columns, 72 rows
+3  ·       size   5 columns, 73 rows
 
 query ITTT
 EXPLAIN SHOW DATABASE
@@ -194,7 +194,7 @@ EXPLAIN SHOW COLUMNS FROM foo
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·
-7  ·       size      13 columns, 609 rows
+7  ·       size      13 columns, 617 rows
 5  render  ·         ·
 6  filter  ·         ·
 7  values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -284,6 +284,9 @@ statement ok
 CREATE TABLE other_db.xyz (i INT)
 
 statement ok
+CREATE SEQUENCE other_db.seq
+
+statement ok
 CREATE VIEW other_db.abc AS SELECT i from other_db.xyz
 
 statement ok
@@ -931,20 +934,40 @@ root     def            INSERT          NULL
 root     def            SELECT          NULL
 root     def            UPDATE          NULL
 
-# Check existence of information_schema.sequences
-query TTBTT colnames
-SHOW COLUMNS FROM information_schema.sequences
+# information_schema.sequences
+
+statement ok
+SET DATABASE = test
+
+query TTTTIIITTTTT
+SELECT * FROM information_schema.sequences
 ----
-Field                    Type    Null   Default        Indices
-sequence_catalog         STRING  false  '':::STRING    {}
-sequence_schema          STRING  false  '':::STRING    {}
-sequence_name            STRING  false  '':::STRING    {}
-data_type                STRING  false  '':::STRING    {}
-numeric_precision        INT     false  0:::INT        {}
-numeric_precision_radix  INT     false  0:::INT        {}
-numeric_scale            INT     false  0:::INT        {}
-start_value              STRING  false  '':::STRING    {}
-minimum_value            STRING  false  '':::STRING    {}
-maximum_value            STRING  false  '':::STRING    {}
-increment                STRING  false  '':::STRING    {}
-cycle_option             STRING  false  'NO':::STRING  {}
+
+statement ok
+CREATE SEQUENCE test_seq
+
+statement ok
+CREATE SEQUENCE test_seq_2 INCREMENT -1 MINVALUE 5 MAXVALUE 1000 START WITH 15 CYCLE
+
+
+query TTTTIIITTTTT colnames
+SELECT * FROM information_schema.sequences
+----
+sequence_catalog sequence_schema sequence_name data_type numeric_precision numeric_precision_radix numeric_scale start_value minimum_value    maximum_value    increment cycle_option
+def              test            test_seq      INT                      64                       2             0           1             1 9223372036854775807         1 NO
+def              test            test_seq_2    INT                      64                       2             0          15             5                1000        -1 YES
+
+statement ok
+CREATE DATABASE other_db
+
+statement ok
+SET DATABASE = other_db
+
+# Sequences in one database can't be seen from another database.
+
+query TTTTIIITTTTT
+SELECT * FROM information_schema.sequences
+----
+
+statement ok
+DROP DATABASE other_db CASCADE

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -259,6 +259,7 @@ pg_catalog          pg_namespace
 pg_catalog          pg_proc
 pg_catalog          pg_range
 pg_catalog          pg_roles
+pg_catalog          pg_sequence
 pg_catalog          pg_settings
 pg_catalog          pg_tables
 pg_catalog          pg_tablespace
@@ -421,6 +422,7 @@ def            pg_catalog          pg_namespace               SYSTEM VIEW  1
 def            pg_catalog          pg_proc                    SYSTEM VIEW  1
 def            pg_catalog          pg_range                   SYSTEM VIEW  1
 def            pg_catalog          pg_roles                   SYSTEM VIEW  1
+def            pg_catalog          pg_sequence                SYSTEM VIEW  1
 def            pg_catalog          pg_settings                SYSTEM VIEW  1
 def            pg_catalog          pg_tables                  SYSTEM VIEW  1
 def            pg_catalog          pg_tablespace              SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -66,6 +66,7 @@ pg_namespace
 pg_proc
 pg_range
 pg_roles
+pg_sequence
 pg_settings
 pg_tables
 pg_tablespace
@@ -1162,6 +1163,39 @@ transaction_isolation          NULL    NULL     NULL     NULL        NULL
 transaction_priority           NULL    NULL     NULL     NULL        NULL
 transaction_read_only          NULL    NULL     NULL     NULL        NULL
 transaction_status             NULL    NULL     NULL     NULL        NULL
+
+# pg_catalog.pg_sequence
+
+statement ok
+CREATE DATABASE seq
+
+query OOIIIIIB
+SELECT * FROM pg_catalog.pg_sequence
+----
+
+statement ok
+CREATE SEQUENCE foo
+
+statement ok
+CREATE SEQUENCE bar MAXVALUE 10 MINVALUE 5 START 6 INCREMENT 2 CYCLE
+
+query OOIIIIIB colnames
+SELECT * FROM pg_catalog.pg_sequence
+----
+seqrelid    seqtypid  seqstart  seqincrement  seqmax               seqmin  seqcache  seqcycle
+1671363588  20        6         2             10                   5       1         true
+3781872120  20        1         1             9223372036854775807  1       1         false
+
+statement ok
+DROP DATABASE seq
+
+statement ok
+SET database = constraint_db
+
+# Verify sequences can't be seen from another database.
+query OOIIIIIB
+SELECT * FROM pg_catalog.pg_sequence
+----
 
 # Verify proper functionality of system information functions.
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -32,7 +32,7 @@ CREATE SEQUENCE err_test AS INT2
 statement error pq: unimplemented at or near "EOF"
 CREATE SEQUENCE err_test OWNED BY someuser
 
-# DML & DDL ERRORS
+# DML ERRORS
 
 statement error pgcode 42809 cannot run INSERT on sequence "foo" - sequences are not updateable
 INSERT INTO foo VALUES (1, 2, 3)


### PR DESCRIPTION
- `information_schema.sequences` was there previously as a placeholder. Now that we actually have sequences, return them.
- also add `pg_catalog.pg_sequence`, since it's practically the same thing.

tracking issue for SQL sequences: #19723