### PR TITLE
cloud: add RBAC config for RBAC-enabled Secure Kubernetes Cluster

### DIFF
--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -333,7 +333,7 @@ Because all of the resources in this example have been tagged with the label `ap
 we can clean up everything that we created in one quick command using a selector on that label:
 
 ```shell
-kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services,poddisruptionbudget -l app=cockroachdb
+kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services,poddisruptionbudget,jobs,rolebinding,clusterrolebinding,role,clusterrole,serviceaccount -l app=cockroachdb
 ```
 
 If running in secure mode, you'll want to cleanup old certificate requests:

--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -86,7 +86,7 @@ Set up your cluster following the
 You can either set up your cluster following the
 [instructions provided in the Kubernetes docs](https://kubernetes.io/docs/getting-started-guides/gce/)
 or by using the hosted
-[Container Engine](https://cloud.google.com/container-engine/docs) service:
+[Kubernetes Engine](https://cloud.google.com/container-engine/docs) service:
 
 ```shell
 gcloud container clusters create NAME

--- a/cloud/kubernetes/README.md
+++ b/cloud/kubernetes/README.md
@@ -86,11 +86,27 @@ Set up your cluster following the
 You can either set up your cluster following the
 [instructions provided in the Kubernetes docs](https://kubernetes.io/docs/getting-started-guides/gce/)
 or by using the hosted
-[Kubernetes Engine](https://cloud.google.com/container-engine/docs) service:
+[Google Kubernetes Engine (GKE)](https://cloud.google.com/container-engine/docs) service:
 
 ```shell
 gcloud container clusters create NAME
 ```
+
+If you're using GKE and want to run a secure cluster, one extra step is
+required. A limitation in GKE's Role-Based Access Control (RBAC) integration
+necessitates running a special command in order to let you create the RBAC
+roles that CockroachDB needs to manage certificates.
+
+1. Get the email address associated with your Google Cloud account by running:
+   ```shell
+   `gcloud info | grep Account`
+   ```
+2. Run [the following command from the GKE
+   documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control#prerequisites_for_using_role-based_access_control)
+   with that email address:
+   ```shell
+   kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=<your.google.cloud.email@example.org>
+   ```
 
 ### On Azure
 
@@ -116,6 +132,8 @@ kubectl create -f cluster-init.yaml
 
 ### Secure mode
 
+#### Prerequisites
+
 **REQUIRED**: the kubernetes cluster must run with the certificate controller enabled.
 This is done by passing the `--cluster-signing-cert-file` and `--cluster-signing-key-file` flags.
 On minikube, you can tell it to use the minikube-generated CA by specifying:
@@ -123,7 +141,14 @@ On minikube, you can tell it to use the minikube-generated CA by specifying:
 minikube start --extra-config=controller-manager.ClusterSigningCertFile="/var/lib/localkube/ca.crt" --extra-config=controller-manager.ClusterSigningKeyFile="/var/lib/localkube/ca.key"
 ```
 
+#### Creating the cluster
+
 Run: `kubectl create -f cockroachdb-statefulset-secure.yaml`
+
+If you get an error saying "attempt to grant extra privileges", you don't have
+sufficient permissions in the cluster to manage certificates. If this happens
+and you're running on Google Kubernetes Engine, see [the note above](#on-gce).
+If not, talk to your cluster administrator.
 
 Each new node will request a certificate from the kubernetes CA during its initialization phase.
 Statefulsets create pods one at a time, waiting for each previous pod to be initialized.

--- a/cloud/kubernetes/client-secure.yaml
+++ b/cloud/kubernetes/client-secure.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: cockroachdb-client
 spec:
+  serviceAccountName: cockroachdb
   initContainers:
   # The init-certs container sends a certificate signing request to the
   # kubernetes cluster.

--- a/cloud/kubernetes/cluster-init-secure.yaml
+++ b/cloud/kubernetes/cluster-init-secure.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: cockroachdb
       initContainers:
       # The init-certs container sends a certificate signing request to the
       # kubernetes cluster.

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -2,11 +2,15 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cockroachdb
+  labels:
+    app: cockroachdb
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cockroachdb
+  labels:
+    app: cockroachdb
 rules:
 - apiGroups:
   - ""
@@ -20,6 +24,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: cockroachdb
+  labels:
+    app: cockroachdb
 rules:
 - apiGroups:
   - certificates.k8s.io
@@ -34,6 +40,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cockroachdb
+  labels:
+    app: cockroachdb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -47,6 +55,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: cockroachdb
+  labels:
+    app: cockroachdb
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -1,4 +1,62 @@
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cockroachdb
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cockroachdb
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cockroachdb
+rules:
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cockroachdb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cockroachdb
+subjects:
+- kind: ServiceAccount
+  name: cockroachdb
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cockroachdb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cockroachdb
+subjects:
+- kind: ServiceAccount
+  name: cockroachdb
+  namespace: default
+---
+apiVersion: v1
 kind: Service
 metadata:
   # This service is meant to be used by clients of the database. It exposes a ClusterIP that will
@@ -78,6 +136,7 @@ spec:
       labels:
         app: cockroachdb
     spec:
+      serviceAccountName: cockroachdb
       # Init containers are run only once in the lifetime of a pod, before
       # it's started up for the first time. It has to exit successfully
       # before the pod's main containers are allowed to start.

--- a/cloud/kubernetes/example-app-secure.yaml
+++ b/cloud/kubernetes/example-app-secure.yaml
@@ -9,6 +9,7 @@ spec:
       labels:
         app: loadgen
     spec:
+      serviceAccountName: cockroachdb
       volumes:
       - name: client-certs
         emptyDir: {}


### PR DESCRIPTION
Hello, I try to run CockroachDB on RBAC-enabled Kubernetes Cluster. Hope this config can help other who have problem like me too.
This might fixed #20065 too ?