### PR TITLE
sql: move end-to-end and KV tests and common test code to a new package sql/tests

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -36,7 +37,7 @@ import (
 func TestAsOfTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
@@ -194,7 +195,7 @@ func TestAsOfTime(t *testing.T) {
 func TestAsOfRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, cmdFilters := createTestServerParams()
+	params, cmdFilters := tests.CreateTestServerParams()
 	// Disable one phase commits because they cannot be restarted.
 	params.Knobs.Store.(*storage.StoreTestingKnobs).DisableOptional1PC = true
 	s, sqlDB, _ := serverutils.StartServer(t, params)

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
@@ -36,7 +37,7 @@ import (
 func TestCopyNullInfNaN(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -130,7 +131,7 @@ func TestCopyNullInfNaN(t *testing.T) {
 func TestCopyRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -256,7 +257,7 @@ func TestCopyRandom(t *testing.T) {
 func TestCopyError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -311,7 +312,7 @@ func TestCopyOne(t *testing.T) {
 
 	t.Skip("#18352")
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -345,7 +346,7 @@ func TestCopyInProgress(t *testing.T) {
 
 	t.Skip("#18352")
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -378,7 +379,7 @@ func TestCopyInProgress(t *testing.T) {
 func TestCopyTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -37,7 +38,7 @@ import (
 
 func TestDatabaseDescriptor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()
@@ -376,7 +377,7 @@ func TestParallelCreateConflictingTables(t *testing.T) {
 // Test that the modification time on a table descriptor is initialized.
 func TestTableReadErrorsBeforeTableCreation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -159,7 +160,7 @@ func TestOperationsWithColumnMutation(t *testing.T) {
 	// so disable leases on tables.
 	defer sql.TestDisableTableLeases()()
 	// Disable external processing of mutations.
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
@@ -391,7 +392,7 @@ func TestOperationsWithIndexMutation(t *testing.T) {
 	// The descriptor changes made must have an immediate effect.
 	defer sql.TestDisableTableLeases()()
 	// Disable external processing of mutations.
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
@@ -536,7 +537,7 @@ func TestOperationsWithColumnAndIndexMutation(t *testing.T) {
 	// so disable leases on tables.
 	defer sql.TestDisableTableLeases()()
 	// Disable external processing of mutations.
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		AsyncExecNotification: asyncSchemaChangerDisabled,
 	}
@@ -699,7 +700,7 @@ func TestSchemaChangeCommandsWithPendingMutations(t *testing.T) {
 	// so disable leases on tables.
 	defer sql.TestDisableTableLeases()()
 	// Disable external processing of mutations.
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs.SQLSchemaChanger = &sql.SchemaChangerTestingKnobs{
 		SyncFilter:            sql.TestingSchemaChangerCollection.ClearSchemaChangers,
 		AsyncExecNotification: asyncSchemaChangerDisabled,
@@ -903,7 +904,7 @@ func TestTableMutationQueue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Disable synchronous and asynchronous schema change processing so that
 	// the mutations get queued up.
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			SyncFilter: func(tscc sql.TestingSchemaChangerCollection) {
@@ -1006,7 +1007,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR UNIQUE);
 func TestAddingFKs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -83,7 +84,7 @@ func descExists(sqlDB *gosql.DB, exists bool, id sqlbase.ID) error {
 
 func TestDropDatabase(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			// Disable the asynchronous path so that the table data left
@@ -208,7 +209,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 // Test that a dropped database's data gets deleted properly.
 func TestDropDatabaseDeleteData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			// Turn on quick garbage collection.
@@ -314,7 +315,7 @@ INSERT INTO t.kv VALUES ('c', 'e'), ('a', 'c'), ('b', 'd');
 // during the time the underlying tables are still being deleted.
 func TestShowTablesAfterRecreateDatabase(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	// Turn off the application of schema changes so that tables do not
 	// get completely dropped.
 	params.Knobs = base.TestingKnobs{
@@ -392,7 +393,7 @@ CREATE INDEX foo on t.kv (v);
 func TestDropIndex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const chunkSize = 200
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			BackfillChunkSize: chunkSize,
@@ -467,7 +468,7 @@ CREATE INDEX intlv_idx ON intlv (k, n) INTERLEAVE IN PARENT kv (k);
 func TestDropIndexInterleaved(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const chunkSize = 200
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			BackfillChunkSize: chunkSize,
@@ -500,7 +501,7 @@ func TestDropIndexInterleaved(t *testing.T) {
 // via the synchronous path.
 func TestDropTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			// Disable the asynchronous path so that the table data left
@@ -585,7 +586,7 @@ func TestDropTable(t *testing.T) {
 // Test that after a DROP TABLE the table eventually gets deleted.
 func TestDropTableDeleteData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			// Turn on quick garbage collection.
@@ -646,7 +647,7 @@ func TestDropTableDeleteData(t *testing.T) {
 // another table.
 func TestDropTableInterleavedDeleteData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			// Turn on quick garbage collection.
@@ -685,7 +686,7 @@ func TestDropTableInterleavedDeleteData(t *testing.T) {
 
 func TestDropTableInTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -721,7 +722,7 @@ CREATE TABLE t.kv (k CHAR PRIMARY KEY, v CHAR);
 
 func TestDropAndCreateTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.UseDatabase = "test"
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
@@ -747,7 +748,7 @@ func TestDropAndCreateTable(t *testing.T) {
 func TestCommandsWhileTableBeingDropped(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	// Block schema changers so that the table we're about to DROP is not
 	// actually dropped; it will be left in the "deleted" state.
 	params.Knobs = base.TestingKnobs{

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -31,7 +32,7 @@ import (
 func TestIndexBackfiller(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 
 	moveToTDelete := make(chan bool)
 	moveToTWrite := make(chan bool)

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -212,7 +213,7 @@ func (t *leaseTest) node(nodeID uint32) *sql.LeaseManager {
 func TestLeaseManager(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 	removalTracker := sql.NewLeaseRemovalTracker()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
 			LeaseStoreTestingKnobs: sql.LeaseStoreTestingKnobs{
@@ -316,7 +317,7 @@ func TestLeaseManager(testingT *testing.T) {
 
 func TestLeaseManagerReacquire(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 
 	params.LeaseManagerConfig = base.NewLeaseManagerConfig()
 	// Set the lease duration such that the next lease acquisition will
@@ -362,7 +363,7 @@ func TestLeaseManagerReacquire(testingT *testing.T) {
 
 func TestLeaseManagerPublishVersionChanged(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	t := newLeaseTest(testingT, params)
 	defer t.cleanup()
 
@@ -425,7 +426,7 @@ func TestLeaseManagerPublishVersionChanged(testingT *testing.T) {
 
 func TestLeaseManagerPublishIllegalVersionChange(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	t := newLeaseTest(testingT, params)
 	defer t.cleanup()
 
@@ -447,7 +448,7 @@ func TestLeaseManagerPublishIllegalVersionChange(testingT *testing.T) {
 
 func TestLeaseManagerDrain(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	leaseRemovalTracker := sql.NewLeaseRemovalTracker()
 	params.Knobs = base.TestingKnobs{
 		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
@@ -509,7 +510,7 @@ func TestCantLeaseDeletedTable(testingT *testing.T) {
 	var mu syncutil.Mutex
 	clearSchemaChangers := false
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			SyncFilter: func(tscc sql.TestingSchemaChangerCollection) {
@@ -589,7 +590,7 @@ func TestLeasesOnDeletedTableAreReleasedImmediately(t *testing.T) {
 	var waitTableID sqlbase.ID
 	deleted := make(chan bool)
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
 			TestingLeasesRefreshedEvent: func(cfg config.SystemConfig) {
@@ -682,7 +683,7 @@ CREATE TABLE test.t(a INT PRIMARY KEY);
 // properly tracked and released.
 func TestSubqueryLeases(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 
 	fooRelease := make(chan struct{}, 10)
 	fooAcquiredCount := int32(0)
@@ -749,7 +750,7 @@ SELECT EXISTS(SELECT * FROM t.foo);
 // table descriptor.
 func TestTxnObeysTableModificationTime(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -826,7 +827,7 @@ INSERT INTO t.timestamp VALUES ('a', 'b');
 // version of a descriptor.
 func TestLeaseAtLatestVersion(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	errChan := make(chan error, 1)
 	params.Knobs = base.TestingKnobs{
 		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
@@ -907,7 +908,7 @@ INSERT INTO t.timestamp VALUES ('a', 'b');
 // parallelism, which is important to also benchmark locking.
 func BenchmarkLeaseAcquireByNameCached(b *testing.B) {
 	defer leaktest.AfterTest(b)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 
 	t := newLeaseTest(b, params)
 	defer t.cleanup()
@@ -958,7 +959,7 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 	var testAcquiredCount int32
 	var testAcquisitionBlockCount int32
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs = base.TestingKnobs{
 		SQLLeaseManager: &sql.LeaseManagerTestingKnobs{
 			LeaseStoreTestingKnobs: sql.LeaseStoreTestingKnobs{

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -45,7 +46,7 @@ type queryCounter struct {
 func TestQueryCounts(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -130,7 +131,7 @@ func TestQueryCounts(t *testing.T) {
 func TestAbortCountConflictingWrites(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, cmdFilters := createTestServerParams()
+	params, cmdFilters := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -196,7 +197,7 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 // results in an error during a txn.
 func TestAbortCountErrorDuringTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/session_test.go
+++ b/pkg/sql/session_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -45,7 +46,7 @@ func TestSessionFinishRollsBackTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	aborter := NewTxnAborter()
 	defer aborter.Close(t)
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.Knobs.SQLExecutor = aborter.executorKnobs()
 	s, mainDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -40,7 +41,7 @@ import (
 func TestShowCreateTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -277,7 +278,7 @@ func TestShowCreateTable(t *testing.T) {
 func TestShowCreateView(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -469,7 +470,7 @@ func TestShowQueries(t *testing.T) {
 func TestShowJobs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, rawSQLDB, _ := serverutils.StartServer(t, params)
 	sqlDB := sqlutils.MakeSQLRunner(rawSQLDB)
 	defer s.Stopper().Stop(context.TODO())

--- a/pkg/sql/sort_test.go
+++ b/pkg/sql/sort_test.go
@@ -19,6 +19,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -26,7 +27,7 @@ import (
 func TestOrderByRandom(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/split_at_test.go
+++ b/pkg/sql/split_at_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -33,7 +34,7 @@ import (
 func TestSplitAt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/table_ref_test.go
+++ b/pkg/sql/table_ref_test.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -28,7 +29,7 @@ import (
 func TestTableRefs(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, db, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -20,32 +20,10 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
-
-// CreateTestTableDescriptor converts a SQL string to a table for test purposes.
-// Will fail on complex tables where that operation requires e.g. looking up
-// other tables or otherwise utilizing a planner, since the planner used here is
-// just a zero value placeholder.
-func CreateTestTableDescriptor(
-	ctx context.Context,
-	parentID, id sqlbase.ID,
-	schema string,
-	privileges *sqlbase.PrivilegeDescriptor,
-) (sqlbase.TableDescriptor, error) {
-	stmt, err := parser.ParseOne(schema)
-	if err != nil {
-		return sqlbase.TableDescriptor{}, err
-	}
-	p := planner{session: new(Session)}
-	p.evalCtx = tree.MakeTestingEvalContext()
-	return p.makeTableDesc(ctx, stmt.(*tree.CreateTable), parentID, id, hlc.Timestamp{}, privileges, nil)
-}
 
 func TestMakeTableDescColumns(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/sql/tests/README.md
+++ b/pkg/sql/tests/README.md
@@ -1,0 +1,1 @@
+This directory contains common code for SQL tests.

--- a/pkg/sql/tests/bank_test.go
+++ b/pkg/sql/tests/bank_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql_test
+package tests_test
 
 import (
 	"bytes"

--- a/pkg/sql/tests/command_filters.go
+++ b/pkg/sql/tests/command_filters.go
@@ -1,0 +1,116 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// CommandFilters provides facilities for registering "TestingCommandFilters"
+// (i.e. functions to be run on every replica command).
+// CommandFilters is thread-safe.
+// CommandFilters also optionally does replay protection if filters need it.
+type CommandFilters struct {
+	syncutil.RWMutex
+	filters []struct {
+		id         int
+		idempotent bool
+		filter     storagebase.ReplicaCommandFilter
+	}
+	nextID int
+
+	numFiltersTrackingReplays int
+	replayProtection          storagebase.ReplicaCommandFilter
+}
+
+// RunFilters executes the registered filters, stopping at the first one
+// that returns an error.
+func (c *CommandFilters) RunFilters(args storagebase.FilterArgs) *roachpb.Error {
+	c.RLock()
+	defer c.RUnlock()
+
+	if c.replayProtection != nil {
+		return c.replayProtection(args)
+	}
+	return c.runFiltersInternal(args)
+}
+
+func (c *CommandFilters) runFiltersInternal(args storagebase.FilterArgs) *roachpb.Error {
+	for _, f := range c.filters {
+		if pErr := f.filter(args); pErr != nil {
+			return pErr
+		}
+	}
+	return nil
+}
+
+// AppendFilter registers a filter function to run after all the previously
+// registered filters.
+// idempotent specifies if this filter can be safely run multiple times on the
+// same command. If this property doesn't hold, CommandFilters will start
+// tracking commands for replay protection, which might be expensive.
+// Returns a closure that the client must run for doing cleanup when the
+// filter should be deregistered.
+func (c *CommandFilters) AppendFilter(
+	filter storagebase.ReplicaCommandFilter, idempotent bool,
+) func() {
+
+	c.Lock()
+	defer c.Unlock()
+	id := c.nextID
+	c.nextID++
+	c.filters = append(c.filters, struct {
+		id         int
+		idempotent bool
+		filter     storagebase.ReplicaCommandFilter
+	}{id, idempotent, filter})
+
+	if !idempotent {
+		if c.numFiltersTrackingReplays == 0 {
+			c.replayProtection =
+				storageutils.WrapFilterForReplayProtection(c.runFiltersInternal)
+		}
+		c.numFiltersTrackingReplays++
+	}
+
+	return func() {
+		c.removeFilter(id)
+	}
+}
+
+// removeFilter removes a filter previously registered. Meant to be used as the
+// closure returned by AppendFilter.
+func (c *CommandFilters) removeFilter(id int) {
+	c.Lock()
+	defer c.Unlock()
+	for i, f := range c.filters {
+		if f.id == id {
+			if !f.idempotent {
+				c.numFiltersTrackingReplays--
+				if c.numFiltersTrackingReplays == 0 {
+					c.replayProtection = nil
+				}
+			}
+			c.filters = append(c.filters[:i], c.filters[i+1:]...)
+			return
+		}
+	}
+	panic(fmt.Sprintf("failed to find filter with id: %d.", id))
+}

--- a/pkg/sql/tests/end_txn_trigger.go
+++ b/pkg/sql/tests/end_txn_trigger.go
@@ -1,0 +1,65 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tests
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
+	"github.com/pkg/errors"
+)
+
+// CheckEndTransactionTrigger verifies that an EndTransactionRequest
+// that includes intents for the SystemDB keys sets the proper trigger.
+func CheckEndTransactionTrigger(args storagebase.FilterArgs) *roachpb.Error {
+	req, ok := args.Req.(*roachpb.EndTransactionRequest)
+	if !ok {
+		return nil
+	}
+
+	if !req.Commit {
+		// This is a rollback: skip trigger verification.
+		return nil
+	}
+
+	modifiedSpanTrigger := req.InternalCommitTrigger.GetModifiedSpanTrigger()
+	modifiedSystemConfigSpan := modifiedSpanTrigger != nil && modifiedSpanTrigger.SystemConfigSpan
+
+	var hasSystemKey bool
+	for _, span := range req.IntentSpans {
+		if bytes.Compare(span.Key, keys.SystemConfigSpan.Key) >= 0 &&
+			bytes.Compare(span.Key, keys.SystemConfigSpan.EndKey) < 0 {
+			hasSystemKey = true
+			break
+		}
+	}
+	// If the transaction in question has intents in the system span, then
+	// modifiedSystemConfigSpan should always be true. However, it is possible
+	// for modifiedSystemConfigSpan to be set, even though no system keys are
+	// present. This can occur with certain conditional DDL statements (e.g.
+	// "CREATE TABLE IF NOT EXISTS"), which set the SystemConfigTrigger
+	// aggressively but may not actually end up changing the system DB depending
+	// on the current state.
+	// For more information, see the related comment at the beginning of
+	// planner.makePlan().
+	if hasSystemKey && !modifiedSystemConfigSpan {
+		return roachpb.NewError(errors.Errorf("EndTransaction hasSystemKey=%t, but hasSystemConfigTrigger=%t",
+			hasSystemKey, modifiedSystemConfigSpan))
+	}
+
+	return nil
+}

--- a/pkg/sql/tests/highlevel/README.md
+++ b/pkg/sql/tests/highlevel/README.md
@@ -1,0 +1,2 @@
+This directory contains tests that exercise multiple aspects of the
+SQL layer simultaneously.

--- a/pkg/sql/tests/impure_builtin_test.go
+++ b/pkg/sql/tests/impure_builtin_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql_test
+package tests_test
 
 import (
 	"testing"

--- a/pkg/sql/tests/kv_test.go
+++ b/pkg/sql/tests/kv_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql_test
+package tests_test
 
 import (
 	"bytes"

--- a/pkg/sql/tests/main_test.go
+++ b/pkg/sql/tests/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Cockroach Authors.
+// Copyright 2017 The Cockroach Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql_test
+package tests_test
 
 import (
 	"os"
@@ -26,7 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
-//go:generate ../util/leaktest/add-leaktest.sh *_test.go
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
 
 func TestMain(m *testing.M) {
 	security.SetAssetLoader(securitytest.EmbeddedAssets)

--- a/pkg/sql/tests/monotonic_insert_test.go
+++ b/pkg/sql/tests/monotonic_insert_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql_test
+package tests_test
 
 import (
 	"bytes"

--- a/pkg/sql/tests/planhook.go
+++ b/pkg/sql/tests/planhook.go
@@ -1,0 +1,46 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tests
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// Add a placeholder implementation to test the plan hook. It accepts statements
+// of the form `SHOW planhook` and returns a single row with the string value
+// 'planhook'.
+func init() {
+	testingPlanHook := func(
+		stmt tree.Statement, state sql.PlanHookState,
+	) (func(context.Context, chan<- tree.Datums) error, sqlbase.ResultColumns, error) {
+		show, ok := stmt.(*tree.ShowVar)
+		if !ok || show.Name != "planhook" {
+			return nil, nil, nil
+		}
+		header := sqlbase.ResultColumns{
+			{Name: "value", Typ: types.String},
+		}
+		return func(_ context.Context, resultsCh chan<- tree.Datums) error {
+			resultsCh <- tree.Datums{tree.NewDString(show.Name)}
+			return nil
+		}, header, nil
+	}
+	sql.AddPlanHook(testingPlanHook)
+}

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql_test
+package tests_test
 
 import (
 	gosql "database/sql"
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -235,7 +236,7 @@ func testRandomSyntax(
 		t.Skip("enable with '-rsg <duration>'")
 	}
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	params.UseDatabase = "ident"
 	// Use a low memory limit to quickly halt runaway functions.
 	params.SQLMemoryPoolSize = 3 * 1024 * 1024 // 3MB

--- a/pkg/sql/tests/server_params.go
+++ b/pkg/sql/tests/server_params.go
@@ -1,0 +1,38 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tests
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
+)
+
+// CreateTestServerParams creates a set of params suitable for SQL tests.
+// It enables some EndTransaction sanity checking and installs a flexible
+// TestingEvalFilter.
+// TODO(andrei): this function is not used consistently by SQL tests. Figure out
+// if the EndTransaction checks are important.
+func CreateTestServerParams() (base.TestServerArgs, *CommandFilters) {
+	var cmdFilters CommandFilters
+	cmdFilters.AppendFilter(CheckEndTransactionTrigger, true)
+	params := base.TestServerArgs{}
+	params.Knobs.Store = &storage.StoreTestingKnobs{
+		EvalKnobs: batcheval.TestingKnobs{
+			TestingEvalFilter: cmdFilters.RunFilters,
+		},
+	}
+	return params, &cmdFilters
+}

--- a/pkg/sql/tests/split_test.go
+++ b/pkg/sql/tests/split_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql_test
+package tests_test
 
 import (
 	"bytes"
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -69,7 +70,7 @@ func rangesMatchSplits(ranges []roachpb.Key, splits []roachpb.RKey) bool {
 func TestSplitOnTableBoundaries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	// We want fast scan.
 	params.ScanInterval = time.Millisecond
 	params.ScanMaxIdleTime = time.Millisecond

--- a/pkg/sql/tests/sqlkv/README.md
+++ b/pkg/sql/tests/sqlkv/README.md
@@ -1,0 +1,1 @@
+This directory contains tests that exercise the SQL/KV interface.

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql_test
+package tests_test
 
 import (
 	"strings"

--- a/pkg/sql/tests/table_split_test.go
+++ b/pkg/sql/tests/table_split_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql_test
+package tests_test
 
 import (
 	"testing"

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -1,0 +1,43 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// CreateTestTableDescriptor converts a SQL string to a table for test purposes.
+// Will fail on complex tables where that operation requires e.g. looking up
+// other tables or otherwise utilizing a planner, since the planner used here is
+// just a zero value placeholder.
+func CreateTestTableDescriptor(
+	ctx context.Context,
+	parentID, id sqlbase.ID,
+	schema string,
+	privileges *sqlbase.PrivilegeDescriptor,
+) (sqlbase.TableDescriptor, error) {
+	stmt, err := parser.ParseOne(schema)
+	if err != nil {
+		return sqlbase.TableDescriptor{}, err
+	}
+	p := planner{session: new(Session)}
+	p.evalCtx = tree.MakeTestingEvalContext()
+	return p.makeTableDesc(ctx, stmt.(*tree.CreateTable), parentID, id, hlc.Timestamp{}, privileges, nil)
+}

--- a/pkg/sql/zone_config_test.go
+++ b/pkg/sql/zone_config_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -86,7 +87,7 @@ func waitForConfigChange(t testing.TB, s *server.TestServer) config.SystemConfig
 // TestGetZoneConfig exercises config.GetZoneConfig and the sql hook for it.
 func TestGetZoneConfig(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	srv, sqlDB, _ := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(context.TODO())
 	s := srv.(*server.TestServer)
@@ -312,7 +313,7 @@ func TestGetZoneConfig(t *testing.T) {
 func BenchmarkGetZoneConfig(b *testing.B) {
 	defer leaktest.AfterTest(b)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	srv, _, _ := serverutils.StartServer(b, params)
 	defer srv.Stopper().Stop(context.TODO())
 	s := srv.(*server.TestServer)

--- a/pkg/sql/zone_test.go
+++ b/pkg/sql/zone_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -31,7 +32,7 @@ import (
 func TestValidSetShowZones(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 
@@ -190,7 +191,7 @@ func TestValidSetShowZones(t *testing.T) {
 func TestInvalidSetShowZones(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	params, _ := createTestServerParams()
+	params, _ := tests.CreateTestServerParams()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 


### PR DESCRIPTION
Visible changes here:
- common test code in `sql/tests`
- high-level SQL tests in `sql/tests/highlevel`
- SQL/KV tests in `sql/tests/sqlkv`
