### PR TITLE
build: update README on deploying Docker image

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -37,7 +37,7 @@ usual fashion. To be more specific, the steps to do this are:
 
 ```
 go/src/github.com/cockroachdb/cockroach $ ./build/builder.sh make build TYPE=release-linux-gnu
-go/src/github.com/cockroachdb/cockroach $ cp ./cockroach build/deploy/cockroach
+go/src/github.com/cockroachdb/cockroach $ cp ./cockroach-linux-2.6.32-gnu-amd64 build/deploy/cockroach
 go/src/github.com/cockroachdb/cockroach $ cd build/deploy && docker build -t cockroachdb/cockroach .
 ```
 


### PR DESCRIPTION
Running `./build/builder.sh make build TYPE=release-linux-gnu` will
create a binary called `cockroach-linux-2.6.32-gnu-amd64`, not
`cockroach`.