### PR TITLE
Makefile: make TESTS without PKG check more targeted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ endif
 
 # Prevent invoking make with a specific test name without a constraining
 # package.
-ifneq "$(filter-out acceptance lint,$(MAKECMDGOALS))" ""
+ifneq "$(filter bench% test% stress%,$(MAKECMDGOALS))" ""
 ifeq "$(PKG)" ""
 $(if $(subst -,,$(TESTS)),$(error TESTS must be specified with PKG (e.g. PKG=./pkg/sql)))
 $(if $(subst -,,$(BENCHES)),$(error BENCHES must be specified with PKG (e.g. PKG=./pkg/sql)))


### PR DESCRIPTION
It's valid to specify TESTS without also specifying PKG when running
`make acceptance` and `make lint`. Due to an oddity of how `make
acceptance` recursively invokes Make, it ends up calling `make build
TESTS=...`, which trips the check as-written.

Adjust the check to use a blacklist of affected targets rather than a
whitelist of unaffected targets. Now the check only triggers when
running Make against a test, bench, or stress target.