### PR TITLE
cherrypick-1.1: build: more robust checking for clean workspaces

### DIFF
--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -16,7 +16,14 @@ build/builder.sh env \
 build/builder.sh make lint 2>&1 | tee artifacts/lint.log | go-test-teamcity
 
 build/builder.sh make generate
-build/builder.sh /bin/bash -c '! git status --porcelain | read || (git status; git diff -a 1>&2; exit 1)'
+
+# The workspace is clean iff `git status --porcelain` produces no output. Any
+# output is either an error message or a listing of an untracked/dirty file.
+if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
+  git status >&2 || true
+  git diff -a >&2 || true
+  exit 1
+fi
 
 # Run the UI tests. This logically belongs in teamcity-test.sh, but we do it
 # here to minimize total build time since the rest of this script completes


### PR DESCRIPTION
The inverted conditional in the previous version of the check for a
clean workspace meant that if `git status --porcelain` failed (e.g., due
to a corrupted Git repository), the workspace was assumed to be clean.
This allowed a commit that forgot to update a generated file to sneak
onto a release branch.

Replace the conditional with one that is both more understandable and
robust against `git status` failures.

Fixes #19639.