### PR TITLE
sql: use binary search to fetch key in JSON

### DIFF
--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -328,6 +328,25 @@ func TestJSONFetch(t *testing.T) {
 	}
 }
 
+func TestJSONRandomFetch(t *testing.T) {
+	rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
+	for i := 0; i < 1000; i++ {
+		// We want a big object to trigger the binary search behaviour in FetchValKey.
+		j, err := Random(1000, rng)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if obj, ok := j.(jsonObject); ok {
+			// Pick a key:
+			idx := rand.Intn(len(obj))
+			result := obj.FetchValKey(string(obj[idx].k))
+			if result.Compare(obj[idx].v) != 0 {
+				t.Fatalf("%s: expected fetching %s to give %s got %s", obj, obj[idx].k, obj[idx].v, result)
+			}
+		}
+	}
+}
+
 func TestJSONFetchIdx(t *testing.T) {
 	json := jsonTestShorthand
 	cases := map[string][]struct {
@@ -825,5 +844,31 @@ func TestNegativeRandomJSONContains(t *testing.T) {
 		if realResult != slowResult {
 			t.Fatal("mismatch for document " + j1.String() + " @> " + j2.String())
 		}
+	}
+}
+
+func BenchmarkFetchKey(b *testing.B) {
+	for _, objectSize := range []int{1, 10, 100, 1000} {
+		b.Run(fmt.Sprintf("object size %d", objectSize), func(b *testing.B) {
+			keys := make([]string, objectSize)
+
+			obj := make(map[string]interface{})
+			for i := 0; i < objectSize; i++ {
+				key := fmt.Sprintf("key%d", i)
+				keys = append(keys, key)
+				obj[key] = i
+			}
+			j, err := MakeJSON(obj)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// TODO(justin): add benchmarks for fetching from still-encoded objects.
+			b.Run("fetch key", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					j.FetchValKey(keys[rand.Intn(len(keys))])
+				}
+			})
+		})
 	}
 }


### PR DESCRIPTION
I finally sat down to benchmark various operators and realized that this
was desperately in need of this.

Benchstat result for always binary searching vs. linear scan:

    name                                   old time/op    new time/op    delta
    FetchKey/object_size_1/fetch_key-8       51.6ns ± 2%    59.9ns ± 3%  +16.07%  (p=0.000 n=9+10)
    FetchKey/object_size_10/fetch_key-8      94.6ns ± 2%   101.3ns ± 2%   +7.04%  (p=0.000 n=10+10)
    FetchKey/object_size_100/fetch_key-8      346ns ± 2%     142ns ± 1%  -58.93%  (p=0.000 n=10+10)
    FetchKey/object_size_1000/fetch_key-8    2.91µs ± 1%    0.20µs ± 2%  -93.14%  (p=0.000 n=9+10)

Benchstat result for binary searching for objects > 20 elements and
linear searching otherwise vs. pure linear scan:

    name                                   old time/op    new time/op    delta
    FetchKey/object_size_1/fetch_key-8       51.6ns ± 2%    50.9ns ± 2%     ~     (p=0.092 n=10+10)
    FetchKey/object_size_10/fetch_key-8      93.1ns ± 1%    94.0ns ± 3%     ~     (p=0.078 n=10+10)
    FetchKey/object_size_100/fetch_key-8      349ns ± 2%     147ns ± 4%  -57.99%  (p=0.000 n=10+10)
    FetchKey/object_size_1000/fetch_key-8    2.94µs ± 2%    0.20µs ± 2%  -93.24%  (p=0.000 n=10+9)

I did a quick search to figure out a good cutoff, 20 seemed reasonable
on my laptop as the point where the two were more or less equal.