### PR TITLE
sql: fix PARTITION BY multiple columns with window functions 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -13,10 +13,10 @@ query TTT
 SELECT span, message, operation FROM [SHOW TRACE FOR SESSION] WHERE message NOT LIKE e'%\n%' AND message NOT LIKE '%canceling context'
 ----
 (0,0)  === SPAN START: sql txn implicit ===  sql txn implicit
-(1,0)  === SPAN START: sql txn ===           sql txn implicit
-(1,0)  executing 1/5: BEGIN TRANSACTION      sql txn implicit
-(1,0)  executing 2/5: SELECT 1               sql txn implicit
-(1,0)  executing 3/5: COMMIT TRANSACTION     sql txn implicit
+(1,0)  === SPAN START: sql txn ===           sql txn
+(1,0)  executing 1/5: BEGIN TRANSACTION      sql txn
+(1,0)  executing 2/5: SELECT 1               sql txn
+(1,0)  executing 3/5: COMMIT TRANSACTION     sql txn
 (2,0)  === SPAN START: sql txn implicit ===  sql txn implicit
 (2,0)  executing 1/1: SELECT 2               sql txn implicit
 (3,0)  === SPAN START: sql txn implicit ===  sql txn implicit

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -68,16 +68,15 @@ SELECT avg(k) OVER (PARTITION BY v) FROM kv ORDER BY 1
 5.5
 5.5
 
-# Not working until #12482 is fixed.
-#query R
-#SELECT avg(k) OVER (PARTITION BY kv.*) FROM kv ORDER BY 1
-#----
-#1
-#3
-#5
-#6
-#7
-#8
+query R
+SELECT avg(k) OVER (PARTITION BY kv.*) FROM kv ORDER BY 1
+----
+1
+3
+5
+6
+7
+8
 
 query R
 SELECT avg(k) OVER (ORDER BY w) FROM kv ORDER BY 1
@@ -90,6 +89,26 @@ SELECT avg(k) OVER (ORDER BY w) FROM kv ORDER BY 1
 7.5
 
 query R
+SELECT avg(k) OVER (ORDER BY b) FROM kv ORDER BY 1
+----
+5
+5
+5
+5
+6.5
+6.5
+
+query R
+SELECT avg(k) OVER (ORDER BY w, b) FROM kv ORDER BY 1
+----
+5
+5.4
+5.5
+5.5
+7.5
+8
+
+query R
 SELECT avg(k) OVER (ORDER BY 1-w) FROM kv ORDER BY 1
 ----
 3.75
@@ -99,16 +118,15 @@ SELECT avg(k) OVER (ORDER BY 1-w) FROM kv ORDER BY 1
 5
 5
 
-# Not working until #12482 is fixed.
-#query R
-#SELECT avg(k) OVER (ORDER BY kv.*) FROM kv ORDER BY 1
-#----
-#1
-#2
-#3
-#3.75
-#4.4
-#5
+query R
+SELECT avg(k) OVER (ORDER BY kv.*) FROM kv ORDER BY 1
+----
+1
+2
+3
+3.75
+4.4
+5
 
 query R
 SELECT avg(k) OVER (ORDER BY w DESC) FROM kv ORDER BY 1

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -69,6 +69,36 @@ SELECT avg(k) OVER (PARTITION BY v) FROM kv ORDER BY 1
 5.5
 
 query R
+SELECT avg(k) OVER (PARTITION BY w) FROM kv ORDER BY 1
+----
+3.5
+3.5
+4
+4
+7.5
+7.5
+
+query R
+SELECT avg(k) OVER (PARTITION BY b) FROM kv ORDER BY 1
+----
+4.25
+4.25
+4.25
+4.25
+6.5
+6.5
+
+query R
+SELECT avg(k) OVER (PARTITION BY w, b) FROM kv ORDER BY 1
+----
+3
+3.5
+3.5
+5
+7
+8
+
+query R
 SELECT avg(k) OVER (PARTITION BY kv.*) FROM kv ORDER BY 1
 ----
 1

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -171,10 +171,6 @@ func (n *windowNode) constructWindowDefinitions(
 			return err
 		}
 
-		// TODO(nvanbenschoten): below we add renders to the renderNode for each
-		// partition and order expression. We should handle cases where the expression
-		// is already referenced by the query like sortNode does.
-
 		// Validate PARTITION BY clause.
 		for _, partition := range windowDef.Partitions {
 			cols, exprs, _, err := s.planner.computeRenderAllowingStars(ctx,
@@ -183,7 +179,9 @@ func (n *windowNode) constructWindowDefinitions(
 			if err != nil {
 				return err
 			}
-			windowFn.partitionIdxs = s.addOrReuseRenders(cols, exprs, true)
+
+			colIdxs := s.addOrReuseRenders(cols, exprs, true)
+			windowFn.partitionIdxs = append(windowFn.partitionIdxs, colIdxs...)
 		}
 
 		// Validate ORDER BY clause.


### PR DESCRIPTION
Fixes #20143.

This has been broken since 278e2e7. Instead of adding to the
`partitionIdxs` slice, we were replacing it for each new partitioning
column.