### PR TITLE
sql: remove the planner ref from planNodes

### DIFF
--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -75,7 +75,7 @@ func (n *alterSequenceNode) Start(params runParams) error {
 		params.p.txn,
 		EventLogAlterSequence,
 		int32(n.seqDesc.ID),
-		int32(params.p.evalCtx.NodeID),
+		int32(params.evalCtx.NodeID),
 		struct {
 			SequenceName string
 			Statement    string

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -79,7 +79,7 @@ func (n *alterTableNode) Start(params runParams) error {
 				return pgerror.Unimplemented(
 					"alter add fk", "adding a REFERENCES constraint via ALTER not supported")
 			}
-			col, idx, err := sqlbase.MakeColumnDefDescs(d, &params.p.semaCtx, &params.p.evalCtx)
+			col, idx, err := sqlbase.MakeColumnDefDescs(d, &params.p.semaCtx, params.evalCtx)
 			if err != nil {
 				return err
 			}
@@ -143,7 +143,7 @@ func (n *alterTableNode) Start(params runParams) error {
 				}
 				if d.PartitionBy != nil {
 					if err := addPartitionedBy(
-						params.ctx, &params.p.evalCtx, n.tableDesc, &idx, &idx.Partitioning,
+						params.ctx, params.evalCtx, n.tableDesc, &idx, &idx.Partitioning,
 						d.PartitionBy, 0, /* colOffset */
 					); err != nil {
 						return err
@@ -160,7 +160,7 @@ func (n *alterTableNode) Start(params runParams) error {
 				}
 
 			case *tree.CheckConstraintTableDef:
-				ck, err := makeCheckConstraint(*n.tableDesc, d, inuseNames, &params.p.semaCtx, &params.p.evalCtx)
+				ck, err := makeCheckConstraint(*n.tableDesc, d, inuseNames, &params.p.semaCtx, params.evalCtx)
 				if err != nil {
 					return err
 				}
@@ -429,7 +429,7 @@ func (n *alterTableNode) Start(params runParams) error {
 				return fmt.Errorf("column %q in the middle of being dropped", t.GetColumn())
 			}
 			if err := applyColumnMutation(
-				&col, t, &params.p.semaCtx, &params.p.evalCtx,
+				&col, t, &params.p.semaCtx, params.evalCtx,
 			); err != nil {
 				return err
 			}
@@ -480,7 +480,7 @@ func (n *alterTableNode) Start(params runParams) error {
 		params.p.txn,
 		EventLogAlterTable,
 		int32(n.tableDesc.ID),
-		int32(params.p.evalCtx.NodeID),
+		int32(params.evalCtx.NodeID),
 		struct {
 			TableName           string
 			Statement           string

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -164,8 +164,9 @@ func (p *planner) validateCheckExpr(
 		return err
 	}
 	next, err := rows.Next(runParams{
-		ctx: ctx,
-		p:   p,
+		ctx:     ctx,
+		evalCtx: &p.evalCtx,
+		p:       p,
 	})
 	if err != nil {
 		return err

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -104,7 +104,7 @@ func (n *createDatabaseNode) Start(params runParams) error {
 			params.p.txn,
 			EventLogCreateDatabase,
 			int32(desc.ID),
-			int32(params.p.evalCtx.NodeID),
+			int32(params.evalCtx.NodeID),
 			struct {
 				DatabaseName string
 				Statement    string
@@ -171,7 +171,7 @@ func (n *createIndexNode) Start(params runParams) error {
 	}
 	if n.n.PartitionBy != nil {
 		if err := addPartitionedBy(
-			params.ctx, &params.p.evalCtx, n.tableDesc, &indexDesc, &indexDesc.Partitioning,
+			params.ctx, params.evalCtx, n.tableDesc, &indexDesc, &indexDesc.Partitioning,
 			n.n.PartitionBy, 0, /* colOffset */
 		); err != nil {
 			return err
@@ -213,7 +213,7 @@ func (n *createIndexNode) Start(params runParams) error {
 		params.p.txn,
 		EventLogCreateIndex,
 		int32(n.tableDesc.ID),
-		int32(params.p.evalCtx.NodeID),
+		int32(params.evalCtx.NodeID),
 		struct {
 			TableName  string
 			IndexName  string
@@ -608,7 +608,7 @@ func (n *createViewNode) Start(params runParams) error {
 		params.p.txn,
 		EventLogCreateView,
 		int32(desc.ID),
-		int32(params.p.evalCtx.NodeID),
+		int32(params.evalCtx.NodeID),
 		struct {
 			ViewName  string
 			Statement string
@@ -744,7 +744,7 @@ func (n *createTableNode) Start(params runParams) error {
 	var affected map[sqlbase.ID]*sqlbase.TableDescriptor
 	creationTime := params.p.txn.OrigTimestamp()
 	if n.n.As() {
-		desc, err = makeTableDescIfAs(n.n, n.dbDesc.ID, id, creationTime, planColumns(n.sourcePlan), privs, &params.p.semaCtx, &params.p.evalCtx)
+		desc, err = makeTableDescIfAs(n.n, n.dbDesc.ID, id, creationTime, planColumns(n.sourcePlan), privs, &params.p.semaCtx, params.evalCtx)
 	} else {
 		affected = make(map[sqlbase.ID]*sqlbase.TableDescriptor)
 		desc, err = params.p.makeTableDesc(params.ctx, n.n, n.dbDesc.ID, id, creationTime, privs, affected)
@@ -793,7 +793,7 @@ func (n *createTableNode) Start(params runParams) error {
 		params.p.txn,
 		EventLogCreateTable,
 		int32(desc.ID),
-		int32(params.p.evalCtx.NodeID),
+		int32(params.evalCtx.NodeID),
 		struct {
 			TableName string
 			Statement string
@@ -1436,7 +1436,7 @@ func (n *createViewNode) makeViewTableDesc(
 		if len(columnNames) > i {
 			columnTableDef.Name = columnNames[i]
 		}
-		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, &params.p.semaCtx, &params.p.evalCtx)
+		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, &params.p.semaCtx, params.evalCtx)
 		if err != nil {
 			return desc, err
 		}
@@ -1949,7 +1949,7 @@ func (n *createSequenceNode) Start(params runParams) error {
 		params.p.txn,
 		EventLogCreateSequence,
 		int32(desc.ID),
-		int32(params.p.evalCtx.NodeID),
+		int32(params.evalCtx.NodeID),
 		struct {
 			SequenceName string
 			Statement    string

--- a/pkg/sql/create.go
+++ b/pkg/sql/create.go
@@ -450,7 +450,6 @@ func (*alterUserSetPasswordNode) Values() tree.Datums          { return tree.Dat
 
 // createViewNode represents a CREATE VIEW statement.
 type createViewNode struct {
-	p             *planner
 	n             *tree.CreateView
 	dbDesc        *sqlbase.DatabaseDescriptor
 	sourceColumns sqlbase.ResultColumns
@@ -526,7 +525,6 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 	log.VEventf(ctx, 2, "collected view dependencies:\n%s", planDeps.String())
 
 	return &createViewNode{
-		p:             p,
 		n:             n,
 		dbDesc:        dbDesc,
 		sourceColumns: sourceColumns,
@@ -538,14 +536,14 @@ func (n *createViewNode) Start(params runParams) error {
 	viewName := n.n.Name.TableName().Table()
 	tKey := tableKey{parentID: n.dbDesc.ID, name: viewName}
 	key := tKey.Key()
-	if exists, err := descExists(params.ctx, n.p.txn, key); err == nil && exists {
+	if exists, err := descExists(params.ctx, params.p.txn, key); err == nil && exists {
 		// TODO(a-robinson): Support CREATE OR REPLACE commands.
 		return sqlbase.NewRelationAlreadyExistsError(tKey.Name())
 	} else if err != nil {
 		return err
 	}
 
-	id, err := GenerateUniqueDescID(params.ctx, n.p.session.execCfg.DB)
+	id, err := GenerateUniqueDescID(params.ctx, params.p.session.execCfg.DB)
 	if err != nil {
 		return nil
 	}
@@ -554,14 +552,13 @@ func (n *createViewNode) Start(params runParams) error {
 	privs := n.dbDesc.GetPrivileges()
 
 	desc, err := n.makeViewTableDesc(
-		params.ctx,
+		params,
 		viewName,
 		n.n.ColumnNames,
 		n.dbDesc.ID,
 		id,
 		n.sourceColumns,
 		privs,
-		&n.p.evalCtx,
 	)
 	if err != nil {
 		return err
@@ -576,7 +573,7 @@ func (n *createViewNode) Start(params runParams) error {
 		desc.DependsOn = append(desc.DependsOn, backrefID)
 	}
 
-	if err = n.p.createDescriptorWithID(params.ctx, key, id, &desc); err != nil {
+	if err = params.p.createDescriptorWithID(params.ctx, key, id, &desc); err != nil {
 		return err
 	}
 
@@ -592,31 +589,31 @@ func (n *createViewNode) Start(params runParams) error {
 			dep.ID = desc.ID
 			backrefDesc.DependedOnBy = append(backrefDesc.DependedOnBy, dep)
 		}
-		if err := n.p.saveNonmutationAndNotify(params.ctx, &backrefDesc); err != nil {
+		if err := params.p.saveNonmutationAndNotify(params.ctx, &backrefDesc); err != nil {
 			return err
 		}
 	}
 
 	if desc.Adding() {
-		n.p.notifySchemaChange(&desc, sqlbase.InvalidMutationID)
+		params.p.notifySchemaChange(&desc, sqlbase.InvalidMutationID)
 	}
-	if err := desc.Validate(params.ctx, n.p.txn); err != nil {
+	if err := desc.Validate(params.ctx, params.p.txn); err != nil {
 		return err
 	}
 
 	// Log Create View event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
-	return MakeEventLogger(n.p.LeaseMgr()).InsertEventRecord(
+	return MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
 		params.ctx,
-		n.p.txn,
+		params.p.txn,
 		EventLogCreateView,
 		int32(desc.ID),
-		int32(n.p.evalCtx.NodeID),
+		int32(params.p.evalCtx.NodeID),
 		struct {
 			ViewName  string
 			Statement string
 			User      string
-		}{n.n.Name.String(), n.n.String(), n.p.session.User},
+		}{n.n.Name.String(), n.n.String(), params.p.session.User},
 	)
 }
 
@@ -1420,16 +1417,15 @@ func initTableDescriptor(
 // doesn't matter if reads/writes use a cached descriptor that doesn't
 // include the back-references.
 func (n *createViewNode) makeViewTableDesc(
-	ctx context.Context,
+	params runParams,
 	viewName string,
 	columnNames tree.NameList,
 	parentID sqlbase.ID,
 	id sqlbase.ID,
 	resultColumns []sqlbase.ResultColumn,
 	privileges *sqlbase.PrivilegeDescriptor,
-	evalCtx *tree.EvalContext,
 ) (sqlbase.TableDescriptor, error) {
-	desc := initTableDescriptor(id, parentID, viewName, n.p.txn.OrigTimestamp(), privileges)
+	desc := initTableDescriptor(id, parentID, viewName, params.p.txn.OrigTimestamp(), privileges)
 	desc.ViewQuery = tree.AsStringWithFlags(n.n.AsSource, tree.FmtParsable)
 	for i, colRes := range resultColumns {
 		colType, err := coltypes.DatumTypeToColumnType(colRes.Typ)
@@ -1440,7 +1436,7 @@ func (n *createViewNode) makeViewTableDesc(
 		if len(columnNames) > i {
 			columnTableDef.Name = columnNames[i]
 		}
-		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, &n.p.semaCtx, evalCtx)
+		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, &params.p.semaCtx, &params.p.evalCtx)
 		if err != nil {
 			return desc, err
 		}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2253,8 +2253,9 @@ func (dsp *DistSQLPlanner) createPlanForValues(
 
 	var a sqlbase.DatumAlloc
 	params := runParams{
-		ctx: planCtx.ctx,
-		p:   nil,
+		ctx:     planCtx.ctx,
+		evalCtx: planCtx.evalCtx,
+		p:       nil,
 	}
 	if err := n.Start(params); err != nil {
 		return physicalPlan{}, err

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -652,7 +652,7 @@ func (dsp *DistSQLPlanner) nodeVersionIsCompatible(
 // initTableReaderSpec initializes a TableReaderSpec/PostProcessSpec that
 // corresponds to a scanNode, except for the Spans and OutputColumns.
 func initTableReaderSpec(
-	n *scanNode,
+	n *scanNode, evalCtx *tree.EvalContext,
 ) (distsqlrun.TableReaderSpec, distsqlrun.PostProcessSpec, error) {
 	s := distsqlrun.TableReaderSpec{
 		Table:   *n.desc,
@@ -673,7 +673,7 @@ func initTableReaderSpec(
 	}
 
 	post := distsqlrun.PostProcessSpec{
-		Filter: distsqlplan.MakeExpression(n.filter, &n.p.evalCtx, nil),
+		Filter: distsqlplan.MakeExpression(n.filter, evalCtx, nil),
 	}
 
 	if n.hardLimit != 0 {
@@ -740,7 +740,7 @@ func (dsp *DistSQLPlanner) convertOrdering(
 func (dsp *DistSQLPlanner) createTableReaders(
 	planCtx *planningCtx, n *scanNode, overrideResultColumns []uint32,
 ) (physicalPlan, error) {
-	spec, post, err := initTableReaderSpec(n)
+	spec, post, err := initTableReaderSpec(n, planCtx.evalCtx)
 	if err != nil {
 		return physicalPlan{}, err
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2261,8 +2261,8 @@ func (dsp *DistSQLPlanner) createPlanForValues(
 	}
 	defer n.Close(planCtx.ctx)
 
-	s.RawBytes = make([][]byte, n.Len())
-	for i := 0; i < n.Len(); i++ {
+	s.RawBytes = make([][]byte, n.rows.Len())
+	for i := 0; i < n.rows.Len(); i++ {
 		if next, err := n.Next(runParams{ctx: planCtx.ctx}); !next {
 			return physicalPlan{}, err
 		}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2210,7 +2210,7 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 		if err != nil {
 			return physicalPlan{}, err
 		}
-		if err := n.evalLimit(); err != nil {
+		if err := n.evalLimit(planCtx.evalCtx); err != nil {
 			return physicalPlan{}, err
 		}
 		if err := plan.AddLimit(n.count, n.offset, dsp.nodeDesc.NodeID); err != nil {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1198,7 +1198,9 @@ func (l *DistLoader) LoadCSV(
 // the select data source (a n.source) and updates it to produce results
 // corresponding to the render node itself. An evaluator stage is added if the
 // render node has any expressions which are not just simple column references.
-func (dsp *DistSQLPlanner) selectRenders(p *physicalPlan, n *renderNode) {
+func (dsp *DistSQLPlanner) selectRenders(
+	p *physicalPlan, n *renderNode, evalCtx *tree.EvalContext,
+) {
 	// We want to skip any unused renders.
 	planToStreamColMap := makePlanToStreamColMap(len(n.render))
 	renders := make([]tree.TypedExpr, 0, len(n.render))
@@ -1209,7 +1211,7 @@ func (dsp *DistSQLPlanner) selectRenders(p *physicalPlan, n *renderNode) {
 		}
 	}
 
-	p.AddRendering(renders, &n.planner.evalCtx, p.planToStreamColMap, getTypesForPlanResult(n, planToStreamColMap))
+	p.AddRendering(renders, evalCtx, p.planToStreamColMap, getTypesForPlanResult(n, planToStreamColMap))
 	p.planToStreamColMap = planToStreamColMap
 }
 
@@ -2170,7 +2172,7 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 		if err != nil {
 			return physicalPlan{}, err
 		}
-		dsp.selectRenders(&plan, n)
+		dsp.selectRenders(&plan, n, planCtx.evalCtx)
 		return plan, nil
 
 	case *groupNode:

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -532,7 +532,7 @@ func (n *dropViewNode) Start(params runParams) error {
 			params.p.txn,
 			EventLogDropView,
 			int32(droppedDesc.ID),
-			int32(params.p.evalCtx.NodeID),
+			int32(params.evalCtx.NodeID),
 			struct {
 				ViewName            string
 				Statement           string
@@ -612,7 +612,7 @@ func (n *dropSequenceNode) Start(params runParams) error {
 			params.p.txn,
 			EventLogDropSequence,
 			int32(droppedDesc.ID),
-			int32(params.p.evalCtx.NodeID),
+			int32(params.evalCtx.NodeID),
 			struct {
 				SequenceName string
 				Statement    string
@@ -842,7 +842,7 @@ func (n *dropTableNode) Start(params runParams) error {
 			params.p.txn,
 			EventLogDropTable,
 			int32(droppedDesc.ID),
-			int32(params.p.evalCtx.NodeID),
+			int32(params.evalCtx.NodeID),
 			struct {
 				TableName           string
 				Statement           string

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1993,8 +1993,9 @@ func (e *Executor) execClassic(
 	}
 
 	params := runParams{
-		ctx: ctx,
-		p:   planner,
+		ctx:     ctx,
+		evalCtx: &planner.evalCtx,
+		p:       planner,
 	}
 
 	switch rowResultWriter.StatementType() {
@@ -2032,8 +2033,8 @@ func forEachRow(params runParams, p planNode, f func(tree.Datums) error) error {
 	next, err := p.Next(params)
 	for ; next; next, err = p.Next(params) {
 		// If we're tracking memory, clear the previous row's memory account.
-		if params.p.evalCtx.ActiveMemAcc != nil {
-			params.p.evalCtx.ActiveMemAcc.Clear(params.ctx)
+		if params.evalCtx.ActiveMemAcc != nil {
+			params.evalCtx.ActiveMemAcc.Clear(params.ctx)
 		}
 
 		if err := f(p.Values()); err != nil {
@@ -2190,8 +2191,9 @@ func (e *Executor) execStmtInParallel(
 	session := planner.session
 	ctx := session.Ctx()
 	params := runParams{
-		ctx: ctx,
-		p:   planner,
+		ctx:     ctx,
+		evalCtx: &planner.evalCtx,
+		p:       planner,
 	}
 
 	plan, err := planner.makePlan(ctx, stmt)

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -2085,7 +2085,7 @@ func (e *Executor) shouldUseDistSQL(planner *planner, plan planNode) (bool, erro
 		err = errors.New("writing txn")
 	} else {
 		// Trigger limit propagation.
-		setUnlimited(plan)
+		planner.setUnlimited(plan)
 		distribute, err = e.distSQLPlanner.CheckSupport(plan)
 	}
 

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -87,7 +87,7 @@ func doExpandPlan(
 			// during the plan's Start() phase. This may trigger additional
 			// optimizations (eg. in sortNode) which the user of EXPLAIN will be
 			// interested in.
-			setUnlimited(n.plan)
+			p.setUnlimited(n.plan)
 		}
 
 	case *indexJoinNode:

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -380,7 +380,7 @@ func expandRenderNode(
 		}
 	}
 
-	r.computePhysicalProps(planPhysicalProps(r.source.plan))
+	p.computePhysicalPropsForRender(r, planPhysicalProps(r.source.plan))
 	return r, nil
 }
 
@@ -570,7 +570,7 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 		// TODO(radu): in some cases there may be multiple possible n.orderings for
 		// a given source plan ordering; we should pass usefulOrdering to help make
 		// that choice (#13709).
-		n.computePhysicalProps(planPhysicalProps(n.source.plan))
+		p.computePhysicalPropsForRender(n, planPhysicalProps(n.source.plan))
 
 	case *delayedNode:
 		n.plan = p.simplifyOrderings(n.plan, usefulOrdering)

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -174,7 +174,7 @@ var explainDistSQLColumns = sqlbase.ResultColumns{
 
 func (n *explainDistSQLNode) Start(params runParams) error {
 	// Trigger limit propagation.
-	setUnlimited(n.plan)
+	params.p.setUnlimited(n.plan)
 
 	distSQLPlanner := params.p.session.distSQLPlanner
 

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -189,7 +189,7 @@ func (n *explainDistSQLNode) Start(params runParams) error {
 		return err
 	}
 	distSQLPlanner.FinalizePlan(&planCtx, &plan)
-	flows := plan.GenerateFlowSpecs(params.p.evalCtx.NodeID)
+	flows := plan.GenerateFlowSpecs(params.evalCtx.NodeID)
 	planJSON, planURL, err := distsqlrun.GeneratePlanDiagramWithURL(flows)
 	if err != nil {
 		return err

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -64,9 +64,9 @@ func (f *filterNode) Next(params runParams) (bool, error) {
 			return false, err
 		}
 
-		params.p.evalCtx.IVarHelper = &f.ivarHelper
-		passesFilter, err := sqlbase.RunFilter(f.filter, &params.p.evalCtx)
-		params.p.evalCtx.IVarHelper = nil
+		params.evalCtx.IVarHelper = &f.ivarHelper
+		passesFilter, err := sqlbase.RunFilter(f.filter, params.evalCtx)
+		params.evalCtx.IVarHelper = nil
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/generator.go
+++ b/pkg/sql/generator.go
@@ -73,7 +73,7 @@ func (p *planner) makeGenerator(ctx context.Context, t *tree.FuncExpr) (planNode
 }
 
 func (n *valueGenerator) Start(params runParams) error {
-	expr, err := n.expr.Eval(&params.p.evalCtx)
+	expr, err := n.expr.Eval(params.evalCtx)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -245,7 +245,7 @@ func (p *planner) groupBy(
 		// also be updated (for IndexedVarResolvedType to work).
 		havingNode.source.info = newSourceInfoForSingleTable(anonymousTable, group.columns)
 
-		havingNode.filter, err = r.planner.analyzeExpr(
+		havingNode.filter, err = p.analyzeExpr(
 			ctx, havingExpr, nil /* no source info */, havingNode.ivarHelper,
 			types.Bool, true /* require type */, "HAVING",
 		)
@@ -255,8 +255,7 @@ func (p *planner) groupBy(
 	}
 
 	postRender := &renderNode{
-		planner: r.planner,
-		source:  planDataSource{plan: plan},
+		source: planDataSource{plan: plan},
 	}
 	plan = postRender
 

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -395,7 +395,7 @@ func (n *groupNode) Next(params runParams) (bool, error) {
 				value = values[f.argRenderIdx]
 			}
 
-			if err := f.add(params.ctx, &params.p.evalCtx, bucket, value); err != nil {
+			if err := f.add(params.ctx, params.evalCtx, bucket, value); err != nil {
 				return false, err
 			}
 		}
@@ -419,7 +419,7 @@ func (n *groupNode) Next(params runParams) (bool, error) {
 			// No input for this bucket (possible if f has a FILTER).
 			// In most cases the result is NULL but there are exceptions
 			// (like COUNT).
-			aggregateFunc = f.create(&params.p.evalCtx)
+			aggregateFunc = f.create(params.evalCtx)
 		}
 		var err error
 		n.values[i], err = aggregateFunc.Result()

--- a/pkg/sql/group_test.go
+++ b/pkg/sql/group_test.go
@@ -48,33 +48,35 @@ func TestDesiredAggregateOrder(t *testing.T) {
 	}
 	p := makeTestPlanner()
 	for _, d := range testData {
-		evalCtx := tree.NewTestingEvalContext()
-		defer evalCtx.Stop(context.Background())
-		sel := makeSelectNode(t, evalCtx)
-		expr := parseAndNormalizeExpr(t, evalCtx, d.expr, sel)
-		group := &groupNode{planner: p}
-		render := &renderNode{planner: p}
-		postRender := &renderNode{planner: p}
-		postRender.ivarHelper = tree.MakeIndexedVarHelper(postRender, len(group.funcs))
-		v := extractAggregatesVisitor{
-			ctx:        context.TODO(),
-			groupNode:  group,
-			preRender:  render,
-			ivarHelper: &postRender.ivarHelper,
-			planner:    p,
-		}
-		if _, err := v.extract(expr); err != nil {
-			t.Fatal(err)
-		}
-		ordering := group.desiredAggregateOrdering()
-		if !reflect.DeepEqual(d.ordering, ordering) {
-			t.Fatalf("%s: expected %v, but found %v", d.expr, d.ordering, ordering)
-		}
-		// Verify we never have a desired ordering if there is a GROUP BY.
-		group.numGroupCols = 1
-		ordering = group.desiredAggregateOrdering()
-		if len(ordering) > 0 {
-			t.Fatalf("%s: expected no ordering when there is a GROUP BY, found %v", d.expr, ordering)
-		}
+		t.Run(d.expr, func(t *testing.T) {
+			p.evalCtx = tree.MakeTestingEvalContext()
+			defer p.evalCtx.Stop(context.Background())
+			sel := makeSelectNode(t, p)
+			expr := parseAndNormalizeExpr(t, p, d.expr, sel)
+			group := &groupNode{planner: p}
+			render := &renderNode{}
+			postRender := &renderNode{}
+			postRender.ivarHelper = tree.MakeIndexedVarHelper(postRender, len(group.funcs))
+			v := extractAggregatesVisitor{
+				ctx:        context.TODO(),
+				groupNode:  group,
+				preRender:  render,
+				ivarHelper: &postRender.ivarHelper,
+				planner:    p,
+			}
+			if _, err := v.extract(expr); err != nil {
+				t.Fatal(err)
+			}
+			ordering := group.desiredAggregateOrdering()
+			if !reflect.DeepEqual(d.ordering, ordering) {
+				t.Fatalf("%s: expected %v, but found %v", d.expr, d.ordering, ordering)
+			}
+			// Verify we never have a desired ordering if there is a GROUP BY.
+			group.numGroupCols = 1
+			ordering = group.desiredAggregateOrdering()
+			if len(ordering) > 0 {
+				t.Fatalf("%s: expected no ordering when there is a GROUP BY, found %v", d.expr, ordering)
+			}
+		})
 	}
 }

--- a/pkg/sql/group_test.go
+++ b/pkg/sql/group_test.go
@@ -53,7 +53,7 @@ func TestDesiredAggregateOrder(t *testing.T) {
 			defer p.evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr := parseAndNormalizeExpr(t, p, d.expr, sel)
-			group := &groupNode{planner: p}
+			group := &groupNode{}
 			render := &renderNode{}
 			postRender := &renderNode{}
 			postRender.ivarHelper = tree.MakeIndexedVarHelper(postRender, len(group.funcs))
@@ -67,13 +67,13 @@ func TestDesiredAggregateOrder(t *testing.T) {
 			if _, err := v.extract(expr); err != nil {
 				t.Fatal(err)
 			}
-			ordering := group.desiredAggregateOrdering()
+			ordering := group.desiredAggregateOrdering(&p.evalCtx)
 			if !reflect.DeepEqual(d.ordering, ordering) {
 				t.Fatalf("%s: expected %v, but found %v", d.expr, d.ordering, ordering)
 			}
 			// Verify we never have a desired ordering if there is a GROUP BY.
 			group.numGroupCols = 1
-			ordering = group.desiredAggregateOrdering()
+			ordering = group.desiredAggregateOrdering(&p.evalCtx)
 			if len(ordering) > 0 {
 				t.Fatalf("%s: expected no ordering when there is a GROUP BY, found %v", d.expr, ordering)
 			}

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -122,9 +122,9 @@ func (p *planner) makeIndexJoin(
 	// Create a new scanNode that will be used with the primary index.
 	table := p.Scan()
 	table.desc = origScan.desc
-	// Note: initDescDefaults can only error out if its 2nd argument is not nil.
-	_ = table.initDescDefaults(origScan.scanVisibility, nil)
-	table.initOrdering(0)
+	// Note: initDescDefaults can only error out if its 3rd argument is not nil.
+	_ = table.initDescDefaults(p.planDeps, origScan.scanVisibility, nil)
+	table.initOrdering(0, &p.evalCtx)
 	table.disableBatchLimit()
 
 	colIDtoRowIndex := map[sqlbase.ColumnID]int{}
@@ -190,7 +190,7 @@ func (p *planner) makeIndexJoin(
 	// table scanNode fully.
 	table.filter = table.filterVars.Rebind(table.filter, true, false)
 
-	indexScan.initOrdering(exactPrefix)
+	indexScan.initOrdering(exactPrefix, &p.evalCtx)
 
 	primaryKeyPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(table.desc, table.index.ID))
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -382,7 +382,7 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 		return false, err
 	}
 
-	rowVals, err := GenerateInsertRow(n.defaultExprs, n.insertColIDtoRowIndex, n.insertCols, params.p.evalCtx, n.tableDesc, n.run.rows.Values())
+	rowVals, err := GenerateInsertRow(n.defaultExprs, n.insertColIDtoRowIndex, n.insertCols, *params.evalCtx, n.tableDesc, n.run.rows.Values())
 	if err != nil {
 		return false, err
 	}
@@ -390,7 +390,7 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 	if err := n.checkHelper.loadRow(n.insertColIDtoRowIndex, rowVals, false); err != nil {
 		return false, err
 	}
-	if err := n.checkHelper.check(&params.p.evalCtx); err != nil {
+	if err := n.checkHelper.check(params.evalCtx); err != nil {
 		return false, err
 	}
 

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -346,7 +346,6 @@ func (p *planner) makeJoin(
 	//    8: right.y             @6
 
 	r := &renderNode{
-		planner:    p,
 		source:     joinDataSource,
 		sourceInfo: multiSourceInfo{info},
 	}

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -649,7 +649,7 @@ func (n *joinNode) Next(params runParams) (res bool, err error) {
 		// on condition, if the on condition passes we add it to the buffer.
 		foundMatch := false
 		for idx, rrow := range b.Rows() {
-			passesOnCond, err := n.pred.eval(&params.p.evalCtx, n.output, lrow, rrow)
+			passesOnCond, err := n.pred.eval(params.evalCtx, n.output, lrow, rrow)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -77,7 +77,7 @@ func (n *limitNode) Start(params runParams) error {
 		return err
 	}
 
-	return n.evalLimit(&params.p.evalCtx)
+	return n.evalLimit(params.evalCtx)
 }
 
 // estimateLimit pre-computes the count and offset fields if they are constants,

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -538,7 +538,7 @@ func (p *planner) addRenderFilter(
 // function will add `b.x > 10`.
 //
 // The expanded expression can then be split as necessary.
-func expandOnCond(n *joinNode, cond tree.TypedExpr) tree.TypedExpr {
+func expandOnCond(n *joinNode, cond tree.TypedExpr, evalCtx *tree.EvalContext) tree.TypedExpr {
 	if isFilterTrue(cond) || len(n.pred.leftEqualityIndices) == 0 {
 		return cond
 	}
@@ -587,7 +587,7 @@ func expandOnCond(n *joinNode, cond tree.TypedExpr) tree.TypedExpr {
 
 	var result tree.TypedExpr = tree.DBoolTrue
 
-	andExprs := splitAndExpr(&n.planner.evalCtx, cond, nil)
+	andExprs := splitAndExpr(evalCtx, cond, nil)
 	for _, e := range andExprs {
 		convLeft := func(expr tree.VariableExpr) (bool, tree.Expr) {
 			iv, ok := expr.(*tree.IndexedVar)
@@ -713,7 +713,7 @@ func (p *planner) addJoinFilter(
 	// constraints can be pushed down. This is not useful for FULL OUTER
 	// joins, where nothing can be pushed down.
 	if n.joinType != joinTypeFullOuter {
-		onCond = expandOnCond(n, onCond)
+		onCond = expandOnCond(n, onCond, &p.evalCtx)
 	}
 
 	// Step 4: propagate the filter and ON conditions as allowed by the join type.

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -74,8 +74,7 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 
 	case *sortNode:
 		if n.needSort && numRows != math.MaxInt64 {
-			v := p.newContainerValuesNode(planColumns(n.plan), int(numRows))
-			v.ordering = n.ordering
+			v := p.newSortValues(n.ordering, planColumns(n.plan), int(numRows))
 			if soft {
 				n.sortStrategy = newIterativeSortStrategy(v)
 			} else {

--- a/pkg/sql/optimize.go
+++ b/pkg/sql/optimize.go
@@ -82,7 +82,7 @@ func (i *subqueryInitializer) subqueryNode(ctx context.Context, sq *subquery) er
 				numRows = 2
 			}
 
-			sq.plan = &limitNode{p: i.p, plan: sq.plan, countExpr: tree.NewDInt(numRows)}
+			sq.plan = &limitNode{plan: sq.plan, countExpr: tree.NewDInt(numRows)}
 		}
 
 		needed := make([]bool, len(planColumns(sq.plan)))

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -456,7 +456,11 @@ func TestSpanBasedDependencyAnalyzer(t *testing.T) {
 
 				planAndAnalyze := func(q string) (planNode, func()) {
 					p, plan, finish := planQuery(t, s, q)
-					params := runParams{ctx: context.TODO(), p: p}
+					params := runParams{
+						ctx:     context.TODO(),
+						evalCtx: &p.evalCtx,
+						p:       p,
+					}
 
 					if err := da.Analyze(params, plan); err != nil {
 						t.Fatalf("plan analysis failed: %v", err)

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -234,7 +234,7 @@ func (p *planner) startPlan(ctx context.Context, plan planNode) error {
 		return err
 	}
 	// Trigger limit propagation through the plan and sub-queries.
-	setUnlimited(plan)
+	p.setUnlimited(plan)
 	return nil
 }
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -76,7 +76,12 @@ type runParams struct {
 	// context.Context for this method call.
 	ctx context.Context
 
-	// planner associated with this planNode.
+	// evalCtx is the tree.EvalContext associated with this execution.
+	// Used during local execution and distsql physical planning.
+	evalCtx *tree.EvalContext
+
+	// planner associated with this execution. Only used during local
+	// execution.
 	p *planner
 }
 
@@ -227,8 +232,9 @@ func (p *planner) startPlan(ctx context.Context, plan planNode) error {
 		return err
 	}
 	params := runParams{
-		ctx: ctx,
-		p:   p,
+		ctx:     ctx,
+		evalCtx: &p.evalCtx,
+		p:       p,
 	}
 	if err := plan.Start(params); err != nil {
 		return err

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -149,8 +149,8 @@ func insertNodeWithValuesSpans(
 	// Importantly, we only Reset the valuesNode, instead of Closing it when
 	// completed, so that the values don't need to be computed again during
 	// plan execution.
-	rowAcc := params.p.evalCtx.Mon.MakeBoundAccount()
-	params.p.evalCtx.ActiveMemAcc = &rowAcc
+	rowAcc := params.evalCtx.Mon.MakeBoundAccount()
+	params.evalCtx.ActiveMemAcc = &rowAcc
 	defer rowAcc.Close(params.ctx)
 
 	defer v.Reset(params.ctx)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -306,8 +306,9 @@ func (p *planner) queryRows(
 		return nil, err
 	}
 	params := runParams{
-		ctx: ctx,
-		p:   p,
+		ctx:     ctx,
+		evalCtx: &p.evalCtx,
+		p:       p,
 	}
 	var rows []tree.Datums
 	if err = forEachRow(params, plan, func(values tree.Datums) error {
@@ -336,8 +337,9 @@ func (p *planner) exec(ctx context.Context, sql string, args ...interface{}) (in
 		return 0, err
 	}
 	params := runParams{
-		ctx: ctx,
-		p:   p,
+		ctx:     ctx,
+		evalCtx: &p.evalCtx,
+		p:       p,
 	}
 	return countRowsAffected(params, plan)
 }

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -110,7 +110,7 @@ func (r *renderNode) Next(params runParams) (bool, error) {
 
 	r.curSourceRow = r.source.plan.Values()
 
-	err := r.renderRow(&params.p.evalCtx)
+	err := r.renderRow(params.evalCtx)
 	return err == nil, err
 }
 

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -30,8 +30,6 @@ import (
 // renderNode encapsulates the render logic of a select statement:
 // expressing new values using expressions over source values.
 type renderNode struct {
-	planner *planner
-
 	// source describes where the data is coming from.
 	// populated initially by initFrom().
 	// potentially modified by index selection.
@@ -112,7 +110,7 @@ func (r *renderNode) Next(params runParams) (bool, error) {
 
 	r.curSourceRow = r.source.plan.Values()
 
-	err := r.renderRow()
+	err := r.renderRow(&params.p.evalCtx)
 	return err == nil, err
 }
 
@@ -217,16 +215,16 @@ func (p *planner) SelectClause(
 	desiredTypes []types.T,
 	scanVisibility scanVisibility,
 ) (planNode, error) {
-	r := &renderNode{planner: p}
+	r := &renderNode{}
 
-	if err := r.initFrom(ctx, parsed, scanVisibility); err != nil {
+	if err := p.initFrom(ctx, r, parsed, scanVisibility); err != nil {
 		return nil, err
 	}
 
 	var where *filterNode
 	if parsed.Where != nil {
 		var err error
-		where, err = r.initWhere(ctx, parsed.Where.Expr)
+		where, err = p.initWhere(ctx, r, parsed.Where.Expr)
 		if err != nil {
 			return nil, err
 		}
@@ -234,7 +232,7 @@ func (p *planner) SelectClause(
 
 	r.ivarHelper = tree.MakeIndexedVarHelper(r, len(r.sourceInfo[0].sourceColumns))
 
-	if err := r.initTargets(ctx, parsed.Exprs, desiredTypes); err != nil {
+	if err := p.initTargets(ctx, r, parsed.Exprs, desiredTypes); err != nil {
 		return nil, err
 	}
 
@@ -256,7 +254,7 @@ func (p *planner) SelectClause(
 	if group != nil && group.requiresIsNotNullFilter() {
 		if where == nil {
 			var err error
-			where, err = r.initWhere(ctx, nil)
+			where, err = p.initWhere(ctx, r, nil)
 			if err != nil {
 				return nil, err
 			}
@@ -295,15 +293,15 @@ func (p *planner) SelectClause(
 }
 
 // initFrom initializes the table node, given the parsed select expression
-func (r *renderNode) initFrom(
-	ctx context.Context, parsed *tree.SelectClause, scanVisibility scanVisibility,
+func (p *planner) initFrom(
+	ctx context.Context, r *renderNode, parsed *tree.SelectClause, scanVisibility scanVisibility,
 ) error {
 	// AS OF expressions are either not supported in this context (e.g. in a view
 	// definition), or they should have been handled by the executor.
-	if parsed.From.AsOf.Expr != nil && !r.planner.avoidCachedDescriptors {
+	if parsed.From.AsOf.Expr != nil && !p.avoidCachedDescriptors {
 		return fmt.Errorf("AS OF SYSTEM TIME not supported in this context")
 	}
-	src, err := r.planner.getSources(ctx, parsed.From.Tables, scanVisibility)
+	src, err := p.getSources(ctx, parsed.From.Tables, scanVisibility)
 	if err != nil {
 		return err
 	}
@@ -312,8 +310,8 @@ func (r *renderNode) initFrom(
 	return nil
 }
 
-func (r *renderNode) initTargets(
-	ctx context.Context, targets tree.SelectExprs, desiredTypes []types.T,
+func (p *planner) initTargets(
+	ctx context.Context, r *renderNode, targets tree.SelectExprs, desiredTypes []types.T,
 ) error {
 	// Loop over the select expressions and expand them into the expressions
 	// we're going to use to generate the returned column set and the names for
@@ -326,7 +324,7 @@ func (r *renderNode) initTargets(
 
 		// Output column names should exactly match the original expression, so we
 		// have to determine the output column name before we rewrite SRFs below.
-		outputName, err := getRenderColName(r.planner.session.SearchPath, target, &r.ivarHelper)
+		outputName, err := getRenderColName(p.session.SearchPath, target, &r.ivarHelper)
 		if err != nil {
 			return err
 		}
@@ -334,18 +332,18 @@ func (r *renderNode) initTargets(
 		// If the current expression contains a set-returning function, we need to
 		// move it up to the sources list as a cross join and add a render for the
 		// function's column in the join.
-		newTarget, err := r.rewriteSRFs(ctx, target)
+		newTarget, err := p.rewriteSRFs(ctx, r, target)
 		if err != nil {
 			return err
 		}
 
-		cols, exprs, hasStar, err := r.planner.computeRenderAllowingStars(ctx, newTarget, desiredType,
+		cols, exprs, hasStar, err := p.computeRenderAllowingStars(ctx, newTarget, desiredType,
 			r.sourceInfo, r.ivarHelper, outputName)
 		if err != nil {
 			return err
 		}
 
-		r.planner.hasStar = r.planner.hasStar || hasStar
+		p.hasStar = p.hasStar || hasStar
 		_ = r.addOrReuseRenders(cols, exprs, false)
 	}
 	// `groupBy` or `orderBy` may internally add additional columns which we
@@ -365,12 +363,11 @@ func (p *planner) insertRender(
 ) (*renderNode, error) {
 	src := planDataSource{info: newSourceInfoForSingleTable(*tn, planColumns(plan)), plan: plan}
 	render := &renderNode{
-		planner:    p,
 		source:     src,
 		sourceInfo: multiSourceInfo{src.info},
 	}
 	render.ivarHelper = tree.MakeIndexedVarHelper(render, len(src.info.sourceColumns))
-	if err := render.initTargets(ctx,
+	if err := p.initTargets(ctx, render,
 		tree.SelectExprs{tree.SelectExpr{Expr: &tree.AllColumnsSelector{}}},
 		nil /*desiredTypes*/); err != nil {
 		return nil, err
@@ -387,7 +384,6 @@ func (p *planner) makeTupleRender(
 	// Make a simple renderNode that renders all the columns in its
 	// source.
 	r := &renderNode{
-		planner:    p,
 		source:     src,
 		sourceInfo: multiSourceInfo{src.info},
 	}
@@ -399,7 +395,7 @@ func (p *planner) makeTupleRender(
 	for i := range src.info.sourceColumns {
 		tExpr.Exprs[i] = r.ivarHelper.IndexedVar(i)
 	}
-	if err := r.initTargets(ctx,
+	if err := p.initTargets(ctx, r,
 		tree.SelectExprs{tree.SelectExpr{Expr: tExpr}}, nil); err != nil {
 		return nil, err
 	}
@@ -457,16 +453,16 @@ func (v *srfExtractionVisitor) VisitPost(expr tree.Expr) tree.Expr {
 // Expressions with more than one SRF require lateral correlated subqueries,
 // which are not yet supported. For now, this function returns an error if more
 // than one SRF is present in the render expression.
-func (r *renderNode) rewriteSRFs(
-	ctx context.Context, target tree.SelectExpr,
+func (p *planner) rewriteSRFs(
+	ctx context.Context, r *renderNode, target tree.SelectExpr,
 ) (tree.SelectExpr, error) {
 	// Walk the render expression looking for SRFs.
-	v := &r.planner.srfExtractionVisitor
+	v := &p.srfExtractionVisitor
 	*v = srfExtractionVisitor{
 		err:        nil,
 		srf:        nil,
 		ivarHelper: &r.ivarHelper,
-		searchPath: r.planner.session.SearchPath,
+		searchPath: p.session.SearchPath,
 	}
 	expr, _ := tree.WalkExpr(v, target.Expr)
 	if v.err != nil {
@@ -481,14 +477,14 @@ func (r *renderNode) rewriteSRFs(
 
 	// We rewrote exactly one SRF; cross-join it with our sources and return the
 	// new render expression.
-	src, err := r.planner.getDataSourceAsOneColumn(ctx, v.srf)
+	src, err := p.getDataSourceAsOneColumn(ctx, v.srf)
 	if err != nil {
 		return target, err
 	}
 
 	if !isUnarySource(r.source) {
 		// The FROM clause specifies something. Replace with a cross-join.
-		src, err = r.planner.makeJoin(ctx, "CROSS JOIN", r.source, src, nil)
+		src, err = p.makeJoin(ctx, "CROSS JOIN", r.source, src, nil)
 		if err != nil {
 			return target, err
 		}
@@ -507,13 +503,15 @@ func isUnarySource(src planDataSource) bool {
 	return ok && len(src.info.sourceColumns) == 0
 }
 
-func (r *renderNode) initWhere(ctx context.Context, whereExpr tree.Expr) (*filterNode, error) {
+func (p *planner) initWhere(
+	ctx context.Context, r *renderNode, whereExpr tree.Expr,
+) (*filterNode, error) {
 	f := &filterNode{source: r.source}
 	f.ivarHelper = tree.MakeIndexedVarHelper(f, len(r.sourceInfo[0].sourceColumns))
 
 	if whereExpr != nil {
 		var err error
-		f.filter, err = r.planner.analyzeExpr(ctx, whereExpr, r.sourceInfo, f.ivarHelper,
+		f.filter, err = p.analyzeExpr(ctx, whereExpr, r.sourceInfo, f.ivarHelper,
 			types.Bool, true, "WHERE")
 		if err != nil {
 			return nil, err
@@ -521,8 +519,8 @@ func (r *renderNode) initWhere(ctx context.Context, whereExpr tree.Expr) (*filte
 
 		// Make sure there are no aggregation/window functions in the filter
 		// (after subqueries have been expanded).
-		if err := r.planner.txCtx.AssertNoAggregationOrWindowing(
-			f.filter, "WHERE", r.planner.session.SearchPath,
+		if err := p.txCtx.AssertNoAggregationOrWindowing(
+			f.filter, "WHERE", p.session.SearchPath,
 		); err != nil {
 			return nil, err
 		}
@@ -606,14 +604,14 @@ func (r *renderNode) resetRenderColumns(exprs []tree.TypedExpr, cols sqlbase.Res
 }
 
 // renderRow renders the row by evaluating the render expressions.
-func (r *renderNode) renderRow() error {
+func (r *renderNode) renderRow(evalCtx *tree.EvalContext) error {
 	if r.row == nil {
 		r.row = make([]tree.Datum, len(r.render))
 	}
 	for i, e := range r.render {
 		var err error
-		r.planner.evalCtx.IVarHelper = &r.ivarHelper
-		r.row[i], err = e.Eval(&r.planner.evalCtx)
+		evalCtx.IVarHelper = &r.ivarHelper
+		r.row[i], err = e.Eval(evalCtx)
 		if err != nil {
 			return err
 		}
@@ -621,8 +619,8 @@ func (r *renderNode) renderRow() error {
 	return nil
 }
 
-// Computes ordering information for the render node, given ordering information for the "from"
-// node.
+// computePhysicalPropsForRender computes ordering information for the
+// render node, given ordering information for the "from" node.
 //
 //    SELECT a, b FROM t@abc ...
 //      the ordering is: first by column 0 (a), then by column 1 (b).
@@ -646,7 +644,9 @@ func (r *renderNode) renderRow() error {
 //    SELECT a, b, a FROM t@abc ...
 //      we have an equivalency group between columns 0 and 2 and the ordering is
 //      first by column 0 (a), then by column 1.
-func (r *renderNode) computePhysicalProps(fromOrder physicalProps) {
+//
+// The planner is necessary to perform name resolution while detecting constant columns.
+func (p *planner) computePhysicalPropsForRender(r *renderNode, fromOrder physicalProps) {
 	// See physicalProps.project for a description of the projection map.
 	projMap := make([]int, len(r.render))
 	for i, expr := range r.render {
@@ -661,7 +661,7 @@ func (r *renderNode) computePhysicalProps(fromOrder physicalProps) {
 
 	// Detect constants.
 	for col, expr := range r.render {
-		_, hasRowDependentValues, _, err := r.resolveNames(expr)
+		_, hasRowDependentValues, _, err := p.resolveNamesForRender(expr, r)
 		if err != nil {
 			// If we get an error here, the expression must contain an unresolved name
 			// or invalid indexed var; ignore.

--- a/pkg/sql/run_control.go
+++ b/pkg/sql/run_control.go
@@ -35,7 +35,7 @@ type controlJobNode struct {
 func (*controlJobNode) Values() tree.Datums { return nil }
 
 func (n *controlJobNode) Start(params runParams) error {
-	jobIDDatum, err := n.jobID.Eval(&params.p.evalCtx)
+	jobIDDatum, err := n.jobID.Eval(params.evalCtx)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (*cancelQueryNode) Values() tree.Datums { return nil }
 func (n *cancelQueryNode) Start(params runParams) error {
 	statusServer := params.p.session.execCfg.StatusServer
 
-	queryIDDatum, err := n.queryID.Eval(&params.p.evalCtx)
+	queryIDDatum, err := n.queryID.Eval(params.evalCtx)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -195,8 +195,8 @@ func (n *scanNode) Next(params runParams) (bool, error) {
 		if err != nil || n.row == nil {
 			return false, err
 		}
-		params.p.evalCtx.IVarHelper = &n.filterVars
-		passesFilter, err := sqlbase.RunFilter(n.filter, &params.p.evalCtx)
+		params.evalCtx.IVarHelper = &n.filterVars
+		passesFilter, err := sqlbase.RunFilter(n.filter, params.evalCtx)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -198,8 +198,12 @@ func (v *nameResolutionVisitor) VisitPre(expr tree.Expr) (recurse bool, newNode 
 
 func (*nameResolutionVisitor) VisitPost(expr tree.Expr) tree.Expr { return expr }
 
-func (s *renderNode) resolveNames(expr tree.Expr) (tree.Expr, bool, bool, error) {
-	return s.planner.resolveNames(expr, s.sourceInfo, s.ivarHelper)
+// resolveNamesForRender resolves the names in expr using the naming
+// context of the given renderNode (FROM clause).
+func (p *planner) resolveNamesForRender(
+	expr tree.Expr, s *renderNode,
+) (tree.Expr, bool, bool, error) {
+	return p.resolveNames(expr, s.sourceInfo, s.ivarHelper)
 }
 
 // resolveNames walks the provided expression and resolves all names

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -25,10 +25,10 @@ import (
 
 func testInitDummySelectNode(desc *sqlbase.TableDescriptor) *renderNode {
 	p := makeTestPlanner()
-	scan := &scanNode{p: p}
+	scan := &scanNode{}
 	scan.desc = desc
 	// Note: scan.initDescDefaults only returns an error if its 2nd argument is not nil.
-	_ = scan.initDescDefaults(publicColumns, nil)
+	_ = scan.initDescDefaults(p.planDeps, publicColumns, nil)
 
 	sel := &renderNode{planner: p}
 	sel.source.plan = scan

--- a/pkg/sql/session_mem_usage.go
+++ b/pkg/sql/session_mem_usage.go
@@ -88,11 +88,6 @@ func (w WrappedMemoryAccount) Clear(ctx context.Context) {
 	w.mon.ClearAccount(ctx, w.acc)
 }
 
-// ResizeItem interfaces between Session and mon.MemoryMonitor.
-func (w WrappedMemoryAccount) ResizeItem(ctx context.Context, oldSize, newSize int64) error {
-	return w.mon.ResizeItem(ctx, w.acc, oldSize, newSize)
-}
-
 // noteworthyMemoryUsageBytes is the minimum size tracked by a
 // transaction or session monitor before the monitor starts explicitly
 // logging overall usage growth in the log.

--- a/pkg/sql/session_mem_usage.go
+++ b/pkg/sql/session_mem_usage.go
@@ -23,13 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
 
-// OpenAccount interfaces between Session and mon.MemoryMonitor.
-func (s *Session) OpenAccount() WrappableMemoryAccount {
-	res := WrappableMemoryAccount{}
-	s.mon.OpenAccount(&res.acc)
-	return res
-}
-
 // WrappableMemoryAccount encapsulates a MemoryAccount to
 // give it the Wsession() method below.
 type WrappableMemoryAccount struct {
@@ -57,19 +50,9 @@ func (w WrappedMemoryAccount) OpenAndInit(ctx context.Context, initialAllocation
 	return w.mon.OpenAndInitAccount(ctx, w.acc, initialAllocation)
 }
 
-// Grow interfaces between Session and mon.MemoryMonitor.
-func (w WrappedMemoryAccount) Grow(ctx context.Context, extraSize int64) error {
-	return w.mon.GrowAccount(ctx, w.acc, extraSize)
-}
-
 // Close interfaces between Session and mon.MemoryMonitor.
 func (w WrappedMemoryAccount) Close(ctx context.Context) {
 	w.mon.CloseAccount(ctx, w.acc)
-}
-
-// Clear interfaces between Session and mon.MemoryMonitor.
-func (w WrappedMemoryAccount) Clear(ctx context.Context) {
-	w.mon.ClearAccount(ctx, w.acc)
 }
 
 // noteworthyMemoryUsageBytes is the minimum size tracked by a

--- a/pkg/sql/session_mem_usage.go
+++ b/pkg/sql/session_mem_usage.go
@@ -30,15 +30,8 @@ func (s *Session) OpenAccount() WrappableMemoryAccount {
 	return res
 }
 
-// OpenAccount interfaces between TxnState and mon.MemoryMonitor.
-func (ts *txnState) OpenAccount() WrappableMemoryAccount {
-	res := WrappableMemoryAccount{}
-	ts.mon.OpenAccount(&res.acc)
-	return res
-}
-
 // WrappableMemoryAccount encapsulates a MemoryAccount to
-// give it the Wsession()/Wtxn() method below.
+// give it the Wsession() method below.
 type WrappableMemoryAccount struct {
 	acc mon.BytesAccount
 }
@@ -49,15 +42,6 @@ func (w *WrappableMemoryAccount) Wsession(s *Session) WrappedMemoryAccount {
 	return WrappedMemoryAccount{
 		acc: &w.acc,
 		mon: &s.sessionMon,
-	}
-}
-
-// Wtxn captures the current txn-specific monitor pointer so it can be provided
-// transparently to the other Account APIs below.
-func (w *WrappableMemoryAccount) Wtxn(s *Session) WrappedMemoryAccount {
-	return WrappedMemoryAccount{
-		acc: &w.acc,
-		mon: &s.TxnState.mon,
 	}
 }
 

--- a/pkg/sql/set.go
+++ b/pkg/sql/set.go
@@ -104,7 +104,7 @@ func (p *planner) SetVar(ctx context.Context, n *tree.SetVar) (planNode, error) 
 func (n *setNode) Start(params runParams) error {
 	if n.typedValues != nil {
 		for i, v := range n.typedValues {
-			d, err := v.Eval(&params.p.evalCtx)
+			d, err := v.Eval(params.evalCtx)
 			if err != nil {
 				return err
 			}
@@ -220,7 +220,7 @@ func (n *setClusterSettingNode) Start(params runParams) error {
 		params.p.txn,
 		EventLogSetClusterSetting,
 		0, /* no target */
-		int32(params.p.evalCtx.NodeID),
+		int32(params.evalCtx.NodeID),
 		struct {
 			SettingName string
 			Value       string

--- a/pkg/sql/show.go
+++ b/pkg/sql/show.go
@@ -592,7 +592,6 @@ func (p *planner) ShowConstraints(ctx context.Context, n *tree.ShowConstraints) 
 
 			// Sort the results by constraint name.
 			return &sortNode{
-				p:    p,
 				plan: v,
 				ordering: sqlbase.ColumnOrdering{
 					{ColIdx: 0, Direction: encoding.Ascending},

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -31,7 +31,6 @@ import (
 // sortNode represents a node that sorts the rows returned by its
 // sub-node.
 type sortNode struct {
-	p        *planner
 	plan     planNode
 	columns  sqlbase.ResultColumns
 	ordering sqlbase.ColumnOrdering
@@ -239,7 +238,7 @@ func (p *planner) orderBy(
 		// No ordering; simply drop the sort node.
 		return nil, nil
 	}
-	return &sortNode{p: p, columns: columns, ordering: ordering}, nil
+	return &sortNode{columns: columns, ordering: ordering}, nil
 }
 
 // flattenTuples extracts the members of tuples into a list of columns.
@@ -441,7 +440,7 @@ func (n *sortNode) Next(params runParams) (bool, error) {
 			n.needSort = false
 			break
 		} else if n.sortStrategy == nil {
-			v := n.p.newContainerValuesNode(planColumns(n.plan), 0)
+			v := params.p.newContainerValuesNode(planColumns(n.plan), 0)
 			v.ordering = n.ordering
 			n.sortStrategy = newSortAllStrategy(v)
 		}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -438,7 +438,7 @@ func (n *sortNode) Next(params runParams) (bool, error) {
 			v := &sortValues{
 				ordering: n.ordering,
 				rows:     vn.rows,
-				evalCtx:  &params.p.evalCtx,
+				evalCtx:  params.evalCtx,
 			}
 			n.sortStrategy = newSortAllStrategy(v)
 			n.sortStrategy.Finish(params.ctx, cancelChecker)

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -16,6 +16,7 @@ package sql
 
 import (
 	"container/heap"
+	"sort"
 
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -432,16 +433,24 @@ func (n *sortNode) Next(params runParams) (bool, error) {
 	cancelChecker := params.p.cancelChecker
 
 	for n.needSort {
-		if v, ok := n.plan.(*valuesNode); ok {
+		if vn, ok := n.plan.(*valuesNode); ok {
 			// The plan we wrap is already a values node. Just sort it.
-			v.ordering = n.ordering
+			v := &sortValues{
+				ordering: n.ordering,
+				rows:     vn.rows,
+				evalCtx:  &params.p.evalCtx,
+			}
 			n.sortStrategy = newSortAllStrategy(v)
 			n.sortStrategy.Finish(params.ctx, cancelChecker)
+			// Sorting is done. Relinquish the reference on the row container,
+			// so as to avoid closing it twice.
+			n.sortStrategy = nil
+			// Fall through -- the remainder of the work is done by the
+			// valuesNode itself.
 			n.needSort = false
 			break
 		} else if n.sortStrategy == nil {
-			v := params.p.newContainerValuesNode(planColumns(n.plan), 0)
-			v.ordering = n.ordering
+			v := params.p.newSortValues(n.ordering, planColumns(n.plan), 0 /*capacity*/)
 			n.sortStrategy = newSortAllStrategy(v)
 		}
 
@@ -519,10 +528,10 @@ type sortingStrategy interface {
 //
 // The strategy is intended to be used when all values need to be sorted.
 type sortAllStrategy struct {
-	vNode *valuesNode
+	vNode *sortValues
 }
 
-func newSortAllStrategy(vNode *valuesNode) sortingStrategy {
+func newSortAllStrategy(vNode *sortValues) sortingStrategy {
 	return &sortAllStrategy{
 		vNode: vNode,
 	}
@@ -549,7 +558,7 @@ func (ss *sortAllStrategy) Close(ctx context.Context) {
 	ss.vNode.Close(ctx)
 }
 
-// iterativeSortStrategy reads in all values into the wrapped valuesNode
+// iterativeSortStrategy reads in all values into the wrapped sortValues
 // and turns the underlying slice into a min-heap. It then pops a value
 // off of the heap for each call to Next, meaning that it only needs to
 // sort the number of values needed, instead of the entire slice. If the
@@ -560,12 +569,12 @@ func (ss *sortAllStrategy) Close(ctx context.Context) {
 // The strategy is intended to be used when an unknown number of values
 // need to be sorted, but that most likely not all values need to be sorted.
 type iterativeSortStrategy struct {
-	vNode      *valuesNode
+	vNode      *sortValues
 	lastVal    tree.Datums
 	nextRowIdx int
 }
 
-func newIterativeSortStrategy(vNode *valuesNode) sortingStrategy {
+func newIterativeSortStrategy(vNode *sortValues) sortingStrategy {
 	return &iterativeSortStrategy{
 		vNode: vNode,
 	}
@@ -597,7 +606,7 @@ func (ss *iterativeSortStrategy) Close(ctx context.Context) {
 	ss.vNode.Close(ctx)
 }
 
-// sortTopKStrategy creates a max-heap in its wrapped valuesNode and keeps
+// sortTopKStrategy creates a max-heap in its wrapped sortValues and keeps
 // this heap populated with only the top k values seen. It accomplishes this
 // by comparing new values (before the deep copy) with the top of the heap.
 // If the new value is less than the current top, the top will be replaced
@@ -614,11 +623,11 @@ func (ss *iterativeSortStrategy) Close(ctx context.Context) {
 // a worst-case space complexity of O(k). For instance, the top k can be found
 // in linear time, and then this can be sorted in linearithmic time.
 type sortTopKStrategy struct {
-	vNode *valuesNode
+	vNode *sortValues
 	topK  int64
 }
 
-func newSortTopKStrategy(vNode *valuesNode, topK int64) sortingStrategy {
+func newSortTopKStrategy(vNode *sortValues, topK int64) sortingStrategy {
 	ss := &sortTopKStrategy{
 		vNode: vNode,
 		topK:  topK,
@@ -677,3 +686,153 @@ func (ss *sortTopKStrategy) Close(ctx context.Context) {
 // the client we should revisit.
 //
 // type onDiskSortStrategy struct{}
+
+// sortValues is a reduced form of valuesNode for use in a sortStrategy.
+type sortValues struct {
+	// invertSorting inverts the sorting predicate.
+	invertSorting bool
+	// ordering indicates the desired ordering of each column in the rows
+	ordering sqlbase.ColumnOrdering
+	// rows contains the columns during sorting.
+	rows *sqlbase.RowContainer
+
+	// evalCtx is needed because we use datum.Compare() which needs it,
+	// and the sort.Interface and heap.Interface do not allow
+	// introducing extra parameters into the Less() method.
+	evalCtx *tree.EvalContext
+
+	// rowsPopped is used for heaps, it indicates the number of rows
+	// that were "popped". These rows are still part of the underlying
+	// sqlbase.RowContainer, in the range [rows.Len()-n.rowsPopped,
+	// rows.Len).
+	rowsPopped int
+
+	// nextRow is used while iterating.
+	nextRow int
+}
+
+var _ valueIterator = &sortValues{}
+var _ sort.Interface = &sortValues{}
+var _ heap.Interface = &sortValues{}
+
+func (p *planner) newSortValues(
+	ordering sqlbase.ColumnOrdering, columns sqlbase.ResultColumns, capacity int,
+) *sortValues {
+	return &sortValues{
+		ordering: ordering,
+		rows: sqlbase.NewRowContainer(
+			p.session.TxnState.makeBoundAccount(),
+			sqlbase.ColTypeInfoFromResCols(columns),
+			capacity,
+		),
+		evalCtx: &p.evalCtx,
+	}
+}
+
+// Values implement the valuesIterator interface.
+func (n *sortValues) Values() tree.Datums {
+	return n.rows.At(n.nextRow - 1)
+}
+
+// Next implements the valuesIterator interface.
+func (n *sortValues) Next(runParams) (bool, error) {
+	if n.nextRow >= n.rows.Len() {
+		return false, nil
+	}
+	n.nextRow++
+	return true, nil
+}
+
+// Close implements the valuesIterator interface.
+func (n *sortValues) Close(ctx context.Context) {
+	n.rows.Close(ctx)
+}
+
+// Len implements the sort.Interface interface.
+func (n *sortValues) Len() int {
+	return n.rows.Len() - n.rowsPopped
+}
+
+// ValuesLess returns the comparison result between the two provided
+// Datums slices in the context of the sortValues ordering.
+func (n *sortValues) ValuesLess(ra, rb tree.Datums) bool {
+	return sqlbase.CompareDatums(n.ordering, n.evalCtx, ra, rb) < 0
+}
+
+// Less implements the sort.Interface interface.
+func (n *sortValues) Less(i, j int) bool {
+	// TODO(pmattis): An alternative to this type of field-based comparison would
+	// be to construct a sort-key per row using encodeTableKey(). Using a
+	// sort-key approach would likely fit better with a disk-based sort.
+	ra, rb := n.rows.At(i), n.rows.At(j)
+	return n.invertSorting != n.ValuesLess(ra, rb)
+}
+
+// Swap implements the sort.Interface interface.
+func (n *sortValues) Swap(i, j int) {
+	n.rows.Swap(i, j)
+}
+
+// Push implements the heap.Interface interface.
+func (n *sortValues) Push(x interface{}) {
+	// We can't push to the heap via heap.Push because that doesn't
+	// allow us to return an error. Instead we use PushValues(), which
+	// adds the value *then* calls heap.Push.  By the time control
+	// arrives here, the value is already added, so there is nothing
+	// left to do.
+}
+
+// PushValues pushes the given Datums value into the heap
+// representation of the sortValues.
+func (n *sortValues) PushValues(ctx context.Context, values tree.Datums) error {
+	_, err := n.rows.AddRow(ctx, values)
+	// We still need to call heap.Push() to sort the heap.
+	heap.Push(n, nil)
+	return err
+}
+
+// Pop implements the heap.Interface interface.
+func (n *sortValues) Pop() interface{} {
+	if n.rowsPopped >= n.rows.Len() {
+		panic("no more rows to pop")
+	}
+	n.rowsPopped++
+	// Returning a Datums as an interface{} involves an allocation. Luckily, the
+	// value of Pop is only used for the return value of heap.Pop, which we can
+	// avoid using.
+	return nil
+}
+
+// PopValues pops the top Datums value off the heap representation
+// of the sortValues. We avoid using heap.Pop() directly to
+// avoid allocating an interface{}.
+func (n *sortValues) PopValues() tree.Datums {
+	heap.Pop(n)
+	// Return the last popped row.
+	return n.rows.At(n.rows.Len() - n.rowsPopped)
+}
+
+// ResetLen resets the length to that of the underlying row
+// container. This resets the effect that popping values had on the
+// sortValues's visible length.
+func (n *sortValues) ResetLen() {
+	n.rowsPopped = 0
+}
+
+// SortAll sorts all values in the sortValues.rows slice.
+func (n *sortValues) SortAll(cancelChecker *sqlbase.CancelChecker) {
+	n.invertSorting = false
+	sqlbase.Sort(n, cancelChecker)
+}
+
+// InitMaxHeap initializes the sortValues.rows slice as a max-heap.
+func (n *sortValues) InitMaxHeap() {
+	n.invertSorting = true
+	heap.Init(n)
+}
+
+// InitMinHeap initializes the sortValues.rows slice as a min-heap.
+func (n *sortValues) InitMinHeap() {
+	n.invertSorting = false
+	heap.Init(n)
+}

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -113,8 +113,9 @@ func (s *subquery) doEval(ctx context.Context) (result tree.Datum, err error) {
 	defer func() { s.plan.Close(ctx); s.plan = nil }()
 
 	params := runParams{
-		ctx: ctx,
-		p:   s.planner,
+		ctx:     ctx,
+		evalCtx: &s.planner.evalCtx,
+		p:       s.planner,
 	}
 	switch s.execMode {
 	case execModeExists:

--- a/pkg/sql/trace.go
+++ b/pkg/sql/trace.go
@@ -33,7 +33,6 @@ type traceNode struct {
 	// plan is the wrapped execution plan that will be traced.
 	plan    planNode
 	columns sqlbase.ResultColumns
-	p       *planner
 
 	execDone bool
 
@@ -43,9 +42,9 @@ type traceNode struct {
 	// around the interaction of SQL with KV. Some of the messages are per-row.
 	kvTracingEnabled bool
 
-	// recording is set if this node started tracing on the session. If it did,
-	// then Close() needs to stop the recording.
-	recording bool
+	// stopTracing is set if this node started tracing on the
+	// session. If it is set, then Close() must call it.
+	stopTracing func() error
 }
 
 var sessionTraceTableName = tree.TableName{
@@ -67,7 +66,6 @@ func (p *planner) makeTraceNode(plan planNode, kvTracingEnabled bool) (planNode,
 	}
 	return &traceNode{
 		plan:             plan,
-		p:                p,
 		columns:          sqlbase.ResultColumnsFromColDescs(desc.Columns),
 		kvTracingEnabled: kvTracingEnabled,
 	}, nil
@@ -78,15 +76,16 @@ var errTracingAlreadyEnabled = errors.New(
 		" - did you mean SHOW TRACE FOR SESSION?")
 
 func (n *traceNode) Start(params runParams) error {
-	if n.p.session.Tracing.Enabled() {
+	if params.p.session.Tracing.Enabled() {
 		return errTracingAlreadyEnabled
 	}
-	if err := n.p.session.Tracing.StartTracing(
+	if err := params.p.session.Tracing.StartTracing(
 		tracing.SnowballRecording, n.kvTracingEnabled,
 	); err != nil {
 		return err
 	}
-	n.recording = true
+	session := params.p.session
+	n.stopTracing = func() error { return stopTracing(session) }
 
 	startCtx, sp := tracing.ChildSpan(params.ctx, "starting plan")
 	defer sp.Finish()
@@ -99,8 +98,8 @@ func (n *traceNode) Close(ctx context.Context) {
 		n.plan.Close(ctx)
 	}
 	n.traceRows = nil
-	if n.recording {
-		if err := stopTracing(n.p.session); err != nil {
+	if n.stopTracing != nil {
+		if err := n.stopTracing(); err != nil {
 			log.Errorf(ctx, "error stopping tracing at end of SHOW TRACE FOR: %v", err)
 		}
 	}
@@ -148,13 +147,13 @@ func (n *traceNode) Next(params runParams) (bool, error) {
 			log.VEventf(consumeCtx, 2, "resources released, stopping trace")
 		}()
 
-		n.recording = false
-		if err := stopTracing(n.p.session); err != nil {
+		if err := stopTracing(params.p.session); err != nil {
 			return false, err
 		}
+		n.stopTracing = nil
 
 		var err error
-		n.traceRows, err = n.p.session.Tracing.generateSessionTraceVTable()
+		n.traceRows, err = params.p.session.Tracing.generateSessionTraceVTable()
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -182,7 +182,7 @@ func (ss scalarSlot) checkColumnTypes(row []tree.TypedExpr, pmap *tree.Placehold
 // addOrMergeExpr inserts an Expr into a renderNode, attempting to reuse
 // previous renders if possible by using render.addOrMergeRender, returning the
 // column index at which the rendered value can be accessed.
-func addOrMergeExpr(
+func (p *planner) addOrMergeExpr(
 	ctx context.Context,
 	e tree.Expr,
 	currentUpdateIdx int,
@@ -193,7 +193,7 @@ func addOrMergeExpr(
 	e = fillDefault(e, currentUpdateIdx, defaultExprs)
 	selectExpr := tree.SelectExpr{Expr: e}
 	typ := updateCols[currentUpdateIdx].Type.ToDatumType()
-	col, expr, err := render.planner.computeRender(ctx, selectExpr, typ,
+	col, expr, err := p.computeRender(ctx, selectExpr, typ,
 		render.sourceInfo, render.ivarHelper, autoGenerateRenderOutputName)
 	if err != nil {
 		return -1, err
@@ -313,7 +313,7 @@ func (p *planner) Update(
 				// the tuple) because when assigning a literal tuple like this it's valid
 				// to assign DEFAULT to some of the columns, which is not valid generally.
 				for _, e := range t.Exprs {
-					colIdx, err := addOrMergeExpr(ctx, e, currentUpdateIdx, updateCols, defaultExprs, render)
+					colIdx, err := p.addOrMergeExpr(ctx, e, currentUpdateIdx, updateCols, defaultExprs, render)
 					if err != nil {
 						return nil, err
 					}
@@ -331,7 +331,7 @@ func (p *planner) Update(
 				for i := range setExpr.Names {
 					desiredTupleType[i] = updateCols[currentUpdateIdx+i].Type.ToDatumType()
 				}
-				col, expr, err := render.planner.computeRender(ctx, selectExpr, desiredTupleType,
+				col, expr, err := p.computeRender(ctx, selectExpr, desiredTupleType,
 					render.sourceInfo, render.ivarHelper, autoGenerateRenderOutputName)
 				if err != nil {
 					return nil, err
@@ -349,7 +349,7 @@ func (p *planner) Update(
 			}
 
 		} else {
-			colIdx, err := addOrMergeExpr(ctx, setExpr.Expr, currentUpdateIdx, updateCols, defaultExprs, render)
+			colIdx, err := p.addOrMergeExpr(ctx, setExpr.Expr, currentUpdateIdx, updateCols, defaultExprs, render)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -448,7 +448,7 @@ func (u *updateNode) Next(params runParams) (bool, error) {
 	if err := u.checkHelper.loadRow(u.updateColsIdx, updateValues, true); err != nil {
 		return false, err
 	}
-	if err := u.checkHelper.check(&params.p.evalCtx); err != nil {
+	if err := u.checkHelper.check(params.evalCtx); err != nil {
 		return false, err
 	}
 

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -33,7 +33,6 @@ func newValuesListLenErr(exp, got int) error {
 }
 
 type valuesNode struct {
-	p	*planner
 	n       *tree.ValuesClause
 	columns sqlbase.ResultColumns
 	tuples  [][]tree.TypedExpr
@@ -50,7 +49,6 @@ type valuesNode struct {
 
 func (p *planner) newContainerValuesNode(columns sqlbase.ResultColumns, capacity int) *valuesNode {
 	return &valuesNode{
-		p:       p,
 		columns: columns,
 		rows: sqlbase.NewRowContainer(
 			p.session.TxnState.makeBoundAccount(), sqlbase.ColTypeInfoFromResCols(columns), capacity,
@@ -63,7 +61,6 @@ func (p *planner) ValuesClause(
 	ctx context.Context, n *tree.ValuesClause, desiredTypes []types.T,
 ) (planNode, error) {
 	v := &valuesNode{
-		p:       p,
 		n:       n,
 		isConst: true,
 	}
@@ -155,7 +152,7 @@ func (n *valuesNode) Start(params runParams) error {
 				row[i] = tree.DNull
 			} else {
 				var err error
-				row[i], err = typedExpr.Eval(&n.p.evalCtx)
+				row[i], err = typedExpr.Eval(params.evalCtx)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -143,7 +143,7 @@ func (n *valuesNode) Start(params runParams) error {
 	// from other planNodes), so its expressions need evaluting.
 	// This may run subqueries.
 	n.rows = sqlbase.NewRowContainer(
-		n.p.session.TxnState.makeBoundAccount(),
+		params.evalCtx.Mon.MakeBoundAccount(),
 		sqlbase.ColTypeInfoFromResCols(n.columns),
 		len(n.n.Tuples),
 	)

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -15,7 +15,6 @@
 package sql
 
 import (
-	"container/heap"
 	"fmt"
 	"strconv"
 
@@ -34,12 +33,11 @@ func newValuesListLenErr(exp, got int) error {
 }
 
 type valuesNode struct {
-	n        *tree.ValuesClause
-	p        *planner
-	columns  sqlbase.ResultColumns
-	ordering sqlbase.ColumnOrdering
-	tuples   [][]tree.TypedExpr
-	rows     *sqlbase.RowContainer
+	p	*planner
+	n       *tree.ValuesClause
+	columns sqlbase.ResultColumns
+	tuples  [][]tree.TypedExpr
+	rows    *sqlbase.RowContainer
 
 	// isConst is set if the valuesNode only contains constant expressions (no
 	// subqueries). In this case, rows will be evaluated during the first call
@@ -47,13 +45,7 @@ type valuesNode struct {
 	// isConst = true can serve its values multiple times. See valuesNode.Reset.
 	isConst bool
 
-	// rowsPopped is used for heaps, it indicates the number of rows that were
-	// "popped". These rows are still part of the underlying sqlbase.RowContainer, in the
-	// range [rows.Len()-n.rowsPopped, rows.Len).
-	rowsPopped int
-
-	nextRow       int  // The index of the next row.
-	invertSorting bool // Inverts the sorting predicate.
+	nextRow int // The index of the next row.
 }
 
 func (p *planner) newContainerValuesNode(columns sqlbase.ResultColumns, capacity int) *valuesNode {
@@ -204,84 +196,4 @@ func (n *valuesNode) Close(ctx context.Context) {
 		n.rows.Close(ctx)
 		n.rows = nil
 	}
-}
-
-func (n *valuesNode) Len() int {
-	return n.rows.Len() - n.rowsPopped
-}
-
-func (n *valuesNode) Less(i, j int) bool {
-	// TODO(pmattis): An alternative to this type of field-based comparison would
-	// be to construct a sort-key per row using encodeTableKey(). Using a
-	// sort-key approach would likely fit better with a disk-based sort.
-	ra, rb := n.rows.At(i), n.rows.At(j)
-	return n.invertSorting != n.ValuesLess(ra, rb)
-}
-
-// ValuesLess returns the comparison result between the two provided Datums slices
-// in the context of the valuesNode ordering.
-func (n *valuesNode) ValuesLess(ra, rb tree.Datums) bool {
-	return sqlbase.CompareDatums(n.ordering, &n.p.evalCtx, ra, rb) < 0
-}
-
-func (n *valuesNode) Swap(i, j int) {
-	n.rows.Swap(i, j)
-}
-
-var _ heap.Interface = (*valuesNode)(nil)
-
-// Push implements the heap.Interface interface.
-func (n *valuesNode) Push(x interface{}) {
-}
-
-// PushValues pushes the given Datums value into the heap representation
-// of the valuesNode.
-func (n *valuesNode) PushValues(ctx context.Context, values tree.Datums) error {
-	_, err := n.rows.AddRow(ctx, values)
-	heap.Push(n, nil)
-	return err
-}
-
-// Pop implements the heap.Interface interface.
-func (n *valuesNode) Pop() interface{} {
-	if n.rowsPopped >= n.rows.Len() {
-		panic("no more rows to pop")
-	}
-	n.rowsPopped++
-	// Returning a Datums as an interface{} involves an allocation. Luckily, the
-	// value of Pop is only used for the return value of heap.Pop, which we can
-	// avoid using.
-	return nil
-}
-
-// PopValues pops the top Datums value off the heap representation
-// of the valuesNode.
-func (n *valuesNode) PopValues() tree.Datums {
-	heap.Pop(n)
-	// Return the last popped row.
-	return n.rows.At(n.rows.Len() - n.rowsPopped)
-}
-
-// ResetLen resets the length to that of the underlying row container. This
-// resets the effect that popping values had on the valuesNode's visible length.
-func (n *valuesNode) ResetLen() {
-	n.rowsPopped = 0
-}
-
-// SortAll sorts all values in the valuesNode.rows slice.
-func (n *valuesNode) SortAll(cancelChecker *sqlbase.CancelChecker) {
-	n.invertSorting = false
-	sqlbase.Sort(n, cancelChecker)
-}
-
-// InitMaxHeap initializes the valuesNode.rows slice as a max-heap.
-func (n *valuesNode) InitMaxHeap() {
-	n.invertSorting = true
-	heap.Init(n)
-}
-
-// InitMinHeap initializes the valuesNode.rows slice as a min-heap.
-func (n *valuesNode) InitMinHeap() {
-	n.invertSorting = false
-	heap.Init(n)
 }

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -480,7 +480,7 @@ func (n *windowNode) Next(params runParams) (bool, error) {
 		}
 		if !next {
 			n.populated = true
-			if err := n.computeWindows(params.ctx, &params.p.evalCtx); err != nil {
+			if err := n.computeWindows(params.ctx, params.evalCtx); err != nil {
 				return false, err
 			}
 			n.values.rows = sqlbase.NewRowContainer(
@@ -488,7 +488,7 @@ func (n *windowNode) Next(params runParams) (bool, error) {
 				sqlbase.ColTypeInfoFromResCols(n.values.columns),
 				n.wrappedRenderVals.Len(),
 			)
-			if err := n.populateValues(params.ctx, &params.p.evalCtx); err != nil {
+			if err := n.populateValues(params.ctx, params.evalCtx); err != nil {
 				return false, err
 			}
 			break

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -86,7 +86,7 @@ func (p *planner) window(
 	}
 	window.sourceCols = len(s.columns)
 
-	if err := window.constructWindowDefinitions(ctx, n, s); err != nil {
+	if err := p.constructWindowDefinitions(ctx, window, n, s); err != nil {
 		return nil, err
 	}
 
@@ -151,8 +151,8 @@ func (n *windowNode) extractWindowFunctions(s *renderNode) error {
 // function application by combining specific window definition from a
 // given window function application with referenced window specifications
 // on the SelectClause.
-func (n *windowNode) constructWindowDefinitions(
-	ctx context.Context, sc *tree.SelectClause, s *renderNode,
+func (p *planner) constructWindowDefinitions(
+	ctx context.Context, n *windowNode, sc *tree.SelectClause, s *renderNode,
 ) error {
 	// Process each named window specification on the select clause.
 	namedWindowSpecs := make(map[string]*tree.WindowDef, len(sc.Window))
@@ -173,7 +173,7 @@ func (n *windowNode) constructWindowDefinitions(
 
 		// Validate PARTITION BY clause.
 		for _, partition := range windowDef.Partitions {
-			cols, exprs, _, err := s.planner.computeRenderAllowingStars(ctx,
+			cols, exprs, _, err := p.computeRenderAllowingStars(ctx,
 				tree.SelectExpr{Expr: partition}, types.Any, s.sourceInfo, s.ivarHelper,
 				autoGenerateRenderOutputName)
 			if err != nil {
@@ -186,7 +186,7 @@ func (n *windowNode) constructWindowDefinitions(
 
 		// Validate ORDER BY clause.
 		for _, orderBy := range windowDef.OrderBy {
-			cols, exprs, _, err := s.planner.computeRenderAllowingStars(ctx,
+			cols, exprs, _, err := p.computeRenderAllowingStars(ctx,
 				tree.SelectExpr{Expr: orderBy.Expr}, types.Any, s.sourceInfo, s.ivarHelper,
 				autoGenerateRenderOutputName)
 			if err != nil {

--- a/pkg/sql/zone.go
+++ b/pkg/sql/zone.go
@@ -174,7 +174,7 @@ func (p *planner) SetZoneConfig(ctx context.Context, n *tree.SetZoneConfig) (pla
 
 func (n *setZoneConfigNode) Start(params runParams) error {
 	var yamlConfig *string
-	datum, err := n.yamlConfig.Eval(&params.p.evalCtx)
+	datum, err := n.yamlConfig.Eval(params.evalCtx)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The first commit from #20169.

Visible changes: the `*planner` reference is removed from planNodes.

Release notes: none.