### PR TITLE
rfcs: Rename scrub index implementation RFC to add merge-date prefix

### DIFF
--- a/20171120_scrub_index_and_physical_implementation.md
+++ b/20171120_scrub_index_and_physical_implementation.md
@@ -1,5 +1,5 @@
 - Feature Name: SCRUB index and physical check implementation
-- Status: draft
+- Status: in-progress
 - Start Date: 2017-10-11
 - Authors: Joey Pereira
 - RFC PR: [#19327](https://github.com/cockroachdb/cockroach/pull/19327)


### PR DESCRIPTION
Unfortunately, when merging the RFC, I ran into rebase problems (welp,
rebased a month in there...). Those were un-done, only to find out that the
change to finalize the RFC before merging were also removed.

cc: @richardwu. Thanks for catching this!