### PR TITLE
encoding: separate alias for interleave sentinel encoding/decoding

### DIFF
--- a/pkg/ccl/storageccl/key_rewriter.go
+++ b/pkg/ccl/storageccl/key_rewriter.go
@@ -173,8 +173,8 @@ func (kr *KeyRewriter) RewriteKey(key []byte) ([]byte, bool, error) {
 		}
 		k = k[n:]
 	}
-	// If we get a NotNULL, it's interleaved.
-	k, ok = encoding.DecodeIfNotNull(k)
+	// We might have an interleaved key.
+	k, ok = encoding.DecodeIfInterleavedSentinel(k)
 	if !ok {
 		return key, true, nil
 	}

--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -1092,7 +1092,7 @@ func spansFromLogicalSpans(
 					encoding.EncodeUvarintAscending(interstices[sharedPrefixLen], uint64(ancestor.IndexID))
 			}
 			sharedPrefixLen += int(ancestor.SharedPrefixLen)
-			interstices[sharedPrefixLen] = encoding.EncodeNotNullDescending(interstices[sharedPrefixLen])
+			interstices[sharedPrefixLen] = encoding.EncodeInterleavedSentinel(interstices[sharedPrefixLen])
 		}
 		interstices[sharedPrefixLen] =
 			encoding.EncodeUvarintAscending(interstices[sharedPrefixLen], uint64(tableDesc.ID))

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -254,9 +254,9 @@ func MakeIndexKeyPrefix(desc *TableDescriptor, indexID IndexID) []byte {
 // EncodeIndexKey creates a key by concatenating keyPrefix with the encodings of
 // the columns in the index.
 //
-// If a table or index is interleaved, `encoding.encodedNullDesc` is used in
-// place of the family id (a varint) to signal the next component of the key.
-// An example of one level of interleaving (a parent):
+// If a table or index is interleaved, `encoding.interleavedSentinel` is used
+// in place of the family id (a varint) to signal the next component of the
+// key.  An example of one level of interleaving (a parent):
 // /<parent_table_id>/<parent_index_id>/<field_1>/<field_2>/NullDesc/<table_id>/<index_id>/<field_3>/<family>
 //
 // Returns the key and whether any of the encoded values were NULLs.
@@ -324,8 +324,9 @@ func EncodePartialIndexKey(
 				return key, containsNull, nil
 			}
 			colIDs, dirs = colIDs[length:], dirs[length:]
-			// We reuse NotNullDescending (0xfe) as the interleave sentinel.
-			key = encoding.EncodeNotNullDescending(key)
+			// Each ancestor is separated by an interleaved
+			// sentinel (0xfe).
+			key = encoding.EncodeInterleavedSentinel(key)
 		}
 
 		key = encoding.EncodeUvarintAscending(key, uint64(tableDesc.ID))
@@ -412,9 +413,9 @@ func appendEncDatumsToKey(
 // encodings of the given EncDatum values. The values correspond to
 // index.ColumnIDs.
 //
-// If a table or index is interleaved, `encoding.encodedNullDesc` is used in
-// place of the family id (a varint) to signal the next component of the key.
-// An example of one level of interleaving (a parent):
+// If a table or index is interleaved, `encoding.interleavedSentinel` is used
+// in place of the family id (a varint) to signal the next component of the
+// key.  An example of one level of interleaving (a parent):
 // /<parent_table_id>/<parent_index_id>/<field_1>/<field_2>/NullDesc/<table_id>/<index_id>/<field_3>/<family>
 //
 // Note that ExtraColumnIDs are not encoded, so the result isn't always a
@@ -455,8 +456,9 @@ func MakeKeyFromEncDatums(
 			}
 			types, values, dirs = types[length:], values[length:], dirs[length:]
 
-			// We reuse NotNullDescending (0xfe) as the interleave sentinel.
-			key = encoding.EncodeNotNullDescending(key)
+			// Each ancestor is separated by an interleaved
+			// sentinel (0xfe).
+			key = encoding.EncodeInterleavedSentinel(key)
 		}
 
 		key = encoding.EncodeUvarintAscending(key, uint64(tableDesc.ID))
@@ -743,9 +745,9 @@ func DecodeIndexKeyPrefix(
 			key = key[l:]
 		}
 
-		// We reuse NotNullDescending as the interleave sentinel, consume it.
+		// Consume the interleaved sentinel.
 		var ok bool
-		key, ok = encoding.DecodeIfNotNull(key)
+		key, ok = encoding.DecodeIfInterleavedSentinel(key)
 		if !ok {
 			return 0, nil, errors.Errorf("invalid interleave key")
 		}
@@ -791,9 +793,9 @@ func DecodeIndexKey(
 			}
 			types, vals, colDirs = types[length:], vals[length:], colDirs[length:]
 
-			// We reuse NotNullDescending as the interleave sentinel, consume it.
+			// Consume the interleaved sentinel.
 			var ok bool
-			key, ok = encoding.DecodeIfNotNull(key)
+			key, ok = encoding.DecodeIfInterleavedSentinel(key)
 			if !ok {
 				return nil, false, nil
 			}
@@ -813,9 +815,10 @@ func DecodeIndexKey(
 		return nil, false, err
 	}
 
-	// We're expecting a column family id next (a varint). If descNotNull is
-	// actually next, then this key is for a child table.
-	if _, ok := encoding.DecodeIfNotNull(key); ok {
+	// We're expecting a column family id next (a varint). If
+	// interleavedSentinel is actually next, then this key is for a child
+	// table.
+	if _, ok := encoding.DecodeIfInterleavedSentinel(key); ok {
 		return nil, false, nil
 	}
 
@@ -2380,7 +2383,7 @@ func IndexKeyEquivSignature(
 		var isSentinel bool
 		// Peek and discard encoded index values.
 		for {
-			key, isSentinel = encoding.DecodeIfNotNull(key)
+			key, isSentinel = encoding.DecodeIfInterleavedSentinel(key)
 			// We stop once the key is empty or if we encounter a
 			// sentinel for the next TableID-IndexID pair.
 			if len(key) == 0 || isSentinel {
@@ -2407,7 +2410,7 @@ func IndexKeyEquivSignature(
 		// descendant(s).
 		// We insert an interleave sentinel and continue extracting the
 		// next descendant's IDs.
-		signatureBuf = encoding.EncodeNotNullDescending(signatureBuf)
+		signatureBuf = encoding.EncodeInterleavedSentinel(signatureBuf)
 	}
 }
 
@@ -2436,7 +2439,7 @@ func TableEquivSignatures(
 		// signature.
 		signatures[i] = fullSignature
 		// Append Interleave sentinel after every ancestor.
-		fullSignature = encoding.EncodeNotNullDescending(fullSignature)
+		fullSignature = encoding.EncodeInterleavedSentinel(fullSignature)
 	}
 
 	// Encode the table's table and index IDs.

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -597,7 +597,7 @@ func equivSignatures(
 		copy(info.equivSig, curParent)
 		signatures = append(signatures, info.equivSig)
 		if len(info.children) > 0 {
-			curParent = encoding.EncodeNotNullDescending(curParent)
+			curParent = encoding.EncodeInterleavedSentinel(curParent)
 			signatures = equivSignatures(info.children, curParent, signatures)
 		}
 	}


### PR DESCRIPTION
Release notes: none

Make references to encoding/decoding interleaved sentinels as explicit as possible by creating a new constant ("alias") `interleavedSentinel` (from `encodedNotNullDesc`) with its respective `EncodeInterleavedSentinel` (formerly `EncodeNotNulDescending`) and `DecodeIfInterleavedSentinel` (formerly `DecodeIfNotNull`) functions.

I grepped for `EncodeNotNullDescending`, `DecodeIfNotNull`, `NotNull`, `encodedNotNullDesc` and replaced all interleaved sentinel references to them.