### PR TITLE
sql: support SHOW TRACE FOR SELECT ... AS OF SYSTEM TIME 

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -22,6 +22,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -168,8 +169,10 @@ func TestAsOfTime(t *testing.T) {
 	}
 
 	// Subqueries shouldn't work.
-	if _, err := db.Query(fmt.Sprintf("SELECT (SELECT a FROM d.t AS OF SYSTEM TIME %s)", tsVal1)); !testutils.IsError(err, "pq: unexpected AS OF SYSTEM TIME") {
-		t.Fatal(err)
+	_, err := db.Query(
+		fmt.Sprintf("SELECT (SELECT a FROM d.t AS OF SYSTEM TIME %s)", tsVal1))
+	if !testutils.IsError(err, "pq: AS OF SYSTEM TIME not supported in this context") {
+		t.Fatalf("expected not supported, got: %v", err)
 	}
 
 	// Verify that we can read columns in the past that are dropped in the future.
@@ -183,8 +186,10 @@ func TestAsOfTime(t *testing.T) {
 	}
 
 	// Can't use in a transaction.
-	if _, err := db.Query(fmt.Sprintf("BEGIN; SELECT a FROM d.t AS OF SYSTEM TIME %s; COMMIT;", tsVal1)); !testutils.IsError(err, "pq: unexpected AS OF SYSTEM TIME") {
-		t.Fatal(err)
+	_, err = db.Query(
+		fmt.Sprintf("BEGIN; SELECT a FROM d.t AS OF SYSTEM TIME %s; COMMIT;", tsVal1))
+	if !testutils.IsError(err, "pq: AS OF SYSTEM TIME not supported in this context") {
+		t.Fatalf("expected not supported, got: %v", err)
 	}
 }
 
@@ -286,5 +291,62 @@ func TestAsOfRetry(t *testing.T) {
 		t.Fatal(err)
 	} else if i != val2 {
 		t.Fatalf("unexpected val: %v", i)
+	}
+}
+
+// Test that SHOW TRACE FOR SELECT ... AS OF SYSTEM TIME works.
+// AS OF SYSTEM TIME is generally only accepted at the topmost level of a query,
+// but SHOW TRACE FOR is a special case.
+func TestShowTraceAsOfTime(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	const val1 = 456
+	const val2 = 789
+
+	if _, err := db.Exec(`
+		CREATE DATABASE test;
+		CREATE TABLE test.t (x INT);
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := db.Exec("INSERT INTO test.t (x) VALUES ($1)", val1); err != nil {
+		t.Fatal(err)
+	}
+	var tsVal1 string
+	var i int
+	err := db.QueryRow("SELECT x, cluster_logical_timestamp() FROM test.t").Scan(
+		&i, &tsVal1)
+	if err != nil {
+		t.Fatal(err)
+	} else if i != val1 {
+		t.Fatalf("expected %d, got %v", val1, i)
+	}
+	if _, err := db.Exec("UPDATE test.t SET x = $1", val2); err != nil {
+		t.Fatal(err)
+	}
+
+	// We now run a traced historical query and expect to see val1 instead of the
+	// more recent val2. We play some tricks for testing this; we run a SHOW KV
+	// TRACE so that rows like "output row: [<foo>]" are part of the results. And
+	// then we look for a particular such row. Unfortunately we can't easily do
+	// this on the original query because SELECT ... FROM [SHOW TRACE FOR ... AS
+	// OF SYSTEM TIME ... ) WHERE ...  is not supported because of AS OF SYSTEM
+	// TIME limitations. So, we cheat and we use a subsequent SHOW TRACE FOR
+	// SESSION, which will present the results recorded by the first query.
+	query := fmt.Sprintf("SHOW KV TRACE FOR SELECT x FROM test.t AS OF SYSTEM TIME %s", tsVal1)
+	if _, err := db.Exec(query); err != nil {
+		t.Fatal(err)
+	}
+
+	query = fmt.Sprintf("select count(1) from [show kv trace for session] "+
+		"where message = 'output row: [%d]'", val1)
+	if err := db.QueryRow(query).Scan(&i); err != nil {
+		t.Fatal(err)
+	} else if i != 1 {
+		t.Fatalf("expected to find one matching row, got %v", i)
 	}
 }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -2485,7 +2485,14 @@ func isAsOf(session *Session, stmt tree.Statement, max hlc.Timestamp) (*hlc.Time
 	if !ok {
 		return nil, nil
 	}
-	sc, ok := s.Select.(*tree.SelectClause)
+
+	selStmt := s.Select
+	var parenSel *tree.ParenSelect
+	for parenSel, ok = selStmt.(*tree.ParenSelect); ok; parenSel, ok = selStmt.(*tree.ParenSelect) {
+		selStmt = parenSel.Select.Select
+	}
+
+	sc, ok := selStmt.(*tree.SelectClause)
 	if !ok {
 		return nil, nil
 	}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -2477,6 +2477,10 @@ func decimalToHLC(d *apd.Decimal) (hlc.Timestamp, error) {
 // max is a lower bound on what the transaction's timestamp will be. Used to
 // check that the user didn't specify a timestamp in the future.
 func isAsOf(session *Session, stmt tree.Statement, max hlc.Timestamp) (*hlc.Timestamp, error) {
+	if ts, err := isShowTraceForAsOf(session, stmt, max); ts != nil || err != nil {
+		return ts, err
+	}
+
 	s, ok := stmt.(*tree.Select)
 	if !ok {
 		return nil, nil
@@ -2492,6 +2496,16 @@ func isAsOf(session *Session, stmt tree.Statement, max hlc.Timestamp) (*hlc.Time
 	evalCtx := session.evalCtx()
 	ts, err := EvalAsOfTimestamp(&evalCtx, sc.From.AsOf, max)
 	return &ts, err
+}
+
+func isShowTraceForAsOf(
+	session *Session, stmt tree.Statement, max hlc.Timestamp,
+) (*hlc.Timestamp, error) {
+	stf, ok := stmt.(*tree.ShowTrace)
+	if !ok {
+		return nil, nil
+	}
+	return isAsOf(session, stf.Statement, max)
 }
 
 // isSavepoint returns true if stmt is a SAVEPOINT statement.

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -30,7 +30,7 @@ forks blue
 forks red
 forks green
 
-statement error pq: unexpected AS OF SYSTEM TIME
+statement error pq: AS OF SYSTEM TIME not supported in this context
 CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '2016-01-01'
 
 statement error pgcode 42601 CREATE TABLE specifies 3 column names, but data source has 2 columns

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -351,7 +351,7 @@ SELECT * FROM dt2
 statement ok
 CREATE VIEW v AS SELECT d, t FROM t
 
-statement error pq: unexpected AS OF SYSTEM TIME
+statement error pq: AS OF SYSTEM TIME not supported in this context
 CREATE TABLE t2 AS SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
 
 statement ok

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -298,9 +298,10 @@ func (p *planner) SelectClause(
 func (r *renderNode) initFrom(
 	ctx context.Context, parsed *tree.SelectClause, scanVisibility scanVisibility,
 ) error {
-	// AS OF expressions should be handled by the executor.
+	// AS OF expressions are either not supported in this context (e.g. in a view
+	// definition), or they should have been handled by the executor.
 	if parsed.From.AsOf.Expr != nil && !r.planner.avoidCachedDescriptors {
-		return fmt.Errorf("unexpected AS OF SYSTEM TIME")
+		return fmt.Errorf("AS OF SYSTEM TIME not supported in this context")
 	}
 	src, err := r.planner.getSources(ctx, parsed.From.Tables, scanVisibility)
 	if err != nil {

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -81,8 +81,9 @@ func (node *ShowDatabases) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("SHOW DATABASES")
 }
 
-// ShowTrace represents a SHOW TRACE FOR SESSION statement.
+// ShowTrace represents a SHOW TRACE FOR <stmt>/SESSION statement.
 type ShowTrace struct {
+	// If statement is nil, this is asking for the session trace.
 	Statement   Statement
 	OnlyKVTrace bool
 }


### PR DESCRIPTION
Release note: SHOW TRACE FOR SELECT ... AS OF SYSTEM TIME is now
supported.

Before this patch, the Executor wasn't recognizing the AS OF SYSTEM TIME
and so the SELECT was failing with a planning error.

I'm going to cherry-pick the first commit into 1.1 because a client wants it.