### PR TITLE
sql: random numbers with %v rather than %f in json

### DIFF
--- a/pkg/util/json/random.go
+++ b/pkg/util/json/random.go
@@ -35,7 +35,7 @@ func randomJSONString(rng *rand.Rand) interface{} {
 }
 
 func randomJSONNumber(rng *rand.Rand) interface{} {
-	return json.Number(fmt.Sprintf("%f", rand.ExpFloat64()))
+	return json.Number(fmt.Sprintf("%v", rand.ExpFloat64()))
 }
 
 func doRandomJSON(complexity int, rng *rand.Rand) interface{} {


### PR DESCRIPTION
Fixes #20141.

TestDumpRandom checks for round-tripping of dump results, however, our
DECIMALs do not currently round trip if they are some alternative
precision of 0, 0.0000 gets read out as just 0. This shouldn't have been
a problem since the random generator shouldn't generate 0 values, but
since the random string was getting generated with %f, it was getting
truncated to six digits and so we could end up with values which were in
fact logically 0.