### PR TITLE
release-1.1: distsqlrun: Fix MergeJoiner correctness issue with NULL values

### DIFF
--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -345,6 +345,44 @@ func TestMergeJoiner(t *testing.T) {
 				{null, v[5], v[1]},
 			},
 		},
+		{
+			spec: MergeJoinerSpec{
+				LeftOrdering: convertToSpecOrdering(
+					sqlbase.ColumnOrdering{
+						{ColIdx: 0, Direction: encoding.Ascending},
+						{ColIdx: 1, Direction: encoding.Ascending},
+					}),
+				RightOrdering: convertToSpecOrdering(
+					sqlbase.ColumnOrdering{
+						{ColIdx: 0, Direction: encoding.Ascending},
+						{ColIdx: 1, Direction: encoding.Ascending},
+					}),
+				Type: JoinType_FULL_OUTER,
+			},
+			outCols: []uint32{0, 1, 2, 3},
+			inputs: []sqlbase.EncDatumRows{
+				{
+					{null, v[4]},
+					{v[0], null},
+					{v[0], v[1]},
+					{v[2], v[4]},
+				},
+				{
+					{null, v[4]},
+					{v[0], null},
+					{v[0], v[1]},
+					{v[2], v[4]},
+				},
+			},
+			expected: sqlbase.EncDatumRows{
+				{null, v[4], null, null},
+				{null, null, null, v[4]},
+				{v[0], null, null, null},
+				{null, null, v[0], null},
+				{v[0], v[1], v[0], v[1]},
+				{v[2], v[4], v[2], v[4]},
+			},
+		},
 	}
 
 	for _, c := range testCases {

--- a/pkg/sql/distsqlrun/stream_merger.go
+++ b/pkg/sql/distsqlrun/stream_merger.go
@@ -103,6 +103,13 @@ func CompareEncDatumRowForMerge(
 	for i, ord := range leftOrdering {
 		lIdx := ord.ColIdx
 		rIdx := rightOrdering[i].ColIdx
+		// If both datums are NULL, we need to follow SQL semantics where
+		// they are not equal. This differs from our datum semantics where
+		// they are equal.
+		if lhs[lIdx].IsNull() && rhs[rIdx].IsNull() {
+			// We can return either -1 or 1, it does not change the behavior.
+			return -1, nil
+		}
 		cmp, err := lhs[lIdx].Compare(da, evalCtx, &rhs[rIdx])
 		if err != nil {
 			return 0, err

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -198,3 +198,48 @@ query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d)))]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzsmE1v4kgQhu_7K6I67Sq9Et02H0FaydesNMkoM7cRBwf3ECRCo7aRJory30dAZhi7Sb1U2kECcQT8uKor7cdv-pnmrrA3-aMtafiNNCkypCghRSkp6tJI0cK7sS1L51eXbIDr4gcNO4qm88WyWn09UjR23tLwmappNbM0pK_5_cze2bywnhQVtsqns3WRhZ8-5v4pK_IqJ0W3y2p4kWmVGZUlKktp9KLILavXO29veP908ZCXD_Wb1cGRorLKJ5aG-kV9ZKvvaLLWnvm49nbMcFs3kdT94nzVLJnpS5WZy9j1p2_2sb2V84X1tniz_t5X7ljaJ-sn9n83nTfXN7Pfq79f0X_-89PJw_bjh23WbuQ0VJZcqiwVTOUP4r3T-XWLxpR-f809L9ul9_ZY-nK-ayk7O79x_7pF47Ldhfu1wvp4XNZ6q-26rNX2BC4DdQ_mMn12WdQ0TsZl5niU0nqr7Sql1fYESgF1D6YUc1ZK1DRORinJ8Sil9VbbVUqr7QmUAuoeTCnJWSlR0zgZpaTHo5TWW21XKa22J1AKqHswpaRnpURN42SUAk4V72y5cPPS7nVK01mtzBYTu5lj6ZZ-bD97N16X2Xy8XXPr_zULW1abX7ubD9fzzU-rBveHtYmiBzG0SWPopMPTmqVBaR7WOorux9AmiaKveNo06U5t5DW404QTwcSNDG5MXEr3Y-jGxKX0FU-ngmdbCDeebSk9iKEN-HPzdOPZDuguu017_B7v8Xtc85u8H-NiHkYuBjRwMU8jF_M0cvEgxsU8jFwMaOBinkYuBjRw8RW7T3WH36eaf3uCxxPQSMcIBz4GOBIywoGRNf8KBUoGNHIywoGUAY6sDHCkZc3HB-Blzb9IgVoBjdyKcCBXgCO7AhxGXf5tioqDHIDCLsBR2gU5AsVdgAPHaj5J6B6QbJAlRJLlaShZgCPJ8jiULMCRZCU5SkpDyYqSlBSHkhVlqRAPUoVIskGqEEmWp6FkAY4ky-NQsjyOJGskgUpKI8kiHEgW4EiyCEeHCkGqqO1YY3jJmiBVSCQLaCRZhAPJAhxJFuFAskaSqKQ0kizCgWQBjiQLcCRZE8QKiWRNkCokkgU0kizCgWQBjiQLcChZSaCS0lCyokAlxaFkRYEqxINUUZfsAEhWckQTPi6iMxoxjiQrOqUR40iykkQlpaFkRYlKikPJihJVeHAexApWsqOXv34GAAD___sgIII=
+
+
+# Test that the distSQL MergeJoiner follows SQL NULL semantics for ON predicate equivilance.
+# The use of sorts here force
+
+statement ok
+CREATE TABLE distsql_mj_test (k INT, v INT)
+
+statement ok
+INSERT INTO distsql_mj_test VALUES (0, NULL), (0, 1), (2, 4), (NULL, 4)
+
+# If SQL NULL semantics are not followed, NULL = NULL is truthy. This makes the rows with NULL also appear in the inner join.
+
+query IIII rowsort
+SELECT l.k, l.v, r.k, r.v FROM (SELECT * FROM distsql_mj_test ORDER BY k, v) l INNER JOIN (SELECT * FROM distsql_mj_test ORDER BY k, v) r ON l.k = r.k AND l.v = r.v
+----
+0  1  0  1
+2  4  2  4
+
+statement ok
+DELETE FROM distsql_mj_test WHERE TRUE;
+
+statement ok
+INSERT INTO distsql_mj_test VALUES (0, NULL), (1, NULL), (2, NULL)
+
+# We should not have any results for values with NULLs
+query IIII rowsort
+SELECT l.k, l.v, r.k, r.v FROM (SELECT * FROM distsql_mj_test ORDER BY k, v) l INNER JOIN (SELECT * FROM distsql_mj_test ORDER BY k, v) r ON l.k = r.k AND l.v = r.v
+----
+
+statement ok
+DELETE FROM distsql_mj_test WHERE TRUE;
+
+statement ok
+INSERT INTO distsql_mj_test VALUES (NULL)
+
+# We shouldn't expect a row of (NULL, NULL), otherwise NULL = NULL was joined.
+query II rowsort
+SELECT l.k, r.k FROM (SELECT * FROM distsql_mj_test ORDER BY k) l INNER JOIN (SELECT * FROM distsql_mj_test ORDER BY k) r ON l.k = r.k
+----
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT l.k, r.k FROM (SELECT * FROM distsql_mj_test ORDER BY k) l INNER JOIN (SELECT * FROM distsql_mj_test ORDER BY k) r ON l.k = r.k)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzMkkFr4zAQhe_7K8KcdokWIifOwVDwNSVNStqeSgiuNXVVHMkdjaEl5L8XW4ckplaaQ6E3aTTfm_fE7MBYhYtsiw6SR5AgIIa1gIpsjs5Zasq-aabeIRkJ0KaquSmvBeSWEJIdsOYSIYGF_W8rEKCQM122TXsBtuYD4jgrEJLpXhzJyrDsffZU4gozhXQiDhXpbUYfqdKO3Vu52b5uGB2DgBUahZQMUikGi4f5HPqMyEuM3FnirodUDnvFo9-ScvyTKSe94gfN2lhSSKi623G-5QuHN0gFXlttujZLfOa_qRz-uyJdvPgjCFjW3H5SOu4NEZ-EOLPnK3SVNQ6_teqjJgGqAv2POFtTjrdk83aMvy5bri0odOxfp_4yM_6pMXgMyyAcheEoCMcnsOzC4yA8CU-eXDA56sJxEB51Jq_3fz4DAAD__1iyncU=


### PR DESCRIPTION
This cherrypicks the fix from #20090.

---

Previously, when a distSQL merge join was being executed the comparison
check was using Datum.Compare while processing the incoming streams we
are joining on.

This is problematic when both sides of the stream have a NULL value,
because this comparison is considered equal which is a violation of the
semantics of equals (=) with SQL NULLs.

Unfortunately, this bug was present before distSQL merge joins were
being planned (#17214) and so it exists in 1.1.0.