### PR TITLE
cherrypick-1.1: sqlccl: correctly mutate table descriptors during resumed RESTORE

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -130,9 +130,7 @@ func allocateTableRewrites(
 			if index.ForeignKey.IsSet() {
 				to := index.ForeignKey.Table
 				if _, ok := tablesByID[to]; !ok {
-					if _, ok := opts[restoreOptSkipMissingFKs]; ok {
-						index.ForeignKey = sqlbase.ForeignKeyReference{}
-					} else {
+					if _, ok := opts[restoreOptSkipMissingFKs]; !ok {
 						return errors.Errorf(
 							"cannot restore table %q without referenced table %d (or %q option)",
 							table.Name, to, restoreOptSkipMissingFKs,
@@ -285,10 +283,12 @@ func rewriteTableDescs(tables []*sqlbase.TableDescriptor, tableRewrites tableRew
 				to := index.ForeignKey.Table
 				if indexRewrite, ok := tableRewrites[to]; ok {
 					index.ForeignKey.Table = indexRewrite.TableID
+				} else {
+					// If indexRewrite doesn't exist, the user has specified
+					// restoreOptSkipMissingFKs. Error checking in the case the user hasn't has
+					// already been done in allocateTableRewrites.
+					index.ForeignKey = sqlbase.ForeignKeyReference{}
 				}
-				// If indexRewrite doesn't exist, either the user has specified
-				// restoreOptSkipMissingFKs, or we've already errored in
-				// allocateTableRewrites. Move on.
 
 				// TODO(dt): if there is an existing (i.e. non-restoring) table with
 				// a db and name matching the one the FK pointed to at backup, should


### PR DESCRIPTION
If a RESTORE was resumed after a pause or node failure, it would
attempt to regenerate the sql descriptors it was using. However it did
this in a way that was different than the first invocation that didn't
use the same resume codepath. This mutation was to remove the FK on
indexes if the user requested it. Move the mutation to a downstream
place so both invocation paths will mutate index descriptors in the
same way.

Release note: correctly resume RESTORE jobs that skip foreign keys.

Cherrypick of #20092 