### PR TITLE
cherry-pick 1.1: sql: fix handling of errors on Flush

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1204,7 +1204,12 @@ func runTxnAttempt(
 	// statements. We also want future ResultsSentToClient() calls to return
 	// false.
 	if err := txnState.txnResults.Flush(session.Ctx()); err != nil {
-		err = txnState.updateStateAndCleanupOnErr(err, e)
+		// If there's a KV txn open, we have to roll it back.
+		// If there isn't, there's nothing to do. The state of the session doesn't
+		// matter any more after a communication error.
+		if txnState.state.kvTxnIsOpen() {
+			err = txnState.updateStateAndCleanupOnErr(err, e)
+		}
 		return nil, false, err
 	}
 


### PR DESCRIPTION
cherry-pick of #20175

Release note: Fix a possible crash due to statements finishing execution
after the client connection has been closed.

The Executor Flush()es results to the client on occasions. Before this
patch, if the flush failed (because the client conn had died) we'd
always try to roll back the kv txn. If there was no kv txn (e.g. because
it was a COMMIT that we were flushing), the server would panic. This
patch makes the rollback conditional on the state.

Fixes #20007