### PR TITLE
cli: pretty-print intents in `debug keys`

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -92,7 +92,7 @@ func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (*engine.R
 }
 
 func printKey(kv engine.MVCCKeyValue) (bool, error) {
-	fmt.Printf("%s", kv.Key)
+	fmt.Printf("%s %s: ", kv.Key.Timestamp, kv.Key.Key)
 	if debugCtx.sizes {
 		fmt.Printf(" %d %d", len(kv.Key.Key), len(kv.Value))
 	}
@@ -101,11 +101,8 @@ func printKey(kv engine.MVCCKeyValue) (bool, error) {
 }
 
 func printKeyValue(kv engine.MVCCKeyValue) (bool, error) {
-	if kv.Key.Timestamp != (hlc.Timestamp{}) {
-		fmt.Printf("%s %s: ", kv.Key.Timestamp, kv.Key.Key)
-	} else {
-		fmt.Printf("%s: ", kv.Key.Key)
-	}
+	fmt.Printf("%s %s: ", kv.Key.Timestamp, kv.Key.Key)
+
 	if debugCtx.sizes {
 		fmt.Printf("%d %d: ", len(kv.Key.Key), len(kv.Value))
 	}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -112,6 +112,7 @@ func printKeyValue(kv engine.MVCCKeyValue) (bool, error) {
 		tryMeta,
 		tryTxn,
 		tryRangeIDKey,
+		tryIntent,
 	}
 	for _, decoder := range decoders {
 		out, err := decoder(kv)
@@ -353,6 +354,21 @@ func printRangeDescriptor(kv engine.MVCCKeyValue) (bool, error) {
 		fmt.Printf("%s %q: %s\n", kv.Key.Timestamp, kv.Key.Key, out)
 	}
 	return false, nil
+}
+
+func tryIntent(kv engine.MVCCKeyValue) (string, error) {
+	if len(kv.Value) == 0 {
+		return "", errors.New("empty")
+	}
+	var meta enginepb.MVCCMetadata
+	if err := protoutil.Unmarshal(kv.Value, &meta); err != nil {
+		return "", err
+	}
+	s := fmt.Sprintf("%+v", meta)
+	if meta.Txn != nil {
+		s = meta.Txn.Timestamp.String() + " " + s
+	}
+	return s, nil
 }
 
 func getProtoValue(data []byte, msg protoutil.Message) error {


### PR DESCRIPTION
Can improve this by pretty-printing the inlined value, but may not be
necessary for a while.