### PR TITLE
metrics: write vars to temporary buffer.

### DIFF
--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -15,6 +15,7 @@
 package status
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -227,7 +228,20 @@ func (mr *MetricsRecorder) scrapePrometheusLocked() {
 }
 
 // PrintAsText writes the current metrics values as plain-text to the writer.
+// We write metrics to a temporary buffer which is then copied to the writer.
+// This is to avoid hanging requests from holding the lock.
 func (mr *MetricsRecorder) PrintAsText(w io.Writer) error {
+	var buf bytes.Buffer
+	if err := mr.lockAndPrintAsText(&buf); err != nil {
+		return err
+	}
+	_, err := buf.WriteTo(w)
+	return err
+}
+
+// lockAndPrintAsText grabs the recorder lock and generates the prometheus
+// metrics page.
+func (mr *MetricsRecorder) lockAndPrintAsText(w io.Writer) error {
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
 	mr.scrapePrometheusLocked()


### PR DESCRIPTION
Fixes #20186.

We have seen cases of requests hanging (see #20118) while trying to
write the contents of `/_status/vars`. Since this was done while holding
the lock, all further requests failed.

This workaround allows a single connection to hang without blocking
future requests. It does nothing to detect/fix hangs and will actually
hide such issues by not causing a goroutine/filedescriptor blowup.