### PR TITLE
sql/stats: Add new cache for system.table_statistics

### DIFF
--- a/pkg/sql/stats/main_test.go
+++ b/pkg/sql/stats/main_test.go
@@ -1,0 +1,33 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -1,0 +1,270 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/aws/aws-sdk-go/aws/awsutil"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/pkg/errors"
+)
+
+// A TableStatistic object holds a statistic for a particular column or group
+// of columns. It mirrors the structure of the system.table_statistics table.
+type TableStatistic struct {
+	// The ID of the table.
+	TableID sqlbase.ID
+
+	// The ID for this statistic.  It need not be globally unique,
+	// but must be unique for this table.
+	StatisticID uint32
+
+	// Optional user-defined name for the statistic.
+	Name string
+
+	// The column ID(s) for which this statistic is generated.
+	ColumnIDs []sqlbase.ColumnID
+
+	// The time at which the statistic was created.
+	CreatedAt time.Time
+
+	// The total number of rows in the table.
+	RowCount uint64
+
+	// The estimated number of distinct values of the columns in ColumnIDs.
+	DistinctCount uint64
+
+	// The number of rows that have a NULL in any of the columns in ColumnIDs.
+	NullCount uint64
+
+	// Optional, and can only be set if there is a single column in ColumnIDs.
+	// Defines a histogram of the distribution of values in the column.
+	Histogram *HistogramData
+}
+
+func (s TableStatistic) String() string {
+	return awsutil.Prettify(s)
+}
+
+// A TableStatisticsCache is a cache of TableStatistic objects, keyed by
+// table ID.
+type TableStatisticsCache struct {
+	// NB: This can't be a RWMutex for lookup because UnorderedCache.Get
+	// manipulates an internal LRU list.
+	mu struct {
+		syncutil.Mutex
+		cache *cache.UnorderedCache
+	}
+	ClientDB    *client.DB
+	SQLExecutor sqlutil.InternalExecutor
+}
+
+// NewTableStatisticsCache creates a new TableStatisticsCache of the given size.
+// The underlying cache internally uses a hash map, so lookups are cheap.
+func NewTableStatisticsCache(
+	size int, db *client.DB, sqlExecutor sqlutil.InternalExecutor,
+) *TableStatisticsCache {
+	tableStatsCache := &TableStatisticsCache{
+		ClientDB:    db,
+		SQLExecutor: sqlExecutor,
+	}
+	tableStatsCache.mu.cache = cache.NewUnorderedCache(cache.Config{
+		Policy:      cache.CacheLRU,
+		ShouldEvict: func(s int, key, value interface{}) bool { return s > size },
+	})
+	return tableStatsCache
+}
+
+// LookupTableStats returns the cached statistics of the given table ID.
+// The second return value is true if the stats were found in the
+// cache, and false otherwise.
+func (sc *TableStatisticsCache) LookupTableStats(
+	ctx context.Context, tableID sqlbase.ID,
+) ([]*TableStatistic, bool) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	if v, ok := sc.mu.cache.Get(tableID); ok {
+		if log.V(2) {
+			log.Infof(ctx, "r%d: lookup statistics for table: %s", tableID, v)
+		}
+		return v.([]*TableStatistic), true
+	}
+	if log.V(2) {
+		log.Infof(ctx, "r%d: lookup statistics for table: not found", tableID)
+	}
+	return nil, false
+}
+
+// Refresh updates the cached statistics for the given table ID
+// by issuing a query to system.table_statistics, and returns the statistics.
+func (sc *TableStatisticsCache) Refresh(
+	ctx context.Context, tableID sqlbase.ID,
+) ([]*TableStatistic, error) {
+	tableStatistics, err := sc.getTableStatistics(ctx, tableID)
+	if err != nil {
+		return nil, err
+	}
+
+	if log.V(2) {
+		log.Infof(ctx, "r%d: updating statistics for table: %s", tableID, tableStatistics)
+	}
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.mu.cache.Add(tableID, tableStatistics)
+	return tableStatistics, nil
+}
+
+// GetTableStats is a convenience function to look up statistics for the
+// requested table ID in the cache using LookupTableStats, and if the stats
+// are not present in the cache, it looks them up in system.table_statistics
+// using Refresh.
+func (sc *TableStatisticsCache) GetTableStats(
+	ctx context.Context, tableID sqlbase.ID,
+) ([]*TableStatistic, error) {
+	if stats, ok := sc.LookupTableStats(ctx, tableID); ok {
+		return stats, nil
+	}
+	return sc.Refresh(ctx, tableID)
+}
+
+// Invalidate invalidates the cached statistics for the given table ID.
+func (sc *TableStatisticsCache) Invalidate(ctx context.Context, tableID sqlbase.ID) {
+	if log.V(2) {
+		log.Infof(ctx, "r%d: evicting statistics for table", tableID)
+	}
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.mu.cache.Del(tableID)
+}
+
+const (
+	tableIDIndex = iota
+	statisticsIDIndex
+	nameIndex
+	columnIDsIndex
+	createdAtIndex
+	rowCountIndex
+	distinctCountIndex
+	nullCountIndex
+	histogramIndex
+	statsLen
+)
+
+// parseStats converts the given datums to a TableStatistic object. It only includes
+// a histogram in the output if the histogram in datums is non-null and
+// includeHistogram is true.
+func parseStats(datums tree.Datums, includeHistogram bool) (*TableStatistic, error) {
+	if datums == nil || datums.Len() == 0 {
+		return nil, nil
+	}
+
+	// Validate the input length.
+	if datums.Len() != statsLen {
+		return nil, errors.Errorf("%d values returned from table statistics lookup. Expected %d", datums.Len(), statsLen)
+	}
+
+	// Validate the input types.
+	expectedTypes := []struct {
+		fieldName    string
+		fieldIndex   int
+		expectedType types.T
+		nullable     bool
+	}{
+		{"tableID", tableIDIndex, types.Int, false},
+		{"statisticsID", statisticsIDIndex, types.Int, false},
+		{"name", nameIndex, types.String, true},
+		{"columnIDs", columnIDsIndex, types.TArray{Typ: types.Int}, false},
+		{"createdAt", createdAtIndex, types.Timestamp, false},
+		{"rowCount", rowCountIndex, types.Int, false},
+		{"distinctCount", distinctCountIndex, types.Int, false},
+		{"nullCount", nullCountIndex, types.Int, false},
+		{"histogram", histogramIndex, types.Bytes, true},
+	}
+	for _, v := range expectedTypes {
+		if datums[v.fieldIndex].ResolvedType() != v.expectedType &&
+			(!v.nullable || datums[v.fieldIndex].ResolvedType() != types.Null) {
+			return nil, errors.Errorf("%s returned from table statistics lookup has type %s. Expected %s",
+				v.fieldName, datums[v.fieldIndex].ResolvedType(), v.expectedType)
+		}
+	}
+
+	// Extract datum values.
+	tableStatistic := &TableStatistic{
+		TableID:       sqlbase.ID((int32)(*datums[tableIDIndex].(*tree.DInt))),
+		StatisticID:   (uint32)(*datums[statisticsIDIndex].(*tree.DInt)),
+		CreatedAt:     datums[createdAtIndex].(*tree.DTimestamp).Time,
+		RowCount:      (uint64)(*datums[rowCountIndex].(*tree.DInt)),
+		DistinctCount: (uint64)(*datums[distinctCountIndex].(*tree.DInt)),
+		NullCount:     (uint64)(*datums[nullCountIndex].(*tree.DInt)),
+	}
+	columnIDs := datums[columnIDsIndex].(*tree.DArray)
+	tableStatistic.ColumnIDs = make([]sqlbase.ColumnID, len(columnIDs.Array))
+	for i, d := range columnIDs.Array {
+		tableStatistic.ColumnIDs[i] = sqlbase.ColumnID((int32)(*d.(*tree.DInt)))
+	}
+	if datums[nameIndex].ResolvedType() == types.String {
+		tableStatistic.Name = string(*datums[nameIndex].(*tree.DString))
+	}
+	if includeHistogram && datums[histogramIndex].ResolvedType() == types.Bytes {
+		tableStatistic.Histogram = &HistogramData{}
+		if err := protoutil.Unmarshal([]byte(*datums[histogramIndex].(*tree.DBytes)), tableStatistic.Histogram); err != nil {
+			return nil, err
+		}
+	}
+
+	return tableStatistic, nil
+}
+
+// getTableStatistics retrieves the statistics in system.table_statistics
+// for the given table ID.
+func (sc *TableStatisticsCache) getTableStatistics(
+	ctx context.Context, tableID sqlbase.ID,
+) ([]*TableStatistic, error) {
+	const getTableStatisticsStmt = `
+SELECT "tableID", "statisticID", name, "columnIDs", "createdAt", "rowCount", "distinctCount", "nullCount", histogram
+FROM system.table_statistics
+WHERE "tableID" = $1
+`
+	var rows []tree.Datums
+	if err := sc.ClientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		var err error
+		rows, err = sc.SQLExecutor.QueryRowsInTransaction(ctx, "get-table-statistics", txn, getTableStatisticsStmt, tableID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	var statsList []*TableStatistic
+	for _, row := range rows {
+		stats, err := parseStats(row, true /* includeHistogram */)
+		if err != nil {
+			return nil, err
+		}
+		statsList = append(statsList, stats)
+	}
+
+	return statsList, nil
+}

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -1,0 +1,240 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats_test
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"time"
+
+	"reflect"
+
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/pkg/errors"
+)
+
+func insertTableStats(
+	ctx context.Context,
+	db *client.DB,
+	sqlExecutor sqlutil.InternalExecutor,
+	stats *stats.TableStatistic,
+) error {
+	insertStatsStmt := `
+INSERT INTO system.table_statistics ("tableID", "statisticID", name, "columnIDs", "createdAt",
+	"rowCount", "distinctCount", "nullCount", histogram)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+`
+	columnIDs := tree.NewDArray(types.Int)
+	for _, id := range stats.ColumnIDs {
+		if err := columnIDs.Append(tree.NewDInt(tree.DInt(int(id)))); err != nil {
+			return err
+		}
+	}
+
+	args := []interface{}{
+		stats.TableID,
+		stats.StatisticID,
+		nil, // name
+		columnIDs,
+		stats.CreatedAt,
+		stats.RowCount,
+		stats.DistinctCount,
+		stats.NullCount,
+		nil, // histogram
+	}
+	if len(stats.Name) != 0 {
+		args[2] = stats.Name
+	}
+	if stats.Histogram != nil {
+		histogramBytes, err := protoutil.Marshal(stats.Histogram)
+		if err != nil {
+			return err
+		}
+		args[8] = histogramBytes
+	}
+
+	var rows int
+	if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		var err error
+		rows, err = sqlExecutor.ExecuteStatementInTransaction(ctx, "insert-table-stats", txn, insertStatsStmt, args...)
+		return err
+	}); err != nil {
+		return err
+	}
+	if rows != 1 {
+		return errors.Errorf("%d rows affected by stats insertion; expected exactly one row affected.", rows)
+	}
+	return nil
+
+}
+
+func checkStatsForTable(
+	ctx context.Context,
+	db *client.DB,
+	sc *stats.TableStatisticsCache,
+	expected []*stats.TableStatistic,
+	tableID sqlbase.ID,
+) error {
+	// Initially the stats won't be in the cache.
+	if statsList, ok := sc.LookupTableStats(ctx, tableID); ok {
+		return errors.Errorf("lookup of missing key %d returned: %s", tableID, statsList)
+	}
+
+	// Perform the lookup and refresh, and confirm the
+	// returned stats match the expected values.
+	statsList, err := sc.GetTableStats(ctx, tableID)
+	if err != nil {
+		return errors.Errorf(err.Error())
+	} else {
+		testutils.SortStructs(statsList, "TableID", "StatisticID")
+		if !reflect.DeepEqual(statsList, expected) {
+			return errors.Errorf("for lookup of key %d, expected stats %s, got %s", tableID, expected, statsList)
+		}
+	}
+
+	// Now the stats should be in the cache.
+	if _, ok := sc.LookupTableStats(ctx, tableID); !ok {
+		return errors.Errorf("for lookup of key %d, expected stats %s", tableID, expected)
+	}
+	return nil
+}
+
+func TestTableStatisticsCache(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	ex := sql.InternalExecutor{LeaseManager: s.LeaseManager().(*sql.LeaseManager)}
+
+	expStatsList := []stats.TableStatistic{
+		{
+			TableID:       sqlbase.ID(0),
+			StatisticID:   0,
+			Name:          "table0",
+			ColumnIDs:     []sqlbase.ColumnID{1, 2},
+			CreatedAt:     time.Date(2010, 11, 20, 11, 35, 23, 0, time.UTC),
+			RowCount:      32,
+			DistinctCount: 30,
+			NullCount:     0,
+			Histogram: &stats.HistogramData{Buckets: []stats.HistogramData_Bucket{
+				{NumEq: 3, NumRange: 30, UpperBound: encoding.EncodeVarintAscending(nil, 3000)}},
+			},
+		},
+		{
+			TableID:       sqlbase.ID(0),
+			StatisticID:   1,
+			ColumnIDs:     []sqlbase.ColumnID{3},
+			CreatedAt:     time.Date(2010, 11, 20, 11, 35, 23, 0, time.UTC),
+			RowCount:      32,
+			DistinctCount: 5,
+			NullCount:     5,
+		},
+		{
+			TableID:       sqlbase.ID(1),
+			StatisticID:   0,
+			ColumnIDs:     []sqlbase.ColumnID{0},
+			CreatedAt:     time.Date(2017, 11, 20, 11, 35, 23, 0, time.UTC),
+			RowCount:      320000,
+			DistinctCount: 300000,
+			NullCount:     100,
+		},
+		{
+			TableID:       sqlbase.ID(2),
+			StatisticID:   34,
+			Name:          "table2",
+			ColumnIDs:     []sqlbase.ColumnID{1, 2, 3},
+			CreatedAt:     time.Date(2001, 1, 10, 5, 25, 14, 0, time.UTC),
+			RowCount:      0,
+			DistinctCount: 0,
+			NullCount:     0,
+		},
+	}
+
+	// Sort the expected stats so they can later be compared with the returned
+	// stats using reflect.DeepEqual.
+	testutils.SortStructs(expStatsList, "TableID", "StatisticID")
+
+	// Insert the stats into system.table_statistics
+	// and store them in a map keyed by table ID for fast retrieval.
+	expected := make(map[sqlbase.ID][]*stats.TableStatistic)
+	for i := range expStatsList {
+		stats := &expStatsList[i]
+		if err := insertTableStats(ctx, db, ex, stats); err != nil {
+			t.Fatal(err)
+		}
+		expected[stats.TableID] = append(expected[stats.TableID], stats)
+	}
+	// Add another TableID for which we don't have stats.
+	expected[sqlbase.ID(3)] = nil
+
+	// Collect the tableIDs and sort them so we can iterate over them in a
+	// consistent order (Go randomizes the order of iteration over maps).
+	var tableIDs sqlbase.IDs
+	for tableID := range expected {
+		tableIDs = append(tableIDs, tableID)
+	}
+	sort.Sort(tableIDs)
+
+	// Create a cache and iteratively query the cache for each tableID. This
+	// will result in the cache getting populated. When the cache size is
+	// exceeded, entries should be evicted according to the LRU policy.
+	cacheSize := 2
+	sc := stats.NewTableStatisticsCache(cacheSize, db, ex)
+	for _, tableID := range tableIDs {
+		if err := checkStatsForTable(ctx, db, sc, expected[tableID], tableID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Table IDs 0 and 1 should have been evicted since the cache size is 2.
+	tableIDs = []sqlbase.ID{sqlbase.ID(0), sqlbase.ID(1)}
+	for _, tableID := range tableIDs {
+		if statsList, ok := sc.LookupTableStats(ctx, tableID); ok {
+			t.Fatalf("lookup of evicted key %d returned: %s", tableID, statsList)
+		}
+	}
+
+	// Table IDs 2 and 3 should still be in the cache.
+	tableIDs = []sqlbase.ID{sqlbase.ID(2), sqlbase.ID(3)}
+	for _, tableID := range tableIDs {
+		if _, ok := sc.LookupTableStats(ctx, tableID); !ok {
+			t.Fatalf("for lookup of key %d, expected stats %s", tableID, expected[tableID])
+		}
+	}
+
+	// After invalidation Table ID 2 should be gone.
+	tableID := sqlbase.ID(2)
+	sc.Invalidate(ctx, tableID)
+	if statsList, ok := sc.LookupTableStats(ctx, tableID); ok {
+		t.Fatalf("lookup of invalidated key %d returned: %s", tableID, statsList)
+	}
+}


### PR DESCRIPTION
Add a new cache for the system.table_statistics table called
TableStatisticsCache. The cache is keyed by table ID, and each
entry stores all the statistics for a given table. The cache is
responsible for querying the underlying database in case of a
cache miss or requested Refresh. The eviction policy is LRU, and
entries are evicted when the cache exceeds a specified size.

For simplicity, this first implementation includes histogram data
in each entry. In the next iteration, we will split this cache into
two underlying caches: one keyed by table ID, and one keyed by
(tableID, statisticID). The former will not include histogram data,
but the latter will.

See docs/RFCS/20170908_sql_optimizer_statistics.md for additional
details.

Relsease note (sql): Added a cache for the system.table_statistics
table.