### PR TITLE
sql: support json_object_keys of JSON builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -752,9 +752,13 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>json_array_elements_text(input: jsonb) &rarr; setof tuple{string}</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of text values.</p>
 </span></td></tr>
+<tr><td><code>json_object_keys(input: jsonb) &rarr; setof tuple{string}</code></td><td><span class="funcdesc"><p>Returns sorted set of keys in the outermost JSON object.</p>
+</span></td></tr>
 <tr><td><code>jsonb_array_elements(input: jsonb) &rarr; setof tuple{jsonb}</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of JSON values.</p>
 </span></td></tr>
 <tr><td><code>jsonb_array_elements_text(input: jsonb) &rarr; setof tuple{string}</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of text values.</p>
+</span></td></tr>
+<tr><td><code>jsonb_object_keys(input: jsonb) &rarr; setof tuple{string}</code></td><td><span class="funcdesc"><p>Returns sorted set of keys in the outermost JSON object.</p>
 </span></td></tr>
 <tr><td><code>oid(int: <a href="int.html">int</a>) &rarr; oid</code></td><td><span class="funcdesc"><p>Converts an integer to an OID.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -148,3 +148,38 @@ SELECT json_array_elements_text('{"1": 2}'::JSON)
 
 query error pq: jsonb_array_elements_text\(\): cannot be called on a non-array
 SELECT jsonb_array_elements_text('{"1": 2}'::JSON)
+
+
+## json_object_keys and jsonb_object_keys
+
+query T
+SELECT json_object_keys('{"1": 2, "3": 4}'::JSON)
+----
+1
+3
+
+query T
+SELECT jsonb_object_keys('{"1": 2, "3": 4}'::JSON)
+----
+1
+3
+
+query T
+SELECT json_object_keys('{}'::JSON)
+----
+
+query T
+SELECT json_object_keys('{"\"1\"": 2}'::JSON)
+----
+"1"
+
+# Keys are sorted.
+query T
+SELECT json_object_keys('{"a": 1, "1": 2, "3": {"4": 5, "6": 7}}'::JSON)
+----
+1
+3
+a
+
+query error pq: json_object_keys\(\): cannot iterate keys of non-object
+SELECT json_object_keys('[1, 2, 3]'::JSON)

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -105,6 +105,8 @@ var Generators = map[string][]tree.Builtin{
 	"jsonb_array_elements":      {jsonArrayElementsImpl},
 	"json_array_elements_text":  {jsonArrayElementsTextImpl},
 	"jsonb_array_elements_text": {jsonArrayElementsTextImpl},
+	"json_object_keys":          {jsonObjectKeysImpl},
+	"jsonb_object_keys":         {jsonObjectKeysImpl},
 }
 
 func makeGeneratorBuiltin(
@@ -439,4 +441,58 @@ func (g *jsonArrayGenerator) Values() tree.Datums {
 			JSON: val,
 		},
 	}
+}
+
+// jsonObjectKeysImpl is a key generator of a JSON object.
+var jsonObjectKeysImpl = makeGeneratorBuiltin(
+	tree.ArgTypes{{"input", types.JSON}},
+	jsonObjectKeysGeneratorType,
+	makeJSONObjectKeysGenerator,
+	"Returns sorted set of keys in the outermost JSON object.",
+)
+
+var jsonObjectKeysGeneratorType = types.TTable{
+	Cols:   types.TTuple{types.String},
+	Labels: []string{"json_object_keys"},
+}
+
+type jsonObjectKeysGenerator struct {
+	iter    *json.ObjectKeyIterator
+	nextVal string
+}
+
+func makeJSONObjectKeysGenerator(
+	_ *tree.EvalContext, args tree.Datums,
+) (tree.ValueGenerator, error) {
+	target := tree.MustBeDJSON(args[0])
+	iter, err := target.IterObjectKey()
+	if err != nil {
+		return nil, err
+	}
+	return &jsonObjectKeysGenerator{
+		iter: iter,
+	}, nil
+}
+
+// ResolvedType implements the tree.ValueGenerator interface.
+func (g *jsonObjectKeysGenerator) ResolvedType() types.TTable {
+	return jsonObjectKeysGeneratorType
+}
+
+// Start implements the tree.ValueGenerator interface.
+func (g *jsonObjectKeysGenerator) Start() error { return nil }
+
+// Close implements the tree.ValueGenerator interface.
+func (g *jsonObjectKeysGenerator) Close() {}
+
+// Next implements the tree.ValueGenerator interface.
+func (g *jsonObjectKeysGenerator) Next() (bool, error) {
+	ok, val := g.iter.Next()
+	g.nextVal = val
+	return ok, nil
+}
+
+// Values implements the tree.ValueGenerator interface.
+func (g *jsonObjectKeysGenerator) Values() tree.Datums {
+	return tree.Datums{tree.NewDString(g.nextVal)}
 }

--- a/pkg/util/json/iterator.go
+++ b/pkg/util/json/iterator.go
@@ -1,0 +1,31 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package json
+
+// ObjectKeyIterator is an iterator to access the keys of an object.
+type ObjectKeyIterator struct {
+	src jsonObject
+	idx int
+}
+
+// Next returns true and the next key in the iterator if one exists,
+// and false otherwise.
+func (it *ObjectKeyIterator) Next() (bool, string) {
+	it.idx++
+	if it.idx >= len(it.src) {
+		return false, ""
+	}
+	return true, string(it.src[it.idx].k)
+}

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -89,6 +89,10 @@ type JSON interface {
 	// Exists implements the `?` operator.
 	Exists(string) bool
 
+	// IterObjectKey returns an ObjectKeyIterator, and it returns error if the obj
+	// is not an object.
+	IterObjectKey() (*ObjectKeyIterator, error)
+
 	// isScalar returns whether the JSON document is null, true, false, a string,
 	// or a number.
 	isScalar() bool
@@ -699,6 +703,34 @@ func (j jsonArray) Exists(s string) bool {
 }
 func (j jsonObject) Exists(s string) bool {
 	return j.FetchValKey(s) != nil
+}
+
+var errIterateKeysNonObject = pgerror.NewError(pgerror.CodeInvalidParameterValueError,
+	"cannot iterate keys of non-object")
+
+func (jsonNull) IterObjectKey() (*ObjectKeyIterator, error) {
+	return nil, errIterateKeysNonObject
+}
+func (jsonTrue) IterObjectKey() (*ObjectKeyIterator, error) {
+	return nil, errIterateKeysNonObject
+}
+func (jsonFalse) IterObjectKey() (*ObjectKeyIterator, error) {
+	return nil, errIterateKeysNonObject
+}
+func (jsonNumber) IterObjectKey() (*ObjectKeyIterator, error) {
+	return nil, errIterateKeysNonObject
+}
+func (jsonString) IterObjectKey() (*ObjectKeyIterator, error) {
+	return nil, errIterateKeysNonObject
+}
+func (jsonArray) IterObjectKey() (*ObjectKeyIterator, error) {
+	return nil, errIterateKeysNonObject
+}
+func (j jsonObject) IterObjectKey() (*ObjectKeyIterator, error) {
+	return &ObjectKeyIterator{
+		src: j,
+		idx: -1,
+	}, nil
 }
 
 func (jsonNull) isScalar() bool   { return true }


### PR DESCRIPTION
I implemented `json{b}_object_keys()` of JSON builtin functions.
However, I'm anxious that `json_object_keys()` returns sorted keys depending on the internal data structure. PostgreSQL's `json_object_keys()` returns keys in a sequential order.

Ref: #20120 