### PR TITLE
sql: fix wrong results of json_typeof boolean

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -45,22 +45,22 @@ array
 query T
 SELECT json_typeof('true'::JSON)
 ----
-true
+boolean
 
 query T
 SELECT jsonb_typeof('true'::JSON)
 ----
-true
+boolean
 
 query T
 SELECT json_typeof('false'::JSON)
 ----
-false
+boolean
 
 query T
 SELECT jsonb_typeof('false'::JSON)
 ----
-false
+boolean
 
 query T
 SELECT json_typeof('null'::JSON)

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -80,9 +80,6 @@ type JSON interface {
 	// RemoveIndex implements the `-` operator for ints.
 	RemoveIndex(idx int) (JSON, error)
 
-	// TypeAsText returns the type of JSON document as a string.
-	TypeAsText() string
-
 	// AsText returns the JSON document as a string, with quotes around strings removed, and null as nil.
 	AsText() *string
 
@@ -649,14 +646,6 @@ func (jsonTrue) RemoveIndex(int) (JSON, error)   { return nil, errCannotDeleteFr
 func (jsonFalse) RemoveIndex(int) (JSON, error)  { return nil, errCannotDeleteFromScalar }
 func (jsonString) RemoveIndex(int) (JSON, error) { return nil, errCannotDeleteFromScalar }
 func (jsonNumber) RemoveIndex(int) (JSON, error) { return nil, errCannotDeleteFromScalar }
-
-func (j jsonString) TypeAsText() string { return "string" }
-func (j jsonNull) TypeAsText() string   { return "null" }
-func (j jsonTrue) TypeAsText() string   { return "true" }
-func (j jsonFalse) TypeAsText() string  { return "false" }
-func (j jsonNumber) TypeAsText() string { return "number" }
-func (j jsonArray) TypeAsText() string  { return "array" }
-func (j jsonObject) TypeAsText() string { return "object" }
 
 func (j jsonString) AsText() *string {
 	s := string(j)


### PR DESCRIPTION
The result of json_typeof(true or false) should be "boolean" instead of "true" or "false"

Related to #20120