### PR TITLE
rpc: Remove old locking workaround for removing connection

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -445,11 +445,7 @@ func (ctx *Context) GRPCDial(target string, opts ...grpc.DialOption) (*grpc.Clie
 					})
 				}); err != nil {
 				meta.dialErr = err
-				// removeConn and ctx's cleanup worker both lock ctx.conns. However,
-				// to avoid racing with meta's initialization, the cleanup worker
-				// blocks on meta.Do while holding ctx.conns. Invoke removeConn
-				// asynchronously to avoid deadlock.
-				go ctx.removeConn(target, meta)
+				ctx.removeConn(target, meta)
 			}
 		}
 	})


### PR DESCRIPTION
Previously we had to call removeConn from connMeta's initialization
method in order to avoid deadlocks. However, the switch from a mutex
to using a syncmap.Map in 9831c3feb47f4ed8f198c6301239089480f8420a
removed the potential for deadlock with the cleanup worker because
there's no longer a lock at all. Nothing will stop the removeConn from
succeeding even if the cleanup worker is already active.