### PR TITLE
sql: extract the run-time state from planNodes

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -39,12 +39,15 @@ type deleteNode struct {
 
 	tw tableDeleter
 
-	run struct {
-		// The following fields are populated during Start().
-		editNodeRun
+	run deleteRun
+}
 
-		fastPath bool
-	}
+// deleteRun contains the run-time state of deleteNode during local execution.
+type deleteRun struct {
+	// The following fields are populated during Start().
+	editNodeRun
+
+	fastPath bool
 }
 
 // Delete removes rows from a table.

--- a/pkg/sql/drop.go
+++ b/pkg/sql/drop.go
@@ -1164,6 +1164,12 @@ func (p *planner) getViewDescForCascade(
 type dropUserNode struct {
 	ifExists bool
 	names    func() ([]string, error)
+
+	run dropUserRun
+}
+
+// dropUserRun contains the run-time state of dropUserNode during local execution.
+type dropUserRun struct {
 	// The number of users deleted.
 	numDeleted int
 }
@@ -1257,7 +1263,7 @@ func (n *dropUserNode) Start(params runParams) error {
 		numDeleted += rowsAffected
 	}
 
-	n.numDeleted = numDeleted
+	n.run.numDeleted = numDeleted
 
 	return nil
 }
@@ -1265,7 +1271,7 @@ func (n *dropUserNode) Start(params runParams) error {
 func (*dropUserNode) Next(runParams) (bool, error)   { return false, nil }
 func (*dropUserNode) Close(context.Context)          {}
 func (*dropUserNode) Values() tree.Datums            { return tree.Datums{} }
-func (n *dropUserNode) FastPathResults() (int, bool) { return n.numDeleted, true }
+func (n *dropUserNode) FastPathResults() (int, bool) { return n.run.numDeleted, true }
 
 // DropUser drops a list of users.
 // Privileges: DELETE on system.users.

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -2033,7 +2033,7 @@ func (e *Executor) execClassic(
 		}
 	case tree.DDL:
 		if n, ok := plan.(*createTableNode); ok && n.n.As() {
-			rowResultWriter.IncrementRowsAffected(n.count)
+			rowResultWriter.IncrementRowsAffected(n.run.count)
 		}
 	}
 	return nil

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -155,6 +155,11 @@ type explainDistSQLNode struct {
 
 	plan planNode
 
+	run explainDistSQLRun
+}
+
+// explainDistSQLRun contains the run-time state of explainDistSQLNode during local execution.
+type explainDistSQLRun struct {
 	// The single row returned by the node.
 	values tree.Datums
 
@@ -195,7 +200,7 @@ func (n *explainDistSQLNode) Start(params runParams) error {
 		return err
 	}
 
-	n.values = tree.Datums{
+	n.run.values = tree.Datums{
 		tree.MakeDBool(tree.DBool(auto)),
 		tree.NewDString(planURL.String()),
 		tree.NewDString(planJSON),
@@ -204,13 +209,11 @@ func (n *explainDistSQLNode) Start(params runParams) error {
 }
 
 func (n *explainDistSQLNode) Next(runParams) (bool, error) {
-	if n.done {
+	if n.run.done {
 		return false, nil
 	}
-	n.done = true
+	n.run.done = true
 	return true, nil
 }
 
-func (n *explainDistSQLNode) Values() tree.Datums {
-	return n.values
-}
+func (n *explainDistSQLNode) Values() tree.Datums { return n.run.values }

--- a/pkg/sql/opt_decompose_test.go
+++ b/pkg/sql/opt_decompose_test.go
@@ -68,7 +68,7 @@ func makeSelectNode(t *testing.T, p *planner) *renderNode {
 	numColumns := len(sel.sourceInfo[0].sourceColumns)
 	sel.ivarHelper = tree.MakeIndexedVarHelper(sel, numColumns)
 	p.evalCtx.IVarHelper = &sel.ivarHelper
-	sel.curSourceRow = make(tree.Datums, numColumns)
+	sel.run.curSourceRow = make(tree.Datums, numColumns)
 	return sel
 }
 
@@ -105,8 +105,8 @@ func checkEquivExpr(evalCtx *tree.EvalContext, a, b tree.TypedExpr, sel *renderN
 		tree.NewDInt(3),
 		tree.DNull,
 	} {
-		for i := range sel.curSourceRow {
-			sel.curSourceRow[i] = v
+		for i := range sel.run.curSourceRow {
+			sel.run.curSourceRow[i] = v
 		}
 		da, err := a.Eval(evalCtx)
 		if err != nil {

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -213,7 +213,7 @@ func (p *planner) selectIndex(
 	c := candidates[0]
 	s.index = c.index
 	s.specifiedIndex = nil
-	s.isSecondaryIndex = (c.index != &s.desc.PrimaryIndex)
+	s.run.isSecondaryIndex = (c.index != &s.desc.PrimaryIndex)
 	var err error
 	s.spans, err = makeSpans(&p.evalCtx, c.constraints, c.desc, c.index)
 	if err != nil {

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -76,9 +76,9 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 		if n.needSort && numRows != math.MaxInt64 {
 			v := p.newSortValues(n.ordering, planColumns(n.plan), int(numRows))
 			if soft {
-				n.sortStrategy = newIterativeSortStrategy(v)
+				n.run.sortStrategy = newIterativeSortStrategy(v)
 			} else {
-				n.sortStrategy = newSortTopKStrategy(v, numRows)
+				n.run.sortStrategy = newSortTopKStrategy(v, numRows)
 			}
 		}
 		if n.needSort {

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -72,9 +72,9 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 	case *valuesNode:
 		return n.columns
 	case *explainPlanNode:
-		return n.results.columns
+		return n.run.results.columns
 	case *windowNode:
-		return n.values.columns
+		return n.run.values.columns
 	case *traceNode:
 		return n.columns
 

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -27,7 +27,7 @@ import "github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 func planPhysicalProps(plan planNode) physicalProps {
 	switch n := plan.(type) {
 	case *explainPlanNode:
-		return planPhysicalProps(n.results)
+		return planPhysicalProps(n.run.results)
 	case *distinctNode:
 		return planPhysicalProps(n.plan)
 	case *limitNode:

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -78,13 +78,7 @@ type renderNode struct {
 	// modified by index selection.
 	props physicalProps
 
-	// The current source row, with one value per source column.
-	// populated by Next(), used by renderRow().
-	curSourceRow tree.Datums
-
-	// The rendered row, with one value for each render expression.
-	// populated by Next().
-	row tree.Datums
+	run renderRun
 
 	// This struct must be allocated on the heap and its location stay
 	// stable after construction because it implements
@@ -96,8 +90,19 @@ type renderNode struct {
 	noCopy util.NoCopy
 }
 
+// renderRun contains the run-time state of renderNode during local execution.
+type renderRun struct {
+	// The current source row, with one value per source column.
+	// populated by Next(), used by renderRow().
+	curSourceRow tree.Datums
+
+	// The rendered row, with one value for each render expression.
+	// populated by Next().
+	row tree.Datums
+}
+
 func (r *renderNode) Values() tree.Datums {
-	return r.row
+	return r.run.row
 }
 
 func (r *renderNode) Start(params runParams) error {
@@ -109,7 +114,7 @@ func (r *renderNode) Next(params runParams) (bool, error) {
 		return false, err
 	}
 
-	r.curSourceRow = r.source.plan.Values()
+	r.run.curSourceRow = r.source.plan.Values()
 
 	err := r.renderRow(params.evalCtx)
 	return err == nil, err
@@ -121,7 +126,7 @@ func (r *renderNode) Close(ctx context.Context) {
 
 // IndexedVarEval implements the tree.IndexedVarContainer interface.
 func (r *renderNode) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum, error) {
-	return r.curSourceRow[idx].Eval(ctx)
+	return r.run.curSourceRow[idx].Eval(ctx)
 }
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
@@ -631,13 +636,13 @@ func (r *renderNode) resetRenderColumns(exprs []tree.TypedExpr, cols sqlbase.Res
 
 // renderRow renders the row by evaluating the render expressions.
 func (r *renderNode) renderRow(evalCtx *tree.EvalContext) error {
-	if r.row == nil {
-		r.row = make([]tree.Datum, len(r.render))
+	if r.run.row == nil {
+		r.run.row = make([]tree.Datum, len(r.render))
 	}
 	for i, e := range r.render {
 		var err error
 		evalCtx.IVarHelper = &r.ivarHelper
-		r.row[i], err = e.Eval(evalCtx)
+		r.run.row[i], err = e.Eval(evalCtx)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -743,7 +743,7 @@ func (td *tableDeleter) fastDelete(
 				continue
 			}
 
-			after, ok, err := scan.fetcher.ReadIndexKey(i)
+			after, ok, err := scan.run.fetcher.ReadIndexKey(i)
 			if err != nil {
 				return 0, err
 			}

--- a/pkg/sql/unary.go
+++ b/pkg/sql/unary.go
@@ -23,6 +23,11 @@ import (
 // which is used by select statements that have no table. It is used for its
 // property as the join identity.
 type unaryNode struct {
+	run unaryRun
+}
+
+// unaryRun contains the run-time state of unaryNode during local execution.
+type unaryRun struct {
 	consumed bool
 }
 
@@ -31,7 +36,7 @@ func (*unaryNode) Start(runParams) error { return nil }
 func (*unaryNode) Close(context.Context) {}
 
 func (u *unaryNode) Next(runParams) (bool, error) {
-	r := !u.consumed
-	u.consumed = true
+	r := !u.run.consumed
+	u.run.consumed = true
 	return r, nil
 }

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -122,10 +122,13 @@ type updateNode struct {
 	checkHelper   checkHelper
 	sourceSlots   []sourceSlot
 
-	run struct {
-		// The following fields are populated during Start().
-		editNodeRun
-	}
+	run updateRun
+}
+
+// updateRun contains the run-time state of updateNode during local execution.
+type updateRun struct {
+	// The following fields are populated during Start().
+	editNodeRun
 }
 
 // sourceSlot abstracts the idea that our update sources can either be tuples

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -252,7 +252,7 @@ func (v *planVisitor) visit(plan planNode) {
 				order.addOrderColumn(o.ColIdx, o.Direction)
 			}
 			v.observer.attr(name, "order", order.AsString(columns))
-			switch ss := n.sortStrategy.(type) {
+			switch ss := n.run.sortStrategy.(type) {
 			case *iterativeSortStrategy:
 				v.observer.attr(name, "strategy", "iterative")
 			case *sortTopKStrategy:


### PR DESCRIPTION
The new "Run" structs contain the fields from each
planNodes that are either:

- written to during local execution, and thus need to be reset
  if local execution takes place multiple times (e.g.
  if we reuse the planNode).
- only read from during local execution, i.e. they are
  initialized once during logical planning and never read again
  until local execution takes place.

They expose the following invariants:

- every field *not* in a Run struct can be considered immutable
  after planning has completed,

- every field in a Run struct needs not be initialized if local
  execution is known not to take place.

This patch places some fields in the Run struct that are immutable
across executions (after planning has completed). It is not the case
that *all* Run fields must be re-initialized on every execution.

The fields that are allowed in the Run struct and do not remain in the
main planNode are those that are known to be produced during planning
but not *used* during planning.

This patch *may* have kept some immutable fields in the main planNode
that are not used during planning (and only used during execution).
Subsequent patches can strive to migrate more fields from the planNode
to the Run struct if possible.