### PR TITLE
storage: unblock the GC queue for large transaction cleanups

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -576,9 +575,8 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 			hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
 			config.GCPolicy{TTLSeconds: 24 * 60 * 60 /* 1 day */},
 			func([]roachpb.GCRequest_GCKey, *storage.GCInfo) error { return nil },
-			func(_ hlc.Timestamp, _ *roachpb.Transaction, _ roachpb.PushTxnType) {},
-			func(_ []roachpb.Intent, _ storage.ResolveOptions) error { return nil },
-			func(_ []result.IntentsWithArg) error { return nil },
+			func(_ []roachpb.Intent) error { return nil },
+			func(_ *roachpb.Transaction, _ []roachpb.Intent) error { return nil },
 		)
 		if err != nil {
 			return err

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -27,11 +26,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
-	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -70,10 +67,6 @@ const (
 	// on keys and intents.
 	gcKeyScoreThreshold    = 2
 	gcIntentScoreThreshold = 10
-
-	// gcTaskLimit is the maximum number of concurrent goroutines
-	// that will be created by GC.
-	gcTaskLimit = 25
 
 	// gcChunkKeySize is the default size for GCRequest's batch key size.
 	gcChunkKeySize = 256 * 1000
@@ -116,9 +109,8 @@ func newGCQueue(store *Store, gossip *gossip.Gossip) *gcQueue {
 }
 
 type gcFunc func([]roachpb.GCRequest_GCKey, *GCInfo) error
-type pushFunc func(hlc.Timestamp, *roachpb.Transaction, roachpb.PushTxnType)
-type resolveFunc func([]roachpb.Intent, ResolveOptions) error
-type processAsyncFunc func([]result.IntentsWithArg) error
+type cleanupIntentsFunc func([]roachpb.Intent) error
+type cleanupTxnIntentsFunc func(*roachpb.Transaction, []roachpb.Intent) error
 
 // gcQueueScore holds details about the score returned by makeGCQueueScoreImpl for
 // testing and logging. The fields in this struct are documented in
@@ -355,9 +347,7 @@ func makeGCQueueScoreImpl(
 // transaction records, queue last processed timestamps, and range descriptors.
 //
 // - Transaction entries:
-//   - Update txnMap with transactions which are old and in state
-//     PENDING for subsequent PushTxn.
-//   - For transactions in state ABORTED or COMMITTED, schedule the
+//   - For transactions older than the cutoff timestamp, schedule the
 //     intents for asynchronous resolution. The actual transaction spans
 //     are not returned for GC in this pass, but are separately GC'ed
 //     after successful resolution of all intents. The exception is if
@@ -369,10 +359,9 @@ func processLocalKeyRange(
 	ctx context.Context,
 	snap engine.Reader,
 	desc *roachpb.RangeDescriptor,
-	txnMap map[uuid.UUID]*roachpb.Transaction,
 	cutoff hlc.Timestamp,
 	infoMu *lockableGCInfo,
-	processAsyncFn processAsyncFunc,
+	cleanupTxnIntentsFn cleanupTxnIntentsFunc,
 ) ([]roachpb.GCRequest_GCKey, error) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -380,17 +369,11 @@ func processLocalKeyRange(
 	var gcKeys []roachpb.GCRequest_GCKey
 
 	handleTxnIntents := func(key roachpb.Key, txn *roachpb.Transaction) error {
-		if len(txn.Intents) > 0 {
-			// Synthesize an EndTransaction request in order to send IntentsWithArgs.
-			return processAsyncFn([]result.IntentsWithArg{
-				{
-					Arg: &roachpb.EndTransactionRequest{
-						Span:   roachpb.Span{Key: txn.Key},
-						Commit: txn.Status == roachpb.COMMITTED,
-					},
-					Intents: roachpb.AsIntents(txn.Intents, txn),
-				},
-			})
+		// If the transaction needs to be pushed or there are intents to
+		// resolve, invoke the cleanup function.
+		if txn.Status == roachpb.PENDING || len(txn.Intents) > 0 {
+			infoMu.ResolveTotal += len(txn.Intents)
+			return cleanupTxnIntentsFn(txn, roachpb.AsIntents(txn.Intents, txn))
 		}
 		gcKeys = append(gcKeys, roachpb.GCRequest_GCKey{Key: key}) // zero timestamp
 		return nil
@@ -406,31 +389,18 @@ func processLocalKeyRange(
 			return nil
 		}
 
-		txnID := txn.ID
-
 		// The transaction record should be considered for removal.
 		switch txn.Status {
 		case roachpb.PENDING:
-			// Marked as running, so we need to push it to abort it but won't
-			// try to GC it in this cycle (for convenience).
-			// TODO(tschottdorf): refactor so that we can GC PENDING entries
-			// in the same cycle, but keeping the calls to pushTxn in a central
-			// location (keeping it easy to batch them up in the future).
 			infoMu.TransactionSpanGCPending++
-			txnMap[txnID] = &txn
-			return nil
-
 		case roachpb.ABORTED:
 			infoMu.TransactionSpanGCAborted++
-			return handleTxnIntents(kv.Key, &txn)
-
 		case roachpb.COMMITTED:
 			infoMu.TransactionSpanGCCommitted++
-			return handleTxnIntents(kv.Key, &txn)
-
 		default:
 			panic(fmt.Sprintf("invalid transaction state: %s", txn))
 		}
+		return handleTxnIntents(kv.Key, &txn)
 	}
 
 	handleOneQueueLastProcessed := func(kv roachpb.KeyValue, rangeKey roachpb.RKey) error {
@@ -484,7 +454,6 @@ func processAbortSpan(
 	rangeID roachpb.RangeID,
 	threshold hlc.Timestamp,
 	infoMu *lockableGCInfo,
-	pushTxn pushFunc,
 ) []roachpb.GCRequest_GCKey {
 	var gcKeys []roachpb.GCRequest_GCKey
 	abortSpan := abortspan.New(rangeID)
@@ -612,21 +581,23 @@ func (gcq *gcQueue) processImpl(
 			}
 			return nil
 		},
-		func(now hlc.Timestamp, txn *roachpb.Transaction, typ roachpb.PushTxnType) {
-			pushTxn(ctx, gcq.store.DB(), now, txn, typ)
+		func(intents []roachpb.Intent) error {
+			intentCount, err := repl.store.intentResolver.cleanupIntents(ctx, intents, now, roachpb.PUSH_ABORT)
+			if err == nil {
+				gcq.store.metrics.GCResolveSuccess.Inc(int64(intentCount))
+			}
+			return err
 		},
-		func(intents []roachpb.Intent, opts ResolveOptions) error {
-			return repl.store.intentResolver.resolveIntents(ctx, intents, opts)
+		func(txn *roachpb.Transaction, intents []roachpb.Intent) error {
+			return repl.store.intentResolver.cleanupTxnIntentsOnGCAsync(ctx, txn, intents, now)
 		},
-		func(intents []result.IntentsWithArg) error {
-			return repl.store.intentResolver.processIntentsAsync(ctx, repl, intents, false /* allowSyncProcessing */)
-		})
+	)
 	if err != nil {
 		return err
 	}
 
-	log.Eventf(ctx, "MVCC stats: %+v", repl.GetMVCCStats())
-	log.Eventf(ctx, "done GC'ing, new score is %s", makeGCQueueScore(ctx, repl, repl.store.Clock().Now(), sysCfg))
+	log.Eventf(ctx, "MVCC stats after GC: %+v", repl.GetMVCCStats())
+	log.Eventf(ctx, "GC score after GC: %s", makeGCQueueScore(ctx, repl, repl.store.Clock().Now(), sysCfg))
 	info.updateMetrics(gcq.store.metrics)
 
 	return nil
@@ -664,8 +635,6 @@ type GCInfo struct {
 	// ResolveTotal is the total number of attempted intent resolutions in
 	// this cycle.
 	ResolveTotal int
-	// ResolveErrors is the number of successful intent resolutions.
-	ResolveSuccess int
 	// Threshold is the computed expiration timestamp. Equal to `Now - Policy`.
 	Threshold hlc.Timestamp
 }
@@ -683,7 +652,6 @@ func (info *GCInfo) updateMetrics(metrics *StoreMetrics) {
 	metrics.GCAbortSpanGCNum.Inc(int64(info.AbortSpanGCNum))
 	metrics.GCPushTxn.Inc(int64(info.PushTxn))
 	metrics.GCResolveTotal.Inc(int64(info.ResolveTotal))
-	metrics.GCResolveSuccess.Inc(int64(info.ResolveSuccess))
 }
 
 type lockableGCInfo struct {
@@ -692,11 +660,11 @@ type lockableGCInfo struct {
 }
 
 // RunGC runs garbage collection for the specified descriptor on the
-// provided Engine (which is not mutated). It uses the provided
-// pushTxnFn to clarify the true status of a transaction,
-// resolveIntentsFn to resolve intents synchronously, and
-// processAsyncFn to asynchronously clean up after encountered
-// transactions.
+// provided Engine (which is not mutated). It uses the provided gcFn
+// to run garbage collection once on all implicated spans,
+// cleanupIntentsFn to resolve intents synchronously, and
+// cleanupTxnIntentsFn to asynchronously cleanup intents and
+// associated transaction record on success.
 func RunGC(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
@@ -704,9 +672,8 @@ func RunGC(
 	now hlc.Timestamp,
 	policy config.GCPolicy,
 	gcFn gcFunc,
-	pushTxnFn pushFunc,
-	resolveIntentsFn resolveFunc,
-	processAsyncFn processAsyncFunc,
+	cleanupIntentsFn cleanupIntentsFunc,
+	cleanupTxnIntentsFn cleanupTxnIntentsFunc,
 ) (GCInfo, error) {
 
 	iter := NewReplicaDataIterator(desc, snap, true /* replicatedOnly */)
@@ -715,45 +682,6 @@ func RunGC(
 	var infoMu = lockableGCInfo{}
 	infoMu.Policy = policy
 	infoMu.Now = now
-
-	{
-		realResolveIntentsFn := resolveIntentsFn
-		resolveIntentsFn = func(intents []roachpb.Intent, opts ResolveOptions) (err error) {
-			defer func() {
-				infoMu.Lock()
-				infoMu.ResolveTotal += len(intents)
-				if err == nil {
-					infoMu.ResolveSuccess += len(intents)
-				}
-				infoMu.Unlock()
-			}()
-			return realResolveIntentsFn(intents, opts)
-		}
-		realProcessAsyncFn := processAsyncFn
-		processAsyncFn = func(intents []result.IntentsWithArg) (err error) {
-			defer func() {
-				// Note: infoMu lock is already held.
-				infoMu.ResolveTotal += len(intents)
-				if err == nil {
-					// TODO(spencer): this is only partially correct; what it
-					// provides is a count of the intents for which async
-					// resolution was undertaken, not the count of intents which
-					// were successfully resolved. We need to keep a separate
-					// count of successes / failures for intent resolution in the
-					// intent resolver instead.
-					infoMu.ResolveSuccess += len(intents)
-				}
-			}()
-			return realProcessAsyncFn(intents)
-		}
-		realPushTxnFn := pushTxnFn
-		pushTxnFn = func(ts hlc.Timestamp, txn *roachpb.Transaction, typ roachpb.PushTxnType) {
-			infoMu.Lock()
-			infoMu.PushTxn++
-			infoMu.Unlock()
-			realPushTxnFn(ts, txn, typ)
-		}
-	}
 
 	// Compute intent expiration (intent age at which we attempt to resolve).
 	intentExp := now
@@ -850,7 +778,7 @@ func RunGC(
 	infoMu.NumKeysAffected = len(gcKeys)
 
 	// Process local range key entries (txn records, queue last processed times).
-	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, txnMap, txnExp, &infoMu, processAsyncFn)
+	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, txnExp, &infoMu, cleanupTxnIntentsFn)
 	if err != nil {
 		return GCInfo{}, err
 	}
@@ -865,7 +793,7 @@ func RunGC(
 	// Clean up the AbortSpan.
 	log.Event(ctx, "processing AbortSpan")
 	gcKeys = append(gcKeys, processAbortSpan(
-		ctx, snap, desc.RangeID, abortSpanGCThreshold, &infoMu, pushTxnFn)...)
+		ctx, snap, desc.RangeID, abortSpanGCThreshold, &infoMu)...)
 
 	infoMu.Lock()
 	log.Eventf(ctx, "assembled GC keys, now proceeding to GC; stats so far %+v", infoMu.GCInfo)
@@ -875,57 +803,17 @@ func RunGC(
 		return GCInfo{}, err
 	}
 
-	// Process push transactions in parallel. We first push all
-	// transactions before resolving intents. If we have too many
-	// transactions, that can lead to the case in which our context
-	// expires and we can't actually clean up any of the intents. Since
-	// we have hopefully succeeded in pushing a lot of transactions, the
-	// next time around we should have less work here and manage to get
-	// to the intents.
-	log.Eventf(ctx, "pushing up to %d transactions (concurrency %d)", len(txnMap), gcTaskLimit)
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, gcTaskLimit)
-	for _, txn := range txnMap {
-		if txn.Status != roachpb.PENDING {
-			continue
-		}
-		wg.Add(1)
-		sem <- struct{}{}
-		// Avoid passing loop variable into closure.
-		txnCopy := txn
-		go func() {
-			defer func() {
-				<-sem
-				wg.Done()
-			}()
-			if ctx.Err() != nil {
-				return // don't bother if already expired
-			}
-			pushTxnFn(now, txnCopy, roachpb.PUSH_ABORT)
-		}()
-	}
-	wg.Wait()
-
-	if err := ctx.Err(); err != nil {
-		// Don't bother if already expired.
-		return GCInfo{}, err
-	}
-
-	// Resolve all intents. If we have too many intents, that can lead to
-	// the case in which our context expires and we can't finish. However,
-	// because all of these intents fall within a single range, this is
-	// likely to be less problematic than cleaning up a highly distributed
-	// transaction's intents. Because the intent resolution is done in batches
-	// of 100 intents, even if this times out, the next pass will be easier.
+	// Push transactions (only if pending) and resolve intents, asynchronously.
 	var intents []roachpb.Intent
 	for txnID, txn := range txnMap {
-		if txn.Status != roachpb.PENDING {
-			intents = append(intents, roachpb.AsIntents(intentSpanMap[txnID], txn)...)
-		}
+		intents = append(intents, roachpb.AsIntents(intentSpanMap[txnID], txn)...)
 	}
-	log.Eventf(ctx, "resolving %d intents", len(intents))
-
-	if err := resolveIntentsFn(intents, ResolveOptions{Wait: true, Poison: false}); err != nil {
+	infoMu.Lock()
+	infoMu.PushTxn = len(txnMap)
+	infoMu.ResolveTotal += len(intents)
+	infoMu.Unlock()
+	log.Eventf(ctx, "cleanup of %d intents", len(intents))
+	if err := cleanupIntentsFn(intents); err != nil {
 		return GCInfo{}, err
 	}
 
@@ -941,34 +829,4 @@ func (*gcQueue) timer(_ time.Duration) time.Duration {
 // purgatoryChan returns nil.
 func (*gcQueue) purgatoryChan() <-chan struct{} {
 	return nil
-}
-
-// pushTxn attempts to abort the txn via push. The wait group is signaled on
-// completion.
-func pushTxn(
-	ctx context.Context,
-	db *client.DB,
-	now hlc.Timestamp,
-	txn *roachpb.Transaction,
-	typ roachpb.PushTxnType,
-) {
-	// Attempt to push the transaction which created the intent.
-	pushArgs := &roachpb.PushTxnRequest{
-		Span: roachpb.Span{
-			Key: txn.Key,
-		},
-		Now:       now,
-		PusherTxn: roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Priority: math.MaxInt32}},
-		PusheeTxn: txn.TxnMeta,
-		PushType:  typ,
-	}
-	b := &client.Batch{}
-	b.AddRawRequest(pushArgs)
-	if err := db.Run(ctx, b); err != nil {
-		log.Warningf(ctx, "push of txn %s failed: %s", txn, err)
-		return
-	}
-	br := b.RawResponse()
-	// Update the supplied txn on successful push.
-	*txn = br.Responses[0].GetInner().(*roachpb.PushTxnResponse).PusheeTxn
 }

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -86,8 +87,8 @@ const (
 //    as implemented going forward).
 //  - Resolve extant write intents (pushing their transactions).
 //  - GC of old transaction and AbortSpan entries. This should include
-//    most committed entries almost immediately and, after a threshold on
-//    inactivity, all others.
+//    committed and aborted entries almost immediately and, after a
+//    threshold on inactivity, all others.
 //
 // The shouldQueue function combines the need for the above tasks into a
 // single priority. If any task is overdue, shouldQueue returns true.
@@ -114,8 +115,10 @@ func newGCQueue(store *Store, gossip *gossip.Gossip) *gcQueue {
 	return gcq
 }
 
+type gcFunc func([]roachpb.GCRequest_GCKey, *GCInfo) error
 type pushFunc func(hlc.Timestamp, *roachpb.Transaction, roachpb.PushTxnType)
 type resolveFunc func([]roachpb.Intent, ResolveOptions) error
+type processAsyncFunc func([]result.IntentsWithArg) error
 
 // gcQueueScore holds details about the score returned by makeGCQueueScoreImpl for
 // testing and logging. The fields in this struct are documented in
@@ -351,14 +354,15 @@ func makeGCQueueScoreImpl(
 // processLocalKeyRange scans the local range key entries, consisting of
 // transaction records, queue last processed timestamps, and range descriptors.
 //
-// - Transaction entries: updates txnMap with those transactions which
-//   are old and either PENDING or with intents registered. In the
-//   first case we want to push the transaction so that it is aborted,
-//   and in the second case we may have to resolve the intents
-//   success- fully before GCing the entry. The transaction records
-//   which can be gc'ed are returned separately and are not added to
-//   txnMap nor intentSpanMap.
-//
+// - Transaction entries:
+//   - Update txnMap with transactions which are old and in state
+//     PENDING for subsequent PushTxn.
+//   - For transactions in state ABORTED or COMMITTED, schedule the
+//     intents for asynchronous resolution. The actual transaction spans
+//     are not returned for GC in this pass, but are separately GC'ed
+//     after successful resolution of all intents. The exception is if
+//     there are no intents on the txn record, in which case it's returned
+//     for immediate GC.
 // - Queue last processed times: cleanup any entries which don't match
 //   this range's start key. This can happen on range merges.
 func processLocalKeyRange(
@@ -368,14 +372,29 @@ func processLocalKeyRange(
 	txnMap map[uuid.UUID]*roachpb.Transaction,
 	cutoff hlc.Timestamp,
 	infoMu *lockableGCInfo,
-	resolveIntentsFn resolveFunc,
+	processAsyncFn processAsyncFunc,
 ) ([]roachpb.GCRequest_GCKey, error) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
 
 	var gcKeys []roachpb.GCRequest_GCKey
 
-	const maxIntentHack = 800
+	handleTxnIntents := func(key roachpb.Key, txn *roachpb.Transaction) error {
+		if len(txn.Intents) > 0 {
+			// Synthesize an EndTransaction request in order to send IntentsWithArgs.
+			return processAsyncFn([]result.IntentsWithArg{
+				{
+					Arg: &roachpb.EndTransactionRequest{
+						Span:   roachpb.Span{Key: txn.Key},
+						Commit: txn.Status == roachpb.COMMITTED,
+					},
+					Intents: roachpb.AsIntents(txn.Intents, txn),
+				},
+			})
+		}
+		gcKeys = append(gcKeys, roachpb.GCRequest_GCKey{Key: key}) // zero timestamp
+		return nil
+	}
 
 	handleOneTransaction := func(kv roachpb.KeyValue) error {
 		var txn roachpb.Transaction
@@ -400,62 +419,18 @@ func processLocalKeyRange(
 			infoMu.TransactionSpanGCPending++
 			txnMap[txnID] = &txn
 			return nil
-		case roachpb.ABORTED:
-			// If we remove this transaction, it effectively still counts as
-			// ABORTED (by design). So this can be GC'ed even if we can't
-			// resolve the intents.
-			// Note: Most aborted transaction weren't aborted by their client,
-			// but instead by the coordinator - those will not have any intents
-			// persisted, though they still might exist in the system.
-			infoMu.TransactionSpanGCAborted++
-			if err := func() error {
-				// Simply don't resolve these intents. We don't have to and don't want to get bogged down
-				// trying to do so.
-				if len(txn.Intents) > maxIntentHack {
-					return nil
-				}
-				infoMu.Unlock() // intentional
-				defer infoMu.Lock()
-				return resolveIntentsFn(roachpb.AsIntents(txn.Intents, &txn),
-					ResolveOptions{Wait: true, Poison: false})
-			}(); err != nil {
-				// Ignore above error, but if context is expired, no point in keeping going.
-				if ctx.Err() != nil {
-					return errors.Wrap(err, "context timed out during local key range processing after")
-				}
-				log.Warningf(ctx, "failed to resolve intents of aborted txn on gc (removing anyway): %s", err)
-				// Keep going.
-			}
-		case roachpb.COMMITTED:
-			// It's committed, so it doesn't need a push but we can only
-			// GC it after its intents are resolved.
-			if err := func() error {
-				infoMu.Unlock() // intentional
-				defer infoMu.Lock()
 
-				if len(txn.Intents) > maxIntentHack {
-					// Return an error so that we leave this transaction alone. Don't try to resolve its intents.
-					return errors.Errorf("cannot GC transaction with %d intents", len(txn.Intents))
-				}
-				return resolveIntentsFn(roachpb.AsIntents(txn.Intents, &txn), ResolveOptions{Wait: true, Poison: false})
-			}(); err != nil {
-				// Returning the error here would abort the whole GC run, and
-				// we don't want that. Instead, we simply don't GC this entry.
-				if ctx.Err() != nil {
-					// ... but if our context is expired, no need to keep going.
-					return errors.Wrap(err, "context timed out during local key range processing after")
-				}
-				log.Warningf(ctx, "unable to resolve intents of committed txn on gc; skipping: %s", err)
-				// Do not keep going, or we'll still remove this transaction, and we're not
-				// allowed to unless the intents are certifiably removed.
-				return nil
-			}
+		case roachpb.ABORTED:
+			infoMu.TransactionSpanGCAborted++
+			return handleTxnIntents(kv.Key, &txn)
+
+		case roachpb.COMMITTED:
 			infoMu.TransactionSpanGCCommitted++
+			return handleTxnIntents(kv.Key, &txn)
+
 		default:
 			panic(fmt.Sprintf("invalid transaction state: %s", txn))
 		}
-		gcKeys = append(gcKeys, roachpb.GCRequest_GCKey{Key: kv.Key}) // zero timestamp
-		return nil
 	}
 
 	handleOneQueueLastProcessed := func(kv roachpb.KeyValue, rangeKey roachpb.RKey) error {
@@ -544,7 +519,7 @@ func processAbortSpan(
 // 3) scan the transaction table, collecting abandoned or completed txns
 // 4) push all of these transactions (possibly recreating entries)
 // 5) resolve all intents (unless the txn is still PENDING), which will recreate
-//    AbortSpan entries (but with the txn timestamp; i.e. likely gc'able)
+//    AbortSpan entries (but with the txn timestamp; i.e. likely GC'able)
 // 6) scan the AbortSpan table for old entries
 // 7) push these transactions (again, recreating txn entries).
 // 8) send a GCRequest.
@@ -609,46 +584,51 @@ func (gcq *gcQueue) processImpl(
 		return errors.Errorf("could not find zone config for range %s: %s", repl, err)
 	}
 
-	gcKeys, info, err := RunGC(ctx, desc, snap, now, zone.GC,
+	info, err := RunGC(ctx, desc, snap, now, zone.GC,
+		func(gcKeys []roachpb.GCRequest_GCKey, info *GCInfo) error {
+			// Now chunk the keys into multiple GC requests and process. We do
+			// this before beginning to push transactions and resolve intents so
+			// that we don't lose all of the work we've done thus far gathering
+			// GC'able keys.
+			batches := chunkGCRequest(desc, info, gcKeys)
+
+			for i, gcArgs := range batches {
+				var ba roachpb.BatchRequest
+
+				// Technically not needed since we're talking directly to the Range.
+				ba.RangeID = desc.RangeID
+				ba.Timestamp = now
+
+				// TODO(tschottdorf): This is one of these instances in which we want
+				// to be more careful that the request ends up on the correct Replica,
+				// and we might have to worry about mixing range-local and global keys
+				// in a batch which might end up spanning Ranges by the time it executes.
+				ba.Add(&gcArgs)
+				log.Eventf(ctx, "sending batch %d of %d", i+1, len(batches))
+				if _, pErr := repl.Send(ctx, ba); pErr != nil {
+					log.ErrEvent(ctx, pErr.String())
+					return pErr.GoError()
+				}
+			}
+			return nil
+		},
 		func(now hlc.Timestamp, txn *roachpb.Transaction, typ roachpb.PushTxnType) {
 			pushTxn(ctx, gcq.store.DB(), now, txn, typ)
 		},
 		func(intents []roachpb.Intent, opts ResolveOptions) error {
 			return repl.store.intentResolver.resolveIntents(ctx, intents, opts)
+		},
+		func(intents []result.IntentsWithArg) error {
+			return repl.store.intentResolver.processIntentsAsync(ctx, repl, intents, false /* allowSyncProcessing */)
 		})
-
 	if err != nil {
 		return err
 	}
 
 	log.Eventf(ctx, "MVCC stats: %+v", repl.GetMVCCStats())
-	log.Eventf(ctx, "assembled GC keys, now proceeding to GC; stats so far %+v", info)
-	defer func() {
-		info.updateMetrics(gcq.store.metrics)
-	}()
-
-	batches := chunkGCRequest(desc, &info, gcKeys)
-
-	for i, gcArgs := range batches {
-		var ba roachpb.BatchRequest
-
-		// Technically not needed since we're talking directly to the Range.
-		ba.RangeID = desc.RangeID
-		ba.Timestamp = now
-
-		// TODO(tschottdorf): This is one of these instances in which we want
-		// to be more careful that the request ends up on the correct Replica,
-		// and we might have to worry about mixing range-local and global keys
-		// in a batch which might end up spanning Ranges by the time it executes.
-		ba.Add(&gcArgs)
-		log.Eventf(ctx, "sending batch %d of %d", i+1, len(batches))
-		if _, pErr := repl.Send(ctx, ba); pErr != nil {
-			log.ErrEvent(ctx, pErr.String())
-			return pErr.GoError()
-		}
-	}
-
 	log.Eventf(ctx, "done GC'ing, new score is %s", makeGCQueueScore(ctx, repl, repl.store.Clock().Now(), sysCfg))
+	info.updateMetrics(gcq.store.metrics)
+
 	return nil
 }
 
@@ -711,20 +691,23 @@ type lockableGCInfo struct {
 	GCInfo
 }
 
-// RunGC runs garbage collection for the specified descriptor on the provided
-// Engine (which is not mutated). It uses the provided functions pushTxnFn and
-// resolveIntentsFn to clarify the true status of and clean up after encountered
-// transactions. It returns a slice of gc'able keys from the data, transaction,
-// and abort spans.
+// RunGC runs garbage collection for the specified descriptor on the
+// provided Engine (which is not mutated). It uses the provided
+// pushTxnFn to clarify the true status of a transaction,
+// resolveIntentsFn to resolve intents synchronously, and
+// processAsyncFn to asynchronously clean up after encountered
+// transactions.
 func RunGC(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
 	snap engine.Reader,
 	now hlc.Timestamp,
 	policy config.GCPolicy,
+	gcFn gcFunc,
 	pushTxnFn pushFunc,
 	resolveIntentsFn resolveFunc,
-) ([]roachpb.GCRequest_GCKey, GCInfo, error) {
+	processAsyncFn processAsyncFunc,
+) (GCInfo, error) {
 
 	iter := NewReplicaDataIterator(desc, snap, true /* replicatedOnly */)
 	defer iter.Close()
@@ -745,6 +728,23 @@ func RunGC(
 				infoMu.Unlock()
 			}()
 			return realResolveIntentsFn(intents, opts)
+		}
+		realProcessAsyncFn := processAsyncFn
+		processAsyncFn = func(intents []result.IntentsWithArg) (err error) {
+			defer func() {
+				// Note: infoMu lock is already held.
+				infoMu.ResolveTotal += len(intents)
+				if err == nil {
+					// TODO(spencer): this is only partially correct; what it
+					// provides is a count of the intents for which async
+					// resolution was undertaken, not the count of intents which
+					// were successfully resolved. We need to keep a separate
+					// count of successes / failures for intent resolution in the
+					// intent resolver instead.
+					infoMu.ResolveSuccess += len(intents)
+				}
+			}()
+			return realProcessAsyncFn(intents)
 		}
 		realPushTxnFn := pushTxnFn
 		pushTxnFn = func(ts hlc.Timestamp, txn *roachpb.Transaction, typ roachpb.PushTxnType) {
@@ -819,7 +819,7 @@ func RunGC(
 	log.Event(ctx, "iterating through range")
 	for ; ; iter.Next() {
 		if ok, err := iter.Valid(); err != nil {
-			return nil, GCInfo{}, err
+			return GCInfo{}, err
 		} else if !ok {
 			break
 		}
@@ -850,9 +850,9 @@ func RunGC(
 	infoMu.NumKeysAffected = len(gcKeys)
 
 	// Process local range key entries (txn records, queue last processed times).
-	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, txnMap, txnExp, &infoMu, resolveIntentsFn)
+	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, txnMap, txnExp, &infoMu, processAsyncFn)
 	if err != nil {
-		return nil, GCInfo{}, err
+		return GCInfo{}, err
 	}
 
 	// From now on, all newly added keys are range-local.
@@ -862,15 +862,26 @@ func RunGC(
 	// we send directly to the Replica, though.
 	gcKeys = append(gcKeys, localRangeKeys...)
 
-	// Process push transactions in parallel.
-	//
-	// TODO(tschottdorf): we first push all transactions before resolving intents.
-	// If we have too many transactions, that can lead to the case in which our context
-	// expires and we can't actually clean up any of the intents. Since we have hopefully
-	// succeeded in pushing a lot of transactions, the next time around we should have
-	// less work here and manage to get to the intents, but it would be better to let
-	// another goroutine resolve intents for transactions we've handled so that work that
-	// is prepared is executed right away.
+	// Clean up the AbortSpan.
+	log.Event(ctx, "processing AbortSpan")
+	gcKeys = append(gcKeys, processAbortSpan(
+		ctx, snap, desc.RangeID, abortSpanGCThreshold, &infoMu, pushTxnFn)...)
+
+	infoMu.Lock()
+	log.Eventf(ctx, "assembled GC keys, now proceeding to GC; stats so far %+v", infoMu.GCInfo)
+	infoMu.Unlock()
+
+	if err := gcFn(gcKeys, &infoMu.GCInfo); err != nil {
+		return GCInfo{}, err
+	}
+
+	// Process push transactions in parallel. We first push all
+	// transactions before resolving intents. If we have too many
+	// transactions, that can lead to the case in which our context
+	// expires and we can't actually clean up any of the intents. Since
+	// we have hopefully succeeded in pushing a lot of transactions, the
+	// next time around we should have less work here and manage to get
+	// to the intents.
 	log.Eventf(ctx, "pushing up to %d transactions (concurrency %d)", len(txnMap), gcTaskLimit)
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, gcTaskLimit)
@@ -897,29 +908,28 @@ func RunGC(
 
 	if err := ctx.Err(); err != nil {
 		// Don't bother if already expired.
-		return nil, GCInfo{}, err
+		return GCInfo{}, err
 	}
 
-	// Resolve all intents.
-	log.Eventf(ctx, "resolving up to %d intents", len(txnMap))
+	// Resolve all intents. If we have too many intents, that can lead to
+	// the case in which our context expires and we can't finish. However,
+	// because all of these intents fall within a single range, this is
+	// likely to be less problematic than cleaning up a highly distributed
+	// transaction's intents. Because the intent resolution is done in batches
+	// of 100 intents, even if this times out, the next pass will be easier.
 	var intents []roachpb.Intent
 	for txnID, txn := range txnMap {
 		if txn.Status != roachpb.PENDING {
-			for _, intent := range intentSpanMap[txnID] {
-				intents = append(intents, roachpb.Intent{Span: intent, Status: txn.Status, Txn: txn.TxnMeta})
-			}
+			intents = append(intents, roachpb.AsIntents(intentSpanMap[txnID], txn)...)
 		}
 	}
+	log.Eventf(ctx, "resolving %d intents", len(intents))
 
 	if err := resolveIntentsFn(intents, ResolveOptions{Wait: true, Poison: false}); err != nil {
-		return nil, GCInfo{}, err
+		return GCInfo{}, err
 	}
 
-	// Clean up the AbortSpan.
-	log.Event(ctx, "processing AbortSpan")
-	gcKeys = append(gcKeys, processAbortSpan(
-		ctx, snap, desc.RangeID, abortSpanGCThreshold, &infoMu, pushTxnFn)...)
-	return gcKeys, infoMu.GCInfo, nil
+	return infoMu.GCInfo, nil
 }
 
 // timer returns a constant duration to space out GC processing

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -48,14 +49,6 @@ const (
 	// processing intents is best effort, we'd rather give up than wait too long
 	// (this helps avoid deadlocks during test shutdown).
 	intentResolverTimeout = 30 * time.Second
-
-	// intentResolverBatchSize is the maximum number of intents that will
-	// be resolved in a single batch. Batches that span many ranges (which
-	// is possible for the commit of a transaction that spans many ranges)
-	// will be split into many batches with NoopRequests by the
-	// DistSender, leading to high CPU overhead and quadratic memory
-	// usage.
-	intentResolverBatchSize = 100
 )
 
 // intentResolver manages the process of pushing transactions and
@@ -101,7 +94,9 @@ func (ir *intentResolver) processWriteIntentError(
 		log.Infof(ctx, "resolving write intent %s", wiErr)
 	}
 
-	resolveIntents, pErr := ir.maybePushTransactions(ctx, wiErr.Intents, h, pushType, false)
+	resolveIntents, pErr := ir.maybePushTransactions(
+		ctx, wiErr.Intents, h, pushType, false, /* skipIfInFlight */
+	)
 	if pErr != nil {
 		return pErr
 	}
@@ -191,9 +186,11 @@ func (ir *intentResolver) maybePushTransactions(
 			cleanupPushIntentsLocked()
 			ir.mu.Unlock()
 			return nil, roachpb.NewErrorf("unexpected %s intent: %+v", intent.Status, intent)
-		} else if _, ok := ir.mu.inFlight[intent.Txn.ID]; ok && skipIfInFlight {
-			// Another goroutine is working on this transaction so we can
-			// skip it.
+		}
+		_, alreadyPushing := pushTxns[intent.Txn.ID]
+		_, pushTxnInFlight := ir.mu.inFlight[intent.Txn.ID]
+		if !alreadyPushing && pushTxnInFlight && skipIfInFlight {
+			// Another goroutine is working on this transaction so we can skip it.
 			if log.V(1) {
 				log.Infof(ctx, "skipping PushTxn for %s; attempt already in flight", intent.Txn.ID)
 			}
@@ -230,28 +227,35 @@ func (ir *intentResolver) maybePushTransactions(
 			PushType: pushType,
 		})
 	}
+
+	// Sort the push txn requests to maximize batching by range.
+	sort.Slice(pushReqs, func(i, j int) bool {
+		return pushReqs[i].Header().Key.Compare(pushReqs[j].Header().Key) < 0
+	})
+
+	var pErr *roachpb.Error
+	pushedTxns := map[uuid.UUID]roachpb.Transaction{}
 	b := &client.Batch{}
 	b.AddRawRequest(pushReqs...)
-	var pErr *roachpb.Error
-	if err := ir.store.db.Run(ctx, b); err != nil {
+	if err := ir.store.DB().Run(ctx, b); err != nil {
 		pErr = b.MustPErr()
+	} else {
+		br := b.RawResponse()
+		for _, resp := range br.Responses {
+			txn := resp.GetInner().(*roachpb.PushTxnResponse).PusheeTxn
+			if _, ok := pushedTxns[txn.ID]; ok {
+				panic(fmt.Sprintf("have two PushTxn responses for %s", txn.ID))
+			}
+			pushedTxns[txn.ID] = txn
+			log.Eventf(ctx, "%s is now %s", txn.ID, txn.Status)
+		}
 	}
+
 	ir.mu.Lock()
 	cleanupPushIntentsLocked()
 	ir.mu.Unlock()
 	if pErr != nil {
 		return nil, pErr
-	}
-
-	br := b.RawResponse()
-	pushedTxns := map[uuid.UUID]roachpb.Transaction{}
-	for _, resp := range br.Responses {
-		txn := resp.GetInner().(*roachpb.PushTxnResponse).PusheeTxn
-		if _, ok := pushedTxns[txn.ID]; ok {
-			panic(fmt.Sprintf("have two PushTxn responses for %s", txn.ID))
-		}
-		pushedTxns[txn.ID] = txn
-		log.Eventf(ctx, "%s is now %s", txn.ID, txn.Status)
 	}
 
 	var resolveIntents []roachpb.Intent
@@ -264,6 +268,7 @@ func (ir *intentResolver) maybePushTransactions(
 		intent.Status = pushee.Status
 		resolveIntents = append(resolveIntents, intent)
 	}
+
 	return resolveIntents, nil
 }
 
@@ -313,96 +318,168 @@ func (ir *intentResolver) processIntents(
 	ctx context.Context, r *Replica, item result.IntentsWithArg, now hlc.Timestamp,
 ) {
 	if item.Arg.Method() != roachpb.EndTransaction {
-		h := roachpb.Header{Timestamp: now}
-		resolveIntents, pushErr := ir.maybePushTransactions(ctx,
-			item.Intents, h, roachpb.PUSH_TOUCH, true /* skipInFlight */)
-
-		// resolveIntents with poison=true because we're resolving
-		// intents outside of the context of an EndTransaction.
-		//
-		// Naively, it doesn't seem like we need to poison the abort
-		// cache since we're pushing with PUSH_TOUCH - meaning that
-		// the primary way our Push leads to aborting intents is that
-		// of the transaction having timed out (and thus presumably no
-		// client being around any more, though at the time of writing
-		// we don't guarantee that). But there are other paths in which
-		// the Push comes back successful while the coordinating client
-		// may still be active. Examples of this are when:
-		//
-		// - the transaction was aborted by someone else, but the
-		//   coordinating client may still be running.
-		// - the transaction entry wasn't written yet, which at the
-		//   time of writing has our push abort it, leading to the
-		//   same situation as above.
-		//
-		// Thus, we must poison.
-		if err := ir.resolveIntents(ctx, resolveIntents,
-			ResolveOptions{Wait: true, Poison: true}); err != nil {
-			log.Warningf(ctx, "%s: failed to resolve intents: %s", r, err)
-			return
-		}
-		if pushErr != nil {
-			log.Warningf(ctx, "%s: failed to push during intent resolution: %s", r, pushErr)
-			return
+		if _, err := ir.cleanupIntents(ctx, item.Intents, now, roachpb.PUSH_TOUCH); err != nil {
+			log.Warning(ctx, err)
 		}
 	} else { // EndTransaction
-		// For EndTransaction, we know the transaction is finalized so
-		// we can skip the push and go straight to the resolve.
-		//
-		// This mechanism assumes that when an EndTransaction fails,
-		// the client makes no assumptions about the result. For
-		// example, an attempt to explicitly rollback the transaction
-		// may succeed (triggering this code path), but the result may
-		// not make it back to the client.
-		if err := ir.resolveIntents(ctx, item.Intents,
-			ResolveOptions{Wait: true, Poison: false}); err != nil {
-			log.Warningf(ctx, "%s: failed to resolve intents: %s", r, err)
-			return
+		partialTxn := &roachpb.Transaction{
+			TxnMeta: item.Intents[0].Txn,
+			Status:  item.Intents[0].Status,
 		}
-
-		// We successfully resolved the intents, so we're able to GC from
-		// the txn span directly.
-		b := &client.Batch{}
-		txn := item.Intents[0].Txn
-		txnKey := keys.TransactionKey(txn.Key, txn.ID)
-
-		// This is pretty tricky. Transaction keys are range-local and
-		// so they are encoded specially. The key range addressed by
-		// (txnKey, txnKey.Next()) might be empty (since Next() does
-		// not imply monotonicity on the address side). Instead, we
-		// send this request to a range determined using the resolved
-		// transaction anchor, i.e. if the txn is anchored on
-		// /Local/RangeDescriptor/"a"/uuid, the key range below would
-		// be ["a", "a\x00"). However, the first range is special again
-		// because the above procedure results in KeyMin, but we need
-		// at least KeyLocalMax.
-		//
-		// #7880 will address this by making GCRequest less special and
-		// thus obviating the need to cook up an artificial range here.
-		var gcArgs roachpb.GCRequest
-		{
-			key := keys.MustAddr(txn.Key)
-			if localMax := keys.MustAddr(keys.LocalMax); key.Less(localMax) {
-				key = localMax
-			}
-			endKey := key.Next()
-
-			gcArgs.Span = roachpb.Span{
-				Key:    key.AsRawKey(),
-				EndKey: endKey.AsRawKey(),
-			}
-		}
-
-		gcArgs.Keys = append(gcArgs.Keys, roachpb.GCRequest_GCKey{
-			Key: txnKey,
-		})
-		b.AddRawRequest(&gcArgs)
-		if err := ir.store.db.Run(ctx, b); err != nil {
-			log.Warningf(ctx, "could not GC completed transaction anchored at %s: %s",
-				roachpb.Key(txn.Key), err)
-			return
+		if err := ir.cleanupTxnIntents(ctx, partialTxn, item.Intents, now); err != nil {
+			log.Warning(ctx, err)
 		}
 	}
+}
+
+// cleanupIntents processes a collection of intents by pushing each
+// implicated transaction using the specified pushType. Intents
+// belonging to non-pending transactions after the push are resolved.
+// Returns the number of resolved intents.
+func (ir *intentResolver) cleanupIntents(
+	ctx context.Context, intents []roachpb.Intent, now hlc.Timestamp, pushType roachpb.PushTxnType,
+) (int, error) {
+	h := roachpb.Header{Timestamp: now}
+	resolveIntents, pushErr := ir.maybePushTransactions(
+		ctx, intents, h, pushType, true, /* skipIfInFlight */
+	)
+
+	// resolveIntents with poison=true because we're resolving
+	// intents outside of the context of an EndTransaction.
+	//
+	// Naively, it doesn't seem like we need to poison the abort
+	// cache since we're pushing with PUSH_TOUCH - meaning that
+	// the primary way our Push leads to aborting intents is that
+	// of the transaction having timed out (and thus presumably no
+	// client being around any more, though at the time of writing
+	// we don't guarantee that). But there are other paths in which
+	// the Push comes back successful while the coordinating client
+	// may still be active. Examples of this are when:
+	//
+	// - the transaction was aborted by someone else, but the
+	//   coordinating client may still be running.
+	// - the transaction entry wasn't written yet, which at the
+	//   time of writing has our push abort it, leading to the
+	//   same situation as above.
+	//
+	// Thus, we must poison.
+	if err := ir.resolveIntents(ctx, resolveIntents,
+		ResolveOptions{Wait: true, Poison: true}); err != nil {
+		return 0, errors.Wrapf(err, "failed to resolve intents")
+	}
+	if pushErr != nil {
+		return len(resolveIntents), errors.Wrapf(pushErr.GoError(), "failed to push during intent resolution")
+	}
+	return len(resolveIntents), nil
+}
+
+// cleanupTxnIntentsOnGCAsync cleans up extant intents owned by a
+// single transaction, asynchronously. This method updates the metrics
+// for intents resolved on GC on success.
+func (ir *intentResolver) cleanupTxnIntentsOnGCAsync(
+	ctx context.Context, txn *roachpb.Transaction, intents []roachpb.Intent, now hlc.Timestamp,
+) error {
+	err := ir.store.Stopper().RunLimitedAsyncTask(
+		// If we've successfully launched a background task,
+		// dissociate this work from our caller's context and
+		// timeout.
+		context.Background(),
+		"processing txn intents",
+		ir.sem,
+		false, /* wait */
+		func(ctx context.Context) {
+			if err := ir.cleanupTxnIntents(ctx, txn, intents, now); err != nil {
+				log.Warningf(ctx, "failed to cleanup transaction intents: %s", err)
+			} else {
+				ir.store.metrics.GCResolveSuccess.Inc(int64(len(intents)))
+			}
+		},
+	)
+	if err != nil {
+		return errors.Wrapf(err, "intents for txn %+v not asynchonously processed", intents[0].Txn)
+	}
+	return nil
+}
+
+// cleanupTxnIntents cleans up extant intents owned by a single
+// transaction and when all intents have been successfully
+// resolved, the transaction record is GC'ed.
+func (ir *intentResolver) cleanupTxnIntents(
+	ctx context.Context, txn *roachpb.Transaction, intents []roachpb.Intent, now hlc.Timestamp,
+) error {
+	// If the transaction is still pending, but expired, push it
+	// before resolving the intents.
+	if txn.Status == roachpb.PENDING {
+		if !txnwait.IsExpired(now, txn) {
+			return fmt.Errorf("cannot push a PENDING transaction which is not expired: %s", txn)
+		}
+		b := &client.Batch{}
+		b.AddRawRequest(&roachpb.PushTxnRequest{
+			Span: roachpb.Span{Key: txn.Key},
+			PusherTxn: roachpb.Transaction{
+				TxnMeta: enginepb.TxnMeta{Priority: roachpb.MaxTxnPriority},
+			},
+			PusheeTxn: txn.TxnMeta,
+			Now:       now,
+			PushType:  roachpb.PUSH_ABORT,
+		})
+		if err := ir.store.DB().Run(ctx, b); err != nil {
+			return err
+		}
+		// Get the pushed txn and update the intents slice.
+		txn = &b.RawResponse().Responses[0].GetInner().(*roachpb.PushTxnResponse).PusheeTxn
+		for _, intent := range intents {
+			intent.Txn = txn.TxnMeta
+			intent.Status = txn.Status
+		}
+	}
+
+	// Resolve intents.
+	if err := ir.resolveIntents(ctx, intents, ResolveOptions{Wait: true, Poison: false}); err != nil {
+		return errors.Wrapf(err, "failed to resolve intents")
+	}
+
+	// We successfully resolved the intents, so we're able to GC from
+	// the txn span directly.
+	b := &client.Batch{}
+	txnKey := keys.TransactionKey(txn.Key, txn.ID)
+
+	// This is pretty tricky. Transaction keys are range-local and
+	// so they are encoded specially. The key range addressed by
+	// (txnKey, txnKey.Next()) might be empty (since Next() does
+	// not imply monotonicity on the address side). Instead, we
+	// send this request to a range determined using the resolved
+	// transaction anchor, i.e. if the txn is anchored on
+	// /Local/RangeDescriptor/"a"/uuid, the key range below would
+	// be ["a", "a\x00"). However, the first range is special again
+	// because the above procedure results in KeyMin, but we need
+	// at least KeyLocalMax.
+	//
+	// #7880 will address this by making GCRequest less special and
+	// thus obviating the need to cook up an artificial range here.
+	var gcArgs roachpb.GCRequest
+	{
+		key := keys.MustAddr(txn.Key)
+		if localMax := keys.MustAddr(keys.LocalMax); key.Less(localMax) {
+			key = localMax
+		}
+		endKey := key.Next()
+
+		gcArgs.Span = roachpb.Span{
+			Key:    key.AsRawKey(),
+			EndKey: endKey.AsRawKey(),
+		}
+	}
+
+	gcArgs.Keys = append(gcArgs.Keys, roachpb.GCRequest_GCKey{
+		Key: txnKey,
+	})
+	b.AddRawRequest(&gcArgs)
+	if err := ir.store.db.Run(ctx, b); err != nil {
+		return errors.Wrapf(err, "could not GC completed transaction anchored at %s",
+			roachpb.Key(txn.Key))
+	}
+	return nil
 }
 
 // ResolveOptions is used during intent resolution. It specifies whether the
@@ -459,36 +536,13 @@ func (ir *intentResolver) resolveIntents(
 		reqs = append(reqs, resolveArgs)
 	}
 
-	// Sort the intents to maximize batching by range.
-	sort.Slice(reqs, func(i, j int) bool {
-		return reqs[i].Header().Key.Compare(reqs[j].Header().Key) < 0
-	})
+	b := &client.Batch{}
+	b.AddRawRequest(reqs...)
 
-	// Resolve all of the intents in batches of size intentResolverBatchSize.
-	// The maximum timeout is intentResolverTimeout, and this is applied to
-	// each batch to ensure forward progress is made. A large set of intents
-	// might require more time than a single timeout allows.
-	for len(reqs) > 0 {
-		b := &client.Batch{}
-		if len(reqs) > intentResolverBatchSize {
-			b.AddRawRequest(reqs[:intentResolverBatchSize]...)
-			reqs = reqs[intentResolverBatchSize:]
-		} else {
-			b.AddRawRequest(reqs...)
-			reqs = nil
-		}
-
-		// Everything here is best effort; so give the context a timeout to avoid
-		// waiting too long. This may be a larger timeout than the context already
-		// has, in which case we'll respect the existing timeout.
-		ctxWithTimeout, cancel := context.WithTimeout(ctx, intentResolverTimeout)
-		err := ir.store.DB().Run(ctxWithTimeout, b)
-		cancel()
-		if err != nil {
-			// Bail out on the first error.
-			return err
-		}
-	}
-
-	return nil
+	// Everything here is best effort; so give the context a timeout to avoid
+	// waiting too long. This may be a larger timeout than the context already
+	// has, in which case we'll respect the existing timeout.
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, intentResolverTimeout)
+	defer cancel()
+	return ir.store.DB().Run(ctxWithTimeout, b)
 }

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2619,7 +2619,9 @@ func (r *Replica) executeReadOnlyBatch(
 		// RangeLookup request which prohibits any concurrent requests for the same
 		// range. See #17760.
 		_, hasRangeLookup := ba.GetArg(roachpb.RangeLookup)
-		r.store.intentResolver.processIntentsAsync(ctx, r, intents, !hasRangeLookup)
+		if err := r.store.intentResolver.processIntentsAsync(ctx, r, intents, !hasRangeLookup); err != nil {
+			log.Warning(ctx, err)
+		}
 	}
 	if pErr != nil {
 		log.ErrEvent(ctx, pErr.String())
@@ -2829,7 +2831,9 @@ func (r *Replica) tryExecuteWriteBatch(
 				// both leave intents to GC that don't hit this code path. No good
 				// solution presents itself at the moment and such intents will be
 				// resolved on reads.
-				r.store.intentResolver.processIntentsAsync(ctx, r, propResult.Intents, true /* allowSync*/)
+				if err := r.store.intentResolver.processIntentsAsync(ctx, r, propResult.Intents, true /* allowSync*/); err != nil {
+					log.Warning(ctx, err)
+				}
 			}
 			return propResult.Reply, propResult.Err, propResult.ProposalRetry
 		case <-slowTimer.C:
@@ -5671,7 +5675,9 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (config.SystemConfig, er
 		// There were intents, so what we read may not be consistent. Attempt
 		// to nudge the intents in case they're expired; next time around we'll
 		// hopefully have more luck.
-		r.store.intentResolver.processIntentsAsync(ctx, r, intents, true /* allowSync */)
+		if err := r.store.intentResolver.processIntentsAsync(ctx, r, intents, true /* allowSync */); err != nil {
+			log.Warning(ctx, err)
+		}
 		return config.SystemConfig{}, errSystemConfigIntent
 	}
 	kvs := br.Responses[0].GetInner().(*roachpb.ScanResponse).Rows


### PR DESCRIPTION
Transactions with enough intent spans to GC have proven problematic when
the intents cannot be resolved within the timeout. This can lead to the
GC queue timing out without ever being able to finish a range.

This PR removes a temporary fix to limit synchronous intent cleanups to
a maximum of 800 and replaces that with two different initiatives:

- Expired transaction records are now processed entirely asynchronously
  using the intent resolver's `processIntentsAsync()`. This avoids hanging
  normal processing of GC'able spans.
 - `intentResolver.resolveIntents` was previously creating additional
   async tasks for every batch, which while the batching alleviates the
   quadratic slowdown from noop entries in the batches, would end up with
   up to 100 batches in parallel, each with 100 intents. That would be a
   massive hit to any system, much less one with 3 nodes. Seems better to
   simplify this method and run the batches serially, each with its own
   timeout. Intent resolution is inherently amortizable; there's no need
   for this kind of rush.
 - `intentResolver.resolveIntents` now sets a separate timeout for every
   batch of 100 intents. The idea here is that we want to always be making
   forward progress within the intent resolution timeout, as opposed to
   being able to finish resolving every intent within the timeout.
- GC'able spans are chunked and GC'ed *before* we move to pushing txns
  and resolving intents for user keyspace spans. This prevents us from
  doing all the work to scan the range only to never send the GC request
  because we timeout trying to push potentially many txns and resolve
  potentially many intents.