### PR TITLE
encoding: return rest of decode buffer when decoding NaN, Inf, -Inf decimals

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -117,6 +117,43 @@ SELECT 'NaN'::decimal, '-NaN'::decimal, 'sNaN'::decimal, '-sNaN'::decimal
 ----
 NaN NaN NaN NaN
 
+query ITTT
+EXPLAIN SELECT * FROM t2 WHERE d IS NaN and v IS NaN
+----
+0  scan  ·      ·
+0  ·     table  t2@primary
+0  ·     spans  /NaN/NaN-/NaN/-Infinity
+
+query RR
+SELECT * FROM t2 WHERE d IS NaN and v IS NaN
+----
+NaN NaN
+
+# The NaN suffix is decimalNaNDesc, not decimalNaN(Asc).
+query ITTT
+EXPLAIN SELECT * FROM t2 WHERE d = 'Infinity' and v = 'Infinity'
+----
+0  scan  ·      ·
+0  ·     table  t2@primary
+0  ·     spans  /Infinity/Infinity-/Infinity/NaN
+
+query RR
+SELECT * FROM t2 WHERE d = 'Infinity' and v = 'Infinity'
+----
+Infinity Infinity
+
+query ITTT
+EXPLAIN SELECT * FROM t2 WHERE d = '-Infinity' and v = '-Infinity'
+----
+0  scan  ·      ·
+0  ·     table  t2@primary
+0  ·     spans  /-Infinity/-Infinity-/-Infinity/-Infinity/PrefixEnd
+
+query RR
+SELECT * FROM t2 WHERE d = '-Infinity' and v = '-Infinity'
+----
+-Infinity -Infinity
+
 # Ensure special values are handled correctly.
 
 statement ok

--- a/pkg/util/encoding/decimal.go
+++ b/pkg/util/encoding/decimal.go
@@ -264,11 +264,11 @@ func decodeDecimal(buf []byte, tmp []byte, invert bool) ([]byte, apd.Decimal, er
 	// Handle the simplistic cases first.
 	switch buf[0] {
 	case decimalNaN, decimalNaNDesc:
-		return nil, apd.Decimal{Form: apd.NaN}, nil
+		return buf[1:], apd.Decimal{Form: apd.NaN}, nil
 	case decimalInfinity:
-		return nil, apd.Decimal{Form: apd.Infinite, Negative: invert}, nil
+		return buf[1:], apd.Decimal{Form: apd.Infinite, Negative: invert}, nil
 	case decimalNegativeInfinity:
-		return nil, apd.Decimal{Form: apd.Infinite, Negative: !invert}, nil
+		return buf[1:], apd.Decimal{Form: apd.Infinite, Negative: !invert}, nil
 	case decimalZero:
 		return buf[1:], apd.Decimal{}, nil
 	}


### PR DESCRIPTION
This affected `prettyPrintFirstValue` since the buffer would be wiped after the first `NaN`, `Infinity`, or `-Infinity` was decoded.

This also "affected" `DecodeTableKey` which is used in `EncDatum.EnsureDecoded`. Note however that we parsed each byte slice on a datum basis so each call to `EnsureDecoded` was at most to one `NaN, Inf` etc. or a regular decimal value.