### PR TITLE
sql: support to_json of JSON builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1,3 +1,14 @@
+### ANYELEMENT Functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>to_json(val: anyelement) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the value as JSON or JSONB.</p>
+</span></td></tr>
+<tr><td><code>to_jsonb(val: anyelement) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the value as JSON or JSONB.</p>
+</span></td></tr></tbody>
+</table>
+
 ### Array Functions
 
 <table>

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -72,6 +72,197 @@ SELECT jsonb_typeof('null'::JSON)
 ----
 null
 
+## to_json and to_jsonb
+
+query T
+SELECT to_json(123::INT)
+----
+123
+
+query T
+SELECT to_json('\a'::TEXT)
+----
+"\\a"
+
+query T
+SELECT to_json('\a'::TEXT COLLATE "fr_FR")
+----
+"\\a"
+
+query T
+SELECT to_json(3::OID::INT::OID)
+----
+"3"
+
+query T
+SELECT to_json('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::UUID);
+----
+"a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+
+query T
+SELECT to_json('\x0001'::BYTEA)
+----
+"\\x0001"
+
+query T
+SELECT to_json(true::BOOL)
+----
+true
+
+query T
+SELECT to_json(false::BOOL)
+----
+false
+
+query T
+SELECT to_json('"a"'::JSON)
+----
+"a"
+
+query T
+SELECT to_json(1.234::FLOAT)
+----
+1.234
+
+query T
+SELECT to_json(1.234::DECIMAL)
+----
+1.234
+
+query T
+SELECT to_json('10.1.0.0/16'::INET)
+----
+"10.1.0.0/16"
+
+query T
+SELECT to_json(ARRAY[[1, 2], [3, 4]])
+----
+[[1,2],[3,4]]
+
+query T
+SELECT to_json('2014-05-28 12:22:35.614298'::TIMESTAMP)
+----
+"2014-05-28 12:22:35.614298+00:00"
+
+query T
+SELECT to_json('2014-05-28 12:22:35.614298-04'::TIMESTAMPTZ)
+----
+"2014-05-28 12:22:35.614298-04:00"
+
+query T
+SELECT to_json('2014-05-28'::DATE)
+----
+"2014-05-28"
+
+query T
+SELECT to_json('00:00:00'::TIME)
+----
+"00:00:00"
+
+query T
+SELECT to_json('2h45m2s234ms'::INTERVAL)
+----
+"2h45m2s234ms"
+
+query T
+SELECT to_json((1, 2, 'hello', NULL, NULL))
+----
+{"f1":1,"f2":2,"f3":"hello","f4":null,"f5":null}
+
+query T
+SELECT to_jsonb(123::INT)
+----
+123
+
+query T
+SELECT to_jsonb('\a'::TEXT)
+----
+"\\a"
+
+query T
+SELECT to_jsonb('\a'::TEXT COLLATE "fr_FR")
+----
+"\\a"
+
+query T
+SELECT to_jsonb(3::OID::INT::OID)
+----
+"3"
+
+query T
+SELECT to_jsonb('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'::UUID);
+----
+"a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+
+query T
+SELECT to_jsonb('\x0001'::BYTEA)
+----
+"\\x0001"
+
+query T
+SELECT to_jsonb(true::BOOL)
+----
+true
+
+query T
+SELECT to_jsonb(false::BOOL)
+----
+false
+
+query T
+SELECT to_jsonb('"a"'::JSON)
+----
+"a"
+
+query T
+SELECT to_jsonb(1.234::FLOAT)
+----
+1.234
+
+query T
+SELECT to_jsonb(1.234::DECIMAL)
+----
+1.234
+
+query T
+SELECT to_jsonb('10.1.0.0/16'::INET)
+----
+"10.1.0.0/16"
+
+query T
+SELECT to_jsonb(ARRAY[[1, 2], [3, 4]])
+----
+[[1,2],[3,4]]
+
+query T
+SELECT to_jsonb('2014-05-28 12:22:35.614298'::TIMESTAMP)
+----
+"2014-05-28 12:22:35.614298+00:00"
+
+query T
+SELECT to_jsonb('2014-05-28 12:22:35.614298-04'::TIMESTAMPTZ)
+----
+"2014-05-28 12:22:35.614298-04:00"
+
+query T
+SELECT to_jsonb('2014-05-28'::DATE)
+----
+"2014-05-28"
+
+query T
+SELECT to_jsonb('00:00:00'::TIME)
+----
+"00:00:00"
+
+query T
+SELECT to_jsonb('2h45m2s234ms'::INTERVAL)
+----
+"2h45m2s234ms"
+
+query T
+SELECT to_jsonb((1, 2, 'hello', NULL, NULL))
+----
+{"f1":1,"f2":2,"f3":"hello","f4":null,"f5":null}
 
 ## json_array_elements and jsonb_array_elements
 

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -501,6 +501,98 @@ func (j jsonObject) EncodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 	return outKeys, nil
 }
 
+// FromDecimal returns a JSON value given a apd.Decimal.
+func FromDecimal(v apd.Decimal) JSON {
+	return jsonNumber(v)
+}
+
+// FromArrayOfJSON returns a JSON value given a []JSON.
+func FromArrayOfJSON(v []JSON) JSON {
+	return jsonArray(v)
+}
+
+// FromNumber returns a JSON value given a json.Number.
+func FromNumber(v json.Number) (JSON, error) {
+	// The JSON decoder has already verified that the string `v` represents a
+	// valid JSON number, and the set of valid JSON numbers is a [proper] subset
+	// of the set of valid apd.Decimal values.
+	dec := apd.Decimal{}
+	_, _, err := dec.SetString(string(v))
+	return jsonNumber(dec), err
+}
+
+// FromString returns a JSON value given a string.
+func FromString(v string) JSON {
+	return jsonString(v)
+}
+
+// FromBool returns a JSON value given a bool.
+func FromBool(v bool) JSON {
+	if v {
+		return TrueJSONValue
+	}
+	return FalseJSONValue
+}
+
+func fromArray(v []interface{}) (JSON, error) {
+	elems := make([]JSON, len(v))
+	for i := range v {
+		var err error
+		elems[i], err = MakeJSON(v[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return jsonArray(elems), nil
+}
+
+// FromMap returns a JSON value given a map[string]interface{}.
+func FromMap(v map[string]interface{}) (JSON, error) {
+	keys := make([]string, len(v))
+	i := 0
+	for k := range v {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+	result := make([]jsonKeyValuePair, len(v))
+	for i := range keys {
+		v, err := MakeJSON(v[keys[i]])
+		if err != nil {
+			return nil, err
+		}
+		result[i] = jsonKeyValuePair{
+			k: jsonString(keys[i]),
+			v: v,
+		}
+	}
+	return jsonObject(result), nil
+}
+
+// FromInt returns a JSON value given a int.
+func FromInt(v int) JSON {
+	dec := apd.Decimal{}
+	dec.SetCoefficient(int64(v))
+	return jsonNumber(dec)
+}
+
+// FromInt64 returns a JSON value given a int64.
+func FromInt64(v int64) JSON {
+	dec := apd.Decimal{}
+	dec.SetCoefficient(v)
+	return jsonNumber(dec)
+}
+
+// FromFloat64 returns a JSON value given a float64.
+func FromFloat64(v float64) (JSON, error) {
+	dec := apd.Decimal{}
+	_, err := dec.SetFloat64(v)
+	if err != nil {
+		return nil, err
+	}
+	return jsonNumber(dec), nil
+}
+
 // MakeJSON returns a JSON value given a Go-style representation of JSON.
 // * JSON null is Go `nil`,
 // * JSON true is Go `true`,
@@ -512,68 +604,25 @@ func (j jsonObject) EncodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 func MakeJSON(d interface{}) (JSON, error) {
 	switch v := d.(type) {
 	case json.Number:
-		// The JSON decoder has already verified that the string `v` represents a
-		// valid JSON number, and the set of valid JSON numbers is a [proper] subset
-		// of the set of valid apd.Decimal values.
-		dec := apd.Decimal{}
-		_, _, err := dec.SetString(string(v))
-		return jsonNumber(dec), err
+		return FromNumber(v)
 	case string:
-		return jsonString(v), nil
+		return FromString(v), nil
 	case bool:
-		if v {
-			return TrueJSONValue, nil
-		}
-		return FalseJSONValue, nil
+		return FromBool(v), nil
 	case nil:
 		return NullJSONValue, nil
 	case []interface{}:
-		elems := make([]JSON, len(v))
-		for i := range v {
-			var err error
-			elems[i], err = MakeJSON(v[i])
-			if err != nil {
-				return nil, err
-			}
-		}
-		return jsonArray(elems), nil
+		return fromArray(v)
 	case map[string]interface{}:
-		keys := make([]string, len(v))
-		i := 0
-		for k := range v {
-			keys[i] = k
-			i++
-		}
-		sort.Strings(keys)
-		result := make([]jsonKeyValuePair, len(v))
-		for i := range keys {
-			v, err := MakeJSON(v[keys[i]])
-			if err != nil {
-				return nil, err
-			}
-			result[i] = jsonKeyValuePair{
-				k: jsonString(keys[i]),
-				v: v,
-			}
-		}
-		return jsonObject(result), nil
+		return FromMap(v)
 		// The below are not used by ParseJSON, but are provided for ease-of-use when
 		// constructing Datums.
 	case int:
-		dec := apd.Decimal{}
-		dec.SetCoefficient(int64(v))
-		return jsonNumber(dec), nil
+		return FromInt(v), nil
 	case int64:
-		dec := apd.Decimal{}
-		dec.SetCoefficient(v)
-		return jsonNumber(dec), nil
+		return FromInt64(v), nil
 	case float64:
-		dec := apd.Decimal{}
-		_, err := dec.SetFloat64(v)
-		if err != nil {
-			return nil, err
-		}
-		return jsonNumber(dec), nil
+		return FromFloat64(v)
 	case JSON:
 		// If we get passed a JSON, just accept it. This is useful in cases like the
 		// random JSON generator.


### PR DESCRIPTION
Hi @justinj , 

I am still working on some AsJSON functions and tests. I am not sure if I am on the right track. Could you take a skim on it? 

Also, when I tried to refer [Postgres json tests](https://github.com/postgres/postgres/blob/b574228715f0fd77ed1f4f084603cff9e757e992/src/test/regress/expected/json.out) to write some tests, I found that the parser could not handle some of them successfully, like select date 'Infinity',SELECT to_json('{{1,5},{99,100}}'::int[]) and so on. I am not sure if they need to be taken into account. 

Related to #20120.