### PR TITLE
sql: tighten spans at the beginning and end to not scan interleaved rows

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -122,7 +122,7 @@ EXPLAIN SELECT * FROM t2 WHERE d IS NaN and v IS NaN
 ----
 0  scan  ·      ·
 0  ·     table  t2@primary
-0  ·     spans  /NaN/NaN-/NaN/-Infinity
+0  ·     spans  /NaN/NaN-/NaN/NaN/#
 
 query RR
 SELECT * FROM t2 WHERE d IS NaN and v IS NaN
@@ -135,7 +135,7 @@ EXPLAIN SELECT * FROM t2 WHERE d = 'Infinity' and v = 'Infinity'
 ----
 0  scan  ·      ·
 0  ·     table  t2@primary
-0  ·     spans  /Infinity/Infinity-/Infinity/NaN
+0  ·     spans  /Infinity/Infinity-/Infinity/Infinity/#
 
 query RR
 SELECT * FROM t2 WHERE d = 'Infinity' and v = 'Infinity'
@@ -147,7 +147,7 @@ EXPLAIN SELECT * FROM t2 WHERE d = '-Infinity' and v = '-Infinity'
 ----
 0  scan  ·      ·
 0  ·     table  t2@primary
-0  ·     spans  /-Infinity/-Infinity-/-Infinity/-Infinity/PrefixEnd
+0  ·     spans  /-Infinity/-Infinity-/-Infinity/-Infinity/#
 
 query RR
 SELECT * FROM t2 WHERE d = '-Infinity' and v = '-Infinity'

--- a/pkg/sql/logictest/testdata/logic_test/deep_interleaving
+++ b/pkg/sql/logictest/testdata/logic_test/deep_interleaving
@@ -145,7 +145,7 @@ EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
 ----
 0  scan  ·      ·
 0  ·     table  level4@primary
-0  ·     spans  /2/#/52/1/#/53/1/20/101/#/54/1-/2/#/52/1/#/53/1/20/299/#/54/2
+0  ·     spans  /2/#/52/1/#/53/1/20/101/#/54/1-/2/#/52/1/#/53/1/20/299/#/54/1/#
 
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
@@ -157,7 +157,7 @@ EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
 ----
 0  scan  ·      ·
 0  ·     table  level4@primary
-0  ·     spans  /2/#/52/1/#/53/1/20/200/#/54/1-/2/#/52/1/#/53/1/20/200/#/54/2
+0  ·     spans  /2/#/52/1/#/53/1/20/200/#/54/1-/2/#/52/1/#/53/1/20/200/#/54/1/#
 
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200

--- a/pkg/sql/logictest/testdata/logic_test/explain_plan
+++ b/pkg/sql/logictest/testdata/logic_test/explain_plan
@@ -41,7 +41,7 @@ EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
 0  scan  ·      ·
 0  ·     table  t@primary
-0  ·     spans  /1-/2 /3-/4
+0  ·     spans  /1-/1/# /3-/3/#
 
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -312,7 +312,7 @@ EXPLAIN SELECT * FROM orders WHERE customer = 1 AND id = 1000
 ----
 0  scan  ·      ·
 0  ·     table  orders@primary
-0  ·     spans  /1/#/66/1/1000-/1/#/66/1/1001
+0  ·     spans  /1/#/66/1/1000-/1/#/66/1/1000/#
 
 # Check that interleaving can occur across databases
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1088,7 +1088,7 @@ SELECT *
 3  ·       filter    b > 1
 3  scan    ·         ·
 3  ·       table     square@primary
-3  ·       spans     /!NULL-/6
+3  ·       spans     /!NULL-/5/#
 
 query IIII rowsort
 SELECT *
@@ -1147,7 +1147,7 @@ SELECT *
 2  ·       filter    ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
 2  scan    ·         ·
 2  ·       table     square@primary
-2  ·       spans     /2-/6
+2  ·       spans     /2-/5/#
 
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -142,7 +142,7 @@ EXPLAIN (METADATA) DELETE FROM kv WHERE k = 3
 1  render  ·      ·           (k)              k=CONST; key()
 2  scan    ·      ·           (k, v[omitted])  k=CONST; key()
 2  ·       table  kv@primary  ·                ·
-2  ·       spans  /3-/4       ·                ·
+2  ·       spans  /3-/3/#     ·                ·
 
 # Ensure that propagations through a render node removes the renders
 # and properly propagates the remaining needed columns.

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -758,7 +758,7 @@ EXPLAIN (METADATA) DELETE FROM t WHERE a = 3 RETURNING b
 0  ·       from   t          ·          ·
 1  scan    ·      ·          (a, b, c)  a=CONST; key()
 1  ·       table  t@primary  ·          ·
-1  ·       spans  /3-/4      ·          ·
+1  ·       spans  /3-/3/#    ·          ·
 
 query ITTTTT
 EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b

--- a/pkg/sql/logictest/testdata/logic_test/physical_props
+++ b/pkg/sql/logictest/testdata/logic_test/physical_props
@@ -18,7 +18,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = 1
 Level  Type  Field  Description   Columns       Ordering
 0      scan  ·      ·             (a, b, c, d)  a=CONST; key()
 0      ·     table  abcd@primary  ·             ·
-0      ·     spans  /1-/2         ·             ·
+0      ·     spans  /1-/1/#       ·             ·
 
 query ITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE b = 1
@@ -35,7 +35,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = 1 AND b = 1
 Level  Type  Field   Description   Columns       Ordering
 0      scan  ·       ·             (a, b, c, d)  a=CONST; b=CONST; key()
 0      ·     table   abcd@primary  ·             ·
-0      ·     spans   /1-/2         ·             ·
+0      ·     spans   /1-/1/#       ·             ·
 0      ·     filter  b = 1         ·             ·
 
 query ITTTTT colnames
@@ -44,7 +44,7 @@ EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = 1 AND b = d
 Level  Type  Field   Description   Columns       Ordering
 0      scan  ·       ·             (a, b, c, d)  b=d; a=CONST; b!=NULL; d!=NULL; key()
 0      ·     table   abcd@primary  ·             ·
-0      ·     spans   /1-/2         ·             ·
+0      ·     spans   /1-/1/#       ·             ·
 0      ·     filter  b = d         ·             ·
 
 query ITTTTT colnames
@@ -124,10 +124,10 @@ Level  Type  Field           Description   Columns                Ordering
 0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
 1      scan  ·               ·             (a, b, c, d)           a=CONST; key()
 1      ·     table           abcd@primary  ·                      ·
-1      ·     spans           /1-/2         ·                      ·
+1      ·     spans           /1-/1/#       ·                      ·
 1      scan  ·               ·             (e, f, g)              f=g; e=CONST; f!=NULL; g!=NULL; key()
 1      ·     table           efg@primary   ·                      ·
-1      ·     spans           /1-/2         ·                      ·
+1      ·     spans           /1-/1/#       ·                      ·
 1      ·     filter          f = g         ·                      ·
 
 query ITTTTT colnames

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -419,6 +419,7 @@ EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
 1  ·       table  t@bc
 1  ·       spans  ALL
 
+# Note the span is reversed because of #20203.
 query ITTT
 EXPLAIN SELECT a FROM t WHERE b IN (5.0, 1)
 ----

--- a/pkg/sql/logictest/testdata/logic_test/select_index_hints
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_hints
@@ -27,7 +27,7 @@ EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
 0  scan  ·      ·
 0  ·     table  abcd@primary
-0  ·     spans  /20-/31
+0  ·     spans  /20-/30/#
 
 # Force primary
 
@@ -42,7 +42,7 @@ EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
 0  scan  ·      ·
 0  ·     table  abcd@primary
-0  ·     spans  /20-/31
+0  ·     spans  /20-/30/#
 
 # Force index b
 

--- a/pkg/sql/logictest/testdata/logic_test/select_tighten_spans
+++ b/pkg/sql/logictest/testdata/logic_test/select_tighten_spans
@@ -1,0 +1,488 @@
+# LogicTest: 5node-distsql
+
+# This test verifies that we correctly tighten spans during index selection as
+# well as after partitioning spans in distsql.
+
+################
+# Schema setup #
+################
+
+statement ok
+CREATE TABLE p1 (
+  a INT,
+  b INT,
+  PRIMARY KEY (a, b),
+  INDEX b (b)
+)
+
+statement ok
+CREATE TABLE c1 (
+  a INT,
+  b INT,
+  PRIMARY KEY (a,b)
+) INTERLEAVE IN PARENT p1 (a, b)
+
+statement ok
+CREATE TABLE p2 (
+  i INT PRIMARY KEY,
+  d INT
+)
+
+statement ok
+CREATE INDEX p2_id ON p2 (i, d) INTERLEAVE IN PARENT p2 (i)
+
+statement ok
+CREATE TABLE bytes_t (a BYTES PRIMARY KEY)
+
+statement ok
+CREATE TABLE decimal_t (a DECIMAL PRIMARY KEY)
+
+#######################
+# Insert dummy values #
+#######################
+
+statement ok
+INSERT INTO p1 VALUES
+  (1,10),
+  (2,1),
+  (2,2),
+  (2,8),
+  (3,5),
+  (3,10),
+  (4,1),
+  (4,2),
+  (4,4)
+
+statement ok
+INSERT INTO c1 VALUES
+  (1,10),
+  (2,1),
+  (2,4),
+  (2,8),
+  (2,10),
+  (4,2)
+
+statement ok
+INSERT INTO p2 VALUES
+  (1, NULL),
+  (2, 2),
+  (3, 1),
+  (4, NULL),
+  (5, NULL),
+  (6, 10),
+  (7, 2),
+  (8, 3)
+
+statement ok
+INSERT INTO bytes_t VALUES
+  ('a'),
+  ('aa'),
+  ('b'),
+  ('c'),
+  ('ca')
+
+statement ok
+INSERT INTO decimal_t VALUES
+  (1),
+  (1.000001),
+  (1.5),
+  (2),
+  (2.001)
+
+############################
+# Split ranges for distsql #
+############################
+
+# Perform some splits to exercise distsql partitioning as well.
+
+# Create split points at X = 2.
+# Also split at the beginning of each index (0 for ASC, 100 for DESC) to
+# prevent interfering with previous indexes/tables.
+
+# p1 table (interleaved index)
+statement ok
+ALTER TABLE p1 SPLIT AT VALUES(2)
+
+# Create a split at /2/#
+statement ok
+ALTER TABLE c1 SPLIT AT VALUES(2,1)
+
+# Split index
+statement ok
+ALTER INDEX b SPLIT AT VALUES(0)
+
+statement ok
+ALTER INDEX b SPLIT AT VALUES(2)
+
+# p2 table (interleaved index)
+statement ok
+ALTER TABLE p2 SPLIT AT VALUES(0)
+
+statement ok
+ALTER TABLE p2 SPLIT AT VALUES(2)
+
+# Create a split at /2/#
+statement ok
+ALTER INDEX p2_id SPLIT AT VALUES(2)
+
+#####################
+# Distribute ranges #
+#####################
+
+# Distribute our ranges across the first 3 (for primary index) and last 2
+# (for seconary indexes) nodes.
+
+statement ok
+ALTER TABLE p1 TESTING_RELOCATE SELECT ARRAY[i], i FROM generate_series(1,3) AS g(i)
+
+statement ok
+ALTER INDEX b TESTING_RELOCATE SELECT ARRAY[i+3], i FROM generate_series(1,2) AS g(i)
+
+# Interleaved index table
+statement ok
+ALTER TABLE p2 TESTING_RELOCATE SELECT ARRAY[i], i FROM generate_series(1,3) as g(i)
+
+#############################
+# Verify range distribution #
+#############################
+
+# p1 table (interleaved table)
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE p1
+----
+Start Key    End Key      Range ID  Replicas  Lease Holder
+NULL         /2           1         {1}       1
+/2           /2/1/#/52/1  2         {2}       2
+/2/1/#/52/1  NULL         3         {3}       3
+
+# Indexes
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM INDEX b
+----
+Start Key  End Key  Range ID  Replicas  Lease Holder
+NULL       /0       3         {3}       3
+/0         /2       4         {4}       4
+/2         NULL     5         {5}       5
+
+# p2 table (interleaved index)
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE p2
+----
+Start Key  End Key    Range ID  Replicas  Lease Holder
+NULL       /0         5         {5}       5
+/0         /2         6         {1}       1
+/2         /2/#/53/2  7         {2}       2
+/2/#/53/2  NULL       8         {3}       3
+
+###############
+# Query tests #
+###############
+
+# p1 table
+
+# Secondary index should not be tightened.
+query ITTT
+EXPLAIN SELECT * FROM p1 WHERE b <= 3
+----
+0  scan  ·      ·
+0  ·     table  p1@b
+0  ·     spans  /!NULL-/4
+
+query II rowsort
+SELECT * FROM p1 WHERE b <= 3
+----
+2 1
+2 2
+4 1
+4 2
+
+# Partial predicate on primary key should not be tightened.
+query ITTT
+EXPLAIN SELECT * FROM p1 WHERE a <= 3
+----
+0  scan  ·      ·
+0  ·     table  p1@primary
+0  ·     spans  /!NULL-/4
+
+query II rowsort
+SELECT * FROM p1 WHERE a <= 3
+----
+1 10
+2 1
+2 2
+2 8
+3 5
+3 10
+
+# Tighten end key if span contains full primary key.
+query ITTT
+EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b <= 3
+----
+0  scan  ·      ·
+0  ·     table  p1@primary
+0  ·     spans  /!NULL-/3/3/#
+
+query ITTT
+EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b < 4
+----
+0  scan  ·      ·
+0  ·     table  p1@primary
+0  ·     spans  /!NULL-/3/3/#
+
+query II rowsort
+SELECT * FROM p1 WHERE a <= 3 AND b <= 3
+----
+2 1
+2 2
+
+# Mixed bounds.
+query ITTT
+EXPLAIN SELECT * FROM p1 WHERE a >= 2 AND b <= 3
+----
+0  scan  ·      ·
+0  ·     table  p1@b
+0  ·     spans  /!NULL-/4
+
+query II rowsort
+SELECT * FROM p1 WHERE a >= 2 AND b <= 3
+----
+2 1
+2 2
+4 1
+4 2
+
+# Edge cases.
+
+query ITTT
+EXPLAIN SELECT * FROM p1 WHERE a <= 0 AND b <= 0
+----
+0  scan  ·      ·
+0  ·     table  p1@primary
+0  ·     spans  /!NULL-/0/0/#
+
+query ITTT
+EXPLAIN SELECT * FROM p1 WHERE a <= -1 AND b <= -1
+----
+0  scan  ·      ·
+0  ·     table  p1@primary
+0  ·     spans  /!NULL-/-1/-1/#
+
+query ITTT
+EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= -9223372036854775808
+----
+0  scan  ·      ·
+0  ·     table  p1@primary
+0  ·     spans  /1/!NULL-/1/-9223372036854775808/#
+
+query ITTT
+EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= 9223372036854775807
+----
+0  scan  ·      ·
+0  ·     table  p1@primary
+0  ·     spans  /1/!NULL-/1/9223372036854775807/#
+
+# Table c1 (interleaved table)
+
+# Partial primary key does not tighten.
+
+query ITTT
+EXPLAIN SELECT * FROM c1 WHERE a <= 3
+----
+0  scan  ·      ·
+0  ·     table  c1@primary
+0  ·     spans  /!NULL-/4
+
+query II rowsort
+SELECT * FROM c1 WHERE a <= 3
+----
+1 10
+2 1
+2 4
+2 8
+2 10
+
+# Tighten span on fully primary key.
+query ITTT
+EXPLAIN SELECT * FROM c1 WHERE a <= 3 AND b <= 3
+----
+0  scan  ·      ·
+0  ·     table  c1@primary
+0  ·     spans  /!NULL-/3/3/#/52/1/#
+
+query II rowsort
+SELECT * FROM c1 WHERE a <= 3 AND b <= 3
+----
+2 1
+
+# Table p2 with interleaved index.
+
+# From the primary index.
+
+# Lower bound (i >= 2)
+query ITTT
+EXPLAIN SELECT * FROM p2 WHERE i >= 2
+----
+0  scan  ·      ·
+0  ·     table  p2@primary
+0  ·     spans  /2-
+
+query II rowsort
+SELECT * FROM p2 WHERE i>= 2
+----
+2 2
+3 1
+4 NULL
+5 NULL
+6 10
+7 2
+8 3
+
+# Upper bound (i <= 5)
+
+query ITTT
+EXPLAIN SELECT * FROM p2 WHERE i <= 5
+----
+0  scan  ·      ·
+0  ·     table  p2@primary
+0  ·     spans  /!NULL-/5/#
+
+query II rowsort
+SELECT * FROM p2 WHERE i <= 5
+----
+1 NULL
+2 2
+3 1
+4 NULL
+5 NULL
+
+# From the interleaved index: no tightening at all.
+
+# Lower bound (i >= 1 AND d >= 2)
+
+# Note 53/2 refers to the 2nd index (after primary index) of table p2.
+query ITTT
+EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d >= 2
+----
+0  scan  ·      ·
+0  ·     table  p2@p2_id
+0  ·     spans  /1/#/53/2/2-
+
+query II rowsort
+SELECT * FROM p2@p2_id WHERE i>= 1 AND d >= 2
+----
+2 2
+6 10
+7 2
+8 3
+
+# Upper bound (i <= 6 AND d <= 5)
+
+query ITTT
+EXPLAIN SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
+----
+0  scan  ·      ·
+0  ·     table  p2@p2_id
+0  ·     spans  /!NULL-/6/#/53/2/6
+
+query II rowsort
+SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
+----
+2 2
+3 1
+
+# IS NULL
+
+query ITTT
+EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NULL
+----
+0  scan  ·      ·
+0  ·     table  p2@p2_id
+0  ·     spans  /1/#/53/2-
+
+query II rowsort
+SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NULL
+----
+1 NULL
+4 NULL
+5 NULL
+
+# IS NOT NULL
+
+query ITTT
+EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NOT NULL
+----
+0  scan  ·      ·
+0  ·     table  p2@p2_id
+0  ·     spans  /1/#/53/2/!NULL-
+
+query II rowsort
+SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NOT NULL
+----
+2 2
+3 1
+6 10
+7 2
+8 3
+
+# String table
+
+query ITTT colnames
+EXPLAIN SELECT * FROM bytes_t WHERE a = 'a'
+----
+Level  Type  Field  Description
+0      scan  ·      ·
+0      ·     table  bytes_t@primary
+0      ·     spans  /"a"-/"a"/#
+
+query T
+SELECT * FROM bytes_t WHERE a = 'a'
+----
+a
+
+# No tightening.
+
+query ITTT colnames
+EXPLAIN SELECT * FROM bytes_t WHERE a < 'aa'
+----
+Level  Type  Field  Description
+0      scan  ·      ·
+0      ·     table  bytes_t@primary
+0      ·     spans  /!NULL-/"aa"
+
+query T
+SELECT * FROM bytes_t WHERE a < 'aa'
+----
+a
+
+query ITTT colnames
+EXPLAIN SELECT * FROM decimal_t WHERE a = 1.00
+----
+Level  Type  Field  Description
+0      scan  ·      ·
+0      ·     table  decimal_t@primary
+0      ·     spans  /1-/1/#
+
+query R
+SELECT * FROM decimal_t WHERE a = 1.00
+----
+1
+
+# No tightening.
+
+query ITTT colnames
+EXPLAIN SELECT * FROM decimal_t WHERE a < 2
+----
+Level  Type  Field  Description
+0      scan  ·      ·
+0      ·     table  decimal_t@primary
+0      ·     spans  /!NULL-/2
+
+query R rowsort
+SELECT * FROM decimal_t WHERE a < 2
+----
+1
+1.000001
+1.5

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -485,7 +485,7 @@ EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 2  limit   ·      ·
 3  scan    ·      ·
 3  ·       table  kv@primary
-3  ·       spans  /!NULL-/3
+3  ·       spans  /!NULL-/2/#
 3  ·       limit  1
 
 query II

--- a/pkg/sql/sqlbase/utils_test.go
+++ b/pkg/sql/sqlbase/utils_test.go
@@ -1,0 +1,157 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+var tableNames = map[string]bool{
+	"parent1":     true,
+	"child1":      true,
+	"grandchild1": true,
+	"child2":      true,
+	"parent2":     true,
+}
+
+// This file contains test helper and utility functions for sqlbase.
+
+// EncodeTestKey takes the short format representation of a key and transforms
+// it into an actual roachpb.Key. Refer to ShortToLongKeyFmt for more info. on
+// the short format.
+func EncodeTestKey(tb testing.TB, kvDB *client.DB, keyStr string) roachpb.Key {
+	var key []byte
+	tokens := strings.Split(keyStr, "/")
+	if tokens[0] != "" {
+		panic("missing '/' token at the beginning of long format")
+	}
+
+	// Omit the first empty string.
+	tokens = tokens[1:]
+
+	for _, tok := range tokens {
+		// Encode the table ID if the token is a table name.
+		if tableNames[tok] {
+			desc := GetTableDescriptor(kvDB, sqlutils.TestDB, tok)
+			key = encoding.EncodeUvarintAscending(key, uint64(desc.ID))
+			continue
+		}
+
+		if tok == "NULLASC" {
+			key = encoding.EncodeNullAscending(key)
+			continue
+		}
+
+		if tok == "NOTNULLASC" {
+			key = encoding.EncodeNotNullAscending(key)
+			continue
+		}
+
+		if tok == "NULLDESC" {
+			key = encoding.EncodeNullDescending(key)
+			continue
+		}
+
+		// We make a distinction between this and the interleave
+		// sentinel below.
+		if tok == "NOTNULLDESC" {
+			key = encoding.EncodeNotNullDescending(key)
+			continue
+		}
+
+		// Interleaved sentinel.
+		if tok == "#" {
+			key = encoding.EncodeNotNullDescending(key)
+			continue
+		}
+
+		// Assume any other value is an unsigned integer.
+		tokInt, err := strconv.ParseInt(tok, 10, 64)
+		if err != nil {
+			tb.Fatal(err)
+		}
+		key = encoding.EncodeVarintAscending(key, tokInt)
+	}
+
+	return key
+}
+
+// See CreateTestInterleavedHierarchy for the longest chain used for the short
+// format.
+var shortFormTables = [3]string{"parent1", "child1", "grandchild1"}
+
+// ShortToLongKeyFmt converts the short key format preferred in test cases
+//    /1/#/3/4
+// to its long form required by parseTestkey
+//    parent1/1/1/#/child1/1/3/4
+// The short key format can end in an interleave sentinel '#' (i.e. after
+// TightenEndKey).
+// The short key format can also be "/" or end in "#/" which will append
+// the parent's table/index info. without a trailing index column value.
+func ShortToLongKeyFmt(short string) string {
+	tableOrder := shortFormTables
+	curTableIdx := 0
+
+	var long []byte
+	tokens := strings.Split(short, "/")
+	// Verify short format starts with '/'.
+	if tokens[0] != "" {
+		panic("missing '/' token at the beginning of short format")
+	}
+	// Skip the first element since short format has starting '/'.
+	tokens = tokens[1:]
+
+	// Always append parent1.
+	long = append(long, []byte(fmt.Sprintf("/%s/1/", tableOrder[curTableIdx]))...)
+	curTableIdx++
+
+	for i, tok := range tokens {
+		// Permits ".../#/" to append table name without a value
+		if tok == "" {
+			continue
+		}
+
+		if tok == "#" {
+			long = append(long, []byte("#/")...)
+			// It's possible for the short-format to end with a #.
+			if i == len(tokens)-1 {
+				break
+			}
+
+			// New interleaved table and primary keys follow.
+			if curTableIdx >= len(tableOrder) {
+				panic("too many '#' tokens specified in short format (max 2 for child1 and 3 for grandchild1)")
+			}
+
+			long = append(long, []byte(fmt.Sprintf("%s/1/", tableOrder[curTableIdx]))...)
+			curTableIdx++
+
+			continue
+		}
+
+		long = append(long, []byte(fmt.Sprintf("%s/", tok))...)
+	}
+
+	// Remove the last '/'.
+	return string(long[:len(long)-1])
+}

--- a/pkg/testutils/sqlutils/table_gen.go
+++ b/pkg/testutils/sqlutils/table_gen.go
@@ -27,6 +27,9 @@ import (
 
 const rowsPerInsert = 100
 
+// TestDB is the name of the database created for test tables.
+const TestDB = "test"
+
 // GenRowFn is a function that takes a (1-based) row index and returns a row of
 // Datums that will be converted to strings to form part of an INSERT statement.
 type GenRowFn func(row int) []tree.Datum
@@ -64,16 +67,16 @@ func CreateTableInterleaved(
 	fn GenRowFn,
 ) {
 	if interleaveSchema != "" {
-		interleaveSchema = fmt.Sprintf(`INTERLEAVE IN PARENT %s`, interleaveSchema)
+		interleaveSchema = fmt.Sprintf(`INTERLEAVE IN PARENT %s.%s`, TestDB, interleaveSchema)
 	}
 
 	r := MakeSQLRunner(sqlDB)
 	stmt := `CREATE DATABASE IF NOT EXISTS test;`
-	stmt += fmt.Sprintf(`CREATE TABLE test.%s (%s) %s;`, tableName, schema, interleaveSchema)
+	stmt += fmt.Sprintf(`CREATE TABLE %s.%s (%s) %s;`, TestDB, tableName, schema, interleaveSchema)
 	r.Exec(tb, stmt)
 	for i := 1; i <= numRows; {
 		var buf bytes.Buffer
-		fmt.Fprintf(&buf, `INSERT INTO test.%s VALUES `, tableName)
+		fmt.Fprintf(&buf, `INSERT INTO %s.%s VALUES `, TestDB, tableName)
 		batchEnd := i + rowsPerInsert
 		if batchEnd > numRows {
 			batchEnd = numRows
@@ -83,6 +86,66 @@ func CreateTableInterleaved(
 		r.Exec(tb, buf.String())
 		i = batchEnd + 1
 	}
+}
+
+// CreateTestInterleavedHierarchy generates the following interleaved hierarchy
+// for testing:
+//   <table>		  <primary index/interleave prefix>   <nrows>
+//   parent1		  (pid1)			      100
+//     child1		  (pid1, cid1, cid2)		      250
+//       grandchild1	  (pid1, cid1, cid2, gcid1)	      1000
+//     child2		  (pid1, cid3, cid4)		      50
+//   parent2		  (pid1)			      20
+func CreateTestInterleavedHierarchy(t *testing.T, sqlDB *gosql.DB) {
+	vMod := 42
+	CreateTable(t, sqlDB, "parent1",
+		"pid1 INT PRIMARY KEY, v INT",
+		100,
+		ToRowFn(RowIdxFn, RowModuloFn(vMod)),
+	)
+
+	CreateTableInterleaved(t, sqlDB, "child1",
+		"pid1 INT, cid1 INT, cid2 INT, v INT, PRIMARY KEY (pid1, cid1, cid2)",
+		"parent1 (pid1)",
+		250,
+		ToRowFn(
+			RowModuloShiftedFn(100),
+			RowIdxFn,
+			RowIdxFn,
+			RowModuloFn(vMod),
+		),
+	)
+
+	CreateTableInterleaved(t, sqlDB, "grandchild1",
+		"pid1 INT, cid1 INT, cid2 INT, gcid1 INT, v INT, PRIMARY KEY (pid1, cid1, cid2, gcid1)",
+		"child1 (pid1, cid1, cid2)",
+		1000,
+		ToRowFn(
+			RowModuloShiftedFn(250, 100),
+			RowModuloShiftedFn(250),
+			RowModuloShiftedFn(250),
+			RowIdxFn,
+			RowModuloFn(vMod),
+		),
+	)
+
+	CreateTableInterleaved(t, sqlDB, "child2",
+		"pid1 INT, cid3 INT, cid4 INT, v INT, PRIMARY KEY (pid1, cid3, cid4)",
+		"parent1 (pid1)",
+		50,
+		ToRowFn(
+			RowModuloShiftedFn(100),
+			RowIdxFn,
+			RowIdxFn,
+			RowModuloFn(vMod),
+		),
+	)
+
+	CreateTable(t, sqlDB, "parent2",
+		"pid1 INT PRIMARY KEY, v INT",
+		20,
+		ToRowFn(RowIdxFn, RowModuloFn(vMod)),
+	)
 }
 
 // GenValueFn is a function that takes a (1-based) row index and returns a Datum

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -80,6 +80,8 @@ const (
 	IntMax = 0xfd // 253
 
 	// Nulls come last when encoded descendingly.
+	// This value is not actually ever present in a stored key, but
+	// it's used in keys used as span boundaries for index scans.
 	encodedNotNullDesc = 0xfe
 	// interleavedSentinel uses the same byte as encodedNotNullDesc.
 	// It is used in the key encoding of interleaved index keys in order
@@ -741,20 +743,29 @@ func DecodeIfNotNull(b []byte) ([]byte, bool) {
 	return b, false
 }
 
+// DecodeIfNotNullDescending decodes encodedNotNullDesc from the input buffer
+// and returns the remaining buffer without the sentinel if encodedNotNullDesc
+// is the first byte.
+// Otherwise, the buffer is returned unchanged and false is returned.
+func DecodeIfNotNullDescending(b []byte) ([]byte, bool) {
+	if len(b) == 0 {
+		return b, false
+	}
+
+	if b[0] == encodedNotNullDesc {
+		return b[1:], true
+	}
+
+	return b, false
+}
+
 // DecodeIfInterleavedSentinel decodes the interleavedSentinel from the input
 // buffer and returns the remaining buffer without the sentinel if the
 // interleavedSentinel is the first byte.
 // Otherwise, the buffer is returned unchanged and false is returned.
 func DecodeIfInterleavedSentinel(b []byte) ([]byte, bool) {
-	if len(b) == 0 {
-		return b, false
-	}
-
-	if b[0] == interleavedSentinel {
-		return b[1:], true
-	}
-
-	return b, false
+	// The interleavedSentinel is equivalent to encodedNotNullDesc
+	return DecodeIfNotNullDescending(b)
 }
 
 // EncodeTimeAscending encodes a time value, appends it to the supplied buffer,
@@ -1918,4 +1929,22 @@ func PrettyPrintValueEncoded(b []byte) ([]byte, string, error) {
 	default:
 		return b, "", errors.Errorf("unknown type %s", typ)
 	}
+}
+
+// DecomposeKeyTokens breaks apart a key into its individual key-encoded values
+// and returns a slice of byte slices, one for each key-encoded value.
+func DecomposeKeyTokens(b []byte) ([][]byte, error) {
+	var out [][]byte
+
+	for len(b) > 0 {
+		tokenLen, err := PeekLength(b)
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, b[:tokenLen])
+		b = b[tokenLen:]
+	}
+
+	return out, nil
 }


### PR DESCRIPTION
I apologize in advance for the really long PR (80% of it are tests, I promise!).

Still to do (probably in a later PR so not to over-bloat this one) is to do the same during/after `partitionSpans` in DistSQL.


