### PR TITLE
sql: primary indexes permit duplicate columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -30,6 +30,9 @@ CREATE INDEX foo ON t (a)
 statement error index \"bar\" contains unknown column \"c\"
 CREATE INDEX bar ON t (c)
 
+statement error index \"bar\" contains duplicate column \"b\"
+CREATE INDEX bar ON t (b, b);
+
 query TTBITTBB colnames
 SHOW INDEXES FROM t
 ----

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -30,6 +30,12 @@ CREATE TABLE b (id INT PRIMARY KEY, id INT)
 statement error multiple primary keys for table "b" are not allowed
 CREATE TABLE b (id INT PRIMARY KEY, id2 INT PRIMARY KEY)
 
+statement error index \"primary\" contains duplicate column \"a\"
+CREATE TABLE dup_primary (a int, primary key (a,a))
+
+statement error index \"dup_unique_a_a_key\" contains duplicate column \"a\"
+CREATE TABLE dup_unique (a int, unique (a,a))
+
 statement ok
 CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
 

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1212,6 +1212,7 @@ func (desc *TableDescriptor) validateTableIndexes(
 			return fmt.Errorf("index %q must contain at least 1 column", index.Name)
 		}
 
+		validateIndexDup := make(map[ColumnID]struct{})
 		for i, name := range index.ColumnNames {
 			colID, ok := columnNames[name]
 			if !ok {
@@ -1221,6 +1222,10 @@ func (desc *TableDescriptor) validateTableIndexes(
 				return fmt.Errorf("index %q column %q should have ID %d, but found ID %d",
 					index.Name, name, colID, index.ColumnIDs[i])
 			}
+			if _, ok := validateIndexDup[colID]; ok {
+				return fmt.Errorf("index %q contains duplicate column %q", index.Name, name)
+			}
+			validateIndexDup[colID] = struct{}{}
 		}
 	}
 


### PR DESCRIPTION
fixes #20200 There's no reason why this should be allowed. Postgres doesn't permit it for instance.