### PR TITLE
sql: support LIMIT and ORDER BY in views

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -671,10 +671,15 @@ func (p *planner) getViewPlan(
 		p.planDeps = nil
 	}
 
-	// TODO(a-robinson): Support ORDER BY and LIMIT in views. Is it as simple as
-	// just passing the entire select here or will inserting an ORDER BY in the
-	// middle of a query plan break things?
-	return p.getSubqueryPlan(ctx, *tn, sel.Select, sqlbase.ResultColumnsFromColDescs(desc.Columns))
+	plan, err := p.newPlan(ctx, sel, nil)
+	if err != nil {
+		return planDataSource{}, err
+	}
+	return planDataSource{
+		info: newSourceInfoForSingleTable(*tn,
+			sqlbase.ResultColumnsFromColDescs(desc.Columns)),
+		plan: plan,
+	}, nil
 }
 
 // getSubqueryPlan builds a planDataSource for a select statement, including

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -7,31 +7,31 @@ statement ok
 INSERT INTO t VALUES (1, 99), (2, 98), (3, 97)
 
 statement ok
-CREATE VIEW v1 AS select a, b from t
+CREATE VIEW v1 AS SELECT a, b FROM t
 
 statement error pgcode 42P07 relation \"v1\" already exists
-CREATE VIEW v1 AS select a, b from t
+CREATE VIEW v1 AS SELECT a, b FROM t
 
 statement error pgcode 42P07 relation \"t\" already exists
-CREATE VIEW t AS select a, b from t
+CREATE VIEW t AS SELECT a, b FROM t
 
 statement ok
-CREATE VIEW v2 (x, y) AS select a, b from t
+CREATE VIEW v2 (x, y) AS SELECT a, b FROM t
 
 statement error pgcode 42601 CREATE VIEW specifies 1 column name, but data source has 2 columns
-CREATE VIEW v3 (x) AS select a, b from t
+CREATE VIEW v3 (x) AS SELECT a, b FROM t
 
 statement error pgcode 42601 CREATE VIEW specifies 3 column names, but data source has 2 columns
-CREATE VIEW v4 (x, y, z) AS select a, b from t
+CREATE VIEW v4 (x, y, z) AS SELECT a, b FROM t
 
 statement error pgcode 42P01 relation "dne" does not exist
-CREATE VIEW v5 AS select a, b from dne
+CREATE VIEW v5 AS SELECT a, b FROM dne
 
 statement ok
-CREATE VIEW v6 (x, y) AS select a, b from v1
+CREATE VIEW v6 (x, y) AS SELECT a, b FROM v1
 
 statement ok
-CREATE VIEW v7 (x, y) AS select a, b from v1 order by a desc limit 2
+CREATE VIEW v7 (x, y) AS SELECT a, b FROM v1 ORDER BY a DESC LIMIT 2
 
 query II colnames,rowsort
 SELECT * FROM v1

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -30,6 +30,9 @@ CREATE VIEW v5 AS select a, b from dne
 statement ok
 CREATE VIEW v6 (x, y) AS select a, b from v1
 
+statement ok
+CREATE VIEW v7 (x, y) AS select a, b from v1 order by a desc limit 2
+
 query II colnames,rowsort
 SELECT * FROM v1
 ----
@@ -54,6 +57,19 @@ x y
 2 98
 3 97
 
+query II colnames
+SELECT * FROM v7
+----
+x y
+3 97
+2 98
+
+query II colnames
+SELECT * FROM v7 ORDER BY x LIMIT 1
+----
+x y
+2 98
+
 query II
 SELECT * FROM v2 ORDER BY x DESC LIMIT 1
 ----
@@ -72,6 +88,28 @@ SELECT y FROM v2
 99
 98
 97
+
+query I
+SELECT x FROM v7
+----
+3
+2
+
+query I
+SELECT x FROM v7 ORDER BY x LIMIT 1
+----
+2
+
+query I
+SELECT y FROM v7
+----
+97
+98
+
+query I
+SELECT y FROM v7 ORDER BY x LIMIT 1
+----
+98
 
 query IIII rowsort
 SELECT * FROM v1 AS v1 INNER JOIN v2 AS v2 ON v1.a = v2.x
@@ -110,6 +148,19 @@ x y
 2 98
 3 97
 
+query II colnames
+SELECT * FROM test.v7
+----
+x y
+3 97
+2 98
+
+query II colnames
+SELECT * FROM test.v7 ORDER BY x LIMIT 1
+----
+x y
+2 98
+
 statement ok
 CREATE VIEW v1 AS SELECT x, y FROM test.v2
 
@@ -138,6 +189,11 @@ query TT
 SHOW CREATE VIEW v6
 ----
 v6 CREATE VIEW v6 (x, y) AS SELECT a, b FROM test.v1
+
+query TT
+SHOW CREATE VIEW v7
+----
+v7 CREATE VIEW v7 (x, y) AS SELECT a, b FROM test.v1 ORDER BY a DESC LIMIT 2
 
 query TT
 SHOW CREATE VIEW test2.v1
@@ -232,6 +288,9 @@ DROP VIEW v2
 
 statement ok
 DROP VIEW test2.v1
+
+statement ok
+DROP VIEW v7
 
 statement ok
 DROP VIEW v6


### PR DESCRIPTION
Previously, LIMIT and ORDER BY clauses in view definitions were silently
ignored. For example, given the following view

    CREATE VIEW v AS SELECT generate_series FROM generate_series(1, 100) ORDER BY 1 DESC LIMIT 10

the following query would return 100 results in ascending order, instead
of the expected ten results in descending order:

    SELECT * FROM v

This commit ensures the above query instead observes the ORDER BY and
LIMIT specified in the view definition, as Postgres does. As in
Postgres, additional ORDER BY and LIMIT clauses can be specified at query time

    SELECT * FROM v ORDER BY 1 ASC LIMIT 10

in which case the effect is the same as if the view definition had been
specified inline as a subquery:

    SELECT *
      FROM (SELECT generate_series FROM generate_series(1, 100) ORDER BY 1 DESC LIMIT 10)
      ORDER BY 1 ASC LIMIT 10

---

XXX: The TODO I removed suggests there's some gotcha I'm not considering here.