### PR TITLE
sql: cleanup privileges a bit

### DIFF
--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -736,7 +736,8 @@ func restoreTableDescs(
 				if err != nil {
 					return errors.Wrapf(err, "failed to lookup parent DB %d", table.ParentID)
 				}
-				if err := sql.CheckPrivilege(user, parentDB, privilege.CREATE); err != nil {
+				// TODO(mberhault): CheckPrivilege wants a planner.
+				if err := sql.CheckPrivilegeForUser(user, parentDB, privilege.CREATE); err != nil {
 					return err
 				}
 				// Default is to copy privs from restoring parent db, like CREATE TABLE.

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -28,7 +28,7 @@ type createDatabaseNode struct {
 }
 
 // CreateDatabase creates a database.
-// Privileges: security.RootUser user.
+// Privileges: superuser.
 //   Notes: postgres requires superuser or "CREATEDB".
 //          mysql uses the mysqladmin command.
 func (p *planner) CreateDatabase(n *tree.CreateDatabase) (planNode, error) {

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -299,7 +298,7 @@ func (p *planner) getVirtualDataSource(
 		prefix := string(tn.PrefixName)
 		if !tn.PrefixOriginallySpecified {
 			prefix = p.session.Database
-			if prefix == "" && p.session.User != security.RootUser {
+			if prefix == "" && p.RequireSuperUser("access virtual tables across all databases") != nil {
 				prefix = sqlbase.SystemDB.Name
 			}
 		}

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -632,7 +632,7 @@ func forEachDatabaseDesc(
 
 	sort.Sort(sortedDBDescs(dbDescs))
 	for _, db := range dbDescs {
-		if userCanSeeDatabase(db, p.session.User) {
+		if userCanSeeDatabase(p, db) {
 			if err := fn(db); err != nil {
 				return err
 			}
@@ -827,7 +827,7 @@ func forEachTableDescWithTableLookupInternal(
 		sort.Strings(dbTableNames)
 		for _, tableName := range dbTableNames {
 			tableDesc := db.tables[tableName]
-			if userCanSeeTable(tableDesc, p.session.User, allowAdding) {
+			if userCanSeeTable(p, tableDesc, allowAdding) {
 				if err := fn(db.desc, tableDesc, tableLookup); err != nil {
 					return err
 				}
@@ -910,14 +910,14 @@ func forEachUser(ctx context.Context, origPlanner *planner, fn func(username str
 	return nil
 }
 
-func userCanSeeDatabase(db *sqlbase.DatabaseDescriptor, user string) bool {
-	return userCanSeeDescriptor(db, user)
+func userCanSeeDatabase(p *planner, db *sqlbase.DatabaseDescriptor) bool {
+	return p.CheckAnyPrivilege(db) == nil
 }
 
-func userCanSeeTable(table *sqlbase.TableDescriptor, user string, allowAdding bool) bool {
+func userCanSeeTable(p *planner, table *sqlbase.TableDescriptor, allowAdding bool) bool {
 	if !(table.State == sqlbase.TableDescriptor_PUBLIC ||
 		(allowAdding && table.State == sqlbase.TableDescriptor_ADD)) {
 		return false
 	}
-	return userCanSeeDescriptor(table, user)
+	return p.CheckAnyPrivilege(table) == nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -237,7 +237,7 @@ select crdb_internal.force_log_fatal('foo')
 query error pq: insufficient privilege
 select crdb_internal.set_vmodule('')
 
-query error pq: only root can access the node runtime information
+query error pq: only root is allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 
 query error pq: only root is allowed to read crdb_internal.ranges

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -26,7 +26,7 @@ import (
 )
 
 // RenameDatabase renames the database.
-// Privileges: security.RootUser user, DROP on source database.
+// Privileges: superuser, DROP on source database.
 //   Notes: postgres requires superuser, db owner, or "CREATEDB".
 //          mysql >= 5.1.23 does not allow database renames.
 func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (planNode, error) {

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -73,7 +73,7 @@ type checkOperation interface {
 }
 
 // Scrub checks the database.
-// Privileges: security.RootUser user.
+// Privileges: superuser.
 func (p *planner) Scrub(ctx context.Context, n *tree.Scrub) (planNode, error) {
 	if err := p.RequireSuperUser("SCRUB"); err != nil {
 		return nil, err

--- a/pkg/sql/show_constraints.go
+++ b/pkg/sql/show_constraints.go
@@ -39,7 +39,7 @@ func (p *planner) ShowConstraints(ctx context.Context, n *tree.ShowConstraints) 
 	if err != nil {
 		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}
-	if err := p.anyPrivilege(desc); err != nil {
+	if err := p.CheckAnyPrivilege(desc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/show_table.go
+++ b/pkg/sql/show_table.go
@@ -48,7 +48,7 @@ func (p *planner) showTableDetails(
 		if err != nil {
 			return err
 		}
-		return p.anyPrivilege(desc)
+		return p.CheckAnyPrivilege(desc)
 	}
 
 	return p.delegateQuery(ctx, showType,

--- a/pkg/sql/sqlbase/privilege.go
+++ b/pkg/sql/sqlbase/privilege.go
@@ -78,6 +78,12 @@ func (p *PrivilegeDescriptor) removeUser(user string) {
 	p.Users = append(p.Users[:idx], p.Users[idx+1:]...)
 }
 
+// NewCustomRootPrivilegeDescriptor returns a privilege descriptor for the root user
+// and specified privileges.
+func NewCustomRootPrivilegeDescriptor(priv privilege.List) *PrivilegeDescriptor {
+	return NewPrivilegeDescriptor(security.RootUser, priv)
+}
+
 // NewPrivilegeDescriptor returns a privilege descriptor for the given
 // user with the specified list of privileges.
 func NewPrivilegeDescriptor(user string, priv privilege.List) *PrivilegeDescriptor {

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 )
 
@@ -248,15 +247,14 @@ var (
 		Name: "system",
 		ID:   keys.SystemDatabaseID,
 		// Assign max privileges to root user.
-		Privileges: NewPrivilegeDescriptor(security.RootUser,
-			SystemDesiredPrivileges(keys.SystemDatabaseID)),
+		Privileges: NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.SystemDatabaseID)),
 	}
 
 	// NamespaceTable is the descriptor for the namespace table.
 	NamespaceTable = TableDescriptor{
 		Name:     "namespace",
 		ID:       keys.NamespaceTableID,
-		ParentID: 1,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "parentID", ID: 1, Type: colTypeInt},
@@ -278,7 +276,7 @@ var (
 			ColumnIDs:        []ColumnID{1, 2},
 		},
 		NextIndexID:    2,
-		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.NamespaceTableID)),
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.NamespaceTableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -287,8 +285,8 @@ var (
 	DescriptorTable = TableDescriptor{
 		Name:       "descriptor",
 		ID:         keys.DescriptorTableID,
-		Privileges: NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.DescriptorTableID)),
-		ParentID:   1,
+		Privileges: NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.DescriptorTableID)),
+		ParentID:   keys.SystemDatabaseID,
 		Version:    1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: colTypeInt},
@@ -310,7 +308,7 @@ var (
 	UsersTable = TableDescriptor{
 		Name:     "users",
 		ID:       keys.UsersTableID,
-		ParentID: 1,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "username", ID: 1, Type: colTypeString},
@@ -324,7 +322,7 @@ var (
 		PrimaryIndex:   pk("username"),
 		NextFamilyID:   3,
 		NextIndexID:    2,
-		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.UsersTableID)),
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.UsersTableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -333,7 +331,7 @@ var (
 	ZonesTable = TableDescriptor{
 		Name:     "zones",
 		ID:       keys.ZonesTableID,
-		ParentID: 1,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: colTypeInt},
@@ -354,7 +352,7 @@ var (
 		},
 		NextFamilyID:   3,
 		NextIndexID:    2,
-		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.ZonesTableID)),
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.ZonesTableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -362,7 +360,7 @@ var (
 	SettingsTable = TableDescriptor{
 		Name:     "settings",
 		ID:       keys.SettingsTableID,
-		ParentID: 1,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "name", ID: 1, Type: colTypeString},
@@ -382,7 +380,7 @@ var (
 		NextFamilyID:   1,
 		PrimaryIndex:   pk("name"),
 		NextIndexID:    2,
-		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.SettingsTableID)),
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.SettingsTableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -398,7 +396,7 @@ var (
 	LeaseTable = TableDescriptor{
 		Name:     "lease",
 		ID:       keys.LeaseTableID,
-		ParentID: 1,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "descID", ID: 1, Type: colTypeInt},
@@ -420,7 +418,7 @@ var (
 		},
 		NextFamilyID:   1,
 		NextIndexID:    2,
-		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.LeaseTableID)),
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.LeaseTableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -431,7 +429,7 @@ var (
 	EventLogTable = TableDescriptor{
 		Name:     "eventlog",
 		ID:       keys.EventLogTableID,
-		ParentID: 1,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "timestamp", ID: 1, Type: colTypeTimestamp},
@@ -459,7 +457,7 @@ var (
 		},
 		NextFamilyID:   6,
 		NextIndexID:    2,
-		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.EventLogTableID)),
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.EventLogTableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -470,7 +468,7 @@ var (
 	RangeEventTable = TableDescriptor{
 		Name:     "rangelog",
 		ID:       keys.RangeEventTableID,
-		ParentID: 1,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "timestamp", ID: 1, Type: colTypeTimestamp},
@@ -500,7 +498,7 @@ var (
 		},
 		NextFamilyID:   7,
 		NextIndexID:    2,
-		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.RangeEventTableID)),
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.RangeEventTableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -509,7 +507,7 @@ var (
 	UITable = TableDescriptor{
 		Name:     "ui",
 		ID:       keys.UITableID,
-		ParentID: 1,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "key", ID: 1, Type: colTypeString},
@@ -525,7 +523,7 @@ var (
 		NextFamilyID:   4,
 		PrimaryIndex:   pk("key"),
 		NextIndexID:    2,
-		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.UITableID)),
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.UITableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -536,7 +534,7 @@ var (
 	JobsTable = TableDescriptor{
 		Name:     "jobs",
 		ID:       keys.JobsTableID,
-		ParentID: 1,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: colTypeInt, DefaultExpr: &uniqueRowIDString},
@@ -567,7 +565,7 @@ var (
 			},
 		},
 		NextIndexID:    3,
-		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.JobsTableID)),
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.JobsTableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -575,8 +573,8 @@ var (
 	// WebSessions table to authenticate sessions over stateless connections.
 	WebSessionsTable = TableDescriptor{
 		Name:     "web_sessions",
-		ID:       19,
-		ParentID: 1,
+		ID:       keys.WebSessionsTableID,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "id", ID: 1, Type: colTypeInt, DefaultExpr: &uniqueRowIDString},
@@ -628,12 +626,8 @@ var (
 				ExtraColumnIDs:   []ColumnID{1},
 			},
 		},
-		NextIndexID: 4,
-		Privileges: &PrivilegeDescriptor{
-			Users: []UserPrivileges{
-				{User: "root", Privileges: 0x1f0},
-			},
-		},
+		NextIndexID:    4,
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.WebSessionsTableID)),
 		NextMutationID: 1,
 		FormatVersion:  3,
 	}
@@ -642,7 +636,7 @@ var (
 	TableStatisticsTable = TableDescriptor{
 		Name:     "table_statistics",
 		ID:       keys.TableStatisticsTableID,
-		ParentID: 1,
+		ParentID: keys.SystemDatabaseID,
 		Version:  1,
 		Columns: []ColumnDescriptor{
 			{Name: "tableID", ID: 1, Type: colTypeInt},
@@ -684,7 +678,7 @@ var (
 			ColumnIDs:        []ColumnID{1, 2},
 		},
 		NextIndexID:    2,
-		Privileges:     NewPrivilegeDescriptor(security.RootUser, SystemDesiredPrivileges(keys.TableStatisticsTableID)),
+		Privileges:     NewCustomRootPrivilegeDescriptor(SystemDesiredPrivileges(keys.TableStatisticsTableID)),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}


### PR DESCRIPTION
A tiny bit of cleanup to make changing the privilege check implementations more centralized.

For role-based access control, the authorization methods will most likely need to perform lookups, so it would be nice to have a planner for everything. Restore is missing one though, not sure about the right way to plumb it through.

A second pass will probably be to add a `Has...(..) (bool, error)` variant to distinguish between "not allowed" and "error while performing permission check" errors. Not needed yet, but it will be.