### PR TITLE
cli: dump: fix infinite loop in when resolving dependencies.

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -126,13 +126,14 @@ func collect(tid int64, byID map[int64]tableMetadata, seen map[int64]bool, colle
 	if seen[tid] {
 		return
 	}
-	// no: add it
+	// no: mark it as seen.
+	seen[tid] = true
 	for _, dep := range byID[tid].dependsOn {
 		// depth-first collection of dependencies
 		collect(dep, byID, seen, collected)
 	}
+	// Only add it after its dependencies.
 	*collected = append(*collected, tid)
-	seen[tid] = true
 }
 
 // tableMetadata describes one table to dump.

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -919,3 +919,52 @@ INSERT INTO t (i) VALUES
 		t.Fatalf("expected: %s\ngot: %s", expect, out)
 	}
 }
+
+// TestDumpReferenceCycle tests dumping in the presence of cycles.
+// This used to crash before with stack overflow due to an infinite loop before:
+// https://github.com/cockroachdb/cockroach/pull/20255
+func TestDumpReferenceCycle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest(cliTestParams{t: t})
+	defer c.cleanup()
+
+	const create = `
+	CREATE DATABASE d;
+	CREATE TABLE d.t (
+		PRIMARY KEY (id),
+		FOREIGN KEY (next_id) REFERENCES d.t(id),
+		id INT,
+		next_id INT
+	);
+	INSERT INTO d.t VALUES (
+		1,
+		NULL
+	);
+`
+
+	c.RunWithArgs([]string{"sql", "-e", create})
+
+	out, err := c.RunWithCapture("dump d t")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const expect = `dump d t
+CREATE TABLE t (
+	id INT NOT NULL,
+	next_id INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	CONSTRAINT fk_next_id_ref_t FOREIGN KEY (next_id) REFERENCES t (id),
+	INDEX t_auto_index_fk_next_id_ref_t (next_id ASC),
+	FAMILY "primary" (id, next_id)
+);
+
+INSERT INTO t (id, next_id) VALUES
+	(1, NULL);
+`
+
+	if out != expect {
+		t.Fatalf("expected: %s\ngot: %s", expect, out)
+	}
+}


### PR DESCRIPTION
While this will avoid the loop and keep dependency order, there may
still be problems with dependency cycles.

This came up in #20254 when encountering a foreign key referring to the
same table.

@mjibson: please have a look, there more here than just not looping forever. How do we export tables that have a reference cycle? There's no particularly good order there.