### PR TITLE
tracing: update lightstep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -528,8 +528,8 @@
 [[projects]]
   name = "github.com/lightstep/lightstep-tracer-go"
   packages = [".","collectorpb","lightstep_thrift","lightsteppb","thrift_0_9_2/lib/go/thrift"]
-  revision = "8ea6e2a40aeb49f0a846212f919d156082f58e16"
-  version = "v0.14.0"
+  revision = "ba38bae1f0ec1ece9092d35bbecbb497ee344cbc"
+  version = "v0.15.0"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"
@@ -840,7 +840,7 @@
   branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "eb3733d160e74a9c7e442f435eb3bea458e1d19f"
+  revision = "287cf08546ab5e7e37d55a84f7ed3fd1db036de5"
 
 [[projects]]
   branch = "master"

--- a/pkg/util/tracing/shadow.go
+++ b/pkg/util/tracing/shadow.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"os"
 
+	"golang.org/x/net/context"
+
 	lightstep "github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
 	zipkin "github.com/openzipkin/zipkin-go-opentracing"
@@ -41,13 +43,7 @@ func (lightStepManager) Name() string {
 }
 
 func (lightStepManager) Close(tr opentracing.Tracer) {
-	// TODO(radu): these calls are not reliable. FlushLightstepTracer exits
-	// immediately if a flush is in progress (see
-	// github.com/lightstep/lightstep-tracer-go/issues/89), and CloseTracer always
-	// exits immediately (see
-	// https://github.com/lightstep/lightstep-tracer-go/pull/85#discussion_r123800322).
-	_ = lightstep.FlushLightStepTracer(tr)
-	_ = lightstep.CloseTracer(tr)
+	lightstep.Close(context.TODO(), tr)
 }
 
 type zipkinManager struct {


### PR DESCRIPTION
Update lightstep and use the new, reliable Close API. The traces now get
flushed, e.g. at the end of a test where COCKROACH_TEST_LIGHTSTEP_TOKEN was set.