### PR TITLE
WIP: cli: add enterprise-encryption flag.

### DIFF
--- a/pkg/base/store_spec_test.go
+++ b/pkg/base/store_spec_test.go
@@ -34,49 +34,49 @@ func TestNewStoreSpec(t *testing.T) {
 		expected    StoreSpec
 	}{
 		// path
-		{"path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}}},
-		{",path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}}},
-		{",,,path=/mnt/hda1,,,", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}}},
-		{"/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}}},
+		{"path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}, nil}},
+		{",path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}, nil}},
+		{",,,path=/mnt/hda1,,,", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}, nil}},
+		{"/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}, nil}},
 		{"path=", "no value specified for path", StoreSpec{}},
 		{"path=/mnt/hda1,path=/mnt/hda2", "path field was used twice in store definition", StoreSpec{}},
 		{"/mnt/hda1,path=/mnt/hda2", "path field was used twice in store definition", StoreSpec{}},
 
 		// attributes
-		{"path=/mnt/hda1,attrs=ssd", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"ssd"}}}},
-		{"path=/mnt/hda1,attrs=ssd:hdd", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}}},
-		{"path=/mnt/hda1,attrs=hdd:ssd", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}}},
-		{"attrs=ssd:hdd,path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}}},
-		{"attrs=hdd:ssd,path=/mnt/hda1,", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}}},
+		{"path=/mnt/hda1,attrs=ssd", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"ssd"}}, nil}},
+		{"path=/mnt/hda1,attrs=ssd:hdd", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, nil}},
+		{"path=/mnt/hda1,attrs=hdd:ssd", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, nil}},
+		{"attrs=ssd:hdd,path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, nil}},
+		{"attrs=hdd:ssd,path=/mnt/hda1,", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, nil}},
 		{"attrs=hdd:ssd", "no path specified", StoreSpec{}},
 		{"path=/mnt/hda1,attrs=", "no value specified for attrs", StoreSpec{}},
 		{"path=/mnt/hda1,attrs=hdd:hdd", "duplicate attribute given for store: hdd", StoreSpec{}},
 		{"path=/mnt/hda1,attrs=hdd,attrs=ssd", "attrs field was used twice in store definition", StoreSpec{}},
 
 		// size
-		{"path=/mnt/hda1,size=671088640", "", StoreSpec{"/mnt/hda1", 671088640, 0, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,size=20GB", "", StoreSpec{"/mnt/hda1", 20000000000, 0, false, roachpb.Attributes{}}},
-		{"size=20GiB,path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 21474836480, 0, false, roachpb.Attributes{}}},
-		{"size=0.1TiB,path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 109951162777, 0, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,size=.1TiB", "", StoreSpec{"/mnt/hda1", 109951162777, 0, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,size=123TB", "", StoreSpec{"/mnt/hda1", 123000000000000, 0, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,size=123TiB", "", StoreSpec{"/mnt/hda1", 135239930216448, 0, false, roachpb.Attributes{}}},
+		{"path=/mnt/hda1,size=671088640", "", StoreSpec{"/mnt/hda1", 671088640, 0, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,size=20GB", "", StoreSpec{"/mnt/hda1", 20000000000, 0, false, roachpb.Attributes{}, nil}},
+		{"size=20GiB,path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 21474836480, 0, false, roachpb.Attributes{}, nil}},
+		{"size=0.1TiB,path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 109951162777, 0, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,size=.1TiB", "", StoreSpec{"/mnt/hda1", 109951162777, 0, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,size=123TB", "", StoreSpec{"/mnt/hda1", 123000000000000, 0, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,size=123TiB", "", StoreSpec{"/mnt/hda1", 135239930216448, 0, false, roachpb.Attributes{}, nil}},
 		// %
-		{"path=/mnt/hda1,size=50.5%", "", StoreSpec{"/mnt/hda1", 0, 50.5, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,size=100%", "", StoreSpec{"/mnt/hda1", 0, 100, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,size=1%", "", StoreSpec{"/mnt/hda1", 0, 1, false, roachpb.Attributes{}}},
+		{"path=/mnt/hda1,size=50.5%", "", StoreSpec{"/mnt/hda1", 0, 50.5, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,size=100%", "", StoreSpec{"/mnt/hda1", 0, 100, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,size=1%", "", StoreSpec{"/mnt/hda1", 0, 1, false, roachpb.Attributes{}, nil}},
 		{"path=/mnt/hda1,size=0.999999%", "store size (0.999999%) must be between 1% and 100%", StoreSpec{}},
 		{"path=/mnt/hda1,size=100.0001%", "store size (100.0001%) must be between 1% and 100%", StoreSpec{}},
 		// 0.xxx
-		{"path=/mnt/hda1,size=0.99", "", StoreSpec{"/mnt/hda1", 0, 99, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,size=0.5000000", "", StoreSpec{"/mnt/hda1", 0, 50, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,size=0.01", "", StoreSpec{"/mnt/hda1", 0, 1, false, roachpb.Attributes{}}},
+		{"path=/mnt/hda1,size=0.99", "", StoreSpec{"/mnt/hda1", 0, 99, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,size=0.5000000", "", StoreSpec{"/mnt/hda1", 0, 50, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,size=0.01", "", StoreSpec{"/mnt/hda1", 0, 1, false, roachpb.Attributes{}, nil}},
 		{"path=/mnt/hda1,size=0.009999", "store size (0.009999) must be between 1% and 100%", StoreSpec{}},
 		// .xxx
-		{"path=/mnt/hda1,size=.999", "", StoreSpec{"/mnt/hda1", 0, 99.9, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,size=.5000000", "", StoreSpec{"/mnt/hda1", 0, 50, false, roachpb.Attributes{}}},
-		{"path=/mnt/hda1,size=.01", "", StoreSpec{"/mnt/hda1", 0, 1, false, roachpb.Attributes{}}},
+		{"path=/mnt/hda1,size=.999", "", StoreSpec{"/mnt/hda1", 0, 99.9, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,size=.5000000", "", StoreSpec{"/mnt/hda1", 0, 50, false, roachpb.Attributes{}, nil}},
+		{"path=/mnt/hda1,size=.01", "", StoreSpec{"/mnt/hda1", 0, 1, false, roachpb.Attributes{}, nil}},
 		{"path=/mnt/hda1,size=.009999", "store size (.009999) must be between 1% and 100%", StoreSpec{}},
 		// errors
 		{"path=/mnt/hda1,size=0", "store size (0) must be larger than 640 MiB", StoreSpec{}},
@@ -86,10 +86,10 @@ func TestNewStoreSpec(t *testing.T) {
 		{"size=123TB", "no path specified", StoreSpec{}},
 
 		// type
-		{"type=mem,size=20GiB", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{}}},
-		{"size=20GiB,type=mem", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{}}},
-		{"size=20.5GiB,type=mem", "", StoreSpec{"", 22011707392, 0, true, roachpb.Attributes{}}},
-		{"size=20GiB,type=mem,attrs=mem", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{Attrs: []string{"mem"}}}},
+		{"type=mem,size=20GiB", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{}, nil}},
+		{"size=20GiB,type=mem", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{}, nil}},
+		{"size=20.5GiB,type=mem", "", StoreSpec{"", 22011707392, 0, true, roachpb.Attributes{}, nil}},
+		{"size=20GiB,type=mem,attrs=mem", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{Attrs: []string{"mem"}}, nil}},
 		{"type=mem,size=20", "store size (20) must be larger than 640 MiB", StoreSpec{}},
 		{"type=mem,size=", "no value specified for size", StoreSpec{}},
 		{"type=mem,attrs=ssd", "size must be specified for an in memory store", StoreSpec{}},
@@ -98,8 +98,8 @@ func TestNewStoreSpec(t *testing.T) {
 		{"path=/mnt/hda1,type=mem,size=20GiB", "path specified for in memory store", StoreSpec{}},
 
 		// all together
-		{"path=/mnt/hda1,attrs=hdd:ssd,size=20GiB", "", StoreSpec{"/mnt/hda1", 21474836480, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}}},
-		{"type=mem,attrs=hdd:ssd,size=20GiB", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}}},
+		{"path=/mnt/hda1,attrs=hdd:ssd,size=20GiB", "", StoreSpec{"/mnt/hda1", 21474836480, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, nil}},
+		{"type=mem,attrs=hdd:ssd,size=20GiB", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, nil}},
 
 		// other error cases
 		{"", "no value specified", StoreSpec{}},

--- a/pkg/ccl/baseccl/encryption_spec_test.go
+++ b/pkg/ccl/baseccl/encryption_spec_test.go
@@ -1,0 +1,87 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package baseccl
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// TestNewStoreEncryptionSpec verifies that the --enterprise-encryption arguments are correctly parsed
+// into StoreEncryptionSpecs.
+func TestNewStoreEncryptionSpec(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		value       string
+		expectedErr string
+		expected    StoreEncryptionSpec
+	}{
+		// path
+		{",", "no path specified", StoreEncryptionSpec{}},
+		{"", "no path specified", StoreEncryptionSpec{}},
+		{"/mnt/hda1", "field not in the form <key>=<value>: /mnt/hda1", StoreEncryptionSpec{}},
+		{"path=", "no value specified for path", StoreEncryptionSpec{}},
+		{"path=~/data", "path cannot start with '~': ~/data", StoreEncryptionSpec{}},
+		{"path=data,path=data2", "path field was used twice in encryption definition", StoreEncryptionSpec{}},
+
+		// The same logic applies to key and old-key, don't repeat everything.
+		{"path=data", "no key specified", StoreEncryptionSpec{}},
+		{"path=data,key=new.key", "no old-key specified", StoreEncryptionSpec{}},
+
+		// Rotation period.
+		{"path=data,key=new.key,old-key=old.key,rotation-period", "field not in the form <key>=<value>: rotation-period", StoreEncryptionSpec{}},
+		{"path=data,key=new.key,old-key=old.key,rotation-period=", "no value specified for rotation-period", StoreEncryptionSpec{}},
+		{"path=data,key=new.key,old-key=old.key,rotation-period=1", "could not parse rotation-duration value: 1: time: missing unit in duration 1", StoreEncryptionSpec{}},
+		{"path=data,key=new.key,old-key=old.key,rotation-period=1d", "could not parse rotation-duration value: 1d: time: unknown unit d in duration 1d", StoreEncryptionSpec{}},
+
+		// Good values.
+		{"path=/data,key=/new.key,old-key=/old.key", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "/old.key", RotationPeriod: DefaultRotationPeriod}},
+		{"path=/data,key=/new.key,old-key=/old.key,rotation-period=1h", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "/old.key", RotationPeriod: time.Hour}},
+	}
+
+	for i, testCase := range testCases {
+		storeEncryptionSpec, err := NewStoreEncryptionSpec(testCase.value)
+		if err != nil {
+			if len(testCase.expectedErr) == 0 {
+				t.Errorf("%d(%s): no expected error, got %s", i, testCase.value, err)
+			}
+			if testCase.expectedErr != fmt.Sprint(err) {
+				t.Errorf("%d(%s): expected error \"%s\" does not match actual \"%s\"", i, testCase.value,
+					testCase.expectedErr, err)
+			}
+			continue
+		}
+		if len(testCase.expectedErr) > 0 {
+			t.Errorf("%d(%s): expected error %s but there was none", i, testCase.value, testCase.expectedErr)
+			continue
+		}
+		if !reflect.DeepEqual(testCase.expected, storeEncryptionSpec) {
+			t.Errorf("%d(%s): actual doesn't match expected\nactual:   %+v\nexpected: %+v", i,
+				testCase.value, storeEncryptionSpec, testCase.expected)
+		}
+
+		// Now test String() to make sure the result can be parsed.
+		storeEncryptionSpecString := storeEncryptionSpec.String()
+		storeEncryptionSpec2, err := NewStoreEncryptionSpec(storeEncryptionSpecString)
+		if err != nil {
+			t.Errorf("%d(%s): error parsing String() result: %s", i, testCase.value, err)
+			continue
+		}
+		// Compare strings to deal with floats not matching exactly.
+		if !reflect.DeepEqual(storeEncryptionSpecString, storeEncryptionSpec2.String()) {
+			t.Errorf("%d(%s): actual doesn't match expected\nactual:   %#+v\nexpected: %#+v", i, testCase.value,
+				storeEncryptionSpec, storeEncryptionSpec2)
+		}
+	}
+}

--- a/pkg/ccl/cliccl/start.go
+++ b/pkg/ccl/cliccl/start.go
@@ -1,0 +1,47 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cliccl
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/ccl/baseccl"
+	"github.com/cockroachdb/cockroach/pkg/cli"
+)
+
+// This does not define a `start` command, only modifications to the existing command
+// in `pkg/cli/start.go`.
+
+var storeEncryptionSpecs baseccl.StoreEncryptionSpecList
+
+const (
+	// TODO(mberhault): use pkg/cli helpers to format flag descriptions.
+	encryptionFlagDesc = `
+        *** Valid enterprise licenses only ***
+
+        TODO(mberhault): fill this.
+
+        Valid fields:
+        * path: must match the path of one of the stores
+        * key: path to the current key file
+        * old-key: path to the previous key file
+        * rotation-period: amount of time after which data keys should be rotated
+`
+)
+
+func init() {
+	// Add additional flags to the existing start command.
+	// This relies upon init-order between packages.
+	cli.StartCmd.Flags().VarP(&storeEncryptionSpecs, "enterprise-encryption", "", encryptionFlagDesc)
+	cli.ExtraStartPreRunHook = matchStoreEncryptionSpecs
+}
+
+// matchStoreEncryptionSpecs is a PreRun hook that matches store encryption specs with the
+// parsed stores.
+func matchStoreEncryptionSpecs() error {
+	return baseccl.MatchStoreAndEncryptionSpecs(cli.ServerCfg.Stores, storeEncryptionSpecs)
+}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -46,7 +46,7 @@ func Main() {
 		os.Args[1],
 	)
 
-	defer log.RecoverAndReportPanic(context.Background(), &serverCfg.Settings.SV)
+	defer log.RecoverAndReportPanic(context.Background(), &ServerCfg.Settings.SV)
 
 	errCode := 0
 	if err := Run(os.Args[1:]); err != nil {
@@ -129,7 +129,7 @@ func init() {
 	})
 
 	cockroachCmd.AddCommand(
-		startCmd,
+		StartCmd,
 		initCmd,
 		certCmd,
 		quitCmd,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -58,14 +58,15 @@ type cliContext struct {
 	showTimes bool
 }
 
-var serverCfg = func() server.Config {
+// ServerCfg is the config for the `start` command.
+var ServerCfg = func() server.Config {
 	st := cluster.MakeClusterSettings(cluster.BinaryMinimumSupportedVersion, cluster.BinaryServerVersion)
 	settings.SetCanonicalValuesContainer(&st.SV)
 
 	return server.MakeConfig(context.Background(), st)
 }()
 
-var baseCfg = serverCfg.Config
+var baseCfg = ServerCfg.Config
 var cliCtx = cliContext{Config: baseCfg}
 
 type tableDisplayFormat int

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -78,7 +78,7 @@ func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (*engine.R
 	}
 	db, err := engine.NewRocksDB(
 		engine.RocksDBConfig{
-			Settings:     serverCfg.Settings,
+			Settings:     ServerCfg.Settings,
 			Dir:          dir,
 			MaxOpenFiles: maxOpenFiles,
 		},

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -58,37 +58,37 @@ func TestNoLinkForbidden(t *testing.T) {
 func TestCacheFlagValue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	f := startCmd.Flags()
+	f := StartCmd.Flags()
 	args := []string{"--cache", "100MB"}
 	if err := f.Parse(args); err != nil {
 		t.Fatal(err)
 	}
 
 	const expectedCacheSize = 100 * 1000 * 1000
-	if expectedCacheSize != serverCfg.CacheSize {
-		t.Errorf("expected %d, but got %d", expectedCacheSize, serverCfg.CacheSize)
+	if expectedCacheSize != ServerCfg.CacheSize {
+		t.Errorf("expected %d, but got %d", expectedCacheSize, ServerCfg.CacheSize)
 	}
 }
 
 func TestSQLMemoryPoolFlagValue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	f := startCmd.Flags()
+	f := StartCmd.Flags()
 	args := []string{"--max-sql-memory", "100MB"}
 	if err := f.Parse(args); err != nil {
 		t.Fatal(err)
 	}
 
 	const expectedSQLMemSize = 100 * 1000 * 1000
-	if expectedSQLMemSize != serverCfg.SQLMemoryPoolSize {
-		t.Errorf("expected %d, but got %d", expectedSQLMemSize, serverCfg.SQLMemoryPoolSize)
+	if expectedSQLMemSize != ServerCfg.SQLMemoryPoolSize {
+		t.Errorf("expected %d, but got %d", expectedSQLMemSize, ServerCfg.SQLMemoryPoolSize)
 	}
 }
 
 func TestClockOffsetFlagValue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	f := startCmd.Flags()
+	f := StartCmd.Flags()
 	testData := []struct {
 		args     []string
 		expected time.Duration
@@ -101,8 +101,8 @@ func TestClockOffsetFlagValue(t *testing.T) {
 		if err := f.Parse(td.args); err != nil {
 			t.Fatal(err)
 		}
-		if td.expected != time.Duration(serverCfg.MaxOffset) {
-			t.Errorf("%d. MaxOffset expected %v, but got %v", i, td.expected, serverCfg.MaxOffset)
+		if td.expected != time.Duration(ServerCfg.MaxOffset) {
+			t.Errorf("%d. MaxOffset expected %v, but got %v", i, td.expected, ServerCfg.MaxOffset)
 		}
 	}
 }
@@ -123,7 +123,7 @@ func TestServerConnSettings(t *testing.T) {
 	}
 	defer resetGlobals()
 
-	f := startCmd.Flags()
+	f := StartCmd.Flags()
 	testData := []struct {
 		args                  []string
 		expectedAddr          string
@@ -158,13 +158,13 @@ func TestServerConnSettings(t *testing.T) {
 		}
 
 		extraServerFlagInit()
-		if td.expectedAddr != serverCfg.Addr {
-			t.Errorf("%d. serverCfg.Addr expected '%s', but got '%s'. td.args was '%#v'.",
-				i, td.expectedAddr, serverCfg.Addr, td.args)
+		if td.expectedAddr != ServerCfg.Addr {
+			t.Errorf("%d. ServerCfg.Addr expected '%s', but got '%s'. td.args was '%#v'.",
+				i, td.expectedAddr, ServerCfg.Addr, td.args)
 		}
-		if td.expectedAdvertiseAddr != serverCfg.AdvertiseAddr {
-			t.Errorf("%d. serverCfg.AdvertiseAddr expected '%s', but got '%s'. td.args was '%#v'.",
-				i, td.expectedAdvertiseAddr, serverCfg.AdvertiseAddr, td.args)
+		if td.expectedAdvertiseAddr != ServerCfg.AdvertiseAddr {
+			t.Errorf("%d. ServerCfg.AdvertiseAddr expected '%s', but got '%s'. td.args was '%#v'.",
+				i, td.expectedAdvertiseAddr, ServerCfg.AdvertiseAddr, td.args)
 		}
 	}
 }
@@ -209,9 +209,9 @@ func TestClientConnSettings(t *testing.T) {
 		}
 
 		extraClientFlagInit()
-		if td.expectedAddr != serverCfg.Addr {
-			t.Errorf("%d. serverCfg.Addr expected '%s', but got '%s'. td.args was '%#v'.",
-				i, td.expectedAddr, serverCfg.Addr, td.args)
+		if td.expectedAddr != ServerCfg.Addr {
+			t.Errorf("%d. ServerCfg.Addr expected '%s', but got '%s'. td.args was '%#v'.",
+				i, td.expectedAddr, ServerCfg.Addr, td.args)
 		}
 	}
 }
@@ -219,7 +219,7 @@ func TestClientConnSettings(t *testing.T) {
 func TestHttpHostFlagValue(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	f := startCmd.Flags()
+	f := StartCmd.Flags()
 	testData := []struct {
 		args     []string
 		expected string
@@ -243,8 +243,8 @@ func TestHttpHostFlagValue(t *testing.T) {
 		}
 
 		extraServerFlagInit()
-		if td.expected != serverCfg.HTTPAddr {
-			t.Errorf("%d. serverCfg.HTTPAddr expected '%s', but got '%s'. td.args was '%#v'.", i, td.expected, serverCfg.HTTPAddr, td.args)
+		if td.expected != ServerCfg.HTTPAddr {
+			t.Errorf("%d. ServerCfg.HTTPAddr expected '%s', but got '%s'. td.args was '%#v'.", i, td.expected, ServerCfg.HTTPAddr, td.args)
 		}
 	}
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -66,9 +66,13 @@ import (
 // The function takes a filename to write the profile to.
 var jemallocHeapDump func(string) error
 
-// startCmd starts a node by initializing the stores and joining
+// ExtraStartPreRunHook is an optional function that is run in the start
+// PreRun hook.
+var ExtraStartPreRunHook func() error
+
+// StartCmd starts a node by initializing the stores and joining
 // the cluster.
-var startCmd = &cobra.Command{
+var StartCmd = &cobra.Command{
 	Use:   "start",
 	Short: "start a node",
 	Long: `
@@ -203,7 +207,7 @@ func initCPUProfile(ctx context.Context, dir string) {
 	}
 
 	go func() {
-		defer log.RecoverAndReportPanic(ctx, &serverCfg.Settings.SV)
+		defer log.RecoverAndReportPanic(ctx, &ServerCfg.Settings.SV)
 
 		ctx := context.Background()
 
@@ -397,8 +401,8 @@ func (b *bytesOrPercentageValue) IsSet() bool {
 	return b.bval.IsSet()
 }
 
-var cacheSizeValue = newBytesOrPercentageValue(&serverCfg.CacheSize, memoryPercentResolver)
-var sqlSizeValue = newBytesOrPercentageValue(&serverCfg.SQLMemoryPoolSize, memoryPercentResolver)
+var cacheSizeValue = newBytesOrPercentageValue(&ServerCfg.CacheSize, memoryPercentResolver)
+var sqlSizeValue = newBytesOrPercentageValue(&ServerCfg.SQLMemoryPoolSize, memoryPercentResolver)
 var diskTempStorageSizeValue = newBytesOrPercentageValue(nil /* v */, nil /* percentResolver */)
 
 func initExternalIODir(ctx context.Context, firstStore base.StoreSpec) (string, error) {
@@ -516,22 +520,22 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 	// Deal with flags that may depend on other flags.
 
-	tracer := serverCfg.Settings.Tracer
+	tracer := ServerCfg.Settings.Tracer
 	sp := tracer.StartSpan("server start")
 	ctx := opentracing.ContextWithSpan(context.Background(), sp)
 
 	var err error
-	if serverCfg.TempStorageConfig, err = initTempStorageConfig(ctx, serverCfg.Stores.Specs[0]); err != nil {
+	if ServerCfg.TempStorageConfig, err = initTempStorageConfig(ctx, ServerCfg.Stores.Specs[0]); err != nil {
 		return err
 	}
-	if serverCfg.Settings.ExternalIODir, err = initExternalIODir(ctx, serverCfg.Stores.Specs[0]); err != nil {
+	if ServerCfg.Settings.ExternalIODir, err = initExternalIODir(ctx, ServerCfg.Stores.Specs[0]); err != nil {
 		return err
 	}
 
 	// Use the server-specific values for some flags and settings.
-	serverCfg.Insecure = startCtx.serverInsecure
-	serverCfg.SSLCertsDir = startCtx.serverSSLCertsDir
-	serverCfg.User = security.NodeUser
+	ServerCfg.Insecure = startCtx.serverInsecure
+	ServerCfg.SSLCertsDir = startCtx.serverSSLCertsDir
+	ServerCfg.User = security.NodeUser
 
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
@@ -544,7 +548,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	serverCfg.Report(ctx)
+	ServerCfg.Report(ctx)
 
 	// Run the rest of the startup process in the background to avoid preventing
 	// proper handling of signals if we get stuck on something during
@@ -569,7 +573,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 		}()
 		defer sp.Finish()
 		if err := func() error {
-			if err := serverCfg.InitNode(); err != nil {
+			if err := ServerCfg.InitNode(); err != nil {
 				return errors.Wrap(err, "failed to initialize node")
 			}
 
@@ -579,7 +583,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 			}
 
 			var err error
-			s, err = server.NewServer(serverCfg, stopper)
+			s, err = server.NewServer(ServerCfg, stopper)
 			if err != nil {
 				return errors.Wrap(err, "failed to start server")
 			}
@@ -594,9 +598,9 @@ func runStart(cmd *cobra.Command, args []string) error {
 			if err := s.Start(ctx); err != nil {
 				if le, ok := err.(server.ListenError); ok {
 					const errorPrefix = "consider changing the port via --"
-					if le.Addr == serverCfg.Addr {
+					if le.Addr == ServerCfg.Addr {
 						err = errors.Wrap(err, errorPrefix+cliflags.ServerPort.Name)
-					} else if le.Addr == serverCfg.HTTPAddr {
+					} else if le.Addr == ServerCfg.HTTPAddr {
 						err = errors.Wrap(err, errorPrefix+cliflags.ServerHTTPPort.Name)
 					}
 				}
@@ -614,7 +618,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 				s.PeriodicallyCheckForUpdates()
 			}
 
-			pgURL, err := serverCfg.PGURL(url.User(sqlConnUser))
+			pgURL, err := ServerCfg.PGURL(url.User(sqlConnUser))
 			if err != nil {
 				return err
 			}
@@ -623,17 +627,17 @@ func runStart(cmd *cobra.Command, args []string) error {
 			tw := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
 			fmt.Fprintf(tw, "CockroachDB node starting at %s (took %0.1fs)\n", timeutil.Now(), timeutil.Since(tBegin).Seconds())
 			fmt.Fprintf(tw, "build:\t%s %s @ %s (%s)\n", info.Distribution, info.Tag, info.Time, info.GoVersion)
-			fmt.Fprintf(tw, "admin:\t%s\n", serverCfg.AdminURL())
+			fmt.Fprintf(tw, "admin:\t%s\n", ServerCfg.AdminURL())
 			fmt.Fprintf(tw, "sql:\t%s\n", pgURL)
-			if len(serverCfg.SocketFile) != 0 {
-				fmt.Fprintf(tw, "socket:\t%s\n", serverCfg.SocketFile)
+			if len(ServerCfg.SocketFile) != 0 {
+				fmt.Fprintf(tw, "socket:\t%s\n", ServerCfg.SocketFile)
 			}
 			fmt.Fprintf(tw, "logs:\t%s\n", flag.Lookup("log-dir").Value)
-			if serverCfg.Attrs != "" {
-				fmt.Fprintf(tw, "attrs:\t%s\n", serverCfg.Attrs)
+			if ServerCfg.Attrs != "" {
+				fmt.Fprintf(tw, "attrs:\t%s\n", ServerCfg.Attrs)
 			}
-			if len(serverCfg.Locality.Tiers) > 0 {
-				fmt.Fprintf(tw, "locality:\t%s\n", serverCfg.Locality)
+			if len(ServerCfg.Locality.Tiers) > 0 {
+				fmt.Fprintf(tw, "locality:\t%s\n", ServerCfg.Locality)
 			}
 			if s.TempDir() != "" {
 				fmt.Fprintf(tw, "temp dir:\t%s\n", s.TempDir())
@@ -643,8 +647,13 @@ func runStart(cmd *cobra.Command, args []string) error {
 			} else {
 				fmt.Fprintf(tw, "external I/O path: \t<disabled>\n")
 			}
-			for i, spec := range serverCfg.Stores.Specs {
+			for i, spec := range ServerCfg.Stores.Specs {
 				fmt.Fprintf(tw, "store[%d]:\t%s\n", i, spec)
+				if spec.ExtraFields != nil {
+					for k, v := range spec.ExtraFields {
+						fmt.Fprintf(tw, "  %s:\t%s\n", k, v)
+					}
+				}
 			}
 			initialBoot := s.InitialBoot()
 			nodeID := s.NodeID()
@@ -822,7 +831,7 @@ func setupAndInitializeLoggingAndProfiling(ctx context.Context) (*stop.Stopper, 
 		// We only override the log directory if the user has not explicitly
 		// disabled file logging using --log-dir="".
 		newDir := ""
-		for _, spec := range serverCfg.Stores.Specs {
+		for _, spec := range ServerCfg.Stores.Specs {
 			if spec.InMemory {
 				continue
 			}
@@ -924,12 +933,12 @@ func getClientGRPCConn() (*grpc.ClientConn, *hlc.Clock, *stop.Stopper, error) {
 	clock := hlc.NewClock(hlc.UnixNano, 0)
 	stopper := stop.NewStopper()
 	rpcContext := rpc.NewContext(
-		log.AmbientContext{Tracer: serverCfg.Settings.Tracer},
-		serverCfg.Config,
+		log.AmbientContext{Tracer: ServerCfg.Settings.Tracer},
+		ServerCfg.Config,
 		clock,
 		stopper,
 	)
-	addr, err := addrWithDefaultHost(serverCfg.AdvertiseAddr)
+	addr, err := addrWithDefaultHost(ServerCfg.AdvertiseAddr)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/cli/start_test.go
+++ b/pkg/cli/start_test.go
@@ -31,7 +31,7 @@ import (
 func TestInitInsecure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	f := startCmd.Flags()
+	f := StartCmd.Flags()
 
 	testCases := []struct {
 		args     []string
@@ -76,7 +76,7 @@ func TestInitInsecure(t *testing.T) {
 func TestStartArgChecking(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	f := startCmd.Flags()
+	f := StartCmd.Flags()
 
 	testCases := []struct {
 		args     []string
@@ -86,7 +86,7 @@ func TestStartArgChecking(t *testing.T) {
 		{[]string{`--insecure=blu`}, `parsing "blu": invalid syntax`},
 		{[]string{`--store=path=`}, `no value specified`},
 		{[]string{`--store=path=blah,path=blih`}, `field was used twice`},
-		{[]string{`--store=path=~/blah`}, `store path cannot start with '~'`},
+		{[]string{`--store=path=~/blah`}, `path cannot start with '~': ~/blah`},
 		{[]string{`--store=path=./~/blah`}, ``},
 		{[]string{`--store=size=blih`}, `could not parse store size`},
 		{[]string{`--store=size=0.005`}, `store size \(0.005\) must be between 1% and 100%`},

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -28,7 +28,7 @@ import (
 var startBackground bool
 
 func init() {
-	boolFlag(startCmd.Flags(), &startBackground, cliflags.Background, false)
+	boolFlag(StartCmd.Flags(), &startBackground, cliflags.Background, false)
 }
 
 func maybeRerunBackground() (bool, error) {


### PR DESCRIPTION
Part of encryption-at-rest work.

Add a CCL-only `--enterprise-encryption` flag (does not show
up on OSS builds) that adds arbitrary fields to the store spec.

This is a bit tortuous as we need to:
* modify the startCmd flags (startCmd made public)
* run an extra PreRun hook (added custom extra hook)
* access the store specs from CCL code (serverCfg made public)
* have a generic enough datastructure in `StoreSpec`

Some of these can be generalized. eg:
* accessing all commands from CCL code (including flag formatting)
* allow arbitrary number of additional hooks per command

How to hook those up into libroach is still TBD. These flags will
control at least two things:
* the store version (only bumped if those flags are set)
* the use of encryption in libroachccl