### PR TITLE
sql/parser: move TestHelpURLs to the linter

### DIFF
--- a/pkg/cmd/urlcheck/lib/urlcheck/urlcheck.go
+++ b/pkg/cmd/urlcheck/lib/urlcheck/urlcheck.go
@@ -19,7 +19,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net"
 	"net/http"
@@ -154,13 +153,6 @@ func checkURLWithRetries(client *http.Client, url string) error {
 		return err
 	}
 	return fmt.Errorf("timed out on %d separate tries, giving up", timeoutRetries)
-}
-
-// Check verifies the URLs provided by the given io.Reader.
-func Check(r io.Reader) error {
-	cmd := exec.Command("grep", "-nE", URLRE)
-	cmd.Stdin = r
-	return CheckURLsFromGrepOutput(cmd)
 }
 
 // CheckURLsFromGrepOutput runs the specified cmd, which should be

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -15,24 +15,11 @@
 package parser
 
 import (
-	"bytes"
 	"strings"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/cmd/urlcheck/lib/urlcheck"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 )
-
-func TestHelpURLs(t *testing.T) {
-	var buf bytes.Buffer
-	for key, body := range HelpMessages {
-		msg := HelpMessage{Command: key, HelpMessageBody: body}
-		buf.WriteString(msg.String())
-	}
-	if err := urlcheck.Check(&buf); err != nil {
-		t.Fatal(err)
-	}
-}
 
 func TestHelpMessagesDefined(t *testing.T) {
 	var emptyBody HelpMessageBody

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -34,6 +34,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/urlcheck/lib/urlcheck"
+	sqlparser "github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/ghemawat/stream"
 	"github.com/kisielk/gotool"
 	"github.com/pkg/errors"
@@ -1085,6 +1087,21 @@ func TestLint(t *testing.T) {
 			if out := stderr.String(); len(out) > 0 {
 				t.Fatalf("err=%s, stderr=%s", err, out)
 			}
+		}
+	})
+
+	// TestHelpURLs checks that all help texts have a valid documentation URL.
+	t.Run("TestHelpURLs", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		for key, body := range sqlparser.HelpMessages {
+			msg := sqlparser.HelpMessage{Command: key, HelpMessageBody: body}
+			buf.WriteString(msg.String())
+		}
+		cmd := exec.Command("grep", "-nE", urlcheck.URLRE)
+		cmd.Stdin = &buf
+		if err := urlcheck.CheckURLsFromGrepOutput(cmd); err != nil {
+			t.Fatal(err)
 		}
 	})
 }


### PR DESCRIPTION
Fixes #20240.

cc @nvanbenschoten 