### PR TITLE
sql: ensure that AS OF SYSTEM TIME is handled consistently

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -582,10 +582,6 @@ func (p *planner) getTableDesc(
 	ctx context.Context, tn *tree.TableName,
 ) (*sqlbase.TableDescriptor, error) {
 	if p.avoidCachedDescriptors {
-		// AS OF SYSTEM TIME queries need to fetch the table descriptor at the
-		// specified time, and never lease anything. The proto transaction already
-		// has its timestamps set correctly so getTableOrViewDesc will fetch with
-		// the correct timestamp.
 		return MustGetTableOrViewDesc(
 			ctx, p.txn, p.getVirtualTabler(), tn, false /*allowAdding*/)
 	}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -532,6 +532,10 @@ func (e *Executor) Prepare(
 	planner.evalCtx.ActiveMemAcc = &prepared.constantAcc
 
 	if protoTS != nil {
+		planner.asOfSystemTime = true
+		// We can't use cached descriptors anywhere in this query, because
+		// we want the descriptors at the timestamp given, not the latest
+		// known to the cache.
 		planner.avoidCachedDescriptors = true
 		txn.SetFixedTimestamp(session.Ctx(), *protoTS)
 	}
@@ -766,6 +770,7 @@ func (e *Executor) execParsed(
 	session *Session, stmts StatementList, pinfo *tree.PlaceholderInfo, copymsg copyMsg,
 ) error {
 	var avoidCachedDescriptors bool
+	var asOfSystemTime bool
 	txnState := &session.TxnState
 	resultWriter := session.ResultsWriter
 
@@ -807,6 +812,7 @@ func (e *Executor) execParsed(
 					return err
 				}
 				if protoTS != nil {
+					asOfSystemTime = true
 					// When running AS OF SYSTEM TIME queries, we want to use the
 					// table descriptors from the specified time, and never lease
 					// anything. To do this, we pass down the avoidCachedDescriptors
@@ -833,7 +839,7 @@ func (e *Executor) execParsed(
 		var transitionToOpen bool
 		remainingStmts, transitionToOpen, err = runWithAutoRetry(
 			e, session, stmtsToExec, !inTxn /* txnPrefix */, autoCommit,
-			protoTS, pinfo, avoidCachedDescriptors,
+			protoTS, pinfo, asOfSystemTime, avoidCachedDescriptors,
 		)
 		if autoCommit && txnState.State() != NoTxn {
 			log.Fatalf(session.Ctx(), "after an implicit txn, state should always be NoTxn, but found: %s",
@@ -972,6 +978,7 @@ func runWithAutoRetry(
 	autoCommit bool,
 	protoTS *hlc.Timestamp,
 	pinfo *tree.PlaceholderInfo,
+	asOfSystemTime bool,
 	avoidCachedDescriptors bool,
 ) (remainingStmts StatementList, transitionToOpen bool, _ error) {
 
@@ -1016,7 +1023,7 @@ func runWithAutoRetry(
 		// Run some statements.
 		remainingStmts, transitionToOpen, err = runTxnAttempt(
 			e, session, stmtsToExec, pinfo, origState,
-			txnPrefix, avoidCachedDescriptors, automaticRetryCount, txnState.txnResults)
+			txnPrefix, asOfSystemTime, avoidCachedDescriptors, automaticRetryCount, txnState.txnResults)
 
 		// Sanity checks.
 		if err != nil && txnState.TxnIsOpen() {
@@ -1152,6 +1159,7 @@ func runTxnAttempt(
 	pinfo *tree.PlaceholderInfo,
 	origState TxnStateEnum,
 	txnPrefix bool,
+	asOfSystemTime bool,
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
 	txnResults ResultsGroup,
@@ -1191,7 +1199,7 @@ func runTxnAttempt(
 		if err := e.execSingleStatement(
 			session, stmt, pinfo,
 			txnPrefix && i == 0, /* firstInTxn */
-			avoidCachedDescriptors, automaticRetryCount, stmtResult,
+			asOfSystemTime, avoidCachedDescriptors, automaticRetryCount, stmtResult,
 		); err != nil {
 			return nil, false, err
 		}
@@ -1244,6 +1252,7 @@ func runTxnAttempt(
 // pinfo:      The placeholders to use in the statements.
 // firstInTxn: Set if the statements represents the first statement in a txn.
 //   Used to trap nested BEGINs.
+// asOfSystemTime: Set if the statement is using AS OF SYSTEM TIME.
 // avoidCachedDescriptors: Set if the statement execution should avoid
 //   using cached descriptors.
 // automaticRetryCount: Increases with each retry; 0 for the first attempt.
@@ -1255,6 +1264,7 @@ func (e *Executor) execSingleStatement(
 	stmt Statement,
 	pinfo *tree.PlaceholderInfo,
 	firstInTxn bool,
+	asOfSystemTime bool,
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
 	res StatementResult,
@@ -1320,7 +1330,7 @@ func (e *Executor) execSingleStatement(
 		case Open, AutoRetry:
 			err = e.execStmtInOpenTxn(
 				session, stmt, pinfo, firstInTxn,
-				avoidCachedDescriptors, automaticRetryCount, res)
+				asOfSystemTime, avoidCachedDescriptors, automaticRetryCount, res)
 		case Aborted, RestartWait:
 			err = e.execStmtInAbortedTxn(session, stmt, res)
 		case CommitWait:
@@ -1534,6 +1544,7 @@ func sessionEventf(session *Session, format string, args ...interface{}) {
 // pinfo: the placeholders to use in the statement.
 // firstInTxn: set for the first statement in a transaction. Used
 //  so that nested BEGIN statements are caught.
+// asOfSystemTime: set if the statement is using AS OF SYSTEM TIME.
 // avoidCachedDescriptors: set if the statement execution should avoid
 //  using cached descriptors.
 // automaticRetryCount: increases with each retry; 0 for the first attempt.
@@ -1543,6 +1554,7 @@ func (e *Executor) execStmtInOpenTxn(
 	stmt Statement,
 	pinfo *tree.PlaceholderInfo,
 	firstInTxn bool,
+	asOfSystemTime bool,
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
 	res StatementResult,
@@ -1779,6 +1791,7 @@ func (e *Executor) execStmtInOpenTxn(
 	p.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
 	p.semaCtx.Placeholders.Assign(pinfo)
 	p.evalCtx.Placeholders = &p.semaCtx.Placeholders
+	p.asOfSystemTime = asOfSystemTime
 	p.avoidCachedDescriptors = avoidCachedDescriptors
 	p.phaseTimes[plannerStartExecStmt] = timeutil.Now()
 	p.stmt = &stmt

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -30,7 +30,7 @@ forks blue
 forks red
 forks green
 
-statement error pq: AS OF SYSTEM TIME not supported in this context
+statement error pq: AS OF SYSTEM TIME must be provided on a top level SELECT statement
 CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '2016-01-01'
 
 statement error pgcode 42601 CREATE TABLE specifies 3 column names, but data source has 2 columns

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -351,7 +351,7 @@ SELECT * FROM dt2
 statement ok
 CREATE VIEW v AS SELECT d, t FROM t
 
-statement error pq: AS OF SYSTEM TIME not supported in this context
+statement error pq: AS OF SYSTEM TIME must be provided on a top level SELECT statement
 CREATE TABLE t2 AS SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
 
 statement ok

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -55,6 +55,16 @@ type planner struct {
 	semaCtx tree.SemaContext
 	evalCtx tree.EvalContext
 
+	// asOfSystemTime indicates whether the transaction timestamp was
+	// forced to a specific value (in which case that value is stored in
+	// txn.mu.Proto.OrigTimestamp). If set, avoidCachedDescriptors below
+	// must also be set.
+	// TODO(anyone): we may want to support table readers at arbitrary
+	// timestamps, so that each FROM clause can have its own
+	// timestamp. In that case, the timestamp would not be set
+	// globally for the entire txn and this field would not be needed.
+	asOfSystemTime bool
+
 	// avoidCachedDescriptors, when true, instructs all code that
 	// accesses table/view descriptors to force reading the descriptors
 	// within the transaction. This is necessary to:

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -706,10 +706,6 @@ func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *tree.TableNa
 
 	descFunc := p.session.tables.getTableVersion
 	if p.avoidCachedDescriptors {
-		// AS OF SYSTEM TIME queries need to fetch the table descriptor at the
-		// specified time, and never lease anything. The proto transaction already
-		// has its timestamps set correctly so getTableOrViewDesc will fetch with
-		// the correct timestamp.
 		descFunc = getTableOrViewDesc
 	}
 


### PR DESCRIPTION
Fixes #20182.

Prior to this patch, two inconsistencies were present in the code:

- a user-visible inconsistency: `AS OF SYSTEM TIME` (henceforth
  referred to as "AOST") was accepted anywhere in a query as soon as
  it was present at the top level SELECT statement, including with
  conflicting timestamps. Accepting AOST in multiple places doesn't
  feel undesirable, but allowing conflicting timestamps to be
  specified is unsound with the current underlying mechanism (a shared
  timestamp for the entire transaction).

- an internal inconsistency, visible to CockroachDB developers: the
  presence of an AOST clause during planning was erroneously conflated
  with the flag that disables caching of table descriptors
  (`planner.avoidCachedDescriptors`). This is erroneous because,
  although AOST *implies* `avoidCachedDescriptors == true` (we can't
  use the cache while time travelling), the converse is not true: when
  processing view descriptors (and perhaps, in the future, for other
  reasons), we also disable descriptor caching although AOST is not
  involved.

This patch rectifies this situation as follows:

- a new planner flag `asOfSystemTime` is introduced to indicate
  that an AOST clause was properly recognized at the top level.

- the logic that allows or refuses AOST clauses in FROM clauses in
  arbitrarily nested SELECT clauses (including, potentially, those
  expanded from views), is modified to use this new flag.

- the time stamps of AOST clauses, if multiple are specified, are
  checked to be equal to the one set at the top level. This
  restriction might be lifted in the future if we ever support
  different AOST clauses per data source.

In addition, the error message when an AOST clause is not given in the
proper syntactic position is improved to hint where it should be
placed instead.

----

Release note (sql, bug fix): it is not possible any more to indicate
conflicting `AS OF SYSTEM TIME` clauses in different part of a query.