### PR TITLE
build: Fix copying of licenses into RHEL docker image

### DIFF
--- a/build/deploy/rhel/Dockerfile
+++ b/build/deploy/rhel/Dockerfile
@@ -16,7 +16,7 @@ LABEL name="cockroachdb/cockroach" \
 COPY help.1 /help.1
 
 # Licenses
-COPY LICENSE APL.txt /licenses/
+COPY licenses/* /licenses/
 
 # Start script and CockroachDB binary
 RUN mkdir -p /cockroach

--- a/build/deploy/rhel/build.sh
+++ b/build/deploy/rhel/build.sh
@@ -5,6 +5,8 @@ set -ux
 # Temporarily copy the necessary files into this directory (and clean
 # them up afterwards) because docker build can't access resources
 # from parent directories.
-cp ../../../LICENSE ../../../APL.txt ../cockroach.sh ../cockroach ./
+cp ../cockroach.sh ../cockroach ./
+mkdir licenses
+cp -r ../../../LICENSE ../../../licenses/ ./licenses
 docker build --no-cache --pull -t cockroachdb:${VERSION} .
-rm LICENSE APL.txt cockroach.sh cockroach
+rm -r licenses cockroach.sh cockroach


### PR DESCRIPTION
This was broken by the recent license refactoring in
d8b551ba1ca930cb765e53c918e28d6f3a2133f8