### PR TITLE
storage: allow for multiple txns to be updated in a batch

### DIFF
--- a/pkg/storage/batcheval/cmd_push_txn.go
+++ b/pkg/storage/batcheval/cmd_push_txn.go
@@ -135,7 +135,7 @@ func PushTxn(
 		// Setting OrigTimestamp bumps LastActive(); see #9265.
 		reply.PusheeTxn.OrigTimestamp = args.Now
 		result := result.Result{}
-		result.Local.UpdatedTxn = &reply.PusheeTxn
+		result.Local.UpdatedTxns = &[]*roachpb.Transaction{&reply.PusheeTxn}
 		return result, engine.MVCCPutProto(ctx, batch, cArgs.Stats, key, hlc.Timestamp{}, nil, &reply.PusheeTxn)
 	}
 	// Start with the persisted transaction record as final transaction.
@@ -226,6 +226,6 @@ func PushTxn(
 		return result.Result{}, err
 	}
 	result := result.Result{}
-	result.Local.UpdatedTxn = &reply.PusheeTxn
+	result.Local.UpdatedTxns = &[]*roachpb.Transaction{&reply.PusheeTxn}
 	return result, nil
 }

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -496,7 +496,7 @@ func evalEndTransaction(
 	// don't want the intents to be up for resolution. That should happen only
 	// if the commit actually happens; otherwise, we risk losing writes.
 	intentsResult := result.FromIntents(externalIntents, args, false /* alwaysReturn */)
-	intentsResult.Local.UpdatedTxn = reply.Txn
+	intentsResult.Local.UpdatedTxns = &[]*roachpb.Transaction{reply.Txn}
 	if err := pd.MergeAndDestroy(intentsResult); err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -725,9 +725,11 @@ func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult result.Loca
 		lResult.LeaseMetricsResult = nil
 	}
 
-	if lResult.UpdatedTxn != nil {
-		r.txnWaitQueue.UpdateTxn(ctx, lResult.UpdatedTxn)
-		lResult.UpdatedTxn = nil
+	if lResult.UpdatedTxns != nil {
+		for _, txn := range *lResult.UpdatedTxns {
+			r.txnWaitQueue.UpdateTxn(ctx, txn)
+			lResult.UpdatedTxns = nil
+		}
 	}
 
 	if (lResult != result.LocalResult{}) {


### PR DESCRIPTION
The `LocalResult.UpdatedTxn` field is used to signal that a transaction
was updated via `EndTransaction` or `PushTxn` commands. However, it allowed
only a single transaction to be updated, when in fact multiple `PushTxn`
commands are possible in a batch.

This PR changes the singular `UpdatedTxn` field to a slice `UpdatedTxns`,
and adds a unittest to verify that a scan across intents originating from
multiple txns can be resolved together.