### PR TITLE
sql: fix pg_class's `relkind` column for sequences

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -383,6 +383,43 @@ v1            a        false         true        0            NULL    NULL      
 v1            b        false         true        0            NULL    NULL        NULL
 v1            c        false         true        0            NULL    NULL        NULL
 
+# Check relkind codes.
+statement ok
+CREATE DATABASE relkinds
+
+statement ok
+SET DATABASE = relkinds
+
+statement ok
+CREATE TABLE tbl_test (k int primary key, v int)
+
+statement ok
+CREATE INDEX tbl_test_v_idx ON tbl_test (v)
+
+statement ok
+CREATE VIEW view_test AS SELECT k, v FROM tbl_test ORDER BY v
+
+statement ok
+CREATE SEQUENCE seq_test
+
+query TT
+SELECT relname, relkind
+FROM pg_catalog.pg_class c
+JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
+WHERE n.nspname = 'relkinds'
+ORDER BY relname
+----
+primary         i
+seq_test        S
+tbl_test        r
+tbl_test_v_idx  i
+view_test       v
+
+statement ok
+DROP DATABASE relkinds
+
+statement ok
+SET DATABASE = constraint_db
 
 # Select all columns with collations.
 query TTTOT colnames

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -221,9 +221,10 @@ CREATE TABLE pg_catalog.pg_attribute (
 }
 
 var (
-	relKindTable = tree.NewDString("r")
-	relKindIndex = tree.NewDString("i")
-	relKindView  = tree.NewDString("v")
+	relKindTable    = tree.NewDString("r")
+	relKindIndex    = tree.NewDString("i")
+	relKindView     = tree.NewDString("v")
+	relKindSequence = tree.NewDString("S")
 
 	relPersistencePermanent = tree.NewDString("p")
 )
@@ -264,11 +265,12 @@ CREATE TABLE pg_catalog.pg_class (
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
-			// Table.
+			// The only difference between tables, views and sequences is the relkind column.
 			relKind := relKindTable
 			if table.IsView() {
-				// The only difference between tables and views is the relkind column.
 				relKind = relKindView
+			} else if table.IsSequence() {
+				relKind = relKindSequence
 			}
 			if err := addRow(
 				h.TableOid(db, table),       // oid


### PR DESCRIPTION
Rows in `pg_class` describing sequences have a value of `S` in column `relkind`. (PG docs here: https://www.postgresql.org/docs/9.3/static/catalog-pg-class.html)

Sequences tracking issue: #19723