### PR TITLE
cherrypick-1.1: cli: dump: fix infinite loop in when resolving depend…

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -125,13 +125,14 @@ func collect(tid int64, byID map[int64]tableMetadata, seen map[int64]bool, colle
 	if seen[tid] {
 		return
 	}
-	// no: add it
+	// no: mark it as seen.
+	seen[tid] = true
 	for _, dep := range byID[tid].dependsOn {
 		// depth-first collection of dependencies
 		collect(dep, byID, seen, collected)
 	}
+	// Only add it after its dependencies.
 	*collected = append(*collected, tid)
-	seen[tid] = true
 }
 
 // tableMetadata describes one table to dump.


### PR DESCRIPTION
…encies.

Release Note (cli): fix panic on `cockroach dump` in the presence of
reference cycles.

While this will avoid the loop and keep dependency order, there may
still be problems with dependency cycles.

This came up in #20254 when encountering a foreign key referring to the
same table.

Before the fix, the test fails with:
```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow
```