### PR TITLE
cherry-pick 1.1: sql: ensure that AS OF SYSTEM TIME is handled consistently

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -170,8 +170,19 @@ func TestAsOfTime(t *testing.T) {
 	// Subqueries shouldn't work.
 	_, err := db.Query(
 		fmt.Sprintf("SELECT (SELECT a FROM d.t AS OF SYSTEM TIME %s)", tsVal1))
-	if !testutils.IsError(err, "pq: AS OF SYSTEM TIME not supported in this context") {
+	if !testutils.IsError(err, "pq: AS OF SYSTEM TIME must be provided on a top level SELECT statement") {
 		t.Fatalf("expected not supported, got: %v", err)
+	}
+
+	// Subqueries do work of the timestamps are consistent.
+	_, err = db.Query(
+		fmt.Sprintf("SELECT (SELECT a FROM d.t AS OF SYSTEM TIME %s) FROM (SELECT 1) AS OF SYSTEM TIME '1980-01-01'", tsVal1))
+	if !testutils.IsError(err, "pq: cannot specify AS OF SYSTEM TIME with different timestamps") {
+		t.Fatalf("expected inconsistent statements, got: %v", err)
+	}
+	if err := db.QueryRow(
+		fmt.Sprintf("SELECT (SELECT 1 FROM d.t AS OF SYSTEM TIME %s) FROM (SELECT 1) AS OF SYSTEM TIME %s", tsVal1, tsVal1)).Scan(&i); err != nil {
+		t.Fatal(err)
 	}
 
 	// Verify that we can read columns in the past that are dropped in the future.
@@ -187,7 +198,7 @@ func TestAsOfTime(t *testing.T) {
 	// Can't use in a transaction.
 	_, err = db.Query(
 		fmt.Sprintf("BEGIN; SELECT a FROM d.t AS OF SYSTEM TIME %s; COMMIT;", tsVal1))
-	if !testutils.IsError(err, "pq: AS OF SYSTEM TIME not supported in this context") {
+	if !testutils.IsError(err, "pq: AS OF SYSTEM TIME must be provided on a top level SELECT statement") {
 		t.Fatalf("expected not supported, got: %v", err)
 	}
 }

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -538,10 +538,6 @@ func (p *planner) getTableDesc(
 	ctx context.Context, tn *parser.TableName,
 ) (*sqlbase.TableDescriptor, error) {
 	if p.avoidCachedDescriptors {
-		// AS OF SYSTEM TIME queries need to fetch the table descriptor at the
-		// specified time, and never lease anything. The proto transaction already
-		// has its timestamps set correctly so getTableOrViewDesc will fetch with
-		// the correct timestamp.
 		return MustGetTableOrViewDesc(
 			ctx, p.txn, p.getVirtualTabler(), tn, false /*allowAdding*/)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -30,7 +30,7 @@ forks blue
 forks red
 forks green
 
-statement error pq: AS OF SYSTEM TIME not supported in this context
+statement error pq: AS OF SYSTEM TIME must be provided on a top level SELECT statement
 CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '2016-01-01'
 
 statement error pgcode 42601 CREATE TABLE specifies 3 column names, but data source has 2 columns

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -351,7 +351,7 @@ SELECT * FROM dt2
 statement ok
 CREATE VIEW v AS SELECT d, t FROM t
 
-statement error pq: AS OF SYSTEM TIME not supported in this context
+statement error pq: AS OF SYSTEM TIME must be provided on a top level SELECT statement
 CREATE TABLE t2 AS SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
 
 statement ok

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -50,6 +50,16 @@ type planner struct {
 	semaCtx parser.SemaContext
 	evalCtx parser.EvalContext
 
+	// asOfSystemTime indicates whether the transaction timestamp was
+	// forced to a specific value (in which case that value is stored in
+	// txn.mu.Proto.OrigTimestamp). If set, avoidCachedDescriptors below
+	// must also be set.
+	// TODO(anyone): we may want to support table readers at arbitrary
+	// timestamps, so that each FROM clause can have its own
+	// timestamp. In that case, the timestamp would not be set
+	// globally for the entire txn and this field would not be needed.
+	asOfSystemTime bool
+
 	// avoidCachedDescriptors, when true, instructs all code that
 	// accesses table/view descriptors to force reading the descriptors
 	// within the transaction. This is necessary to:

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 // renderNode encapsulates the render logic of a select statement:
@@ -295,11 +296,36 @@ func (p *planner) SelectClause(
 func (r *renderNode) initFrom(
 	ctx context.Context, parsed *parser.SelectClause, scanVisibility scanVisibility,
 ) error {
-	// AS OF expressions are either not supported in this context (e.g. in a view
-	// definition), or they should have been handled by the executor.
-	if parsed.From.AsOf.Expr != nil && !r.planner.avoidCachedDescriptors {
-		return fmt.Errorf("AS OF SYSTEM TIME not supported in this context")
+	if parsed.From.AsOf.Expr != nil {
+		// If AS OF SYSTEM TIME is specified in any part of the query,
+		// then it must be consistent with what is known to the
+		// Executor.
+
+		// At this point, the executor only knows how to recognize AS OF
+		// SYSTEM TIME at the top level. When it finds it there,
+		// p.asOfSystemTime is set. If AS OF SYSTEM TIME wasn't found
+		// there, we cannot accept it anywhere else either.
+		// TODO(anyone): this restriction might be lifted if we support
+		// table readers at arbitrary timestamps, and each FROM clause
+		// can have its own timestamp. In that case, the timestamp
+		// would not be set globally for the entire txn.
+		if !r.planner.asOfSystemTime {
+			return fmt.Errorf("AS OF SYSTEM TIME must be provided on a top level SELECT statement")
+		}
+
+		// The Executor found an AS OF SYSTEM TIME clause at the top
+		// level. We accept AS OF SYSTEM TIME in multiple places (e.g. in
+		// subqueries or view queries) but they must all point to the same
+		// timestamp.
+		ts, err := EvalAsOfTimestamp(&r.planner.evalCtx, parsed.From.AsOf, hlc.MaxTimestamp)
+		if err != nil {
+			return err
+		}
+		if ts != r.planner.txn.OrigTimestamp() {
+			return fmt.Errorf("cannot specify AS OF SYSTEM TIME with different timestamps")
+		}
 	}
+
 	src, err := r.planner.getSources(ctx, parsed.From.Tables, scanVisibility)
 	if err != nil {
 		return err

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -675,10 +675,6 @@ func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *parser.Table
 
 	descFunc := p.session.tables.getTableVersion
 	if p.avoidCachedDescriptors {
-		// AS OF SYSTEM TIME queries need to fetch the table descriptor at the
-		// specified time, and never lease anything. The proto transaction already
-		// has its timestamps set correctly so getTableOrViewDesc will fetch with
-		// the correct timestamp.
 		descFunc = getTableOrViewDesc
 	}
 


### PR DESCRIPTION
Cherry-pick of #20267.

Prior to this patch, two inconsistencies were present in the code:

- a user-visible inconsistency: `AS OF SYSTEM TIME` (henceforth
  referred to as "AOST") was accepted anywhere in a query as soon as
  it was present at the top level SELECT statement, including with
  conflicting timestamps. Accepting AOST in multiple places doesn't
  feel undesirable, but allowing conflicting timestamps to be
  specified is unsound with the current underlying mechanism (a shared
  timestamp for the entire transaction).

- an internal inconsistency, visible to CockroachDB developers: the
  presence of an AOST clause during planning was erroneously conflated
  with the flag that disables caching of table descriptors
  (`planner.avoidCachedDescriptors`). This is erroneous because,
  although AOST *implies* `avoidCachedDescriptors == true` (we can't
  use the cache while time travelling), the converse is not true: when
  processing view descriptors (and perhaps, in the future, for other
  reasons), we also disable descriptor caching although AOST is not
  involved.

This patch rectifies this situation as follows:

- a new planner flag `asOfSystemTime` is introduced to indicate
  that an AOST clause was properly recognized at the top level.

- the logic that allows or refuses AOST clauses in FROM clauses in
  arbitrarily nested SELECT clauses (including, potentially, those
  expanded from views), is modified to use this new flag.

- the timestamps of AOST clauses, if multiple are specified, are
  checked to be equal to the one set at the top level. This
  restriction might be lifted in the future if we ever support
  different AOST clauses per data source.

In addition, the error message when an AOST clause is not given in the
proper syntactic position is improved to hint where it should be
placed instead.

----

Release note (sql, bug fix): it is not possible any more to indicate
conflicting `AS OF SYSTEM TIME` clauses in different part of a query.

cc @cockroachdb/release 