### PR TITLE
storage: don't use quota pool throttling for NodeLiveness range

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -250,12 +250,6 @@ func (r *Replica) ReplicaIDLocked() roachpb.ReplicaID {
 	return r.mu.replicaID
 }
 
-func (r *Replica) GetLastUpdateTimeForReplica(replicaID roachpb.ReplicaID) time.Time {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	return r.mu.lastUpdateTimes[replicaID]
-}
-
 func (r *Replica) DescLocked() *roachpb.RangeDescriptor {
 	return r.mu.state.Desc
 }
@@ -313,6 +307,12 @@ func (r *Replica) QuotaReleaseQueueLen() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.mu.quotaReleaseQueue)
+}
+
+func (r *Replica) IsFollowerActive(ctx context.Context, followerID roachpb.ReplicaID) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.isFollowerActiveLocked(ctx, followerID)
 }
 
 func (r *Replica) CommandSizesLen() int {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -86,9 +86,11 @@ const (
 	splitTxnName         = "split"
 	mergeTxnName         = "merge"
 
-	// MinQuotaReplicaLivenessDuration is the minimum duration that we could make sure
-	// the follower of this replica is active.
-	MinQuotaReplicaLivenessDuration   = 10 * time.Second
+	// MaxQuotaReplicaLivenessDuration is the maximum duration that a replica
+	// can remain inactive while still being counting against the range's
+	// available proposal quota.
+	MaxQuotaReplicaLivenessDuration = 10 * time.Second
+
 	defaultReplicaRaftMuWarnThreshold = 500 * time.Millisecond
 )
 
@@ -1076,11 +1078,8 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 
 	// Find the minimum index that active followers have acknowledged.
 	minIndex := status.Commit
-
-	now := timeutil.Unix(0, r.store.Clock().PhysicalNow())
 	for _, rep := range r.mu.state.Desc.Replicas {
-		// Only consider followers that that have "healthy" RPC connections and
-		// have made communication with leader in the last MinQuotaReplicaLivenessDuration.
+		// Only consider followers that that have "healthy" RPC connections.
 		if r.store.cfg.Transport.resolver != nil {
 			addr, err := r.store.cfg.Transport.resolver(rep.NodeID)
 			if err != nil {
@@ -1089,10 +1088,10 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 			if err := r.store.cfg.Transport.rpcContext.ConnHealth(addr.String()); err != nil {
 				continue
 			}
-			if lastUpdateTime, ok := r.mu.lastUpdateTimes[rep.ReplicaID]; !ok ||
-				now.Sub(lastUpdateTime) > MinQuotaReplicaLivenessDuration {
-				continue
-			}
+		}
+		// Only consider followers that are active.
+		if !r.isFollowerActiveLocked(ctx, rep.ReplicaID) {
+			continue
 		}
 		if progress, ok := status.Progress[uint64(rep.ReplicaID)]; ok {
 			// Only consider followers who are in advance of the quota base
@@ -1722,21 +1721,35 @@ func (r *Replica) setQueueLastProcessed(
 	return r.store.DB().PutInline(ctx, key, &timestamp)
 }
 
-func (r *Replica) setLastUpdateTimeForReplicaLocked(replicaID roachpb.ReplicaID) {
-	if r.mu.replicaID == r.mu.leaderID {
+func (r *Replica) refreshLastUpdateTimeForReplicaLocked(replicaID roachpb.ReplicaID) {
+	if r.mu.lastUpdateTimes != nil {
 		r.mu.lastUpdateTimes[replicaID] = r.store.Clock().PhysicalTime()
 	}
 }
 
-func (r *Replica) setLastUpdateTimesLocked() {
-	if r.mu.replicaID == r.mu.leaderID {
+func (r *Replica) refreshLastUpdateTimeForAllReplicasLocked() {
+	if r.mu.lastUpdateTimes != nil {
+		now := r.store.Clock().PhysicalTime()
 		for _, rep := range r.mu.state.Desc.Replicas {
-			if rep.ReplicaID == r.mu.replicaID {
-				continue
-			}
-			r.mu.lastUpdateTimes[rep.ReplicaID] = r.store.Clock().PhysicalTime()
+			r.mu.lastUpdateTimes[rep.ReplicaID] = now
 		}
 	}
+}
+
+// isFollowerActiveLocked returns whether the specified follower has made
+// communication with the leader in the last MaxQuotaReplicaLivenessDuration.
+func (r *Replica) isFollowerActiveLocked(ctx context.Context, followerID roachpb.ReplicaID) bool {
+	if r.mu.lastUpdateTimes == nil {
+		log.Fatalf(ctx, "replica %d has uninitialized lastUpdateTimes map", r.mu.replicaID)
+	}
+	lastUpdateTime, ok := r.mu.lastUpdateTimes[followerID]
+	if !ok {
+		// If the follower has no entry in lastUpdateTimes, it has not been
+		// updated since r became the leader.
+		return false
+	}
+	now := r.store.Clock().PhysicalTime()
+	return now.Sub(lastUpdateTime) <= MaxQuotaReplicaLivenessDuration
 }
 
 // RaftStatus returns the current raft status of the replica. It returns nil
@@ -3219,7 +3232,7 @@ func (r *Replica) unquiesceLocked() {
 			log.Infof(ctx, "unquiescing")
 		}
 		r.mu.quiescent = false
-		r.setLastUpdateTimesLocked()
+		r.refreshLastUpdateTimeForAllReplicasLocked()
 	}
 }
 
@@ -3246,7 +3259,7 @@ func (r *Replica) stepRaftGroup(req *RaftMessageRequest) error {
 		if req.Message.Type == raftpb.MsgApp {
 			r.setEstimatedCommitIndexLocked(req.Message.Commit)
 		}
-		r.setLastUpdateTimeForReplicaLocked(req.FromReplica.ReplicaID)
+		r.refreshLastUpdateTimeForReplicaLocked(req.FromReplica.ReplicaID)
 		return false, /* unquiesceAndWakeLeader */
 			raftGroup.Step(req.Message)
 	})


### PR DESCRIPTION
We don't want to throttle updates to the `NodeLiveness` range even
if a follower is falling behind because this could result in
cascading failures.

I suspected that this may have caused issues see previously with https://blog.stathat.com/2014/12/22/fix_ec2_network_issue_skb_rides_the_rocket.html,
although that claim remains unsubstantiated as I haven't been able to find any
reference to the NodeLiveness range being throttled. Still, this seems like a
good idea.