### PR TITLE
ui: fix the type of formattedDatum

### DIFF
--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -286,7 +286,7 @@ function ComputeTimeAxisDomain(
 }
 
 type formattedDatum = {
-  values: protos.cockroach.ts.tspb.TimeSeriesDatapoint$Properties,
+  values: protos.cockroach.ts.tspb.TimeSeriesDatapoint$Properties[],
   key: string,
   area: boolean,
   fillOpacity: number,


### PR DESCRIPTION
In the course of other refactorings, it was noticed that the type on
formattedDatum was wrong.  The values property is an array of values,
not a single value.

Release notes: none.