### PR TITLE
cluster: allow version bump without naming the version

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -750,6 +750,8 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
+<tr><td><code>crdb_internal.node_executable_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the version of CockroachDB this node is running.</p>
+</span></td></tr>
 <tr><td><code>crdb_internal.set_vmodule(vmodule_string: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used for internal debugging purposes. Incorrect use can severely impact performance.</p>
 </span></td></tr>
 <tr><td><code>current_database() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current database.</p>

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -259,6 +259,7 @@ func (ds *ServerImpl) setupFlow(
 		return ctx, nil, err
 	}
 	evalCtx := tree.EvalContext{
+		Settings:     ds.ServerConfig.Settings,
 		Location:     &location,
 		Database:     req.EvalContext.Database,
 		User:         req.EvalContext.User,

--- a/pkg/sql/logictest/testdata/logic_test/cluster_version
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_version
@@ -5,6 +5,11 @@ SHOW CLUSTER SETTING version
 ----
 1.0
 
+query T
+SELECT crdb_internal.node_executable_version()
+----
+1.1
+
 user testuser
 
 statement error only root is allowed to SET CLUSTER SETTING
@@ -51,7 +56,7 @@ statement error cannot upgrade directly from 1.0-500 to 1.2
 SET CLUSTER SETTING version = '1.2'
 
 statement ok
-SET CLUSTER SETTING version = '1.1'
+SET CLUSTER SETTING version = crdb_internal.node_executable_version()
 
 statement error cannot downgrade from 1.1 to 1.0-2
 SET CLUSTER SETTING version = '1.0-2'
@@ -60,3 +65,9 @@ query T
 SHOW CLUSTER SETTING version
 ----
 1.1
+
+statement ok
+SET CLUSTER SETTING version = '1.1'
+
+statement error cannot upgrade to 1.1-999: node running 1.1
+SET CLUSTER SETTING version = '1.1-999'

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -205,6 +205,11 @@ select crdb_internal.set_vmodule('')
 ----
 0
 
+query T
+select crdb_internal.node_executable_version()
+----
+1.1-6
+
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
 ----
@@ -242,3 +247,9 @@ select * from crdb_internal.node_runtime_info
 
 query error pq: only root is allowed to read crdb_internal.ranges
 select * from crdb_internal.ranges
+
+# Anyone can see the executable version.
+query T
+select crdb_internal.node_executable_version()
+----
+1.1-6

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2129,6 +2129,25 @@ CockroachDB supports the following flags:
 		},
 	},
 
+	"crdb_internal.node_executable_version": {
+		tree.Builtin{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.String),
+			Category:   categorySystemInfo,
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				v := "unknown"
+				// TODO(tschottdorf): we should always have a Settings, but there
+				// are many random places that create an ad-hoc EvalContext that
+				// they only partially populate.
+				if st := ctx.Settings; st != nil {
+					v = st.Version.ServerVersion.String()
+				}
+				return tree.NewDString(v), nil
+			},
+			Info: "Returns the version of CockroachDB this node is running.",
+		},
+	},
+
 	"crdb_internal.cluster_id": {
 		tree.Builtin{
 			Types:      tree.ArgTypes{},

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -1972,6 +1973,7 @@ func (*EvalContextTestingKnobs) ModuleTestingKnobs() {}
 // distsqlrun.EvalContext. Make sure to keep the two in sync.
 // TODO(andrei): remove or limit the duplication.
 type EvalContext struct {
+	Settings  *cluster.Settings
 	ClusterID uuid.UUID
 	NodeID    roachpb.NodeID
 	// The statement timestamp. May be different for every statement.

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -680,10 +681,15 @@ func (s *Session) newPlanner(e *Executor, txn *client.Txn) *planner {
 // evalCtx creates a tree.EvalContext from the Session's current configuration.
 func (s *Session) evalCtx() tree.EvalContext {
 	var evalContextTestingKnobs tree.EvalContextTestingKnobs
+	var st *cluster.Settings
 	if s.execCfg != nil {
 		evalContextTestingKnobs = s.execCfg.EvalContextTestingKnobs
+		// TODO(tschottdorf): it looks like this should always be provided.
+		// Perhaps `*Settings` should live somewhere else.
+		st = s.execCfg.Settings
 	}
 	return tree.EvalContext{
+		Settings:     st,
 		Location:     &s.Location,
 		Database:     s.Database,
 		User:         s.User,


### PR DESCRIPTION
This simplifies documentation and usage, especially when it comes to
alpha releases.

I'm accepting bikesheds on the name of the alias.

Fixes https://github.com/cockroachdb/docs/issues/2213.