### PR TITLE
tscache: re-use memory arena when cycling intervalSkl pages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -84,7 +84,7 @@
   branch = "master"
   name = "github.com/andy-kimball/arenaskl"
   packages = ["."]
-  revision = "1b13f9a73da39445e8106e6cdc1af59f06ea6c20"
+  revision = "ba9004a07e17a74381b3cf56ef32216464d26172"
 
 [[projects]]
   branch = "master"

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -390,7 +390,7 @@ func (s *intervalSkl) rotatePages(filledPage *sklPage) {
 	var oldArena *arenaskl.Arena
 	for s.pages.Len() >= s.minPages {
 		bp := back.Value.(*sklPage)
-		bpMaxTS := hlc.Timestamp{WallTime: atomic.LoadInt64(&bp.maxWallTime)}
+		bpMaxTS := hlc.Timestamp{WallTime: bp.maxWallTime}
 		if !bpMaxTS.Less(minTSToRetain) {
 			// The back page's maximum timestamp is within the time
 			// window we've promised to retain, so we can't evict it.
@@ -413,7 +413,7 @@ func (s *intervalSkl) rotatePages(filledPage *sklPage) {
 	// In other words, it assures that the maxWallTime for a page is not only
 	// the maximum timestamp for all values it contains, but also for all values
 	// any earlier pages contain.
-	s.pushNewPage(atomic.LoadInt64(&fp.maxWallTime), oldArena)
+	s.pushNewPage(fp.maxWallTime, oldArena)
 }
 
 // LookupTimestamp returns the latest timestamp value at which the given key was


### PR DESCRIPTION
The `intervalSkl` structure used by `sklImpl` uses 32 MB page sizes.
These are large enough to warrant special care to prevent from
re-allocating them continuously. This change re-uses arenas during
page rotation whenever possible (which is most of the time).