### PR TITLE
sql: add the rest of the sequence builtins

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -314,8 +314,6 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>gen_random_uuid() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Generates a random UUID and returns it as a value of UUID type.</p>
 </span></td></tr>
-<tr><td><code>nextval(sequence_name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Advances the given sequence and returns its new value.</p>
-</span></td></tr>
 <tr><td><code>unique_rowid() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a unique ID used by CockroachDB to generate unique row IDs if a Primary Key isn’t defined for the table. The value is a combination of the  insert timestamp and the ID of the node executing the statement, which  guarantees this combination is globally unique.</p>
 </span></td></tr>
 <tr><td><code>uuid_v4() &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns a UUID.</p>
@@ -504,6 +502,21 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <tr><td><code>trunc(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Truncates the decimal values of <code>val</code>.</p>
 </span></td></tr>
 <tr><td><code>trunc(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Truncates the decimal values of <code>val</code>.</p>
+</span></td></tr></tbody>
+</table>
+
+### Sequence Functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>currval(sequence_name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns the latest value obtained with nextval for this sequence in this session.</p>
+</span></td></tr>
+<tr><td><code>lastval() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return value most recently obtained with nextval in this session.</p>
+</span></td></tr>
+<tr><td><code>nextval(sequence_name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Advances the given sequence and returns its new value.</p>
+</span></td></tr>
+<tr><td><code>setval(sequence_name: <a href="string.html">string</a>, value: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Set the given sequence’s current value.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -2,6 +2,61 @@
 
 # see also files `drop_sequence`, `alter_sequence`, `rename_sequence`
 
+# USING THE `lastval` FUNCTION
+# (at the top because it requires a session in which `lastval` has never been called)
+
+statement ok
+SET DATABASE = test
+
+statement ok
+CREATE SEQUENCE lastval_test
+
+statement ok
+CREATE SEQUENCE lastval_test_2 START WITH 10
+
+statement error pgcode 55000 pq: lastval\(\): lastval is not yet defined in this session
+SELECT lastval()
+
+query I
+SELECT nextval('lastval_test')
+----
+1
+
+query I
+SELECT lastval()
+----
+1
+
+query I
+SELECT nextval('lastval_test_2')
+----
+10
+
+query I
+SELECT lastval()
+----
+10
+
+query I
+SELECT nextval('lastval_test')
+----
+2
+
+query I
+SELECT lastval()
+----
+2
+
+query I
+SELECT nextval('lastval_test_2')
+----
+11
+
+query I
+SELECT lastval()
+----
+11
+
 # SEQUENCE CREATION
 
 statement ok
@@ -50,10 +105,14 @@ TRUNCATE foo
 statement error pgcode 42809 "foo" is not a table
 DROP TABLE foo
 
-# USING THE nextval() FUNCTION
+# TODO(vilterp): match PG (returns a single row with the sequence settings and value)
+statement error pgcode 42809 pq: cannot SELECT from a sequence
+SELECT * FROM foo
 
-# `select * from foo` currently returns 0 columns & 0 rows;
-# testing against that is a Test-Script syntax error.
+# USING THE `nextval` AND `currval` FUNCTIONS
+
+statement error pgcode 55000 pq: currval\(\): currval of sequence "foo" is not yet defined in this session
+SELECT currval('foo')
 
 query I
 SELECT nextval('foo')
@@ -62,6 +121,11 @@ SELECT nextval('foo')
 
 query I
 SELECT nextval('foo')
+----
+2
+
+query I
+SELECT currval('foo')
 ----
 2
 
@@ -174,6 +238,60 @@ SELECT nextval('other_db.other_db_test')
 ----
 1
 
+# USING THE `setval` FUNCTION
+
+statement ok
+SET DATABASE = test
+
+statement ok
+CREATE SEQUENCE setval_test
+
+query I
+SELECT nextval('setval_test')
+----
+1
+
+query I
+SELECT nextval('setval_test')
+----
+2
+
+query I
+SELECT setval('setval_test', 10)
+----
+10
+
+# Setval doesn't affect currval or lastval; they return the last value obtained with nextval.
+query I
+SELECT currval('setval_test')
+----
+2
+
+query I
+SELECT lastval()
+----
+2
+
+query I
+SELECT nextval('setval_test')
+----
+11
+
+query I
+SELECT currval('setval_test')
+----
+11
+
+query I
+SELECT lastval()
+----
+11
+
+# nextval fails with nonexistent sequences.
+
+statement error pgcode 42P01 relation "nonexistent_seq" does not exist
+SELECT nextval('nonexistent_seq')
+
 # USE WITH TABLES
 
 # You can use a sequence in a DEFAULT expression to create an auto-incrementing primary key.
@@ -195,3 +313,28 @@ SELECT id FROM blog_posts ORDER BY id
 ----
 1
 2
+
+# USE WITH PARALLEL STATEMENTS
+
+# Both accesses to the sequence value in the KV layer and the sequenceState struct in
+# the Session are serialized, so after the last parallel statement you'll get the last value.
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO blog_posts (title) VALUES ('par_test_1') RETURNING NOTHING
+
+statement ok
+INSERT INTO blog_posts (title) VALUES ('par_test_2') RETURNING NOTHING
+
+statement ok
+INSERT INTO blog_posts (title) VALUES ('par_test_3') RETURNING NOTHING
+
+query I
+SELECT lastval()
+----
+5
+
+statement ok
+COMMIT

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
@@ -287,17 +286,6 @@ func (p *planner) QueryRow(
 	default:
 		return nil, &tree.MultipleResultsError{SQL: sql}
 	}
-}
-
-// IncrementSequence implements the parser.EvalPlanner interface.
-func (p *planner) IncrementSequence(ctx context.Context, seqName *tree.TableName) (int64, error) {
-	descriptor, err := getSequenceDesc(ctx, p.txn, p.getVirtualTabler(), seqName)
-	if err != nil {
-		return 0, err
-	}
-	seqValueKey := keys.MakeSequenceKey(uint32(descriptor.ID))
-	return client.IncrementValRetryable(
-		ctx, p.txn.DB(), seqValueKey, descriptor.SequenceOpts.Increment)
 }
 
 // queryRows executes a SQL query string where multiple result rows are returned.

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -1,0 +1,114 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"golang.org/x/net/context"
+)
+
+// IncrementSequence implements the tree.SequenceAccessor interface.
+func (p *planner) IncrementSequence(ctx context.Context, seqName *tree.TableName) (int64, error) {
+	descriptor, err := getSequenceDesc(ctx, p.txn, p.getVirtualTabler(), seqName)
+	if err != nil {
+		return 0, err
+	}
+	seqValueKey := keys.MakeSequenceKey(uint32(descriptor.ID))
+	val, err := client.IncrementValRetryable(
+		ctx, p.txn.DB(), seqValueKey, descriptor.SequenceOpts.Increment)
+	if err != nil {
+		return 0, err
+	}
+
+	p.session.mu.Lock()
+	defer p.session.mu.Unlock()
+	p.session.mu.SequenceState.lastSequenceIncremented = descriptor.ID
+	p.session.mu.SequenceState.latestValues[descriptor.ID] = val
+
+	return val, nil
+}
+
+// GetLastSequenceValue implements the tree.SequenceAccessor interface.
+func (p *planner) GetLastSequenceValue(ctx context.Context) (int64, error) {
+	p.session.mu.RLock()
+	defer p.session.mu.RUnlock()
+
+	seqState := p.session.mu.SequenceState
+
+	if !seqState.nextvalEverCalled() {
+		return 0, pgerror.NewError(
+			pgerror.CodeObjectNotInPrerequisiteStateError, "lastval is not yet defined in this session")
+	}
+
+	return seqState.latestValues[seqState.lastSequenceIncremented], nil
+}
+
+// GetLatestValueInSessionForSequence implements the tree.SequenceAccessor interface.
+func (p *planner) GetLatestValueInSessionForSequence(
+	ctx context.Context, seqName *tree.TableName,
+) (int64, error) {
+	descriptor, err := getSequenceDesc(ctx, p.txn, p.getVirtualTabler(), seqName)
+	if err != nil {
+		return 0, err
+	}
+
+	p.session.mu.RLock()
+	defer p.session.mu.RUnlock()
+
+	val, ok := p.session.mu.SequenceState.latestValues[descriptor.ID]
+	if !ok {
+		return 0, pgerror.NewErrorf(
+			pgerror.CodeObjectNotInPrerequisiteStateError,
+			`currval of sequence "%s" is not yet defined in this session`, seqName)
+	}
+
+	return val, nil
+}
+
+// SetSequenceValue implements the tree.SequenceAccessor interface.
+func (p *planner) SetSequenceValue(
+	ctx context.Context, seqName *tree.TableName, newVal int64,
+) error {
+	descriptor, err := getSequenceDesc(ctx, p.txn, p.getVirtualTabler(), seqName)
+	if err != nil {
+		return err
+	}
+	seqValueKey := keys.MakeSequenceKey(uint32(descriptor.ID))
+	return p.txn.Put(ctx, seqValueKey, newVal)
+}
+
+// sequenceState stores session-scoped state used by sequence builtins.
+type sequenceState struct {
+	// latestValues stores the last value obtained by nextval() in this session by descriptor id.
+	latestValues map[sqlbase.ID]int64
+
+	// lastSequenceIncremented records the descriptor id of the last sequence nextval() was
+	// called on in this session.
+	lastSequenceIncremented sqlbase.ID
+}
+
+func newSequenceState() sequenceState {
+	return sequenceState{
+		latestValues: make(map[sqlbase.ID]int64),
+	}
+}
+
+func (ss *sequenceState) nextvalEverCalled() bool {
+	return len(ss.latestValues) > 0
+}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -332,6 +332,10 @@ type Session struct {
 		// LastActiveQuery contains a reference to the AST of the last
 		// query that ran on this session.
 		LastActiveQuery tree.Statement
+
+		// sequenceState stores state related to calls to sequence
+		// builtins currval(), nextval(), and lastval().
+		SequenceState sequenceState
 	}
 
 	//
@@ -484,6 +488,7 @@ func NewSession(
 	s.PreparedPortals = makePreparedPortals(s)
 	s.Tracing.session = s
 	s.mu.ActiveQueries = make(map[uint128.Uint128]*queryMeta)
+	s.mu.SequenceState = newSequenceState()
 	s.ActiveSyncQueries = make([]uint128.Uint128, 0)
 
 	remoteStr := "<admin>"

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -918,3 +918,15 @@ func resolveTableNameFromID(
 	}
 	return tree.ErrString(&tn)
 }
+
+// ParseQualifiedTableName implements the tree.EvalPlanner interface.
+func (p *planner) ParseQualifiedTableName(
+	ctx context.Context, sql string,
+) (*tree.TableName, error) {
+	parsedNameWithIndex, err := p.ParseTableNameWithIndex(sql)
+	if err != nil {
+		return nil, err
+	}
+	parsedName := parsedNameWithIndex.Table
+	return p.QualifyWithDatabase(ctx, &parsedName)
+}


### PR DESCRIPTION
Namely:

- `currval(seq_name)`
- `setval(seq_name, val)`
- `lastval()`

(See PG docs: https://www.postgresql.org/docs/10/static/functions-sequence.html)

Skipping `setval(seq_name, val, is_called)` for now since it introduces additional state (a flag indicating whether the next call of `nextval` should increment the sequence or not) which would require more round trips to KV (in addition to the `Inc` operation) or introducing a new KV op.

Also, it may not be necessary since it's ["only for use in pg_dump" according to the PG source](https://github.com/postgres/postgres/blob/6a2fa09c0cba0e5a11854d733872ac18511f4c83/src/backend/commands/sequence.c#L888-L891). Since we don't do data-only backups (our backups create the schema and import the data), we should just be able to put `CREATE SEQUENCE <name> START WITH <val>` in our backup script. Will investigate this more when I do backup/restore support in a later PR.

Tracking issue: #19723