### PR TITLE
cli: add timeouts to `node status` and `node ls`

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -581,6 +581,13 @@ Takes any of the following values:
 </PRE>`,
 	}
 
+	Timeout = FlagInfo{
+		Name: "timeout",
+		Description: `
+		If nonzero, return with an error if the operation does not conclude within the specified timeout.
+		The timeout is specified with a suffix of 's' for seconds, 'm' for minutes, and 'h' for hours.`,
+	}
+
 	NodeRanges = FlagInfo{
 		Name:        "ranges",
 		Description: `Show node details for ranges and replicas.`,

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -131,7 +131,7 @@ func printKeyValue(kv engine.MVCCKeyValue) (bool, error) {
 
 func runDebugKeys(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop(stopperContext(stopper))
+	defer stopper.Stop(context.Background())
 
 	if len(args) != 1 {
 		return errors.New("one argument required: dir")
@@ -163,7 +163,7 @@ state like the raft HardState. With --replicated, only includes data covered by
 
 func runDebugRangeData(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop(stopperContext(stopper))
+	defer stopper.Stop(context.Background())
 
 	if len(args) != 2 {
 		return errors.New("two arguments required: dir range_id")
@@ -401,7 +401,7 @@ func loadRangeDescriptor(
 
 func runDebugRangeDescriptors(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop(stopperContext(stopper))
+	defer stopper.Stop(context.Background())
 
 	if len(args) != 1 {
 		return errors.New("one argument required: dir")
@@ -473,7 +473,7 @@ func printRaftLogEntry(kv engine.MVCCKeyValue) (bool, error) {
 
 func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop(stopperContext(stopper))
+	defer stopper.Stop(context.Background())
 
 	if len(args) != 2 {
 		return errors.New("two arguments required: dir range_id")
@@ -512,7 +512,7 @@ Uses a hard-coded GC policy with a 24 hour TTL for old versions.
 
 func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop(stopperContext(stopper))
+	defer stopper.Stop(context.Background())
 
 	var rangeID roachpb.RangeID
 	switch len(args) {
@@ -601,7 +601,7 @@ type replicaCheckInfo struct {
 
 func runDebugCheckStoreCmd(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop(stopperContext(stopper))
+	defer stopper.Stop(context.Background())
 
 	if len(args) != 1 {
 		return errors.New("one required argument: dir")
@@ -723,7 +723,7 @@ Compact the sstables in a store.
 
 func runDebugCompact(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop(stopperContext(stopper))
+	defer stopper.Stop(context.Background())
 
 	if len(args) != 1 {
 		return errors.New("one argument is required")
@@ -766,7 +766,7 @@ and TiB.
 
 func runDebugSSTables(cmd *cobra.Command, args []string) error {
 	stopper := stop.NewStopper()
-	defer stopper.Stop(stopperContext(stopper))
+	defer stopper.Stop(context.Background())
 
 	if len(args) != 1 {
 		return errors.New("one argument is required")

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -809,10 +809,11 @@ func runDebugGossipValues(cmd *cobra.Command, args []string) error {
 			return errors.Wrap(err, "failed to parse provided file as gossip.InfoStatus")
 		}
 	} else {
-		conn, _, err := getClientGRPCConn(ctx)
+		conn, _, finish, err := getClientGRPCConn(ctx)
 		if err != nil {
 			return err
 		}
+		defer finish()
 
 		status := serverpb.NewStatusClient(conn)
 		gossipInfo, err = status.Gossip(ctx, &serverpb.GossipRequest{})

--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -17,6 +17,9 @@ package cli
 import (
 	"net"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -34,27 +37,54 @@ func MaybeDecorateGRPCError(
 	return func(cmd *cobra.Command, args []string) error {
 		err := wrapped(cmd, args)
 
-		{
-			unwrappedErr := errors.Cause(err)
-			if unwrappedErr == nil {
-				return err
-			}
-			_, isSendError := unwrappedErr.(*roachpb.SendError)
-			isGRPCError := grpcutil.IsClosedConnection(unwrappedErr)
-			_, isNetError := unwrappedErr.(*net.OpError)
-			if !(isSendError || isGRPCError || isNetError) {
-				return err // intentionally return original to keep wrapping
-			}
+		if err == nil {
+			return nil
 		}
 
-		format := `unable to connect or connection lost.
+		connDropped := func() error {
+			const format = `unable to connect or connection lost.
 
 Please check the address and credentials such as certificates (if attempting to
 communicate with a secure cluster).
 
 %s`
+			return errors.Errorf(format, err)
+		}
+		opTimeout := func() error {
+			const format = `operation timed out.
 
-		return errors.Errorf(format, err)
+%s`
+			return errors.Errorf(format, err)
+		}
+
+		// Is this an "unable to connect" type of error?
+		unwrappedErr := errors.Cause(err)
+		switch unwrappedErr.(type) {
+		case *roachpb.SendError:
+			return connDropped()
+		case *net.OpError:
+			return connDropped()
+		}
+
+		// No, it's not. Is it a plain context cancellation (i.e. timeout)?
+		switch unwrappedErr {
+		case context.DeadlineExceeded:
+			return opTimeout()
+		case context.Canceled:
+			return opTimeout()
+		}
+
+		// Is it a GRPC-observed context cancellation (i.e. timeout) or a GRPC
+		// connection error?
+		switch {
+		case grpc.Code(err) == codes.DeadlineExceeded:
+			return opTimeout()
+		case grpcutil.IsClosedConnection(unwrappedErr):
+			return connDropped()
+		}
+
+		// Nothing we can special case, just return what we have.
+		return err
 	}
 }
 

--- a/pkg/cli/haproxy.go
+++ b/pkg/cli/haproxy.go
@@ -54,10 +54,11 @@ func runGenHAProxyCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	conn, _, err := getClientGRPCConn(ctx)
+	conn, _, finish, err := getClientGRPCConn(ctx)
 	if err != nil {
 		return err
 	}
+	defer finish()
 	c := serverpb.NewStatusClient(conn)
 
 	nodeStatuses, err := c.Nodes(ctx, &serverpb.NodesRequest{})

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -46,10 +46,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	conn, _, err := getClientGRPCConn(ctx)
+	conn, _, finish, err := getClientGRPCConn(ctx)
 	if err != nil {
 		return err
 	}
+	defer finish()
+
 	c := serverpb.NewInitClient(conn)
 
 	if _, err = c.Bootstrap(ctx, &serverpb.BootstrapRequest{}); err != nil {

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -129,7 +129,7 @@ func runStatusNode(cmd *cobra.Command, args []string) error {
 func runStatusNodeInner(
 	showDecommissioned bool, args []string,
 ) ([]status.NodeStatus, *serverpb.DecommissionStatusResponse, error) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := cmdTimeoutContext(context.Background())
 	defer cancel()
 
 	var nodeStatuses []status.NodeStatus

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -134,10 +134,12 @@ func runStatusNodeInner(
 
 	var nodeStatuses []status.NodeStatus
 
-	conn, _, err := getClientGRPCConn(ctx)
+	conn, _, finish, err := getClientGRPCConn(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+	defer finish()
+
 	c := serverpb.NewStatusClient(conn)
 
 	var decommissionStatusRequest *serverpb.DecommissionStatusRequest
@@ -180,10 +182,11 @@ func runStatusNodeInner(
 		return nil, nil, errors.Errorf("expected no arguments or a single node ID")
 	}
 
-	cAdmin, err := getAdminClient(ctx)
+	cAdmin, finish, err := getAdminClient(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+	defer finish()
 
 	decommissionStatusResp, err := cAdmin.DecommissionStatus(ctx, decommissionStatusRequest)
 	if err != nil {
@@ -320,10 +323,11 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	c, err := getAdminClient(ctx)
+	c, finish, err := getAdminClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer finish()
 
 	return runDecommissionNodeImpl(ctx, c, nodeCtx.nodeDecommissionWait, args)
 }
@@ -440,10 +444,11 @@ func runRecommissionNode(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	c, err := getAdminClient(ctx)
+	c, finish, err := getAdminClient(ctx)
 	if err != nil {
 		return err
 	}
+	defer finish()
 
 	req := &serverpb.DecommissionRequest{
 		NodeIDs:         nodeIDs,

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -966,12 +966,6 @@ func getAdminClient(ctx context.Context) (serverpb.AdminClient, error) {
 	return serverpb.NewAdminClient(conn), nil
 }
 
-func stopperContext(stopper *stop.Stopper) context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	stopper.AddCloser(stop.CloserFn(cancel))
-	return ctx
-}
-
 // quitCmd command shuts down the node server.
 var quitCmd = &cobra.Command{
 	Use:   "quit",

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -508,7 +508,12 @@ func runStart(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		return usageAndError(cmd)
 	}
+
 	tBegin := timeutil.Now()
+
+	// We don't care about GRPCs fairly verbose logs in most client commands,
+	// but when actually starting a server, we enable it.
+	grpcutil.EnableLogging()
 
 	if ok, err := maybeRerunBackground(); ok {
 		return err

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -512,8 +512,8 @@ func runStart(cmd *cobra.Command, args []string) error {
 	tBegin := timeutil.Now()
 
 	// We don't care about GRPCs fairly verbose logs in most client commands,
-	// but when actually starting a server, we enable it.
-	grpcutil.EnableLogging()
+	// but when actually starting a server, we enable them.
+	grpcutil.SetSeverity(log.Severity_WARNING)
 
 	if ok, err := maybeRerunBackground(); ok {
 		return err

--- a/pkg/cli/testutils.go
+++ b/pkg/cli/testutils.go
@@ -29,4 +29,5 @@ func TestingReset() {
 	sqlCtx.execStmts = nil
 	zoneCtx.zoneConfig = ""
 	zoneCtx.zoneDisableReplication = false
+	cmdTimeout = defaultCmdTimeout
 }

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"sort"
 
+	"golang.org/x/net/context"
+
 	"github.com/spf13/cobra"
 
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -107,12 +109,13 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 		return usageAndError(cmd)
 	}
 
-	conn, _, stopper, err := getClientGRPCConn()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	conn, _, err := getClientGRPCConn(ctx)
 	if err != nil {
 		return err
 	}
-	ctx := stopperContext(stopper)
-	defer stopper.Stop(ctx)
 
 	status := serverpb.NewStatusClient(conn)
 	admin := serverpb.NewAdminClient(conn)

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -112,10 +112,11 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	conn, _, err := getClientGRPCConn(ctx)
+	conn, _, finish, err := getClientGRPCConn(ctx)
 	if err != nil {
 		return err
 	}
+	defer finish()
 
 	status := serverpb.NewStatusClient(conn)
 	admin := serverpb.NewAdminClient(conn)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1092,6 +1092,10 @@ func TestLint(t *testing.T) {
 
 	// TestHelpURLs checks that all help texts have a valid documentation URL.
 	t.Run("TestHelpURLs", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("short flag")
+		}
+
 		t.Parallel()
 		var buf bytes.Buffer
 		for key, body := range sqlparser.HelpMessages {

--- a/pkg/util/grpcutil/log.go
+++ b/pkg/util/grpcutil/log.go
@@ -16,7 +16,7 @@
 package grpcutil
 
 import (
-	"io/ioutil"
+	"math"
 	"regexp"
 	"strings"
 	"time"
@@ -30,16 +30,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-var discardLogger = grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard)
-
 func init() {
-	grpclog.SetLoggerV2(discardLogger)
+	SetSeverity(log.Severity_ERROR)
 }
 
-// EnableLogging turns on relay of GRPC log messages to pkg/util/log.
-// It must be called before GRPC is used.
-func EnableLogging() {
-	grpclog.SetLoggerV2(&logger{})
+// SetSeverity sets the severity level below which GRPC log messages are
+// suppressed.
+//
+// Must be called before GRPC is used.
+func SetSeverity(s log.Severity) {
+	grpclog.SetLoggerV2((*logger)(&s))
 }
 
 // NB: This interface is implemented by a pointer because using a value causes
@@ -52,62 +52,102 @@ func EnableLogging() {
 // from the actual logging site.
 var _ grpclog.LoggerV2 = (*logger)(nil)
 
-type logger struct{}
+type logger log.Severity
 
-func (*logger) Info(args ...interface{}) {
+func (severity *logger) Info(args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_INFO {
+		return
+	}
 	log.InfofDepth(context.TODO(), 2, "", args...)
 }
 
-func (*logger) Infoln(args ...interface{}) {
+func (severity *logger) Infoln(args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_INFO {
+		return
+	}
 	log.InfofDepth(context.TODO(), 2, "", args...)
 }
 
-func (*logger) Infof(format string, args ...interface{}) {
+func (severity *logger) Infof(format string, args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_INFO {
+		return
+	}
 	log.InfofDepth(context.TODO(), 2, format, args...)
 }
 
-func (*logger) Warning(args ...interface{}) {
+func (severity *logger) Warning(args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_WARNING {
+		return
+	}
 	log.WarningfDepth(context.TODO(), 2, "", args...)
 }
 
-func (*logger) Warningln(args ...interface{}) {
+func (severity *logger) Warningln(args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_WARNING {
+		return
+	}
 	log.WarningfDepth(context.TODO(), 2, "", args...)
 }
 
-func (*logger) Warningf(format string, args ...interface{}) {
+func (severity *logger) Warningf(format string, args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_WARNING {
+		return
+	}
 	if shouldPrint(transportFailedRe, connectionRefusedRe, time.Minute, format, args...) {
 		log.WarningfDepth(context.TODO(), 2, format, args...)
 	}
 }
 
-func (*logger) Error(args ...interface{}) {
+func (severity *logger) Error(args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_ERROR {
+		return
+	}
 	log.ErrorfDepth(context.TODO(), 2, "", args...)
 }
 
-func (*logger) Errorln(args ...interface{}) {
+func (severity *logger) Errorln(args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_ERROR {
+		return
+	}
 	log.ErrorfDepth(context.TODO(), 2, "", args...)
 }
 
-func (*logger) Errorf(format string, args ...interface{}) {
+func (severity *logger) Errorf(format string, args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_ERROR {
+		return
+	}
 	log.ErrorfDepth(context.TODO(), 2, format, args...)
 }
 
-func (*logger) Fatal(args ...interface{}) {
+func (severity *logger) Fatal(args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_NONE {
+		return
+	}
 	log.FatalfDepth(context.TODO(), 2, "", args...)
 }
 
-func (*logger) Fatalln(args ...interface{}) {
+func (severity *logger) Fatalln(args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_NONE {
+		return
+	}
 	log.FatalfDepth(context.TODO(), 2, "", args...)
 }
 
-func (*logger) Fatalf(format string, args ...interface{}) {
+func (severity *logger) Fatalf(format string, args ...interface{}) {
+	if log.Severity(*severity) > log.Severity_NONE {
+		return
+	}
 	log.FatalfDepth(context.TODO(), 2, format, args...)
 }
 
-func (*logger) V(int) bool {
-	// Proxying this to log.VDepth doesn't work because the argument type
-	// to that function is unexported.
-	return true
+func (severity *logger) V(i int) bool {
+	if i < 0 {
+		i = 0
+	}
+	if i > math.MaxInt32 {
+		i = math.MaxInt32
+	}
+	return log.VDepth(int32(i) /* level */, 1 /* depth */)
 }
 
 // https://github.com/grpc/grpc-go/blob/v1.7.0/clientconn.go#L937

--- a/pkg/util/grpcutil/log.go
+++ b/pkg/util/grpcutil/log.go
@@ -16,6 +16,7 @@
 package grpcutil
 
 import (
+	"io/ioutil"
 	"regexp"
 	"strings"
 	"time"
@@ -29,7 +30,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
+var discardLogger = grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard)
+
 func init() {
+	grpclog.SetLoggerV2(discardLogger)
+}
+
+// EnableLogging turns on relay of GRPC log messages to pkg/util/log.
+// It must be called before GRPC is used.
+func EnableLogging() {
 	grpclog.SetLoggerV2(&logger{})
 }
 

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -1155,7 +1155,7 @@ func (l *loggingT) setV(pc uintptr) level {
 }
 
 func v(level level) bool {
-	return VDepth(level, 1)
+	return VDepth(int32(level), 1)
 }
 
 // InterceptorFn is the type of function accepted by Intercept().
@@ -1187,12 +1187,12 @@ func (l *loggingT) Intercept(ctx context.Context, f InterceptorFn) {
 
 // VDepth reports whether verbosity at the call site is at least the requested
 // level.
-func VDepth(level level, depth int) bool {
+func VDepth(l int32, depth int) bool {
 	// This function tries hard to be cheap unless there's work to do.
 	// The fast path is three atomic loads and compares.
 
 	// Here is a cheap but safe test to see if V logging is enabled globally.
-	if logging.verbosity.get() >= level {
+	if logging.verbosity.get() >= level(l) {
 		return true
 	}
 
@@ -1215,7 +1215,7 @@ func VDepth(level level, depth int) bool {
 		if !ok {
 			v = logging.setV(logging.pcs[0])
 		}
-		return v >= level
+		return v >= level(l)
 	}
 	return false
 }

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -176,7 +176,7 @@ func FatalfDepth(ctx context.Context, depth int, format string, args ...interfac
 //
 // TODO(andrei): Audit uses of V() and see which ones should actually use the
 // newer ExpensiveLogEnabled().
-func V(level level) bool {
+func V(level int32) bool {
 	return VDepth(level, 1)
 }
 
@@ -200,7 +200,7 @@ func V(level level) bool {
 //   log.VEventf(ctx, 2, msg)
 // }
 //
-func ExpensiveLogEnabled(ctx context.Context, level level) bool {
+func ExpensiveLogEnabled(ctx context.Context, level int32) bool {
 	if sp := opentracing.SpanFromContext(ctx); sp != nil {
 		if tracing.IsRecording(sp) {
 			return true

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -182,7 +182,7 @@ func ErrEventf(ctx context.Context, format string, args ...interface{}) {
 // VEvent either logs a message to the log files (which also outputs to the
 // active trace or event log) or to the trace/event log alone, depending on
 // whether the specified verbosity level is active.
-func VEvent(ctx context.Context, level level, msg string) {
+func VEvent(ctx context.Context, level int32, msg string) {
 	if VDepth(level, 1) {
 		// Log to INFO (which also logs an event).
 		logDepth(ctx, 1, Severity_INFO, "", []interface{}{msg})
@@ -194,7 +194,7 @@ func VEvent(ctx context.Context, level level, msg string) {
 // VEventf either logs a message to the log files (which also outputs to the
 // active trace or event log) or to the trace/event log alone, depending on
 // whether the specified verbosity level is active.
-func VEventf(ctx context.Context, level level, format string, args ...interface{}) {
+func VEventf(ctx context.Context, level int32, format string, args ...interface{}) {
 	if VDepth(level, 1) {
 		// Log to INFO (which also logs an event).
 		logDepth(ctx, 1, Severity_INFO, format, args)
@@ -205,7 +205,7 @@ func VEventf(ctx context.Context, level level, format string, args ...interface{
 
 // VEventfDepth performs the same as VEventf but checks the verbosity level
 // at the given depth in the call stack.
-func VEventfDepth(ctx context.Context, depth int, level level, format string, args ...interface{}) {
+func VEventfDepth(ctx context.Context, depth int, level int32, format string, args ...interface{}) {
 	if VDepth(level, 1+depth) {
 		// Log to INFO (which also logs an event).
 		logDepth(ctx, 1+depth, Severity_INFO, format, args)

--- a/pkg/util/log/trace_test.go
+++ b/pkg/util/log/trace_test.go
@@ -75,7 +75,7 @@ func TestTrace(t *testing.T) {
 	ctxWithSpan := opentracing.ContextWithSpan(ctx, sp)
 	Event(ctxWithSpan, "test1")
 	ErrEvent(ctxWithSpan, "testerr")
-	VEvent(ctxWithSpan, logging.verbosity.get()+1, "test2")
+	VEvent(ctxWithSpan, int32(logging.verbosity.get()+1), "test2")
 	Info(ctxWithSpan, "log")
 
 	// Events to parent context should still be no-ops.
@@ -106,7 +106,7 @@ func TestTraceWithTags(t *testing.T) {
 
 	Event(ctxWithSpan, "test1")
 	ErrEvent(ctxWithSpan, "testerr")
-	VEvent(ctxWithSpan, logging.verbosity.get()+1, "test2")
+	VEvent(ctxWithSpan, int32(logging.verbosity.get()+1), "test2")
 	Info(ctxWithSpan, "log")
 
 	sp.Finish()
@@ -151,7 +151,7 @@ func TestEventLog(t *testing.T) {
 
 	Eventf(ctxWithEventLog, "test%d", 1)
 	ErrEvent(ctxWithEventLog, "testerr")
-	VEventf(ctxWithEventLog, logging.verbosity.get()+1, "test%d", 2)
+	VEventf(ctxWithEventLog, int32(logging.verbosity.get()+1), "test%d", 2)
 	Info(ctxWithEventLog, "log")
 	Errorf(ctxWithEventLog, "errlog%d", 1)
 


### PR DESCRIPTION
GRPC in its recent versions has become quite noisy and in particular does
not play well with context cancellation.

Mute it in all client commands except when actually starting a server.

Refactor the cli package to avoid the previously common mixing of stoppers
and contexts. Nobody really needs the stopper usually (and if so, they
could make their own); it is simpler to just have a context and cancel it
when done.

Touches #16489 (by making it more straightforward to use timeouts).

Fixes #20308.