### PR TITLE
tscache: add intervalSkl metrics

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -830,7 +830,6 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 		cfg:      cfg,
 		db:       cfg.DB, // TODO(tschottdorf): remove redundancy.
 		engine:   eng,
-		tsCache:  tscache.New(cfg.Clock),
 		nodeDesc: nodeDesc,
 		metrics:  newStoreMetrics(cfg.HistogramWindowInterval),
 	}
@@ -856,6 +855,10 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.mu.replicasByKey = btree.New(64 /* degree */)
 	s.mu.uninitReplicas = map[roachpb.RangeID]*Replica{}
 	s.mu.Unlock()
+
+	tsCacheMetrics := tscache.MakeMetrics()
+	s.tsCache = tscache.New(cfg.Clock, tsCacheMetrics)
+	s.metrics.registry.AddMetricStruct(tsCacheMetrics)
 
 	s.snapshotApplySem = make(chan struct{}, cfg.concurrentSnapshotApplyLimit)
 

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -84,11 +84,11 @@ type Cache interface {
 }
 
 // New returns a new timestamp cache with the supplied hybrid clock.
-func New(clock *hlc.Clock) Cache {
+func New(clock *hlc.Clock, metrics Metrics) Cache {
 	if envutil.EnvOrDefaultBool("COCKROACH_USE_TREE_TSCACHE", false) {
 		return newTreeImpl(clock)
 	}
-	return newSklImpl(clock)
+	return newSklImpl(clock, metrics)
 }
 
 // cacheValue combines a timestamp with an optional txnID. It is shared between

--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -38,7 +38,7 @@ import (
 
 var cacheImplConstrs = []func(clock *hlc.Clock) Cache{
 	func(clock *hlc.Clock) Cache { return newTreeImpl(clock) },
-	func(clock *hlc.Clock) Cache { return newSklImpl(clock) },
+	func(clock *hlc.Clock) Cache { return newSklImpl(clock, MakeMetrics()) },
 }
 
 func forEachCacheImpl(
@@ -658,7 +658,7 @@ func identicalAndRatcheted(
 func BenchmarkTimestampCacheInsertion(b *testing.B) {
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
-	tc := New(clock)
+	tc := New(clock, MakeMetrics())
 
 	for i := 0; i < b.N; i++ {
 		cdTS := clock.Now()

--- a/pkg/storage/tscache/metrics.go
+++ b/pkg/storage/tscache/metrics.go
@@ -1,0 +1,71 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tscache
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+// Metrics holds all metrics relating to a Cache.
+type Metrics struct {
+	Skl sklImplMetrics
+}
+
+// sklImplMetrics holds all metrics relating to an sklImpl Cache implementation.
+type sklImplMetrics struct {
+	Read, Write sklMetrics
+}
+
+// sklMetrics holds all metrics relating to an intervalSkl.
+type sklMetrics struct {
+	Pages         *metric.Gauge
+	PageRotations *metric.Counter
+}
+
+// MetricStruct implements the metrics.Struct interface.
+func (sklImplMetrics) MetricStruct() {}
+func (sklMetrics) MetricStruct()     {}
+
+var _ metric.Struct = sklImplMetrics{}
+var _ metric.Struct = sklMetrics{}
+
+var (
+	metaSklReadPages = metric.Metadata{
+		Name: "tscache.skl.read.pages",
+		Help: "Number of pages in the read timestamp cache"}
+	metaSklReadRotations = metric.Metadata{
+		Name: "tscache.skl.read.rotations",
+		Help: "Number of page rotations in the read timestamp cache"}
+	metaSklWritePages = metric.Metadata{
+		Name: "tscache.skl.write.pages",
+		Help: "Number of pages in the write timestamp cache"}
+	metaSklWriteRotations = metric.Metadata{
+		Name: "tscache.skl.write.rotations",
+		Help: "Number of page rotations in the write timestamp cache"}
+)
+
+// MakeMetrics returns a Metrics struct.
+func MakeMetrics() Metrics {
+	return Metrics{
+		Skl: sklImplMetrics{
+			Read: sklMetrics{
+				Pages:         metric.NewGauge(metaSklReadPages),
+				PageRotations: metric.NewCounter(metaSklReadRotations),
+			},
+			Write: sklMetrics{
+				Pages:         metric.NewGauge(metaSklWritePages),
+				PageRotations: metric.NewCounter(metaSklWriteRotations),
+			},
+		},
+	}
+}


### PR DESCRIPTION
These metrics will help us track page count and page rotation rate so
that we can monitor that the tscache remains healthy.