### PR TITLE
sql/stats: Add histogram cache for system.table_statistics

### DIFF
--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -33,14 +33,15 @@ import (
 )
 
 // A TableStatistic object holds a statistic for a particular column or group
-// of columns. It mirrors the structure of the system.table_statistics table.
+// of columns. It mirrors the structure of the system.table_statistics table,
+// excluding the histogram.
 type TableStatistic struct {
 	// The ID of the table.
 	TableID sqlbase.ID
 
 	// The ID for this statistic.  It need not be globally unique,
 	// but must be unique for this table.
-	StatisticID uint32
+	StatisticID uint64
 
 	// Optional user-defined name for the statistic.
 	Name string
@@ -60,104 +61,185 @@ type TableStatistic struct {
 	// The number of rows that have a NULL in any of the columns in ColumnIDs.
 	NullCount uint64
 
-	// Optional, and can only be set if there is a single column in ColumnIDs.
-	// Defines a histogram of the distribution of values in the column.
-	Histogram *HistogramData
+	// Indicates whether or not there is a histogram for this statistic.
+	HasHistogram bool
 }
 
 func (s TableStatistic) String() string {
 	return awsutil.Prettify(s)
 }
 
-// A TableStatisticsCache is a cache of TableStatistic objects, keyed by
-// table ID.
+// HistogramCacheKey is used as the key type for entries in the TableStatisticsCache
+// which contain a histogram.
+type HistogramCacheKey struct {
+	TableID     sqlbase.ID
+	StatisticID uint64
+}
+
+// A TableStatisticsCache contains two underlying LRU caches:
+// (1) A cache of []*TableStatistic objects, keyed by table ID.
+//     Each entry consists of all the statistics for different columns and
+//     column groups for the given table.
+// (2) A cache of *HistogramData objects, keyed by
+//     HistogramCacheKey{table ID, statistic ID}.
 type TableStatisticsCache struct {
 	// NB: This can't be a RWMutex for lookup because UnorderedCache.Get
 	// manipulates an internal LRU list.
 	mu struct {
 		syncutil.Mutex
-		cache *cache.UnorderedCache
+		statsCache     *cache.UnorderedCache
+		histogramCache *cache.UnorderedCache
 	}
 	ClientDB    *client.DB
 	SQLExecutor sqlutil.InternalExecutor
 }
 
-// NewTableStatisticsCache creates a new TableStatisticsCache of the given size.
-// The underlying cache internally uses a hash map, so lookups are cheap.
+// NewTableStatisticsCache creates a new TableStatisticsCache, with the
+// size of the underlying statsCache set to statsCacheSize, and the size of
+// the underlying histogramCache set to histogramCacheSize.
+// Both underlying caches internally use a hash map, so lookups are cheap.
 func NewTableStatisticsCache(
-	size int, db *client.DB, sqlExecutor sqlutil.InternalExecutor,
+	statsCacheSize int, histogramCacheSize int, db *client.DB, sqlExecutor sqlutil.InternalExecutor,
 ) *TableStatisticsCache {
 	tableStatsCache := &TableStatisticsCache{
 		ClientDB:    db,
 		SQLExecutor: sqlExecutor,
 	}
-	tableStatsCache.mu.cache = cache.NewUnorderedCache(cache.Config{
+	tableStatsCache.mu.statsCache = cache.NewUnorderedCache(cache.Config{
 		Policy:      cache.CacheLRU,
-		ShouldEvict: func(s int, key, value interface{}) bool { return s > size },
+		ShouldEvict: func(s int, key, value interface{}) bool { return s > statsCacheSize },
+	})
+	tableStatsCache.mu.histogramCache = cache.NewUnorderedCache(cache.Config{
+		Policy:      cache.CacheLRU,
+		ShouldEvict: func(s int, key, value interface{}) bool { return s > histogramCacheSize },
 	})
 	return tableStatsCache
 }
 
-// LookupTableStats returns the cached statistics of the given table ID.
+// lookupTableStats returns the cached statistics of the given table ID.
 // The second return value is true if the stats were found in the
 // cache, and false otherwise.
-func (sc *TableStatisticsCache) LookupTableStats(
+func (sc *TableStatisticsCache) lookupTableStats(
 	ctx context.Context, tableID sqlbase.ID,
 ) ([]*TableStatistic, bool) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	if v, ok := sc.mu.cache.Get(tableID); ok {
+	if v, ok := sc.mu.statsCache.Get(tableID); ok {
 		if log.V(2) {
-			log.Infof(ctx, "r%d: lookup statistics for table: %s", tableID, v)
+			log.Infof(ctx, "lookup statistics for table %d: %s", tableID, v)
 		}
 		return v.([]*TableStatistic), true
 	}
 	if log.V(2) {
-		log.Infof(ctx, "r%d: lookup statistics for table: not found", tableID)
+		log.Infof(ctx, "lookup statistics for table %d: not found", tableID)
 	}
 	return nil, false
 }
 
-// Refresh updates the cached statistics for the given table ID
+// lookupHistogram returns the cached histogram of the given table ID and
+// statistic ID. The second return value is true if the histogram was found
+// in the cache, and false otherwise.
+func (sc *TableStatisticsCache) lookupHistogram(
+	ctx context.Context, tableID sqlbase.ID, statisticID uint64,
+) (*HistogramData, bool) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	if v, ok := sc.mu.histogramCache.Get(HistogramCacheKey{tableID, statisticID}); ok {
+		if log.V(2) {
+			log.Infof(ctx, "lookup histogram for table %d, statistic %d: %s", tableID, statisticID, v)
+		}
+		return v.(*HistogramData), true
+	}
+	if log.V(2) {
+		log.Infof(ctx, "lookup histogram for table %d, statistic %d: not found", tableID, statisticID)
+	}
+	return nil, false
+}
+
+// refreshTableStats updates the cached statistics for the given table ID
 // by issuing a query to system.table_statistics, and returns the statistics.
-func (sc *TableStatisticsCache) Refresh(
+func (sc *TableStatisticsCache) refreshTableStats(
 	ctx context.Context, tableID sqlbase.ID,
 ) ([]*TableStatistic, error) {
-	tableStatistics, err := sc.getTableStatistics(ctx, tableID)
+	tableStatistics, err := sc.getTableStatsFromDB(ctx, tableID)
 	if err != nil {
 		return nil, err
 	}
 
 	if log.V(2) {
-		log.Infof(ctx, "r%d: updating statistics for table: %s", tableID, tableStatistics)
+		log.Infof(ctx, "updating statistics for table %d: %s", tableID, tableStatistics)
 	}
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	sc.mu.cache.Add(tableID, tableStatistics)
+	sc.mu.statsCache.Add(tableID, tableStatistics)
 	return tableStatistics, nil
 }
 
-// GetTableStats is a convenience function to look up statistics for the
-// requested table ID in the cache using LookupTableStats, and if the stats
-// are not present in the cache, it looks them up in system.table_statistics
-// using Refresh.
-func (sc *TableStatisticsCache) GetTableStats(
-	ctx context.Context, tableID sqlbase.ID,
-) ([]*TableStatistic, error) {
-	if stats, ok := sc.LookupTableStats(ctx, tableID); ok {
-		return stats, nil
+// refreshHistogram updates the cached histogram for the given table ID and
+// statistic ID by issuing a query to system.table_statistics, and
+// returns the histogram.
+func (sc *TableStatisticsCache) refreshHistogram(
+	ctx context.Context, tableID sqlbase.ID, statisticID uint64,
+) (*HistogramData, error) {
+	histogram, err := sc.getHistogramFromDB(ctx, tableID, statisticID)
+	if err != nil {
+		return nil, err
 	}
-	return sc.Refresh(ctx, tableID)
-}
 
-// Invalidate invalidates the cached statistics for the given table ID.
-func (sc *TableStatisticsCache) Invalidate(ctx context.Context, tableID sqlbase.ID) {
 	if log.V(2) {
-		log.Infof(ctx, "r%d: evicting statistics for table", tableID)
+		log.Infof(ctx, "updating histogram for table %d, statistic %d: %s", tableID, statisticID, histogram)
 	}
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	sc.mu.cache.Del(tableID)
+	sc.mu.histogramCache.Add(HistogramCacheKey{tableID, statisticID}, histogram)
+	return histogram, nil
+}
+
+// GetTableStats looks up statistics for the requested table ID in the cache,
+// and if the stats are not present in the cache, it looks them up in
+// system.table_statistics.
+func (sc *TableStatisticsCache) GetTableStats(
+	ctx context.Context, tableID sqlbase.ID,
+) ([]*TableStatistic, error) {
+	if stats, ok := sc.lookupTableStats(ctx, tableID); ok {
+		return stats, nil
+	}
+	return sc.refreshTableStats(ctx, tableID)
+}
+
+// GetHistogram looks up the histogram for the requested table ID and
+// statistic ID in the cache, and if the histogram is not present in the
+// cache, it looks it up in system.table_statistics.
+func (sc *TableStatisticsCache) GetHistogram(
+	ctx context.Context, tableID sqlbase.ID, statisticID uint64,
+) (*HistogramData, error) {
+	if histogram, ok := sc.lookupHistogram(ctx, tableID, statisticID); ok {
+		return histogram, nil
+	}
+	return sc.refreshHistogram(ctx, tableID, statisticID)
+}
+
+// InvalidateTableStats invalidates the cached statistics for the given table ID.
+func (sc *TableStatisticsCache) InvalidateTableStats(ctx context.Context, tableID sqlbase.ID) {
+	if log.V(2) {
+		log.Infof(ctx, "evicting statistics for table %d", tableID)
+	}
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.mu.statsCache.Del(tableID)
+}
+
+// InvalidateHistogram invalidates the cached histogram for the given table ID
+// and statistic ID.
+func (sc *TableStatisticsCache) InvalidateHistogram(
+	ctx context.Context, tableID sqlbase.ID, statisticID uint64,
+) {
+	if log.V(2) {
+		log.Infof(ctx, "evicting histogram for table %d, statistic %d", tableID, statisticID)
+	}
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.mu.histogramCache.Del(HistogramCacheKey{tableID, statisticID})
 }
 
 const (
@@ -169,14 +251,12 @@ const (
 	rowCountIndex
 	distinctCountIndex
 	nullCountIndex
-	histogramIndex
+	hasHistogramIndex
 	statsLen
 )
 
-// parseStats converts the given datums to a TableStatistic object. It only includes
-// a histogram in the output if the histogram in datums is non-null and
-// includeHistogram is true.
-func parseStats(datums tree.Datums, includeHistogram bool) (*TableStatistic, error) {
+// parseStats converts the given datums to a TableStatistic object.
+func parseStats(datums tree.Datums) (*TableStatistic, error) {
 	if datums == nil || datums.Len() == 0 {
 		return nil, nil
 	}
@@ -201,7 +281,7 @@ func parseStats(datums tree.Datums, includeHistogram bool) (*TableStatistic, err
 		{"rowCount", rowCountIndex, types.Int, false},
 		{"distinctCount", distinctCountIndex, types.Int, false},
 		{"nullCount", nullCountIndex, types.Int, false},
-		{"histogram", histogramIndex, types.Bytes, true},
+		{"histogram", hasHistogramIndex, types.Bool, false},
 	}
 	for _, v := range expectedTypes {
 		if datums[v.fieldIndex].ResolvedType() != v.expectedType &&
@@ -214,11 +294,12 @@ func parseStats(datums tree.Datums, includeHistogram bool) (*TableStatistic, err
 	// Extract datum values.
 	tableStatistic := &TableStatistic{
 		TableID:       sqlbase.ID((int32)(*datums[tableIDIndex].(*tree.DInt))),
-		StatisticID:   (uint32)(*datums[statisticsIDIndex].(*tree.DInt)),
+		StatisticID:   (uint64)(*datums[statisticsIDIndex].(*tree.DInt)),
 		CreatedAt:     datums[createdAtIndex].(*tree.DTimestamp).Time,
 		RowCount:      (uint64)(*datums[rowCountIndex].(*tree.DInt)),
 		DistinctCount: (uint64)(*datums[distinctCountIndex].(*tree.DInt)),
 		NullCount:     (uint64)(*datums[nullCountIndex].(*tree.DInt)),
+		HasHistogram:  (bool)(*datums[hasHistogramIndex].(*tree.DBool)),
 	}
 	columnIDs := datums[columnIDsIndex].(*tree.DArray)
 	tableStatistic.ColumnIDs = make([]sqlbase.ColumnID, len(columnIDs.Array))
@@ -228,23 +309,47 @@ func parseStats(datums tree.Datums, includeHistogram bool) (*TableStatistic, err
 	if datums[nameIndex].ResolvedType() == types.String {
 		tableStatistic.Name = string(*datums[nameIndex].(*tree.DString))
 	}
-	if includeHistogram && datums[histogramIndex].ResolvedType() == types.Bytes {
-		tableStatistic.Histogram = &HistogramData{}
-		if err := protoutil.Unmarshal([]byte(*datums[histogramIndex].(*tree.DBytes)), tableStatistic.Histogram); err != nil {
-			return nil, err
-		}
-	}
 
 	return tableStatistic, nil
 }
 
-// getTableStatistics retrieves the statistics in system.table_statistics
+// parseHistogram converts the given datums to a HistogramData object.
+func parseHistogram(datums tree.Datums) (*HistogramData, error) {
+	if datums == nil || datums.Len() == 0 {
+		return nil, nil
+	}
+
+	// Validate the input length.
+	if datums.Len() != 1 {
+		return nil, errors.Errorf("%d values returned from table statistics lookup. Expected %d", datums.Len(), 1)
+	}
+	datum := datums[0]
+
+	// Validate the input type.
+	if datum.ResolvedType() != types.Bytes && datum.ResolvedType() != types.Null {
+		return nil, errors.Errorf("histogram returned from table statistics lookup has type %s. Expected %s",
+			datum.ResolvedType(), types.Bytes)
+	}
+
+	// Extract datum value.
+	if datum.ResolvedType() == types.Bytes {
+		histogram := &HistogramData{}
+		if err := protoutil.Unmarshal([]byte(*datum.(*tree.DBytes)), histogram); err != nil {
+			return nil, err
+		}
+		return histogram, nil
+	}
+
+	return nil, nil
+}
+
+// getTableStatsFromDB retrieves the statistics in system.table_statistics
 // for the given table ID.
-func (sc *TableStatisticsCache) getTableStatistics(
+func (sc *TableStatisticsCache) getTableStatsFromDB(
 	ctx context.Context, tableID sqlbase.ID,
 ) ([]*TableStatistic, error) {
 	const getTableStatisticsStmt = `
-SELECT "tableID", "statisticID", name, "columnIDs", "createdAt", "rowCount", "distinctCount", "nullCount", histogram
+SELECT "tableID", "statisticID", name, "columnIDs", "createdAt", "rowCount", "distinctCount", "nullCount", histogram IS NOT NULL
 FROM system.table_statistics
 WHERE "tableID" = $1
 `
@@ -259,7 +364,7 @@ WHERE "tableID" = $1
 
 	var statsList []*TableStatistic
 	for _, row := range rows {
-		stats, err := parseStats(row, true /* includeHistogram */)
+		stats, err := parseStats(row)
 		if err != nil {
 			return nil, err
 		}
@@ -267,4 +372,36 @@ WHERE "tableID" = $1
 	}
 
 	return statsList, nil
+}
+
+// getHistogramFromDB retrieves the histogram in system.table_statistics
+// for the given table ID and statistic ID. Returns an error if the histogram
+// does not exist.
+func (sc *TableStatisticsCache) getHistogramFromDB(
+	ctx context.Context, tableID sqlbase.ID, statisticID uint64,
+) (*HistogramData, error) {
+	const getHistogramStmt = `
+SELECT histogram
+FROM system.table_statistics
+WHERE "tableID" = $1 AND "statisticID" = $2
+`
+	var row tree.Datums
+	if err := sc.ClientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		var err error
+		row, err = sc.SQLExecutor.QueryRowInTransaction(ctx, "get-histogram", txn, getHistogramStmt, tableID, statisticID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	histogram, err := parseHistogram(row)
+	if err != nil {
+		return nil, err
+	}
+
+	if histogram == nil {
+		return nil, errors.Errorf("histogram not found for table %d, statistic %d", tableID, statisticID)
+	}
+
+	return histogram, nil
 }

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package stats_test
+package stats
 
 import (
 	"testing"
@@ -27,12 +27,10 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
-	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -41,40 +39,41 @@ import (
 	"github.com/pkg/errors"
 )
 
-func insertTableStats(
+func insertTableStat(
 	ctx context.Context,
 	db *client.DB,
-	sqlExecutor sqlutil.InternalExecutor,
-	stats *stats.TableStatistic,
+	ex sqlutil.InternalExecutor,
+	stat *TableStatistic,
+	histogram *HistogramData,
 ) error {
-	insertStatsStmt := `
+	insertStatStmt := `
 INSERT INTO system.table_statistics ("tableID", "statisticID", name, "columnIDs", "createdAt",
 	"rowCount", "distinctCount", "nullCount", histogram)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 `
 	columnIDs := tree.NewDArray(types.Int)
-	for _, id := range stats.ColumnIDs {
+	for _, id := range stat.ColumnIDs {
 		if err := columnIDs.Append(tree.NewDInt(tree.DInt(int(id)))); err != nil {
 			return err
 		}
 	}
 
 	args := []interface{}{
-		stats.TableID,
-		stats.StatisticID,
+		stat.TableID,
+		stat.StatisticID,
 		nil, // name
 		columnIDs,
-		stats.CreatedAt,
-		stats.RowCount,
-		stats.DistinctCount,
-		stats.NullCount,
+		stat.CreatedAt,
+		stat.RowCount,
+		stat.DistinctCount,
+		stat.NullCount,
 		nil, // histogram
 	}
-	if len(stats.Name) != 0 {
-		args[2] = stats.Name
+	if len(stat.Name) != 0 {
+		args[2] = stat.Name
 	}
-	if stats.Histogram != nil {
-		histogramBytes, err := protoutil.Marshal(stats.Histogram)
+	if histogram != nil {
+		histogramBytes, err := protoutil.Marshal(histogram)
 		if err != nil {
 			return err
 		}
@@ -84,7 +83,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	var rows int
 	if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		var err error
-		rows, err = sqlExecutor.ExecuteStatementInTransaction(ctx, "insert-table-stats", txn, insertStatsStmt, args...)
+		rows, err = ex.ExecuteStatementInTransaction(ctx, "insert-table-stats", txn, insertStatStmt, args...)
 		return err
 	}); err != nil {
 		return err
@@ -97,14 +96,10 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 }
 
 func checkStatsForTable(
-	ctx context.Context,
-	db *client.DB,
-	sc *stats.TableStatisticsCache,
-	expected []*stats.TableStatistic,
-	tableID sqlbase.ID,
+	ctx context.Context, sc *TableStatisticsCache, expected []*TableStatistic, tableID sqlbase.ID,
 ) error {
 	// Initially the stats won't be in the cache.
-	if statsList, ok := sc.LookupTableStats(ctx, tableID); ok {
+	if statsList, ok := sc.lookupTableStats(ctx, tableID); ok {
 		return errors.Errorf("lookup of missing key %d returned: %s", tableID, statsList)
 	}
 
@@ -113,18 +108,148 @@ func checkStatsForTable(
 	statsList, err := sc.GetTableStats(ctx, tableID)
 	if err != nil {
 		return errors.Errorf(err.Error())
-	} else {
-		testutils.SortStructs(statsList, "TableID", "StatisticID")
-		if !reflect.DeepEqual(statsList, expected) {
-			return errors.Errorf("for lookup of key %d, expected stats %s, got %s", tableID, expected, statsList)
-		}
+	}
+	testutils.SortStructs(statsList, "TableID", "StatisticID")
+	if !reflect.DeepEqual(statsList, expected) {
+		return errors.Errorf("for lookup of key %d, expected stats %s, got %s", tableID, expected, statsList)
 	}
 
 	// Now the stats should be in the cache.
-	if _, ok := sc.LookupTableStats(ctx, tableID); !ok {
+	if _, ok := sc.lookupTableStats(ctx, tableID); !ok {
 		return errors.Errorf("for lookup of key %d, expected stats %s", tableID, expected)
 	}
 	return nil
+}
+
+func checkHistForTable(
+	ctx context.Context,
+	sc *TableStatisticsCache,
+	expected *HistogramData,
+	tableID sqlbase.ID,
+	statisticID uint64,
+) error {
+	// Initially the histogram won't be in the cache.
+	if histogram, ok := sc.lookupHistogram(ctx, tableID, statisticID); ok {
+		return errors.Errorf("lookup of missing key {table %d, statistic %d} returned: %s",
+			tableID, statisticID, histogram)
+	}
+
+	// Perform the lookup and refresh, and confirm the
+	// returned histogram matches the expected value.
+	histogram, err := sc.GetHistogram(ctx, tableID, statisticID)
+	if expected == nil {
+		// GetHistogram should return an error if the requested histogram doesn't exist.
+		if err == nil {
+			return errors.Errorf("expected an error for lookup of nonexistent histogram with key {table %d, statistic %d}",
+				tableID, statisticID)
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(histogram, expected) {
+		return errors.Errorf("for lookup of table %d and statistic %d, expected stat %s, got %s",
+			tableID, statisticID, expected, histogram)
+	}
+
+	// Now the histogram should be in the cache.
+	if _, ok := sc.lookupHistogram(ctx, tableID, statisticID); !ok {
+		return errors.Errorf("for lookup of table %d and statistic %d, expected stats %s",
+			tableID, statisticID, expected)
+	}
+	return nil
+}
+
+func initTestData(
+	ctx context.Context, db *client.DB, ex sqlutil.InternalExecutor,
+) (map[sqlbase.ID][]*TableStatistic, map[HistogramCacheKey]*HistogramData, error) {
+	// The expected stats must be ordered by TableID, StatisticID so they can
+	// later be compared with the returned stats using reflect.DeepEqual.
+	expStatsList := []struct {
+		Stat      TableStatistic
+		Histogram *HistogramData
+	}{
+		{
+			Stat: TableStatistic{
+				TableID:       sqlbase.ID(0),
+				StatisticID:   0,
+				Name:          "table0",
+				ColumnIDs:     []sqlbase.ColumnID{1},
+				CreatedAt:     time.Date(2010, 11, 20, 11, 35, 23, 0, time.UTC),
+				RowCount:      32,
+				DistinctCount: 30,
+				NullCount:     0,
+				HasHistogram:  true,
+			},
+			Histogram: &HistogramData{Buckets: []HistogramData_Bucket{
+				{NumEq: 3, NumRange: 30, UpperBound: encoding.EncodeVarintAscending(nil, 3000)}},
+			},
+		},
+		{
+			Stat: TableStatistic{
+				TableID:       sqlbase.ID(0),
+				StatisticID:   1,
+				ColumnIDs:     []sqlbase.ColumnID{2, 3},
+				CreatedAt:     time.Date(2010, 11, 20, 11, 35, 23, 0, time.UTC),
+				RowCount:      32,
+				DistinctCount: 5,
+				NullCount:     5,
+			},
+		},
+		{
+			Stat: TableStatistic{
+				TableID:       sqlbase.ID(1),
+				StatisticID:   0,
+				ColumnIDs:     []sqlbase.ColumnID{0},
+				CreatedAt:     time.Date(2017, 11, 20, 11, 35, 23, 0, time.UTC),
+				RowCount:      320000,
+				DistinctCount: 300000,
+				NullCount:     100,
+			},
+		},
+		{
+			Stat: TableStatistic{
+				TableID:       sqlbase.ID(2),
+				StatisticID:   34,
+				Name:          "table2",
+				ColumnIDs:     []sqlbase.ColumnID{1, 2, 3},
+				CreatedAt:     time.Date(2001, 1, 10, 5, 25, 14, 0, time.UTC),
+				RowCount:      0,
+				DistinctCount: 0,
+				NullCount:     0,
+			},
+		},
+	}
+
+	// Insert the stats into system.table_statistics
+	// and store them in maps for fast retrieval.
+	expectedStats := make(map[sqlbase.ID][]*TableStatistic)
+	expectedHist := make(map[HistogramCacheKey]*HistogramData)
+	for i := range expStatsList {
+		stat := &expStatsList[i].Stat
+		histogram := expStatsList[i].Histogram
+
+		if err := insertTableStat(ctx, db, ex, stat, histogram); err != nil {
+			return nil, nil, err
+		}
+
+		expectedStats[stat.TableID] = append(expectedStats[stat.TableID], stat)
+		if stat.HasHistogram != (histogram != nil) {
+			return nil, nil, errors.Errorf("HasHistogram must be true iff there is a histogram. Data: %s",
+				expStatsList[i])
+		}
+		if histogram != nil {
+			histCacheKey := HistogramCacheKey{TableID: stat.TableID, StatisticID: stat.StatisticID}
+			expectedHist[histCacheKey] = histogram
+		}
+	}
+
+	// Add another TableID for which we don't have stats.
+	expectedStats[sqlbase.ID(3)] = nil
+	expectedHist[HistogramCacheKey{TableID: sqlbase.ID(3), StatisticID: 0}] = nil
+
+	return expectedStats, expectedHist, nil
 }
 
 func TestTableStatisticsCache(t *testing.T) {
@@ -133,84 +258,28 @@ func TestTableStatisticsCache(t *testing.T) {
 	ctx := context.Background()
 	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
-	ex := sql.InternalExecutor{LeaseManager: s.LeaseManager().(*sql.LeaseManager)}
+	ex := s.InternalExecutor().(sqlutil.InternalExecutor)
 
-	expStatsList := []stats.TableStatistic{
-		{
-			TableID:       sqlbase.ID(0),
-			StatisticID:   0,
-			Name:          "table0",
-			ColumnIDs:     []sqlbase.ColumnID{1, 2},
-			CreatedAt:     time.Date(2010, 11, 20, 11, 35, 23, 0, time.UTC),
-			RowCount:      32,
-			DistinctCount: 30,
-			NullCount:     0,
-			Histogram: &stats.HistogramData{Buckets: []stats.HistogramData_Bucket{
-				{NumEq: 3, NumRange: 30, UpperBound: encoding.EncodeVarintAscending(nil, 3000)}},
-			},
-		},
-		{
-			TableID:       sqlbase.ID(0),
-			StatisticID:   1,
-			ColumnIDs:     []sqlbase.ColumnID{3},
-			CreatedAt:     time.Date(2010, 11, 20, 11, 35, 23, 0, time.UTC),
-			RowCount:      32,
-			DistinctCount: 5,
-			NullCount:     5,
-		},
-		{
-			TableID:       sqlbase.ID(1),
-			StatisticID:   0,
-			ColumnIDs:     []sqlbase.ColumnID{0},
-			CreatedAt:     time.Date(2017, 11, 20, 11, 35, 23, 0, time.UTC),
-			RowCount:      320000,
-			DistinctCount: 300000,
-			NullCount:     100,
-		},
-		{
-			TableID:       sqlbase.ID(2),
-			StatisticID:   34,
-			Name:          "table2",
-			ColumnIDs:     []sqlbase.ColumnID{1, 2, 3},
-			CreatedAt:     time.Date(2001, 1, 10, 5, 25, 14, 0, time.UTC),
-			RowCount:      0,
-			DistinctCount: 0,
-			NullCount:     0,
-		},
+	expectedStats, expectedHist, err := initTestData(ctx, db, ex)
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	// Sort the expected stats so they can later be compared with the returned
-	// stats using reflect.DeepEqual.
-	testutils.SortStructs(expStatsList, "TableID", "StatisticID")
-
-	// Insert the stats into system.table_statistics
-	// and store them in a map keyed by table ID for fast retrieval.
-	expected := make(map[sqlbase.ID][]*stats.TableStatistic)
-	for i := range expStatsList {
-		stats := &expStatsList[i]
-		if err := insertTableStats(ctx, db, ex, stats); err != nil {
-			t.Fatal(err)
-		}
-		expected[stats.TableID] = append(expected[stats.TableID], stats)
-	}
-	// Add another TableID for which we don't have stats.
-	expected[sqlbase.ID(3)] = nil
 
 	// Collect the tableIDs and sort them so we can iterate over them in a
 	// consistent order (Go randomizes the order of iteration over maps).
 	var tableIDs sqlbase.IDs
-	for tableID := range expected {
+	for tableID := range expectedStats {
 		tableIDs = append(tableIDs, tableID)
 	}
 	sort.Sort(tableIDs)
 
 	// Create a cache and iteratively query the cache for each tableID. This
-	// will result in the cache getting populated. When the cache size is
+	// will result in the cache getting populated. When the stats cache size is
 	// exceeded, entries should be evicted according to the LRU policy.
-	cacheSize := 2
-	sc := stats.NewTableStatisticsCache(cacheSize, db, ex)
+	statsCacheSize, histogramCacheSize := 2, 2
+	sc := NewTableStatisticsCache(statsCacheSize, histogramCacheSize, db, ex)
 	for _, tableID := range tableIDs {
-		if err := checkStatsForTable(ctx, db, sc, expected[tableID], tableID); err != nil {
+		if err := checkStatsForTable(ctx, sc, expectedStats[tableID], tableID); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -218,7 +287,7 @@ func TestTableStatisticsCache(t *testing.T) {
 	// Table IDs 0 and 1 should have been evicted since the cache size is 2.
 	tableIDs = []sqlbase.ID{sqlbase.ID(0), sqlbase.ID(1)}
 	for _, tableID := range tableIDs {
-		if statsList, ok := sc.LookupTableStats(ctx, tableID); ok {
+		if statsList, ok := sc.lookupTableStats(ctx, tableID); ok {
 			t.Fatalf("lookup of evicted key %d returned: %s", tableID, statsList)
 		}
 	}
@@ -226,15 +295,36 @@ func TestTableStatisticsCache(t *testing.T) {
 	// Table IDs 2 and 3 should still be in the cache.
 	tableIDs = []sqlbase.ID{sqlbase.ID(2), sqlbase.ID(3)}
 	for _, tableID := range tableIDs {
-		if _, ok := sc.LookupTableStats(ctx, tableID); !ok {
-			t.Fatalf("for lookup of key %d, expected stats %s", tableID, expected[tableID])
+		if _, ok := sc.lookupTableStats(ctx, tableID); !ok {
+			t.Fatalf("for lookup of key %d, expected stats %s", tableID, expectedStats[tableID])
 		}
 	}
 
 	// After invalidation Table ID 2 should be gone.
 	tableID := sqlbase.ID(2)
-	sc.Invalidate(ctx, tableID)
-	if statsList, ok := sc.LookupTableStats(ctx, tableID); ok {
+	sc.InvalidateTableStats(ctx, tableID)
+	if statsList, ok := sc.lookupTableStats(ctx, tableID); ok {
 		t.Fatalf("lookup of invalidated key %d returned: %s", tableID, statsList)
+	}
+
+	// Now test the histogram cache.
+	for key, hist := range expectedHist {
+		if err := checkHistForTable(ctx, sc, hist, key.TableID, key.StatisticID); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Key {0, 0} should still be in the cache.
+	key := HistogramCacheKey{TableID: 0, StatisticID: 0}
+	if _, ok := sc.lookupHistogram(ctx, key.TableID, key.StatisticID); !ok {
+		t.Fatalf("for lookup of table %d and statistic %d, expected histogram %s",
+			key.TableID, key.StatisticID, expectedHist[key])
+	}
+
+	// After invalidation key {0, 0} should be gone.
+	sc.InvalidateHistogram(ctx, key.TableID, key.StatisticID)
+	if histogram, ok := sc.lookupHistogram(ctx, key.TableID, key.StatisticID); ok {
+		t.Fatalf("lookup of invalidated key {table %d, statistic %d} returned: %s",
+			key.TableID, key.StatisticID, histogram)
 	}
 }


### PR DESCRIPTION
Update the stats cache so that now there are two types of entries.
One type is keyed by table ID, and each entry includes all the
statistics for the given table, excluding the histograms. The other
type is keyed by (table ID, statistic ID), and each entry consists
of a single table statistic, including the histogram.

There are now corresponding new functions to look up a histogram
in the cache, refresh it from system.table_statistics, etc.

Release note: none