### PR TITLE
ui: use classnames everywhere

### DIFF
--- a/pkg/ui/src/views/cluster/components/visualization/index.tsx
+++ b/pkg/ui/src/views/cluster/components/visualization/index.tsx
@@ -31,10 +31,14 @@ interface VisualizationProps {
 export default class extends React.Component<VisualizationProps, {}> {
   render() {
     const { title, tooltip, stale } = this.props;
-    const vizClasses = classNames({
-      "visualization": true,
-      "visualization--faded": stale || false,
-    });
+    const vizClasses = classNames(
+      "visualization",
+      { "visualization--faded": stale || false },
+    );
+    const contentClasses = classNames(
+      "visualization__content",
+      { "visualization--loading": this.props.loading },
+    );
 
     let tooltipNode: React.ReactNode = "";
     if (tooltip) {
@@ -64,7 +68,7 @@ export default class extends React.Component<VisualizationProps, {}> {
             tooltipNode
           }
         </div>
-        <div className={"visualization__content" + (this.props.loading ? " visualization--loading" : "")}>
+        <div className={contentClasses}>
           {this.props.loading ? <img className="visualization__spinner" src={spinner} /> :  this.props.children }
         </div>
       </div>

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import d3 from "d3";
 import React from "react";
 import { connect } from "react-redux";
@@ -68,13 +69,25 @@ interface NodeLivenessProps {
 
 function renderNodeLiveness(props: NodeLivenessProps) {
   const { liveNodes, suspectNodes, deadNodes } = props;
+  const suspectClasses = classNames(
+    "node-liveness",
+    "cluster-summary__metric",
+    "suspect-nodes",
+    { "warning": suspectNodes > 0 },
+  );
+  const deadClasses = classNames(
+    "node-liveness",
+    "cluster-summary__metric",
+    "dead-nodes",
+    { "alert": deadNodes > 0 },
+  );
   return [
     <h3 className="node-liveness cluster-summary__title">Node Liveness</h3>,
     <div className="node-liveness cluster-summary__metric live-nodes">{ liveNodes }</div>,
     <div className="node-liveness cluster-summary__label live-nodes">Live<br />Nodes</div>,
-    <div className={ "node-liveness cluster-summary__metric suspect-nodes" + (suspectNodes ? " warning" : "") }>{ suspectNodes }</div>,
+    <div className={suspectClasses}>{ suspectNodes }</div>,
     <div className="node-liveness cluster-summary__label suspect-nodes">Suspect<br />Nodes</div>,
-    <div className={ "node-liveness cluster-summary__metric dead-nodes" + (deadNodes ? " alert" : "") }>{ deadNodes }</div>,
+    <div className={deadClasses}>{ deadNodes }</div>,
     <div className="node-liveness cluster-summary__label dead-nodes">Dead<br />Nodes</div>,
   ];
 }
@@ -99,13 +112,25 @@ interface ReplicationStatusProps {
 
 function renderReplicationStatus(props: ReplicationStatusProps) {
   const { totalRanges, underReplicatedRanges, unavailableRanges } = props;
+  const underReplicatedClasses = classNames(
+    "replication-status",
+    "cluster-summary__metric",
+    "under-replicated-ranges",
+    { "warning": underReplicatedRanges > 0 },
+  );
+  const unavailableClasses = classNames(
+    "replication-status",
+    "cluster-summary__metric",
+    "unavailable-ranges",
+    { "alert": unavailableRanges > 0 },
+  );
   return [
     <h3 className="replication-status cluster-summary__title">Replication Status</h3>,
     <div className="replication-status cluster-summary__metric total-ranges">{ totalRanges }</div>,
     <div className="replication-status cluster-summary__label total-ranges">Total<br />Ranges</div>,
-    <div className={ "replication-status cluster-summary__metric under-replicated-ranges" + (underReplicatedRanges ? " warning" : "") }>{ underReplicatedRanges }</div>,
+    <div className={underReplicatedClasses}>{ underReplicatedRanges }</div>,
     <div className="replication-status cluster-summary__label under-replicated-ranges">Under-replicated<br />Ranges</div>,
-    <div className={ "replication-status cluster-summary__metric unavailable-ranges" + (unavailableRanges ? " alert" : "") }>{ unavailableRanges }</div>,
+    <div className={unavailableClasses}>{ unavailableRanges }</div>,
     <div className="replication-status cluster-summary__label unavailable-ranges">Unavailable<br />Ranges</div>,
   ];
 }

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { deviation as d3Deviation, mean as d3Mean } from "d3";
 import _ from "lodash";
 import moment from "moment";
@@ -145,10 +146,11 @@ function noConnectionTable(noConnections: NoConnection[]) {
 function createHeaderCell(staleIDs: Set<number>, id: Identity, key: string) {
   const node = `n${id.nodeID.toString()}`;
   const title = _.join([node, id.address, id.locality], "\n");
-  let className = "network-table__cell network-table__cell--header";
-  if (staleIDs.has(id.nodeID)) {
-    className = className + " network-table__cell--header-warning";
-  }
+  const className = classNames(
+    "network-table__cell",
+    "network-table__cell--header",
+    { "network-table__cell--header-warning": staleIDs.has(id.nodeID) },
+  );
   return <td key={key} className={className} title={title}>
     {node}
   </td>;
@@ -215,19 +217,15 @@ class Network extends React.Component<NetworkProps, {}> {
         </td>;
       }
       const latency = NanoToMilli(a[nodeIDb].latency.toNumber());
-      let heat: string;
-      if (latency > stddevPlus2) {
-        heat = "stddev-plus-2";
-      } else if (latency > stddevPlus1) {
-        heat = "stddev-plus-1";
-      } else if (latency < stddevMinus2) {
-        heat = "stddev-minus-2";
-      } else if (latency < stddevMinus1) {
-        heat = "stddev-minus-1";
-      } else {
-        heat = "stddev-even";
-      }
-      const className = `network-table__cell network-table__cell--${heat}`;
+      const className = classNames({
+        "network-table__cell": true,
+        "network-table__cell--stddev-minus-2": latency < stddevMinus2,
+        "network-table__cell--stddev-minus-1": latency < stddevMinus1 && latency >= stddevMinus2,
+        "network-table__cell--stddev-even": latency >= stddevMinus1 && latency <= stddevPlus1,
+        "network-table__cell--stddev-plus-1": latency > stddevPlus1 && latency <= stddevPlus2,
+        "network-table__cell--stddev-plus-2": latency > stddevPlus2,
+      });
+
       const title = `n${nodeIDa} -> n${nodeIDb}\n${latency.toString()}ms`;
       return <td key={key} className={className} title={title}>
         {latency.toFixed(2)}ms

--- a/pkg/ui/src/views/reports/containers/nodes/index.tsx
+++ b/pkg/ui/src/views/reports/containers/nodes/index.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import _ from "lodash";
 import Long from "long";
 import moment from "moment";
@@ -260,15 +261,17 @@ class Nodes extends React.Component<NodesProps, {}> {
     equality?: (ns: protos.cockroach.server.status.NodeStatus$Properties) => string,
     cellTitle?: (ns: protos.cockroach.server.status.NodeStatus$Properties) => string,
   ) {
-    let headerClassName: string = "nodes-table__cell nodes-table__cell--header";
-    if (!_.isNil(equality) && _.chain(orderedNodeIDs)
+    const inconsistent = !_.isNil(equality) && _.chain(orderedNodeIDs)
       .map(nodeID => this.props.nodesSummary.nodeStatusByID[nodeID])
       .map(status => equality(status))
       .uniq()
       .value()
-      .length > 1) {
-      headerClassName += " nodes-table__cell--header-warning";
-    }
+      .length > 1;
+    const headerClassName = classNames(
+      "nodes-table__cell",
+      "nodes-table__cell--header",
+      { "nodes-table__cell--header-warning": inconsistent },
+    );
 
     return (
       <tr className="nodes-table__row" key={key}>

--- a/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import _ from "lodash";
 import React from "react";
 
@@ -30,10 +31,10 @@ export default function ConnectionsTable(props: ConnectionsTableProps) {
           {
             _.map(ids, id => {
               const resp = rangeResponse.responses_by_node_id[id];
-              let rowClassName = "connections-table__row";
-              if (!resp.response || !_.isEmpty(resp.error_message)) {
-                rowClassName += " connections-table__row--warning";
-              }
+              const rowClassName = classNames(
+                "connections-table__row",
+                { "connections-table__row--warning": !resp.response || !_.isEmpty(resp.error_message) },
+              );
               return (
                 <tr key={id} className={rowClassName}>
                   <td className="connections-table__cell">n{id}</td>

--- a/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import _ from "lodash";
 import Long from "long";
 import moment from "moment";
@@ -217,18 +218,15 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
     leaderCell?: RangeTableCellContent,
   ) {
     const title = _.join(_.isNil(cell.title) ? cell.value : cell.title, "\n");
-    const classNames = ["range-table__cell"];
-    if (dormant) {
-      classNames.push("range-table__cell--dormant");
-    } else {
-      if (!_.isNil(cell.className)) {
-        classNames.push(...cell.className);
-      }
-      if (!_.isNil(leaderCell) && row.compareToLeader && !_.isEqual(cell.value, leaderCell.value)) {
-        classNames.push("range-table__cell--different-from-leader-warning");
-      }
-    }
-    const className = _.join(classNames, " ");
+    const differentFromLeader = !dormant && !_.isNil(leaderCell) && row.compareToLeader && !_.isEqual(cell.value, leaderCell.value);
+    const className = classNames(
+      "range-table__cell",
+      {
+        "range-table__cell--dormant": dormant,
+        "range-table__cell--different-from-leader-warning": differentFromLeader,
+      },
+      (!dormant && !_.isNil(cell.className) ? cell.className : []),
+    );
     return (
       <td key={key} className={className} title={title}>
         <ul className="range-entries-list">
@@ -252,19 +250,20 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
     sortedStoreIDs: number[],
     key: number,
   ) {
-    let headerClassName = "range-table__cell range-table__cell--header";
     const leaderDetail = detailsByStoreID.get(leaderStoreID);
+    const values: Set<string> = new Set();
     if (row.compareToLeader) {
-      const values: Set<string> = new Set();
       detailsByStoreID.forEach((detail, storeID) => {
         if (!dormantStoreIDs.has(storeID)) {
           values.add(_.join(detail[row.variable].value, " "));
         }
       });
-      if (values.size > 1) {
-        headerClassName += " range-table__cell--header-warning";
-      }
     }
+    const headerClassName = classNames(
+      "range-table__cell",
+      "range-table__cell--header",
+      { "range-table__cell--header-warning": values.size > 1 },
+    );
     return (
       <tr key={key} className="range-table__row">
         <th className={headerClassName}>
@@ -297,25 +296,20 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
     localStoreID: number,
     dormant: boolean,
   ) {
-    let className = "range-table__cell";
+    const differentFromLeader = !dormant && (_.isNil(replica) ? leaderReplicaIDs.has(replicaID) : !leaderReplicaIDs.has(replica.replica_id));
+    const localReplica = !dormant && !differentFromLeader && replica && replica.store_id === localStoreID;
+    const className = classNames({
+      "range-table__cell": true,
+      "range-table__cell--dormant": dormant,
+      "range-table__cell--different-from-leader-warning": differentFromLeader,
+      "range-table__cell--local-replica": localReplica,
+    });
     if (_.isNil(replica)) {
-      if (dormant) {
-        className += " range-table__cell--dormant";
-      } else if (leaderReplicaIDs.has(replicaID)) {
-        className += " range-table__cell--different-from-leader-warning";
-      }
       return (
         <td key={localStoreID} className={className}>
           -
         </td>
       );
-    }
-    if (dormant) {
-      className += " range-table__cell--dormant";
-    } else if (!leaderReplicaIDs.has(replica.replica_id)) {
-      className += " range-table__cell--different-from-leader-warning";
-    } else if (replica.store_id === localStoreID) {
-      className += " range-table__cell--local-replica";
     }
     const value = Print.ReplicaID(rangeID, replica);
     return (

--- a/pkg/ui/src/views/shared/components/dropdown/index.tsx
+++ b/pkg/ui/src/views/shared/components/dropdown/index.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import Select from "react-select";
 import React from "react";
 import _ from "lodash";
@@ -34,20 +35,19 @@ interface DropdownOwnProps {
 export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
   render() {
     const {selected, options, onChange, onArrowClick, disabledArrows} = this.props;
-    let className = "dropdown";
-    if (onArrowClick) {
-      className += " dropdown--side-arrows";
-    }
 
-    let leftClassName = "dropdown__side-arrow";
-    if (_.includes(disabledArrows, ArrowDirection.LEFT)) {
-      leftClassName += " dropdown__side-arrow--disabled";
-    }
-
-    let rightClassName = "dropdown__side-arrow";
-    if (_.includes(disabledArrows, ArrowDirection.RIGHT)) {
-      rightClassName += " dropdown__side-arrow--disabled";
-    }
+    const className = classNames(
+      "dropdown",
+      { "dropdown--side-arrows": !_.isNil(onArrowClick) },
+    );
+    const leftClassName = classNames(
+      "dropdown__side-arrow",
+      { "dropdown__side-arrow--disabled": _.includes(disabledArrows, ArrowDirection.LEFT) },
+    );
+    const rightClassName = classNames(
+      "dropdown__side-arrow",
+      { "dropdown__side-arrow--disabled": _.includes(disabledArrows, ArrowDirection.RIGHT) },
+    );
 
     return <div className={className}>
       {/* TODO (maxlang): consider moving arrows outside the dropdown component */}


### PR DESCRIPTION
Rather than conditionally concatenating strings, let's use the
classnames helper package.

Closes #20314.

Release notes: none.