### PR TITLE
sql: Self-referencing tables can now reference a non-primary index without manually adding an index.

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -404,15 +404,22 @@ func resolveFK(
 		constraintName = fmt.Sprintf("fk_%s_ref_%s", string(d.FromCols[0]), target.Name)
 	}
 
-	var targetIdx *sqlbase.IndexDescriptor
+	// We can't keep a reference to the index in the slice and at the same time
+	// add a new index to that slice without losing the reference. Instead, keep
+	// the index's index into target's list of indexes. If it is a primary index,
+	// targetIdxIndex is set to -1. Also store the targetIndex's ID so we
+	// don't have to do the lookup twice.
+	targetIdxIndex := -1
+	var targetIdxID sqlbase.IndexID
 	if matchesIndex(targetCols, target.PrimaryIndex, matchExact) {
-		targetIdx = &target.PrimaryIndex
+		targetIdxID = target.PrimaryIndex.ID
 	} else {
 		found := false
 		// Find the index corresponding to the referenced column.
 		for i, idx := range target.Indexes {
 			if idx.Unique && matchesIndex(targetCols, idx, matchExact) {
-				targetIdx = &target.Indexes[i]
+				targetIdxIndex = i
+				targetIdxID = idx.ID
 				found = true
 				break
 			}
@@ -438,7 +445,7 @@ func resolveFK(
 	}
 	ref := sqlbase.ForeignKeyReference{
 		Table:           target.ID,
-		Index:           targetIdx.ID,
+		Index:           targetIdxID,
 		Name:            constraintName,
 		SharedPrefixLen: int32(len(srcCols)),
 		OnDelete:        sqlbase.ForeignKeyReferenceActionValue[d.Actions.Delete],
@@ -484,7 +491,11 @@ func resolveFK(
 			backref.Index = added
 		}
 	}
-	targetIdx.ReferencedBy = append(targetIdx.ReferencedBy, backref)
+	if targetIdxIndex > -1 {
+		target.Indexes[targetIdxIndex].ReferencedBy = append(target.Indexes[targetIdxIndex].ReferencedBy, backref)
+	} else {
+		target.PrimaryIndex.ReferencedBy = append(target.PrimaryIndex.ReferencedBy, backref)
+	}
 	return nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -872,6 +872,25 @@ pkref_b  CREATE TABLE pkref_b (
         FAMILY "primary" (b)
 )
 
+statement ok
+CREATE TABLE test20042 (
+  x STRING PRIMARY KEY
+ ,y STRING UNIQUE
+ ,z STRING REFERENCES test20042(y)
+);
+
+statement ok
+INSERT INTO test20042 (x, y, z) VALUES ('pk1', 'k1', null);
+
+statement ok
+INSERT INTO test20042 (x, y, z) VALUES ('pk2', 'k2 ', 'k1');
+
+statement ok
+DELETE FROM test20042 WHERE x = 'pk2';
+
+statement ok
+DELETE FROM test20042 WHERE x = 'pk1';
+
 # See https://github.com/cockroachdb/cockroach/issues/20045
 statement ok
 CREATE TABLE self_x2 (
@@ -880,9 +899,9 @@ CREATE TABLE self_x2 (
  ,z STRING REFERENCES self_x2(y)
  ,INDEX(z)
 );
-
+ 
 statement ok
 INSERT INTO self_x2 (x, y, z) VALUES ('pk1', NULL, NULL);
-
+ 
 statement ok
 DELETE FROM self_x2 WHERE x = 'pk1';

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -891,17 +891,27 @@ DELETE FROM test20042 WHERE x = 'pk2';
 statement ok
 DELETE FROM test20042 WHERE x = 'pk1';
 
-# See https://github.com/cockroachdb/cockroach/issues/20045
 statement ok
-CREATE TABLE self_x2 (
+CREATE TABLE test20045 (
   x STRING PRIMARY KEY
- ,y STRING UNIQUE REFERENCES self_x2(x)
- ,z STRING REFERENCES self_x2(y)
- ,INDEX(z)
+ ,y STRING UNIQUE REFERENCES test20045(x)
+ ,z STRING REFERENCES test20045(y)
 );
- 
+
 statement ok
-INSERT INTO self_x2 (x, y, z) VALUES ('pk1', NULL, NULL);
- 
+INSERT INTO test20045 (x, y, z) VALUES ('pk1', NULL, NULL);
+
 statement ok
-DELETE FROM self_x2 WHERE x = 'pk1';
+INSERT INTO test20045 (x, y, z) VALUES ('pk2', 'pk1', NULL);
+
+statement ok
+INSERT INTO test20045 (x, y, z) VALUES ('pk3', 'pk2', 'pk1');
+
+statement ok
+DELETE FROM test20045 WHERE x = 'pk3';
+
+statement ok
+DELETE FROM test20045 WHERE x = 'pk2';
+
+statement ok
+DELETE FROM test20045 WHERE x = 'pk1';


### PR DESCRIPTION
Previously, this would fail:
```sql
CREATE TABLE test20042 (
  x STRING PRIMARY KEY
 ,y STRING UNIQUE
 ,z STRING REFERENCES test20042(y)
);
```

But this would pass:

```sql
CREATE TABLE test20042 (
  x STRING PRIMARY KEY
 ,y STRING UNIQUE
 ,z STRING REFERENCES test20042(y)
 ,INDEX(z)
);
```

Release Note: Fixed a bug that prevented creating self-referencing tables that referenced a non-primary index without manually including the index on the referencing column.

Fixes #20042.