### PR TITLE
batcheval: absorb command registration

### DIFF
--- a/pkg/ccl/storageccl/add_sstable.go
+++ b/pkg/ccl/storageccl/add_sstable.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl/engineccl"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -26,10 +25,7 @@ import (
 )
 
 func init() {
-	storage.SetAddSSTableCmd(storage.Command{
-		DeclareKeys: batcheval.DefaultDeclareKeys,
-		Eval:        evalAddSSTable,
-	})
+	batcheval.RegisterCommand(roachpb.AddSSTable, batcheval.DefaultDeclareKeys, evalAddSSTable)
 }
 
 func evalAddSSTable(

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
@@ -43,10 +42,7 @@ const ExportRequestLimit = 5
 var exportRequestLimiter = makeConcurrentRequestLimiter(ExportRequestLimit)
 
 func init() {
-	storage.SetExportCmd(storage.Command{
-		DeclareKeys: declareKeysExport,
-		Eval:        evalExport,
-	})
+	batcheval.RegisterCommand(roachpb.Export, declareKeysExport, evalExport)
 }
 
 func declareKeysExport(

--- a/pkg/storage/batch_spanset_test.go
+++ b/pkg/storage/batch_spanset_test.go
@@ -49,7 +49,7 @@ func TestSpanSetBatch(t *testing.T) {
 		t.Fatalf("direct write failed: %s", err)
 	}
 
-	batch := makeSpanSetBatch(eng.NewBatch(), &ss)
+	batch := spanset.NewBatch(eng.NewBatch(), &ss)
 	defer batch.Close()
 
 	// Writes inside the range work. Write twice for later read testing.
@@ -153,7 +153,7 @@ func TestSpanSetBatch(t *testing.T) {
 	if err := batch.Commit(true); err != nil {
 		t.Fatal(err)
 	}
-	iter := &SpanSetIterator{eng.NewIterator(false), &ss, nil, false}
+	iter := spanset.NewIterator(eng.NewIterator(false), &ss)
 	defer iter.Close()
 	iter.SeekReverse(outsideKey)
 	if _, err := iter.Valid(); !isReadSpanErr(err) {

--- a/pkg/storage/batcheval/cmd_compute_checksum.go
+++ b/pkg/storage/batcheval/cmd_compute_checksum.go
@@ -25,6 +25,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
+func init() {
+	RegisterCommand(roachpb.ComputeChecksum, DefaultDeclareKeys, ComputeChecksum)
+}
+
 // Version numbers for Replica checksum computation. Requests fail unless the
 // versions are compatible.
 const (

--- a/pkg/storage/batcheval/cmd_conditional_put.go
+++ b/pkg/storage/batcheval/cmd_conditional_put.go
@@ -22,6 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
+func init() {
+	RegisterCommand(roachpb.ConditionalPut, DefaultDeclareKeys, ConditionalPut)
+}
+
 // ConditionalPut sets the value for a specified key only if
 // the expected value matches. If not, the return value contains
 // the actual value.

--- a/pkg/storage/batcheval/cmd_delete.go
+++ b/pkg/storage/batcheval/cmd_delete.go
@@ -22,6 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
+func init() {
+	RegisterCommand(roachpb.Delete, DefaultDeclareKeys, Delete)
+}
+
 // Delete deletes the key and value specified by key.
 func Delete(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,

--- a/pkg/storage/batcheval/cmd_delete_range.go
+++ b/pkg/storage/batcheval/cmd_delete_range.go
@@ -23,6 +23,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
+func init() {
+	RegisterCommand(roachpb.DeleteRange, DefaultDeclareKeys, DeleteRange)
+}
+
 // DeleteRange deletes the range of key/value pairs specified by
 // start and end keys.
 func DeleteRange(

--- a/pkg/storage/batcheval/cmd_deprecated_verify_checksum.go
+++ b/pkg/storage/batcheval/cmd_deprecated_verify_checksum.go
@@ -20,36 +20,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 func init() {
-	RegisterCommand(roachpb.Put, DefaultDeclareKeys, Put)
+	RegisterCommand(roachpb.DeprecatedVerifyChecksum, DefaultDeclareKeys, deprecatedVerifyChecksum)
 }
 
-// Put sets the value for a specified key.
-func Put(
-	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,
+func deprecatedVerifyChecksum(
+	context.Context, engine.ReadWriter, CommandArgs, roachpb.Response,
 ) (result.Result, error) {
-	args := cArgs.Args.(*roachpb.PutRequest)
-	h := cArgs.Header
-	ms := cArgs.Stats
-
-	var ts hlc.Timestamp
-	if !args.Inline {
-		ts = h.Timestamp
-	}
-	if h.DistinctSpans {
-		if b, ok := batch.(engine.Batch); ok {
-			// Use the distinct batch for both blind and normal ops so that we don't
-			// accidentally flush mutations to make them visible to the distinct
-			// batch.
-			batch = b.Distinct()
-			defer batch.Close()
-		}
-	}
-	if args.Blind {
-		return result.Result{}, engine.MVCCBlindPut(ctx, batch, ms, args.Key, ts, args.Value, h.Txn)
-	}
-	return result.Result{}, engine.MVCCPut(ctx, batch, ms, args.Key, ts, args.Value, h.Txn)
+	return result.Result{}, nil
 }

--- a/pkg/storage/batcheval/cmd_get.go
+++ b/pkg/storage/batcheval/cmd_get.go
@@ -22,6 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
+func init() {
+	RegisterCommand(roachpb.Get, DefaultDeclareKeys, Get)
+}
+
 // Get returns the value for a specified key.
 func Get(
 	ctx context.Context, batch engine.ReadWriter, cArgs CommandArgs, resp roachpb.Response,

--- a/pkg/storage/batcheval/cmd_increment.go
+++ b/pkg/storage/batcheval/cmd_increment.go
@@ -22,6 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
+func init() {
+	RegisterCommand(roachpb.Increment, DefaultDeclareKeys, Increment)
+}
+
 // Increment increments the value (interpreted as varint64 encoded) and
 // returns the newly incremented value (encoded as varint64). If no value
 // exists for the key, zero is incremented.

--- a/pkg/storage/batcheval/cmd_init_put.go
+++ b/pkg/storage/batcheval/cmd_init_put.go
@@ -22,6 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
+func init() {
+	RegisterCommand(roachpb.InitPut, DefaultDeclareKeys, InitPut)
+}
+
 // InitPut sets the value for a specified key only if it doesn't exist. It
 // returns a ConditionFailedError if the key exists with an existing value that
 // is different from the value provided. If FailOnTombstone is set to true,

--- a/pkg/storage/batcheval/cmd_lease.go
+++ b/pkg/storage/batcheval/cmd_lease.go
@@ -19,12 +19,21 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 )
+
+func declareKeysRequestLease(
+	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+) {
+	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.RangeLeaseKey(header.RangeID)})
+	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})
+}
 
 func newFailedLeaseTrigger(isTransfer bool) result.Result {
 	var trigger result.Result

--- a/pkg/storage/batcheval/cmd_lease_info.go
+++ b/pkg/storage/batcheval/cmd_lease_info.go
@@ -17,10 +17,22 @@ package batcheval
 import (
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 )
+
+func init() {
+	RegisterCommand(roachpb.LeaseInfo, declareKeysLeaseInfo, LeaseInfo)
+}
+
+func declareKeysLeaseInfo(
+	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+) {
+	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeLeaseKey(header.RangeID)})
+}
 
 // LeaseInfo returns information about the lease holder for the range.
 func LeaseInfo(

--- a/pkg/storage/batcheval/cmd_lease_request.go
+++ b/pkg/storage/batcheval/cmd_lease_request.go
@@ -22,6 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
+func init() {
+	RegisterCommand(roachpb.RequestLease, declareKeysRequestLease, RequestLease)
+}
+
 // RequestLease sets the range lease for this range. The command fails
 // only if the desired start timestamp collides with a previous lease.
 // Otherwise, the start timestamp is wound back to right after the expiration

--- a/pkg/storage/batcheval/cmd_lease_transfer.go
+++ b/pkg/storage/batcheval/cmd_lease_transfer.go
@@ -23,6 +23,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
+func init() {
+	RegisterCommand(roachpb.TransferLease, declareKeysRequestLease, TransferLease)
+}
+
 // TransferLease sets the lease holder for the range.
 // Unlike with RequestLease(), the new lease is allowed to overlap the old one,
 // the contract being that the transfer must have been initiated by the (soon

--- a/pkg/storage/batcheval/cmd_merge.go
+++ b/pkg/storage/batcheval/cmd_merge.go
@@ -22,6 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
+func init() {
+	RegisterCommand(roachpb.Merge, DefaultDeclareKeys, Merge)
+}
+
 // Merge is used to merge a value into an existing key. Merge is an
 // efficient accumulation operation which is exposed by RocksDB, used
 // by CockroachDB for the efficient accumulation of certain

--- a/pkg/storage/batcheval/cmd_query_txn.go
+++ b/pkg/storage/batcheval/cmd_query_txn.go
@@ -27,6 +27,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+func init() {
+	RegisterCommand(roachpb.QueryTxn, DefaultDeclareKeys, QueryTxn)
+}
+
 // QueryTxn fetches the current state of a transaction.
 // This method is used to continually update the state of a txn
 // which is blocked waiting to resolve a conflicting intent. It

--- a/pkg/storage/batcheval/cmd_range_lookup.go
+++ b/pkg/storage/batcheval/cmd_range_lookup.go
@@ -24,9 +24,21 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 )
+
+func init() {
+	RegisterCommand(roachpb.RangeLookup, declareKeysRangeLookup, RangeLookup)
+}
+
+func declareKeysRangeLookup(
+	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+) {
+	DefaultDeclareKeys(desc, header, req, spans)
+	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})
+}
 
 // RangeLookup is used to look up RangeDescriptors - a RangeDescriptor
 // is a metadata structure which describes the key range and replica locations

--- a/pkg/storage/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_range.go
@@ -22,7 +22,18 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 )
+
+func init() {
+	RegisterCommand(roachpb.ResolveIntentRange, declareKeysResolveIntentRange, ResolveIntentRange)
+}
+
+func declareKeysResolveIntentRange(
+	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+) {
+	declareKeysResolveIntentCombined(desc, header, req, spans)
+}
 
 // ResolveIntentRange resolves write intents in the specified
 // key range according to the status of the transaction which created it.

--- a/pkg/storage/batcheval/cmd_resolve_intent_test.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package storage
+package batcheval
 
 import (
 	"fmt"
@@ -21,16 +21,89 @@ import (
 
 	"golang.org/x/net/context"
 
+	opentracing "github.com/opentracing/opentracing-go"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
-	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
+
+type mockEvalCtx struct {
+	abortSpan *abortspan.AbortSpan
+}
+
+func (m *mockEvalCtx) String() string {
+	return "mock"
+}
+func (m *mockEvalCtx) ClusterSettings() *cluster.Settings {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) EvalKnobs() TestingKnobs {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) Tracer() opentracing.Tracer {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) Engine() engine.Engine {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) DB() *client.DB {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) AbortSpan() *abortspan.AbortSpan {
+	return m.abortSpan
+}
+func (m *mockEvalCtx) GetTxnWaitQueue() *txnwait.Queue {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) NodeID() roachpb.NodeID {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) StoreID() roachpb.StoreID {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) GetRangeID() roachpb.RangeID {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) IsFirstRange() bool {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) GetFirstIndex() (uint64, error) {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) GetTerm(uint64) (uint64, error) {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) Desc() *roachpb.RangeDescriptor {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) ContainsKey(key roachpb.Key) bool {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) GetMVCCStats() enginepb.MVCCStats {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) GetGCThreshold() hlc.Timestamp {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) GetTxnSpanGCThreshold() hlc.Timestamp {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) GetLastReplicaGCTimestamp(context.Context) (hlc.Timestamp, error) {
+	panic("unimplemented")
+}
+func (m *mockEvalCtx) GetLease() (roachpb.Lease, *roachpb.Lease) {
+	panic("unimplemented")
+}
 
 func TestDeclareKeysResolveIntent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -95,25 +168,25 @@ func TestDeclareKeysResolveIntent(t *testing.T) {
 
 				var spans spanset.SpanSet
 				batch := engine.NewBatch()
-				batch = makeSpanSetBatch(batch, &spans)
+				batch = spanset.NewBatch(batch, &spans)
 				defer batch.Close()
 
 				var h roachpb.Header
 				h.RangeID = desc.RangeID
 
-				cArgs := batcheval.CommandArgs{Header: h}
-				cArgs.EvalCtx = &Replica{abortSpan: ac}
+				cArgs := CommandArgs{Header: h}
+				cArgs.EvalCtx = &mockEvalCtx{abortSpan: ac}
 
 				if !ranged {
 					cArgs.Args = &ri
 					declareKeysResolveIntent(desc, h, &ri, &spans)
-					if _, err := batcheval.ResolveIntent(ctx, batch, cArgs, &roachpb.ResolveIntentResponse{}); err != nil {
+					if _, err := ResolveIntent(ctx, batch, cArgs, &roachpb.ResolveIntentResponse{}); err != nil {
 						t.Fatal(err)
 					}
 				} else {
 					cArgs.Args = &rir
 					declareKeysResolveIntentRange(desc, h, &rir, &spans)
-					if _, err := batcheval.ResolveIntentRange(ctx, batch, cArgs, &roachpb.ResolveIntentRangeResponse{}); err != nil {
+					if _, err := ResolveIntentRange(ctx, batch, cArgs, &roachpb.ResolveIntentRangeResponse{}); err != nil {
 						t.Fatal(err)
 					}
 				}

--- a/pkg/storage/batcheval/cmd_reverse_scan.go
+++ b/pkg/storage/batcheval/cmd_reverse_scan.go
@@ -22,6 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
+func init() {
+	RegisterCommand(roachpb.ReverseScan, DefaultDeclareKeys, ReverseScan)
+}
+
 // ReverseScan scans the key range specified by start key through
 // end key in descending order up to some maximum number of results.
 // maxKeys stores the number of scan results remaining for this batch

--- a/pkg/storage/batcheval/cmd_scan.go
+++ b/pkg/storage/batcheval/cmd_scan.go
@@ -22,6 +22,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
+func init() {
+	RegisterCommand(roachpb.Scan, DefaultDeclareKeys, Scan)
+}
+
 // Scan scans the key range specified by start key through end key
 // in ascending order up to some maximum number of results. maxKeys
 // stores the number of scan results remaining for this batch

--- a/pkg/storage/batcheval/command.go
+++ b/pkg/storage/batcheval/command.go
@@ -1,0 +1,69 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package batcheval
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// A Command is the implementation of a single request within a BatchRequest.
+type Command struct {
+	// DeclareKeys adds all keys this command touches to the given spanSet.
+	DeclareKeys func(roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet)
+
+	// Eval evaluates a command on the given engine. It should populate
+	// the supplied response (always a non-nil pointer to the correct
+	// type) and return special side effects (if any) in the Result.
+	// If it writes to the engine it should also update
+	// *CommandArgs.Stats.
+	Eval func(context.Context, engine.ReadWriter, CommandArgs, roachpb.Response) (result.Result, error)
+}
+
+var cmds = make(map[roachpb.Method]Command)
+
+// RegisterCommand makes a command available for execution. It must only be
+// called before any evaluation takes place.
+func RegisterCommand(
+	method roachpb.Method,
+	declare func(roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet),
+	impl func(context.Context, engine.ReadWriter, CommandArgs, roachpb.Response) (result.Result, error),
+) {
+	if _, ok := cmds[method]; ok {
+		log.Fatalf(context.TODO(), "cannot overwrite previously registered method %v", method)
+	}
+	cmds[method] = Command{
+		DeclareKeys: declare,
+		Eval:        impl,
+	}
+}
+
+// UnregisterCommand is provided for testing and allows removing a command.
+// It is a no-op if the command is not registered.
+func UnregisterCommand(method roachpb.Method) {
+	delete(cmds, method)
+}
+
+// LookupCommand returns the command for the given method, with the boolean
+// indicating success or failure.
+func LookupCommand(method roachpb.Method) (Command, bool) {
+	cmd, ok := cmds[method]
+	return cmd, ok
+}

--- a/pkg/storage/cclglue.go
+++ b/pkg/storage/cclglue.go
@@ -19,50 +19,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
-	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/pkg/errors"
 )
 
-// The variables/methods here are initialized/called at init() time, often from
-// the ccl packages.
-
-func makeUnimplementedCommand(method roachpb.Method) Command {
-	return Command{
-		DeclareKeys: batcheval.DefaultDeclareKeys,
-		Eval: func(
-			_ context.Context, _ engine.ReadWriter, _ batcheval.CommandArgs, _ roachpb.Response,
-		) (result.Result, error) {
-			return result.Result{}, errors.Errorf("unimplemented command: %s", method.String())
-		}}
-}
-
-var writeBatchCmd = makeUnimplementedCommand(roachpb.WriteBatch)
-var addSSTableCmd = makeUnimplementedCommand(roachpb.AddSSTable)
-var exportCmd = makeUnimplementedCommand(roachpb.Export)
 var importCmdFn ImportCmdFunc = func(context.Context, batcheval.CommandArgs) (*roachpb.ImportResponse, error) {
 	return &roachpb.ImportResponse{}, errors.Errorf("unimplemented command: %s", roachpb.Import)
-}
-
-// SetWriteBatchCmd allows setting the function that will be called as the
-// implementation of the WriteBatch command. Only allowed to be called by Init.
-func SetWriteBatchCmd(cmd Command) {
-	// This is safe if SetWriteBatchCmd is only called at init time.
-	commands[roachpb.WriteBatch] = cmd
-}
-
-// SetAddSSTableCmd allows setting the function that will be called as the
-// implementation of the AddSSTable command. Only allowed to be called by Init.
-func SetAddSSTableCmd(cmd Command) {
-	// This is safe if SetAddSSTableCmd is only called at init time.
-	commands[roachpb.AddSSTable] = cmd
-}
-
-// SetExportCmd allows setting the function that will be called as the
-// implementation of the Export command. Only allowed to be called by Init.
-func SetExportCmd(cmd Command) {
-	// This is safe if SetExportCmd is only called at init time.
-	commands[roachpb.Export] = cmd
 }
 
 // ImportCmdFunc is the type of the function that will be called as the

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -451,7 +451,7 @@ func ProposeAddSSTable(ctx context.Context, key, val string, ts hlc.Timestamp, s
 }
 
 func SetMockAddSSTable() (undo func()) {
-	prev := commands[roachpb.AddSSTable]
+	prev, _ := batcheval.LookupCommand(roachpb.AddSSTable)
 
 	// TODO(tschottdorf): this already does nontrivial work. Worth open-sourcing the relevant
 	// subparts of the real evalAddSSTable to make this test less likely to rot.
@@ -471,12 +471,11 @@ func SetMockAddSSTable() (undo func()) {
 		}, nil
 	}
 
-	SetAddSSTableCmd(Command{
-		DeclareKeys: batcheval.DefaultDeclareKeys,
-		Eval:        evalAddSSTable,
-	})
+	batcheval.UnregisterCommand(roachpb.AddSSTable)
+	batcheval.RegisterCommand(roachpb.AddSSTable, batcheval.DefaultDeclareKeys, evalAddSSTable)
 	return func() {
-		SetAddSSTableCmd(prev)
+		batcheval.UnregisterCommand(roachpb.AddSSTable)
+		batcheval.RegisterCommand(roachpb.AddSSTable, prev.DeclareKeys, prev.Eval)
 	}
 }
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2164,7 +2164,7 @@ func collectSpans(
 		if _, ok := inner.(*roachpb.NoopRequest); ok {
 			continue
 		}
-		if cmd, ok := commands[inner.Method()]; ok {
+		if cmd, ok := batcheval.LookupCommand(inner.Method()); ok {
 			cmd.DeclareKeys(desc, ba.Header, inner, spans)
 		} else {
 			return nil, errors.Errorf("unrecognized command %s", inner.Method())
@@ -5070,7 +5070,7 @@ func (r *Replica) evaluateTxnWriteBatch(
 		// If all writes occurred at the intended timestamp, we've succeeded on the fast path.
 		batch := r.store.Engine().NewBatch()
 		if util.RaceEnabled && spans != nil {
-			batch = makeSpanSetBatch(batch, spans)
+			batch = spanset.NewBatch(batch, spans)
 		}
 		rec := NewReplicaEvalContext(r, spans)
 		br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, &ms, strippedBa)
@@ -5122,7 +5122,7 @@ func (r *Replica) evaluateTxnWriteBatch(
 
 	batch := r.store.Engine().NewBatch()
 	if util.RaceEnabled && spans != nil {
-		batch = makeSpanSetBatch(batch, spans)
+		batch = spanset.NewBatch(batch, spans)
 	}
 	rec := NewReplicaEvalContext(r, spans)
 	br, result, pErr := evaluateBatch(ctx, idKey, batch, rec, &ms, ba)

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -60,55 +60,6 @@ const (
 	collectChecksumTimeout = 5 * time.Second
 )
 
-// A Command is the implementation of a single request within a BatchRequest.
-type Command struct {
-	// DeclareKeys adds all keys this command touches to the given spanSet.
-	DeclareKeys func(roachpb.RangeDescriptor, roachpb.Header, roachpb.Request, *spanset.SpanSet)
-
-	// Eval evaluates a command on the given engine. It should populate
-	// the supplied response (always a non-nil pointer to the correct
-	// type) and return special side effects (if any) in the Result.
-	// If it writes to the engine it should also update
-	// *CommandArgs.Stats.
-	Eval func(context.Context, engine.ReadWriter, batcheval.CommandArgs, roachpb.Response) (result.Result, error)
-}
-
-var commands = map[roachpb.Method]Command{
-	roachpb.Get:                {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.Get},
-	roachpb.Put:                {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.Put},
-	roachpb.ConditionalPut:     {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.ConditionalPut},
-	roachpb.InitPut:            {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.InitPut},
-	roachpb.Increment:          {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.Increment},
-	roachpb.Delete:             {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.Delete},
-	roachpb.DeleteRange:        {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.DeleteRange},
-	roachpb.Scan:               {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.Scan},
-	roachpb.ReverseScan:        {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.ReverseScan},
-	roachpb.BeginTransaction:   {DeclareKeys: declareKeysBeginTransaction, Eval: batcheval.BeginTransaction},
-	roachpb.EndTransaction:     {DeclareKeys: declareKeysEndTransaction, Eval: evalEndTransaction},
-	roachpb.RangeLookup:        {DeclareKeys: declareKeysRangeLookup, Eval: batcheval.RangeLookup},
-	roachpb.HeartbeatTxn:       {DeclareKeys: declareKeysHeartbeatTransaction, Eval: batcheval.HeartbeatTxn},
-	roachpb.GC:                 {DeclareKeys: declareKeysGC, Eval: batcheval.GC},
-	roachpb.PushTxn:            {DeclareKeys: declareKeysPushTransaction, Eval: batcheval.PushTxn},
-	roachpb.QueryTxn:           {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.QueryTxn},
-	roachpb.ResolveIntent:      {DeclareKeys: declareKeysResolveIntent, Eval: batcheval.ResolveIntent},
-	roachpb.ResolveIntentRange: {DeclareKeys: declareKeysResolveIntentRange, Eval: batcheval.ResolveIntentRange},
-	roachpb.Merge:              {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.Merge},
-	roachpb.TruncateLog:        {DeclareKeys: declareKeysTruncateLog, Eval: batcheval.TruncateLog},
-	roachpb.RequestLease:       {DeclareKeys: declareKeysRequestLease, Eval: batcheval.RequestLease},
-	roachpb.TransferLease:      {DeclareKeys: declareKeysRequestLease, Eval: batcheval.TransferLease},
-	roachpb.LeaseInfo:          {DeclareKeys: declareKeysLeaseInfo, Eval: batcheval.LeaseInfo},
-	roachpb.ComputeChecksum:    {DeclareKeys: batcheval.DefaultDeclareKeys, Eval: batcheval.ComputeChecksum},
-	roachpb.WriteBatch:         writeBatchCmd,
-	roachpb.Export:             exportCmd,
-	roachpb.AddSSTable:         addSSTableCmd,
-
-	roachpb.DeprecatedVerifyChecksum: {
-		DeclareKeys: batcheval.DefaultDeclareKeys,
-		Eval: func(context.Context, engine.ReadWriter, batcheval.CommandArgs, roachpb.Response) (result.Result, error) {
-			return result.Result{}, nil
-		}},
-}
-
 // evaluateCommand delegates to the eval method for the given
 // roachpb.Request. The returned Result may be partially valid
 // even if an error is returned. maxKeys is the number of scan results
@@ -149,7 +100,7 @@ func evaluateCommand(
 	var err error
 	var pd result.Result
 
-	if cmd, ok := commands[args.Method()]; ok {
+	if cmd, ok := batcheval.LookupCommand(args.Method()); ok {
 		cArgs := batcheval.CommandArgs{
 			EvalCtx: rec,
 			Header:  h,
@@ -205,30 +156,16 @@ func evaluateCommand(
 	return pd, pErr
 }
 
-// declareKeysWriteTransaction is the shared portion of
-// declareKeys{Begin,End,Heartbeat}Transaction
-func declareKeysWriteTransaction(
-	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	if header.Txn != nil {
-		header.Txn.AssertInitialized(context.TODO())
-		spans.Add(spanset.SpanReadWrite, roachpb.Span{
-			Key: keys.TransactionKey(req.Header().Key, header.Txn.ID),
-		})
-	}
-}
-
-func declareKeysBeginTransaction(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	declareKeysWriteTransaction(desc, header, req, spans)
-	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeTxnSpanGCThresholdKey(header.RangeID)})
+func init() {
+	// TODO(tschottdorf): move EndTransaction into batcheval. In doing so,
+	// unexport DeclareKeysWriteTransaction.
+	batcheval.RegisterCommand(roachpb.EndTransaction, declareKeysEndTransaction, evalEndTransaction)
 }
 
 func declareKeysEndTransaction(
 	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
 ) {
-	declareKeysWriteTransaction(desc, header, req, spans)
+	batcheval.DeclareKeysWriteTransaction(desc, header, req, spans)
 	et := req.(*roachpb.EndTransactionRequest)
 	// The spans may extend beyond this Range, but it's ok for the
 	// purpose of the command queue. The parts in our Range will
@@ -759,107 +696,6 @@ func runCommitTrigger(
 	}
 	log.Fatalf(ctx, "unknown commit trigger: %+v", ct)
 	return result.Result{}, nil
-}
-
-func declareKeysRangeLookup(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	batcheval.DefaultDeclareKeys(desc, header, req, spans)
-	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})
-}
-
-func declareKeysHeartbeatTransaction(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	declareKeysWriteTransaction(desc, header, req, spans)
-	if header.Txn != nil {
-		header.Txn.AssertInitialized(context.TODO())
-		spans.Add(spanset.SpanReadOnly, roachpb.Span{
-			Key: keys.AbortSpanKey(header.RangeID, header.Txn.ID),
-		})
-	}
-}
-
-func declareKeysGC(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	// Intentionally don't call  batcheval.DefaultDeclareKeys: the key range in the header
-	// is usually the whole range (pending resolution of #7880).
-	gcr := req.(*roachpb.GCRequest)
-	for _, key := range gcr.Keys {
-		spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: key.Key})
-	}
-	// Be smart here about blocking on the threshold keys. The GC queue can send an empty
-	// request first to bump the thresholds, and then another one that actually does work
-	// but can avoid declaring these keys below.
-	if gcr.Threshold != (hlc.Timestamp{}) {
-		spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.RangeLastGCKey(header.RangeID)})
-	}
-	if gcr.TxnSpanGCThreshold != (hlc.Timestamp{}) {
-		spans.Add(spanset.SpanReadWrite, roachpb.Span{
-			// TODO(bdarnell): since this must be checked by all
-			// reads, this should be factored out into a separate
-			// waiter which blocks only those reads far enough in the
-			// past to be affected by the in-flight GCRequest (i.e.
-			// normally none). This means this key would be special
-			// cased and not tracked by the command queue.
-			Key: keys.RangeTxnSpanGCThresholdKey(header.RangeID),
-		})
-	}
-	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})
-}
-
-func declareKeysPushTransaction(
-	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	pr := req.(*roachpb.PushTxnRequest)
-	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.TransactionKey(pr.PusheeTxn.Key, pr.PusheeTxn.ID)})
-	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.AbortSpanKey(header.RangeID, pr.PusheeTxn.ID)})
-}
-
-func declareKeysResolveIntentCombined(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	batcheval.DefaultDeclareKeys(desc, header, req, spans)
-	var args *roachpb.ResolveIntentRequest
-	switch t := req.(type) {
-	case *roachpb.ResolveIntentRequest:
-		args = t
-	case *roachpb.ResolveIntentRangeRequest:
-		// Ranged and point requests only differ in whether the header's EndKey
-		// is used, so we can convert them.
-		args = (*roachpb.ResolveIntentRequest)(t)
-	}
-	if batcheval.WriteAbortSpanOnResolve(args.Status) {
-		spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.AbortSpanKey(header.RangeID, args.IntentTxn.ID)})
-	}
-}
-
-func declareKeysResolveIntent(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	declareKeysResolveIntentCombined(desc, header, req, spans)
-}
-
-func declareKeysResolveIntentRange(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	declareKeysResolveIntentCombined(desc, header, req, spans)
-}
-
-func declareKeysTruncateLog(
-	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.RaftTruncatedStateKey(header.RangeID)})
-	prefix := keys.RaftLogPrefix(header.RangeID)
-	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()})
-}
-
-func declareKeysRequestLease(
-	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	spans.Add(spanset.SpanReadWrite, roachpb.Span{Key: keys.RangeLeaseKey(header.RangeID)})
-	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeDescriptorKey(desc.StartKey)})
 }
 
 // CheckConsistency runs a consistency check on the range. It first applies a
@@ -2514,12 +2350,6 @@ func updateRangeDescriptor(
 	}
 	b.CPut(descKey, newValue, oldValue)
 	return nil
-}
-
-func declareKeysLeaseInfo(
-	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
-) {
-	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeLeaseKey(header.RangeID)})
 }
 
 // TestingRelocateRange relocates a given range to a given set of stores. The first


### PR DESCRIPTION
You'll notice that `EndTransaction` is still lingering in `replica_command.go`,
but that will be done in a follow-up.

Touches #18779.