### PR TITLE
build/packer: move TeamCity agents to GCE

### DIFF
--- a/build/packer/README.md
+++ b/build/packer/README.md
@@ -9,11 +9,10 @@ $ packer build VM-TEMPLATE.json
 
 The location of the created VM image will be printed when the build completes.
 
-At present, the only VM template available builds TeamCity agents. You'll need
-`DIGITALOCEAN_API_TOKEN` set in your environment. Employees can find the token
-in customenv.mk. You'll also need to use [Nikhil's fork of
-Packer][benesch-packer] until [packer#5527] lands.
+At present, the only VM template available builds TeamCity agent images for
+Google Compute Engine. You'll need to be either authenticated with the `gcloud`
+tool or provide your Google Cloud JSON credentials in a [known location][gauth].
+
 
 [Packer]: https://www.packer.io
-[benesch-packer]: https://github.com/benesch/packer/tree/digitalocean
-[packer#5527]: https://github.com/hashicorp/packer/pull/5527
+[gauth]: https://www.packer.io/docs/builders/googlecompute.html#running-without-a-compute-engine-service-account

--- a/build/packer/teamcity-agent.json
+++ b/build/packer/teamcity-agent.json
@@ -4,21 +4,20 @@
   },
 
   "builders": [{
-      "type": "digitalocean",
-      "image": "ubuntu-16-04-x64",
-      "region": "nyc3",
-      "size": "c-16",
-      "snapshot_name": "{{user `image_id`}}",
-      "ssh_username": "root",
-      "volumes": [{
-        "size": 25,
-        "snapshot_name": "{{user `image_id`}}-vol"
-      }]
+      "type": "googlecompute",
+      "project_id": "cockroach-ephemeral",
+      "source_image_family": "ubuntu-1604-lts",
+      "zone": "us-east1-b",
+      "machine_type": "n1-highcpu-32",
+      "image_name": "{{user `image_id`}}",
+      "ssh_username": "packer",
+      "disk_size": 50,
+      "disk_type": "pd-ssd"
   }],
 
   "provisioners": [{
     "type": "shell",
-    "environment_vars": ["DIGITAL_OCEAN_IMAGE_ID={{user `image_id`}}"],
-    "script": "teamcity-agent.sh"
+    "script": "teamcity-agent.sh",
+    "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
   }]
 }

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -9,20 +9,11 @@ name=
 workDir=../work
 tempDir=../temp
 systemDir=../system
-digitalocean-cloud.image.id=$DIGITAL_OCEAN_IMAGE_ID
 EOF
 }
 
 # Avoid saving any Bash history.
 HISTSIZE=0
-
-# High CPU instances only have 20GiB of local SSD, so mount a block storage
-# volume to hold Docker's data.
-[[ -e /dev/sda ]] || { echo "no volume attached, exiting" >&2; exit 1; }
-mkfs.ext4 /dev/sda
-mkdir -p /var/lib/docker
-echo '/dev/sda /var/lib/docker ext4 discard 0 2' >> /etc/fstab
-mount -a
 
 # Add third-party APT repositories.
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0EBFCD88


### PR DESCRIPTION
The TeamCity DigitalOcean plugin isn't suitable for heavy use and leaks
resources whenever DigitalOcean runs out of high CPU capacity. Move the
agents to Google Compute Engine, which has an official,
JetBrains-supported TeamCity plugin.

/cc @lego FYI 😢 