### PR TITLE
build: Publish a separate docker image for unstable releases

### DIFF
--- a/build/teamcity-publish-artifacts.sh
+++ b/build/teamcity-publish-artifacts.sh
@@ -9,11 +9,16 @@ export BUILDER_HIDE_GOPATH_SRC=1
 
 build/teamcity-publish-s3-binaries.sh "$@"
 
-# For final/production releases, build and publish a docker image.
-# According to semver rules, non-final releases can be distinguished
-# by the presence of a hyphen in the version number.
-if [[ "$TC_BUILD_BRANCH" != *-* ]] && [ "$TEAMCITY_BUILDCONF_NAME" == 'Publish Releases' ]; then
-  image=docker.io/cockroachdb/cockroach
+# When publishing a release, build and publish a docker image.
+if [ "$TEAMCITY_BUILDCONF_NAME" == 'Publish Releases' ]; then
+  # Unstable releases go to a special cockroach-unstable image name, while
+  # stable releases go to the official cockroachdb/cockroach image name.
+  # According to semver rules, non-final releases can be distinguished
+  # by the presence of a hyphen in the version number.
+  image=docker.io/cockroachdb/cockroach-unstable
+  if [[ "$TC_BUILD_BRANCH" != *-* ]]; then
+    image=docker.io/cockroachdb/cockroach
+  fi
 
   cp cockroach-linux-2.6.32-gnu-amd64 build/deploy/cockroach
   docker build --no-cache --tag=$image:{latest,"$TC_BUILD_BRANCH"} build/deploy


### PR DESCRIPTION
Tested locally to push out an image for our latest alpha release. All
unstable images get published to
https://hub.docker.com/r/cockroachdb/cockroach-unstable/