### PR TITLE
sqlccl: allow canceling of IMPORT jobs

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -17,6 +17,8 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -836,9 +838,10 @@ func TestBackupRestoreControlJob(t *testing.T) {
 	_, _, outerDB, _, cleanup := backupRestoreTestSetupWithParams(t, multiNode, numAccounts, initNone, params)
 	defer cleanup()
 
-	run := func(t *testing.T, op, query string, args ...interface{}) (int64, error) {
-		sqlDB := sqlutils.MakeSQLRunner(outerDB.DB)
+	sqlDB := sqlutils.MakeSQLRunner(outerDB.DB)
+	sqlDB.Exec(t, `SET CLUSTER SETTING experimental.importcsv.enabled = true`)
 
+	run := func(t *testing.T, op, query string, args ...interface{}) (int64, error) {
 		allowResponse = make(chan struct{})
 		errCh := make(chan error)
 		go func() {
@@ -858,7 +861,6 @@ func TestBackupRestoreControlJob(t *testing.T) {
 	}
 
 	t.Run("foreign", func(t *testing.T) {
-		sqlDB := sqlutils.MakeSQLRunner(outerDB.DB)
 		foreignDir := "nodelocal:///foreign"
 		sqlDB.Exec(t, `CREATE DATABASE orig_fkdb`)
 		sqlDB.Exec(t, `CREATE DATABASE restore_fkdb`)
@@ -890,7 +892,6 @@ func TestBackupRestoreControlJob(t *testing.T) {
 	})
 
 	t.Run("pause", func(t *testing.T) {
-		sqlDB := sqlutils.MakeSQLRunner(outerDB.DB)
 		pauseDir := "nodelocal:///pause"
 		sqlDB.Exec(t, `CREATE DATABASE pause`)
 
@@ -915,7 +916,6 @@ func TestBackupRestoreControlJob(t *testing.T) {
 	})
 
 	t.Run("cancel", func(t *testing.T) {
-		sqlDB := sqlutils.MakeSQLRunner(outerDB.DB)
 		cancelDir := "nodelocal:///cancel"
 		sqlDB.Exec(t, `CREATE DATABASE cancel`)
 
@@ -935,6 +935,33 @@ func TestBackupRestoreControlJob(t *testing.T) {
 			`SELECT name FROM crdb_internal.tables WHERE database_name = 'cancel' AND state = 'DROP'`,
 			[][]string{{"bank"}},
 		)
+	})
+
+	t.Run("cancel import", func(t *testing.T) {
+		cancelDir := "nodelocal:///cancel-import"
+		sqlDB.Exec(t, `CREATE DATABASE cancelimport`)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "GET" {
+				<-allowResponse
+				_, _ = w.Write([]byte("1"))
+			}
+		}))
+		defer srv.Close()
+
+		var urls []string
+		for i := 0; i < 10; i++ {
+			urls = append(urls, fmt.Sprintf("'%s/%d.csv'", srv.URL, i))
+		}
+		csvURLs := strings.Join(urls, ", ")
+		query := fmt.Sprintf(`IMPORT TABLE t (i INT) CSV DATA (%s) WITH temp = $1, into_db = 'cancelimport'`, csvURLs)
+
+		if _, err := run(t, "cancel", query, cancelDir); !testutils.IsError(err, "job canceled") {
+			t.Fatalf("expected 'job canceled' error, but got %+v", err)
+		}
+		// Check that executing again succeeds. This won't work if the first import
+		// was not successfully canceled.
+		sqlDB.Exec(t, query, cancelDir)
 	})
 }
 

--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -110,6 +110,11 @@ func (e *InvalidStatusError) Error() string {
 	return fmt.Sprintf("cannot %s %s job (id %d)", e.op, e.status, e.id)
 }
 
+// Status returns the errors status.
+func (e InvalidStatusError) Status() Status {
+	return e.status
+}
+
 // ID returns the ID of the job that this Job is currently tracking. This will
 // be nil if Created has not yet been called.
 func (j *Job) ID() *int64 {

--- a/pkg/sql/jobs/jobs_test.go
+++ b/pkg/sql/jobs/jobs_test.go
@@ -1022,6 +1022,21 @@ func TestJobLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("cannot pause or cancel uncontrollable jobs", func(t *testing.T) {
+		job, _ := createJob(jobs.Record{
+			Details: jobs.SchemaChangeDetails{},
+		})
+		if err := registry.Pause(ctx, nil, *job.ID()); !testutils.IsError(err, "is not controllable") {
+			t.Fatalf("unexpected %v", err)
+		}
+		if err := registry.Cancel(ctx, nil, *job.ID()); !testutils.IsError(err, "is not controllable") {
+			t.Fatalf("unexpected %v", err)
+		}
+		if err := registry.Resume(ctx, nil, *job.ID()); !testutils.IsError(err, "is not controllable") {
+			t.Fatalf("unexpected %v", err)
+		}
+	})
 }
 
 func TestRunAndWaitForTerminalState(t *testing.T) {


### PR DESCRIPTION
Special case import jobs in the job cancel function. This allows them
to be marked as canceled, even though they are not resumable. This
is a short term fix (for some unknown definition of short term) until
the jobs API can be yet again improved to support jobs that start jobs.

IMPORT needed to be taught about monitoring the progress callback so
it could cancel itself.

While here, improve the error message around attempting to
pause/cancel/resume schema change jobs.