### PR TITLE
ui: capitalize label of capacity series on overview

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -106,7 +106,7 @@ export default function (props: GraphDashboardProps) {
       )}
     >
       <Axis units={AxisUnits.Bytes} label="capacity">
-        <Metric name="cr.store.capacity" title="capacity" />
+        <Metric name="cr.store.capacity" title="Capacity" />
         <Metric name="cr.store.capacity.available" title="Available" />
         <Metric name="cr.store.capacity.used" title="Used" />
       </Axis>


### PR DESCRIPTION
In #19870 I accidentally changed the capitalization of the capcity series
title on the capacity chart on the overview page.  This restores it to the
correct capitalization.

Release notes: none.