### PR TITLE
cli: use FlagInfo in CCL code.

### DIFF
--- a/pkg/ccl/baseccl/encryption_spec.go
+++ b/pkg/ccl/baseccl/encryption_spec.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/cliccl/cliflagsccl"
 )
 
 // DefaultRotationPeriod is the rotation period used if not specified.
@@ -127,8 +128,7 @@ var _ pflag.Value = &StoreEncryptionSpecList{}
 func (encl StoreEncryptionSpecList) String() string {
 	var buffer bytes.Buffer
 	for _, ss := range encl.Specs {
-		// TODO(mberhault): use the FlagInfo once refactored.
-		fmt.Fprintf(&buffer, "--enterprise-encryption=%s ", ss)
+		fmt.Fprintf(&buffer, "--%s=%s ", cliflagsccl.EnterpriseEncryption.Name, ss)
 	}
 	// Trim the extra space from the end if it exists.
 	if l := buffer.Len(); l > 0 {

--- a/pkg/ccl/cliccl/cliflagsccl/flags.go
+++ b/pkg/ccl/cliccl/cliflagsccl/flags.go
@@ -1,0 +1,64 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cliflagsccl
+
+import "github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+
+// Attrs and others store the static information for CLI flags.
+var (
+	EnterpriseEncryption = cliflags.FlagInfo{
+		Name: "enterprise-encryption",
+		Description: `
+*** Valid enterprise licenses only ***
+
+TODO(mberhault): fill this.
+
+Valid fields:
+* path: must match the path of one of the stores
+* key: path to the current key file
+* old-key: path to the previous key file
+* rotation-period: amount of time after which data keys should be rotated
+`,
+	}
+
+	CSVTable = cliflags.FlagInfo{
+		Name:        "table",
+		Description: `location of a file containing a single CREATE TABLE statement`,
+	}
+
+	CSVDataNames = cliflags.FlagInfo{
+		Name:        "data",
+		Description: `filenames of CSV data; uses <table>.dat if empty`,
+	}
+
+	CSVDest = cliflags.FlagInfo{
+		Name:        "dest",
+		Description: `destination directory for backup files`,
+	}
+
+	CSVNullIf = cliflags.FlagInfo{
+		Name:        "nullif",
+		Description: `if specified, the value of NULL; can specify the empty string`,
+	}
+
+	CSVComma = cliflags.FlagInfo{
+		Name:        "delimited",
+		Description: `if specified, the CSV delimiter instead of a comma`,
+	}
+
+	CSVComment = cliflags.FlagInfo{
+		Name:        "comment",
+		Description: `if specified, allows comment lines starting with this character`,
+	}
+
+	CSVTempDir = cliflags.FlagInfo{
+		Name:        "tempdir",
+		Description: `directory to store intermediate temp files`,
+	}
+)

--- a/pkg/ccl/cliccl/load.go
+++ b/pkg/ccl/cliccl/load.go
@@ -16,6 +16,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/cliccl/cliflagsccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
 	"github.com/cockroachdb/cockroach/pkg/cli"
@@ -66,14 +67,14 @@ Then the file could be converted and saved to /data/backup with:
 `,
 		RunE: cli.MaybeDecorateGRPCError(runLoadCSV),
 	}
-	flags := loadCSVCmd.PersistentFlags()
-	flags.StringVar(&csvTableName, "table", "", "location of a file containing a single CREATE TABLE statement")
-	flags.StringSliceVar(&csvDataNames, "data", nil, "filenames of CSV data; uses <table>.dat if empty")
-	flags.StringVar(&csvDest, "dest", "", "destination directory for backup files")
-	flags.StringVar(&csvNullIf, "nullif", "", "if specified, the value of NULL; can specify the empty string")
-	flags.StringVar(&csvComma, "delimiter", "", "if specified, the CSV delimiter instead of a comma")
-	flags.StringVar(&csvComment, "comment", "", "if specified, allows comment lines starting with this character")
-	flags.StringVar(&csvTempDir, "tempdir", os.TempDir(), "directory to store intermediate temp files")
+	f := loadCSVCmd.PersistentFlags()
+	cli.StringFlag(f, &csvTableName, cliflagsccl.CSVTable, "")
+	cli.StringSliceFlag(f, &csvDataNames, cliflagsccl.CSVDataNames, nil)
+	cli.StringFlag(f, &csvDest, cliflagsccl.CSVDest, "")
+	cli.StringFlag(f, &csvNullIf, cliflagsccl.CSVNullIf, "")
+	cli.StringFlag(f, &csvComma, cliflagsccl.CSVComma, "")
+	cli.StringFlag(f, &csvComment, cliflagsccl.CSVComment, "")
+	cli.StringFlag(f, &csvTempDir, cliflagsccl.CSVTempDir, os.TempDir())
 
 	loadShowCmd := &cobra.Command{
 		Use:   "show <basepath>",

--- a/pkg/ccl/cliccl/start.go
+++ b/pkg/ccl/cliccl/start.go
@@ -10,6 +10,7 @@ package cliccl
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/baseccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/cliccl/cliflagsccl"
 	"github.com/cockroachdb/cockroach/pkg/cli"
 	"github.com/spf13/cobra"
 )
@@ -19,23 +20,8 @@ import (
 
 var storeEncryptionSpecs baseccl.StoreEncryptionSpecList
 
-const (
-	// TODO(mberhault): use pkg/cli helpers to format flag descriptions.
-	encryptionFlagDesc = `
-        *** Valid enterprise licenses only ***
-
-        TODO(mberhault): fill this.
-
-        Valid fields:
-        * path: must match the path of one of the stores
-        * key: path to the current key file
-        * old-key: path to the previous key file
-        * rotation-period: amount of time after which data keys should be rotated
-`
-)
-
 func init() {
-	cli.StartCmd.Flags().VarP(&storeEncryptionSpecs, "enterprise-encryption", "", encryptionFlagDesc)
+	cli.VarFlag(cli.StartCmd.Flags(), &storeEncryptionSpecs, cliflagsccl.EnterpriseEncryption)
 
 	// Add a new pre-run command to match encryption specs to store specs.
 	cli.AddPersistentPreRunE(cli.StartCmd, func(cmd *cobra.Command, _ []string) error {

--- a/pkg/cli/start_unix.go
+++ b/pkg/cli/start_unix.go
@@ -28,7 +28,7 @@ import (
 var startBackground bool
 
 func init() {
-	boolFlag(StartCmd.Flags(), &startBackground, cliflags.Background, false)
+	BoolFlag(StartCmd.Flags(), &startBackground, cliflags.Background, false)
 }
 
 func maybeRerunBackground() (bool, error) {


### PR DESCRIPTION
* move some of the FlagInfo helpers to `cliflags`
* use a similar flag definition layout in cliccl
* add `StringSliceFlag`
* convert all ccl flags to `FlagInfo`
* use the `FlagInfo` name for the encryption flag

I'm leaving the `cli.<type>Flag` functions in `cli` to avoid having to
prepend `cliflags.` to all of them.