### PR TITLE
sql: improve spans for IS NULL constraint

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -746,3 +746,129 @@ ORDER BY total DESC
 ts 1
 ts2 1
 ts3 1
+
+# Regression tests for #20362 (IS NULL handling).
+statement ok
+INSERT INTO abcd VALUES
+(NULL, NULL, NULL),
+(NULL, NULL, 1),
+(NULL, NULL, 5),
+(NULL, NULL, 10),
+(NULL, 1,    NULL),
+(NULL, 1,    1),
+(NULL, 1,    5),
+(NULL, 1,    10),
+(NULL, 5,    NULL),
+(NULL, 5,    1),
+(NULL, 5,    5),
+(NULL, 5,    10),
+(NULL, 10,   NULL),
+(NULL, 10,   1),
+(NULL, 10,   5),
+(NULL, 10,   10),
+(1,    NULL, NULL),
+(1,    NULL, 1),
+(1,    NULL, 5),
+(1,    NULL, 10),
+(1,    1,    NULL),
+(1,    1,    1),
+(1,    1,    5),
+(1,    1,    10),
+(1,    5,    NULL),
+(1,    5,    1),
+(1,    5,    5),
+(1,    5,    10),
+(1,    10,   NULL),
+(1,    10,   1),
+(1,    10,   5),
+(1,    10,   10)
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b > 5
+----
+0  render  ·         ·               (a, b, c, d)                         a=CONST; b!=NULL
+0  ·       render 0  test.abcd.a     ·                                    ·
+0  ·       render 1  test.abcd.b     ·                                    ·
+0  ·       render 2  test.abcd.c     ·                                    ·
+0  ·       render 3  test.abcd.d     ·                                    ·
+1  scan    ·         ·               (a, b, c, d, rowid[hidden,omitted])  a=CONST; b!=NULL; rowid!=NULL; weak-key(b,c,d,rowid)
+1  ·       table     abcd@abcd       ·                                    ·
+1  ·       spans     /NULL/6-/!NULL  ·                                    ·
+
+query IIII rowsort
+SELECT * FROM abcd@abcd WHERE a IS NULL AND b > 5
+----
+NULL  10  NULL  NULL
+NULL  10  1     NULL
+NULL  10  5     NULL
+NULL  10  10    NULL
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b < 5
+----
+0  render  ·         ·                    (a, b, c, d)                         a=CONST; b!=NULL
+0  ·       render 0  test.abcd.a          ·                                    ·
+0  ·       render 1  test.abcd.b          ·                                    ·
+0  ·       render 2  test.abcd.c          ·                                    ·
+0  ·       render 3  test.abcd.d          ·                                    ·
+1  scan    ·         ·                    (a, b, c, d, rowid[hidden,omitted])  a=CONST; b!=NULL; rowid!=NULL; weak-key(b,c,d,rowid)
+1  ·       table     abcd@abcd            ·                                    ·
+1  ·       spans     /NULL/!NULL-/NULL/5  ·                                    ·
+
+query IIII rowsort
+SELECT * FROM abcd@abcd WHERE a IS NULL AND b < 5
+----
+NULL  1  NULL  NULL
+NULL  1  1     NULL
+NULL  1  5     NULL
+NULL  1  10    NULL
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL ORDER BY b
+----
+0  render  ·         ·             (a, b, c, d)                         a=CONST; +b
+0  ·       render 0  test.abcd.a   ·                                    ·
+0  ·       render 1  test.abcd.b   ·                                    ·
+0  ·       render 2  test.abcd.c   ·                                    ·
+0  ·       render 3  test.abcd.d   ·                                    ·
+1  scan    ·         ·             (a, b, c, d, rowid[hidden,omitted])  a=CONST; rowid!=NULL; weak-key(b,c,d,rowid); +b
+1  ·       table     abcd@abcd     ·                                    ·
+1  ·       spans     /NULL-/!NULL  ·                                    ·
+
+query IIII partialsort(1,2)
+SELECT * FROM abcd@abcd WHERE a IS NULL ORDER BY b
+----
+NULL  NULL  NULL  NULL
+NULL  NULL  1     NULL
+NULL  NULL  5     NULL
+NULL  NULL  10    NULL
+NULL  1     NULL  NULL
+NULL  1     1     NULL
+NULL  1     5     NULL
+NULL  1     10    NULL
+NULL  5     NULL  NULL
+NULL  5     1     NULL
+NULL  5     5     NULL
+NULL  5     10    NULL
+NULL  10    NULL  NULL
+NULL  10    1     NULL
+NULL  10    5     NULL
+NULL  10    10    NULL
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c
+----
+0  render  ·         ·                     (a, b, c, d)                         a=CONST; b=CONST; c!=NULL; +c
+0  ·       render 0  test.abcd.a           ·                                    ·
+0  ·       render 1  test.abcd.b           ·                                    ·
+0  ·       render 2  test.abcd.c           ·                                    ·
+0  ·       render 3  test.abcd.d           ·                                    ·
+1  scan    ·         ·                     (a, b, c, d, rowid[hidden,omitted])  a=CONST; b=CONST; c!=NULL; rowid!=NULL; weak-key(c,d,rowid); +c
+1  ·       table     abcd@abcd             ·                                    ·
+1  ·       spans     /1/NULL/1-/1/NULL/10  ·                                    ·
+
+query IIII 
+SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c
+----
+1  NULL  1  NULL
+1  NULL  5  NULL

--- a/pkg/sql/logictest/testdata/logic_test/select_tighten_spans
+++ b/pkg/sql/logictest/testdata/logic_test/select_tighten_spans
@@ -400,7 +400,7 @@ EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NULL
 ----
 0  scan  ·      ·
 0  ·     table  p2@p2_id
-0  ·     spans  /1/#/53/2-
+0  ·     spans  /1/#/53/2/NULL-
 
 query II rowsort
 SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NULL

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -727,8 +727,13 @@ func (v *indexInfo) makeIndexConstraints(
 						*endExpr = c
 					}
 				case tree.Is:
-					if c.Right == tree.DNull && !*endDone {
-						*endExpr = c
+					if c.Right == tree.DNull {
+						if !*startDone {
+							*startExpr = c
+						}
+						if !*endDone {
+							*endExpr = c
+						}
 					}
 				case tree.IsNot:
 					if c.Right == tree.DNull && !*startDone && (*startExpr == nil) {
@@ -836,6 +841,17 @@ func (v indexInfoByCost) Sort() {
 
 func encodeStartConstraintAscending(c *tree.ComparisonExpr) logicalKeyPart {
 	switch c.Operator {
+	case tree.Is:
+		// An IS NULL expression allows us to constrain the start of the range
+		// to begin at NULL.
+		if c.Right != tree.DNull {
+			panic(fmt.Sprintf("expected NULL operand for IS operator, found %v", c.Right))
+		}
+		return logicalKeyPart{
+			val:       tree.DNull,
+			dir:       encoding.Ascending,
+			inclusive: true,
+		}
 	case tree.IsNot:
 		// A IS NOT NULL expression allows us to constrain the start of
 		// the range to not include NULL.
@@ -899,14 +915,16 @@ func encodeEndConstraintAscending(c *tree.ComparisonExpr) logicalKeyPart {
 			dir:       encoding.Ascending,
 			inclusive: true,
 		}
-	case tree.NE:
-		panic("'!=' operators should have been transformed to 'IS NOT NULL'")
+
 	case tree.LE, tree.EQ, tree.LT:
 		return logicalKeyPart{
 			val:       c.Right.(tree.Datum),
 			dir:       encoding.Ascending,
 			inclusive: c.Operator != tree.LT,
 		}
+
+	case tree.NE:
+		panic("'!=' operators should have been transformed to 'IS NOT NULL'")
 	default:
 		panic(fmt.Sprintf("unexpected operator: %s", c))
 	}
@@ -914,6 +932,18 @@ func encodeEndConstraintAscending(c *tree.ComparisonExpr) logicalKeyPart {
 
 func encodeEndConstraintDescending(c *tree.ComparisonExpr) logicalKeyPart {
 	switch c.Operator {
+	case tree.Is:
+		// An IS NULL expressions allows us to constrain the end of the range
+		// to stop after NULL.
+		if c.Right != tree.DNull {
+			panic(fmt.Sprintf("expected NULL operand for IS operator, found %v", c.Right))
+		}
+		return logicalKeyPart{
+			val:       tree.DNull,
+			dir:       encoding.Descending,
+			inclusive: true,
+		}
+
 	case tree.IsNot:
 		// An IS NOT NULL expressions allows us to constrain the end of the range
 		// to stop at NULL.
@@ -925,14 +955,16 @@ func encodeEndConstraintDescending(c *tree.ComparisonExpr) logicalKeyPart {
 			dir:       encoding.Descending,
 			inclusive: false,
 		}
-	case tree.NE:
-		panic("'!=' operators should have been transformed to 'IS NOT NULL'")
+
 	case tree.GE, tree.EQ, tree.GT:
 		return logicalKeyPart{
 			val:       c.Right.(tree.Datum),
 			dir:       encoding.Descending,
 			inclusive: c.Operator != tree.GT,
 		}
+
+	case tree.NE:
+		panic("'!=' operators should have been transformed to 'IS NOT NULL'")
 	default:
 		panic(fmt.Sprintf("unexpected operator: %s", c))
 	}
@@ -1304,7 +1336,7 @@ func (ic indexConstraints) exactPrefix() int {
 			return prefix
 		}
 		switch c.start.Operator {
-		case tree.EQ:
+		case tree.EQ, tree.Is:
 			prefix++
 		case tree.In:
 			if tuple, ok := c.start.Right.(*tree.DTuple); !ok || len(tuple.D) != 1 {
@@ -1355,6 +1387,12 @@ func (ic indexConstraints) exactPrefixDatums(num int) []tree.Datum {
 				// We have something like `a IN (1)`.
 				datums = append(datums, right)
 			}
+		case tree.Is:
+			if c.start.Right != tree.DNull {
+				panic(fmt.Sprintf("expected NULL operand for IS operator, found %v", c.start.Right))
+			}
+			datums = append(datums, tree.DNull)
+
 		default:
 			panic("asking for too many datums")
 		}
@@ -1452,7 +1490,7 @@ func applyIndexConstraints(
 		if c.start == c.end {
 			// The first is that both the start and end constraints are
 			// equality.
-			if c.start.Operator == tree.EQ {
+			if c.start.Operator == tree.EQ || c.start.Operator == tree.Is {
 				continue
 			}
 			// The second case is that both the start and end constraint are an IN

--- a/pkg/sql/opt_index_selection_test.go
+++ b/pkg/sql/opt_index_selection_test.go
@@ -352,9 +352,9 @@ func TestMakeSpans(t *testing.T) {
 		{`c != false`, `c`, `/1-`, `-/0`},
 		{`NOT c`, `c`, `/!NULL-/1`, `/0-/NULL`},
 		{`c IS TRUE`, `c`, `/1-/2`, `/1-/0`},
-		{`c IS NOT TRUE`, `c`, `-/1`, `/0-`},
+		{`c IS NOT TRUE`, `c`, `/NULL-/1`, `/0-`},
 		{`c IS FALSE`, `c`, `/0-/1`, `/0-/-1`},
-		{`c IS NOT FALSE`, `c`, `-/!NULL /1-`, `-/0 /NULL-`},
+		{`c IS NOT FALSE`, `c`, `/NULL-/!NULL /1-`, `-/0 /NULL-`},
 
 		{`a = 1`, `a`, `/1-/2`, `/1-/0`},
 		{`a != 1`, `a`, `/!NULL-`, `-/NULL`},
@@ -362,7 +362,7 @@ func TestMakeSpans(t *testing.T) {
 		{`a >= 1`, `a`, `/1-`, `-/0`},
 		{`a < 1`, `a`, `/!NULL-/1`, `/0-/NULL`},
 		{`a <= 1`, `a`, `/!NULL-/2`, `/1-/NULL`},
-		{`a IS NULL`, `a`, `-/!NULL`, `/NULL-`},
+		{`a IS NULL`, `a`, `/NULL-/!NULL`, `/NULL-`},
 		{`a IS NOT NULL`, `a`, `/!NULL-`, `-/NULL`},
 
 		{`a IN (1,2,3)`, `a`, `/1-/4`, `/3-/0`},
@@ -387,7 +387,7 @@ func TestMakeSpans(t *testing.T) {
 		{`a = 1 AND b >= 1`, `a,b`, `/1/1-/2`, `/1-/1/0`},
 		{`a = 1 AND b < 1`, `a,b`, `/1/!NULL-/1/1`, `/1/0-/1/NULL`},
 		{`a = 1 AND b <= 1`, `a,b`, `/1/!NULL-/1/2`, `/1/1-/1/NULL`},
-		{`a = 1 AND b IS NULL`, `a,b`, `/1-/1/!NULL`, `/1/NULL-/0`},
+		{`a = 1 AND b IS NULL`, `a,b`, `/1/NULL-/1/!NULL`, `/1/NULL-/0`},
 		{`a = 1 AND b IS NOT NULL`, `a,b`, `/1/!NULL-/2`, `/1-/1/NULL`},
 
 		{`a != 1 AND b = 1`, `a,b`, `/!NULL-`, `-/NULL`},
@@ -405,7 +405,7 @@ func TestMakeSpans(t *testing.T) {
 		{`a > 1 AND b >= 1`, `a,b`, `/2/1-`, `-/2/0`},
 		{`a > 1 AND b < 1`, `a,b`, `/2-`, `-/1`},
 		{`a > 1 AND b <= 1`, `a,b`, `/2-`, `-/1`},
-		{`a > 1 AND b IS NULL`, `a,b`, `/2-`, `-/1`},
+		{`a > 1 AND b IS NULL`, `a,b`, `/2/NULL-`, `-/1`},
 		{`a > 1 AND b IS NOT NULL`, `a,b`, `/2/!NULL-`, `-/2/NULL`},
 
 		{`a >= 1 AND b = 1`, `a,b`, `/1/1-`, `-/1/0`},
@@ -414,7 +414,7 @@ func TestMakeSpans(t *testing.T) {
 		{`a >= 1 AND b >= 1`, `a,b`, `/1/1-`, `-/1/0`},
 		{`a >= 1 AND b < 1`, `a,b`, `/1-`, `-/0`},
 		{`a >= 1 AND b <= 1`, `a,b`, `/1-`, `-/0`},
-		{`a >= 1 AND b IS NULL`, `a,b`, `/1-`, `-/0`},
+		{`a >= 1 AND b IS NULL`, `a,b`, `/1/NULL-`, `-/0`},
 		{`a >= 1 AND b IS NOT NULL`, `a,b`, `/1/!NULL-`, `-/1/NULL`},
 
 		{`a < 1 AND b = 1`, `a,b`, `/!NULL-/0/2`, `/0/1-/NULL`},
@@ -441,7 +441,7 @@ func TestMakeSpans(t *testing.T) {
 		{`a IN (1) AND b >= 1`, `a,b`, `/1/1-/2`, `/1-/1/0`},
 		{`a IN (1) AND b < 1`, `a,b`, `/1/!NULL-/1/1`, `/1/0-/1/NULL`},
 		{`a IN (1) AND b <= 1`, `a,b`, `/1/!NULL-/1/2`, `/1/1-/1/NULL`},
-		{`a IN (1) AND b IS NULL`, `a,b`, `/1-/1/!NULL`, `/1/NULL-/0`},
+		{`a IN (1) AND b IS NULL`, `a,b`, `/1/NULL-/1/!NULL`, `/1/NULL-/0`},
 		{`a IN (1) AND b IS NOT NULL`, `a,b`, `/1/!NULL-/2`, `/1-/1/NULL`},
 
 		{`(a, b) = (1, 2)`, `a`, `/1-/2`, `/1-/0`},


### PR DESCRIPTION
At the level of index selection and span generation, the IS NULL constraint
should behave the same as EQ.

This change fixes incorrect/incomplete handling of IS NULL:
 - it was only generating an "end" constraint; it now generates both
   "start" and "end";
 - it was not handled when finding the "exact prefix" formed by index
    constraints;
 - it was not handled when simplifying the filter.

Fixes #20362.

Release note: Improved handling of IS NULL constraints (enhancement, correctness wasn't affected).