### PR TITLE
sql: add root user to the system.users table

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -748,7 +748,8 @@ func Example_sql() {
 	// user ls --echo-sql
 	// > SHOW USERS
 	// username
-	// # 0 rows
+	// root
+	// # 1 row
 }
 
 func Example_sql_format() {
@@ -1252,16 +1253,19 @@ func Example_user() {
 	// Output:
 	// user ls
 	// username
-	// # 0 rows
+	// root
+	// # 1 row
 	// user ls --format=pretty
 	// +----------+
 	// | username |
 	// +----------+
+	// | root     |
 	// +----------+
-	// (0 rows)
+	// (1 row)
 	// user ls --format=tsv
 	// username
-	// # 0 rows
+	// root
+	// # 1 row
 	// user set FOO
 	// CREATE USER 1
 	// sql -e create user if not exists 'FOO'
@@ -1314,10 +1318,11 @@ func Example_user() {
 	// | foo0                                                            |
 	// | foo_                                                            |
 	// | foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo |
+	// | root                                                            |
 	// | table                                                           |
 	// | ομηρος                                                          |
 	// +-----------------------------------------------------------------+
-	// (10 rows)
+	// (11 rows)
 	// user rm foo
 	// DROP USER 1
 	// user ls --format=pretty
@@ -1331,10 +1336,11 @@ func Example_user() {
 	// | foo0                                                            |
 	// | foo_                                                            |
 	// | foofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoofoo |
+	// | root                                                            |
 	// | table                                                           |
 	// | ομηρος                                                          |
 	// +-----------------------------------------------------------------+
-	// (9 rows)
+	// (10 rows)
 }
 
 func Example_cert() {

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -698,6 +698,7 @@ VALUES ('admin', 'abc'), ('bob', 'xyz')`
 		Users: []serverpb.UsersResponse_User{
 			{Username: "admin"},
 			{Username: "bob"},
+			{Username: "root"},
 		},
 	}
 

--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -17,6 +17,7 @@ package sql
 import (
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/pkg/errors"
@@ -65,6 +66,11 @@ func (n *alterUserSetPasswordNode) Start(params runParams) error {
 	normalizedUsername, hashedPassword, err := n.userAuthInfo.resolve()
 	if err != nil {
 		return err
+	}
+
+	// The root user is not allowed a password.
+	if normalizedUsername == security.RootUser {
+		return errors.Errorf("user %s cannot use password authentication", security.RootUser)
 	}
 
 	internalExecutor := InternalExecutor{LeaseManager: params.p.LeaseMgr()}

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -127,8 +128,9 @@ func (n *dropUserNode) Start(params runParams) error {
 
 	numDeleted := 0
 	for normalizedUsername := range userNames {
-		// Note: protected users like security.RootUser are not included in system.users,
-		// so there is no need to filter them out.
+		if normalizedUsername == security.RootUser {
+			return errors.Errorf("user %s cannot be dropped", security.RootUser)
+		}
 
 		// TODO: Remove the privileges granted to the user.
 		// Note: The current remove user from CLI just deletes the entry from system.users,

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -895,12 +895,6 @@ func forEachUser(ctx context.Context, origPlanner *planner, fn func(username str
 		return nil
 	}
 
-	// TODO(cuongdo/asubiotto): Get rid of root user special-casing if/when a row
-	// for "root" exists in system.user.
-	if err := fn(security.RootUser); err != nil {
-		return err
-	}
-
 	for _, row := range rows {
 		username := tree.MustBeDString(row[0])
 		if err := fn(string(username)); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -7,6 +7,7 @@ query T colnames
 SHOW USERS
 ----
 username
+root
 testuser
 user1
 
@@ -17,6 +18,7 @@ query T colnames
 SHOW USERS
 ----
 username
+root
 testuser
 
 statement ok
@@ -26,6 +28,7 @@ query T colnames
 SHOW USERS
 ----
 username
+root
 testuser
 user1
 
@@ -36,6 +39,7 @@ query T colnames
 SHOW USERS
 ----
 username
+root
 testuser
 
 statement error user user1 does not exist
@@ -69,6 +73,7 @@ query T colnames
 SHOW USERS
 ----
 username
+root
 testuser
 user1
 user2
@@ -82,6 +87,7 @@ query T colnames
 SHOW USERS
 ----
 username
+root
 testuser
 user3
 user4
@@ -93,6 +99,7 @@ query T colnames
 SHOW USERS
 ----
 username
+root
 testuser
 user3
 user4
@@ -121,9 +128,15 @@ query T colnames
 SHOW USERS
 ----
 username
+root
 testuser
 
 user testuser
 
 statement error pq: user testuser does not have DELETE privilege on relation users
 DROP USER user2
+
+user root
+
+statement error pq: cannot drop users root: grants still exist on .*
+DROP USER root

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -240,6 +240,7 @@ query T colnames
 SELECT * FROM [SHOW USERS]
 ----
 username
+root
 testuser
 
 

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -4,6 +4,7 @@ query T colnames
 SHOW USERS
 ----
 username
+root
 testuser
 
 statement ok
@@ -13,6 +14,7 @@ query T colnames
 SHOW USERS
 ----
 username
+root
 testuser
 user1
 
@@ -62,6 +64,7 @@ SHOW USERS
 ----
 username
 foo
+root
 testuser
 user1
 user2
@@ -91,3 +94,8 @@ query TTT
 SELECT current_user, session_user, user
 ----
 testuser  testuser  testuser
+
+user root
+
+statement error pq: user root cannot use password authentication
+ALTER USER root WITH PASSWORD 'foo'

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -77,7 +77,7 @@ func TestQueryCounts(t *testing.T) {
 	// Initialize accum while accounting for system migrations that may have run
 	// DDL statements.
 	accum := queryCounter{
-		insertCount: 1, // version setting population migration
+		insertCount: 2, // version setting population migration and root user addition.
 		ddlCount:    s.MustGetSQLCounter(sql.MetaDdl.Name),
 		miscCount:   s.MustGetSQLCounter(sql.MetaMisc.Name),
 	}
@@ -188,7 +188,7 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 	if err := checkCounterEQ(s, sql.MetaTxnCommit, 0); err != nil {
 		t.Error(err)
 	}
-	if err := checkCounterEQ(s, sql.MetaInsert, 2); err != nil {
+	if err := checkCounterEQ(s, sql.MetaInsert, 3); err != nil {
 		t.Error(err)
 	}
 }

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -698,7 +698,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.Results("UTC"),
 		},
 		"SHOW USERS": {
-			baseTest,
+			baseTest.Results("root"),
 		},
 		"SELECT (SELECT 1+$1)": {
 			baseTest.SetArgs(1).Results(2),

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -29,7 +29,7 @@ func GetUserHashedPassword(
 	ctx context.Context, executor *Executor, metrics *MemoryMetrics, username string,
 ) (bool, []byte, error) {
 	normalizedUsername := tree.Name(username).Normalize()
-	// The root user is not in system.users.
+	// Always return no password for the root user, even if someone manually inserts one.
 	if normalizedUsername == security.RootUser {
 		return true, nil, nil
 	}


### PR DESCRIPTION
Release Note: none (mostly not a user-visible change unless they really
dig around).

The [rbac RFC](https://github.com/cockroachdb/cockroach/pull/20149) proposes the addition of a fixed `admin` role, with default member `root`.
Membership management becomes a lot simpler if root actually has an entry in the users table.

Root is still special in the sense that:
* it cannot be dropped (already enforced by remaining permissions, but
now with extra check)
* it cannot have a password (`ALTER ... WITH PASSWORD` not allowed, and
password always returned as nil to avoid the "hacky way" of setting it)
