### PR TITLE
storage: improve batching algorithm when sending keys for GC

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -574,7 +574,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 			snap,
 			hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
 			config.GCPolicy{TTLSeconds: 24 * 60 * 60 /* 1 day */},
-			func([]roachpb.GCRequest_GCKey, *storage.GCInfo) error { return nil },
+			func([][]roachpb.GCRequest_GCKey, *storage.GCInfo) error { return nil },
 			func(_ hlc.Timestamp, _ *roachpb.Transaction, _ roachpb.PushTxnType) {},
 			func(_ []roachpb.Intent, _ storage.ResolveOptions) error { return nil },
 			func(_ *roachpb.Transaction, _ []roachpb.Intent) error { return nil },

--- a/pkg/storage/engine/gc.go
+++ b/pkg/storage/engine/gc.go
@@ -39,13 +39,15 @@ func MakeGarbageCollector(now hlc.Timestamp, policy config.GCPolicy) GarbageColl
 	}
 }
 
-// Filter makes decisions about garbage collection based on the garbage
-// collection policy for batches of values for the same key. Returns the
+// Filter makes decisions about garbage collection based on the
+// garbage collection policy for batches of values for the same
+// key. Returns the index of the first key to be GC'd and the
 // timestamp including, and after which, all values should be garbage
-// collected. If no values should be GC'd, returns the zero timestamp. keys
-// must be in descending time order. Values deleted at or before the returned
-// timestamp can be deleted without invalidating any reads in the time
-// interval (gc.expiration, \infinity).
+// collected. If no values should be GC'd, returns -1 for the index
+// and the zero timestamp. keys must be in descending time
+// order. Values deleted at or before the returned timestamp can be
+// deleted without invalidating any reads in the time interval
+// (gc.expiration, \infinity).
 //
 // The GC keeps all values (including deletes) above the expiration time, plus
 // the first value before or at the expiration time. This allows reads to be
@@ -54,22 +56,20 @@ func MakeGarbageCollector(now hlc.Timestamp, policy config.GCPolicy) GarbageColl
 // deleted value is the most recent before expiration, it can be deleted. This
 // would still allow for the tombstone bugs in #6227, so in the future we will
 // add checks that disallow writes before the last GC expiration time.
-func (gc GarbageCollector) Filter(keys []MVCCKey, values [][]byte) hlc.Timestamp {
+func (gc GarbageCollector) Filter(keys []MVCCKey, values [][]byte) (int, hlc.Timestamp) {
 	if gc.policy.TTLSeconds <= 0 {
-		return hlc.Timestamp{}
+		return -1, hlc.Timestamp{}
 	}
 	if len(keys) == 0 {
-		return hlc.Timestamp{}
+		return -1, hlc.Timestamp{}
 	}
 
 	// find the first expired key index using binary search
 	i := sort.Search(len(keys), func(i int) bool { return !gc.Threshold.Less(keys[i].Timestamp) })
 
 	if i == len(keys) {
-		return hlc.Timestamp{}
+		return -1, hlc.Timestamp{}
 	}
-
-	var delTS hlc.Timestamp
 
 	// Now keys[i].Timestamp is <= gc.expiration, but the key-value pair is still
 	// "visible" at timestamp gc.expiration (and up to the next version).
@@ -78,12 +78,12 @@ func (gc GarbageCollector) Filter(keys []MVCCKey, values [][]byte) hlc.Timestamp
 		// the outcome of the read). Note however that we can't touch deletes at
 		// higher timestamps immediately preceding this one, since they're above
 		// gc.expiration and are needed for correctness; see #6227.
-		delTS = keys[i].Timestamp
+		return i, keys[i].Timestamp
 	} else if i+1 < len(keys) {
 		// Otherwise mark the previous timestamp for deletion (since it won't ever
 		// be returned for reads at gc.expiration and up).
-		delTS = keys[i+1].Timestamp
+		return i + 1, keys[i+1].Timestamp
 	}
 
-	return delTS
+	return -1, hlc.Timestamp{}
 }

--- a/pkg/storage/engine/gc_test.go
+++ b/pkg/storage/engine/gc_test.go
@@ -54,31 +54,35 @@ func TestGarbageCollectorFilter(t *testing.T) {
 		time     hlc.Timestamp
 		keys     []MVCCKey
 		values   [][]byte
+		expIdx   int
 		expDelTS hlc.Timestamp
 	}{
-		{gcA, hlc.Timestamp{WallTime: 0, Logical: 0}, aKeys, [][]byte{n, n, n}, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 0, Logical: 0}, aKeys, [][]byte{d, d, d}, hlc.Timestamp{}},
-		{gcB, hlc.Timestamp{WallTime: 0, Logical: 0}, bKeys, [][]byte{n, n}, hlc.Timestamp{}},
-		{gcB, hlc.Timestamp{WallTime: 0, Logical: 0}, bKeys, [][]byte{d, d}, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 1E9, Logical: 0}, aKeys, [][]byte{n, n, n}, hlc.Timestamp{}},
-		{gcB, hlc.Timestamp{WallTime: 1E9, Logical: 0}, bKeys, [][]byte{n, n}, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 2E9, Logical: 0}, aKeys, [][]byte{n, n, n}, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 2E9, Logical: 0}, aKeys, [][]byte{d, d, d}, hlc.Timestamp{WallTime: 1E9, Logical: 0}},
-		{gcB, hlc.Timestamp{WallTime: 2E9, Logical: 0}, bKeys, [][]byte{n, n}, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 3E9, Logical: 0}, aKeys, [][]byte{n, n, n}, hlc.Timestamp{WallTime: 1E9, Logical: 1}},
-		{gcA, hlc.Timestamp{WallTime: 3E9, Logical: 0}, aKeys, [][]byte{d, n, n}, hlc.Timestamp{WallTime: 2E9, Logical: 0}},
-		{gcB, hlc.Timestamp{WallTime: 3E9, Logical: 0}, bKeys, [][]byte{n, n}, hlc.Timestamp{}},
-		{gcA, hlc.Timestamp{WallTime: 4E9, Logical: 0}, aKeys, [][]byte{n, n, n}, hlc.Timestamp{WallTime: 1E9, Logical: 1}},
-		{gcB, hlc.Timestamp{WallTime: 4E9, Logical: 0}, bKeys, [][]byte{n, n}, hlc.Timestamp{WallTime: 1E9, Logical: 0}},
-		{gcB, hlc.Timestamp{WallTime: 4E9, Logical: 0}, bKeys, [][]byte{d, n}, hlc.Timestamp{WallTime: 2E9, Logical: 0}},
-		{gcA, hlc.Timestamp{WallTime: 5E9, Logical: 0}, aKeys, [][]byte{n, n, n}, hlc.Timestamp{WallTime: 1E9, Logical: 1}},
-		{gcB, hlc.Timestamp{WallTime: 5E9, Logical: 0}, bKeys, [][]byte{n, n}, hlc.Timestamp{WallTime: 1E9, Logical: 0}},
-		{gcB, hlc.Timestamp{WallTime: 5E9, Logical: 0}, bKeys, [][]byte{d, n}, hlc.Timestamp{WallTime: 2E9, Logical: 0}},
+		{gcA, hlc.Timestamp{WallTime: 0, Logical: 0}, aKeys, [][]byte{n, n, n}, -1, hlc.Timestamp{}},
+		{gcA, hlc.Timestamp{WallTime: 0, Logical: 0}, aKeys, [][]byte{d, d, d}, -1, hlc.Timestamp{}},
+		{gcB, hlc.Timestamp{WallTime: 0, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
+		{gcB, hlc.Timestamp{WallTime: 0, Logical: 0}, bKeys, [][]byte{d, d}, -1, hlc.Timestamp{}},
+		{gcA, hlc.Timestamp{WallTime: 1E9, Logical: 0}, aKeys, [][]byte{n, n, n}, -1, hlc.Timestamp{}},
+		{gcB, hlc.Timestamp{WallTime: 1E9, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
+		{gcA, hlc.Timestamp{WallTime: 2E9, Logical: 0}, aKeys, [][]byte{n, n, n}, -1, hlc.Timestamp{}},
+		{gcA, hlc.Timestamp{WallTime: 2E9, Logical: 0}, aKeys, [][]byte{d, d, d}, 2, hlc.Timestamp{WallTime: 1E9, Logical: 0}},
+		{gcB, hlc.Timestamp{WallTime: 2E9, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
+		{gcA, hlc.Timestamp{WallTime: 3E9, Logical: 0}, aKeys, [][]byte{n, n, n}, 1, hlc.Timestamp{WallTime: 1E9, Logical: 1}},
+		{gcA, hlc.Timestamp{WallTime: 3E9, Logical: 0}, aKeys, [][]byte{d, n, n}, 0, hlc.Timestamp{WallTime: 2E9, Logical: 0}},
+		{gcB, hlc.Timestamp{WallTime: 3E9, Logical: 0}, bKeys, [][]byte{n, n}, -1, hlc.Timestamp{}},
+		{gcA, hlc.Timestamp{WallTime: 4E9, Logical: 0}, aKeys, [][]byte{n, n, n}, 1, hlc.Timestamp{WallTime: 1E9, Logical: 1}},
+		{gcB, hlc.Timestamp{WallTime: 4E9, Logical: 0}, bKeys, [][]byte{n, n}, 1, hlc.Timestamp{WallTime: 1E9, Logical: 0}},
+		{gcB, hlc.Timestamp{WallTime: 4E9, Logical: 0}, bKeys, [][]byte{d, n}, 0, hlc.Timestamp{WallTime: 2E9, Logical: 0}},
+		{gcA, hlc.Timestamp{WallTime: 5E9, Logical: 0}, aKeys, [][]byte{n, n, n}, 1, hlc.Timestamp{WallTime: 1E9, Logical: 1}},
+		{gcB, hlc.Timestamp{WallTime: 5E9, Logical: 0}, bKeys, [][]byte{n, n}, 1, hlc.Timestamp{WallTime: 1E9, Logical: 0}},
+		{gcB, hlc.Timestamp{WallTime: 5E9, Logical: 0}, bKeys, [][]byte{d, n}, 0, hlc.Timestamp{WallTime: 2E9, Logical: 0}},
 	}
 	for i, test := range testData {
 		test.gc.Threshold = test.time
 		test.gc.Threshold.WallTime -= int64(test.gc.policy.TTLSeconds) * 1E9
-		delTS := test.gc.Filter(test.keys, test.values)
+		idx, delTS := test.gc.Filter(test.keys, test.values)
+		if idx != test.expIdx {
+			t.Errorf("%d: expected index %d; got %d", i, test.expIdx, idx)
+		}
 		if delTS != test.expDelTS {
 			t.Errorf("%d: expected deletion timestamp %s; got %s", i, test.expDelTS, delTS)
 		}

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -76,8 +76,9 @@ const (
 	// that will be created by GC.
 	gcTaskLimit = 25
 
-	// gcChunkKeySize is the default size for GCRequest's batch key size.
-	gcChunkKeySize = 256 * 1000
+	// gcKeyVersionChunkBytes is the threshold size for splitting
+	// GCRequests into multiple batches.
+	gcKeyVersionChunkBytes = 256 * 1000
 )
 
 // gcQueue manages a queue of replicas slated to be scanned in their
@@ -116,7 +117,7 @@ func newGCQueue(store *Store, gossip *gossip.Gossip) *gcQueue {
 	return gcq
 }
 
-type gcFunc func([]roachpb.GCRequest_GCKey, *GCInfo) error
+type gcFunc func([][]roachpb.GCRequest_GCKey, *GCInfo) error
 type pushFunc func(hlc.Timestamp, *roachpb.Transaction, roachpb.PushTxnType)
 type resolveFunc func([]roachpb.Intent, ResolveOptions) error
 type processAsyncFunc func(*roachpb.Transaction, []roachpb.Intent) error
@@ -531,36 +532,28 @@ func (gcq *gcQueue) process(ctx context.Context, repl *Replica, sysCfg config.Sy
 // chunkGCRequest chunks the supplied gcKeys (which are consumed by this method) into
 // multiple batches which must be executed in order by the caller.
 func chunkGCRequest(
-	desc *roachpb.RangeDescriptor, info *GCInfo, gcKeys []roachpb.GCRequest_GCKey,
+	desc *roachpb.RangeDescriptor, info *GCInfo, gcKeys [][]roachpb.GCRequest_GCKey,
 ) []roachpb.GCRequest {
 	var template roachpb.GCRequest
-	var ret []roachpb.GCRequest
 	template.Key = desc.StartKey.AsRawKey()
 	template.EndKey = desc.EndKey.AsRawKey()
+	ret := make([]roachpb.GCRequest, 0, len(gcKeys)+1)
 
 	gc1 := template
 	gc1.Threshold = info.Threshold
 	gc1.TxnSpanGCThreshold = info.TxnSpanGCThreshold
+	// The first request is intentionally kept very small since it
+	// updates the Range-wide GCThresholds, and thus must block all
+	// reads and writes while it is being applied.
 
 	ret = append(ret, gc1)
 
-	size := 0
-	idx := 0
-	for i, key := range gcKeys {
-		size += len(key.Key)
-		if size >= gcChunkKeySize {
-			gc2 := template
-			gc2.Keys = gcKeys[idx : i+1]
-			ret = append(ret, gc2)
-			idx = i + 1
-			size = 0
-		}
+	for _, keys := range gcKeys {
+		gc := template
+		gc.Keys = keys
+		ret = append(ret, gc)
 	}
-	if idx < len(gcKeys) {
-		gc2 := template
-		gc2.Keys = gcKeys[idx:]
-		ret = append(ret, gc2)
-	}
+
 	return ret
 }
 
@@ -578,7 +571,7 @@ func (gcq *gcQueue) processImpl(
 	}
 
 	info, err := RunGC(ctx, desc, snap, now, zone.GC,
-		func(gcKeys []roachpb.GCRequest_GCKey, info *GCInfo) error {
+		func(gcKeys [][]roachpb.GCRequest_GCKey, info *GCInfo) error {
 			// Chunk the keys into multiple GC requests to interleave more
 			// gracefully with other Raft traffic.
 			batches := chunkGCRequest(desc, info, gcKeys)
@@ -778,7 +771,9 @@ func RunGC(
 	infoMu.Threshold = gc.Threshold
 	infoMu.TxnSpanGCThreshold = txnExp
 
-	var gcKeys []roachpb.GCRequest_GCKey
+	var gcKeys [][]roachpb.GCRequest_GCKey
+	var batchGCKeys []roachpb.GCRequest_GCKey
+	var batchGCKeysBytes int64
 	var expBaseKey roachpb.Key
 	var keys []engine.MVCCKey
 	var vals [][]byte
@@ -806,10 +801,12 @@ func RunGC(
 					// expiration threshold.
 					if hlc.Timestamp(meta.Timestamp).Less(intentExp) {
 						txnID := meta.Txn.ID
-						txn := &roachpb.Transaction{
-							TxnMeta: *meta.Txn,
+						if _, ok := txnMap[txnID]; !ok {
+							txnMap[txnID] = &roachpb.Transaction{
+								TxnMeta: *meta.Txn,
+							}
+							infoMu.IntentTxns++
 						}
-						txnMap[txnID] = txn
 						infoMu.IntentsConsidered++
 						intentSpanMap[txnID] = append(intentSpanMap[txnID], roachpb.Span{Key: expBaseKey})
 					}
@@ -817,11 +814,30 @@ func RunGC(
 					startIdx = 2
 				}
 				// See if any values may be GC'd.
-				if gcTS := gc.Filter(keys[startIdx:], vals[startIdx:]); gcTS != (hlc.Timestamp{}) {
-					// TODO(spencer): need to split the requests up into
-					// multiple requests in the event that more than X keys
-					// are added to the request.
-					gcKeys = append(gcKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: gcTS})
+				if idx, gcTS := gc.Filter(keys[startIdx:], vals[startIdx:]); gcTS != (hlc.Timestamp{}) {
+					// Batch keys after the total size of version keys exceeds
+					// the threshold limit. This avoids sending potentially large
+					// GC requests through Raft. Iterate through the keys in reverse
+					// order so that GC requests can be made multiple times even on
+					// a single key, with successively newer timestamps to prevent
+					// any single request from exploding during GC evaluation.
+					for i := len(keys) - 1; i >= startIdx+idx; i-- {
+						batchGCKeysBytes += int64(len(keys[i].Key))
+						// If the current key brings the batch over the target
+						// size, add the current timestamp to finish the current
+						// chunk and start a new one.
+						if batchGCKeysBytes >= gcKeyVersionChunkBytes {
+							batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: keys[i].Timestamp})
+							gcKeys = append(gcKeys, batchGCKeys)
+							batchGCKeys = []roachpb.GCRequest_GCKey{}
+							batchGCKeysBytes = 0
+						}
+					}
+					// Add the key to the batch at the GC timestamp, unless it was already added.
+					if batchGCKeysBytes != 0 {
+						batchGCKeys = append(batchGCKeys, roachpb.GCRequest_GCKey{Key: expBaseKey, Timestamp: gcTS})
+					}
+					infoMu.NumKeysAffected++
 				}
 			}
 		}
@@ -857,9 +873,9 @@ func RunGC(
 	}
 	// Handle last collected set of keys/vals.
 	processKeysAndValues()
-
-	infoMu.IntentTxns = len(txnMap)
-	infoMu.NumKeysAffected = len(gcKeys)
+	if len(batchGCKeys) > 0 {
+		gcKeys = append(gcKeys, batchGCKeys)
+	}
 
 	// Process local range key entries (txn records, queue last processed times).
 	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, txnMap, txnExp, &infoMu, processAsyncFn)
@@ -872,12 +888,17 @@ func RunGC(
 	// hard-coded the full non-local key range in the header, but that does
 	// not take into account the range-local keys. It will be OK as long as
 	// we send directly to the Replica, though.
-	gcKeys = append(gcKeys, localRangeKeys...)
+	if len(localRangeKeys) > 0 {
+		gcKeys = append(gcKeys, localRangeKeys)
+	}
 
 	// Clean up the AbortSpan.
 	log.Event(ctx, "processing AbortSpan")
-	gcKeys = append(gcKeys, processAbortSpan(
-		ctx, snap, desc.RangeID, abortSpanGCThreshold, &infoMu, pushTxnFn)...)
+	abortSpanKeys := processAbortSpan(
+		ctx, snap, desc.RangeID, abortSpanGCThreshold, &infoMu, pushTxnFn)
+	if len(abortSpanKeys) > 0 {
+		gcKeys = append(gcKeys, abortSpanKeys)
+	}
 
 	infoMu.Lock()
 	log.Eventf(ctx, "assembled GC keys, now proceeding to GC; stats so far %+v", infoMu.GCInfo)


### PR DESCRIPTION
Previously the batching algorithm only considered the size of
top-level keys. This used to work well when we were doing
replica-evaluated Raft. With leader-evaluated, keys with many
versions can blow up into massive write batch values which can
end up clogging up Raft, causing performance degradation.

This PR augments the `GC.Filter` method to return the index of
the first version of a key to be GC'ed, allowing us to keep track
of the total number of keys to be GC'd. The GC queue is now able
to send a more appropriate number of keys per batch, which results
in significant improvements in 99th percentile latencies.

This was tested with a modified version of the kv load generator,
set up to write large keys (1024 bytes) with a short cycle length,
creating lots of key versions for GC. A three node local cluster
with the TTL set to 120 seconds could be made to experience up to
6 second 99th %ile latencies after about 10 minutes of running.
With this change, p99 latencies appear stable.

N.B. an alternative to this change was to let each replica handle
GC locally, and change the consistency checker to avoid considering
versions earlier than the GC threshold. However, this ran into
fairly tricky problems around keeping the MVCC stats values correct.

See #20052

Release note: improved p99 latencies for garbage collection of
previous versions of a key, when there are **many** versions.
