### PR TITLE
build/teamcity-stress: ccache builds

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -3,6 +3,9 @@ set -euxo pipefail
 
 export BUILDER_HIDE_GOPATH_SRC=1
 
+source "$(dirname "${0}")/teamcity-support.sh"
+maybe_ccache
+
 mkdir -p artifacts
 
 exit_status=0


### PR DESCRIPTION
Turn on ccache for stress builds, too. Should save some compute
resources. Plus, since this was disabled, the several nightly stress
failures from the morning of Dec. 1 can't be related.