### PR TITLE
storage: move txn intent cleanup out of GC critical path, & GC keys early

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -568,9 +568,17 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	for _, desc := range descs {
 		snap := db.NewSnapshot()
 		defer snap.Close()
-		_, info, err := storage.RunGC(context.Background(), &desc, snap, hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
-			config.GCPolicy{TTLSeconds: 24 * 60 * 60 /* 1 day */}, func(_ hlc.Timestamp, _ *roachpb.Transaction, _ roachpb.PushTxnType) {
-			}, func(_ []roachpb.Intent, _ storage.ResolveOptions) error { return nil })
+		info, err := storage.RunGC(
+			context.Background(),
+			&desc,
+			snap,
+			hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
+			config.GCPolicy{TTLSeconds: 24 * 60 * 60 /* 1 day */},
+			func([]roachpb.GCRequest_GCKey, *storage.GCInfo) error { return nil },
+			func(_ hlc.Timestamp, _ *roachpb.Transaction, _ roachpb.PushTxnType) {},
+			func(_ []roachpb.Intent, _ storage.ResolveOptions) error { return nil },
+			func(_ *roachpb.Transaction, _ []roachpb.Intent) error { return nil },
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/intent_resolver_test.go
+++ b/pkg/storage/intent_resolver_test.go
@@ -49,7 +49,7 @@ func TestPushTransactionsWithNonPendingIntent(t *testing.T) {
 			t.Errorf("expected error on aborted/resolved intent, but got %s", pErr)
 		}
 		if cnt := len(tc.store.intentResolver.mu.inFlight); cnt != 0 {
-			t.Errorf("expected no inflight refcount map entries, found %d", cnt)
+			t.Errorf("expected no inflight push refcount map entries, found %d", cnt)
 		}
 	}
 }


### PR DESCRIPTION
This change first moves the cleanup of potentially "fat" transactions out
of the GC critical path by sending them to the intent resolver's asynchronous
cleanup mechanism. This prevents a txn laden with significant numbers of
unresolved intents from gumming up the GC queue and experiencing context
timeouts.

Moved GC of keys scanned during the GC process to execute before intents
encountered during the scan are processed. This makes progress in the GC
queue more likely and greatly lessens the chance of a stubborn range
entering into an infinite GC loop.

Removed unused code for the `ResolveOptions.Wait` boolean and changed
`intentResolver.resolveIntents` to send batches of 100 serially with a new
timeout for each batch. In concert with this, removed the timeout previously
set in `intentResolver.processIntents`.
    
Release note: improve garbage collection of very large transactions and
large volumes of abandoned writes (intents).