### PR TITLE
storage: fix a bug which failed to resolve all intents after pushing txn

### DIFF
--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -192,7 +192,10 @@ func (ir *intentResolver) maybePushTransactions(
 			cleanupPushIntentsLocked()
 			ir.mu.Unlock()
 			return nil, roachpb.NewErrorf("unexpected %s intent: %+v", intent.Status, intent)
-		} else if _, ok := ir.mu.inFlight[intent.Txn.ID]; ok && skipIfInFlight {
+		}
+		_, alreadyPushing := pushTxns[intent.Txn.ID]
+		_, pushTxnInFlight := ir.mu.inFlight[intent.Txn.ID]
+		if !alreadyPushing && pushTxnInFlight && skipIfInFlight {
 			// Another goroutine is working on this transaction so we can
 			// skip it.
 			if log.V(1) {


### PR DESCRIPTION
This has been in the code a long time. We would ignore all but the first
intent for a transaction being pushed. Note that this wouldn't happen
on a consistent read, only an inconsistent read, so it would be
infrequent in practice.