### PR TITLE
storage: general GC / intent resolution cleanup

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -574,10 +574,9 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 			snap,
 			hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
 			config.GCPolicy{TTLSeconds: 24 * 60 * 60 /* 1 day */},
-			func([][]roachpb.GCRequest_GCKey, *storage.GCInfo) error { return nil },
-			func(_ hlc.Timestamp, _ *roachpb.Transaction, _ roachpb.PushTxnType) {},
-			func(_ []roachpb.Intent, _ storage.ResolveOptions) error { return nil },
-			func(_ *roachpb.Transaction, _ []roachpb.Intent) error { return nil },
+			func(_ context.Context, _ [][]roachpb.GCRequest_GCKey, _ *storage.GCInfo) error { return nil },
+			func(_ context.Context, _ []roachpb.Intent) error { return nil },
+			func(_ context.Context, _ *roachpb.Transaction, _ []roachpb.Intent) error { return nil },
 		)
 		if err != nil {
 			return err

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -27,11 +26,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
-	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -71,10 +68,6 @@ const (
 	// on keys and intents.
 	gcKeyScoreThreshold    = 2
 	gcIntentScoreThreshold = 10
-
-	// gcTaskLimit is the maximum number of concurrent goroutines
-	// that will be created by GC.
-	gcTaskLimit = 25
 
 	// gcKeyVersionChunkBytes is the threshold size for splitting
 	// GCRequests into multiple batches.
@@ -117,10 +110,20 @@ func newGCQueue(store *Store, gossip *gossip.Gossip) *gcQueue {
 	return gcq
 }
 
-type gcFunc func([][]roachpb.GCRequest_GCKey, *GCInfo) error
-type pushFunc func(hlc.Timestamp, *roachpb.Transaction, roachpb.PushTxnType)
-type resolveFunc func([]roachpb.Intent, ResolveOptions) error
-type processAsyncFunc func(*roachpb.Transaction, []roachpb.Intent) error
+// A gcFunc sends the chunks of GCRequests in the order in which they
+// appear. It may but does not have to return on the first error.
+type gcFunc func(context.Context, [][]roachpb.GCRequest_GCKey, *GCInfo) error
+
+// A cleanupIntentsFunc synchronously resolves the supplied intents
+// (which may be PENDING, in which case they are first pushed) while
+// taking care of proper batching.
+type cleanupIntentsFunc func(context.Context, []roachpb.Intent) error
+
+// A cleanupTxnIntentsFunc asynchronously cleans up intents from a
+// transaction record, pushing the transaction first if it is
+// PENDING. Once all intents are resolved successfully, removes the
+// transaction record.
+type cleanupTxnIntentsAsyncFunc func(context.Context, *roachpb.Transaction, []roachpb.Intent) error
 
 // gcQueueScore holds details about the score returned by makeGCQueueScoreImpl for
 // testing and logging. The fields in this struct are documented in
@@ -357,14 +360,12 @@ func makeGCQueueScoreImpl(
 // transaction records, queue last processed timestamps, and range descriptors.
 //
 // - Transaction entries:
-//   - Update txnMap with transactions which are old and in state
-//     PENDING for subsequent PushTxn.
-//   - For transactions in state ABORTED or COMMITTED, schedule the
-//     intents for asynchronous resolution. The actual transaction spans
-//     are not returned for GC in this pass, but are separately GC'ed
-//     after successful resolution of all intents. The exception is if
-//     there are no intents on the txn record, in which case it's returned
-//     for immediate GC.
+//   - For expired transactions , schedule the intents for
+//     asynchronous resolution. The actual transaction spans are not
+//     returned for GC in this pass, but are separately GC'ed after
+//     successful resolution of all intents. The exception is if there
+//     are no intents on the txn record, in which case it's returned for
+//     immediate GC.
 //
 // - Queue last processed times: cleanup any entries which don't match
 //   this range's start key. This can happen on range merges.
@@ -372,10 +373,9 @@ func processLocalKeyRange(
 	ctx context.Context,
 	snap engine.Reader,
 	desc *roachpb.RangeDescriptor,
-	txnMap map[uuid.UUID]*roachpb.Transaction,
 	cutoff hlc.Timestamp,
 	infoMu *lockableGCInfo,
-	processAsyncFn processAsyncFunc,
+	cleanupTxnIntentsAsyncFn cleanupTxnIntentsAsyncFunc,
 ) ([]roachpb.GCRequest_GCKey, error) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
@@ -383,8 +383,10 @@ func processLocalKeyRange(
 	var gcKeys []roachpb.GCRequest_GCKey
 
 	handleTxnIntents := func(key roachpb.Key, txn *roachpb.Transaction) error {
-		if len(txn.Intents) > 0 {
-			return processAsyncFn(txn, roachpb.AsIntents(txn.Intents, txn))
+		// If the transaction needs to be pushed or there are intents to
+		// resolve, invoke the cleanup function.
+		if txn.Status == roachpb.PENDING || len(txn.Intents) > 0 {
+			return cleanupTxnIntentsAsyncFn(ctx, txn, roachpb.AsIntents(txn.Intents, txn))
 		}
 		gcKeys = append(gcKeys, roachpb.GCRequest_GCKey{Key: key}) // zero timestamp
 		return nil
@@ -400,31 +402,18 @@ func processLocalKeyRange(
 			return nil
 		}
 
-		txnID := txn.ID
-
 		// The transaction record should be considered for removal.
 		switch txn.Status {
 		case roachpb.PENDING:
-			// Marked as running, so we need to push it to abort it but won't
-			// try to GC it in this cycle (for convenience).
-			// TODO(tschottdorf): refactor so that we can GC PENDING entries
-			// in the same cycle, but keeping the calls to pushTxn in a central
-			// location (keeping it easy to batch them up in the future).
 			infoMu.TransactionSpanGCPending++
-			txnMap[txnID] = &txn
-			return nil
-
 		case roachpb.ABORTED:
 			infoMu.TransactionSpanGCAborted++
-			return handleTxnIntents(kv.Key, &txn)
-
 		case roachpb.COMMITTED:
 			infoMu.TransactionSpanGCCommitted++
-			return handleTxnIntents(kv.Key, &txn)
-
 		default:
 			panic(fmt.Sprintf("invalid transaction state: %s", txn))
 		}
+		return handleTxnIntents(kv.Key, &txn)
 	}
 
 	handleOneQueueLastProcessed := func(kv roachpb.KeyValue, rangeKey roachpb.RKey) error {
@@ -478,7 +467,6 @@ func processAbortSpan(
 	rangeID roachpb.RangeID,
 	threshold hlc.Timestamp,
 	infoMu *lockableGCInfo,
-	pushTxn pushFunc,
 ) []roachpb.GCRequest_GCKey {
 	var gcKeys []roachpb.GCRequest_GCKey
 	abortSpan := abortspan.New(rangeID)
@@ -571,7 +559,7 @@ func (gcq *gcQueue) processImpl(
 	}
 
 	info, err := RunGC(ctx, desc, snap, now, zone.GC,
-		func(gcKeys [][]roachpb.GCRequest_GCKey, info *GCInfo) error {
+		func(ctx context.Context, gcKeys [][]roachpb.GCRequest_GCKey, info *GCInfo) error {
 			// Chunk the keys into multiple GC requests to interleave more
 			// gracefully with other Raft traffic.
 			batches := chunkGCRequest(desc, info, gcKeys)
@@ -596,30 +584,15 @@ func (gcq *gcQueue) processImpl(
 			}
 			return nil
 		},
-		func(now hlc.Timestamp, txn *roachpb.Transaction, typ roachpb.PushTxnType) {
-			pushTxn(ctx, gcq.store.DB(), now, txn, typ)
-		},
-		func(intents []roachpb.Intent, opts ResolveOptions) error {
-			return repl.store.intentResolver.resolveIntents(ctx, intents, opts)
-		},
-		func(txn *roachpb.Transaction, intents []roachpb.Intent) error {
-			// Synthesize an EndTransaction request in order to send IntentsWithArgs.
-			iwa := result.IntentsWithArg{
-				Arg: &roachpb.EndTransactionRequest{
-					Span:   roachpb.Span{Key: txn.Key},
-					Commit: txn.Status == roachpb.COMMITTED,
-				},
-				Intents: intents,
+		func(ctx context.Context, intents []roachpb.Intent) error {
+			intentCount, err := repl.store.intentResolver.cleanupIntents(ctx, intents, now, roachpb.PUSH_ABORT)
+			if err == nil {
+				gcq.store.metrics.GCResolveSuccess.Inc(int64(intentCount))
 			}
-			// We really do not want to hang up the queue on this kind of
-			// processing, so it's better to just skip txns which we can't
-			// pass to the async processor (allowSyncProcessing=false).
-			// Their intents will get cleaned up on demand, and we'll
-			// eventually get back to them. Not much harm in having old txn
-			// records lying around in the meantime.
-			err := repl.store.intentResolver.processIntentsAsync(
-				ctx, repl, []result.IntentsWithArg{iwa}, false, /* allowSyncProcessing */
-			)
+			return err
+		},
+		func(ctx context.Context, txn *roachpb.Transaction, intents []roachpb.Intent) error {
+			err := repl.store.intentResolver.cleanupTxnIntentsOnGCAsync(ctx, txn, intents, now)
 			if errors.Cause(err) == stop.ErrThrottled {
 				log.Eventf(ctx, "processing txn %s: %s; skipping for future GC", txn.ID.Short(), err)
 				return nil
@@ -669,8 +642,6 @@ type GCInfo struct {
 	// ResolveTotal is the total number of attempted intent resolutions in
 	// this cycle.
 	ResolveTotal int
-	// ResolveErrors is the number of successful intent resolutions.
-	ResolveSuccess int
 	// Threshold is the computed expiration timestamp. Equal to `Now - Policy`.
 	Threshold hlc.Timestamp
 }
@@ -688,7 +659,6 @@ func (info *GCInfo) updateMetrics(metrics *StoreMetrics) {
 	metrics.GCAbortSpanGCNum.Inc(int64(info.AbortSpanGCNum))
 	metrics.GCPushTxn.Inc(int64(info.PushTxn))
 	metrics.GCResolveTotal.Inc(int64(info.ResolveTotal))
-	metrics.GCResolveSuccess.Inc(int64(info.ResolveSuccess))
 }
 
 type lockableGCInfo struct {
@@ -697,11 +667,11 @@ type lockableGCInfo struct {
 }
 
 // RunGC runs garbage collection for the specified descriptor on the
-// provided Engine (which is not mutated). It uses the provided
-// pushTxnFn to clarify the true status of a transaction,
-// resolveIntentsFn to resolve intents synchronously, and
-// processAsyncFn to asynchronously cleanup after encountered
-// transactions.
+// provided Engine (which is not mutated). It uses the provided gcFn
+// to run garbage collection once on all implicated spans,
+// cleanupIntentsFn to resolve intents synchronously, and
+// cleanupTxnIntentsAsyncFn to asynchronously cleanup intents and
+// associated transaction record on success.
 func RunGC(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
@@ -709,9 +679,8 @@ func RunGC(
 	now hlc.Timestamp,
 	policy config.GCPolicy,
 	gcFn gcFunc,
-	pushTxnFn pushFunc,
-	resolveIntentsFn resolveFunc,
-	processAsyncFn processAsyncFunc,
+	cleanupIntentsFn cleanupIntentsFunc,
+	cleanupTxnIntentsAsyncFn cleanupTxnIntentsAsyncFunc,
 ) (GCInfo, error) {
 
 	iter := NewReplicaDataIterator(desc, snap, true /* replicatedOnly */)
@@ -720,45 +689,6 @@ func RunGC(
 	var infoMu = lockableGCInfo{}
 	infoMu.Policy = policy
 	infoMu.Now = now
-
-	{
-		realResolveIntentsFn := resolveIntentsFn
-		resolveIntentsFn = func(intents []roachpb.Intent, opts ResolveOptions) (err error) {
-			defer func() {
-				infoMu.Lock()
-				infoMu.ResolveTotal += len(intents)
-				if err == nil {
-					infoMu.ResolveSuccess += len(intents)
-				}
-				infoMu.Unlock()
-			}()
-			return realResolveIntentsFn(intents, opts)
-		}
-		realProcessAsyncFn := processAsyncFn
-		processAsyncFn = func(txn *roachpb.Transaction, intents []roachpb.Intent) (err error) {
-			defer func() {
-				// Note: infoMu lock is already held.
-				infoMu.ResolveTotal += len(intents)
-				if err == nil {
-					// TODO(spencer): this is only partially correct; what it
-					// provides is a count of the intents for which async
-					// resolution was undertaken, not the count of intents which
-					// were successfully resolved. We need to keep a separate
-					// count of successes / failures for intent resolution in the
-					// intent resolver instead.
-					infoMu.ResolveSuccess += len(intents)
-				}
-			}()
-			return realProcessAsyncFn(txn, intents)
-		}
-		realPushTxnFn := pushTxnFn
-		pushTxnFn = func(ts hlc.Timestamp, txn *roachpb.Transaction, typ roachpb.PushTxnType) {
-			infoMu.Lock()
-			infoMu.PushTxn++
-			infoMu.Unlock()
-			realPushTxnFn(ts, txn, typ)
-		}
-	}
 
 	// Compute intent expiration (intent age at which we attempt to resolve).
 	intentExp := now
@@ -805,7 +735,16 @@ func RunGC(
 							txnMap[txnID] = &roachpb.Transaction{
 								TxnMeta: *meta.Txn,
 							}
+							// IntentTxns and PushTxn will be equal here, since
+							// pushes to transactions whose record lies in this
+							// range (but which are not associated to a remaining
+							// intent on it) happen asynchronously and are accounted
+							// for separately. Thus higher up in the stack, we
+							// expect PushTxn > IntentTxns.
 							infoMu.IntentTxns++
+							// All transactions in txnMap may be PENDING and
+							// cleanupIntentsFn will push them to finalize them.
+							infoMu.PushTxn++
 						}
 						infoMu.IntentsConsidered++
 						intentSpanMap[txnID] = append(intentSpanMap[txnID], roachpb.Span{Key: expBaseKey})
@@ -878,7 +817,7 @@ func RunGC(
 	}
 
 	// Process local range key entries (txn records, queue last processed times).
-	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, txnMap, txnExp, &infoMu, processAsyncFn)
+	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, txnExp, &infoMu, cleanupTxnIntentsAsyncFn)
 	if err != nil {
 		return GCInfo{}, err
 	}
@@ -894,8 +833,7 @@ func RunGC(
 
 	// Clean up the AbortSpan.
 	log.Event(ctx, "processing AbortSpan")
-	abortSpanKeys := processAbortSpan(
-		ctx, snap, desc.RangeID, abortSpanGCThreshold, &infoMu, pushTxnFn)
+	abortSpanKeys := processAbortSpan(ctx, snap, desc.RangeID, abortSpanGCThreshold, &infoMu)
 	if len(abortSpanKeys) > 0 {
 		gcKeys = append(gcKeys, abortSpanKeys)
 	}
@@ -907,61 +845,20 @@ func RunGC(
 	// Process the keys before beginning to push transactions and
 	// resolve intents so that we don't lose all of the work we've done
 	// thus far gathering GC'able keys.
-	if err := gcFn(gcKeys, &infoMu.GCInfo); err != nil {
+	if err := gcFn(ctx, gcKeys, &infoMu.GCInfo); err != nil {
 		return GCInfo{}, err
 	}
 
-	// Process push transactions in parallel. We first push all
-	// transactions before resolving intents. If we have too many
-	// transactions, that can lead to the case in which our context
-	// expires and we can't actually clean up any of the intents. Since
-	// we have hopefully succeeded in pushing a lot of transactions, the
-	// next time around we should have less work here and manage to get
-	// to the intents.
-	log.Eventf(ctx, "pushing up to %d transactions (concurrency %d)", len(txnMap), gcTaskLimit)
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, gcTaskLimit)
-	for _, txn := range txnMap {
-		if txn.Status != roachpb.PENDING {
-			continue
-		}
-		wg.Add(1)
-		sem <- struct{}{}
-		// Avoid passing loop variable into closure.
-		txnCopy := txn
-		go func() {
-			defer func() {
-				<-sem
-				wg.Done()
-			}()
-			if ctx.Err() != nil {
-				return // don't bother if already expired
-			}
-			pushTxnFn(now, txnCopy, roachpb.PUSH_ABORT)
-		}()
-	}
-	wg.Wait()
-
-	if err := ctx.Err(); err != nil {
-		// Don't bother if already expired.
-		return GCInfo{}, err
-	}
-
-	// Resolve all intents. If we have too many intents, that can lead to
-	// the case in which our context expires and we can't finish. However,
-	// because all of these intents fall within a single range, this is
-	// likely to be less problematic than cleaning up a highly distributed
-	// transaction's intents. Because the intent resolution is done in batches
-	// of 100 intents, even if this times out, the next pass will be easier.
+	// Push transactions (if pending) and resolve intents.
 	var intents []roachpb.Intent
 	for txnID, txn := range txnMap {
-		if txn.Status != roachpb.PENDING {
-			intents = append(intents, roachpb.AsIntents(intentSpanMap[txnID], txn)...)
-		}
+		intents = append(intents, roachpb.AsIntents(intentSpanMap[txnID], txn)...)
 	}
-	log.Eventf(ctx, "resolving %d intents", len(intents))
-
-	if err := resolveIntentsFn(intents, ResolveOptions{Wait: true, Poison: false}); err != nil {
+	infoMu.Lock()
+	infoMu.ResolveTotal += len(intents)
+	infoMu.Unlock()
+	log.Eventf(ctx, "cleanup of %d intents", len(intents))
+	if err := cleanupIntentsFn(ctx, intents); err != nil {
 		return GCInfo{}, err
 	}
 
@@ -977,34 +874,4 @@ func (*gcQueue) timer(_ time.Duration) time.Duration {
 // purgatoryChan returns nil.
 func (*gcQueue) purgatoryChan() <-chan struct{} {
 	return nil
-}
-
-// pushTxn attempts to abort the txn via push. The wait group is signaled on
-// completion.
-func pushTxn(
-	ctx context.Context,
-	db *client.DB,
-	now hlc.Timestamp,
-	txn *roachpb.Transaction,
-	typ roachpb.PushTxnType,
-) {
-	// Attempt to push the transaction which created the intent.
-	pushArgs := &roachpb.PushTxnRequest{
-		Span: roachpb.Span{
-			Key: txn.Key,
-		},
-		Now:       now,
-		PusherTxn: roachpb.Transaction{TxnMeta: enginepb.TxnMeta{Priority: math.MaxInt32}},
-		PusheeTxn: txn.TxnMeta,
-		PushType:  typ,
-	}
-	b := &client.Batch{}
-	b.AddRawRequest(pushArgs)
-	if err := db.Run(ctx, b); err != nil {
-		log.Warningf(ctx, "push of txn %s failed: %s", txn, err)
-		return
-	}
-	br := b.RawResponse()
-	// Update the supplied txn on successful push.
-	*txn = br.Responses[0].GetInner().(*roachpb.PushTxnResponse).PusheeTxn
 }

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -512,30 +512,35 @@ func TestGCQueueProcess(t *testing.T) {
 		{key11, ts1},
 	}
 	// Read data directly from engine to avoid intent errors from MVCC.
-	kvs, err := engine.Scan(tc.store.Engine(), engine.MakeMVCCMetadataKey(key1),
-		engine.MakeMVCCMetadataKey(keys.MaxKey), 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for i, kv := range kvs {
-		if log.V(1) {
-			log.Infof(context.Background(), "%d: %s", i, kv.Key)
+	// However, because the GC processing pushes transactions and
+	// resolves intents asynchronously, we use a SucceedsSoon loop.
+	testutils.SucceedsSoon(t, func() error {
+		kvs, err := engine.Scan(tc.store.Engine(), engine.MakeMVCCMetadataKey(key1),
+			engine.MakeMVCCMetadataKey(keys.MaxKey), 0)
+		if err != nil {
+			return err
 		}
-	}
-	if len(kvs) != len(expKVs) {
-		t.Fatalf("expected length %d; got %d", len(expKVs), len(kvs))
-	}
-	for i, kv := range kvs {
-		if !kv.Key.Key.Equal(expKVs[i].key) {
-			t.Errorf("%d: expected key %q; got %q", i, expKVs[i].key, kv.Key.Key)
+		for i, kv := range kvs {
+			if log.V(1) {
+				log.Infof(context.Background(), "%d: %s", i, kv.Key)
+			}
 		}
-		if kv.Key.Timestamp != expKVs[i].ts {
-			t.Errorf("%d: expected ts=%s; got %s", i, expKVs[i].ts, kv.Key.Timestamp)
+		if len(kvs) != len(expKVs) {
+			return fmt.Errorf("expected length %d; got %d", len(expKVs), len(kvs))
 		}
-		if log.V(1) {
-			log.Infof(context.Background(), "%d: %s", i, kv.Key)
+		for i, kv := range kvs {
+			if !kv.Key.Key.Equal(expKVs[i].key) {
+				return fmt.Errorf("%d: expected key %q; got %q", i, expKVs[i].key, kv.Key.Key)
+			}
+			if kv.Key.Timestamp != expKVs[i].ts {
+				return fmt.Errorf("%d: expected ts=%s; got %s", i, expKVs[i].ts, kv.Key.Timestamp)
+			}
+			if log.V(1) {
+				log.Infof(context.Background(), "%d: %s", i, kv.Key)
+			}
 		}
-	}
+		return nil
+	})
 }
 
 func TestGCQueueTransactionTable(t *testing.T) {
@@ -595,13 +600,14 @@ func TestGCQueueTransactionTable(t *testing.T) {
 			newStatus:  roachpb.ABORTED,
 			expAbortGC: true,
 		},
-		// Old, pending and abandoned. Should push and abort it successfully,
-		// but not GC it just yet (this is an artifact of the implementation).
-		// The AbortSpan gets cleaned up though.
+		// Old, pending and abandoned. Should push and abort it
+		// successfully, and GC it, along with resolving the intent. The
+		// AbortSpan is also cleaned up.
 		"c": {
 			status:     roachpb.PENDING,
 			orig:       gcTxnAndAC - 1,
-			newStatus:  roachpb.ABORTED,
+			newStatus:  -1,
+			expResolve: true,
 			expAbortGC: true,
 		},
 		// Old and aborted, should delete.
@@ -796,8 +802,8 @@ func TestGCQueueIntentResolution(t *testing.T) {
 	now := tc.Clock().Now().WallTime
 
 	txns := []*roachpb.Transaction{
-		newTransaction("txn1", roachpb.Key("0-00000"), 1, enginepb.SERIALIZABLE, tc.Clock()),
-		newTransaction("txn2", roachpb.Key("1-00000"), 1, enginepb.SERIALIZABLE, tc.Clock()),
+		newTransaction("txn1", roachpb.Key("0-0"), 1, enginepb.SERIALIZABLE, tc.Clock()),
+		newTransaction("txn2", roachpb.Key("1-0"), 1, enginepb.SERIALIZABLE, tc.Clock()),
 	}
 	intentResolveTS := makeTS(now-intentAgeThreshold.Nanoseconds(), 0)
 	txns[0].OrigTimestamp = intentResolveTS
@@ -808,9 +814,8 @@ func TestGCQueueIntentResolution(t *testing.T) {
 	// Two transactions.
 	for i := 0; i < 2; i++ {
 		// 5 puts per transaction.
-		// TODO(spencerkimball): benchmark with ~50k.
 		for j := 0; j < 5; j++ {
-			pArgs := putArgs(roachpb.Key(fmt.Sprintf("%d-%05d", i, j)), []byte("value"))
+			pArgs := putArgs(roachpb.Key(fmt.Sprintf("%d-%d", i, j)), []byte("value"))
 			if _, err := tc.SendWrappedWith(roachpb.Header{
 				Txn: txns[i],
 			}, &pArgs); err != nil {
@@ -820,34 +825,34 @@ func TestGCQueueIntentResolution(t *testing.T) {
 		}
 	}
 
+	// Process through GC queue.
 	cfg, ok := tc.gossip.GetSystemConfig()
 	if !ok {
 		t.Fatal("config not set")
 	}
-
-	// Process through a scan queue.
 	gcQ := newGCQueue(tc.store, tc.gossip)
 	if err := gcQ.processImpl(context.Background(), tc.repl, cfg, tc.Clock().Now()); err != nil {
 		t.Fatal(err)
 	}
 
 	// Iterate through all values to ensure intents have been fully resolved.
-	meta := &enginepb.MVCCMetadata{}
-	err := tc.store.Engine().Iterate(engine.MakeMVCCMetadataKey(roachpb.KeyMin),
-		engine.MakeMVCCMetadataKey(roachpb.KeyMax), func(kv engine.MVCCKeyValue) (bool, error) {
-			if !kv.Key.IsValue() {
-				if err := protoutil.Unmarshal(kv.Value, meta); err != nil {
-					return false, err
+	// This must be done in a SucceedsSoon loop because intent resolution
+	// is initiated asynchronously from the GC queue.
+	testutils.SucceedsSoon(t, func() error {
+		meta := &enginepb.MVCCMetadata{}
+		return tc.store.Engine().Iterate(engine.MakeMVCCMetadataKey(roachpb.KeyMin),
+			engine.MakeMVCCMetadataKey(roachpb.KeyMax), func(kv engine.MVCCKeyValue) (bool, error) {
+				if !kv.Key.IsValue() {
+					if err := protoutil.Unmarshal(kv.Value, meta); err != nil {
+						return false, err
+					}
+					if meta.Txn != nil {
+						return false, errors.Errorf("non-nil Txn after GC for key %s", kv.Key)
+					}
 				}
-				if meta.Txn != nil {
-					return false, errors.Errorf("non-nil Txn after GC for key %s", kv.Key)
-				}
-			}
-			return false, nil
-		})
-	if err != nil {
-		t.Fatal(err)
-	}
+				return false, nil
+			})
+	})
 }
 
 func TestGCQueueLastProcessedTimestamps(t *testing.T) {

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -16,7 +16,6 @@
 package storage
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -68,7 +68,7 @@ type intentResolver struct {
 	mu struct {
 		syncutil.Mutex
 		// Map from txn ID being pushed to a refcount of intents waiting on the push.
-		inFlight map[uuid.UUID]int
+		inFlightPushes map[uuid.UUID]int
 		// Set of txn IDs whose list of intent spans are being resolved. Note that
 		// this pertains only to EndTransaction-style intent cleanups, whether called
 		// directly after EndTransaction evaluation or during GC of txn spans.
@@ -81,7 +81,7 @@ func newIntentResolver(store *Store, taskLimit int) *intentResolver {
 		store: store,
 		sem:   make(chan struct{}, taskLimit),
 	}
-	ir.mu.inFlight = map[uuid.UUID]int{}
+	ir.mu.inFlightPushes = map[uuid.UUID]int{}
 	ir.mu.inFlightTxnCleanups = map[uuid.UUID]struct{}{}
 	return ir
 }
@@ -106,7 +106,9 @@ func (ir *intentResolver) processWriteIntentError(
 		log.Infof(ctx, "resolving write intent %s", wiErr)
 	}
 
-	resolveIntents, pErr := ir.maybePushTransactions(ctx, wiErr.Intents, h, pushType, false)
+	resolveIntents, pErr := ir.maybePushTransactions(
+		ctx, wiErr.Intents, h, pushType, false, /* skipIfInFlight */
+	)
 	if pErr != nil {
 		return pErr
 	}
@@ -180,9 +182,9 @@ func (ir *intentResolver) maybePushTransactions(
 	var pushIntents []roachpb.Intent
 	cleanupPushIntentsLocked := func() {
 		for _, intent := range pushIntents {
-			ir.mu.inFlight[intent.Txn.ID]--
-			if ir.mu.inFlight[intent.Txn.ID] == 0 {
-				delete(ir.mu.inFlight, intent.Txn.ID)
+			ir.mu.inFlightPushes[intent.Txn.ID]--
+			if ir.mu.inFlightPushes[intent.Txn.ID] == 0 {
+				delete(ir.mu.inFlightPushes, intent.Txn.ID)
 			}
 		}
 	}
@@ -198,7 +200,7 @@ func (ir *intentResolver) maybePushTransactions(
 			return nil, roachpb.NewErrorf("unexpected %s intent: %+v", intent.Status, intent)
 		}
 		_, alreadyPushing := pushTxns[intent.Txn.ID]
-		_, pushTxnInFlight := ir.mu.inFlight[intent.Txn.ID]
+		_, pushTxnInFlight := ir.mu.inFlightPushes[intent.Txn.ID]
 		if !alreadyPushing && pushTxnInFlight && skipIfInFlight {
 			// Another goroutine is working on this transaction so we can
 			// skip it.
@@ -209,12 +211,12 @@ func (ir *intentResolver) maybePushTransactions(
 		} else {
 			pushTxns[intent.Txn.ID] = intent.Txn
 			pushIntents = append(pushIntents, intent)
-			ir.mu.inFlight[intent.Txn.ID]++
+			ir.mu.inFlightPushes[intent.Txn.ID]++
 		}
 	}
 	ir.mu.Unlock()
 	if len(pushIntents) == 0 {
-		return []roachpb.Intent(nil), nil
+		return nil, nil
 	}
 
 	log.Eventf(ctx, "pushing %d transaction(s)", len(pushTxns))
@@ -256,7 +258,7 @@ func (ir *intentResolver) maybePushTransactions(
 	for _, resp := range br.Responses {
 		txn := resp.GetInner().(*roachpb.PushTxnResponse).PusheeTxn
 		if _, ok := pushedTxns[txn.ID]; ok {
-			panic(fmt.Sprintf("have two PushTxn responses for %s", txn.ID))
+			log.Fatalf(ctx, "have two PushTxn responses for %s\nreqs: %+v", txn.ID, pushReqs)
 		}
 		pushedTxns[txn.ID] = txn
 		log.Eventf(ctx, "%s is now %s", txn.ID, txn.Status)
@@ -266,7 +268,7 @@ func (ir *intentResolver) maybePushTransactions(
 	for _, intent := range pushIntents {
 		pushee, ok := pushedTxns[intent.Txn.ID]
 		if !ok {
-			panic(fmt.Sprintf("no PushTxn response for intent %+v", intent))
+			log.Fatalf(ctx, "no PushTxn response for intent %+v\nreqs: %+v", intent, pushReqs)
 		}
 		intent.Txn = pushee.TxnMeta
 		intent.Status = pushee.Status
@@ -296,7 +298,7 @@ func (ir *intentResolver) processIntentsAsync(
 			// If we've successfully launched a background task,
 			// dissociate this work from our caller's context and
 			// timeout.
-			context.Background(),
+			ir.store.AnnotateCtx(context.Background()),
 			"storage.intentResolver: processing intents",
 			ir.sem, false /* wait */, func(ctx context.Context) {
 				ir.processIntents(ctx, r, item, now)
@@ -318,116 +320,207 @@ func (ir *intentResolver) processIntents(
 	ctx context.Context, r *Replica, item result.IntentsWithArg, now hlc.Timestamp,
 ) {
 	if item.Arg.Method() != roachpb.EndTransaction {
-		h := roachpb.Header{Timestamp: now}
-		resolveIntents, pushErr := ir.maybePushTransactions(
-			ctx, item.Intents, h, roachpb.PUSH_TOUCH, true, /* skipInFlight */
-		)
-
-		// resolveIntents with poison=true because we're resolving
-		// intents outside of the context of an EndTransaction.
-		//
-		// Naively, it doesn't seem like we need to poison the abort
-		// cache since we're pushing with PUSH_TOUCH - meaning that
-		// the primary way our Push leads to aborting intents is that
-		// of the transaction having timed out (and thus presumably no
-		// client being around any more, though at the time of writing
-		// we don't guarantee that). But there are other paths in which
-		// the Push comes back successful while the coordinating client
-		// may still be active. Examples of this are when:
-		//
-		// - the transaction was aborted by someone else, but the
-		//   coordinating client may still be running.
-		// - the transaction entry wasn't written yet, which at the
-		//   time of writing has our push abort it, leading to the
-		//   same situation as above.
-		//
-		// Thus, we must poison.
-		if err := ir.resolveIntents(ctx, resolveIntents,
-			ResolveOptions{Wait: true, Poison: true}); err != nil {
-			log.Warningf(ctx, "%s: failed to resolve intents: %s", r, err)
-			return
-		}
-		if pushErr != nil {
-			log.Warningf(ctx, "%s: failed to push during intent resolution: %s", r, pushErr)
-			return
+		if _, err := ir.cleanupIntents(ctx, item.Intents, now, roachpb.PUSH_TOUCH); err != nil {
+			log.Warning(ctx, err)
 		}
 	} else { // EndTransaction
-
-		// Skip processing if we're already in the middle of resolving
-		// this transaction's intents.
-		txn := item.Intents[0].Txn
-		txnKey := keys.TransactionKey(txn.Key, txn.ID)
-		ir.mu.Lock()
-		_, inFlight := ir.mu.inFlightTxnCleanups[txn.ID]
-		if !inFlight {
-			ir.mu.inFlightTxnCleanups[txn.ID] = struct{}{}
-		}
-		ir.mu.Unlock()
-		if inFlight {
-			log.Eventf(ctx, "skipping txn resolved; already in flight")
-			return
-		}
-		defer func() {
-			ir.mu.Lock()
-			delete(ir.mu.inFlightTxnCleanups, txn.ID)
-			ir.mu.Unlock()
-		}()
-
-		// For EndTransaction, we know the transaction is finalized so
-		// we can skip the push and go straight to the resolve.
-		//
-		// This mechanism assumes that when an EndTransaction fails,
-		// the client makes no assumptions about the result. For
-		// example, an attempt to explicitly rollback the transaction
-		// may succeed (triggering this code path), but the result may
-		// not make it back to the client.
-		if err := ir.resolveIntents(ctx, item.Intents,
-			ResolveOptions{Wait: true, Poison: false}); err != nil {
-			log.Warningf(ctx, "%s: failed to resolve intents: %s", r, err)
-			return
-		}
-
-		// We successfully resolved the intents, so we're able to GC from
-		// the txn span directly.
-		b := &client.Batch{}
-
-		// This is pretty tricky. Transaction keys are range-local and
-		// so they are encoded specially. The key range addressed by
-		// (txnKey, txnKey.Next()) might be empty (since Next() does
-		// not imply monotonicity on the address side). Instead, we
-		// send this request to a range determined using the resolved
-		// transaction anchor, i.e. if the txn is anchored on
-		// /Local/RangeDescriptor/"a"/uuid, the key range below would
-		// be ["a", "a\x00"). However, the first range is special again
-		// because the above procedure results in KeyMin, but we need
-		// at least KeyLocalMax.
-		//
-		// #7880 will address this by making GCRequest less special and
-		// thus obviating the need to cook up an artificial range here.
-		var gcArgs roachpb.GCRequest
-		{
-			key := keys.MustAddr(txn.Key)
-			if localMax := keys.MustAddr(keys.LocalMax); key.Less(localMax) {
-				key = localMax
+		if locked, release := ir.lockInFlightTxnCleanup(ctx, item.Intents[0].Txn.ID); locked {
+			defer release()
+			if err := ir.cleanupFinishedTxnIntents(ctx, item.Intents, now); err != nil {
+				log.Warning(ctx, err)
 			}
-			endKey := key.Next()
-
-			gcArgs.Span = roachpb.Span{
-				Key:    key.AsRawKey(),
-				EndKey: endKey.AsRawKey(),
-			}
-		}
-
-		gcArgs.Keys = append(gcArgs.Keys, roachpb.GCRequest_GCKey{
-			Key: txnKey,
-		})
-		b.AddRawRequest(&gcArgs)
-		if err := ir.store.db.Run(ctx, b); err != nil {
-			log.Warningf(ctx, "could not GC completed transaction anchored at %s: %s",
-				roachpb.Key(txn.Key), err)
-			return
 		}
 	}
+}
+
+// lockInFlightTxnCleanup ensures that only a single attempt is being made
+// to cleanup the intents belonging to the specified transaction. Returns
+// whether this attempt to lock succeeded and if so, a function to release
+// the lock, to be invoked subsequently by the caller.
+func (ir *intentResolver) lockInFlightTxnCleanup(
+	ctx context.Context, txnID uuid.UUID,
+) (bool, func()) {
+	ir.mu.Lock()
+	defer ir.mu.Unlock()
+	_, inFlight := ir.mu.inFlightTxnCleanups[txnID]
+	if inFlight {
+		log.Eventf(ctx, "skipping txn resolved; already in flight")
+		return false, nil
+	}
+	ir.mu.inFlightTxnCleanups[txnID] = struct{}{}
+	return true, func() {
+		ir.mu.Lock()
+		delete(ir.mu.inFlightTxnCleanups, txnID)
+		ir.mu.Unlock()
+	}
+}
+
+// cleanupIntents processes a collection of intents by pushing each
+// implicated transaction using the specified pushType. Intents
+// belonging to non-pending transactions after the push are resolved.
+// On success, returns the number of resolved intents. On error, a
+// subset of the intents may have been resolved, but zero will be
+// returned.
+func (ir *intentResolver) cleanupIntents(
+	ctx context.Context, intents []roachpb.Intent, now hlc.Timestamp, pushType roachpb.PushTxnType,
+) (int, error) {
+	h := roachpb.Header{Timestamp: now}
+	resolveIntents, pushErr := ir.maybePushTransactions(
+		ctx, intents, h, pushType, true, /* skipIfInFlight */
+	)
+	if pushErr != nil {
+		return 0, errors.Wrapf(pushErr.GoError(), "failed to push during intent resolution")
+	}
+
+	// resolveIntents with poison=true because we're resolving
+	// intents outside of the context of an EndTransaction.
+	//
+	// Naively, it doesn't seem like we need to poison the abort
+	// cache since we're pushing with PUSH_TOUCH - meaning that
+	// the primary way our Push leads to aborting intents is that
+	// of the transaction having timed out (and thus presumably no
+	// client being around any more, though at the time of writing
+	// we don't guarantee that). But there are other paths in which
+	// the Push comes back successful while the coordinating client
+	// may still be active. Examples of this are when:
+	//
+	// - the transaction was aborted by someone else, but the
+	//   coordinating client may still be running.
+	// - the transaction entry wasn't written yet, which at the
+	//   time of writing has our push abort it, leading to the
+	//   same situation as above.
+	//
+	// Thus, we must poison.
+	if err := ir.resolveIntents(
+		ctx, resolveIntents, ResolveOptions{Wait: true, Poison: true},
+	); err != nil {
+		return 0, errors.Wrapf(err, "failed to resolve intents")
+	}
+	return len(resolveIntents), nil
+}
+
+// cleanupTxnIntentsOnGCAsync cleans up extant intents owned by a
+// single transaction, asynchronously (but returning an error if the
+// intentResolver's semaphore is maxed out). If the transaction is
+// PENDING, but expired, it is pushed first to abort it. This method
+// updates the metrics for intents resolved on GC on success.
+func (ir *intentResolver) cleanupTxnIntentsOnGCAsync(
+	ctx context.Context, txn *roachpb.Transaction, intents []roachpb.Intent, now hlc.Timestamp,
+) error {
+	return ir.store.Stopper().RunLimitedAsyncTask(
+		// If we've successfully launched a background task,
+		// dissociate this work from our caller's context and
+		// timeout.
+		ir.store.AnnotateCtx(context.Background()),
+		"processing txn intents",
+		ir.sem,
+		// We really do not want to hang up the GC queue on this kind of
+		// processing, so it's better to just skip txns which we can't
+		// pass to the async processor (wait=false). Their intents will
+		// get cleaned up on demand, and we'll eventually get back to
+		// them. Not much harm in having old txn records lying around in
+		// the meantime.
+		false, /* wait */
+		func(ctx context.Context) {
+			locked, release := ir.lockInFlightTxnCleanup(ctx, txn.ID)
+			if !locked {
+				return
+			}
+			defer release()
+
+			// If the transaction is still pending, but expired, push it
+			// before resolving the intents.
+			if txn.Status == roachpb.PENDING {
+				if !txnwait.IsExpired(now, txn) {
+					log.ErrEventf(ctx, "cannot push a PENDING transaction which is not expired: %s", txn)
+					return
+				}
+				b := &client.Batch{}
+				b.AddRawRequest(&roachpb.PushTxnRequest{
+					Span: roachpb.Span{Key: txn.Key},
+					PusherTxn: roachpb.Transaction{
+						TxnMeta: enginepb.TxnMeta{Priority: roachpb.MaxTxnPriority},
+					},
+					PusheeTxn: txn.TxnMeta,
+					Now:       now,
+					PushType:  roachpb.PUSH_ABORT,
+				})
+				ir.store.metrics.GCPushTxn.Inc(1)
+				if err := ir.store.DB().Run(ctx, b); err != nil {
+					log.ErrEventf(ctx, "failed to push PENDING, expired txn (%s): %s", txn, err)
+					return
+				}
+				// Get the pushed txn and update the intents slice.
+				txn = &b.RawResponse().Responses[0].GetInner().(*roachpb.PushTxnResponse).PusheeTxn
+				for _, intent := range intents {
+					intent.Txn = txn.TxnMeta
+					intent.Status = txn.Status
+				}
+			}
+
+			if err := ir.cleanupFinishedTxnIntents(ctx, intents, now); err != nil {
+				log.Warningf(ctx, "failed to cleanup transaction intents: %s", err)
+			} else {
+				ir.store.metrics.GCResolveSuccess.Inc(int64(len(intents)))
+			}
+		},
+	)
+}
+
+// cleanupFinishedTxnIntents cleans up extant intents owned by a
+// single transaction and when all intents have been successfully
+// resolved, the transaction record is GC'ed.
+func (ir *intentResolver) cleanupFinishedTxnIntents(
+	ctx context.Context, intents []roachpb.Intent, now hlc.Timestamp,
+) error {
+	// Resolve intents.
+	if err := ir.resolveIntents(ctx, intents, ResolveOptions{Wait: true, Poison: false}); err != nil {
+		return errors.Wrapf(err, "failed to resolve intents")
+	}
+
+	// We successfully resolved the intents, so we're able to GC from
+	// the txn span directly.
+	b := &client.Batch{}
+	txn := intents[0].Txn
+	txnKey := keys.TransactionKey(txn.Key, txn.ID)
+
+	// This is pretty tricky. Transaction keys are range-local and
+	// so they are encoded specially. The key range addressed by
+	// (txnKey, txnKey.Next()) might be empty (since Next() does
+	// not imply monotonicity on the address side). Instead, we
+	// send this request to a range determined using the resolved
+	// transaction anchor, i.e. if the txn is anchored on
+	// /Local/RangeDescriptor/"a"/uuid, the key range below would
+	// be ["a", "a\x00"). However, the first range is special again
+	// because the above procedure results in KeyMin, but we need
+	// at least KeyLocalMax.
+	//
+	// #7880 will address this by making GCRequest less special and
+	// thus obviating the need to cook up an artificial range here.
+	var gcArgs roachpb.GCRequest
+	{
+		key := keys.MustAddr(txn.Key)
+		if localMax := keys.MustAddr(keys.LocalMax); key.Less(localMax) {
+			key = localMax
+		}
+		endKey := key.Next()
+
+		gcArgs.Span = roachpb.Span{
+			Key:    key.AsRawKey(),
+			EndKey: endKey.AsRawKey(),
+		}
+	}
+
+	gcArgs.Keys = append(gcArgs.Keys, roachpb.GCRequest_GCKey{
+		Key: txnKey,
+	})
+	b.AddRawRequest(&gcArgs)
+	if err := ir.store.db.Run(ctx, b); err != nil {
+		return errors.Wrapf(err, "could not GC completed transaction anchored at %s",
+			roachpb.Key(txn.Key))
+	}
+
+	return nil
 }
 
 // ResolveOptions is used during intent resolution. It specifies whether the

--- a/pkg/storage/intent_resolver_test.go
+++ b/pkg/storage/intent_resolver_test.go
@@ -48,8 +48,8 @@ func TestPushTransactionsWithNonPendingIntent(t *testing.T) {
 		); !testutils.IsPError(pErr, "unexpected (ABORTED|COMMITTED) intent") {
 			t.Errorf("expected error on aborted/resolved intent, but got %s", pErr)
 		}
-		if cnt := len(tc.store.intentResolver.mu.inFlight); cnt != 0 {
-			t.Errorf("expected no inflight push refcount map entries, found %d", cnt)
+		if cnt := len(tc.store.intentResolver.mu.inFlightPushes); cnt != 0 {
+			t.Errorf("expected no inflight pushe refcount map entries, found %d", cnt)
 		}
 	}
 }


### PR DESCRIPTION
The goal with this PR is to move the gc queue to use the intent
resolver's machinery entirely. This is accomplished by widening
the `intentResolver` API so that it can be used by `gcQueue`
without having to synthesize an `EndTransaction` request.

Release notes: none.