### PR TITLE
tscache: reduce page size during deadlock testing 

### DIFF
--- a/pkg/build/deadlock_off.go
+++ b/pkg/build/deadlock_off.go
@@ -1,0 +1,21 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+// +build !deadlock
+
+package build
+
+// DeadlockEnabled is true if CockroachDB was built with the deadlock build tag.
+const DeadlockEnabled = false

--- a/pkg/build/deadlock_on.go
+++ b/pkg/build/deadlock_on.go
@@ -1,0 +1,21 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+// +build deadlock
+
+package build
+
+// DeadlockEnabled is true if CockroachDB was built with the deadlock build tag.
+const DeadlockEnabled = true

--- a/pkg/build/race_off.go
+++ b/pkg/build/race_off.go
@@ -13,33 +13,19 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-// +build race
+// +build !race
 
-package util
-
-import "runtime"
+package build
 
 // RaceEnabled is true if CockroachDB was built with the race build tag.
-const RaceEnabled = true
-
-// racePreemptionPoints is set in EnableRacePreemptionPoints.
-var racePreemptionPoints = false
+const RaceEnabled = false
 
 // EnableRacePreemptionPoints enables goroutine preemption points declared with
 // RacePreempt for builds using the race build tag.
-func EnableRacePreemptionPoints() func() {
-	racePreemptionPoints = true
-	return func() {
-		racePreemptionPoints = false
-	}
-}
+func EnableRacePreemptionPoints() func() { return func() {} }
 
 // RacePreempt adds a goroutine preemption point if CockroachDB was built with
 // the race build tag and preemption points have been enabled. The function is a
 // no-op (and should be optimized out through dead code elimination) if the race
 // build tag was not used.
-func RacePreempt() {
-	if racePreemptionPoints {
-		runtime.Gosched()
-	}
-}
+func RacePreempt() {}

--- a/pkg/build/race_on.go
+++ b/pkg/build/race_on.go
@@ -13,19 +13,33 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-// +build !race
+// +build race
 
-package util
+package build
+
+import "runtime"
 
 // RaceEnabled is true if CockroachDB was built with the race build tag.
-const RaceEnabled = false
+const RaceEnabled = true
+
+// racePreemptionPoints is set in EnableRacePreemptionPoints.
+var racePreemptionPoints = false
 
 // EnableRacePreemptionPoints enables goroutine preemption points declared with
 // RacePreempt for builds using the race build tag.
-func EnableRacePreemptionPoints() func() { return func() {} }
+func EnableRacePreemptionPoints() func() {
+	racePreemptionPoints = true
+	return func() {
+		racePreemptionPoints = false
+	}
+}
 
 // RacePreempt adds a goroutine preemption point if CockroachDB was built with
 // the race build tag and preemption points have been enabled. The function is a
 // no-op (and should be optimized out through dead code elimination) if the race
 // build tag was not used.
-func RacePreempt() {}
+func RacePreempt() {
+	if racePreemptionPoints {
+		runtime.Gosched()
+	}
+}

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -34,11 +34,11 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -1743,7 +1743,7 @@ func (r *rocksDBIterator) ComputeStats(
 ) (enginepb.MVCCStats, error) {
 	result := C.MVCCComputeStats(r.iter, goToCKey(start), goToCKey(end), C.int64_t(nowNanos))
 	stats, err := cStatsToGoStats(result, nowNanos)
-	if util.RaceEnabled {
+	if build.RaceEnabled {
 		// If we've come here via rocksDBBatchIterator, then flushMutations
 		// (which forces reseek) was called just before C.MVCCComputeStats. Set
 		// it here as well to match.

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -25,11 +25,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -373,7 +373,7 @@ func TestReadAmplification(t *testing.T) {
 func TestConcurrentBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	if testutils.NightlyStress() || util.RaceEnabled {
+	if testutils.NightlyStress() || build.RaceEnabled {
 		t.Skip()
 	}
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -35,6 +35,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -51,7 +52,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/storage/txnwait"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -4818,7 +4818,7 @@ func (r *Replica) applyRaftCommand(
 	start := timeutil.Now()
 
 	var assertHS *raftpb.HardState
-	if util.RaceEnabled && rResult.Split != nil && r.store.cfg.Settings.Version.IsActive(cluster.VersionSplitHardStateBelowRaft) {
+	if build.RaceEnabled && rResult.Split != nil && r.store.cfg.Settings.Version.IsActive(cluster.VersionSplitHardStateBelowRaft) {
 		rsl := stateloader.Make(r.store.cfg.Settings, rResult.Split.RightDesc.RangeID)
 		oldHS, err := rsl.LoadHardState(ctx, r.store.Engine())
 		if err != nil {
@@ -4989,7 +4989,7 @@ func (r *Replica) evaluateTxnWriteBatch(
 
 		// If all writes occurred at the intended timestamp, we've succeeded on the fast path.
 		batch := r.store.Engine().NewBatch()
-		if util.RaceEnabled && spans != nil {
+		if build.RaceEnabled && spans != nil {
 			batch = spanset.NewBatch(batch, spans)
 		}
 		rec := NewReplicaEvalContext(r, spans)
@@ -5041,7 +5041,7 @@ func (r *Replica) evaluateTxnWriteBatch(
 	}
 
 	batch := r.store.Engine().NewBatch()
-	if util.RaceEnabled && spans != nil {
+	if build.RaceEnabled && spans != nil {
 		batch = spanset.NewBatch(batch, spans)
 	}
 	rec := NewReplicaEvalContext(r, spans)

--- a/pkg/storage/replica_eval_context.go
+++ b/pkg/storage/replica_eval_context.go
@@ -17,9 +17,9 @@ package storage
 import (
 	"golang.org/x/net/context"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
@@ -40,7 +40,7 @@ func NewReplicaEvalContext(r *Replica, ss *spanset.SpanSet) batcheval.EvalContex
 	if ss == nil {
 		log.Fatalf(r.AnnotateCtx(context.Background()), "can't create a ReplicaEvalContext with assertions but no SpanSet")
 	}
-	if util.RaceEnabled {
+	if build.RaceEnabled {
 		return &SpanSetReplicaEvalContext{
 			i:  r,
 			ss: *ss,

--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -27,9 +27,9 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -461,7 +461,7 @@ func TestTimestampCacheEqualTimestamps(t *testing.T) {
 // concurrent load.
 func TestTimestampCacheImplsIdentical(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer util.EnableRacePreemptionPoints()()
+	defer build.EnableRacePreemptionPoints()()
 
 	// Run one subtest using a real clock to generate timestamps and one subtest
 	// using a fake clock to generate timestamps. The former is good for
@@ -487,7 +487,7 @@ func TestTimestampCacheImplsIdentical(t *testing.T) {
 		// random intervals, but verify that the value in their slot always
 		// ratchets.
 		slots := 4 * runtime.NumCPU()
-		if util.RaceEnabled {
+		if build.RaceEnabled {
 			// We add in a lot of preemption points when race detection
 			// is enabled, so things will already be very slow. Reduce
 			// the concurrency to that we don't time out.

--- a/pkg/storage/tscache/interval_skl.go
+++ b/pkg/storage/tscache/interval_skl.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/andy-kimball/arenaskl"
 
-	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -691,7 +691,7 @@ func (p *sklPage) ensureInitialized(it *arenaskl.Iterator, key []byte) error {
 	prevGapVal := p.incomingGapVal(it, key)
 
 	// Make sure we're on the right key again.
-	if util.RaceEnabled && !bytes.Equal(it.Key(), key) {
+	if build.RaceEnabled && !bytes.Equal(it.Key(), key) {
 		panic("no node found")
 	}
 
@@ -705,7 +705,7 @@ func (p *sklPage) ensureInitialized(it *arenaskl.Iterator, key []byte) error {
 // successful (true) or whether it saw an ErrArenaFull while ratcheting (false).
 func (p *sklPage) ensureFloorValue(it *arenaskl.Iterator, to []byte, val cacheValue) bool {
 	for it.Valid() {
-		util.RacePreempt()
+		build.RacePreempt()
 
 		// If "to" is not nil (open range) then it is treated as an exclusive
 		// bound.
@@ -803,7 +803,7 @@ func (p *sklPage) ratchetValueSet(
 	var arr [encodedValSize * 2]byte
 
 	for {
-		util.RacePreempt()
+		build.RacePreempt()
 
 		meta := it.Meta()
 		inited := (meta & initialized) != 0
@@ -987,7 +987,7 @@ func (p *sklPage) scanTo(
 	prevGapVal, maxVal = initGapVal, initGapVal
 	first := true
 	for {
-		util.RacePreempt()
+		build.RacePreempt()
 
 		if !it.Valid() {
 			// No more nodes, which can happen for open ranges.
@@ -1045,7 +1045,7 @@ func (p *sklPage) scanTo(
 // is a no-op.
 func prevInitNode(it *arenaskl.Iterator) {
 	for {
-		util.RacePreempt()
+		build.RacePreempt()
 
 		if !it.Valid() {
 			// No more previous nodes, so use the zero value.

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -898,7 +898,7 @@ func TestIntervalSklMinRetentionWindow(t *testing.T) {
 
 func TestIntervalSklConcurrency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer util.EnableRacePreemptionPoints()()
+	defer build.EnableRacePreemptionPoints()()
 
 	testCases := []struct {
 		name     string
@@ -932,7 +932,7 @@ func TestIntervalSklConcurrency(t *testing.T) {
 				// over random intervals, but verify that the value in their
 				// slot always ratchets.
 				slots := 4 * runtime.NumCPU()
-				if util.RaceEnabled {
+				if build.RaceEnabled {
 					// We add in a lot of preemption points when race detection
 					// is enabled, so things will already be very slow. Reduce
 					// the concurrency to that we don't time out.
@@ -1007,7 +1007,7 @@ func TestIntervalSklConcurrency(t *testing.T) {
 
 func TestIntervalSklConcurrentVsSequential(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer util.EnableRacePreemptionPoints()()
+	defer build.EnableRacePreemptionPoints()()
 
 	// Run one subtest using a real clock to generate timestamps and one subtest
 	// using a fake clock to generate timestamps. The former is good for
@@ -1026,7 +1026,7 @@ func TestIntervalSklConcurrentVsSequential(t *testing.T) {
 		// over random intervals, but verify that the value in their
 		// slot always ratchets.
 		slots := 4 * runtime.NumCPU()
-		if util.RaceEnabled {
+		if build.RaceEnabled {
 			// We add in a lot of preemption points when race detection
 			// is enabled, so things will already be very slow. Reduce
 			// the concurrency to that we don't time out.

--- a/pkg/storage/tscache/skl_impl.go
+++ b/pkg/storage/tscache/skl_impl.go
@@ -48,11 +48,12 @@ func newSklImpl(clock *hlc.Clock, metrics Metrics) *sklImpl {
 // clear clears the cache and resets the low-water mark.
 func (tc *sklImpl) clear(lowWater hlc.Timestamp) {
 	pageSize := uint32(sklPageSize)
-	if build.RaceEnabled {
-		// Race testing consumes significantly more memory that normal testing.
-		// In addition, while running a group of tests in parallel, each will
-		// create a timestamp cache for every Store needed. Reduce the page size
-		// during race testing to accommodate these two factors.
+	if build.RaceEnabled || build.DeadlockEnabled {
+		// Both race testing and deadlock testing consumes significantly more
+		// memory than normal testing. In addition, while running a group of
+		// tests in parallel, each will create a timestamp cache for every Store
+		// needed. Reduce the page size during these kinds of testing to
+		// accommodate these two factors.
 		pageSize /= 4
 	}
 	tc.rCache = newIntervalSkl(tc.clock, MinRetentionWindow, pageSize, tc.metrics.Skl.Read)

--- a/pkg/storage/tscache/skl_impl.go
+++ b/pkg/storage/tscache/skl_impl.go
@@ -15,8 +15,8 @@
 package tscache
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -48,7 +48,7 @@ func newSklImpl(clock *hlc.Clock, metrics Metrics) *sklImpl {
 // clear clears the cache and resets the low-water mark.
 func (tc *sklImpl) clear(lowWater hlc.Timestamp) {
 	pageSize := uint32(sklPageSize)
-	if util.RaceEnabled {
+	if build.RaceEnabled {
 		// Race testing consumes significantly more memory that normal testing.
 		// In addition, while running a group of tests in parallel, each will
 		// create a timestamp cache for every Store needed. Reduce the page size


### PR DESCRIPTION
Closes #20401.

We already reduced the page size of the `sklImpl` timestamp cache during
race testing. We now do it during deadlock testing as well.