### PR TITLE
storage: reduce tscache page size in tests

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 )
 
-// This file implements method receivers for members of server.Context struct
+// This file implements method receivers for members of server.Config struct
 // -- 'Stores' and 'JoinList', which satisfies pflag's value interface
 
 // MinimumStoreSize is the smallest size in bytes that a store can have. This

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -187,6 +187,10 @@ type Config struct {
 	// ReadWithinUncertaintyIntervalError.
 	MaxOffset MaxOffsetType
 
+	// TimestampCachePageSize is the size in bytes of the pages in the
+	// timestamp cache held by each store.
+	TimestampCachePageSize uint32
+
 	// MetricsSampleInterval determines the time between records of
 	// server internal metrics.
 	// Environment Variable: COCKROACH_METRICS_SAMPLE_INTERVAL

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -94,8 +94,6 @@ func createTestNode(
 	)
 	cfg.DB = client.NewDB(sender, cfg.Clock)
 	cfg.Transport = storage.NewDummyRaftTransport(st)
-	cfg.MetricsSampleInterval = metric.TestSampleInterval
-	cfg.HistogramWindowInterval = metric.TestSampleInterval
 	active, renewal := cfg.NodeLivenessDurations()
 	cfg.NodeLiveness = storage.NewNodeLiveness(
 		cfg.AmbientCtx,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -136,7 +136,7 @@ type Server struct {
 	serveMode
 }
 
-// NewServer creates a Server from a server.Context.
+// NewServer creates a Server from a server.Config.
 func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if _, err := net.ResolveTCPAddr("tcp", cfg.AdvertiseAddr); err != nil {
 		return nil, errors.Errorf("unable to resolve RPC address %q: %v", cfg.AdvertiseAddr, err)
@@ -353,6 +353,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		RPCContext:              s.rpcContext,
 		ScanInterval:            s.cfg.ScanInterval,
 		ScanMaxIdleTime:         s.cfg.ScanMaxIdleTime,
+		TimestampCachePageSize:  s.cfg.TimestampCachePageSize,
 		MetricsSampleInterval:   s.cfg.MetricsSampleInterval,
 		HistogramWindowInterval: s.cfg.HistogramWindowInterval(),
 		StorePool:               s.storePool,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -42,6 +42,7 @@ import (
 	migrations "github.com/cockroachdb/cockroach/pkg/sqlmigrations"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/tscache"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -89,6 +90,7 @@ func makeTestConfig(st *cluster.Settings) Config {
 	cfg.HTTPAddr = util.TestAddr.String()
 	// Set standard user for intra-cluster traffic.
 	cfg.User = security.NodeUser
+	cfg.TimestampCachePageSize = tscache.TestSklPageSize
 	cfg.MetricsSampleInterval = metric.TestSampleInterval
 
 	// Enable web session authentication.

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -281,7 +281,7 @@ type ExecutorConfig struct {
 
 	TestingKnobs              *ExecutorTestingKnobs
 	SchemaChangerTestingKnobs *SchemaChangerTestingKnobs
-	// HistogramWindowInterval is (server.Context).HistogramWindowInterval.
+	// HistogramWindowInterval is (server.Config).HistogramWindowInterval.
 	HistogramWindowInterval time.Duration
 
 	// Caches updated by DistSQL.

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -83,12 +83,13 @@ type Cache interface {
 	getLowWater(readCache bool) hlc.Timestamp
 }
 
-// New returns a new timestamp cache with the supplied hybrid clock.
-func New(clock *hlc.Clock, metrics Metrics) Cache {
+// New returns a new timestamp cache with the supplied hybrid clock. If the
+// pageSize is provided, it will override the default page size.
+func New(clock *hlc.Clock, pageSize uint32, metrics Metrics) Cache {
 	if envutil.EnvOrDefaultBool("COCKROACH_USE_TREE_TSCACHE", false) {
 		return newTreeImpl(clock)
 	}
-	return newSklImpl(clock, metrics)
+	return newSklImpl(clock, pageSize, metrics)
 }
 
 // cacheValue combines a timestamp with an optional txnID. It is shared between

--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -38,7 +38,7 @@ import (
 
 var cacheImplConstrs = []func(clock *hlc.Clock) Cache{
 	func(clock *hlc.Clock) Cache { return newTreeImpl(clock) },
-	func(clock *hlc.Clock) Cache { return newSklImpl(clock, MakeMetrics()) },
+	func(clock *hlc.Clock) Cache { return newSklImpl(clock, 0, MakeMetrics()) },
 }
 
 func forEachCacheImpl(
@@ -658,7 +658,7 @@ func identicalAndRatcheted(
 func BenchmarkTimestampCacheInsertion(b *testing.B) {
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
-	tc := New(clock, MakeMetrics())
+	tc := New(clock, 0, MakeMetrics())
 
 	for i := 0; i < b.N; i++ {
 		cdTS := clock.Now()

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/tscache"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -143,6 +144,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 		/* deterministic */ false,
 	)
 	cfg.Transport = transport
+	cfg.TimestampCachePageSize = tscache.TestSklPageSize
 	cfg.MetricsSampleInterval = metric.TestSampleInterval
 	cfg.HistogramWindowInterval = metric.TestSampleInterval
 	ltc.Store = storage.NewStore(cfg, ltc.Eng, nodeDesc)


### PR DESCRIPTION
Fixes  #20401.
Closes #20405.

We were already reducing the page size of the `sklImpl` timestamp cache
during race testing. We now do it during all testing that uses test
configurations.