### PR TITLE
sql: do not recurse the initialization of local execution via Start()

### DIFF
--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -55,7 +55,7 @@ func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (pla
 	return &alterSequenceNode{n: n, seqDesc: seqDesc}, nil
 }
 
-func (n *alterSequenceNode) Start(params runParams) error {
+func (n *alterSequenceNode) startExec(params runParams) error {
 	desc := n.seqDesc
 
 	err := assignSequenceOptions(desc.SequenceOpts, n.n.Options, false /* setDefaults */)

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -59,7 +59,7 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 	return &alterTableNode{n: n, tableDesc: tableDesc}, nil
 }
 
-func (n *alterTableNode) Start(params runParams) error {
+func (n *alterTableNode) startExec(params runParams) error {
 	// Commands can either change the descriptor directly (for
 	// alterations that don't require a backfill) or add a mutation to
 	// the list.

--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -62,7 +62,7 @@ type alterUserSetPasswordRun struct {
 	rowsAffected int
 }
 
-func (n *alterUserSetPasswordNode) Start(params runParams) error {
+func (n *alterUserSetPasswordNode) startExec(params runParams) error {
 	normalizedUsername, hashedPassword, err := n.userAuthInfo.resolve()
 	if err != nil {
 		return err

--- a/pkg/sql/cancel_query.go
+++ b/pkg/sql/cancel_query.go
@@ -49,7 +49,7 @@ func (p *planner) CancelQuery(ctx context.Context, n *tree.CancelQuery) (planNod
 	}, nil
 }
 
-func (n *cancelQueryNode) Start(params runParams) error {
+func (n *cancelQueryNode) startExec(params runParams) error {
 	statusServer := params.p.session.execCfg.StatusServer
 
 	queryIDDatum, err := n.queryID.Eval(params.evalCtx)

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -160,14 +160,15 @@ func (p *planner) validateCheckExpr(
 	if err != nil {
 		return err
 	}
-	if err := p.startPlan(ctx, rows); err != nil {
-		return err
-	}
-	next, err := rows.Next(runParams{
+	params := runParams{
 		ctx:     ctx,
 		evalCtx: &p.evalCtx,
 		p:       p,
-	})
+	}
+	if err := startPlan(params, rows); err != nil {
+		return err
+	}
+	next, err := rows.Next(params)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/control_job.go
+++ b/pkg/sql/control_job.go
@@ -89,7 +89,7 @@ func (p *planner) CancelJob(ctx context.Context, n *tree.CancelJob) (planNode, e
 	}, nil
 }
 
-func (n *controlJobNode) Start(params runParams) error {
+func (n *controlJobNode) startExec(params runParams) error {
 	jobIDDatum, err := n.jobID.Eval(params.evalCtx)
 	if err != nil {
 		return err

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -80,8 +80,7 @@ func (p *planner) Copy(ctx context.Context, n *tree.CopyFrom) (planNode, error) 
 	return cn, nil
 }
 
-// Start implements the planNode interface.
-func (n *copyNode) Start(params runParams) error {
+func (n *copyNode) startExec(params runParams) error {
 	// Should never happen because the executor prevents non-COPY messages during
 	// a COPY.
 	if params.p.session.copyFrom != nil {

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -73,7 +73,7 @@ func (p *planner) CreateDatabase(n *tree.CreateDatabase) (planNode, error) {
 	return &createDatabaseNode{n: n}, nil
 }
 
-func (n *createDatabaseNode) Start(params runParams) error {
+func (n *createDatabaseNode) startExec(params runParams) error {
 	desc := makeDatabaseDesc(n.n)
 
 	created, err := params.p.createDatabase(params.ctx, &desc, n.n.IfNotExists)

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -51,7 +51,7 @@ func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNod
 	return &createIndexNode{tableDesc: tableDesc, n: n}, nil
 }
 
-func (n *createIndexNode) Start(params runParams) error {
+func (n *createIndexNode) startExec(params runParams) error {
 	_, dropped, err := n.tableDesc.FindIndexByName(string(n.n.Name))
 	if err == nil {
 		if dropped {

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -50,7 +50,7 @@ func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (p
 	}, nil
 }
 
-func (n *createSequenceNode) Start(params runParams) error {
+func (n *createSequenceNode) startExec(params runParams) error {
 	seqName := n.n.Name.TableName().Table()
 	tKey := tableKey{parentID: n.dbDesc.ID, name: seqName}
 	key := tKey.Key()

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -67,10 +67,6 @@ func (p *planner) CreateStatistics(ctx context.Context, n *tree.CreateStats) (pl
 	}, nil
 }
 
-func (*createStatsNode) Start(runParams) error {
-	return errors.Errorf("statistics can only be created via DistSQL")
-}
-
 func (*createStatsNode) Next(runParams) (bool, error) { panic("not implemented") }
 func (*createStatsNode) Close(context.Context)        {}
 func (*createStatsNode) Values() tree.Datums          { panic("not implemented") }

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -215,7 +215,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		if err != nil {
 			return err
 		}
-		if err = params.p.startPlan(params.ctx, insertPlan); err != nil {
+		if err = startPlan(params, insertPlan); err != nil {
 			return err
 		}
 		// This driver function call is done here instead of in the Next

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -102,7 +102,7 @@ type createTableRun struct {
 	rowsAffected int
 }
 
-func (n *createTableNode) Start(params runParams) error {
+func (n *createTableNode) startExec(params runParams) error {
 	tKey := tableKey{parentID: n.dbDesc.ID, name: n.n.Table.TableName().Table()}
 	key := tKey.Key()
 	if exists, err := descExists(params.ctx, params.p.txn, key); err == nil && exists {

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -58,7 +58,7 @@ func (p *planner) CreateUser(ctx context.Context, n *tree.CreateUser) (planNode,
 	}, nil
 }
 
-func (n *createUserNode) Start(params runParams) error {
+func (n *createUserNode) startExec(params runParams) error {
 	normalizedUsername, hashedPassword, err := n.userAuthInfo.resolve()
 	if err != nil {
 		return err

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -112,7 +112,7 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 	}, nil
 }
 
-func (n *createViewNode) Start(params runParams) error {
+func (n *createViewNode) startExec(params runParams) error {
 	viewName := n.n.Name.TableName().Table()
 	tKey := tableKey{parentID: n.dbDesc.ID, name: viewName}
 	key := tKey.Key()

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -33,7 +33,6 @@ type delayedNode struct {
 
 type nodeConstructor func(context.Context, *planner) (planNode, error)
 
-func (d *delayedNode) Start(params runParams) error        { return d.plan.Start(params) }
 func (d *delayedNode) Next(params runParams) (bool, error) { return d.plan.Next(params) }
 func (d *delayedNode) Values() tree.Datums                 { return d.plan.Values() }
 

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -118,11 +118,10 @@ type deleteRun struct {
 	fastPath bool
 }
 
-func (d *deleteNode) Start(params runParams) error {
+func (d *deleteNode) startExec(params runParams) error {
 	if err := d.run.startEditNode(params, &d.editNodeBase); err != nil {
 		return err
 	}
-
 	// Check if we can avoid doing a round-trip to read the values and just
 	// "fast-path" skip to deleting the key ranges without reading them first.
 	// TODO(dt): We could probably be smarter when presented with an index-join,

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -54,11 +54,11 @@ type distinctRun struct {
 	suffixMemAcc mon.BoundAccount
 }
 
-func (n *distinctNode) Start(params runParams) error {
+func (n *distinctNode) startExec(params runParams) error {
 	n.run.prefixMemAcc = params.p.session.TxnState.mon.MakeBoundAccount()
 	n.run.suffixMemAcc = params.p.session.TxnState.mon.MakeBoundAccount()
 	n.run.suffixSeen = make(map[string]struct{})
-	return n.plan.Start(params)
+	return nil
 }
 
 func (n *distinctNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1869,7 +1869,7 @@ func (dsp *DistSQLPlanner) createPlanForValues(
 		evalCtx: planCtx.evalCtx,
 		p:       nil,
 	}
-	if err := n.Start(params); err != nil {
+	if err := n.startExec(params); err != nil {
 		return physicalPlan{}, err
 	}
 	defer n.Close(planCtx.ctx)

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -114,7 +114,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 	return &dropDatabaseNode{n: n, dbDesc: dbDesc, td: td}, nil
 }
 
-func (n *dropDatabaseNode) Start(params runParams) error {
+func (n *dropDatabaseNode) startExec(params runParams) error {
 	ctx := params.ctx
 	p := params.p
 	tbNameStrings := make([]string, 0, len(n.td))

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -67,7 +67,7 @@ func (p *planner) DropIndex(ctx context.Context, n *tree.DropIndex) (planNode, e
 	return &dropIndexNode{n: n, idxNames: idxNames}, nil
 }
 
-func (n *dropIndexNode) Start(params runParams) error {
+func (n *dropIndexNode) startExec(params runParams) error {
 	ctx := params.ctx
 	for _, index := range n.idxNames {
 		// Need to retrieve the descriptor again for each index name in

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -66,7 +66,7 @@ func (p *planner) DropSequence(ctx context.Context, n *tree.DropSequence) (planN
 	}, nil
 }
 
-func (n *dropSequenceNode) Start(params runParams) error {
+func (n *dropSequenceNode) startExec(params runParams) error {
 	ctx := params.ctx
 	for _, droppedDesc := range n.td {
 		if droppedDesc == nil {

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -101,7 +101,7 @@ func (p *planner) DropTable(ctx context.Context, n *tree.DropTable) (planNode, e
 	return &dropTableNode{n: n, td: td}, nil
 }
 
-func (n *dropTableNode) Start(params runParams) error {
+func (n *dropTableNode) startExec(params runParams) error {
 	ctx := params.ctx
 	for _, droppedDesc := range n.td {
 		if droppedDesc == nil {

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -64,7 +64,7 @@ type dropUserRun struct {
 	numDeleted int
 }
 
-func (n *dropUserNode) Start(params runParams) error {
+func (n *dropUserNode) startExec(params runParams) error {
 	names, err := n.names()
 	if err != nil {
 		return err

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -87,7 +87,7 @@ func (p *planner) DropView(ctx context.Context, n *tree.DropView) (planNode, err
 	return &dropViewNode{n: n, td: td}, nil
 }
 
-func (n *dropViewNode) Start(params runParams) error {
+func (n *dropViewNode) startExec(params runParams) error {
 	ctx := params.ctx
 	for _, droppedDesc := range n.td {
 		if droppedDesc == nil {

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -2001,14 +2001,14 @@ func (e *Executor) execClassic(
 	planner.evalCtx.ActiveMemAcc = &rowAcc
 	defer rowAcc.Close(ctx)
 
-	if err := planner.startPlan(ctx, plan); err != nil {
-		return err
-	}
-
 	params := runParams{
 		ctx:     ctx,
 		evalCtx: &planner.evalCtx,
 		p:       planner,
+	}
+
+	if err := startPlan(params, plan); err != nil {
+		return err
 	}
 
 	switch rowResultWriter.StatementType() {

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -42,7 +42,7 @@ type explainDistSQLRun struct {
 	done bool
 }
 
-func (n *explainDistSQLNode) Start(params runParams) error {
+func (n *explainDistSQLNode) startExec(params runParams) error {
 	// Trigger limit propagation.
 	params.p.setUnlimited(n.plan)
 

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -93,10 +93,7 @@ type explainPlanRun struct {
 	results *valuesNode
 }
 
-func (e *explainPlanNode) Start(params runParams) error {
-	// Note that we don't call start on e.plan. That's on purpose, Start() can
-	// have side effects. And it's supposed to not be needed for the way in which
-	// we're going to use e.plan.
+func (e *explainPlanNode) startExec(params runParams) error {
 	return params.p.populateExplain(params.ctx, &e.explainer, e.run.results, e.plan)
 }
 

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -238,7 +238,7 @@ func (e *explainer) expr(nodeName, fieldName string, n int, expr tree.Expr) {
 }
 
 // enterNode implements the planObserver interface.
-func (e *explainer) enterNode(_ context.Context, name string, plan planNode) bool {
+func (e *explainer) enterNode(_ context.Context, name string, plan planNode) (bool, error) {
 	desc := ""
 	if e.doIndent {
 		desc = fmt.Sprintf("%*s-> %s", e.level*3, " ", name)
@@ -246,7 +246,7 @@ func (e *explainer) enterNode(_ context.Context, name string, plan planNode) boo
 	e.makeRow(e.level, name, "", desc, plan)
 
 	e.level++
-	return true
+	return true, nil
 }
 
 // attr implements the planObserver interface.
@@ -258,8 +258,9 @@ func (e *explainer) attr(nodeName, fieldName, attr string) {
 }
 
 // leaveNode implements the planObserver interface.
-func (e *explainer) leaveNode(name string) {
+func (e *explainer) leaveNode(name string, _ planNode) error {
 	e.level--
+	return nil
 }
 
 // formatColumns converts a column signature for a data source /

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -50,11 +50,6 @@ func (f *filterNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	return f.source.info.NodeFormatter(idx)
 }
 
-// Start implements the planNode interface.
-func (f *filterNode) Start(params runParams) error {
-	return f.source.plan.Start(params)
-}
-
 // Next implements the planNode interface.
 func (f *filterNode) Next(params runParams) (bool, error) {
 	for {

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -342,10 +342,6 @@ type groupRun struct {
 	gotOneRow bool
 }
 
-func (n *groupNode) Start(params runParams) error {
-	return n.plan.Start(params)
-}
-
 func (n *groupNode) Next(params runParams) (bool, error) {
 	var scratch []byte
 	// We're going to consume n.plan until it's exhausted (feeding all the rows to

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -209,13 +209,6 @@ type indexJoinRun struct {
 	colIDtoRowIndex map[sqlbase.ColumnID]int
 }
 
-func (n *indexJoinNode) Start(params runParams) error {
-	if err := n.table.Start(params); err != nil {
-		return err
-	}
-	return n.index.Start(params)
-}
-
 const indexJoinBatchSize = 100
 
 func (n *indexJoinNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -279,7 +279,7 @@ type insertRun struct {
 	rowsUpserted  *sqlbase.RowContainer
 }
 
-func (n *insertNode) Start(params runParams) error {
+func (n *insertNode) startExec(params runParams) error {
 	// Prepare structures for building values to pass to rh.
 	// TODO(couchand): Delete this, use tablewriter interface.
 	if n.rh.exprs != nil {

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -362,15 +362,7 @@ type joinRun struct {
 	finishedOutput bool
 }
 
-// Start implements the planNode interface.
-func (n *joinNode) Start(params runParams) error {
-	if err := n.left.plan.Start(params); err != nil {
-		return err
-	}
-	if err := n.right.plan.Start(params); err != nil {
-		return err
-	}
-
+func (n *joinNode) startExec(params runParams) error {
 	if err := n.hashJoinStart(params); err != nil {
 		return err
 	}

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -78,11 +78,7 @@ type limitRun struct {
 	rowIndex int64
 }
 
-func (n *limitNode) Start(params runParams) error {
-	if err := n.plan.Start(params); err != nil {
-		return err
-	}
-
+func (n *limitNode) startExec(params runParams) error {
 	return n.evalLimit(params.evalCtx)
 }
 

--- a/pkg/sql/optimize.go
+++ b/pkg/sql/optimize.go
@@ -103,6 +103,6 @@ func (i *subqueryInitializer) subqueryNode(ctx context.Context, sq *subquery) er
 	return nil
 }
 
-func (i *subqueryInitializer) enterNode(_ context.Context, _ string, _ planNode) bool {
-	return true
+func (i *subqueryInitializer) enterNode(_ context.Context, _ string, _ planNode) (bool, error) {
+	return true, nil
 }

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -93,8 +93,6 @@ type ordinalityRun struct {
 	curCnt int64
 }
 
-func (o *ordinalityNode) Start(params runParams) error { return o.source.Start(params) }
-
 func (o *ordinalityNode) Next(params runParams) (bool, error) {
 	hasNext, err := o.source.Next(params)
 	if !hasNext || err != nil {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -223,17 +223,12 @@ func (p *planner) makePlan(ctx context.Context, stmt Statement) (planNode, error
 }
 
 // startPlan starts the plan and all its sub-query nodes.
-func (p *planner) startPlan(ctx context.Context, plan planNode) error {
-	params := runParams{
-		ctx:     ctx,
-		evalCtx: &p.evalCtx,
-		p:       p,
-	}
+func startPlan(params runParams, plan planNode) error {
 	if err := startExec(params, plan); err != nil {
 		return err
 	}
 	// Trigger limit propagation through the plan and sub-queries.
-	p.setUnlimited(plan)
+	params.p.setUnlimited(plan)
 	return nil
 }
 

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -154,7 +154,7 @@ func insertNodeWithValuesSpans(
 	defer rowAcc.Close(params.ctx)
 
 	defer v.Reset(params.ctx)
-	if err = v.Start(params); err != nil {
+	if err = v.startExec(params); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -81,7 +81,7 @@ type hookFnRun struct {
 	row tree.Datums
 }
 
-func (f *hookFnNode) Start(params runParams) error {
+func (f *hookFnNode) startExec(params runParams) error {
 	// TODO(dan): Make sure the resultCollector is set to flush after every row.
 	f.run.resultsCh = make(chan tree.Datums)
 	f.run.errCh = make(chan error)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -120,7 +120,6 @@ type planner struct {
 	parser                parser.Parser
 	txCtx                 transform.ExprTransformContext
 	subqueryVisitor       subqueryVisitor
-	subqueryPlanVisitor   subqueryPlanVisitor
 	nameResolutionVisitor nameResolutionVisitor
 	srfExtractionVisitor  srfExtractionVisitor
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -299,13 +299,14 @@ func (p *planner) queryRows(
 		return nil, err
 	}
 	defer plan.Close(ctx)
-	if err := p.startPlan(ctx, plan); err != nil {
-		return nil, err
-	}
+
 	params := runParams{
 		ctx:     ctx,
 		evalCtx: &p.evalCtx,
 		p:       p,
+	}
+	if err := startPlan(params, plan); err != nil {
+		return nil, err
 	}
 	var rows []tree.Datums
 	if err = forEachRow(params, plan, func(values tree.Datums) error {
@@ -330,13 +331,14 @@ func (p *planner) exec(ctx context.Context, sql string, args ...interface{}) (in
 		return 0, err
 	}
 	defer plan.Close(ctx)
-	if err := p.startPlan(ctx, plan); err != nil {
-		return 0, err
-	}
+
 	params := runParams{
 		ctx:     ctx,
 		evalCtx: &p.evalCtx,
 		p:       p,
+	}
+	if err := startPlan(params, plan); err != nil {
+		return 0, err
 	}
 	return countRowsAffected(params, plan)
 }

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -275,8 +275,6 @@ type renderRun struct {
 	row tree.Datums
 }
 
-func (r *renderNode) Start(params runParams) error { return r.source.plan.Start(params) }
-
 func (r *renderNode) Next(params runParams) (bool, error) {
 	if next, err := r.source.plan.Next(params); !next {
 		return false, err

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -149,7 +149,7 @@ type scanRun struct {
 	fetcher sqlbase.MultiRowFetcher
 }
 
-func (n *scanNode) Start(params runParams) error {
+func (n *scanNode) startExec(params runParams) error {
 	tableArgs := sqlbase.MultiRowFetcherTableArgs{
 		Desc:             n.desc,
 		Index:            n.index,

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -126,7 +126,7 @@ type scatterRun struct {
 	ranges   []roachpb.AdminScatterResponse_Range
 }
 
-func (n *scatterNode) Start(params runParams) error {
+func (n *scatterNode) startExec(params runParams) error {
 	db := params.p.ExecCfg().DB
 	req := &roachpb.AdminScatterRequest{
 		Span: roachpb.Span{Key: n.run.span.Key, EndKey: n.run.span.EndKey},

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -57,14 +57,14 @@ type checkOperation interface {
 
 	// Start initializes the check. In many cases, this does the bulk of
 	// the work behind a check.
-	Start(context.Context, *planner) error
+	Start(params runParams) error
 
 	// Next will return the next check result. The datums returned have
 	// the column types specified by scrubTypes, which are the valeus
 	// returned to the user.
 	//
 	// Next is not called if Done() is false.
-	Next(context.Context, *planner) (tree.Datums, error)
+	Next(params runParams) (tree.Datums, error)
 
 	// Done indicates when there are no more results to iterate through.
 	Done(context.Context) bool
@@ -134,7 +134,7 @@ func (n *scrubNode) Next(params runParams) (bool, error) {
 	for len(n.run.checkQueue) > 0 {
 		nextCheck := n.run.checkQueue[0]
 		if !nextCheck.Started() {
-			if err := nextCheck.Start(params.ctx, params.p); err != nil {
+			if err := nextCheck.Start(params); err != nil {
 				return false, err
 			}
 		}
@@ -143,7 +143,7 @@ func (n *scrubNode) Next(params runParams) (bool, error) {
 		// happens if there are no more results to report.
 		if !nextCheck.Done(params.ctx) {
 			var err error
-			n.run.row, err = nextCheck.Next(params.ctx, params.p)
+			n.run.row, err = nextCheck.Next(params)
 			if err != nil {
 				return false, err
 			}
@@ -374,7 +374,9 @@ func newIndexCheckOperation(
 
 // Start will plan and run an index check using the distSQL execution
 // engine.
-func (o *indexCheckOperation) Start(ctx context.Context, p *planner) error {
+func (o *indexCheckOperation) Start(params runParams) error {
+	ctx := params.ctx
+
 	columns, columnNames, columnTypes := getColumns(o.tableDesc, o.indexDesc)
 
 	// Because the row results include both primary key data and secondary
@@ -389,7 +391,7 @@ func (o *indexCheckOperation) Start(ctx context.Context, p *planner) error {
 	}
 
 	checkQuery := createIndexCheckQuery(columnNames, o.tableDesc, o.tableName, o.indexDesc)
-	plan, err := p.delegateQuery(ctx, "SCRUB TABLE ... WITH OPTIONS INDEX", checkQuery, nil, nil)
+	plan, err := params.p.delegateQuery(ctx, "SCRUB TABLE ... WITH OPTIONS INDEX", checkQuery, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -404,15 +406,15 @@ func (o *indexCheckOperation) Start(ctx context.Context, p *planner) error {
 
 	// Optimize the plan. This is required in order to populate scanNode
 	// spans.
-	plan, err = p.optimizePlan(ctx, plan, needed)
+	plan, err = params.p.optimizePlan(ctx, plan, needed)
 	if err != nil {
 		plan.Close(ctx)
 		return err
 	}
 	defer plan.Close(ctx)
 
-	planCtx := p.session.distSQLPlanner.newPlanningCtx(ctx, &p.evalCtx, p.txn)
-	physPlan, err := scrubPlanDistSQL(ctx, &planCtx, p, plan)
+	planCtx := params.p.session.distSQLPlanner.newPlanningCtx(ctx, params.evalCtx, params.p.txn)
+	physPlan, err := scrubPlanDistSQL(ctx, &planCtx, params.p, plan)
 	if err != nil {
 		return err
 	}
@@ -433,7 +435,7 @@ func (o *indexCheckOperation) Start(ctx context.Context, p *planner) error {
 		return errors.Errorf("could not find MergeJoinerSpec in plan")
 	}
 
-	rows, err := scrubRunDistSQL(ctx, &planCtx, p, physPlan, columnTypes)
+	rows, err := scrubRunDistSQL(ctx, &planCtx, params.p, physPlan, columnTypes)
 	if err != nil {
 		rows.Close(ctx)
 		return err
@@ -450,7 +452,7 @@ func (o *indexCheckOperation) Start(ctx context.Context, p *planner) error {
 }
 
 // Next implements the checkOperation interface.
-func (o *indexCheckOperation) Next(ctx context.Context, p *planner) (tree.Datums, error) {
+func (o *indexCheckOperation) Next(params runParams) (tree.Datums, error) {
 	row := o.run.rows.At(o.run.rowIndex)
 	o.run.rowIndex++
 
@@ -482,7 +484,7 @@ func (o *indexCheckOperation) Next(ctx context.Context, p *planner) (tree.Datums
 	}
 	primaryKey := tree.NewDString(primaryKeyDatums.String())
 	timestamp := tree.MakeDTimestamp(
-		p.evalCtx.GetStmtTimestamp(), time.Nanosecond)
+		params.p.evalCtx.GetStmtTimestamp(), time.Nanosecond)
 
 	details := make(map[string]interface{})
 	rowDetails := make(map[string]interface{})

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -99,7 +99,7 @@ type scrubRun struct {
 	row        tree.Datums
 }
 
-func (n *scrubNode) Start(params runParams) error {
+func (n *scrubNode) startExec(params runParams) error {
 	switch n.n.Typ {
 	case tree.ScrubTable:
 		tableName, err := n.n.Table.NormalizeWithDatabaseName(params.p.session.Database)

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -96,7 +96,7 @@ func (p *planner) SetClusterSetting(
 	return &setClusterSettingNode{name: name, st: st, setting: setting, value: value}, nil
 }
 
-func (n *setClusterSettingNode) Start(params runParams) error {
+func (n *setClusterSettingNode) startExec(params runParams) error {
 	ie := InternalExecutor{LeaseManager: params.p.LeaseMgr()}
 
 	var reportedValue string

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -97,7 +97,7 @@ func (p *planner) SetVar(ctx context.Context, n *tree.SetVar) (planNode, error) 
 	return &setVarNode{v: v, typedValues: typedValues}, nil
 }
 
-func (n *setVarNode) Start(params runParams) error {
+func (n *setVarNode) startExec(params runParams) error {
 	if n.typedValues != nil {
 		for i, v := range n.typedValues {
 			d, err := v.Eval(params.evalCtx)

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -54,7 +54,7 @@ type setZoneConfigRun struct {
 	numAffected int
 }
 
-func (n *setZoneConfigNode) Start(params runParams) error {
+func (n *setZoneConfigNode) startExec(params runParams) error {
 	var yamlConfig *string
 	datum, err := n.yamlConfig.Eval(params.evalCtx)
 	if err != nil {

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -89,7 +89,7 @@ type showFingerprintsRun struct {
 	values []tree.Datum
 }
 
-func (n *showFingerprintsNode) Start(params runParams) error {
+func (n *showFingerprintsNode) startExec(params runParams) error {
 	n.run.values = []tree.Datum{tree.DNull, tree.DNull}
 	return nil
 }

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -104,7 +104,7 @@ type showRangesRun struct {
 	values []tree.Datum
 }
 
-func (n *showRangesNode) Start(params runParams) error {
+func (n *showRangesNode) startExec(params runParams) error {
 	var err error
 	n.valDirs = sqlbase.IndexKeyValDirs(n.index)
 	n.run.descriptorKVs, err = scanMetaKVs(params.ctx, params.p.txn, n.span)

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -195,7 +195,7 @@ type traceRun struct {
 	stopTracing func() error
 }
 
-func (n *showTraceNode) Start(params runParams) error {
+func (n *showTraceNode) startExec(params runParams) error {
 	if params.p.session.Tracing.Enabled() {
 		return errTracingAlreadyEnabled
 	}
@@ -210,7 +210,7 @@ func (n *showTraceNode) Start(params runParams) error {
 	startCtx, sp := tracing.ChildSpan(params.ctx, "starting plan")
 	defer sp.Finish()
 	params.ctx = startCtx
-	return n.plan.Start(params)
+	return startExec(params, n.plan)
 }
 
 func (n *showTraceNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -72,7 +72,7 @@ type showZoneConfigRun struct {
 	done         bool
 }
 
-func (n *showZoneConfigNode) Start(params runParams) error {
+func (n *showZoneConfigNode) startExec(params runParams) error {
 	if n.zoneSpecifier.TargetsIndex() {
 		_, err := params.p.expandIndexName(params.ctx, &n.zoneSpecifier.TableOrIndex, true /* requireTable */)
 		if err != nil {

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -242,10 +242,6 @@ type sortRun struct {
 	valueIter    valueIterator
 }
 
-func (n *sortNode) Start(params runParams) error {
-	return n.plan.Start(params)
-}
-
 func (n *sortNode) Next(params runParams) (bool, error) {
 	cancelChecker := params.p.cancelChecker
 

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -97,10 +97,6 @@ type splitRun struct {
 	lastSplitKey []byte
 }
 
-func (n *splitNode) Start(params runParams) error {
-	return n.rows.Start(params)
-}
-
 func (n *splitNode) Next(params runParams) (bool, error) {
 	// TODO(radu): instead of performing the splits sequentially, accumulate all
 	// the split keys and then perform the splits in parallel (e.g. split at the

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -260,12 +260,12 @@ func (v *subqueryPlanVisitor) subqueryNode(ctx context.Context, sq *subquery) er
 	return nil
 }
 
-func (v *subqueryPlanVisitor) enterNode(_ context.Context, _ string, n planNode) bool {
+func (v *subqueryPlanVisitor) enterNode(_ context.Context, _ string, n planNode) (bool, error) {
 	if _, ok := n.(*explainPlanNode); ok {
 		// EXPLAIN doesn't start/substitute sub-queries.
-		return false
+		return false, nil
 	}
-	return true
+	return true, nil
 }
 
 func (p *planner) startSubqueryPlans(ctx context.Context, plan planNode) error {

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -41,7 +41,8 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.startPlan(context.TODO(), plan); !testutils.IsError(err, `forced`) {
+	params := runParams{ctx: context.TODO(), p: p}
+	if err := startPlan(params, plan); !testutils.IsError(err, `forced`) {
 		t.Fatalf("expected error from force_error(), got: %v", err)
 	}
 }

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -41,7 +41,7 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.startSubqueryPlans(context.TODO(), plan); !testutils.IsError(err, `forced`) {
+	if err := p.startPlan(context.TODO(), plan); !testutils.IsError(err, `forced`) {
 		t.Fatalf("expected error from force_error(), got: %v", err)
 	}
 }

--- a/pkg/sql/testing_relocate.go
+++ b/pkg/sql/testing_relocate.go
@@ -120,10 +120,6 @@ type testingRelocateRun struct {
 	storeMap map[roachpb.StoreID]roachpb.NodeID
 }
 
-func (n *testingRelocateNode) Start(params runParams) error {
-	return n.rows.Start(params)
-}
-
 func (n *testingRelocateNode) Next(params runParams) (bool, error) {
 	// Each Next call relocates one range (corresponding to one row from n.rows).
 	// TODO(radu): perform multiple relocations in parallel.

--- a/pkg/sql/unary.go
+++ b/pkg/sql/unary.go
@@ -31,8 +31,7 @@ type unaryRun struct {
 	consumed bool
 }
 
-func (*unaryNode) Start(runParams) error { return nil }
-func (*unaryNode) Values() tree.Datums   { return nil }
+func (*unaryNode) Values() tree.Datums { return nil }
 
 func (u *unaryNode) Next(runParams) (bool, error) {
 	r := !u.run.consumed

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -154,9 +154,6 @@ func (p *planner) Union(
 		inverted: inverted,
 		emitAll:  emitAll,
 		emit:     emit,
-		run: unionRun{
-			scratch: make([]byte, 0),
-		},
 	}
 	return node, nil
 }
@@ -168,11 +165,9 @@ type unionRun struct {
 	scratch []byte
 }
 
-func (n *unionNode) Start(params runParams) error {
-	if err := n.right.Start(params); err != nil {
-		return err
-	}
-	return n.left.Start(params)
+func (n *unionNode) startExec(params runParams) error {
+	n.run.scratch = make([]byte, 0)
+	return nil
 }
 
 func (n *unionNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -249,7 +249,7 @@ type updateRun struct {
 	editNodeRun
 }
 
-func (u *updateNode) Start(params runParams) error {
+func (u *updateNode) startExec(params runParams) error {
 	if err := u.run.startEditNode(params, &u.editNodeBase); err != nil {
 		return err
 	}
@@ -408,12 +408,9 @@ func (r *editNodeRun) initEditNode(
 func (r *editNodeRun) startEditNode(params runParams, en *editNodeBase) error {
 	if sqlbase.IsSystemConfigID(en.tableDesc.GetID()) {
 		// Mark transaction as operating on the system DB.
-		if err := en.p.txn.SetSystemConfigTrigger(); err != nil {
-			return err
-		}
+		return en.p.txn.SetSystemConfigTrigger()
 	}
-
-	return r.rows.Start(params)
+	return nil
 }
 
 // sourceSlot abstracts the idea that our update sources can either be tuples

--- a/pkg/sql/value_generator.go
+++ b/pkg/sql/value_generator.go
@@ -78,7 +78,7 @@ type valueGeneratorRun struct {
 	gen tree.ValueGenerator
 }
 
-func (n *valueGenerator) Start(params runParams) error {
+func (n *valueGenerator) startExec(params runParams) error {
 	expr, err := n.expr.Eval(params.evalCtx)
 	if err != nil {
 		return err

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -128,8 +128,7 @@ type valuesRun struct {
 	nextRow int // The index of the next row.
 }
 
-// Start implements the planNode interface.
-func (n *valuesNode) Start(params runParams) error {
+func (n *valuesNode) startExec(params runParams) error {
 	if n.rows != nil {
 		if !n.isConst {
 			log.Fatalf(params.ctx, "valuesNode evaluted twice")

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -15,6 +15,7 @@
 package sql
 
 import (
+	"fmt"
 	"go/constant"
 	"reflect"
 	"testing"
@@ -112,43 +113,46 @@ func TestValues(t *testing.T) {
 		},
 	}
 
+	ctx := context.TODO()
 	for i, tc := range testCases {
-		ctx := context.TODO()
-		plan, err := func() (_ planNode, err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = errors.Errorf("%v", r)
-				}
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			plan, err := func() (_ planNode, err error) {
+				defer func() {
+					if r := recover(); r != nil {
+						err = errors.Errorf("%v", r)
+					}
+				}()
+				return p.Values(context.TODO(), tc.stmt, nil)
 			}()
-			return p.Values(context.TODO(), tc.stmt, nil)
-		}()
-		if err == nil != tc.ok {
-			t.Errorf("%d: error_expected=%t, but got error %v", i, tc.ok, err)
-		}
-		if plan != nil {
-			defer plan.Close(ctx)
+			if plan != nil {
+				defer plan.Close(ctx)
+			}
+			if err == nil != tc.ok {
+				t.Errorf("%d: error_expected=%t, but got error %v", i, tc.ok, err)
+			}
+			if plan == nil {
+				return
+			}
 			plan, err = p.optimizePlan(ctx, plan, allColumns(plan))
 			if err != nil {
-				t.Errorf("%d: unexpected error in optimizePlan: %v", i, err)
-				continue
+				t.Fatalf("%d: unexpected error in optimizePlan: %v", i, err)
 			}
-			if err := p.startPlan(ctx, plan); err != nil {
-				t.Errorf("%d: unexpected error in Start: %v", i, err)
-				continue
+			params := runParams{ctx: ctx, p: p, evalCtx: &p.evalCtx}
+			if err := startPlan(params, plan); err != nil {
+				t.Fatalf("%d: unexpected error in Start: %v", i, err)
 			}
 			var rows []tree.Datums
-			next, err := plan.Next(runParams{ctx: ctx})
-			for ; next; next, err = plan.Next(runParams{ctx: ctx}) {
+			next, err := plan.Next(params)
+			for ; next; next, err = plan.Next(params) {
 				rows = append(rows, plan.Values())
 			}
 			if err != nil {
-				t.Error(err)
-				continue
+				t.Fatal(err)
 			}
 			if !reflect.DeepEqual(rows, tc.rows) {
 				t.Errorf("%d: expected rows:\n%+v\nactual rows:\n%+v", i, tc.rows, rows)
 			}
-		}
+		})
 	}
 }
 

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -158,10 +158,9 @@ type windowRun struct {
 	windowsAcc mon.BoundAccount
 }
 
-func (n *windowNode) Start(params runParams) error {
+func (n *windowNode) startExec(params runParams) error {
 	n.run.windowsAcc = params.p.session.TxnState.makeBoundAccount()
-
-	return n.plan.Start(params)
+	return nil
 }
 
 func (n *windowNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/zero.go
+++ b/pkg/sql/zero.go
@@ -31,7 +31,6 @@ type zeroNode struct {
 	_ interface{}
 }
 
-func (*zeroNode) Start(runParams) error          { return nil }
 func (z *zeroNode) Next(runParams) (bool, error) { return false, nil }
 func (*zeroNode) Values() tree.Datums            { return nil }
 func (*zeroNode) Close(context.Context)          {}


### PR DESCRIPTION
As stated earlier I want to clamp down on the amount of knowledge about the structure of the logical plan that's needed to perform local execution. In particular, eventually, the execution methods should not have access to the logical plan directly -- only the execution structure -- and thus should not need / be able to fish the "children" from the logical plan.

This first PR make a step in that direction, by extracting the recursion for the initialization step (Start) from the implementation of planNode.Start() methods into the previously-defined walkPlan(). The remaining initialization code stays in a new method called `startExec`, only implemented for nodes that need to initialize something. The result of this is that the remaining startExec() methods do not need to know about the children nodes, only their own nodes.

If we can make this happen successfully, I'll follow the same pattern in a subsequent PR for the part of Close() that pertains to local execution.  After these two have been segregated, I'll work on Next/Values which are comparatively much more easy.

@jordanlewis @RaduBerinde this code as it stands uses a closure to define the `planObserver`. Do you think this is allocation-heavy? If so, I can turn the planObserver into a proper visitor.


