### PR TITLE
ui: allow browsers to cache assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1012,7 +1012,7 @@ $(UI_ROOT)/dist%/bindata.go: $(UI_ROOT)/webpack.%.js $(UI_DLLS) $(UI_JS) $(UI_MA
 	find $(UI_ROOT)/dist$* -mindepth 1 -not -name dist$*.go -delete
 	set -e; for dll in $(notdir $(UI_DLLS)); do ln -s ../dist/$$dll $(UI_ROOT)/dist$*/$$dll; done
 	$(NODE_RUN) -C $(UI_ROOT) $(WEBPACK) --config webpack.$*.js
-	go-bindata -nometadata -pkg dist$* -o $@ -prefix $(UI_ROOT)/dist$* $(UI_ROOT)/dist$*/...
+	go-bindata -pkg dist$* -o $@ -prefix $(UI_ROOT)/dist$* $(UI_ROOT)/dist$*/...
 	$(SED_INPLACE) -f $(UI_ROOT)/process-bindata.sed $@
 	gofmt -s -w $@
 


### PR DESCRIPTION
Include the the UI asset files' mtimes in bindata.go so that Go's HTTP
server can properly compute a Last-Modified header. This allows
browsers to cache the UI assets, which can improve performance
significantly on slow connections.

(The metadata is not sensitive; it was previously stripped because the
compiled UI was checked into version control and so needed to be
reproducible.)

Partially fixes #20425.
Fixes #18668.