### PR TITLE
kv: Print which replica we're waiting on if an RPC is slow

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1238,8 +1238,9 @@ func (ds *DistSender) sendToReplicas(
 		select {
 		case <-slowTimer.C:
 			slowTimer.Read = true
-			log.Warningf(ctx, "have been waiting %s sending RPC to r%d for batch: %s",
-				base.SlowRequestThreshold, rangeID, args)
+			log.Warningf(ctx,
+				"have been waiting %s sending RPC to r%d (currently pending: %s) for batch: %s",
+				base.SlowRequestThreshold, rangeID, transport.GetPending(), args)
 			ds.metrics.SlowRequestsCount.Inc(1)
 			defer ds.metrics.SlowRequestsCount.Dec(1)
 

--- a/pkg/kv/dist_sender_test.go
+++ b/pkg/kv/dist_sender_test.go
@@ -149,6 +149,10 @@ func (l *legacyTransportAdapter) IsExhausted() bool {
 	return l.called
 }
 
+func (l *legacyTransportAdapter) GetPending() []roachpb.ReplicaDescriptor {
+	return nil
+}
+
 func (l *legacyTransportAdapter) SendNext(ctx context.Context, done chan<- BatchCall) {
 	l.called = true
 	br, err := l.fn(ctx, l.opts, l.replicas, l.args, l.rpcContext)

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -89,6 +89,10 @@ func (f *firstNErrorTransport) IsExhausted() bool {
 	return f.numSent >= len(f.replicas)
 }
 
+func (f *firstNErrorTransport) GetPending() []roachpb.ReplicaDescriptor {
+	return nil
+}
+
 func (f *firstNErrorTransport) SendNext(_ context.Context, done chan<- BatchCall) {
 	call := BatchCall{
 		Reply: &roachpb.BatchResponse{},

--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -164,14 +164,14 @@ func (gt *grpcTransport) IsExhausted() bool {
 	if gt.clientIndex < len(gt.orderedClients) {
 		return false
 	}
-	return !gt.maybeResurrectRetryables()
+	return !gt.maybeResurrectRetryablesLocked()
 }
 
-// maybeResurrectRetryables moves already-tried replicas which
+// maybeResurrectRetryablesLocked moves already-tried replicas which
 // experienced a retryable error (currently this means a
 // NotLeaseHolderError) into a newly-active state so that they can be
 // retried. Returns true if any replicas were moved to active.
-func (gt *grpcTransport) maybeResurrectRetryables() bool {
+func (gt *grpcTransport) maybeResurrectRetryablesLocked() bool {
 	var resurrect []batchClient
 	for i := 0; i < gt.clientIndex; i++ {
 		if c := gt.orderedClients[i]; !c.pending && c.retryable && timeutil.Since(c.deadline) >= 0 {

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -445,6 +445,10 @@ func (t *multiTestContextKVTransport) IsExhausted() bool {
 	return t.idx == len(t.replicas)
 }
 
+func (t *multiTestContextKVTransport) GetPending() []roachpb.ReplicaDescriptor {
+	return nil
+}
+
 func (t *multiTestContextKVTransport) SendNext(ctx context.Context, done chan<- kv.BatchCall) {
 	rep := t.replicas[t.idx]
 	t.idx++


### PR DESCRIPTION
This has been bugging me for quite a while -- normally you can figure
out which replica is being waited on pretty easily when a cluster is
still running, but not if all you have are logs provided by a user after
the fact.

This makes for log messages like:
`W171203 19:23:13.991929 214 kv/dist_sender.go:1242  [summaries,n3] have been waiting 1m0s sending RPC to r4 (currently pending: [(n1,s1):1]) for batch: Put [/System/StatusNode/3,/Min)`

While I'm here, also fix up the naming of a `grpcTransport` method that should indicate the mutex needs to be held.