### PR TITLE
storage: Include command timestamps in command queue debug string

### DIFF
--- a/pkg/storage/command_queue.go
+++ b/pkg/storage/command_queue.go
@@ -124,7 +124,7 @@ func (c *cmd) String() string {
 	if c.readOnly {
 		readOnly = " readonly"
 	}
-	fmt.Fprintf(&buf, "%d%s [%s", c.id, readOnly, roachpb.Key(c.key.Start))
+	fmt.Fprintf(&buf, "%d %s%s [%s", c.id, c.timestamp, readOnly, roachpb.Key(c.key.Start))
 	if !roachpb.Key(c.key.End).Equal(roachpb.Key(c.key.Start).Next()) {
 		fmt.Fprintf(&buf, ",%s", roachpb.Key(c.key.End))
 	}


### PR DESCRIPTION
Would have been nice when looking into #20114 to get a sense of whether progress was being made and whether new requests were coming in.