### PR TITLE
cherrypick-1.1: storage: move txn intent cleanup out of GC critical path, & GC keys early

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -568,9 +568,17 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	for _, desc := range descs {
 		snap := db.NewSnapshot()
 		defer snap.Close()
-		_, info, err := storage.RunGC(context.Background(), &desc, snap, hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
-			config.GCPolicy{TTLSeconds: 24 * 60 * 60 /* 1 day */}, func(_ hlc.Timestamp, _ *roachpb.Transaction, _ roachpb.PushTxnType) {
-			}, func(_ []roachpb.Intent, _ storage.ResolveOptions) error { return nil })
+		info, err := storage.RunGC(
+			context.Background(),
+			&desc,
+			snap,
+			hlc.Timestamp{WallTime: timeutil.Now().UnixNano()},
+			config.GCPolicy{TTLSeconds: 24 * 60 * 60 /* 1 day */},
+			func([]roachpb.GCRequest_GCKey, *storage.GCInfo) error { return nil },
+			func(_ hlc.Timestamp, _ *roachpb.Transaction, _ roachpb.PushTxnType) {},
+			func(_ []roachpb.Intent, _ storage.ResolveOptions) error { return nil },
+			func(_ *roachpb.Transaction, _ []roachpb.Intent) error { return nil },
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -84,9 +85,9 @@ const (
 //  - GC of version data via TTL expiration (and more complex schemes
 //    as implemented going forward).
 //  - Resolve extant write intents (pushing their transactions).
-//  - GC of old transaction and abort cache entries. This should include
-//    most committed entries almost immediately and, after a threshold on
-//    inactivity, all others.
+//  - GC of old transaction and AbortSpan entries. This should include
+//    most committed and aborted entries almost immediately and, after a
+//    threshold on inactivity, all others.
 //
 // The shouldQueue function combines the need for the above tasks into a
 // single priority. If any task is overdue, shouldQueue returns true.
@@ -113,8 +114,10 @@ func newGCQueue(store *Store, gossip *gossip.Gossip) *gcQueue {
 	return gcq
 }
 
+type gcFunc func([]roachpb.GCRequest_GCKey, *GCInfo) error
 type pushFunc func(hlc.Timestamp, *roachpb.Transaction, roachpb.PushTxnType)
 type resolveFunc func([]roachpb.Intent, ResolveOptions) error
+type processAsyncFunc func(*roachpb.Transaction, []roachpb.Intent) error
 
 // gcQueueScore holds details about the score returned by makeGCQueueScoreImpl for
 // testing and logging. The fields in this struct are documented in
@@ -350,13 +353,15 @@ func makeGCQueueScoreImpl(
 // processLocalKeyRange scans the local range key entries, consisting of
 // transaction records, queue last processed timestamps, and range descriptors.
 //
-// - Transaction entries: updates txnMap with those transactions which
-//   are old and either PENDING or with intents registered. In the
-//   first case we want to push the transaction so that it is aborted,
-//   and in the second case we may have to resolve the intents
-//   success- fully before GCing the entry. The transaction records
-//   which can be gc'ed are returned separately and are not added to
-//   txnMap nor intentSpanMap.
+// - Transaction entries:
+//   - Update txnMap with transactions which are old and in state
+//     PENDING for subsequent PushTxn.
+//   - For transactions in state ABORTED or COMMITTED, schedule the
+//     intents for asynchronous resolution. The actual transaction spans
+//     are not returned for GC in this pass, but are separately GC'ed
+//     after successful resolution of all intents. The exception is if
+//     there are no intents on the txn record, in which case it's returned
+//     for immediate GC.
 //
 // - Queue last processed times: cleanup any entries which don't match
 //   this range's start key. This can happen on range merges.
@@ -367,14 +372,20 @@ func processLocalKeyRange(
 	txnMap map[uuid.UUID]*roachpb.Transaction,
 	cutoff hlc.Timestamp,
 	infoMu *lockableGCInfo,
-	resolveIntents resolveFunc,
+	processAsyncFn processAsyncFunc,
 ) ([]roachpb.GCRequest_GCKey, error) {
 	infoMu.Lock()
 	defer infoMu.Unlock()
 
 	var gcKeys []roachpb.GCRequest_GCKey
 
-	const maxIntentHack = 800
+	handleTxnIntents := func(key roachpb.Key, txn *roachpb.Transaction) error {
+		if len(txn.Intents) > 0 {
+			return processAsyncFn(txn, roachpb.AsIntents(txn.Intents, txn))
+		}
+		gcKeys = append(gcKeys, roachpb.GCRequest_GCKey{Key: key}) // zero timestamp
+		return nil
+	}
 
 	handleOneTransaction := func(kv roachpb.KeyValue) error {
 		var txn roachpb.Transaction
@@ -399,62 +410,18 @@ func processLocalKeyRange(
 			infoMu.TransactionSpanGCPending++
 			txnMap[txnID] = &txn
 			return nil
-		case roachpb.ABORTED:
-			// If we remove this transaction, it effectively still counts as
-			// ABORTED (by design). So this can be GC'ed even if we can't
-			// resolve the intents.
-			// Note: Most aborted transaction weren't aborted by their client,
-			// but instead by the coordinator - those will not have any intents
-			// persisted, though they still might exist in the system.
-			infoMu.TransactionSpanGCAborted++
-			if err := func() error {
-				// Simply don't resolve these intents. We don't have to and don't want to get bogged down
-				// trying to do so.
-				if len(txn.Intents) > maxIntentHack {
-					return nil
-				}
-				infoMu.Unlock() // intentional
-				defer infoMu.Lock()
-				return resolveIntents(roachpb.AsIntents(txn.Intents, &txn),
-					ResolveOptions{Wait: true, Poison: false})
-			}(); err != nil {
-				// Ignore above error, but if context is expired, no point in keeping going.
-				if ctx.Err() != nil {
-					return errors.Wrap(err, "context timed out during local key range processing after")
-				}
-				log.Warningf(ctx, "failed to resolve intents of aborted txn on gc (removing anyway): %s", err)
-				// Keep going.
-			}
-		case roachpb.COMMITTED:
-			// It's committed, so it doesn't need a push but we can only
-			// GC it after its intents are resolved.
-			if err := func() error {
-				infoMu.Unlock() // intentional
-				defer infoMu.Lock()
 
-				if len(txn.Intents) > maxIntentHack {
-					// Return an error so that we leave this transaction alone. Don't try to resolve its intents.
-					return errors.Errorf("cannot GC transaction with %d intents", len(txn.Intents))
-				}
-				return resolveIntents(roachpb.AsIntents(txn.Intents, &txn), ResolveOptions{Wait: true, Poison: false})
-			}(); err != nil {
-				// Returning the error here would abort the whole GC run, and
-				// we don't want that. Instead, we simply don't GC this entry.
-				if ctx.Err() != nil {
-					// ... but if our context is expired, no need to keep going.
-					return errors.Wrap(err, "context timed out during local key range processing after")
-				}
-				log.Warningf(ctx, "unable to resolve intents of committed txn on gc; skipping: %s", err)
-				// Do not keep going, or we'll still remove this transaction, and we're not
-				// allowed to unless the intents are certifiably removed.
-				return nil
-			}
+		case roachpb.ABORTED:
+			infoMu.TransactionSpanGCAborted++
+			return handleTxnIntents(kv.Key, &txn)
+
+		case roachpb.COMMITTED:
 			infoMu.TransactionSpanGCCommitted++
+			return handleTxnIntents(kv.Key, &txn)
+
 		default:
 			panic(fmt.Sprintf("invalid transaction state: %s", txn))
 		}
-		gcKeys = append(gcKeys, roachpb.GCRequest_GCKey{Key: kv.Key}) // zero timestamp
-		return nil
 	}
 
 	handleOneQueueLastProcessed := func(kv roachpb.KeyValue, rangeKey roachpb.RKey) error {
@@ -543,8 +510,8 @@ func processAbortCache(
 // 3) scan the transaction table, collecting abandoned or completed txns
 // 4) push all of these transactions (possibly recreating entries)
 // 5) resolve all intents (unless the txn is still PENDING), which will recreate
-//    abort cache entries (but with the txn timestamp; i.e. likely gc'able)
-// 6) scan the abort cache table for old entries
+//    AbortSpan entries (but with the txn timestamp; i.e. likely GC'able)
+// 6) scan the AbortSpan table for old entries
 // 7) push these transactions (again, recreating txn entries).
 // 8) send a GCRequest.
 func (gcq *gcQueue) process(ctx context.Context, repl *Replica, sysCfg config.SystemConfig) error {
@@ -608,46 +575,70 @@ func (gcq *gcQueue) processImpl(
 		return errors.Errorf("could not find zone config for range %s: %s", repl, err)
 	}
 
-	gcKeys, info, err := RunGC(ctx, desc, snap, now, zone.GC,
+	info, err := RunGC(ctx, desc, snap, now, zone.GC,
+		func(gcKeys []roachpb.GCRequest_GCKey, info *GCInfo) error {
+			// Chunk the keys into multiple GC requests to interleave more
+			// gracefully with other Raft traffic.
+			batches := chunkGCRequest(desc, info, gcKeys)
+
+			for i, gcArgs := range batches {
+				var ba roachpb.BatchRequest
+
+				// Technically not needed since we're talking directly to the Range.
+				ba.RangeID = desc.RangeID
+				ba.Timestamp = now
+
+				// TODO(tschottdorf): This is one of these instances in which we want
+				// to be more careful that the request ends up on the correct Replica,
+				// and we might have to worry about mixing range-local and global keys
+				// in a batch which might end up spanning Ranges by the time it executes.
+				ba.Add(&gcArgs)
+				log.Eventf(ctx, "sending batch %d of %d", i+1, len(batches))
+				if _, pErr := repl.Send(ctx, ba); pErr != nil {
+					log.ErrEvent(ctx, pErr.String())
+					return pErr.GoError()
+				}
+			}
+			return nil
+		},
 		func(now hlc.Timestamp, txn *roachpb.Transaction, typ roachpb.PushTxnType) {
 			pushTxn(ctx, gcq.store.DB(), now, txn, typ)
 		},
 		func(intents []roachpb.Intent, opts ResolveOptions) error {
 			return repl.store.intentResolver.resolveIntents(ctx, intents, opts)
+		},
+		func(txn *roachpb.Transaction, intents []roachpb.Intent) error {
+			// Synthesize an EndTransaction request in order to send intentsWithArgs.
+			iwa := intentsWithArg{
+				args: &roachpb.EndTransactionRequest{
+					Span:   roachpb.Span{Key: txn.Key},
+					Commit: txn.Status == roachpb.COMMITTED,
+				},
+				intents: intents,
+			}
+			// We really do not want to hang up the queue on this kind of
+			// processing, so it's better to just skip txns which we can't
+			// pass to the async processor (allowSyncProcessing=false).
+			// Their intents will get cleaned up on demand, and we'll
+			// eventually get back to them. Not much harm in having old txn
+			// records lying around in the meantime.
+			err := repl.store.intentResolver.processIntentsAsync(
+				ctx, repl, []intentsWithArg{iwa}, false, /* allowSyncProcessing */
+			)
+			if errors.Cause(err) == stop.ErrThrottled {
+				log.Eventf(ctx, "processing txn %s: %s; skipping for future GC", txn.ID.Short(), err)
+				return nil
+			}
+			return err
 		})
-
 	if err != nil {
 		return err
 	}
 
-	log.Eventf(ctx, "MVCC stats: %+v", repl.GetMVCCStats())
-	log.Eventf(ctx, "assembled GC keys, now proceeding to GC; stats so far %+v", info)
-	defer func() {
-		info.updateMetrics(gcq.store.metrics)
-	}()
+	log.Eventf(ctx, "MVCC stats after GC: %+v", repl.GetMVCCStats())
+	log.Eventf(ctx, "GC score after GC: %s", makeGCQueueScore(ctx, repl, repl.store.Clock().Now(), sysCfg))
+	info.updateMetrics(gcq.store.metrics)
 
-	batches := chunkGCRequest(desc, &info, gcKeys)
-
-	for i, gcArgs := range batches {
-		var ba roachpb.BatchRequest
-
-		// Technically not needed since we're talking directly to the Range.
-		ba.RangeID = desc.RangeID
-		ba.Timestamp = now
-
-		// TODO(tschottdorf): This is one of these instances in which we want
-		// to be more careful that the request ends up on the correct Replica,
-		// and we might have to worry about mixing range-local and global keys
-		// in a batch which might end up spanning Ranges by the time it executes.
-		ba.Add(&gcArgs)
-		log.Eventf(ctx, "sending batch %d of %d", i+1, len(batches))
-		if _, pErr := repl.Send(ctx, ba); pErr != nil {
-			log.ErrEvent(ctx, pErr.String())
-			return pErr.GoError()
-		}
-	}
-
-	log.Eventf(ctx, "done GC'ing, new score is %s", makeGCQueueScore(ctx, repl, repl.store.Clock().Now(), sysCfg))
 	return nil
 }
 
@@ -710,20 +701,23 @@ type lockableGCInfo struct {
 	GCInfo
 }
 
-// RunGC runs garbage collection for the specified descriptor on the provided
-// Engine (which is not mutated). It uses the provided functions pushTxnFn and
-// resolveIntentsFn to clarify the true status of and clean up after encountered
-// transactions. It returns a slice of gc'able keys from the data, transaction,
-// and abort spans.
+// RunGC runs garbage collection for the specified descriptor on the
+// provided Engine (which is not mutated). It uses the provided
+// pushTxnFn to clarify the true status of a transaction,
+// resolveIntentsFn to resolve intents synchronously, and
+// processAsyncFn to asynchronously cleanup after encountered
+// transactions.
 func RunGC(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,
 	snap engine.Reader,
 	now hlc.Timestamp,
 	policy config.GCPolicy,
+	gcFn gcFunc,
 	pushTxnFn pushFunc,
 	resolveIntentsFn resolveFunc,
-) ([]roachpb.GCRequest_GCKey, GCInfo, error) {
+	processAsyncFn processAsyncFunc,
+) (GCInfo, error) {
 
 	iter := NewReplicaDataIterator(desc, snap, true /* replicatedOnly */)
 	defer iter.Close()
@@ -744,6 +738,23 @@ func RunGC(
 				infoMu.Unlock()
 			}()
 			return realResolveIntentsFn(intents, opts)
+		}
+		realProcessAsyncFn := processAsyncFn
+		processAsyncFn = func(txn *roachpb.Transaction, intents []roachpb.Intent) (err error) {
+			defer func() {
+				// Note: infoMu lock is already held.
+				infoMu.ResolveTotal += len(intents)
+				if err == nil {
+					// TODO(spencer): this is only partially correct; what it
+					// provides is a count of the intents for which async
+					// resolution was undertaken, not the count of intents which
+					// were successfully resolved. We need to keep a separate
+					// count of successes / failures for intent resolution in the
+					// intent resolver instead.
+					infoMu.ResolveSuccess += len(intents)
+				}
+			}()
+			return realProcessAsyncFn(txn, intents)
 		}
 		realPushTxnFn := pushTxnFn
 		pushTxnFn = func(ts hlc.Timestamp, txn *roachpb.Transaction, typ roachpb.PushTxnType) {
@@ -818,7 +829,7 @@ func RunGC(
 	log.Event(ctx, "iterating through range")
 	for ; ; iter.Next() {
 		if ok, err := iter.Valid(); err != nil {
-			return nil, GCInfo{}, err
+			return GCInfo{}, err
 		} else if !ok {
 			break
 		}
@@ -849,9 +860,9 @@ func RunGC(
 	infoMu.NumKeysAffected = len(gcKeys)
 
 	// Process local range key entries (txn records, queue last processed times).
-	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, txnMap, txnExp, &infoMu, resolveIntentsFn)
+	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, txnMap, txnExp, &infoMu, processAsyncFn)
 	if err != nil {
-		return nil, GCInfo{}, err
+		return GCInfo{}, err
 	}
 
 	// From now on, all newly added keys are range-local.
@@ -861,15 +872,29 @@ func RunGC(
 	// we send directly to the Replica, though.
 	gcKeys = append(gcKeys, localRangeKeys...)
 
-	// Process push transactions in parallel.
-	//
-	// TODO(tschottdorf): we first push all transactions before resolving intents.
-	// If we have too many transactions, that can lead to the case in which our context
-	// expires and we can't actually clean up any of the intents. Since we have hopefully
-	// succeeded in pushing a lot of transactions, the next time around we should have
-	// less work here and manage to get to the intents, but it would be better to let
-	// another goroutine resolve intents for transactions we've handled so that work that
-	// is prepared is executed right away.
+	// Clean up the abort cache.
+	log.Event(ctx, "processing abort cache")
+	gcKeys = append(gcKeys, processAbortCache(
+		ctx, snap, desc.RangeID, abortSpanGCThreshold, &infoMu, pushTxnFn)...)
+
+	infoMu.Lock()
+	log.Eventf(ctx, "assembled GC keys, now proceeding to GC; stats so far %+v", infoMu.GCInfo)
+	infoMu.Unlock()
+
+	// Process the keys before beginning to push transactions and
+	// resolve intents so that we don't lose all of the work we've done
+	// thus far gathering GC'able keys.
+	if err := gcFn(gcKeys, &infoMu.GCInfo); err != nil {
+		return GCInfo{}, err
+	}
+
+	// Process push transactions in parallel. We first push all
+	// transactions before resolving intents. If we have too many
+	// transactions, that can lead to the case in which our context
+	// expires and we can't actually clean up any of the intents. Since
+	// we have hopefully succeeded in pushing a lot of transactions, the
+	// next time around we should have less work here and manage to get
+	// to the intents.
 	log.Eventf(ctx, "pushing up to %d transactions (concurrency %d)", len(txnMap), gcTaskLimit)
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, gcTaskLimit)
@@ -896,29 +921,28 @@ func RunGC(
 
 	if err := ctx.Err(); err != nil {
 		// Don't bother if already expired.
-		return nil, GCInfo{}, err
+		return GCInfo{}, err
 	}
 
-	// Resolve all intents.
-	log.Eventf(ctx, "resolving up to %d intents", len(txnMap))
+	// Resolve all intents. If we have too many intents, that can lead to
+	// the case in which our context expires and we can't finish. However,
+	// because all of these intents fall within a single range, this is
+	// likely to be less problematic than cleaning up a highly distributed
+	// transaction's intents. Because the intent resolution is done in batches
+	// of 100 intents, even if this times out, the next pass will be easier.
 	var intents []roachpb.Intent
 	for txnID, txn := range txnMap {
 		if txn.Status != roachpb.PENDING {
-			for _, intent := range intentSpanMap[txnID] {
-				intents = append(intents, roachpb.Intent{Span: intent, Status: txn.Status, Txn: txn.TxnMeta})
-			}
+			intents = append(intents, roachpb.AsIntents(intentSpanMap[txnID], txn)...)
 		}
 	}
+	log.Eventf(ctx, "resolving %d intents", len(intents))
 
 	if err := resolveIntentsFn(intents, ResolveOptions{Wait: true, Poison: false}); err != nil {
-		return nil, GCInfo{}, err
+		return GCInfo{}, err
 	}
 
-	// Clean up the abort cache.
-	log.Event(ctx, "processing abort cache")
-	gcKeys = append(gcKeys, processAbortCache(
-		ctx, snap, desc.RangeID, abortSpanGCThreshold, &infoMu, pushTxnFn)...)
-	return gcKeys, infoMu.GCInfo, nil
+	return infoMu.GCInfo, nil
 }
 
 // timer returns a constant duration to space out GC processing

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
+	"golang.org/x/sync/syncmap"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -639,16 +640,22 @@ func TestGCQueueTransactionTable(t *testing.T) {
 		},
 	}
 
-	resolved := map[string][]roachpb.Span{}
+	var resolved syncmap.Map
 
 	tsc.TestingKnobs.TestingEvalFilter =
 		func(filterArgs storagebase.FilterArgs) *roachpb.Error {
 			if resArgs, ok := filterArgs.Req.(*roachpb.ResolveIntentRequest); ok {
 				id := string(resArgs.IntentTxn.Key)
-				resolved[id] = append(resolved[id], roachpb.Span{
+				var spans []roachpb.Span
+				val, ok := resolved.Load(id)
+				if ok {
+					spans = val.([]roachpb.Span)
+				}
+				spans = append(spans, roachpb.Span{
 					Key:    resArgs.Key,
 					EndKey: resArgs.EndKey,
 				})
+				resolved.Store(id, spans)
 				// We've special cased one test case. Note that the intent is still
 				// counted in `resolved`.
 				if testCases[id].failResolve {
@@ -721,9 +728,13 @@ func TestGCQueueTransactionTable(t *testing.T) {
 			if sp.expResolve {
 				expIntents = testIntents
 			}
-			if !reflect.DeepEqual(resolved[strKey], expIntents) {
-				return fmt.Errorf("%s: unexpected intent resolutions:\nexpected: %s\nobserved: %s",
-					strKey, expIntents, resolved[strKey])
+			var spans []roachpb.Span
+			val, ok := resolved.Load(strKey)
+			if ok {
+				spans = val.([]roachpb.Span)
+			}
+			if !reflect.DeepEqual(spans, expIntents) {
+				return fmt.Errorf("%s: unexpected intent resolutions:\nexpected: %s\nobserved: %s", strKey, expIntents, spans)
 			}
 			entry := &roachpb.AbortCacheEntry{}
 			abortExists, err := tc.repl.abortCache.Get(context.Background(), tc.store.Engine(), txns[strKey].ID, entry)

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -18,8 +18,10 @@ package storage
 import (
 	"fmt"
 	"sort"
-	"sync"
 	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -29,9 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"golang.org/x/net/context"
 )
 
 const (
@@ -66,8 +66,12 @@ type intentResolver struct {
 
 	mu struct {
 		syncutil.Mutex
-		// Maps transaction ids to a refcount.
+		// Map from txn ID being pushed to a refcount of intents waiting on the push.
 		inFlight map[uuid.UUID]int
+		// Set of txn IDs whose list of intent spans are being resolved. Note that
+		// this pertains only to EndTransaction-style intent cleanups, whether called
+		// directly after EndTransaction evaluation or during GC of txn spans.
+		inFlightTxnCleanups map[uuid.UUID]struct{}
 	}
 }
 
@@ -77,6 +81,7 @@ func newIntentResolver(store *Store, taskLimit int) *intentResolver {
 		sem:   make(chan struct{}, taskLimit),
 	}
 	ir.mu.inFlight = map[uuid.UUID]int{}
+	ir.mu.inFlightTxnCleanups = map[uuid.UUID]struct{}{}
 	return ir
 }
 
@@ -272,47 +277,44 @@ func (ir *intentResolver) maybePushTransactions(
 // but combining them simplifies the plumbing necessary in Replica.
 func (ir *intentResolver) processIntentsAsync(
 	ctx context.Context, r *Replica, intents []intentsWithArg, allowSyncProcessing bool,
-) {
+) error {
 	if r.store.TestingKnobs().DisableAsyncIntentResolution {
-		return
+		return errors.New("intents not processed as async resolution is disabled")
 	}
 	now := r.store.Clock().Now()
 	stopper := r.store.Stopper()
 
 	for _, item := range intents {
 		err := stopper.RunLimitedAsyncTask(
-			ctx, "storage.intentResolver: processing intents", ir.sem, false, /* wait */
-			func(_ context.Context) {
-				// If we've successfully launched a background task, dissociate
-				// this work from our caller's context and timeout.
-				ir.processIntents(context.Background(), r, item, now)
-			})
-		if err != nil {
-			if err == stop.ErrThrottled && allowSyncProcessing {
-				// A limited task was not available. Rather than waiting for one, we
-				// reuse the current goroutine.
+			// If we've successfully launched a background task,
+			// dissociate this work from our caller's context and
+			// timeout.
+			context.Background(),
+			"storage.intentResolver: processing intents",
+			ir.sem, false /* wait */, func(ctx context.Context) {
 				ir.processIntents(ctx, r, item, now)
-			} else {
-				log.Warningf(ctx, "failed to resolve intents: %s", err)
-				return
-			}
+			},
+		)
+		if err == stop.ErrThrottled && allowSyncProcessing {
+			// A limited task was not available. Rather than waiting for one, we
+			// reuse the current goroutine.
+			ir.processIntents(ctx, r, item, now)
+		} else if err != nil {
+			return errors.Wrapf(err, "during async intent resolution")
 		}
 	}
+
+	return nil
 }
 
 func (ir *intentResolver) processIntents(
 	ctx context.Context, r *Replica, item intentsWithArg, now hlc.Timestamp,
 ) {
-	// Everything here is best effort; so give the context a timeout to avoid
-	// waiting too long. This may be a larger timeout than the context already
-	// has, in which case we'll respect the existing timeout.
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, intentResolverTimeout)
-	defer cancel()
-
 	if item.args.Method() != roachpb.EndTransaction {
 		h := roachpb.Header{Timestamp: now}
-		resolveIntents, pushErr := ir.maybePushTransactions(ctxWithTimeout,
-			item.intents, h, roachpb.PUSH_TOUCH, true /* skipInFlight */)
+		resolveIntents, pushErr := ir.maybePushTransactions(
+			ctx, item.intents, h, roachpb.PUSH_TOUCH, true, /* skipInFlight */
+		)
 
 		// resolveIntents with poison=true because we're resolving
 		// intents outside of the context of an EndTransaction.
@@ -333,7 +335,7 @@ func (ir *intentResolver) processIntents(
 		//   same situation as above.
 		//
 		// Thus, we must poison.
-		if err := ir.resolveIntents(ctxWithTimeout, resolveIntents,
+		if err := ir.resolveIntents(ctx, resolveIntents,
 			ResolveOptions{Wait: true, Poison: true}); err != nil {
 			log.Warningf(ctx, "%s: failed to resolve intents: %s", r, err)
 			return
@@ -343,6 +345,27 @@ func (ir *intentResolver) processIntents(
 			return
 		}
 	} else { // EndTransaction
+
+		// Skip processing if we're already in the middle of resolving
+		// this transaction's intents.
+		txn := item.intents[0].Txn
+		txnKey := keys.TransactionKey(txn.Key, txn.ID)
+		ir.mu.Lock()
+		_, inFlight := ir.mu.inFlightTxnCleanups[txn.ID]
+		if !inFlight {
+			ir.mu.inFlightTxnCleanups[txn.ID] = struct{}{}
+		}
+		ir.mu.Unlock()
+		if inFlight {
+			log.Eventf(ctx, "skipping txn resolved; already in flight")
+			return
+		}
+		defer func() {
+			ir.mu.Lock()
+			delete(ir.mu.inFlightTxnCleanups, txn.ID)
+			ir.mu.Unlock()
+		}()
+
 		// For EndTransaction, we know the transaction is finalized so
 		// we can skip the push and go straight to the resolve.
 		//
@@ -351,7 +374,7 @@ func (ir *intentResolver) processIntents(
 		// example, an attempt to explicitly rollback the transaction
 		// may succeed (triggering this code path), but the result may
 		// not make it back to the client.
-		if err := ir.resolveIntents(ctxWithTimeout, item.intents,
+		if err := ir.resolveIntents(ctx, item.intents,
 			ResolveOptions{Wait: true, Poison: false}); err != nil {
 			log.Warningf(ctx, "%s: failed to resolve intents: %s", r, err)
 			return
@@ -360,8 +383,6 @@ func (ir *intentResolver) processIntents(
 		// We successfully resolved the intents, so we're able to GC from
 		// the txn span directly.
 		b := &client.Batch{}
-		txn := item.intents[0].Txn
-		txnKey := keys.TransactionKey(txn.Key, txn.ID)
 
 		// This is pretty tricky. Transaction keys are range-local and
 		// so they are encoded specially. The key range addressed by
@@ -405,6 +426,14 @@ func (ir *intentResolver) processIntents(
 // ResolveOptions is used during intent resolution. It specifies whether the caller wants the
 // call to block, and whether the ranges containing the intents are to be poisoned.
 type ResolveOptions struct {
+	// Resolve intents synchronously. When set to `false`, requests a
+	// semi-synchronous operation, returning when all local commands have
+	// been *proposed* but not yet committed or executed. This ensures that
+	// if a waiting client retries immediately after calling this function,
+	// it will not hit the same intents again.
+	//
+	// TODO(bdarnell): Note that this functionality has been removed and
+	// will be ignored, pending resolution of #8360.
 	Wait   bool
 	Poison bool
 }
@@ -423,8 +452,6 @@ type ResolveOptions struct {
 func (ir *intentResolver) resolveIntents(
 	ctx context.Context, intents []roachpb.Intent, opts ResolveOptions,
 ) error {
-	// Force synchronous operation; see above TODO.
-	opts.Wait = true
 	if len(intents) == 0 {
 		return nil
 	}
@@ -433,9 +460,6 @@ func (ir *intentResolver) resolveIntents(
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	// We're doing async stuff below; those need new traces.
-	ctx, cleanup := tracing.EnsureContext(ctx, ir.store.Tracer(), "resolve intents")
-	defer cleanup()
 	log.Eventf(ctx, "resolving intents [wait=%t]", opts.Wait)
 
 	var reqs []roachpb.Request
@@ -468,14 +492,10 @@ func (ir *intentResolver) resolveIntents(
 		return reqs[i].Header().Key.Compare(reqs[j].Header().Key) < 0
 	})
 
-	// Resolve all of the intents.
-	var wg sync.WaitGroup
-	var errCh chan error
-	if opts.Wait {
-		// If the caller is waiting, use this channel to collect the first
-		// non-nil error (if any) from the async tasks.
-		errCh = make(chan error, 1)
-	}
+	// Resolve all of the intents in batches of size intentResolverBatchSize.
+	// The maximum timeout is intentResolverTimeout, and this is applied to
+	// each batch to ensure forward progress is made. A large set of intents
+	// might require more time than a single timeout allows.
 	for len(reqs) > 0 {
 		b := &client.Batch{}
 		if len(reqs) > intentResolverBatchSize {
@@ -485,48 +505,20 @@ func (ir *intentResolver) resolveIntents(
 			b.AddRawRequest(reqs...)
 			reqs = nil
 		}
-		wg.Add(1)
-		action := func(ctx context.Context) error {
-			return ir.store.DB().Run(ctx, b)
-		}
-		// NB: Don't wait for an async task slot as we might be configured with an
-		// insufficient number (i.e. 0 or 1).
-		if ir.store.Stopper().RunLimitedAsyncTask(
-			ctx, "storage.intentResolve: resolving intents", ir.sem, false, /* wait */
-			func(ctx context.Context) {
-				defer wg.Done()
-
-				if err := action(ctx); err != nil {
-					// If we have a waiting caller, pass the first non-nil
-					// error out on the channel.
-					select {
-					case errCh <- err:
-						return
-					default:
-					}
-					// No caller waiting or channel full, so just log the error.
-					log.Warningf(ctx, "unable to resolve external intents: %s", err)
-				}
-			}) != nil {
-			wg.Done()
-			// Try async to not keep the caller waiting, but when draining
-			// just go ahead and do it synchronously. See #1684.
-			// TODO(tschottdorf): This is ripe for removal.
-			if err := action(ctx); err != nil {
-				return err
-			}
-		}
-	}
-
-	if opts.Wait {
-		// Wait for all resolutions to complete. We don't want to return
-		// as soon as the first one fails because of issue #8360 (see
-		// comment at the top of this method)
-		wg.Wait()
-		select {
-		case err := <-errCh:
+		// Everything here is best effort; so give the context a timeout
+		// to avoid waiting too long. This may be a larger timeout than
+		// the context already has, in which case we'll respect the
+		// existing timeout. A single txn can have more intents than we
+		// can handle in the normal timeout, which would prevent us from
+		// ever cleaning up all of its intents in time to then delete the
+		// txn record, causing an infinite loop on that txn record, where
+		// the same initial set of intents is endlessly re-resolved.
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, intentResolverTimeout)
+		err := ir.store.DB().Run(ctxWithTimeout, b)
+		cancel()
+		if err != nil {
+			// Bail out on the first error.
 			return err
-		default:
 		}
 	}
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2465,7 +2465,9 @@ func (r *Replica) executeReadOnlyBatch(
 		// RangeLookup request which prohibits any concurrent requests for the same
 		// range. See #17760.
 		_, hasRangeLookup := ba.GetArg(roachpb.RangeLookup)
-		r.store.intentResolver.processIntentsAsync(ctx, r, intents, !hasRangeLookup)
+		if err := r.store.intentResolver.processIntentsAsync(ctx, r, intents, !hasRangeLookup); err != nil {
+			log.Warning(ctx, err)
+		}
 	}
 	if pErr != nil {
 		log.ErrEvent(ctx, pErr.String())
@@ -2675,7 +2677,9 @@ func (r *Replica) tryExecuteWriteBatch(
 				// both leave intents to GC that don't hit this code path. No good
 				// solution presents itself at the moment and such intents will be
 				// resolved on reads.
-				r.store.intentResolver.processIntentsAsync(ctx, r, propResult.Intents, true /* allowSync*/)
+				if err := r.store.intentResolver.processIntentsAsync(ctx, r, propResult.Intents, true /* allowSync*/); err != nil {
+					log.Warning(ctx, err)
+				}
 			}
 			return propResult.Reply, propResult.Err, propResult.ProposalRetry
 		case <-slowTimer.C:
@@ -5401,7 +5405,9 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (config.SystemConfig, er
 		// There were intents, so what we read may not be consistent. Attempt
 		// to nudge the intents in case they're expired; next time around we'll
 		// hopefully have more luck.
-		r.store.intentResolver.processIntentsAsync(ctx, r, intents, true /* allowSync */)
+		if err := r.store.intentResolver.processIntentsAsync(ctx, r, intents, true /* allowSync */); err != nil {
+			log.Warning(ctx, err)
+		}
 		return config.SystemConfig{}, errSystemConfigIntent
 	}
 	kvs := br.Responses[0].GetInner().(*roachpb.ScanResponse).Rows


### PR DESCRIPTION
cherrypick-1.1:

This change first moves the cleanup of potentially "fat" transactions out
of the GC critical path by sending them to the intent resolver's asynchronous
cleanup mechanism. This prevents a txn laden with significant numbers of
unresolved intents from gumming up the GC queue and experiencing context
timeouts.

Moved GC of keys scanned during the GC process to execute before intents
encountered during the scan are processed. This makes progress in the GC
queue more likely and greatly lessens the chance of a stubborn range
entering into an infinite GC loop.

Removed unused code for the `ResolveOptions.Wait` boolean and changed
`intentResolver.resolveIntents` to send batches of 100 serially with a new
timeout for each batch. In concert with this, removed the timeout previously
set in `intentResolver.processIntents`.

Release note: improve garbage collection of very large transactions and
large volumes of abandoned writes (intents).

cc @cockroachdb/release