### PR TITLE
sql,acceptance: Add scrub checks to schema changer and allocator tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/scrub
+++ b/pkg/sql/logictest/testdata/logic_test/scrub
@@ -7,27 +7,28 @@ EXPERIMENTAL SCRUB TABLE t
 statement ok
 CREATE TABLE t (
   id int PRIMARY KEY,
-  name string,
-  CONSTRAINT abc CHECK (name > 'he')
+  name STRING,
+  data INT DEFAULT 2,
+  CONSTRAINT abc CHECK (name > 'he'),
+  INDEX name_idx (name)
 )
 
 statement ok
-INSERT INTO t VALUES (1, 'hello')
+INSERT INTO t VALUES (1, 'hello'), (2, 'help'), (0, 'heeee')
+
+# Test scrub against a table with some data and with various different options.
 
 query TTTTTTTT
 EXPERIMENTAL SCRUB TABLE t
 -----
 
 query TTTTTTTT
-EXPERIMENTAL SCRUB TABLE t WITH OPTIONS INDEX ALL
------
-
-statement ok
-CREATE INDEX name_idx ON t (name)
-
-query TTTTTTTT
 EXPERIMENTAL SCRUB TABLE t WITH OPTIONS PHYSICAL
 -----
+
+query TTTTTTTT
+EXPERIMENTAL SCRUB TABLE t WITH OPTIONS INDEX ALL
+------
 
 query TTTTTTTT
 EXPERIMENTAL SCRUB TABLE t WITH OPTIONS PHYSICAL, INDEX (name_idx)
@@ -47,7 +48,6 @@ EXPERIMENTAL SCRUB TABLE t WITH OPTIONS CONSTRAINT (abc)
 statement error pq: constraint "xyz" of relation "t" does not exist
 EXPERIMENTAL SCRUB TABLE t WITH OPTIONS CONSTRAINT (xyz)
 
-# test views
 # test that scrub cannot be used with views
 
 statement ok

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -413,6 +414,10 @@ CREATE INDEX foo ON t.test (v)
 		indexQuery := fmt.Sprintf(`SELECT v FROM t.test@foo%d`, i)
 		mTest.CheckQueryResults(t, indexQuery, [][]string{{"b"}, {"d"}})
 	}
+
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // checkTableKeyCount returns the number of KVs in the DB, the multiple should be the
@@ -518,6 +523,9 @@ func runSchemaChangeWithOperations(
 	if err := checkTableKeyCount(ctx, kvDB, keyMultiple, maxValue+numInserts); err != nil {
 		t.Fatal(err)
 	}
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+		t.Fatal(err)
+	}
 
 	// Delete the rows inserted.
 	for i := 0; i < numInserts; i++ {
@@ -617,6 +625,9 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	// number of keys == 2 * number of rows; 1 column family and 1 index entry
 	// for each row.
 	if err := checkTableKeyCount(ctx, kvDB, 2, maxValue); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -776,6 +787,9 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	// number of keys == 2 * number of rows; 1 column family and 1 index entry
 	// for each row.
 	if err := checkTableKeyCount(ctx, kvDB, 2, maxValue); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1095,6 +1109,10 @@ COMMIT;
 			if err := checkTableKeyCount(
 				ctx, kvDB, testCase.expectedNumKeysPerRow, maxValue,
 			); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -1503,6 +1521,10 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		t.Fatal(err)
 	}
 
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+		t.Fatal(err)
+	}
+
 	// Enable async schema change processing to ensure that it cleans up the
 	// above garbage left behind.
 	atomic.StoreUint32(&enableAsyncSchemaChanges, 1)
@@ -1707,6 +1729,10 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	if err := checkTableKeyCount(ctx, kvDB, 2, maxValue); err != nil {
 		t.Fatal(err)
 	}
+
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // This test checks backward compatibility with old data that contains
@@ -1783,6 +1809,10 @@ CREATE TABLE t.test (
 	const setKey = 5
 	const setVal = maxValue - setKey
 	if _, err := sqlDB.Exec(`UPDATE t.test SET v = $1 WHERE k = $2`, setVal, setKey); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1874,6 +1904,10 @@ CREATE TABLE t.test (
 
 	close(continueBackfillNotification)
 	wg.Wait()
+
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // Test an UPDATE using a primary and a secondary index in the middle
@@ -1941,6 +1975,10 @@ INSERT INTO t.test (k, v, length) VALUES (0, 1, 1);
 	close(continueBackfillNotification)
 
 	wg.Wait()
+
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // Test that a schema change backfill that completes on a
@@ -2021,6 +2059,10 @@ func TestBackfillCompletesOnChunkBoundary(t *testing.T) {
 			if err := checkTableKeyCount(ctx, kvDB, tc.numKeysPerRow, maxValue); err != nil {
 				t.Fatal(err)
 			}
+
+			if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+				t.Fatal(err)
+			}
 		})
 	}
 }
@@ -2094,6 +2136,10 @@ INSERT INTO t.kv VALUES ('a', 'b');
 					t.Fatal(err)
 				}
 				if err := tx.Commit(); err != nil {
+					t.Fatal(err)
+				}
+
+				if err := sqlutils.RunScrub(t, sqlDB, "t", "kv"); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -2205,6 +2251,10 @@ CREATE TABLE d.t (
 				t.Error(err)
 			} else if count != 1 {
 				t.Errorf("expected one row but read %d", count)
+			}
+
+			if err := sqlutils.RunScrub(t, sqlDB, "d", "t"); err != nil {
+				t.Fatal(err)
 			}
 		}
 	}
@@ -2332,6 +2382,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	if err := checkTableKeyCount(ctx, kvDB, 1, maxValue); err != nil {
 		t.Fatal(err)
 	}
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+		t.Fatal(err)
+	}
 
 	// Do not execute the first schema change so that the second schema
 	// change gets queued up behind it. The second schema change will be
@@ -2372,6 +2425,14 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 	if err := checkTableKeyCount(ctx, kvDB, 3, maxValue); err != nil {
 		t.Fatal(err)
 	}
+
+	// The notify schema change channel must be nil-ed out, or else
+	// running scrub will cause it to trigger again on an already closed
+	// channel when we run another statement.
+	notifySchemaChange = nil
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // Test that a table TRUNCATE leaves the database in the correct state
@@ -2409,6 +2470,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14
 	if err := checkTableKeyCount(ctx, kvDB, 1, maxValue); err != nil {
 		t.Fatal(err)
 	}
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+		t.Fatal(err)
+	}
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 
@@ -2432,6 +2496,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14
 
 	// Check that SQL thinks the table is empty.
 	if err := checkTableKeyCount(ctx, kvDB, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2504,6 +2571,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL REFERENCES t.pi (d) DE
 	if err := checkTableKeyCount(ctx, kvDB, 2, maxValue); err != nil {
 		t.Fatal(err)
 	}
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
+		t.Fatal(err)
+	}
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 
@@ -2536,6 +2606,9 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL REFERENCES t.pi (d) DE
 	}
 
 	if err := checkTableKeyCount(ctx, kvDB, 2, maxValue); err != nil {
+		t.Fatal(err)
+	}
+	if err := sqlutils.RunScrub(t, sqlDB, "t", "test"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/sqlbase/multirowfetcher.go
+++ b/pkg/sql/sqlbase/multirowfetcher.go
@@ -1031,8 +1031,9 @@ func (mrf *MultiRowFetcher) checkKeyOrdering(ctx context.Context) error {
 	}
 
 	evalCtx := tree.EvalContext{}
-	for i := range mrf.rowReadyTable.index.ColumnIDs {
-		result := mrf.rowReadyTable.decodedRow[i].Compare(&evalCtx, mrf.rowReadyTable.lastDatums[i])
+	for i, id := range mrf.rowReadyTable.index.ColumnIDs {
+		idx := mrf.rowReadyTable.colIdxMap[id]
+		result := mrf.rowReadyTable.decodedRow[idx].Compare(&evalCtx, mrf.rowReadyTable.lastDatums[idx])
 		expectedDirection := mrf.rowReadyTable.index.ColumnDirections[i]
 		if mrf.reverse && expectedDirection == IndexDescriptor_ASC {
 			expectedDirection = IndexDescriptor_DESC

--- a/pkg/testutils/sqlutils/scrub.go
+++ b/pkg/testutils/sqlutils/scrub.go
@@ -16,7 +16,11 @@ package sqlutils
 
 import (
 	gosql "database/sql"
+	"fmt"
+	"testing"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 // ScrubResult is the go struct for the row results for an
@@ -60,4 +64,23 @@ func GetScrubResultRows(rows *gosql.Rows) (results []ScrubResult, err error) {
 	}
 
 	return results, nil
+}
+
+// RunScrub will run execute an exhaustive scrub check for a table.
+func RunScrub(t *testing.T, sqlDB *gosql.DB, database string, table string) error {
+	rows, err := sqlDB.Query(fmt.Sprintf(`EXPERIMENTAL SCRUB TABLE %s.%s`,
+		database, table))
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	results, err := GetScrubResultRows(rows)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	if len(results) > 0 {
+		return errors.Errorf("expected no scrub results instead got: %#v", results)
+	}
+	return nil
 }

--- a/pkg/testutils/sqlutils/scrub.go
+++ b/pkg/testutils/sqlutils/scrub.go
@@ -1,0 +1,63 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlutils
+
+import (
+	gosql "database/sql"
+	"time"
+)
+
+// ScrubResult is the go struct for the row results for an
+// EXPERIMENTAL SCRUB query.
+type ScrubResult struct {
+	ErrorType  string
+	Database   string
+	Table      string
+	PrimaryKey string
+	Timestamp  time.Time
+	Repaired   bool
+	Details    string
+}
+
+// GetScrubResultRows will scan and unmarshal ScrubResults from a Rows
+// iterator. The Rows iterate must from an EXPERIMENTAL SCRUB query.
+func GetScrubResultRows(rows *gosql.Rows) (results []ScrubResult, err error) {
+	defer rows.Close()
+
+	var unused *string
+	for rows.Next() {
+		result := ScrubResult{}
+		if err := rows.Scan(
+			// TODO(joey): In the future, SCRUB will run as a job during execution.
+			&unused, /* job_uuid */
+			&result.ErrorType,
+			&result.Database,
+			&result.Table,
+			&result.PrimaryKey,
+			&result.Timestamp,
+			&result.Repaired,
+			&result.Details,
+		); err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+	}
+
+	if rows.Err() != nil {
+		return nil, err
+	}
+
+	return results, nil
+}


### PR DESCRIPTION
This adds index integrity to all of the existing schema changer tests.
This compliments the existing assertions ensuring that the right amount
of KVs exist for the expected amount of rows.

This also adds additional checks using scrub to validate the integrity of
allocator acceptance tests when they run schema changes.

cc: @vivekmenezes were there any other tests you were thinking of that we could add these checks to?