### PR TITLE
RFCS: mark quiesce ranges RFC as obsolete

### DIFF
--- a/docs/RFCS/20160824_quiesce_ranges.md
+++ b/docs/RFCS/20160824_quiesce_ranges.md
@@ -1,5 +1,5 @@
 - Feature Name: Quiesce Ranges
-- Status: postponed
+- Status: obsolete
 - Start Date: 2016-06-24
 - Authors: David Taylor, Daniel Harrison, Tobias Schottdorf
 - RFC PR: #8811


### PR DESCRIPTION
We implemented range quiescence a while ago, though not in the manner
described in this RFC.