### PR TITLE
pgwire: fix issue with re-using old buffer data

### DIFF
--- a/pkg/acceptance/testdata/node/base-test.js
+++ b/pkg/acceptance/testdata/node/base-test.js
@@ -65,3 +65,21 @@ describe('arrays', () => {
     });
   });
 });
+
+describe('regression tests', () => {
+  it('allows you to switch between format modes for arrays', () => {
+    return client.query({
+            text: 'SELECT $1:::int[] as b',
+            values: [[1, 2, 8]],
+            binary: false,
+          }).then(r => {
+            return client.query({
+              text: 'SELECT $1:::int[] a',
+              values: [[4, 5, 6]],
+              binary: true,
+            });
+          }).then(results => {
+            assert.deepEqual([4, 5, 6], results.rows[0].a);
+          });
+  });
+})

--- a/pkg/sql/pgwire/encoding.go
+++ b/pkg/sql/pgwire/encoding.go
@@ -211,6 +211,17 @@ func (b *writeBuffer) writeLengthPrefixedVariablePutbuf() {
 	}
 }
 
+// writeLengthPrefixedBuffer writes the contents of a bytes.Buffer with a
+// length prefix.
+func (b *writeBuffer) writeLengthPrefixedBuffer(buf *bytes.Buffer) {
+	if b.err == nil {
+		b.putInt32(int32(buf.Len()))
+
+		// bytes.Buffer.WriteTo resets the Buffer.
+		_, b.err = buf.WriteTo(&b.wrapped)
+	}
+}
+
 // writeLengthPrefixedString writes a length-prefixed string. The
 // length is encoded as an int32.
 func (b *writeBuffer) writeLengthPrefixedString(s string) {

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -389,7 +389,7 @@ func (b *writeBuffer) writeBinaryDatum(
 			b.setError(errors.New("unsupported binary serialization of multidimensional arrays"))
 			return
 		}
-		subWriter := &writeBuffer{wrapped: b.variablePutbuf}
+		subWriter := &writeBuffer{}
 		// Put the number of dimensions. We currently support 1d arrays only.
 		subWriter.putInt32(1)
 		hasNulls := 0
@@ -403,8 +403,7 @@ func (b *writeBuffer) writeBinaryDatum(
 		for _, elem := range v.Array {
 			subWriter.writeBinaryDatum(ctx, elem, sessionLoc)
 		}
-		b.variablePutbuf = subWriter.wrapped
-		b.writeLengthPrefixedVariablePutbuf()
+		b.writeLengthPrefixedBuffer(&subWriter.wrapped)
 	case *tree.DOid:
 		b.putInt32(4)
 		b.putInt32(int32(v.DInt))

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -15,6 +15,8 @@
 package pgwire
 
 import (
+	"bytes"
+	"reflect"
 	"testing"
 	"time"
 
@@ -22,6 +24,7 @@ import (
 
 	"github.com/lib/pq/oid"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -80,6 +83,30 @@ func TestTimestampRoundtrip(t *testing.T) {
 		if actual := parse(formatTs(ts, tz, nil)); !ts.Equal(actual) {
 			t.Fatalf("[%s]: timestamp did not roundtrip got [%s] expected [%s]", tz, actual, ts)
 		}
+	}
+}
+
+func TestWriteBinaryArray(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Regression test for #20372. Ensure that writing twice to the same
+	// writeBuffer is equivalent to writing to two different writeBuffers and
+	// then concatenating the result.
+	ary, _ := tree.ParseDArrayFromString(tree.NewTestingEvalContext(), "{1}", coltypes.Int)
+
+	writeBuf1 := &writeBuffer{}
+	writeBuf1.writeTextDatum(context.Background(), ary, time.UTC)
+	writeBuf1.writeBinaryDatum(context.Background(), ary, time.UTC)
+
+	writeBuf2 := &writeBuffer{}
+	writeBuf2.writeTextDatum(context.Background(), ary, time.UTC)
+
+	writeBuf3 := &writeBuffer{}
+	writeBuf3.writeBinaryDatum(context.Background(), ary, time.UTC)
+
+	concatted := bytes.Join([][]byte{writeBuf2.wrapped.Bytes(), writeBuf3.wrapped.Bytes()}, nil)
+
+	if !reflect.DeepEqual(writeBuf1.wrapped.Bytes(), concatted) {
+		t.Fatalf("expected %v, got %v", concatted, writeBuf1.wrapped.Bytes())
 	}
 }
 


### PR DESCRIPTION
Release notes: fix issue with stale buffer data when using the binary
format for arrays.

Fixes #20372.
Fixes #19669.

This commit fixes an issue involving passing a bytes.Buffer by value
which would cause old buffered data for arrays to be re-used.

The bug here was somewhat subtle and had to do with copying a
bytes.Buffer by value whose slice header pointed to its fixed-size array
used for small allocations, and then *re-assigning* the original buffer,
causing the fixed-size array to be overwritten and the buffered value
changed. A reduced version of the issue can be seen here:

https://play.golang.org/p/4-v_AeqYtR