### PR TITLE
cli: check existing instance in RocksDB debug

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -1549,7 +1549,7 @@ rocksdb::Options DBMakeOptions(DBOptions db_opts) {
   options.max_subcompactions = std::max(db_opts.num_cpu / 2, 1);
   options.WAL_ttl_seconds = db_opts.wal_ttl_seconds;
   options.comparator = &kComparator;
-  options.create_if_missing = true;
+  options.create_if_missing = !db_opts.must_exist;
   options.info_log.reset(new DBLogger(db_opts.logging_enabled));
   options.merge_operator.reset(new DBMergeOperator);
   options.prefix_extractor.reset(new DBPrefixExtractor);

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -72,6 +72,7 @@ typedef struct {
   int num_cpu;
   int max_open_files;
   bool use_switching_env;
+  bool must_exist;
 } DBOptions;
 
 // Create a new cache with the specified size.

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -69,7 +69,7 @@ func parseRangeID(arg string) (roachpb.RangeID, error) {
 	return roachpb.RangeID(rangeIDInt), nil
 }
 
-func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (*engine.RocksDB, error) {
+func openExistingStore(dir string, stopper *stop.Stopper) (*engine.RocksDB, error) {
 	cache := engine.NewRocksDBCache(server.DefaultCacheSize)
 	defer cache.Release()
 	maxOpenFiles, err := server.SetOpenFileLimitForOneStore()
@@ -81,6 +81,7 @@ func openStore(cmd *cobra.Command, dir string, stopper *stop.Stopper) (*engine.R
 			Settings:     serverCfg.Settings,
 			Dir:          dir,
 			MaxOpenFiles: maxOpenFiles,
+			MustExist:    true,
 		},
 		cache,
 	)
@@ -137,7 +138,7 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 		return errors.New("one argument required: dir")
 	}
 
-	db, err := openStore(cmd, args[0], stopper)
+	db, err := openExistingStore(args[0], stopper)
 	if err != nil {
 		return err
 	}
@@ -169,7 +170,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 		return errors.New("two arguments required: dir range_id")
 	}
 
-	db, err := openStore(cmd, args[0], stopper)
+	db, err := openExistingStore(args[0], stopper)
 	if err != nil {
 		return err
 	}
@@ -407,7 +408,7 @@ func runDebugRangeDescriptors(cmd *cobra.Command, args []string) error {
 		return errors.New("one argument required: dir")
 	}
 
-	db, err := openStore(cmd, args[0], stopper)
+	db, err := openExistingStore(args[0], stopper)
 	if err != nil {
 		return err
 	}
@@ -479,7 +480,7 @@ func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 		return errors.New("two arguments required: dir range_id")
 	}
 
-	db, err := openStore(cmd, args[0], stopper)
+	db, err := openExistingStore(args[0], stopper)
 	if err != nil {
 		return err
 	}
@@ -529,7 +530,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 		return errors.New("arguments: dir [range_id]")
 	}
 
-	db, err := openStore(cmd, args[0], stopper)
+	db, err := openExistingStore(args[0], stopper)
 	if err != nil {
 		return err
 	}
@@ -615,7 +616,7 @@ func runDebugCheckStoreCmd(cmd *cobra.Command, args []string) error {
 		return errors.New("one required argument: dir")
 	}
 
-	db, err := openStore(cmd, args[0], stopper)
+	db, err := openExistingStore(args[0], stopper)
 	if err != nil {
 		return err
 	}
@@ -737,7 +738,7 @@ func runDebugCompact(cmd *cobra.Command, args []string) error {
 		return errors.New("one argument is required")
 	}
 
-	db, err := openStore(cmd, args[0], stopper)
+	db, err := openExistingStore(args[0], stopper)
 	if err != nil {
 		return err
 	}
@@ -780,7 +781,7 @@ func runDebugSSTables(cmd *cobra.Command, args []string) error {
 		return errors.New("one argument is required")
 	}
 
-	db, err := openStore(cmd, args[0], stopper)
+	db, err := openExistingStore(args[0], stopper)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/debug_test.go
+++ b/pkg/cli/debug_test.go
@@ -1,0 +1,77 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+)
+
+func TestOpenExistingStore(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	baseDir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	dirExists := filepath.Join(baseDir, "exists")
+	dirMissing := filepath.Join(baseDir, "missing")
+
+	func() {
+		cache := engine.NewRocksDBCache(server.DefaultCacheSize)
+		defer cache.Release()
+		db, err := engine.NewRocksDB(
+			engine.RocksDBConfig{
+				Dir:       dirExists,
+				MustExist: false,
+			},
+			cache,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		db.Close()
+	}()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.Background())
+
+	for _, test := range []struct {
+		dir    string
+		expErr string
+	}{
+		{
+			dir:    dirExists,
+			expErr: "",
+		},
+		{
+			dir:    dirMissing,
+			expErr: `could not open rocksdb instance: .* does not exist \(create_if_missing is false\)`,
+		},
+	} {
+		_, err := openExistingStore(test.dir, stopper)
+		if !testutils.IsError(err, test.expErr) {
+			t.Fatalf("%s: wanted %s but got %v", test.dir, test.expErr, err)
+		}
+	}
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -462,9 +462,12 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 		return Engines{}, err
 	}
 
+	log.Event(ctx, "initializing engines")
+
 	skipSizeCheck := cfg.TestingKnobs.Store != nil &&
 		cfg.TestingKnobs.Store.(*storage.StoreTestingKnobs).SkipMinSizeCheck
 	for i, spec := range cfg.Stores.Specs {
+		log.Eventf(ctx, "initializing %+v", spec)
 		var sizeInBytes = spec.SizeInBytes
 		if spec.InMemory {
 			if spec.SizePercent > 0 {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -295,6 +295,11 @@ type RocksDBConfig struct {
 	Attrs roachpb.Attributes
 	// Dir is the data directory for this store.
 	Dir string
+	// If true, creating the instance fails if the target directory does not hold
+	// an initialized RocksDB instance.
+	//
+	// Makes no sense for in-memory instances.
+	MustExist bool
 	// MaxSizeBytes is used for calculating free space and making rebalancing
 	// decisions. Zero indicates that there is no maximum size.
 	MaxSizeBytes int64
@@ -458,6 +463,7 @@ func (r *RocksDB) open() error {
 			num_cpu:           C.int(runtime.NumCPU()),
 			max_open_files:    C.int(maxOpenFiles),
 			use_switching_env: C.bool(newVersion == versionCurrent),
+			must_exist:        C.bool(r.cfg.MustExist),
 		})
 	if err := statusToError(status); err != nil {
 		return errors.Wrap(err, "could not open rocksdb instance")

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -370,6 +370,27 @@ func TestReadAmplification(t *testing.T) {
 	}
 }
 
+func TestInMemIllegalOption(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cache := NewRocksDBCache(10 << 20 /* 10mb */)
+	defer cache.Release()
+
+	r := &RocksDB{
+		cfg: RocksDBConfig{
+			MustExist: true,
+		},
+		// dir: empty dir == "mem" RocksDB instance.
+		cache: cache.ref(),
+	}
+	err := r.open()
+	const expErr = `could not open rocksdb instance: Invalid argument: ` +
+		`: does not exist \(create_if_missing is false\)`
+	if !testutils.IsError(err, expErr) {
+		t.Error(err)
+	}
+}
+
 func TestConcurrentBatch(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
Running, for example, `./cockroach debug keys no-such-dir` would result
in a new RocksDB instance to be initialized at `no-such-dir`. This is
confusing and annyoing; instead, return an error.

Release note: None