### PR TITLE
distsql: Properly measure synchronous flows

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -343,12 +343,14 @@ func (ds *ServerImpl) RunSyncFlow(stream DistSQL_RunSyncFlowServer) error {
 		ctx, ctxCancel := contextutil.WithCancel(ctx)
 		defer ctxCancel()
 		mbox.start(ctx, &f.waitGroup, ctxCancel)
+		ds.Metrics.FlowStart()
 		if err := f.Start(ctx, func() {}); err != nil {
 			log.Fatalf(ctx, "unexpected error from syncFlow.Start(): %s "+
 				"The error should have gone to the consumer.", err)
 		}
 		f.Wait()
 		f.Cleanup(ctx)
+		ds.Metrics.FlowStop()
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
We were missing calls to account for them in our metrics.

Fixes #20501

Release note (bug fix): Account for some distsql flows in the exported
sql.distsql.flows.active and sql.distsql.flows.total metrics and the
"Active Flows for Distributed SQL Queries" admin UI graph that had
previously been missing.