### PR TITLE
storage: thread ctx into reportSnapshotStatus

### DIFF
--- a/pkg/storage/raft_snapshot_queue.go
+++ b/pkg/storage/raft_snapshot_queue.go
@@ -116,7 +116,7 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 	err := repl.sendSnapshot(ctx, repDesc, snapTypeRaft, SnapshotRequest_RECOVERY)
 	// Report the snapshot status to Raft, which expects us to do this once
 	// we finish sending the snapshot.
-	repl.reportSnapshotStatus(uint64(id), err)
+	repl.reportSnapshotStatus(ctx, id, err)
 	return err
 }
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4316,7 +4316,7 @@ func (r *Replica) sendRaftMessageRequest(ctx context.Context, req *RaftMessageRe
 	return ok
 }
 
-func (r *Replica) reportSnapshotStatus(to uint64, snapErr error) {
+func (r *Replica) reportSnapshotStatus(ctx context.Context, to roachpb.ReplicaID, snapErr error) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 
@@ -4326,10 +4326,9 @@ func (r *Replica) reportSnapshotStatus(to uint64, snapErr error) {
 	}
 
 	if err := r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
-		raftGroup.ReportSnapshot(to, snapStatus)
+		raftGroup.ReportSnapshot(uint64(to), snapStatus)
 		return true, nil
 	}); err != nil {
-		ctx := r.AnnotateCtx(context.TODO())
 		log.Fatal(ctx, err)
 	}
 }


### PR DESCRIPTION
Driveby cleanup from [this experiment](https://github.com/cockroachdb/cockroach/pull/19229#issuecomment-349442752). The experiment didn't prove successful but at least we now have one fewer `context.TODO()`!

Release note: None