### PR TITLE
sql: fix BenchmarkTableReader panic on trying to specify 0 internal columns

### DIFF
--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -268,6 +268,7 @@ func BenchmarkTableReader(b *testing.B) {
 		nodeID: s.NodeID(),
 	}
 	spec := TableReaderSpec{
+		Table: *tableDesc,
 		Spans: []TableReaderSpan{{Span: tableDesc.PrimaryIndexSpan()}},
 	}
 	post := PostProcessSpec{}


### PR DESCRIPTION
Noticed that nightlies for benchmarks were failing because of this

https://teamcity.cockroachdb.com/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=430383&_focus=19515

Release notes: none