### PR TITLE
cherrypick-1.1: distsql: fix crash in addSorters

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1235,14 +1235,18 @@ func (dsp *distSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
 		// in the output columns of the sortNode; we set a projection such that the
 		// plan results map 1-to-1 to sortNode columns.
 		//
-		// Note that internally, AddProjection might retain more columns as
-		// necessary so we can preserve the p.Ordering between parallel streams when
-		// they merge later.
+		// Note that internally, AddProjection might retain more columns than
+		// necessary so we can preserve the p.Ordering between parallel streams
+		// when they merge later.
 		p.planToStreamColMap = p.planToStreamColMap[:len(n.columns)]
-		columns := make([]uint32, len(n.columns))
+		columns := make([]uint32, 0, len(n.columns))
 		for i, col := range p.planToStreamColMap {
-			columns[i] = uint32(col)
-			p.planToStreamColMap[i] = i
+			if col < 0 {
+				// This column isn't needed; ignore it.
+				continue
+			}
+			p.planToStreamColMap[i] = len(columns)
+			columns = append(columns, uint32(col))
 		}
 		p.AddProjection(columns)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -276,3 +276,14 @@ SELECT y, str, REPEAT('test', y) FROM NumToStr ORDER BY str
 # Verify we use the "top K" strategy and thus don't hit OOM as above.
 statement ok
 SELECT y, str, REPEAT('test', y) FROM NumToStr ORDER BY str LIMIT 10
+
+# Regression test for #20481.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT COUNT(*) FROM (SELECT 1 AS one FROM NumToSquare WHERE x > 10 ORDER BY xsquared LIMIT 10)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJyUkUFLxDAQhe_-iuWdFHPYdG85rXhakK3srniQIrEZSqBtajIBZel_lzaIWmhxj_Mm3_sCc0brDO11QwHqBRKFQOddSSE4P0Tpwc58QK0FbNtFHuJCoHSeoM5gyzVB4aTfajqQNuQhYIi1rcfSzttG-89tGxt24T1qTxDII6vVNkPRC7jIP72BdUVQshf_dx-d56l2K2-_NRB4sI3llVzP-rJLfHdV5anS7CbO-_xpf3o95M_H65tZ0-YS04FC59pAfzxzzeu-ECBTUbpccNGX9OhdOWrSmI_cGBgKnLYyDbs2rYYP_oblIpwtw9kivJnARX_1FQAA___U0tm5
+
+query I
+SELECT COUNT(*) FROM (SELECT 1 AS one FROM NumToSquare WHERE x > 10 ORDER BY xsquared LIMIT 10)
+----
+10


### PR DESCRIPTION
Fixing a crash triggered by a case where we don't actually need a sortNode
column.

Fixes #20481.

Release note (bug fix): fixed a crash triggered by some corner-case queries
containing ORDER BY.

@cockroachdb/release 