### PR TITLE
sql/sem/tree: get rid of sql/sem/tests

### DIFF
--- a/pkg/sql/sem/tests/README.md
+++ b/pkg/sql/sem/tests/README.md
@@ -1,9 +1,0 @@
-This directory contains SQL front-end tests that cannot be placed in
-their respective front-end packages because a circular dependency
-would be otherwise necessary.
-
-This is typical of tests that exercise some tree aspect (e.g. type
-checking) but need the SQL parser to input test trees. As the `parser`
-package depends on `tree`, a tests that needs both cannot live in
-`tree`. We do not wish to place such tests in the `parser` package to
-keep `parser` as small as possible.

--- a/pkg/sql/sem/tree/col_types_test.go
+++ b/pkg/sql/sem/tree/col_types_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"fmt"

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"go/constant"

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"math"

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"fmt"

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"reflect"

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"bytes"

--- a/pkg/sql/sem/tree/function_name_test.go
+++ b/pkg/sql/sem/tree/function_name_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"testing"

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"testing"

--- a/pkg/sql/sem/tree/table_name_test.go
+++ b/pkg/sql/sem/tree/table_name_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"fmt"

--- a/pkg/sql/sem/tree/timeconv_test.go
+++ b/pkg/sql/sem/tree/timeconv_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"testing"

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"go/constant"

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tests
+package tree_test
 
 import (
 	"regexp"


### PR DESCRIPTION
Integrate the tests in sql/sem/tests into sql/sem/tree by placing them
in the `tree_test` package.

Release note: None