### PR TITLE
sql: extend VariadicType to support fixed types

### DIFF
--- a/docs/codelabs/00-sql-function.md
+++ b/docs/codelabs/00-sql-function.md
@@ -67,7 +67,7 @@ let’s add it right at the top of the definition for simplicity:
 var Builtins = map[string][]tree.Builtin{
   "whois": {
     tree.Builtin{
-      Types:      tree.VariadicType{Typ: types.String},
+      Types:      tree.VariadicType{VarType: types.String},
       ReturnType: tree.FixedReturnType(types.String),
       Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
         return tree.DNull, fmt.Errorf("nothing to see here")
@@ -339,7 +339,7 @@ check your solution against ours.
   ```diff
     "whois": {
       tree.Builtin{
-        Types:      tree.VariadicType{Typ: types.String},
+        Types:      tree.VariadicType{VarType: types.String},
         ReturnType: tree.FixedReturnType(types.TypeString),
         Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
           users := map[string]string{

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -358,7 +358,11 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
+<tr><td><code>json_extract_path(jsonb, <a href="string.html">string</a>...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the JSON value pointed to by the variadic arguments.</p>
+</span></td></tr>
 <tr><td><code>json_typeof(val: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the type of the outermost JSON value as a text string.</p>
+</span></td></tr>
+<tr><td><code>jsonb_extract_path(jsonb, <a href="string.html">string</a>...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the JSON value pointed to by the variadic arguments.</p>
 </span></td></tr>
 <tr><td><code>jsonb_typeof(val: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the type of the outermost JSON value as a text string.</p>
 </span></td></tr></tbody>

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -183,3 +183,33 @@ a
 
 query error pq: json_object_keys\(\): cannot iterate keys of non-object
 SELECT json_object_keys('[1, 2, 3]'::JSON)
+
+query T
+SELECT json_extract_path('{"a": 1}', 'a')
+----
+1
+
+query T
+SELECT json_extract_path('{"a": 1}')
+----
+{"a":1}
+
+query T
+SELECT json_extract_path('{"a": {"b": 2}}', 'a')
+----
+{"b":2}
+
+query T
+SELECT json_extract_path('{"a": {"b": 2}}', 'a', 'b')
+----
+2
+
+query T
+SELECT jsonb_extract_path('{"a": {"b": 2}}', 'a', 'b')
+----
+2
+
+query T
+SELECT json_extract_path('{"a": {"b": 2}}', 'a', 'b', 'c')
+----
+NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1030,7 +1030,7 @@ FROM pg_catalog.pg_proc
 WHERE proname='least'
 ----
 proname  provariadic  pronargs  prorettype  proargtypes  proargmodes
-least    2283         1         2283        2283         v
+least    2283         1         2283        2283         {"v"}
 
 ## pg_catalog.pg_range
 query IIIIII colnames

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1032,6 +1032,14 @@ WHERE proname='least'
 proname  provariadic  pronargs  prorettype  proargtypes  proargmodes
 least    2283         1         2283        2283         {"v"}
 
+query TOIOTT colnames
+SELECT proname, provariadic, pronargs, prorettype, proargtypes, proargmodes
+FROM pg_catalog.pg_proc
+WHERE proname='json_extract_path'
+----
+proname              provariadic  pronargs  prorettype  proargtypes  proargmodes
+json_extract_path    25           2         3802        3802, 25     {"i","v"}
+
 ## pg_catalog.pg_range
 query IIIIII colnames
 SELECT * from pg_catalog.pg_range

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1598,6 +1598,10 @@ CockroachDB supports the following flags:
 	// implemented.
 	},
 
+	"json_extract_path": {jsonExtractPathImpl},
+
+	"jsonb_extract_path": {jsonExtractPathImpl},
+
 	"json_typeof": {jsonTypeOfImpl},
 
 	"jsonb_typeof": {jsonTypeOfImpl},
@@ -2411,6 +2415,30 @@ var (
 	jsonArrayDString   = tree.NewDString("array")
 	jsonObjectDString  = tree.NewDString("object")
 )
+
+var jsonExtractPathImpl = tree.Builtin{
+	Types:      tree.VariadicType{FixedTypes: []types.T{types.JSON}, VarType: types.String},
+	ReturnType: tree.FixedReturnType(types.JSON),
+	Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+		j := tree.MustBeDJSON(args[0])
+		path := make([]string, len(args)-1)
+		for i, v := range args {
+			if i == 0 {
+				continue
+			}
+			path[i-1] = string(tree.MustBeDString(v))
+		}
+		result, err := json.FetchPath(j.JSON, path)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			return tree.DNull, nil
+		}
+		return &tree.DJSON{JSON: result}, nil
+	},
+	Info: "Returns the JSON value pointed to by the variadic arguments.",
+}
 
 var jsonTypeOfImpl = tree.Builtin{
 	Types:      tree.ArgTypes{{"val", types.JSON}},

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -136,7 +136,7 @@ var Builtins = map[string][]tree.Builtin{
 	// NULL arguments are ignored.
 	"concat": {
 		tree.Builtin{
-			Types:        tree.VariadicType{Typ: types.String},
+			Types:        tree.VariadicType{VarType: types.String},
 			ReturnType:   tree.FixedReturnType(types.String),
 			NullableArgs: true,
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
@@ -159,7 +159,7 @@ var Builtins = map[string][]tree.Builtin{
 
 	"concat_ws": {
 		tree.Builtin{
-			Types:        tree.VariadicType{Typ: types.String},
+			Types:        tree.VariadicType{VarType: types.String},
 			ReturnType:   tree.FixedReturnType(types.String),
 			NullableArgs: true,
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
@@ -2594,7 +2594,7 @@ func feedHash(h hash.Hash, args tree.Datums) {
 func hashBuiltin(newHash func() hash.Hash, info string) []tree.Builtin {
 	return []tree.Builtin{
 		{
-			Types:        tree.VariadicType{Typ: types.String},
+			Types:        tree.VariadicType{VarType: types.String},
 			ReturnType:   tree.FixedReturnType(types.String),
 			NullableArgs: true,
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
@@ -2605,7 +2605,7 @@ func hashBuiltin(newHash func() hash.Hash, info string) []tree.Builtin {
 			Info: info,
 		},
 		{
-			Types:        tree.VariadicType{Typ: types.Bytes},
+			Types:        tree.VariadicType{VarType: types.Bytes},
 			ReturnType:   tree.FixedReturnType(types.String),
 			NullableArgs: true,
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
@@ -2621,7 +2621,7 @@ func hashBuiltin(newHash func() hash.Hash, info string) []tree.Builtin {
 func hash32Builtin(newHash func() hash.Hash32, info string) []tree.Builtin {
 	return []tree.Builtin{
 		{
-			Types:        tree.VariadicType{Typ: types.String},
+			Types:        tree.VariadicType{VarType: types.String},
 			ReturnType:   tree.FixedReturnType(types.Int),
 			NullableArgs: true,
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
@@ -2632,7 +2632,7 @@ func hash32Builtin(newHash func() hash.Hash32, info string) []tree.Builtin {
 			Info: info,
 		},
 		{
-			Types:        tree.VariadicType{Typ: types.Bytes},
+			Types:        tree.VariadicType{VarType: types.Bytes},
 			ReturnType:   tree.FixedReturnType(types.Int),
 			NullableArgs: true,
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
@@ -2647,7 +2647,7 @@ func hash32Builtin(newHash func() hash.Hash32, info string) []tree.Builtin {
 func hash64Builtin(newHash func() hash.Hash64, info string) []tree.Builtin {
 	return []tree.Builtin{
 		{
-			Types:        tree.VariadicType{Typ: types.String},
+			Types:        tree.VariadicType{VarType: types.String},
 			ReturnType:   tree.FixedReturnType(types.Int),
 			NullableArgs: true,
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
@@ -2658,7 +2658,7 @@ func hash64Builtin(newHash func() hash.Hash64, info string) []tree.Builtin {
 			Info: info,
 		},
 		{
-			Types:        tree.VariadicType{Typ: types.Bytes},
+			Types:        tree.VariadicType{VarType: types.Bytes},
 			ReturnType:   tree.FixedReturnType(types.Int),
 			NullableArgs: true,
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -161,11 +161,12 @@ func (HomogeneousType) String() string {
 	return "anyelement..."
 }
 
-// VariadicType is a TypeList implementation which accepts any number of
-// arguments and matches when each argument is either NULL or of the type
-// typ.
+// VariadicType is a TypeList implementation which accepts a fixed number of
+// arguments at the beginning and an arbitrary number of homogenous arguments
+// at the end.
 type VariadicType struct {
-	Typ types.T
+	FixedTypes []types.T
+	VarType    types.T
 }
 
 func (v VariadicType) match(types []types.T) bool {
@@ -178,29 +179,51 @@ func (v VariadicType) match(types []types.T) bool {
 }
 
 func (v VariadicType) matchAt(typ types.T, i int) bool {
-	return typ == types.Null || v.Typ.Equivalent(typ)
+	if i < len(v.FixedTypes) {
+		return typ == types.Null || v.FixedTypes[i].Equivalent(typ)
+	}
+	return typ == types.Null || v.VarType.Equivalent(typ)
 }
 
 func (v VariadicType) matchLen(l int) bool {
-	return true
+	return l >= len(v.FixedTypes)
 }
 
 func (v VariadicType) getAt(i int) types.T {
-	return v.Typ
+	if i < len(v.FixedTypes) {
+		return v.FixedTypes[i]
+	}
+	return v.VarType
 }
 
 // Length implements the TypeList interface.
 func (v VariadicType) Length() int {
-	return 1
+	return len(v.FixedTypes) + 1
 }
 
 // Types implements the TypeList interface.
 func (v VariadicType) Types() []types.T {
-	return []types.T{v.Typ}
+	result := make([]types.T, len(v.FixedTypes)+1)
+	for i := range v.FixedTypes {
+		result[i] = v.FixedTypes[i]
+	}
+	result[len(result)-1] = v.VarType
+	return result
 }
 
 func (v VariadicType) String() string {
-	return fmt.Sprintf("%s...", v.Typ)
+	var s bytes.Buffer
+	for i, t := range v.FixedTypes {
+		if i != 0 {
+			s.WriteString(", ")
+		}
+		s.WriteString(t.String())
+	}
+	if len(v.FixedTypes) > 0 {
+		s.WriteString(", ")
+	}
+	s.WriteString(fmt.Sprintf("%s...", v.VarType))
+	return s.String()
 }
 
 // UnknownReturnType is returned from ReturnTypers when the arguments provided are

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -187,8 +187,11 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 				args = append(args, r.GenerateRandomArg(typ))
 			}
 		case tree.VariadicType:
+			for _, t := range ft.FixedTypes {
+				args = append(args, r.GenerateRandomArg(t))
+			}
 			for i := r.Intn(5); i > 0; i-- {
-				args = append(args, r.GenerateRandomArg(ft.Typ))
+				args = append(args, r.GenerateRandomArg(ft.VarType))
 			}
 		default:
 			panic(fmt.Sprintf("unknown fn.Types: %T", ft))


### PR DESCRIPTION
Release note: None

This commit extends the behaviour of VariadicType to support a set of
fixed types preceding the variadic splat at the end. It also implements
json{b,}_extract_path using this functionality and updates pg_catalog to
accurately represent this.