### PR TITLE
sql: Add assertions for {Unary,Binary,Func}Expr return types

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -91,33 +91,33 @@
 </span></td></tr>
 <tr><td><code>array_position(array: oid[], elem: oid) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return the index of the first occurrence of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="bool.html">bool</a>[], elem: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="bool.html">bool</a>[], elem: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="bytes.html">bytes</a>[], elem: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="bytes.html">bytes</a>[], elem: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="date.html">date</a>[], elem: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="date.html">date</a>[], elem: <a href="date.html">date</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="decimal.html">decimal</a>[], elem: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="decimal.html">decimal</a>[], elem: <a href="decimal.html">decimal</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="float.html">float</a>[], elem: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="float.html">float</a>[], elem: <a href="float.html">float</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="inet.html">inet</a>[], elem: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="inet.html">inet</a>[], elem: <a href="inet.html">inet</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
 <tr><td><code>array_positions(array: <a href="int.html">int</a>[], elem: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="interval.html">interval</a>[], elem: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="interval.html">interval</a>[], elem: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="string.html">string</a>[], elem: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="string.html">string</a>[], elem: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="time.html">time</a>[], elem: <a href="time.html">time</a>) &rarr; <a href="time.html">time</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="time.html">time</a>[], elem: <a href="time.html">time</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="timestamp.html">timestamp</a>[], elem: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="timestamp.html">timestamp</a>[], elem: <a href="timestamp.html">timestamp</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="timestamp.html">timestamptz</a>[], elem: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="timestamp.html">timestamptz</a>[], elem: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: <a href="uuid.html">uuid</a>[], elem: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: <a href="uuid.html">uuid</a>[], elem: <a href="uuid.html">uuid</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
-<tr><td><code>array_positions(array: oid[], elem: oid) &rarr; oid[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
+<tr><td><code>array_positions(array: oid[], elem: oid) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Returns and array of indexes of all occurrences of <code>elem</code> in <code>array</code>.</p>
 </span></td></tr>
 <tr><td><code>array_prepend(elem: <a href="bool.html">bool</a>, array: <a href="bool.html">bool</a>[]) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Prepends <code>elem</code> to <code>array</code>, returning the result.</p>
 </span></td></tr>

--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -11,7 +11,7 @@
 <table><thead>
 <tr><td><code>#>></code></td><td>Return</td></tr>
 </thead><tbody>
-<tr><td>jsonb <code>#>></code> <a href="string.html">string[]</a></td><td>jsonb</td></tr>
+<tr><td>jsonb <code>#>></code> <a href="string.html">string[]</a></td><td><a href="string.html">string</a></td></tr>
 </tbody></table>
 <table><thead>
 <tr><td><code>%</code></td><td>Return</td></tr>

--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -29,4 +29,5 @@ type TestingKnobs struct {
 	SQLLeaseManager  ModuleTestingKnobs
 	SQLSchemaChanger ModuleTestingKnobs
 	DistSQL          ModuleTestingKnobs
+	SQLEvalContext   ModuleTestingKnobs
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,6 +32,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
 	"golang.org/x/net/context"
 
 	"github.com/elazarl/go-bindata-assetfs"
@@ -475,6 +477,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		execCfg.SchemaChangerTestingKnobs = sqlSchemaChangerTestingKnobs.(*sql.SchemaChangerTestingKnobs)
 	} else {
 		execCfg.SchemaChangerTestingKnobs = new(sql.SchemaChangerTestingKnobs)
+	}
+	if sqlEvalContext := s.cfg.TestingKnobs.SQLEvalContext; sqlEvalContext != nil {
+		execCfg.EvalContextTestingKnobs = *sqlEvalContext.(*tree.EvalContextTestingKnobs)
 	}
 	s.sqlExecutor = sql.NewExecutor(execCfg, s.stopper)
 	s.registry.AddMetricStruct(s.sqlExecutor)

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -281,6 +281,7 @@ type ExecutorConfig struct {
 
 	TestingKnobs              *ExecutorTestingKnobs
 	SchemaChangerTestingKnobs *SchemaChangerTestingKnobs
+	EvalContextTestingKnobs   tree.EvalContextTestingKnobs
 	// HistogramWindowInterval is (server.Config).HistogramWindowInterval.
 	HistogramWindowInterval time.Duration
 

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -37,6 +37,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
@@ -802,6 +804,11 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 				},
 				Store: &storage.StoreTestingKnobs{
 					BootstrapVersion: cfg.bootstrapVersion,
+				},
+				SQLEvalContext: &tree.EvalContextTestingKnobs{
+					AssertBinaryExprReturnTypes: true,
+					AssertUnaryExprReturnTypes:  true,
+					AssertFuncExprReturnTypes:   true,
 				},
 			},
 		},

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1987,7 +1987,7 @@ CockroachDB supports the following flags:
 	"array_positions": arrayBuiltin(func(typ types.T) tree.Builtin {
 		return tree.Builtin{
 			Types:        tree.ArgTypes{{"array", types.TArray{Typ: typ}}, {"elem", typ}},
-			ReturnType:   tree.FixedReturnType(types.TArray{Typ: typ}),
+			ReturnType:   tree.FixedReturnType(types.TArray{Typ: types.Int}),
 			Category:     categoryArray,
 			NullableArgs: true,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1940,7 +1940,20 @@ func (s backgroundCtxProvider) Ctx() context.Context {
 var _ CtxProvider = backgroundCtxProvider{}
 
 // EvalContextTestingKnobs contains test knobs.
-type EvalContextTestingKnobs struct {}
+type EvalContextTestingKnobs struct {
+	// AssertFuncExprReturnTypes indicates whether FuncExpr evaluations
+	// should assert that the returned Datum matches the expected
+	// ReturnType of the function.
+	AssertFuncExprReturnTypes bool
+	// AssertUnaryExprReturnTypes indicates whether UnaryExpr evaluations
+	// should assert that the returned Datum matches the expected
+	// ReturnType of the function.
+	AssertUnaryExprReturnTypes bool
+	// AssertBinaryExprReturnTypes indicates whether BinaryExpr
+	// evaluations should assert that the returned Datum matches the
+	// expected ReturnType of the function.
+	AssertBinaryExprReturnTypes bool
+}
 
 var _ base.ModuleTestingKnobs = &EvalContextTestingKnobs{}
 
@@ -2223,7 +2236,16 @@ func (expr *BinaryExpr) Eval(ctx *EvalContext) (Datum, error) {
 	if right == DNull && !expr.fn.nullableArgs {
 		return DNull, nil
 	}
-	return expr.fn.fn(ctx, left, right)
+	res, err := expr.fn.fn(ctx, left, right)
+	if err != nil {
+		return nil, err
+	}
+	if ctx.TestingKnobs.AssertBinaryExprReturnTypes {
+		if err := ensureExpectedType(expr.fn.ReturnType, res); err != nil {
+			return nil, errors.Wrapf(err, "binary op %q", expr.String())
+		}
+	}
+	return res, err
 }
 
 // Eval implements the TypedExpr interface.
@@ -2965,7 +2987,23 @@ func (expr *FuncExpr) Eval(ctx *EvalContext) (Datum, error) {
 		}
 		return nil, errors.Wrapf(err, "%s()", fName)
 	}
+	if ctx.TestingKnobs.AssertFuncExprReturnTypes {
+		if err := ensureExpectedType(expr.fn.FixedReturnType(), res); err != nil {
+			return nil, errors.Wrapf(err, "function %q", expr.String())
+		}
+	}
 	return res, nil
+}
+
+// ensureExpectedType will return an error if a datum does not match the
+// provided type. If the expected type is Any or if the datum is a Null
+// type, then no error will be returned.
+func ensureExpectedType(exp types.T, d Datum) error {
+	if !(exp.FamilyEqual(types.Any) || d.ResolvedType().Equivalent(types.Null) ||
+		d.ResolvedType().Equivalent(exp)) {
+		return errors.Errorf("expected return type %q, got: %q", exp, d.ResolvedType())
+	}
+	return nil
 }
 
 // Eval implements the TypedExpr interface.
@@ -3083,7 +3121,16 @@ func (expr *UnaryExpr) Eval(ctx *EvalContext) (Datum, error) {
 	if d == DNull {
 		return DNull, nil
 	}
-	return expr.fn.fn(ctx, d)
+	res, err := expr.fn.fn(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+	if ctx.TestingKnobs.AssertUnaryExprReturnTypes {
+		if err := ensureExpectedType(expr.fn.ReturnType, res); err != nil {
+			return nil, errors.Wrapf(err, "unary op %q", expr.String())
+		}
+	}
+	return res, err
 }
 
 // Eval implements the TypedExpr interface.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
@@ -1938,6 +1939,14 @@ func (s backgroundCtxProvider) Ctx() context.Context {
 
 var _ CtxProvider = backgroundCtxProvider{}
 
+// EvalContextTestingKnobs contains test knobs.
+type EvalContextTestingKnobs struct {}
+
+var _ base.ModuleTestingKnobs = &EvalContextTestingKnobs{}
+
+// ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
+func (*EvalContextTestingKnobs) ModuleTestingKnobs() {}
+
 // EvalContext defines the context in which to evaluate an expression, allowing
 // the retrieval of state such as the node ID or statement start time.
 //
@@ -2004,6 +2013,8 @@ type EvalContext struct {
 	SkipNormalize bool
 
 	collationEnv CollationEnvironment
+
+	TestingKnobs EvalContextTestingKnobs
 
 	Mon *mon.BytesMonitor
 

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1289,7 +1289,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 		BinOp{
 			LeftType:   types.JSON,
 			RightType:  types.TArray{Typ: types.String},
-			ReturnType: types.JSON,
+			ReturnType: types.String,
 			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
 				res, err := getJSONPath(*left.(*DJSON), *MustBeDArray(right))
 				if err != nil {

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -683,13 +683,18 @@ func (s *Session) newPlanner(e *Executor, txn *client.Txn) *planner {
 
 // evalCtx creates a tree.EvalContext from the Session's current configuration.
 func (s *Session) evalCtx() tree.EvalContext {
+	var evalContextTestingKnobs tree.EvalContextTestingKnobs
+	if s.execCfg != nil {
+		evalContextTestingKnobs = s.execCfg.EvalContextTestingKnobs
+	}
 	return tree.EvalContext{
-		Location:    &s.Location,
-		Database:    s.Database,
-		User:        s.User,
-		SearchPath:  s.SearchPath,
-		CtxProvider: s,
-		Mon:         &s.TxnState.mon,
+		Location:     &s.Location,
+		Database:     s.Database,
+		User:         s.User,
+		SearchPath:   s.SearchPath,
+		CtxProvider:  s,
+		Mon:          &s.TxnState.mon,
+		TestingKnobs: evalContextTestingKnobs,
 	}
 }
 


### PR DESCRIPTION
Assertions were added to BinaryExpr, UnaryExpr, and FuncExpr evaluation
to ensure that the returned datum type matches the declared expression
return type. If this assertion is violated, the datum that mismatches
the type annotations will continue to be used but may cause subtle or
unexpected bugs.

For example, local execution worked correctly in a basic query with
this problem, but distSQL would always panic if a FuncExpr returned
datum did not match the type annotation. (#20465)

Closes #20465.

Fix return type signature of JSON #>> operator and array_positions.
The following type signatures were changed

    JSON #>> STRING[] now returns a STRING (previously JSON)

    array_positions(<TYPE>[], <TYPE>) now returns a INT[] (previously
        <TYPE>[])

Release note (bug fix): Fixed the return type signature of JSON #>>
operator.

Release note (bug fix): Fixed the return type signature of the
array_positions built-in funtion.

Release note: none