### PR TITLE
ui: avoid null reference error on nodesOverview

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -210,6 +210,10 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
               title: `${statusName} Since`,
               cell: (ns) => {
                 const liveness = nodesSummary.livenessByNodeID[ns.desc.node_id];
+                if (!liveness) {
+                  return "no information";
+                }
+
                 const deadTime = liveness.expiration.wall_time;
                 const deadMoment = LongToMoment(deadTime);
                 return `${moment.duration(deadMoment.diff(moment())).humanize()} ago`;


### PR DESCRIPTION
Before this change, the NotLiveNodesList would blindly step
through the liveness record for each node in the list to get
the last update time.  Unfortunately, nodes without liveness
records are also shown on this list, causing a null
reference error.  This fixes it by just showing the text
"no information" in the case of a node without liveness.

Fixes #20415.

Release note: None