### PR TITLE
build: move commit message guidelines into comment.

### DIFF
--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -9,16 +9,20 @@ fi
 old=$(sed -n '1!p' "$1")
 
 cat > "$1" << EOF
-<pkg>: <short description>
+
 
 Release note: None
 
+# Write a commit message of the form
+#
+# <pkg>: <short description>
+#
 # Please add a release note with a category if your commit has user-facing
-# changes. Leave the message above if not. For example:
+# changes. Leave the default above if not. For example,
 #
 # Release note (sql change): Add support for JSON columns.
 #
-# Category list:
+# Categories.
 # - cli change
 # - sql change
 # - admin ui change


### PR DESCRIPTION
It's nice to have guidance for commit messages, but putting
placeholders in the text itself wastes keystrokes by
requiring users to delete the line every time.  This moves
the guidance into a comment, so it can be left alone.

In addition, this edits the rest of the comment to remove
trailing colons, which cause the corresponding lines to be
lowlighted in the popular vim-polyglot gitcommit syntax.

Release note: None