### PR TITLE
tscache: bump max key size, lose precision if exceeded

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -84,7 +84,7 @@
   branch = "master"
   name = "github.com/andy-kimball/arenaskl"
   packages = ["."]
-  revision = "ba9004a07e17a74381b3cf56ef32216464d26172"
+  revision = "224761e552afe64db9d93004f8d5d3a686b89771"
 
 [[projects]]
   branch = "master"

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -61,7 +61,7 @@ type Cache interface {
 	Add(start, end roachpb.Key, ts hlc.Timestamp, txnID uuid.UUID, readCache bool)
 	// SetLowWater sets the low water mark of the cache for the specified span
 	// to the provided timestamp.
-	SetLowWater(start, end roachpb.Key, timestamp hlc.Timestamp)
+	SetLowWater(start, end roachpb.Key, ts hlc.Timestamp)
 
 	// GetMaxRead returns the maximum read timestamp which overlaps the interval
 	// spanning from start to end. If that maximum timestamp belongs to a single

--- a/pkg/storage/tscache/skl_impl.go
+++ b/pkg/storage/tscache/skl_impl.go
@@ -15,8 +15,11 @@
 package tscache
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -28,7 +31,7 @@ const (
 	// sklImpl to limit its memory footprint. Reducing this size can hurt
 	// performance but it decreases the risk of OOM failures when many tests
 	// are running concurrently.
-	TestSklPageSize = 32 << 10 // 32 KB
+	TestSklPageSize = 128 << 10 // 128 KB
 )
 
 // sklImpl implements the Cache interface. It maintains a pair of skiplists
@@ -73,8 +76,9 @@ func (tc *sklImpl) getSkl(readCache bool) *intervalSkl {
 
 // Add implements the Cache interface.
 func (tc *sklImpl) Add(start, end roachpb.Key, ts hlc.Timestamp, txnID uuid.UUID, readCache bool) {
-	skl := tc.getSkl(readCache)
+	start, end = tc.boundKeyLengths(start, end)
 
+	skl := tc.getSkl(readCache)
 	val := cacheValue{ts: ts, txnID: txnID}
 	if len(end) == 0 {
 		skl.Add(nonNil(start), val)
@@ -114,6 +118,33 @@ func (tc *sklImpl) getMax(start, end roachpb.Key, readCache bool) (hlc.Timestamp
 		val = skl.LookupTimestampRange(nonNil(start), end, excludeTo)
 	}
 	return val.ts, val.txnID
+}
+
+// boundKeyLengths makes sure that the key lengths provided are well below the
+// size of each sklPage, otherwise we'll never be successful in adding it to
+// an intervalSkl.
+func (tc *sklImpl) boundKeyLengths(start, end roachpb.Key) (roachpb.Key, roachpb.Key) {
+	// We bound keys to 1/32 of the page size. These could be slightly larger
+	// and still not trigger the "key range too large" panic in intervalSkl,
+	// but anything larger could require multiple page rotations before it's
+	// able to fit in if other ranges are being added concurrently.
+	maxKeySize := int(tc.pageSize / 32)
+
+	// If either key is too long, truncate its length, making sure to always
+	// grow the [start,end) range instead of shrinking it. This will reduce the
+	// precision of the entry in the cache, which could allow independent
+	// requests to interfere, but will never permit consistency anomalies.
+	if l := len(start); l > maxKeySize {
+		start = start[:maxKeySize]
+		log.Warningf(context.TODO(), "start key with length %d exceeds maximum key length of %d; "+
+			"losing precision in timestamp cache", l, maxKeySize)
+	}
+	if l := len(end); l > maxKeySize {
+		end = end[:maxKeySize].PrefixEnd() // PrefixEnd to grow range
+		log.Warningf(context.TODO(), "end key with length %d exceeds maximum key length of %d; "+
+			"losing precision in timestamp cache", l, maxKeySize)
+	}
+	return start, end
 }
 
 // intervalSkl doesn't handle nil keys the same way as empty keys. Cockroach's


### PR DESCRIPTION
Fixes #20389.

This change bump the dependency on `andy-kimball/arenaskl` to include:
https://github.com/andy-kimball/arenaskl/pull/2

In doing so, it increases the maximum key size allowed by the library
from 64Kb to 4Gb. However, even though the max key size is now this
large, we can't actually store keys larger than the `intervalSkl` page
size. When keys exceed this size (or approach it), we truncate them and
lose precision to prevent hitting a panic in a new sanity check.

Release note: None