### PR TITLE
storage: add information about the size of the freed keys/values to GCInfo

### DIFF
--- a/pkg/storage/engine/gc.go
+++ b/pkg/storage/engine/gc.go
@@ -44,7 +44,7 @@ func MakeGarbageCollector(now hlc.Timestamp, policy config.GCPolicy) GarbageColl
 // key. Returns the index of the first key to be GC'd and the
 // timestamp including, and after which, all values should be garbage
 // collected. If no values should be GC'd, returns -1 for the index
-// and the zero timestamp. keys must be in descending time
+// and the zero timestamp. Keys must be in descending time
 // order. Values deleted at or before the returned timestamp can be
 // deleted without invalidating any reads in the time interval
 // (gc.expiration, \infinity).


### PR DESCRIPTION
Related to #20458

```bash
$ ./cockroach debug estimate-gc ./cockroach-data
...
RangeID: 4 [/System/NodeLivenessMax, /System/tsd):
storage.GCInfo{
    Now:                        hlc.Timestamp{WallTime:1512590365477252547, Logical:0},
    Policy:                     config.GCPolicy{TTLSeconds:86400},
    NumKeysAffected:            4,
    IntentsConsidered:          0,
    IntentTxns:                 0,
    TransactionSpanTotal:       0,
    TransactionSpanGCAborted:   0,
    TransactionSpanGCCommitted: 0,
    TransactionSpanGCPending:   0,
    TxnSpanGCThreshold:         hlc.Timestamp{WallTime:1512586765477252547, Logical:0},
    AbortSpanTotal:             0,
    AbortSpanConsidered:        0,
    AbortSpanGCNum:             0,
    PushTxn:                    0,
    ResolveTotal:               0,
    ResolveSuccess:             0,
    Threshold:                  hlc.Timestamp{WallTime:1512503965477252547, Logical:0},
    AffectedVersionsKeyBytes:   367,
    AffectedVersionsValBytes:   213,
}
...
```

* About logging - **RunGC** has [this](https://github.com/cockroachdb/cockroach/blob/2934e987f0c7c12c1cd374cc741910f9532f9d9b/pkg/storage/gc_queue.go#L904) for **GCInfo**. Do we need an additional logging of new fields?
* Do I need to print out an info about the total space that we could free at the end of output of `debug estimate-gc `?