### PR TITLE
cherrypick-1.1: fix panic when indexing selecting with additional schema change columns.

### DIFF
--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -796,6 +796,12 @@ func (v *indexInfo) isCoveringIndex(scan *scanNode) bool {
 	}
 
 	for i, needed := range scan.valNeededForCol {
+		// This is possible during a schema change when we have
+		// additional mutation columns.
+		if i >= len(v.desc.Columns) {
+			return false
+		}
+
 		if needed {
 			colID := v.desc.Columns[i].ID
 			if !v.index.ContainsColumnID(colID) {


### PR DESCRIPTION
I just remembered I forgot to cherrypick this fix in when I merged #19701 https://github.com/cockroachdb/cockroach/commit/dc2ebdf15a635b04005541759997429df088b270#diff-32a45104bdefeaeb4868cc4521d5c05bR804.

Release note (bug fix): fixed a panic for an edge-case when queries are
run against a table undergoing a schema change.