### PR TITLE
cherrypick-1.1: build: separate out race logic tests

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+export BUILDER_HIDE_GOPATH_SRC=1
+
+mkdir -p artifacts
+
+build/builder.sh env \
+	make testrace \
+  PKG=./pkg/sql/logictest
+	TESTFLAGS='-v' \
+	2>&1 \
+	| tee artifacts/testlogicrace.log \
+	| go-test-teamcity

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -13,6 +13,7 @@ build/builder.sh env \
 	github-pull-request-make
 
 build/builder.sh env \
+	COCKROACH_LOGIC_TESTS_SKIP=true \
 	make testrace \
 	TESTFLAGS='-v' \
 	2>&1 \

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -1499,12 +1500,20 @@ func (t *logicTest) runFile(path string, config testClusterConfig) {
 	t.outf("file %s done with config: %s", path, config.name)
 }
 
+var skipLogicTests = envutil.EnvOrDefaultBool("COCKROACH_LOGIC_TESTS_SKIP", false)
+var logicTestsConfigExclude = envutil.EnvOrDefaultString("COCKROACH_LOGIC_TESTS_SKIP_CONFIG", "")
+var logicTestsConfigFilter = envutil.EnvOrDefaultString("COCKROACH_LOGIC_TESTS_CONFIG", "")
+
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	if testutils.NightlyStress() {
 		// See https://github.com/cockroachdb/cockroach/pull/10966.
 		t.Skip()
+	}
+
+	if skipLogicTests {
+		t.Skip("COCKROACH_LOGIC_TESTS_SKIP")
 	}
 
 	// run the logic tests indicated by the bigtest and logictestdata flags.
@@ -1596,6 +1605,12 @@ func TestLogic(t *testing.T) {
 		}
 		// Top-level test: one per test configuration.
 		t.Run(cfg.name, func(t *testing.T) {
+			if logicTestsConfigExclude != "" && cfg.name == logicTestsConfigExclude {
+				t.Skip("config excluded via env var")
+			}
+			if logicTestsConfigFilter != "" && cfg.name != logicTestsConfigFilter {
+				t.Skip("config does not match env var")
+			}
 			for _, path := range paths {
 				path := path // Rebind range variable.
 				// Inner test: one per file path.


### PR DESCRIPTION
Logic tests spin exceed the race detectors goroutine limit on 16 CPU machines, so the testlogicrace build in CI is pinned to 8 CPU machines. Unfortunately the release-1.1 branch does not split testrace and testlogicrace, so backport that split.

---

the testrace build is going over 20min lately, so pulling logic tests (~15min) into their own build should help a bit.
a follow up step might be to split default from the rest of the logic tests if testlogicrace is still the slowest build.