### PR TITLE
sql: support read-only transactions

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -827,6 +827,7 @@ func (e *Executor) execParsed(
 				e.cfg.Clock.PhysicalTime(), /* sqlTimestamp */
 				session.DefaultIsolationLevel,
 				roachpb.NormalUserPriority,
+				session.DefaultReadOnly,
 			)
 		}
 
@@ -1469,12 +1470,13 @@ func (e *Executor) execStmtInAbortedTxn(
 			// state, so this is consistent.
 			// The old txn has already been rolled back; we start a new txn with the
 			// same sql timestamp and isolation as the current one.
-			curTs, curIso, curPri := txnState.sqlTimestamp, txnState.isolation, txnState.priority
+			curTs, curIso, curPri, curRo := txnState.sqlTimestamp, txnState.isolation,
+				txnState.priority, txnState.readOnly
 			txnState.finishSQLTxn(session)
 			txnState.resetForNewSQLTxn(
 				e, session,
 				false /* implicitTxn */, true, /* retryIntent */
-				curTs /* sqlTimestamp */, curIso /* isolation */, curPri /* priority */)
+				curTs /* sqlTimestamp */, curIso /* isolation */, curPri /* priority */, curRo /* readOnly */)
 		}
 		// TODO(andrei/cdo): add a counter for user-directed retries.
 		return nil

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -145,7 +145,7 @@ EXPLAIN SHOW DATABASE
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 23 rows
+2  ·       size  2 columns, 24 rows
 
 query ITTT
 EXPLAIN SHOW TIME ZONE
@@ -153,7 +153,7 @@ EXPLAIN SHOW TIME ZONE
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 23 rows
+2  ·       size  2 columns, 24 rows
 
 query ITTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -161,7 +161,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 23 rows
+2  ·       size  2 columns, 24 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -169,7 +169,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 23 rows
+2  ·       size  2 columns, 24 rows
 
 query ITTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -177,7 +177,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 0  render  ·     ·
 1  filter  ·     ·
 2  values  ·     ·
-2  ·       size  2 columns, 23 rows
+2  ·       size  2 columns, 24 rows
 
 query ITTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1093,6 +1093,7 @@ client_min_messages            ·             NULL      NULL        NULL        
 database                       test          NULL      NULL        NULL        string
 datestyle                      ISO           NULL      NULL        NULL        string
 default_transaction_isolation  serializable  NULL      NULL        NULL        string
+default_transaction_read_only  off           NULL      NULL        NULL        string
 distsql                        off           NULL      NULL        NULL        string
 extra_float_digits             ·             NULL      NULL        NULL        string
 intervalstyle                  postgres      NULL      NULL        NULL        string
@@ -1121,6 +1122,7 @@ client_min_messages            ·             NULL  user     NULL      ·       
 database                       test          NULL  user     NULL      test          test
 datestyle                      ISO           NULL  user     NULL      ISO           ISO
 default_transaction_isolation  serializable  NULL  user     NULL      serializable  serializable
+default_transaction_read_only  off           NULL  user     NULL      off           off
 distsql                        off           NULL  user     NULL      off           off
 extra_float_digits             ·             NULL  user     NULL      ·             ·
 intervalstyle                  postgres      NULL  user     NULL      postgres      postgres
@@ -1149,6 +1151,7 @@ client_min_messages            NULL    NULL     NULL     NULL        NULL
 database                       NULL    NULL     NULL     NULL        NULL
 datestyle                      NULL    NULL     NULL     NULL        NULL
 default_transaction_isolation  NULL    NULL     NULL     NULL        NULL
+default_transaction_read_only  NULL    NULL     NULL     NULL        NULL
 distsql                        NULL    NULL     NULL     NULL        NULL
 extra_float_digits             NULL    NULL     NULL     NULL        NULL
 intervalstyle                  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -83,6 +83,7 @@ client_min_messages            ·
 database                       foo
 datestyle                      ISO
 default_transaction_isolation  serializable
+default_transaction_read_only  off
 distsql                        off
 extra_float_digits             ·
 intervalstyle                  postgres

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -28,6 +28,7 @@ client_min_messages            ·
 database                       test
 datestyle                      ISO
 default_transaction_isolation  serializable
+default_transaction_read_only  off
 distsql                        off
 extra_float_digits             ·
 intervalstyle                  postgres

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -778,6 +778,43 @@ ROLLBACK
 statement ok
 BEGIN
 
+query T
+SHOW transaction_read_only
+----
+off
+
+statement ok
+SET TRANSACTION READ ONLY
+
+query T
+SHOW transaction_read_only
+----
+on
+
+statement ok
+SET TRANSACTION READ WRITE
+
+query T
+SHOW transaction_read_only
+----
+off
+
+statement ok
+SET transaction_read_only = true
+
+query T
+SHOW transaction_read_only
+----
+on
+
+statement ok
+SET transaction_read_only = false
+
+query T
+SHOW transaction_read_only
+----
+off
+
 statement error read mode specified multiple times
 SET TRANSACTION READ ONLY, READ WRITE
 
@@ -785,10 +822,120 @@ statement ok
 ROLLBACK
 
 statement ok
-BEGIN READ WRITE; COMMIT
+BEGIN READ WRITE
 
-statement error read only not supported
+query T
+SHOW transaction_read_only
+----
+off
+
+statement ok
+COMMIT
+
+statement ok
 BEGIN READ ONLY
+
+query T
+SHOW transaction_read_only
+----
+on
+
+statement ok
+COMMIT
+
+# Test default read-only status.
+query T
+SHOW default_transaction_read_only
+----
+off
+
+statement ok
+SET default_transaction_read_only = true
+
+query T
+SHOW default_transaction_read_only
+----
+on
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION READ WRITE
+
+query T
+SHOW default_transaction_read_only
+----
+off
+
+statement ok
+SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY
+
+query T
+SHOW default_transaction_read_only
+----
+on
+
+statement ok
+BEGIN
+
+statement ok
+SAVEPOINT cockroach_restart
+
+query T
+SHOW transaction_read_only
+----
+on
+
+# Can override setting.
+statement ok
+SET TRANSACTION READ WRITE
+
+query T
+SHOW transaction_read_only
+----
+off
+
+# Rolling back to savepoint doesn't reset to default.
+# TODO(jordan) fix this if necessary.
+statement ok
+ROLLBACK TO SAVEPOINT cockroach_restart
+
+query T
+SHOW transaction_read_only
+----
+off
+
+statement ok
+COMMIT
+
+# BEGIN READ WRITE overwrites READ ONLY default
+statement ok
+BEGIN READ WRITE
+
+statement ok
+CREATE SEQUENCE a
+
+statement ok
+COMMIT
+
+statement error cannot execute CREATE TABLE in a read-only transaction
+CREATE TABLE a (a int)
+
+statement error cannot execute INSERT in a read-only transaction
+INSERT INTO a VALUES(1)
+
+statement error cannot execute UPDATE in a read-only transaction
+UPDATE a SET a = 1
+
+statement error cannot execute INSERT in a read-only transaction
+UPSERT INTO a VALUES(2)
+
+statement error cannot execute DELETE in a read-only transaction
+DELETE FROM a
+
+statement error cannot execute nextval\(\) in a read-only transaction
+SELECT nextval('a')
+
+statement error cannot execute setval\(\) in a read-only transaction
+SELECT setval('a', 2)
 
 query T
 SHOW TRANSACTION STATUS

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2282,9 +2282,9 @@ set_session_stmt:
     $$.val = $2.stmt()
   }
 // Special form for pg compatibility:
-| SET SESSION CHARACTERISTICS AS TRANSACTION transaction_iso_level
+| SET SESSION CHARACTERISTICS AS TRANSACTION transaction_mode_list
   {
-    $$.val = &tree.SetDefaultIsolation{Isolation: $6.isoLevel()}
+    $$.val = &tree.SetSessionCharacteristics{Modes: $6.transactionModes()}
   }
 
 // %Help: SET TRANSACTION - configure the transaction settings

--- a/pkg/sql/sem/tree/set.go
+++ b/pkg/sql/sem/tree/set.go
@@ -70,16 +70,13 @@ func (node *SetTransaction) Format(buf *bytes.Buffer, f FmtFlags) {
 	node.Modes.Format(buf, f)
 }
 
-// SetDefaultIsolation represents a SET SESSION CHARACTERISTICS AS TRANSACTION statement.
-type SetDefaultIsolation struct {
-	Isolation IsolationLevel
+// SetSessionCharacteristics represents a SET SESSION CHARACTERISTICS AS TRANSACTION statement.
+type SetSessionCharacteristics struct {
+	Modes TransactionModes
 }
 
 // Format implements the NodeFormatter interface.
-func (node *SetDefaultIsolation) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL")
-	if node.Isolation != UnspecifiedIsolation {
-		buf.WriteByte(' ')
-		buf.WriteString(node.Isolation.String())
-	}
+func (node *SetSessionCharacteristics) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("SET SESSION CHARACTERISTICS AS TRANSACTION")
+	node.Modes.Format(buf, f)
 }

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -101,6 +101,22 @@ func CanModifySchema(stmt Statement) bool {
 	return ok && scm.modifiesSchema()
 }
 
+// CanWriteData returns true if the statement can modify data.
+func CanWriteData(stmt Statement) bool {
+	switch stmt.(type) {
+	// Normal write operations.
+	case *Insert, *Delete, *Update, *Truncate:
+		return true
+	// Import operations.
+	case *CopyFrom, *Import, *Restore:
+		return true
+	// CockroachDB extensions.
+	case *Split, *TestingRelocate, *Scatter:
+		return true
+	}
+	return false
+}
+
 // HiddenFromStats is a pseudo-interface to be implemented
 // by statements that should not show up in per-app statistics.
 type HiddenFromStats interface {
@@ -514,12 +530,12 @@ func (*SetZoneConfig) StatementType() StatementType { return RowsAffected }
 func (*SetZoneConfig) StatementTag() string { return "CONFIGURE ZONE" }
 
 // StatementType implements the Statement interface.
-func (*SetDefaultIsolation) StatementType() StatementType { return Ack }
+func (*SetSessionCharacteristics) StatementType() StatementType { return Ack }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*SetDefaultIsolation) StatementTag() string { return "SET" }
+func (*SetSessionCharacteristics) StatementTag() string { return "SET" }
 
-func (*SetDefaultIsolation) hiddenFromStats() {}
+func (*SetSessionCharacteristics) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*ShowVar) StatementType() StatementType { return Rows }
@@ -743,91 +759,91 @@ func (ValuesClause) StatementType() StatementType { return Rows }
 // StatementTag returns a short string identifying the type of statement.
 func (ValuesClause) StatementTag() string { return "VALUES" }
 
-func (n *AlterTable) String() string               { return AsString(n) }
-func (n AlterTableCmds) String() string            { return AsString(n) }
-func (n *AlterTableAddColumn) String() string      { return AsString(n) }
-func (n *AlterTableAddConstraint) String() string  { return AsString(n) }
-func (n *AlterTableDropColumn) String() string     { return AsString(n) }
-func (n *AlterTableDropConstraint) String() string { return AsString(n) }
-func (n *AlterTableDropNotNull) String() string    { return AsString(n) }
-func (n *AlterTableSetDefault) String() string     { return AsString(n) }
-func (n *AlterUserSetPassword) String() string     { return AsString(n) }
-func (n *AlterSequence) String() string            { return AsString(n) }
-func (n *Backup) String() string                   { return AsString(n) }
-func (n *BeginTransaction) String() string         { return AsString(n) }
-func (n *CancelJob) String() string                { return AsString(n) }
-func (n *CancelQuery) String() string              { return AsString(n) }
-func (n *CommitTransaction) String() string        { return AsString(n) }
-func (n *CopyFrom) String() string                 { return AsString(n) }
-func (n *CreateDatabase) String() string           { return AsString(n) }
-func (n *CreateIndex) String() string              { return AsString(n) }
-func (n *CreateTable) String() string              { return AsString(n) }
-func (n *CreateSequence) String() string           { return AsString(n) }
-func (n *CreateStats) String() string              { return AsString(n) }
-func (n *CreateUser) String() string               { return AsString(n) }
-func (n *CreateView) String() string               { return AsString(n) }
-func (n *Deallocate) String() string               { return AsString(n) }
-func (n *Delete) String() string                   { return AsString(n) }
-func (n *DropDatabase) String() string             { return AsString(n) }
-func (n *DropIndex) String() string                { return AsString(n) }
-func (n *DropTable) String() string                { return AsString(n) }
-func (n *DropView) String() string                 { return AsString(n) }
-func (n *DropSequence) String() string             { return AsString(n) }
-func (n *DropUser) String() string                 { return AsString(n) }
-func (n *Execute) String() string                  { return AsString(n) }
-func (n *Explain) String() string                  { return AsString(n) }
-func (n *Grant) String() string                    { return AsString(n) }
-func (n *Insert) String() string                   { return AsString(n) }
-func (n *Import) String() string                   { return AsString(n) }
-func (n *ParenSelect) String() string              { return AsString(n) }
-func (n *PauseJob) String() string                 { return AsString(n) }
-func (n *Prepare) String() string                  { return AsString(n) }
-func (n *ReleaseSavepoint) String() string         { return AsString(n) }
-func (n *TestingRelocate) String() string          { return AsString(n) }
-func (n *RenameColumn) String() string             { return AsString(n) }
-func (n *RenameDatabase) String() string           { return AsString(n) }
-func (n *RenameIndex) String() string              { return AsString(n) }
-func (n *RenameTable) String() string              { return AsString(n) }
-func (n *Restore) String() string                  { return AsString(n) }
-func (n *ResumeJob) String() string                { return AsString(n) }
-func (n *Revoke) String() string                   { return AsString(n) }
-func (n *RollbackToSavepoint) String() string      { return AsString(n) }
-func (n *RollbackTransaction) String() string      { return AsString(n) }
-func (n *Savepoint) String() string                { return AsString(n) }
-func (n *Scatter) String() string                  { return AsString(n) }
-func (n *Scrub) String() string                    { return AsString(n) }
-func (n *Select) String() string                   { return AsString(n) }
-func (n *SelectClause) String() string             { return AsString(n) }
-func (n *SetClusterSetting) String() string        { return AsString(n) }
-func (n *SetZoneConfig) String() string            { return AsString(n) }
-func (n *SetDefaultIsolation) String() string      { return AsString(n) }
-func (n *SetTransaction) String() string           { return AsString(n) }
-func (n *SetVar) String() string                   { return AsString(n) }
-func (n *ShowBackup) String() string               { return AsString(n) }
-func (n *ShowClusterSetting) String() string       { return AsString(n) }
-func (n *ShowColumns) String() string              { return AsString(n) }
-func (n *ShowConstraints) String() string          { return AsString(n) }
-func (n *ShowCreateTable) String() string          { return AsString(n) }
-func (n *ShowCreateView) String() string           { return AsString(n) }
-func (n *ShowDatabases) String() string            { return AsString(n) }
-func (n *ShowGrants) String() string               { return AsString(n) }
-func (n *ShowHistogram) String() string            { return AsString(n) }
-func (n *ShowIndex) String() string                { return AsString(n) }
-func (n *ShowJobs) String() string                 { return AsString(n) }
-func (n *ShowQueries) String() string              { return AsString(n) }
-func (n *ShowRanges) String() string               { return AsString(n) }
-func (n *ShowSessions) String() string             { return AsString(n) }
-func (n *ShowTableStats) String() string           { return AsString(n) }
-func (n *ShowTables) String() string               { return AsString(n) }
-func (n *ShowTrace) String() string                { return AsString(n) }
-func (n *ShowTransactionStatus) String() string    { return AsString(n) }
-func (n *ShowUsers) String() string                { return AsString(n) }
-func (n *ShowVar) String() string                  { return AsString(n) }
-func (n *ShowZoneConfig) String() string           { return AsString(n) }
-func (n *ShowFingerprints) String() string         { return AsString(n) }
-func (n *Split) String() string                    { return AsString(n) }
-func (l StatementList) String() string             { return AsString(l) }
-func (n *Truncate) String() string                 { return AsString(n) }
-func (n *UnionClause) String() string              { return AsString(n) }
-func (n *Update) String() string                   { return AsString(n) }
-func (n *ValuesClause) String() string             { return AsString(n) }
+func (n *AlterTable) String() string                { return AsString(n) }
+func (n AlterTableCmds) String() string             { return AsString(n) }
+func (n *AlterTableAddColumn) String() string       { return AsString(n) }
+func (n *AlterTableAddConstraint) String() string   { return AsString(n) }
+func (n *AlterTableDropColumn) String() string      { return AsString(n) }
+func (n *AlterTableDropConstraint) String() string  { return AsString(n) }
+func (n *AlterTableDropNotNull) String() string     { return AsString(n) }
+func (n *AlterTableSetDefault) String() string      { return AsString(n) }
+func (n *AlterUserSetPassword) String() string      { return AsString(n) }
+func (n *AlterSequence) String() string             { return AsString(n) }
+func (n *Backup) String() string                    { return AsString(n) }
+func (n *BeginTransaction) String() string          { return AsString(n) }
+func (n *CancelJob) String() string                 { return AsString(n) }
+func (n *CancelQuery) String() string               { return AsString(n) }
+func (n *CommitTransaction) String() string         { return AsString(n) }
+func (n *CopyFrom) String() string                  { return AsString(n) }
+func (n *CreateDatabase) String() string            { return AsString(n) }
+func (n *CreateIndex) String() string               { return AsString(n) }
+func (n *CreateTable) String() string               { return AsString(n) }
+func (n *CreateSequence) String() string            { return AsString(n) }
+func (n *CreateStats) String() string               { return AsString(n) }
+func (n *CreateUser) String() string                { return AsString(n) }
+func (n *CreateView) String() string                { return AsString(n) }
+func (n *Deallocate) String() string                { return AsString(n) }
+func (n *Delete) String() string                    { return AsString(n) }
+func (n *DropDatabase) String() string              { return AsString(n) }
+func (n *DropIndex) String() string                 { return AsString(n) }
+func (n *DropTable) String() string                 { return AsString(n) }
+func (n *DropView) String() string                  { return AsString(n) }
+func (n *DropSequence) String() string              { return AsString(n) }
+func (n *DropUser) String() string                  { return AsString(n) }
+func (n *Execute) String() string                   { return AsString(n) }
+func (n *Explain) String() string                   { return AsString(n) }
+func (n *Grant) String() string                     { return AsString(n) }
+func (n *Insert) String() string                    { return AsString(n) }
+func (n *Import) String() string                    { return AsString(n) }
+func (n *ParenSelect) String() string               { return AsString(n) }
+func (n *PauseJob) String() string                  { return AsString(n) }
+func (n *Prepare) String() string                   { return AsString(n) }
+func (n *ReleaseSavepoint) String() string          { return AsString(n) }
+func (n *TestingRelocate) String() string           { return AsString(n) }
+func (n *RenameColumn) String() string              { return AsString(n) }
+func (n *RenameDatabase) String() string            { return AsString(n) }
+func (n *RenameIndex) String() string               { return AsString(n) }
+func (n *RenameTable) String() string               { return AsString(n) }
+func (n *Restore) String() string                   { return AsString(n) }
+func (n *ResumeJob) String() string                 { return AsString(n) }
+func (n *Revoke) String() string                    { return AsString(n) }
+func (n *RollbackToSavepoint) String() string       { return AsString(n) }
+func (n *RollbackTransaction) String() string       { return AsString(n) }
+func (n *Savepoint) String() string                 { return AsString(n) }
+func (n *Scatter) String() string                   { return AsString(n) }
+func (n *Scrub) String() string                     { return AsString(n) }
+func (n *Select) String() string                    { return AsString(n) }
+func (n *SelectClause) String() string              { return AsString(n) }
+func (n *SetClusterSetting) String() string         { return AsString(n) }
+func (n *SetZoneConfig) String() string             { return AsString(n) }
+func (n *SetSessionCharacteristics) String() string { return AsString(n) }
+func (n *SetTransaction) String() string            { return AsString(n) }
+func (n *SetVar) String() string                    { return AsString(n) }
+func (n *ShowBackup) String() string                { return AsString(n) }
+func (n *ShowClusterSetting) String() string        { return AsString(n) }
+func (n *ShowColumns) String() string               { return AsString(n) }
+func (n *ShowConstraints) String() string           { return AsString(n) }
+func (n *ShowCreateTable) String() string           { return AsString(n) }
+func (n *ShowCreateView) String() string            { return AsString(n) }
+func (n *ShowDatabases) String() string             { return AsString(n) }
+func (n *ShowGrants) String() string                { return AsString(n) }
+func (n *ShowHistogram) String() string             { return AsString(n) }
+func (n *ShowIndex) String() string                 { return AsString(n) }
+func (n *ShowJobs) String() string                  { return AsString(n) }
+func (n *ShowQueries) String() string               { return AsString(n) }
+func (n *ShowRanges) String() string                { return AsString(n) }
+func (n *ShowSessions) String() string              { return AsString(n) }
+func (n *ShowTableStats) String() string            { return AsString(n) }
+func (n *ShowTables) String() string                { return AsString(n) }
+func (n *ShowTrace) String() string                 { return AsString(n) }
+func (n *ShowTransactionStatus) String() string     { return AsString(n) }
+func (n *ShowUsers) String() string                 { return AsString(n) }
+func (n *ShowVar) String() string                   { return AsString(n) }
+func (n *ShowZoneConfig) String() string            { return AsString(n) }
+func (n *ShowFingerprints) String() string          { return AsString(n) }
+func (n *Split) String() string                     { return AsString(n) }
+func (l StatementList) String() string              { return AsString(l) }
+func (n *Truncate) String() string                  { return AsString(n) }
+func (n *UnionClause) String() string               { return AsString(n) }
+func (n *Update) String() string                    { return AsString(n) }
+func (n *ValuesClause) String() string              { return AsString(n) }

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -198,6 +198,9 @@ type Session struct {
 	// DefaultIsolationLevel indicates the default isolation level of
 	// newly created transactions.
 	DefaultIsolationLevel enginepb.IsolationType
+	// DefaultReadOnly indicates the default read-only status of
+	// newly created transactions.
+	DefaultReadOnly bool
 	// DistSQLMode indicates whether to run queries using the distributed
 	// execution engine.
 	DistSQLMode DistSQLExecMode
@@ -999,6 +1002,9 @@ type txnState struct {
 	// The transaction's priority.
 	priority roachpb.UserPriority
 
+	// The transaction's read only state.
+	readOnly bool
+
 	// mon tracks txn-bound objects like the running state of
 	// planNode in the midst of performing a computation. We
 	// host this here instead of TxnState because TxnState is
@@ -1041,6 +1047,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	sqlTimestamp time.Time,
 	isolation enginepb.IsolationType,
 	priority roachpb.UserPriority,
+	readOnly bool,
 ) {
 	if ts.sp != nil || ts.txnResults != nil {
 		log.Fatalf(s.Ctx(),
@@ -1125,6 +1132,7 @@ func (ts *txnState) resetForNewSQLTxn(
 	if err := ts.setPriority(priority); err != nil {
 		panic(err)
 	}
+	ts.setReadOnly(readOnly)
 
 	// Discard the old schemaChangers, if any.
 	ts.schemaChangers = schemaChangerCollection{}
@@ -1271,6 +1279,10 @@ func (ts *txnState) setPriority(userPriority roachpb.UserPriority) error {
 	}
 	ts.priority = userPriority
 	return nil
+}
+
+func (ts *txnState) setReadOnly(readOnly bool) {
+	ts.readOnly = readOnly
 }
 
 // isSerializableRestart returns true if the KV transaction is serializable and

--- a/pkg/sql/set_default_isolation.go
+++ b/pkg/sql/set_default_isolation.go
@@ -17,20 +17,39 @@ package sql
 import (
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 )
 
-func (p *planner) SetDefaultIsolation(n *tree.SetDefaultIsolation) (planNode, error) {
+func (p *planner) SetSessionCharacteristics(n *tree.SetSessionCharacteristics) (planNode, error) {
 	// Note: We also support SET DEFAULT_TRANSACTION_ISOLATION TO ' .... ' above.
 	// Ensure both versions stay in sync.
-	switch n.Isolation {
+	switch n.Modes.Isolation {
 	case tree.SerializableIsolation:
 		p.session.DefaultIsolationLevel = enginepb.SERIALIZABLE
 	case tree.SnapshotIsolation:
 		p.session.DefaultIsolationLevel = enginepb.SNAPSHOT
+	case tree.UnspecifiedIsolation:
 	default:
-		return nil, fmt.Errorf("unsupported default isolation level: %s", n.Isolation)
+		return nil, fmt.Errorf("unsupported default isolation level: %s", n.Modes.Isolation)
+	}
+
+	switch n.Modes.ReadWriteMode {
+	case tree.ReadOnly:
+		p.session.DefaultReadOnly = true
+	case tree.ReadWrite:
+		p.session.DefaultReadOnly = false
+	case tree.UnspecifiedReadWriteMode:
+	default:
+		return nil, fmt.Errorf("unsupported default read write mode: %s", n.Modes.ReadWriteMode)
+	}
+
+	switch n.Modes.UserPriority {
+	case tree.UnspecifiedUserPriority:
+	default:
+		return nil, pgerror.Unimplemented("default transaction priority",
+			"unsupported session default: transaction priority")
 	}
 	return &zeroNode{}, nil
 }

--- a/pkg/sql/set_transaction.go
+++ b/pkg/sql/set_transaction.go
@@ -69,18 +69,16 @@ func (p *planner) setUserPriority(userPriority tree.UserPriority) error {
 	return p.session.TxnState.setPriority(up)
 }
 
-// Note: This setting currently doesn't have any effect and therefor is not
-// persisted anywhere. If this changes, care needs to be taken to restore it
-// when ROLLBACK TO SAVEPOINT starts a new sql transaction.
 func (p *planner) setReadWriteMode(readWriteMode tree.ReadWriteMode) error {
 	switch readWriteMode {
 	case tree.UnspecifiedReadWriteMode:
 		return nil
 	case tree.ReadOnly:
-		return errors.New("read only not supported")
+		p.session.TxnState.setReadOnly(true)
 	case tree.ReadWrite:
-		return nil
+		p.session.TxnState.setReadOnly(false)
 	default:
 		return errors.Errorf("unknown read mode: %s", readWriteMode)
 	}
+	return nil
 }


### PR DESCRIPTION
Add support for:

- SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY/READ WRITE;
- SET TRANSACTION READ ONLY/READ WRITE;
- SET default_transaction_read_only;
- SET transaction_read_only;

Fixes #16033.

Release note: Add support for read-only transactions via Postgres
compatible syntax.