### PR TITLE
libroach: use #pragma once instead of include guards.

### DIFF
--- a/c-deps/libroach/encoding.h
+++ b/c-deps/libroach/encoding.h
@@ -12,8 +12,7 @@
 // implied.  See the License for the specific language governing
 // permissions and limitations under the License.
 
-#ifndef ROACHLIB_ENCODING_H
-#define ROACHLIB_ENCODING_H
+#pragma once
 
 #include <stdint.h>
 #include "rocksdb/slice.h"
@@ -33,8 +32,6 @@ bool DecodeUint32(rocksdb::Slice* buf, uint32_t* value);
 // DecodedUint64 decodes a fixed-length encoded uint64 from a buffer, returning
 // true on a successful decode. The decoded value is returned in *value.
 bool DecodeUint64(rocksdb::Slice* buf, uint64_t* value);
-
-#endif  // ROACHLIB_ENCODING_H
 
 // local variables:
 // mode: c++

--- a/c-deps/libroach/eventlistener.h
+++ b/c-deps/libroach/eventlistener.h
@@ -12,8 +12,7 @@
 // implied.  See the License for the specific language governing
 // permissions and limitations under the License.
 
-#ifndef ROACHLIB_EVENTLISTENER_H
-#define ROACHLIB_EVENTLISTENER_H
+#pragma once
 
 #include <atomic>
 
@@ -38,5 +37,3 @@ class DBEventListener : public rocksdb::EventListener {
   std::atomic<uint64_t> flushes_;
   std::atomic<uint64_t> compactions_;
 };
-
-#endif  // ROACHLIB_EVENTLISTENER_H

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -12,8 +12,7 @@
 // implied.  See the License for the specific language governing
 // permissions and limitations under the License.
 
-#ifndef LIBROACH_H
-#define LIBROACH_H
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -297,5 +296,3 @@ DBStatus DBEnvWriteFile(DBEngine* db, DBSlice path, DBSlice contents);
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-
-#endif  // LIBROACH_H

--- a/c-deps/libroach/include/libroachccl.h
+++ b/c-deps/libroach/include/libroachccl.h
@@ -6,8 +6,7 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
-#ifndef LIBROACHCCL_H
-#define LIBROACHCCL_H
+#pragma once
 
 #include <libroach.h>
 
@@ -22,5 +21,3 @@ DBStatus DBBatchReprVerify(DBSlice repr, DBKey start, DBKey end, int64_t now_nan
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-
-#endif  // LIBROACHCCL_H


### PR DESCRIPTION
Release note: None

Rocksdb is (mostly) using pragma. Doing the same here for consistency.