### PR TITLE
jepsen: automatically create SSH key if it doesn't exist

### DIFF
--- a/build/jepsen-common.sh
+++ b/build/jepsen-common.sh
@@ -8,6 +8,8 @@ cd "${LOG_DIR}"
 
 KEY_NAME="${KEY_NAME-google_compute_engine}"
 
+[ -f "$HOME/.ssh/$KEY_NAME" ] || ssh-keygen -f "$HOME/.ssh/$KEY_NAME" -N ''
+
 SSH_OPTIONS=(-o "ServerAliveInterval=60" -o "StrictHostKeyChecking no" -i "$HOME/.ssh/${KEY_NAME}")
 
 # Ensure that the terraform config is canceled if one of the run scripts fails


### PR DESCRIPTION
Rather than relying on TeamCity to provide an SSH key in the right
place, just automatically create the SSH key if it doesn't already
exist. Plus, this is how the rest of the nightly tests work.

Release note: None