### PR TITLE
acceptance: use subdir of disk for data dir

### DIFF
--- a/pkg/acceptance/util_farmer.go
+++ b/pkg/acceptance/util_farmer.go
@@ -15,6 +15,7 @@
 package acceptance
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -99,7 +100,7 @@ func MakeFarmer(t testing.TB, prefix string, stopper *stop.Stopper) *terrafarm.F
 	}
 	var stores string
 	for j := 0; j < *flagStores; j++ {
-		stores += " --store=/mnt/data" + strconv.Itoa(j)
+		stores += fmt.Sprintf(" --store=/mnt/data%d/cockroach-data", j)
 	}
 
 	var name string


### PR DESCRIPTION
using the fs root might mean that that unexpected fs-related files (e.g. lost+found) might be in our store dir and cause problems.

Release note: none.