### PR TITLE
engine: just ignore 'lost+found' dir

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -672,6 +672,12 @@ func (r *RocksDB) Capacity() (roachpb.StoreCapacity, error) {
 			if os.IsNotExist(err) {
 				return nil
 			}
+			// Special-case: if the store-dir is configured using the root of some fs,
+			// e.g. "/mnt/db", we might have special fs-created files like lost+found
+			// that we can't read, so just ignore them rather than crashing.
+			if os.IsPermission(err) && filepath.Base(path) == "lost+found" {
+				return nil
+			}
 			return err
 		}
 		if info.Mode().IsRegular() {


### PR DESCRIPTION
Release note: ignore filesytem-generated "lost+found" directory if it appears in store-dir

Fixes #20564.