### PR TITLE
distsqlrun: add RowChannel pipeline benchmark

### DIFF
--- a/pkg/sql/distsqlrun/base_test.go
+++ b/pkg/sql/distsqlrun/base_test.go
@@ -1,0 +1,73 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package distsqlrun
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// Benchmark a pipeline of RowChannels.
+func BenchmarkRowChannelPipeline(b *testing.B) {
+	columnTypeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
+
+	for _, length := range []int{1, 2, 3, 4} {
+		b.Run(fmt.Sprintf("length=%d", length), func(b *testing.B) {
+			rc := make([]RowChannel, length)
+			var wg sync.WaitGroup
+			wg.Add(len(rc))
+
+			for i := range rc {
+				rc[i].Init([]sqlbase.ColumnType{columnTypeInt})
+
+				go func(i int) {
+					defer wg.Done()
+					cur := &rc[i]
+					var next *RowChannel
+					if i+1 != len(rc) {
+						next = &rc[i+1]
+					}
+					for {
+						row, meta := cur.Next()
+						if row == nil {
+							if next != nil {
+								next.ProducerDone()
+							}
+							break
+						}
+						if next != nil {
+							_ = next.Push(row, meta)
+						}
+					}
+				}(i)
+			}
+
+			row := sqlbase.EncDatumRow{
+				sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(1))),
+			}
+			b.SetBytes(int64(unsafe.Sizeof(tree.DInt(1))))
+			for i := 0; i < b.N; i++ {
+				_ = rc[0].Push(row, ProducerMetadata{})
+			}
+			rc[0].ProducerDone()
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
Add BenchmarkRowChannelPipeline which benchmarks throughput and latency
through a pipeline of RowChannels. The results are disappointing:

```
name                    time/op
RowChannelPipeline/1-8     110ns ± 2%
RowChannelPipeline/2-8     272ns ± 1%
RowChannelPipeline/3-8     377ns ± 4%
RowChannelPipeline/4-8     421ns ± 1%

name                    speed
RowChannelPipeline/1-8  72.8MB/s ± 3%
RowChannelPipeline/2-8  29.3MB/s ± 1%
RowChannelPipeline/3-8  21.2MB/s ± 4%
RowChannelPipeline/4-8  19.0MB/s ± 1%
```

Release note: None

See #20550
See #20553
See #20568