### PR TITLE
cherrypick-1.1: sql: trace schema changes

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -929,6 +929,7 @@ If problems persist, please see https://www.cockroachlabs.com/docs/v` + serverVe
 	}
 	sql.NewSchemaChangeManager(
 		s.st,
+		s.cfg.AmbientCtx,
 		testingKnobs,
 		*s.db,
 		s.node.Descriptor,


### PR DESCRIPTION
Motivated by the fact that previously, `DROP TABLE` did not allow any
kind of introspection. Now, at least there's something you can look
at in `/debug/requests` to see activity.

Touches #19004

Release note: None

cc @cockroachdb/release 