### PR TITLE
sql/distsqlrun: fix buglet in aggregator memory account

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -285,11 +285,13 @@ func (ag *aggregator) accumulateRows(ctx context.Context) (err error) {
 			return err
 		}
 
-		if err := ag.bucketsAcc.Grow(ctx, int64(len(encoded))); err != nil {
-			return err
+		if _, ok := ag.buckets[string(encoded)]; !ok {
+			if err := ag.bucketsAcc.Grow(ctx, int64(len(encoded))); err != nil {
+				return err
+			}
+			ag.buckets[string(encoded)] = struct{}{}
 		}
 
-		ag.buckets[string(encoded)] = struct{}{}
 		// Feed the func holders for this bucket the non-grouping datums.
 		for i, a := range ag.aggregations {
 			if a.FilterColIdx != nil {

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -310,6 +310,8 @@ func (p *planner) groupBy(
 	// Queries like `SELECT MAX(n) FROM t` expect a row of NULLs if nothing was aggregated.
 	group.run.addNullBucketIfEmpty = len(groupByExprs) == 0
 
+	// TODO(peter): This memory isn't being accounted for. The similar code in
+	// sql/distsqlrun/aggregator.go does account for the memory.
 	group.run.buckets = make(map[string]struct{})
 
 	if log.V(2) {


### PR DESCRIPTION
Only grow the memory accounting when adding to the buckets map. This is
both a memory account correctness fix and a performance improvement. A
`select count(*)` query over 5m rows dropped from 6.0s to 5.3s.

Release note (bug fix): Fix over-counting of memory usage by aggregations.