### PR TITLE
util/mon: reserve extra bytes for allocation in BytesAccount

### DIFF
--- a/pkg/sql/builtin_mem_usage_test.go
+++ b/pkg/sql/builtin_mem_usage_test.go
@@ -133,12 +133,12 @@ func TestBuiltinsAccountForMemory(t *testing.T) {
 			evalCtx := tree.NewTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
 			defer evalCtx.ActiveMemAcc.Close(context.Background())
-			previouslyAllocated := evalCtx.ActiveMemAcc.CurrentlyAllocated()
+			previouslyAllocated := evalCtx.ActiveMemAcc.Used()
 			_, err := test.builtin.Fn(evalCtx, test.args)
 			if err != nil {
 				t.Fatal(err)
 			}
-			deltaAllocated := evalCtx.ActiveMemAcc.CurrentlyAllocated() - previouslyAllocated
+			deltaAllocated := evalCtx.ActiveMemAcc.Used() - previouslyAllocated
 			if deltaAllocated != test.expectedAllocation {
 				t.Errorf("Expected to allocate %d, actually allocated %d", test.expectedAllocation, deltaAllocated)
 			}

--- a/pkg/sql/builtin_mem_usage_test.go
+++ b/pkg/sql/builtin_mem_usage_test.go
@@ -133,12 +133,12 @@ func TestBuiltinsAccountForMemory(t *testing.T) {
 			evalCtx := tree.NewTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
 			defer evalCtx.ActiveMemAcc.Close(context.Background())
-			previouslyAllocated := evalCtx.Mon.GetCurrentAllocationForTesting()
+			previouslyAllocated := evalCtx.ActiveMemAcc.CurrentlyAllocated()
 			_, err := test.builtin.Fn(evalCtx, test.args)
 			if err != nil {
 				t.Fatal(err)
 			}
-			deltaAllocated := evalCtx.Mon.GetCurrentAllocationForTesting() - previouslyAllocated
+			deltaAllocated := evalCtx.ActiveMemAcc.CurrentlyAllocated() - previouslyAllocated
 			if deltaAllocated != test.expectedAllocation {
 				t.Errorf("Expected to allocate %d, actually allocated %d", test.expectedAllocation, deltaAllocated)
 			}

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -87,7 +87,7 @@ func (n *distinctNode) Next(params runParams) (bool, error) {
 				n.run.suffixMemAcc.Clear(ctx)
 				n.run.suffixSeen = make(map[string]struct{})
 			}
-			if err := n.run.prefixMemAcc.ResizeItem(
+			if err := n.run.prefixMemAcc.Resize(
 				ctx, int64(len(n.run.prefixSeen)), int64(len(prefix))); err != nil {
 				return false, err
 			}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -485,10 +485,7 @@ func (e *Executor) Prepare(
 	prepared := &PreparedStatement{
 		TypeHints:   placeholderHints,
 		portalNames: make(map[string]struct{}),
-		// We need a memory account available in order to prepare a statement, since we
-		// might need to allocate memory for constant-folded values in the process of
-		// planning it.
-		memAcc: session.mon.MakeBoundAccount(),
+		memAcc:      session.mon.MakeBoundAccount(),
 	}
 
 	if stmt.AST == nil {
@@ -553,7 +550,12 @@ func (e *Executor) Prepare(
 	if plan == nil {
 		return prepared, nil
 	}
-	defer plan.Close(session.Ctx())
+	defer func() {
+		plan.Close(session.Ctx())
+		// NB: if we start caching the plan, we'll want to keep around the memory
+		// account used for the plan, rather than clearing it.
+		prepared.memAcc.Clear(session.Ctx())
+	}()
 	prepared.Columns = planColumns(plan)
 	for _, c := range prepared.Columns {
 		if err := checkResultType(c.Typ); err != nil {

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -485,7 +485,7 @@ func (e *Executor) Prepare(
 	prepared := &PreparedStatement{
 		TypeHints:   placeholderHints,
 		portalNames: make(map[string]struct{}),
-		memAcc:      session.mon.MakeBoundAccount(),
+		memAcc:      session.sessionMon.MakeBoundAccount(),
 	}
 
 	if stmt.AST == nil {

--- a/pkg/sql/session_mem_usage.go
+++ b/pkg/sql/session_mem_usage.go
@@ -17,43 +17,9 @@ package sql
 import (
 	"math"
 
-	"golang.org/x/net/context"
-
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 )
-
-// WrappableMemoryAccount encapsulates a MemoryAccount to
-// give it the Wsession() method below.
-type WrappableMemoryAccount struct {
-	acc mon.BytesAccount
-}
-
-// Wsession captures the current session monitor pointer so it can be provided
-// transparently to the other Account APIs below.
-func (w *WrappableMemoryAccount) Wsession(s *Session) WrappedMemoryAccount {
-	return WrappedMemoryAccount{
-		acc: &w.acc,
-		mon: &s.sessionMon,
-	}
-}
-
-// WrappedMemoryAccount is the transient structure that carries
-// the extra argument to the MemoryAccount APIs.
-type WrappedMemoryAccount struct {
-	acc *mon.BytesAccount
-	mon *mon.BytesMonitor
-}
-
-// OpenAndInit interfaces between Session and mon.MemoryMonitor.
-func (w WrappedMemoryAccount) OpenAndInit(ctx context.Context, initialAllocation int64) error {
-	return w.mon.OpenAndInitAccount(ctx, w.acc, initialAllocation)
-}
-
-// Close interfaces between Session and mon.MemoryMonitor.
-func (w WrappedMemoryAccount) Close(ctx context.Context) {
-	w.mon.CloseAccount(ctx, w.acc)
-}
 
 // noteworthyMemoryUsageBytes is the minimum size tracked by a
 // transaction or session monitor before the monitor starts explicitly

--- a/pkg/sql/sqlbase/row_container.go
+++ b/pkg/sql/sqlbase/row_container.go
@@ -331,7 +331,7 @@ func (c *RowContainer) Replace(ctx context.Context, i int, newRow tree.Datums) e
 	row := c.At(i)
 	oldSz := c.rowSize(row)
 	if newSz != oldSz {
-		if err := c.memAcc.ResizeItem(ctx, oldSz, newSz); err != nil {
+		if err := c.memAcc.Resize(ctx, oldSz, newSz); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/sqlbase/row_container.go
+++ b/pkg/sql/sqlbase/row_container.go
@@ -341,5 +341,5 @@ func (c *RowContainer) Replace(ctx context.Context, i int, newRow tree.Datums) e
 
 // MemUsage returns the current accounted memory usage.
 func (c *RowContainer) MemUsage() int64 {
-	return c.memAcc.CurrentlyAllocated()
+	return c.memAcc.Used()
 }

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -182,7 +182,7 @@ type BytesMonitor struct {
 
 		// curBudget represents the budget allocated at the pool on behalf of
 		// this monitor.
-		curBudget BytesAccount
+		curBudget bytesAccount
 	}
 
 	// name identifies this monitor in logging messages.
@@ -410,16 +410,16 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 	mm.reserved.Clear(ctx)
 }
 
-// BytesAccount tracks the cumulated allocations for one client of a pool or
+// bytesAccount tracks the cumulated allocations for one client of a pool or
 // monitor. BytesMonitor has an account to its pool; BytesMonitor clients have
 // an account to the monitor. This allows each client to release all the bytes
-// at once when it completes its work. Internally, BytesAccount amortizes
+// at once when it completes its work. Internally, bytesAccount amortizes
 // allocations from whichever BytesMonitor it is associated with by allocating
-// additional memory and parceling it out (see BytesAccount.reserved).
+// additional memory and parceling it out (see bytesAccount.reserved).
 //
 // See the comments in bytes_usage.go for a fuller picture of how these accounts
 // are used in CockroachDB.
-type BytesAccount struct {
+type bytesAccount struct {
 	used int64
 	// reserved is a small buffer to amortize the cost of growing an account. It
 	// decreases as curAllocated increases (and vice-versa).
@@ -427,31 +427,16 @@ type BytesAccount struct {
 }
 
 // Used returns the number of bytes currently allocated through this account.
-func (acc BytesAccount) Used() int64 {
+func (acc bytesAccount) Used() int64 {
 	return acc.used
 }
 
-func (acc BytesAccount) allocated() int64 {
+func (acc bytesAccount) allocated() int64 {
 	return acc.used + acc.reserved
 }
 
-// OpenAccount creates a new empty account.
-func (mm *BytesMonitor) OpenAccount(_ *BytesAccount) {
-	// TODO(knz): conditionally track accounts in the monitor (#9122).
-}
-
-// OpenAndInitAccount creates a new account and pre-allocates some initial
-// amount of bytes. Upon success, acc.curAllocated will be equal to
-// initialAllocation while acc.reserved may be greater than or equal to zero.
-func (mm *BytesMonitor) OpenAndInitAccount(
-	ctx context.Context, acc *BytesAccount, initialAllocation int64,
-) error {
-	mm.OpenAccount(acc)
-	return mm.GrowAccount(ctx, acc, initialAllocation)
-}
-
-// GrowAccount requests a new allocation in an account.
-func (mm *BytesMonitor) GrowAccount(ctx context.Context, acc *BytesAccount, extraSize int64) error {
+// growAccount requests a new allocation in an account.
+func (mm *BytesMonitor) growAccount(ctx context.Context, acc *bytesAccount, extraSize int64) error {
 	if acc.reserved < extraSize {
 		minExtra := mm.roundSize(extraSize)
 		if err := mm.reserveBytes(ctx, minExtra); err != nil {
@@ -464,25 +449,23 @@ func (mm *BytesMonitor) GrowAccount(ctx context.Context, acc *BytesAccount, extr
 	return nil
 }
 
-// CloseAccount releases all the cumulated allocations of an account at once.
-func (mm *BytesMonitor) CloseAccount(ctx context.Context, acc *BytesAccount) {
-	if acc.used == 0 && acc.reserved == 0 {
-		// Fast path so as to avoid locking the monitor.
-		return
+// closeAccount releases all the cumulated allocations of an account at once.
+func (mm *BytesMonitor) closeAccount(ctx context.Context, acc *bytesAccount) {
+	if a := acc.allocated(); a > 0 {
+		mm.releaseBytes(ctx, a)
 	}
-	mm.releaseBytes(ctx, acc.allocated())
 }
 
-// ClearAccount releases all the cumulated allocations of an account at once
+// clearAccount releases all the cumulated allocations of an account at once
 // and primes it for reuse.
-func (mm *BytesMonitor) ClearAccount(ctx context.Context, acc *BytesAccount) {
-	mm.CloseAccount(ctx, acc)
+func (mm *BytesMonitor) clearAccount(ctx context.Context, acc *bytesAccount) {
+	mm.closeAccount(ctx, acc)
 	acc.used = 0
 	acc.reserved = 0
 }
 
-// ShrinkAccount releases part of the cumulated allocations by the specified size.
-func (mm *BytesMonitor) ShrinkAccount(ctx context.Context, acc *BytesAccount, delta int64) {
+// chrinkAccount releases part of the cumulated allocations by the specified size.
+func (mm *BytesMonitor) shrinkAccount(ctx context.Context, acc *bytesAccount, delta int64) {
 	if acc.used < delta {
 		panic(fmt.Sprintf("%s: no bytes in account to release, current %d, free %d",
 			mm.name, acc.used, delta))
@@ -495,36 +478,36 @@ func (mm *BytesMonitor) ShrinkAccount(ctx context.Context, acc *BytesAccount, de
 	}
 }
 
-// ResizeItem requests a size change for an object already registered
+// resizeItem requests a size change for an object already registered
 // in an account. The reservation is not modified if the new allocation is
 // refused, so that the caller can keep using the original item
 // without an accounting error. This is better than calling ClearAccount
 // then GrowAccount because if the Clear succeeds and the Grow fails
 // the original item becomes invisible from the perspective of the
 // monitor.
-func (mm *BytesMonitor) ResizeItem(
-	ctx context.Context, acc *BytesAccount, oldSize, newSize int64,
+func (mm *BytesMonitor) resizeItem(
+	ctx context.Context, acc *bytesAccount, oldSize, newSize int64,
 ) error {
 	delta := newSize - oldSize
 	switch {
 	case delta > 0:
-		return mm.GrowAccount(ctx, acc, delta)
+		return mm.growAccount(ctx, acc, delta)
 	case delta < 0:
-		mm.ShrinkAccount(ctx, acc, -delta)
+		mm.shrinkAccount(ctx, acc, -delta)
 	}
 	return nil
 }
 
-// BoundAccount implements a BytesAccount attached to a specific monitor.
+// BoundAccount implements a bytesAccount attached to a specific monitor.
 type BoundAccount struct {
-	BytesAccount
+	bytesAccount
 	mon *BytesMonitor
 }
 
 // MakeStandaloneBudget creates a BoundAccount suitable for root
 // monitors.
 func MakeStandaloneBudget(capacity int64) BoundAccount {
-	return BoundAccount{BytesAccount: BytesAccount{used: capacity}}
+	return BoundAccount{bytesAccount: bytesAccount{used: capacity}}
 }
 
 // MakeBoundAccount creates a BoundAccount connected to the given monitor.
@@ -539,7 +522,7 @@ func (b *BoundAccount) Clear(ctx context.Context) {
 		// monitor -- "bytes out of the aether". This needs not be closed.
 		return
 	}
-	b.mon.ClearAccount(ctx, &b.BytesAccount)
+	b.mon.clearAccount(ctx, &b.bytesAccount)
 }
 
 // Close is an accessor for b.mon.CloseAccount.
@@ -549,27 +532,22 @@ func (b *BoundAccount) Close(ctx context.Context) {
 		// monitor -- "bytes out of the aether". This needs not be closed.
 		return
 	}
-	b.mon.CloseAccount(ctx, &b.BytesAccount)
+	b.mon.closeAccount(ctx, &b.bytesAccount)
 }
 
 // ResizeItem is an accessor for b.mon.ResizeItem.
 func (b *BoundAccount) ResizeItem(ctx context.Context, oldSz, newSz int64) error {
-	return b.mon.ResizeItem(ctx, &b.BytesAccount, oldSz, newSz)
+	return b.mon.resizeItem(ctx, &b.bytesAccount, oldSz, newSz)
 }
 
 // Grow is an accessor for b.mon.GrowAccount.
 func (b *BoundAccount) Grow(ctx context.Context, x int64) error {
-	if x < b.reserved {
-		b.reserved -= x
-		b.used += x
-		return nil
-	}
-	return b.mon.GrowAccount(ctx, &b.BytesAccount, x)
+	return b.mon.growAccount(ctx, &b.bytesAccount, x)
 }
 
 // Shrink is an accessor for b.mon.ShrinkAccount.
 func (b *BoundAccount) Shrink(ctx context.Context, x int64) {
-	b.mon.ShrinkAccount(ctx, &b.BytesAccount, x)
+	b.mon.shrinkAccount(ctx, &b.bytesAccount, x)
 }
 
 // reserveBytes declares an allocation to this monitor. An error is returned if
@@ -652,7 +630,7 @@ func (mm *BytesMonitor) increaseBudget(ctx context.Context, minExtra int64) erro
 		log.Infof(ctx, "%s: requesting %d bytes from the pool", mm.name, minExtra)
 	}
 
-	return mm.pool.GrowAccount(ctx, &mm.mu.curBudget, minExtra)
+	return mm.pool.growAccount(ctx, &mm.mu.curBudget, minExtra)
 }
 
 // roundSize rounds its argument to the smallest greater or equal
@@ -675,7 +653,7 @@ func (mm *BytesMonitor) releaseBudget(ctx context.Context) {
 	if log.V(2) {
 		log.Infof(ctx, "%s: releasing %d bytes to the pool", mm.name, mm.mu.curBudget.allocated())
 	}
-	mm.pool.ClearAccount(ctx, &mm.mu.curBudget)
+	mm.pool.clearAccount(ctx, &mm.mu.curBudget)
 }
 
 // adjustBudget ensures that the monitor does not keep many more bytes reserved
@@ -693,6 +671,6 @@ func (mm *BytesMonitor) adjustBudget(ctx context.Context) {
 		neededBytes = mm.roundSize(neededBytes - mm.reserved.used)
 	}
 	if neededBytes <= mm.mu.curBudget.used-margin {
-		mm.pool.ShrinkAccount(ctx, &mm.mu.curBudget, mm.mu.curBudget.used-neededBytes)
+		mm.pool.shrinkAccount(ctx, &mm.mu.curBudget, mm.mu.curBudget.used-neededBytes)
 	}
 }

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -413,12 +413,17 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 // BytesAccount tracks the cumulated allocations for one client of a pool or
 // monitor. BytesMonitor has an account to its pool; BytesMonitor clients have
 // an account to the monitor. This allows each client to release all the bytes
-// at once when it completes its work.
+// at once when it completes its work. Internally, BytesAccount amortizes
+// allocations from whichever BytesMonitor it is associated with by allocating
+// additional memory and parceling it out (see BytesAccount.reserved).
 //
 // See the comments in bytes_usage.go for a fuller picture of how these accounts
 // are used in CockroachDB.
 type BytesAccount struct {
 	curAllocated int64
+	// reserved is a small buffer to amortize the cost of growing an account. It
+	// decreases as curAllocated increases (and vice-versa).
+	reserved int64
 }
 
 // CurrentlyAllocated returns the number of bytes currently allocated through
@@ -427,13 +432,18 @@ func (acc BytesAccount) CurrentlyAllocated() int64 {
 	return acc.curAllocated
 }
 
+func (acc BytesAccount) totalAllocated() int64 {
+	return acc.curAllocated + acc.reserved
+}
+
 // OpenAccount creates a new empty account.
 func (mm *BytesMonitor) OpenAccount(_ *BytesAccount) {
 	// TODO(knz): conditionally track accounts in the monitor (#9122).
 }
 
-// OpenAndInitAccount creates a new account and pre-allocates some
-// initial amount of bytes.
+// OpenAndInitAccount creates a new account and pre-allocates some initial
+// amount of bytes. Upon success, acc.curAllocated will be equal to
+// initialAllocation while acc.reserved may be greater than or equal to zero.
 func (mm *BytesMonitor) OpenAndInitAccount(
 	ctx context.Context, acc *BytesAccount, initialAllocation int64,
 ) error {
@@ -443,20 +453,25 @@ func (mm *BytesMonitor) OpenAndInitAccount(
 
 // GrowAccount requests a new allocation in an account.
 func (mm *BytesMonitor) GrowAccount(ctx context.Context, acc *BytesAccount, extraSize int64) error {
-	if err := mm.reserveBytes(ctx, extraSize); err != nil {
-		return err
+	if acc.reserved < extraSize {
+		minExtra := mm.roundSize(extraSize)
+		if err := mm.reserveBytes(ctx, minExtra); err != nil {
+			return err
+		}
+		acc.reserved += minExtra
 	}
+	acc.reserved -= extraSize
 	acc.curAllocated += extraSize
 	return nil
 }
 
 // CloseAccount releases all the cumulated allocations of an account at once.
 func (mm *BytesMonitor) CloseAccount(ctx context.Context, acc *BytesAccount) {
-	if acc.curAllocated == 0 {
+	if acc.curAllocated == 0 && acc.reserved == 0 {
 		// Fast path so as to avoid locking the monitor.
 		return
 	}
-	mm.releaseBytes(ctx, acc.curAllocated)
+	mm.releaseBytes(ctx, acc.totalAllocated())
 }
 
 // ClearAccount releases all the cumulated allocations of an account at once
@@ -464,6 +479,7 @@ func (mm *BytesMonitor) CloseAccount(ctx context.Context, acc *BytesAccount) {
 func (mm *BytesMonitor) ClearAccount(ctx context.Context, acc *BytesAccount) {
 	mm.CloseAccount(ctx, acc)
 	acc.curAllocated = 0
+	acc.reserved = 0
 }
 
 // ShrinkAccount releases part of the cumulated allocations by the specified size.
@@ -472,8 +488,12 @@ func (mm *BytesMonitor) ShrinkAccount(ctx context.Context, acc *BytesAccount, de
 		panic(fmt.Sprintf("%s: no bytes in account to release, current %d, free %d",
 			mm.name, acc.curAllocated, delta))
 	}
-	mm.releaseBytes(ctx, delta)
 	acc.curAllocated -= delta
+	acc.reserved += delta
+	if acc.reserved >= mm.poolAllocationSize {
+		mm.releaseBytes(ctx, acc.reserved-mm.poolAllocationSize)
+		acc.reserved = mm.poolAllocationSize
+	}
 }
 
 // ResizeItem requests a size change for an object already registered
@@ -553,8 +573,10 @@ func (b *BoundAccount) Shrink(ctx context.Context, x int64) {
 func (mm *BytesMonitor) reserveBytes(ctx context.Context, x int64) error {
 	mm.mu.Lock()
 	defer mm.mu.Unlock()
-	// Check the local limit first.
-	if mm.mu.curAllocated+x > mm.limit {
+	// Check the local limit first. NB: The condition is written in this manner
+	// so that it handles overflow correctly. Consider what happens if
+	// x==math.MaxInt64. mm.limit-x will be a large negative number.
+	if mm.mu.curAllocated > mm.limit-x {
 		return errors.Wrap(mm.resource.NewBudgetExceededError(x, mm.limit), mm.name)
 	}
 	// Check whether we need to request an increase of our budget.
@@ -632,6 +654,12 @@ func (mm *BytesMonitor) increaseBudget(ctx context.Context, minExtra int64) erro
 // roundSize rounds its argument to the smallest greater or equal
 // multiple of `poolAllocationSize`.
 func (mm *BytesMonitor) roundSize(sz int64) int64 {
+	const maxRoundSize = 4 << 20 // 4 MB
+	if sz >= maxRoundSize {
+		// Don't round the size up if the allocation is large. This also avoids
+		// edge cases in the math below if sz == math.MaxInt64.
+		return sz
+	}
 	chunks := (sz + mm.poolAllocationSize - 1) / mm.poolAllocationSize
 	return chunks * mm.poolAllocationSize
 }
@@ -641,7 +669,7 @@ func (mm *BytesMonitor) roundSize(sz int64) int64 {
 func (mm *BytesMonitor) releaseBudget(ctx context.Context) {
 	// NB: mm.mu need not be locked here, as this is only called from StopMonitor().
 	if log.V(2) {
-		log.Infof(ctx, "%s: releasing %d bytes to the pool", mm.name, mm.mu.curBudget.curAllocated)
+		log.Infof(ctx, "%s: releasing %d bytes to the pool", mm.name, mm.mu.curBudget.totalAllocated())
 	}
 	mm.pool.ClearAccount(ctx, &mm.mu.curBudget)
 }
@@ -663,10 +691,4 @@ func (mm *BytesMonitor) adjustBudget(ctx context.Context) {
 	if neededBytes <= mm.mu.curBudget.curAllocated-margin {
 		mm.pool.ShrinkAccount(ctx, &mm.mu.curBudget, mm.mu.curBudget.curAllocated-neededBytes)
 	}
-}
-
-// GetCurrentAllocationForTesting returns the number of bytes that have
-// currently been allocated in the BytesMonitor. Intended for use in testing.
-func (mm *BytesMonitor) GetCurrentAllocationForTesting() int64 {
-	return mm.mu.curAllocated
 }

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -46,6 +46,7 @@ import (
 //   to their monitor. Grow/Resize requests can be denied (return an error),
 //   which indicates the budget has been reached.
 //
+
 // - different instances of BoundAccount are associated to different usage
 //   categories in components, in principle to track different object
 //   lifetimes.  Each account tracks the total amount of bytes allocated in
@@ -468,13 +469,13 @@ func (b *BoundAccount) Close(ctx context.Context) {
 	}
 }
 
-// ResizeItem requests a size change for an object already registered in an
+// Resize requests a size change for an object already registered in an
 // account. The reservation is not modified if the new allocation is refused,
 // so that the caller can keep using the original item without an accounting
 // error. This is better than calling ClearAccount then GrowAccount because if
 // the Clear succeeds and the Grow fails the original item becomes invisible
 // from the perspective of the monitor.
-func (b *BoundAccount) ResizeItem(ctx context.Context, oldSz, newSz int64) error {
+func (b *BoundAccount) Resize(ctx context.Context, oldSz, newSz int64) error {
 	delta := newSz - oldSz
 	switch {
 	case delta > 0:

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -311,3 +311,14 @@ func TestBytesMonitor(t *testing.T) {
 	limitedMonitor.Stop(ctx)
 	m.Stop(ctx)
 }
+
+func BenchmarkBoundAccountGrow(b *testing.B) {
+	ctx := context.Background()
+	m := MakeMonitor("test", MemoryResource, nil, nil, 1e9, 1e9)
+	m.Start(ctx, nil, MakeStandaloneBudget(1e9))
+
+	a := m.MakeBoundAccount()
+	for i := 0; i < b.N; i++ {
+		_ = a.Grow(ctx, 1)
+	}
+}

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -188,7 +188,7 @@ func TestMemoryAllocations(t *testing.T) {
 							osz := rnd.Int63n(accs[accI].used + 1)
 							nsz := randomSize(rnd, mmax)
 							reportAndCheck("R [%5d] %5d %5d", accI, osz, nsz)
-							err := accs[accI].ResizeItem(ctx, osz, nsz)
+							err := accs[accI].Resize(ctx, osz, nsz)
 							if err == nil {
 								reportAndCheck("R [%5d] ok", accI)
 							} else {
@@ -249,15 +249,15 @@ func TestBoundAccount(t *testing.T) {
 		t.Fatalf("monitor refused allocation: %v", err)
 	}
 
-	if err := a2.ResizeItem(ctx, 50, 60); err == nil {
+	if err := a2.Resize(ctx, 50, 60); err == nil {
 		t.Fatalf("monitor accepted excessive allocation")
 	}
 
-	if err := a1.ResizeItem(ctx, 0, 5); err != nil {
+	if err := a1.Resize(ctx, 0, 5); err != nil {
 		t.Fatalf("monitor refused allocation: %v", err)
 	}
 
-	if err := a2.ResizeItem(ctx, a2.used, 40); err != nil {
+	if err := a2.Resize(ctx, a2.used, 40); err != nil {
 		t.Fatalf("monitor refused reset + allocation: %v", err)
 	}
 

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -16,6 +16,7 @@ package mon
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"testing"
 
@@ -52,6 +53,8 @@ func TestMemoryAllocations(t *testing.T) {
 	// The following invariants will be checked at every step of the
 	// test underneath.
 	checkInvariants := func() {
+		t.Helper()
+
 		var sum int64
 		fail := false
 		for accI := range accs {
@@ -59,7 +62,7 @@ func TestMemoryAllocations(t *testing.T) {
 				t.Errorf("account %d went negative: %d", accI, accs[accI].curAllocated)
 				fail = true
 			}
-			sum += accs[accI].curAllocated
+			sum += accs[accI].totalAllocated()
 		}
 		if m.mu.curAllocated < 0 {
 			t.Errorf("monitor current count went negative: %d", m.mu.curAllocated)
@@ -73,7 +76,7 @@ func TestMemoryAllocations(t *testing.T) {
 			t.Errorf("monitor current budget went negative: %d", m.mu.curBudget.curAllocated)
 			fail = true
 		}
-		avail := m.mu.curBudget.curAllocated + m.reserved.curAllocated
+		avail := m.mu.curBudget.totalAllocated() + m.reserved.curAllocated
 		if sum > avail {
 			t.Errorf("total account sum %d greater than total monitor budget %d", sum, avail)
 			fail = true
@@ -82,7 +85,7 @@ func TestMemoryAllocations(t *testing.T) {
 			t.Errorf("pool cur %d exceeds max %d", pool.mu.curAllocated, pool.reserved.curAllocated)
 			fail = true
 		}
-		if m.mu.curBudget.curAllocated != pool.mu.curAllocated {
+		if m.mu.curBudget.totalAllocated() != pool.mu.curAllocated {
 			t.Errorf("monitor budget %d different from pool cur %d", m.mu.curBudget.curAllocated, pool.mu.curAllocated)
 			fail = true
 		}
@@ -98,7 +101,7 @@ func TestMemoryAllocations(t *testing.T) {
 	var reportAndCheck func(string, ...interface{})
 	if log.V(2) {
 		// Detailed output: report the intermediate values of the
-		// important variables at every stafe of the test.
+		// important variables at every stage of the test.
 		linesBetweenHeaderReminders = 5
 		generateHeader = func() {
 			fmt.Println("")
@@ -110,6 +113,7 @@ func TestMemoryAllocations(t *testing.T) {
 			fmt.Println("")
 		}
 		reportAndCheck = func(extraFmt string, extras ...interface{}) {
+			t.Helper()
 			fmt.Printf("%5d %5d %5d %5d ", m.mu.curAllocated, m.mu.curBudget.curAllocated, m.reserved.curAllocated, pool.mu.curAllocated)
 			for accI := range accs {
 				fmt.Printf("%5d ", accs[accI].curAllocated)
@@ -127,7 +131,10 @@ func TestMemoryAllocations(t *testing.T) {
 		} else {
 			generateHeader = func() {}
 		}
-		reportAndCheck = func(_ string, _ ...interface{}) { checkInvariants() }
+		reportAndCheck = func(_ string, _ ...interface{}) {
+			t.Helper()
+			checkInvariants()
+		}
 	}
 
 	for _, max := range maxs {
@@ -312,9 +319,30 @@ func TestBytesMonitor(t *testing.T) {
 	m.Stop(ctx)
 }
 
+func TestMemoryAllocationEdgeCases(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	m := MakeMonitor("test", MemoryResource,
+		nil /* curCount */, nil /* maxHist */, 1e9 /* increment */, 1e9 /* noteworthy */)
+	m.Start(ctx, nil, MakeStandaloneBudget(1e9))
+
+	a := m.MakeBoundAccount()
+	if err := a.Grow(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Grow(ctx, math.MaxInt64); err == nil {
+		t.Fatalf("expected error, but found success")
+	}
+
+	a.Close(ctx)
+	m.Stop(ctx)
+}
+
 func BenchmarkBoundAccountGrow(b *testing.B) {
 	ctx := context.Background()
-	m := MakeMonitor("test", MemoryResource, nil, nil, 1e9, 1e9)
+	m := MakeMonitor("test", MemoryResource,
+		nil /* curCount */, nil /* maxHist */, 1e9 /* increment */, 1e9 /* noteworthy */)
 	m.Start(ctx, nil, MakeStandaloneBudget(1e9))
 
 	a := m.MakeBoundAccount()


### PR DESCRIPTION
```
name                time/op
BoundAccountGrow-8  61.6ns ± 5%
```

This is very expensive. For comparison, pushing a row through a distsql
`RowChannel` takes ~100ns (which is also very expensive).

Release note: None