### PR TITLE
libroach: use gtest in unitests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "c-deps/cryptopp"]
 	path = c-deps/cryptopp
 	url = https://github.com/cockroachdb/cryptopp.git
+[submodule "c-deps/googletest"]
+	path = c-deps/googletest
+	url = https://github.com/cockroachdb/googletest

--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -51,22 +51,59 @@ target_include_directories(roachccl
 )
 target_link_libraries(roachccl roach)
 
-include(CTest)
-enable_testing()
-
-add_executable(encoding_test encoding_test.cc)
-target_include_directories(encoding_test PRIVATE ../rocksdb/include)
-target_link_libraries(encoding_test roach)
-add_test(encoding_test encoding_test)
-
-add_custom_target(check
-  COMMAND ${CMAKE_CTEST_COMMAND} -V
-  DEPENDS encoding_test
-)
-
-set_target_properties(roach roachccl encoding_test PROPERTIES
+set_target_properties(roach roachccl PROPERTIES
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED YES
   CXX_EXTENSIONS NO
   COMPILE_OPTIONS "-Werror;-Wall;-Wno-sign-compare"
 )
+
+enable_testing()
+
+# Tests executables are named after the source file (eg: libroach_test for libroach_test.cc)
+# Test names are the same as test executables.
+set(tests
+  encoding_test.cc
+  libroach_test.cc
+  ccl/libroach_ccl_test.cc
+)
+
+# "test" doesn't depend on the actual tests. Let's add a "check" target
+# that depends on all test executables and runs "ctest".
+add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -V)
+
+# Add googletest and get around a weird cmake issue:
+# https://gitlab.kitware.com/cmake/cmake/issues/16920
+set(THREADS_PTHREAD_ARG "2" CACHE STRING "Forcibly set by CMakeLists.txt." FORCE)
+add_subdirectory(../googletest/googletest
+                 ${CMAKE_BINARY_DIR}/googletest
+                 EXCLUDE_FROM_ALL)
+
+foreach(tsrc ${tests})
+  get_filename_component(filename ${tsrc} NAME_WE)
+  get_filename_component(dirname ${tsrc} DIRECTORY)
+  if("${dirname}" STREQUAL "" )
+    set(tname ${filename})
+  else()
+    set(tname ${dirname}_${filename})
+  endif()
+
+  # Add a new executable and set includes/libraries/properties.
+  add_executable(${tname} ${tsrc})
+  target_include_directories(${tname}
+    PRIVATE ../googletest/googletest/include
+    PRIVATE ../rocksdb/include
+  )
+  target_link_libraries(${tname} roachccl gtest_main pthread)
+
+  set_target_properties(${tname} PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+    COMPILE_OPTIONS "-Werror;-Wall;-Wno-sign-compare"
+  )
+
+  # Add the executable to the set of tests run by the "check" target.
+  add_test(${tname} ${tname})
+  add_dependencies(check ${tname})
+endforeach(tsrc)

--- a/c-deps/libroach/ccl/libroach_ccl_test.cc
+++ b/c-deps/libroach/ccl/libroach_ccl_test.cc
@@ -1,0 +1,3 @@
+#include <gtest/gtest.h>
+
+TEST(Libroach, Noop) { ASSERT_TRUE(true); }

--- a/c-deps/libroach/encoding_test.cc
+++ b/c-deps/libroach/encoding_test.cc
@@ -14,11 +14,12 @@
 
 #include <cinttypes>
 #include <cstdint>
+#include <gtest/gtest.h>
 #include <random>
 #include <vector>
 #include "encoding.h"
 
-int main() {
+TEST(Libroach, Encoding) {
   // clang-format off
   std::vector<uint32_t> cases32{
     0, 1, 2, 3,
@@ -46,18 +47,13 @@ int main() {
 
   cases64.insert(cases64.end(), cases32.begin(), cases32.end());
 
-  int nfailed = 0;
-
   for (auto it = cases32.begin(); it != cases32.end(); it++) {
     std::string buf;
     EncodeUint32(&buf, *it);
     uint32_t out;
     rocksdb::Slice slice(buf);
     DecodeUint32(&slice, &out);
-    if (*it != out) {
-      nfailed++;
-      printf("uint32: %" PRIu32 " != %" PRIu32 "\n", *it, out);
-    }
+    EXPECT_EQ(*it, out);
   }
 
   for (auto it = cases64.begin(); it != cases64.end(); it++) {
@@ -66,11 +62,6 @@ int main() {
     uint64_t out;
     rocksdb::Slice slice(buf);
     DecodeUint64(&slice, &out);
-    if (*it != out) {
-      nfailed++;
-      printf("uint64: %" PRIu64 " != %" PRIu64 "\n", *it, out);
-    }
+    EXPECT_EQ(*it, out);
   }
-
-  return nfailed > 0;
 }

--- a/c-deps/libroach/libroach_test.cc
+++ b/c-deps/libroach/libroach_test.cc
@@ -1,0 +1,3 @@
+#include <gtest/gtest.h>
+
+TEST(Libroach, Noop) { ASSERT_TRUE(true); }


### PR DESCRIPTION
Release Note: none.

Add new `googletest` c-dep and use it for libroach unitests.
Add support for many unittests in libroach, with naming scheme based on
the dir and filename. (eg: `ccl_libroach_ccl_test` for `ccl/libroach_ccl_test.cc`)