### PR TITLE
libroach: add encoding tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -624,6 +624,10 @@ libroach: $(LIBROACH_DIR)/Makefile $(CPP_PROTOS_TARGET)
 libroachccl: $(LIBROACH_DIR)/Makefile libroach
 	@$(MAKE) --no-print-directory -C $(LIBROACH_DIR) roachccl
 
+PHONY: check-libroach
+check-libroach: $(LIBROACH_DIR)/Makefile
+	@$(MAKE) --no-print-directory -C $(LIBROACH_DIR) check
+
 override TAGS += make $(NATIVE_SPECIFIER_TAG)
 
 # On macOS 10.11, XCode SDK v8.1 (and possibly others) indicate the presence of

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -22,3 +22,5 @@ build/builder.sh env \
 	2>&1 \
 	| tee artifacts/test.log \
 	| go-test-teamcity
+
+build/builder.sh make check-libroach

--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -49,7 +49,20 @@ target_include_directories(roachccl
 )
 target_link_libraries(roachccl roach)
 
-set_target_properties(roach roachccl PROPERTIES
+include(CTest)
+enable_testing()
+
+add_executable(encoding_test encoding_test.cc)
+target_include_directories(encoding_test PRIVATE ../rocksdb/include)
+target_link_libraries(encoding_test roach)
+add_test(encoding_test encoding_test)
+
+add_custom_target(check
+  COMMAND ${CMAKE_CTEST_COMMAND} -V
+  DEPENDS encoding_test
+)
+
+set_target_properties(roach roachccl encoding_test PROPERTIES
   CXX_STANDARD 11
   CXX_STANDARD_REQUIRED YES
   CXX_EXTENSIONS NO

--- a/c-deps/libroach/encoding.cc
+++ b/c-deps/libroach/encoding.cc
@@ -15,8 +15,6 @@
 #include "encoding.h"
 #include "rocksdb/slice.h"
 
-// TODO(benesch): Set up a CI pipeline to test these functions.
-
 void EncodeUint32(std::string* buf, uint32_t v) {
   const uint8_t tmp[sizeof(v)] = {
       uint8_t(v >> 24),

--- a/c-deps/libroach/encoding.h
+++ b/c-deps/libroach/encoding.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
+#include <rocksdb/slice.h>
 #include <stdint.h>
-#include "rocksdb/slice.h"
 
 // EncodeUint32 encodes the uint32 value using a big-endian 4 byte
 // representation. The bytes are appended to the supplied buffer.

--- a/c-deps/libroach/encoding_test.cc
+++ b/c-deps/libroach/encoding_test.cc
@@ -1,0 +1,76 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include <cinttypes>
+#include <cstdint>
+#include <random>
+#include <vector>
+#include "encoding.h"
+
+int main() {
+  // clang-format off
+  std::vector<uint32_t> cases32{
+    0, 1, 2, 3,
+    1 << 16, (1 << 16) - 1, (1 << 16) + 1,
+    1 << 24, (1 << 24) - 1, (1 << 24) + 1,
+    UINT32_MAX, UINT32_MAX - 1,
+  };
+
+  std::vector<uint64_t> cases64{
+    (1ULL << 32) + 1,
+    1ULL << 40, (1ULL << 40) - 1, (1ULL << 40) + 1,
+    1ULL << 48, (1ULL << 48) - 1, (1ULL << 48) + 1,
+    1ULL << 56, (1ULL << 56) - 1, (1ULL << 56) + 1,
+    UINT64_MAX - 1, UINT64_MAX
+  };
+  // clang-format on
+
+  std::mt19937 rng;
+  std::uniform_int_distribution<uint32_t> uniform32;
+  std::uniform_int_distribution<uint64_t> uniform64;
+  for (int i = 0; i < 32; i++) {
+    cases32.push_back(uniform32(rng));
+    cases64.push_back(uniform64(rng));
+  }
+
+  cases64.insert(cases64.end(), cases32.begin(), cases32.end());
+
+  int nfailed = 0;
+
+  for (auto it = cases32.begin(); it != cases32.end(); it++) {
+    std::string buf;
+    EncodeUint32(&buf, *it);
+    uint32_t out;
+    rocksdb::Slice slice(buf);
+    DecodeUint32(&slice, &out);
+    if (*it != out) {
+      nfailed++;
+      printf("uint32: %" PRIu32 " != %" PRIu32 "\n", *it, out);
+    }
+  }
+
+  for (auto it = cases64.begin(); it != cases64.end(); it++) {
+    std::string buf;
+    EncodeUint64(&buf, *it);
+    uint64_t out;
+    rocksdb::Slice slice(buf);
+    DecodeUint64(&slice, &out);
+    if (*it != out) {
+      nfailed++;
+      printf("uint64: %" PRIu64 " != %" PRIu64 "\n", *it, out);
+    }
+  }
+
+  return nfailed > 0;
+}


### PR DESCRIPTION
Complete a TODO now that cgo is no longer in the way. This paves the way
for future libroach tests.

Release note: None