### PR TITLE
build: specify snappy target.

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -430,7 +430,7 @@ libprotobuf: $(PROTOBUF_DIR)/Makefile
 
 .PHONY: libsnappy
 libsnappy: $(SNAPPY_DIR)/Makefile
-	@$(MAKE) --no-print-directory -C $(SNAPPY_DIR)
+	@$(MAKE) --no-print-directory -C $(SNAPPY_DIR) snappy
 
 .PHONY: librocksdb
 librocksdb: $(ROCKSDB_DIR)/Makefile


### PR DESCRIPTION
Release Note: fix build when new versions of libgtest are installed.

Fixes #20596

When `libgtest` is installed, the snappy unittests fail to build.
Since we never run the snappy tests, let's stop building them entirely.

This is a 1.1 fix only, `master` already specifies the `snappy` target.