### PR TITLE
libroach: make OSS/CCL tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -584,7 +584,9 @@ $(LIBROACH_DIR)/Makefile: $(C_DEPS_DIR)/libroach-rebuild $(BOOTSTRAP_TARGET)
 	mkdir -p $(LIBROACH_DIR)
 	@# NOTE: If you change the CMake flags below, bump the version in
 	@# $(C_DEPS_DIR)/libroach-rebuild. See above for rationale.
-	cd $(LIBROACH_DIR) && cmake $(CMAKE_FLAGS) $(LIBROACH_SRC_DIR) -DCMAKE_BUILD_TYPE=Release
+	cd $(LIBROACH_DIR) && cmake $(CMAKE_FLAGS) $(LIBROACH_SRC_DIR) -DCMAKE_BUILD_TYPE=Release \
+		-DPROTOBUF_LIB=$(PROTOBUF_DIR)/libprotobuf.a -DROCKSDB_LIB=$(ROCKSDB_DIR)/librocksdb.a \
+		-DJEMALLOC_LIB=$(JEMALLOC_DIR)/lib/libjemalloc.a -DSNAPPY_LIB=$(SNAPPY_DIR)/libsnappy.a
 
 # We mark C and C++ dependencies as .PHONY (or .ALWAYS_REBUILD) to avoid
 # having to name the artifact (for .PHONY), which can vary by platform, and so
@@ -620,7 +622,7 @@ libroachccl: $(LIBROACH_DIR)/Makefile $(CPP_PROTOS_CCL_TARGET) libroach
 	@$(MAKE) --no-print-directory -C $(LIBROACH_DIR) roachccl
 
 PHONY: check-libroach
-check-libroach: $(LIBROACH_DIR)/Makefile
+check-libroach: $(LIBROACH_DIR)/Makefile libjemalloc libprotobuf libsnappy librocksdb
 	@$(MAKE) --no-print-directory -C $(LIBROACH_DIR) check
 
 override TAGS += make $(NATIVE_SPECIFIER_TAG)

--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -15,8 +15,9 @@
 # NB: Despite CMake's portability, this build configuration makes no attempt to
 # support non-GCC-like compilers.
 
-# The CXX_STANDARD property was introduced in version 3.1.
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+# The CXX_STANDARD property was introduced in version 3.1
+# 3.3 fixes https://cmake.org/cmake/help/v3.3/policy/CMP0060.html
+cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 
 project(roachlib)
 
@@ -60,12 +61,12 @@ set_target_properties(roach roachccl PROPERTIES
 
 enable_testing()
 
-# Tests executables are named after the source file (eg: libroach_test for libroach_test.cc)
-# Test names are the same as test executables.
+# List of tests to build and run. Tests in `ccl/` are linked against roachccl, all others
+# are linked against roach only.
 set(tests
+  db_test.cc
   encoding_test.cc
-  libroach_test.cc
-  ccl/libroach_ccl_test.cc
+  ccl/db_test.cc
 )
 
 # "test" doesn't depend on the actual tests. Let's add a "check" target
@@ -79,7 +80,9 @@ add_subdirectory(../googletest/googletest
                  ${CMAKE_BINARY_DIR}/googletest
                  EXCLUDE_FROM_ALL)
 
+# Iterate over all test sources.
 foreach(tsrc ${tests})
+  # Build target name from filename (eg: ccl_db_test.cc for ccl/db_test.cc).
   get_filename_component(filename ${tsrc} NAME_WE)
   get_filename_component(dirname ${tsrc} DIRECTORY)
   if("${dirname}" STREQUAL "" )
@@ -93,8 +96,16 @@ foreach(tsrc ${tests})
   target_include_directories(${tname}
     PRIVATE ../googletest/googletest/include
     PRIVATE ../rocksdb/include
+    PRIVATE ../protobuf/src
   )
-  target_link_libraries(${tname} roachccl gtest_main pthread)
+
+  # Link `ccl/` tests against roachccl.
+  if(${tsrc} MATCHES "^ccl/")
+    target_link_libraries(${tname} roachccl)
+  endif()
+
+  # Add all other libraries.
+  target_link_libraries(${tname} roach ${PROTOBUF_LIB} ${ROCKSDB_LIB} ${SNAPPY_LIB} ${JEMALLOC_LIB} gtest_main pthread)
 
   set_target_properties(${tname} PROPERTIES
     CXX_STANDARD 11

--- a/c-deps/libroach/ccl/db_test.cc
+++ b/c-deps/libroach/ccl/db_test.cc
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include "../db.h"
+
+TEST(LibroachCCL, DBOpenHook) {
+  DBOptions db_opts;
+
+  // Try an empty extra_options.
+  db_opts.extra_options = ToDBSlice("");
+  EXPECT_EQ(NULL, DBOpenHook(db_opts).data);
+
+  // Try extra_options with bad data.
+  db_opts.extra_options = ToDBSlice("blah");
+  // TODO(mberhault): we need to convert to a std::string because the DBSlice's data
+  // is not null-terminated. Switch internal-only data to be "normal" objects.
+  EXPECT_EQ(std::string("failed to parse extra options"), ToString(DBOpenHook(db_opts)));
+}

--- a/c-deps/libroach/ccl/db_test.cc
+++ b/c-deps/libroach/ccl/db_test.cc
@@ -6,11 +6,9 @@ TEST(LibroachCCL, DBOpenHook) {
 
   // Try an empty extra_options.
   db_opts.extra_options = ToDBSlice("");
-  EXPECT_EQ(NULL, DBOpenHook(db_opts).data);
+  EXPECT_TRUE(DBOpenHook(db_opts).ok());
 
   // Try extra_options with bad data.
   db_opts.extra_options = ToDBSlice("blah");
-  // TODO(mberhault): we need to convert to a std::string because the DBSlice's data
-  // is not null-terminated. Switch internal-only data to be "normal" objects.
-  EXPECT_EQ(std::string("failed to parse extra options"), ToString(DBOpenHook(db_opts)));
+  EXPECT_STREQ("failed to parse extra options", DBOpenHook(db_opts).getState());
 }

--- a/c-deps/libroach/ccl/libroach_ccl_test.cc
+++ b/c-deps/libroach/ccl/libroach_ccl_test.cc
@@ -1,3 +1,0 @@
-#include <gtest/gtest.h>
-
-TEST(Libroach, Noop) { ASSERT_TRUE(true); }

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -48,7 +48,7 @@ static void __attribute__((noreturn)) die_missing_symbol(const char* name) {
 // DBOpenHook in OSS mode only verifies that no extra options are specified.
 __attribute__((weak)) DBStatus DBOpenHook(const DBOptions opts) {
   if (opts.extra_options.len != 0) {
-    return FmtStatus("DBOPtions has extra_options, but OSS code cannot handle them");
+    return FmtStatus("DBOptions has extra_options, but OSS code cannot handle them");
   }
   return kSuccess;
 }
@@ -199,6 +199,8 @@ struct DBIterator {
 };
 
 std::string ToString(DBSlice s) { return std::string(s.data, s.len); }
+
+std::string ToString(DBString s) { return std::string(s.data, s.len); }
 
 rocksdb::Slice ToSlice(DBSlice s) { return rocksdb::Slice(s.data, s.len); }
 

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -45,14 +45,6 @@ static void __attribute__((noreturn)) die_missing_symbol(const char* name) {
   abort();
 }
 
-// DBOpenHook in OSS mode only verifies that no extra options are specified.
-__attribute__((weak)) DBStatus DBOpenHook(const DBOptions opts) {
-  if (opts.extra_options.len != 0) {
-    return FmtStatus("DBOptions has extra_options, but OSS code cannot handle them");
-  }
-  return kSuccess;
-}
-
 // These are Go functions exported by storage/engine. We provide these stubs,
 // which simply panic if called, to to allow intermediate build products to link
 // successfully. Otherwise, when building ccl/storageccl/engineccl, Go will
@@ -68,6 +60,14 @@ char* __attribute__((weak)) prettyPrintKey(DBKey) { die_missing_symbol(__func__)
 #else
 #define WARN_UNUSED_RESULT
 #endif
+
+// DBOpenHook in OSS mode only verifies that no extra options are specified.
+__attribute__((weak)) rocksdb::Status DBOpenHook(const DBOptions opts) {
+  if (opts.extra_options.len != 0) {
+    return rocksdb::Status::InvalidArgument("DBOptions has extra_options, but OSS code cannot handle them");
+  }
+  return rocksdb::Status::OK();
+}
 
 struct DBCache {
   std::mutex mu;
@@ -1578,8 +1578,8 @@ DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions db_opts) {
 
   // Call hooks to handle db_opts.extra_options.
   auto hook_status = DBOpenHook(db_opts);
-  if (hook_status.data != NULL) {
-    return hook_status;
+  if (!hook_status.ok()) {
+    return ToDBStatus(hook_status);
   }
 
   // Register listener for tracking RocksDB stats.

--- a/c-deps/libroach/db.h
+++ b/c-deps/libroach/db.h
@@ -18,8 +18,14 @@
 #include <rocksdb/write_batch.h>
 #include <rocksdb/write_batch_base.h>
 
+// ToDBSlice returns a DBSlice from a rocksdb::Slice
+DBSlice ToDBSlice(const rocksdb::Slice& s);
+
 // ToString returns a c++ string with the contents of a DBSlice.
 std::string ToString(DBSlice s);
+
+// ToString returns a c++ string with the contents of a DBString.
+std::string ToString(DBString s);
 
 // MVCC keys are encoded as <key>[<wall_time>[<logical>]]<#timestamp-bytes>. A
 // custom RocksDB comparator (DBComparator) is used to maintain the desired

--- a/c-deps/libroach/db.h
+++ b/c-deps/libroach/db.h
@@ -15,8 +15,12 @@
 #include <libroach.h>
 #include <rocksdb/comparator.h>
 #include <rocksdb/iterator.h>
+#include <rocksdb/status.h>
 #include <rocksdb/write_batch.h>
 #include <rocksdb/write_batch_base.h>
+
+// DBOpenHook is called at the beginning of DBOpen. It can be implemented in CCL code.
+rocksdb::Status DBOpenHook(const DBOptions opts);
 
 // ToDBSlice returns a DBSlice from a rocksdb::Slice
 DBSlice ToDBSlice(const rocksdb::Slice& s);

--- a/c-deps/libroach/db_test.cc
+++ b/c-deps/libroach/db_test.cc
@@ -7,11 +7,9 @@ TEST(Libroach, DBOpenHook) {
 
   // Try an empty extra_options.
   db_opts.extra_options = ToDBSlice("");
-  EXPECT_EQ(NULL, DBOpenHook(db_opts).data);
+  EXPECT_TRUE(DBOpenHook(db_opts).ok());
 
   // Try extra_options with anything at all.
   db_opts.extra_options = ToDBSlice("blah");
-  // TODO(mberhault): we need to convert to a std::string because the DBSlice's data
-  // is not null-terminated. Switch internal-only data to be "normal" objects.
-  EXPECT_EQ(std::string("DBOptions has extra_options, but OSS code cannot handle them"), ToString(DBOpenHook(db_opts)));
+  EXPECT_STREQ("DBOptions has extra_options, but OSS code cannot handle them", DBOpenHook(db_opts).getState());
 }

--- a/c-deps/libroach/db_test.cc
+++ b/c-deps/libroach/db_test.cc
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+#include "db.h"
+#include "include/libroach.h"
+
+TEST(Libroach, DBOpenHook) {
+  DBOptions db_opts;
+
+  // Try an empty extra_options.
+  db_opts.extra_options = ToDBSlice("");
+  EXPECT_EQ(NULL, DBOpenHook(db_opts).data);
+
+  // Try extra_options with anything at all.
+  db_opts.extra_options = ToDBSlice("blah");
+  // TODO(mberhault): we need to convert to a std::string because the DBSlice's data
+  // is not null-terminated. Switch internal-only data to be "normal" objects.
+  EXPECT_EQ(std::string("DBOptions has extra_options, but OSS code cannot handle them"), ToString(DBOpenHook(db_opts)));
+}

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -75,9 +75,6 @@ typedef struct {
   DBSlice extra_options;
 } DBOptions;
 
-// DBOpenHook is called at the beginning of DBOpen. It can be implemented in CCL code.
-DBStatus DBOpenHook(const DBOptions opts);
-
 // Create a new cache with the specified size.
 DBCache* DBNewCache(uint64_t size);
 

--- a/c-deps/libroach/libroach_test.cc
+++ b/c-deps/libroach/libroach_test.cc
@@ -1,3 +1,0 @@
-#include <gtest/gtest.h>
-
-TEST(Libroach, Noop) { ASSERT_TRUE(true); }


### PR DESCRIPTION
Release note: None

We link against `roachccl` only for tests inside the `ccl/` directory.
`db_test.cc` and `ccl/db_test.cc` show working behavior (DBOpenHook
differs between OSS and CCL).

We also need to properly link in all other libraries. It worked before
due to those symbols not beeing needed (we had trivial tests).