### PR TITLE
sql: provide guidance in duplicate partition name error

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -46,22 +46,35 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     )
 )
 
-statement error PARTITION p1: name must be unique
+statement error PARTITION p1: name must be unique \(used twice in index "primary"\)
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1),
     PARTITION p1 VALUES IN (2)
 )
 
-statement error PARTITION p1: name must be unique
+statement error PARTITION p1: name must be unique \(used twice in index "primary"\)
+CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) (
+    PARTITION p1 VALUES < 1,
+    PARTITION p1 VALUES < 2
+)
+
+statement error PARTITION p1: name must be unique \(used twice in index "primary"\)
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1),
     PARTITION P1 VALUES IN (2)
 )
 
-statement error PARTITION p1: name must be unique
+statement error PARTITION p1: name must be unique \(used twice in index "primary"\)
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1) PARTITION BY LIST (b) (
         PARTITION p1 VALUES IN (2)
+    )
+)
+
+statement error PARTITION p1: name must be unique \(used twice in index "primary"\)
+CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN (1) PARTITION BY RANGE (b) (
+        PARTITION p1 VALUES < (2)
     )
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/partitioning_index
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning_index
@@ -86,7 +86,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS i4 ON indexes (b) PARTITION BY LIST (b) (
     PARTITION p4 VALUES IN (1)
 )
 
-statement error PARTITION p1: name must be unique
+statement error PARTITION p1: name must be unique \(used in both index "i1" and index "i5"\)
 CREATE INDEX i5 ON indexes (b) PARTITION BY LIST (b) (
     PARTITION p1 VALUES IN (1)
 )


### PR DESCRIPTION
Partition names must be unique across all of a table's indexes. This can
be rather surprising, so tell the user what they did wrong in more
detail in the error message. With this change, a duplicate partition
name will result in a message like

    PARTITION foo: name must be unique (used twice in index "primary")

or

    PARTITION foo: name must be unique (used in both index "a" and index "b")

instead of just:

    PARTITION foo: name must be unique

Release note: None