### PR TITLE
[DO NOT MERGE] distsql: row batching

### DIFF
--- a/pkg/sql/distsqlrun/base_test.go
+++ b/pkg/sql/distsqlrun/base_test.go
@@ -20,8 +20,10 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"golang.org/x/net/context"
 )
 
 // TODO(asubiotto): Add test and benchmark for RowChannel juggling batches.
@@ -71,5 +73,179 @@ func BenchmarkRowChannelPipeline(b *testing.B) {
 			rc[0].ProducerDone()
 			wg.Wait()
 		})
+
 	}
+}
+
+type callbackFn func(row sqlbase.EncDatumRow, meta ProducerMetadata) ConsumerStatus
+
+type CallbackReceiver struct {
+	fn callbackFn
+}
+
+func NewCallbackReceiver(fn callbackFn) *CallbackReceiver {
+	return &CallbackReceiver{fn: fn}
+}
+
+func (c *CallbackReceiver) Push(row sqlbase.EncDatumRow, meta ProducerMetadata) ConsumerStatus {
+	return c.fn(row, meta)
+}
+
+func (c *CallbackReceiver) ProducerDone() {}
+
+var _ RowReceiver = &CallbackReceiver{}
+
+func BenchmarkJoinAndCount(b *testing.B) {
+	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext()
+	defer evalCtx.Stop(ctx)
+	flowCtx := FlowCtx{
+		Settings: cluster.MakeTestingClusterSettings(),
+		EvalCtx:  evalCtx,
+	}
+
+	spec := HashJoinerSpec{
+		LeftEqColumns:  []uint32{0},
+		RightEqColumns: []uint32{0},
+		Type:           JoinType_INNER,
+	}
+	//post := PostProcessSpec{Projection: true, OutputColumns: []uint32{0}}
+	// TODO(asubiotto): I think this should be right.
+	post := PostProcessSpec{}
+
+	columnTypeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
+
+	// Input will serve as both left and right inputs. Every row will have the
+	// same column value, thus producing inputSize^2 rows.
+	const inputSize = 1000
+	input := make(sqlbase.EncDatumRows, inputSize)
+	for i := range input {
+		input[i] = sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(columnTypeInt, tree.NewDInt(tree.DInt(1)))}
+	}
+
+	types := []sqlbase.ColumnType{columnTypeInt}
+
+	leftInput := NewRepeatableRowSource(types, input)
+	rightInput := NewRepeatableRowSource(types, input)
+
+	b.Run("Normal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			leftInput.Reset()
+			rightInput.Reset()
+			conn := &RowChannel{}
+			conn.Init(types)
+			ag, err := newAggregator(
+				&flowCtx,
+				&AggregatorSpec{
+					Aggregations: []AggregatorSpec_Aggregation{{Func: AggregatorSpec_COUNT_ROWS}},
+				},
+				conn,
+				&post,
+				&RowDisposer{},
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			var wg sync.WaitGroup
+			go func() {
+				wg.Add(1)
+				ag.Run(ctx, &wg)
+			}()
+			h, err := newHashJoiner(&flowCtx, &spec, leftInput, rightInput, &post, conn)
+			if err != nil {
+				b.Fatal(err)
+			}
+			h.Run(ctx, nil)
+
+			wg.Wait()
+		}
+	})
+
+	b.Run("ElideRowChan", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			leftInput.Reset()
+			rightInput.Reset()
+			ag, err := newAggregator(
+				&flowCtx,
+				&AggregatorSpec{
+					Aggregations: []AggregatorSpec_Aggregation{{Func: AggregatorSpec_COUNT_ROWS}},
+				},
+				// This doesn't matter as we're not reading from input.
+				&RepeatableRowSource{},
+				&post,
+				&RowDisposer{},
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			defer ag.Close(ctx)
+			var scratch []byte
+			out := NewCallbackReceiver(func(row sqlbase.EncDatumRow, meta ProducerMetadata) ConsumerStatus {
+				if _, err := ag.NextRow(ctx, scratch, row, meta); err != nil {
+					b.Fatal(err)
+				}
+				return NeedMoreRows
+			})
+			h, err := newHashJoiner(&flowCtx, &spec, leftInput, rightInput, &post, out)
+			if err != nil {
+				b.Fatal(err)
+			}
+			h.Run(ctx, nil)
+			ag.RenderResults(ctx)
+		}
+	})
+
+	b.Run("RowBatching", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			leftInput.Reset()
+			rightInput.Reset()
+			conn := &RowChannel{}
+			conn.Init(types)
+			ag, err := newAggregator(
+				&flowCtx,
+				&AggregatorSpec{
+					Aggregations: []AggregatorSpec_Aggregation{{Func: AggregatorSpec_COUNT_ROWS}},
+				},
+				conn,
+				&post,
+				&RowDisposer{},
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			ag.Batching = true
+			var wg sync.WaitGroup
+			go func() {
+				wg.Add(1)
+				ag.Run(ctx, &wg)
+			}()
+			batch := make(RowBatch, 0, RowBatchSize)
+			h, err := newHashJoiner(
+				&flowCtx,
+				&spec,
+				leftInput,
+				rightInput,
+				&post,
+				NewCallbackReceiver(func(row sqlbase.EncDatumRow, meta ProducerMetadata) ConsumerStatus {
+					if row != nil {
+						batch = append(batch, row)
+						if len(batch) == RowBatchSize {
+							status := conn.PushBatch(batch)
+							batch = make(RowBatch, 0, RowBatchSize)
+							return status
+						}
+						return NeedMoreRows
+					}
+					return conn.Push(row, meta)
+				}),
+			)
+			if err != nil {
+				b.Fatal(err)
+			}
+			h.Run(ctx, nil)
+			conn.ProducerDone()
+
+			wg.Wait()
+		}
+	})
 }

--- a/pkg/sql/distsqlrun/base_test.go
+++ b/pkg/sql/distsqlrun/base_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
+// TODO(asubiotto): Add test and benchmark for RowChannel juggling batches.
+
 // Benchmark a pipeline of RowChannels.
 func BenchmarkRowChannelPipeline(b *testing.B) {
 	columnTypeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/pkg/errors"
 )
 
 func TestTableReader(t *testing.T) {
@@ -294,4 +295,110 @@ func BenchmarkTableReader(b *testing.B) {
 			}
 		}
 	}
+}
+
+func BenchmarkNextSteps(b *testing.B) {
+	s, sqlDB, kvDB := serverutils.StartServer(b, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	sqlutils.CreateTable(
+		b, sqlDB, "t",
+		"k INT PRIMARY KEY, v INT",
+		10000,
+		sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowModuloFn(42)),
+	)
+
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "test", "t")
+
+	evalCtx := tree.MakeTestingEvalContext()
+	defer evalCtx.Stop(context.Background())
+	flowCtx := FlowCtx{
+		EvalCtx:  evalCtx,
+		Settings: s.ClusterSettings(),
+		// Pass a DB without a TxnCoordSender.
+		txn:    client.NewTxn(client.NewDB(s.DistSender(), s.Clock()), s.NodeID()),
+		nodeID: s.NodeID(),
+	}
+	spec := TableReaderSpec{
+		Table: *tableDesc,
+		Spans: []TableReaderSpan{{Span: tableDesc.PrimaryIndexSpan()}},
+	}
+	post := PostProcessSpec{}
+	types := make([]sqlbase.ColumnType, len(tableDesc.Columns))
+	for i := range types {
+		types[i] = tableDesc.Columns[i].Type
+	}
+	b.Run("Normal", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			out := &RowChannel{}
+			out.Init(types)
+			errChan := make(chan error)
+			go func() {
+				for {
+					row, meta := out.Next()
+					if !meta.Empty() {
+						errChan <- errors.Errorf("unexpected metadata: %+v", meta)
+					}
+					if row == nil {
+						break
+					}
+				}
+				errChan <- nil
+			}()
+			tr, err := newTableReader(&flowCtx, &spec, &post, out)
+			if err != nil {
+				b.Fatal(err)
+			}
+			tr.Run(context.Background(), nil)
+
+			if err := <-errChan; err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("ElideRowChan", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			// Out doesn't matter
+			out := &RowBuffer{}
+			tr, err := newTableReader(&flowCtx, &spec, &post, out)
+			if err != nil {
+				b.Fatal(err)
+			}
+			tr.ReadyForFetch()
+			for {
+				row, meta := tr.NextRow()
+				if !meta.Empty() {
+					b.Fatalf("unexpected metadata: %+v", meta)
+				}
+				if row == nil {
+					break
+				}
+			}
+		}
+	})
+	b.Run("RowBatch", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			out := &RowChannel{}
+			out.Init(types)
+			errChan := make(chan error)
+			go func() {
+				for {
+					batch, meta := out.NextBatch()
+					if !meta.Empty() {
+						errChan <- errors.Errorf("unexpected metadata: %+v", meta)
+					}
+					if batch == nil {
+						break
+					}
+				}
+				errChan <- nil
+			}()
+			tr, err := newTableReader(&flowCtx, &spec, &post, out)
+			if err != nil {
+				b.Fatal(err)
+			}
+			tr.Batching = true
+			tr.Run(context.Background(), nil)
+		}
+	})
 }


### PR DESCRIPTION
Draft work on row batching with benchmark. Thought it would be useful to share this given discussion on #20555. Results:
```
name                      time/op
NextSteps/Normal-8        14.5ms ± 3%
NextSteps/ElideRowChan-8  11.3ms ± 5%
NextSteps/RowBatch-8      12.4ms ± 2%
```
This is a meaningless benchmark as `RowBatch` is equal to `ElideRowChan` but with row copies. Keep in mind that `RowBatch` needs to allocate row copies, but this is a cost that occurs once per local flow and can be amortized.

More meaningful benchmarks could be to set up flows with remote communication and longer flows with only local communication.