### PR TITLE
Fix GOPATH in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ new engineers.
 
    ```shell
    go get -d github.com/cockroachdb/cockroach
-   cd $GOPATH/src/github.com/cockroachdb/cockroach
+   cd $(go env GOPATH)/src/github.com/cockroachdb/cockroach
    ```
 
 3. Run `make build`, `make test`, or anything else our Makefile offers.


### PR DESCRIPTION
there is no need for users to set GOPATH if they're using the default
of `~/go`. Update `CONTRIBUTING.md` to reflect that.

Release note: None