### PR TITLE
[WIP] sql: unblock introspection during schema changes

### DIFF
--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -81,7 +81,7 @@ func (n *createSequenceNode) startExec(params runParams) error {
 		return err
 	}
 
-	if err = params.p.createDescriptorWithID(params.ctx, key, id, &desc); err != nil {
+	if err = params.p.createDescriptorWithID(params.ctx, key, id, &desc, true); err != nil {
 		return err
 	}
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -147,7 +147,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		return err
 	}
 
-	if err := params.p.createDescriptorWithID(params.ctx, key, id, &desc); err != nil {
+	if err := params.p.createDescriptorWithID(params.ctx, key, id, &desc, false); err != nil {
 		return err
 	}
 
@@ -228,6 +228,8 @@ func (n *createTableNode) startExec(params runParams) error {
 		// Return the number of rows affected as result.
 		n.run.rowsAffected = count
 	}
+
+	params.p.session.tables.addUncommittedTable(desc)
 	return nil
 }
 

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -153,7 +153,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		desc.DependsOn = append(desc.DependsOn, backrefID)
 	}
 
-	if err = params.p.createDescriptorWithID(params.ctx, key, id, &desc); err != nil {
+	if err = params.p.createDescriptorWithID(params.ctx, key, id, &desc, true); err != nil {
 		return err
 	}
 

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -202,7 +202,7 @@ func (p *planner) truncateTable(ctx context.Context, id sqlbase.ID, traceKV bool
 	newTableDesc.Mutations = nil
 	tKey := tableKey{parentID: newTableDesc.ParentID, name: newTableDesc.Name}
 	key := tKey.Key()
-	if err := p.createDescriptorWithID(ctx, key, newID, &newTableDesc); err != nil {
+	if err := p.createDescriptorWithID(ctx, key, newID, &newTableDesc, true); err != nil {
 		return err
 	}
 	p.notifySchemaChange(&newTableDesc, sqlbase.InvalidMutationID)


### PR DESCRIPTION
Please hold off on reviewing while I finalize this PR.

Release note: Fixed a bug where long running schema changes sometimes
blocked introspection queries until the schema change completed. These
introspection queries are often performed by ORMs and SQL tools on
startup, which blocked using all those tools during running schema
changes.