### PR TITLE
sql: bugfix to evalling null as collated string

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -278,3 +278,12 @@ query T
 SELECT '40 days' COLLATE en::INTERVAL
 ----
 40d
+
+statement ok
+CREATE TABLE foo(a STRING COLLATE en_u_ks_level2)
+
+statement ok
+PREPARE x AS INSERT INTO foo VALUES ($1 COLLATE en_u_ks_level2)
+
+query error incompatible type for COLLATE: NULL
+EXECUTE x(NULL)

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2854,7 +2854,7 @@ func (expr *CollateExpr) Eval(ctx *EvalContext) (Datum, error) {
 	case *DCollatedString:
 		return NewDCollatedString(d.Contents, expr.Locale, &ctx.collationEnv), nil
 	default:
-		panic(fmt.Sprintf("invalid argument to COLLATE: %s", d))
+		return nil, pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError, "incompatible type for COLLATE: %s", d)
 	}
 }
 


### PR DESCRIPTION
Previously, evaluating a prepared statement where a placeholder was
directly collated with the `COLLATE` operator could panic if the input
was null.

Fixes #20636.

Release note (bug fix): Fix a panic with null collated strings.