### PR TITLE
sql: extricate the prepared statements code from the Executor

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -428,7 +428,8 @@ func (e *Executor) Start(
 	ctx = log.WithLogTag(ctx, "startup", nil)
 	startupSession := NewSession(ctx, SessionArgs{}, e, nil, startupMemMetrics)
 	startupSession.StartUnlimitedMonitor()
-	if err := e.virtualSchemas.init(ctx, startupSession.newPlanner(e, nil)); err != nil {
+	if err := e.virtualSchemas.init(
+		ctx, newPlanner(startupSession, nil /* txn */, e.cfg.ClusterID(), e.cfg.NodeID.Get(), e.reCache)); err != nil {
 		log.Fatal(ctx, err)
 	}
 	startupSession.Finish(e)
@@ -470,14 +471,35 @@ func (e *Executor) getDatabaseCache() *databaseCache {
 	return nil
 }
 
+// DBCacheHolder is used by GetDatabaseCache() to export a *databaseCache.
+// pgwire will pass this back into the sql package.
+// WIP(andrei): This will go away with the Executor.
+type DBCacheHolder struct {
+	dbCache *databaseCache
+}
+
+// GetDatabaseCache is like getDatabaseCache(), but exported for the pgwire
+// package. It also returns an exported type.
+// WIP(andrei): This will go away with the Executor.
+func (e *Executor) GetDatabaseCache() DBCacheHolder {
+	dbc := e.getDatabaseCache()
+	return DBCacheHolder{dbc}
+}
+
 // Prepare returns the result types of the given statement. pinfo may
 // contain partial type information for placeholders. Prepare will
 // populate the missing types. The PreparedStatement is returned (or
 // nil if there are no results).
-func (e *Executor) Prepare(
-	stmt Statement, stmtStr string, session *Session, placeholderHints tree.PlaceholderTypes,
+func Prepare(
+	stmt Statement,
+	stmtStr string,
+	session *Session,
+	placeholderHints tree.PlaceholderTypes,
+	dbCache *databaseCache,
+	execCfg *ExecutorConfig,
+	reCache *tree.RegexpCache,
 ) (res *PreparedStatement, err error) {
-	session.resetForBatch(e)
+	session.resetForBatch(dbCache)
 	sessionEventf(session, "preparing: %s", stmtStr)
 
 	defer session.maybeRecover("preparing", stmtStr)
@@ -498,7 +520,8 @@ func (e *Executor) Prepare(
 	if err := placeholderHints.ProcessPlaceholderAnnotations(stmt.AST); err != nil {
 		return nil, err
 	}
-	protoTS, err := isAsOf(session, stmt.AST, e.cfg.Clock.Now())
+	evalCtx := session.evalCtx()
+	protoTS, err := isAsOf(stmt.AST, &evalCtx, execCfg.Clock.Now())
 	if err != nil {
 		return nil, err
 	}
@@ -515,14 +538,14 @@ func (e *Executor) Prepare(
 		// TODO(vivek): perhaps we should be more consistent and update
 		// session.TxnState.mu.txn, but more thought needs to be put into whether that
 		// is really needed.
-		txn = client.NewTxn(e.cfg.DB, e.cfg.NodeID.Get())
+		txn = client.NewTxn(execCfg.DB, execCfg.NodeID.Get())
 		if err := txn.SetIsolation(session.DefaultIsolationLevel); err != nil {
 			panic(fmt.Errorf("cannot set up txn for prepare %q: %v", stmtStr, err))
 		}
-		txn.Proto().OrigTimestamp = e.cfg.Clock.Now()
+		txn.Proto().OrigTimestamp = execCfg.Clock.Now()
 	}
 
-	planner := session.newPlanner(e, txn)
+	planner := newPlanner(session, txn, execCfg.ClusterID(), execCfg.NodeID.Get(), reCache)
 	planner.semaCtx.Placeholders.SetTypeHints(placeholderHints)
 	planner.evalCtx.PrepareOnly = true
 	planner.evalCtx.ActiveMemAcc = &prepared.memAcc
@@ -536,7 +559,7 @@ func (e *Executor) Prepare(
 		txn.SetFixedTimestamp(session.Ctx(), *protoTS)
 	}
 
-	if filter := e.cfg.TestingKnobs.BeforePrepare; filter != nil {
+	if filter := execCfg.TestingKnobs.BeforePrepare; filter != nil {
 		res, err := filter(session.Ctx(), stmtStr, planner)
 		if res != nil || err != nil {
 			return res, err
@@ -606,7 +629,7 @@ func (e *Executor) ExecuteStatementsBuffered(
 func (e *Executor) ExecuteStatements(
 	session *Session, stmts string, pinfo *tree.PlaceholderInfo,
 ) error {
-	session.resetForBatch(e)
+	session.resetForBatch(e.getDatabaseCache())
 	session.phaseTimes[sessionStartBatch] = timeutil.Now()
 
 	defer session.maybeRecover("executing", stmts)
@@ -808,7 +831,8 @@ func (e *Executor) execParsed(
 				// Check for AS OF SYSTEM TIME. If it is present but not detected here,
 				// it will raise an error later on.
 				var err error
-				protoTS, err = isAsOf(session, stmtsToExec[0].AST, e.cfg.Clock.Now())
+				evalCtx := session.evalCtx()
+				protoTS, err = isAsOf(stmtsToExec[0].AST, &evalCtx, e.cfg.Clock.Now())
 				if err != nil {
 					return err
 				}
@@ -1758,7 +1782,9 @@ func (e *Executor) execStmtInOpenTxn(
 	case *tree.Prepare:
 		// This must be handled here instead of the common path below
 		// because we need to use the Executor reference.
-		if err := e.PrepareStmt(session, s); err != nil {
+		if err := PrepareStmt(
+			session, s, e.getDatabaseCache(), &e.cfg, e.reCache,
+		); err != nil {
 			return err
 		}
 		res.BeginResult((*tree.Prepare)(nil))
@@ -1783,12 +1809,14 @@ func (e *Executor) execStmtInOpenTxn(
 	if runInParallel {
 		// Create a new planner from the Session to execute the statement, since
 		// we're executing in parallel.
-		p = session.newPlanner(e, txnState.mu.txn)
+		p = newPlanner(
+			session, txnState.mu.txn, e.cfg.ClusterID(),
+			e.cfg.NodeID.Get(), e.reCache)
 	} else {
 		// We're not executing in parallel. We can use the cached planner on the
 		// session.
 		p = &session.planner
-		session.resetPlanner(p, e, txnState.mu.txn)
+		resetPlanner(p, session, txnState.mu.txn, e.cfg.ClusterID(), e.cfg.NodeID.Get(), e.reCache)
 	}
 	p.evalCtx.SetTxnTimestamp(txnState.sqlTimestamp)
 	p.evalCtx.SetStmtTimestamp(e.cfg.Clock.PhysicalTime())
@@ -2293,6 +2321,18 @@ func (e *Executor) generateQueryID() uint128.Uint128 {
 	return uint128.FromInts((uint64)(timestamp.WallTime), loInt)
 }
 
+// GetExecCfg is exported for the pgwire package.
+// WIP(andrei): This will go away with the Executor.
+func (e *Executor) GetExecCfg() *ExecutorConfig {
+	return &e.cfg
+}
+
+// GetReCache is exported for the pgwire package.
+// WIP(andrei): This will go away with the Executor.
+func (e *Executor) GetReCache() *tree.RegexpCache {
+	return e.reCache
+}
+
 // golangFillQueryArguments populates the placeholder map with
 // types and values from an array of Go values.
 // TODO: This does not support arguments of the SQL 'Date' type, as there is not
@@ -2496,7 +2536,9 @@ func decimalToHLC(d *apd.Decimal) (hlc.Timestamp, error) {
 //
 // max is a lower bound on what the transaction's timestamp will be.
 // Used to check that the user didn't specify a timestamp in the future.
-func isAsOf(session *Session, stmt tree.Statement, max hlc.Timestamp) (*hlc.Timestamp, error) {
+func isAsOf(
+	stmt tree.Statement, evalCtx *tree.EvalContext, max hlc.Timestamp,
+) (*hlc.Timestamp, error) {
 	var asOf tree.AsOfClause
 	switch s := stmt.(type) {
 	case *tree.Select:
@@ -2517,7 +2559,7 @@ func isAsOf(session *Session, stmt tree.Statement, max hlc.Timestamp) (*hlc.Time
 
 		asOf = sc.From.AsOf
 	case *tree.ShowTrace:
-		return isAsOf(session, s.Statement, max)
+		return isAsOf(s.Statement, evalCtx, max)
 	case *tree.Scrub:
 		if s.AsOf.Expr == nil {
 			return nil, nil
@@ -2527,8 +2569,7 @@ func isAsOf(session *Session, stmt tree.Statement, max hlc.Timestamp) (*hlc.Time
 		return nil, nil
 	}
 
-	evalCtx := session.evalCtx()
-	ts, err := EvalAsOfTimestamp(&evalCtx, asOf, max)
+	ts, err := EvalAsOfTimestamp(evalCtx, asOf, max)
 	return &ts, err
 }
 

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -669,7 +669,8 @@ func (c *v3Conn) handleParse(buf *readBuffer) error {
 		sqlTypeHints[strconv.Itoa(i+1)] = v
 	}
 	// Create the new PreparedStatement in the connection's Session.
-	stmt, err := c.session.PreparedStatements.NewFromString(c.executor, name, query, sqlTypeHints)
+	stmt, err := c.session.PreparedStatements.NewFromString(
+		name, query, sqlTypeHints, c.executor.GetDatabaseCache(), c.executor.GetExecCfg(), c.executor.GetReCache())
 	if err != nil {
 		return c.sendError(err)
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
@@ -29,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -171,7 +173,8 @@ func makeInternalPlanner(
 		-1, noteworthyInternalMemoryUsageBytes/5)
 	s.TxnState.mon.Start(ctx, &s.mon, mon.BoundAccount{})
 
-	p := s.newPlanner(nil, txn)
+	// TODO(andrei): figure out how to pass proper arguments to this planner.
+	p := newPlanner(s, txn, uuid.UUID{}, roachpb.NodeID(0), nil /* reCache */)
 
 	if txn != nil {
 		if txn.Proto().OrigTimestamp == (hlc.Timestamp{}) {

--- a/pkg/sql/prepare.go
+++ b/pkg/sql/prepare.go
@@ -24,7 +24,13 @@ import (
 
 // PrepareStmt implements the PREPARE statement.
 // See https://www.postgresql.org/docs/current/static/sql-prepare.html for details.
-func (e *Executor) PrepareStmt(session *Session, s *tree.Prepare) error {
+func PrepareStmt(
+	session *Session,
+	s *tree.Prepare,
+	dbCache *databaseCache,
+	execCfg *ExecutorConfig,
+	reCache *tree.RegexpCache,
+) error {
 	name := s.Name.String()
 	if session.PreparedStatements.Exists(name) {
 		return pgerror.NewErrorf(pgerror.CodeDuplicatePreparedStatementError,
@@ -35,7 +41,8 @@ func (e *Executor) PrepareStmt(session *Session, s *tree.Prepare) error {
 		typeHints[strconv.Itoa(i+1)] = coltypes.CastTargetToDatumType(t)
 	}
 	_, err := session.PreparedStatements.New(
-		e, name, Statement{AST: s.Statement}, s.Statement.String(), typeHints,
+		name, Statement{AST: s.Statement}, s.Statement.String(), typeHints,
+		dbCache, execCfg, reCache,
 	)
 	return err
 }

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -91,7 +91,11 @@ func (ps PreparedStatements) Exists(name string) bool {
 //
 // ps.session.Ctx() is used as the logging context for the prepare operation.
 func (ps PreparedStatements) NewFromString(
-	e *Executor, name, query string, placeholderHints tree.PlaceholderTypes,
+	name, query string,
+	placeholderHints tree.PlaceholderTypes,
+	dbCache DBCacheHolder,
+	execCfg *ExecutorConfig,
+	reCache *tree.RegexpCache,
 ) (*PreparedStatement, error) {
 	sessionEventf(ps.session, "parsing: %s", query)
 
@@ -110,7 +114,7 @@ func (ps PreparedStatements) NewFromString(
 		return nil, errWrongNumberOfPreparedStatements(len(stmts))
 	}
 
-	return ps.New(e, name, st, query, placeholderHints)
+	return ps.New(name, st, query, placeholderHints, dbCache.dbCache, execCfg, reCache)
 }
 
 // New creates a new PreparedStatement with the provided name and corresponding
@@ -119,10 +123,16 @@ func (ps PreparedStatements) NewFromString(
 //
 // ps.session.Ctx() is used as the logging context for the prepare operation.
 func (ps PreparedStatements) New(
-	e *Executor, name string, stmt Statement, stmtStr string, placeholderHints tree.PlaceholderTypes,
+	name string,
+	stmt Statement,
+	stmtStr string,
+	placeholderHints tree.PlaceholderTypes,
+	dbCache *databaseCache,
+	execCfg *ExecutorConfig,
+	reCache *tree.RegexpCache,
 ) (*PreparedStatement, error) {
 	// Prepare the query. This completes the typing of placeholders.
-	pStmt, err := e.Prepare(stmt, stmtStr, ps.session, placeholderHints)
+	pStmt, err := Prepare(stmt, stmtStr, ps.session, placeholderHints, dbCache, execCfg, reCache)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Various code around building prepared statements was tangled with the
Executor. I want to reuse this code in the context of the up and coming
connExecutor.
This code is also tangled with a Session, which I need to figure
something about because the plan was for the connExecutor to replace
Session; unfortunately divorcing it from that is much more difficult
because a planner holds a reference to a Session and uses it everywhere.
But one step at a time; this patch will at least allow me to pass a nil
session and compile.

Release note: none