### PR TITLE
cmd/docgen: allow numbers in expr names

### DIFF
--- a/pkg/cmd/docgen/extract/extract.go
+++ b/pkg/cmd/docgen/extract/extract.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	reIsExpr  = regexp.MustCompile("^[a-z_]+$")
+	reIsExpr  = regexp.MustCompile("^[a-z_0-9]+$")
 	reIsIdent = regexp.MustCompile("^[A-Z_0-9]+$")
 	rrLock    syncutil.Mutex
 )


### PR DESCRIPTION
The recent iconst64 requires this.

Release note: None

Fixes cockroachdb/docs#2273