### PR TITLE
storage: small node liveness improvements

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -574,8 +574,7 @@ func (nl *NodeLiveness) IncrementEpoch(ctx context.Context, liveness *Liveness) 
 		return err
 	}
 
-	log.VEventf(ctx, 1, "incremented node %d liveness epoch to %d",
-		newLiveness.NodeID, newLiveness.Epoch)
+	log.Infof(ctx, "incremented n%d liveness epoch to %d", newLiveness.NodeID, newLiveness.Epoch)
 	nl.maybeUpdate(newLiveness)
 	nl.metrics.EpochIncrements.Inc(1)
 	return nil

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -338,7 +338,9 @@ func (nl *NodeLiveness) StartHeartbeat(
 		for {
 			if !nl.pauseHeartbeat.Load().(bool) {
 				func() {
-					ctx, cancel := context.WithTimeout(context.Background(), nl.heartbeatInterval/2)
+					// Give the context a timeout approximately as long as the time we
+					// have left before our liveness entry expires.
+					ctx, cancel := context.WithTimeout(context.Background(), nl.livenessThreshold-nl.heartbeatInterval)
 					ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "heartbeat")
 					defer cancel()
 					defer sp.Finish()


### PR DESCRIPTION
Both of these changes have been tested in large distributed IMPORT jobs. Neither was enough to fix things with the disk acting up as it used to, but both are improvements.

**storage: Lengthen node liveness heartbeat timeout**

In logs from an IMPORT job that got derailed by liveness issues, there
were a lot of 1-2 second heartbeats that appear to have slowly increased
to being 2+ seconds and hitting the context timeout, causing a new
heartbeat request to have to start which are likely to not finish before
the liveness record expires.

I don't know why we'd want these heartbeats to time out before the
liveness record expires. I'm not sure what we gain by using
`heartbeatInterval/2` instead of just `heartbeatInterval`. cc @nvanbenschoten 

**storage: Don't increment a node's epoch unless new leaseholder is live**

Pulled out of #19436