### PR TITLE
1.1: sql: Fix return type signature of array_positions built-in

### DIFF
--- a/pkg/sql/parser/builtins.go
+++ b/pkg/sql/parser/builtins.go
@@ -1726,7 +1726,7 @@ CockroachDB supports the following flags:
 	"array_positions": arrayBuiltin(func(typ Type) Builtin {
 		return Builtin{
 			Types:        ArgTypes{{"array", TArray{typ}}, {"elem", typ}},
-			ReturnType:   fixedReturnType(TArray{typ}),
+			ReturnType:   fixedReturnType(TArray{TypeInt}),
 			category:     categoryArray,
 			nullableArgs: true,
 			fn: func(ctx *EvalContext, args Datums) (Datum, error) {


### PR DESCRIPTION
This error was fixed in #20524, and just the fix is
being backported to 1.1.

The following type signature was changed:

    array_positions(<TYPE>[], <TYPE>) now returns a INT[] (previously
        <TYPE>[])

Due to the incorrect type signature returned, a query that contains this
function would cause a panic in distSQL, as follows:

    panic: invalid datum type given: int[], expected string[]

    goroutine 336 [running]:
    github.com/cockroachdb/cockroach/pkg/sql/sqlbase.DatumToEncDatum(0xf, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc4202ff0e8, 0x6673720, 0xc420428450, ...)
      /Users/joey/.go/src/github.com/cockroachdb/cockroach/pkg/sql/sqlbase/encoded_datum.go:122 +0x292
    github.com/cockroachdb/cockroach/pkg/sql/distsqlrun.(*ProcOutputHelper).EmitRow(0xc420c04000, 0x6665820, 0xc42012e120, 0xc42106a9a0, 0x3, 0x3, 0x3, 0x0, 0x0)
      /Users/joey/.go/src/github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/processors.go:286 +0xa79
    github.com/cockroachdb/cockroach/pkg/sql/distsqlrun.(*tableReader).Run(0xc420c04000, 0x6665820, 0xc42012e120, 0xc420669398)
      /Users/joey/.go/src/github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/tablereader.go:214 +0x412
    created by github.com/cockroachdb/cockroach/pkg/sql/distsqlrun.(*Flow).Start
      /Users/joey/.go/src/github.com/cockroachdb/cockroach/pkg/sql/distsqlrun/flow.go:394 +0x3d7

Release note (bug fix): Fixed the return type signature of the
array_positions built-in funtion. This caused a panic if the
function was used in query executing in the distributed execution
engine.