### PR TITLE
1.1 fix: sql: fix LIKE with '_...%', '%..._' and '\' escaped character patterns

### DIFF
--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1785,7 +1785,12 @@ func evalArrayCmp(
 
 func matchLike(ctx *EvalContext, left, right Datum, caseInsensitive bool) (Datum, error) {
 	pattern := string(MustBeDString(right))
-	like := optimizedLikeFunc(pattern, caseInsensitive)
+	like, err := optimizedLikeFunc(pattern, caseInsensitive)
+	if err != nil {
+		return DBoolFalse, pgerror.NewErrorf(
+			pgerror.CodeInvalidRegularExpressionError, "LIKE regexp compilation failed: %v", err)
+	}
+
 	if like == nil {
 		key := likeKey{s: pattern, caseInsensitive: caseInsensitive}
 		re, err := ctx.ReCache.GetRegexp(key)
@@ -3169,28 +3174,48 @@ func foldComparisonExpr(
 // Simplifies LIKE/ILIKE expressions that do not need full regular expressions to
 // evaluate the condition. For example, when the expression is just checking to see
 // if a string starts with a given pattern.
-func optimizedLikeFunc(pattern string, caseInsensitive bool) func(string) bool {
+func optimizedLikeFunc(pattern string, caseInsensitive bool) (func(string) bool, error) {
 	switch len(pattern) {
 	case 0:
 		return func(s string) bool {
 			return s == ""
-		}
+		}, nil
 	case 1:
 		switch pattern[0] {
 		case '%':
 			return func(s string) bool {
 				return true
-			}
+			}, nil
 		case '_':
 			return func(s string) bool {
 				return len(s) == 1
-			}
+			}, nil
 		}
 	default:
 		if !strings.ContainsAny(pattern[1:len(pattern)-1], "_%") {
 			// Cases like "something\%" are not optimized, but this does not affect correctness.
 			anyEnd := pattern[len(pattern)-1] == '%' && pattern[len(pattern)-2] != '\\'
 			anyStart := pattern[0] == '%'
+
+			// singleAnyEnd and anyEnd are mutually exclusive
+			// (similarly with Start).
+			singleAnyEnd := pattern[len(pattern)-1] == '_' && pattern[len(pattern)-2] != '\\'
+			singleAnyStart := pattern[0] == '_'
+
+			// Cherry-pick 1.1: re-route this edge case to the
+			// non-optimized pathway. See discussion in #20600.
+			if singleAnyEnd || singleAnyStart {
+				return nil, nil
+			}
+
+			// Since we've already checked for escaped characters
+			// at the end, we can un-escape every character.
+			// This is required since we do direct string
+			// comparison.
+			var err error
+			if pattern, err = unescapePattern(pattern, `\`); err != nil {
+				return nil, err
+			}
 			switch {
 			case anyEnd && anyStart:
 				return func(s string) bool {
@@ -3199,7 +3224,8 @@ func optimizedLikeFunc(pattern string, caseInsensitive bool) func(string) bool {
 						s, substr = strings.ToUpper(s), strings.ToUpper(substr)
 					}
 					return strings.Contains(s, substr)
-				}
+				}, nil
+
 			case anyEnd:
 				return func(s string) bool {
 					prefix := pattern[:len(pattern)-1]
@@ -3207,7 +3233,8 @@ func optimizedLikeFunc(pattern string, caseInsensitive bool) func(string) bool {
 						s, prefix = strings.ToUpper(s), strings.ToUpper(prefix)
 					}
 					return strings.HasPrefix(s, prefix)
-				}
+				}, nil
+
 			case anyStart:
 				return func(s string) bool {
 					suffix := pattern[1:]
@@ -3215,11 +3242,11 @@ func optimizedLikeFunc(pattern string, caseInsensitive bool) func(string) bool {
 						s, suffix = strings.ToUpper(s), strings.ToUpper(suffix)
 					}
 					return strings.HasSuffix(s, suffix)
-				}
+				}, nil
 			}
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 type likeKey struct {
@@ -3227,11 +3254,156 @@ type likeKey struct {
 	caseInsensitive bool
 }
 
+// unescapePattern unescapes a pattern for a given escape token.
+// It handles escaped escape tokens properly by maintaining them as the escape
+// token in the return string.
+// For example, suppose we have escape token `\` (e.g. `B` is escaped in
+// `A\BC` and `\` is escaped in `A\\C`).
+// We need to convert
+//    `\` --> ``
+//    `\\` --> `\`
+// We cannot simply use strings.Replace for each conversion since the first
+// conversion will incorrectly replace our escaped escape token `\\` with ``.
+// Another example is if our escape token is `\\` (e.g. after
+// regexp.QuoteMeta).
+// We need to convert
+//    `\\` --> ``
+//    `\\\\` --> `\\`
+func unescapePattern(pattern, escapeToken string) (string, error) {
+	escapedEscapeToken := escapeToken + escapeToken
+
+	// We need to subtract the escaped escape tokens to avoid double
+	// counting.
+	nEscapes := strings.Count(pattern, escapeToken) - strings.Count(pattern, escapedEscapeToken)
+	if nEscapes == 0 {
+		return pattern, nil
+	}
+
+	// Allocate buffer for final un-escaped pattern.
+	ret := make([]byte, len(pattern)-nEscapes*len(escapeToken))
+	retWidth := 0
+	for i := 0; i < nEscapes; i++ {
+		nextIdx := strings.Index(pattern, escapeToken)
+		if nextIdx == len(pattern)-len(escapeToken) {
+			return "", errors.Errorf(`pattern ends with escape character`)
+		}
+
+		retWidth += copy(ret[retWidth:], pattern[:nextIdx])
+
+		if nextIdx < len(pattern)-len(escapedEscapeToken) && pattern[nextIdx:nextIdx+len(escapedEscapeToken)] == escapedEscapeToken {
+			// We have an escaped escape token.
+			// We want to keep it as the original escape token in
+			// the return string.
+			retWidth += copy(ret[retWidth:], escapeToken)
+			pattern = pattern[nextIdx+len(escapedEscapeToken):]
+			continue
+		}
+
+		// Skip over the escape character we removed.
+		pattern = pattern[nextIdx+len(escapeToken):]
+	}
+
+	retWidth += copy(ret[retWidth:], pattern)
+	return string(ret[0:retWidth]), nil
+}
+
+// replaceUnescaped replaces all instances of oldStr that are not escaped (read:
+// preceded) with the specified unescape token with newStr.
+// For example, with an escape token of `\\`
+//    replaceUnescaped("TE\\__ST", "_", ".", `\\`) --> "TE\\_.ST"
+//    replaceUnescaped("TE\\%%ST", "%", ".*", `\\`) --> "TE\\%.*ST"
+// If the preceding escape token is escaped, then oldStr will be replaced.
+// For example
+//    replaceUnescaped("TE\\\\_ST", "_", ".", `\\`) --> "TE\\\\.ST"
+func replaceUnescaped(s, oldStr, newStr string, escapeToken string) string {
+	// We count the number of occurrences of 'oldStr'.
+	// This however can be an overestimate since the oldStr token could be
+	// escaped.  e.g. `\\_`.
+	nOld := strings.Count(s, oldStr)
+	if nOld == 0 {
+		return s
+	}
+
+	// Allocate buffer for final string.
+	// This can be an overestimate since some of the oldStr tokens may
+	// be escaped.
+	// This is fine since we keep track of the running number of bytes
+	// actually copied.
+	// It's rather difficult to count the exact number of unescaped
+	// tokens without manually iterating through the entire string and
+	// keeping track of escaped escape tokens.
+	retLen := len(s)
+	// If len(newStr) - len(oldStr) < 0, then this can under-allocate which
+	// will not behave correctly with copy.
+	if addnBytes := nOld * (len(newStr) - len(oldStr)); addnBytes > 0 {
+		retLen += addnBytes
+	}
+	ret := make([]byte, retLen)
+	retWidth := 0
+	start := 0
+OldLoop:
+	for i := 0; i < nOld; i++ {
+		nextIdx := start + strings.Index(s[start:], oldStr)
+
+		escaped := false
+		for {
+			// We need to look behind to check if the escape token
+			// is really an escape token.
+			// E.g. if our specified escape token is `\\` and oldStr
+			// is `_`, then
+			//    `\\_` --> escaped
+			//    `\\\\_` --> not escaped
+			//    `\\\\\\_` --> escaped
+			curIdx := nextIdx
+			lookbehindIdx := curIdx - len(escapeToken)
+			for lookbehindIdx >= 0 && s[lookbehindIdx:curIdx] == escapeToken {
+				escaped = !escaped
+				curIdx = lookbehindIdx
+				lookbehindIdx = curIdx - len(escapeToken)
+			}
+
+			// The token was not be escaped. Proceed.
+			if !escaped {
+				break
+			}
+
+			// Token was escaped. Copy eveything over and continue.
+			retWidth += copy(ret[retWidth:], s[start:nextIdx+len(oldStr)])
+			start = nextIdx + len(oldStr)
+
+			// Continue with next oldStr token.
+			continue OldLoop
+		}
+
+		// Token was not escaped so we replace it with newStr.
+		// Two copies is more efficient than concatenating the slices.
+		retWidth += copy(ret[retWidth:], s[start:nextIdx])
+		retWidth += copy(ret[retWidth:], newStr)
+		start = nextIdx + len(oldStr)
+	}
+
+	retWidth += copy(ret[retWidth:], s[start:])
+	return string(ret[0:retWidth])
+}
+
+// Pattern implements the RegexpCacheKey interface.
 func (k likeKey) pattern() (string, error) {
+	// QuoteMeta escapes `\` to `\\`.
 	pattern := regexp.QuoteMeta(k.s)
+
 	// Replace LIKE/ILIKE specific wildcards with standard wildcards
-	pattern = strings.Replace(pattern, "%", ".*", -1)
-	pattern = strings.Replace(pattern, "_", ".", -1)
+	pattern = replaceUnescaped(pattern, `%`, `.*`, `\\`)
+	pattern = replaceUnescaped(pattern, `_`, `.`, `\\`)
+
+	// After QuoteMeta, our original escape character `\` has become
+	// `\\`.
+	// We need to unescape escaped escape tokens `\\` (now `\\\\`) and
+	// other escaped characters `\A` (now `\\A`).
+	var err error
+	if pattern, err = unescapePattern(pattern, `\\`); err != nil {
+		return "", err
+	}
+
 	return anchorPattern(pattern, k.caseInsensitive), nil
 }
 

--- a/pkg/sql/parser/eval_internal_test.go
+++ b/pkg/sql/parser/eval_internal_test.go
@@ -1,0 +1,121 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package parser
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUnescapePattern(t *testing.T) {
+	testCases := []struct {
+		pattern     string
+		expected    string
+		escapeToken string
+	}{
+		{``, ``, `\`},
+		{``, ``, `\\`},
+		{`ABC\\`, `ABC\`, `\`},
+		{`ABC\\\\`, `ABC\\`, `\\`},
+		{`A\\\\BC`, `A\\BC`, `\`},
+		{`A\\\\\\\\C`, `A\\\\C`, `\\`},
+		{`A\\B\\C`, `A\B\C`, `\`},
+		{`A\\\\B\\\\C`, `A\\B\\C`, `\\`},
+		{`ABC`, `ABC`, `\`},
+		{`ABC`, `ABC`, `\\`},
+		{`A\BC`, `ABC`, `\`},
+		{`A\BC`, `A\BC`, `\\`},
+		{`A\\\BC`, `A\BC`, `\`},
+		{`A\\\\\\BC`, `A\\BC`, `\\`},
+		{`\漢\字`, `漢字`, `\`},
+		{`\ \\A\B`, ` \AB`, `\`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s-->%s Escape=%s", tc.pattern, tc.expected, tc.escapeToken), func(t *testing.T) {
+			actual, err := unescapePattern(tc.pattern, tc.escapeToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.expected != actual {
+				t.Errorf("expected unescaped pattern: %s, got %s\n", tc.expected, actual)
+			}
+		})
+	}
+}
+
+func TestUnescapePatternError(t *testing.T) {
+	testCases := []struct {
+		pattern     string
+		escapeToken string
+	}{
+		{`\`, `\`},
+		{`\\`, `\\`},
+		{`ABC\`, `\`},
+		{`ABC\\`, `\\`},
+		{`ABC\\\`, `\`},
+		{`ABC\\\\\\`, `\\`},
+	}
+
+	const errorMessage = "pattern ends with escape character"
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Pattern=%s Escape=%s", tc.pattern, tc.escapeToken), func(t *testing.T) {
+			actual, err := unescapePattern(tc.pattern, tc.escapeToken)
+			if err == nil {
+				t.Fatalf("error not raised. expected error message: %s\ngot unescaped pattern: %s\n", errorMessage, actual)
+			}
+
+			if err.Error() != errorMessage {
+				t.Errorf("expected error message: %s\ngot error message: %s\n", errorMessage, err.Error())
+			}
+		})
+	}
+}
+
+func TestReplaceUnescaped(t *testing.T) {
+	testCases := []struct {
+		pattern     string
+		old         string
+		new         string
+		escapeToken string
+		expected    string
+	}{
+		{``, `B`, `DEF`, `\`, ``},
+		{`ABC`, `B`, `DEF`, `\`, `ADEFC`},
+		{`A\BC`, `B`, `DEF`, `\`, `A\BC`},
+		{`A\\BC`, `B`, `DEF`, `\`, `A\\DEFC`},
+		{`\\\\BC`, `B`, `DEF`, `\`, `\\\\DEFC`},
+		{`\\\\\BC`, `B`, `DEF`, `\`, `\\\\\BC`},
+		{`A\\BC`, `B`, `DEF`, `\\`, `A\\BC`},
+		{`A\\\BC`, `B`, `DEF`, `\\`, `A\\\BC`},
+		{`ACE`, `B`, `DEF`, `\`, `ACE`},
+		{`B\\B\\\B`, `B`, `DEF`, `\`, `DEF\\DEF\\\B`},
+		{`漢字\\漢\字\\\漢`, `漢`, `字`, `\`, `字字\\字\字\\\漢`},
+		{`ABCABC`, `ABC`, `D`, `\`, `DD`},
+		{`ABC\ABCABC`, `ABC`, `D`, `\`, `D\ABCD`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s-->%s Escape=%s", tc.pattern, tc.expected, tc.escapeToken), func(t *testing.T) {
+			actual := replaceUnescaped(tc.pattern, tc.old, tc.new, tc.escapeToken)
+
+			if tc.expected != actual {
+				t.Errorf("expected replaced pattern: %s, got %s\n", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/sql/parser/eval_test.go
+++ b/pkg/sql/parser/eval_test.go
@@ -274,6 +274,46 @@ func TestEval(t *testing.T) {
 		// LIKE and NOT LIKE
 		{`'TEST' LIKE 'TEST'`, `true`},
 		{`'TEST' LIKE 'test'`, `false`},
+		{`'TEST' LIKE 'TESTER'`, `false`},
+		{`'TEST' LIKE ''`, `false`},
+
+		{`'' LIKE ''`, `true`},
+		// Regex special characters.
+		{`'[' LIKE '['`, `true`},
+		{`'.' LIKE '.'`, `true`},
+		{`'.A' LIKE '._'`, `true`},
+		{`'AB' LIKE '._'`, `false`},
+		{`'.*B' LIKE '.*B'`, `true`},
+		{`'AB' LIKE '.*B'`, `false`},
+
+		// Escaped character cases.
+		{`'[' LIKE '\['`, `true`},
+		{`'.' LIKE '\.'`, `true`},
+		{`'\.*' LIKE '\\.*'`, `true`},
+		{`'\.*' LIKE '\\.\*'`, `true`},
+		{`'\.*' LIKE '\\\.\*'`, `true`},
+		{`'\\.' LIKE '\\.'`, `false`},
+		{`'\\.' LIKE '\\\\.'`, `true`},
+		{`'\\.' LIKE '\\\\\.'`, `true`},
+		{`'\A' LIKE '\\A'`, `true`},
+		{`'A' LIKE '\\A'`, `false`},
+		{`'_' LIKE '\_'`, `true`},
+		{`'\' LIKE '\\'`, `true`},
+		{`'\\' LIKE '\\'`, `false`},
+		{`'\\' LIKE '\\_'`, `true`},
+		{`'\\' LIKE '_\\'`, `true`},
+		{`'A\' LIKE '_\\'`, `true`},
+		{`'%' LIKE '\%'`, `true`},
+		{`'ABC' LIKE '\AB%'`, `true`},
+		{`'ABC' LIKE '\AB_'`, `true`},
+		{`'ABC' LIKE '%B\C'`, `true`},
+		{`'ABC' LIKE '_B\C'`, `true`},
+		{`'TEST' LIKE 'TE\ST'`, `true`},
+		{`'_漢' LIKE '\__'`, `true`},
+		{`'漢漢' LIKE '漢\漢'`, `true`},
+		{`'_漢' LIKE '\_\漢'`, `true`},
+
+		// optimizedLikeFunc expressions.
 		{`'TEST' LIKE 'TE%'`, `true`},
 		{`'TEST' LIKE '%E%'`, `true`},
 		{`'TEST' LIKE '%e%'`, `false`},
@@ -282,11 +322,32 @@ func TestEval(t *testing.T) {
 		{`'TEST' LIKE 'TE_'`, `false`},
 		{`'TEST' LIKE '%'`, `true`},
 		{`'TEST' LIKE '%R'`, `false`},
-		{`'TEST' LIKE 'TESTER'`, `false`},
-		{`'TEST' LIKE ''`, `false`},
-		{`'' LIKE ''`, `true`},
+		{`'T' LIKE '\_'`, `false`},
+		{`'T' LIKE '\%'`, `false`},
+		{`'TE_T' LIKE 'TE\_T'`, `true`},
+		{`'TE\AT' LIKE 'TE\_T'`, `false`},
+		{`'TES%T' LIKE 'TES\%T'`, `true`},
+		{`'TES\AT' LIKE 'TES\%T'`, `false`},
 		{`'T' LIKE '_'`, `true`},
 		{`'TE' LIKE '_'`, `false`},
+		{`'TE' LIKE '_%'`, `true`},
+		{`'T' LIKE '_%'`, `true`},
+		{`'' LIKE '_%'`, `false`},
+		{`'TE' LIKE '%_'`, `true`},
+		{`'' LIKE '%_'`, `false`},
+		{`'T' LIKE '%_'`, `true`},
+		{`'TEST' LIKE '_ES_'`, `true`},
+		{`'' LIKE '__'`, `false`},
+		{`'A' LIKE 'T_'`, `false`},
+		{`'A' LIKE '_T'`, `false`},
+		{`'TEST' LIKE '_E%'`, `true`},
+		{`'TEST' LIKE '_E\%'`, `false`},
+		{`'TES_' LIKE '%S\_'`, `true`},
+		{`'TES%' LIKE '%S\%'`, `true`},
+		{`'TES_' LIKE '_ES\_'`, `true`},
+		{`'TES%' LIKE '_ES\%'`, `true`},
+		{`'TEST' LIKE '%S_'`, `true`},
+		{`'TEST' LIKE '%S\_'`, `false`},
 		{`'TEST' NOT LIKE '%E%'`, `false`},
 		{`'TEST' NOT LIKE 'TES_'`, `false`},
 		{`'TEST' NOT LIKE 'TeS_'`, `true`},
@@ -864,27 +925,29 @@ func TestEval(t *testing.T) {
 	defer ctx.Mon.Stop(context.Background())
 	defer ctx.ActiveMemAcc.Close(context.Background())
 	for _, d := range testData {
-		expr, err := ParseExpr(d.expr)
-		if err != nil {
-			t.Fatalf("%s: %v", d.expr, err)
-		}
-		// expr.TypeCheck to avoid constant folding.
-		typedExpr, err := expr.TypeCheck(nil, TypeAny)
-		if err != nil {
-			t.Fatalf("%s: %v", d.expr, err)
-		}
-		// We have to manually close this account because we're doing the evaluations
-		// ourselves.
-		if typedExpr, err = ctx.NormalizeExpr(typedExpr); err != nil {
-			t.Fatalf("%s: %v", d.expr, err)
-		}
-		r, err := typedExpr.Eval(ctx)
-		if err != nil {
-			t.Fatalf("%s: %v", d.expr, err)
-		}
-		if s := r.String(); d.expected != s {
-			t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
-		}
+		t.Run(d.expr, func(t *testing.T) {
+			expr, err := ParseExpr(d.expr)
+			if err != nil {
+				t.Fatalf("%s: %v", d.expr, err)
+			}
+			// expr.TypeCheck to avoid constant folding.
+			typedExpr, err := expr.TypeCheck(nil, TypeAny)
+			if err != nil {
+				t.Fatalf("%s: %v", d.expr, err)
+			}
+			// We have to manually close this account because we're doing the evaluations
+			// ourselves.
+			if typedExpr, err = ctx.NormalizeExpr(typedExpr); err != nil {
+				t.Fatalf("%s: %v", d.expr, err)
+			}
+			r, err := typedExpr.Eval(ctx)
+			if err != nil {
+				t.Fatalf("%s: %v", d.expr, err)
+			}
+			if s := r.String(); d.expected != s {
+				t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This cherry-pick (with modifications) fixes LIKE comparison operators
where we did not handle single wildcards ('_') properly in the optimized
LIKE pattern pathway whenever we had a wildcard ('%') at the beginning or end.

It also fixes how we handle `\` escaped characters with LIKE patterns.
This fix should align Cockroach's LIKE pattern matching with Postgres'.

The original PR that fixed this in 2.0 is #20600.

Release note: fixed an issue where wildcards ('_', '%') and '\' escaped
characters in LIKE patterns were not handled properly.