### PR TITLE
sql: support printing unicode characters in arrays

### DIFF
--- a/pkg/sql/lex/encode.go
+++ b/pkg/sql/lex/encode.go
@@ -25,6 +25,7 @@ package lex
 
 import (
 	"bytes"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/util/stringencoding"
@@ -124,9 +125,9 @@ func EncodeSQLStringInsideArray(buf *bytes.Buffer, in string) {
 	// Loop through each unicode code point.
 	for i, r := range in {
 		ch := byte(r)
-		if r >= 0x20 && r < 0x7F && !stringencoding.NeedEscape(ch) && ch != '"' {
+		if unicode.IsPrint(r) && !stringencoding.NeedEscape(ch) && ch != '"' {
 			// Character is printable doesn't need escaping - just print it out.
-			buf.WriteByte(ch)
+			buf.WriteRune(r)
 		} else {
 			stringencoding.EncodeEscapedChar(buf, in, r, ch, i, '"')
 		}

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -56,6 +56,13 @@ SELECT NULL::INT[]
 ----
 NULL
 
+# #19821
+
+query T
+SELECT ARRAY['one', 'two', 'fünf']
+----
+{"one","two","fünf"}
+
 query T
 SELECT ARRAY[e'\n', e'g\x10h']
 ----


### PR DESCRIPTION
Fixes #19821.

Release note: Fixed an issue with the formatting of unicode values in
string arrays.