### PR TITLE
storage/idalloc: move idAllocator to idalloc.Allocator

### DIFF
--- a/pkg/storage/idalloc/helpers_test.go
+++ b/pkg/storage/idalloc/helpers_test.go
@@ -1,0 +1,27 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package idalloc
+
+import "github.com/cockroachdb/cockroach/pkg/roachpb"
+
+// SetIDKey sets the key which the allocator increments.
+func (ia *Allocator) SetIDKey(idKey roachpb.Key) {
+	ia.idKey.Store(idKey)
+}
+
+// IDs returns the channel that the allocator uses to buffer available ids.
+func (ia *Allocator) IDs() <-chan uint32 {
+	return ia.ids
+}

--- a/pkg/storage/idalloc/main_test.go
+++ b/pkg/storage/idalloc/main_test.go
@@ -1,0 +1,26 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package idalloc_test
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+)
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
+
+func init() {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/compactor"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/idalloc"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
@@ -356,7 +357,7 @@ type Store struct {
 	compactor          *compactor.Compactor        // Schedules compaction of the engine
 	tsCache            tscache.Cache               // Most recent timestamps for keys / key ranges
 	allocator          Allocator                   // Makes allocation decisions
-	rangeIDAlloc       *idAllocator                // Range ID allocator
+	rangeIDAlloc       *idalloc.Allocator          // Range ID allocator
 	gcQueue            *gcQueue                    // Garbage collection queue
 	splitQueue         *splitQueue                 // Range splitting queue
 	replicateQueue     *replicateQueue             // Replication queue
@@ -1092,8 +1093,8 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 	}
 
 	// Create ID allocators.
-	idAlloc, err := newIDAllocator(
-		s.cfg.AmbientCtx, keys.RangeIDGenerator, s.db, 2 /* min ID */, rangeIDAllocCount, s.stopper,
+	idAlloc, err := idalloc.NewAllocator(
+		s.cfg.AmbientCtx, keys.RangeIDGenerator, s.db, 2 /* minID */, rangeIDAllocCount, s.stopper,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
In the spirit of https://github.com/cockroachdb/cockroach/issues/18779.

idAllocator is used to allocate new Range IDs. This change moves the type
to a new `idalloc` package.

The only changes to `id_alloc.go` are renaming `idAllocator` to `Allocator`
and exporting the constructor. The test had to change a bit to break the
dependency on the `storage` package. We now use a `LocalTestCluster`
instead of a `Store` directly.