### PR TITLE
ui: don't load font files from fonts.googleapis.com

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/sim.css
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/sim.css
@@ -6,8 +6,6 @@
  *
  *     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
  */
-@import
-url('https://fonts.googleapis.com/css?family=Lato:400,700');
 
 .map-background {
     width: 100%;


### PR DESCRIPTION
Fixes #20425.

Release note: None