### PR TITLE
sql: Remove the reference to queryMeta from Statement

### DIFF
--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -168,11 +168,7 @@ type queryMeta struct {
 	// Current phase of execution of query.
 	phase queryPhase
 
-	// Context associated with this query's transaction.
-	ctx context.Context
-
 	// Cancellation function for the context associated with this query's transaction.
-	// Set to session.txnState.cancel in executor.
 	ctxCancel context.CancelFunc
 }
 

--- a/pkg/sql/statement.go
+++ b/pkg/sql/statement.go
@@ -28,7 +28,6 @@ type Statement struct {
 	ExpectedTypes sqlbase.ResultColumns
 	AnonymizedStr string
 	queryID       uint128.Uint128
-	queryMeta     *queryMeta
 }
 
 func (s Statement) String() string {


### PR DESCRIPTION
queryMeta is a runtime data structure. Statement is basically an AST.
The queryMeta did not belong hanging there, and it also wasn't needed.

Also remove queryMeta.Ctx. It was not needed.

Release note: None