### PR TITLE
ui: finish short-term enhancements to cluster overview

### DIFF
--- a/pkg/ui/src/hacks/require.d.ts
+++ b/pkg/ui/src/hacks/require.d.ts
@@ -1,5 +1,0 @@
-declare var require: {
-    <T>(path: string): T;
-    (paths: string[], callback: (...modules: any[]) => void): void;
-    ensure: (paths: string[], callback: (require: <T>(path: string) => T) => void) => void;
-};

--- a/pkg/ui/src/interfaces/assets.d.ts
+++ b/pkg/ui/src/interfaces/assets.d.ts
@@ -1,3 +1,8 @@
+declare module "assets/*" {
+    var _: string;
+    export default _;
+}
+
 declare module "!!raw-loader!*" {
     var _: string;
     export default _;

--- a/pkg/ui/src/views/cluster/components/visualization/index.tsx
+++ b/pkg/ui/src/views/cluster/components/visualization/index.tsx
@@ -1,12 +1,10 @@
-// tslint:disable-next-line:no-var-requires
-const spinner = require<string>("assets/spinner.gif");
-
 import React from "react";
 import classNames from "classnames";
 
-import "./visualizations.styl";
-
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
+
+import "./visualizations.styl";
+import spinner from "assets/spinner.gif";
 
 interface VisualizationProps {
   title: string;

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -4,13 +4,16 @@
 .cluster-overview
   /* TODO(couchand): Update the layout styles to get rid of this hack. */
   margin-top -1 * $page-padding-top
-  border-bottom 1px solid $table-border-color
 
   .cluster-summary
     background-color white
     padding-top $page-padding-top
     padding-bottom $page-padding-top
     padding-left 20px
+    margin-left 24px
+    margin-right 24px
+    border 1px solid $table-border-color
+
     color gray
     display grid
     align-items end

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -6,10 +6,6 @@
   margin-top -1 * $page-padding-top
   border-bottom 1px solid $table-border-color
 
-  .cluster-ticker
-    padding-top 0
-    padding-bottom 0
-
   .cluster-summary
     background-color white
     padding-top $page-padding-top

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -23,7 +23,7 @@ class ClusterTicker extends React.Component<{}, {}> {
   render() {
     return (
       <section className="section cluster-ticker">
-        <h2>Cluster Overview</h2>
+        <h1>Cluster Overview</h1>
       </section>
     );
   }

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -12,9 +12,7 @@ import createChartComponent from "src/views/shared/util/d3-react";
 import capacityChart from "./capacity";
 
 import "./cluster.styl";
-
-// tslint:disable-next-line:no-var-requires
-const spinner = require<string>("assets/spinner.gif");
+import spinner from "assets/spinner.gif";
 
 // tslint:disable-next-line:variable-name
 const CapacityChart = createChartComponent(capacityChart);
@@ -167,7 +165,7 @@ class ClusterSummary extends React.Component<ClusterSummaryProps, {}> {
       children.push(
         ...renderCapacityUsage(this.props.capacityUsage),
         ...renderNodeLiveness(this.props.nodeLiveness),
-        ...renderReplicationStatus(this.props.replicationStatus)
+        ...renderReplicationStatus(this.props.replicationStatus),
       );
     }
 

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -13,6 +13,9 @@ import capacityChart from "./capacity";
 
 import "./cluster.styl";
 
+// tslint:disable-next-line:no-var-requires
+const spinner = require<string>("assets/spinner.gif");
+
 // tslint:disable-next-line:variable-name
 const CapacityChart = createChartComponent(capacityChart);
 
@@ -151,15 +154,23 @@ interface ClusterSummaryProps {
   capacityUsage: CapacityUsageProps;
   nodeLiveness: NodeLivenessProps;
   replicationStatus: ReplicationStatusProps;
+  loading: boolean;
 }
 
 class ClusterSummary extends React.Component<ClusterSummaryProps, {}> {
   render() {
-    const children = [
-      ...renderCapacityUsage(this.props.capacityUsage),
-      ...renderNodeLiveness(this.props.nodeLiveness),
-      ...renderReplicationStatus(this.props.replicationStatus),
-    ];
+    const children = [];
+
+    if (this.props.loading) {
+      children.push(<img className="visualization__spinner" src={spinner} />);
+    } else {
+      children.push(
+        ...renderCapacityUsage(this.props.capacityUsage),
+        ...renderNodeLiveness(this.props.nodeLiveness),
+        ...renderReplicationStatus(this.props.replicationStatus)
+      );
+    }
+
     return <section className="cluster-summary" children={children} />;
   }
 }
@@ -169,6 +180,7 @@ function mapStateToClusterSummaryProps (state: AdminUIState) {
     capacityUsage: mapStateToCapacityUsageProps(state),
     nodeLiveness: mapStateToNodeLivenessProps(state),
     replicationStatus: mapStateToReplicationStatusProps(state),
+    loading: !state.cachedData.nodes.data,
   };
 }
 

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -1,8 +1,3 @@
-// tslint:disable-next-line:no-var-requires
-const spinner = require<string>("assets/spinner.gif");
-// tslint:disable-next-line:no-var-requires
-const noResults = require<string>("assets/noresults.svg");
-
 import _ from "lodash";
 import moment from "moment";
 import { Line } from "rc-progress";
@@ -21,6 +16,9 @@ import { PageConfig, PageConfigItem } from "src/views/shared/components/pageconf
 import { SortSetting } from "src/views/shared/components/sortabletable";
 import { ColumnDescriptor, SortedTable } from "src/views/shared/components/sortedtable";
 import { ToolTipWrapper } from "src/views/shared/components/toolTip";
+
+import spinner from "assets/spinner.gif";
+import noResults from "assets/noresults.svg";
 
 type Job = protos.cockroach.server.serverpb.JobsResponse.Job;
 

--- a/pkg/ui/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/logTable.tsx
@@ -1,6 +1,3 @@
-// tslint:disable-next-line:no-var-requires
-const spinner = require<string>("assets/spinner.gif");
-
 import _ from "lodash";
 import React from "react";
 
@@ -9,6 +6,8 @@ import { FixLong } from "src/util/fixLong";
 import Print from "src/views/reports/containers/range/print";
 import Loading from "src/views/shared/components/loading";
 import { TimestampToMoment } from "src/util/convert";
+
+import spinner from "assets/spinner.gif";
 
 interface LogTableProps {
   rangeID: Long;


### PR DESCRIPTION
This fixes everything from #19512, leaving #20540 and #19945 for future work.

![screen shot 2017-12-12 at 6 47 07 pm](https://user-images.githubusercontent.com/793969/33914582-e285b336-df6c-11e7-9c93-9a892e5c5a90.png)
