### PR TITLE
sqlccl: delay writing checkpoint file during IMPORT

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -990,9 +990,6 @@ func importPlanHook(
 			return err
 		}
 		defer tempStorage.Close()
-		if err := verifyUsableExportTarget(ctx, tempStorage, temp); err != nil {
-			return err
-		}
 
 		sstSize := config.DefaultZoneConfig().RangeMaxBytes / 2
 		if override, ok := opts[importOptionSSTSize]; ok {
@@ -1029,6 +1026,11 @@ func importPlanHook(
 
 		jobDesc, err := importJobDescription(importStmt, create.Defs, files, opts)
 		if err != nil {
+			return err
+		}
+
+		// Delay writing the BACKUP-CHECKPOINT file until as late as possible.
+		if err := verifyUsableExportTarget(ctx, tempStorage, temp); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -703,6 +703,13 @@ func TestImportStmt(t *testing.T) {
 		if !testutils.IsError(err, "expected 1 fields, got 2") {
 			t.Fatalf("unexpected: %v", err)
 		}
+
+		// Specify wrong table name; still shouldn't leave behind a checkpoint file.
+		_, err = conn.Exec(fmt.Sprintf(`IMPORT TABLE bad CREATE USING $1 CSV DATA (%s) WITH temp = $2, transform_only`, files[0]), schema[0], nodetmp)
+		if !testutils.IsError(err, `file specifies a schema for table "t"`) {
+			t.Fatalf("unexpected: %v", err)
+		}
+
 		// Expect it to succeed with correct columns.
 		sqlDB.Exec(t, fmt.Sprintf(`IMPORT TABLE t (a INT, b STRING) CSV DATA (%s) WITH temp = $1, transform_only`, files[0]), nodetmp)
 	})


### PR DESCRIPTION
Prevents table schema errors from leaving an orphaned CHECKPOINT file
(preventing a successful IMPORT on the following attempt).

Release note: None