### PR TITLE
sql/sqlbase: micro optimizations for RowContainer.At

### DIFF
--- a/pkg/sql/sqlbase/row_container_test.go
+++ b/pkg/sql/sqlbase/row_container_test.go
@@ -76,3 +76,91 @@ func TestRowContainer(t *testing.T) {
 		}
 	}
 }
+
+func TestRowContainerAtOutOfRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	m := mon.MakeUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64)
+	defer m.Stop(ctx)
+
+	resCols := ResultColumns{ResultColumn{Typ: types.Int}}
+	rc := NewRowContainer(m.MakeBoundAccount(), ColTypeInfoFromResCols(resCols), 0)
+	defer rc.Close(ctx)
+
+	// Verify that a panic is thrown for out-of-range conditions.
+	for _, i := range []int{-1, 0} {
+		var p interface{}
+		func() {
+			defer func() {
+				p = recover()
+			}()
+			rc.At(i)
+		}()
+		if p == nil {
+			t.Fatalf("%d: expected panic, but found success", i)
+		}
+	}
+}
+
+func TestRowContainerZeroCols(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	m := mon.MakeUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64)
+	defer m.Stop(ctx)
+
+	rc := NewRowContainer(m.MakeBoundAccount(), ColTypeInfoFromResCols(nil), 0)
+	defer rc.Close(ctx)
+
+	const numRows = 10
+	for i := 0; i < numRows; i++ {
+		if _, err := rc.AddRow(context.Background(), nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if rc.Len() != numRows {
+		t.Fatalf("expected %d rows, but found %d", numRows, rc.Len())
+	}
+	row := rc.At(0)
+	if row == nil {
+		t.Fatalf("expected non-nil row")
+	}
+	if len(row) != 0 {
+		t.Fatalf("expected empty row")
+	}
+}
+
+func BenchmarkRowContainerAt(b *testing.B) {
+	const numCols = 3
+	const numRows = 1024
+
+	m := mon.MakeUnlimitedMonitor(
+		context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64,
+	)
+	defer m.Stop(context.Background())
+
+	resCol := make(ResultColumns, numCols)
+	for i := range resCol {
+		resCol[i] = ResultColumn{Typ: types.Int}
+	}
+
+	rc := NewRowContainer(m.MakeBoundAccount(), ColTypeInfoFromResCols(resCol), 0)
+	defer rc.Close(context.Background())
+
+	row := make(tree.Datums, numCols)
+	for i := 0; i < numRows; i++ {
+		for j := range row {
+			row[j] = tree.NewDInt(tree.DInt(i*numCols + j))
+		}
+		if _, err := rc.AddRow(context.Background(), row); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = rc.At(i & (numRows - 1))
+	}
+	b.StopTimer()
+}


### PR DESCRIPTION
Rework `RowContainer.getChunkAndPos` to use shifting instead of
division. Rework how `numCols==0` is handled to remove the need for
various special cases in `RowContainer.At`.

```
name              old time/op  new time/op  delta
RowContainerAt-8  5.84ns ± 2%  2.45ns ± 3%  -58.12%  (p=0.000 n=9+10)
```

Release note (performance improvement): Improve performance of low-level
row manipulation routines.