### PR TITLE
rpc: remove grpc.DialOption args from GRPCDial

### DIFF
--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip/resolver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -349,7 +348,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 		c := newClient(log.AmbientContext{Tracer: tracing.NewTracer()}, local.GetNodeAddr(), makeMetrics())
 
 		testutils.SucceedsSoon(t, func() error {
-			conn, err := peer.rpcContext.GRPCDial(c.addr.String(), grpc.WithBlock()).Connect(ctx)
+			conn, err := peer.rpcContext.GRPCDial(c.addr.String()).Connect(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -807,7 +807,7 @@ func (m *multiTestContext) addStore(idx int) {
 	// having to worry about such conditions we pre-warm the connection
 	// cache. See #8440 for an example of the headaches the long dial times
 	// cause.
-	if _, err := m.rpcContext.GRPCDial(ln.Addr().String(), grpc.WithBlock()).Connect(ctx); err != nil {
+	if _, err := m.rpcContext.GRPCDial(ln.Addr().String()).Connect(ctx); err != nil {
 		m.t.Fatal(err)
 	}
 

--- a/pkg/storage/raft_transport.go
+++ b/pkg/storage/raft_transport.go
@@ -440,7 +440,7 @@ func (t *RaftTransport) connectAndProcess(
 		if err != nil {
 			return err
 		}
-		conn, err := t.rpcContext.GRPCDial(addr.String(), grpc.WithBlock()).Connect(ctx)
+		conn, err := t.rpcContext.GRPCDial(addr.String()).Connect(ctx)
 		if err != nil {
 			return err
 		}
@@ -624,7 +624,7 @@ func (t *RaftTransport) SendSnapshot(
 		if err != nil {
 			return err
 		}
-		conn, err := t.rpcContext.GRPCDial(addr.String(), grpc.WithBlock()).Connect(ctx)
+		conn, err := t.rpcContext.GRPCDial(addr.String()).Connect(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`Context.GRPCDial` only dials a given address once. All other calls
for a given address simply return the already existing connection.
This means that if a second call to `Context.GRPCDial` provides
`grpc.DialOptions`, they will be silently ignored. For instance,
I suspect that a number of the `grpc.WithBlock()` options were being
ignored without us knowing it.

This change removes the ability to set/override specific dial options in
`Context.GRPCDial`. Instead, the few tests that require this ability
are given it through a testing-only function.

Release note: None