### PR TITLE
build: fix testlogicrace invocation

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -10,7 +10,7 @@ mkdir -p artifacts
 
 build/builder.sh env \
 	make testrace \
-  PKG=./pkg/sql/logictest
+	PKG=./pkg/sql/logictest \
 	TESTFLAGS='-v' \
 	2>&1 \
 	| tee artifacts/testlogicrace.log \


### PR DESCRIPTION
It was not being properly executed due to a missing `\`.

Release note: None