### PR TITLE
distsql: adjust/tighten span partitions to avoid scanning over interleaved rows

### DIFF
--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -134,6 +134,13 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 		return physicalPlan{}, false, err
 	}
 
+	if ancsPartitions, err = tightenPartitionsForInterleave(ancsPartitions, ancestor.desc, ancestor.index); err != nil {
+		return physicalPlan{}, false, err
+	}
+	if descPartitions, err = tightenPartitionsForInterleave(descPartitions, descendant.desc, descendant.index); err != nil {
+		return physicalPlan{}, false, err
+	}
+
 	// We want to ensure that all child spans with a given interleave
 	// prefix value (which also happens to be our equality join columns)
 	// are read on the same node as the corresponding ancestor rows.

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -1322,6 +1322,15 @@ func TestAdjustEndKeyForInterleave(t *testing.T) {
 			expected: "/12345678901234/#/12345/12345678901234/#",
 		},
 
+		// Non-interleaved sentinel (e.g. family ID) needs to be
+		// included in EndKey.
+		{
+			table:    child,
+			index:    &child.PrimaryIndex,
+			input:    "/12345678901234/#/12345/12345678901234/shelloworld",
+			expected: "/12345678901234/#/12345/12345678901234/shelloworld/NULLASC",
+		},
+
 		// Index key with extra columns (implicit primary key columns).
 		// We should expect two extra columns (in addition to the
 		// two index columns).

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -257,6 +257,10 @@ func EncodeVarintDescending(b []byte, v int64) []byte {
 // getVarintLen returns the encoded length of an encoded varint. Assumes the
 // slice has at least one byte.
 func getVarintLen(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, errors.Errorf("insufficient bytes to get varint length")
+	}
+
 	length := int(b[0]) - intZero
 	if length >= 0 {
 		if length <= intSmall {


### PR DESCRIPTION
Ignore the first commit since that is addressed in #20726

This is a follow-up from #20235 where we adjusted the span during the initial planning phases to avoid scanning over interleaved children.

This patch does the same for spans that have been partitioned during distsql planning.

Release notes: none

cc: @jordanlewis for the backfill span adjusting