### PR TITLE
opt: support multiple expression spans, implement neOp

### DIFF
--- a/pkg/sql/opt/expr.go
+++ b/pkg/sql/opt/expr.go
@@ -47,15 +47,16 @@ func (e *expr) opClass() operatorClass {
 	return operatorTab[e.op].class
 }
 
-func (e *expr) inputs() []*expr {
-	return e.children
-}
-
+// formatExprs formats the given expressions as children of the same
+// node. Optionally creates a new parent node (if title is not "", and we have
+// expressions).
 func formatExprs(tp treeprinter.Node, title string, exprs []*expr) {
 	if len(exprs) > 0 {
-		n := tp.Child(title)
+		if title != "" {
+			tp = tp.Child(title)
+		}
 		for _, e := range exprs {
-			e.format(n)
+			e.format(tp)
 		}
 	}
 }

--- a/pkg/sql/opt/index_constraints_test.go
+++ b/pkg/sql/opt/index_constraints_test.go
@@ -138,8 +138,8 @@ func TestIntersectSpan(t *testing.T) {
 			sp2 := parseSpan(tc.b)
 			c := indexConstraintCalc{evalCtx: &evalCtx}
 			res := ""
-			if c.intersectSpan(&sp1, &sp2) {
-				res = sp1.String()
+			if sp3, ok := c.intersectSpan(&sp1, &sp2); ok {
+				res = sp3.String()
 			}
 			if res != tc.e {
 				t.Errorf("expected  %s  got  %s", tc.e, res)

--- a/pkg/sql/opt/scalar.go
+++ b/pkg/sql/opt/scalar.go
@@ -100,7 +100,7 @@ func (scalarClass) format(e *expr, tp treeprinter.Node) {
 	}
 	fmt.Fprintf(&buf, " (type: %s)", e.scalarProps.typ)
 	n := tp.Child(buf.String())
-	formatExprs(n, "inputs", e.inputs())
+	formatExprs(n, "", e.children)
 }
 
 // The following initializers are called on an already allocated expression

--- a/pkg/sql/opt/testdata/build-scalar
+++ b/pkg/sql/opt/testdata/build-scalar
@@ -7,9 +7,8 @@ build-scalar
 1 + 2
 ----
 plus (type: int)
- └── inputs
-      ├── const (1) (type: int)
-      └── const (2) (type: int)
+ ├── const (1) (type: int)
+ └── const (2) (type: int)
 
 build-scalar string
 @1
@@ -20,152 +19,115 @@ build-scalar int
 @1 + 2
 ----
 plus (type: int)
- └── inputs
-      ├── variable (0) (type: int)
-      └── const (2) (type: int)
+ ├── variable (0) (type: int)
+ └── const (2) (type: int)
 
 build-scalar int int
 @1 >= 5 AND @1 <= 10 AND @2 < 4
 ----
 and (type: bool)
- └── inputs
-      ├── and (type: bool)
-      │    └── inputs
-      │         ├── ge (type: bool)
-      │         │    └── inputs
-      │         │         ├── variable (0) (type: int)
-      │         │         └── const (5) (type: int)
-      │         └── le (type: bool)
-      │              └── inputs
-      │                   ├── variable (0) (type: int)
-      │                   └── const (10) (type: int)
-      └── lt (type: bool)
-           └── inputs
-                ├── variable (1) (type: int)
-                └── const (4) (type: int)
+ ├── and (type: bool)
+ │    ├── ge (type: bool)
+ │    │    ├── variable (0) (type: int)
+ │    │    └── const (5) (type: int)
+ │    └── le (type: bool)
+ │         ├── variable (0) (type: int)
+ │         └── const (10) (type: int)
+ └── lt (type: bool)
+      ├── variable (1) (type: int)
+      └── const (4) (type: int)
 
 build-scalar,normalize int int
 @1 >= 5 AND @1 <= 10 AND @2 > 0 AND @2 < 10
 ----
 and (type: bool)
- └── inputs
-      ├── ge (type: bool)
-      │    └── inputs
-      │         ├── variable (0) (type: int)
-      │         └── const (5) (type: int)
-      ├── le (type: bool)
-      │    └── inputs
-      │         ├── variable (0) (type: int)
-      │         └── const (10) (type: int)
-      ├── gt (type: bool)
-      │    └── inputs
-      │         ├── variable (1) (type: int)
-      │         └── const (0) (type: int)
-      └── lt (type: bool)
-           └── inputs
-                ├── variable (1) (type: int)
-                └── const (10) (type: int)
+ ├── ge (type: bool)
+ │    ├── variable (0) (type: int)
+ │    └── const (5) (type: int)
+ ├── le (type: bool)
+ │    ├── variable (0) (type: int)
+ │    └── const (10) (type: int)
+ ├── gt (type: bool)
+ │    ├── variable (1) (type: int)
+ │    └── const (0) (type: int)
+ └── lt (type: bool)
+      ├── variable (1) (type: int)
+      └── const (10) (type: int)
 
 build-scalar,normalize int int
 @1 >= 5 OR @1 <= 10 OR @2 > 0 OR @2 < 10
 ----
 or (type: bool)
- └── inputs
-      ├── ge (type: bool)
-      │    └── inputs
-      │         ├── variable (0) (type: int)
-      │         └── const (5) (type: int)
-      ├── le (type: bool)
-      │    └── inputs
-      │         ├── variable (0) (type: int)
-      │         └── const (10) (type: int)
-      ├── gt (type: bool)
-      │    └── inputs
-      │         ├── variable (1) (type: int)
-      │         └── const (0) (type: int)
-      └── lt (type: bool)
-           └── inputs
-                ├── variable (1) (type: int)
-                └── const (10) (type: int)
+ ├── ge (type: bool)
+ │    ├── variable (0) (type: int)
+ │    └── const (5) (type: int)
+ ├── le (type: bool)
+ │    ├── variable (0) (type: int)
+ │    └── const (10) (type: int)
+ ├── gt (type: bool)
+ │    ├── variable (1) (type: int)
+ │    └── const (0) (type: int)
+ └── lt (type: bool)
+      ├── variable (1) (type: int)
+      └── const (10) (type: int)
 
 build-scalar,normalize int int int
 @1 >= 5 AND (@2 = 1 OR @2 > 3) AND (@3 > 2)
 ----
 and (type: bool)
- └── inputs
-      ├── ge (type: bool)
-      │    └── inputs
-      │         ├── variable (0) (type: int)
-      │         └── const (5) (type: int)
-      ├── or (type: bool)
-      │    └── inputs
-      │         ├── eq (type: bool)
-      │         │    └── inputs
-      │         │         ├── variable (1) (type: int)
-      │         │         └── const (1) (type: int)
-      │         └── gt (type: bool)
-      │              └── inputs
-      │                   ├── variable (1) (type: int)
-      │                   └── const (3) (type: int)
-      └── gt (type: bool)
-           └── inputs
-                ├── variable (2) (type: int)
-                └── const (2) (type: int)
+ ├── ge (type: bool)
+ │    ├── variable (0) (type: int)
+ │    └── const (5) (type: int)
+ ├── or (type: bool)
+ │    ├── eq (type: bool)
+ │    │    ├── variable (1) (type: int)
+ │    │    └── const (1) (type: int)
+ │    └── gt (type: bool)
+ │         ├── variable (1) (type: int)
+ │         └── const (3) (type: int)
+ └── gt (type: bool)
+      ├── variable (2) (type: int)
+      └── const (2) (type: int)
 
 build-scalar,normalize int int int
 @1 >= 5 AND (@2 = 1 OR @2 = 3 OR @2 > 5) AND (@3 > 2)
 ----
 and (type: bool)
- └── inputs
-      ├── ge (type: bool)
-      │    └── inputs
-      │         ├── variable (0) (type: int)
-      │         └── const (5) (type: int)
-      ├── or (type: bool)
-      │    └── inputs
-      │         ├── eq (type: bool)
-      │         │    └── inputs
-      │         │         ├── variable (1) (type: int)
-      │         │         └── const (1) (type: int)
-      │         ├── eq (type: bool)
-      │         │    └── inputs
-      │         │         ├── variable (1) (type: int)
-      │         │         └── const (3) (type: int)
-      │         └── gt (type: bool)
-      │              └── inputs
-      │                   ├── variable (1) (type: int)
-      │                   └── const (5) (type: int)
-      └── gt (type: bool)
-           └── inputs
-                ├── variable (2) (type: int)
-                └── const (2) (type: int)
+ ├── ge (type: bool)
+ │    ├── variable (0) (type: int)
+ │    └── const (5) (type: int)
+ ├── or (type: bool)
+ │    ├── eq (type: bool)
+ │    │    ├── variable (1) (type: int)
+ │    │    └── const (1) (type: int)
+ │    ├── eq (type: bool)
+ │    │    ├── variable (1) (type: int)
+ │    │    └── const (3) (type: int)
+ │    └── gt (type: bool)
+ │         ├── variable (1) (type: int)
+ │         └── const (5) (type: int)
+ └── gt (type: bool)
+      ├── variable (2) (type: int)
+      └── const (2) (type: int)
 
 build-scalar,normalize int int int
 (@1 >= 5 AND @1 <= 10) OR (@2 > 1 AND @2 < 3) OR (@3 > 2)
 ----
 or (type: bool)
- └── inputs
-      ├── and (type: bool)
-      │    └── inputs
-      │         ├── ge (type: bool)
-      │         │    └── inputs
-      │         │         ├── variable (0) (type: int)
-      │         │         └── const (5) (type: int)
-      │         └── le (type: bool)
-      │              └── inputs
-      │                   ├── variable (0) (type: int)
-      │                   └── const (10) (type: int)
-      ├── and (type: bool)
-      │    └── inputs
-      │         ├── gt (type: bool)
-      │         │    └── inputs
-      │         │         ├── variable (1) (type: int)
-      │         │         └── const (1) (type: int)
-      │         └── lt (type: bool)
-      │              └── inputs
-      │                   ├── variable (1) (type: int)
-      │                   └── const (3) (type: int)
-      └── gt (type: bool)
-           └── inputs
-                ├── variable (2) (type: int)
-                └── const (2) (type: int)
+ ├── and (type: bool)
+ │    ├── ge (type: bool)
+ │    │    ├── variable (0) (type: int)
+ │    │    └── const (5) (type: int)
+ │    └── le (type: bool)
+ │         ├── variable (0) (type: int)
+ │         └── const (10) (type: int)
+ ├── and (type: bool)
+ │    ├── gt (type: bool)
+ │    │    ├── variable (1) (type: int)
+ │    │    └── const (1) (type: int)
+ │    └── lt (type: bool)
+ │         ├── variable (1) (type: int)
+ │         └── const (3) (type: int)
+ └── gt (type: bool)
+      ├── variable (2) (type: int)
+      └── const (2) (type: int)

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -9,6 +9,12 @@ build-scalar,normalize,index-constraints int
 [/2 - ]
 
 build-scalar,normalize,index-constraints int
+@1 != 2
+----
+[ - /2)
+(/2 - ]
+
+build-scalar,normalize,index-constraints int
 @1 < 2
 ----
 [ - /1]
@@ -32,6 +38,12 @@ build-scalar,normalize,index-constraints int int
 @1 > 2 AND @2 > 5
 ----
 [/3/6 - ]
+
+build-scalar,normalize,index-constraints int
+@1 >= 1 AND @1 <= 5 AND @1 != 3
+----
+[/1 - /3)
+(/3 - /5]
 
 build-scalar,normalize,index-constraints int int
 @1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
@@ -61,6 +73,17 @@ build-scalar,normalize,index-constraints int int
 build-scalar,normalize,index-constraints int
 @1 > 2 AND @1 < 1
 ----
+
+build-scalar,normalize,index-constraints int int
+@1 = 1 AND @2 != 2
+----
+[/1 - /1/2)
+(/1/2 - /1]
+
+build-scalar,normalize,index-constraints int int
+@1 >= 1 AND @1 <= 5 AND @2 != 2
+----
+[/1 - /5]
 
 # Tests with a type that doesn't support Prev.
 build-scalar,normalize,index-constraints string


### PR DESCRIPTION
#### opt: simplify scalar expression printout

Remove the unnecessary intermediate "inputs:" node from scalar
expression tree printouts.

Release note: None

#### opt: support multiple expression spans, implement neOp

The existing code only works with expressions that generate a single span.
This change adds support for multiple spans. We implement neOp as the first
use-case.

We make a small change on how we use LogicalKeys: instead of modifying them in
place (by copying from one Vals to another), we now allow LogicalKeys to alias
the same slices. This works because the only mutation we allow is appending.

Release Note: None.
