### PR TITLE
sql: show tree structure in EXPLAIN

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1035,7 +1035,7 @@ func Example_sql_table() {
 	c.RunWithArgs([]string{"sql", "--format=raw", "-e", "select * from t.t"})
 	c.RunWithArgs([]string{"sql", "--format=records", "-e", "select * from t.t"})
 	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "select '  hai' as x"})
-	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "explain(indent) select s from t.t union all select s from t.t"})
+	c.RunWithArgs([]string{"sql", "--format=pretty", "-e", "explain select s from t.t union all select s from t.t"})
 
 	// Output:
 	// sql -e create database t; create table t.t (s string, d string);
@@ -1240,20 +1240,20 @@ func Example_sql_table() {
 	// |   hai |
 	// +-------+
 	// (1 row)
-	// sql --format=pretty -e explain(indent) select s from t.t union all select s from t.t
-	// +-------+--------+-------+--------------------+
-	// | Level |  Type  | Field |    Description     |
-	// +-------+--------+-------+--------------------+
-	// |     0 | append |       |  -> append         |
-	// |     1 | render |       |    -> render       |
-	// |     2 | scan   |       |       -> scan      |
-	// |     2 |        | table |          t@primary |
-	// |     2 |        | spans |          ALL       |
-	// |     1 | render |       |    -> render       |
-	// |     2 | scan   |       |       -> scan      |
-	// |     2 |        | table |          t@primary |
-	// |     2 |        | spans |          ALL       |
-	// +-------+--------+-------+--------------------+
+	// sql --format=pretty -e explain select s from t.t union all select s from t.t
+	// +----------------+-------+-------------+
+	// |      Tree      | Field | Description |
+	// +----------------+-------+-------------+
+	// | append         |       |             |
+	// |  ├── render    |       |             |
+	// |  │    └── scan |       |             |
+	// |  │             | table | t@primary   |
+	// |  │             | spans | ALL         |
+	// |  └── render    |       |             |
+	// |       └── scan |       |             |
+	// |                | table | t@primary   |
+	// |                | spans | ALL         |
+	// +----------------+-------+-------------+
 	// (9 rows)
 }
 

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -53,7 +53,6 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 		showMetadata: false,
 		showExprs:    false,
 		showTypes:    false,
-		doIndent:     false,
 	}
 
 	for _, opt := range n.Options {
@@ -74,9 +73,6 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 				explainer.showTypes = true
 				// TYPES implies METADATA.
 				explainer.showMetadata = true
-
-			case "indent":
-				explainer.doIndent = true
 
 			case "symvars":
 				explainer.symbolicVars = true

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -250,18 +250,18 @@ query error column "s" must appear in the GROUP BY clause or be used in an aggre
 SELECT COUNT(*), s FROM kv GROUP BY UPPER(s)
 
 # Selecting and grouping on a more complex expression works.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
-0  group   ·            ·                      (count, "k + v")                ·
-0  ·       aggregate 0  count_rows()           ·                               ·
-0  ·       aggregate 1  test.kv.k + test.kv.v  ·                               ·
-0  ·       group by     @1-@1                  ·                               ·
-1  render  ·            ·                      ("k + v")                       ·
-1  ·       render 0     test.kv.k + test.kv.v  ·                               ·
-2  scan    ·            ·                      (k, v, w[omitted], s[omitted])  k!=NULL; key(k)
-2  ·       table        kv@primary             ·                               ·
-2  ·       spans        ALL                    ·                               ·
+group           0  group   ·            ·                      (count, "k + v")  ·
+ │              0  ·       aggregate 0  count_rows()           ·                 ·
+ │              0  ·       aggregate 1  test.kv.k + test.kv.v  ·                 ·
+ │              0  ·       group by     @1-@1                  ·                 ·
+ └── render     1  render  ·            ·                      (count, "k + v")  ·
+      │         1  ·       render 0     test.kv.k + test.kv.v  ·                 ·
+      └── scan  2  scan    ·            ·                      (count, "k + v")  ·
+·               2  ·       table        kv@primary             ·                 ·
+·               2  ·       spans        ALL                    ·                 ·
 
 query II rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k+v
@@ -275,23 +275,23 @@ SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
-0  render  ·            ·             (count, "k + v")                ·
-0  ·       render 0     count_rows    ·                               ·
-0  ·       render 1     k + v         ·                               ·
-1  group   ·            ·             (count_rows, k, v)              ·
-1  ·       aggregate 0  count_rows()  ·                               ·
-1  ·       aggregate 1  test.kv.k     ·                               ·
-1  ·       aggregate 2  test.kv.v     ·                               ·
-1  ·       group by     @1-@2         ·                               ·
-2  render  ·            ·             (k, v)                          k!=NULL; key(k)
-2  ·       render 0     test.kv.k     ·                               ·
-2  ·       render 1     test.kv.v     ·                               ·
-3  scan    ·            ·             (k, v, w[omitted], s[omitted])  k!=NULL; key(k)
-3  ·       table        kv@primary    ·                               ·
-3  ·       spans        ALL           ·                               ·
+render               0  render  ·            ·             (count, "k + v")  ·
+ │                   0  ·       render 0     count_rows    ·                 ·
+ │                   0  ·       render 1     k + v         ·                 ·
+ └── group           1  group   ·            ·             (count, "k + v")  ·
+      │              1  ·       aggregate 0  count_rows()  ·                 ·
+      │              1  ·       aggregate 1  test.kv.k     ·                 ·
+      │              1  ·       aggregate 2  test.kv.v     ·                 ·
+      │              1  ·       group by     @1-@2         ·                 ·
+      └── render     2  render  ·            ·             (count, "k + v")  ·
+           │         2  ·       render 0     test.kv.k     ·                 ·
+           │         2  ·       render 1     test.kv.v     ·                 ·
+           └── scan  3  scan    ·            ·             (count, "k + v")  ·
+·                    3  ·       table        kv@primary    ·                 ·
+·                    3  ·       spans        ALL           ·                 ·
 
 query II rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k, v
@@ -533,29 +533,29 @@ SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
 ----
 14.0
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT COUNT(k) FROM kv
 ----
-0  group   ·            ·
-0  ·       aggregate 0  count(k)
-1  render  ·            ·
-1  ·       render 0     k
-2  scan    ·            ·
-2  ·       table        kv@primary
-2  ·       spans        ALL
+group           ·            ·
+ │              aggregate 0  count(k)
+ └── render     ·            ·
+      │         render 0     k
+      └── scan  ·            ·
+·               table        kv@primary
+·               spans        ALL
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT COUNT(k), SUM(k), MAX(k) FROM kv
 ----
-0  group   ·            ·
-0  ·       aggregate 0  count(k)
-0  ·       aggregate 1  sum(k)
-0  ·       aggregate 2  max(k)
-1  render  ·            ·
-1  ·       render 0     k
-2  scan    ·            ·
-2  ·       table        kv@primary
-2  ·       spans        ALL
+group           ·            ·
+ │              aggregate 0  count(k)
+ │              aggregate 1  sum(k)
+ │              aggregate 2  max(k)
+ └── render     ·            ·
+      │         render 0     k
+      └── scan  ·            ·
+·               table        kv@primary
+·               spans        ALL
 
 statement ok
 CREATE TABLE abc (
@@ -568,17 +568,17 @@ CREATE TABLE abc (
 statement ok
 INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::decimal)
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
 ----
-0  group   ·            ·
-0  ·       aggregate 0  min(a)
-1  render  ·            ·
-1  ·       render 0     a
-2  scan    ·            ·
-2  ·       table        abc@primary
-2  ·       spans        ALL
-2  ·       limit        1
+group           ·            ·
+ │              aggregate 0  min(a)
+ └── render     ·            ·
+      │         render 0     a
+      └── scan  ·            ·
+·               table        abc@primary
+·               spans        ALL
+·               limit        1
 
 query TRBR
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
@@ -648,136 +648,136 @@ SELECT MIN(x) FROM xyz
 ----
 1
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz
 ----
-0  group   ·            ·
-0  ·       aggregate 0  min(x)
-1  render  ·            ·
-1  ·       render 0     x
-2  scan    ·            ·
-2  ·       table        xyz@xy
-2  ·       spans        ALL
-2  ·       limit        1
+group           ·            ·
+ │              aggregate 0  min(x)
+ └── render     ·            ·
+      │         render 0     x
+      └── scan  ·            ·
+·               table        xyz@xy
+·               spans        ALL
+·               limit        1
 
 query I
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
 4
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
-0  group   ·            ·
-0  ·       aggregate 0  min(x)
-1  render  ·            ·
-1  ·       render 0     x
-2  scan    ·            ·
-2  ·       table        xyz@xy
-2  ·       spans        /0-/1 /4-/5 /7-/8
-2  ·       limit        1
+group           ·            ·
+ │              aggregate 0  min(x)
+ └── render     ·            ·
+      │         render 0     x
+      └── scan  ·            ·
+·               table        xyz@xy
+·               spans        /0-/1 /4-/5 /7-/8
+·               limit        1
 
 query I
 SELECT MAX(x) FROM xyz
 ----
 7
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MAX(x) FROM xyz
 ----
-0  group    ·            ·
-0  ·        aggregate 0  max(x)
-1  render   ·            ·
-1  ·        render 0     x
-2  revscan  ·            ·
-2  ·        table        xyz@xy
-2  ·        spans        ALL
-2  ·        limit        1
+group              ·            ·
+ │                 aggregate 0  max(x)
+ └── render        ·            ·
+      │            render 0     x
+      └── revscan  ·            ·
+·                  table        xyz@xy
+·                  spans        ALL
+·                  limit        1
 
 query I
 SELECT MIN(y) FROM xyz WHERE x = 1
 ----
 2
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MIN(y) FROM xyz WHERE x = 1
 ----
-0  group   ·            ·
-0  ·       aggregate 0  min(y)
-1  render  ·            ·
-1  ·       render 0     y
-2  scan    ·            ·
-2  ·       table        xyz@xy
-2  ·       spans        /1/!NULL-/2
-2  ·       limit        1
+group           ·            ·
+ │              aggregate 0  min(y)
+ └── render     ·            ·
+      │         render 0     y
+      └── scan  ·            ·
+·               table        xyz@xy
+·               spans        /1/!NULL-/2
+·               limit        1
 
 query I
 SELECT MAX(y) FROM xyz WHERE x = 1
 ----
 2
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MAX(y) FROM xyz WHERE x = 1
 ----
-0  group    ·            ·
-0  ·        aggregate 0  max(y)
-1  render   ·            ·
-1  ·        render 0     y
-2  revscan  ·            ·
-2  ·        table        xyz@xy
-2  ·        spans        /1/!NULL-/2
-2  ·        limit        1
+group              ·            ·
+ │                 aggregate 0  max(y)
+ └── render        ·            ·
+      │            render 0     y
+      └── revscan  ·            ·
+·                  table        xyz@xy
+·                  spans        /1/!NULL-/2
+·                  limit        1
 
 query I
 SELECT MIN(y) FROM xyz WHERE x = 7
 ----
 NULL
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MIN(y) FROM xyz WHERE x = 7
 ----
-0  group   ·            ·
-0  ·       aggregate 0  min(y)
-1  render  ·            ·
-1  ·       render 0     y
-2  scan    ·            ·
-2  ·       table        xyz@xy
-2  ·       spans        /7/!NULL-/8
-2  ·       limit        1
+group           ·            ·
+ │              aggregate 0  min(y)
+ └── render     ·            ·
+      │         render 0     y
+      └── scan  ·            ·
+·               table        xyz@xy
+·               spans        /7/!NULL-/8
+·               limit        1
 
 query I
 SELECT MAX(y) FROM xyz WHERE x = 7
 ----
 NULL
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MAX(y) FROM xyz WHERE x = 7
 ----
-0  group    ·            ·
-0  ·        aggregate 0  max(y)
-1  render   ·            ·
-1  ·        render 0     y
-2  revscan  ·            ·
-2  ·        table        xyz@xy
-2  ·        spans        /7/!NULL-/8
-2  ·        limit        1
+group              ·            ·
+ │                 aggregate 0  max(y)
+ └── render        ·            ·
+      │            render 0     y
+      └── revscan  ·            ·
+·                  table        xyz@xy
+·                  spans        /7/!NULL-/8
+·                  limit        1
 
 query I
 SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 1
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
-0  group   ·            ·
-0  ·       aggregate 0  min(x)
-1  render  ·            ·
-1  ·       render 0     x
-2  scan    ·            ·
-2  ·       table        xyz@zyx
-2  ·       spans        /3/2-/3/3
-2  ·       limit        1
+group           ·            ·
+ │              aggregate 0  min(x)
+ └── render     ·            ·
+      │         render 0     x
+      └── scan  ·            ·
+·               table        xyz@zyx
+·               spans        /3/2-/3/3
+·               limit        1
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)]
@@ -791,17 +791,17 @@ SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 1
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
-0  group    ·            ·
-0  ·        aggregate 0  max(x)
-1  render   ·            ·
-1  ·        render 0     x
-2  revscan  ·            ·
-2  ·        table        xyz@zyx
-2  ·        spans        /3/2-/3/3
-2  ·        limit        1
+group              ·            ·
+ │                 aggregate 0  max(x)
+ └── render        ·            ·
+      │            render 0     x
+      └── revscan  ·            ·
+·                  table        xyz@zyx
+·                  spans        /3/2-/3/3
+·                  limit        1
 
 # VARIANCE/STDDEV
 
@@ -834,16 +834,16 @@ SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
 NULL
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
-0  group   ·            ·
-0  ·       aggregate 0  variance(x)
-1  render  ·            ·
-1  ·       render 0     x
-2  scan    ·            ·
-2  ·       table        xyz@xy
-2  ·       spans        /1-/2
+group           ·            ·
+ │              aggregate 0  variance(x)
+ └── render     ·            ·
+      │         render 0     x
+      └── scan  ·            ·
+·               table        xyz@xy
+·               spans        /1-/2
 
 query RRR
 SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
@@ -979,17 +979,17 @@ INSERT INTO ab VALUES
   (4, 40),
   (5, 50)
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
 ----
-0  group   ·            ·
-0  ·       aggregate 0  min(a)
-1  render  ·            ·
-1  ·       render 0     a
-2  scan    ·            ·
-2  ·       table        abc@primary
-2  ·       spans        ALL
-2  ·       limit        1
+group           ·            ·
+ │              aggregate 0  min(a)
+ └── render     ·            ·
+      │         render 0     a
+      └── scan  ·            ·
+·               table        abc@primary
+·               spans        ALL
+·               limit        1
 
 # Verify we only buffer one row.
 query T
@@ -1000,17 +1000,17 @@ fetched: /ab/primary/1 -> NULL
 fetched: /ab/primary/1/b -> 10
 output row: [1]
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT MAX(a) FROM abc
 ----
-0  group    ·            ·
-0  ·        aggregate 0  max(a)
-1  render   ·            ·
-1  ·        render 0     a
-2  revscan  ·            ·
-2  ·        table        abc@primary
-2  ·        spans        ALL
-2  ·        limit        1
+group              ·            ·
+ │                 aggregate 0  max(a)
+ └── render        ·            ·
+      │            render 0     a
+      └── revscan  ·            ·
+·                  table        abc@primary
+·                  spans        ALL
+·                  limit        1
 
 # Verify we only buffer one row.
 query T
@@ -1021,68 +1021,68 @@ fetched: /ab/primary/5/b -> 50
 fetched: /ab/primary/5 -> NULL
 output row: [5]
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 ----
-0  sort    ·            ·
-0  ·       order        +count
-1  group   ·            ·
-1  ·       aggregate 0  v
-1  ·       aggregate 1  count(k)
-1  ·       group by     @1-@1
-2  render  ·            ·
-2  ·       render 0     v
-2  ·       render 1     k
-3  scan    ·            ·
-3  ·       table        kv@primary
-3  ·       spans        ALL
+sort                 ·            ·
+ │                   order        +count
+ └── group           ·            ·
+      │              aggregate 0  v
+      │              aggregate 1  count(k)
+      │              group by     @1-@1
+      └── render     ·            ·
+           │         render 0     v
+           │         render 1     k
+           └── scan  ·            ·
+·                    table        kv@primary
+·                    spans        ALL
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 ----
-0  sort    ·            ·
-0  ·       order        +count
-1  group   ·            ·
-1  ·       aggregate 0  v
-1  ·       aggregate 1  count_rows()
-1  ·       group by     @1-@1
-2  render  ·            ·
-2  ·       render 0     v
-3  scan    ·            ·
-3  ·       table        kv@primary
-3  ·       spans        ALL
+sort                 ·            ·
+ │                   order        +count
+ └── group           ·            ·
+      │              aggregate 0  v
+      │              aggregate 1  count_rows()
+      │              group by     @1-@1
+      └── render     ·            ·
+           │         render 0     v
+           └── scan  ·            ·
+·                    table        kv@primary
+·                    spans        ALL
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
 ----
-0  sort    ·            ·
-0  ·       order        +count
-1  group   ·            ·
-1  ·       aggregate 0  v
-1  ·       aggregate 1  count(1)
-1  ·       group by     @1-@1
-2  render  ·            ·
-2  ·       render 0     v
-2  ·       render 1     1
-3  scan    ·            ·
-3  ·       table        kv@primary
-3  ·       spans        ALL
+sort                 ·            ·
+ │                   order        +count
+ └── group           ·            ·
+      │              aggregate 0  v
+      │              aggregate 1  count(1)
+      │              group by     @1-@1
+      └── render     ·            ·
+           │         render 0     v
+           │         render 1     1
+           └── scan  ·            ·
+·                    table        kv@primary
+·                    spans        ALL
 
 # Check that filters propagate through no-op aggregation.
-query ITTT
+query TTT
 EXPLAIN(EXPRS) SELECT * FROM (SELECT v, COUNT(1) FROM kv GROUP BY v) WHERE v > 10
 ----
-0  group   ·            ·
-0  ·       aggregate 0  v
-0  ·       aggregate 1  count(1)
-0  ·       group by     @1-@1
-1  render  ·            ·
-1  ·       render 0     v
-1  ·       render 1     1
-2  scan    ·            ·
-2  ·       table        kv@primary
-2  ·       spans        ALL
-2  ·       filter       v > 10
+group           ·            ·
+ │              aggregate 0  v
+ │              aggregate 1  count(1)
+ │              group by     @1-@1
+ └── render     ·            ·
+      │         render 0     v
+      │         render 1     1
+      └── scan  ·            ·
+·               table        kv@primary
+·               spans        ALL
+·               filter       v > 10
 
 # Verify that FILTER works.
 
@@ -1130,44 +1130,44 @@ query error aggregate functions are not allowed in FILTER
 SELECT v, COUNT(*) FILTER (WHERE COUNT(*) > 5) FROM filter_test GROUP BY v
 
 # Check that filter expressions are only rendered once.
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT COUNT(*) FILTER (WHERE k>5), MAX(k>5) FILTER(WHERE k>5) FROM filter_test GROUP BY v
 ----
-0  group   ·            ·
-0  ·       aggregate 0  count_rows() FILTER (WHERE k > 5)
-0  ·       aggregate 1  max(k > 5) FILTER (WHERE k > 5)
-0  ·       group by     @1-@1
-1  render  ·            ·
-1  ·       render 0     v
-1  ·       render 1     k > 5
-2  scan    ·            ·
-2  ·       table        filter_test@primary
-2  ·       spans        ALL
+group           ·            ·
+ │              aggregate 0  count_rows() FILTER (WHERE k > 5)
+ │              aggregate 1  max(k > 5) FILTER (WHERE k > 5)
+ │              group by     @1-@1
+ └── render     ·            ·
+      │         render 0     v
+      │         render 1     k > 5
+      └── scan  ·            ·
+·               table        filter_test@primary
+·               spans        ALL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 ----
-0  group   ·            ·                                                               (count int)                                                    ·
-0  ·       aggregate 0  (count_rows() FILTER (WHERE ((k)[int] > (5)[int])[bool]))[int]  ·                                                              ·
-0  ·       group by     @1-@1                                                           ·                                                              ·
-1  render  ·            ·                                                               (v int, "k > 5" bool)                                          ·
-1  ·       render 0     (v)[int]                                                        ·                                                              ·
-1  ·       render 1     ((k)[int] > (5)[int])[bool]                                     ·                                                              ·
-2  scan    ·            ·                                                               (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)  rowid!=NULL; key(rowid)
-2  ·       table        filter_test@primary                                             ·                                                              ·
-2  ·       spans        ALL                                                             ·                                                              ·
+group           0  group   ·            ·                                                               (count int)  ·
+ │              0  ·       aggregate 0  (count_rows() FILTER (WHERE ((k)[int] > (5)[int])[bool]))[int]  ·            ·
+ │              0  ·       group by     @1-@1                                                           ·            ·
+ └── render     1  render  ·            ·                                                               (count int)  ·
+      │         1  ·       render 0     (v)[int]                                                        ·            ·
+      │         1  ·       render 1     ((k)[int] > (5)[int])[bool]                                     ·            ·
+      └── scan  2  scan    ·            ·                                                               (count int)  ·
+·               2  ·       table        filter_test@primary                                             ·            ·
+·               2  ·       spans        ALL                                                             ·            ·
 
 # Tests with * inside GROUP BY.
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT 1 FROM kv GROUP BY kv.*;
 ----
-0  render  ·         ·
-0  ·       render 0  1
-1  group   ·         ·
-1  ·       group by  @1-@4
-2  scan    ·         ·
-2  ·       table     kv@primary
-2  ·       spans     ALL
+render          ·         ·
+ │              render 0  1
+ └── group      ·         ·
+      │         group by  @1-@4
+      └── scan  ·         ·
+·               table     kv@primary
+·               spans     ALL
 
 query I
 SELECT 1 FROM kv GROUP BY kv.*;
@@ -1179,27 +1179,27 @@ SELECT 1 FROM kv GROUP BY kv.*;
 1
 1
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
-0  group   ·            ·
-0  ·       aggregate 0  sum(d)
-0  ·       group by     @1-@4
-1  render  ·            ·
-1  ·       render 0     k
-1  ·       render 1     v
-1  ·       render 2     w
-1  ·       render 3     s
-1  ·       render 4     d
-2  join    ·            ·
-2  ·       type         inner
-2  ·       pred         test.kv.k >= test.abc.d
-3  scan    ·            ·
-3  ·       table        kv@primary
-3  ·       spans        ALL
-3  scan    ·            ·
-3  ·       table        abc@primary
-3  ·       spans        ALL
+group                ·            ·
+ │                   aggregate 0  sum(d)
+ │                   group by     @1-@4
+ └── render          ·            ·
+      │              render 0     k
+      │              render 1     v
+      │              render 2     w
+      │              render 3     s
+      │              render 4     d
+      └── join       ·            ·
+           │         type         inner
+           │         pred         test.kv.k >= test.abc.d
+           ├── scan  ·            ·
+           │         table        kv@primary
+           │         spans        ALL
+           └── scan  ·            ·
+·                    table        abc@primary
+·                    spans        ALL
 
 query R rowsort
 SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
@@ -1218,17 +1218,17 @@ statement ok
 INSERT INTO opt_test VALUES (1, NULL), (2, 10), (3, NULL), (4, 5)
 
 # Verify that we correctly add the v IS NOT NULL constraint (which restricts the span).
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
 ----
-0  group   ·            ·                     (min)            ·
-0  ·       aggregate 0  min(test.opt_test.v)  ·                ·
-1  render  ·            ·                     (v)              v!=NULL; +v
-1  ·       render 0     test.opt_test.v       ·                ·
-2  scan    ·            ·                     (k[omitted], v)  k!=NULL; v!=NULL; key(k,v); +v
-2  ·       table        opt_test@v            ·                ·
-2  ·       spans        /!NULL-               ·                ·
-2  ·       limit        1                     ·                ·
+group           0  group   ·            ·                     (min)  ·
+ │              0  ·       aggregate 0  min(test.opt_test.v)  ·      ·
+ └── render     1  render  ·            ·                     (min)  ·
+      │         1  ·       render 0     test.opt_test.v       ·      ·
+      └── scan  2  scan    ·            ·                     (min)  ·
+·               2  ·       table        opt_test@v            ·      ·
+·               2  ·       spans        /!NULL-               ·      ·
+·               2  ·       limit        1                     ·      ·
 
 # Without the "v IS NOT NULL" constraint, this result would incorrectly be NULL.
 query I
@@ -1243,17 +1243,17 @@ SELECT MIN(v) FROM opt_test@primary
 5
 
 # Repeat test when there is an existing filter.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
 ----
-0  group   ·            ·                     (min)   ·
-0  ·       aggregate 0  min(test.opt_test.v)  ·       ·
-1  render  ·            ·                     (v)     v!=NULL; +v
-1  ·       render 0     test.opt_test.v       ·       ·
-2  scan    ·            ·                     (k, v)  k!=NULL; v!=NULL; key(k,v); +v
-2  ·       table        opt_test@v            ·       ·
-2  ·       spans        /!NULL-               ·       ·
-2  ·       filter       k != 4                ·       ·
+group           0  group   ·            ·                     (min)  ·
+ │              0  ·       aggregate 0  min(test.opt_test.v)  ·      ·
+ └── render     1  render  ·            ·                     (min)  ·
+      │         1  ·       render 0     test.opt_test.v       ·      ·
+      └── scan  2  scan    ·            ·                     (min)  ·
+·               2  ·       table        opt_test@v            ·      ·
+·               2  ·       spans        /!NULL-               ·      ·
+·               2  ·       filter       k != 4                ·      ·
 
 query I
 SELECT MIN(v) FROM opt_test WHERE k <> 4
@@ -1263,28 +1263,28 @@ SELECT MIN(v) FROM opt_test WHERE k <> 4
 # Check the optimization when the argument is non-trivial. The renderNode can't
 # present an ordering on v+1 so the optimization is not applied, but the IS NOT
 # NULL filter should be added.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
 ----
-0  group   ·            ·                                             (min)      ·
-0  ·       aggregate 0  min(test.opt_test.v + 1)                      ·          ·
-1  render  ·            ·                                             ("v + 1")  ·
-1  ·       render 0     test.opt_test.v + 1                           ·          ·
-2  scan    ·            ·                                             (k, v)     k!=NULL; v!=NULL; key(k)
-2  ·       table        opt_test@primary                              ·          ·
-2  ·       spans        /!NULL-                                       ·          ·
-2  ·       filter       (k != 4) AND ((v + 1) IS NOT NULL)  ·          ·
+group           0  group   ·            ·                                   (min)  ·
+ │              0  ·       aggregate 0  min(test.opt_test.v + 1)            ·      ·
+ └── render     1  render  ·            ·                                   (min)  ·
+      │         1  ·       render 0     test.opt_test.v + 1                 ·      ·
+      └── scan  2  scan    ·            ·                                   (min)  ·
+·               2  ·       table        opt_test@primary                    ·      ·
+·               2  ·       spans        /!NULL-                             ·      ·
+·               2  ·       filter       (k != 4) AND ((v + 1) IS NOT NULL)  ·      ·
 
 # Verify that we don't use the optimization if there is a GROUP BY.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
 ----
-0  group  ·            ·                     (min)   ·
-0  ·      aggregate 0  min(test.opt_test.v)  ·       ·
-0  ·      group by     @1-@1                 ·       ·
-1  scan   ·            ·                     (k, v)  k!=NULL; key(k)
-1  ·      table        opt_test@primary      ·       ·
-1  ·      spans        ALL                   ·       ·
+group      0  group  ·            ·                     (min)  ·
+ │         0  ·      aggregate 0  min(test.opt_test.v)  ·      ·
+ │         0  ·      group by     @1-@1                 ·      ·
+ └── scan  1  scan   ·            ·                     (min)  ·
+·          1  ·      table        opt_test@primary      ·      ·
+·          1  ·      spans        ALL                   ·      ·
 
 query I rowsort
 SELECT MIN(v) FROM opt_test GROUP BY k
@@ -1345,21 +1345,21 @@ SELECT (b, a) FROM ab GROUP BY (b, a)
 (2,1)
 (4,3)
 
-query ITTT
+query TTT
 EXPLAIN(EXPRS) SELECT (b, a) FROM ab GROUP BY (b, a)
 ----
-0  render  ·            ·
-0  ·       render 0     (b, a)
-1  group   ·            ·
-1  ·       aggregate 0  b
-1  ·       aggregate 1  a
-1  ·       group by     @1-@2
-2  render  ·            ·
-2  ·       render 0     b
-2  ·       render 1     a
-3  scan    ·            ·
-3  ·       table        ab@primary
-3  ·       spans        ALL
+render               ·            ·
+ │                   render 0     (b, a)
+ └── group           ·            ·
+      │              aggregate 0  b
+      │              aggregate 1  a
+      │              group by     @1-@2
+      └── render     ·            ·
+           │         render 0     b
+           │         render 1     a
+           └── scan  ·            ·
+·                    table        ab@primary
+·                    spans        ALL
 
 query TT rowsort
 SELECT MIN(y), (b, a)
@@ -1370,29 +1370,29 @@ d  (2,1)
 b  (4,3)
 d  (4,3)
 
-query ITTT
+query TTT
 EXPLAIN(EXPRS)
    SELECT MIN(y), (b, a)
      FROM ab, xy GROUP BY (x, (a, b))
 ----
-0  render  ·            ·
-0  ·       render 0     min
-0  ·       render 1     (b, a)
-1  group   ·            ·
-1  ·       aggregate 0  min(y)
-1  ·       aggregate 1  b
-1  ·       aggregate 2  a
-1  ·       group by     @1-@3
-2  render  ·            ·
-2  ·       render 0     x
-2  ·       render 1     a
-2  ·       render 2     b
-2  ·       render 3     y
-3  join    ·            ·
-3  ·       type         cross
-4  scan    ·            ·
-4  ·       table        ab@primary
-4  ·       spans        ALL
-4  scan    ·            ·
-4  ·       table        xy@primary
-4  ·       spans        ALL
+render                    ·            ·
+ │                        render 0     min
+ │                        render 1     (b, a)
+ └── group                ·            ·
+      │                   aggregate 0  min(y)
+      │                   aggregate 1  b
+      │                   aggregate 2  a
+      │                   group by     @1-@3
+      └── render          ·            ·
+           │              render 0     x
+           │              render 1     a
+           │              render 2     b
+           │              render 3     y
+           └── join       ·            ·
+                │         type         cross
+                ├── scan  ·            ·
+                │         table        ab@primary
+                │         spans        ALL
+                └── scan  ·            ·
+·                         table        xy@primary
+·                         spans        ALL

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -633,17 +633,17 @@ statement ok
 CREATE TABLE s (k1 INT, k2 INT, v INT, PRIMARY KEY (k1,k2))
 
 # Verify limits and orderings are propagated correctly to the select.
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (METADATA) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
 ----
-Level  Type    Field  Description  Columns               Ordering
-0      split   ·      ·            (key, pretty)         ·
-1      limit   ·      ·            (k1, k2)              k1!=NULL; k2!=NULL; key(k1,k2); +k1
-2      render  ·      ·            (k1, k2)              k1!=NULL; k2!=NULL; key(k1,k2); +k1
-3      scan    ·      ·            (k1, k2, v[omitted])  k1!=NULL; k2!=NULL; key(k1,k2); +k1
-3      ·       table  s@primary    ·                     ·
-3      ·       spans  ALL          ·                     ·
-3      ·       limit  3            ·                     ·
+Tree                 Level  Type    Field  Description  Columns        Ordering
+split                0      split   ·      ·            (key, pretty)  ·
+ └── limit           1      limit   ·      ·            (key, pretty)  ·
+      └── render     2      render  ·      ·            (key, pretty)  ·
+           └── scan  3      scan    ·      ·            (key, pretty)  ·
+·                    3      ·       table  s@primary    ·              ·
+·                    3      ·       spans  ALL          ·              ·
+·                    3      ·       limit  3            ·              ·
 
 # Verify that impure defaults are evaluated separately on each row
 # (#14352)

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
@@ -71,13 +71,13 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 statement ok
 CREATE INDEX ON t (b, a) STORING (c)
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -92,13 +92,13 @@ x  5
 ü  5
 ü  6
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_b_a_idx
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_b_a_idx
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -133,13 +133,13 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -154,13 +154,13 @@ aa  3
 AA  1
 AA  2
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_b_a_idx
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_b_a_idx
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -180,13 +180,13 @@ SELECT b, a FROM t ORDER BY b, a
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -199,13 +199,13 @@ aa  3
 AA  1
 AA  2
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_b_a_idx
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_b_a_idx
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
@@ -71,13 +71,13 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 statement ok
 CREATE INDEX ON t (a, b) STORING (c)
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_a_b_idx
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_a_b_idx
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -92,13 +92,13 @@ B  3
 ü  6
 x  5
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -133,13 +133,13 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_a_b_idx
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_a_b_idx
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -154,13 +154,13 @@ BB  3
 üü  6
 xx  5
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -180,13 +180,13 @@ SELECT b, a FROM t ORDER BY b, a
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_a_b_idx
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_a_b_idx
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -195,13 +195,13 @@ SELECT a, b FROM t ORDER BY a, b
 üü  6
 xx  5
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
@@ -28,13 +28,13 @@ INSERT INTO t VALUES
 statement ok
 CREATE UNIQUE INDEX ON t (b, a)
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -49,13 +49,13 @@ x  5
 ü  5
 ü  6
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_b_a_key
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_b_a_key
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -90,13 +90,13 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -111,13 +111,13 @@ aa  3
 AA  1
 AA  2
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_b_a_key
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_b_a_key
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -137,13 +137,13 @@ SELECT b, a FROM t ORDER BY b, a
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -156,13 +156,13 @@ aa  3
 AA  1
 AA  2
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_b_a_key
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_b_a_key
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
@@ -28,13 +28,13 @@ INSERT INTO t VALUES
 statement ok
 CREATE UNIQUE INDEX ON t (a, b)
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_a_b_key
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_a_b_key
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -49,13 +49,13 @@ B  3
 ü  6
 x  5
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -90,13 +90,13 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_a_b_key
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_a_b_key
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -111,13 +111,13 @@ BB  3
 üü  6
 xx  5
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -137,13 +137,13 @@ SELECT b, a FROM t ORDER BY b, a
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY a, b
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@t_a_b_key
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@t_a_b_key
+·          spans  ALL
 
 query TI
 SELECT a, b FROM t ORDER BY a, b
@@ -152,13 +152,13 @@ SELECT a, b FROM t ORDER BY a, b
 üü  6
 xx  5
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, a FROM t ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -117,12 +117,12 @@ SELECT 'NaN'::decimal, '-NaN'::decimal, 'sNaN'::decimal, '-sNaN'::decimal
 ----
 NaN NaN NaN NaN
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t2 WHERE d IS NaN and v IS NaN
 ----
-0  scan  ·      ·
-0  ·     table  t2@primary
-0  ·     spans  /NaN/NaN-/NaN/NaN/#
+scan  ·      ·
+·     table  t2@primary
+·     spans  /NaN/NaN-/NaN/NaN/#
 
 query RR
 SELECT * FROM t2 WHERE d IS NaN and v IS NaN
@@ -130,24 +130,24 @@ SELECT * FROM t2 WHERE d IS NaN and v IS NaN
 NaN NaN
 
 # The NaN suffix is decimalNaNDesc, not decimalNaN(Asc).
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t2 WHERE d = 'Infinity' and v = 'Infinity'
 ----
-0  scan  ·      ·
-0  ·     table  t2@primary
-0  ·     spans  /Infinity/Infinity-/Infinity/Infinity/#
+scan  ·      ·
+·     table  t2@primary
+·     spans  /Infinity/Infinity-/Infinity/Infinity/#
 
 query RR
 SELECT * FROM t2 WHERE d = 'Infinity' and v = 'Infinity'
 ----
 Infinity Infinity
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t2 WHERE d = '-Infinity' and v = '-Infinity'
 ----
-0  scan  ·      ·
-0  ·     table  t2@primary
-0  ·     spans  /-Infinity/-Infinity-/-Infinity/-Infinity/#
+scan  ·      ·
+·     table  t2@primary
+·     spans  /-Infinity/-Infinity-/-Infinity/-Infinity/#
 
 query RR
 SELECT * FROM t2 WHERE d = '-Infinity' and v = '-Infinity'
@@ -204,29 +204,29 @@ Infinity
 # - `WHERE d = 'NaN'` should also perform a point lookup.
 # - `WHERE isnan(d)` is a function so it can't perform a point lookup.
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM s WHERE d IS NaN
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  s@s_d_idx
-1  ·       spans  /NaN-/-Infinity
+render     ·      ·
+ └── scan  ·      ·
+·          table  s@s_d_idx
+·          spans  /NaN-/-Infinity
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM s WHERE d = 'NaN'
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  s@s_d_idx
-1  ·       spans  /NaN-/-Infinity
+render     ·      ·
+ └── scan  ·      ·
+·          table  s@s_d_idx
+·          spans  /NaN-/-Infinity
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM s WHERE isnan(d)
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  s@s_d_idx
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  s@s_d_idx
+·          spans  ALL
 
 query R
 SELECT * FROM s WHERE d = 'NaN'

--- a/pkg/sql/logictest/testdata/logic_test/deep_interleaving
+++ b/pkg/sql/logictest/testdata/logic_test/deep_interleaving
@@ -64,12 +64,12 @@ INSERT INTO level4 VALUES
   (3, 20, 100), (3, 20, 200), (3, 20, 300),
   (3, 30, 100), (3, 30, 200), (3, 30, 300)
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM level4
 ----
-0  scan  ·      ·
-0  ·     table  level4@primary
-0  ·     spans  ALL
+scan  ·      ·
+·     table  level4@primary
+·     spans  ALL
 
 query III rowsort
 SELECT * FROM level4
@@ -106,12 +106,12 @@ SELECT * FROM level4
 # constraining the value of k2 or k3. This is confusing on first glance because
 # the second interleave in the hierarchy doesn't contain any new primary key
 # columns on top of the first interleave.
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 ----
-0  scan  ·      ·
-0  ·     table  level4@primary
-0  ·     spans  /2/#/52/1/#/53/1-/2/#/52/1/#/53/2
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/52/1/#/53/1-/2/#/52/1/#/53/2
 
 query III rowsort
 SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
@@ -126,12 +126,12 @@ SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 2  30  200
 2  30  300
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 ----
-0  scan  ·      ·
-0  ·     table  level4@primary
-0  ·     spans  /2/#/52/1/#/53/1/11-/2/#/52/1/#/53/1/30
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/52/1/#/53/1/11-/2/#/52/1/#/53/1/30
 
 query III rowsort
 SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
@@ -140,24 +140,24 @@ SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 2  20  200
 2  20  300
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
 ----
-0  scan  ·      ·
-0  ·     table  level4@primary
-0  ·     spans  /2/#/52/1/#/53/1/20/101/#/54/1-/2/#/52/1/#/53/1/20/299/#/54/1/#
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/52/1/#/53/1/20/101/#/54/1-/2/#/52/1/#/53/1/20/299/#/54/1/#
 
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
 ----
 2  20  200
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
 ----
-0  scan  ·      ·
-0  ·     table  level4@primary
-0  ·     spans  /2/#/52/1/#/53/1/20/200/#/54/1-/2/#/52/1/#/53/1/20/200/#/54/1/#
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/52/1/#/53/1/20/200/#/54/1-/2/#/52/1/#/53/1/20/200/#/54/1/#
 
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -140,16 +140,16 @@ k v
 7 8
 
 # Check that EXPLAIN does not destroy data (#6613)
-query ITTT colnames
+query TTT colnames
 EXPLAIN DELETE FROM unindexed
 ----
-Level  Type    Field  Description
-0      delete  ·      ·
-0      ·       from   unindexed
-1      render  ·      ·
-2      scan    ·      ·
-2      ·       table  unindexed@primary
-2      ·       spans  ALL
+Tree            Field  Description
+delete          ·      ·
+ │              from   unindexed
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  unindexed@primary
+·               spans  ALL
 
 query II colnames,rowsort
 SELECT k, v FROM unindexed
@@ -179,16 +179,16 @@ DELETE FROM indexed WHERE value = 5
 statement ok
 INSERT INTO unindexed VALUES (1, 9), (8, 2), (3, 7), (6, 4)
 
-query ITTT
+query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v
 ----
-0  delete  ·      ·
-0  ·       from   unindexed
-1  nosort  ·      ·
-1  ·       order  +v
-2  scan    ·      ·
-2  ·       table  unindexed@primary
-2  ·       spans  ALL
+delete          ·      ·
+ │              from   unindexed
+ └── nosort     ·      ·
+      │         order  +v
+      └── scan  ·      ·
+·               table  unindexed@primary
+·               spans  ALL
 
 query II
 DELETE FROM unindexed WHERE k > 1 AND v < 7 ORDER BY v DESC RETURNING v,k
@@ -207,16 +207,16 @@ DELETE FROM unindexed ORDER BY v RETURNING k,v
 statement ok
 INSERT INTO unindexed VALUES (1, 2), (3, 4), (5, 6), (7, 8)
 
-query ITTT
+query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 5 LIMIT 10
 ----
-0  delete  ·      ·
-0  ·       from   unindexed
-1  limit   ·      ·
-2  render  ·      ·
-3  scan    ·      ·
-3  ·       table  unindexed@primary
-3  ·       spans  ALL
+delete               ·      ·
+ │                   from   unindexed
+ └── limit           ·      ·
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  unindexed@primary
+·                    spans  ALL
 
 query I
 SELECT COUNT(*) FROM [DELETE FROM unindexed LIMIT 2 RETURNING v]
@@ -233,43 +233,43 @@ SELECT COUNT(*) FROM [DELETE FROM unindexed LIMIT 5 RETURNING v]
 ----
 1
 
-query ITTT
+query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10
 ----
-0  delete  ·      ·
-0  ·       from   indexed
-1  limit   ·      ·
-2  render  ·      ·
-3  scan    ·      ·
-3  ·       table  indexed@indexed_value_idx
-3  ·       spans  /5-/6
-3  ·       limit  10
+delete               ·      ·
+ │                   from   indexed
+ └── limit           ·      ·
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  indexed@indexed_value_idx
+·                    spans  /5-/6
+·                    limit  10
 
-query ITTT
+query TTT
 EXPLAIN DELETE FROM indexed LIMIT 10
 ----
-0  delete  ·      ·
-0  ·       from   indexed
-1  limit   ·      ·
-2  render  ·      ·
-3  scan    ·      ·
-3  ·       table  indexed@primary
-3  ·       spans  ALL
-3  ·       limit  10
+delete               ·      ·
+ │                   from   indexed
+ └── limit           ·      ·
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  indexed@primary
+·                    spans  ALL
+·                    limit  10
 
-query ITTT
+query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 ----
-0  delete      ·      ·
-0  ·           from   indexed
-1  limit       ·      ·
-2  index-join  ·      ·
-3  scan        ·      ·
-3  ·           table  indexed@indexed_value_idx
-3  ·           spans  /5-/6
-3  ·           limit  10
-3  scan        ·      ·
-3  ·           table  indexed@primary
+delete                ·      ·
+ │                    from   indexed
+ └── limit            ·      ·
+      └── index-join  ·      ·
+           ├── scan   ·      ·
+           │          table  indexed@indexed_value_idx
+           │          spans  /5-/6
+           │          limit  10
+           └── scan   ·      ·
+·                     table  indexed@primary
 
 # Ensure that if the fast path is selected, DELETE is still a valid
 # data source (#19805).

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -48,14 +48,14 @@ SELECT y FROM (SELECT DISTINCT y, z FROM xyz)
 2
 
 # TODO(vivek): Use the secondary index. Use distinct in index selection.
-query ITTT
+query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz
 ----
-0  distinct  ·      ·
-1  render    ·      ·
-2  scan      ·      ·
-2  ·         table  xyz@primary
-2  ·         spans  ALL
+distinct        ·      ·
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  xyz@primary
+·               spans  ALL
 
 query II partialsort(2)
 SELECT DISTINCT y, z FROM xyz ORDER BY z
@@ -66,15 +66,15 @@ SELECT DISTINCT y, z FROM xyz ORDER BY z
 5 6
 2 9
 
-query ITTT
+query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
-0  distinct  ·      ·
-0  ·         order key    y, z
-1  render    ·      ·
-2  scan      ·      ·
-2  ·         table  xyz@foo
-2  ·         spans  ALL
+distinct        ·          ·
+ │              order key  y, z
+ └── render     ·          ·
+      └── scan  ·          ·
+·               table      xyz@foo
+·               spans      ALL
 
 query II partialsort(1)
 SELECT DISTINCT y, z FROM xyz ORDER BY y
@@ -85,17 +85,17 @@ SELECT DISTINCT y, z FROM xyz ORDER BY y
 3 5
 5 6
 
-query ITTT
+query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
 ----
-0  distinct  ·      ·
-0  ·         order key    y
-1  sort      ·      ·
-1  ·         order  +y
-2  render    ·      ·
-3  scan      ·      ·
-3  ·         table  xyz@foo
-3  ·         spans  ALL
+distinct             ·          ·
+ │                   order key  y
+ └── sort            ·          ·
+      │              order      +y
+      └── render     ·          ·
+           └── scan  ·          ·
+·                    table      xyz@foo
+·                    spans      ALL
 
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY y, z
@@ -106,17 +106,17 @@ SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 3 5
 5 6
 
-query ITTT
+query TTT
 EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 ----
-0  distinct  ·      ·
-0  ·         order key    y, z
-1  sort      ·      ·
-1  ·         order  +y,+z
-2  render    ·      ·
-3  scan      ·      ·
-3  ·         table  xyz@foo
-3  ·         spans  ALL
+distinct             ·          ·
+ │                   order key  y, z
+ └── sort            ·          ·
+      │              order      +y,+z
+      └── render     ·          ·
+           └── scan  ·          ·
+·                    table      xyz@foo
+·                    spans      ALL
 
 query I
 SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
@@ -125,17 +125,17 @@ SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
 8
 11
 
-query ITTT
+query TTT
 EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 ----
-0  distinct  ·      ·
-0  ·         order key    y + z
-1  sort      ·      ·
-1  ·         order  +"y + z"
-2  render    ·      ·
-3  scan      ·      ·
-3  ·         table  xyz@primary
-3  ·         spans  ALL
+distinct             ·          ·
+ │                   order key  y + z
+ └── sort            ·          ·
+      │              order      +"y + z"
+      └── render     ·          ·
+           └── scan  ·          ·
+·                    table      xyz@primary
+·                    spans      ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by z
@@ -144,16 +144,16 @@ SELECT DISTINCT y AS w FROM xyz ORDER by z
 3
 5
 
-query ITTT
+query TTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY z
 ----
-0  distinct  ·      ·
-1  nosort    ·      ·
-1  ·         order  +z
-2  render    ·      ·
-3  scan      ·      ·
-3  ·         table  xyz@foo
-3  ·         spans  ALL
+distinct             ·      ·
+ └── nosort          ·      ·
+      │              order  +z
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  xyz@foo
+·                    spans  ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by y
@@ -162,17 +162,17 @@ SELECT DISTINCT y AS w FROM xyz ORDER by y
 3
 5
 
-query ITTT
+query TTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
 ----
-0  distinct  ·      ·
-0  ·         order key    w
-1  sort      ·      ·
-1  ·         order  +w
-2  render    ·      ·
-3  scan      ·      ·
-3  ·         table  xyz@foo
-3  ·         spans  ALL
+distinct             ·          ·
+ │                   order key  w
+ └── sort            ·          ·
+      │              order      +w
+      └── render     ·          ·
+           └── scan  ·          ·
+·                    table      xyz@foo
+·                    spans      ALL
 
 # Insert NULL values for z.
 statement ok
@@ -204,20 +204,20 @@ SELECT COUNT(*) FROM (SELECT DISTINCT y FROM xyz)
 3
 
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT x FROM xyz
 ----
-0  render  ·      ·            (x)                          x!=NULL; key(x)
-1  scan    ·      ·            (x, y[omitted], z[omitted])  x!=NULL; key(x)
-1  ·       table  xyz@primary  ·                            ·
-1  ·       spans  ALL          ·                            ·
+render     0  render  ·      ·            (x)  x!=NULL; key(x)
+ └── scan  1  scan    ·      ·            (x)  x!=NULL; key(x)
+·          1  ·       table  xyz@primary  ·    ·
+·          1  ·       spans  ALL          ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT x, y, z FROM xyz
 ----
-0  scan  ·      ·            (x, y, z)  x!=NULL; key(x)
-0  ·     table  xyz@primary  ·          ·
-0  ·     spans  ALL          ·          ·
+scan  0  scan  ·      ·            (x, y, z)  x!=NULL; key(x)
+·     0  ·     table  xyz@primary  ·          ·
+·     0  ·     spans  ALL          ·          ·
 
 statement ok
 CREATE TABLE abcd (
@@ -229,38 +229,38 @@ CREATE TABLE abcd (
   UNIQUE INDEX (d, b)
 )
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT 1, d, b FROM abcd ORDER BY d, b
 ----
-0  render  ·      ·                  ("1", d, b)                     "1"=CONST; d!=NULL; b!=NULL; key(d,b); +d,+b
-1  scan    ·      ·                  (a[omitted], b, c[omitted], d)  b!=NULL; d!=NULL; key(b,d); +d,+b
-1  ·       table  abcd@abcd_d_b_key  ·                               ·
-1  ·       spans  ALL                ·                               ·
+render     0  render  ·      ·                  ("1", d, b)  "1"=CONST; d!=NULL; b!=NULL; key(d,b); +d,+b
+ └── scan  1  scan    ·      ·                  ("1", d, b)  "1"=CONST; d!=NULL; b!=NULL; key(d,b); +d,+b
+·          1  ·       table  abcd@abcd_d_b_key  ·            ·
+·          1  ·       spans  ALL                ·            ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT a, b FROM abcd
 ----
-0  distinct  ·          ·             (a, b)                          a!=NULL; b!=NULL; key(a,b); +a,+b
-0  ·         order key  a, b          ·                               ·
-1  render    ·          ·             (a, b)                          a!=NULL; b!=NULL; +a,+b
-2  scan      ·          ·             (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b
-2  ·         table      abcd@primary  ·                               ·
-2  ·         spans      ALL           ·                               ·
+distinct        0  distinct  ·          ·             (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
+ │              0  ·         order key  a, b          ·       ·
+ └── render     1  render    ·          ·             (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
+      └── scan  2  scan      ·          ·             (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
+·               2  ·         table      abcd@primary  ·       ·
+·               2  ·         spans      ALL           ·       ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT a, b, c FROM abcd
 ----
-0  render  ·      ·             (a, b, c)              a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-1  scan    ·      ·             (a, b, c, d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-1  ·       table  abcd@primary  ·                      ·
-1  ·       spans  ALL           ·                      ·
+render     0  render  ·      ·             (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ └── scan  1  scan    ·      ·             (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·          1  ·       table  abcd@primary  ·          ·
+·          1  ·       spans  ALL           ·          ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT a, b, c, d FROM abcd
 ----
-0  scan  ·      ·             (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-0  ·     table  abcd@primary  ·             ·
-0  ·     spans  ALL           ·             ·
+scan  0  scan  ·      ·             (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·     0  ·     table  abcd@primary  ·             ·
+·     0  ·     spans  ALL           ·             ·
 
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
@@ -268,16 +268,16 @@ CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
 statement ok
 INSERT INTO kv VALUES (1, 1), (2, 2), (3, NULL), (4, NULL), (5, 5), (6, NULL)
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv
 ----
-Level  Type      Field     Description  Columns          Ordering
-0      distinct  ·         ·            (v)              weak-key(v)
-1      render    ·         ·            (v)              ·
-1      ·         render 0  test.kv.v    ·                ·
-2      scan      ·         ·            (k[omitted], v)  k!=NULL; key(k)
-2      ·         table     kv@primary   ·                ·
-2      ·         spans     ALL          ·                ·
+Tree            Level  Type      Field     Description  Columns  Ordering
+distinct        0      distinct  ·         ·            (v)      weak-key(v)
+ └── render     1      render    ·         ·            (v)      weak-key(v)
+      │         1      ·         render 0  test.kv.v    ·        ·
+      └── scan  2      scan      ·         ·            (v)      weak-key(v)
+·               2      ·         table     kv@primary   ·        ·
+·               2      ·         spans     ALL          ·        ·
 
 query I rowsort
 SELECT DISTINCT v FROM kv
@@ -288,17 +288,17 @@ NULL
 5
 
 # Verify we don't incorrectly elide the distinct node when we only have a weak key (#19343).
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx
 ----
-Level  Type      Field     Description  Columns          Ordering
-0      distinct  ·         ·            (v)              weak-key(v); +v
-0      ·         order key       v            ·                ·
-1      render    ·         ·            (v)              weak-key(v); +v
-1      ·         render 0  test.kv.v    ·                ·
-2      scan      ·         ·            (k[omitted], v)  weak-key(v); +v
-2      ·         table     kv@idx       ·                ·
-2      ·         spans     ALL          ·                ·
+Tree            Level  Type      Field      Description  Columns  Ordering
+distinct        0      distinct  ·          ·            (v)      weak-key(v); +v
+ │              0      ·         order key  v            ·        ·
+ └── render     1      render    ·          ·            (v)      weak-key(v); +v
+      │         1      ·         render 0   test.kv.v    ·        ·
+      └── scan  2      scan      ·          ·            (v)      weak-key(v); +v
+·               2      ·         table      kv@idx       ·        ·
+·               2      ·         spans      ALL          ·        ·
 
 query I rowsort
 SELECT DISTINCT v FROM kv@idx
@@ -309,15 +309,15 @@ NULL
 5
 
 # Here we can infer that v is not-NULL so eliding the node is correct.
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx WHERE v > 0
 ----
-Level  Type    Field     Description  Columns          Ordering
-0      render  ·         ·            (v)              v!=NULL; key(v)
-0      ·       render 0  test.kv.v    ·                ·
-1      scan    ·         ·            (k[omitted], v)  v!=NULL; key(v)
-1      ·       table     kv@idx       ·                ·
-1      ·       spans     /1-          ·                ·
+Tree       Level  Type    Field     Description  Columns  Ordering
+render     0      render  ·         ·            (v)      v!=NULL; key(v)
+ │         0      ·       render 0  test.kv.v    ·        ·
+ └── scan  1      scan    ·         ·            (v)      v!=NULL; key(v)
+·          1      ·       table     kv@idx       ·        ·
+·          1      ·       spans     /1-          ·        ·
 
 query I rowsort
 SELECT DISTINCT v FROM kv@idx WHERE v > 0
@@ -330,12 +330,12 @@ statement ok
 CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
 
 # In this case it is correct to elide the distinct node.
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv2@idx
 ----
-Level  Type    Field     Description  Columns          Ordering
-0      render  ·         ·            (v)              v!=NULL; key(v)
-0      ·       render 0  test.kv2.v   ·                ·
-1      scan    ·         ·            (k[omitted], v)  v!=NULL; key(v)
-1      ·       table     kv2@idx      ·                ·
-1      ·       spans     ALL          ·                ·
+Tree       Level  Type    Field     Description  Columns  Ordering
+render     0      render  ·         ·            (v)      v!=NULL; key(v)
+ │         0      ·       render 0  test.kv2.v   ·        ·
+ └── scan  1      scan    ·         ·            (v)      v!=NULL; key(v)
+·          1      ·       table     kv2@idx      ·        ·
+·          1      ·       spans     ALL          ·        ·

--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -40,18 +40,18 @@ INSERT INTO abc VALUES
 
 # 3/3 columns
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 ----
-0  distinct  ·            ·            (x, y, z)                              weak-key(x,y,z)
-0  ·         distinct on  x, y, z      ·                                      ·
-1  render    ·            ·            (x, y, z)                              ·
-1  ·         render 0     test.xyz.x   ·                                      ·
-1  ·         render 1     test.xyz.y   ·                                      ·
-1  ·         render 2     test.xyz.z   ·                                      ·
-2  scan      ·            ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-2  ·         table        xyz@primary  ·                                      ·
-2  ·         spans        ALL          ·                                      ·
+distinct        0  distinct  ·            ·            (x, y, z)  weak-key(x,y,z)
+ │              0  ·         distinct on  x, y, z      ·          ·
+ └── render     1  render    ·            ·            (x, y, z)  weak-key(x,y,z)
+      │         1  ·         render 0     test.xyz.x   ·          ·
+      │         1  ·         render 1     test.xyz.y   ·          ·
+      │         1  ·         render 2     test.xyz.z   ·          ·
+      └── scan  2  scan      ·            ·            (x, y, z)  weak-key(x,y,z)
+·               2  ·         table        xyz@primary  ·          ·
+·               2  ·         spans        ALL          ·          ·
 
 query III rowsort
 SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
@@ -63,20 +63,20 @@ SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 4 5 6
 4 1 6
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
 ----
-0  render    ·            ·            (x)                                    ·
-0  ·         render 0     x            ·                                      ·
-1  distinct  ·            ·            (x, z, y)                              weak-key(x,z,y)
-1  ·         distinct on  x, z, y      ·                                      ·
-2  render    ·            ·            (x, z, y)                              ·
-2  ·         render 0     test.xyz.x   ·                                      ·
-2  ·         render 1     test.xyz.z   ·                                      ·
-2  ·         render 2     test.xyz.y   ·                                      ·
-3  scan      ·            ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-3  ·         table        xyz@primary  ·                                      ·
-3  ·         spans        ALL          ·                                      ·
+render               0  render    ·            ·            (x)  ·
+ │                   0  ·         render 0     x            ·    ·
+ └── distinct        1  distinct  ·            ·            (x)  ·
+      │              1  ·         distinct on  x, z, y      ·    ·
+      └── render     2  render    ·            ·            (x)  ·
+           │         2  ·         render 0     test.xyz.x   ·    ·
+           │         2  ·         render 1     test.xyz.z   ·    ·
+           │         2  ·         render 2     test.xyz.y   ·    ·
+           └── scan  3  scan      ·            ·            (x)  ·
+·                    3  ·         table        xyz@primary  ·    ·
+·                    3  ·         spans        ALL          ·    ·
 
 query I rowsort
 SELECT DISTINCT ON (y, x, z) x FROM xyz
@@ -98,16 +98,16 @@ NULL
 6
 6
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
 ----
-0  render  ·         ·            (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b)
-0  ·       render 0  test.abc.a   ·          ·
-0  ·       render 1  test.abc.c   ·          ·
-0  ·       render 2  test.abc.b   ·          ·
-1  scan    ·         ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-1  ·       table     abc@primary  ·          ·
-1  ·       spans     ALL          ·          ·
+render     0  render  ·         ·            (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b)
+ │         0  ·       render 0  test.abc.a   ·          ·
+ │         0  ·       render 1  test.abc.c   ·          ·
+ │         0  ·       render 2  test.abc.b   ·          ·
+ └── scan  1  scan    ·         ·            (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b)
+·          1  ·       table     abc@primary  ·          ·
+·          1  ·       spans     ALL          ·          ·
 
 query TTT rowsort
 SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
@@ -117,14 +117,14 @@ SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
 1 2 2
 
 # Distinct node should be elided since we have a strong key.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a FROM abc
 ----
-0  render  ·         ·            (a)        a!=NULL
-0  ·       render 0  a            ·          ·
-1  scan    ·         ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-1  ·       table     abc@primary  ·          ·
-1  ·       spans     ALL          ·          ·
+render     0  render  ·         ·            (a)  a!=NULL
+ │         0  ·       render 0  a            ·    ·
+ └── scan  1  scan    ·         ·            (a)  a!=NULL
+·          1  ·       table     abc@primary  ·    ·
+·          1  ·       spans     ALL          ·    ·
 
 
 query T rowsort
@@ -136,20 +136,20 @@ SELECT DISTINCT ON (b, c, a) a FROM abc
 
 
 # Distinct node should be elided since we have a strong key.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 ----
-0  render  ·         ·            (b)                          b!=NULL; +b
-0  ·       render 0  b            ·                            ·
-1  sort    ·         ·            (b, c[omitted], a[omitted])  b!=NULL; c!=NULL; a!=NULL; key(b,c,a); +b
-1  ·       order     +b           ·                            ·
-2  render  ·         ·            (b, c[omitted], a[omitted])  b!=NULL; c!=NULL; a!=NULL; key(b,c,a)
-2  ·       render 0  test.abc.b   ·                            ·
-2  ·       render 1  NULL         ·                            ·
-2  ·       render 2  NULL         ·                            ·
-3  scan    ·         ·            (a[omitted], b, c[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-3  ·       table     abc@primary  ·                            ·
-3  ·       spans     ALL          ·                            ·
+render               0  render  ·         ·            (b)  b!=NULL; +b
+ │                   0  ·       render 0  b            ·    ·
+ └── sort            1  sort    ·         ·            (b)  b!=NULL; +b
+      │              1  ·       order     +b           ·    ·
+      └── render     2  render  ·         ·            (b)  b!=NULL; +b
+           │         2  ·       render 0  test.abc.b   ·    ·
+           │         2  ·       render 1  NULL         ·    ·
+           │         2  ·       render 2  NULL         ·    ·
+           └── scan  3  scan    ·         ·            (b)  b!=NULL; +b
+·                    3  ·       table     abc@primary  ·    ·
+·                    3  ·       spans     ALL          ·    ·
 
 
 query T rowsort
@@ -162,17 +162,17 @@ SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 
 # 2/3 columns
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y) y, x FROM xyz
 ----
-0  distinct  ·            ·            (y, x)                                          weak-key(y,x)
-0  ·         distinct on  y, x         ·                                               ·
-1  render    ·            ·            (y, x)                                          ·
-1  ·         render 0     test.xyz.y   ·                                               ·
-1  ·         render 1     test.xyz.x   ·                                               ·
-2  scan      ·            ·            (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-2  ·         table        xyz@primary  ·                                               ·
-2  ·         spans        ALL          ·                                               ·
+distinct        0  distinct  ·            ·            (y, x)  weak-key(y,x)
+ │              0  ·         distinct on  y, x         ·       ·
+ └── render     1  render    ·            ·            (y, x)  weak-key(y,x)
+      │         1  ·         render 0     test.xyz.y   ·       ·
+      │         1  ·         render 1     test.xyz.x   ·       ·
+      └── scan  2  scan      ·            ·            (y, x)  weak-key(y,x)
+·               2  ·         table        xyz@primary  ·       ·
+·               2  ·         spans        ALL          ·       ·
 
 query II rowsort
 SELECT DISTINCT ON (x, y) y, x FROM xyz
@@ -183,19 +183,19 @@ SELECT DISTINCT ON (x, y) y, x FROM xyz
 5 4
 1 4
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
 ----
-0  render    ·            ·            (x)                                             ·
-0  ·         render 0     x            ·                                               ·
-1  distinct  ·            ·            (x, y)                                          weak-key(x,y)
-1  ·         distinct on  x, y         ·                                               ·
-2  render    ·            ·            (x, y)                                          ·
-2  ·         render 0     test.xyz.x   ·                                               ·
-2  ·         render 1     test.xyz.y   ·                                               ·
-3  scan      ·            ·            (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-3  ·         table        xyz@primary  ·                                               ·
-3  ·         spans        ALL          ·                                               ·
+render               0  render    ·            ·            (x)  ·
+ │                   0  ·         render 0     x            ·    ·
+ └── distinct        1  distinct  ·            ·            (x)  ·
+      │              1  ·         distinct on  x, y         ·    ·
+      └── render     2  render    ·            ·            (x)  ·
+           │         2  ·         render 0     test.xyz.x   ·    ·
+           │         2  ·         render 1     test.xyz.y   ·    ·
+           └── scan  3  scan      ·            ·            (x)  ·
+·                    3  ·         table        xyz@primary  ·    ·
+·                    3  ·         spans        ALL          ·    ·
 
 query I rowsort
 SELECT DISTINCT ON (y, x) x FROM xyz
@@ -215,43 +215,43 @@ SELECT DISTINCT ON (x, y) y FROM xyz
 5
 1
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
 ----
-0  distinct  ·            ·            (x, y)                                          weak-key(x,y)
-0  ·         distinct on  x, y         ·                                               ·
-1  render    ·            ·            (x, y)                                          ·
-1  ·         render 0     test.xyz.x   ·                                               ·
-1  ·         render 1     test.xyz.y   ·                                               ·
-2  scan      ·            ·            (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-2  ·         table        xyz@primary  ·                                               ·
-2  ·         spans        ALL          ·                                               ·
+distinct        0  distinct  ·            ·            (x, y)  weak-key(x,y)
+ │              0  ·         distinct on  x, y         ·       ·
+ └── render     1  render    ·            ·            (x, y)  weak-key(x,y)
+      │         1  ·         render 0     test.xyz.x   ·       ·
+      │         1  ·         render 1     test.xyz.y   ·       ·
+      └── scan  2  scan      ·            ·            (x, y)  weak-key(x,y)
+·               2  ·         table        xyz@primary  ·       ·
+·               2  ·         spans        ALL          ·       ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
 ----
-0  distinct  ·            ·             (pk1, x)                                        pk1!=NULL; weak-key(pk1,x); +pk1
-0  ·         distinct on  pk1, x        ·                                               ·
-0  ·         order key    pk1           ·                                               ·
-1  render    ·            ·             (pk1, x)                                        pk1!=NULL; +pk1
-1  ·         render 0     test.xyz.pk1  ·                                               ·
-1  ·         render 1     test.xyz.x    ·                                               ·
-2  scan      ·            ·             (x, y[omitted], z[omitted], pk1, pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
-2  ·         table        xyz@primary   ·                                               ·
-2  ·         spans        ALL           ·                                               ·
+distinct        0  distinct  ·            ·             (pk1, x)  pk1!=NULL; weak-key(pk1,x); +pk1
+ │              0  ·         distinct on  pk1, x        ·         ·
+ │              0  ·         order key    pk1           ·         ·
+ └── render     1  render    ·            ·             (pk1, x)  pk1!=NULL; weak-key(pk1,x); +pk1
+      │         1  ·         render 0     test.xyz.pk1  ·         ·
+      │         1  ·         render 1     test.xyz.x    ·         ·
+      └── scan  2  scan      ·            ·             (pk1, x)  pk1!=NULL; weak-key(pk1,x); +pk1
+·               2  ·         table        xyz@primary   ·         ·
+·               2  ·         spans        ALL           ·         ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
 ----
-0  render    ·            ·            (a, b)     a!=NULL; b!=NULL; +a
-0  ·         render 0     a            ·          ·
-0  ·         render 1     b            ·          ·
-1  distinct  ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,c); +a
-1  ·         distinct on  a, c         ·          ·
-1  ·         order key    a            ·          ·
-2  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
-2  ·         table        abc@primary  ·          ·
-2  ·         spans        ALL          ·          ·
+render          0  render    ·            ·            (a, b)  a!=NULL; b!=NULL; +a
+ │              0  ·         render 0     a            ·       ·
+ │              0  ·         render 1     b            ·       ·
+ └── distinct   1  distinct  ·            ·            (a, b)  a!=NULL; b!=NULL; +a
+      │         1  ·         distinct on  a, c         ·       ·
+      │         1  ·         order key    a            ·       ·
+      └── scan  2  scan      ·            ·            (a, b)  a!=NULL; b!=NULL; +a
+·               2  ·         table        abc@primary  ·       ·
+·               2  ·         spans        ALL          ·       ·
 
 query TT rowsort
 SELECT DISTINCT ON (a, c) a, b FROM abc ORDER BY a, c, b
@@ -259,19 +259,19 @@ SELECT DISTINCT ON (a, c) a, b FROM abc ORDER BY a, c, b
 1 1
 1 1
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
 ----
-0  distinct  ·            ·            (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(c,a); +a
-0  ·         distinct on  c, a         ·          ·
-0  ·         order key    a            ·          ·
-1  render    ·            ·            (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(b,c,a); +a
-1  ·         render 0     test.abc.b   ·          ·
-1  ·         render 1     test.abc.c   ·          ·
-1  ·         render 2     test.abc.a   ·          ·
-2  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
-2  ·         table        abc@primary  ·          ·
-2  ·         spans        ALL          ·          ·
+distinct        0  distinct  ·            ·            (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(c,a); +a
+ │              0  ·         distinct on  c, a         ·          ·
+ │              0  ·         order key    a            ·          ·
+ └── render     1  render    ·            ·            (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(c,a); +a
+      │         1  ·         render 0     test.abc.b   ·          ·
+      │         1  ·         render 1     test.abc.c   ·          ·
+      │         1  ·         render 2     test.abc.a   ·          ·
+      └── scan  2  scan      ·            ·            (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(c,a); +a
+·               2  ·         table        abc@primary  ·          ·
+·               2  ·         spans        ALL          ·          ·
 
 # We wrap this with an ORDER BY otherwise this would be non-deterministic.
 query TTT rowsort
@@ -292,18 +292,18 @@ SELECT DISTINCT ON (y) y FROM xyz
 
 # Check that distinct propagates the smaller, tighter key (pk1) as opposed to
 # the original key (pk1, pk2).
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (pk1) pk1, pk2 FROM xyz
 ----
-0  distinct  ·            ·             (pk1, pk2)                                      pk1!=NULL; pk2!=NULL; key(pk1); +pk1
-0  ·         distinct on  pk1           ·                                               ·
-0  ·         order key    pk1           ·                                               ·
-1  render    ·            ·             (pk1, pk2)                                      pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
-1  ·         render 0     test.xyz.pk1  ·                                               ·
-1  ·         render 1     test.xyz.pk2  ·                                               ·
-2  scan      ·            ·             (x[omitted], y[omitted], z[omitted], pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
-2  ·         table        xyz@primary   ·                                               ·
-2  ·         spans        ALL           ·                                               ·
+distinct        0  distinct  ·            ·             (pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1); +pk1
+ │              0  ·         distinct on  pk1           ·           ·
+ │              0  ·         order key    pk1           ·           ·
+ └── render     1  render    ·            ·             (pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1); +pk1
+      │         1  ·         render 0     test.xyz.pk1  ·           ·
+      │         1  ·         render 1     test.xyz.pk2  ·           ·
+      └── scan  2  scan      ·            ·             (pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1); +pk1
+·               2  ·         table        xyz@primary   ·           ·
+·               2  ·         spans        ALL           ·           ·
 
 query T rowsort
 SELECT DISTINCT ON (c) a FROM abc
@@ -328,21 +328,21 @@ SELECT DISTINCT ON (a) a, b, c FROM abc ORDER BY a, b, c
 # an explicit order from ORDER BY.
 # Note that the -c ordering was reduced after the distinct: this is because
 # we have a strong key on 'a' so ordering after '+a' is unnecessary.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-0  distinct  ·            ·            (a, c)     a!=NULL; c!=NULL; key(a); +a
-0  ·         distinct on  a            ·          ·
-0  ·         order key    a            ·          ·
-1  sort      ·            ·            (a, c)     a!=NULL; c!=NULL; +a,-c
-1  ·         order        +a,-c,+b     ·          ·
-2  render    ·            ·            (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b); +a
-2  ·         render 0     test.abc.a   ·          ·
-2  ·         render 1     test.abc.c   ·          ·
-2  ·         render 2     test.abc.b   ·          ·
-3  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
-3  ·         table        abc@primary  ·          ·
-3  ·         spans        ALL          ·          ·
+distinct             0  distinct  ·            ·            (a, c)  a!=NULL; c!=NULL; key(a); +a
+ │                   0  ·         distinct on  a            ·       ·
+ │                   0  ·         order key    a            ·       ·
+ └── sort            1  sort      ·            ·            (a, c)  a!=NULL; c!=NULL; key(a); +a
+      │              1  ·         order        +a,-c,+b     ·       ·
+      └── render     2  render    ·            ·            (a, c)  a!=NULL; c!=NULL; key(a); +a
+           │         2  ·         render 0     test.abc.a   ·       ·
+           │         2  ·         render 1     test.abc.c   ·       ·
+           │         2  ·         render 2     test.abc.b   ·       ·
+           └── scan  3  scan      ·            ·            (a, c)  a!=NULL; c!=NULL; key(a); +a
+·                    3  ·         table        abc@primary  ·       ·
+·                    3  ·         spans        ALL          ·       ·
 
 query TT
 SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
@@ -362,19 +362,19 @@ SELECT DISTINCT ON (y) x, y, z FROM xyz ORDER BY x, y
 statement error SELECT DISTINCT ON expressions must be a prefix of or include all ORDER BY expressions
 SELECT DISTINCT ON (y, z) x, y, z FROM xyz ORDER BY x
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 ----
-0  distinct  ·            ·            (x)                                                      weak-key(x); -x
-0  ·         distinct on  x            ·                                                        ·
-0  ·         order key    x            ·                                                        ·
-1  sort      ·            ·            (x)                                                      -x
-1  ·         order        -x           ·                                                        ·
-2  render    ·            ·            (x)                                                      ·
-2  ·         render 0     test.xyz.x   ·                                                        ·
-3  scan      ·            ·            (x, y[omitted], z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-3  ·         table        xyz@primary  ·                                                        ·
-3  ·         spans        ALL          ·                                                        ·
+distinct             0  distinct  ·            ·            (x)  weak-key(x); -x
+ │                   0  ·         distinct on  x            ·    ·
+ │                   0  ·         order key    x            ·    ·
+ └── sort            1  sort      ·            ·            (x)  weak-key(x); -x
+      │              1  ·         order        -x           ·    ·
+      └── render     2  render    ·            ·            (x)  weak-key(x); -x
+           │         2  ·         render 0     test.xyz.x   ·    ·
+           └── scan  3  scan      ·            ·            (x)  weak-key(x); -x
+·                    3  ·         table        xyz@primary  ·    ·
+·                    3  ·         spans        ALL          ·    ·
 
 query I
 SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
@@ -383,21 +383,21 @@ SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 2
 1
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
 ----
-0  distinct  ·            ·            (y, z, x)                              weak-key(z,x); +z
-0  ·         distinct on  z, x         ·                                      ·
-0  ·         order key    z            ·                                      ·
-1  sort      ·            ·            (y, z, x)                              +z
-1  ·         order        +z           ·                                      ·
-2  render    ·            ·            (y, z, x)                              ·
-2  ·         render 0     test.xyz.y   ·                                      ·
-2  ·         render 1     test.xyz.z   ·                                      ·
-2  ·         render 2     test.xyz.x   ·                                      ·
-3  scan      ·            ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-3  ·         table        xyz@primary  ·                                      ·
-3  ·         spans        ALL          ·                                      ·
+distinct             0  distinct  ·            ·            (y, z, x)  weak-key(z,x); +z
+ │                   0  ·         distinct on  z, x         ·          ·
+ │                   0  ·         order key    z            ·          ·
+ └── sort            1  sort      ·            ·            (y, z, x)  weak-key(z,x); +z
+      │              1  ·         order        +z           ·          ·
+      └── render     2  render    ·            ·            (y, z, x)  weak-key(z,x); +z
+           │         2  ·         render 0     test.xyz.y   ·          ·
+           │         2  ·         render 1     test.xyz.z   ·          ·
+           │         2  ·         render 2     test.xyz.x   ·          ·
+           └── scan  3  scan      ·            ·            (y, z, x)  weak-key(z,x); +z
+·                    3  ·         table        xyz@primary  ·          ·
+·                    3  ·         spans        ALL          ·          ·
 
 # We add a filter to eliminate one of the rows that may be flakily returned
 # depending on parallel execution of DISTINCT ON.
@@ -410,21 +410,21 @@ SELECT DISTINCT ON (x, z) y, z, x FROM xyz WHERE (x,y,z) != (4, 1, 6) ORDER BY z
 2 3 2
 5 6 4
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 ----
-0  distinct  ·            ·            (y, z, x)                              weak-key(x); +x,-z,-y
-0  ·         distinct on  x            ·                                      ·
-0  ·         order key    x            ·                                      ·
-1  sort      ·            ·            (y, z, x)                              +x,-z,-y
-1  ·         order        +x,-z,-y     ·                                      ·
-2  render    ·            ·            (y, z, x)                              ·
-2  ·         render 0     test.xyz.y   ·                                      ·
-2  ·         render 1     test.xyz.z   ·                                      ·
-2  ·         render 2     test.xyz.x   ·                                      ·
-3  scan      ·            ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-3  ·         table        xyz@primary  ·                                      ·
-3  ·         spans        ALL          ·                                      ·
+distinct             0  distinct  ·            ·            (y, z, x)  weak-key(x); +x,-z,-y
+ │                   0  ·         distinct on  x            ·          ·
+ │                   0  ·         order key    x            ·          ·
+ └── sort            1  sort      ·            ·            (y, z, x)  weak-key(x); +x,-z,-y
+      │              1  ·         order        +x,-z,-y     ·          ·
+      └── render     2  render    ·            ·            (y, z, x)  weak-key(x); +x,-z,-y
+           │         2  ·         render 0     test.xyz.y   ·          ·
+           │         2  ·         render 1     test.xyz.z   ·          ·
+           │         2  ·         render 2     test.xyz.x   ·          ·
+           └── scan  3  scan      ·            ·            (y, z, x)  weak-key(x); +x,-z,-y
+·                    3  ·         table        xyz@primary  ·          ·
+·                    3  ·         spans        ALL          ·          ·
 
 query III
 SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
@@ -443,22 +443,22 @@ SELECT DISTINCT ON(MAX(x)) y FROM xyz
 statement error column "z" must appear in the GROUP BY clause or be used in an aggregate function
 SELECT DISTINCT ON(MAX(x), z) MIN(y) FROM xyz
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (MAX(y)) MAX(x) FROM xyz
 ----
-0  render    ·            ·                (max)                                           ·
-0  ·         render 0     max              ·                                               ·
-1  distinct  ·            ·                (max, max)                                      weak-key(max)
-1  ·         distinct on  max              ·                                               ·
-2  group     ·            ·                (max, max)                                      ·
-2  ·         aggregate 0  max(test.xyz.x)  ·                                               ·
-2  ·         aggregate 1  max(test.xyz.y)  ·                                               ·
-3  render    ·            ·                (x, y)                                          ·
-3  ·         render 0     test.xyz.x       ·                                               ·
-3  ·         render 1     test.xyz.y       ·                                               ·
-4  scan      ·            ·                (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-4  ·         table        xyz@primary      ·                                               ·
-4  ·         spans        ALL              ·                                               ·
+render                    0  render    ·            ·                (max)  ·
+ │                        0  ·         render 0     max              ·      ·
+ └── distinct             1  distinct  ·            ·                (max)  ·
+      │                   1  ·         distinct on  max              ·      ·
+      └── group           2  group     ·            ·                (max)  ·
+           │              2  ·         aggregate 0  max(test.xyz.x)  ·      ·
+           │              2  ·         aggregate 1  max(test.xyz.y)  ·      ·
+           └── render     3  render    ·            ·                (max)  ·
+                │         3  ·         render 0     test.xyz.x       ·      ·
+                │         3  ·         render 1     test.xyz.y       ·      ·
+                └── scan  4  scan      ·            ·                (max)  ·
+·                         4  ·         table        xyz@primary      ·      ·
+·                         4  ·         spans        ALL              ·      ·
 
 query I
 SELECT DISTINCT ON (MAX(x)) MIN(y) FROM xyz
@@ -470,21 +470,21 @@ SELECT DISTINCT ON (MIN(x)) MAX(y) FROM xyz
 ----
 5
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(a) FROM abc
 ----
-0  render    ·            ·                (max)                 ·
-0  ·         render 0     max              ·                     ·
-1  distinct  ·            ·                (max, min, max, min)  weak-key(min,max,min)
-1  ·         distinct on  min, max, min    ·                     ·
-2  group     ·            ·                (max, min, max, min)  ·
-2  ·         aggregate 0  max(test.abc.a)  ·                     ·
-2  ·         aggregate 1  min(test.abc.a)  ·                     ·
-2  ·         aggregate 2  max(test.abc.b)  ·                     ·
-2  ·         aggregate 3  min(test.abc.c)  ·                     ·
-3  scan      ·            ·                (a, b, c)             a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-3  ·         table        abc@primary      ·                     ·
-3  ·         spans        ALL              ·                     ·
+render               0  render    ·            ·                (max)  ·
+ │                   0  ·         render 0     max              ·      ·
+ └── distinct        1  distinct  ·            ·                (max)  ·
+      │              1  ·         distinct on  min, max, min    ·      ·
+      └── group      2  group     ·            ·                (max)  ·
+           │         2  ·         aggregate 0  max(test.abc.a)  ·      ·
+           │         2  ·         aggregate 1  min(test.abc.a)  ·      ·
+           │         2  ·         aggregate 2  max(test.abc.b)  ·      ·
+           │         2  ·         aggregate 3  min(test.abc.c)  ·      ·
+           └── scan  3  scan      ·            ·                (max)  ·
+·                    3  ·         table        abc@primary      ·      ·
+·                    3  ·         spans        ALL              ·      ·
 
 query T
 SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(c) FROM abc
@@ -500,23 +500,23 @@ SELECT DISTINCT ON (x) MIN(x) FROM xyz GROUP BY y
 
 # TODO(richardwu): we can elide the DISTINCT ON since its key is equivalent
 # to the group key.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
 ----
-0  render    ·            ·                (min)                                           ·
-0  ·         render 0     min              ·                                               ·
-1  distinct  ·            ·                (min, y)                                        weak-key(y)
-1  ·         distinct on  y                ·                                               ·
-2  group     ·            ·                (min, y)                                        ·
-2  ·         aggregate 0  min(test.xyz.x)  ·                                               ·
-2  ·         aggregate 1  test.xyz.y       ·                                               ·
-2  ·         group by     @1-@1            ·                                               ·
-3  render    ·            ·                (y, x)                                          ·
-3  ·         render 0     test.xyz.y       ·                                               ·
-3  ·         render 1     test.xyz.x       ·                                               ·
-4  scan      ·            ·                (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-4  ·         table        xyz@primary      ·                                               ·
-4  ·         spans        ALL              ·                                               ·
+render                    0  render    ·            ·                (min)  ·
+ │                        0  ·         render 0     min              ·      ·
+ └── distinct             1  distinct  ·            ·                (min)  ·
+      │                   1  ·         distinct on  y                ·      ·
+      └── group           2  group     ·            ·                (min)  ·
+           │              2  ·         aggregate 0  min(test.xyz.x)  ·      ·
+           │              2  ·         aggregate 1  test.xyz.y       ·      ·
+           │              2  ·         group by     @1-@1            ·      ·
+           └── render     3  render    ·            ·                (min)  ·
+                │         3  ·         render 0     test.xyz.y       ·      ·
+                │         3  ·         render 1     test.xyz.x       ·      ·
+                └── scan  4  scan      ·            ·                (min)  ·
+·                         4  ·         table        xyz@primary      ·      ·
+·                         4  ·         spans        ALL              ·      ·
 
 query I rowsort
 SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
@@ -525,25 +525,25 @@ SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
 1
 4
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
 ----
-0  distinct  ·            ·                (min)                                           weak-key(min)
-0  ·         distinct on  min              ·                                               ·
-1  render    ·            ·                (min)                                           ·
-1  ·         render 0     min              ·                                               ·
-2  filter    ·            ·                (min, min)                                      min=CONST
-2  ·         filter       min = 1          ·                                               ·
-3  group     ·            ·                (min, min)                                      ·
-3  ·         aggregate 0  min(test.xyz.x)  ·                                               ·
-3  ·         aggregate 1  min(test.xyz.x)  ·                                               ·
-3  ·         group by     @1-@1            ·                                               ·
-4  render    ·            ·                (y, x)                                          ·
-4  ·         render 0     test.xyz.y       ·                                               ·
-4  ·         render 1     test.xyz.x       ·                                               ·
-5  scan      ·            ·                (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-5  ·         table        xyz@primary      ·                                               ·
-5  ·         spans        ALL              ·                                               ·
+distinct                       0  distinct  ·            ·                (min)  weak-key(min)
+ │                             0  ·         distinct on  min              ·      ·
+ └── render                    1  render    ·            ·                (min)  weak-key(min)
+      │                        1  ·         render 0     min              ·      ·
+      └── filter               2  filter    ·            ·                (min)  weak-key(min)
+           │                   2  ·         filter       min = 1          ·      ·
+           └── group           3  group     ·            ·                (min)  weak-key(min)
+                │              3  ·         aggregate 0  min(test.xyz.x)  ·      ·
+                │              3  ·         aggregate 1  min(test.xyz.x)  ·      ·
+                │              3  ·         group by     @1-@1            ·      ·
+                └── render     4  render    ·            ·                (min)  weak-key(min)
+                     │         4  ·         render 0     test.xyz.y       ·      ·
+                     │         4  ·         render 1     test.xyz.x       ·      ·
+                     └── scan  5  scan      ·            ·                (min)  weak-key(min)
+·                              5  ·         table        xyz@primary      ·      ·
+·                              5  ·         spans        ALL              ·      ·
 
 query I
 SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
@@ -554,21 +554,21 @@ SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
 # With window functions #
 #########################
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
 ----
-0  render    ·            ·                     (y)                                                      ·
-0  ·         render 0     y                     ·                                                        ·
-1  distinct  ·            ·                     (y, row_number)                                          weak-key(row_number)
-1  ·         distinct on  row_number            ·                                                        ·
-2  window    ·            ·                     (y, row_number)                                          ·
-2  ·         window 0     row_number() OVER ()  ·                                                        ·
-2  ·         render 1     row_number() OVER ()  ·                                                        ·
-3  render    ·            ·                     (y)                                                      ·
-3  ·         render 0     test.xyz.y            ·                                                        ·
-4  scan      ·            ·                     (x[omitted], y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-4  ·         table        xyz@primary           ·                                                        ·
-4  ·         spans        ALL                   ·                                                        ·
+render                    0  render    ·            ·                     (y)  ·
+ │                        0  ·         render 0     y                     ·    ·
+ └── distinct             1  distinct  ·            ·                     (y)  ·
+      │                   1  ·         distinct on  row_number            ·    ·
+      └── window          2  window    ·            ·                     (y)  ·
+           │              2  ·         window 0     row_number() OVER ()  ·    ·
+           │              2  ·         render 1     row_number() OVER ()  ·    ·
+           └── render     3  render    ·            ·                     (y)  ·
+                │         3  ·         render 0     test.xyz.y            ·    ·
+                └── scan  4  scan      ·            ·                     (y)  ·
+·                         4  ·         table        xyz@primary           ·    ·
+·                         4  ·         spans        ALL                   ·    ·
 
 query I rowsort
 SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
@@ -599,18 +599,18 @@ SELECT DISTINCT ON(row_number() OVER()) y FROM xyz ORDER BY row_number() OVER() 
 statement error DISTINCT ON position 2 is not in select list
 SELECT DISTINCT ON (2) x FROM xyz
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz
 ----
-0  distinct  ·            ·            (x, y, z)                              weak-key(x)
-0  ·         distinct on  x            ·                                      ·
-1  render    ·            ·            (x, y, z)                              ·
-1  ·         render 0     test.xyz.x   ·                                      ·
-1  ·         render 1     test.xyz.y   ·                                      ·
-1  ·         render 2     test.xyz.z   ·                                      ·
-2  scan      ·            ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-2  ·         table        xyz@primary  ·                                      ·
-2  ·         spans        ALL          ·                                      ·
+distinct        0  distinct  ·            ·            (x, y, z)  weak-key(x)
+ │              0  ·         distinct on  x            ·          ·
+ └── render     1  render    ·            ·            (x, y, z)  weak-key(x)
+      │         1  ·         render 0     test.xyz.x   ·          ·
+      │         1  ·         render 1     test.xyz.y   ·          ·
+      │         1  ·         render 2     test.xyz.z   ·          ·
+      └── scan  2  scan      ·            ·            (x, y, z)  weak-key(x)
+·               2  ·         table        xyz@primary  ·          ·
+·               2  ·         spans        ALL          ·          ·
 
 query I rowsort
 SELECT DISTINCT ON (1) x FROM xyz
@@ -620,12 +620,12 @@ SELECT DISTINCT ON (1) x FROM xyz
 4
 
 # Distinct node elided because of strong key.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1,2,3) a, b, c FROM abc
 ----
-0  scan  ·      ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-0  ·     table  abc@primary  ·          ·
-0  ·     spans  ALL          ·          ·
+scan  0  scan  ·      ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·     0  ·     table  abc@primary  ·          ·
+·     0  ·     spans  ALL          ·          ·
 
 query III rowsort
 SELECT DISTINCT ON (1,2,3) x, y, z FROM xyz
@@ -642,17 +642,17 @@ SELECT DISTINCT ON (1,2,3) x, y, z FROM xyz
 #########################
 
 # This should priortize alias (use 'x' as the key).
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz
 ----
-0  distinct  ·            ·            (y, x)                                          weak-key(y)
-0  ·         distinct on  y            ·                                               ·
-1  render    ·            ·            (y, x)                                          ·
-1  ·         render 0     test.xyz.x   ·                                               ·
-1  ·         render 1     test.xyz.y   ·                                               ·
-2  scan      ·            ·            (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-2  ·         table        xyz@primary  ·                                               ·
-2  ·         spans        ALL          ·                                               ·
+distinct        0  distinct  ·            ·            (y, x)  weak-key(y)
+ │              0  ·         distinct on  y            ·       ·
+ └── render     1  render    ·            ·            (y, x)  weak-key(y)
+      │         1  ·         render 0     test.xyz.x   ·       ·
+      │         1  ·         render 1     test.xyz.y   ·       ·
+      └── scan  2  scan      ·            ·            (y, x)  weak-key(y)
+·               2  ·         table        xyz@primary  ·       ·
+·               2  ·         spans        ALL          ·       ·
 
 # This would be non-deterministic if we don't select y (actually x) from the
 # subquery.
@@ -664,16 +664,16 @@ SELECT y FROM (SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz)
 4
 
 # Ignores the alias.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(x) x AS y FROM xyz
 ----
-0  distinct  ·            ·            (y)                                                      weak-key(y)
-0  ·         distinct on  y            ·                                                        ·
-1  render    ·            ·            (y)                                                      ·
-1  ·         render 0     test.xyz.x   ·                                                        ·
-2  scan      ·            ·            (x, y[omitted], z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-2  ·         table        xyz@primary  ·                                                        ·
-2  ·         spans        ALL          ·                                                        ·
+distinct        0  distinct  ·            ·            (y)  weak-key(y)
+ │              0  ·         distinct on  y            ·    ·
+ └── render     1  render    ·            ·            (y)  weak-key(y)
+      │         1  ·         render 0     test.xyz.x   ·    ·
+      └── scan  2  scan      ·            ·            (y)  weak-key(y)
+·               2  ·         table        xyz@primary  ·    ·
+·               2  ·         spans        ALL          ·    ·
 
 query I rowsort
 SELECT DISTINCT ON(x) x AS y FROM xyz
@@ -686,17 +686,17 @@ SELECT DISTINCT ON(x) x AS y FROM xyz
 # With nested parentheses/tuples #
 ##################################
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
 ----
-0  distinct  ·            ·            (x, y)                                          weak-key(x,y)
-0  ·         distinct on  x, y         ·                                               ·
-1  render    ·            ·            (x, y)                                          ·
-1  ·         render 0     test.xyz.x   ·                                               ·
-1  ·         render 1     test.xyz.y   ·                                               ·
-2  scan      ·            ·            (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-2  ·         table        xyz@primary  ·                                               ·
-2  ·         spans        ALL          ·                                               ·
+distinct        0  distinct  ·            ·            (x, y)  weak-key(x,y)
+ │              0  ·         distinct on  x, y         ·       ·
+ └── render     1  render    ·            ·            (x, y)  weak-key(x,y)
+      │         1  ·         render 0     test.xyz.x   ·       ·
+      │         1  ·         render 1     test.xyz.y   ·       ·
+      └── scan  2  scan      ·            ·            (x, y)  weak-key(x,y)
+·               2  ·         table        xyz@primary  ·       ·
+·               2  ·         spans        ALL          ·       ·
 
 
 query II rowsort
@@ -713,18 +713,18 @@ SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
 ################################
 
 # Distinct elided because of strong key presence.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 ----
-0  render  ·         ·            (x, y, z)                              +x,+y
-0  ·       render 0  x            ·                                      ·
-0  ·       render 1  y            ·                                      ·
-0  ·       render 2  z            ·                                      ·
-1  sort    ·         ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +x,+y
-1  ·       order     +x,+y        ·                                      ·
-2  scan    ·         ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-2  ·       table     xyz@primary  ·                                      ·
-2  ·       spans     ALL          ·                                      ·
+render          0  render  ·         ·            (x, y, z)  +x,+y
+ │              0  ·       render 0  x            ·          ·
+ │              0  ·       render 1  y            ·          ·
+ │              0  ·       render 2  z            ·          ·
+ └── sort       1  sort    ·         ·            (x, y, z)  +x,+y
+      │         1  ·       order     +x,+y        ·          ·
+      └── scan  2  scan    ·         ·            (x, y, z)  +x,+y
+·               2  ·       table     xyz@primary  ·          ·
+·               2  ·       spans     ALL          ·          ·
 
 # We need to rowsort this since the ORDER BY isn't on the entire SELECT columns.
 query III rowsort
@@ -740,24 +740,24 @@ SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 
 # Ordering only propagates up until distinctNode.
 # pk1 ordering does not propagate at all since it's not explicitly needed.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
 ----
-0  render    ·            ·             (pk1)                         pk1!=NULL
-0  ·         render 0     pk1           ·                             ·
-1  distinct  ·            ·             (pk1, x, y, z)                pk1!=NULL; weak-key(x,y,z); +x
-1  ·         distinct on  x, y, z       ·                             ·
-1  ·         order key    x             ·                             ·
-2  sort      ·            ·             (pk1, x, y, z)                pk1!=NULL; +x
-2  ·         order        +x            ·                             ·
-3  render    ·            ·             (pk1, x, y, z)                pk1!=NULL
-3  ·         render 0     test.xyz.pk1  ·                             ·
-3  ·         render 1     test.xyz.x    ·                             ·
-3  ·         render 2     test.xyz.y    ·                             ·
-3  ·         render 3     test.xyz.z    ·                             ·
-4  scan      ·            ·             (x, y, z, pk1, pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-4  ·         table        xyz@primary   ·                             ·
-4  ·         spans        ALL           ·                             ·
+render                    0  render    ·            ·             (pk1)  pk1!=NULL
+ │                        0  ·         render 0     pk1           ·      ·
+ └── distinct             1  distinct  ·            ·             (pk1)  pk1!=NULL
+      │                   1  ·         distinct on  x, y, z       ·      ·
+      │                   1  ·         order key    x             ·      ·
+      └── sort            2  sort      ·            ·             (pk1)  pk1!=NULL
+           │              2  ·         order        +x            ·      ·
+           └── render     3  render    ·            ·             (pk1)  pk1!=NULL
+                │         3  ·         render 0     test.xyz.pk1  ·      ·
+                │         3  ·         render 1     test.xyz.x    ·      ·
+                │         3  ·         render 2     test.xyz.y    ·      ·
+                │         3  ·         render 3     test.xyz.z    ·      ·
+                └── scan  4  scan      ·            ·             (pk1)  pk1!=NULL
+·                         4  ·         table        xyz@primary   ·      ·
+·                         4  ·         spans        ALL           ·      ·
 
 # We add a filter since there could be multiple valid pk1s otherwise for distinct
 # rows.

--- a/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
@@ -82,18 +82,18 @@ NULL             /NULL/NULL/NULL  5         {5}       5
 /"2"/"3"/"4"     /"3"/"4"/"5"     24        {4}       4
 /"3"/"4"/"5"     NULL             25        {5}       5
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 ----
-0  distinct  ·            ·            (x, y, z)               weak-key(x,y,z)
-0  ·         distinct on  x, y, z      ·                       ·
-1  render    ·            ·            (x, y, z)               ·
-1  ·         render 0     test.xyz.x   ·                       ·
-1  ·         render 1     test.xyz.y   ·                       ·
-1  ·         render 2     test.xyz.z   ·                       ·
-2  scan      ·            ·            (id[omitted], x, y, z)  id!=NULL; key(id)
-2  ·         table        xyz@primary  ·                       ·
-2  ·         spans        ALL          ·                       ·
+distinct        0  distinct  ·            ·            (x, y, z)  weak-key(x,y,z)
+ │              0  ·         distinct on  x, y, z      ·          ·
+ └── render     1  render    ·            ·            (x, y, z)  weak-key(x,y,z)
+      │         1  ·         render 0     test.xyz.x   ·          ·
+      │         1  ·         render 1     test.xyz.y   ·          ·
+      │         1  ·         render 2     test.xyz.z   ·          ·
+      └── scan  2  scan      ·            ·            (x, y, z)  weak-key(x,y,z)
+·               2  ·         table        xyz@primary  ·          ·
+·               2  ·         spans        ALL          ·          ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz]
@@ -111,21 +111,21 @@ SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 4 1 6
 
 # Ensure that ordering propagates past local DISTINCT processors.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 ----
-0  distinct  ·            ·            (x, y, z)               weak-key(x,y,z); +x
-0  ·         distinct on  x, y, z      ·                       ·
-0  ·         order key    x            ·                       ·
-1  sort      ·            ·            (x, y, z)               +x
-1  ·         order        +x           ·                       ·
-2  render    ·            ·            (x, y, z)               ·
-2  ·         render 0     test.xyz.x   ·                       ·
-2  ·         render 1     test.xyz.y   ·                       ·
-2  ·         render 2     test.xyz.z   ·                       ·
-3  scan      ·            ·            (id[omitted], x, y, z)  id!=NULL; key(id)
-3  ·         table        xyz@primary  ·                       ·
-3  ·         spans        ALL          ·                       ·
+distinct             0  distinct  ·            ·            (x, y, z)  weak-key(x,y,z); +x
+ │                   0  ·         distinct on  x, y, z      ·          ·
+ │                   0  ·         order key    x            ·          ·
+ └── sort            1  sort      ·            ·            (x, y, z)  weak-key(x,y,z); +x
+      │              1  ·         order        +x           ·          ·
+      └── render     2  render    ·            ·            (x, y, z)  weak-key(x,y,z); +x
+           │         2  ·         render 0     test.xyz.x   ·          ·
+           │         2  ·         render 1     test.xyz.y   ·          ·
+           │         2  ·         render 2     test.xyz.z   ·          ·
+           └── scan  3  scan      ·            ·            (x, y, z)  weak-key(x,y,z); +x
+·                    3  ·         table        xyz@primary  ·          ·
+·                    3  ·         spans        ALL          ·          ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x]
@@ -144,20 +144,20 @@ SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 
 # Ensure that even with more ordering columns, ordering propagates past local
 # DISTINCT processors.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x
 ----
-0  distinct  ·            ·            (x, y)                           weak-key(y); +y,+x
-0  ·         distinct on  y            ·                                ·
-0  ·         order key    y            ·                                ·
-1  sort      ·            ·            (x, y)                           +y,+x
-1  ·         order        +y,+x        ·                                ·
-2  render    ·            ·            (x, y)                           ·
-2  ·         render 0     test.xyz.x   ·                                ·
-2  ·         render 1     test.xyz.y   ·                                ·
-3  scan      ·            ·            (id[omitted], x, y, z[omitted])  id!=NULL; key(id)
-3  ·         table        xyz@primary  ·                                ·
-3  ·         spans        ALL          ·                                ·
+distinct             0  distinct  ·            ·            (x, y)  weak-key(y); +y,+x
+ │                   0  ·         distinct on  y            ·       ·
+ │                   0  ·         order key    y            ·       ·
+ └── sort            1  sort      ·            ·            (x, y)  weak-key(y); +y,+x
+      │              1  ·         order        +y,+x        ·       ·
+      └── render     2  render    ·            ·            (x, y)  weak-key(y); +y,+x
+           │         2  ·         render 0     test.xyz.x   ·       ·
+           │         2  ·         render 1     test.xyz.y   ·       ·
+           └── scan  3  scan      ·            ·            (x, y)  weak-key(y); +y,+x
+·                    3  ·         table        xyz@primary  ·       ·
+·                    3  ·         spans        ALL          ·       ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x]
@@ -172,12 +172,12 @@ SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x
 4 5
 
 # Distinct processors elided becaue of strong key.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc
 ----
-0  scan  ·      ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-0  ·     table  abc@primary  ·          ·
-0  ·     spans  ALL          ·          ·
+scan  0  scan  ·      ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·     0  ·     table  abc@primary  ·          ·
+·     0  ·     spans  ALL          ·          ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a,b,c) a, b, c FROM abc]
@@ -193,17 +193,17 @@ SELECT DISTINCT ON (a,b,c) a, b, c FROM abc
 2  3  4
 3  4  5
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c
 ----
-0  distinct  ·            ·            (a, b)     a!=NULL; b!=NULL; key(a,b); +a,+b
-0  ·         distinct on  a, b         ·          ·
-0  ·         order key    a, b         ·          ·
-1  nosort    ·            ·            (a, b)     a!=NULL; b!=NULL; +a,+b
-1  ·         order        +a,+b,+c     ·          ·
-2  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b,+c
-2  ·         table        abc@primary  ·          ·
-2  ·         spans        ALL          ·          ·
+distinct        0  distinct  ·            ·            (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
+ │              0  ·         distinct on  a, b         ·       ·
+ │              0  ·         order key    a, b         ·       ·
+ └── nosort     1  nosort    ·            ·            (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
+      │         1  ·         order        +a,+b,+c     ·       ·
+      └── scan  2  scan      ·            ·            (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
+·               2  ·         table        abc@primary  ·       ·
+·               2  ·         spans        ALL          ·       ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c]

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -40,52 +40,52 @@ statement ok
 SET CLUSTER SETTING sql.distsql.merge_joins.enabled = true;
 
 # ensure merge joins are planned when there's orderings.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b FROM data AS data2))
 ----
-0  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL
-0  ·       render 0        a                  ·                               ·
-0  ·       render 1        b                  ·                               ·
-1  join    ·               ·                  (a, b, a[omitted], b[omitted])  a=a; b=b; a!=NULL; b!=NULL
-1  ·       type            inner              ·                               ·
-1  ·       equality        (a, b) = (a, b)    ·                               ·
-1  ·       mergeJoinOrder  +"(a=a)",+"(b=b)"  ·                               ·
-2  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL; +a,+b
-2  ·       render 0        test.data.a        ·                               ·
-2  ·       render 1        test.data.b        ·                               ·
-3  scan    ·               ·                  (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
-3  ·       table           data@primary       ·                               ·
-3  ·       spans           ALL                ·                               ·
-2  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL; +a,+b
-2  ·       render 0        data2.a            ·                               ·
-2  ·       render 1        data2.b            ·                               ·
-3  scan    ·               ·                  (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
-3  ·       table           data@primary       ·                               ·
-3  ·       spans           ALL                ·                               ·
+render               0  render  ·               ·                  (a, b)  a!=NULL; b!=NULL
+ │                   0  ·       render 0        a                  ·       ·
+ │                   0  ·       render 1        b                  ·       ·
+ └── join            1  join    ·               ·                  (a, b)  a!=NULL; b!=NULL
+      │              1  ·       type            inner              ·       ·
+      │              1  ·       equality        (a, b) = (a, b)    ·       ·
+      │              1  ·       mergeJoinOrder  +"(a=a)",+"(b=b)"  ·       ·
+      ├── render     2  render  ·               ·                  (a, b)  a!=NULL; b!=NULL
+      │    │         2  ·       render 0        test.data.a        ·       ·
+      │    │         2  ·       render 1        test.data.b        ·       ·
+      │    └── scan  3  scan    ·               ·                  (a, b)  a!=NULL; b!=NULL
+      │              3  ·       table           data@primary       ·       ·
+      │              3  ·       spans           ALL                ·       ·
+      └── render     2  render  ·               ·                  (a, b)  a!=NULL; b!=NULL
+           │         2  ·       render 0        data2.a            ·       ·
+           │         2  ·       render 1        data2.b            ·       ·
+           └── scan  3  scan    ·               ·                  (a, b)  a!=NULL; b!=NULL
+·                    3  ·       table           data@primary       ·       ·
+·                    3  ·       spans           ALL                ·       ·
 
 
 # ORDER BY on the mergeJoinOrder columns should not require a SORT node
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY c,d)
 ----
-0  join    ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
-0  ·       type            inner              ·                               ·
-0  ·       equality        (a, b) = (c, d)    ·                               ·
-0  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·                               ·
-1  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL; +a,+b
-1  ·       render 0        data1.a            ·                               ·
-1  ·       render 1        data1.b            ·                               ·
-2  scan    ·               ·                  (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
-2  ·       table           data@primary       ·                               ·
-2  ·       spans           ALL                ·                               ·
-1  sort    ·               ·                  (c, d)                          c!=NULL; d!=NULL; +c,+d
-1  ·       order           +c,+d              ·                               ·
-2  render  ·               ·                  (c, d)                          c!=NULL; d!=NULL
-2  ·       render 0        data2.c            ·                               ·
-2  ·       render 1        data2.d            ·                               ·
-3  scan    ·               ·                  (a[omitted], b[omitted], c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
-3  ·       table           data@primary       ·                               ·
-3  ·       spans           ALL                ·                               ·
+join                 0  join    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+ │                   0  ·       type            inner              ·             ·
+ │                   0  ·       equality        (a, b) = (c, d)    ·             ·
+ │                   0  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·             ·
+ ├── render          1  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+ │    │              1  ·       render 0        data1.a            ·             ·
+ │    │              1  ·       render 1        data1.b            ·             ·
+ │    └── scan       2  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+ │                   2  ·       table           data@primary       ·             ·
+ │                   2  ·       spans           ALL                ·             ·
+ └── sort            1  sort    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+      │              1  ·       order           +c,+d              ·             ·
+      └── render     2  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+           │         2  ·       render 0        data2.c            ·             ·
+           │         2  ·       render 1        data2.d            ·             ·
+           └── scan  3  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+·                    3  ·       table           data@primary       ·             ·
+·                    3  ·       spans           ALL                ·             ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY c,d)]
@@ -94,27 +94,27 @@ https://cockroachdb.github.io/distsqlplan/decode.html?eJzclk1r20AQhu_9FWFOLdmCdy
 
 # ORDER BY on the columns equal to the mergeJoinOrder columns should not
 # require a terminal SORT node.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY a,b)
 ----
-0  join    ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
-0  ·       type            inner              ·                               ·
-0  ·       equality        (a, b) = (c, d)    ·                               ·
-0  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·                               ·
-1  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL; +a,+b
-1  ·       render 0        data1.a            ·                               ·
-1  ·       render 1        data1.b            ·                               ·
-2  scan    ·               ·                  (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
-2  ·       table           data@primary       ·                               ·
-2  ·       spans           ALL                ·                               ·
-1  sort    ·               ·                  (c, d)                          c!=NULL; d!=NULL; +c,+d
-1  ·       order           +c,+d              ·                               ·
-2  render  ·               ·                  (c, d)                          c!=NULL; d!=NULL
-2  ·       render 0        data2.c            ·                               ·
-2  ·       render 1        data2.d            ·                               ·
-3  scan    ·               ·                  (a[omitted], b[omitted], c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
-3  ·       table           data@primary       ·                               ·
-3  ·       spans           ALL                ·                               ·
+join                 0  join    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+ │                   0  ·       type            inner              ·             ·
+ │                   0  ·       equality        (a, b) = (c, d)    ·             ·
+ │                   0  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·             ·
+ ├── render          1  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+ │    │              1  ·       render 0        data1.a            ·             ·
+ │    │              1  ·       render 1        data1.b            ·             ·
+ │    └── scan       2  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+ │                   2  ·       table           data@primary       ·             ·
+ │                   2  ·       spans           ALL                ·             ·
+ └── sort            1  sort    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+      │              1  ·       order           +c,+d              ·             ·
+      └── render     2  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+           │         2  ·       render 0        data2.c            ·             ·
+           │         2  ·       render 1        data2.d            ·             ·
+           └── scan  3  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
+·                    3  ·       table           data@primary       ·             ·
+·                    3  ·       spans           ALL                ·             ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY a,b)]
@@ -122,29 +122,29 @@ SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS dat
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzclk1r20AQhu_9FWFOLdmCdyXnQ1DQNYUmJe2t-KBYW1vgeM1qDQ3B_73YSjGS4nk9rGuMj4r1aEazz-TVK81dae-LZ1tT9os0KTKkKCFFKSka0kjRwruxrWvn17c0wF35h7KBomq-WIb1n0eKxs5byl4pVGFmKaOfxdPMPtqitJ4UlTYU1WxTZOGr58K_5GURClL0sAzZRa5Vbmi0UuSW4e2Z20c9vVxMi3rafsw_ZKSoDsXEUqZX6n-1l6g87bS3rWskdX84H7olc32pcnMZ-_7Jzj62j3K-tN6WO-vvfec7r_bN-on96qp59_1m9nf4-IZ--uKryXR72TJA8YNO41_wnbbv3We3aN2_q_6wVV-ftv8HbU_gP6h7NP_1uftvTtu_g7Yn8A_UPZp_5tz9S07bv4O2J_AP1D2af8m5-5eetn8HbU_gH6h7NP_Sc_cPfOg_2nrh5rXd68tysH4fW05sM63aLf3YfvduvCnTXD5suM2HTWnr0PyaNBd38-andYP7wzcxsDZR9FUMbQY8rbv0oEW34EEXNoKBGxl8EwN3Bi6lr2LozsB7dMIOPOVPK-VPS_PHNYzZDx4G-8HDaD8ADfaDp9F-XLETv-YHfh2zHzwM9oOH0X4AGuwHT6P9uInZj9sYw3kYGM7DyHBAA8N5GiZAL0BaE9fgn4ruJYhEckADywGNNEc48BzgSHTdyxGJ6bqXIxLVAQ1cBzSSHeHAdoBD3fkM1UOguyRE-2cuSVEpDXUX5agUh7rzSYp0l0SplEa6i8JUjCPdRXHax_k81bdAd0mi9s9cEqlSGuouClUpjnQ3fKp2dR-tPvwNAAD__1XEQ9M=
 
 # ORDER BY on a different ordering should require a terminal SORT NODE.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)
 ----
-0  sort    ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +b,+a
-0  ·       order           +b,+a              ·                               ·
-1  join    ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL
-1  ·       type            inner              ·                               ·
-1  ·       equality        (a, b) = (c, d)    ·                               ·
-1  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·                               ·
-2  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL; +a,+b
-2  ·       render 0        data1.a            ·                               ·
-2  ·       render 1        data1.b            ·                               ·
-3  scan    ·               ·                  (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
-3  ·       table           data@primary       ·                               ·
-3  ·       spans           ALL                ·                               ·
-2  sort    ·               ·                  (c, d)                          c!=NULL; d!=NULL; +c,+d
-2  ·       order           +c,+d              ·                               ·
-3  render  ·               ·                  (c, d)                          c!=NULL; d!=NULL
-3  ·       render 0        data2.c            ·                               ·
-3  ·       render 1        data2.d            ·                               ·
-4  scan    ·               ·                  (a[omitted], b[omitted], c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
-4  ·       table           data@primary       ·                               ·
-4  ·       spans           ALL                ·                               ·
+sort                      0  sort    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
+ │                        0  ·       order           +b,+a              ·             ·
+ └── join                 1  join    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
+      │                   1  ·       type            inner              ·             ·
+      │                   1  ·       equality        (a, b) = (c, d)    ·             ·
+      │                   1  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·             ·
+      ├── render          2  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
+      │    │              2  ·       render 0        data1.a            ·             ·
+      │    │              2  ·       render 1        data1.b            ·             ·
+      │    └── scan       3  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
+      │                   3  ·       table           data@primary       ·             ·
+      │                   3  ·       spans           ALL                ·             ·
+      └── sort            2  sort    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
+           │              2  ·       order           +c,+d              ·             ·
+           └── render     3  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
+                │         3  ·       render 0        data2.c            ·             ·
+                │         3  ·       render 1        data2.d            ·             ·
+                └── scan  4  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
+·                         4  ·       table           data@primary       ·             ·
+·                         4  ·       spans           ALL                ·             ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)]
@@ -176,37 +176,37 @@ https://cockroachdb.github.io/distsqlplan/decode.html?eJzcl1GL2kAUhd_7K5b71LJTcC
 
 
 # Nested merge joins should be planned on the same ordering
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d))
 ----
-0  render  ·               ·                                    (a, b)                                                                          a!=NULL; b!=NULL
-0  ·       render 0        data3.a                              ·                                                                               ·
-0  ·       render 1        data3.b                              ·                                                                               ·
-1  join    ·               ·                                    (a, b, c[omitted], d[omitted], a[omitted], b[omitted], c[omitted], d[omitted])  a=c=a=c; b=d=b=d; a!=NULL; b!=NULL
-1  ·       type            inner                                ·                                                                               ·
-1  ·       equality        (a, b, c, d) = (a, b, c, d)          ·                                                                               ·
-1  ·       mergeJoinOrder  +"(a=a)",+"(b=b)",+"(c=c)",+"(d=d)"  ·                                                                               ·
-2  scan    ·               ·                                    (a, b, c, d)                                                                    a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b,+c,+d
-2  ·       table           data@primary                         ·                                                                               ·
-2  ·       spans           ALL                                  ·                                                                               ·
-2  join    ·               ·                                    (a, b, c, d)                                                                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
-2  ·       type            inner                                ·                                                                               ·
-2  ·       equality        (a, b) = (c, d)                      ·                                                                               ·
-2  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"                    ·                                                                               ·
-3  render  ·               ·                                    (a, b)                                                                          a!=NULL; b!=NULL; +a,+b
-3  ·       render 0        data1.a                              ·                                                                               ·
-3  ·       render 1        data1.b                              ·                                                                               ·
-4  scan    ·               ·                                    (a, b, c[omitted], d[omitted])                                                  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
-4  ·       table           data@primary                         ·                                                                               ·
-4  ·       spans           ALL                                  ·                                                                               ·
-3  sort    ·               ·                                    (c, d)                                                                          c!=NULL; d!=NULL; +c,+d
-3  ·       order           +c,+d                                ·                                                                               ·
-4  render  ·               ·                                    (c, d)                                                                          c!=NULL; d!=NULL
-4  ·       render 0        data2.c                              ·                                                                               ·
-4  ·       render 1        data2.d                              ·                                                                               ·
-5  scan    ·               ·                                    (a[omitted], b[omitted], c, d)                                                  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
-5  ·       table           data@primary                         ·                                                                               ·
-5  ·       spans           ALL                                  ·                                                                               ·
+render                         0  render  ·               ·                                    (a, b)  a!=NULL; b!=NULL
+ │                             0  ·       render 0        data3.a                              ·       ·
+ │                             0  ·       render 1        data3.b                              ·       ·
+ └── join                      1  join    ·               ·                                    (a, b)  a!=NULL; b!=NULL
+      │                        1  ·       type            inner                                ·       ·
+      │                        1  ·       equality        (a, b, c, d) = (a, b, c, d)          ·       ·
+      │                        1  ·       mergeJoinOrder  +"(a=a)",+"(b=b)",+"(c=c)",+"(d=d)"  ·       ·
+      ├── scan                 2  scan    ·               ·                                    (a, b)  a!=NULL; b!=NULL
+      │                        2  ·       table           data@primary                         ·       ·
+      │                        2  ·       spans           ALL                                  ·       ·
+      └── join                 2  join    ·               ·                                    (a, b)  a!=NULL; b!=NULL
+           │                   2  ·       type            inner                                ·       ·
+           │                   2  ·       equality        (a, b) = (c, d)                      ·       ·
+           │                   2  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"                    ·       ·
+           ├── render          3  render  ·               ·                                    (a, b)  a!=NULL; b!=NULL
+           │    │              3  ·       render 0        data1.a                              ·       ·
+           │    │              3  ·       render 1        data1.b                              ·       ·
+           │    └── scan       4  scan    ·               ·                                    (a, b)  a!=NULL; b!=NULL
+           │                   4  ·       table           data@primary                         ·       ·
+           │                   4  ·       spans           ALL                                  ·       ·
+           └── sort            3  sort    ·               ·                                    (a, b)  a!=NULL; b!=NULL
+                │              3  ·       order           +c,+d                                ·       ·
+                └── render     4  render  ·               ·                                    (a, b)  a!=NULL; b!=NULL
+                     │         4  ·       render 0        data2.c                              ·       ·
+                     │         4  ·       render 1        data2.d                              ·       ·
+                     └── scan  5  scan    ·               ·                                    (a, b)  a!=NULL; b!=NULL
+·                              5  ·       table           data@primary                         ·       ·
+·                              5  ·       spans           ALL                                  ·       ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d)))]

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -140,24 +140,24 @@ query IT rowsort label-sq-str
 SELECT x, str FROM NumToSquare JOIN NumToStr ON y = xsquared
 
 # Merge join.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
-0  render  ·               ·                    (x, str)                                 x!=NULL; key(x)
-0  ·       render 0        test.numtosquare.x   ·                                        ·
-0  ·       render 1        test.numtostr.str    ·                                        ·
-1  join    ·               ·                    (x, xsquared[omitted], y[omitted], str)  x=y; x!=NULL; key(x)
-1  ·       type            inner                ·                                        ·
-1  ·       equality        (x) = (y)            ·                                        ·
-1  ·       mergeJoinOrder  +"(x=y)"             ·                                        ·
-2  scan    ·               ·                    (x, xsquared[omitted])                   x!=NULL; key(x); +x
-2  ·       table           numtosquare@primary  ·                                        ·
-2  ·       spans           ALL                  ·                                        ·
-2  ·       filter          (x % 2) = 0          ·                                        ·
-2  scan    ·               ·                    (y, str)                                 y!=NULL; key(y); +y
-2  ·       table           numtostr@primary     ·                                        ·
-2  ·       spans           ALL                  ·                                        ·
-2  ·       filter          (y % 2) = 0          ·                                        ·
+render          0  render  ·               ·                    (x, str)  x!=NULL; key(x)
+ │              0  ·       render 0        test.numtosquare.x   ·         ·
+ │              0  ·       render 1        test.numtostr.str    ·         ·
+ └── join       1  join    ·               ·                    (x, str)  x!=NULL; key(x)
+      │         1  ·       type            inner                ·         ·
+      │         1  ·       equality        (x) = (y)            ·         ·
+      │         1  ·       mergeJoinOrder  +"(x=y)"             ·         ·
+      ├── scan  2  scan    ·               ·                    (x, str)  x!=NULL; key(x)
+      │         2  ·       table           numtosquare@primary  ·         ·
+      │         2  ·       spans           ALL                  ·         ·
+      │         2  ·       filter          (x % 2) = 0          ·         ·
+      └── scan  2  scan    ·               ·                    (x, str)  x!=NULL; key(x)
+·               2  ·       table           numtostr@primary     ·         ·
+·               2  ·       spans           ALL                  ·         ·
+·               2  ·       filter          (y % 2) = 0          ·         ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0]
@@ -273,18 +273,18 @@ SELECT y, str, REPEAT('test', y) FROM NumToStr ORDER BY str
 statement ok
 SELECT y, str, REPEAT('test', y) FROM NumToStr ORDER BY str LIMIT 10
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumToSquare)
 ----
-0  render  ·         ·                    (x)                                      x!=NULL; key(x)
-0  ·       render 0  x                    ·                                        ·
-1  render  ·         ·                    (x, "2 * x"[omitted], "x + 1"[omitted])  x!=NULL; key(x)
-1  ·       render 0  test.numtosquare.x   ·                                        ·
-1  ·       render 1  NULL                 ·                                        ·
-1  ·       render 2  NULL                 ·                                        ·
-2  scan    ·         ·                    (x, xsquared[omitted])                   x!=NULL; key(x)
-2  ·       table     numtosquare@primary  ·                                        ·
-2  ·       spans     ALL                  ·                                        ·
+render          0  render  ·         ·                    (x)  x!=NULL; key(x)
+ │              0  ·       render 0  x                    ·    ·
+ └── render     1  render  ·         ·                    (x)  x!=NULL; key(x)
+      │         1  ·       render 0  test.numtosquare.x   ·    ·
+      │         1  ·       render 1  NULL                 ·    ·
+      │         1  ·       render 2  NULL                 ·    ·
+      └── scan  2  scan    ·         ·                    (x)  x!=NULL; key(x)
+·               2  ·       table     numtosquare@primary  ·    ·
+·               2  ·       spans     ALL                  ·    ·
 
 # Verifies that unused renders don't cause us to do rendering instead of a
 # simple projection.

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -1,25 +1,25 @@
 # LogicTest: default distsql
 
-query ITTT colnames
+query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE FALSE
 ----
-Level  Type     Field  Description
-0      render   ·      ·
-1      norows   ·      ·
+Tree         Field  Description
+render       ·      ·
+ └── norows  ·      ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (PLAN, METADATA) SELECT 1
 ----
-Level  Type      Field  Description  Columns  Ordering
-0      render    ·      ·            ("1")    "1"=CONST
-1      emptyrow  ·      ·            ()       ·
+Tree           Level  Type      Field  Description  Columns  Ordering
+render         0      render    ·      ·            ("1")    "1"=CONST
+ └── emptyrow  1      emptyrow  ·      ·            ("1")    "1"=CONST
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (METADATA,PLAN) SELECT 1
 ----
-Level  Type      Field  Description  Columns  Ordering
-0      render    ·      ·            ("1")    "1"=CONST
-1      emptyrow  ·      ·            ()       ·
+Tree           Level  Type      Field  Description  Columns  Ordering
+render         0      render    ·      ·            ("1")    "1"=CONST
+ └── emptyrow  1      emptyrow  ·      ·            ("1")    "1"=CONST
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT 1]
@@ -27,13 +27,13 @@ SELECT message FROM [SHOW KV TRACE FOR SELECT 1]
 ----
 output row: [1]
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (TYPES) SELECT 1
 ----
-Level  Type      Field     Description  Columns    Ordering
-0      render    ·         ·            ("1" int)  "1"=CONST
-0      ·         render 0  (1)[int]     ·          ·
-1      emptyrow  ·         ·            ()         ·
+Tree           Level  Type      Field     Description  Columns    Ordering
+render         0      render    ·         ·            ("1" int)  "1"=CONST
+ │             0      ·         render 0  (1)[int]     ·          ·
+ └── emptyrow  1      emptyrow  ·         ·            ("1" int)  "1"=CONST
 
 statement error cannot set EXPLAIN mode more than once
 EXPLAIN (PLAN,PLAN) SELECT 1
@@ -45,193 +45,193 @@ statement error unsupported EXPLAIN option
 EXPLAIN (PLAN,UNKNOWN) SELECT 1
 
 # Ensure that tracing results are sorted after gathering
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SHOW TRACE FOR SELECT 1
 ----
-0  sort            ·      ·             ("timestamp", age, message, tag, loc, operation, span)                                 +"timestamp"
-0  ·               order  +"timestamp"  ·                                                                                      ·
-1  window          ·      ·             ("timestamp", age, message, tag, loc, operation, span)                                 ·
-2  render          ·      ·             ("timestamp", """timestamp""", message, tag, loc, operation, span)                     "timestamp"="""timestamp"""
-3  window          ·      ·             ("timestamp", message, tag, loc, operation, span)                                      ·
-4  render          ·      ·             ("timestamp", message, tag, loc, operation, span, txn_idx, span_idx, message_idx)      ·
-5  show trace for  ·      ·             (txn_idx, span_idx, message_idx, "timestamp", duration, operation, loc, tag, message)  ·
-6  render          ·      ·             ("1")                                                                                  "1"=CONST
-7  emptyrow        ·      ·             ()                                                                                     ·
+sort                                         0  sort            ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
+ │                                           0  ·               order  +"timestamp"  ·                                                       ·
+ └── window                                  1  window          ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
+      └── render                             2  render          ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
+           └── window                        3  window          ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
+                └── render                   4  render          ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
+                     └── show trace for      5  show trace for  ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
+                          └── render         6  render          ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
+                               └── emptyrow  7  emptyrow        ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
 
 # Ensure that all relevant statement types can be explained
-query ITTT
+query TTT
 EXPLAIN CREATE DATABASE foo
 ----
-0  create database  ·  ·
+create database  ·  ·
 
-query ITTT
+query TTT
 EXPLAIN CREATE TABLE foo (x INT)
 ----
-0  create table  ·  ·
+create table  ·  ·
 
 statement ok
 CREATE TABLE foo (x INT)
 
-query ITTT
+query TTT
 EXPLAIN CREATE INDEX a ON foo(x)
 ----
-0  create index  ·  ·
+create index  ·  ·
 
 statement ok
 CREATE DATABASE foo
 
-query ITTT
+query TTT
 EXPLAIN DROP DATABASE foo
 ----
-0  drop database  ·  ·
+drop database  ·  ·
 
 # explain SHOW JOBS - beware to test this before the CREATE INDEX
 # below, otherwise the result becomes non-deterministic.
 # Migrations with backfill will affect the number of rows.
-query ITTT
+query TTT
 EXPLAIN SHOW JOBS
 ----
-0  render  ·     ·
-1  values  ·     ·
-1  ·       size  13 columns, 1 row
+render       ·     ·
+ └── values  ·     ·
+·            size  13 columns, 1 row
 
 statement ok
 CREATE INDEX a ON foo(x)
 
-query ITTT
+query TTT
 EXPLAIN DROP INDEX foo@a
 ----
-0  drop index  ·  ·
+drop index  ·  ·
 
-query ITTT
+query TTT
 EXPLAIN ALTER TABLE foo ADD COLUMN y INT
 ----
-0  alter table  ·  ·
+alter table  ·  ·
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) ALTER TABLE foo SPLIT AT VALUES (42)
 ----
-0  split   ·              ·
-1  values  ·              ·
-1  ·       size           1 column, 1 row
-1  ·       row 0, expr 0  42
+split        ·              ·
+ └── values  ·              ·
+·            size           1 column, 1 row
+·            row 0, expr 0  42
 
-query ITTT
+query TTT
 EXPLAIN DROP TABLE foo
 ----
-0  drop table  ·  ·
+drop table  ·  ·
 
-query ITTT
+query TTT
 EXPLAIN SHOW DATABASES
 ----
-0  sort    ·      ·
-0  ·       order  +"Database"
-1  render  ·      ·
-2  values  ·      ·
-2  ·       size   4 columns, 6 rows
+sort              ·      ·
+ │                order  +"Database"
+ └── render       ·      ·
+      └── values  ·      ·
+·                 size   4 columns, 6 rows
 
-query ITTT
+query TTT
 EXPLAIN SHOW TABLES
 ----
-0  sort    ·      ·
-0  ·       order  +"Table"
-1  render  ·      ·
-2  filter  ·      ·
-3  values  ·      ·
-3  ·       size   5 columns, 75 rows
+sort                   ·      ·
+ │                     order  +"Table"
+ └── render            ·      ·
+      └── filter       ·      ·
+           └── values  ·      ·
+·                      size   5 columns, 75 rows
 
-query ITTT
+query TTT
 EXPLAIN SHOW DATABASE
 ----
-0  render  ·     ·
-1  filter  ·     ·
-2  values  ·     ·
-2  ·       size  2 columns, 24 rows
+render            ·     ·
+ └── filter       ·     ·
+      └── values  ·     ·
+·                 size  2 columns, 24 rows
 
-query ITTT
+query TTT
 EXPLAIN SHOW TIME ZONE
 ----
-0  render  ·     ·
-1  filter  ·     ·
-2  values  ·     ·
-2  ·       size  2 columns, 24 rows
+render            ·     ·
+ └── filter       ·     ·
+      └── values  ·     ·
+·                 size  2 columns, 24 rows
 
-query ITTT
+query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 ----
-0  render  ·     ·
-1  filter  ·     ·
-2  values  ·     ·
-2  ·       size  2 columns, 24 rows
+render            ·     ·
+ └── filter       ·     ·
+      └── values  ·     ·
+·                 size  2 columns, 24 rows
 
-query ITTT
+query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 ----
-0  render  ·     ·
-1  filter  ·     ·
-2  values  ·     ·
-2  ·       size  2 columns, 24 rows
+render            ·     ·
+ └── filter       ·     ·
+      └── values  ·     ·
+·                 size  2 columns, 24 rows
 
-query ITTT
+query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
 ----
-0  render  ·     ·
-1  filter  ·     ·
-2  values  ·     ·
-2  ·       size  2 columns, 24 rows
+render            ·     ·
+ └── filter       ·     ·
+      └── values  ·     ·
+·                 size  2 columns, 24 rows
 
-query ITTT
+query TTT
 EXPLAIN SHOW COLUMNS FROM foo
 ----
-0  sort    ·         ·
-0  ·       order     +ordinal_position
-1  render  ·         ·
-2  group   ·         ·
-2  ·       group by  @1-@5
-3  render  ·         ·
-4  join    ·         ·
-4  ·       type      left outer
-4  ·       equality  (column_name) = (column_name)
-5  render  ·         ·
-6  filter  ·         ·
-7  values  ·         ·
-7  ·       size      13 columns, 628 rows
-5  render  ·         ·
-6  filter  ·         ·
-7  values  ·         ·
-7  ·       size      13 columns, 37 rows
+sort                                       ·         ·
+ │                                         order     +ordinal_position
+ └── render                                ·         ·
+      └── group                            ·         ·
+           │                               group by  @1-@5
+           └── render                      ·         ·
+                └── join                   ·         ·
+                     │                     type      left outer
+                     │                     equality  (column_name) = (column_name)
+                     ├── render            ·         ·
+                     │    └── filter       ·         ·
+                     │         └── values  ·         ·
+                     │                     size      13 columns, 628 rows
+                     └── render            ·         ·
+                          └── filter       ·         ·
+                               └── values  ·         ·
+·                                          size      13 columns, 37 rows
 
-query ITTT
+query TTT
 EXPLAIN SHOW GRANTS ON foo
 ----
-0  sort    ·      ·
-0  ·       order  +"Database",+"Table",+"User",+"Privileges"
-1  render  ·      ·
-2  filter  ·      ·
-3  values  ·      ·
-3  ·       size   8 columns, 130 rows
+sort                   ·      ·
+ │                     order  +"Database",+"Table",+"User",+"Privileges"
+ └── render            ·      ·
+      └── filter       ·      ·
+           └── values  ·      ·
+·                      size   8 columns, 130 rows
 
 
-query ITTT
+query TTT
 EXPLAIN SHOW INDEX FROM foo
 ----
-0  render  ·     ·
-1  filter  ·     ·
-2  values  ·     ·
-2  ·       size  13 columns, 37 rows
+render            ·     ·
+ └── filter       ·     ·
+      └── values  ·     ·
+·                 size  13 columns, 37 rows
 
-query ITTT
+query TTT
 EXPLAIN SHOW CONSTRAINTS FROM foo
 ----
-0  sort    ·      ·
-0  ·       order  +"Table",+"Name"
-1  values  ·      ·
-1  ·       size   5 columns, 0 rows
+sort         ·      ·
+ │           order  +"Table",+"Name"
+ └── values  ·      ·
+·            size   5 columns, 0 rows
 
-query ITTT
+query TTT
 EXPLAIN SHOW USERS
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  users@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  users@primary
+·          spans  ALL

--- a/pkg/sql/logictest/testdata/logic_test/explain_plan
+++ b/pkg/sql/logictest/testdata/logic_test/explain_plan
@@ -6,138 +6,138 @@ CREATE TABLE t (
   v INT
 )
 
-query ITTT
+query TTT
 EXPLAIN INSERT INTO t VALUES (1, 2)
 ----
-0  insert  ·     ·
-0  ·       into  t(k, v)
-1  values  ·     ·
-1  ·       size  2 columns, 1 row
+insert       ·     ·
+ │           into  t(k, v)
+ └── values  ·     ·
+·            size  2 columns, 1 row
 
 query I
-SELECT MAX("Level") FROM [EXPLAIN INSERT INTO t VALUES (1, 2)]
+SELECT MAX("Level") FROM [EXPLAIN (VERBOSE) INSERT INTO t VALUES (1, 2)]
 ----
 1
 
 statement ok
 INSERT INTO t VALUES (1, 2)
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t
 ----
-0  scan  ·      ·
-0  ·     table  t@primary
-0  ·     spans  ALL
+scan  ·      ·
+·     table  t@primary
+·     spans  ALL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM t
 ----
-0  scan  ·      ·          (k, v)  k!=NULL; key(k)
-0  ·     table  t@primary  ·       ·
-0  ·     spans  ALL        ·       ·
+scan  0  scan  ·      ·          (k, v)  k!=NULL; key(k)
+·     0  ·     table  t@primary  ·       ·
+·     0  ·     spans  ALL        ·       ·
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t WHERE k = 1 OR k = 3
 ----
-0  scan  ·      ·
-0  ·     table  t@primary
-0  ·     spans  /1-/1/# /3-/3/#
+scan  ·      ·
+·     table  t@primary
+·     spans  /1-/1/# /3-/3/#
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE k % 2 = 0
 ----
-0  scan  ·       ·            (k, v)  k!=NULL; key(k)
-0  ·     table   t@primary    ·       ·
-0  ·     spans   ALL          ·       ·
-0  ·     filter  (k % 2) = 0  ·       ·
+scan  0  scan  ·       ·            (k, v)  k!=NULL; key(k)
+·     0  ·     table   t@primary    ·       ·
+·     0  ·     spans   ALL          ·       ·
+·     0  ·     filter  (k % 2) = 0  ·       ·
 
-query ITTT
+query TTT
 EXPLAIN VALUES (1, 2, 3), (4, 5, 6)
 ----
-0  values  ·     ·
-0  ·       size  3 columns, 2 rows
+values  ·     ·
+·       size  3 columns, 2 rows
 
-query ITTT
+query TTT
 EXPLAIN VALUES (1)
 ----
-0  values  ·     ·
-0  ·       size  1 column, 1 row
+values  ·     ·
+·       size  1 column, 1 row
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
 ----
-0  limit       ·       ·
-0  ·           count   1
-0  ·           offset  1
-1  ordinality  ·       ·
-2  scan        ·       ·
-2  ·           table   t@primary
-2  ·           spans   ALL
-2  ·           limit   2
+limit            ·       ·
+ │               count   1
+ │               offset  1
+ └── ordinality  ·       ·
+      └── scan   ·       ·
+·                table   t@primary
+·                spans   ALL
+·                limit   2
 
-query ITTT
+query TTT
 EXPLAIN SELECT DISTINCT v FROM t
 ----
-0  distinct  ·      ·
-1  render    ·      ·
-2  scan      ·      ·
-2  ·         table  t@primary
-2  ·         spans  ALL
+distinct        ·      ·
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  t@primary
+·               spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1
 ----
-0  limit     ·         ·
-0  ·         count     1
-0  ·         offset    1
-1  distinct  ·         ·
-2  render    ·         ·
-2  ·         render 0  v
-3  scan      ·         ·
-3  ·         table     t@primary
-3  ·         spans     ALL
+limit                ·         ·
+ │                   count     1
+ │                   offset    1
+ └── distinct        ·         ·
+      └── render     ·         ·
+           │         render 0  v
+           └── scan  ·         ·
+·                    table     t@primary
+·                    spans     ALL
 
 # Ensure EXPLAIN EXECUTE works properly
 
 statement ok
 PREPARE x AS SELECT DISTINCT v from t LIMIT $1
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) EXECUTE x(3)
 ----
-0  limit     ·         ·
-0  ·         count     3
-1  distinct  ·         ·
-2  render    ·         ·
-2  ·         render 0  v
-3  scan      ·         ·
-3  ·         table     t@primary
-3  ·         spans     ALL
+limit                ·         ·
+ │                   count     3
+ └── distinct        ·         ·
+      └── render     ·         ·
+           │         render 0  v
+           └── scan  ·         ·
+·                    table     t@primary
+·                    spans     ALL
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM [EXECUTE x(3)]
 ----
-0  limit     ·         ·
-0  ·         count     3
-1  distinct  ·         ·
-2  render    ·         ·
-2  ·         render 0  v
-3  scan      ·         ·
-3  ·         table     t@primary
-3  ·         spans     ALL
+limit                ·         ·
+ │                   count     3
+ └── distinct        ·         ·
+      └── render     ·         ·
+           │         render 0  v
+           └── scan  ·         ·
+·                    table     t@primary
+·                    spans     ALL
 
 statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-0  sort        ·      ·           (a, b)                                   a=CONST; +b
-0  ·           order  +b          ·                                        ·
-1  render      ·      ·           (a, b)                                   a=CONST
-2  index-join  ·      ·           (a, b, rowid[hidden,omitted])            a=CONST; rowid!=NULL; key(rowid)
-3  scan        ·      ·           (a[omitted], b[omitted], rowid[hidden])  a=CONST; rowid!=NULL; key(rowid)
-3  ·           table  tc@c        ·                                        ·
-3  ·           spans  /10-/11     ·                                        ·
-3  scan        ·      ·           (a, b, rowid[hidden,omitted])            ·
-3  ·           table  tc@primary  ·                                        ·
+sort                  0  sort        ·      ·           (a, b)  a=CONST; +b
+ │                    0  ·           order  +b          ·       ·
+ └── render           1  render      ·      ·           (a, b)  a=CONST; +b
+      └── index-join  2  index-join  ·      ·           (a, b)  a=CONST; +b
+           ├── scan   3  scan        ·      ·           (a, b)  a=CONST; +b
+           │          3  ·           table  tc@c        ·       ·
+           │          3  ·           spans  /10-/11     ·       ·
+           └── scan   3  scan        ·      ·           (a, b)  a=CONST; +b
+·                     3  ·           table  tc@primary  ·       ·

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -6,301 +6,301 @@ CREATE TABLE t (
   v INT
 )
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
-Level  Type    Field          Description       Columns                     Ordering
-0      insert  ·              ·                 ()                          ·
-0      ·       into           t(k, v)           ·                           ·
-1      values  ·              ·                 (column1 int, column2 int)  ·
-1      ·       size           2 columns, 1 row  ·                           ·
-1      ·       row 0, expr 0  (1)[int]          ·                           ·
-1      ·       row 0, expr 1  (2)[int]          ·                           ·
+Tree         Level  Type    Field          Description       Columns  Ordering
+insert       0      insert  ·              ·                 ()       ·
+ │           0      ·       into           t(k, v)           ·        ·
+ └── values  1      values  ·              ·                 ()       ·
+·            1      ·       size           2 columns, 1 row  ·        ·
+·            1      ·       row 0, expr 0  (1)[int]          ·        ·
+·            1      ·       row 0, expr 1  (2)[int]          ·        ·
 
 statement ok
 INSERT INTO t VALUES (1, 2)
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT 42
 ----
-0  render    ·         ·          ("42" int)  "42"=CONST
-0  ·         render 0  (42)[int]  ·           ·
-1  emptyrow  ·         ·          ()          ·
+render         0  render    ·         ·          ("42" int)  "42"=CONST
+ │             0  ·         render 0  (42)[int]  ·           ·
+ └── emptyrow  1  emptyrow  ·         ·          ("42" int)  "42"=CONST
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT * FROM t
 ----
-0  scan  ·      ·          (k int, v int)  k!=NULL; key(k)
-0  ·     table  t@primary  ·               ·
-0  ·     spans  ALL        ·               ·
+scan  0  scan  ·      ·          (k int, v int)  k!=NULL; key(k)
+·     0  ·     table  t@primary  ·               ·
+·     0  ·     spans  ALL        ·               ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,SYMVARS) SELECT k FROM t
 ----
-0  render  ·         ·          (k int)                  k!=NULL; key(k)
-0  ·       render 0  (@1)[int]  ·                        ·
-1  scan    ·         ·          (k int, v[omitted] int)  k!=NULL; key(k)
-1  ·       table     t@primary  ·                        ·
-1  ·       spans     ALL        ·                        ·
+render     0  render  ·         ·          (k int)  k!=NULL; key(k)
+ │         0  ·       render 0  (@1)[int]  ·        ·
+ └── scan  1  scan    ·         ·          (k int)  k!=NULL; key(k)
+·          1  ·       table     t@primary  ·        ·
+·          1  ·       spans     ALL        ·        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,QUALIFY) SELECT k FROM t
 ----
-0  render  ·         ·                (k int)                  k!=NULL; key(k)
-0  ·       render 0  (test.t.k)[int]  ·                        ·
-1  scan    ·         ·                (k int, v[omitted] int)  k!=NULL; key(k)
-1  ·       table     t@primary        ·                        ·
-1  ·       spans     ALL              ·                        ·
+render     0  render  ·         ·                (k int)  k!=NULL; key(k)
+ │         0  ·       render 0  (test.t.k)[int]  ·        ·
+ └── scan  1  scan    ·         ·                (k int)  k!=NULL; key(k)
+·          1  ·       table     t@primary        ·        ·
+·          1  ·       spans     ALL              ·        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
 ----
-0  render  ·         ·                              (k int, v int)  ·
-0  ·       render 0  (k)[int]                       ·               ·
-0  ·       render 1  (v)[int]                       ·               ·
-1  scan    ·         ·                              (k int, v int)  ·
-1  ·       table     t@primary                      ·               ·
-1  ·       filter    ((v)[int] > (123)[int])[bool]  ·               ·
+render     0  render  ·         ·                              (k int, v int)  ·
+ │         0  ·       render 0  (k)[int]                       ·               ·
+ │         0  ·       render 1  (v)[int]                       ·               ·
+ └── scan  1  scan    ·         ·                              (k int, v int)  ·
+·          1  ·       table     t@primary                      ·               ·
+·          1  ·       filter    ((v)[int] > (123)[int])[bool]  ·               ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT * FROM t WHERE v > 123
 ----
-0  scan  ·       ·                              (k int, v int)  k!=NULL; v!=NULL; key(k)
-0  ·     table   t@primary                      ·               ·
-0  ·     spans   ALL                            ·               ·
-0  ·     filter  ((v)[int] > (123)[int])[bool]  ·               ·
+scan  0  scan  ·       ·                              (k int, v int)  k!=NULL; v!=NULL; key(k)
+·     0  ·     table   t@primary                      ·               ·
+·     0  ·     spans   ALL                            ·               ·
+·     0  ·     filter  ((v)[int] > (123)[int])[bool]  ·               ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
 ----
-0  values  ·              ·                  (column1 int, column2 int, column3 int)  ·
-0  ·       size           3 columns, 2 rows  ·                                        ·
-0  ·       row 0, expr 0  (1)[int]           ·                                        ·
-0  ·       row 0, expr 1  (2)[int]           ·                                        ·
-0  ·       row 0, expr 2  (3)[int]           ·                                        ·
-0  ·       row 1, expr 0  (4)[int]           ·                                        ·
-0  ·       row 1, expr 1  (5)[int]           ·                                        ·
-0  ·       row 1, expr 2  (6)[int]           ·                                        ·
+values  0  values  ·              ·                  (column1 int, column2 int, column3 int)  ·
+·       0  ·       size           3 columns, 2 rows  ·                                        ·
+·       0  ·       row 0, expr 0  (1)[int]           ·                                        ·
+·       0  ·       row 0, expr 1  (2)[int]           ·                                        ·
+·       0  ·       row 0, expr 2  (3)[int]           ·                                        ·
+·       0  ·       row 1, expr 0  (4)[int]           ·                                        ·
+·       0  ·       row 1, expr 1  (5)[int]           ·                                        ·
+·       0  ·       row 1, expr 2  (6)[int]           ·                                        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND COUNT(k)>1
 ----
-0  render  ·            ·                                                                          (z int, v int)                        ·
-0  ·       render 0     ((2)[int] * (count)[int])[int]                                             ·                                     ·
-0  ·       render 1     (v)[int]                                                                   ·                                     ·
-1  filter  ·            ·                                                                          (v int, count int, count int, v int)  ·
-1  ·       filter       ((count)[int] > (1)[int])[bool]                                            ·                                     ·
-2  group   ·            ·                                                                          (v int, count int, count int, v int)  ·
-2  ·       aggregate 0  (v)[int]                                                                   ·                                     ·
-2  ·       aggregate 1  (count((k)[int]))[int]                                                     ·                                     ·
-2  ·       aggregate 2  (count((k)[int]))[int]                                                     ·                                     ·
-2  ·       aggregate 3  (v)[int]                                                                   ·                                     ·
-2  ·       group by     @1-@1                                                                      ·                                     ·
-3  render  ·            ·                                                                          (v int, k int)                        ·
-3  ·       render 0     (v)[int]                                                                   ·                                     ·
-3  ·       render 1     (k)[int]                                                                   ·                                     ·
-4  scan    ·            ·                                                                          (k int, v int)                        ·
-4  ·       table        t@primary                                                                  ·                                     ·
-4  ·       filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]  ·                                     ·
+render                    0  render  ·            ·                                                                          (z int, v int)  ·
+ │                        0  ·       render 0     ((2)[int] * (count)[int])[int]                                             ·               ·
+ │                        0  ·       render 1     (v)[int]                                                                   ·               ·
+ └── filter               1  filter  ·            ·                                                                          (z int, v int)  ·
+      │                   1  ·       filter       ((count)[int] > (1)[int])[bool]                                            ·               ·
+      └── group           2  group   ·            ·                                                                          (z int, v int)  ·
+           │              2  ·       aggregate 0  (v)[int]                                                                   ·               ·
+           │              2  ·       aggregate 1  (count((k)[int]))[int]                                                     ·               ·
+           │              2  ·       aggregate 2  (count((k)[int]))[int]                                                     ·               ·
+           │              2  ·       aggregate 3  (v)[int]                                                                   ·               ·
+           │              2  ·       group by     @1-@1                                                                      ·               ·
+           └── render     3  render  ·            ·                                                                          (z int, v int)  ·
+                │         3  ·       render 0     (v)[int]                                                                   ·               ·
+                │         3  ·       render 1     (k)[int]                                                                   ·               ·
+                └── scan  4  scan    ·            ·                                                                          (z int, v int)  ·
+·                         4  ·       table        t@primary                                                                  ·               ·
+·                         4  ·       filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]  ·               ·
 
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND COUNT(k)>1
 ----
-0  render  ·            ·                                (z int, v int)                        ·
-0  ·       render 0     ((2)[int] * (count)[int])[int]   ·                                     ·
-0  ·       render 1     (v)[int]                         ·                                     ·
-1  filter  ·            ·                                (v int, count int, count int, v int)  count!=NULL
-1  ·       filter       ((count)[int] > (1)[int])[bool]  ·                                     ·
-2  group   ·            ·                                (v int, count int, count int, v int)  ·
-2  ·       aggregate 0  (v)[int]                         ·                                     ·
-2  ·       aggregate 1  (count((k)[int]))[int]           ·                                     ·
-2  ·       aggregate 2  (count((k)[int]))[int]           ·                                     ·
-2  ·       aggregate 3  (v)[int]                         ·                                     ·
-2  ·       group by     @1-@1                            ·                                     ·
-3  render  ·            ·                                (v int, k int)                        ·
-3  ·       render 0     (v)[int]                         ·                                     ·
-3  ·       render 1     (k)[int]                         ·                                     ·
-4  norows  ·            ·                                ()                                    ·
+render                      0  render  ·            ·                                (z int, v int)  ·
+ │                          0  ·       render 0     ((2)[int] * (count)[int])[int]   ·               ·
+ │                          0  ·       render 1     (v)[int]                         ·               ·
+ └── filter                 1  filter  ·            ·                                (z int, v int)  ·
+      │                     1  ·       filter       ((count)[int] > (1)[int])[bool]  ·               ·
+      └── group             2  group   ·            ·                                (z int, v int)  ·
+           │                2  ·       aggregate 0  (v)[int]                         ·               ·
+           │                2  ·       aggregate 1  (count((k)[int]))[int]           ·               ·
+           │                2  ·       aggregate 2  (count((k)[int]))[int]           ·               ·
+           │                2  ·       aggregate 3  (v)[int]                         ·               ·
+           │                2  ·       group by     @1-@1                            ·               ·
+           └── render       3  render  ·            ·                                (z int, v int)  ·
+                │           3  ·       render 0     (v)[int]                         ·               ·
+                │           3  ·       render 1     (k)[int]                         ·               ·
+                └── norows  4  norows  ·            ·                                (z int, v int)  ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1
 ----
-0  delete  ·         ·                            ()              ·
-0  ·       from      t                            ·               ·
-1  render  ·         ·                            (k int)         ·
-1  ·       render 0  (k)[int]                     ·               ·
-2  scan    ·         ·                            (k int, v int)  ·
-2  ·       table     t@primary                    ·               ·
-2  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
+delete          0  delete  ·         ·                            ()  ·
+ │              0  ·       from      t                            ·   ·
+ └── render     1  render  ·         ·                            ()  ·
+      │         1  ·       render 0  (k)[int]                     ·   ·
+      └── scan  2  scan    ·         ·                            ()  ·
+·               2  ·       table     t@primary                    ·   ·
+·               2  ·       filter    ((v)[int] > (1)[int])[bool]  ·   ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-0  delete  ·         ·                            ()              ·
-0  ·       from      t                            ·               ·
-1  render  ·         ·                            (k int)         k!=NULL; key(k)
-1  ·       render 0  (k)[int]                     ·               ·
-2  scan    ·         ·                            (k int, v int)  k!=NULL; v!=NULL; key(k)
-2  ·       table     t@primary                    ·               ·
-2  ·       spans     ALL                          ·               ·
-2  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
+delete          0  delete  ·         ·                            ()  ·
+ │              0  ·       from      t                            ·   ·
+ └── render     1  render  ·         ·                            ()  ·
+      │         1  ·       render 0  (k)[int]                     ·   ·
+      └── scan  2  scan    ·         ·                            ()  ·
+·               2  ·       table     t@primary                    ·   ·
+·               2  ·       spans     ALL                          ·   ·
+·               2  ·       filter    ((v)[int] > (1)[int])[bool]  ·   ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-0  update  ·         ·                              ()                           ·
-0  ·       table     t                              ·                            ·
-0  ·       set       v                              ·                            ·
-1  render  ·         ·                              (k int, v int, "k + 1" int)  k!=NULL; v!=NULL; key(k)
-1  ·       render 0  (k)[int]                       ·                            ·
-1  ·       render 1  (v)[int]                       ·                            ·
-1  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
-2  scan    ·         ·                              (k int, v int)               k!=NULL; v!=NULL; key(k)
-2  ·       table     t@primary                      ·                            ·
-2  ·       spans     ALL                            ·                            ·
-2  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
+update          0  update  ·         ·                              ()  ·
+ │              0  ·       table     t                              ·   ·
+ │              0  ·       set       v                              ·   ·
+ └── render     1  render  ·         ·                              ()  ·
+      │         1  ·       render 0  (k)[int]                       ·   ·
+      │         1  ·       render 1  (v)[int]                       ·   ·
+      │         1  ·       render 2  ((k)[int] + (1)[int])[int]     ·   ·
+      └── scan  2  scan    ·         ·                              ()  ·
+·               2  ·       table     t@primary                      ·   ·
+·               2  ·       spans     ALL                            ·   ·
+·               2  ·       filter    ((v)[int] > (123)[int])[bool]  ·   ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-0  update  ·         ·                              ()                           ·
-0  ·       table     t                              ·                            ·
-0  ·       set       v                              ·                            ·
-1  render  ·         ·                              (k int, v int, "k + 1" int)  ·
-1  ·       render 0  (k)[int]                       ·                            ·
-1  ·       render 1  (v)[int]                       ·                            ·
-1  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
-2  scan    ·         ·                              (k int, v int)               ·
-2  ·       table     t@primary                      ·                            ·
-2  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
+update          0  update  ·         ·                              ()  ·
+ │              0  ·       table     t                              ·   ·
+ │              0  ·       set       v                              ·   ·
+ └── render     1  render  ·         ·                              ()  ·
+      │         1  ·       render 0  (k)[int]                       ·   ·
+      │         1  ·       render 1  (v)[int]                       ·   ·
+      │         1  ·       render 2  ((k)[int] + (1)[int])[int]     ·   ·
+      └── scan  2  scan    ·         ·                              ()  ·
+·               2  ·       table     t@primary                      ·   ·
+·               2  ·       filter    ((v)[int] > (123)[int])[bool]  ·   ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
 ----
-0  union   ·              ·                (column1 int)  ·
-1  values  ·              ·                (column1 int)  ·
-1  ·       size           1 column, 1 row  ·              ·
-1  ·       row 0, expr 0  (2)[int]         ·              ·
-1  values  ·              ·                (column1 int)  ·
-1  ·       size           1 column, 1 row  ·              ·
-1  ·       row 0, expr 0  (1)[int]         ·              ·
+union        0  union   ·              ·                (column1 int)  ·
+ ├── values  1  values  ·              ·                (column1 int)  ·
+ │           1  ·       size           1 column, 1 row  ·              ·
+ │           1  ·       row 0, expr 0  (2)[int]         ·              ·
+ └── values  1  values  ·              ·                (column1 int)  ·
+·            1  ·       size           1 column, 1 row  ·              ·
+·            1  ·       row 0, expr 0  (1)[int]         ·              ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-0  render  ·         ·          (k int)                  k!=NULL; key(k)
-0  ·       render 0  (k)[int]   ·                        ·
-1  scan    ·         ·          (k int, v[omitted] int)  k!=NULL; key(k)
-1  ·       table     t@primary  ·                        ·
-1  ·       spans     ALL        ·                        ·
+render     0  render  ·         ·          (k int)  k!=NULL; key(k)
+ │         0  ·       render 0  (k)[int]   ·        ·
+ └── scan  1  scan    ·         ·          (k int)  k!=NULL; key(k)
+·          1  ·       table     t@primary  ·        ·
+·          1  ·       spans     ALL        ·        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT DISTINCT k FROM t
 ----
-0  distinct  ·         ·          (k int)                  weak-key(k)
-1  render    ·         ·          (k int)                  ·
-1  ·         render 0  (k)[int]   ·                        ·
-2  scan      ·         ·          (k int, v[omitted] int)  ·
-2  ·         table     t@primary  ·                        ·
+distinct        0  distinct  ·         ·          (k int)  weak-key(k)
+ └── render     1  render    ·         ·          (k int)  weak-key(k)
+      │         1  ·         render 0  (k)[int]   ·        ·
+      └── scan  2  scan      ·         ·          (k int)  weak-key(k)
+·               2  ·         table     t@primary  ·        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 ----
-0  sort    ·         ·          (v int)                  +v
-0  ·       order     +v         ·                        ·
-1  render  ·         ·          (v int)                  ·
-1  ·       render 0  (v)[int]   ·                        ·
-2  scan    ·         ·          (k[omitted] int, v int)  k!=NULL; key(k)
-2  ·       table     t@primary  ·                        ·
-2  ·       spans     ALL        ·                        ·
+sort            0  sort    ·         ·          (v int)  +v
+ │              0  ·       order     +v         ·        ·
+ └── render     1  render  ·         ·          (v int)  +v
+      │         1  ·       render 0  (v)[int]   ·        ·
+      └── scan  2  scan    ·         ·          (v int)  +v
+·               2  ·       table     t@primary  ·        ·
+·               2  ·       spans     ALL        ·        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t ORDER BY v
 ----
-0  nosort  ·         ·          (v int)                  ·
-0  ·       order     +v         ·                        ·
-1  render  ·         ·          (v int)                  ·
-1  ·       render 0  (v)[int]   ·                        ·
-2  scan    ·         ·          (k[omitted] int, v int)  ·
-2  ·       table     t@primary  ·                        ·
+nosort          0  nosort  ·         ·          (v int)  ·
+ │              0  ·       order     +v         ·        ·
+ └── render     1  render  ·         ·          (v int)  ·
+      │         1  ·       render 0  (v)[int]   ·        ·
+      └── scan  2  scan    ·         ·          (v int)  ·
+·               2  ·       table     t@primary  ·        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 ----
-0  limit   ·         ·          (v int)                  ·
-0  ·       count     (1)[int]   ·                        ·
-1  render  ·         ·          (v int)                  ·
-1  ·       render 0  (v)[int]   ·                        ·
-2  scan    ·         ·          (k[omitted] int, v int)  k!=NULL; key(k)
-2  ·       table     t@primary  ·                        ·
-2  ·       spans     ALL        ·                        ·
-2  ·       limit     1          ·                        ·
+limit           0  limit   ·         ·          (v int)  ·
+ │              0  ·       count     (1)[int]   ·        ·
+ └── render     1  render  ·         ·          (v int)  ·
+      │         1  ·       render 0  (v)[int]   ·        ·
+      └── scan  2  scan    ·         ·          (v int)  ·
+·               2  ·       table     t@primary  ·        ·
+·               2  ·       spans     ALL        ·        ·
+·               2  ·       limit     1          ·        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t LIMIT 1
 ----
-0  limit   ·         ·          (v int)                  ·
-0  ·       count     (1)[int]   ·                        ·
-1  render  ·         ·          (v int)                  ·
-1  ·       render 0  (v)[int]   ·                        ·
-2  scan    ·         ·          (k[omitted] int, v int)  ·
-2  ·       table     t@primary  ·                        ·
+limit           0  limit   ·         ·          (v int)  ·
+ │              0  ·       count     (1)[int]   ·        ·
+ └── render     1  render  ·         ·          (v int)  ·
+      │         1  ·       render 0  (v)[int]   ·        ·
+      └── scan  2  scan    ·         ·          (v int)  ·
+·               2  ·       table     t@primary  ·        ·
 
 statement ok
 CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0  render      ·         ·                             (x int, y int)                                       x!=NULL; y!=NULL
-0  ·           render 0  (x)[int]                      ·                                                    ·
-0  ·           render 1  (y)[int]                      ·                                                    ·
-1  index-join  ·         ·                             (x int, y int, rowid[hidden,omitted] int)            x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
-2  scan        ·         ·                             (x[omitted] int, y[omitted] int, rowid[hidden] int)  x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
-2  ·           table     tt@a                          ·                                                    ·
-2  ·           spans     /!NULL-/10                    ·                                                    ·
-2  scan        ·         ·                             (x int, y int, rowid[hidden,omitted] int)            ·
-2  ·           table     tt@primary                    ·                                                    ·
-2  ·           filter    ((y)[int] > (10)[int])[bool]  ·                                                    ·
+render           0  render      ·         ·                             (x int, y int)  x!=NULL; y!=NULL
+ │               0  ·           render 0  (x)[int]                      ·               ·
+ │               0  ·           render 1  (y)[int]                      ·               ·
+ └── index-join  1  index-join  ·         ·                             (x int, y int)  x!=NULL; y!=NULL
+      ├── scan   2  scan        ·         ·                             (x int, y int)  x!=NULL; y!=NULL
+      │          2  ·           table     tt@a                          ·               ·
+      │          2  ·           spans     /!NULL-/10                    ·               ·
+      └── scan   2  scan        ·         ·                             (x int, y int)  x!=NULL; y!=NULL
+·                2  ·           table     tt@primary                    ·               ·
+·                2  ·           filter    ((y)[int] > (10)[int])[bool]  ·               ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-0  render  ·         ·                                                                          (x int, y int)                             ·
-0  ·       render 0  (x)[int]                                                                   ·                                          ·
-0  ·       render 1  (y)[int]                                                                   ·                                          ·
-1  scan    ·         ·                                                                          (x int, y int, rowid[hidden,omitted] int)  ·
-1  ·       table     tt@primary                                                                 ·                                          ·
-1  ·       filter    ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·                                          ·
+render     0  render  ·         ·                                                                          (x int, y int)  ·
+ │         0  ·       render 0  (x)[int]                                                                   ·               ·
+ │         0  ·       render 1  (y)[int]                                                                   ·               ·
+ └── scan  1  scan    ·         ·                                                                          (x int, y int)  ·
+·          1  ·       table     tt@primary                                                                 ·               ·
+·          1  ·       filter    ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·               ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT $1 + 2 AS a
 ----
-0  render    ·         ·                            (a int)  a=CONST
-0  ·         render 0  (($1)[int] + (2)[int])[int]  ·        ·
-1  emptyrow  ·         ·                            ()       ·
+render         0  render    ·         ·                            (a int)  a=CONST
+ │             0  ·         render 0  (($1)[int] + (2)[int])[int]  ·        ·
+ └── emptyrow  1  emptyrow  ·         ·                            (a int)  a=CONST
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT ABS(2-3) AS a
 ----
-0  render    ·         ·                      (a int)  a=CONST
-0  ·         render 0  (abs((-1)[int]))[int]  ·        ·
-1  emptyrow  ·         ·                      ()       ·
+render         0  render    ·         ·                      (a int)  a=CONST
+ │             0  ·         render 0  (abs((-1)[int]))[int]  ·        ·
+ └── emptyrow  1  emptyrow  ·         ·                      (a int)  a=CONST
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT ABS(2-3) AS a
 ----
-0  render    ·         ·         (a int)  a=CONST
-0  ·         render 0  (1)[int]  ·        ·
-1  emptyrow  ·         ·         ()       ·
+render         0  render    ·         ·         (a int)  a=CONST
+ │             0  ·         render 0  (1)[int]  ·        ·
+ └── emptyrow  1  emptyrow  ·         ·         (a int)  a=CONST
 
 # Check array subscripts (#13811)
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT x[1] FROM (SELECT ARRAY[1,2,3] AS x)
 ----
-0  render    ·         ·                                           ("x[1]" int)  ·
-0  ·         render 0  ((x)[int[]][(1)[int]])[int]                 ·             ·
-1  render    ·         ·                                           (x int[])     x=CONST
-1  ·         render 0  (ARRAY[(1)[int],(2)[int],(3)[int]])[int[]]  ·             ·
-2  emptyrow  ·         ·                                           ()            ·
+render              0  render    ·         ·                                           ("x[1]" int)  ·
+ │                  0  ·         render 0  ((x)[int[]][(1)[int]])[int]                 ·             ·
+ └── render         1  render    ·         ·                                           ("x[1]" int)  ·
+      │             1  ·         render 0  (ARRAY[(1)[int],(2)[int],(3)[int]])[int[]]  ·             ·
+      └── emptyrow  2  emptyrow  ·         ·                                           ("x[1]" int)  ·

--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -18,29 +18,29 @@ INSERT INTO p VALUES ('-0'::float)
 # - `WHERE f = 'NaN'` should also perform a point lookup.
 # - `WHERE isnan(f)` is a function so it can't perform a point lookup.
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p WHERE f IS NaN
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  p@p_f_key
-1  ·       spans  /NaN-/NaN/PrefixEnd
+render     ·      ·
+ └── scan  ·      ·
+·          table  p@p_f_key
+·          spans  /NaN-/NaN/PrefixEnd
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p WHERE f = 'NaN'
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  p@p_f_key
-1  ·       spans  /NaN-/NaN/PrefixEnd
+render     ·      ·
+ └── scan  ·      ·
+·          table  p@p_f_key
+·          spans  /NaN-/NaN/PrefixEnd
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p WHERE isnan(f)
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  p@p_f_key
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  p@p_f_key
+·          spans  ALL
 
 query R
 SELECT * FROM p WHERE f = 'NaN'

--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -30,10 +30,10 @@ query T
 SELECT * FROM GENERATE_SERIES('2017-11-11 00:00:00'::TIMESTAMP, '2017-11-11 03:00:00'::TIMESTAMP, '-1 hour')
 ----
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM GENERATE_SERIES(1, 3)
 ----
-0  generator  ·  ·
+generator  ·  ·
 
 query II colnames
 SELECT * FROM GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
@@ -44,13 +44,13 @@ generate_series  generate_series
 2                1
 2                2
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
 ----
-0  join       ·     ·
-0  ·          type  cross
-1  generator  ·     ·
-1  generator  ·     ·
+join            ·     ·
+ │              type  cross
+ ├── generator  ·     ·
+ └── generator  ·     ·
 
 query I
 SELECT * FROM GENERATE_SERIES(3, 1, -1)
@@ -101,10 +101,10 @@ generate_series
 1
 2
 
-query ITTT
+query TTT
 EXPLAIN SELECT GENERATE_SERIES(1, 3)
 ----
-0  generator  ·  ·
+generator  ·  ·
 
 query II colnames
 SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(3, 4)
@@ -115,13 +115,13 @@ generate_series             generate_series
 2                           3
 2                           4
 
-query ITTT
+query TTT
 EXPLAIN SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
 ----
-0  join       ·     ·
-0  ·          type  cross
-1  generator  ·     ·
-1  generator  ·     ·
+join            ·     ·
+ │              type  cross
+ ├── generator  ·     ·
+ └── generator  ·     ·
 
 statement ok
 CREATE TABLE t (a string)
@@ -146,30 +146,30 @@ cat  bird  1  4
 cat  bird  2  3
 cat  bird  2  4
 
-query ITTT
+query TTT
 EXPLAIN(EXPRS) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
 ----
-0  render     ·         ·
-0  ·          render 0  a
-0  ·          render 1  b
-0  ·          render 2  generate_series
-0  ·          render 3  generate_series
-1  join       ·         ·
-1  ·          type      cross
-2  join       ·         ·
-2  ·          type      cross
-3  join       ·         ·
-3  ·          type      cross
-4  scan       ·         ·
-4  ·          table     t@primary
-4  ·          spans     ALL
-4  scan       ·         ·
-4  ·          table     u@primary
-4  ·          spans     ALL
-3  generator  ·         ·
-3  ·          expr      generate_series(1, 2)
-2  generator  ·         ·
-2  ·          expr      generate_series(3, 4)
+render                    ·         ·
+ │                        render 0  a
+ │                        render 1  b
+ │                        render 2  generate_series
+ │                        render 3  generate_series
+ └── join                 ·         ·
+      │                   type      cross
+      ├── join            ·         ·
+      │    │              type      cross
+      │    ├── join       ·         ·
+      │    │    │         type      cross
+      │    │    ├── scan  ·         ·
+      │    │    │         table     t@primary
+      │    │    │         spans     ALL
+      │    │    └── scan  ·         ·
+      │    │              table     u@primary
+      │    │              spans     ALL
+      │    └── generator  ·         ·
+      │                   expr      generate_series(1, 2)
+      └── generator       ·         ·
+·                         expr      generate_series(3, 4)
 
 query TTII
 SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series(3, 4) AS b

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -591,22 +591,22 @@ INSERT INTO select_t VALUES (1, 9), (8, 2), (3, 7), (6, 4)
 
 # Check that INSERT supports ORDER BY (MySQL extension)
 
-query ITTT
+query TTT
 EXPLAIN (PLAN,EXPRS) INSERT INTO insert_t TABLE select_t ORDER BY v DESC
 ----
-0  insert  ·          ·
-0  ·       into       insert_t(x, v, rowid)
-0  ·       default 0  NULL
-0  ·       default 1  NULL
-0  ·       default 2  unique_rowid()
-1  sort    ·          ·
-1  ·       order      -v
-2  render  ·          ·
-2  ·       render 0   x
-2  ·       render 1   v
-3  scan    ·          ·
-3  ·       table      select_t@primary
-3  ·       spans      ALL
+insert               ·          ·
+ │                   into       insert_t(x, v, rowid)
+ │                   default 0  NULL
+ │                   default 1  NULL
+ │                   default 2  unique_rowid()
+ └── sort            ·          ·
+      │              order      -v
+      └── render     ·          ·
+           │         render 0   x
+           │         render 1   v
+           └── scan  ·          ·
+·                    table      select_t@primary
+·                    spans      ALL
 
 query II
 INSERT INTO insert_t TABLE select_t ORDER BY v DESC RETURNING x, v
@@ -621,23 +621,23 @@ INSERT INTO insert_t TABLE select_t ORDER BY v DESC RETURNING x, v
 statement ok
 TRUNCATE TABLE insert_t
 
-query ITTT
+query TTT
 EXPLAIN (PLAN,EXPRS) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
 ----
-0  insert  ·          ·
-0  ·       into       insert_t(x, v, rowid)
-0  ·       default 0  NULL
-0  ·       default 1  NULL
-0  ·       default 2  unique_rowid()
-1  limit   ·          ·
-1  ·       count      1
-2  render  ·          ·
-2  ·       render 0   x
-2  ·       render 1   v
-3  scan    ·          ·
-3  ·       table      select_t@primary
-3  ·       spans      ALL
-3  ·       limit      1
+insert               ·          ·
+ │                   into       insert_t(x, v, rowid)
+ │                   default 0  NULL
+ │                   default 1  NULL
+ │                   default 2  unique_rowid()
+ └── limit           ·          ·
+      │              count      1
+      └── render     ·          ·
+           │         render 0   x
+           │         render 1   v
+           └── scan  ·          ·
+·                    table      select_t@primary
+·                    spans      ALL
+·                    limit      1
 
 statement ok
 INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
@@ -660,50 +660,50 @@ SELECT * FROM insert_t
 
 # Check the grouping of LIMIT and ORDER BY
 
-query ITTT
+query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) LIMIT 1
 ----
-0  insert  ·     ·
-0  ·       into  insert_t(x, v, rowid)
-1  limit   ·     ·
-2  values  ·     ·
-2  ·       size  2 columns, 2 rows
+insert            ·     ·
+ │                into  insert_t(x, v, rowid)
+ └── limit        ·     ·
+      └── values  ·     ·
+·                 size  2 columns, 2 rows
 
-query ITTT
+query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1
 ----
-0  insert  ·         ·
-0  ·       into      insert_t(x, v, rowid)
-1  limit   ·         ·
-2  sort    ·         ·
-2  ·       order     +column2
-2  ·       strategy  top 1
-3  values  ·         ·
-3  ·       size      2 columns, 2 rows
+insert                 ·         ·
+ │                     into      insert_t(x, v, rowid)
+ └── limit             ·         ·
+      └── sort         ·         ·
+           │           order     +column2
+           │           strategy  top 1
+           └── values  ·         ·
+·                      size      2 columns, 2 rows
 
-query ITTT
+query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2) LIMIT 1
 ----
-0  insert  ·         ·
-0  ·       into      insert_t(x, v, rowid)
-1  limit   ·         ·
-2  sort    ·         ·
-2  ·       order     +column2
-2  ·       strategy  top 1
-3  values  ·         ·
-3  ·       size      2 columns, 2 rows
+insert                 ·         ·
+ │                     into      insert_t(x, v, rowid)
+ └── limit             ·         ·
+      └── sort         ·         ·
+           │           order     +column2
+           │           strategy  top 1
+           └── values  ·         ·
+·                      size      2 columns, 2 rows
 
-query ITTT
+query TTT
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) ORDER BY 2 LIMIT 1)
 ----
-0  insert  ·         ·
-0  ·       into      insert_t(x, v, rowid)
-1  limit   ·         ·
-2  sort    ·         ·
-2  ·       order     +column2
-2  ·       strategy  top 1
-3  values  ·         ·
-3  ·       size      2 columns, 2 rows
+insert                 ·         ·
+ │                     into      insert_t(x, v, rowid)
+ └── limit             ·         ·
+      └── sort         ·         ·
+           │           order     +column2
+           │           strategy  top 1
+           └── values  ·         ·
+·                      size      2 columns, 2 rows
 
 statement error pq: multiple LIMIT clauses not allowed
 EXPLAIN (PLAN) INSERT INTO insert_t (VALUES (1,1), (2,2) LIMIT 1) LIMIT 1

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -307,12 +307,12 @@ SELECT * FROM orders WHERE customer = 1 AND id = 1000
 ----
 1 1000 100.00000
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM orders WHERE customer = 1 AND id = 1000
 ----
-0  scan  ·      ·
-0  ·     table  orders@primary
-0  ·     spans  /1/#/66/1/1000-/1/#/66/1/1000/#
+scan  ·      ·
+·     table  orders@primary
+·     spans  /1/#/66/1/1000-/1/#/66/1/1000/#
 
 # Check that interleaving can occur across databases
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -427,23 +427,23 @@ SELECT "URL" FROM [EXPLAIN (DISTSQL)
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzslNGL1DAQxt_9K8I87eIITXunGFiIIMKK7Mrim_YhNHN7gV5SklSUo_-7pPW626Mriigc9K3JN1-_mfbH3IN1mnbqjgKIz8ABIQeEaygRGu8qCsH5JA2FW_0NRIZgbNPGdF0iVM4TiHuIJtYEArY2kq9JfaUDKU3-vTOWPCBoisrUfc4HuomQEsyd8t9lozzZmMKTwN6ZOpIXbLVaSc6-tFlW0IZxLoTY7j6t2ZvdWzYq1Ybx4qeyZvsDm5peXzLlD6-bcRUXo4ox6qHZfRsFkxxl-m4Hc7w9H-zoldXVran1qD6Z6YZuT-OhLFBeobwGhPGf1nQTV5I_X298Ku8fAeHclSwoX6J8BWWH4Np4YidEdSQQvMMLfJ2waq3zmjzpCUllN0Pgzr1wzaOy-eB8EswXsBew_yHY-cLXwtd_WpwzfB0oNM4G-q3NmKXFSvpIwxYOrvUVffSu6mOG47739ReaQhxUPhy2tpf6Bs_N_Jfmq4k5e2zO_ya5-CNz2T37EQAA__-LHJN8
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
   pid1 >= 11 AND pid1 <= 13
   OR pid1 >= 19 AND pid1 <= 21
   OR pid1 >= 31 AND pid1 <= 33
 ----
-0  render  ·               ·
-1  join    ·               ·
-1  ·       type            inner
-1  ·       equality        (pid1) = (pid1)
-1  ·       mergeJoinOrder  +"(pid1=pid1)"
-2  scan    ·               ·
-2  ·       table           parent1@primary
-2  ·       spans           /11-/13/# /19-/21/# /31-/33/#
-2  scan    ·               ·
-2  ·       table           grandchild2@primary
-2  ·       spans           /11/#/54/1-/13/#/54/2 /19/#/54/1-/21/#/54/2 /31/#/54/1-/33/#/54/2
+render          ·               ·
+ └── join       ·               ·
+      │         type            inner
+      │         equality        (pid1) = (pid1)
+      │         mergeJoinOrder  +"(pid1=pid1)"
+      ├── scan  ·               ·
+      │         table           parent1@primary
+      │         spans           /11-/13/# /19-/21/# /31-/33/#
+      └── scan  ·               ·
+·               table           grandchild2@primary
+·               spans           /11/#/54/1-/13/#/54/2 /19/#/54/1-/21/#/54/2 /31/#/54/1-/33/#/54/2
 
 # Swap parent1 and grandchild2 positions.
 query IIIIII rowsort,colnames
@@ -474,23 +474,23 @@ SELECT "URL" FROM [EXPLAIN (DISTSQL)
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzslNGL1DAQxt_9K8I87eIITXuHGFiIIMKKdKX4pn0IzVwv0EtKkopy9H-Xtu7udemKIgpC35p88_WbaX_MI1inKVcPFEB8Ag4IKSDcQonQeldRCM4P0lS4119BJAjGtl0crkuEynkC8QjRxIZAwN5G8g2pL1SQ0uTfOWPJA4KmqEwz5rynuwhDgnlQ_pusvbK6ujeNHsIHkb01TSQv2GazkZx97pIkox3jXAixzz9u2ev8DTsp1Y7x7IeyZYeCzU2vrpnS4-sWXNnVqOwUdWz20EXBJEeZosxQ3qC8BYTC1PdPp2yVJxv5UflvRpy6Pc8ICKd_2tBd3Ej-fLvzQ9X4CAgLHwTlSyh7BNfFMzshqppA8B6v8HXGqrPOa_KkZySV_QKBuXvh2ouy5eB0FsxXsFew_yLY6crXytc_WpwLfBUUWmcD_dJmTIbFSrqmaQsH1_mKPnhXjTHT8TD6xgtNIU4qnw57O0pjg0_N_Kfmm5k5uTSnf5Kc_Za57J99DwAA__-nJ5Nz
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
   pid1 >= 11 AND pid1 <= 13
   OR pid1 >= 19 AND pid1 <= 21
   OR pid1 >= 31 AND pid1 <= 33
 ----
-0  render  ·               ·
-1  join    ·               ·
-1  ·       type            inner
-1  ·       equality        (pid1) = (pid1)
-1  ·       mergeJoinOrder  +"(pid1=pid1)"
-2  scan    ·               ·
-2  ·       table           grandchild2@primary
-2  ·       spans           /11/#/54/1-/13/#/54/2 /19/#/54/1-/21/#/54/2 /31/#/54/1-/33/#/54/2
-2  scan    ·               ·
-2  ·       table           parent1@primary
-2  ·       spans           /11-/13/# /19-/21/# /31-/33/#
+render          ·               ·
+ └── join       ·               ·
+      │         type            inner
+      │         equality        (pid1) = (pid1)
+      │         mergeJoinOrder  +"(pid1=pid1)"
+      ├── scan  ·               ·
+      │         table           grandchild2@primary
+      │         spans           /11/#/54/1-/13/#/54/2 /19/#/54/1-/21/#/54/2 /31/#/54/1-/33/#/54/2
+      └── scan  ·               ·
+·               table           parent1@primary
+·               spans           /11-/13/# /19-/21/# /31-/33/#
 
 # Join on multiple interleaved columns with an overarching ancestor (parent1).
 # Returns:
@@ -530,7 +530,7 @@ SELECT "URL" FROM [EXPLAIN (DISTSQL)
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzsls-K2zAQh-99CjEnh0zBku3driCgQimklKSE3lofjDWbNXitIMmlZcm7F9mNdh3Sf-QWctSMvvwm_gTSE3RG06p6JAfyC3BAEICQAUIOCAWUCDtranLO2LBlBJb6O8gUoel2vQ_lEqE2lkA-gW98SyBh2XmyLVXfaEOVJvvBNB1ZQNDkq6Yd8j7SvYeQ0DxW9oeqH5pWh_xQZ-veS6Y4KoEqQxXm2TTbh5fA1ladjtTQZe-b1pOVLEkSxdnXPk0zWrBCSrlcfZ6xt6t3LDbqBbv91Zix9YYliRIR4WLKiMjw_AAdqDxS-d2UyiNV8AMVZz3-i6gKQIhfqqV7nyg-RyXmqLL5bGEDNikBwolfQXWD6hbVG1R3UO4RTO-fVTlfbQkk3-NvdD5b7DtjNVnSE3Hl_oTwlXltdkfbTgeLSTC_nqNLOkfiqvOSdGZXnZekM7_qvCSdf3mDbcjtTOfon27lNFzqpLc0vgCc6W1Nn6yph5hxuR64oaDJ-bHLx8WyG1rDgC9h_kf4ZgKnx7A4Jzk7B87PgYv_gsv9q58BAAD__5XeUlM=
 
-query ITTT
+query TTT
 EXPLAIN
   SELECT * FROM child2 JOIN grandchild2 ON
     child2.pid1=grandchild2.pid1
@@ -541,16 +541,16 @@ EXPLAIN
     OR child2.cid2 >= 12 AND child2.cid2 <= 14
     OR gcid2 >= 49 AND gcid2 <= 51
 ----
-0  join  ·               ·
-0  ·     type            inner
-0  ·     equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
-0  ·     mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
-1  scan  ·               ·
-1  ·     table           child2@primary
-1  ·     spans           ALL
-1  scan  ·               ·
-1  ·     table           grandchild2@primary
-1  ·     spans           ALL
+join       ·               ·
+ │         type            inner
+ │         equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
+ │         mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
+ ├── scan  ·               ·
+ │         table           child2@primary
+ │         spans           ALL
+ └── scan  ·               ·
+·          table           grandchild2@primary
+·          spans           ALL
 
 # Aggregation over parent and child keys.
 # There are 4 rows for each 10 <= pid1 <= 30 and 3 rows for each 30 < pid1 <=
@@ -805,21 +805,21 @@ SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN (SELECT * FROM c
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJzclsFq20AQhu99ijCnlm7Bu5IdR1DQsekhKWlvRQfF2toCRytWa2gIfvciqWAkOftn2BiMb3XtTzM7-01-vVBlCn2XP-mGkt8kSZAiQREJiknQnDJBtTUr3TTGtj_pgdviLyUzQWVV71z735mglbGakhdypdtqSuhX_rjVDzovtCVBhXZ5ue2K1LZ8yu1zWudWV64teb9zyVUqRaoo2wsyO_f_sYenPT5fbfJmM3xSKinbZ4Ial681JXIv3rG91abcFsPuRBqNGjwUV5ziP41147qp-hx0-ujVBg7P2VXGFtrqYvCkrCXRT46c4lvebL6bshqfZKv_uI-p_PTVlutN96_RFGORzl8dZBxwjiNN3pkvph4f92jh-aCwPG-7Q9sLshsUP73d8kLsVuctWWh7QZKB4qeXTF2IZNF5SxbaXpBkoPjpJYsuRLL4vCULbS9IMlD89JLFFyIZeKt-0E1tqka_6W1v1h5CF2vdD6UxO7vSP6xZdWX6j_cd171uFLpx_bdR_-G26r9qG3w7vAyBpQqiFyG0mvlpOaZnA3oAz8awYgxc8eBlCDwaOJdehNCjgU_oyDvw2H9bsf-2pP-65iH74YfBfvhhtB-ABvvhp9F-LLwTv_YP_DpkP_ww2A8_jPYD0GA__DTaj2XIftyEGO6HgeF-GBkOaGC4n4YJMAmQwcQl-KMiJwnCkRzQwHJAI80RDjwHOBJdTnKEY7qc5AhHdUAD1wGNZEc4sB3gUHd_hso50J0TotM756Qol4a6s3KUi0Pd_UmKdOdEKZdGurPClI0j3VlxOsX9eSpvgO6cRJ3eOSdSuTTUnRWqXBzprvypOtY923_4FwAA__9byzFW
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING (pid1)
 ----
- 0  render  ·         ·
- 1  join    ·         ·
- 1  ·       type      inner
- 1  ·       equality  (pid1) = (pid1)
- 2  scan    ·         ·
- 2  ·       table     parent1@primary
- 2  ·       spans     ALL
- 2  sort    ·         ·
- 2  ·       order     +cid1
- 3  scan    ·         ·
- 3  ·       table     child1@primary
- 3  ·       spans     ALL
+render               ·         ·
+ └── join            ·         ·
+      │              type      inner
+      │              equality  (pid1) = (pid1)
+      ├── scan       ·         ·
+      │              table     parent1@primary
+      │              spans     ALL
+      └── sort       ·         ·
+           │         order     +cid1
+           └── scan  ·         ·
+·                    table     child1@primary
+·                    spans     ALL
 
 # Multi-table staggered join uses interleaved joiner on the bottom join
 # and a merge joiner.

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -409,129 +409,129 @@ x  x  y  b  d  e
 
 
 # Check EXPLAIN.
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
-0  render  ·         ·
-0  ·       render 0  x
-0  ·       render 1  y
-1  join    ·         ·
-1  ·       type      inner
-1  ·       equality  (x) = (x)
-2  scan    ·         ·
-2  ·       table     onecolumn@primary
-2  ·       spans     ALL
-2  scan    ·         ·
-2  ·       table     twocolumn@primary
-2  ·       spans     ALL
+render          ·         ·
+ │              render 0  x
+ │              render 1  y
+ └── join       ·         ·
+      │         type      inner
+      │         equality  (x) = (x)
+      ├── scan  ·         ·
+      │         table     onecolumn@primary
+      │         spans     ALL
+      └── scan  ·         ·
+·               table     twocolumn@primary
+·               spans     ALL
 
 # Check EXPLAIN.
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
-0  render  ·         ·
-0  ·       render 0  x
-0  ·       render 1  y
-0  ·       render 2  x
-0  ·       render 3  y
-1  join    ·         ·
-1  ·       type      inner
-1  ·       equality  (x) = (y)
-2  scan    ·         ·
-2  ·       table     twocolumn@primary
-2  ·       spans     ALL
-2  scan    ·         ·
-2  ·       table     twocolumn@primary
-2  ·       spans     ALL
+render          ·         ·
+ │              render 0  x
+ │              render 1  y
+ │              render 2  x
+ │              render 3  y
+ └── join       ·         ·
+      │         type      inner
+      │         equality  (x) = (y)
+      ├── scan  ·         ·
+      │         table     twocolumn@primary
+      │         spans     ALL
+      └── scan  ·         ·
+·               table     twocolumn@primary
+·               spans     ALL
 
 # Check EXPLAIN.
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
-0  render  ·         ·
-0  ·       render 0  x
-0  ·       render 1  y
-0  ·       render 2  x
-0  ·       render 3  y
-1  join    ·         ·
-1  ·       type      cross
-2  scan    ·         ·
-2  ·       table     twocolumn@primary
-2  ·       spans     ALL
-2  ·       filter    x = 44
-2  scan    ·         ·
-2  ·       table     twocolumn@primary
-2  ·       spans     ALL
+render          ·         ·
+ │              render 0  x
+ │              render 1  y
+ │              render 2  x
+ │              render 3  y
+ └── join       ·         ·
+      │         type      cross
+      ├── scan  ·         ·
+      │         table     twocolumn@primary
+      │         spans     ALL
+      │         filter    x = 44
+      └── scan  ·         ·
+·               table     twocolumn@primary
+·               spans     ALL
 
 # Check EXPLAIN.
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
-0  render  ·         ·
-0  ·       render 0  x
-0  ·       render 1  x
-0  ·       render 2  y
-1  join    ·         ·
-1  ·       type      inner
-1  ·       equality  (x) = (y)
-2  scan    ·         ·
-2  ·       table     onecolumn@primary
-2  ·       spans     ALL
-2  scan    ·         ·
-2  ·       table     twocolumn@primary
-2  ·       spans     ALL
+render          ·         ·
+ │              render 0  x
+ │              render 1  x
+ │              render 2  y
+ └── join       ·         ·
+      │         type      inner
+      │         equality  (x) = (y)
+      ├── scan  ·         ·
+      │         table     onecolumn@primary
+      │         spans     ALL
+      └── scan  ·         ·
+·               table     twocolumn@primary
+·               spans     ALL
 
 # Check EXPLAIN.
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
-0  render  ·         ·
-0  ·       render 0  x
-0  ·       render 1  x
-0  ·       render 2  y
-1  join    ·         ·
-1  ·       type      inner
-1  ·       equality  (x) = (y)
-2  scan    ·         ·
-2  ·       table     onecolumn@primary
-2  ·       spans     ALL
-2  scan    ·         ·
-2  ·       table     twocolumn@primary
-2  ·       spans     ALL
+render          ·         ·
+ │              render 0  x
+ │              render 1  x
+ │              render 2  y
+ └── join       ·         ·
+      │         type      inner
+      │         equality  (x) = (y)
+      ├── scan  ·         ·
+      │         table     onecolumn@primary
+      │         spans     ALL
+      └── scan  ·         ·
+·               table     twocolumn@primary
+·               spans     ALL
 
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
 ----
-0  limit   ·         ·
-0  ·       count     1
-1  render  ·         ·
-1  ·       render 0  x
-1  ·       render 1  x
-1  ·       render 2  y
-1  ·       render 3  b
-1  ·       render 4  d
-1  ·       render 5  e
-2  join    ·         ·
-2  ·       type      inner
-2  ·       equality  (b, x) = (d, d)
-3  join    ·         ·
-3  ·       type      inner
-3  ·       equality  (x) = (b)
-4  join    ·         ·
-4  ·       type      cross
-5  scan    ·         ·
-5  ·       table     onecolumn@primary
-5  ·       spans     ALL
-5  scan    ·         ·
-5  ·       table     twocolumn@primary
-5  ·       spans     ALL
-4  scan    ·         ·
-4  ·       table     onecolumn@primary
-4  ·       spans     ALL
-3  scan    ·         ·
-3  ·       table     twocolumn@primary
-3  ·       spans     ALL
+limit                          ·         ·
+ │                             count     1
+ └── render                    ·         ·
+      │                        render 0  x
+      │                        render 1  x
+      │                        render 2  y
+      │                        render 3  b
+      │                        render 4  d
+      │                        render 5  e
+      └── join                 ·         ·
+           │                   type      inner
+           │                   equality  (b, x) = (d, d)
+           ├── join            ·         ·
+           │    │              type      inner
+           │    │              equality  (x) = (b)
+           │    ├── join       ·         ·
+           │    │    │         type      cross
+           │    │    ├── scan  ·         ·
+           │    │    │         table     onecolumn@primary
+           │    │    │         spans     ALL
+           │    │    └── scan  ·         ·
+           │    │              table     twocolumn@primary
+           │    │              spans     ALL
+           │    └── scan       ·         ·
+           │                   table     onecolumn@primary
+           │                   spans     ALL
+           └── scan            ·         ·
+·                              table     twocolumn@primary
+·                              spans     ALL
 
 # Check sub-queries in ON conditions.
 query III colnames
@@ -620,85 +620,85 @@ statement ok
 CREATE TABLE s(x INT); INSERT INTO s(x) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10)
 
 # THe following queries verify that only the necessary columns are scanned.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
-0  render  ·      ·                  (x, y)                                                                        ·
-1  join    ·      ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
-1  ·       type   cross              ·                                                                             ·
-2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                        rowid!=NULL; key(rowid)
-2  ·       table  twocolumn@primary  ·                                                                             ·
-2  ·       spans  ALL                ·                                                                             ·
-2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                        rowid!=NULL; key(rowid)
-2  ·       table  twocolumn@primary  ·                                                                             ·
-2  ·       spans  ALL                ·                                                                             ·
+render          0  render  ·      ·                  (x, y)  ·
+ └── join       1  join    ·      ·                  (x, y)  ·
+      │         1  ·       type   cross              ·       ·
+      ├── scan  2  scan    ·      ·                  (x, y)  ·
+      │         2  ·       table  twocolumn@primary  ·       ·
+      │         2  ·       spans  ALL                ·       ·
+      └── scan  2  scan    ·      ·                  (x, y)  ·
+·               2  ·       table  twocolumn@primary  ·       ·
+·               2  ·       spans  ALL                ·       ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
-0  render  ·         ·                  (y)                                                                                    ·
-1  join    ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
-1  ·       type      inner              ·                                                                                      ·
-1  ·       equality  (x) = (x)          ·                                                                                      ·
-2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
-2  ·       table     twocolumn@primary  ·                                                                                      ·
-2  ·       spans     ALL                ·                                                                                      ·
-2  scan    ·         ·                  (x, y, rowid[hidden,omitted])                                                          rowid!=NULL; key(rowid)
-2  ·       table     twocolumn@primary  ·                                                                                      ·
-2  ·       spans     ALL                ·                                                                                      ·
+render          0  render  ·         ·                  (y)  ·
+ └── join       1  join    ·         ·                  (y)  ·
+      │         1  ·       type      inner              ·    ·
+      │         1  ·       equality  (x) = (x)          ·    ·
+      ├── scan  2  scan    ·         ·                  (y)  ·
+      │         2  ·       table     twocolumn@primary  ·    ·
+      │         2  ·       spans     ALL                ·    ·
+      └── scan  2  scan    ·         ·                  (y)  ·
+·               2  ·       table     twocolumn@primary  ·    ·
+·               2  ·       spans     ALL                ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
-0  render  ·         ·                  (y)                                                                                    ·
-1  join    ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
-1  ·       type      inner              ·                                                                                      ·
-1  ·       equality  (x) = (x)          ·                                                                                      ·
-2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
-2  ·       table     twocolumn@primary  ·                                                                                      ·
-2  ·       spans     ALL                ·                                                                                      ·
-2  scan    ·         ·                  (x, y, rowid[hidden,omitted])                                                          rowid!=NULL; key(rowid)
-2  ·       table     twocolumn@primary  ·                                                                                      ·
-2  ·       spans     ALL                ·                                                                                      ·
+render          0  render  ·         ·                  (y)  ·
+ └── join       1  join    ·         ·                  (y)  ·
+      │         1  ·       type      inner              ·    ·
+      │         1  ·       equality  (x) = (x)          ·    ·
+      ├── scan  2  scan    ·         ·                  (y)  ·
+      │         2  ·       table     twocolumn@primary  ·    ·
+      │         2  ·       spans     ALL                ·    ·
+      └── scan  2  scan    ·         ·                  (y)  ·
+·               2  ·       table     twocolumn@primary  ·    ·
+·               2  ·       spans     ALL                ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
-0  render  ·      ·                  (x)                                                                                    ·
-1  join    ·      ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
-1  ·       type   inner              ·                                                                                      ·
-2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
-2  ·       table  twocolumn@primary  ·                                                                                      ·
-2  ·       spans  ALL                ·                                                                                      ·
-2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
-2  ·       table  twocolumn@primary  ·                                                                                      ·
-2  ·       spans  ALL                ·                                                                                      ·
+render          0  render  ·      ·                  (x)  ·
+ └── join       1  join    ·      ·                  (x)  ·
+      │         1  ·       type   inner              ·    ·
+      ├── scan  2  scan    ·      ·                  (x)  ·
+      │         2  ·       table  twocolumn@primary  ·    ·
+      │         2  ·       spans  ALL                ·    ·
+      └── scan  2  scan    ·      ·                  (x)  ·
+·               2  ·       table  twocolumn@primary  ·    ·
+·               2  ·       spans  ALL                ·    ·
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
                 INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
-0  sort    ·         ·                  (k, u, w)                     +u
-0  ·       order     +u                 ·                             ·
-1  render  ·         ·                  (k, u, w)                     ·
-2  render  ·         ·                  (k, u, k[hidden,omitted], w)  ·
-3  join    ·         ·                  (u, k, k[omitted], w)         ·
-3  ·       type      inner              ·                             ·
-3  ·       equality  (k) = (k)          ·                             ·
-4  sort    ·         ·                  (u, k)                        +k
-4  ·       order     +k                 ·                             ·
-5  values  ·         ·                  (u, k)                        ·
-5  ·       size      2 columns, 2 rows  ·                             ·
-4  values  ·         ·                  (column1, column2)            ·
-4  ·       size      2 columns, 2 rows  ·                             ·
+sort                             0  sort    ·         ·                  (k, u, w)  +u
+ │                               0  ·       order     +u                 ·          ·
+ └── render                      1  render  ·         ·                  (k, u, w)  +u
+      └── render                 2  render  ·         ·                  (k, u, w)  +u
+           └── join              3  join    ·         ·                  (k, u, w)  +u
+                │                3  ·       type      inner              ·          ·
+                │                3  ·       equality  (k) = (k)          ·          ·
+                ├── sort         4  sort    ·         ·                  (k, u, w)  +u
+                │    │           4  ·       order     +k                 ·          ·
+                │    └── values  5  values  ·         ·                  (k, u, w)  +u
+                │                5  ·       size      2 columns, 2 rows  ·          ·
+                └── values       4  values  ·         ·                  (k, u, w)  +u
+·                                4  ·       size      2 columns, 2 rows  ·          ·
 
 # Ensure that large cross-joins are optimized somehow (#10633)
 statement ok
 CREATE TABLE customers(id INT PRIMARY KEY NOT NULL); CREATE TABLE orders(id INT, cust INT REFERENCES customers(id))
 
 query ITTT
-SELECT * FROM [EXPLAIN SELECT
+SELECT "Level", "Type", "Field", "Description" FROM [EXPLAIN (VERBOSE) SELECT
        NULL::text  AS pktable_cat,
        pkn.nspname AS pktable_schem,
        pkc.relname AS pktable_name,
@@ -764,39 +764,61 @@ SELECT * FROM [EXPLAIN SELECT
            pos.n
   ] WHERE "Type" <> 'values' AND "Field" <> 'size'
 ----
-0   sort       ·         ·
-0   ·          order     +pktable_schem,+pktable_name,+fk_name,+key_seq
-1   render     ·         ·
-2   join       ·         ·
-2   ·          type      inner
-2   ·          equality  (oid) = (relnamespace)
-3   join       ·         ·
-3   ·          type      inner
-3   ·          equality  (oid, oid) = (attrelid, confrelid)
-4   join       ·         ·
-4   ·          type      inner
-5   join       ·         ·
-5   ·          type      inner
-5   ·          equality  (oid) = (relnamespace)
-6   filter     ·         ·
-6   join       ·         ·
-6   ·          type      inner
-6   ·          equality  (oid, oid) = (attrelid, conrelid)
-7   filter     ·         ·
-7   join       ·         ·
-7   ·          type      inner
-8   join       ·         ·
-8   ·          type      inner
-8   ·          equality  (oid) = (objid)
-9   filter     ·         ·
-9   join       ·         ·
-9   ·          type      cross
-10  generator  ·         ·
-10  join       ·         ·
-10  ·          type      inner
-10  ·          equality  (refobjid) = (oid)
-11  filter     ·         ·
-11  filter     ·         ·
+0   sort       ·          ·
+0   ·          order      +pktable_schem,+pktable_name,+fk_name,+key_seq
+1   render     ·          ·
+1   ·          render 0   NULL
+1   ·          render 1   pkn.nspname
+1   ·          render 2   pkc.relname
+1   ·          render 3   pka.attname
+1   ·          render 4   NULL
+1   ·          render 5   fkn.nspname
+1   ·          render 6   fkc.relname
+1   ·          render 7   fka.attname
+1   ·          render 8   pos.n
+1   ·          render 9   CASE con.confupdtype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE NULL END
+1   ·          render 10  CASE con.confdeltype WHEN 'c' THEN 0 WHEN 'n' THEN 2 WHEN 'd' THEN 4 WHEN 'r' THEN 1 WHEN 'a' THEN 3 ELSE NULL END
+1   ·          render 11  con.conname
+1   ·          render 12  pkic.relname
+1   ·          render 13  CASE WHEN con.condeferrable AND con.condeferred THEN 5 WHEN con.condeferrable THEN 6 ELSE 7 END
+2   join       ·          ·
+2   ·          type       inner
+2   ·          equality   (oid) = (relnamespace)
+3   join       ·          ·
+3   ·          type       inner
+3   ·          equality   (oid, oid) = (attrelid, confrelid)
+4   join       ·          ·
+4   ·          type       inner
+4   ·          pred       pka.attnum = con.confkey[pos.n]
+5   join       ·          ·
+5   ·          type       inner
+5   ·          equality   (oid) = (relnamespace)
+6   filter     ·          ·
+6   ·          filter     fkn.nspname = 'test'
+6   join       ·          ·
+6   ·          type       inner
+6   ·          equality   (oid, oid) = (attrelid, conrelid)
+7   filter     ·          ·
+7   ·          filter     fkc.relname = 'orders'
+7   join       ·          ·
+7   ·          type       inner
+7   ·          pred       fka.attnum = con.conkey[pos.n]
+8   join       ·          ·
+8   ·          type       inner
+8   ·          equality   (oid) = (objid)
+9   filter     ·          ·
+9   ·          filter     con.contype = 'f'
+9   join       ·          ·
+9   ·          type       cross
+10  generator  ·          ·
+10  ·          expr       generate_series(1, 32)
+10  join       ·          ·
+10  ·          type       inner
+10  ·          equality   (refobjid) = (oid)
+11  filter     ·          ·
+11  ·          filter     (dep.classid = 402060402) AND (dep.refclassid = 1311305873)
+11  filter     ·          ·
+11  ·          filter     pkic.relkind = 'i'
 
 query TTTTTTTTIIITTI
 SELECT     NULL::text  AS pktable_cat,
@@ -881,19 +903,19 @@ statement ok
 INSERT INTO pairs VALUES (1,1), (1,2), (1,3), (1,4), (1,5), (1,6), (2,3), (2,4), (2,5), (2,6), (3,4), (3,5), (3,6), (4,5), (4,6)
 
 # The filter expression becomes an equality constraint.
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
-0  render  ·         ·
-1  join    ·         ·
-1  ·       type      inner
-1  ·       equality  (b) = (n)
-2  scan    ·         ·
-2  ·       table     pairs@primary
-2  ·       spans     ALL
-2  scan    ·         ·
-2  ·       table     square@primary
-2  ·       spans     ALL
+render          ·         ·
+ └── join       ·         ·
+      │         type      inner
+      │         equality  (b) = (n)
+      ├── scan  ·         ·
+      │         table     pairs@primary
+      │         spans     ALL
+      └── scan  ·         ·
+·               table     square@primary
+·               spans     ALL
 
 query IIII rowsort
 SELECT * FROM pairs, square WHERE pairs.b = square.n
@@ -915,23 +937,23 @@ SELECT * FROM pairs, square WHERE pairs.b = square.n
 4  6  6  36
 
 # The filter expression becomes an ON predicate.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 ----
-0  render  ·         ·                                               (a, b, n, sq)                         ·
-0  ·       render 0  test.pairs.a                                    ·                                     ·
-0  ·       render 1  test.pairs.b                                    ·                                     ·
-0  ·       render 2  test.square.n                                   ·                                     ·
-0  ·       render 3  test.square.sq                                  ·                                     ·
-1  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
-1  ·       type      inner                                           ·                                     ·
-1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
-2  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
-2  ·       table     pairs@primary                                   ·                                     ·
-2  ·       spans     ALL                                             ·                                     ·
-2  scan    ·         ·                                               (n, sq)                               n!=NULL; key(n)
-2  ·       table     square@primary                                  ·                                     ·
-2  ·       spans     ALL                                             ·                                     ·
+render          0  render  ·         ·                                               (a, b, n, sq)  ·
+ │              0  ·       render 0  test.pairs.a                                    ·              ·
+ │              0  ·       render 1  test.pairs.b                                    ·              ·
+ │              0  ·       render 2  test.square.n                                   ·              ·
+ │              0  ·       render 3  test.square.sq                                  ·              ·
+ └── join       1  join    ·         ·                                               (a, b, n, sq)  ·
+      │         1  ·       type      inner                                           ·              ·
+      │         1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·              ·
+      ├── scan  2  scan    ·         ·                                               (a, b, n, sq)  ·
+      │         2  ·       table     pairs@primary                                   ·              ·
+      │         2  ·       spans     ALL                                             ·              ·
+      └── scan  2  scan    ·         ·                                               (a, b, n, sq)  ·
+·               2  ·       table     square@primary                                  ·              ·
+·               2  ·       spans     ALL                                             ·              ·
 
 query IIII rowsort
 SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
@@ -943,30 +965,30 @@ SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 # Query similar to the one above, but the filter refers to a rendered
 # expression and can't "break through". See the comment for propagateFilters
 # in fitler_opt.go for all the details.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
 ----
-0  render  ·         ·                            (a, b, n, sq)                         sq!=NULL
-0  ·       render 0  a                            ·                                     ·
-0  ·       render 1  b                            ·                                     ·
-0  ·       render 2  n                            ·                                     ·
-0  ·       render 3  sq                           ·                                     ·
-1  filter  ·         ·                            (a, b, sum, n, sq)                    sum=sq; sum!=NULL; sq!=NULL
-1  ·       filter    sum = sq                     ·                                     ·
-2  render  ·         ·                            (a, b, sum, n, sq)                    ·
-2  ·       render 0  test.pairs.a                 ·                                     ·
-2  ·       render 1  test.pairs.b                 ·                                     ·
-2  ·       render 2  test.pairs.a + test.pairs.b  ·                                     ·
-2  ·       render 3  test.square.n                ·                                     ·
-2  ·       render 4  test.square.sq               ·                                     ·
-3  join    ·         ·                            (a, b, rowid[hidden,omitted], n, sq)  ·
-3  ·       type      cross                        ·                                     ·
-4  scan    ·         ·                            (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
-4  ·       table     pairs@primary                ·                                     ·
-4  ·       spans     ALL                          ·                                     ·
-4  scan    ·         ·                            (n, sq)                               n!=NULL; key(n)
-4  ·       table     square@primary               ·                                     ·
-4  ·       spans     ALL                          ·                                     ·
+render                    0  render  ·         ·                            (a, b, n, sq)  sq!=NULL
+ │                        0  ·       render 0  a                            ·              ·
+ │                        0  ·       render 1  b                            ·              ·
+ │                        0  ·       render 2  n                            ·              ·
+ │                        0  ·       render 3  sq                           ·              ·
+ └── filter               1  filter  ·         ·                            (a, b, n, sq)  sq!=NULL
+      │                   1  ·       filter    sum = sq                     ·              ·
+      └── render          2  render  ·         ·                            (a, b, n, sq)  sq!=NULL
+           │              2  ·       render 0  test.pairs.a                 ·              ·
+           │              2  ·       render 1  test.pairs.b                 ·              ·
+           │              2  ·       render 2  test.pairs.a + test.pairs.b  ·              ·
+           │              2  ·       render 3  test.square.n                ·              ·
+           │              2  ·       render 4  test.square.sq               ·              ·
+           └── join       3  join    ·         ·                            (a, b, n, sq)  sq!=NULL
+                │         3  ·       type      cross                        ·              ·
+                ├── scan  4  scan    ·         ·                            (a, b, n, sq)  sq!=NULL
+                │         4  ·       table     pairs@primary                ·              ·
+                │         4  ·       spans     ALL                          ·              ·
+                └── scan  4  scan    ·         ·                            (a, b, n, sq)  sq!=NULL
+·                         4  ·       table     square@primary               ·              ·
+·                         4  ·       spans     ALL                          ·              ·
 
 query IIII rowsort
 SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
@@ -976,23 +998,23 @@ SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WH
 4  5  3  9
 
 # The filter expression must stay on top of the outer join.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
-0  render  ·         ·                                               (a, b, n, sq)                         ·
-0  ·       render 0  test.pairs.a                                    ·                                     ·
-0  ·       render 1  test.pairs.b                                    ·                                     ·
-0  ·       render 2  test.square.n                                   ·                                     ·
-0  ·       render 3  test.square.sq                                  ·                                     ·
-1  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
-1  ·       type      full outer                                      ·                                     ·
-1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
-2  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
-2  ·       table     pairs@primary                                   ·                                     ·
-2  ·       spans     ALL                                             ·                                     ·
-2  scan    ·         ·                                               (n, sq)                               n!=NULL; key(n)
-2  ·       table     square@primary                                  ·                                     ·
-2  ·       spans     ALL                                             ·                                     ·
+render          0  render  ·         ·                                               (a, b, n, sq)  ·
+ │              0  ·       render 0  test.pairs.a                                    ·              ·
+ │              0  ·       render 1  test.pairs.b                                    ·              ·
+ │              0  ·       render 2  test.square.n                                   ·              ·
+ │              0  ·       render 3  test.square.sq                                  ·              ·
+ └── join       1  join    ·         ·                                               (a, b, n, sq)  ·
+      │         1  ·       type      full outer                                      ·              ·
+      │         1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·              ·
+      ├── scan  2  scan    ·         ·                                               (a, b, n, sq)  ·
+      │         2  ·       table     pairs@primary                                   ·              ·
+      │         2  ·       spans     ALL                                             ·              ·
+      └── scan  2  scan    ·         ·                                               (a, b, n, sq)  ·
+·               2  ·       table     square@primary                                  ·              ·
+·               2  ·       spans     ALL                                             ·              ·
 
 query IIII rowsort
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
@@ -1017,25 +1039,25 @@ NULL  NULL  4     16
 NULL  NULL  5     25
 NULL  NULL  6     36
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
-0  render  ·         ·                                               (a, b, n, sq)                         b!=NULL; sq!=NULL
-0  ·       render 0  test.pairs.a                                    ·                                     ·
-0  ·       render 1  test.pairs.b                                    ·                                     ·
-0  ·       render 2  test.square.n                                   ·                                     ·
-0  ·       render 3  test.square.sq                                  ·                                     ·
-1  filter  ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  b!=NULL; sq!=NULL
-1  ·       filter    (test.pairs.b % 2) != (test.square.sq % 2)      ·                                     ·
-2  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
-2  ·       type      full outer                                      ·                                     ·
-2  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
-3  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
-3  ·       table     pairs@primary                                   ·                                     ·
-3  ·       spans     ALL                                             ·                                     ·
-3  scan    ·         ·                                               (n, sq)                               n!=NULL; key(n)
-3  ·       table     square@primary                                  ·                                     ·
-3  ·       spans     ALL                                             ·                                     ·
+render               0  render  ·         ·                                               (a, b, n, sq)  b!=NULL; sq!=NULL
+ │                   0  ·       render 0  test.pairs.a                                    ·              ·
+ │                   0  ·       render 1  test.pairs.b                                    ·              ·
+ │                   0  ·       render 2  test.square.n                                   ·              ·
+ │                   0  ·       render 3  test.square.sq                                  ·              ·
+ └── filter          1  filter  ·         ·                                               (a, b, n, sq)  b!=NULL; sq!=NULL
+      │              1  ·       filter    (test.pairs.b % 2) != (test.square.sq % 2)      ·              ·
+      └── join       2  join    ·         ·                                               (a, b, n, sq)  b!=NULL; sq!=NULL
+           │         2  ·       type      full outer                                      ·              ·
+           │         2  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·              ·
+           ├── scan  3  scan    ·         ·                                               (a, b, n, sq)  b!=NULL; sq!=NULL
+           │         3  ·       table     pairs@primary                                   ·              ·
+           │         3  ·       spans     ALL                                             ·              ·
+           └── scan  3  scan    ·         ·                                               (a, b, n, sq)  b!=NULL; sq!=NULL
+·                    3  ·       table     square@primary                                  ·              ·
+·                    3  ·       spans     ALL                                             ·              ·
 
 query IIII rowsort
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
@@ -1065,31 +1087,31 @@ SELECT *
 4  5  NULL  NULL
 4  6  NULL  NULL
 
-query ITTT
+query TTT
 EXPLAIN(EXPRS)
 SELECT *
   FROM (SELECT * FROM pairs LEFT JOIN square ON b = sq AND a > 1 AND n < 6)
  WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
 ----
-0  render  ·         ·
-0  ·       render 0  a
-0  ·       render 1  b
-0  ·       render 2  n
-0  ·       render 3  sq
-1  filter  ·         ·
-1  ·       filter    ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
-2  join    ·         ·
-2  ·       type      left outer
-2  ·       equality  (b) = (sq)
-2  ·       pred      test.pairs.a > 1
-3  scan    ·         ·
-3  ·       table     pairs@primary
-3  ·       spans     ALL
-3  ·       filter    b > 1
-3  scan    ·         ·
-3  ·       table     square@primary
-3  ·       spans     /!NULL-/5/#
-3  ·       filter    sq > 1
+render               ·         ·
+ │                   render 0  a
+ │                   render 1  b
+ │                   render 2  n
+ │                   render 3  sq
+ └── filter          ·         ·
+      │              filter    ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
+      └── join       ·         ·
+           │         type      left outer
+           │         equality  (b) = (sq)
+           │         pred      test.pairs.a > 1
+           ├── scan  ·         ·
+           │         table     pairs@primary
+           │         spans     ALL
+           │         filter    b > 1
+           └── scan  ·         ·
+·                    table     square@primary
+·                    spans     /!NULL-/5/#
+·                    filter    sq > 1
 
 query IIII rowsort
 SELECT *
@@ -1102,53 +1124,53 @@ NULL  NULL  4  16
 NULL  NULL  5  25
 NULL  NULL  6  36
 
-query ITTT
+query TTT
 EXPLAIN(EXPRS)
 SELECT *
   FROM (SELECT * FROM pairs RIGHT JOIN square ON b = sq AND a > 1 AND n < 6)
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ----
-0  render  ·         ·
-0  ·       render 0  a
-0  ·       render 1  b
-0  ·       render 2  n
-0  ·       render 3  sq
-1  filter  ·         ·
-1  ·       filter    ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
-2  join    ·         ·
-2  ·       type      right outer
-2  ·       equality  (b) = (sq)
-2  ·       pred      test.square.n < 6
-3  scan    ·         ·
-3  ·       table     pairs@primary
-3  ·       spans     ALL
-3  ·       filter    a > 1
-3  scan    ·         ·
-3  ·       table     square@primary
-3  ·       spans     /2-
+render               ·         ·
+ │                   render 0  a
+ │                   render 1  b
+ │                   render 2  n
+ │                   render 3  sq
+ └── filter          ·         ·
+      │              filter    ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
+      └── join       ·         ·
+           │         type      right outer
+           │         equality  (b) = (sq)
+           │         pred      test.square.n < 6
+           ├── scan  ·         ·
+           │         table     pairs@primary
+           │         spans     ALL
+           │         filter    a > 1
+           └── scan  ·         ·
+·                    table     square@primary
+·                    spans     /2-
 
 # The simpler plan for an inner join, to compare.
-query ITTT
+query TTT
 EXPLAIN(EXPRS)
 SELECT *
   FROM (SELECT * FROM pairs JOIN square ON b = sq AND a > 1 AND n < 6)
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ----
-0  render  ·         ·
-0  ·       render 0  a
-0  ·       render 1  b
-0  ·       render 2  n
-0  ·       render 3  sq
-1  join    ·         ·
-1  ·       type      inner
-1  ·       equality  (b) = (sq)
-2  scan    ·         ·
-2  ·       table     pairs@primary
-2  ·       spans     ALL
-2  ·       filter    ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
-2  scan    ·         ·
-2  ·       table     square@primary
-2  ·       spans     /2-/5/#
+render          ·         ·
+ │              render 0  a
+ │              render 1  b
+ │              render 2  n
+ │              render 3  sq
+ └── join       ·         ·
+      │         type      inner
+      │         equality  (b) = (sq)
+      ├── scan  ·         ·
+      │         table     pairs@primary
+      │         spans     ALL
+      │         filter    ((a > 1) AND ((a IS NULL) OR (a > 2))) AND ((a IS NULL) OR (a < b))
+      └── scan  ·         ·
+·               table     square@primary
+·               spans     /2-/5/#
 
 
 statement ok
@@ -1225,35 +1247,35 @@ SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
 1
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
-0  render  ·         ·                (x)                                                                                                                                       ·
-0  ·       render 0  test.t1.x        ·                                                                                                                                         ·
-1  render  ·         ·                (x, y[omitted], col1[omitted], col2[omitted], rowid[hidden,omitted], col3[omitted], y[hidden,omitted], x[hidden,omitted], col4[omitted])  ·
-1  ·       render 0  test.t1.x        ·                                                                                                                                         ·
-1  ·       render 1  NULL             ·                                                                                                                                         ·
-1  ·       render 2  NULL             ·                                                                                                                                         ·
-1  ·       render 3  NULL             ·                                                                                                                                         ·
-1  ·       render 4  NULL             ·                                                                                                                                         ·
-1  ·       render 5  NULL             ·                                                                                                                                         ·
-1  ·       render 6  NULL             ·                                                                                                                                         ·
-1  ·       render 7  NULL             ·                                                                                                                                         ·
-1  ·       render 8  NULL             ·                                                                                                                                         ·
-2  join    ·         ·                (col1[omitted], x, col2[omitted], y[omitted], rowid[hidden,omitted], col3[omitted], y[omitted], x[omitted], col4[omitted])                ·
-2  ·       type      inner            ·                                                                                                                                         ·
-2  ·       equality  (x, y) = (x, y)  ·                                                                                                                                         ·
-3  scan    ·         ·                (col1[omitted], x, col2[omitted], y, rowid[hidden,omitted])                                                                               rowid!=NULL; key(rowid)
-3  ·       table     t1@primary       ·                                                                                                                                         ·
-3  ·       spans     ALL              ·                                                                                                                                         ·
-3  render  ·         ·                (col3[omitted], y, x, col4[omitted])                                                                                                      ·
-3  ·       render 0  NULL             ·                                                                                                                                         ·
-3  ·       render 1  test.t2.y        ·                                                                                                                                         ·
-3  ·       render 2  test.t2.x        ·                                                                                                                                         ·
-3  ·       render 3  NULL             ·                                                                                                                                         ·
-4  scan    ·         ·                (col3[omitted], y, x, col4[omitted], rowid[hidden,omitted])                                                                               rowid!=NULL; key(rowid)
-4  ·       table     t2@primary       ·                                                                                                                                         ·
-4  ·       spans     ALL              ·                                                                                                                                         ·
+render                    0  render  ·         ·                (x)  ·
+ │                        0  ·       render 0  test.t1.x        ·    ·
+ └── render               1  render  ·         ·                (x)  ·
+      │                   1  ·       render 0  test.t1.x        ·    ·
+      │                   1  ·       render 1  NULL             ·    ·
+      │                   1  ·       render 2  NULL             ·    ·
+      │                   1  ·       render 3  NULL             ·    ·
+      │                   1  ·       render 4  NULL             ·    ·
+      │                   1  ·       render 5  NULL             ·    ·
+      │                   1  ·       render 6  NULL             ·    ·
+      │                   1  ·       render 7  NULL             ·    ·
+      │                   1  ·       render 8  NULL             ·    ·
+      └── join            2  join    ·         ·                (x)  ·
+           │              2  ·       type      inner            ·    ·
+           │              2  ·       equality  (x, y) = (x, y)  ·    ·
+           ├── scan       3  scan    ·         ·                (x)  ·
+           │              3  ·       table     t1@primary       ·    ·
+           │              3  ·       spans     ALL              ·    ·
+           └── render     3  render  ·         ·                (x)  ·
+                │         3  ·       render 0  NULL             ·    ·
+                │         3  ·       render 1  test.t2.y        ·    ·
+                │         3  ·       render 2  test.t2.x        ·    ·
+                │         3  ·       render 3  NULL             ·    ·
+                └── scan  4  scan    ·         ·                (x)  ·
+·                         4  ·       table     t2@primary       ·    ·
+·                         4  ·       spans     ALL              ·    ·
 
 # Tests for merge join ordering information.
 statement ok
@@ -1268,72 +1290,72 @@ CREATE TABLE pkBAC (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,c))
 statement ok
 CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
-0  join  ·               ·                      (a, b, c, d, a, b, c, d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b); key(b,c)
-0  ·     type            inner                  ·                         ·
-0  ·     equality        (a, b, c) = (a, b, c)  ·                         ·
-0  ·     mergeJoinOrder  +"(b=b)"               ·                         ·
-1  scan  ·               ·                      (a, b, c, d)              a!=NULL; b!=NULL; key(a,b); +b
-1  ·     table           pkba@primary           ·                         ·
-1  ·     spans           ALL                    ·                         ·
-1  scan  ·               ·                      (a, b, c, d)              b!=NULL; c!=NULL; key(b,c); +b
-1  ·     table           pkbc@primary           ·                         ·
-1  ·     spans           ALL                    ·                         ·
+join       0  join  ·               ·                      (a, b, c, d, a, b, c, d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b); key(b,c)
+ │         0  ·     type            inner                  ·                         ·
+ │         0  ·     equality        (a, b, c) = (a, b, c)  ·                         ·
+ │         0  ·     mergeJoinOrder  +"(b=b)"               ·                         ·
+ ├── scan  1  scan  ·               ·                      (a, b, c, d, a, b, c, d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b); key(b,c)
+ │         1  ·     table           pkba@primary           ·                         ·
+ │         1  ·     spans           ALL                    ·                         ·
+ └── scan  1  scan  ·               ·                      (a, b, c, d, a, b, c, d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b); key(b,c)
+·          1  ·     table           pkbc@primary           ·                         ·
+·          1  ·     spans           ALL                    ·                         ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
-0  render  ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
-0  ·       render 0        test.pkba.a                  ·                                                             ·
-0  ·       render 1        test.pkba.b                  ·                                                             ·
-0  ·       render 2        test.pkba.c                  ·                                                             ·
-0  ·       render 3        test.pkba.d                  ·                                                             ·
-1  join    ·               ·                            (a, b, c, d, a[omitted], b[omitted], c[omitted], d[omitted])  a=a; b=b; c=c; d=d; a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
-1  ·       type            inner                        ·                                                             ·
-1  ·       equality        (a, b, c, d) = (a, b, c, d)  ·                                                             ·
-1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(d=d)"   ·                                                             ·
-2  scan    ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; key(a,b); +b,+a
-2  ·       table           pkba@primary                 ·                                                             ·
-2  ·       spans           ALL                          ·                                                             ·
-2  scan    ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; d!=NULL; key(a,b,d); +b,+a,+d
-2  ·       table           pkbad@primary                ·                                                             ·
-2  ·       spans           ALL                          ·                                                             ·
+render          0  render  ·               ·                            (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
+ │              0  ·       render 0        test.pkba.a                  ·             ·
+ │              0  ·       render 1        test.pkba.b                  ·             ·
+ │              0  ·       render 2        test.pkba.c                  ·             ·
+ │              0  ·       render 3        test.pkba.d                  ·             ·
+ └── join       1  join    ·               ·                            (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
+      │         1  ·       type            inner                        ·             ·
+      │         1  ·       equality        (a, b, c, d) = (a, b, c, d)  ·             ·
+      │         1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(d=d)"   ·             ·
+      ├── scan  2  scan    ·               ·                            (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
+      │         2  ·       table           pkba@primary                 ·             ·
+      │         2  ·       spans           ALL                          ·             ·
+      └── scan  2  scan    ·               ·                            (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
+·               2  ·       table           pkbad@primary                ·             ·
+·               2  ·       spans           ALL                          ·             ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
-0  render  ·               ·                           (a, b, c, d, d)                                      a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-0  ·       render 0        l.a                         ·                                                    ·
-0  ·       render 1        l.b                         ·                                                    ·
-0  ·       render 2        l.c                         ·                                                    ·
-0  ·       render 3        l.d                         ·                                                    ·
-0  ·       render 4        r.d                         ·                                                    ·
-1  join    ·               ·                           (a, b, c, d, a[omitted], b[omitted], c[omitted], d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-1  ·       type            inner                       ·                                                    ·
-1  ·       equality        (a, b, c) = (a, b, c)       ·                                                    ·
-1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                                                    ·
-2  scan    ·               ·                           (a, b, c, d)                                         a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
-2  ·       table           pkbac@primary               ·                                                    ·
-2  ·       spans           ALL                         ·                                                    ·
-2  scan    ·               ·                           (a, b, c, d)                                         a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
-2  ·       table           pkbac@primary               ·                                                    ·
-2  ·       spans           ALL                         ·                                                    ·
+render          0  render  ·               ·                           (a, b, c, d, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ │              0  ·       render 0        l.a                         ·                ·
+ │              0  ·       render 1        l.b                         ·                ·
+ │              0  ·       render 2        l.c                         ·                ·
+ │              0  ·       render 3        l.d                         ·                ·
+ │              0  ·       render 4        r.d                         ·                ·
+ └── join       1  join    ·               ·                           (a, b, c, d, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+      │         1  ·       type            inner                       ·                ·
+      │         1  ·       equality        (a, b, c) = (a, b, c)       ·                ·
+      │         1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                ·
+      ├── scan  2  scan    ·               ·                           (a, b, c, d, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+      │         2  ·       table           pkbac@primary               ·                ·
+      │         2  ·       spans           ALL                         ·                ·
+      └── scan  2  scan    ·               ·                           (a, b, c, d, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·               2  ·       table           pkbac@primary               ·                ·
+·               2  ·       spans           ALL                         ·                ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
-0  join  ·               ·                           (a, b, c, d, a, b, c, d)  a=a; b=b; c=d; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-0  ·     type            inner                       ·                         ·
-0  ·     equality        (c, a, b) = (d, a, b)       ·                         ·
-0  ·     mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
-1  scan  ·               ·                           (a, b, c, d)              a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
-1  ·     table           pkbac@primary               ·                         ·
-1  ·     spans           ALL                         ·                         ·
-1  scan  ·               ·                           (a, b, c, d)              a!=NULL; b!=NULL; d!=NULL; key(a,b,d); +b,+a,+d
-1  ·     table           pkbad@primary               ·                         ·
-1  ·     spans           ALL                         ·                         ·
+join       0  join  ·               ·                           (a, b, c, d, a, b, c, d)  a=a; b=b; c=d; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ │         0  ·     type            inner                       ·                         ·
+ │         0  ·     equality        (c, a, b) = (d, a, b)       ·                         ·
+ │         0  ·     mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
+ ├── scan  1  scan  ·               ·                           (a, b, c, d, a, b, c, d)  a=a; b=b; c=d; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ │         1  ·     table           pkbac@primary               ·                         ·
+ │         1  ·     spans           ALL                         ·                         ·
+ └── scan  1  scan  ·               ·                           (a, b, c, d, a, b, c, d)  a=a; b=b; c=d; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·          1  ·     table           pkbad@primary               ·                         ·
+·          1  ·     spans           ALL                         ·                         ·
 
 # Tests with joins with merged columns of collated string type.
 statement ok
@@ -1348,27 +1370,27 @@ CREATE TABLE str2 (a INT PRIMARY KEY, s STRING COLLATE en_u_ks_level1)
 statement ok
 INSERT INTO str2 VALUES (1, 'A' COLLATE en_u_ks_level1), (2, 'B' COLLATE en_u_ks_level1), (3, 'C' COLLATE en_u_ks_level1), (4, 'E' COLLATE en_u_ks_level1)
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
 ----
-0  render  ·         ·             (s, s, s)                               s=s
-0  ·       render 0  test.str1.s   ·                                       ·
-0  ·       render 1  test.str1.s   ·                                       ·
-0  ·       render 2  test.str2.s   ·                                       ·
-1  render  ·         ·             (s, a[omitted], a[omitted], s[hidden])  ·
-1  ·       render 0  test.str1.s   ·                                       ·
-1  ·       render 1  NULL          ·                                       ·
-1  ·       render 2  NULL          ·                                       ·
-1  ·       render 3  test.str2.s   ·                                       ·
-2  join    ·         ·             (a[omitted], s, a[omitted], s)          ·
-2  ·       type      inner         ·                                       ·
-2  ·       equality  (s) = (s)     ·                                       ·
-3  scan    ·         ·             (a[omitted], s)                         a!=NULL; key(a)
-3  ·       table     str1@primary  ·                                       ·
-3  ·       spans     ALL           ·                                       ·
-3  scan    ·         ·             (a[omitted], s)                         a!=NULL; key(a)
-3  ·       table     str2@primary  ·                                       ·
-3  ·       spans     ALL           ·                                       ·
+render               0  render  ·         ·             (s, s, s)  s=s
+ │                   0  ·       render 0  test.str1.s   ·          ·
+ │                   0  ·       render 1  test.str1.s   ·          ·
+ │                   0  ·       render 2  test.str2.s   ·          ·
+ └── render          1  render  ·         ·             (s, s, s)  s=s
+      │              1  ·       render 0  test.str1.s   ·          ·
+      │              1  ·       render 1  NULL          ·          ·
+      │              1  ·       render 2  NULL          ·          ·
+      │              1  ·       render 3  test.str2.s   ·          ·
+      └── join       2  join    ·         ·             (s, s, s)  s=s
+           │         2  ·       type      inner         ·          ·
+           │         2  ·       equality  (s) = (s)     ·          ·
+           ├── scan  3  scan    ·         ·             (s, s, s)  s=s
+           │         3  ·       table     str1@primary  ·          ·
+           │         3  ·       spans     ALL           ·          ·
+           └── scan  3  scan    ·         ·             (s, s, s)  s=s
+·                    3  ·       table     str2@primary  ·          ·
+·                    3  ·       spans     ALL           ·          ·
 
 query TTT rowsort
 SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
@@ -1377,27 +1399,27 @@ a  a  A
 A  A  A
 c  c  C
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
 ----
-0  render  ·         ·             (s, s, s)                               s=s
-0  ·       render 0  test.str1.s   ·                                       ·
-0  ·       render 1  test.str1.s   ·                                       ·
-0  ·       render 2  test.str2.s   ·                                       ·
-1  render  ·         ·             (s, a[omitted], a[omitted], s[hidden])  ·
-1  ·       render 0  test.str1.s   ·                                       ·
-1  ·       render 1  NULL          ·                                       ·
-1  ·       render 2  NULL          ·                                       ·
-1  ·       render 3  test.str2.s   ·                                       ·
-2  join    ·         ·             (a[omitted], s, a[omitted], s)          ·
-2  ·       type      left outer    ·                                       ·
-2  ·       equality  (s) = (s)     ·                                       ·
-3  scan    ·         ·             (a[omitted], s)                         a!=NULL; key(a)
-3  ·       table     str1@primary  ·                                       ·
-3  ·       spans     ALL           ·                                       ·
-3  scan    ·         ·             (a[omitted], s)                         a!=NULL; key(a)
-3  ·       table     str2@primary  ·                                       ·
-3  ·       spans     ALL           ·                                       ·
+render               0  render  ·         ·             (s, s, s)  s=s
+ │                   0  ·       render 0  test.str1.s   ·          ·
+ │                   0  ·       render 1  test.str1.s   ·          ·
+ │                   0  ·       render 2  test.str2.s   ·          ·
+ └── render          1  render  ·         ·             (s, s, s)  s=s
+      │              1  ·       render 0  test.str1.s   ·          ·
+      │              1  ·       render 1  NULL          ·          ·
+      │              1  ·       render 2  NULL          ·          ·
+      │              1  ·       render 3  test.str2.s   ·          ·
+      └── join       2  join    ·         ·             (s, s, s)  s=s
+           │         2  ·       type      left outer    ·          ·
+           │         2  ·       equality  (s) = (s)     ·          ·
+           ├── scan  3  scan    ·         ·             (s, s, s)  s=s
+           │         3  ·       table     str1@primary  ·          ·
+           │         3  ·       spans     ALL           ·          ·
+           └── scan  3  scan    ·         ·             (s, s, s)  s=s
+·                    3  ·       table     str2@primary  ·          ·
+·                    3  ·       spans     ALL           ·          ·
 
 query TTT rowsort
 SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
@@ -1407,28 +1429,28 @@ A  A  A
 c  c  C
 D  D  NULL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
 ----
-0  render  ·         ·                                 (s, s, s)                                          ·
-0  ·       render 0  s                                 ·                                                  ·
-0  ·       render 1  test.str1.s                       ·                                                  ·
-0  ·       render 2  test.str2.s                       ·                                                  ·
-1  render  ·         ·                                 (s, a[omitted], s[hidden], a[omitted], s[hidden])  ·
-1  ·       render 0  IFNULL(test.str1.s, test.str2.s)  ·                                                  ·
-1  ·       render 1  NULL                              ·                                                  ·
-1  ·       render 2  test.str1.s                       ·                                                  ·
-1  ·       render 3  NULL                              ·                                                  ·
-1  ·       render 4  test.str2.s                       ·                                                  ·
-2  join    ·         ·                                 (a[omitted], s, a[omitted], s)                     ·
-2  ·       type      right outer                       ·                                                  ·
-2  ·       equality  (s) = (s)                         ·                                                  ·
-3  scan    ·         ·                                 (a[omitted], s)                                    a!=NULL; key(a)
-3  ·       table     str1@primary                      ·                                                  ·
-3  ·       spans     ALL                               ·                                                  ·
-3  scan    ·         ·                                 (a[omitted], s)                                    a!=NULL; key(a)
-3  ·       table     str2@primary                      ·                                                  ·
-3  ·       spans     ALL                               ·                                                  ·
+render               0  render  ·         ·                                 (s, s, s)  ·
+ │                   0  ·       render 0  s                                 ·          ·
+ │                   0  ·       render 1  test.str1.s                       ·          ·
+ │                   0  ·       render 2  test.str2.s                       ·          ·
+ └── render          1  render  ·         ·                                 (s, s, s)  ·
+      │              1  ·       render 0  IFNULL(test.str1.s, test.str2.s)  ·          ·
+      │              1  ·       render 1  NULL                              ·          ·
+      │              1  ·       render 2  test.str1.s                       ·          ·
+      │              1  ·       render 3  NULL                              ·          ·
+      │              1  ·       render 4  test.str2.s                       ·          ·
+      └── join       2  join    ·         ·                                 (s, s, s)  ·
+           │         2  ·       type      right outer                       ·          ·
+           │         2  ·       equality  (s) = (s)                         ·          ·
+           ├── scan  3  scan    ·         ·                                 (s, s, s)  ·
+           │         3  ·       table     str1@primary                      ·          ·
+           │         3  ·       spans     ALL                               ·          ·
+           └── scan  3  scan    ·         ·                                 (s, s, s)  ·
+·                    3  ·       table     str2@primary                      ·          ·
+·                    3  ·       spans     ALL                               ·          ·
 
 
 query TTT rowsort
@@ -1440,28 +1462,28 @@ c  c     C
 B  NULL  B
 E  NULL  E
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
 ----
-0  render  ·         ·                                 (s, s, s)                                          ·
-0  ·       render 0  s                                 ·                                                  ·
-0  ·       render 1  test.str1.s                       ·                                                  ·
-0  ·       render 2  test.str2.s                       ·                                                  ·
-1  render  ·         ·                                 (s, a[omitted], s[hidden], a[omitted], s[hidden])  ·
-1  ·       render 0  IFNULL(test.str1.s, test.str2.s)  ·                                                  ·
-1  ·       render 1  NULL                              ·                                                  ·
-1  ·       render 2  test.str1.s                       ·                                                  ·
-1  ·       render 3  NULL                              ·                                                  ·
-1  ·       render 4  test.str2.s                       ·                                                  ·
-2  join    ·         ·                                 (a[omitted], s, a[omitted], s)                     ·
-2  ·       type      full outer                        ·                                                  ·
-2  ·       equality  (s) = (s)                         ·                                                  ·
-3  scan    ·         ·                                 (a[omitted], s)                                    a!=NULL; key(a)
-3  ·       table     str1@primary                      ·                                                  ·
-3  ·       spans     ALL                               ·                                                  ·
-3  scan    ·         ·                                 (a[omitted], s)                                    a!=NULL; key(a)
-3  ·       table     str2@primary                      ·                                                  ·
-3  ·       spans     ALL                               ·                                                  ·
+render               0  render  ·         ·                                 (s, s, s)  ·
+ │                   0  ·       render 0  s                                 ·          ·
+ │                   0  ·       render 1  test.str1.s                       ·          ·
+ │                   0  ·       render 2  test.str2.s                       ·          ·
+ └── render          1  render  ·         ·                                 (s, s, s)  ·
+      │              1  ·       render 0  IFNULL(test.str1.s, test.str2.s)  ·          ·
+      │              1  ·       render 1  NULL                              ·          ·
+      │              1  ·       render 2  test.str1.s                       ·          ·
+      │              1  ·       render 3  NULL                              ·          ·
+      │              1  ·       render 4  test.str2.s                       ·          ·
+      └── join       2  join    ·         ·                                 (s, s, s)  ·
+           │         2  ·       type      full outer                        ·          ·
+           │         2  ·       equality  (s) = (s)                         ·          ·
+           ├── scan  3  scan    ·         ·                                 (s, s, s)  ·
+           │         3  ·       table     str1@primary                      ·          ·
+           │         3  ·       spans     ALL                               ·          ·
+           └── scan  3  scan    ·         ·                                 (s, s, s)  ·
+·                    3  ·       table     str2@primary                      ·          ·
+·                    3  ·       spans     ALL                               ·          ·
 
 query TTT rowsort
 SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
@@ -1475,28 +1497,28 @@ B  NULL  B
 
 # Verify that we resolve the merged column a to str2.a but use IFNULL for
 # column s which is a collated string.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 ----
-0  render  ·               ·                                 (a, s)                                                           ·
-0  ·       render 0        test.str2.a                       ·                                                                ·
-0  ·       render 1        s                                 ·                                                                ·
-1  render  ·               ·                                 (a, s, a[hidden,omitted], s[hidden,omitted], s[hidden,omitted])  ·
-1  ·       render 0        test.str2.a                       ·                                                                ·
-1  ·       render 1        IFNULL(test.str1.s, test.str2.s)  ·                                                                ·
-1  ·       render 2        NULL                              ·                                                                ·
-1  ·       render 3        NULL                              ·                                                                ·
-1  ·       render 4        NULL                              ·                                                                ·
-2  join    ·               ·                                 (a[omitted], s, a, s)                                            ·
-2  ·       type            right outer                       ·                                                                ·
-2  ·       equality        (a, s) = (a, s)                   ·                                                                ·
-2  ·       mergeJoinOrder  +"(a=a)"                          ·                                                                ·
-3  scan    ·               ·                                 (a, s)                                                           a!=NULL; key(a); +a
-3  ·       table           str1@primary                      ·                                                                ·
-3  ·       spans           ALL                               ·                                                                ·
-3  scan    ·               ·                                 (a, s)                                                           a!=NULL; key(a); +a
-3  ·       table           str2@primary                      ·                                                                ·
-3  ·       spans           ALL                               ·                                                                ·
+render               0  render  ·               ·                                 (a, s)  ·
+ │                   0  ·       render 0        test.str2.a                       ·       ·
+ │                   0  ·       render 1        s                                 ·       ·
+ └── render          1  render  ·               ·                                 (a, s)  ·
+      │              1  ·       render 0        test.str2.a                       ·       ·
+      │              1  ·       render 1        IFNULL(test.str1.s, test.str2.s)  ·       ·
+      │              1  ·       render 2        NULL                              ·       ·
+      │              1  ·       render 3        NULL                              ·       ·
+      │              1  ·       render 4        NULL                              ·       ·
+      └── join       2  join    ·               ·                                 (a, s)  ·
+           │         2  ·       type            right outer                       ·       ·
+           │         2  ·       equality        (a, s) = (a, s)                   ·       ·
+           │         2  ·       mergeJoinOrder  +"(a=a)"                          ·       ·
+           ├── scan  3  scan    ·               ·                                 (a, s)  ·
+           │         3  ·       table           str1@primary                      ·       ·
+           │         3  ·       spans           ALL                               ·       ·
+           └── scan  3  scan    ·               ·                                 (a, s)  ·
+·                    3  ·       table           str2@primary                      ·       ·
+·                    3  ·       spans           ALL                               ·       ·
 
 
 statement ok
@@ -1511,48 +1533,48 @@ CREATE TABLE xyv (x INT, y INT, v INT, PRIMARY KEY(x,y,v))
 statement ok
 INSERT INTO xyv VALUES (1, 1, 1), (2, 2, 2), (3, 1, 31), (3, 3, 33), (5, 5, 55)
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
-0  render  ·               ·                  (x, y, u, v)                          x!=NULL; y!=NULL
-0  ·       render 0        test.xyu.x         ·                                     ·
-0  ·       render 1        test.xyu.y         ·                                     ·
-0  ·       render 2        test.xyu.u         ·                                     ·
-0  ·       render 3        test.xyv.v         ·                                     ·
-1  join    ·               ·                  (x, y, u, x[omitted], y[omitted], v)  x=x; y=y; x!=NULL; y!=NULL
-1  ·       type            inner              ·                                     ·
-1  ·       equality        (x, y) = (x, y)    ·                                     ·
-1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
-2  scan    ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-2  ·       table           xyu@primary        ·                                     ·
-2  ·       spans           /3-                ·                                     ·
-2  scan    ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-2  ·       table           xyv@primary        ·                                     ·
-2  ·       spans           /3-                ·                                     ·
+render          0  render  ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
+ │              0  ·       render 0        test.xyu.x         ·             ·
+ │              0  ·       render 1        test.xyu.y         ·             ·
+ │              0  ·       render 2        test.xyu.u         ·             ·
+ │              0  ·       render 3        test.xyv.v         ·             ·
+ └── join       1  join    ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
+      │         1  ·       type            inner              ·             ·
+      │         1  ·       equality        (x, y) = (x, y)    ·             ·
+      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
+      ├── scan  2  scan    ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
+      │         2  ·       table           xyu@primary        ·             ·
+      │         2  ·       spans           /3-                ·             ·
+      └── scan  2  scan    ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
+·               2  ·       table           xyv@primary        ·             ·
+·               2  ·       spans           /3-                ·             ·
 
 query IIII
 SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
 3  1  31  31
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-0  render  ·               ·                  (x, y, u, v)                          ·
-0  ·       render 0        test.xyu.x         ·                                     ·
-0  ·       render 1        test.xyu.y         ·                                     ·
-0  ·       render 2        test.xyu.u         ·                                     ·
-0  ·       render 3        test.xyv.v         ·                                     ·
-1  join    ·               ·                  (x, y, u, x[omitted], y[omitted], v)  ·
-1  ·       type            left outer         ·                                     ·
-1  ·       equality        (x, y) = (x, y)    ·                                     ·
-1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
-2  scan    ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-2  ·       table           xyu@primary        ·                                     ·
-2  ·       spans           /3-                ·                                     ·
-2  scan    ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-2  ·       table           xyv@primary        ·                                     ·
-2  ·       spans           /3-                ·                                     ·
+render          0  render  ·               ·                  (x, y, u, v)  ·
+ │              0  ·       render 0        test.xyu.x         ·             ·
+ │              0  ·       render 1        test.xyu.y         ·             ·
+ │              0  ·       render 2        test.xyu.u         ·             ·
+ │              0  ·       render 3        test.xyv.v         ·             ·
+ └── join       1  join    ·               ·                  (x, y, u, v)  ·
+      │         1  ·       type            left outer         ·             ·
+      │         1  ·       equality        (x, y) = (x, y)    ·             ·
+      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
+      ├── scan  2  scan    ·               ·                  (x, y, u, v)  ·
+      │         2  ·       table           xyu@primary        ·             ·
+      │         2  ·       spans           /3-                ·             ·
+      └── scan  2  scan    ·               ·                  (x, y, u, v)  ·
+·               2  ·       table           xyv@primary        ·             ·
+·               2  ·       spans           /3-                ·             ·
 
 query IIII rowsort
 SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -1561,31 +1583,31 @@ SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 3  2  32  NULL
 4  4  44  NULL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-0  render  ·               ·                  (x, y, u, v)                                        ·
-0  ·       render 0        test.xyv.x         ·                                                   ·
-0  ·       render 1        test.xyv.y         ·                                                   ·
-0  ·       render 2        test.xyu.u         ·                                                   ·
-0  ·       render 3        test.xyv.v         ·                                                   ·
-1  render  ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, v)  ·
-1  ·       render 0        test.xyv.x         ·                                                   ·
-1  ·       render 1        test.xyv.y         ·                                                   ·
-1  ·       render 2        NULL               ·                                                   ·
-1  ·       render 3        NULL               ·                                                   ·
-1  ·       render 4        test.xyu.u         ·                                                   ·
-1  ·       render 5        test.xyv.v         ·                                                   ·
-2  join    ·               ·                  (x[omitted], y[omitted], u, x, y, v)                ·
-2  ·       type            right outer        ·                                                   ·
-2  ·       equality        (x, y) = (x, y)    ·                                                   ·
-2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                   ·
-3  scan    ·               ·                  (x, y, u)                                           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-3  ·       table           xyu@primary        ·                                                   ·
-3  ·       spans           /3-                ·                                                   ·
-3  scan    ·               ·                  (x, y, v)                                           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-3  ·       table           xyv@primary        ·                                                   ·
-3  ·       spans           /3-                ·                                                   ·
+render               0  render  ·               ·                  (x, y, u, v)  ·
+ │                   0  ·       render 0        test.xyv.x         ·             ·
+ │                   0  ·       render 1        test.xyv.y         ·             ·
+ │                   0  ·       render 2        test.xyu.u         ·             ·
+ │                   0  ·       render 3        test.xyv.v         ·             ·
+ └── render          1  render  ·               ·                  (x, y, u, v)  ·
+      │              1  ·       render 0        test.xyv.x         ·             ·
+      │              1  ·       render 1        test.xyv.y         ·             ·
+      │              1  ·       render 2        NULL               ·             ·
+      │              1  ·       render 3        NULL               ·             ·
+      │              1  ·       render 4        test.xyu.u         ·             ·
+      │              1  ·       render 5        test.xyv.v         ·             ·
+      └── join       2  join    ·               ·                  (x, y, u, v)  ·
+           │         2  ·       type            right outer        ·             ·
+           │         2  ·       equality        (x, y) = (x, y)    ·             ·
+           │         2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
+           ├── scan  3  scan    ·               ·                  (x, y, u, v)  ·
+           │         3  ·       table           xyu@primary        ·             ·
+           │         3  ·       spans           /3-                ·             ·
+           └── scan  3  scan    ·               ·                  (x, y, u, v)  ·
+·                    3  ·       table           xyv@primary        ·             ·
+·                    3  ·       spans           /3-                ·             ·
 
 query IIII rowsort
 SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -1594,35 +1616,35 @@ SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 3  3  NULL  33
 5  5  NULL  55
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-0  render  ·               ·                               (x, y, u, v)                                                                              x!=NULL
-0  ·       render 0        x                               ·                                                                                         ·
-0  ·       render 1        y                               ·                                                                                         ·
-0  ·       render 2        test.xyu.u                      ·                                                                                         ·
-0  ·       render 3        test.xyv.v                      ·                                                                                         ·
-1  filter  ·               ·                               (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  x!=NULL
-1  ·       filter          x > 2                           ·                                                                                         ·
-2  render  ·               ·                               (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
-2  ·       render 0        IFNULL(test.xyu.x, test.xyv.x)  ·                                                                                         ·
-2  ·       render 1        IFNULL(test.xyu.y, test.xyv.y)  ·                                                                                         ·
-2  ·       render 2        NULL                            ·                                                                                         ·
-2  ·       render 3        NULL                            ·                                                                                         ·
-2  ·       render 4        test.xyu.u                      ·                                                                                         ·
-2  ·       render 5        NULL                            ·                                                                                         ·
-2  ·       render 6        NULL                            ·                                                                                         ·
-2  ·       render 7        test.xyv.v                      ·                                                                                         ·
-3  join    ·               ·                               (x, y, u, x, y, v)                                                                        ·
-3  ·       type            full outer                      ·                                                                                         ·
-3  ·       equality        (x, y) = (x, y)                 ·                                                                                         ·
-3  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"               ·                                                                                         ·
-4  scan    ·               ·                               (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-4  ·       table           xyu@primary                     ·                                                                                         ·
-4  ·       spans           ALL                             ·                                                                                         ·
-4  scan    ·               ·                               (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-4  ·       table           xyv@primary                     ·                                                                                         ·
-4  ·       spans           ALL                             ·                                                                                         ·
+render                    0  render  ·               ·                               (x, y, u, v)  x!=NULL
+ │                        0  ·       render 0        x                               ·             ·
+ │                        0  ·       render 1        y                               ·             ·
+ │                        0  ·       render 2        test.xyu.u                      ·             ·
+ │                        0  ·       render 3        test.xyv.v                      ·             ·
+ └── filter               1  filter  ·               ·                               (x, y, u, v)  x!=NULL
+      │                   1  ·       filter          x > 2                           ·             ·
+      └── render          2  render  ·               ·                               (x, y, u, v)  x!=NULL
+           │              2  ·       render 0        IFNULL(test.xyu.x, test.xyv.x)  ·             ·
+           │              2  ·       render 1        IFNULL(test.xyu.y, test.xyv.y)  ·             ·
+           │              2  ·       render 2        NULL                            ·             ·
+           │              2  ·       render 3        NULL                            ·             ·
+           │              2  ·       render 4        test.xyu.u                      ·             ·
+           │              2  ·       render 5        NULL                            ·             ·
+           │              2  ·       render 6        NULL                            ·             ·
+           │              2  ·       render 7        test.xyv.v                      ·             ·
+           └── join       3  join    ·               ·                               (x, y, u, v)  x!=NULL
+                │         3  ·       type            full outer                      ·             ·
+                │         3  ·       equality        (x, y) = (x, y)                 ·             ·
+                │         3  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"               ·             ·
+                ├── scan  4  scan    ·               ·                               (x, y, u, v)  x!=NULL
+                │         4  ·       table           xyu@primary                     ·             ·
+                │         4  ·       spans           ALL                             ·             ·
+                └── scan  4  scan    ·               ·                               (x, y, u, v)  x!=NULL
+·                         4  ·       table           xyv@primary                     ·             ·
+·                         4  ·       spans           ALL                             ·             ·
 
 query IIII rowsort
 SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -1634,58 +1656,58 @@ SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 5  5  NULL  55
 
 # Verify that we transfer constraints between the two sides.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
-0  join  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
-0  ·     type            inner              ·                   ·
-0  ·     equality        (x, y) = (x, y)    ·                   ·
-0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
-1  scan  ·               ·                  (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
-1  ·     table           xyu@primary        ·                   ·
-1  ·     spans           /1/!NULL-/1/10         ·                   ·
-1  scan  ·               ·                  (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
-1  ·     table           xyv@primary        ·                   ·
-1  ·     spans           /1/!NULL-/1/10         ·                   ·
+join       0  join  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+ │         0  ·     type            inner              ·                   ·
+ │         0  ·     equality        (x, y) = (x, y)    ·                   ·
+ │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan  1  scan  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+ │         1  ·     table           xyu@primary        ·                   ·
+ │         1  ·     spans           /1/!NULL-/1/10     ·                   ·
+ └── scan  1  scan  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+·          1  ·     table           xyv@primary        ·                   ·
+·          1  ·     spans           /1/!NULL-/1/10     ·                   ·
 
 query IIIIII
 SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
 1  1  1  1  1  1
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-0  join  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
-0  ·     type            inner              ·                   ·
-0  ·     equality        (x, y) = (x, y)    ·                   ·
-0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
-1  scan  ·               ·                  (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
-1  ·     table           xyu@primary        ·                   ·
-1  ·     spans           /1/!NULL-/1/10         ·                   ·
-1  scan  ·               ·                  (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
-1  ·     table           xyv@primary        ·                   ·
-1  ·     spans           /1/!NULL-/1/10         ·                   ·
+join       0  join  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+ │         0  ·     type            inner              ·                   ·
+ │         0  ·     equality        (x, y) = (x, y)    ·                   ·
+ │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
+ ├── scan  1  scan  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+ │         1  ·     table           xyu@primary        ·                   ·
+ │         1  ·     spans           /1/!NULL-/1/10     ·                   ·
+ └── scan  1  scan  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+·          1  ·     table           xyv@primary        ·                   ·
+·          1  ·     spans           /1/!NULL-/1/10     ·                   ·
 
 query IIIIII
 SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 1  1  1  1  1  1
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-0  join  ·               ·                                       (x, y, u, x, y, v)  ·
-0  ·     type            left outer                              ·                   ·
-0  ·     equality        (x, y) = (x, y)                         ·                   ·
-0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"                       ·                   ·
-0  ·     pred            (test.xyu.x = 1) AND (test.xyu.y < 10)  ·                   ·
-1  scan  ·               ·                                       (x, y, u)           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-1  ·     table           xyu@primary                             ·                   ·
-1  ·     spans           ALL                                     ·                   ·
-1  scan  ·               ·                                       (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
-1  ·     table           xyv@primary                             ·                   ·
-1  ·     spans           /1/!NULL-/1/10                              ·                   ·
+join       0  join  ·               ·                                       (x, y, u, x, y, v)  ·
+ │         0  ·     type            left outer                              ·                   ·
+ │         0  ·     equality        (x, y) = (x, y)                         ·                   ·
+ │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"                       ·                   ·
+ │         0  ·     pred            (test.xyu.x = 1) AND (test.xyu.y < 10)  ·                   ·
+ ├── scan  1  scan  ·               ·                                       (x, y, u, x, y, v)  ·
+ │         1  ·     table           xyu@primary                             ·                   ·
+ │         1  ·     spans           ALL                                     ·                   ·
+ └── scan  1  scan  ·               ·                                       (x, y, u, x, y, v)  ·
+·          1  ·     table           xyv@primary                             ·                   ·
+·          1  ·     spans           /1/!NULL-/1/10                          ·                   ·
 
 query IIIIII rowsort
 SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
@@ -1696,20 +1718,20 @@ SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu
 3  2  32  NULL  NULL  NULL
 4  4  44  NULL  NULL  NULL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-0  join  ·               ·                                       (x, y, u, x, y, v)  ·
-0  ·     type            right outer                             ·                   ·
-0  ·     equality        (x, y) = (x, y)                         ·                   ·
-0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"                       ·                   ·
-0  ·     pred            (test.xyv.x = 1) AND (test.xyv.y < 10)  ·                   ·
-1  scan  ·               ·                                       (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
-1  ·     table           xyu@primary                             ·                   ·
-1  ·     spans           /1/!NULL-/1/10                              ·                   ·
-1  scan  ·               ·                                       (x, y, v)           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-1  ·     table           xyv@primary                             ·                   ·
-1  ·     spans           ALL                                     ·                   ·
+join       0  join  ·               ·                                       (x, y, u, x, y, v)  ·
+ │         0  ·     type            right outer                             ·                   ·
+ │         0  ·     equality        (x, y) = (x, y)                         ·                   ·
+ │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"                       ·                   ·
+ │         0  ·     pred            (test.xyv.x = 1) AND (test.xyv.y < 10)  ·                   ·
+ ├── scan  1  scan  ·               ·                                       (x, y, u, x, y, v)  ·
+ │         1  ·     table           xyu@primary                             ·                   ·
+ │         1  ·     spans           /1/!NULL-/1/10                          ·                   ·
+ └── scan  1  scan  ·               ·                                       (x, y, u, x, y, v)  ·
+·          1  ·     table           xyv@primary                             ·                   ·
+·          1  ·     spans           ALL                                     ·                   ·
 
 query IIIIII rowsort
 SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
@@ -1723,24 +1745,24 @@ NULL  NULL  NULL  2  2  2
 
 # Test OUTER joins that are run in the distSQL merge joiner
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-0  render  ·               ·                  (x, y, u, v)                          ·
-0  ·       render 0        xyu.x              ·                                     ·
-0  ·       render 1        xyu.y              ·                                     ·
-0  ·       render 2        xyu.u              ·                                     ·
-0  ·       render 3        xyv.v              ·                                     ·
-1  join    ·               ·                  (x, y, u, x[omitted], y[omitted], v)  ·
-1  ·       type            left outer         ·                                     ·
-1  ·       equality        (x, y) = (x, y)    ·                                     ·
-1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
-2  scan    ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-2  ·       table           xyu@primary        ·                                     ·
-2  ·       spans           /3-                ·                                     ·
-2  scan    ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-2  ·       table           xyv@primary        ·                                     ·
-2  ·       spans           /3-                ·                                     ·
+render          0  render  ·               ·                  (x, y, u, v)  ·
+ │              0  ·       render 0        xyu.x              ·             ·
+ │              0  ·       render 1        xyu.y              ·             ·
+ │              0  ·       render 2        xyu.u              ·             ·
+ │              0  ·       render 3        xyv.v              ·             ·
+ └── join       1  join    ·               ·                  (x, y, u, v)  ·
+      │         1  ·       type            left outer         ·             ·
+      │         1  ·       equality        (x, y) = (x, y)    ·             ·
+      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
+      ├── scan  2  scan    ·               ·                  (x, y, u, v)  ·
+      │         2  ·       table           xyu@primary        ·             ·
+      │         2  ·       spans           /3-                ·             ·
+      └── scan  2  scan    ·               ·                  (x, y, u, v)  ·
+·               2  ·       table           xyv@primary        ·             ·
+·               2  ·       spans           /3-                ·             ·
 
 query IIII rowsort
 SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
@@ -1749,31 +1771,31 @@ SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT *
 3  2  32  NULL
 4  4  44  NULL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-0  render  ·               ·                  (x, y, u, v)                                        ·
-0  ·       render 0        xyv.x              ·                                                   ·
-0  ·       render 1        xyv.y              ·                                                   ·
-0  ·       render 2        xyu.u              ·                                                   ·
-0  ·       render 3        xyv.v              ·                                                   ·
-1  render  ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, v)  ·
-1  ·       render 0        xyv.x              ·                                                   ·
-1  ·       render 1        xyv.y              ·                                                   ·
-1  ·       render 2        NULL               ·                                                   ·
-1  ·       render 3        NULL               ·                                                   ·
-1  ·       render 4        xyu.u              ·                                                   ·
-1  ·       render 5        xyv.v              ·                                                   ·
-2  join    ·               ·                  (x[omitted], y[omitted], u, x, y, v)                ·
-2  ·       type            right outer        ·                                                   ·
-2  ·       equality        (x, y) = (x, y)    ·                                                   ·
-2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                   ·
-3  scan    ·               ·                  (x, y, u)                                           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-3  ·       table           xyu@primary        ·                                                   ·
-3  ·       spans           /3-                ·                                                   ·
-3  scan    ·               ·                  (x, y, v)                                           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-3  ·       table           xyv@primary        ·                                                   ·
-3  ·       spans           /3-                ·                                                   ·
+render               0  render  ·               ·                  (x, y, u, v)  ·
+ │                   0  ·       render 0        xyv.x              ·             ·
+ │                   0  ·       render 1        xyv.y              ·             ·
+ │                   0  ·       render 2        xyu.u              ·             ·
+ │                   0  ·       render 3        xyv.v              ·             ·
+ └── render          1  render  ·               ·                  (x, y, u, v)  ·
+      │              1  ·       render 0        xyv.x              ·             ·
+      │              1  ·       render 1        xyv.y              ·             ·
+      │              1  ·       render 2        NULL               ·             ·
+      │              1  ·       render 3        NULL               ·             ·
+      │              1  ·       render 4        xyu.u              ·             ·
+      │              1  ·       render 5        xyv.v              ·             ·
+      └── join       2  join    ·               ·                  (x, y, u, v)  ·
+           │         2  ·       type            right outer        ·             ·
+           │         2  ·       equality        (x, y) = (x, y)    ·             ·
+           │         2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
+           ├── scan  3  scan    ·               ·                  (x, y, u, v)  ·
+           │         3  ·       table           xyu@primary        ·             ·
+           │         3  ·       spans           /3-                ·             ·
+           └── scan  3  scan    ·               ·                  (x, y, u, v)  ·
+·                    3  ·       table           xyv@primary        ·             ·
+·                    3  ·       spans           /3-                ·             ·
 
 query IIII rowsort
 SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
@@ -1782,35 +1804,35 @@ SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT 
 3  3  NULL  33
 5  5  NULL  55
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-0  render  ·               ·                     (x, y, u, v)                                                                              x!=NULL
-0  ·       render 0        x                     ·                                                                                         ·
-0  ·       render 1        y                     ·                                                                                         ·
-0  ·       render 2        xyu.u                 ·                                                                                         ·
-0  ·       render 3        xyv.v                 ·                                                                                         ·
-1  filter  ·               ·                     (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  x!=NULL
-1  ·       filter          x > 2                 ·                                                                                         ·
-2  render  ·               ·                     (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
-2  ·       render 0        IFNULL(xyu.x, xyv.x)  ·                                                                                         ·
-2  ·       render 1        IFNULL(xyu.y, xyv.y)  ·                                                                                         ·
-2  ·       render 2        NULL                  ·                                                                                         ·
-2  ·       render 3        NULL                  ·                                                                                         ·
-2  ·       render 4        xyu.u                 ·                                                                                         ·
-2  ·       render 5        NULL                  ·                                                                                         ·
-2  ·       render 6        NULL                  ·                                                                                         ·
-2  ·       render 7        xyv.v                 ·                                                                                         ·
-3  join    ·               ·                     (x, y, u, x, y, v)                                                                        ·
-3  ·       type            full outer            ·                                                                                         ·
-3  ·       equality        (x, y) = (x, y)       ·                                                                                         ·
-3  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"     ·                                                                                         ·
-4  scan    ·               ·                     (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-4  ·       table           xyu@primary           ·                                                                                         ·
-4  ·       spans           ALL                   ·                                                                                         ·
-4  scan    ·               ·                     (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-4  ·       table           xyv@primary           ·                                                                                         ·
-4  ·       spans           ALL                   ·                                                                                         ·
+render                    0  render  ·               ·                     (x, y, u, v)  x!=NULL
+ │                        0  ·       render 0        x                     ·             ·
+ │                        0  ·       render 1        y                     ·             ·
+ │                        0  ·       render 2        xyu.u                 ·             ·
+ │                        0  ·       render 3        xyv.v                 ·             ·
+ └── filter               1  filter  ·               ·                     (x, y, u, v)  x!=NULL
+      │                   1  ·       filter          x > 2                 ·             ·
+      └── render          2  render  ·               ·                     (x, y, u, v)  x!=NULL
+           │              2  ·       render 0        IFNULL(xyu.x, xyv.x)  ·             ·
+           │              2  ·       render 1        IFNULL(xyu.y, xyv.y)  ·             ·
+           │              2  ·       render 2        NULL                  ·             ·
+           │              2  ·       render 3        NULL                  ·             ·
+           │              2  ·       render 4        xyu.u                 ·             ·
+           │              2  ·       render 5        NULL                  ·             ·
+           │              2  ·       render 6        NULL                  ·             ·
+           │              2  ·       render 7        xyv.v                 ·             ·
+           └── join       3  join    ·               ·                     (x, y, u, v)  x!=NULL
+                │         3  ·       type            full outer            ·             ·
+                │         3  ·       equality        (x, y) = (x, y)       ·             ·
+                │         3  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"     ·             ·
+                ├── scan  4  scan    ·               ·                     (x, y, u, v)  x!=NULL
+                │         4  ·       table           xyu@primary           ·             ·
+                │         4  ·       spans           ALL                   ·             ·
+                └── scan  4  scan    ·               ·                     (x, y, u, v)  x!=NULL
+·                         4  ·       table           xyv@primary           ·             ·
+·                         4  ·       spans           ALL                   ·             ·
 
 query IIII rowsort
 SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
@@ -1821,20 +1843,20 @@ SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT *
 3  3  NULL  33
 5  5  NULL  55
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-0  join  ·               ·                             (x, y, u, x, y, v)  ·
-0  ·     type            left outer                    ·                   ·
-0  ·     equality        (x, y) = (x, y)               ·                   ·
-0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"             ·                   ·
-0  ·     pred            (xyu.x = 1) AND (xyu.y < 10)  ·                   ·
-1  scan  ·               ·                             (x, y, u)           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-1  ·     table           xyu@primary                   ·                   ·
-1  ·     spans           ALL                           ·                   ·
-1  scan  ·               ·                             (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
-1  ·     table           xyv@primary                   ·                   ·
-1  ·     spans           /1/!NULL-/1/10                ·                   ·
+join       0  join  ·               ·                             (x, y, u, x, y, v)  ·
+ │         0  ·     type            left outer                    ·                   ·
+ │         0  ·     equality        (x, y) = (x, y)               ·                   ·
+ │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"             ·                   ·
+ │         0  ·     pred            (xyu.x = 1) AND (xyu.y < 10)  ·                   ·
+ ├── scan  1  scan  ·               ·                             (x, y, u, x, y, v)  ·
+ │         1  ·     table           xyu@primary                   ·                   ·
+ │         1  ·     spans           ALL                           ·                   ·
+ └── scan  1  scan  ·               ·                             (x, y, u, x, y, v)  ·
+·          1  ·     table           xyv@primary                   ·                   ·
+·          1  ·     spans           /1/!NULL-/1/10                ·                   ·
 
 query IIIIII rowsort
 SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
@@ -1845,20 +1867,20 @@ SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT *
 3  2  32  NULL  NULL  NULL
 4  4  44  NULL  NULL  NULL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
-0  join  ·               ·                             (x, y, u, x, y, v)  ·
-0  ·     type            right outer                   ·                   ·
-0  ·     equality        (x, y) = (x, y)               ·                   ·
-0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"             ·                   ·
-0  ·     pred            (xyv.x = 1) AND (xyv.y < 10)  ·                   ·
-1  scan  ·               ·                             (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
-1  ·     table           xyu@primary                   ·                   ·
-1  ·     spans           /1/!NULL-/1/10                ·                   ·
-1  scan  ·               ·                             (x, y, v)           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-1  ·     table           xyv@primary                   ·                   ·
-1  ·     spans           ALL                           ·                   ·
+join       0  join  ·               ·                             (x, y, u, x, y, v)  ·
+ │         0  ·     type            right outer                   ·                   ·
+ │         0  ·     equality        (x, y) = (x, y)               ·                   ·
+ │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"             ·                   ·
+ │         0  ·     pred            (xyv.x = 1) AND (xyv.y < 10)  ·                   ·
+ ├── scan  1  scan  ·               ·                             (x, y, u, x, y, v)  ·
+ │         1  ·     table           xyu@primary                   ·                   ·
+ │         1  ·     spans           /1/!NULL-/1/10                ·                   ·
+ └── scan  1  scan  ·               ·                             (x, y, u, x, y, v)  ·
+·          1  ·     table           xyv@primary                   ·                   ·
+·          1  ·     spans           ALL                           ·                   ·
 
 query IIIIII rowsort
 SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
@@ -1870,26 +1892,26 @@ NULL  NULL  NULL  5  5  55
 NULL  NULL  NULL  2  2  2
 
 # Regression test for #20472: break up tuple inequalities.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
-0  render  ·               ·                      (x, y, u, v)                          x!=NULL; y!=NULL
-0  ·       render 0        test.xyu.x             ·                                     ·
-0  ·       render 1        test.xyu.y             ·                                     ·
-0  ·       render 2        test.xyu.u             ·                                     ·
-0  ·       render 3        test.xyv.v             ·                                     ·
-1  join    ·               ·                      (x, y, u, x[omitted], y[omitted], v)  x=x; y=y; x!=NULL; y!=NULL
-1  ·       type            inner                  ·                                     ·
-1  ·       equality        (x, y) = (x, y)        ·                                     ·
-1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"      ·                                     ·
-2  scan    ·               ·                      (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
-2  ·       table           xyu@primary            ·                                     ·
-2  ·       spans           /1/2/4-                ·                                     ·
-2  ·       filter          (x, y, u) > (1, 2, 3)  ·                                     ·
-2  scan    ·               ·                      (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
-2  ·       table           xyv@primary            ·                                     ·
-2  ·       spans           /1/2-                  ·                                     ·
-2  ·       filter          (x, y) >= (1, 2)       ·                                     ·
+render          0  render  ·               ·                      (x, y, u, v)  x!=NULL; y!=NULL
+ │              0  ·       render 0        test.xyu.x             ·             ·
+ │              0  ·       render 1        test.xyu.y             ·             ·
+ │              0  ·       render 2        test.xyu.u             ·             ·
+ │              0  ·       render 3        test.xyv.v             ·             ·
+ └── join       1  join    ·               ·                      (x, y, u, v)  x!=NULL; y!=NULL
+      │         1  ·       type            inner                  ·             ·
+      │         1  ·       equality        (x, y) = (x, y)        ·             ·
+      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"      ·             ·
+      ├── scan  2  scan    ·               ·                      (x, y, u, v)  x!=NULL; y!=NULL
+      │         2  ·       table           xyu@primary            ·             ·
+      │         2  ·       spans           /1/2/4-                ·             ·
+      │         2  ·       filter          (x, y, u) > (1, 2, 3)  ·             ·
+      └── scan  2  scan    ·               ·                      (x, y, u, v)  x!=NULL; y!=NULL
+·               2  ·       table           xyv@primary            ·             ·
+·               2  ·       spans           /1/2-                  ·             ·
+·               2  ·       filter          (x, y) >= (1, 2)       ·             ·
 
 
 # Regression test for #20858.
@@ -1900,68 +1922,68 @@ CREATE TABLE l (a INT PRIMARY KEY)
 statement ok
 CREATE TABLE r (a INT PRIMARY KEY)
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-0  render  ·               ·           (a)              ·
-0  ·       render 0        test.l.a    ·                ·
-1  join    ·               ·           (a, a[omitted])  ·
-1  ·       type            left outer  ·                ·
-1  ·       equality        (a) = (a)   ·                ·
-1  ·       mergeJoinOrder  +"(a=a)"    ·                ·
-2  scan    ·               ·           (a)              a=CONST; key()
-2  ·       table           l@primary   ·                ·
-2  ·       spans           /3-/3/#     ·                ·
-2  scan    ·               ·           (a)              a=CONST; key()
-2  ·       table           r@primary   ·                ·
-2  ·       spans           /3-/3/#     ·                ·
+render          0  render  ·               ·           (a)  ·
+ │              0  ·       render 0        test.l.a    ·    ·
+ └── join       1  join    ·               ·           (a)  ·
+      │         1  ·       type            left outer  ·    ·
+      │         1  ·       equality        (a) = (a)   ·    ·
+      │         1  ·       mergeJoinOrder  +"(a=a)"    ·    ·
+      ├── scan  2  scan    ·               ·           (a)  ·
+      │         2  ·       table           l@primary   ·    ·
+      │         2  ·       spans           /3-/3/#     ·    ·
+      └── scan  2  scan    ·               ·           (a)  ·
+·               2  ·       table           r@primary   ·    ·
+·               2  ·       spans           /3-/3/#     ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
-0  join  ·               ·           (a, a)  ·
-0  ·     type            left outer  ·       ·
-0  ·     equality        (a) = (a)   ·       ·
-0  ·     mergeJoinOrder  +"(a=a)"    ·       ·
-1  scan  ·               ·           (a)     a=CONST; key()
-1  ·     table           l@primary   ·       ·
-1  ·     spans           /3-/3/#     ·       ·
-1  scan  ·               ·           (a)     a=CONST; key()
-1  ·     table           r@primary   ·       ·
-1  ·     spans           /3-/3/#     ·       ·
+join       0  join  ·               ·           (a, a)  ·
+ │         0  ·     type            left outer  ·       ·
+ │         0  ·     equality        (a) = (a)   ·       ·
+ │         0  ·     mergeJoinOrder  +"(a=a)"    ·       ·
+ ├── scan  1  scan  ·               ·           (a, a)  ·
+ │         1  ·     table           l@primary   ·       ·
+ │         1  ·     spans           /3-/3/#     ·       ·
+ └── scan  1  scan  ·               ·           (a, a)  ·
+·          1  ·     table           r@primary   ·       ·
+·          1  ·     spans           /3-/3/#     ·       ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-0  render  ·               ·            (a)                     ·
-0  ·       render 0        test.r.a     ·                       ·
-1  render  ·               ·            (a, a[hidden,omitted])  ·
-1  ·       render 0        test.r.a     ·                       ·
-1  ·       render 1        NULL         ·                       ·
-2  join    ·               ·            (a[omitted], a)         ·
-2  ·       type            right outer  ·                       ·
-2  ·       equality        (a) = (a)    ·                       ·
-2  ·       mergeJoinOrder  +"(a=a)"     ·                       ·
-3  scan    ·               ·            (a)                     a=CONST; key()
-3  ·       table           l@primary    ·                       ·
-3  ·       spans           /3-/3/#      ·                       ·
-3  scan    ·               ·            (a)                     a=CONST; key()
-3  ·       table           r@primary    ·                       ·
-3  ·       spans           /3-/3/#      ·                       ·
+render               0  render  ·               ·            (a)  ·
+ │                   0  ·       render 0        test.r.a     ·    ·
+ └── render          1  render  ·               ·            (a)  ·
+      │              1  ·       render 0        test.r.a     ·    ·
+      │              1  ·       render 1        NULL         ·    ·
+      └── join       2  join    ·               ·            (a)  ·
+           │         2  ·       type            right outer  ·    ·
+           │         2  ·       equality        (a) = (a)    ·    ·
+           │         2  ·       mergeJoinOrder  +"(a=a)"     ·    ·
+           ├── scan  3  scan    ·               ·            (a)  ·
+           │         3  ·       table           l@primary    ·    ·
+           │         3  ·       spans           /3-/3/#      ·    ·
+           └── scan  3  scan    ·               ·            (a)  ·
+·                    3  ·       table           r@primary    ·    ·
+·                    3  ·       spans           /3-/3/#      ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
 ----
-0  join  ·               ·            (a, a)  ·
-0  ·     type            right outer  ·       ·
-0  ·     equality        (a) = (a)    ·       ·
-0  ·     mergeJoinOrder  +"(a=a)"     ·       ·
-1  scan  ·               ·            (a)     a=CONST; key()
-1  ·     table           l@primary    ·       ·
-1  ·     spans           /3-/3/#      ·       ·
-1  scan  ·               ·            (a)     a=CONST; key()
-1  ·     table           r@primary    ·       ·
-1  ·     spans           /3-/3/#      ·       ·
+join       0  join  ·               ·            (a, a)  ·
+ │         0  ·     type            right outer  ·       ·
+ │         0  ·     equality        (a) = (a)    ·       ·
+ │         0  ·     mergeJoinOrder  +"(a=a)"     ·       ·
+ ├── scan  1  scan  ·               ·            (a, a)  ·
+ │         1  ·     table           l@primary    ·       ·
+ │         1  ·     spans           /3-/3/#      ·       ·
+ └── scan  1  scan  ·               ·            (a, a)  ·
+·          1  ·     table           r@primary    ·       ·
+·          1  ·     spans           /3-/3/#      ·       ·
 
 statement ok
 INSERT INTO l VALUES (1), (2), (3)

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -57,38 +57,38 @@ SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
 5 25 125
 
 # There must be no limit at the index scan level.
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
 ----
-Level  Type        Field   Description  Columns                      Ordering
-0      limit       ·       ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
-0      ·           count   2            ·                            ·
-1      index-join  ·       ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
-2      scan        ·       ·            (k, v[omitted], w[omitted])  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
-2      ·           table   t@t_v_idx    ·                            ·
-2      ·           spans   /5-          ·                            ·
-2      scan        ·       ·            (k, v, w)                    ·
-2      ·           table   t@primary    ·                            ·
-2      ·           filter  w > 30       ·                            ·
+Tree             Level  Type        Field   Description  Columns    Ordering
+limit            0      limit       ·       ·            (k, v, w)  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+ │               0      ·           count   2            ·          ·
+ └── index-join  1      index-join  ·       ·            (k, v, w)  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+      ├── scan   2      scan        ·       ·            (k, v, w)  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+      │          2      ·           table   t@t_v_idx    ·          ·
+      │          2      ·           spans   /5-          ·          ·
+      └── scan   2      scan        ·       ·            (k, v, w)  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+·                2      ·           table   t@primary    ·          ·
+·                2      ·           filter  w > 30       ·          ·
 
 # This kind of query can be used to work around memory usage limits. We need to
 # choose the "hard" limit of 100 over the "soft" limit of 25 (with the hard
 # limit we will only store 100 rows in the sort node). See #19677.
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT w FROM (SELECT w FROM t ORDER BY w LIMIT 100) ORDER BY w LIMIT 25
 ----
-Level  Type      Field     Description  Columns                      Ordering
-0      limit     ·          ·            (w)                          weak-key(w); +w
-0      ·         count      25           ·                            ·
-1      distinct  ·          ·            (w)                          weak-key(w); +w
-1      ·         order key  w            ·                            ·
-2      limit     ·          ·            (w)                          +w
-2      ·         count      100          ·                            ·
-3      sort      ·          ·            (w)                          +w
-3      ·         order      +w           ·                            ·
-3      ·         strategy   top 100      ·                            ·
-4      render    ·          ·            (w)                          ·
-4      ·         render 0   test.t.w     ·                            ·
-5      scan      ·          ·            (k[omitted], v[omitted], w)  k!=NULL; key(k)
-5      ·         table      t@primary    ·                            ·
-5      ·         spans      ALL          ·                            ·
+Tree                           Level  Type      Field      Description  Columns  Ordering
+limit                          0      limit     ·          ·            (w)      weak-key(w); +w
+ │                             0      ·         count      25           ·        ·
+ └── distinct                  1      distinct  ·          ·            (w)      weak-key(w); +w
+      │                        1      ·         order key  w            ·        ·
+      └── limit                2      limit     ·          ·            (w)      weak-key(w); +w
+           │                   2      ·         count      100          ·        ·
+           └── sort            3      sort      ·          ·            (w)      weak-key(w); +w
+                │              3      ·         order      +w           ·        ·
+                │              3      ·         strategy   top 100      ·        ·
+                └── render     4      render    ·          ·            (w)      weak-key(w); +w
+                     │         4      ·         render 0   test.t.w     ·        ·
+                     └── scan  5      scan      ·          ·            (w)      weak-key(w); +w
+·                              5      ·         table      t@primary    ·        ·
+·                              5      ·         spans      ALL          ·        ·

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -1,187 +1,187 @@
 # LogicTest: default distsql
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA,NOOPTIMIZE) SELECT 1 FROM (SELECT 2 AS s)
 ----
-0  render    ·  ·  ("1")  "1"=CONST
-1  render    ·  ·  (s)    s=CONST
-2  emptyrow  ·  ·  ()     ·
+render              0  render    ·  ·  ("1")  "1"=CONST
+ └── render         1  render    ·  ·  ("1")  "1"=CONST
+      └── emptyrow  2  emptyrow  ·  ·  ("1")  "1"=CONST
 
 # Propagation to data sources.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s)
 ----
-0  render    ·  ·  ("1")         "1"=CONST
-1  render    ·  ·  (s[omitted])  ·
-2  emptyrow  ·  ·  ()            ·
+render              0  render    ·  ·  ("1")  "1"=CONST
+ └── render         1  render    ·  ·  ("1")  "1"=CONST
+      └── emptyrow  2  emptyrow  ·  ·  ("1")  "1"=CONST
 
 # Propagation through CREATE TABLE.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) CREATE TABLE t AS SELECT 1 FROM (SELECT 2 AS s)
 ----
-0  create table  ·  ·  ()            ·
-1  render        ·  ·  ("1")         "1"=CONST
-2  render        ·  ·  (s[omitted])  ·
-3  emptyrow      ·  ·  ()            ·
+create table             0  create table  ·  ·  ()  ·
+ └── render              1  render        ·  ·  ()  ·
+      └── render         2  render        ·  ·  ()  ·
+           └── emptyrow  3  emptyrow      ·  ·  ()  ·
 
 # Propagation through LIMIT.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s) LIMIT 1
 ----
-0  limit     ·  ·  ("1")         "1"=CONST
-1  render    ·  ·  ("1")         "1"=CONST
-2  render    ·  ·  (s[omitted])  ·
-3  emptyrow  ·  ·  ()            ·
+limit                    0  limit     ·  ·  ("1")  "1"=CONST
+ └── render              1  render    ·  ·  ("1")  "1"=CONST
+      └── render         2  render    ·  ·  ("1")  "1"=CONST
+           └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s LIMIT 1)
 ----
-0  render    ·  ·  ("1")         "1"=CONST
-1  limit     ·  ·  (s[omitted])  ·
-2  render    ·  ·  (s[omitted])  ·
-3  emptyrow  ·  ·  ()            ·
+render                   0  render    ·  ·  ("1")  "1"=CONST
+ └── limit               1  limit     ·  ·  ("1")  "1"=CONST
+      └── render         2  render    ·  ·  ("1")  "1"=CONST
+           └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
 
 # Propagation through UNION.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION SELECT 2 AS s)
 ----
-0  render    ·  ·  ("1")  "1"=CONST
-1  union     ·  ·  (s)    ·
-2  render    ·  ·  (s)    s=CONST
-3  emptyrow  ·  ·  ()     ·
-2  render    ·  ·  (s)    s=CONST
-3  emptyrow  ·  ·  ()     ·
+render                   0  render    ·  ·  ("1")  "1"=CONST
+ └── union               1  union     ·  ·  ("1")  "1"=CONST
+      ├── render         2  render    ·  ·  ("1")  "1"=CONST
+      │    └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
+      └── render         2  render    ·  ·  ("1")  "1"=CONST
+           └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION ALL SELECT 2 AS s)
 ----
-0  render    ·  ·  ("1")         "1"=CONST
-1  append    ·  ·  (s[omitted])  ·
-2  render    ·  ·  (s[omitted])  ·
-3  emptyrow  ·  ·  ()            ·
-2  render    ·  ·  (s[omitted])  ·
-3  emptyrow  ·  ·  ()            ·
+render                   0  render    ·  ·  ("1")  "1"=CONST
+ └── append              1  append    ·  ·  ("1")  "1"=CONST
+      ├── render         2  render    ·  ·  ("1")  "1"=CONST
+      │    └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
+      └── render         2  render    ·  ·  ("1")  "1"=CONST
+           └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
 
 # Propagation through WITH ORDINALITY.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s) WITH ORDINALITY
 ----
-0  render      ·  ·  ("1")                       "1"=CONST
-1  ordinality  ·  ·  (s[omitted], "ordinality")  weak-key("ordinality")
-2  render      ·  ·  (s[omitted])                ·
-3  emptyrow    ·  ·  ()                          ·
+render                   0  render      ·  ·  ("1")  "1"=CONST
+ └── ordinality          1  ordinality  ·  ·  ("1")  "1"=CONST
+      └── render         2  render      ·  ·  ("1")  "1"=CONST
+           └── emptyrow  3  emptyrow    ·  ·  ("1")  "1"=CONST
 
 # Propagation through sort, when the sorting column is in the results.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y) ORDER BY x
 ----
-0  render    ·  ·  (x)              x=CONST
-1  render    ·  ·  (x, y[omitted])  x=CONST
-2  emptyrow  ·  ·  ()               ·
+render              0  render    ·  ·  (x)  x=CONST
+ └── render         1  render    ·  ·  (x)  x=CONST
+      └── emptyrow  2  emptyrow  ·  ·  (x)  x=CONST
 
 # Propagation through sort, when the sorting column is not in the results.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y, 3 AS z) ORDER BY y
 ----
-0  nosort    ·      ·   (x)                 x=CONST
-0  ·         order  +y  ·                   ·
-1  render    ·      ·   (x, y)              x=CONST; y=CONST
-2  render    ·      ·   (x, y, z[omitted])  x=CONST; y=CONST
-3  emptyrow  ·      ·   ()                  ·
+nosort                   0  nosort    ·      ·   (x)  x=CONST
+ │                       0  ·         order  +y  ·    ·
+ └── render              1  render    ·      ·   (x)  x=CONST
+      └── render         2  render    ·      ·   (x)  x=CONST
+           └── emptyrow  3  emptyrow  ·      ·   (x)  x=CONST
 
 # Propagation to sub-queries.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
 ----
-0  render    ·           ·  (y)           y=CONST
-0  ·         subqueries  1  ·             ·
-1  limit     ·           ·  (x)           x=CONST
-2  render    ·           ·  (x)           x=CONST
-3  render    ·           ·  (s[omitted])  ·
-4  emptyrow  ·           ·  ()            ·
-1  emptyrow  ·           ·  ()            ·
+render                        0  render    ·           ·  (y)  y=CONST
+ │                            0  ·         subqueries  1  ·    ·
+ ├── limit                    1  limit     ·           ·  (y)  y=CONST
+ │    └── render              2  render    ·           ·  (y)  y=CONST
+ │         └── render         3  render    ·           ·  (y)  y=CONST
+ │              └── emptyrow  4  emptyrow  ·           ·  (y)  y=CONST
+ └── emptyrow                 1  emptyrow  ·           ·  (y)  y=CONST
 
 # Propagation through table scans.
 statement ok
 CREATE TABLE kv(k INT PRIMARY KEY, v INT)
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM kv
 ----
-0  render  ·      ·           ("1")                     "1"=CONST
-1  scan    ·      ·           (k[omitted], v[omitted])  k!=NULL; key(k)
-1  ·       table  kv@primary  ·                         ·
-1  ·       spans  ALL         ·                         ·
+render     0  render  ·      ·           ("1")  "1"=CONST
+ └── scan  1  scan    ·      ·           ("1")  "1"=CONST
+·          1  ·       table  kv@primary  ·      ·
+·          1  ·       spans  ALL         ·      ·
 
 # Propagation through DISTINCT.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT v FROM kv
 ----
-0  distinct  ·      ·           (v)              weak-key(v)
-1  render    ·      ·           (v)              ·
-2  scan      ·      ·           (k[omitted], v)  k!=NULL; key(k)
-2  ·         table  kv@primary  ·                ·
-2  ·         spans  ALL         ·                ·
+distinct        0  distinct  ·      ·           (v)  weak-key(v)
+ └── render     1  render    ·      ·           (v)  weak-key(v)
+      └── scan  2  scan      ·      ·           (v)  weak-key(v)
+·               2  ·         table  kv@primary  ·    ·
+·               2  ·         spans  ALL         ·    ·
 
 # Propagation through INSERT.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) INSERT INTO kv(k, v) SELECT 1, 2 FROM (SELECT 3 AS x, 4 AS y)
 ----
-0  insert    ·     ·         ()                        ·
-0  ·         into  kv(k, v)  ·                         ·
-1  render    ·     ·         ("1", "2")                "1"=CONST; "2"=CONST
-2  render    ·     ·         (x[omitted], y[omitted])  ·
-3  emptyrow  ·     ·         ()                        ·
+insert                   0  insert    ·     ·         ()  ·
+ │                       0  ·         into  kv(k, v)  ·   ·
+ └── render              1  render    ·     ·         ()  ·
+      └── render         2  render    ·     ·         ()  ·
+           └── emptyrow  3  emptyrow  ·     ·         ()  ·
 
 # Propagation through DELETE.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) DELETE FROM kv WHERE k = 3
 ----
-0  delete  ·      ·           ()               ·
-0  ·       from   kv          ·                ·
-1  render  ·      ·           (k)              k=CONST; key()
-2  scan    ·      ·           (k, v[omitted])  k=CONST; key()
-2  ·       table  kv@primary  ·                ·
-2  ·       spans  /3-/3/#     ·                ·
+delete          0  delete  ·      ·           ()  ·
+ │              0  ·       from   kv          ·   ·
+ └── render     1  render  ·      ·           ()  ·
+      └── scan  2  scan    ·      ·           ()  ·
+·               2  ·       table  kv@primary  ·   ·
+·               2  ·       spans  /3-/3/#     ·   ·
 
 # Ensure that propagations through a render node removes the renders
 # and properly propagates the remaining needed columns.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT x FROM (SELECT 1 AS x, y FROM (SELECT 2 AS y))
 ----
-0  render    ·         ·     (x)              x=CONST
-0  ·         render 0  x     ·                ·
-1  render    ·         ·     (x, y[omitted])  x=CONST
-1  ·         render 0  1     ·                ·
-1  ·         render 1  NULL  ·                ·
-2  render    ·         ·     (y[omitted])     ·
-2  ·         render 0  NULL  ·                ·
-3  emptyrow  ·         ·     ()               ·
+render                   0  render    ·         ·     (x)  x=CONST
+ │                       0  ·         render 0  x     ·    ·
+ └── render              1  render    ·         ·     (x)  x=CONST
+      │                  1  ·         render 0  1     ·    ·
+      │                  1  ·         render 1  NULL  ·    ·
+      └── render         2  render    ·         ·     (x)  x=CONST
+           │             2  ·         render 0  NULL  ·    ·
+           └── emptyrow  3  emptyrow  ·         ·     (x)  x=CONST
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT k+1 AS x, v-2 AS y FROM kv)
 ----
-0  render  ·         ·           ("1")                     "1"=CONST
-0  ·       render 0  1           ·                         ·
-1  scan    ·         ·           (k[omitted], v[omitted])  k!=NULL; key(k)
-1  ·       table     kv@primary  ·                         ·
-1  ·       spans     ALL         ·                         ·
+render     0  render  ·         ·           ("1")  "1"=CONST
+ │         0  ·       render 0  1           ·      ·
+ └── scan  1  scan    ·         ·           ("1")  "1"=CONST
+·          1  ·       table     kv@primary  ·      ·
+·          1  ·       spans     ALL         ·      ·
 
 statement ok
 CREATE TABLE a ("name" string, age int);
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT "name", age FROM a);
 ----
-0  group   ·            ·             (count)                                                 ·
-0  ·       aggregate 0  count_rows()  ·                                                       ·
-1  render  ·            ·             ()                                                      ·
-2  render  ·            ·             ("name"[omitted], age[omitted])                         ·
-2  ·       render 0     NULL          ·                                                       ·
-2  ·       render 1     NULL          ·                                                       ·
-3  scan    ·            ·             ("name"[omitted], age[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-3  ·       table        a@primary     ·                                                       ·
-3  ·       spans        ALL           ·                                                       ·
+group                0  group   ·            ·             (count)  ·
+ │                   0  ·       aggregate 0  count_rows()  ·        ·
+ └── render          1  render  ·            ·             (count)  ·
+      └── render     2  render  ·            ·             (count)  ·
+           │         2  ·       render 0     NULL          ·        ·
+           │         2  ·       render 1     NULL          ·        ·
+           └── scan  3  scan    ·            ·             (count)  ·
+·                    3  ·       table        a@primary     ·        ·
+·                    3  ·       spans        ALL           ·        ·
 
 # Ensure that variables within filter conditions are omitted (not decoded) if
 # the filter condition is replaced by an index search.
@@ -189,12 +189,12 @@ EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT "name", age FROM a);
 statement ok
 CREATE TABLE ab (a INT, b INT, PRIMARY KEY (a, b));
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM ab WHERE a=1
 ----
-0  group   ·            ·             (count)                   ·
-0  ·       aggregate 0  count_rows()  ·                         ·
-1  render  ·            ·             ()                        ·
-2  scan    ·            ·             (a[omitted], b[omitted])  a=CONST; b!=NULL; key(b)
-2  ·       table        ab@primary    ·                         ·
-2  ·       spans        /1-/2         ·                         ·
+group           0  group   ·            ·             (count)  ·
+ │              0  ·       aggregate 0  count_rows()  ·        ·
+ └── render     1  render  ·            ·             (count)  ·
+      └── scan  2  scan    ·            ·             (count)  ·
+·               2  ·       table        ab@primary    ·        ·
+·               2  ·       spans        /1-/2         ·        ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -40,15 +40,15 @@ SELECT a, b FROM t ORDER BY b
 2 8
 1 9
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b
 ----
-0  sort    ·      ·
-0  ·       order  +b
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  t@primary
-2  ·       spans  ALL
+sort            ·      ·
+ │              order  +b
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  t@primary
+·               spans  ALL
 
 query II
 SELECT a, b FROM t ORDER BY b DESC
@@ -57,15 +57,15 @@ SELECT a, b FROM t ORDER BY b DESC
 2 8
 3 7
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b DESC
 ----
-0  sort    ·      ·
-0  ·       order  -b
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  t@primary
-2  ·       spans  ALL
+sort            ·      ·
+ │              order  -b
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  t@primary
+·               spans  ALL
 
 query I
 SELECT a FROM t ORDER BY 1 DESC
@@ -74,17 +74,17 @@ SELECT a FROM t ORDER BY 1 DESC
 2
 1
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
-0  limit   ·         ·
-1  sort    ·         ·
-1  ·       order     +b
-1  ·       strategy  top 2
-2  render  ·         ·
-3  scan    ·         ·
-3  ·       table     t@primary
-3  ·       spans     ALL
+limit                ·         ·
+ └── sort            ·         ·
+      │              order     +b
+      │              strategy  top 2
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     t@primary
+·                    spans     ALL
 
 query II
 SELECT a, b FROM t ORDER BY b DESC LIMIT 2
@@ -92,21 +92,21 @@ SELECT a, b FROM t ORDER BY b DESC LIMIT 2
 1 9
 2 8
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT c FROM t ORDER BY b LIMIT 2
 ----
-0  limit     ·         ·          (c)                 weak-key(c)
-0  ·         count     2          ·                   ·
-1  distinct  ·         ·          (c)                 weak-key(c)
-2  sort      ·         ·          (c)                 ·
-2  ·         order     +b         ·                   ·
-2  ·         strategy  iterative  ·                   ·
-3  render    ·         ·          (c, b)              ·
-3  ·         render 0  test.t.c   ·                   ·
-3  ·         render 1  test.t.b   ·                   ·
-4  scan      ·         ·          (a[omitted], b, c)  a!=NULL; key(a)
-4  ·         table     t@primary  ·                   ·
-4  ·         spans     ALL        ·                   ·
+limit                     0  limit     ·         ·          (c)  weak-key(c)
+ │                        0  ·         count     2          ·    ·
+ └── distinct             1  distinct  ·         ·          (c)  weak-key(c)
+      └── sort            2  sort      ·         ·          (c)  weak-key(c)
+           │              2  ·         order     +b         ·    ·
+           │              2  ·         strategy  iterative  ·    ·
+           └── render     3  render    ·         ·          (c)  weak-key(c)
+                │         3  ·         render 0  test.t.c   ·    ·
+                │         3  ·         render 1  test.t.b   ·    ·
+                └── scan  4  scan      ·         ·          (c)  weak-key(c)
+·                         4  ·         table     t@primary  ·    ·
+·                         4  ·         spans     ALL        ·    ·
 
 query B
 SELECT DISTINCT c FROM t ORDER BY b DESC LIMIT 2
@@ -153,84 +153,84 @@ SELECT b FROM t ORDER BY a DESC
 8
 9
 
-query ITTT
+query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
-0  nosort   ·      ·
-0  ·        order  -a
-1  render   ·      ·
-2  revscan  ·      ·
-2  ·        table  t@primary
-2  ·        spans  ALL
+nosort             ·      ·
+ │                 order  -a
+ └── render        ·      ·
+      └── revscan  ·      ·
+·                  table  t@primary
+·                  spans  ALL
 
 # Check that LIMIT propagates past nosort nodes.
-query ITTT
+query TTT
 EXPLAIN SELECT b FROM t ORDER BY a LIMIT 1
 ----
-0  limit   ·      ·
-1  nosort  ·      ·
-1  ·       order  +a
-2  render  ·      ·
-3  scan    ·      ·
-3  ·       table  t@primary
-3  ·       spans  ALL
-3  ·       limit  1
+limit                ·      ·
+ └── nosort          ·      ·
+      │              order  +a
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  t@primary
+·                    spans  ALL
+·                    limit  1
 
-query ITTT
+query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
-0  nosort   ·      ·
-0  ·        order  -a,+b
-1  render   ·      ·
-2  revscan  ·      ·
-2  ·        table  t@primary
-2  ·        spans  ALL
+nosort             ·      ·
+ │                 order  -a,+b
+ └── render        ·      ·
+      └── revscan  ·      ·
+·                  table  t@primary
+·                  spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
-0  nosort   ·      ·
-0  ·        order  -a,-b
-1  render   ·      ·
-2  revscan  ·      ·
-2  ·        table  t@primary
-2  ·        spans  ALL
+nosort             ·      ·
+ │                 order  -a,-b
+ └── render        ·      ·
+      └── revscan  ·      ·
+·                  table  t@primary
+·                  spans  ALL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, t.*)
 ----
-0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
-0  ·     order  +b,+a,+c   ·          ·
-1  scan  ·      ·          (a, b, c)  a!=NULL; key(a)
-1  ·     table  t@primary  ·          ·
-1  ·     spans  ALL        ·          ·
+sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+ │         0  ·     order  +b,+a,+c   ·          ·
+ └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+·          1  ·     table  t@primary  ·          ·
+·          1  ·     spans  ALL        ·          ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, a), c
 ----
-0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
-0  ·     order  +b,+a,+c   ·          ·
-1  scan  ·      ·          (a, b, c)  a!=NULL; key(a)
-1  ·     table  t@primary  ·          ·
-1  ·     spans  ALL        ·          ·
+sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+ │         0  ·     order  +b,+a,+c   ·          ·
+ └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+·          1  ·     table  t@primary  ·          ·
+·          1  ·     spans  ALL        ·          ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN(METADATA) SELECT * FROM t ORDER BY b, (a, c)
 ----
-0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
-0  ·     order  +b,+a,+c   ·          ·
-1  scan  ·      ·          (a, b, c)  a!=NULL; key(a)
-1  ·     table  t@primary  ·          ·
-1  ·     spans  ALL        ·          ·
+sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+ │         0  ·     order  +b,+a,+c   ·          ·
+ └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+·          1  ·     table  t@primary  ·          ·
+·          1  ·     spans  ALL        ·          ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, (a, c))
 ----
-0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
-0  ·     order  +b,+a,+c   ·          ·
-1  scan  ·      ·          (a, b, c)  a!=NULL; key(a)
-1  ·     table  t@primary  ·          ·
-1  ·     spans  ALL        ·          ·
+sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+ │         0  ·     order  +b,+a,+c   ·          ·
+ └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+·          1  ·     table  t@primary  ·          ·
+·          1  ·     spans  ALL        ·          ·
 
 statement ok
 INSERT INTO t VALUES (4, 7), (5, 7)
@@ -345,66 +345,66 @@ SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER 
 
 
 # Check that sort is skipped if the ORDER BY clause is constant.
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t ORDER BY 1+2
 ----
-0  nosort  ·      ·
-0  ·       order  +"1 + 2"
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  t@primary
-2  ·       spans  ALL
+nosort          ·      ·
+ │              order  +"1 + 2"
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  t@primary
+·               spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN SELECT 1, * FROM t ORDER BY 1
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
-0  nosort  ·      ·
-0  ·       order  +length
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  t@primary
-2  ·       spans  ALL
+nosort          ·      ·
+ │              order  +length
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  t@primary
+·               spans  ALL
 
 # Check that the sort key reuses the existing render.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT b+2 FROM t ORDER BY b+2
 ----
-0  sort    ·      ·          ("b + 2")                    +"b + 2"
-0  ·       order  +"b + 2"   ·                            ·
-1  render  ·      ·          ("b + 2")                    ·
-2  scan    ·      ·          (a[omitted], b, c[omitted])  a!=NULL; key(a)
-2  ·       table  t@primary  ·                            ·
-2  ·       spans  ALL        ·                            ·
+sort            0  sort    ·      ·          ("b + 2")  +"b + 2"
+ │              0  ·       order  +"b + 2"   ·          ·
+ └── render     1  render  ·      ·          ("b + 2")  +"b + 2"
+      └── scan  2  scan    ·      ·          ("b + 2")  +"b + 2"
+·               2  ·       table  t@primary  ·          ·
+·               2  ·       spans  ALL        ·          ·
 
 # Check that the sort picks up a renamed render properly.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY y
 ----
-0  sort    ·      ·          (y)                          +y
-0  ·       order  +y         ·                            ·
-1  render  ·      ·          (y)                          ·
-2  scan    ·      ·          (a[omitted], b, c[omitted])  a!=NULL; key(a)
-2  ·       table  t@primary  ·                            ·
-2  ·       spans  ALL        ·                            ·
+sort            0  sort    ·      ·          (y)  +y
+ │              0  ·       order  +y         ·    ·
+ └── render     1  render  ·      ·          (y)  +y
+      └── scan  2  scan    ·      ·          (y)  +y
+·               2  ·       table  t@primary  ·    ·
+·               2  ·       spans  ALL        ·    ·
 
 # Check that the sort reuses a render behind a rename properly.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
 ----
-0  sort    ·      ·          (y)                          +y
-0  ·       order  +y         ·                            ·
-1  render  ·      ·          (y)                          ·
-2  scan    ·      ·          (a[omitted], b, c[omitted])  a!=NULL; key(a)
-2  ·       table  t@primary  ·                            ·
-2  ·       spans  ALL        ·                            ·
+sort            0  sort    ·      ·          (y)  +y
+ │              0  ·       order  +y         ·    ·
+ └── render     1  render  ·      ·          (y)  +y
+      └── scan  2  scan    ·      ·          (y)  +y
+·               2  ·       table  t@primary  ·    ·
+·               2  ·       spans  ALL        ·    ·
 
 statement ok
 CREATE TABLE abc (
@@ -439,12 +439,12 @@ fetched: /abc/primary/4/5/6 -> NULL
 fetched: /abc/primary/4/5/6/d -> 'Two'
 output row: [4 5 6 'Two']
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM abc ORDER BY a
 ----
-0  scan  ·      ·
-0  ·     table  abc@primary
-0  ·     spans  ALL
+scan  ·      ·
+·     table  abc@primary
+·     spans  ALL
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT a, b FROM abc ORDER BY b, a]
@@ -455,91 +455,91 @@ output row: [1 2]
 fetched: /abc/ba/5/4/6 -> NULL
 output row: [4 5]
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abc@ba
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  abc@ba
+·          spans  ALL
 
 # The non-unique index ba includes column c (required to make the keys unique)
 # so the results will already be sorted.
-query ITTT
+query TTT
 EXPLAIN SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abc@ba
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  abc@ba
+·          spans  ALL
 
 # We use the WHERE condition to force the use of index ba.
-query ITTT
+query TTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
-0  sort        ·      ·
-0  ·           order  +b,+a,+d
-1  index-join  ·      ·
-2  scan        ·      ·
-2  ·           table  abc@ba
-2  ·           spans  /11-
-2  scan        ·      ·
-2  ·           table  abc@primary
+sort             ·      ·
+ │               order  +b,+a,+d
+ └── index-join  ·      ·
+      ├── scan   ·      ·
+      │          table  abc@ba
+      │          spans  /11-
+      └── scan   ·      ·
+·                table  abc@primary
 
 # We cannot have rows with identical values for a,b,c so we don't need to
 # sort for d.
-query ITTT
+query TTT
 EXPLAIN SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
 ----
-0  index-join  ·      ·
-1  scan        ·      ·
-1  ·           table  abc@ba
-1  ·           spans  /11-
-1  scan        ·      ·
-1  ·           table  abc@primary
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  abc@ba
+ │          spans  /11-
+ └── scan   ·      ·
+·           table  abc@primary
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
-0  nosort  ·      ·
-0  ·       order  +b,+c
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  abc@bc
-2  ·       spans  ALL
+nosort          ·      ·
+ │              order  +b,+c
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  abc@bc
+·               spans  ALL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
-0  nosort  ·         ·           (a, b)                 b!=NULL; +b
-0  ·       order     +b,+c       ·                      ·
-1  render  ·         ·           (a, b, c)              b!=NULL; c!=NULL; key(b,c); +b,+c
-1  ·       render 0  test.abc.a  ·                      ·
-1  ·       render 1  test.abc.b  ·                      ·
-1  ·       render 2  test.abc.c  ·                      ·
-2  scan    ·         ·           (a, b, c, d[omitted])  b!=NULL; c!=NULL; key(b,c); +b,+c
-2  ·       table     abc@bc      ·                      ·
-2  ·       spans     ALL         ·                      ·
+nosort          0  nosort  ·         ·           (a, b)  b!=NULL; +b
+ │              0  ·       order     +b,+c       ·       ·
+ └── render     1  render  ·         ·           (a, b)  b!=NULL; +b
+      │         1  ·       render 0  test.abc.a  ·       ·
+      │         1  ·       render 1  test.abc.b  ·       ·
+      │         1  ·       render 2  test.abc.c  ·       ·
+      └── scan  2  scan    ·         ·           (a, b)  b!=NULL; +b
+·               2  ·       table     abc@bc      ·       ·
+·               2  ·       spans     ALL         ·       ·
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
-0  nosort  ·      ·
-0  ·       order  +b,+c,+a
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  abc@bc
-2  ·       spans  ALL
+nosort          ·      ·
+ │              order  +b,+c,+a
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  abc@bc
+·               spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
-0  nosort  ·      ·
-0  ·       order  +b,+c,-a
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  abc@bc
-2  ·       spans  ALL
+nosort          ·      ·
+ │              order  +b,+c,-a
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  abc@bc
+·               spans  ALL
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT b, c FROM abc ORDER BY b, c]
@@ -570,13 +570,13 @@ fetched: /abc/primary/1/2/3/d -> 'one'
 fetched: /abc/primary/1/2/3 -> NULL
 output row: [1]
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM abc ORDER BY a DESC
 ----
-0  render   ·      ·
-1  revscan  ·      ·
-1  ·        table  abc@primary
-1  ·        spans  ALL
+render        ·      ·
+ └── revscan  ·      ·
+·             table  abc@primary
+·             spans  ALL
 
 query I
 SELECT a FROM abc ORDER BY a DESC
@@ -594,32 +594,32 @@ SELECT a FROM abc ORDER BY a DESC OFFSET 1
 ----
 1
 
-query ITTT
+query TTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abc@bc
-1  ·       spans  /2-/3
+render     ·      ·
+ └── scan  ·      ·
+·          table  abc@bc
+·          spans  /2-/3
 
-query ITTT
+query TTT
 EXPLAIN SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
-0  render   ·      ·
-1  revscan  ·      ·
-1  ·        table  abc@bc
-1  ·        spans  /2-/3
+render        ·      ·
+ └── revscan  ·      ·
+·             table  abc@bc
+·             spans  /2-/3
 
 # Verify that the ordering of the primary index is still used for the outer sort.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-0  nosort  ·      ·            (b, c)                          b!=NULL; c!=NULL; key(b,c); +b,+c
-0  ·       order  +b,+c        ·                               ·
-1  render  ·      ·            (b, c, a[omitted])              a=CONST; b!=NULL; c!=NULL; key(b,c); +b,+c
-2  scan    ·      ·            (a[omitted], b, c, d[omitted])  a=CONST; b!=NULL; c!=NULL; key(b,c); +b,+c
-2  ·       table  abc@primary  ·                               ·
-2  ·       spans  /1-/2        ·                               ·
+nosort          0  nosort  ·      ·            (b, c)  b!=NULL; c!=NULL; key(b,c); +b,+c
+ │              0  ·       order  +b,+c        ·       ·
+ └── render     1  render  ·      ·            (b, c)  b!=NULL; c!=NULL; key(b,c); +b,+c
+      └── scan  2  scan    ·      ·            (b, c)  b!=NULL; c!=NULL; key(b,c); +b,+c
+·               2  ·       table  abc@primary  ·       ·
+·               2  ·       spans  /1-/2        ·       ·
 
 statement ok
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
@@ -627,14 +627,14 @@ CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
 statement ok
 INSERT INTO bar VALUES (0, NULL), (1, NULL)
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM bar ORDER BY baz, id
 ----
-0  sort  ·      ·          (id, baz)  weak-key(baz); +baz,+id
-0  ·     order  +baz,+id   ·          ·
-1  scan  ·      ·          (id, baz)  weak-key(baz); +baz
-1  ·     table  bar@i_bar  ·          ·
-1  ·     spans  ALL        ·          ·
+sort       0  sort  ·      ·          (id, baz)  weak-key(baz); +baz,+id
+ │         0  ·     order  +baz,+id   ·          ·
+ └── scan  1  scan  ·      ·          (id, baz)  weak-key(baz); +baz,+id
+·          1  ·     table  bar@i_bar  ·          ·
+·          1  ·     spans  ALL        ·          ·
 
 # Here rowsort is needed because the ORDER BY clause does not guarantee any
 # relative ordering between rows where baz is NULL. As we see above, because
@@ -659,37 +659,37 @@ statement ok
 INSERT INTO abcd VALUES (1, 4, 2, 3), (2, 3, 4, 1), (3, 2, 1, 2), (4, 4, 1, 1)
 
 # The following tests verify we recognize that sorting is not necessary
-query ITTT
+query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@abc
-1  ·       spans  /1/4-/1/5
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@abc
+·          spans  /1/4-/1/5
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@abc
-1  ·       spans  /1/4-/1/5
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@abc
+·          spans  /1/4-/1/5
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@abc
-1  ·       spans  /1/4-/1/5
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@abc
+·          spans  /1/4-/1/5
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@abc
-1  ·       spans  /1/4-/1/5
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@abc
+·          spans  /1/4-/1/5
 
 statement ok
 CREATE TABLE nan (id INT PRIMARY KEY, x REAL)
@@ -705,74 +705,74 @@ NaN
 -1
 1
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
-0  sort    ·      ·                 (x)  +x
-0  ·       order  +x                ·    ·
-1  values  ·      ·                 (x)  ·
-1  ·       size   1 column, 3 rows  ·    ·
+sort         0  sort    ·      ·                 (x)  +x
+ │           0  ·       order  +x                ·    ·
+ └── values  1  values  ·      ·                 (x)  +x
+·            1  ·       size   1 column, 3 rows  ·    ·
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
 ----
-0  ordinality  ·     ·
-1  values      ·     ·
-1  ·           size  1 column, 3 rows
+ordinality   ·     ·
+ └── values  ·     ·
+·            size  1 column, 3 rows
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
 ----
-0  sort        ·      ·
-0  ·           order  -"ordinality"
-1  ordinality  ·      ·
-2  values      ·      ·
-2  ·           size   1 column, 3 rows
+sort              ·      ·
+ │                order  -"ordinality"
+ └── ordinality   ·      ·
+      └── values  ·      ·
+·                 size   1 column, 3 rows
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
-0  ordinality  ·     ·                 (x, "ordinality")  weak-key("ordinality")
-1  values      ·     ·                 (x)                ·
-1  ·           size  1 column, 3 rows  ·                  ·
+ordinality   0  ordinality  ·     ·                 (x, "ordinality")  weak-key("ordinality")
+ └── values  1  values      ·     ·                 (x, "ordinality")  weak-key("ordinality")
+·            1  ·           size  1 column, 3 rows  ·                  ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
-0  ordinality  ·      ·                 (x, "ordinality")  weak-key("ordinality")
-1  sort        ·      ·                 (x)                +x
-1  ·           order  +x                ·                  ·
-2  values      ·      ·                 (x)                ·
-2  ·           size   1 column, 3 rows  ·                  ·
+ordinality        0  ordinality  ·      ·                 (x, "ordinality")  weak-key("ordinality")
+ └── sort         1  sort        ·      ·                 (x, "ordinality")  weak-key("ordinality")
+      │           1  ·           order  +x                ·                  ·
+      └── values  2  values      ·      ·                 (x, "ordinality")  weak-key("ordinality")
+·                 2  ·           size   1 column, 3 rows  ·                  ·
 
 # Check that the ordering of the source does not propagate blindly to RETURNING.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 ----
-0  insert    ·     ·        (b)     ·
-0  ·         into  t(a, b)  ·       ·
-1  render    ·     ·        (x, y)  x=CONST; y=CONST
-2  emptyrow  ·     ·        ()      ·
+insert              0  insert    ·     ·        (b)  ·
+ │                  0  ·         into  t(a, b)  ·    ·
+ └── render         1  render    ·     ·        (b)  ·
+      └── emptyrow  2  emptyrow  ·     ·        (b)  ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) DELETE FROM t WHERE a = 3 RETURNING b
 ----
-0  delete  ·      ·          (b)        ·
-0  ·       from   t          ·          ·
-1  scan    ·      ·          (a, b, c)  a=CONST; key()
-1  ·       table  t@primary  ·          ·
-1  ·       spans  /3-/3/#    ·          ·
+delete     0  delete  ·      ·          (b)  ·
+ │         0  ·       from   t          ·    ·
+ └── scan  1  scan    ·      ·          (b)  ·
+·          1  ·       table  t@primary  ·    ·
+·          1  ·       spans  /3-/3/#    ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b
 ----
-0  update  ·      ·          (b)                ·
-0  ·       table  t          ·                  ·
-0  ·       set    c          ·                  ·
-1  render  ·      ·          (a, b, c, "true")  "true"=CONST; a!=NULL; key(a)
-2  scan    ·      ·          (a, b, c)          a!=NULL; key(a)
-2  ·       table  t@primary  ·                  ·
-2  ·       spans  ALL        ·                  ·
+update          0  update  ·      ·          (b)  ·
+ │              0  ·       table  t          ·    ·
+ │              0  ·       set    c          ·    ·
+ └── render     1  render  ·      ·          (b)  ·
+      └── scan  2  scan    ·      ·          (b)  ·
+·               2  ·       table  t@primary  ·    ·
+·               2  ·       spans  ALL        ·    ·
 
 statement ok
 CREATE TABLE uvwxyz (
@@ -788,13 +788,13 @@ CREATE TABLE uvwxyz (
 
 # Verify that the outer ordering is propagated to index selection and we choose
 # the index that avoids any sorting.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
-0  render  ·      ·            (y, w, x)                                                             y=CONST; +w,+x
-1  scan    ·      ·            (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  y=CONST; rowid!=NULL; weak-key(u,v,w,x,z,rowid); +w,+x
-1  ·       table  uvwxyz@ywxz  ·                                                                     ·
-1  ·       spans  /1-/2        ·                                                                     ·
+render     0  render  ·      ·            (y, w, x)  y=CONST; +w,+x
+ └── scan  1  scan    ·      ·            (y, w, x)  y=CONST; +w,+x
+·          1  ·       table  uvwxyz@ywxz  ·          ·
+·          1  ·       spans  /1-/2        ·          ·
 
 
 statement ok
@@ -808,12 +808,12 @@ CREATE TABLE blocks (
 
 # Test that ordering goes "through" a renderNode that has a duplicate render of
 # an order-by column (#13696).
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
 ----
-0  limit   ·      ·               (block_id, writer_id, block_num, block_id)            block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
-1  render  ·      ·               (block_id, writer_id, block_num, block_id)            block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
-2  scan    ·      ·               (block_id, writer_id, block_num, raw_bytes[omitted])  block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
-2  ·       table  blocks@primary  ·                                                     ·
-2  ·       spans  ALL             ·                                                     ·
-2  ·       limit  1               ·                                                     ·
+limit           0  limit   ·      ·               (block_id, writer_id, block_num, block_id)  block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+ └── render     1  render  ·      ·               (block_id, writer_id, block_num, block_id)  block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+      └── scan  2  scan    ·      ·               (block_id, writer_id, block_num, block_id)  block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+·               2  ·       table  blocks@primary  ·                                           ·
+·               2  ·       spans  ALL             ·                                           ·
+·               2  ·       limit  1               ·                                           ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -3,81 +3,81 @@
 statement ok
 CREATE TABLE kv(k INT PRIMARY KEY, v INT); CREATE INDEX foo ON kv(v DESC)
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv
 ----
-0  nosort  ·      ·           (v)     ·
-0  ·       order  +k          ·       ·
-1  render  ·      ·           (v, k)  k!=NULL; key(k); +k
-2  scan    ·      ·           (k, v)  k!=NULL; key(k); +k
-2  ·       table  kv@primary  ·       ·
-2  ·       spans  ALL         ·       ·
+nosort          0  nosort  ·      ·           (v)  ·
+ │              0  ·       order  +k          ·    ·
+ └── render     1  render  ·      ·           (v)  ·
+      └── scan  2  scan    ·      ·           (v)  ·
+·               2  ·       table  kv@primary  ·    ·
+·               2  ·       spans  ALL         ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
 ----
-0  nosort  ·      ·           (v)     ·
-0  ·       order  +k          ·       ·
-1  render  ·      ·           (v, k)  k!=NULL; key(k); +k
-2  scan    ·      ·           (k, v)  k!=NULL; key(k); +k
-2  ·       table  kv@primary  ·       ·
-2  ·       spans  ALL         ·       ·
+nosort          0  nosort  ·      ·           (v)  ·
+ │              0  ·       order  +k          ·    ·
+ └── render     1  render  ·      ·           (v)  ·
+      └── scan  2  scan    ·      ·           (v)  ·
+·               2  ·       table  kv@primary  ·    ·
+·               2  ·       spans  ALL         ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
 ----
-0  nosort   ·      ·           (v)     ·
-0  ·        order  -k          ·       ·
-1  render   ·      ·           (v, k)  k!=NULL; key(k); -k
-2  revscan  ·      ·           (k, v)  k!=NULL; key(k); -k
-2  ·        table  kv@primary  ·       ·
-2  ·        spans  ALL         ·       ·
+nosort             0  nosort   ·      ·           (v)  ·
+ │                 0  ·        order  -k          ·    ·
+ └── render        1  render   ·      ·           (v)  ·
+      └── revscan  2  revscan  ·      ·           (v)  ·
+·                  2  ·        table  kv@primary  ·    ·
+·                  2  ·        spans  ALL         ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
 ----
-0  sort     ·      ·               (k)              k!=NULL
-0  ·        order  +v,+k,+"v - 2"  ·                ·
-1  render   ·      ·               (k, v, "v - 2")  k!=NULL; weak-key(k,v); +v
-2  revscan  ·      ·               (k, v)           k!=NULL; weak-key(k,v); +v
-2  ·        table  kv@foo          ·                ·
-2  ·        spans  ALL             ·                ·
+sort               0  sort     ·      ·               (k)  k!=NULL
+ │                 0  ·        order  +v,+k,+"v - 2"  ·    ·
+ └── render        1  render   ·      ·               (k)  k!=NULL
+      └── revscan  2  revscan  ·      ·               (k)  k!=NULL
+·                  2  ·        table  kv@foo          ·    ·
+·                  2  ·        spans  ALL             ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
-0  nosort  ·      ·       (k)     k!=NULL
-0  ·       order  -v      ·       ·
-1  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
-1  ·       table  kv@foo  ·       ·
-1  ·       spans  ALL     ·       ·
+nosort     0  nosort  ·      ·       (k)  k!=NULL
+ │         0  ·       order  -v      ·    ·
+ └── scan  1  scan    ·      ·       (k)  k!=NULL
+·          1  ·       table  kv@foo  ·    ·
+·          1  ·       spans  ALL     ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
-0  nosort  ·      ·       (k)     k!=NULL
-0  ·       order  -v      ·       ·
-1  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
-1  ·       table  kv@foo  ·       ·
-1  ·       spans  ALL     ·       ·
+nosort     0  nosort  ·      ·       (k)  k!=NULL
+ │         0  ·       order  -v      ·    ·
+ └── scan  1  scan    ·      ·       (k)  k!=NULL
+·          1  ·       table  kv@foo  ·    ·
+·          1  ·       spans  ALL     ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
-0  nosort   ·      ·       (k)     k!=NULL
-0  ·        order  +v      ·       ·
-1  revscan  ·      ·       (k, v)  k!=NULL; weak-key(k,v); +v
-1  ·        table  kv@foo  ·       ·
-1  ·        spans  ALL     ·       ·
+nosort        0  nosort   ·      ·       (k)  k!=NULL
+ │            0  ·        order  +v      ·    ·
+ └── revscan  1  revscan  ·      ·       (k)  k!=NULL
+·             1  ·        table  kv@foo  ·    ·
+·             1  ·        spans  ALL     ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
-0  nosort  ·      ·       (k)     k!=NULL
-0  ·       order  -v,+k   ·       ·
-1  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v,+k
-1  ·       table  kv@foo  ·       ·
-1  ·       spans  ALL     ·       ·
+nosort     0  nosort  ·      ·       (k)  k!=NULL
+ │         0  ·       order  -v,+k   ·    ·
+ └── scan  1  scan    ·      ·       (k)  k!=NULL
+·          1  ·       table  kv@foo  ·    ·
+·          1  ·       spans  ALL     ·    ·
 
 # Check the syntax can be used with joins.
 #
@@ -85,55 +85,55 @@ EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 # does not imply use of that index by the underlying scan.
 #
 
-query ITTTTT
+query TITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv JOIN (VALUES (1,2)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
-0  sort    ·         ·                 (k)                             ·
-0  ·       order     -v                ·                               ·
-1  render  ·         ·                 (k, v)                          ·
-2  join    ·         ·                 (k, v, a[omitted], b[omitted])  ·
-2  ·       type      inner             ·                               ·
-2  ·       equality  (k) = (a)         ·                               ·
-3  scan    ·         ·                 (k, v)                          k!=NULL; key(k)
-3  ·       table     kv@primary        ·                               ·
-3  ·       spans     ALL               ·                               ·
-3  values  ·         ·                 (column1, column2[omitted])     ·
-3  ·       size      2 columns, 1 row  ·                               ·
+sort                   0  sort    ·         ·                 (k)  ·
+ │                     0  ·       order     -v                ·    ·
+ └── render            1  render  ·         ·                 (k)  ·
+      └── join         2  join    ·         ·                 (k)  ·
+           │           2  ·       type      inner             ·    ·
+           │           2  ·       equality  (k) = (a)         ·    ·
+           ├── scan    3  scan    ·         ·                 (k)  ·
+           │           3  ·       table     kv@primary        ·    ·
+           │           3  ·       spans     ALL               ·    ·
+           └── values  3  values  ·         ·                 (k)  ·
+·                      3  ·       size      2 columns, 1 row  ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-0  sort    ·               ·                (k)                             k!=NULL; key(k)
-0  ·       order           -v               ·                               ·
-1  render  ·               ·                (k, v)                          k!=NULL; v!=NULL; key(k)
-2  join    ·               ·                (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; key(k)
-2  ·       type            inner            ·                               ·
-2  ·       equality        (k, v) = (k, v)  ·                               ·
-2  ·       mergeJoinOrder  +"(k=k)"         ·                               ·
-3  scan    ·               ·                (k, v)                          k!=NULL; key(k); +k
-3  ·       table           kv@primary       ·                               ·
-3  ·       spans           ALL              ·                               ·
-3  scan    ·               ·                (k, v)                          k!=NULL; key(k); +k
-3  ·       table           kv@primary       ·                               ·
-3  ·       spans           ALL              ·                               ·
+sort                 0  sort    ·               ·                (k)  k!=NULL; key(k)
+ │                   0  ·       order           -v               ·    ·
+ └── render          1  render  ·               ·                (k)  k!=NULL; key(k)
+      └── join       2  join    ·               ·                (k)  k!=NULL; key(k)
+           │         2  ·       type            inner            ·    ·
+           │         2  ·       equality        (k, v) = (k, v)  ·    ·
+           │         2  ·       mergeJoinOrder  +"(k=k)"         ·    ·
+           ├── scan  3  scan    ·               ·                (k)  k!=NULL; key(k)
+           │         3  ·       table           kv@primary       ·    ·
+           │         3  ·       spans           ALL              ·    ·
+           └── scan  3  scan    ·               ·                (k)  k!=NULL; key(k)
+·                    3  ·       table           kv@primary       ·    ·
+·                    3  ·       spans           ALL              ·    ·
 
 # The underlying index can be forced manually, of course.
-query ITTTTT
+query TITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@foo
 ----
-0  nosort  ·               ·                  (k)                             k!=NULL
-0  ·       order           -v                 ·                               ·
-1  render  ·               ·                  (k, v)                          k!=NULL; v!=NULL; -v
-2  join    ·               ·                  (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; -v
-2  ·       type            inner              ·                               ·
-2  ·       equality        (k, v) = (k, v)    ·                               ·
-2  ·       mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                               ·
-3  scan    ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
-3  ·       table           kv@foo             ·                               ·
-3  ·       spans           ALL                ·                               ·
-3  scan    ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
-3  ·       table           kv@foo             ·                               ·
-3  ·       spans           ALL                ·                               ·
+nosort               0  nosort  ·               ·                  (k)  k!=NULL
+ │                   0  ·       order           -v                 ·    ·
+ └── render          1  render  ·               ·                  (k)  k!=NULL
+      └── join       2  join    ·               ·                  (k)  k!=NULL
+           │         2  ·       type            inner              ·    ·
+           │         2  ·       equality        (k, v) = (k, v)    ·    ·
+           │         2  ·       mergeJoinOrder  -"(v=v)",+"(k=k)"  ·    ·
+           ├── scan  3  scan    ·               ·                  (k)  k!=NULL
+           │         3  ·       table           kv@foo             ·    ·
+           │         3  ·       spans           ALL                ·    ·
+           └── scan  3  scan    ·               ·                  (k)  k!=NULL
+·                    3  ·       table           kv@foo             ·    ·
+·                    3  ·       spans           ALL                ·    ·
 
 # Check the extended syntax cannot be used in case of renames.
 statement error source name "kv" not found in FROM clause

--- a/pkg/sql/logictest/testdata/logic_test/ordinal_references
+++ b/pkg/sql/logictest/testdata/logic_test/ordinal_references
@@ -47,17 +47,17 @@ c 1
 a 3
 
 # Check that sort by ordinal picks up the existing render.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
-0  sort    ·         ·            (b, a)                         +a
-0  ·       order     +a           ·                              ·
-1  render  ·         ·            (b, a)                         ·
-1  ·       render 0  test.foo.b   ·                              ·
-1  ·       render 1  test.foo.a   ·                              ·
-2  scan    ·         ·            (a, b, rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-2  ·       table     foo@primary  ·                              ·
-2  ·       spans     ALL          ·                              ·
+sort            0  sort    ·         ·            (b, a)  +a
+ │              0  ·       order     +a           ·       ·
+ └── render     1  render  ·         ·            (b, a)  +a
+      │         1  ·       render 0  test.foo.b   ·       ·
+      │         1  ·       render 1  test.foo.a   ·       ·
+      └── scan  2  scan    ·         ·            (b, a)  +a
+·               2  ·       table     foo@primary  ·       ·
+·               2  ·       spans     ALL          ·       ·
 
 statement ok
 INSERT INTO foo(a, b) VALUES (4, 'c'), (5, 'c'), (6, 'c')
@@ -80,30 +80,30 @@ SELECT SUM(a) AS s FROM foo GROUP BY @2 ORDER BY s
 16
 
 # Check that GROUP BY picks up column ordinals.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
-0  group   ·            ·                (m)                                     ·
-0  ·       aggregate 0  min(test.foo.a)  ·                                       ·
-0  ·       group by     @1-@1            ·                                       ·
-1  render  ·            ·                (a)                                     ·
-1  ·       render 0     test.foo.a       ·                                       ·
-2  scan    ·            ·                (a, b[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-2  ·       table        foo@primary      ·                                       ·
-2  ·       spans        ALL              ·                                       ·
+group           0  group   ·            ·                (m)  ·
+ │              0  ·       aggregate 0  min(test.foo.a)  ·    ·
+ │              0  ·       group by     @1-@1            ·    ·
+ └── render     1  render  ·            ·                (m)  ·
+      │         1  ·       render 0     test.foo.a       ·    ·
+      └── scan  2  scan    ·            ·                (m)  ·
+·               2  ·       table        foo@primary      ·    ·
+·               2  ·       spans        ALL              ·    ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
-0  group   ·            ·                (m)                            ·
-0  ·       aggregate 0  min(test.foo.a)  ·                              ·
-0  ·       group by     @1-@1            ·                              ·
-1  render  ·            ·                (b, a)                         ·
-1  ·       render 0     test.foo.b       ·                              ·
-1  ·       render 1     test.foo.a       ·                              ·
-2  scan    ·            ·                (a, b, rowid[hidden,omitted])  rowid!=NULL; key(rowid)
-2  ·       table        foo@primary      ·                              ·
-2  ·       spans        ALL              ·                              ·
+group           0  group   ·            ·                (m)  ·
+ │              0  ·       aggregate 0  min(test.foo.a)  ·    ·
+ │              0  ·       group by     @1-@1            ·    ·
+ └── render     1  render  ·            ·                (m)  ·
+      │         1  ·       render 0     test.foo.b       ·    ·
+      │         1  ·       render 1     test.foo.a       ·    ·
+      └── scan  2  scan    ·            ·                (m)  ·
+·               2  ·       table        foo@primary      ·    ·
+·               2  ·       spans        ALL              ·    ·
 
 statement error column reference @1 not allowed in this context
 INSERT INTO foo(a, b) VALUES (@1, @2)

--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -82,21 +82,21 @@ true
 true
 
 # Show that the primary key is used under ordinalityNode.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
 ----
-0  ordinality  ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
-1  scan        ·      ·            (x)                x!=NULL; key(x)
-1  ·           table  foo@primary  ·                  ·
-1  ·           spans  /"a\x00"-    ·                  ·
+ordinality  0  ordinality  ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
+ └── scan   1  scan        ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
+·           1  ·           table  foo@primary  ·                  ·
+·           1  ·           spans  /"a\x00"-    ·                  ·
 
 # Show that the primary key cannot be used with a PK predicate
 # outside of ordinalityNode.
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
 ----
-0  filter      ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
-1  ordinality  ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
-2  scan        ·      ·            (x)                x!=NULL; key(x)
-2  ·           table  foo@primary  ·                  ·
-2  ·           spans  ALL          ·                  ·
+filter           0  filter      ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
+ └── ordinality  1  ordinality  ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
+      └── scan   2  scan        ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
+·                2  ·           table  foo@primary  ·                  ·
+·                2  ·           spans  ALL          ·                  ·

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -45,12 +45,12 @@ SELECT 'pg_constraint'::REGCLASS
 ----
 pg_constraint
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT 'pg_constraint'::REGCLASS
 ----
-0  render    ·         ·                          ("'pg_constraint'::REGCLASS" regclass)  "'pg_constraint'::REGCLASS"=CONST
-0  ·         render 0  (pg_constraint)[regclass]  ·                                       ·
-1  emptyrow  ·         ·                          ()                                      ·
+render         0  render    ·         ·                          ("'pg_constraint'::REGCLASS" regclass)  "'pg_constraint'::REGCLASS"=CONST
+ │             0  ·         render 0  (pg_constraint)[regclass]  ·                                       ·
+ └── emptyrow  1  emptyrow  ·         ·                          ("'pg_constraint'::REGCLASS" regclass)  "'pg_constraint'::REGCLASS"=CONST
 
 query OO
 SELECT '"pg_constraint"'::REGCLASS, '  "pg_constraint" '::REGCLASS

--- a/pkg/sql/logictest/testdata/logic_test/physical_props
+++ b/pkg/sql/logictest/testdata/logic_test/physical_props
@@ -3,193 +3,193 @@
 statement ok
 CREATE TABLE abcd (a INT PRIMARY KEY, b INT, c INT, d INT)
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE b = c
 ----
-Level  Type  Field   Description   Columns       Ordering
-0      scan  ·       ·             (a, b, c, d)  b=c; a!=NULL; b!=NULL; c!=NULL; key(a)
-0      ·     table   abcd@primary  ·             ·
-0      ·     spans   ALL           ·             ·
-0      ·     filter  b = c         ·             ·
+Tree  Level  Type  Field   Description   Columns       Ordering
+scan  0      scan  ·       ·             (a, b, c, d)  b=c; a!=NULL; b!=NULL; c!=NULL; key(a)
+·     0      ·     table   abcd@primary  ·             ·
+·     0      ·     spans   ALL           ·             ·
+·     0      ·     filter  b = c         ·             ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = 1
 ----
-Level  Type  Field  Description   Columns       Ordering
-0      scan  ·      ·             (a, b, c, d)  a=CONST; key()
-0      ·     table  abcd@primary  ·             ·
-0      ·     spans  /1-/1/#       ·             ·
+Tree  Level  Type  Field  Description   Columns       Ordering
+scan  0      scan  ·      ·             (a, b, c, d)  a=CONST; key()
+·     0      ·     table  abcd@primary  ·             ·
+·     0      ·     spans  /1-/1/#       ·             ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE b = 1
 ----
-Level  Type  Field   Description   Columns       Ordering
-0      scan  ·       ·             (a, b, c, d)  b=CONST; a!=NULL; key(a)
-0      ·     table   abcd@primary  ·             ·
-0      ·     spans   ALL           ·             ·
-0      ·     filter  b = 1         ·             ·
+Tree  Level  Type  Field   Description   Columns       Ordering
+scan  0      scan  ·       ·             (a, b, c, d)  b=CONST; a!=NULL; key(a)
+·     0      ·     table   abcd@primary  ·             ·
+·     0      ·     spans   ALL           ·             ·
+·     0      ·     filter  b = 1         ·             ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = 1 AND b = 1
 ----
-Level  Type  Field   Description   Columns       Ordering
-0      scan  ·       ·             (a, b, c, d)  a=CONST; b=CONST; key()
-0      ·     table   abcd@primary  ·             ·
-0      ·     spans   /1-/1/#       ·             ·
-0      ·     filter  b = 1         ·             ·
+Tree  Level  Type  Field   Description   Columns       Ordering
+scan  0      scan  ·       ·             (a, b, c, d)  a=CONST; b=CONST; key()
+·     0      ·     table   abcd@primary  ·             ·
+·     0      ·     spans   /1-/1/#       ·             ·
+·     0      ·     filter  b = 1         ·             ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = 1 AND b = d
 ----
-Level  Type  Field   Description   Columns       Ordering
-0      scan  ·       ·             (a, b, c, d)  b=d; a=CONST; b!=NULL; d!=NULL; key()
-0      ·     table   abcd@primary  ·             ·
-0      ·     spans   /1-/1/#       ·             ·
-0      ·     filter  b = d         ·             ·
+Tree  Level  Type  Field   Description   Columns       Ordering
+scan  0      scan  ·       ·             (a, b, c, d)  b=d; a=CONST; b!=NULL; d!=NULL; key()
+·     0      ·     table   abcd@primary  ·             ·
+·     0      ·     spans   /1-/1/#       ·             ·
+·     0      ·     filter  b = d         ·             ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = b AND b = c
 ----
-Level  Type  Field   Description          Columns       Ordering
-0      scan  ·       ·                    (a, b, c, d)  a=b=c; a!=NULL; b!=NULL; c!=NULL; key(a)
-0      ·     table   abcd@primary         ·             ·
-0      ·     spans   ALL                  ·             ·
-0      ·     filter  (a = b) AND (b = c)  ·             ·
+Tree  Level  Type  Field   Description          Columns       Ordering
+scan  0      scan  ·       ·                    (a, b, c, d)  a=b=c; a!=NULL; b!=NULL; c!=NULL; key(a)
+·     0      ·     table   abcd@primary         ·             ·
+·     0      ·     spans   ALL                  ·             ·
+·     0      ·     filter  (a = b) AND (b = c)  ·             ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd WHERE a = b AND b = c AND c = 1
 ----
-Level  Type  Field   Description                        Columns       Ordering
-0      scan  ·       ·                                  (a, b, c, d)  a=b=c; a=CONST; b!=NULL; c!=NULL; key()
-0      ·     table   abcd@primary                       ·             ·
-0      ·     spans   ALL                                ·             ·
-0      ·     filter  ((a = b) AND (b = c)) AND (c = 1)  ·             ·
+Tree  Level  Type  Field   Description                        Columns       Ordering
+scan  0      scan  ·       ·                                  (a, b, c, d)  a=b=c; a=CONST; b!=NULL; c!=NULL; key()
+·     0      ·     table   abcd@primary                       ·             ·
+·     0      ·     spans   ALL                                ·             ·
+·     0      ·     filter  ((a = b) AND (b = c)) AND (c = 1)  ·             ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE a = 1
 ----
-Level  Type    Field          Description        Columns    Ordering
-0      filter  ·              ·                  (a, b, c)  a=CONST
-0      ·       filter         x.a = 1            ·          ·
-1      values  ·              ·                  (a, b, c)  ·
-1      ·       size           3 columns, 2 rows  ·          ·
-1      ·       row 0, expr 0  1                  ·          ·
-1      ·       row 0, expr 1  2                  ·          ·
-1      ·       row 0, expr 2  3                  ·          ·
-1      ·       row 1, expr 0  4                  ·          ·
-1      ·       row 1, expr 1  5                  ·          ·
-1      ·       row 1, expr 2  6                  ·          ·
+Tree         Level  Type    Field          Description        Columns    Ordering
+filter       0      filter  ·              ·                  (a, b, c)  a=CONST
+ │           0      ·       filter         x.a = 1            ·          ·
+ └── values  1      values  ·              ·                  (a, b, c)  a=CONST
+·            1      ·       size           3 columns, 2 rows  ·          ·
+·            1      ·       row 0, expr 0  1                  ·          ·
+·            1      ·       row 0, expr 1  2                  ·          ·
+·            1      ·       row 0, expr 2  3                  ·          ·
+·            1      ·       row 1, expr 0  4                  ·          ·
+·            1      ·       row 1, expr 1  5                  ·          ·
+·            1      ·       row 1, expr 2  6                  ·          ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE a = b
 ----
-Level  Type    Field          Description        Columns    Ordering
-0      filter  ·              ·                  (a, b, c)  a=b; a!=NULL; b!=NULL
-0      ·       filter         x.a = x.b          ·          ·
-1      values  ·              ·                  (a, b, c)  ·
-1      ·       size           3 columns, 2 rows  ·          ·
-1      ·       row 0, expr 0  1                  ·          ·
-1      ·       row 0, expr 1  2                  ·          ·
-1      ·       row 0, expr 2  3                  ·          ·
-1      ·       row 1, expr 0  4                  ·          ·
-1      ·       row 1, expr 1  5                  ·          ·
-1      ·       row 1, expr 2  6                  ·          ·
+Tree         Level  Type    Field          Description        Columns    Ordering
+filter       0      filter  ·              ·                  (a, b, c)  a=b; a!=NULL; b!=NULL
+ │           0      ·       filter         x.a = x.b          ·          ·
+ └── values  1      values  ·              ·                  (a, b, c)  a=b; a!=NULL; b!=NULL
+·            1      ·       size           3 columns, 2 rows  ·          ·
+·            1      ·       row 0, expr 0  1                  ·          ·
+·            1      ·       row 0, expr 1  2                  ·          ·
+·            1      ·       row 0, expr 2  3                  ·          ·
+·            1      ·       row 1, expr 0  4                  ·          ·
+·            1      ·       row 1, expr 1  5                  ·          ·
+·            1      ·       row 1, expr 2  6                  ·          ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE a = b AND b = 1
 ----
-Level  Type    Field          Description                Columns    Ordering
-0      filter  ·              ·                          (a, b, c)  a=b; a=CONST; b!=NULL
-0      ·       filter         (x.a = x.b) AND (x.b = 1)  ·          ·
-1      values  ·              ·                          (a, b, c)  ·
-1      ·       size           3 columns, 2 rows          ·          ·
-1      ·       row 0, expr 0  1                          ·          ·
-1      ·       row 0, expr 1  2                          ·          ·
-1      ·       row 0, expr 2  3                          ·          ·
-1      ·       row 1, expr 0  4                          ·          ·
-1      ·       row 1, expr 1  5                          ·          ·
-1      ·       row 1, expr 2  6                          ·          ·
+Tree         Level  Type    Field          Description                Columns    Ordering
+filter       0      filter  ·              ·                          (a, b, c)  a=b; a=CONST; b!=NULL
+ │           0      ·       filter         (x.a = x.b) AND (x.b = 1)  ·          ·
+ └── values  1      values  ·              ·                          (a, b, c)  a=b; a=CONST; b!=NULL
+·            1      ·       size           3 columns, 2 rows          ·          ·
+·            1      ·       row 0, expr 0  1                          ·          ·
+·            1      ·       row 0, expr 1  2                          ·          ·
+·            1      ·       row 0, expr 2  3                          ·          ·
+·            1      ·       row 1, expr 0  4                          ·          ·
+·            1      ·       row 1, expr 1  5                          ·          ·
+·            1      ·       row 1, expr 2  6                          ·          ·
 
 
 statement ok
 CREATE TABLE efg (e INT PRIMARY KEY, f INT, g INT)
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=e AND a=1 AND f=g
 ----
-Level  Type  Field           Description   Columns                Ordering
-0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST; key()
-0      ·     type            inner         ·                      ·
-0      ·     equality        (a) = (e)     ·                      ·
-0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
-1      scan  ·               ·             (a, b, c, d)           a=CONST; key()
-1      ·     table           abcd@primary  ·                      ·
-1      ·     spans           /1-/1/#       ·                      ·
-1      scan  ·               ·             (e, f, g)              f=g; e=CONST; f!=NULL; g!=NULL; key()
-1      ·     table           efg@primary   ·                      ·
-1      ·     spans           /1-/1/#       ·                      ·
-1      ·     filter          f = g         ·                      ·
+Tree       Level  Type  Field           Description   Columns                Ordering
+join       0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST; key()
+ │         0      ·     type            inner         ·                      ·
+ │         0      ·     equality        (a) = (e)     ·                      ·
+ │         0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
+ ├── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST; key()
+ │         1      ·     table           abcd@primary  ·                      ·
+ │         1      ·     spans           /1-/1/#       ·                      ·
+ └── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST; key()
+·          1      ·     table           efg@primary   ·                      ·
+·          1      ·     spans           /1-/1/#       ·                      ·
+·          1      ·     filter          f = g         ·                      ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=e AND b=1 AND f=g
 ----
-Level  Type  Field           Description   Columns                Ordering
-0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; b=CONST; a!=NULL; key(a)
-0      ·     type            inner         ·                      ·
-0      ·     equality        (a) = (e)     ·                      ·
-0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
-1      scan  ·               ·             (a, b, c, d)           b=CONST; a!=NULL; key(a); +a
-1      ·     table           abcd@primary  ·                      ·
-1      ·     spans           ALL           ·                      ·
-1      ·     filter          b = 1         ·                      ·
-1      scan  ·               ·             (e, f, g)              f=g; e!=NULL; f!=NULL; g!=NULL; key(e); +e
-1      ·     table           efg@primary   ·                      ·
-1      ·     spans           ALL           ·                      ·
-1      ·     filter          f = g         ·                      ·
+Tree       Level  Type  Field           Description   Columns                Ordering
+join       0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; b=CONST; a!=NULL; key(a)
+ │         0      ·     type            inner         ·                      ·
+ │         0      ·     equality        (a) = (e)     ·                      ·
+ │         0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
+ ├── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; b=CONST; a!=NULL; key(a)
+ │         1      ·     table           abcd@primary  ·                      ·
+ │         1      ·     spans           ALL           ·                      ·
+ │         1      ·     filter          b = 1         ·                      ·
+ └── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; b=CONST; a!=NULL; key(a)
+·          1      ·     table           efg@primary   ·                      ·
+·          1      ·     spans           ALL           ·                      ·
+·          1      ·     filter          f = g         ·                      ·
 
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=e
 ----
-Level  Type  Field           Description   Columns                Ordering
-0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; a!=NULL; key(a)
-0      ·     type            inner         ·                      ·
-0      ·     equality        (a) = (e)     ·                      ·
-0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
-1      scan  ·               ·             (a, b, c, d)           a!=NULL; key(a); +a
-1      ·     table           abcd@primary  ·                      ·
-1      ·     spans           ALL           ·                      ·
-1      scan  ·               ·             (e, f, g)              e!=NULL; key(e); +e
-1      ·     table           efg@primary   ·                      ·
-1      ·     spans           ALL           ·                      ·
+Tree       Level  Type  Field           Description   Columns                Ordering
+join       0      join  ·               ·             (a, b, c, d, e, f, g)  a=e; a!=NULL; key(a)
+ │         0      ·     type            inner         ·                      ·
+ │         0      ·     equality        (a) = (e)     ·                      ·
+ │         0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
+ ├── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; a!=NULL; key(a)
+ │         1      ·     table           abcd@primary  ·                      ·
+ │         1      ·     spans           ALL           ·                      ·
+ └── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; a!=NULL; key(a)
+·          1      ·     table           efg@primary   ·                      ·
+·          1      ·     spans           ALL           ·                      ·
 
 # Verify keys don't get propagated when not appropriate.
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN efg ON a=f
 ----
-Level  Type  Field     Description   Columns                Ordering
-0      join  ·         ·             (a, b, c, d, e, f, g)  ·
-0      ·     type      inner         ·                      ·
-0      ·     equality  (a) = (f)     ·                      ·
-1      scan  ·         ·             (a, b, c, d)           a!=NULL; key(a)
-1      ·     table     abcd@primary  ·                      ·
-1      ·     spans     ALL           ·                      ·
-1      scan  ·         ·             (e, f, g)              e!=NULL; key(e)
-1      ·     table     efg@primary   ·                      ·
-1      ·     spans     ALL           ·                      ·
+Tree       Level  Type  Field     Description   Columns                Ordering
+join       0      join  ·         ·             (a, b, c, d, e, f, g)  ·
+ │         0      ·     type      inner         ·                      ·
+ │         0      ·     equality  (a) = (f)     ·                      ·
+ ├── scan  1      scan  ·         ·             (a, b, c, d, e, f, g)  ·
+ │         1      ·     table     abcd@primary  ·                      ·
+ │         1      ·     spans     ALL           ·                      ·
+ └── scan  1      scan  ·         ·             (a, b, c, d, e, f, g)  ·
+·          1      ·     table     efg@primary   ·                      ·
+·          1      ·     spans     ALL           ·                      ·
 
 # Verify we retain all keys when appropriate.
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM abcd JOIN (SELECT * FROM efg WITH ORDINALITY) ON a=e
 ----
-Level  Type        Field           Description   Columns                              Ordering
-0      join        ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; a!=NULL; key(a); weak-key("ordinality")
-0      ·           type            inner         ·                                    ·
-0      ·           equality        (a) = (e)     ·                                    ·
-0      ·           mergeJoinOrder  +"(a=e)"      ·                                    ·
-1      scan        ·               ·             (a, b, c, d)                         a!=NULL; key(a); +a
-1      ·           table           abcd@primary  ·                                    ·
-1      ·           spans           ALL           ·                                    ·
-1      ordinality  ·               ·             (e, f, g, "ordinality")              e!=NULL; key(e); weak-key("ordinality"); +e
-2      scan        ·               ·             (e, f, g)                            e!=NULL; key(e); +e
-2      ·           table           efg@primary   ·                                    ·
-2      ·           spans           ALL           ·                                    ·
+Tree             Level  Type        Field           Description   Columns                              Ordering
+join             0      join        ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; a!=NULL; key(a); weak-key("ordinality")
+ │               0      ·           type            inner         ·                                    ·
+ │               0      ·           equality        (a) = (e)     ·                                    ·
+ │               0      ·           mergeJoinOrder  +"(a=e)"      ·                                    ·
+ ├── scan        1      scan        ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; a!=NULL; key(a); weak-key("ordinality")
+ │               1      ·           table           abcd@primary  ·                                    ·
+ │               1      ·           spans           ALL           ·                                    ·
+ └── ordinality  1      ordinality  ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; a!=NULL; key(a); weak-key("ordinality")
+      └── scan   2      scan        ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; a!=NULL; key(a); weak-key("ordinality")
+·                2      ·           table           efg@primary   ·                                    ·
+·                2      ·           spans           ALL           ·                                    ·

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -109,17 +109,17 @@ NULL       /8       {1}       1
 /100/50    NULL     {1}       1
 
 # Verify limits and orderings are propagated correctly to the select.
-query ITTTTT colnames
+query TITTTTT colnames
 EXPLAIN (METADATA) ALTER TABLE t SPLIT AT SELECT k1,k2 FROM t ORDER BY k1 LIMIT 3
 ----
-Level  Type    Field  Description  Columns                           Ordering
-0      split   ·      ·            (key, pretty)                     ·
-1      limit   ·      ·            (k1, k2)                          k1!=NULL; k2!=NULL; key(k1,k2); +k1
-2      render  ·      ·            (k1, k2)                          k1!=NULL; k2!=NULL; key(k1,k2); +k1
-3      scan    ·      ·            (k1, k2, v[omitted], w[omitted])  k1!=NULL; k2!=NULL; key(k1,k2); +k1
-3      ·       table  t@primary    ·                                 ·
-3      ·       spans  ALL          ·                                 ·
-3      ·       limit  3            ·                                 ·
+Tree                 Level  Type    Field  Description  Columns        Ordering
+split                0      split   ·      ·            (key, pretty)  ·
+ └── limit           1      limit   ·      ·            (key, pretty)  ·
+      └── render     2      render  ·      ·            (key, pretty)  ·
+           └── scan  3      scan    ·      ·            (key, pretty)  ·
+·                    3      ·       table  t@primary    ·              ·
+·                    3      ·       spans  ALL          ·              ·
+·                    3      ·       limit  3            ·              ·
 
 # -- Tests with interleaved tables --
 

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -142,27 +142,27 @@ fetched: /t/a_desc/2/'two' -> NULL
 output row: [2]
 
 # Index selection occurs in direct join operands too.
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t x JOIN t y USING(b) WHERE x.b < '3'
 ----
-0  render      ·               ·
-1  render      ·               ·
-2  join        ·               ·
-2  ·           type            inner
-2  ·           equality        (b) = (b)
-2  ·           mergeJoinOrder  +"(b=b)"
-3  index-join  ·               ·
-4  scan        ·               ·
-4  ·           table           t@bc
-4  ·           spans           /!NULL-/"3"
-4  scan        ·               ·
-4  ·           table           t@primary
-3  index-join  ·               ·
-4  scan        ·               ·
-4  ·           table           t@bc
-4  ·           spans           /!NULL-/"3"
-4  scan        ·               ·
-4  ·           table           t@primary
+render                     ·               ·
+ └── render                ·               ·
+      └── join             ·               ·
+           │               type            inner
+           │               equality        (b) = (b)
+           │               mergeJoinOrder  +"(b=b)"
+           ├── index-join  ·               ·
+           │    ├── scan   ·               ·
+           │    │          table           t@bc
+           │    │          spans           /!NULL-/"3"
+           │    └── scan   ·               ·
+           │               table           t@primary
+           └── index-join  ·               ·
+                ├── scan   ·               ·
+                │          table           t@bc
+                │          spans           /!NULL-/"3"
+                └── scan   ·               ·
+·                          table           t@primary
 
 statement ok
 TRUNCATE TABLE t
@@ -192,11 +192,11 @@ SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE a > 1 AND b > 'b']
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
 ----
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
-0  render  ·  ·
-1  norows  ·  ·
+render       ·  ·
+ └── norows  ·  ·
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b]
@@ -312,11 +312,11 @@ SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t@ab WHERE a + 1 = 4]
 fetched: /t/ab/3/4 -> NULL
 output row: [3 4]
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
-0  render  ·  ·
-1  norows  ·  ·
+render       ·  ·
+ └── norows  ·  ·
 
 # Make sure that mixed type comparison operations are not used
 # for selecting indexes.
@@ -347,86 +347,86 @@ SELECT b FROM t WHERE c > 4.0 AND a < 4
 ----
 4
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t WHERE c > 1
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@bc
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@bc
+·          spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t WHERE c < 1 AND b < 5
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@bc
-1  ·       spans  /!NULL-/4/1
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@bc
+·          spans  /!NULL-/4/1
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t WHERE c > 1.0
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@bc
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@bc
+·          spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t WHERE c < 1.0
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@bc
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@bc
+·          spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t WHERE c > 1.0 AND b < 5
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@bc
-1  ·       spans  /!NULL-/5
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@bc
+·          spans  /!NULL-/5
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t WHERE b < 5.0 AND c < 1
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@bc
-1  ·       spans  /!NULL-/4/1
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@bc
+·          spans  /!NULL-/4/1
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5, 1)
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@bc
-1  ·       spans  /5/1-/5/2
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@bc
+·          spans  /5/1-/5/2
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.0, 1)
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@bc
-1  ·       spans  /5/1-/5/2
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@bc
+·          spans  /5/1-/5/2
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@bc
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@bc
+·          spans  ALL
 
 # Note the span is reversed because of #20203.
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t WHERE b IN (5.0, 1)
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t@b_desc
-1  ·       spans  /5-/4 /1-/0
+render     ·      ·
+ └── scan  ·      ·
+·          table  t@b_desc
+·          spans  /5-/4 /1-/0
 
 statement ok
 CREATE TABLE abcd (
@@ -440,21 +440,21 @@ CREATE TABLE abcd (
 
 # Verify that we prefer the index where more columns are constrained, even if it
 # has more keys per row.
-query ITTT
+query TTT
 EXPLAIN SELECT b FROM abcd WHERE (a, b) = (1, 4)
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@abcd
-1  ·       spans  /1/4-/1/5
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@abcd
+·          spans  /1/4-/1/5
 
-query ITTT
+query TTT
 EXPLAIN SELECT b FROM abcd WHERE (a, b) IN ((1, 4), (2, 9))
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@abcd
-1  ·       spans  /1/4-/1/5 /2/9-/2/10
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@abcd
+·          spans  /1/4-/1/5 /2/9-/2/10
 
 statement ok
 CREATE TABLE ab (
@@ -477,13 +477,13 @@ SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 1 a
 1 b
 
-query ITTT
+query TTT
 EXPLAIN SELECT i, s FROM ab@baz WHERE (i, s) < (1, 'c')
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  ab@baz
-1  ·       spans  /!NULL-/1/"c"
+render     ·      ·
+ └── scan  ·      ·
+·          table  ab@baz
+·          spans  /!NULL-/1/"c"
 
 # Check that primary key definitions can indicate index ordering,
 # and this information is subsequently used during index selection
@@ -497,25 +497,25 @@ abz    abz_c_b_key  true      1  c       DESC       false    false
 abz    abz_c_b_key  true      2  b       ASC        false    false
 abz    abz_c_b_key  true      3  a       ASC        false    true
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM abz ORDER BY a DESC LIMIT 1
 ----
-0  limit   ·      ·
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  abz@primary
-2  ·       spans  ALL
-2  ·       limit  1
+limit           ·      ·
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  abz@primary
+·               spans  ALL
+·               limit  1
 
-query ITTT
+query TTT
 EXPLAIN SELECT c FROM abz ORDER BY c DESC LIMIT 1
 ----
-0  limit   ·      ·
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  abz@abz_c_b_key
-2  ·       spans  ALL
-2  ·       limit  1
+limit           ·      ·
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  abz@abz_c_b_key
+·               spans  ALL
+·               limit  1
 
 # Issue #14426: verify we don't have an internal filter that contains "a IN ()"
 # (which causes an error in DistSQL due to expression serialization).
@@ -526,15 +526,15 @@ CREATE TABLE tab0(
   b INT
 )
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
 ----
-0  render  ·         ·                                     (k)        k!=NULL; key(k)
-0  ·       render 0  test.tab0.k                           ·          ·
-1  scan    ·         ·                                     (k, a, b)  k!=NULL; key(k)
-1  ·       table     tab0@primary                          ·          ·
-1  ·       spans     ALL                                   ·          ·
-1  ·       filter    ((a IN (6)) AND (a > 6)) OR (b >= 4)  ·          ·
+render     0  render  ·         ·                                     (k)  k!=NULL; key(k)
+ │         0  ·       render 0  test.tab0.k                           ·    ·
+ └── scan  1  scan    ·         ·                                     (k)  k!=NULL; key(k)
+·          1  ·       table     tab0@primary                          ·    ·
+·          1  ·       spans     ALL                                   ·    ·
+·          1  ·       filter    ((a IN (6)) AND (a > 6)) OR (b >= 4)  ·    ·
 
 query I
 SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
@@ -613,17 +613,17 @@ CREATE TABLE test2 (id BIGSERIAL PRIMARY KEY, k TEXT UNIQUE, v INT DEFAULT 42);
 # Plan check:
 # The query is using an index-join and the limit is propagated to the scan.
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM test2 WHERE k <= '100' ORDER BY k DESC LIMIT 20
 ----
-0  limit       ·      ·
-1  index-join  ·      ·
-2  revscan     ·      ·
-2  ·           table  test2@test2_k_key
-2  ·           spans  /!NULL-/"100"/PrefixEnd
-2  ·           limit  20
-2  scan        ·      ·
-2  ·           table  test2@primary
+limit              ·      ·
+ └── index-join    ·      ·
+      ├── revscan  ·      ·
+      │            table  test2@test2_k_key
+      │            spans  /!NULL-/"100"/PrefixEnd
+      │            limit  20
+      └── scan     ·      ·
+·                  table  test2@primary
 
 # Result check: The following query must not issue more than the
 # requested LIMIT K/V reads, even though an index join batches 100
@@ -706,7 +706,7 @@ INSERT INTO favorites (customerid, guid_id, resource_type, device_group, jurisdi
          (5, '5', 'GAME', 'web', 'MT', 'xxx', 'en_GB', 'ts3'),
          (6, '6', 'GAME', 'web', 'MT', 'xxx', 'en_GB', 'ts4')
 
-query ITTT
+query TTT
 EXPLAIN SELECT
   resource_key,
   count(resource_key) total
@@ -720,14 +720,14 @@ AND   f1.resource_key IN ('ts', 'ts2', 'ts3')
 GROUP BY resource_key
 ORDER BY total DESC
 ----
-0  sort    ·         ·
-0  ·       order     -total
-1  group   ·         ·
-1  ·       group by  @1-@1
-2  render  ·         ·
-3  scan    ·         ·
-3  ·       table     favorites@favorites_glob_fav_idx
-3  ·       spans     /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"/PrefixEnd
+sort                 ·         ·
+ │                   order     -total
+ └── group           ·         ·
+      │              group by  @1-@1
+      └── render     ·         ·
+           └── scan  ·         ·
+·                    table     favorites@favorites_glob_fav_idx
+·                    spans     /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts2"/PrefixEnd /"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"-/"GAME"/"web"/"MT"/"xxx"/"en_GB"/"ts3"/PrefixEnd
 
 query TI rowsort
 SELECT
@@ -783,17 +783,17 @@ INSERT INTO abcd VALUES
 (1,    10,   5),
 (1,    10,   10)
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b > 5
 ----
-0  render  ·         ·               (a, b, c, d)                         a=CONST; b!=NULL
-0  ·       render 0  test.abcd.a     ·                                    ·
-0  ·       render 1  test.abcd.b     ·                                    ·
-0  ·       render 2  test.abcd.c     ·                                    ·
-0  ·       render 3  test.abcd.d     ·                                    ·
-1  scan    ·         ·               (a, b, c, d, rowid[hidden,omitted])  a=CONST; b!=NULL; rowid!=NULL; weak-key(b,c,d,rowid)
-1  ·       table     abcd@abcd       ·                                    ·
-1  ·       spans     /NULL/6-/!NULL  ·                                    ·
+render     0  render  ·         ·               (a, b, c, d)  a=CONST; b!=NULL
+ │         0  ·       render 0  test.abcd.a     ·             ·
+ │         0  ·       render 1  test.abcd.b     ·             ·
+ │         0  ·       render 2  test.abcd.c     ·             ·
+ │         0  ·       render 3  test.abcd.d     ·             ·
+ └── scan  1  scan    ·         ·               (a, b, c, d)  a=CONST; b!=NULL
+·          1  ·       table     abcd@abcd       ·             ·
+·          1  ·       spans     /NULL/6-/!NULL  ·             ·
 
 query IIII rowsort
 SELECT * FROM abcd@abcd WHERE a IS NULL AND b > 5
@@ -803,17 +803,17 @@ NULL  10  1     NULL
 NULL  10  5     NULL
 NULL  10  10    NULL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b < 5
 ----
-0  render  ·         ·                    (a, b, c, d)                         a=CONST; b!=NULL
-0  ·       render 0  test.abcd.a          ·                                    ·
-0  ·       render 1  test.abcd.b          ·                                    ·
-0  ·       render 2  test.abcd.c          ·                                    ·
-0  ·       render 3  test.abcd.d          ·                                    ·
-1  scan    ·         ·                    (a, b, c, d, rowid[hidden,omitted])  a=CONST; b!=NULL; rowid!=NULL; weak-key(b,c,d,rowid)
-1  ·       table     abcd@abcd            ·                                    ·
-1  ·       spans     /NULL/!NULL-/NULL/5  ·                                    ·
+render     0  render  ·         ·                    (a, b, c, d)  a=CONST; b!=NULL
+ │         0  ·       render 0  test.abcd.a          ·             ·
+ │         0  ·       render 1  test.abcd.b          ·             ·
+ │         0  ·       render 2  test.abcd.c          ·             ·
+ │         0  ·       render 3  test.abcd.d          ·             ·
+ └── scan  1  scan    ·         ·                    (a, b, c, d)  a=CONST; b!=NULL
+·          1  ·       table     abcd@abcd            ·             ·
+·          1  ·       spans     /NULL/!NULL-/NULL/5  ·             ·
 
 query IIII rowsort
 SELECT * FROM abcd@abcd WHERE a IS NULL AND b < 5
@@ -823,17 +823,17 @@ NULL  1  1     NULL
 NULL  1  5     NULL
 NULL  1  10    NULL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL ORDER BY b
 ----
-0  render  ·         ·             (a, b, c, d)                         a=CONST; +b
-0  ·       render 0  test.abcd.a   ·                                    ·
-0  ·       render 1  test.abcd.b   ·                                    ·
-0  ·       render 2  test.abcd.c   ·                                    ·
-0  ·       render 3  test.abcd.d   ·                                    ·
-1  scan    ·         ·             (a, b, c, d, rowid[hidden,omitted])  a=CONST; rowid!=NULL; weak-key(b,c,d,rowid); +b
-1  ·       table     abcd@abcd     ·                                    ·
-1  ·       spans     /NULL-/!NULL  ·                                    ·
+render     0  render  ·         ·             (a, b, c, d)  a=CONST; +b
+ │         0  ·       render 0  test.abcd.a   ·             ·
+ │         0  ·       render 1  test.abcd.b   ·             ·
+ │         0  ·       render 2  test.abcd.c   ·             ·
+ │         0  ·       render 3  test.abcd.d   ·             ·
+ └── scan  1  scan    ·         ·             (a, b, c, d)  a=CONST; +b
+·          1  ·       table     abcd@abcd     ·             ·
+·          1  ·       spans     /NULL-/!NULL  ·             ·
 
 query IIII partialsort(1,2)
 SELECT * FROM abcd@abcd WHERE a IS NULL ORDER BY b
@@ -855,17 +855,17 @@ NULL  10    1     NULL
 NULL  10    5     NULL
 NULL  10    10    NULL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c
 ----
-0  render  ·         ·                     (a, b, c, d)                         a=CONST; b=CONST; c!=NULL; +c
-0  ·       render 0  test.abcd.a           ·                                    ·
-0  ·       render 1  test.abcd.b           ·                                    ·
-0  ·       render 2  test.abcd.c           ·                                    ·
-0  ·       render 3  test.abcd.d           ·                                    ·
-1  scan    ·         ·                     (a, b, c, d, rowid[hidden,omitted])  a=CONST; b=CONST; c!=NULL; rowid!=NULL; weak-key(c,d,rowid); +c
-1  ·       table     abcd@abcd             ·                                    ·
-1  ·       spans     /1/NULL/1-/1/NULL/10  ·                                    ·
+render     0  render  ·         ·                     (a, b, c, d)  a=CONST; b=CONST; c!=NULL; +c
+ │         0  ·       render 0  test.abcd.a           ·             ·
+ │         0  ·       render 1  test.abcd.b           ·             ·
+ │         0  ·       render 2  test.abcd.c           ·             ·
+ │         0  ·       render 3  test.abcd.d           ·             ·
+ └── scan  1  scan    ·         ·                     (a, b, c, d)  a=CONST; b=CONST; c!=NULL; +c
+·          1  ·       table     abcd@abcd             ·             ·
+·          1  ·       spans     /1/NULL/1-/1/NULL/10  ·             ·
 
 query IIII 
 SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c

--- a/pkg/sql/logictest/testdata/logic_test/select_index_hints
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_hints
@@ -22,12 +22,12 @@ SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 20 21 22 23
 30 31 32 33
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM abcd WHERE a >= 20 AND a <= 30
 ----
-0  scan  ·      ·
-0  ·     table  abcd@primary
-0  ·     spans  /20-/30/#
+scan  ·      ·
+·     table  abcd@primary
+·     spans  /20-/30/#
 
 # Force primary
 
@@ -37,12 +37,12 @@ SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 20 21 22 23
 30 31 32 33
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM abcd@primary WHERE a >= 20 AND a <= 30
 ----
-0  scan  ·      ·
-0  ·     table  abcd@primary
-0  ·     spans  /20-/30/#
+scan  ·      ·
+·     table  abcd@primary
+·     spans  /20-/30/#
 
 # Force index b
 
@@ -52,15 +52,15 @@ SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 20 21 22 23
 30 31 32 33
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-0  index-join  ·      ·
-1  scan        ·      ·
-1  ·           table  abcd@b
-1  ·           spans  ALL
-1  scan        ·      ·
-1  ·           table  abcd@primary
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  abcd@b
+ │          spans  ALL
+ └── scan   ·      ·
+·           table  abcd@primary
 
 # Force index cd
 
@@ -70,24 +70,24 @@ SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 20 21 22 23
 30 31 32 33
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM abcd@cd WHERE a >= 20 AND a <= 30
 ----
-0  index-join  ·      ·
-1  scan        ·      ·
-1  ·           table  abcd@cd
-1  ·           spans  ALL
-1  scan        ·      ·
-1  ·           table  abcd@primary
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  abcd@cd
+ │          spans  ALL
+ └── scan   ·      ·
+·           table  abcd@primary
 
 # Force index bcd
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 ----
-0  scan  ·      ·
-0  ·     table  abcd@bcd
-0  ·     spans  ALL
+scan  ·      ·
+·     table  abcd@bcd
+·     spans  ALL
 
 query IIII rowsort
 SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
@@ -97,26 +97,26 @@ SELECT * FROM abcd@bcd WHERE a >= 20 AND a <= 30
 
 # Force index b (covering)
 
-query ITTT
+query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE a >= 20 AND a <= 30
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@b
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@b
+·          spans  ALL
 
 # Force index b (non-covering due to WHERE clause)
 
-query ITTT
+query TTT
 EXPLAIN SELECT b FROM abcd@b WHERE c >= 20 AND c <= 30
 ----
-0  render      ·      ·
-1  index-join  ·      ·
-2  scan        ·      ·
-2  ·           table  abcd@b
-2  ·           spans  ALL
-2  scan        ·      ·
-2  ·           table  abcd@primary
+render           ·      ·
+ └── index-join  ·      ·
+      ├── scan   ·      ·
+      │          table  abcd@b
+      │          spans  ALL
+      └── scan   ·      ·
+·                table  abcd@primary
 
 # No hint, should be using index cd
 
@@ -126,13 +126,13 @@ SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 22 23
 32 33
 
-query ITTT
+query TTT
 EXPLAIN SELECT c, d FROM abcd WHERE c >= 20 AND c < 40
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@cd
-1  ·       spans  /20-/40
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@cd
+·          spans  /20-/40
 
 # Force no index
 
@@ -142,13 +142,13 @@ SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 22 23
 32 33
 
-query ITTT
+query TTT
 EXPLAIN SELECT c, d FROM abcd@primary WHERE c >= 20 AND c < 40
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@primary
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@primary
+·          spans  ALL
 
 # Force index b
 
@@ -158,16 +158,16 @@ SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 22 23
 32 33
 
-query ITTT
+query TTT
 EXPLAIN SELECT c, d FROM abcd@b WHERE c >= 20 AND c < 40
 ----
-0  render      ·      ·
-1  index-join  ·      ·
-2  scan        ·      ·
-2  ·           table  abcd@b
-2  ·           spans  ALL
-2  scan        ·      ·
-2  ·           table  abcd@primary
+render           ·      ·
+ └── index-join  ·      ·
+      ├── scan   ·      ·
+      │          table  abcd@b
+      │          spans  ALL
+      └── scan   ·      ·
+·                table  abcd@primary
 
 query error index \"badidx\" not found
 SELECT * FROM abcd@badidx
@@ -175,53 +175,53 @@ SELECT * FROM abcd@badidx
 query error index \"badidx\" not found
 SELECT * FROM abcd@{FORCE_INDEX=badidx}
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM abcd@{FORCE_INDEX=b} WHERE a >= 20 AND a <= 30
 ----
-0  index-join  ·      ·
-1  scan        ·      ·
-1  ·           table  abcd@b
-1  ·           spans  ALL
-1  scan        ·      ·
-1  ·           table  abcd@primary
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  abcd@b
+ │          spans  ALL
+ └── scan   ·      ·
+·           table  abcd@primary
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
 ----
-0  render      ·      ·
-1  index-join  ·      ·
-2  scan        ·      ·
-2  ·           table  abcd@cd
-2  ·           spans  /10-/11
-2  scan        ·      ·
-2  ·           table  abcd@primary
+render           ·      ·
+ └── index-join  ·      ·
+      ├── scan   ·      ·
+      │          table  abcd@cd
+      │          spans  /10-/11
+      └── scan   ·      ·
+·                table  abcd@primary
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@bcd
-1  ·       hint   no index join
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@bcd
+·          hint   no index join
+·          spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=bcd,NO_INDEX_JOIN} WHERE c = 10
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@bcd
-1  ·       hint   no index join
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@bcd
+·          hint   no index join
+·          spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=primary,NO_INDEX_JOIN} WHERE c = 10
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  abcd@primary
-1  ·       hint   no index join
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  abcd@primary
+·          hint   no index join
+·          spans  ALL
 
 query error index \"cd\" is not covering and NO_INDEX_JOIN was specified
 EXPLAIN SELECT b, c, d FROM abcd@{FORCE_INDEX=cd,NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
@@ -54,15 +54,15 @@ ALTER INDEX t@c SPLIT AT VALUES (90)
 statement ok
 ALTER INDEX c SPLIT AT VALUES (10)
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t WHERE (c >= 80) ORDER BY c
 ----
-0  index-join  ·      ·
-1  scan        ·      ·
-1  ·           table  t@c
-1  ·           spans  /80-
-1  scan        ·      ·
-1  ·           table  t@primary
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  t@c
+ │          spans  /80-
+ └── scan   ·      ·
+·           table  t@primary
 
 query IIII partialsort(3)
 SELECT * FROM t WHERE (c >= 80) ORDER BY c

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
@@ -17,15 +17,15 @@ CREATE TABLE t (
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t WHERE b = 2
 ----
-0  index-join  ·      ·
-1  scan        ·      ·
-1  ·           table  t@b
-1  ·           spans  /2-/3
-1  scan        ·      ·
-1  ·           table  t@primary
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  t@b
+ │          spans  /2-/3
+ └── scan   ·      ·
+·           table  t@primary
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE b = 2]
@@ -43,15 +43,15 @@ SELECT * FROM t WHERE b = 2
 ----
 1 2 3 4
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t WHERE c = 6
 ----
-0  index-join  ·      ·
-1  scan        ·      ·
-1  ·           table  t@c
-1  ·           spans  /6-/7
-1  scan        ·      ·
-1  ·           table  t@primary
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  t@c
+ │          spans  /6-/7
+ └── scan   ·      ·
+·           table  t@primary
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE c = 7]
@@ -69,15 +69,15 @@ SELECT * FROM t WHERE c = 7
 ----
 5 6 7 8
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 ----
-0  index-join  ·      ·          (a, b, c, d)                             c!=NULL; key(c); -c
-1  revscan     ·      ·          (a, b[omitted], c[omitted], d[omitted])  c!=NULL; key(c); -c
-1  ·           table  t@c        ·                                        ·
-1  ·           spans  /1-        ·                                        ·
-1  scan        ·      ·          (a, b, c, d)                             ·
-1  ·           table  t@primary  ·                                        ·
+index-join    0  index-join  ·      ·          (a, b, c, d)  c!=NULL; key(c); -c
+ ├── revscan  1  revscan     ·      ·          (a, b, c, d)  c!=NULL; key(c); -c
+ │            1  ·           table  t@c        ·             ·
+ │            1  ·           spans  /1-        ·             ·
+ └── scan     1  scan        ·      ·          (a, b, c, d)  c!=NULL; key(c); -c
+·             1  ·           table  t@primary  ·             ·
 
 query IIII
 SELECT * FROM t WHERE c > 0 ORDER BY c DESC
@@ -85,88 +85,88 @@ SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 5 6 7 8
 1 2 3 4
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t WHERE c > 0 ORDER BY c
 ----
-0  index-join  ·      ·
-1  scan        ·      ·
-1  ·           table  t@c
-1  ·           spans  /1-
-1  scan        ·      ·
-1  ·           table  t@primary
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  t@c
+ │          spans  /1-
+ └── scan   ·      ·
+·           table  t@primary
 
 query IIII
 SELECT * FROM t WHERE c > 0 AND d = 8
 ----
 5 6 7 8
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t WHERE c > 0 AND d = 8
 ----
-0  index-join  ·      ·
-1  scan        ·      ·
-1  ·           table  t@c
-1  ·           spans  /1-
-1  scan        ·      ·
-1  ·           table  t@primary
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  t@c
+ │          spans  /1-
+ └── scan   ·      ·
+·           table  t@primary
 
 # The following testcases verify that when we have a small limit, we prefer an
 # order-matching index.
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t ORDER BY c
 ----
-0  sort  ·      ·
-0  ·     order  +c
-1  scan  ·      ·
-1  ·     table  t@primary
-1  ·     spans  ALL
+sort       ·      ·
+ │         order  +c
+ └── scan  ·      ·
+·          table  t@primary
+·          spans  ALL
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM t ORDER BY c LIMIT 5
 ----
-0  limit       ·      ·
-1  index-join  ·      ·
-2  scan        ·      ·
-2  ·           table  t@c
-2  ·           spans  ALL
-2  ·           limit  5
-2  scan        ·      ·
-2  ·           table  t@primary
+limit            ·      ·
+ └── index-join  ·      ·
+      ├── scan   ·      ·
+      │          table  t@c
+      │          spans  ALL
+      │          limit  5
+      └── scan   ·      ·
+·                table  t@primary
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c OFFSET 5
 ----
-0  limit  ·       ·
-0  ·      offset  5
-1  sort   ·       ·
-1  ·      order   +c
-2  scan   ·       ·
-2  ·      table   t@primary
-2  ·      spans   ALL
+limit           ·       ·
+ │              offset  5
+ └── sort       ·       ·
+      │         order   +c
+      └── scan  ·       ·
+·               table   t@primary
+·               spans   ALL
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
 ----
-0  limit       ·       ·
-0  ·           count   5
-0  ·           offset  5
-1  index-join  ·       ·
-2  scan        ·       ·
-2  ·           table   t@c
-2  ·           spans   ALL
-2  ·           limit   10
-2  scan        ·       ·
-2  ·           table   t@primary
+limit            ·       ·
+ │               count   5
+ │               offset  5
+ └── index-join  ·       ·
+      ├── scan   ·       ·
+      │          table   t@c
+      │          spans   ALL
+      │          limit   10
+      └── scan   ·       ·
+·                table   t@primary
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c LIMIT 1000000
 ----
-0  limit  ·         ·
-0  ·      count     1000000
-1  sort   ·         ·
-1  ·      order     +c
-1  ·      strategy  top 1000000
-2  scan   ·         ·
-2  ·      table     t@primary
-2  ·      spans     ALL
+limit           ·         ·
+ │              count     1000000
+ └── sort       ·         ·
+      │         order     +c
+      │         strategy  top 1000000
+      └── scan  ·         ·
+·               table     t@primary
+·               spans     ALL

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
@@ -29,16 +29,16 @@ INSERT INTO t VALUES
   (8, 3, 2, '32'),
   (9, 3, 3, '33')
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM t WHERE b = 2 AND c % 2 = 0
 ----
-0  index-join  ·       ·
-1  scan        ·       ·
-1  ·           table   t@bc
-1  ·           spans   /2-/3
-1  ·           filter  (c % 2) = 0
-1  scan        ·       ·
-1  ·           table   t@primary
+index-join  ·       ·
+ ├── scan   ·       ·
+ │          table   t@bc
+ │          spans   /2-/3
+ │          filter  (c % 2) = 0
+ └── scan   ·       ·
+·           table   t@primary
 
 # We do NOT look up the table row for '21' and '23'.
 query T
@@ -54,16 +54,16 @@ fetched: /t/primary/5/c -> 2
 fetched: /t/primary/5/s -> '22'
 output row: [5 2 2 '22']
 
-query ITTT
+query TTT
 EXPLAIN (EXPRS) SELECT * FROM t WHERE b = 2 AND c != b
 ----
-0  index-join  ·       ·
-1  scan        ·       ·
-1  ·           table   t@bc
-1  ·           spans   /2-/3
-1  ·           filter  c != b
-1  scan        ·       ·
-1  ·           table   t@primary
+index-join  ·       ·
+ ├── scan   ·       ·
+ │          table   t@bc
+ │          spans   /2-/3
+ │          filter  c != b
+ └── scan   ·       ·
+·           table   t@primary
 
 # We do NOT look up the table row for '22'.
 query T
@@ -131,17 +131,17 @@ output row: [9 3 3 '33']
 # bring non-indexed columns (s) under the index scanNode. (#12582)
 # To test this we need an expression containing non-indexed
 # columns that disappears during range simplification.
-query ITTTTT
+query TITTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
 ----
-0  render      ·         ·          (a)                                      a!=NULL
-0  ·           render 0  test.t.a   ·                                        ·
-1  index-join  ·         ·          (a, b[omitted], c[omitted], s[omitted])  b=CONST; a!=NULL; weak-key(a,c)
-2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  b=CONST; a!=NULL; weak-key(a,c)
-2  ·           table     t@bc       ·                                        ·
-2  ·           spans     /2-/3      ·                                        ·
-2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  ·
-2  ·           table     t@primary  ·                                        ·
+render           0  render      ·         ·          (a)  a!=NULL
+ │               0  ·           render 0  test.t.a   ·    ·
+ └── index-join  1  index-join  ·         ·          (a)  a!=NULL
+      ├── scan   2  scan        ·         ·          (a)  a!=NULL
+      │          2  ·           table     t@bc       ·    ·
+      │          2  ·           spans     /2-/3      ·    ·
+      └── scan   2  scan        ·         ·          (a)  a!=NULL
+·                2  ·           table     t@primary  ·    ·
 
 query I rowsort
 SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))

--- a/pkg/sql/logictest/testdata/logic_test/select_tighten_spans
+++ b/pkg/sql/logictest/testdata/logic_test/select_tighten_spans
@@ -184,12 +184,12 @@ NULL       /0         5         {5}       5
 # p1 table
 
 # Secondary index should not be tightened.
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p1 WHERE b <= 3
 ----
-0  scan  ·      ·
-0  ·     table  p1@b
-0  ·     spans  /!NULL-/4
+scan  ·      ·
+·     table  p1@b
+·     spans  /!NULL-/4
 
 query II rowsort
 SELECT * FROM p1 WHERE b <= 3
@@ -200,12 +200,12 @@ SELECT * FROM p1 WHERE b <= 3
 4 2
 
 # Partial predicate on primary key should not be tightened.
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3
 ----
-0  scan  ·      ·
-0  ·     table  p1@primary
-0  ·     spans  /!NULL-/4
+scan  ·      ·
+·     table  p1@primary
+·     spans  /!NULL-/4
 
 query II rowsort
 SELECT * FROM p1 WHERE a <= 3
@@ -218,19 +218,19 @@ SELECT * FROM p1 WHERE a <= 3
 3 10
 
 # Tighten end key if span contains full primary key.
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b <= 3
 ----
-0  scan  ·      ·
-0  ·     table  p1@primary
-0  ·     spans  /!NULL-/3/3/#
+scan  ·      ·
+·     table  p1@primary
+·     spans  /!NULL-/3/3/#
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b < 4
 ----
-0  scan  ·      ·
-0  ·     table  p1@primary
-0  ·     spans  /!NULL-/3/3/#
+scan  ·      ·
+·     table  p1@primary
+·     spans  /!NULL-/3/3/#
 
 query II rowsort
 SELECT * FROM p1 WHERE a <= 3 AND b <= 3
@@ -239,12 +239,12 @@ SELECT * FROM p1 WHERE a <= 3 AND b <= 3
 2 2
 
 # Mixed bounds.
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p1 WHERE a >= 2 AND b <= 3
 ----
-0  scan  ·      ·
-0  ·     table  p1@b
-0  ·     spans  /!NULL-/4
+scan  ·      ·
+·     table  p1@b
+·     spans  /!NULL-/4
 
 query II rowsort
 SELECT * FROM p1 WHERE a >= 2 AND b <= 3
@@ -256,44 +256,44 @@ SELECT * FROM p1 WHERE a >= 2 AND b <= 3
 
 # Edge cases.
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 0 AND b <= 0
 ----
-0  scan  ·      ·
-0  ·     table  p1@primary
-0  ·     spans  /!NULL-/0/0/#
+scan  ·      ·
+·     table  p1@primary
+·     spans  /!NULL-/0/0/#
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= -1 AND b <= -1
 ----
-0  scan  ·      ·
-0  ·     table  p1@primary
-0  ·     spans  /!NULL-/-1/-1/#
+scan  ·      ·
+·     table  p1@primary
+·     spans  /!NULL-/-1/-1/#
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= -9223372036854775808
 ----
-0  scan  ·      ·
-0  ·     table  p1@primary
-0  ·     spans  /1/!NULL-/1/-9223372036854775808/#
+scan  ·      ·
+·     table  p1@primary
+·     spans  /1/!NULL-/1/-9223372036854775808/#
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= 9223372036854775807
 ----
-0  scan  ·      ·
-0  ·     table  p1@primary
-0  ·     spans  /1/!NULL-/1/9223372036854775807/#
+scan  ·      ·
+·     table  p1@primary
+·     spans  /1/!NULL-/1/9223372036854775807/#
 
 # Table c1 (interleaved table)
 
 # Partial primary key does not tighten.
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM c1 WHERE a <= 3
 ----
-0  scan  ·      ·
-0  ·     table  c1@primary
-0  ·     spans  /!NULL-/4
+scan  ·      ·
+·     table  c1@primary
+·     spans  /!NULL-/4
 
 query II rowsort
 SELECT * FROM c1 WHERE a <= 3
@@ -305,12 +305,12 @@ SELECT * FROM c1 WHERE a <= 3
 2 10
 
 # Tighten span on fully primary key.
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM c1 WHERE a <= 3 AND b <= 3
 ----
-0  scan  ·      ·
-0  ·     table  c1@primary
-0  ·     spans  /!NULL-/3/3/#/52/1/#
+scan  ·      ·
+·     table  c1@primary
+·     spans  /!NULL-/3/3/#/52/1/#
 
 query II rowsort
 SELECT * FROM c1 WHERE a <= 3 AND b <= 3
@@ -322,12 +322,12 @@ SELECT * FROM c1 WHERE a <= 3 AND b <= 3
 # From the primary index.
 
 # Lower bound (i >= 2)
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p2 WHERE i >= 2
 ----
-0  scan  ·      ·
-0  ·     table  p2@primary
-0  ·     spans  /2-
+scan  ·      ·
+·     table  p2@primary
+·     spans  /2-
 
 query II rowsort
 SELECT * FROM p2 WHERE i>= 2
@@ -342,12 +342,12 @@ SELECT * FROM p2 WHERE i>= 2
 
 # Upper bound (i <= 5)
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p2 WHERE i <= 5
 ----
-0  scan  ·      ·
-0  ·     table  p2@primary
-0  ·     spans  /!NULL-/5/#
+scan  ·      ·
+·     table  p2@primary
+·     spans  /!NULL-/5/#
 
 query II rowsort
 SELECT * FROM p2 WHERE i <= 5
@@ -363,12 +363,12 @@ SELECT * FROM p2 WHERE i <= 5
 # Lower bound (i >= 1 AND d >= 2)
 
 # Note 53/2 refers to the 2nd index (after primary index) of table p2.
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d >= 2
 ----
-0  scan  ·      ·
-0  ·     table  p2@p2_id
-0  ·     spans  /1/#/53/2/2-
+scan  ·      ·
+·     table  p2@p2_id
+·     spans  /1/#/53/2/2-
 
 query II rowsort
 SELECT * FROM p2@p2_id WHERE i>= 1 AND d >= 2
@@ -380,12 +380,12 @@ SELECT * FROM p2@p2_id WHERE i>= 1 AND d >= 2
 
 # Upper bound (i <= 6 AND d <= 5)
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
 ----
-0  scan  ·      ·
-0  ·     table  p2@p2_id
-0  ·     spans  /!NULL-/6/#/53/2/6
+scan  ·      ·
+·     table  p2@p2_id
+·     spans  /!NULL-/6/#/53/2/6
 
 query II rowsort
 SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
@@ -395,12 +395,12 @@ SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
 
 # IS NULL
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NULL
 ----
-0  scan  ·      ·
-0  ·     table  p2@p2_id
-0  ·     spans  /1/#/53/2/NULL-
+scan  ·      ·
+·     table  p2@p2_id
+·     spans  /1/#/53/2/NULL-
 
 query II rowsort
 SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NULL
@@ -411,12 +411,12 @@ SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NULL
 
 # IS NOT NULL
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NOT NULL
 ----
-0  scan  ·      ·
-0  ·     table  p2@p2_id
-0  ·     spans  /1/#/53/2/!NULL-
+scan  ·      ·
+·     table  p2@p2_id
+·     spans  /1/#/53/2/!NULL-
 
 query II rowsort
 SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NOT NULL
@@ -429,13 +429,13 @@ SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NOT NULL
 
 # String table
 
-query ITTT colnames
+query TTT colnames
 EXPLAIN SELECT * FROM bytes_t WHERE a = 'a'
 ----
-Level  Type  Field  Description
-0      scan  ·      ·
-0      ·     table  bytes_t@primary
-0      ·     spans  /"a"-/"a"/#
+Tree  Field  Description
+scan  ·      ·
+·     table  bytes_t@primary
+·     spans  /"a"-/"a"/#
 
 query T
 SELECT * FROM bytes_t WHERE a = 'a'
@@ -444,26 +444,26 @@ a
 
 # No tightening.
 
-query ITTT colnames
+query TTT colnames
 EXPLAIN SELECT * FROM bytes_t WHERE a < 'aa'
 ----
-Level  Type  Field  Description
-0      scan  ·      ·
-0      ·     table  bytes_t@primary
-0      ·     spans  /!NULL-/"aa"
+Tree  Field  Description
+scan  ·      ·
+·     table  bytes_t@primary
+·     spans  /!NULL-/"aa"
 
 query T
 SELECT * FROM bytes_t WHERE a < 'aa'
 ----
 a
 
-query ITTT colnames
+query TTT colnames
 EXPLAIN SELECT * FROM decimal_t WHERE a = 1.00
 ----
-Level  Type  Field  Description
-0      scan  ·      ·
-0      ·     table  decimal_t@primary
-0      ·     spans  /1-/1/#
+Tree  Field  Description
+scan  ·      ·
+·     table  decimal_t@primary
+·     spans  /1-/1/#
 
 query R
 SELECT * FROM decimal_t WHERE a = 1.00
@@ -472,13 +472,13 @@ SELECT * FROM decimal_t WHERE a = 1.00
 
 # No tightening.
 
-query ITTT colnames
+query TTT colnames
 EXPLAIN SELECT * FROM decimal_t WHERE a < 2
 ----
-Level  Type  Field  Description
-0      scan  ·      ·
-0      ·     table  decimal_t@primary
-0      ·     spans  /!NULL-/2
+Tree  Field  Description
+scan  ·      ·
+·     table  decimal_t@primary
+·     spans  /!NULL-/2
 
 query R rowsort
 SELECT * FROM decimal_t WHERE a < 2

--- a/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
+++ b/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
@@ -25,120 +25,120 @@ SELECT COUNT(DISTINCT x.*) FROM a x, a y
 ----
 2
 
-query ITTTTT
+query TITTTTT
 EXPLAIN(VERBOSE) SELECT COUNT(DISTINCT x.*) FROM a x, a y
 ----
-0  group   ·            ·                           (count)                                                                       ·
-0  ·       aggregate 0  count(DISTINCT (x.x, x.y))  ·                                                                             ·
-1  render  ·            ·                           ("(x, y)")                                                                    ·
-1  ·       render 0     (x.x, x.y)                  ·                                                                             ·
-2  join    ·            ·                           (x, y, rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
-2  ·       type         cross                       ·                                                                             ·
-3  scan    ·            ·                           (x, y, rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
-3  ·       table        a@primary                   ·                                                                             ·
-3  ·       spans        ALL                         ·                                                                             ·
-3  scan    ·            ·                           (x[omitted], y[omitted], rowid[hidden,omitted])                               rowid!=NULL; key(rowid)
-3  ·       table        a@primary                   ·                                                                             ·
-3  ·       spans        ALL                         ·                                                                             ·
+group                0  group   ·            ·                           (count)  ·
+ │                   0  ·       aggregate 0  count(DISTINCT (x.x, x.y))  ·        ·
+ └── render          1  render  ·            ·                           (count)  ·
+      │              1  ·       render 0     (x.x, x.y)                  ·        ·
+      └── join       2  join    ·            ·                           (count)  ·
+           │         2  ·       type         cross                       ·        ·
+           ├── scan  3  scan    ·            ·                           (count)  ·
+           │         3  ·       table        a@primary                   ·        ·
+           │         3  ·       spans        ALL                         ·        ·
+           └── scan  3  scan    ·            ·                           (count)  ·
+·                    3  ·       table        a@primary                   ·        ·
+·                    3  ·       spans        ALL                         ·        ·
 
-query ITTT
+query TTT
 EXPLAIN(EXPRS) SELECT * FROM a ORDER BY a.*
 ----
-0  sort    ·         ·
-0  ·       order     +x,+y
-1  render  ·         ·
-1  ·       render 0  x
-1  ·       render 1  y
-2  scan    ·         ·
-2  ·       table     a@primary
-2  ·       spans     ALL
+sort            ·         ·
+ │              order     +x,+y
+ └── render     ·         ·
+      │         render 0  x
+      │         render 1  y
+      └── scan  ·         ·
+·               table     a@primary
+·               spans     ALL
 
-query ITTT
+query TTT
 EXPLAIN(EXPRS) SELECT * FROM a ORDER BY (a.*)
 ----
-0  sort    ·         ·
-0  ·       order     +x,+y
-1  render  ·         ·
-1  ·       render 0  x
-1  ·       render 1  y
-2  scan    ·         ·
-2  ·       table     a@primary
-2  ·       spans     ALL
+sort            ·         ·
+ │              order     +x,+y
+ └── render     ·         ·
+      │         render 0  x
+      │         render 1  y
+      └── scan  ·         ·
+·               table     a@primary
+·               spans     ALL
 
-query ITTT
+query TTT
 EXPLAIN(EXPRS) SELECT MIN(y.x) FROM a x, a y GROUP BY x.*
 ----
-0  group   ·            ·
-0  ·       aggregate 0  min(x)
-0  ·       group by     @1-@2
-1  render  ·            ·
-1  ·       render 0     x
-1  ·       render 1     y
-1  ·       render 2     x
-2  join    ·            ·
-2  ·       type         cross
-3  scan    ·            ·
-3  ·       table        a@primary
-3  ·       spans        ALL
-3  scan    ·            ·
-3  ·       table        a@primary
-3  ·       spans        ALL
+group                ·            ·
+ │                   aggregate 0  min(x)
+ │                   group by     @1-@2
+ └── render          ·            ·
+      │              render 0     x
+      │              render 1     y
+      │              render 2     x
+      └── join       ·            ·
+           │         type         cross
+           ├── scan  ·            ·
+           │         table        a@primary
+           │         spans        ALL
+           └── scan  ·            ·
+·                    table        a@primary
+·                    spans        ALL
 
-query ITTT
+query TTT
 EXPLAIN(EXPRS) SELECT MIN(y.x) FROM a x, a y GROUP BY (1, (x.*))
 ----
-0  group   ·            ·
-0  ·       aggregate 0  min(x)
-0  ·       group by     @1-@3
-1  render  ·            ·
-1  ·       render 0     1
-1  ·       render 1     x
-1  ·       render 2     y
-1  ·       render 3     x
-2  join    ·            ·
-2  ·       type         cross
-3  scan    ·            ·
-3  ·       table        a@primary
-3  ·       spans        ALL
-3  scan    ·            ·
-3  ·       table        a@primary
-3  ·       spans        ALL
+group                ·            ·
+ │                   aggregate 0  min(x)
+ │                   group by     @1-@3
+ └── render          ·            ·
+      │              render 0     1
+      │              render 1     x
+      │              render 2     y
+      │              render 3     x
+      └── join       ·            ·
+           │         type         cross
+           ├── scan  ·            ·
+           │         table        a@primary
+           │         spans        ALL
+           └── scan  ·            ·
+·                    table        a@primary
+·                    spans        ALL
 
 # A useful optimization: naked tuple expansion in GROUP BY clause.
-query ITTT
+query TTT
 EXPLAIN(EXPRS) SELECT MIN(y.x) FROM a x, a y GROUP BY (x.*)
 ----
-0  group   ·            ·
-0  ·       aggregate 0  min(x)
-0  ·       group by     @1-@2
-1  render  ·            ·
-1  ·       render 0     x
-1  ·       render 1     y
-1  ·       render 2     x
-2  join    ·            ·
-2  ·       type         cross
-3  scan    ·            ·
-3  ·       table        a@primary
-3  ·       spans        ALL
-3  scan    ·            ·
-3  ·       table        a@primary
-3  ·       spans        ALL
+group                ·            ·
+ │                   aggregate 0  min(x)
+ │                   group by     @1-@2
+ └── render          ·            ·
+      │              render 0     x
+      │              render 1     y
+      │              render 2     x
+      └── join       ·            ·
+           │         type         cross
+           ├── scan  ·            ·
+           │         table        a@primary
+           │         spans        ALL
+           └── scan  ·            ·
+·                    table        a@primary
+·                    spans        ALL
 
 # Show reuse of renders expression inside an expansion.
-query ITTT
+query TTT
 EXPLAIN(EXPRS) SELECT x.y FROM a x, a y GROUP BY x.*
 ----
-0  group   ·            ·
-0  ·       aggregate 0  y
-0  ·       group by     @1-@2
-1  render  ·            ·
-1  ·       render 0     x
-1  ·       render 1     y
-2  join    ·            ·
-2  ·       type         cross
-3  scan    ·            ·
-3  ·       table        a@primary
-3  ·       spans        ALL
-3  scan    ·            ·
-3  ·       table        a@primary
-3  ·       spans        ALL
+group                ·            ·
+ │                   aggregate 0  y
+ │                   group by     @1-@2
+ └── render          ·            ·
+      │              render 0     x
+      │              render 1     y
+      └── join       ·            ·
+           │         type         cross
+           ├── scan  ·            ·
+           │         table        a@primary
+           │         spans        ALL
+           └── scan  ·            ·
+·                    table        a@primary
+·                    spans        ALL

--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -98,13 +98,13 @@ INSERT INTO t14601 VALUES
 statement ok
 DELETE FROM t14601 WHERE a > 'a' AND a < 'c'
 
-query ITTT
+query TTT
 EXPLAIN SELECT a FROM t14601 ORDER BY a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t14601@i14601
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t14601@i14601
+·          spans  ALL
 
 query T
 SELECT a FROM t14601 ORDER BY a
@@ -145,13 +145,13 @@ INSERT INTO t14601a VALUES
 statement ok
 UPDATE t14601a SET b = NOT b WHERE a > 'a' AND a < 'c'
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t14601a@i14601a
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t14601a@i14601a
+·          spans  ALL
 
 query TB
 SELECT a, b FROM t14601a ORDER BY a
@@ -185,13 +185,13 @@ INSERT INTO t14601a VALUES
 statement ok
 UPDATE t14601a SET b = NOT b WHERE a > 'a' AND a < 'c'
 
-query ITTT
+query TTT
 EXPLAIN SELECT a, b FROM t14601a ORDER BY a
 ----
-0  render  ·      ·
-1  scan    ·      ·
-1  ·       table  t14601a@i14601a
-1  ·       spans  ALL
+render     ·      ·
+ └── scan  ·      ·
+·          table  t14601a@i14601a
+·          spans  ALL
 
 query TB
 SELECT a, b FROM t14601a ORDER BY a

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -42,16 +42,16 @@ CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
 statement ok
 INSERT INTO abc VALUES (1, 2, 3), (4, 5, 6)
 
-query ITTT
+query TTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
-0  split     ·           ·
-1  values    ·           ·
-1  ·         size        1 column, 1 row
-1  ·         subqueries  1
-2  limit     ·           ·
-3  render    ·           ·
-4  emptyrow  ·           ·
+split                         ·           ·
+ └── values                   ·           ·
+      │                       size        1 column, 1 row
+      │                       subqueries  1
+      └── limit               ·           ·
+           └── render         ·           ·
+                └── emptyrow  ·           ·
 
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
@@ -75,17 +75,17 @@ SELECT (SELECT * FROM abc)
 query error more than one row returned by a subquery used as an expression
 SELECT (SELECT a FROM abc)
 
-query ITTT
+query TTT
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
-0  render    ·           ·
-0  ·         subqueries  1
-1  limit     ·           ·
-2  render    ·           ·
-3  scan      ·           ·
-3  ·         table       abc@primary
-3  ·         spans       ALL
-1  emptyrow  ·           ·
+render               ·           ·
+ │                   subqueries  1
+ ├── limit           ·           ·
+ │    └── render     ·           ·
+ │         └── scan  ·           ·
+ │                   table       abc@primary
+ │                   spans       ALL
+ └── emptyrow        ·           ·
 
 query I
 SELECT (SELECT a FROM abc WHERE false)
@@ -285,13 +285,13 @@ foo1 moo2 moo3
 2    4    4
 3    1    1
 
-query ITTT
+query TTT
 EXPLAIN SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
 ----
-0  sort    ·      ·
-0  ·       order  +foo1
-1  values  ·      ·
-1  ·       size   3 columns, 3 rows
+sort         ·      ·
+ │           order  +foo1
+ └── values  ·      ·
+·            size   3 columns, 3 rows
 
 query II colnames
 SELECT a, b FROM (VALUES (1, 2, 3), (3, 4, 7), (5, 6, 10)) AS foo (a, b, c) WHERE a + b = c
@@ -339,18 +339,18 @@ INSERT INTO xyz (x, y, z) VALUES (13, 11, 12) RETURNING (y IN (SELECT y FROM xyz
 true
 
 # check that residual filters are not expanded twice
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
 ----
-0  render  ·           ·            (x)                          x!=NULL; key(x)
-1  scan    ·           ·            (x, y[omitted], z[omitted])  x!=NULL; key(x)
-1  ·       table       xyz@primary  ·                            ·
-1  ·       spans       ALL          ·                            ·
-1  ·       subqueries  1            ·                            ·
-2  render  ·           ·            (x)                          x!=NULL; key(x)
-3  scan    ·           ·            (x, y[omitted], z[omitted])  x!=NULL; key(x)
-3  ·       table       xyz@primary  ·                            ·
-3  ·       spans       ALL          ·                            ·
+render               0  render  ·           ·            (x)  x!=NULL; key(x)
+ └── scan            1  scan    ·           ·            (x)  x!=NULL; key(x)
+      │              1  ·       table       xyz@primary  ·    ·
+      │              1  ·       spans       ALL          ·    ·
+      │              1  ·       subqueries  1            ·    ·
+      └── render     2  render  ·           ·            (x)  x!=NULL; key(x)
+           └── scan  3  scan    ·           ·            (x)  x!=NULL; key(x)
+·                    3  ·       table       xyz@primary  ·    ·
+·                    3  ·       spans       ALL          ·    ·
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not
@@ -368,23 +368,23 @@ query I
 SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
 
-query ITTT
+query TTT
 EXPLAIN SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-0  render      ·           ·
-1  index-join  ·           ·
-2  scan        ·           ·
-2  ·           table       tab4@idx_tab4_0
-2  ·           spans       /!NULL-/5.38/1
-2  ·           subqueries  1
-3  render      ·           ·
-4  scan        ·           ·
-4  ·           table       tab4@primary
-4  ·           spans       ALL
-2  scan        ·           ·
-2  ·           table       tab4@primary
-2  ·           subqueries  1
-3  render      ·           ·
-4  scan        ·           ·
-4  ·           table       tab4@primary
-4  ·           spans       ALL
+render                    ·           ·
+ └── index-join           ·           ·
+      ├── scan            ·           ·
+      │    │              table       tab4@idx_tab4_0
+      │    │              spans       /!NULL-/5.38/1
+      │    │              subqueries  1
+      │    └── render     ·           ·
+      │         └── scan  ·           ·
+      │                   table       tab4@primary
+      │                   spans       ALL
+      └── scan            ·           ·
+           │              table       tab4@primary
+           │              subqueries  1
+           └── render     ·           ·
+                └── scan  ·           ·
+·                         table       tab4@primary
+·                         spans       ALL

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -143,31 +143,31 @@ SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 
 3
 2
 
-query ITTT rowsort
+query TTT rowsort
 EXPLAIN SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
-0  union   ·      ·
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  uniontest@primary
-2  ·       spans  ALL
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  uniontest@primary
-2  ·       spans  ALL
+union           ·      ·
+ ├── render     ·      ·
+ │    └── scan  ·      ·
+ │              table  uniontest@primary
+ │              spans  ALL
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  uniontest@primary
+·               spans  ALL
 
-query ITTT rowsort
+query TTT rowsort
 EXPLAIN SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
-0  append  ·      ·
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  uniontest@primary
-2  ·       spans  ALL
-1  render  ·      ·
-2  scan    ·      ·
-2  ·       table  uniontest@primary
-2  ·       spans  ALL
+append          ·      ·
+ ├── render     ·      ·
+ │    └── scan  ·      ·
+ │              table  uniontest@primary
+ │              spans  ALL
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  uniontest@primary
+·               spans  ALL
 
 query II
 SELECT * FROM (SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1);
@@ -201,12 +201,12 @@ query error column z does not exist
 SELECT 1 UNION SELECT 3 ORDER BY z
 
 # Check that EXPLAIN properly releases memory for virtual tables.
-query ITTT
+query TTT
 EXPLAIN SELECT node_id FROM crdb_internal.node_build_info UNION VALUES(123)
 ----
-0  union   ·     ·
-1  values  ·     ·
-1  ·       size  1 column, 1 row
-1  render  ·     ·
-2  values  ·     ·
-2  ·       size  3 columns, 5 rows
+union             ·     ·
+ ├── values       ·     ·
+ │                size  1 column, 1 row
+ └── render       ·     ·
+      └── values  ·     ·
+·                 size  3 columns, 5 rows

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -333,47 +333,47 @@ SELECT * from xyz
 ----
 2 777 666
 
-query ITTT
+query TTT
 EXPLAIN UPDATE xyz SET y = x
 ----
-0  update  ·      ·
-0  ·       table  xyz
-0  ·       set    y
-1  scan    ·      ·
-1  ·       table  xyz@primary
-1  ·       spans  ALL
+update     ·      ·
+ │         table  xyz
+ │         set    y
+ └── scan  ·      ·
+·          table  xyz@primary
+·          spans  ALL
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (1, 2)
 ----
-0  update  ·      ·            ()                   ·
-0  ·       table  xyz          ·                    ·
-0  ·       set    x, y         ·                    ·
-1  render  ·      ·            (x, y, z, "1", "2")  "1"=CONST; "2"=CONST; x!=NULL; key(x)
-2  scan    ·      ·            (x, y, z)            x!=NULL; key(x)
-2  ·       table  xyz@primary  ·                    ·
-2  ·       spans  ALL          ·                    ·
+update          0  update  ·      ·            ()  ·
+ │              0  ·       table  xyz          ·   ·
+ │              0  ·       set    x, y         ·   ·
+ └── render     1  render  ·      ·            ()  ·
+      └── scan  2  scan    ·      ·            ()  ·
+·               2  ·       table  xyz@primary  ·   ·
+·               2  ·       spans  ALL          ·   ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (y, x)
 ----
-0  update  ·      ·            ()         ·
-0  ·       table  xyz          ·          ·
-0  ·       set    x, y         ·          ·
-1  scan    ·      ·            (x, y, z)  x!=NULL; key(x)
-1  ·       table  xyz@primary  ·          ·
-1  ·       spans  ALL          ·          ·
+update     0  update  ·      ·            ()  ·
+ │         0  ·       table  xyz          ·   ·
+ │         0  ·       set    x, y         ·   ·
+ └── scan  1  scan    ·      ·            ()  ·
+·          1  ·       table  xyz@primary  ·   ·
+·          1  ·       spans  ALL          ·   ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (2, 2)
 ----
-0  update  ·      ·            ()              ·
-0  ·       table  xyz          ·               ·
-0  ·       set    x, y         ·               ·
-1  render  ·      ·            (x, y, z, "2")  "2"=CONST; x!=NULL; key(x)
-2  scan    ·      ·            (x, y, z)       x!=NULL; key(x)
-2  ·       table  xyz@primary  ·               ·
-2  ·       spans  ALL          ·               ·
+update          0  update  ·      ·            ()  ·
+ │              0  ·       table  xyz          ·   ·
+ │              0  ·       set    x, y         ·   ·
+ └── render     1  render  ·      ·            ()  ·
+      └── scan  2  scan    ·      ·            ()  ·
+·               2  ·       table  xyz@primary  ·   ·
+·               2  ·       spans  ALL          ·   ·
 
 statement ok
 CREATE TABLE lots (
@@ -441,18 +441,18 @@ TRUNCATE kv
 statement ok
 INSERT INTO kv VALUES (1, 9), (8, 2), (3, 7), (6, 4)
 
-query ITTT
+query TTT
 EXPLAIN UPDATE kv SET v = v + 1 ORDER BY v DESC
 ----
-0  update  ·      ·
-0  ·       table  kv
-0  ·       set    v
-1  render  ·      ·
-2  sort    ·      ·
-2  ·       order  -v
-3  scan    ·      ·
-3  ·       table  kv@primary
-3  ·       spans  ALL
+update               ·      ·
+ │                   table  kv
+ │                   set    v
+ └── render          ·      ·
+      └── sort       ·      ·
+           │         order  -v
+           └── scan  ·      ·
+·                    table  kv@primary
+·                    spans  ALL
 
 query II
 UPDATE kv SET v = v + 1 ORDER BY v DESC RETURNING k,v
@@ -475,18 +475,18 @@ UPDATE kv SET k = k * 2 ORDER BY k DESC
 statement ok
 TRUNCATE kv; INSERT INTO kv VALUES (1, 2), (2, 3), (3, 4)
 
-query ITTT
+query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-0  update  ·      ·
-0  ·       table  kv
-0  ·       set    v
-1  render  ·      ·
-2  limit   ·      ·
-3  scan    ·      ·
-3  ·       table  kv@primary
-3  ·       spans  /!NULL-/2/#
-3  ·       limit  1
+update               ·      ·
+ │                   table  kv
+ │                   set    v
+ └── render          ·      ·
+      └── limit      ·      ·
+           └── scan  ·      ·
+·                    table  kv@primary
+·                    spans  /!NULL-/2/#
+·                    limit  1
 
 query II
 UPDATE kv SET v = v - 1 WHERE k < 10 ORDER BY k LIMIT 1 RETURNING k, v

--- a/pkg/sql/logictest/testdata/logic_test/values
+++ b/pkg/sql/logictest/testdata/logic_test/values
@@ -28,12 +28,12 @@ VALUES ((SELECT 1)), ((SELECT 2))
 2
 
 # the subquery's plan must be visible in EXPLAIN
-query ITTT
+query TTT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
-0  values    ·           ·
-0  ·         size        1 column, 2 rows
-0  ·         subqueries  1
-1  limit     ·           ·
-2  render    ·           ·
-3  emptyrow  ·           ·
+values                   ·           ·
+ │                       size        1 column, 2 rows
+ │                       subqueries  1
+ └── limit               ·           ·
+      └── render         ·           ·
+           └── emptyrow  ·           ·

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -521,16 +521,16 @@ SELECT k, max(stddev) OVER (ORDER BY d DESC) FROM (SELECT k, d, stddev(d) OVER (
 7  3.5355339059327376220
 8  3.5355339059327376220
 
-query ITTT
+query TTT
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-0  sort    ·      ·
-0  ·       order  +variance,+k
-1  window  ·      ·
-2  render  ·      ·
-3  scan    ·      ·
-3  ·       table  kv@primary
-3  ·       spans  ALL
+sort                 ·      ·
+ │                   order  +variance,+k
+ └── window          ·      ·
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  kv@primary
+·                    spans  ALL
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k]
@@ -560,140 +560,140 @@ output row: [7 3.4501207708330056852]
 output row: [3 3.5355339059327376220]
 output row: [8 3.5355339059327376220]
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-0  sort    ·         ·                                         (k int, stddev decimal)                                                                          ·
-0  ·       order     +variance,+k                              ·                                                                                                ·
-1  window  ·         ·                                         (k int, stddev decimal, variance decimal)                                                        ·
-1  ·       window 0  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
-1  ·       window 1  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
-1  ·       render 1  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
-1  ·       render 2  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
-2  render  ·         ·                                         (k int, d decimal, d decimal, v int)                                                             d=d; k!=NULL; key(k)
-2  ·       render 0  (k)[int]                                  ·                                                                                                ·
-2  ·       render 1  (d)[decimal]                              ·                                                                                                ·
-2  ·       render 2  (d)[decimal]                              ·                                                                                                ·
-2  ·       render 3  (v)[int]                                  ·                                                                                                ·
-3  scan    ·         ·                                         (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
-3  ·       table     kv@primary                                ·                                                                                                ·
-3  ·       spans     ALL                                       ·                                                                                                ·
+sort                 0  sort    ·         ·                                         (k int, stddev decimal)  ·
+ │                   0  ·       order     +variance,+k                              ·                        ·
+ └── window          1  window  ·         ·                                         (k int, stddev decimal)  ·
+      │              1  ·       window 0  (stddev((d)[decimal]) OVER w)[decimal]    ·                        ·
+      │              1  ·       window 1  (variance((d)[decimal]) OVER w)[decimal]  ·                        ·
+      │              1  ·       render 1  (stddev((d)[decimal]) OVER w)[decimal]    ·                        ·
+      │              1  ·       render 2  (variance((d)[decimal]) OVER w)[decimal]  ·                        ·
+      └── render     2  render  ·         ·                                         (k int, stddev decimal)  ·
+           │         2  ·       render 0  (k)[int]                                  ·                        ·
+           │         2  ·       render 1  (d)[decimal]                              ·                        ·
+           │         2  ·       render 2  (d)[decimal]                              ·                        ·
+           │         2  ·       render 3  (v)[int]                                  ·                        ·
+           └── scan  3  scan    ·         ·                                         (k int, stddev decimal)  ·
+·                    3  ·       table     kv@primary                                ·                        ·
+·                    3  ·       spans     ALL                                       ·                        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  sort    ·         ·                                                                            (k int, stddev decimal)                                                                          ·
-0  ·       order     +variance,+k                                                                 ·                                                                                                ·
-1  window  ·         ·                                                                            (k int, stddev decimal, variance decimal)                                                        ·
-1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
-1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                ·
-1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
-1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                ·
-2  render  ·         ·                                                                            (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                    d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
-2  ·       render 0  (k)[int]                                                                     ·                                                                                                ·
-2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                ·
-2  ·       render 2  (d)[decimal]                                                                 ·                                                                                                ·
-2  ·       render 3  (v)[int]                                                                     ·                                                                                                ·
-2  ·       render 4  ('a')[string]                                                                ·                                                                                                ·
-2  ·       render 5  (100)[int]                                                                   ·                                                                                                ·
-3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
-3  ·       table     kv@primary                                                                   ·                                                                                                ·
-3  ·       spans     ALL                                                                          ·                                                                                                ·
+sort                 0  sort    ·         ·                                                                            (k int, stddev decimal)  ·
+ │                   0  ·       order     +variance,+k                                                                 ·                        ·
+ └── window          1  window  ·         ·                                                                            (k int, stddev decimal)  ·
+      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                        ·
+      │              1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                        ·
+      │              1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                        ·
+      │              1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                        ·
+      └── render     2  render  ·         ·                                                                            (k int, stddev decimal)  ·
+           │         2  ·       render 0  (k)[int]                                                                     ·                        ·
+           │         2  ·       render 1  (d)[decimal]                                                                 ·                        ·
+           │         2  ·       render 2  (d)[decimal]                                                                 ·                        ·
+           │         2  ·       render 3  (v)[int]                                                                     ·                        ·
+           │         2  ·       render 4  ('a')[string]                                                                ·                        ·
+           │         2  ·       render 5  (100)[int]                                                                   ·                        ·
+           └── scan  3  scan    ·         ·                                                                            (k int, stddev decimal)  ·
+·                    3  ·       table     kv@primary                                                                   ·                        ·
+·                    3  ·       spans     ALL                                                                          ·                        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
-0  sort    ·         ·                                                                            (k int, stddev decimal)                                                                          +k
-0  ·       order     +k                                                                           ·                                                                                                ·
-1  window  ·         ·                                                                            (k int, stddev decimal)                                                                          ·
-1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
-1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
-2  render  ·         ·                                                                            (k int, d decimal, v int, "'a'" string)                                                          "'a'"=CONST; k!=NULL; key(k)
-2  ·       render 0  (k)[int]                                                                     ·                                                                                                ·
-2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                ·
-2  ·       render 2  (v)[int]                                                                     ·                                                                                                ·
-2  ·       render 3  ('a')[string]                                                                ·                                                                                                ·
-3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
-3  ·       table     kv@primary                                                                   ·                                                                                                ·
-3  ·       spans     ALL                                                                          ·                                                                                                ·
+sort                 0  sort    ·         ·                                                                            (k int, stddev decimal)  +k
+ │                   0  ·       order     +k                                                                           ·                        ·
+ └── window          1  window  ·         ·                                                                            (k int, stddev decimal)  +k
+      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                        ·
+      │              1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                        ·
+      └── render     2  render  ·         ·                                                                            (k int, stddev decimal)  +k
+           │         2  ·       render 0  (k)[int]                                                                     ·                        ·
+           │         2  ·       render 1  (d)[decimal]                                                                 ·                        ·
+           │         2  ·       render 2  (v)[int]                                                                     ·                        ·
+           │         2  ·       render 3  ('a')[string]                                                                ·                        ·
+           └── scan  3  scan    ·         ·                                                                            (k int, stddev decimal)  +k
+·                    3  ·       table     kv@primary                                                                   ·                        ·
+·                    3  ·       spans     ALL                                                                          ·                        ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  sort    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                      ·
-0  ·       order     +variance,+k                                                                                       ·                                                                                                ·
-1  window  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)                    ·
-1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                        ·                                                                                                ·
-1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                ·
-1  ·       render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                ·
-1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                ·
-2  render  ·         ·                                                                                                  (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                    d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
-2  ·       render 0  (k)[int]                                                                                           ·                                                                                                ·
-2  ·       render 1  (d)[decimal]                                                                                       ·                                                                                                ·
-2  ·       render 2  (d)[decimal]                                                                                       ·                                                                                                ·
-2  ·       render 3  (v)[int]                                                                                           ·                                                                                                ·
-2  ·       render 4  ('a')[string]                                                                                      ·                                                                                                ·
-2  ·       render 5  (100)[int]                                                                                         ·                                                                                                ·
-3  scan    ·         ·                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
-3  ·       table     kv@primary                                                                                         ·                                                                                                ·
-3  ·       spans     ALL                                                                                                ·                                                                                                ·
+sort                 0  sort    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
+ │                   0  ·       order     +variance,+k                                                                                       ·                                                            ·
+ └── window          1  window  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
+      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                        ·                                                            ·
+      │              1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                            ·
+      │              1  ·       render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                            ·
+      │              1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                            ·
+      └── render     2  render  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
+           │         2  ·       render 0  (k)[int]                                                                                           ·                                                            ·
+           │         2  ·       render 1  (d)[decimal]                                                                                       ·                                                            ·
+           │         2  ·       render 2  (d)[decimal]                                                                                       ·                                                            ·
+           │         2  ·       render 3  (v)[int]                                                                                           ·                                                            ·
+           │         2  ·       render 4  ('a')[string]                                                                                      ·                                                            ·
+           │         2  ·       render 5  (100)[int]                                                                                         ·                                                            ·
+           └── scan  3  scan    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
+·                    3  ·       table     kv@primary                                                                                         ·                                                            ·
+·                    3  ·       spans     ALL                                                                                                ·                                                            ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
-0  sort    ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                               ·
-0  ·       order        +variance                                                                                                      ·                                                                                                ·
-1  window  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)             ·
-1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                                    ·                                                                                                ·
-1  ·       window 1     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                ·
-1  ·       render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                ·
-1  ·       render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                ·
-2  render  ·            ·                                                                                                              (max int, d decimal, d decimal, v int, "'a'" string, "100" int)                                  "'a'"=CONST; "100"=CONST
-2  ·       render 0     (max)[int]                                                                                                     ·                                                                                                ·
-2  ·       render 1     (d)[decimal]                                                                                                   ·                                                                                                ·
-2  ·       render 2     (d)[decimal]                                                                                                   ·                                                                                                ·
-2  ·       render 3     (v)[int]                                                                                                       ·                                                                                                ·
-2  ·       render 4     ('a')[string]                                                                                                  ·                                                                                                ·
-2  ·       render 5     (100)[int]                                                                                                     ·                                                                                                ·
-3  group   ·            ·                                                                                                              (max int, d decimal, d decimal, v int)                                                           ·
-3  ·       aggregate 0  (max((k)[int]))[int]                                                                                           ·                                                                                                ·
-3  ·       aggregate 1  (d)[decimal]                                                                                                   ·                                                                                                ·
-3  ·       aggregate 2  (d)[decimal]                                                                                                   ·                                                                                                ·
-3  ·       aggregate 3  (v)[int]                                                                                                       ·                                                                                                ·
-3  ·       group by     @1-@2                                                                                                          ·                                                                                                ·
-4  render  ·            ·                                                                                                              (d decimal, v int, k int)                                                                        k!=NULL; key(k)
-4  ·       render 0     (d)[decimal]                                                                                                   ·                                                                                                ·
-4  ·       render 1     (v)[int]                                                                                                       ·                                                                                                ·
-4  ·       render 2     (k)[int]                                                                                                       ·                                                                                                ·
-5  scan    ·            ·                                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
-5  ·       table        kv@primary                                                                                                     ·                                                                                                ·
-5  ·       spans        ALL                                                                                                            ·                                                                                                ·
+sort                           0  sort    ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
+ │                             0  ·       order        +variance                                                                                                      ·                                                                   ·
+ └── window                    1  window  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
+      │                        1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                                    ·                                                                   ·
+      │                        1  ·       window 1     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                   ·
+      │                        1  ·       render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                   ·
+      │                        1  ·       render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                   ·
+      └── render               2  render  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
+           │                   2  ·       render 0     (max)[int]                                                                                                     ·                                                                   ·
+           │                   2  ·       render 1     (d)[decimal]                                                                                                   ·                                                                   ·
+           │                   2  ·       render 2     (d)[decimal]                                                                                                   ·                                                                   ·
+           │                   2  ·       render 3     (v)[int]                                                                                                       ·                                                                   ·
+           │                   2  ·       render 4     ('a')[string]                                                                                                  ·                                                                   ·
+           │                   2  ·       render 5     (100)[int]                                                                                                     ·                                                                   ·
+           └── group           3  group   ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
+                │              3  ·       aggregate 0  (max((k)[int]))[int]                                                                                           ·                                                                   ·
+                │              3  ·       aggregate 1  (d)[decimal]                                                                                                   ·                                                                   ·
+                │              3  ·       aggregate 2  (d)[decimal]                                                                                                   ·                                                                   ·
+                │              3  ·       aggregate 3  (v)[int]                                                                                                       ·                                                                   ·
+                │              3  ·       group by     @1-@2                                                                                                          ·                                                                   ·
+                └── render     4  render  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
+                     │         4  ·       render 0     (d)[decimal]                                                                                                   ·                                                                   ·
+                     │         4  ·       render 1     (v)[int]                                                                                                       ·                                                                   ·
+                     │         4  ·       render 2     (k)[int]                                                                                                       ·                                                                   ·
+                     └── scan  5  scan    ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
+·                              5  ·       table        kv@primary                                                                                                     ·                                                                   ·
+·                              5  ·       spans        ALL                                                                                                            ·                                                                   ·
 
-query ITTTTT
+query TITTTTT
 EXPLAIN (TYPES) SELECT MAX(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
 ----
-0  sort    ·            ·                                                                            (max int, stddev decimal)                                                                        +max
-0  ·       order        +max                                                                         ·                                                                                                ·
-1  window  ·            ·                                                                            (max int, stddev decimal)                                                                        ·
-1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
-1  ·       render 1     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
-2  render  ·            ·                                                                            (max int, d decimal, v int, "'a'" string)                                                        "'a'"=CONST
-2  ·       render 0     (max)[int]                                                                   ·                                                                                                ·
-2  ·       render 1     (d)[decimal]                                                                 ·                                                                                                ·
-2  ·       render 2     (v)[int]                                                                     ·                                                                                                ·
-2  ·       render 3     ('a')[string]                                                                ·                                                                                                ·
-3  group   ·            ·                                                                            (max int, d decimal, v int)                                                                      ·
-3  ·       aggregate 0  (max((k)[int]))[int]                                                         ·                                                                                                ·
-3  ·       aggregate 1  (d)[decimal]                                                                 ·                                                                                                ·
-3  ·       aggregate 2  (v)[int]                                                                     ·                                                                                                ·
-3  ·       group by     @1-@2                                                                        ·                                                                                                ·
-4  render  ·            ·                                                                            (d decimal, v int, k int)                                                                        k!=NULL; key(k)
-4  ·       render 0     (d)[decimal]                                                                 ·                                                                                                ·
-4  ·       render 1     (v)[int]                                                                     ·                                                                                                ·
-4  ·       render 2     (k)[int]                                                                     ·                                                                                                ·
-5  scan    ·            ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
-5  ·       table        kv@primary                                                                   ·                                                                                                ·
-5  ·       spans        ALL                                                                          ·                                                                                                ·
+sort                           0  sort    ·            ·                                                                            (max int, stddev decimal)  +max
+ │                             0  ·       order        +max                                                                         ·                          ·
+ └── window                    1  window  ·            ·                                                                            (max int, stddev decimal)  +max
+      │                        1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                          ·
+      │                        1  ·       render 1     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                          ·
+      └── render               2  render  ·            ·                                                                            (max int, stddev decimal)  +max
+           │                   2  ·       render 0     (max)[int]                                                                   ·                          ·
+           │                   2  ·       render 1     (d)[decimal]                                                                 ·                          ·
+           │                   2  ·       render 2     (v)[int]                                                                     ·                          ·
+           │                   2  ·       render 3     ('a')[string]                                                                ·                          ·
+           └── group           3  group   ·            ·                                                                            (max int, stddev decimal)  +max
+                │              3  ·       aggregate 0  (max((k)[int]))[int]                                                         ·                          ·
+                │              3  ·       aggregate 1  (d)[decimal]                                                                 ·                          ·
+                │              3  ·       aggregate 2  (v)[int]                                                                     ·                          ·
+                │              3  ·       group by     @1-@2                                                                        ·                          ·
+                └── render     4  render  ·            ·                                                                            (max int, stddev decimal)  +max
+                     │         4  ·       render 0     (d)[decimal]                                                                 ·                          ·
+                     │         4  ·       render 1     (v)[int]                                                                     ·                          ·
+                     │         4  ·       render 2     (k)[int]                                                                     ·                          ·
+                     └── scan  5  scan    ·            ·                                                                            (max int, stddev decimal)  +max
+·                              5  ·       table        kv@primary                                                                   ·                          ·
+·                              5  ·       spans        ALL                                                                          ·                          ·
 
 statement OK
 INSERT INTO kv VALUES

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -877,7 +877,7 @@ func TestPGPreparedQuery(t *testing.T) {
 		},
 		// #14238
 		"EXPLAIN SELECT 1": {
-			baseTest.SetArgs().Results(0, "render", "", "").Results(1, "emptyrow", "", ""),
+			baseTest.SetArgs().Results("render", "", "").Results(" └── emptyrow", "", ""),
 		},
 		// #14245
 		"SELECT 1::oid = $1": {

--- a/pkg/util/treeprinter/tree_printer_test.go
+++ b/pkg/util/treeprinter/tree_printer_test.go
@@ -23,25 +23,38 @@ func TestTreePrinter(t *testing.T) {
 	n := New()
 
 	r := n.Child("root")
+	r.AddEmptyLine()
 	n1 := r.Childf("%d", 1)
 	n1.Child("1.1")
 	n12 := n1.Child("1.2")
+	r.AddEmptyLine()
+	r.AddEmptyLine()
 	n12.Child("1.2.1")
+	r.AddEmptyLine()
 	n12.Child("1.2.2")
-	n1.Child("1.3").Child("1.3.1")
+	n13 := n1.Child("1.3")
+	n13.AddEmptyLine()
+	n13.Child("1.3.1")
+	n13.AddEmptyLine()
 	n1.Child("1.4")
 	r.Child("2")
 
 	res := n.String()
 	exp := `
 root
+ │
  ├── 1
  │    ├── 1.1
  │    ├── 1.2
+ │    │    │
+ │    │    │
  │    │    ├── 1.2.1
+ │    │    │
  │    │    └── 1.2.2
  │    ├── 1.3
+ │    │    │
  │    │    └── 1.3.1
+ │    │
  │    └── 1.4
  └── 2
 `


### PR DESCRIPTION
I am putting this out there to see what folks think. I think it makes the output more understandable, but there may be downsides (?)

Before:

```
0  limit       ·      ·
1  index-join  ·      ·
2  revscan     ·      ·
2  ·           table  test2@test2_k_key
2  ·           spans  /!NULL-/"100"/PrefixEnd
2  ·           limit  20
2  scan        ·      ·
2  ·           table  test2@primary
```

After:
```
limit              ·      ·
 └── index-join    ·      ·
      ├── revscan  ·      ·
      │            table  test2@test2_k_key
      │            spans  /!NULL-/"100"/PrefixEnd
      │            limit  20
      └── scan     ·      ·
·                  table  test2@primary
```

Release note: improved the output of EXPLAIN to show the plan tree structure.