### PR TITLE
sqlccl: actually split during distributed IMPORT

### DIFF
--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -692,6 +692,18 @@ func TestImportStmt(t *testing.T) {
 			if result != expectedNulls {
 				t.Fatalf("expected %d rows, got %d", expectedNulls, result)
 			}
+
+			// Verify sstsize created > 1 SST files.
+			if tc.name == "schema-in-file-sstsize-dist" {
+				pattern := filepath.Join(dir, fmt.Sprintf("%d", i), "*.sst")
+				matches, err := filepath.Glob(pattern)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(matches) < 2 {
+					t.Fatal("expected > 1 SST files")
+				}
+			}
 		})
 	}
 

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -83,7 +83,7 @@ func newCallbackResultWriter(
 
 // StatementType implements the rowResultWriter interface.
 func (callbackResultWriter) StatementType() tree.StatementType {
-	return tree.Ack
+	return tree.Rows
 }
 
 // IncrementRowsAffected implements the rowResultWriter interface.


### PR DESCRIPTION
Due to the use of the Ack statement type, distsql was not ever calling
AddRow, thus only a single span was being created. This would result
in distributed IMPORT creating a single, huge sst file which could
OOM a node if a very large import was being done.

Release note: None