### PR TITLE
sqlmigrations: persist table desc format upgrades

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -362,12 +362,20 @@ func (ts *TestServer) ExpectedInitialRangeCount() (int, error) {
 // assuming no additional information is added outside of the normal bootstrap
 // process.
 func ExpectedInitialRangeCount(db *client.DB) (int, error) {
-	_, migrationRangeCount, err := migrations.AdditionalInitialDescriptors(
-		context.Background(), db)
+	descriptorIDs, err := migrations.ExpectedDescriptorIDs(context.Background(), db)
 	if err != nil {
-		return 0, errors.Wrap(err, "counting initial migration ranges")
+		return 0, err
 	}
-	return GetBootstrapSchema().InitialRangeCount() + migrationRangeCount, nil
+	maxDescriptorID := descriptorIDs[len(descriptorIDs)-1]
+
+	// System table splits occur at every possible table boundary between the end
+	// of the system config ID space (keys.MaxSystemConfigDescID) and the system
+	// table with the maximum ID (maxDescriptorID), even when an ID within the
+	// span does not have an associated descriptor.
+	systemTableSplits := int(maxDescriptorID - keys.MaxSystemConfigDescID)
+
+	// `n` splits create `n+1` ranges.
+	return len(config.StaticSplits()) + systemTableSplits + 1, nil
 }
 
 // WaitForInitialSplits waits for the server to complete its expected initial

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -100,12 +99,11 @@ func TestDatabaseDescriptor(t *testing.T) {
 	if kvs, err := kvDB.Scan(ctx, start, start.PrefixEnd(), 0); err != nil {
 		t.Fatal(err)
 	} else {
-		migrationDescriptors, _, err := sqlmigrations.AdditionalInitialDescriptors(ctx, kvDB)
+		descriptorIDs, err := sqlmigrations.ExpectedDescriptorIDs(ctx, kvDB)
 		if err != nil {
 			t.Fatal(err)
 		}
-		e := server.GetBootstrapSchema().SystemDescriptorCount() + migrationDescriptors
-		if a := len(kvs); a != e {
+		if e, a := len(descriptorIDs), len(kvs); a != e {
 			t.Fatalf("expected %d keys to have been written, found %d keys", e, a)
 		}
 	}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -435,11 +435,6 @@ func (e *Executor) Start(
 	startupSession.Finish(e)
 }
 
-// GetVirtualTabler retrieves the VirtualTabler reference for this executor.
-func (e *Executor) GetVirtualTabler() VirtualTabler {
-	return &e.virtualSchemas
-}
-
 // SetDistSQLSpanResolver changes the SpanResolver used for DistSQL. It is the
 // caller's responsibility to make sure no queries are being run with DistSQL at
 // the same time.

--- a/pkg/sql/sqlbase/metadata.go
+++ b/pkg/sql/sqlbase/metadata.go
@@ -20,7 +20,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -176,16 +175,13 @@ func (ms MetadataSchema) GetInitialValues() []roachpb.KeyValue {
 	return ret
 }
 
-// InitialRangeCount returns the number of ranges that would be installed if
-// this metadata schema were installed on a fresh cluster and nothing else. Most
-// clusters will have additional ranges installed by migrations, so this
-// function should be used when only a lower bound, and not an exact count, is
-// needed. See server.ExpectedInitialRangeCount() for a count that includes
-// migrations.
-func (ms MetadataSchema) InitialRangeCount() int {
-	// The number of initial ranges is determined by the number of static splits,
-	// plus the number of non-config system tables. (System config tables all
-	// share a range, while each non-config table is split into its own range.)
-	// Note that `n` static splits create `n+1` ranges.
-	return len(config.StaticSplits()) + 1 + len(ms.descs) - ms.configs
+// DescriptorIDs returns the descriptor IDs present in the metadata schema in
+// sorted order.
+func (ms MetadataSchema) DescriptorIDs() IDs {
+	descriptorIDs := IDs{}
+	for _, md := range ms.descs {
+		descriptorIDs = append(descriptorIDs, md.desc.GetID())
+	}
+	sort.Sort(descriptorIDs)
+	return descriptorIDs
 }

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -47,11 +47,6 @@ var (
 	leaseRefreshInterval = leaseDuration / 5
 )
 
-const (
-	addDefaultMetaAndLivenessZoneConfigsName = "add default .meta and .liveness zone configs"
-	addSystemUsersIsRoleAndCreateAdminRole   = "add system.users isRole column and create admin role"
-)
-
 // MigrationManagerTestingKnobs contains testing knobs.
 type MigrationManagerTestingKnobs struct {
 	// DisableMigrations skips all migrations.
@@ -125,7 +120,7 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		newDescriptorIDs: []sqlbase.ID{keys.LocationsTableID},
 	},
 	{
-		name:   addDefaultMetaAndLivenessZoneConfigsName,
+		name:   "add default .meta and .liveness zone configs",
 		workFn: addDefaultMetaAndLivenessZoneConfigs,
 	},
 	{
@@ -134,7 +129,7 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		newDescriptorIDs: []sqlbase.ID{keys.RoleMembersTableID},
 	},
 	{
-		name:         addSystemUsersIsRoleAndCreateAdminRole,
+		name:         "add system.users isRole column and create admin role",
 		workFn:       addRoles,
 		doesBackfill: true,
 	},

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -32,10 +32,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -360,6 +360,85 @@ func TestLeaseExpiration(t *testing.T) {
 	}
 }
 
+// isolatedMigrationTest assists in testing the effects of one migration in
+// isolation.
+//
+// It boots a test server after removing the migration under test from the list
+// of automatically-run migrations. The migration can be triggered manually by
+// calling the runMigration method; its effects can be verified by inspecting
+// the state before and after via the exposed KV and SQL interfaces.
+type isolatedMigrationTest struct {
+	oldMigrations []migrationDescriptor
+	migration     migrationDescriptor
+	server        serverutils.TestServerInterface
+	sqlDB         *sqlutils.SQLRunner
+	kvDB          *client.DB
+	memMetrics    *sql.MemoryMetrics
+}
+
+// makeIsolatedMigrationTest creates an IsolatedMigrationTest to test the
+// migration whose name starts with namePrefix. It fails the test if the number
+// of migrations that match namePrefix is not exactly one.
+//
+// The caller is responsible for calling the test's close method at the end of
+// the test.
+func makeIsolatedMigrationTest(
+	ctx context.Context, t testing.TB, namePrefix string,
+) isolatedMigrationTest {
+	t.Helper()
+
+	var migration migrationDescriptor
+	oldMigrations := append([]migrationDescriptor(nil), backwardCompatibleMigrations...)
+	backwardCompatibleMigrations = []migrationDescriptor{}
+	for _, m := range oldMigrations {
+		if strings.HasPrefix(m.name, namePrefix) {
+			migration = m
+			continue
+		}
+		backwardCompatibleMigrations = append(backwardCompatibleMigrations, m)
+	}
+	if n := len(oldMigrations) - len(backwardCompatibleMigrations); n != 1 {
+		t.Fatalf("expected prefix %q to match exactly one migration, but matched %d", namePrefix, n)
+	}
+
+	memMetrics := sql.MakeMemMetrics("migration-test-internal", time.Minute)
+
+	return isolatedMigrationTest{
+		migration:     migration,
+		oldMigrations: oldMigrations,
+		memMetrics:    &memMetrics,
+	}
+}
+
+// start starts a test server with the given serverArgs.
+func (mt *isolatedMigrationTest) start(t testing.TB, serverArgs base.TestServerArgs) {
+	server, sqlDB, kvDB := serverutils.StartServer(t, serverArgs)
+	mt.server = server
+	mt.sqlDB = sqlutils.MakeSQLRunner(sqlDB)
+	mt.kvDB = kvDB
+}
+
+// runMigration triggers a manual run of the migration under test. It does not
+// mark the migration as completed, so subsequent calls will cause the migration
+// to be re-executed. This is useful for verifying idempotency.
+//
+// You must call start before calling runMigration.
+func (mt *isolatedMigrationTest) runMigration(ctx context.Context) error {
+	return mt.migration.workFn(ctx, runner{
+		db:          mt.kvDB,
+		memMetrics:  mt.memMetrics,
+		sqlExecutor: mt.server.Executor().(*sql.Executor),
+	})
+}
+
+// close stops the test server and restores package-global state.
+func (mt *isolatedMigrationTest) close(ctx context.Context) {
+	if mt.server != nil {
+		mt.server.Stopper().Stop(ctx)
+	}
+	backwardCompatibleMigrations = mt.oldMigrations
+}
+
 func TestCreateSystemTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
@@ -373,78 +452,62 @@ func TestCreateSystemTable(t *testing.T) {
 	settingsDescKey := sqlbase.MakeDescMetadataKey(settingsDesc.GetID())
 	settingsDescVal := sqlbase.WrapDescriptor(&settingsDesc)
 
-	// Start up a test server without running the system.jobs migration.
-	newMigrations := []migrationDescriptor{}
-	for _, m := range backwardCompatibleMigrations {
-		if strings.HasPrefix(m.name, "create system.jobs") {
-			continue
-		}
+	mt := makeIsolatedMigrationTest(ctx, t, "create system.jobs table")
+	defer mt.close(ctx)
+
+	for i, m := range backwardCompatibleMigrations {
 		if m.doesBackfill {
 			// Disable all migrations after (and including) a backfill, the backfill
 			// needs the jobs table and following migrations may depend on these.
+			backwardCompatibleMigrations = backwardCompatibleMigrations[:i]
 			break
 		}
-		newMigrations = append(newMigrations, m)
 	}
-	defer func(prev []migrationDescriptor) { backwardCompatibleMigrations = prev }(backwardCompatibleMigrations)
-	backwardCompatibleMigrations = newMigrations
 
-	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
+	mt.start(t, base.TestServerArgs{})
 
 	// Verify that the system.jobs keys were not written, but the system.settings
 	// keys were. This verifies that the migration system table migrations work.
-	if kv, err := kvDB.Get(ctx, jobsNameKey); err != nil {
+	if kv, err := mt.kvDB.Get(ctx, jobsNameKey); err != nil {
 		t.Error(err)
 	} else if kv.Exists() {
 		t.Errorf("expected %q not to exist, got %v", jobsNameKey, kv)
 	}
-	if kv, err := kvDB.Get(ctx, jobsDescKey); err != nil {
+	if kv, err := mt.kvDB.Get(ctx, jobsDescKey); err != nil {
 		t.Error(err)
 	} else if kv.Exists() {
 		t.Errorf("expected %q not to exist, got %v", jobsDescKey, kv)
 	}
-	if kv, err := kvDB.Get(ctx, settingsNameKey); err != nil {
+	if kv, err := mt.kvDB.Get(ctx, settingsNameKey); err != nil {
 		t.Error(err)
 	} else if !kv.Exists() {
 		t.Errorf("expected %q to exist, got that it doesn't exist", settingsNameKey)
 	}
 	var descriptor sqlbase.Descriptor
-	if err := kvDB.GetProto(ctx, settingsDescKey, &descriptor); err != nil {
+	if err := mt.kvDB.GetProto(ctx, settingsDescKey, &descriptor); err != nil {
 		t.Error(err)
 	} else if !proto.Equal(settingsDescVal, &descriptor) {
 		t.Errorf("expected %v for key %q, got %v", settingsDescVal, settingsDescKey, descriptor)
 	}
 
-	// Run the system.jobs migration outside the context of a migration manager
-	// such that its work gets done but the key indicating it's been completed
-	// doesn't get written.
-	if err := createJobsTable(ctx, runner{db: kvDB}); err != nil {
+	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 
 	// Verify that the appropriate keys were written.
-	if kv, err := kvDB.Get(ctx, jobsNameKey); err != nil {
+	if kv, err := mt.kvDB.Get(ctx, jobsNameKey); err != nil {
 		t.Error(err)
 	} else if !kv.Exists() {
 		t.Errorf("expected %q to exist, got that it doesn't exist", jobsNameKey)
 	}
-	if err := kvDB.GetProto(ctx, jobsDescKey, &descriptor); err != nil {
+	if err := mt.kvDB.GetProto(ctx, jobsDescKey, &descriptor); err != nil {
 		t.Error(err)
 	} else if !proto.Equal(jobsDescVal, &descriptor) {
 		t.Errorf("expected %v for key %q, got %v", jobsDescVal, jobsDescKey, descriptor)
 	}
 
-	// Finally, try running both migrations and make sure they still succeed.
-	// This verifies the idempotency of the migration, since the system.jobs
-	// migration will get rerun here.
-	mgr := NewManager(s.Stopper(), kvDB, nil, s.Clock(), MigrationManagerTestingKnobs{}, nil, "clientID")
-	backwardCompatibleMigrations = append(backwardCompatibleMigrations, migrationDescriptor{
-		name:             "create system.jobs table",
-		workFn:           createJobsTable,
-		newDescriptorIDs: sqlbase.IDs{keys.JobsTableID},
-	})
-	if err := mgr.EnsureMigrations(ctx); err != nil {
+	// Verify the idempotency of the migration.
+	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -453,39 +516,13 @@ func TestUpdateViewDependenciesMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	// remove the view update migration so we can test its effects.
-	newMigrations := make([]migrationDescriptor, 0, len(backwardCompatibleMigrations))
-	for _, m := range backwardCompatibleMigrations {
-		if strings.HasPrefix(m.name, "establish conservative dependencies for views") {
-			// Remove this migration.
-			// This is safe because it neither adds descriptors nor ranges.
-			continue
-		}
-		newMigrations = append(newMigrations, m)
-	}
+	mt := makeIsolatedMigrationTest(ctx, t, "establish conservative dependencies for views")
+	defer mt.close(ctx)
 
-	// We also hijack the migration process to capture the SQL memory
-	// metric object, needed below.
-	var memMetrics *sql.MemoryMetrics
-	newMigrations = append(newMigrations,
-		migrationDescriptor{
-			name: "capture mem metrics",
-			workFn: func(ctx context.Context, r runner) error {
-				memMetrics = r.memMetrics
-				return nil
-			},
-		})
+	mt.start(t, base.TestServerArgs{})
 
-	defer func(prev []migrationDescriptor) { backwardCompatibleMigrations = prev }(backwardCompatibleMigrations)
-	backwardCompatibleMigrations = newMigrations
-
-	t.Log("starting server")
-
-	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
 	t.Log("create test tables")
-
-	const createStmts = `
+	mt.sqlDB.Exec(t, `
 CREATE DATABASE test;
 CREATE DATABASE test2;
 SET DATABASE=test;
@@ -505,14 +542,11 @@ CREATE VIEW test2.v5 AS SELECT x FROM w;
 CREATE TABLE x(x INT);
 CREATE INDEX y ON x(x);
 CREATE VIEW v6 AS SELECT x FROM x@y;
-`
-	if _, err := sqlDB.Exec(createStmts); err != nil {
-		t.Fatal(err)
-	}
+`)
 
 	testDesc := []struct {
-		dbName tree.Name
-		tname  tree.Name
+		dbName string
+		tname  string
 		desc   *sqlbase.TableDescriptor
 	}{
 		{"test", "t", nil},
@@ -524,27 +558,13 @@ CREATE VIEW v6 AS SELECT x FROM x@y;
 	}
 
 	t.Log("fetch descriptors")
-
-	e := s.Executor().(*sql.Executor)
-	vt := e.GetVirtualTabler()
-
-	if err := kvDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		for i := range testDesc {
-			desc, err := sql.MustGetTableOrViewDesc(ctx, txn, vt,
-				&tree.TableName{DatabaseName: testDesc[i].dbName, TableName: testDesc[i].tname}, true)
-			if err != nil {
-				return err
-			}
-			testDesc[i].desc = desc
-		}
-		return nil
-	}); err != nil {
-		t.Fatal(err)
+	for i, td := range testDesc {
+		testDesc[i].desc = sqlbase.GetTableDescriptor(mt.kvDB, td.dbName, td.tname)
 	}
 
 	// Now, corrupt the descriptors by breaking their dependency information.
 	t.Log("break descriptors")
-	if err := kvDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+	if err := mt.kvDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		if err := txn.SetSystemConfigTrigger(); err != nil {
 			return err
 		}
@@ -568,22 +588,18 @@ CREATE VIEW v6 AS SELECT x FROM x@y;
 	// Break further by deleting the referenced tables. This has become possible
 	// because the dependency links have been broken above.
 	t.Log("delete tables")
-
-	if _, err := sqlDB.Exec(`
+	mt.sqlDB.Exec(t, `
 DROP TABLE test.t;
 DROP VIEW test.v1;
 DROP TABLE test.u;
 DROP TABLE test.w;
-DROP INDEX test.x@y;
-`); err != nil {
-		t.Fatal(err)
-	}
+DROP INDEX test.x@y;`)
 
 	// Check the views are effectively broken.
 	t.Log("check views are broken")
 
 	for _, vname := range []string{"test.v2", "test.v3", "test2.v5", "test.v6"} {
-		_, err := sqlDB.Exec(fmt.Sprintf(`TABLE %s`, vname))
+		_, err := mt.sqlDB.DB.Exec(fmt.Sprintf(`TABLE %s`, vname))
 		if !testutils.IsError(err,
 			`relation ".*" does not exist|index ".*" not found|table is being dropped`) {
 			t.Fatalf("%s: unexpected error: %v", vname, err)
@@ -593,21 +609,16 @@ DROP INDEX test.x@y;
 	// Restore missing dependencies for the rest of the test.
 	t.Log("restore dependencies")
 
-	if _, err := sqlDB.Exec(`
+	mt.sqlDB.Exec(t, `
 CREATE TABLE test.t(x INT, y INT);
 CREATE TABLE test.u(x INT, y INT);
 CREATE TABLE test.w(x INT);
 CREATE VIEW test.v1 AS SELECT x FROM test.t WHERE false;
 CREATE INDEX y ON test.x(x);
-`); err != nil {
-		t.Fatal(err)
-	}
+`)
 
-	// Run the migration outside the context of a migration manager
-	// such that its work gets done but the key indicating it's been completed
-	// doesn't get written.
-	t.Log("fix view deps manually")
-	if err := repopulateViewDeps(ctx, runner{db: kvDB, sqlExecutor: e}); err != nil {
+	t.Log("run migration")
+	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -616,14 +627,12 @@ CREATE INDEX y ON test.x(x);
 
 	// Check the views can be queried.
 	for _, vname := range []string{"test.v1", "test.v2", "test.v3", "test.v4", "test2.v5", "test.v6"} {
-		if _, err := sqlDB.Exec(fmt.Sprintf("TABLE %s", vname)); err != nil {
-			t.Fatal(err)
-		}
+		mt.sqlDB.Exec(t, fmt.Sprintf("TABLE %s", vname))
 	}
 
 	// Check that the tables cannot be dropped any more.
 	for _, tn := range []string{"TABLE test.t", "TABLE test.u", "TABLE test.w", "INDEX test.x@y"} {
-		_, err := sqlDB.Exec(fmt.Sprintf(`DROP %s`, tn))
+		_, err := mt.sqlDB.DB.Exec(fmt.Sprintf(`DROP %s`, tn))
 		if !testutils.IsError(err,
 			`cannot drop (relation|index) .* because view .* depends on it`) {
 			t.Fatalf("unexpected error: %v", err)
@@ -632,14 +641,8 @@ CREATE INDEX y ON test.x(x);
 
 	// Finally, try running the migration and make sure it still succeeds.
 	// This verifies the idempotency of the migration.
-	t.Log("run migration")
-
-	mgr := NewManager(s.Stopper(), kvDB, e, s.Clock(), MigrationManagerTestingKnobs{}, memMetrics, "clientID")
-	backwardCompatibleMigrations = append(backwardCompatibleMigrations, migrationDescriptor{
-		name:   "repopulate view dependencies",
-		workFn: repopulateViewDeps,
-	})
-	if err := mgr.EnsureMigrations(ctx); err != nil {
+	t.Log("run migration again")
+	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -648,39 +651,22 @@ func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	// Remove the migration so we can test its effects.
-	newMigrations := make([]migrationDescriptor, 0, len(backwardCompatibleMigrations))
-	for _, m := range backwardCompatibleMigrations {
-		if m.name == addDefaultMetaAndLivenessZoneConfigsName {
-			continue
-		}
-		newMigrations = append(newMigrations, m)
-	}
+	mt := makeIsolatedMigrationTest(ctx, t, "add default .meta and .liveness zone configs")
+	defer mt.close(ctx)
 
-	defer func(prev []migrationDescriptor) {
-		backwardCompatibleMigrations = prev
-	}(backwardCompatibleMigrations)
-	backwardCompatibleMigrations = newMigrations
+	mt.start(t, base.TestServerArgs{})
 
-	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
 	ids := []uint32{keys.MetaRangesID, keys.LivenessRangesID}
-
 	for _, id := range ids {
 		var s string
-		err := sqlDB.QueryRow(`SELECT config FROM system.zones WHERE id = $1`, id).Scan(&s)
+		err := mt.sqlDB.DB.QueryRow(`SELECT config FROM system.zones WHERE id = $1`, id).Scan(&s)
 		if err != gosql.ErrNoRows {
 			t.Fatalf("expected no rows, but found %v", err)
 		}
 	}
 
-	r := runner{
-		db:          kvDB,
-		sqlExecutor: s.Executor().(*sql.Executor),
-		memMetrics:  &sql.MemoryMetrics{},
-	}
 	// Run the migration and verify its effects.
-	if err := addDefaultMetaAndLivenessZoneConfigs(ctx, r); err != nil {
+	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -688,10 +674,7 @@ func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
 		t.Helper()
 
 		var s string
-		err := sqlDB.QueryRow(`SELECT config FROM system.zones WHERE id = $1`, id).Scan(&s)
-		if err != nil {
-			t.Fatal(err)
-		}
+		mt.sqlDB.QueryRow(t, `SELECT config FROM system.zones WHERE id = $1`, id).Scan(&s)
 		var zone config.ZoneConfig
 		if err := protoutil.Unmarshal([]byte(s), &zone); err != nil {
 			t.Fatal(err)
@@ -709,10 +692,7 @@ func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
 	checkZoneConfig(keys.LivenessRangesID, expectedLiveness)
 
 	deleteZoneConfig := func(id int) {
-		const stmt = `DELETE FROM system.zones WHERE id=$1`
-		if _, err := sqlDB.Exec(stmt, id); err != nil {
-			t.Fatal(err)
-		}
+		mt.sqlDB.Exec(t, `DELETE FROM system.zones WHERE id=$1`, id)
 	}
 
 	setZoneConfig := func(id int, zone config.ZoneConfig) {
@@ -720,10 +700,7 @@ func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		const stmt = `UPSERT INTO system.zones (id, config) VALUES ($1, $2)`
-		if _, err := sqlDB.Exec(stmt, id, buf); err != nil {
-			t.Fatal(err)
-		}
+		mt.sqlDB.Exec(t, `UPSERT INTO system.zones (id, config) VALUES ($1, $2)`, id, buf)
 	}
 
 	// Set configs for the .meta and .system zones and clear the zone config for
@@ -733,7 +710,7 @@ func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
 	setZoneConfig(keys.MetaRangesID, testZone)
 	setZoneConfig(keys.SystemRangesID, testZone)
 	deleteZoneConfig(keys.LivenessRangesID)
-	if err := addDefaultMetaAndLivenessZoneConfigs(ctx, r); err != nil {
+	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 	checkZoneConfig(keys.MetaRangesID, testZone)
@@ -746,7 +723,7 @@ func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
 	setZoneConfig(keys.MetaRangesID, testZone)
 	setZoneConfig(keys.SystemRangesID, testZone)
 	deleteZoneConfig(keys.LivenessRangesID)
-	if err := addDefaultMetaAndLivenessZoneConfigs(ctx, r); err != nil {
+	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 	checkZoneConfig(keys.MetaRangesID, testZone)
@@ -761,7 +738,7 @@ func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
 	setZoneConfig(keys.SystemRangesID, testZone)
 	deleteZoneConfig(keys.MetaRangesID)
 	deleteZoneConfig(keys.LivenessRangesID)
-	if err := addDefaultMetaAndLivenessZoneConfigs(ctx, r); err != nil {
+	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 	testZone.GC.TTLSeconds = 60 * 60
@@ -774,7 +751,7 @@ func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
 	testZone.RangeMaxBytes = 863
 	testZone.GC.TTLSeconds = config.DefaultZoneConfig().GC.TTLSeconds
 	setZoneConfig(keys.MetaRangesID, testZone)
-	if err := addDefaultMetaAndLivenessZoneConfigs(ctx, r); err != nil {
+	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 	testZone.GC.TTLSeconds = 60 * 60
@@ -785,40 +762,19 @@ func TestAdminUserExists(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	// Remove the migration so we can test its effects.
-	newMigrations := make([]migrationDescriptor, 0, len(backwardCompatibleMigrations))
-	for _, m := range backwardCompatibleMigrations {
-		if m.name == addSystemUsersIsRoleAndCreateAdminRole {
-			continue
-		}
-		newMigrations = append(newMigrations, m)
-	}
-	defer func(prev []migrationDescriptor) {
-		backwardCompatibleMigrations = prev
-	}(backwardCompatibleMigrations)
-	backwardCompatibleMigrations = newMigrations
+	mt := makeIsolatedMigrationTest(ctx, t, "add system.users isRole column and create admin role")
+	defer mt.close(ctx)
 
-	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
+	mt.start(t, base.TestServerArgs{})
 
 	// Create a user named "admin". We have to do a manual insert as "CREATE USER"
 	// knows about "isRole", but the migration hasn't run yet.
-	if _, err := sqlDB.Exec(
-		`INSERT INTO system.users (username, "hashedPassword") VALUES ($1, '')`,
-		sqlbase.AdminRole,
-	); err != nil {
-		t.Fatal(err)
-	}
+	mt.sqlDB.Exec(t, `INSERT INTO system.users (username, "hashedPassword") VALUES ($1, '')`,
+		sqlbase.AdminRole)
 
-	r := runner{
-		db:          kvDB,
-		sqlExecutor: s.Executor().(*sql.Executor),
-		memMetrics:  &sql.MemoryMetrics{},
-	}
-	// Run the migration and verify its effects.
-	err := addRoles(ctx, r)
-	if e := `cannot create role "admin", a user with that name exists.`; !testutils.IsError(err, e) {
-		t.Errorf("expected error %s, got %s", e, err)
+	e := `cannot create role "admin", a user with that name exists.`
+	if err := mt.runMigration(ctx); !testutils.IsError(err, e) {
+		t.Errorf("expected error %q, got %q", err, e)
 	}
 }
 

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -941,3 +941,54 @@ func TestReplayMigrations(t *testing.T) {
 		}
 	}
 }
+
+func TestExpectedInitialRangeCount(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	testutils.SucceedsSoon(t, func() error {
+		lastMigration := backwardCompatibleMigrations[len(backwardCompatibleMigrations)-1]
+		if _, err := kvDB.Get(ctx, migrationKey(lastMigration)); err != nil {
+			return errors.New("last migration has not completed")
+		}
+
+		sysCfg, ok := s.Gossip().GetSystemConfig()
+		if !ok {
+			return errors.New("gossipped system config not available")
+		}
+
+		rows, err := sqlDB.Query(`SELECT range_id, start_key, end_key FROM crdb_internal.ranges`)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		nranges := 0
+		for rows.Next() {
+			var rangeID int
+			var startKey, endKey []byte
+			if err := rows.Scan(&rangeID, &startKey, &endKey); err != nil {
+				return err
+			}
+			if sysCfg.NeedsSplit(startKey, endKey) {
+				return fmt.Errorf("range %d needs split", rangeID)
+			}
+			nranges++
+		}
+		if rows.Err() != nil {
+			return err
+		}
+
+		expectedRanges, err := s.ExpectedInitialRangeCount()
+		if err != nil {
+			return err
+		}
+		if expectedRanges != nranges {
+			return fmt.Errorf("expected %d ranges but got %d", expectedRanges, nranges)
+		}
+
+		return nil
+	})
+}

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -799,6 +799,67 @@ func TestReplayMigrations(t *testing.T) {
 	}
 }
 
+func TestUpgradeTableDescsToInterleavedFormatVersionMigration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	mt := makeIsolatedMigrationTest(ctx, t, "upgrade table descs to interleaved format version")
+	defer mt.close(ctx)
+
+	mt.start(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+				// Block schema changes to ensure that our migration sees some table
+				// descriptors in the DROP state. The schema changer might otherwise
+				// erase them before our migration runs.
+				AsyncExecNotification: func() error { return errors.New("schema changes disabled") },
+			},
+		},
+	})
+
+	defer func(prev int64) { upgradeTableDescBatchSize = prev }(upgradeTableDescBatchSize)
+	upgradeTableDescBatchSize = 5
+	n := int(upgradeTableDescBatchSize) * 3
+
+	// Create n tables.
+	mt.sqlDB.Exec(t, `CREATE DATABASE db`)
+	for i := 0; i < n; i++ {
+		mt.sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE db.t%d ()`, i))
+	}
+
+	// Corrupt every second table's format version, and mark every third table as
+	// dropping.
+	for i := 0; i < n; i++ {
+		tableDesc := sqlbase.GetTableDescriptor(mt.kvDB, "db", fmt.Sprintf("t%d", i))
+		if i%2 == 0 {
+			tableDesc.FormatVersion = sqlbase.FamilyFormatVersion
+		}
+		if i%3 == 0 {
+			tableDesc.State = sqlbase.TableDescriptor_DROP
+		}
+		tableKey := sqlbase.MakeDescMetadataKey(tableDesc.ID)
+		if err := mt.kvDB.Put(ctx, tableKey, sqlbase.WrapDescriptor(tableDesc)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Ensure the migration upgrades the format of all tables, even those that
+	// are dropping.
+	if err := mt.runMigration(ctx); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		tableDesc := sqlbase.GetTableDescriptor(mt.kvDB, "db", fmt.Sprintf("t%d", i))
+		if e, a := sqlbase.InterleavedFormatVersion, tableDesc.FormatVersion; e != a {
+			t.Errorf("t%d: expected format version %s, but got %s", i, e, a)
+		}
+	}
+
+	// Verify idempotency.
+	if err := mt.runMigration(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestExpectedInitialRangeCount(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -144,6 +144,12 @@ type TestServerInterface interface {
 	SplitRange(
 		splitKey roachpb.Key,
 	) (left roachpb.RangeDescriptor, right roachpb.RangeDescriptor, err error)
+
+	// ExpectedInitialRangeCount returns the expected number of ranges that should
+	// be on the server after initial (asynchronous) splits have been completed,
+	// assuming no additional information is added outside of the normal bootstrap
+	// process.
+	ExpectedInitialRangeCount() (int, error)
 }
 
 // TestServerFactory encompasses the actual implementation of the shim


### PR DESCRIPTION
See commit messages for details. The last commit is the one that really matters:

```
Add a migration that ensures that the upgrade to InterleavedFormatVersion is
persisted to disk for all table descriptors. It must otherwise be performed
on-the-fly whenever a table descriptor is loaded. In fact, before this
migration, a cluster that was continuously upgraded from before beta-20161013
would retain its old-format table descriptors until a schema-mutating statement
was executed against every old-format table.
```

The earlier commits are mostly yak-shaving.

@danhhz you probably want to look at just the last commit.