### PR TITLE
ui: replace NVD3 tooltip with custom details tooltip

### DIFF
--- a/pkg/ui/src/redux/hover.ts
+++ b/pkg/ui/src/redux/hover.ts
@@ -15,8 +15,13 @@ export const HOVER_OFF = "cockroachui/hover/HOVER_OFF";
  * HoverInfo is conveys the current hover position to the state.
  */
 export interface HoverInfo {
+  // The logical hover state.
   hoverChart: string;
   hoverTime: moment.Moment;
+
+  // The physical hover state.
+  x: number;
+  y: number;
 }
 
 export class HoverState {
@@ -26,16 +31,20 @@ export class HoverState {
   hoverChart: string;
   // What point in time are we hovering over?
   hoverTime: moment.Moment;
+
+  // The page x-coordinate of the mouse.
+  x: number;
+  // The page y-coordinate of the mouse.
+  y: number;
 }
 
 export function hoverReducer(state = new HoverState(), action: Action): HoverState {
   switch (action.type) {
     case HOVER_ON:
-      const { payload: hi } = action as PayloadAction<HoverInfo>;
+      const { payload: hoverInfo } = action as PayloadAction<HoverInfo>;
       return {
         currentlyHovering: true,
-        hoverChart: hi.hoverChart,
-        hoverTime: hi.hoverTime,
+        ...hoverInfo,
       };
     case HOVER_OFF:
       return new HoverState();
@@ -44,10 +53,10 @@ export function hoverReducer(state = new HoverState(), action: Action): HoverSta
   }
 }
 
-export function hoverOn(hi: HoverInfo): PayloadAction<HoverInfo> {
+export function hoverOn(hoverInfo: HoverInfo): PayloadAction<HoverInfo> {
   return {
     type: HOVER_ON,
-    payload: hi,
+    payload: hoverInfo,
   };
 }
 

--- a/pkg/ui/src/redux/hover.ts
+++ b/pkg/ui/src/redux/hover.ts
@@ -32,9 +32,9 @@ export class HoverState {
   // What point in time are we hovering over?
   hoverTime: moment.Moment;
 
-  // The page x-coordinate of the mouse.
+  // The x-coordinate of the mouse relative to the page.
   x: number;
-  // The page y-coordinate of the mouse.
+  // The y-coordinate of the mouse relative to the page.
   y: number;
 }
 

--- a/pkg/ui/src/redux/metrics.ts
+++ b/pkg/ui/src/redux/metrics.ts
@@ -106,7 +106,7 @@ function metricsQueryReducer(state: MetricsQuery, action: Action) {
  * MetricsQueries is a collection of individual MetricsQuery objects, indexed by
  * component id.
  */
-interface MetricQuerySet {
+export interface MetricQuerySet {
   [id: string]: MetricsQuery;
 }
 

--- a/pkg/ui/src/util/charts.ts
+++ b/pkg/ui/src/util/charts.ts
@@ -1,0 +1,32 @@
+export type Measure = "count" | "bytes" | "duration";
+
+type Metric = {
+  name: string,
+  title?: string,
+};
+
+type MetricsChart = {
+  type: "metrics",
+  measure: Measure,
+  metrics: Metric[],
+};
+
+type NodesChart = {
+  type: "nodes",
+  measure: Measure,
+  metric: Metric,
+};
+
+type Chart = MetricsChart | NodesChart;
+
+export type ChartConfig = {
+  [key: string]: Chart,
+};
+
+export function isMetricsChart(chart: Chart): chart is MetricsChart {
+  return chart.type === "metrics";
+}
+
+export function isNodesChart(chart: Chart): chart is NodesChart {
+  return chart.type === "nodes";
+}

--- a/pkg/ui/src/util/format.ts
+++ b/pkg/ui/src/util/format.ts
@@ -1,3 +1,5 @@
+import d3 from "d3";
+
 export const kibi = 1024;
 const byteUnits: string[] = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
 const durationUnits: string[] = ["ns", "µs", "ms", "s"];
@@ -93,4 +95,23 @@ export function Duration(nanoseconds: number): string {
   const scale = ComputeDurationScale(nanoseconds);
   const unitVal = nanoseconds / scale.value;
   return unitVal.toFixed(1) + " " + scale.units;
+}
+
+const metricFormat = d3.format(".4s");
+const decimalFormat = d3.format(".4f");
+
+/**
+ *  Count creates a string representation for a count.
+ *
+ *  For numbers larger than 1, the tooltip displays fractional values with
+ *  metric multiplicative prefixes (e.g. kilo, mega, giga). For numbers smaller
+ *  than 1, we simply display the fractional value without converting to a
+ *  fractional metric prefix; this is because the use of fractional metric
+ *  prefixes (i.e. milli, micro, nano) have proved confusing to users.
+ */
+export function Count(n: number) {
+  if (n < 1) {
+    return decimalFormat(n);
+  }
+  return metricFormat(n);
 }

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -17,7 +17,14 @@ import { MetricsDataComponentProps } from "src/views/shared/components/metricQue
 import Visualization from "src/views/cluster/components/visualization";
 import { NanoToMilli } from "src/util/convert";
 
-type TSDatapoint = protos.cockroach.ts.tspb.TimeSeriesDatapoint$Properties;
+type TSDatapoint = protos.cockroach.ts.tspb.ITimeSeriesDatapoint;
+
+export interface ForwardProps {
+  hoverOn?: typeof hoverOn;
+  hoverOff?: typeof hoverOff;
+  hoverState?: HoverState;
+  chartKey?: string;
+}
 
 interface LineGraphProps extends MetricsDataComponentProps {
   title?: string;
@@ -25,10 +32,6 @@ interface LineGraphProps extends MetricsDataComponentProps {
   legend?: boolean;
   xAxis?: boolean;
   tooltip?: React.ReactNode;
-  hoverOn?: typeof hoverOn;
-  hoverOff?: typeof hoverOff;
-  hoverState?: HoverState;
-  chartKey?: string;
 }
 
 // Find which data point is closest to a specific time.
@@ -66,7 +69,7 @@ function bisectSeries(datapoints: TSDatapoint[], time: number) {
  * supports a single Y-axis, but multiple metrics can be graphed on the same
  * axis.
  */
-export class LineGraph extends React.Component<LineGraphProps, {}> {
+export class LineGraph extends React.Component<LineGraphProps & ForwardProps, {}> {
   // The SVG Element in the DOM used to render the graph.
   graphEl: SVGElement;
 

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -80,10 +80,15 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
     //   - first series is missing data points
     //   - series are missing data points at different timestamps
     if (!this.props.data.results) {
-        return;
+      return;
     }
 
-    const datapoints = this.props.data.results[0].datapoints;
+    // TODO(couchand): get rid of this ugly hack
+    const datapoints = this.props.data.results[0].datapoints || this.props.data.results[1].datapoints;
+    if (!datapoints) {
+      return;
+    }
+
     const timeScale = this.chart.xAxis.scale();
 
     // To get the x-coordinate within the chart we subtract the left side of the SVG
@@ -159,16 +164,17 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
       }
 
       let hoverTime: moment.Moment;
+      let thisChart = false;
       if (this.props.hoverState) {
         const { currentlyHovering, hoverChart } = this.props.hoverState;
-        // Don't draw the linked guideline on the hovered chart, NVD3 does that for us.
-        if (currentlyHovering && hoverChart !== this.props.title) {
+        if (currentlyHovering) {
           hoverTime = this.props.hoverState.hoverTime;
+          thisChart = hoverChart !== this.props.chartKey;
         }
       }
 
       ConfigureLineChart(
-        this.chart, this.graphEl, metrics, axis, this.props.data, this.props.timeInfo, hoverTime,
+        this.chart, this.graphEl, metrics, axis, this.props.data, this.props.timeInfo, hoverTime, thisChart,
       );
     }
   }

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -175,7 +175,7 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
         const { currentlyHovering, hoverChart } = this.props.hoverState;
         if (currentlyHovering) {
           hoverTime = this.props.hoverState.hoverTime;
-          thisChart = hoverChart !== this.props.chartKey;
+          thisChart = hoverChart === this.props.chartKey;
         }
       }
 

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -119,11 +119,16 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
       return;
     }
 
+    const positionX = e.clientX + window.scrollX;
+    const positionY = e.clientY + window.scrollY;
+
     // Only dispatch if we have something to change to avoid action spamming.
-    if (this.props.hoverState.hoverChart !== this.props.chartKey || !result.isSame(this.props.hoverState.hoverTime)) {
+    if (this.props.hoverState.hoverChart !== this.props.chartKey || !result.isSame(this.props.hoverState.hoverTime) || this.props.hoverState.x !== positionX || this.props.hoverState.y !== positionY) {
       this.props.hoverOn({
         hoverChart: this.props.chartKey,
         hoverTime: result,
+        x: positionX,
+        y: positionY,
       });
     }
   }

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -25,6 +25,7 @@ interface LineGraphProps extends MetricsDataComponentProps {
   hoverOn?: typeof hoverOn;
   hoverOff?: typeof hoverOff;
   hoverState?: HoverState;
+  chartKey?: string;
 }
 
 /**
@@ -119,9 +120,9 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
     }
 
     // Only dispatch if we have something to change to avoid action spamming.
-    if (this.props.hoverState.hoverChart !== this.props.title || !result.isSame(this.props.hoverState.hoverTime)) {
+    if (this.props.hoverState.hoverChart !== this.props.chartKey || !result.isSame(this.props.hoverState.hoverTime)) {
       this.props.hoverOn({
-        hoverChart: this.props.title,
+        hoverChart: this.props.chartKey,
         hoverTime: result,
       });
     }

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -79,6 +79,10 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
     // TODO(couchand): handle the following cases:
     //   - first series is missing data points
     //   - series are missing data points at different timestamps
+    if (!this.props.data.results) {
+        return;
+    }
+
     const datapoints = this.props.data.results[0].datapoints;
     const timeScale = this.chart.xAxis.scale();
 

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -93,7 +93,7 @@ $viz-sides = 62px
     opacity .2
 
 .linked-guideline__line
-  stroke $link-color
+  stroke $tooltip-color
 
   &--current
-    stroke $tooltip-color
+    stroke $link-color

--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -94,3 +94,6 @@ $viz-sides = 62px
 
 .linked-guideline__line
   stroke $link-color
+
+  &--current
+    stroke $tooltip-color

--- a/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
@@ -67,11 +67,10 @@ class DetailsTooltip extends React.Component<DetailsTooltipProps, {}> {
   render() {
     const { hoverChart, hoverTime, x, y } = this.props.hoverState;
 
-    if (!hoverChart) {
+    if (!hoverChart || !(hoverChart in this.props.metrics)) {
       return null;
     }
 
-    // TODO(couchand): make this safer
     const data = this.props.metrics[hoverChart].data.results;
 
     const bisect = d3.bisector((d: any) => NanoToMilli(d.timestamp_nanos.toNumber())).left;

--- a/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
@@ -85,13 +85,16 @@ class DetailsTooltip extends React.Component<DetailsTooltipProps, {}> {
     if (isMetricsChart(currentChart)) {
       metrics = currentChart.metrics
         .map(({ title }, i) => ({ title, datapoints: data[i].datapoints }))
-        .filter(({ datapoints} ) => datapoints && datapoints.length)
         .map(({ title, datapoints }, i) => {
-          const index = bisect(datapoints, moment(hoverTime).valueOf());
+          let value = "-";
+          if (datapoints && datapoints.length) {
+            const index = bisect(datapoints, moment(hoverTime).valueOf());
+            value = formatValue(datapoints[index].value);
+          }
           return {
             title,
             color: seriesPalette[i], // TODO(couchand): this seems hacky.
-            value: formatValue(datapoints[index].value),
+            value,
           };
         });
     } else if (isNodesChart(currentChart)) {

--- a/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
@@ -1,0 +1,163 @@
+import d3 from "d3";
+import moment from "moment";
+import React from "react";
+import { connect } from "react-redux";
+import _ from "lodash";
+
+import { hoverStateSelector, HoverState } from "src/redux/hover";
+import { MetricQuerySet } from "src/redux/metrics";
+import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
+import { AdminUIState } from "src/redux/state";
+import { ChartConfig, isMetricsChart, isNodesChart, Measure } from "src/util/charts";
+import { NanoToMilli } from "src/util/convert";
+import { Bytes, Count, Duration } from "src/util/format";
+
+import { charts as distributedCharts } from "src/views/cluster/containers/nodeGraphs/dashboards/distributed";
+import { charts as overviewCharts } from "src/views/cluster/containers/nodeGraphs/dashboards/overview";
+import { charts as queuesCharts } from "src/views/cluster/containers/nodeGraphs/dashboards/queues";
+import { charts as replicationCharts } from "src/views/cluster/containers/nodeGraphs/dashboards/replication";
+import { charts as requestsCharts } from "src/views/cluster/containers/nodeGraphs/dashboards/requests";
+import { charts as runtimeCharts } from "src/views/cluster/containers/nodeGraphs/dashboards/runtime";
+import { charts as sqlCharts } from "src/views/cluster/containers/nodeGraphs/dashboards/sql";
+import { charts as storageCharts } from "src/views/cluster/containers/nodeGraphs/dashboards/storage";
+import { nodeDisplayName } from "src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils";
+import { seriesPalette } from "src/views/cluster/util/graphs";
+
+interface DetailsTooltipProps {
+  hoverState: HoverState;
+  metrics: MetricQuerySet;
+  nodesSummary: NodesSummary;
+}
+
+interface DetailsTooltipMetric {
+  title: string;
+  color: string;
+  value: string;
+}
+
+type Formatter = (n: number) => string;
+function getFormatter(m: Measure): Formatter {
+  switch (m) {
+    case "bytes": return Bytes;
+    case "count": return Count;
+    case "duration": return Duration;
+    default: return _.identity;
+  }
+}
+
+const charts: ChartConfig = _.assign(
+  {},
+  distributedCharts,
+  overviewCharts,
+  queuesCharts,
+  replicationCharts,
+  requestsCharts,
+  runtimeCharts,
+  sqlCharts,
+  storageCharts,
+);
+
+class DetailsTooltip extends React.Component<DetailsTooltipProps, {}> {
+  render() {
+    const { hoverChart, hoverTime, x, y } = this.props.hoverState;
+
+    if (!hoverChart) {
+      return null;
+    }
+
+    // TODO(couchand): make this safer
+    const data = this.props.metrics[hoverChart].data.results;
+
+    const bisect = d3.bisector((d: any) => NanoToMilli(d.timestamp_nanos.toNumber())).left;
+
+    // TODO(couchand): get real nodeSources value
+    const nodeSources = false;
+    const nodeIDs = nodeSources ? nodeSources : this.props.nodesSummary.nodeIDs;
+
+    if (!(hoverChart in charts)) {
+      return null;
+    }
+
+    const currentChart = charts[hoverChart];
+    const formatValue = getFormatter(currentChart.measure);
+
+    let metrics: DetailsTooltipMetric[];
+    if (isMetricsChart(currentChart)) {
+      metrics = currentChart.metrics
+        .map(({ title }, i) => ({ title, datapoints: data[i].datapoints }))
+        .filter(({ datapoints} ) => datapoints && datapoints.length)
+        .map(({ title, datapoints }, i) => {
+          const index = bisect(datapoints, moment(hoverTime).valueOf());
+          return {
+            title,
+            color: seriesPalette[i], // TODO(couchand): this seems hacky.
+            value: formatValue(datapoints[index].value),
+          };
+        });
+    } else if (isNodesChart(currentChart)) {
+      metrics = nodeIDs
+        .map((id, i) => ({ id, datapoints: data[i].datapoints }))
+        .filter(({ datapoints }) => datapoints && datapoints.length )
+        .map(({ id, datapoints }, i) => {
+          const index = bisect(datapoints, moment(hoverTime).valueOf());
+          return {
+            title: nodeDisplayName(this.props.nodesSummary, id),
+            color: seriesPalette[i], // TODO(couchand): this seems hacky.
+            value: formatValue(datapoints[index].value),
+          };
+        });
+    }
+
+    const time = moment(hoverTime).utc();
+    return (
+      <div className="hover-thing nvtooltip xy-tooltip" style={{
+        position: "absolute",
+        left: 0,
+        top: 0,
+        transform: `translate(${x + 25}px,${y - 20}px)`,
+      }}>
+        {/* TODO(couchand): revisit this markup */}
+        <table>
+          <thead>
+            <tr>
+              <td colSpan={3}>
+                  <strong className="x-value">
+                    { time.format("HH:mm:ss") }
+                    { " " }
+                    <span className="legend-subtext">on</span>
+                    { " " }
+                    { time.format("MMM Do, YYYY") }
+                  </strong>
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            {
+              metrics.map((metric) => (
+                <tr>
+                  <td className="legend-color-guide">
+                    <svg width={9} height={9}>
+                      <circle cx={4.5} cy={4.5} r={3.5} fill={metric.color} />
+                    </svg>
+                  </td>
+                  <td className="key">{ metric.title }</td>
+                  <td className="value">{ metric.value }</td>
+                </tr>
+              ))
+            }
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state: AdminUIState) {
+  return {
+    hoverState: hoverStateSelector(state),
+    metrics: state.metrics.queries,
+    nodesSummary: nodesSummarySelector(state),
+  };
+}
+
+export default connect(mapStateToProps)(DetailsTooltip);

--- a/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/detailsTooltip/index.tsx
@@ -23,11 +23,17 @@ import { charts as storageCharts } from "src/views/cluster/containers/nodeGraphs
 import { nodeDisplayName } from "src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils";
 import { seriesPalette } from "src/views/cluster/util/graphs";
 
-interface DetailsTooltipProps {
+interface DetailsTooltipOwnProps {
   hoverState: HoverState;
   metrics: MetricQuerySet;
   nodesSummary: NodesSummary;
 }
+
+interface DetailsTooltipConnectedProps {
+  nodeSources: string[];
+}
+
+type DetailsTooltipProps = DetailsTooltipOwnProps & DetailsTooltipConnectedProps;
 
 interface DetailsTooltipMetric {
   title: string;
@@ -70,8 +76,7 @@ class DetailsTooltip extends React.Component<DetailsTooltipProps, {}> {
 
     const bisect = d3.bisector((d: any) => NanoToMilli(d.timestamp_nanos.toNumber())).left;
 
-    // TODO(couchand): get real nodeSources value
-    const nodeSources = false;
+    const { nodeSources } = this.props;
     const nodeIDs = nodeSources ? nodeSources : this.props.nodesSummary.nodeIDs;
 
     if (!(hoverChart in charts)) {
@@ -155,7 +160,7 @@ class DetailsTooltip extends React.Component<DetailsTooltipProps, {}> {
   }
 }
 
-function mapStateToProps(state: AdminUIState) {
+function mapStateToProps(state: AdminUIState): DetailsTooltipOwnProps {
   return {
     hoverState: hoverStateSelector(state),
     metrics: state.metrics.queries,
@@ -163,4 +168,6 @@ function mapStateToProps(state: AdminUIState) {
   };
 }
 
-export default connect(mapStateToProps)(DetailsTooltip);
+// tslint:disable-next-line:variable-name
+const DetailsTooltipConnected = connect<DetailsTooltipOwnProps, {}, DetailsTooltipConnectedProps>(mapStateToProps)(DetailsTooltip);
+export default DetailsTooltipConnected;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -3,8 +3,67 @@ import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
+import { ChartConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
+
+export const charts: ChartConfig = {
+  "nodes.distributed.0": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.distsender.batches", title: "Batches" },
+      { name: "cr.node.distsender.batches.partial", title: "Partial Batches" },
+    ],
+  },
+  "nodes.distributed.1": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.distsender.rpc.sent", title: "RPCs Sent" },
+      { name: "cr.node.distsender.rpc.sent.local", title: "Local Fast-path" },
+    ],
+  },
+  "nodes.distributed.2": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.distsender.rpc.sent.sendnexttimeout", title: "RPC Timeouts" },
+      { name: "cr.node.distsender.rpc.sent.nextreplicaerror", title: "Replica Errors" },
+      { name: "cr.node.distsender.errors.notleaseholder", title: "Not Leaseholder Errors" },
+    ],
+  },
+  "nodes.distributed.3": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.txn.commits", title: "Committed" },
+      { name: "cr.node.txn.commits1PC", title: "Fast-path Committed" },
+      { name: "cr.node.txn.aborts", title: "Aborted" },
+      { name: "cr.node.txn.abandons", title: "Abandoned" },
+    ],
+  },
+  "nodes.distributed.4": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.txn.restarts.writetooold", title: "Write Too Old" },
+      { name: "cr.node.txn.restarts.deleterange", title: "Forwarded Timestamp (delete range)" },
+      { name: "cr.node.txn.restarts.serializable", title: "Forwarded Timestamp (iso=serializable)" },
+      { name: "cr.node.txn.restarts.possiblereplay", title: "Possible Replay" },
+    ],
+  },
+  "nodes.distributed.5": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.node.txn.durations-p99" },
+  },
+  "nodes.distributed.6": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.node.txn.durations-p90" },
+  },
+};
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources } = props;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -4,8 +4,42 @@ import _ from "lodash";
 import * as docsURL from "src/util/docs";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
+import { ChartConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
+
+export const charts: ChartConfig = {
+  "nodes.overview.0": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sql.select.count", title: "Total Reads" },
+      { name: "cr.node.sql.distsql.select.count", title: "DistSQL Reads" },
+      { name: "cr.node.sql.update.count", title: "Updates" },
+      { name: "cr.node.sql.insert.count", title: "Inserts" },
+      { name: "cr.node.sql.delete.count", title: "Deletes" },
+    ],
+  },
+  "nodes.overview.1": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.node.sql.service.latency-p99" },
+  },
+  "nodes.overview.2": {
+    type: "nodes",
+    measure: "count",
+    metric: { name: "cr.store.replicas" },
+  },
+  "nodes.overview.3": {
+    type: "metrics",
+    measure: "bytes",
+    metrics: [
+      { name: "cr.store.capacity", title: "Capacity" },
+      { name: "cr.store.capacity.available", title: "Available" },
+      { name: "cr.store.capacity.used", title: "Used" },
+    ],
+  },
+};
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, storeSources, tooltipSelection } = props;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -2,8 +2,101 @@ import React from "react";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
+import { ChartConfig } from "src/util/charts";
 
 import { GraphDashboardProps } from "./dashboardUtils";
+
+export const charts: ChartConfig = {
+  "nodes.queues.0": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.queue.gc.process.failure", title: "GC" },
+      { name: "cr.store.queue.replicagc.process.failure", title: "Replica GC" },
+      { name: "cr.store.queue.replicate.process.failure", title: "Replication" },
+      { name: "cr.store.queue.split.process.failure", title: "Split" },
+      { name: "cr.store.queue.consistency.process.failure", title: "Consistency" },
+      { name: "cr.store.queue.raftlog.process.failure", title: "Raft Log" },
+      { name: "cr.store.queue.tsmaintenance.process.failure", title: "Time Series Maintenance" },
+    ],
+  },
+  "nodes.queues.1": {
+    type: "metrics",
+    measure: "duration",
+    metrics: [
+      { name: "cr.store.queue.gc.processingnanos", title: "GC" },
+      { name: "cr.store.queue.replicagc.processingnanos", title: "Replica GC" },
+      { name: "cr.store.queue.replicate.processingnanos", title: "Replication" },
+      { name: "cr.store.queue.split.processingnanos", title: "Split" },
+      { name: "cr.store.queue.consistency.processingnanos", title: "Consistency" },
+      { name: "cr.store.queue.raftlog.processingnanos", title: "Raft Log" },
+      { name: "cr.store.queue.tsmaintenance.processingnanos", title: "Time Series Maintenance" },
+    ],
+  },
+  "nodes.queues.2": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.queue.replicagc.process.success", title: "Successful Actions / sec" },
+      { name: "cr.store.queue.replicagc.pending", title: "Pending Actions" },
+      { name: "cr.store.queue.replicagc.removereplica", title: "Replicas Removed / sec" },
+    ],
+  },
+  "nodes.queues.3": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.queue.replicate.process.success", title: "Successful Actions / sec" },
+      { name: "cr.store.queue.replicate.pending", title: "Pending Actions" },
+      { name: "cr.store.queue.replicate.addreplica", title: "Replicas Added / sec" },
+      { name: "cr.store.queue.replicate.removereplica", title: "Replicas Removed / sec" },
+      { name: "cr.store.queue.replicate.removedeadreplica", title: "Dead Replicas Removed / sec" },
+      { name: "cr.store.queue.replicate.rebalancereplica", title: "Replicas Rebalanced / sec" },
+      { name: "cr.store.queue.replicate.transferlease", title: "Leases Transferred / sec" },
+      { name: "cr.store.queue.replicate.purgatory", title: "Replicas in Purgatory" },
+    ],
+  },
+  "nodes.queues.4": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.queue.split.process.success", title: "Successful Actions / sec" },
+      { name: "cr.store.queue.split.pending", title: "Pending Actions" },
+    ],
+  },
+  "nodes.queues.5": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.queue.gc.process.success", title: "Successful Actions / sec" },
+      { name: "cr.store.queue.gc.pending", title: "Pending Actions" },
+    ],
+  },
+  "nodes.queues.6": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.queue.raftlog.process.success", title: "Successful Actions / sec" },
+      { name: "cr.store.queue.raftlog.pending", title: "Pending Actions" },
+    ],
+  },
+  "nodes.queues.7": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.queue.consistency.process.success", title: "Successful Actions / sec" },
+      { name: "cr.store.queue.consistency.pending", title: "Pending Actions" },
+    ],
+  },
+  "nodes.queues.8": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.queue.tsmaintenance.process.success", title: "Successful Actions / sec" },
+      { name: "cr.store.queue.tsmaintenance.pending", title: "Pending Actions" },
+    ],
+  },
+};
 
 export default function (props: GraphDashboardProps) {
   const { storeSources } = props;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -3,8 +3,71 @@ import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
+import { ChartConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
+
+export const charts: ChartConfig = {
+  "nodes.replication.0": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.ranges", title: "Ranges" },
+      { name: "cr.store.replicas.leaders", title: "Leaders" },
+      { name: "cr.store.replicas.leaseholders", title: "Lease Holders" },
+      { name: "cr.store.replicas.leaders_not_leaseholders", title: "Leaders w/o Lease" },
+      { name: "cr.store.ranges.unavailable", title: "Unavailable" },
+      { name: "cr.store.ranges.underreplicated", title: "Under-replicated" },
+    ],
+  },
+  "nodes.replication.1": {
+    type: "nodes",
+    measure: "count",
+    metric: { name: "cr.store.replicas" },
+  },
+  "nodes.replication.2": {
+    type: "nodes",
+    measure: "count",
+    metric: { name: "cr.store.replicas.leaseholders" },
+  },
+  "nodes.replication.3": {
+    type: "nodes",
+    measure: "bytes",
+    metric: { name: "cr.store.totalbytes" },
+  },
+  "nodes.replication.4": {
+    type: "nodes",
+    measure: "count",
+    metric: { name: "cr.store.rebalancing.writespersecond" },
+  },
+  "nodes.replication.5": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.replicas", title: "Replicas" },
+      { name: "cr.store.replicas.quiescent", title: "Quiescent" },
+    ],
+  },
+  "nodes.replication.6": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.range.splits", title: "Splits" },
+      { name: "cr.store.range.adds", title: "Adds" },
+      { name: "cr.store.range.removes", title: "Removes" },
+    ],
+  },
+  "nodes.replication.7": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.range.snapshots.generated", title: "Generated" },
+      { name: "cr.store.range.snapshots.normal-applied", title: "Normal-applied" },
+      { name: "cr.store.range.snapshots.preemptive-applied", title: "Preemptive-applied" },
+      { name: "cr.store.replicas.reserved", title: "Reserved" },
+    ],
+  },
+};
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, storeSources } = props;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
@@ -2,8 +2,40 @@ import React from "react";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis } from "src/views/shared/components/metricQuery";
+import { ChartConfig } from "src/util/charts";
 
 import { GraphDashboardProps } from "./dashboardUtils";
+
+export const charts: ChartConfig = {
+  "nodes.requests.0": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.requests.slow.distsender", title: "Slow Distsender Requests" },
+    ],
+  },
+  "nodes.requests.1": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.requests.slow.raft", title: "Slow Raft Proposals" },
+    ],
+  },
+  "nodes.requests.2": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.requests.slow.lease", title: "Slow Lease Acquisitions" },
+    ],
+  },
+  "nodes.requests.3": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.requests.slow.commandqueue", title: "Slow Command Queue Entries" },
+    ],
+  },
+};
 
 export default function (props: GraphDashboardProps) {
   const { storeSources } = props;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -3,8 +3,60 @@ import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
+import { ChartConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
+
+export const charts: ChartConfig = {
+  "nodes.runtime.0": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.liveness.livenodes", title: "Live Nodes" },
+    ],
+  },
+  "nodes.runtime.1": {
+    type: "metrics",
+    measure: "bytes",
+    metrics: [
+      { name: "cr.node.sys.rss", title: "Total memory (RSS)" },
+      { name: "cr.node.sys.go.allocbytes", title: "Go Allocated" },
+      { name: "cr.node.sys.go.totalbytes", title: "Go Total" },
+      { name: "cr.node.sys.cgo.allocbytes", title: "CGo Allocated" },
+      { name: "cr.node.sys.cgo.totalbytes", title: "CGo Total" },
+    ],
+  },
+  "nodes.runtime.2": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sys.goroutines", title: "Goroutine Count" },
+    ],
+  },
+  "nodes.runtime.3": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sys.gc.count", title: "GC Runs" },
+    ],
+  },
+  "nodes.runtime.4": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sys.gc.pause.ns", title: "GC Pause Time" },
+    ],
+  },
+  "nodes.runtime.5": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sys.cpu.user.ns", title: "User CPU Time" },
+      { name: "cr.node.sys.cpu.sys.ns", title: "Sys CPU Time" },
+      { name: "cr.node.sys.gc.pause.ns", title: "GC Pause Time" },
+    ],
+  },
+};
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -3,8 +3,97 @@ import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
+import { ChartConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
+
+export const charts: ChartConfig = {
+  "nodes.sql.0": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sql.conns", title: "Client Connections" },
+    ],
+  },
+  "nodes.sql.1": {
+    type: "metrics",
+    measure: "bytes",
+    metrics: [
+      { name: "cr.node.sql.bytesin", title: "Bytes In" },
+      { name: "cr.node.sql.bytesout", title: "Bytes Out" },
+    ],
+  },
+  "nodes.sql.2": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sql.select.count", title: "Total Reads" },
+      { name: "cr.node.sql.distsql.select.count", title: "DistSQL Reads" },
+      { name: "cr.node.sql.update.count", title: "Updates" },
+      { name: "cr.node.sql.insert.count", title: "Inserts" },
+      { name: "cr.node.sql.delete.count", title: "Deletes" },
+    ],
+  },
+  "nodes.sql.3": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sql.distsql.queries.active", title: "Active Queries" },
+    ],
+  },
+  "nodes.sql.4": {
+    type: "nodes",
+    measure: "count",
+    metric: { name: "cr.node.sql.distsql.flows.active" },
+  },
+  "nodes.sql.5": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.node.sql.service.latency-p99" },
+  },
+  "nodes.sql.6": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.node.sql.service.latency-p90" },
+  },
+  "nodes.sql.7": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.node.sql.distsql.service.latency-p99" },
+  },
+  "nodes.sql.8": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.node.sql.distsql.service.latency-p90" },
+  },
+  "nodes.sql.9": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.node.exec.latency-p99" },
+  },
+  "nodes.sql.10": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.node.exec.latency-p90" },
+  },
+  "nodes.sql.11": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sql.txn.begin.count", title: "Begin" },
+      { name: "cr.node.sql.txn.commit.count", title: "Commits" },
+      { name: "cr.node.sql.txn.rollback.count", title: "Rollbacks" },
+      { name: "cr.node.sql.txn.abort.count", title: "Aborts" },
+    ],
+  },
+  "nodes.sql.12": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sql.ddl.count", title: "DDL Statements" },
+    ],
+  },
+};
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -3,8 +3,61 @@ import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
+import { ChartConfig } from "src/util/charts";
 
 import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
+
+export const charts: ChartConfig = {
+  "nodes.storage.0": {
+    type: "metrics",
+    measure: "bytes",
+    metrics: [
+      { name: "cr.store.capacity", title: "Capacity" },
+      { name: "cr.store.capacity.available", title: "Available" },
+      { name: "cr.store.capacity.used", title: "Used" },
+    ],
+  },
+  "nodes.storage.1": {
+    type: "metrics",
+    measure: "bytes",
+    metrics: [
+      { name: "cr.store.livebytes", title: "Live" },
+      { name: "cr.store.sysbytes", title: "System" },
+    ],
+  },
+  "nodes.storage.2": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.store.raft.process.logcommit.latency-p99" },
+  },
+  "nodes.storage.3": {
+    type: "nodes",
+    measure: "duration",
+    metric: { name: "cr.store.raft.process.commandcommit.latency-p99" },
+  },
+  "nodes.storage.4": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.rocksdb.read-amplification", title: "Read Amplification" },
+    ],
+  },
+  "nodes.storage.5": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.store.rocksdb.num-sstables", title: "SSTables" },
+    ],
+  },
+  "nodes.storage.6": {
+    type: "metrics",
+    measure: "count",
+    metrics: [
+      { name: "cr.node.sys.fd.open", title: "Open" },
+      { name: "cr.node.sys.fd.softlimit", title: "Limit" },
+    ],
+  },
+};
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, storeSources, tooltipSelection } = props;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -19,6 +19,7 @@ import { AdminUIState } from "src/redux/state";
 import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
 import { hoverStateSelector, HoverState, hoverOn, hoverOff } from "src/redux/hover";
 import { nodesSummarySelector, NodesSummary, LivenessStatus } from "src/redux/nodes";
+import extend from "src/util/nextState";
 import Alerts from "src/views/shared/containers/alerts";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
 
@@ -192,10 +193,11 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
     const graphs = dashboards[dashboard].component(dashboardProps);
     const graphComponents = _.map(graphs, (graph, idx) => {
       const key = `nodes.${dashboard}.${idx}`;
+      const forward = extend(forwardParams, { chartKey: key });
       return (
         <div key={key}>
           <MetricsDataProvider id={key}>
-            { React.cloneElement(graph, forwardParams) }
+            { React.cloneElement(graph, forward) }
           </MetricsDataProvider>
         </div>
       );

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -20,6 +20,7 @@ import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
 import { hoverStateSelector, HoverState, hoverOn, hoverOff } from "src/redux/hover";
 import { nodesSummarySelector, NodesSummary, LivenessStatus } from "src/redux/nodes";
 import extend from "src/util/nextState";
+import DetailsTooltip from "src/views/cluster/containers/detailsTooltip";
 import Alerts from "src/views/shared/containers/alerts";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
 
@@ -241,6 +242,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </div>
           </div>
         </section>
+        <DetailsTooltip />
       </div>
     );
   }

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -242,7 +242,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
             </div>
           </div>
         </section>
-        <DetailsTooltip />
+        <DetailsTooltip nodeSources={nodeSources} />
       </div>
     );
   }

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -20,6 +20,7 @@ import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
 import { hoverStateSelector, HoverState, hoverOn, hoverOff } from "src/redux/hover";
 import { nodesSummarySelector, NodesSummary, LivenessStatus } from "src/redux/nodes";
 import extend from "src/util/nextState";
+import { ForwardProps } from "src/views/cluster/components/linegraph";
 import DetailsTooltip from "src/views/cluster/containers/detailsTooltip";
 import Alerts from "src/views/shared/containers/alerts";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
@@ -183,7 +184,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
       tooltipSelection,
     };
 
-    const forwardParams = {
+    const forwardParams: ForwardProps = {
       hoverOn: this.props.hoverOn,
       hoverOff: this.props.hoverOff,
       hoverState: this.props.hoverState,

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -49,6 +49,8 @@ class AxisDomain {
   label: string = "";
   // tickFormat returns a function used to format the tick values for display.
   tickFormat: (n: number) => string = _.identity;
+  // guideFormat returns a function used to format the guide values for display.
+  guideFormat?: (n: number) => string = _.identity;
 
   // constructs a new AxisDomain with the given minimum and maximum value, with
   // ticks placed at intervals of the given increment in between the min and

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -6,7 +6,7 @@ import moment from "moment";
 
 import * as protos from "src/js/protos";
 import { NanoToMilli } from "src/util/convert";
-import { Bytes, ComputeByteScale, ComputeDurationScale, Duration } from "src/util/format";
+import { Bytes, ComputePrefixExponent, ComputeByteScale, ComputeDurationScale, Count, Duration } from "src/util/format";
 
 import {
   MetricProps, AxisProps, AxisUnits, QueryTimeInfo,
@@ -133,19 +133,7 @@ function computeAxisDomain(extent: Extent, factor: number = 1): AxisDomain {
 function ComputeCountAxisDomain(extent: Extent): AxisDomain {
   const axisDomain = computeAxisDomain(extent);
 
-  // For numbers larger than 1, the tooltip displays fractional values with
-  // metric multiplicative prefixes (e.g. kilo, mega, giga). For numbers smaller
-  // than 1, we simply display the fractional value without converting to a
-  // fractional metric prefix; this is because the use of fractional metric
-  // prefixes (i.e. milli, micro, nano) have proved confusing to users.
-  const metricFormat = d3.format(".4s");
-  const decimalFormat = d3.format(".4f");
-  axisDomain.guideFormat = (n: number) => {
-    if (n < 1) {
-      return decimalFormat(n);
-    }
-    return metricFormat(n);
-  };
+  axisDomain.guideFormat = Count;
 
   return axisDomain;
 }

--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -274,26 +274,6 @@ function formatMetricData(
   return formattedData;
 }
 
-function filterInvalidDatapoints(
-  formattedData: formattedSeries[],
-  timeInfo: QueryTimeInfo,
-): formattedSeries[] {
-  return _.map(formattedData, (datum) => {
-    // Drop any returned points at the beginning that have a lower timestamp
-    // than the explicitly queried domain. This works around a bug in NVD3
-    // which causes the interactive guideline to highlight the wrong points.
-    // https://github.com/novus/nvd3/issues/1913
-    const filteredValues = _.dropWhile(datum.values, (dp) => {
-      return dp.timestamp_nanos.toNumber() < timeInfo.start.toNumber();
-    });
-
-    return {
-      ...datum,
-      values: filteredValues,
-    };
-  });
-}
-
 export function InitLineChart(chart: nvd3.LineChart) {
     chart
       .x((d: protos.cockroach.ts.tspb.TimeSeriesDatapoint) => new Date(NanoToMilli(d && d.timestamp_nanos.toNumber())))
@@ -328,8 +308,7 @@ export function ConfigureLineChart(
   let xAxisDomain, yAxisDomain: AxisDomain;
 
   if (data) {
-    const formattedRaw = formatMetricData(metrics, data);
-    formattedData = filterInvalidDatapoints(formattedRaw, timeInfo);
+    formattedData = formatMetricData(metrics, data);
 
     xAxisDomain = calculateXAxisDomain(timeInfo);
     yAxisDomain = calculateYAxisDomain(axis.props.units, data);

--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -119,3 +119,7 @@
 .nvd3 text
   opacity .6
   font-size 10px
+
+// I really, really hate NVD3.
+.nv-point.hover
+  opacity 0


### PR DESCRIPTION
This is the last major step before replacing NVD3, using our own component for the details tooltip rather than relying on NVD3 for it.

This is not quite ready to merge.  To do items:
- [x] format the values in the tooltip
- [x] convert the rest of the dashboard pages
  - [x] runtime
  - [x] sql
  - [x] storage
  - [x] replication
  - [x] queues
  - [x] slow requests
- [x] figure out the issue with the rpc errors chart
- [x] rename `hoverThing` to `detailsTooltip`
- ~[ ] split out the last commit into smaller pieces~ (probably not worth the effort)
- [x] address in-line todo comments

(no screenshot included, as it looks the same as the current version)