### PR TITLE
opt: support tuples, make index constraints for IN

### DIFF
--- a/pkg/sql/opt/build.go
+++ b/pkg/sql/opt/build.go
@@ -153,6 +153,20 @@ func buildScalar(buildCtx *buildContext, pexpr tree.TypedExpr) *expr {
 	case *tree.IndexedVar:
 		initVariableExpr(e, t.Idx)
 
+	case *tree.Tuple:
+		children := make([]*expr, len(t.Exprs))
+		for i, e := range t.Exprs {
+			children[i] = buildScalar(buildCtx, e.(tree.TypedExpr))
+		}
+		initTupleExpr(e, children)
+
+	case *tree.DTuple:
+		children := make([]*expr, len(t.D))
+		for i, d := range t.D {
+			children[i] = buildScalar(buildCtx, d)
+		}
+		initTupleExpr(e, children)
+
 	case tree.Datum:
 		initConstExpr(e, t)
 

--- a/pkg/sql/opt/scalar.go
+++ b/pkg/sql/opt/scalar.go
@@ -153,6 +153,18 @@ func initTupleExpr(e *expr, children []*expr) {
 	e.children = children
 }
 
+func isTupleOfConstants(e *expr) bool {
+	if e.op != orderedListOp {
+		return false
+	}
+	for _, c := range e.children {
+		if c.op != constOp {
+			return false
+		}
+	}
+	return true
+}
+
 // Applies a set of normalization rules to a scalar expression.
 //
 // For now, we expect to build exprs from TypedExprs which have gone through a

--- a/pkg/sql/opt/scalar.go
+++ b/pkg/sql/opt/scalar.go
@@ -144,6 +144,15 @@ func isIndexedVar(e *expr, index int) bool {
 	return e.op == variableOp && e.private.(int) == index
 }
 
+func initTupleExpr(e *expr, children []*expr) {
+	// In general, the order matters in a tuple so we use an "ordered list"
+	// operator. In some cases (IN) the order doesn't matter; we could convert
+	// those to listOp during normalization, but there doesn't seem to be a
+	// benefit at this time.
+	e.op = orderedListOp
+	e.children = children
+}
+
 // Applies a set of normalization rules to a scalar expression.
 //
 // For now, we expect to build exprs from TypedExprs which have gone through a

--- a/pkg/sql/opt/testdata/build-scalar
+++ b/pkg/sql/opt/testdata/build-scalar
@@ -131,3 +131,38 @@ or (type: bool)
  └── gt (type: bool)
       ├── variable (2) (type: int)
       └── const (2) (type: int)
+
+build-scalar int int
+(@1, @2) = (1, 2)
+----
+eq (type: bool)
+ ├── ordered-list (type: tuple{int, int})
+ │    ├── variable (0) (type: int)
+ │    └── variable (1) (type: int)
+ └── ordered-list (type: tuple{int, int})
+      ├── const (1) (type: int)
+      └── const (2) (type: int)
+
+build-scalar int
+@1 IN (1, 2)
+----
+in (type: bool)
+ ├── variable (0) (type: int)
+ └── ordered-list (type: tuple{int, int})
+      ├── const (1) (type: int)
+      └── const (2) (type: int)
+
+build-scalar int int
+(@1, @2) IN ((1, 2), (3, 4))
+----
+in (type: bool)
+ ├── ordered-list (type: tuple{int, int})
+ │    ├── variable (0) (type: int)
+ │    └── variable (1) (type: int)
+ └── ordered-list (type: tuple{tuple{int, int}, tuple{int, int}})
+      ├── ordered-list (type: tuple{int, int})
+      │    ├── const (1) (type: int)
+      │    └── const (2) (type: int)
+      └── ordered-list (type: tuple{int, int})
+           ├── const (3) (type: int)
+           └── const (4) (type: int)

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -113,3 +113,53 @@ build-scalar,normalize,index-constraints decimal decimal
 @1 > 1.5 AND @2 > 2
 ----
 (/1.5 - ]
+
+build-scalar,normalize,index-constraints int
+@1 IN (1, 2, 3)
+----
+[/1 - /1]
+[/2 - /2]
+[/3 - /3]
+
+build-scalar,legacy-normalize,index-constraints int
+@1 IN (1, 5, 1, 4)
+----
+[/1 - /1]
+[/4 - /4]
+[/5 - /5]
+
+build-scalar,normalize,index-constraints int int
+@1 = 1 AND @2 IN (1, 2, 3)
+----
+[/1/1 - /1/1]
+[/1/2 - /1/2]
+[/1/3 - /1/3]
+
+build-scalar,normalize,index-constraints int int
+@1 IN (1, 2) AND @2 IN (1, 2, 3)
+----
+[/1/1 - /1/1]
+[/1/2 - /1/2]
+[/1/3 - /1/3]
+[/2/1 - /2/1]
+[/2/2 - /2/2]
+[/2/3 - /2/3]
+
+build-scalar,normalize,index-constraints int int
+@1 >= 2 AND @1 <= 4 AND @2 IN (1, 2, 3)
+----
+[/2/1 - /4/3]
+
+build-scalar,normalize,index-constraints int int
+@1 IN (1, 2, 3) AND @2 = 4
+----
+[/1/4 - /1/4]
+[/2/4 - /2/4]
+[/3/4 - /3/4]
+
+build-scalar,normalize,index-constraints int int
+@1 IN (1, 2, 3) AND @2 >= 2 AND @2 <= 4
+----
+[/1/2 - /1/4]
+[/2/2 - /2/4]
+[/3/2 - /3/4]


### PR DESCRIPTION
#### opt: support Tuple and DTuple when building a scalar

Adding support for tuples, using orderedListOp.

Release Notes: None

#### opt: index constraints for IN

Release note: None
