### PR TITLE
sql/distsqlrun: plumb context into RowSource.Next

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -1424,7 +1424,7 @@ func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 		batch := store.NewBatchWriter()
 		var key, val []byte
 		for {
-			row, err := input.NextRow()
+			row, err := input.NextRow(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -69,7 +69,7 @@ func runTestFlow(
 
 	var rowBuf distsqlrun.RowBuffer
 
-	ctx, flow, err := distSQLSrv.SetupSyncFlow(context.TODO(), &req, &rowBuf)
+	ctx, flow, err := distSQLSrv.SetupSyncFlow(context.Background(), &req, &rowBuf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func runTestFlow(
 
 	var res sqlbase.EncDatumRows
 	for {
-		row, meta := rowBuf.Next()
+		row, meta := rowBuf.Next(context.Background())
 		if !meta.Empty() {
 			t.Fatalf("unexpected metadata: %v", meta)
 		}

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -257,7 +257,7 @@ func (ag *aggregator) accumulateRows(ctx context.Context) (err error) {
 
 	var scratch []byte
 	for {
-		row, meta := ag.input.Next()
+		row, meta := ag.input.Next(ctx)
 		if !meta.Empty() {
 			if meta.Err != nil {
 				return meta.Err

--- a/pkg/sql/distsqlrun/algebraic_set_op.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op.go
@@ -122,11 +122,11 @@ func (e *algebraicSetOp) exceptAll(ctx context.Context) error {
 		convertToColumnOrdering(e.ordering),
 	)
 
-	leftRows, err := leftGroup.advanceGroup()
+	leftRows, err := leftGroup.advanceGroup(ctx)
 	if err != nil {
 		return err
 	}
-	rightRows, err := rightGroup.advanceGroup()
+	rightRows, err := rightGroup.advanceGroup(ctx)
 	if err != nil {
 		return err
 	}
@@ -195,11 +195,11 @@ func (e *algebraicSetOp) exceptAll(ctx context.Context) error {
 					}
 				}
 			}
-			leftRows, err = leftGroup.advanceGroup()
+			leftRows, err = leftGroup.advanceGroup(ctx)
 			if err != nil {
 				return err
 			}
-			rightRows, err = rightGroup.advanceGroup()
+			rightRows, err = rightGroup.advanceGroup(ctx)
 			if err != nil {
 				return err
 			}
@@ -214,13 +214,13 @@ func (e *algebraicSetOp) exceptAll(ctx context.Context) error {
 					return err
 				}
 			}
-			leftRows, err = leftGroup.advanceGroup()
+			leftRows, err = leftGroup.advanceGroup(ctx)
 			if err != nil {
 				return err
 			}
 		}
 		if cmp > 0 {
-			rightRows, err = rightGroup.advanceGroup()
+			rightRows, err = rightGroup.advanceGroup(ctx)
 			if len(rightRows) == 0 {
 				break
 			}
@@ -244,7 +244,7 @@ func (e *algebraicSetOp) exceptAll(ctx context.Context) error {
 
 		// Emit all remaining rows.
 		for {
-			leftRows, err = leftGroup.advanceGroup()
+			leftRows, err = leftGroup.advanceGroup(ctx)
 			// Emit all left rows until completion/error.
 			if err != nil || len(leftRows) == 0 {
 				return err

--- a/pkg/sql/distsqlrun/algebraic_set_op_test.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op_test.go
@@ -92,14 +92,15 @@ func runProcessors(tc testCase) (sqlbase.EncDatumRows, error) {
 		return nil, err
 	}
 
-	s.Run(context.Background(), nil)
+	ctx := context.Background()
+	s.Run(ctx, nil)
 	if !out.ProducerClosed {
 		return nil, errors.Errorf("output RowReceiver not closed")
 	}
 
 	var res sqlbase.EncDatumRows
 	for {
-		row, meta := out.Next()
+		row, meta := out.Next(ctx)
 		if !meta.Empty() {
 			return nil, errors.Errorf("unexpected metadata: %v", meta)
 		}

--- a/pkg/sql/distsqlrun/base_test.go
+++ b/pkg/sql/distsqlrun/base_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"golang.org/x/net/context"
 )
 
 // Benchmark a pipeline of RowChannels.
@@ -45,7 +46,7 @@ func BenchmarkRowChannelPipeline(b *testing.B) {
 						next = &rc[i+1]
 					}
 					for {
-						row, meta := cur.Next()
+						row, meta := cur.Next(context.Background())
 						if row == nil {
 							if next != nil {
 								next.ProducerDone()

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -94,7 +94,7 @@ func (d *distinct) Run(ctx context.Context, wg *sync.WaitGroup) {
 func (d *distinct) mainLoop(ctx context.Context) (earlyExit bool, _ error) {
 	var scratch []byte
 	for {
-		row, meta := d.input.Next()
+		row, meta := d.input.Next(ctx)
 		if !meta.Empty() {
 			if meta.Err != nil {
 				return false, meta.Err

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -275,7 +275,7 @@ func (h *hashJoiner) receiveRow(
 	ctx context.Context, src RowSource, side joinSide,
 ) (_ sqlbase.EncDatumRow, earlyExit bool, _ error) {
 	for {
-		row, meta := src.Next()
+		row, meta := src.Next(ctx)
 		if row == nil {
 			if meta.Empty() {
 				// Done.

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -611,7 +611,7 @@ func checkExpectedRows(
 
 	var rets []string
 	for {
-		row, meta := results.Next()
+		row, meta := results.Next(context.Background())
 		if !meta.Empty() {
 			return errors.Errorf("unexpected metadata: %v", meta)
 		}

--- a/pkg/sql/distsqlrun/input_sync_test.go
+++ b/pkg/sql/distsqlrun/input_sync_test.go
@@ -121,7 +121,7 @@ func TestOrderedSync(t *testing.T) {
 		}
 		var retRows sqlbase.EncDatumRows
 		for {
-			row, meta := src.Next()
+			row, meta := src.Next(context.Background())
 			if !meta.Empty() {
 				t.Fatalf("unexpected metadata: %v", meta)
 			}
@@ -161,7 +161,7 @@ func TestUnorderedSync(t *testing.T) {
 	}
 	var retRows sqlbase.EncDatumRows
 	for {
-		row, meta := mrc.Next()
+		row, meta := mrc.Next(context.Background())
 		if !meta.Empty() {
 			t.Fatalf("unexpected metadata: %v", meta)
 		}
@@ -213,7 +213,7 @@ func TestUnorderedSync(t *testing.T) {
 	}
 	foundErr := false
 	for {
-		row, meta := mrc.Next()
+		row, meta := mrc.Next(context.Background())
 		if meta.Err != nil {
 			if meta.Err.Error() != "Test error" {
 				t.Error(meta.Err)

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -411,7 +411,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 
 			var res sqlbase.EncDatumRows
 			for {
-				row, meta := out.Next()
+				row, meta := out.Next(context.Background())
 				if !meta.Empty() {
 					t.Fatalf("unexpected metadata: %+v", meta)
 				}

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -134,7 +134,7 @@ func (jr *joinReader) mainLoop(ctx context.Context) error {
 		// a soft limit (perhaps send the batch out if we don't get a result
 		// within a certain amount of time).
 		for spans = spans[:0]; len(spans) < joinReaderBatchSize; {
-			row, meta := jr.input.Next()
+			row, meta := jr.input.Next(ctx)
 			if !meta.Empty() {
 				if meta.Err != nil {
 					return meta.Err

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -214,7 +214,7 @@ func TestJoinReaderDrain(t *testing.T) {
 			t.Fatal(err)
 		}
 		jr.Run(ctx, nil)
-		row, meta := out.Next()
+		row, meta := out.Next(context.Background())
 		if row != nil {
 			t.Fatalf("row was pushed unexpectedly: %s", row.String(oneIntCol))
 		}

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -112,7 +112,7 @@ func (m *mergeJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 func (m *mergeJoiner) outputBatch(
 	ctx context.Context, cancelChecker *sqlbase.CancelChecker,
 ) (bool, error) {
-	leftRows, rightRows, err := m.streamMerger.NextBatch()
+	leftRows, rightRows, err := m.streamMerger.NextBatch(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -407,7 +407,7 @@ func (n *noopProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
 	defer tracing.FinishSpan(span)
 
 	for {
-		row, meta := n.input.Next()
+		row, meta := n.input.Next(ctx)
 		if row == nil && meta.Empty() {
 			sendTraceData(ctx, n.out.output)
 			n.out.Close()

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -464,7 +464,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 				if consumerStatus != NeedMoreRows {
 					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 				}
-				_, meta := chans[0].Next()
+				_, meta := chans[0].Next(context.Background())
 				if meta.Err != err1 {
 					t.Fatalf("unexpected meta.Err %v, expected %s", meta.Err, err1)
 				}
@@ -477,7 +477,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 				if consumerStatus != NeedMoreRows {
 					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 				}
-				_, meta := chans[0].Next()
+				_, meta := chans[0].Next(context.Background())
 				if meta.Err != err2 {
 					t.Fatalf("unexpected meta.Err %v, expected %s", meta.Err, err2)
 				}
@@ -529,7 +529,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 
 func drainRowChannel(rc *RowChannel) {
 	for {
-		row, meta := rc.Next()
+		row, meta := rc.Next(context.Background())
 		if row == nil && meta.Empty() {
 			return
 		}

--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -131,7 +131,7 @@ func (s *sampleAggregator) mainLoop(ctx context.Context) (earlyExit bool, _ erro
 	var da sqlbase.DatumAlloc
 	var tmpSketch hyperloglog.Sketch
 	for {
-		row, meta := s.input.Next()
+		row, meta := s.input.Next(ctx)
 		if !meta.Empty() {
 			if !emitHelper(ctx, &s.out, nil /* row */, meta, s.input) {
 				// No cleanup required; emitHelper() took care of it.

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -149,7 +149,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, _ erro
 	var da sqlbase.DatumAlloc
 	var buf []byte
 	for {
-		row, meta := s.input.Next()
+		row, meta := s.input.Next(ctx)
 		if !meta.Empty() {
 			if !emitHelper(ctx, &s.out, nil /* row */, meta, s.input) {
 				// No cleanup required; emitHelper() took care of it.

--- a/pkg/sql/distsqlrun/sorterstrategy.go
+++ b/pkg/sql/distsqlrun/sorterstrategy.go
@@ -121,7 +121,7 @@ func (ss *sortAllStrategy) executeImpl(
 	ctx context.Context, s *sorter, r sortableRowContainer,
 ) (sqlbase.EncDatumRow, error) {
 	for {
-		row, err := s.input.NextRow()
+		row, err := s.input.NextRow(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -197,7 +197,7 @@ func (ss *sortTopKStrategy) Execute(ctx context.Context, s *sorter) error {
 	defer ss.rows.Close(ctx)
 	heapCreated := false
 	for {
-		row, err := s.input.NextRow()
+		row, err := s.input.NextRow(ctx)
 		if err != nil {
 			return err
 		}
@@ -267,7 +267,7 @@ func (ss *sortChunksStrategy) Execute(ctx context.Context, s *sorter) error {
 		return true, nil
 	}
 
-	nextRow, err := s.input.NextRow()
+	nextRow, err := s.input.NextRow(ctx)
 	if err != nil || nextRow == nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func (ss *sortChunksStrategy) Execute(ctx context.Context, s *sorter) error {
 				return err
 			}
 
-			nextRow, err = s.input.NextRow()
+			nextRow, err = s.input.NextRow(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -213,7 +213,7 @@ ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3
 	var res sqlbase.EncDatumRows
 	var metas []ProducerMetadata
 	for {
-		row, meta := out.Next()
+		row, meta := out.Next(context.Background())
 		if !meta.Empty() {
 			metas = append(metas, meta)
 			continue
@@ -285,7 +285,7 @@ func BenchmarkTableReader(b *testing.B) {
 		}
 
 		for {
-			row, meta := out.Next()
+			row, meta := out.Next(context.Background())
 			if !meta.Empty() {
 				b.Fatalf("unexpected metadata: %+v", meta)
 			}

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -62,7 +62,7 @@ func (r *RepeatableRowSource) Types() []sqlbase.ColumnType {
 }
 
 // Next is part of the RowSource interface.
-func (r *RepeatableRowSource) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
+func (r *RepeatableRowSource) Next(_ context.Context) (sqlbase.EncDatumRow, ProducerMetadata) {
 	// If we've emitted all rows, signal that we have reached the end.
 	if r.nextRowIdx >= len(r.rows) {
 		return nil, ProducerMetadata{}
@@ -100,7 +100,7 @@ func (r *RowDisposer) ProducerDone() {}
 // NextNoMeta is a version of Next which fails the test if
 // it encounters any metadata.
 func (rb *RowBuffer) NextNoMeta(tb testing.TB) sqlbase.EncDatumRow {
-	row, meta := rb.Next()
+	row, meta := rb.Next(context.Background())
 	if !meta.Empty() {
 		tb.Fatalf("unexpected metadata: %v", meta)
 	}


### PR DESCRIPTION
This is a prerequisite for making processors implement RowSource because
we will want to pass a context from Processor.Run to RowSource.Next in
order to maintain tracing data.

Release note: None