### PR TITLE
storage: try to clarify error message about incompatible store versions

### DIFF
--- a/pkg/storage/stores.go
+++ b/pkg/storage/stores.go
@@ -447,8 +447,8 @@ func SynthesizeClusterVersionFromEngines(
 		// restarting into 1.1 after having upgraded to 1.2 doesn't work.
 		for _, v := range []roachpb.Version{cv.MinimumVersion, cv.UseVersion} {
 			if serverVersion.Less(v) {
-				return cluster.ClusterVersion{}, errors.Errorf("engine %s requires at least v%s, but running version is %s",
-					eng, v, serverVersion)
+				return cluster.ClusterVersion{}, errors.Errorf("cockroach version v%s is incompatible with data in store %s; use version v%s or later",
+					serverVersion, eng, v)
 			}
 		}
 
@@ -484,9 +484,9 @@ func SynthesizeClusterVersionFromEngines(
 		// may not yet have picked up the final versions we're actually planning
 		// to use.
 		if v.Version.Less(minSupportedVersion) {
-			return cluster.ClusterVersion{}, errors.Errorf("engine %s at v%s too old for running version %s "+
-				"(requires at least v%s)", v.origin, v.Version, serverVersion,
-				minSupportedVersion)
+			return cluster.ClusterVersion{}, errors.Errorf("store %s, last used with cockroach version v%s, "+
+				"is too old for running version v%s (which requires data from v%s or later)",
+				v.origin, v.Version, serverVersion, minSupportedVersion)
 		}
 	}
 	// Write the "actual" version back to all stores. This is almost always a

--- a/pkg/storage/stores_test.go
+++ b/pkg/storage/stores_test.go
@@ -579,7 +579,7 @@ func TestStoresClusterVersionIncompatible(t *testing.T) {
 			cv.MinimumVersion = ls.serverVersion
 			// UseVersion is way too high for this node.
 			cv.UseVersion = roachpb.Version{Major: 9}
-			return `engine <no-attributes>=<in-mem> requires at least v9\.0, but running version is 1.0-1`
+			return `cockroach version v1\.0-1 is incompatible with data in store <no-attributes>=<in-mem>; use version v9\.0 or later`
 		},
 		"StoreTooNewMinVersion": func(cv *cluster.ClusterVersion, ls *Stores) string {
 			ls.minSupportedVersion = vOne
@@ -588,7 +588,7 @@ func TestStoresClusterVersionIncompatible(t *testing.T) {
 			// sure it doesn't change the outcome.
 			cv.UseVersion = ls.serverVersion
 			cv.MinimumVersion = roachpb.Version{Major: 9}
-			return `engine <no-attributes>=<in-mem> requires at least v9\.0, but running version is 1.0-1`
+			return `cockroach version v1\.0-1 is incompatible with data in store <no-attributes>=<in-mem>; use version v9\.0 or later`
 		},
 		"StoreTooOldUseVersion": func(cv *cluster.ClusterVersion, ls *Stores) string {
 			// This is what the running node requires from its stores.
@@ -599,7 +599,7 @@ func TestStoresClusterVersionIncompatible(t *testing.T) {
 			cv.MinimumVersion = ls.serverVersion
 			// UseVersion is way too low.
 			cv.UseVersion = roachpb.Version{Major: 4}
-			return `engine <no-attributes>=<in-mem> at v4\.0 too old for running version 9\.0 \(requires at least v5\.0\)`
+			return `store <no-attributes>=<in-mem>, last used with cockroach version v4\.0, is too old for running version v9\.0 \(which requires data from v5\.0 or later\)`
 		},
 		"StoreTooOldMinVersion": func(cv *cluster.ClusterVersion, ls *Stores) string {
 			// Like the previous test case, but this time cv.MinimumVersion is the culprit.
@@ -607,7 +607,7 @@ func TestStoresClusterVersionIncompatible(t *testing.T) {
 			ls.serverVersion = roachpb.Version{Major: 9}
 			cv.MinimumVersion = ls.serverVersion
 			cv.UseVersion = roachpb.Version{Major: 4}
-			return `engine <no-attributes>=<in-mem> at v4\.0 too old for running version 9\.0 \(requires at least v5\.0\)`
+			return `store <no-attributes>=<in-mem>, last used with cockroach version v4\.0, is too old for running version v9\.0 \(which requires data from v5\.0 or later\)`
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
This recently left Jesse unsure of what the problem was when he tried
starting a v1.1.3 binary with a data directory previously used by a
v1.2-alpha release.

@jseldess, would this have been any clearer? The new message would be:

```
ERROR: cockroach server exited with error: inspecting engines: store <no-attributes>=/cockroach/cockroach-data requires at least cockroach version v1.1-4, but running version is 1.1
```

I wonder if printing the `<no-attributes>` part should also be removed if no attributes are set on the store, to make things clearer for people who don't know what store attributes are.

Release note: None