### PR TITLE
storage: never fuzz GC scores up

### DIFF
--- a/pkg/storage/engine/enginepb/mvcc.pb.go
+++ b/pkg/storage/engine/enginepb/mvcc.pb.go
@@ -83,7 +83,15 @@ func (*MVCCMetadata) Descriptor() ([]byte, []int) { return fileDescriptorMvcc, [
 // don't change last_update_nanos until an update at a timestamp which,
 // truncated to the second, is ahead of last_update_nanos/1e9. Then, that
 // difference in seconds times the base quantity (excluding the currently
-// running update) is added to the age. It gets more complicated when data is
+// running update) is added to the age.
+//
+// To give an example, if an intent is around from `t=2.5s` to `t=4.1s` (the
+// current time), then it contributes an intent age of two seconds (one second
+// picked up when crossing `t=3s`, another one at `t=4s`). Similarly, if a
+// GC'able kv pair is around for this amount of time, it contributes two seconds
+// times its size in bytes.
+//
+// It gets more complicated when data is
 // accounted for with a timestamp behind last_update_nanos. In this case, if
 // more than a second has passed (computed via truncation above), the ages have
 // to be adjusted to account for this late addition. This isn't hard: add the

--- a/pkg/storage/engine/enginepb/mvcc.proto
+++ b/pkg/storage/engine/enginepb/mvcc.proto
@@ -59,7 +59,15 @@ message MVCCMetadata {
 // don't change last_update_nanos until an update at a timestamp which,
 // truncated to the second, is ahead of last_update_nanos/1e9. Then, that
 // difference in seconds times the base quantity (excluding the currently
-// running update) is added to the age. It gets more complicated when data is
+// running update) is added to the age.
+//
+// To give an example, if an intent is around from `t=2.5s` to `t=4.1s` (the
+// current time), then it contributes an intent age of two seconds (one second
+// picked up when crossing `t=3s`, another one at `t=4s`). Similarly, if a
+// GC'able kv pair is around for this amount of time, it contributes two seconds
+// times its size in bytes.
+//
+// It gets more complicated when data is
 // accounted for with a timestamp behind last_update_nanos. In this case, if
 // more than a second has passed (computed via truncation above), the ages have
 // to be adjusted to account for this late addition. This isn't hard: add the

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -343,10 +343,10 @@ func makeGCQueueScoreImpl(
 	// undergone a reality check yet.
 	r.IntentScore = ms.AvgIntentAge(now.WallTime) / float64(intentAgeNormalization.Nanoseconds()/1E9)
 
-	// Random factor in [0.75, 1.25] to cause decoherence of replicas with
-	// similar load. This isn't 100% symmetric due to rounding issues near zero,
-	// but not an issue in practice.
-	r.FuzzFactor = 0.75 + rand.New(rand.NewSource(fuzzSeed)).Float64()/2.0
+	// Randomly skew the score down a bit to cause decoherence of replicas with
+	// similar load. Note that we'll only ever reduce the score, never increase
+	// it (for increasing it could lead to a fruitless run).
+	r.FuzzFactor = 0.95 + 0.05*rand.New(rand.NewSource(fuzzSeed)).Float64()
 
 	// Compute priority.
 	valScore := r.DeadFraction * r.ValuesScalableScore


### PR DESCRIPTION
I haven't seen this be an issue in practice, but it seems good to be prudent.

Release note: None