### PR TITLE
sql: fix Adjust(Start|End)Keys for secondary indexes

### DIFF
--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -1204,9 +1204,9 @@ func spanFromLogicalSpan(
 		}
 	}
 
-	// TightenStartKey is not needed here (unlike TightenEndKey) since
-	// start keys at this point cannot be generated with interleaved
-	// keys.
+	// AdjustStartKeyForInterleave is not needed here (unlike
+	// AdjustEndKeyForInterleave) since start keys at this point cannot be
+	// generated with interleaved keys.
 
 	lastPartInclusive := true
 	// Encode each logical part of the end key as span.EndKey.
@@ -1232,7 +1232,7 @@ func spanFromLogicalSpan(
 	}
 	// We tighten the end key to prevent reading interleaved children
 	// after the last parent key.
-	s.EndKey, err = sqlbase.TightenEndKey(tableDesc, index, s.EndKey, lastPartInclusive)
+	s.EndKey, err = sqlbase.AdjustEndKeyForInterleave(tableDesc, index, s.EndKey, lastPartInclusive)
 
 	return s, err
 }

--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -692,7 +692,9 @@ type IndexDescriptor struct {
 	//
 	// Only used for secondary indexes.
 	// For non-unique indexes, these columns are appended to the key.
-	// For unique indexes, these columns are stored in the value.
+	// For unique indexes, these columns are stored in the value (unless the key
+	// contains a NULL value: then the extra columns are appended to the key to
+	// unique-ify it).
 	// This distinction exists because we want to be able to insert an entry using
 	// a single conditional put on the key.
 	ExtraColumnIDs []ColumnID `protobuf:"varint,7,rep,name=extra_column_ids,json=extraColumnIds,casttype=ColumnID" json:"extra_column_ids,omitempty"`

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -316,7 +316,9 @@ message IndexDescriptor {
   //
   // Only used for secondary indexes.
   // For non-unique indexes, these columns are appended to the key.
-  // For unique indexes, these columns are stored in the value.
+  // For unique indexes, these columns are stored in the value (unless the key
+  // contains a NULL value: then the extra columns are appended to the key to
+  // unique-ify it).
   // This distinction exists because we want to be able to insert an entry using
   // a single conditional put on the key.
   repeated uint32 extra_column_ids = 7 [(gogoproto.customname) = "ExtraColumnIDs",

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -2456,7 +2456,10 @@ func TableEquivSignatures(
 }
 
 // maxKeyTokens returns the maximum number of key tokens in an index's key,
-// including the table ID, index ID, and index column values.
+// including the table ID, index ID, and index column values (ncluding extra
+// columns that may be stored in the key).
+// It requires knowledge of whether the key will or might contain a NULL value:
+// if uncertain, pass in true to 'overestimate' the maxKeyTokens.
 //
 // In general, a key belonging to an interleaved index grandchild is encoded as:
 //
@@ -2473,9 +2476,17 @@ func TableEquivSignatures(
 //    /table/index/<parent-pk1>/.../<parent-pkX>
 //
 // We return the maximum number of <tokens> in this prefix.
-func maxKeyTokens(index *IndexDescriptor) int {
+func maxKeyTokens(index *IndexDescriptor, containsNull bool) int {
 	nTables := len(index.Interleave.Ancestors) + 1
-	nKeys := len(index.ColumnIDs)
+	nKeyCols := len(index.ColumnIDs)
+
+	// Non-unique secondary indexes or unique secondary indexes with a NULL
+	// value have additional columns in the key that may appear in a span
+	// (e.g. primary key columns not part of the index).
+	// See EncodeSecondaryIndex.
+	if !index.Unique || containsNull {
+		nKeyCols += len(index.ExtraColumnIDs)
+	}
 
 	// To illustrate how we compute max # of key tokens, take the
 	// key in the example above and let the respective index be child.
@@ -2490,13 +2501,12 @@ func maxKeyTokens(index *IndexDescriptor) int {
 	// Each <parent-pkX> must be a part of the index's columns (nKeys).
 	// Finally, we do not want to include the interleave sentinel for the
 	// current index (-1).
-	return 3*nTables + nKeys - 1
+	return 3*nTables + nKeyCols - 1
 }
 
-// TightenStartKey pushes forward the start key to the first key belonging to
-// the index (whether it exists or not) in the span.
-// This is relevant for parent spans that have an interleaved child's index key
-// as a start key.
+// AdjustStartKeyForInterleave adjusts the start key to skip unnecessary
+// interleaved sections.
+//
 // For example, if child is interleaved into parent, a typical parent
 // span might look like
 //    /1 - /3
@@ -2510,12 +2520,12 @@ func maxKeyTokens(index *IndexDescriptor) int {
 // We can thus push forward the start key from /1/#/2 to /2. If the start key
 // was /1, we cannot push this forwards since that is the first key we want
 // to read.
-func TightenStartKey(index *IndexDescriptor, start roachpb.Key) (roachpb.Key, error) {
-	nIndexTokens := maxKeyTokens(index)
-	keyTokens, err := encoding.DecomposeKeyTokens(start)
+func AdjustStartKeyForInterleave(index *IndexDescriptor, start roachpb.Key) (roachpb.Key, error) {
+	keyTokens, containsNull, err := encoding.DecomposeKeyTokens(start)
 	if err != nil {
 		return roachpb.Key{}, err
 	}
+	nIndexTokens := maxKeyTokens(index, containsNull)
 
 	// This is either the index's own key or one of its ancestor's key.
 	// Nothing to do.
@@ -2525,20 +2535,28 @@ func TightenStartKey(index *IndexDescriptor, start roachpb.Key) (roachpb.Key, er
 
 	// len(keyTokens) > nIndexTokens, so this must be a child key.
 	// Transform /1/#/2 --> /2.
-	return start[:nIndexTokens].PrefixEnd(), nil
+	firstNTokenLen := 0
+	for _, token := range keyTokens[:nIndexTokens] {
+		firstNTokenLen += len(token)
+	}
+
+	return start[:firstNTokenLen].PrefixEnd(), nil
 }
 
-// TightenEndKey pushes back the end key to the last key of the last row
-// belonging to the index (whether it exists or not) in the span.
-// This is relevant for parent spans that have interleaved children.
+// AdjustEndKeyForInterleave returns an exclusive end key. It does two things:
+//    - determines the end key based on the prior: inclusive vs exclusive
+//    - adjusts the end key to skip unnecessary interleaved sections
+//
 // For example, the parent span composed from the filter PK >= 1 and PK < 3 is
 //    /1 - /3
 // This reads all keys up to the first parent key for PK = 3. If parent had
 // interleaved tables and keys, it would unncessarily scan over interleaved
 // rows under PK2 (e.g. /2/#/5).
-// We can instead "tighten" the end key from /3 to /2/#.
-// TightenEndKey is idempotent upon successive invocation(s).
-func TightenEndKey(
+// We can instead "tighten" or adjust the end key from /3 to /2/#.
+// DO NOT pass in any keys that have been invoked with PrefixEnd: this may
+// cause issues when trying to decode the key tokens.
+// AdjustEndKeyForInterleave is idempotent upon successive invocation(s).
+func AdjustEndKeyForInterleave(
 	table *TableDescriptor, index *IndexDescriptor, end roachpb.Key, inclusive bool,
 ) (roachpb.Key, error) {
 	// To illustrate, suppose we have the interleaved hierarchy
@@ -2546,16 +2564,28 @@ func TightenEndKey(
 	//	child
 	//	  grandchild
 	// Suppose our target index is child.
-	nIndexTokens := maxKeyTokens(index)
-	keyTokens, err := encoding.DecomposeKeyTokens(end)
+	keyTokens, containsNull, err := encoding.DecomposeKeyTokens(end)
 	if err != nil {
 		return roachpb.Key{}, err
 	}
+	nIndexTokens := maxKeyTokens(index, containsNull)
+
+	// Sibling/nibling keys: it is possible for this key to be part
+	// of a sibling tree in the interleaved hierarchy, especially after
+	// partitioning on range split keys.
+	// As such, a sibling may be interpretted as an ancestor (if the sibling
+	// has fewer key-encoded columns) or a descendant (if the sibling has
+	// more key-encoded columns). Similarly for niblings.
+	// This is fine because if the sibling is sorted before or after the
+	// current index (child in our example), it is not possible for us to
+	// adjust the sibling key such that we add or remove child (the current
+	// index's) rows from our span.
 
 	if index.ID != table.PrimaryIndex.ID || len(keyTokens) < nIndexTokens {
 		// Case 1: secondary index, parent key or partial child key:
 		// Secondary indexes cannot have interleaved rows.
-		// We cannot tighten parent keys with respect to a child index.
+		// We cannot adjust or tighten parent keys with respect to a
+		// child index.
 		// Partial child keys e.g. /1/#/1 vs /1/#/1/2 cannot have
 		// interleaved rows.
 		// Nothing to do besides making the end key exclusive if it was
@@ -2611,32 +2641,30 @@ func TightenEndKey(
 	}
 
 	// len(keyTokens) > nIndexTokens
-	// Case 3: tightened child key or grandchild key
-
-	// Since there are more key tokens than the index token, we should
-	// expected an interleaved sentinel next, or else this index key
-	// cannot possibly be generated.
-	if _, isSentinel := encoding.DecodeIfInterleavedSentinel(keyTokens[nIndexTokens]); !isSentinel {
-		panic("expected interleaved sentinel as the next key token")
-	}
+	// Case 3: tightened child, sibling/nibling, or grandchild key
 
 	// Case 3a: tightened child key
-	// This could from a previous invocation of TightenEndKey. For
-	// example, if during index selection the key for child was
+	// This could from a previous invocation of AdjustEndKeyForInterleave.
+	// For example, if during index selection the key for child was
 	// tightened
 	//	/1/#/2 --> /1/#/1/#
 	// We don't really want to tighten on '#' again.
-	if len(keyTokens) == nIndexTokens+1 {
+	if _, isSentinel := encoding.DecodeIfInterleavedSentinel(keyTokens[nIndexTokens]); isSentinel && len(keyTokens)-1 == nIndexTokens {
 		if inclusive {
 			end = end.PrefixEnd()
 		}
 		return end, nil
 	}
 
-	// Case 3b: grandchild key
+	// Case 3b/c: sibling/nibling or grandchild key
 	// Ideally, we want to form
 	//    /1/#/2/#/3 --> /1/#/2/#
-	// We truncate up to the interleave sentinel after the last index
-	// key token.
-	return end[:nIndexTokens+1], nil
+	// We truncate up to and including the interleave sentinel (or next
+	// sibling/nibling column value) after the last index key token.
+	firstNTokenLen := 0
+	for _, token := range keyTokens[:nIndexTokens] {
+		firstNTokenLen += len(token)
+	}
+
+	return end[:firstNTokenLen+1], nil
 }

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -819,7 +819,7 @@ func TestEquivSignature(t *testing.T) {
 	}
 }
 
-func TestTightenStartKey(t *testing.T) {
+func TestAdjustStartKeyForInterleave(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
@@ -827,11 +827,14 @@ func TestTightenStartKey(t *testing.T) {
 
 	sqlutils.CreateTestInterleavedHierarchy(t, sqlDB)
 
-	// Create DESC indexes for testing.
+	// Secondary indexes with DESC direction in the last column.
 	r := sqlutils.MakeSQLRunner(sqlDB)
 	r.Exec(t, fmt.Sprintf(`CREATE INDEX pid1_desc ON %s.parent1 (pid1 DESC)`, sqlutils.TestDB))
 	r.Exec(t, fmt.Sprintf(`CREATE INDEX child_desc ON %s.child1 (pid1, cid1, cid2 DESC) INTERLEAVE IN PARENT %s.parent1 (pid1)`, sqlutils.TestDB, sqlutils.TestDB))
 	r.Exec(t, fmt.Sprintf(`CREATE INDEX grandchild_desc ON %s.grandchild1 (pid1, cid1, cid2, gcid1 DESC) INTERLEAVE IN PARENT %s.child1(pid1, cid1, cid2)`, sqlutils.TestDB, sqlutils.TestDB))
+	// Index with implicit primary columns (pid1, cid2).
+	r.Exec(t, fmt.Sprintf(`CREATE INDEX child_non_unique ON %s.child1 (v, cid1)`, sqlutils.TestDB))
+	r.Exec(t, fmt.Sprintf(`CREATE UNIQUE INDEX child_unique ON %s.child1 (v, cid1)`, sqlutils.TestDB))
 
 	// The interleaved hierarchy is as follows:
 	//    parent		(pid1)
@@ -843,6 +846,8 @@ func TestTightenStartKey(t *testing.T) {
 
 	parentDescIdx := parent.Indexes[0]
 	childDescIdx := child.Indexes[0]
+	childNonUniqueIdx := child.Indexes[1]
+	childUniqueIdx := child.Indexes[2]
 	grandchildDescIdx := grandchild.Indexes[0]
 
 	testCases := []struct {
@@ -943,11 +948,75 @@ func TestTightenStartKey(t *testing.T) {
 			input:    "/1/#/2/3/#/4",
 			expected: "/1/#/2/4",
 		},
+
+		// Key with len > 1 tokens.
+		{
+			index:    &child.PrimaryIndex,
+			input:    "/12345678901234/#/1234/1234567890/#/123/1234567",
+			expected: "/12345678901234/#/1234/1234567891",
+		},
+		{
+			index:    &child.PrimaryIndex,
+			input:    "/12345678901234/#/d1403.2594/shelloworld/#/123/1234567",
+			expected: "/12345678901234/#/d1403.2594/shelloworld/PrefixEnd",
+		},
+
+		// Index key with extra columns (implicit primary key columns).
+		// We should expect two extra columns (in addition to the
+		// two index columns).
+		{
+			index:    &childNonUniqueIdx,
+			input:    "/2/3",
+			expected: "/2/3",
+		},
+		{
+			index:    &childNonUniqueIdx,
+			input:    "/2/3/4",
+			expected: "/2/3/4",
+		},
+		{
+			index:    &childNonUniqueIdx,
+			input:    "/2/3/4/5",
+			expected: "/2/3/4/5",
+		},
+		{
+			index:    &childNonUniqueIdx,
+			input:    "/2/3/4/5/#/10",
+			expected: "/2/3/4/6",
+		},
+
+		// Unique indexes only include implicit columns if they have
+		// a NULL value.
+		{
+			index:    &childUniqueIdx,
+			input:    "/2/3",
+			expected: "/2/3",
+		},
+		{
+			index:    &childUniqueIdx,
+			input:    "/2/3/4",
+			expected: "/2/4",
+		},
+		{
+			index:    &childUniqueIdx,
+			input:    "/2/NULLASC/4",
+			expected: "/2/NULLASC/4",
+		},
+		{
+			index:    &childUniqueIdx,
+			input:    "/2/NULLASC/4/5",
+			expected: "/2/NULLASC/4/5",
+		},
+		{
+			index:    &childUniqueIdx,
+			input:    "/2/NULLASC/4/5/#/6",
+			expected: "/2/NULLASC/4/6",
+		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			actual, err := TightenStartKey(tc.index, EncodeTestKey(t, kvDB, ShortToLongKeyFmt(tc.input)))
+			actual, err := AdjustStartKeyForInterleave(tc.index, EncodeTestKey(t, kvDB, ShortToLongKeyFmt(tc.input)))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -960,7 +1029,7 @@ func TestTightenStartKey(t *testing.T) {
 	}
 }
 
-func TestTightenEndKey(t *testing.T) {
+func TestAdjustEndKeyForInterleave(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
@@ -968,11 +1037,14 @@ func TestTightenEndKey(t *testing.T) {
 
 	sqlutils.CreateTestInterleavedHierarchy(t, sqlDB)
 
-	// Create DESC indexes for testing.
+	// Secondary indexes with DESC direction in the last column.
 	r := sqlutils.MakeSQLRunner(sqlDB)
 	r.Exec(t, fmt.Sprintf(`CREATE INDEX pid1_desc ON %s.parent1 (pid1 DESC)`, sqlutils.TestDB))
 	r.Exec(t, fmt.Sprintf(`CREATE INDEX child_desc ON %s.child1 (pid1, cid1, cid2 DESC) INTERLEAVE IN PARENT %s.parent1 (pid1)`, sqlutils.TestDB, sqlutils.TestDB))
 	r.Exec(t, fmt.Sprintf(`CREATE INDEX grandchild_desc ON %s.grandchild1 (pid1, cid1, cid2, gcid1 DESC) INTERLEAVE IN PARENT %s.child1(pid1, cid1, cid2)`, sqlutils.TestDB, sqlutils.TestDB))
+	// Index with implicit primary columns (pid1, cid2).
+	r.Exec(t, fmt.Sprintf(`CREATE INDEX child_non_unique ON %s.child1 (v, cid1)`, sqlutils.TestDB))
+	r.Exec(t, fmt.Sprintf(`CREATE UNIQUE INDEX child_unique ON %s.child1 (v, cid1)`, sqlutils.TestDB))
 
 	// The interleaved hierarchy is as follows:
 	//    parent		(pid1)
@@ -984,6 +1056,8 @@ func TestTightenEndKey(t *testing.T) {
 
 	parentDescIdx := parent.Indexes[0]
 	childDescIdx := child.Indexes[0]
+	childNonUniqueIdx := child.Indexes[1]
+	childUniqueIdx := child.Indexes[2]
 	grandchildDescIdx := grandchild.Indexes[0]
 
 	testCases := []struct {
@@ -992,7 +1066,7 @@ func TestTightenEndKey(t *testing.T) {
 		// See ShortToLongKeyFmt for how to represent a key.
 		input string
 		// If the end key is assumed to be inclusive when passed to
-		// to TightenEndKey.
+		// to AdjustEndKeyForInterleave.
 		inclusive bool
 		expected  string
 	}{
@@ -1239,11 +1313,130 @@ func TestTightenEndKey(t *testing.T) {
 			inclusive: true,
 			expected:  "/1/#/3",
 		},
+
+		// Key with len > 1 tokens.
+		{
+			table:    child,
+			index:    &child.PrimaryIndex,
+			input:    "/12345678901234/#/12345/12345678901234/#/123/1234567",
+			expected: "/12345678901234/#/12345/12345678901234/#",
+		},
+
+		// Index key with extra columns (implicit primary key columns).
+		// We should expect two extra columns (in addition to the
+		// two index columns).
+		{
+			table:    child,
+			index:    &childNonUniqueIdx,
+			input:    "/2/3",
+			expected: "/2/3",
+		},
+		{
+			table:    child,
+			index:    &childNonUniqueIdx,
+			input:    "/2/3/4",
+			expected: "/2/3/4",
+		},
+		{
+			table:    child,
+			index:    &childNonUniqueIdx,
+			input:    "/2/3/4/5",
+			expected: "/2/3/4/5",
+		},
+		// End key not adjusted since secondary indexes can't have
+		// interleaved rows.
+		{
+			table:    child,
+			index:    &childNonUniqueIdx,
+			input:    "/2/3/4/5/#/10",
+			expected: "/2/3/4/5/#/10",
+		},
+
+		{
+			table:    child,
+			index:    &childUniqueIdx,
+			input:    "/2/3",
+			expected: "/2/3",
+		},
+		// End key not adjusted since secondary indexes can't have
+		// interleaved rows.
+		{
+			table:    child,
+			index:    &childUniqueIdx,
+			input:    "/2/3/4",
+			expected: "/2/3/4",
+		},
+		{
+			table:    child,
+			index:    &childUniqueIdx,
+			input:    "/2/NULLASC/4",
+			expected: "/2/NULLASC/4",
+		},
+		{
+			table:    child,
+			index:    &childUniqueIdx,
+			input:    "/2/NULLASC/4/5",
+			expected: "/2/NULLASC/4/5",
+		},
+		// End key not adjusted since secondary indexes can't have
+		// interleaved rows.
+		{
+			table:    child,
+			index:    &childUniqueIdx,
+			input:    "/2/NULLASC/4/5/#/6",
+			expected: "/2/NULLASC/4/5/#/6",
+		},
+
+		// Keys with decimal values.
+		// Not tightened since it's difficult to "go back" one logical
+		// decimal value.
+		{
+			table:    child,
+			index:    &child.PrimaryIndex,
+			input:    "/1/#/2/d3.4567",
+			expected: "/1/#/2/d3.4567",
+		},
+		{
+			table:     child,
+			index:     &child.PrimaryIndex,
+			input:     "/1/#/2/d3.4567",
+			inclusive: true,
+			expected:  "/1/#/2/d3.4567/#",
+		},
+		{
+			table:    child,
+			index:    &child.PrimaryIndex,
+			input:    "/1/#/2/d3.4567/#/8",
+			expected: "/1/#/2/d3.4567/#",
+		},
+
+		// Keys with bytes values.
+		// Not tightened since it's difficult to "go back" one logical
+		// bytes value.
+		{
+			table:    child,
+			index:    &child.PrimaryIndex,
+			input:    "/1/#/2/shelloworld",
+			expected: "/1/#/2/shelloworld",
+		},
+		{
+			table:     child,
+			index:     &child.PrimaryIndex,
+			input:     "/1/#/2/shelloworld",
+			inclusive: true,
+			expected:  "/1/#/2/shelloworld/#",
+		},
+		{
+			table:    child,
+			index:    &child.PrimaryIndex,
+			input:    "/1/#/2/shelloworld/#/3",
+			expected: "/1/#/2/shelloworld/#",
+		},
 	}
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			actual, err := TightenEndKey(tc.table, tc.index, EncodeTestKey(t, kvDB, ShortToLongKeyFmt(tc.input)), tc.inclusive)
+			actual, err := AdjustEndKeyForInterleave(tc.table, tc.index, EncodeTestKey(t, kvDB, ShortToLongKeyFmt(tc.input)), tc.inclusive)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -57,7 +57,7 @@ const (
 	durationMarker       byte = durationBigNegMarker + 1
 	durationBigPosMarker byte = durationMarker + 1 // Only used for durations > MaxInt64 nanos.
 
-	decimalNaN              = durationBigPosMarker + 1
+	decimalNaN              = durationBigPosMarker + 1 // 24
 	decimalNegativeInfinity = decimalNaN + 1
 	decimalNegLarge         = decimalNegativeInfinity + 1
 	decimalNegMedium        = decimalNegLarge + 11
@@ -1954,18 +1954,23 @@ func PrettyPrintValueEncoded(b []byte) ([]byte, string, error) {
 
 // DecomposeKeyTokens breaks apart a key into its individual key-encoded values
 // and returns a slice of byte slices, one for each key-encoded value.
-func DecomposeKeyTokens(b []byte) ([][]byte, error) {
+// It also returns whether the key contains a NULL value.
+func DecomposeKeyTokens(b []byte) (tokens [][]byte, containsNull bool, err error) {
 	var out [][]byte
 
 	for len(b) > 0 {
 		tokenLen, err := PeekLength(b)
 		if err != nil {
-			return nil, err
+			return nil, false, err
+		}
+
+		if PeekType(b) == Null {
+			containsNull = true
 		}
 
 		out = append(out, b[:tokenLen])
 		b = b[tokenLen:]
 	}
 
-	return out, nil
+	return out, containsNull, nil
 }


### PR DESCRIPTION
We need to add the number of extra columns (i.e. primary columns
not in the index and old STORING columns) to number of key token
calculation for an index key.

There was a also bug where we were truncating the key's byte with the desired number
of tokens instead of with _the length of_ the desired number of tokens.

Also renamed from `Tighten(Start|End)Key` --> `Adjust(Start|End)KeyForInterleave` (although `AdjustStartKey` always tightens if possible, I've renamed them both for symmetry).

Release note: None