### PR TITLE
logictest: fix interaction between let and --rewrite-results-in-testfiles

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -62,7 +62,6 @@ RoacH
 
 statement error unknown signature: concat\(string, bool, decimal, bool\)
 SELECT CONCAT('RoacH', false, 64.532, TRUE)
-----
 
 query T
 SELECT SUBSTR('RoacH', 2, 3)
@@ -178,7 +177,6 @@ abcde,2
 
 statement error unknown signature: concat_ws\(string, string, int, NULL, int\)
 SELECT CONCAT_WS(',', 'abcde', 2, NULL, 22)
-----
 
 query T
 SELECT split_part('abc~@~def~@~ghi', '~@~', 2)

--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -598,7 +598,6 @@ SELECT DISTINCT ON(row_number() OVER()) y FROM xyz ORDER BY row_number() OVER() 
 
 statement error DISTINCT ON position 2 is not in select list
 SELECT DISTINCT ON (2) x FROM xyz
-----
 
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz

--- a/pkg/sql/logictest/testdata/logic_test/partitioning_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning_constraints
@@ -33,7 +33,6 @@ statement ok
 INSERT INTO no_check VALUES (1), (2)
 
 statement ok
-----
 CREATE TABLE moderate (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
     PARTITION p1 VALUES IN ((1, 3), (2, 4)),
     PARTITION p2 VALUES IN ((1, 5), (2, DEFAULT))

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -36,7 +36,6 @@ ALTER DATABASE test RENAME TO u
 
 statement error relation "kv" does not exist
 SELECT * FROM kv
-----
 
 statement error database "test" does not exist
 SHOW GRANTS ON DATABASE test

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -344,7 +344,6 @@ user testuser
 
 statement error user testuser does not have SELECT privilege on relation settings
 select name from system.settings
-----
 
 statement error user testuser does not have INSERT privilege on relation settings
 UPSERT INTO system.settings (name, value) VALUES ('somesetting', 'somevalueother')

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -163,7 +163,6 @@ BEGIN TRANSACTION
 
 statement error current transaction is aborted, commands ignored until end of transaction block
 SELECT * FROM kv
-----
 
 statement ok
 ROLLBACK TRANSACTION


### PR DESCRIPTION
When using `let`, the `--rewrite-results-in-testfiles` flag
accidentally rewrites statements replacing the variable references
with the particular values during that run. This is fixed by emitting
the unprocessed lines. In addition, we now only do the substitution
for statements and queries (fixing other issues, like replacing
variables in `let` directives).

Fixes #20698.

Release note: None