### PR TITLE
sql/distsqlrun: avoid repeated EvalContext allocation

### DIFF
--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -267,3 +267,15 @@ func createDummyStream() (
 	}
 	return serverStream, clientStream, cleanup, nil
 }
+
+// mintIntRows constructs a numRows x numCols table where rows[i][j] = i + j.
+func makeIntRows(numRows, numCols int) sqlbase.EncDatumRows {
+	rows := make(sqlbase.EncDatumRows, numRows)
+	for i := range rows {
+		rows[i] = make(sqlbase.EncDatumRow, numCols)
+		for j := 0; j < numCols; j++ {
+			rows[i][j] = sqlbase.DatumToEncDatum(intType, tree.NewDInt(tree.DInt(i+j)))
+		}
+	}
+	return rows
+}


### PR DESCRIPTION
```
name        old time/op  new time/op  delta
Distinct-8   430µs ± 1%   291µs ± 2%  -32.31%  (p=0.000 n=9+10)
```

Release note (performance improvement): Speed up DISTINCT by avoiding an
unnecessary allocation.