### PR TITLE
sql/distsqlrun: add benchmarks for aggregator and mergeJoiner

### DIFF
--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -388,3 +388,90 @@ func TestAggregator(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkAggregation(b *testing.B) {
+	const numCols = 1
+	const numRows = 1000
+
+	aggFuncs := []AggregatorSpec_Func{
+		AggregatorSpec_IDENT,
+		AggregatorSpec_AVG,
+		AggregatorSpec_COUNT,
+		AggregatorSpec_MAX,
+		AggregatorSpec_MIN,
+		AggregatorSpec_STDDEV,
+		AggregatorSpec_SUM,
+		AggregatorSpec_SUM_INT,
+		AggregatorSpec_VARIANCE,
+		AggregatorSpec_XOR_AGG,
+	}
+
+	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext()
+	defer evalCtx.Stop(ctx)
+
+	flowCtx := &FlowCtx{
+		Settings: cluster.MakeTestingClusterSettings(),
+		EvalCtx:  evalCtx,
+	}
+
+	for _, aggFunc := range aggFuncs {
+		b.Run(aggFunc.String(), func(b *testing.B) {
+			spec := &AggregatorSpec{
+				Aggregations: []AggregatorSpec_Aggregation{
+					{
+						Func:   aggFunc,
+						ColIdx: []uint32{0},
+					},
+				},
+			}
+			post := &PostProcessSpec{}
+			disposer := &RowDisposer{}
+			input := NewRepeatableRowSource(oneIntCol, makeIntRows(numRows, numCols))
+
+			b.SetBytes(int64(8 * numRows * numCols))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				d, err := newAggregator(flowCtx, spec, input, post, disposer)
+				if err != nil {
+					b.Fatal(err)
+				}
+				d.Run(ctx, nil)
+				input.Reset()
+			}
+			b.StopTimer()
+		})
+	}
+}
+
+func BenchmarkGrouping(b *testing.B) {
+	const numCols = 1
+	const numRows = 1000
+
+	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext()
+	defer evalCtx.Stop(ctx)
+
+	flowCtx := &FlowCtx{
+		Settings: cluster.MakeTestingClusterSettings(),
+		EvalCtx:  evalCtx,
+	}
+	spec := &AggregatorSpec{
+		GroupCols: []uint32{0},
+	}
+	post := &PostProcessSpec{}
+	disposer := &RowDisposer{}
+	input := NewRepeatableRowSource(oneIntCol, makeIntRows(numRows, numCols))
+
+	b.SetBytes(int64(8 * numRows * numCols))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d, err := newAggregator(flowCtx, spec, input, post, disposer)
+		if err != nil {
+			b.Fatal(err)
+		}
+		d.Run(ctx, nil)
+		input.Reset()
+	}
+	b.StopTimer()
+}

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -186,12 +186,9 @@ func BenchmarkDistinct(b *testing.B) {
 		DistinctColumns: []uint32{0},
 	}
 	post := &PostProcessSpec{}
+	input := NewRepeatableRowSource(oneIntCol, makeIntRows(numRows, numCols))
 
-	types := make([]sqlbase.ColumnType, numCols)
-	for i := 0; i < numCols; i++ {
-		types[i] = intType
-	}
-	input := NewRepeatableRowSource(types, makeIntRows(numRows, numCols))
+	b.SetBytes(8 * numRows * numCols)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		d, err := newDistinct(flowCtx, spec, input, post, &RowDisposer{})
@@ -201,4 +198,5 @@ func BenchmarkDistinct(b *testing.B) {
 		d.Run(ctx, nil)
 		input.Reset()
 	}
+	b.StopTimer()
 }

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -15,6 +15,7 @@
 package distsqlrun
 
 import (
+	"fmt"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -549,6 +550,51 @@ func TestConsumerClosed(t *testing.T) {
 
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
+			}
+		})
+	}
+}
+
+func BenchmarkMergeJoiner(b *testing.B) {
+	ctx := context.Background()
+	evalCtx := tree.MakeTestingEvalContext()
+	defer evalCtx.Stop(ctx)
+	flowCtx := &FlowCtx{
+		Settings: cluster.MakeTestingClusterSettings(),
+		EvalCtx:  evalCtx,
+	}
+
+	spec := &MergeJoinerSpec{
+		LeftOrdering: convertToSpecOrdering(
+			sqlbase.ColumnOrdering{
+				{ColIdx: 0, Direction: encoding.Ascending},
+			}),
+		RightOrdering: convertToSpecOrdering(
+			sqlbase.ColumnOrdering{
+				{ColIdx: 0, Direction: encoding.Ascending},
+			}),
+		Type: JoinType_INNER,
+		// Implicit @1 = @2 constraint.
+	}
+	post := &PostProcessSpec{}
+	disposer := &RowDisposer{}
+
+	const numCols = 1
+	for _, inputSize := range []int{0, 1 << 2, 1 << 4, 1 << 8, 1 << 12, 1 << 16} {
+		b.Run(fmt.Sprintf("InputSize=%d", inputSize), func(b *testing.B) {
+			rows := makeIntRows(inputSize, numCols)
+			leftInput := NewRepeatableRowSource(oneIntCol, rows)
+			rightInput := NewRepeatableRowSource(oneIntCol, rows)
+			b.SetBytes(int64(8 * inputSize * numCols))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				m, err := newMergeJoiner(flowCtx, spec, leftInput, rightInput, post, disposer)
+				if err != nil {
+					b.Fatal(err)
+				}
+				m.Run(ctx, nil)
+				leftInput.Reset()
+				rightInput.Reset()
 			}
 		})
 	}


### PR DESCRIPTION
Interesting that grouping is slightly faster than distinct. They are
doing the same work in these benchmarks. The STDDEV and VARIANCE
aggregations are slow due to decimal computations.

```
name                      time/op
Aggregation/IDENT-8         49.6µs ± 2%
Aggregation/AVG-8           70.4µs ± 1%
Aggregation/COUNT-8         49.6µs ± 2%
Aggregation/MAX-8           56.7µs ± 2%
Aggregation/MIN-8           55.6µs ± 2%
Aggregation/STDDEV-8        1.50ms ± 1%
Aggregation/SUM-8           64.8µs ± 2%
Aggregation/SUM_INT-8       65.4µs ± 4%
Aggregation/VARIANCE-8      1.48ms ± 3%
Aggregation/XOR_AGG-8       50.5µs ± 2%
Grouping-8                   260µs ± 1%
Distinct-8                   291µs ± 1%

name                      speed
Aggregation/IDENT-8        161MB/s ± 2%
Aggregation/AVG-8          114MB/s ± 1%
Aggregation/COUNT-8        161MB/s ± 2%
Aggregation/MAX-8          141MB/s ± 2%
Aggregation/MIN-8          144MB/s ± 2%
Aggregation/STDDEV-8      5.35MB/s ± 1%
Aggregation/SUM-8          124MB/s ± 2%
Aggregation/SUM_INT-8      122MB/s ± 4%
Aggregation/VARIANCE-8    5.42MB/s ± 3%
Aggregation/XOR_AGG-8      158MB/s ± 2%
Grouping-8                30.8MB/s ± 1%
Distinct-8                27.5MB/s ± 1%
```

```
name                      time/op
HashJoiner/rows=0-8         2.90µs ± 1%
HashJoiner/rows=4-8         7.50µs ± 1%
HashJoiner/rows=16-8        18.0µs ± 1%
HashJoiner/rows=256-8        217µs ± 1%
HashJoiner/rows=4096-8      3.39ms ± 1%
HashJoiner/rows=65536-8     64.4ms ± 4%
MergeJoiner/rows=0-8        3.15µs ± 0%
MergeJoiner/rows=4-8        6.50µs ± 1%
MergeJoiner/rows=16-8       14.9µs ± 0%
MergeJoiner/rows=256-8       170µs ± 1%
MergeJoiner/rows=4096-8     2.64ms ± 0%
MergeJoiner/rows=65536-8    44.4ms ± 1%

name                      speed
HashJoiner/rows=0-8
HashJoiner/rows=4-8       4.27MB/s ± 1%
HashJoiner/rows=16-8      7.09MB/s ± 1%
HashJoiner/rows=256-8     9.43MB/s ± 1%
HashJoiner/rows=4096-8    9.66MB/s ± 1%
HashJoiner/rows=65536-8   8.14MB/s ± 4%
MergeJoiner/rows=0-8
MergeJoiner/rows=4-8      4.93MB/s ± 0%
MergeJoiner/rows=16-8     8.61MB/s ± 0%
MergeJoiner/rows=256-8    12.0MB/s ± 1%
MergeJoiner/rows=4096-8   12.4MB/s ± 0%
MergeJoiner/rows=65536-8  11.8MB/s ± 1%
```

Release note: None