### PR TITLE
sql: return an error if IS NULL or IS NOT NULL is ever compared

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2927,6 +2927,10 @@ func (expr *ComparisonExpr) Eval(ctx *EvalContext) (Datum, error) {
 			return MakeDBool(!DBool(left == DNull && right == DNull)), nil
 		case IsNotDistinctFrom:
 			return MakeDBool(left == DNull && right == DNull), nil
+		case Is:
+			return nil, errors.Errorf("IS NULL should never be compared: use IS NOT DISTINCT FROM")
+		case IsNot:
+			return nil, errors.Errorf("IS NOT NULL should never be compared: use IS DISTINCT FROM")
 		default:
 			return DNull, nil
 		}


### PR DESCRIPTION
Comparison expressions with `IS` and `IS NOT` [are normalized](https://github.com/cockroachdb/cockroach/blob/4d3d4d301f327d920b1d93eabcb163b7a85ef4fa/pkg/sql/sem/tree/normalize.go#L448#L457) to `IS NOT DISTINCT FROM` and `IS DISTINCT FROM` respectively.

If `IS NULL` and `IS NOT NULL` is not normalized (e.g. in a go test with a hardcoded filter expression), then `DNull` will always be returned (see changes) (and the filter would fail).

We should raise an error if this ever happens since this is unexpected behavior. 

Release note: None