### PR TITLE
build: allow TESTS to be specified for `make acceptance`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -789,6 +789,7 @@ upload-coverage: $(BOOTSTRAP_TARGET)
 .PHONY: acceptance
 acceptance: TESTTIMEOUT := $(ACCEPTANCETIMEOUT)
 acceptance: export TESTTIMEOUT := $(TESTTIMEOUT)
+acceptance: export TESTS := $(TESTS)
 acceptance: ## Run acceptance tests.
 	@pkg/acceptance/run.sh
 

--- a/pkg/acceptance/run.sh
+++ b/pkg/acceptance/run.sh
@@ -12,4 +12,4 @@ export TMPDIR=$PWD/artifacts/acceptance
 
 # For the acceptance tests that run without Docker.
 make build
-make test PKG=./pkg/acceptance TESTTIMEOUT="${TESTTIMEOUT-30m}" TAGS=acceptance TESTFLAGS="${TESTFLAGS--v -nodes 4} -l $TMPDIR"
+make test PKG=./pkg/acceptance TESTS="${TESTS-.}" TESTTIMEOUT="${TESTTIMEOUT-30m}" TAGS=acceptance TESTFLAGS="${TESTFLAGS--v -nodes 4} -l $TMPDIR"


### PR DESCRIPTION
Release note: None