### PR TITLE
acceptance: Fix schema change allocator test

### DIFF
--- a/pkg/acceptance/allocator_test.go
+++ b/pkg/acceptance/allocator_test.go
@@ -198,7 +198,7 @@ func (at *allocatorTest) Run(ctx context.Context, t *testing.T) {
 				t.Error(err)
 			}
 
-			if err := at.runScrubChecks(ctx, t, "tpcc", "customer"); err != nil {
+			if err := at.runScrubChecks(ctx, t, "tpch", "customer"); err != nil {
 				t.Error(err)
 			}
 		}


### PR DESCRIPTION
A typo in an acceptance test table was causing a failure in the schema
changer tests.

Release note: None