### PR TITLE
sql: build JSON Object by sorting and uniqueifying the key value pair sequence

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3295,15 +3295,15 @@ func asJSON(d tree.Datum) (json.JSON, error) {
 		}
 		return json.FromArrayOfJSON(jsons), nil
 	case *tree.DTuple:
-		m := map[string]interface{}{}
+		builder := json.NewBuilder()
 		for i, e := range t.D {
 			j, err := asJSON(e)
 			if err != nil {
 				return nil, err
 			}
-			m[fmt.Sprintf("f%d", i+1)] = j
+			builder.Add(fmt.Sprintf("f%d", i+1), j)
 		}
-		return json.FromMap(m)
+		return builder.Build(), nil
 	case *tree.DTimestamp, *tree.DTimestampTZ, *tree.DDate, *tree.DUuid, *tree.DOid, *tree.DInterval, *tree.DBytes, *tree.DIPAddr, *tree.DTime:
 		return json.FromString(tree.AsStringWithFlags(t, tree.FmtBareStrings)), nil
 	default:

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -137,6 +137,92 @@ type jsonKeyValuePair struct {
 	v JSON
 }
 
+// Builder builds JSON Object by a key value pair sequence.
+type Builder struct {
+	pairs []jsonKeyValuePair
+}
+
+// NewBuilder returns a Builder with empty state.
+func NewBuilder() *Builder {
+	return &Builder{
+		pairs: []jsonKeyValuePair{},
+	}
+}
+
+// Add appends key value pair to the sequence.
+func (b *Builder) Add(k string, v JSON) {
+	b.pairs = append(b.pairs, jsonKeyValuePair{k: jsonString(k), v: v})
+}
+
+// Build returns a JSON object built from a key value pair sequence and clears
+// Builder to empty state.
+func (b *Builder) Build() JSON {
+	orders := make([]int, len(b.pairs))
+	for i := range orders {
+		orders[i] = i
+	}
+	sorter := pairSorter{
+		pairs:        b.pairs,
+		orders:       orders,
+		hasNonUnique: false,
+	}
+	b.pairs = []jsonKeyValuePair{}
+	sort.Sort(&sorter)
+	sorter.unique()
+	return jsonObject(sorter.pairs)
+}
+
+// pairSorter sorts and uniqueifies JSON pairs. In order to keep
+// the last one for pairs with the same key while sort.Sort is
+// not stable, pairSorter uses []int orders to maintain order and
+// bool hasNonUnique to skip unnecessary uniqueifying.
+type pairSorter struct {
+	pairs        []jsonKeyValuePair
+	orders       []int
+	hasNonUnique bool
+}
+
+func (s *pairSorter) Len() int {
+	return len(s.pairs)
+}
+
+func (s *pairSorter) Less(i, j int) bool {
+	cmp := strings.Compare(string(s.pairs[i].k), string(s.pairs[j].k))
+	if cmp != 0 {
+		return cmp == -1
+	}
+	s.hasNonUnique = true
+	// The element with greater order has lower rank when their keys
+	// are same, since unique algorithm will prefer first element.
+	return s.orders[i] > s.orders[j]
+}
+
+func (s *pairSorter) Swap(i, j int) {
+	s.pairs[i], s.orders[i], s.pairs[j], s.orders[j] = s.pairs[j], s.orders[j], s.pairs[i], s.orders[i]
+}
+
+func (s *pairSorter) unique() {
+	// If there are any duplicate keys, then in sorted order it will have
+	// two pairs with rank i and i + 1 whose keys are same.
+	// For sorting based on comparisons, if two unique elements (pair.k, order)
+	// have rank i and i + 1, they have to compare once to figure out their
+	// relative order in the final position i and i + 1. So if there are any
+	// equal elements, then the sort must have compared them at some point.
+	if !s.hasNonUnique {
+		return
+	}
+	top := 0
+	for i := 1; i < len(s.pairs); i++ {
+		if s.pairs[top].k != s.pairs[i].k {
+			top++
+			if top != i {
+				s.pairs[top] = s.pairs[i]
+			}
+		}
+	}
+	s.pairs = s.pairs[:top+1]
+}
+
 // jsonObject represents a JSON object as a sorted-by-key list of key-value
 // pairs, which are unique by key.
 type jsonObject []jsonKeyValuePair

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -156,7 +156,7 @@ func TestJSONRoundTrip(t *testing.T) {
 		`true`,
 		` true `,
 		`
-        
+
         true
         `,
 		`false`,
@@ -334,6 +334,42 @@ func TestMakeJSON(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			c, err := result.Compare(expectedResult)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if c != 0 {
+				t.Fatalf("expected %v to equal %v", result, expectedResult)
+			}
+		})
+	}
+}
+
+func TestBuildJSONObject(t *testing.T) {
+	testCases := []struct {
+		input []string
+	}{
+		{[]string{}},
+		{[]string{"a"}},
+		{[]string{"a", "c", "a", "b", "a"}},
+		{[]string{"2", "1", "10", "3", "10", "1"}},
+	}
+	// Test whether JSONs built by sorting and map are same and whether
+	// Builder could be reused.
+	b := NewBuilder()
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("keys %v", tc.input), func(t *testing.T) {
+			m := map[string]interface{}{}
+			for i, k := range tc.input {
+				j := FromString(fmt.Sprintf("%d", i))
+				m[k] = j
+				b.Add(k, j)
+			}
+			expectedResult, err := MakeJSON(m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result := b.Build()
 			c, err := result.Compare(expectedResult)
 			if err != nil {
 				t.Fatal(err)
@@ -1146,6 +1182,42 @@ func TestPretty(t *testing.T) {
 			if pretty != tc.expected {
 				t.Fatalf("expected:\n%s\ngot:\n%s\n", tc.expected, pretty)
 			}
+		})
+	}
+}
+
+func BenchmarkBuildJSONObject(b *testing.B) {
+	for _, objectSize := range []int{1, 10, 100, 1000, 10000, 100000} {
+		keys := make([]string, objectSize)
+		for i := 0; i < objectSize; i++ {
+			keys[i] = fmt.Sprintf("key%d", i)
+		}
+		for i := 0; i < objectSize; i++ {
+			p := rand.Intn(objectSize-i) + i
+			keys[i], keys[p] = keys[p], keys[i]
+		}
+		b.Run(fmt.Sprintf("object size %d", objectSize), func(b *testing.B) {
+			b.Run("from builder", func(b *testing.B) {
+				for n := 0; n < b.N; n++ {
+					builder := NewBuilder()
+					for i, k := range keys {
+						builder.Add(k, FromInt(i))
+					}
+					_ = builder.Build()
+				}
+			})
+
+			b.Run("from go map", func(b *testing.B) {
+				for n := 0; n < b.N; n++ {
+					m := map[string]interface{}{}
+					for i, k := range keys {
+						m[k] = FromInt(i)
+					}
+					if _, err := FromMap(m); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
@justinj, here is the benchmark result generated from my laptop. It seems that if all keys are unique, using sorting outperforms other ways.  The way to implement sorting and uniqueify follows [postgresql code](https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/jsonb_util.c#L1819). Please take a look.
```
BenchmarkBuildJSONObject/object_size_1/from_json_pairs-8	       235 ns/op
BenchmarkBuildJSONObject/object_size_10/from_json_pairs-8	      2116 ns/op
BenchmarkBuildJSONObject/object_size_100/from_json_pairs-8	     26620 ns/op
BenchmarkBuildJSONObject/object_size_1000/from_json_pairs-8	    371934 ns/op
BenchmarkBuildJSONObject/object_size_10000/from_json_pairs-8       5226114 ns/op
BenchmarkBuildJSONObject/object_size_100000/from_json_pairs-8     79085001 ns/op
BenchmarkBuildJSONObject/object_size_1/from_go_map-8	               516 ns/op
BenchmarkBuildJSONObject/object_size_10/from_go_map-8     	      3820 ns/op
BenchmarkBuildJSONObject/object_size_100/from_go_map-8   	     45213 ns/op
BenchmarkBuildJSONObject/object_size_1000/from_go_map-8    	    558757 ns/op
BenchmarkBuildJSONObject/object_size_10000/from_go_map-8   	   6254232 ns/op
BenchmarkBuildJSONObject/object_size_100000/from_go_map-8	  97002903 ns/op
BenchmarkBuildJSONObject/object_size_1/from_heap-8       	       276 ns/op
BenchmarkBuildJSONObject/object_size_10/from_heap-8      	      3537 ns/op
BenchmarkBuildJSONObject/object_size_100/from_heap-8     	     47781 ns/op
BenchmarkBuildJSONObject/object_size_1000/from_heap-8     	    685762 ns/op
BenchmarkBuildJSONObject/object_size_10000/from_heap-8  	   8699520 ns/op
BenchmarkBuildJSONObject/object_size_100000/from_heap-8  	 143295973 ns/op
```