### PR TITLE
sql: add several compatibility features

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -113,7 +113,10 @@ CREATE TABLE information_schema.columns (
 	CHARACTER_OCTET_LENGTH INT,
 	NUMERIC_PRECISION INT,
 	NUMERIC_SCALE INT,
-	DATETIME_PRECISION INT
+	DATETIME_PRECISION INT,
+	CHARACTER_SET_CATALOG STRING,
+	CHARACTER_SET_SCHEMA STRING,
+	CHARACTER_SET_NAME STRING
 );
 `,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
@@ -136,6 +139,9 @@ CREATE TABLE information_schema.columns (
 					numericPrecision(column.Type),            // numeric_precision
 					numericScale(column.Type),                // numeric_scale
 					datetimePrecision(column.Type),           // datetime_precision
+					tree.DNull,                               // character_set_catalog
+					tree.DNull,                               // character_set_schema
+					tree.DNull,                               // character_set_name
 				)
 			})
 		})

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1664,3 +1664,8 @@ query TT
 SELECT pg_catalog.pg_encoding_to_char(6), pg_catalog.pg_encoding_to_char(7)
 ----
 UTF8  NULL
+
+query TITI
+SELECT pg_catalog.inet_client_addr(), pg_catalog.inet_client_port(), pg_catalog.inet_server_addr(), pg_catalog.inet_server_port()
+----
+::/0  0  ::/0  0

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1525,12 +1525,12 @@ query error unknown index \(OID=0\)
 SELECT pg_catalog.pg_get_indexdef(0)
 
 statement ok
-CREATE TABLE test.pg_indexdef_test (a INT, INDEX pg_indexdef_idx (a ASC), INDEX other (a DESC))
+CREATE TABLE test.pg_indexdef_test (a INT, UNIQUE INDEX pg_indexdef_idx (a ASC), INDEX other (a DESC))
 
 query T
 SELECT pg_catalog.pg_get_indexdef((SELECT oid from pg_class WHERE relname='pg_indexdef_idx'))
 ----
-CREATE INDEX pg_indexdef_idx ON test.pg_indexdef_test (a ASC)
+CREATE UNIQUE INDEX pg_indexdef_idx ON test.pg_indexdef_test (a ASC)
 
 query error pq: unknown signature: pg_get_indexdef\(int, int, bool\)
 SELECT pg_catalog.pg_get_indexdef(0, 0, true)
@@ -1570,6 +1570,23 @@ query T
 SELECT pg_catalog.pg_get_viewdef('pg_viewdef_view'::regclass::oid, false)
 ----
 SELECT a, b FROM test.pg_viewdef_test
+
+statement ok
+CREATE TABLE test.pg_constraintdef_test (
+  a int,
+  b int unique,
+  c int check (c > a),
+  FOREIGN KEY(a) REFERENCES test.pg_indexdef_test(a) ON DELETE CASCADE
+)
+
+query T rowsort
+SELECT pg_catalog.pg_get_constraintdef(oid)
+FROM pg_catalog.pg_constraint
+WHERE conrelid='pg_constraintdef_test'::regclass
+----
+FOREIGN KEY (a) REFERENCES pg_indexdef_test (a) ON DELETE CASCADE
+CHECK (c > a)
+UNIQUE (b ASC)
 
 # These functions always return NULL since we don't support comments.
 query TTTT

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -138,7 +138,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   5 columns, 77 rows
+·                      size   5 columns, 78 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -195,7 +195,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      13 columns, 639 rows
+                     │                     size      16 columns, 651 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -195,7 +195,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      16 columns, 651 rows
+                     │                     size      16 columns, 652 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -266,6 +266,7 @@ pg_catalog          pg_settings
 pg_catalog          pg_tables
 pg_catalog          pg_tablespace
 pg_catalog          pg_type
+pg_catalog          pg_user
 pg_catalog          pg_views
 system              descriptor
 system              eventlog
@@ -433,6 +434,7 @@ def            pg_catalog          pg_settings                SYSTEM VIEW  1
 def            pg_catalog          pg_tables                  SYSTEM VIEW  1
 def            pg_catalog          pg_tablespace              SYSTEM VIEW  1
 def            pg_catalog          pg_type                    SYSTEM VIEW  1
+def            pg_catalog          pg_user                    SYSTEM VIEW  1
 def            pg_catalog          pg_views                   SYSTEM VIEW  1
 def            system              descriptor                 BASE TABLE   1
 def            system              eventlog                   BASE TABLE   2

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -71,6 +71,7 @@ pg_settings
 pg_tables
 pg_tablespace
 pg_type
+pg_user
 pg_views
 
 query TT colnames
@@ -1073,6 +1074,17 @@ oid         rolname   rolconnlimit  rolpassword  rolvaliduntil  rolbypassrls  ro
 823966177   admin     -1            ********     NULL           false         NULL
 2901009604  root      -1            ********     NULL           false         NULL
 2499926009  testuser  -1            ********     NULL           false         NULL
+
+## pg_catalog.pg_user
+
+query TOBBBBTTA colnames
+SELECT usename, usesysid, usecreatedb, usesuper, userepl, usebypassrls, passwd, valuntil, useconfig
+FROM pg_catalog.pg_user
+ORDER BY usename
+----
+usename   usesysid    usecreatedb  usesuper  userepl  usebypassrls  passwd    valuntil  useconfig
+root      2901009604  true         true      false    false         ********  NULL      NULL
+testuser  2499926009  false        false     false    false         ********  NULL      NULL
 
 ## pg_catalog.pg_description
 

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -40,10 +40,13 @@ SELECT pg_typeof('upper'::REGPROC), pg_typeof('upper'::REGPROCEDURE), pg_typeof(
 ----
 regproc  regprocedure  regtype
 
-query O
-SELECT 'pg_constraint'::REGCLASS
+query OO
+SELECT 'pg_constraint'::REGCLASS, 'pg_catalog.pg_constraint'::REGCLASS
 ----
-pg_constraint
+pg_constraint  pg_constraint
+
+query error relation 'pg_constraint' does not exist
+SELECT 'foo.pg_constraint'::REGCLASS
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT 'pg_constraint'::REGCLASS

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 )
 
 // This file contains builtin functions that we implement primarily for
@@ -415,6 +416,58 @@ var pgBuiltins = map[string][]tree.Builtin{
 					return nil, err
 				}
 				return tree.MakeDBool(tree.DBool(t != nil)), nil
+			},
+			Info: notUsableInfo,
+		},
+	},
+
+	// inet_{client,server}_{addr,port} return either an INet address or integer
+	// port that corresponds to either the client or server side of the current
+	// session's connection.
+	//
+	// They're currently trivially implemented by always returning 0, to prevent
+	// tools that expect them to exist from failing. The output of these builtins
+	// is used in an advisory capacity for displaying in a UI, and is therefore
+	// okay to fake for the time being. Implementing these properly requires
+	// plumbing these values into the EvalContext.
+	//
+	// See https://www.postgresql.org/docs/10/static/functions-info.html
+	"inet_client_addr": {
+		tree.Builtin{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.INet),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return tree.NewDIPAddr(tree.DIPAddr{IPAddr: ipaddr.IPAddr{}}), nil
+			},
+			Info: notUsableInfo,
+		},
+	},
+	"inet_client_port": {
+		tree.Builtin{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return tree.DZero, nil
+			},
+			Info: notUsableInfo,
+		},
+	},
+	"inet_server_addr": {
+		tree.Builtin{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.INet),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return tree.NewDIPAddr(tree.DIPAddr{IPAddr: ipaddr.IPAddr{}}), nil
+			},
+			Info: notUsableInfo,
+		},
+	},
+	"inet_server_port": {
+		tree.Builtin{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Int),
+			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return tree.DZero, nil
 			},
 			Info: notUsableInfo,
 		},

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -85,6 +85,45 @@ func (p *planner) showCreateView(
 	return buf.String(), nil
 }
 
+func (p *planner) printForeignKeyConstraint(
+	ctx context.Context, buf *bytes.Buffer, dbPrefix string, idx sqlbase.IndexDescriptor,
+) error {
+	fk := idx.ForeignKey
+	if !fk.IsSet() {
+		return nil
+	}
+	fkTable, err := p.session.tables.getTableVersionByID(ctx, p.txn, fk.Table)
+	if err != nil {
+		return err
+	}
+	fkDb, err := sqlbase.GetDatabaseDescFromID(ctx, p.txn, fkTable.ParentID)
+	if err != nil {
+		return err
+	}
+	fkIdx, err := fkTable.FindIndexByID(fk.Index)
+	if err != nil {
+		return err
+	}
+	fkTableName := tree.TableName{
+		DatabaseName:            tree.Name(fkDb.Name),
+		TableName:               tree.Name(fkTable.Name),
+		DBNameOriginallyOmitted: fkDb.Name == dbPrefix,
+	}
+	fmt.Fprintf(buf, "FOREIGN KEY (%s) REFERENCES %s (%s)",
+		quoteNames(idx.ColumnNames[0:idx.ForeignKey.SharedPrefixLen]...),
+		&fkTableName,
+		quoteNames(fkIdx.ColumnNames...),
+	)
+	idx.ColNamesString()
+	if fk.OnDelete != sqlbase.ForeignKeyReference_NO_ACTION {
+		fmt.Fprintf(buf, " ON DELETE %s", fk.OnDelete.String())
+	}
+	if fk.OnUpdate != sqlbase.ForeignKeyReference_NO_ACTION {
+		fmt.Fprintf(buf, " ON UPDATE %s", fk.OnUpdate.String())
+	}
+	return nil
+}
+
 // showCreateTable returns a valid SQL representation of the CREATE
 // TABLE statement used to create the given table.
 //
@@ -109,43 +148,18 @@ func (p *planner) showCreateTable(
 		buf.WriteString(col.SQLString())
 		if desc.IsPhysicalTable() && desc.PrimaryIndex.ColumnIDs[0] == col.ID {
 			// Only set primary if the primary key is on a visible column (not rowid).
-			primary = fmt.Sprintf(",\n\tCONSTRAINT %s PRIMARY KEY (%s)",
+			primary = fmt.Sprintf(",\n\tCONSTRAINT %s %s",
 				quoteNames(desc.PrimaryIndex.Name),
-				desc.PrimaryIndex.ColNamesString(),
+				desc.PrimaryKeyString(),
 			)
 		}
 	}
 	buf.WriteString(primary)
 	for _, idx := range append(desc.Indexes, desc.PrimaryIndex) {
 		if fk := idx.ForeignKey; fk.IsSet() {
-			fkTable, err := p.session.tables.getTableVersionByID(ctx, p.txn, fk.Table)
-			if err != nil {
+			fmt.Fprintf(&buf, ",\n\tCONSTRAINT %s ", tree.Name(fk.Name))
+			if err := p.printForeignKeyConstraint(ctx, &buf, dbPrefix, idx); err != nil {
 				return "", err
-			}
-			fkDb, err := sqlbase.GetDatabaseDescFromID(ctx, p.txn, fkTable.ParentID)
-			if err != nil {
-				return "", err
-			}
-			fkIdx, err := fkTable.FindIndexByID(fk.Index)
-			if err != nil {
-				return "", err
-			}
-			fkTableName := tree.TableName{
-				DatabaseName:            tree.Name(fkDb.Name),
-				TableName:               tree.Name(fkTable.Name),
-				DBNameOriginallyOmitted: fkDb.Name == dbPrefix,
-			}
-			fmt.Fprintf(&buf, ",\n\tCONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s)",
-				tree.Name(fk.Name),
-				quoteNames(idx.ColumnNames[0:idx.ForeignKey.SharedPrefixLen]...),
-				&fkTableName,
-				quoteNames(fkIdx.ColumnNames...),
-			)
-			if fk.OnDelete != sqlbase.ForeignKeyReference_NO_ACTION {
-				fmt.Fprintf(&buf, " ON DELETE %s", fk.OnDelete.String())
-			}
-			if fk.OnUpdate != sqlbase.ForeignKeyReference_NO_ACTION {
-				fmt.Fprintf(&buf, " ON UPDATE %s", fk.OnUpdate.String())
 			}
 		}
 		if idx.ID != desc.PrimaryIndex.ID {

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -273,16 +273,24 @@ func (desc *IndexDescriptor) FullColumnIDs() ([]ColumnID, []encoding.Direction) 
 	return columnIDs, dirs
 }
 
-// ColNamesString returns a string describing the column names and directions
-// in this index.
-func (desc *IndexDescriptor) ColNamesString() string {
-	var buf bytes.Buffer
+// ColNamesFormat writes a string describing the column names and directions
+// in this index to the given buffer.
+func (desc *IndexDescriptor) ColNamesFormat(buf *bytes.Buffer) {
 	for i, name := range desc.ColumnNames {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		fmt.Fprintf(&buf, "%s %s", tree.Name(name), desc.ColumnDirections[i])
+		tree.Name(name).Format(buf, tree.FmtSimple)
+		buf.WriteByte(' ')
+		buf.WriteString(desc.ColumnDirections[i].String())
 	}
+}
+
+// ColNamesString returns a string describing the column names and directions
+// in this index.
+func (desc *IndexDescriptor) ColNamesString() string {
+	var buf bytes.Buffer
+	desc.ColNamesFormat(&buf)
 	return buf.String()
 }
 
@@ -1397,6 +1405,14 @@ func PrintPartitioningTuple(buf *bytes.Buffer, datums []tree.Datum, numColumns i
 			buf.WriteString(s)
 		}
 	}
+}
+
+// PrimaryKeyString returns the pretty-printed primary key declaration for a
+// table descriptor.
+func (desc *TableDescriptor) PrimaryKeyString() string {
+	return fmt.Sprintf("PRIMARY KEY (%s)",
+		desc.PrimaryIndex.ColNamesString(),
+	)
 }
 
 // validatePartitioningDescriptor validates that a PartitioningDescriptor, which


### PR DESCRIPTION
[pgweb](http://sosedoff.github.io/pgweb/) has been requested by several users. All of the following compatibility items are required by that tool. `has_schema_privilege` is still a blocker for `pgweb` and will be added in a separate PR.

- Add `pg_get_constraintdef`. Closes #20787.
- Add no-op `inet_{client_server}_{addr,port}`
- Add `pg_catalog.pg_user` virtual table. Closes #20785.
- Add some missing always-NULL fields to `information_schema.columns`
- Support `schema.name` format in `::regclass` casts. Closes #20786.