### PR TITLE
storage: avoid panicing on uninitialized replica in IsInitialized

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1543,7 +1543,7 @@ func (r *Replica) IsInitialized() bool {
 // to an incoming message but we are waiting for our initial snapshot.
 // isInitializedLocked requires that the replica lock is held.
 func (r *Replica) isInitializedRLocked() bool {
-	return r.mu.state.Desc.IsInitialized()
+	return r.mu.state.Desc != nil && r.mu.state.Desc.IsInitialized()
 }
 
 // Desc returns the authoritative range descriptor, acquiring a replica lock in

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -363,6 +363,23 @@ func createReplicaSets(replicaNumbers []roachpb.StoreID) []roachpb.ReplicaDescri
 	return result
 }
 
+// TestIsInitialized verifies that IsInitialized can be called on a completely
+// un-initialized replica without triggering a nil pointer exception.
+func TestIsInitialized(t *testing.T) {
+	var r Replica
+	if r.IsInitialized() {
+		t.Fatalf("r.IsInitialized() got true, want false")
+	}
+	r.mu.state.Desc = &roachpb.RangeDescriptor{
+		RangeID:  1,
+		StartKey: roachpb.RKey("a"),
+		EndKey:   roachpb.RKey("b"),
+	}
+	if !r.IsInitialized() {
+		t.Fatalf("r.IsInitialized() got false, want true")
+	}
+}
+
 // TestIsOnePhaseCommit verifies the circumstances where a
 // transactional batch can be committed as an atomic write.
 func TestIsOnePhaseCommit(t *testing.T) {


### PR DESCRIPTION
This is the lazy man's fix -- I haven't tracked down in what situation `replica.mu.state.Desc` hasn't been initialized but the replica is still being processed in the queues. If that situation is unexpected to you, I can dig more into why that's happening. It's also causing https://github.com/cockroachdb/cockroach/issues/20793 (on the same 1.0.4 cluster).

Fixes #20791

Release note (bug fix): Fix panic caused by very rare
uninitialized state.