### PR TITLE
sql: support NULLs in COLLATE expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -21,6 +21,11 @@ SELECT 'A' COLLATE en
 ----
 A
 
+query T
+SELECT NULL COLLATE en
+----
+NULL
+
 query B
 SELECT 'a' COLLATE en < ('B' COLLATE de) COLLATE en
 ----
@@ -283,7 +288,14 @@ statement ok
 CREATE TABLE foo(a STRING COLLATE en_u_ks_level2)
 
 statement ok
-PREPARE x AS INSERT INTO foo VALUES ($1 COLLATE en_u_ks_level2)
+PREPARE x AS INSERT INTO foo VALUES ($1 COLLATE en_u_ks_level2) RETURNING a
 
-query error incompatible type for COLLATE: NULL
+query T
 EXECUTE x(NULL)
+----
+NULL
+
+query T
+SELECT a FROM foo
+----
+NULL

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2886,7 +2886,11 @@ func (expr *CollateExpr) Eval(ctx *EvalContext) (Datum, error) {
 	if err != nil {
 		return DNull, err
 	}
-	switch d := UnwrapDatum(ctx, d).(type) {
+	unwrapped := UnwrapDatum(ctx, d)
+	if unwrapped == DNull {
+		return DNull, nil
+	}
+	switch d := unwrapped.(type) {
 	case *DString:
 		return NewDCollatedString(string(*d), expr.Locale, &ctx.collationEnv), nil
 	case *DCollatedString:

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -365,7 +365,7 @@ func (expr *CollateExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr
 		return nil, err
 	}
 	t := subExpr.ResolvedType()
-	if types.IsStringType(t) {
+	if types.IsStringType(t) || t == types.Null {
 		expr.Expr = subExpr
 		expr.typ = types.TCollatedString{Locale: expr.Locale}
 		return expr, nil


### PR DESCRIPTION
Fixes #20646.

Release note: allowed NULLs to appear in COLLATE expressions.