### PR TITLE
sql: Add DROP INDEX restrict behaviour

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -297,7 +297,14 @@ func (n *alterTableNode) startExec(params runParams) error {
 				if containsThisColumn {
 					if containsOnlyThisColumn || t.DropBehavior == tree.DropCascade {
 						if err := params.p.dropIndexByName(
-							params.ctx, tree.UnrestrictedName(idx.Name), n.tableDesc, false, t.DropBehavior, ignoreOutboundFK,
+							params.ctx,
+							tree.UnrestrictedName(idx.Name),
+							n.tableDesc,
+							false, /* ifExists */
+							nil,   /* constraints */
+							true,  /* droppingColumn */
+							t.DropBehavior,
+							ignoreOutboundFK,
 							tree.AsStringWithFlags(n.n, tree.FmtSimpleQualified),
 						); err != nil {
 							return err

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -188,7 +188,7 @@ statement error UNIQUE constraint depends on index "foo", use DROP INDEX if you 
 ALTER TABLE t DROP CONSTRAINT foo
 
 statement ok
-DROP INDEX foo
+DROP INDEX foo CASCADE
 
 query TTTTRT
 SELECT type, description, username, status, fraction_completed, error
@@ -196,7 +196,7 @@ FROM crdb_internal.jobs
 ORDER BY created DESC
 LIMIT 1
 ----
-SCHEMA CHANGE  DROP INDEX test.t@foo  root  succeeded  1  ·
+SCHEMA CHANGE  DROP INDEX test.t@foo CASCADE  root  succeeded  1  ·
 
 query TTBITTBB colnames
 SHOW INDEXES FROM t

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -82,8 +82,15 @@ GRANT CREATE ON TABLE users TO testuser
 
 user testuser
 
-statement ok
+# Test drop index will not drop an index when a unique constraint depends on it if not using CASCADE
+statement error index "bar" is in use by unique constraint "bar"
+DROP INDEX users@bar RESTRICT
+
+statement error index "bar" is in use by unique constraint "bar"
 DROP INDEX users@bar
+
+statement ok
+DROP INDEX users@bar CASCADE
 
 query TTBITTBB colnames
 SHOW INDEXES FROM users

--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -201,7 +201,7 @@ b  false
 c  false
 
 statement ok
-DROP INDEX i14601a
+DROP INDEX i14601a CASCADE
 
 query TB
 SELECT a, b FROM t14601a ORDER BY a


### PR DESCRIPTION
Previously if DROP INDEX was run on an index that had a constraints that
depended on it, those constraints would be dropped as if the drop
operation was cascade. This adds the restrict behaviour which will now
prevent this.

Fixes #12620