### PR TITLE
sqlbase: alias coltype.BigInt to VisibleType.BIGINT

### DIFF
--- a/pkg/sql/coltypes/aliases.go
+++ b/pkg/sql/coltypes/aliases.go
@@ -21,6 +21,7 @@ var (
 	Bool = &TBool{Name: "BOOL"}
 	// Boolean is an immutable T instance.
 	Boolean = &TBool{Name: "BOOLEAN"}
+
 	// Bit is an immutable T instance.
 	Bit = &TInt{Name: "BIT", Width: 1, ImplicitWidth: true}
 	// Int is an immutable T instance.

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -360,7 +360,7 @@ query TTBTT colnames
 SHOW COLUMNS FROM test.alltypes
 ----
 Field             Type                      Null  Default         Indices
-cbigint           INT                       true  NULL            {}
+cbigint           BIGINT                    true  NULL            {}
 cbigserial        INT                       true  unique_rowid()  {}
 cbit              BIT(1)                    true  NULL            {}
 cbit12            BIT(12)                   true  NULL            {}

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -38,18 +38,23 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
-var nameToVisibleTypeMap = map[string]ColumnType_VisibleType{
-	"INTEGER":          ColumnType_INTEGER,
-	"INT4":             ColumnType_INTEGER,
-	"INT8":             ColumnType_BIGINT,
-	"INT64":            ColumnType_BIGINT,
-	"BIT":              ColumnType_BIT,
-	"INT2":             ColumnType_SMALLINT,
-	"SMALLINT":         ColumnType_SMALLINT,
-	"FLOAT4":           ColumnType_REAL,
-	"REAL":             ColumnType_REAL,
-	"FLOAT8":           ColumnType_DOUBLE_PRECISION,
-	"DOUBLE PRECISION": ColumnType_DOUBLE_PRECISION,
+// aliasToVisibleTypeMap maps type aliases to ColumnType_VisibleType variants
+// so that the alias is persisted. When adding new column type aliases or new
+// VisibleType variants, consider adding to this mapping as well.
+var aliasToVisibleTypeMap = map[string]ColumnType_VisibleType{
+	coltypes.Bit.Name:      ColumnType_BIT,
+	coltypes.Int2.Name:     ColumnType_SMALLINT,
+	coltypes.Int4.Name:     ColumnType_INTEGER,
+	coltypes.Int8.Name:     ColumnType_BIGINT,
+	coltypes.Int64.Name:    ColumnType_BIGINT,
+	coltypes.Integer.Name:  ColumnType_INTEGER,
+	coltypes.SmallInt.Name: ColumnType_SMALLINT,
+	coltypes.BigInt.Name:   ColumnType_BIGINT,
+
+	coltypes.Real.Name:   ColumnType_REAL,
+	coltypes.Float4.Name: ColumnType_REAL,
+	coltypes.Float8.Name: ColumnType_DOUBLE_PRECISION,
+	coltypes.Double.Name: ColumnType_DOUBLE_PRECISION,
 }
 
 func exprContainsVarsError(context string, Expr tree.Expr) error {
@@ -95,7 +100,7 @@ func populateTypeAttrs(
 	case *coltypes.TBool:
 	case *coltypes.TInt:
 		base.Width = int32(t.Width)
-		if val, present := nameToVisibleTypeMap[t.Name]; present {
+		if val, present := aliasToVisibleTypeMap[t.Name]; present {
 			base.VisibleType = val
 		}
 	case *coltypes.TFloat:
@@ -104,7 +109,7 @@ func populateTypeAttrs(
 			return ColumnType{}, errors.New("precision for type float must be at least 1 bit")
 		}
 		base.Precision = int32(t.Prec)
-		if val, present := nameToVisibleTypeMap[t.Name]; present {
+		if val, present := aliasToVisibleTypeMap[t.Name]; present {
 			base.VisibleType = val
 		}
 	case *coltypes.TDecimal:

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -54,8 +54,38 @@ func TestMakeTableDescColumns(t *testing.T) {
 			true,
 		},
 		{
+			"INT2",
+			sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT, Width: 16, VisibleType: sqlbase.ColumnType_SMALLINT},
+			true,
+		},
+		{
+			"INT4",
+			sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT, Width: 32, VisibleType: sqlbase.ColumnType_INTEGER},
+			true,
+		},
+		{
+			"INT8",
+			sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT, VisibleType: sqlbase.ColumnType_BIGINT},
+			true,
+		},
+		{
+			"INT64",
+			sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT, VisibleType: sqlbase.ColumnType_BIGINT},
+			true,
+		},
+		{
+			"BIGINT",
+			sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT, VisibleType: sqlbase.ColumnType_BIGINT},
+			true,
+		},
+		{
 			"FLOAT(3)",
 			sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_FLOAT, Precision: 3},
+			true,
+		},
+		{
+			"DOUBLE PRECISION",
+			sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_FLOAT, VisibleType: sqlbase.ColumnType_DOUBLE_PRECISION},
 			true,
 		},
 		{


### PR DESCRIPTION
Fixes #19197.

This change cleans up the `coltype` to `VisibleType` alias mapping and adds
an alias for `coltype.BigInt -> VisibleType.BIGINT`.

The `coltypes.Double -> VisibleType.DOUBLE_PRECISION` mapping referenced in
the associated issue was already addressed during some previous refactor.

Release note (bug fix): The BIGINT type alias is now correctly shown
when using SHOW CREATE TABLE.