### PR TITLE
ui: don't render GC pause time twice

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -97,7 +97,6 @@ export default function (props: GraphDashboardProps) {
       <Axis units={AxisUnits.Duration}>
         <Metric name="cr.node.sys.cpu.user.ns" title="User CPU Time" nonNegativeRate />
         <Metric name="cr.node.sys.cpu.sys.ns" title="Sys CPU Time" nonNegativeRate />
-        <Metric name="cr.node.sys.gc.pause.ns" title="GC Pause Time" nonNegativeRate />
       </Axis>
     </LineGraph>,
   ];


### PR DESCRIPTION
I opted for leaving it in its own graph, for it is usually much smaller than
what's plotted under CPU Time, and that would make even pronounced spikes easy
to miss.

Fixes #20736.

Release note (admin ui change): Removed a redundant rendering of the GC pause time from the CPU time graph.