### PR TITLE
cli: split the notions of "interactive session" and "terminal output"

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"text/tabwriter"
 
-	"github.com/mattn/go-isatty"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/context"
@@ -110,11 +109,6 @@ var cockroachCmd = &cobra.Command{
 	// in fact, a result of a bad invocation, e.g. too many arguments.
 	SilenceUsage: true,
 }
-
-// isInteractive indicates whether both stdin and stdout refer to the
-// terminal.
-var isInteractive = isatty.IsTerminal(os.Stdout.Fd()) &&
-	isatty.IsTerminal(os.Stdin.Fd())
 
 func init() {
 	cobra.EnableCommandSorting = false

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -705,7 +705,6 @@ func Example_sql() {
 
 	c.RunWithArgs([]string{"sql", "-e", "show application_name"})
 	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int); insert into t.f values (42, 69)"})
-	c.RunWithArgs([]string{"sql", "-e", "delete from t.f"})
 	c.RunWithArgs([]string{"sql", "-e", "select 3", "-e", "select * from t.f"})
 	c.RunWithArgs([]string{"sql", "-e", "begin", "-e", "select 3", "-e", "commit"})
 	c.RunWithArgs([]string{"sql", "-e", "select * from t.f"})
@@ -733,8 +732,6 @@ func Example_sql() {
 	// # 1 row
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
 	// INSERT 1
-	// sql -e delete from t.f
-	// pq: rejected: DELETE without WHERE clause (sql_safe_updates = true)
 	// sql -e select 3 -e select * from t.f
 	// 3
 	// 3

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -359,7 +359,7 @@ func init() {
 	// in the CLI shell.
 	cliCtx.tableDisplayFormat = tableDisplayTSV
 	cliCtx.showTimes = false
-	if isInteractive {
+	if cliCtx.terminalOutput {
 		cliCtx.tableDisplayFormat = tableDisplayPretty
 	}
 	for _, cmd := range tableOutputCommands {

--- a/pkg/cli/interactive_tests/test_last_statement.tcl
+++ b/pkg/cli/interactive_tests/test_last_statement.tcl
@@ -68,12 +68,12 @@ eexpect ":/# "
 end_test
 
 start_test "Check that a final comment after a final statement does not cause an error message. #9482"
-send "printf 'select 1;-- final comment' | $argv sql\r"
+send "printf 'select 1;-- final comment' | $argv sql | cat\r"
 eexpect "1\r\n1\r\n# 1 row\r\n:/# "
 end_test
 
 start_test "Check that a final comment does not cause an error message. #9243"
-send "printf 'select 1;\\n-- final comment' | $argv sql\r"
+send "printf 'select 1;\\n-- final comment' | $argv sql | cat\r"
 eexpect "1\r\n1\r\n# 1 row\r\n:/# "
 end_test
 

--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -10,18 +10,25 @@ eexpect ":/# "
 
 # Check table ASCII art with and without --format=pretty. (#7268)
 
-start_test "Check that tables are pretty-printed when input is not a terminal but --format=pretty is specified."
-send "echo 'select 1;' | $argv sql --format=pretty\r"
+start_test "Check that tables are pretty-printed when output is not a terminal but --format=pretty is specified."
+send "echo 'select 1;' | $argv sql --format=pretty | cat\r"
 eexpect "+-*+\r\n*\r\n+-*+\r\n*1 row"
 eexpect ":/# "
 end_test
 
-start_test "Check that tables are not pretty-printed when input is not a terminal and --format=pretty is not specified."
+start_test "Check that tables are pretty-printed when input is not a terminal and --format=pretty is not specified, but output is a terminal."
 send "echo begin; echo 'select 1;' | $argv sql\r"
-eexpect "begin\r\n1\r\n1\r\n# 1 row\r\n"
+eexpect "+-*+\r\n*\r\n+-*+\r\n*1 row"
+eexpect ":/# "
 end_test
 
-start_test "Check that tables are pretty-printed when input is a terminal and --format=pretty is not specified."
+start_test "Check that tables are not pretty-printed when output is not a terminal and --format=pretty is not specified"
+send "echo begin; echo 'select 1;' | $argv sql | cat\r"
+eexpect "begin\r\n1\r\n1\r\n# 1 row\r\n"
+eexpect ":/# "
+end_test
+
+start_test "Check that tables are pretty-printed when input and output are a terminal and --format=pretty is not specified."
 send "$argv sql\r"
 eexpect root@
 send "select 1;\r"
@@ -37,7 +44,7 @@ eexpect "+-*+\r\n*1 row"
 eexpect root@
 end_test
 
-start_test "Check that tables are not pretty-printed when input is a terminal and --format=tsv is specified."
+start_test "Check that tables are not pretty-printed when output is a terminal and --format=tsv is specified."
 send "\\q\r"
 eexpect ":/# "
 send "$argv sql --format=tsv\r"

--- a/pkg/cli/interactive_tests/test_sql_safe_updates.tcl
+++ b/pkg/cli/interactive_tests/test_sql_safe_updates.tcl
@@ -1,0 +1,53 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn /bin/bash
+send "PS1=':''/# '\r"
+eexpect ":/# "
+
+start_test "Check that dangerous statements are properly rejected when running interactively with terminal output."
+send "$argv sql\r"
+eexpect root@
+send "create database d;\rcreate table d.t(x int);\r"
+eexpect "CREATE"
+eexpect "CREATE"
+eexpect root@
+
+send "delete from d.t;\r"
+eexpect "rejected: DELETE without WHERE clause (sql_safe_updates = true)"
+eexpect root@
+end_test
+
+send "\\q\r"
+eexpect ":/# "
+
+start_test "Check that dangerous statements are properly rejected when inputting from user even with output redirected."
+send "$argv sql | cat\r"
+# We can't immediately send input, because the shell will eat stdin just before it's ready.
+eexpect "brief introduction"
+sleep 0.4
+send "show sql_safe_updates;\r"
+eexpect "true"
+eexpect "1 row"
+send "delete from d.t;\r"
+eexpect "rejected: DELETE without WHERE clause (sql_safe_updates = true)"
+send "\\q\r"
+eexpect ":/# "
+end_test
+
+start_test "Check that dangerous statements are not rejected when input redirected."
+send "echo 'delete from d.t;' | $argv sql \r"
+eexpect "DELETE"
+eexpect ":/# "
+end_test
+
+start_test "Check that dangerous statements are not rejected when using -e."
+send "$argv sql -e 'delete from d.t'\r"
+eexpect "DELETE"
+eexpect ":/# "
+end_test
+
+stop_server $argv

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -67,7 +67,7 @@ type sqlConn struct {
 
 func (c *sqlConn) ensureConn() error {
 	if c.conn == nil {
-		if c.reconnecting && isInteractive {
+		if c.reconnecting && cliCtx.isInteractive {
 			fmt.Fprintf(stderr, "connection lost; opening new connection: all session settings will be lost\n")
 		}
 		conn, err := pq.Open(c.url)
@@ -97,8 +97,9 @@ func (c *sqlConn) ensureConn() error {
 // the last connection, based on the last known values in the sqlConn
 // struct.
 func (c *sqlConn) checkServerMetadata() error {
-	if !isInteractive {
-		// Version reporting is just noise in non-interactive sessions.
+	if !cliCtx.isInteractive {
+		// Version reporting is just noise if the user is not present to
+		// change their mind upon seeing the information.
 		return nil
 	}
 

--- a/pkg/cli/testutils.go
+++ b/pkg/cli/testutils.go
@@ -21,6 +21,7 @@ func TestingReset() {
 	// pointers (because they are tied into the flags), but instead
 	// overwrite the existing structs' values.
 	baseCfg.InitDefaults()
+	cliCtx.isInteractive = false
 	cliCtx.tableDisplayFormat = tableDisplayTSV
 	cliCtx.showTimes = false
 	dumpCtx.dumpMode = dumpBoth


### PR DESCRIPTION
Fixes #19775.
Informs https://github.com/cockroachdb/docs/issues/2263 & https://github.com/cockroachdb/docs/issues/2248

Prior to this patch, a single boolean notion "interactive session" was
used to decide default settings for client commands that issue SQL
queries. This characteristic was decided based on whether both standard
input and standard output are on a terminal.

This characterisation was erroneous however as it didn't properly
account for the following:

- sessions started with `cockroach sql -e`, or non-interactive
  commands like `cockroach node`. These are definitely
  non-interactive, even if the standard input is a terminal.
- sessions started with `cockroach sql >foo.out`, i.e. letting the
  human enter commands from standard input but redirecting output to a
  file. These are arguably interactive and should benefit from the
  various defaults meant to help human users.

To achieve this, this patch separates the notions:

- an *interactive session* is one where the `cockroach` command is
  confident there's a user *manually entering queries*, looking at
  results in-between inputs. This is only decided to be true if 1) the
  `cockroach sql` command is used, 2) the standard input is a terminal
  3) `-e` is not used.
- a session with *terminal output* is where the `cockroach` command
  is confident there's a user *looking at the output*.

These characteristics are then used as follows to decide defaults:

| Setting                        | New default                                             | Previous bug(s) |
|--------------------------------|---------------------------------------------------------|------------------|
| `sql_safe_updates` (session)   | true when the session is interactive and `--unsafe-updates` not given, false otherwise. | defaulted to true always, not only when interactive |
| `check_syntax` (client)        | true when the session is interactive, false otherwise.  | erroneously false when inputting from user with output redirected |
| `errexit` (client)             | false when the session is interactive, true otherwise.  | erroneously true when inputting from user with output redirected |
| `display_format` (client)      | `pretty` when the output goes to a terminal and `--display-format` not given, `tsv` otherwise. | erroneously `tsv` when outputing to terminal with input redirected |
| `show_times` (client)          | true when the output goes to a terminal and `display_format` is `pretty`, false otherwise.     | erroneously false when outputting to terminal with input redirected |
| Input line editor              | true when the session is both interactive and outputting on a terminal, false otherwise.       | N/A |
| `smart_prompt` (client)        | true when the input line editor is enabled.             | N/A |
| Display of input prompt        | true when the input line editor is enabled.             | N/A |
| Storing the input history      | true when the input line editor is enabled.             | N/A |
| `echo` (client)                | always false unless `--echo-sql` given.                 | N/A |

Release note (bug fix, cli change):

- The session variable `sql_safe_updates` defaults to `false` unless
  the shell is truly interactive (using `cockroach sql`, `-e` not
  provided, standard input not redirected) and `--unsafe-updates` is
  not provided.
  Previously it would always default to `true` unless `--unsafe-updates`
  was set.

- The client-side option `errexit` defaults to `false` only if the
  shell is truly interactive, not only when the input is not
  redirected as previously.

- The client-side option `display_format` defaults to `pretty` in
  every case where the output goes to a terminal, not only when the
  input is not redirected as previously.

- `check_syntax`, `smart_prompt` (client-side options), together with
  the interactive line editor, are only enabled if the session is
  interactive and output goes to a terminal.