### PR TITLE
*: Reduce log spam when starting node in an unhealthy cluster

### DIFF
--- a/pkg/util/log/every_n.go
+++ b/pkg/util/log/every_n.go
@@ -1,0 +1,55 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package log
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// EveryN provides a way to rate limit spammy log messages. It tracks how
+// recently a given log message has been emitted so that it can determine
+// whether it's worth logging again.
+type EveryN struct {
+	// N is the minimum duration of time between log messages.
+	N time.Duration
+
+	syncutil.Mutex
+	lastLog time.Time
+}
+
+// Every is a convenience constructor for an EveryN object that allows a log
+// message every n duration.
+func Every(n time.Duration) EveryN {
+	return EveryN{N: n}
+}
+
+// ShouldLog returns whether it's been more than N time since the last event.
+func (e *EveryN) ShouldLog() bool {
+	return e.shouldLog(timeutil.Now())
+}
+
+func (e *EveryN) shouldLog(now time.Time) bool {
+	var shouldLog bool
+	e.Lock()
+	if now.Sub(e.lastLog) >= e.N {
+		shouldLog = true
+		e.lastLog = now
+	}
+	e.Unlock()
+	return shouldLog
+}

--- a/pkg/util/log/every_n_test.go
+++ b/pkg/util/log/every_n_test.go
@@ -1,0 +1,48 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package log
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func TestEveryN(t *testing.T) {
+	start := timeutil.Now()
+	en := EveryN{N: time.Minute}
+	testCases := []struct {
+		t        time.Duration // time since start
+		expected bool
+	}{
+		{0, true}, // the first attempt to log should always succeed
+		{0, false},
+		{time.Second, false},
+		{time.Minute - 1, false},
+		{time.Minute, true},
+		{time.Minute, false},
+		{time.Minute + 30*time.Second, false},
+		{10 * time.Minute, true},
+		{10 * time.Minute, false},
+		{10*time.Minute + 59*time.Second, false},
+		{11 * time.Minute, true},
+	}
+	for _, tc := range testCases {
+		if a, e := en.shouldLog(start.Add(tc.t)), tc.expected; a != e {
+			t.Errorf("ShouldLog(%v) got %v, want %v", tc.t, a, e)
+		}
+	}
+}


### PR DESCRIPTION
You could also reasonably argue that we should reduce the frequency of

`could not gossip system config: [NotLeaseHolderError] r7: replica (n1,s1):1 not lease holder; lease holder unknown`

Since we log that about once a second as well. I'm erring on the side of
leaving it in, though, unless reviewers feel otherwise.

Fixes #19599

Release note: None