### PR TITLE
ui: add 404 page

### DIFF
--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -50,6 +50,7 @@ import Certificates from "src/views/reports/containers/certificates";
 import Range from "src/views/reports/containers/range";
 import CommandQueue from "src/views/reports/containers/commandQueue";
 import Debug from "src/views/reports/containers/debug";
+import NotFound from "src/views/app/components/NotFound";
 
 import { alertDataSync } from "src/redux/alerts";
 
@@ -110,6 +111,7 @@ ReactDOM.render(
           <Route path={`range/:${rangeIDAttr}/cmdqueue`} component={ CommandQueue } />
         </Route>
         { visualizationRoutes() }
+        <Route path="*" component={ NotFound } />
       </Route>
     </Router>
   </Provider>,

--- a/pkg/ui/src/views/app/components/NotFound/index.tsx
+++ b/pkg/ui/src/views/app/components/NotFound/index.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+function NotFound() {
+  return (
+    <div className="section">
+      <h1>Page Not Found</h1>
+    </div>
+  );
+}
+
+export default NotFound;


### PR DESCRIPTION
Only works when no route is matched, not when a route is matched but the API call gets a not found. (Not sure if the latter is even standardized in our API calls)

<img width="952" alt="screen shot 2017-12-18 at 12 12 27 pm" src="https://user-images.githubusercontent.com/7341/34121172-2765b16c-e3f6-11e7-94d7-e4825c70700a.png">

Fixes #20687

Release note: Add 404 page to the UI.