### PR TITLE
sql: permit table alias use in RETURNING clauses

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -53,7 +53,7 @@ func (p *planner) Delete(
 		return nil, pgerror.NewDangerousStatementErrorf("DELETE without WHERE clause")
 	}
 
-	tn, err := p.getAliasedTableName(n.Table)
+	tn, alias, err := p.getAliasedTableName(n.Table)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (p *planner) Delete(
 	}
 
 	if err := dn.run.initEditNode(
-		ctx, &dn.editNodeBase, rows, &dn.tw, tn, n.Returning, desiredTypes); err != nil {
+		ctx, &dn.editNodeBase, rows, &dn.tw, alias, n.Returning, desiredTypes); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -66,7 +66,7 @@ type insertNode struct {
 func (p *planner) Insert(
 	ctx context.Context, n *tree.Insert, desiredTypes []types.T,
 ) (planNode, error) {
-	tn, err := p.getAliasedTableName(n.Table)
+	tn, alias, err := p.getAliasedTableName(n.Table)
 	if err != nil {
 		return nil, err
 	}
@@ -261,7 +261,7 @@ func (p *planner) Insert(
 	}
 
 	if err := in.run.initEditNode(
-		ctx, &in.editNodeBase, rows, in.tw, tn, n.Returning, desiredTypes); err != nil {
+		ctx, &in.editNodeBase, rows, in.tw, alias, n.Returning, desiredTypes); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/returning
+++ b/pkg/sql/logictest/testdata/logic_test/returning
@@ -1,0 +1,25 @@
+# LogicTest: default parallel-stmts
+
+statement ok
+CREATE TABLE a (a int, b int)
+
+# Issue #6092 - table aliases in returning clauses.
+
+query II
+INSERT INTO a AS alias VALUES(1, 2) RETURNING alias.a, alias.b
+----
+1 2
+
+query II
+UPDATE a AS alias SET b = 1 RETURNING alias.a, alias.b
+----
+1 1
+
+# Can't mix aliases and non-aliases.
+query error source name "a" not found in FROM clause
+UPDATE a AS alias SET b = 1 RETURNING alias.a, a.b
+
+query II
+DELETE FROM a AS alias RETURNING alias.a, alias.b
+----
+1 1

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -61,7 +61,7 @@ func (p *planner) Update(
 
 	tracing.AnnotateTrace()
 
-	tn, err := p.getAliasedTableName(n.Table)
+	tn, alias, err := p.getAliasedTableName(n.Table)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +239,7 @@ func (p *planner) Update(
 		return nil, err
 	}
 	if err := un.run.initEditNode(
-		ctx, &un.editNodeBase, rows, &un.tw, tn, n.Returning, desiredTypes); err != nil {
+		ctx, &un.editNodeBase, rows, &un.tw, alias, n.Returning, desiredTypes); err != nil {
 		return nil, err
 	}
 	return un, nil


### PR DESCRIPTION
Fixes #6092.

Release note (sql change): permit use of table aliases in RETURNING
clauses.