### PR TITLE
server: remove COCKROACH_METRICS_SAMPLE_INTERVAL

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -75,7 +75,6 @@ type TestServerArgs struct {
 	// Fields copied to the server.Config.
 	Insecure                 bool
 	RetryOptions             retry.Options
-	MetricsSampleInterval    time.Duration
 	SocketFile               string
 	ScanInterval             time.Duration
 	ScanMaxIdleTime          time.Duration

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -94,9 +94,6 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		if err := os.Unsetenv("COCKROACH_LINEARIZABLE"); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.Unsetenv("COCKROACH_METRICS_SAMPLE_INTERVAL"); err != nil {
-			t.Fatal(err)
-		}
 		if err := os.Unsetenv("COCKROACH_SCAN_INTERVAL"); err != nil {
 			t.Fatal(err)
 		}
@@ -130,10 +127,6 @@ func TestReadEnvironmentVariables(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfgExpected.Linearizable = true
-	if err := os.Setenv("COCKROACH_METRICS_SAMPLE_INTERVAL", "1h10m"); err != nil {
-		t.Fatal(err)
-	}
-	cfgExpected.MetricsSampleInterval = time.Hour + time.Minute*10
 	if err := os.Setenv("COCKROACH_SCAN_INTERVAL", "48h"); err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +144,6 @@ func TestReadEnvironmentVariables(t *testing.T) {
 
 	for _, envVar := range []string{
 		"COCKROACH_LINEARIZABLE",
-		"COCKROACH_METRICS_SAMPLE_INTERVAL",
 		"COCKROACH_SCAN_INTERVAL",
 		"COCKROACH_SCAN_MAX_IDLE_TIME",
 	} {

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -184,7 +184,6 @@ func bootstrapCluster(
 	cfg.Gossip = nil
 	cfg.TestingKnobs = storage.StoreTestingKnobs{}
 	cfg.ScanInterval = 10 * time.Minute
-	cfg.MetricsSampleInterval = time.Duration(math.MaxInt64)
 	cfg.HistogramWindowInterval = time.Duration(math.MaxInt64)
 	tr := cfg.Settings.Tracer
 	defer tr.Close()
@@ -423,7 +422,7 @@ func (n *Node) start(
 
 	n.startedAt = n.storeCfg.Clock.Now().WallTime
 
-	n.startComputePeriodicMetrics(n.stopper, n.storeCfg.MetricsSampleInterval)
+	n.startComputePeriodicMetrics(n.stopper, DefaultMetricsSampleInterval)
 	n.startGossip(ctx, n.stopper)
 
 	log.Infof(ctx, "%s: started with %v engine(s) and attributes %v", n, bootstrappedEngines, attrs.Attrs)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -358,7 +358,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		ScanInterval:            s.cfg.ScanInterval,
 		ScanMaxIdleTime:         s.cfg.ScanMaxIdleTime,
 		TimestampCachePageSize:  s.cfg.TimestampCachePageSize,
-		MetricsSampleInterval:   s.cfg.MetricsSampleInterval,
 		HistogramWindowInterval: s.cfg.HistogramWindowInterval(),
 		StorePool:               s.storePool,
 		SQLExecutor:             sqlExecutor,
@@ -1083,15 +1082,15 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	s.recorder.AddNode(s.registry, s.node.Descriptor, s.node.startedAt, s.cfg.AdvertiseAddr, s.cfg.HTTPAddr)
 
 	// Begin recording runtime statistics.
-	s.startSampleEnvironment(s.cfg.MetricsSampleInterval)
+	s.startSampleEnvironment(DefaultMetricsSampleInterval)
 
 	// Begin recording time series data collected by the status monitor.
 	s.tsDB.PollSource(
-		s.cfg.AmbientCtx, s.recorder, s.cfg.MetricsSampleInterval, ts.Resolution10s, s.stopper,
+		s.cfg.AmbientCtx, s.recorder, DefaultMetricsSampleInterval, ts.Resolution10s, s.stopper,
 	)
 
 	// Begin recording status summaries.
-	s.node.startWriteSummaries(s.cfg.MetricsSampleInterval)
+	s.node.startWriteSummaries(DefaultMetricsSampleInterval)
 
 	// Create and start the schema change manager only after a NodeID
 	// has been assigned.

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -374,12 +374,12 @@ func TestMetricsRecording(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
-		MetricsSampleInterval: 5 * time.Millisecond})
+	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
 	// Verify that metrics for the current timestamp are recorded. This should
-	// be true very quickly.
+	// be true very quickly even though DefaultMetricsSampleInterval is large,
+	// because the server writes an entry eagerly on startup.
 	testutils.SucceedsSoon(t, func() error {
 		now := s.Clock().PhysicalNow()
 

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -91,7 +91,6 @@ func makeTestConfig(st *cluster.Settings) Config {
 	// Set standard user for intra-cluster traffic.
 	cfg.User = security.NodeUser
 	cfg.TimestampCachePageSize = tscache.TestSklPageSize
-	cfg.MetricsSampleInterval = metric.TestSampleInterval
 
 	// Enable web session authentication.
 	cfg.EnableWebSessionAuthentication = true
@@ -121,9 +120,6 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.Insecure = params.Insecure
 	cfg.SocketFile = params.SocketFile
 	cfg.RetryOptions = params.RetryOptions
-	if params.MetricsSampleInterval != 0 {
-		cfg.MetricsSampleInterval = params.MetricsSampleInterval
-	}
 	if knobs := params.Knobs.Store; knobs != nil {
 		if mo := knobs.(*storage.StoreTestingKnobs).MaxOffset; mo != 0 {
 			cfg.MaxOffset = MaxOffsetType(mo)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -137,7 +137,6 @@ func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 		RaftHeartbeatIntervalTicks:  1,
 		ScanInterval:                10 * time.Minute,
 		TimestampCachePageSize:      tscache.TestSklPageSize,
-		MetricsSampleInterval:       metric.TestSampleInterval,
 		HistogramWindowInterval:     metric.TestSampleInterval,
 		EnableEpochRangeLeases:      true,
 	}
@@ -622,9 +621,6 @@ type StoreConfig struct {
 
 	// TimestampCachePageSize is (server.Config).TimestampCachePageSize
 	TimestampCachePageSize uint32
-
-	// MetricsSampleInterval is (server.Config).MetricsSampleInterval
-	MetricsSampleInterval time.Duration
 
 	// HistogramWindowInterval is (server.Config).HistogramWindowInterval
 	HistogramWindowInterval time.Duration

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -146,7 +146,6 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 	)
 	cfg.Transport = transport
 	cfg.TimestampCachePageSize = tscache.TestSklPageSize
-	cfg.MetricsSampleInterval = metric.TestSampleInterval
 	cfg.HistogramWindowInterval = metric.TestSampleInterval
 	ltc.Store = storage.NewStore(cfg, ltc.Eng, nodeDesc)
 	ctx := context.TODO()


### PR DESCRIPTION
Hard-code it to 10s instead, the only value we actually use.

Fixes #20310.

Release note: None