### PR TITLE
sql: fix date encoding type in array headers

### DIFF
--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1874,9 +1874,12 @@ func parserTypeToEncodingType(t types.T) (encoding.Type, error) {
 		return encoding.Decimal, nil
 	case types.Bytes, types.String, types.Name:
 		return encoding.Bytes, nil
-	case types.Timestamp, types.TimestampTZ, types.Date:
+	case types.Timestamp, types.TimestampTZ:
 		return encoding.Time, nil
-	case types.Time:
+	// Note: types.Date was incorrectly mapped to encoding.Time when arrays were
+	// first introduced. If any 1.1 users used date arrays, they would have been
+	// persisted with incorrect elementType values.
+	case types.Date, types.Time:
 		return encoding.Int, nil
 	case types.Interval:
 		return encoding.Duration, nil


### PR DESCRIPTION
When we encode arrays, we were storing the wrong encoding type for
dates (encoding.Time rather than encoding.Int). This is now fixed.

This hasn't caused any problems so far since we don't use the
`elementType` header value for anything. If we start using it in the
future, there's a slim possibility there are persisted date arrays out
there with the incorrect value, in which case we would need some special
handling to detect and handle that scenario.

Refers #19942

Release note: None