### PR TITLE
sql: builtin render colnames are the builtin name

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -778,7 +778,7 @@ func Example_sql() {
 	// sql -e create table t.g2 as select * from generate_series(1,10)
 	// SELECT 10
 	// sql -d nonexistent -e select count(*) from pg_class limit 0
-	// count(*)
+	// count
 	// # 0 rows
 	// sql -d nonexistent -e create database nonexistent; create table foo(x int); select * from foo
 	// x

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -253,7 +253,7 @@ SELECT COUNT(*), s FROM kv GROUP BY UPPER(s)
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
-0  group   ·            ·                      ("count(*)", "k + v")           ·
+0  group   ·            ·                      (count, "k + v")                ·
 0  ·       aggregate 0  count_rows()           ·                               ·
 0  ·       aggregate 1  test.kv.k + test.kv.v  ·                               ·
 0  ·       group by     @1-@1                  ·                               ·
@@ -278,10 +278,10 @@ SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
-0  render  ·            ·             ("count(*)", "k + v")           ·
-0  ·       render 0     "count(*)"    ·                               ·
+0  render  ·            ·             (count, "k + v")                ·
+0  ·       render 0     count_rows    ·                               ·
 0  ·       render 1     k + v         ·                               ·
-1  group   ·            ·             ("count(*)", k, v)              ·
+1  group   ·            ·             (count_rows, k, v)              ·
 1  ·       aggregate 0  count_rows()  ·                               ·
 1  ·       aggregate 1  test.kv.k     ·                               ·
 1  ·       aggregate 2  test.kv.v     ·                               ·
@@ -430,8 +430,8 @@ NULL 1
 query III colnames
 SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM kv
 ----
-count(*)  count(k)  count(kv.v)
-6         6         5
+count  count  count
+6      6      5
 
 query I
 SELECT COUNT(kv.*) FROM kv
@@ -1025,7 +1025,7 @@ query ITTT
 EXPLAIN (EXPRS) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 ----
 0  sort    ·            ·
-0  ·       order        +"count(k)"
+0  ·       order        +count
 1  group   ·            ·
 1  ·       aggregate 0  v
 1  ·       aggregate 1  count(k)
@@ -1041,7 +1041,7 @@ query ITTT
 EXPLAIN (EXPRS) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 ----
 0  sort    ·            ·
-0  ·       order        +"count(*)"
+0  ·       order        +count
 1  group   ·            ·
 1  ·       aggregate 0  v
 1  ·       aggregate 1  count_rows()
@@ -1056,7 +1056,7 @@ query ITTT
 EXPLAIN (EXPRS) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
 ----
 0  sort    ·            ·
-0  ·       order        +"count(1)"
+0  ·       order        +count
 1  group   ·            ·
 1  ·       aggregate 0  v
 1  ·       aggregate 1  count(1)
@@ -1147,7 +1147,7 @@ EXPLAIN (EXPRS) SELECT COUNT(*) FILTER (WHERE k>5), MAX(k>5) FILTER(WHERE k>5) F
 query ITTTTT
 EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 ----
-0  group   ·            ·                                                               ("count(*) FILTER (WHERE k > 5)" int)                          ·
+0  group   ·            ·                                                               (count int)                                                    ·
 0  ·       aggregate 0  (count_rows() FILTER (WHERE ((k)[int] > (5)[int])[bool]))[int]  ·                                                              ·
 0  ·       group by     @1-@1                                                           ·                                                              ·
 1  render  ·            ·                                                               (v int, "k > 5" bool)                                          ·
@@ -1221,7 +1221,7 @@ INSERT INTO opt_test VALUES (1, NULL), (2, 10), (3, NULL), (4, 5)
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
 ----
-0  group   ·            ·                     ("min(v)")       ·
+0  group   ·            ·                     (min)            ·
 0  ·       aggregate 0  min(test.opt_test.v)  ·                ·
 1  render  ·            ·                     (v)              v!=NULL; +v
 1  ·       render 0     test.opt_test.v       ·                ·
@@ -1246,14 +1246,14 @@ SELECT MIN(v) FROM opt_test@primary
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
 ----
-0  group   ·            ·                     ("min(v)")  ·
-0  ·       aggregate 0  min(test.opt_test.v)  ·           ·
-1  render  ·            ·                     (v)         v!=NULL; +v
-1  ·       render 0     test.opt_test.v       ·           ·
-2  scan    ·            ·                     (k, v)      k!=NULL; v!=NULL; key(k,v); +v
-2  ·       table        opt_test@v            ·           ·
-2  ·       spans        /!NULL-               ·           ·
-2  ·       filter       k != 4                ·           ·
+0  group   ·            ·                     (min)   ·
+0  ·       aggregate 0  min(test.opt_test.v)  ·       ·
+1  render  ·            ·                     (v)     v!=NULL; +v
+1  ·       render 0     test.opt_test.v       ·       ·
+2  scan    ·            ·                     (k, v)  k!=NULL; v!=NULL; key(k,v); +v
+2  ·       table        opt_test@v            ·       ·
+2  ·       spans        /!NULL-               ·       ·
+2  ·       filter       k != 4                ·       ·
 
 query I
 SELECT MIN(v) FROM opt_test WHERE k <> 4
@@ -1266,25 +1266,25 @@ SELECT MIN(v) FROM opt_test WHERE k <> 4
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
 ----
-0  group   ·            ·                                   ("min(v + 1)")  ·
-0  ·       aggregate 0  min(test.opt_test.v + 1)            ·               ·
-1  render  ·            ·                                   ("v + 1")       ·
-1  ·       render 0     test.opt_test.v + 1                 ·               ·
-2  scan    ·            ·                                   (k, v)          k!=NULL; v!=NULL; key(k)
-2  ·       table        opt_test@primary                    ·               ·
-2  ·       spans        /!NULL-                             ·               ·
-2  ·       filter       (k != 4) AND ((v + 1) IS DISTINCT FROM NULL)  ·               ·
+0  group   ·            ·                                             (min)      ·
+0  ·       aggregate 0  min(test.opt_test.v + 1)                      ·          ·
+1  render  ·            ·                                             ("v + 1")  ·
+1  ·       render 0     test.opt_test.v + 1                           ·          ·
+2  scan    ·            ·                                             (k, v)     k!=NULL; v!=NULL; key(k)
+2  ·       table        opt_test@primary                              ·          ·
+2  ·       spans        /!NULL-                                       ·          ·
+2  ·       filter       (k != 4) AND ((v + 1) IS DISTINCT FROM NULL)  ·          ·
 
 # Verify that we don't use the optimization if there is a GROUP BY.
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
 ----
-0  group  ·            ·                     ("min(v)")  ·
-0  ·      aggregate 0  min(test.opt_test.v)  ·           ·
-0  ·      group by     @1-@1                 ·           ·
-1  scan   ·            ·                     (k, v)      k!=NULL; key(k)
-1  ·      table        opt_test@primary      ·           ·
-1  ·      spans        ALL                   ·           ·
+0  group  ·            ·                     (min)   ·
+0  ·      aggregate 0  min(test.opt_test.v)  ·       ·
+0  ·      group by     @1-@1                 ·       ·
+1  scan   ·            ·                     (k, v)  k!=NULL; key(k)
+1  ·      table        opt_test@primary      ·       ·
+1  ·      spans        ALL                   ·       ·
 
 query I rowsort
 SELECT MIN(v) FROM opt_test GROUP BY k
@@ -1376,7 +1376,7 @@ EXPLAIN(EXPRS)
      FROM ab, xy GROUP BY (x, (a, b))
 ----
 0  render  ·            ·
-0  ·       render 0     "min(y)"
+0  ·       render 0     min
 0  ·       render 1     (b, a)
 1  group   ·            ·
 1  ·       aggregate 0  min(y)

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -9,8 +9,8 @@ SELECT defaults()
 query II colnames
 SELECT LENGTH('roach7'), LENGTH(b'roach77')
 ----
-length('roach7')  length(b'roach77')
-6                 7
+length length
+6      7
 
 query II
 SELECT LENGTH('Hello, 世界'), LENGTH(b'Hello, 世界')
@@ -28,7 +28,7 @@ SELECT octet_length('Hello'), octet_length(b'世界')
 query T colnames
 SELECT UPPER('roacH7')
 ----
-upper('roacH7')
+upper
 ROACH7
 
 statement error unknown signature: upper\(decimal\)
@@ -37,7 +37,7 @@ SELECT UPPER(2.2)
 query T colnames
 SELECT LOWER('RoacH7')
 ----
-lower('RoacH7')
+lower
 roach7
 
 statement error unknown signature: lower\(int\)

--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -446,11 +446,11 @@ SELECT DISTINCT ON(MAX(x), z) MIN(y) FROM xyz
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (MAX(y)) MAX(x) FROM xyz
 ----
-0  render    ·            ·                ("max(x)")                                      ·
-0  ·         render 0     "max(x)"         ·                                               ·
-1  distinct  ·            ·                ("max(x)", "max(y)")                            weak-key("max(y)")
-1  ·         distinct on  max(y)           ·                                               ·
-2  group     ·            ·                ("max(x)", "max(y)")                            ·
+0  render    ·            ·                (max)                                           ·
+0  ·         render 0     max              ·                                               ·
+1  distinct  ·            ·                (max, max)                                      weak-key(max)
+1  ·         distinct on  max              ·                                               ·
+2  group     ·            ·                (max, max)                                      ·
 2  ·         aggregate 0  max(test.xyz.x)  ·                                               ·
 2  ·         aggregate 1  max(test.xyz.y)  ·                                               ·
 3  render    ·            ·                (x, y)                                          ·
@@ -473,18 +473,18 @@ SELECT DISTINCT ON (MIN(x)) MAX(y) FROM xyz
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(a) FROM abc
 ----
-0  render    ·            ·                       ("max(a)")                                ·
-0  ·         render 0     "max(a)"                ·                                         ·
-1  distinct  ·            ·                       ("max(a)", "min(a)", "max(b)", "min(c)")  weak-key("min(a)","max(b)","min(c)")
-1  ·         distinct on  min(a), max(b), min(c)  ·                                         ·
-2  group     ·            ·                       ("max(a)", "min(a)", "max(b)", "min(c)")  ·
-2  ·         aggregate 0  max(test.abc.a)         ·                                         ·
-2  ·         aggregate 1  min(test.abc.a)         ·                                         ·
-2  ·         aggregate 2  max(test.abc.b)         ·                                         ·
-2  ·         aggregate 3  min(test.abc.c)         ·                                         ·
-3  scan      ·            ·                       (a, b, c)                                 a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-3  ·         table        abc@primary             ·                                         ·
-3  ·         spans        ALL                     ·                                         ·
+0  render    ·            ·                (max)                 ·
+0  ·         render 0     max              ·                     ·
+1  distinct  ·            ·                (max, min, max, min)  weak-key(min,max,min)
+1  ·         distinct on  min, max, min    ·                     ·
+2  group     ·            ·                (max, min, max, min)  ·
+2  ·         aggregate 0  max(test.abc.a)  ·                     ·
+2  ·         aggregate 1  min(test.abc.a)  ·                     ·
+2  ·         aggregate 2  max(test.abc.b)  ·                     ·
+2  ·         aggregate 3  min(test.abc.c)  ·                     ·
+3  scan      ·            ·                (a, b, c)             a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+3  ·         table        abc@primary      ·                     ·
+3  ·         spans        ALL              ·                     ·
 
 query T
 SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(c) FROM abc
@@ -503,11 +503,11 @@ SELECT DISTINCT ON (x) MIN(x) FROM xyz GROUP BY y
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
 ----
-0  render    ·            ·                ("min(x)")                                      ·
-0  ·         render 0     "min(x)"         ·                                               ·
-1  distinct  ·            ·                ("min(x)", y)                                   weak-key(y)
+0  render    ·            ·                (min)                                           ·
+0  ·         render 0     min              ·                                               ·
+1  distinct  ·            ·                (min, y)                                        weak-key(y)
 1  ·         distinct on  y                ·                                               ·
-2  group     ·            ·                ("min(x)", y)                                   ·
+2  group     ·            ·                (min, y)                                        ·
 2  ·         aggregate 0  min(test.xyz.x)  ·                                               ·
 2  ·         aggregate 1  test.xyz.y       ·                                               ·
 2  ·         group by     @1-@1            ·                                               ·
@@ -528,13 +528,13 @@ SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
 ----
-0  distinct  ·            ·                ("min(x)")                                      weak-key("min(x)")
-0  ·         distinct on  min(x)           ·                                               ·
-1  render    ·            ·                ("min(x)")                                      ·
-1  ·         render 0     "min(x)"         ·                                               ·
-2  filter    ·            ·                ("min(x)", "min(x)")                            "min(x)"=CONST
-2  ·         filter       "min(x)" = 1     ·                                               ·
-3  group     ·            ·                ("min(x)", "min(x)")                            ·
+0  distinct  ·            ·                (min)                                           weak-key(min)
+0  ·         distinct on  min              ·                                               ·
+1  render    ·            ·                (min)                                           ·
+1  ·         render 0     min              ·                                               ·
+2  filter    ·            ·                (min, min)                                      min=CONST
+2  ·         filter       min = 1          ·                                               ·
+3  group     ·            ·                (min, min)                                      ·
 3  ·         aggregate 0  min(test.xyz.x)  ·                                               ·
 3  ·         aggregate 1  min(test.xyz.x)  ·                                               ·
 3  ·         group by     @1-@1            ·                                               ·
@@ -559,9 +559,9 @@ EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
 ----
 0  render    ·            ·                     (y)                                                      ·
 0  ·         render 0     y                     ·                                                        ·
-1  distinct  ·            ·                     (y, "row_number() OVER ()")                              weak-key("row_number() OVER ()")
-1  ·         distinct on  row_number() OVER ()  ·                                                        ·
-2  window    ·            ·                     (y, "row_number() OVER ()")                              ·
+1  distinct  ·            ·                     (y, row_number)                                          weak-key(row_number)
+1  ·         distinct on  row_number            ·                                                        ·
+2  window    ·            ·                     (y, row_number)                                          ·
 2  ·         window 0     row_number() OVER ()  ·                                                        ·
 2  ·         render 1     row_number() OVER ()  ·                                                        ·
 3  render    ·            ·                     (y)                                                      ·

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -85,43 +85,43 @@ EXPLAIN (TYPES) VALUES (1, 2, 3), (4, 5, 6)
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND COUNT(k)>1
 ----
-0  render  ·            ·                                                                          (z int, v int)                                  ·
-0  ·       render 0     ((2)[int] * ("count(k)")[int])[int]                                        ·                                               ·
-0  ·       render 1     (v)[int]                                                                   ·                                               ·
-1  filter  ·            ·                                                                          (v int, "count(k)" int, "count(k)" int, v int)  ·
-1  ·       filter       (("count(k)")[int] > (1)[int])[bool]                                       ·                                               ·
-2  group   ·            ·                                                                          (v int, "count(k)" int, "count(k)" int, v int)  ·
-2  ·       aggregate 0  (v)[int]                                                                   ·                                               ·
-2  ·       aggregate 1  (count((k)[int]))[int]                                                     ·                                               ·
-2  ·       aggregate 2  (count((k)[int]))[int]                                                     ·                                               ·
-2  ·       aggregate 3  (v)[int]                                                                   ·                                               ·
-2  ·       group by     @1-@1                                                                      ·                                               ·
-3  render  ·            ·                                                                          (v int, k int)                                  ·
-3  ·       render 0     (v)[int]                                                                   ·                                               ·
-3  ·       render 1     (k)[int]                                                                   ·                                               ·
-4  scan    ·            ·                                                                          (k int, v int)                                  ·
-4  ·       table        t@primary                                                                  ·                                               ·
-4  ·       filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]  ·                                               ·
+0  render  ·            ·                                                                          (z int, v int)                        ·
+0  ·       render 0     ((2)[int] * (count)[int])[int]                                             ·                                     ·
+0  ·       render 1     (v)[int]                                                                   ·                                     ·
+1  filter  ·            ·                                                                          (v int, count int, count int, v int)  ·
+1  ·       filter       ((count)[int] > (1)[int])[bool]                                            ·                                     ·
+2  group   ·            ·                                                                          (v int, count int, count int, v int)  ·
+2  ·       aggregate 0  (v)[int]                                                                   ·                                     ·
+2  ·       aggregate 1  (count((k)[int]))[int]                                                     ·                                     ·
+2  ·       aggregate 2  (count((k)[int]))[int]                                                     ·                                     ·
+2  ·       aggregate 3  (v)[int]                                                                   ·                                     ·
+2  ·       group by     @1-@1                                                                      ·                                     ·
+3  render  ·            ·                                                                          (v int, k int)                        ·
+3  ·       render 0     (v)[int]                                                                   ·                                     ·
+3  ·       render 1     (k)[int]                                                                   ·                                     ·
+4  scan    ·            ·                                                                          (k int, v int)                        ·
+4  ·       table        t@primary                                                                  ·                                     ·
+4  ·       filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]  ·                                     ·
 
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND COUNT(k)>1
 ----
-0  render  ·            ·                                     (z int, v int)                                  ·
-0  ·       render 0     ((2)[int] * ("count(k)")[int])[int]   ·                                               ·
-0  ·       render 1     (v)[int]                              ·                                               ·
-1  filter  ·            ·                                     (v int, "count(k)" int, "count(k)" int, v int)  "count(k)"!=NULL
-1  ·       filter       (("count(k)")[int] > (1)[int])[bool]  ·                                               ·
-2  group   ·            ·                                     (v int, "count(k)" int, "count(k)" int, v int)  ·
-2  ·       aggregate 0  (v)[int]                              ·                                               ·
-2  ·       aggregate 1  (count((k)[int]))[int]                ·                                               ·
-2  ·       aggregate 2  (count((k)[int]))[int]                ·                                               ·
-2  ·       aggregate 3  (v)[int]                              ·                                               ·
-2  ·       group by     @1-@1                                 ·                                               ·
-3  render  ·            ·                                     (v int, k int)                                  ·
-3  ·       render 0     (v)[int]                              ·                                               ·
-3  ·       render 1     (k)[int]                              ·                                               ·
-4  norows  ·            ·                                     ()                                              ·
+0  render  ·            ·                                (z int, v int)                        ·
+0  ·       render 0     ((2)[int] * (count)[int])[int]   ·                                     ·
+0  ·       render 1     (v)[int]                         ·                                     ·
+1  filter  ·            ·                                (v int, count int, count int, v int)  count!=NULL
+1  ·       filter       ((count)[int] > (1)[int])[bool]  ·                                     ·
+2  group   ·            ·                                (v int, count int, count int, v int)  ·
+2  ·       aggregate 0  (v)[int]                         ·                                     ·
+2  ·       aggregate 1  (count((k)[int]))[int]           ·                                     ·
+2  ·       aggregate 2  (count((k)[int]))[int]           ·                                     ·
+2  ·       aggregate 3  (v)[int]                         ·                                     ·
+2  ·       group by     @1-@1                            ·                                     ·
+3  render  ·            ·                                (v int, k int)                        ·
+3  ·       render 0     (v)[int]                         ·                                     ·
+3  ·       render 1     (k)[int]                         ·                                     ·
+4  norows  ·            ·                                ()                                    ·
 
 query ITTTTT
 EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -173,7 +173,7 @@ CREATE TABLE a ("name" string, age int);
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT "name", age FROM a);
 ----
-0  group   ·            ·             ("count(*)")                                            ·
+0  group   ·            ·             (count)                                                 ·
 0  ·       aggregate 0  count_rows()  ·                                                       ·
 1  render  ·            ·             ()                                                      ·
 2  render  ·            ·             ("name"[omitted], age[omitted])                         ·
@@ -192,7 +192,7 @@ CREATE TABLE ab (a INT, b INT, PRIMARY KEY (a, b));
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM ab WHERE a=1
 ----
-0  group   ·            ·             ("count(*)")              ·
+0  group   ·            ·             (count)                   ·
 0  ·       aggregate 0  count_rows()  ·                         ·
 1  render  ·            ·             ()                        ·
 2  scan    ·            ·             (a[omitted], b[omitted])  a=CONST; b!=NULL; key(b)

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -367,7 +367,7 @@ query ITTT
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
 0  nosort  ·      ·
-0  ·       order  +"length('abc')"
+0  ·       order  +length
 1  render  ·      ·
 2  scan    ·      ·
 2  ·       table  t@primary

--- a/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
+++ b/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
@@ -28,7 +28,7 @@ SELECT COUNT(DISTINCT x.*) FROM a x, a y
 query ITTTTT
 EXPLAIN(VERBOSE) SELECT COUNT(DISTINCT x.*) FROM a x, a y
 ----
-0  group   ·            ·                           ("count(DISTINCT x.*)")                                                       ·
+0  group   ·            ·                           (count)                                                                       ·
 0  ·       aggregate 0  count(DISTINCT (x.x, x.y))  ·                                                                             ·
 1  render  ·            ·                           ("(x, y)")                                                                    ·
 1  ·       render 0     (x.x, x.y)                  ·                                                                             ·

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -211,7 +211,7 @@ SELECT avg(k) OVER (w ORDER BY w) FROM kv WINDOW w AS (PARTITION BY v) ORDER BY 
 query IIIRRTBR colnames
 SELECT *, avg(k) OVER (w ORDER BY w) FROM kv WINDOW w AS (PARTITION BY v) ORDER BY 1
 ----
-k  v     w  f    d     s     b      avg(k) OVER (w ORDER BY w)
+k  v     w  f    d     s     b      avg
 1  2     3  1    1     a     true   4.6666666666666666667
 3  4     5  2    8     a     true   5.5
 5  NULL  5  9.9  -321  NULL  false  5
@@ -222,7 +222,7 @@ k  v     w  f    d     s     b      avg(k) OVER (w ORDER BY w)
 query IIIRRTBR colnames
 SELECT *, avg(k) OVER w FROM kv WINDOW w AS (PARTITION BY v ORDER BY w) ORDER BY avg(k) OVER w, k
 ----
-k  v     w  f    d     s     b      avg(k) OVER w
+k  v     w  f    d     s     b      avg
 1  2     3  1    1     a     true   4.6666666666666666667
 6  2     3  4.4  4.4   b     true   4.6666666666666666667
 5  NULL  5  9.9  -321  NULL  false  5
@@ -525,7 +525,7 @@ query ITTT
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
 0  sort    ·      ·
-0  ·       order  +"variance(d) OVER w",+k
+0  ·       order  +variance,+k
 1  window  ·      ·
 2  render  ·      ·
 3  scan    ·      ·
@@ -563,9 +563,9 @@ output row: [8 3.5355339059327376220]
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-0  sort    ·         ·                                         (k int, "stddev(d) OVER w" decimal)                                                              ·
-0  ·       order     +"variance(d) OVER w",+k                  ·                                                                                                ·
-1  window  ·         ·                                         (k int, "stddev(d) OVER w" decimal, "variance(d) OVER w" decimal)                                ·
+0  sort    ·         ·                                         (k int, stddev decimal)                                                                          ·
+0  ·       order     +variance,+k                              ·                                                                                                ·
+1  window  ·         ·                                         (k int, stddev decimal, variance decimal)                                                        ·
 1  ·       window 0  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
 1  ·       window 1  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
 1  ·       render 1  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
@@ -582,30 +582,30 @@ EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) 
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  sort    ·         ·                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    ·
-0  ·       order     +"variance(d) OVER (PARTITION BY v, 100)",+k                                 ·                                                                                                          ·
-1  window  ·         ·                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)  ·
-1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                          ·
-1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                          ·
-1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                          ·
-1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                          ·
-2  render  ·         ·                                                                            (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                              d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
-2  ·       render 0  (k)[int]                                                                     ·                                                                                                          ·
-2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                          ·
-2  ·       render 2  (d)[decimal]                                                                 ·                                                                                                          ·
-2  ·       render 3  (v)[int]                                                                     ·                                                                                                          ·
-2  ·       render 4  ('a')[string]                                                                ·                                                                                                          ·
-2  ·       render 5  (100)[int]                                                                   ·                                                                                                          ·
-3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)            k!=NULL; key(k)
-3  ·       table     kv@primary                                                                   ·                                                                                                          ·
-3  ·       spans     ALL                                                                          ·                                                                                                          ·
+0  sort    ·         ·                                                                            (k int, stddev decimal)                                                                          ·
+0  ·       order     +variance,+k                                                                 ·                                                                                                ·
+1  window  ·         ·                                                                            (k int, stddev decimal, variance decimal)                                                        ·
+1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                ·
+1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                ·
+2  render  ·         ·                                                                            (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                    d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
+2  ·       render 0  (k)[int]                                                                     ·                                                                                                ·
+2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                ·
+2  ·       render 2  (d)[decimal]                                                                 ·                                                                                                ·
+2  ·       render 3  (v)[int]                                                                     ·                                                                                                ·
+2  ·       render 4  ('a')[string]                                                                ·                                                                                                ·
+2  ·       render 5  (100)[int]                                                                   ·                                                                                                ·
+3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+3  ·       table     kv@primary                                                                   ·                                                                                                ·
+3  ·       spans     ALL                                                                          ·                                                                                                ·
 
 query ITTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
-0  sort    ·         ·                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          +k
+0  sort    ·         ·                                                                            (k int, stddev decimal)                                                                          +k
 0  ·       order     +k                                                                           ·                                                                                                ·
-1  window  ·         ·                                                                            (k int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                          ·
+1  window  ·         ·                                                                            (k int, stddev decimal)                                                                          ·
 1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
 1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
 2  render  ·         ·                                                                            (k int, d decimal, v int, "'a'" string)                                                          "'a'"=CONST; k!=NULL; key(k)
@@ -620,69 +620,69 @@ EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM 
 query ITTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-0  sort    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    ·
-0  ·       order     +"variance(d) OVER (PARTITION BY v, 100)",+k                                                       ·                                                                                                              ·
-1  window  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)  ·
-1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                        ·                                                                                                              ·
-1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                              ·
-1  ·       render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                              ·
-1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                              ·
-2  render  ·         ·                                                                                                  (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                                  d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
-2  ·       render 0  (k)[int]                                                                                           ·                                                                                                              ·
-2  ·       render 1  (d)[decimal]                                                                                       ·                                                                                                              ·
-2  ·       render 2  (d)[decimal]                                                                                       ·                                                                                                              ·
-2  ·       render 3  (v)[int]                                                                                           ·                                                                                                              ·
-2  ·       render 4  ('a')[string]                                                                                      ·                                                                                                              ·
-2  ·       render 5  (100)[int]                                                                                         ·                                                                                                              ·
-3  scan    ·         ·                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                k!=NULL; key(k)
-3  ·       table     kv@primary                                                                                         ·                                                                                                              ·
-3  ·       spans     ALL                                                                                                ·                                                                                                              ·
+0  sort    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                      ·
+0  ·       order     +variance,+k                                                                                       ·                                                                                                ·
+1  window  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)                    ·
+1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                        ·                                                                                                ·
+1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                ·
+1  ·       render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                ·
+1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                ·
+2  render  ·         ·                                                                                                  (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                    d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
+2  ·       render 0  (k)[int]                                                                                           ·                                                                                                ·
+2  ·       render 1  (d)[decimal]                                                                                       ·                                                                                                ·
+2  ·       render 2  (d)[decimal]                                                                                       ·                                                                                                ·
+2  ·       render 3  (v)[int]                                                                                           ·                                                                                                ·
+2  ·       render 4  ('a')[string]                                                                                      ·                                                                                                ·
+2  ·       render 5  (100)[int]                                                                                         ·                                                                                                ·
+3  scan    ·         ·                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+3  ·       table     kv@primary                                                                                         ·                                                                                                ·
+3  ·       spans     ALL                                                                                                ·                                                                                                ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
-0  sort    ·            ·                                                                                                              ("max(k)" int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                                    ·
-0  ·       order        +"variance(d) OVER (PARTITION BY v, 100)"                                                                      ·                                                                                                                          ·
-1  window  ·            ·                                                                                                              ("max(k)" int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal, "variance(d) OVER (PARTITION BY v, 100)" decimal)  ·
-1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                                    ·                                                                                                                          ·
-1  ·       window 1     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                                          ·
-1  ·       render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                                          ·
-1  ·       render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                                          ·
-2  render  ·            ·                                                                                                              ("max(k)" int, d decimal, d decimal, v int, "'a'" string, "100" int)                                                       "'a'"=CONST; "100"=CONST
-2  ·       render 0     ("max(k)")[int]                                                                                                ·                                                                                                                          ·
-2  ·       render 1     (d)[decimal]                                                                                                   ·                                                                                                                          ·
-2  ·       render 2     (d)[decimal]                                                                                                   ·                                                                                                                          ·
-2  ·       render 3     (v)[int]                                                                                                       ·                                                                                                                          ·
-2  ·       render 4     ('a')[string]                                                                                                  ·                                                                                                                          ·
-2  ·       render 5     (100)[int]                                                                                                     ·                                                                                                                          ·
-3  group   ·            ·                                                                                                              ("max(k)" int, d decimal, d decimal, v int)                                                                                ·
-3  ·       aggregate 0  (max((k)[int]))[int]                                                                                           ·                                                                                                                          ·
-3  ·       aggregate 1  (d)[decimal]                                                                                                   ·                                                                                                                          ·
-3  ·       aggregate 2  (d)[decimal]                                                                                                   ·                                                                                                                          ·
-3  ·       aggregate 3  (v)[int]                                                                                                       ·                                                                                                                          ·
-3  ·       group by     @1-@2                                                                                                          ·                                                                                                                          ·
-4  render  ·            ·                                                                                                              (d decimal, v int, k int)                                                                                                  k!=NULL; key(k)
-4  ·       render 0     (d)[decimal]                                                                                                   ·                                                                                                                          ·
-4  ·       render 1     (v)[int]                                                                                                       ·                                                                                                                          ·
-4  ·       render 2     (k)[int]                                                                                                       ·                                                                                                                          ·
-5  scan    ·            ·                                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)                            k!=NULL; key(k)
-5  ·       table        kv@primary                                                                                                     ·                                                                                                                          ·
-5  ·       spans        ALL                                                                                                            ·                                                                                                                          ·
+0  sort    ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                               ·
+0  ·       order        +variance                                                                                                      ·                                                                                                ·
+1  window  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)             ·
+1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                                    ·                                                                                                ·
+1  ·       window 1     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                ·
+1  ·       render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                ·
+1  ·       render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                ·
+2  render  ·            ·                                                                                                              (max int, d decimal, d decimal, v int, "'a'" string, "100" int)                                  "'a'"=CONST; "100"=CONST
+2  ·       render 0     (max)[int]                                                                                                     ·                                                                                                ·
+2  ·       render 1     (d)[decimal]                                                                                                   ·                                                                                                ·
+2  ·       render 2     (d)[decimal]                                                                                                   ·                                                                                                ·
+2  ·       render 3     (v)[int]                                                                                                       ·                                                                                                ·
+2  ·       render 4     ('a')[string]                                                                                                  ·                                                                                                ·
+2  ·       render 5     (100)[int]                                                                                                     ·                                                                                                ·
+3  group   ·            ·                                                                                                              (max int, d decimal, d decimal, v int)                                                           ·
+3  ·       aggregate 0  (max((k)[int]))[int]                                                                                           ·                                                                                                ·
+3  ·       aggregate 1  (d)[decimal]                                                                                                   ·                                                                                                ·
+3  ·       aggregate 2  (d)[decimal]                                                                                                   ·                                                                                                ·
+3  ·       aggregate 3  (v)[int]                                                                                                       ·                                                                                                ·
+3  ·       group by     @1-@2                                                                                                          ·                                                                                                ·
+4  render  ·            ·                                                                                                              (d decimal, v int, k int)                                                                        k!=NULL; key(k)
+4  ·       render 0     (d)[decimal]                                                                                                   ·                                                                                                ·
+4  ·       render 1     (v)[int]                                                                                                       ·                                                                                                ·
+4  ·       render 2     (k)[int]                                                                                                       ·                                                                                                ·
+5  scan    ·            ·                                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+5  ·       table        kv@primary                                                                                                     ·                                                                                                ·
+5  ·       spans        ALL                                                                                                            ·                                                                                                ·
 
 query ITTTTT
 EXPLAIN (TYPES) SELECT MAX(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
 ----
-0  sort    ·            ·                                                                            ("max(k)" int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                   +"max(k)"
-0  ·       order        +"max(k)"                                                                    ·                                                                                                ·
-1  window  ·            ·                                                                            ("max(k)" int, "stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                   ·
+0  sort    ·            ·                                                                            (max int, stddev decimal)                                                                        +max
+0  ·       order        +max                                                                         ·                                                                                                ·
+1  window  ·            ·                                                                            (max int, stddev decimal)                                                                        ·
 1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
 1  ·       render 1     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
-2  render  ·            ·                                                                            ("max(k)" int, d decimal, v int, "'a'" string)                                                   "'a'"=CONST
-2  ·       render 0     ("max(k)")[int]                                                              ·                                                                                                ·
+2  render  ·            ·                                                                            (max int, d decimal, v int, "'a'" string)                                                        "'a'"=CONST
+2  ·       render 0     (max)[int]                                                                   ·                                                                                                ·
 2  ·       render 1     (d)[decimal]                                                                 ·                                                                                                ·
 2  ·       render 2     (v)[int]                                                                     ·                                                                                                ·
 2  ·       render 3     ('a')[string]                                                                ·                                                                                                ·
-3  group   ·            ·                                                                            ("max(k)" int, d decimal, v int)                                                                 ·
+3  group   ·            ·                                                                            (max int, d decimal, v int)                                                                      ·
 3  ·       aggregate 0  (max((k)[int]))[int]                                                         ·                                                                                                ·
 3  ·       aggregate 1  (d)[decimal]                                                                 ·                                                                                                ·
 3  ·       aggregate 2  (v)[int]                                                                     ·                                                                                                ·

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -312,11 +312,11 @@ func TestShowCreateView(t *testing.T) {
 		},
 		{
 			`CREATE VIEW %s AS SELECT count(*) FROM t`,
-			`CREATE VIEW %s ("count(*)") AS SELECT count(*) FROM d.t`,
+			`CREATE VIEW %s (count) AS SELECT count(*) FROM d.t`,
 		},
 		{
 			`CREATE VIEW %s AS SELECT s, count(*) FROM t GROUP BY s HAVING count(*) > 3:::INT`,
-			`CREATE VIEW %s (s, "count(*)") AS SELECT s, count(*) FROM d.t GROUP BY s HAVING count(*) > 3:::INT`,
+			`CREATE VIEW %s (s, count) AS SELECT s, count(*) FROM d.t GROUP BY s HAVING count(*) > 3:::INT`,
 		},
 		{
 			`CREATE VIEW %s (a, b, c, d) AS SELECT i, s, v, t FROM t`,


### PR DESCRIPTION
Previously, a function render like `SELECT length(x)` would be titled
`length(x)`. This is incompatible behavior with Postgres, which titles
function renders by just their names - so the title in this example
should be `length`. This is causing adverse effects for some tools.

Fixes #20783.

Release note (sql change): render columns for builtin functions in
are now just titled by the name of the builtin function, to improve
Postgres compatibility.