### PR TITLE
ui: Display capacity as "-" instead of 100% when data can't be loaded

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -61,7 +61,7 @@ export default function(props: ClusterSummaryProps) {
   // Capacity math used in the summary status section.
   const { capacityAvailable, capacityUsed } = props.nodesSummary.nodeSums;
   const usableCapacity = capacityAvailable + capacityUsed;
-  const capacityPercent = usableCapacity !== 0 ? (capacityUsed / usableCapacity) : 1;
+  const capacityPercent = usableCapacity !== 0 ? (capacityUsed / usableCapacity) : null;
 
   return (
     <div>


### PR DESCRIPTION
I didn't think it would be this easy, but it works.

Before:
<img width="314" alt="screen shot 2017-12-18 at 2 23 06 pm" src="https://user-images.githubusercontent.com/7085343/34123997-54cc12aa-e3ff-11e7-8fc1-a305e9d2ddaf.png">

After:
<img width="309" alt="screen shot 2017-12-18 at 2 23 12 pm" src="https://user-images.githubusercontent.com/7085343/34123999-5758f16e-e3ff-11e7-8fd0-54b6c9fc7dc8.png">

Fixes #14326

Release note (admin ui change): Display "Capacity Used" as "-" instead
of 100% when the UI can't load the real data from the server.