### PR TITLE
sql: Fix CREATE TABLE to not discard NULL for primary key columns

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1072,7 +1072,7 @@ func MakeTableDesc(
 		return sqlbase.TableDescriptor{}, err
 	}
 	desc := initTableDescriptor(id, parentID, tableName.Table(), creationTime, privileges)
-
+	nullability := make(map[string]tree.Nullability, len(n.Defs))
 	for _, def := range n.Defs {
 		if d, ok := def.(*tree.ColumnTableDef); ok {
 			if !desc.IsVirtualTable() {
@@ -1083,6 +1083,7 @@ func MakeTableDesc(
 					)
 				}
 			}
+			nullability[string(d.Name)] = d.Nullable.Nullability
 			col, idx, err := sqlbase.MakeColumnDefDescs(d, semaCtx, evalCtx)
 			if err != nil {
 				return desc, err
@@ -1178,6 +1179,12 @@ func MakeTableDesc(
 		// Primary index columns are not nullable.
 		for i := range desc.Columns {
 			if _, ok := primaryIndexColumnSet[desc.Columns[i].Name]; ok {
+				if nullability[desc.Columns[i].Name] == tree.Null {
+					return desc, pgerror.NewErrorf(pgerror.CodeInvalidTableDefinitionError,
+						"column %q cannot be nullable and in the primary key", desc.Columns[i].Name)
+				}
+				// Implicit nullability behavior does not happen if the column
+				// is in the primary key.
 				desc.Columns[i].Nullable = false
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1,0 +1,10 @@
+# LogicTest: default parallel-stmts distsql
+
+statement error column "id" cannot be nullable and in the primary key
+CREATE TABLE test1 (id INT NULL PRIMARY KEY)
+
+statement error column "id" cannot be nullable and in the primary key
+CREATE TABLE test2 (id INT NULL, PRIMARY KEY (id))
+
+statement error column "id" cannot be nullable and in the primary key
+CREATE TABLE test3 (id INT NULL, data INT, PRIMARY KEY (id, data))

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -14,7 +14,7 @@ CREATE TABLE t (a INT PRIMARY KEY DEFAULT b)
 
 # Issue #14308: support tables with DEFAULT NULL columns.
 statement ok
-CREATE TABLE null_default (ts TIMESTAMP PRIMARY KEY NULL DEFAULT NULL)
+CREATE TABLE null_default (ts TIMESTAMP NULL DEFAULT NULL)
 
 # Aggregate function calls in CHECK are not ok.
 statement error aggregate functions are not allowed in DEFAULT expressions

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -76,27 +76,15 @@ c      c_bar_key      true    2    id      ASC        false    true
 
 # primary keys can never be null
 
-statement ok
+statement error column "id" cannot be nullable and in the primary key
 CREATE TABLE d (
   id    INT PRIMARY KEY NULL
 )
 
-query TTBTT colnames
-SHOW COLUMNS FROM d
-----
-Field Type   Null  Default Indices
-id    INT    false NULL    {"primary"}
-
-statement ok
+statement error column "id" cannot be nullable and in the primary key
 CREATE TABLE e (
   id    INT NULL PRIMARY KEY
 )
-
-query TTBTT colnames
-SHOW COLUMNS FROM e
-----
-Field Type   Null   Default Indices
-id    INT    false  NULL    {"primary"}
 
 statement ok
 CREATE TABLE f (
@@ -120,8 +108,6 @@ SHOW TABLES FROM test
 a
 b
 c
-d
-e
 f
 
 statement ok

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -133,11 +133,6 @@ func TestMakeTableDescColumns(t *testing.T) {
 			sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT},
 			false,
 		},
-		{
-			"INT NULL",
-			sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT},
-			true,
-		},
 	}
 	for i, d := range testData {
 		s := "CREATE TABLE foo.test (a " + d.sqlType + " PRIMARY KEY, b " + d.sqlType + ")"


### PR DESCRIPTION
Previously, if a columns were specified to be nullable but were part of
the primary key they would silently become non-nullable.

Fixes #20202.

Release note (bug fix): CREATE TABLE now returns an error when creating
a nullable column but it is part of the primary key. Previously, the
column would silently become non-nullable.