### PR TITLE
ui: Separate the invalidation time from the timeout

### DIFF
--- a/pkg/ui/src/views/reports/containers/certificates/index.tsx
+++ b/pkg/ui/src/views/reports/containers/certificates/index.tsx
@@ -183,10 +183,11 @@ class Certificates extends React.Component<CertificatesProps, {}> {
   }
 }
 
-function mapStateToProps(state: AdminUIState) {
+function mapStateToProps(state: AdminUIState, props: CertificatesProps) {
+  const nodeID = props.params[nodeIDAttr];
   return {
-    certificates: state.cachedData.certificates.data,
-    lastError: state.cachedData.certificates.lastError,
+    certificates: state.cachedData.certificates[nodeID] && state.cachedData.certificates[nodeID].data,
+    lastError: state.cachedData.certificates[nodeID] && state.cachedData.certificates[nodeID].lastError,
   };
 }
 

--- a/pkg/ui/src/views/reports/containers/commandQueue/index.tsx
+++ b/pkg/ui/src/views/reports/containers/commandQueue/index.tsx
@@ -5,7 +5,6 @@ import React from "react";
 import { connect } from "react-redux";
 
 import * as protos from "src/js/protos";
-import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { refreshCommandQueue } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { rangeIDAttr } from "src/util/constants";
@@ -13,8 +12,7 @@ import Print from "src/views/reports/containers/range/print";
 import CommandQueueViz from "src/views/reports/containers/commandQueue/commandQueueViz";
 
 interface CommandQueueOwnProps {
-  commandQueueReducerState:
-    CachedDataReducerState<protos.cockroach.server.serverpb.CommandQueueResponse>;
+  commandQueueReducerState: protos.cockroach.server.serverpb.CommandQueueResponse;
   refreshCommandQueue: typeof refreshCommandQueue;
 }
 
@@ -36,11 +34,11 @@ class CommandQueue extends React.Component<CommandQueueProps, {}> {
   }
 
   renderReportBody() {
-    if (_.isNil(this.props.commandQueueReducerState.data)) {
+    if (_.isNil(this.props.commandQueueReducerState)) {
       return (<p>Loading...</p>);
     }
 
-    const snapshot = this.props.commandQueueReducerState.data.snapshot;
+    const snapshot = this.props.commandQueueReducerState.snapshot;
 
     return (
       <div>
@@ -85,9 +83,10 @@ class CommandQueue extends React.Component<CommandQueueProps, {}> {
   }
 }
 
-function mapStateToProps(state: AdminUIState) {
+function mapStateToProps(state: AdminUIState, props: CommandQueueProps) {
+  const rangeID = props.params[rangeIDAttr];
   return {
-    commandQueueReducerState: state.cachedData.commandQueue,
+    commandQueueReducerState: state.cachedData.commandQueue[rangeID] && state.cachedData.commandQueue[rangeID].data,
   };
 }
 

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -159,9 +159,10 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
 }
 
 export default connect(
-  (state: AdminUIState) => {
+  (state: AdminUIState, props: ProblemRangesProps) => {
+    const nodeID = props.params[nodeIDAttr];
     return {
-      problemRanges: state.cachedData.problemRanges.data,
+      problemRanges: state.cachedData.problemRanges[nodeID] && state.cachedData.problemRanges[nodeID].data,
     };
   },
   {

--- a/pkg/ui/src/views/reports/containers/range/allocator.tsx
+++ b/pkg/ui/src/views/reports/containers/range/allocator.tsx
@@ -2,27 +2,30 @@ import _ from "lodash";
 import React from "react";
 
 import * as protos from "src/js/protos";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import Print from "src/views/reports/containers/range/print";
+import Loading from "src/views/shared/components/loading";
+
+import spinner from "assets/spinner.gif";
 
 interface AllocatorOutputProps {
-  allocatorRangeResponse: protos.cockroach.server.serverpb.AllocatorRangeResponse;
-  lastError: Error;
+  allocator: CachedDataReducerState<protos.cockroach.server.serverpb.AllocatorRangeResponse>;
 }
 
 export default class AllocatorOutput extends React.Component<AllocatorOutputProps, {}> {
   render() {
-    const { allocatorRangeResponse, lastError } = this.props;
+    const { allocator } = this.props;
 
-    if (!_.isNil(lastError)) {
+    if (allocator && !_.isNil(allocator.lastError)) {
       return (
         <div>
           <h2>Simulated Allocator Output</h2>
-          {lastError.toString()}
+          {allocator.lastError.toString()}
         </div>
       );
     }
 
-    if (_.isEmpty(allocatorRangeResponse) || _.isEmpty(allocatorRangeResponse.dry_run)) {
+    if (allocator && (_.isEmpty(allocator.data) || _.isEmpty(allocator.data.dry_run))) {
       return (
         <div>
           <h2>Simulated Allocator Output</h2>
@@ -31,25 +34,36 @@ export default class AllocatorOutput extends React.Component<AllocatorOutputProp
       );
     }
 
+    let fromNodeID = "";
+    if (allocator && !_.isEmpty(allocator.data)) {
+      fromNodeID = ` (from n${allocator.data.node_id.toString()})`;
+    }
+
     return (
       <div>
-        <h2>Simulated Allocator Output (from n{allocatorRangeResponse.node_id.toString()})</h2>
-        <table className="allocator-table">
-          <tbody>
-            <tr className="allocator-table__row allocator-table__row--header">
-              <th className="allocator-table__cell allocator-table__cell--header">Timestamp</th>
-              <th className="allocator-table__cell allocator-table__cell--header">Message</th>
-            </tr>
-            {
-              _.map(allocatorRangeResponse.dry_run.events, (event, key) => (
-                <tr key={key} className="allocator-table__row">
-                  <td className="allocator-table__cell allocator-table__cell--date">{Print.Timestamp(event.time)}</td>
-                  <td className="allocator-table__cell">{event.message}</td>
-                </tr>
-              ))
-            }
-          </tbody>
-        </table>
+        <h2>Simulated Allocator Output {fromNodeID}</h2>
+        <Loading
+          loading={!allocator || allocator.inFlight}
+          className="loading-image loading-image__spinner-left"
+          image={spinner}
+        >
+          <table className="allocator-table">
+            <tbody>
+              <tr className="allocator-table__row allocator-table__row--header">
+                <th className="allocator-table__cell allocator-table__cell--header">Timestamp</th>
+                <th className="allocator-table__cell allocator-table__cell--header">Message</th>
+              </tr>
+              {
+                _.map(allocator.data.dry_run.events, (event, key) => (
+                  <tr key={key} className="allocator-table__row">
+                    <td className="allocator-table__cell allocator-table__cell--date">{Print.Timestamp(event.time)}</td>
+                    <td className="allocator-table__cell">{event.message}</td>
+                  </tr>
+                ))
+              }
+            </tbody>
+          </table>
+        </Loading>
       </div>
     );
   }

--- a/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
@@ -3,52 +3,68 @@ import _ from "lodash";
 import React from "react";
 
 import * as protos from "src/js/protos";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import Loading from "src/views/shared/components/loading";
+
+import spinner from "assets/spinner.gif";
 
 interface ConnectionsTableProps {
-  rangeResponse: protos.cockroach.server.serverpb.RangeResponse$Properties;
+  range: CachedDataReducerState<protos.cockroach.server.serverpb.RangeResponse>;
 }
 
 export default function ConnectionsTable(props: ConnectionsTableProps) {
-  const { rangeResponse } = props;
-  if (_.isNil(rangeResponse)) {
+  const { range } = props;
+  if (!range || _.isNil(range.data)) {
     return null;
   }
-  const ids = _.chain(_.keys(rangeResponse.responses_by_node_id))
+  const ids = _.chain(_.keys(range.data.responses_by_node_id))
     .map(id => parseInt(id, 10))
     .sortBy(id => id)
     .value();
+
+  let viaNodeID = "";
+  if (range && !_.isEmpty(range.data)) {
+    viaNodeID = ` (via n${range.data.node_id.toString()})`;
+  }
+
   return (
     <div>
-      <h2>Connections (via Node {rangeResponse.node_id})</h2>
-      <table className="connections-table">
-        <tbody>
-          <tr className="connections-table__row connections-table__row--header">
-            <th className="connections-table__cell connections-table__cell--header">Node</th>
-            <th className="connections-table__cell connections-table__cell--header">Valid</th>
-            <th className="connections-table__cell connections-table__cell--header">Replicas</th>
-            <th className="connections-table__cell connections-table__cell--header">Error</th>
-          </tr>
-          {
-            _.map(ids, id => {
-              const resp = rangeResponse.responses_by_node_id[id];
-              const rowClassName = classNames(
-                "connections-table__row",
-                { "connections-table__row--warning": !resp.response || !_.isEmpty(resp.error_message) },
-              );
-              return (
-                <tr key={id} className={rowClassName}>
-                  <td className="connections-table__cell">n{id}</td>
-                  <td className="connections-table__cell">
-                    {resp.response ? "ok" : "error"}
-                  </td>
-                  <td className="connections-table__cell">{resp.infos.length}</td>
-                  <td className="connections-table__cell">{resp.error_message}</td>
-                </tr>
-              );
-            })
-          }
-        </tbody>
-      </table>
+      <h2>Connections {viaNodeID}</h2>
+      <Loading
+        loading={!range || range.inFlight}
+        className="loading-image loading-image__spinner-left"
+        image={spinner}
+      >
+        <table className="connections-table">
+          <tbody>
+            <tr className="connections-table__row connections-table__row--header">
+              <th className="connections-table__cell connections-table__cell--header">Node</th>
+              <th className="connections-table__cell connections-table__cell--header">Valid</th>
+              <th className="connections-table__cell connections-table__cell--header">Replicas</th>
+              <th className="connections-table__cell connections-table__cell--header">Error</th>
+            </tr>
+            {
+              _.map(ids, id => {
+                const resp = range.data.responses_by_node_id[id];
+                const rowClassName = classNames(
+                  "connections-table__row",
+                  { "connections-table__row--warning": !resp.response || !_.isEmpty(resp.error_message) },
+                );
+                return (
+                  <tr key={id} className={rowClassName}>
+                    <td className="connections-table__cell">n{id}</td>
+                    <td className="connections-table__cell">
+                      {resp.response ? "ok" : "error"}
+                    </td>
+                    <td className="connections-table__cell">{resp.infos.length}</td>
+                    <td className="connections-table__cell">{resp.error_message}</td>
+                  </tr>
+                );
+              })
+            }
+          </tbody>
+        </table>
+      </Loading>
     </div>
   );
 }

--- a/pkg/ui/src/views/reports/containers/range/index.tsx
+++ b/pkg/ui/src/views/reports/containers/range/index.tsx
@@ -6,6 +6,7 @@ import { RouterState } from "react-router";
 
 import * as protos from "src/js/protos";
 import { refreshAllocatorRange, refreshRange, refreshRangeLog } from "src/redux/apiReducers";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { AdminUIState } from "src/redux/state";
 import { rangeIDAttr } from "src/util/constants";
 import { FixLong } from "src/util/fixLong";
@@ -17,12 +18,9 @@ import RangeInfo from "src/views/reports/containers/range/rangeInfo";
 import LeaseTable from "src/views/reports/containers/range/leaseTable";
 
 interface RangeOwnProps {
-  range: protos.cockroach.server.serverpb.RangeResponse;
-  allocatorRange: protos.cockroach.server.serverpb.AllocatorRangeResponse;
-  rangeLog: protos.cockroach.server.serverpb.RangeLogResponse;
-  lastError: Error;
-  allocatorLastError: Error;
-  rangeLogLastError: Error;
+  range: CachedDataReducerState<protos.cockroach.server.serverpb.RangeResponse>;
+  allocator: CachedDataReducerState<protos.cockroach.server.serverpb.AllocatorRangeResponse>;
+  rangeLog: CachedDataReducerState<protos.cockroach.server.serverpb.RangeLogResponse>;
   refreshRange: typeof refreshRange;
   refreshAllocatorRange: typeof refreshAllocatorRange;
   refreshRangeLog: typeof refreshRangeLog;
@@ -31,17 +29,15 @@ interface RangeOwnProps {
 type RangeProps = RangeOwnProps & RouterState;
 
 function ErrorPage(props: {
-  rangeID: string,
-  errorText: string,
-  rangeResponse?: protos.cockroach.server.serverpb.RangeResponse;
+  rangeID: string;
+  errorText: string;
+  range?: CachedDataReducerState<protos.cockroach.server.serverpb.RangeResponse>;
 }) {
   return (
     <div className="section">
       <h1>Range Report for r{props.rangeID}</h1>
       <h2>{props.errorText}</h2>
-      {
-        _.isNil(props.rangeResponse) ? null : <ConnectionsTable rangeResponse={props.rangeResponse} />
-      }
+      <ConnectionsTable range={props.range} />
     </div>
   );
 }
@@ -52,17 +48,23 @@ function ErrorPage(props: {
 class Range extends React.Component<RangeProps, {}> {
   refresh(props = this.props) {
     const rangeID = Long.fromString(props.params[rangeIDAttr]);
-    props.refreshRange(new protos.cockroach.server.serverpb.RangeRequest({
-      range_id: rangeID,
-    }));
-    props.refreshAllocatorRange(new protos.cockroach.server.serverpb.AllocatorRangeRequest({
-      range_id: rangeID,
-    }));
+    props.refreshRange(
+      new protos.cockroach.server.serverpb.RangeRequest({
+        range_id: rangeID,
+      }),
+    );
+    props.refreshAllocatorRange(
+      new protos.cockroach.server.serverpb.AllocatorRangeRequest({
+        range_id: rangeID,
+      }),
+    );
     // TODO(bram): Remove this limit once #18159 is resolved.
-    props.refreshRangeLog(new protos.cockroach.server.serverpb.RangeLogRequest({
-      range_id: rangeID,
-      limit: -1,
-    }));
+    props.refreshRangeLog(
+      new protos.cockroach.server.serverpb.RangeLogRequest({
+        range_id: rangeID,
+        limit: -1,
+      }),
+    );
   }
 
   componentWillMount() {
@@ -81,58 +83,62 @@ class Range extends React.Component<RangeProps, {}> {
     const { range } = this.props;
 
     // A bunch of quick error cases.
-    if (!_.isNil(this.props.lastError)) {
-      return <ErrorPage
-        rangeID={rangeID}
-        errorText={`Error loading range ${this.props.lastError}`}
-      />;
+    if (!_.isNil(range) && !_.isNil(range.lastError)) {
+      return (
+        <ErrorPage
+          rangeID={rangeID}
+          errorText={`Error loading range ${range.lastError}`}
+        />
+      );
     }
-    if (_.isEmpty(range)) {
-      return <ErrorPage
-        rangeID={rangeID}
-        errorText={`Loading cluster status...`}
-      />;
+    if (_.isNil(range) || _.isEmpty(range.data)) {
+      return (
+        <ErrorPage rangeID={rangeID} errorText={`Loading cluster status...`} />
+      );
     }
-    const responseRangeID = FixLong(range.range_id);
+    const responseRangeID = FixLong(range.data.range_id);
     if (!responseRangeID.eq(rangeID)) {
-      return <ErrorPage
-        rangeID={rangeID}
-        errorText={`Updating cluster status...`}
-      />;
+      return (
+        <ErrorPage rangeID={rangeID} errorText={`Updating cluster status...`} />
+      );
     }
     if (responseRangeID.isNegative() || responseRangeID.isZero()) {
-      return <ErrorPage
-        rangeID={rangeID}
-        errorText={`Range ID must be a positive non-zero integer. "${rangeID}"`}
-      />;
+      return (
+        <ErrorPage
+          rangeID={rangeID}
+          errorText={`Range ID must be a positive non-zero integer. "${rangeID}"`}
+        />
+      );
     }
 
     // Did we get any responses?
-    if (!_.some(range.responses_by_node_id, resp => resp.infos.length > 0)) {
-      return <ErrorPage
-        rangeID={rangeID}
-        errorText={`No results found, perhaps r${this.props.params[rangeIDAttr]} doesn't exist.`}
-        rangeResponse={range}
-      />;
+    if (!_.some(range.data.responses_by_node_id, resp => resp.infos.length > 0)) {
+      return (
+        <ErrorPage
+          rangeID={rangeID}
+          errorText={`No results found, perhaps r${this.props.params[rangeIDAttr]} doesn't exist.`}
+          range={range}
+        />
+      );
     }
 
     // Collect all the infos and sort them, putting the leader (or the replica
     // with the highest term, first.
     const infos = _.orderBy(
-      _.flatMap(range.responses_by_node_id, resp => {
+      _.flatMap(range.data.responses_by_node_id, resp => {
         if (resp.response && _.isEmpty(resp.error_message)) {
           return resp.infos;
         }
         return [];
       }),
       [
-        (info => RangeInfo.IsLeader(info)),
-        (info => FixLong(info.raft_state.applied).toNumber()),
-        (info => FixLong(info.raft_state.hard_state.term).toNumber()),
-        (info => {
+        info => RangeInfo.IsLeader(info),
+        info => FixLong(info.raft_state.applied).toNumber(),
+        info => FixLong(info.raft_state.hard_state.term).toNumber(),
+        info => {
           const localReplica = RangeInfo.GetLocalReplica(info);
           return _.isNil(localReplica) ? 0 : localReplica.replica_id;
-        }),
+        },
       ],
       ["desc", "desc", "desc", "asc"],
     );
@@ -149,29 +155,20 @@ class Range extends React.Component<RangeProps, {}> {
         <h1>Range Report for r{responseRangeID.toString()}</h1>
         <RangeTable infos={infos} replicas={replicas} />
         <LeaseTable info={_.head(infos)} />
-        <ConnectionsTable rangeResponse={range} />
-        <AllocatorOutput
-          allocatorRangeResponse={this.props.allocatorRange}
-          lastError={this.props.allocatorLastError}
-        />
-        <LogTable
-          rangeID={responseRangeID}
-          log={this.props.rangeLog}
-          lastError={this.props.rangeLogLastError}
-        />
+        <ConnectionsTable range={range} />
+        <AllocatorOutput allocator={this.props.allocator} />
+        <LogTable rangeID={responseRangeID} log={this.props.rangeLog} />
       </div>
     );
   }
 }
 
-function mapStateToProps(state: AdminUIState) {
+function mapStateToProps(state: AdminUIState, props: RangeProps) {
+  const rangeID = props.params[rangeIDAttr];
   return {
-    range: state.cachedData.range.data,
-    allocatorRange: state.cachedData.allocatorRange.data,
-    rangeLog: state.cachedData.rangeLog.data,
-    lastError: state.cachedData.range.lastError,
-    allocatorLastError: state.cachedData.allocatorRange.lastError,
-    rangeLogLastError: state.cachedData.rangeLog.lastError,
+    range: state.cachedData.range[rangeID],
+    allocator: state.cachedData.allocatorRange[rangeID],
+    rangeLog: state.cachedData.rangeLog[rangeID],
   };
 }
 

--- a/pkg/ui/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/logTable.tsx
@@ -2,6 +2,7 @@ import _ from "lodash";
 import React from "react";
 
 import * as protos from "src/js/protos";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { FixLong } from "src/util/fixLong";
 import Print from "src/views/reports/containers/range/print";
 import Loading from "src/views/shared/components/loading";
@@ -11,16 +12,21 @@ import spinner from "assets/spinner.gif";
 
 interface LogTableProps {
   rangeID: Long;
-  log: protos.cockroach.server.serverpb.RangeLogResponse$Properties;
-  lastError: Error;
+  log: CachedDataReducerState<protos.cockroach.server.serverpb.RangeLogResponse>;
 }
 
-function printLogEventType(eventType: protos.cockroach.storage.RangeLogEventType) {
+function printLogEventType(
+  eventType: protos.cockroach.storage.RangeLogEventType,
+) {
   switch (eventType) {
-    case protos.cockroach.storage.RangeLogEventType.add: return "Add";
-    case protos.cockroach.storage.RangeLogEventType.remove: return "Remove";
-    case protos.cockroach.storage.RangeLogEventType.split: return "Split";
-    default: return "Unknown";
+    case protos.cockroach.storage.RangeLogEventType.add:
+      return "Add";
+    case protos.cockroach.storage.RangeLogEventType.remove:
+      return "Remove";
+    case protos.cockroach.storage.RangeLogEventType.split:
+      return "Split";
+    default:
+      return "Unknown";
   }
 }
 
@@ -44,9 +50,7 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
     );
   }
 
-  renderLogInfoDescriptor(
-    title: string, desc: string,
-  ) {
+  renderLogInfoDescriptor(title: string, desc: string) {
     if (_.isEmpty(desc)) {
       return null;
     }
@@ -57,10 +61,15 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
     );
   }
 
-  renderLogInfo(info: protos.cockroach.server.serverpb.RangeLogResponse.PrettyInfo$Properties) {
+  renderLogInfo(
+    info: protos.cockroach.server.serverpb.RangeLogResponse.PrettyInfo$Properties,
+  ) {
     return (
       <ul className="log-entries-list">
-        {this.renderLogInfoDescriptor("Updated Range Descriptor", info.updated_desc)}
+        {this.renderLogInfoDescriptor(
+          "Updated Range Descriptor",
+          info.updated_desc,
+        )}
         {this.renderLogInfoDescriptor("New Range Descriptor", info.new_desc)}
         {this.renderLogInfoDescriptor("Added Replica", info.added_replica)}
         {this.renderLogInfoDescriptor("Removed Replica", info.removed_replica)}
@@ -71,55 +80,75 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
   }
 
   render() {
-    const { log, lastError } = this.props;
+    const { log } = this.props;
 
-    if (!_.isEmpty(lastError)) {
+    if (log && !_.isEmpty(log.lastError)) {
       return (
         <div>
           <h2>Range Log</h2>
           There was an error retrieving the range log:
-          {lastError}
+          {log.lastError}
         </div>
       );
     }
 
     // Sort by descending timestamp.
-    const events = _.orderBy(log && log.events, event => TimestampToMoment(event.event.timestamp).valueOf(), "desc");
+    const events = _.orderBy(
+      log && log.data && log.data.events,
+      event => TimestampToMoment(event.event.timestamp).valueOf(),
+      "desc",
+    );
 
     return (
       <div>
         <h2>Range Log</h2>
         <Loading
-          loading={_.isNil(log)}
+          loading={!log || log.inFlight}
           className="loading-image loading-image__spinner-left"
           image={spinner}
         >
           <table className="log-table">
             <tbody>
               <tr className="log-table__row log-table__row--header">
-                <th className="log-table__cell log-table__cell--header">Timestamp</th>
-                <th className="log-table__cell log-table__cell--header">Store</th>
-                <th className="log-table__cell log-table__cell--header">Event Type</th>
-                <th className="log-table__cell log-table__cell--header">Range</th>
-                <th className="log-table__cell log-table__cell--header">Other Range</th>
-                <th className="log-table__cell log-table__cell--header">Info</th>
+                <th className="log-table__cell log-table__cell--header">
+                  Timestamp
+                </th>
+                <th className="log-table__cell log-table__cell--header">
+                  Store
+                </th>
+                <th className="log-table__cell log-table__cell--header">
+                  Event Type
+                </th>
+                <th className="log-table__cell log-table__cell--header">
+                  Range
+                </th>
+                <th className="log-table__cell log-table__cell--header">
+                  Other Range
+                </th>
+                <th className="log-table__cell log-table__cell--header">
+                  Info
+                </th>
               </tr>
-              {
-                _.map(events, (event, key) => (
-                  <tr key={key} className="log-table__row">
-                    <td className="log-table__cell log-table__cell--date">
-                      {Print.Timestamp(event.event.timestamp)}
-                    </td>
-                    <td className="log-table__cell">s{event.event.store_id}</td>
-                    <td className="log-table__cell">{printLogEventType(event.event.event_type)}</td>
-                    <td className="log-table__cell">{this.renderRangeID(event.event.range_id)}</td>
-                    <td className="log-table__cell">
-                      {this.renderRangeID(event.event.other_range_id)}
-                    </td>
-                    <td className="log-table__cell">{this.renderLogInfo(event.pretty_info)}</td>
-                  </tr>
-                ))
-              }
+              {_.map(events, (event, key) => (
+                <tr key={key} className="log-table__row">
+                  <td className="log-table__cell log-table__cell--date">
+                    {Print.Timestamp(event.event.timestamp)}
+                  </td>
+                  <td className="log-table__cell">s{event.event.store_id}</td>
+                  <td className="log-table__cell">
+                    {printLogEventType(event.event.event_type)}
+                  </td>
+                  <td className="log-table__cell">
+                    {this.renderRangeID(event.event.range_id)}
+                  </td>
+                  <td className="log-table__cell">
+                    {this.renderRangeID(event.event.other_range_id)}
+                  </td>
+                  <td className="log-table__cell">
+                    {this.renderLogInfo(event.pretty_info)}
+                  </td>
+                </tr>
+              ))}
             </tbody>
           </table>
         </Loading>


### PR DESCRIPTION
The invalidation time for cashed data reducers was used for both invalidation and as the api timeout. This change turns that into two different optional values.

Also included in this change:

- Set all debug pages to use KeyedCacheDataReducers instead of CachedDataReducers which fixes a number of bugs in which parts of the debug pages
might not update.
- Set the invalidation period for all debug pages to 0, so they are already reloaded intead of using cached values.
- Set the timeout for all debug pages to be 1m or greater (depending on the expected lenght of the request).

Fixes: #20634, #19920, #20683

Release note: None