### PR TITLE
sql: match postgres's accepted bool formats

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -143,10 +143,10 @@ CREATE TABLE t15050b (c DECIMAL DEFAULT IF(NOW() < '2017-04-18 18:00', 2, 2));
 
 # Regression tests for #15632
 
-statement error incompatible IFNULL expressions: could not parse "foo" as type bool: strconv.ParseBool: parsing "foo": invalid syntax
+statement error incompatible IFNULL expressions: could not parse "foo" as type bool
 SELECT IFNULL('foo', false)
 
-statement error incompatible IFNULL expressions: could not parse "foo" as type bool: strconv.ParseBool: parsing "foo": invalid syntax
+statement error incompatible IFNULL expressions: could not parse "foo" as type bool
 SELECT IFNULL(true, 'foo')
 
 query B

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -412,6 +412,67 @@ func TestParseDDate(t *testing.T) {
 	}
 }
 
+func TestParseDBool(t *testing.T) {
+	testData := []struct {
+		str      string
+		expected *tree.DBool
+		err      bool
+	}{
+		{str: "t", expected: tree.DBoolTrue},
+		{str: "tr", expected: tree.DBoolTrue},
+		{str: "tru", expected: tree.DBoolTrue},
+		{str: "true", expected: tree.DBoolTrue},
+		{str: "tr", expected: tree.DBoolTrue},
+		{str: "TRUE", expected: tree.DBoolTrue},
+		{str: "tRUe", expected: tree.DBoolTrue},
+		{str: "  tRUe    ", expected: tree.DBoolTrue},
+		{str: "  tR    ", expected: tree.DBoolTrue},
+		{str: "on", expected: tree.DBoolTrue},
+		{str: "On", expected: tree.DBoolTrue},
+		{str: "oN", expected: tree.DBoolTrue},
+		{str: "ON", expected: tree.DBoolTrue},
+		{str: "1", expected: tree.DBoolTrue},
+		{str: "yes", expected: tree.DBoolTrue},
+		{str: "ye", expected: tree.DBoolTrue},
+		{str: "y", expected: tree.DBoolTrue},
+
+		{str: "false", expected: tree.DBoolFalse},
+		{str: "FALSE", expected: tree.DBoolFalse},
+		{str: "fALse", expected: tree.DBoolFalse},
+		{str: "f", expected: tree.DBoolFalse},
+		{str: "off", expected: tree.DBoolFalse},
+		{str: "Off", expected: tree.DBoolFalse},
+		{str: "oFF", expected: tree.DBoolFalse},
+		{str: "OFF", expected: tree.DBoolFalse},
+		{str: "0", expected: tree.DBoolFalse},
+
+		{str: "foo", err: true},
+		{str: "tr ue", err: true},
+		{str: "o", err: true},
+		{str: "", err: true},
+		{str: " ", err: true},
+		{str: "  ", err: true},
+	}
+
+	for _, td := range testData {
+		t.Run(td.str, func(t *testing.T) {
+			result, err := tree.ParseDBool(td.str)
+			if td.err {
+				if err == nil {
+					t.Fatalf("expected parsing %v to error, got %v", td.str, result)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected parsing %v to be %s, got error: %s", td.str, td.expected, err)
+			}
+			if *td.expected != *result {
+				t.Fatalf("expected parsing %v to be %s, got %s", td.str, td.expected, result)
+			}
+		})
+	}
+}
+
 func TestParseDTime(t *testing.T) {
 	// Since ParseDTime mostly delegates parsing logic to ParseDTimestamp, we only test a subset of
 	// the timestamp test cases.

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -1142,7 +1142,7 @@ func TestEvalError(t *testing.T) {
 		{`'11h2m'::interval / 0`, `division by zero`},
 		{`'11h2m'::interval / 0.0::float`, `division by zero`},
 		{`'???'::bool`,
-			`could not parse "???" as type bool: strconv.ParseBool: parsing "???": invalid syntax`},
+			`could not parse "???" as type bool`},
 		{`'foo'::int`,
 			`could not parse "foo" as type int: strconv.ParseInt: parsing "foo": invalid syntax`},
 		{`'3\r2'::int`,


### PR DESCRIPTION
Fixes #20822.

Release note: Match Postgres's list of bool formats.

There was a comment saying that ParseBool was *more* lenient than the
SQL spec, but it was actually strictly *less* lenient than Postgres:
https://golang.org/pkg/strconv/#ParseBool

See the Postgres implementation of this function:
https://github.com/postgres/postgres/blob/90627cf98a8e7d0531789391fd798c9bfcc3bc1a/src/backend/utils/adt/bool.c#L36

We don't just string.ToLower based on an unsubstantiated fear of
allocating more strings than necessary.