### PR TITLE
sql/parser: trim sqlSymType and Scanner structs

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -525,7 +525,6 @@ func (u *sqlSymUnion) scrubOption() tree.ScrubOption {
 %union {
   id             int
   pos            int
-  empty          struct{}
   str            string
   union          sqlSymUnion
 }


### PR DESCRIPTION
Closes #13643.

The referenced issue was a little off because the `id` and `pos` fields were
exactly where we'd want them. We wanted to maintain that state for each token,
and `sqlSymType` was the right place to hold token-specific state.

That said, it was on the right track. We could remove the unused `empty` struct
from `sqlSymType`. We could also trim a few fields from `Scanner`. This change
makes both of these changes, which in total result in a reduction of the `Scanner`
size from 256 bytes to 184 bytes.

```
name     old time/op    new time/op    delta
Parse-4    30.2µs ± 2%    28.2µs ± 5%  -6.32%  (p=0.000 n=10+10)

name     old alloc/op   new alloc/op   delta
Parse-4    6.27kB ± 0%    6.14kB ± 0%  -2.04%  (p=0.000 n=10+10)

name     old allocs/op  new allocs/op  delta
Parse-4       142 ± 0%       142 ± 0%    ~     (all equal)
```

Note that during experimentation I changed the token ID type from an `int` to an
`int32`. Surprisingly, this resulted in a 15% performance hit on `BenchmarkParse`.
I looked into the generated assembly to determine why and couldn't see anything,
other than that the main switch-case in `Scanner.scan` seemed to have different
binary search pivots.

Release note: None