### PR TITLE
cli: avoid special line at the end of CSV/TSV output

### DIFF
--- a/build/verify-archive.sh
+++ b/build/verify-archive.sh
@@ -24,6 +24,5 @@ EOF
 diff -u - <(cockroach sql --insecure -e 'SELECT * FROM bank.accounts') <<EOF
 id	balance
 1	1000.50
-# 1 row
 EOF
 cockroach quit --insecure

--- a/pkg/acceptance/decommission_test.go
+++ b/pkg/acceptance/decommission_test.go
@@ -145,6 +145,7 @@ func testDecommissionInner(
 		InitialBackoff: time.Second,
 		MaxBackoff:     5 * time.Second,
 		Multiplier:     1,
+		MaxRetries:     20,
 	}
 	for r := retry.Start(retryOpts); r.Next(); {
 		o, err := decommission(ctx, c, 1, idMap[0], "decommission", "--wait", "none", "--format", "csv")

--- a/pkg/acceptance/decommission_test.go
+++ b/pkg/acceptance/decommission_test.go
@@ -156,7 +156,6 @@ func testDecommissionInner(
 		exp := [][]string{
 			decommissionHeader,
 			{strconv.Itoa(int(idMap[0])), "true", "0", "true", "true"},
-			{"# 1 row"},
 			decommissionFooterLive,
 		}
 		log.Infof(ctx, o)
@@ -180,7 +179,6 @@ func testDecommissionInner(
 			{"2"},
 			{"3"},
 			{"4"},
-			{"# 4 rows"},
 		}
 		if err := matchCSV(o, exp); err != nil {
 			t.Fatal(err)
@@ -198,7 +196,6 @@ func testDecommissionInner(
 			{`2`, `.*`, `.*`, `.*`, `.*`, `.*`},
 			{`3`, `.*`, `.*`, `.*`, `.*`, `.*`},
 			{`4`, `.*`, `.*`, `.*`, `.*`, `.*`},
-			{"# 4 rows"},
 		}
 		if err := matchCSV(o, exp); err != nil {
 			t.Fatal(err)
@@ -231,7 +228,6 @@ func testDecommissionInner(
 		exp := [][]string{
 			decommissionHeader,
 			{strconv.Itoa(int(target)), "true", "0", "true", "true"},
-			{"# 1 row"},
 			decommissionFooter,
 		}
 		if err := matchCSV(o, exp); err != nil {
@@ -289,7 +285,6 @@ func testDecommissionInner(
 		exp := [][]string{
 			decommissionHeader,
 			{strconv.Itoa(int(target)), "true", "0", "true", "true"},
-			{"# 1 row"},
 			decommissionFooter,
 		}
 		if err := matchCSV(o, exp); err != nil {
@@ -337,7 +332,6 @@ func testDecommissionInner(
 		exp := [][]string{
 			decommissionHeader,
 			{strconv.Itoa(int(target)), "true", "0", "true", "true"},
-			{"# 1 row"},
 			decommissionFooter,
 		}
 		if err := matchCSV(o, exp); err != nil {
@@ -379,7 +373,6 @@ func testDecommissionInner(
 		exp := [][]string{
 			decommissionHeader,
 			{strconv.Itoa(int(target)), `true|false`, `\d+`, `true`, `true|false`},
-			{"# 1 row"},
 			decommissionFooterLive,
 		}
 		if err := matchCSV(o, exp); err != nil {
@@ -402,7 +395,6 @@ func testDecommissionInner(
 			{"2"},
 			{"3"},
 			{"4"},
-			{"# 3 rows"},
 		}
 
 		if err := matchCSV(o, exp); err != nil {
@@ -424,7 +416,6 @@ func testDecommissionInner(
 			{`2`, `.*`, `.*`, `.*`, `.*`, `.*`},
 			{`3`, `.*`, `.*`, `.*`, `.*`, `.*`},
 			{`4`, `.*`, `.*`, `.*`, `.*`, `.*`},
-			{"# 3 rows"},
 		}
 		if err := matchCSV(o, exp); err != nil {
 			time.Sleep(time.Second)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -403,27 +403,21 @@ func Example_logging() {
 	// sql --logtostderr=false -e select 1
 	// 1
 	// 1
-	// # 1 row
 	// sql --log-backtrace-at=foo.go:1 -e select 1
 	// 1
 	// 1
-	// # 1 row
 	// sql --log-dir= -e select 1
 	// 1
 	// 1
-	// # 1 row
 	// sql --logtostderr=true -e select 1
 	// 1
 	// 1
-	// # 1 row
 	// sql --verbosity=0 -e select 1
 	// 1
 	// 1
-	// # 1 row
 	// sql --vmodule=foo=1 -e select 1
 	// 1
 	// 1
-	// # 1 row
 }
 
 func Example_zone() {
@@ -672,26 +666,21 @@ func Example_sql() {
 	// sql -e show application_name
 	// application_name
 	// cockroach
-	// # 1 row
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
 	// INSERT 1
 	// sql -e select 3 -e select * from t.f
 	// 3
 	// 3
-	// # 1 row
 	// x	y
 	// 42	69
-	// # 1 row
 	// sql -e begin -e select 3 -e commit
 	// BEGIN
 	// 3
 	// 3
-	// # 1 row
 	// COMMIT
 	// sql -e select * from t.f
 	// x	y
 	// 42	69
-	// # 1 row
 	// sql --execute=show databases
 	// Database
 	// crdb_internal
@@ -699,37 +688,29 @@ func Example_sql() {
 	// pg_catalog
 	// system
 	// t
-	// # 5 rows
 	// sql -e select 1; select 2
 	// 1
 	// 1
-	// # 1 row
 	// 2
 	// 2
-	// # 1 row
 	// sql -e select 1; select 2 where false
 	// 1
 	// 1
-	// # 1 row
 	// 2
-	// # 0 rows
 	// sql -e create table t.g1 (x int)
 	// CREATE TABLE
 	// sql -e create table t.g2 as select * from generate_series(1,10)
 	// SELECT 10
 	// sql -d nonexistent -e select count(*) from pg_class limit 0
 	// count
-	// # 0 rows
 	// sql -d nonexistent -e create database nonexistent; create table foo(x int); select * from foo
 	// x
-	// # 0 rows
 	// sql -e copy t.f from stdin
 	// woops! COPY has confused this client! Suggestion: use 'psql' for COPY
 	// user ls --echo-sql
 	// > SHOW USERS
 	// username
 	// root
-	// # 1 row
 }
 
 func Example_sql_format() {
@@ -748,7 +729,6 @@ func Example_sql_format() {
 	// sql -e select * from t.times
 	// bare	withtz
 	// 2016-01-25 10:10:10+00:00	2016-01-25 15:10:10+00:00
-	// # 1 row
 }
 
 func Example_sql_column_labels() {
@@ -809,14 +789,12 @@ thenshort`,
 	// κόσμε	INT	true	NULL	{}
 	// a|b	INT	true	NULL	{}
 	// ܈85	INT	true	NULL	{}
-	// # 8 rows
 	// sql -e select * from t.u
 	// "f""oo"	f'oo	f\oo	"short
 	// very very long
 	// not much"	"very very long
 	// thenshort"	κόσμε	a|b	܈85
 	// 0	0	0	0	0	0	0	0
-	// # 1 row
 	// sql --format=pretty -e show columns from t.u
 	// +----------------+------+------+---------+---------+
 	// |     Field      | Type | Null | Default | Indices |
@@ -854,14 +832,12 @@ thenshort`,
 	// not much"	"very very long
 	// thenshort"	κόσμε	a|b	܈85
 	// 0	0	0	0	0	0	0	0
-	// # 1 row
 	// sql --format=csv -e select * from t.u
 	// "f""oo",f'oo,f\oo,"short
 	// very very long
 	// not much","very very long
 	// thenshort",κόσμε,a|b,܈85
 	// 0,0,0,0,0,0,0,0
-	// # 1 row
 	// sql --format=pretty -e select * from t.u
 	// +------+------+------+----------------+----------------+-------+-----+-----+
 	// | f"oo | f'oo | f\oo |     short      | very very long | κόσμε | a|b | ܈85 |
@@ -951,10 +927,8 @@ func Example_sql_empty_table() {
 	// INSERT 3
 	// sql --format=tsv -e select * from t.norows
 	// x
-	// # 0 rows
 	// sql --format=csv -e select * from t.norows
 	// x
-	// # 0 rows
 	// sql --format=pretty -e select * from t.norows
 	// +---+
 	// | x |
@@ -981,13 +955,11 @@ func Example_sql_empty_table() {
 	// # empty
 	// # empty
 	// # empty
-	// # 3 rows
 	// sql --format=csv -e select * from t.nocols
 	// # no columns
 	// # empty
 	// # empty
 	// # empty
-	// # 3 rows
 	// sql --format=pretty -e select * from t.nocols
 	// --
 	// (3 rows)
@@ -1018,10 +990,8 @@ func Example_sql_empty_table() {
 	// # 3 rows
 	// sql --format=tsv -e select * from t.nocolsnorows
 	// # no columns
-	// # 0 rows
 	// sql --format=csv -e select * from t.nocolsnorows
 	// # no columns
-	// # 0 rows
 	// sql --format=pretty -e select * from t.nocolsnorows
 	// --
 	// (0 rows)
@@ -1078,19 +1048,15 @@ def`,
 	// sql --format=csv -e select 'ab' as s, 'ab' as t
 	// s,t
 	// ab,ab
-	// # 1 row
 	// sql --format=tsv -e select 'ab' as s, 'ab' as t
 	// s	t
 	// ab	ab
-	// # 1 row
 	// sql --format=csv -e select 'a b' as s, 'a b' as t
 	// s,t
 	// a b,a b
-	// # 1 row
 	// sql --format=tsv -e select 'a b' as s, 'a b' as t
 	// s	t
 	// a b	a b
-	// # 1 row
 	// sql --format=csv -e select e'a\nbc\ndef' as s, e'a\nbc\ndef' as t
 	// s,t
 	// "a
@@ -1098,7 +1064,6 @@ def`,
 	// def","a
 	// bc
 	// def"
-	// # 1 row
 	// sql --format=tsv -e select e'a\nbc\ndef' as s, e'a\nbc\ndef' as t
 	// s	t
 	// "a
@@ -1106,63 +1071,48 @@ def`,
 	// def"	"a
 	// bc
 	// def"
-	// # 1 row
 	// sql --format=csv -e select 'a, b' as s, 'a, b' as t
 	// s,t
 	// "a, b","a, b"
-	// # 1 row
 	// sql --format=tsv -e select 'a, b' as s, 'a, b' as t
 	// s	t
 	// a, b	a, b
-	// # 1 row
 	// sql --format=csv -e select '"a", "b"' as s, '"a", "b"' as t
 	// s,t
 	// """a"", ""b""","""a"", ""b"""
-	// # 1 row
 	// sql --format=tsv -e select '"a", "b"' as s, '"a", "b"' as t
 	// s	t
 	// """a"", ""b"""	"""a"", ""b"""
-	// # 1 row
 	// sql --format=csv -e select e'\'a\', \'b\'' as s, e'\'a\', \'b\'' as t
 	// s,t
 	// "'a', 'b'","'a', 'b'"
-	// # 1 row
 	// sql --format=tsv -e select e'\'a\', \'b\'' as s, e'\'a\', \'b\'' as t
 	// s	t
 	// 'a', 'b'	'a', 'b'
-	// # 1 row
 	// sql --format=csv -e select e'a\\,b' as s, e'a\\,b' as t
 	// s,t
 	// "a\,b","a\,b"
-	// # 1 row
 	// sql --format=tsv -e select e'a\\,b' as s, e'a\\,b' as t
 	// s	t
 	// a\,b	a\,b
-	// # 1 row
 	// sql --format=csv -e select e'a\tb' as s, e'a\tb' as t
 	// s,t
 	// a	b,a	b
-	// # 1 row
 	// sql --format=tsv -e select e'a\tb' as s, e'a\tb' as t
 	// s	t
 	// "a	b"	"a	b"
-	// # 1 row
 	// sql --format=csv -e select 1 as ab1, 2 as ab2
 	// ab1,ab2
 	// 1,2
-	// # 1 row
 	// sql --format=tsv -e select 1 as ab1, 2 as ab2
 	// ab1	ab2
 	// 1	2
-	// # 1 row
 	// sql --format=csv -e select 1 as "a b1", 2 as "a b2"
 	// a b1,a b2
 	// 1,2
-	// # 1 row
 	// sql --format=tsv -e select 1 as "a b1", 2 as "a b2"
 	// a b1	a b2
 	// 1	2
-	// # 1 row
 	// sql --format=csv -e select 1 as "a
 	// bc
 	// def1", 2 as "a
@@ -1174,7 +1124,6 @@ def`,
 	// bc
 	// def2"
 	// 1,2
-	// # 1 row
 	// sql --format=tsv -e select 1 as "a
 	// bc
 	// def1", 2 as "a
@@ -1186,47 +1135,36 @@ def`,
 	// bc
 	// def2"
 	// 1	2
-	// # 1 row
 	// sql --format=csv -e select 1 as "a, b1", 2 as "a, b2"
 	// "a, b1","a, b2"
 	// 1,2
-	// # 1 row
 	// sql --format=tsv -e select 1 as "a, b1", 2 as "a, b2"
 	// a, b1	a, b2
 	// 1	2
-	// # 1 row
 	// sql --format=csv -e select 1 as """a"", ""b""1", 2 as """a"", ""b""2"
 	// """a"", ""b""1","""a"", ""b""2"
 	// 1,2
-	// # 1 row
 	// sql --format=tsv -e select 1 as """a"", ""b""1", 2 as """a"", ""b""2"
 	// """a"", ""b""1"	"""a"", ""b""2"
 	// 1	2
-	// # 1 row
 	// sql --format=csv -e select 1 as "'a', 'b'1", 2 as "'a', 'b'2"
 	// "'a', 'b'1","'a', 'b'2"
 	// 1,2
-	// # 1 row
 	// sql --format=tsv -e select 1 as "'a', 'b'1", 2 as "'a', 'b'2"
 	// 'a', 'b'1	'a', 'b'2
 	// 1	2
-	// # 1 row
 	// sql --format=csv -e select 1 as "a\,b1", 2 as "a\,b2"
 	// "a\,b1","a\,b2"
 	// 1,2
-	// # 1 row
 	// sql --format=tsv -e select 1 as "a\,b1", 2 as "a\,b2"
 	// a\,b1	a\,b2
 	// 1	2
-	// # 1 row
 	// sql --format=csv -e select 1 as "a	b1", 2 as "a	b2"
 	// a	b1,a	b2
 	// 1,2
-	// # 1 row
 	// sql --format=tsv -e select 1 as "a	b1", 2 as "a	b2"
 	// "a	b1"	"a	b2"
 	// 1	2
-	// # 1 row
 }
 
 func Example_sql_table() {
@@ -1297,7 +1235,6 @@ func Example_sql_table() {
 	// ܈85	UTF8 string with RTL char
 	// "a	b	c
 	// 12	123123213	12313"	tabs
-	// # 9 rows
 	// sql --format=tsv -e select * from t.t
 	// s	d
 	// foo	printable ASCII
@@ -1311,7 +1248,6 @@ func Example_sql_table() {
 	// ܈85	UTF8 string with RTL char
 	// "a	b	c
 	// 12	123123213	12313"	tabs
-	// # 9 rows
 	// sql --format=csv -e select * from t.t
 	// s,d
 	// foo,printable ASCII
@@ -1325,7 +1261,6 @@ func Example_sql_table() {
 	// ܈85,UTF8 string with RTL char
 	// "a	b	c
 	// 12	123123213	12313",tabs
-	// # 9 rows
 	// sql --format=pretty -e select * from t.t
 	// +---------------------+--------------------------------+
 	// |          s          |               d                |
@@ -1531,7 +1466,6 @@ func Example_user() {
 	// user ls
 	// username
 	// root
-	// # 1 row
 	// user ls --format=pretty
 	// +----------+
 	// | username |
@@ -1542,7 +1476,6 @@ func Example_user() {
 	// user ls --format=tsv
 	// username
 	// root
-	// # 1 row
 	// user set FOO
 	// CREATE USER 1
 	// sql -e create user if not exists 'FOO'
@@ -1748,7 +1681,6 @@ func Example_node() {
 	// node ls
 	// id
 	// 1
-	// # 1 row
 	// node ls --format=pretty
 	// +----+
 	// | id |
@@ -2176,7 +2108,7 @@ func Example_in_memory() {
 	// node ls
 	// id
 	// 1
-	// # 1 row
+	//
 }
 
 func Example_pretty_print_numerical_strings() {

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -542,9 +542,9 @@ func TestDumpAsOf(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Last line is the row count, last-before-last is the timestamp.
+	// Last line is the timestamp.
 	fs := strings.Split(strings.TrimSpace(out), "\n")
-	ts := fs[len(fs)-2]
+	ts := fs[len(fs)-1]
 
 	dump1, err := c.RunWithCaptureArgs([]string{"dump", "d", "t"})
 	if err != nil {
@@ -818,10 +818,8 @@ SELECT * FROM c;
 
 i
 1
-# 1 row
 i
 1
-# 1 row
 `
 
 	if out != expect {

--- a/pkg/cli/format_table.go
+++ b/pkg/cli/format_table.go
@@ -316,7 +316,6 @@ func (p *csvReporter) doneNoRows(_ io.Writer) error                   { return n
 
 func (p *csvReporter) doneRows(w io.Writer, seenRows int) error {
 	p.csvWriter.Flush()
-	fmt.Fprintf(w, "# %d row%s\n", seenRows, util.Pluralize(int64(seenRows)))
 	return nil
 }
 

--- a/pkg/cli/interactive_tests/test_last_statement.tcl
+++ b/pkg/cli/interactive_tests/test_last_statement.tcl
@@ -35,8 +35,8 @@ eexpect ":/# "
 
 send "$argv sql\r"
 eexpect root@
-send "select * from t.foo;\r"
-eexpect "0 rows"
+send "select count(*) from t.foo;\r"
+eexpect "0"
 eexpect root@
 send "\\q\r"
 eexpect ":/# "
@@ -53,8 +53,8 @@ send "echo 'insert into t.foo(x) values (42)--;' | $argv sql\r"
 eexpect "missing semicolon at end of statement"
 eexpect ":/# "
 
-send "echo 'select * from t.foo;' | $argv sql\r"
-eexpect "0 rows"
+send "echo 'select count(*) from t.foo;' | $argv sql\r"
+eexpect "0"
 eexpect ":/# "
 end_test
 
@@ -62,19 +62,19 @@ start_test "Check that a complete last statement terminated with a semicolon jus
 send "printf 'insert into t.foo(x) values(42);' | $argv sql\r"
 eexpect "INSERT"
 eexpect ":/# "
-send "echo 'select * from t.foo;' | $argv sql\r"
-eexpect "1 row"
+send "echo 'select count(*) from t.foo;' | $argv sql\r"
+eexpect "1"
 eexpect ":/# "
 end_test
 
 start_test "Check that a final comment after a final statement does not cause an error message. #9482"
 send "printf 'select 1;-- final comment' | $argv sql | cat\r"
-eexpect "1\r\n1\r\n# 1 row\r\n:/# "
+eexpect "1\r\n1\r\n:/# "
 end_test
 
 start_test "Check that a final comment does not cause an error message. #9243"
 send "printf 'select 1;\\n-- final comment' | $argv sql | cat\r"
-eexpect "1\r\n1\r\n# 1 row\r\n:/# "
+eexpect "1\r\n1\r\n:/# "
 end_test
 
 # Finally terminate with Ctrl+C

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -37,7 +37,6 @@ end_test
 start_test "Check that \\| reads statements."
 send "\\| echo 'select '; echo '38 + 4;'\r"
 eexpect 42
-eexpect "1 row"
 eexpect root@
 end_test
 
@@ -58,7 +57,7 @@ send "\\?\r"
 eexpect " ->"
 
 send "1;\r"
-eexpect "1 row"
+expect "Time"
 eexpect root@
 end_test
 
@@ -90,7 +89,7 @@ send "\\?\r"
 eexpect " ->"
 send "world';\r"
 eexpect "hello\\\\nworld"
-eexpect "1 row"
+eexpect "Time"
 eexpect root@
 end_test
 
@@ -100,7 +99,7 @@ send "\\unset show_times\r\\set\r"
 eexpect "show_times\tfalse"
 eexpect root@
 send "select 1;\r"
-eexpect "1 row"
+eexpect "1\r\n1\r\n"
 expect {
     "Time:" {
 	report "unexpected Time"

--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -24,7 +24,7 @@ end_test
 
 start_test "Check that tables are not pretty-printed when output is not a terminal and --format=pretty is not specified"
 send "echo begin; echo 'select 1;' | $argv sql | cat\r"
-eexpect "begin\r\n1\r\n1\r\n# 1 row\r\n"
+eexpect "begin\r\n1\r\n1\r\n"
 eexpect ":/# "
 end_test
 
@@ -50,8 +50,8 @@ eexpect ":/# "
 send "$argv sql --format=tsv\r"
 eexpect root@
 send "select 42; select 1;\r"
-eexpect "42\r\n# 1 row\r\n"
-eexpect "1\r\n1\r\n# 1 row\r\n"
+eexpect "42\r\n42\r\n"
+eexpect "1\r\n1\r\n"
 eexpect root@
 send "\\q\r"
 end_test

--- a/pkg/cli/interactive_tests/test_sql_safe_updates.tcl
+++ b/pkg/cli/interactive_tests/test_sql_safe_updates.tcl
@@ -31,7 +31,7 @@ eexpect "brief introduction"
 sleep 0.4
 send "show sql_safe_updates;\r"
 eexpect "true"
-eexpect "1 row"
+eexpect "\r\n"
 send "delete from d.t;\r"
 eexpect "rejected: DELETE without WHERE clause (sql_safe_updates = true)"
 send "\\q\r"


### PR DESCRIPTION
Fixes #18584.

Prior to this patch, the csv/tsv formatters would end a table with a
row count. This is not great for interoperability with external tools
which may expect to be able to redirect the table output to a file and
open that directly in a csv/tsv reader, where the final row count
would be incorrectly interpreted as an extra row.

This patch changes the behavior by omitting the row count altogether
for csv/tsv output.

Release note (cli change): when printing tabular results as CSV or
TSV, no final row count is emitted. This is intended to increase
interoperability with external tools.