### PR TITLE
sql: require CASCADE to drop UNIQUE index

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -297,7 +297,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 				if containsThisColumn {
 					if containsOnlyThisColumn || t.DropBehavior == tree.DropCascade {
 						if err := params.p.dropIndexByName(
-							params.ctx, tree.UnrestrictedName(idx.Name), n.tableDesc, false, t.DropBehavior, ignoreOutboundFK,
+							params.ctx, tree.UnrestrictedName(idx.Name), n.tableDesc, false,
+							t.DropBehavior, ignoreIdxConstraint,
 							tree.AsStringWithFlags(n.n, tree.FmtSimpleQualified),
 						); err != nil {
 							return err
@@ -337,7 +338,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			case sqlbase.ConstraintTypePK:
 				return fmt.Errorf("cannot drop primary key")
 			case sqlbase.ConstraintTypeUnique:
-				return fmt.Errorf("UNIQUE constraint depends on index %q, use DROP INDEX if you really want to drop it", t.Constraint)
+				return fmt.Errorf("UNIQUE constraint depends on index %q, use DROP INDEX with CASCADE if you really want to drop it", t.Constraint)
 			case sqlbase.ConstraintTypeCheck:
 				for i := range n.tableDesc.Checks {
 					if n.tableDesc.Checks[i].Name == name {

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -184,11 +184,11 @@ ALTER TABLE t DROP CONSTRAINT bar
 statement ok
 ALTER TABLE t DROP CONSTRAINT IF EXISTS bar
 
-statement error UNIQUE constraint depends on index "foo", use DROP INDEX if you really want to drop it
+statement error UNIQUE constraint depends on index "foo", use DROP INDEX with CASCADE if you really want to drop it
 ALTER TABLE t DROP CONSTRAINT foo
 
 statement ok
-DROP INDEX foo
+DROP INDEX foo CASCADE
 
 query TTTTRT
 SELECT type, description, username, status, fraction_completed, error
@@ -196,7 +196,7 @@ FROM crdb_internal.jobs
 ORDER BY created DESC
 LIMIT 1
 ----
-SCHEMA CHANGE  DROP INDEX test.t@foo  root  succeeded  1  ·
+SCHEMA CHANGE  DROP INDEX test.t@foo CASCADE root  succeeded  1  ·
 
 query TTBITTBB colnames
 SHOW INDEXES FROM t

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -82,8 +82,14 @@ GRANT CREATE ON TABLE users TO testuser
 
 user testuser
 
-statement ok
+statement error in use as unique constraint
 DROP INDEX users@bar
+
+statement error in use as unique constraint
+DROP INDEX users@bar RESTRICT
+
+statement ok
+DROP INDEX users@bar CASCADE
 
 query TTBITTBB colnames
 SHOW INDEXES FROM users

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -396,7 +396,7 @@ statement ok
 ALTER TABLE delivery DROP COLUMN "item"
 
 statement ok
-DROP INDEX products@products_upc_key
+DROP INDEX products@products_upc_key CASCADE
 
 statement error index "orders_product_idx" is in use as a foreign key constraint
 DROP INDEX orders@orders_product_idx

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -317,7 +317,7 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv]
 
 query TTT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
-  FROM [SHOW KV TRACE FOR DROP INDEX t.kv@woo] WHERE message NOT LIKE '%Z/%'
+  FROM [SHOW KV TRACE FOR DROP INDEX t.kv@woo CASCADE] WHERE message NOT LIKE '%Z/%'
 ----
 (0,1)  starting plan  querying next range at /Table/2/1/0/"t"/3/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1

--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -201,7 +201,7 @@ b  false
 c  false
 
 statement ok
-DROP INDEX i14601a
+DROP INDEX i14601a CASCADE
 
 query TB
 SELECT a, b FROM t14601a ORDER BY a

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -672,7 +672,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 		sqlDB,
 		kvDB,
 		jobRegistry,
-		"DROP INDEX t.test@vidx",
+		"DROP INDEX t.test@vidx CASCADE",
 		maxValue,
 		2,
 		initBackfillNotification())
@@ -1046,7 +1046,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		{"ALTER TABLE t.test ADD COLUMN x DECIMAL DEFAULT (DECIMAL '1.4')", 1},
 		{"ALTER TABLE t.test DROP x", 1},
 		{"CREATE UNIQUE INDEX foo ON t.test (v)", 2},
-		{"DROP INDEX t.test@foo", 1},
+		{"DROP INDEX t.test@foo CASCADE", 1},
 	}
 
 	for _, testCase := range testCases {
@@ -2042,7 +2042,7 @@ func TestBackfillCompletesOnChunkBoundary(t *testing.T) {
 		{sql: "ALTER TABLE t.test ADD COLUMN x DECIMAL DEFAULT (DECIMAL '1.4')", numKeysPerRow: 2},
 		{sql: "ALTER TABLE t.test DROP pi", numKeysPerRow: 2},
 		{sql: "CREATE UNIQUE INDEX foo ON t.test (v)", numKeysPerRow: 3},
-		{sql: "DROP INDEX t.test@vidx", numKeysPerRow: 2},
+		{sql: "DROP INDEX t.test@vidx CASCADE", numKeysPerRow: 2},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #12620.

Release note: Require CASCADE to drop an index that is used by UNIQUE constraint.