### PR TITLE
log: ensure panic details are logged to file even when stderr is not redirected

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -70,6 +70,28 @@ end_test
 interrupt
 eexpect ":/# "
 
+start_test "Check that panic reports are printed to the log even when --logtostderr is specified"
+send "$argv start -s=path=logs/db --insecure --logtostderr\r"
+eexpect "CockroachDB node starting"
+
+system "$argv sql --insecure -e \"select crdb_internal.force_panic('helloworld')\" || true"
+# Check the panic is reported on the server's stderr
+eexpect "panic: helloworld"
+eexpect "panic while executing"
+eexpect "goroutine"
+eexpect ":/# "
+# Check the panic is reported on the server log file
+send "cat logs/db/logs/cockroach.log\r"
+eexpect "a panic has occurred"
+eexpect "panic while executing"
+eexpect "helloworld"
+eexpect "goroutine"
+eexpect ":/# "
+
+end_test
+
+
+
 start_server $argv
 
 start_test "Test that quit does not emit unwanted logging output"

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -710,6 +711,26 @@ func (l *loggingT) putBuffer(b *buffer) {
 	l.freeListMu.Unlock()
 }
 
+// ensureFile ensures that l.file is set and valid.
+func (l *loggingT) ensureFile() error {
+	if l.file == nil {
+		return l.createFile()
+	}
+	return nil
+}
+
+// writeToFile writes to the file and applies the synchronization policy.
+func (l *loggingT) writeToFile(data []byte) error {
+	if _, err := l.file.Write(data); err != nil {
+		return err
+	}
+	if l.syncWrites {
+		_ = l.file.Flush()
+		_ = l.file.Sync()
+	}
+	return nil
+}
+
 // outputLogEntry marshals a log entry proto into bytes, and writes
 // the data to the log files. If a trace location is set, stack traces
 // are added to the entry before marshaling.
@@ -726,7 +747,6 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 	// TODO(tschottdorf): this is a pretty horrible critical section.
 	l.mu.Lock()
 
-	// On fatal log, set all stacks.
 	var stacks []byte
 	if s == Severity_FATAL {
 		switch traceback {
@@ -748,38 +768,57 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 		l.outputToStderr(entry, stacks)
 	}
 	if logDir.isSet() && s >= l.fileThreshold.get() {
-		if l.file == nil {
-			if err := l.createFile(); err != nil {
-				// Make sure the message appears somewhere.
-				l.outputToStderr(entry, stacks)
-				l.exitLocked(err)
-				l.mu.Unlock()
-				return
-			}
+		if err := l.ensureFile(); err != nil {
+			// Make sure the message appears somewhere.
+			l.outputToStderr(entry, stacks)
+			l.exitLocked(err)
+			l.mu.Unlock()
+			return
 		}
 
 		buf := l.processForFile(entry, stacks)
 		data := buf.Bytes()
 
-		if _, err := l.file.Write(data); err != nil {
+		if err := l.writeToFile(data); err != nil {
 			l.exitLocked(err)
 			l.mu.Unlock()
 			return
 		}
-		if l.syncWrites {
-			_ = l.file.Flush()
-			_ = l.file.Sync()
-		}
 
 		l.putBuffer(buf)
 	}
-	exitFunc := l.exitFunc
+	exitFunc := l.exitFunc // restore the exitFunc
 	l.mu.Unlock()
 	// Flush and exit on fatal logging.
 	if s == Severity_FATAL {
 		// If we got here via Exit rather than Fatal, print no stacks.
 		timeoutFlush(10 * time.Second)
 		exitFunc(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
+	}
+}
+
+// printPanicToFile copies the panic details to the log file. This is
+// useful when the standard error is not redirected to the log file
+// (!stderrRedirected), as the go runtime will only print panics to
+// stderr.
+func (l *loggingT) printPanicToFile(r interface{}) {
+	if !logDir.isSet() {
+		// There's no log file. Nothing to do.
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if err := l.ensureFile(); err != nil {
+		fmt.Fprintf(OrigStderr, "log: %v", err)
+		return
+	}
+
+	panicBytes := []byte(fmt.Sprintf("%v\n\n%s\n", r, debug.Stack()))
+	if err := l.writeToFile(panicBytes); err != nil {
+		fmt.Fprintf(OrigStderr, "log: %v", err)
+		return
 	}
 }
 


### PR DESCRIPTION
Prior to this patch, panic details would not be captured to logs
unless the log file was forcing redirection of stderr. This was
notoriously not the case when passing `--logtostderr` or
`--logtostderr=INFO`.  (In contrast, `--logtostderr=WARNING` would
redirect stderr and cause the panic details to be properly captured.)

This patch fixes the issue by capturing the panic details every time
stderr is not redirected.

Release note (bug fix): the crash details are now properly copied to
the log file when starting a node with `--logtostderr` (and in some
other circumstances where they could be lost previously).

Fixes #18907.

Should we cherry pick this into 1.1?