### PR TITLE
kv: fix distSender error index alignment bug

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -1044,7 +1044,6 @@ func (txn *Txn) Send(
 // verifies that if an EndTransactionRequest is included, then it is the last
 // request in the batch.
 func firstWriteIndex(ba roachpb.BatchRequest) (int, *roachpb.Error) {
-	firstWriteIdx := -1
 	for i, ru := range ba.Requests {
 		args := ru.GetInner()
 		if i < len(ba.Requests)-1 /* if not last*/ {
@@ -1053,12 +1052,10 @@ func firstWriteIndex(ba roachpb.BatchRequest) (int, *roachpb.Error) {
 			}
 		}
 		if roachpb.IsTransactionWrite(args) {
-			if firstWriteIdx == -1 {
-				firstWriteIdx = i
-			}
+			return i, nil
 		}
 	}
-	return firstWriteIdx, nil
+	return -1, nil
 }
 
 // UpdateStateOnRemoteRetryableErr updates the Txn, and the Transaction proto

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -605,6 +605,8 @@ func (ds *DistSender) Send(
 		// Such a batch should never need splitting.
 		panic("batch with MaxSpanRequestKeys needs splitting")
 	}
+
+	errIdxOffset := 0
 	for len(parts) > 0 {
 		part := parts[0]
 		ba.Requests = part
@@ -616,6 +618,7 @@ func (ds *DistSender) Send(
 		if err != nil {
 			return nil, roachpb.NewError(err)
 		}
+
 		rpl, pErr := ds.divideAndSendBatchToRanges(ctx, ba, rs, 0 /* batchIdx */)
 
 		if pErr == errNo1PCTxn {
@@ -629,11 +632,20 @@ func (ds *DistSender) Send(
 			if len(parts) != 2 {
 				panic("split of final EndTransaction chunk resulted in != 2 parts")
 			}
+			// Restart transaction of the last chunk as two parts
+			// with EndTransaction in the second part.
 			continue
 		}
 		if pErr != nil {
+			if pErr.Index != nil && pErr.Index.Index != -1 {
+				pErr.Index.Index += int32(errIdxOffset)
+			}
+
 			return nil, pErr
 		}
+
+		errIdxOffset += len(ba.Requests)
+
 		// Propagate transaction from last reply to next request. The final
 		// update is taken and put into the response's main header.
 		ba.UpdateTxn(rpl.Txn)
@@ -1015,6 +1027,12 @@ func (ds *DistSender) sendPartialBatch(
 		// If sending succeeded, return immediately.
 		if pErr == nil {
 			return response{reply: reply, positions: positions}
+		}
+
+		// Re-map the error index within this partial batch back
+		// to its position in the encompassing batch.
+		if pErr.Index != nil && pErr.Index.Index != -1 && positions != nil {
+			pErr.Index.Index = int32(positions[pErr.Index.Index])
 		}
 
 		log.ErrEventf(ctx, "reply error %s: %s", ba, pErr)

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -341,3 +341,39 @@ DROP INDEX t1@c;
 
 statement ok
 DROP TABLE t1
+
+# Regression test for #20067.
+
+statement ok
+CREATE TABLE p20067 (
+  p_id INT PRIMARY KEY,
+  name STRING NOT NULL
+)
+
+statement ok
+CREATE TABLE c20067 (
+  p_id INT,
+  c_id INT,
+  name STRING NOT NULL,
+  PRIMARY KEY (p_id, c_id),
+  CONSTRAINT uq_name UNIQUE(name)
+) INTERLEAVE IN PARENT p20067 (p_id)
+
+statement ok
+BEGIN;
+INSERT INTO p20067 VALUES (1, 'John Doe');
+INSERT INTO c20067 VALUES (1, 1, 'John Doe Junior');
+COMMIT;
+
+statement error duplicate key value \(name\)=\('John Doe Junior'\) violates unique constraint "uq_name"
+INSERT INTO c20067 VALUES (2, 1, 'John Doe Junior')
+
+statement error duplicate key value \(name\)=\('John Doe Junior'\) violates unique constraint "uq_name"
+BEGIN; INSERT INTO p20067 VALUES (2, 'John Doe'); INSERT INTO c20067 VALUES (2, 1, 'John Doe Junior'); END;
+
+# End the last transaction.
+statement ok
+END
+
+statement error duplicate key value \(p_id,c_id\)=\(1,1\) violates unique constraint "primary"
+INSERT INTO c20067 VALUES (1, 1, 'John Doe')


### PR DESCRIPTION
Fixes #20780 and fixes #20067

When `distSender` sends off a batch for processing, it may create partial batches if the batch touches multiple ranges.

The error index generated within each partial batch was previously a relative offset within the partial batch. For example, if we had two partial batches each with one batch request and the second batch generated an error, it would have an error index of `0` which would be associated with the request in the first batch. This was the error seen in #20067 where a primary key violation error (first batch that inserts the primary index row) was being returned instead of a unique constraint violation error (second batch that does a `CPut` on the unique index).

This also caused some errors to have index 0 which would collide with the `BeginTxn` index in the overall batch. Since the index collided with `BeginTxn`, a certain codepath unset the the `Index` causing the raw Go error to be raised (as described in #20780).

Release note: (bug fix): fixed an issue where seemingly irrelevant error
messages were being returned for certain insert statements.

Huge thanks to @tschottdorf for helping out with the KV stuff.