### PR TITLE
cherry-pick 1.1: log: ensure panic details are logged to file even when stderr is not redirected

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -67,6 +67,28 @@ end_test
 interrupt
 eexpect ":/# "
 
+start_test "Check that panic reports are printed to the log even when --logtostderr is specified"
+send "$argv start -s=path=logs/db --insecure --logtostderr\r"
+eexpect "CockroachDB node starting"
+
+system "$argv sql --insecure -e \"select crdb_internal.force_panic('helloworld')\" || true"
+# Check the panic is reported on the server's stderr
+eexpect "panic: helloworld"
+eexpect "panic while executing"
+eexpect "goroutine"
+eexpect ":/# "
+# Check the panic is reported on the server log file
+send "cat logs/db/logs/cockroach.log\r"
+eexpect "a panic has occurred"
+eexpect "panic while executing"
+eexpect "helloworld"
+eexpect "goroutine"
+eexpect ":/# "
+
+end_test
+
+
+
 start_server $argv
 
 start_test "Test that quit does not emit unwanted logging output"

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -112,22 +112,27 @@ func Safe(v interface{}) SafeType {
 func ReportPanic(ctx context.Context, sv *settings.Values, r interface{}, depth int) {
 	Shout(ctx, Severity_ERROR, "a panic has occurred!")
 
+	if stderrRedirected {
+		// We do not use Shout() to print the panic details here, because
+		// if stderr is not redirected (e.g. when logging to file is
+		// disabled) Shout() would copy its argument to stderr
+		// unconditionally, and we don't want that: Go's runtime system
+		// already unconditonally copies the panic details to stderr.
+		// Instead, we copy manually the details to stderr, only when stderr
+		// is redirected to a file otherwise.
+		fmt.Fprintf(OrigStderr, "%v\n\n%s\n", r, debug.Stack())
+	} else {
+		// If stderr is not redirected, then Go's runtime will only print
+		// out the panic details to the original stderr, and we'll miss a copy
+		// in the log file. Produce it here.
+		logging.printPanicToFile(r)
+	}
+
 	SendCrashReport(ctx, sv, depth+1, "", []interface{}{r})
 
 	// Ensure that the logs are flushed before letting a panic
 	// terminate the server.
 	Flush()
-
-	// We do not use Shout() to print the panic details here, because
-	// if stderr is not redirected (e.g. when logging to file is
-	// disabled) Shout() would copy its argument to stderr
-	// unconditionally, and we don't want that: Go's runtime system
-	// already unconditonally copies the panic details to stderr.
-	// Instead, we copy manually the details to stderr, only when stderr
-	// is redirected to a file otherwise.
-	if stderrRedirected {
-		fmt.Fprintf(OrigStderr, "%v\n\n%s\n", r, debug.Stack())
-	}
 }
 
 var crashReportURL = func() string {


### PR DESCRIPTION
Cherry-pick of #20839.

Prior to this patch, panic details would not be captured to logs
unless the log file was forcing redirection of stderr. This was
notoriously not the case when passing `--logtostderr` or
`--logtostderr=INFO`.  (In contrast, `--logtostderr=WARNING` would
redirect stderr and cause the panic details to be properly captured.)

This patch fixes the issue by capturing the panic details every time
stderr is not redirected.

Release note (bug fix): the crash details are now properly copied to
the log file when starting a node with `--logtostderr` (and in some
other circumstances where they could be lost previously).

cc @cockroachdb/release 