### PR TITLE
ui: change "!" to "i" next to chart titles

### DIFF
--- a/pkg/ui/src/views/cluster/components/visualization/index.tsx
+++ b/pkg/ui/src/views/cluster/components/visualization/index.tsx
@@ -44,7 +44,7 @@ export default class extends React.Component<VisualizationProps, {}> {
         <div className="visualization__tooltip">
           <ToolTipWrapper text={tooltip}>
             <div className="visualization__tooltip-hover-area">
-              <div className="visualization__info-icon">!</div>
+              <div className="visualization__info-icon">i</div>
             </div>
           </ToolTipWrapper>
         </div>


### PR DESCRIPTION
(it's the hover zone for tooltips)

Was:
![screen shot 2017-12-18 at 5 24 48 pm](https://user-images.githubusercontent.com/7341/34131245-cde47290-e418-11e7-8bca-4661834e214d.png)

Now:
![screen shot 2017-12-18 at 5 26 27 pm](https://user-images.githubusercontent.com/7341/34131236-c8f5f394-e418-11e7-977a-a1cf0b710ddd.png)

Release note: ui: change "!" to "i" next to chart titles

Fixes #20843