### PR TITLE
sql: don't allow StatementSources to commit the txn 

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -294,7 +294,7 @@ func (sc *SchemaChanger) truncateIndexes(
 					return err
 				}
 				resume, err = td.deleteIndex(
-					ctx, &desc, resumeAt, chunkSize, false, /* traceKV */
+					ctx, &desc, resumeAt, chunkSize, noAutoCommit, false, /* traceKV */
 				)
 				done = resume.Key == nil
 				return err

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -415,7 +415,7 @@ func (p *planner) getDataSource(
 		return p.makeJoin(ctx, t.Join, left, right, t.Cond)
 
 	case *tree.StatementSource:
-		plan, err := p.newPlan(ctx, t.Statement, nil)
+		plan, err := p.newPlan(ctx, t.Statement, nil /* desiredTypes */)
 		if err != nil {
 			return planDataSource{}, err
 		}

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -31,6 +31,9 @@ type delayedNode struct {
 	plan        planNode
 }
 
+// delayedNode implements the autoCommitNode interface.
+var _ autoCommitNode = &delayedNode{}
+
 type nodeConstructor func(context.Context, *planner) (planNode, error)
 
 func (d *delayedNode) Next(params runParams) (bool, error) { return d.plan.Next(params) }
@@ -40,5 +43,12 @@ func (d *delayedNode) Close(ctx context.Context) {
 	if d.plan != nil {
 		d.plan.Close(ctx)
 		d.plan = nil
+	}
+}
+
+// enableAutoCommit is part of the autoCommitNode interface.
+func (d *delayedNode) enableAutoCommit() {
+	if ac, ok := d.plan.(autoCommitNode); ok {
+		ac.enableAutoCommit()
 	}
 }

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -34,6 +34,13 @@ func (p *planner) expandPlan(ctx context.Context, plan planNode) (planNode, erro
 		return plan, err
 	}
 	plan = p.simplifyOrderings(plan, nil)
+
+	if p.autoCommit {
+		if ac, ok := plan.(autoCommitNode); ok {
+			ac.enableAutoCommit()
+		}
+	}
+
 	return plan, nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -145,7 +145,7 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) V
 (0,0)  sql txn implicit  CPut /Table/52/2/2/0 -> /BYTES/‰
 (0,2)  consuming rows    output row: []
 (0,0)  sql txn implicit  querying next range at /Table/52/1/1/0
-(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
@@ -154,7 +154,7 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) V
 (0,0)  sql txn implicit  CPut /Table/52/2/2/0 -> /BYTES/‰
 (0,2)  consuming rows    output row: []
 (0,0)  sql txn implicit  querying next range at /Table/52/1/1/0
-(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
 (0,2)  consuming rows    execution failed: duplicate key value (k)=(1) violates unique constraint "primary"
 
 query TTT
@@ -164,7 +164,7 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) V
 (0,0)  sql txn implicit  CPut /Table/52/2/2/0 -> /BYTES/Š
 (0,2)  consuming rows    output row: []
 (0,0)  sql txn implicit  querying next range at /Table/52/1/2/0
-(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
 (0,2)  consuming rows    execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
 query TTT
@@ -177,7 +177,7 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) V
 (0,0)  sql txn implicit  CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/3
 (0,0)  sql txn implicit  CPut /Table/52/2/3/0 -> /BYTES/Š
 (0,0)  sql txn implicit  querying next range at /Table/52/1/2/0
-(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (1,2)]
@@ -189,7 +189,7 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) V
 (0,0)  sql txn implicit  fetched: /kv/primary/1/v -> /2
 (0,0)  sql txn implicit  Put /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
 (0,0)  sql txn implicit  querying next range at /Table/52/1/1/0
-(0,0)  sql txn implicit  r1: sending batch 1 Put, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,2)]
@@ -203,7 +203,7 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) V
 (0,0)  sql txn implicit  Del /Table/52/2/3/0
 (0,0)  sql txn implicit  CPut /Table/52/2/2/0 -> /BYTES/Š
 (0,0)  sql txn implicit  querying next range at /Table/52/1/2/0
-(0,0)  sql txn implicit  r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn to (n1,s1):1
 (0,2)  consuming rows    execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
 query TTT
@@ -256,7 +256,7 @@ SELECT span, operation, regexp_replace(message, '\d\d\d\d\d+', '...PK...') as me
 (0,0)  sql txn implicit  Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
 (0,2)  consuming rows    output row: [...PK... 2 5]
 (0,0)  sql txn implicit  querying next range at /Table/53/1/...PK.../0
-(0,0)  sql txn implicit  r1: sending batch 2 Put, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 2 Put, 1 BeginTxn to (n1,s1):1
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv2]
@@ -266,8 +266,8 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv2]
 (0,1)  starting plan   r1: sending batch 1 Scan to (n1,s1):1
 (0,1)  starting plan   DelRange /Table/53/1 - /Table/53/2
 (0,1)  starting plan   querying next range at /Table/53/1
-(0,1)  starting plan   r1: sending batch 1 DelRng, 1 BeginTxn, 1 EndTxn to (n1,s1):1
-(0,4)  consuming rows  fast path - rows affected: 2
+(0,1)  starting plan   r1: sending batch 1 DelRng, 1 BeginTxn to (n1,s1):1
+(0,5)  consuming rows  fast path - rows affected: 2
 
 query TTT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 'wall_time:...'), 'gc_deadline:\d+', 'gc_deadline:...') as message
@@ -313,7 +313,7 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv]
 (0,0)  sql txn implicit  DelRange /Table/52/1/2 - /Table/52/1/2/#
 (0,2)  consuming rows    output row: [2 3]
 (0,0)  sql txn implicit  querying next range at /Table/52/1/1
-(0,0)  sql txn implicit  r1: sending batch 2 Del, 2 DelRng, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 2 Del, 2 DelRng, 1 BeginTxn to (n1,s1):1
 
 query TTT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
@@ -734,3 +734,24 @@ fetched: /abc/primary/1/'one' -> NULL
 fetched: /abc/primary/1/'one'/c -> 1.1
 fetched: /abc/primary/2/'two' -> NULL
 fetched: /abc/primary/3/'three' -> NULL
+
+# Check that session tracing does not inhibit the fast path for inserts &
+# friends (the path resulting in 1PC transactions). This is in contrast with
+# SHOW TRACE FOR <stmt>, which does prevent the inner statement from ever
+# committing the txn.
+
+subtest autocommit
+
+statement ok
+CREATE TABLE t.kv3(k INT PRIMARY KEY, v INT)
+
+statement ok
+SET tracing = on; INSERT INTO t.kv3 (k, v) VALUES (1,1); SET tracing = off;
+
+# We look for rows containing a BeginTxn and an EndTxn, as proof that the
+# insertNode is committing the txn.
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE e'%1 CPut, 1 BeginTxn, 1 EndTxn%'
+----
+r1: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn to (n1,s1):1
+1 CPut, 1 BeginTxn, 1 EndTxn

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -114,6 +114,10 @@ func (r *runParams) SessionData() *sessiondata.SessionData {
 // - planOrdering()                (plan_ordering.go)
 // - planColumns()                 (plan_columns.go)
 //
+// Also, there are optional interfaces that new nodes may want to implement:
+// - execStartable
+// - autoCommitNode
+//
 type planNode interface {
 	// Next performs one unit of work, returning false if an error is
 	// encountered or if there is no more work to do. For statements
@@ -291,6 +295,22 @@ func startPlan(params runParams, plan planNode) error {
 // execution step.
 type execStartable interface {
 	startExec(params runParams) error
+}
+
+// autoCommitNode is implemented by planNodes that might be able to commit the
+// KV txn in which they operate. Some nodes might want to do this to take
+// advantage of the 1PC optimization in case they're running as an implicit
+// transaction.
+// Only the top-level node in a plan is allowed to auto-commit. A node that
+// choses to do so has to be cognizant of all its children: it needs to only
+// auto-commit after all the children have finished performing KV operations
+// and, more generally, after the plan is guaranteed to not produce any
+// execution errors (in case of an error anywhere in the query, we do not want
+// to commit the txn).
+type autoCommitNode interface {
+	// enableAutoCommit is called on the root planNode (if it implements this
+	// interface).
+	enableAutoCommit()
 }
 
 // startExec calls startExec() on each planNode that supports

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -140,6 +140,9 @@ type planner struct {
 	// If autoCommit is true, the plan is allowed (but not required) to commit the
 	// transaction along with other KV operations. Committing the txn might be
 	// beneficial because it may enable the 1PC optimization.
+	//
+	// NOTE: This member is for internal use of the planner only. PlanNodes that
+	// want to do 1PC transactions have to implement the autoCommitNode interface.
 	autoCommit bool
 
 	// phaseTimes helps measure the time spent in each phase of SQL execution.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -136,11 +136,10 @@ type planner struct {
 	// initializing plans to read from a table. This should be used with care.
 	skipSelectPrivilegeChecks bool
 
-	// autoCommit indicates whether we're planning for a spontaneous transaction.
-	// If autoCommit is true, the plan is allowed (but not required) to
-	// commit the transaction along with other KV operations.
-	// Note: The autoCommit parameter enables operations to enable the
-	// 1PC optimization. This is a bit hackish/preliminary at present.
+	// autoCommit indicates whether we're planning for an implicit transaction.
+	// If autoCommit is true, the plan is allowed (but not required) to commit the
+	// transaction along with other KV operations. Committing the txn might be
+	// beneficial because it may enable the 1PC optimization.
 	autoCommit bool
 
 	// phaseTimes helps measure the time spent in each phase of SQL execution.

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -361,7 +361,7 @@ func (v *subqueryVisitor) replaceSubquery(
 	// Calling newPlan() might recursively invoke replaceSubqueries, so we need
 	// to preserve the state of the visitor across the call to newPlan().
 	visitorCopy := v.planner.subqueryVisitor
-	plan, err := v.planner.newPlan(v.ctx, sub.Select, nil)
+	plan, err := v.planner.newPlan(v.ctx, sub.Select, nil /* desiredTypes */)
 	v.planner.subqueryVisitor = visitorCopy
 	if err != nil {
 		return nil, err

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -390,9 +390,7 @@ func (tu *tableUpserter) row(
 }
 
 // flush commits to tu.txn any rows batched up in tu.insertRows.
-func (tu *tableUpserter) flush(
-	ctx context.Context, finalize, traceKV bool,
-) (*sqlbase.RowContainer, error) {
+func (tu *tableUpserter) flush(ctx context.Context, traceKV bool) (*sqlbase.RowContainer, error) {
 	tableDesc := tu.tableDesc()
 	existingRows, err := tu.fetchExisting(ctx, traceKV)
 	if err != nil {
@@ -480,7 +478,7 @@ func (tu *tableUpserter) flush(
 		}
 	}
 
-	if finalize && tu.autoCommit {
+	if tu.autoCommit {
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction
 		// coordinator.
@@ -642,7 +640,7 @@ func (tu *tableUpserter) finalize(
 		}
 		return nil, nil
 	}
-	return tu.flush(ctx, true /* finalize */, traceKV)
+	return tu.flush(ctx, traceKV)
 }
 
 func (tu *tableUpserter) tableDesc() *sqlbase.TableDescriptor {

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -74,7 +74,12 @@ type tableWriter interface {
 	// The traceKV parameter determines whether the individual K/V operations
 	// should be logged to the context. See the comment above for why
 	// this a separate parameter as opposed to a Value field on the context.
-	finalize(context.Context, bool /* traceKV */) (*sqlbase.RowContainer, error)
+	//
+	// autoCommit specifies whether the tableWriter is free to commit the txn in
+	// which it was operating once all writes are performed.
+	finalize(
+		ctx context.Context, autoCommit autoCommitOpt, traceKV bool,
+	) (*sqlbase.RowContainer, error)
 
 	// tableDesc returns the TableDescriptor for the table that the tableWriter
 	// will modify.
@@ -87,6 +92,13 @@ type tableWriter interface {
 	close(context.Context)
 }
 
+type autoCommitOpt int
+
+const (
+	noAutoCommit autoCommitOpt = iota
+	autoCommitEnabled
+)
+
 var _ tableWriter = (*tableInserter)(nil)
 var _ tableWriter = (*tableUpdater)(nil)
 var _ tableWriter = (*tableUpserter)(nil)
@@ -94,8 +106,7 @@ var _ tableWriter = (*tableDeleter)(nil)
 
 // tableInserter handles writing kvs and forming table rows for inserts.
 type tableInserter struct {
-	ri         sqlbase.RowInserter
-	autoCommit bool
+	ri sqlbase.RowInserter
 
 	// Set by init.
 	txn *client.Txn
@@ -116,9 +127,11 @@ func (ti *tableInserter) row(
 	return nil, ti.ri.InsertRow(ctx, ti.b, values, false, traceKV)
 }
 
-func (ti *tableInserter) finalize(ctx context.Context, _ bool) (*sqlbase.RowContainer, error) {
+func (ti *tableInserter) finalize(
+	ctx context.Context, autoCommit autoCommitOpt, _ bool,
+) (*sqlbase.RowContainer, error) {
 	var err error
-	if ti.autoCommit {
+	if autoCommit == autoCommitEnabled {
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction
 		// coordinator.
@@ -143,9 +156,8 @@ func (ti *tableInserter) fkSpanCollector() sqlbase.FkSpanCollector {
 
 // tableUpdater handles writing kvs and forming table rows for updates.
 type tableUpdater struct {
-	ru         sqlbase.RowUpdater
-	autoCommit bool
-	mon        *mon.BytesMonitor
+	ru  sqlbase.RowUpdater
+	mon *mon.BytesMonitor
 
 	// Set by init.
 	txn *client.Txn
@@ -171,9 +183,11 @@ func (tu *tableUpdater) row(
 	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, tu.mon, traceKV)
 }
 
-func (tu *tableUpdater) finalize(ctx context.Context, _ bool) (*sqlbase.RowContainer, error) {
+func (tu *tableUpdater) finalize(
+	ctx context.Context, autoCommit autoCommitOpt, _ bool,
+) (*sqlbase.RowContainer, error) {
 	var err error
-	if tu.autoCommit {
+	if autoCommit == autoCommitEnabled {
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction
 		// coordinator.
@@ -234,7 +248,6 @@ type tableUpsertEvaler interface {
 // as the other `tableFoo`s, which are more simple than upsert.
 type tableUpserter struct {
 	ri            sqlbase.RowInserter
-	autoCommit    bool
 	conflictIndex sqlbase.IndexDescriptor
 	isUpsertAlias bool
 	alloc         *sqlbase.DatumAlloc
@@ -390,7 +403,9 @@ func (tu *tableUpserter) row(
 }
 
 // flush commits to tu.txn any rows batched up in tu.insertRows.
-func (tu *tableUpserter) flush(ctx context.Context, traceKV bool) (*sqlbase.RowContainer, error) {
+func (tu *tableUpserter) flush(
+	ctx context.Context, autoCommit autoCommitOpt, traceKV bool,
+) (*sqlbase.RowContainer, error) {
 	tableDesc := tu.tableDesc()
 	existingRows, err := tu.fetchExisting(ctx, traceKV)
 	if err != nil {
@@ -478,7 +493,7 @@ func (tu *tableUpserter) flush(ctx context.Context, traceKV bool) (*sqlbase.RowC
 		}
 	}
 
-	if tu.autoCommit {
+	if autoCommit == autoCommitEnabled {
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction
 		// coordinator.
@@ -614,11 +629,12 @@ func (tu *tableUpserter) fetchExisting(ctx context.Context, traceKV bool) ([]tre
 	return rows, nil
 }
 
+// finalize is part of the tableWriter interface.
 func (tu *tableUpserter) finalize(
-	ctx context.Context, traceKV bool,
+	ctx context.Context, autoCommit autoCommitOpt, traceKV bool,
 ) (*sqlbase.RowContainer, error) {
 	if tu.fastPathBatch != nil {
-		if tu.autoCommit {
+		if autoCommit == autoCommitEnabled {
 			// An auto-txn can commit the transaction with the batch. This is an
 			// optimization to avoid an extra round-trip to the transaction
 			// coordinator.
@@ -640,7 +656,7 @@ func (tu *tableUpserter) finalize(
 		}
 		return nil, nil
 	}
-	return tu.flush(ctx, traceKV)
+	return tu.flush(ctx, autoCommit, traceKV)
 }
 
 func (tu *tableUpserter) tableDesc() *sqlbase.TableDescriptor {
@@ -660,10 +676,9 @@ func (tu *tableUpserter) close(ctx context.Context) {
 
 // tableDeleter handles writing kvs and forming table rows for deletes.
 type tableDeleter struct {
-	rd         sqlbase.RowDeleter
-	autoCommit bool
-	alloc      *sqlbase.DatumAlloc
-	mon        *mon.BytesMonitor
+	rd    sqlbase.RowDeleter
+	alloc *sqlbase.DatumAlloc
+	mon   *mon.BytesMonitor
 
 	// Set by init.
 	txn *client.Txn
@@ -686,8 +701,10 @@ func (td *tableDeleter) row(
 }
 
 // finalize is part of the tableWriter interface.
-func (td *tableDeleter) finalize(ctx context.Context, _ bool) (*sqlbase.RowContainer, error) {
-	if td.autoCommit {
+func (td *tableDeleter) finalize(
+	ctx context.Context, autoCommit autoCommitOpt, _ bool,
+) (*sqlbase.RowContainer, error) {
+	if autoCommit == autoCommitEnabled {
 		// An auto-txn can commit the transaction with the batch. This is an
 		// optimization to avoid an extra round-trip to the transaction
 		// coordinator.
@@ -723,7 +740,7 @@ func (td *tableDeleter) fastPathAvailable(ctx context.Context) bool {
 // without knowing the values that are currently present. fastDelete calls
 // finalize, so it should not be called after.
 func (td *tableDeleter) fastDelete(
-	ctx context.Context, scan *scanNode, traceKV bool,
+	ctx context.Context, scan *scanNode, autoCommit autoCommitOpt, traceKV bool,
 ) (rowCount int, err error) {
 
 	for _, span := range scan.spans {
@@ -731,10 +748,10 @@ func (td *tableDeleter) fastDelete(
 		if traceKV {
 			log.VEventf(ctx, 2, "DelRange %s - %s", span.Key, span.EndKey)
 		}
-		td.b.DelRange(span.Key, span.EndKey, true)
+		td.b.DelRange(span.Key, span.EndKey, true /* returnKeys */)
 	}
 
-	_, err = td.finalize(ctx, traceKV)
+	_, err = td.finalize(ctx, autoCommit, traceKV)
 	if err != nil {
 		return 0, err
 	}
@@ -776,13 +793,13 @@ func (td *tableDeleter) fastDelete(
 // limit is a limit on either the number of keys or table-rows (for
 // interleaved tables) deleted in the operation.
 func (td *tableDeleter) deleteAllRows(
-	ctx context.Context, resume roachpb.Span, limit int64, traceKV bool,
+	ctx context.Context, resume roachpb.Span, limit int64, autoCommit autoCommitOpt, traceKV bool,
 ) (roachpb.Span, error) {
 	if td.rd.Helper.TableDesc.IsInterleaved() {
 		log.VEvent(ctx, 2, "delete forced to scan: table is interleaved")
-		return td.deleteAllRowsScan(ctx, resume, limit, traceKV)
+		return td.deleteAllRowsScan(ctx, resume, limit, autoCommit, traceKV)
 	}
-	return td.deleteAllRowsFast(ctx, resume, limit, traceKV)
+	return td.deleteAllRowsFast(ctx, resume, limit, autoCommit, traceKV)
 }
 
 // deleteAllRowsFast employs a ClearRange KV API call to delete the
@@ -791,7 +808,7 @@ func (td *tableDeleter) deleteAllRows(
 // efficient ranged tombstone, preventing unnecessary write
 // amplification.
 func (td *tableDeleter) deleteAllRowsFast(
-	ctx context.Context, resume roachpb.Span, limit int64, traceKV bool,
+	ctx context.Context, resume roachpb.Span, limit int64, autoCommit autoCommitOpt, traceKV bool,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
 		tablePrefix := roachpb.Key(
@@ -806,7 +823,7 @@ func (td *tableDeleter) deleteAllRowsFast(
 	// If GCDeadline isn't set, assume this drop request is from a version
 	// 1.1 server and invoke legacy code that uses DeleteRange and range GC.
 	if td.tableDesc().GCDeadline == 0 {
-		return td.legacyDeleteAllRowsFast(ctx, resume, limit, traceKV)
+		return td.legacyDeleteAllRowsFast(ctx, resume, limit, autoCommit, traceKV)
 	}
 
 	// Assert that GC deadline is in the past.
@@ -826,7 +843,7 @@ func (td *tableDeleter) deleteAllRowsFast(
 	if err := td.txn.DB().Run(ctx, b); err != nil {
 		return resume, err
 	}
-	if _, err := td.finalize(ctx, traceKV); err != nil {
+	if _, err := td.finalize(ctx, autoCommit, traceKV); err != nil {
 		return resume, err
 	}
 	return roachpb.Span{}, nil
@@ -836,12 +853,12 @@ func (td *tableDeleter) deleteAllRowsFast(
 // and so deletion must fall back to relying on DeleteRange and the
 // eventual range GC cycle.
 func (td *tableDeleter) legacyDeleteAllRowsFast(
-	ctx context.Context, resume roachpb.Span, limit int64, traceKV bool,
+	ctx context.Context, resume roachpb.Span, limit int64, autoCommit autoCommitOpt, traceKV bool,
 ) (roachpb.Span, error) {
 	log.VEventf(ctx, 2, "DelRange %s - %s", resume.Key, resume.EndKey)
 	td.b.DelRange(resume.Key, resume.EndKey, false /* returnKeys */)
 	td.b.Header.MaxSpanRequestKeys = limit
-	if _, err := td.finalize(ctx, traceKV); err != nil {
+	if _, err := td.finalize(ctx, autoCommit, traceKV); err != nil {
 		return resume, err
 	}
 	if l := len(td.b.Results); l != 1 {
@@ -851,7 +868,7 @@ func (td *tableDeleter) legacyDeleteAllRowsFast(
 }
 
 func (td *tableDeleter) deleteAllRowsScan(
-	ctx context.Context, resume roachpb.Span, limit int64, traceKV bool,
+	ctx context.Context, resume roachpb.Span, limit int64, autoCommit autoCommitOpt, traceKV bool,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
 		resume = td.rd.Helper.TableDesc.PrimaryIndexSpan()
@@ -898,7 +915,7 @@ func (td *tableDeleter) deleteAllRowsScan(
 		// Update the resume start key for the next iteration.
 		resume.Key = rf.Key()
 	}
-	_, err := td.finalize(ctx, traceKV)
+	_, err := td.finalize(ctx, autoCommit, traceKV)
 	return resume, err
 }
 
@@ -912,19 +929,29 @@ func (td *tableDeleter) deleteAllRowsScan(
 //
 // limit is a limit on the number of index entries deleted in the operation.
 func (td *tableDeleter) deleteIndex(
-	ctx context.Context, idx *sqlbase.IndexDescriptor, resume roachpb.Span, limit int64, traceKV bool,
+	ctx context.Context,
+	idx *sqlbase.IndexDescriptor,
+	resume roachpb.Span,
+	limit int64,
+	autoCommit autoCommitOpt,
+	traceKV bool,
 ) (roachpb.Span, error) {
 	if len(idx.Interleave.Ancestors) > 0 || len(idx.InterleavedBy) > 0 {
 		if log.V(2) {
 			log.Info(ctx, "delete forced to scan: table is interleaved")
 		}
-		return td.deleteIndexScan(ctx, idx, resume, limit, traceKV)
+		return td.deleteIndexScan(ctx, idx, resume, limit, autoCommit, traceKV)
 	}
-	return td.deleteIndexFast(ctx, idx, resume, limit, traceKV)
+	return td.deleteIndexFast(ctx, idx, resume, limit, autoCommit, traceKV)
 }
 
 func (td *tableDeleter) deleteIndexFast(
-	ctx context.Context, idx *sqlbase.IndexDescriptor, resume roachpb.Span, limit int64, traceKV bool,
+	ctx context.Context,
+	idx *sqlbase.IndexDescriptor,
+	resume roachpb.Span,
+	limit int64,
+	autoCommit autoCommitOpt,
+	traceKV bool,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
 		resume = td.rd.Helper.TableDesc.IndexSpan(idx.ID)
@@ -937,7 +964,7 @@ func (td *tableDeleter) deleteIndexFast(
 	// deadline / ClearRange fast path that table deletion uses.
 	td.b.DelRange(resume.Key, resume.EndKey, false /* returnKeys */)
 	td.b.Header.MaxSpanRequestKeys = limit
-	if _, err := td.finalize(ctx, traceKV); err != nil {
+	if _, err := td.finalize(ctx, autoCommit, traceKV); err != nil {
 		return resume, err
 	}
 	if l := len(td.b.Results); l != 1 {
@@ -947,7 +974,12 @@ func (td *tableDeleter) deleteIndexFast(
 }
 
 func (td *tableDeleter) deleteIndexScan(
-	ctx context.Context, idx *sqlbase.IndexDescriptor, resume roachpb.Span, limit int64, traceKV bool,
+	ctx context.Context,
+	idx *sqlbase.IndexDescriptor,
+	resume roachpb.Span,
+	limit int64,
+	autoCommit autoCommitOpt,
+	traceKV bool,
 ) (roachpb.Span, error) {
 	if resume.Key == nil {
 		resume = td.rd.Helper.TableDesc.PrimaryIndexSpan()
@@ -993,7 +1025,7 @@ func (td *tableDeleter) deleteIndexScan(
 		// Update the resume start key for the next iteration.
 		resume.Key = rf.Key()
 	}
-	_, err := td.finalize(ctx, traceKV)
+	_, err := td.finalize(ctx, autoCommit, traceKV)
 	return resume, err
 }
 

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -356,7 +356,7 @@ func truncateTableInChunks(
 			if err := td.init(txn, nil /* *mon.BytesMonitor */); err != nil {
 				return err
 			}
-			resume, err = td.deleteAllRows(ctx, resumeAt, chunkSize, traceKV)
+			resume, err = td.deleteAllRows(ctx, resumeAt, chunkSize, noAutoCommit, traceKV)
 			return err
 		}); err != nil {
 			return err


### PR DESCRIPTION
Fixes #18806

Before this patch, each planNode would independently decide whether it's
allowed to auto-commit or not regardless of parts of the query that were
not under the node in question. This was no bueno - the transaction
could be committed before others might want to use or while a query
could still generate errors (in which case one would expect the txn to
be rolled back, not committed).
Concretely, something like SELECT * FROM [INSERT ... RETURNING ...] was
quite broken.

This patch makes it so that only the top-level node is allowed to
auto-commit.
I have gone a different path for a while, thinking that the node that
can auto-commit could be any node that is an ancestor of all other nodes
that perform KV addresses, but that's not true because of the error
handling semantics: the txn can only be committed once nothing returns
an error any more. Hence the somewhat brutal fix in this patch.

As a consequence, in SHOW TRACE FOR <stmt>, <stmt> can no longer do
auto-commit. I tried to do something special for SHOW TRACE FOR
(although supporting it was dubious because, if the STF was inside of
another SELECT, we again generally do not want the auto-commit), but
it's complicated because STF changes the plan and inserts several nodes
at the top of the tree (a sort, etc), and it's not very clear how to
handle them.
Queries traced under SHOW TRACE FOR SESSION still do 1PC normally.

The changes to the logic tests are caused by 1PC not being used for SHOW
TRACE FOR <stmt> statements any more - which caused one log line to
change.

Release note (bug fix): INSERT/UPDATE/DELETE ... RETURNING  ...
statments used with the "statement data source" syntax (e.g. SELECT *
FROM  [INSERT INTO ... RETURNING ...]) no longer ever commit the
transaction, causing errors for the higher-level query.