### PR TITLE
[wip] ui: enlarge clickable area area on dropdowns

### DIFF
--- a/pkg/ui/src/views/shared/components/dropdown/dropdown.styl
+++ b/pkg/ui/src/views/shared/components/dropdown/dropdown.styl
@@ -3,29 +3,30 @@
 
 $dropdown-hover-color = darken($background-color, 2.5%)
 
+.dropdown__selectedOption
+  color $link-color
+
 .dropdown
-  text-transform uppercase
-  letter-spacing 2px
-  line-height 17px
-  padding 12px 24px
-  vertical-align middle
   border 1px solid $button-border-color
   border-radius 4px
   display inline-flex
-  white-space nowrap
-  padding-right 10px
-  color $body-color
 
-  &:hover
-    background-color $dropdown-hover-color
+  .dropdown__inner
+    text-transform uppercase
+    letter-spacing 2px
+    line-height 17px
+    padding 12px 24px
+    vertical-align middle
+    white-space nowrap
+    padding-right 10px
+    color $body-color
 
   &__title
-    vertical-align middle
-    display inline-block
+    padding-right 10px
+    display inline
 
   &__select
     display inline-block
-    vertical-align middle
 
     &:hover
       background-color $dropdown-hover-color

--- a/pkg/ui/src/views/shared/components/dropdown/index.tsx
+++ b/pkg/ui/src/views/shared/components/dropdown/index.tsx
@@ -49,20 +49,36 @@ export default class Dropdown extends React.Component<DropdownOwnProps, {}> {
       { "dropdown__side-arrow--disabled": _.includes(disabledArrows, ArrowDirection.RIGHT) },
     );
 
-    return <div className={className}>
-      {/* TODO (maxlang): consider moving arrows outside the dropdown component */}
-      <span
-        className={leftClassName}
-        dangerouslySetInnerHTML={trustIcon(leftArrow)}
-        onClick={() => this.props.onArrowClick(ArrowDirection.LEFT)}>
-      </span>
-      <span className="dropdown__title">{this.props.title}{this.props.title ? ":" : ""}</span>
-      <Select className="dropdown__select" clearable={false} searchable={false} options={options} value={selected} onChange={onChange} />
-      <span
-        className={rightClassName}
-        dangerouslySetInnerHTML={trustIcon(rightArrow)}
-        onClick={() => this.props.onArrowClick(ArrowDirection.RIGHT)}>
-      </span>
-    </div>;
+    return (
+      <div className={className}>
+        {/* TODO (maxlang): consider moving arrows outside the dropdown component */}
+        <span
+          className={leftClassName}
+          dangerouslySetInnerHTML={trustIcon(leftArrow)}
+          onClick={() => this.props.onArrowClick(ArrowDirection.LEFT)}>
+        </span>
+        <Select
+          className="dropdown__select"
+          clearable={false}
+          searchable={false}
+          options={options}
+          value={selected}
+          onChange={onChange}
+          valueRenderer={(selectedOption) => (
+            <div className="dropdown__inner">
+              <span className="dropdown__title">
+                {this.props.title}{this.props.title ? ":" : ""}
+              </span>
+              <span className="dropdown__selectedOption">{selectedOption.label}</span>
+            </div>
+          )}
+        />
+        <span
+          className={rightClassName}
+          dangerouslySetInnerHTML={trustIcon(rightArrow)}
+          onClick={() => this.props.onArrowClick(ArrowDirection.RIGHT)}>
+        </span>
+      </div>
+    );
   }
 }

--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -5,6 +5,7 @@
 .has-value.Select--single > .Select-control .Select-value .Select-value-label,
 .has-value.is-pseudo-focused.Select--single > .Select-control .Select-value .Select-value-label
   color $link-color !important
+  overflow visible !important
 
 .Select-option
   padding 10px 25px !important
@@ -25,6 +26,7 @@
   box-shadow 0 0 0 black !important
   border-radius 0 3px 3px 0 !important
   background-color transparent !important
+  cursor pointer !important
 
 .Select-input
   line-height inherit !important
@@ -37,7 +39,8 @@
 
 .Select-menu-outer
   width auto !important
-  top calc(100% + 21px) !important
+  top calc(100% + 3px) !important
+  left calc(100% - 130px) !important
   border none !important
   box-shadow 0 2px 4px rgba(0, 0, 0, .2) !important
   max-height 200px !important
@@ -62,8 +65,6 @@
   width 100%
 
 .dropdown--side-arrows
-  .Select
-    padding 12px 24px !important
   .Select-arrow-zone
     display none
 


### PR DESCRIPTION
Previously, the darken-on-hover area was not the same as the clickable area. Now the whole area is clickable.

Fixes #20818 

TODO before merging: fix visual regressions:
- [ ] fix overlap on time selector
- [ ] fix text overflow being hidden:

<img width="673" alt="screen shot 2017-12-18 at 7 12 42 pm" src="https://user-images.githubusercontent.com/7341/34134354-24c6bc94-e428-11e7-9ae5-336bdc395272.png">

Release note: ui: enlarge clickable area on dropdowns