### PR TITLE
cli, storage: fix temporary directory from being wiped on subsequent failed startup

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -2605,3 +2605,11 @@ const rocksdb::Comparator* CockroachComparator() { return &kComparator; }
 rocksdb::WriteBatch::Handler* GetDBBatchInserter(::rocksdb::WriteBatchBase* batch) {
   return new DBBatchInserter(batch);
 }
+
+DBStatus DBLockFile(DBSlice filename, DBFileLock* lock) {
+  return ToDBStatus(rocksdb::Env::Default()->LockFile(ToString(filename), (rocksdb::FileLock**)lock));
+}
+
+DBStatus DBUnlockFile(DBFileLock lock) {
+  return ToDBStatus(rocksdb::Env::Default()->UnlockFile((rocksdb::FileLock*)lock));
+}

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -303,6 +303,15 @@ void DBRunLDB(int argc, char** argv);
 // DBEnvWriteFile writes the given data as a new "file" in the given engine.
 DBStatus DBEnvWriteFile(DBEngine* db, DBSlice path, DBSlice contents);
 
+// DBFileLock contains various parameters set during DBLockFile and required for DBUnlockFile.
+typedef void* DBFileLock;
+
+// DBLockFile sets a lock on the specified file using RocksDB's file locking interface.
+DBStatus DBLockFile(DBSlice filename, DBFileLock* lock);
+
+// DBUnlockFile unlocks the file asscoiated with the specified lock and GCs any allocated memory for the lock.
+DBStatus DBUnlockFile(DBFileLock lock);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/pkg/cli/interactive_tests/test_temp_dir.tcl
+++ b/pkg/cli/interactive_tests/test_temp_dir.tcl
@@ -114,3 +114,19 @@ glob_not_exists "$storedir/$tempprefix*"
 # Verify the store file still exists.
 file_exists $storedir
 end_test
+
+start_test "Check that temp directory does not get wiped upon subsequent failed cockroach start attempt and that a cockroach instance can be subsequently started up after a shutdown"
+send "$argv start --insecure --store=$storedir --background\r"
+eexpect "node starting"
+# Try to start up a second cockroach instance with the same store path.
+send "$argv start --insecure --store=$storedir\r"
+eexpect "ERROR: could not cleanup temporary directories from record file: could not lock temporary directory $cwd/$storedir/$tempprefix*"
+# Verify the temp directory still exists.
+glob_exists "$storedir/$tempprefix*"
+send "pkill -9 cockroach\r"
+# We should be able to start the cockroach instance again.
+send "$argv start --insecure --store=$storedir\r"
+eexpect "node starting"
+interrupt
+eexpect "shutdown completed"
+end_test

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -45,7 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
-	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -278,7 +278,7 @@ func initExternalIODir(ctx context.Context, firstStore base.StoreSpec) (string, 
 }
 
 func initTempStorageConfig(
-	ctx context.Context, firstStore base.StoreSpec,
+	ctx context.Context, stopper *stop.Stopper, firstStore base.StoreSpec,
 ) (base.TempStorageConfig, error) {
 	var recordPath string
 	if !firstStore.InMemory {
@@ -290,7 +290,7 @@ func initTempStorageConfig(
 	// the temporary directory record file before creating any new
 	// temporary directories in case the disk is completely full.
 	if recordPath != "" {
-		if err = util.CleanupTempDirs(recordPath); err != nil {
+		if err = engine.CleanupTempDirs(recordPath); err != nil {
 			return base.TempStorageConfig{}, errors.Wrap(err, "could not cleanup temporary directories from record file")
 		}
 	}
@@ -345,14 +345,14 @@ func initTempStorageConfig(
 		tempDir = firstStore.Path
 	}
 	// Create the temporary subdirectory for the temp engine.
-	if tempStorageConfig.Path, err = util.CreateTempDir(tempDir, server.TempDirPrefix); err != nil {
+	if tempStorageConfig.Path, err = engine.CreateTempDir(tempDir, server.TempDirPrefix, stopper); err != nil {
 		return base.TempStorageConfig{}, errors.Wrap(err, "could not create temporary directory for temp storage")
 	}
 
 	// We record the new temporary directory in the record file (if it
 	// exists) for cleanup in case the node crashes.
 	if recordPath != "" {
-		if err = util.RecordTempDir(recordPath, tempStorageConfig.Path); err != nil {
+		if err = engine.RecordTempDir(recordPath, tempStorageConfig.Path); err != nil {
 			return base.TempStorageConfig{}, errors.Wrapf(
 				err,
 				"could not record temporary directory path to record file: %s",
@@ -390,9 +390,6 @@ func runStart(cmd *cobra.Command, args []string) error {
 	ctx := opentracing.ContextWithSpan(context.Background(), sp)
 
 	var err error
-	if serverCfg.TempStorageConfig, err = initTempStorageConfig(ctx, serverCfg.Stores.Specs[0]); err != nil {
-		return err
-	}
 	if serverCfg.Settings.ExternalIODir, err = initExternalIODir(ctx, serverCfg.Stores.Specs[0]); err != nil {
 		return err
 	}
@@ -410,6 +407,10 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// will be created in $TMPDIR instead of their expected location.
 	stopper, err := setupAndInitializeLoggingAndProfiling(ctx)
 	if err != nil {
+		return err
+	}
+
+	if serverCfg.TempStorageConfig, err = initTempStorageConfig(ctx, stopper, serverCfg.Stores.Specs[0]); err != nil {
 		return err
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -335,7 +335,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			// also remove the record after the temp directory is
 			// removed.
 			recordPath := filepath.Join(firstStore.Path, TempDirsRecordFilename)
-			err = util.CleanupTempDirs(recordPath)
+			err = engine.CleanupTempDirs(recordPath)
 		}
 		if err != nil {
 			log.Errorf(context.TODO(), "could not remove temporary store directory: %v", err.Error())

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2343,3 +2343,14 @@ func (r *RocksDB) WriteFile(filename string, data []byte) error {
 func IsValidSplitKey(key roachpb.Key, allowMeta2Splits bool) bool {
 	return bool(C.MVCCIsValidSplitKey(goToCSlice(key), C._Bool(allowMeta2Splits)))
 }
+
+// lockFile sets a lock on the specified file using RocksDB's file locking interface.
+func lockFile(filename string) (C.DBFileLock, error) {
+	var lock C.DBFileLock
+	return lock, statusToError(C.DBLockFile(goToCSlice([]byte(filename)), &lock))
+}
+
+// unlockFile unlocks the file asscoiated with the specified lock and GCs any allocated memory for the lock.
+func unlockFile(lock C.DBFileLock) error {
+	return statusToError(C.DBUnlockFile(lock))
+}

--- a/pkg/storage/engine/temp_dir.go
+++ b/pkg/storage/engine/temp_dir.go
@@ -12,27 +12,55 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package util
+package engine
 
 import (
+	"C"
 	"bufio"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+const lockFilename = `TEMP_DIR.LOCK`
 
 // CreateTempDir creates a temporary directory with a prefix under the given
 // parentDir and returns the absolute path of the temporary directory.
 // It is advised to invoke CleanupTempDirs before creating new temporary
 // directories in cases where the disk is completely full.
-func CreateTempDir(parentDir, prefix string) (string, error) {
+func CreateTempDir(parentDir, prefix string, stopper *stop.Stopper) (string, error) {
 	// We generate a unique temporary directory with the specified prefix.
 	tempPath, err := ioutil.TempDir(parentDir, prefix)
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Abs(tempPath)
+	absPath, err := filepath.Abs(tempPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Create a lock file.
+	flock, err := lockFile(filepath.Join(absPath, lockFilename))
+	if err != nil {
+		return "", errors.Wrapf(err, "could not create lock on new temporary directory")
+	}
+	stopper.AddCloser(stop.CloserFn(func() {
+		if err := unlockFile(flock); err != nil {
+			log.Errorf(context.TODO(), "could not unlock file lock on temporary directory: %s", err.Error())
+		}
+	}))
+
+	return absPath, nil
 }
 
 // RecordTempDir records tempPath to the record file specified by recordPath to
@@ -78,6 +106,19 @@ func CleanupTempDirs(recordPath string) error {
 		if path == "" {
 			continue
 		}
+
+		// Check if another Cockroach instance is using this temporary
+		// directory i.e. has a lock on the temp dir lock file.
+		flock, err := lockFile(filepath.Join(path, lockFilename))
+		if err != nil {
+			return errors.Wrapf(err, "could not lock temporary directory %s, may still be in use", path)
+		}
+		defer func() {
+			if err := unlockFile(flock); err != nil {
+				log.Errorf(context.TODO(), "could not unlock file lock when removing temporary directory: %s", err.Error())
+			}
+		}()
+
 		// If path/directory does not exist, error is nil.
 		if err := os.RemoveAll(path); err != nil {
 			return err

--- a/pkg/storage/engine/temp_dir_test.go
+++ b/pkg/storage/engine/temp_dir_test.go
@@ -12,18 +12,26 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package util
+package engine
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 func TestCreateTempDir(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
 	// Temporary parent directory to test this.
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
@@ -35,7 +43,7 @@ func TestCreateTempDir(t *testing.T) {
 		}
 	}()
 
-	tempDir, err := CreateTempDir(dir, "test-create-temp")
+	tempDir, err := CreateTempDir(dir, "test-create-temp", stopper)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,6 +62,7 @@ func TestCreateTempDir(t *testing.T) {
 }
 
 func TestRecordTempDir(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	recordFile := "foobar"
 
 	f, err := ioutil.TempFile("", "record-file")
@@ -87,6 +96,8 @@ func TestRecordTempDir(t *testing.T) {
 }
 
 func TestCleanupTempDirs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	recordFile, err := ioutil.TempFile("", "record-file")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Fixes #20673

Release note: (bug fix): fixed a bug where the temporary directory was
being wiped on subsequent failed CockroachDB start-ups, causing
importing and DistSQL queries to fail.

cc: @mjibson 

This only affects the mater branch.