### PR TITLE
storage: return canApplySnapshot error, don't silently drop request

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3036,19 +3036,16 @@ func (s *Store) processRaftSnapshotRequest(
 		var addedPlaceholder bool
 		var removePlaceholder bool
 		if !r.IsInitialized() {
-			if earlyReturn := func() bool {
+			if err := func() error {
 				s.mu.Lock()
 				defer s.mu.Unlock()
 				placeholder, err := s.canApplySnapshotLocked(ctx, inSnap.State.Desc)
 				if err != nil {
-					// If the storage cannot accept the snapshot, drop it before
-					// passing it to RawNode.Step, since our error handling
-					// options past that point are limited.
-					// TODO(arjun): Now that we have better raft transport error
-					// handling, consider if this error should be returned and
-					// handled by the sending store.
+					// If the storage cannot accept the snapshot, return an
+					// error before passing it to RawNode.Step, since our
+					// error handling options past that point are limited.
 					log.Infof(ctx, "cannot apply snapshot: %s", err)
-					return true
+					return err
 				}
 
 				if placeholder != nil {
@@ -3061,9 +3058,9 @@ func (s *Store) processRaftSnapshotRequest(
 					}
 					addedPlaceholder = true
 				}
-				return false
-			}(); earlyReturn {
 				return nil
+			}(); err != nil {
+				return roachpb.NewError(err)
 			}
 
 			if addedPlaceholder {


### PR DESCRIPTION
Fixes #8672.

We've had a TODO for a while to return an error over the `RaftTransport`
stream if `canApplySnapshot` fails. Addressing this was possible
when the TODO was introduced, but it became a lot more straightforward
once the changes in #9292 were made. In fact, that change already
returned an error if `canApplySnapshot` failed before accepting the
snapshot request (see https://github.com/cockroachdb/cockroach/commit/1973f61414384e4e5bda0652ef9a91782873c5d1#diff-dae9f8a58ca2ec436440b12989c1982dR2319).

This change addresses this TODO and returns an error when
`canApplySnapsot` fails during the snapshot application phase.
This is essentially an optimization, as it prevents the sender
from thinking the message was dropped by the network and retrying
the snapshot again.

Release note: None