### PR TITLE
sql: fix merge skew

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -208,7 +208,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-1.1-6
+1.1-7
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -252,4 +252,4 @@ select * from crdb_internal.ranges
 query T
 select crdb_internal.node_executable_version()
 ----
-1.1-6
+1.1-7


### PR DESCRIPTION
A test hadn't been updated to the latest internal version.

Fixes #20850.
Fixes #20851.

Release note: None