### PR TITLE
sql: infer constraints on equality columns in one-sided joins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1089,6 +1089,7 @@ SELECT *
 3  scan    ·         ·
 3  ·       table     square@primary
 3  ·       spans     /!NULL-/5/#
+3  ·       filter    sq > 1
 
 query IIII rowsort
 SELECT *
@@ -1551,7 +1552,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 2  ·       spans           /3-                ·                                     ·
 2  scan    ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
 2  ·       table           xyv@primary        ·                                     ·
-2  ·       spans           ALL                ·                                     ·
+2  ·       spans           /3-                ·                                     ·
 
 query IIII rowsort
 SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -1581,7 +1582,7 @@ EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                   ·
 3  scan    ·               ·                  (x, y, u)                                           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
 3  ·       table           xyu@primary        ·                                                   ·
-3  ·       spans           ALL                ·                                                   ·
+3  ·       spans           /3-                ·                                                   ·
 3  scan    ·               ·                  (x, y, v)                                           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
 3  ·       table           xyv@primary        ·                                                   ·
 3  ·       spans           /3-                ·                                                   ·
@@ -1739,7 +1740,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OU
 2  ·       spans           /3-                ·                                     ·
 2  scan    ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
 2  ·       table           xyv@primary        ·                                     ·
-2  ·       spans           ALL                ·                                     ·
+2  ·       spans           /3-                ·                                     ·
 
 query IIII rowsort
 SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
@@ -1769,7 +1770,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT O
 2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                   ·
 3  scan    ·               ·                  (x, y, u)                                           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
 3  ·       table           xyu@primary        ·                                                   ·
-3  ·       spans           ALL                ·                                                   ·
+3  ·       spans           /3-                ·                                                   ·
 3  scan    ·               ·                  (x, y, v)                                           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
 3  ·       table           xyv@primary        ·                                                   ·
 3  ·       spans           /3-                ·                                                   ·
@@ -1889,3 +1890,101 @@ EXPLAIN (VERBOSE) SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2
 2  ·       table           xyv@primary            ·                                     ·
 2  ·       spans           /1/2-                  ·                                     ·
 2  ·       filter          (x, y) >= (1, 2)       ·                                     ·
+
+
+# Regression test for #20858.
+
+statement ok
+CREATE TABLE l (a INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE r (a INT PRIMARY KEY)
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 3;
+----
+0  render  ·               ·           (a)              ·
+0  ·       render 0        test.l.a    ·                ·
+1  join    ·               ·           (a, a[omitted])  ·
+1  ·       type            left outer  ·                ·
+1  ·       equality        (a) = (a)   ·                ·
+1  ·       mergeJoinOrder  +"(a=a)"    ·                ·
+2  scan    ·               ·           (a)              a=CONST; key()
+2  ·       table           l@primary   ·                ·
+2  ·       spans           /3-/3/#     ·                ·
+2  scan    ·               ·           (a)              a=CONST; key()
+2  ·       table           r@primary   ·                ·
+2  ·       spans           /3-/3/#     ·                ·
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
+----
+0  join  ·               ·           (a, a)  ·
+0  ·     type            left outer  ·       ·
+0  ·     equality        (a) = (a)   ·       ·
+0  ·     mergeJoinOrder  +"(a=a)"    ·       ·
+1  scan  ·               ·           (a)     a=CONST; key()
+1  ·     table           l@primary   ·       ·
+1  ·     spans           /3-/3/#     ·       ·
+1  scan  ·               ·           (a)     a=CONST; key()
+1  ·     table           r@primary   ·       ·
+1  ·     spans           /3-/3/#     ·       ·
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3;
+----
+0  render  ·               ·            (a)                     ·
+0  ·       render 0        test.r.a     ·                       ·
+1  render  ·               ·            (a, a[hidden,omitted])  ·
+1  ·       render 0        test.r.a     ·                       ·
+1  ·       render 1        NULL         ·                       ·
+2  join    ·               ·            (a[omitted], a)         ·
+2  ·       type            right outer  ·                       ·
+2  ·       equality        (a) = (a)    ·                       ·
+2  ·       mergeJoinOrder  +"(a=a)"     ·                       ·
+3  scan    ·               ·            (a)                     a=CONST; key()
+3  ·       table           l@primary    ·                       ·
+3  ·       spans           /3-/3/#      ·                       ·
+3  scan    ·               ·            (a)                     a=CONST; key()
+3  ·       table           r@primary    ·                       ·
+3  ·       spans           /3-/3/#      ·                       ·
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
+----
+0  join  ·               ·            (a, a)  ·
+0  ·     type            right outer  ·       ·
+0  ·     equality        (a) = (a)    ·       ·
+0  ·     mergeJoinOrder  +"(a=a)"     ·       ·
+1  scan  ·               ·            (a)     a=CONST; key()
+1  ·     table           l@primary    ·       ·
+1  ·     spans           /3-/3/#      ·       ·
+1  scan  ·               ·            (a)     a=CONST; key()
+1  ·     table           r@primary    ·       ·
+1  ·     spans           /3-/3/#      ·       ·
+
+statement ok
+INSERT INTO l VALUES (1), (2), (3)
+
+statement ok
+INSERT INTO r VALUES (2), (3), (4)
+
+query I
+SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 1
+----
+1
+
+query I
+SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 2
+----
+2
+
+query I
+SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3
+----
+3
+
+query I
+SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 4
+----
+4

--- a/pkg/sql/opt_decompose.go
+++ b/pkg/sql/opt_decompose.go
@@ -70,9 +70,9 @@ func splitOrExpr(
 	return append(exprs, e)
 }
 
-// splitAndExpr flattens a tree of AND expressions returning all of the child
-// expressions as a list. Any non-AND expression is returned as a single
-// element in the list.
+// splitAndExpr flattens a tree of AND expressions, appending all of the child
+// expressions as a list. Any non-AND expression is appended as a single element
+// in the list.
 //
 //   a AND b AND c AND d -> [a, b, c, d]
 func splitAndExpr(

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -639,6 +639,42 @@ func expandOnCond(n *joinNode, cond tree.TypedExpr, evalCtx *tree.EvalContext) t
 	return result
 }
 
+// remapLeftEqColConstraints takes an expression that applies to the left side
+// of the join and returns any constraints that refer to left equality columns,
+// remapped to refer to the corresponding columns on the right side.
+func remapLeftEqColConstraints(n *joinNode, cond tree.TypedExpr) tree.TypedExpr {
+	conv := func(expr tree.VariableExpr) (bool, tree.Expr) {
+		if iv, ok := expr.(*tree.IndexedVar); ok {
+			for i, c := range n.pred.leftEqualityIndices {
+				if c == iv.Idx {
+					return true, n.pred.iVarHelper.IndexedVar(n.pred.rightEqualityIndices[i])
+				}
+			}
+		}
+		return false, expr
+	}
+	result, _ := splitFilter(cond, conv)
+	return result
+}
+
+// remapRightEqColConstraints takes an expression that applies to the right side
+// of the join and returns any constraints that refer to right equality columns,
+// remapped to refer to the corresponding columns on the left side.
+func remapRightEqColConstraints(n *joinNode, cond tree.TypedExpr) tree.TypedExpr {
+	conv := func(expr tree.VariableExpr) (bool, tree.Expr) {
+		if iv, ok := expr.(*tree.IndexedVar); ok {
+			for i, c := range n.pred.rightEqualityIndices {
+				if c == iv.Idx {
+					return true, n.pred.iVarHelper.IndexedVar(n.pred.leftEqualityIndices[i])
+				}
+			}
+		}
+		return false, expr
+	}
+	result, _ := splitFilter(cond, conv)
+	return result
+}
+
 // splitJoinFilter splits a predicate over both sides of the join into
 // three predicates: the part that definitely refers only to the left,
 // the part that definitely refers only to the right, and the rest.
@@ -698,6 +734,7 @@ func (p *planner) addJoinFilter(
 
 	// Step 1: for inner joins, incorporate the filter into the ON condition.
 	if n.joinType == joinTypeInner {
+		// Split the filter into conjunctions and append them to onAndExprs.
 		onAndExprs = splitAndExpr(&p.evalCtx, extraFilter, onAndExprs)
 		extraFilter = nil
 	}
@@ -750,9 +787,24 @@ func (p *planner) addJoinFilter(
 		// Extract filterLeft towards propagation on the left.
 		// filterRemainder = filterRight AND filterCombined.
 		propagateLeft, filterRemainder = splitJoinFilterLeft(n, numLeft, extraFilter)
+
 		// Extract onRight towards propagation on the right.
 		// onCond = onLeft AND onCombined.
 		propagateRight, onCond = splitJoinFilterRight(n, numLeft, onCond)
+
+		// For left joins, if we have any conditions on the left-hand equality
+		// columns, we can remap these to the right-hand equality columns and
+		// incorporate in the ON condition. For example:
+		//
+		//   SELECT * FROM l LEFT JOIN r USING (a) WHERE l.a = 1
+		//
+		// In this case, we can push down r.a = 1 to the right side.
+		//
+		// Note that this is what happens when a merged column name is used; for
+		// outer left joins, `a` is an alias for the left side equality column and
+		// the following query is equivalent to the one above:
+		//   SELECT * FROM l LEFT JOIN r USING (a) WHERE a = 1
+		propagateRight = mergeConj(propagateRight, remapLeftEqColConstraints(n, propagateLeft))
 
 	case joinTypeRightOuter:
 		// We transform:
@@ -773,6 +825,12 @@ func (p *planner) addJoinFilter(
 		// Extract onLeft towards propagation on the left.
 		// onCond = onRight AND onCombined.
 		propagateLeft, onCond = splitJoinFilterLeft(n, numLeft, onCond)
+
+		// Symmetric to the corresponding case above, for example:
+		//   SELECT * FROM l RIGHT JOIN r USING (a) WHERE r.a = 1
+		//
+		// In this case, we can push down l.a = 1 to the left side.
+		propagateLeft = mergeConj(propagateLeft, remapRightEqColConstraints(n, propagateRight))
 
 	case joinTypeFullOuter:
 		// Not much we can do for full outer joins.


### PR DESCRIPTION
Issue #20765 points out an interesting case:
  `SELECT * FROM l LEFT JOIN r USING(a) WHERE a=3`

In this case, `WHERE a=3` is internally `WHERE l.a=3`. We can push
down a corresponding constraint `r.a=3` because only those rows can
contribute to any final results.

In general, for LEFT JOINs we remap any constraints on left-side
equality columns and push them down to the right side. The case for
RIGHT JOINs is symmetric.

Fixes #20765.