### PR TITLE
tests: speed up TestParseArrayRandomParseArray

### DIFF
--- a/pkg/sql/sem/tree/parse_array_test.go
+++ b/pkg/sql/sem/tree/parse_array_test.go
@@ -99,7 +99,7 @@ lo}`, coltypes.String, Datums{NewDString(`hel`), NewDString(`lo`)}},
 	}
 }
 
-const randomArrayIterations = 10000
+const randomArrayIterations = 1000
 const randomArrayMaxLength = 10
 const randomStringMaxLength = 1000
 


### PR DESCRIPTION
In testrace, this is taking 2+ min on CI and 35s locally.

Release note: none.