### PR TITLE
opt: support column directions

### DIFF
--- a/pkg/sql/opt/testdata/build-scalar
+++ b/pkg/sql/opt/testdata/build-scalar
@@ -10,19 +10,19 @@ plus (type: int)
  ├── const (1) (type: int)
  └── const (2) (type: int)
 
-build-scalar string
+build-scalar columns=(string)
 @1
 ----
 variable (0) (type: string)
 
-build-scalar int
+build-scalar columns=(int)
 @1 + 2
 ----
 plus (type: int)
  ├── variable (0) (type: int)
  └── const (2) (type: int)
 
-build-scalar int int
+build-scalar columns=(int, int)
 @1 >= 5 AND @1 <= 10 AND @2 < 4
 ----
 and (type: bool)
@@ -37,7 +37,7 @@ and (type: bool)
       ├── variable (1) (type: int)
       └── const (4) (type: int)
 
-build-scalar,normalize int int
+build-scalar,normalize columns=(int, int)
 @1 >= 5 AND @1 <= 10 AND @2 > 0 AND @2 < 10
 ----
 and (type: bool)
@@ -54,7 +54,7 @@ and (type: bool)
       ├── variable (1) (type: int)
       └── const (10) (type: int)
 
-build-scalar,normalize int int
+build-scalar,normalize columns=(int, int)
 @1 >= 5 OR @1 <= 10 OR @2 > 0 OR @2 < 10
 ----
 or (type: bool)
@@ -71,7 +71,7 @@ or (type: bool)
       ├── variable (1) (type: int)
       └── const (10) (type: int)
 
-build-scalar,normalize int int int
+build-scalar,normalize columns=(int, int, int)
 @1 >= 5 AND (@2 = 1 OR @2 > 3) AND (@3 > 2)
 ----
 and (type: bool)
@@ -89,7 +89,7 @@ and (type: bool)
       ├── variable (2) (type: int)
       └── const (2) (type: int)
 
-build-scalar,normalize int int int
+build-scalar,normalize columns=(int, int, int)
 @1 >= 5 AND (@2 = 1 OR @2 = 3 OR @2 > 5) AND (@3 > 2)
 ----
 and (type: bool)
@@ -110,7 +110,7 @@ and (type: bool)
       ├── variable (2) (type: int)
       └── const (2) (type: int)
 
-build-scalar,normalize int int int
+build-scalar,normalize columns=(int, int, int)
 (@1 >= 5 AND @1 <= 10) OR (@2 > 1 AND @2 < 3) OR (@3 > 2)
 ----
 or (type: bool)
@@ -132,7 +132,7 @@ or (type: bool)
       ├── variable (2) (type: int)
       └── const (2) (type: int)
 
-build-scalar int int
+build-scalar columns=(int, int)
 (@1, @2) = (1, 2)
 ----
 eq (type: bool)
@@ -143,7 +143,7 @@ eq (type: bool)
       ├── const (1) (type: int)
       └── const (2) (type: int)
 
-build-scalar int
+build-scalar columns=(int)
 @1 IN (1, 2)
 ----
 in (type: bool)
@@ -152,7 +152,7 @@ in (type: bool)
       ├── const (1) (type: int)
       └── const (2) (type: int)
 
-build-scalar int int
+build-scalar columns=(int, int)
 (@1, @2) IN ((1, 2), (3, 4))
 ----
 in (type: bool)
@@ -167,7 +167,7 @@ in (type: bool)
            ├── const (3) (type: int)
            └── const (4) (type: int)
 
-build-scalar int int int int
+build-scalar columns=(int, int, int, int)
 (@1, @2 + @3, 5 + @4 * 2) = (@2 + @3, 8, @1 - @4)
 ----
 eq (type: bool)
@@ -190,7 +190,7 @@ eq (type: bool)
            ├── variable (0) (type: int)
            └── variable (3) (type: int)
 
-build-scalar,normalize int int int int
+build-scalar,normalize columns=(int, int, int, int)
 (@1, @2 + @3, 5 + @4 * 2) = (@2 + @3, 8, @1 - @4)
 ----
 and (type: bool)
@@ -214,7 +214,7 @@ and (type: bool)
            ├── variable (0) (type: int)
            └── variable (3) (type: int)
 
-build-scalar int int int int
+build-scalar columns=(int, int, int, int)
 ((@1, @2), (@3, @4)) = ((1, 2), (3, 4))
 ----
 eq (type: bool)
@@ -233,7 +233,7 @@ eq (type: bool)
            ├── const (3) (type: int)
            └── const (4) (type: int)
 
-build-scalar,normalize int int int int
+build-scalar,normalize columns=(int, int, int, int)
 ((@1, @2), (@3, @4)) = ((1, 2), (3, 4))
 ----
 and (type: bool)
@@ -250,7 +250,7 @@ and (type: bool)
       ├── variable (3) (type: int)
       └── const (4) (type: int)
 
-build-scalar int int int string
+build-scalar columns=(int, int, int, string)
 (@1, (@2, 'a'), (@3, 'b', 5)) = (9, (@1 + @3, @4), (5, @4, @1))
 ----
 eq (type: bool)
@@ -275,7 +275,7 @@ eq (type: bool)
            ├── variable (3) (type: string)
            └── variable (0) (type: int)
 
-build-scalar,normalize int int int string
+build-scalar,normalize columns=(int, int, int, string)
 (@1, (@2, 'a'), (@3, 'b', 5)) = (9, (@1 + @3, @4), (5, @4, @1))
 ----
 and (type: bool)

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -1,141 +1,141 @@
-build-scalar,normalize,index-constraints int
+build-scalar,normalize,index-constraints columns=(int)
 @1 > 2
 ----
 [/3 - ]
 
-build-scalar,normalize,index-constraints int
+build-scalar,normalize,index-constraints columns=(int)
 @1 >= 2
 ----
 [/2 - ]
 
-build-scalar,normalize,index-constraints int
+build-scalar,normalize,index-constraints columns=(int)
 @1 != 2
 ----
 [ - /2)
 (/2 - ]
 
-build-scalar,normalize,index-constraints int
+build-scalar,normalize,index-constraints columns=(int)
 @1 < 2
 ----
 [ - /1]
 
-build-scalar,normalize,index-constraints int
+build-scalar,normalize,index-constraints columns=(int)
 @1 = 2
 ----
 [/2 - /2]
 
-build-scalar,normalize,index-constraints int
+build-scalar,normalize,index-constraints columns=(int)
 @1 > 2 AND @1 < 4
 ----
 [/3 - /3]
 
-build-scalar,normalize,index-constraints int
+build-scalar,normalize,index-constraints columns=(int)
 @1 >= 2 AND @1 <= 4
 ----
 [/2 - /4]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 > 2 AND @2 > 5
 ----
 [/3/6 - ]
 
-build-scalar,normalize,index-constraints int
+build-scalar,normalize,index-constraints columns=(int)
 @1 >= 1 AND @1 <= 5 AND @1 != 3
 ----
 [/1 - /3)
 (/3 - /5]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
 ----
 [/1/8 - /2/9]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 > 1 AND @1 < 4 AND @2 > 5 AND @2 < 8
 ----
 [/2/6 - /3/7]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 > 1 AND @1 < 4 AND @2 = 5
 ----
 [/2/5 - /3/5]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 = 1 AND @2 > 3 AND @2 < 5
 ----
 [/1/4 - /1/4]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 = 1 AND @2 > 3 AND @2 < 8
 ----
 [/1/4 - /1/7]
 
-build-scalar,normalize,index-constraints int
+build-scalar,normalize,index-constraints columns=(int)
 @1 > 2 AND @1 < 1
 ----
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 = 1 AND @2 != 2
 ----
 [/1 - /1/2)
 (/1/2 - /1]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 >= 1 AND @1 <= 5 AND @2 != 2
 ----
 [/1 - /5]
 
-# Tests with a type that doesn't support Prev.
-build-scalar,normalize,index-constraints string
+# Tests with a type that doesn't support columns=(Prev.
+build-scalar,normalize,index-constraints columns=(string)
 @1 > 'a' AND @1 < 'z'
 ----
 [/e'a\x00' - /'z')
 
-build-scalar,normalize,index-constraints string int
+build-scalar,normalize,index-constraints columns=(string, int)
 @1 > 'a' AND @1 < 'z' AND @2 = 5
 ----
 [/e'a\x00'/5 - /'z')
 
-# Tests with a type that doesn't support Next or Prev.
-build-scalar,normalize,index-constraints decimal
+# Tests with a type that doesn't support columns=(Next or Prev.
+build-scalar,normalize,index-constraints columns=(decimal)
 @1 > 1.5
 ----
 (/1.5 - ]
 
-build-scalar,normalize,index-constraints decimal
+build-scalar,normalize,index-constraints columns=(decimal)
 @1 > 1.5 AND @1 < 2
 ----
 (/1.5 - /2)
 
-# Note the difference here between decimal and int: we
+# Note the difference here between decimacolumns=(l and int: we
 # can't extend the exclusive start key.
-build-scalar,normalize,index-constraints decimal decimal
+build-scalar,normalize,index-constraints columns=(decimal, decimal)
 @1 > 1.5 AND @2 > 2
 ----
 (/1.5 - ]
 
-build-scalar,normalize,index-constraints int
+build-scalar,normalize,index-constraints columns=(int)
 @1 IN (1, 2, 3)
 ----
 [/1 - /1]
 [/2 - /2]
 [/3 - /3]
 
-build-scalar,legacy-normalize,index-constraints int
+build-scalar,legacy-normalize,index-constraints columns=(int)
 @1 IN (1, 5, 1, 4)
 ----
 [/1 - /1]
 [/4 - /4]
 [/5 - /5]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 = 1 AND @2 IN (1, 2, 3)
 ----
 [/1/1 - /1/1]
 [/1/2 - /1/2]
 [/1/3 - /1/3]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 IN (1, 2) AND @2 IN (1, 2, 3)
 ----
 [/1/1 - /1/1]
@@ -145,41 +145,41 @@ build-scalar,normalize,index-constraints int int
 [/2/2 - /2/2]
 [/2/3 - /2/3]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 >= 2 AND @1 <= 4 AND @2 IN (1, 2, 3)
 ----
 [/2/1 - /4/3]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 IN (1, 2, 3) AND @2 = 4
 ----
 [/1/4 - /1/4]
 [/2/4 - /2/4]
 [/3/4 - /3/4]
 
-build-scalar,normalize,index-constraints int int
+build-scalar,normalize,index-constraints columns=(int, int)
 @1 IN (1, 2, 3) AND @2 >= 2 AND @2 <= 4
 ----
 [/1/2 - /1/4]
 [/2/2 - /2/4]
 [/3/2 - /3/4]
 
-build-scalar,normalize,index-constraints int int int
+build-scalar,normalize,index-constraints columns=(int, int, int)
 (@1, @2, @3) = (1, 2, 3)
 ----
 [/1/2/3 - /1/2/3]
 
-build-scalar,normalize,index-constraints int int int int int
+build-scalar,normalize,index-constraints columns=(int, int, int, int, int)
 (@1, @2, 3, (4, @5)) = (1, 2, @3, (@4, 5))
 ----
 [/1/2/3/4/5 - /1/2/3/4/5]
 
-build-scalar,normalize,index-constraints int int int int
+build-scalar,normalize,index-constraints columns=(int, int, int, int)
 (@1, @2, @3) = (1, 2, 3) AND @4 > 4
 ----
 [/1/2/3/5 - /1/2/3]
 
-build-scalar,normalize,index-constraints int int int int
+build-scalar,normalize,index-constraints columns=(int, int, int, int)
 @1 > 5 AND @1 < 10 AND (@2, @3, @4) = (2, 3, 4)
 ----
 [/6/2/3/4 - /9/2/3/4]

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -3,12 +3,28 @@ build-scalar,normalize,index-constraints columns=(int)
 ----
 [/3 - ]
 
+build-scalar,normalize,index-constraints columns=(int descending)
+@1 > 2
+----
+[ - /3]
+
 build-scalar,normalize,index-constraints columns=(int)
 @1 >= 2
 ----
 [/2 - ]
 
+build-scalar,normalize,index-constraints columns=(int descending)
+@1 >= 2
+----
+[ - /2]
+
 build-scalar,normalize,index-constraints columns=(int)
+@1 != 2
+----
+[ - /2)
+(/2 - ]
+
+build-scalar,normalize,index-constraints columns=(int descending)
 @1 != 2
 ----
 [ - /2)
@@ -19,7 +35,17 @@ build-scalar,normalize,index-constraints columns=(int)
 ----
 [ - /1]
 
+build-scalar,normalize,index-constraints columns=(int descending)
+@1 < 2
+----
+[/1 - ]
+
 build-scalar,normalize,index-constraints columns=(int)
+@1 = 2
+----
+[/2 - /2]
+
+build-scalar,normalize,index-constraints columns=(int descending)
 @1 = 2
 ----
 [/2 - /2]
@@ -39,6 +65,11 @@ build-scalar,normalize,index-constraints columns=(int, int)
 ----
 [/3/6 - ]
 
+build-scalar,normalize,index-constraints columns=(int, int descending)
+@1 > 2 AND @2 < 5
+----
+[/3/4 - ]
+
 build-scalar,normalize,index-constraints columns=(int)
 @1 >= 1 AND @1 <= 5 AND @1 != 3
 ----
@@ -49,6 +80,16 @@ build-scalar,normalize,index-constraints columns=(int, int)
 @1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
 ----
 [/1/8 - /2/9]
+
+build-scalar,normalize,index-constraints columns=(int descending, int)
+@1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
+----
+[/2/8 - /1/9]
+
+build-scalar,normalize,index-constraints columns=(int, int descending)
+@1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
+----
+[/1/9 - /2/8]
 
 build-scalar,normalize,index-constraints columns=(int, int)
 @1 > 1 AND @1 < 4 AND @2 > 5 AND @2 < 8
@@ -85,7 +126,7 @@ build-scalar,normalize,index-constraints columns=(int, int)
 ----
 [/1 - /5]
 
-# Tests with a type that doesn't support columns=(Prev.
+# Tests with a type that doesn't support Prev.
 build-scalar,normalize,index-constraints columns=(string)
 @1 > 'a' AND @1 < 'z'
 ----
@@ -96,7 +137,17 @@ build-scalar,normalize,index-constraints columns=(string, int)
 ----
 [/e'a\x00'/5 - /'z')
 
-# Tests with a type that doesn't support columns=(Next or Prev.
+build-scalar,normalize,index-constraints columns=(string descending)
+@1 > 'a' AND @1 < 'z'
+----
+(/'z' - /e'a\x00']
+
+build-scalar,normalize,index-constraints columns=(string descending, int)
+@1 > 'a' AND @1 < 'z' AND @2 = 5
+----
+(/'z' - /e'a\x00'/5]
+
+# Tests with a type that doesn't support Next or Prev.
 build-scalar,normalize,index-constraints columns=(decimal)
 @1 > 1.5
 ----
@@ -107,7 +158,7 @@ build-scalar,normalize,index-constraints columns=(decimal)
 ----
 (/1.5 - /2)
 
-# Note the difference here between decimacolumns=(l and int: we
+# Note the difference here between decimal and int: we
 # can't extend the exclusive start key.
 build-scalar,normalize,index-constraints columns=(decimal, decimal)
 @1 > 1.5 AND @2 > 2
@@ -121,6 +172,13 @@ build-scalar,normalize,index-constraints columns=(int)
 [/2 - /2]
 [/3 - /3]
 
+build-scalar,normalize,index-constraints columns=(int descending)
+@1 IN (1, 2, 3)
+----
+[/3 - /3]
+[/2 - /2]
+[/1 - /1]
+
 build-scalar,legacy-normalize,index-constraints columns=(int)
 @1 IN (1, 5, 1, 4)
 ----
@@ -128,12 +186,26 @@ build-scalar,legacy-normalize,index-constraints columns=(int)
 [/4 - /4]
 [/5 - /5]
 
+build-scalar,legacy-normalize,index-constraints columns=(int descending)
+@1 IN (1, 5, 1, 4)
+----
+[/5 - /5]
+[/4 - /4]
+[/1 - /1]
+
 build-scalar,normalize,index-constraints columns=(int, int)
 @1 = 1 AND @2 IN (1, 2, 3)
 ----
 [/1/1 - /1/1]
 [/1/2 - /1/2]
 [/1/3 - /1/3]
+
+build-scalar,normalize,index-constraints columns=(int, int descending)
+@1 = 1 AND @2 IN (1, 2, 3)
+----
+[/1/3 - /1/3]
+[/1/2 - /1/2]
+[/1/1 - /1/1]
 
 build-scalar,normalize,index-constraints columns=(int, int)
 @1 IN (1, 2) AND @2 IN (1, 2, 3)
@@ -145,12 +217,42 @@ build-scalar,normalize,index-constraints columns=(int, int)
 [/2/2 - /2/2]
 [/2/3 - /2/3]
 
+build-scalar,normalize,index-constraints columns=(int descending, int descending)
+@1 IN (1, 2) AND @2 IN (1, 2, 3)
+----
+[/2/3 - /2/3]
+[/2/2 - /2/2]
+[/2/1 - /2/1]
+[/1/3 - /1/3]
+[/1/2 - /1/2]
+[/1/1 - /1/1]
+
 build-scalar,normalize,index-constraints columns=(int, int)
 @1 >= 2 AND @1 <= 4 AND @2 IN (1, 2, 3)
 ----
 [/2/1 - /4/3]
 
+build-scalar,normalize,index-constraints columns=(int descending, int descending)
+@1 >= 2 AND @1 <= 4 AND @2 IN (1, 2, 3)
+----
+[/4/3 - /2/1]
+
+
 build-scalar,normalize,index-constraints columns=(int, int)
+@1 IN (1, 2, 3) AND @2 = 4
+----
+[/1/4 - /1/4]
+[/2/4 - /2/4]
+[/3/4 - /3/4]
+
+build-scalar,normalize,index-constraints columns=(int descending, int)
+@1 IN (1, 2, 3) AND @2 = 4
+----
+[/3/4 - /3/4]
+[/2/4 - /2/4]
+[/1/4 - /1/4]
+
+build-scalar,normalize,index-constraints columns=(int, int descending)
 @1 IN (1, 2, 3) AND @2 = 4
 ----
 [/1/4 - /1/4]
@@ -183,3 +285,8 @@ build-scalar,normalize,index-constraints columns=(int, int, int, int)
 @1 > 5 AND @1 < 10 AND (@2, @3, @4) = (2, 3, 4)
 ----
 [/6/2/3/4 - /9/2/3/4]
+
+build-scalar,normalize,index-constraints columns=(int descending, int descending, int descending, int descending)
+@1 > 5 AND @1 < 10 AND (@2, @3, @4) = (2, 3, 4)
+----
+[/9/2/3/4 - /6/2/3/4]


### PR DESCRIPTION
#### opt: allow specifying column directions in testcases

Switching the opt test syntax to use a
`column=(type [ascending|descending], ...)`
argument.

Release note: None

#### opt: support column directions

Adding support for column directions. This will need to be taken into
account in a bunch of cases so it makes sense to do it early.

At a high level, the column direction simply negates the result of a
comparison on that column.

Release note: None