### PR TITLE
sql: speed up TestDropTableDeleteData

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -583,6 +583,12 @@ func TestDropTable(t *testing.T) {
 func TestDropTableDeleteData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
+			// Turn on quick garbage collection.
+			AsyncExecQuickly: true,
+		},
+	}
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.TODO())
 	ctx := context.TODO()


### PR DESCRIPTION
This test was missing a testing knob that vastly speeds up DROP TABLE
garbage collection. (Other similar tests, like the interleaved variant,
already had this knob enabled.) This shaves 30s of the test runtime
under race.

Release note: None