### PR TITLE
sql: add logictest for sequence behavior w/r/t txns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -338,3 +338,34 @@ SELECT lastval()
 
 statement ok
 COMMIT
+
+# BEHAVIOR WITH TRANSACTIONS
+
+# Verify that sequence updates are not rolled back with their corresponding transactions, leaving a gap.
+
+statement ok
+CREATE SEQUENCE txn_test_seq;
+
+statement ok
+CREATE TABLE txn_test (id INT PRIMARY KEY DEFAULT nextval('txn_test_seq'), something text)
+
+statement ok
+INSERT INTO txn_test (something) VALUES ('foo')
+
+statement ok
+BEGIN
+
+statement ok
+INSERT INTO txn_test (something) VALUES ('bar')
+
+statement ok
+ROLLBACK
+
+statement ok
+INSERT INTO txn_test (something) VALUES ('baz')
+
+query IT
+SELECT * FROM txn_test
+----
+1 foo
+3 baz


### PR DESCRIPTION
It's an important property of our sequences (following PG and others) that sequence updates aren't rolled back with the transactions that initiate them, possibly leaving gaps. This is called out in our documentation (https://github.com/cockroachdb/docs/pull/2292); figured it should be tested explicitly.

Release note: None

Tracking issue: #19723