### PR TITLE
cmd/allocsim: Add configs with differing numbers of nodes per locality

### DIFF
--- a/pkg/cmd/allocsim/configs/different-nodes-per-locality-imbalanced-load.json
+++ b/pkg/cmd/allocsim/configs/different-nodes-per-locality-imbalanced-load.json
@@ -1,0 +1,49 @@
+{
+  "Localities": [
+    {
+      "Name": "1",
+      "NumNodes": 2,
+      "NumWorkers": 0,
+      "OutgoingLatencies": [
+        {
+          "Name": "2",
+          "Latency": "50ms"
+        },
+        {
+          "Name": "3",
+          "Latency": "50ms"
+        }
+      ]
+    },
+    {
+      "Name": "2",
+      "NumNodes": 2,
+      "NumWorkers": 32,
+      "OutgoingLatencies": [
+        {
+          "Name": "1",
+          "Latency": "50ms"
+        },
+        {
+          "Name": "3",
+          "Latency": "50ms"
+        }
+      ]
+    },
+    {
+      "Name": "3",
+      "NumNodes": 4,
+      "NumWorkers": 0,
+      "OutgoingLatencies": [
+        {
+          "Name": "1",
+          "Latency": "50ms"
+        },
+        {
+          "Name": "2",
+          "Latency": "50ms"
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/cmd/allocsim/configs/different-nodes-per-locality-low-latency.json
+++ b/pkg/cmd/allocsim/configs/different-nodes-per-locality-low-latency.json
@@ -1,0 +1,17 @@
+{
+  "NumWorkers": 32,
+  "Localities": [
+    {
+      "Name": "1",
+      "NumNodes": 2
+    },
+    {
+      "Name": "2",
+      "NumNodes": 2
+    },
+    {
+      "Name": "3",
+      "NumNodes": 4
+    }
+  ]
+}


### PR DESCRIPTION
To make cases like #20241 easier to test against in the future.
Both configs perform reasonably on master (although I didn't test with
stats-based rebalancing enabled).

Release note: None