### PR TITLE
sql: fully consume statement sources despite outer limits

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -407,8 +407,13 @@ func (p *planner) getDataSource(
 		if err != nil {
 			return planDataSource{}, err
 		}
+		cols := planColumns(plan)
+		if len(cols) == 0 {
+			return planDataSource{}, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError,
+				"statement source \"%v\" does not return any columns", t.Statement)
+		}
 		return planDataSource{
-			info: newSourceInfoForSingleTable(anonymousTable, planColumns(plan)),
+			info: newSourceInfoForSingleTable(anonymousTable, cols),
 			plan: plan,
 		}, nil
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -252,7 +252,7 @@ func (p *planner) Insert(
 		tw:           tw,
 		run: insertRun{
 			insertColIDtoRowIndex: ri.InsertColIDtoRowIndex,
-			isUpsertReturning:     isUpsertReturning,
+			drainOnStart:          isUpsertReturning,
 		},
 	}
 
@@ -273,14 +273,15 @@ type insertRun struct {
 	// The following fields are populated during Start().
 	editNodeRun
 
-	isUpsertReturning     bool
 	insertColIDtoRowIndex map[sqlbase.ColumnID]int
 
 	rowIdxToRetIdx []int
 	rowTemplate    tree.Datums
 
-	doneUpserting bool
-	rowsUpserted  *sqlbase.RowContainer
+	// drainOnStart indicates that this node will finish its work entirely upon
+	// startExec, saving the results into the rowsInserted container.
+	drainOnStart bool
+	rowsInserted *sqlbase.RowContainer
 }
 
 func (n *insertNode) startExec(params runParams) error {
@@ -312,14 +313,24 @@ func (n *insertNode) startExec(params runParams) error {
 		return err
 	}
 
-	return n.run.tw.init(params.p.txn)
-}
+	if err := n.run.tw.init(params.p.txn); err != nil {
+		return err
+	}
 
-func (n *insertNode) Next(params runParams) (bool, error) {
-	if n.run.isUpsertReturning {
+	if n.run.drainOnStart {
+		// Because TableUpserter batches the upserts, we need to completely drain the
+		// source and handle all the rows before returning from the first call to Next,
+		// so that we can return an upserted row from each call to Values.
 		return n.drain(params)
 	}
 
+	return nil
+}
+
+func (n *insertNode) Next(params runParams) (bool, error) {
+	if n.run.drainOnStart {
+		return n.run.rowsInserted.Len() > 0, nil
+	}
 	return n.internalNext(params)
 }
 
@@ -327,9 +338,9 @@ func (n *insertNode) Close(ctx context.Context) {
 	n.tw.close(ctx)
 	n.run.rows.Close(ctx)
 	n.run.rows = nil
-	if n.run.rowsUpserted != nil {
-		n.run.rowsUpserted.Close(ctx)
-		n.run.rowsUpserted = nil
+	if n.run.rowsInserted != nil {
+		n.run.rowsInserted.Close(ctx)
+		n.run.rowsInserted = nil
 	}
 	switch t := n.tw.(type) {
 	case *tableInserter:
@@ -344,27 +355,27 @@ func (n *insertNode) Close(ctx context.Context) {
 }
 
 func (n *insertNode) Values() tree.Datums {
-	if !n.run.isUpsertReturning {
+	if !n.run.drainOnStart {
 		return n.run.resultRow
 	}
 
-	row := n.run.rowsUpserted.At(0)
-	n.run.rowsUpserted.PopFirst()
+	row := n.run.rowsInserted.At(0)
+	n.run.rowsInserted.PopFirst()
 	return row
 }
 
-// Because TableUpserter batches the upserts, we need to completely drain the
-// source and handle all the rows before returning from the first call to Next,
-// so that we can return an upserted row from each call to Values.
-func (n *insertNode) drain(params runParams) (bool, error) {
-	for !n.run.doneUpserting {
-		_, err := n.internalNext(params)
+// drain finishes all work for this insertNode, without giving the parent plan
+// a chance to see any return values from this node.
+func (n *insertNode) drain(params runParams) error {
+	moreRows := true
+	var err error
+	for moreRows {
+		moreRows, err = n.internalNext(params)
 		if err != nil {
-			return false, err
+			return err
 		}
 	}
-	hasRows := n.run.rowsUpserted.Len() > 0
-	return hasRows, nil
+	return nil
 }
 
 func (n *insertNode) internalNext(params runParams) (bool, error) {
@@ -379,8 +390,8 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 				return false, err
 			}
 
-			if n.run.isUpsertReturning {
-				n.run.rowsUpserted = sqlbase.NewRowContainer(
+			if n.run.drainOnStart {
+				n.run.rowsInserted = sqlbase.NewRowContainer(
 					params.p.session.TxnState.makeBoundAccount(),
 					sqlbase.ColTypeInfoFromResCols(n.rh.columns),
 					rows.Len(),
@@ -390,12 +401,11 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 					if err != nil {
 						return false, err
 					}
-					_, err = n.run.rowsUpserted.AddRow(params.ctx, cooked)
+					_, err = n.run.rowsInserted.AddRow(params.ctx, cooked)
 					if err != nil {
 						return false, err
 					}
 				}
-				n.run.doneUpserting = true
 			}
 		}
 		return false, err
@@ -426,7 +436,7 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 	}
 
 	// Handle regular INSERT ... RETURNING without ON CONFLICT clause
-	if !n.run.isUpsertReturning {
+	if !n.run.drainOnStart {
 		for i, val := range rowVals {
 			if n.run.rowTemplate != nil {
 				n.run.rowTemplate[n.run.rowIdxToRetIdx[i]] = val

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -270,10 +270,3 @@ EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 3  ·           limit  10
 3  scan        ·      ·
 3  ·           table  indexed@primary
-
-# Ensure that if the fast path is selected, DELETE is still a valid
-# data source (#19805).
-query I
-INSERT INTO indexed(id,value) VALUES (1,2); SELECT 1 FROM [DELETE FROM indexed]
-----
-1

--- a/pkg/sql/logictest/testdata/logic_test/statement_source
+++ b/pkg/sql/logictest/testdata/logic_test/statement_source
@@ -8,3 +8,64 @@ SELECT 1 FROM [INSERT INTO a VALUES (1, 2)]
 
 query error statement source "DELETE FROM a" does not return any columns
 SELECT 1 FROM [DELETE FROM a]
+
+# Ensure statement sources are fully consumed.
+
+query I
+SELECT * FROM [INSERT INTO a VALUES (1, 0), (2, 0) RETURNING a] LIMIT 1
+----
+1
+
+query II
+SELECT * FROM a
+----
+1 0
+2 0
+
+query II
+SELECT * FROM [UPDATE a SET a = a-1 RETURNING a, b] LIMIT 1
+----
+0 0
+
+query II
+SELECT * FROM a
+----
+0 0
+1 0
+
+query II
+SELECT * FROM [INSERT INTO a(a) VALUES (0), (1) ON CONFLICT(a) DO UPDATE SET a.a = excluded.a + 5 RETURNING a, b] LIMIT 1
+----
+5 0
+
+query II
+SELECT * FROM a
+----
+5 0
+6 0
+
+query II
+SELECT * FROM [UPSERT INTO a VALUES (5, 1), (7, 1) RETURNING a, b] LIMIT 1
+----
+5 1
+
+query II
+SELECT * FROM a
+----
+5 1
+6 0
+7 1
+
+query I
+SELECT * FROM [DELETE FROM a RETURNING a] LIMIT 1
+----
+5
+
+query II
+SELECT * FROM a
+----
+
+# Ensure errors from draining statement sources are propagated.
+
+query error duplicate key value \(a\)=\(1\) violates unique constraint "primary"
+SELECT * FROM [INSERT INTO a VALUES (1), (1) RETURNING a] LIMIT 1

--- a/pkg/sql/logictest/testdata/logic_test/statement_source
+++ b/pkg/sql/logictest/testdata/logic_test/statement_source
@@ -1,0 +1,10 @@
+# LogicTest: default parallel-stmts
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY, b INT)
+
+query error statement source "INSERT INTO a VALUES \(1, 2\)" does not return any columns
+SELECT 1 FROM [INSERT INTO a VALUES (1, 2)]
+
+query error statement source "DELETE FROM a" does not return any columns
+SELECT 1 FROM [DELETE FROM a]

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -224,11 +224,11 @@ func (p *planner) makePlan(ctx context.Context, stmt Statement) (planNode, error
 
 // startPlan starts the plan and all its sub-query nodes.
 func startPlan(params runParams, plan planNode) error {
+	// Trigger limit propagation through the plan and sub-queries.
+	params.p.setUnlimited(plan)
 	if err := startExec(params, plan); err != nil {
 		return err
 	}
-	// Trigger limit propagation through the plan and sub-queries.
-	params.p.setUnlimited(plan)
 	return nil
 }
 

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -131,7 +131,7 @@ type valuesRun struct {
 func (n *valuesNode) startExec(params runParams) error {
 	if n.rows != nil {
 		if !n.isConst {
-			log.Fatalf(params.ctx, "valuesNode evaluted twice")
+			log.Fatalf(params.ctx, "valuesNode evaluated twice")
 		}
 		return nil
 	}


### PR DESCRIPTION
Previously, DMLs within the `[]` statement source syntax wouldn't always
be fully consumed. For example, the query

```
SELECT * FROM [INSERT INTO t VALUES (1), (2)] LIMIT 1
```

would not insert any values into `t` because the insertNode didn't get
flushed. Additionally, even if the insertNode was flushed, only `1`
would be inserted, not both `1` and `2`.

Now, the inner DML statement is drained completely upon starting the plan.

Fixes #20732.
Fixes #20970.