### PR TITLE
ui: change "!" to "i" in jobs page icon

### DIFF
--- a/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
+++ b/pkg/ui/src/views/cluster/components/visualization/visualizations.styl
@@ -72,7 +72,7 @@ $viz-sides = 62px
     border-radius 50%
     border 1px solid $tooltip-color
     font-size 12px
-    line-height 14px  // Visual tweak to vertically center the exclamation mark
+    line-height 14px  // Visual tweak to vertically center the "i"
     text-align center
     color $tooltip-color
 

--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -183,7 +183,7 @@ class JobsTable extends React.Component<JobsTableProps, {}> {
         <div className="section-heading__tooltip">
           <ToolTipWrapper text={titleTooltip}>
             <div className="section-heading__tooltip-hover-area">
-              <div className="section-heading__info-icon">!</div>
+              <div className="section-heading__info-icon">i</div>
             </div>
           </ToolTipWrapper>
         </div>


### PR DESCRIPTION
Follow up to #20845

Now:
<img width="126" alt="screen shot 2017-12-20 at 2 55 23 am" src="https://user-images.githubusercontent.com/7341/34196700-447ae178-e531-11e7-8c4e-8571ca8e17e8.png">

Also, filed #20921 to factor this out into a component; we should put these all over the place to explain stuff.

Release note: None