### PR TITLE
cli, cli/sql: misc improvements

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -249,13 +249,14 @@ results of each SQL statement are printed on the standard output.`,
 Reveal the SQL statements sent implicitly by the command-line utility.`,
 	}
 
-	UnsafeUpdates = FlagInfo{
-		Name: "unsafe-updates",
+	SafeUpdates = FlagInfo{
+		Name: "safe-updates",
 		Description: `
-Allow SQL statements that may have undesired side effects. For example
-a DELETE or UPDATE without a WHERE clause. By default, such statements
-are rejected to prevent accidents. This can also be overridden in a
-session with SET sql_safe_updates = FALSE.`,
+Disable SQL statements that may have undesired side effects. For
+example a DELETE or UPDATE without a WHERE clause. By default, this
+setting is enabled (true) and such statements are rejected to prevent
+accidents. This can also be overridden in a session with SET
+sql_safe_updates = FALSE.`,
 	}
 
 	TableDisplayFormat = FlagInfo{

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -164,9 +164,9 @@ var sqlCtx = struct {
 	// execStmts is a list of statements to execute.
 	execStmts statementsValue
 
-	// unsafeUpdates indicates whether to unset
-	// sql_safe_updates in the CLI shell.
-	unsafeUpdates bool
+	// safeUpdates indicates whether to set sql_safe_updates in the CLI
+	// shell.
+	safeUpdates bool
 
 	// echo, when set, requests that SQL queries sent to the server are
 	// also printed out on the client.

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -327,7 +327,7 @@ func init() {
 	BoolFlag(zf, &zoneCtx.zoneDisableReplication, cliflags.ZoneDisableReplication, false)
 
 	VarFlag(sqlShellCmd.Flags(), &sqlCtx.execStmts, cliflags.Execute)
-	BoolFlag(sqlShellCmd.Flags(), &sqlCtx.unsafeUpdates, cliflags.UnsafeUpdates, false)
+	BoolFlag(sqlShellCmd.Flags(), &sqlCtx.safeUpdates, cliflags.SafeUpdates, true)
 
 	VarFlag(dumpCmd.Flags(), &dumpCtx.dumpMode, cliflags.DumpMode)
 	StringFlag(dumpCmd.Flags(), &dumpCtx.asOf, cliflags.DumpTime, "")

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -108,6 +108,6 @@ proc stop_server {argv} {
 
 proc force_stop_server {argv} {
     report "BEGIN FORCE STOP SERVER"
-    system "$argv quit & sleep 1; if kill -CONT `cat server_pid` 2>/dev/null; then kill -TERM `cat server pid`; sleep 1; if kill -CONT `cat server_pid` 2>/dev/null; then kill -KILL `cat server_pid`; fi; fi"
+    system "$argv quit & sleep 1; if kill -CONT `cat server_pid` 2>/dev/null; then kill -TERM `cat server_pid`; sleep 1; if kill -CONT `cat server_pid` 2>/dev/null; then kill -KILL `cat server_pid`; fi; fi"
     report "END FORCE STOP SERVER"
 }

--- a/pkg/cli/interactive_tests/test_sql_safe_updates.tcl
+++ b/pkg/cli/interactive_tests/test_sql_safe_updates.tcl
@@ -50,4 +50,10 @@ eexpect "DELETE"
 eexpect ":/# "
 end_test
 
+start_test "Check that dangerous statements are properly rejected when using --safe-updates -e."
+send "$argv sql --safe-updates -e 'delete from d.t'\r"
+eexpect "rejected: DELETE without WHERE clause"
+eexpect ":/# "
+end_test
+
 stop_server $argv

--- a/pkg/cli/interactive_tests/test_version_reporting.tcl
+++ b/pkg/cli/interactive_tests/test_version_reporting.tcl
@@ -62,15 +62,21 @@ eexpect "New ID:"
 eexpect root@
 end_test
 
-start_test "Check that the client picks up a new server version."
-force_stop_server $argv
-set env(COCKROACH_TESTING_VERSION_TAG) "fakever"
+interrupt
+eexpect eof
+
+stop_server $argv
+
+start_test "Check that the client picks up a new server version, and warns about lower versions."
+set env(COCKROACH_TESTING_VERSION_TAG) "v0.1-fakever"
 start_server $argv
+set env(COCKROACH_TESTING_VERSION_TAG) "v0.2-fakever"
+spawn $argv sql
 send "select 1;\r"
-eexpect "opening new connection"
 eexpect "# Client version: CockroachDB"
 eexpect "# Server version: CockroachDB"
 eexpect "fakever"
+eexpect "warning: server version older than client"
 eexpect root@
 end_test
 

--- a/pkg/cli/interactive_tests/test_version_reporting.tcl
+++ b/pkg/cli/interactive_tests/test_version_reporting.tcl
@@ -33,7 +33,8 @@ start_server $argv
 send "select 1;\r"
 eexpect "driver: bad connection"
 # Check that the prompt immediately succeeds the error message
-eexpect "connection lost; opening new connection: all session settings will be lost"
+eexpect "connection lost"
+eexpect "opening new connection: all session settings will be lost"
 expect {
     "\r\n# " {
 	report "unexpected server message"

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1143,15 +1143,29 @@ func runTerm(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if cliCtx.isInteractive && !sqlCtx.unsafeUpdates {
-		if err := conn.Exec("SET sql_safe_updates = TRUE", nil); err != nil {
-			return err
-		}
-	}
+	// Enable safe updates, unless disabled.
+	setupSafeUpdates(conn)
 
 	if len(sqlCtx.execStmts) > 0 {
 		// Single-line sql; run as simple as possible, without noise on stdout.
 		return runStatements(conn, sqlCtx.execStmts)
 	}
 	return runInteractive(conn)
+}
+
+// setupSafeUpdates attempts to enable "safe mode" if the session is
+// interactive and the user is not disabling this behavior with
+// --unsafe-updates.
+func setupSafeUpdates(conn *sqlConn) {
+	if !cliCtx.isInteractive || sqlCtx.unsafeUpdates {
+		// nothing to do.
+		return
+	}
+
+	if err := conn.Exec("SET sql_safe_updates = TRUE", nil); err != nil {
+		// We only enable the setting in interactive sessions. Ignoring
+		// the error with a warning is acceptable, because the user is
+		// there to decide what they want to do if it doesn't work.
+		fmt.Fprintf(stderr, "warning: cannot enable safe updates: %v\n", err)
+	}
 }

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1155,9 +1155,9 @@ func runTerm(cmd *cobra.Command, args []string) error {
 
 // setupSafeUpdates attempts to enable "safe mode" if the session is
 // interactive and the user is not disabling this behavior with
-// --unsafe-updates.
+// --safe-updates=false.
 func setupSafeUpdates(conn *sqlConn) {
-	if !cliCtx.isInteractive || sqlCtx.unsafeUpdates {
+	if !cliCtx.isInteractive || !sqlCtx.safeUpdates {
 		// nothing to do.
 		return
 	}


### PR DESCRIPTION
Fixes  #19245.
Informs #19445.

- This ensures that a 1.1+ client can connect to a 1.0 server.
- prints a warning when the server version is older, as requested in #19245.
- also renames `--unsafe-updates` (with default false) to `--safe-updates` (with default true)
- fixes a bug introduced two days ago

Will cherry-pick at least the 1st and last commit into 1.1. 

Should I also cherry-pick the other 3? In particular the 3rd which renames the flag?