### PR TITLE
sql: prevent non-constant expressions in partitionings

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -794,9 +794,13 @@ func valueEncodePartitionTuple(
 			// Fall-through.
 		}
 
-		typedExpr, err := tree.TypeCheck(expr, nil, cols[i].Type.ToDatumType())
+		typedExpr, err := sqlbase.SanitizeVarFreeExpr(expr, cols[i].Type.ToDatumType(), "partition",
+			nil /* semaCtx */, evalCtx)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, expr.String())
+			return nil, nil, err
+		}
+		if !tree.IsConst(evalCtx, typedExpr) {
+			return nil, nil, fmt.Errorf("%s: partition values must be constant", typedExpr)
 		}
 		datum, err := typedExpr.Eval(evalCtx)
 		if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -76,7 +76,7 @@ statement error CHECK expression .* may not contain variable sub-expressions
 CREATE TABLE t4 (a INT, b INT CHECK (EXISTS (SELECT * FROM t2)))
 
 # non-boolean expressions are errors
-statement error pq: incompatible type for CHECK expression: bool vs int
+statement error pq: expected CHECK expression to have type bool, but '1' has type int
 CREATE TABLE t4 (a INT CHECK(1))
 
 # Function calls in CHECK are okay.

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -1,6 +1,6 @@
 # LogicTest: default parallel-stmts distsql
 
-statement error incompatible type for DEFAULT expression: int vs bool
+statement error expected DEFAULT expression to have type int, but 'false' has type bool
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT false)
 
 statement error DEFAULT expression .* may not contain variable sub-expressions

--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -208,12 +208,12 @@ CREATE TABLE collate_de (a STRING COLLATE de PRIMARY KEY) PARTITION BY RANGE (a)
     PARTITION p2 VALUES < ('x' COLLATE de)
 )
 
-statement error value type decimal doesn't match type INT of column "a"
+statement error expected partition expression to have type int, but '1.2' has type decimal
 CREATE TABLE foo (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (1.2)
 )
 
-statement error value type decimal doesn't match type INT of column "b"
+statement error expected partition expression to have type int, but '1.2' has type decimal
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (0) PARTITION BY LIST (b) (
         PARTITION p1_1 VALUES IN (1.2)
@@ -248,6 +248,26 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) 
 statement error unimplemented: placeholders are not supported in PARTITION BY
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN ($1)
+)
+
+statement error syntax error
+CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN (SELECT 1)
+)
+
+statement error PARTITION p1: partition expression '\(SELECT 1\)' may not contain variable sub-expressions
+CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN ((SELECT 1))
+)
+
+statement error PARTITION p1: now\(\): partition values must be constant
+CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN (now())
+)
+
+statement error PARTITION p1: uuid_v4\(\) || 'foo': partition values must be constant
+CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
+    PARTITION p1 VALUES IN (uuid_v4\(\) || 'foo')
 )
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -80,7 +80,7 @@ EXECUTE a(3, 1)
 query error could not parse "foo" as type int
 EXECUTE a('foo', 1)
 
-query error incompatible type for EXECUTE parameter expression: int vs decimal
+query error expected EXECUTE parameter expression to have type int, but '3.5' has type decimal
 EXECUTE a(3.5, 1)
 
 query error aggregate functions are not allowed in EXECUTE parameters
@@ -152,7 +152,7 @@ EXECUTE i(2)
 query error could not parse "foo" as type int
 EXECUTE i('foo')
 
-query error incompatible type for EXECUTE parameter expression: int vs decimal
+query error expected EXECUTE parameter expression to have type int, but '2.3' has type decimal
 EXECUTE i(2.3)
 
 query I

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -820,6 +820,13 @@ func (v *isConstVisitor) run(expr Expr) bool {
 	return v.isConst
 }
 
+// IsConst returns whether the expression is constant. A constant expression
+// does not contain variables, as defined by ContainsVars, nor impure functions.
+func IsConst(evalCtx *EvalContext, expr Expr) bool {
+	v := isConstVisitor{ctx: evalCtx}
+	return v.run(expr)
+}
+
 // isVar returns true if the expression's value can vary during plan
 // execution.
 func isVar(evalCtx *EvalContext, expr Expr) bool {


### PR DESCRIPTION
Addresses half of #20877.
Fixes #20871.