### PR TITLE
sql: harmonize duplicate partition errors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -114,19 +114,19 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p2 VALUES IN (1)
 )
 
-statement error prefix \(DEFAULT\) cannot be present in more than one partition
+statement error \(DEFAULT\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (DEFAULT),
     PARTITION p2 VALUES IN (DEFAULT)
 )
 
-statement error prefix \(1, 2, DEFAULT\) cannot be present in more than one partition
+statement error \(1, 2, DEFAULT\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a, b, c) (
     PARTITION p1 VALUES IN ((1, 2, DEFAULT)),
     PARTITION p2 VALUES IN ((1, 2, DEFAULT))
 )
 
-statement error prefix \(1, DEFAULT\) cannot be present in more than one partition
+statement error \(1, DEFAULT, DEFAULT\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a, b, c) (
     PARTITION p1 VALUES IN ((1, DEFAULT, DEFAULT)),
     PARTITION p2 VALUES IN ((1, DEFAULT, DEFAULT))
@@ -141,6 +141,14 @@ CREATE TABLE t (a DECIMAL PRIMARY KEY) PARTITION BY LIST (a) (
 statement error PARTITION p1: non-DEFAULT value \(1\) not allowed after DEFAULT
 CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
     PARTITION p1 VALUES IN ((DEFAULT, 1))
+)
+
+# Ensure this error takes precedence over the "cannot be present in more than
+# one partition" error.
+statement error PARTITION p1: non-DEFAULT value \(1\) not allowed after DEFAULT
+CREATE TABLE t (a INT, b INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b) (
+    PARTITION p1 VALUES IN ((DEFAULT, 1)),
+    PARTITION p2 VALUES IN ((DEFAULT, 1))
 )
 
 statement error values must be strictly increasing: \(1\) is out of order
@@ -161,13 +169,13 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY RANGE (a) 
     PARTITION p2 VALUES < 1
 )
 
-statement error prefix \(1, 2, MAXVALUE\) cannot be present in more than one partition
+statement error \(1, 2, MAXVALUE\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY RANGE (a, b, c) (
     PARTITION p1 VALUES < (1, 2, MAXVALUE),
     PARTITION p2 VALUES < (1, 2, MAXVALUE)
 )
 
-statement error prefix \(1, MAXVALUE\) cannot be present in more than one partition
+statement error \(1, MAXVALUE, MAXVALUE\) cannot be present in more than one partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY RANGE (a, b, c) (
     PARTITION p1 VALUES < (1, MAXVALUE, MAXVALUE),
     PARTITION p2 VALUES < (1, MAXVALUE, MAXVALUE)

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1377,9 +1377,9 @@ func TranslateValueEncodingToSpan(
 	return datums, key, nil
 }
 
-func printPartitioningPrefix(datums []tree.Datum, s string) string {
+func printPartitioningPrefix(datums []tree.Datum, numColumns int, s string) string {
 	var buf bytes.Buffer
-	PrintPartitioningTuple(&buf, datums, len(datums)+1, s)
+	PrintPartitioningTuple(&buf, datums, numColumns, s)
 	return buf.String()
 }
 
@@ -1478,12 +1478,8 @@ func (desc *TableDescriptor) validatePartitioningDescriptor(
 					return fmt.Errorf("PARTITION %s: %v", p.Name, err)
 				}
 				if _, exists := listValues[string(keyPrefix)]; exists {
-					if len(datums) != int(partDesc.NumColumns) {
-						return fmt.Errorf("prefix (%s) cannot be present in more than one partition",
-							printPartitioningPrefix(datums, "DEFAULT"))
-					}
-					return fmt.Errorf("%s cannot be present in more than one partition",
-						tree.AsString(datums))
+					return fmt.Errorf("(%s) cannot be present in more than one partition",
+						printPartitioningPrefix(datums, int(partDesc.NumColumns), "DEFAULT"))
 				}
 				listValues[string(keyPrefix)] = struct{}{}
 			}
@@ -1514,12 +1510,8 @@ func (desc *TableDescriptor) validatePartitioningDescriptor(
 				return fmt.Errorf("PARTITION %s: %v", p.Name, err)
 			}
 			if _, exists := rangeValues[string(endKey)]; exists {
-				if len(datums) != int(partDesc.NumColumns) {
-					return fmt.Errorf("prefix (%s) cannot be present in more than one partition",
-						printPartitioningPrefix(datums, "MAXVALUE"))
-				}
-				return fmt.Errorf("%s cannot be present in more than one partition",
-					tree.AsString(datums))
+				return fmt.Errorf("(%s) cannot be present in more than one partition",
+					printPartitioningPrefix(datums, int(partDesc.NumColumns), "MAXVALUE"))
 			}
 
 			rangeValues[string(endKey)] = struct{}{}


### PR DESCRIPTION
Previously, an invalid partitioning scheme like

    ... PARTITION BY LIST (a, b, c) (
      PARTITION p1 VALUES IN (1, 2, 3)
      PARTITION p2 VALUES IN (1, 2, 3)
    )

would result in an error message like "(1, 2, 3) cannot be present in
more than one partition," but an invalid partitioning scheme involving
DEFAULT, like

    ... PARTITION BY LIST (a, b, c) (
      PARTITION p1 VALUES IN (1, DEFAULT, DEFAULT)
      PARTITION p2 VALUES IN (1, DEFAULT, DEFAULT)
    )

would result in a more confusing error message like "prefix (1, DEFAULT)
cannot be present in more than one partition". Similarly for MAXVALUE.

Since the only thing that can appear after DEFAULT is another DEFAULT,
we can unify the error messages and simply say "(1, DEFAULT, DEFAULT)
cannot be present in more than one partition."

Release note: None