### PR TITLE
opt: index constraints for tuple inequalities

### DIFF
--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -438,6 +438,8 @@ func (c *indexConstraintCalc) makeSpansForSingleColumn(
 		spans := LogicalSpans{MakeFullSpan(), MakeFullSpan()}
 		spans[0].End = LogicalKey{Vals: tree.Datums{datum}, Inclusive: false}
 		spans[1].Start = LogicalKey{Vals: tree.Datums{datum}, Inclusive: false}
+		c.preferInclusive(offset, &spans[0])
+		c.preferInclusive(offset, &spans[1])
 		return spans, true
 
 	default:

--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -447,13 +447,119 @@ func (c *indexConstraintCalc) makeSpansForSingleColumn(
 	}
 }
 
+// makeSpansForTupleInequality creates spans for index columns starting at
+// <offset> from a tuple inequality.
+// Assumes that e.op is an inequality and both sides are tuples.
+func (c *indexConstraintCalc) makeSpansForTupleInequality(
+	offset int, e *expr,
+) (LogicalSpans, bool) {
+	lhs, rhs := e.children[0], e.children[1]
+
+	// Find the longest prefix of the tuple that maps to index columns (with the
+	// same direction) starting at <offset>.
+	prefixLen := 0
+	dir := c.colInfos[offset].direction
+	for i := range lhs.children {
+		if !isIndexedVar(lhs.children[i], offset+i) {
+			// Variable doesn't refer to the right column.
+			break
+		}
+		if rhs.children[i].op != constOp {
+			// Right-hand value is not a constant.
+			break
+		}
+		if c.colInfos[offset+i].direction != dir {
+			// The direction changed. For example:
+			//   a ASCENDING, b DESCENDING, c ASCENDING
+			//   (a, b, c) >= (1, 2, 3)
+			// We can only use a >= 1 here.
+			//
+			// TODO(radu): we could support inequalities for cases like this by
+			// allowing negation, for example:
+			//  (a, -b, c) >= (1, -2, 3)
+			break
+		}
+		prefixLen++
+	}
+	if prefixLen == 0 {
+		return nil, false
+	}
+
+	datums := make(tree.Datums, prefixLen)
+	for i := range datums {
+		datums[i] = rhs.children[i].private.(tree.Datum)
+	}
+
+	// less is true if the op is < or <= and false if the op is > or >=.
+	// inclusive is true if the op is <= or >= and false if the op is < or >.
+	var less, inclusive bool
+
+	switch e.op {
+	case neOp:
+		if prefixLen < len(lhs.children) {
+			// If we have (a, b, c) != (1, 2, 3), we cannot
+			// determine any constraint on (a, b).
+			return nil, false
+		}
+		spans := LogicalSpans{MakeFullSpan(), MakeFullSpan()}
+		spans[0].End = LogicalKey{Vals: datums, Inclusive: false}
+		// We don't want the spans to alias each other, the preferInclusive
+		// calls below could mangle them.
+		datumsCopy := append([]tree.Datum(nil), datums...)
+		spans[1].Start = LogicalKey{Vals: datumsCopy, Inclusive: false}
+		c.preferInclusive(offset, &spans[0])
+		c.preferInclusive(offset, &spans[1])
+		return spans, true
+
+	case ltOp:
+		less, inclusive = true, false
+	case leOp:
+		less, inclusive = true, true
+	case gtOp:
+		less, inclusive = false, false
+	case geOp:
+		less, inclusive = false, true
+	default:
+		panic(fmt.Sprintf("unsupported op %s", e.op))
+	}
+
+	if prefixLen < len(lhs.children) {
+		// If we only keep a prefix, exclusive inequalities become exclusive.
+		// For example:
+		//   (a, b, c) > (1, 2, 3) becomes (a, b) >= (1, 2)
+		inclusive = true
+	}
+
+	if dir == encoding.Descending {
+		// If the direction is descending, the inequality is reversed.
+		less = !less
+	}
+
+	sp := MakeFullSpan()
+	if less {
+		sp.End = LogicalKey{Vals: datums, Inclusive: inclusive}
+	} else {
+		sp.Start = LogicalKey{Vals: datums, Inclusive: inclusive}
+	}
+	c.preferInclusive(offset, &sp)
+	return LogicalSpans{sp}, true
+}
+
 // makeSpansForExpr creates spans for index columns starting at <offset>
 // from the given expression.
 func (c *indexConstraintCalc) makeSpansForExpr(offset int, e *expr) (LogicalSpans, bool) {
 	// Check for an operation where the left-hand side is an
 	// indexed var for this column.
-	if isIndexedVar(e.children[0], offset) {
+	if len(e.children) > 0 && isIndexedVar(e.children[0], offset) {
 		return c.makeSpansForSingleColumn(offset, e.op, e.children[1])
+	}
+	// Check for tuple operations.
+	if len(e.children) == 2 && e.children[0].op == orderedListOp && e.children[1].op == orderedListOp {
+		switch e.op {
+		case ltOp, leOp, gtOp, geOp, neOp:
+			// Tuple inequality.
+			return c.makeSpansForTupleInequality(offset, e)
+		}
 	}
 	return nil, false
 }

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -21,14 +21,14 @@ build-scalar,normalize,index-constraints columns=(int descending)
 build-scalar,normalize,index-constraints columns=(int)
 @1 != 2
 ----
-[ - /2)
-(/2 - ]
+[ - /1]
+[/3 - ]
 
 build-scalar,normalize,index-constraints columns=(int descending)
 @1 != 2
 ----
-[ - /2)
-(/2 - ]
+[ - /3]
+[/1 - ]
 
 build-scalar,normalize,index-constraints columns=(int)
 @1 < 2
@@ -70,11 +70,23 @@ build-scalar,normalize,index-constraints columns=(int, int descending)
 ----
 [/3/4 - ]
 
+build-scalar,normalize,index-constraints columns=(int, int)
+@1 != 1 AND @2 > 5
+----
+[ - /0]
+[/2/6 - ]
+
+build-scalar,normalize,index-constraints columns=(int, int)
+@1 != 1 AND @2 < 5
+----
+[ - /0/4]
+[/2 - ]
+
 build-scalar,normalize,index-constraints columns=(int)
 @1 >= 1 AND @1 <= 5 AND @1 != 3
 ----
-[/1 - /3)
-(/3 - /5]
+[/1 - /2]
+[/4 - /5]
 
 build-scalar,normalize,index-constraints columns=(int, int)
 @1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
@@ -118,8 +130,8 @@ build-scalar,normalize,index-constraints columns=(int)
 build-scalar,normalize,index-constraints columns=(int, int)
 @1 = 1 AND @2 != 2
 ----
-[/1 - /1/2)
-(/1/2 - /1]
+[/1 - /1/1]
+[/1/3 - /1]
 
 build-scalar,normalize,index-constraints columns=(int, int)
 @1 >= 1 AND @1 <= 5 AND @2 != 2

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -3,7 +3,7 @@ build-scalar,normalize,index-constraints columns=(int)
 ----
 [/3 - ]
 
-build-scalar,normalize,index-constraints columns=(int descending)
+build-scalar,normalize,index-constraints columns=(int desc)
 @1 > 2
 ----
 [ - /3]
@@ -13,7 +13,7 @@ build-scalar,normalize,index-constraints columns=(int)
 ----
 [/2 - ]
 
-build-scalar,normalize,index-constraints columns=(int descending)
+build-scalar,normalize,index-constraints columns=(int desc)
 @1 >= 2
 ----
 [ - /2]
@@ -24,7 +24,7 @@ build-scalar,normalize,index-constraints columns=(int)
 [ - /1]
 [/3 - ]
 
-build-scalar,normalize,index-constraints columns=(int descending)
+build-scalar,normalize,index-constraints columns=(int desc)
 @1 != 2
 ----
 [ - /3]
@@ -35,7 +35,7 @@ build-scalar,normalize,index-constraints columns=(int)
 ----
 [ - /1]
 
-build-scalar,normalize,index-constraints columns=(int descending)
+build-scalar,normalize,index-constraints columns=(int desc)
 @1 < 2
 ----
 [/1 - ]
@@ -45,7 +45,7 @@ build-scalar,normalize,index-constraints columns=(int)
 ----
 [/2 - /2]
 
-build-scalar,normalize,index-constraints columns=(int descending)
+build-scalar,normalize,index-constraints columns=(int desc)
 @1 = 2
 ----
 [/2 - /2]
@@ -65,7 +65,7 @@ build-scalar,normalize,index-constraints columns=(int, int)
 ----
 [/3/6 - ]
 
-build-scalar,normalize,index-constraints columns=(int, int descending)
+build-scalar,normalize,index-constraints columns=(int, int desc)
 @1 > 2 AND @2 < 5
 ----
 [/3/4 - ]
@@ -93,12 +93,12 @@ build-scalar,normalize,index-constraints columns=(int, int)
 ----
 [/1/8 - /2/9]
 
-build-scalar,normalize,index-constraints columns=(int descending, int)
+build-scalar,normalize,index-constraints columns=(int desc, int)
 @1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
 ----
 [/2/8 - /1/9]
 
-build-scalar,normalize,index-constraints columns=(int, int descending)
+build-scalar,normalize,index-constraints columns=(int, int desc)
 @1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
 ----
 [/1/9 - /2/8]
@@ -149,12 +149,12 @@ build-scalar,normalize,index-constraints columns=(string, int)
 ----
 [/e'a\x00'/5 - /'z')
 
-build-scalar,normalize,index-constraints columns=(string descending)
+build-scalar,normalize,index-constraints columns=(string desc)
 @1 > 'a' AND @1 < 'z'
 ----
 (/'z' - /e'a\x00']
 
-build-scalar,normalize,index-constraints columns=(string descending, int)
+build-scalar,normalize,index-constraints columns=(string desc, int)
 @1 > 'a' AND @1 < 'z' AND @2 = 5
 ----
 (/'z' - /e'a\x00'/5]
@@ -177,6 +177,8 @@ build-scalar,normalize,index-constraints columns=(decimal, decimal)
 ----
 (/1.5 - ]
 
+# Tests with variable IN tuple.
+
 build-scalar,normalize,index-constraints columns=(int)
 @1 IN (1, 2, 3)
 ----
@@ -184,21 +186,21 @@ build-scalar,normalize,index-constraints columns=(int)
 [/2 - /2]
 [/3 - /3]
 
-build-scalar,normalize,index-constraints columns=(int descending)
+build-scalar,normalize,index-constraints columns=(int desc)
 @1 IN (1, 2, 3)
 ----
 [/3 - /3]
 [/2 - /2]
 [/1 - /1]
 
-build-scalar,legacy-normalize,index-constraints columns=(int)
+legacy-normalize,build-scalar,index-constraints columns=(int)
 @1 IN (1, 5, 1, 4)
 ----
 [/1 - /1]
 [/4 - /4]
 [/5 - /5]
 
-build-scalar,legacy-normalize,index-constraints columns=(int descending)
+legacy-normalize,build-scalar,index-constraints columns=(int desc)
 @1 IN (1, 5, 1, 4)
 ----
 [/5 - /5]
@@ -212,7 +214,7 @@ build-scalar,normalize,index-constraints columns=(int, int)
 [/1/2 - /1/2]
 [/1/3 - /1/3]
 
-build-scalar,normalize,index-constraints columns=(int, int descending)
+build-scalar,normalize,index-constraints columns=(int, int desc)
 @1 = 1 AND @2 IN (1, 2, 3)
 ----
 [/1/3 - /1/3]
@@ -229,7 +231,7 @@ build-scalar,normalize,index-constraints columns=(int, int)
 [/2/2 - /2/2]
 [/2/3 - /2/3]
 
-build-scalar,normalize,index-constraints columns=(int descending, int descending)
+build-scalar,normalize,index-constraints columns=(int desc, int desc)
 @1 IN (1, 2) AND @2 IN (1, 2, 3)
 ----
 [/2/3 - /2/3]
@@ -244,7 +246,7 @@ build-scalar,normalize,index-constraints columns=(int, int)
 ----
 [/2/1 - /4/3]
 
-build-scalar,normalize,index-constraints columns=(int descending, int descending)
+build-scalar,normalize,index-constraints columns=(int desc, int desc)
 @1 >= 2 AND @1 <= 4 AND @2 IN (1, 2, 3)
 ----
 [/4/3 - /2/1]
@@ -257,14 +259,14 @@ build-scalar,normalize,index-constraints columns=(int, int)
 [/2/4 - /2/4]
 [/3/4 - /3/4]
 
-build-scalar,normalize,index-constraints columns=(int descending, int)
+build-scalar,normalize,index-constraints columns=(int desc, int)
 @1 IN (1, 2, 3) AND @2 = 4
 ----
 [/3/4 - /3/4]
 [/2/4 - /2/4]
 [/1/4 - /1/4]
 
-build-scalar,normalize,index-constraints columns=(int, int descending)
+build-scalar,normalize,index-constraints columns=(int, int desc)
 @1 IN (1, 2, 3) AND @2 = 4
 ----
 [/1/4 - /1/4]
@@ -277,6 +279,8 @@ build-scalar,normalize,index-constraints columns=(int, int)
 [/1/2 - /1/4]
 [/2/2 - /2/4]
 [/3/2 - /3/4]
+
+# Tests with tuple equality.
 
 build-scalar,normalize,index-constraints columns=(int, int, int)
 (@1, @2, @3) = (1, 2, 3)
@@ -298,7 +302,95 @@ build-scalar,normalize,index-constraints columns=(int, int, int, int)
 ----
 [/6/2/3/4 - /9/2/3/4]
 
-build-scalar,normalize,index-constraints columns=(int descending, int descending, int descending, int descending)
+build-scalar,normalize,index-constraints columns=(int desc, int desc, int desc, int desc)
 @1 > 5 AND @1 < 10 AND (@2, @3, @4) = (2, 3, 4)
 ----
 [/9/2/3/4 - /6/2/3/4]
+
+# Tests with tuple inequalities.
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) >= (1, 2, 3)
+----
+[/1/2/3 - ]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) >= (1, 2, @1)
+----
+[/1/2 - ]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) > (1, 2, 3)
+----
+[/1/2/4 - ]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) > (1, 2, @1)
+----
+[/1/2 - ]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) <= (1, 2, 3)
+----
+[ - /1/2/3]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) <= (1, 2, @1)
+----
+[ - /1/2]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) < (1, 2, 3)
+----
+[ - /1/2/2]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) < (1, 2, @1)
+----
+[ - /1/2]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/2]
+[/1/2/4 - ]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) != (1, 2, @1)
+----
+[ - ]
+
+build-scalar,normalize,index-constraints columns=(int desc, int desc, int desc)
+(@1, @2, @3) >= (1, 2, 3)
+----
+[ - /1/2/3]
+
+build-scalar,normalize,index-constraints columns=(int desc, int desc, int)
+(@1, @2, @3) > (1, 2, 3)
+----
+[ - /1/2]
+
+build-scalar,normalize,index-constraints columns=(int, int, int desc)
+(@1, @2, @3) > (1, 2, 3)
+----
+[/1/2 - ]
+
+build-scalar,normalize,index-constraints columns=(int, int, int desc)
+(@2, @3) > (1, 2)
+----
+[ - ]
+
+build-scalar,normalize,index-constraints columns=(int, int)
+(@1, @2) >= (1, 2) AND (@1, @2) <= (3, 4)
+----
+[/1/2 - /3/4]
+
+legacy-normalize,build-scalar,index-constraints columns=(int, int)
+(@1, @2) BETWEEN (1, 2) AND (3, 4)
+----
+[/1/2 - /3/4]
+
+legacy-normalize,build-scalar,index-constraints columns=(int, int, int, int)
+(@1, @2, @4) BETWEEN (1, 2, 3) AND (4, 5, 6)
+----
+[/1/2 - /4/5]


### PR DESCRIPTION
#### opt: prefer inclusive constraints for neOp

A slight omission in the handling of NE: we still want the spans to be
inclusive if possible (to allow extending them with more constraints).

Release note: None

#### opt: index constraints for tuple inequalities

Support for tuple inequalities like `(a, b, c) > (1, 2, 3)`.

This code is more functional than the legacy index constraints code:
 - we support restricting the inequalities to a prefix, e.g.
   `(a, b, c) > (1, 2, 3)  ->  (a, b) >= (1, 2)` (#6390).
 - we correctly handle cases like `(a, b) BETWEEN (1, 2) AND (3, 4))`
   (#20504).

Minor changes to opt test: support `asc/desc` and switch the order of
`legacy-normalize` and `build-scalar` in tests (we don't want to build
a scalar before doing the normalization).

Release note: None