### PR TITLE
sql: fix nondeterminism in logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -364,7 +364,7 @@ ROLLBACK
 statement ok
 INSERT INTO txn_test (something) VALUES ('baz')
 
-query IT
+query IT rowsort
 SELECT * FROM txn_test
 ----
 1 foo


### PR DESCRIPTION
...by adding a `rowsort`.

Fixes #20920

Release note: None