### PR TITLE
sql, distsql: move projection out of sortNode by adding a parent render node

### DIFF
--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -170,16 +170,10 @@ func (p *planner) distinct(
 	// We add a post renderNode if DISTINCT ON introduced additional render
 	// expressions.
 	if len(origRender) < len(r.render) {
-		src := planDataSource{info: newSourceInfoForSingleTable(anonymousTable, origColumns), plan: d}
-		postRender := &renderNode{
-			source:     src,
-			sourceInfo: multiSourceInfo{src.info},
-		}
-		postRender.ivarHelper = tree.MakeIndexedVarHelper(postRender, len(src.info.sourceColumns))
-		if err := p.initTargets(ctx, postRender, tree.SelectExprs{tree.SelectExpr{Expr: &tree.AllColumnsSelector{}}}, nil /* desiredTypes */); err != nil {
+		var err error
+		if plan, err = p.insertRender(ctx, d, &anonymousTable, origColumns); err != nil {
 			return nil, nil, err
 		}
-		plan = postRender
 	}
 
 	return plan, d, nil

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -851,6 +851,11 @@ func (dsp *DistSQLPlanner) selectRenders(
 // addSorters adds sorters corresponding to a sortNode and updates the plan to
 // reflect the sort node.
 func (dsp *DistSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
+	if !n.needSort {
+		// This node exists only to keep track of an ordering requirement,
+		// we don't need to do anything.
+		return
+	}
 
 	matchLen := planPhysicalProps(n.plan).computeMatch(n.ordering)
 
@@ -881,29 +886,6 @@ func (dsp *DistSQLPlanner) addSorters(p *physicalPlan, n *sortNode) {
 			p.ResultTypes,
 			ordering,
 		)
-	}
-
-	if len(n.columns) != len(p.planToStreamColMap) {
-		// In cases like:
-		//   SELECT a FROM t ORDER BY b
-		// we have columns (b) that are only used for sorting. These columns are not
-		// in the output columns of the sortNode; we set a projection such that the
-		// plan results map 1-to-1 to sortNode columns.
-		//
-		// Note that internally, AddProjection might retain more columns than
-		// necessary so we can preserve the p.Ordering between parallel streams
-		// when they merge later.
-		p.planToStreamColMap = p.planToStreamColMap[:len(n.columns)]
-		columns := make([]uint32, 0, len(n.columns))
-		for i, col := range p.planToStreamColMap {
-			if col < 0 {
-				// This column isn't needed; ignore it.
-				continue
-			}
-			p.planToStreamColMap[i] = len(columns)
-			columns = append(columns, uint32(col))
-		}
-		p.AddProjection(columns)
 	}
 }
 

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -29,9 +29,8 @@ import (
 // fails.
 func (p *planner) expandPlan(ctx context.Context, plan planNode) (planNode, error) {
 	var err error
-	plan, err = doExpandPlan(ctx, p, noParams, plan)
-	if err != nil {
-		return plan, err
+	if plan, err = doExpandPlan(ctx, p, noParams, plan); err != nil {
+		return nil, err
 	}
 	plan = p.simplifyOrderings(plan, nil)
 
@@ -193,7 +192,7 @@ func doExpandPlan(
 
 		if s, ok := n.plan.(*sortNode); ok {
 			// (... ORDER BY x) ORDER BY y -> keep the outer sort
-			elideDoubleSort(n, s)
+			n.plan = s.plan
 		}
 
 		// Check to see if the requested ordering is compatible with the existing
@@ -266,17 +265,6 @@ func doExpandPlan(
 		panic(fmt.Sprintf("unhandled node type: %T", plan))
 	}
 	return plan, err
-}
-
-// elideDoubleSort removes the source sortNode because it is
-// redundant.
-func elideDoubleSort(parent, source *sortNode) {
-	parent.plan = source.plan
-	// Propagate renamed columns
-	mutSourceCols := planMutableColumns(parent.plan)
-	for i, col := range parent.columns {
-		mutSourceCols[i].Name = col.Name
-	}
 }
 
 func expandDistinctNode(
@@ -571,23 +559,18 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 				n.plan = p.simplifyOrderings(n.plan, sortOrder)
 			}
 		}
-
 		if !n.needSort {
-			if len(n.columns) < len(planColumns(n.plan)) {
-				// No sorting required, but we have to strip off the extra render
-				// expressions we added. So keep the sort node.
-				// TODO(radu): replace with a renderNode
-			} else {
-				// Sort node fully disappears.
-				// Just be sure to propagate the column names.
-				mutSourceCols := planMutableColumns(n.plan)
-				for i, col := range n.columns {
-					mutSourceCols[i].Name = col.Name
+			containsOrdering := true
+			for _, o := range planPhysicalProps(n.plan).ordering {
+				if o.ColIdx >= len(n.needed) || !n.needed[o.ColIdx] {
+					containsOrdering = false
+					break
 				}
+			}
+			if containsOrdering {
 				plan = n.plan
 			}
 		}
-
 	case *distinctNode:
 		// distinctNode uses the ordering computed from its source but
 		// trimmed to the DISTINCT ON columns (if applicable).

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -184,8 +184,7 @@ EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v
 ----
 delete          ·      ·
  │              from   unindexed
- └── nosort     ·      ·
-      │         order  +v
+ └── render     ·      ·
       └── scan  ·      ·
 ·               table  unindexed@primary
 ·               spans  ALL

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -147,13 +147,14 @@ SELECT DISTINCT y AS w FROM xyz ORDER by z
 query TTT
 EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY z
 ----
-distinct             ·      ·
- └── nosort          ·      ·
-      │              order  +z
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  xyz@foo
-·                    spans  ALL
+distinct                  ·      ·
+ └── render               ·      ·
+      └── nosort          ·      ·
+           │              order  +z
+           └── render     ·      ·
+                └── scan  ·      ·
+·                         table  xyz@foo
+·                         spans  ALL
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by y

--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -331,18 +331,21 @@ SELECT DISTINCT ON (a) a, b, c FROM abc ORDER BY a, b, c
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-distinct             0  distinct  ·            ·            (a, c)     a!=NULL; c!=NULL; key(a); +a
- │                   0  ·         distinct on  a            ·          ·
- │                   0  ·         order key    a            ·          ·
- └── sort            1  sort      ·            ·            (a, c)     a!=NULL; c!=NULL; +a,-c
-      │              1  ·         order        +a,-c,+b     ·          ·
-      └── render     2  render    ·            ·            (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b); +a
-           │         2  ·         render 0     test.abc.a   ·          ·
-           │         2  ·         render 1     test.abc.c   ·          ·
-           │         2  ·         render 2     test.abc.b   ·          ·
-           └── scan  3  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
-·                    3  ·         table        abc@primary  ·          ·
-·                    3  ·         spans        ALL          ·          ·
+distinct                  0  distinct  ·            ·            (a, c)     a!=NULL; c!=NULL; key(a); +a
+ │                        0  ·         distinct on  a            ·          ·
+ │                        0  ·         order key    a            ·          ·
+ └── render               1  render    ·            ·            (a, c)     a!=NULL; c!=NULL; +a,-c
+      │                   1  ·         render 0     a            ·          ·
+      │                   1  ·         render 1     c            ·          ·
+      └── sort            2  sort      ·            ·            (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b); +a,-c,+b
+           │              2  ·         order        +a,-c,+b     ·          ·
+           └── render     3  render    ·            ·            (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b); +a
+                │         3  ·         render 0     test.abc.a   ·          ·
+                │         3  ·         render 1     test.abc.c   ·          ·
+                │         3  ·         render 2     test.abc.b   ·          ·
+                └── scan  4  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
+·                         4  ·         table        abc@primary  ·          ·
+·                         4  ·         spans        ALL          ·          ·
 
 query TT
 SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b

--- a/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
@@ -196,14 +196,17 @@ SELECT DISTINCT ON (a,b,c) a, b, c FROM abc
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c
 ----
-distinct        0  distinct  ·            ·            (a, b)     a!=NULL; b!=NULL; key(a,b); +a,+b
- │              0  ·         distinct on  a, b         ·          ·
- │              0  ·         order key    a, b         ·          ·
- └── nosort     1  nosort    ·            ·            (a, b)     a!=NULL; b!=NULL; +a,+b
-      │         1  ·         order        +a,+b,+c     ·          ·
-      └── scan  2  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b,+c
-·               2  ·         table        abc@primary  ·          ·
-·               2  ·         spans        ALL          ·          ·
+distinct             0  distinct  ·            ·            (a, b)     a!=NULL; b!=NULL; key(a,b); +a,+b
+ │                   0  ·         distinct on  a, b         ·          ·
+ │                   0  ·         order key    a, b         ·          ·
+ └── render          1  render    ·            ·            (a, b)     a!=NULL; b!=NULL; +a,+b
+      │              1  ·         render 0     a            ·          ·
+      │              1  ·         render 1     b            ·          ·
+      └── nosort     2  nosort    ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b,+c
+           │         2  ·         order        +a,+b,+c     ·          ·
+           └── scan  3  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b,+c
+·                    3  ·         table        abc@primary  ·          ·
+·                    3  ·         spans        ALL          ·          ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c]

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -210,23 +210,24 @@ render            ·     ·
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo
 ----
-sort                                       ·         ·
- │                                         order     +ordinal_position
- └── render                                ·         ·
-      └── group                            ·         ·
-           │                               group by  @1-@5
-           └── render                      ·         ·
-                └── join                   ·         ·
-                     │                     type      left outer
-                     │                     equality  (column_name) = (column_name)
-                     ├── render            ·         ·
-                     │    └── filter       ·         ·
-                     │         └── values  ·         ·
-                     │                     size      16 columns, 751 rows
-                     └── render            ·         ·
-                          └── filter       ·         ·
-                               └── values  ·         ·
-·                                          size      13 columns, 37 rows
+render                                          ·         ·
+ └── sort                                       ·         ·
+      │                                         order     +ordinal_position
+      └── render                                ·         ·
+           └── group                            ·         ·
+                │                               group by  @1-@5
+                └── render                      ·         ·
+                     └── join                   ·         ·
+                          │                     type      left outer
+                          │                     equality  (column_name) = (column_name)
+                          ├── render            ·         ·
+                          │    └── filter       ·         ·
+                          │         └── values  ·         ·
+                          │                     size      16 columns, 751 rows
+                          └── render            ·         ·
+                               └── filter       ·         ·
+                                    └── values  ·         ·
+·                                               size      13 columns, 37 rows
 
 query TTT
 EXPLAIN SHOW GRANTS ON foo

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -83,11 +83,10 @@ render              0  render    ·  ·  (x)              x=CONST
 query TITTTTT
 EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y, 3 AS z) ORDER BY y
 ----
-nosort                   0  nosort    ·      ·   (x)                 x=CONST
- │                       0  ·         order  +y  ·                   ·
- └── render              1  render    ·      ·   (x, y)              x=CONST; y=CONST
-      └── render         2  render    ·      ·   (x, y, z[omitted])  x=CONST; y=CONST
-           └── emptyrow  3  emptyrow  ·      ·   ()                  ·
+render                   0  render    ·  ·  (x)                          x=CONST
+ └── render              1  render    ·  ·  (x, y[omitted])              x=CONST; y=CONST
+      └── render         2  render    ·  ·  (x, y[omitted], z[omitted])  x=CONST; y=CONST
+           └── emptyrow  3  emptyrow  ·  ·  ()                           ·
 
 # Propagation to sub-queries.
 query TITTTTT

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -95,18 +95,20 @@ SELECT a, b FROM t ORDER BY b DESC LIMIT 2
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT c FROM t ORDER BY b LIMIT 2
 ----
-limit                     0  limit     ·         ·          (c)                 weak-key(c)
- │                        0  ·         count     2          ·                   ·
- └── distinct             1  distinct  ·         ·          (c)                 weak-key(c)
-      └── sort            2  sort      ·         ·          (c)                 ·
-           │              2  ·         order     +b         ·                   ·
-           │              2  ·         strategy  iterative  ·                   ·
-           └── render     3  render    ·         ·          (c, b)              ·
-                │         3  ·         render 0  test.t.c   ·                   ·
-                │         3  ·         render 1  test.t.b   ·                   ·
-                └── scan  4  scan      ·         ·          (a[omitted], b, c)  a!=NULL; key(a)
-·                         4  ·         table     t@primary  ·                   ·
-·                         4  ·         spans     ALL        ·                   ·
+limit                          0  limit     ·         ·          (c)                 weak-key(c)
+ │                             0  ·         count     2          ·                   ·
+ └── distinct                  1  distinct  ·         ·          (c)                 weak-key(c)
+      └── render               2  render    ·         ·          (c)                 ·
+           │                   2  ·         render 0  c          ·                   ·
+           └── sort            3  sort      ·         ·          (c, b)              +b
+                │              3  ·         order     +b         ·                   ·
+                │              3  ·         strategy  iterative  ·                   ·
+                └── render     4  render    ·         ·          (c, b)              ·
+                     │         4  ·         render 0  test.t.c   ·                   ·
+                     │         4  ·         render 1  test.t.b   ·                   ·
+                     └── scan  5  scan      ·         ·          (a[omitted], b, c)  a!=NULL; key(a)
+·                              5  ·         table     t@primary  ·                   ·
+·                              5  ·         spans     ALL        ·                   ·
 
 query B
 SELECT DISTINCT c FROM t ORDER BY b DESC LIMIT 2
@@ -156,45 +158,49 @@ SELECT b FROM t ORDER BY a DESC
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC
 ----
-nosort             ·      ·
- │                 order  -a
- └── render        ·      ·
-      └── revscan  ·      ·
-·                  table  t@primary
-·                  spans  ALL
+render                  ·      ·
+ └── nosort             ·      ·
+      │                 order  -a
+      └── render        ·      ·
+           └── revscan  ·      ·
+·                       table  t@primary
+·                       spans  ALL
 
 # Check that LIMIT propagates past nosort nodes.
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a LIMIT 1
 ----
-limit                ·      ·
- └── nosort          ·      ·
-      │              order  +a
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  t@primary
-·                    spans  ALL
-·                    limit  1
+limit                     ·      ·
+ └── render               ·      ·
+      └── nosort          ·      ·
+           │              order  +a
+           └── render     ·      ·
+                └── scan  ·      ·
+·                         table  t@primary
+·                         spans  ALL
+·                         limit  1
 
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b ASC
 ----
-nosort             ·      ·
- │                 order  -a,+b
- └── render        ·      ·
-      └── revscan  ·      ·
-·                  table  t@primary
-·                  spans  ALL
+render                  ·      ·
+ └── nosort             ·      ·
+      │                 order  -a,+b
+      └── render        ·      ·
+           └── revscan  ·      ·
+·                       table  t@primary
+·                       spans  ALL
 
 query TTT
 EXPLAIN SELECT b FROM t ORDER BY a DESC, b DESC
 ----
-nosort             ·      ·
- │                 order  -a,-b
- └── render        ·      ·
-      └── revscan  ·      ·
-·                  table  t@primary
-·                  spans  ALL
+render                  ·      ·
+ └── nosort             ·      ·
+      │                 order  -a,-b
+      └── render        ·      ·
+           └── revscan  ·      ·
+·                       table  t@primary
+·                       spans  ALL
 
 query TITTTTT
 EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, t.*)
@@ -348,8 +354,7 @@ SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER 
 query TTT
 EXPLAIN SELECT * FROM t ORDER BY 1+2
 ----
-nosort          ·      ·
- │              order  +"1 + 2"
+render          ·      ·
  └── render     ·      ·
       └── scan  ·      ·
 ·               table  t@primary
@@ -366,8 +371,7 @@ render     ·      ·
 query TTT
 EXPLAIN SELECT * FROM t ORDER BY length('abc')
 ----
-nosort          ·      ·
- │              order  +length
+render          ·      ·
  └── render     ·      ·
       └── scan  ·      ·
 ·               table  t@primary
@@ -477,14 +481,15 @@ render     ·      ·
 query TTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
-sort             ·      ·
- │               order  +b,+a,+d
- └── index-join  ·      ·
-      ├── scan   ·      ·
-      │          table  abc@ba
-      │          spans  /11-
-      └── scan   ·      ·
-·                table  abc@primary
+render                ·      ·
+ └── sort             ·      ·
+      │               order  +b,+a,+d
+      └── index-join  ·      ·
+           ├── scan   ·      ·
+           │          table  abc@ba
+           │          spans  /11-
+           └── scan   ·      ·
+·                     table  abc@primary
 
 # We cannot have rows with identical values for a,b,c so we don't need to
 # sort for d.
@@ -501,45 +506,51 @@ index-join  ·      ·
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c
 ----
-nosort          ·      ·
- │              order  +b,+c
- └── render     ·      ·
-      └── scan  ·      ·
-·               table  abc@bc
-·               spans  ALL
+render               ·      ·
+ └── nosort          ·      ·
+      │              order  +b,+c
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  abc@bc
+·                    spans  ALL
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
-nosort          0  nosort  ·         ·           (a, b)                 b!=NULL; +b
- │              0  ·       order     +b,+c       ·                      ·
- └── render     1  render  ·         ·           (a, b, c)              b!=NULL; c!=NULL; key(b,c); +b,+c
-      │         1  ·       render 0  test.abc.a  ·                      ·
-      │         1  ·       render 1  test.abc.b  ·                      ·
-      │         1  ·       render 2  test.abc.c  ·                      ·
-      └── scan  2  scan    ·         ·           (a, b, c, d[omitted])  b!=NULL; c!=NULL; key(b,c); +b,+c
-·               2  ·       table     abc@bc      ·                      ·
-·               2  ·       spans     ALL         ·                      ·
+render               0  render  ·         ·           (a, b)                 b!=NULL; +b
+ │                   0  ·       render 0  a           ·                      ·
+ │                   0  ·       render 1  b           ·                      ·
+ └── nosort          1  nosort  ·         ·           (a, b, c)              b!=NULL; c!=NULL; key(b,c); +b,+c
+      │              1  ·       order     +b,+c       ·                      ·
+      └── render     2  render  ·         ·           (a, b, c)              b!=NULL; c!=NULL; key(b,c); +b,+c
+           │         2  ·       render 0  test.abc.a  ·                      ·
+           │         2  ·       render 1  test.abc.b  ·                      ·
+           │         2  ·       render 2  test.abc.c  ·                      ·
+           └── scan  3  scan    ·         ·           (a, b, c, d[omitted])  b!=NULL; c!=NULL; key(b,c); +b,+c
+·                    3  ·       table     abc@bc      ·                      ·
+·                    3  ·       spans     ALL         ·                      ·
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
 ----
-nosort          ·      ·
- │              order  +b,+c,+a
- └── render     ·      ·
-      └── scan  ·      ·
-·               table  abc@bc
-·               spans  ALL
+render               ·      ·
+ └── nosort          ·      ·
+      │              order  +b,+c,+a
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  abc@bc
+·                    spans  ALL
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
-nosort          ·      ·
- │              order  +b,+c,-a
- └── render     ·      ·
-      └── scan  ·      ·
-·               table  abc@bc
-·               spans  ALL
+render               ·      ·
+ └── nosort          ·      ·
+      │              order  +b,+c,-a
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  abc@bc
+·                    spans  ALL
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT b, c FROM abc ORDER BY b, c]
@@ -614,8 +625,7 @@ render        ·      ·
 query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-nosort          0  nosort  ·      ·            (b, c)                          b!=NULL; c!=NULL; key(b,c); +b,+c
- │              0  ·       order  +b,+c        ·                               ·
+render          0  render  ·      ·            (b, c)                          b!=NULL; c!=NULL; key(b,c); +b,+c
  └── render     1  render  ·      ·            (b, c, a[omitted])              a=CONST; b!=NULL; c!=NULL; key(b,c); +b,+c
       └── scan  2  scan    ·      ·            (a[omitted], b, c, d[omitted])  a=CONST; b!=NULL; c!=NULL; key(b,c); +b,+c
 ·               2  ·       table  abc@primary  ·                               ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -6,78 +6,86 @@ CREATE TABLE kv(k INT PRIMARY KEY, v INT); CREATE INDEX foo ON kv(v DESC)
 query TITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv
 ----
-nosort          0  nosort  ·      ·           (v)     ·
- │              0  ·       order  +k          ·       ·
- └── render     1  render  ·      ·           (v, k)  k!=NULL; key(k); +k
-      └── scan  2  scan    ·      ·           (k, v)  k!=NULL; key(k); +k
-·               2  ·       table  kv@primary  ·       ·
-·               2  ·       spans  ALL         ·       ·
+render               0  render  ·      ·           (v)     ·
+ └── nosort          1  nosort  ·      ·           (v, k)  k!=NULL; key(k); +k
+      │              1  ·       order  +k          ·       ·
+      └── render     2  render  ·      ·           (v, k)  k!=NULL; key(k); +k
+           └── scan  3  scan    ·      ·           (k, v)  k!=NULL; key(k); +k
+·                    3  ·       table  kv@primary  ·       ·
+·                    3  ·       spans  ALL         ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
 ----
-nosort          0  nosort  ·      ·           (v)     ·
- │              0  ·       order  +k          ·       ·
- └── render     1  render  ·      ·           (v, k)  k!=NULL; key(k); +k
-      └── scan  2  scan    ·      ·           (k, v)  k!=NULL; key(k); +k
-·               2  ·       table  kv@primary  ·       ·
-·               2  ·       spans  ALL         ·       ·
+render               0  render  ·      ·           (v)     ·
+ └── nosort          1  nosort  ·      ·           (v, k)  k!=NULL; key(k); +k
+      │              1  ·       order  +k          ·       ·
+      └── render     2  render  ·      ·           (v, k)  k!=NULL; key(k); +k
+           └── scan  3  scan    ·      ·           (k, v)  k!=NULL; key(k); +k
+·                    3  ·       table  kv@primary  ·       ·
+·                    3  ·       spans  ALL         ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
 ----
-nosort             0  nosort   ·      ·           (v)     ·
- │                 0  ·        order  -k          ·       ·
- └── render        1  render   ·      ·           (v, k)  k!=NULL; key(k); -k
-      └── revscan  2  revscan  ·      ·           (k, v)  k!=NULL; key(k); -k
-·                  2  ·        table  kv@primary  ·       ·
-·                  2  ·        spans  ALL         ·       ·
+render                  0  render   ·      ·           (v)     ·
+ └── nosort             1  nosort   ·      ·           (v, k)  k!=NULL; key(k); -k
+      │                 1  ·        order  -k          ·       ·
+      └── render        2  render   ·      ·           (v, k)  k!=NULL; key(k); -k
+           └── revscan  3  revscan  ·      ·           (k, v)  k!=NULL; key(k); -k
+·                       3  ·        table  kv@primary  ·       ·
+·                       3  ·        spans  ALL         ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
 ----
-sort               0  sort     ·      ·               (k)              k!=NULL
- │                 0  ·        order  +v,+k,+"v - 2"  ·                ·
- └── render        1  render   ·      ·               (k, v, "v - 2")  k!=NULL; weak-key(k,v); +v
-      └── revscan  2  revscan  ·      ·               (k, v)           k!=NULL; weak-key(k,v); +v
-·                  2  ·        table  kv@foo          ·                ·
-·                  2  ·        spans  ALL             ·                ·
+render                  0  render   ·      ·               (k)              k!=NULL
+ └── sort               1  sort     ·      ·               (k, v, "v - 2")  k!=NULL; weak-key(k,v); +v,+k,+"v - 2"
+      │                 1  ·        order  +v,+k,+"v - 2"  ·                ·
+      └── render        2  render   ·      ·               (k, v, "v - 2")  k!=NULL; weak-key(k,v); +v
+           └── revscan  3  revscan  ·      ·               (k, v)           k!=NULL; weak-key(k,v); +v
+·                       3  ·        table  kv@foo          ·                ·
+·                       3  ·        spans  ALL             ·                ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
-nosort     0  nosort  ·      ·       (k)     k!=NULL
- │         0  ·       order  -v      ·       ·
- └── scan  1  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
-·          1  ·       table  kv@foo  ·       ·
-·          1  ·       spans  ALL     ·       ·
+render          0  render  ·      ·       (k)     k!=NULL
+ └── nosort     1  nosort  ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
+      │         1  ·       order  -v      ·       ·
+      └── scan  2  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
+·               2  ·       table  kv@foo  ·       ·
+·               2  ·       spans  ALL     ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
-nosort     0  nosort  ·      ·       (k)     k!=NULL
- │         0  ·       order  -v      ·       ·
- └── scan  1  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
-·          1  ·       table  kv@foo  ·       ·
-·          1  ·       spans  ALL     ·       ·
+render          0  render  ·      ·       (k)     k!=NULL
+ └── nosort     1  nosort  ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
+      │         1  ·       order  -v      ·       ·
+      └── scan  2  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
+·               2  ·       table  kv@foo  ·       ·
+·               2  ·       spans  ALL     ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
-nosort        0  nosort   ·      ·       (k)     k!=NULL
- │            0  ·        order  +v      ·       ·
- └── revscan  1  revscan  ·      ·       (k, v)  k!=NULL; weak-key(k,v); +v
-·             1  ·        table  kv@foo  ·       ·
-·             1  ·        spans  ALL     ·       ·
+render             0  render   ·      ·       (k)     k!=NULL
+ └── nosort        1  nosort   ·      ·       (k, v)  k!=NULL; weak-key(k,v); +v
+      │            1  ·        order  +v      ·       ·
+      └── revscan  2  revscan  ·      ·       (k, v)  k!=NULL; weak-key(k,v); +v
+·                  2  ·        table  kv@foo  ·       ·
+·                  2  ·        spans  ALL     ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
-nosort     0  nosort  ·      ·       (k)     k!=NULL
- │         0  ·       order  -v,+k   ·       ·
- └── scan  1  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v,+k
-·          1  ·       table  kv@foo  ·       ·
-·          1  ·       spans  ALL     ·       ·
+render          0  render  ·      ·       (k)     k!=NULL
+ └── nosort     1  nosort  ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v,+k
+      │         1  ·       order  -v,+k   ·       ·
+      └── scan  2  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v,+k
+·               2  ·       table  kv@foo  ·       ·
+·               2  ·       spans  ALL     ·       ·
 
 # Check the syntax can be used with joins.
 #
@@ -88,52 +96,55 @@ nosort     0  nosort  ·      ·       (k)     k!=NULL
 query TITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv JOIN (VALUES (1,2)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
-sort                   0  sort    ·         ·                 (k)                             ·
- │                     0  ·       order     -v                ·                               ·
- └── render            1  render  ·         ·                 (k, v)                          ·
-      └── join         2  join    ·         ·                 (k, v, a[omitted], b[omitted])  ·
-           │           2  ·       type      inner             ·                               ·
-           │           2  ·       equality  (k) = (a)         ·                               ·
-           ├── scan    3  scan    ·         ·                 (k, v)                          k!=NULL; key(k)
-           │           3  ·       table     kv@primary        ·                               ·
-           │           3  ·       spans     ALL               ·                               ·
-           └── values  3  values  ·         ·                 (column1, column2[omitted])     ·
-·                      3  ·       size      2 columns, 1 row  ·                               ·
+render                      0  render  ·         ·                 (k)                             ·
+ └── sort                   1  sort    ·         ·                 (k, v)                          -v
+      │                     1  ·       order     -v                ·                               ·
+      └── render            2  render  ·         ·                 (k, v)                          ·
+           └── join         3  join    ·         ·                 (k, v, a[omitted], b[omitted])  ·
+                │           3  ·       type      inner             ·                               ·
+                │           3  ·       equality  (k) = (a)         ·                               ·
+                ├── scan    4  scan    ·         ·                 (k, v)                          k!=NULL; key(k)
+                │           4  ·       table     kv@primary        ·                               ·
+                │           4  ·       spans     ALL               ·                               ·
+                └── values  4  values  ·         ·                 (column1, column2[omitted])     ·
+·                           4  ·       size      2 columns, 1 row  ·                               ·
 
 query TITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-sort                 0  sort    ·               ·                (k)                             k!=NULL; key(k)
- │                   0  ·       order           -v               ·                               ·
- └── render          1  render  ·               ·                (k, v)                          k!=NULL; v!=NULL; key(k)
-      └── join       2  join    ·               ·                (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; key(k)
-           │         2  ·       type            inner            ·                               ·
-           │         2  ·       equality        (k, v) = (k, v)  ·                               ·
-           │         2  ·       mergeJoinOrder  +"(k=k)"         ·                               ·
-           ├── scan  3  scan    ·               ·                (k, v)                          k!=NULL; key(k); +k
-           │         3  ·       table           kv@primary       ·                               ·
-           │         3  ·       spans           ALL              ·                               ·
-           └── scan  3  scan    ·               ·                (k, v)                          k!=NULL; key(k); +k
-·                    3  ·       table           kv@primary       ·                               ·
-·                    3  ·       spans           ALL              ·                               ·
+render                    0  render  ·               ·                (k)                             k!=NULL; key(k)
+ └── sort                 1  sort    ·               ·                (k, v)                          k!=NULL; v!=NULL; key(k); -v
+      │                   1  ·       order           -v               ·                               ·
+      └── render          2  render  ·               ·                (k, v)                          k!=NULL; v!=NULL; key(k)
+           └── join       3  join    ·               ·                (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; key(k)
+                │         3  ·       type            inner            ·                               ·
+                │         3  ·       equality        (k, v) = (k, v)  ·                               ·
+                │         3  ·       mergeJoinOrder  +"(k=k)"         ·                               ·
+                ├── scan  4  scan    ·               ·                (k, v)                          k!=NULL; key(k); +k
+                │         4  ·       table           kv@primary       ·                               ·
+                │         4  ·       spans           ALL              ·                               ·
+                └── scan  4  scan    ·               ·                (k, v)                          k!=NULL; key(k); +k
+·                         4  ·       table           kv@primary       ·                               ·
+·                         4  ·       spans           ALL              ·                               ·
 
 # The underlying index can be forced manually, of course.
 query TITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@foo
 ----
-nosort               0  nosort  ·               ·                  (k)                             k!=NULL
- │                   0  ·       order           -v                 ·                               ·
- └── render          1  render  ·               ·                  (k, v)                          k!=NULL; v!=NULL; -v
-      └── join       2  join    ·               ·                  (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; -v
-           │         2  ·       type            inner              ·                               ·
-           │         2  ·       equality        (k, v) = (k, v)    ·                               ·
-           │         2  ·       mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                               ·
-           ├── scan  3  scan    ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
-           │         3  ·       table           kv@foo             ·                               ·
-           │         3  ·       spans           ALL                ·                               ·
-           └── scan  3  scan    ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
-·                    3  ·       table           kv@foo             ·                               ·
-·                    3  ·       spans           ALL                ·                               ·
+render                    0  render  ·               ·                  (k)                             k!=NULL
+ └── nosort               1  nosort  ·               ·                  (k, v)                          k!=NULL; v!=NULL; -v
+      │                   1  ·       order           -v                 ·                               ·
+      └── render          2  render  ·               ·                  (k, v)                          k!=NULL; v!=NULL; -v
+           └── join       3  join    ·               ·                  (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; -v
+                │         3  ·       type            inner              ·                               ·
+                │         3  ·       equality        (k, v) = (k, v)    ·                               ·
+                │         3  ·       mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                               ·
+                ├── scan  4  scan    ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
+                │         4  ·       table           kv@foo             ·                               ·
+                │         4  ·       spans           ALL                ·                               ·
+                └── scan  4  scan    ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
+·                         4  ·       table           kv@foo             ·                               ·
+·                         4  ·       spans           ALL                ·                               ·
 
 # Check the extended syntax cannot be used in case of renames.
 statement error source name "kv" not found in FROM clause

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -524,13 +524,14 @@ SELECT k, max(stddev) OVER (ORDER BY d DESC) FROM (SELECT k, d, stddev(d) OVER (
 query TTT
 EXPLAIN SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-sort                 ·      ·
- │                   order  +variance,+k
- └── window          ·      ·
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  kv@primary
-·                    spans  ALL
+render                    ·      ·
+ └── sort                 ·      ·
+      │                   order  +variance,+k
+      └── window          ·      ·
+           └── render     ·      ·
+                └── scan  ·      ·
+·                         table  kv@primary
+·                         spans  ALL
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k]
@@ -563,42 +564,48 @@ output row: [8 3.5355339059327376220]
 query TITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-sort                 0  sort    ·         ·                                         (k int, stddev decimal)                                                                          ·
- │                   0  ·       order     +variance,+k                              ·                                                                                                ·
- └── window          1  window  ·         ·                                         (k int, stddev decimal, variance decimal)                                                        ·
-      │              1  ·       window 0  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
-      │              1  ·       window 1  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
-      │              1  ·       render 1  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
-      │              1  ·       render 2  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
-      └── render     2  render  ·         ·                                         (k int, d decimal, d decimal, v int)                                                             d=d; k!=NULL; key(k)
-           │         2  ·       render 0  (k)[int]                                  ·                                                                                                ·
-           │         2  ·       render 1  (d)[decimal]                              ·                                                                                                ·
-           │         2  ·       render 2  (d)[decimal]                              ·                                                                                                ·
-           │         2  ·       render 3  (v)[int]                                  ·                                                                                                ·
-           └── scan  3  scan    ·         ·                                         (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
-·                    3  ·       table     kv@primary                                ·                                                                                                ·
-·                    3  ·       spans     ALL                                       ·                                                                                                ·
+render                    0  render  ·         ·                                         (k int, stddev decimal)                                                                          ·
+ │                        0  ·       render 0  (k)[int]                                  ·                                                                                                ·
+ │                        0  ·       render 1  (stddev)[decimal]                         ·                                                                                                ·
+ └── sort                 1  sort    ·         ·                                         (k int, stddev decimal, variance decimal)                                                        +variance,+k
+      │                   1  ·       order     +variance,+k                              ·                                                                                                ·
+      └── window          2  window  ·         ·                                         (k int, stddev decimal, variance decimal)                                                        ·
+           │              2  ·       window 0  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
+           │              2  ·       window 1  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
+           │              2  ·       render 1  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
+           │              2  ·       render 2  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
+           └── render     3  render  ·         ·                                         (k int, d decimal, d decimal, v int)                                                             d=d; k!=NULL; key(k)
+                │         3  ·       render 0  (k)[int]                                  ·                                                                                                ·
+                │         3  ·       render 1  (d)[decimal]                              ·                                                                                                ·
+                │         3  ·       render 2  (d)[decimal]                              ·                                                                                                ·
+                │         3  ·       render 3  (v)[int]                                  ·                                                                                                ·
+                └── scan  4  scan    ·         ·                                         (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+·                         4  ·       table     kv@primary                                ·                                                                                                ·
+·                         4  ·       spans     ALL                                       ·                                                                                                ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-sort                 0  sort    ·         ·                                                                            (k int, stddev decimal)                                                                          ·
- │                   0  ·       order     +variance,+k                                                                 ·                                                                                                ·
- └── window          1  window  ·         ·                                                                            (k int, stddev decimal, variance decimal)                                                        ·
-      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
-      │              1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                ·
-      │              1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
-      │              1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                ·
-      └── render     2  render  ·         ·                                                                            (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                    d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
-           │         2  ·       render 0  (k)[int]                                                                     ·                                                                                                ·
-           │         2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                ·
-           │         2  ·       render 2  (d)[decimal]                                                                 ·                                                                                                ·
-           │         2  ·       render 3  (v)[int]                                                                     ·                                                                                                ·
-           │         2  ·       render 4  ('a')[string]                                                                ·                                                                                                ·
-           │         2  ·       render 5  (100)[int]                                                                   ·                                                                                                ·
-           └── scan  3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
-·                    3  ·       table     kv@primary                                                                   ·                                                                                                ·
-·                    3  ·       spans     ALL                                                                          ·                                                                                                ·
+render                    0  render  ·         ·                                                                            (k int, stddev decimal)                                                                          ·
+ │                        0  ·       render 0  (k)[int]                                                                     ·                                                                                                ·
+ │                        0  ·       render 1  (stddev)[decimal]                                                            ·                                                                                                ·
+ └── sort                 1  sort    ·         ·                                                                            (k int, stddev decimal, variance decimal)                                                        +variance,+k
+      │                   1  ·       order     +variance,+k                                                                 ·                                                                                                ·
+      └── window          2  window  ·         ·                                                                            (k int, stddev decimal, variance decimal)                                                        ·
+           │              2  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+           │              2  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                ·
+           │              2  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+           │              2  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                ·
+           └── render     3  render  ·         ·                                                                            (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                    d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
+                │         3  ·       render 0  (k)[int]                                                                     ·                                                                                                ·
+                │         3  ·       render 1  (d)[decimal]                                                                 ·                                                                                                ·
+                │         3  ·       render 2  (d)[decimal]                                                                 ·                                                                                                ·
+                │         3  ·       render 3  (v)[int]                                                                     ·                                                                                                ·
+                │         3  ·       render 4  ('a')[string]                                                                ·                                                                                                ·
+                │         3  ·       render 5  (100)[int]                                                                   ·                                                                                                ·
+                └── scan  4  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+·                         4  ·       table     kv@primary                                                                   ·                                                                                                ·
+·                         4  ·       spans     ALL                                                                          ·                                                                                                ·
 
 query TITTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
@@ -620,54 +627,60 @@ sort                 0  sort    ·         ·                                   
 query TITTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-sort                 0  sort    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                      ·
- │                   0  ·       order     +variance,+k                                                                                       ·                                                                                                ·
- └── window          1  window  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)                    ·
-      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                        ·                                                                                                ·
-      │              1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                ·
-      │              1  ·       render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                ·
-      │              1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                ·
-      └── render     2  render  ·         ·                                                                                                  (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                    d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
-           │         2  ·       render 0  (k)[int]                                                                                           ·                                                                                                ·
-           │         2  ·       render 1  (d)[decimal]                                                                                       ·                                                                                                ·
-           │         2  ·       render 2  (d)[decimal]                                                                                       ·                                                                                                ·
-           │         2  ·       render 3  (v)[int]                                                                                           ·                                                                                                ·
-           │         2  ·       render 4  ('a')[string]                                                                                      ·                                                                                                ·
-           │         2  ·       render 5  (100)[int]                                                                                         ·                                                                                                ·
-           └── scan  3  scan    ·         ·                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
-·                    3  ·       table     kv@primary                                                                                         ·                                                                                                ·
-·                    3  ·       spans     ALL                                                                                                ·                                                                                                ·
+render                    0  render  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                      ·
+ │                        0  ·       render 0  (k)[int]                                                                                           ·                                                                                                ·
+ │                        0  ·       render 1  ("k + stddev(d) OVER (PARTITION BY v, 'a')")[decimal]                                              ·                                                                                                ·
+ └── sort                 1  sort    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)                    +variance,+k
+      │                   1  ·       order     +variance,+k                                                                                       ·                                                                                                ·
+      └── window          2  window  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)                    ·
+           │              2  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                        ·                                                                                                ·
+           │              2  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                ·
+           │              2  ·       render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                ·
+           │              2  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                ·
+           └── render     3  render  ·         ·                                                                                                  (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                    d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
+                │         3  ·       render 0  (k)[int]                                                                                           ·                                                                                                ·
+                │         3  ·       render 1  (d)[decimal]                                                                                       ·                                                                                                ·
+                │         3  ·       render 2  (d)[decimal]                                                                                       ·                                                                                                ·
+                │         3  ·       render 3  (v)[int]                                                                                           ·                                                                                                ·
+                │         3  ·       render 4  ('a')[string]                                                                                      ·                                                                                                ·
+                │         3  ·       render 5  (100)[int]                                                                                         ·                                                                                                ·
+                └── scan  4  scan    ·         ·                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+·                         4  ·       table     kv@primary                                                                                         ·                                                                                                ·
+·                         4  ·       spans     ALL                                                                                                ·                                                                                                ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
-sort                           0  sort    ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                               ·
- │                             0  ·       order        +variance                                                                                                      ·                                                                                                ·
- └── window                    1  window  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)             ·
-      │                        1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                                    ·                                                                                                ·
-      │                        1  ·       window 1     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                ·
-      │                        1  ·       render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                ·
-      │                        1  ·       render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                ·
-      └── render               2  render  ·            ·                                                                                                              (max int, d decimal, d decimal, v int, "'a'" string, "100" int)                                  "'a'"=CONST; "100"=CONST
-           │                   2  ·       render 0     (max)[int]                                                                                                     ·                                                                                                ·
-           │                   2  ·       render 1     (d)[decimal]                                                                                                   ·                                                                                                ·
-           │                   2  ·       render 2     (d)[decimal]                                                                                                   ·                                                                                                ·
-           │                   2  ·       render 3     (v)[int]                                                                                                       ·                                                                                                ·
-           │                   2  ·       render 4     ('a')[string]                                                                                                  ·                                                                                                ·
-           │                   2  ·       render 5     (100)[int]                                                                                                     ·                                                                                                ·
-           └── group           3  group   ·            ·                                                                                                              (max int, d decimal, d decimal, v int)                                                           ·
-                │              3  ·       aggregate 0  (max((k)[int]))[int]                                                                                           ·                                                                                                ·
-                │              3  ·       aggregate 1  (d)[decimal]                                                                                                   ·                                                                                                ·
-                │              3  ·       aggregate 2  (d)[decimal]                                                                                                   ·                                                                                                ·
-                │              3  ·       aggregate 3  (v)[int]                                                                                                       ·                                                                                                ·
-                │              3  ·       group by     @1-@2                                                                                                          ·                                                                                                ·
-                └── render     4  render  ·            ·                                                                                                              (d decimal, v int, k int)                                                                        k!=NULL; key(k)
-                     │         4  ·       render 0     (d)[decimal]                                                                                                   ·                                                                                                ·
-                     │         4  ·       render 1     (v)[int]                                                                                                       ·                                                                                                ·
-                     │         4  ·       render 2     (k)[int]                                                                                                       ·                                                                                                ·
-                     └── scan  5  scan    ·            ·                                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
-·                              5  ·       table        kv@primary                                                                                                     ·                                                                                                ·
-·                              5  ·       spans        ALL                                                                                                            ·                                                                                                ·
+render                              0  render  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                               ·
+ │                                  0  ·       render 0     (max)[int]                                                                                                     ·                                                                                                ·
+ │                                  0  ·       render 1     ("max(k) + stddev(d) OVER (PARTITION BY v, 'a')")[decimal]                                                     ·                                                                                                ·
+ └── sort                           1  sort    ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)             +variance
+      │                             1  ·       order        +variance                                                                                                      ·                                                                                                ·
+      └── window                    2  window  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)             ·
+           │                        2  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                                    ·                                                                                                ·
+           │                        2  ·       window 1     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                ·
+           │                        2  ·       render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                ·
+           │                        2  ·       render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                ·
+           └── render               3  render  ·            ·                                                                                                              (max int, d decimal, d decimal, v int, "'a'" string, "100" int)                                  "'a'"=CONST; "100"=CONST
+                │                   3  ·       render 0     (max)[int]                                                                                                     ·                                                                                                ·
+                │                   3  ·       render 1     (d)[decimal]                                                                                                   ·                                                                                                ·
+                │                   3  ·       render 2     (d)[decimal]                                                                                                   ·                                                                                                ·
+                │                   3  ·       render 3     (v)[int]                                                                                                       ·                                                                                                ·
+                │                   3  ·       render 4     ('a')[string]                                                                                                  ·                                                                                                ·
+                │                   3  ·       render 5     (100)[int]                                                                                                     ·                                                                                                ·
+                └── group           4  group   ·            ·                                                                                                              (max int, d decimal, d decimal, v int)                                                           ·
+                     │              4  ·       aggregate 0  (max((k)[int]))[int]                                                                                           ·                                                                                                ·
+                     │              4  ·       aggregate 1  (d)[decimal]                                                                                                   ·                                                                                                ·
+                     │              4  ·       aggregate 2  (d)[decimal]                                                                                                   ·                                                                                                ·
+                     │              4  ·       aggregate 3  (v)[int]                                                                                                       ·                                                                                                ·
+                     │              4  ·       group by     @1-@2                                                                                                          ·                                                                                                ·
+                     └── render     5  render  ·            ·                                                                                                              (d decimal, v int, k int)                                                                        k!=NULL; key(k)
+                          │         5  ·       render 0     (d)[decimal]                                                                                                   ·                                                                                                ·
+                          │         5  ·       render 1     (v)[int]                                                                                                       ·                                                                                                ·
+                          │         5  ·       render 2     (k)[int]                                                                                                       ·                                                                                                ·
+                          └── scan  6  scan    ·            ·                                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+·                                   6  ·       table        kv@primary                                                                                                     ·                                                                                                ·
+·                                   6  ·       spans        ALL                                                                                                            ·                                                                                                ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT MAX(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -320,7 +320,7 @@ func (p *planner) hideHiddenColumns(
 	}
 
 	var tn tree.TableName
-	newPlan, err := p.insertRender(ctx, plan, &tn)
+	newPlan, err := p.insertRender(ctx, plan, &tn, planColumns(plan))
 	if err != nil {
 		// Don't return a nil plan on error -- the caller must be able to
 		// Close() it even if the replacement fails.

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -63,8 +63,6 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.columns
 	case *scanNode:
 		return n.resultColumns
-	case *sortNode:
-		return n.columns
 	case *valueGenerator:
 		return n.columns
 	case *valuesNode:
@@ -106,6 +104,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 
 	// Nodes that have the same schema as their source or their
 	// valueNode helper.
+	case *sortNode:
+		return getPlanColumns(n.plan, mut)
 	case *distinctNode:
 		return getPlanColumns(n.plan, mut)
 	case *filterNode:

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -92,19 +92,6 @@ func sortPhysicalProps(n *sortNode) physicalProps {
 		}
 	}
 
-	if numPlanColumns := len(planColumns(n.plan)); len(n.columns) < numPlanColumns {
-		// The sortNode is projecting away columns, e.g:
-		//   SELECT k FROM kv ORDER BY v.
-		colMap := make([]int, numPlanColumns)
-		for i := range colMap {
-			if i < len(n.columns) {
-				colMap[i] = i
-			} else {
-				colMap[i] = -1
-			}
-		}
-		return props.project(colMap)
-	}
 	return props
 }
 

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -134,13 +134,13 @@ func (p *planner) Select(
 		if err != nil {
 			return nil, err
 		}
-		sort, err := p.orderBy(ctx, orderBy, plan)
+		sortPlan, sort, err := p.orderBy(ctx, orderBy, plan)
 		if err != nil {
 			return nil, err
 		}
 		if sort != nil {
 			sort.plan = plan
-			plan = sort
+			plan = sortPlan
 		}
 		limit, err := p.Limit(ctx, limit)
 		if err != nil {
@@ -231,7 +231,7 @@ func (p *planner) SelectClause(
 	if err != nil {
 		return nil, err
 	}
-	sort, err := p.orderBy(ctx, orderBy, r)
+	sortPlan, sort, err := p.orderBy(ctx, orderBy, r)
 	if err != nil {
 		return nil, err
 	}
@@ -297,7 +297,7 @@ func (p *planner) SelectClause(
 	}
 	if sort != nil {
 		sort.plan = result
-		result = sort
+		result = sortPlan
 	}
 	if distinctComplex != nil && distinct != nil {
 		distinct.plan = result
@@ -415,11 +415,12 @@ func (p *planner) initTargets(
 }
 
 // insertRender creates a new renderNode that renders exactly its
-// source plan.
+// source plan with given columns which must be the prefix of result columns
+// of the source plan.
 func (p *planner) insertRender(
-	ctx context.Context, plan planNode, tn *tree.TableName,
+	ctx context.Context, plan planNode, tn *tree.TableName, columns sqlbase.ResultColumns,
 ) (*renderNode, error) {
-	src := planDataSource{info: newSourceInfoForSingleTable(*tn, planColumns(plan)), plan: plan}
+	src := planDataSource{info: newSourceInfoForSingleTable(*tn, columns), plan: plan}
 	render := &renderNode{
 		source:     src,
 		sourceInfo: multiSourceInfo{src.info},

--- a/pkg/sql/show_constraints.go
+++ b/pkg/sql/show_constraints.go
@@ -85,16 +85,12 @@ func (p *planner) ShowConstraints(ctx context.Context, n *tree.ShowConstraints) 
 					return nil, err
 				}
 			}
-
+			ordering := sqlbase.ColumnOrdering{
+				{ColIdx: 0, Direction: encoding.Ascending},
+				{ColIdx: 1, Direction: encoding.Ascending},
+			}
 			// Sort the results by constraint name.
-			return &sortNode{
-				plan: v,
-				ordering: sqlbase.ColumnOrdering{
-					{ColIdx: 0, Direction: encoding.Ascending},
-					{ColIdx: 1, Direction: encoding.Ascending},
-				},
-				columns: v.columns,
-			}, nil
+			return newSortNode(v, ordering, len(columns)), nil
 		},
 	}, nil
 }

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -137,7 +137,11 @@ WHERE message LIKE 'fetched: %'
 	// is complete. If we want to enable EXPLAIN [SHOW TRACE FOR ...],
 	// this limitation of the vtable session_trace must be lifted first.
 	// TODO(andrei): make this code more elegant.
-	if s, ok := plan.(*sortNode); ok {
+	pl := plan
+	if r, ok := pl.(*renderNode); ok {
+		pl = r.source.plan
+	}
+	if s, ok := pl.(*sortNode); ok {
 		if w, ok := s.plan.(*windowNode); ok {
 			if r, ok := w.plan.(*renderNode); ok {
 				subPlan := r.source.plan

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -33,12 +33,24 @@ import (
 // sub-node.
 type sortNode struct {
 	plan     planNode
-	columns  sqlbase.ResultColumns
 	ordering sqlbase.ColumnOrdering
+	needed   []bool
 
 	needSort bool
 
 	run sortRun
+}
+
+func newSortNode(plan planNode, ordering sqlbase.ColumnOrdering, numColumns int) *sortNode {
+	needed := make([]bool, numColumns)
+	for i := range needed {
+		needed[i] = true
+	}
+	return &sortNode{
+		plan:     plan,
+		ordering: ordering,
+		needed:   needed,
+	}
 }
 
 // orderBy constructs a sortNode based on the ORDER BY clause.
@@ -56,9 +68,9 @@ type sortNode struct {
 // generalization of how to add derived columns to a SelectStatement.
 func (p *planner) orderBy(
 	ctx context.Context, orderBy tree.OrderBy, n planNode,
-) (*sortNode, error) {
+) (planNode, *sortNode, error) {
 	if orderBy == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Multiple tests below use renderNode as a special case.
@@ -77,7 +89,7 @@ func (p *planner) orderBy(
 	var err error
 	orderBy, err = p.rewriteIndexOrderings(ctx, orderBy)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for _, o := range orderBy {
@@ -127,7 +139,7 @@ func (p *planner) orderBy(
 		// First, deal with render aliases.
 		index, err := s.colIdxByRenderAlias(expr, columns, "ORDER BY")
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		// If the expression does not refer to an alias, deal with
@@ -135,7 +147,7 @@ func (p *planner) orderBy(
 		if index == -1 {
 			col, err := p.colIndex(numOriginalCols, expr, "ORDER BY")
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if col != -1 {
 				index = col
@@ -146,7 +158,7 @@ func (p *planner) orderBy(
 		// column type we can order on.
 		if index != -1 {
 			if err := ensureColumnOrderable(columns[index]); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 
@@ -160,7 +172,7 @@ func (p *planner) orderBy(
 				ctx, tree.SelectExpr{Expr: expr}, types.Any,
 				s.sourceInfo, s.ivarHelper, autoGenerateRenderOutputName)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			p.curPlan.hasStar = p.curPlan.hasStar || hasStar
 
@@ -184,13 +196,13 @@ func (p *planner) orderBy(
 			renderCols := planColumns(s)
 			for _, colIdx := range colIdxs {
 				if err := ensureColumnOrderable(renderCols[colIdx]); err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 			}
 		}
 
 		if index == -1 {
-			return nil, pgerror.NewErrorf(
+			return nil, nil, pgerror.NewErrorf(
 				pgerror.CodeUndefinedColumnError,
 				"column %s does not exist", expr,
 			)
@@ -201,9 +213,18 @@ func (p *planner) orderBy(
 
 	if ordering == nil {
 		// No ordering; simply drop the sort node.
-		return nil, nil
+		return nil, nil, nil
 	}
-	return &sortNode{columns: columns, ordering: ordering}, nil
+	sort := newSortNode(nil, ordering, len(columns))
+	if len(columns) == len(planColumns(n)) {
+		return sort, sort, nil
+	}
+
+	render, err := p.insertRender(ctx, sort, &anonymousTable, columns)
+	if err != nil {
+		return nil, nil, err
+	}
+	return render, sort, nil
 }
 
 // sortRun contains the run-time state of sortNode during local
@@ -278,7 +299,7 @@ func (n *sortNode) Next(params runParams) (bool, error) {
 func (n *sortNode) Values() tree.Datums {
 	// If an ordering expression was used the number of columns in each row might
 	// differ from the number of columns requested, so trim the result.
-	return n.run.valueIter.Values()[:len(n.columns)]
+	return n.run.valueIter.Values()
 }
 
 func (n *sortNode) Close(ctx context.Context) {

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -163,7 +163,7 @@ func (p *planner) Update(
 	if r, ok := rows.(*renderNode); ok {
 		render = r
 	} else {
-		render, err = p.insertRender(ctx, rows, tn)
+		render, err = p.insertRender(ctx, rows, tn, planColumns(rows))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Add a parent render node if not needSort for projection and skip adding sorter in dist physical planner. Related to #20659.