### PR TITLE
sql: introduce new statement: `SHOW ROLES`

### DIFF
--- a/docs/generated/sql/docs/generated/sql/bnf/show_var.bnf
+++ b/docs/generated/sql/docs/generated/sql/bnf/show_var.bnf
@@ -11,6 +11,7 @@ show_stmt ::=
 	| show_indexes_stmt
 	| show_jobs_stmt
 	| show_queries_stmt
+	| show_roles_stmt
 	| show_session_stmt
 	| show_sessions_stmt
 	| show_stats_stmt

--- a/docs/generated/sql/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/docs/generated/sql/bnf/stmt_block.bnf
@@ -145,6 +145,7 @@ show_stmt ::=
 	| show_indexes_stmt
 	| show_jobs_stmt
 	| show_queries_stmt
+	| show_roles_stmt
 	| show_session_stmt
 	| show_sessions_stmt
 	| show_stats_stmt
@@ -425,6 +426,9 @@ show_queries_stmt ::=
 	| 'SHOW' 'CLUSTER' 'QUERIES'
 	| 'SHOW' 'LOCAL' 'QUERIES'
 
+show_roles_stmt ::=
+	'SHOW' 'ROLES'
+
 show_session_stmt ::=
 	'SHOW' session_var
 	| 'SHOW' 'SESSION' session_var
@@ -673,6 +677,7 @@ unreserved_keyword ::=
 	| 'RESTRICT'
 	| 'RESUME'
 	| 'REVOKE'
+	| 'ROLES'
 	| 'ROLLBACK'
 	| 'ROLLUP'
 	| 'ROWS'
@@ -1300,6 +1305,7 @@ reserved_keyword ::=
 	| 'PRIMARY'
 	| 'REFERENCES'
 	| 'RETURNING'
+	| 'ROLE'
 	| 'SELECT'
 	| 'SESSION_USER'
 	| 'SOME'

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1,0 +1,7 @@
+# LogicTest: default
+
+query T colnames
+SHOW ROLES
+----
+username
+admin

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -251,6 +251,8 @@ func TestContextualHelp(t *testing.T) {
 		{`SHOW INDEXES FROM ??`, `SHOW INDEXES`},
 		{`SHOW INDEXES FROM blah ??`, `SHOW INDEXES`},
 
+		{`SHOW ROLES ??`, `SHOW ROLES`},
+
 		{`SHOW TABLES FROM ??`, `SHOW TABLES`},
 		{`SHOW TABLES FROM blah ??`, `SHOW TABLES`},
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -331,6 +331,7 @@ func TestParse(t *testing.T) {
 		{`SHOW CONSTRAINTS FROM a`},
 		{`SHOW CONSTRAINTS FROM a.b.c`},
 		{`SHOW TABLES FROM a; SHOW COLUMNS FROM b`},
+		{`SHOW ROLES`},
 		{`SHOW USERS`},
 		{`SHOW JOBS`},
 		{`SHOW CLUSTER QUERIES`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -488,7 +488,7 @@ func (u *sqlSymUnion) scrubOption() tree.ScrubOption {
 %token <str>   REGCLASS REGPROC REGPROCEDURE REGNAMESPACE REGTYPE
 %token <str>   REMOVE_PATH RENAME REPEATABLE
 %token <str>   RELEASE RESET RESTORE RESTRICT RESUME RETURNING REVOKE RIGHT
-%token <str>   ROLLBACK ROLLUP ROW ROWS RSHIFT
+%token <str>   ROLE ROLES ROLLBACK ROLLUP ROW ROWS RSHIFT
 
 %token <str>   SAVEPOINT SCATTER SCRUB SEARCH SECOND SELECT SEQUENCE SEQUENCES
 %token <str>   SERIAL SERIAL2 SERIAL4 SERIAL8
@@ -657,6 +657,7 @@ func (u *sqlSymUnion) scrubOption() tree.ScrubOption {
 %type <tree.Statement> show_indexes_stmt
 %type <tree.Statement> show_jobs_stmt
 %type <tree.Statement> show_queries_stmt
+%type <tree.Statement> show_roles_stmt
 %type <tree.Statement> show_session_stmt
 %type <tree.Statement> show_sessions_stmt
 %type <tree.Statement> show_stats_stmt
@@ -2470,7 +2471,7 @@ non_reserved_word_or_sconst:
 // %Text:
 // SHOW SESSION, SHOW CLUSTER SETTING, SHOW DATABASES, SHOW TABLES, SHOW COLUMNS, SHOW INDEXES,
 // SHOW CONSTRAINTS, SHOW CREATE TABLE, SHOW CREATE VIEW, SHOW USERS, SHOW TRANSACTION, SHOW BACKUP,
-// SHOW JOBS, SHOW QUERIES, SHOW SESSIONS, SHOW TRACE
+// SHOW JOBS, SHOW QUERIES, SHOW ROLES, SHOW SESSIONS, SHOW TRACE
 show_stmt:
   show_backup_stmt       // EXTEND WITH HELP: SHOW BACKUP
 | show_columns_stmt      // EXTEND WITH HELP: SHOW COLUMNS
@@ -2484,6 +2485,7 @@ show_stmt:
 | show_indexes_stmt      // EXTEND WITH HELP: SHOW INDEXES
 | show_jobs_stmt         // EXTEND WITH HELP: SHOW JOBS
 | show_queries_stmt      // EXTEND WITH HELP: SHOW QUERIES
+| show_roles_stmt        // EXTEND WITH HELP: SHOW ROLES
 | show_session_stmt      // EXTEND WITH HELP: SHOW SESSION
 | show_sessions_stmt     // EXTEND WITH HELP: SHOW SESSIONS
 | show_stats_stmt        // EXTEND WITH HELP: SHOW STATISTICS
@@ -2803,6 +2805,16 @@ show_users_stmt:
     $$.val = &tree.ShowUsers{}
   }
 | SHOW USERS error // SHOW HELP: SHOW USERS
+
+// %Help: SHOW ROLES - list defined roles
+// %Category: Priv
+// %Text: SHOW ROLES
+show_roles_stmt:
+  SHOW ROLES
+  {
+    $$.val = &tree.ShowRoles{}
+  }
+| SHOW ROLES error // SHOW HELP: SHOW ROLES
 
 show_zone_stmt:
   EXPERIMENTAL SHOW ZONE CONFIGURATION FOR RANGE unrestricted_name
@@ -7124,6 +7136,7 @@ unreserved_keyword:
 | RESTRICT
 | RESUME
 | REVOKE
+| ROLES
 | ROLLBACK
 | ROLLUP
 | ROWS
@@ -7351,6 +7364,7 @@ reserved_keyword:
 | PRIMARY
 | REFERENCES
 | RETURNING
+| ROLE
 | SELECT
 | SESSION_USER
 | SOME

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -505,6 +505,8 @@ func (p *planner) newPlan(
 		return p.ShowQueries(ctx, n)
 	case *tree.ShowJobs:
 		return p.ShowJobs(ctx, n)
+	case *tree.ShowRoles:
+		return p.ShowRoles(ctx, n)
 	case *tree.ShowSessions:
 		return p.ShowSessions(ctx, n)
 	case *tree.ShowTableStats:
@@ -603,6 +605,8 @@ func (p *planner) prepare(ctx context.Context, stmt tree.Statement) (planNode, e
 		return p.ShowQueries(ctx, n)
 	case *tree.ShowJobs:
 		return p.ShowJobs(ctx, n)
+	case *tree.ShowRoles:
+		return p.ShowRoles(ctx, n)
 	case *tree.ShowSessions:
 		return p.ShowSessions(ctx, n)
 	case *tree.ShowTables:

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -244,6 +244,15 @@ func (node *ShowUsers) Format(buf *bytes.Buffer, f FmtFlags) {
 	buf.WriteString("SHOW USERS")
 }
 
+// ShowRoles represents a SHOW ROLES statement.
+type ShowRoles struct {
+}
+
+// Format implements the NodeFormatter interface.
+func (node *ShowRoles) Format(buf *bytes.Buffer, f FmtFlags) {
+	buf.WriteString("SHOW ROLES")
+}
+
 // ShowRanges represents a SHOW TESTING_RANGES statement.
 // Only one of Table and Index can be set.
 type ShowRanges struct {

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -690,6 +690,15 @@ func (*ShowUsers) hiddenFromStats()                   {}
 func (*ShowUsers) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
+func (*ShowRoles) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowRoles) StatementTag() string { return "SHOW ROLES" }
+
+func (*ShowRoles) hiddenFromStats()                   {}
+func (*ShowRoles) independentFromParallelizedPriors() {}
+
+// StatementType implements the Statement interface.
 func (*ShowZoneConfig) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -832,6 +841,7 @@ func (n *ShowIndex) String() string                 { return AsString(n) }
 func (n *ShowJobs) String() string                  { return AsString(n) }
 func (n *ShowQueries) String() string               { return AsString(n) }
 func (n *ShowRanges) String() string                { return AsString(n) }
+func (n *ShowRoles) String() string                 { return AsString(n) }
 func (n *ShowSessions) String() string              { return AsString(n) }
 func (n *ShowTableStats) String() string            { return AsString(n) }
 func (n *ShowTables) String() string                { return AsString(n) }

--- a/pkg/sql/show_roles.go
+++ b/pkg/sql/show_roles.go
@@ -1,0 +1,28 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// ShowRoles returns all the roles.
+// Privileges: SELECT on system.users.
+func (p *planner) ShowRoles(ctx context.Context, n *tree.ShowRoles) (planNode, error) {
+	return p.delegateQuery(ctx, "SHOW ROLES",
+		`SELECT username FROM system.users WHERE "isRole" = true ORDER BY 1`, nil, nil)
+}


### PR DESCRIPTION
Release note (sql change): introduce experimental statement `SHOW ROLES` listing existing roles.

Part of [role-based access control](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20171220_sql_role_based_access_control.md).

Add `SHOW ROLES` statement. Similar to `SHOW USERS`.
Intentionally not gated by enterprise license.

`ROLE` keyword marked as reserved but not yet used.