### PR TITLE
Implement grpc-gateway Delimited interface

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -421,7 +421,7 @@
   branch = "master"
   name = "github.com/grpc-ecosystem/grpc-gateway"
   packages = ["protoc-gen-grpc-gateway","protoc-gen-grpc-gateway/descriptor","protoc-gen-grpc-gateway/generator","protoc-gen-grpc-gateway/gengateway","protoc-gen-grpc-gateway/httprule","runtime","runtime/internal","utilities"]
-  revision = "b0be3cdef0ed27e3c420795e2efbfe9c27e839cc"
+  revision = "8879672da99842abac4c1e84ea91d1ae082673fb"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -47,7 +47,7 @@ ignored = [
   name = "github.com/go-sql-driver/mysql"
   branch = "master"
 
-# https://github.com/grpc-ecosystem/grpc-gateway/commit/893772d
+# https://github.com/grpc-ecosystem/grpc-gateway/commit/8db8c1a
 [[constraint]]
   name = "github.com/grpc-ecosystem/grpc-gateway"
   branch = "master"

--- a/pkg/util/protoutil/jsonpb_marshal.go
+++ b/pkg/util/protoutil/jsonpb_marshal.go
@@ -133,3 +133,10 @@ func (j *JSONPb) NewEncoder(w io.Writer) gwruntime.Encoder {
 		return errors.Errorf("unexpected type %T does not implement %s", v, typeProtoMessage)
 	})
 }
+
+var _ gwruntime.Delimited = (*JSONPb)(nil)
+
+// Delimiter implements gwruntime.Delimited.
+func (*JSONPb) Delimiter() []byte {
+	return []byte("\n")
+}

--- a/pkg/util/protoutil/marshaler.go
+++ b/pkg/util/protoutil/marshaler.go
@@ -101,3 +101,10 @@ func (e *protoEncoder) Encode(v interface{}) error {
 	}
 	return errors.Errorf("unexpected type %T does not implement %s", v, typeProtoMessage)
 }
+
+var _ gwruntime.Delimited = (*ProtoPb)(nil)
+
+// Delimiter implements gwruntime.Delimited.
+func (*ProtoPb) Delimiter() []byte {
+	return nil
+}


### PR DESCRIPTION
Implement the Delimited interface for the gogo/protobuf JSONPb marshaller. This was added in https://github.com/grpc-ecosystem/grpc-gateway/commit/e4b8a938efae14de11fd97311e873e989896348c.

Fixes #20925

@tamird 