### PR TITLE
opt: index constraints for tuple IN tuple

### DIFF
--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -394,3 +394,110 @@ legacy-normalize,build-scalar,index-constraints columns=(int, int, int, int)
 (@1, @2, @4) BETWEEN (1, 2, 3) AND (4, 5, 6)
 ----
 [/1/2 - /4/5]
+
+# Tests with tuple IN tuple.
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) IN ((1, 2, 3), (4, 5, 6))
+----
+[/1/2/3 - /1/2/3]
+[/4/5/6 - /4/5/6]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) IN ((4, 5, 6), (1, 2, 3))
+----
+[/1/2/3 - /1/2/3]
+[/4/5/6 - /4/5/6]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) IN ((1, 2, 3), (1, 2, 3))
+----
+[/1/2/3 - /1/2/3]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1, @2, @3) IN ((1, 2, 3), (4, 5, 6), (1, 2, 3))
+----
+[/1/2/3 - /1/2/3]
+[/4/5/6 - /4/5/6]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+(@1+5, @1, @1+@2, @2) IN ((1, 5, 1, 6), (2, 7, 2, 8), (3, 9, 3, 10))
+----
+[/5/6 - /5/6]
+[/7/8 - /7/8]
+[/9/10 - /9/10]
+
+# Verify we sort and de-duplicate if we "project" the tuples;
+# in this case the expression becomes:
+#   (@1, @2) IN ((5, 5), (4, 4), (5, 5))
+build-scalar,normalize,index-constraints columns=(int, int)
+(@1+5, @1, @1+@2, @2) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
+----
+[/4/4 - /4/4]
+[/5/5 - /5/5]
+
+build-scalar,normalize,index-constraints columns=(int, int)
+(@2, @1) IN ((1, 5), (2, 1), (3, 4), (4, 1))
+----
+[/1/2 - /1/2]
+[/1/4 - /1/4]
+[/4/3 - /4/3]
+[/5/1 - /5/1]
+
+build-scalar,normalize,index-constraints columns=(int desc, int)
+(@2, @1) IN ((1, 5), (2, 1), (3, 4), (4, 1))
+----
+[/5/1 - /5/1]
+[/4/3 - /4/3]
+[/1/2 - /1/2]
+[/1/4 - /1/4]
+
+build-scalar,normalize,index-constraints columns=(int, int desc)
+(@2, @1) IN ((1, 5), (2, 1), (3, 4), (4, 1))
+----
+[/1/4 - /1/4]
+[/1/2 - /1/2]
+[/4/3 - /4/3]
+[/5/1 - /5/1]
+
+build-scalar,normalize,index-constraints columns=(int desc, int desc)
+(@2, @1) IN ((1, 5), (2, 1), (3, 4), (4, 1))
+----
+[/5/1 - /5/1]
+[/4/3 - /4/3]
+[/1/4 - /1/4]
+[/1/2 - /1/2]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+@1 = 1 AND (@2, @3) IN ((2, 3), (4, 5), (6, 7))
+----
+[/1/2/3 - /1/2/3]
+[/1/4/5 - /1/4/5]
+[/1/6/7 - /1/6/7]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+@3 = 1 AND (@1, @2) IN ((2, 3), (4, 5), (6, 7))
+----
+[/2/3/1 - /2/3/1]
+[/4/5/1 - /4/5/1]
+[/6/7/1 - /6/7/1]
+
+# Here the best we can do is to effectively break up the IN constraint into
+# constraints on @1 and on @3, which results in more spans than we need.
+build-scalar,normalize,index-constraints columns=(int, int, int)
+@2 = 1 AND (@1, @3) IN ((2, 3), (4, 5), (6, 7))
+----
+[/2/1/3 - /2/1/3]
+[/2/1/5 - /2/1/5]
+[/2/1/7 - /2/1/7]
+[/4/1/3 - /4/1/3]
+[/4/1/5 - /4/1/5]
+[/4/1/7 - /4/1/7]
+[/6/1/3 - /6/1/3]
+[/6/1/5 - /6/1/5]
+[/6/1/7 - /6/1/7]
+
+build-scalar,normalize,index-constraints columns=(int, int, int)
+@1 > 1 AND (@2, @3) IN ((2, 3), (4, 5), (6, 7))
+----
+[/2/2/3 - ]


### PR DESCRIPTION
Index constraints for expressions like `(a, b) IN ((1, 2), (3, 4))`.

Release note: None