### PR TITLE
 sql: disallow statement sources with no output

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -407,8 +407,13 @@ func (p *planner) getDataSource(
 		if err != nil {
 			return planDataSource{}, err
 		}
+		cols := planColumns(plan)
+		if len(cols) == 0 {
+			return planDataSource{}, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError,
+				"statement source \"%v\" does not return any columns", t.Statement)
+		}
 		return planDataSource{
-			info: newSourceInfoForSingleTable(anonymousTable, planColumns(plan)),
+			info: newSourceInfoForSingleTable(anonymousTable, cols),
 			plan: plan,
 		}, nil
 

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -270,10 +270,3 @@ delete                ·      ·
            │          limit  10
            └── scan   ·      ·
 ·                     table  indexed@primary
-
-# Ensure that if the fast path is selected, DELETE is still a valid
-# data source (#19805).
-query I
-INSERT INTO indexed(id,value) VALUES (1,2); SELECT 1 FROM [DELETE FROM indexed]
-----
-1

--- a/pkg/sql/logictest/testdata/logic_test/statement_source
+++ b/pkg/sql/logictest/testdata/logic_test/statement_source
@@ -1,0 +1,10 @@
+# LogicTest: default parallel-stmts
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY, b INT)
+
+query error statement source "INSERT INTO a VALUES \(1, 2\)" does not return any columns
+SELECT 1 FROM [INSERT INTO a VALUES (1, 2)]
+
+query error statement source "DELETE FROM a" does not return any columns
+SELECT 1 FROM [DELETE FROM a]

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -131,7 +131,7 @@ type valuesRun struct {
 func (n *valuesNode) startExec(params runParams) error {
 	if n.rows != nil {
 		if !n.isConst {
-			log.Fatalf(params.ctx, "valuesNode evaluted twice")
+			log.Fatalf(params.ctx, "valuesNode evaluated twice")
 		}
 		return nil
 	}


### PR DESCRIPTION
Split from #20919. 

Previously, statements like the following were permitted:

```
SELECT 1 FROM [DELETE FROM x]
```

This is nonsensical, because the `DELETE FROM x` statement doesn't
return any rows or columns.

Fixes #20970.