### PR TITLE
storage/ui: add metric and graphs for node liveness heartbeat latency

### DIFF
--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -97,6 +97,7 @@ func createTestNode(
 	cfg.DB = client.NewDB(sender, cfg.Clock)
 	cfg.Transport = storage.NewDummyRaftTransport(st)
 	active, renewal := cfg.NodeLivenessDurations()
+	cfg.HistogramWindowInterval = metric.TestSampleInterval
 	cfg.NodeLiveness = storage.NewNodeLiveness(
 		cfg.AmbientCtx,
 		cfg.Clock,
@@ -104,6 +105,7 @@ func createTestNode(
 		cfg.Gossip,
 		active,
 		renewal,
+		cfg.HistogramWindowInterval,
 	)
 	storage.TimeUntilStoreDead.Override(&cfg.Settings.SV, 10*time.Millisecond)
 	cfg.StorePool = storage.NewStorePool(

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -256,7 +256,13 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	nlActive, nlRenewal := s.cfg.NodeLivenessDurations()
 
 	s.nodeLiveness = storage.NewNodeLiveness(
-		s.cfg.AmbientCtx, s.clock, s.db, s.gossip, nlActive, nlRenewal,
+		s.cfg.AmbientCtx,
+		s.clock,
+		s.db,
+		s.gossip,
+		nlActive,
+		nlRenewal,
+		s.cfg.HistogramWindowInterval(),
 	)
 	s.registry.AddMetricStruct(s.nodeLiveness.Metrics())
 

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -743,7 +743,7 @@ func (m *multiTestContext) addStore(idx int) {
 	nlActive, nlRenewal := cfg.NodeLivenessDurations()
 	m.nodeLivenesses[idx] = storage.NewNodeLiveness(
 		ambient, m.clocks[idx], m.dbs[idx], m.gossips[idx],
-		nlActive, nlRenewal,
+		nlActive, nlRenewal, metric.TestSampleInterval,
 	)
 	m.populateStorePool(idx, m.nodeLivenesses[idx])
 	cfg.DB = m.dbs[idx]
@@ -903,7 +903,7 @@ func (m *multiTestContext) restartStoreWithoutHeartbeat(i int) {
 	nlActive, nlRenewal := cfg.NodeLivenessDurations()
 	m.nodeLivenesses[i] = storage.NewNodeLiveness(
 		log.AmbientContext{Tracer: m.storeConfig.Settings.Tracer}, m.clocks[i], m.dbs[i], m.gossips[i],
-		nlActive, nlRenewal,
+		nlActive, nlRenewal, metric.TestSampleInterval,
 	)
 	m.populateStorePool(i, m.nodeLivenesses[i])
 	cfg.DB = m.dbs[i]

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -126,6 +126,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 	cfg.AmbientCtx = ambient
 	cfg.DB = ltc.DB
 	cfg.Gossip = ltc.Gossip
+	cfg.HistogramWindowInterval = metric.TestSampleInterval
 	active, renewal := cfg.NodeLivenessDurations()
 	cfg.NodeLiveness = storage.NewNodeLiveness(
 		cfg.AmbientCtx,
@@ -134,6 +135,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 		cfg.Gossip,
 		active,
 		renewal,
+		cfg.HistogramWindowInterval,
 	)
 	storage.TimeUntilStoreDead.Override(&cfg.Settings.SV, storage.TestTimeUntilStoreDead)
 	cfg.StorePool = storage.NewStorePool(
@@ -146,7 +148,6 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initSende
 	)
 	cfg.Transport = transport
 	cfg.TimestampCachePageSize = tscache.TestSklPageSize
-	cfg.HistogramWindowInterval = metric.TestSampleInterval
 	ltc.Store = storage.NewStore(cfg, ltc.Eng, nodeDesc)
 	ctx := context.TODO()
 

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -52,7 +52,7 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph title="KV Transaction Durations: 99th percentile"
       tooltip={`The 99th percentile of transaction durations over a 1 minute period.
-                              Values are displayed individually for each node on each node.`}>
+                              Values are displayed individually for each node.`}>
       <Axis units={AxisUnits.Duration} label="transaction duration">
         {
           _.map(nodeIDs, (node) => (
@@ -70,13 +70,49 @@ export default function (props: GraphDashboardProps) {
 
     <LineGraph title="KV Transaction Durations: 90th percentile"
       tooltip={`The 90th percentile of transaction durations over a 1 minute period.
-                              Values are displayed individually for each node on each node.`}>
+                              Values are displayed individually for each node.`}>
       <Axis units={AxisUnits.Duration} label="transaction duration">
         {
           _.map(nodeIDs, (node) => (
             <Metric
               key={node}
               name="cr.node.txn.durations-p90"
+              title={nodeAddress(nodesSummary, node)}
+              sources={[node]}
+              downsampleMax
+            />
+          ))
+        }
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Node Liveness Heartbeat Latency: 99th percentile"
+      tooltip={`The 99th percentile of latency to heartbeat a node's internal liveness record over a 1 minute period.
+                              Values are displayed individually for each node.`}>
+      <Axis units={AxisUnits.Duration} label="heartbeat latency">
+        {
+          _.map(nodeIDs, (node) => (
+            <Metric
+              key={node}
+              name="cr.node.liveness.heartbeatlatency-p99"
+              title={nodeAddress(nodesSummary, node)}
+              sources={[node]}
+              downsampleMax
+            />
+          ))
+        }
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph title="Node Liveness Heartbeat Latency: 90th percentile"
+      tooltip={`The 90th percentile of latency to heartbeat a node's internal liveness record over a 1 minute period.
+                              Values are displayed individually for each node.`}>
+      <Axis units={AxisUnits.Duration} label="heartbeat latency">
+        {
+          _.map(nodeIDs, (node) => (
+            <Metric
+              key={node}
+              name="cr.node.liveness.heartbeatlatency-p90"
               title={nodeAddress(nodesSummary, node)}
               sources={[node]}
               downsampleMax

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -174,7 +174,7 @@ export default function (props: GraphDashboardProps) {
       title="Execution Latency: 99th percentile"
       tooltip={
         `The 99th percentile of latency between query requests and responses over a
-          1 minute period. Values are displayed individually for each node on each node.`
+          1 minute period. Values are displayed individually for each node.`
       }
     >
       <Axis units={AxisUnits.Duration} label="execution latency">
@@ -196,7 +196,7 @@ export default function (props: GraphDashboardProps) {
       title="Execution Latency: 90th percentile"
       tooltip={
         `The 90th percentile of latency between query requests and responses over a
-           1 minute period. Values are displayed individually for each node on each node.`
+           1 minute period. Values are displayed individually for each node.`
       }
     >
       <Axis units={AxisUnits.Duration} label="execution latency">


### PR DESCRIPTION
Release note (admin ui change): Added graphs of node liveness heartbeat
latency, an important internal signal of health, to the Distributed
dashboard.

cc #19699