### PR TITLE
cherrypick-1.1: ccl/storageccl: retry s3 region fetch

### DIFF
--- a/pkg/ccl/storageccl/export_storage.go
+++ b/pkg/ccl/storageccl/export_storage.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	gcs "cloud.google.com/go/storage"
 	azr "github.com/Azure/azure-sdk-for-go/storage"
@@ -315,6 +316,25 @@ type s3Storage struct {
 	s3     *s3.S3
 }
 
+func s3Retry(ctx context.Context, fn func() error) error {
+	const maxAttempts = 3
+	return retry.WithMaxAttempts(ctx, base.DefaultRetryOptions(), maxAttempts, func() error {
+		err := fn()
+		if s3err, ok := err.(s3.RequestFailure); ok {
+			// A 503 error could mean we need to reduce our request rate. Impose an
+			// arbitrary slowdown in that case.
+			// See http://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+			if s3err.StatusCode() == 503 {
+				select {
+				case <-time.After(time.Second * 5):
+				case <-ctx.Done():
+				}
+			}
+		}
+		return err
+	})
+}
+
 var _ ExportStorage = &s3Storage{}
 
 func makeS3Storage(ctx context.Context, conf *roachpb.ExportStorage_S3) (ExportStorage, error) {
@@ -325,7 +345,12 @@ func makeS3Storage(ctx context.Context, conf *roachpb.ExportStorage_S3) (ExportS
 	if err != nil {
 		return nil, errors.Wrap(err, "new aws session")
 	}
-	region, err := s3manager.GetBucketRegion(ctx, sess, conf.Bucket, "us-east-1")
+	var region string
+	err = s3Retry(ctx, func() error {
+		var err error
+		region, err = s3manager.GetBucketRegion(ctx, sess, conf.Bucket, "us-east-1")
+		return err
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "could not find s3 bucket's region")
 	}


### PR DESCRIPTION
Retry an S3 operation that has been causing transient errors. If a
503 is returned, we may need to slow down our request rate. Although
the retry package does wait a bit, it is only some 10s of ms. We
instead wait 5s on these errors to attempt to slightly decrease the
request rate. This 5s is purely a guess, but it is also a low enough
time that it won't matter too much if we are waiting longer than
minimally needed.

For now put this only in the place we have seen the failure. We can
optionally retry the other locations if we see problems there. This
is the same approach we used for Azure and GCE with good results.

Release note (bug fix): make S3 region detection more resilient.

Fixes #20994
Fixes #19502
Cherrypick of #19556