### PR TITLE
ui: show explanatory tooltips next to db stats

### DIFF
--- a/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
@@ -107,7 +107,7 @@ class DatabaseSummaryTables extends DatabaseSummaryBase {
             <SummaryBar>
               <SummaryHeadlineStat
                 title="Database Size"
-                tooltip="Total disk size of this database."
+                tooltip="Approximate total disk size of this database across all replicas."
                 value={this.totalSize()}
                 format={Bytes} />
               <SummaryHeadlineStat

--- a/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
+++ b/pkg/ui/src/views/databases/containers/tableDetails/index.tsx
@@ -123,7 +123,7 @@ class TableMain extends React.Component<TableMainProps, {}> {
                   format={ Bytes }/>
                 <SummaryHeadlineStat
                   title="Ranges"
-                  tooltip="The total number of ranges in this database."
+                  tooltip="The total number of ranges in this table."
                   value={ tableInfo.rangeCount }/>
               </SummaryBar>
             </div>

--- a/pkg/ui/src/views/shared/components/summaryBar/index.tsx
+++ b/pkg/ui/src/views/shared/components/summaryBar/index.tsx
@@ -6,6 +6,7 @@ import "./summarybar.styl";
 
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
 import { MetricsDataComponentProps } from "src/views/shared/components/metricQuery";
+import {ToolTipWrapper} from "oss/src/views/shared/components/toolTip";
 
 interface SummaryValueProps {
   title: React.ReactNode;
@@ -163,7 +164,16 @@ export class SummaryHeadlineStat extends React.Component<SummaryHeadlineStatProp
   render() {
     return <div className="summary-headline">
       <div className="summary-headline__value">{computeValue(this.props.value, this.props.format)}</div>
-      <div className="summary-headline__title">{this.props.title}</div>
+      <div className="summary-headline__title">
+        {this.props.title}
+        <div className="section-heading__tooltip">
+          <ToolTipWrapper text={this.props.tooltip}>
+            <div className="section-heading__tooltip-hover-area">
+              <div className="section-heading__info-icon">i</div>
+            </div>
+          </ToolTipWrapper>
+        </div>
+      </div>
     </div>;
   }
 }

--- a/pkg/ui/styl/layout/layout.styl
+++ b/pkg/ui/styl/layout/layout.styl
@@ -146,6 +146,7 @@ $page-padding-top   = 20px
     color $tooltip-color
     line-height 11px
     text-align center
+    cursor default
 
   .hover-tooltip--hovered &__info-icon
     border-color $body-color


### PR DESCRIPTION
(The text for these was there but not getting rendered)
On db page:
<img width="627" alt="screen shot 2017-12-21 at 6 26 44 pm" src="https://user-images.githubusercontent.com/7341/34279046-90a59b8c-e67c-11e7-8249-304b84d13ddd.png">

On table details page:
<img width="546" alt="screen shot 2017-12-21 at 6 22 47 pm" src="https://user-images.githubusercontent.com/7341/34279049-98daed02-e67c-11e7-9041-880d71d028ee.png">

cc @tschottdorf

Also should follow up with #20921 

Release note: None