### PR TITLE
storage: expand TestingRelocateRange's retryable snapshot error whitelist

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -2385,7 +2385,8 @@ func TestingRelocateRange(
 
 	canRetry := func(err error) bool {
 		whitelist := []string{
-			"snapshot intersects existing range",
+			snapshotApplySemBusyMsg,
+			IntersectingSnapshotMsg,
 		}
 		for _, substr := range whitelist {
 			if strings.Contains(err.Error(), substr) {


### PR DESCRIPTION
TestLogic/5node-distsql-disk/distsql_distinct_on was flaky because
TESTING_RELOCATE would occasionally fail with "store busy applying
snapshots and/or removing replicas." TESTING_RELOCATE should
automatically retry in that case, so add the error message to the list.

Also take the opportunity to use the recently-created constants for
these error messages.

Fixes #20999.

Release note: None