### PR TITLE
sql: add json_object

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -373,11 +373,15 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>json_extract_path(jsonb, <a href="string.html">string</a>...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the JSON value pointed to by the variadic arguments.</p>
 </span></td></tr>
+<tr><td><code>json_object(keys: <a href="string.html">string</a>[], values: <a href="string.html">string</a>[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>This form of json_object takes keys and values pairwise from two separate arrays. In all other respects it is identical to the one-argument form.</p>
+</span></td></tr>
 <tr><td><code>json_typeof(val: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the type of the outermost JSON value as a text string.</p>
 </span></td></tr>
 <tr><td><code>jsonb_build_array(anyelement...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Builds a possibly-heterogeneously-typed JSON or JSONB array out of a variadic argument list.</p>
 </span></td></tr>
 <tr><td><code>jsonb_extract_path(jsonb, <a href="string.html">string</a>...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the JSON value pointed to by the variadic arguments.</p>
+</span></td></tr>
+<tr><td><code>jsonb_object(keys: <a href="string.html">string</a>[], values: <a href="string.html">string</a>[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>This form of json_object takes keys and values pairwise from two separate arrays. In all other respects it is identical to the one-argument form.</p>
 </span></td></tr>
 <tr><td><code>jsonb_pretty(val: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the given JSON value as a STRING indented and with newlines.</p>
 </span></td></tr>
@@ -523,6 +527,17 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <tr><td><code>trunc(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Truncates the decimal values of <code>val</code>.</p>
 </span></td></tr>
 <tr><td><code>trunc(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Truncates the decimal values of <code>val</code>.</p>
+</span></td></tr></tbody>
+</table>
+
+### STRING[] Functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>json_object(texts: <a href="string.html">string</a>[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Builds a JSON or JSONB object out of a text array. The array must have exactly one dimension with an even number of members, in which case they are taken as alternating key/value pairs.</p>
+</span></td></tr>
+<tr><td><code>jsonb_object(texts: <a href="string.html">string</a>[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Builds a JSON or JSONB object out of a text array. The array must have exactly one dimension with an even number of members, in which case they are taken as alternating key/value pairs.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -454,3 +454,109 @@ query T
 SELECT jsonb_build_array(1, '1'::JSON, 1.2, NULL, ARRAY['x', 'y'])
 ----
 [1,1,1.2,null,["x","y"]]
+
+query error pq: json_object\(\): array must have even number of elements
+SELECT json_object('{a,b,c}'::TEXT[])
+
+query error pq: json_object\(\): null value not allowed for object key
+SELECT json_object('{NULL, a}'::TEXT[])
+
+query error pq: json_object\(\): null value not allowed for object key
+SELECT json_object('{a,b,NULL,"d e f"}'::TEXT[],'{1,2,3,"a b c"}'::TEXT[])
+
+query error pq: json_object\(\): mismatched array dimensions
+SELECT json_object('{a,b,c,"d e f",g}'::TEXT[],'{1,2,3,"a b c"}'::TEXT[])
+
+query error pq: json_object\(\): mismatched array dimensions
+SELECT json_object('{a,b,c,"d e f"}'::TEXT[],'{1,2,3,"a b c",g}'::TEXT[])
+
+query error pq: unknown signature: json_object\(collatedstring\{fr_FR\}\[\]\)
+SELECT json_object(ARRAY['a'::TEXT COLLATE "fr_FR"])
+
+query T
+SELECT json_object('{}'::TEXT[])
+----
+{}
+
+query T
+SELECT json_object('{}'::TEXT[], '{}'::TEXT[])
+----
+{}
+
+query T
+SELECT json_object('{b, 3, a, 1, b, 4, a, 2}'::TEXT[])
+----
+{"a":"2","b":"4"}
+
+query T
+SELECT json_object('{b, b, a, a}'::TEXT[], '{1, 2, 3, 4}'::TEXT[])
+----
+{"a":"4","b":"2"}
+
+query T
+SELECT json_object('{a,1,b,2,3,NULL,"d e f","a b c"}'::TEXT[])
+----
+{"3":null,"a":"1","b":"2","d e f":"a b c"}
+
+query T
+SELECT json_object('{a,b,"","d e f"}'::TEXT[],'{1,2,3,"a b c"}'::TEXT[])
+----
+{"":"3","a":"1","b":"2","d e f":"a b c"}
+
+query T
+SELECT json_object('{a,b,c,"d e f"}'::TEXT[],'{1,2,3,"a b c"}'::TEXT[])
+----
+{"a":"1","b":"2","c":"3","d e f":"a b c"}
+
+query error pq: jsonb_object\(\): array must have even number of elements
+SELECT jsonb_object('{a,b,c}'::TEXT[])
+
+query error pq: jsonb_object\(\): null value not allowed for object key
+SELECT jsonb_object('{NULL, a}'::TEXT[])
+
+query error pq: jsonb_object\(\): null value not allowed for object key
+SELECT jsonb_object('{a,b,NULL,"d e f"}'::TEXT[],'{1,2,3,"a b c"}'::TEXT[])
+
+query error pq: jsonb_object\(\): mismatched array dimensions
+SELECT jsonb_object('{a,b,c,"d e f",g}'::TEXT[],'{1,2,3,"a b c"}'::TEXT[])
+
+query error pq: jsonb_object\(\): mismatched array dimensions
+SELECT jsonb_object('{a,b,c,"d e f"}'::TEXT[],'{1,2,3,"a b c",g}'::TEXT[])
+
+query error pq: unknown signature: jsonb_object\(collatedstring\{fr_FR\}\[\]\)
+SELECT jsonb_object(ARRAY['a'::TEXT COLLATE "fr_FR"])
+
+query T
+SELECT jsonb_object('{}'::TEXT[])
+----
+{}
+
+query T
+SELECT jsonb_object('{}'::TEXT[], '{}'::TEXT[])
+----
+{}
+
+query T
+SELECT jsonb_object('{b, 3, a, 1, b, 4, a, 2}'::TEXT[])
+----
+{"a":"2","b":"4"}
+
+query T
+SELECT jsonb_object('{b, b, a, a}'::TEXT[], '{1, 2, 3, 4}'::TEXT[])
+----
+{"a":"4","b":"2"}
+
+query T
+SELECT jsonb_object('{a,1,b,2,3,NULL,"d e f","a b c"}'::TEXT[])
+----
+{"3":null,"a":"1","b":"2","d e f":"a b c"}
+
+query T
+SELECT jsonb_object('{a,b,"","d e f"}'::TEXT[],'{1,2,3,"a b c"}'::TEXT[])
+----
+{"":"3","a":"1","b":"2","d e f":"a b c"}
+
+query T
+SELECT jsonb_object('{a,b,c,"d e f"}'::TEXT[],'{1,2,3,"a b c"}'::TEXT[])
+----
+{"a":"1","b":"2","c":"3","d e f":"a b c"}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1629,6 +1629,10 @@ CockroachDB supports the following flags:
 
 	"jsonb_build_array": {jsonBuildArrayImpl},
 
+	"json_object": jsonObjectImpls,
+
+	"jsonb_object": jsonObjectImpls,
+
 	"ln": {
 		floatBuiltin1(func(x float64) (tree.Datum, error) {
 			return tree.NewDFloat(tree.DFloat(math.Log(x))), nil
@@ -2458,6 +2462,15 @@ var (
 	jsonObjectDString  = tree.NewDString("object")
 )
 
+var (
+	errJSONObjectNotEvenNumberOfElements = pgerror.NewError(pgerror.CodeInvalidParameterValueError,
+		"array must have even number of elements")
+	errJSONObjectNullValueForKey = pgerror.NewError(pgerror.CodeInvalidParameterValueError,
+		"null value not allowed for object key")
+	errJSONObjectMismatchedArrayDim = pgerror.NewError(pgerror.CodeInvalidParameterValueError,
+		"mismatched array dimensions")
+)
+
 var jsonExtractPathImpl = tree.Builtin{
 	Types:      tree.VariadicType{FixedTypes: []types.T{types.JSON}, VarType: types.String},
 	ReturnType: tree.FixedReturnType(types.JSON),
@@ -2535,6 +2548,69 @@ var jsonBuildArrayImpl = tree.Builtin{
 		return tree.NewDJSON(json.FromArrayOfJSON(jsons)), nil
 	},
 	Info: "Builds a possibly-heterogeneously-typed JSON or JSONB array out of a variadic argument list.",
+}
+
+var jsonObjectImpls = []tree.Builtin{
+	{
+		Types:      tree.ArgTypes{{"texts", types.TArray{Typ: types.String}}},
+		ReturnType: tree.FixedReturnType(types.JSON),
+		Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+			arr := tree.MustBeDArray(args[0])
+			if arr.Len()%2 != 0 {
+				return nil, errJSONObjectNotEvenNumberOfElements
+			}
+			builder := json.NewBuilder()
+			for i := 0; i < arr.Len(); i += 2 {
+				if arr.Array[i] == tree.DNull {
+					return nil, errJSONObjectNullValueForKey
+				}
+				key, err := asJSONObjectKey(arr.Array[i])
+				if err != nil {
+					return nil, err
+				}
+				val, err := asJSON(arr.Array[i+1])
+				if err != nil {
+					return nil, err
+				}
+				builder.Add(key, val)
+			}
+			return tree.NewDJSON(builder.Build()), nil
+		},
+		Info: "Builds a JSON or JSONB object out of a text array. The array must have " +
+			"exactly one dimension with an even number of members, in which case " +
+			"they are taken as alternating key/value pairs.",
+	},
+	{
+		Types: tree.ArgTypes{{"keys", types.TArray{Typ: types.String}},
+			{"values", types.TArray{Typ: types.String}}},
+		ReturnType: tree.FixedReturnType(types.JSON),
+		Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+			keys := tree.MustBeDArray(args[0])
+			values := tree.MustBeDArray(args[1])
+			if keys.Len() != values.Len() {
+				return nil, errJSONObjectMismatchedArrayDim
+			}
+			builder := json.NewBuilder()
+			for i := 0; i < keys.Len(); i++ {
+				if keys.Array[i] == tree.DNull {
+					return nil, errJSONObjectNullValueForKey
+				}
+				key, err := asJSONObjectKey(keys.Array[i])
+				if err != nil {
+					return nil, err
+				}
+				val, err := asJSON(values.Array[i])
+				if err != nil {
+					return nil, err
+				}
+				builder.Add(key, val)
+			}
+			return tree.NewDJSON(builder.Build()), nil
+		},
+		Info: "This form of json_object takes keys and values pairwise from two " +
+			"separate arrays. In all other respects it is identical to the " +
+			"one-argument form.",
+	},
 }
 
 func arrayBuiltin(impl func(types.T) tree.Builtin) []tree.Builtin {
@@ -3333,5 +3409,14 @@ func asJSON(d tree.Datum) (json.JSON, error) {
 			return json.MakeJSON(nil)
 		}
 		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected type %T for asJSON", d)
+	}
+}
+
+func asJSONObjectKey(d tree.Datum) (string, error) {
+	switch t := d.(type) {
+	case *tree.DString:
+		return string(*t), nil
+	default:
+		return "", pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected type %T for asJSONObjectKey", d)
 	}
 }


### PR DESCRIPTION
Partially implements the functions of json_object, sqls below are not supported.
1. collocated string or mix collocated string with string
```
SELECT json_object(ARRAY['a'::TEXT COLLATE "fr_FR"])
SELECT json_object(ARRAY['a'::TEXT COLLATE "fr_FR", 'b'])
```

Related to #20120.

Release note: None