### PR TITLE
sql: support builtin json_build_object

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -371,6 +371,8 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <tbody>
 <tr><td><code>json_build_array(anyelement...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Builds a possibly-heterogeneously-typed JSON or JSONB array out of a variadic argument list.</p>
 </span></td></tr>
+<tr><td><code>json_build_object(anyelement...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Builds a JSON object out of a variadic argument list.</p>
+</span></td></tr>
 <tr><td><code>json_extract_path(jsonb, <a href="string.html">string</a>...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the JSON value pointed to by the variadic arguments.</p>
 </span></td></tr>
 <tr><td><code>json_object(keys: <a href="string.html">string</a>[], values: <a href="string.html">string</a>[]) &rarr; jsonb</code></td><td><span class="funcdesc"><p>This form of json_object takes keys and values pairwise from two separate arrays. In all other respects it is identical to the one-argument form.</p>
@@ -378,6 +380,8 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <tr><td><code>json_typeof(val: jsonb) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the type of the outermost JSON value as a text string.</p>
 </span></td></tr>
 <tr><td><code>jsonb_build_array(anyelement...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Builds a possibly-heterogeneously-typed JSON or JSONB array out of a variadic argument list.</p>
+</span></td></tr>
+<tr><td><code>jsonb_build_object(anyelement...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Builds a JSON object out of a variadic argument list.</p>
 </span></td></tr>
 <tr><td><code>jsonb_extract_path(jsonb, <a href="string.html">string</a>...) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the JSON value pointed to by the variadic arguments.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -375,6 +375,74 @@ a
 query error pq: json_object_keys\(\): cannot iterate keys of non-object
 SELECT json_object_keys('[1, 2, 3]'::JSON)
 
+## json_build_object
+
+query T
+SELECT json_build_object()
+----
+{}
+
+query T
+SELECT json_build_object('a', 2, 'b', 4)
+----
+{"a":2,"b":4}
+
+query T
+SELECT jsonb_build_object(true,'val',1, 0, 1.3, 2, date '2019-02-03' - date '2019-01-01', 4)
+----
+{"1":0,"1.3":2,"33":4,"true":"val"}
+
+query T
+SELECT json_build_object('a',1,'b',1.2,'c',true,'d',null,'e','{"x": 3, "y": [1,2,3]}'::JSON)
+----
+{"a":1,"b":1.2,"c":true,"d":null,"e":{"x":3,"y":[1,2,3]}}
+
+query T
+SELECT json_build_object(
+       'a', json_build_object('b',false,'c',99),
+       'd', json_build_object('e',ARRAY[9,8,7]::int[])
+)
+----
+{"a":{"b":false,"c":99},"d":{"e":[9,8,7]}}
+
+query T
+SELECT json_build_object(a,3) FROM (SELECT 1 AS a, 2 AS b) r
+----
+{"1":3}
+
+query T
+SELECT json_build_object('\a'::TEXT COLLATE "fr_FR", 1)
+----
+{"\\a":1}
+
+query T
+SELECT json_build_object('\a', 1)
+----
+{"\\a":1}
+
+query T
+SELECT json_build_object(json_object_keys('{"x":3, "y":4}'::JSON), 2)
+----
+{"x":2}
+{"y":2}
+
+# even number of arguments
+query error pq: json_build_object\(\): argument list must have even number of elements
+SELECT json_build_object(1,2,3)
+
+# keys must be scalar and not null
+query error pq: json_build_object\(\): argument 1 cannot be null
+SELECT json_build_object(null,2)
+
+query error pq: json_build_object\(\): key value must be scalar, not array, tuple, or json
+SELECT json_build_object((1,2),3)
+
+query error pq: json_build_object\(\): key value must be scalar, not array, tuple, or json
+SELECT json_build_object('{"a":1,"b":2}'::JSON, 3)
+
+query error pq: json_build_object\(\): key value must be scalar, not array, tuple, or json
+SELECT json_build_object('{1,2,3}'::int[], 3)
+
 query T
 SELECT json_extract_path('{"a": 1}', 'a')
 ----

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1629,6 +1629,10 @@ CockroachDB supports the following flags:
 
 	"jsonb_build_array": {jsonBuildArrayImpl},
 
+	"json_build_object": {jsonBuildObjectImpl},
+
+	"jsonb_build_object": {jsonBuildObjectImpl},
+
 	"json_object": jsonObjectImpls,
 
 	"jsonb_object": jsonObjectImpls,
@@ -2517,6 +2521,41 @@ var jsonTypeOfImpl = tree.Builtin{
 		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected JSON type %d", t)
 	},
 	Info: "Returns the type of the outermost JSON value as a text string.",
+}
+
+var jsonBuildObjectImpl = tree.Builtin{
+	Types:        tree.VariadicType{VarType: types.Any},
+	ReturnType:   tree.FixedReturnType(types.JSON),
+	NullableArgs: true,
+	Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+		if len(args)%2 != 0 {
+			return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError,
+				"argument list must have even number of elements")
+		}
+
+		builder := json.NewBuilder()
+		for i := 0; i < len(args); i += 2 {
+			if args[i] == tree.DNull {
+				return nil, pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError,
+					"argument %d cannot be null", i+1)
+			}
+
+			key, err := asJSONBuildObjectKey(args[i])
+			if err != nil {
+				return nil, err
+			}
+
+			val, err := asJSON(args[i+1])
+			if err != nil {
+				return nil, err
+			}
+
+			builder.Add(key, val)
+		}
+
+		return tree.NewDJSON(builder.Build()), nil
+	},
+	Info: "Builds a JSON object out of a variadic argument list.",
 }
 
 var toJSONImpl = tree.Builtin{
@@ -3409,6 +3448,23 @@ func asJSON(d tree.Datum) (json.JSON, error) {
 			return json.MakeJSON(nil)
 		}
 		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected type %T for asJSON", d)
+	}
+}
+
+// Converts a scalar Datum to its string representation
+func asJSONBuildObjectKey(d tree.Datum) (string, error) {
+	switch t := d.(type) {
+	case *tree.DJSON, *tree.DArray, *tree.DTuple:
+		return "", pgerror.NewError(pgerror.CodeInvalidParameterValueError,
+			"key value must be scalar, not array, tuple, or json")
+	case *tree.DString:
+		return string(*t), nil
+	case *tree.DCollatedString:
+		return t.Contents, nil
+	case *tree.DBool, *tree.DInt, *tree.DFloat, *tree.DDecimal, *tree.DTimestamp, *tree.DTimestampTZ, *tree.DDate, *tree.DUuid, *tree.DInterval, *tree.DBytes, *tree.DIPAddr, *tree.DOid, *tree.DTime:
+		return tree.AsStringWithFlags(d, tree.FmtBareStrings), nil
+	default:
+		return "", pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected type %T for key value", d)
 	}
 }
 


### PR DESCRIPTION
Implements json_build_object as mentioned in #20120. I noticed this might have some overlaps with #21015. Let me know if I should consolidate common functionality after that PR is merged.