### PR TITLE
opt: index constraints for top-level OR

### DIFF
--- a/pkg/sql/opt/index_constraints_spans_test.go
+++ b/pkg/sql/opt/index_constraints_spans_test.go
@@ -16,12 +16,16 @@ package opt
 
 import (
 	"fmt"
+	"math/rand"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 // parses a span with integer column values in the format of LogicalSpan.String.
@@ -79,7 +83,34 @@ func parseSpan(str string) LogicalSpan {
 	return LogicalSpan{Start: start, End: end}
 }
 
+// parseSpans parses a list of spans with integer values
+// like:
+//   [/1 - /2], [/5 - /6]
+func parseSpans(str string) LogicalSpans {
+	if str == "" {
+		return nil
+	}
+	var result LogicalSpans
+	for _, s := range strings.Split(str, ", ") {
+		result = append(result, parseSpan(s))
+	}
+	return result
+}
+
+func spansStr(spans LogicalSpans) string {
+	var str string
+	for _, sp := range spans {
+		if str != "" {
+			str += ", "
+		}
+		str += sp.String()
+	}
+	return str
+}
+
 func TestIntersectSpan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	testData := []struct {
 		a, b string
 		// expected value
@@ -137,18 +168,16 @@ func TestIntersectSpan(t *testing.T) {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			sp1 := parseSpan(tc.a)
 			sp2 := parseSpan(tc.b)
-			c := indexConstraintCalc{
-				indexConstraintCtx: indexConstraintCtx{
-					// Only the directions from colInfos are used by intersectSpan
-					colInfos: []IndexColumnInfo{
-						{Direction: encoding.Ascending},
-						{Direction: encoding.Ascending},
-					},
-					evalCtx: &evalCtx,
+			c := indexConstraintCtx{
+				// Only the directions from colInfos are used by intersectSpan
+				colInfos: []IndexColumnInfo{
+					{Direction: encoding.Ascending},
+					{Direction: encoding.Ascending},
 				},
+				evalCtx: &evalCtx,
 			}
 			res := ""
-			if sp3, ok := c.intersectSpan(0 /* depth */, &sp1, &sp2); ok {
+			if sp3, ok := c.intersectSpan(0 /* offset */, &sp1, &sp2); ok {
 				res = sp3.String()
 			}
 			if res != tc.e {
@@ -156,4 +185,181 @@ func TestIntersectSpan(t *testing.T) {
 			}
 		})
 	}
+}
+
+// randSpans is a set of randomly generated LogicalSpans with
+// integer endpoints, along with a bitmap representation of the
+// intervals.
+type randSpans struct {
+	spans  LogicalSpans
+	bitmap []bool
+}
+
+const randSpansBitmapSize = 1000
+
+func makeRandSpans(rng *rand.Rand) randSpans {
+	spans := make(LogicalSpans, rng.Intn(5))
+	bitmap := make([]bool, randSpansBitmapSize)
+	last := 0
+	for i := range spans {
+		// Generate an integer interval [start, end].
+		// We multiply by two to make sure we don't generate intervals
+		// like [0, 1] and [2, 3] which seem disjoint but are not disjoint
+		// in the bitmap.
+		start := last + 2 + 2*rng.Intn(10)
+		end := start + 2 + 2*rng.Intn(10)
+		last = end
+		for k := start; k <= end; k++ {
+			bitmap[k] = true
+		}
+
+		sp := &spans[i]
+		*sp = MakeFullSpan()
+		// Randomly make the endpoints inclusive or exclusive (while
+		// effectively indicating the same interval).
+		if rng.Intn(2) == 0 {
+			sp.Start.Inclusive = false
+			start--
+		}
+		if rng.Intn(2) == 0 {
+			sp.End.Inclusive = false
+			end++
+		}
+		sp.Start.Vals = tree.Datums{tree.NewDInt(tree.DInt(start))}
+		sp.End.Vals = tree.Datums{tree.NewDInt(tree.DInt(end))}
+	}
+	return randSpans{spans: spans, bitmap: bitmap}
+}
+
+// mergeRandSpans merges the bitmaps of two randSpans and returns
+// the result as a list of intervals.
+func mergeRandSpans(a randSpans, b randSpans) [][2]int {
+	var result [][2]int
+
+	for i := 0; i < randSpansBitmapSize; i++ {
+		if !a.bitmap[i] && !b.bitmap[i] {
+			continue
+		}
+		start := i
+		for i++; a.bitmap[i] || b.bitmap[i]; i++ {
+		}
+		end := i - 1
+		result = append(result, [2]int{start, end})
+	}
+	return result
+}
+
+func TestMergeSpanSets(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testData := []struct {
+		a, b string
+		// expected value
+		e string
+	}{
+		{
+			a: "[/1 - /3]",
+			b: "[/2 - /4]",
+			e: "[/1 - /4]",
+		},
+		{
+			a: "",
+			b: "[/1 - /2]",
+			e: "[/1 - /2]",
+		},
+		{
+			a: "[ - ]",
+			b: "[/1 - /2]",
+			e: "[ - ]",
+		},
+		{
+			a: "[/1 - /2], [/3 - /5]",
+			b: "[/2 - /4]",
+			e: "[/1 - /5]",
+		},
+		{
+			a: "[/1 - /2], [/3 - /5]",
+			b: "[/2/5 - /4]",
+			e: "[/1 - /5]",
+		},
+		{
+			a: "[/1 - /2), [/3 - /5]",
+			b: "[/2/5 - /4]",
+			e: "[/1 - /2), [/2/5 - /5]",
+		},
+		{
+			a: "[/1 - /2], [/4 - /5]",
+			b: "(/2 - /4)",
+			e: "[/1 - /5]",
+		},
+		{
+			a: "[/1 - /2), (/4 - /5]",
+			b: "[/2 - /4]",
+			e: "[/1 - /5]",
+		},
+		{
+			a: "[/1 - /3], [/8 - /10], (/13 - /15)",
+			b: "[/0 - /0], (/4 - /5], (/9 - /14]",
+			e: "[/0 - /0], [/1 - /3], (/4 - /5], [/8 - /15)",
+		},
+	}
+
+	evalCtx := tree.MakeTestingEvalContext()
+
+	for i, tc := range testData {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			a := parseSpans(tc.a)
+			b := parseSpans(tc.b)
+			c := indexConstraintCtx{
+				colInfos: []IndexColumnInfo{
+					{Direction: encoding.Ascending},
+					{Direction: encoding.Ascending},
+				},
+				evalCtx: &evalCtx,
+			}
+			res := spansStr(c.mergeSpanSets(0 /* offset */, a, b))
+			if res != tc.e {
+				t.Errorf("expected  %s  got  %s", tc.e, res)
+			}
+		})
+	}
+
+	t.Run("rand", func(t *testing.T) {
+		rng, _ := randutil.NewPseudoRand()
+		for n := 0; n < 100; n++ {
+			// We generate two random sets of intervals with small integer values and
+			// cross-check mergeSpanSets with a simple bitmap-based implementation.
+			a := makeRandSpans(rng)
+			b := makeRandSpans(rng)
+			c := indexConstraintCtx{
+				colInfos: []IndexColumnInfo{{Direction: encoding.Ascending}},
+				evalCtx:  &evalCtx,
+			}
+			mergedSpans := c.mergeSpanSets(0 /* offset */, a.spans, b.spans)
+			// Convert back to integer intervals and check against the bitmap.
+			var result [][2]int
+			for _, sp := range mergedSpans {
+				start := int(*sp.Start.Vals[0].(*tree.DInt))
+				if !sp.Start.Inclusive {
+					start++
+				}
+				end := int(*sp.End.Vals[0].(*tree.DInt))
+				if !sp.End.Inclusive {
+					end--
+				}
+				result = append(result, [2]int{start, end})
+			}
+			expected := mergeRandSpans(a, b)
+			if !reflect.DeepEqual(expected, result) {
+				t.Errorf(`
+       a: %v
+       b: %v
+  merged: %v
+  result: %v
+expected: %v
+`,
+					a.spans, b.spans, mergedSpans, result, expected)
+			}
+		}
+	})
 }

--- a/pkg/sql/opt/main_test.go
+++ b/pkg/sql/opt/main_test.go
@@ -1,0 +1,29 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package opt
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	randutil.SeedForTests()
+	os.Exit(m.Run())
+}

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -77,6 +77,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 var (
@@ -269,6 +270,8 @@ func runTest(t *testing.T, path string, f func(d *testdata) string) {
 }
 
 func TestOpt(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
 	paths, err := filepath.Glob(*logicTestData)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -702,3 +702,60 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1 not null, @2)
 @1 = @2
 ----
 [ - ]
+
+# Tests with top-level OR.
+
+build-scalar,normalize,index-constraints vars=(int) index=(@1)
+@1 = 1 OR @1 = 2
+----
+[/1 - /1]
+[/2 - /2]
+
+build-scalar,normalize,index-constraints vars=(int) index=(@1)
+@1 IS NULL OR @1 = 1
+----
+[/NULL - /NULL]
+[/1 - /1]
+
+build-scalar,normalize,index-constraints vars=(int) index=(@1)
+(@1 >= 1 AND @1 <= 5) OR (@1 >= 2 AND @1 <= 8)
+----
+[/1 - /8]
+
+build-scalar,normalize,index-constraints vars=(int) index=(@1)
+(@1 >= 1 AND @1 <= 3) OR (@1 >= 5 AND @1 <= 8)
+----
+[/1 - /3]
+[/5 - /8]
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1)
+(@1 = 1 AND @2 = 5) OR (@1 = 2 and @2 = 6)
+----
+[/1 - /1]
+[/2 - /2]
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@2)
+(@1 = 1 AND @2 = 5) OR (@1 = 2 and @2 = 6)
+----
+[/5 - /5]
+[/6 - /6]
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@2)
+@1 = 1 OR @2 = 2
+----
+[ - ]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 OR (@1, @2, @3) IN ((4, 5, 6), (7, 8, 9))
+----
+[/1 - /1]
+[/4/5/6 - /4/5/6]
+[/7/8/9 - /7/8/9]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 OR (@1 = 2 AND (@2, @3) IN ((4, 5), (6, 7))) OR (@1 = 3)
+----
+[/1 - /1]
+[/2/4/5 - /2/4/5]
+[/2/6/7 - /2/6/7]
+[/3 - /3]


### PR DESCRIPTION
Support top-level disjunction for index constraints:
 - use the existing code to generate spans for each disjunct
 - add new code to merge span sets.

Release note: None