### PR TITLE
sql: Added infomationSchmaColumnPrivilege

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -36,6 +36,7 @@ const (
 var informationSchema = virtualSchema{
 	name: informationSchemaName,
 	tables: []virtualSchemaTable{
+		informationSchemaColumnPrivileges,
 		informationSchemaColumnsTable,
 		informationSchemaKeyColumnUsageTable,
 		informationSchemaSchemataTable,
@@ -96,6 +97,47 @@ func dIntFnOrNull(fn func() (int32, bool)) tree.Datum {
 		return tree.NewDInt(tree.DInt(n))
 	}
 	return tree.DNull
+}
+
+var informationSchemaColumnPrivileges = virtualSchemaTable{
+	schema: `
+CREATE TABLE information_schema.column_privileges (
+	GRANTOR STRING NOT NULL DEFAULT '',
+	GRANTEE STRING NOT NULL DEFAULT '',
+	TABLE_CATALOG STRING NOT NULL DEFAULT '',
+	TABLE_SCHEMA STRING NOT NULL DEFAULT '',
+	TABLE_NAME STRING NOT NULL DEFAULT '',
+	COLUMN_NAME STRING NOT NULL DEFAULT '',
+	PRIVILEGE_TYPE STRING NOT NULL DEFAULT '',
+	IS_GRANTABLE BOOL NOT NULL DEFAULT FALSE
+);
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
+		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
+			columndata := privilege.List{privilege.SELECT, privilege.INSERT, privilege.UPDATE} // privileges for column level granularity
+			for _, u := range table.Privileges.Users {
+				for _, privilege := range columndata {
+					if privilege.Mask()&u.Privileges != 0 {
+						for _, cd := range table.Columns {
+							if err := addRow(
+								tree.DNull,                          // grantor
+								tree.NewDString(u.User),             // grantee
+								defString,                           // table_catalog
+								tree.NewDString(db.Name),            // table_schema
+								tree.NewDString(table.Name),         // table_name
+								tree.NewDString(cd.Name),            // column_name
+								tree.NewDString(privilege.String()), // privilege_type
+								tree.DNull,                          // is_grantable
+							); err != nil {
+								return err
+							}
+						}
+					}
+				}
+			}
+			return nil
+		})
+	},
 }
 
 var informationSchemaColumnsTable = virtualSchemaTable{
@@ -265,7 +307,7 @@ CREATE TABLE information_schema.schema_privileges (
 				for _, privilege := range u.Privileges {
 					if err := addRow(
 						tree.NewDString(u.User),    // grantee
-						defString,                  // table_catalog,
+						defString,                  // table_catalog
 						tree.NewDString(db.Name),   // table_schema
 						tree.NewDString(privilege), // privilege_type
 						tree.DNull,                 // is_grantable
@@ -513,14 +555,14 @@ CREATE TABLE information_schema.table_privileges (
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
 			for _, u := range table.Privileges.Show() {
-				for _, privilege := range u.Privileges {
+				for _, priv := range u.Privileges {
 					if err := addRow(
 						tree.DNull,                  // grantor
 						tree.NewDString(u.User),     // grantee
-						defString,                   // table_catalog,
+						defString,                   // table_catalog
 						tree.NewDString(db.Name),    // table_schema
 						tree.NewDString(table.Name), // table_name
-						tree.NewDString(privilege),  // privilege_type
+						tree.NewDString(priv),       // privilege_type
 						tree.DNull,                  // is_grantable
 						tree.DNull,                  // with_hierarchy
 					); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -165,7 +165,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   5 columns, 83 rows
+·                      size   5 columns, 84 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -222,7 +222,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      16 columns, 704 rows
+                     │                     size      16 columns, 712 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -107,6 +107,7 @@ test
 query T
 SHOW TABLES FROM information_schema
 ----
+column_privileges
 columns
 key_column_usage
 schema_privileges
@@ -230,6 +231,7 @@ crdb_internal       table_columns
 crdb_internal       table_indexes
 crdb_internal       tables
 crdb_internal       zones
+information_schema  column_privileges
 information_schema  columns
 information_schema  key_column_usage
 information_schema  schema_privileges
@@ -401,6 +403,7 @@ def            crdb_internal       table_columns              SYSTEM VIEW  1
 def            crdb_internal       table_indexes              SYSTEM VIEW  1
 def            crdb_internal       tables                     SYSTEM VIEW  1
 def            crdb_internal       zones                      SYSTEM VIEW  1
+def            information_schema  column_privileges          SYSTEM VIEW  1
 def            information_schema  columns                    SYSTEM VIEW  1
 def            information_schema  key_column_usage           SYSTEM VIEW  1
 def            information_schema  schema_privileges          SYSTEM VIEW  1
@@ -1100,3 +1103,59 @@ SELECT * FROM information_schema.sequences
 
 statement ok
 DROP DATABASE other_db CASCADE
+
+# test infomration_schema.colunm_privileges
+query TTBTT colnames
+SHOW COLUMNS FROM information_schema.column_privileges
+----
+Field           Type    Null   Default      Indices
+grantor         STRING  false  '':::STRING  {}
+grantee         STRING  false  '':::STRING  {}
+table_catalog   STRING  false  '':::STRING  {}
+table_schema    STRING  false  '':::STRING  {}
+table_name      STRING  false  '':::STRING  {}
+column_name     STRING  false  '':::STRING  {}
+privilege_type  STRING  false  '':::STRING  {}
+is_grantable    BOOL    false  false        {}
+
+
+query TTTTTTTT colnames
+SELECT * FROM information_schema.column_privileges WHERE table_name = 'eventlog'
+----
+grantor  grantee  table_catalog  table_schema  table_name  column_name  privilege_type  is_grantable
+NULL     admin    def            system        eventlog    timestamp    SELECT          NULL
+NULL     admin    def            system        eventlog    eventType    SELECT          NULL
+NULL     admin    def            system        eventlog    targetID     SELECT          NULL
+NULL     admin    def            system        eventlog    reportingID  SELECT          NULL
+NULL     admin    def            system        eventlog    info         SELECT          NULL
+NULL     admin    def            system        eventlog    uniqueID     SELECT          NULL
+NULL     admin    def            system        eventlog    timestamp    INSERT          NULL
+NULL     admin    def            system        eventlog    eventType    INSERT          NULL
+NULL     admin    def            system        eventlog    targetID     INSERT          NULL
+NULL     admin    def            system        eventlog    reportingID  INSERT          NULL
+NULL     admin    def            system        eventlog    info         INSERT          NULL
+NULL     admin    def            system        eventlog    uniqueID     INSERT          NULL
+NULL     admin    def            system        eventlog    timestamp    UPDATE          NULL
+NULL     admin    def            system        eventlog    eventType    UPDATE          NULL
+NULL     admin    def            system        eventlog    targetID     UPDATE          NULL
+NULL     admin    def            system        eventlog    reportingID  UPDATE          NULL
+NULL     admin    def            system        eventlog    info         UPDATE          NULL
+NULL     admin    def            system        eventlog    uniqueID     UPDATE          NULL
+NULL     root     def            system        eventlog    timestamp    SELECT          NULL
+NULL     root     def            system        eventlog    eventType    SELECT          NULL
+NULL     root     def            system        eventlog    targetID     SELECT          NULL
+NULL     root     def            system        eventlog    reportingID  SELECT          NULL
+NULL     root     def            system        eventlog    info         SELECT          NULL
+NULL     root     def            system        eventlog    uniqueID     SELECT          NULL
+NULL     root     def            system        eventlog    timestamp    INSERT          NULL
+NULL     root     def            system        eventlog    eventType    INSERT          NULL
+NULL     root     def            system        eventlog    targetID     INSERT          NULL
+NULL     root     def            system        eventlog    reportingID  INSERT          NULL
+NULL     root     def            system        eventlog    info         INSERT          NULL
+NULL     root     def            system        eventlog    uniqueID     INSERT          NULL
+NULL     root     def            system        eventlog    timestamp    UPDATE          NULL
+NULL     root     def            system        eventlog    eventType    UPDATE          NULL
+NULL     root     def            system        eventlog    targetID     UPDATE          NULL
+NULL     root     def            system        eventlog    reportingID  UPDATE          NULL
+NULL     root     def            system        eventlog    info         UPDATE          NULL
+NULL     root     def            system        eventlog    uniqueID     UPDATE          NULL


### PR DESCRIPTION
The default value of `granter` and `is_grantable` currently is NULL, 
I picked this from other table.

Also the [postgres documentation](https://www.postgresql.org/docs/8.3/static/infoschema-column-privileges.html) mentions about a `REFERENCES` privilege, However I am assuming its not yet part of cockroachdb

refers #8675 
