### PR TITLE
sql: return DEmptyTable when generator functions don't accept null args

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -1,5 +1,9 @@
 # LogicTest: default parallel-stmts distsql
 
+query T
+SELECT * FROM GENERATE_SERIES(NULL::INT, 3)
+----
+
 query I colnames
 SELECT * FROM GENERATE_SERIES(1, 3)
 ----

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -267,6 +267,10 @@ SELECT to_jsonb((1, 2, 'hello', NULL, NULL))
 ## json_array_elements and jsonb_array_elements
 
 query T
+SELECT json_array_elements(NULL::JSON)
+----
+
+query T
 SELECT json_array_elements('[1, 2, 3]'::JSON)
 ----
 1
@@ -342,6 +346,10 @@ SELECT jsonb_array_elements_text('{"1": 2}'::JSON)
 
 
 ## json_object_keys and jsonb_object_keys
+
+query T
+SELECT json_object_keys(NULL::JSON)
+----
 
 query T
 SELECT json_object_keys('{"1": 2, "3": 4}'::JSON)

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -66,6 +66,9 @@ var (
 
 	// DZero is the zero-valued integer Datum.
 	DZero = NewDInt(0)
+
+	// DEmptyTable is the zero-row table Datum.
+	DEmptyTable Datum = &DTable{&emptyValueGenerator{}}
 )
 
 // Datum represents a SQL value.
@@ -2790,6 +2793,30 @@ func (*DTable) Min(_ *EvalContext) (Datum, bool) { return nil, false }
 
 // Size implements the Datum interface.
 func (*DTable) Size() uintptr { return unsafe.Sizeof(DTable{}) }
+
+type emptyValueGenerator struct {
+}
+
+var emptyValueGeneratorType = types.TTable{
+	Cols:   types.TTuple{},
+	Labels: []string{},
+}
+
+func (*emptyValueGenerator) ResolvedType() types.TTable { return emptyValueGeneratorType }
+
+func (*emptyValueGenerator) Close() {}
+
+func (*emptyValueGenerator) Start() error {
+	return nil
+}
+
+func (*emptyValueGenerator) Next() (bool, error) {
+	return false, nil
+}
+
+func (*emptyValueGenerator) Values() Datums {
+	return Datums{}
+}
 
 // DOid is the Postgres OID datum. It can represent either an OID type or any
 // of the reg* types, such as regproc or regclass.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2999,6 +2999,9 @@ func (expr *FuncExpr) Eval(ctx *EvalContext) (Datum, error) {
 			return nil, err
 		}
 		if arg == DNull && !expr.fn.NullableArgs {
+			if expr.fn.Class == GeneratorClass {
+				return DEmptyTable, nil
+			}
 			return DNull, nil
 		}
 		args.D = append(args.D, arg)


### PR DESCRIPTION
Sorry, I misunderstood something about the evaluation of generator functions. Please skip it.