### PR TITLE
config,sql,sqlccl: remove index's zone configs when index is dropped

### DIFF
--- a/pkg/ccl/sqlccl/drop_test.go
+++ b/pkg/ccl/sqlccl/drop_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestDropIndexWithZoneConfigCCL(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const numRows = 100
+
+	params, _ := tests.CreateTestServerParams()
+	s, sqlDBRaw, kvDB := serverutils.StartServer(t, params)
+	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
+	defer s.Stopper().Stop(context.Background())
+
+	// Create a test table with a partitioned secondary index.
+	if err := tests.CreateKVTable(sqlDB.DB, numRows); err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.Exec(t, `CREATE INDEX i ON t.kv (v) PARTITION BY LIST (v) (
+		PARTITION p1 VALUES IN (1),
+		PARTITION p2 VALUES IN (2)
+	)`)
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "kv")
+	indexDesc, _, err := tableDesc.FindIndexByName("i")
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexSpan := tableDesc.IndexSpan(indexDesc.ID)
+	tests.CheckKeyCount(t, kvDB, indexSpan, numRows)
+
+	// Set zone configs on the primary index, secondary index, and one partition
+	// of the secondary index.
+	sqlutils.SetZoneConfig(t, sqlDB, "INDEX t.kv@primary", "")
+	sqlutils.SetZoneConfig(t, sqlDB, "INDEX t.kv@i", "")
+	sqlutils.SetZoneConfig(t, sqlDB, "PARTITION p2 OF TABLE t.kv", "")
+	for _, target := range []string{"t.kv@primary", "t.kv@i", "t.kv.p2"} {
+		if exists := sqlutils.ZoneConfigExists(t, sqlDB, target); !exists {
+			t.Fatalf(`zone config for %s does not exist`, target)
+		}
+	}
+
+	// Drop the index and verify that the zone config for the secondary index and
+	// its partition are removed but the zone config for the primary index
+	// remains.
+	sqlDB.Exec(t, `DROP INDEX t.kv@i`)
+	tests.CheckKeyCount(t, kvDB, indexSpan, 0)
+	tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "kv")
+	if _, _, err := tableDesc.FindIndexByName("i"); err == nil {
+		t.Fatalf("table descriptor still contains index after index is dropped")
+	}
+	if exists := sqlutils.ZoneConfigExists(t, sqlDB, "t.kv@primary"); !exists {
+		t.Fatal("zone config for primary index removed after dropping secondary index")
+	}
+	for _, target := range []string{"t.kv@i", "t.kv.p2"} {
+		if exists := sqlutils.ZoneConfigExists(t, sqlDB, target); exists {
+			t.Fatalf(`zone config for %s still exists`, target)
+		}
+	}
+}

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -407,6 +407,19 @@ func (z *ZoneConfig) DeleteSubzone(indexID uint32, partition string) bool {
 	return false
 }
 
+// DeleteIndexSubzones deletes all subzones that refer to the index with the
+// specified ID. This includes subzones for partitions of the index as well as
+// the index subzone itself.
+func (z *ZoneConfig) DeleteIndexSubzones(indexID uint32) {
+	subzones := z.Subzones[:0]
+	for _, s := range z.Subzones {
+		if s.IndexID != indexID {
+			subzones = append(subzones, s)
+		}
+	}
+	z.Subzones = subzones
+}
+
 func (z ZoneConfig) subzoneSplits() []roachpb.RKey {
 	var out []roachpb.RKey
 	for _, span := range z.SubzoneSpans {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1140,6 +1140,7 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 		s.clock,
 		s.jobRegistry,
 		distSQLPlanner,
+		s.st,
 		s.distSender.RangeDescriptorCache(),
 		s.distSender.LeaseHolderCache(),
 	).Start(s.stopper)

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -19,6 +19,7 @@ import (
 	gosql "database/sql"
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -385,6 +386,81 @@ func TestDropIndex(t *testing.T) {
 	}
 	tests.CheckKeyCount(t, kvDB, indexSpan, 0)
 
+	tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "kv")
+	if _, _, err := tableDesc.FindIndexByName("foo"); err == nil {
+		t.Fatalf("table descriptor still contains index after index is dropped")
+	}
+}
+
+func TestDropIndexWithZoneConfigOSS(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const chunkSize = 200
+	const numRows = 2*chunkSize + 1
+
+	params, _ := tests.CreateTestServerParams()
+	params.Knobs = base.TestingKnobs{
+		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{BackfillChunkSize: chunkSize},
+	}
+	s, sqlDBRaw, kvDB := serverutils.StartServer(t, params)
+	sqlDB := sqlutils.MakeSQLRunner(sqlDBRaw)
+	defer s.Stopper().Stop(context.Background())
+
+	// Create a test table with a secondary index.
+	if err := tests.CreateKVTable(sqlDB.DB, numRows); err != nil {
+		t.Fatal(err)
+	}
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "kv")
+	indexDesc, _, err := tableDesc.FindIndexByName("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	indexSpan := tableDesc.IndexSpan(indexDesc.ID)
+	tests.CheckKeyCount(t, kvDB, indexSpan, numRows)
+
+	// Hack in zone configs for the primary and secondary indexes. (You need a CCL
+	// binary to do this properly.) Dropping the index will thus require
+	// regenerating the zone config's SubzoneSpans, which will fail with a "CCL
+	// required" error.
+	zoneConfig := config.ZoneConfig{
+		Subzones: []config.Subzone{
+			{IndexID: uint32(tableDesc.PrimaryIndex.ID), Config: config.DefaultZoneConfig()},
+			{IndexID: uint32(indexDesc.ID), Config: config.DefaultZoneConfig()},
+		},
+	}
+	zoneConfigBytes, err := protoutil.Marshal(&zoneConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.Exec(t, `INSERT INTO system.zones VALUES ($1, $2)`, tableDesc.ID, zoneConfigBytes)
+	if exists := sqlutils.ZoneConfigExists(t, sqlDB, "t.kv@foo"); !exists {
+		t.Fatal("zone config for index does not exist")
+	}
+
+	// Verify that dropping the index fails with a "CCL required" error.
+	_, err = sqlDB.DB.Exec(`DROP INDEX t.kv@foo`)
+	if pqErr, ok := err.(*pq.Error); !ok || pqErr.Code != sqlbase.CodeCCLRequired {
+		t.Fatalf("expected pq error with CCLRequired code, but got %v", err)
+	}
+
+	// Verify that the index and its zone config still exist.
+	if exists := sqlutils.ZoneConfigExists(t, sqlDB, "t.kv@foo"); !exists {
+		t.Fatal("zone config for index no longer exists")
+	}
+	tests.CheckKeyCount(t, kvDB, indexSpan, numRows)
+	// TODO(benesch): Run scrub here. It can't currently handle the way t.kv
+	// declares column families.
+
+	// Manually remove the zone config. (Again, doing this through the normal
+	// channels requires a CCL binary.)
+	sqlDB.Exec(t, `DELETE FROM system.zones WHERE id = $1`, tableDesc.ID)
+
+	// Verify the index can now be properly dropped from an OSS binary.
+	sqlDB.Exec(t, `DROP INDEX t.kv@foo`)
+	if exists := sqlutils.ZoneConfigExists(t, sqlDB, "t.kv@foo"); exists {
+		t.Fatal("zone config for index still exists after dropping index")
+	}
+	tests.CheckKeyCount(t, kvDB, indexSpan, 0)
 	tableDesc = sqlbase.GetTableDescriptor(kvDB, "t", "kv")
 	if _, _, err := tableDesc.FindIndexByName("foo"); err == nil {
 		t.Fatalf("table descriptor still contains index after index is dropped")

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -88,6 +89,7 @@ type SchemaChanger struct {
 	rangeDescriptorCache *kv.RangeDescriptorCache
 	leaseHolderCache     *kv.LeaseHolderCache
 	clock                *hlc.Clock
+	settings             *cluster.Settings
 }
 
 // NewSchemaChangerForTesting only for tests.
@@ -106,6 +108,7 @@ func NewSchemaChangerForTesting(
 		db:          db,
 		leaseMgr:    leaseMgr,
 		jobRegistry: jobRegistry,
+		settings:    cluster.MakeTestingClusterSettings(),
 	}
 }
 
@@ -945,6 +948,7 @@ type SchemaChangeManager struct {
 	distSQLPlanner *DistSQLPlanner
 	clock          *hlc.Clock
 	jobRegistry    *jobs.Registry
+	settings       *cluster.Settings
 	// Caches updated by DistSQL.
 	rangeDescriptorCache *kv.RangeDescriptorCache
 	leaseHolderCache     *kv.LeaseHolderCache
@@ -964,6 +968,7 @@ func NewSchemaChangeManager(
 	clock *hlc.Clock,
 	jobRegistry *jobs.Registry,
 	dsp *DistSQLPlanner,
+	settings *cluster.Settings,
 	rangeDescriptorCache *kv.RangeDescriptorCache,
 	leaseHolderCache *kv.LeaseHolderCache,
 ) *SchemaChangeManager {
@@ -977,6 +982,7 @@ func NewSchemaChangeManager(
 		distSQLPlanner:       dsp,
 		jobRegistry:          jobRegistry,
 		clock:                clock,
+		settings:             settings,
 		rangeDescriptorCache: rangeDescriptorCache,
 		leaseHolderCache:     leaseHolderCache,
 	}
@@ -1031,6 +1037,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					leaseHolderCache:     s.leaseHolderCache,
 					rangeDescriptorCache: s.rangeDescriptorCache,
 					clock:                s.clock,
+					settings:             s.settings,
 				}
 				// Keep track of existing schema changers.
 				oldSchemaChangers := make(map[sqlbase.ID]struct{}, len(s.schemaChangers))

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -31,7 +31,11 @@ const (
 	// CodeRangeUnavailable signals that some data from the cluster cannot be
 	// accessed (e.g. because all replicas awol).
 	// We're using the postgres "Internal Error" error class "XX".
-	CodeRangeUnavailable string = "XXC00"
+	CodeRangeUnavailable = "XXC00"
+
+	// CodeCCLRequired signals that a CCL binary is required to complete this
+	// task.
+	CodeCCLRequired = "XXC01"
 )
 
 const (
@@ -97,6 +101,17 @@ func IsUniquenessConstraintViolationError(err error) bool {
 // definition such as a schema definition that doesn't parse.
 func NewInvalidSchemaDefinitionError(err error) error {
 	return pgerror.NewError(pgerror.CodeInvalidSchemaDefinitionError, err.Error())
+}
+
+// NewCCLRequiredError creates an error for when a CCL feature is used in an OSS
+// binary.
+func NewCCLRequiredError(err error) error {
+	return pgerror.NewError(CodeCCLRequired, err.Error())
+}
+
+// IsCCLRequiredError returns whether the error is a CCLRequired error.
+func IsCCLRequiredError(err error) bool {
+	return errHasCode(err, CodeCCLRequired)
 }
 
 // IsPermanentSchemaChangeError returns true if the error results in

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -119,7 +119,8 @@ func IsCCLRequiredError(err error) bool {
 func IsPermanentSchemaChangeError(err error) bool {
 	return errHasCode(err, pgerror.CodeNotNullViolationError) ||
 		errHasCode(err, pgerror.CodeUniqueViolationError) ||
-		errHasCode(err, pgerror.CodeInvalidSchemaDefinitionError)
+		errHasCode(err, pgerror.CodeInvalidSchemaDefinitionError) ||
+		errHasCode(err, CodeCCLRequired)
 }
 
 // NewUndefinedDatabaseError creates an error that represents a missing database.

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -651,6 +651,7 @@ func (p *planner) notifySchemaChange(
 		leaseHolderCache:     p.ExecCfg().LeaseHolderCache,
 		rangeDescriptorCache: p.ExecCfg().RangeDescriptorCache,
 		clock:                p.ExecCfg().Clock,
+		settings:             p.ExecCfg().Settings,
 	}
 	p.session.TxnState.schemaChangers.queueSchemaChanger(sc)
 }

--- a/pkg/sql/tests/data.go
+++ b/pkg/sql/tests/data.go
@@ -1,0 +1,105 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// CheckKeyCount checks that the number of keys in the provided span matches
+// numKeys.
+func CheckKeyCount(t *testing.T, kvDB *client.DB, span roachpb.Span, numKeys int) {
+	t.Helper()
+	if kvs, err := kvDB.Scan(context.TODO(), span.Key, span.EndKey, 0); err != nil {
+		t.Fatal(err)
+	} else if l := numKeys; len(kvs) != l {
+		t.Fatalf("expected %d key value pairs, but got %d", l, len(kvs))
+	}
+}
+
+// CreateKVTable creates a basic table named t.kv that stores key/value pairs
+// with numRows of arbitrary data.
+func CreateKVTable(sqlDB *gosql.DB, numRows int) error {
+	// Fix the column families so the key counts don't change if the family
+	// heuristics are updated.
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE IF NOT EXISTS t;
+CREATE TABLE t.kv (k INT PRIMARY KEY, v INT, FAMILY (k), FAMILY (v));
+CREATE INDEX foo on t.kv (v);
+`); err != nil {
+		return err
+	}
+
+	// Bulk insert.
+	var insert bytes.Buffer
+	if _, err := insert.WriteString(fmt.Sprintf(`INSERT INTO t.kv VALUES (%d, %d)`, 0, numRows-1)); err != nil {
+		return err
+	}
+	for i := 1; i < numRows; i++ {
+		if _, err := insert.WriteString(fmt.Sprintf(` ,(%d, %d)`, i, numRows-i)); err != nil {
+			return err
+		}
+	}
+	_, err := sqlDB.Exec(insert.String())
+	return err
+}
+
+// CreateKVInterleavedTable is like CreateKVTable, but it interleaves table
+// t.intlv inside of t.kv and adds rows to both.
+func CreateKVInterleavedTable(t *testing.T, sqlDB *gosql.DB, numRows int) {
+	// Fix the column families so the key counts don't change if the family
+	// heuristics are updated.
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+SET DATABASE=t;
+CREATE TABLE kv (k INT PRIMARY KEY, v INT);
+CREATE TABLE intlv (k INT, m INT, n INT, PRIMARY KEY (k, m)) INTERLEAVE IN PARENT kv (k);
+CREATE INDEX intlv_idx ON intlv (k, n) INTERLEAVE IN PARENT kv (k);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	var insert bytes.Buffer
+	if _, err := insert.WriteString(fmt.Sprintf(`INSERT INTO t.kv VALUES (%d, %d)`, 0, numRows-1)); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i < numRows; i++ {
+		if _, err := insert.WriteString(fmt.Sprintf(` ,(%d, %d)`, i, numRows-i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := sqlDB.Exec(insert.String()); err != nil {
+		t.Fatal(err)
+	}
+	insert.Reset()
+	if _, err := insert.WriteString(fmt.Sprintf(`INSERT INTO t.intlv VALUES (%d, %d, %d)`, 0, numRows-1, numRows-1)); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i < numRows; i++ {
+		if _, err := insert.WriteString(fmt.Sprintf(` ,(%d, %d, %d)`, i, numRows-i, numRows-i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := sqlDB.Exec(insert.String()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -16,7 +16,6 @@ package sql
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
@@ -159,7 +158,8 @@ func GetTableDesc(cfg config.SystemConfig, id sqlbase.ID) (*sqlbase.TableDescrip
 var GenerateSubzoneSpans = func(
 	*sqlbase.TableDescriptor, []config.Subzone,
 ) ([]config.SubzoneSpan, error) {
-	return nil, fmt.Errorf("setting zone configs on indexes or partitions requires a CCL binary")
+	return nil, sqlbase.NewCCLRequiredError(errors.New(
+		"setting zone configs on indexes or partitions requires a CCL binary"))
 }
 
 func zoneSpecifierNotFoundError(zs tree.ZoneSpecifier) error {

--- a/pkg/testutils/sqlutils/zone.go
+++ b/pkg/testutils/sqlutils/zone.go
@@ -100,3 +100,14 @@ func VerifyAllZoneConfigs(t testing.TB, sqlDB *SQLRunner, rows ...ZoneRow) {
 	}
 	sqlDB.CheckQueryResults(t, "EXPERIMENTAL SHOW ALL ZONE CONFIGURATIONS", expected)
 }
+
+// ZoneConfigExists returns whether a zone config with the provided cliSpecifier
+// exists.
+func ZoneConfigExists(t testing.TB, sqlDB *SQLRunner, cliSpecifier string) bool {
+	t.Helper()
+	var exists bool
+	sqlDB.QueryRow(
+		t, "SELECT EXISTS (SELECT 1 FROM crdb_internal.zones WHERE cli_specifier = $1)", cliSpecifier,
+	).Scan(&exists)
+	return exists
+}


### PR DESCRIPTION
When dropping an index, ensure that any zone configs set on that index
or partitions of that index are removed.
    
Fixes #20881.
    
Release note: None