### PR TITLE
sql: add json_each{_text}

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -805,11 +805,19 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>json_array_elements_text(input: jsonb) &rarr; setof tuple{string}</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of text values.</p>
 </span></td></tr>
+<tr><td><code>json_each(input: jsonb) &rarr; setof tuple{<a href="string.html">string</a>, jsonb}</code></td><td><span class="funcdesc"><p>Expands the outermost JSON or JSONB object into a set of key/value pairs.</p>
+</span></td></tr>
+<tr><td><code>json_each_text(input: jsonb) &rarr; setof tuple{<a href="string.html">string</a>, string}</code></td><td><span class="funcdesc"><p>Expands the outermost JSON or JSONB object into a set of key/value pairs. The returned values will be of type text.</p>
+</span></td></tr>
 <tr><td><code>json_object_keys(input: jsonb) &rarr; setof tuple{string}</code></td><td><span class="funcdesc"><p>Returns sorted set of keys in the outermost JSON object.</p>
 </span></td></tr>
 <tr><td><code>jsonb_array_elements(input: jsonb) &rarr; setof tuple{jsonb}</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of JSON values.</p>
 </span></td></tr>
 <tr><td><code>jsonb_array_elements_text(input: jsonb) &rarr; setof tuple{string}</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of text values.</p>
+</span></td></tr>
+<tr><td><code>jsonb_each(input: jsonb) &rarr; setof tuple{<a href="string.html">string</a>, jsonb}</code></td><td><span class="funcdesc"><p>Expands the outermost JSON or JSONB object into a set of key/value pairs.</p>
+</span></td></tr>
+<tr><td><code>jsonb_each_text(input: jsonb) &rarr; setof tuple{<a href="string.html">string</a>, string}</code></td><td><span class="funcdesc"><p>Expands the outermost JSON or JSONB object into a set of key/value pairs. The returned values will be of type text.</p>
 </span></td></tr>
 <tr><td><code>jsonb_object_keys(input: jsonb) &rarr; setof tuple{string}</code></td><td><span class="funcdesc"><p>Returns sorted set of keys in the outermost JSON object.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -372,7 +372,10 @@ SELECT json_object_keys('{"a": 1, "1": 2, "3": {"4": 5, "6": 7}}'::JSON)
 3
 a
 
-query error pq: json_object_keys\(\): cannot iterate keys of non-object
+query error pq: json_object_keys\(\): cannot call json_object_keys on a scalar
+SELECT json_object_keys('null'::JSON)
+
+query error pq: json_object_keys\(\): cannot call json_object_keys on an array
 SELECT json_object_keys('[1, 2, 3]'::JSON)
 
 query T
@@ -560,3 +563,91 @@ query T
 SELECT jsonb_object('{a,b,c,"d e f"}'::TEXT[],'{1,2,3,"a b c"}'::TEXT[])
 ----
 {"a":"1","b":"2","c":"3","d e f":"a b c"}
+
+query error pq: json_each\(\): cannot deconstruct an array as an object
+SELECT json_each('[1]'::JSON)
+
+query error pq: json_each\(\): cannot deconstruct a scalar
+SELECT json_each('null'::JSON)
+
+query TT
+SELECT * from json_each('{}') q
+----
+
+query TT colnames
+SELECT * from json_each('{"f1":[1,2,3],"f2":{"f3":1},"f4":null,"f5":99,"f6":"stringy"}') q
+----
+key value
+f1  [1,2,3]
+f2  {"f3":1}
+f4  null
+f5  99
+f6  "stringy"
+
+query error pq: jsonb_each\(\): cannot deconstruct an array as an object
+SELECT jsonb_each('[1]'::JSON)
+
+query error pq: jsonb_each\(\): cannot deconstruct a scalar
+SELECT jsonb_each('null'::JSON)
+
+query TT
+SELECT * from jsonb_each('{}') q
+----
+
+query TT colnames
+SELECT * from jsonb_each('{"f1":[1,2,3],"f2":{"f3":1},"f4":null,"f5":99,"f6":"stringy"}') q
+----
+key value
+f1  [1,2,3]
+f2  {"f3":1}
+f4  null
+f5  99
+f6  "stringy"
+
+query error pq: jsonb_each_text\(\): cannot deconstruct an array as an object
+SELECT jsonb_each_text('[1]'::JSON)
+
+query error pq: jsonb_each_text\(\): cannot deconstruct a scalar
+SELECT jsonb_each_text('null'::JSON)
+
+query TT
+SELECT * from jsonb_each_text('{}') q
+----
+
+query TT
+SELECT * from jsonb_each_text('{}') q
+----
+
+query TT colnames
+SELECT * from jsonb_each_text('{"f1":[1,2,3],"f2":{"f3":1},"f4":null,"f5":99,"f6":"stringy"}') q
+----
+key value
+f1  [1,2,3]
+f2  {"f3":1}
+f4  NULL
+f5  99
+f6  stringy
+
+query error pq: json_each_text\(\): cannot deconstruct an array as an object
+SELECT json_each_text('[1]'::JSON)
+
+query error pq: json_each_text\(\): cannot deconstruct a scalar
+SELECT json_each_text('null'::JSON)
+
+query TT
+SELECT * from json_each_text('{}') q
+----
+
+query TT
+SELECT * from json_each_text('{}') q
+----
+
+query TT colnames
+SELECT * from json_each_text('{"f1":[1,2,3],"f2":{"f3":1},"f4":null,"f5":99,"f6":"stringy"}') q
+----
+key value
+f1  [1,2,3]
+f2  {"f3":1}
+f4  NULL
+f5  99
+f6  stringy

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -265,12 +265,12 @@ func (j *jsonEncoded) iterObject() (encodedObjectIterator, error) {
 	}, nil
 }
 
-func (j *jsonEncoded) IterObjectKey() (*ObjectKeyIterator, error) {
+func (j *jsonEncoded) ObjectIter() (*ObjectIterator, error) {
 	dec, err := j.shallowDecode()
 	if err != nil {
 		return nil, err
 	}
-	return dec.IterObjectKey()
+	return dec.ObjectIter()
 }
 
 func (j *jsonEncoded) FetchValIdx(idx int) (JSON, error) {

--- a/pkg/util/json/iterator.go
+++ b/pkg/util/json/iterator.go
@@ -14,18 +14,35 @@
 
 package json
 
-// ObjectKeyIterator is an iterator to access the keys of an object.
-type ObjectKeyIterator struct {
+// ObjectIterator is an iterator to access the key value pair of an object in
+// sorted order based on key.
+type ObjectIterator struct {
 	src jsonObject
 	idx int
 }
 
-// Next returns true and the next key in the iterator if one exists,
-// and false otherwise.
-func (it *ObjectKeyIterator) Next() (bool, string) {
-	it.idx++
-	if it.idx >= len(it.src) {
-		return false, ""
+func newObjectIterator(src jsonObject) *ObjectIterator {
+	return &ObjectIterator{
+		src: src,
+		idx: -1,
 	}
-	return true, string(it.src[it.idx].k)
+}
+
+// Next updates the cursor and returns whether the next pair exists.
+func (it *ObjectIterator) Next() bool {
+	if it.idx >= len(it.src)-1 {
+		return false
+	}
+	it.idx++
+	return true
+}
+
+// Key returns key of the current pair.
+func (it *ObjectIterator) Key() string {
+	return string(it.src[it.idx].k)
+}
+
+// Value returns value of the current pair
+func (it *ObjectIterator) Value() JSON {
+	return it.src[it.idx].v
 }

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -89,9 +89,8 @@ type JSON interface {
 	// Exists implements the `?` operator.
 	Exists(string) (bool, error)
 
-	// IterObjectKey returns an ObjectKeyIterator, and it returns error if the obj
-	// is not an object.
-	IterObjectKey() (*ObjectKeyIterator, error)
+	// ObjectIter returns an *ObjectKeyIterator, nil if json is not an object.
+	ObjectIter() (*ObjectIterator, error)
 
 	// isScalar returns whether the JSON document is null, true, false, a string,
 	// or a number.
@@ -1013,32 +1012,26 @@ func (j jsonObject) Exists(s string) (bool, error) {
 	return v != nil, nil
 }
 
-var errIterateKeysNonObject = pgerror.NewError(pgerror.CodeInvalidParameterValueError,
-	"cannot iterate keys of non-object")
-
-func (jsonNull) IterObjectKey() (*ObjectKeyIterator, error) {
-	return nil, errIterateKeysNonObject
+func (jsonNull) ObjectIter() (*ObjectIterator, error) {
+	return nil, nil
 }
-func (jsonTrue) IterObjectKey() (*ObjectKeyIterator, error) {
-	return nil, errIterateKeysNonObject
+func (jsonTrue) ObjectIter() (*ObjectIterator, error) {
+	return nil, nil
 }
-func (jsonFalse) IterObjectKey() (*ObjectKeyIterator, error) {
-	return nil, errIterateKeysNonObject
+func (jsonFalse) ObjectIter() (*ObjectIterator, error) {
+	return nil, nil
 }
-func (jsonNumber) IterObjectKey() (*ObjectKeyIterator, error) {
-	return nil, errIterateKeysNonObject
+func (jsonNumber) ObjectIter() (*ObjectIterator, error) {
+	return nil, nil
 }
-func (jsonString) IterObjectKey() (*ObjectKeyIterator, error) {
-	return nil, errIterateKeysNonObject
+func (jsonString) ObjectIter() (*ObjectIterator, error) {
+	return nil, nil
 }
-func (jsonArray) IterObjectKey() (*ObjectKeyIterator, error) {
-	return nil, errIterateKeysNonObject
+func (jsonArray) ObjectIter() (*ObjectIterator, error) {
+	return nil, nil
 }
-func (j jsonObject) IterObjectKey() (*ObjectKeyIterator, error) {
-	return &ObjectKeyIterator{
-		src: j,
-		idx: -1,
-	}, nil
+func (j jsonObject) ObjectIter() (*ObjectIterator, error) {
+	return newObjectIterator(j), nil
 }
 
 func (jsonNull) isScalar() bool   { return true }


### PR DESCRIPTION
For implementing json_each{_text}, I changed ObjectKeyIterator so that it can access both key and value in the object and reused it. Related to #20120. Please take a look. 
Also, I found that for JSON type, its formats in tuple and in array are different. 
```
select ARRAY['null'::JSON, '{"1":2}'::JSON, '[1, 2]'::JSON];
             array
-------------------------------
 {"null","{\"1\":2}","[1, 2]"}
```
```
select ('null'::JSON, '{"1":2}'::JSON, '[1, 2]'::JSON);
             row
-----------------------------
 (null,"{""1"":2}","[1, 2]")
```
The current code seems to only use [FmtSimple flag](https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/pgwire/types.go#L195) to format it. Maybe it still needs some changes.