### PR TITLE
sqlccl: construct expressions to match rows in partitions

### DIFF
--- a/pkg/ccl/sqlccl/partition.go
+++ b/pkg/ccl/sqlccl/partition.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/pkg/errors"
 )
 
 type repartitioningSide string
@@ -165,6 +166,165 @@ func RepartitioningFastPathAvailable(
 		}
 	}
 	return true, nil
+}
+
+// selectPartitionExprs constructs an expression for selecting all rows in the
+// given partitions.
+func selectPartitionExprs(
+	evalCtx *tree.EvalContext, tableDesc *sqlbase.TableDescriptor, partNames tree.NameList,
+) (tree.Expr, error) {
+	exprsByPartName := make(map[string]tree.TypedExpr)
+
+	a := &sqlbase.DatumAlloc{}
+	var prefixDatums []tree.Datum
+	if err := tableDesc.ForeachNonDropIndex(func(idxDesc *sqlbase.IndexDescriptor) error {
+		return selectPartitionExprsByName(
+			a, tableDesc, idxDesc, &idxDesc.Partitioning, prefixDatums, exprsByPartName)
+	}); err != nil {
+		return nil, err
+	}
+
+	var expr tree.TypedExpr = tree.DBoolFalse
+	for _, partName := range partNames {
+		partExpr, ok := exprsByPartName[string(partName)]
+		if !ok || partExpr == nil {
+			return nil, errors.Errorf("unknown partition: %s", partName)
+		}
+		expr = tree.NewTypedOrExpr(expr, partExpr)
+	}
+
+	var err error
+	expr, err = evalCtx.NormalizeExpr(expr)
+	if err != nil {
+		return nil, err
+	}
+	if e, equiv := sql.SimplifyExpr(evalCtx, expr); equiv {
+		expr = e
+	}
+	// In order to typecheck during simplification and normalization, we used
+	// dummy IndexVars. Swap them out for actual column references.
+	finalExpr, err := tree.SimpleVisit(expr, func(e tree.Expr) (error, bool, tree.Expr) {
+		if ivar, ok := e.(*tree.IndexedVar); ok {
+			col, err := tableDesc.FindColumnByID(sqlbase.ColumnID(ivar.Idx))
+			if err != nil {
+				return err, false, nil
+			}
+			return nil, false, &tree.ColumnItem{ColumnName: tree.Name(col.Name)}
+		}
+		return nil, true, e
+	})
+	return finalExpr, err
+}
+
+// selectPartitionExprsByName constructs an expression for selecting all rows in
+// each partition and subpartition in the given index. To make it easy to
+// simplify and normalize the exprs, references to table columns are represented
+// as TypedOrdinalReferences with an ordinal of the column ID.
+//
+// NB Subpartitions do not affect the expression for their parent partitions. So
+// if a partition foo (a=3) is then subpartitiond by (b=5) and no DEFAULT, the
+// expression for foo is still `a=3`, not `a=3 AND b=5`.
+func selectPartitionExprsByName(
+	a *sqlbase.DatumAlloc,
+	tableDesc *sqlbase.TableDescriptor,
+	idxDesc *sqlbase.IndexDescriptor,
+	partDesc *sqlbase.PartitioningDescriptor,
+	prefixDatums tree.Datums,
+	exprsByPartName map[string]tree.TypedExpr,
+) error {
+	if partDesc.NumColumns == 0 {
+		return nil
+	}
+
+	var colVars tree.TypedExprs
+	{
+		// The recursive calls of selectPartitionExprsByName don't pass though
+		// the column ordinal references, so reconstruct them here.
+		colVars = make(tree.TypedExprs, len(prefixDatums)+int(partDesc.NumColumns))
+		for i := range colVars {
+			col, err := tableDesc.FindActiveColumnByID(idxDesc.ColumnIDs[i])
+			if err != nil {
+				return err
+			}
+			colVars[i] = tree.NewTypedOrdinalReference(int(col.ID), col.Type.ToDatumType())
+		}
+	}
+
+	if len(partDesc.List) > 0 {
+		type exprAndPartName struct {
+			expr tree.TypedExpr
+			name string
+		}
+		// Any partitions using DEFAULT must specifically exclude any relevant
+		// higher specificity partitions (e.g for partitions `(1, DEFAULT)`,
+		// `(1, 2)`, the expr for the former must exclude the latter. This is
+		// done by bucketing the expression for each partition value by the
+		// number of DEFAULTs it involves.
+		partValueExprs := make([][]exprAndPartName, int(partDesc.NumColumns)+1)
+
+		for _, l := range partDesc.List {
+			for _, valueEncBuf := range l.Values {
+				datums, _, err := sqlbase.TranslateValueEncodingToSpan(
+					a, tableDesc, idxDesc, partDesc, valueEncBuf, prefixDatums)
+				if err != nil {
+					return err
+				}
+				allDatums := append(prefixDatums, datums...)
+
+				// When len(allDatums) < len(colVars), the missing elements are DEFAULTs, so
+				// we can simply exclude them from the expr.
+				partValueExpr := tree.NewTypedComparisonExpr(tree.EQ,
+					tree.NewTypedTuple(colVars[:len(allDatums)]), tree.NewDTuple(allDatums...))
+				partValueExprs[len(datums)] = append(partValueExprs[len(datums)], exprAndPartName{
+					expr: partValueExpr,
+					name: l.Name,
+				})
+
+				if err := selectPartitionExprsByName(
+					a, tableDesc, idxDesc, &l.Subpartitioning, allDatums, exprsByPartName,
+				); err != nil {
+					return err
+				}
+			}
+		}
+
+		// Walk backward through partValueExprs, so partition values with fewest
+		// DEFAULTs to most. As we go, keep an expression to be AND NOT'd with
+		// each partition value's expression in `excludeExpr`. This handles the
+		// exclusion of `(1, 2)` from the expression for `(1, DEFAULT)` in the
+		// example above.
+		//
+		// TODO(dan): The result of the way this currently works is correct but
+		// too broad. In a two column partitioning with cases for `(a, b)` and
+		// `(c, DEFAULT)`, the expression generated for `(c, DEFAULT)` will
+		// needlessly exclude `(a, b)`. Concretely, we end up with expressions
+		// like `(a) IN (1) AND ... (a, b) != (2, 3)`, where the `!= (2, 3)`
+		// part is irrelevant. This only happens in fairly unrealistic
+		// partitionings, so it's unclear if anything really needs to be done
+		// here.
+		excludeExpr := tree.TypedExpr(tree.DBoolFalse)
+		for i := len(partValueExprs) - 1; i >= 0; i-- {
+			nextExcludeExpr := tree.TypedExpr(tree.DBoolFalse)
+			for _, v := range partValueExprs[i] {
+				nextExcludeExpr = tree.NewTypedOrExpr(nextExcludeExpr, v.expr)
+				partValueExpr := tree.NewTypedAndExpr(v.expr, tree.NewTypedNotExpr(excludeExpr))
+				// We can get multiple expressions for the same partition in
+				// a single-col `PARTITION foo VALUES IN ((1), (2))`.
+				if e, ok := exprsByPartName[v.name]; !ok || e == nil {
+					exprsByPartName[v.name] = partValueExpr
+				} else {
+					exprsByPartName[v.name] = tree.NewTypedOrExpr(e, partValueExpr)
+				}
+			}
+			excludeExpr = tree.NewTypedOrExpr(excludeExpr, nextExcludeExpr)
+		}
+	}
+
+	for range partDesc.Range {
+		return errors.New("TODO(dan): unsupported for range partitionings")
+	}
+
+	return nil
 }
 
 func init() {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -954,7 +954,7 @@ func createPartitionedBy(
 	}
 	var checkConstraint *sqlbase.TableDescriptor_CheckConstraint
 	if checkExpr != nil && checkExpr != tree.DBoolTrue {
-		if e, equiv := simplifyExpr(evalCtx, checkExpr); equiv {
+		if e, equiv := SimplifyExpr(evalCtx, checkExpr); equiv {
 			checkExpr = e
 		}
 		checkExpr, err = evalCtx.NormalizeExpr(checkExpr)

--- a/pkg/sql/opt_decompose_test.go
+++ b/pkg/sql/opt_decompose_test.go
@@ -303,7 +303,7 @@ func TestSimplifyExpr(t *testing.T) {
 			defer p.evalCtx.ActiveMemAcc.Close(context.Background())
 			p.evalCtx.IVarHelper = &sel.ivarHelper
 			expr := parseAndNormalizeExpr(t, p, d.expr, sel)
-			expr, equiv := simplifyExpr(&p.evalCtx, expr)
+			expr, equiv := SimplifyExpr(&p.evalCtx, expr)
 			if s := expr.String(); d.expected != s {
 				t.Errorf("%s: structure: expected %s, but found %s", d.expr, d.expected, s)
 			}
@@ -357,7 +357,7 @@ func TestSimplifyNotExpr(t *testing.T) {
 			defer p.evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr1 := parseAndNormalizeExpr(t, p, d.expr, sel)
-			expr2, equiv := simplifyExpr(&p.evalCtx, expr1)
+			expr2, equiv := SimplifyExpr(&p.evalCtx, expr1)
 			if s := expr2.String(); d.expected != s {
 				t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 			}
@@ -395,7 +395,7 @@ func TestSimplifyAndExpr(t *testing.T) {
 			defer p.evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr1 := parseAndNormalizeExpr(t, p, d.expr, sel)
-			expr2, equiv := simplifyExpr(&p.evalCtx, expr1)
+			expr2, equiv := SimplifyExpr(&p.evalCtx, expr1)
 			if s := expr2.String(); d.expected != s {
 				t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 			}
@@ -601,7 +601,7 @@ func TestSimplifyAndExprCheck(t *testing.T) {
 			defer p.evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr1 := parseAndNormalizeExpr(t, p, d.expr, sel)
-			expr2, equiv := simplifyExpr(&p.evalCtx, expr1)
+			expr2, equiv := SimplifyExpr(&p.evalCtx, expr1)
 			if s := expr2.String(); d.expected != s {
 				t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 			}
@@ -623,7 +623,7 @@ func TestSimplifyAndExprCheck(t *testing.T) {
 				expr1 = parseAndNormalizeExpr(t, p, d.expr, sel)
 				andExpr := expr1.(*tree.AndExpr)
 				andExpr.Left, andExpr.Right = andExpr.Right, andExpr.Left
-				expr3, equiv := simplifyExpr(&p.evalCtx, andExpr)
+				expr3, equiv := SimplifyExpr(&p.evalCtx, andExpr)
 				if s := expr3.String(); d.expected != s {
 					t.Errorf("%s: expected %s, but found %s", expr1, d.expected, s)
 				}
@@ -654,7 +654,7 @@ func TestSimplifyOrExpr(t *testing.T) {
 			defer p.evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr1 := parseAndNormalizeExpr(t, p, d.expr, sel)
-			expr2, _ := simplifyExpr(&p.evalCtx, expr1)
+			expr2, _ := SimplifyExpr(&p.evalCtx, expr1)
 			if s := expr2.String(); d.expected != s {
 				t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 			}
@@ -830,7 +830,7 @@ func TestSimplifyOrExprCheck(t *testing.T) {
 			defer p.evalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr1 := parseAndNormalizeExpr(t, p, d.expr, sel)
-			expr2, equiv := simplifyExpr(&p.evalCtx, expr1)
+			expr2, equiv := SimplifyExpr(&p.evalCtx, expr1)
 			if s := expr2.String(); d.expected != s {
 				t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 			}
@@ -849,7 +849,7 @@ func TestSimplifyOrExprCheck(t *testing.T) {
 				expr1 = parseAndNormalizeExpr(t, p, d.expr, sel)
 				orExpr := expr1.(*tree.OrExpr)
 				orExpr.Left, orExpr.Right = orExpr.Right, orExpr.Left
-				expr3, equiv := simplifyExpr(&p.evalCtx, orExpr)
+				expr3, equiv := SimplifyExpr(&p.evalCtx, orExpr)
 				if s := expr3.String(); d.expected != s {
 					t.Errorf("%s: expected %s, but found %s", expr1, d.expected, s)
 				}

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -681,7 +681,7 @@ func (v *indexInfo) makeIndexConstraints(
 					// We rewrite "a != x" to "a IS DISTINCT FROM NULL", since this is all that
 					// makeSpans() cares about.
 					// We don't simplify "a != x" to "a IS DISTINCT FROM NULL" in
-					// simplifyExpr because doing so affects other simplifications.
+					// SimplifyExpr because doing so affects other simplifications.
 					if *startDone || *startExpr != nil {
 						continue
 					}
@@ -1657,7 +1657,7 @@ func applyConstraint(
 ) tree.Expr {
 	// Check that both expressions have the same variable on the left.
 	// It is always true for the constraint, and
-	// simplifyExpr() has ensured this is true in most sub-expressions of t.
+	// SimplifyExpr() has ensured this is true in most sub-expressions of t.
 	varLeft := c.Left.(*tree.IndexedVar)
 	if varRight, ok := t.Left.(*tree.IndexedVar); !ok || varLeft.Idx != varRight.Idx {
 		return t


### PR DESCRIPTION
selectPartitionExprs constructs an expression for selecting all rows in given partitions. This is most of the interesting logic behind the upcoming `SELECT ... FROM ... PARTITION (p0, p1)`.