### PR TITLE
sql: compat: pg_catalog tables get array types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -81,17 +81,17 @@ pg_catalog.pg_namespace  CREATE TABLE pg_namespace (
                              oid OID NULL,
                              nspname NAME NOT NULL,
                              nspowner OID NULL,
-                             nspacl STRING NULL
+                             nspacl STRING[] NULL
 )
 
 query TTBTT colnames
 SHOW COLUMNS FROM pg_catalog.pg_namespace
 ----
-Field     Type    Null   Default Indices
-oid       OID     true   NULL    {}
-nspname   NAME    false  NULL    {}
-nspowner  OID     true   NULL    {}
-nspacl    STRING  true   NULL    {}
+Field     Type      Null   Default Indices
+oid       OID       true   NULL    {}
+nspname   NAME      false  NULL    {}
+nspowner  OID       true   NULL    {}
+nspacl    STRING[]  true   NULL    {}
 
 query TTBITTBB colnames
 SHOW INDEXES FROM pg_catalog.pg_namespace
@@ -1070,9 +1070,9 @@ FROM pg_catalog.pg_roles
 ORDER BY rolname
 ----
 oid         rolname   rolconnlimit  rolpassword  rolvaliduntil  rolbypassrls  rolconfig
-823966177   admin     -1            ********     NULL           false         {}
-2901009604  root      -1            ********     NULL           false         {}
-2499926009  testuser  -1            ********     NULL           false         {}
+823966177   admin     -1            ********     NULL           false         NULL
+2901009604  root      -1            ********     NULL           false         NULL
+2499926009  testuser  -1            ********     NULL           false         NULL
 
 ## pg_catalog.pg_description
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -160,9 +160,9 @@ CREATE TABLE pg_catalog.pg_attribute (
 	attislocal BOOL,
 	attinhcount INT,
 	attcollation OID,
-	attacl STRING,
-	attoptions STRING,
-	attfdwoptions STRING
+	attacl STRING[],
+	attoptions STRING[],
+	attfdwoptions STRING[]
 );
 `,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
@@ -259,8 +259,8 @@ CREATE TABLE pg_catalog.pg_class (
 	relhastriggers BOOL,
 	relhassubclass BOOL,
 	relfrozenxid INT,
-	relacl STRING,
-	reloptions STRING
+	relacl STRING[],
+	reloptions STRING[]
 );
 `,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
@@ -432,10 +432,10 @@ CREATE TABLE pg_catalog.pg_constraint (
 	connoinherit BOOL,
 	conkey INT[],
 	confkey INT[],
-	conpfeqop STRING,
-	conppeqop STRING,
-	conffeqop STRING,
-	conexclop STRING,
+	conpfeqop OID[],
+	conppeqop OID[],
+	conffeqop OID[],
+	conexclop OID[],
 	conbin STRING,
 	consrc STRING
 );
@@ -599,7 +599,7 @@ CREATE TABLE pg_catalog.pg_database (
 	datfrozenxid INT,
 	datminmxid INT,
 	dattablespace OID,
-	datacl STRING
+	datacl STRING[]
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
@@ -793,8 +793,8 @@ CREATE TABLE pg_catalog.pg_foreign_server (
   srvfdw OID,
   srvtype STRING,
   srvversion STRING,
-  srvacl STRING,
-  srvoptions STRING
+  srvacl STRING[],
+  srvoptions STRING[]
 );
 `,
 	populate: func(_ context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
@@ -809,7 +809,7 @@ var pgCatalogForeignTableTable = virtualSchemaTable{
 CREATE TABLE pg_catalog.pg_foreign_table (
   ftrelid OID,
   ftserver OID,
-  ftoptions STRING
+  ftoptions STRING[]
 );
 `,
 	populate: func(_ context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
@@ -1006,7 +1006,7 @@ CREATE TABLE pg_catalog.pg_namespace (
 	oid OID,
 	nspname NAME NOT NULL,
 	nspowner OID,
-	nspacl STRING
+	nspacl STRING[]
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
@@ -1065,15 +1065,15 @@ CREATE TABLE pg_catalog.pg_proc (
 	pronargdefaults INT,
 	prorettype OID,
 	proargtypes STRING,
-	proallargtypes STRING,
+	proallargtypes STRING[],
 	proargmodes STRING[],
-	proargnames STRING,
+	proargnames STRING[],
 	proargdefaults STRING,
-	protrftypes STRING,
+	protrftypes OID[],
 	prosrc STRING,
 	probin STRING,
-	proconfig STRING,
-	proacl STRING
+	proconfig STRING[],
+	proacl STRING[]
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
@@ -1236,7 +1236,7 @@ CREATE TABLE pg_catalog.pg_roles (
 	rolpassword STRING,
 	rolvaliduntil TIMESTAMPTZ,
 	rolbypassrls BOOL,
-	rolconfig STRING
+	rolconfig STRING[]
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
@@ -1262,7 +1262,7 @@ CREATE TABLE pg_catalog.pg_roles (
 					tree.NewDString("********"), // rolpassword
 					tree.DNull,                  // rolvaliduntil
 					tree.DBoolFalse,             // rolbypassrls
-					tree.NewDString("{}"),       // rolconfig
+					tree.DNull,                  // rolconfig
 				)
 			})
 	},
@@ -1403,8 +1403,8 @@ CREATE TABLE pg_catalog.pg_tablespace (
   spcname NAME,
   spcowner OID,
   spclocation TEXT,
-  spcacl STRING,
-  spcoptions TEXT
+  spcacl TEXT[],
+  spcoptions TEXT[]
 );
 `,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
@@ -1499,7 +1499,7 @@ CREATE TABLE pg_catalog.pg_type (
 	typcollation OID,
 	typdefaultbin STRING,
 	typdefault STRING,
-	typacl STRING
+	typacl STRING[]
 );
 `,
 	populate: func(_ context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {


### PR DESCRIPTION
Previously, most of the array-typed columns in pg_catalog were
implemented as `TEXT` columns. Even though we implement all of these
examples as `NULL`, it still confuses some drivers.

Also, `rolconfig` was implemented as always being the string `{}`, which
is incorrect. It should be the `NULL` array.

Release note (sql change): improve compatibility of array columns in
pg_catalog tables.