### PR TITLE
opt: convert back to TypedExpr

### DIFF
--- a/pkg/sql/opt/testdata/build-scalar
+++ b/pkg/sql/opt/testdata/build-scalar
@@ -1,28 +1,32 @@
-build-scalar
+build-scalar,semtree-expr
 1
 ----
 const (1) (type: int)
+1
 
-build-scalar
+build-scalar,semtree-expr
 1 + 2
 ----
 plus (type: int)
  ├── const (1) (type: int)
  └── const (2) (type: int)
+1 + 2
 
-build-scalar vars=(string)
+build-scalar,semtree-expr vars=(string)
 @1
 ----
 variable (0) (type: string)
+@1
 
-build-scalar vars=(int)
+build-scalar,semtree-expr vars=(int)
 @1 + 2
 ----
 plus (type: int)
  ├── variable (0) (type: int)
  └── const (2) (type: int)
+@1 + 2
 
-build-scalar vars=(int, int)
+build-scalar,semtree-expr vars=(int, int)
 @1 >= 5 AND @1 <= 10 AND @2 < 4
 ----
 and (type: bool)
@@ -36,8 +40,9 @@ and (type: bool)
  └── lt (type: bool)
       ├── variable (1) (type: int)
       └── const (4) (type: int)
+((@1 >= 5) AND (@1 <= 10)) AND (@2 < 4)
 
-build-scalar,normalize vars=(int, int)
+build-scalar,normalize,semtree-expr vars=(int, int)
 @1 >= 5 AND @1 <= 10 AND @2 > 0 AND @2 < 10
 ----
 and (type: bool)
@@ -53,8 +58,9 @@ and (type: bool)
  └── lt (type: bool)
       ├── variable (1) (type: int)
       └── const (10) (type: int)
+(((@1 >= 5) AND (@1 <= 10)) AND (@2 > 0)) AND (@2 < 10)
 
-build-scalar,normalize vars=(int, int)
+build-scalar,normalize,semtree-expr vars=(int, int)
 @1 >= 5 OR @1 <= 10 OR @2 > 0 OR @2 < 10
 ----
 or (type: bool)
@@ -70,8 +76,9 @@ or (type: bool)
  └── lt (type: bool)
       ├── variable (1) (type: int)
       └── const (10) (type: int)
+(((@1 >= 5) OR (@1 <= 10)) OR (@2 > 0)) OR (@2 < 10)
 
-build-scalar,normalize vars=(int, int, int)
+build-scalar,normalize,semtree-expr vars=(int, int, int)
 @1 >= 5 AND (@2 = 1 OR @2 > 3) AND (@3 > 2)
 ----
 and (type: bool)
@@ -88,8 +95,9 @@ and (type: bool)
  └── gt (type: bool)
       ├── variable (2) (type: int)
       └── const (2) (type: int)
+((@1 >= 5) AND ((@2 = 1) OR (@2 > 3))) AND (@3 > 2)
 
-build-scalar,normalize vars=(int, int, int)
+build-scalar,normalize,semtree-expr vars=(int, int, int)
 @1 >= 5 AND (@2 = 1 OR @2 = 3 OR @2 > 5) AND (@3 > 2)
 ----
 and (type: bool)
@@ -109,8 +117,9 @@ and (type: bool)
  └── gt (type: bool)
       ├── variable (2) (type: int)
       └── const (2) (type: int)
+((@1 >= 5) AND (((@2 = 1) OR (@2 = 3)) OR (@2 > 5))) AND (@3 > 2)
 
-build-scalar,normalize vars=(int, int, int)
+build-scalar,normalize,semtree-expr vars=(int, int, int)
 (@1 >= 5 AND @1 <= 10) OR (@2 > 1 AND @2 < 3) OR (@3 > 2)
 ----
 or (type: bool)
@@ -131,8 +140,9 @@ or (type: bool)
  └── gt (type: bool)
       ├── variable (2) (type: int)
       └── const (2) (type: int)
+(((@1 >= 5) AND (@1 <= 10)) OR ((@2 > 1) AND (@2 < 3))) OR (@3 > 2)
 
-build-scalar vars=(int, int)
+build-scalar,semtree-expr vars=(int, int)
 (@1, @2) = (1, 2)
 ----
 eq (type: bool)
@@ -142,8 +152,9 @@ eq (type: bool)
  └── ordered-list (type: tuple{int, int})
       ├── const (1) (type: int)
       └── const (2) (type: int)
+(@1, @2) = (1, 2)
 
-build-scalar vars=(int)
+build-scalar,semtree-expr vars=(int)
 @1 IN (1, 2)
 ----
 in (type: bool)
@@ -151,8 +162,9 @@ in (type: bool)
  └── ordered-list (type: tuple{int, int})
       ├── const (1) (type: int)
       └── const (2) (type: int)
+@1 IN (1, 2)
 
-build-scalar vars=(int, int)
+build-scalar,semtree-expr vars=(int, int)
 (@1, @2) IN ((1, 2), (3, 4))
 ----
 in (type: bool)
@@ -166,8 +178,9 @@ in (type: bool)
       └── ordered-list (type: tuple{int, int})
            ├── const (3) (type: int)
            └── const (4) (type: int)
+(@1, @2) IN ((1, 2), (3, 4))
 
-build-scalar vars=(int, int, int, int)
+build-scalar,semtree-expr vars=(int, int, int, int)
 (@1, @2 + @3, 5 + @4 * 2) = (@2 + @3, 8, @1 - @4)
 ----
 eq (type: bool)
@@ -189,8 +202,9 @@ eq (type: bool)
       └── minus (type: int)
            ├── variable (0) (type: int)
            └── variable (3) (type: int)
+(@1, @2 + @3, 5 + (@4 * 2)) = (@2 + @3, 8, @1 - @4)
 
-build-scalar,normalize vars=(int, int, int, int)
+build-scalar,normalize,semtree-expr vars=(int, int, int, int)
 (@1, @2 + @3, 5 + @4 * 2) = (@2 + @3, 8, @1 - @4)
 ----
 and (type: bool)
@@ -213,8 +227,9 @@ and (type: bool)
       └── minus (type: int)
            ├── variable (0) (type: int)
            └── variable (3) (type: int)
+((@1 = (@2 + @3)) AND ((@2 + @3) = 8)) AND ((5 + (@4 * 2)) = (@1 - @4))
 
-build-scalar vars=(int, int, int, int)
+build-scalar,semtree-expr vars=(int, int, int, int)
 ((@1, @2), (@3, @4)) = ((1, 2), (3, 4))
 ----
 eq (type: bool)
@@ -232,8 +247,9 @@ eq (type: bool)
       └── ordered-list (type: tuple{int, int})
            ├── const (3) (type: int)
            └── const (4) (type: int)
+((@1, @2), (@3, @4)) = ((1, 2), (3, 4))
 
-build-scalar,normalize vars=(int, int, int, int)
+build-scalar,normalize,semtree-expr vars=(int, int, int, int)
 ((@1, @2), (@3, @4)) = ((1, 2), (3, 4))
 ----
 and (type: bool)
@@ -249,8 +265,9 @@ and (type: bool)
  └── eq (type: bool)
       ├── variable (3) (type: int)
       └── const (4) (type: int)
+(((@1 = 1) AND (@2 = 2)) AND (@3 = 3)) AND (@4 = 4)
 
-build-scalar vars=(int, int, int, string)
+build-scalar,semtree-expr vars=(int, int, int, string)
 (@1, (@2, 'a'), (@3, 'b', 5)) = (9, (@1 + @3, @4), (5, @4, @1))
 ----
 eq (type: bool)
@@ -274,8 +291,9 @@ eq (type: bool)
            ├── const (5) (type: int)
            ├── variable (3) (type: string)
            └── variable (0) (type: int)
+(@1, (@2, 'a'), (@3, 'b', 5)) = (9, (@1 + @3, @4), (5, @4, @1))
 
-build-scalar,normalize vars=(int, int, int, string)
+build-scalar,normalize,semtree-expr vars=(int, int, int, string)
 (@1, (@2, 'a'), (@3, 'b', 5)) = (9, (@1 + @3, @4), (5, @4, @1))
 ----
 and (type: bool)
@@ -299,45 +317,62 @@ and (type: bool)
  └── eq (type: bool)
       ├── variable (0) (type: int)
       └── const (5) (type: int)
+(((((@1 = 9) AND (@2 = (@1 + @3))) AND (@4 = 'a')) AND (@3 = 5)) AND (@4 = 'b')) AND (@1 = 5)
 
-build-scalar vars=(int, int)
+build-scalar,semtree-expr vars=(int, int)
 @1 IS NULL
 ----
 is (type: bool)
  ├── variable (0) (type: int)
  └── const (NULL) (type: NULL)
+@1 IS NULL
 
-build-scalar vars=(int, int)
+build-scalar,semtree-expr vars=(int, int)
 @1 IS NOT DISTINCT FROM NULL
 ----
 is (type: bool)
  ├── variable (0) (type: int)
  └── const (NULL) (type: NULL)
+@1 IS NULL
 
-build-scalar vars=(int, int)
+build-scalar,semtree-expr vars=(int, int)
 @1 IS NOT DISTINCT FROM @2
 ----
 is (type: bool)
  ├── variable (0) (type: int)
  └── variable (1) (type: int)
+@1 IS NOT DISTINCT FROM @2
 
-build-scalar vars=(int, int)
+build-scalar,semtree-expr vars=(int, int)
 @1 IS NOT NULL
 ----
 is-not (type: bool)
  ├── variable (0) (type: int)
  └── const (NULL) (type: NULL)
+@1 IS NOT NULL
 
-build-scalar vars=(int, int)
+build-scalar,semtree-expr vars=(int, int)
 @1 IS DISTINCT FROM NULL
 ----
 is-not (type: bool)
  ├── variable (0) (type: int)
  └── const (NULL) (type: NULL)
+@1 IS NOT NULL
 
-build-scalar vars=(int, int)
+build-scalar,semtree-expr vars=(int, int)
 @1 IS DISTINCT FROM @2
 ----
 is-not (type: bool)
  ├── variable (0) (type: int)
  └── variable (1) (type: int)
+@1 IS DISTINCT FROM @2
+
+build-scalar,semtree-expr vars=(int, int)
++ @1 + (- @2)
+----
+plus (type: int)
+ ├── unary-plus (type: int)
+ │    └── variable (0) (type: int)
+ └── unary-minus (type: int)
+      └── variable (1) (type: int)
+(+@1) + (-@2)

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -15,8 +15,7 @@ build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1
 ----
 [ - ]
-Remaining filter:
-variable (0) (type: int)
+Remaining filter: @1
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1 > 2
@@ -134,19 +133,13 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1)
 @1 = 1 AND @2 = 2
 ----
 [/1 - /1]
-Remaining filter:
-eq (type: bool)
- ├── variable (1) (type: int)
- └── const (2) (type: int)
+Remaining filter: @2 = 2
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@2)
 @1 = 1 AND @2 = 2
 ----
 [/2 - /2]
-Remaining filter:
-eq (type: bool)
- ├── variable (0) (type: int)
- └── const (1) (type: int)
+Remaining filter: @1 = 1
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 = 1 AND @2 > NULL
@@ -170,39 +163,27 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 > 2 AND @2 > 5
 ----
 [/3/6 - ]
-Remaining filter:
-gt (type: bool)
- ├── variable (1) (type: int)
- └── const (5) (type: int)
+Remaining filter: @2 > 5
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2 desc)
 @1 > 2 AND @2 < 5
 ----
 [/3/4 - ]
-Remaining filter:
-lt (type: bool)
- ├── variable (1) (type: int)
- └── const (5) (type: int)
+Remaining filter: @2 < 5
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 != 1 AND @2 > 5
 ----
 (/NULL - /0]
 [/2/6 - ]
-Remaining filter:
-gt (type: bool)
- ├── variable (1) (type: int)
- └── const (5) (type: int)
+Remaining filter: @2 > 5
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 != 1 AND @2 < 5
 ----
 (/NULL - /0/4]
 (/2/NULL - ]
-Remaining filter:
-lt (type: bool)
- ├── variable (1) (type: int)
- └── const (5) (type: int)
+Remaining filter: @2 < 5
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1 >= 1 AND @1 <= 5 AND @1 != 3
@@ -214,62 +195,31 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
 ----
 [/1/8 - /2/9]
-Remaining filter:
-and (type: bool)
- ├── ge (type: bool)
- │    ├── variable (1) (type: int)
- │    └── const (8) (type: int)
- └── le (type: bool)
-      ├── variable (1) (type: int)
-      └── const (9) (type: int)
+Remaining filter: (@2 >= 8) AND (@2 <= 9)
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1 desc, @2)
 @1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
 ----
 [/2/8 - /1/9]
-Remaining filter:
-and (type: bool)
- ├── ge (type: bool)
- │    ├── variable (1) (type: int)
- │    └── const (8) (type: int)
- └── le (type: bool)
-      ├── variable (1) (type: int)
-      └── const (9) (type: int)
+Remaining filter: (@2 >= 8) AND (@2 <= 9)
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2 desc)
 @1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
 ----
 [/1/9 - /2/8]
-Remaining filter:
-and (type: bool)
- ├── ge (type: bool)
- │    ├── variable (1) (type: int)
- │    └── const (8) (type: int)
- └── le (type: bool)
-      ├── variable (1) (type: int)
-      └── const (9) (type: int)
+Remaining filter: (@2 >= 8) AND (@2 <= 9)
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 > 1 AND @1 < 4 AND @2 > 5 AND @2 < 8
 ----
 [/2/6 - /3/7]
-Remaining filter:
-and (type: bool)
- ├── gt (type: bool)
- │    ├── variable (1) (type: int)
- │    └── const (5) (type: int)
- └── lt (type: bool)
-      ├── variable (1) (type: int)
-      └── const (8) (type: int)
+Remaining filter: (@2 > 5) AND (@2 < 8)
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 > 1 AND @1 < 4 AND @2 = 5
 ----
 [/2/5 - /3/5]
-Remaining filter:
-eq (type: bool)
- ├── variable (1) (type: int)
- └── const (5) (type: int)
+Remaining filter: @2 = 5
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 = 1 AND @2 > 3 AND @2 < 5
@@ -295,10 +245,7 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 >= 1 AND @1 <= 5 AND @2 != 2
 ----
 (/1/NULL - /5]
-Remaining filter:
-ne (type: bool)
- ├── variable (1) (type: int)
- └── const (2) (type: int)
+Remaining filter: @2 != 2
 
 # Tests with a type that doesn't support Prev.
 build-scalar,normalize,index-constraints vars=(string) index=(@1)
@@ -310,10 +257,7 @@ build-scalar,normalize,index-constraints vars=(string, int) index=(@1, @2)
 @1 > 'a' AND @1 < 'z' AND @2 = 5
 ----
 [/e'a\x00'/5 - /'z')
-Remaining filter:
-eq (type: bool)
- ├── variable (1) (type: int)
- └── const (5) (type: int)
+Remaining filter: @2 = 5
 
 build-scalar,normalize,index-constraints vars=(string) index=(@1 desc)
 @1 > 'a' AND @1 < 'z'
@@ -324,10 +268,7 @@ build-scalar,normalize,index-constraints vars=(string, int) index=(@1 desc, @2)
 @1 > 'a' AND @1 < 'z' AND @2 = 5
 ----
 (/'z' - /e'a\x00'/5]
-Remaining filter:
-eq (type: bool)
- ├── variable (1) (type: int)
- └── const (5) (type: int)
+Remaining filter: @2 = 5
 
 # Tests with a type that doesn't support Next or Prev.
 build-scalar,normalize,index-constraints vars=(decimal) index=(@1)
@@ -346,10 +287,7 @@ build-scalar,normalize,index-constraints vars=(decimal, decimal) index=(@1, @2)
 @1 > 1.5 AND @2 > 2
 ----
 (/1.5 - ]
-Remaining filter:
-gt (type: bool)
- ├── variable (1) (type: decimal)
- └── const (2) (type: decimal)
+Remaining filter: @2 > 2
 
 # Tests with variable IN tuple.
 
@@ -367,14 +305,14 @@ build-scalar,normalize,index-constraints vars=(int) index=(@1 desc)
 [/2 - /2]
 [/1 - /1]
 
-legacy-normalize,build-scalar,index-constraints vars=(int) index=(@1)
+semtree-normalize,build-scalar,index-constraints vars=(int) index=(@1)
 @1 IN (1, 5, 1, 4)
 ----
 [/1 - /1]
 [/4 - /4]
 [/5 - /5]
 
-legacy-normalize,build-scalar,index-constraints vars=(int) index=(@1 desc)
+semtree-normalize,build-scalar,index-constraints vars=(int) index=(@1 desc)
 @1 IN (1, 5, 1, 4)
 ----
 [/5 - /5]
@@ -404,13 +342,7 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 [/2/1 - /2/1]
 [/2/2 - /2/2]
 [/2/3 - /2/3]
-Remaining filter:
-in (type: bool)
- ├── variable (1) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── const (3) (type: int)
+Remaining filter: @2 IN (1, 2, 3)
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1 desc, @2 desc)
 @1 IN (1, 2) AND @2 IN (1, 2, 3)
@@ -421,37 +353,19 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1 desc, @2 desc
 [/1/3 - /1/3]
 [/1/2 - /1/2]
 [/1/1 - /1/1]
-Remaining filter:
-in (type: bool)
- ├── variable (1) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── const (3) (type: int)
+Remaining filter: @2 IN (1, 2, 3)
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 >= 2 AND @1 <= 4 AND @2 IN (1, 2, 3)
 ----
 [/2/1 - /4/3]
-Remaining filter:
-in (type: bool)
- ├── variable (1) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── const (3) (type: int)
+Remaining filter: @2 IN (1, 2, 3)
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1 desc, @2 desc)
 @1 >= 2 AND @1 <= 4 AND @2 IN (1, 2, 3)
 ----
 [/4/3 - /2/1]
-Remaining filter:
-in (type: bool)
- ├── variable (1) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── const (3) (type: int)
+Remaining filter: @2 IN (1, 2, 3)
 
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
@@ -493,19 +407,13 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @3)
 (@1, @2, @3) = (1, 2, 3)
 ----
 [/1/3 - /1/3]
-Remaining filter:
-eq (type: bool)
- ├── variable (1) (type: int)
- └── const (2) (type: int)
+Remaining filter: @2 = 2
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@3, @2)
 (@1, @2, @3) = (1, 2, 3)
 ----
 [/3/2 - /3/2]
-Remaining filter:
-eq (type: bool)
- ├── variable (0) (type: int)
- └── const (1) (type: int)
+Remaining filter: @1 = 1
 
 build-scalar,normalize,index-constraints vars=(int, int, int, int, int) index=(@1, @2, @3, @4, @5)
 (@1, @2, 3, (4, @5)) = (1, 2, @3, (@4, 5))
@@ -521,33 +429,13 @@ build-scalar,normalize,index-constraints vars=(int, int, int, int) index=(@1, @2
 @1 > 5 AND @1 < 10 AND (@2, @3, @4) = (2, 3, 4)
 ----
 [/6/2/3/4 - /9/2/3/4]
-Remaining filter:
-and (type: bool)
- ├── eq (type: bool)
- │    ├── variable (1) (type: int)
- │    └── const (2) (type: int)
- ├── eq (type: bool)
- │    ├── variable (2) (type: int)
- │    └── const (3) (type: int)
- └── eq (type: bool)
-      ├── variable (3) (type: int)
-      └── const (4) (type: int)
+Remaining filter: ((@2 = 2) AND (@3 = 3)) AND (@4 = 4)
 
 build-scalar,normalize,index-constraints vars=(int, int, int, int) index=(@1 desc, @2 desc, @3 desc, @4 desc)
 @1 > 5 AND @1 < 10 AND (@2, @3, @4) = (2, 3, 4)
 ----
 [/9/2/3/4 - /6/2/3/4]
-Remaining filter:
-and (type: bool)
- ├── eq (type: bool)
- │    ├── variable (1) (type: int)
- │    └── const (2) (type: int)
- ├── eq (type: bool)
- │    ├── variable (2) (type: int)
- │    └── const (3) (type: int)
- └── eq (type: bool)
-      ├── variable (3) (type: int)
-      └── const (4) (type: int)
+Remaining filter: ((@2 = 2) AND (@3 = 3)) AND (@4 = 4)
 
 # Tests with tuple inequalities.
 
@@ -560,16 +448,7 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) >= (1, 2, @1)
 ----
 [/1/2 - ]
-Remaining filter:
-ge (type: bool)
- ├── ordered-list (type: tuple{int, int, int})
- │    ├── variable (0) (type: int)
- │    ├── variable (1) (type: int)
- │    └── variable (2) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── variable (0) (type: int)
+Remaining filter: (@1, @2, @3) >= (1, 2, @1)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) > (1, 2, 3)
@@ -580,16 +459,7 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) > (1, 2, @1)
 ----
 [/1/2 - ]
-Remaining filter:
-gt (type: bool)
- ├── ordered-list (type: tuple{int, int, int})
- │    ├── variable (0) (type: int)
- │    ├── variable (1) (type: int)
- │    └── variable (2) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── variable (0) (type: int)
+Remaining filter: (@1, @2, @3) > (1, 2, @1)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) <= (1, 2, 3)
@@ -600,16 +470,7 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) <= (1, 2, @1)
 ----
 [ - /1/2]
-Remaining filter:
-le (type: bool)
- ├── ordered-list (type: tuple{int, int, int})
- │    ├── variable (0) (type: int)
- │    ├── variable (1) (type: int)
- │    └── variable (2) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── variable (0) (type: int)
+Remaining filter: (@1, @2, @3) <= (1, 2, @1)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) < (1, 2, 3)
@@ -620,16 +481,7 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) < (1, 2, @1)
 ----
 [ - /1/2]
-Remaining filter:
-lt (type: bool)
- ├── ordered-list (type: tuple{int, int, int})
- │    ├── variable (0) (type: int)
- │    ├── variable (1) (type: int)
- │    └── variable (2) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── variable (0) (type: int)
+Remaining filter: (@1, @2, @3) < (1, 2, @1)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) != (1, 2, 3)
@@ -641,16 +493,7 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) != (1, 2, @1)
 ----
 [ - ]
-Remaining filter:
-ne (type: bool)
- ├── ordered-list (type: tuple{int, int, int})
- │    ├── variable (0) (type: int)
- │    ├── variable (1) (type: int)
- │    └── variable (2) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── variable (0) (type: int)
+Remaining filter: (@1, @2, @3) != (1, 2, @1)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 desc, @2 desc, @3 desc)
 (@1, @2, @3) >= (1, 2, 3)
@@ -661,79 +504,35 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 desc, @2
 (@1, @2, @3) > (1, 2, 3)
 ----
 [ - /1/2]
-Remaining filter:
-gt (type: bool)
- ├── ordered-list (type: tuple{int, int, int})
- │    ├── variable (0) (type: int)
- │    ├── variable (1) (type: int)
- │    └── variable (2) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── const (3) (type: int)
+Remaining filter: (@1, @2, @3) > (1, 2, 3)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3 desc)
 (@1, @2, @3) > (1, 2, 3)
 ----
 [/1/2 - ]
-Remaining filter:
-gt (type: bool)
- ├── ordered-list (type: tuple{int, int, int})
- │    ├── variable (0) (type: int)
- │    ├── variable (1) (type: int)
- │    └── variable (2) (type: int)
- └── ordered-list (type: tuple{int, int, int})
-      ├── const (1) (type: int)
-      ├── const (2) (type: int)
-      └── const (3) (type: int)
+Remaining filter: (@1, @2, @3) > (1, 2, 3)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3 desc)
 (@2, @3) > (1, 2)
 ----
 [ - ]
-Remaining filter:
-gt (type: bool)
- ├── ordered-list (type: tuple{int, int})
- │    ├── variable (1) (type: int)
- │    └── variable (2) (type: int)
- └── ordered-list (type: tuple{int, int})
-      ├── const (1) (type: int)
-      └── const (2) (type: int)
+Remaining filter: (@2, @3) > (1, 2)
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 (@1, @2) >= (1, 2) AND (@1, @2) <= (3, 4)
 ----
 [/1/2 - /3/4]
 
-legacy-normalize,build-scalar,index-constraints vars=(int, int) index=(@1, @2)
+semtree-normalize,build-scalar,index-constraints vars=(int, int) index=(@1, @2)
 (@1, @2) BETWEEN (1, 2) AND (3, 4)
 ----
 [/1/2 - /3/4]
 
-legacy-normalize,build-scalar,index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
+semtree-normalize,build-scalar,index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
 (@1, @2, @4) BETWEEN (1, 2, 3) AND (4, 5, 6)
 ----
 [/1/2 - /4/5]
-Remaining filter:
-and (type: bool)
- ├── ge (type: bool)
- │    ├── ordered-list (type: tuple{int, int, int})
- │    │    ├── variable (0) (type: int)
- │    │    ├── variable (1) (type: int)
- │    │    └── variable (3) (type: int)
- │    └── ordered-list (type: tuple{int, int, int})
- │         ├── const (1) (type: int)
- │         ├── const (2) (type: int)
- │         └── const (3) (type: int)
- └── le (type: bool)
-      ├── ordered-list (type: tuple{int, int, int})
-      │    ├── variable (0) (type: int)
-      │    ├── variable (1) (type: int)
-      │    └── variable (3) (type: int)
-      └── ordered-list (type: tuple{int, int, int})
-           ├── const (4) (type: int)
-           ├── const (5) (type: int)
-           └── const (6) (type: int)
+Remaining filter: ((@1, @2, @4) >= (1, 2, 3)) AND ((@1, @2, @4) <= (4, 5, 6))
 
 # Tests with tuple IN tuple.
 
@@ -760,40 +559,13 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 [/1/2/3 - /1/2/3]
 [/4/5/6 - /4/5/6]
 
-
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1+5, @1, @1+@2, @2) IN ((1, 5, 1, 6), (2, 7, 2, 8), (3, 9, 3, 10))
 ----
 [/5/6 - /5/6]
 [/7/8 - /7/8]
 [/9/10 - /9/10]
-Remaining filter:
-in (type: bool)
- ├── ordered-list (type: tuple{int, int, int, int})
- │    ├── plus (type: int)
- │    │    ├── variable (0) (type: int)
- │    │    └── const (5) (type: int)
- │    ├── variable (0) (type: int)
- │    ├── plus (type: int)
- │    │    ├── variable (0) (type: int)
- │    │    └── variable (1) (type: int)
- │    └── variable (1) (type: int)
- └── ordered-list (type: tuple{tuple{int, int, int, int}, tuple{int, int, int, int}, tuple{int, int, int, int}})
-      ├── ordered-list (type: tuple{int, int, int, int})
-      │    ├── const (1) (type: int)
-      │    ├── const (5) (type: int)
-      │    ├── const (1) (type: int)
-      │    └── const (6) (type: int)
-      ├── ordered-list (type: tuple{int, int, int, int})
-      │    ├── const (2) (type: int)
-      │    ├── const (7) (type: int)
-      │    ├── const (2) (type: int)
-      │    └── const (8) (type: int)
-      └── ordered-list (type: tuple{int, int, int, int})
-           ├── const (3) (type: int)
-           ├── const (9) (type: int)
-           ├── const (3) (type: int)
-           └── const (10) (type: int)
+Remaining filter: (@1 + 5, @1, @1 + @2, @2) IN ((1, 5, 1, 6), (2, 7, 2, 8), (3, 9, 3, 10))
 
 # Verify that we sort and de-duplicate if we "project" the tuples;
 # in this case the expression becomes:
@@ -803,58 +575,14 @@ build-scalar,normalize,index-constraints vars=(int, int, int, int) index=(@2, @4
 ----
 [/4/4 - /4/4]
 [/5/5 - /5/5]
-Remaining filter:
-in (type: bool)
- ├── ordered-list (type: tuple{int, int, int, int})
- │    ├── variable (0) (type: int)
- │    ├── variable (1) (type: int)
- │    ├── variable (2) (type: int)
- │    └── variable (3) (type: int)
- └── ordered-list (type: tuple{tuple{int, int, int, int}, tuple{int, int, int, int}, tuple{int, int, int, int}})
-      ├── ordered-list (type: tuple{int, int, int, int})
-      │    ├── const (1) (type: int)
-      │    ├── const (5) (type: int)
-      │    ├── const (1) (type: int)
-      │    └── const (5) (type: int)
-      ├── ordered-list (type: tuple{int, int, int, int})
-      │    ├── const (2) (type: int)
-      │    ├── const (4) (type: int)
-      │    ├── const (2) (type: int)
-      │    └── const (4) (type: int)
-      └── ordered-list (type: tuple{int, int, int, int})
-           ├── const (3) (type: int)
-           ├── const (5) (type: int)
-           ├── const (3) (type: int)
-           └── const (5) (type: int)
+Remaining filter: (@1, @2, @3, @4) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
 
 build-scalar,normalize,index-constraints vars=(int, int, int, int) index=(@2)
 (@1, @2, @3, @4) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
 ----
 [/4 - /4]
 [/5 - /5]
-Remaining filter:
-in (type: bool)
- ├── ordered-list (type: tuple{int, int, int, int})
- │    ├── variable (0) (type: int)
- │    ├── variable (1) (type: int)
- │    ├── variable (2) (type: int)
- │    └── variable (3) (type: int)
- └── ordered-list (type: tuple{tuple{int, int, int, int}, tuple{int, int, int, int}, tuple{int, int, int, int}})
-      ├── ordered-list (type: tuple{int, int, int, int})
-      │    ├── const (1) (type: int)
-      │    ├── const (5) (type: int)
-      │    ├── const (1) (type: int)
-      │    └── const (5) (type: int)
-      ├── ordered-list (type: tuple{int, int, int, int})
-      │    ├── const (2) (type: int)
-      │    ├── const (4) (type: int)
-      │    ├── const (2) (type: int)
-      │    └── const (4) (type: int)
-      └── ordered-list (type: tuple{int, int, int, int})
-           ├── const (3) (type: int)
-           ├── const (5) (type: int)
-           ├── const (3) (type: int)
-           └── const (5) (type: int)
+Remaining filter: (@1, @2, @3, @4) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 (@2, @1) IN ((1, 5), (2, 1), (3, 4), (4, 1))
@@ -916,41 +644,13 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 [/6/1/3 - /6/1/3]
 [/6/1/5 - /6/1/5]
 [/6/1/7 - /6/1/7]
-Remaining filter:
-in (type: bool)
- ├── ordered-list (type: tuple{int, int})
- │    ├── variable (0) (type: int)
- │    └── variable (2) (type: int)
- └── ordered-list (type: tuple{tuple{int, int}, tuple{int, int}, tuple{int, int}})
-      ├── ordered-list (type: tuple{int, int})
-      │    ├── const (2) (type: int)
-      │    └── const (3) (type: int)
-      ├── ordered-list (type: tuple{int, int})
-      │    ├── const (4) (type: int)
-      │    └── const (5) (type: int)
-      └── ordered-list (type: tuple{int, int})
-           ├── const (6) (type: int)
-           └── const (7) (type: int)
+Remaining filter: (@1, @3) IN ((2, 3), (4, 5), (6, 7))
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 @1 > 1 AND (@2, @3) IN ((2, 3), (4, 5), (6, 7))
 ----
 [/2/2/3 - ]
-Remaining filter:
-in (type: bool)
- ├── ordered-list (type: tuple{int, int})
- │    ├── variable (1) (type: int)
- │    └── variable (2) (type: int)
- └── ordered-list (type: tuple{tuple{int, int}, tuple{int, int}, tuple{int, int}})
-      ├── ordered-list (type: tuple{int, int})
-      │    ├── const (2) (type: int)
-      │    └── const (3) (type: int)
-      ├── ordered-list (type: tuple{int, int})
-      │    ├── const (4) (type: int)
-      │    └── const (5) (type: int)
-      └── ordered-list (type: tuple{int, int})
-           ├── const (6) (type: int)
-           └── const (7) (type: int)
+Remaining filter: (@2, @3) IN ((2, 3), (4, 5), (6, 7))
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1 IS NULL
@@ -976,10 +676,7 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 >= 1 AND @2 IS NULL
 ----
 [/1/NULL - ]
-Remaining filter:
-is (type: bool)
- ├── variable (1) (type: int)
- └── const (NULL) (type: NULL)
+Remaining filter: @2 IS NULL
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1 IS NOT DISTINCT FROM NULL
@@ -1033,28 +730,19 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @2 = @1
 ----
 (/NULL - ]
-Remaining filter:
-eq (type: bool)
- ├── variable (1) (type: int)
- └── variable (0) (type: int)
+Remaining filter: @2 = @1
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @2 < @1
 ----
 (/NULL - ]
-Remaining filter:
-lt (type: bool)
- ├── variable (1) (type: int)
- └── variable (0) (type: int)
+Remaining filter: @2 < @1
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1 not null, @2)
 @1 = @2
 ----
 [ - ]
-Remaining filter:
-eq (type: bool)
- ├── variable (0) (type: int)
- └── variable (1) (type: int)
+Remaining filter: @1 = @2
 
 # Tests with top-level OR.
 
@@ -1063,112 +751,47 @@ build-scalar,normalize,index-constraints vars=(int) index=(@1)
 ----
 [/1 - /1]
 [/2 - /2]
-Remaining filter:
-or (type: bool)
- ├── eq (type: bool)
- │    ├── variable (0) (type: int)
- │    └── const (1) (type: int)
- └── eq (type: bool)
-      ├── variable (0) (type: int)
-      └── const (2) (type: int)
+Remaining filter: (@1 = 1) OR (@1 = 2)
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1 IS NULL OR @1 = 1
 ----
 [/NULL - /NULL]
 [/1 - /1]
-Remaining filter:
-or (type: bool)
- ├── is (type: bool)
- │    ├── variable (0) (type: int)
- │    └── const (NULL) (type: NULL)
- └── eq (type: bool)
-      ├── variable (0) (type: int)
-      └── const (1) (type: int)
+Remaining filter: (@1 IS NULL) OR (@1 = 1)
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 (@1 >= 1 AND @1 <= 5) OR (@1 >= 2 AND @1 <= 8)
 ----
 [/1 - /8]
-Remaining filter:
-or (type: bool)
- ├── le (type: bool)
- │    ├── variable (0) (type: int)
- │    └── const (5) (type: int)
- └── ge (type: bool)
-      ├── variable (0) (type: int)
-      └── const (2) (type: int)
+Remaining filter: (@1 <= 5) OR (@1 >= 2)
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 (@1 >= 1 AND @1 <= 3) OR (@1 >= 5 AND @1 <= 8)
 ----
 [/1 - /3]
 [/5 - /8]
-Remaining filter:
-or (type: bool)
- ├── le (type: bool)
- │    ├── variable (0) (type: int)
- │    └── const (3) (type: int)
- └── ge (type: bool)
-      ├── variable (0) (type: int)
-      └── const (5) (type: int)
+Remaining filter: (@1 <= 3) OR (@1 >= 5)
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1)
 (@1 = 1 AND @2 = 5) OR (@1 = 2 and @2 = 6)
 ----
 [/1 - /1]
 [/2 - /2]
-Remaining filter:
-or (type: bool)
- ├── and (type: bool)
- │    ├── eq (type: bool)
- │    │    ├── variable (0) (type: int)
- │    │    └── const (1) (type: int)
- │    └── eq (type: bool)
- │         ├── variable (1) (type: int)
- │         └── const (5) (type: int)
- └── and (type: bool)
-      ├── eq (type: bool)
-      │    ├── variable (0) (type: int)
-      │    └── const (2) (type: int)
-      └── eq (type: bool)
-           ├── variable (1) (type: int)
-           └── const (6) (type: int)
+Remaining filter: ((@1 = 1) AND (@2 = 5)) OR ((@1 = 2) AND (@2 = 6))
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@2)
 (@1 = 1 AND @2 = 5) OR (@1 = 2 and @2 = 6)
 ----
 [/5 - /5]
 [/6 - /6]
-Remaining filter:
-or (type: bool)
- ├── and (type: bool)
- │    ├── eq (type: bool)
- │    │    ├── variable (0) (type: int)
- │    │    └── const (1) (type: int)
- │    └── eq (type: bool)
- │         ├── variable (1) (type: int)
- │         └── const (5) (type: int)
- └── and (type: bool)
-      ├── eq (type: bool)
-      │    ├── variable (0) (type: int)
-      │    └── const (2) (type: int)
-      └── eq (type: bool)
-           ├── variable (1) (type: int)
-           └── const (6) (type: int)
+Remaining filter: ((@1 = 1) AND (@2 = 5)) OR ((@1 = 2) AND (@2 = 6))
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@2)
 @1 = 1 OR @2 = 2
 ----
 [ - ]
-Remaining filter:
-or (type: bool)
- ├── eq (type: bool)
- │    ├── variable (0) (type: int)
- │    └── const (1) (type: int)
- └── eq (type: bool)
-      ├── variable (1) (type: int)
-      └── const (2) (type: int)
+Remaining filter: (@1 = 1) OR (@2 = 2)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 @1 = 1 OR (@1, @2, @3) IN ((4, 5, 6), (7, 8, 9))
@@ -1176,25 +799,7 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 [/1 - /1]
 [/4/5/6 - /4/5/6]
 [/7/8/9 - /7/8/9]
-Remaining filter:
-or (type: bool)
- ├── eq (type: bool)
- │    ├── variable (0) (type: int)
- │    └── const (1) (type: int)
- └── in (type: bool)
-      ├── ordered-list (type: tuple{int, int, int})
-      │    ├── variable (0) (type: int)
-      │    ├── variable (1) (type: int)
-      │    └── variable (2) (type: int)
-      └── ordered-list (type: tuple{tuple{int, int, int}, tuple{int, int, int}})
-           ├── ordered-list (type: tuple{int, int, int})
-           │    ├── const (4) (type: int)
-           │    ├── const (5) (type: int)
-           │    └── const (6) (type: int)
-           └── ordered-list (type: tuple{int, int, int})
-                ├── const (7) (type: int)
-                ├── const (8) (type: int)
-                └── const (9) (type: int)
+Remaining filter: (@1 = 1) OR ((@1, @2, @3) IN ((4, 5, 6), (7, 8, 9)))
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 @1 = 1 OR (@1 = 2 AND (@2, @3) IN ((4, 5), (6, 7))) OR (@1 = 3)
@@ -1203,26 +808,4 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 [/2/4/5 - /2/4/5]
 [/2/6/7 - /2/6/7]
 [/3 - /3]
-Remaining filter:
-or (type: bool)
- ├── eq (type: bool)
- │    ├── variable (0) (type: int)
- │    └── const (1) (type: int)
- ├── and (type: bool)
- │    ├── eq (type: bool)
- │    │    ├── variable (0) (type: int)
- │    │    └── const (2) (type: int)
- │    └── in (type: bool)
- │         ├── ordered-list (type: tuple{int, int})
- │         │    ├── variable (1) (type: int)
- │         │    └── variable (2) (type: int)
- │         └── ordered-list (type: tuple{tuple{int, int}, tuple{int, int}})
- │              ├── ordered-list (type: tuple{int, int})
- │              │    ├── const (4) (type: int)
- │              │    └── const (5) (type: int)
- │              └── ordered-list (type: tuple{int, int})
- │                   ├── const (6) (type: int)
- │                   └── const (7) (type: int)
- └── eq (type: bool)
-      ├── variable (0) (type: int)
-      └── const (3) (type: int)
+Remaining filter: ((@1 = 1) OR ((@1 = 2) AND ((@2, @3) IN ((4, 5), (6, 7))))) OR (@1 = 3)


### PR DESCRIPTION
Adding code to convert a expr back to a tree.TypedExpr. This will be
used to return a simplified filter back to sql code (after index
constraint generation).

For testing, we add a `legacy-expr` directive which converts the
expression and prints the result. This expression should be equivalent
to the original.

Release note: None