### PR TITLE
sql: add empty impls of a bunch more pg_catalog tables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -138,7 +138,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   5 columns, 79 rows
+·                      size   5 columns, 80 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -195,7 +195,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      16 columns, 659 rows
+                     │                     size      16 columns, 663 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -138,7 +138,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   5 columns, 82 rows
+·                      size   5 columns, 83 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -195,7 +195,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      16 columns, 686 rows
+                     │                     size      16 columns, 704 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -138,7 +138,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   5 columns, 80 rows
+·                      size   5 columns, 81 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -195,7 +195,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      16 columns, 663 rows
+                     │                     size      16 columns, 678 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -138,7 +138,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   5 columns, 81 rows
+·                      size   5 columns, 82 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -195,7 +195,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      16 columns, 678 rows
+                     │                     size      16 columns, 686 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -138,7 +138,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   5 columns, 78 rows
+·                      size   5 columns, 79 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -195,7 +195,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      16 columns, 652 rows
+                     │                     size      16 columns, 659 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -268,6 +268,7 @@ pg_catalog          pg_sequence
 pg_catalog          pg_settings
 pg_catalog          pg_tables
 pg_catalog          pg_tablespace
+pg_catalog          pg_trigger
 pg_catalog          pg_type
 pg_catalog          pg_user
 pg_catalog          pg_user_mapping
@@ -440,6 +441,7 @@ def            pg_catalog          pg_sequence                SYSTEM VIEW  1
 def            pg_catalog          pg_settings                SYSTEM VIEW  1
 def            pg_catalog          pg_tables                  SYSTEM VIEW  1
 def            pg_catalog          pg_tablespace              SYSTEM VIEW  1
+def            pg_catalog          pg_trigger                 SYSTEM VIEW  1
 def            pg_catalog          pg_type                    SYSTEM VIEW  1
 def            pg_catalog          pg_user                    SYSTEM VIEW  1
 def            pg_catalog          pg_user_mapping            SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -262,6 +262,7 @@ pg_catalog          pg_namespace
 pg_catalog          pg_operator
 pg_catalog          pg_proc
 pg_catalog          pg_range
+pg_catalog          pg_rewrite
 pg_catalog          pg_roles
 pg_catalog          pg_sequence
 pg_catalog          pg_settings
@@ -433,6 +434,7 @@ def            pg_catalog          pg_namespace               SYSTEM VIEW  1
 def            pg_catalog          pg_operator                SYSTEM VIEW  1
 def            pg_catalog          pg_proc                    SYSTEM VIEW  1
 def            pg_catalog          pg_range                   SYSTEM VIEW  1
+def            pg_catalog          pg_rewrite                 SYSTEM VIEW  1
 def            pg_catalog          pg_roles                   SYSTEM VIEW  1
 def            pg_catalog          pg_sequence                SYSTEM VIEW  1
 def            pg_catalog          pg_settings                SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -259,6 +259,7 @@ pg_catalog          pg_index
 pg_catalog          pg_indexes
 pg_catalog          pg_inherits
 pg_catalog          pg_namespace
+pg_catalog          pg_operator
 pg_catalog          pg_proc
 pg_catalog          pg_range
 pg_catalog          pg_roles
@@ -429,6 +430,7 @@ def            pg_catalog          pg_index                   SYSTEM VIEW  1
 def            pg_catalog          pg_indexes                 SYSTEM VIEW  1
 def            pg_catalog          pg_inherits                SYSTEM VIEW  1
 def            pg_catalog          pg_namespace               SYSTEM VIEW  1
+def            pg_catalog          pg_operator                SYSTEM VIEW  1
 def            pg_catalog          pg_proc                    SYSTEM VIEW  1
 def            pg_catalog          pg_range                   SYSTEM VIEW  1
 def            pg_catalog          pg_roles                   SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -268,6 +268,7 @@ pg_catalog          pg_tables
 pg_catalog          pg_tablespace
 pg_catalog          pg_type
 pg_catalog          pg_user
+pg_catalog          pg_user_mapping
 pg_catalog          pg_views
 system              descriptor
 system              eventlog
@@ -437,6 +438,7 @@ def            pg_catalog          pg_tables                  SYSTEM VIEW  1
 def            pg_catalog          pg_tablespace              SYSTEM VIEW  1
 def            pg_catalog          pg_type                    SYSTEM VIEW  1
 def            pg_catalog          pg_user                    SYSTEM VIEW  1
+def            pg_catalog          pg_user_mapping            SYSTEM VIEW  1
 def            pg_catalog          pg_views                   SYSTEM VIEW  1
 def            system              descriptor                 BASE TABLE   1
 def            system              eventlog                   BASE TABLE   2

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -252,6 +252,7 @@ pg_catalog          pg_depend
 pg_catalog          pg_description
 pg_catalog          pg_enum
 pg_catalog          pg_extension
+pg_catalog          pg_foreign_data_wrapper
 pg_catalog          pg_foreign_server
 pg_catalog          pg_foreign_table
 pg_catalog          pg_index
@@ -420,6 +421,7 @@ def            pg_catalog          pg_depend                  SYSTEM VIEW  1
 def            pg_catalog          pg_description             SYSTEM VIEW  1
 def            pg_catalog          pg_enum                    SYSTEM VIEW  1
 def            pg_catalog          pg_extension               SYSTEM VIEW  1
+def            pg_catalog          pg_foreign_data_wrapper    SYSTEM VIEW  1
 def            pg_catalog          pg_foreign_server          SYSTEM VIEW  1
 def            pg_catalog          pg_foreign_table           SYSTEM VIEW  1
 def            pg_catalog          pg_index                   SYSTEM VIEW  1

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -64,6 +64,7 @@ pg_index
 pg_indexes
 pg_inherits
 pg_namespace
+pg_operator
 pg_proc
 pg_range
 pg_roles

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -73,6 +73,7 @@ pg_tables
 pg_tablespace
 pg_type
 pg_user
+pg_user_mapping
 pg_views
 
 query TT colnames

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -67,6 +67,7 @@ pg_namespace
 pg_operator
 pg_proc
 pg_range
+pg_rewrite
 pg_roles
 pg_sequence
 pg_settings

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -57,6 +57,7 @@ pg_depend
 pg_description
 pg_enum
 pg_extension
+pg_foreign_data_wrapper
 pg_foreign_server
 pg_foreign_table
 pg_index

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -73,6 +73,7 @@ pg_sequence
 pg_settings
 pg_tables
 pg_tablespace
+pg_trigger
 pg_type
 pg_user
 pg_user_mapping

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -75,6 +75,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogIndexesTable,
 		pgCatalogInheritsTable,
 		pgCatalogNamespaceTable,
+		pgCatalogOperatorTable,
 		pgCatalogProcTable,
 		pgCatalogRangeTable,
 		pgCatalogRolesTable,
@@ -1064,6 +1065,32 @@ CREATE TABLE pg_catalog.pg_namespace (
 				tree.DNull,               // nspacl
 			)
 		})
+	},
+}
+
+// See: https://www.postgresql.org/docs/10/static/catalog-pg-operator.html.
+var pgCatalogOperatorTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_operator (
+	oid OID,
+  oprname NAME,
+  oprnamespace OID,
+  oprowner OID,
+  oprkind TEXT,
+  oprcanmerge BOOL,
+  oprcanhash BOOL,
+  oprleft OID,
+  oprright OID,
+  oprresult OID,
+  oprcom OID,
+  oprnegate OID,
+  oprcode OID,
+  oprrest OID,
+  oprjoin OID
+);
+`,
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
+		return nil
 	},
 }
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -68,6 +68,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogDescriptionTable,
 		pgCatalogEnumTable,
 		pgCatalogExtensionTable,
+		pgCatalogForeignDataWrapperTable,
 		pgCatalogForeignServerTable,
 		pgCatalogForeignTableTable,
 		pgCatalogIndexTable,
@@ -803,6 +804,25 @@ CREATE TABLE pg_catalog.pg_extension (
 `,
 	populate: func(_ context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
 		// Extensions are not supported.
+		return nil
+	},
+}
+
+// See: https://www.postgresql.org/docs/10/static/catalog-pg-foreign-data-wrapper.html
+var pgCatalogForeignDataWrapperTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_foreign_data_wrapper (
+  oid OID,
+  fdwname NAME,
+  fdwowner OID,
+  fdwhandler OID,
+  fdwvalidator OID,
+  fdwacl STRING[],
+  fdwoptions STRING[]
+);
+`,
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
+		// Foreign data wrappers are not supported.
 		return nil
 	},
 }

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -81,6 +81,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogSequencesTable,
 		pgCatalogSettingsTable,
 		pgCatalogUserTable,
+		pgCatalogUserMappingTable,
 		pgCatalogTablesTable,
 		pgCatalogTablespaceTable,
 		pgCatalogTypeTable,
@@ -1649,6 +1650,23 @@ CREATE TABLE pg_catalog.pg_user (
 					tree.DNull,              // useconfig
 				)
 			})
+	},
+}
+
+// See: https://www.postgresql.org/docs/10/static/view-pg-user.html
+var pgCatalogUserMappingTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_user_mapping (
+  oid OID,
+  umuser OID,
+  umserver OID,
+  umoptions TEXT[]
+);
+`,
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
+		// This table stores the mapping to foreign server users.
+		// Foreign servers are not supported.
+		return nil
 	},
 }
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -86,6 +86,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogUserMappingTable,
 		pgCatalogTablesTable,
 		pgCatalogTablespaceTable,
+		pgCatalogTriggerTable,
 		pgCatalogTypeTable,
 		pgCatalogViewsTable,
 	},
@@ -1509,6 +1510,36 @@ CREATE TABLE pg_catalog.pg_tablespace (
 			tree.DNull,                    // spcacl
 			tree.DNull,                    // spcoptions
 		)
+	},
+}
+
+// See: https://www.postgresql.org/docs/10/static/catalog-pg-trigger.html
+var pgCatalogTriggerTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_trigger (
+  oid OID,
+  tgrelid OID,
+  tgname NAME,
+  tgfoid OID,
+  tgtype INT,
+  tgenabled TEXT,
+  tgisinternal BOOL,
+  tgconstrrelid OID,
+  tgconstrindid OID,
+  tgconstraint OID,
+  tgdeferrable BOOL,
+  tginitdeferred BOOL,
+  tgnargs INT,
+  tgattr INT2VECTOR,
+  tgargs BYTEA,
+  tgqual TEXT,
+  tgoldtable NAME,
+  tgnewtable NAME
+);
+`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
+		// Triggers are unsupported.
+		return nil
 	},
 }
 

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -78,6 +78,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogOperatorTable,
 		pgCatalogProcTable,
 		pgCatalogRangeTable,
+		pgCatalogRewriteTable,
 		pgCatalogRolesTable,
 		pgCatalogSequencesTable,
 		pgCatalogSettingsTable,
@@ -1287,6 +1288,26 @@ CREATE TABLE pg_catalog.pg_range (
 		// We currently do not support any range types, so this table is empty.
 		// This table should be populated when any range types are added to
 		// oidToDatum (and therefore pg_type).
+		return nil
+	},
+}
+
+// See: https://www.postgresql.org/docs/10/static/catalog-pg-rewrite.html.
+var pgCatalogRewriteTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_rewrite (
+  oid OID,
+  rulename NAME,
+  ev_class OID,
+  ev_type TEXT,
+  ev_enabled TEXT,
+  is_instead BOOL,
+  ev_qual TEXT,
+  ev_action TEXT
+);
+`,
+	populate: func(_ context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
+		// Rewrite rules are not supported.
 		return nil
 	},
 }


### PR DESCRIPTION
Add empty implementations of the following `pg_catalog` tables, for compatibility purposes:

- `foreign_data_wrapper` 
- `pg_user_mapping`
- `pg_operator`
- `pg_rewrite`
- `pg_trigger`

JetBrains DataGrip needs these, and so does at least one other tool whose name escapes me right now.