### PR TITLE
sql: don't scan table on NULL WHERE predicate

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -7,6 +7,22 @@ Tree         Field  Description
 render       ·      ·
  └── norows  ·      ·
 
+query TTT colnames
+EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE NULL
+----
+Tree         Field  Description
+render       ·      ·
+ └── norows  ·      ·
+
+query TTT colnames
+EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE TRUE
+----
+Tree       Field  Description
+render     ·      ·
+└── scan  ·      ·
+·          table  jobs@primary
+·          spans  ALL
+
 query TITTTTT colnames
 EXPLAIN (PLAN, METADATA) SELECT 1
 ----

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -318,6 +318,18 @@ EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 render       ·  ·
  └── norows  ·  ·
 
+query TTT
+EXPLAIN SELECT * FROM t WHERE a = 1 AND NULL
+----
+render       ·  ·
+ └── norows  ·  ·
+
+query TTT
+EXPLAIN SELECT * FROM t WHERE a = NULL AND a != NULL
+----
+render       ·  ·
+ └── norows  ·  ·
+
 # Make sure that mixed type comparison operations are not used
 # for selecting indexes.
 

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -240,10 +240,10 @@ func (p *planner) selectIndex(
 		if err != nil {
 			return nil, err
 		}
-		if s.filter == tree.DBoolFalse {
+		switch s.filter {
+		case tree.DBoolFalse, tree.DNull:
 			return &zeroNode{}, nil
-		}
-		if s.filter == tree.DBoolTrue {
+		case tree.DBoolTrue:
 			s.filter = nil
 		}
 	}


### PR DESCRIPTION
NULL is treated like FALSE in WHERE predicates, so we don't need to scan
any rows if a WHERE predicate simplifies to NULL. This is an extension
of the logic we already had for WHERE predicates that simplified to FALSE.

Release note (sql change): WHERE predicates that simplify to NULL will
no longer perform a table scan.