### PR TITLE
engine: better randomized MVCCStats testing; fix bugs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -67,7 +67,6 @@ kv.allocator.range_rebalance_threshold             5E-02          f     minimum 
 kv.allocator.stat_based_rebalancing.enabled        false          b     set to enable rebalancing of range replicas based on write load and disk usage
 kv.allocator.stat_rebalance_threshold              2E-01          f     minimum fraction away from the mean a store's stats (like disk usage or writes per second) can be before it is considered overfull or underfull
 kv.bulk_io_write.max_rate                          8.0 EiB        z     the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops
-kv.gc.batch_size                                   100000         i     maximum number of keys in a batch for MVCC garbage collection
 kv.raft.command.max_size                           64 MiB         z     maximum size of a raft command
 kv.raft_log.synchronize                            true           b     set to true to synchronize on Raft log writes to persistent storage
 kv.range_descriptor_cache.size                     1000000        i     maximum number of entries in the range descriptor and leaseholder caches

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -78,6 +78,7 @@ func TestQueryCounts(t *testing.T) {
 	accum := queryCounter{
 		selectCount: 2, // non-zero due to migrations
 		insertCount: 6, // non-zero due to migrations
+		deleteCount: 1, // non-zero due to migrations
 		ddlCount:    s.MustGetSQLCounter(sql.MetaDdl.Name),
 		miscCount:   s.MustGetSQLCounter(sql.MetaMisc.Name),
 	}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -146,6 +146,10 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		name:   "upgrade table descs to interleaved format version",
 		workFn: upgradeTableDescsToInterleavedFormatVersion,
 	},
+	{
+		name:   "remove cluster setting `kv.gc.batch_size`",
+		workFn: purgeClusterSettingKVGCBatchSize,
+	},
 }
 
 // migrationDescriptor describes a single migration hook that's used to modify
@@ -917,4 +921,9 @@ func upgradeTableDescsToInterleavedFormatVersion(ctx context.Context, r runner) 
 		}
 	}
 	return nil
+}
+
+func purgeClusterSettingKVGCBatchSize(ctx context.Context, r runner) error {
+	// This cluster setting has been removed.
+	return runStmtAsRootWithRetry(ctx, r, `DELETE FROM SYSTEM.SETTINGS WHERE name='kv.gc.batch_size'`)
 }

--- a/pkg/storage/batcheval/cmd_clear_range_test.go
+++ b/pkg/storage/batcheval/cmd_clear_range_test.go
@@ -96,7 +96,7 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 			var stats enginepb.MVCCStats
 			for i := 0; i < test.keyCount; i++ {
 				key := roachpb.Key(fmt.Sprintf("%04d", i))
-				if err := engine.MVCCPut(ctx, eng, &stats, key, hlc.Timestamp{}, value, nil); err != nil {
+				if err := engine.MVCCPut(ctx, eng, &stats, key, hlc.Timestamp{WallTime: int64(i % 2)}, value, nil); err != nil {
 					t.Fatal(err)
 				}
 			}
@@ -115,21 +115,20 @@ func TestCmdClearRangeBytesThreshold(t *testing.T) {
 					EndKey: endKey,
 				},
 			}
-			var delta enginepb.MVCCStats
-			cArgs.Stats = &delta
+			cArgs.Stats = &enginepb.MVCCStats{}
 
 			if _, err := ClearRange(ctx, batch, cArgs, &roachpb.ClearRangeResponse{}); err != nil {
 				t.Fatal(err)
 			}
 
-			// Verify delta is equal to the stats we wrote.
+			// Verify cArgs.Stats is equal to the stats we wrote.
 			newStats := stats
-			newStats.SysBytes, newStats.SysCount = 0, 0 // ignore these values
-			delta.SysBytes, delta.SysCount = 0, 0       // these too, as GC threshold is updated
-			delta.AgeTo(newStats.LastUpdateNanos)
-			newStats.Add(delta)
+			newStats.SysBytes, newStats.SysCount = 0, 0       // ignore these values
+			cArgs.Stats.SysBytes, cArgs.Stats.SysCount = 0, 0 // these too, as GC threshold is updated
+			newStats.Add(*cArgs.Stats)
+			newStats.AgeTo(0) // pin at LastUpdateNanos==0
 			if !newStats.Equal(enginepb.MVCCStats{}) {
-				t.Errorf("expected stats on original writes to be negated on clear range: %+v vs %+v", stats, delta)
+				t.Errorf("expected stats on original writes to be negated on clear range: %+v vs %+v", stats, *cArgs.Stats)
 			}
 
 			// Verify we see the correct counts for Clear and ClearRange.

--- a/pkg/storage/batcheval/cmd_gc.go
+++ b/pkg/storage/batcheval/cmd_gc.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
@@ -30,11 +29,6 @@ import (
 func init() {
 	RegisterCommand(roachpb.GC, declareKeysGC, GC)
 }
-
-var gcBatchSize = settings.RegisterIntSetting("kv.gc.batch_size",
-	"maximum number of keys in a batch for MVCC garbage collection",
-	100000,
-)
 
 func declareKeysGC(
 	desc roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
@@ -90,7 +84,6 @@ func GC(
 	// Garbage collect the specified keys by expiration timestamps.
 	if err := engine.MVCCGarbageCollect(
 		ctx, batch, cArgs.Stats, keys, h.Timestamp,
-		gcBatchSize.Get(&cArgs.EvalCtx.ClusterSettings().SV),
 	); err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -786,7 +786,7 @@ func BenchmarkMVCCGarbageCollect(b *testing.B) {
 
 			b.StartTimer()
 			if err := MVCCGarbageCollect(
-				ctx, engine, &enginepb.MVCCStats{}, gcKeys, now, math.MaxInt64,
+				ctx, engine, &enginepb.MVCCStats{}, gcKeys, now,
 			); err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/storage/engine/enginepb/mvcc.go
+++ b/pkg/storage/engine/enginepb/mvcc.go
@@ -52,15 +52,21 @@ func (ms MVCCStats) GCByteAge(nowNanos int64) int64 {
 	return ms.GCBytesAge
 }
 
-// AgeTo encapsulates the complexity of computing the increment in age
-// quantities contained in MVCCStats. Two MVCCStats structs only add and
-// subtract meaningfully if their LastUpdateNanos matches, so aging them to
-// the max of their LastUpdateNanos is a prerequisite.
-// If nowNanos is behind ms.LastUpdateNanos, this method is a noop.
+// AgeTo is like ForceAge, but if nowNanos is not ahead of ms.LastUpdateNanos,
+// this method is a noop.
 func (ms *MVCCStats) AgeTo(nowNanos int64) {
 	if ms.LastUpdateNanos >= nowNanos {
 		return
 	}
+	ms.ForceAge(nowNanos)
+}
+
+// ForceAge encapsulates the complexity of computing the increment in age
+// quantities contained in MVCCStats. Two MVCCStats structs only add and
+// subtract meaningfully if their LastUpdateNanos matches, so aging them to
+// the max of their LastUpdateNanos is a prerequisite, though Add() takes
+// care of this internally.
+func (ms *MVCCStats) ForceAge(nowNanos int64) {
 	// Seconds are counted every time each individual nanosecond timestamp
 	// crosses a whole second boundary (i.e. is zero mod 1E9). Thus it would
 	// be a mistake to use the (nonequivalent) expression (a-b)/1E9.

--- a/pkg/storage/engine/enginepb/mvcc.go
+++ b/pkg/storage/engine/enginepb/mvcc.go
@@ -52,21 +52,21 @@ func (ms MVCCStats) GCByteAge(nowNanos int64) int64 {
 	return ms.GCBytesAge
 }
 
-// AgeTo is like ForceAge, but if nowNanos is not ahead of ms.LastUpdateNanos,
+// Forward is like AgeTo, but if nowNanos is not ahead of ms.LastUpdateNanos,
 // this method is a noop.
-func (ms *MVCCStats) AgeTo(nowNanos int64) {
+func (ms *MVCCStats) Forward(nowNanos int64) {
 	if ms.LastUpdateNanos >= nowNanos {
 		return
 	}
-	ms.ForceAge(nowNanos)
+	ms.AgeTo(nowNanos)
 }
 
-// ForceAge encapsulates the complexity of computing the increment in age
+// AgeTo encapsulates the complexity of computing the increment in age
 // quantities contained in MVCCStats. Two MVCCStats structs only add and
 // subtract meaningfully if their LastUpdateNanos matches, so aging them to
 // the max of their LastUpdateNanos is a prerequisite, though Add() takes
 // care of this internally.
-func (ms *MVCCStats) ForceAge(nowNanos int64) {
+func (ms *MVCCStats) AgeTo(nowNanos int64) {
 	// Seconds are counted every time each individual nanosecond timestamp
 	// crosses a whole second boundary (i.e. is zero mod 1E9). Thus it would
 	// be a mistake to use the (nonequivalent) expression (a-b)/1E9.
@@ -82,8 +82,8 @@ func (ms *MVCCStats) ForceAge(nowNanos int64) {
 func (ms *MVCCStats) Add(oms MVCCStats) {
 	// Enforce the max LastUpdateNanos for both ages based on their
 	// pre-addition state.
-	ms.AgeTo(oms.LastUpdateNanos)
-	oms.AgeTo(ms.LastUpdateNanos)
+	ms.Forward(oms.LastUpdateNanos)
+	oms.Forward(ms.LastUpdateNanos) // on local copy
 	// If either stats object contains estimates, their sum does too.
 	ms.ContainsEstimates = ms.ContainsEstimates || oms.ContainsEstimates
 	// Now that we've done that, we may just add them.
@@ -106,8 +106,8 @@ func (ms *MVCCStats) Add(oms MVCCStats) {
 func (ms *MVCCStats) Subtract(oms MVCCStats) {
 	// Enforce the max LastUpdateNanos for both ages based on their
 	// pre-subtraction state.
-	ms.AgeTo(oms.LastUpdateNanos)
-	oms.AgeTo(ms.LastUpdateNanos)
+	ms.Forward(oms.LastUpdateNanos)
+	oms.Forward(ms.LastUpdateNanos)
 	// If either stats object contains estimates, their difference does too.
 	ms.ContainsEstimates = ms.ContainsEstimates || oms.ContainsEstimates
 	// Now that we've done that, we may subtract.

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -337,7 +337,7 @@ func updateStatsOnResolve(
 	}
 
 	if sys {
-		ms.SysBytes += metaKeySize + metaValSize - origMetaValSize - origMetaKeySize
+		ms.SysBytes += (metaKeySize + metaValSize) - (origMetaValSize + origMetaKeySize)
 	} else {
 		// At orig.Timestamp, the original meta key disappears.
 		ms.KeyBytes -= origMetaKeySize + orig.KeyBytes
@@ -372,7 +372,7 @@ func updateStatsOnResolve(
 		}
 
 		if !meta.Deleted {
-			ms.LiveBytes += metaKeySize + metaValSize + meta.KeyBytes + meta.ValBytes
+			ms.LiveBytes += (metaKeySize + metaValSize) + (meta.KeyBytes + meta.ValBytes)
 		}
 	}
 	return ms

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -240,7 +240,7 @@ func updateStatsOnPut(
 			// Move the (so far empty) stats to the timestamp at which the
 			// previous entry was created, which is where we wish to reclassify
 			// its contributions.
-			ms.ForceAge(orig.Timestamp.WallTime)
+			ms.AgeTo(orig.Timestamp.WallTime)
 			// If original version value for this key wasn't deleted, subtract
 			// its contribution from live bytes in anticipation of adding in
 			// contribution from new version below.
@@ -274,10 +274,10 @@ func updateStatsOnPut(
 	// meta.Timestamp.WallTime < orig.Timestamp.WallTime. This wouldn't happen
 	// outside of tests (due to our semantics of txn.OrigTimestamp, which never
 	// decreases) but it sure does happen in randomized testing. An earlier
-	// version of the code used `AgeTo` here, which is incorrect as it would be
+	// version of the code used `Forward` here, which is incorrect as it would be
 	// a no-op and fail to subtract out the intent bytes/GC age incurred due to
 	// removing the meta entry at `orig.Timestamp` (when `orig != nil`).
-	ms.ForceAge(meta.Timestamp.WallTime)
+	ms.AgeTo(meta.Timestamp.WallTime)
 
 	if sys {
 		ms.SysBytes += meta.KeyBytes + meta.ValBytes + metaKeySize + metaValSize
@@ -338,7 +338,6 @@ func updateStatsOnResolve(
 
 	if sys {
 		ms.SysBytes += metaKeySize + metaValSize - origMetaValSize - origMetaKeySize
-		ms.AgeTo(meta.Timestamp.WallTime)
 	} else {
 		// At orig.Timestamp, the original meta key disappears.
 		ms.KeyBytes -= origMetaKeySize + orig.KeyBytes

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -2229,15 +2229,12 @@ func MVCCResolveWriteIntentRangeUsingIter(
 // keys slice. The engine iterator is seeked in turn to each listed
 // key, clearing all values with timestamps <= to expiration. The
 // timestamp parameter is used to compute the intent age on GC.
-// Garbage collection stops after clearing maxClears values
-// (to limit the size of the WriteBatch produced).
 func MVCCGarbageCollect(
 	ctx context.Context,
 	engine ReadWriter,
 	ms *enginepb.MVCCStats,
 	keys []roachpb.GCRequest_GCKey,
 	timestamp hlc.Timestamp,
-	maxClears int64,
 ) error {
 	// We're allowed to use a prefix iterator because we always Seek() the
 	// iterator when handling a new user key.
@@ -2246,7 +2243,7 @@ func MVCCGarbageCollect(
 
 	var count int64
 	defer func(begin time.Time) {
-		log.Eventf(ctx, "done with GC evaluation for %d keys at %.2f keys/sec. Deleted %d versions",
+		log.Eventf(ctx, "done with GC evaluation for %d keys at %.2f keys/sec. Deleted %d entries",
 			len(keys), float64(len(keys))*1E9/float64(timeutil.Since(begin)), count)
 	}(timeutil.Now())
 
@@ -2264,6 +2261,13 @@ func MVCCGarbageCollect(
 		inlinedValue := meta.IsInline()
 		implicitMeta := iter.UnsafeKey().IsValue()
 		// First, check whether all values of the key are being deleted.
+		//
+		// Note that we naively can't terminate GC'ing keys loop early if we
+		// enter this branch, as it will update the stats under the provision
+		// that the (implicit or explicit) meta key (and thus all versions) are
+		// being removed. We had this faulty functionality at some point; it
+		// should no longer be necessary since the higher levels already make
+		// sure each individual GCRequest does bounded work.
 		if !gcKey.Timestamp.Less(hlc.Timestamp(meta.Timestamp)) {
 			// For version keys, don't allow GC'ing the meta key if it's
 			// not marked deleted. However, for inline values we allow it;
@@ -2289,9 +2293,6 @@ func MVCCGarbageCollect(
 					return err
 				}
 				count++
-				if count >= maxClears {
-					return nil
-				}
 			}
 		}
 
@@ -2320,12 +2321,9 @@ func MVCCGarbageCollect(
 						int64(len(iter.UnsafeValue())), nil, unsafeIterKey.Timestamp.WallTime,
 						timestamp.WallTime))
 				}
+				count++
 				if err := engine.Clear(unsafeIterKey); err != nil {
 					return err
-				}
-				count++
-				if count >= maxClears {
-					return nil
 				}
 			}
 		}

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -234,7 +234,13 @@ func updateStatsOnPut(
 	// Remove current live counts for this key.
 	if orig != nil {
 		if sys {
-			ms.SysBytes -= (origMetaKeySize + origMetaValSize)
+			ms.SysBytes -= origMetaKeySize + origMetaValSize
+			if orig.Txn != nil {
+				// If the original value was an intent, we're replacing the
+				// intent. Note that since it's a system key, it doesn't affect
+				// IntentByte, IntentCount, and correspondingly, IntentAge.
+				ms.SysBytes -= orig.KeyBytes + orig.ValBytes
+			}
 			ms.SysCount--
 		} else {
 			// Move the (so far empty) stats to the timestamp at which the

--- a/pkg/storage/engine/mvcc_stats_test.go
+++ b/pkg/storage/engine/mvcc_stats_test.go
@@ -842,6 +842,15 @@ func TestMVCCStatsRandomized(t *testing.T) {
 		}
 		return ""
 	}
+	s.actions["DelRange"] = func(s *state) string {
+		returnKeys := (s.TS.WallTime % 2) == 0
+		max := s.TS.WallTime % 5
+		desc := fmt.Sprintf("returnKeys=%t, max=%d", returnKeys, max)
+		if _, _, _, err := MVCCDeleteRange(ctx, s.eng, s.MS, roachpb.KeyMin, roachpb.KeyMax, max, s.TS, s.Txn, returnKeys); err != nil {
+			return desc + ": " + err.Error()
+		}
+		return desc
+	}
 	s.actions["EnsureTxn"] = func(s *state) string {
 		if s.Txn == nil {
 			s.Txn = &roachpb.Transaction{TxnMeta: enginepb.TxnMeta{ID: uuid.MakeV4(), Timestamp: s.TS}}

--- a/pkg/storage/engine/mvcc_stats_test.go
+++ b/pkg/storage/engine/mvcc_stats_test.go
@@ -322,10 +322,10 @@ func TestMVCCStatsPutIntentTimestampNotPutTimestamp(t *testing.T) {
 
 	// Replace the intent with an identical one, but we write it at 1s-1 now. If
 	// you're confused, don't worry. There are two timestamps here: the one in
-	// the txn (which is, perhaps surprisingly, only used to read the existing
-	// values), and the timestamp passed directly to MVCCPut (which is where the
-	// intent will actually end up being written at, and which usually
-	// corresponds to txn.OrigTimestamp).
+	// the txn (which is, perhaps surprisingly, only really used when
+	// committing/aborting intents), and the timestamp passed directly to
+	// MVCCPut (which is where the intent will actually end up being written at,
+	// and which usually corresponds to txn.OrigTimestamp).
 	txn.Sequence++
 
 	// Annoyingly, the new meta value is actually a little larger thanks to the

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3494,7 +3494,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 		{Key: roachpb.Key("inline-bad"), Timestamp: hlc.Timestamp{}},
 	}
 	if err := MVCCGarbageCollect(
-		context.Background(), engine, ms, keys, ts3, math.MaxInt64,
+		context.Background(), engine, ms, keys, ts3,
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -3567,7 +3567,7 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 		keys := []roachpb.GCRequest_GCKey{
 			{Key: test.key, Timestamp: ts2},
 		}
-		err := MVCCGarbageCollect(context.Background(), engine, nil, keys, ts2, math.MaxInt64)
+		err := MVCCGarbageCollect(context.Background(), engine, nil, keys, ts2)
 		if !testutils.IsError(err, test.expError) {
 			t.Fatalf("expected error %q when garbage collecting a non-deleted live value, found %v", test.expError, err)
 		}
@@ -3599,7 +3599,7 @@ func TestMVCCGarbageCollectIntent(t *testing.T) {
 		{Key: key, Timestamp: ts2},
 	}
 	if err := MVCCGarbageCollect(
-		context.Background(), engine, nil, keys, ts2, math.MaxInt64,
+		context.Background(), engine, nil, keys, ts2,
 	); err == nil {
 		t.Fatal("expected error garbage collecting an intent")
 	}

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -289,7 +289,7 @@ func makeGCQueueScore(
 func makeGCQueueScoreImpl(
 	ctx context.Context, fuzzSeed int64, now hlc.Timestamp, ms enginepb.MVCCStats, ttlSeconds int32,
 ) gcQueueScore {
-	ms.AgeTo(now.WallTime)
+	ms.Forward(now.WallTime)
 	var r gcQueueScore
 	r.TTL = time.Duration(ttlSeconds) * time.Second
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4898,6 +4898,9 @@ func (r *Replica) applyRaftCommand(
 	// delta upgrades. Thanks to commutativity, the command queue does not
 	// have to serialize on the stats key.
 	deltaStats := rResult.Delta.ToStats()
+	// Note that calling ms.Add will never result in ms.LastUpdateNanos
+	// decreasing (and thus LastUpdateNanos tracks the maximum LastUpdateNanos
+	// across all deltaStats).
 	ms.Add(deltaStats)
 	if err := r.raftMu.stateLoader.SetMVCCStats(ctx, writer, &ms); err != nil {
 		return enginepb.MVCCStats{}, errors.Wrap(err, "unable to update MVCCStats")


### PR DESCRIPTION
This PR removes `TestMVCCStatsWithRandomRuns` and replaces it with a
more principled test that achieves much better coverage. This can be seen
from the amount of additional tests it inspired, each of which explores one
family of failures of the new `TestMVCCStatsRandomized`.

Release note: None