### PR TITLE
storage: revert change to TestInitRaftGroupOnRequest, deflake test

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3754,9 +3754,13 @@ func TestInitRaftGroupOnRequest(t *testing.T) {
 		t.Fatal("replica should not be nil for RHS range")
 	}
 
+	// TODO(spencer): Raft messages seem to turn up
+	// occasionally on restart, which initialize the replica, so
+	// this is not a test failure. Not sure how to work around this
+	// problem.
 	// Verify the raft group isn't initialized yet.
 	if repl.IsRaftGroupInitialized() {
-		t.Fatal("expected raft group to be uninitialized")
+		log.Errorf(context.TODO(), "expected raft group to be uninitialized")
 	}
 
 	// Send an increment and verify that initializes the Raft group.


### PR DESCRIPTION
Closes #21025.

This change reverts the change to `client_raft_test.go` in
https://github.com/cockroachdb/cockroach/commit/4b0232db345aeb4443980c9c9bc0d3b3f5c361d3#diff-b1bd51088f60beeacafe950f5bc700f8.

I thought that I had addressed the TODO by preventing Raft messages sent
when a store is down from reaching that store. However, this did not
prevent Raft messages sent before a store went down from reaching that
store.

Release note: None