### PR TITLE
opt: index constraints code cleanup and improvements

### DIFF
--- a/pkg/sql/opt/index_constraints_spans.go
+++ b/pkg/sql/opt/index_constraints_spans.go
@@ -142,6 +142,15 @@ type indexConstraintCtx struct {
 	evalCtx *tree.EvalContext
 }
 
+func makeIndexConstraintCtx(
+	colInfos []IndexColumnInfo, evalCtx *tree.EvalContext,
+) indexConstraintCtx {
+	return indexConstraintCtx{
+		colInfos: colInfos,
+		evalCtx:  evalCtx,
+	}
+}
+
 // isIndexColumn returns true if e is an indexed var that corresponds
 // to index column <offset>.
 func (c *indexConstraintCtx) isIndexColumn(e *expr, index int) bool {

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -366,8 +366,11 @@ func TestOpt(t *testing.T) {
 							d.fatalf(t, "no expression for index-constraints")
 						}
 
-						spans := MakeIndexConstraints(e, colInfos, &evalCtx)
 						var buf bytes.Buffer
+						spans, ok := MakeIndexConstraints(e, colInfos, &evalCtx)
+						if !ok {
+							spans = LogicalSpans{MakeFullSpan()}
+						}
 						for _, sp := range spans {
 							fmt.Fprintf(&buf, "%s\n", sp)
 						}

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -745,6 +745,9 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1 not null, @2)
 Remaining filter: @1 = @2
 
 # Tests with top-level OR.
+# TODO(radu): expression simplification is limited when dealing with ORs; some
+# of the remaining filters below are not necessary (or could be simplified
+# further).
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1 = 1 OR @1 = 2
@@ -809,6 +812,35 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 [/2/6/7 - /2/6/7]
 [/3 - /3]
 Remaining filter: ((@1 = 1) OR ((@1 = 2) AND ((@2, @3) IN ((4, 5), (6, 7))))) OR (@1 = 3)
+
+# Tests with inner OR.
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
+@1 = 1 AND (@2 = 2 OR @2 = 3)
+----
+[/1/2 - /1/2]
+[/1/3 - /1/3]
+Remaining filter: (@2 = 2) OR (@2 = 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 AND (@2 = 2 OR (@2 = 3 AND @3 = 4))
+----
+[/1/2 - /1/2]
+[/1/3/4 - /1/3/4]
+Remaining filter: (@2 = 2) OR ((@2 = 3) AND (@3 = 4))
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
+@1 >= 1 AND (@2 = 2 OR @2 = 3)
+----
+[/1/2 - ]
+Remaining filter: (@2 = 2) OR (@2 = 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 AND (@2 = 2 OR @2 = 3) AND (@3 >= 4)
+----
+[/1/2/4 - /1/2]
+[/1/3/4 - /1/3]
+Remaining filter: (@2 = 2) OR (@2 = 3)
 
 build-scalar,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 @1 = 1 AND @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END


### PR DESCRIPTION
Reorganizing the code as follows:

 - return "ok" flag in more functions. This saves allocations because
   it replaces cases where we return `LogicalSpans{MakeFullSpan()}`,
   most importantly in `calcOffset`.

 - OR/AND are now handled by `makeSpansForExpr`; this allows us to
   support more expressions, like ORs inside ANDs.

 - `indexConstraintsCalc` devolved into something that's only useful
   for ANDs; renamed to `indexConstraintsConjunctionCtx` and now only
   implements `calcOffset`.

Release note: None