### PR TITLE
opt: pass through unsupported TypedExprs

### DIFF
--- a/pkg/sql/opt/build.go
+++ b/pkg/sql/opt/build.go
@@ -218,7 +218,7 @@ func buildScalar(buildCtx *buildContext, pexpr tree.TypedExpr) *expr {
 		initConstExpr(e, t)
 
 	default:
-		panic(fmt.Sprintf("node %T not supported", t))
+		initUnsupportedExpr(e, t)
 	}
 	return e
 }
@@ -279,6 +279,8 @@ func init() {
 		rShiftOp:   binaryOpToTypedExpr,
 
 		tupleOp: tupleOpToTypedExpr,
+
+		unsupportedScalarOp: unsupportedScalarOpToTypedExpr,
 	}
 }
 
@@ -349,6 +351,10 @@ func binaryOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 		scalarToTypedExpr(e.children[1], ivh),
 		e.scalarProps.typ,
 	)
+}
+
+func unsupportedScalarOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
+	return e.private.(tree.TypedExpr)
 }
 
 func scalarToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -62,9 +62,6 @@ const (
 	regIMatchOp
 	notRegIMatchOp
 
-	isDistinctFromOp
-	isNotDistinctFromOp
-
 	// isOp implements the SQL operator IS, as well as its extended
 	// version IS NOT DISTINCT FROM.
 	isOp
@@ -96,6 +93,10 @@ const (
 	unaryComplementOp
 
 	functionCallOp
+
+	// unsupportedScalarOp is a temporary facility to pass through an unsupported
+	// TypedExpr (like a subquery) through MakeIndexConstraints.
+	unsupportedScalarOp
 
 	// This should be last.
 	numOperators

--- a/pkg/sql/opt/scalar.go
+++ b/pkg/sql/opt/scalar.go
@@ -52,8 +52,6 @@ func init() {
 		notRegMatchOp:       {name: "not-regmatch"},
 		regIMatchOp:         {name: "regimatch"},
 		notRegIMatchOp:      {name: "not-regimatch"},
-		isDistinctFromOp:    {name: "is-distinct-from"},
-		isNotDistinctFromOp: {name: "is-not-distinct-from"},
 		isOp:                {name: "is"},
 		isNotOp:             {name: "is-not"},
 		anyOp:               {name: "any"},
@@ -76,6 +74,7 @@ func init() {
 		unaryMinusOp:        {name: "unary-minus"},
 		unaryComplementOp:   {name: "complement"},
 		functionCallOp:      {name: "func"},
+		unsupportedScalarOp: {name: "unsupported-scalar"},
 	}
 
 	for op, info := range scalarOpInfos {
@@ -127,6 +126,11 @@ func isConstBool(e *expr) (ok bool, val bool) {
 		}
 	}
 	return false, false
+}
+
+func initUnsupportedExpr(e *expr, typedExpr tree.TypedExpr) {
+	e.op = unsupportedScalarOp
+	e.private = typedExpr
 }
 
 // initFunctionCallExpr initializes a functionCallOp expression node.

--- a/pkg/sql/opt/testdata/build-scalar
+++ b/pkg/sql/opt/testdata/build-scalar
@@ -376,3 +376,9 @@ plus (type: int)
  └── unary-minus (type: int)
       └── variable (1) (type: int)
 (+@1) + (-@2)
+
+build-scalar,semtree-expr vars=(int, int)
+CASE WHEN @1 = 2 THEN 1 ELSE 2 END
+----
+unsupported-scalar (CASE WHEN @1 = 2 THEN 1 ELSE 2 END) (type: int)
+CASE WHEN @1 = 2 THEN 1 ELSE 2 END

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -809,3 +809,9 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 [/2/6/7 - /2/6/7]
 [/3 - /3]
 Remaining filter: ((@1 = 1) OR ((@1 = 2) AND ((@2, @3) IN ((4, 5), (6, 7))))) OR (@1 = 3)
+
+build-scalar,index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 AND @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
+----
+[/1 - /1]
+Remaining filter: @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END


### PR DESCRIPTION
Adding `unsupportedScalarOp` which stores a `TypedExpr`; this can be
used to pass otherwise unsupported expressions through index
constraint generation (most importantly: `sql.subquery`).

Release note: None