### PR TITLE
[DO NOT MERGE] sql/sem/types: add TVarTuple

### DIFF
--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1130,7 +1130,12 @@ func subOpCompError(leftType, rightType types.T, subOp, op ComparisonOperator) *
 // typeCheckSubqueryWithIn checks the case where the right side of an IN
 // expression is a subquery.
 func typeCheckSubqueryWithIn(left, right types.T) error {
-	if rTuple, ok := right.(types.TTuple); ok {
+	unwrappedRight := right
+	if vtuple, ok := right.(*types.TVarTuple); ok {
+		unwrappedRight = vtuple.Typ
+	}
+
+	if rTuple, ok := unwrappedRight.(types.TTuple); ok {
 		if lTuple, ok := left.(types.TTuple); ok {
 			if len(lTuple) != len(rTuple) {
 				return pgerror.NewErrorf(pgerror.CodeInvalidParameterValueError, unsupportedCompErrFmt, fmt.Sprintf(compSignatureFmt, left, In, right))


### PR DESCRIPTION
Add TVarTuple (a.k.a. vtuple) for representing variable length tuple
types where each element of the tuple has the same type. This is to be
used for typing subqueries in table contexts. For example:

  `SELECT 1 IN (SELECT 1)`

The type of the subquery is `vtuple{int}`.

Adjust `typeCheckSubqueryWithIn` to "unwrap" `TVarTuple`.

Release note: None