### PR TITLE
sql: fix typing of subqueries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -13,6 +13,24 @@ SELECT 1 IN (SELECT 1)
 true
 
 query B
+SELECT 1 IN ((((SELECT 1))))
+----
+true
+
+query I
+SELECT ARRAY(((((VALUES (1), (2))))))[2]
+----
+2
+
+query I
+SELECT 1 + (SELECT 1)
+----
+2
+
+query error unsupported binary operator: <int> \+ <tuple{int, int}>
+SELECT 1 + (SELECT 1, 2)
+
+query B
 SELECT (1, 2, 3) IN (SELECT 1, 2, 3)
 ----
 true
@@ -27,13 +45,79 @@ SELECT (1, 2, 3) != (SELECT 1, 2, 3)
 ----
 false
 
+query B
+SELECT (SELECT 1, 2, 3) = (SELECT 1, 2, 3)
+----
+true
+
+query B
+SELECT (SELECT 1) IN (SELECT 1)
+----
+true
+
+query B
+SELECT (SELECT 1) IN (1)
+----
+true
+
+query B
+SELECT (SELECT 1, 2) IN (SELECT 1, 2)
+----
+true
+
+query B
+SELECT (SELECT 1, 2) IN ((1, 2))
+----
+true
+
+query B
+SELECT (SELECT (1, 2)) IN (SELECT 1, 2)
+----
+true
+
+query error unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{tuple{int, int}}}>
+SELECT (SELECT 1, 2) IN (SELECT (1, 2))
+
+query error unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{tuple{int, int}}}>
+SELECT (SELECT (1, 2)) IN (SELECT (1, 2))
+
+query B
+SELECT 1 = ANY(SELECT 1)
+----
+true
+
+query B
+SELECT (1, 2) = ANY(SELECT 1, 2)
+----
+true
+
+query B
+SELECT 1 = SOME(SELECT 1)
+----
+true
+
+query B
+SELECT (1, 2) = SOME(SELECT 1, 2)
+----
+true
+
+query B
+SELECT 1 = ALL(SELECT 1)
+----
+true
+
+query B
+SELECT (1, 2) = ALL(SELECT 1, 2)
+----
+true
+
 query error subquery must return only one column, found 2
 SELECT (SELECT 1, 2)
 
-query error subquery must return only one column, found 2
+query error unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>
 SELECT 1 IN (SELECT 1, 2)
 
-query error subquery must return 2 columns, found 1
+query error unsupported comparison operator: <tuple{int, int}> IN <tuple{int}>
 SELECT (1, 2) IN (SELECT 1)
 
 statement ok
@@ -56,7 +140,7 @@ split                         ·           ·
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
 
-query error subquery must return 2 columns
+query error unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int, int, int}}>
 SELECT (1, 2) IN (SELECT * FROM abc)
 
 query B

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -177,5 +177,5 @@ SELECT (1, 2) IN (SELECT 1, 2)
 ----
 true
 
-statement error subquery must return 2 columns, found 1
+statement error unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{tuple{int, int}}}>
 SELECT (1, 2) IN (SELECT (1, 2))

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -169,7 +169,7 @@ true
 statement error unsupported comparison operator: <int> IN <tuple{string}>
 SELECT 1 IN (SELECT 'a')
 
-statement error unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>
+statement error unsupported comparison operator: <int> IN <tuple{tuple{tuple{int, int}}}>
 SELECT 1 IN (SELECT (1, 2))
 
 query B

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -45,19 +45,19 @@ type subquery struct {
 type subqueryExecMode int
 
 const (
-	// Sub-query is argument to EXISTS. Only 0 or 1 row is expected.
+	// Subquery is argument to EXISTS. Only 0 or 1 row is expected.
 	// Result type is Bool.
 	execModeExists subqueryExecMode = iota
-	// Sub-query is argument to IN, ANY, SOME, or ALL. Any number of rows
+	// Subquery is argument to IN, ANY, SOME, or ALL. Any number of rows
 	// expected. Result type is tuple of rows. As a special case, if
 	// there is only one column selected, the result is a tuple of the
 	// selected values (instead of a tuple of 1-tuples).
 	execModeAllRowsNormalized
-	// Sub-query is argument to an ARRAY constructor. Any number of rows
+	// Subquery is argument to an ARRAY constructor. Any number of rows
 	// expected, and exactly one column is expected. Result type is tuple
 	// of selected values.
 	execModeAllRows
-	// Sub-query is argument to another function. Exactly 1 row
+	// Subquery is argument to another function. Exactly 1 row
 	// expected. Result type is tuple of columns, unless there is
 	// exactly 1 column in which case the result type is that column's
 	// type.
@@ -87,10 +87,10 @@ func (s *subquery) Walk(v tree.Visitor) tree.Expr {
 func (s *subquery) Variable() {}
 
 func (s *subquery) TypeCheck(_ *tree.SemaContext, desired types.T) (tree.TypedExpr, error) {
-	// TODO(knz): if/when type checking can be extracted from the
-	// newPlan recursion, we can propagate the desired type to the
-	// sub-query. For now, the type is simply derived during the subquery node
-	// creation by looking at the result column types.
+	// TODO(knz): if/when type checking can be extracted from the newPlan
+	// recursion, we can propagate the desired type to the subquery. For now, the
+	// type is simply derived during the subquery node creation by looking at the
+	// result column types.
 
 	// TODO(nvanbenschoten): Type checking for the comparison operator(s)
 	// should take this new node into account. In particular it should
@@ -265,12 +265,10 @@ func collectSubquerySpans(params runParams, plan planNode) (roachpb.Spans, error
 
 // subqueryVisitor replaces tree.Subquery syntax nodes by a
 // sql.subquery node and an initial query plan for running the
-// sub-query.
+// subquery.
 type subqueryVisitor struct {
 	*planner
 	columns int
-	path    []tree.Expr // parent expressions
-	pathBuf [4]tree.Expr
 	err     error
 
 	// TODO(andrei): plumb the context through the tree.Visitor.
@@ -289,181 +287,160 @@ func (v *subqueryVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.E
 		return false, expr
 	}
 
-	v.path = append(v.path, expr)
-
-	var exists *tree.ExistsExpr
-	sq, ok := expr.(*tree.Subquery)
-	if !ok {
-		exists, ok = expr.(*tree.ExistsExpr)
-		if !ok {
-			return true, expr
-		}
-		sq, ok = exists.Subquery.(*tree.Subquery)
-		if !ok {
-			return true, expr
-		}
-	}
-
-	v.hasSubqueries = true
-
-	// Calling newPlan() might recursively invoke expandSubqueries, so we need to preserve
-	// the state of the visitor across the call to newPlan().
-	visitorCopy := v.planner.subqueryVisitor
-	plan, err := v.planner.newPlan(v.ctx, sq.Select, nil)
-	v.planner.subqueryVisitor = visitorCopy
-	if err != nil {
-		v.err = err
-		return false, expr
-	}
-
-	result := &subquery{subquery: sq, plan: plan}
-
-	if exists != nil {
-		result.execMode = execModeExists
-		result.typ = types.Bool
-	} else {
-		wantedNumColumns, execMode := v.getSubqueryContext()
-		result.execMode = execMode
-
-		// First check that the number of columns match.
-		cols := planColumns(plan)
-		if numColumns := len(cols); wantedNumColumns != numColumns {
-			switch wantedNumColumns {
-			case 1:
-				v.err = fmt.Errorf("subquery must return only one column, found %d",
-					numColumns)
-			default:
-				v.err = fmt.Errorf("subquery must return %d columns, found %d",
-					wantedNumColumns, numColumns)
+	switch t := expr.(type) {
+	case *tree.ArrayFlatten:
+		if sub, ok := t.Subquery.(*tree.Subquery); ok {
+			result, err := v.replaceSubquery(sub, true /* multi-row */, 1 /* desired-columns */)
+			if err != nil {
+				v.err = err
+				return false, expr
 			}
+			result.execMode = execModeAllRows
+			// Multi-row types are always wrapped in a tuple-type, but the ARRAY
+			// flatten operator wants the unwrapped type.
+			result.typ = result.typ.(types.TTuple)[0]
+			t.Subquery = result
+		}
+
+	case *tree.ExistsExpr:
+		if sub, ok := t.Subquery.(*tree.Subquery); ok {
+			result, err := v.replaceSubquery(sub, true /* multi-row */, -1 /* desired-columns */)
+			if err != nil {
+				v.err = err
+				return false, expr
+			}
+			result.execMode = execModeExists
+			result.typ = types.Bool
+			expr = result
+		}
+
+	case *tree.Subquery:
+		result, err := v.replaceSubquery(t, false /* multi-row */, v.columns /* desired-columns */)
+		if err != nil {
+			v.err = err
 			return false, expr
 		}
+		result.execMode = execModeOneRow
+		expr = result
 
-		wrap := true
-		if len(cols) == 1 {
-			if execMode != execModeAllRowsNormalized {
-				// The subquery has only a single column and is not in a table context, we
-				// don't want to wrap the type in a tuple. For example:
-				//
-				//   SELECT (SELECT 1)
-				//
-				// and
-				//
-				//   SELECT (SELECT (1, 2))
-				//
-				// This will result in the types "int" and "tuple{int,int}" respectively.
-				wrap = false
-			} else if !types.FamTuple.FamilyEqual(cols[0].Typ) {
-				// The subquery has only a single column and is in a table context. We
-				// only wrap if the type of the result column is not a tuple. For
-				// example:
-				//
-				//   SELECT 1 IN (SELECT 1)
-				//
-				// The type of the subquery will be "tuple{int}". Now consider:
-				//
-				//   SELECT (1, 2) IN (SELECT (1, 2))
-				//
-				// We want the type of subquery to be "tuple{tuple{tuple{int,int}}}" in
-				// order to distinguish it from:
-				//
-				//   SELECT (1, 2) IN (SELECT 1, 2)
-				//
-				// Note that this query is semantically valid (the subquery has type
-				// "tuple{tuple{int,int}}"), while the previous query was not.
-				wrap = false
+	case *tree.ComparisonExpr:
+		switch t.Operator {
+		case tree.In, tree.NotIn, tree.Any, tree.Some, tree.All:
+			if sub, ok := t.Right.(*tree.Subquery); ok {
+				result, err := v.replaceSubquery(sub, true /* multi-row */, -1 /* desired-columns */)
+				if err != nil {
+					v.err = err
+					return false, expr
+				}
+				result.execMode = execModeAllRowsNormalized
+				t.Right = result
 			}
-		}
 
-		if !wrap {
-			result.typ = cols[0].Typ
-		} else {
-			colTypes := make(types.TTuple, len(cols))
-			for i, col := range cols {
-				colTypes[i] = col.Typ
-			}
-			result.typ = colTypes
-		}
-
-		if execMode == execModeAllRowsNormalized {
-			// The subquery is in a "table" context. For example:
-			//
-			//   SELECT 1 IN (SELECT * FROM t)
-			//
-			// Wrap the type in a tuple.
-			result.typ = types.TTuple{result.typ}
+			// Note that we recurse into the comparison expression and a subquery in
+			// the left-hand side is handled by the *tree.Subquery case above.
 		}
 	}
 
-	return false, result
+	// If the subquery is a child of any other expression, type checking will
+	// verify the number of columns.
+	v.columns = -1
+
+	return true, expr
 }
 
 func (v *subqueryVisitor) VisitPost(expr tree.Expr) tree.Expr {
-	if v.err == nil {
-		v.path = v.path[:len(v.path)-1]
-	}
 	return expr
+}
+
+func (v *subqueryVisitor) replaceSubquery(
+	sub *tree.Subquery, multiRow bool, desiredColumns int,
+) (*subquery, error) {
+	v.hasSubqueries = true
+
+	// Calling newPlan() might recursively invoke replaceSubqueries, so we need
+	// to preserve the state of the visitor across the call to newPlan().
+	visitorCopy := v.planner.subqueryVisitor
+	plan, err := v.planner.newPlan(v.ctx, sub.Select, nil)
+	v.planner.subqueryVisitor = visitorCopy
+	if err != nil {
+		return nil, err
+	}
+
+	cols := planColumns(plan)
+	if desiredColumns > 0 && len(cols) != desiredColumns {
+		switch desiredColumns {
+		case 1:
+			return nil, fmt.Errorf("subquery must return only one column, found %d", len(cols))
+		default:
+			return nil, fmt.Errorf("subquery must return %d columns, found %d", desiredColumns, len(cols))
+		}
+	}
+
+	result := &subquery{subquery: sub, plan: plan}
+
+	wrap := true
+	if len(cols) == 1 {
+		if !multiRow {
+			// The subquery has only a single column and is not in a multi-row
+			// context, we don't want to wrap the type in a tuple. For example:
+			//
+			//   SELECT (SELECT 1)
+			//
+			// and
+			//
+			//   SELECT (SELECT (1, 2))
+			//
+			// This will result in the types "int" and "tuple{int,int}" respectively.
+			wrap = false
+		} else if !types.FamTuple.FamilyEqual(cols[0].Typ) {
+			// The subquery has only a single column and is in a multi-row
+			// context. We only wrap if the type of the result column is not a
+			// tuple. For example:
+			//
+			//   SELECT 1 IN (SELECT 1)
+			//
+			// The type of the subquery will be "tuple{int}". Now consider this
+			// invalid query:
+			//
+			//   SELECT (1, 2) IN (SELECT (1, 2))
+			//
+			// We want the type of the subquery to be "tuple{tuple{tuple{int,int}}}"
+			// in order to distinguish it from this semantically valid query:
+			//
+			//   SELECT (1, 2) IN (SELECT 1, 2)
+			//
+			// In this query, the subquery has the type "tuple{tuple{int,int}}"
+			// making the IN expression valid.
+			wrap = false
+		}
+	}
+
+	if !wrap {
+		result.typ = cols[0].Typ
+	} else {
+		colTypes := make(types.TTuple, len(cols))
+		for i, col := range cols {
+			colTypes[i] = col.Typ
+		}
+		result.typ = colTypes
+	}
+
+	if multiRow {
+		// The subquery is in a multi-row context. For example:
+		//
+		//   SELECT 1 IN (SELECT * FROM t)
+		//
+		// Wrap the type in a tuple.
+		result.typ = types.TTuple{result.typ}
+	}
+
+	return result, nil
 }
 
 func (p *planner) replaceSubqueries(
 	ctx context.Context, expr tree.Expr, columns int,
 ) (tree.Expr, error) {
 	p.subqueryVisitor = subqueryVisitor{planner: p, columns: columns, ctx: ctx}
-	p.subqueryVisitor.path = p.subqueryVisitor.pathBuf[:0]
 	expr, _ = tree.WalkExpr(&p.subqueryVisitor, expr)
 	return expr, p.subqueryVisitor.err
-}
-
-// getSubqueryContext returns:
-// - the desired number of columns;
-// - the mode in which the sub-query should be executed.
-func (v *subqueryVisitor) getSubqueryContext() (columns int, execMode subqueryExecMode) {
-	for i := len(v.path) - 1; i >= 0; i-- {
-		switch e := v.path[i].(type) {
-		case *tree.ExistsExpr:
-			continue
-		case *tree.Subquery:
-			continue
-		case *tree.ParenExpr:
-			continue
-
-		case *tree.ArrayFlatten:
-			// If the subquery is inside of an ARRAY constructor, it must return a
-			// single-column, multi-row result.
-			return 1, execModeAllRows
-
-		case *tree.ComparisonExpr:
-			// The subquery must occur on the right hand side of the comparison.
-			//
-			// TODO(pmattis): Figure out a way to lift this restriction so that we
-			// can support:
-			//
-			//   SELECT (SELECT 1, 2) = (SELECT 1, 2)
-			columns = 1
-			switch t := e.Left.(type) {
-			case *tree.Tuple:
-				columns = len(t.Exprs)
-			case *tree.DTuple:
-				columns = len(t.D)
-			}
-
-			execMode = execModeOneRow
-			switch e.Operator {
-			case tree.In, tree.NotIn, tree.Any, tree.Some, tree.All:
-				execMode = execModeAllRowsNormalized
-			}
-
-			return columns, execMode
-
-		default:
-			// Any other expr that has this sub-query as operand
-			// is expecting a single value.
-			return 1, execModeOneRow
-		}
-	}
-
-	// We have not encountered any non-paren, non-IN expression so far,
-	// so the outer context is informing us of the desired number of
-	// columns.
-	return v.columns, execModeOneRow
 }


### PR DESCRIPTION
Subqueries in "table" contexts (e.g. the right hand side of an IN) were
previously being given an incorrect type in some instances. For example:

  `SELECT (1, 2) in (SELECT 1, 2)`

The subquery was being given the type `tuple{int,int}`. We were then
type checking `<tuple{int,int}> IN <tuple{int,int>}`. This was
succeeding because of special code (a bug) in
`typeCheckSubqueryWithin`. The subquery in the above example is now
given the tuple `tuple{tuple{int,int}}` which makes the comparison
expression match the parameterization `U in tuple{U}`.

The two bugs above cancelled each other out for query execution. A
difference can be seen in the output of `EXPLAIN (TYPES)`.

Release note: None