### PR TITLE
storage: preserve Lease.Sequence for "equivalent" leases

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1137,6 +1137,9 @@ func (l Lease) Equivalent(ol Lease) bool {
 	// Ignore proposed timestamp & deprecated start stasis.
 	l.ProposedTS, ol.ProposedTS = nil, nil
 	l.DeprecatedStartStasis, ol.DeprecatedStartStasis = nil, nil
+	// Ignore sequence numbers, they are simply a reflection of
+	// the equivalency of other fields.
+	l.Sequence, ol.Sequence = 0, 0
 	// If both leases are epoch-based, we must dereference the epochs
 	// and then set to nil.
 	switch l.Type() {

--- a/pkg/roachpb/data.pb.go
+++ b/pkg/roachpb/data.pb.go
@@ -462,10 +462,15 @@ type Lease struct {
 	// The epoch of the lease holder's node liveness entry. If this value
 	// is non-zero, the start and expiration values are ignored.
 	Epoch int64 `protobuf:"varint,6,opt,name=epoch,proto3" json:"epoch,omitempty"`
-	// A zero-indexed sequence number which is increased on each new range lease
-	// acquisition. The sequence number is used to detect lease changes between
-	// command proposal and application without requiring that we send the entire
-	// Lease through Raft.
+	// A zero-indexed sequence number which is incremented during the acquisition
+	// of each new range lease that is not equivalent to the previous range lease
+	// (i.e. an acquisition that implies a leaseholder change). The sequence
+	// number is used to detect lease changes between command proposal and
+	// application without requiring that we send the entire lease through Raft.
+	// Lease sequence numbers are a reflection of the "lease equivalency" property
+	// (see Lease.Equivalent). Two adjacent leases that are equivalent will have
+	// the same sequence number and two adjacent leases that are not equivalent
+	// will have different sequence numbers.
 	Sequence LeaseSequence `protobuf:"varint,7,opt,name=sequence,proto3,casttype=LeaseSequence" json:"sequence,omitempty"`
 }
 

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -360,10 +360,15 @@ message Lease {
   // is non-zero, the start and expiration values are ignored.
   int64 epoch = 6;
 
-  // A zero-indexed sequence number which is increased on each new range lease
-  // acquisition. The sequence number is used to detect lease changes between
-  // command proposal and application without requiring that we send the entire
-  // Lease through Raft.
+  // A zero-indexed sequence number which is incremented during the acquisition
+  // of each new range lease that is not equivalent to the previous range lease
+  // (i.e. an acquisition that implies a leaseholder change). The sequence
+  // number is used to detect lease changes between command proposal and
+  // application without requiring that we send the entire lease through Raft.
+  // Lease sequence numbers are a reflection of the "lease equivalency" property
+  // (see Lease.Equivalent). Two adjacent leases that are equivalent will have
+  // the same sequence number and two adjacent leases that are not equivalent
+  // will have different sequence numbers.
   int64 sequence = 7 [(gogoproto.casttype) = "LeaseSequence"];
 }
 

--- a/pkg/storage/batcheval/cmd_lease.go
+++ b/pkg/storage/batcheval/cmd_lease.go
@@ -105,6 +105,7 @@ func evalNewLease(
 				Message:   "sequence number should not be set",
 			}
 	}
+
 	// Set the lease's sequence number once VersionLeaseSequence is the minimum
 	// version. We don't want to do it once VersionLeaseSequence IsActive but
 	// not IsMinSupported because that means that the cluster could be
@@ -119,15 +120,27 @@ func evalNewLease(
 	// never stop setting lease sequences once a range has started to.
 	if prevLease.Sequence != 0 ||
 		rec.ClusterSettings().Version.IsMinSupported(cluster.VersionLeaseSequence) {
-		// We set the new lease sequence to one more than the previous lease
-		// sequence. This is safe and will never result in repeated lease
-		// sequences because the sequence check beneath Raft acts as an atomic
-		// compare-and-swap of sorts. If two lease requests are proposed in
-		// parallel, both with the same previous lease, only one will be
-		// accepted and the other will get a LeaseRejectedError and need to
-		// retry with a different sequence number. This is actually exactly what
-		// the sequence number is used to enforce!
-		lease.Sequence = prevLease.Sequence + 1
+
+		if prevLease.Equivalent(lease) {
+			// If the proposed lease is equivalent to the previous lease, it is
+			// given the same sequence number. This is subtle, but is important
+			// to ensure that leases which are meant to be considered the same
+			// lease for the purpose of matching leases during command execution
+			// (see Lease.Equivalent) will be considered so. For example, an
+			// extension to an expiration-based lease will result in a new lease
+			// with the same sequence number.
+			lease.Sequence = prevLease.Sequence
+		} else {
+			// We set the new lease sequence to one more than the previous lease
+			// sequence. This is safe and will never result in repeated lease
+			// sequences because the sequence check beneath Raft acts as an atomic
+			// compare-and-swap of sorts. If two lease requests are proposed in
+			// parallel, both with the same previous lease, only one will be
+			// accepted and the other will get a LeaseRejectedError and need to
+			// retry with a different sequence number. This is actually exactly what
+			// the sequence number is used to enforce!
+			lease.Sequence = prevLease.Sequence + 1
+		}
 	}
 
 	// Store the lease to disk & in-memory.

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -229,8 +229,9 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 			log.Fatalf(ctx, "lease sequence inversion, prevLease=%s, newLease=%s", prevLease, newLease)
 		case s2 == s1:
 			// If the sequence numbers are the same, make sure they're actually
-			// the same lease. This can happen when callers are using leasePostApply
-			// for some of its side effects, like with splitPostApply.
+			// the same lease. This can happen when callers are using
+			// leasePostApply for some of its side effects, like with
+			// splitPostApply. It can also happen during lease extensions.
 			if !prevLease.Equivalent(newLease) {
 				log.Fatalf(ctx, "sequence identical for different leases, prevLease=%s, newLease=%s",
 					prevLease, newLease)


### PR DESCRIPTION
Fixes #21094.
Fixes #21088.
Fixes #21082.
Fixes #21080.

I saw a few flaky tests after merging #20953 (`TestRaceWithBackfill`
and `TestDropWhileBackfill`). That change added a sequence number
to `roachpb.Lease` and replaced the full `Lease` struct on
`RaftCommand` with the much lighter-weight `Sequence` number.

It turns out that the change included an oversight that caused a
few tests to become flaky under race testing. To add the new
`Sequence` field to `Leases`, the change had introduced logic to
increment the lease sequence on each new lease. A lease
equivalency check beneath Raft was then replaced by a sequence number
equality check. The problem was that there are valid cases where a
new lease may be "equivalent" to its previous lease. In these cases,
we don't want the check beneath Raft to make a distinction between the
two leases, but with the change to compare sequence numbers instead of
deferring to `Lease.Equivalent`, the check was making that distinction.

To address this, we now only increment the lease sequence on a new lease
if it is not equivalent to its previous lease. If the new and old
leases are equivalent, we give them the same sequence number.

Release note: None