### PR TITLE
build: goimports pb.gw.go files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -964,6 +964,8 @@ $(GW_PROTOS_TARGET): $(PROTOC) $(GW_SERVER_PROTOS) $(GW_TS_PROTOS) $(GO_PROTOS) 
 	@# TODO(benesch): Remove after https://github.com/grpc/grpc-go/issues/711.
 	$(SED_INPLACE) -E 's!golang.org/x/net/context!context!g' $(GW_SOURCES)
 	gofmt -s -w $(GW_SOURCES)
+	@# TODO(jordan,benesch) This can be removed along with the above TODO.
+	goimports -w $(GW_SOURCES)
 	touch $@
 
 $(CPP_PROTOS_TARGET): $(PROTOC) $(CPP_PROTOS)

--- a/pkg/server/serverpb/admin.pb.gw.go
+++ b/pkg/server/serverpb/admin.pb.gw.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"context"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"

--- a/pkg/server/serverpb/authentication.pb.gw.go
+++ b/pkg/server/serverpb/authentication.pb.gw.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"context"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"

--- a/pkg/server/serverpb/status.pb.gw.go
+++ b/pkg/server/serverpb/status.pb.gw.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"context"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"

--- a/pkg/ts/tspb/timeseries.pb.gw.go
+++ b/pkg/ts/tspb/timeseries.pb.gw.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 
 	"context"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"


### PR DESCRIPTION
Previously, the output of the pb.gw.go generator wasn't formatted
according to `goimports`, because of our manual replacement of
`x/net/context` with `context`. Now, we run `goimports` on the files to
prevent format fights.

Release note: None