### PR TITLE
build: avoid building test bins with duplicate TAGS, GOFLAGS, LINKFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -748,7 +748,7 @@ testrace: TESTTIMEOUT := $(RACETIMEOUT)
 FIND_RELEVANT := find $(PKG_ROOT) -name node_modules -prune -o
 
 pkg/%.test: main.go $(shell $(FIND_RELEVANT) ! -name 'zcgo_flags.go' -name '*.go')
-	$(MAKE) testbuild GOFLAGS='$(GOFLAGS)' TAGS='$(TAGS)' LINKFLAGS='$(LINKFLAGS)' PKG='./pkg/$(*D)'
+	$(MAKE) testbuild PKG='./pkg/$(*D)'
 
 bench: ## Run benchmarks.
 bench: TESTS := -


### PR DESCRIPTION
Fixes #21086.

Recursively calling `$(MAKE) TAGS='$(TAGS)'` (ditto GOFLAGS,
LINKFLAGS) causes the various strings to be appended twice to these
variables (once in the caller make, one in the callee make) and then
passed twice to the actual go commands. This causes some troubles on
e.g. freebsd (see issue #21086).

This patch alleviates the issue by removing the explicit variable
overrides from the recursive make invocation.

I have checked manually that if a user runs `make testlogic TAGS=foo`
then the custom TAGS is properly propagated to the recursive make.

Release note: None
