### PR TITLE
build: only run testrace on changed packages

### DIFF
--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -15,9 +15,23 @@ build/builder.sh env \
 	TARGET=stressrace \
 	github-pull-request-make
 
+if [[ "${TC_BUILD_BRANCH}" == master ]] || [[ "${TC_BUILD_BRANCH}" == release* ]] ; then
+	PKGSPEC="./pkg/..."
+else
+	git fetch origin master
+	PKGSPEC=$(git diff --name-only $(git merge-base HEAD origin/master) | grep "^pkg*.go" || true)
+	if [ -z "${PKGSPEC}" ]; then
+		echo "No changed packages; skipping race detector tests"
+		exit 0
+	fi
+	PKGSPEC=$(echo "${PKGSPEC}" | xargs -n1 dirname | sort | uniq | sed 's/^/.\//' | paste -sd " " -)
+	echo "Running testrace on packages ${PKGSPEC}"
+fi
+
 build/builder.sh env \
 	COCKROACH_LOGIC_TESTS_SKIP=true \
 	make testrace \
+	PKG="${PKGSPEC}" \
 	TESTFLAGS='-v' \
 	2>&1 \
 	| tee artifacts/testrace.log \


### PR DESCRIPTION
For all builds but `master` and `release*`, only run testrace on packages with changed files.