### PR TITLE
opt: external API for index constraints

### DIFF
--- a/pkg/sql/opt/index_constraints_spans.go
+++ b/pkg/sql/opt/index_constraints_spans.go
@@ -91,6 +91,11 @@ func MakeFullSpan() LogicalSpan {
 	}
 }
 
+// IsFullSpan returns true if the given span is unconstrained.
+func (sp LogicalSpan) IsFullSpan() bool {
+	return len(sp.Start.Vals) == 0 && len(sp.End.Vals) == 0
+}
+
 // String formats a LogicalSpan. Inclusivity/exclusivity is shown using
 // brackets/parens. Some examples:
 //   [/1 - /2]

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -515,9 +515,9 @@ func (v *indexInfo) makeOrConstraints(evalCtx *tree.EvalContext, orExprs []tree.
 }
 
 // TODO(radu): we will change makeIndexConstraints to use
-// opt.MakeIndexConstraints. For now, just make sure the linter doesn't
-// complain about unused packages.
-var _ = opt.MakeIndexConstraints
+// opt.IndexConstraints. For now, just make sure the linter doesn't complain
+// about unused packages.
+var _ = (*opt.IndexConstraints).Init
 
 // makeIndexConstraints generates constraints for a set of conjunctions (AND
 // expressions). These expressions can be the entire filter, or they can be one


### PR DESCRIPTION
Implementing an API that can be used from the sql index selection
code. Sample usage:
```go
  var ic IndexConstraints
  if err := ic.Init(filter, colInfos, evalCtx); err != nil {
    return err
  }
  spans, ok := ic.Spans()
  remainingFilter := ic.RemainingFilter(&iVarHelper)
```

Release note: None