### PR TITLE
opt: fix a bug related to extending LogicalKeys, improve handling of contradictions

### DIFF
--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -496,12 +496,22 @@ func (c indexConstraintConjunctionCtx) calcOffset(offset int) (_ LogicalSpans, o
 			}
 			switch len(s) {
 			case 0:
+				// We found a contradiction.
+				spans = LogicalSpans{}
+				c.results[offset] = calcOffsetResult{
+					visited:        true,
+					spansPopulated: true,
+					spans:          spans,
+				}
+				return spans, true
+
 			case 1:
 				spans[i].Start.extend(s[0].Start)
 				spans[i].End.extend(s[0].End)
 				if newSpans != nil {
 					newSpans = append(newSpans, spans[i])
 				}
+
 			default:
 				if newSpans == nil {
 					newSpans = make(LogicalSpans, 0, len(spans)-1+len(s))

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -857,3 +857,8 @@ build-scalar,index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
 [/1/2/3/4 - /1/2/3/4]
 [/1/2/3/5 - /1/2/3/5]
 [/1/2/3/6 - /1/2/3/6]
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
+(@1 = 1) AND (@2 > 5) AND (@2 < 1)
+----
+

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -847,3 +847,13 @@ build-scalar,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 ----
 [/1 - /1]
 Remaining filter: @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
+
+# This testcase exposed an issue around extending spans. We don't normalize the
+# expression so we have a hierarchy of ANDs (which requires a more complex path
+# for calculating spans).
+build-scalar,index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
+@1 = 1 AND @2 = 2 AND @3 = 3 AND @4 IN (4,5,6)
+----
+[/1/2/3/4 - /1/2/3/4]
+[/1/2/3/5 - /1/2/3/5]
+[/1/2/3/6 - /1/2/3/6]


### PR DESCRIPTION
#### opt: fix a bug related to extending LogicalKeys

We have a few places (in calcOffset) where we don't clone the keys
before extending them. Fixing this by making extend safe and removing
the clone function altogether.

Release note: None

#### opt: improve handling of contradictions

If any call to calcOffset returns no spans, then there is a
contradiction. We were ignoring such cases when extending spans.

For example: for `(@1 = 1) AND (@2 > 5) AND (@2 < 1)` we now
get no spans. We used to get `[/1 - /1]` with remaining filter
`(@2 > 5) AND (@2 < 1)`.

Release note: None