### PR TITLE
opt: fix preferInclusive bug

### DIFF
--- a/pkg/sql/opt/index_constraints_spans.go
+++ b/pkg/sql/opt/index_constraints_spans.go
@@ -303,7 +303,13 @@ func (c *indexConstraintCtx) nextDatum(
 	d tree.Datum, direction encoding.Direction,
 ) (tree.Datum, bool) {
 	if direction == encoding.Descending {
+		if d.IsMin(c.evalCtx) {
+			return nil, false
+		}
 		return d.Prev(c.evalCtx)
+	}
+	if d.IsMax(c.evalCtx) {
+		return nil, false
 	}
 	return d.Next(c.evalCtx)
 }

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -281,6 +281,18 @@ build-scalar,normalize,index-constraints vars=(decimal) index=(@1)
 ----
 (/1.5 - /2)
 
+# Tests with a type that supports Next/Prev but we have a maximal/minimal value.
+
+build-scalar,normalize,index-constraints vars=(bool) index=(@1)
+@1 > true
+----
+(/true - ]
+
+build-scalar,normalize,index-constraints vars=(bool) index=(@1)
+@1 < false
+----
+(/NULL - /false)
+
 # Note the difference here between decimal and int: we
 # can't extend the exclusive start key.
 build-scalar,normalize,index-constraints vars=(decimal, decimal) index=(@1, @2)
@@ -533,6 +545,21 @@ semtree-normalize,build-scalar,index-constraints vars=(int, int, int, int) index
 ----
 [/1/2 - /4/5]
 Remaining filter: ((@1, @2, @4) >= (1, 2, 3)) AND ((@1, @2, @4) <= (4, 5, 6))
+
+build-scalar,normalize,index-constraints vars=(int, bool) index=(@1, @2)
+(@1, @2) > (1, NULL)
+----
+(/1/NULL - ]
+
+build-scalar,normalize,index-constraints vars=(int, bool) index=(@1, @2)
+(@1, @2) > (1, true)
+----
+(/1/true - ]
+
+build-scalar,normalize,index-constraints vars=(int, bool) index=(@1, @2)
+(@1, @2) < (1, false)
+----
+[ - /1/false)
 
 # Tests with tuple IN tuple.
 


### PR DESCRIPTION
We try to use Datum.Next/Prev to convert exclusive constraints into
inclusive constraints. However, Next and Prev actually return the same
value if the value is already the maximum (and minimum respectively).
Check for this using IsMin/IsMax.

Release note: None