### PR TITLE
opt: check for NULL values in tuple inequalities

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -221,3 +221,399 @@ query B
 SELECT (1, 2) > (1.0, 2.0)
 ----
 false
+
+statement ok
+CREATE TABLE uvw (
+  u INT,
+  v INT,
+  w INT,
+  INDEX (u,v,w)
+)
+
+statement ok
+INSERT INTO uvw SELECT u, v, w FROM
+  GENERATE_SERIES(0, 3) AS u,
+  GENERATE_SERIES(0, 3) AS v,
+  GENERATE_SERIES(0, 3) AS w;
+UPDATE uvw SET u = NULL WHERE u = 0;
+UPDATE uvw SET v = NULL WHERE v = 0;
+UPDATE uvw SET w = NULL WHERE w = 0
+
+query III
+SELECT * FROM uvw ORDER BY u, v, w
+----
+NULL  NULL  NULL
+NULL  NULL  1
+NULL  NULL  2
+NULL  NULL  3
+NULL  1     NULL
+NULL  1     1
+NULL  1     2
+NULL  1     3
+NULL  2     NULL
+NULL  2     1
+NULL  2     2
+NULL  2     3
+NULL  3     NULL
+NULL  3     1
+NULL  3     2
+NULL  3     3
+1     NULL  NULL
+1     NULL  1
+1     NULL  2
+1     NULL  3
+1     1     NULL
+1     1     1
+1     1     2
+1     1     3
+1     2     NULL
+1     2     1
+1     2     2
+1     2     3
+1     3     NULL
+1     3     1
+1     3     2
+1     3     3
+2     NULL  NULL
+2     NULL  1
+2     NULL  2
+2     NULL  3
+2     1     NULL
+2     1     1
+2     1     2
+2     1     3
+2     2     NULL
+2     2     1
+2     2     2
+2     2     3
+2     3     NULL
+2     3     1
+2     3     2
+2     3     3
+3     NULL  NULL
+3     NULL  1
+3     NULL  2
+3     NULL  3
+3     1     NULL
+3     1     1
+3     1     2
+3     1     3
+3     2     NULL
+3     2     1
+3     2     2
+3     2     3
+3     3     NULL
+3     3     1
+3     3     2
+3     3     3
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
+----
+render     0  render  ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ │         0  ·       render 0  test.uvw.u              ·          ·
+ │         0  ·       render 1  test.uvw.v              ·          ·
+ │         0  ·       render 2  test.uvw.w              ·          ·
+ └── scan  1  scan    ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx       ·          ·
+·          1  ·       spans     /1/2/3-                 ·          ·
+·          1  ·       filter    (u, v, w) >= (1, 2, 3)  ·          ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
+----
+1  2     3
+1  3     NULL
+1  3     1
+1  3     2
+1  3     3
+2  NULL  NULL
+2  NULL  1
+2  NULL  2
+2  NULL  3
+2  1     NULL
+2  1     1
+2  1     2
+2  1     3
+2  2     NULL
+2  2     1
+2  2     2
+2  2     3
+2  3     NULL
+2  3     1
+2  3     2
+2  3     3
+3  NULL  NULL
+3  NULL  1
+3  NULL  2
+3  NULL  3
+3  1     NULL
+3  1     1
+3  1     2
+3  1     3
+3  2     NULL
+3  2     1
+3  2     2
+3  2     3
+3  3     NULL
+3  3     1
+3  3     2
+3  3     3
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
+----
+render     0  render  ·         ·                      (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ │         0  ·       render 0  test.uvw.u             ·          ·
+ │         0  ·       render 1  test.uvw.v             ·          ·
+ │         0  ·       render 2  test.uvw.w             ·          ·
+ └── scan  1  scan    ·         ·                      (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx      ·          ·
+·          1  ·       spans     /2/1/2-                ·          ·
+·          1  ·       filter    (u, v, w) > (2, 1, 1)  ·          ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
+----
+2  1     2
+2  1     3
+2  2     NULL
+2  2     1
+2  2     2
+2  2     3
+2  3     NULL
+2  3     1
+2  3     2
+2  3     3
+3  NULL  NULL
+3  NULL  1
+3  NULL  2
+3  NULL  3
+3  1     NULL
+3  1     1
+3  1     2
+3  1     3
+3  2     NULL
+3  2     1
+3  2     2
+3  2     3
+3  3     NULL
+3  3     1
+3  3     2
+3  3     3
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
+----
+render     0  render  ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ │         0  ·       render 0  test.uvw.u              ·          ·
+ │         0  ·       render 1  test.uvw.v              ·          ·
+ │         0  ·       render 2  test.uvw.w              ·          ·
+ └── scan  1  scan    ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx       ·          ·
+·          1  ·       spans     /!NULL-/2/3/2           ·          ·
+·          1  ·       filter    (u, v, w) <= (2, 3, 1)  ·          ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
+----
+1  NULL  NULL
+1  NULL  1
+1  NULL  2
+1  NULL  3
+1  1     NULL
+1  1     1
+1  1     2
+1  1     3
+1  2     NULL
+1  2     1
+1  2     2
+1  2     3
+1  3     NULL
+1  3     1
+1  3     2
+1  3     3
+2  1     NULL
+2  1     1
+2  1     2
+2  1     3
+2  2     NULL
+2  2     1
+2  2     2
+2  2     3
+2  3     1
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
+----
+render     0  render  ·         ·                      (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ │         0  ·       render 0  test.uvw.u             ·          ·
+ │         0  ·       render 1  test.uvw.v             ·          ·
+ │         0  ·       render 2  test.uvw.w             ·          ·
+ └── scan  1  scan    ·         ·                      (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx      ·          ·
+·          1  ·       spans     /!NULL-/2/2/2          ·          ·
+·          1  ·       filter    (u, v, w) < (2, 2, 2)  ·          ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
+----
+1  NULL  NULL
+1  NULL  1
+1  NULL  2
+1  NULL  3
+1  1     NULL
+1  1     1
+1  1     2
+1  1     3
+1  2     NULL
+1  2     1
+1  2     2
+1  2     3
+1  3     NULL
+1  3     1
+1  3     2
+1  3     3
+2  1     NULL
+2  1     1
+2  1     2
+2  1     3
+2  2     1
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
+----
+render     0  render  ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ │         0  ·       render 0  test.uvw.u              ·          ·
+ │         0  ·       render 1  test.uvw.v              ·          ·
+ │         0  ·       render 2  test.uvw.w              ·          ·
+ └── scan  1  scan    ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx       ·          ·
+·          1  ·       spans     /!NULL-                 ·          ·
+·          1  ·       filter    (u, v, w) != (1, 2, 3)  ·          ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
+----
+1  1     NULL
+1  1     1
+1  1     2
+1  1     3
+1  2     1
+1  2     2
+1  3     NULL
+1  3     1
+1  3     2
+1  3     3
+2  NULL  NULL
+2  NULL  1
+2  NULL  2
+2  NULL  3
+2  1     NULL
+2  1     1
+2  1     2
+2  1     3
+2  2     NULL
+2  2     1
+2  2     2
+2  2     3
+2  3     NULL
+2  3     1
+2  3     2
+2  3     3
+3  NULL  NULL
+3  NULL  1
+3  NULL  2
+3  NULL  3
+3  1     NULL
+3  1     1
+3  1     2
+3  1     3
+3  2     NULL
+3  2     1
+3  2     2
+3  2     3
+3  3     NULL
+3  3     1
+3  3     2
+3  3     3
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
+----
+render     0  render  ·         ·                          (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ │         0  ·       render 0  test.uvw.u                 ·          ·
+ │         0  ·       render 1  test.uvw.v                 ·          ·
+ │         0  ·       render 2  test.uvw.w                 ·          ·
+ └── scan  1  scan    ·         ·                          (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx          ·          ·
+·          1  ·       spans     ALL                        ·          ·
+·          1  ·       filter    (u, v, w) >= (1, NULL, 3)  ·          ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
+----
+2  NULL  NULL
+2  NULL  1
+2  NULL  2
+2  NULL  3
+2  1     NULL
+2  1     1
+2  1     2
+2  1     3
+2  2     NULL
+2  2     1
+2  2     2
+2  2     3
+2  3     NULL
+2  3     1
+2  3     2
+2  3     3
+3  NULL  NULL
+3  NULL  1
+3  NULL  2
+3  NULL  3
+3  1     NULL
+3  1     1
+3  1     2
+3  1     3
+3  2     NULL
+3  2     1
+3  2     2
+3  2     3
+3  3     NULL
+3  3     1
+3  3     2
+3  3     3
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
+----
+render     0  render  ·         ·                         (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ │         0  ·       render 0  test.uvw.u                ·          ·
+ │         0  ·       render 1  test.uvw.v                ·          ·
+ │         0  ·       render 2  test.uvw.w                ·          ·
+ └── scan  1  scan    ·         ·                         (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx         ·          ·
+·          1  ·       spans     ALL                       ·          ·
+·          1  ·       filter    (u, v, w) < (2, NULL, 3)  ·          ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
+----
+1  NULL  NULL
+1  NULL  1
+1  NULL  2
+1  NULL  3
+1  1     NULL
+1  1     1
+1  1     2
+1  1     3
+1  2     NULL
+1  2     1
+1  2     2
+1  2     3
+1  3     NULL
+1  3     1
+1  3     2
+1  3     3

--- a/pkg/sql/opt/scalar.go
+++ b/pkg/sql/opt/scalar.go
@@ -114,6 +114,11 @@ func initConstExpr(e *expr, datum tree.Datum) {
 	e.private = datum
 }
 
+// isConstNull returns true if a constOp with a NULL value.
+func isConstNull(e *expr) bool {
+	return e.op == constOp && e.private == tree.DNull
+}
+
 // isConstBool checks whether e is a constOp with a boolean value, in
 // which case it returns the boolean value.
 func isConstBool(e *expr) (ok bool, val bool) {

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -467,32 +467,40 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 ----
 [/1/2/4 - ]
 
-build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
-(@1, @2, @3) > (1, 2, @1)
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2)
+(@1, @2, @3) > (1, 2, 3)
 ----
 [/1/2 - ]
-Remaining filter: (@1, @2, @3) > (1, 2, @1)
+Remaining filter: (@1, @2, @3) > (1, 2, 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2)
+(@1, @2, @3) < (1, 2, 3)
+----
+(/NULL - /1/2]
+Remaining filter: (@1, @2, @3) < (1, 2, 3)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) <= (1, 2, 3)
 ----
-[ - /1/2/3]
+(/NULL - /1/2/3]
+Remaining filter: (@1, @2, @3) <= (1, 2, 3)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) <= (1, 2, @1)
 ----
-[ - /1/2]
+(/NULL - /1/2]
 Remaining filter: (@1, @2, @3) <= (1, 2, @1)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) < (1, 2, 3)
 ----
-[ - /1/2/2]
+(/NULL - /1/2/2]
+Remaining filter: (@1, @2, @3) < (1, 2, 3)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) < (1, 2, @1)
 ----
-[ - /1/2]
+(/NULL - /1/2]
 Remaining filter: (@1, @2, @3) < (1, 2, @1)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
@@ -511,6 +519,7 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 desc, @2
 (@1, @2, @3) >= (1, 2, 3)
 ----
 [ - /1/2/3]
+Remaining filter: (@1, @2, @3) >= (1, 2, 3)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 desc, @2 desc, @3)
 (@1, @2, @3) > (1, 2, 3)
@@ -534,11 +543,13 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 (@1, @2) >= (1, 2) AND (@1, @2) <= (3, 4)
 ----
 [/1/2 - /3/4]
+Remaining filter: (@1, @2) <= (3, 4)
 
 semtree-normalize,build-scalar,index-constraints vars=(int, int) index=(@1, @2)
 (@1, @2) BETWEEN (1, 2) AND (3, 4)
 ----
 [/1/2 - /3/4]
+Remaining filter: (@1, @2) <= (3, 4)
 
 semtree-normalize,build-scalar,index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
 (@1, @2, @4) BETWEEN (1, 2, 3) AND (4, 5, 6)
@@ -554,7 +565,80 @@ build-scalar,normalize,index-constraints vars=(int, bool) index=(@1, @2)
 build-scalar,normalize,index-constraints vars=(int, bool) index=(@1, @2)
 (@1, @2) < (1, false)
 ----
-[ - /1/false)
+(/NULL - /1/false)
+Remaining filter: (@1, @2) < (1, false)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 not null, @2 not null, @3 not null)
+(@1, @2, @3) <= (1, 2, 3)
+----
+[ - /1/2/3]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 not null, @2 not null, @3 not null)
+(@1, @2, @3) >= (1, 2, 3)
+----
+[/1/2/3 - ]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 not null, @2 not null, @3 not null)
+(@1, @2, @3) < (1, 2, 3)
+----
+[ - /1/2/2]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 not null, @2 not null, @3 not null)
+(@1, @2, @3) > (1, 2, 3)
+----
+[/1/2/4 - ]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2 not null, @3 not null)
+(@1, @2, @3) <= (1, 2, 3)
+----
+(/NULL - /1/2/3]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2 not null, @3)
+(@1, @2, @3) <= (1, 2, 3)
+----
+(/NULL - /1/2/3]
+Remaining filter: (@1, @2, @3) <= (1, 2, 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3 not null)
+(@1, @2, @3) <= (1, 2, 3)
+----
+(/NULL - /1/2/3]
+Remaining filter: (@1, @2, @3) <= (1, 2, 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 desc not null, @2 desc not null, @3 desc not null)
+(@1, @2, @3) > (1, 2, 3)
+----
+[ - /1/2/4]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 desc, @2 desc not null, @3 desc)
+(@1, @2, @3) > (1, 2, 3)
+----
+[ - /1/2/4]
+Remaining filter: (@1, @2, @3) > (1, 2, 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 desc, @2 desc, @3 desc not null)
+(@1, @2, @3) > (1, 2, 3)
+----
+[ - /1/2/4]
+Remaining filter: (@1, @2, @3) > (1, 2, 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @3, @2) != (1, NULL, 2)
+----
+[ - ]
+Remaining filter: (@1, @3, @2) != (1, NULL, 2)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 not null, @2 not null)
+(@1, @2, @3) > (1, 2, 3)
+----
+[/1/2 - ]
+Remaining filter: (@1, @2, @3) > (1, 2, 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 not null, @2 not null)
+(@1, @2, @3) <= (1, 2, 3)
+----
+[ - /1/2]
+Remaining filter: (@1, @2, @3) <= (1, 2, 3)
 
 # Cases with NULLs in tuple inequalities. These conditions are true only when
 # they don't depend on the NULL value, i.e. when the inequality holds true for
@@ -573,17 +657,22 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 (@1, @2) < (1, NULL)
 ----
+(/NULL - /0]
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1 not null, @2)
+(@1, @2) < (1, NULL)
+----
 [ - /0]
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 (@1, @2) <= (1, NULL)
 ----
-[ - /0]
+(/NULL - /0]
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) < (1, NULL, 1)
 ----
-[ - /0]
+(/NULL - /0]
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) >= (1, NULL, 1)
@@ -925,4 +1014,3 @@ build-scalar,index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 (@1 = 1) AND (@2 > 5) AND (@2 < 1)
 ----
-

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -547,11 +547,6 @@ semtree-normalize,build-scalar,index-constraints vars=(int, int, int, int) index
 Remaining filter: ((@1, @2, @4) >= (1, 2, 3)) AND ((@1, @2, @4) <= (4, 5, 6))
 
 build-scalar,normalize,index-constraints vars=(int, bool) index=(@1, @2)
-(@1, @2) > (1, NULL)
-----
-(/1/NULL - ]
-
-build-scalar,normalize,index-constraints vars=(int, bool) index=(@1, @2)
 (@1, @2) > (1, true)
 ----
 (/1/true - ]
@@ -560,6 +555,48 @@ build-scalar,normalize,index-constraints vars=(int, bool) index=(@1, @2)
 (@1, @2) < (1, false)
 ----
 [ - /1/false)
+
+# Cases with NULLs in tuple inequalities. These conditions are true only when
+# they don't depend on the NULL value, i.e. when the inequality holds true for
+# the prefix up to the first NULL.
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) > (1, NULL)
+----
+[/2 - ]
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) >= (1, NULL)
+----
+[/2 - ]
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) < (1, NULL)
+----
+[ - /0]
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) <= (1, NULL)
+----
+[ - /0]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) < (1, NULL, 1)
+----
+[ - /0]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) >= (1, NULL, 1)
+----
+[/2 - ]
+
+# TODO(radu): here we could be smarter - the condition below is equivalent to
+# (@1, @3) != (1, 3).
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) != (1, NULL, 3)
+----
+[ - ]
+Remaining filter: (@1, @2, @3) != (1, NULL, 3)
 
 # Tests with tuple IN tuple.
 


### PR DESCRIPTION
#### opt: check for NULL values in tuple inequalities

`(@1, @2) >= (1, NULL)` is equivalent to `@1 > 1`. It now results in
span `[/2 - ]` instead of the incorrrect `(/1/NULL - ]`.

Release note: None

#### opt: support nullable columns for tuple inequalities

The current code for tuple inequalities assumes not-nullable columns.

Consider `(a, b, c) <= (1, 2, 3)`.

If the columns are not null, the condition is equivalent to
the span `[ - /1/2/3]`.

If column `a` is nullable, the condition is equivalent to the
span `(/NULL - /1/2/3]`.

However, if column `b` or `c` is nullable, we still have to
filter out the NULLs on those columns, so whatever span we
generate is not "tight".

Also adding logic tests with tuple inequalities and NULLs (note that they don't
exercise `opt` code right now but they will when we switch).

Release note: None