### PR TITLE
build: fix race skip grep invocation

### DIFF
--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -19,7 +19,7 @@ if [[ "${TC_BUILD_BRANCH}" == master ]] || [[ "${TC_BUILD_BRANCH}" == release* ]
 	PKGSPEC="./pkg/..."
 else
 	git fetch origin master
-	PKGSPEC=$(git diff --name-only $(git merge-base HEAD origin/master) | grep "^pkg*.go" || true)
+	PKGSPEC=$(git diff --name-only origin/master... | grep "^pkg.*\.go" || true)
 	if [ -z "${PKGSPEC}" ]; then
 		echo "No changed packages; skipping race detector tests"
 		exit 0


### PR DESCRIPTION
Had the wrong `grep` invocation in #21096.

Release note: None