### PR TITLE
sql: fix tuple equality comparisons for tuples with NULL values

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -495,6 +495,8 @@ render     0  render  ·         ·                       (u, v, w)  +u,+v,+w
 query III
 SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 ----
+1  NULL  1
+1  NULL  2
 1  1     NULL
 1  1     1
 1  1     2

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -554,6 +554,68 @@ func TestEval(t *testing.T) {
 		{`(1+1, (2+2, (3+3))) = (2, (4, (6)))`, `true`},
 		{`(1, 'a') != (1, 'a')`, `false`},
 		{`(1, 'a') != (1, 'b')`, `true`},
+		{`(1, 2, 3) = (1, 2, 3)`, `true`},
+		{`(1, 2, 3) != (1, 2, 3)`, `false`},
+		{`(1, 2, 3) > (1, 2, 3)`, `false`},
+		{`(1, 2, 3) >= (1, 2, 3)`, `true`},
+		{`(1, 2, 3) < (1, 2, 3)`, `false`},
+		{`(1, 2, 3) <= (1, 2, 3)`, `true`},
+		{`(1, 2, 3) = (1, 2, 4)`, `false`},
+		{`(1, 2, 3) != (1, 2, 4)`, `true`},
+		{`(1, 2, 3) > (1, 2, 4)`, `false`},
+		{`(1, 2, 3) >= (1, 2, 4)`, `false`},
+		{`(1, 2, 4) = (1, 2, 3)`, `false`},
+		{`(1, 2, 4) != (1, 2, 3)`, `true`},
+		{`(1, 2, 4) > (1, 2, 3)`, `true`},
+		{`(1, 2, 4) >= (1, 2, 3)`, `true`},
+		// Row (tuple) comparisons with NULLs.
+		{`(1, 2, 3) = (1, NULL, 3)`, `NULL`},
+		{`(1, 2, 3) != (1, NULL, 3)`, `NULL`},
+		{`(1, 2, 3) > (1, NULL, 3)`, `NULL`},
+		{`(1, 2, 3) >= (1, NULL, 3)`, `NULL`},
+		{`(1, 2, 3) = (0, NULL, 3)`, `false`},
+		{`(1, 2, 3) != (0, NULL, 3)`, `true`},
+		{`(1, 2, 3) > (0, NULL, 3)`, `true`},
+		{`(1, 2, 3) >= (0, NULL, 3)`, `true`},
+		{`(1, 2, 3) = (2, NULL, 3)`, `false`},
+		{`(1, 2, 3) != (2, NULL, 3)`, `true`},
+		{`(1, 2, 3) > (2, NULL, 3)`, `false`},
+		{`(1, 2, 3) >= (2, NULL, 3)`, `false`},
+		{`(1, 2, 3) = (1, NULL, 4)`, `false`},
+		{`(1, 2, 3) != (1, NULL, 4)`, `true`},
+		{`(1, 2, 3) > (1, NULL, 4)`, `NULL`},
+		{`(1, 2, 3) >= (1, NULL, 4)`, `NULL`},
+		{`(1, NULL, 3) = (1, 2, 3)`, `NULL`},
+		{`(1, NULL, 3) != (1, 2, 3)`, `NULL`},
+		{`(1, NULL, 3) > (1, 2, 3)`, `NULL`},
+		{`(1, NULL, 3) >= (1, 2, 3)`, `NULL`},
+		{`(1, NULL, 3) = (0, 2, 3)`, `false`},
+		{`(1, NULL, 3) != (0, 2, 3)`, `true`},
+		{`(1, NULL, 3) > (0, 2, 3)`, `true`},
+		{`(1, NULL, 3) >= (0, 2, 3)`, `true`},
+		{`(1, NULL, 3) = (2, 2, 3)`, `false`},
+		{`(1, NULL, 3) != (2, 2, 3)`, `true`},
+		{`(1, NULL, 3) > (2, 2, 3)`, `false`},
+		{`(1, NULL, 3) >= (2, 2, 3)`, `false`},
+		{`(1, NULL, 3) = (1, 2, 4)`, `false`},
+		{`(1, NULL, 3) != (1, 2, 4)`, `true`},
+		{`(1, NULL, 3) > (1, 2, 4)`, `NULL`},
+		{`(1, NULL, 3) >= (1, 2, 4)`, `NULL`},
+		// Tuple equality is equivalent to conjunctive equality.
+		{`(1, 2, 3) = (1, 2, 3)`, `true`},
+		{`1 = 1 AND 2 = 2 AND 3 = 3`, `true`},
+		{`(1, 2, 3) = (2, 2, 3)`, `false`},
+		{`1 = 2 AND 2 = 2 AND 3 = 3`, `false`},
+		{`(1, 2, 4) = (1, 2, 3)`, `false`},
+		{`1 = 1 AND 2 = 2 AND 4 = 3`, `false`},
+		{`(NULL, 2, 3) = (1, 2, 3)`, `NULL`},
+		{`NULL = 1 AND 2 = 2 AND 3 = 3`, `NULL`},
+		{`(NULL, 2, 3) = (NULL, 2, 3)`, `NULL`},
+		{`NULL = NULL AND 2 = 2 AND 3 = 3`, `NULL`},
+		{`(NULL, 2, 3) = (NULL, 3, 3)`, `false`},
+		{`NULL = NULL AND 2 = 3 AND 3 = 3`, `false`},
+		{`(NULL, 2, 3) = (1, 2, NULL)`, `NULL`},
+		{`NULL = 1 AND 2 = 2 AND 3 = NULL`, `NULL`},
 		// IN and NOT IN expressions.
 		{`1 NOT IN (2, 3, 4)`, `true`},
 		{`1+1 IN (2, 3, 4)`, `true`},
@@ -975,6 +1037,8 @@ func TestEval(t *testing.T) {
 		{`'NaN'::float::decimal`, `NaN`},
 	}
 	ctx := tree.NewTestingEvalContext()
+	// We have to manually close this account because we're doing the evaluations
+	// ourselves.
 	defer ctx.Mon.Stop(context.Background())
 	defer ctx.ActiveMemAcc.Close(context.Background())
 	for _, d := range testData {
@@ -988,8 +1052,6 @@ func TestEval(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
-			// We have to manually close this account because we're doing the evaluations
-			// ourselves.
 			if typedExpr, err = ctx.NormalizeExpr(typedExpr); err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}


### PR DESCRIPTION
Fixes #21113.

Previously, tuple equality evaluation would short-circuit on NULL elements
just like tuple inequality evaluation. This behavior was desired for tuple
comparisons using inequality operators but was a deviation from the SQL
standard for tuple comparisons using the equality operator.

In other words, `(1, 2, 4) > (1, NULL, 5)` evaluated to `NULL`, correctly,
but `(1, 2, 4) = (1, NULL, 5)` also evaluated to `NULL`, incorrectly. Instead,
the latter expression should have evaluated to `false`. This is because tuple
comparison should only return NULL when the non-NULL elements are not sufficient
to determine the result. Since tuple inequality is defined lexicographically,
the first NULL element encountered causes ambiguity. For tuple equality, it
may still be possible to evaluate the expression even after NULL elements are
seen, so the evaluation cannot short circuit.

This change fixes the behavior for tuple equality, bringing it inline with
PostgreSQL and MySQL.

Note that we already had very similar logic for the `IN`, `ANY`, `SOME`, and
`ALL` comparison operators, so the behavior replaced here must have simply
been an oversight when tuple comparison was introduced.

Release note (sql change/bug fix): Fix tuple equality to evaluate correctly
in the presence of NULL elements.