### PR TITLE
storage: make RaftTombstoneKey unreplicated

### DIFF
--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -215,9 +215,13 @@ func DecodeAbortSpanKey(key roachpb.Key, dest []byte) (uuid.UUID, error) {
 	return txnID, err
 }
 
-// RaftTombstoneKey returns a system-local key for a raft tombstone.
-func RaftTombstoneKey(rangeID roachpb.RangeID) roachpb.Key {
-	return MakeRangeIDPrefixBuf(rangeID).RaftTombstoneKey()
+// RaftTombstoneIncorrectLegacyKey returns a system-local key for a raft tombstone.
+// This key was accidentally made replicated though it is not, requiring awkward
+// workarounds. This method and all users can be removed in any binary version > 2.1.
+//
+// See https://github.com/cockroachdb/cockroach/issues/12154.
+func RaftTombstoneIncorrectLegacyKey(rangeID roachpb.RangeID) roachpb.Key {
+	return MakeRangeIDPrefixBuf(rangeID).RaftTombstoneIncorrectLegacyKey()
 }
 
 // RaftAppliedIndexKey returns a system-local key for a raft applied index.
@@ -284,6 +288,11 @@ func makeRangeIDUnreplicatedKey(
 	key = append(key, suffix...)
 	key = append(key, detail...)
 	return key
+}
+
+// RaftTombstoneKey returns a system-local key for a raft tombstone.
+func RaftTombstoneKey(rangeID roachpb.RangeID) roachpb.Key {
+	return MakeRangeIDPrefixBuf(rangeID).RaftTombstoneKey()
 }
 
 // RaftHardStateKey returns a system-local key for a Raft HardState.
@@ -802,8 +811,8 @@ func (b RangeIDPrefixBuf) AbortSpanKey(txnID uuid.UUID) roachpb.Key {
 	return encoding.EncodeBytesAscending(key, txnID.GetBytes())
 }
 
-// RaftTombstoneKey returns a system-local key for a raft tombstone.
-func (b RangeIDPrefixBuf) RaftTombstoneKey() roachpb.Key {
+// RaftTombstoneIncorrectLegacyKey returns a system-local key for a raft tombstone.
+func (b RangeIDPrefixBuf) RaftTombstoneIncorrectLegacyKey() roachpb.Key {
 	return append(b.replicatedPrefix(), LocalRaftTombstoneSuffix...)
 }
 
@@ -847,6 +856,11 @@ func (b RangeIDPrefixBuf) RangeLastGCKey() roachpb.Key {
 // threshold on the txn span.
 func (b RangeIDPrefixBuf) RangeTxnSpanGCThresholdKey() roachpb.Key {
 	return append(b.replicatedPrefix(), LocalTxnSpanGCThresholdSuffix...)
+}
+
+// RaftTombstoneKey returns a system-local key for a raft tombstone.
+func (b RangeIDPrefixBuf) RaftTombstoneKey() roachpb.Key {
+	return append(b.unreplicatedPrefix(), LocalRaftTombstoneSuffix...)
 }
 
 // RaftHardStateKey returns a system-local key for a Raft HardState.

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -52,7 +52,7 @@ func TestPrettyPrint(t *testing.T) {
 		{StoreSuggestedCompactionKey(roachpb.Key("a"), MaxKey), `/Local/Store/suggestedCompaction/{"a"-/Max}`},
 
 		{AbortSpanKey(roachpb.RangeID(1000001), txnID), fmt.Sprintf(`/Local/RangeID/1000001/r/AbortSpan/%q`, txnID)},
-		{RaftTombstoneKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RaftTombstone"},
+		{RaftTombstoneIncorrectLegacyKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RaftTombstone"},
 		{RaftAppliedIndexKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RaftAppliedIndex"},
 		{LeaseAppliedIndexKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/LeaseAppliedIndex"},
 		{RaftTruncatedStateKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/r/RaftTruncatedState"},
@@ -64,6 +64,7 @@ func TestPrettyPrint(t *testing.T) {
 
 		{RaftHardStateKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RaftHardState"},
 		{RaftLastIndexKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RaftLastIndex"},
+		{RaftTombstoneKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RaftTombstone"},
 		{RaftLogKey(roachpb.RangeID(1000001), uint64(200001)), "/Local/RangeID/1000001/u/RaftLog/logIndex:200001"},
 		{RangeLastReplicaGCTimestampKey(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RangeLastReplicaGCTimestamp"},
 		{RangeLastVerificationTimestampKeyDeprecated(roachpb.RangeID(1000001)), "/Local/RangeID/1000001/u/RangeLastVerificationTimestamp"},

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -376,8 +376,8 @@ func (n *Node) start(
 	n.initDescriptor(addr, attrs, locality)
 
 	n.storeCfg.Settings.Version.OnChange(func(cv cluster.ClusterVersion) {
-		if err := n.stores.WriteClusterVersion(ctx, cv); err != nil {
-			log.Fatalf(ctx, "error updating persisted cluster version: %s", err)
+		if err := n.stores.OnClusterVersionChange(ctx, cv); err != nil {
+			log.Fatal(ctx, errors.Wrapf(err, "updating cluster version to %s", cv))
 		}
 	})
 
@@ -423,6 +423,11 @@ func (n *Node) start(
 	n.startedAt = n.storeCfg.Clock.Now().WallTime
 
 	n.startComputePeriodicMetrics(n.stopper, DefaultMetricsSampleInterval)
+	// Be careful about moving this line above `startStores`; store migrations rely
+	// on the fact that the cluster version has not been updated via Gossip (we
+	// have migrations that want to run only if the server starts with a given
+	// cluster version, but not if the server starts with a lower one and gets
+	// bumped immediately, which would be possible if gossip got started earlier).
 	n.startGossip(ctx, n.stopper)
 
 	log.Infof(ctx, "%s: started with %v engine(s) and attributes %v", n, bootstrappedEngines, attrs.Attrs)

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -22,11 +22,14 @@ import (
 	gosql "database/sql"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -124,9 +127,50 @@ func TestClusterVersionUpgrade1_0To1_2(t *testing.T) {
 	tc := setupMixedCluster(t, bootstrapVersion, versions)
 	defer tc.Stopper().Stop(ctx)
 
+	tombstone := roachpb.RaftTombstone{NextReplicaID: 0}
+	tombstoneOp := func(f func(engine.Engine, roachpb.Key) error) error {
+		visitor := func(s *storage.Store) error {
+			// Put down a few fake legacy tombstones (#12154) to jog `migrateLegacyTombstones`, including
+			// one for the existing range, but also some for non-existing ones.
+
+			legacyTombstoneKeys := []roachpb.Key{
+				// Range 1 actually exists, at least on some stores.
+				keys.RaftTombstoneIncorrectLegacyKey(1 /* rangeID */),
+				// These ranges don't exist.
+				keys.RaftTombstoneIncorrectLegacyKey(200 /* rangeID */),
+				keys.RaftTombstoneIncorrectLegacyKey(300 /* rangeID */),
+			}
+			for _, legacyTombstoneKey := range legacyTombstoneKeys {
+				if err := f(s.Engine(), legacyTombstoneKey); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		for i := 0; i < tc.NumServers(); i++ {
+			if err := tc.Server(i).GetStores().(*storage.Stores).VisitStores(visitor); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
 	for i := 0; i < tc.NumServers(); i++ {
 		if exp, version := bootstrapVersion.MinimumVersion.String(), tc.getVersionFromShow(i); version != exp {
 			t.Fatalf("%d: incorrect version %s (wanted %s)", i, version, exp)
+		}
+
+		// Put some legacy tombstones down. We're going to test the migration for removing those in the
+		// negative: the tombstones are to be removed only after a node at *cluster version* v1.2 boots
+		// up. We don't restart nodes in this test, so the only boot is at the initial version v1.0,
+		// and we verify that the  tombstones remain. The rewrite functionality is tested in
+		// TestStoreInitAndBootstrap.
+		if err := tombstoneOp(func(eng engine.Engine, legacyTombstoneKey roachpb.Key) error {
+			return engine.MVCCPutProto(
+				ctx, eng, nil /* ms */, legacyTombstoneKey, hlc.Timestamp{}, nil /* txn */, &tombstone,
+			)
+		}); err != nil {
+			t.Fatal(err)
 		}
 	}
 
@@ -175,16 +219,30 @@ func TestClusterVersionUpgrade1_0To1_2(t *testing.T) {
 				vers := tc.getVersionFromSetting(i)
 				if v := vers.Version().MinimumVersion.String(); v == curVersion {
 					if isNoopUpdate {
-						// Just what we wanted!
-						return nil
+						continue
 					}
 					return errors.Errorf("%d: still waiting for %s (now at %s)", i, exp, v)
 				} else if v != exp {
 					t.Fatalf("%d: should never see version %s (wanted %s)", i, v, exp)
 				}
 			}
-			// Everyone is at the version we're waiting for.
-			return nil
+
+			// Everyone is at the version we're waiting for. Check that the tombstones are still there.
+			return tombstoneOp(func(eng engine.Engine, legacyTombstoneKey roachpb.Key) error {
+				ok, err := engine.MVCCGetProto(
+					ctx, eng, legacyTombstoneKey, hlc.Timestamp{}, true /* consistent */, nil, /* txn */
+					nil,
+				)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return errors.Errorf(
+						"legacy tombstone at %s unexpectedly removed", legacyTombstoneKey,
+					)
+				}
+				return nil
+			})
 		})
 
 		// Since the wrapped version setting exposes the new versions, it must

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -40,6 +40,7 @@ const (
 	VersionClearRange
 	VersionPartitioning
 	VersionLeaseSequence
+	VersionUnreplicatedTombstoneKey
 
 	// Add new versions here (step one of two).
 
@@ -139,6 +140,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionLeaseSequence is https://github.com/cockroachdb/cockroach/pull/20953.
 		Key:     VersionLeaseSequence,
 		Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 8},
+	},
+	{
+		// VersionUnreplicatedTombstoneKey is https://github.com/cockroachdb/cockroach/pull/21120.
+		Key:     VersionUnreplicatedTombstoneKey,
+		Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 9},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -208,7 +208,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-1.1-8
+1.1-9
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -270,4 +270,4 @@ select * from crdb_internal.gossip_liveness
 query T
 select crdb_internal.node_executable_version()
 ----
-1.1-8
+1.1-9

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -99,7 +99,7 @@ timeseries.storage.enabled                         true           b     if set, 
 trace.debug.enable                                 false          b     if set, traces for recent requests can be seen in the /debug page
 trace.lightstep.token                              ·              s     if set, traces go to Lightstep using this token
 trace.zipkin.collector                             ·              s     if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.
-version                                            1.1-8          m     set the active cluster version in the format '<major>.<minor>'.
+version                                            1.1-9          m     set the active cluster version in the format '<major>.<minor>'.
 
 query T colnames
 SELECT * FROM [SHOW SESSION_USER]

--- a/pkg/storage/migrations.go
+++ b/pkg/storage/migrations.go
@@ -1,0 +1,84 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package storage
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// clearLegacyTombstone removes the legacy tombstone for the given rangeID, taking
+// care to do this without reading from the engine (as is required by one of the
+// callers).
+func clearLegacyTombstone(eng engine.Writer, rangeID roachpb.RangeID) error {
+	return eng.Clear(engine.MakeMVCCMetadataKey(keys.RaftTombstoneIncorrectLegacyKey(rangeID)))
+}
+
+// migrateLegacyTombstones rewrites all legacy tombstones into the correct key.
+// It can be removed in binaries post v2.1.
+func migrateLegacyTombstones(ctx context.Context, eng engine.Engine) error {
+	var tombstone roachpb.RaftTombstone
+	handleTombstone := func(rangeID roachpb.RangeID) (more bool, _ error) {
+		batch := eng.NewBatch()
+		defer batch.Close()
+
+		tombstoneKey := keys.RaftTombstoneKey(rangeID)
+
+		{
+			// If there's already a new-style tombstone, pick the larger NextReplicaID
+			// (this will be the new-style tombstone's).
+			var exTombstone roachpb.RaftTombstone
+			ok, err := engine.MVCCGetProto(ctx, batch, tombstoneKey,
+				hlc.Timestamp{}, true, nil, &exTombstone)
+			if err != nil {
+				return false, err
+			}
+			if ok && exTombstone.NextReplicaID > tombstone.NextReplicaID {
+				tombstone.NextReplicaID = exTombstone.NextReplicaID
+			}
+		}
+
+		if err := engine.MVCCPutProto(ctx, batch, nil, tombstoneKey,
+			hlc.Timestamp{}, nil, &tombstone); err != nil {
+			return false, err
+		}
+		if err := clearLegacyTombstone(batch, rangeID); err != nil {
+			return false, err
+		}
+		// Specify sync==false because we don't want to sync individually,
+		// but see the end of the surrounding method where we sync explicitly.
+		err := batch.Commit(false /* sync */)
+		return err == nil, err
+	}
+	err := IterateIDPrefixKeys(ctx, eng, keys.RaftTombstoneIncorrectLegacyKey, &tombstone,
+		handleTombstone)
+	if err != nil {
+		return err
+	}
+
+	// Write a final bogus batch so that we get to do a sync commit, which
+	// implicitly also syncs everything written before.
+	batch := eng.NewBatch()
+	defer batch.Close()
+
+	if err := clearLegacyTombstone(batch, 1 /* rangeID */); err != nil {
+		return err
+	}
+	return batch.Commit(true /* sync */)
+}

--- a/pkg/storage/rditer/replica_data_iter_test.go
+++ b/pkg/storage/rditer/replica_data_iter_test.go
@@ -87,6 +87,7 @@ func createRangeData(
 		{keys.LeaseAppliedIndexKey(desc.RangeID), ts0},
 		{keys.RangeStatsKey(desc.RangeID), ts0},
 		{keys.RangeTxnSpanGCThresholdKey(desc.RangeID), ts0},
+		{keys.RaftTombstoneKey(desc.RangeID), ts0},
 		{keys.RaftHardStateKey(desc.RangeID), ts0},
 		{keys.RaftLastIndexKey(desc.RangeID), ts0},
 		{keys.RaftLogKey(desc.RangeID, 1), ts0},

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -853,7 +853,11 @@ func (r *Replica) setTombstoneKey(
 	nextReplicaID := r.nextReplicaIDLocked(desc)
 	r.mu.minReplicaID = nextReplicaID
 	r.mu.Unlock()
+
 	tombstoneKey := keys.RaftTombstoneKey(desc.RangeID)
+	if !r.store.cfg.Settings.Version.IsMinSupported(cluster.VersionUnreplicatedTombstoneKey) {
+		tombstoneKey = keys.RaftTombstoneIncorrectLegacyKey(desc.RangeID)
+	}
 	tombstone := &roachpb.RaftTombstone{
 		NextReplicaID: nextReplicaID,
 	}

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -339,7 +339,7 @@ func (r *Replica) sha512(
 	snap engine.Reader,
 	snapshot *roachpb.RaftSnapshotData,
 ) (*replicaHash, error) {
-	tombstoneKey := engine.MakeMVCCMetadataKey(keys.RaftTombstoneKey(desc.RangeID))
+	legacyTombstoneKey := engine.MakeMVCCMetadataKey(keys.RaftTombstoneIncorrectLegacyKey(desc.RangeID))
 
 	// Iterate over all the data in the range.
 	iter := snap.NewIterator(false /* prefix */)
@@ -350,7 +350,7 @@ func (r *Replica) sha512(
 
 	var legacyTimestamp hlc.LegacyTimestamp
 	visitor := func(unsafeKey engine.MVCCKey, unsafeValue []byte) error {
-		if unsafeKey.Equal(tombstoneKey) {
+		if unsafeKey.Equal(legacyTombstoneKey) {
 			// Skip the tombstone key which is marked as replicated even though it
 			// isn't.
 			//

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -777,6 +777,16 @@ func (r *Replica) applySnapshot(
 		}
 	}
 
+	// Nodes before v2.0 may send an incorrect Raft tombstone (see #12154) that was supposed
+	// to be unreplicated. Simply remove it.
+	//
+	// NB: this can be removed in v2.1. This is because when we are running a binary at
+	// v2.1, we know that peers are at least running v2.0, which will never send out these
+	// snapshots.
+	if err := clearLegacyTombstone(batch, r.RangeID); err != nil {
+		return errors.Wrap(err, "while clearing legacy tombstone key")
+	}
+
 	// The log entries are all written to distinct keys so we can use a
 	// distinct batch.
 	distinctBatch := batch.Distinct()

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1008,6 +1008,81 @@ func (s *Store) IsStarted() bool {
 	return atomic.LoadInt32(&s.started) == 1
 }
 
+// IterateIDPrefixKeys helps visit system keys that use RangeID prefixing ( such as
+// RaftHardStateKey, RaftTombstoneKey, and many others). Such keys could in principle exist at any
+// RangeID, and this helper efficiently discovers all the keys of the desired type (as specified by
+// the supplied `keyFn`) and, for each key-value pair discovered, unmarshals it into `msg` and then
+// invokes `f`.
+//
+// Iteration stops on the first error (and will pass through that error).
+func IterateIDPrefixKeys(
+	ctx context.Context,
+	eng engine.Reader,
+	keyFn func(roachpb.RangeID) roachpb.Key,
+	msg protoutil.Message,
+	f func(_ roachpb.RangeID) (more bool, _ error),
+) error {
+	rangeID := roachpb.RangeID(1)
+	iter := eng.NewIterator(false /* prefix */)
+
+	for {
+		bumped := false
+		mvccKey := engine.MakeMVCCMetadataKey(keyFn(rangeID))
+		iter.Seek(mvccKey)
+
+		if ok, err := iter.Valid(); !ok {
+			return err
+		}
+
+		unsafeKey := iter.UnsafeKey()
+
+		if !bytes.HasPrefix(unsafeKey.Key, keys.LocalRangeIDPrefix) {
+			// Left the local keyspace, so we're done.
+			return nil
+		}
+
+		curRangeID, _, _, _, err := keys.DecodeRangeIDKey(unsafeKey.Key)
+		if err != nil {
+			return err
+		}
+
+		if curRangeID > rangeID {
+			// `bumped` is always `false` here, but let's be explicit.
+			if !bumped {
+				rangeID = curRangeID
+				bumped = true
+			}
+			mvccKey = engine.MakeMVCCMetadataKey(keyFn(rangeID))
+		}
+
+		if !unsafeKey.Key.Equal(mvccKey.Key) {
+			if !bumped {
+				// Don't increment the rangeID if it has already been incremented
+				// above, or we could skip past a value we ought to see.
+				rangeID++
+				bumped = true // for completeness' sake; continuing below anyway
+			}
+			continue
+		}
+
+		ok, err := engine.MVCCGetProto(
+			ctx, eng, unsafeKey.Key, hlc.Timestamp{}, true /* consistent */, nil /* txn */, msg,
+		)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errors.Errorf("unable to unmarshal %s into %T", unsafeKey.Key, msg)
+		}
+
+		more, err := f(rangeID)
+		if !more || err != nil {
+			return err
+		}
+		rangeID++
+	}
+}
+
 // IterateRangeDescriptors calls the provided function with each descriptor
 // from the provided Engine. The return values of this method and fn have
 // semantics similar to engine.MVCCIterate.
@@ -1103,6 +1178,34 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 
 	now := s.cfg.Clock.Now()
 	s.startedAt = now.WallTime
+
+	// Migrate legacy tombstones away if we can. We want to do this when the node boots with a
+	// cluster version as below or higher, i.e. not when the upgrade happens for a running node.
+	// In fact, we do it on *every* such boot (i.e. not only once); this is because we want the
+	// migration to run when the v2.1 binary is started (the next release at the time of writing
+	// is v2.0) so that that version doesn't have to know about legacy tombstones (outside of
+	// this migration).
+	//
+	// NB: we could defer this migration until we actually release v2.1, but that would open the
+	// code up to rot and requires more tracking of this migration than it seems worth it.
+	// However, should this be found to impact startup times too much, it can be removed and
+	// later reintroduced (in a way that runs it only once, in v2.1).
+	//
+	// Note that `Settings.Version` is the persisted cluster version and has not been updated
+	// via Gossip (see `(*Node).start`).
+	if s.cfg.Settings.Version.IsMinSupported(cluster.VersionUnreplicatedTombstoneKey) {
+		tBegin := timeutil.Now()
+		if err := migrateLegacyTombstones(ctx, s.engine); err != nil {
+			return errors.Wrapf(err, "migrating legacy tombstones for %v", s.engine)
+		}
+		f := log.Eventf
+
+		dur := timeutil.Since(tBegin)
+		if dur > 10*time.Second {
+			f = log.Infof
+		}
+		f(ctx, "ran legacy tombstone migration in %s", dur)
+	}
 
 	// Iterate over all range descriptors, ignoring uncommitted versions
 	// (consistent=false). Uncommitted intents which have been abandoned
@@ -3948,15 +4051,25 @@ func (s *Store) tryGetOrCreateReplica(
 	// No replica currently exists, so we'll try to create one. Before creating
 	// the replica, see if there is a tombstone which would indicate that this is
 	// a stale message.
-	tombstoneKey := keys.RaftTombstoneKey(rangeID)
-	var tombstone roachpb.RaftTombstone
-	if ok, err := engine.MVCCGetProto(
-		ctx, s.Engine(), tombstoneKey, hlc.Timestamp{}, true, nil, &tombstone,
-	); err != nil {
-		return nil, false, err
-	} else if ok {
-		if replicaID != 0 && replicaID < tombstone.NextReplicaID {
-			return nil, false, &roachpb.RaftGroupDeletedError{}
+	tombstoneKeys := []roachpb.Key{
+		keys.RaftTombstoneKey(rangeID),
+		keys.RaftTombstoneIncorrectLegacyKey(rangeID),
+	}
+
+	var minReplicaID roachpb.ReplicaID
+	for _, tombstoneKey := range tombstoneKeys {
+		var tombstone roachpb.RaftTombstone
+		if ok, err := engine.MVCCGetProto(
+			ctx, s.Engine(), tombstoneKey, hlc.Timestamp{}, true, nil, &tombstone,
+		); err != nil {
+			return nil, false, err
+		} else if ok {
+			if replicaID != 0 && replicaID < tombstone.NextReplicaID {
+				return nil, false, &roachpb.RaftGroupDeletedError{}
+			}
+			if minReplicaID < tombstone.NextReplicaID {
+				minReplicaID = tombstone.NextReplicaID
+			}
 		}
 	}
 
@@ -3973,7 +4086,7 @@ func (s *Store) tryGetOrCreateReplica(
 	// replica even outside of raft processing. Have to do this after grabbing
 	// Store.mu to maintain lock ordering invariant.
 	repl.mu.Lock()
-	repl.mu.minReplicaID = tombstone.NextReplicaID
+	repl.mu.minReplicaID = minReplicaID
 	// Add the range to range map, but not replicasByKey since the range's start
 	// key is unknown. The range will be added to replicasByKey later when a
 	// snapshot is applied. After unlocking Store.mu above, another goroutine

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -19,7 +19,9 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"reflect"
+	"sort"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -48,6 +50,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -178,9 +181,140 @@ func createTestStoreWithConfig(t testing.TB, stopper *stop.Stopper, cfg *StoreCo
 	return store
 }
 
+// TestIterateIDPrefixKeys lays down a number of tombstones (at keys.RaftTombstoneKey) interspersed
+// with other irrelevant keys (both chosen randomly). It then verifies that IterateIDPrefixKeys
+// correctly returns only the relevant keys and values.
+func TestIterateIDPrefixKeys(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	eng := engine.NewInMem(roachpb.Attributes{}, 1<<20)
+	stopper.AddCloser(eng)
+
+	seed := randutil.NewPseudoSeed()
+	//const seed = -1666367124291055473
+	t.Logf("seed is %d", seed)
+	rng := rand.New(rand.NewSource(seed))
+
+	ops := []func(rangeID roachpb.RangeID) roachpb.Key{
+		keys.RaftAppliedIndexKey, // replicated; sorts before tombstone
+		keys.RaftHardStateKey,    // unreplicated; sorts after tombstone
+		// Replicated key-anchored local key (i.e. not one we should care about).
+		// Will be written at zero timestamp, but that's ok.
+		func(rangeID roachpb.RangeID) roachpb.Key {
+			return keys.RangeDescriptorKey([]byte(fmt.Sprintf("fakerange%d", rangeID)))
+		},
+		func(rangeID roachpb.RangeID) roachpb.Key {
+			return roachpb.Key(fmt.Sprintf("fakeuserkey%d", rangeID))
+		},
+	}
+
+	const rangeCount = 10
+	rangeIDFn := func() roachpb.RangeID {
+		return 1 + roachpb.RangeID(rng.Intn(10*rangeCount)) // spread rangeIDs out
+	}
+
+	// Write a number of keys that should be irrelevant to the iteration in this test.
+	for i := 0; i < rangeCount; i++ {
+		rangeID := rangeIDFn()
+
+		// Grab between one and all ops, randomly.
+		for _, opIdx := range rng.Perm(len(ops))[:rng.Intn(1+len(ops))] {
+			key := ops[opIdx](rangeID)
+			t.Logf("writing op=%d rangeID=%d", opIdx, rangeID)
+			if err := engine.MVCCPut(
+				ctx,
+				eng,
+				nil, /* ms */
+				key,
+				hlc.Timestamp{},
+				roachpb.MakeValueFromString("fake value for "+key.String()),
+				nil, /* txn */
+			); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+
+	type seenT struct {
+		rangeID   roachpb.RangeID
+		tombstone roachpb.RaftTombstone
+	}
+
+	// Next, write the keys we're planning to see again.
+	var wanted []seenT
+	{
+		used := make(map[roachpb.RangeID]struct{})
+		for {
+			rangeID := rangeIDFn()
+			if _, ok := used[rangeID]; ok {
+				// We already wrote this key, so roll the dice again.
+				continue
+			}
+
+			tombstone := roachpb.RaftTombstone{
+				NextReplicaID: roachpb.ReplicaID(rng.Int31n(100)),
+			}
+
+			used[rangeID] = struct{}{}
+			wanted = append(wanted, seenT{rangeID: rangeID, tombstone: tombstone})
+
+			t.Logf("writing tombstone at rangeID=%d", rangeID)
+			if err := engine.MVCCPutProto(
+				ctx, eng, nil /* ms */, keys.RaftTombstoneKey(rangeID), hlc.Timestamp{}, nil /* txn */, &tombstone,
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			if len(wanted) >= rangeCount {
+				break
+			}
+		}
+	}
+
+	sort.Slice(wanted, func(i, j int) bool {
+		return wanted[i].rangeID < wanted[j].rangeID
+	})
+
+	var seen []seenT
+	var tombstone roachpb.RaftTombstone
+
+	handleTombstone := func(rangeID roachpb.RangeID) (more bool, _ error) {
+		seen = append(seen, seenT{rangeID: rangeID, tombstone: tombstone})
+		return true, nil
+	}
+
+	if err := IterateIDPrefixKeys(ctx, eng, keys.RaftTombstoneKey, &tombstone, handleTombstone); err != nil {
+		t.Fatal(err)
+	}
+	placeholder := seenT{
+		rangeID: roachpb.RangeID(9999),
+	}
+
+	if len(wanted) != len(seen) {
+		t.Errorf("wanted %d results, got %d", len(wanted), len(seen))
+	}
+
+	for len(wanted) < len(seen) {
+		wanted = append(wanted, placeholder)
+	}
+	for len(seen) < len(wanted) {
+		seen = append(seen, placeholder)
+	}
+
+	if diff := pretty.Diff(wanted, seen); len(diff) > 0 {
+		pretty.Ldiff(t, wanted, seen)
+		t.Fatal("diff(wanted, seen) is nonempty")
+	}
+}
+
 // TestStoreInitAndBootstrap verifies store initialization and bootstrap.
 func TestStoreInitAndBootstrap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
 	// We need a fixed clock to avoid LastUpdateNanos drifting on us.
 	cfg := TestStoreConfig(hlc.NewClock(func() int64 { return 123 }, time.Nanosecond))
 	stopper := stop.NewStopper()
@@ -221,12 +355,79 @@ func TestStoreInitAndBootstrap(t *testing.T) {
 		}
 	}
 
+	// Put down a few fake legacy tombstones (#12154) to jog `migrateLegacyTombstones`, including
+	// one for the existing range, but also some for non-existing ones. We'll check that these get
+	// migrated properly.
+	//
+	// Range 1 actually exists (since we will bootstrap it). The rest don't.
+	legacyTombstones := []struct {
+		rangeID         roachpb.RangeID
+		legacyTombstone roachpb.ReplicaID // legacy tombstone's NextReplicaID
+		newTombstone    roachpb.ReplicaID // new-style tombstone's NextReplicaID (if nonzero)
+		exNewTombstone  roachpb.ReplicaID // resulting new-style tombstone
+	}{
+		{rangeID: 1, legacyTombstone: 1, exNewTombstone: 1},
+		{rangeID: 200, legacyTombstone: 123, newTombstone: 122, exNewTombstone: 123},
+		{rangeID: 300, legacyTombstone: 333, newTombstone: 335, exNewTombstone: 335},
+	}
+
+	for _, stone := range legacyTombstones {
+		legacyTombstoneKey := keys.RaftTombstoneIncorrectLegacyKey(stone.rangeID)
+
+		if err := engine.MVCCPutProto(
+			ctx, eng, nil /* ms */, legacyTombstoneKey, hlc.Timestamp{}, nil, /* txn */
+			&roachpb.RaftTombstone{NextReplicaID: stone.legacyTombstone},
+		); err != nil {
+			t.Fatal(err)
+		}
+		if stone.newTombstone == 0 {
+			// No new-style tombstone for this key is present.
+			continue
+		}
+
+		tombstoneKey := keys.RaftTombstoneKey(stone.rangeID)
+		if err := engine.MVCCPutProto(
+			ctx, eng, nil /* ms */, tombstoneKey, hlc.Timestamp{},
+			nil /* txn */, &roachpb.RaftTombstone{NextReplicaID: stone.newTombstone},
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+
 	// Now, attempt to initialize a store with a now-bootstrapped range.
 	{
 		store := NewStore(cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 		if err := store.Start(ctx, stopper); err != nil {
 			t.Fatalf("failure initializing bootstrapped store: %s", err)
 		}
+
+		// Check that `migrateLegacyTombstone` did what it was supposed to.
+		for _, stone := range legacyTombstones {
+			legacyTombstoneKey := keys.RaftTombstoneIncorrectLegacyKey(stone.rangeID)
+			if ok, err := engine.MVCCGetProto(
+				ctx, store.engine, legacyTombstoneKey, hlc.Timestamp{}, true /* consistent */, nil /* txn */, nil, /* msg */
+			); err != nil {
+				t.Fatal(err)
+			} else if ok {
+				t.Fatalf("unexpectedly found legacy tombstone key at %s", legacyTombstoneKey)
+			}
+
+			tombstoneKey := keys.RaftTombstoneKey(stone.rangeID)
+			var tombstone roachpb.RaftTombstone
+			ok, err := engine.MVCCGetProto(
+				ctx, store.engine, tombstoneKey, hlc.Timestamp{}, true /* consistent */, nil /* txn */, &tombstone, /* msg */
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !ok {
+				t.Fatalf("unexpectedly did not find migrated tombstone key at %s", legacyTombstoneKey)
+			}
+			if tombstone.NextReplicaID != stone.exNewTombstone {
+				t.Fatalf("tombstone at %d is %d, but wanted %d", stone.rangeID, tombstone.NextReplicaID, stone.exNewTombstone)
+			}
+		}
+
 		// 1st range should be available.
 		r, err := store.GetReplica(1)
 		if err != nil {

--- a/pkg/storage/stores.go
+++ b/pkg/storage/stores.go
@@ -525,10 +525,29 @@ func (ls *Stores) SynthesizeClusterVersion(ctx context.Context) (cluster.Cluster
 // WriteClusterVersion makes no attempt to validate the supplied version.
 func (ls *Stores) WriteClusterVersion(ctx context.Context, cv cluster.ClusterVersion) error {
 	// Update all stores.
-	var engines []engine.Engine
+	engines := ls.engines()
 	ls.storeMap.Range(func(_ int64, v unsafe.Pointer) bool {
 		engines = append(engines, (*Store)(v).Engine())
 		return true // want more
 	})
 	return WriteClusterVersionToEngines(ctx, engines, cv)
+}
+
+func (ls *Stores) engines() []engine.Engine {
+	var engines []engine.Engine
+	ls.storeMap.Range(func(_ int64, v unsafe.Pointer) bool {
+		engines = append(engines, (*Store)(v).Engine())
+		return true // want more
+	})
+	return engines
+}
+
+// OnClusterVersionChange is invoked when the running node receives a notification
+// indicating that the cluster version has changed.
+func (ls *Stores) OnClusterVersionChange(ctx context.Context, cv cluster.ClusterVersion) error {
+	if err := ls.WriteClusterVersion(ctx, cv); err != nil {
+		return errors.Wrap(err, "writing cluster version")
+	}
+
+	return nil
 }


### PR DESCRIPTION
RaftTombstoneKey was accidentally made a replicated key when it was first
introduced, a problem we first realized existed when it was [included in
snapshots].

At the time, we included workarounds to skip this key in various places
(snapshot application, consistency checker) but of course we have failed to
insert further hacks of the same kind elsewhere since (the one that prompting
this PR being the stats recomputation on splits, which I'm looking into as part
of #20181 -- unfortunately this commit doesn't seem to pertain to that problem)

It feels sloppy that we didn't follow through back then, but luckily the damage
appears to be limited; it is likely that the replicated existence of this key
results in MVCCStats SysBytes inconsistencies, but as it happens, these stats
are [already] [very] [inconsistent].

This commit does a few things:

- renames the old tombstone key to `RaftIncorrectLegacyTombstoneKey`
- introduces a (correctly unreplicated) `RaftTombstoneKey`
- introduces a migration that rewrites all legacy keys early in the node
  start sequence; as a result, a node running this commit or later will
  never see any legacy keys, except when they come in through a snapshot
- when applying a snapshot, forcibly delete any legacy tombstone contained
  within.

`RaftIncorrectLegacyTombstoneKey` can be purged from the codebase in binaries
post v2.0, as at that point all peers have version at least v2.0 (which has this
commit and will never send legacy tombstones in snapshots).

Since sending legacy keys in snapshots was never intended (and isn't relied
upon), none of this needs a cluster version migration.

Fixes #12154.

Release note: None

[included in snapshots]: https://github.com/cockroachdb/cockroach/pull/12131
[already]: https://github.com/cockroachdb/cockroach/issues/20554
[very]: https://github.com/cockroachdb/cockroach/pull/20996
[inconsistent]: https://github.com/cockroachdb/cockroach/pull/21070