### PR TITLE
opt: pass through FuncExpr as unsupported op

### DIFF
--- a/pkg/sql/opt/build.go
+++ b/pkg/sql/opt/build.go
@@ -190,12 +190,14 @@ func (bc *buildContext) buildScalar(pexpr tree.TypedExpr) *expr {
 	case *tree.UnaryExpr:
 		initUnaryExpr(e, unaryOpMap[t.Operator], bc.buildScalar(t.TypedInnerExpr()))
 
-	case *tree.FuncExpr:
-		children := make([]*expr, len(t.Exprs))
-		for i, pexpr := range t.Exprs {
-			children[i] = bc.buildScalar(pexpr.(tree.TypedExpr))
-		}
-		initFunctionCallExpr(e, t.ResolvedFunc(), children)
+	// TODO(radu): for now, we pass through FuncExprs as unsupported
+	// expressions.
+	//case *tree.FuncExpr:
+	//	children := make([]*expr, len(t.Exprs))
+	//	for i, pexpr := range t.Exprs {
+	//		children[i] = bc.buildScalar(pexpr.(tree.TypedExpr))
+	//	}
+	//	initFunctionCallExpr(e, t.ResolvedFunc(), children)
 
 	case *tree.IndexedVar:
 		initVariableExpr(e, t.Idx)

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -83,6 +83,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+
+	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 )
 
 var (

--- a/pkg/sql/opt/scalar.go
+++ b/pkg/sql/opt/scalar.go
@@ -133,6 +133,10 @@ func initUnsupportedExpr(e *expr, typedExpr tree.TypedExpr) {
 	e.private = typedExpr
 }
 
+// TODO(radu): remove this once we support function calls.
+var _ = initFunctionCallExpr
+var _ = (*tree.FuncExpr).ResolvedFunc
+
 // initFunctionCallExpr initializes a functionCallOp expression node.
 func initFunctionCallExpr(e *expr, def *tree.FunctionDefinition, children []*expr) {
 	e.op = functionCallOp

--- a/pkg/sql/opt/testdata/build-scalar
+++ b/pkg/sql/opt/testdata/build-scalar
@@ -382,3 +382,11 @@ CASE WHEN @1 = 2 THEN 1 ELSE 2 END
 ----
 unsupported-scalar (CASE WHEN @1 = 2 THEN 1 ELSE 2 END) (type: int)
 CASE WHEN @1 = 2 THEN 1 ELSE 2 END
+
+build-scalar,semtree-expr vars=(string)
+LENGTH(@1) = 2
+----
+eq (type: bool)
+ ├── unsupported-scalar (length(@1)) (type: int)
+ └── const (2) (type: int)
+length(@1) = 2


### PR DESCRIPTION
We currently can't convert a functionCallOp back to a TypedExpr. For
now, just pass it through as an opaque expression.

Release note: None