### PR TITLE
sql/distsqlrun: remove context argument from Processor.Run

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -1234,6 +1234,7 @@ func newReadCSVProcessor(
 	flowCtx *distsqlrun.FlowCtx, spec distsqlrun.ReadCSVSpec, output distsqlrun.RowReceiver,
 ) (distsqlrun.Processor, error) {
 	cp := &readCSVProcessor{
+		flowCtx:    flowCtx,
 		csvOptions: spec.Options,
 		sampleSize: spec.SampleSize,
 		tableDesc:  spec.TableDesc,
@@ -1248,6 +1249,7 @@ func newReadCSVProcessor(
 }
 
 type readCSVProcessor struct {
+	flowCtx    *distsqlrun.FlowCtx
 	csvOptions roachpb.CSVOptions
 	sampleSize int32
 	tableDesc  sqlbase.TableDescriptor
@@ -1263,8 +1265,8 @@ func (cp *readCSVProcessor) OutputTypes() []sqlbase.ColumnType {
 	return csvOutputTypes
 }
 
-func (cp *readCSVProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
-	ctx, span := tracing.ChildSpan(ctx, "readCSVProcessor")
+func (cp *readCSVProcessor) Run(wg *sync.WaitGroup) {
+	ctx, span := tracing.ChildSpan(cp.flowCtx.Ctx, "readCSVProcessor")
 	defer tracing.FinishSpan(span)
 
 	if wg != nil {
@@ -1388,6 +1390,7 @@ func newSSTWriterProcessor(
 	output distsqlrun.RowReceiver,
 ) (distsqlrun.Processor, error) {
 	sp := &sstWriter{
+		flowCtx:     flowCtx,
 		spec:        spec,
 		input:       input,
 		output:      output,
@@ -1401,6 +1404,7 @@ func newSSTWriterProcessor(
 }
 
 type sstWriter struct {
+	flowCtx     *distsqlrun.FlowCtx
 	spec        distsqlrun.SSTWriterSpec
 	input       distsqlrun.RowSource
 	out         distsqlrun.ProcOutputHelper
@@ -1415,8 +1419,8 @@ func (sp *sstWriter) OutputTypes() []sqlbase.ColumnType {
 	return sstOutputTypes
 }
 
-func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
-	ctx, span := tracing.ChildSpan(ctx, "sstWriter")
+func (sp *sstWriter) Run(wg *sync.WaitGroup) {
+	ctx, span := tracing.ChildSpan(sp.flowCtx.Ctx, "sstWriter")
 	defer tracing.FinishSpan(span)
 
 	if wg != nil {

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -173,10 +173,11 @@ func newAggregator(
 }
 
 // Run is part of the processor interface.
-func (ag *aggregator) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (ag *aggregator) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
+	ctx := ag.flowCtx.Ctx
 	defer ag.bucketsAcc.Close(ctx)
 	defer func() {
 		for _, f := range ag.funcs {

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -351,6 +351,7 @@ func TestAggregator(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
+				Ctx:      context.Background(),
 				Settings: cluster.MakeTestingClusterSettings(),
 				EvalCtx:  evalCtx,
 			}
@@ -360,7 +361,7 @@ func TestAggregator(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ag.Run(context.Background(), nil)
+			ag.Run(nil)
 
 			var expected []string
 			for _, row := range c.expected {
@@ -410,6 +411,7 @@ func BenchmarkAggregation(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
+		Ctx:      ctx,
 		Settings: cluster.MakeTestingClusterSettings(),
 		EvalCtx:  evalCtx,
 	}
@@ -435,7 +437,7 @@ func BenchmarkAggregation(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(ctx, nil)
+				d.Run(nil)
 				input.Reset()
 			}
 			b.StopTimer()
@@ -452,6 +454,7 @@ func BenchmarkGrouping(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
+		Ctx:      ctx,
 		Settings: cluster.MakeTestingClusterSettings(),
 		EvalCtx:  evalCtx,
 	}
@@ -469,7 +472,7 @@ func BenchmarkGrouping(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		d.Run(ctx, nil)
+		d.Run(nil)
 		input.Reset()
 	}
 	b.StopTimer()

--- a/pkg/sql/distsqlrun/algebraic_set_op.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op.go
@@ -89,12 +89,12 @@ func newAlgebraicSetOp(
 	return e, nil
 }
 
-func (e *algebraicSetOp) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (e *algebraicSetOp) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
 
-	ctx = log.WithLogTag(ctx, "ExceptAll", nil)
+	ctx := log.WithLogTag(e.flowCtx.Ctx, "ExceptAll", nil)
 	ctx, span := processorSpan(ctx, "exceptAll")
 	defer tracing.FinishSpan(span)
 

--- a/pkg/sql/distsqlrun/algebraic_set_op_test.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op_test.go
@@ -85,14 +85,17 @@ func runProcessors(tc testCase) (sqlbase.EncDatumRows, error) {
 	inR := NewRowBuffer(types, tc.inputRight, RowBufferArgs{})
 	out := NewRowBuffer(types, nil /* rows */, RowBufferArgs{})
 
-	flowCtx := FlowCtx{Settings: cluster.MakeTestingClusterSettings()}
+	flowCtx := FlowCtx{
+		Ctx:      context.Background(),
+		Settings: cluster.MakeTestingClusterSettings(),
+	}
 
 	s, err := newAlgebraicSetOp(&flowCtx, &tc.spec, inL, inR, &PostProcessSpec{}, out)
 	if err != nil {
 		return nil, err
 	}
 
-	s.Run(context.Background(), nil)
+	s.Run(nil)
 	if !out.ProducerClosed {
 		return nil, errors.Errorf("output RowReceiver not closed")
 	}

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -70,13 +70,13 @@ func (*backfiller) OutputTypes() []sqlbase.ColumnType {
 }
 
 // Run is part of the processor interface.
-func (b *backfiller) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (b *backfiller) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
 
 	opName := fmt.Sprintf("%sBackfiller", b.name)
-	ctx = log.WithLogTagInt(ctx, opName, int(b.spec.Table.ID))
+	ctx := log.WithLogTagInt(b.flowCtx.Ctx, opName, int(b.spec.Table.ID))
 	ctx, span := processorSpan(ctx, opName)
 	defer tracing.FinishSpan(span)
 

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -76,14 +76,11 @@ func newDistinct(
 }
 
 // Run is part of the processor interface.
-func (d *distinct) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (d *distinct) Run(wg *sync.WaitGroup) {
 	if d.out.output == nil {
 		panic("distinct output not initialized for emitting rows")
 	}
-	if ctx != d.flowCtx.ctx {
-		panic("unexpected context")
-	}
-	Run(ctx, d, d.out.output)
+	Run(d.flowCtx.Ctx, d, d.out.output)
 	if wg != nil {
 		wg.Done()
 	}
@@ -171,7 +168,7 @@ func (d *distinct) Types() []sqlbase.ColumnType {
 func (d *distinct) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 	if !d.started {
 		d.started = true
-		d.ctx = log.WithLogTag(d.flowCtx.ctx, "Evaluator", nil)
+		d.ctx = log.WithLogTag(d.flowCtx.Ctx, "Evaluator", nil)
 		d.ctx, d.span = processorSpan(d.ctx, "distinct")
 		d.evalCtx = d.flowCtx.NewEvalCtx()
 	}

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -140,7 +140,7 @@ func TestDistinct(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				ctx:      context.Background(),
+				Ctx:      context.Background(),
 				Settings: cluster.MakeTestingClusterSettings(),
 				EvalCtx:  evalCtx,
 			}
@@ -150,7 +150,7 @@ func TestDistinct(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			d.Run(context.Background(), nil)
+			d.Run(nil)
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -179,6 +179,7 @@ func BenchmarkDistinct(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
+		Ctx:      ctx,
 		Settings: cluster.MakeTestingClusterSettings(),
 		EvalCtx:  evalCtx,
 	}
@@ -195,7 +196,7 @@ func BenchmarkDistinct(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		d.Run(ctx, nil)
+		d.Run(nil)
 		input.Reset()
 	}
 	b.StopTimer()

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -148,12 +148,12 @@ func newHashJoiner(
 }
 
 // Run is part of the processor interface.
-func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (h *hashJoiner) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
 
-	ctx = log.WithLogTag(ctx, "HashJoiner", nil)
+	ctx := log.WithLogTag(h.flowCtx.Ctx, "HashJoiner", nil)
 	ctx, span := processorSpan(ctx, "hash joiner")
 	defer tracing.FinishSpan(span)
 

--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -70,7 +70,7 @@ func processInboundStreamHelper(
 		} else {
 			// Check for context cancellation before recv()ing the next message.
 			select {
-			case <-f.ctx.Done():
+			case <-f.Ctx.Done():
 				// This will error out the FlowStream(), and also cancel
 				// the flow context on the producer.
 				return sqlbase.NewQueryCanceledError()

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -226,7 +226,7 @@ func (irj *interleavedReaderJoiner) sendMisplannedRangesMetadata(ctx context.Con
 }
 
 // Run is part of the processor interface.
-func (irj *interleavedReaderJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (irj *interleavedReaderJoiner) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
@@ -235,7 +235,7 @@ func (irj *interleavedReaderJoiner) Run(ctx context.Context, wg *sync.WaitGroup)
 	for i := range tableIDs {
 		tableIDs[i] = irj.tables[i].tableID
 	}
-	ctx = log.WithLogTag(ctx, "InterleaveReaderJoiner", tableIDs)
+	ctx := log.WithLogTag(irj.flowCtx.Ctx, "InterleaveReaderJoiner", tableIDs)
 	ctx, span := processorSpan(ctx, "interleaved reader joiner")
 	defer tracing.FinishSpan(span)
 

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -396,6 +396,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
+				Ctx:      context.Background(),
 				EvalCtx:  evalCtx,
 				Settings: s.ClusterSettings(),
 				// Pass a DB without a TxnCoordSender.
@@ -408,7 +409,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			irj.Run(context.Background(), nil)
+			irj.Run(nil)
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
 			}

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -202,12 +202,12 @@ func (jr *joinReader) mainLoop(ctx context.Context) error {
 }
 
 // Run is part of the processor interface.
-func (jr *joinReader) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (jr *joinReader) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
 
-	ctx = log.WithLogTagInt(ctx, "JoinReader", int(jr.desc.ID))
+	ctx := log.WithLogTagInt(jr.flowCtx.Ctx, "JoinReader", int(jr.desc.ID))
 	ctx, span := processorSpan(ctx, "join reader")
 	defer tracing.FinishSpan(span)
 

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -103,6 +103,7 @@ func TestJoinReader(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
+				Ctx:      context.Background(),
 				EvalCtx:  evalCtx,
 				Settings: cluster.MakeTestingClusterSettings(),
 				// Pass a DB without a TxnCoordSender.
@@ -125,7 +126,7 @@ func TestJoinReader(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			jr.Run(context.Background(), nil)
+			jr.Run(nil)
 
 			if !in.Done {
 				t.Fatal("joinReader didn't consume all the rows")
@@ -171,6 +172,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext()
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
+		Ctx:      context.Background(),
 		EvalCtx:  evalCtx,
 		Settings: s.ClusterSettings(),
 		// Pass a DB without a TxnCoordSender.
@@ -179,8 +181,6 @@ func TestJoinReaderDrain(t *testing.T) {
 
 	encRow := make(sqlbase.EncDatumRow, 1)
 	encRow[0] = sqlbase.DatumToEncDatum(intType, tree.NewDInt(1))
-
-	ctx := context.Background()
 
 	// ConsumerClosed verifies that when a joinReader's consumer is closed, the
 	// joinReader finishes gracefully.
@@ -193,7 +193,7 @@ func TestJoinReaderDrain(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		jr.Run(ctx, nil)
+		jr.Run(nil)
 	})
 
 	// ConsumerDone verifies that the producer drains properly by checking that
@@ -212,7 +212,7 @@ func TestJoinReaderDrain(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		jr.Run(ctx, nil)
+		jr.Run(nil)
 		row, meta := out.Next()
 		if row != nil {
 			t.Fatalf("row was pushed unexpectedly: %s", row.String(oneIntCol))

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -83,12 +83,12 @@ func newMergeJoiner(
 }
 
 // Run is part of the processor interface.
-func (m *mergeJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (m *mergeJoiner) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
 
-	ctx = log.WithLogTag(ctx, "MergeJoiner", nil)
+	ctx := log.WithLogTag(m.flowCtx.Ctx, "MergeJoiner", nil)
 	ctx, span := processorSpan(ctx, "merge joiner")
 	defer tracing.FinishSpan(span)
 	log.VEventf(ctx, 2, "starting merge joiner run")

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -432,7 +432,11 @@ func TestMergeJoiner(t *testing.T) {
 			out := &RowBuffer{}
 			evalCtx := tree.MakeTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
-			flowCtx := FlowCtx{Settings: cluster.MakeTestingClusterSettings(), EvalCtx: evalCtx}
+			flowCtx := FlowCtx{
+				Ctx:      context.Background(),
+				Settings: cluster.MakeTestingClusterSettings(),
+				EvalCtx:  evalCtx,
+			}
 
 			post := PostProcessSpec{Projection: true, OutputColumns: c.outCols}
 			m, err := newMergeJoiner(&flowCtx, &ms, leftInput, rightInput, &post, out)
@@ -440,7 +444,7 @@ func TestMergeJoiner(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.Run(context.Background(), nil /* wg */)
+			m.Run(nil /* wg */)
 
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
@@ -536,6 +540,7 @@ func TestConsumerClosed(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
+				Ctx:      context.Background(),
 				Settings: cluster.MakeTestingClusterSettings(),
 				EvalCtx:  evalCtx,
 			}
@@ -545,7 +550,7 @@ func TestConsumerClosed(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.Run(context.TODO(), nil /* wg */)
+			m.Run(nil /* wg */)
 
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
@@ -559,6 +564,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 	evalCtx := tree.MakeTestingEvalContext()
 	defer evalCtx.Stop(ctx)
 	flowCtx := &FlowCtx{
+		Ctx:      ctx,
 		Settings: cluster.MakeTestingClusterSettings(),
 		EvalCtx:  evalCtx,
 	}
@@ -591,7 +597,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(ctx, nil)
+				m.Run(nil)
 				leftInput.Reset()
 				rightInput.Reset()
 			}

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -37,7 +37,7 @@ type Processor interface {
 
 	// Run is the main loop of the processor.
 	// If wg is non-nil, wg.Done is called before exiting.
-	Run(ctx context.Context, wg *sync.WaitGroup)
+	Run(wg *sync.WaitGroup)
 }
 
 // ProcOutputHelper is a helper type that performs filtering and projection on
@@ -403,11 +403,11 @@ func processorSpan(ctx context.Context, name string) (context.Context, opentraci
 }
 
 // Run is part of the processor interface.
-func (n *noopProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (n *noopProcessor) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
-	ctx, span := processorSpan(ctx, "noop")
+	ctx, span := processorSpan(n.flowCtx.Ctx, "noop")
 	defer tracing.FinishSpan(span)
 
 	for {

--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -109,11 +109,11 @@ func newSampleAggregator(
 }
 
 // Run is part of the Processor interface.
-func (s *sampleAggregator) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (s *sampleAggregator) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
-	ctx, span := processorSpan(ctx, "sample aggregator")
+	ctx, span := processorSpan(s.flowCtx.Ctx, "sample aggregator")
 	defer tracing.FinishSpan(span)
 
 	earlyExit, err := s.mainLoop(ctx)

--- a/pkg/sql/distsqlrun/sample_aggregator_test.go
+++ b/pkg/sql/distsqlrun/sample_aggregator_test.go
@@ -42,6 +42,7 @@ func TestSampleAggregator(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext()
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
+		Ctx:      context.Background(),
 		Settings: cluster.MakeTestingClusterSettings(),
 		EvalCtx:  evalCtx,
 		clientDB: kvDB,
@@ -109,7 +110,7 @@ func TestSampleAggregator(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		p.Run(context.Background(), nil /* wg */)
+		p.Run(nil /* wg */)
 	}
 	// Randomly interleave the output rows from the samplers into a single buffer.
 	samplerResults := NewRowBuffer(samplerOutTypes, nil /* rows */, RowBufferArgs{})
@@ -136,7 +137,7 @@ func TestSampleAggregator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	agg.Run(context.Background(), nil /* wg */)
+	agg.Run(nil /* wg */)
 	// Make sure there was no error.
 	finalOut.GetRowsNoMeta(t)
 	r := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -126,11 +126,11 @@ func newSamplerProcessor(
 }
 
 // Run is part of the Processor interface.
-func (s *samplerProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (s *samplerProcessor) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
-	ctx, span := processorSpan(ctx, "sampler")
+	ctx, span := processorSpan(s.flowCtx.Ctx, "sampler")
 	defer tracing.FinishSpan(span)
 
 	earlyExit, err := s.mainLoop(ctx)

--- a/pkg/sql/distsqlrun/sampler_test.go
+++ b/pkg/sql/distsqlrun/sampler_test.go
@@ -46,6 +46,7 @@ func runSampler(t *testing.T, numRows, numSamples int) []int {
 	evalCtx := tree.MakeTestingEvalContext()
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
+		Ctx:      context.Background(),
 		Settings: cluster.MakeTestingClusterSettings(),
 		EvalCtx:  evalCtx,
 	}
@@ -55,7 +56,7 @@ func runSampler(t *testing.T, numRows, numSamples int) []int {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.Run(context.Background(), nil)
+	p.Run(nil)
 
 	// Verify we have numSamples distinct rows.
 	res := make([]int, 0, numSamples)
@@ -150,6 +151,7 @@ func TestSamplerSketch(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext()
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
+		Ctx:      context.Background(),
 		Settings: cluster.MakeTestingClusterSettings(),
 		EvalCtx:  evalCtx,
 	}
@@ -171,7 +173,7 @@ func TestSamplerSketch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.Run(context.Background(), nil)
+	p.Run(nil)
 
 	rows = out.GetRowsNoMeta(t)
 	// We expect one sampled row and two sketch rows.

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -15,7 +15,6 @@
 package distsqlrun
 
 import (
-	"context"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -75,12 +74,12 @@ func newSorter(
 }
 
 // Run is part of the processor interface.
-func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (s *sorter) Run(wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
 
-	ctx = log.WithLogTag(ctx, "Sorter", nil)
+	ctx := log.WithLogTag(s.flowCtx.Ctx, "Sorter", nil)
 	ctx, span := processorSpan(ctx, "sorter")
 	defer tracing.FinishSpan(span)
 

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -203,6 +203,7 @@ func TestSorter(t *testing.T) {
 	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
 	flowCtx := FlowCtx{
+		Ctx:         ctx,
 		EvalCtx:     evalCtx,
 		Settings:    cluster.MakeTestingClusterSettings(),
 		TempStorage: tempEngine,
@@ -231,7 +232,7 @@ func TestSorter(t *testing.T) {
 				// a memory row container which will hit this limit and fall
 				// back to using a disk row container.
 				s.flowCtx.testingKnobs.MemoryLimitBytes = memLimit
-				s.Run(ctx, nil)
+				s.Run(nil)
 				if !out.ProducerClosed {
 					t.Fatalf("output RowReceiver not closed")
 				}
@@ -262,6 +263,7 @@ func BenchmarkSortAll(b *testing.B) {
 	evalCtx := tree.MakeTestingEvalContext()
 	defer evalCtx.Stop(ctx)
 	flowCtx := FlowCtx{
+		Ctx:      ctx,
 		Settings: cluster.MakeTestingClusterSettings(),
 		EvalCtx:  evalCtx,
 	}
@@ -291,7 +293,7 @@ func BenchmarkSortAll(b *testing.B) {
 			}
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				s.Run(ctx, nil)
+				s.Run(nil)
 				rowSource.Reset()
 			}
 		})
@@ -305,6 +307,7 @@ func BenchmarkSortLimit(b *testing.B) {
 	evalCtx := tree.MakeTestingEvalContext()
 	defer evalCtx.Stop(ctx)
 	flowCtx := FlowCtx{
+		Ctx:      ctx,
 		Settings: cluster.MakeTestingClusterSettings(),
 		EvalCtx:  evalCtx,
 	}
@@ -338,7 +341,7 @@ func BenchmarkSortLimit(b *testing.B) {
 				}
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
-					s.Run(ctx, nil)
+					s.Run(nil)
 					rowSource.Reset()
 				}
 			})

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -55,7 +55,7 @@ type tableReader struct {
 	processorBase
 
 	// ctx and span contain the tracing state while the processor is active
-	// (i.e. hasn't been closed). Initialized using flowCtx.ctx (which should not
+	// (i.e. hasn't been closed). Initialized using flowCtx.Ctx (which should not
 	// be otherwise used).
 	ctx  context.Context
 	span opentracing.Span
@@ -205,14 +205,11 @@ func initRowFetcher(
 }
 
 // Run is part of the processor interface.
-func (tr *tableReader) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (tr *tableReader) Run(wg *sync.WaitGroup) {
 	if tr.out.output == nil {
 		panic("tableReader output not initialized for emitting rows")
 	}
-	if ctx != tr.flowCtx.ctx {
-		panic("unexpected context")
-	}
-	Run(ctx, tr, tr.out.output)
+	Run(tr.flowCtx.Ctx, tr, tr.out.output)
 	if wg != nil {
 		wg.Done()
 	}
@@ -342,7 +339,7 @@ func (tr *tableReader) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 			log.Fatalf(tr.ctx, "tableReader outside of txn")
 		}
 
-		tr.ctx = log.WithLogTagInt(tr.flowCtx.ctx, "TableReader", int(tr.tableDesc.ID))
+		tr.ctx = log.WithLogTagInt(tr.flowCtx.Ctx, "TableReader", int(tr.tableDesc.ID))
 		tr.ctx, tr.span = processorSpan(tr.ctx, "table reader")
 		log.VEventf(tr.ctx, 1, "starting")
 

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -123,7 +123,7 @@ func TestTableReader(t *testing.T) {
 					evalCtx := tree.MakeTestingEvalContext()
 					defer evalCtx.Stop(context.Background())
 					flowCtx := FlowCtx{
-						ctx:      context.Background(),
+						Ctx:      context.Background(),
 						EvalCtx:  evalCtx,
 						Settings: s.ClusterSettings(),
 						// Pass a DB without a TxnCoordSender.
@@ -202,7 +202,7 @@ ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3
 	defer evalCtx.Stop(context.Background())
 	nodeID := tc.Server(0).NodeID()
 	flowCtx := FlowCtx{
-		ctx:      context.Background(),
+		Ctx:      context.Background(),
 		EvalCtx:  evalCtx,
 		Settings: tc.Server(0).ClusterSettings(),
 		// Pass a DB without a TxnCoordSender.
@@ -291,7 +291,7 @@ func BenchmarkTableReader(b *testing.B) {
 	evalCtx := tree.MakeTestingEvalContext()
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		ctx:      context.Background(),
+		Ctx:      context.Background(),
 		EvalCtx:  evalCtx,
 		Settings: s.ClusterSettings(),
 		// Pass a DB without a TxnCoordSender.

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -67,14 +67,11 @@ func newValuesProcessor(
 }
 
 // Run is part of the processor interface.
-func (v *valuesProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (v *valuesProcessor) Run(wg *sync.WaitGroup) {
 	if v.out.output == nil {
 		panic("valuesProcessor output not initialized for emitting rows")
 	}
-	if ctx != v.flowCtx.ctx {
-		panic("unexpected context")
-	}
-	Run(ctx, v, v.out.output)
+	Run(v.flowCtx.Ctx, v, v.out.output)
 	if wg != nil {
 		wg.Done()
 	}
@@ -118,7 +115,7 @@ func (v *valuesProcessor) Types() []sqlbase.ColumnType {
 func (v *valuesProcessor) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 	if !v.started {
 		v.started = true
-		v.ctx, v.span = processorSpan(v.flowCtx.ctx, "values")
+		v.ctx, v.span = processorSpan(v.flowCtx.Ctx, "values")
 
 		// Add a bogus header to apease the StreamDecoder, which wants to receive a
 		// header before any data.

--- a/pkg/sql/distsqlrun/values_test.go
+++ b/pkg/sql/distsqlrun/values_test.go
@@ -71,7 +71,7 @@ func TestValues(t *testing.T) {
 
 					out := &RowBuffer{}
 					flowCtx := FlowCtx{
-						ctx:      context.Background(),
+						Ctx:      context.Background(),
 						Settings: cluster.MakeTestingClusterSettings(),
 					}
 
@@ -79,7 +79,7 @@ func TestValues(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					v.Run(context.Background(), nil)
+					v.Run(nil)
 					if !out.ProducerClosed {
 						t.Fatalf("output RowReceiver not closed")
 					}


### PR DESCRIPTION
The context is available via `FlowCtx.Ctx`.

Release note: None