### PR TITLE
sql/distsqlrun: rename RowSource.Types to RowSource.OutputTypes

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -1427,7 +1427,7 @@ func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 	err := func() error {
 		// Sort incoming KVs, which will be from multiple spans, into a single
 		// RocksDB instance.
-		types := sp.input.Types()
+		types := sp.input.OutputTypes()
 		input := distsqlrun.MakeNoMetadataRowSource(sp.input, sp.output)
 		alloc := &sqlbase.DatumAlloc{}
 		store := engine.NewRocksDBMultiMap(sp.tempStorage)

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -132,7 +132,7 @@ func newAggregator(
 	// (which just returns the last value added to them for a bucket) to provide
 	// grouped-by values for each bucket.  ag.funcs is updated to contain all
 	// the functions which need to be fed values.
-	ag.inputTypes = input.Types()
+	ag.inputTypes = input.OutputTypes()
 	for i, aggInfo := range spec.Aggregations {
 		if aggInfo.FilterColIdx != nil {
 			col := *aggInfo.FilterColIdx

--- a/pkg/sql/distsqlrun/algebraic_set_op.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op.go
@@ -65,8 +65,8 @@ func newAlgebraicSetOp(
 		return nil, errors.Errorf("cannot create algebraicSetOp for unsupported algebraicSetOpType %v", e.opType)
 	}
 
-	lt := leftSource.Types()
-	rt := rightSource.Types()
+	lt := leftSource.OutputTypes()
+	rt := rightSource.OutputTypes()
 	if len(lt) != len(rt) {
 		return nil, errors.Errorf(
 			"Non union compatible: left and right have different numbers of columns %d and %d",

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -105,8 +105,8 @@ type CancellableRowReceiver interface {
 // RowSource is any component of a flow that produces rows that cam be consumed
 // by another component.
 type RowSource interface {
-	// Types returns the schema for the rows in this source.
-	Types() []sqlbase.ColumnType
+	// OutputTypes returns the schema for the rows in this source.
+	OutputTypes() []sqlbase.ColumnType
 
 	// Next returns the next record from the source. At most one of the return
 	// values will be non-empty. Both of them can be empty when the RowSource has
@@ -200,7 +200,7 @@ func DrainAndForwardMetadata(ctx context.Context, src RowSource, dst RowReceiver
 		if row != nil {
 			log.Fatalf(
 				ctx, "both row data and metadata in the same record. row: %s meta: %+v",
-				row.String(src.Types()), meta,
+				row.String(src.OutputTypes()), meta,
 			)
 		}
 
@@ -278,9 +278,9 @@ func MakeNoMetadataRowSource(src RowSource, sink RowReceiver) NoMetadataRowSourc
 	return NoMetadataRowSource{src: src, metadataSink: sink}
 }
 
-// Types returns the source types.
-func (rs *NoMetadataRowSource) Types() []sqlbase.ColumnType {
-	return rs.src.Types()
+// OutputTypes returns the source types.
+func (rs *NoMetadataRowSource) OutputTypes() []sqlbase.ColumnType {
+	return rs.src.OutputTypes()
 }
 
 // NextRow is analogous to RowSource.Next. If the producer sends an error, we
@@ -384,8 +384,8 @@ func (rc *RowChannel) ProducerDone() {
 	close(rc.dataChan)
 }
 
-// Types is part of the RowSource interface.
-func (rc *RowChannel) Types() []sqlbase.ColumnType {
+// OutputTypes is part of the RowSource interface.
+func (rc *RowChannel) OutputTypes() []sqlbase.ColumnType {
 	return rc.types
 }
 
@@ -461,8 +461,8 @@ func (mrc *MultiplexedRowChannel) ProducerDone() {
 	}
 }
 
-// Types is part of the RowSource interface.
-func (mrc *MultiplexedRowChannel) Types() []sqlbase.ColumnType {
+// OutputTypes is part of the RowSource interface.
+func (mrc *MultiplexedRowChannel) OutputTypes() []sqlbase.ColumnType {
 	return mrc.rowChan.types
 }
 
@@ -609,8 +609,8 @@ func (rb *RowBuffer) ProducerDone() {
 	rb.ProducerClosed = true
 }
 
-// Types is part of the RowSource interface.
-func (rb *RowBuffer) Types() []sqlbase.ColumnType {
+// OutputTypes is part of the RowSource interface.
+func (rb *RowBuffer) OutputTypes() []sqlbase.ColumnType {
 	if rb.types == nil {
 		panic("not initialized")
 	}

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -67,7 +67,7 @@ func newDistinct(
 		d.distinctCols.Add(int(col))
 	}
 
-	d.types = input.Types()
+	d.types = input.OutputTypes()
 	if err := d.init(post, d.types, flowCtx, output); err != nil {
 		return nil, err
 	}
@@ -160,11 +160,6 @@ func (d *distinct) producerMeta(err error) ProducerMetadata {
 		d.close()
 	}
 	return meta
-}
-
-// Types is part of the RowSource interface.
-func (d *distinct) Types() []sqlbase.ColumnType {
-	return d.OutputTypes()
 }
 
 // Next is part of the RowSource interface.

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -132,8 +132,8 @@ func newHashJoiner(
 	}
 	if err := h.joinerBase.init(
 		flowCtx,
-		leftSource.Types(),
-		rightSource.Types(),
+		leftSource.OutputTypes(),
+		rightSource.OutputTypes(),
 		spec.Type,
 		spec.OnExpr,
 		spec.LeftEqColumns,
@@ -189,8 +189,10 @@ func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 
 	evalCtx := h.flowCtx.NewEvalCtx()
-	h.rows[leftSide].initWithMon(nil /* ordering */, h.leftSource.Types(), evalCtx, rowContainerMon)
-	h.rows[rightSide].initWithMon(nil /* ordering */, h.rightSource.Types(), evalCtx, rowContainerMon)
+	h.rows[leftSide].initWithMon(
+		nil /* ordering */, h.leftSource.OutputTypes(), evalCtx, rowContainerMon)
+	h.rows[rightSide].initWithMon(
+		nil /* ordering */, h.rightSource.OutputTypes(), evalCtx, rowContainerMon)
 	defer h.rows[leftSide].Close(ctx)
 	defer h.rows[rightSide].Close(ctx)
 

--- a/pkg/sql/distsqlrun/input_sync.go
+++ b/pkg/sql/distsqlrun/input_sync.go
@@ -93,8 +93,8 @@ type orderedSynchronizer struct {
 
 var _ RowSource = &orderedSynchronizer{}
 
-// Types is part of the RowSource interface.
-func (s *orderedSynchronizer) Types() []sqlbase.ColumnType {
+// OutputTypes is part of the RowSource interface.
+func (s *orderedSynchronizer) OutputTypes() []sqlbase.ColumnType {
 	return s.types
 }
 
@@ -346,7 +346,7 @@ func makeOrderedSync(
 	s := &orderedSynchronizer{
 		state:    notInitialized,
 		sources:  make([]srcInfo, len(sources)),
-		types:    sources[0].Types(),
+		types:    sources[0].OutputTypes(),
 		heap:     make([]srcIdx, 0, len(sources)),
 		ordering: ordering,
 		evalCtx:  evalCtx,

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -65,7 +65,7 @@ func newJoinReader(
 		flowCtx:    flowCtx,
 		desc:       spec.Table,
 		input:      input,
-		inputTypes: input.Types(),
+		inputTypes: input.OutputTypes(),
 	}
 
 	types := make([]sqlbase.ColumnType, len(spec.Table.Columns))

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -62,7 +62,9 @@ func newMergeJoiner(
 		rightSource: rightSource,
 	}
 	// TODO: Adapt MergeJoiner to new joinerBase constructor.
-	err := m.joinerBase.init(flowCtx, leftSource.Types(), rightSource.Types(), spec.Type, spec.OnExpr, nil, nil, 0, post, output)
+	err := m.joinerBase.init(flowCtx,
+		leftSource.OutputTypes(), rightSource.OutputTypes(),
+		spec.Type, spec.OnExpr, nil, nil, 0, post, output)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -385,7 +385,7 @@ func newNoopProcessor(
 	flowCtx *FlowCtx, input RowSource, post *PostProcessSpec, output RowReceiver,
 ) (*noopProcessor, error) {
 	n := &noopProcessor{flowCtx: flowCtx, input: input}
-	if err := n.init(post, input.Types(), flowCtx, output); err != nil {
+	if err := n.init(post, input.OutputTypes(), flowCtx, output); err != nil {
 		return nil, err
 	}
 	return n, nil

--- a/pkg/sql/distsqlrun/processors_test.go
+++ b/pkg/sql/distsqlrun/processors_test.go
@@ -256,7 +256,7 @@ func TestPostProcess(t *testing.T) {
 			var out ProcOutputHelper
 			evalCtx := tree.NewTestingEvalContext()
 			defer evalCtx.Stop(context.Background())
-			if err := out.Init(&tc.post, inBuf.Types(), evalCtx, outBuf); err != nil {
+			if err := out.Init(&tc.post, inBuf.OutputTypes(), evalCtx, outBuf); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -80,7 +80,7 @@ func newSampleAggregator(
 	s := &sampleAggregator{
 		flowCtx:      flowCtx,
 		input:        input,
-		inTypes:      input.Types(),
+		inTypes:      input.OutputTypes(),
 		tableID:      spec.TableID,
 		sampledCols:  spec.SampledColumnIDs,
 		sketches:     make([]sketchInfo, len(spec.Sketches)),

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -91,7 +91,7 @@ func newSamplerProcessor(
 
 	s.sr.Init(int(spec.SampleSize))
 
-	inTypes := input.Types()
+	inTypes := input.OutputTypes()
 	outTypes := make([]sqlbase.ColumnType, 0, len(inTypes)+5)
 
 	// First columns are the same as the input.

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -68,7 +68,7 @@ func newSorter(
 		count:       count,
 		tempStorage: flowCtx.TempStorage,
 	}
-	if err := s.init(post, input.Types(), flowCtx, output); err != nil {
+	if err := s.init(post, input.OutputTypes(), flowCtx, output); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -113,7 +113,7 @@ func (s *sorter) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 		rowContainerMon = &limitedMon
 	}
-	sv.initWithMon(s.ordering, s.rawInput.Types(), s.flowCtx.NewEvalCtx(), rowContainerMon)
+	sv.initWithMon(s.ordering, s.rawInput.OutputTypes(), s.flowCtx.NewEvalCtx(), rowContainerMon)
 	// Construct the optimal sorterStrategy.
 	var ss sorterStrategy
 	if s.matchLen == 0 {

--- a/pkg/sql/distsqlrun/stream_group_accumulator.go
+++ b/pkg/sql/distsqlrun/stream_group_accumulator.go
@@ -41,7 +41,7 @@ func makeStreamGroupAccumulator(
 ) streamGroupAccumulator {
 	return streamGroupAccumulator{
 		src:      src,
-		types:    src.Types(),
+		types:    src.OutputTypes(),
 		ordering: ordering,
 	}
 }

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -328,11 +328,6 @@ func (tr *tableReader) producerMeta(err error) ProducerMetadata {
 	return ProducerMetadata{}
 }
 
-// Types is part of the RowSource interface.
-func (tr *tableReader) Types() []sqlbase.ColumnType {
-	return tr.OutputTypes()
-}
-
 // Next is part of the RowSource interface.
 func (tr *tableReader) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 	if !tr.started {

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -57,8 +57,8 @@ func NewRepeatableRowSource(
 	return &RepeatableRowSource{rows: rows, types: types}
 }
 
-// Types is part of the RowSource interface.
-func (r *RepeatableRowSource) Types() []sqlbase.ColumnType {
+// OutputTypes is part of the RowSource interface.
+func (r *RepeatableRowSource) OutputTypes() []sqlbase.ColumnType {
 	return r.types
 }
 

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -109,11 +109,6 @@ func (v *valuesProcessor) producerMeta(err error) ProducerMetadata {
 	return meta
 }
 
-// Types is part of the RowSource interface.
-func (v *valuesProcessor) Types() []sqlbase.ColumnType {
-	return v.OutputTypes()
-}
-
 // Next is part of the RowSource interface.
 func (v *valuesProcessor) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 	if !v.started {


### PR DESCRIPTION
This unifies the name of this method between `RowSource` and `Processor`
and thus gives us an implementation of this method for every `Processor`
during the transition to make processors implement `RowSource`.

Release note: None