### PR TITLE
storage: refactor consistency check runner

### DIFF
--- a/pkg/storage/api.pb.go
+++ b/pkg/storage/api.pb.go
@@ -83,6 +83,9 @@ type CollectChecksumResponse struct {
 	Checksum []byte `protobuf:"bytes,1,opt,name=checksum,proto3" json:"checksum,omitempty"`
 	// snapshot is set if the roachpb.ComputeChecksumRequest had snapshot = true
 	// and the response checksum is different from the request checksum.
+	//
+	// TODO(tschottdorf): with larger ranges, this is no longer tenable.
+	// See https://github.com/cockroachdb/cockroach/issues/21128.
 	Snapshot *cockroach_roachpb1.RaftSnapshotData `protobuf:"bytes,2,opt,name=snapshot" json:"snapshot,omitempty"`
 }
 

--- a/pkg/storage/api.proto
+++ b/pkg/storage/api.proto
@@ -45,6 +45,9 @@ message CollectChecksumResponse {
   bytes checksum = 1;
   // snapshot is set if the roachpb.ComputeChecksumRequest had snapshot = true
   // and the response checksum is different from the request checksum.
+  //
+  // TODO(tschottdorf): with larger ranges, this is no longer tenable.
+  // See https://github.com/cockroachdb/cockroach/issues/21128.
   roachpb.RaftSnapshotData snapshot = 2;
 }
 

--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3357,9 +3357,10 @@ func TestCheckConsistencyMultiStore(t *testing.T) {
 	}, &checkArgs); err != nil {
 		t.Fatal(err)
 	}
+
 }
 
-func TestCheckInconsistent(t *testing.T) {
+func TestCheckConsistencyInconsistent(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sc := storage.TestStoreConfig(nil)

--- a/pkg/storage/raft_transport.go
+++ b/pkg/storage/raft_transport.go
@@ -26,6 +26,7 @@ import (
 	"unsafe"
 
 	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/pkg/errors"
 	"github.com/rubyist/circuitbreaker"
 	"google.golang.org/grpc"
 
@@ -165,7 +166,10 @@ type RaftTransport struct {
 // NewDummyRaftTransport returns a dummy raft transport for use in tests which
 // need a non-nil raft transport that need not function.
 func NewDummyRaftTransport(st *cluster.Settings) *RaftTransport {
-	return NewRaftTransport(log.AmbientContext{Tracer: st.Tracer}, st, nil, nil, nil)
+	resolver := func(roachpb.NodeID) (net.Addr, error) {
+		return nil, errors.New("dummy resolver")
+	}
+	return NewRaftTransport(log.AmbientContext{Tracer: st.Tracer}, st, resolver, nil, nil)
 }
 
 // NewRaftTransport creates a new RaftTransport.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -178,18 +178,15 @@ type proposalResult struct {
 
 // ReplicaChecksum contains progress on a replica checksum computation.
 type ReplicaChecksum struct {
+	CollectChecksumResponse
 	// started is true if the checksum computation has started.
 	started bool
-	// Computed checksum. This is set to nil on error.
-	checksum []byte
 	// If gcTimestamp is nonzero, GC this checksum after gcTimestamp. gcTimestamp
 	// is zero if and only if the checksum computation is in progress.
 	gcTimestamp time.Time
 	// This channel is closed after the checksum is computed, and is used
 	// as a notification.
 	notify chan struct{}
-	// Some debug output that can be added to the CollectChecksumResponse.
-	snapshot *roachpb.RaftSnapshotData
 }
 
 type atomicDescString struct {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1098,15 +1098,15 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	minIndex := status.Commit
 	for _, rep := range r.mu.state.Desc.Replicas {
 		// Only consider followers that that have "healthy" RPC connections.
-		if r.store.cfg.Transport.resolver != nil {
-			addr, err := r.store.cfg.Transport.resolver(rep.NodeID)
-			if err != nil {
-				continue
-			}
-			if err := r.store.cfg.Transport.rpcContext.ConnHealth(addr.String()); err != nil {
-				continue
-			}
+
+		addr, err := r.store.cfg.Transport.resolver(rep.NodeID)
+		if err != nil {
+			continue
 		}
+		if err := r.store.cfg.Transport.rpcContext.ConnHealth(addr.String()); err != nil {
+			continue
+		}
+
 		// Only consider followers that are active.
 		if !r.isFollowerActiveLocked(ctx, rep.ReplicaID) {
 			continue

--- a/pkg/storage/stores_server.go
+++ b/pkg/storage/stores_server.go
@@ -64,12 +64,16 @@ func (is Server) CollectChecksum(
 			if err != nil {
 				return err
 			}
-			resp.Checksum = c.checksum
-			if !bytes.Equal(req.Checksum, c.checksum) {
+			ccr := c.CollectChecksumResponse
+			if !bytes.Equal(req.Checksum, ccr.Checksum) {
 				log.Errorf(ctx, "consistency check failed on range r%d: expected checksum %x, got %x",
-					req.RangeID, req.Checksum, c.checksum)
-				resp.Snapshot = c.snapshot
+					req.RangeID, req.Checksum, ccr.Checksum)
+				// Leave resp.Snapshot alone so that the caller will receive what's
+				// in it (if anything).
+			} else {
+				ccr.Snapshot = nil
 			}
+			resp = &ccr
 			return nil
 		})
 	return resp, err


### PR DESCRIPTION
In preparation for checking stats during consistency checker runs,
separate out the phases of obtaining results and acting upon them.

Special care was taken to make the code more symmetrical in minimizing
the role of the local replica. This makes the code more transparent.

Release note: None