### PR TITLE
sql: fix not-null column deduction from tuple operations

### DIFF
--- a/pkg/sql/expr_filter_test.go
+++ b/pkg/sql/expr_filter_test.go
@@ -224,7 +224,7 @@ func TestExtractNotNullConstraints(t *testing.T) {
 		{`a = 1 OR b = 2`, []int{}},
 		{`(a = 1 AND b = 2) OR (b = 3 AND j = 4)`, []int{1}},
 		{`(a, b) = (1, 2)`, []int{0, 1}},
-		{`(a, b) > (1, 2)`, []int{0, 1}},
+		{`(a, b) > (1, 2)`, []int{}},
 		{`a IN (b,j)`, []int{0}},
 		{`(a, b) IN ((1,j))`, []int{0, 1}},
 		{`a NOT IN (b,j)`, []int{0}},

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -310,11 +310,11 @@ NULL  3     3
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+render     0  render  ·         ·                       (u, v, w)  +u,+v,+w
  │         0  ·       render 0  test.uvw.u              ·          ·
  │         0  ·       render 1  test.uvw.v              ·          ·
  │         0  ·       render 2  test.uvw.w              ·          ·
- └── scan  1  scan    ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ └── scan  1  scan    ·         ·                       (u, v, w)  +u,+v,+w
 ·          1  ·       table     uvw@uvw_u_v_w_idx       ·          ·
 ·          1  ·       spans     /1/2/3-                 ·          ·
 ·          1  ·       filter    (u, v, w) >= (1, 2, 3)  ·          ·
@@ -363,11 +363,11 @@ SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                      (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+render     0  render  ·         ·                      (u, v, w)  +u,+v,+w
  │         0  ·       render 0  test.uvw.u             ·          ·
  │         0  ·       render 1  test.uvw.v             ·          ·
  │         0  ·       render 2  test.uvw.w             ·          ·
- └── scan  1  scan    ·         ·                      (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ └── scan  1  scan    ·         ·                      (u, v, w)  +u,+v,+w
 ·          1  ·       table     uvw@uvw_u_v_w_idx      ·          ·
 ·          1  ·       spans     /2/1/2-                ·          ·
 ·          1  ·       filter    (u, v, w) > (2, 1, 1)  ·          ·
@@ -405,11 +405,11 @@ SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+render     0  render  ·         ·                       (u, v, w)  +u,+v,+w
  │         0  ·       render 0  test.uvw.u              ·          ·
  │         0  ·       render 1  test.uvw.v              ·          ·
  │         0  ·       render 2  test.uvw.w              ·          ·
- └── scan  1  scan    ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ └── scan  1  scan    ·         ·                       (u, v, w)  +u,+v,+w
 ·          1  ·       table     uvw@uvw_u_v_w_idx       ·          ·
 ·          1  ·       spans     /!NULL-/2/3/2           ·          ·
 ·          1  ·       filter    (u, v, w) <= (2, 3, 1)  ·          ·
@@ -446,11 +446,11 @@ SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                      (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+render     0  render  ·         ·                      (u, v, w)  +u,+v,+w
  │         0  ·       render 0  test.uvw.u             ·          ·
  │         0  ·       render 1  test.uvw.v             ·          ·
  │         0  ·       render 2  test.uvw.w             ·          ·
- └── scan  1  scan    ·         ·                      (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ └── scan  1  scan    ·         ·                      (u, v, w)  +u,+v,+w
 ·          1  ·       table     uvw@uvw_u_v_w_idx      ·          ·
 ·          1  ·       spans     /!NULL-/2/2/2          ·          ·
 ·          1  ·       filter    (u, v, w) < (2, 2, 2)  ·          ·
@@ -483,11 +483,11 @@ SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+render     0  render  ·         ·                       (u, v, w)  +u,+v,+w
  │         0  ·       render 0  test.uvw.u              ·          ·
  │         0  ·       render 1  test.uvw.v              ·          ·
  │         0  ·       render 2  test.uvw.w              ·          ·
- └── scan  1  scan    ·         ·                       (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ └── scan  1  scan    ·         ·                       (u, v, w)  +u,+v,+w
 ·          1  ·       table     uvw@uvw_u_v_w_idx       ·          ·
 ·          1  ·       spans     /!NULL-                 ·          ·
 ·          1  ·       filter    (u, v, w) != (1, 2, 3)  ·          ·
@@ -541,11 +541,11 @@ SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                          (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+render     0  render  ·         ·                          (u, v, w)  +u,+v,+w
  │         0  ·       render 0  test.uvw.u                 ·          ·
  │         0  ·       render 1  test.uvw.v                 ·          ·
  │         0  ·       render 2  test.uvw.w                 ·          ·
- └── scan  1  scan    ·         ·                          (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ └── scan  1  scan    ·         ·                          (u, v, w)  +u,+v,+w
 ·          1  ·       table     uvw@uvw_u_v_w_idx          ·          ·
 ·          1  ·       spans     ALL                        ·          ·
 ·          1  ·       filter    (u, v, w) >= (1, NULL, 3)  ·          ·
@@ -589,11 +589,11 @@ SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                         (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+render     0  render  ·         ·                         (u, v, w)  +u,+v,+w
  │         0  ·       render 0  test.uvw.u                ·          ·
  │         0  ·       render 1  test.uvw.v                ·          ·
  │         0  ·       render 2  test.uvw.w                ·          ·
- └── scan  1  scan    ·         ·                         (u, v, w)  u!=NULL; v!=NULL; w!=NULL; +u,+v,+w
+ └── scan  1  scan    ·         ·                         (u, v, w)  +u,+v,+w
 ·          1  ·       table     uvw@uvw_u_v_w_idx         ·          ·
 ·          1  ·       spans     ALL                       ·          ·
 ·          1  ·       filter    (u, v, w) < (2, NULL, 3)  ·          ·


### PR DESCRIPTION
We were incorrectly inferring that all members of two tuples in a comparison
must be not NULL; this is only true for EQ.

Release note: None