### PR TITLE
cherry-pick 1.1: cli/sql: avoid check_syntax on client/server version mismatch

### DIFF
--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/chzyer/readline"
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -629,7 +630,14 @@ func (c *cliState) doStart(nextState cliStateEnum) cliStateEnum {
 
 		fmt.Println("#\n# Enter \\? for a brief introduction.\n#")
 
-		c.checkSyntax = true
+		if c.conn.serverVersion != build.GetInfo().Tag {
+			fmt.Fprintln(stderr,
+				"warning: client-side syntax checking disabled because versions don't match.\n"+
+					"override if desired with \\set check_syntax.")
+			c.checkSyntax = false
+		} else {
+			c.checkSyntax = true
+		}
 		c.normalizeHistory = true
 		c.errExit = false
 		c.smartPrompt = true


### PR DESCRIPTION
This is a toned down cherry-pick of #21119, as advised by #19445.

Fixes #19445.

Release note (cli change): client-side syntax checking is now
only automatically enabled if the client and server are running
the same version of CockroachDB. This restriction will be
lifted in CockroachDB 2.0.

cc @cockroachdb/release 