### PR TITLE
sql/distsqlrun: fix drain and forward metadata mode of Run

### DIFF
--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -157,7 +157,6 @@ func Run(ctx context.Context, src RowSource, dst RowReceiver) {
 			case NeedMoreRows:
 				continue
 			case DrainRequested:
-				src.ConsumerDone()
 				row = nil
 			case ConsumerClosed:
 				src.ConsumerClosed()


### PR DESCRIPTION
Fixes #21139

Release note: None