### PR TITLE
sql: ensure that hidden columns are effectively hidden

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain_distsql
+++ b/pkg/sql/logictest/testdata/logic_test/explain_distsql
@@ -8,11 +8,12 @@
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)
 
-# Verify the EXPLAIN (DISTSQL) schema.
+# Verify that EXPLAIN (DISTSQL) hides the JSON column by default (#21089)
 query BT colnames
-SELECT * FROM [EXPLAIN (DISTSQL) SELECT * FROM kv] WHERE false
+EXPLAIN (DISTSQL) VALUES (1)
 ----
-Automatic URL
+Automatic  URL
+true       https://cockroachdb.github.io/distsqlplan/decode.html?eJyMjzFrwzAQhff-CvOmFjTYHTV289KWDFmCBiEdjomjMzoJAkb_PVgaQoZAxvee9H3chsCefu2VBPqEAUZhjexIhONetQejv0H3CnNYc9pro-A4EvSGNKeFoHG0SyaBgqdk56Xyvruf7nPo3DmHi3zBFAXO6cGQZCeC7ot633MgWTkIPZlek40C-YnaLcI5OvqP7Kqmxb_6rxaeJLV1aGEMbSqmfNwDAAD__7pEYro=
 
 # Check the JSON column is still there, albeit hidden.
 query T colnames


### PR DESCRIPTION
CockroachDB supports "hidden columns" in logical plans -- columns that
can be selected explicitly if their name is known, but that are
otherwise invisible: not visible to star expansion, and (in principle)
*not visible to clients* except in the output of EXPLAIN.

This was true for the longest time, but became broken at some point
during summer 2017 when we introduced result streaming: values for
hidden columns in the top-level of queries became erroneously streamed
alongside those for visible columns. This escaped testing because we
didn't have tests for this.

This patch corrects the issue by ensuring that a renderNode
(projection) is added at the top of the logical plan to only render
visible columns if there are any hidden columns underneath. The
solution uses an alteration of the logical plan (as opposed to
e.g. special code in the executor/pgwire) so that the hidden columns
can be properly optimized away from the logical plans if they are not
rendered in the result.

Release note (bug fix): the "JSON" column in the output of
EXPLAIN(DISTSQL) is now properly hidden by default. It can be shown
using `SELECT *, JSON FROM [EXPLAIN(DISTSQL) ...]`.

Fixes  #21089.