### PR TITLE
cloud: Use advertise-host instead of host in Kubernetes configs

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -211,7 +211,7 @@ spec:
           - "-ecx"
           # The use of qualified `hostname -f` is crucial:
           # Other nodes aren't able to look up the unqualified hostname.
-          - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --host $(hostname -f) --http-host 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
+          - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --advertise-host $(hostname -f) --http-host 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -107,7 +107,7 @@ spec:
           - "-ecx"
           # The use of qualified `hostname -f` is crucial:
           # Other nodes aren't able to look up the unqualified hostname.
-          - "exec /cockroach/cockroach start --logtostderr --insecure --host $(hostname -f) --http-host 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
+          - "exec /cockroach/cockroach start --logtostderr --insecure --advertise-host $(hostname -f) --http-host 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60


### PR DESCRIPTION
This makes it possible to port-forward to the pods, as has been
requested in a couple stack overflow questions (e.g. https://stackoverflow.com/questions/44403931/how-can-i-connect-to-cockroachdb-from-outside-the-kubernetes-cluster/44404252, https://stackoverflow.com/questions/48037973/exposing-cockroachdb-on-kubernetes-to-public-ip/48063719).

Release note: None