### PR TITLE
ui: Say "Node Status" instead of "Node Liveness" in overview

### DIFF
--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -83,7 +83,7 @@ function renderNodeLiveness(props: NodeLivenessProps) {
     { "alert": deadNodes > 0 },
   );
   return [
-    <h3 className="node-liveness cluster-summary__title">Node Liveness</h3>,
+    <h3 className="node-liveness cluster-summary__title">Node Status</h3>,
     <div className="node-liveness cluster-summary__metric live-nodes">{ liveNodes }</div>,
     <div className="node-liveness cluster-summary__label live-nodes">Live<br />Nodes</div>,
     <div className={suspectClasses}>{ suspectNodes }</div>,

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -86,7 +86,7 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Node Liveness Heartbeat Latency: 99th percentile"
+    <LineGraph title="Node Heartbeat Latency: 99th percentile"
       tooltip={`The 99th percentile of latency to heartbeat a node's internal liveness record over a 1 minute period.
                               Values are displayed individually for each node.`}>
       <Axis units={AxisUnits.Duration} label="heartbeat latency">
@@ -104,7 +104,7 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Node Liveness Heartbeat Latency: 90th percentile"
+    <LineGraph title="Node Heartbeat Latency: 90th percentile"
       tooltip={`The 90th percentile of latency to heartbeat a node's internal liveness record over a 1 minute period.
                               Values are displayed individually for each node.`}>
       <Axis units={AxisUnits.Duration} label="heartbeat latency">


### PR DESCRIPTION
"Status" is a more widely-understood word.

Now:
![screen shot 2018-01-02 at 1 31 58 pm](https://user-images.githubusercontent.com/7341/34495040-5a868e50-efc1-11e7-8891-302983b68f6a.png)

Suggestion by @nstewart in Slack: https://cockroachlabs.slack.com/archives/C2BN46C8L/p1514479614000219

Release note: None