### PR TITLE
sql: fix EXPLAIN with placeholders

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -60,6 +60,17 @@ EXPLAIN (PLAN,DISTSQL) SELECT 1
 statement error unsupported EXPLAIN option
 EXPLAIN (PLAN,UNKNOWN) SELECT 1
 
+statement error could not determine data type of placeholder \$1
+EXPLAIN (TYPES) SELECT $1
+
+query TITTTTT colnames
+EXPLAIN (TYPES) SELECT $1::INT
+----
+Tree           Level  Type      Field     Description               Columns          Ordering
+render         0      render    ·         ·                         ("$1::INT" int)  "$1::INT"=CONST
+│             0      ·         render 0  (($1)[string]::INT)[int]  ·                ·
+└── emptyrow  1      emptyrow  ·         ·                         ("$1::INT" int)  "$1::INT"=CONST
+
 # Ensure that tracing results are sorted after gathering
 query TITTTTT
 EXPLAIN (METADATA) SHOW TRACE FOR SELECT 1

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -203,11 +203,12 @@ func FormatNode(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
 	if f.disambiguateDatumTypes {
 		var typ types.T
 		if d, isDatum := n.(Datum); isDatum {
-			if d.AmbiguousFormat() {
+			if p, isPlaceholder := d.(*Placeholder); isPlaceholder {
+				// p.typ will be nil if the placeholder has not been type-checked yet.
+				typ = p.typ
+			} else if d.AmbiguousFormat() {
 				typ = d.ResolvedType()
 			}
-		} else if p, isPlaceholder := n.(*Placeholder); isPlaceholder {
-			typ = p.typ
 		}
 		if typ != nil {
 			buf.WriteString(":::")


### PR DESCRIPTION
Fixes #21166.

Previously, an explain query with a placeholder would panic. This change
fixes this.

Release note (bug fix): EXPLAIN queries with placeholders no longer
panic.