### PR TITLE
sql,sqlccl: allow all repartitions to take the fast path

### DIFF
--- a/pkg/ccl/sqlccl/partition.go
+++ b/pkg/ccl/sqlccl/partition.go
@@ -15,158 +15,11 @@
 package sqlccl
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/intervalccl"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/pkg/errors"
 )
-
-type repartitioningSide string
-
-const (
-	repartitioningBefore repartitioningSide = "old"
-	repartitioningAfter  repartitioningSide = "new"
-)
-
-// partitionLeafSpans returns the spans covered by all partitions which are not
-// subpartitioned, which we call a "leaf covering".
-func partitionLeafSpans(
-	a *sqlbase.DatumAlloc,
-	tableDesc *sqlbase.TableDescriptor,
-	idxDesc *sqlbase.IndexDescriptor,
-	partDesc *sqlbase.PartitioningDescriptor,
-	prefixDatums []tree.Datum,
-	payload interface{},
-) ([]intervalccl.Covering, error) {
-	var coverings []intervalccl.Covering
-
-	if len(partDesc.List) > 0 {
-		// The span for `(1, DEFAULT)` overlaps with `(1, 2)` and
-		// intervalccl.Covering is required to be non-overlapping so we have be
-		// tricky here. Because of the partitioning validation, we're guaranteed
-		// that all entries in a list partitioning with the same number of
-		// DEFAULTs are non-overlapping. So, bucket the `intervalccl.Range`s by
-		// the number of non-DEFAULT columns.
-		listCoverings := make([]intervalccl.Covering, int(partDesc.NumColumns)+1)
-		for _, p := range partDesc.List {
-			for _, valueEncBuf := range p.Values {
-				datums, keyPrefix, err := sqlbase.TranslateValueEncodingToSpan(
-					a, tableDesc, idxDesc, partDesc, valueEncBuf, prefixDatums)
-				if err != nil {
-					return nil, err
-				}
-				newPrefixDatums := append(prefixDatums, datums...)
-				if p.Subpartitioning.NumColumns > 0 {
-					descendentCoverings, err := partitionLeafSpans(
-						a, tableDesc, idxDesc, &p.Subpartitioning, newPrefixDatums, payload)
-					if err != nil {
-						return nil, err
-					}
-					if len(descendentCoverings) > 0 {
-						coverings = append(coverings, descendentCoverings...)
-						continue
-					}
-				}
-				listCoverings[len(datums)] = append(listCoverings[len(datums)], intervalccl.Range{
-					Start: keyPrefix, End: roachpb.Key(keyPrefix).PrefixEnd(), Payload: payload,
-				})
-			}
-		}
-		for _, covering := range listCoverings {
-			if len(covering) > 0 {
-				coverings = append(coverings, covering)
-			}
-		}
-	} else if len(partDesc.Range) > 0 {
-		lastEndKey := sqlbase.MakeIndexKeyPrefix(tableDesc, idxDesc.ID)
-		if len(prefixDatums) > 0 {
-			colMap := make(map[sqlbase.ColumnID]int, len(prefixDatums))
-			for i := range prefixDatums {
-				colMap[idxDesc.ColumnIDs[i]] = i
-			}
-
-			var err error
-			lastEndKey, _, err = sqlbase.EncodePartialIndexKey(
-				tableDesc, idxDesc, len(prefixDatums), colMap, prefixDatums, lastEndKey)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		var covering intervalccl.Covering
-		for _, p := range partDesc.Range {
-			_, endKey, err := sqlbase.TranslateValueEncodingToSpan(
-				a, tableDesc, idxDesc, partDesc, p.UpperBound, prefixDatums)
-			if err != nil {
-				return nil, err
-			}
-
-			covering = append(covering, intervalccl.Range{
-				Start: lastEndKey, End: endKey, Payload: payload,
-			})
-			lastEndKey = endKey
-		}
-		coverings = append(coverings, covering)
-	} else {
-		// An unpartitioned index essentially has one anonymous DEFAULT
-		// partition covering the whole thing.
-		span := tableDesc.IndexSpan(idxDesc.ID)
-		coverings = append(coverings, intervalccl.Covering{{
-			Start: span.Key, End: span.EndKey, Payload: payload,
-		}})
-	}
-
-	return coverings, nil
-}
-
-// RepartitioningFastPathAvailable returns true when the schema change to
-// validate existing data can be skipped.
-//
-// Each partitioned index guarantees that all rows in that index belong to one
-// of its partitions. Certain repartitionings (removing partitioning entirely, a
-// LIST partitioning that is a superset of the previous partitioning, etc) can
-// assume the the existing data meets this guarantee without checking it via a
-// sort of "inductive proof" logic.
-func RepartitioningFastPathAvailable(
-	oldTableDesc, newTableDesc *sqlbase.TableDescriptor,
-) (bool, error) {
-	a := &sqlbase.DatumAlloc{}
-	var emptyPrefix []tree.Datum
-	var coverings []intervalccl.Covering
-
-	if err := oldTableDesc.ForeachNonDropIndex(func(idxDesc *sqlbase.IndexDescriptor) error {
-		partitionCoverings, err := partitionLeafSpans(
-			a, newTableDesc, idxDesc, &idxDesc.Partitioning, emptyPrefix, repartitioningBefore)
-		coverings = append(coverings, partitionCoverings...)
-		return err
-	}); err != nil {
-		return false, err
-	}
-
-	if err := newTableDesc.ForeachNonDropIndex(func(idxDesc *sqlbase.IndexDescriptor) error {
-		partitionCoverings, err := partitionLeafSpans(
-			a, newTableDesc, idxDesc, &idxDesc.Partitioning, emptyPrefix, repartitioningAfter)
-		coverings = append(coverings, partitionCoverings...)
-		return err
-	}); err != nil {
-		return false, err
-	}
-
-	ranges := intervalccl.OverlapCoveringMerge(coverings)
-
-	for _, r := range ranges {
-		payloads := r.Payload.([]interface{})
-		// Because the old partitions are before the new partitions in the input
-		// to OverlapCoveringMerge, if the last thing in the payload is
-		// repartitioningBefore, then we don't have the fast path.
-		if p := payloads[len(payloads)-1].(repartitioningSide); p == repartitioningBefore {
-			return false, nil
-		}
-	}
-	return true, nil
-}
 
 // selectPartitionExprs constructs an expression for selecting all rows in the
 // given partitions.
@@ -367,8 +220,4 @@ func selectPartitionExprsByName(
 	}
 
 	return nil
-}
-
-func init() {
-	sql.RepartitioningFastPathAvailable = RepartitioningFastPathAvailable
 }

--- a/pkg/ccl/sqlccl/partition_test.go
+++ b/pkg/ccl/sqlccl/partition_test.go
@@ -99,9 +99,8 @@ type partitioningTest struct {
 }
 
 type repartitioningTest struct {
-	index      string
-	old, new   partitioningTest
-	isFastPath bool
+	index    string
+	old, new partitioningTest
 }
 
 // parse fills in the various fields of `partitioningTest.parsed`.
@@ -762,90 +761,76 @@ func allPartitioningTests(rng *rand.Rand) []partitioningTest {
 func allRepartitioningTests(partitioningTests []partitioningTest) ([]repartitioningTest, error) {
 	tests := []repartitioningTest{
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `unpartitioned`},
-			new:        partitioningTest{name: `unpartitioned`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `unpartitioned`},
+			new:   partitioningTest{name: `unpartitioned`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `unpartitioned`},
-			new:        partitioningTest{name: `single col list partitioning`},
-			isFastPath: false,
+			index: `primary`,
+			old:   partitioningTest{name: `unpartitioned`},
+			new:   partitioningTest{name: `single col list partitioning`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `unpartitioned`},
-			new:        partitioningTest{name: `single col list partitioning - DEFAULT`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `unpartitioned`},
+			new:   partitioningTest{name: `single col list partitioning - DEFAULT`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `unpartitioned`},
-			new:        partitioningTest{name: `single col range partitioning`},
-			isFastPath: false,
+			index: `primary`,
+			old:   partitioningTest{name: `unpartitioned`},
+			new:   partitioningTest{name: `single col range partitioning`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `unpartitioned`},
-			new:        partitioningTest{name: `single col range partitioning - MAXVALUE`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `unpartitioned`},
+			new:   partitioningTest{name: `single col range partitioning - MAXVALUE`},
 		},
 
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `single col list partitioning`},
-			new:        partitioningTest{name: `single col list partitioning - DEFAULT`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `single col list partitioning`},
+			new:   partitioningTest{name: `single col list partitioning - DEFAULT`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `single col list partitioning - DEFAULT`},
-			new:        partitioningTest{name: `single col list partitioning`},
-			isFastPath: false,
+			index: `primary`,
+			old:   partitioningTest{name: `single col list partitioning - DEFAULT`},
+			new:   partitioningTest{name: `single col list partitioning`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `multi col list partitioning`},
-			new:        partitioningTest{name: `multi col list partitioning - DEFAULT`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `multi col list partitioning`},
+			new:   partitioningTest{name: `multi col list partitioning - DEFAULT`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `multi col list partitioning - DEFAULT`},
-			new:        partitioningTest{name: `multi col list partitioning`},
-			isFastPath: false,
+			index: `primary`,
+			old:   partitioningTest{name: `multi col list partitioning - DEFAULT`},
+			new:   partitioningTest{name: `multi col list partitioning`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `multi col list partitioning - DEFAULT`},
-			new:        partitioningTest{name: `multi col list partitioning - DEFAULT DEFAULT`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `multi col list partitioning - DEFAULT`},
+			new:   partitioningTest{name: `multi col list partitioning - DEFAULT DEFAULT`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `multi col list partitioning - DEFAULT DEFAULT`},
-			new:        partitioningTest{name: `multi col list partitioning - DEFAULT`},
-			isFastPath: false,
+			index: `primary`,
+			old:   partitioningTest{name: `multi col list partitioning - DEFAULT DEFAULT`},
+			new:   partitioningTest{name: `multi col list partitioning - DEFAULT`},
 		},
 
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `single col range partitioning`},
-			new:        partitioningTest{name: `single col range partitioning - MAXVALUE`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `single col range partitioning`},
+			new:   partitioningTest{name: `single col range partitioning - MAXVALUE`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `single col range partitioning - MAXVALUE`},
-			new:        partitioningTest{name: `single col range partitioning`},
-			isFastPath: false,
+			index: `primary`,
+			old:   partitioningTest{name: `single col range partitioning - MAXVALUE`},
+			new:   partitioningTest{name: `single col range partitioning`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `multi col range partitioning`},
-			new:        partitioningTest{name: `multi col range partitioning - MAXVALUE`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `multi col range partitioning`},
+			new:   partitioningTest{name: `multi col range partitioning - MAXVALUE`},
 		},
 		{
 			// NB: Most of these fast path tests are false one way and true the
@@ -853,87 +838,74 @@ func allRepartitioningTests(partitioningTests []partitioningTest) ([]repartition
 			// The `multi col range partitioning - MAXVALUE` partition test has
 			// been constructed to cover exactly the same set of values so we
 			// can have a true<->true test case as well.
-			index:      `primary`,
-			old:        partitioningTest{name: `multi col range partitioning - MAXVALUE`},
-			new:        partitioningTest{name: `multi col range partitioning`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `multi col range partitioning - MAXVALUE`},
+			new:   partitioningTest{name: `multi col range partitioning`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `multi col range partitioning - MAXVALUE`},
-			new:        partitioningTest{name: `multi col range partitioning - MAXVALUE MAXVALUE`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `multi col range partitioning - MAXVALUE`},
+			new:   partitioningTest{name: `multi col range partitioning - MAXVALUE MAXVALUE`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `multi col range partitioning - MAXVALUE MAXVALUE`},
-			new:        partitioningTest{name: `multi col range partitioning - MAXVALUE`},
-			isFastPath: false,
+			index: `primary`,
+			old:   partitioningTest{name: `multi col range partitioning - MAXVALUE MAXVALUE`},
+			new:   partitioningTest{name: `multi col range partitioning - MAXVALUE`},
 		},
 
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `single col list partitioning`},
-			new:        partitioningTest{name: `single col range partitioning`},
-			isFastPath: false,
+			index: `primary`,
+			old:   partitioningTest{name: `single col list partitioning`},
+			new:   partitioningTest{name: `single col range partitioning`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `single col range partitioning`},
-			new:        partitioningTest{name: `single col list partitioning`},
-			isFastPath: false,
+			index: `primary`,
+			old:   partitioningTest{name: `single col range partitioning`},
+			new:   partitioningTest{name: `single col list partitioning`},
 		},
 
 		// TODO(dan): One repartitioning is fully implemented, these tests also
 		// need to pass with no ccl code.
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `single col list partitioning`},
-			new:        partitioningTest{name: `unpartitioned`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `single col list partitioning`},
+			new:   partitioningTest{name: `unpartitioned`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `single col list partitioning - DEFAULT`},
-			new:        partitioningTest{name: `unpartitioned`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `single col list partitioning - DEFAULT`},
+			new:   partitioningTest{name: `unpartitioned`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `single col range partitioning`},
-			new:        partitioningTest{name: `unpartitioned`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `single col range partitioning`},
+			new:   partitioningTest{name: `unpartitioned`},
 		},
 		{
-			index:      `primary`,
-			old:        partitioningTest{name: `single col range partitioning - MAXVALUE`},
-			new:        partitioningTest{name: `unpartitioned`},
-			isFastPath: true,
+			index: `primary`,
+			old:   partitioningTest{name: `single col range partitioning - MAXVALUE`},
+			new:   partitioningTest{name: `unpartitioned`},
 		},
 
 		{
-			index:      `b_idx`,
-			old:        partitioningTest{name: `secondary index - unpartitioned`},
-			new:        partitioningTest{name: `secondary index - list partitioning`},
-			isFastPath: false,
+			index: `b_idx`,
+			old:   partitioningTest{name: `secondary index - unpartitioned`},
+			new:   partitioningTest{name: `secondary index - list partitioning`},
 		},
 		{
-			index:      `b_idx`,
-			old:        partitioningTest{name: `secondary index - list partitioning`},
-			new:        partitioningTest{name: `secondary index - unpartitioned`},
-			isFastPath: true,
+			index: `b_idx`,
+			old:   partitioningTest{name: `secondary index - list partitioning`},
+			new:   partitioningTest{name: `secondary index - unpartitioned`},
 		},
 		{
-			index:      `b_idx`,
-			old:        partitioningTest{name: `secondary index - list partitioning`},
-			new:        partitioningTest{name: `secondary index - list partitioning - DEFAULT`},
-			isFastPath: true,
+			index: `b_idx`,
+			old:   partitioningTest{name: `secondary index - list partitioning`},
+			new:   partitioningTest{name: `secondary index - list partitioning - DEFAULT`},
 		},
 		{
-			index:      `b_idx`,
-			old:        partitioningTest{name: `secondary index - list partitioning - DEFAULT`},
-			new:        partitioningTest{name: `secondary index - list partitioning`},
-			isFastPath: false,
+			index: `b_idx`,
+			old:   partitioningTest{name: `secondary index - list partitioning - DEFAULT`},
+			new:   partitioningTest{name: `secondary index - list partitioning`},
 		},
 	}
 
@@ -999,28 +971,6 @@ func verifyScansOnNode(db *gosql.DB, query string, node string) error {
 		return errors.New(err.String())
 	}
 	return nil
-}
-
-func TestRepartitioningFastPathAvailable(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	rng, _ := randutil.NewPseudoRand()
-	testCases, err := allRepartitioningTests(allPartitioningTests(rng))
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
-
-	for _, test := range testCases {
-		t.Run(fmt.Sprintf("%s/%s", test.old.name, test.new.name), func(t *testing.T) {
-			isFastPath, err := RepartitioningFastPathAvailable(
-				test.old.parsed.tableDesc, test.new.parsed.tableDesc)
-			if err != nil {
-				t.Fatalf("%+v", err)
-			}
-			if isFastPath != test.isFastPath {
-				t.Errorf("got %v expected %v", isFastPath, test.isFastPath)
-			}
-		})
-	}
 }
 
 func TestInitialPartitioning(t *testing.T) {
@@ -1174,10 +1124,6 @@ func TestRepartitioning(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 
 	for _, test := range testCases {
-		if !test.isFastPath {
-			// non-fastpath repartitioning is unimplemented
-			continue
-		}
 		t.Run(fmt.Sprintf("%s/%s", test.old.name, test.new.name), func(t *testing.T) {
 			sqlDB.Exec(t, `DROP DATABASE IF EXISTS data`)
 			sqlDB.Exec(t, `CREATE DATABASE data`)

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -439,37 +439,18 @@ func (n *alterTableNode) startExec(params runParams) error {
 			descriptorChanged = true
 
 		case *tree.AlterTablePartitionBy:
-			previousTableDesc := *n.tableDesc
 			partitioning, err := createPartitionedBy(params.ctx, params.p.ExecCfg().Settings,
 				&params.p.evalCtx, n.tableDesc, &n.tableDesc.PrimaryIndex, t.PartitionBy)
 			if err != nil {
 				return err
 			}
-			n.tableDesc.PrimaryIndex.Partitioning = partitioning
-			// TODO(dan): This checks TableDescriptors instead of
-			// PartitioningDescriptors to mirror the fast path check. Of course,
-			// RepartitioningFastPathAvailable could also be acting on
-			// PartitioningDescriptors but then it would need a complicated
-			// method signature and it felt weird to impose that on the
-			// sql<->sqlccl hook. Revisit?
 			descriptorChanged = !proto.Equal(
-				&previousTableDesc.PrimaryIndex.Partitioning,
 				&n.tableDesc.PrimaryIndex.Partitioning,
+				&partitioning,
 			)
-			if descriptorChanged {
-				// TODO(dan): Consider the case of a table that is repartitioned
-				// when it has not finished the schema change for adding the
-				// partitioning CHECK constraint from the last partitioning.
-				fastPath, err := RepartitioningFastPathAvailable(&previousTableDesc, n.tableDesc)
-				if err != nil {
-					return err
-				}
-				if !fastPath {
-					return fmt.Errorf("data validation is required for this repartitioning, but is currently unimplemented")
-				}
-				// TODO(dan): Remove zone configs which no longer point at a
-				// partition. This also needs to be done for indexes.
-			}
+			n.tableDesc.PrimaryIndex.Partitioning = partitioning
+			// TODO(dan): Remove zone configs which no longer point at a
+			// partition. This also needs to be done for indexes.
 		default:
 			return fmt.Errorf("unsupported alter command: %T", cmd)
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -922,23 +922,6 @@ func createPartitionedBy(
 		ctx, evalCtx, tableDesc, indexDesc, partBy, 0 /* colOffset */)
 }
 
-// RepartitioningFastPathAvailable returns true when the schema change to
-// validate existing data can be skipped.
-//
-// Each partitioned index guarantees that all rows in that index belong to one
-// of its partitions. Certain repartitionings (removing partitioning entirely, a
-// LIST partitioning that is a superset of the previous partitioning, etc) can
-// assume the the existing data meets this guarantee without checking it via a
-// sort of "inductive proof".
-var RepartitioningFastPathAvailable = func(
-	oldTableDesc, newTableDesc *sqlbase.TableDescriptor,
-) (bool, error) {
-	// TODO(dan): non-ccl binaries should be able to removing partitionings. The
-	// logic for this is simple, but I'm intentionally leaving it unimplemented
-	// until there is a test for it.
-	return false, errors.New("repartitioning in a non-ccl binary is currently unimplimented")
-}
-
 func initTableDescriptor(
 	id, parentID sqlbase.ID,
 	name string,


### PR DESCRIPTION
In an update to the partitioning RFC (#20933), we decided to no longer
validate that all data in a table belongs to exactly one leaf partition.
That means every repartitioning is trivially valid, as we don't care if
the new partitions do not include every existing row in the table.
Remove the concept of a repartitioning fast path entirely, implicitly
allowing all repartitionings to take the fast path.

Release note: None