### PR TITLE
opt: fix a crash caused by spans becoming invalid

### DIFF
--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -1041,3 +1041,14 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 ----
 [/1 - ]
 Remaining filter: (@1, @2) >= (1, 2.5)
+
+# Verify that we ignore spans that become invalid after extension.
+build-scalar,index-constraints vars=(int, int) index=(@1, @2)
+@1 >= 1 AND (@1, @2) < (1, 2) AND @2 = 5
+----
+
+build-scalar,index-constraints vars=(int, int) index=(@1, @2)
+(@1 >= 1 AND (@1, @2) < (1, 2) OR @1 > 3) AND @2 = 5
+----
+[/4/5 - ]
+Remaining filter: @2 = 5


### PR DESCRIPTION
Consider this condition:
  @1 >= 1 AND (@1, @2) <= (1, 2) AND @2 = 5

We generate the span [/1 - /1/2] for offset 0 and try to extend it
with the span [/5 - /5] for offset 1. This results in an invalid span
which needs to be ignored. We were not checking for this, leading to a
crash in this case.

Release note: None