### PR TITLE
storage: fix subtests in TestRangeTransferLease

### DIFF
--- a/pkg/storage/client_replica_test.go
+++ b/pkg/storage/client_replica_test.go
@@ -654,6 +654,12 @@ func TestRangeTransferLease(t *testing.T) {
 	// that. Test that the transfer still happens (it'll wait until the extension
 	// is done).
 	t.Run("TransferWithExtension", func(t *testing.T) {
+		// Ensure that replica1 has the lease.
+		if err := replica0.AdminTransferLease(context.Background(), replica1Desc.StoreID); err != nil {
+			t.Fatal(err)
+		}
+		checkHasLease(t, mtc.senders[1])
+
 		extensionSem := make(chan struct{})
 		setFilter(true, extensionSem)
 
@@ -749,6 +755,12 @@ func TestRangeTransferLease(t *testing.T) {
 	// in-progress lease requests to complete before transferring away the new
 	// lease.
 	t.Run("DrainTransferWithExtension", func(t *testing.T) {
+		// Ensure that replica1 has the lease.
+		if err := replica0.AdminTransferLease(context.Background(), replica1Desc.StoreID); err != nil {
+			t.Fatal(err)
+		}
+		checkHasLease(t, mtc.senders[1])
+
 		extensionSem := make(chan struct{})
 		setFilter(true, extensionSem)
 


### PR DESCRIPTION
Previously, 2 of the 4 subtests in TestRangeTransferLease were
dependent on the first subtest running. This meant that in isolation
they would not succeed, which was against the spirit of subtests. This
change addresses that.

An alternative to this is just to rip out the subtests completely. I'm
fine with either approach.

Release note: None