### PR TITLE
ui: darken yaxis labels for better readability

### DIFF
--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -111,7 +111,7 @@
 
   .nv-axislabel
     font-family Lato-Regular
-    fill $tooltip-color
+    fill $headings-color
 
 .nv-y .nv-axis .domain
   opacity 0


### PR DESCRIPTION
Previously, we darkened the yaxis labels slightly, but it is still not dark enough. This further darkens the yaxis labels.