### PR TITLE
opt: index constraints from "bare" booleans

### DIFF
--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -129,6 +129,16 @@ build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1 != NULL
 ----
 
+build-scalar,normalize,index-constraints vars=(bool) index=(@1)
+@1
+----
+[/true - /true]
+
+build-scalar,normalize,index-constraints vars=(bool) index=(@1)
+NOT @1
+----
+[/false - /false]
+
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1)
 @1 = 1 AND @2 = 2
 ----


### PR DESCRIPTION
Support expressions `a` and `NOT a` when `a` is boolean.

Release note: None