### PR TITLE
opt: improve the interface for index constraints

### DIFF
--- a/pkg/sql/opt/build.go
+++ b/pkg/sql/opt/build.go
@@ -126,7 +126,7 @@ const scalarPropsAllocChunk = 16
 
 type buildContext struct {
 	preallocScalarProps []scalarProps
-	preallocExprs       []expr
+	preallocExprs       []Expr
 }
 
 func (bc *buildContext) newScalarProps() *scalarProps {
@@ -139,9 +139,9 @@ func (bc *buildContext) newScalarProps() *scalarProps {
 }
 
 // newExpr returns a new *expr with a new, blank scalarProps.
-func (bc *buildContext) newExpr() *expr {
+func (bc *buildContext) newExpr() *Expr {
 	if len(bc.preallocExprs) == 0 {
-		bc.preallocExprs = make([]expr, exprAllocChunk)
+		bc.preallocExprs = make([]Expr, exprAllocChunk)
 	}
 	e := &bc.preallocExprs[0]
 	bc.preallocExprs = bc.preallocExprs[1:]
@@ -150,7 +150,7 @@ func (bc *buildContext) newExpr() *expr {
 }
 
 // buildScalar converts a tree.TypedExpr to an expr tree.
-func (bc *buildContext) buildScalar(pexpr tree.TypedExpr) *expr {
+func (bc *buildContext) buildScalar(pexpr tree.TypedExpr) *Expr {
 	switch t := pexpr.(type) {
 	case *tree.ParenExpr:
 		return bc.buildScalar(t.TypedInnerExpr())
@@ -203,14 +203,14 @@ func (bc *buildContext) buildScalar(pexpr tree.TypedExpr) *expr {
 		initVariableExpr(e, t.Idx)
 
 	case *tree.Tuple:
-		children := make([]*expr, len(t.Exprs))
+		children := make([]*Expr, len(t.Exprs))
 		for i, e := range t.Exprs {
 			children[i] = bc.buildScalar(e.(tree.TypedExpr))
 		}
 		initTupleExpr(e, children)
 
 	case *tree.DTuple:
-		children := make([]*expr, len(t.D))
+		children := make([]*Expr, len(t.D))
 		for i, d := range t.D {
 			children[i] = bc.buildScalar(d)
 		}
@@ -226,7 +226,7 @@ func (bc *buildContext) buildScalar(pexpr tree.TypedExpr) *expr {
 }
 
 // buildScalar converts a tree.TypedExpr to an expr tree.
-func buildScalar(pexpr tree.TypedExpr) (_ *expr, err error) {
+func buildScalar(pexpr tree.TypedExpr) (_ *Expr, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("%v", r)
@@ -236,12 +236,12 @@ func buildScalar(pexpr tree.TypedExpr) (_ *expr, err error) {
 	return buildCtx.buildScalar(pexpr), nil
 }
 
-var typedExprConvMap [numOperators]func(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr
+var typedExprConvMap [numOperators]func(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr
 
 func init() {
 	// This code is not inline to avoid an initialization loop error (some of the
 	// functions depend on scalarToTypedExpr which depends on typedExprConvMap).
-	typedExprConvMap = [numOperators]func(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr{
+	typedExprConvMap = [numOperators]func(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr{
 		constOp:    constOpToTypedExpr,
 		variableOp: variableOpToTypedExpr,
 
@@ -297,15 +297,15 @@ func init() {
 	}
 }
 
-func constOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
+func constOpToTypedExpr(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	return e.private.(tree.Datum)
 }
 
-func variableOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
+func variableOpToTypedExpr(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	return ivh.IndexedVar(e.private.(int))
 }
 
-func boolOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
+func boolOpToTypedExpr(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	switch e.op {
 	case andOp, orOp:
 		n := scalarToTypedExpr(e.children[0], ivh)
@@ -326,7 +326,7 @@ func boolOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	}
 }
 
-func tupleOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
+func tupleOpToTypedExpr(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	if isTupleOfConstants(e) {
 		datums := make(tree.Datums, len(e.children))
 		for i, child := range e.children {
@@ -341,7 +341,7 @@ func tupleOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	return tree.NewTypedTuple(children)
 }
 
-func unaryOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
+func unaryOpToTypedExpr(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	return tree.NewTypedUnaryExpr(
 		unaryOpReverseMap[e.op],
 		scalarToTypedExpr(e.children[0], ivh),
@@ -349,7 +349,7 @@ func unaryOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	)
 }
 
-func comparisonOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
+func comparisonOpToTypedExpr(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	return tree.NewTypedComparisonExpr(
 		comparisonOpReverseMap[e.op],
 		scalarToTypedExpr(e.children[0], ivh),
@@ -357,7 +357,7 @@ func comparisonOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr
 	)
 }
 
-func binaryOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
+func binaryOpToTypedExpr(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	return tree.NewTypedBinaryExpr(
 		binaryOpReverseMap[e.op],
 		scalarToTypedExpr(e.children[0], ivh),
@@ -366,11 +366,11 @@ func binaryOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	)
 }
 
-func unsupportedScalarOpToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
+func unsupportedScalarOpToTypedExpr(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	return e.private.(tree.TypedExpr)
 }
 
-func scalarToTypedExpr(e *expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
+func scalarToTypedExpr(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	if fn := typedExprConvMap[e.op]; fn != nil {
 		return fn(e, ivh)
 	}

--- a/pkg/sql/opt/build.go
+++ b/pkg/sql/opt/build.go
@@ -376,3 +376,16 @@ func scalarToTypedExpr(e *Expr, ivh *tree.IndexedVarHelper) tree.TypedExpr {
 	}
 	panic(fmt.Sprintf("unsupported op %s", e.op))
 }
+
+// BuildScalarExpr converts a TypedExpr to a *Expr tree and normalizes it.
+func BuildScalarExpr(typedExpr tree.TypedExpr) (*Expr, error) {
+	if typedExpr == nil {
+		return nil, nil
+	}
+	e, err := buildScalar(typedExpr)
+	if err != nil {
+		return nil, err
+	}
+	normalizeExpr(e)
+	return e, nil
+}

--- a/pkg/sql/opt/expr.go
+++ b/pkg/sql/opt/expr.go
@@ -16,7 +16,7 @@ package opt
 
 import "github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 
-// expr implements the node of a unified expressions tree for both relational
+// Expr implements the node of a unified expressions tree for both relational
 // and scalar expressions in a query.
 //
 // Expressions have optional inputs. Expressions also maintain properties; the
@@ -24,18 +24,18 @@ import "github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 // type). For scalar expressions, the properties are stored in scalarProps. An
 // example of a scalar property is the type (types.T) of the scalar expression.
 //
-// Currently, expr only supports scalar expressions and operators. More
+// Currently, Expr only supports scalar expressions and operators. More
 // information pertaining to relational operators will be added when they are
 // supported.
 //
 // TODO(radu): support relational operators and extend this description.
-type expr struct {
+type Expr struct {
 	op operator
 	// Child expressions. The interpretation of the children is operator
 	// dependent. For example, for a eqOp, there are two child expressions (the
 	// left-hand side and the right-hand side); for an andOp, there are at least
 	// two child expressions (each one being a conjunct).
-	children []*expr
+	children []*Expr
 	// Scalar properties (properties that pertain only to scalar operators).
 	scalarProps *scalarProps
 	// Operator-dependent data used by this expression. For example, constOp
@@ -43,12 +43,12 @@ type expr struct {
 	private interface{}
 }
 
-func (e *expr) opClass() operatorClass {
+func (e *Expr) opClass() operatorClass {
 	return operatorTab[e.op].class
 }
 
 // Applies normalization rules to an expression.
-func normalizeExpr(e *expr) {
+func normalizeExpr(e *Expr) {
 	for _, input := range e.children {
 		normalizeExpr(input)
 	}
@@ -57,7 +57,7 @@ func normalizeExpr(e *expr) {
 
 // Applies normalization rules to an expression node. This is like
 // normalizeExpr, except that it does not recursively normalize children.
-func normalizeExprNode(e *expr) {
+func normalizeExprNode(e *Expr) {
 	if normalizeFn := operatorTab[e.op].normalizeFn; normalizeFn != nil {
 		normalizeFn(e)
 	}
@@ -66,7 +66,7 @@ func normalizeExprNode(e *expr) {
 // formatExprs formats the given expressions as children of the same
 // node. Optionally creates a new parent node (if title is not "", and we have
 // expressions).
-func formatExprs(tp treeprinter.Node, title string, exprs []*expr) {
+func formatExprs(tp treeprinter.Node, title string, exprs []*Expr) {
 	if len(exprs) > 0 {
 		if title != "" {
 			tp = tp.Child(title)
@@ -78,34 +78,34 @@ func formatExprs(tp treeprinter.Node, title string, exprs []*expr) {
 }
 
 // format is part of the operatorClass interface.
-func (e *expr) format(tp treeprinter.Node) {
+func (e *Expr) format(tp treeprinter.Node) {
 	if e == nil {
-		panic("format on nil expr")
+		panic("format on nil Expr")
 	}
 	e.opClass().format(e, tp)
 }
 
-func (e *expr) String() string {
+func (e *Expr) String() string {
 	tp := treeprinter.New()
 	e.format(tp)
 	return tp.String()
 }
 
-func (e *expr) shallowCopy() *expr {
+func (e *Expr) shallowCopy() *Expr {
 	// TODO(radu): use something like buildContext to allocate in bulk.
-	r := &expr{
+	r := &Expr{
 		op:          e.op,
 		scalarProps: &scalarProps{},
 		private:     e.private,
 	}
 	*r.scalarProps = *e.scalarProps
 	if len(e.children) > 0 {
-		r.children = append([]*expr(nil), e.children...)
+		r.children = append([]*Expr(nil), e.children...)
 	}
 	return r
 }
 
-func (e *expr) deepCopy() *expr {
+func (e *Expr) deepCopy() *Expr {
 	// TODO(radu): use something like buildContext to allocate in bulk.
 	e = e.shallowCopy()
 	for i, c := range e.children {

--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -911,21 +911,6 @@ type IndexConstraints struct {
 
 // Init processes the filter and calculates the spans.
 func (ic *IndexConstraints) Init(
-	filter tree.TypedExpr, colInfos []IndexColumnInfo, evalCtx *tree.EvalContext,
-) (err error) {
-	e, err := buildScalar(filter)
-	if err != nil {
-		return err
-	}
-	if e != nil {
-		normalizeExpr(e)
-	}
-
-	ic.initWithExpr(e, colInfos, evalCtx)
-	return nil
-}
-
-func (ic *IndexConstraints) initWithExpr(
 	filter *Expr, colInfos []IndexColumnInfo, evalCtx *tree.EvalContext,
 ) {
 	*ic = IndexConstraints{

--- a/pkg/sql/opt/index_constraints_spans.go
+++ b/pkg/sql/opt/index_constraints_spans.go
@@ -151,7 +151,7 @@ func makeIndexConstraintCtx(
 
 // isIndexColumn returns true if e is an indexed var that corresponds
 // to index column <offset>.
-func (c *indexConstraintCtx) isIndexColumn(e *expr, index int) bool {
+func (c *indexConstraintCtx) isIndexColumn(e *Expr, index int) bool {
 	return isIndexedVar(e, c.colInfos[index].VarIdx)
 }
 

--- a/pkg/sql/opt/index_constraints_test.go
+++ b/pkg/sql/opt/index_constraints_test.go
@@ -76,18 +76,17 @@ func BenchmarkIndexConstraints(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			e, err := buildScalar(typedExpr)
+			e, err := BuildScalarExpr(typedExpr)
 			if err != nil {
 				b.Fatal(err)
 			}
-			normalizeExpr(e)
 
 			evalCtx := tree.MakeTestingEvalContext()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				var ic IndexConstraints
 
-				ic.initWithExpr(e, colInfos, &evalCtx)
+				ic.Init(e, colInfos, &evalCtx)
 				_, _ = ic.Spans()
 				_ = ic.RemainingFilter(&iVarHelper)
 			}

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -109,7 +109,7 @@ type operatorInfo struct {
 	// class of the operator (see operatorClass).
 	class operatorClass
 
-	normalizeFn func(*expr)
+	normalizeFn func(*Expr)
 }
 
 // operatorTab stores static information about all operators.
@@ -135,5 +135,5 @@ func registerOperator(op operator, info operatorInfo) {
 // operators.
 type operatorClass interface {
 	// format outputs information about the expr tree to a treePrinter.
-	format(e *expr, tp treeprinter.Node)
+	format(e *Expr, tp treeprinter.Node)
 }

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -290,7 +290,7 @@ func TestOpt(t *testing.T) {
 	for _, path := range paths {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			runTest(t, path, func(d *testdata) string {
-				var e *expr
+				var e *Expr
 				var varTypes []types.T
 				var iVarHelper tree.IndexedVarHelper
 				var colInfos []IndexColumnInfo

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -368,7 +368,7 @@ func TestOpt(t *testing.T) {
 						}
 						var ic IndexConstraints
 
-						ic.initWithExpr(e, colInfos, &evalCtx)
+						ic.Init(e, colInfos, &evalCtx)
 						spans, ok := ic.Spans()
 
 						var buf bytes.Buffer


### PR DESCRIPTION
#### opt: export Expr

Export expr. Initially it will just be passed around opaquely so we
don't need to export any of its members yet.

Release note: None

#### opt: improve the interface for index constraints

The current interface for index constraints takes in a
`parser.TypedExpr` and converts it to an `*Expr` tree. This means that
the conversion has to happen multiple times, once for each index.

This change improves the interface: we export a separate
`BuildScalarExpr` function that can be used once, and the result can
be used for multiple `IndexConstraints.Init` calls.

Release note: None
