### PR TITLE
opt: handle NULLs correctly for tuple neOp

### DIFF
--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -529,6 +529,41 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 ----
 [ - /1/2/2]
 [/1/2/4 - ]
+Remaining filter: (@1, @2, @3) != (1, 2, 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 desc, @2 desc, @3 desc)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/4]
+[/1/2/2 - ]
+Remaining filter: (@1, @2, @3) != (1, 2, 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 desc, @2, @3)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/2]
+[/1/2/4 - ]
+Remaining filter: (@1, @2, @3) != (1, 2, 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 not null, @2, @3)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/2]
+[/1/2/4 - ]
+Remaining filter: (@1, @2, @3) != (1, 2, 3)
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 not null, @2 not null, @3 not null)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/2]
+[/1/2/4 - ]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2 not null, @3 not null)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/2]
+[/1/2/4 - ]
+Remaining filter: (@1, @2, @3) != (1, 2, 3)
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (@1, @2, @3) != (1, 2, @1)


### PR DESCRIPTION
An earlier change supporting nullable columns for tuple comparisons
was incomplete - neOp has a special path which also needs similar
handling.

This change fixes handling of nullable columns for constraints on
tuple != tuple.

Release note: None