### PR TITLE
opt: support wrapping the directive line in opt test

### DIFF
--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -196,6 +196,14 @@ func (r *testdataReader) Next(t *testing.T) bool {
 			// Skip comment lines.
 			continue
 		}
+		// Support wrapping directive lines using \, for example:
+		//   build-scalar \
+		//   vars(int)
+		for strings.HasSuffix(line, `\`) && r.scanner.Scan() {
+			nextLine := r.scanner.Text()
+			r.emit(nextLine)
+			line = strings.TrimSuffix(line, `\`) + " " + strings.TrimSpace(nextLine)
+		}
 
 		fields := splitDirectives(t, line)
 		if len(fields) == 0 {

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -464,7 +464,9 @@ build-scalar,normalize,index-constraints vars=(int, int, int, int) index=(@1, @2
 [/6/2/3/4 - /9/2/3/4]
 Remaining filter: ((@2 = 2) AND (@3 = 3)) AND (@4 = 4)
 
-build-scalar,normalize,index-constraints vars=(int, int, int, int) index=(@1 desc, @2 desc, @3 desc, @4 desc)
+build-scalar,normalize,index-constraints \
+  vars=(int, int, int, int) \
+  index=(@1 desc, @2 desc, @3 desc, @4 desc)
 @1 > 5 AND @1 < 10 AND (@2, @3, @4) = (2, 3, 4)
 ----
 [/9/2/3/4 - /6/2/3/4]
@@ -626,7 +628,9 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3 
 (/NULL - /1/2/3]
 Remaining filter: (@1, @2, @3) <= (1, 2, 3)
 
-build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1 desc not null, @2 desc not null, @3 desc not null)
+build-scalar,normalize,index-constraints \
+  vars=(int, int, int) \
+  index=(@1 desc not null, @2 desc not null, @3 desc not null)
 (@1, @2, @3) > (1, 2, 3)
 ----
 [ - /1/2/4]


### PR DESCRIPTION
Directive lines can now be split using `\`. For example:
```
build-scalar \
  vars=(int)
```
is equivalent to `build-scalar vars=(int)`.

Release note: None