### PR TITLE
build: ignore files not ending in .go for testrace

### DIFF
--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -19,7 +19,7 @@ if [[ "${TC_BUILD_BRANCH}" == master ]] || [[ "${TC_BUILD_BRANCH}" == release* ]
 	PKGSPEC="./pkg/..."
 else
 	git fetch origin master
-	PKGSPEC=$(git diff --name-only origin/master... | grep "^pkg.*\.go" || true)
+	PKGSPEC=$(git diff --name-only origin/master... | grep "^pkg.*\.go$" || true)
 	if [ -z "${PKGSPEC}" ]; then
 		echo "No changed packages; skipping race detector tests"
 		exit 0


### PR DESCRIPTION
Release note: None