### PR TITLE
storage: factor out ReplicaDataIterator

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -184,7 +185,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	iter := storage.NewReplicaDataIterator(&desc, db, debugCtx.replicated)
+	iter := rditer.NewReplicaDataIterator(&desc, db, debugCtx.replicated)
 	for ; ; iter.Next() {
 		if ok, err := iter.Valid(); err != nil {
 			return err

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -691,7 +692,7 @@ func RunGC(
 	cleanupTxnIntentsAsyncFn cleanupTxnIntentsAsyncFunc,
 ) (GCInfo, error) {
 
-	iter := NewReplicaDataIterator(desc, snap, true /* replicatedOnly */)
+	iter := rditer.NewReplicaDataIterator(desc, snap, true /* replicatedOnly */)
 	defer iter.Close()
 
 	var infoMu = lockableGCInfo{}

--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -330,7 +331,7 @@ func (r *Replica) sha512(
 	tombstoneKey := engine.MakeMVCCMetadataKey(keys.RaftTombstoneKey(desc.RangeID))
 
 	// Iterate over all the data in the range.
-	iter := NewReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
+	iter := rditer.NewReplicaDataIterator(&desc, snap, true /* replicatedOnly */)
 	defer iter.Close()
 
 	var legacyTimestamp hlc.LegacyTimestamp

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -209,8 +210,8 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 		// lease's expiration but instead use the new lease's start to initialize
 		// the timestamp cache low water.
 		desc := r.Desc()
-		for _, keyRange := range makeReplicatedKeyRanges(desc) {
-			r.store.tsCache.SetLowWater(keyRange.start.Key, keyRange.end.Key, newLease.Start)
+		for _, keyRange := range rditer.MakeReplicatedKeyRanges(desc) {
+			r.store.tsCache.SetLowWater(keyRange.Start.Key, keyRange.End.Key, newLease.Start)
 		}
 
 		// Reset the request counts used to make lease placement decisions whenever

--- a/pkg/storage/stats.go
+++ b/pkg/storage/stats.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 )
 
 // ComputeStatsForRange computes the stats for a given range by
@@ -30,8 +31,8 @@ func ComputeStatsForRange(
 	defer iter.Close()
 
 	ms := enginepb.MVCCStats{}
-	for _, r := range makeReplicatedKeyRanges(d) {
-		msDelta, err := iter.ComputeStats(r.start, r.end, nowNanos)
+	for _, keyRange := range rditer.MakeReplicatedKeyRanges(d) {
+		msDelta, err := iter.ComputeStats(keyRange.Start, keyRange.End, nowNanos)
 		if err != nil {
 			return enginepb.MVCCStats{}, err
 		}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3436,7 +3436,7 @@ func sendSnapshot(
 		}
 		var key engine.MVCCKey
 		var value []byte
-		alloc, key, value = snap.Iter.allocIterKeyValue(alloc)
+		alloc, key, value = snap.Iter.AllocIterKeyValue(alloc)
 		if bytes.HasPrefix(key.Key, unreplicatedPrefix) {
 			continue
 		}


### PR DESCRIPTION
Move it to the new `pkg/storage/rditer` package. This is necessary
since we'll soon have to recompute stats in `batcheval` and need
to avoid circular dependencies.

As a side effect, the tests now look much nicer, and a bit related
to replica GC has been moved into a more appropriate test.

Release note: None