### PR TITLE
sql/distsqlrun: refactor mergeJoiner to implement RowSource

### DIFF
--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -277,11 +277,6 @@ func MakeNoMetadataRowSource(src RowSource, sink RowReceiver) NoMetadataRowSourc
 	return NoMetadataRowSource{src: src, metadataSink: sink}
 }
 
-// OutputTypes returns the source types.
-func (rs *NoMetadataRowSource) OutputTypes() []sqlbase.ColumnType {
-	return rs.src.OutputTypes()
-}
-
 // NextRow is analogous to RowSource.Next. If the producer sends an error, we
 // can't just forward it to metadataSink. We need to let the consumer know so
 // that it's not under the impression that everything is hunky-dory and it can

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -141,6 +141,7 @@ func shouldEmitUnmatchedRow(side joinSide, joinType joinType) bool {
 		if side == rightSide {
 			return false
 		}
+	case fullOuter:
 	}
 	return true
 }

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -15,14 +15,12 @@
 package distsqlrun
 
 import (
-	"context"
 	"errors"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 // mergeJoiner performs merge join, it has two input row sources with the same
@@ -32,7 +30,8 @@ import (
 type mergeJoiner struct {
 	joinerBase
 
-	evalCtx *tree.EvalContext
+	evalCtx       *tree.EvalContext
+	cancelChecker *sqlbase.CancelChecker
 
 	leftSource, rightSource RowSource
 	leftRows, rightRows     []sqlbase.EncDatumRow
@@ -44,6 +43,7 @@ type mergeJoiner struct {
 }
 
 var _ Processor = &mergeJoiner{}
+var _ RowSource = &mergeJoiner{}
 
 func newMergeJoiner(
 	flowCtx *FlowCtx,
@@ -87,56 +87,84 @@ func newMergeJoiner(
 
 // Run is part of the processor interface.
 func (m *mergeJoiner) Run(wg *sync.WaitGroup) {
+	if m.out.output == nil {
+		panic("mergeJoiner output not initialized for emitting rows")
+	}
+	Run(m.flowCtx.Ctx, m, m.out.output)
 	if wg != nil {
-		defer wg.Done()
+		wg.Done()
 	}
-
-	ctx := log.WithLogTag(m.flowCtx.Ctx, "MergeJoiner", nil)
-	ctx, span := processorSpan(ctx, "merge joiner")
-	defer tracing.FinishSpan(span)
-	log.VEventf(ctx, 2, "starting merge joiner run")
-
-	cancelChecker := sqlbase.NewCancelChecker(ctx)
-	m.evalCtx = m.flowCtx.NewEvalCtx()
-
-	var err error
-	for {
-		if err = cancelChecker.Check(); err != nil {
-			break
-		}
-
-		row, meta := m.nextRow(ctx)
-		if meta != nil {
-			if m.out.output.Push(nil, *meta) != NeedMoreRows || meta.Err != nil {
-				break
-			}
-			continue
-		}
-		if row == nil {
-			break
-		}
-
-		var outRow sqlbase.EncDatumRow
-		var status ConsumerStatus
-		outRow, status, err = m.out.ProcessRow(ctx, row)
-		if outRow != nil {
-			if m.out.output.Push(outRow, ProducerMetadata{}) != NeedMoreRows {
-				break
-			}
-			continue
-		}
-		if err != nil || status != NeedMoreRows {
-			break
-		}
-	}
-
-	DrainAndClose(ctx, m.out.output, err, m.leftSource, m.rightSource)
-	log.VEventf(ctx, 2, "exiting merge joiner run")
 }
 
-func (m *mergeJoiner) nextRow(ctx context.Context) (sqlbase.EncDatumRow, *ProducerMetadata) {
-	// The loops below form a restartable state machine that iterates over a batch
-	// of rows from the left and right side of the join. The state machine
+func (m *mergeJoiner) close() {
+	if !m.closed {
+		log.VEventf(m.ctx, 2, "exiting merge joiner run")
+	}
+	if m.internalClose() {
+		m.leftSource.ConsumerClosed()
+		m.rightSource.ConsumerClosed()
+	}
+}
+
+// producerMeta constructs the ProducerMetadata after consumption of rows has
+// terminated, either due to being indicated by the consumer, or because the
+// processor ran out of rows or encountered an error. It is ok for err to be
+// nil indicating that we're done producing rows even though no error occurred.
+func (m *mergeJoiner) producerMeta(err error) ProducerMetadata {
+	var meta ProducerMetadata
+	if !m.closed {
+		meta = ProducerMetadata{Err: err}
+		if err == nil {
+			meta.TraceData = getTraceData(m.ctx)
+		}
+		// We need to close as soon as we send producer metadata as we're done
+		// sending rows. The consumer is allowed to not call ConsumerDone().
+		m.close()
+	}
+	return meta
+}
+
+func (m *mergeJoiner) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
+	if m.maybeStart("merge joiner", "MergeJoiner") {
+		m.evalCtx = m.flowCtx.NewEvalCtx()
+		m.cancelChecker = sqlbase.NewCancelChecker(m.ctx)
+		log.VEventf(m.ctx, 2, "starting merge joiner run")
+	}
+
+	for {
+		row, meta := m.nextRow()
+		if m.closed || meta != nil {
+			return nil, *meta
+		}
+		if row == nil {
+			return nil, m.producerMeta(nil /* err */)
+		}
+
+		outRow, status, err := m.out.ProcessRow(m.ctx, row)
+		if err != nil {
+			return nil, m.producerMeta(err)
+		}
+		switch status {
+		case NeedMoreRows:
+			if outRow == nil && err == nil {
+				continue
+			}
+		case DrainRequested:
+			// TODO(peter): Could we be calling ConsumerDone twice on the inputs?
+			// Looks like it can happen here and in response to
+			// mergeJoiner.ConsumerDone(). This also affects distinct and
+			// noopProcessor.
+			m.leftSource.ConsumerDone()
+			m.rightSource.ConsumerDone()
+			continue
+		}
+		return outRow, ProducerMetadata{}
+	}
+}
+
+func (m *mergeJoiner) nextRow() (sqlbase.EncDatumRow, *ProducerMetadata) {
+	// The loops below form a restartable state machine that iterates over a
+	// batch of rows from the left and right side of the join. The state machine
 	// returns a result for every row that should be output.
 
 	for {
@@ -158,6 +186,12 @@ func (m *mergeJoiner) nextRow(ctx context.Context) (sqlbase.EncDatumRow, *Produc
 					}
 					return renderedRow, nil
 				}
+			}
+
+			// Perform the cancellation check. We don't perform this on every row,
+			// but once for every iteration through the right-side batch.
+			if err := m.cancelChecker.Check(); err != nil {
+				return nil, &ProducerMetadata{Err: err}
 			}
 
 			// We've exhausted the right-side batch. Adjust the indexes for the next
@@ -206,4 +240,16 @@ func (m *mergeJoiner) nextRow(ctx context.Context) (sqlbase.EncDatumRow, *Produc
 		}
 		m.leftIdx, m.rightIdx = 0, 0
 	}
+}
+
+// ConsumerDone is part of the RowSource interface.
+func (m *mergeJoiner) ConsumerDone() {
+	m.leftSource.ConsumerDone()
+	m.rightSource.ConsumerDone()
+}
+
+// ConsumerClosed is part of the RowSource interface.
+func (m *mergeJoiner) ConsumerClosed() {
+	// The consumer is done, Next() will not be called again.
+	m.close()
 }

--- a/pkg/sql/distsqlrun/stream_group_accumulator.go
+++ b/pkg/sql/distsqlrun/stream_group_accumulator.go
@@ -23,7 +23,7 @@ import (
 // streamGroupAccumulator groups input rows coming from src into groups dictated
 // by equality according to the ordering columns.
 type streamGroupAccumulator struct {
-	src   NoMetadataRowSource
+	src   RowSource
 	types []sqlbase.ColumnType
 
 	// srcConsumed is set once src has been exhausted.
@@ -37,7 +37,7 @@ type streamGroupAccumulator struct {
 }
 
 func makeStreamGroupAccumulator(
-	src NoMetadataRowSource, ordering sqlbase.ColumnOrdering,
+	src RowSource, ordering sqlbase.ColumnOrdering,
 ) streamGroupAccumulator {
 	return streamGroupAccumulator{
 		src:      src,
@@ -46,34 +46,27 @@ func makeStreamGroupAccumulator(
 	}
 }
 
-// peekAtCurrentGroup returns the first row of the current group.
-func (s *streamGroupAccumulator) peekAtCurrentGroup() (sqlbase.EncDatumRow, error) {
-	// On all but the very first call, either there will be (one or all) rows
-	// accumulated already in the current group, or srcConsumed will be set.
-	if s.srcConsumed {
-		return nil, nil
-	}
-	if len(s.curGroup) == 0 {
-		row, err := s.src.NextRow()
-		if err != nil {
-			return nil, err
+// advanceGroup returns all rows of the current group and advances the internal
+// state to the next group.
+func (s *streamGroupAccumulator) advanceGroup(
+	evalCtx *tree.EvalContext, metadataSink RowReceiver,
+) ([]sqlbase.EncDatumRow, error) {
+	for {
+		batch, meta := s.nextGroup(evalCtx)
+		if meta != nil {
+			if meta.Err != nil {
+				return nil, meta.Err
+			}
+			_ = metadataSink.Push(nil /* row */, *meta)
+			continue
 		}
-		if row != nil {
-			s.curGroup = append(s.curGroup, row)
-		} else {
-			s.srcConsumed = true
-			return nil, nil
-		}
+		return batch, nil
 	}
-	return s.curGroup[0], nil
 }
 
-// advanceGroup returns all rows of the current group and advances the internal
-// state to the next group, so that a subsequent peekAtCurrentGroup() will
-// return the first row of the next group.
-func (s *streamGroupAccumulator) advanceGroup(
+func (s *streamGroupAccumulator) nextGroup(
 	evalCtx *tree.EvalContext,
-) ([]sqlbase.EncDatumRow, error) {
+) ([]sqlbase.EncDatumRow, *ProducerMetadata) {
 	if s.srcConsumed {
 		// If src has been exhausted, then we also must have advanced away from the
 		// last group.
@@ -81,9 +74,13 @@ func (s *streamGroupAccumulator) advanceGroup(
 	}
 
 	for {
-		row, err := s.src.NextRow()
-		if err != nil {
-			return nil, err
+		row, meta := s.src.Next()
+		if !meta.Empty() {
+			// Return a new pointer. Doing this copy manually is much better than
+			// returning &meta because it doesn't force meta on to the heap.
+			t := &ProducerMetadata{}
+			*t = meta
+			return nil, t
 		}
 		if row == nil {
 			s.srcConsumed = true
@@ -100,15 +97,16 @@ func (s *streamGroupAccumulator) advanceGroup(
 
 		cmp, err := s.curGroup[0].Compare(s.types, &s.datumAlloc, s.ordering, evalCtx, row)
 		if err != nil {
-			return nil, err
+			return nil, &ProducerMetadata{Err: err}
 		}
 		if cmp == 0 {
 			s.curGroup = append(s.curGroup, row)
 		} else if cmp == 1 {
-			return nil, errors.Errorf(
-				"detected badly ordered input: %s > %s, but expected '<'",
-				s.curGroup[0].String(s.types), row.String(s.types),
-			)
+			return nil, &ProducerMetadata{
+				Err: errors.Errorf(
+					"detected badly ordered input: %s > %s, but expected '<'",
+					s.curGroup[0].String(s.types), row.String(s.types)),
+			}
 		} else {
 			n := len(s.curGroup)
 			ret := s.curGroup[:n:n]

--- a/pkg/sql/distsqlrun/stream_merger.go
+++ b/pkg/sql/distsqlrun/stream_merger.go
@@ -26,8 +26,10 @@ import (
 // batches of rows that are the cross-product of matching groups from each
 // stream.
 type streamMerger struct {
-	left  streamGroupAccumulator
-	right streamGroupAccumulator
+	left       streamGroupAccumulator
+	right      streamGroupAccumulator
+	leftGroup  []sqlbase.EncDatumRow
+	rightGroup []sqlbase.EncDatumRow
 	// nulLEquality indicates when NULL = NULL is truth-y. This is helpful
 	// when we want NULL to be meaningful during equality, for example
 	// during SCRUB secondary index checks.
@@ -40,17 +42,31 @@ type streamMerger struct {
 // be empty.
 func (sm *streamMerger) NextBatch(
 	evalCtx *tree.EvalContext,
-) ([]sqlbase.EncDatumRow, []sqlbase.EncDatumRow, error) {
-	lrow, err := sm.left.peekAtCurrentGroup()
-	if err != nil {
-		return nil, nil, err
+) ([]sqlbase.EncDatumRow, []sqlbase.EncDatumRow, *ProducerMetadata) {
+	if sm.leftGroup == nil {
+		var meta *ProducerMetadata
+		sm.leftGroup, meta = sm.left.nextGroup(evalCtx)
+		if meta != nil {
+			return nil, nil, meta
+		}
 	}
-	rrow, err := sm.right.peekAtCurrentGroup()
-	if err != nil {
-		return nil, nil, err
+	if sm.rightGroup == nil {
+		var meta *ProducerMetadata
+		sm.rightGroup, meta = sm.right.nextGroup(evalCtx)
+		if meta != nil {
+			return nil, nil, meta
+		}
 	}
-	if lrow == nil && rrow == nil {
+	if sm.leftGroup == nil && sm.rightGroup == nil {
 		return nil, nil, nil
+	}
+
+	var lrow, rrow sqlbase.EncDatumRow
+	if len(sm.leftGroup) > 0 {
+		lrow = sm.leftGroup[0]
+	}
+	if len(sm.rightGroup) > 0 {
+		rrow = sm.rightGroup[0]
 	}
 
 	cmp, err := CompareEncDatumRowForMerge(
@@ -58,20 +74,16 @@ func (sm *streamMerger) NextBatch(
 		sm.nullEquality, &sm.datumAlloc, evalCtx,
 	)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, &ProducerMetadata{Err: err}
 	}
 	var leftGroup, rightGroup []sqlbase.EncDatumRow
 	if cmp <= 0 {
-		leftGroup, err = sm.left.advanceGroup(evalCtx)
-		if err != nil {
-			return nil, nil, err
-		}
+		leftGroup = sm.leftGroup
+		sm.leftGroup = nil
 	}
 	if cmp >= 0 {
-		rightGroup, err = sm.right.advanceGroup(evalCtx)
-		if err != nil {
-			return nil, nil, err
-		}
+		rightGroup = sm.rightGroup
+		sm.rightGroup = nil
 	}
 	return leftGroup, rightGroup, nil
 }
@@ -146,7 +158,6 @@ func makeStreamMerger(
 	leftOrdering sqlbase.ColumnOrdering,
 	rightSource RowSource,
 	rightOrdering sqlbase.ColumnOrdering,
-	metadataSink RowReceiver,
 	nullEquality bool,
 ) (streamMerger, error) {
 	if len(leftOrdering) != len(rightOrdering) {
@@ -160,12 +171,8 @@ func makeStreamMerger(
 	}
 
 	return streamMerger{
-		left: makeStreamGroupAccumulator(
-			MakeNoMetadataRowSource(leftSource, metadataSink),
-			leftOrdering),
-		right: makeStreamGroupAccumulator(
-			MakeNoMetadataRowSource(rightSource, metadataSink),
-			rightOrdering),
+		left:         makeStreamGroupAccumulator(leftSource, leftOrdering),
+		right:        makeStreamGroupAccumulator(rightSource, rightOrdering),
 		nullEquality: nullEquality,
 	}, nil
 }


### PR DESCRIPTION
The performance diff at smaller input sizes is due to the removal of the
`log.VEventf` lines.

```
name                           old time/op    new time/op    delta
MergeJoiner/InputSize=0-8        3.39µs ± 2%    2.30µs ± 2%  -32.22%  (p=0.000 n=10+9)
MergeJoiner/InputSize=4-8        5.66µs ± 1%    4.19µs ± 1%  -25.91%  (p=0.000 n=10+8)
MergeJoiner/InputSize=16-8       8.76µs ± 1%    7.14µs ± 1%  -18.55%  (p=0.000 n=9+10)
MergeJoiner/InputSize=256-8      66.6µs ± 1%    64.3µs ± 1%   -3.50%  (p=0.000 n=9+9)
MergeJoiner/InputSize=4096-8      987µs ± 1%     991µs ± 1%     ~     (p=0.089 n=10+10)
MergeJoiner/InputSize=65536-8    16.1ms ± 3%    16.4ms ± 3%     ~     (p=0.113 n=9+10)
```

Release note: None