### PR TITLE
sql: fix not-NULL spans for tuple !=

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -489,56 +489,68 @@ render     0  render  ·         ·                       (u, v, w)  +u,+v,+w
  │         0  ·       render 2  test.uvw.w              ·          ·
  └── scan  1  scan    ·         ·                       (u, v, w)  +u,+v,+w
 ·          1  ·       table     uvw@uvw_u_v_w_idx       ·          ·
-·          1  ·       spans     /!NULL-                 ·          ·
+·          1  ·       spans     ALL                     ·          ·
 ·          1  ·       filter    (u, v, w) != (1, 2, 3)  ·          ·
 
 query III
 SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 ----
-1  NULL  1
-1  NULL  2
-1  1     NULL
-1  1     1
-1  1     2
-1  1     3
-1  2     1
-1  2     2
-1  3     NULL
-1  3     1
-1  3     2
-1  3     3
-2  NULL  NULL
-2  NULL  1
-2  NULL  2
-2  NULL  3
-2  1     NULL
-2  1     1
-2  1     2
-2  1     3
-2  2     NULL
-2  2     1
-2  2     2
-2  2     3
-2  3     NULL
-2  3     1
-2  3     2
-2  3     3
-3  NULL  NULL
-3  NULL  1
-3  NULL  2
-3  NULL  3
-3  1     NULL
-3  1     1
-3  1     2
-3  1     3
-3  2     NULL
-3  2     1
-3  2     2
-3  2     3
-3  3     NULL
-3  3     1
-3  3     2
-3  3     3
+NULL  NULL  1
+NULL  NULL  2
+NULL  1     NULL
+NULL  1     1
+NULL  1     2
+NULL  1     3
+NULL  2     1
+NULL  2     2
+NULL  3     NULL
+NULL  3     1
+NULL  3     2
+NULL  3     3
+1     NULL  1
+1     NULL  2
+1     1     NULL
+1     1     1
+1     1     2
+1     1     3
+1     2     1
+1     2     2
+1     3     NULL
+1     3     1
+1     3     2
+1     3     3
+2     NULL  NULL
+2     NULL  1
+2     NULL  2
+2     NULL  3
+2     1     NULL
+2     1     1
+2     1     2
+2     1     3
+2     2     NULL
+2     2     1
+2     2     2
+2     2     3
+2     3     NULL
+2     3     1
+2     3     2
+2     3     3
+3     NULL  NULL
+3     NULL  1
+3     NULL  2
+3     NULL  3
+3     1     NULL
+3     1     1
+3     1     2
+3     1     3
+3     2     NULL
+3     2     1
+3     2     2
+3     2     3
+3     3     NULL
+3     3     1
+3     3     2
+3     3     3
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w

--- a/pkg/sql/opt_index_selection_test.go
+++ b/pkg/sql/opt_index_selection_test.go
@@ -283,6 +283,8 @@ func TestMakeConstraints(t *testing.T) {
 		{`(b, a) = (1, 2)`, `a,b`, `[(b, a) IN ((1, 2))]`},
 		{`(b, a) = (1, 2)`, `a`, `[(b, a) IN ((1, 2))]`},
 
+		{`(a, b) != (1, 2)`, `a,b`, ``},
+
 		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, `a,b`, `[(a, b) IN ((1, 2))]`},
 
 		{`a IS NULL`, `a`, `[a IS NULL]`},
@@ -531,7 +533,7 @@ func TestMakeSpans(t *testing.T) {
 		{`(a, b) < (1, 4)`, `a,b`, `/!NULL-/1/4`, `/1/3-/NULL`},
 		{`(a, b) <= (1, 4)`, `a,b`, `/!NULL-/1/5`, `/1/4-/NULL`},
 		{`(a, b) = (1, 4)`, `a,b`, `/1/4-/1/5`, `/1/4-/1/3`},
-		{`(a, b) != (1, 4)`, `a,b`, `/!NULL-`, `-/NULL`},
+		{`(a, b) != (1, 4)`, `a,b`, `-`, `-`},
 	}
 	p := makeTestPlanner()
 	for _, d := range testData {
@@ -735,6 +737,7 @@ func TestApplyConstraints(t *testing.T) {
 		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, `a,b`, `false`},
 		{`a IN (1) AND a = 1`, `a`, `<nil>`},
 		{`(a, b) = (1, 2)`, `a`, `b = 2`},
+		{`(a, b) != (1, 2)`, `a,b`, `(a, b) != (1, 2)`},
 		{`a > 1`, `a`, `<nil>`},
 		{`a < 1`, `a`, `<nil>`},
 		// The constraint (l, m) < (123, 456) must be treated as implying


### PR DESCRIPTION
PR #21115 fixed the logic for `tuple != tuple` which was incorrectly handling
NULLs. This change fixes the corresponding logic in the index selection code
(which is incorrectly generating `/!NULL` spans).

Release note (sql change/bug fix): Fix tuple equality to evaluate correctly
in the presence of NULL elements.