### PR TITLE
opt: Add preliminary support for relational operators

### DIFF
--- a/pkg/sql/opt/build.go
+++ b/pkg/sql/opt/build.go
@@ -15,8 +15,10 @@
 package opt
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -120,13 +122,30 @@ var unaryOpReverseMap = [...]tree.UnaryOperator{
 	unaryComplementOp: tree.UnaryComplement,
 }
 
-// We allocate *scalarProps and *expr in chunks of these sizes.
+// We allocate *Expr, *scalarProps and *relationalProps in chunks of these sizes.
 const exprAllocChunk = 16
 const scalarPropsAllocChunk = 16
 
+// TODO(rytaft): Increase the relationalProps chunk size after more relational
+// operators are implemented.
+const relationalPropsAllocChunk = 1
+
 type buildContext struct {
-	preallocScalarProps []scalarProps
-	preallocExprs       []Expr
+	preallocScalarProps     []scalarProps
+	preallocExprs           []Expr
+	preallocRelationalProps []relationalProps
+	catalog                 optbase.Catalog
+	state                   queryState
+	ctx                     context.Context
+}
+
+func (bc *buildContext) newRelationalProps() *relationalProps {
+	if len(bc.preallocRelationalProps) == 0 {
+		bc.preallocRelationalProps = make([]relationalProps, relationalPropsAllocChunk)
+	}
+	p := &bc.preallocRelationalProps[0]
+	bc.preallocRelationalProps = bc.preallocRelationalProps[1:]
+	return p
 }
 
 func (bc *buildContext) newScalarProps() *scalarProps {
@@ -138,25 +157,185 @@ func (bc *buildContext) newScalarProps() *scalarProps {
 	return p
 }
 
-// newExpr returns a new *expr with a new, blank scalarProps.
+// newExpr returns a new *Expr.
 func (bc *buildContext) newExpr() *Expr {
 	if len(bc.preallocExprs) == 0 {
 		bc.preallocExprs = make([]Expr, exprAllocChunk)
 	}
 	e := &bc.preallocExprs[0]
 	bc.preallocExprs = bc.preallocExprs[1:]
+	return e
+}
+
+// newScalarExpr returns a new *Expr with a new, blank scalarProps.
+func (bc *buildContext) newScalarExpr() *Expr {
+	e := bc.newExpr()
 	e.scalarProps = bc.newScalarProps()
 	return e
 }
 
-// buildScalar converts a tree.TypedExpr to an expr tree.
+// newRelationalExpr returns a new *Expr with a new, blank relationalProps.
+func (bc *buildContext) newRelationalExpr() *Expr {
+	e := bc.newExpr()
+	e.relProps = bc.newRelationalProps()
+	return e
+}
+
+// build converts a tree.Statement to an Expr tree.
+func (bc *buildContext) build(stmt tree.Statement) *Expr {
+	var result *Expr
+	switch stmt := stmt.(type) {
+	case *tree.ParenSelect:
+		result = bc.buildSelect(stmt.Select)
+
+	case *tree.Select:
+		result = bc.buildSelect(stmt)
+
+	default:
+		panic(fmt.Sprintf("unexpected statement: %T", stmt))
+	}
+
+	return result
+}
+
+// buildSelect converts a tree.Select to an Expr tree. This method will
+// expand significantly once we implement joins, aggregations, filters, etc.
+func (bc *buildContext) buildSelect(stmt *tree.Select) *Expr {
+	var result *Expr
+	switch t := stmt.Select.(type) {
+	case *tree.ParenSelect:
+		result = bc.buildSelect(t.Select)
+
+	case *tree.SelectClause:
+		if t.Where != nil || (t.GroupBy != nil && len(t.GroupBy) > 0) || len(t.Exprs) > 1 || t.Distinct {
+			panic("complex queries not yet supported.")
+		}
+		result = bc.buildFrom(t.From)
+
+	default:
+		panic(fmt.Sprintf("unexpected select statement: %T", stmt.Select))
+	}
+
+	return result
+}
+
+// buildSelect converts a tree.From to an Expr tree. This method
+// will expand significantly once we implement joins and filters.
+func (bc *buildContext) buildFrom(from *tree.From) *Expr {
+	if len(from.Tables) != 1 {
+		panic("joins not yet supported.")
+	}
+	return bc.buildTable(from.Tables[0])
+}
+
+// buildTable converts a tree.TableExpr to an Expr tree.  For example,
+// if the tree.TableExpr consists of a single table, the resulting Expr
+// tree would consist of a single expression with a scanOp operator.
+func (bc *buildContext) buildTable(texpr tree.TableExpr) *Expr {
+	// NB: The case statements are sorted lexicographically.
+	switch source := texpr.(type) {
+	case *tree.AliasedTableExpr:
+		result := bc.buildTable(source.Expr)
+		if source.As.Alias != "" {
+			if n := len(source.As.Cols); n > 0 && n != len(result.relProps.columns) {
+				panic(fmt.Sprintf("rename specified %d columns, but table contains %d",
+					n, len(result.relProps.columns)))
+			}
+
+			for i := range result.relProps.columns {
+				col := &result.relProps.columns[i]
+				if i < len(source.As.Cols) {
+					col.name = columnName(source.As.Cols[i])
+				}
+				col.table = tableName(source.As.Alias)
+			}
+		}
+		return result
+
+	case *tree.FuncExpr:
+		panic(fmt.Sprintf("unimplemented table expr: %T", texpr))
+
+	case *tree.JoinTableExpr:
+		panic(fmt.Sprintf("unimplemented table expr: %T", texpr))
+
+	case *tree.NormalizableTableName:
+		tn, err := source.Normalize()
+		if err != nil {
+			panic(fmt.Sprintf("%s", err))
+		}
+		tab, err := bc.catalog.FindTable(bc.ctx, tn)
+		if err != nil {
+			panic(fmt.Sprintf("%s", err))
+		}
+
+		return bc.buildScan(tab)
+
+	case *tree.ParenTableExpr:
+		return bc.buildTable(source.Expr)
+
+	case *tree.StatementSource:
+		panic(fmt.Sprintf("unimplemented table expr: %T", texpr))
+
+	case *tree.Subquery:
+		return bc.build(source.Select)
+
+	case *tree.TableRef:
+		panic(fmt.Sprintf("unimplemented table expr: %T", texpr))
+
+	default:
+		panic(fmt.Sprintf("unexpected table expr: %T", texpr))
+	}
+}
+
+// buildScan creates an Expr with a scanOp operator for the given table.
+func (bc *buildContext) buildScan(tab optbase.Table) *Expr {
+	result := bc.newRelationalExpr()
+	initScanExpr(result, tab)
+	result.relProps.columns = make([]columnProps, 0, len(tab.TabName()))
+	props := result.relProps
+
+	// Every reference to a table in the query gets a new set of output column
+	// indexes. Consider the query:
+	//
+	//   SELECT * FROM a AS l JOIN a AS r ON (l.x = r.y)
+	//
+	// In this query, `l.x` is not equivalent to `r.x` and `l.y` is not
+	// equivalent to `r.y`. In order to achieve this, we need to give these
+	// columns different indexes.
+	tabName := tableName(tab.TabName())
+	bc.state.tables[tabName] = append(bc.state.tables[tabName], bc.state.nextColumnIndex)
+
+	for i := 0; i < tab.NumColumns(); i++ {
+		col := tab.Column(i)
+		colProps := columnProps{
+			index: bc.state.nextColumnIndex,
+			name:  columnName(col.ColName()),
+			table: tabName,
+			typ:   col.DatumType(),
+		}
+		props.columns = append(props.columns, colProps)
+		bc.state.nextColumnIndex++
+	}
+
+	// Initialize not-NULL columns from the table schema.
+	for i := 0; i < tab.NumColumns(); i++ {
+		if !tab.Column(i).IsNullable() {
+			props.notNullCols.Add(props.columns[i].index)
+		}
+	}
+
+	result.initProps()
+	return result
+}
+
+// buildScalar converts a tree.TypedExpr to an Expr tree.
 func (bc *buildContext) buildScalar(pexpr tree.TypedExpr) *Expr {
 	switch t := pexpr.(type) {
 	case *tree.ParenExpr:
 		return bc.buildScalar(t.TypedInnerExpr())
 	}
 
-	e := bc.newExpr()
+	e := bc.newScalarExpr()
 	e.scalarProps.typ = pexpr.ResolvedType()
 
 	switch t := pexpr.(type) {
@@ -225,7 +404,22 @@ func (bc *buildContext) buildScalar(pexpr tree.TypedExpr) *Expr {
 	return e
 }
 
-// buildScalar converts a tree.TypedExpr to an expr tree.
+// build converts a tree.Statement to an Expr tree.
+func build(ctx context.Context, stmt tree.Statement, catalog optbase.Catalog) (_ *Expr, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+	buildCtx := buildContext{
+		catalog: catalog,
+		state:   queryState{tables: make(map[tableName][]columnIndex)},
+		ctx:     ctx,
+	}
+	return buildCtx.build(stmt), nil
+}
+
+// buildScalar converts a tree.TypedExpr to an Expr tree.
 func buildScalar(pexpr tree.TypedExpr) (_ *Expr, err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/pkg/sql/opt/expr.go
+++ b/pkg/sql/opt/expr.go
@@ -14,7 +14,12 @@
 
 package opt
 
-import "github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+)
 
 // Expr implements the node of a unified expressions tree for both relational
 // and scalar expressions in a query.
@@ -23,12 +28,58 @@ import "github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 // types of properties depend on the expression type (or equivalently, operator
 // type). For scalar expressions, the properties are stored in scalarProps. An
 // example of a scalar property is the type (types.T) of the scalar expression.
+// For relational expressions, the properties are stored in relProps. An example
+// of a relational property is the set of columns referenced in the expression.
 //
-// Currently, Expr only supports scalar expressions and operators. More
-// information pertaining to relational operators will be added when they are
-// supported.
+// Every unique column and every projection (that is more than just a pass
+// through of a column) is given a column index within the query. Additionally,
+// every reference to a table in the query gets a new set of output column
+// indexes. Consider the query:
 //
-// TODO(radu): support relational operators and extend this description.
+//   SELECT * FROM a AS l JOIN a AS r ON (l.x = r.y)
+//
+// In this query, `l.x` is not equivalent to `r.x` and `l.y` is not
+// equivalent to `r.y`. In order to achieve this, we need to give these
+// columns different indexes.
+//
+// In all cases, the column indexes are global to the query. For example,
+// consider the query:
+//
+//   SELECT x FROM a WHERE y > 0
+//
+// There are 2 columns in the above query: x and y. During name resolution, the
+// above query becomes:
+//
+//   SELECT [0] FROM a WHERE [1] > 0
+//   -- [0] -> x
+//   -- [1] -> y
+//
+// Relational expressions are composed of inputs, and optional auxiliary
+// expressions (not yet implemented). The output columns are derived by the
+// operator from the inputs and stored in relProps.columns.
+//
+//   +---------+---------+-------+--------+
+//   |  out 0  |  out 1  |  ...  |  out N |
+//   +---------+---------+-------+--------+
+//   |                operator            |
+//   +---------+---------+-------+--------+
+//   |  in 0   |  in 1   |  ...  |  in N  |
+//   +---------+---------+-------+--------+
+//
+// A query is composed of a tree of relational expressions. For example, a
+// simple join might look like:
+//
+//   +-----------+
+//   | join a, b |
+//   +-----------+
+//      |     |
+//      |     |   +--------+
+//      |     +---| scan b |
+//      |         +--------+
+//      |
+//      |    +--------+
+//      +----| scan a |
+//           +--------+
 type Expr struct {
 	op operator
 	// Child expressions. The interpretation of the children is operator
@@ -36,7 +87,10 @@ type Expr struct {
 	// left-hand side and the right-hand side); for an andOp, there are at least
 	// two child expressions (each one being a conjunct).
 	children []*Expr
+	// Relational properties. Nil for scalar expressions.
+	relProps *relationalProps
 	// Scalar properties (properties that pertain only to scalar operators).
+	// Nil for relational expressions.
 	scalarProps *scalarProps
 	// Operator-dependent data used by this expression. For example, constOp
 	// stores a pointer to the constant value.
@@ -61,6 +115,19 @@ func normalizeExprNode(e *Expr) {
 	if normalizeFn := operatorTab[e.op].normalizeFn; normalizeFn != nil {
 		normalizeFn(e)
 	}
+}
+
+// formatRelational adds a node for a relational operator and returns a
+// reference to the new treeprinter.Node (for adding more children).
+func formatRelational(e *Expr, tp treeprinter.Node) treeprinter.Node {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%v", e.op)
+	if !e.relProps.outputCols.Empty() {
+		fmt.Fprintf(&buf, " [out=%s]", e.relProps.outputCols)
+	}
+	n := tp.Child(buf.String())
+	e.relProps.format(n)
+	return n
 }
 
 // formatExprs formats the given expressions as children of the same
@@ -89,6 +156,12 @@ func (e *Expr) String() string {
 	tp := treeprinter.New()
 	e.format(tp)
 	return tp.String()
+}
+
+func (e *Expr) initProps() {
+	if e.relProps != nil {
+		e.relProps.init()
+	}
 }
 
 func (e *Expr) shallowCopy() *Expr {

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -25,7 +25,13 @@ type operator uint8
 const (
 	unknownOp operator = iota
 
-	// TODO(radu): no relational operators yet.
+	// -- Relational operators --
+	// This list will grow significantly as we implement new operators.
+	// The only relational operator implemented so far is scanOp.
+
+	// scan is the lowest level relational operator, responsible for scanning
+	// tables.
+	scanOp
 
 	// -- Scalar operators --
 

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -66,6 +66,7 @@ package opt
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -77,13 +78,18 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 )
 
@@ -284,8 +290,22 @@ func runTest(t *testing.T, path string, f func(d *testdata) string) {
 	}
 }
 
+// testCatalog implements the sqlbase.Catalog interface.
+type testCatalog struct {
+	kvDB *client.DB
+}
+
+// FindTable implements the sqlbase.Catalog interface.
+func (c testCatalog) FindTable(ctx context.Context, name *tree.TableName) (optbase.Table, error) {
+	return sqlbase.GetTableDescriptor(c.kvDB, string(name.DatabaseName), string(name.TableName)), nil
+}
+
 func TestOpt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	catalog := testCatalog{kvDB: kvDB}
 
 	paths, err := filepath.Glob(*logicTestData)
 	if err != nil {
@@ -338,28 +358,52 @@ func TestOpt(t *testing.T) {
 						d.fatalf(t, "unknown argument: %s", key)
 					}
 				}
+				getTypedExpr := func() tree.TypedExpr {
+					if typedExpr == nil {
+						var err error
+						typedExpr, err = parseScalarExpr(d.sql, &iVarHelper)
+						if err != nil {
+							d.fatalf(t, "%v", err)
+						}
+					}
+					return typedExpr
+				}
 				buildScalarFn := func() {
 					var err error
-					e, err = buildScalar(typedExpr)
+					e, err = buildScalar(getTypedExpr())
 					if err != nil {
 						t.Fatal(err)
 					}
 				}
 
 				evalCtx := tree.MakeTestingEvalContext()
-				var err error
-				typedExpr, err = parseScalarExpr(d.sql, &iVarHelper)
-				if err != nil {
-					d.fatalf(t, "%v", err)
-				}
 				for _, cmd := range strings.Split(d.cmd, ",") {
 					switch cmd {
 					case "semtree-normalize":
 						// Apply the TypedExpr normalization and rebuild the expression.
-						typedExpr, err = evalCtx.NormalizeExpr(typedExpr)
+						typedExpr, err = evalCtx.NormalizeExpr(getTypedExpr())
 						if err != nil {
 							d.fatalf(t, "%v", err)
 						}
+
+					case "exec":
+						_, err := sqlDB.Exec(d.sql)
+						if err != nil {
+							d.fatalf(t, "%v", err)
+						}
+						return ""
+
+					case "build":
+						stmt, err := parser.ParseOne(d.sql)
+						if err != nil {
+							d.fatalf(t, "%v", err)
+						}
+						e, err = build(ctx, stmt, catalog)
+						if err != nil {
+							return fmt.Sprintf("error: %v\n", err)
+						}
+						return e.String()
+
 					case "build-scalar":
 						buildScalarFn()
 

--- a/pkg/sql/opt/relational_props.go
+++ b/pkg/sql/opt/relational_props.go
@@ -1,0 +1,135 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package opt
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+)
+
+type tableName string
+type columnName string
+type columnSet = util.FastIntSet
+type columnIndex = int
+
+// queryState holds per-query state.
+type queryState struct {
+	// Map from table name to the column index for the table's columns within the
+	// query (they form a contiguous group starting at this index). Note that a
+	// table can occur multiple times in a query and each occurrence is given its
+	// own column indexes so the map is from table name to slice of base indexes.
+	// For example, consider the query:
+	//
+	//   SELECT * FROM a AS l JOIN a AS r ON (l.x = r.y)
+	//
+	// In this query, `l.x` is not equivalent to `r.x` and `l.y` is not
+	// equivalent to `r.y`. In order to achieve this, we need to give these
+	// columns different indexes.
+	//
+	// Therefore, the tables map might look like this:
+	//   a -> [0, 2]
+	//
+	// columnIndex 0 is the first of two columnIndexes corresponding to the
+	// columns x and y from table a AS l. Likewise, columnIndex 2 is the first of
+	// two columnIndexes for table a AS r.
+	tables map[tableName][]columnIndex
+
+	// nextColumnIndex is the next unique column index. This field is incremented
+	// each time a new column is added to the query Expr tree.
+	nextColumnIndex columnIndex
+}
+
+// columnProps holds properties about each column in a relational expression.
+type columnProps struct {
+	// name is the column name.
+	name columnName
+
+	// table is the name of the table.
+	table tableName
+
+	// typ contains the datum type held by the column.
+	typ types.T
+
+	// index is the index for this column, which is unique across all the
+	// columns in the expression.
+	index columnIndex
+}
+
+func (c columnProps) String() string {
+	if c.table == "" {
+		return tree.Name(c.name).String()
+	}
+	return fmt.Sprintf("%s.%s", tree.Name(c.table), tree.Name(c.name))
+}
+
+// relationalProps holds properties of a relational expression.
+type relationalProps struct {
+	// outputCols is the output column set.
+	outputCols columnSet
+
+	// notNullCols is a column set indicating which output columns are known to
+	// never be NULL. The NULL-ability of columns flows from the inputs and can
+	// also be derived from filters that are NULL-intolerant.
+	notNullCols columnSet
+
+	// columns is the set of all columns used in the relational expression.
+	columns []columnProps
+}
+
+func (p *relationalProps) init() {
+	p.outputCols = p.availableOutputCols()
+}
+
+func (p *relationalProps) String() string {
+	tp := treeprinter.New()
+	p.format(tp)
+	return tp.String()
+}
+
+func (p *relationalProps) format(tp treeprinter.Node) {
+	var buf bytes.Buffer
+	if len(p.columns) > 0 {
+		buf.WriteString("columns:")
+		for _, col := range p.columns {
+			buf.WriteString(" ")
+			buf.WriteString(string(col.table))
+			buf.WriteString(".")
+			buf.WriteString(string(col.name))
+			buf.WriteString(":")
+			buf.WriteString(col.typ.String())
+			if !p.notNullCols.Contains(col.index) {
+				buf.WriteString(",null")
+			}
+			buf.WriteString(":")
+			fmt.Fprintf(&buf, "%d", col.index)
+
+		}
+		tp.Child(buf.String())
+	}
+}
+
+// availableOutputCols returns the set of columns output by the expression.
+func (p *relationalProps) availableOutputCols() columnSet {
+	var v columnSet
+	for _, col := range p.columns {
+		v.Add(col.index)
+	}
+	return v
+}

--- a/pkg/sql/opt/scan.go
+++ b/pkg/sql/opt/scan.go
@@ -12,25 +12,26 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package opt_test
+package opt
 
 import (
-	"os"
-	"testing"
-
-	"github.com/cockroachdb/cockroach/pkg/security"
-	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
-	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
-//go:generate ../../util/leaktest/add-leaktest.sh *_test.go
+func init() {
+	registerOperator(scanOp, operatorInfo{name: "scan", class: scanClass{}})
+}
 
-func TestMain(m *testing.M) {
-	security.SetAssetLoader(securitytest.EmbeddedAssets)
-	randutil.SeedForTests()
-	serverutils.InitTestServerFactory(server.TestServerFactory)
+func initScanExpr(e *Expr, tab optbase.Table) {
+	e.op = scanOp
+	e.private = tab
+}
 
-	os.Exit(m.Run())
+type scanClass struct{}
+
+var _ operatorClass = scanClass{}
+
+func (scanClass) format(e *Expr, tp treeprinter.Node) {
+	formatRelational(e, tp)
 }

--- a/pkg/sql/opt/testdata/build
+++ b/pkg/sql/opt/testdata/build
@@ -1,0 +1,26 @@
+exec
+CREATE DATABASE t
+
+exec
+CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)
+
+build
+SELECT * FROM t.a
+----
+scan [out=(0,1)]
+ └── columns: a.x:int:0 a.y:float,null:1
+
+build
+SELECT * FROM t.b
+----
+error: table missing
+
+build
+SELECT * FROM b
+----
+error: database missing
+
+build
+SELECT * FROM u.a
+----
+error: database missing

--- a/pkg/sql/optbase/catalog.go
+++ b/pkg/sql/optbase/catalog.go
@@ -1,0 +1,59 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbase
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// This file contains interfaces that are used by the query optimizer to avoid
+// including specifics of sqlbase structures in the opt code.
+
+// Column is an interface to a table column, exposing only the information
+// needed by the query optimizer.
+type Column interface {
+	// IsNullable returns true if the column is nullable.
+	IsNullable() bool
+
+	// ColName returns the name of the column.
+	ColName() string
+
+	// DatumType returns the data type of the column.
+	DatumType() types.T
+}
+
+// Table is an interface to a database table, exposing only the information
+// needed by the query optimizer.
+type Table interface {
+	// TabName returns the name of the table.
+	TabName() string
+
+	// NumColumns returns the number of columns in the table.
+	NumColumns() int
+
+	// Column returns a Column interface to the ith column of the table.
+	Column(i int) Column
+}
+
+// Catalog is an interface to a database catalog, exposing only the information
+// needed by the query optimizer.
+type Catalog interface {
+	// FindTable returns a Table interface for the database table matching the
+	// given table name.  Returns an error if the table does not exist.
+	FindTable(ctx context.Context, name *tree.TableName) (Table, error)
+}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -2538,4 +2539,34 @@ var ForeignKeyReferenceActionValue = [...]ForeignKeyReference_Action{
 	tree.SetDefault: ForeignKeyReference_SET_DEFAULT,
 	tree.SetNull:    ForeignKeyReference_SET_NULL,
 	tree.Cascade:    ForeignKeyReference_CASCADE,
+}
+
+// IsNullable is part of the optbase.Column interface.
+func (desc *ColumnDescriptor) IsNullable() bool {
+	return desc.Nullable
+}
+
+// ColName is part of the optbase.Column interface.
+func (desc *ColumnDescriptor) ColName() string {
+	return desc.Name
+}
+
+// DatumType is part of the optbase.Column interface.
+func (desc *ColumnDescriptor) DatumType() types.T {
+	return desc.Type.ToDatumType()
+}
+
+// TabName is part of the optbase.Table interface.
+func (desc *TableDescriptor) TabName() string {
+	return desc.GetName()
+}
+
+// NumColumns is part of the optbase.Table interface.
+func (desc *TableDescriptor) NumColumns() int {
+	return len(desc.Columns)
+}
+
+// Column is part of the optbase.Table interface.
+func (desc *TableDescriptor) Column(i int) optbase.Column {
+	return &desc.Columns[i]
 }


### PR DESCRIPTION
This is the first commit of many needed to support relational operators
in the query optimizer. This commit adds the scaffolding to allow building
a relational Expr tree from a SQL query. Expressions (Expr objects) now
include optional relational properties (nil for scalar expressions) such
as the set of columns output by the expression.

As a proof of concept, this commit includes support for building an
Expr tree for the simplest of queries: `SELECT * from t`. The resulting
Expr tree consists of a single Expr with a single relational operator,
the `scanOp`. Future commits will add other relational operators and
functionality to build an Expr tree with those operators.

This code is based on code originally written by @petermattis in the
opttoy project.

Release note: None