### PR TITLE
sql, sem/tree: revisit the NodeFormatter interface

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -322,7 +322,7 @@ func backupJobDescription(
 		}
 		b.IncrementalFrom = append(b.IncrementalFrom, tree.NewDString(sanitizedFrom))
 	}
-	return tree.AsStringWithFlags(b, tree.FmtSimpleQualified), nil
+	return tree.AsStringWithFlags(b, tree.FmtAlwaysQualifyTableNames), nil
 }
 
 // clusterNodeCount returns the approximate number of nodes in the cluster.

--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -864,7 +864,7 @@ func importJobDescription(
 		stmt.Options = append(stmt.Options, tree.KVOption{Key: importOptionTransformOnly})
 	}
 	sort.Slice(stmt.Options, func(i, j int) bool { return stmt.Options[i].Key < stmt.Options[j].Key })
-	return tree.AsStringWithFlags(&stmt, tree.FmtSimpleQualified), nil
+	return tree.AsStringWithFlags(&stmt, tree.FmtAlwaysQualifyTableNames), nil
 }
 
 const importCSVEnabledSetting = "experimental.importcsv.enabled"

--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -1012,7 +1012,7 @@ func importPlanHook(
 
 		var create *tree.CreateTable
 		if importStmt.CreateDefs != nil {
-			normName := tree.NormalizableTableName{TableNameReference: importStmt.Table}
+			normName := tree.NormalizableTableName{TableNameReference: &importStmt.Table}
 			create = &tree.CreateTable{Table: normName, Defs: importStmt.CreateDefs}
 		} else {
 			filename, err := createFileFn()

--- a/pkg/ccl/sqlccl/partition_test.go
+++ b/pkg/ccl/sqlccl/partition_test.go
@@ -99,7 +99,7 @@ type repartitioningTest struct {
 
 // parse fills in the various fields of `partitioningTest.parsed`.
 func (t *partitioningTest) parse() error {
-	t.parsed.tableName = tree.Name(t.name).String()
+	t.parsed.tableName = tree.NameStringP(&t.name)
 	t.parsed.createStmt = fmt.Sprintf(t.schema, t.parsed.tableName)
 
 	{
@@ -148,7 +148,7 @@ func (t *partitioningTest) parse() error {
 			if len(constraints) > 0 {
 				fmt.Fprintf(&zoneConfigStmts,
 					`ALTER INDEX %s@%s EXPERIMENTAL CONFIGURE ZONE 'constraints: [%s]';`,
-					tree.Name(t.name), idxDesc.Name, constraints,
+					t.parsed.tableName, idxDesc.Name, constraints,
 				)
 			}
 		} else if strings.HasPrefix(subzoneShort, ".") {
@@ -159,7 +159,7 @@ func (t *partitioningTest) parse() error {
 			if len(constraints) > 0 {
 				fmt.Fprintf(&zoneConfigStmts,
 					`ALTER PARTITION %s OF TABLE %s EXPERIMENTAL CONFIGURE ZONE 'constraints: [%s]';`,
-					subzone.PartitionName, tree.Name(t.name), constraints,
+					subzone.PartitionName, t.parsed.tableName, constraints,
 				)
 			}
 		}
@@ -188,7 +188,7 @@ func (t *partitioningTest) parse() error {
 func (t *partitioningTest) verifyScansFn(ctx context.Context, db *gosql.DB) func() error {
 	return func() error {
 		for where, expectedNodes := range t.scans {
-			query := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE %s`, tree.Name(t.name), where)
+			query := fmt.Sprintf(`SELECT COUNT(*) FROM %s WHERE %s`, tree.NameStringP(&t.name), where)
 			log.Infof(ctx, "query: %s", query)
 			if err := verifyScansOnNode(db, query, expectedNodes); err != nil {
 				if log.V(1) {

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -89,7 +89,7 @@ func selectTargets(
 		}
 	}
 	if !seenTable {
-		return nil, nil, errors.Errorf("no tables found: %s", tree.AsString(targets))
+		return nil, nil, errors.Errorf("no tables found: %s", &targets)
 	}
 
 	if lastBackupDesc.FormatVersion >= BackupFormatDescriptorTrackingVersion {

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -775,7 +775,7 @@ func restoreJobDescription(restore *tree.Restore, from []string) (string, error)
 		r.From[i] = tree.NewDString(sf)
 	}
 
-	return tree.AsStringWithFlags(r, tree.FmtSimpleQualified), nil
+	return tree.AsStringWithFlags(r, tree.FmtAlwaysQualifyTableNames), nil
 }
 
 // restore imports a SQL table (or tables) from sets of non-overlapping sstable

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -79,7 +79,7 @@ func (c *sqlConn) ensureConn() error {
 		if c.reconnecting && c.dbName != "" {
 			// Attempt to reset the current database.
 			if _, err := conn.(sqlConnI).Exec(
-				`SET DATABASE = `+tree.Name(c.dbName).String(), nil,
+				`SET DATABASE = `+tree.NameStringP(&c.dbName), nil,
 			); err != nil {
 				fmt.Fprintf(stderr, "warning: unable to restore current database: %v\n", err)
 			}

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -86,7 +86,7 @@ func runGetZone(cmd *cobra.Command, args []string) error {
 	defer conn.Close()
 
 	vals, err := conn.QueryRow(fmt.Sprintf(
-		`SELECT cli_specifier, config_yaml FROM [EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s]`, zs), nil)
+		`SELECT cli_specifier, config_yaml FROM [EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s]`, &zs), nil)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 	defer conn.Close()
 
 	return runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(fmt.Sprintf(`ALTER %s EXPERIMENTAL CONFIGURE ZONE NULL`, zs)))
+		makeQuery(fmt.Sprintf(`ALTER %s EXPERIMENTAL CONFIGURE ZONE NULL`, &zs)))
 }
 
 // A setZoneCmd command creates a new or updates an existing zone config.
@@ -242,12 +242,12 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 	}
 
 	err = conn.ExecTxn(func(conn *sqlConn) error {
-		if err := conn.Exec(fmt.Sprintf(`ALTER %s EXPERIMENTAL CONFIGURE ZONE %s`, zs,
+		if err := conn.Exec(fmt.Sprintf(`ALTER %s EXPERIMENTAL CONFIGURE ZONE %s`, &zs,
 			lex.EscapeSQLString(string(configYAML))), nil); err != nil {
 			return err
 		}
 		vals, err := conn.QueryRow(fmt.Sprintf(
-			`SELECT config_yaml FROM [EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s]`, zs), nil)
+			`SELECT config_yaml FROM [EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s]`, &zs), nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -151,7 +151,7 @@ func CLIZoneSpecifier(zs tree.ZoneSpecifier) string {
 		// The index is redundant when the partition is specified, so omit it.
 		ti.Index = ""
 	}
-	return tree.AsStringWithFlags(&ti, tree.FmtSimpleQualified)
+	return tree.AsStringWithFlags(&ti, tree.FmtAlwaysQualifyTableNames)
 }
 
 // ResolveZoneSpecifier converts a zone specifier to the ID of most specific

--- a/pkg/config/zone_test.go
+++ b/pkg/config/zone_test.go
@@ -311,7 +311,7 @@ func TestZoneSpecifiers(t *testing.T) {
 				if e, a := tc.id, int(id); a != e {
 					t.Errorf("path %d did not match expected path %d", a, e)
 				}
-				if e, a := tc.cliSpecifier, config.CLIZoneSpecifier(zs); e != a {
+				if e, a := tc.cliSpecifier, config.CLIZoneSpecifier(&zs); e != a {
 					t.Errorf("expected %q to roundtrip, but got %q", e, a)
 				}
 				return nil
@@ -348,7 +348,7 @@ func TestZoneSpecifiers(t *testing.T) {
 			if tc.err != "" {
 				return
 			}
-			if e, a := tc.cliSpecifier, config.CLIZoneSpecifier(zs); e != a {
+			if e, a := tc.cliSpecifier, config.CLIZoneSpecifier(&zs); e != a {
 				t.Errorf("expected %q specifier for ID %d, but got %q", e, tc.id, a)
 			}
 		})

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -197,7 +197,7 @@ func (s *adminServer) DatabaseDetails(
 	ctx, session := s.NewContextAndSessionForRPC(ctx, args)
 	defer session.Finish(s.server.sqlExecutor)
 
-	escDBName := tree.Name(req.Database).String()
+	escDBName := tree.NameStringP(&req.Database)
 	if err := s.assertNotVirtualSchema(escDBName); err != nil {
 		return nil, err
 	}
@@ -296,14 +296,14 @@ func (s *adminServer) TableDetails(
 	ctx, session := s.NewContextAndSessionForRPC(ctx, args)
 	defer session.Finish(s.server.sqlExecutor)
 
-	escDBName := tree.Name(req.Database).String()
+	escDBName := tree.NameStringP(&req.Database)
 	if err := s.assertNotVirtualSchema(escDBName); err != nil {
 		return nil, err
 	}
 
 	// TODO(cdo): Use real placeholders for the table and database names when we've extended our SQL
 	// grammar to allow that.
-	escTableName := tree.Name(req.Table).String()
+	escTableName := tree.NameStringP(&req.Table)
 	escQualTable := fmt.Sprintf("%s.%s", escDBName, escTableName)
 	query := fmt.Sprintf("SHOW COLUMNS FROM %[1]s; SHOW INDEX FROM %[1]s; SHOW GRANTS ON TABLE %[1]s; SHOW CREATE TABLE %[1]s;",
 		escQualTable)
@@ -505,7 +505,7 @@ func (s *adminServer) TableDetails(
 func (s *adminServer) TableStats(
 	ctx context.Context, req *serverpb.TableStatsRequest,
 ) (*serverpb.TableStatsResponse, error) {
-	escDBName := tree.Name(req.Database).String()
+	escDBName := tree.NameStringP(&req.Database)
 	if err := s.assertNotVirtualSchema(escDBName); err != nil {
 		return nil, err
 	}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -426,8 +426,8 @@ func TestAdminAPITableDetails(t *testing.T) {
 			defer s.Stopper().Stop(context.TODO())
 			ts := s.(*TestServer)
 
-			escDBName := tree.Name(tc.dbName).String()
-			escTblName := tree.Name(tc.tblName).String()
+			escDBName := tree.NameStringP(&tc.dbName)
+			escTblName := tree.NameStringP(&tc.tblName)
 
 			ac := log.AmbientContext{Tracer: s.ClusterSettings().Tracer}
 			ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -85,7 +85,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 	var err error
 	if addedMutations {
 		mutationID, err = params.p.createSchemaChangeJob(params.ctx, n.tableDesc,
-			tree.AsStringWithFlags(n.n, tree.FmtSimpleQualified))
+			tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames))
 	} else if descriptorChanged {
 		err = n.tableDesc.SetUpVersion()
 	}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -616,7 +616,7 @@ func exprContainsColumnName(expr tree.Expr, col sqlbase.ColumnDescriptor) (bool,
 			exprContainsColumnName = true
 		}
 		// Convert to a dummy node of the correct type.
-		return nil, false, dummyColumnItem{col.Type.ToDatumType()}
+		return nil, false, &dummyColumnItem{col.Type.ToDatumType()}
 	}
 
 	_, err := tree.SimpleVisit(expr, preFn)

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -298,7 +298,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 						if err := params.p.dropIndexByName(
 							params.ctx, tree.UnrestrictedName(idx.Name), n.tableDesc, false,
 							t.DropBehavior, ignoreIdxConstraint,
-							tree.AsStringWithFlags(n.n, tree.FmtSimpleQualified),
+							tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames),
 						); err != nil {
 							return err
 						}
@@ -504,7 +504,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 	var err error
 	if addedMutations {
 		mutationID, err = params.p.createSchemaChangeJob(params.ctx, n.tableDesc,
-			tree.AsStringWithFlags(n.n, tree.FmtSimpleQualified))
+			tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames))
 	} else {
 		err = n.tableDesc.SetUpVersion()
 	}

--- a/pkg/sql/analyze_expr.go
+++ b/pkg/sql/analyze_expr.go
@@ -58,7 +58,7 @@ func (p *planner) analyzeExpr(
 		if err != nil {
 			return nil, err
 		}
-		p.hasStar = p.hasStar || hasStar
+		p.curPlan.hasStar = p.curPlan.hasStar || hasStar
 	}
 
 	// Type check.

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -267,7 +267,9 @@ func scrubStmtStatKey(vt virtualSchemaHolder, key string) (string, bool) {
 	}
 
 	// Re-format to remove most names.
-	formatter := tree.FmtReformatTableNames(tree.FmtAnonymize,
+	var buf bytes.Buffer
+	fmtCtx := tree.MakeFmtCtx(&buf, tree.FmtAnonymize)
+	fmtCtx.WithReformatTableNames(
 		func(ctx *tree.FmtCtx, t *tree.NormalizableTableName) {
 			tn, err := t.Normalize()
 			if err != nil {
@@ -283,7 +285,8 @@ func scrubStmtStatKey(vt virtualSchemaHolder, key string) (string, bool) {
 			keepNameCtx := ctx.CopyWithFlags(tree.FmtParsable)
 			keepNameCtx.FormatNode(tn)
 		})
-	return tree.AsStringWithFlags(stmt, formatter), true
+	fmtCtx.FormatNode(stmt)
+	return buf.String(), true
 }
 
 // GetScrubbedStmtStats returns the statement statistics by app, with the

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -201,10 +201,6 @@ func (p *planner) validateForeignKey(
 		return err
 	}
 
-	escape := func(s string) string {
-		return tree.Name(s).String()
-	}
-
 	prefix := len(srcIdx.ColumnNames)
 	if p := len(targetIdx.ColumnNames); p < prefix {
 		prefix = p
@@ -214,8 +210,8 @@ func (p *planner) validateForeignKey(
 	join, where := make([]string, prefix), make([]string, prefix)
 
 	for i := 0; i < prefix; i++ {
-		srcCols[i] = fmt.Sprintf("s.%s", escape(srcIdx.ColumnNames[i]))
-		targetCols[i] = fmt.Sprintf("t.%s", escape(targetIdx.ColumnNames[i]))
+		srcCols[i] = fmt.Sprintf("s.%s", tree.NameString(srcIdx.ColumnNames[i]))
+		targetCols[i] = fmt.Sprintf("t.%s", tree.NameString(targetIdx.ColumnNames[i]))
 		join[i] = fmt.Sprintf("(%s = %s OR (%s IS NULL AND %s IS NULL))",
 			srcCols[i], targetCols[i], srcCols[i], targetCols[i])
 		where[i] = fmt.Sprintf("(%s IS NOT NULL AND %s IS NULL)", srcCols[i], targetCols[i])
@@ -224,7 +220,7 @@ func (p *planner) validateForeignKey(
 	query := fmt.Sprintf(
 		`SELECT %s FROM %s@%s AS s LEFT OUTER JOIN %s@%s AS t ON %s WHERE %s LIMIT 1`,
 		strings.Join(srcCols, ", "),
-		srcName, escape(srcIdx.Name), targetName, escape(targetIdx.Name),
+		srcName, tree.NameString(srcIdx.Name), targetName, tree.NameString(targetIdx.Name),
 		strings.Join(join, " AND "),
 		strings.Join(where, " OR "),
 	)

--- a/pkg/sql/coltypes/interface.go
+++ b/pkg/sql/coltypes/interface.go
@@ -30,7 +30,7 @@ type ColTypeFormatter interface {
 // ColTypeAsString print a T to a string.
 func ColTypeAsString(n ColTypeFormatter) string {
 	var buf bytes.Buffer
-	n.Format(&buf, lex.EncodeFlags{})
+	n.Format(&buf, lex.EncNoFlags)
 	return buf.String()
 }
 

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -340,7 +340,7 @@ func (p *planner) CopyData(ctx context.Context, n CopyDataBlock) (planNode, erro
 }
 
 // Format implements the NodeFormatter interface.
-func (CopyDataBlock) Format(buf *bytes.Buffer, f tree.FmtFlags) {}
+func (CopyDataBlock) Format(_ *tree.FmtCtx) {}
 
 // StatementType implements the Statement interface.
 func (CopyDataBlock) StatementType() tree.StatementType { return tree.RowsAffected }

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -138,7 +138,7 @@ func (s *Session) ProcessCopyData(
 		if buf.Len() > 0 {
 			err = cf.addRow(ctx, buf.Bytes(), &evalCtx)
 		}
-		return StatementList{{AST: CopyDataBlock{Done: true}}}, err
+		return StatementList{{AST: &CopyDataBlock{Done: true}}}, err
 	default:
 		return nil, fmt.Errorf("expected copy command")
 	}
@@ -165,7 +165,7 @@ func (s *Session) ProcessCopyData(
 			return nil, err
 		}
 	}
-	return StatementList{{AST: CopyDataBlock{}}}, nil
+	return StatementList{{AST: &CopyDataBlock{}}}, nil
 }
 
 func (n *copyNode) addRow(ctx context.Context, line []byte, evalCtx *tree.EvalContext) error {
@@ -312,7 +312,7 @@ var decodeMap = map[byte]byte{
 // CopyData is the statement type after a block of COPY data has been
 // received. There may be additional rows ready to insert. If so, return an
 // insertNode, otherwise emptyNode.
-func (p *planner) CopyData(ctx context.Context, n CopyDataBlock) (planNode, error) {
+func (p *planner) CopyData(ctx context.Context, n *CopyDataBlock) (planNode, error) {
 	// When this many rows are in the copy buffer, they are inserted.
 	const copyRowSize = 100
 
@@ -340,11 +340,11 @@ func (p *planner) CopyData(ctx context.Context, n CopyDataBlock) (planNode, erro
 }
 
 // Format implements the NodeFormatter interface.
-func (CopyDataBlock) Format(_ *tree.FmtCtx) {}
+func (*CopyDataBlock) Format(_ *tree.FmtCtx) {}
 
 // StatementType implements the Statement interface.
-func (CopyDataBlock) StatementType() tree.StatementType { return tree.RowsAffected }
+func (*CopyDataBlock) StatementType() tree.StatementType { return tree.RowsAffected }
 
 // StatementTag returns a short string identifying the type of statement.
-func (CopyDataBlock) StatementTag() string { return "" }
-func (CopyDataBlock) String() string       { return "CopyDataBlock" }
+func (*CopyDataBlock) StatementTag() string { return "" }
+func (*CopyDataBlock) String() string       { return "CopyDataBlock" }

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -912,13 +912,13 @@ CREATE TABLE crdb_internal.create_statements (
 				typeSequence := tree.DString("sequence")
 				if table.IsView() {
 					descType = &typeView
-					stmt, err = p.showCreateView(ctx, tree.Name(table.Name), table)
+					stmt, err = p.showCreateView(ctx, (*tree.Name)(&table.Name), table)
 				} else if table.IsSequence() {
 					descType = &typeSequence
-					stmt, err = p.showCreateSequence(ctx, tree.Name(table.Name), table)
+					stmt, err = p.showCreateSequence(ctx, (*tree.Name)(&table.Name), table)
 				} else {
 					descType = &typeTable
-					stmt, err = p.showCreateTable(ctx, tree.Name(table.Name), prefix, table)
+					stmt, err = p.showCreateTable(ctx, (*tree.Name)(&table.Name), prefix, table)
 				}
 				if err != nil {
 					return err
@@ -1499,7 +1499,7 @@ CREATE TABLE crdb_internal.zones (
 				}
 				if err := addRow(
 					r[0], // id
-					tree.NewDString(config.CLIZoneSpecifier(zs)),
+					tree.NewDString(config.CLIZoneSpecifier(&zs)),
 					tree.NewDBytes(tree.DBytes(configYAML)),
 					tree.NewDBytes(tree.DBytes(configBytes)),
 				); err != nil {
@@ -1530,7 +1530,7 @@ CREATE TABLE crdb_internal.zones (
 					}
 					if err := addRow(
 						r[0], // id
-						tree.NewDString(config.CLIZoneSpecifier(zs)),
+						tree.NewDString(config.CLIZoneSpecifier(&zs)),
 						tree.NewDBytes(tree.DBytes(configYAML)),
 						tree.NewDBytes(tree.DBytes(configBytes)),
 					); err != nil {

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -117,7 +117,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 	}
 
 	mutationID, err := params.p.createSchemaChangeJob(params.ctx, n.tableDesc,
-		tree.AsStringWithFlags(n.n, tree.FmtSimpleQualified))
+		tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames))
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1056,8 +1056,8 @@ func (d dummyColumnItem) String() string {
 }
 
 // Format implements the NodeFormatter interface.
-func (d dummyColumnItem) Format(buf *bytes.Buffer, _ tree.FmtFlags) {
-	buf.WriteString(d.String())
+func (d dummyColumnItem) Format(ctx *tree.FmtCtx) {
+	ctx.WriteString(d.String())
 }
 
 // Walk implements the Expr interface.

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -641,7 +641,7 @@ func addInterleave(
 		return pgerror.NewErrorf(
 			pgerror.CodeInvalidSchemaDefinitionError,
 			"declared interleaved columns (%s) must match the parent's primary index (%s)",
-			interleave.Fields,
+			&interleave.Fields,
 			strings.Join(parentIndex.ColumnNames, ", "),
 		)
 	}
@@ -649,7 +649,7 @@ func addInterleave(
 		return pgerror.NewErrorf(
 			pgerror.CodeInvalidSchemaDefinitionError,
 			"declared interleaved columns (%s) must be a prefix of the %s columns being interleaved (%s)",
-			interleave.Fields,
+			&interleave.Fields,
 			typeOfIndex,
 			strings.Join(index.ColumnNames, ", "),
 		)
@@ -668,7 +668,7 @@ func addInterleave(
 			return pgerror.NewErrorf(
 				pgerror.CodeInvalidSchemaDefinitionError,
 				"declared interleaved columns (%s) must refer to a prefix of the %s column names being interleaved (%s)",
-				interleave.Fields,
+				&interleave.Fields,
 				typeOfIndex,
 				strings.Join(index.ColumnNames, ", "),
 			)
@@ -677,7 +677,7 @@ func addInterleave(
 			return pgerror.NewErrorf(
 				pgerror.CodeInvalidSchemaDefinitionError,
 				"declared interleaved columns (%s) must match type and sort direction of the parent's primary index (%s)",
-				interleave.Fields,
+				&interleave.Fields,
 				strings.Join(parentIndex.ColumnNames, ", "),
 			)
 		}
@@ -1051,32 +1051,34 @@ type dummyColumnItem struct {
 }
 
 // String implements the Stringer interface.
-func (d dummyColumnItem) String() string {
-	return fmt.Sprintf("<%s>", d.typ)
+func (d *dummyColumnItem) String() string {
+	return tree.AsString(d)
 }
 
 // Format implements the NodeFormatter interface.
-func (d dummyColumnItem) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString(d.String())
+func (d *dummyColumnItem) Format(ctx *tree.FmtCtx) {
+	ctx.WriteByte('<')
+	ctx.WriteString(d.typ.String())
+	ctx.WriteByte('>')
 }
 
 // Walk implements the Expr interface.
-func (d dummyColumnItem) Walk(_ tree.Visitor) tree.Expr {
+func (d *dummyColumnItem) Walk(_ tree.Visitor) tree.Expr {
 	return d
 }
 
 // TypeCheck implements the Expr interface.
-func (d dummyColumnItem) TypeCheck(_ *tree.SemaContext, desired types.T) (tree.TypedExpr, error) {
+func (d *dummyColumnItem) TypeCheck(_ *tree.SemaContext, desired types.T) (tree.TypedExpr, error) {
 	return d, nil
 }
 
 // Eval implements the TypedExpr interface.
-func (dummyColumnItem) Eval(_ *tree.EvalContext) (tree.Datum, error) {
+func (*dummyColumnItem) Eval(_ *tree.EvalContext) (tree.Datum, error) {
 	panic("dummyColumnItem.Eval() is undefined")
 }
 
 // ResolvedType implements the TypedExpr interface.
-func (d dummyColumnItem) ResolvedType() types.T {
+func (d *dummyColumnItem) ResolvedType() types.T {
 	return d.typ
 }
 
@@ -1122,7 +1124,7 @@ func makeCheckConstraint(
 			nameBuf.WriteString(col.Name)
 		}
 		// Convert to a dummy node of the correct type.
-		return nil, false, dummyColumnItem{col.Type.ToDatumType()}
+		return nil, false, &dummyColumnItem{col.Type.ToDatumType()}
 	}
 
 	expr, err := tree.SimpleVisit(d.Expr, preFn)

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -63,10 +63,13 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 	// changes are persisted in n.AsSource. We use tree.FormatNode
 	// merely as a traversal method; its output buffer is discarded
 	// immediately after the traversal because it is not needed further.
-	var queryBuf bytes.Buffer
 	var fmtErr error
-	fmtCtx := tree.MakeFmtCtx(&queryBuf, tree.FmtParsable)
-	fmtCtx.WithReformatTableNames(
+	var f struct {
+		queryBuf bytes.Buffer // unused
+		ctx      tree.FmtCtx
+	}
+	f.ctx = tree.MakeFmtCtx(&f.queryBuf, tree.FmtParsable)
+	f.ctx.WithReformatTableNames(
 		func(_ *tree.FmtCtx, t *tree.NormalizableTableName) {
 			tn, err := p.QualifyWithDatabase(ctx, t)
 			if err != nil {
@@ -79,7 +82,7 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 			tn.DBNameOriginallyOmitted = false
 		},
 	)
-	fmtCtx.FormatNode(n.AsSource)
+	f.ctx.FormatNode(n.AsSource)
 
 	if fmtErr != nil {
 		return nil, fmtErr

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -65,11 +65,11 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 	// immediately after the traversal because it is not needed further.
 	var queryBuf bytes.Buffer
 	var fmtErr error
-	tree.FormatNode(
+	fmtCtx := tree.MakeFmtCtx(
 		&queryBuf,
 		tree.FmtReformatTableNames(
 			tree.FmtParsable,
-			func(t *tree.NormalizableTableName, buf *bytes.Buffer, f tree.FmtFlags) {
+			func(_ *tree.FmtCtx, t *tree.NormalizableTableName) {
 				tn, err := p.QualifyWithDatabase(ctx, t)
 				if err != nil {
 					log.Warningf(ctx, "failed to qualify table name %q with database name: %v",
@@ -80,9 +80,9 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 				// Persist the database prefix expansion.
 				tn.DBNameOriginallyOmitted = false
 			},
-		),
-		n.AsSource,
-	)
+		))
+	fmtCtx.FormatNode(n.AsSource)
+
 	if fmtErr != nil {
 		return nil, fmtErr
 	}

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -663,20 +663,20 @@ func (p *planner) getViewPlan(
 	}
 
 	// Register the dependency to the planner, if requested.
-	if p.planDeps != nil {
+	if p.curPlan.deps != nil {
 		usedColumns := make([]sqlbase.ColumnID, len(desc.Columns))
 		for i := range desc.Columns {
 			usedColumns[i] = desc.Columns[i].ID
 		}
-		deps := p.planDeps[desc.ID]
+		deps := p.curPlan.deps[desc.ID]
 		deps.desc = desc
 		deps.deps = append(deps.deps, sqlbase.TableDescriptor_Reference{ColumnIDs: usedColumns})
-		p.planDeps[desc.ID] = deps
+		p.curPlan.deps[desc.ID] = deps
 
 		// We are only interested in the dependency to this view descriptor. Any
 		// further dependency by the view's query should not be tracked in this planner.
-		defer func(prev planDependencies) { p.planDeps = prev }(p.planDeps)
-		p.planDeps = nil
+		defer func(prev planDependencies) { p.curPlan.deps = prev }(p.curPlan.deps)
+		p.curPlan.deps = nil
 	}
 
 	plan, err := p.newPlan(ctx, sel, nil)

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -553,7 +553,7 @@ func renameSource(
 				if tableAlias.DatabaseName != "" {
 					srcName = tree.ErrString(&tableAlias)
 				} else {
-					srcName = tree.ErrString(tableAlias.TableName)
+					srcName = tree.ErrString(&tableAlias.TableName)
 				}
 
 				return planDataSource{}, errors.Errorf(
@@ -771,8 +771,8 @@ func newUnknownSourceError(tn *tree.TableName) error {
 		"source name %q not found in FROM clause", tree.ErrString(tn))
 }
 
-func newAmbiguousSourceError(t tree.Name, dbContext tree.Name) error {
-	if dbContext == "" {
+func newAmbiguousSourceError(t *tree.Name, dbContext *tree.Name) error {
+	if *dbContext == "" {
 		return pgerror.NewErrorf(pgerror.CodeAmbiguousAliasError,
 			"ambiguous source name: %q", tree.ErrString(t))
 
@@ -792,7 +792,7 @@ func (sources multiSourceInfo) checkDatabaseName(tn tree.TableName) (tree.TableN
 			for _, alias := range src.sourceAliases {
 				if alias.name.TableName == tn.TableName {
 					if found {
-						return tree.TableName{}, newAmbiguousSourceError(tn.TableName, "")
+						return tree.TableName{}, newAmbiguousSourceError(&tn.TableName, &tree.NoName)
 					}
 					tn.DatabaseName = alias.name.DatabaseName
 					found = true
@@ -810,7 +810,7 @@ func (sources multiSourceInfo) checkDatabaseName(tn tree.TableName) (tree.TableN
 	for _, src := range sources {
 		if _, ok := src.sourceAliases.srcIdx(tn); ok {
 			if found {
-				return tree.TableName{}, newAmbiguousSourceError(tn.TableName, tn.DatabaseName)
+				return tree.TableName{}, newAmbiguousSourceError(&tn.TableName, &tn.DatabaseName)
 			}
 			found = true
 		}
@@ -830,7 +830,7 @@ func (src *dataSourceInfo) checkDatabaseName(tn tree.TableName) (tree.TableName,
 		for _, alias := range src.sourceAliases {
 			if alias.name.TableName == tn.TableName {
 				if found {
-					return tree.TableName{}, newAmbiguousSourceError(tn.TableName, "")
+					return tree.TableName{}, newAmbiguousSourceError(&tn.TableName, &tree.NoName)
 				}
 				found = true
 				tn.DatabaseName = alias.name.DatabaseName
@@ -946,14 +946,14 @@ type varFormatter struct {
 func (c *varFormatter) Format(ctx *tree.FmtCtx) {
 	if ctx.HasFlags(tree.FmtShowTableAliases) && c.TableName.TableName != "" {
 		if c.TableName.DatabaseName != "" {
-			ctx.FormatNode(c.TableName.DatabaseName)
+			ctx.FormatNode(&c.TableName.DatabaseName)
 			ctx.WriteByte('.')
 		}
 
-		ctx.FormatNode(c.TableName.TableName)
+		ctx.FormatNode(&c.TableName.TableName)
 		ctx.WriteByte('.')
 	}
-	ctx.FormatNode(c.ColumnName)
+	ctx.FormatNode(&c.ColumnName)
 }
 
 // NodeFormatter returns a tree.NodeFormatter that, when formatted,

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -943,17 +943,17 @@ type varFormatter struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (c *varFormatter) Format(buf *bytes.Buffer, f tree.FmtFlags) {
-	if f.ShowTableAliases && c.TableName.TableName != "" {
+func (c *varFormatter) Format(ctx *tree.FmtCtx) {
+	if ctx.ShowTableAliases() && c.TableName.TableName != "" {
 		if c.TableName.DatabaseName != "" {
-			tree.FormatNode(buf, f, c.TableName.DatabaseName)
-			buf.WriteByte('.')
+			ctx.FormatNode(c.TableName.DatabaseName)
+			ctx.WriteByte('.')
 		}
 
-		tree.FormatNode(buf, f, c.TableName.TableName)
-		buf.WriteByte('.')
+		ctx.FormatNode(c.TableName.TableName)
+		ctx.WriteByte('.')
 	}
-	tree.FormatNode(buf, f, c.ColumnName)
+	ctx.FormatNode(c.ColumnName)
 }
 
 // NodeFormatter returns a tree.NodeFormatter that, when formatted,

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -944,7 +944,7 @@ type varFormatter struct {
 
 // Format implements the NodeFormatter interface.
 func (c *varFormatter) Format(ctx *tree.FmtCtx) {
-	if ctx.ShowTableAliases() && c.TableName.TableName != "" {
+	if ctx.HasFlags(tree.FmtShowTableAliases) && c.TableName.TableName != "" {
 		if c.TableName.DatabaseName != "" {
 			ctx.FormatNode(c.TableName.DatabaseName)
 			ctx.WriteByte('.')

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -138,7 +138,7 @@ func (p *planner) distinct(
 			if err != nil {
 				return nil, nil, err
 			}
-			p.hasStar = p.hasStar || hasStar
+			p.curPlan.hasStar = p.curPlan.hasStar || hasStar
 
 			if len(cols) == 0 {
 				// Nothing was expanded! No distinct on here.

--- a/pkg/sql/distsqlplan/aggregator_funcs.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs.go
@@ -295,7 +295,8 @@ func (tc *typeContainer) IndexedVarResolvedType(idx int) types.T {
 }
 
 func (tc *typeContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return tree.Name(fmt.Sprintf("$%d", idx+1))
+	n := tree.Name(fmt.Sprintf("$%d", idx+1))
+	return &n
 }
 
 // MakeTypeIndexedVarHelper returns an IndexedVarHelper which creates IndexedVars

--- a/pkg/sql/distsqlplan/expression.go
+++ b/pkg/sql/distsqlplan/expression.go
@@ -58,12 +58,10 @@ func MakeExpression(
 	}
 
 	// We format the expression using the IndexedVar and Placeholder formatting interceptors.
-	var f tree.FmtFlags
-	if indexVarMap == nil {
-		f = exprFmtFlagsBase(evalCtx)
-	} else {
-		f = tree.FmtIndexedVarFormat(
-			exprFmtFlagsBase(evalCtx),
+	var buf bytes.Buffer
+	fmtCtx := tree.MakeFmtCtx(&buf, exprFmtFlagsBase(evalCtx))
+	if indexVarMap != nil {
+		fmtCtx.WithIndexedVarFormat(
 			func(ctx *tree.FmtCtx, idx int) {
 				remappedIdx := indexVarMap[idx]
 				if remappedIdx < 0 {
@@ -73,8 +71,6 @@ func MakeExpression(
 			},
 		)
 	}
-	var buf bytes.Buffer
-	fmtCtx := tree.MakeFmtCtx(&buf, f)
 	fmtCtx.FormatNode(expr)
 	if log.V(1) {
 		log.Infof(context.TODO(), "Expr %s:\n%s", buf.String(), tree.ExprDebugString(expr))

--- a/pkg/sql/distsqlrun/expr.go
+++ b/pkg/sql/distsqlrun/expr.go
@@ -121,7 +121,8 @@ func (eh *exprHelper) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum
 
 // IndexedVarNodeFormatter is part of the parser.IndexedVarContainer interface.
 func (eh *exprHelper) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return tree.Name(fmt.Sprintf("$%d", idx))
+	n := tree.Name(fmt.Sprintf("$%d", idx))
+	return &n
 }
 
 func (eh *exprHelper) init(

--- a/pkg/sql/distsqlrun/expr_test.go
+++ b/pkg/sql/distsqlrun/expr_test.go
@@ -34,7 +34,8 @@ func (d testVarContainer) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.D
 }
 
 func (d testVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return tree.Name(fmt.Sprintf("var%d", idx))
+	n := tree.Name(fmt.Sprintf("var%d", idx))
+	return &n
 }
 
 func TestProcessExpression(t *testing.T) {

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -75,7 +75,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		case tree.DropRestrict:
 			return nil, pgerror.NewErrorf(pgerror.CodeDependentObjectsStillExistError,
 				"database %q is not empty and RESTRICT was specified",
-				tree.ErrString(tree.Name(dbDesc.Name)))
+				tree.ErrNameString(&dbDesc.Name))
 		case tree.DropDefault:
 			// The default is CASCADE, however be cautious if CASCADE was
 			// not specified explicitly.

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -84,7 +84,7 @@ func (n *dropIndexNode) startExec(params runParams) error {
 
 		if err := params.p.dropIndexByName(
 			ctx, index.idxName, tableDesc, n.n.IfExists, n.n.DropBehavior, checkIdxConstraint,
-			tree.AsStringWithFlags(n.n, tree.FmtSimpleQualified),
+			tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames),
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -109,7 +109,7 @@ func (n *DropUserNode) startExec(params runParams) error {
 					if f.usedBy.Len() > 0 {
 						f.usedBy.WriteString(", ")
 					}
-					f.ctx.FormatNode(tree.Name(db.Name))
+					f.ctx.FormatNameP(&db.Name)
 				}
 			}
 			return nil
@@ -144,7 +144,7 @@ func (n *DropUserNode) startExec(params runParams) error {
 			if i > 0 {
 				fnl.nameList.WriteString(", ")
 			}
-			fnl.ctx.FormatNode(tree.Name(name))
+			fnl.ctx.FormatName(name)
 		}
 		return pgerror.NewErrorf(pgerror.CodeGroupingError,
 			"cannot drop user%s or role%s %s: grants still exist on %s",

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -98,6 +98,7 @@ func (n *DropUserNode) startExec(params runParams) error {
 	}
 
 	var usedBy bytes.Buffer
+	fmtCtx := tree.MakeFmtCtx(&usedBy, tree.FmtSimple)
 	if err := forEachDatabaseDesc(params.ctx, params.p,
 		func(db *sqlbase.DatabaseDescriptor) error {
 			for _, u := range db.GetPrivileges().Users {
@@ -105,7 +106,7 @@ func (n *DropUserNode) startExec(params runParams) error {
 					if usedBy.Len() > 0 {
 						usedBy.WriteString(", ")
 					}
-					tree.Name(db.Name).Format(&usedBy, tree.FmtSimple)
+					fmtCtx.FormatNode(tree.Name(db.Name))
 				}
 			}
 			return nil
@@ -123,7 +124,7 @@ func (n *DropUserNode) startExec(params runParams) error {
 					if usedBy.Len() > 0 {
 						usedBy.WriteString(", ")
 					}
-					tn.Format(&usedBy, tree.FmtSimple)
+					fmtCtx.FormatNode(&tn)
 				}
 			}
 			return nil
@@ -132,11 +133,12 @@ func (n *DropUserNode) startExec(params runParams) error {
 	}
 	if usedBy.Len() > 0 {
 		var nameList bytes.Buffer
+		nameListFmtCtx := tree.MakeFmtCtx(&nameList, tree.FmtSimple)
 		for i, name := range names {
 			if i > 0 {
 				nameList.WriteString(", ")
 			}
-			tree.Name(name).Format(&nameList, tree.FmtSimple)
+			nameListFmtCtx.FormatNode(tree.Name(name))
 		}
 		return pgerror.NewErrorf(pgerror.CodeGroupingError,
 			"cannot drop user%s or role%s %s: grants still exist on %s",

--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -32,11 +32,11 @@ func (p *planner) Execute(ctx context.Context, n *tree.Execute) (planNode, error
 	if p.isPreparing {
 		return nil, pgerror.NewErrorf(pgerror.CodeInvalidPreparedStatementDefinitionError,
 			"can't prepare an EXECUTE statement")
-	} else if p.plannedExecute {
+	} else if p.curPlan.plannedExecute {
 		return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
 			"can't have more than 1 EXECUTE per statement")
 	}
-	p.plannedExecute = true
+	p.curPlan.plannedExecute = true
 	ps, newPInfo, err := getPreparedStatementForExecute(p.session, n)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -328,11 +328,12 @@ func formatColumns(cols sqlbase.ResultColumns, printTypes bool) string {
 	}
 	f.ctx = tree.MakeFmtCtx(&f.buf, tree.FmtSimple)
 	f.buf.WriteByte('(')
-	for i, rCol := range cols {
+	for i := range cols {
+		rCol := &cols[i]
 		if i > 0 {
 			f.buf.WriteString(", ")
 		}
-		f.ctx.FormatNode(tree.Name(rCol.Name))
+		f.ctx.FormatNameP(&rCol.Name)
 		// Output extra properties like [hidden,omitted].
 		hasProps := false
 		outputProp := func(prop string) {

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -272,9 +272,9 @@ func (e *explainer) observer() planObserver {
 func (e *explainer) expr(nodeName, fieldName string, n int, expr tree.Expr) {
 	if e.showExprs && expr != nil {
 		if nodeName == "join" {
-			qualifySave := e.fmtFlags.ShowTableAliases
-			e.fmtFlags.ShowTableAliases = true
-			defer func() { e.fmtFlags.ShowTableAliases = qualifySave }()
+			qualifySave := e.fmtFlags
+			e.fmtFlags.SetFlags(tree.FmtShowTableAliases)
+			defer func(e *explainer, f tree.FmtFlags) { e.fmtFlags = f }(e, qualifySave)
 		}
 		if n >= 0 {
 			fieldName = fmt.Sprintf("%s %d", fieldName, n)

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -280,11 +280,14 @@ func (e *explainer) expr(nodeName, fieldName string, n int, expr tree.Expr) {
 			fieldName = fmt.Sprintf("%s %d", fieldName, n)
 		}
 
-		var buf bytes.Buffer
-		fmtCtx := tree.MakeFmtCtx(&buf, e.fmtFlags)
-		fmtCtx.WithPlaceholderFormat(e.showPlaceholderValues)
-		fmtCtx.FormatNode(expr)
-		e.attr(nodeName, fieldName, buf.String())
+		var f struct {
+			buf bytes.Buffer
+			ctx tree.FmtCtx
+		}
+		f.ctx = tree.MakeFmtCtx(&f.buf, e.fmtFlags)
+		f.ctx.WithPlaceholderFormat(e.showPlaceholderValues)
+		f.ctx.FormatNode(expr)
+		e.attr(nodeName, fieldName, f.buf.String())
 	}
 }
 
@@ -319,24 +322,27 @@ func (e *explainer) leaveNode(name string, _ planNode) error {
 // planNode to a string. The column types are printed iff the 2nd
 // argument specifies so.
 func formatColumns(cols sqlbase.ResultColumns, printTypes bool) string {
-	var buf bytes.Buffer
-	fmtCtx := tree.MakeFmtCtx(&buf, tree.FmtSimple)
-	buf.WriteByte('(')
+	var f struct {
+		buf bytes.Buffer
+		ctx tree.FmtCtx
+	}
+	f.ctx = tree.MakeFmtCtx(&f.buf, tree.FmtSimple)
+	f.buf.WriteByte('(')
 	for i, rCol := range cols {
 		if i > 0 {
-			buf.WriteString(", ")
+			f.buf.WriteString(", ")
 		}
-		fmtCtx.FormatNode(tree.Name(rCol.Name))
+		f.ctx.FormatNode(tree.Name(rCol.Name))
 		// Output extra properties like [hidden,omitted].
 		hasProps := false
 		outputProp := func(prop string) {
 			if hasProps {
-				buf.WriteByte(',')
+				f.buf.WriteByte(',')
 			} else {
-				buf.WriteByte('[')
+				f.buf.WriteByte('[')
 			}
 			hasProps = true
-			buf.WriteString(prop)
+			f.buf.WriteString(prop)
 		}
 		if rCol.Hidden {
 			outputProp("hidden")
@@ -345,14 +351,14 @@ func formatColumns(cols sqlbase.ResultColumns, printTypes bool) string {
 			outputProp("omitted")
 		}
 		if hasProps {
-			buf.WriteByte(']')
+			f.buf.WriteByte(']')
 		}
 
 		if printTypes {
-			buf.WriteByte(' ')
-			buf.WriteString(rCol.Typ.String())
+			f.buf.WriteByte(' ')
+			f.buf.WriteString(rCol.Typ.String())
 		}
 	}
-	buf.WriteByte(')')
-	return buf.String()
+	f.buf.WriteByte(')')
+	return f.buf.String()
 }

--- a/pkg/sql/expr_filter_test.go
+++ b/pkg/sql/expr_filter_test.go
@@ -163,7 +163,8 @@ func TestSplitFilter(t *testing.T) {
 					if colName == col {
 						// Convert to a VarName (to check that conversion happens correctly). It
 						// will print the same.
-						return true, tree.UnresolvedName{tree.Name(colName)}
+						cn := tree.Name(colName)
+						return true, &tree.UnresolvedName{&cn}
 					}
 				}
 				return false, nil

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -66,7 +66,7 @@ func (p *planner) changePrivileges(
 	}
 	for _, grantee := range grantees {
 		if _, ok := users[string(grantee)]; !ok {
-			return nil, errors.Errorf("user %s does not exist", grantee)
+			return nil, errors.Errorf("user %s does not exist", &grantee)
 		}
 	}
 

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -158,7 +158,7 @@ func (p *planner) groupBy(
 				if err != nil {
 					return nil, nil, err
 				}
-				p.hasStar = p.hasStar || hasStar
+				p.curPlan.hasStar = p.curPlan.hasStar || hasStar
 			}
 			groupByExprs[i] = resolvedExpr
 		}
@@ -213,7 +213,7 @@ func (p *planner) groupBy(
 		if err != nil {
 			return nil, nil, err
 		}
-		p.hasStar = p.hasStar || hasStar
+		p.curPlan.hasStar = p.curPlan.hasStar || hasStar
 
 		// GROUP BY (a, b) -> GROUP BY a, b
 		cols, exprs = flattenTuples(cols, exprs, &r.ivarHelper)

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -611,7 +611,7 @@ func (v *extractAggregatesVisitor) VisitPre(expr tree.Expr) (recurse bool, newEx
 
 				if err := v.planner.txCtx.AssertNoAggregationOrWindowing(
 					argExpr,
-					fmt.Sprintf("the argument of %s()", t.Func),
+					fmt.Sprintf("the argument of %s()", &t.Func),
 					v.planner.session.SearchPath,
 				); err != nil {
 					v.err = err

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -108,7 +108,7 @@ func (p *planner) makeIndexJoin(
 	table := p.Scan()
 	table.desc = origScan.desc
 	// Note: initDescDefaults can only error out if its 3rd argument is not nil.
-	_ = table.initDescDefaults(p.planDeps, origScan.scanVisibility, nil)
+	_ = table.initDescDefaults(p.curPlan.deps, origScan.scanVisibility, nil)
 	table.initOrdering(0, &p.evalCtx)
 	table.disableBatchLimit()
 

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -513,14 +513,15 @@ func (p *planner) processColumns(
 
 	cols := make([]sqlbase.ColumnDescriptor, len(node))
 	colIDSet := make(map[sqlbase.ColumnID]struct{}, len(node))
-	for i, n := range node {
-		c, err := n.NormalizeUnqualifiedColumnItem()
+	for i := range node {
+		c, err := node[i].NormalizeUnqualifiedColumnItem()
 		if err != nil {
 			return nil, err
 		}
 
 		if len(c.Selector) > 0 {
-			return nil, pgerror.UnimplementedWithIssueErrorf(8318, "compound types not supported yet: %q", n)
+			return nil, pgerror.UnimplementedWithIssueErrorf(8318,
+				"compound types not supported yet: %q", &node[i])
 		}
 
 		col, err := tableDesc.FindActiveColumnByName(string(c.ColumnName))
@@ -529,7 +530,7 @@ func (p *planner) processColumns(
 		}
 
 		if _, ok := colIDSet[col.ID]; ok {
-			return nil, fmt.Errorf("multiple assignments to the same column %q", n)
+			return nil, fmt.Errorf("multiple assignments to the same column %q", &node[i])
 		}
 		colIDSet[col.ID] = struct{}{}
 		cols[i] = col

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -33,7 +33,7 @@ func newTestScanNode(kvDB *client.DB, tableName string) (*scanNode, error) {
 	p := planner{}
 	scan := p.Scan()
 	scan.desc = desc
-	err := scan.initDescDefaults(p.planDeps, publicColumns, nil)
+	err := scan.initDescDefaults(p.curPlan.deps, publicColumns, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/lex/encode_test.go
+++ b/pkg/sql/lex/encode_test.go
@@ -87,7 +87,7 @@ func BenchmarkEncodeSQLString(b *testing.B) {
 	str := strings.Repeat("foo", 10000)
 	b.Run("old version", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			lex.EncodeSQLStringWithFlags(bytes.NewBuffer(nil), str, lex.EncodeFlags{BareStrings: true})
+			lex.EncodeSQLStringWithFlags(bytes.NewBuffer(nil), str, lex.EncBareStrings)
 		}
 	})
 	b.Run("new version", func(b *testing.B) {

--- a/pkg/sql/opt/relational_props.go
+++ b/pkg/sql/opt/relational_props.go
@@ -74,9 +74,10 @@ type columnProps struct {
 
 func (c columnProps) String() string {
 	if c.table == "" {
-		return tree.Name(c.name).String()
+		return tree.NameString(string(c.name))
 	}
-	return fmt.Sprintf("%s.%s", tree.Name(c.table), tree.Name(c.name))
+	return fmt.Sprintf("%s.%s",
+		tree.NameString(string(c.table)), tree.NameString(string(c.name)))
 }
 
 // relationalProps holds properties of a relational expression.

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -133,6 +133,12 @@ func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
 	return 1
 }
 
+func helpWithFunctionByName(sqllex sqlLexer, s string) int {
+	n := tree.Name(s)
+	un := tree.UnresolvedName{&n}
+	return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: &un})
+}
+
 const (
 	hGroup        = ""
 	hDDL          = "schema manipulation"

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1346,7 +1346,7 @@ func TestParse2(t *testing.T) {
 			t.Errorf("%s: expected success, but found %s", d.sql, err)
 			continue
 		}
-		s := tree.AsStringWithFlags(stmts, tree.FmtShowPasswords)
+		s := tree.AsStringWithFlags(&stmts, tree.FmtShowPasswords)
 		if d.expected != s {
 			t.Errorf("%s: expected %s, but found (%d statements): %s", d.sql, d.expected, len(stmts), s)
 		}
@@ -1377,7 +1377,7 @@ func TestParseTree(t *testing.T) {
 			t.Errorf("%s: expected success, but found %s", d.sql, err)
 			continue
 		}
-		s := tree.AsStringWithFlags(stmts, tree.FmtAlwaysGroupExprs)
+		s := tree.AsStringWithFlags(&stmts, tree.FmtAlwaysGroupExprs)
 		if d.expected != s {
 			t.Errorf("%s: expected %s, but found (%d statements): %s", d.sql, d.expected, len(stmts), s)
 		}

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1346,7 +1346,7 @@ func TestParse2(t *testing.T) {
 			t.Errorf("%s: expected success, but found %s", d.sql, err)
 			continue
 		}
-		s := tree.AsStringWithFlags(stmts, tree.FmtSimpleWithPasswords)
+		s := tree.AsStringWithFlags(stmts, tree.FmtShowPasswords)
 		if d.expected != s {
 			t.Errorf("%s: expected %s, but found (%d statements): %s", d.sql, d.expected, len(stmts), s)
 		}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -140,15 +140,6 @@ func (u *sqlSymUnion) unresolvedNames() tree.UnresolvedNames {
 func (u *sqlSymUnion) functionReference() tree.FunctionReference {
     return u.val.(tree.FunctionReference)
 }
-func (u *sqlSymUnion) resolvableFunctionReference() tree.ResolvableFunctionReference {
-    return tree.ResolvableFunctionReference{FunctionReference: u.val.(tree.FunctionReference)}
-}
-func (u *sqlSymUnion) normalizableTableName() tree.NormalizableTableName {
-    return tree.NormalizableTableName{TableNameReference: u.val.(tree.TableNameReference)}
-}
-func (u *sqlSymUnion) newNormalizableTableName() *tree.NormalizableTableName {
-    return &tree.NormalizableTableName{TableNameReference: u.val.(tree.TableNameReference)}
-}
 func (u *sqlSymUnion) tablePatterns() tree.TablePatterns {
     return u.val.(tree.TablePatterns)
 }
@@ -261,7 +252,7 @@ func (u *sqlSymUnion) selExprs() tree.SelectExprs {
     return u.val.(tree.SelectExprs)
 }
 func (u *sqlSymUnion) retClause() tree.ReturningClause {
-	return u.val.(tree.ReturningClause)
+        return u.val.(tree.ReturningClause)
 }
 func (u *sqlSymUnion) aliasClause() tree.AliasClause {
     return u.val.(tree.AliasClause)
@@ -423,11 +414,24 @@ func (u *sqlSymUnion) referenceActions() tree.ReferenceActions {
 func (u *sqlSymUnion) scrubOptions() tree.ScrubOptions {
     return u.val.(tree.ScrubOptions)
 }
-
 func (u *sqlSymUnion) scrubOption() tree.ScrubOption {
     return u.val.(tree.ScrubOption)
 }
-
+func (u *sqlSymUnion) normalizableTableNameFromUnresolvedName() tree.NormalizableTableName {
+    un := u.val.(tree.UnresolvedName)
+    return tree.NormalizableTableName{TableNameReference: &un}
+}
+func (u *sqlSymUnion) newNormalizableTableNameFromUnresolvedName() *tree.NormalizableTableName {
+    un := u.val.(tree.UnresolvedName)
+    return &tree.NormalizableTableName{TableNameReference: &un}
+}
+func (u *sqlSymUnion) resolvableFunctionReferenceFromUnresolvedName() tree.ResolvableFunctionReference {
+    un := u.val.(tree.UnresolvedName)
+    return tree.ResolvableFunctionReference{FunctionReference: &un}
+}
+func newNameFromStr(s string) *tree.Name {
+    return (*tree.Name)(&s)
+}
 %}
 
 // NB: the %token definitions must come before the %type definitions in this
@@ -1139,11 +1143,11 @@ alter_sequence_stmt:
 alter_sequence_options_stmt:
   ALTER SEQUENCE relation_expr sequence_option_list
   {
-    $$.val = &tree.AlterSequence{Name: $3.normalizableTableName(), Options: $4.seqOpts(), IfExists: false}
+    $$.val = &tree.AlterSequence{Name: $3.normalizableTableNameFromUnresolvedName(), Options: $4.seqOpts(), IfExists: false}
   }
 | ALTER SEQUENCE IF EXISTS relation_expr sequence_option_list
   {
-    $$.val = &tree.AlterSequence{Name: $5.normalizableTableName(), Options: $6.seqOpts(), IfExists: true}
+    $$.val = &tree.AlterSequence{Name: $5.normalizableTableNameFromUnresolvedName(), Options: $6.seqOpts(), IfExists: true}
   }
 
 // %Help: ALTER USER - change user properties
@@ -1195,11 +1199,11 @@ alter_index_stmt:
 alter_onetable_stmt:
   ALTER TABLE relation_expr alter_table_cmds
   {
-    $$.val = &tree.AlterTable{Table: $3.normalizableTableName(), IfExists: false, Cmds: $4.alterTableCmds()}
+    $$.val = &tree.AlterTable{Table: $3.normalizableTableNameFromUnresolvedName(), IfExists: false, Cmds: $4.alterTableCmds()}
   }
 | ALTER TABLE IF EXISTS relation_expr alter_table_cmds
   {
-    $$.val = &tree.AlterTable{Table: $5.normalizableTableName(), IfExists: true, Cmds: $6.alterTableCmds()}
+    $$.val = &tree.AlterTable{Table: $5.normalizableTableNameFromUnresolvedName(), IfExists: true, Cmds: $6.alterTableCmds()}
   }
 
 alter_oneindex_stmt:
@@ -1215,7 +1219,7 @@ alter_oneindex_stmt:
 alter_split_stmt:
   ALTER TABLE qualified_name SPLIT AT select_stmt
   {
-    $$.val = &tree.Split{Table: $3.newNormalizableTableName(), Rows: $6.slct()}
+    $$.val = &tree.Split{Table: $3.newNormalizableTableNameFromUnresolvedName(), Rows: $6.slct()}
   }
 
 alter_split_index_stmt:
@@ -1228,7 +1232,7 @@ alter_testing_relocate_stmt:
   ALTER TABLE qualified_name TESTING_RELOCATE select_stmt
   {
     /* SKIP DOC */
-    $$.val = &tree.TestingRelocate{Table: $3.newNormalizableTableName(), Rows: $5.slct()}
+    $$.val = &tree.TestingRelocate{Table: $3.newNormalizableTableNameFromUnresolvedName(), Rows: $5.slct()}
   }
 
 alter_testing_relocate_index_stmt:
@@ -1264,7 +1268,7 @@ alter_zone_table_stmt:
     /* SKIP DOC */
     $$.val = &tree.SetZoneConfig{
       ZoneSpecifier: tree.ZoneSpecifier{
-        TableOrIndex: tree.TableNameWithIndex{Table: $3.normalizableTableName()},
+        TableOrIndex: tree.TableNameWithIndex{Table: $3.normalizableTableNameFromUnresolvedName()},
       },
       YAMLConfig: $7.expr(),
     }
@@ -1274,7 +1278,7 @@ alter_zone_table_stmt:
     /* SKIP DOC */
     $$.val = &tree.SetZoneConfig{
       ZoneSpecifier: tree.ZoneSpecifier{
-        TableOrIndex: tree.TableNameWithIndex{Table: $6.normalizableTableName()},
+        TableOrIndex: tree.TableNameWithIndex{Table: $6.normalizableTableNameFromUnresolvedName()},
         Partition: tree.Name($3),
       },
       YAMLConfig: $10.expr(),
@@ -1296,11 +1300,11 @@ alter_zone_index_stmt:
 alter_scatter_stmt:
   ALTER TABLE qualified_name SCATTER
   {
-    $$.val = &tree.Scatter{Table: $3.newNormalizableTableName()}
+    $$.val = &tree.Scatter{Table: $3.newNormalizableTableNameFromUnresolvedName()}
   }
 | ALTER TABLE qualified_name SCATTER FROM '(' expr_list ')' TO '(' expr_list ')'
   {
-    $$.val = &tree.Scatter{Table: $3.newNormalizableTableName(), From: $7.exprs(), To: $11.exprs()}
+    $$.val = &tree.Scatter{Table: $3.newNormalizableTableNameFromUnresolvedName(), From: $7.exprs(), To: $11.exprs()}
   }
 
 alter_scatter_index_stmt:
@@ -1648,15 +1652,19 @@ opt_with_options:
 copy_from_stmt:
   COPY qualified_name FROM STDIN
   {
-    $$.val = &tree.CopyFrom{Table: $2.normalizableTableName(), Stdin: true}
+    $$.val = &tree.CopyFrom{Table: $2.normalizableTableNameFromUnresolvedName(), Stdin: true}
   }
 | COPY qualified_name '(' ')' FROM STDIN
   {
-    $$.val = &tree.CopyFrom{Table: $2.normalizableTableName(), Stdin: true}
+    $$.val = &tree.CopyFrom{Table: $2.normalizableTableNameFromUnresolvedName(), Stdin: true}
   }
 | COPY qualified_name '(' qualified_name_list ')' FROM STDIN
   {
-    $$.val = &tree.CopyFrom{Table: $2.normalizableTableName(), Columns: $4.unresolvedNames(), Stdin: true}
+    $$.val = &tree.CopyFrom{
+       Table: $2.normalizableTableNameFromUnresolvedName(),
+       Columns: $4.unresolvedNames(),
+       Stdin: true,
+    }
   }
 
 // %Help: CANCEL
@@ -1740,7 +1748,7 @@ create_stats_stmt:
     $$.val = &tree.CreateStats{
       Name: tree.Name($3),
       ColumnNames: $5.nameList(),
-      Table: $7.normalizableTableName(),
+      Table: $7.normalizableTableNameFromUnresolvedName(),
     }
   }
 | CREATE STATISTICS error // SHOW HELP: CREATE STATISTICS
@@ -1921,31 +1929,33 @@ drop_role_stmt:
 table_name_list:
   any_name
   {
-    $$.val = tree.TableNameReferences{$1.unresolvedName()}
+    n := $1.unresolvedName()
+    $$.val = tree.TableNameReferences{&n}
   }
 | table_name_list ',' any_name
   {
-    $$.val = append($1.tableNameReferences(), $3.unresolvedName())
+    n := $3.unresolvedName()
+    $$.val = append($1.tableNameReferences(), &n)
   }
 
 any_name:
   name
   {
-    $$.val = tree.UnresolvedName{tree.Name($1)}
+    $$.val = tree.UnresolvedName{newNameFromStr($1)}
   }
 | name attrs
   {
-    $$.val = append(tree.UnresolvedName{tree.Name($1)}, $2.unresolvedName()...)
+    $$.val = append(tree.UnresolvedName{newNameFromStr($1)}, $2.unresolvedName()...)
   }
 
 attrs:
   '.' unrestricted_name
   {
-    $$.val = tree.UnresolvedName{tree.Name($2)}
+    $$.val = tree.UnresolvedName{newNameFromStr($2)}
   }
 | attrs '.' unrestricted_name
   {
-    $$.val = append($1.unresolvedName(), tree.Name($3))
+    $$.val = append($1.unresolvedName(), newNameFromStr($3))
   }
 
 // %Help: EXPLAIN - show the logical plan of a query
@@ -2225,11 +2235,11 @@ reset_stmt:
 reset_session_stmt:
   RESET session_var
   {
-    $$.val = &tree.SetVar{Name: tree.UnresolvedName{tree.Name($2)}, Values:tree.Exprs{tree.DefaultVal{}}}
+    $$.val = &tree.SetVar{Name: &tree.UnresolvedName{newNameFromStr($2)}, Values:tree.Exprs{tree.DefaultVal{}}}
   }
 | RESET SESSION session_var
   {
-    $$.val = &tree.SetVar{Name: tree.UnresolvedName{tree.Name($3)}, Values:tree.Exprs{tree.DefaultVal{}}}
+    $$.val = &tree.SetVar{Name: &tree.UnresolvedName{newNameFromStr($3)}, Values:tree.Exprs{tree.DefaultVal{}}}
   }
 | RESET error // SHOW HELP: RESET
 
@@ -2240,7 +2250,8 @@ reset_session_stmt:
 reset_csetting_stmt:
   RESET CLUSTER SETTING var_name
   {
-    $$.val = &tree.SetClusterSetting{Name: $4.unresolvedName(), Value:tree.DefaultVal{}}
+    n := $4.unresolvedName()
+    $$.val = &tree.SetClusterSetting{Name: &n, Value:tree.DefaultVal{}}
   }
 | RESET CLUSTER error // SHOW HELP: RESET CLUSTER SETTING
 
@@ -2249,7 +2260,7 @@ use_stmt:
   USE var_value
   {
     /* SKIP DOC */
-    $$.val = &tree.SetVar{Name: tree.UnresolvedName{tree.Name("database")}, Values: tree.Exprs{$2.expr()}}
+    $$.val = &tree.SetVar{Name: &tree.UnresolvedName{newNameFromStr("database")}, Values: tree.Exprs{$2.expr()}}
   }
 | USE error // SHOW HELP: SET SESSION
 
@@ -2313,7 +2324,12 @@ scrub_database_stmt:
 scrub_table_stmt:
   EXPERIMENTAL SCRUB TABLE qualified_name opt_as_of_clause opt_scrub_options_clause
   {
-    $$.val = &tree.Scrub{Typ: tree.ScrubTable, Table: $4.normalizableTableName(), AsOf: $5.asOfClause(), Options: $6.scrubOptions()}
+    $$.val = &tree.Scrub{
+        Typ: tree.ScrubTable,
+        Table: $4.normalizableTableNameFromUnresolvedName(),
+        AsOf: $5.asOfClause(),
+        Options: $6.scrubOptions(),
+    }
   }
 | EXPERIMENTAL SCRUB TABLE error // SHOW HELP: SCRUB TABLE
 
@@ -2367,11 +2383,13 @@ scrub_option:
 set_csetting_stmt:
   SET CLUSTER SETTING var_name '=' var_value
   {
-    $$.val = &tree.SetClusterSetting{Name: $4.unresolvedName(), Value: $6.expr()}
+    n := $4.unresolvedName()
+    $$.val = &tree.SetClusterSetting{Name: &n, Value: $6.expr()}
   }
 | SET CLUSTER SETTING var_name TO var_value
   {
-    $$.val = &tree.SetClusterSetting{Name: $4.unresolvedName(), Value: $6.expr()}
+    n := $4.unresolvedName()
+    $$.val = &tree.SetClusterSetting{Name: &n, Value: $6.expr()}
   }
 | SET CLUSTER error // SHOW HELP: SET CLUSTER SETTING
 
@@ -2433,11 +2451,13 @@ set_transaction_stmt:
 generic_set:
 var_name TO var_list
   {
-    $$.val = &tree.SetVar{Name: $1.unresolvedName(), Values: $3.exprs()}
+    n := $1.unresolvedName()
+    $$.val = &tree.SetVar{Name: &n, Values: $3.exprs()}
   }
 | var_name '=' var_list
   {
-    $$.val = &tree.SetVar{Name: $1.unresolvedName(), Values: $3.exprs()}
+    n := $1.unresolvedName()
+    $$.val = &tree.SetVar{Name: &n, Values: $3.exprs()}
   }
 
 set_rest_more:
@@ -2447,7 +2467,7 @@ set_rest_more:
 | TIME ZONE zone_value
   {
     /* SKIP DOC */
-    $$.val = &tree.SetVar{Name: tree.UnresolvedName{tree.Name("timezone")}, Values: tree.Exprs{$3.expr()}}
+    $$.val = &tree.SetVar{Name: &tree.UnresolvedName{newNameFromStr("timezone")}, Values: tree.Exprs{$3.expr()}}
   }
 | var_name FROM CURRENT { return unimplemented(sqllex, "set from current") }
 | set_names
@@ -2459,12 +2479,12 @@ set_names:
   NAMES var_value
   {
     /* SKIP DOC */
-    $$.val = &tree.SetVar{Name: tree.UnresolvedName{tree.Name("client_encoding")}, Values: tree.Exprs{$2.expr()}}
+    $$.val = &tree.SetVar{Name: &tree.UnresolvedName{newNameFromStr("client_encoding")}, Values: tree.Exprs{$2.expr()}}
   }
 | NAMES
   {
     /* SKIP DOC */
-    $$.val = &tree.SetVar{Name: tree.UnresolvedName{tree.Name("client_encoding")}, Values: tree.Exprs{tree.DefaultVal{}}}
+    $$.val = &tree.SetVar{Name: &tree.UnresolvedName{newNameFromStr("client_encoding")}, Values: tree.Exprs{tree.DefaultVal{}}}
   }
 
 var_name:
@@ -2474,7 +2494,7 @@ var_value:
   a_expr
 | ON
   {
-    $$.val = tree.UnresolvedName{tree.Name($1)}
+    $$.val = tree.Expr(&tree.UnresolvedName{newNameFromStr($1)})
   }
 
 var_list:
@@ -2624,7 +2644,7 @@ session_var:
 show_stats_stmt:
   SHOW STATISTICS FOR TABLE qualified_name
   {
-    $$.val = &tree.ShowTableStats{Table: $5.normalizableTableName()}
+    $$.val = &tree.ShowTableStats{Table: $5.normalizableTableNameFromUnresolvedName() }
   }
 | SHOW STATISTICS error // SHOW HELP: SHOW STATISTICS
 
@@ -2667,7 +2687,8 @@ show_backup_stmt:
 show_csettings_stmt:
   SHOW CLUSTER SETTING any_name
   {
-    $$.val = &tree.ShowClusterSetting{Name: tree.AsStringWithFlags($4.unresolvedName(), tree.FmtBareIdentifiers)}
+    n := $4.unresolvedName()
+    $$.val = &tree.ShowClusterSetting{Name: tree.AsStringWithFlags(&n, tree.FmtBareIdentifiers)}
   }
 | SHOW CLUSTER SETTING ALL
   {
@@ -2687,7 +2708,7 @@ show_csettings_stmt:
 show_columns_stmt:
   SHOW COLUMNS FROM var_name
   {
-    $$.val = &tree.ShowColumns{Table: $4.normalizableTableName()}
+     $$.val = &tree.ShowColumns{Table: $4.normalizableTableNameFromUnresolvedName()}
   }
 | SHOW COLUMNS error // SHOW HELP: SHOW COLUMNS
 
@@ -2720,17 +2741,17 @@ show_grants_stmt:
 show_indexes_stmt:
   SHOW INDEX FROM var_name
   {
-    $$.val = &tree.ShowIndex{Table: $4.normalizableTableName()}
+    $$.val = &tree.ShowIndex{Table: $4.normalizableTableNameFromUnresolvedName()}
   }
 | SHOW INDEX error // SHOW HELP: SHOW INDEXES
 | SHOW INDEXES FROM var_name
   {
-    $$.val = &tree.ShowIndex{Table: $4.normalizableTableName()}
+    $$.val = &tree.ShowIndex{Table: $4.normalizableTableNameFromUnresolvedName()}
   }
 | SHOW INDEXES error // SHOW HELP: SHOW INDEXES
 | SHOW KEYS FROM var_name
   {
-    $$.val = &tree.ShowIndex{Table: $4.normalizableTableName()}
+    $$.val = &tree.ShowIndex{Table: $4.normalizableTableNameFromUnresolvedName()}
   }
 | SHOW KEYS error // SHOW HELP: SHOW INDEXES
 
@@ -2741,12 +2762,12 @@ show_indexes_stmt:
 show_constraints_stmt:
   SHOW CONSTRAINT FROM var_name
   {
-    $$.val = &tree.ShowConstraints{Table: $4.normalizableTableName()}
+    $$.val = &tree.ShowConstraints{Table: $4.normalizableTableNameFromUnresolvedName()}
   }
 | SHOW CONSTRAINT error // SHOW HELP: SHOW CONSTRAINTS
 | SHOW CONSTRAINTS FROM var_name
   {
-    $$.val = &tree.ShowConstraints{Table: $4.normalizableTableName()}
+    $$.val = &tree.ShowConstraints{Table: $4.normalizableTableNameFromUnresolvedName()}
   }
 | SHOW CONSTRAINTS error // SHOW HELP: SHOW CONSTRAINTS
 
@@ -2883,7 +2904,7 @@ show_transaction_stmt:
 show_create_table_stmt:
   SHOW CREATE TABLE var_name
   {
-    $$.val = &tree.ShowCreateTable{Table: $4.normalizableTableName()}
+    $$.val = &tree.ShowCreateTable{Table: $4.normalizableTableNameFromUnresolvedName()}
   }
 | SHOW CREATE TABLE error // SHOW HELP: SHOW CREATE TABLE
 
@@ -2894,7 +2915,7 @@ show_create_table_stmt:
 show_create_view_stmt:
   SHOW CREATE VIEW var_name
   {
-    $$.val = &tree.ShowCreateView{View: $4.normalizableTableName()}
+    $$.val = &tree.ShowCreateView{View: $4.normalizableTableNameFromUnresolvedName()}
   }
 | SHOW CREATE VIEW error // SHOW HELP: SHOW CREATE VIEW
 
@@ -2904,7 +2925,7 @@ show_create_view_stmt:
 show_create_sequence_stmt:
   SHOW CREATE SEQUENCE var_name
   {
-    $$.val = &tree.ShowCreateSequence{Sequence: $4.normalizableTableName()}
+    $$.val = &tree.ShowCreateSequence{Sequence: $4.normalizableTableNameFromUnresolvedName()}
   }
 | SHOW CREATE SEQUENCE error // SHOW HELP: SHOW CREATE SEQUENCE
 
@@ -2944,14 +2965,14 @@ show_zone_stmt:
   {
     /* SKIP DOC */
     $$.val = &tree.ShowZoneConfig{ZoneSpecifier: tree.ZoneSpecifier{
-      TableOrIndex: tree.TableNameWithIndex{Table: $7.normalizableTableName()},
+        TableOrIndex: tree.TableNameWithIndex{Table: $7.normalizableTableNameFromUnresolvedName() },
     }}
   }
 | EXPERIMENTAL SHOW ZONE CONFIGURATION FOR PARTITION unrestricted_name OF TABLE qualified_name
   {
     /* SKIP DOC */
     $$.val = &tree.ShowZoneConfig{ZoneSpecifier: tree.ZoneSpecifier{
-      TableOrIndex: tree.TableNameWithIndex{Table: $10.normalizableTableName()},
+        TableOrIndex: tree.TableNameWithIndex{Table: $10.normalizableTableNameFromUnresolvedName() },
       Partition: tree.Name($7),
     }}
   }
@@ -2977,7 +2998,7 @@ show_testing_stmt:
   SHOW TESTING_RANGES FROM TABLE qualified_name
   {
     /* SKIP DOC */
-    $$.val = &tree.ShowRanges{Table: $5.newNormalizableTableName()}
+    $$.val = &tree.ShowRanges{Table: $5.newNormalizableTableNameFromUnresolvedName()}
   }
 | SHOW TESTING_RANGES FROM INDEX table_name_with_index
   {
@@ -2987,7 +3008,7 @@ show_testing_stmt:
 | SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE qualified_name
   {
     /* SKIP DOC */
-    $$.val = &tree.ShowFingerprints{Table: $5.newNormalizableTableName()}
+    $$.val = &tree.ShowFingerprints{Table: $5.newNormalizableTableNameFromUnresolvedName()}
   }
 
 on_privilege_target_clause:
@@ -3057,7 +3078,7 @@ create_table_stmt:
   CREATE TABLE any_name '(' opt_table_elem_list ')' opt_interleave opt_partition_by
   {
     $$.val = &tree.CreateTable{
-      Table: $3.normalizableTableName(),
+      Table: $3.normalizableTableNameFromUnresolvedName(),
       IfNotExists: false,
       Interleave: $7.interleave(),
       Defs: $5.tblDefs(),
@@ -3069,7 +3090,7 @@ create_table_stmt:
 | CREATE TABLE IF NOT EXISTS any_name '(' opt_table_elem_list ')' opt_interleave opt_partition_by
   {
     $$.val = &tree.CreateTable{
-      Table: $6.normalizableTableName(),
+      Table: $6.normalizableTableNameFromUnresolvedName(),
       IfNotExists: true,
       Interleave: $10.interleave(),
       Defs: $8.tblDefs(),
@@ -3082,11 +3103,25 @@ create_table_stmt:
 create_table_as_stmt:
   CREATE TABLE any_name opt_column_list AS select_stmt
   {
-    $$.val = &tree.CreateTable{Table: $3.normalizableTableName(), IfNotExists: false, Interleave: nil, Defs: nil, AsSource: $6.slct(), AsColumnNames: $4.nameList()}
+    $$.val = &tree.CreateTable{
+      Table: $3.normalizableTableNameFromUnresolvedName(),
+      IfNotExists: false,
+      Interleave: nil,
+      Defs: nil,
+      AsSource: $6.slct(),
+      AsColumnNames: $4.nameList(),
+    }
   }
 | CREATE TABLE IF NOT EXISTS any_name opt_column_list AS select_stmt
   {
-    $$.val = &tree.CreateTable{Table: $6.normalizableTableName(), IfNotExists: true, Interleave: nil, Defs: nil, AsSource: $9.slct(), AsColumnNames: $7.nameList()}
+    $$.val = &tree.CreateTable{
+      Table: $6.normalizableTableNameFromUnresolvedName(),
+      IfNotExists: true,
+      Interleave: nil,
+      Defs: nil,
+      AsSource: $9.slct(),
+      AsColumnNames: $7.nameList(),
+    }
   }
 
 opt_table_elem_list:
@@ -3122,7 +3157,7 @@ opt_interleave:
   INTERLEAVE IN PARENT qualified_name '(' name_list ')' opt_interleave_drop_behavior
   {
     $$.val = &tree.InterleaveDef{
-               Parent: $4.newNormalizableTableName(),
+               Parent: $4.newNormalizableTableNameFromUnresolvedName(),
                Fields: $6.nameList(),
                DropBehavior: $8.dropBehavior(),
     }
@@ -3316,7 +3351,7 @@ col_qualification_elem:
 | REFERENCES qualified_name opt_name_parens key_match reference_actions
  {
     $$.val = &tree.ColumnFKConstraint{
-      Table: $2.normalizableTableName(),
+      Table: $2.normalizableTableNameFromUnresolvedName(),
       Col: tree.Name($3),
       Actions: $5.referenceActions(),
     }
@@ -3400,7 +3435,7 @@ constraint_elem:
     opt_column_list key_match reference_actions
   {
     $$.val = &tree.ForeignKeyConstraintTableDef{
-      Table: $7.normalizableTableName(),
+      Table: $7.normalizableTableNameFromUnresolvedName(),
       FromCols: $4.nameList(),
       ToCols: $8.nameList(),
       Actions: $10.referenceActions(),
@@ -3536,7 +3571,7 @@ create_sequence_stmt:
   CREATE SEQUENCE any_name opt_sequence_option_list
   {
     node := &tree.CreateSequence{
-      Name: $3.normalizableTableName(),
+      Name: $3.normalizableTableNameFromUnresolvedName(),
       Options: $4.seqOpts(),
     }
     $$.val = node
@@ -3544,7 +3579,7 @@ create_sequence_stmt:
 | CREATE SEQUENCE IF NOT EXISTS any_name opt_sequence_option_list
   {
     node := &tree.CreateSequence{
-      Name: $6.normalizableTableName(),
+      Name: $6.normalizableTableNameFromUnresolvedName(),
       Options: $7.seqOpts(),
       IfNotExists: true,
     }
@@ -3639,7 +3674,7 @@ create_view_stmt:
   CREATE VIEW any_name opt_column_list AS select_stmt
   {
     $$.val = &tree.CreateView{
-      Name: $3.normalizableTableName(),
+      Name: $3.normalizableTableNameFromUnresolvedName(),
       ColumnNames: $4.nameList(),
       AsSource: $6.slct(),
     }
@@ -3665,7 +3700,7 @@ create_index_stmt:
   {
     $$.val = &tree.CreateIndex{
       Name:    tree.Name($4),
-      Table:   $6.normalizableTableName(),
+      Table:   $6.normalizableTableNameFromUnresolvedName(),
       Unique:  $2.bool(),
       Columns: $8.idxElems(),
       Storing: $10.nameList(),
@@ -3678,7 +3713,7 @@ create_index_stmt:
   {
     $$.val = &tree.CreateIndex{
       Name:        tree.Name($7),
-      Table:       $9.normalizableTableName(),
+      Table:       $9.normalizableTableNameFromUnresolvedName(),
       Unique:      $2.bool(),
       IfNotExists: true,
       Columns:     $11.idxElems(),
@@ -3692,7 +3727,7 @@ create_index_stmt:
   {
     $$.val = &tree.CreateIndex{
       Name:       tree.Name($4),
-      Table:      $6.normalizableTableName(),
+      Table:      $6.normalizableTableNameFromUnresolvedName(),
       Inverted:   true,
       Columns:    $8.idxElems(),
     }
@@ -3701,7 +3736,7 @@ create_index_stmt:
   {
     $$.val = &tree.CreateIndex{
       Name:        tree.Name($7),
-      Table:       $9.normalizableTableName(),
+      Table:       $9.normalizableTableNameFromUnresolvedName(),
       Inverted:    true,
       IfNotExists: true,
       Columns:     $11.idxElems(),
@@ -3789,19 +3824,19 @@ alter_user_password_stmt:
 alter_rename_table_stmt:
   ALTER TABLE relation_expr RENAME TO qualified_name
   {
-    $$.val = &tree.RenameTable{Name: $3.normalizableTableName(), NewName: $6.normalizableTableName(), IfExists: false, IsView: false}
+    $$.val = &tree.RenameTable{Name: $3.normalizableTableNameFromUnresolvedName(), NewName: $6.normalizableTableNameFromUnresolvedName(), IfExists: false, IsView: false}
   }
 | ALTER TABLE IF EXISTS relation_expr RENAME TO qualified_name
   {
-    $$.val = &tree.RenameTable{Name: $5.normalizableTableName(), NewName: $8.normalizableTableName(), IfExists: true, IsView: false}
+    $$.val = &tree.RenameTable{Name: $5.normalizableTableNameFromUnresolvedName(), NewName: $8.normalizableTableNameFromUnresolvedName(), IfExists: true, IsView: false}
   }
 | ALTER TABLE relation_expr RENAME opt_column name TO name
   {
-    $$.val = &tree.RenameColumn{Table: $3.normalizableTableName(), Name: tree.Name($6), NewName: tree.Name($8), IfExists: false}
+    $$.val = &tree.RenameColumn{Table: $3.normalizableTableNameFromUnresolvedName(), Name: tree.Name($6), NewName: tree.Name($8), IfExists: false}
   }
 | ALTER TABLE IF EXISTS relation_expr RENAME opt_column name TO name
   {
-    $$.val = &tree.RenameColumn{Table: $5.normalizableTableName(), Name: tree.Name($8), NewName: tree.Name($10), IfExists: true}
+    $$.val = &tree.RenameColumn{Table: $5.normalizableTableNameFromUnresolvedName(), Name: tree.Name($8), NewName: tree.Name($10), IfExists: true}
   }
 | ALTER TABLE relation_expr RENAME CONSTRAINT name TO name
   { return unimplemented(sqllex, "alter table rename constraint") }
@@ -3811,21 +3846,21 @@ alter_rename_table_stmt:
 alter_rename_view_stmt:
   ALTER VIEW relation_expr RENAME TO qualified_name
   {
-    $$.val = &tree.RenameTable{Name: $3.normalizableTableName(), NewName: $6.normalizableTableName(), IfExists: false, IsView: true}
+    $$.val = &tree.RenameTable{Name: $3.normalizableTableNameFromUnresolvedName(), NewName: $6.normalizableTableNameFromUnresolvedName(), IfExists: false, IsView: true}
   }
 | ALTER VIEW IF EXISTS relation_expr RENAME TO qualified_name
   {
-    $$.val = &tree.RenameTable{Name: $5.normalizableTableName(), NewName: $8.normalizableTableName(), IfExists: true, IsView: true}
+    $$.val = &tree.RenameTable{Name: $5.normalizableTableNameFromUnresolvedName(), NewName: $8.normalizableTableNameFromUnresolvedName(), IfExists: true, IsView: true}
   }
 
 alter_rename_sequence_stmt:
   ALTER SEQUENCE relation_expr RENAME TO qualified_name
   {
-    $$.val = &tree.RenameTable{Name: $3.normalizableTableName(), NewName: $6.normalizableTableName(), IfExists: false, IsSequence: true}
+    $$.val = &tree.RenameTable{Name: $3.normalizableTableNameFromUnresolvedName(), NewName: $6.normalizableTableNameFromUnresolvedName(), IfExists: false, IsSequence: true}
   }
 | ALTER SEQUENCE IF EXISTS relation_expr RENAME TO qualified_name
   {
-    $$.val = &tree.RenameTable{Name: $5.normalizableTableName(), NewName: $8.normalizableTableName(), IfExists: true, IsSequence: true}
+    $$.val = &tree.RenameTable{Name: $5.normalizableTableNameFromUnresolvedName(), NewName: $8.normalizableTableNameFromUnresolvedName(), IfExists: true, IsSequence: true}
   }
 
 alter_rename_index_stmt:
@@ -4179,7 +4214,7 @@ upsert_stmt:
 insert_target:
   qualified_name
   {
-    $$.val = $1.newNormalizableTableName()
+    $$.val = $1.newNormalizableTableNameFromUnresolvedName()
   }
 // Can't easily make AS optional here, because VALUES in insert_rest would have
 // a shift/reduce conflict with VALUES as an optional alias. We could easily
@@ -4187,7 +4222,7 @@ insert_target:
 // divergence from other places. So just require AS for now.
 | qualified_name AS name
   {
-    $$.val = &tree.AliasedTableExpr{Expr: $1.newNormalizableTableName(), As: tree.AliasClause{Alias: tree.Name($3)}}
+    $$.val = &tree.AliasedTableExpr{Expr: $1.newNormalizableTableNameFromUnresolvedName(), As: tree.AliasClause{Alias: tree.Name($3)}}
   }
 
 insert_rest:
@@ -4653,11 +4688,11 @@ sortby:
   }
 | PRIMARY KEY qualified_name opt_asc_desc
   {
-    $$.val = &tree.Order{OrderType: tree.OrderByIndex, Direction: $4.dir(), Table: $3.normalizableTableName()}
+    $$.val = &tree.Order{OrderType: tree.OrderByIndex, Direction: $4.dir(), Table: $3.normalizableTableNameFromUnresolvedName()}
   }
 | INDEX qualified_name '@' unrestricted_name opt_asc_desc
   {
-    $$.val = &tree.Order{OrderType: tree.OrderByIndex, Direction: $5.dir(), Table: $2.normalizableTableName(), Index: tree.UnrestrictedName($4) }
+    $$.val = &tree.Order{OrderType: tree.OrderByIndex, Direction: $5.dir(), Table: $2.normalizableTableNameFromUnresolvedName(), Index: tree.UnrestrictedName($4) }
   }
 
 // TODO(pmattis): Support ordering using arbitrary math ops?
@@ -4928,7 +4963,7 @@ table_ref:
                  Expr: &tree.TableRef{
                     TableID: $2.int64(),
                     Columns: $3.tableRefCols(),
-		    As: $4.aliasClause(),
+                    As: $4.aliasClause(),
                  },
                  Hints: $6.indexHints(),
                  Ordinality: $7.bool(),
@@ -4937,13 +4972,13 @@ table_ref:
   }
 | relation_expr opt_index_hints opt_ordinality opt_alias_clause
   {
-    $$.val = &tree.AliasedTableExpr{Expr: $1.newNormalizableTableName(), Hints: $2.indexHints(), Ordinality: $3.bool(), As: $4.aliasClause() }
+    $$.val = &tree.AliasedTableExpr{Expr: $1.newNormalizableTableNameFromUnresolvedName(), Hints: $2.indexHints(), Ordinality: $3.bool(), As: $4.aliasClause() }
   }
 | qualified_name '(' opt_expr_list ')' opt_ordinality opt_alias_clause
   {
-    $$.val = &tree.AliasedTableExpr{Expr: &tree.FuncExpr{Func: $1.resolvableFunctionReference(), Exprs: $3.exprs()}, Ordinality: $5.bool(), As: $6.aliasClause() }
+    $$.val = &tree.AliasedTableExpr{Expr: &tree.FuncExpr{Func: $1.resolvableFunctionReferenceFromUnresolvedName(), Exprs: $3.exprs()}, Ordinality: $5.bool(), As: $6.aliasClause() }
   }
-| qualified_name '(' error { return helpWithFunction(sqllex, $1.resolvableFunctionReference()) }
+| qualified_name '(' error { return helpWithFunction(sqllex, $1.resolvableFunctionReferenceFromUnresolvedName()) }
 | select_with_parens opt_ordinality opt_alias_clause
   {
     $$.val = &tree.AliasedTableExpr{Expr: &tree.Subquery{Select: $1.selectStmt()}, Ordinality: $2.bool(), As: $3.aliasClause() }
@@ -5141,11 +5176,13 @@ relation_expr:
 relation_expr_list:
   relation_expr
   {
-    $$.val = tree.TableNameReferences{$1.unresolvedName()}
+    n := $1.unresolvedName()
+    $$.val = tree.TableNameReferences{&n}
   }
 | relation_expr_list ',' relation_expr
   {
-    $$.val = append($1.tableNameReferences(), $3.unresolvedName())
+    n := $3.unresolvedName()
+    $$.val = append($1.tableNameReferences(), &n)
   }
 
 // Given "UPDATE foo set set ...", we have to decide without looking any
@@ -5158,15 +5195,15 @@ relation_expr_list:
 relation_expr_opt_alias:
   relation_expr %prec UMINUS
   {
-    $$.val = $1.newNormalizableTableName()
+    $$.val = $1.newNormalizableTableNameFromUnresolvedName()
   }
 | relation_expr name
   {
-    $$.val = &tree.AliasedTableExpr{Expr: $1.newNormalizableTableName(), As: tree.AliasClause{Alias: tree.Name($2)}}
+    $$.val = &tree.AliasedTableExpr{Expr: $1.newNormalizableTableNameFromUnresolvedName(), As: tree.AliasClause{Alias: tree.Name($2)}}
   }
 | relation_expr AS name
   {
-    $$.val = &tree.AliasedTableExpr{Expr: $1.newNormalizableTableName(), As: tree.AliasClause{Alias: tree.Name($3)}}
+    $$.val = &tree.AliasedTableExpr{Expr: $1.newNormalizableTableNameFromUnresolvedName(), As: tree.AliasClause{Alias: tree.Name($3)}}
   }
 
 where_clause:
@@ -6163,7 +6200,8 @@ c_expr:
 d_expr:
   qualified_name
   {
-    $$.val = $1.unresolvedName()
+    n := $1.unresolvedName()
+    $$.val = tree.Expr(&n)
   }
 | a_expr_const
 | '@' iconst64
@@ -6210,27 +6248,27 @@ d_expr:
 func_application:
   func_name '(' ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFunctionReference()}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFunctionReferenceFromUnresolvedName()}
   }
 | func_name '(' expr_list opt_sort_clause ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFunctionReference(), Exprs: $3.exprs()}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFunctionReferenceFromUnresolvedName(), Exprs: $3.exprs()}
   }
 | func_name '(' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
 | func_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
 | func_name '(' ALL expr_list opt_sort_clause ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFunctionReference(), Type: tree.AllFuncType, Exprs: $4.exprs()}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFunctionReferenceFromUnresolvedName(), Type: tree.AllFuncType, Exprs: $4.exprs()}
   }
 | func_name '(' DISTINCT expr_list opt_sort_clause ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFunctionReference(), Type: tree.DistinctFuncType, Exprs: $4.exprs()}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFunctionReferenceFromUnresolvedName(), Type: tree.DistinctFuncType, Exprs: $4.exprs()}
   }
 | func_name '(' '*' ')'
   {
-    $$.val = &tree.FuncExpr{Func: $1.resolvableFunctionReference(), Exprs: tree.Exprs{tree.StarExpr()}}
+    $$.val = &tree.FuncExpr{Func: $1.resolvableFunctionReferenceFromUnresolvedName(), Exprs: tree.Exprs{tree.StarExpr()}}
   }
-| func_name '(' error { return helpWithFunction(sqllex, $1.resolvableFunctionReference()) }
+| func_name '(' error { return helpWithFunction(sqllex, $1.resolvableFunctionReferenceFromUnresolvedName()) }
 
 // func_expr and its cousin func_expr_windowless are split out from c_expr just
 // so that we have classifications for "everything that is a function call or
@@ -6271,7 +6309,7 @@ func_expr_common_subexpr:
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1)}
   }
-| CURRENT_DATE '(' error { return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: tree.UnresolvedName{tree.Name($1)}}) }
+  | CURRENT_DATE '(' error { return helpWithFunctionByName(sqllex, $1) }
 | CURRENT_SCHEMA
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1)}
@@ -6280,7 +6318,7 @@ func_expr_common_subexpr:
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1)}
   }
-| CURRENT_SCHEMA '(' error { return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: tree.UnresolvedName{tree.Name($1)}}) }
+| CURRENT_SCHEMA '(' error { return helpWithFunctionByName(sqllex, $1) }
 | CURRENT_TIMESTAMP
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1)}
@@ -6289,7 +6327,7 @@ func_expr_common_subexpr:
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1)}
   }
-| CURRENT_TIMESTAMP '(' error { return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: tree.UnresolvedName{tree.Name($1)}}) }
+| CURRENT_TIMESTAMP '(' error { return helpWithFunctionByName(sqllex, $1) }
 | CURRENT_ROLE { return unimplemented(sqllex, "current role") }
 | CURRENT_USER
   {
@@ -6299,7 +6337,7 @@ func_expr_common_subexpr:
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1)}
   }
-| CURRENT_USER '(' error { return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: tree.UnresolvedName{tree.Name($1)}}) }
+| CURRENT_USER '(' error { return helpWithFunctionByName(sqllex, $1) }
 | SESSION_USER
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction("current_user")}
@@ -6320,17 +6358,17 @@ func_expr_common_subexpr:
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1), Exprs: $3.exprs()}
   }
-| EXTRACT '(' error { return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: tree.UnresolvedName{tree.Name($1)}}) }
+| EXTRACT '(' error { return helpWithFunctionByName(sqllex, $1) }
 | EXTRACT_DURATION '(' extract_list ')'
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1), Exprs: $3.exprs()}
   }
-| EXTRACT_DURATION '(' error { return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: tree.UnresolvedName{tree.Name($1)}}) }
+| EXTRACT_DURATION '(' error { return helpWithFunctionByName(sqllex, $1) }
 | OVERLAY '(' overlay_list ')'
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1), Exprs: $3.exprs()}
   }
-| OVERLAY '(' error { return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: tree.UnresolvedName{tree.Name($1)}}) }
+| OVERLAY '(' error { return helpWithFunctionByName(sqllex, $1) }
 | POSITION '(' position_list ')'
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction("STRPOS"), Exprs: $3.exprs()}
@@ -6339,7 +6377,7 @@ func_expr_common_subexpr:
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1), Exprs: $3.exprs()}
   }
-| SUBSTRING '(' error { return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: tree.UnresolvedName{tree.Name($1)}}) }
+| SUBSTRING '(' error { return helpWithFunctionByName(sqllex, $1) }
 | TREAT '(' a_expr AS typename ')' { return unimplemented(sqllex, "treat") }
 | TRIM '(' BOTH trim_list ')'
   {
@@ -6377,12 +6415,12 @@ func_expr_common_subexpr:
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1), Exprs: $3.exprs()}
   }
-| GREATEST '(' error { return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: tree.UnresolvedName{tree.Name($1)}}) }
+| GREATEST '(' error { return helpWithFunctionByName(sqllex, $1) }
 | LEAST '(' expr_list ')'
   {
     $$.val = &tree.FuncExpr{Func: tree.WrapFunction($1), Exprs: $3.exprs()}
   }
-| LEAST '(' error { return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: tree.UnresolvedName{tree.Name($1)}}) }
+| LEAST '(' error { return helpWithFunctionByName(sqllex, $1) }
 
 // Aggregate decoration clauses
 within_group_clause:
@@ -6815,7 +6853,7 @@ opt_slice_bound:
 name_indirection:
   '.' unrestricted_name
   {
-    $$.val = tree.Name($2)
+    $$.val = newNameFromStr($2)
   }
 
 glob_indirection:
@@ -6916,11 +6954,13 @@ table_name_with_index_list:
 table_pattern_list:
   table_pattern
   {
-    $$.val = tree.TablePatterns{$1.unresolvedName()}
+    n := $1.unresolvedName()
+    $$.val = tree.TablePatterns{&n}
   }
 | table_pattern_list ',' table_pattern
   {
-    $$.val = append($1.tablePatterns(), $3.unresolvedName())
+    n := $3.unresolvedName()
+    $$.val = append($1.tablePatterns(), &n)
   }
 
 // The production for a qualified relation name has to exactly match the
@@ -6931,23 +6971,29 @@ table_pattern_list:
 qualified_name:
   name
   {
-    $$.val = tree.UnresolvedName{tree.Name($1)}
+    $$.val = tree.UnresolvedName{newNameFromStr($1)}
   }
 | name qname_indirection
   {
-    $$.val = append(tree.UnresolvedName{tree.Name($1)}, $2.unresolvedName()...)
+    $$.val = append(tree.UnresolvedName{newNameFromStr($1)}, $2.unresolvedName()...)
   }
 
 table_name_with_index:
   qualified_name '@' unrestricted_name
   {
-    $$.val = tree.TableNameWithIndex{Table: $1.normalizableTableName(), Index: tree.UnrestrictedName($3)}
+    $$.val = tree.TableNameWithIndex{
+       Table: $1.normalizableTableNameFromUnresolvedName(),
+       Index: tree.UnrestrictedName($3),
+    }
   }
 | qualified_name
   {
     // This case allows specifying just an index name (potentially schema-qualified).
     // We temporarily store the index name in Table (see tree.TableNameWithIndex).
-    $$.val = tree.TableNameWithIndex{Table: $1.normalizableTableName(), SearchTable: true}
+    $$.val = tree.TableNameWithIndex{
+        Table: $1.normalizableTableNameFromUnresolvedName(),
+        SearchTable: true,
+    }
   }
 
 // table_pattern accepts:
@@ -6958,7 +7004,7 @@ table_name_with_index:
 table_pattern:
   name
   {
-    $$.val = tree.UnresolvedName{tree.Name($1)}
+    $$.val = tree.UnresolvedName{newNameFromStr($1)}
   }
 | '*'
   {
@@ -6966,11 +7012,11 @@ table_pattern:
   }
 | name name_indirection
   {
-    $$.val = tree.UnresolvedName{tree.Name($1), $2.namePart()}
+    $$.val = tree.UnresolvedName{newNameFromStr($1), $2.namePart()}
   }
 | name glob_indirection
   {
-    $$.val = tree.UnresolvedName{tree.Name($1), $2.namePart()}
+    $$.val = tree.UnresolvedName{newNameFromStr($1), $2.namePart()}
   }
 
 name_list:
@@ -6992,11 +7038,11 @@ name_list:
 func_name:
   type_function_name
   {
-    $$.val = tree.UnresolvedName{tree.Name($1)}
+    $$.val = tree.UnresolvedName{newNameFromStr($1)}
   }
 | name qname_indirection
   {
-    $$.val = append(tree.UnresolvedName{tree.Name($1)}, $2.unresolvedName()...)
+    $$.val = append(tree.UnresolvedName{newNameFromStr($1)}, $2.unresolvedName()...)
   }
 
 // Constants

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -530,15 +530,11 @@ CREATE TABLE pg_catalog.pg_constraint (
 					if err != nil {
 						return err
 					}
-					var f struct {
-						buf bytes.Buffer
-						ctx tree.FmtCtx
-					}
-					f.ctx = tree.MakeFmtCtx(&f.buf, tree.FmtSimple)
-					f.buf.WriteString("UNIQUE (")
-					c.Index.ColNamesFormat(&f.ctx)
-					f.buf.WriteByte(')')
-					condef = tree.NewDString(f.buf.String())
+					f := tree.NewFmtCtxWithBuf(tree.FmtSimple)
+					f.WriteString("UNIQUE (")
+					c.Index.ColNamesFormat(f)
+					f.WriteByte(')')
+					condef = tree.NewDString(f.CloseAndGetString())
 
 				case sqlbase.ConstraintTypeCheck:
 					oid = h.CheckConstraintOid(db, table, c.CheckConstraint)

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -516,7 +516,7 @@ CREATE TABLE pg_catalog.pg_constraint (
 						return err
 					}
 					var buf bytes.Buffer
-					if err := p.printForeignKeyConstraint(ctx, &buf, db.Name, *c.Index); err != nil {
+					if err := p.printForeignKeyConstraint(ctx, &buf, db.Name, c.Index); err != nil {
 						return err
 					}
 					condef = tree.NewDString(buf.String())
@@ -530,11 +530,15 @@ CREATE TABLE pg_catalog.pg_constraint (
 					if err != nil {
 						return err
 					}
-					var buf bytes.Buffer
-					buf.WriteString("UNIQUE (")
-					c.Index.ColNamesFormat(&buf)
-					buf.WriteByte(')')
-					condef = tree.NewDString(buf.String())
+					var f struct {
+						buf bytes.Buffer
+						ctx tree.FmtCtx
+					}
+					f.ctx = tree.MakeFmtCtx(&f.buf, tree.FmtSimple)
+					f.buf.WriteString("UNIQUE (")
+					c.Index.ColNamesFormat(&f.ctx)
+					f.buf.WriteByte(')')
+					condef = tree.NewDString(f.buf.String())
 
 				case sqlbase.ConstraintTypeCheck:
 					oid = h.CheckConstraintOid(db, table, c.CheckConstraint)

--- a/pkg/sql/pgwire/encoding.go
+++ b/pkg/sql/pgwire/encoding.go
@@ -232,7 +232,8 @@ func (b *writeBuffer) writeLengthPrefixedString(s string) {
 // writeLengthPrefixedDatum writes a length-prefixed Datum in its
 // string representation. The length is encoded as an int32.
 func (b *writeBuffer) writeLengthPrefixedDatum(d tree.Datum) {
-	tree.FormatNode(&b.variablePutbuf, tree.FmtSimple, d)
+	fmtCtx := tree.MakeFmtCtx(&b.variablePutbuf, tree.FmtSimple)
+	fmtCtx.FormatNode(d)
 	b.writeLengthPrefixedVariablePutbuf()
 }
 

--- a/pkg/sql/pgwire/types.go
+++ b/pkg/sql/pgwire/types.go
@@ -183,6 +183,7 @@ func (b *writeBuffer) writeTextDatum(ctx context.Context, d tree.Datum, sessionL
 
 	case *tree.DTuple:
 		b.variablePutbuf.WriteString("(")
+		fmtCtx := tree.MakeFmtCtx(&b.variablePutbuf, tree.FmtSimple)
 		for i, d := range v.D {
 			if i > 0 {
 				b.variablePutbuf.WriteString(",")
@@ -191,7 +192,7 @@ func (b *writeBuffer) writeTextDatum(ctx context.Context, d tree.Datum, sessionL
 				// Emit nothing on NULL.
 				continue
 			}
-			tree.FormatNode(&b.variablePutbuf, tree.FmtSimple, d)
+			fmtCtx.FormatNode(d)
 		}
 		b.variablePutbuf.WriteString(")")
 		b.writeLengthPrefixedVariablePutbuf()
@@ -207,12 +208,13 @@ func (b *writeBuffer) writeTextDatum(ctx context.Context, d tree.Datum, sessionL
 		}
 
 		b.variablePutbuf.WriteString(begin)
+		fmtCtx := tree.MakeFmtCtx(&b.variablePutbuf, tree.FmtArrays)
 		for i, d := range v.Array {
 			if i > 0 {
 				b.variablePutbuf.WriteString(sep)
 			}
 			// TODO(justin): add a test for nested arrays.
-			tree.FormatNode(&b.variablePutbuf, tree.FmtArrays, d)
+			fmtCtx.FormatNode(d)
 		}
 		b.variablePutbuf.WriteString(end)
 		b.writeLengthPrefixedVariablePutbuf()

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -92,14 +92,14 @@ func TestWriteBinaryArray(t *testing.T) {
 	// then concatenating the result.
 	ary, _ := tree.ParseDArrayFromString(tree.NewTestingEvalContext(), "{1}", coltypes.Int)
 
-	writeBuf1 := &writeBuffer{}
+	writeBuf1 := newWriteBuffer()
 	writeBuf1.writeTextDatum(context.Background(), ary, time.UTC)
 	writeBuf1.writeBinaryDatum(context.Background(), ary, time.UTC)
 
-	writeBuf2 := &writeBuffer{}
+	writeBuf2 := newWriteBuffer()
 	writeBuf2.writeTextDatum(context.Background(), ary, time.UTC)
 
-	writeBuf3 := &writeBuffer{}
+	writeBuf3 := newWriteBuffer()
 	writeBuf3.writeBinaryDatum(context.Background(), ary, time.UTC)
 
 	concatted := bytes.Join([][]byte{writeBuf2.wrapped.Bytes(), writeBuf3.wrapped.Bytes()}, nil)
@@ -112,7 +112,8 @@ func TestWriteBinaryArray(t *testing.T) {
 func TestIntArrayRoundTrip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	buf := writeBuffer{bytecount: metric.NewCounter(metric.Metadata{})}
+	buf := newWriteBuffer()
+	buf.bytecount = metric.NewCounter(metric.Metadata{})
 	d := tree.NewDArray(types.Int)
 	for i := 0; i < 10; i++ {
 		if err := d.Append(tree.NewDInt(tree.DInt(i))); err != nil {
@@ -138,7 +139,8 @@ func TestIntArrayRoundTrip(t *testing.T) {
 func benchmarkWriteType(b *testing.B, d tree.Datum, format formatCode) {
 	ctx := context.Background()
 
-	buf := writeBuffer{bytecount: metric.NewCounter(metric.Metadata{Name: ""})}
+	buf := newWriteBuffer()
+	buf.bytecount = metric.NewCounter(metric.Metadata{Name: ""})
 
 	writeMethod := buf.writeTextDatum
 	if format == formatBinary {
@@ -314,7 +316,8 @@ func BenchmarkWriteTextArray(b *testing.B) {
 }
 
 func BenchmarkDecodeBinaryDecimal(b *testing.B) {
-	wbuf := writeBuffer{bytecount: metric.NewCounter(metric.Metadata{Name: ""})}
+	wbuf := newWriteBuffer()
+	wbuf.bytecount = metric.NewCounter(metric.Metadata{})
 
 	expected := new(tree.DDecimal)
 	s := "-1728718718271827121233.1212121212"

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -176,7 +176,7 @@ type v3Conn struct {
 	wr          *bufio.Writer
 	executor    *sql.Executor
 	readBuf     readBuffer
-	writeBuf    writeBuffer
+	writeBuf    *writeBuffer
 	tagBuf      [64]byte
 	sessionArgs sql.SessionArgs
 	session     *sql.Session
@@ -255,11 +255,13 @@ func (s *streamingState) reset(formatCodes []formatCode, sendDescription bool, l
 func makeV3Conn(
 	conn net.Conn, metrics *ServerMetrics, sqlMemoryPool *mon.BytesMonitor, executor *sql.Executor,
 ) v3Conn {
+	wb := newWriteBuffer()
+	wb.bytecount = metrics.BytesOutCount
 	return v3Conn{
 		conn:          conn,
 		rd:            bufio.NewReader(conn),
 		wr:            bufio.NewWriter(conn),
-		writeBuf:      writeBuffer{bytecount: metrics.BytesOutCount},
+		writeBuf:      wb,
 		metrics:       metrics,
 		executor:      executor,
 		sqlMemoryPool: sqlMemoryPool,

--- a/pkg/sql/physical_props.go
+++ b/pkg/sql/physical_props.go
@@ -261,7 +261,7 @@ func (pp *physicalProps) Format(buf *bytes.Buffer, columns sqlbase.ResultColumns
 		if columns == nil || colIdx >= len(columns) {
 			fmt.Fprintf(buf, "@%d", colIdx+1)
 		} else {
-			fmtCtx.FormatNode(tree.Name(columns[colIdx].Name))
+			fmtCtx.FormatNameP(&columns[colIdx].Name)
 		}
 	}
 

--- a/pkg/sql/physical_props.go
+++ b/pkg/sql/physical_props.go
@@ -256,11 +256,12 @@ func (pp *physicalProps) reduce(order sqlbase.ColumnOrdering) sqlbase.ColumnOrde
 //   a=b=c; d=e=f; g=CONST; h=CONST; b+,d-
 func (pp *physicalProps) Format(buf *bytes.Buffer, columns sqlbase.ResultColumns) {
 	pp.check()
+	fmtCtx := tree.MakeFmtCtx(buf, tree.FmtSimple)
 	printCol := func(buf *bytes.Buffer, columns sqlbase.ResultColumns, colIdx int) {
 		if columns == nil || colIdx >= len(columns) {
 			fmt.Fprintf(buf, "@%d", colIdx+1)
 		} else {
-			tree.FormatNode(buf, tree.FmtSimple, tree.Name(columns[colIdx].Name))
+			fmtCtx.FormatNode(tree.Name(columns[colIdx].Name))
 		}
 	}
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -456,7 +456,7 @@ func (p *planner) newPlan(
 		return p.CancelJob(ctx, n)
 	case *tree.Scrub:
 		return p.Scrub(ctx, n)
-	case CopyDataBlock:
+	case *CopyDataBlock:
 		return p.CopyData(ctx, n)
 	case *tree.CopyFrom:
 		return p.Copy(ctx, n)

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -400,7 +400,7 @@ func (p *planner) initTargets(
 			return err
 		}
 
-		p.hasStar = p.hasStar || hasStar
+		p.curPlan.hasStar = p.curPlan.hasStar || hasStar
 		_ = r.addOrReuseRenders(cols, exprs, false)
 	}
 	// `groupBy` or `orderBy` may internally add additional columns which we

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -270,7 +270,7 @@ func (n *scanNode) initTable(
 	}
 
 	n.noIndexJoin = (indexHints != nil && indexHints.NoIndexJoin)
-	return n.initDescDefaults(p.planDeps, scanVisibility, wantedColumns)
+	return n.initDescDefaults(p.curPlan.deps, scanVisibility, wantedColumns)
 }
 
 func (n *scanNode) lookupSpecifiedIndex(indexHints *tree.IndexHints) error {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -131,7 +131,7 @@ func (n *scanNode) IndexedVarResolvedType(idx int) types.T {
 }
 
 func (n *scanNode) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return tree.Name(n.resultColumns[idx].Name)
+	return (*tree.Name)(&n.resultColumns[idx].Name)
 }
 
 // scanRun contains the run-time state of scanNode during local execution.
@@ -288,7 +288,7 @@ func (n *scanNode) lookupSpecifiedIndex(indexHints *tree.IndexHints) error {
 			}
 		}
 		if n.specifiedIndex == nil {
-			return errors.Errorf("index %q not found", tree.ErrString(indexHints.Index))
+			return errors.Errorf("index %q not found", tree.ErrString(&indexHints.Index))
 		}
 	} else if indexHints.IndexID != 0 {
 		// Search index by ID.

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -106,7 +106,7 @@ func (v *nameResolutionVisitor) VisitPre(expr tree.Expr) (recurse bool, newNode 
 		v.foundDependentVars = true
 		return false, t
 
-	case tree.UnresolvedName:
+	case *tree.UnresolvedName:
 		vn, err := t.NormalizeVarName()
 		if err != nil {
 			v.err = err
@@ -163,9 +163,10 @@ func (v *nameResolutionVisitor) VisitPre(expr tree.Expr) (recurse bool, newNode 
 				// columns. A * is invalid elsewhere (and will be caught by TypeCheck()).
 				// Replace the function with COUNT_ROWS (which doesn't take any
 				// arguments).
+				cr := tree.Name("COUNT_ROWS")
 				e := &tree.FuncExpr{
 					Func: tree.ResolvableFunctionReference{
-						FunctionReference: tree.UnresolvedName{tree.Name("COUNT_ROWS")},
+						FunctionReference: &tree.UnresolvedName{&cr},
 					},
 				}
 				// We call TypeCheck to fill in FuncExpr internals. This is a fixed

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -27,7 +27,7 @@ func testInitDummySelectNode(p *planner, desc *sqlbase.TableDescriptor) *renderN
 	scan := &scanNode{}
 	scan.desc = desc
 	// Note: scan.initDescDefaults only returns an error if its 2nd argument is not nil.
-	_ = scan.initDescDefaults(p.planDeps, publicColumns, nil)
+	_ = scan.initDescDefaults(p.curPlan.deps, publicColumns, nil)
 
 	sel := &renderNode{}
 	sel.source.plan = scan

--- a/pkg/sql/sem/tree/alter_index.go
+++ b/pkg/sql/sem/tree/alter_index.go
@@ -14,10 +14,6 @@
 
 package tree
 
-import (
-	"bytes"
-)
-
 // AlterIndex represents an ALTER INDEX statement.
 type AlterIndex struct {
 	IfExists bool
@@ -28,25 +24,25 @@ type AlterIndex struct {
 var _ Statement = &AlterIndex{}
 
 // Format implements the NodeFormatter interface.
-func (node *AlterIndex) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER INDEX ")
+func (node *AlterIndex) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER INDEX ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.Index)
-	FormatNode(buf, f, node.Cmds)
+	ctx.FormatNode(node.Index)
+	ctx.FormatNode(node.Cmds)
 }
 
 // AlterIndexCmds represents a list of index alterations.
 type AlterIndexCmds []AlterIndexCmd
 
 // Format implements the NodeFormatter interface.
-func (node AlterIndexCmds) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node AlterIndexCmds) Format(ctx *FmtCtx) {
 	for i, n := range node {
 		if i > 0 {
-			buf.WriteString(",")
+			ctx.WriteString(",")
 		}
-		FormatNode(buf, f, n)
+		ctx.FormatNode(n)
 	}
 }
 
@@ -69,6 +65,6 @@ type AlterIndexPartitionBy struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterIndexPartitionBy) Format(buf *bytes.Buffer, f FmtFlags) {
-	FormatNode(buf, f, node.PartitionBy)
+func (node *AlterIndexPartitionBy) Format(ctx *FmtCtx) {
+	ctx.FormatNode(node.PartitionBy)
 }

--- a/pkg/sql/sem/tree/alter_index.go
+++ b/pkg/sql/sem/tree/alter_index.go
@@ -30,15 +30,15 @@ func (node *AlterIndex) Format(ctx *FmtCtx) {
 		ctx.WriteString("IF EXISTS ")
 	}
 	ctx.FormatNode(node.Index)
-	ctx.FormatNode(node.Cmds)
+	ctx.FormatNode(&node.Cmds)
 }
 
 // AlterIndexCmds represents a list of index alterations.
 type AlterIndexCmds []AlterIndexCmd
 
 // Format implements the NodeFormatter interface.
-func (node AlterIndexCmds) Format(ctx *FmtCtx) {
-	for i, n := range node {
+func (node *AlterIndexCmds) Format(ctx *FmtCtx) {
+	for i, n := range *node {
 		if i > 0 {
 			ctx.WriteString(",")
 		}

--- a/pkg/sql/sem/tree/alter_sequence.go
+++ b/pkg/sql/sem/tree/alter_sequence.go
@@ -14,8 +14,6 @@
 
 package tree
 
-import "bytes"
-
 // AlterSequence represents an ALTER SEQUENCE statement, except in the case of
 // ALTER SEQUENCE <seqName> RENAME TO <newSeqName>, which is represented by a
 // RenameTable node.
@@ -26,11 +24,11 @@ type AlterSequence struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterSequence) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER SEQUENCE ")
+func (node *AlterSequence) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER SEQUENCE ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, &node.Name)
-	FormatNode(buf, f, node.Options)
+	ctx.FormatNode(&node.Name)
+	ctx.FormatNode(node.Options)
 }

--- a/pkg/sql/sem/tree/alter_sequence.go
+++ b/pkg/sql/sem/tree/alter_sequence.go
@@ -30,5 +30,5 @@ func (node *AlterSequence) Format(ctx *FmtCtx) {
 		ctx.WriteString("IF EXISTS ")
 	}
 	ctx.FormatNode(&node.Name)
-	ctx.FormatNode(node.Options)
+	ctx.FormatNode(&node.Options)
 }

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -28,15 +28,15 @@ func (node *AlterTable) Format(ctx *FmtCtx) {
 		ctx.WriteString("IF EXISTS ")
 	}
 	ctx.FormatNode(&node.Table)
-	ctx.FormatNode(node.Cmds)
+	ctx.FormatNode(&node.Cmds)
 }
 
 // AlterTableCmds represents a list of table alterations.
 type AlterTableCmds []AlterTableCmd
 
 // Format implements the NodeFormatter interface.
-func (node AlterTableCmds) Format(ctx *FmtCtx) {
-	for i, n := range node {
+func (node *AlterTableCmds) Format(ctx *FmtCtx) {
+	for i, n := range *node {
 		if i > 0 {
 			ctx.WriteString(",")
 		}
@@ -138,7 +138,7 @@ func (node *AlterTableDropColumn) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(node.Column)
+	ctx.FormatNode(&node.Column)
 	if node.DropBehavior != DropDefault {
 		ctx.Printf(" %s", node.DropBehavior)
 	}
@@ -157,7 +157,7 @@ func (node *AlterTableDropConstraint) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(node.Constraint)
+	ctx.FormatNode(&node.Constraint)
 	if node.DropBehavior != DropDefault {
 		ctx.Printf(" %s", node.DropBehavior)
 	}
@@ -171,7 +171,7 @@ type AlterTableValidateConstraint struct {
 // Format implements the NodeFormatter interface.
 func (node *AlterTableValidateConstraint) Format(ctx *FmtCtx) {
 	ctx.WriteString(" VALIDATE CONSTRAINT ")
-	ctx.FormatNode(node.Constraint)
+	ctx.FormatNode(&node.Constraint)
 }
 
 // AlterTableSetDefault represents an ALTER COLUMN SET DEFAULT
@@ -193,7 +193,7 @@ func (node *AlterTableSetDefault) Format(ctx *FmtCtx) {
 	if node.ColumnKeyword {
 		ctx.WriteString("COLUMN ")
 	}
-	ctx.FormatNode(node.Column)
+	ctx.FormatNode(&node.Column)
 	if node.Default == nil {
 		ctx.WriteString(" DROP DEFAULT")
 	} else {
@@ -220,7 +220,7 @@ func (node *AlterTableDropNotNull) Format(ctx *FmtCtx) {
 	if node.ColumnKeyword {
 		ctx.WriteString("COLUMN ")
 	}
-	ctx.FormatNode(node.Column)
+	ctx.FormatNode(&node.Column)
 	ctx.WriteString(" DROP NOT NULL")
 }
 

--- a/pkg/sql/sem/tree/alter_table.go
+++ b/pkg/sql/sem/tree/alter_table.go
@@ -14,11 +14,6 @@
 
 package tree
 
-import (
-	"bytes"
-	"fmt"
-)
-
 // AlterTable represents an ALTER TABLE statement.
 type AlterTable struct {
 	IfExists bool
@@ -27,25 +22,25 @@ type AlterTable struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterTable) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER TABLE ")
+func (node *AlterTable) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER TABLE ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, &node.Table)
-	FormatNode(buf, f, node.Cmds)
+	ctx.FormatNode(&node.Table)
+	ctx.FormatNode(node.Cmds)
 }
 
 // AlterTableCmds represents a list of table alterations.
 type AlterTableCmds []AlterTableCmd
 
 // Format implements the NodeFormatter interface.
-func (node AlterTableCmds) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node AlterTableCmds) Format(ctx *FmtCtx) {
 	for i, n := range node {
 		if i > 0 {
-			buf.WriteString(",")
+			ctx.WriteString(",")
 		}
-		FormatNode(buf, f, n)
+		ctx.FormatNode(n)
 	}
 }
 
@@ -90,15 +85,15 @@ type AlterTableAddColumn struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterTableAddColumn) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(" ADD ")
+func (node *AlterTableAddColumn) Format(ctx *FmtCtx) {
+	ctx.WriteString(" ADD ")
 	if node.ColumnKeyword {
-		buf.WriteString("COLUMN ")
+		ctx.WriteString("COLUMN ")
 	}
 	if node.IfNotExists {
-		buf.WriteString("IF NOT EXISTS ")
+		ctx.WriteString("IF NOT EXISTS ")
 	}
-	FormatNode(buf, f, node.ColumnDef)
+	ctx.FormatNode(node.ColumnDef)
 }
 
 // ValidationBehavior specifies whether or not a constraint is validated.
@@ -118,11 +113,11 @@ type AlterTableAddConstraint struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterTableAddConstraint) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(" ADD ")
-	FormatNode(buf, f, node.ConstraintDef)
+func (node *AlterTableAddConstraint) Format(ctx *FmtCtx) {
+	ctx.WriteString(" ADD ")
+	ctx.FormatNode(node.ConstraintDef)
 	if node.ValidationBehavior == ValidationSkip {
-		buf.WriteString(" NOT VALID")
+		ctx.WriteString(" NOT VALID")
 	}
 }
 
@@ -135,17 +130,17 @@ type AlterTableDropColumn struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterTableDropColumn) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(" DROP ")
+func (node *AlterTableDropColumn) Format(ctx *FmtCtx) {
+	ctx.WriteString(" DROP ")
 	if node.ColumnKeyword {
-		buf.WriteString("COLUMN ")
+		ctx.WriteString("COLUMN ")
 	}
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.Column)
+	ctx.FormatNode(node.Column)
 	if node.DropBehavior != DropDefault {
-		fmt.Fprintf(buf, " %s", node.DropBehavior)
+		ctx.Printf(" %s", node.DropBehavior)
 	}
 }
 
@@ -157,14 +152,14 @@ type AlterTableDropConstraint struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterTableDropConstraint) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(" DROP CONSTRAINT ")
+func (node *AlterTableDropConstraint) Format(ctx *FmtCtx) {
+	ctx.WriteString(" DROP CONSTRAINT ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.Constraint)
+	ctx.FormatNode(node.Constraint)
 	if node.DropBehavior != DropDefault {
-		fmt.Fprintf(buf, " %s", node.DropBehavior)
+		ctx.Printf(" %s", node.DropBehavior)
 	}
 }
 
@@ -174,9 +169,9 @@ type AlterTableValidateConstraint struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterTableValidateConstraint) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(" VALIDATE CONSTRAINT ")
-	FormatNode(buf, f, node.Constraint)
+func (node *AlterTableValidateConstraint) Format(ctx *FmtCtx) {
+	ctx.WriteString(" VALIDATE CONSTRAINT ")
+	ctx.FormatNode(node.Constraint)
 }
 
 // AlterTableSetDefault represents an ALTER COLUMN SET DEFAULT
@@ -193,17 +188,17 @@ func (node *AlterTableSetDefault) GetColumn() Name {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterTableSetDefault) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(" ALTER ")
+func (node *AlterTableSetDefault) Format(ctx *FmtCtx) {
+	ctx.WriteString(" ALTER ")
 	if node.ColumnKeyword {
-		buf.WriteString("COLUMN ")
+		ctx.WriteString("COLUMN ")
 	}
-	FormatNode(buf, f, node.Column)
+	ctx.FormatNode(node.Column)
 	if node.Default == nil {
-		buf.WriteString(" DROP DEFAULT")
+		ctx.WriteString(" DROP DEFAULT")
 	} else {
-		fmt.Fprintf(buf, " SET DEFAULT ")
-		FormatNode(buf, f, node.Default)
+		ctx.WriteString(" SET DEFAULT ")
+		ctx.FormatNode(node.Default)
 	}
 }
 
@@ -220,13 +215,13 @@ func (node *AlterTableDropNotNull) GetColumn() Name {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterTableDropNotNull) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(" ALTER ")
+func (node *AlterTableDropNotNull) Format(ctx *FmtCtx) {
+	ctx.WriteString(" ALTER ")
 	if node.ColumnKeyword {
-		buf.WriteString("COLUMN ")
+		ctx.WriteString("COLUMN ")
 	}
-	FormatNode(buf, f, node.Column)
-	buf.WriteString(" DROP NOT NULL")
+	ctx.FormatNode(node.Column)
+	ctx.WriteString(" DROP NOT NULL")
 }
 
 // AlterTablePartitionBy represents an ALTER TABLE PARTITION BY
@@ -236,6 +231,6 @@ type AlterTablePartitionBy struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *AlterTablePartitionBy) Format(buf *bytes.Buffer, f FmtFlags) {
-	FormatNode(buf, f, node.PartitionBy)
+func (node *AlterTablePartitionBy) Format(ctx *FmtCtx) {
+	ctx.FormatNode(node.PartitionBy)
 }

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -14,8 +14,6 @@
 
 package tree
 
-import "bytes"
-
 // Backup represents a BACKUP statement.
 type Backup struct {
 	Targets         TargetList
@@ -28,22 +26,22 @@ type Backup struct {
 var _ Statement = &Backup{}
 
 // Format implements the NodeFormatter interface.
-func (node *Backup) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("BACKUP ")
-	FormatNode(buf, f, node.Targets)
-	buf.WriteString(" TO ")
-	FormatNode(buf, f, node.To)
+func (node *Backup) Format(ctx *FmtCtx) {
+	ctx.WriteString("BACKUP ")
+	ctx.FormatNode(node.Targets)
+	ctx.WriteString(" TO ")
+	ctx.FormatNode(node.To)
 	if node.AsOf.Expr != nil {
-		buf.WriteString(" ")
-		FormatNode(buf, f, node.AsOf)
+		ctx.WriteString(" ")
+		ctx.FormatNode(node.AsOf)
 	}
 	if node.IncrementalFrom != nil {
-		buf.WriteString(" INCREMENTAL FROM ")
-		FormatNode(buf, f, node.IncrementalFrom)
+		ctx.WriteString(" INCREMENTAL FROM ")
+		ctx.FormatNode(node.IncrementalFrom)
 	}
 	if node.Options != nil {
-		buf.WriteString(" WITH ")
-		FormatNode(buf, f, node.Options)
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(node.Options)
 	}
 }
 
@@ -58,18 +56,18 @@ type Restore struct {
 var _ Statement = &Restore{}
 
 // Format implements the NodeFormatter interface.
-func (node *Restore) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("RESTORE ")
-	FormatNode(buf, f, node.Targets)
-	buf.WriteString(" FROM ")
-	FormatNode(buf, f, node.From)
+func (node *Restore) Format(ctx *FmtCtx) {
+	ctx.WriteString("RESTORE ")
+	ctx.FormatNode(node.Targets)
+	ctx.WriteString(" FROM ")
+	ctx.FormatNode(node.From)
 	if node.AsOf.Expr != nil {
-		buf.WriteString(" EXPERIMENTAL ")
-		FormatNode(buf, f, node.AsOf)
+		ctx.WriteString(" EXPERIMENTAL ")
+		ctx.FormatNode(node.AsOf)
 	}
 	if node.Options != nil {
-		buf.WriteString(" WITH ")
-		FormatNode(buf, f, node.Options)
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(node.Options)
 	}
 }
 
@@ -83,15 +81,15 @@ type KVOption struct {
 type KVOptions []KVOption
 
 // Format implements the NodeFormatter interface.
-func (o KVOptions) Format(buf *bytes.Buffer, f FmtFlags) {
+func (o KVOptions) Format(ctx *FmtCtx) {
 	for i, n := range o {
 		if i > 0 {
-			buf.WriteString(", ")
+			ctx.WriteString(", ")
 		}
-		FormatNode(buf, f, n.Key)
+		ctx.FormatNode(n.Key)
 		if n.Value != nil {
-			buf.WriteString(` = `)
-			FormatNode(buf, f, n.Value)
+			ctx.WriteString(` = `)
+			ctx.FormatNode(n.Value)
 		}
 	}
 }

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -28,20 +28,20 @@ var _ Statement = &Backup{}
 // Format implements the NodeFormatter interface.
 func (node *Backup) Format(ctx *FmtCtx) {
 	ctx.WriteString("BACKUP ")
-	ctx.FormatNode(node.Targets)
+	ctx.FormatNode(&node.Targets)
 	ctx.WriteString(" TO ")
 	ctx.FormatNode(node.To)
 	if node.AsOf.Expr != nil {
 		ctx.WriteString(" ")
-		ctx.FormatNode(node.AsOf)
+		ctx.FormatNode(&node.AsOf)
 	}
 	if node.IncrementalFrom != nil {
 		ctx.WriteString(" INCREMENTAL FROM ")
-		ctx.FormatNode(node.IncrementalFrom)
+		ctx.FormatNode(&node.IncrementalFrom)
 	}
 	if node.Options != nil {
 		ctx.WriteString(" WITH ")
-		ctx.FormatNode(node.Options)
+		ctx.FormatNode(&node.Options)
 	}
 }
 
@@ -58,16 +58,16 @@ var _ Statement = &Restore{}
 // Format implements the NodeFormatter interface.
 func (node *Restore) Format(ctx *FmtCtx) {
 	ctx.WriteString("RESTORE ")
-	ctx.FormatNode(node.Targets)
+	ctx.FormatNode(&node.Targets)
 	ctx.WriteString(" FROM ")
-	ctx.FormatNode(node.From)
+	ctx.FormatNode(&node.From)
 	if node.AsOf.Expr != nil {
 		ctx.WriteString(" EXPERIMENTAL ")
-		ctx.FormatNode(node.AsOf)
+		ctx.FormatNode(&node.AsOf)
 	}
 	if node.Options != nil {
 		ctx.WriteString(" WITH ")
-		ctx.FormatNode(node.Options)
+		ctx.FormatNode(&node.Options)
 	}
 }
 
@@ -81,12 +81,13 @@ type KVOption struct {
 type KVOptions []KVOption
 
 // Format implements the NodeFormatter interface.
-func (o KVOptions) Format(ctx *FmtCtx) {
-	for i, n := range o {
+func (o *KVOptions) Format(ctx *FmtCtx) {
+	for i := range *o {
+		n := &(*o)[i]
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		ctx.FormatNode(n.Key)
+		ctx.FormatNode(&n.Key)
 		if n.Value != nil {
 			ctx.WriteString(` = `)
 			ctx.FormatNode(n.Value)

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -15,7 +15,6 @@
 package tree
 
 import (
-	"bytes"
 	"fmt"
 	"go/constant"
 	"go/token"
@@ -125,12 +124,12 @@ type NumVal struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (expr *NumVal) Format(buf *bytes.Buffer, f FmtFlags) {
+func (expr *NumVal) Format(ctx *FmtCtx) {
 	s := expr.OrigString
 	if s == "" {
 		s = expr.Value.String()
 	}
-	buf.WriteString(s)
+	ctx.WriteString(s)
 }
 
 // canBeInt64 checks if it's possible for the value to become an int64:
@@ -368,7 +367,8 @@ func (expr *StrVal) RawString() string {
 }
 
 // Format implements the NodeFormatter interface.
-func (expr *StrVal) Format(buf *bytes.Buffer, f FmtFlags) {
+func (expr *StrVal) Format(ctx *FmtCtx) {
+	buf, f := ctx.Buffer, ctx.flags
 	if expr.bytesEsc {
 		lex.EncodeSQLBytes(buf, expr.s)
 	} else {

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -372,7 +372,7 @@ func (expr *StrVal) Format(ctx *FmtCtx) {
 	if expr.bytesEsc {
 		lex.EncodeSQLBytes(buf, expr.s)
 	} else {
-		lex.EncodeSQLStringWithFlags(buf, expr.s, f.encodeFlags)
+		lex.EncodeSQLStringWithFlags(buf, expr.s, f.EncodeFlags())
 	}
 }
 

--- a/pkg/sql/sem/tree/copy.go
+++ b/pkg/sql/sem/tree/copy.go
@@ -27,7 +27,7 @@ func (node *CopyFrom) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Table)
 	if len(node.Columns) > 0 {
 		ctx.WriteString(" (")
-		ctx.FormatNode(node.Columns)
+		ctx.FormatNode(&node.Columns)
 		ctx.WriteString(")")
 	}
 	ctx.WriteString(" FROM ")

--- a/pkg/sql/sem/tree/copy.go
+++ b/pkg/sql/sem/tree/copy.go
@@ -14,8 +14,6 @@
 
 package tree
 
-import "bytes"
-
 // CopyFrom represents a COPY FROM statement.
 type CopyFrom struct {
 	Table   NormalizableTableName
@@ -24,16 +22,16 @@ type CopyFrom struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *CopyFrom) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("COPY ")
-	FormatNode(buf, f, &node.Table)
+func (node *CopyFrom) Format(ctx *FmtCtx) {
+	ctx.WriteString("COPY ")
+	ctx.FormatNode(&node.Table)
 	if len(node.Columns) > 0 {
-		buf.WriteString(" (")
-		FormatNode(buf, f, node.Columns)
-		buf.WriteString(")")
+		ctx.WriteString(" (")
+		ctx.FormatNode(node.Columns)
+		ctx.WriteString(")")
 	}
-	buf.WriteString(" FROM ")
+	ctx.WriteString(" FROM ")
 	if node.Stdin {
-		buf.WriteString("STDIN")
+		ctx.WriteString("STDIN")
 	}
 }

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -47,7 +47,6 @@ type CreateDatabase struct {
 
 // Format implements the NodeFormatter interface.
 func (node *CreateDatabase) Format(ctx *FmtCtx) {
-	f := ctx.flags
 	ctx.WriteString("CREATE DATABASE ")
 	if node.IfNotExists {
 		ctx.WriteString("IF NOT EXISTS ")
@@ -55,19 +54,19 @@ func (node *CreateDatabase) Format(ctx *FmtCtx) {
 	ctx.FormatNode(node.Name)
 	if node.Template != "" {
 		ctx.WriteString(" TEMPLATE = ")
-		lex.EncodeSQLStringWithFlags(ctx.Buffer, node.Template, f.encodeFlags)
+		lex.EncodeSQLStringWithFlags(ctx.Buffer, node.Template, ctx.flags.EncodeFlags())
 	}
 	if node.Encoding != "" {
 		ctx.WriteString(" ENCODING = ")
-		lex.EncodeSQLStringWithFlags(ctx.Buffer, node.Encoding, f.encodeFlags)
+		lex.EncodeSQLStringWithFlags(ctx.Buffer, node.Encoding, ctx.flags.EncodeFlags())
 	}
 	if node.Collate != "" {
 		ctx.WriteString(" LC_COLLATE = ")
-		lex.EncodeSQLStringWithFlags(ctx.Buffer, node.Collate, f.encodeFlags)
+		lex.EncodeSQLStringWithFlags(ctx.Buffer, node.Collate, ctx.flags.EncodeFlags())
 	}
 	if node.CType != "" {
 		ctx.WriteString(" LC_CTYPE = ")
-		lex.EncodeSQLStringWithFlags(ctx.Buffer, node.CType, f.encodeFlags)
+		lex.EncodeSQLStringWithFlags(ctx.Buffer, node.CType, ctx.flags.EncodeFlags())
 	}
 }
 
@@ -349,7 +348,7 @@ func (node *ColumnTableDef) HasColumnFamily() bool {
 func (node *ColumnTableDef) Format(ctx *FmtCtx) {
 	ctx.FormatNode(node.Name)
 	ctx.WriteByte(' ')
-	node.Type.Format(ctx.Buffer, ctx.flags.encodeFlags)
+	node.Type.Format(ctx.Buffer, ctx.flags.EncodeFlags())
 	if node.Nullable.Nullability != SilentNull && node.Nullable.ConstraintName != "" {
 		ctx.WriteString(" CONSTRAINT ")
 		ctx.FormatNode(node.Nullable.ConstraintName)
@@ -946,7 +945,7 @@ func (node *CreateUser) Format(ctx *FmtCtx) {
 	ctx.FormatNode(node.Name)
 	if node.HasPassword() {
 		ctx.WriteString(" WITH PASSWORD ")
-		if ctx.flags.showPasswords {
+		if ctx.flags.HasFlags(FmtShowPasswords) {
 			ctx.FormatNode(node.Password)
 		} else {
 			ctx.WriteString("*****")
@@ -969,7 +968,7 @@ func (node *AlterUserSetPassword) Format(ctx *FmtCtx) {
 	}
 	ctx.FormatNode(node.Name)
 	ctx.WriteString(" WITH PASSWORD ")
-	if ctx.flags.showPasswords {
+	if ctx.flags.HasFlags(FmtShowPasswords) {
 		ctx.FormatNode(node.Password)
 	} else {
 		ctx.WriteString("*****")

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -951,7 +951,7 @@ func (d *DCollatedString) Format(ctx *FmtCtx) {
 	} else {
 		lex.EncodeSQLString(buf, d.Contents)
 		ctx.WriteString(" COLLATE ")
-		lex.EncodeUnrestrictedSQLIdent(buf, d.Locale, lex.EncodeFlags{})
+		lex.EncodeUnrestrictedSQLIdent(buf, d.Locale, lex.EncNoFlags)
 	}
 }
 
@@ -1085,7 +1085,7 @@ func (*DBytes) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DBytes) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	withQuotes := f.withinArray || !f.encodeFlags.BareStrings
+	withQuotes := f.withinArray || !f.encodeFlags.HasFlags(lex.EncBareStrings)
 	if withQuotes {
 		ctx.WriteByte('\'')
 	}
@@ -1181,11 +1181,12 @@ func (*DUuid) AmbiguousFormat() bool { return false }
 // Format implements the NodeFormatter interface.
 func (d *DUuid) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if !f.encodeFlags.BareStrings {
+	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 	ctx.WriteString(d.UUID.String())
-	if !f.encodeFlags.BareStrings {
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 }
@@ -1340,11 +1341,12 @@ func (*DIPAddr) AmbiguousFormat() bool {
 // Format implements the NodeFormatter interface.
 func (d *DIPAddr) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if !f.encodeFlags.BareStrings {
+	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 	ctx.WriteString(d.IPAddr.String())
-	if !f.encodeFlags.BareStrings {
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 }
@@ -1450,11 +1452,12 @@ func (*DDate) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DDate) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if !f.encodeFlags.BareStrings {
+	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 	ctx.WriteString(timeutil.Unix(int64(*d)*SecondsInDay, 0).Format(dateFormat))
-	if !f.encodeFlags.BareStrings {
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 }
@@ -1549,11 +1552,12 @@ func (*DTime) AmbiguousFormat() bool { return false }
 // Format implements the NodeFormatter interface.
 func (d *DTime) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if !f.encodeFlags.BareStrings {
+	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 	ctx.WriteString(timeofday.TimeOfDay(*d).String())
-	if !f.encodeFlags.BareStrings {
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 }
@@ -1783,11 +1787,12 @@ func (*DTimestamp) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DTimestamp) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if !f.encodeFlags.BareStrings {
+	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 	ctx.WriteString(d.UTC().Format(TimestampOutputFormat))
-	if !f.encodeFlags.BareStrings {
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 }
@@ -1881,11 +1886,12 @@ func (*DTimestampTZ) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DTimestampTZ) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if !f.encodeFlags.BareStrings {
+	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 	ctx.WriteString(d.Time.Format(TimestampOutputFormat))
-	if !f.encodeFlags.BareStrings {
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 }
@@ -2089,11 +2095,12 @@ func (*DInterval) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DInterval) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if !f.encodeFlags.BareStrings {
+	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 	d.Duration.Format(ctx.Buffer)
-	if !f.encodeFlags.BareStrings {
+	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
 }
@@ -2864,7 +2871,7 @@ func (d *DOid) Format(ctx *FmtCtx) {
 		// a DInt, I _think_ it's correct to just delegate to the DInt's Format.
 		d.DInt.Format(ctx)
 	} else {
-		lex.EncodeSQLStringWithFlags(ctx.Buffer, d.name, lex.EncodeFlags{BareStrings: true})
+		lex.EncodeSQLStringWithFlags(ctx.Buffer, d.name, lex.EncBareStrings)
 	}
 }
 

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -151,9 +151,9 @@ func (d Datums) Reverse() {
 }
 
 // Format implements the NodeFormatter interface.
-func (d Datums) Format(ctx *FmtCtx) {
+func (d *Datums) Format(ctx *FmtCtx) {
 	ctx.WriteByte('(')
-	for i, v := range d {
+	for i, v := range *d {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
@@ -2425,7 +2425,7 @@ func (*DTuple) AmbiguousFormat() bool { return false }
 
 // Format implements the NodeFormatter interface.
 func (d *DTuple) Format(ctx *FmtCtx) {
-	ctx.FormatNode(d.D)
+	ctx.FormatNode(&d.D)
 }
 
 // SetSorted sets the sorted flag on the DTuple. This should be used when a

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -487,7 +487,7 @@ func (*DInt) AmbiguousFormat() bool { return true }
 func (d *DInt) Format(ctx *FmtCtx) {
 	// If the number is negative, we need to use parens or the `:::INT` type hint
 	// will take precedence over the negation sign.
-	quote := ctx.flags.disambiguateDatumTypes && *d < 0
+	quote := ctx.flags.HasFlags(fmtDisambiguateDatumTypes) && *d < 0
 	if quote {
 		ctx.WriteByte('(')
 	}
@@ -616,7 +616,7 @@ func (*DFloat) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DFloat) Format(ctx *FmtCtx) {
 	fl := float64(*d)
-	quote := ctx.flags.disambiguateDatumTypes && (math.IsNaN(fl) || math.IsInf(fl, 0))
+	quote := ctx.flags.HasFlags(fmtDisambiguateDatumTypes) && (math.IsNaN(fl) || math.IsInf(fl, 0))
 	if quote {
 		ctx.WriteByte('\'')
 	}
@@ -747,7 +747,7 @@ func (*DDecimal) AmbiguousFormat() bool { return true }
 
 // Format implements the NodeFormatter interface.
 func (d *DDecimal) Format(ctx *FmtCtx) {
-	quote := ctx.flags.disambiguateDatumTypes && d.Decimal.Form != apd.Finite
+	quote := ctx.flags.HasFlags(fmtDisambiguateDatumTypes) && d.Decimal.Form != apd.Finite
 	if quote {
 		ctx.WriteByte('\'')
 	}
@@ -877,10 +877,10 @@ func (*DString) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DString) Format(ctx *FmtCtx) {
 	buf, f := ctx.Buffer, ctx.flags
-	if f.withinArray {
+	if f.HasFlags(fmtWithinArray) {
 		lex.EncodeSQLStringInsideArray(buf, string(*d))
 	} else {
-		lex.EncodeSQLStringWithFlags(buf, string(*d), f.encodeFlags)
+		lex.EncodeSQLStringWithFlags(buf, string(*d), f.EncodeFlags())
 	}
 }
 
@@ -946,7 +946,7 @@ func (*DCollatedString) AmbiguousFormat() bool { return false }
 // Format implements the NodeFormatter interface.
 func (d *DCollatedString) Format(ctx *FmtCtx) {
 	buf, f := ctx.Buffer, ctx.flags
-	if f.withinArray {
+	if f.HasFlags(fmtWithinArray) {
 		lex.EncodeSQLStringInsideArray(buf, d.Contents)
 	} else {
 		lex.EncodeSQLString(buf, d.Contents)
@@ -1085,7 +1085,7 @@ func (*DBytes) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DBytes) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	withQuotes := f.withinArray || !f.encodeFlags.HasFlags(lex.EncBareStrings)
+	withQuotes := f.HasFlags(fmtWithinArray) || !f.HasFlags(FmtFlags(lex.EncBareStrings))
 	if withQuotes {
 		ctx.WriteByte('\'')
 	}
@@ -1181,7 +1181,7 @@ func (*DUuid) AmbiguousFormat() bool { return false }
 // Format implements the NodeFormatter interface.
 func (d *DUuid) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	bareStrings := f.HasFlags(FmtFlags(lex.EncBareStrings))
 	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
@@ -1341,7 +1341,7 @@ func (*DIPAddr) AmbiguousFormat() bool {
 // Format implements the NodeFormatter interface.
 func (d *DIPAddr) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	bareStrings := f.HasFlags(FmtFlags(lex.EncBareStrings))
 	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
@@ -1452,7 +1452,7 @@ func (*DDate) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DDate) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	bareStrings := f.HasFlags(FmtFlags(lex.EncBareStrings))
 	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
@@ -1552,7 +1552,7 @@ func (*DTime) AmbiguousFormat() bool { return false }
 // Format implements the NodeFormatter interface.
 func (d *DTime) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	bareStrings := f.HasFlags(FmtFlags(lex.EncBareStrings))
 	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
@@ -1787,7 +1787,7 @@ func (*DTimestamp) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DTimestamp) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	bareStrings := f.HasFlags(FmtFlags(lex.EncBareStrings))
 	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
@@ -1886,7 +1886,7 @@ func (*DTimestampTZ) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DTimestampTZ) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	bareStrings := f.HasFlags(FmtFlags(lex.EncBareStrings))
 	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
@@ -2095,7 +2095,7 @@ func (*DInterval) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DInterval) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	bareStrings := f.encodeFlags.HasFlags(lex.EncBareStrings)
+	bareStrings := f.HasFlags(FmtFlags(lex.EncBareStrings))
 	if !bareStrings {
 		ctx.WriteByte('\'')
 	}
@@ -2230,7 +2230,7 @@ func (d *DJSON) Format(ctx *FmtCtx) {
 	// TODO(justin): ideally the JSON string encoder should know it needs to
 	// escape things to be inside SQL strings in order to avoid this allocation.
 	s := d.JSON.String()
-	lex.EncodeSQLStringWithFlags(ctx.Buffer, s, ctx.flags.encodeFlags)
+	lex.EncodeSQLStringWithFlags(ctx.Buffer, s, ctx.flags.EncodeFlags())
 }
 
 // Size implements the Datum interface.

--- a/pkg/sql/sem/tree/delete.go
+++ b/pkg/sql/sem/tree/delete.go
@@ -23,8 +23,6 @@
 
 package tree
 
-import "bytes"
-
 // Delete represents a DELETE statement.
 type Delete struct {
 	With      *With
@@ -36,12 +34,12 @@ type Delete struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Delete) Format(buf *bytes.Buffer, f FmtFlags) {
-	FormatNode(buf, f, node.With)
-	buf.WriteString("DELETE FROM ")
-	FormatNode(buf, f, node.Table)
-	FormatNode(buf, f, node.Where)
-	FormatNode(buf, f, node.OrderBy)
-	FormatNode(buf, f, node.Limit)
-	FormatNode(buf, f, node.Returning)
+func (node *Delete) Format(ctx *FmtCtx) {
+	ctx.FormatNode(node.With)
+	ctx.WriteString("DELETE FROM ")
+	ctx.FormatNode(node.Table)
+	ctx.FormatNode(node.Where)
+	ctx.FormatNode(node.OrderBy)
+	ctx.FormatNode(node.Limit)
+	ctx.FormatNode(node.Returning)
 }

--- a/pkg/sql/sem/tree/delete.go
+++ b/pkg/sql/sem/tree/delete.go
@@ -39,7 +39,7 @@ func (node *Delete) Format(ctx *FmtCtx) {
 	ctx.WriteString("DELETE FROM ")
 	ctx.FormatNode(node.Table)
 	ctx.FormatNode(node.Where)
-	ctx.FormatNode(node.OrderBy)
+	ctx.FormatNode(&node.OrderBy)
 	ctx.FormatNode(node.Limit)
 	ctx.FormatNode(node.Returning)
 }

--- a/pkg/sql/sem/tree/discard.go
+++ b/pkg/sql/sem/tree/discard.go
@@ -14,8 +14,6 @@
 
 package tree
 
-import "bytes"
-
 // Discard represents a DISCARD statement.
 type Discard struct {
 	Mode DiscardMode
@@ -32,10 +30,10 @@ const (
 )
 
 // Format implements the NodeFormatter interface.
-func (node *Discard) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node *Discard) Format(ctx *FmtCtx) {
 	switch node.Mode {
 	case DiscardModeAll:
-		buf.WriteString("DISCARD ALL")
+		ctx.WriteString("DISCARD ALL")
 	}
 }
 

--- a/pkg/sql/sem/tree/drop.go
+++ b/pkg/sql/sem/tree/drop.go
@@ -23,8 +23,6 @@
 
 package tree
 
-import "bytes"
-
 // DropBehavior represents options for dropping schema elements.
 type DropBehavior int
 
@@ -53,15 +51,15 @@ type DropDatabase struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *DropDatabase) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("DROP DATABASE ")
+func (node *DropDatabase) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP DATABASE ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.Name)
+	ctx.FormatNode(node.Name)
 	if node.DropBehavior != DropDefault {
-		buf.WriteByte(' ')
-		buf.WriteString(node.DropBehavior.String())
+		ctx.WriteByte(' ')
+		ctx.WriteString(node.DropBehavior.String())
 	}
 }
 
@@ -73,15 +71,15 @@ type DropIndex struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *DropIndex) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("DROP INDEX ")
+func (node *DropIndex) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP INDEX ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.IndexList)
+	ctx.FormatNode(node.IndexList)
 	if node.DropBehavior != DropDefault {
-		buf.WriteByte(' ')
-		buf.WriteString(node.DropBehavior.String())
+		ctx.WriteByte(' ')
+		ctx.WriteString(node.DropBehavior.String())
 	}
 }
 
@@ -93,15 +91,15 @@ type DropTable struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *DropTable) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("DROP TABLE ")
+func (node *DropTable) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP TABLE ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.Names)
+	ctx.FormatNode(node.Names)
 	if node.DropBehavior != DropDefault {
-		buf.WriteByte(' ')
-		buf.WriteString(node.DropBehavior.String())
+		ctx.WriteByte(' ')
+		ctx.WriteString(node.DropBehavior.String())
 	}
 }
 
@@ -113,15 +111,15 @@ type DropView struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *DropView) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("DROP VIEW ")
+func (node *DropView) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP VIEW ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.Names)
+	ctx.FormatNode(node.Names)
 	if node.DropBehavior != DropDefault {
-		buf.WriteByte(' ')
-		buf.WriteString(node.DropBehavior.String())
+		ctx.WriteByte(' ')
+		ctx.WriteString(node.DropBehavior.String())
 	}
 }
 
@@ -133,15 +131,15 @@ type DropSequence struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *DropSequence) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("DROP SEQUENCE ")
+func (node *DropSequence) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP SEQUENCE ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.Names)
+	ctx.FormatNode(node.Names)
 	if node.DropBehavior != DropDefault {
-		buf.WriteByte(' ')
-		buf.WriteString(node.DropBehavior.String())
+		ctx.WriteByte(' ')
+		ctx.WriteString(node.DropBehavior.String())
 	}
 }
 
@@ -152,12 +150,12 @@ type DropUser struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *DropUser) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("DROP USER ")
+func (node *DropUser) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP USER ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.Names)
+	ctx.FormatNode(node.Names)
 }
 
 // DropRole represents a DROP ROLE statement
@@ -167,10 +165,10 @@ type DropRole struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *DropRole) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("DROP ROLE ")
+func (node *DropRole) Format(ctx *FmtCtx) {
+	ctx.WriteString("DROP ROLE ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.Names)
+	ctx.FormatNode(node.Names)
 }

--- a/pkg/sql/sem/tree/drop.go
+++ b/pkg/sql/sem/tree/drop.go
@@ -56,7 +56,7 @@ func (node *DropDatabase) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(node.Name)
+	ctx.FormatNode(&node.Name)
 	if node.DropBehavior != DropDefault {
 		ctx.WriteByte(' ')
 		ctx.WriteString(node.DropBehavior.String())
@@ -76,7 +76,7 @@ func (node *DropIndex) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(node.IndexList)
+	ctx.FormatNode(&node.IndexList)
 	if node.DropBehavior != DropDefault {
 		ctx.WriteByte(' ')
 		ctx.WriteString(node.DropBehavior.String())
@@ -96,7 +96,7 @@ func (node *DropTable) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(node.Names)
+	ctx.FormatNode(&node.Names)
 	if node.DropBehavior != DropDefault {
 		ctx.WriteByte(' ')
 		ctx.WriteString(node.DropBehavior.String())
@@ -116,7 +116,7 @@ func (node *DropView) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(node.Names)
+	ctx.FormatNode(&node.Names)
 	if node.DropBehavior != DropDefault {
 		ctx.WriteByte(' ')
 		ctx.WriteString(node.DropBehavior.String())
@@ -136,7 +136,7 @@ func (node *DropSequence) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(node.Names)
+	ctx.FormatNode(&node.Names)
 	if node.DropBehavior != DropDefault {
 		ctx.WriteByte(' ')
 		ctx.WriteString(node.DropBehavior.String())
@@ -155,7 +155,7 @@ func (node *DropUser) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(node.Names)
+	ctx.FormatNode(&node.Names)
 }
 
 // DropRole represents a DROP ROLE statement
@@ -170,5 +170,5 @@ func (node *DropRole) Format(ctx *FmtCtx) {
 	if node.IfExists {
 		ctx.WriteString("IF EXISTS ")
 	}
-	ctx.FormatNode(node.Names)
+	ctx.FormatNode(&node.Names)
 }

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2824,8 +2824,8 @@ func performCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 				// Resolve function name.
 				substrs := strings.Split(s, ".")
 				name := UnresolvedName{}
-				for _, substr := range substrs {
-					name = append(name, Name(substr))
+				for i := range substrs {
+					name = append(name, (*Name)(&substrs[i]))
 				}
 				funcDef, err := name.ResolveFunction(ctx.SearchPath)
 				if err != nil {
@@ -3181,7 +3181,7 @@ func (expr UnqualifiedStar) Eval(ctx *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
-func (expr UnresolvedName) Eval(ctx *EvalContext) (Datum, error) {
+func (expr *UnresolvedName) Eval(ctx *EvalContext) (Datum, error) {
 	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", expr)
 }
 

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -15,7 +15,6 @@
 package tree
 
 import (
-	"bytes"
 	"strings"
 )
 
@@ -31,17 +30,17 @@ type Explain struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Explain) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("EXPLAIN ")
+func (node *Explain) Format(ctx *FmtCtx) {
+	ctx.WriteString("EXPLAIN ")
 	if len(node.Options) > 0 {
-		buf.WriteByte('(')
+		ctx.WriteByte('(')
 		for i, opt := range node.Options {
 			if i > 0 {
-				buf.WriteString(", ")
+				ctx.WriteString(", ")
 			}
-			buf.WriteString(strings.ToUpper(opt))
+			ctx.WriteString(strings.ToUpper(opt))
 		}
-		buf.WriteString(") ")
+		ctx.WriteString(") ")
 	}
-	FormatNode(buf, f, node.Statement)
+	ctx.FormatNode(node.Statement)
 }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1347,7 +1347,7 @@ type CollateExpr struct {
 func (node *CollateExpr) Format(ctx *FmtCtx) {
 	exprFmtWithParen(ctx, node.Expr)
 	ctx.WriteString(" COLLATE ")
-	lex.EncodeUnrestrictedSQLIdent(ctx.Buffer, node.Locale, lex.EncodeFlags{})
+	lex.EncodeUnrestrictedSQLIdent(ctx.Buffer, node.Locale, lex.EncNoFlags)
 }
 
 func (node *AliasedTableExpr) String() string { return AsString(node) }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -638,7 +638,7 @@ func (node *CoalesceExpr) TypedExprAt(idx int) TypedExpr {
 func (node *CoalesceExpr) Format(ctx *FmtCtx) {
 	ctx.WriteString(node.Name)
 	ctx.WriteByte('(')
-	ctx.FormatNode(node.Exprs)
+	ctx.FormatNode(&node.Exprs)
 	ctx.WriteByte(')')
 }
 
@@ -720,7 +720,7 @@ func (node *Tuple) Format(ctx *FmtCtx) {
 		ctx.WriteString("ROW")
 	}
 	ctx.WriteByte('(')
-	ctx.FormatNode(node.Exprs)
+	ctx.FormatNode(&node.Exprs)
 	ctx.WriteByte(')')
 }
 
@@ -751,7 +751,7 @@ type Array struct {
 // Format implements the NodeFormatter interface.
 func (node *Array) Format(ctx *FmtCtx) {
 	ctx.WriteString("ARRAY[")
-	ctx.FormatNode(node.Exprs)
+	ctx.FormatNode(&node.Exprs)
 	ctx.WriteByte(']')
 }
 
@@ -773,8 +773,8 @@ func (node *ArrayFlatten) Format(ctx *FmtCtx) {
 type Exprs []Expr
 
 // Format implements the NodeFormatter interface.
-func (node Exprs) Format(ctx *FmtCtx) {
-	for i, n := range node {
+func (node *Exprs) Format(ctx *FmtCtx) {
+	for i, n := range *node {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
@@ -786,10 +786,10 @@ func (node Exprs) Format(ctx *FmtCtx) {
 // because it's not parenthesized.
 type TypedExprs []TypedExpr
 
-func (node TypedExprs) String() string {
+func (node *TypedExprs) String() string {
 	var prefix string
 	var buf bytes.Buffer
-	for _, n := range node {
+	for _, n := range *node {
 		fmt.Fprintf(&buf, "%s%s", prefix, n)
 		prefix = ", "
 	}
@@ -1085,16 +1085,16 @@ func (node *FuncExpr) Format(ctx *FmtCtx) {
 	// We need to remove name anonimization for the function name in
 	// particular. Do this by overriding the flags.
 	subCtx := ctx.CopyWithFlags(ctx.flags & ^FmtAnonymize)
-	subCtx.FormatNode(node.Func)
+	subCtx.FormatNode(&node.Func)
 
 	ctx.WriteByte('(')
 	ctx.WriteString(typ)
-	ctx.FormatNode(node.Exprs)
+	ctx.FormatNode(&node.Exprs)
 	ctx.WriteByte(')')
 	if window := node.WindowDef; window != nil {
 		ctx.WriteString(" OVER ")
 		if window.Name != "" {
-			ctx.FormatNode(window.Name)
+			ctx.FormatNode(&window.Name)
 		} else {
 			ctx.FormatNode(window)
 		}
@@ -1270,8 +1270,8 @@ func validCastTypes(t types.T) []types.T {
 type ArraySubscripts []*ArraySubscript
 
 // Format implements the NodeFormatter interface.
-func (a ArraySubscripts) Format(ctx *FmtCtx) {
-	for _, s := range a {
+func (a *ArraySubscripts) Format(ctx *FmtCtx) {
+	for _, s := range *a {
 		ctx.FormatNode(s)
 	}
 }
@@ -1287,7 +1287,7 @@ type IndirectionExpr struct {
 // Format implements the NodeFormatter interface.
 func (node *IndirectionExpr) Format(ctx *FmtCtx) {
 	exprFmtWithParen(ctx, node.Expr)
-	ctx.FormatNode(node.Indirection)
+	ctx.FormatNode(&node.Indirection)
 }
 
 type annotateSyntaxMode int
@@ -1381,15 +1381,15 @@ func (node *DTable) String() string           { return AsString(node) }
 func (node *DOid) String() string             { return AsString(node) }
 func (node *DOidWrapper) String() string      { return AsString(node) }
 func (node *ExistsExpr) String() string       { return AsString(node) }
-func (node Exprs) String() string             { return AsString(node) }
+func (node *Exprs) String() string            { return AsString(node) }
 func (node *ArrayFlatten) String() string     { return AsString(node) }
 func (node *FuncExpr) String() string         { return AsString(node) }
 func (node *IfExpr) String() string           { return AsString(node) }
 func (node *IndexedVar) String() string       { return AsString(node) }
 func (node *IndirectionExpr) String() string  { return AsString(node) }
 func (node *IsOfTypeExpr) String() string     { return AsString(node) }
-func (node Name) String() string              { return AsString(node) }
-func (node UnrestrictedName) String() string  { return AsString(node) }
+func (node *Name) String() string             { return AsString(node) }
+func (node *UnrestrictedName) String() string { return AsString(node) }
 func (node *NotExpr) String() string          { return AsString(node) }
 func (node *NullIfExpr) String() string       { return AsString(node) }
 func (node *NumVal) String() string           { return AsString(node) }
@@ -1405,4 +1405,4 @@ func (node DefaultVal) String() string        { return AsString(node) }
 func (node MaxVal) String() string            { return AsString(node) }
 func (node *Placeholder) String() string      { return AsString(node) }
 func (node dNull) String() string             { return AsString(node) }
-func (list NameList) String() string          { return AsString(list) }
+func (list *NameList) String() string         { return AsString(list) }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -551,7 +551,7 @@ func (node *IsOfTypeExpr) Format(ctx *FmtCtx) {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		t.Format(ctx.Buffer, ctx.flags.encodeFlags)
+		t.Format(ctx.Buffer, ctx.flags.EncodeFlags())
 	}
 	ctx.WriteByte(')')
 }
@@ -1084,9 +1084,7 @@ func (node *FuncExpr) Format(ctx *FmtCtx) {
 
 	// We need to remove name anonimization for the function name in
 	// particular. Do this by overriding the flags.
-	fmtDisableAnonymize := *ctx.flags
-	fmtDisableAnonymize.anonymize = false
-	subCtx := ctx.CopyWithFlags(&fmtDisableAnonymize)
+	subCtx := ctx.CopyWithFlags(ctx.flags & ^FmtAnonymize)
 	subCtx.FormatNode(node.Func)
 
 	ctx.WriteByte('(')
@@ -1170,14 +1168,14 @@ type CastExpr struct {
 
 // Format implements the NodeFormatter interface.
 func (node *CastExpr) Format(ctx *FmtCtx) {
-	buf, f := ctx.Buffer, ctx.flags
+	buf := ctx.Buffer
 	switch node.SyntaxMode {
 	case CastPrepend:
 		// This is a special case for things like INTERVAL '1s'. These only work
 		// with string constats; if the underlying expression was changed, we fall
 		// back to the short syntax.
 		if _, ok := node.Expr.(*StrVal); ok {
-			node.Type.Format(buf, f.encodeFlags)
+			node.Type.Format(buf, ctx.flags.EncodeFlags())
 			ctx.WriteByte(' ')
 			ctx.FormatNode(node.Expr)
 			break
@@ -1186,12 +1184,12 @@ func (node *CastExpr) Format(ctx *FmtCtx) {
 	case CastShort:
 		exprFmtWithParen(ctx, node.Expr)
 		ctx.WriteString("::")
-		node.Type.Format(buf, f.encodeFlags)
+		node.Type.Format(buf, ctx.flags.EncodeFlags())
 	default:
 		ctx.WriteString("CAST(")
 		ctx.FormatNode(node.Expr)
 		ctx.WriteString(" AS ")
-		node.Type.Format(buf, f.encodeFlags)
+		node.Type.Format(buf, ctx.flags.EncodeFlags())
 		ctx.WriteByte(')')
 	}
 }
@@ -1310,18 +1308,18 @@ type AnnotateTypeExpr struct {
 
 // Format implements the NodeFormatter interface.
 func (node *AnnotateTypeExpr) Format(ctx *FmtCtx) {
-	buf, f := ctx.Buffer, ctx.flags
+	buf := ctx.Buffer
 	switch node.SyntaxMode {
 	case AnnotateShort:
 		exprFmtWithParen(ctx, node.Expr)
 		ctx.WriteString(":::")
-		node.Type.Format(buf, f.encodeFlags)
+		node.Type.Format(buf, ctx.flags.EncodeFlags())
 
 	default:
 		ctx.WriteString("ANNOTATE_TYPE(")
 		ctx.FormatNode(node.Expr)
 		ctx.WriteString(", ")
-		node.Type.Format(buf, f.encodeFlags)
+		node.Type.Format(buf, ctx.flags.EncodeFlags())
 		ctx.WriteByte(')')
 	}
 }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -675,9 +675,8 @@ func NewPlaceholder(name string) *Placeholder {
 
 // Format implements the NodeFormatter interface.
 func (node *Placeholder) Format(ctx *FmtCtx) {
-	f := ctx.flags
-	if f.placeholderFormat != nil {
-		f.placeholderFormat(ctx, node)
+	if ctx.placeholderFormat != nil {
+		ctx.placeholderFormat(ctx, node)
 		return
 	}
 	ctx.WriteByte('$')

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -49,7 +49,8 @@ func TestUnresolvedNameString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		q := tree.UnresolvedName{tree.Name(tc.in)}
+		n := tree.Name(tc.in)
+		q := tree.UnresolvedName{&n}
 		if q.String() != tc.out {
 			t.Errorf("expected q.String() == %q, got %q", tc.out, q.String())
 		}

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -31,10 +31,6 @@ type fmtFlags struct {
 	// tableNameFormatter will be called on all NormalizableTableNames if it is
 	// non-nil.
 	tableNameFormatter func(*FmtCtx, *NormalizableTableName)
-	// indexedVarFormat is an optional interceptor for
-	// IndexedVarContainer.IndexedVarFormat calls; it can be used to
-	// customize the formatting of IndexedVars.
-	indexedVarFormat func(ctx *FmtCtx, idx int)
 	// placeholderFormat is an optional interceptor for Placeholder.Format calls;
 	// it can be used to format placeholders differently than normal.
 	placeholderFormat func(ctx *FmtCtx, p *Placeholder)
@@ -62,6 +58,10 @@ type fmtFlags struct {
 type FmtCtx struct {
 	*bytes.Buffer
 	flags FmtFlags
+	// indexedVarFormat is an optional interceptor for
+	// IndexedVarContainer.IndexedVarFormat calls; it can be used to
+	// customize the formatting of IndexedVars.
+	indexedVarFormat func(ctx *FmtCtx, idx int)
 }
 
 // MakeFmtCtx creates a FmtCtx from an existing buffer and flags.
@@ -180,12 +180,11 @@ func FmtExpr(base FmtFlags, showTypes bool, symbolicVars bool, showTableAliases 
 	return &f
 }
 
-// FmtIndexedVarFormat returns FmtFlags that customizes the printing of
+// WithIndexedVarFormat modifies FmtCtx to customize the printing of
 // IndexedVars using the provided function.
-func FmtIndexedVarFormat(base FmtFlags, fn func(ctx *FmtCtx, idx int)) FmtFlags {
-	f := *base
-	f.indexedVarFormat = fn
-	return &f
+func (ctx *FmtCtx) WithIndexedVarFormat(fn func(ctx *FmtCtx, idx int)) *FmtCtx {
+	ctx.indexedVarFormat = fn
+	return ctx
 }
 
 // FmtPlaceholderFormat returns FmtFlags that customizes the printing of

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -272,11 +272,14 @@ func (ctx *FmtCtx) FormatNode(n NodeFormatter) {
 }
 
 // AsStringWithFlags pretty prints a node to a string given specific flags.
-func AsStringWithFlags(n NodeFormatter, f FmtFlags) string {
-	var buf bytes.Buffer
-	ctx := FmtCtx{Buffer: &buf, flags: f}
-	ctx.FormatNode(n)
-	return buf.String()
+func AsStringWithFlags(n NodeFormatter, fl FmtFlags) string {
+	var f struct {
+		buf bytes.Buffer
+		ctx FmtCtx
+	}
+	f.ctx = MakeFmtCtx(&f.buf, fl)
+	f.ctx.FormatNode(n)
+	return f.buf.String()
 }
 
 // AsString pretty prints a node to a string.

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -86,15 +86,15 @@ var FmtShowTypes FmtFlags = &fmtFlags{showTypes: true}
 
 // FmtBareStrings instructs the pretty-printer to print strings without
 // wrapping quotes, if the string contains no special characters.
-var FmtBareStrings FmtFlags = &fmtFlags{encodeFlags: lex.EncodeFlags{BareStrings: true}}
+var FmtBareStrings FmtFlags = &fmtFlags{encodeFlags: lex.EncBareStrings}
 
 // FmtArrays instructs the pretty-printer to print strings without
 // wrapping quotes, if the string contains no special characters.
-var FmtArrays FmtFlags = &fmtFlags{withinArray: true, encodeFlags: lex.EncodeFlags{BareStrings: true}}
+var FmtArrays FmtFlags = &fmtFlags{withinArray: true, encodeFlags: lex.EncBareStrings}
 
 // FmtBareIdentifiers instructs the pretty-printer to print
 // identifiers without wrapping quotes in any case.
-var FmtBareIdentifiers FmtFlags = &fmtFlags{encodeFlags: lex.EncodeFlags{BareIdentifiers: true}}
+var FmtBareIdentifiers FmtFlags = &fmtFlags{encodeFlags: lex.EncBareIdentifiers}
 
 // FmtParsable instructs the pretty-printer to produce a representation that
 // can be parsed into an equivalent expression (useful for serialization of

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -217,6 +217,19 @@ type NodeFormatter interface {
 	Format(ctx *FmtCtx)
 }
 
+// FormatName formats a string as a name.
+//
+// Note: prefer FormatNameP below when the string is already on the
+// heap.
+func (ctx *FmtCtx) FormatName(s string) {
+	ctx.FormatNode((*Name)(&s))
+}
+
+// FormatNameP formats a string reference as a name.
+func (ctx *FmtCtx) FormatNameP(s *string) {
+	ctx.FormatNode((*Name)(s))
+}
+
 // FormatNode recurses into a node for pretty-printing.
 // Flag-driven special cases can hook into this.
 func (ctx *FmtCtx) FormatNode(n NodeFormatter) {

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -28,9 +28,6 @@ type fmtFlags struct {
 	ShowTableAliases bool
 	symbolicVars     bool
 	hideConstants    bool
-	// placeholderFormat is an optional interceptor for Placeholder.Format calls;
-	// it can be used to format placeholders differently than normal.
-	placeholderFormat func(ctx *FmtCtx, p *Placeholder)
 	// If true, non-function names are replaced by underscores.
 	anonymize bool
 	// If true, strings will be formatted for being contents of ARRAYs.
@@ -62,6 +59,9 @@ type FmtCtx struct {
 	// tableNameFormatter will be called on all NormalizableTableNames if it is
 	// non-nil.
 	tableNameFormatter func(*FmtCtx, *NormalizableTableName)
+	// placeholderFormat is an optional interceptor for Placeholder.Format calls;
+	// it can be used to format placeholders differently than normal.
+	placeholderFormat func(ctx *FmtCtx, p *Placeholder)
 }
 
 // MakeFmtCtx creates a FmtCtx from an existing buffer and flags.
@@ -184,14 +184,11 @@ func (ctx *FmtCtx) WithIndexedVarFormat(fn func(ctx *FmtCtx, idx int)) *FmtCtx {
 	return ctx
 }
 
-// FmtPlaceholderFormat returns FmtFlags that customizes the printing of
+// WithPlaceholderFormat modifies FmtCtx to customizes the printing of
 // StarDatums using the provided function.
-func FmtPlaceholderFormat(
-	base FmtFlags, placeholderFn func(_ *FmtCtx, _ *Placeholder),
-) FmtFlags {
-	f := *base
-	f.placeholderFormat = placeholderFn
-	return &f
+func (ctx *FmtCtx) WithPlaceholderFormat(placeholderFn func(_ *FmtCtx, _ *Placeholder)) *FmtCtx {
+	ctx.placeholderFormat = placeholderFn
+	return ctx
 }
 
 // NodeFormatter is implemented by nodes that can be pretty-printed.

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -28,9 +28,6 @@ type fmtFlags struct {
 	ShowTableAliases bool
 	symbolicVars     bool
 	hideConstants    bool
-	// tableNameFormatter will be called on all NormalizableTableNames if it is
-	// non-nil.
-	tableNameFormatter func(*FmtCtx, *NormalizableTableName)
 	// placeholderFormat is an optional interceptor for Placeholder.Format calls;
 	// it can be used to format placeholders differently than normal.
 	placeholderFormat func(ctx *FmtCtx, p *Placeholder)
@@ -62,6 +59,9 @@ type FmtCtx struct {
 	// IndexedVarContainer.IndexedVarFormat calls; it can be used to
 	// customize the formatting of IndexedVars.
 	indexedVarFormat func(ctx *FmtCtx, idx int)
+	// tableNameFormatter will be called on all NormalizableTableNames if it is
+	// non-nil.
+	tableNameFormatter func(*FmtCtx, *NormalizableTableName)
 }
 
 // MakeFmtCtx creates a FmtCtx from an existing buffer and flags.
@@ -128,14 +128,11 @@ var FmtSimpleQualified FmtFlags = &fmtFlags{alwaysQualify: true}
 // sub-expressions between parentheses.
 var FmtAlwaysGroupExprs FmtFlags = &fmtFlags{alwaysParens: true}
 
-// FmtReformatTableNames returns FmtFlags that instructs the pretty-printer
+// WithReformatTableNames modifies FmtCtx to instructs the pretty-printer
 // to substitute the printing of table names using the provided function.
-func FmtReformatTableNames(
-	base FmtFlags, fn func(*FmtCtx, *NormalizableTableName),
-) FmtFlags {
-	f := *base
-	f.tableNameFormatter = fn
-	return &f
+func (ctx *FmtCtx) WithReformatTableNames(fn func(*FmtCtx, *NormalizableTableName)) *FmtCtx {
+	ctx.tableNameFormatter = fn
+	return ctx
 }
 
 // StripTypeFormatting removes the flag that extracts types from the format flags,

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -30,14 +30,14 @@ type fmtFlags struct {
 	hideConstants    bool
 	// tableNameFormatter will be called on all NormalizableTableNames if it is
 	// non-nil.
-	tableNameFormatter func(*NormalizableTableName, *bytes.Buffer, FmtFlags)
+	tableNameFormatter func(*FmtCtx, *NormalizableTableName)
 	// indexedVarFormat is an optional interceptor for
 	// IndexedVarContainer.IndexedVarFormat calls; it can be used to
 	// customize the formatting of IndexedVars.
-	indexedVarFormat func(buf *bytes.Buffer, idx int)
+	indexedVarFormat func(ctx *FmtCtx, idx int)
 	// placeholderFormat is an optional interceptor for Placeholder.Format calls;
 	// it can be used to format placeholders differently than normal.
-	placeholderFormat func(buf *bytes.Buffer, f FmtFlags, p *Placeholder)
+	placeholderFormat func(ctx *FmtCtx, p *Placeholder)
 	// If true, non-function names are replaced by underscores.
 	anonymize bool
 	// If true, strings will be formatted for being contents of ARRAYs.
@@ -54,6 +54,19 @@ type fmtFlags struct {
 	alwaysParens bool
 	// Flags that control the formatting of strings and identifiers.
 	encodeFlags lex.EncodeFlags
+}
+
+// FmtCtx is suitable for passing to Format() methods.
+// It also exposes the underlying bytes.Buffer interface for
+// convenience.
+type FmtCtx struct {
+	*bytes.Buffer
+	flags FmtFlags
+}
+
+// MakeFmtCtx creates a FmtCtx from an existing buffer and flags.
+func MakeFmtCtx(buf *bytes.Buffer, f FmtFlags) FmtCtx {
+	return FmtCtx{Buffer: buf, flags: f}
 }
 
 // FmtFlags enables conditional formatting in the pretty-printer.
@@ -118,7 +131,7 @@ var FmtAlwaysGroupExprs FmtFlags = &fmtFlags{alwaysParens: true}
 // FmtReformatTableNames returns FmtFlags that instructs the pretty-printer
 // to substitute the printing of table names using the provided function.
 func FmtReformatTableNames(
-	base FmtFlags, fn func(*NormalizableTableName, *bytes.Buffer, FmtFlags),
+	base FmtFlags, fn func(*FmtCtx, *NormalizableTableName),
 ) FmtFlags {
 	f := *base
 	f.tableNameFormatter = fn
@@ -127,10 +140,34 @@ func FmtReformatTableNames(
 
 // StripTypeFormatting removes the flag that extracts types from the format flags,
 // so as to enable rendering expressions for which types have not been computed yet.
-func StripTypeFormatting(f FmtFlags) FmtFlags {
-	nf := *f
+func (ctx *FmtCtx) StripTypeFormatting() {
+	nf := *ctx.flags
 	nf.showTypes = false
-	return &nf
+	ctx.flags = &nf
+}
+
+// CopyWithFlags creates a new FmtCtx with different formatting flags
+// to become those specified, but the same formatting target.
+func (ctx *FmtCtx) CopyWithFlags(f FmtFlags) FmtCtx {
+	ret := *ctx
+	ret.flags = f
+	return ret
+}
+
+// ShowTableAliases returns true iff the flags have the corresponding bit set.
+func (ctx *FmtCtx) ShowTableAliases() bool {
+	return ctx.flags.ShowTableAliases
+}
+
+// Printf calls fmt.Fprintf on the linked bytes.Buffer. It is provided
+// for convenience, to avoid having to call fmt.Fprintf(ctx.Buffer, ...).
+//
+// Note: DO NOT USE THIS TO INTERPOLATE %s ON NodeFormatter OBJECTS.
+// This would call the String() method on them and would fail to reuse
+// the same bytes buffer (and waste allocations). Instead use
+// ctx.FormatNode().
+func (ctx *FmtCtx) Printf(f string, args ...interface{}) {
+	fmt.Fprintf(ctx.Buffer, f, args...)
 }
 
 // FmtExpr returns FmtFlags that indicate how the pretty-printer
@@ -145,7 +182,7 @@ func FmtExpr(base FmtFlags, showTypes bool, symbolicVars bool, showTableAliases 
 
 // FmtIndexedVarFormat returns FmtFlags that customizes the printing of
 // IndexedVars using the provided function.
-func FmtIndexedVarFormat(base FmtFlags, fn func(buf *bytes.Buffer, idx int)) FmtFlags {
+func FmtIndexedVarFormat(base FmtFlags, fn func(ctx *FmtCtx, idx int)) FmtFlags {
 	f := *base
 	f.indexedVarFormat = fn
 	return &f
@@ -154,7 +191,7 @@ func FmtIndexedVarFormat(base FmtFlags, fn func(buf *bytes.Buffer, idx int)) Fmt
 // FmtPlaceholderFormat returns FmtFlags that customizes the printing of
 // StarDatums using the provided function.
 func FmtPlaceholderFormat(
-	base FmtFlags, placeholderFn func(buf *bytes.Buffer, f FmtFlags, p *Placeholder),
+	base FmtFlags, placeholderFn func(_ *FmtCtx, _ *Placeholder),
 ) FmtFlags {
 	f := *base
 	f.placeholderFormat = placeholderFn
@@ -163,41 +200,42 @@ func FmtPlaceholderFormat(
 
 // NodeFormatter is implemented by nodes that can be pretty-printed.
 type NodeFormatter interface {
-	// Format performs pretty-printing towards a bytes buffer. The flags argument
-	// influences the results. Most callers should use FormatNode instead.
-	Format(buf *bytes.Buffer, flags FmtFlags)
+	// Format performs pretty-printing towards a bytes buffer. The flags member
+	// of ctx influences the results. Most callers should use FormatNode instead.
+	Format(ctx *FmtCtx)
 }
 
 // FormatNode recurses into a node for pretty-printing.
 // Flag-driven special cases can hook into this.
-func FormatNode(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
+func (ctx *FmtCtx) FormatNode(n NodeFormatter) {
+	f := ctx.flags
 	if f.showTypes {
 		if te, ok := n.(TypedExpr); ok {
-			buf.WriteByte('(')
-			formatNodeOrHideConstants(buf, f, n)
-			buf.WriteString(")[")
+			ctx.WriteByte('(')
+			ctx.formatNodeOrHideConstants(n)
+			ctx.WriteString(")[")
 			if rt := te.ResolvedType(); rt == nil {
 				// An attempt is made to pretty-print an expression that was
 				// not assigned a type yet. This should not happen, so we make
 				// it clear in the output this needs to be investigated
 				// further.
-				buf.WriteString(fmt.Sprintf("??? %v", te))
+				fmt.Fprintf(ctx.Buffer, "??? %v", te)
 			} else {
-				buf.WriteString(rt.String())
+				ctx.WriteString(rt.String())
 			}
-			buf.WriteByte(']')
+			ctx.WriteByte(']')
 			return
 		}
 	}
 	if f.alwaysParens {
 		if _, ok := n.(Expr); ok {
-			buf.WriteByte('(')
+			ctx.WriteByte('(')
 		}
 	}
-	formatNodeOrHideConstants(buf, f, n)
+	ctx.formatNodeOrHideConstants(n)
 	if f.alwaysParens {
 		if _, ok := n.(Expr); ok {
-			buf.WriteByte(')')
+			ctx.WriteByte(')')
 		}
 	}
 	if f.disambiguateDatumTypes {
@@ -211,12 +249,12 @@ func FormatNode(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
 			}
 		}
 		if typ != nil {
-			buf.WriteString(":::")
+			ctx.WriteString(":::")
 			colType, err := coltypes.DatumTypeToColumnType(typ)
 			if err != nil {
 				panic(err)
 			}
-			colType.Format(buf, f.encodeFlags)
+			colType.Format(ctx.Buffer, f.encodeFlags)
 		}
 	}
 }
@@ -224,7 +262,8 @@ func FormatNode(buf *bytes.Buffer, f FmtFlags, n NodeFormatter) {
 // AsStringWithFlags pretty prints a node to a string given specific flags.
 func AsStringWithFlags(n NodeFormatter, f FmtFlags) string {
 	var buf bytes.Buffer
-	FormatNode(&buf, f, n)
+	ctx := FmtCtx{Buffer: &buf, flags: f}
+	ctx.FormatNode(n)
 	return buf.String()
 }
 

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -37,7 +37,7 @@ func TestFormatStatement(t *testing.T) {
 	}{
 		{`CREATE USER foo WITH PASSWORD 'bar'`, tree.FmtSimple,
 			`CREATE USER 'foo' WITH PASSWORD *****`},
-		{`CREATE USER foo WITH PASSWORD 'bar'`, tree.FmtSimpleWithPasswords,
+		{`CREATE USER foo WITH PASSWORD 'bar'`, tree.FmtShowPasswords,
 			`CREATE USER 'foo' WITH PASSWORD 'bar'`},
 
 		{`CREATE TABLE foo (x INT)`, tree.FmtAnonymize,

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -282,10 +282,13 @@ func BenchmarkFormatRandomStatements(b *testing.B) {
 	b.Run("format", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			for i, stmt := range stmts {
-				var buf bytes.Buffer
-				fmtCtx := tree.MakeFmtCtx(&buf, tree.FmtSimple)
-				fmtCtx.FormatNode(stmt)
-				strs[i] = buf.String()
+				var f struct {
+					buf bytes.Buffer
+					ctx tree.FmtCtx
+				}
+				f.ctx = tree.MakeFmtCtx(&f.buf, tree.FmtSimple)
+				f.ctx.FormatNode(stmt)
+				strs[i] = f.buf.String()
 			}
 		}
 	})

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -31,8 +31,8 @@ import (
 
 func TestFormatStatement(t *testing.T) {
 	tableFormatter := tree.FmtReformatTableNames(tree.FmtSimple,
-		func(_ *tree.NormalizableTableName, buf *bytes.Buffer, _ tree.FmtFlags) {
-			buf.WriteString("xoxoxo")
+		func(ctx *tree.FmtCtx, _ *tree.NormalizableTableName) {
+			ctx.WriteString("xoxoxo")
 		})
 
 	testData := []struct {
@@ -260,7 +260,8 @@ func BenchmarkFormatRandomStatements(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			for i, stmt := range stmts {
 				var buf bytes.Buffer
-				tree.FormatNode(&buf, tree.FmtSimple, stmt)
+				fmtCtx := tree.MakeFmtCtx(&buf, tree.FmtSimple)
+				fmtCtx.FormatNode(stmt)
 				strs[i] = buf.String()
 			}
 		}

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -30,11 +30,6 @@ import (
 )
 
 func TestFormatStatement(t *testing.T) {
-	tableFormatter := tree.FmtReformatTableNames(tree.FmtSimple,
-		func(ctx *tree.FmtCtx, _ *tree.NormalizableTableName) {
-			ctx.WriteString("xoxoxo")
-		})
-
 	testData := []struct {
 		stmt     string
 		f        tree.FmtFlags
@@ -44,28 +39,6 @@ func TestFormatStatement(t *testing.T) {
 			`CREATE USER 'foo' WITH PASSWORD *****`},
 		{`CREATE USER foo WITH PASSWORD 'bar'`, tree.FmtSimpleWithPasswords,
 			`CREATE USER 'foo' WITH PASSWORD 'bar'`},
-
-		{`CREATE TABLE foo (x INT)`, tableFormatter,
-			`CREATE TABLE xoxoxo (x INT)`},
-		{`INSERT INTO foo(x) TABLE bar`, tableFormatter,
-			`INSERT INTO xoxoxo(x) TABLE xoxoxo`},
-		{`UPDATE foo SET x = y`, tableFormatter,
-			`UPDATE xoxoxo SET x = y`},
-		{`DELETE FROM foo`, tableFormatter,
-			`DELETE FROM xoxoxo`},
-		{`ALTER TABLE foo RENAME TO bar`, tableFormatter,
-			`ALTER TABLE xoxoxo RENAME TO xoxoxo`},
-		{`SHOW COLUMNS FROM foo`, tableFormatter,
-			`SHOW COLUMNS FROM xoxoxo`},
-		{`SHOW CREATE TABLE foo`, tableFormatter,
-			`SHOW CREATE TABLE xoxoxo`},
-		// TODO(knz): TRUNCATE and GRANT table names are removed by
-		// tree.FmtAnonymize but not processed by table formatters.
-		//
-		// {`TRUNCATE foo`, tableFormatter,
-		// `TRUNCATE TABLE xoxoxo`},
-		// {`GRANT SELECT ON bar TO foo`, tableFormatter,
-		// `GRANT SELECT ON xoxoxo TO foo`},
 
 		{`CREATE TABLE foo (x INT)`, tree.FmtAnonymize,
 			`CREATE TABLE _ (_ INT)`},
@@ -116,6 +89,56 @@ func TestFormatStatement(t *testing.T) {
 				t.Fatal(err)
 			}
 			stmtStr := tree.AsStringWithFlags(stmt, test.f)
+			if stmtStr != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, stmtStr)
+			}
+		})
+	}
+}
+
+func TestFormatTableName(t *testing.T) {
+	testData := []struct {
+		stmt     string
+		expected string
+	}{
+		{`CREATE TABLE foo (x INT)`,
+			`CREATE TABLE xoxoxo (x INT)`},
+		{`INSERT INTO foo(x) TABLE bar`,
+			`INSERT INTO xoxoxo(x) TABLE xoxoxo`},
+		{`UPDATE foo SET x = y`,
+			`UPDATE xoxoxo SET x = y`},
+		{`DELETE FROM foo`,
+			`DELETE FROM xoxoxo`},
+		{`ALTER TABLE foo RENAME TO bar`,
+			`ALTER TABLE xoxoxo RENAME TO xoxoxo`},
+		{`SHOW COLUMNS FROM foo`,
+			`SHOW COLUMNS FROM xoxoxo`},
+		{`SHOW CREATE TABLE foo`,
+			`SHOW CREATE TABLE xoxoxo`},
+		// TODO(knz): TRUNCATE and GRANT table names are removed by
+		// tree.FmtAnonymize but not processed by table formatters.
+		//
+		// {`TRUNCATE foo`,
+		// `TRUNCATE TABLE xoxoxo`},
+		// {`GRANT SELECT ON bar TO foo`,
+		// `GRANT SELECT ON xoxoxo TO foo`},
+	}
+
+	var buf bytes.Buffer
+	fmtCtx := tree.MakeFmtCtx(&buf, tree.FmtSimple)
+	fmtCtx.WithReformatTableNames(func(ctx *tree.FmtCtx, _ *tree.NormalizableTableName) {
+		ctx.WriteString("xoxoxo")
+	})
+
+	for i, test := range testData {
+		t.Run(fmt.Sprintf("%d %s", i, test.stmt), func(t *testing.T) {
+			stmt, err := parser.ParseOne(test.stmt)
+			if err != nil {
+				t.Fatal(err)
+			}
+			buf.Reset()
+			fmtCtx.FormatNode(stmt)
+			stmtStr := buf.String()
 			if stmtStr != test.expected {
 				t.Fatalf("expected %q, got %q", test.expected, stmtStr)
 			}

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -63,7 +63,7 @@ func (fd *FunctionDefinition) Format(ctx *FmtCtx) {
 func (fd *FunctionDefinition) String() string { return AsString(fd) }
 
 // ResolveFunction transforms an UnresolvedName to a FunctionDefinition.
-func (n UnresolvedName) ResolveFunction(searchPath SearchPath) (*FunctionDefinition, error) {
+func (n *UnresolvedName) ResolveFunction(searchPath SearchPath) (*FunctionDefinition, error) {
 	fn, err := n.normalizeFunctionName()
 	if err != nil {
 		return nil, err

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -15,7 +15,6 @@
 package tree
 
 import (
-	"bytes"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -57,8 +56,8 @@ func NewFunctionDefinition(name string, def []Builtin) *FunctionDefinition {
 var FunDefs map[string]*FunctionDefinition
 
 // Format implements the NodeFormatter interface.
-func (fd *FunctionDefinition) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(fd.Name)
+func (fd *FunctionDefinition) Format(ctx *FmtCtx) {
+	ctx.WriteString(fd.Name)
 }
 
 func (fd *FunctionDefinition) String() string { return AsString(fd) }

--- a/pkg/sql/sem/tree/function_name.go
+++ b/pkg/sql/sem/tree/function_name.go
@@ -15,7 +15,6 @@
 package tree
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -38,8 +37,8 @@ type ResolvableFunctionReference struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (fn ResolvableFunctionReference) Format(buf *bytes.Buffer, f FmtFlags) {
-	FormatNode(buf, f, fn.FunctionReference)
+func (fn ResolvableFunctionReference) Format(ctx *FmtCtx) {
+	ctx.FormatNode(fn.FunctionReference)
 }
 func (fn ResolvableFunctionReference) String() string { return AsString(fn) }
 

--- a/pkg/sql/sem/tree/function_name.go
+++ b/pkg/sql/sem/tree/function_name.go
@@ -37,10 +37,10 @@ type ResolvableFunctionReference struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (fn ResolvableFunctionReference) Format(ctx *FmtCtx) {
+func (fn *ResolvableFunctionReference) Format(ctx *FmtCtx) {
 	ctx.FormatNode(fn.FunctionReference)
 }
-func (fn ResolvableFunctionReference) String() string { return AsString(fn) }
+func (fn *ResolvableFunctionReference) String() string { return AsString(fn) }
 
 // Resolve checks if the function name is already resolved and
 // resolves it as necessary.
@@ -48,7 +48,7 @@ func (fn *ResolvableFunctionReference) Resolve(searchPath SearchPath) (*Function
 	switch t := fn.FunctionReference.(type) {
 	case *FunctionDefinition:
 		return t, nil
-	case UnresolvedName:
+	case *UnresolvedName:
 		fd, err := t.ResolveFunction(searchPath)
 		if err != nil {
 			return nil, err
@@ -79,7 +79,7 @@ type FunctionReference interface {
 	functionReference()
 }
 
-func (UnresolvedName) functionReference()      {}
+func (*UnresolvedName) functionReference()     {}
 func (*FunctionDefinition) functionReference() {}
 
 // functionName implements a structured function name. It is an
@@ -92,15 +92,15 @@ type functionName struct {
 }
 
 // normalizeFunctionName transforms an UnresolvedName to a functionName.
-func (n UnresolvedName) normalizeFunctionName() (functionName, error) {
-	if len(n) == 0 {
+func (n *UnresolvedName) normalizeFunctionName() (functionName, error) {
+	if len(*n) == 0 {
 		return functionName{}, pgerror.NewErrorf(
 			pgerror.CodeInvalidNameError, "invalid function name: %s", n)
 	}
 
 	// Find the first array subscript, if any.
-	i := len(n)
-	for j, p := range n {
+	i := len(*n)
+	for j, p := range *n {
 		if _, ok := p.(*ArraySubscript); ok {
 			i = j
 			break
@@ -116,7 +116,8 @@ func (n UnresolvedName) normalizeFunctionName() (functionName, error) {
 	// The function name, together with its prefix, must /look/ like a
 	// table name. (We don't support record types yet.)  Reuse the
 	// existing normalization code.
-	tn, err := n[:i].normalizeTableNameAsValue()
+	fPref := (*n)[:i]
+	tn, err := fPref.normalizeTableNameAsValue()
 	if err != nil {
 		// Override the error, so as to not confuse the user.
 		return functionName{}, pgerror.NewErrorf(
@@ -127,7 +128,7 @@ func (n UnresolvedName) normalizeFunctionName() (functionName, error) {
 	return functionName{
 		prefixName:   tn.DatabaseName,
 		functionName: tn.TableName,
-		selector:     NameParts(n[i:]),
+		selector:     NameParts((*n)[i:]),
 	}, nil
 }
 

--- a/pkg/sql/sem/tree/grant.go
+++ b/pkg/sql/sem/tree/grant.go
@@ -42,18 +42,18 @@ type TargetList struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (tl TargetList) Format(ctx *FmtCtx) {
+func (tl *TargetList) Format(ctx *FmtCtx) {
 	if tl.Databases != nil {
 		ctx.WriteString("DATABASE ")
-		ctx.FormatNode(tl.Databases)
+		ctx.FormatNode(&tl.Databases)
 	} else {
-		ctx.FormatNode(tl.Tables)
+		ctx.FormatNode(&tl.Tables)
 	}
 }
 
 // NormalizeTablesWithDatabase normalizes all patterns and qualifies TableNames
 // with the provided db name if non-empty.
-func (tl TargetList) NormalizeTablesWithDatabase(db string) error {
+func (tl *TargetList) NormalizeTablesWithDatabase(db string) error {
 	for i, pattern := range tl.Tables {
 		var err error
 		pattern, err = pattern.NormalizeTablePattern()
@@ -78,7 +78,7 @@ func (node *Grant) Format(ctx *FmtCtx) {
 	ctx.WriteString("GRANT ")
 	node.Privileges.Format(ctx.Buffer)
 	ctx.WriteString(" ON ")
-	ctx.FormatNode(node.Targets)
+	ctx.FormatNode(&node.Targets)
 	ctx.WriteString(" TO ")
-	ctx.FormatNode(node.Grantees)
+	ctx.FormatNode(&node.Grantees)
 }

--- a/pkg/sql/sem/tree/grant.go
+++ b/pkg/sql/sem/tree/grant.go
@@ -24,8 +24,6 @@
 package tree
 
 import (
-	"bytes"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 )
 
@@ -44,12 +42,12 @@ type TargetList struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (tl TargetList) Format(buf *bytes.Buffer, f FmtFlags) {
+func (tl TargetList) Format(ctx *FmtCtx) {
 	if tl.Databases != nil {
-		buf.WriteString("DATABASE ")
-		FormatNode(buf, f, tl.Databases)
+		ctx.WriteString("DATABASE ")
+		ctx.FormatNode(tl.Databases)
 	} else {
-		FormatNode(buf, f, tl.Tables)
+		ctx.FormatNode(tl.Tables)
 	}
 }
 
@@ -76,11 +74,11 @@ func (tl TargetList) NormalizeTablesWithDatabase(db string) error {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Grant) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("GRANT ")
-	node.Privileges.Format(buf)
-	buf.WriteString(" ON ")
-	FormatNode(buf, f, node.Targets)
-	buf.WriteString(" TO ")
-	FormatNode(buf, f, node.Grantees)
+func (node *Grant) Format(ctx *FmtCtx) {
+	ctx.WriteString("GRANT ")
+	node.Privileges.Format(ctx.Buffer)
+	ctx.WriteString(" ON ")
+	ctx.FormatNode(node.Targets)
+	ctx.WriteString(" TO ")
+	ctx.FormatNode(node.Grantees)
 }

--- a/pkg/sql/sem/tree/hide_constants.go
+++ b/pkg/sql/sem/tree/hide_constants.go
@@ -20,7 +20,7 @@ package tree
 // unless hideConstants is set in the flags and the node is a datum or
 // a literal.
 func (ctx *FmtCtx) formatNodeOrHideConstants(n NodeFormatter) {
-	if ctx.flags.hideConstants {
+	if ctx.flags.HasFlags(FmtHideConstants) {
 		switch v := n.(type) {
 		case *ValuesClause:
 			v.formatHideConstants(ctx)

--- a/pkg/sql/sem/tree/import.go
+++ b/pkg/sql/sem/tree/import.go
@@ -14,8 +14,6 @@
 
 package tree
 
-import "bytes"
-
 // Import represents a IMPORT statement.
 type Import struct {
 	Table      UnresolvedName
@@ -29,27 +27,27 @@ type Import struct {
 var _ Statement = &Import{}
 
 // Format implements the NodeFormatter interface.
-func (node *Import) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("IMPORT TABLE ")
-	FormatNode(buf, f, node.Table)
+func (node *Import) Format(ctx *FmtCtx) {
+	ctx.WriteString("IMPORT TABLE ")
+	ctx.FormatNode(node.Table)
 
 	if node.CreateFile != nil {
-		buf.WriteString(" CREATE USING ")
-		FormatNode(buf, f, node.CreateFile)
-		buf.WriteString(" ")
+		ctx.WriteString(" CREATE USING ")
+		ctx.FormatNode(node.CreateFile)
+		ctx.WriteString(" ")
 	} else {
-		buf.WriteString(" (")
-		FormatNode(buf, f, node.CreateDefs)
-		buf.WriteString(") ")
+		ctx.WriteString(" (")
+		ctx.FormatNode(node.CreateDefs)
+		ctx.WriteString(") ")
 	}
 
-	buf.WriteString(node.FileFormat)
-	buf.WriteString(" DATA (")
-	FormatNode(buf, f, node.Files)
-	buf.WriteString(") ")
+	ctx.WriteString(node.FileFormat)
+	ctx.WriteString(" DATA (")
+	ctx.FormatNode(node.Files)
+	ctx.WriteString(") ")
 
 	if node.Options != nil {
-		buf.WriteString("WITH ")
-		FormatNode(buf, f, node.Options)
+		ctx.WriteString("WITH ")
+		ctx.FormatNode(node.Options)
 	}
 }

--- a/pkg/sql/sem/tree/import.go
+++ b/pkg/sql/sem/tree/import.go
@@ -29,7 +29,7 @@ var _ Statement = &Import{}
 // Format implements the NodeFormatter interface.
 func (node *Import) Format(ctx *FmtCtx) {
 	ctx.WriteString("IMPORT TABLE ")
-	ctx.FormatNode(node.Table)
+	ctx.FormatNode(&node.Table)
 
 	if node.CreateFile != nil {
 		ctx.WriteString(" CREATE USING ")
@@ -37,17 +37,17 @@ func (node *Import) Format(ctx *FmtCtx) {
 		ctx.WriteString(" ")
 	} else {
 		ctx.WriteString(" (")
-		ctx.FormatNode(node.CreateDefs)
+		ctx.FormatNode(&node.CreateDefs)
 		ctx.WriteString(") ")
 	}
 
 	ctx.WriteString(node.FileFormat)
 	ctx.WriteString(" DATA (")
-	ctx.FormatNode(node.Files)
+	ctx.FormatNode(&node.Files)
 	ctx.WriteString(") ")
 
 	if node.Options != nil {
 		ctx.WriteString("WITH ")
-		ctx.FormatNode(node.Options)
+		ctx.FormatNode(&node.Options)
 	}
 }

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -15,7 +15,6 @@
 package tree
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -93,13 +92,14 @@ func (v *IndexedVar) ResolvedType() types.T {
 }
 
 // Format implements the NodeFormatter interface.
-func (v *IndexedVar) Format(buf *bytes.Buffer, f FmtFlags) {
+func (v *IndexedVar) Format(ctx *FmtCtx) {
+	f := ctx.flags
 	if f.indexedVarFormat != nil {
-		f.indexedVarFormat(buf, v.Idx)
+		f.indexedVarFormat(ctx, v.Idx)
 	} else if f.symbolicVars || v.col == nil {
-		fmt.Fprintf(buf, "@%d", v.Idx+1)
+		ctx.Printf("@%d", v.Idx+1)
 	} else {
-		v.col.Format(buf, f)
+		v.col.Format(ctx)
 	}
 }
 

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -96,7 +96,7 @@ func (v *IndexedVar) Format(ctx *FmtCtx) {
 	f := ctx.flags
 	if ctx.indexedVarFormat != nil {
 		ctx.indexedVarFormat(ctx, v.Idx)
-	} else if f.symbolicVars || v.col == nil {
+	} else if f.HasFlags(fmtSymbolicVars) || v.col == nil {
 		ctx.Printf("@%d", v.Idx+1)
 	} else {
 		v.col.Format(ctx)

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -94,8 +94,8 @@ func (v *IndexedVar) ResolvedType() types.T {
 // Format implements the NodeFormatter interface.
 func (v *IndexedVar) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if f.indexedVarFormat != nil {
-		f.indexedVarFormat(ctx, v.Idx)
+	if ctx.indexedVarFormat != nil {
+		ctx.indexedVarFormat(ctx, v.Idx)
 	} else if f.symbolicVars || v.col == nil {
 		ctx.Printf("@%d", v.Idx+1)
 	} else {

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -76,16 +76,15 @@ func TestIndexedVars(t *testing.T) {
 
 	// Test formatting using the indexed var format interceptor.
 	var buf bytes.Buffer
-	FormatNode(
-		&buf,
+	fmtCtx := MakeFmtCtx(&buf,
 		FmtIndexedVarFormat(
 			FmtSimple,
-			func(buf *bytes.Buffer, idx int) {
-				fmt.Fprintf(buf, "customVar%d", idx)
+			func(ctx *FmtCtx, idx int) {
+				ctx.Printf("customVar%d", idx)
 			},
-		),
-		typedExpr,
-	)
+		))
+	fmtCtx.FormatNode(typedExpr)
+
 	str = buf.String()
 	expectedStr = "customVar0 + (customVar1 * customVar2)"
 	if str != expectedStr {

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -34,7 +34,8 @@ func (d testVarContainer) IndexedVarResolvedType(idx int) types.T {
 }
 
 func (d testVarContainer) IndexedVarNodeFormatter(idx int) NodeFormatter {
-	return Name(fmt.Sprintf("var%d", idx))
+	n := Name(fmt.Sprintf("var%d", idx))
+	return &n
 }
 
 func TestIndexedVars(t *testing.T) {

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -76,13 +76,12 @@ func TestIndexedVars(t *testing.T) {
 
 	// Test formatting using the indexed var format interceptor.
 	var buf bytes.Buffer
-	fmtCtx := MakeFmtCtx(&buf,
-		FmtIndexedVarFormat(
-			FmtSimple,
-			func(ctx *FmtCtx, idx int) {
-				ctx.Printf("customVar%d", idx)
-			},
-		))
+	fmtCtx := MakeFmtCtx(&buf, FmtSimple)
+	fmtCtx.WithIndexedVarFormat(
+		func(ctx *FmtCtx, idx int) {
+			ctx.Printf("customVar%d", idx)
+		},
+	)
 	fmtCtx.FormatNode(typedExpr)
 
 	str = buf.String()

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -15,7 +15,6 @@
 package tree
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -76,16 +75,15 @@ func TestIndexedVars(t *testing.T) {
 	}
 
 	// Test formatting using the indexed var format interceptor.
-	var buf bytes.Buffer
-	fmtCtx := MakeFmtCtx(&buf, FmtSimple)
-	fmtCtx.WithIndexedVarFormat(
+	f := NewFmtCtxWithBuf(FmtSimple)
+	f.WithIndexedVarFormat(
 		func(ctx *FmtCtx, idx int) {
 			ctx.Printf("customVar%d", idx)
 		},
 	)
-	fmtCtx.FormatNode(typedExpr)
+	f.FormatNode(typedExpr)
+	str = f.CloseAndGetString()
 
-	str = buf.String()
 	expectedStr = "customVar0 + (customVar1 * customVar2)"
 	if str != expectedStr {
 		t.Errorf("invalid expression string '%s', expected '%s'", str, expectedStr)

--- a/pkg/sql/sem/tree/insert.go
+++ b/pkg/sql/sem/tree/insert.go
@@ -23,8 +23,6 @@
 
 package tree
 
-import "bytes"
-
 // Insert represents an INSERT statement.
 type Insert struct {
 	With       *With
@@ -36,44 +34,44 @@ type Insert struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Insert) Format(buf *bytes.Buffer, f FmtFlags) {
-	FormatNode(buf, f, node.With)
+func (node *Insert) Format(ctx *FmtCtx) {
+	ctx.FormatNode(node.With)
 	if node.OnConflict.IsUpsertAlias() {
-		buf.WriteString("UPSERT")
+		ctx.WriteString("UPSERT")
 	} else {
-		buf.WriteString("INSERT")
+		ctx.WriteString("INSERT")
 	}
-	buf.WriteString(" INTO ")
-	FormatNode(buf, f, node.Table)
+	ctx.WriteString(" INTO ")
+	ctx.FormatNode(node.Table)
 	if node.Columns != nil {
-		buf.WriteByte('(')
-		FormatNode(buf, f, node.Columns)
-		buf.WriteByte(')')
+		ctx.WriteByte('(')
+		ctx.FormatNode(node.Columns)
+		ctx.WriteByte(')')
 	}
 	if node.DefaultValues() {
-		buf.WriteString(" DEFAULT VALUES")
+		ctx.WriteString(" DEFAULT VALUES")
 	} else {
-		buf.WriteByte(' ')
-		FormatNode(buf, f, node.Rows)
+		ctx.WriteByte(' ')
+		ctx.FormatNode(node.Rows)
 	}
 	if node.OnConflict != nil && !node.OnConflict.IsUpsertAlias() {
-		buf.WriteString(" ON CONFLICT")
+		ctx.WriteString(" ON CONFLICT")
 		if len(node.OnConflict.Columns) > 0 {
-			buf.WriteString(" (")
-			FormatNode(buf, f, node.OnConflict.Columns)
-			buf.WriteString(")")
+			ctx.WriteString(" (")
+			ctx.FormatNode(node.OnConflict.Columns)
+			ctx.WriteString(")")
 		}
 		if node.OnConflict.DoNothing {
-			buf.WriteString(" DO NOTHING")
+			ctx.WriteString(" DO NOTHING")
 		} else {
-			buf.WriteString(" DO UPDATE SET ")
-			FormatNode(buf, f, node.OnConflict.Exprs)
+			ctx.WriteString(" DO UPDATE SET ")
+			ctx.FormatNode(node.OnConflict.Exprs)
 			if node.OnConflict.Where != nil {
-				FormatNode(buf, f, node.OnConflict.Where)
+				ctx.FormatNode(node.OnConflict.Where)
 			}
 		}
 	}
-	FormatNode(buf, f, node.Returning)
+	ctx.FormatNode(node.Returning)
 }
 
 // DefaultValues returns true iff only default values are being inserted.

--- a/pkg/sql/sem/tree/insert.go
+++ b/pkg/sql/sem/tree/insert.go
@@ -45,7 +45,7 @@ func (node *Insert) Format(ctx *FmtCtx) {
 	ctx.FormatNode(node.Table)
 	if node.Columns != nil {
 		ctx.WriteByte('(')
-		ctx.FormatNode(node.Columns)
+		ctx.FormatNode(&node.Columns)
 		ctx.WriteByte(')')
 	}
 	if node.DefaultValues() {
@@ -58,14 +58,14 @@ func (node *Insert) Format(ctx *FmtCtx) {
 		ctx.WriteString(" ON CONFLICT")
 		if len(node.OnConflict.Columns) > 0 {
 			ctx.WriteString(" (")
-			ctx.FormatNode(node.OnConflict.Columns)
+			ctx.FormatNode(&node.OnConflict.Columns)
 			ctx.WriteString(")")
 		}
 		if node.OnConflict.DoNothing {
 			ctx.WriteString(" DO NOTHING")
 		} else {
 			ctx.WriteString(" DO UPDATE SET ")
-			ctx.FormatNode(node.OnConflict.Exprs)
+			ctx.FormatNode(&node.OnConflict.Exprs)
 			if node.OnConflict.Where != nil {
 				ctx.FormatNode(node.OnConflict.Where)
 			}

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -33,10 +33,10 @@ type Name string
 // Format implements the NodeFormatter interface.
 func (n Name) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if f.anonymize {
+	if f.HasFlags(FmtAnonymize) {
 		ctx.WriteByte('_')
 	} else {
-		lex.EncodeRestrictedSQLIdent(ctx.Buffer, string(n), f.encodeFlags)
+		lex.EncodeRestrictedSQLIdent(ctx.Buffer, string(n), f.EncodeFlags())
 	}
 }
 
@@ -63,10 +63,10 @@ type UnrestrictedName string
 // Format implements the NodeFormatter interface.
 func (u UnrestrictedName) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if f.anonymize {
+	if f.HasFlags(FmtAnonymize) {
 		ctx.WriteByte('_')
 	} else {
-		lex.EncodeUnrestrictedSQLIdent(ctx.Buffer, string(u), f.encodeFlags)
+		lex.EncodeUnrestrictedSQLIdent(ctx.Buffer, string(u), f.EncodeFlags())
 	}
 }
 

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -222,7 +222,7 @@ func (v VariadicType) String() string {
 	if len(v.FixedTypes) > 0 {
 		s.WriteString(", ")
 	}
-	s.WriteString(fmt.Sprintf("%s...", v.VarType))
+	fmt.Fprintf(&s, "%s...", v.VarType)
 	return s.String()
 }
 

--- a/pkg/sql/sem/tree/prepare.go
+++ b/pkg/sql/sem/tree/prepare.go
@@ -28,7 +28,7 @@ type Prepare struct {
 // Format implements the NodeFormatter interface.
 func (node *Prepare) Format(ctx *FmtCtx) {
 	ctx.WriteString("PREPARE ")
-	ctx.FormatNode(node.Name)
+	ctx.FormatNode(&node.Name)
 	if len(node.Types) > 0 {
 		ctx.WriteString(" (")
 		for i, t := range node.Types {
@@ -52,10 +52,10 @@ type Execute struct {
 // Format implements the NodeFormatter interface.
 func (node *Execute) Format(ctx *FmtCtx) {
 	ctx.WriteString("EXECUTE ")
-	ctx.FormatNode(node.Name)
+	ctx.FormatNode(&node.Name)
 	if len(node.Params) > 0 {
 		ctx.WriteString(" (")
-		ctx.FormatNode(node.Params)
+		ctx.FormatNode(&node.Params)
 		ctx.WriteByte(')')
 	}
 }
@@ -71,6 +71,6 @@ func (node *Deallocate) Format(ctx *FmtCtx) {
 	if node.Name == "" {
 		ctx.WriteString("ALL")
 	} else {
-		ctx.FormatNode(node.Name)
+		ctx.FormatNode(&node.Name)
 	}
 }

--- a/pkg/sql/sem/tree/prepare.go
+++ b/pkg/sql/sem/tree/prepare.go
@@ -35,7 +35,7 @@ func (node *Prepare) Format(ctx *FmtCtx) {
 			if i > 0 {
 				ctx.WriteString(", ")
 			}
-			t.Format(ctx.Buffer, ctx.flags.encodeFlags)
+			t.Format(ctx.Buffer, ctx.flags.EncodeFlags())
 		}
 		ctx.WriteRune(')')
 	}

--- a/pkg/sql/sem/tree/prepare.go
+++ b/pkg/sql/sem/tree/prepare.go
@@ -15,8 +15,6 @@
 package tree
 
 import (
-	"bytes"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 )
 
@@ -28,21 +26,21 @@ type Prepare struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Prepare) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("PREPARE ")
-	FormatNode(buf, f, node.Name)
+func (node *Prepare) Format(ctx *FmtCtx) {
+	ctx.WriteString("PREPARE ")
+	ctx.FormatNode(node.Name)
 	if len(node.Types) > 0 {
-		buf.WriteString(" (")
+		ctx.WriteString(" (")
 		for i, t := range node.Types {
 			if i > 0 {
-				buf.WriteString(", ")
+				ctx.WriteString(", ")
 			}
-			t.Format(buf, f.encodeFlags)
+			t.Format(ctx.Buffer, ctx.flags.encodeFlags)
 		}
-		buf.WriteRune(')')
+		ctx.WriteRune(')')
 	}
-	buf.WriteString(" AS ")
-	FormatNode(buf, f, node.Statement)
+	ctx.WriteString(" AS ")
+	ctx.FormatNode(node.Statement)
 }
 
 // Execute represents an EXECUTE statement.
@@ -52,13 +50,13 @@ type Execute struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Execute) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("EXECUTE ")
-	FormatNode(buf, f, node.Name)
+func (node *Execute) Format(ctx *FmtCtx) {
+	ctx.WriteString("EXECUTE ")
+	ctx.FormatNode(node.Name)
 	if len(node.Params) > 0 {
-		buf.WriteString(" (")
-		FormatNode(buf, f, node.Params)
-		buf.WriteByte(')')
+		ctx.WriteString(" (")
+		ctx.FormatNode(node.Params)
+		ctx.WriteByte(')')
 	}
 }
 
@@ -68,11 +66,11 @@ type Deallocate struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Deallocate) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("DEALLOCATE ")
+func (node *Deallocate) Format(ctx *FmtCtx) {
+	ctx.WriteString("DEALLOCATE ")
 	if node.Name == "" {
-		buf.WriteString("ALL")
+		ctx.WriteString("ALL")
 	} else {
-		FormatNode(buf, f, node.Name)
+		ctx.FormatNode(node.Name)
 	}
 }

--- a/pkg/sql/sem/tree/rename.go
+++ b/pkg/sql/sem/tree/rename.go
@@ -32,9 +32,9 @@ type RenameDatabase struct {
 // Format implements the NodeFormatter interface.
 func (node *RenameDatabase) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER DATABASE ")
-	ctx.FormatNode(node.Name)
+	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" RENAME TO ")
-	ctx.FormatNode(node.NewName)
+	ctx.FormatNode(&node.NewName)
 }
 
 // RenameTable represents a RENAME TABLE or RENAME VIEW statement.
@@ -81,7 +81,7 @@ func (node *RenameIndex) Format(ctx *FmtCtx) {
 	}
 	ctx.FormatNode(node.Index)
 	ctx.WriteString(" RENAME TO ")
-	ctx.FormatNode(node.NewName)
+	ctx.FormatNode(&node.NewName)
 }
 
 // RenameColumn represents a RENAME COLUMN statement.
@@ -101,7 +101,7 @@ func (node *RenameColumn) Format(ctx *FmtCtx) {
 	}
 	ctx.FormatNode(&node.Table)
 	ctx.WriteString(" RENAME COLUMN ")
-	ctx.FormatNode(node.Name)
+	ctx.FormatNode(&node.Name)
 	ctx.WriteString(" TO ")
-	ctx.FormatNode(node.NewName)
+	ctx.FormatNode(&node.NewName)
 }

--- a/pkg/sql/sem/tree/rename.go
+++ b/pkg/sql/sem/tree/rename.go
@@ -23,8 +23,6 @@
 
 package tree
 
-import "bytes"
-
 // RenameDatabase represents a RENAME DATABASE statement.
 type RenameDatabase struct {
 	Name    Name
@@ -32,11 +30,11 @@ type RenameDatabase struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *RenameDatabase) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER DATABASE ")
-	FormatNode(buf, f, node.Name)
-	buf.WriteString(" RENAME TO ")
-	FormatNode(buf, f, node.NewName)
+func (node *RenameDatabase) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER DATABASE ")
+	ctx.FormatNode(node.Name)
+	ctx.WriteString(" RENAME TO ")
+	ctx.FormatNode(node.NewName)
 }
 
 // RenameTable represents a RENAME TABLE or RENAME VIEW statement.
@@ -51,21 +49,21 @@ type RenameTable struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *RenameTable) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER ")
+func (node *RenameTable) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER ")
 	if node.IsView {
-		buf.WriteString("VIEW ")
+		ctx.WriteString("VIEW ")
 	} else if node.IsSequence {
-		buf.WriteString("SEQUENCE ")
+		ctx.WriteString("SEQUENCE ")
 	} else {
-		buf.WriteString("TABLE ")
+		ctx.WriteString("TABLE ")
 	}
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, &node.Name)
-	buf.WriteString(" RENAME TO ")
-	FormatNode(buf, f, &node.NewName)
+	ctx.FormatNode(&node.Name)
+	ctx.WriteString(" RENAME TO ")
+	ctx.FormatNode(&node.NewName)
 }
 
 // RenameIndex represents a RENAME INDEX statement.
@@ -76,14 +74,14 @@ type RenameIndex struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *RenameIndex) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER INDEX ")
+func (node *RenameIndex) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER INDEX ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, node.Index)
-	buf.WriteString(" RENAME TO ")
-	FormatNode(buf, f, node.NewName)
+	ctx.FormatNode(node.Index)
+	ctx.WriteString(" RENAME TO ")
+	ctx.FormatNode(node.NewName)
 }
 
 // RenameColumn represents a RENAME COLUMN statement.
@@ -96,14 +94,14 @@ type RenameColumn struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *RenameColumn) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER TABLE ")
+func (node *RenameColumn) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER TABLE ")
 	if node.IfExists {
-		buf.WriteString("IF EXISTS ")
+		ctx.WriteString("IF EXISTS ")
 	}
-	FormatNode(buf, f, &node.Table)
-	buf.WriteString(" RENAME COLUMN ")
-	FormatNode(buf, f, node.Name)
-	buf.WriteString(" TO ")
-	FormatNode(buf, f, node.NewName)
+	ctx.FormatNode(&node.Table)
+	ctx.WriteString(" RENAME COLUMN ")
+	ctx.FormatNode(node.Name)
+	ctx.WriteString(" TO ")
+	ctx.FormatNode(node.NewName)
 }

--- a/pkg/sql/sem/tree/returning.go
+++ b/pkg/sql/sem/tree/returning.go
@@ -33,7 +33,7 @@ type ReturningExprs SelectExprs
 // Format implements the NodeFormatter interface.
 func (r *ReturningExprs) Format(ctx *FmtCtx) {
 	ctx.WriteString(" RETURNING ")
-	ctx.FormatNode(SelectExprs(*r))
+	ctx.FormatNode((*SelectExprs)(r))
 }
 
 // ReturningNothingClause is a shared instance to avoid unnecessary allocations.

--- a/pkg/sql/sem/tree/returning.go
+++ b/pkg/sql/sem/tree/returning.go
@@ -14,8 +14,6 @@
 
 package tree
 
-import "bytes"
-
 // ReturningClause represents the returning clause on a statement.
 type ReturningClause interface {
 	NodeFormatter
@@ -33,9 +31,9 @@ var _ ReturningClause = &NoReturningClause{}
 type ReturningExprs SelectExprs
 
 // Format implements the NodeFormatter interface.
-func (r *ReturningExprs) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(" RETURNING ")
-	FormatNode(buf, f, SelectExprs(*r))
+func (r *ReturningExprs) Format(ctx *FmtCtx) {
+	ctx.WriteString(" RETURNING ")
+	ctx.FormatNode(SelectExprs(*r))
 }
 
 // ReturningNothingClause is a shared instance to avoid unnecessary allocations.
@@ -45,8 +43,8 @@ var ReturningNothingClause = &ReturningNothing{}
 type ReturningNothing struct{}
 
 // Format implements the NodeFormatter interface.
-func (*ReturningNothing) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString(" RETURNING NOTHING")
+func (*ReturningNothing) Format(ctx *FmtCtx) {
+	ctx.WriteString(" RETURNING NOTHING")
 }
 
 // AbsentReturningClause is a ReturningClause variant representing the absence of
@@ -57,7 +55,7 @@ var AbsentReturningClause = &NoReturningClause{}
 type NoReturningClause struct{}
 
 // Format implements the NodeFormatter interface.
-func (*NoReturningClause) Format(buf *bytes.Buffer, f FmtFlags) {}
+func (*NoReturningClause) Format(_ *FmtCtx) {}
 
 // used by parent statements to determine their own StatementType.
 func (*ReturningExprs) statementType() StatementType    { return Rows }

--- a/pkg/sql/sem/tree/revoke.go
+++ b/pkg/sql/sem/tree/revoke.go
@@ -40,7 +40,7 @@ func (node *Revoke) Format(ctx *FmtCtx) {
 	ctx.WriteString("REVOKE ")
 	node.Privileges.Format(ctx.Buffer)
 	ctx.WriteString(" ON ")
-	ctx.FormatNode(node.Targets)
+	ctx.FormatNode(&node.Targets)
 	ctx.WriteString(" FROM ")
-	ctx.FormatNode(node.Grantees)
+	ctx.FormatNode(&node.Grantees)
 }

--- a/pkg/sql/sem/tree/revoke.go
+++ b/pkg/sql/sem/tree/revoke.go
@@ -24,8 +24,6 @@
 package tree
 
 import (
-	"bytes"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 )
 
@@ -38,11 +36,11 @@ type Revoke struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Revoke) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("REVOKE ")
-	node.Privileges.Format(buf)
-	buf.WriteString(" ON ")
-	FormatNode(buf, f, node.Targets)
-	buf.WriteString(" FROM ")
-	FormatNode(buf, f, node.Grantees)
+func (node *Revoke) Format(ctx *FmtCtx) {
+	ctx.WriteString("REVOKE ")
+	node.Privileges.Format(ctx.Buffer)
+	ctx.WriteString(" ON ")
+	ctx.FormatNode(node.Targets)
+	ctx.WriteString(" FROM ")
+	ctx.FormatNode(node.Grantees)
 }

--- a/pkg/sql/sem/tree/run_control.go
+++ b/pkg/sql/sem/tree/run_control.go
@@ -14,17 +14,15 @@
 
 package tree
 
-import "bytes"
-
 // PauseJob represents a PAUSE JOB statement.
 type PauseJob struct {
 	ID Expr
 }
 
 // Format implements the NodeFormatter interface.
-func (node *PauseJob) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("PAUSE JOB ")
-	FormatNode(buf, f, node.ID)
+func (node *PauseJob) Format(ctx *FmtCtx) {
+	ctx.WriteString("PAUSE JOB ")
+	ctx.FormatNode(node.ID)
 }
 
 // ResumeJob represents a RESUME JOB statement.
@@ -33,9 +31,9 @@ type ResumeJob struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ResumeJob) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("RESUME JOB ")
-	FormatNode(buf, f, node.ID)
+func (node *ResumeJob) Format(ctx *FmtCtx) {
+	ctx.WriteString("RESUME JOB ")
+	ctx.FormatNode(node.ID)
 }
 
 // CancelJob represents a CANCEL JOB statement.
@@ -44,9 +42,9 @@ type CancelJob struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *CancelJob) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("CANCEL JOB ")
-	FormatNode(buf, f, node.ID)
+func (node *CancelJob) Format(ctx *FmtCtx) {
+	ctx.WriteString("CANCEL JOB ")
+	ctx.FormatNode(node.ID)
 }
 
 // CancelQuery represents a CANCEL QUERY statement.
@@ -55,7 +53,7 @@ type CancelQuery struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *CancelQuery) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("CANCEL QUERY ")
-	FormatNode(buf, f, node.ID)
+func (node *CancelQuery) Format(ctx *FmtCtx) {
+	ctx.WriteString("CANCEL QUERY ")
+	ctx.FormatNode(node.ID)
 }

--- a/pkg/sql/sem/tree/scrub.go
+++ b/pkg/sql/sem/tree/scrub.go
@@ -15,7 +15,6 @@
 package tree
 
 import (
-	"bytes"
 	"fmt"
 )
 
@@ -41,27 +40,27 @@ type Scrub struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (n *Scrub) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("EXPERIMENTAL SCRUB ")
+func (n *Scrub) Format(ctx *FmtCtx) {
+	ctx.WriteString("EXPERIMENTAL SCRUB ")
 	switch n.Typ {
 	case ScrubTable:
-		buf.WriteString("TABLE ")
-		n.Table.Format(buf, f)
+		ctx.WriteString("TABLE ")
+		n.Table.Format(ctx)
 	case ScrubDatabase:
-		buf.WriteString("DATABASE ")
-		n.Database.Format(buf, f)
+		ctx.WriteString("DATABASE ")
+		ctx.FormatNode(n.Database)
 	default:
 		panic("Unhandled ScrubType")
 	}
 
 	if n.AsOf.Expr != nil {
-		buf.WriteByte(' ')
-		FormatNode(buf, f, n.AsOf)
+		ctx.WriteByte(' ')
+		ctx.FormatNode(n.AsOf)
 	}
 
 	if len(n.Options) > 0 {
-		buf.WriteString(" WITH OPTIONS ")
-		n.Options.Format(buf, f)
+		ctx.WriteString(" WITH OPTIONS ")
+		ctx.FormatNode(n.Options)
 	}
 }
 
@@ -69,12 +68,12 @@ func (n *Scrub) Format(buf *bytes.Buffer, f FmtFlags) {
 type ScrubOptions []ScrubOption
 
 // Format implements the NodeFormatter interface.
-func (n ScrubOptions) Format(buf *bytes.Buffer, f FmtFlags) {
+func (n ScrubOptions) Format(ctx *FmtCtx) {
 	for i, option := range n {
 		if i > 0 {
-			buf.WriteString(", ")
+			ctx.WriteString(", ")
 		}
-		option.Format(buf, f)
+		ctx.FormatNode(option)
 	}
 }
 
@@ -103,14 +102,14 @@ type ScrubOptionIndex struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (n *ScrubOptionIndex) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("INDEX ")
+func (n *ScrubOptionIndex) Format(ctx *FmtCtx) {
+	ctx.WriteString("INDEX ")
 	if n.IndexNames != nil {
-		buf.WriteByte('(')
-		n.IndexNames.Format(buf, f)
-		buf.WriteByte(')')
+		ctx.WriteByte('(')
+		ctx.FormatNode(n.IndexNames)
+		ctx.WriteByte(')')
 	} else {
-		buf.WriteString("ALL")
+		ctx.WriteString("ALL")
 	}
 }
 
@@ -118,8 +117,8 @@ func (n *ScrubOptionIndex) Format(buf *bytes.Buffer, f FmtFlags) {
 type ScrubOptionPhysical struct{}
 
 // Format implements the NodeFormatter interface.
-func (n *ScrubOptionPhysical) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("PHYSICAL")
+func (n *ScrubOptionPhysical) Format(ctx *FmtCtx) {
+	ctx.WriteString("PHYSICAL")
 }
 
 // ScrubOptionConstraint represents a CONSTRAINT scrub check.
@@ -128,13 +127,13 @@ type ScrubOptionConstraint struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (n *ScrubOptionConstraint) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("CONSTRAINT ")
+func (n *ScrubOptionConstraint) Format(ctx *FmtCtx) {
+	ctx.WriteString("CONSTRAINT ")
 	if n.ConstraintNames != nil {
-		buf.WriteByte('(')
-		n.ConstraintNames.Format(buf, f)
-		buf.WriteByte(')')
+		ctx.WriteByte('(')
+		ctx.FormatNode(n.ConstraintNames)
+		ctx.WriteByte(')')
 	} else {
-		buf.WriteString("ALL")
+		ctx.WriteString("ALL")
 	}
 }

--- a/pkg/sql/sem/tree/scrub.go
+++ b/pkg/sql/sem/tree/scrub.go
@@ -48,19 +48,19 @@ func (n *Scrub) Format(ctx *FmtCtx) {
 		n.Table.Format(ctx)
 	case ScrubDatabase:
 		ctx.WriteString("DATABASE ")
-		ctx.FormatNode(n.Database)
+		ctx.FormatNode(&n.Database)
 	default:
 		panic("Unhandled ScrubType")
 	}
 
 	if n.AsOf.Expr != nil {
 		ctx.WriteByte(' ')
-		ctx.FormatNode(n.AsOf)
+		ctx.FormatNode(&n.AsOf)
 	}
 
 	if len(n.Options) > 0 {
 		ctx.WriteString(" WITH OPTIONS ")
-		ctx.FormatNode(n.Options)
+		ctx.FormatNode(&n.Options)
 	}
 }
 
@@ -68,8 +68,8 @@ func (n *Scrub) Format(ctx *FmtCtx) {
 type ScrubOptions []ScrubOption
 
 // Format implements the NodeFormatter interface.
-func (n ScrubOptions) Format(ctx *FmtCtx) {
-	for i, option := range n {
+func (n *ScrubOptions) Format(ctx *FmtCtx) {
+	for i, option := range *n {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
@@ -77,7 +77,7 @@ func (n ScrubOptions) Format(ctx *FmtCtx) {
 	}
 }
 
-func (n ScrubOptions) String() string { return AsString(n) }
+func (n *ScrubOptions) String() string { return AsString(n) }
 
 // ScrubOption represents a scrub option.
 type ScrubOption interface {
@@ -106,7 +106,7 @@ func (n *ScrubOptionIndex) Format(ctx *FmtCtx) {
 	ctx.WriteString("INDEX ")
 	if n.IndexNames != nil {
 		ctx.WriteByte('(')
-		ctx.FormatNode(n.IndexNames)
+		ctx.FormatNode(&n.IndexNames)
 		ctx.WriteByte(')')
 	} else {
 		ctx.WriteString("ALL")
@@ -131,7 +131,7 @@ func (n *ScrubOptionConstraint) Format(ctx *FmtCtx) {
 	ctx.WriteString("CONSTRAINT ")
 	if n.ConstraintNames != nil {
 		ctx.WriteByte('(')
-		ctx.FormatNode(n.ConstraintNames)
+		ctx.FormatNode(&n.ConstraintNames)
 		ctx.WriteByte(')')
 	} else {
 		ctx.WriteString("ALL")

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -589,10 +589,13 @@ func (node *WindowDef) Format(ctx *FmtCtx) {
 		} else {
 			// We need to remove the initial space produced by OrderBy.Format.
 			// TODO(knz): this code is horrendous. Figure a way to remove it.
-			var tmpBuf bytes.Buffer
-			tmpCtx := MakeFmtCtx(&tmpBuf, ctx.flags)
-			tmpCtx.FormatNode(node.OrderBy)
-			ctx.WriteString(tmpBuf.String()[1:])
+			var f struct {
+				buf bytes.Buffer
+				ctx FmtCtx
+			}
+			f.ctx = MakeFmtCtx(&f.buf, ctx.flags)
+			f.ctx.FormatNode(node.OrderBy)
+			ctx.WriteString(f.buf.String()[1:])
 		}
 		needSpaceSeparator = true
 		_ = needSpaceSeparator // avoid compiler warning until TODO below is addressed.

--- a/pkg/sql/sem/tree/select.go
+++ b/pkg/sql/sem/tree/select.go
@@ -24,7 +24,6 @@
 package tree
 
 import (
-	"bytes"
 	"fmt"
 )
 
@@ -589,13 +588,8 @@ func (node *WindowDef) Format(ctx *FmtCtx) {
 		} else {
 			// We need to remove the initial space produced by OrderBy.Format.
 			// TODO(knz): this code is horrendous. Figure a way to remove it.
-			var f struct {
-				buf bytes.Buffer
-				ctx FmtCtx
-			}
-			f.ctx = MakeFmtCtx(&f.buf, ctx.flags)
-			f.ctx.FormatNode(&node.OrderBy)
-			ctx.WriteString(f.buf.String()[1:])
+			orderByStr := AsStringWithFlags(&node.OrderBy, ctx.flags)
+			ctx.WriteString(orderByStr[1:])
 		}
 		needSpaceSeparator = true
 		_ = needSpaceSeparator // avoid compiler warning until TODO below is addressed.

--- a/pkg/sql/sem/tree/set.go
+++ b/pkg/sql/sem/tree/set.go
@@ -34,12 +34,12 @@ func (node *SetVar) Format(ctx *FmtCtx) {
 	ctx.WriteString("SET ")
 	if node.Name == nil {
 		ctx.WriteString("ROW (")
-		ctx.FormatNode(node.Values)
+		ctx.FormatNode(&node.Values)
 		ctx.WriteString(")")
 	} else {
 		ctx.FormatNode(node.Name)
 		ctx.WriteString(" = ")
-		ctx.FormatNode(node.Values)
+		ctx.FormatNode(&node.Values)
 	}
 }
 

--- a/pkg/sql/sem/tree/set.go
+++ b/pkg/sql/sem/tree/set.go
@@ -23,8 +23,6 @@
 
 package tree
 
-import "bytes"
-
 // SetVar represents a SET or RESET statement.
 type SetVar struct {
 	Name   VarName
@@ -32,16 +30,16 @@ type SetVar struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *SetVar) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SET ")
+func (node *SetVar) Format(ctx *FmtCtx) {
+	ctx.WriteString("SET ")
 	if node.Name == nil {
-		buf.WriteString("ROW (")
-		FormatNode(buf, f, node.Values)
-		buf.WriteString(")")
+		ctx.WriteString("ROW (")
+		ctx.FormatNode(node.Values)
+		ctx.WriteString(")")
 	} else {
-		FormatNode(buf, f, node.Name)
-		buf.WriteString(" = ")
-		FormatNode(buf, f, node.Values)
+		ctx.FormatNode(node.Name)
+		ctx.WriteString(" = ")
+		ctx.FormatNode(node.Values)
 	}
 }
 
@@ -52,11 +50,11 @@ type SetClusterSetting struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *SetClusterSetting) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SET CLUSTER SETTING ")
-	FormatNode(buf, f, node.Name)
-	buf.WriteString(" = ")
-	FormatNode(buf, f, node.Value)
+func (node *SetClusterSetting) Format(ctx *FmtCtx) {
+	ctx.WriteString("SET CLUSTER SETTING ")
+	ctx.FormatNode(node.Name)
+	ctx.WriteString(" = ")
+	ctx.FormatNode(node.Value)
 }
 
 // SetTransaction represents a SET TRANSACTION statement.
@@ -65,9 +63,9 @@ type SetTransaction struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *SetTransaction) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SET TRANSACTION")
-	node.Modes.Format(buf, f)
+func (node *SetTransaction) Format(ctx *FmtCtx) {
+	ctx.WriteString("SET TRANSACTION")
+	node.Modes.Format(ctx)
 }
 
 // SetSessionCharacteristics represents a SET SESSION CHARACTERISTICS AS TRANSACTION statement.
@@ -76,7 +74,7 @@ type SetSessionCharacteristics struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *SetSessionCharacteristics) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SET SESSION CHARACTERISTICS AS TRANSACTION")
-	node.Modes.Format(buf, f)
+func (node *SetSessionCharacteristics) Format(ctx *FmtCtx) {
+	ctx.WriteString("SET SESSION CHARACTERISTICS AS TRANSACTION")
+	node.Modes.Format(ctx)
 }

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -24,9 +24,6 @@
 package tree
 
 import (
-	"bytes"
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 )
 
@@ -36,9 +33,9 @@ type ShowVar struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowVar) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW ")
-	buf.WriteString(node.Name)
+func (node *ShowVar) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW ")
+	ctx.WriteString(node.Name)
 }
 
 // ShowClusterSetting represents a SHOW CLUSTER SETTING statement.
@@ -47,9 +44,9 @@ type ShowClusterSetting struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowClusterSetting) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW CLUSTER SETTING ")
-	buf.WriteString(node.Name)
+func (node *ShowClusterSetting) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW CLUSTER SETTING ")
+	ctx.WriteString(node.Name)
 }
 
 // ShowBackup represents a SHOW BACKUP statement.
@@ -58,9 +55,9 @@ type ShowBackup struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowBackup) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW BACKUP ")
-	FormatNode(buf, f, node.Path)
+func (node *ShowBackup) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW BACKUP ")
+	ctx.FormatNode(node.Path)
 }
 
 // ShowColumns represents a SHOW COLUMNS statement.
@@ -69,18 +66,17 @@ type ShowColumns struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowColumns) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW COLUMNS FROM ")
-	FormatNode(buf, f, &node.Table)
+func (node *ShowColumns) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW COLUMNS FROM ")
+	ctx.FormatNode(&node.Table)
 }
 
 // ShowDatabases represents a SHOW DATABASES statement.
-type ShowDatabases struct {
-}
+type ShowDatabases struct{}
 
 // Format implements the NodeFormatter interface.
-func (node *ShowDatabases) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW DATABASES")
+func (node *ShowDatabases) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW DATABASES")
 }
 
 // ShowTrace represents a SHOW TRACE FOR <stmt>/SESSION statement.
@@ -92,19 +88,19 @@ type ShowTrace struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowTrace) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW")
+func (node *ShowTrace) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW")
 	if node.Compact {
-		buf.WriteString(" COMPACT")
+		ctx.WriteString(" COMPACT")
 	}
 	if node.OnlyKVTrace {
-		buf.WriteString(" KV")
+		ctx.WriteString(" KV")
 	}
-	fmt.Fprintf(buf, " TRACE FOR ")
+	ctx.WriteString(" TRACE FOR ")
 	if node.Statement == nil {
-		buf.WriteString("SESSION")
+		ctx.WriteString("SESSION")
 	} else {
-		FormatNode(buf, f, node.Statement)
+		ctx.FormatNode(node.Statement)
 	}
 }
 
@@ -114,9 +110,9 @@ type ShowIndex struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowIndex) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW INDEXES FROM ")
-	FormatNode(buf, f, &node.Table)
+func (node *ShowIndex) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW INDEXES FROM ")
+	ctx.FormatNode(&node.Table)
 }
 
 // ShowQueries represents a SHOW QUERIES statement
@@ -125,12 +121,12 @@ type ShowQueries struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowQueries) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW ")
+func (node *ShowQueries) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW ")
 	if node.Cluster {
-		buf.WriteString("CLUSTER QUERIES")
+		ctx.WriteString("CLUSTER QUERIES")
 	} else {
-		buf.WriteString("LOCAL QUERIES")
+		ctx.WriteString("LOCAL QUERIES")
 	}
 }
 
@@ -139,8 +135,8 @@ type ShowJobs struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowJobs) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW JOBS")
+func (node *ShowJobs) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW JOBS")
 }
 
 // ShowSessions represents a SHOW SESSIONS statement
@@ -149,12 +145,12 @@ type ShowSessions struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowSessions) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW ")
+func (node *ShowSessions) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW ")
 	if node.Cluster {
-		buf.WriteString("CLUSTER SESSIONS")
+		ctx.WriteString("CLUSTER SESSIONS")
 	} else {
-		buf.WriteString("LOCAL SESSIONS")
+		ctx.WriteString("LOCAL SESSIONS")
 	}
 }
 
@@ -169,20 +165,20 @@ type ShowConstraints struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowConstraints) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW CONSTRAINTS")
+func (node *ShowConstraints) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW CONSTRAINTS")
 	if node.Table.TableNameReference != nil {
-		buf.WriteString(" FROM ")
-		FormatNode(buf, f, &node.Table)
+		ctx.WriteString(" FROM ")
+		ctx.FormatNode(&node.Table)
 	}
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowTables) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW TABLES")
+func (node *ShowTables) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW TABLES")
 	if node.Database != "" {
-		buf.WriteString(" FROM ")
-		FormatNode(buf, f, node.Database)
+		ctx.WriteString(" FROM ")
+		ctx.FormatNode(node.Database)
 	}
 }
 
@@ -194,15 +190,15 @@ type ShowGrants struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowGrants) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW GRANTS")
+func (node *ShowGrants) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW GRANTS")
 	if node.Targets != nil {
-		buf.WriteString(" ON ")
-		FormatNode(buf, f, node.Targets)
+		ctx.WriteString(" ON ")
+		ctx.FormatNode(node.Targets)
 	}
 	if node.Grantees != nil {
-		buf.WriteString(" FOR ")
-		FormatNode(buf, f, node.Grantees)
+		ctx.WriteString(" FOR ")
+		ctx.FormatNode(node.Grantees)
 	}
 }
 
@@ -212,9 +208,9 @@ type ShowCreateTable struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowCreateTable) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW CREATE TABLE ")
-	FormatNode(buf, f, &node.Table)
+func (node *ShowCreateTable) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW CREATE TABLE ")
+	ctx.FormatNode(&node.Table)
 }
 
 // ShowCreateView represents a SHOW CREATE VIEW statement.
@@ -223,9 +219,9 @@ type ShowCreateView struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowCreateView) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW CREATE VIEW ")
-	FormatNode(buf, f, &node.View)
+func (node *ShowCreateView) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW CREATE VIEW ")
+	ctx.FormatNode(&node.View)
 }
 
 // ShowCreateSequence represents a SHOW CREATE SEQUENCE statement.
@@ -234,9 +230,9 @@ type ShowCreateSequence struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowCreateSequence) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW CREATE SEQUENCE ")
-	FormatNode(buf, f, &node.Sequence)
+func (node *ShowCreateSequence) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW CREATE SEQUENCE ")
+	ctx.FormatNode(&node.Sequence)
 }
 
 // ShowSyntax represents a SHOW SYNTAX statement.
@@ -249,9 +245,9 @@ type ShowSyntax struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowSyntax) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW SYNTAX ")
-	buf.WriteString(lex.EscapeSQLString(node.Statement))
+func (node *ShowSyntax) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW SYNTAX ")
+	ctx.WriteString(lex.EscapeSQLString(node.Statement))
 }
 
 // ShowTransactionStatus represents a SHOW TRANSACTION STATUS statement.
@@ -259,8 +255,8 @@ type ShowTransactionStatus struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowTransactionStatus) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW TRANSACTION STATUS")
+func (node *ShowTransactionStatus) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW TRANSACTION STATUS")
 }
 
 // ShowUsers represents a SHOW USERS statement.
@@ -268,8 +264,8 @@ type ShowUsers struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowUsers) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW USERS")
+func (node *ShowUsers) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW USERS")
 }
 
 // ShowRoles represents a SHOW ROLES statement.
@@ -277,8 +273,8 @@ type ShowRoles struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowRoles) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW ROLES")
+func (node *ShowRoles) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW ROLES")
 }
 
 // ShowRanges represents a SHOW TESTING_RANGES statement.
@@ -289,14 +285,14 @@ type ShowRanges struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowRanges) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW TESTING_RANGES FROM ")
+func (node *ShowRanges) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW TESTING_RANGES FROM ")
 	if node.Index != nil {
-		buf.WriteString("INDEX ")
-		FormatNode(buf, f, node.Index)
+		ctx.WriteString("INDEX ")
+		ctx.FormatNode(node.Index)
 	} else {
-		buf.WriteString("TABLE ")
-		FormatNode(buf, f, node.Table)
+		ctx.WriteString("TABLE ")
+		ctx.FormatNode(node.Table)
 	}
 }
 
@@ -306,9 +302,9 @@ type ShowFingerprints struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowFingerprints) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ")
-	FormatNode(buf, f, node.Table)
+func (node *ShowFingerprints) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE ")
+	ctx.FormatNode(node.Table)
 }
 
 // ShowTableStats represents a SHOW STATISTICS FOR TABLE statement.
@@ -317,9 +313,9 @@ type ShowTableStats struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowTableStats) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SHOW STATISTICS FOR TABLE ")
-	FormatNode(buf, f, &node.Table)
+func (node *ShowTableStats) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW STATISTICS FOR TABLE ")
+	ctx.FormatNode(&node.Table)
 }
 
 // ShowHistogram represents a SHOW HISTOGRAM statement.
@@ -328,6 +324,6 @@ type ShowHistogram struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowHistogram) Format(buf *bytes.Buffer, f FmtFlags) {
-	fmt.Fprintf(buf, "SHOW HISTOGRAM %d", node.HistogramID)
+func (node *ShowHistogram) Format(ctx *FmtCtx) {
+	ctx.Printf("SHOW HISTOGRAM %d", node.HistogramID)
 }

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -178,7 +178,7 @@ func (node *ShowTables) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW TABLES")
 	if node.Database != "" {
 		ctx.WriteString(" FROM ")
-		ctx.FormatNode(node.Database)
+		ctx.FormatNode(&node.Database)
 	}
 }
 
@@ -198,7 +198,7 @@ func (node *ShowGrants) Format(ctx *FmtCtx) {
 	}
 	if node.Grantees != nil {
 		ctx.WriteString(" FOR ")
-		ctx.FormatNode(node.Grantees)
+		ctx.FormatNode(&node.Grantees)
 	}
 }
 

--- a/pkg/sql/sem/tree/split.go
+++ b/pkg/sql/sem/tree/split.go
@@ -14,8 +14,6 @@
 
 package tree
 
-import "bytes"
-
 // Split represents an `ALTER TABLE/INDEX .. SPLIT AT ..` statement.
 type Split struct {
 	// Only one of Table and Index can be set.
@@ -27,17 +25,17 @@ type Split struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Split) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER ")
+func (node *Split) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER ")
 	if node.Index != nil {
-		buf.WriteString("INDEX ")
-		FormatNode(buf, f, node.Index)
+		ctx.WriteString("INDEX ")
+		ctx.FormatNode(node.Index)
 	} else {
-		buf.WriteString("TABLE ")
-		FormatNode(buf, f, node.Table)
+		ctx.WriteString("TABLE ")
+		ctx.FormatNode(node.Table)
 	}
-	buf.WriteString(" SPLIT AT ")
-	FormatNode(buf, f, node.Rows)
+	ctx.WriteString(" SPLIT AT ")
+	ctx.FormatNode(node.Rows)
 }
 
 // TestingRelocate represents an `ALTER TABLE/INDEX .. TESTING_RELOCATE ..`
@@ -53,17 +51,17 @@ type TestingRelocate struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *TestingRelocate) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER ")
+func (node *TestingRelocate) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER ")
 	if node.Index != nil {
-		buf.WriteString("INDEX ")
-		FormatNode(buf, f, node.Index)
+		ctx.WriteString("INDEX ")
+		ctx.FormatNode(node.Index)
 	} else {
-		buf.WriteString("TABLE ")
-		FormatNode(buf, f, node.Table)
+		ctx.WriteString("TABLE ")
+		ctx.FormatNode(node.Table)
 	}
-	buf.WriteString(" TESTING_RELOCATE ")
-	FormatNode(buf, f, node.Rows)
+	ctx.WriteString(" TESTING_RELOCATE ")
+	ctx.FormatNode(node.Rows)
 }
 
 // Scatter represents an `ALTER TABLE/INDEX .. SCATTER ..`
@@ -79,21 +77,21 @@ type Scatter struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Scatter) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER ")
+func (node *Scatter) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER ")
 	if node.Index != nil {
-		buf.WriteString("INDEX ")
-		FormatNode(buf, f, node.Index)
+		ctx.WriteString("INDEX ")
+		ctx.FormatNode(node.Index)
 	} else {
-		buf.WriteString("TABLE ")
-		FormatNode(buf, f, node.Table)
+		ctx.WriteString("TABLE ")
+		ctx.FormatNode(node.Table)
 	}
-	buf.WriteString(" SCATTER")
+	ctx.WriteString(" SCATTER")
 	if node.From != nil {
-		buf.WriteString(" FROM (")
-		FormatNode(buf, f, node.From)
-		buf.WriteString(") TO (")
-		FormatNode(buf, f, node.To)
-		buf.WriteString(")")
+		ctx.WriteString(" FROM (")
+		ctx.FormatNode(node.From)
+		ctx.WriteString(") TO (")
+		ctx.FormatNode(node.To)
+		ctx.WriteString(")")
 	}
 }

--- a/pkg/sql/sem/tree/split.go
+++ b/pkg/sql/sem/tree/split.go
@@ -89,9 +89,9 @@ func (node *Scatter) Format(ctx *FmtCtx) {
 	ctx.WriteString(" SCATTER")
 	if node.From != nil {
 		ctx.WriteString(" FROM (")
-		ctx.FormatNode(node.From)
+		ctx.FormatNode(&node.From)
 		ctx.WriteString(") TO (")
-		ctx.FormatNode(node.To)
+		ctx.FormatNode(&node.To)
 		ctx.WriteString(")")
 	}
 }

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -141,8 +141,8 @@ type IndependentFromParallelizedPriors interface {
 type StatementList []Statement
 
 // Format implements the NodeFormatter interface.
-func (l StatementList) Format(ctx *FmtCtx) {
-	for i, s := range l {
+func (l *StatementList) Format(ctx *FmtCtx) {
+	for i, s := range *l {
 		if i > 0 {
 			ctx.WriteString("; ")
 		}
@@ -813,14 +813,14 @@ func (*UnionClause) StatementType() StatementType { return Rows }
 func (*UnionClause) StatementTag() string { return "UNION" }
 
 // StatementType implements the Statement interface.
-func (ValuesClause) StatementType() StatementType { return Rows }
+func (*ValuesClause) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
-func (ValuesClause) StatementTag() string { return "VALUES" }
+func (*ValuesClause) StatementTag() string { return "VALUES" }
 
 func (n *AlterIndex) String() string                { return AsString(n) }
 func (n *AlterTable) String() string                { return AsString(n) }
-func (n AlterTableCmds) String() string             { return AsString(n) }
+func (n *AlterTableCmds) String() string            { return AsString(n) }
 func (n *AlterTableAddColumn) String() string       { return AsString(n) }
 func (n *AlterTableAddConstraint) String() string   { return AsString(n) }
 func (n *AlterTableDropColumn) String() string      { return AsString(n) }
@@ -907,7 +907,7 @@ func (n *ShowVar) String() string                   { return AsString(n) }
 func (n *ShowZoneConfig) String() string            { return AsString(n) }
 func (n *ShowFingerprints) String() string          { return AsString(n) }
 func (n *Split) String() string                     { return AsString(n) }
-func (l StatementList) String() string              { return AsString(l) }
+func (l *StatementList) String() string             { return AsString(l) }
 func (n *Truncate) String() string                  { return AsString(n) }
 func (n *UnionClause) String() string               { return AsString(n) }
 func (n *Update) String() string                    { return AsString(n) }

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -24,7 +24,6 @@
 package tree
 
 import (
-	"bytes"
 	"fmt"
 )
 
@@ -142,12 +141,12 @@ type IndependentFromParallelizedPriors interface {
 type StatementList []Statement
 
 // Format implements the NodeFormatter interface.
-func (l StatementList) Format(buf *bytes.Buffer, f FmtFlags) {
+func (l StatementList) Format(ctx *FmtCtx) {
 	for i, s := range l {
 		if i > 0 {
-			buf.WriteString("; ")
+			ctx.WriteString("; ")
 		}
-		FormatNode(buf, f, s)
+		ctx.FormatNode(s)
 	}
 }
 

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -114,7 +114,8 @@ type TableName struct {
 // Format implements the NodeFormatter interface.
 func (t *TableName) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if !t.DBNameOriginallyOmitted || f.alwaysQualify || ctx.tableNameFormatter != nil {
+	if !t.DBNameOriginallyOmitted ||
+		f.HasFlags(FmtAlwaysQualifyTableNames) || ctx.tableNameFormatter != nil {
 		if t.PrefixOriginallySpecified {
 			ctx.FormatNode(t.PrefixName)
 			ctx.WriteByte('.')

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -37,9 +37,8 @@ type NormalizableTableName struct {
 
 // Format implements the NodeFormatter interface.
 func (nt *NormalizableTableName) Format(ctx *FmtCtx) {
-	f := ctx.flags
-	if f.tableNameFormatter != nil {
-		f.tableNameFormatter(ctx, nt)
+	if ctx.tableNameFormatter != nil {
+		ctx.tableNameFormatter(ctx, nt)
 	} else {
 		ctx.FormatNode(nt.TableNameReference)
 	}
@@ -115,7 +114,7 @@ type TableName struct {
 // Format implements the NodeFormatter interface.
 func (t *TableName) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if !t.DBNameOriginallyOmitted || f.alwaysQualify || f.tableNameFormatter != nil {
+	if !t.DBNameOriginallyOmitted || f.alwaysQualify || ctx.tableNameFormatter != nil {
 		if t.PrefixOriginallySpecified {
 			ctx.FormatNode(t.PrefixName)
 			ctx.WriteByte('.')

--- a/pkg/sql/sem/tree/table_pattern.go
+++ b/pkg/sql/sem/tree/table_pattern.go
@@ -15,7 +15,6 @@
 package tree
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -95,12 +94,12 @@ type AllTablesSelector struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (at *AllTablesSelector) Format(buf *bytes.Buffer, f FmtFlags) {
+func (at *AllTablesSelector) Format(ctx *FmtCtx) {
 	if !at.DBNameOriginallyOmitted {
-		FormatNode(buf, f, at.Database)
-		buf.WriteByte('.')
+		ctx.FormatNode(at.Database)
+		ctx.WriteByte('.')
 	}
-	buf.WriteByte('*')
+	ctx.WriteByte('*')
 }
 func (at *AllTablesSelector) String() string { return AsString(at) }
 
@@ -125,11 +124,11 @@ func (at *AllTablesSelector) QualifyWithDatabase(database string) error {
 type TablePatterns []TablePattern
 
 // Format implements the NodeFormatter interface.
-func (tt TablePatterns) Format(buf *bytes.Buffer, f FmtFlags) {
+func (tt TablePatterns) Format(ctx *FmtCtx) {
 	for i, t := range tt {
 		if i > 0 {
-			buf.WriteString(", ")
+			ctx.WriteString(", ")
 		}
-		FormatNode(buf, f, t)
+		ctx.FormatNode(t)
 	}
 }

--- a/pkg/sql/sem/tree/table_pattern.go
+++ b/pkg/sql/sem/tree/table_pattern.go
@@ -46,7 +46,7 @@ type DatabaseQualifiable interface {
 	QualifyWithDatabase(database string) error
 }
 
-var _ TablePattern = UnresolvedName{}
+var _ TablePattern = &UnresolvedName{}
 var _ TablePattern = &TableName{}
 var _ TablePattern = &AllTablesSelector{}
 var _ DatabaseQualifiable = &AllTablesSelector{}
@@ -54,32 +54,33 @@ var _ DatabaseQualifiable = &TableName{}
 
 // NormalizeTablePattern resolves an UnresolvedName to either a
 // TableName or AllTablesSelector.
-func (n UnresolvedName) NormalizeTablePattern() (TablePattern, error) {
-	if len(n) == 0 || len(n) > 2 {
-		return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError, "invalid table name: %q", n)
+func (n *UnresolvedName) NormalizeTablePattern() (TablePattern, error) {
+	ln := len(*n)
+	if ln == 0 || ln > 2 {
+		return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError, "invalid table name: %q", *n)
 	}
 
 	var db Name
 	dbOmitted := true
-	if len(n) > 1 {
-		dbName, ok := n[0].(Name)
+	if ln > 1 {
+		dbName, ok := (*n)[0].(*Name)
 		if !ok {
-			return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError, "invalid database name: %q", n[0])
+			return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError, "invalid database name: %q", (*n)[0])
 		}
-		db = dbName
+		db = *dbName
 		dbOmitted = false
 	}
 
-	switch t := n[len(n)-1].(type) {
+	switch t := (*n)[ln-1].(type) {
 	case UnqualifiedStar:
 		return &AllTablesSelector{Database: db, DBNameOriginallyOmitted: dbOmitted}, nil
-	case Name:
-		if len(t) == 0 {
-			return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError, "empty table name: %q", n)
+	case *Name:
+		if len(*t) == 0 {
+			return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError, "empty table name: %q", *n)
 		}
-		return &TableName{DatabaseName: db, TableName: t, DBNameOriginallyOmitted: dbOmitted}, nil
+		return &TableName{DatabaseName: db, TableName: *t, DBNameOriginallyOmitted: dbOmitted}, nil
 	default:
-		return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError, "invalid table pattern: %q", n)
+		return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError, "invalid table pattern: %q", *n)
 	}
 }
 
@@ -96,7 +97,7 @@ type AllTablesSelector struct {
 // Format implements the NodeFormatter interface.
 func (at *AllTablesSelector) Format(ctx *FmtCtx) {
 	if !at.DBNameOriginallyOmitted {
-		ctx.FormatNode(at.Database)
+		ctx.FormatNode(&at.Database)
 		ctx.WriteByte('.')
 	}
 	ctx.WriteByte('*')
@@ -124,8 +125,8 @@ func (at *AllTablesSelector) QualifyWithDatabase(database string) error {
 type TablePatterns []TablePattern
 
 // Format implements the NodeFormatter interface.
-func (tt TablePatterns) Format(ctx *FmtCtx) {
-	for i, t := range tt {
+func (tt *TablePatterns) Format(ctx *FmtCtx) {
+	for i, t := range *tt {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}

--- a/pkg/sql/sem/tree/table_ref.go
+++ b/pkg/sql/sem/tree/table_ref.go
@@ -14,11 +14,6 @@
 
 package tree
 
-import (
-	"bytes"
-	"fmt"
-)
-
 // ID is a custom type for {Database,Table}Descriptor IDs.
 type ID uint32
 
@@ -42,23 +37,23 @@ type TableRef struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (n *TableRef) Format(buf *bytes.Buffer, f FmtFlags) {
-	fmt.Fprintf(buf, "[%d", n.TableID)
+func (n *TableRef) Format(ctx *FmtCtx) {
+	ctx.Printf("[%d", n.TableID)
 	if n.Columns != nil {
-		buf.WriteByte('(')
+		ctx.WriteByte('(')
 		for i, c := range n.Columns {
 			if i > 0 {
-				buf.WriteString(", ")
+				ctx.WriteString(", ")
 			}
-			fmt.Fprintf(buf, "%d", c)
+			ctx.Printf("%d", c)
 		}
-		buf.WriteByte(')')
+		ctx.WriteByte(')')
 	}
 	if n.As.Alias != "" {
-		buf.WriteString(" AS ")
-		FormatNode(buf, f, n.As)
+		ctx.WriteString(" AS ")
+		ctx.FormatNode(n.As)
 	}
-	buf.WriteByte(']')
+	ctx.WriteByte(']')
 }
 func (n *TableRef) String() string { return AsString(n) }
 

--- a/pkg/sql/sem/tree/table_ref.go
+++ b/pkg/sql/sem/tree/table_ref.go
@@ -51,7 +51,7 @@ func (n *TableRef) Format(ctx *FmtCtx) {
 	}
 	if n.As.Alias != "" {
 		ctx.WriteString(" AS ")
-		ctx.FormatNode(n.As)
+		ctx.FormatNode(&n.As)
 	}
 	ctx.WriteByte(']')
 }

--- a/pkg/sql/sem/tree/truncate.go
+++ b/pkg/sql/sem/tree/truncate.go
@@ -23,8 +23,6 @@
 
 package tree
 
-import "bytes"
-
 // Truncate represents a TRUNCATE statement.
 type Truncate struct {
 	Tables       TableNameReferences
@@ -32,16 +30,16 @@ type Truncate struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Truncate) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("TRUNCATE TABLE ")
+func (node *Truncate) Format(ctx *FmtCtx) {
+	ctx.WriteString("TRUNCATE TABLE ")
 	for i, n := range node.Tables {
 		if i > 0 {
-			buf.WriteString(", ")
+			ctx.WriteString(", ")
 		}
-		FormatNode(buf, f, n)
+		ctx.FormatNode(n)
 	}
 	if node.DropBehavior != DropDefault {
-		buf.WriteByte(' ')
-		buf.WriteString(node.DropBehavior.String())
+		ctx.WriteByte(' ')
+		ctx.WriteString(node.DropBehavior.String())
 	}
 }

--- a/pkg/sql/sem/tree/txn.go
+++ b/pkg/sql/sem/tree/txn.go
@@ -15,7 +15,6 @@
 package tree
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 
@@ -101,18 +100,18 @@ type TransactionModes struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *TransactionModes) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node *TransactionModes) Format(ctx *FmtCtx) {
 	var sep string
 	if node.Isolation != UnspecifiedIsolation {
-		fmt.Fprintf(buf, " ISOLATION LEVEL %s", node.Isolation)
+		ctx.Printf(" ISOLATION LEVEL %s", node.Isolation)
 		sep = ","
 	}
 	if node.UserPriority != UnspecifiedUserPriority {
-		fmt.Fprintf(buf, "%s PRIORITY %s", sep, node.UserPriority)
+		ctx.Printf("%s PRIORITY %s", sep, node.UserPriority)
 		sep = ","
 	}
 	if node.ReadWriteMode != UnspecifiedReadWriteMode {
-		fmt.Fprintf(buf, "%s READ %s", sep, node.ReadWriteMode)
+		ctx.Printf("%s READ %s", sep, node.ReadWriteMode)
 	}
 }
 
@@ -152,25 +151,25 @@ type BeginTransaction struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *BeginTransaction) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("BEGIN TRANSACTION")
-	node.Modes.Format(buf, f)
+func (node *BeginTransaction) Format(ctx *FmtCtx) {
+	ctx.WriteString("BEGIN TRANSACTION")
+	node.Modes.Format(ctx)
 }
 
 // CommitTransaction represents a COMMIT statement.
 type CommitTransaction struct{}
 
 // Format implements the NodeFormatter interface.
-func (node *CommitTransaction) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("COMMIT TRANSACTION")
+func (node *CommitTransaction) Format(ctx *FmtCtx) {
+	ctx.WriteString("COMMIT TRANSACTION")
 }
 
 // RollbackTransaction represents a ROLLBACK statement.
 type RollbackTransaction struct{}
 
 // Format implements the NodeFormatter interface.
-func (node *RollbackTransaction) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ROLLBACK TRANSACTION")
+func (node *RollbackTransaction) Format(ctx *FmtCtx) {
+	ctx.WriteString("ROLLBACK TRANSACTION")
 }
 
 // RestartSavepointName is the only savepoint name that we accept, modulo
@@ -194,9 +193,9 @@ type Savepoint struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Savepoint) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("SAVEPOINT ")
-	buf.WriteString(node.Name)
+func (node *Savepoint) Format(ctx *FmtCtx) {
+	ctx.WriteString("SAVEPOINT ")
+	ctx.WriteString(node.Name)
 }
 
 // ReleaseSavepoint represents a RELEASE SAVEPOINT <name> statement.
@@ -205,9 +204,9 @@ type ReleaseSavepoint struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ReleaseSavepoint) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("RELEASE SAVEPOINT ")
-	buf.WriteString(node.Savepoint)
+func (node *ReleaseSavepoint) Format(ctx *FmtCtx) {
+	ctx.WriteString("RELEASE SAVEPOINT ")
+	ctx.WriteString(node.Savepoint)
 }
 
 // RollbackToSavepoint represents a ROLLBACK TO SAVEPOINT <name> statement.
@@ -216,7 +215,7 @@ type RollbackToSavepoint struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *RollbackToSavepoint) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ROLLBACK TRANSACTION TO SAVEPOINT ")
-	buf.WriteString(node.Savepoint)
+func (node *RollbackToSavepoint) Format(ctx *FmtCtx) {
+	ctx.WriteString("ROLLBACK TRANSACTION TO SAVEPOINT ")
+	ctx.WriteString(node.Savepoint)
 }

--- a/pkg/sql/sem/tree/union.go
+++ b/pkg/sql/sem/tree/union.go
@@ -24,7 +24,6 @@
 package tree
 
 import (
-	"bytes"
 	"fmt"
 )
 
@@ -59,13 +58,13 @@ func (i UnionType) String() string {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *UnionClause) Format(buf *bytes.Buffer, f FmtFlags) {
-	FormatNode(buf, f, node.Left)
-	buf.WriteByte(' ')
-	buf.WriteString(node.Type.String())
+func (node *UnionClause) Format(ctx *FmtCtx) {
+	ctx.FormatNode(node.Left)
+	ctx.WriteByte(' ')
+	ctx.WriteString(node.Type.String())
 	if node.All {
-		buf.WriteString(" ALL")
+		ctx.WriteString(" ALL")
 	}
-	buf.WriteByte(' ')
-	FormatNode(buf, f, node.Right)
+	ctx.WriteByte(' ')
+	ctx.FormatNode(node.Right)
 }

--- a/pkg/sql/sem/tree/update.go
+++ b/pkg/sql/sem/tree/update.go
@@ -23,8 +23,6 @@
 
 package tree
 
-import "bytes"
-
 // Update represents an UPDATE statement.
 type Update struct {
 	With      *With
@@ -37,28 +35,28 @@ type Update struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *Update) Format(buf *bytes.Buffer, f FmtFlags) {
-	FormatNode(buf, f, node.With)
-	buf.WriteString("UPDATE ")
-	FormatNode(buf, f, node.Table)
-	buf.WriteString(" SET ")
-	FormatNode(buf, f, node.Exprs)
-	FormatNode(buf, f, node.Where)
-	FormatNode(buf, f, node.OrderBy)
-	FormatNode(buf, f, node.Limit)
-	FormatNode(buf, f, node.Returning)
+func (node *Update) Format(ctx *FmtCtx) {
+	ctx.FormatNode(node.With)
+	ctx.WriteString("UPDATE ")
+	ctx.FormatNode(node.Table)
+	ctx.WriteString(" SET ")
+	ctx.FormatNode(node.Exprs)
+	ctx.FormatNode(node.Where)
+	ctx.FormatNode(node.OrderBy)
+	ctx.FormatNode(node.Limit)
+	ctx.FormatNode(node.Returning)
 }
 
 // UpdateExprs represents a list of update expressions.
 type UpdateExprs []*UpdateExpr
 
 // Format implements the NodeFormatter interface.
-func (node UpdateExprs) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node UpdateExprs) Format(ctx *FmtCtx) {
 	for i, n := range node {
 		if i > 0 {
-			buf.WriteString(", ")
+			ctx.WriteString(", ")
 		}
-		FormatNode(buf, f, n)
+		ctx.FormatNode(n)
 	}
 }
 
@@ -70,14 +68,14 @@ type UpdateExpr struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *UpdateExpr) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node *UpdateExpr) Format(ctx *FmtCtx) {
 	open, close := "", ""
 	if node.Tuple {
 		open, close = "(", ")"
 	}
-	buf.WriteString(open)
-	FormatNode(buf, f, node.Names)
-	buf.WriteString(close)
-	buf.WriteString(" = ")
-	FormatNode(buf, f, node.Expr)
+	ctx.WriteString(open)
+	ctx.FormatNode(node.Names)
+	ctx.WriteString(close)
+	ctx.WriteString(" = ")
+	ctx.FormatNode(node.Expr)
 }

--- a/pkg/sql/sem/tree/update.go
+++ b/pkg/sql/sem/tree/update.go
@@ -40,9 +40,9 @@ func (node *Update) Format(ctx *FmtCtx) {
 	ctx.WriteString("UPDATE ")
 	ctx.FormatNode(node.Table)
 	ctx.WriteString(" SET ")
-	ctx.FormatNode(node.Exprs)
+	ctx.FormatNode(&node.Exprs)
 	ctx.FormatNode(node.Where)
-	ctx.FormatNode(node.OrderBy)
+	ctx.FormatNode(&node.OrderBy)
 	ctx.FormatNode(node.Limit)
 	ctx.FormatNode(node.Returning)
 }
@@ -51,8 +51,8 @@ func (node *Update) Format(ctx *FmtCtx) {
 type UpdateExprs []*UpdateExpr
 
 // Format implements the NodeFormatter interface.
-func (node UpdateExprs) Format(ctx *FmtCtx) {
-	for i, n := range node {
+func (node *UpdateExprs) Format(ctx *FmtCtx) {
+	for i, n := range *node {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
@@ -74,7 +74,7 @@ func (node *UpdateExpr) Format(ctx *FmtCtx) {
 		open, close = "(", ")"
 	}
 	ctx.WriteString(open)
-	ctx.FormatNode(node.Names)
+	ctx.FormatNode(&node.Names)
 	ctx.WriteString(close)
 	ctx.WriteString(" = ")
 	ctx.FormatNode(node.Expr)

--- a/pkg/sql/sem/tree/values.go
+++ b/pkg/sql/sem/tree/values.go
@@ -23,20 +23,18 @@
 
 package tree
 
-import "bytes"
-
 // ValuesClause represents a VALUES clause.
 type ValuesClause struct {
 	Tuples []*Tuple
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ValuesClause) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("VALUES ")
+func (node *ValuesClause) Format(ctx *FmtCtx) {
+	ctx.WriteString("VALUES ")
 	for i, n := range node.Tuples {
 		if i > 0 {
-			buf.WriteString(", ")
+			ctx.WriteString(", ")
 		}
-		FormatNode(buf, f, n)
+		ctx.FormatNode(n)
 	}
 }

--- a/pkg/sql/sem/tree/var_name.go
+++ b/pkg/sql/sem/tree/var_name.go
@@ -15,8 +15,6 @@
 package tree
 
 import (
-	"bytes"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -114,13 +112,13 @@ type AllColumnsSelector struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (a *AllColumnsSelector) Format(buf *bytes.Buffer, f FmtFlags) {
+func (a *AllColumnsSelector) Format(ctx *FmtCtx) {
 	if !a.TableName.DBNameOriginallyOmitted {
-		FormatNode(buf, f, a.TableName.DatabaseName)
-		buf.WriteByte('.')
+		ctx.FormatNode(a.TableName.DatabaseName)
+		ctx.WriteByte('.')
 	}
-	FormatNode(buf, f, a.TableName.TableName)
-	buf.WriteString(".*")
+	ctx.FormatNode(a.TableName.TableName)
+	ctx.WriteString(".*")
 }
 func (a *AllColumnsSelector) String() string { return AsString(a) }
 
@@ -150,21 +148,21 @@ type ColumnItem struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (c *ColumnItem) Format(buf *bytes.Buffer, f FmtFlags) {
+func (c *ColumnItem) Format(ctx *FmtCtx) {
 	if c.TableName.TableName != "" {
 		if !c.TableName.DBNameOriginallyOmitted {
-			FormatNode(buf, f, c.TableName.DatabaseName)
-			buf.WriteByte('.')
+			ctx.FormatNode(c.TableName.DatabaseName)
+			ctx.WriteByte('.')
 		}
-		FormatNode(buf, f, c.TableName.TableName)
-		buf.WriteByte('.')
+		ctx.FormatNode(c.TableName.TableName)
+		ctx.WriteByte('.')
 	}
-	FormatNode(buf, f, c.ColumnName)
+	ctx.FormatNode(c.ColumnName)
 	if len(c.Selector) > 0 {
 		if _, ok := c.Selector[0].(*ArraySubscript); !ok {
-			buf.WriteByte('.')
+			ctx.WriteByte('.')
 		}
-		FormatNode(buf, f, c.Selector)
+		ctx.FormatNode(c.Selector)
 	}
 }
 func (c *ColumnItem) String() string { return AsString(c) }

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -486,7 +486,7 @@ func (expr *ArrayFlatten) Walk(v Visitor) Expr {
 func (expr UnqualifiedStar) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
-func (expr UnresolvedName) Walk(_ Visitor) Expr { return expr }
+func (expr *UnresolvedName) Walk(_ Visitor) Expr { return expr }
 
 // Walk implements the Expr interface.
 func (expr *AllColumnsSelector) Walk(_ Visitor) Expr { return expr }

--- a/pkg/sql/sem/tree/with.go
+++ b/pkg/sql/sem/tree/with.go
@@ -35,7 +35,7 @@ func (node *With) Format(ctx *FmtCtx) {
 		if i != 0 {
 			ctx.WriteString(", ")
 		}
-		ctx.FormatNode(cte.Name)
+		ctx.FormatNode(&cte.Name)
 		ctx.WriteString(" AS (")
 		ctx.FormatNode(cte.Stmt)
 		ctx.WriteString(") ")

--- a/pkg/sql/sem/tree/with.go
+++ b/pkg/sql/sem/tree/with.go
@@ -14,10 +14,6 @@
 
 package tree
 
-import (
-	"bytes"
-)
-
 // With represents a WITH statement.
 type With struct {
 	CTEList []*CTE
@@ -30,18 +26,18 @@ type CTE struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *With) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node *With) Format(ctx *FmtCtx) {
 	if node == nil {
 		return
 	}
-	buf.WriteString("WITH ")
+	ctx.WriteString("WITH ")
 	for i, cte := range node.CTEList {
 		if i != 0 {
-			buf.WriteString(", ")
+			ctx.WriteString(", ")
 		}
-		cte.Name.Format(buf, f)
-		buf.WriteString(" AS (")
-		cte.Stmt.Format(buf, f)
-		buf.WriteString(") ")
+		ctx.FormatNode(cte.Name)
+		ctx.WriteString(" AS (")
+		ctx.FormatNode(cte.Stmt)
+		ctx.WriteString(") ")
 	}
 }

--- a/pkg/sql/sem/tree/zone.go
+++ b/pkg/sql/sem/tree/zone.go
@@ -37,7 +37,7 @@ func (node ZoneSpecifier) TargetsIndex() bool {
 }
 
 // Format implements the NodeFormatter interface.
-func (node ZoneSpecifier) Format(ctx *FmtCtx) {
+func (node *ZoneSpecifier) Format(ctx *FmtCtx) {
 	if node.Partition != "" {
 		ctx.WriteString("PARTITION ")
 		ctx.FormatNode(&node.Partition)
@@ -59,7 +59,7 @@ func (node ZoneSpecifier) Format(ctx *FmtCtx) {
 	}
 }
 
-func (node ZoneSpecifier) String() string { return AsString(node) }
+func (node *ZoneSpecifier) String() string { return AsString(node) }
 
 // ShowZoneConfig represents an EXPERIMENTAL SHOW ZONE CONFIGURATION...
 // statement.
@@ -73,7 +73,7 @@ func (node *ShowZoneConfig) Format(ctx *FmtCtx) {
 		ctx.WriteString("EXPERIMENTAL SHOW ZONE CONFIGURATIONS")
 	} else {
 		ctx.WriteString("EXPERIMENTAL SHOW ZONE CONFIGURATION FOR ")
-		ctx.FormatNode(node.ZoneSpecifier)
+		ctx.FormatNode(&node.ZoneSpecifier)
 	}
 }
 
@@ -87,7 +87,7 @@ type SetZoneConfig struct {
 // Format implements the NodeFormatter interface.
 func (node *SetZoneConfig) Format(ctx *FmtCtx) {
 	ctx.WriteString("ALTER ")
-	ctx.FormatNode(node.ZoneSpecifier)
+	ctx.FormatNode(&node.ZoneSpecifier)
 	ctx.WriteString(" EXPERIMENTAL CONFIGURE ZONE ")
 	ctx.FormatNode(node.YAMLConfig)
 }

--- a/pkg/sql/sem/tree/zone.go
+++ b/pkg/sql/sem/tree/zone.go
@@ -14,10 +14,6 @@
 
 package tree
 
-import (
-	"bytes"
-)
-
 // ZoneSpecifier represents a reference to a configurable zone of the keyspace.
 type ZoneSpecifier struct {
 	// Only one of NamedZone, Database or TableOrIndex may be set.
@@ -41,25 +37,25 @@ func (node ZoneSpecifier) TargetsIndex() bool {
 }
 
 // Format implements the NodeFormatter interface.
-func (node ZoneSpecifier) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node ZoneSpecifier) Format(ctx *FmtCtx) {
 	if node.Partition != "" {
-		buf.WriteString("PARTITION ")
-		FormatNode(buf, f, &node.Partition)
-		buf.WriteString(" OF ")
+		ctx.WriteString("PARTITION ")
+		ctx.FormatNode(&node.Partition)
+		ctx.WriteString(" OF ")
 	}
 	if node.NamedZone != "" {
-		buf.WriteString("RANGE ")
-		FormatNode(buf, f, &node.NamedZone)
+		ctx.WriteString("RANGE ")
+		ctx.FormatNode(&node.NamedZone)
 	} else if node.Database != "" {
-		buf.WriteString("DATABASE ")
-		FormatNode(buf, f, &node.Database)
+		ctx.WriteString("DATABASE ")
+		ctx.FormatNode(&node.Database)
 	} else {
 		if node.TargetsIndex() {
-			buf.WriteString("INDEX ")
+			ctx.WriteString("INDEX ")
 		} else {
-			buf.WriteString("TABLE ")
+			ctx.WriteString("TABLE ")
 		}
-		FormatNode(buf, f, &node.TableOrIndex)
+		ctx.FormatNode(&node.TableOrIndex)
 	}
 }
 
@@ -72,12 +68,12 @@ type ShowZoneConfig struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *ShowZoneConfig) Format(buf *bytes.Buffer, f FmtFlags) {
+func (node *ShowZoneConfig) Format(ctx *FmtCtx) {
 	if node.ZoneSpecifier == (ZoneSpecifier{}) {
-		buf.WriteString("EXPERIMENTAL SHOW ZONE CONFIGURATIONS")
+		ctx.WriteString("EXPERIMENTAL SHOW ZONE CONFIGURATIONS")
 	} else {
-		buf.WriteString("EXPERIMENTAL SHOW ZONE CONFIGURATION FOR ")
-		FormatNode(buf, f, node.ZoneSpecifier)
+		ctx.WriteString("EXPERIMENTAL SHOW ZONE CONFIGURATION FOR ")
+		ctx.FormatNode(node.ZoneSpecifier)
 	}
 }
 
@@ -89,9 +85,9 @@ type SetZoneConfig struct {
 }
 
 // Format implements the NodeFormatter interface.
-func (node *SetZoneConfig) Format(buf *bytes.Buffer, f FmtFlags) {
-	buf.WriteString("ALTER ")
-	FormatNode(buf, f, node.ZoneSpecifier)
-	buf.WriteString(" EXPERIMENTAL CONFIGURE ZONE ")
-	FormatNode(buf, f, node.YAMLConfig)
+func (node *SetZoneConfig) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER ")
+	ctx.FormatNode(node.ZoneSpecifier)
+	ctx.WriteString(" EXPERIMENTAL CONFIGURE ZONE ")
+	ctx.FormatNode(node.YAMLConfig)
 }

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1394,14 +1394,16 @@ func AnonymizeStatementsForReporting(action, sqlStmts string, r interface{}) err
 		stmts, err := parser.Parse(sqlStmts)
 		if err == nil {
 			var buf bytes.Buffer
+			anonCtx := tree.MakeFmtCtx(&buf, tree.FmtAnonymize)
+			hideCtx := tree.MakeFmtCtx(&buf, tree.FmtHideConstants)
 			for _, stmt := range NewStatementList(stmts) {
-				tree.FormatNode(&buf, tree.FmtAnonymize, stmt.AST)
+				anonCtx.FormatNode(stmt.AST)
 				stmt.AST, err = parser.ParseOne(buf.String())
 				buf.Reset()
 				if err != nil {
 					buf.WriteString("[unknown]")
 				} else {
-					tree.FormatNode(&buf, tree.FmtHideConstants, stmt.AST)
+					hideCtx.FormatNode(stmt.AST)
 				}
 
 				anonymized = append(anonymized, buf.String())

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -58,7 +58,7 @@ func (p *planner) SetClusterSetting(
 		// For DEFAULT, let the value reference be nil. That's a RESET in disguise.
 		if _, ok := n.Value.(tree.DefaultVal); !ok {
 			expr := n.Value
-			if s, ok := expr.(tree.UnresolvedName); ok {
+			if s, ok := expr.(*tree.UnresolvedName); ok {
 				// Special rule for SET: because SET doesn't apply in the context
 				// of a table, SET ... = IDENT really means SET ... = 'IDENT'.
 				expr = tree.NewStrVal(tree.AsStringWithFlags(s, tree.FmtBareIdentifiers))

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -64,7 +64,7 @@ func (p *planner) SetVar(ctx context.Context, n *tree.SetVar) (planNode, error) 
 			for i, expr := range n.Values {
 				// Special rule for SET: because SET doesn't apply in the context
 				// of a table, SET ... = IDENT really means SET ... = 'IDENT'.
-				if s, ok := expr.(tree.UnresolvedName); ok {
+				if s, ok := expr.(*tree.UnresolvedName); ok {
 					expr = tree.NewStrVal(tree.AsStringWithFlags(s, tree.FmtBareIdentifiers))
 				}
 

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -93,14 +93,15 @@ func (p *planner) showCreateView(
 	ctx context.Context, tn tree.Name, desc *sqlbase.TableDescriptor,
 ) (string, error) {
 	var buf bytes.Buffer
+	fmtCtx := tree.MakeFmtCtx(&buf, tree.FmtSimple)
 	buf.WriteString("CREATE VIEW ")
-	tn.Format(&buf, tree.FmtSimple)
+	fmtCtx.FormatNode(tn)
 	buf.WriteString(" (")
 	for i, col := range desc.Columns {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		tree.Name(col.Name).Format(&buf, tree.FmtSimple)
+		fmtCtx.FormatNode(tree.Name(col.Name))
 	}
 	fmt.Fprintf(&buf, ") AS %s", desc.ViewQuery)
 	return buf.String(), nil
@@ -152,7 +153,8 @@ func (p *planner) showCreateSequence(
 ) (string, error) {
 	var buf bytes.Buffer
 	buf.WriteString("CREATE SEQUENCE ")
-	tree.FormatNode(&buf, tree.FmtSimple, tn)
+	fmtCtx := tree.MakeFmtCtx(&buf, tree.FmtSimple)
+	fmtCtx.FormatNode(tn)
 	opts := desc.SequenceOpts
 	fmt.Fprintf(&buf, " MINVALUE %d", opts.MinValue)
 	fmt.Fprintf(&buf, " MAXVALUE %d", opts.MaxValue)
@@ -336,12 +338,13 @@ func ShowCreatePartitioning(
 		fmt.Fprintf(buf, idxDesc.ColumnNames[colOffset+i])
 	}
 	buf.WriteString(`) (`)
+	fmtCtx := tree.MakeFmtCtx(buf, tree.FmtSimple)
 	for i, part := range partDesc.List {
 		if i != 0 {
 			buf.WriteString(`, `)
 		}
 		fmt.Fprintf(buf, "\n%s\tPARTITION ", indentStr)
-		tree.FormatNode(buf, tree.FmtSimple, tree.Name(part.Name))
+		fmtCtx.FormatNode(tree.Name(part.Name))
 		buf.WriteString(` VALUES IN (`)
 		for j, values := range part.Values {
 			if j != 0 {

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -90,7 +90,7 @@ func (p *planner) ShowCreateSequence(
 // showCreateView returns a valid SQL representation of the CREATE
 // VIEW statement used to create the given view.
 func (p *planner) showCreateView(
-	ctx context.Context, tn tree.Name, desc *sqlbase.TableDescriptor,
+	ctx context.Context, tn *tree.Name, desc *sqlbase.TableDescriptor,
 ) (string, error) {
 	var f struct {
 		buf bytes.Buffer
@@ -100,20 +100,20 @@ func (p *planner) showCreateView(
 	f.buf.WriteString("CREATE VIEW ")
 	f.ctx.FormatNode(tn)
 	f.buf.WriteString(" (")
-	for i, col := range desc.Columns {
+	for i := range desc.Columns {
 		if i > 0 {
 			f.buf.WriteString(", ")
 		}
-		f.ctx.FormatNode(tree.Name(col.Name))
+		f.ctx.FormatNameP(&desc.Columns[i].Name)
 	}
 	fmt.Fprintf(&f.buf, ") AS %s", desc.ViewQuery)
 	return f.buf.String(), nil
 }
 
 func (p *planner) printForeignKeyConstraint(
-	ctx context.Context, buf *bytes.Buffer, dbPrefix string, idx sqlbase.IndexDescriptor,
+	ctx context.Context, buf *bytes.Buffer, dbPrefix string, idx *sqlbase.IndexDescriptor,
 ) error {
-	fk := idx.ForeignKey
+	fk := &idx.ForeignKey
 	if !fk.IsSet() {
 		return nil
 	}
@@ -152,7 +152,7 @@ func (p *planner) printForeignKeyConstraint(
 // showCreateSequence returns a valid SQL representation of the
 // CREATE SEQUENCE statement used to create the given sequence.
 func (p *planner) showCreateSequence(
-	ctx context.Context, tn tree.Name, desc *sqlbase.TableDescriptor,
+	ctx context.Context, tn *tree.Name, desc *sqlbase.TableDescriptor,
 ) (string, error) {
 	var f struct {
 		buf bytes.Buffer
@@ -181,7 +181,7 @@ func (p *planner) showCreateSequence(
 // the prefix when the given table references other tables in the
 // current database.
 func (p *planner) showCreateTable(
-	ctx context.Context, tn tree.Name, dbPrefix string, desc *sqlbase.TableDescriptor,
+	ctx context.Context, tn *tree.Name, dbPrefix string, desc *sqlbase.TableDescriptor,
 ) (string, error) {
 	a := &sqlbase.DatumAlloc{}
 
@@ -203,9 +203,11 @@ func (p *planner) showCreateTable(
 		}
 	}
 	buf.WriteString(primary)
-	for _, idx := range append(desc.Indexes, desc.PrimaryIndex) {
-		if fk := idx.ForeignKey; fk.IsSet() {
-			fmt.Fprintf(&buf, ",\n\tCONSTRAINT %s ", tree.Name(fk.Name))
+	allIdx := append(desc.Indexes, desc.PrimaryIndex)
+	for i := range allIdx {
+		idx := &allIdx[i]
+		if fk := &idx.ForeignKey; fk.IsSet() {
+			fmt.Fprintf(&buf, ",\n\tCONSTRAINT %s ", tree.NameStringP(&fk.Name))
 			if err := p.printForeignKeyConstraint(ctx, &buf, dbPrefix, idx); err != nil {
 				return "", err
 			}
@@ -215,11 +217,11 @@ func (p *planner) showCreateTable(
 			fmt.Fprintf(&buf, ",\n\t%s", idx.SQLString(""))
 			// Showing the INTERLEAVE and PARTITION BY for the primary index are
 			// handled last.
-			if err := p.showCreateInterleave(ctx, &idx, &buf, dbPrefix); err != nil {
+			if err := p.showCreateInterleave(ctx, idx, &buf, dbPrefix); err != nil {
 				return "", err
 			}
 			if err := ShowCreatePartitioning(
-				a, desc, &idx, &idx.Partitioning, &buf, 1 /* indent */, 0, /* colOffset */
+				a, desc, idx, &idx.Partitioning, &buf, 1 /* indent */, 0, /* colOffset */
 			); err != nil {
 				return "", err
 			}
@@ -263,11 +265,18 @@ func (p *planner) showCreateTable(
 
 // quoteNames quotes and adds commas between names.
 func quoteNames(names ...string) string {
-	nameList := make(tree.NameList, len(names))
-	for i, n := range names {
-		nameList[i] = tree.Name(n)
+	var f struct {
+		buf bytes.Buffer
+		ctx tree.FmtCtx
 	}
-	return tree.AsString(nameList)
+	f.ctx = tree.MakeFmtCtx(&f.buf, tree.FmtSimple)
+	for i, name := range names {
+		if i > 0 {
+			f.buf.WriteString(", ")
+		}
+		f.ctx.FormatName(name)
+	}
+	return f.buf.String()
 }
 
 // showCreateInterleave returns an INTERLEAVE IN PARENT clause for the specified
@@ -345,12 +354,13 @@ func ShowCreatePartitioning(
 	}
 	buf.WriteString(`) (`)
 	fmtCtx := tree.MakeFmtCtx(buf, tree.FmtSimple)
-	for i, part := range partDesc.List {
+	for i := range partDesc.List {
+		part := &partDesc.List[i]
 		if i != 0 {
 			buf.WriteString(`, `)
 		}
 		fmt.Fprintf(buf, "\n%s\tPARTITION ", indentStr)
-		fmtCtx.FormatNode(tree.Name(part.Name))
+		fmtCtx.FormatNameP(&part.Name)
 		buf.WriteString(` VALUES IN (`)
 		for j, values := range part.Values {
 			if j != 0 {

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -100,32 +100,31 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	index := n.indexes[n.run.rowIdx]
 
 	cols := make([]string, 0, len(n.tableDesc.Columns))
-	addColumn := func(col sqlbase.ColumnDescriptor) {
-
+	addColumn := func(col *sqlbase.ColumnDescriptor) {
 		// TODO(dan): This is known to be a flawed way to fingerprint. Any datum
 		// with the same string representation is fingerprinted the same, even
 		// if they're different types.
 		switch col.Type.SemanticType {
 		case sqlbase.ColumnType_BYTES:
-			cols = append(cols, fmt.Sprintf("%s:::bytes", tree.Name(col.Name)))
+			cols = append(cols, fmt.Sprintf("%s:::bytes", tree.NameStringP(&col.Name)))
 		default:
-			cols = append(cols, fmt.Sprintf("%s::string::bytes", tree.Name(col.Name)))
+			cols = append(cols, fmt.Sprintf("%s::string::bytes", tree.NameStringP(&col.Name)))
 		}
 	}
 
 	if index.ID == n.tableDesc.PrimaryIndex.ID {
-		for _, col := range n.tableDesc.Columns {
-			addColumn(col)
+		for i := range n.tableDesc.Columns {
+			addColumn(&n.tableDesc.Columns[i])
 		}
 	} else {
-		colsByID := make(map[sqlbase.ColumnID]sqlbase.ColumnDescriptor)
-		for _, col := range n.tableDesc.Columns {
+		colsByID := make(map[sqlbase.ColumnID]*sqlbase.ColumnDescriptor)
+		for i := range n.tableDesc.Columns {
+			col := &n.tableDesc.Columns[i]
 			colsByID[col.ID] = col
 		}
 		colIDs := append(append(index.ColumnIDs, index.ExtraColumnIDs...), index.StoreColumnIDs...)
 		for _, colID := range colIDs {
-			col := colsByID[colID]
-			addColumn(col)
+			addColumn(colsByID[colID])
 		}
 	}
 

--- a/pkg/sql/show_var.go
+++ b/pkg/sql/show_var.go
@@ -38,10 +38,11 @@ func (p *planner) ShowVar(ctx context.Context, n *tree.ShowVar) (planNode, error
 	}
 
 	varName := lex.EscapeSQLString(name)
+	nm := tree.Name(name)
 	return p.delegateQuery(ctx, "SHOW "+varName,
 		fmt.Sprintf(
 			`SELECT value AS %[1]s FROM crdb_internal.session_variables `+
 				`WHERE variable = %[2]s`,
-			tree.Name(name).String(), varName),
+			nm.String(), varName),
 		nil, nil)
 }

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -108,8 +108,8 @@ func (n *showZoneConfigNode) startExec(params runParams) error {
 
 	// Determine the CLI specifier for the zone config that actually applies
 	// without performing another KV lookup.
-	n.run.cliSpecifier = config.CLIZoneSpecifier(ascendZoneSpecifier(
-		n.zoneSpecifier, uint32(targetID), zoneID, subzone))
+	zs := ascendZoneSpecifier(n.zoneSpecifier, uint32(targetID), zoneID, subzone)
+	n.run.cliSpecifier = config.CLIZoneSpecifier(&zs)
 
 	// Ensure subzone configs don't infect the output of config_bytes.
 	zone.Subzones = nil

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -162,7 +162,7 @@ func (p *planner) orderBy(
 			if err != nil {
 				return nil, err
 			}
-			p.hasStar = p.hasStar || hasStar
+			p.curPlan.hasStar = p.curPlan.hasStar || hasStar
 
 			if len(cols) == 0 {
 				// Nothing was expanded! No order here.

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -396,7 +396,7 @@ func (p *planner) rewriteIndexOrderings(
 					}
 				}
 				if idxDesc == nil {
-					return nil, errors.Errorf("index %q not found", tree.ErrString(o.Index))
+					return nil, errors.Errorf("index %q not found", tree.ErrString(&o.Index))
 				}
 			}
 
@@ -420,12 +420,12 @@ func (p *planner) rewriteIndexOrderings(
 			}
 
 		default:
-			return nil, errors.Errorf("unknown ORDER BY specification: %s", tree.AsString(orderBy))
+			return nil, errors.Errorf("unknown ORDER BY specification: %s", tree.ErrString(&orderBy))
 		}
 	}
 
 	if log.V(2) {
-		log.Infof(ctx, "rewritten ORDER BY clause: %s", tree.AsString(newOrderBy))
+		log.Infof(ctx, "rewritten ORDER BY clause: %s", tree.ErrString(&newOrderBy))
 	}
 	return newOrderBy, nil
 }

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -281,7 +281,8 @@ func (desc *IndexDescriptor) ColNamesFormat(buf *bytes.Buffer) {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		tree.Name(name).Format(buf, tree.FmtSimple)
+		fmtCtx := tree.MakeFmtCtx(buf, tree.FmtSimple)
+		fmtCtx.FormatNode(tree.Name(name))
 		buf.WriteByte(' ')
 		buf.WriteString(desc.ColumnDirections[i].String())
 	}

--- a/pkg/sql/statement.go
+++ b/pkg/sql/statement.go
@@ -15,8 +15,6 @@
 package sql
 
 import (
-	"bytes"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
@@ -49,11 +47,11 @@ func NewStatementList(stmts tree.StatementList) StatementList {
 func (l StatementList) String() string { return tree.AsString(l) }
 
 // Format implements the NodeFormatter interface.
-func (l StatementList) Format(buf *bytes.Buffer, f tree.FmtFlags) {
+func (l StatementList) Format(ctx *tree.FmtCtx) {
 	for i, s := range l {
 		if i > 0 {
-			buf.WriteString("; ")
+			ctx.WriteString("; ")
 		}
-		tree.FormatNode(buf, f, s.AST)
+		ctx.FormatNode(s.AST)
 	}
 }

--- a/pkg/sql/statement.go
+++ b/pkg/sql/statement.go
@@ -44,14 +44,14 @@ func NewStatementList(stmts tree.StatementList) StatementList {
 	return sl
 }
 
-func (l StatementList) String() string { return tree.AsString(l) }
+func (l *StatementList) String() string { return tree.AsString(l) }
 
 // Format implements the NodeFormatter interface.
-func (l StatementList) Format(ctx *tree.FmtCtx) {
-	for i, s := range l {
+func (l *StatementList) Format(ctx *tree.FmtCtx) {
+	for i := range *l {
 		if i > 0 {
 			ctx.WriteString("; ")
 		}
-		ctx.FormatNode(s.AST)
+		ctx.FormatNode((*l)[i].AST)
 	}
 }

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -355,7 +355,7 @@ func (v *subqueryVisitor) VisitPost(expr tree.Expr) tree.Expr {
 func (v *subqueryVisitor) replaceSubquery(
 	sub *tree.Subquery, multiRow bool, desiredColumns int,
 ) (*subquery, error) {
-	v.hasSubqueries = true
+	v.curPlan.hasSubqueries = true
 
 	// Calling newPlan() might recursively invoke replaceSubqueries, so we need
 	// to preserve the state of the visitor across the call to newPlan().

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -15,7 +15,6 @@
 package sql
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
@@ -67,15 +66,17 @@ const (
 var _ tree.TypedExpr = &subquery{}
 var _ tree.VariableExpr = &subquery{}
 
-func (s *subquery) Format(buf *bytes.Buffer, f tree.FmtFlags) {
+func (s *subquery) Format(ctx *tree.FmtCtx) {
 	if s.execMode == execModeExists {
-		buf.WriteString("EXISTS ")
+		ctx.WriteString("EXISTS ")
 	}
 	// Note: we remove the flag to print types, because subqueries can
 	// be printed in a context where type resolution has not occurred
 	// yet. We do not use FmtSimple directly however, in case the
 	// caller wants to use other flags (e.g. to anonymize identifiers).
-	tree.FormatNode(buf, tree.StripTypeFormatting(f), s.subquery)
+	noTypesCtx := *ctx
+	noTypesCtx.StripTypeFormatting()
+	noTypesCtx.FormatNode(s.subquery)
 }
 
 func (s *subquery) String() string { return tree.AsString(s) }

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -57,12 +57,12 @@ func verifyFormat(sql string) error {
 		// Cannot serialize a statement list without parsing it.
 		return nil
 	}
-	formattedSQL := tree.AsStringWithFlags(stmts, tree.FmtSimpleWithPasswords)
+	formattedSQL := tree.AsStringWithFlags(stmts, tree.FmtShowPasswords)
 	formattedStmts, err := parseStatementList(formattedSQL)
 	if err != nil {
 		return errors.Wrapf(err, "cannot parse output of Format: sql=%q, formattedSQL=%q", sql, formattedSQL)
 	}
-	formattedFormattedSQL := tree.AsStringWithFlags(formattedStmts, tree.FmtSimpleWithPasswords)
+	formattedFormattedSQL := tree.AsStringWithFlags(formattedStmts, tree.FmtShowPasswords)
 	if formattedSQL != formattedFormattedSQL {
 		return errors.Errorf("Parse followed by Format is not idempotent: %q -> %q != %q", sql, formattedSQL, formattedFormattedSQL)
 	}

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -57,12 +57,12 @@ func verifyFormat(sql string) error {
 		// Cannot serialize a statement list without parsing it.
 		return nil
 	}
-	formattedSQL := tree.AsStringWithFlags(stmts, tree.FmtShowPasswords)
+	formattedSQL := tree.AsStringWithFlags(&stmts, tree.FmtShowPasswords)
 	formattedStmts, err := parseStatementList(formattedSQL)
 	if err != nil {
 		return errors.Wrapf(err, "cannot parse output of Format: sql=%q, formattedSQL=%q", sql, formattedSQL)
 	}
-	formattedFormattedSQL := tree.AsStringWithFlags(formattedStmts, tree.FmtShowPasswords)
+	formattedFormattedSQL := tree.AsStringWithFlags(&formattedStmts, tree.FmtShowPasswords)
 	if formattedSQL != formattedFormattedSQL {
 		return errors.Errorf("Parse followed by Format is not idempotent: %q -> %q != %q", sql, formattedSQL, formattedFormattedSQL)
 	}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -219,12 +219,13 @@ func upsertExprsAndIndex(
 		updateExprs := make(tree.UpdateExprs, 0, len(insertCols))
 		for _, c := range insertCols {
 			if _, ok := indexColSet[c.ID]; !ok {
+				n := tree.Name(c.Name)
 				names := tree.UnresolvedNames{
-					tree.UnresolvedName{tree.Name(c.Name)},
+					tree.UnresolvedName{&n},
 				}
 				expr := &tree.ColumnItem{
 					TableName:  upsertExcludedTable,
-					ColumnName: tree.Name(c.Name),
+					ColumnName: n,
 				}
 				updateExprs = append(updateExprs, &tree.UpdateExpr{Names: names, Expr: expr})
 			}

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -59,8 +59,8 @@ func (p *planner) Values(
 
 	v.columns = make(sqlbase.ResultColumns, 0, numCols)
 
-	defer func(prev bool) { p.hasSubqueries = prev }(p.hasSubqueries)
-	p.hasSubqueries = false
+	defer func(prev bool) { p.curPlan.hasSubqueries = prev }(p.curPlan.hasSubqueries)
+	p.curPlan.hasSubqueries = false
 
 	for num, tuple := range n.Tuples {
 		if a, e := len(tuple.Exprs), numCols; a != e {
@@ -106,7 +106,7 @@ func (p *planner) Values(
 	// that it must always be called unless an error is returned from a planNode
 	// constructor. This would simplify the Close contract, but would make some
 	// code (like in planner.SelectClause) more messy.
-	v.isConst = !p.hasSubqueries
+	v.isConst = !p.curPlan.hasSubqueries
 	return v, nil
 }
 

--- a/pkg/sql/views.go
+++ b/pkg/sql/views.go
@@ -54,7 +54,7 @@ type planDependencies map[sqlbase.ID]planDependencyInfo
 func (d planDependencies) String() string {
 	var buf bytes.Buffer
 	for id, deps := range d {
-		fmt.Fprintf(&buf, "%d (%q):", id, tree.ErrString(tree.Name(deps.desc.Name)))
+		fmt.Fprintf(&buf, "%d (%q):", id, tree.ErrNameString(&deps.desc.Name))
 		for _, dep := range deps.deps {
 			buf.WriteString(" [")
 			if dep.IndexID != 0 {

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -197,14 +197,17 @@ func (v *planVisitor) visit(plan planNode) {
 			v.observer.attr(name, "type", jType)
 
 			if len(n.pred.leftColNames) > 0 {
-				var buf bytes.Buffer
-				fmtCtx := tree.MakeFmtCtx(&buf, tree.FmtSimple)
-				buf.WriteByte('(')
-				fmtCtx.FormatNode(n.pred.leftColNames)
-				buf.WriteString(") = (")
-				fmtCtx.FormatNode(n.pred.rightColNames)
-				buf.WriteByte(')')
-				v.observer.attr(name, "equality", buf.String())
+				var f struct {
+					buf bytes.Buffer
+					ctx tree.FmtCtx
+				}
+				f.ctx = tree.MakeFmtCtx(&f.buf, tree.FmtSimple)
+				f.buf.WriteByte('(')
+				f.ctx.FormatNode(n.pred.leftColNames)
+				f.buf.WriteString(") = (")
+				f.ctx.FormatNode(n.pred.rightColNames)
+				f.buf.WriteByte(')')
+				v.observer.attr(name, "equality", f.buf.String())
 			}
 			if len(n.mergeJoinOrdering) > 0 {
 				// The ordering refers to equality columns

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -198,10 +198,11 @@ func (v *planVisitor) visit(plan planNode) {
 
 			if len(n.pred.leftColNames) > 0 {
 				var buf bytes.Buffer
+				fmtCtx := tree.MakeFmtCtx(&buf, tree.FmtSimple)
 				buf.WriteByte('(')
-				tree.FormatNode(&buf, tree.FmtSimple, n.pred.leftColNames)
+				fmtCtx.FormatNode(n.pred.leftColNames)
 				buf.WriteString(") = (")
-				tree.FormatNode(&buf, tree.FmtSimple, n.pred.rightColNames)
+				fmtCtx.FormatNode(n.pred.rightColNames)
 				buf.WriteByte(')')
 				v.observer.attr(name, "equality", buf.String())
 			}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -203,9 +203,9 @@ func (v *planVisitor) visit(plan planNode) {
 				}
 				f.ctx = tree.MakeFmtCtx(&f.buf, tree.FmtSimple)
 				f.buf.WriteByte('(')
-				f.ctx.FormatNode(n.pred.leftColNames)
+				f.ctx.FormatNode(&n.pred.leftColNames)
 				f.buf.WriteString(") = (")
-				f.ctx.FormatNode(n.pred.rightColNames)
+				f.ctx.FormatNode(&n.pred.rightColNames)
 				f.buf.WriteByte(')')
 				v.observer.attr(name, "equality", f.buf.String())
 			}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -197,17 +197,13 @@ func (v *planVisitor) visit(plan planNode) {
 			v.observer.attr(name, "type", jType)
 
 			if len(n.pred.leftColNames) > 0 {
-				var f struct {
-					buf bytes.Buffer
-					ctx tree.FmtCtx
-				}
-				f.ctx = tree.MakeFmtCtx(&f.buf, tree.FmtSimple)
-				f.buf.WriteByte('(')
-				f.ctx.FormatNode(&n.pred.leftColNames)
-				f.buf.WriteString(") = (")
-				f.ctx.FormatNode(&n.pred.rightColNames)
-				f.buf.WriteByte(')')
-				v.observer.attr(name, "equality", f.buf.String())
+				f := tree.NewFmtCtxWithBuf(tree.FmtSimple)
+				f.WriteByte('(')
+				f.FormatNode(&n.pred.leftColNames)
+				f.WriteString(") = (")
+				f.FormatNode(&n.pred.rightColNames)
+				f.WriteByte(')')
+				v.observer.attr(name, "equality", f.CloseAndGetString())
 			}
 			if len(n.mergeJoinOrdering) > 0 {
 				// The ordering refers to equality columns

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -834,14 +834,14 @@ func (v *extractWindowFuncsVisitor) VisitPre(expr tree.Expr) (recurse bool, newE
 			// Check if a parent node above this window function is an aggregate.
 			if len(v.aggregatesSeen) > 0 {
 				v.err = errors.Errorf("aggregate function calls cannot contain window function "+
-					"call %s()", t.Func)
+					"call %s()", &t.Func)
 				return false, expr
 			}
 
 			// Make sure this window function does not contain another window function.
 			for _, argExpr := range t.Exprs {
 				if v.subWindowVisitor.ContainsWindowFunc(argExpr) {
-					v.err = fmt.Errorf("window function calls cannot be nested under %s()", t.Func)
+					v.err = fmt.Errorf("window function calls cannot be nested under %s()", &t.Func)
 					return false, expr
 				}
 			}

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -15,7 +15,6 @@
 package sql
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"sort"
@@ -918,9 +917,9 @@ type windowFuncHolder struct {
 
 func (*windowFuncHolder) Variable() {}
 
-func (w *windowFuncHolder) Format(buf *bytes.Buffer, f tree.FmtFlags) {
+func (w *windowFuncHolder) Format(ctx *tree.FmtCtx) {
 	// Avoid duplicating the type annotation by calling .Format directly.
-	w.expr.Format(buf, f)
+	w.expr.Format(ctx)
 }
 
 func (w *windowFuncHolder) String() string { return tree.AsString(w) }


### PR DESCRIPTION
I need to extract subqueries from the expression trees to fix some bugs and advance on my refactoring agenda. This, in turn, requires a more clever Format() interface for expression nodes. 

cc @RaduBerinde 