### PR TITLE
cherrypick-1.1: sql: fix tuple equality comparisons for tuples with NULL values

### DIFF
--- a/pkg/sql/index_selection.go
+++ b/pkg/sql/index_selection.go
@@ -573,6 +573,7 @@ func (v *indexInfo) makeIndexConstraints(andExprs parser.TypedExprs) (indexConst
 					continue
 				}
 
+				leftTuple := false
 				if t, ok := c.Left.(*parser.Tuple); ok {
 					// If we have a tuple comparison we need to rearrange the comparison
 					// so that the order of the columns in the tuple matches the order in
@@ -581,6 +582,7 @@ func (v *indexInfo) makeIndexConstraints(andExprs parser.TypedExprs) (indexConst
 					// 1)". Note that we don't actually need to rewrite the comparison,
 					// but simply provide a mapping from the order in the tuple to the
 					// order in the index.
+					leftTuple = true
 					for _, colID := range v.index.ColumnIDs[i:] {
 						idx := -1
 						for i, val := range t.Exprs {
@@ -644,7 +646,10 @@ func (v *indexInfo) makeIndexConstraints(andExprs parser.TypedExprs) (indexConst
 					// makeSpans() cares about.
 					// We don't simplify "a != x" to "a IS NOT NULL" in
 					// simplifyExpr because doing so affects other simplifications.
-					if *startDone || *startExpr != nil {
+					// Note that we can't use a non-NULL constraint if we have a tuple
+					// comparison. For example (a, b, c) != (1, 2, 3) passes on tuples
+					// like (NULL, 1, 1).
+					if *startDone || *startExpr != nil || leftTuple {
 						continue
 					}
 					*startExpr = parser.NewTypedComparisonExpr(

--- a/pkg/sql/index_selection_test.go
+++ b/pkg/sql/index_selection_test.go
@@ -270,6 +270,8 @@ func TestMakeConstraints(t *testing.T) {
 		{`(b, a) = (1, 2)`, `a,b`, `[(b, a) IN ((1, 2))]`},
 		{`(b, a) = (1, 2)`, `a`, `[(b, a) IN ((1, 2))]`},
 
+		{`(a, b) != (1, 2)`, `a,b`, ``},
+
 		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, `a,b`, `[(a, b) IN ((1, 2))]`},
 
 		{`a IS NULL`, `a`, `[a IS NULL]`},
@@ -499,7 +501,7 @@ func TestMakeSpans(t *testing.T) {
 		{`(a, b) < (1, 4)`, `a,b`, `/#-/1/4`, `/1/3-/#`},
 		{`(a, b) <= (1, 4)`, `a,b`, `/#-/1/5`, `/1/4-/#`},
 		{`(a, b) = (1, 4)`, `a,b`, `/1/4-/1/5`, `/1/4-/1/3`},
-		{`(a, b) != (1, 4)`, `a,b`, `/#-`, `-/#`},
+		{`(a, b) != (1, 4)`, `a,b`, `-`, `-`},
 	}
 	for _, d := range testData {
 		for _, dir := range []encoding.Direction{encoding.Ascending, encoding.Descending} {
@@ -681,6 +683,7 @@ func TestApplyConstraints(t *testing.T) {
 		{`a <= 5 AND b >= 6 AND (a, b) IN ((1, 2))`, `a,b`, `false`},
 		{`a IN (1) AND a = 1`, `a`, `<nil>`},
 		{`(a, b) = (1, 2)`, `a`, `b = 2`},
+		{`(a, b) != (1, 2)`, `a,b`, `(a, b) != (1, 2)`},
 		{`a > 1`, `a`, `<nil>`},
 		{`a < 1`, `a`, `<nil>`},
 		// The constraint (l, m) < (123, 456) must be treated as implying

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -489,56 +489,68 @@ EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, 
 0  ·       render 2  test.uvw.w              ·                                 ·
 1  scan    ·         ·                       (u, v, w, rowid[hidden,omitted])  +u,+v,+w
 1  ·       table     uvw@uvw_u_v_w_idx       ·                                 ·
-1  ·       spans     /#-                     ·                                 ·
+1  ·       spans     ALL                     ·                                 ·
 1  ·       filter    (u, v, w) != (1, 2, 3)  ·                                 ·
 
 query III
 SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 ----
-1  NULL  1
-1  NULL  2
-1  1     NULL
-1  1     1
-1  1     2
-1  1     3
-1  2     1
-1  2     2
-1  3     NULL
-1  3     1
-1  3     2
-1  3     3
-2  NULL  NULL
-2  NULL  1
-2  NULL  2
-2  NULL  3
-2  1     NULL
-2  1     1
-2  1     2
-2  1     3
-2  2     NULL
-2  2     1
-2  2     2
-2  2     3
-2  3     NULL
-2  3     1
-2  3     2
-2  3     3
-3  NULL  NULL
-3  NULL  1
-3  NULL  2
-3  NULL  3
-3  1     NULL
-3  1     1
-3  1     2
-3  1     3
-3  2     NULL
-3  2     1
-3  2     2
-3  2     3
-3  3     NULL
-3  3     1
-3  3     2
-3  3     3
+NULL  NULL  1
+NULL  NULL  2
+NULL  1     NULL
+NULL  1     1
+NULL  1     2
+NULL  1     3
+NULL  2     1
+NULL  2     2
+NULL  3     NULL
+NULL  3     1
+NULL  3     2
+NULL  3     3
+1     NULL  1
+1     NULL  2
+1     1     NULL
+1     1     1
+1     1     2
+1     1     3
+1     2     1
+1     2     2
+1     3     NULL
+1     3     1
+1     3     2
+1     3     3
+2     NULL  NULL
+2     NULL  1
+2     NULL  2
+2     NULL  3
+2     1     NULL
+2     1     1
+2     1     2
+2     1     3
+2     2     NULL
+2     2     1
+2     2     2
+2     2     3
+2     3     NULL
+2     3     1
+2     3     2
+2     3     3
+3     NULL  NULL
+3     NULL  1
+3     NULL  2
+3     NULL  3
+3     1     NULL
+3     1     1
+3     1     2
+3     1     3
+3     2     NULL
+3     2     1
+3     2     2
+3     2     3
+3     3     NULL
+3     3     1
+3     3     2
+3     3     3
 
 query ITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -221,3 +221,401 @@ query B
 SELECT (1, 2) > (1.0, 2.0)
 ----
 false
+
+statement ok
+CREATE TABLE uvw (
+  u INT,
+  v INT,
+  w INT,
+  INDEX (u,v,w)
+)
+
+statement ok
+INSERT INTO uvw SELECT u, v, w FROM
+  GENERATE_SERIES(0, 3) AS u(u),
+  GENERATE_SERIES(0, 3) AS v(v),
+  GENERATE_SERIES(0, 3) AS w(w);
+UPDATE uvw SET u = NULL WHERE u = 0;
+UPDATE uvw SET v = NULL WHERE v = 0;
+UPDATE uvw SET w = NULL WHERE w = 0
+
+query III
+SELECT * FROM uvw ORDER BY u, v, w
+----
+NULL  NULL  NULL
+NULL  NULL  1
+NULL  NULL  2
+NULL  NULL  3
+NULL  1     NULL
+NULL  1     1
+NULL  1     2
+NULL  1     3
+NULL  2     NULL
+NULL  2     1
+NULL  2     2
+NULL  2     3
+NULL  3     NULL
+NULL  3     1
+NULL  3     2
+NULL  3     3
+1     NULL  NULL
+1     NULL  1
+1     NULL  2
+1     NULL  3
+1     1     NULL
+1     1     1
+1     1     2
+1     1     3
+1     2     NULL
+1     2     1
+1     2     2
+1     2     3
+1     3     NULL
+1     3     1
+1     3     2
+1     3     3
+2     NULL  NULL
+2     NULL  1
+2     NULL  2
+2     NULL  3
+2     1     NULL
+2     1     1
+2     1     2
+2     1     3
+2     2     NULL
+2     2     1
+2     2     2
+2     2     3
+2     3     NULL
+2     3     1
+2     3     2
+2     3     3
+3     NULL  NULL
+3     NULL  1
+3     NULL  2
+3     NULL  3
+3     1     NULL
+3     1     1
+3     1     2
+3     1     3
+3     2     NULL
+3     2     1
+3     2     2
+3     2     3
+3     3     NULL
+3     3     1
+3     3     2
+3     3     3
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
+----
+0  render  ·         ·                       (u, v, w)                         +u,+v,+w
+0  ·       render 0  test.uvw.u              ·                                 ·
+0  ·       render 1  test.uvw.v              ·                                 ·
+0  ·       render 2  test.uvw.w              ·                                 ·
+1  scan    ·         ·                       (u, v, w, rowid[hidden,omitted])  +u,+v,+w
+1  ·       table     uvw@uvw_u_v_w_idx       ·                                 ·
+1  ·       spans     /1/2/3-                 ·                                 ·
+1  ·       filter    (u, v, w) >= (1, 2, 3)  ·                                 ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
+----
+1  2     3
+1  3     NULL
+1  3     1
+1  3     2
+1  3     3
+2  NULL  NULL
+2  NULL  1
+2  NULL  2
+2  NULL  3
+2  1     NULL
+2  1     1
+2  1     2
+2  1     3
+2  2     NULL
+2  2     1
+2  2     2
+2  2     3
+2  3     NULL
+2  3     1
+2  3     2
+2  3     3
+3  NULL  NULL
+3  NULL  1
+3  NULL  2
+3  NULL  3
+3  1     NULL
+3  1     1
+3  1     2
+3  1     3
+3  2     NULL
+3  2     1
+3  2     2
+3  2     3
+3  3     NULL
+3  3     1
+3  3     2
+3  3     3
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
+----
+0  render  ·         ·                      (u, v, w)                         +u,+v,+w
+0  ·       render 0  test.uvw.u             ·                                 ·
+0  ·       render 1  test.uvw.v             ·                                 ·
+0  ·       render 2  test.uvw.w             ·                                 ·
+1  scan    ·         ·                      (u, v, w, rowid[hidden,omitted])  +u,+v,+w
+1  ·       table     uvw@uvw_u_v_w_idx      ·                                 ·
+1  ·       spans     /2/1/2-                ·                                 ·
+1  ·       filter    (u, v, w) > (2, 1, 1)  ·                                 ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
+----
+2  1     2
+2  1     3
+2  2     NULL
+2  2     1
+2  2     2
+2  2     3
+2  3     NULL
+2  3     1
+2  3     2
+2  3     3
+3  NULL  NULL
+3  NULL  1
+3  NULL  2
+3  NULL  3
+3  1     NULL
+3  1     1
+3  1     2
+3  1     3
+3  2     NULL
+3  2     1
+3  2     2
+3  2     3
+3  3     NULL
+3  3     1
+3  3     2
+3  3     3
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
+----
+0  render  ·         ·                       (u, v, w)                         +u,+v,+w
+0  ·       render 0  test.uvw.u              ·                                 ·
+0  ·       render 1  test.uvw.v              ·                                 ·
+0  ·       render 2  test.uvw.w              ·                                 ·
+1  scan    ·         ·                       (u, v, w, rowid[hidden,omitted])  +u,+v,+w
+1  ·       table     uvw@uvw_u_v_w_idx       ·                                 ·
+1  ·       spans     /#-/2/3/2               ·                                 ·
+1  ·       filter    (u, v, w) <= (2, 3, 1)  ·                                 ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
+----
+1  NULL  NULL
+1  NULL  1
+1  NULL  2
+1  NULL  3
+1  1     NULL
+1  1     1
+1  1     2
+1  1     3
+1  2     NULL
+1  2     1
+1  2     2
+1  2     3
+1  3     NULL
+1  3     1
+1  3     2
+1  3     3
+2  1     NULL
+2  1     1
+2  1     2
+2  1     3
+2  2     NULL
+2  2     1
+2  2     2
+2  2     3
+2  3     1
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
+----
+0  render  ·         ·                      (u, v, w)                         +u,+v,+w
+0  ·       render 0  test.uvw.u             ·                                 ·
+0  ·       render 1  test.uvw.v             ·                                 ·
+0  ·       render 2  test.uvw.w             ·                                 ·
+1  scan    ·         ·                      (u, v, w, rowid[hidden,omitted])  +u,+v,+w
+1  ·       table     uvw@uvw_u_v_w_idx      ·                                 ·
+1  ·       spans     /#-/2/2/2              ·                                 ·
+1  ·       filter    (u, v, w) < (2, 2, 2)  ·                                 ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
+----
+1  NULL  NULL
+1  NULL  1
+1  NULL  2
+1  NULL  3
+1  1     NULL
+1  1     1
+1  1     2
+1  1     3
+1  2     NULL
+1  2     1
+1  2     2
+1  2     3
+1  3     NULL
+1  3     1
+1  3     2
+1  3     3
+2  1     NULL
+2  1     1
+2  1     2
+2  1     3
+2  2     1
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
+----
+0  render  ·         ·                       (u, v, w)                         +u,+v,+w
+0  ·       render 0  test.uvw.u              ·                                 ·
+0  ·       render 1  test.uvw.v              ·                                 ·
+0  ·       render 2  test.uvw.w              ·                                 ·
+1  scan    ·         ·                       (u, v, w, rowid[hidden,omitted])  +u,+v,+w
+1  ·       table     uvw@uvw_u_v_w_idx       ·                                 ·
+1  ·       spans     /#-                     ·                                 ·
+1  ·       filter    (u, v, w) != (1, 2, 3)  ·                                 ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
+----
+1  NULL  1
+1  NULL  2
+1  1     NULL
+1  1     1
+1  1     2
+1  1     3
+1  2     1
+1  2     2
+1  3     NULL
+1  3     1
+1  3     2
+1  3     3
+2  NULL  NULL
+2  NULL  1
+2  NULL  2
+2  NULL  3
+2  1     NULL
+2  1     1
+2  1     2
+2  1     3
+2  2     NULL
+2  2     1
+2  2     2
+2  2     3
+2  3     NULL
+2  3     1
+2  3     2
+2  3     3
+3  NULL  NULL
+3  NULL  1
+3  NULL  2
+3  NULL  3
+3  1     NULL
+3  1     1
+3  1     2
+3  1     3
+3  2     NULL
+3  2     1
+3  2     2
+3  2     3
+3  3     NULL
+3  3     1
+3  3     2
+3  3     3
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
+----
+0  render  ·         ·                          (u, v, w)                         +u,+v,+w
+0  ·       render 0  test.uvw.u                 ·                                 ·
+0  ·       render 1  test.uvw.v                 ·                                 ·
+0  ·       render 2  test.uvw.w                 ·                                 ·
+1  scan    ·         ·                          (u, v, w, rowid[hidden,omitted])  +u,+v,+w
+1  ·       table     uvw@uvw_u_v_w_idx          ·                                 ·
+1  ·       spans     ALL                        ·                                 ·
+1  ·       filter    (u, v, w) >= (1, NULL, 3)  ·                                 ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
+----
+2  NULL  NULL
+2  NULL  1
+2  NULL  2
+2  NULL  3
+2  1     NULL
+2  1     1
+2  1     2
+2  1     3
+2  2     NULL
+2  2     1
+2  2     2
+2  2     3
+2  3     NULL
+2  3     1
+2  3     2
+2  3     3
+3  NULL  NULL
+3  NULL  1
+3  NULL  2
+3  NULL  3
+3  1     NULL
+3  1     1
+3  1     2
+3  1     3
+3  2     NULL
+3  2     1
+3  2     2
+3  2     3
+3  3     NULL
+3  3     1
+3  3     2
+3  3     3
+
+query ITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
+----
+0  render  ·         ·                         (u, v, w)                         +u,+v,+w
+0  ·       render 0  test.uvw.u                ·                                 ·
+0  ·       render 1  test.uvw.v                ·                                 ·
+0  ·       render 2  test.uvw.w                ·                                 ·
+1  scan    ·         ·                         (u, v, w, rowid[hidden,omitted])  +u,+v,+w
+1  ·       table     uvw@uvw_u_v_w_idx         ·                                 ·
+1  ·       spans     ALL                       ·                                 ·
+1  ·       filter    (u, v, w) < (2, NULL, 3)  ·                                 ·
+
+query III
+SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
+----
+1  NULL  NULL
+1  NULL  1
+1  NULL  2
+1  NULL  3
+1  1     NULL
+1  1     1
+1  1     2
+1  1     3
+1  2     NULL
+1  2     1
+1  2     2
+1  2     3
+1  3     NULL
+1  3     1
+1  3     2
+1  3     3

--- a/pkg/sql/parser/eval.go
+++ b/pkg/sql/parser/eval.go
@@ -1658,13 +1658,28 @@ func cmpOpScalarLEFn(ctx *EvalContext, left, right Datum) (Datum, error) {
 
 func cmpOpTupleFn(ctx *EvalContext, left, right DTuple, op ComparisonOperator) Datum {
 	cmp := 0
+	sawNull := false
 	for i, leftElem := range left.D {
 		rightElem := right.D[i]
 		// Like with cmpOpScalarFn, check for values that need to be handled
 		// differently than when ordering Datums.
 		if leftElem == DNull || rightElem == DNull {
-			// If either Datum is NULL, the result of the comparison is NULL.
-			return DNull
+			if op == EQ {
+				// If either Datum is NULL and the op is EQ, we continue the
+				// comparison and the result is only NULL if the other (non-NULL)
+				// elements are equal. This is because NULL is thought of as "unknown",
+				// so a NULL equality comparison does not prevent the equality from
+				// being proven false, but does prevent it from being proven true.
+				sawNull = true
+				continue
+			} else {
+				// If either Datum is NULL and the op is not EQ, we short-circuit
+				// the evaluation and the result of the comparison is NULL. This is
+				// because NULL is thought of as "unknown" and tuple inequality is
+				// defined lexicographically, so once a NULL comparison is seen,
+				// the result of the entire tuple comparison is unknown.
+				return DNull
+			}
 		}
 		if isNaN(leftElem) || isNaN(rightElem) {
 			// If either Datum is NaN, the result of the comparison is False.
@@ -1675,7 +1690,14 @@ func cmpOpTupleFn(ctx *EvalContext, left, right DTuple, op ComparisonOperator) D
 			break
 		}
 	}
-	return boolFromCmp(cmp, op)
+	b := boolFromCmp(cmp, op)
+	if b == DBoolTrue && sawNull {
+		// The op is EQ and all non-NULL elements are equal, but we saw at least
+		// one NULL element. Since NULL comparisons are treated as unknown, the
+		// result of the comparison becomes unknown (NULL).
+		return DNull
+	}
+	return b
 }
 
 func makeEvalTupleIn(typ Type) CmpOp {


### PR DESCRIPTION
Cherry-picking the fixes in #21115 and #21230. CC @cockroachdb/release 

#### sql: fix tuple equality comparisons for tuples with NULL values

Fixes #21113.

Previously, tuple equality evaluation would short-circuit on NULL elements
just like tuple inequality evaluation. This behavior was desired for tuple
comparisons using inequality operators but was a deviation from the SQL
standard for tuple comparisons using the equality operator.

In other words, `(1, 2, 4) > (1, NULL, 5)` evaluated to `NULL`, correctly,
but `(1, 2, 4) = (1, NULL, 5)` also evaluated to `NULL`, incorrectly. Instead,
the latter expression should have evaluated to `false`. This is because tuple
comparison should only return NULL when the non-NULL elements are not sufficient
to determine the result. Since tuple inequality is defined lexicographically,
the first NULL element encountered causes ambiguity. For tuple equality, it
may still be possible to evaluate the expression even after NULL elements are
seen, so the evaluation cannot short circuit.

This change fixes the behavior for tuple equality, bringing it inline with
PostgreSQL and MySQL.

Note that we already had very similar logic for the `IN`, `ANY`, `SOME`, and
`ALL` comparison operators, so the behavior replaced here must have simply
been an oversight when tuple comparison was introduced.

Release note (sql change/bug fix): Fix tuple equality to evaluate correctly
in the presence of NULL elements.

#### sql: fix not-NULL spans for tuple !=

PR #21115 fixed the logic for `tuple != tuple` which was incorrectly handling
NULLs. This change fixes the corresponding logic in the index selection code
(which is incorrectly generating `/!NULL` spans).

Release note (sql change/bug fix): Fix tuple equality to evaluate correctly
in the presence of NULL elements.