### PR TITLE
libroach: reduce clang-format line length to 100.

### DIFF
--- a/c-deps/libroach/.clang-format
+++ b/c-deps/libroach/.clang-format
@@ -42,7 +42,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     120
+ColumnLimit:     100
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true

--- a/c-deps/libroach/ccl/crypto_utils.cc
+++ b/c-deps/libroach/ccl/crypto_utils.cc
@@ -15,8 +15,9 @@
 std::string HexString(const std::string& s) {
   std::string value;
 
-  CryptoPP::StringSource ss(s, true /* PumpAll */,
-                            new CryptoPP::HexEncoder(new CryptoPP::StringSink(value), false /* uppercase */));
+  CryptoPP::StringSource ss(
+      s, true /* PumpAll */,
+      new CryptoPP::HexEncoder(new CryptoPP::StringSink(value), false /* uppercase */));
 
   return value;
 }

--- a/c-deps/libroach/ccl/db.cc
+++ b/c-deps/libroach/ccl/db.cc
@@ -19,7 +19,8 @@
 
 const DBStatus kSuccess = {NULL, 0};
 
-// DBOpenHook parses the extra_options field of DBOptions and initializes encryption objects if needed.
+// DBOpenHook parses the extra_options field of DBOptions and initializes encryption objects if
+// needed.
 rocksdb::Status DBOpenHook(const std::string& db_dir, const DBOptions db_opts) {
   DBSlice options = db_opts.extra_options;
   if (options.len == 0) {
@@ -41,8 +42,8 @@ rocksdb::Status DBOpenHook(const std::string& db_dir, const DBOptions db_opts) {
             << "  rotation duration: " << opts.data_key_rotation_period() << "\n";
 
   // Initialize store key manager.
-  std::shared_ptr<FileKeyManager> store_key_manager(
-      new FileKeyManager(rocksdb::Env::Default(), opts.key_files().current_key(), opts.key_files().old_key()));
+  std::shared_ptr<FileKeyManager> store_key_manager(new FileKeyManager(
+      rocksdb::Env::Default(), opts.key_files().current_key(), opts.key_files().old_key()));
   rocksdb::Status status = store_key_manager->LoadKeys();
   if (!status.ok()) {
     return status;
@@ -67,7 +68,8 @@ rocksdb::Status DBOpenHook(const std::string& db_dir, const DBOptions db_opts) {
   return rocksdb::Status::InvalidArgument("encryption is not supported");
 }
 
-DBStatus DBBatchReprVerify(DBSlice repr, DBKey start, DBKey end, int64_t now_nanos, MVCCStatsResult* stats) {
+DBStatus DBBatchReprVerify(DBSlice repr, DBKey start, DBKey end, int64_t now_nanos,
+                           MVCCStatsResult* stats) {
   const rocksdb::Comparator* kComparator = CockroachComparator();
 
   // TODO(dan): Inserting into a batch just to iterate over it is unfortunate.

--- a/c-deps/libroach/ccl/key_manager.h
+++ b/c-deps/libroach/ccl/key_manager.h
@@ -28,10 +28,12 @@ static const std::string kKeyRegistryFilename = "COCKROACHDB_DATA_KEYS";
 namespace KeyManagerUtils {
 
 // Read key from a file.
-rocksdb::Status KeyFromFile(rocksdb::Env* env, const std::string& path, enginepbccl::SecretKey* key);
+rocksdb::Status KeyFromFile(rocksdb::Env* env, const std::string& path,
+                            enginepbccl::SecretKey* key);
 
 // Generate a key based on the characteristics of `store_info`.
-rocksdb::Status KeyFromKeyInfo(rocksdb::Env* env, const enginepbccl::KeyInfo& store_info, enginepbccl::SecretKey* key);
+rocksdb::Status KeyFromKeyInfo(rocksdb::Env* env, const enginepbccl::KeyInfo& store_info,
+                               enginepbccl::SecretKey* key);
 
 // Validate a registry. This should be called before using a registry.
 rocksdb::Status ValidateRegistry(enginepbccl::DataKeysRegistry* registry);
@@ -79,7 +81,8 @@ class KeyManager {
 class FileKeyManager : public KeyManager {
  public:
   // `env` is owned by the caller.
-  explicit FileKeyManager(rocksdb::Env* env, const std::string& active_key_path, const std::string& old_key_path)
+  explicit FileKeyManager(rocksdb::Env* env, const std::string& active_key_path,
+                          const std::string& old_key_path)
       : env_(env), active_key_path_(active_key_path), old_key_path_(old_key_path) {}
 
   // LoadKeys tells the key manager to read and validate the key files.
@@ -92,7 +95,8 @@ class FileKeyManager : public KeyManager {
 
   virtual std::unique_ptr<enginepbccl::SecretKey> GetKey(const std::string& id) override {
     if (active_key_ != nullptr && active_key_->info().key_id() == id) {
-      return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*active_key_.get()));
+      return std::unique_ptr<enginepbccl::SecretKey>(
+          new enginepbccl::SecretKey(*active_key_.get()));
     }
     if (old_key_ != nullptr && old_key_->info().key_id() == id) {
       return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*old_key_.get()));
@@ -142,8 +146,8 @@ class DataKeyManager : public KeyManager {
   std::string registry_path_;
   int64_t rotation_period_;
 
-  // The registry is read-only and can only be swapped for another one, it cannot be mutated in place.
-  // mu_ must be held for any registry access.
+  // The registry is read-only and can only be swapped for another one, it cannot be mutated in
+  // place. mu_ must be held for any registry access.
   // TODO(mberhault): use a shared_mutex for multiple read-only holders.
   std::mutex mu_;
   std::unique_ptr<enginepbccl::DataKeysRegistry> registry_;

--- a/c-deps/libroach/ccl/key_manager_test.cc
+++ b/c-deps/libroach/ccl/key_manager_test.cc
@@ -99,13 +99,15 @@ struct testKey {
   testKey() : testKey("") {}
   // Copy constructor.
   testKey(const testKey& k)
-      : testKey(k.id, k.key, k.type, k.approximate_timestamp, k.source, k.was_exposed, k.parent_key_id) {}
+      : testKey(k.id, k.key, k.type, k.approximate_timestamp, k.source, k.was_exposed,
+                k.parent_key_id) {}
   // Key ID only (to test key existence).
   testKey(std::string id) : testKey(id, "", enginepbccl::Plaintext, 0, "") {}
-  testKey(std::string id, std::string key, enginepbccl::EncryptionType type, int64_t timestamp, std::string source)
+  testKey(std::string id, std::string key, enginepbccl::EncryptionType type, int64_t timestamp,
+          std::string source)
       : testKey(id, key, type, timestamp, source, false, "") {}
-  testKey(std::string id, std::string key, enginepbccl::EncryptionType type, int64_t timestamp, std::string source,
-          bool exposed, std::string parent)
+  testKey(std::string id, std::string key, enginepbccl::EncryptionType type, int64_t timestamp,
+          std::string source, bool exposed, std::string parent)
       : id(id),
         key(key),
         type(type),
@@ -131,28 +133,30 @@ enginepbccl::SecretKey secretKeyFromTestKey(const testKey& k) {
   return sk;
 }
 
-rocksdb::Status compareNonRandomKeyInfo(const enginepbccl::KeyInfo& actual, const testKey& expected) {
+rocksdb::Status compareNonRandomKeyInfo(const enginepbccl::KeyInfo& actual,
+                                        const testKey& expected) {
   if (actual.encryption_type() != expected.type) {
-    return rocksdb::Status::InvalidArgument(
-        fmt::StringPrintf("actual type %d does not match expected type %d", actual.encryption_type(), expected.type));
+    return rocksdb::Status::InvalidArgument(fmt::StringPrintf(
+        "actual type %d does not match expected type %d", actual.encryption_type(), expected.type));
   }
 
   auto diff = actual.creation_time() - expected.approximate_timestamp;
   if (diff > 5 || diff < -5) {
     return rocksdb::Status::InvalidArgument(
-        fmt::StringPrintf("actual creation time %lld does not match expected timestamp %lld", actual.creation_time(),
-                          expected.approximate_timestamp));
+        fmt::StringPrintf("actual creation time %lld does not match expected timestamp %lld",
+                          actual.creation_time(), expected.approximate_timestamp));
   }
 
   if (actual.source() != expected.source) {
     return rocksdb::Status::InvalidArgument(
-        fmt::StringPrintf("actual source \"%s\" does not match expected source \"%s\"", actual.source().c_str(),
-                          expected.source.c_str()));
+        fmt::StringPrintf("actual source \"%s\" does not match expected source \"%s\"",
+                          actual.source().c_str(), expected.source.c_str()));
   }
 
   if (actual.was_exposed() != expected.was_exposed) {
-    return rocksdb::Status::InvalidArgument(fmt::StringPrintf(
-        "actual was_exposed %d does not match expected was_exposed %d", actual.was_exposed(), expected.was_exposed));
+    return rocksdb::Status::InvalidArgument(
+        fmt::StringPrintf("actual was_exposed %d does not match expected was_exposed %d",
+                          actual.was_exposed(), expected.was_exposed));
   }
   return rocksdb::Status::OK();
 }
@@ -164,16 +168,18 @@ rocksdb::Status compareKeyInfo(const enginepbccl::KeyInfo& actual, const testKey
   }
 
   if (actual.key_id() != expected.id) {
-    return rocksdb::Status::InvalidArgument(fmt::StringPrintf(
-        "actual key_id \"%s\" does not match expected key_id \"%s\"", actual.key_id().c_str(), expected.id.c_str()));
+    return rocksdb::Status::InvalidArgument(
+        fmt::StringPrintf("actual key_id \"%s\" does not match expected key_id \"%s\"",
+                          actual.key_id().c_str(), expected.id.c_str()));
   }
   return rocksdb::Status::OK();
 }
 
 rocksdb::Status compareKey(const enginepbccl::SecretKey& actual, const testKey& expected) {
   if (actual.key() != expected.key) {
-    return rocksdb::Status::InvalidArgument(fmt::StringPrintf("actual key \"%s\" does not match expected key \"%s\"",
-                                                              actual.key().c_str(), expected.key.c_str()));
+    return rocksdb::Status::InvalidArgument(
+        fmt::StringPrintf("actual key \"%s\" does not match expected key \"%s\"",
+                          actual.key().c_str(), expected.key.c_str()));
   }
   return compareKeyInfo(actual.info(), expected);
 }
@@ -378,11 +384,14 @@ TEST(DataKeyManager, KeyFromKeyInfo) {
       {testKey("plain", "", enginepbccl::Plaintext, now, "plain"), "",
        testKey("plain", "", enginepbccl::Plaintext, now, "data key manager", true, "plain")},
       {testKey(key_id_128, "", enginepbccl::AES128_CTR, now - 86400, "128.key"), "",
-       testKey("someid", "somekey", enginepbccl::AES128_CTR, now, "data key manager", false, key_id_128)},
+       testKey("someid", "somekey", enginepbccl::AES128_CTR, now, "data key manager", false,
+               key_id_128)},
       {testKey(key_id_192, "", enginepbccl::AES192_CTR, now + 86400, "192.key"), "",
-       testKey("someid", "somekey", enginepbccl::AES192_CTR, now, "data key manager", false, key_id_192)},
+       testKey("someid", "somekey", enginepbccl::AES192_CTR, now, "data key manager", false,
+               key_id_192)},
       {testKey(key_id_256, "", enginepbccl::AES256_CTR, 0, "256.key"), "",
-       testKey("someid", "somekey", enginepbccl::AES256_CTR, now, "data key manager", false, key_id_256)},
+       testKey("someid", "somekey", enginepbccl::AES256_CTR, now, "data key manager", false,
+               key_id_256)},
   };
 
   int test_num = 0;
@@ -390,7 +399,8 @@ TEST(DataKeyManager, KeyFromKeyInfo) {
     SCOPED_TRACE(fmt::StringPrintf("Testing #%d", test_num++));
 
     enginepbccl::SecretKey new_key;
-    auto status = KeyManagerUtils::KeyFromKeyInfo(env.get(), keyInfoFromTestKey(t.store_info), &new_key);
+    auto status =
+        KeyManagerUtils::KeyFromKeyInfo(env.get(), keyInfoFromTestKey(t.store_info), &new_key);
     EXPECT_ERR(status, t.error);
     if (!status.ok()) {
       continue;
@@ -451,23 +461,27 @@ TEST(DataKeyManager, SetStoreKey) {
       {
           testKey(key_id_128, "", enginepbccl::AES128_CTR, now - 86400, "128.key"),
           "",
-          testKey(key_id_128, "", enginepbccl::AES128_CTR, now, "data key manager", false, key_id_128),
+          testKey(key_id_128, "", enginepbccl::AES128_CTR, now, "data key manager", false,
+                  key_id_128),
       },
       {
           // Setting the same store key does nothing.
           testKey(key_id_128, "", enginepbccl::AES128_CTR, now - 86400, "128.key"),
           "",
           // We add it again because we don't have a "skip" thing. It's find if it's there twice.
-          testKey(key_id_128, "", enginepbccl::AES128_CTR, now, "data key manager", false, key_id_128),
+          testKey(key_id_128, "", enginepbccl::AES128_CTR, now, "data key manager", false,
+                  key_id_128),
       },
       {
           testKey(key_id_256, "", enginepbccl::AES256_CTR, now - 86400, "256.key"),
           "",
-          testKey(key_id_256, "", enginepbccl::AES256_CTR, now, "data key manager", false, key_id_256),
+          testKey(key_id_256, "", enginepbccl::AES256_CTR, now, "data key manager", false,
+                  key_id_256),
       },
       {
           testKey(key_id_128, "", enginepbccl::AES128_CTR, now - 86400, "128.key"),
-          fmt::StringPrintf("new active store key ID %s already exists as an inactive key. This is really dangerous.",
+          fmt::StringPrintf("new active store key ID %s already exists as an inactive key. This is "
+                            "really dangerous.",
                             key_id_128.c_str()),
           {},
       },
@@ -486,7 +500,8 @@ TEST(DataKeyManager, SetStoreKey) {
     SCOPED_TRACE(fmt::StringPrintf("Testing #%d", test_num++));
 
     // Set new active store key.
-    auto store_info = std::unique_ptr<enginepbccl::KeyInfo>(new enginepbccl::KeyInfo(keyInfoFromTestKey(t.store_info)));
+    auto store_info = std::unique_ptr<enginepbccl::KeyInfo>(
+        new enginepbccl::KeyInfo(keyInfoFromTestKey(t.store_info)));
     auto status = dkm.SetActiveStoreKey(std::move(store_info));
     EXPECT_ERR(status, t.error);
     if (status.ok()) {
@@ -565,19 +580,22 @@ TEST(DataKeyManager, RotateKey) {
           // New key on store key change.
           testKey(key_id_128, "", enginepbccl::AES128_CTR, 0, "128.key"),
           20,
-          testKey("not checked", "not checked", enginepbccl::AES128_CTR, 20, "data key manager", false, key_id_128),
+          testKey("not checked", "not checked", enginepbccl::AES128_CTR, 20, "data key manager",
+                  false, key_id_128),
       },
       {
           // Less than 10 seconds: no change.
           testKey(key_id_128, "", enginepbccl::AES128_CTR, 0, "128.key"),
           29,
-          testKey("not checked", "not checked", enginepbccl::AES128_CTR, 20, "data key manager", false, key_id_128),
+          testKey("not checked", "not checked", enginepbccl::AES128_CTR, 20, "data key manager",
+                  false, key_id_128),
       },
       {
           // Exactly 10 seconds: new key.
           testKey(key_id_128, "", enginepbccl::AES128_CTR, 0, "128.key"),
           30,
-          testKey("not checked", "not checked", enginepbccl::AES128_CTR, 30, "data key manager", false, key_id_128),
+          testKey("not checked", "not checked", enginepbccl::AES128_CTR, 30, "data key manager",
+                  false, key_id_128),
       },
   };
 
@@ -590,7 +608,8 @@ TEST(DataKeyManager, RotateKey) {
     env->SetCurrentTime(t.current_time);
 
     // Set new active store key.
-    auto store_info = std::unique_ptr<enginepbccl::KeyInfo>(new enginepbccl::KeyInfo(keyInfoFromTestKey(t.store_info)));
+    auto store_info = std::unique_ptr<enginepbccl::KeyInfo>(
+        new enginepbccl::KeyInfo(keyInfoFromTestKey(t.store_info)));
     auto status = dkm.SetActiveStoreKey(std::move(store_info));
     ASSERT_OK(status);
 

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -65,7 +65,8 @@ char* __attribute__((weak)) prettyPrintKey(DBKey) { die_missing_symbol(__func__)
 // DBOpenHook in OSS mode only verifies that no extra options are specified.
 __attribute__((weak)) rocksdb::Status DBOpenHook(const std::string& db_dir, const DBOptions opts) {
   if (opts.extra_options.len != 0) {
-    return rocksdb::Status::InvalidArgument("DBOptions has extra_options, but OSS code cannot handle them");
+    return rocksdb::Status::InvalidArgument(
+        "DBOptions has extra_options, but OSS code cannot handle them");
   }
   return rocksdb::Status::OK();
 }
@@ -110,7 +111,12 @@ struct DBImpl : public DBEngine {
   // Either env can be NULL.
   DBImpl(rocksdb::DB* r, rocksdb::Env* m, std::shared_ptr<rocksdb::Cache> bc,
          std::shared_ptr<DBEventListener> event_listener, rocksdb::Env* s_env)
-      : DBEngine(r), switching_env(s_env), memenv(m), rep_deleter(r), block_cache(bc), event_listener(event_listener) {}
+      : DBEngine(r),
+        switching_env(s_env),
+        memenv(m),
+        rep_deleter(r),
+        block_cache(bc),
+        event_listener(event_listener) {}
   virtual ~DBImpl() {
     const rocksdb::Options& opts = rep->GetOptions();
     const std::shared_ptr<rocksdb::Statistics>& s = opts.statistics;
@@ -260,7 +266,8 @@ std::string EncodePrefixNextKey(DBSlice k) {
   return s;
 }
 
-WARN_UNUSED_RESULT bool SplitKey(rocksdb::Slice buf, rocksdb::Slice* key, rocksdb::Slice* timestamp) {
+WARN_UNUSED_RESULT bool SplitKey(rocksdb::Slice buf, rocksdb::Slice* key,
+                                 rocksdb::Slice* timestamp) {
   if (buf.empty()) {
     return false;
   }
@@ -273,7 +280,8 @@ WARN_UNUSED_RESULT bool SplitKey(rocksdb::Slice buf, rocksdb::Slice* key, rocksd
   return true;
 }
 
-WARN_UNUSED_RESULT bool DecodeTimestamp(rocksdb::Slice* timestamp, int64_t* wall_time, int32_t* logical) {
+WARN_UNUSED_RESULT bool DecodeTimestamp(rocksdb::Slice* timestamp, int64_t* wall_time,
+                                        int32_t* logical) {
   uint64_t w;
   if (!DecodeUint64(timestamp, &w)) {
     return false;
@@ -291,7 +299,8 @@ WARN_UNUSED_RESULT bool DecodeTimestamp(rocksdb::Slice* timestamp, int64_t* wall
   return true;
 }
 
-WARN_UNUSED_RESULT bool DecodeHLCTimestamp(rocksdb::Slice buf, cockroach::util::hlc::Timestamp* timestamp) {
+WARN_UNUSED_RESULT bool DecodeHLCTimestamp(rocksdb::Slice buf,
+                                           cockroach::util::hlc::Timestamp* timestamp) {
   int64_t wall_time;
   int32_t logical;
   if (!DecodeTimestamp(&buf, &wall_time, &logical)) {
@@ -302,7 +311,8 @@ WARN_UNUSED_RESULT bool DecodeHLCTimestamp(rocksdb::Slice buf, cockroach::util::
   return true;
 }
 
-WARN_UNUSED_RESULT bool DecodeKey(rocksdb::Slice buf, rocksdb::Slice* key, int64_t* wall_time, int32_t* logical) {
+WARN_UNUSED_RESULT bool DecodeKey(rocksdb::Slice buf, rocksdb::Slice* key, int64_t* wall_time,
+                                  int32_t* logical) {
   key->clear();
 
   rocksdb::Slice timestamp;
@@ -421,7 +431,8 @@ cockroach::roachpb::ValueType GetTag(const std::string& val) {
 
 void SetTag(std::string* val, cockroach::roachpb::ValueType tag) { (*val)[kTagPos] = tag; }
 
-WARN_UNUSED_RESULT bool ParseProtoFromValue(const std::string& val, google::protobuf::MessageLite* msg) {
+WARN_UNUSED_RESULT bool ParseProtoFromValue(const std::string& val,
+                                            google::protobuf::MessageLite* msg) {
   if (val.size() < kHeaderSize) {
     return false;
   }
@@ -446,7 +457,8 @@ bool IsValidSplitKey(const rocksdb::Slice& key, bool allow_meta2_splits) {
     // and the first non-meta range would span [Meta2KeyMax,...).
     return false;
   }
-  const auto& no_split_spans = allow_meta2_splits ? kSortedNoSplitSpans : kSortedNoSplitSpansWithoutMeta2Splits;
+  const auto& no_split_spans =
+      allow_meta2_splits ? kSortedNoSplitSpans : kSortedNoSplitSpansWithoutMeta2Splits;
   for (auto span : no_split_spans) {
     // kSortedNoSplitSpans and kSortedNoSplitSpansWithoutMeta2Splits are
     // both reverse sorted (largest to smallest) on the span end key which
@@ -492,10 +504,13 @@ class DBComparator : public rocksdb::Comparator {
     return ts_b.compare(ts_a);
   }
 
-  virtual bool Equal(const rocksdb::Slice& a, const rocksdb::Slice& b) const override { return a == b; }
+  virtual bool Equal(const rocksdb::Slice& a, const rocksdb::Slice& b) const override {
+    return a == b;
+  }
 
   // The RocksDB docs say it is safe to leave these two methods unimplemented.
-  virtual void FindShortestSeparator(std::string* start, const rocksdb::Slice& limit) const override {}
+  virtual void FindShortestSeparator(std::string* start,
+                                     const rocksdb::Slice& limit) const override {}
 
   virtual void FindShortSuccessor(std::string* key) const override {}
 };
@@ -524,9 +539,13 @@ class DBBatchInserter : public rocksdb::WriteBatch::Handler {
  public:
   DBBatchInserter(rocksdb::WriteBatchBase* batch) : batch_(batch) {}
 
-  virtual void Put(const rocksdb::Slice& key, const rocksdb::Slice& value) { batch_->Put(key, value); }
+  virtual void Put(const rocksdb::Slice& key, const rocksdb::Slice& value) {
+    batch_->Put(key, value);
+  }
   virtual void Delete(const rocksdb::Slice& key) { batch_->Delete(key); }
-  virtual void Merge(const rocksdb::Slice& key, const rocksdb::Slice& value) { batch_->Merge(key, value); }
+  virtual void Merge(const rocksdb::Slice& key, const rocksdb::Slice& value) {
+    batch_->Merge(key, value);
+  }
   virtual rocksdb::Status DeleteRangeCF(uint32_t column_family_id, const rocksdb::Slice& begin_key,
                                         const rocksdb::Slice& end_key) {
     if (column_family_id == 0) {
@@ -548,9 +567,12 @@ bool TimeSeriesSampleOrdering(const cockroach::roachpb::InternalTimeSeriesSample
 
 // IsTimeSeriesData returns true if the given protobuffer Value contains a
 // TimeSeriesData message.
-bool IsTimeSeriesData(const std::string& val) { return GetTag(val) == cockroach::roachpb::TIMESERIES; }
+bool IsTimeSeriesData(const std::string& val) {
+  return GetTag(val) == cockroach::roachpb::TIMESERIES;
+}
 
-void SerializeTimeSeriesToValue(std::string* val, const cockroach::roachpb::InternalTimeSeriesData& ts) {
+void SerializeTimeSeriesToValue(std::string* val,
+                                const cockroach::roachpb::InternalTimeSeriesData& ts) {
   SerializeProtoToValue(val, ts);
   SetTag(val, cockroach::roachpb::TIMESERIES);
 }
@@ -559,8 +581,8 @@ void SerializeTimeSeriesToValue(std::string* val, const cockroach::roachpb::Inte
 // InternalTimeSeriesData messages. The messages cannot be merged if they have
 // different start timestamps or sample durations. Returns true if the merge is
 // successful.
-WARN_UNUSED_RESULT bool MergeTimeSeriesValues(std::string* left, const std::string& right, bool full_merge,
-                                              rocksdb::Logger* logger) {
+WARN_UNUSED_RESULT bool MergeTimeSeriesValues(std::string* left, const std::string& right,
+                                              bool full_merge, rocksdb::Logger* logger) {
   // Attempt to parse TimeSeriesData from both Values.
   cockroach::roachpb::InternalTimeSeriesData left_ts;
   cockroach::roachpb::InternalTimeSeriesData right_ts;
@@ -600,8 +622,8 @@ WARN_UNUSED_RESULT bool MergeTimeSeriesValues(std::string* left, const std::stri
   new_ts.set_sample_duration_nanos(left_ts.sample_duration_nanos());
 
   // Sort values in right_ts. Assume values in left_ts have been sorted.
-  std::stable_sort(right_ts.mutable_samples()->pointer_begin(), right_ts.mutable_samples()->pointer_end(),
-                   TimeSeriesSampleOrdering);
+  std::stable_sort(right_ts.mutable_samples()->pointer_begin(),
+                   right_ts.mutable_samples()->pointer_end(), TimeSeriesSampleOrdering);
 
   // Merge sample values of left and right into new_ts.
   auto left_front = left_ts.samples().begin();
@@ -668,8 +690,8 @@ WARN_UNUSED_RESULT bool ConsolidateTimeSeriesValue(std::string* val, rocksdb::Lo
   new_ts.set_sample_duration_nanos(val_ts.sample_duration_nanos());
 
   // Sort values in the ts value.
-  std::stable_sort(val_ts.mutable_samples()->pointer_begin(), val_ts.mutable_samples()->pointer_end(),
-                   TimeSeriesSampleOrdering);
+  std::stable_sort(val_ts.mutable_samples()->pointer_begin(),
+                   val_ts.mutable_samples()->pointer_end(), TimeSeriesSampleOrdering);
 
   // Consolidate sample values from the ts value with duplicate offsets.
   auto front = val_ts.samples().begin();
@@ -694,8 +716,8 @@ WARN_UNUSED_RESULT bool ConsolidateTimeSeriesValue(std::string* val, rocksdb::Lo
 }
 
 WARN_UNUSED_RESULT bool MergeValues(cockroach::storage::engine::enginepb::MVCCMetadata* left,
-                                    const cockroach::storage::engine::enginepb::MVCCMetadata& right, bool full_merge,
-                                    rocksdb::Logger* logger) {
+                                    const cockroach::storage::engine::enginepb::MVCCMetadata& right,
+                                    bool full_merge, rocksdb::Logger* logger) {
   if (left->has_raw_bytes()) {
     if (!right.has_raw_bytes()) {
       rocksdb::Warn(logger, "inconsistent value types for merge (left = bytes, right = ?)");
@@ -716,7 +738,8 @@ WARN_UNUSED_RESULT bool MergeValues(cockroach::storage::engine::enginepb::MVCCMe
                               "series data (type(left) != type(right))");
         return false;
       }
-      return MergeTimeSeriesValues(left->mutable_raw_bytes(), right.raw_bytes(), full_merge, logger);
+      return MergeTimeSeriesValues(left->mutable_raw_bytes(), right.raw_bytes(), full_merge,
+                                   logger);
     } else {
       const rocksdb::Slice rdata = ValueDataBytes(right.raw_bytes());
       left->mutable_raw_bytes()->append(rdata.data(), rdata.size());
@@ -793,8 +816,10 @@ class DBMergeOperator : public rocksdb::MergeOperator {
     return true;
   }
 
-  virtual bool PartialMergeMulti(const rocksdb::Slice& key, const std::deque<rocksdb::Slice>& operand_list,
-                                 std::string* new_value, rocksdb::Logger* logger) const WARN_UNUSED_RESULT {
+  virtual bool PartialMergeMulti(const rocksdb::Slice& key,
+                                 const std::deque<rocksdb::Slice>& operand_list,
+                                 std::string* new_value,
+                                 rocksdb::Logger* logger) const WARN_UNUSED_RESULT {
     cockroach::storage::engine::enginepb::MVCCMetadata meta;
 
     for (int i = 0; i < operand_list.size(); i++) {
@@ -811,8 +836,9 @@ class DBMergeOperator : public rocksdb::MergeOperator {
   }
 
  private:
-  bool MergeOne(cockroach::storage::engine::enginepb::MVCCMetadata* meta, const rocksdb::Slice& operand,
-                bool full_merge, rocksdb::Logger* logger) const WARN_UNUSED_RESULT {
+  bool MergeOne(cockroach::storage::engine::enginepb::MVCCMetadata* meta,
+                const rocksdb::Slice& operand, bool full_merge,
+                rocksdb::Logger* logger) const WARN_UNUSED_RESULT {
     cockroach::storage::engine::enginepb::MVCCMetadata operand_meta;
     if (!operand_meta.ParseFromArray(operand.data(), operand.size())) {
       rocksdb::Warn(logger, "corrupted operand value");
@@ -948,7 +974,8 @@ struct DBGetter : public Getter {
 // Upon return, the delta iterator will point to the next entry past
 // key. The delta iterator may not be valid if the end of iteration
 // was reached.
-DBStatus ProcessDeltaKey(Getter* base, rocksdb::WBWIIterator* delta, rocksdb::Slice key, DBString* value) {
+DBStatus ProcessDeltaKey(Getter* base, rocksdb::WBWIIterator* delta, rocksdb::Slice key,
+                         DBString* value) {
   if (value->data != NULL) {
     free(value->data);
   }
@@ -1022,7 +1049,8 @@ DBStatus ProcessDeltaKey(Getter* base, rocksdb::WBWIIterator* delta, rocksdb::Sl
 // from a WriteBatchWithIndex.
 class BaseDeltaIterator : public rocksdb::Iterator {
  public:
-  BaseDeltaIterator(rocksdb::Iterator* base_iterator, rocksdb::WBWIIterator* delta_iterator, bool prefix_same_as_start)
+  BaseDeltaIterator(rocksdb::Iterator* base_iterator, rocksdb::WBWIIterator* delta_iterator,
+                    bool prefix_same_as_start)
       : current_at_base_(true),
         equal_keys_(false),
         status_(rocksdb::Status::OK()),
@@ -1034,7 +1062,9 @@ class BaseDeltaIterator : public rocksdb::Iterator {
 
   virtual ~BaseDeltaIterator() { ClearMerged(); }
 
-  bool Valid() const override { return status_.ok() && (current_at_base_ ? BaseValid() : DeltaValid()); }
+  bool Valid() const override {
+    return status_.ok() && (current_at_base_ ? BaseValid() : DeltaValid());
+  }
 
   void SeekToFirst() override {
     base_iterator_->SeekToFirst();
@@ -1080,7 +1110,9 @@ class BaseDeltaIterator : public rocksdb::Iterator {
 
   void Prev() override { status_ = rocksdb::Status::NotSupported("Prev() not supported"); }
 
-  rocksdb::Slice key() const override { return current_at_base_ ? base_iterator_->key() : delta_key_; }
+  rocksdb::Slice key() const override {
+    return current_at_base_ ? base_iterator_->key() : delta_key_;
+  }
 
   rocksdb::Slice value() const override {
     if (current_at_base_) {
@@ -1312,13 +1344,15 @@ DBSSTable* DBEngine::GetSSTables(int* n) {
     tables[i].size = metadata[i].size;
 
     rocksdb::Slice tmp;
-    if (DecodeKey(metadata[i].smallestkey, &tmp, &tables[i].start_key.wall_time, &tables[i].start_key.logical)) {
+    if (DecodeKey(metadata[i].smallestkey, &tmp, &tables[i].start_key.wall_time,
+                  &tables[i].start_key.logical)) {
       // This is a bit ugly because we want DBKey.key to be copied and
       // not refer to the memory in metadata[i].smallestkey.
       DBString str = ToDBString(tmp);
       tables[i].start_key.key = DBSlice{str.data, str.len};
     }
-    if (DecodeKey(metadata[i].largestkey, &tmp, &tables[i].end_key.wall_time, &tables[i].end_key.logical)) {
+    if (DecodeKey(metadata[i].largestkey, &tmp, &tables[i].end_key.wall_time,
+                  &tables[i].end_key.logical)) {
       DBString str = ToDBString(tmp);
       tables[i].end_key.key = DBSlice{str.data, str.len};
     }
@@ -1344,8 +1378,9 @@ DBString DBEngine::GetUserProperties() {
     auto ts_min = userprops.find("crdb.ts.min");
     if (ts_min != userprops.end() && !ts_min->second.empty()) {
       if (!DecodeHLCTimestamp(rocksdb::Slice(ts_min->second), sst->mutable_ts_min())) {
-        fmt::SStringPrintf(all.mutable_error(), "unable to decode crdb.ts.min value '%s' in table %s",
-                           rocksdb::Slice(ts_min->second).ToString(true).c_str(), sst->path().c_str());
+        fmt::SStringPrintf(
+            all.mutable_error(), "unable to decode crdb.ts.min value '%s' in table %s",
+            rocksdb::Slice(ts_min->second).ToString(true).c_str(), sst->path().c_str());
         break;
       }
     }
@@ -1353,8 +1388,9 @@ DBString DBEngine::GetUserProperties() {
     auto ts_max = userprops.find("crdb.ts.max");
     if (ts_max != userprops.end() && !ts_max->second.empty()) {
       if (!DecodeHLCTimestamp(rocksdb::Slice(ts_max->second), sst->mutable_ts_max())) {
-        fmt::SStringPrintf(all.mutable_error(), "unable to decode crdb.ts.max value '%s' in table %s",
-                           rocksdb::Slice(ts_max->second).ToString(true).c_str(), sst->path().c_str());
+        fmt::SStringPrintf(
+            all.mutable_error(), "unable to decode crdb.ts.max value '%s' in table %s",
+            rocksdb::Slice(ts_max->second).ToString(true).c_str(), sst->path().c_str());
         break;
       }
     }
@@ -1362,7 +1398,8 @@ DBString DBEngine::GetUserProperties() {
   return ToDBString(all.SerializeAsString());
 }
 
-DBBatch::DBBatch(DBEngine* db) : DBEngine(db->rep), updates(0), has_delete_range(false), batch(&kComparator) {}
+DBBatch::DBBatch(DBEngine* db)
+    : DBEngine(db->rep), updates(0), has_delete_range(false), batch(&kComparator) {}
 
 DBWriteOnlyBatch::DBWriteOnlyBatch(DBEngine* db) : DBEngine(db->rep), updates(0) {}
 
@@ -1393,8 +1430,9 @@ class TimeBoundTblPropCollector : public rocksdb::TablePropertiesCollector {
     return rocksdb::Status::OK();
   }
 
-  rocksdb::Status AddUserKey(const rocksdb::Slice& user_key, const rocksdb::Slice& value, rocksdb::EntryType type,
-                             rocksdb::SequenceNumber seq, uint64_t file_size) override {
+  rocksdb::Status AddUserKey(const rocksdb::Slice& user_key, const rocksdb::Slice& value,
+                             rocksdb::EntryType type, rocksdb::SequenceNumber seq,
+                             uint64_t file_size) override {
     rocksdb::Slice unused;
     rocksdb::Slice ts;
     if (SplitKey(user_key, &unused, &ts) && !ts.empty()) {
@@ -1421,8 +1459,8 @@ class TimeBoundTblPropCollector : public rocksdb::TablePropertiesCollector {
 class TimeBoundTblPropCollectorFactory : public rocksdb::TablePropertiesCollectorFactory {
  public:
   explicit TimeBoundTblPropCollectorFactory() {}
-  virtual rocksdb::TablePropertiesCollector*
-  CreateTablePropertiesCollector(rocksdb::TablePropertiesCollectorFactory::Context context) override {
+  virtual rocksdb::TablePropertiesCollector* CreateTablePropertiesCollector(
+      rocksdb::TablePropertiesCollectorFactory::Context context) override {
     return new TimeBoundTblPropCollector();
   }
   const char* Name() const override { return "TimeBoundTblPropCollectorFactory"; }
@@ -1610,8 +1648,9 @@ DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions db_opts) {
   if (!status.ok()) {
     return ToDBStatus(status);
   }
-  *db = new DBImpl(db_ptr, memenv.release(), db_opts.cache != nullptr ? db_opts.cache->rep : nullptr, event_listener,
-                   switching_env.release());
+  *db =
+      new DBImpl(db_ptr, memenv.release(), db_opts.cache != nullptr ? db_opts.cache->rep : nullptr,
+                 event_listener, switching_env.release());
   return kSuccess;
 }
 
@@ -1650,9 +1689,7 @@ DBStatus DBSyncWAL(DBEngine* db) {
 #endif
 }
 
-DBStatus DBCompact(DBEngine* db) {
-  return DBCompactRange(db, DBKey(), DBKey());
-}
+DBStatus DBCompact(DBEngine* db) { return DBCompactRange(db, DBKey(), DBKey()); }
 
 DBStatus DBCompactRange(DBEngine* db, DBKey start, DBKey end) {
   rocksdb::CompactRangeOptions options;
@@ -1738,9 +1775,10 @@ DBStatus DBCompactRange(DBEngine* db, DBKey start, DBKey end) {
     sst.push_back(metadata[i]);
   }
   // Sort the metadata by smallest key.
-  std::sort(sst.begin(), sst.end(), [](const rocksdb::SstFileMetaData& a, const rocksdb::SstFileMetaData& b) -> bool {
-      return a.smallestkey < b.smallestkey;
-    });
+  std::sort(sst.begin(), sst.end(),
+            [](const rocksdb::SstFileMetaData& a, const rocksdb::SstFileMetaData& b) -> bool {
+              return a.smallestkey < b.smallestkey;
+            });
 
   // Walk over the bottom-most sstables in order and perform
   // compactions every 128MB.
@@ -1875,7 +1913,8 @@ DBStatus DBSnapshot::Delete(DBKey key) { return FmtStatus("unsupported"); }
 
 DBStatus DBImpl::DeleteRange(DBKey start, DBKey end) {
   rocksdb::WriteOptions options;
-  return ToDBStatus(rep->DeleteRange(options, rep->DefaultColumnFamily(), EncodeKey(start), EncodeKey(end)));
+  return ToDBStatus(
+      rep->DeleteRange(options, rep->DefaultColumnFamily(), EncodeKey(start), EncodeKey(end)));
 }
 
 DBStatus DBBatch::DeleteRange(DBKey start, DBKey end) {
@@ -1981,7 +2020,9 @@ DBStatus DBWriteOnlyBatch::ApplyBatchRepr(DBSlice repr, bool sync) {
 
 DBStatus DBSnapshot::ApplyBatchRepr(DBSlice repr, bool sync) { return FmtStatus("unsupported"); }
 
-DBStatus DBApplyBatchRepr(DBEngine* db, DBSlice repr, bool sync) { return db->ApplyBatchRepr(repr, sync); }
+DBStatus DBApplyBatchRepr(DBEngine* db, DBSlice repr, bool sync) {
+  return db->ApplyBatchRepr(repr, sync);
+}
 
 DBSlice DBImpl::BatchRepr() { return ToDBSlice("unsupported"); }
 
@@ -2043,14 +2084,17 @@ DBStatus DBImpl::GetStats(DBStatsResult* stats) {
   rep->GetIntProperty("rocksdb.estimate-table-readers-mem", &table_readers_mem_estimate);
 
   uint64_t pending_compaction_bytes_estimate;
-  rep->GetIntProperty("rocksdb.estimate-pending-compaction-bytes", &pending_compaction_bytes_estimate);
+  rep->GetIntProperty("rocksdb.estimate-pending-compaction-bytes",
+                      &pending_compaction_bytes_estimate);
 
   stats->block_cache_hits = (int64_t)s->getTickerCount(rocksdb::BLOCK_CACHE_HIT);
   stats->block_cache_misses = (int64_t)s->getTickerCount(rocksdb::BLOCK_CACHE_MISS);
   stats->block_cache_usage = (int64_t)block_cache->GetUsage();
   stats->block_cache_pinned_usage = (int64_t)block_cache->GetPinnedUsage();
-  stats->bloom_filter_prefix_checked = (int64_t)s->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_CHECKED);
-  stats->bloom_filter_prefix_useful = (int64_t)s->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_USEFUL);
+  stats->bloom_filter_prefix_checked =
+      (int64_t)s->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_CHECKED);
+  stats->bloom_filter_prefix_useful =
+      (int64_t)s->getTickerCount(rocksdb::BLOOM_FILTER_PREFIX_USEFUL);
   stats->memtable_total_size = memtable_total_size;
   stats->flushes = (int64_t)event_listener->GetFlushes();
   stats->compactions = (int64_t)event_listener->GetCompactions();
@@ -2098,11 +2142,17 @@ DBStatus DBImpl::EnvWriteFile(DBSlice path, DBSlice contents) {
 
 DBStatus DBBatch::EnvWriteFile(DBSlice path, DBSlice contents) { return FmtStatus("unsupported"); }
 
-DBStatus DBWriteOnlyBatch::EnvWriteFile(DBSlice path, DBSlice contents) { return FmtStatus("unsupported"); }
+DBStatus DBWriteOnlyBatch::EnvWriteFile(DBSlice path, DBSlice contents) {
+  return FmtStatus("unsupported");
+}
 
-DBStatus DBSnapshot::EnvWriteFile(DBSlice path, DBSlice contents) { return FmtStatus("unsupported"); }
+DBStatus DBSnapshot::EnvWriteFile(DBSlice path, DBSlice contents) {
+  return FmtStatus("unsupported");
+}
 
-DBStatus DBEnvWriteFile(DBEngine* db, DBSlice path, DBSlice contents) { return db->EnvWriteFile(path, contents); }
+DBStatus DBEnvWriteFile(DBEngine* db, DBSlice path, DBSlice contents) {
+  return db->EnvWriteFile(path, contents);
+}
 
 DBIterator* DBNewIter(DBEngine* db, bool prefix) {
   rocksdb::ReadOptions opts;
@@ -2265,8 +2315,8 @@ inline int64_t age_factor(int64_t fromNS, int64_t toNS) {
 // should be taken as a hint but determined by the max timestamp encountered.
 //
 // This implementation must match engine.ComputeStatsGo.
-MVCCStatsResult MVCCComputeStatsInternal(::rocksdb::Iterator* const iter_rep, DBKey start, DBKey end,
-                                         int64_t now_nanos) {
+MVCCStatsResult MVCCComputeStatsInternal(::rocksdb::Iterator* const iter_rep, DBKey start,
+                                         DBKey end, int64_t now_nanos) {
   MVCCStatsResult stats;
   memset(&stats, 0, sizeof(stats));
 
@@ -2353,13 +2403,13 @@ MVCCStatsResult MVCCComputeStatsInternal(::rocksdb::Iterator* const iter_rep, DB
           stats.intent_age += age_factor(meta.timestamp().wall_time(), now_nanos);
         }
         if (meta.key_bytes() != kMVCCVersionTimestampSize) {
-          stats.status = FmtStatus("expected mvcc metadata key bytes to equal %d; got %d", kMVCCVersionTimestampSize,
-                                   int(meta.key_bytes()));
+          stats.status = FmtStatus("expected mvcc metadata key bytes to equal %d; got %d",
+                                   kMVCCVersionTimestampSize, int(meta.key_bytes()));
           break;
         }
         if (meta.val_bytes() != value.size()) {
-          stats.status = FmtStatus("expected mvcc metadata val bytes to equal %d; got %d", int(value.size()),
-                                   int(meta.val_bytes()));
+          stats.status = FmtStatus("expected mvcc metadata val bytes to equal %d; got %d",
+                                   int(value.size()), int(meta.val_bytes()));
           break;
         }
       } else {
@@ -2383,8 +2433,8 @@ bool MVCCIsValidSplitKey(DBSlice key, bool allow_meta2_splits) {
   return IsValidSplitKey(ToSlice(key), allow_meta2_splits);
 }
 
-DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_split, int64_t target_size,
-                          bool allow_meta2_splits, DBString* split_key) {
+DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_split,
+                          int64_t target_size, bool allow_meta2_splits, DBString* split_key) {
   auto iter_rep = iter->rep.get();
   const std::string start_key = EncodeKey(start);
   iter_rep->Seek(start_key);
@@ -2407,8 +2457,8 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
     }
 
     ++n;
-    const bool valid =
-        n > 1 && IsValidSplitKey(decoded_key, allow_meta2_splits) && decoded_key.compare(min_split_key) >= 0;
+    const bool valid = n > 1 && IsValidSplitKey(decoded_key, allow_meta2_splits) &&
+                       decoded_key.compare(min_split_key) >= 0;
     int64_t diff = target_size - size_so_far;
     if (diff < 0) {
       diff = -diff;
@@ -2609,7 +2659,8 @@ rocksdb::WriteBatch::Handler* GetDBBatchInserter(::rocksdb::WriteBatchBase* batc
 }
 
 DBStatus DBLockFile(DBSlice filename, DBFileLock* lock) {
-  return ToDBStatus(rocksdb::Env::Default()->LockFile(ToString(filename), (rocksdb::FileLock**)lock));
+  return ToDBStatus(
+      rocksdb::Env::Default()->LockFile(ToString(filename), (rocksdb::FileLock**)lock));
 }
 
 DBStatus DBUnlockFile(DBFileLock lock) {

--- a/c-deps/libroach/db.h
+++ b/c-deps/libroach/db.h
@@ -52,5 +52,5 @@ const ::rocksdb::Comparator* CockroachComparator();
 
 // MVCCComputeStatsInternal returns the mvcc stats of the data in an iterator.
 // Stats are only computed for keys between the given range.
-MVCCStatsResult MVCCComputeStatsInternal(::rocksdb::Iterator* const iter_rep, DBKey start, DBKey end,
-                                         int64_t now_nanos);
+MVCCStatsResult MVCCComputeStatsInternal(::rocksdb::Iterator* const iter_rep, DBKey start,
+                                         DBKey end, int64_t now_nanos);

--- a/c-deps/libroach/db_test.cc
+++ b/c-deps/libroach/db_test.cc
@@ -25,5 +25,6 @@ TEST(Libroach, DBOpenHook) {
 
   // Try extra_options with anything at all.
   db_opts.extra_options = ToDBSlice("blah");
-  EXPECT_ERR(DBOpenHook("", db_opts), "DBOptions has extra_options, but OSS code cannot handle them");
+  EXPECT_ERR(DBOpenHook("", db_opts),
+             "DBOptions has extra_options, but OSS code cannot handle them");
 }

--- a/c-deps/libroach/encoding.cc
+++ b/c-deps/libroach/encoding.cc
@@ -50,8 +50,9 @@ bool DecodeUint64(rocksdb::Slice* buf, uint64_t* value) {
     return false;
   }
   const uint8_t* b = reinterpret_cast<const uint8_t*>(buf->data());
-  *value = (uint64_t(b[0]) << 56) | (uint64_t(b[1]) << 48) | (uint64_t(b[2]) << 40) | (uint64_t(b[3]) << 32) |
-           (uint64_t(b[4]) << 24) | (uint64_t(b[5]) << 16) | (uint64_t(b[6]) << 8) | uint64_t(b[7]);
+  *value = (uint64_t(b[0]) << 56) | (uint64_t(b[1]) << 48) | (uint64_t(b[2]) << 40) |
+           (uint64_t(b[3]) << 32) | (uint64_t(b[4]) << 24) | (uint64_t(b[5]) << 16) |
+           (uint64_t(b[6]) << 8) | uint64_t(b[7]);
   buf->remove_prefix(N);
   return true;
 }

--- a/c-deps/libroach/eventlistener.cc
+++ b/c-deps/libroach/eventlistener.cc
@@ -19,7 +19,8 @@ static const bool kDebug = false;
 
 DBEventListener::DBEventListener() : flushes_(0), compactions_(0) {}
 
-void DBEventListener::OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) {
+void DBEventListener::OnFlushCompleted(rocksdb::DB* db,
+                                       const rocksdb::FlushJobInfo& flush_job_info) {
   ++flushes_;
 
   if (kDebug) {
@@ -27,8 +28,9 @@ void DBEventListener::OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobI
     fprintf(stderr,
             "OnFlushCompleted:\n  %40s:  entries=%d  data=%.1fMB  "
             "index=%.1fMB  filter=%.1fMB\n",
-            flush_job_info.file_path.c_str(), (int)p.num_entries, float(p.data_size) / (1024.0 * 1024.0),
-            float(p.index_size) / (1024.0 * 1024.0), float(p.filter_size) / (1024.0 * 1024.0));
+            flush_job_info.file_path.c_str(), (int)p.num_entries,
+            float(p.data_size) / (1024.0 * 1024.0), float(p.index_size) / (1024.0 * 1024.0),
+            float(p.filter_size) / (1024.0 * 1024.0));
   }
 }
 
@@ -36,12 +38,13 @@ void DBEventListener::OnCompactionCompleted(rocksdb::DB* db, const rocksdb::Comp
   ++compactions_;
 
   if (kDebug) {
-    fprintf(stderr, "OnCompactionCompleted: input=%d output=%d\n", ci.base_input_level, ci.output_level);
+    fprintf(stderr, "OnCompactionCompleted: input=%d output=%d\n", ci.base_input_level,
+            ci.output_level);
     for (auto iter = ci.table_properties.begin(); iter != ci.table_properties.end(); ++iter) {
       const rocksdb::TableProperties& p = *iter->second;
-      fprintf(stderr, "  %40s: entries=%d  data=%.1fMB  index=%.1fMB  filter=%.1fMB\n", iter->first.c_str(),
-              (int)p.num_entries, float(p.data_size) / (1024.0 * 1024.0), float(p.index_size) / (1024.0 * 1024.0),
-              float(p.filter_size) / (1024.0 * 1024.0));
+      fprintf(stderr, "  %40s: entries=%d  data=%.1fMB  index=%.1fMB  filter=%.1fMB\n",
+              iter->first.c_str(), (int)p.num_entries, float(p.data_size) / (1024.0 * 1024.0),
+              float(p.index_size) / (1024.0 * 1024.0), float(p.filter_size) / (1024.0 * 1024.0));
     }
   }
 }

--- a/c-deps/libroach/eventlistener.h
+++ b/c-deps/libroach/eventlistener.h
@@ -30,8 +30,10 @@ class DBEventListener : public rocksdb::EventListener {
   uint64_t GetCompactions() const;
 
   // EventListener methods.
-  virtual void OnFlushCompleted(rocksdb::DB* db, const rocksdb::FlushJobInfo& flush_job_info) override;
-  virtual void OnCompactionCompleted(rocksdb::DB* db, const rocksdb::CompactionJobInfo& ci) override;
+  virtual void OnFlushCompleted(rocksdb::DB* db,
+                                const rocksdb::FlushJobInfo& flush_job_info) override;
+  virtual void OnCompactionCompleted(rocksdb::DB* db,
+                                     const rocksdb::CompactionJobInfo& ci) override;
 
  private:
   std::atomic<uint64_t> flushes_;

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -116,7 +116,7 @@ DBStatus DBCompactRange(DBEngine* db, DBKey start, DBKey end);
 
 // Stores the approximate on-disk size of the given key range into the
 // supplied uint64.
-DBStatus DBApproximateDiskBytes(DBEngine* db, DBKey start, DBKey end, uint64_t *size);
+DBStatus DBApproximateDiskBytes(DBEngine* db, DBKey start, DBKey end, uint64_t* size);
 
 // Sets the database entry for "key" to "value".
 DBStatus DBPut(DBEngine* db, DBKey key, DBSlice value);
@@ -233,8 +233,8 @@ typedef struct {
 MVCCStatsResult MVCCComputeStats(DBIterator* iter, DBKey start, DBKey end, int64_t now_nanos);
 
 bool MVCCIsValidSplitKey(DBSlice key, bool allow_meta2_splits);
-DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_split, int64_t target_size,
-                          bool allow_meta2_splits, DBString* split_key);
+DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_split,
+                          int64_t target_size, bool allow_meta2_splits, DBString* split_key);
 
 // DBStatsResult contains various runtime stats for RocksDB.
 typedef struct {
@@ -309,7 +309,8 @@ typedef void* DBFileLock;
 // DBLockFile sets a lock on the specified file using RocksDB's file locking interface.
 DBStatus DBLockFile(DBSlice filename, DBFileLock* lock);
 
-// DBUnlockFile unlocks the file asscoiated with the specified lock and GCs any allocated memory for the lock.
+// DBUnlockFile unlocks the file asscoiated with the specified lock and GCs any allocated memory for
+// the lock.
 DBStatus DBUnlockFile(DBFileLock lock);
 
 #ifdef __cplusplus

--- a/c-deps/libroach/include/libroachccl.h
+++ b/c-deps/libroach/include/libroachccl.h
@@ -16,7 +16,8 @@ extern "C" {
 
 // DBBatchReprVerify asserts that all keys in a BatchRepr are between the
 // specified start and end keys and computes the MVCCStatsResult for it.
-DBStatus DBBatchReprVerify(DBSlice repr, DBKey start, DBKey end, int64_t now_nanos, MVCCStatsResult* stats);
+DBStatus DBBatchReprVerify(DBSlice repr, DBKey start, DBKey end, int64_t now_nanos,
+                           MVCCStatsResult* stats);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/c-deps/libroach/testutils.cc
+++ b/c-deps/libroach/testutils.cc
@@ -27,12 +27,14 @@ rocksdb::Status compareErrorMessage(rocksdb::Status status, const char* err_msg)
     if (status.ok()) {
       return rocksdb::Status::OK();
     }
-    return rocksdb::Status::InvalidArgument(fmt::StringPrintf("expected success, got error \"%s\"", status.getState()));
+    return rocksdb::Status::InvalidArgument(
+        fmt::StringPrintf("expected success, got error \"%s\"", status.getState()));
   }
 
   // Expected failure.
   if (status.ok()) {
-    return rocksdb::Status::InvalidArgument(fmt::StringPrintf("expected error \"%s\", got success", err_msg));
+    return rocksdb::Status::InvalidArgument(
+        fmt::StringPrintf("expected error \"%s\", got success", err_msg));
   }
   std::regex re(err_msg);
   if (std::regex_match(status.getState(), re)) {

--- a/c-deps/libroach/utils.cc
+++ b/c-deps/libroach/utils.cc
@@ -16,7 +16,8 @@
 
 static const std::string kTempFileNameSuffix = ".crdbtmp";
 
-rocksdb::Status SafeWriteStringToFile(rocksdb::Env* env, const std::string& filename, const std::string& contents) {
+rocksdb::Status SafeWriteStringToFile(rocksdb::Env* env, const std::string& filename,
+                                      const std::string& contents) {
   std::string tmpname = filename + kTempFileNameSuffix;
   auto status = rocksdb::WriteStringToFile(env, contents, tmpname, true /* should_sync */);
   if (status.ok()) {

--- a/c-deps/libroach/utils.h
+++ b/c-deps/libroach/utils.h
@@ -20,4 +20,5 @@
 
 // Write 'contents' to a temporary file, sync, rename to 'filename'.
 // On non-OK status, the original file has not been touched.
-rocksdb::Status SafeWriteStringToFile(rocksdb::Env* env, const std::string& filename, const std::string& contents);
+rocksdb::Status SafeWriteStringToFile(rocksdb::Env* env, const std::string& filename,
+                                      const std::string& contents);


### PR DESCRIPTION
Release note: None

Modified to match our [Go style](https://github.com/cockroachdb/cockroach/blob/master/docs/style.md)

After that, just ran `make c-deps-fmt`. No other changes.
  