### PR TITLE
storage/tscache: reduce testing rounds for race builds

### DIFF
--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -555,8 +555,12 @@ func TestTimestampCacheImplsIdentical(t *testing.T) {
 				txnID := uuid.MakeV4()
 				maxVal := cacheValue{}
 
-				const n = 1000
-				for j := 0; j < n; j++ {
+				rounds := 1000
+				if util.RaceEnabled {
+					// Reduce the number of rounds for race builds.
+					rounds /= 2
+				}
+				for j := 0; j < rounds; j++ {
 					t.Logf("goroutine %d at iter %d", i, j)
 
 					// Wait for all goroutines to synchronize.

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -951,8 +951,12 @@ func TestIntervalSklConcurrency(t *testing.T) {
 						txnID := uuid.MakeV4()
 						maxVal := cacheValue{}
 
-						const n = 1000
-						for j := 0; j < n; j++ {
+						rounds := 1000
+						if util.RaceEnabled {
+							// Reduce the number of rounds for race builds.
+							rounds /= 2
+						}
+						for j := 0; j < rounds; j++ {
 							// Choose a random range.
 							from, middle, to := randRange(rng, slots)
 							opt := randRangeOpt(rng)
@@ -1036,8 +1040,12 @@ func TestIntervalSklConcurrentVsSequential(t *testing.T) {
 			txnIDs[i] = uuid.MakeV4()
 		}
 
-		const n = 1000
-		for j := 0; j < n; j++ {
+		rounds := 1000
+		if util.RaceEnabled {
+			// Reduce the number of rounds for race builds.
+			rounds /= 2
+		}
+		for j := 0; j < rounds; j++ {
 			t.Logf("round %d", j)
 
 			// Create a set of actions to perform.


### PR DESCRIPTION
Fixes #21148.
Fixes #21149.

We've seen nightly testing fail on these tests with `ERROR: signal: killed`
messages, which usually imply that the test was killed because of an OOM.
We've already dropped the memory usage of these tests significantly and the
failures still remain. This attempts to help by reducing the number of
testing rounds run during race testing. I suspect that the issue may be
the large amount of `t.Log` calls in these tests, so reducing this should
help. We could also remove the logging, but if the tests ever fail it will
be really helpful to have the logging present for debugging the failure.

Release note: None