### PR TITLE
sql/distsqlrun: pass ProducerMetadata by reference instead of by value

### DIFF
--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -226,7 +226,7 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	}
 
 	// Push some metadata and check that the caches are updated with it.
-	status := r.Push(nil /* row */, distsqlrun.ProducerMetadata{
+	status := r.Push(nil /* row */, &distsqlrun.ProducerMetadata{
 		Ranges: []roachpb.RangeInfo{
 			{
 				Desc: descs[0],
@@ -242,7 +242,7 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	if status != distsqlrun.NeedMoreRows {
 		t.Fatalf("expected status NeedMoreRows, got: %d", status)
 	}
-	status = r.Push(nil /* row */, distsqlrun.ProducerMetadata{
+	status = r.Push(nil /* row */, &distsqlrun.ProducerMetadata{
 		Ranges: []roachpb.RangeInfo{
 			{
 				Desc: descs[2],

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -310,9 +310,9 @@ func makeDistSQLReceiver(
 
 // Push is part of the RowReceiver interface.
 func (r *distSQLReceiver) Push(
-	row sqlbase.EncDatumRow, meta distsqlrun.ProducerMetadata,
+	row sqlbase.EncDatumRow, meta *distsqlrun.ProducerMetadata,
 ) distsqlrun.ConsumerStatus {
-	if !meta.Empty() {
+	if meta != nil {
 		if meta.Err != nil && r.err == nil {
 			if r.txn != nil {
 				if retryErr, ok := meta.Err.(*roachpb.UnhandledRetryableError); ok {

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -85,7 +85,7 @@ func runTestFlow(
 	var res sqlbase.EncDatumRows
 	for {
 		row, meta := rowBuf.Next()
-		if !meta.Empty() {
+		if meta != nil {
 			t.Fatalf("unexpected metadata: %v", meta)
 		}
 		if row == nil {

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -209,12 +209,13 @@ func (ag *aggregator) close() {
 // terminated, either due to being indicated by the consumer, or because the
 // processor ran out of rows or encountered an error. It is ok for err to be
 // nil indicating that we're done producing rows even though no error occurred.
-func (ag *aggregator) producerMeta(err error) ProducerMetadata {
-	var meta ProducerMetadata
+func (ag *aggregator) producerMeta(err error) *ProducerMetadata {
+	var meta *ProducerMetadata
 	if !ag.closed {
-		meta = ProducerMetadata{Err: err}
-		if err == nil {
-			meta.TraceData = getTraceData(ag.ctx)
+		if err != nil {
+			meta = &ProducerMetadata{Err: err}
+		} else if trace := getTraceData(ag.ctx); trace != nil {
+			meta = &ProducerMetadata{TraceData: trace}
 		}
 		// We need to close as soon as we send producer metadata as we're done
 		// sending rows. The consumer is allowed to not call ConsumerDone().
@@ -224,7 +225,7 @@ func (ag *aggregator) producerMeta(err error) ProducerMetadata {
 }
 
 // Next is part of the RowSource interface.
-func (ag *aggregator) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
+func (ag *aggregator) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	if ag.maybeStart("aggregator", "Agg") {
 		log.VEventf(ag.ctx, 2, "starting aggregation process")
 		ag.accumulating = true
@@ -233,7 +234,7 @@ func (ag *aggregator) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 	if ag.accumulating {
 		for {
 			row, meta := ag.input.Next()
-			if !meta.Empty() {
+			if meta != nil {
 				if meta.Err != nil {
 					return nil, ag.producerMeta(meta.Err)
 				}
@@ -295,7 +296,7 @@ func (ag *aggregator) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 
 		outRow, status, err := ag.out.ProcessRow(ag.ctx, ag.row)
 		if outRow != nil {
-			return outRow, ProducerMetadata{}
+			return outRow, nil
 		}
 		if outRow == nil && err == nil && status == NeedMoreRows {
 			continue

--- a/pkg/sql/distsqlrun/algebraic_set_op_test.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op_test.go
@@ -103,7 +103,7 @@ func runProcessors(tc testCase) (sqlbase.EncDatumRows, error) {
 	var res sqlbase.EncDatumRows
 	for {
 		row, meta := out.Next()
-		if !meta.Empty() {
+		if meta != nil {
 			return nil, errors.Errorf("unexpected metadata: %v", meta)
 		}
 		if row == nil {

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -87,7 +87,7 @@ func (b *backfiller) Run(wg *sync.WaitGroup) {
 	}
 
 	if err := b.mainLoop(ctx); err != nil {
-		b.output.Push(nil /* row */, ProducerMetadata{Err: err})
+		b.output.Push(nil /* row */, &ProducerMetadata{Err: err})
 	}
 	sendTraceData(ctx, b.output)
 	b.output.ProducerDone()

--- a/pkg/sql/distsqlrun/base_test.go
+++ b/pkg/sql/distsqlrun/base_test.go
@@ -34,8 +34,8 @@ func TestRunDrain(t *testing.T) {
 	// A source with no rows and 2 ProducerMetadata messages.
 	src := &RowChannel{}
 	src.InitWithBufSize(nil, 10)
-	src.Push(nil, ProducerMetadata{Err: fmt.Errorf("test")})
-	src.Push(nil, ProducerMetadata{})
+	src.Push(nil /* row */, &ProducerMetadata{Err: fmt.Errorf("test")})
+	src.Push(nil /* row */, nil /* meta */)
 
 	// A receiver that is marked as done consuming rows so that Run will
 	// immediately move from forwarding rows and metadata to draining metadata.
@@ -89,7 +89,7 @@ func BenchmarkRowChannelPipeline(b *testing.B) {
 			}
 			b.SetBytes(int64(unsafe.Sizeof(tree.DInt(1))))
 			for i := 0; i < b.N; i++ {
-				_ = rc[0].Push(row, ProducerMetadata{})
+				_ = rc[0].Push(row, nil /* meta */)
 			}
 			rc[0].ProducerDone()
 			wg.Wait()

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -131,12 +131,13 @@ func (d *distinct) close() {
 // terminated, either due to being indicated by the consumer, or because the
 // processor ran out of rows or encountered an error. It is ok for err to be
 // nil indicating that we're done producing rows even though no error occurred.
-func (d *distinct) producerMeta(err error) ProducerMetadata {
-	var meta ProducerMetadata
+func (d *distinct) producerMeta(err error) *ProducerMetadata {
+	var meta *ProducerMetadata
 	if !d.closed {
-		meta = ProducerMetadata{Err: err}
-		if err == nil {
-			meta.TraceData = getTraceData(d.ctx)
+		if err != nil {
+			meta = &ProducerMetadata{Err: err}
+		} else if trace := getTraceData(d.ctx); trace != nil {
+			meta = &ProducerMetadata{TraceData: trace}
 		}
 		// We need to close as soon as we send producer metadata as we're done
 		// sending rows. The consumer is allowed to not call ConsumerDone().
@@ -146,14 +147,14 @@ func (d *distinct) producerMeta(err error) ProducerMetadata {
 }
 
 // Next is part of the RowSource interface.
-func (d *distinct) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
+func (d *distinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	if d.maybeStart("distinct", "Distinct") {
 		d.evalCtx = d.flowCtx.NewEvalCtx()
 	}
 
 	for {
 		row, meta := d.input.Next()
-		if d.closed || !meta.Empty() {
+		if d.closed || meta != nil {
 			return nil, meta
 		}
 		if row == nil {
@@ -209,7 +210,7 @@ func (d *distinct) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 			continue
 		}
 
-		return outRow, ProducerMetadata{}
+		return outRow, nil
 	}
 }
 

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -402,7 +402,7 @@ func (f *Flow) Start(ctx context.Context, doneFn func()) error {
 	); err != nil {
 		if f.syncFlowConsumer != nil {
 			// For sync flows, the error goes to the consumer.
-			f.syncFlowConsumer.Push(nil /* row */, ProducerMetadata{Err: err})
+			f.syncFlowConsumer.Push(nil /* row */, &ProducerMetadata{Err: err})
 			f.syncFlowConsumer.ProducerDone()
 			return nil
 		}
@@ -485,7 +485,7 @@ func (f *Flow) cancel() {
 			// receiver and prevent it from being connected.
 			is.receiver.Push(
 				nil, /* row */
-				ProducerMetadata{Err: sqlbase.NewQueryCanceledError()})
+				&ProducerMetadata{Err: sqlbase.NewQueryCanceledError()})
 			is.receiver.ProducerDone()
 			f.flowRegistry.finishInboundStreamLocked(f.id, streamID)
 		}

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -191,7 +191,7 @@ func (fr *flowRegistry) RegisterFlow(
 					// processors.
 					is.receiver.Push(
 						nil, /* row */
-						ProducerMetadata{Err: errors.Errorf("no inbound stream connection")})
+						&ProducerMetadata{Err: errors.Errorf("no inbound stream connection")})
 					is.receiver.ProducerDone()
 					fr.finishInboundStreamLocked(id, streamID)
 				}

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -275,7 +275,7 @@ func (h *hashJoiner) receiveRow(
 	for {
 		row, meta := src.Next()
 		if row == nil {
-			if meta.Empty() {
+			if meta == nil {
 				// Done.
 				return nil, false, nil
 			}

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -612,7 +612,7 @@ func checkExpectedRows(
 	var rets []string
 	for {
 		row, meta := results.Next()
-		if !meta.Empty() {
+		if meta != nil {
 			return errors.Errorf("unexpected metadata: %v", meta)
 		}
 		if row == nil {
@@ -791,14 +791,14 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 		rightInputDrainNotification <- nil
 	}
 	rightErrorReturned := false
-	rightInputNext := func(rb *RowBuffer) (sqlbase.EncDatumRow, ProducerMetadata) {
+	rightInputNext := func(rb *RowBuffer) (sqlbase.EncDatumRow, *ProducerMetadata) {
 		if !rightErrorReturned {
 			rightErrorReturned = true
 			// The right input is going to return an error as the first thing.
-			return nil, ProducerMetadata{Err: errors.Errorf("Test error. Please drain.")}
+			return nil, &ProducerMetadata{Err: errors.Errorf("Test error. Please drain.")}
 		}
 		// Let RowBuffer.Next() do its usual thing.
-		return nil, ProducerMetadata{}
+		return nil, nil
 	}
 	leftInput := NewRowBuffer(
 		oneIntCol,

--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -41,7 +41,7 @@ func ProcessInboundStream(
 	// as the last record that the producer gets.
 	if err != nil {
 		log.VEventf(ctx, 1, "inbound stream error: %s", err)
-		dst.Push(nil, ProducerMetadata{Err: err})
+		dst.Push(nil, &ProducerMetadata{Err: err})
 		dst.ProducerDone()
 		return err
 	}
@@ -99,7 +99,7 @@ func processInboundStreamHelper(
 			if err != nil {
 				return err
 			}
-			if row == nil && meta.Empty() {
+			if row == nil && meta == nil {
 				// No more rows in the last message.
 				break
 			}
@@ -110,7 +110,7 @@ func processInboundStreamHelper(
 				}
 				log.Infof(ctx, "inbound stream pushing row %s", row.String(types))
 			}
-			if draining && meta.Empty() {
+			if draining && meta == nil {
 				// Don't forward data rows when we're draining.
 				continue
 			}

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -417,7 +417,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 			var res sqlbase.EncDatumRows
 			for {
 				row, meta := out.Next()
-				if !meta.Empty() {
+				if meta != nil {
 					t.Fatalf("unexpected metadata: %v", meta)
 				}
 				if row == nil {

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -132,7 +132,7 @@ func (jr *joinReader) mainLoop(ctx context.Context) error {
 		// within a certain amount of time).
 		for spans = spans[:0]; len(spans) < joinReaderBatchSize; {
 			row, meta := jr.input.Next()
-			if !meta.Empty() {
+			if meta != nil {
 				if meta.Err != nil {
 					return meta.Err
 				}
@@ -184,7 +184,7 @@ func (jr *joinReader) mainLoop(ctx context.Context) error {
 			}
 
 			// Emit the row; stop if no more rows are needed.
-			if !emitHelper(ctx, &jr.out, row, ProducerMetadata{}, jr.input) {
+			if !emitHelper(ctx, &jr.out, row, nil /* meta */, jr.input) {
 				return nil
 			}
 		}

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -202,7 +202,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	t.Run("ConsumerDone", func(t *testing.T) {
 		expectedMetaErr := errors.New("dummy")
 		in := NewRowBuffer(oneIntCol, nil /* rows */, RowBufferArgs{})
-		if status := in.Push(encRow, ProducerMetadata{Err: expectedMetaErr}); status != NeedMoreRows {
+		if status := in.Push(encRow, &ProducerMetadata{Err: expectedMetaErr}); status != NeedMoreRows {
 			t.Fatalf("unexpected response: %d", status)
 		}
 

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -110,12 +110,13 @@ func (m *mergeJoiner) close() {
 // terminated, either due to being indicated by the consumer, or because the
 // processor ran out of rows or encountered an error. It is ok for err to be
 // nil indicating that we're done producing rows even though no error occurred.
-func (m *mergeJoiner) producerMeta(err error) ProducerMetadata {
-	var meta ProducerMetadata
+func (m *mergeJoiner) producerMeta(err error) *ProducerMetadata {
+	var meta *ProducerMetadata
 	if !m.closed {
-		meta = ProducerMetadata{Err: err}
-		if err == nil {
-			meta.TraceData = getTraceData(m.ctx)
+		if err != nil {
+			meta = &ProducerMetadata{Err: err}
+		} else if trace := getTraceData(m.ctx); trace != nil {
+			meta = &ProducerMetadata{TraceData: trace}
 		}
 		// We need to close as soon as we send producer metadata as we're done
 		// sending rows. The consumer is allowed to not call ConsumerDone().
@@ -124,7 +125,7 @@ func (m *mergeJoiner) producerMeta(err error) ProducerMetadata {
 	return meta
 }
 
-func (m *mergeJoiner) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
+func (m *mergeJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	if m.maybeStart("merge joiner", "MergeJoiner") {
 		m.evalCtx = m.flowCtx.NewEvalCtx()
 		m.cancelChecker = sqlbase.NewCancelChecker(m.ctx)
@@ -134,7 +135,7 @@ func (m *mergeJoiner) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 	for {
 		row, meta := m.nextRow()
 		if m.closed || meta != nil {
-			return nil, *meta
+			return nil, meta
 		}
 		if row == nil {
 			return nil, m.producerMeta(nil /* err */)
@@ -158,7 +159,7 @@ func (m *mergeJoiner) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 			m.rightSource.ConsumerDone()
 			continue
 		}
-		return outRow, ProducerMetadata{}
+		return outRow, nil
 	}
 }
 

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -69,7 +69,7 @@ func TestOutbox(t *testing.T) {
 			row := sqlbase.EncDatumRow{
 				sqlbase.DatumToEncDatum(intType, tree.NewDInt(tree.DInt(0))),
 			}
-			if consumerStatus := outbox.Push(row, ProducerMetadata{}); consumerStatus != NeedMoreRows {
+			if consumerStatus := outbox.Push(row, nil /* meta */); consumerStatus != NeedMoreRows {
 				return errors.Errorf("expected status: %d, got: %d", NeedMoreRows, consumerStatus)
 			}
 
@@ -78,7 +78,7 @@ func TestOutbox(t *testing.T) {
 				row = sqlbase.EncDatumRow{
 					sqlbase.DatumToEncDatum(intType, tree.NewDInt(tree.DInt(-1))),
 				}
-				consumerStatus := outbox.Push(row, ProducerMetadata{})
+				consumerStatus := outbox.Push(row, nil /* meta */)
 				if consumerStatus == DrainRequested {
 					break
 				}
@@ -89,13 +89,13 @@ func TestOutbox(t *testing.T) {
 
 			// Now send another row that the outbox will discard.
 			row = sqlbase.EncDatumRow{sqlbase.DatumToEncDatum(intType, tree.NewDInt(tree.DInt(2)))}
-			if consumerStatus := outbox.Push(row, ProducerMetadata{}); consumerStatus != DrainRequested {
+			if consumerStatus := outbox.Push(row, nil /* meta */); consumerStatus != DrainRequested {
 				return errors.Errorf("expected status: %d, got: %d", NeedMoreRows, consumerStatus)
 			}
 
 			// Send some metadata.
-			outbox.Push(nil /* row */, ProducerMetadata{Err: errors.Errorf("meta 0")})
-			outbox.Push(nil /* row */, ProducerMetadata{Err: errors.Errorf("meta 1")})
+			outbox.Push(nil /* row */, &ProducerMetadata{Err: errors.Errorf("meta 0")})
+			outbox.Push(nil /* row */, &ProducerMetadata{Err: errors.Errorf("meta 1")})
 			// Send the termination signal.
 			outbox.ProducerDone()
 

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -134,7 +134,7 @@ func TestRouters(t *testing.T) {
 				for j := 0; j < numCols; j++ {
 					row[j] = vals[j][rng.Intn(len(vals[j]))]
 				}
-				if status := r.Push(row, ProducerMetadata{}); status != NeedMoreRows {
+				if status := r.Push(row, nil /* meta */); status != NeedMoreRows {
 					t.Fatalf("unexpected status: %d", status)
 				}
 			}
@@ -333,7 +333,7 @@ func TestConsumerStatus(t *testing.T) {
 			}
 
 			// Push a row and expect NeedMoreRows.
-			consumerStatus := router.Push(row0, ProducerMetadata{})
+			consumerStatus := router.Push(row0, nil /* meta */)
 			if consumerStatus != NeedMoreRows {
 				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 			}
@@ -341,22 +341,22 @@ func TestConsumerStatus(t *testing.T) {
 			// Start draining stream 0. Keep expecting NeedMoreRows, regardless on
 			// which stream we send.
 			bufs[0].ConsumerDone()
-			consumerStatus = router.Push(row0, ProducerMetadata{})
+			consumerStatus = router.Push(row0, nil /* meta */)
 			if consumerStatus != NeedMoreRows {
 				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 			}
-			consumerStatus = router.Push(row1, ProducerMetadata{})
+			consumerStatus = router.Push(row1, nil /* meta */)
 			if consumerStatus != NeedMoreRows {
 				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 			}
 
 			// Close stream 0. Continue to expect NeedMoreRows.
 			bufs[0].ConsumerClosed()
-			consumerStatus = router.Push(row0, ProducerMetadata{})
+			consumerStatus = router.Push(row0, nil /* meta */)
 			if consumerStatus != NeedMoreRows {
 				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 			}
-			consumerStatus = router.Push(row1, ProducerMetadata{})
+			consumerStatus = router.Push(row1, nil /* meta */)
 			if consumerStatus != NeedMoreRows {
 				t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 			}
@@ -365,7 +365,7 @@ func TestConsumerStatus(t *testing.T) {
 			// DrainRequested.
 			bufs[1].ConsumerDone()
 			testutils.SucceedsSoon(t, func() error {
-				status := router.Push(row1, ProducerMetadata{})
+				status := router.Push(row1, nil /* meta */)
 				if status != DrainRequested {
 					return fmt.Errorf("expected status %d, got: %d", DrainRequested, consumerStatus)
 				}
@@ -376,7 +376,7 @@ func TestConsumerStatus(t *testing.T) {
 			// only detect this when trying to send metadata - so we still expect
 			// DrainRequested.
 			bufs[1].ConsumerClosed()
-			consumerStatus = router.Push(row1, ProducerMetadata{})
+			consumerStatus = router.Push(row1, nil /* meta */)
 			if consumerStatus != DrainRequested {
 				t.Fatalf("expected status %d, got: %d", DrainRequested, consumerStatus)
 			}
@@ -385,7 +385,7 @@ func TestConsumerStatus(t *testing.T) {
 			// that everything's closed now.
 			testutils.SucceedsSoon(t, func() error {
 				consumerStatus := router.Push(
-					nil /* row */, ProducerMetadata{Err: errors.Errorf("test error")},
+					nil /* row */, &ProducerMetadata{Err: errors.Errorf("test error")},
 				)
 				if consumerStatus != ConsumerClosed {
 					return fmt.Errorf("expected status %d, got: %d", ConsumerClosed, consumerStatus)
@@ -460,7 +460,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 
 			// Push metadata; it should go to stream 0.
 			for i := 0; i < 10; i++ {
-				consumerStatus := router.Push(nil /* row */, ProducerMetadata{Err: err1})
+				consumerStatus := router.Push(nil /* row */, &ProducerMetadata{Err: err1})
 				if consumerStatus != NeedMoreRows {
 					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 				}
@@ -473,7 +473,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 			chans[0].ConsumerDone()
 			// Push metadata; it should still go to stream 0.
 			for i := 0; i < 10; i++ {
-				consumerStatus := router.Push(nil /* row */, ProducerMetadata{Err: err2})
+				consumerStatus := router.Push(nil /* row */, &ProducerMetadata{Err: err2})
 				if consumerStatus != NeedMoreRows {
 					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 				}
@@ -488,7 +488,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 			// Metadata should switch to going to stream 1 once the new status is
 			// observed.
 			testutils.SucceedsSoon(t, func() error {
-				consumerStatus := router.Push(nil /* row */, ProducerMetadata{Err: err3})
+				consumerStatus := router.Push(nil /* row */, &ProducerMetadata{Err: err3})
 				if consumerStatus != NeedMoreRows {
 					t.Fatalf("expected status %d, got: %d", NeedMoreRows, consumerStatus)
 				}
@@ -513,7 +513,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 			}
 
 			testutils.SucceedsSoon(t, func() error {
-				consumerStatus := router.Push(nil /* row */, ProducerMetadata{Err: err4})
+				consumerStatus := router.Push(nil /* row */, &ProducerMetadata{Err: err4})
 				if consumerStatus != ConsumerClosed {
 					return fmt.Errorf("expected status %d, got: %d", ConsumerClosed, consumerStatus)
 				}
@@ -530,7 +530,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 func drainRowChannel(rc *RowChannel) {
 	for {
 		row, meta := rc.Next()
-		if row == nil && meta.Empty() {
+		if row == nil && meta == nil {
 			return
 		}
 	}
@@ -591,7 +591,7 @@ func TestRouterBlocks(t *testing.T) {
 						break Loop
 					default:
 						row := sqlbase.RandEncDatumRowOfTypes(rng, colTypes)
-						status := router.Push(row, ProducerMetadata{})
+						status := router.Push(row, nil /* meta */)
 						if status != NeedMoreRows {
 							break Loop
 						}

--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -129,7 +129,7 @@ func (s *sampleAggregator) mainLoop(ctx context.Context) (earlyExit bool, _ erro
 	var tmpSketch hyperloglog.Sketch
 	for {
 		row, meta := s.input.Next()
-		if !meta.Empty() {
+		if meta != nil {
 			if !emitHelper(ctx, &s.out, nil /* row */, meta, s.input) {
 				// No cleanup required; emitHelper() took care of it.
 				return true, nil

--- a/pkg/sql/distsqlrun/sample_aggregator_test.go
+++ b/pkg/sql/distsqlrun/sample_aggregator_test.go
@@ -120,7 +120,7 @@ func TestSampleAggregator(t *testing.T) {
 		if row == nil {
 			outputs = append(outputs[:i], outputs[i+1:]...)
 		} else {
-			samplerResults.Push(row, ProducerMetadata{})
+			samplerResults.Push(row, nil /* meta */)
 		}
 	}
 

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -149,7 +149,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, _ erro
 	var buf []byte
 	for {
 		row, meta := s.input.Next()
-		if !meta.Empty() {
+		if meta != nil {
 			if !emitHelper(ctx, &s.out, nil /* row */, meta, s.input) {
 				// No cleanup required; emitHelper() took care of it.
 				return true, nil
@@ -193,7 +193,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, _ erro
 	for _, sample := range s.sr.Get() {
 		copy(outRow, sample.Row)
 		outRow[s.rankCol] = sqlbase.EncDatum{Datum: tree.NewDInt(tree.DInt(sample.Rank))}
-		if !emitHelper(ctx, &s.out, outRow, ProducerMetadata{}, s.input) {
+		if !emitHelper(ctx, &s.out, outRow, nil /* meta */, s.input) {
 			return true, nil
 		}
 	}
@@ -214,7 +214,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, _ erro
 			return false, err
 		}
 		outRow[s.sketchCol] = sqlbase.EncDatum{Datum: tree.NewDBytes(tree.DBytes(data))}
-		if !emitHelper(ctx, &s.out, outRow, ProducerMetadata{}, s.input) {
+		if !emitHelper(ctx, &s.out, outRow, nil /* meta */, s.input) {
 			return true, nil
 		}
 	}

--- a/pkg/sql/distsqlrun/stream_data_test.go
+++ b/pkg/sql/distsqlrun/stream_data_test.go
@@ -35,13 +35,13 @@ func testGetDecodedRows(
 		if err != nil {
 			tb.Fatal(err)
 		}
-		if row == nil && meta.Empty() {
+		if row == nil && meta == nil {
 			break
 		}
 		if row != nil {
 			decodedRows = append(decodedRows, row)
 		} else {
-			metas = append(metas, meta)
+			metas = append(metas, *meta)
 		}
 	}
 	return decodedRows, metas
@@ -139,7 +139,7 @@ func TestEmptyStreamEncodeDecode(t *testing.T) {
 	}
 	if row, meta, err := sd.GetRow(nil /* rowBuf */); err != nil {
 		t.Fatal(err)
-	} else if !meta.Empty() || row != nil {
+	} else if meta != nil || row != nil {
 		t.Errorf("received bogus row %v %v", row, meta)
 	}
 }

--- a/pkg/sql/distsqlrun/stream_decoder.go
+++ b/pkg/sql/distsqlrun/stream_decoder.go
@@ -131,9 +131,9 @@ func (sd *StreamDecoder) AddMessage(msg *ProducerMessage) error {
 // coming from the upstream (through ProducerMetadata.Err).
 func (sd *StreamDecoder) GetRow(
 	rowBuf sqlbase.EncDatumRow,
-) (sqlbase.EncDatumRow, ProducerMetadata, error) {
+) (sqlbase.EncDatumRow, *ProducerMetadata, error) {
 	if len(sd.metadata) != 0 {
-		r := sd.metadata[0]
+		r := &sd.metadata[0]
 		sd.metadata = sd.metadata[1:]
 		return nil, r, nil
 	}
@@ -141,11 +141,11 @@ func (sd *StreamDecoder) GetRow(
 	if sd.numEmptyRows > 0 {
 		sd.numEmptyRows--
 		row := make(sqlbase.EncDatumRow, 0) // this doesn't actually allocate.
-		return row, ProducerMetadata{}, nil
+		return row, nil, nil
 	}
 
 	if len(sd.data) == 0 {
-		return nil, ProducerMetadata{}, nil
+		return nil, nil, nil
 	}
 	rowLen := len(sd.typing)
 	if cap(rowBuf) >= rowLen {
@@ -161,10 +161,10 @@ func (sd *StreamDecoder) GetRow(
 		if err != nil {
 			// Reset sd because it is no longer usable.
 			*sd = StreamDecoder{}
-			return nil, ProducerMetadata{}, err
+			return nil, nil, err
 		}
 	}
-	return rowBuf, ProducerMetadata{}, nil
+	return rowBuf, nil, nil
 }
 
 // Types returns the types of the columns; can only be used after we received at

--- a/pkg/sql/distsqlrun/stream_group_accumulator.go
+++ b/pkg/sql/distsqlrun/stream_group_accumulator.go
@@ -57,7 +57,7 @@ func (s *streamGroupAccumulator) advanceGroup(
 			if meta.Err != nil {
 				return nil, meta.Err
 			}
-			_ = metadataSink.Push(nil /* row */, *meta)
+			_ = metadataSink.Push(nil /* row */, meta)
 			continue
 		}
 		return batch, nil
@@ -75,12 +75,8 @@ func (s *streamGroupAccumulator) nextGroup(
 
 	for {
 		row, meta := s.src.Next()
-		if !meta.Empty() {
-			// Return a new pointer. Doing this copy manually is much better than
-			// returning &meta because it doesn't force meta on to the heap.
-			t := &ProducerMetadata{}
-			*t = meta
-			return nil, t
+		if meta != nil {
+			return nil, meta
 		}
 		if row == nil {
 			s.srcConsumed = true

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -151,7 +151,7 @@ func TestTableReader(t *testing.T) {
 					var res sqlbase.EncDatumRows
 					for {
 						row, meta := out.Next()
-						if !meta.Empty() {
+						if meta != nil {
 							t.Fatalf("unexpected metadata: %+v", meta)
 						}
 						if row == nil {
@@ -238,10 +238,10 @@ ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3
 			}
 
 			var res sqlbase.EncDatumRows
-			var metas []ProducerMetadata
+			var metas []*ProducerMetadata
 			for {
 				row, meta := out.Next()
-				if !meta.Empty() {
+				if meta != nil {
 					metas = append(metas, meta)
 					continue
 				}
@@ -311,7 +311,7 @@ func BenchmarkTableReader(b *testing.B) {
 		}
 		for {
 			row, meta := tr.Next()
-			if !meta.Empty() {
+			if meta != nil {
 				b.Fatalf("unexpected metadata: %+v", meta)
 			}
 			if row == nil {

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -63,14 +63,14 @@ func (r *RepeatableRowSource) OutputTypes() []sqlbase.ColumnType {
 }
 
 // Next is part of the RowSource interface.
-func (r *RepeatableRowSource) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
+func (r *RepeatableRowSource) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	// If we've emitted all rows, signal that we have reached the end.
 	if r.nextRowIdx >= len(r.rows) {
-		return nil, ProducerMetadata{}
+		return nil, nil
 	}
 	nextRow := r.rows[r.nextRowIdx]
 	r.nextRowIdx++
-	return nextRow, ProducerMetadata{}
+	return nextRow, nil
 }
 
 // Reset resets the RepeatableRowSource such that a subsequent call to Next()
@@ -91,7 +91,7 @@ type RowDisposer struct{}
 var _ RowReceiver = &RowDisposer{}
 
 // Push is part of the RowReceiver interface.
-func (r *RowDisposer) Push(row sqlbase.EncDatumRow, meta ProducerMetadata) ConsumerStatus {
+func (r *RowDisposer) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
 	return NeedMoreRows
 }
 
@@ -102,7 +102,7 @@ func (r *RowDisposer) ProducerDone() {}
 // it encounters any metadata.
 func (rb *RowBuffer) NextNoMeta(tb testing.TB) sqlbase.EncDatumRow {
 	row, meta := rb.Next()
-	if !meta.Empty() {
+	if meta != nil {
 		tb.Fatalf("unexpected metadata: %v", meta)
 	}
 	return row


### PR DESCRIPTION
Passing ProducerMetadata by value everywhere was a
pessimization. Passing it by reference reduces the bytes passed/returned
from 64 to 8 in the common case.

```
name                           old time/op    new time/op    delta
MergeJoiner/InputSize=0-8        2.43µs ± 3%    2.31µs ± 1%   -5.04%  (p=0.000 n=10+9)
MergeJoiner/InputSize=4-8        4.30µs ± 2%    4.04µs ± 1%   -5.99%  (p=0.000 n=10+10)
MergeJoiner/InputSize=16-8       7.24µs ± 1%    6.47µs ± 1%  -10.71%  (p=0.000 n=10+10)
MergeJoiner/InputSize=256-8      65.0µs ± 3%    54.0µs ± 1%  -16.99%  (p=0.000 n=10+9)
MergeJoiner/InputSize=4096-8     1.01ms ± 3%    0.83ms ± 1%  -17.75%  (p=0.000 n=10+10)
MergeJoiner/InputSize=65536-8    16.2ms ± 2%    13.5ms ± 1%  -16.58%  (p=0.000 n=9+8)
```

Fixes #20552

Release note (performance improvement): Reduce per-row overhead in
distsql query execution.

Note that all but the last commit are part of #21219.