### PR TITLE
sql/distsqlrun: elide RowChannel in simple cases

### DIFF
--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -372,6 +372,52 @@ func (f *Flow) setup(ctx context.Context, spec *FlowSpec) error {
 		if err != nil {
 			return err
 		}
+
+		// If the processor implements RowSource try to hook it up directly to the
+		// input of a later processor.
+		source, ok := f.processors[i].(RowSource)
+		if !ok {
+			continue
+		}
+		pspec := &spec.Processors[i]
+		if len(pspec.Output) != 1 {
+			// The processor has more than one output, use the normal routing
+			// machinery.
+			continue
+		}
+		ospec := &pspec.Output[0]
+		if ospec.Type != OutputRouterSpec_PASS_THROUGH {
+			// The output is not pass-through and thus is being sent through a
+			// router.
+			continue
+		}
+		if len(ospec.Streams) != 1 {
+			// The output contains more than one stream.
+			continue
+		}
+
+		for pIdx, ps := range spec.Processors {
+			if pIdx <= i {
+				// Skip processors which have already been created.
+				continue
+			}
+			for inIdx, in := range ps.Input {
+				// Look for "simple" inputs: an unordered input (which, by definition,
+				// doesn't require an ordered synchronizer), with a single input stream
+				// (which doesn't require a MultiplexedRowChannel).
+				if in.Type != InputSyncSpec_UNORDERED {
+					continue
+				}
+				if len(in.Streams) != 1 {
+					continue
+				}
+				if in.Streams[0].StreamID != ospec.Streams[0].StreamID {
+					continue
+				}
+				inputSyncs[pIdx][inIdx] = source
+				f.processors[i] = nil
+			}
+		}
 	}
 	return nil
 }
@@ -414,9 +460,11 @@ func (f *Flow) Start(ctx context.Context, doneFn func()) error {
 	for _, s := range f.startables {
 		s.start(f.Ctx, &f.waitGroup, f.ctxCancel)
 	}
-	f.waitGroup.Add(len(f.processors))
 	for _, p := range f.processors {
-		go p.Run(&f.waitGroup)
+		if p != nil {
+			f.waitGroup.Add(1)
+			go p.Run(&f.waitGroup)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Elide RowChannel when connecting local processors in simple cases. A
simple `SELECT COUNT(*) FROM test.kv` query where `test.kv` contains 5m
rows is reduced from 5.4s to 4.3s (a 20% speedup). When using distsql,
this query utilizes a `tableReader` connected to an `aggregator`. For
comparison, this query takes 4.5s when running with `set
distsql=off`. These numbers are from a local single-node cluster.

See #20550

Release note (performance improvement): Speed up distsql query execution
by "fusing" processors executing on the same node together.