### PR TITLE
storage: Update estimatedCommitIndex on heartbeats, not just MsgApps

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -284,6 +284,14 @@ func (r *Replica) GetLastIndex() (uint64, error) {
 	return r.raftLastIndexLocked()
 }
 
+// GetEstimatedCommitIndex returns the replica's estimated raft commit index
+// and how far it thinks it's behind the leader.
+func (r *Replica) GetEstimatedCommitIndex() (index uint64, behind int64) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.mu.estimatedCommitIndex, r.getEstimatedBehindCountRLocked(r.raftStatusRLocked())
+}
+
 // SetQuotaPool allows the caller to set a replica's quota pool initialized to
 // a given quota. Additionally it initializes the replica's quota release queue
 // and its command sizes map. Only safe to call on the replica that is both

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1200,7 +1200,7 @@ func (r *Replica) getEstimatedBehindCountRLocked(raftStatus *raft.Status) int64 
 		// starts to return true. The result is that a restarted node will
 		// consider its replicas far behind initially which will in turn cause it
 		// to reject rebalances.
-		return prohibitRebalancesBehindThreshold + 1
+		return ProhibitRebalancesBehindThreshold + 1
 	}
 	if r.mu.estimatedCommitIndex >= r.mu.state.RaftAppliedIndex {
 		return int64(r.mu.estimatedCommitIndex - r.mu.state.RaftAppliedIndex)
@@ -3302,9 +3302,7 @@ func (r *Replica) stepRaftGroup(req *RaftMessageRequest) error {
 		// We're processing a message from another replica which means that the
 		// other replica is not quiesced, so we don't need to wake the leader.
 		r.unquiesceLocked()
-		if req.Message.Type == raftpb.MsgApp {
-			r.setEstimatedCommitIndexLocked(req.Message.Commit)
-		}
+		r.setEstimatedCommitIndexLocked(req.Message.Commit)
 		r.refreshLastUpdateTimeForReplicaLocked(req.FromReplica.ReplicaID)
 		return false, /* unquiesceAndWakeLeader */
 			raftGroup.Step(req.Message)

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -97,12 +97,12 @@ const (
 	// gossip update.
 	systemDataGossipInterval = 1 * time.Minute
 
-	// prohibitRebalancesBehindThreshold is the maximum number of log entries a
+	// ProhibitRebalancesBehindThreshold is the maximum number of log entries a
 	// store allows its replicas to be behind before it starts declining incoming
 	// rebalances. We prohibit rebalances in this situation to avoid adding
 	// additional work to a store that is either not keeping up or is undergoing
 	// recovery because it is on a recently restarted node.
-	prohibitRebalancesBehindThreshold = 1000
+	ProhibitRebalancesBehindThreshold = 1000
 
 	// Messages that provide detail about why a preemptive snapshot was rejected.
 	incomingRebalancesDisabledMsg = "incoming rebalances disabled because node is behind"
@@ -4174,7 +4174,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.RaftLogFollowerBehindCount.Update(behindCount)
 	s.metrics.RaftLogSelfBehindCount.Update(selfBehindCount)
 
-	if selfBehindCount > prohibitRebalancesBehindThreshold {
+	if selfBehindCount > ProhibitRebalancesBehindThreshold {
 		log.Infof(ctx, "temporarily disabling rebalances because RaftLogSelfBehindCount=%d", selfBehindCount)
 		atomic.StoreInt32(&s.incomingRebalancesDisabled, 1)
 	} else {


### PR DESCRIPTION
If estimatedCommitIndex doesn't get updated properly, then preemptive
snapshots to that node can be blocked, as we've seen in a couple test
clusters.

Partial fix for #21102 and #20519. If a node restarts and a range isn't
actively processing writes, no MsgApps are guaranteed to be sent.
I don't understand exactly the situations in play that have caused the
problems in #21102 and #20047, though, so I don't think this is a full
fix. That's backed up by the fact that I can still get
TestEstimatedCommitIndexAfterRestart to flake when run under stressrace.

I can investigate the flake and hope to drill down other corner cases,
but I'm far more inclined to just remove the logic that estimates we're
very far behind if we don't have an estimatedCommitIndex yet. The
estimated commit index isn't all that reliable, and with lazy replica
initialization it seems tricky to guarantee that a restarted replica
will learn of the leader's commit index. Most importantly, the only real
intent of the code is to not start accepting preemptive snapshots too
soon after restart, which can be done more directly.

Release note: None

@bdarnell unless you're aware of major reasons to keep `ProhibitRebalancesBehindThreshold` around, I'll pull it out for the reasoning explained above.