### PR TITLE
[DNM] Demonstrate DistSQL MaxOffset correctness problem

### DIFF
--- a/experiment.sh
+++ b/experiment.sh
@@ -17,6 +17,9 @@ sleep 1
 
 ./cockroach init --insecure
 
+./cockroach sql --insecure -e "set cluster setting sql.defaults.distsql = on"
+./cockroach sql --insecure -e "set cluster setting trace.debug.enable = on"
+
 go run pkg/testutils/workload/cmd/workload/*.go sillyseq \
   --concurrency 24 --duration 10s \
   --tolerate-errors \

--- a/experiment.sh
+++ b/experiment.sh
@@ -2,25 +2,30 @@
 
 set -euxo pipefail
 
+distsql=${1}
+
 killall -9 cockroach || true
 rm -rf cockroach-data
 
-#make build
+
+make build
 
 for i in 0 1 2; do
-  ./cockroach start --insecure --max-offset=experimental-clockless --port $((26257+i)) --http-port $((8080+i)) --store cockroach-data/clockless$i --join :26257 &
+  # ./cockroach start --insecure --max-offset=experimental-clockless --port $((26257+i)) --http-port $((8080+i)) --store cockroach-data/clockless$i --join :26257 &
   # uncomment for "regular mode"
-  # ./cockroach start --insecure --port $((26257+i)) --http-port $((8080+i)) --store cockroach-data/clockless$i --join :26257 &
+  ./cockroach start --insecure --port $((26257+i)) --http-port $((8080+i)) --store cockroach-data/clockless$i --join :26257 &
 done
 
 sleep 1
 
 ./cockroach init --insecure
 
-./cockroach sql --insecure -e "set cluster setting sql.defaults.distsql = on"
+./cockroach sql --insecure -e "set cluster setting sql.defaults.distsql = ${distsql}"
 ./cockroach sql --insecure -e "set cluster setting trace.debug.enable = on"
 
+sleep 10
+
 go run pkg/testutils/workload/cmd/workload/*.go sillyseq \
-  --concurrency 24 --duration 10s \
+  --concurrency 24 --max-ops 1000 \
   --tolerate-errors \
   "postgres://root@localhost:26257?sslmode=disable postgres://root@localhost:26258?sslmode=disable postgres://root@localhost:26259?sslmode=disable"

--- a/experiment.sh
+++ b/experiment.sh
@@ -5,18 +5,19 @@ set -euxo pipefail
 killall -9 cockroach || true
 rm -rf cockroach-data
 
-make build
+#make build
 
 for i in 0 1 2; do
-  #./cockroach start --insecure --max-offset=experimental-clockless --port $((26257+i)) --http-port $((8080+i)) --store cockroach-data/clockless$i --join :26257 &
+  ./cockroach start --insecure --max-offset=experimental-clockless --port $((26257+i)) --http-port $((8080+i)) --store cockroach-data/clockless$i --join :26257 &
   # uncomment for "regular mode"
-  ./cockroach start --insecure --port $((26257+i)) --http-port $((8080+i)) --store cockroach-data/clockless$i --join :26257 &
+  # ./cockroach start --insecure --port $((26257+i)) --http-port $((8080+i)) --store cockroach-data/clockless$i --join :26257 &
 done
 
-sleep 3
+sleep 1
 
 ./cockroach init --insecure
 
 go run pkg/testutils/workload/cmd/workload/*.go sillyseq \
-  --concurrency 24 --tolerate-errors --duration 1h \
+  --concurrency 24 --duration 10s \
+  --tolerate-errors \
   "postgres://root@localhost:26257?sslmode=disable postgres://root@localhost:26258?sslmode=disable postgres://root@localhost:26259?sslmode=disable"

--- a/experiment.sh
+++ b/experiment.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+killall -9 cockroach || true
+rm -rf cockroach-data
+
+make build
+
+for i in 0 1 2; do
+  #./cockroach start --insecure --max-offset=experimental-clockless --port $((26257+i)) --http-port $((8080+i)) --store cockroach-data/clockless$i --join :26257 &
+  # uncomment for "regular mode"
+  ./cockroach start --insecure --port $((26257+i)) --http-port $((8080+i)) --store cockroach-data/clockless$i --join :26257 &
+done
+
+sleep 3
+
+./cockroach init --insecure
+
+go run pkg/testutils/workload/cmd/workload/*.go sillyseq \
+  --concurrency 24 --tolerate-errors --duration 1h \
+  "postgres://root@localhost:26257?sslmode=disable postgres://root@localhost:26258?sslmode=disable postgres://root@localhost:26259?sslmode=disable"

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -485,7 +485,7 @@ func (ds *DistSender) initAndVerifyBatch(
 		txnClone := ba.Txn.Clone()
 		ba.Txn = &txnClone
 
-		if len(ba.Txn.ObservedTimestamps) == 0 {
+		if len(ba.Txn.ObservedTimestamps) == 0 && true { // change to `false` to show that this code path is active too much with DistSQL=on
 			// Ensure the local NodeID is marked as free from clock offset;
 			// the transaction's timestamp was taken off the local clock.
 			// TODO(andrei): This is broken when Txn.OrigTimestamp has not been, in

--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -264,7 +264,8 @@ func (ag *aggregator) Next() (sqlbase.EncDatumRow, ProducerMetadata) {
 		ag.buckets = nil
 
 		ag.accumulating = false
-		log.VEvent(ag.ctx, 1, "accumulation complete")
+		// HACK: causes panic in this workload
+		// log.VEvent(ag.ctx, 1, "accumulation complete")
 
 		ag.row = make(sqlbase.EncDatumRow, len(ag.funcs))
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1217,6 +1217,7 @@ CockroachDB supports the following flags:
 			Category:   categorySystemInfo,
 			Impure:     true,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				time.Sleep(100 * time.Millisecond)
 				return ctx.GetClusterTimestamp(), nil
 			},
 			Info: "This function is used only by CockroachDB's developers for testing purposes.",

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2482,6 +2482,7 @@ func (s *Store) Send(
 			// the above timestamp to the returned response or error. The caller
 			// can use it to shorten its uncertainty interval when it comes back to
 			// this node.
+			log.Infof(ctx, "GREPME %s %s %s %v %v", ba.Txn.ID.Short(), ba.Summary(), ba.Txn.MaxTimestamp, ba.Txn.ObservedTimestamps, pErr)
 			if pErr != nil {
 				pErr.OriginNode = ba.Replica.NodeID
 				if txn := pErr.GetTxn(); txn != nil {

--- a/pkg/testutils/workload/cmd/workload/main.go
+++ b/pkg/testutils/workload/cmd/workload/main.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/testutils/workload"
 	_ "github.com/cockroachdb/cockroach/pkg/testutils/workload/kv"
+	_ "github.com/cockroachdb/cockroach/pkg/testutils/workload/sillyseq"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"

--- a/pkg/testutils/workload/sillyseq/sillyseq.go
+++ b/pkg/testutils/workload/sillyseq/sillyseq.go
@@ -82,8 +82,8 @@ func (g *sillyseq) Ops() []workload.Operation {
 	// qRead1 = `SELECT 1`
 	// Lots of RWU with distsql=auto, very few with distsql=on
 	qRead1 := fmt.Sprintf(`SELECT k FROM test.%s LIMIT 1`, table)
-	// Need to test:
-	// qRead1 := "SELECT cluster_logical_timestamp()"
+	// Basically no RWUs, no matter the distsql mode.
+	// qRead1 := "SELECT CASE WHEN cluster_logical_timestamp()::string = 'foo' THEN 1 ELSE 0 END"
 	// Nearly no RWUs, surprisingly:
 	// qRead1 := fmt.Sprintf(`SELECT COUNT(*) FROM test.%s`, table) // 6-10 over 1.6k ops. less with distsql off (0-3)
 	qRead2 := fmt.Sprintf(`SELECT COUNT(*) FROM test.%s`, table)
@@ -114,6 +114,7 @@ func (g *sillyseq) Ops() []workload.Operation {
 				if err := txn.QueryRow(qRead2).Scan(&n); err != nil {
 					return errors.Wrap(err, "on read 2")
 				}
+				fmt.Print(".")
 				return errors.Wrap(txn.Commit(), "read-commit")
 			}
 

--- a/pkg/testutils/workload/sillyseq/sillyseq.go
+++ b/pkg/testutils/workload/sillyseq/sillyseq.go
@@ -80,10 +80,10 @@ func (g *sillyseq) Ops() []workload.Operation {
 	table := g.Name()
 	// No RWU:
 	// qRead1 = `SELECT 1`
-	// Lots of RWU with distsql=auto, very few with distsql=on
-	qRead1 := fmt.Sprintf(`SELECT k FROM test.%s LIMIT 1`, table)
-	// Basically no RWUs, no matter the distsql mode.
-	// qRead1 := "SELECT CASE WHEN cluster_logical_timestamp()::string = 'foo' THEN 1 ELSE 0 END"
+	// Lots of RWU unless distsql=on
+	// qRead1 := fmt.Sprintf(`SELECT k FROM test.%s LIMIT 1`, table)
+	// Lots of RWUs unless distsql=on, but need to `time.Sleep(100*time.Millsecond)` in `cluster_logical_timestamp`.
+	qRead1 := "SELECT CASE WHEN cluster_logical_timestamp()::string = 'foo' THEN 1 ELSE 0 END"
 	// Nearly no RWUs, surprisingly:
 	// qRead1 := fmt.Sprintf(`SELECT COUNT(*) FROM test.%s`, table) // 6-10 over 1.6k ops. less with distsql off (0-3)
 	qRead2 := fmt.Sprintf(`SELECT COUNT(*) FROM test.%s`, table)

--- a/pkg/testutils/workload/workload.go
+++ b/pkg/testutils/workload/workload.go
@@ -139,7 +139,8 @@ func Setup(db *gosql.DB, tables []Table, batchSize int) (int64, error) {
 
 	var size int64
 	for _, table := range tables {
-		createStmt := fmt.Sprintf(`CREATE TABLE %s %s`, table.Name, table.Schema)
+		createStmt := fmt.Sprintf(`DROP TABLE IF EXISTS %s; CREATE TABLE %s %s`, table.Name, table.Name, table.Schema)
+		fmt.Println(createStmt)
 		if _, err := db.Exec(createStmt); err != nil {
 			return 0, err
 		}

--- a/pkg/testutils/workload/workload.go
+++ b/pkg/testutils/workload/workload.go
@@ -139,7 +139,7 @@ func Setup(db *gosql.DB, tables []Table, batchSize int) (int64, error) {
 
 	var size int64
 	for _, table := range tables {
-		createStmt := fmt.Sprintf(`DROP TABLE IF EXISTS %s; CREATE TABLE %s %s`, table.Name, table.Name, table.Schema)
+		createStmt := fmt.Sprintf(`CREATE TABLE %s %s`, table.Name, table.Schema)
 		fmt.Println(createStmt)
 		if _, err := db.Exec(createStmt); err != nil {
 			return 0, err


### PR DESCRIPTION
NB: This PR is a mess as it includes ongoing experiments that I'm running
for a different issue. This PR is just something I ran into and wanted to
document as it requires resolution.

In this WIP, we run a workload in which there are multiple concurrent
operations. Each of those is either a fast non-conflicting write, or a
sequence of two reads, the first grabbing just one row, and the second
sleeping for a short time and then touching everything.

The table here is very small (due to the short duration of the test) and
there is no manual transaction management.

The only statement that can't be auto-retried at the gateway is the second
read, and the only error that read expects is a
ReadWithinUncertaintyIntervalError.

When we “visit” a node and make a note of its timestamp, we aren’t actually
guaranteed that we won’t see RWUs for a future read. Say a txn starts with
Orig=1, Max=10 and then reads some insignificant key at node1 at 5. So the
next time we visit node1 again for a full range scan. Now in that range,
there are various values at timestamps between 1 and 5 that we didn’t see
before, and all of those are going to trigger RWUs, since they’re in the
window `[OrigTimestamp, 5)`. So TL;DR: we expect to see RWUs in this
workload.

This experiment shows that when distsql=off (or auto), we get these errors (in
~10% of ops, and remember that only 50% of ops are even reads that can get this
error, so it's really one out of five reads that fails that way -- pretty
frequent).

However, with distsql=on (which will force the first read through DistSQL; the
second one is always using DistSQL when not disabled), they vanish (with rare
exceptions).

This exposes a problem in the DistSQL execution path that has been pointed out
by @andreimatei before: we try to mark the "local node" as "super certain" (i.e.
`MaxTiemstamp = OrigTimestamp`) eagerly to optimize for this case, but with
DistSQL execution, the node that code runs on isn't necessary local (it's the
one being planned on). So when we force the first (small) select through
DistSQL, it'll schedule it on the lease holder, and the lease holder will mark
that node as certain (even though it's not, at least not for
`txn.OrigTimestamp`; it would be safe with a timestamp off that node's clock).
This means that when the "big" select query comes in, it will never see RWUs as
`MaxTimestamp == OrigTimestamp`.

It's a bit unfortunate that we didn't address this known problem earlier (since
it's a correctness problem), and we should fix it now.

Assigning to @andreimatei for discussion. We definitely have to move that
code elsewhere, is the suggestion in your comment still appropriate?
 