### PR TITLE
sql: move the session vars out of the Session

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -388,7 +388,7 @@ func resolveTargetsToDescriptors(
 		}
 	}
 
-	sessionDatabase := p.EvalContext().Database
+	sessionDatabase := p.SessionData().Database
 
 	var matched descriptorsMatched
 	if matched, err = descriptorsMatchingTargets(sessionDatabase, allDescs, targets); err != nil {
@@ -659,7 +659,9 @@ func backupPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer tracing.FinishSpan(span)
 
-		if err := backupStmt.Targets.NormalizeTablesWithDatabase(p.EvalContext().Database); err != nil {
+		if err := backupStmt.Targets.NormalizeTablesWithDatabase(
+			p.SessionData().Database,
+		); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -74,7 +74,7 @@ func loadBackupDescs(
 func selectTargets(
 	p sql.PlanHookState, backupDescs []BackupDescriptor, targets tree.TargetList,
 ) ([]sqlbase.Descriptor, []*sqlbase.DatabaseDescriptor, error) {
-	sessionDatabase := p.EvalContext().Database
+	sessionDatabase := p.SessionData().Database
 	lastBackupDesc := backupDescs[len(backupDescs)-1]
 	matched, err := descriptorsMatchingTargets(sessionDatabase, lastBackupDesc.Descriptors, targets)
 	if err != nil {
@@ -1068,7 +1068,9 @@ func doRestorePlan(
 	opts map[string]string,
 	resultsCh chan<- tree.Datums,
 ) error {
-	if err := restoreStmt.Targets.NormalizeTablesWithDatabase(p.EvalContext().Database); err != nil {
+	if err := restoreStmt.Targets.NormalizeTablesWithDatabase(
+		p.SessionData().Database,
+	); err != nil {
 		return err
 	}
 	backupDescs, err := loadBackupDescs(ctx, from, p.ExecCfg().Settings)

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -60,7 +60,9 @@ func (n *alterIndexNode) startExec(params runParams) error {
 		switch t := cmd.(type) {
 		case *tree.AlterIndexPartitionBy:
 			partitioning, err := CreatePartitioning(
-				params.ctx, params.p.evalCtx.Settings, &params.p.evalCtx, n.tableDesc, n.indexDesc, t.PartitionBy)
+				params.ctx, params.extendedEvalCtx.Settings,
+				params.EvalContext(),
+				n.tableDesc, n.indexDesc, t.PartitionBy)
 			if err != nil {
 				return err
 			}
@@ -105,14 +107,17 @@ func (n *alterIndexNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogAlterIndex,
 		int32(n.tableDesc.ID),
-		int32(params.evalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID),
 		struct {
 			TableName  string
 			IndexName  string
 			Statement  string
 			User       string
 			MutationID uint32
-		}{n.tableDesc.Name, n.indexDesc.Name, n.n.String(), params.p.session.User, uint32(mutationID)},
+		}{
+			n.tableDesc.Name, n.indexDesc.Name, n.n.String(),
+			params.SessionData().User, uint32(mutationID),
+		},
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -29,7 +29,7 @@ type alterSequenceNode struct {
 
 // AlterSequence transforms a tree.AlterSequence into a plan node.
 func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (planNode, error) {
-	tn, err := n.Name.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := n.Name.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}
@@ -72,12 +72,12 @@ func (n *alterSequenceNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogAlterSequence,
 		int32(n.seqDesc.ID),
-		int32(params.evalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID),
 		struct {
 			SequenceName string
 			Statement    string
 			User         string
-		}{n.seqDesc.Name, n.n.String(), params.p.session.User},
+		}{n.seqDesc.Name, n.n.String(), params.SessionData().User},
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -39,7 +39,7 @@ type alterTableNode struct {
 //   notes: postgres requires CREATE on the table.
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode, error) {
-	tn, err := n.Table.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := n.Table.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return pgerror.Unimplemented(
 					"alter add fk", "adding a REFERENCES constraint via ALTER not supported")
 			}
-			col, idx, err := sqlbase.MakeColumnDefDescs(d, &params.p.semaCtx, params.evalCtx)
+			col, idx, err := sqlbase.MakeColumnDefDescs(d, &params.p.semaCtx, params.EvalContext())
 			if err != nil {
 				return err
 			}
@@ -144,8 +144,9 @@ func (n *alterTableNode) startExec(params runParams) error {
 					return err
 				}
 				if d.PartitionBy != nil {
-					partitioning, err := CreatePartitioning(params.ctx, params.p.ExecCfg().Settings,
-						params.evalCtx, n.tableDesc, &idx, d.PartitionBy)
+					partitioning, err := CreatePartitioning(
+						params.ctx, params.p.ExecCfg().Settings,
+						params.EvalContext(), n.tableDesc, &idx, d.PartitionBy)
 					if err != nil {
 						return err
 					}
@@ -162,7 +163,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 
 			case *tree.CheckConstraintTableDef:
-				ck, err := makeCheckConstraint(*n.tableDesc, d, inuseNames, &params.p.semaCtx, params.evalCtx)
+				ck, err := makeCheckConstraint(
+					*n.tableDesc, d, inuseNames, &params.p.semaCtx, params.EvalContext())
 				if err != nil {
 					return err
 				}
@@ -171,7 +173,9 @@ func (n *alterTableNode) startExec(params runParams) error {
 				descriptorChanged = true
 
 			case *tree.ForeignKeyConstraintTableDef:
-				if _, err := d.Table.NormalizeWithDatabaseName(params.p.session.Database); err != nil {
+				if _, err := d.Table.NormalizeWithDatabaseName(
+					params.SessionData().Database,
+				); err != nil {
 					return err
 				}
 				affected := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
@@ -191,7 +195,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 			}
 
 		case *tree.AlterTableDropColumn:
-			if params.p.session.SafeUpdates {
+			if params.SessionData().SafeUpdates {
 				return pgerror.NewDangerousStatementErrorf("ALTER TABLE DROP COLUMN will remove all data in that column")
 			}
 
@@ -460,7 +464,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return fmt.Errorf("column %q in the middle of being dropped", t.GetColumn())
 			}
 			if err := applyColumnMutation(
-				&col, t, &params.p.semaCtx, params.evalCtx,
+				&col, t, &params.p.semaCtx, params.EvalContext(),
 			); err != nil {
 				return err
 			}
@@ -468,8 +472,10 @@ func (n *alterTableNode) startExec(params runParams) error {
 			descriptorChanged = true
 
 		case *tree.AlterTablePartitionBy:
-			partitioning, err := CreatePartitioning(params.ctx, params.p.ExecCfg().Settings,
-				&params.p.evalCtx, n.tableDesc, &n.tableDesc.PrimaryIndex, t.PartitionBy)
+			partitioning, err := CreatePartitioning(
+				params.ctx, params.p.ExecCfg().Settings,
+				params.EvalContext(),
+				n.tableDesc, &n.tableDesc.PrimaryIndex, t.PartitionBy)
 			if err != nil {
 				return err
 			}
@@ -524,14 +530,14 @@ func (n *alterTableNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogAlterTable,
 		int32(n.tableDesc.ID),
-		int32(params.evalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID),
 		struct {
 			TableName           string
 			Statement           string
 			User                string
 			MutationID          uint32
 			CascadeDroppedViews []string
-		}{n.tableDesc.Name, n.n.String(), params.p.session.User, uint32(mutationID), droppedViews},
+		}{n.tableDesc.Name, n.n.String(), params.SessionData().User, uint32(mutationID), droppedViews},
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/ambiguous_commit_test.go
+++ b/pkg/sql/ambiguous_commit_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -152,7 +153,7 @@ func TestAmbiguousCommit(t *testing.T) {
 		for _, server := range tc.Servers {
 			st := server.ClusterSettings()
 			st.Manual.Store(true)
-			sql.DistSQLClusterExecMode.Override(&st.SV, int64(sql.DistSQLOff))
+			sql.DistSQLClusterExecMode.Override(&st.SV, int64(sessiondata.DistSQLOff))
 		}
 
 		sqlDB := tc.Conns[0]

--- a/pkg/sql/analyze_expr.go
+++ b/pkg/sql/analyze_expr.go
@@ -76,5 +76,5 @@ func (p *planner) analyzeExpr(
 	}
 
 	// Normalize.
-	return p.txCtx.NormalizeExpr(&p.evalCtx, typedExpr)
+	return p.txCtx.NormalizeExpr(p.EvalContext(), typedExpr)
 }

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -174,18 +174,6 @@ type sqlStats struct {
 	apps map[string]*appStats
 }
 
-// resetApplicationName initializes both Session.mu.ApplicationName and
-// the cached pointer to per-application statistics. It is meant to be
-// used upon session initialization and upon SET APPLICATION_NAME.
-func (s *Session) resetApplicationName(appName string) {
-	s.mu.Lock()
-	s.mu.ApplicationName = appName
-	s.mu.Unlock()
-	if s.sqlStats != nil {
-		s.appStats = s.sqlStats.getStatsForApplication(appName)
-	}
-}
-
 func (s *sqlStats) getStatsForApplication(appName string) *appStats {
 	s.Lock()
 	defer s.Unlock()

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -54,7 +54,7 @@ func CheckPrivilegeForUser(
 func (p *planner) CheckPrivilege(
 	descriptor sqlbase.DescriptorProto, privilege privilege.Kind,
 ) error {
-	return CheckPrivilegeForUser(p.session.User, descriptor, privilege)
+	return CheckPrivilegeForUser(p.SessionData().User, descriptor, privilege)
 }
 
 // CheckAnyPrivilege implements the AuthorizationAccessor interface.
@@ -62,17 +62,18 @@ func (p *planner) CheckAnyPrivilege(descriptor sqlbase.DescriptorProto) error {
 	if isVirtualDescriptor(descriptor) {
 		return nil
 	}
-	if descriptor.GetPrivileges().AnyPrivilege(p.session.User) {
+	if descriptor.GetPrivileges().AnyPrivilege(p.SessionData().User) {
 		return nil
 	}
 
 	return fmt.Errorf("user %s has no privileges on %s %s",
-		p.session.User, descriptor.TypeName(), descriptor.GetName())
+		p.SessionData().User, descriptor.TypeName(), descriptor.GetName())
 }
 
 // RequireSuperUser implements the AuthorizationAccessor interface.
 func (p *planner) RequireSuperUser(action string) error {
-	if p.session.User != security.RootUser && p.session.User != security.NodeUser {
+	user := p.SessionData().User
+	if user != security.RootUser && user != security.NodeUser {
 		return fmt.Errorf("only %s is allowed to %s", security.RootUser, action)
 	}
 	return nil

--- a/pkg/sql/cancel_query.go
+++ b/pkg/sql/cancel_query.go
@@ -52,7 +52,7 @@ func (p *planner) CancelQuery(ctx context.Context, n *tree.CancelQuery) (planNod
 func (n *cancelQueryNode) startExec(params runParams) error {
 	statusServer := params.p.session.execCfg.StatusServer
 
-	queryIDDatum, err := n.queryID.Eval(params.evalCtx)
+	queryIDDatum, err := n.queryID.Eval(params.EvalContext())
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func (n *cancelQueryNode) startExec(params runParams) error {
 	request := &serverpb.CancelQueryRequest{
 		NodeId:   fmt.Sprintf("%d", nodeID),
 		QueryID:  queryIDString,
-		Username: params.p.session.User,
+		Username: params.SessionData().User,
 	}
 
 	response, err := statusServer.CancelQuery(params.ctx, request)

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -161,9 +161,9 @@ func (p *planner) validateCheckExpr(
 		return err
 	}
 	params := runParams{
-		ctx:     ctx,
-		evalCtx: &p.evalCtx,
-		p:       p,
+		ctx:             ctx,
+		extendedEvalCtx: &p.extendedEvalCtx,
+		p:               p,
 	}
 	if err := startPlan(params, rows); err != nil {
 		return err

--- a/pkg/sql/control_job.go
+++ b/pkg/sql/control_job.go
@@ -89,7 +89,7 @@ func (p *planner) CancelJob(ctx context.Context, n *tree.CancelJob) (planNode, e
 }
 
 func (n *controlJobNode) startExec(params runParams) error {
-	jobIDDatum, err := n.jobID.Eval(params.evalCtx)
+	jobIDDatum, err := n.jobID.Eval(params.EvalContext())
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -59,7 +59,7 @@ func (p *planner) Copy(ctx context.Context, n *tree.CopyFrom) (planNode, error) 
 		columns: n.Columns,
 	}
 
-	tn, err := n.Table.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := n.Table.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (s *Session) ProcessCopyData(
 	cf := s.copyFrom
 	buf := cf.buf
 
-	evalCtx := s.evalCtx()
+	evalCtx := s.extendedEvalCtx()
 
 	switch msg {
 	case copyMsgData:
@@ -136,7 +136,7 @@ func (s *Session) ProcessCopyData(
 		var err error
 		// If there's a line in the buffer without \n at EOL, add it here.
 		if buf.Len() > 0 {
-			err = cf.addRow(ctx, buf.Bytes(), &evalCtx)
+			err = cf.addRow(ctx, buf.Bytes(), &evalCtx.EvalContext)
 		}
 		return StatementList{{AST: &CopyDataBlock{Done: true}}}, err
 	default:
@@ -161,7 +161,7 @@ func (s *Session) ProcessCopyData(
 		if buf.Len() == 0 && bytes.Equal(line, []byte(`\.`)) {
 			break
 		}
-		if err := cf.addRow(ctx, line, &evalCtx); err != nil {
+		if err := cf.addRow(ctx, line, &evalCtx.EvalContext); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -389,7 +389,7 @@ CREATE TABLE crdb_internal.jobs (
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		p = makeInternalPlanner("jobs", p.txn, p.evalCtx.User, p.session.memMetrics)
+		p = makeInternalPlanner("jobs", p.txn, p.SessionData().User, p.session.memMetrics)
 		defer finishInternalPlanner(p)
 		rows, err := p.queryRows(ctx, `SELECT id, status, created, payload FROM system.jobs`)
 		if err != nil {
@@ -642,7 +642,7 @@ CREATE TABLE crdb_internal.session_variables (
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
-			value := gen.Get(p.session)
+			value := gen.Get(&p.extendedEvalCtx)
 			if err := addRow(
 				tree.NewDString(vName),
 				tree.NewDString(value),
@@ -673,7 +673,7 @@ CREATE TABLE crdb_internal.%s (
 var crdbInternalLocalQueriesTable = virtualSchemaTable{
 	schema: fmt.Sprintf(queriesSchemaPattern, "node_queries"),
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		req := serverpb.ListSessionsRequest{Username: p.session.User}
+		req := serverpb.ListSessionsRequest{Username: p.SessionData().User}
 		response, err := p.session.execCfg.StatusServer.ListLocalSessions(ctx, &req)
 		if err != nil {
 			return err
@@ -687,7 +687,7 @@ var crdbInternalLocalQueriesTable = virtualSchemaTable{
 var crdbInternalClusterQueriesTable = virtualSchemaTable{
 	schema: fmt.Sprintf(queriesSchemaPattern, "cluster_queries"),
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		req := serverpb.ListSessionsRequest{Username: p.session.User}
+		req := serverpb.ListSessionsRequest{Username: p.SessionData().User}
 		response, err := p.session.execCfg.StatusServer.ListSessions(ctx, &req)
 		if err != nil {
 			return err
@@ -766,7 +766,7 @@ CREATE TABLE crdb_internal.%s (
 var crdbInternalLocalSessionsTable = virtualSchemaTable{
 	schema: fmt.Sprintf(sessionsSchemaPattern, "node_sessions"),
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		req := serverpb.ListSessionsRequest{Username: p.session.User}
+		req := serverpb.ListSessionsRequest{Username: p.SessionData().User}
 		response, err := p.session.execCfg.StatusServer.ListLocalSessions(ctx, &req)
 		if err != nil {
 			return err
@@ -780,7 +780,7 @@ var crdbInternalLocalSessionsTable = virtualSchemaTable{
 var crdbInternalClusterSessionsTable = virtualSchemaTable{
 	schema: fmt.Sprintf(sessionsSchemaPattern, "cluster_sessions"),
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		req := serverpb.ListSessionsRequest{Username: p.session.User}
+		req := serverpb.ListSessionsRequest{Username: p.SessionData().User}
 		response, err := p.session.execCfg.StatusServer.ListSessions(ctx, &req)
 		if err != nil {
 			return err
@@ -1465,7 +1465,7 @@ CREATE TABLE crdb_internal.zones (
 			return 0, "", fmt.Errorf("object with ID %d does not exist", id)
 		}
 
-		p = makeInternalPlanner("zones", p.txn, p.evalCtx.User, p.session.memMetrics)
+		p = makeInternalPlanner("zones", p.txn, p.SessionData().User, p.session.memMetrics)
 		defer finishInternalPlanner(p)
 		rows, err := p.queryRows(ctx, `SELECT id, config FROM system.zones`)
 		if err != nil {

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -87,12 +87,12 @@ func (n *createDatabaseNode) startExec(params runParams) error {
 			params.p.txn,
 			EventLogCreateDatabase,
 			int32(desc.ID),
-			int32(params.evalCtx.NodeID),
+			int32(params.extendedEvalCtx.NodeID),
 			struct {
 				DatabaseName string
 				Statement    string
 				User         string
-			}{n.n.Name.String(), n.n.String(), params.p.session.User},
+			}{n.n.Name.String(), n.n.String(), params.SessionData().User},
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -30,7 +30,7 @@ type createSequenceNode struct {
 }
 
 func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (planNode, error) {
-	name, err := n.Name.NormalizeWithDatabaseName(p.session.Database)
+	name, err := n.Name.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}
@@ -107,12 +107,12 @@ func (n *createSequenceNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogCreateSequence,
 		int32(desc.ID),
-		int32(params.evalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID),
 		struct {
 			SequenceName string
 			Statement    string
 			User         string
-		}{n.n.Name.String(), n.n.String(), params.p.session.User},
+		}{n.n.Name.String(), n.n.String(), params.SessionData().User},
 	)
 }
 

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -43,7 +43,7 @@ type createViewNode struct {
 //						selected columns.
 //          mysql requires CREATE VIEW plus SELECT on all the selected columns.
 func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode, error) {
-	name, err := n.Name.NormalizeWithDatabaseName(p.session.Database)
+	name, err := n.Name.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}
@@ -186,12 +186,12 @@ func (n *createViewNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogCreateView,
 		int32(desc.ID),
-		int32(params.evalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID),
 		struct {
 			ViewName  string
 			Statement string
 			User      string
-		}{n.n.Name.String(), n.n.String(), params.p.session.User},
+		}{n.n.Name.String(), n.n.String(), params.SessionData().User},
 	)
 }
 
@@ -226,7 +226,7 @@ func (n *createViewNode) makeViewTableDesc(
 		if len(columnNames) > i {
 			columnTableDef.Name = columnNames[i]
 		}
-		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, &params.p.semaCtx, params.evalCtx)
+		col, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, &params.p.semaCtx, params.EvalContext())
 		if err != nil {
 			return desc, err
 		}

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -297,7 +297,7 @@ func (p *planner) getVirtualDataSource(
 		// this.
 		prefix := string(tn.PrefixName)
 		if !tn.PrefixOriginallySpecified {
-			prefix = p.session.Database
+			prefix = p.SessionData().Database
 			if prefix == "" && p.RequireSuperUser("access virtual tables across all databases") != nil {
 				prefix = sqlbase.SystemDB.Name
 			}
@@ -345,7 +345,7 @@ func (p *planner) getDataSourceAsOneColumn(
 
 	// We use the name of the function to determine the name of the
 	// rendered column.
-	fd, err := src.Func.Resolve(p.session.SearchPath)
+	fd, err := src.Func.Resolve(p.SessionData().SearchPath)
 	if err != nil {
 		return planDataSource{}, err
 	}

--- a/pkg/sql/database_test.go
+++ b/pkg/sql/database_test.go
@@ -66,7 +66,7 @@ func TestDatabaseAccessors(t *testing.T) {
 		p := makeInternalPlanner("plan", txn, security.RootUser, &MemoryMetrics{})
 		defer finishInternalPlanner(p)
 		p.session.tables.leaseMgr = s.LeaseManager().(*LeaseManager)
-		p.session.Database = "test"
+		p.session.data.Database = "test"
 
 		_, err := p.session.tables.databaseCache.getDatabaseDescByID(ctx, txn, sqlbase.SystemDB.ID)
 		return err

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -56,7 +56,7 @@ func (p *planner) Delete(
 		defer resetter(p)
 	}
 
-	if n.Where == nil && p.session.SafeUpdates {
+	if n.Where == nil && p.SessionData().SafeUpdates {
 		return nil, pgerror.NewDangerousStatementErrorf("DELETE without WHERE clause")
 	}
 

--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -34,7 +34,7 @@ func (p *planner) Discard(ctx context.Context, s *tree.Discard) (planNode, error
 		// RESET ALL
 		for _, v := range varGen {
 			if v.Reset != nil {
-				if err := v.Reset(p.session); err != nil {
+				if err := v.Reset(p.sessionDataMutator); err != nil {
 					return nil, err
 				}
 			}

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -99,7 +99,7 @@ func (l *DistLoader) LoadCSV(
 	ctx context.Context,
 	job *jobs.Job,
 	db *client.DB,
-	evalCtx tree.EvalContext,
+	evalCtx *extendedEvalContext,
 	thisNode roachpb.NodeID,
 	nodes []roachpb.NodeDescriptor,
 	resultRows *RowResultWriter,
@@ -219,7 +219,7 @@ func (l *DistLoader) LoadCSV(
 		return nil
 	})
 
-	planCtx := l.distSQLPlanner.newPlanningCtx(ctx, &evalCtx, nil)
+	planCtx := l.distSQLPlanner.newPlanningCtx(ctx, evalCtx, nil /* txn */)
 	// Because we're not going through the normal pathways, we have to set up
 	// the nodeID -> nodeAddress map ourselves.
 	for _, node := range nodes {

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -112,7 +112,7 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	joinType := distsqlJoinType(n.joinType)
 
 	post, joinToStreamColMap := joinOutColumns(n, plans[0], plans[1])
-	onExpr := remapOnExpr(planCtx.evalCtx, n, plans[0], plans[1])
+	onExpr := remapOnExpr(planCtx.EvalContext(), n, plans[0], plans[1])
 
 	ancestor, descendant := n.interleavedNodes()
 

--- a/pkg/sql/distsql_plan_scrub_physical.go
+++ b/pkg/sql/distsql_plan_scrub_physical.go
@@ -35,7 +35,7 @@ func (dsp *DistSQLPlanner) createScrubPhysicalCheck(
 	spans []roachpb.Span,
 	readAsOf hlc.Timestamp,
 ) (physicalPlan, error) {
-	spec, _, err := initTableReaderSpec(n, planCtx.evalCtx)
+	spec, _, err := initTableReaderSpec(n, planCtx.EvalContext())
 	if err != nil {
 		return physicalPlan{}, err
 	}

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -40,7 +40,8 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	if err != nil {
 		return physicalPlan{}, err
 	}
-	scan.spans, err = makeSpans(planCtx.evalCtx, nil /* constraints */, desc, scan.index)
+	scan.spans, err = makeSpans(
+		planCtx.EvalContext(), nil /* constraints */, desc, scan.index)
 	if err != nil {
 		return physicalPlan{}, err
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -109,7 +109,7 @@ func (dsp *DistSQLPlanner) Run(
 	txn *client.Txn,
 	plan *physicalPlan,
 	recv *distSQLReceiver,
-	evalCtx tree.EvalContext,
+	evalCtx *extendedEvalContext,
 ) error {
 	ctx := planCtx.ctx
 
@@ -139,8 +139,8 @@ func (dsp *DistSQLPlanner) Run(
 	recv.resultToStreamColMap = plan.planToStreamColMap
 	thisNodeID := dsp.nodeDesc.NodeID
 
-	evalCtxProto := distsqlrun.MakeEvalContext(evalCtx)
-	iter := evalCtx.SearchPath.Iter()
+	evalCtxProto := distsqlrun.MakeEvalContext(evalCtx.EvalContext)
+	iter := evalCtx.SessionData.SearchPath.Iter()
 	for s, ok := iter(); ok; s, ok = iter() {
 		evalCtxProto.SearchPath = append(evalCtxProto.SearchPath, s)
 	}
@@ -437,9 +437,9 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 	txn *client.Txn,
 	tree planNode,
 	recv *distSQLReceiver,
-	evalCtx tree.EvalContext,
+	evalCtx *extendedEvalContext,
 ) error {
-	planCtx := dsp.newPlanningCtx(ctx, &evalCtx, txn)
+	planCtx := dsp.newPlanningCtx(ctx, evalCtx, txn)
 
 	log.VEvent(ctx, 1, "creating DistSQL plan")
 

--- a/pkg/sql/distsqlrun/api.go
+++ b/pkg/sql/distsqlrun/api.go
@@ -24,7 +24,7 @@ func MakeEvalContext(evalCtx tree.EvalContext) EvalContext {
 		TxnTimestampNanos:  evalCtx.GetTxnTimestampRaw().UnixNano(),
 		ClusterTimestamp:   evalCtx.GetClusterTimestampRaw(),
 		Location:           evalCtx.GetLocation().String(),
-		Database:           evalCtx.Database,
-		User:               evalCtx.User,
+		Database:           evalCtx.SessionData.Database,
+		User:               evalCtx.SessionData.User,
 	}
 }

--- a/pkg/sql/distsqlrun/expr.go
+++ b/pkg/sql/distsqlrun/expr.go
@@ -140,7 +140,7 @@ func (eh *exprHelper) init(
 		return err
 	}
 	var t transform.ExprTransformContext
-	if t.AggregateInExpr(eh.expr, evalCtx.SearchPath) {
+	if t.AggregateInExpr(eh.expr, evalCtx.SessionData.SearchPath) {
 		return errors.Errorf("expression '%s' has aggregate", eh.expr)
 	}
 	return nil

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -259,11 +260,13 @@ func (ds *ServerImpl) setupFlow(
 		return ctx, nil, err
 	}
 	evalCtx := tree.EvalContext{
-		Settings:     ds.ServerConfig.Settings,
-		Location:     &location,
-		Database:     req.EvalContext.Database,
-		User:         req.EvalContext.User,
-		SearchPath:   tree.MakeSearchPath(req.EvalContext.SearchPath),
+		Settings: ds.ServerConfig.Settings,
+		SessionData: sessiondata.SessionData{
+			Location:   location,
+			Database:   req.EvalContext.Database,
+			User:       req.EvalContext.User,
+			SearchPath: sessiondata.MakeSearchPath(req.EvalContext.SearchPath),
+		},
 		ClusterID:    ds.ServerConfig.ClusterID,
 		NodeID:       nodeID,
 		ReCache:      ds.regexpCache,

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -79,7 +79,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		case tree.DropDefault:
 			// The default is CASCADE, however be cautious if CASCADE was
 			// not specified explicitly.
-			if p.session.SafeUpdates {
+			if p.SessionData().SafeUpdates {
 				return nil, pgerror.NewDangerousStatementErrorf(
 					"DROP DATABASE on non-empty database without explicit CASCADE")
 			}
@@ -172,13 +172,13 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		p.txn,
 		EventLogDropDatabase,
 		int32(n.dbDesc.ID),
-		int32(p.evalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID),
 		struct {
 			DatabaseName          string
 			Statement             string
 			User                  string
 			DroppedTablesAndViews []string
-		}{n.n.Name.String(), n.n.String(), p.session.User, tbNameStrings},
+		}{n.n.Name.String(), n.n.String(), p.SessionData().User, tbNameStrings},
 	)
 }
 

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -228,7 +228,7 @@ func (p *planner) dropIndexByName(
 		p.txn,
 		EventLogDropIndex,
 		int32(tableDesc.ID),
-		int32(p.evalCtx.NodeID),
+		int32(p.extendedEvalCtx.NodeID),
 		struct {
 			TableName           string
 			IndexName           string
@@ -236,7 +236,7 @@ func (p *planner) dropIndexByName(
 			User                string
 			MutationID          uint32
 			CascadeDroppedViews []string
-		}{tableDesc.Name, string(idxName), jobDesc, p.session.User, uint32(mutationID),
+		}{tableDesc.Name, string(idxName), jobDesc, p.SessionData().User, uint32(mutationID),
 			droppedViews},
 	); err != nil {
 		return err

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -34,7 +34,7 @@ func (p *planner) DropSequence(ctx context.Context, n *tree.DropSequence) (planN
 		if err != nil {
 			return nil, err
 		}
-		if err := tn.QualifyWithDatabase(p.session.Database); err != nil {
+		if err := tn.QualifyWithDatabase(p.SessionData().Database); err != nil {
 			return nil, err
 		}
 
@@ -84,12 +84,12 @@ func (n *dropSequenceNode) startExec(params runParams) error {
 			params.p.txn,
 			EventLogDropSequence,
 			int32(droppedDesc.ID),
-			int32(params.evalCtx.NodeID),
+			int32(params.extendedEvalCtx.NodeID),
 			struct {
 				SequenceName string
 				Statement    string
 				User         string
-			}{droppedDesc.Name, n.n.String(), params.p.session.User},
+			}{droppedDesc.Name, n.n.String(), params.SessionData().User},
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -46,7 +46,7 @@ func (p *planner) DropTable(ctx context.Context, n *tree.DropTable) (planNode, e
 		if err != nil {
 			return nil, err
 		}
-		if err := tn.QualifyWithDatabase(p.session.Database); err != nil {
+		if err := tn.QualifyWithDatabase(p.SessionData().Database); err != nil {
 			return nil, err
 		}
 
@@ -122,13 +122,13 @@ func (n *dropTableNode) startExec(params runParams) error {
 			params.p.txn,
 			EventLogDropTable,
 			int32(droppedDesc.ID),
-			int32(params.evalCtx.NodeID),
+			int32(params.extendedEvalCtx.NodeID),
 			struct {
 				TableName           string
 				Statement           string
 				User                string
 				CascadeDroppedViews []string
-			}{droppedDesc.Name, n.n.String(), params.p.session.User, droppedViews},
+			}{droppedDesc.Name, n.n.String(), params.SessionData().User, droppedViews},
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -42,7 +42,7 @@ func (p *planner) DropView(ctx context.Context, n *tree.DropView) (planNode, err
 		if err != nil {
 			return nil, err
 		}
-		if err := tn.QualifyWithDatabase(p.session.Database); err != nil {
+		if err := tn.QualifyWithDatabase(p.SessionData().Database); err != nil {
 			return nil, err
 		}
 
@@ -104,13 +104,13 @@ func (n *dropViewNode) startExec(params runParams) error {
 			params.p.txn,
 			EventLogDropView,
 			int32(droppedDesc.ID),
-			int32(params.evalCtx.NodeID),
+			int32(params.extendedEvalCtx.NodeID),
 			struct {
 				ViewName            string
 				Statement           string
 				User                string
 				CascadeDroppedViews []string
-			}{droppedDesc.Name, n.n.String(), params.p.session.User, cascadeDroppedViews},
+			}{droppedDesc.Name, n.n.String(), params.SessionData().User, cascadeDroppedViews},
 		); err != nil {
 			return err
 		}

--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -44,7 +44,7 @@ func (p *planner) Execute(ctx context.Context, n *tree.Execute) (planNode, error
 
 	p.semaCtx.Placeholders.Assign(newPInfo)
 
-	return p.newPlan(ctx, ps.Statement, nil)
+	return p.newPlan(ctx, ps.Statement, nil /* desiredTypes */)
 }
 
 // getPreparedStatementForExecute implements the EXECUTE foo(args) SQL
@@ -75,7 +75,7 @@ func getPreparedStatementForExecute(
 		if err != nil {
 			return ps, pInfo, pgerror.NewError(pgerror.CodeWrongObjectTypeError, err.Error())
 		}
-		if err := t.AssertNoAggregationOrWindowing(typedExpr, "EXECUTE parameters", session.SearchPath); err != nil {
+		if err := t.AssertNoAggregationOrWindowing(typedExpr, "EXECUTE parameters", session.data.SearchPath); err != nil {
 			return ps, pInfo, err
 		}
 		qArgs[idx] = typedExpr

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -489,7 +489,7 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 
 	case *filterNode:
 		n.source.plan = p.simplifyOrderings(n.source.plan, usefulOrdering)
-		n.computePhysicalProps(&p.evalCtx)
+		n.computePhysicalProps(p.EvalContext())
 
 	case *joinNode:
 		// In DistSQL, we may take advantage of matching orderings on equality

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -117,7 +117,7 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 		mode = explainPlan
 	}
 
-	p.evalCtx.SkipNormalize = !normalizeExprs
+	p.extendedEvalCtx.SkipNormalize = !normalizeExprs
 
 	plan, err := p.newPlan(ctx, n.Statement, nil)
 	if err != nil {

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -53,13 +53,13 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		return err
 	}
 
-	planCtx := distSQLPlanner.newPlanningCtx(params.ctx, &params.p.evalCtx, params.p.txn)
+	planCtx := distSQLPlanner.newPlanningCtx(params.ctx, params.extendedEvalCtx, params.p.txn)
 	plan, err := distSQLPlanner.createPlanForNode(&planCtx, n.plan)
 	if err != nil {
 		return err
 	}
 	distSQLPlanner.FinalizePlan(&planCtx, &plan)
-	flows := plan.GenerateFlowSpecs(params.evalCtx.NodeID)
+	flows := plan.GenerateFlowSpecs(params.extendedEvalCtx.NodeID)
 	planJSON, planURL, err := distsqlrun.GeneratePlanDiagramWithURL(flows)
 	if err != nil {
 		return err

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -82,7 +82,7 @@ func (p *planner) makeExplainPlanNode(
 	)
 	explainer.fmtFlags = noPlaceholderFlags
 	explainer.showPlaceholderValues = func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
-		d, err := placeholder.Eval(&p.evalCtx)
+		d, err := placeholder.Eval(p.EvalContext())
 		if err != nil {
 			// Disable the placeholder formatter so that
 			// we don't recurse infinitely trying to evaluate.

--- a/pkg/sql/expr_filter_test.go
+++ b/pkg/sql/expr_filter_test.go
@@ -183,8 +183,8 @@ func TestSplitFilter(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(fmt.Sprintf("%s~(%s, %s)", d.expr, d.expectedRes, d.expectedRem), func(t *testing.T) {
-			p.evalCtx = tree.MakeTestingEvalContext()
-			defer p.evalCtx.Stop(context.Background())
+			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			// A function that "converts" only vars in the list.
 			conv := func(expr tree.VariableExpr) (bool, tree.Expr) {
@@ -267,8 +267,8 @@ func TestExtractNotNullConstraints(t *testing.T) {
 	p := makeTestPlanner()
 	for _, tc := range testCases {
 		t.Run(tc.expr, func(t *testing.T) {
-			p.evalCtx = tree.MakeTestingEvalContext()
-			defer p.evalCtx.Stop(context.Background())
+			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			defer p.extendedEvalCtx.Stop(context.Background())
 
 			sel := makeSelectNode(t, p)
 			expr := parseAndNormalizeExpr(t, p, tc.expr, sel)

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -57,9 +57,9 @@ func (f *filterNode) Next(params runParams) (bool, error) {
 			return false, err
 		}
 
-		params.evalCtx.IVarHelper = &f.ivarHelper
-		passesFilter, err := sqlbase.RunFilter(f.filter, params.evalCtx)
-		params.evalCtx.IVarHelper = nil
+		params.extendedEvalCtx.IVarHelper = &f.ivarHelper
+		passesFilter, err := sqlbase.RunFilter(f.filter, params.EvalContext())
+		params.extendedEvalCtx.IVarHelper = nil
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -70,7 +70,8 @@ func (p *planner) changePrivileges(
 		}
 	}
 
-	descriptors, err := getDescriptorsFromTargetList(ctx, p.txn, p.getVirtualTabler(), p.session.Database, targets)
+	descriptors, err := getDescriptorsFromTargetList(
+		ctx, p.txn, p.getVirtualTabler(), p.SessionData().Database, targets)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/group_test.go
+++ b/pkg/sql/group_test.go
@@ -48,8 +48,8 @@ func TestDesiredAggregateOrder(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr, func(t *testing.T) {
-			p.evalCtx = tree.MakeTestingEvalContext()
-			defer p.evalCtx.Stop(context.Background())
+			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr := parseAndNormalizeExpr(t, p, d.expr, sel)
 			group := &groupNode{}
@@ -66,13 +66,13 @@ func TestDesiredAggregateOrder(t *testing.T) {
 			if _, err := v.extract(expr); err != nil {
 				t.Fatal(err)
 			}
-			ordering := group.desiredAggregateOrdering(&p.evalCtx)
+			ordering := group.desiredAggregateOrdering(p.EvalContext())
 			if !reflect.DeepEqual(d.ordering, ordering) {
 				t.Fatalf("%s: expected %v, but found %v", d.expr, d.ordering, ordering)
 			}
 			// Verify we never have a desired ordering if there is a GROUP BY.
 			group.numGroupCols = 1
-			ordering = group.desiredAggregateOrdering(&p.evalCtx)
+			ordering = group.desiredAggregateOrdering(p.EvalContext())
 			if len(ordering) > 0 {
 				t.Fatalf("%s: expected no ordering when there is a GROUP BY, found %v", d.expr, ordering)
 			}

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -108,8 +108,8 @@ func (p *planner) makeIndexJoin(
 	table := p.Scan()
 	table.desc = origScan.desc
 	// Note: initDescDefaults can only error out if its 3rd argument is not nil.
-	_ = table.initDescDefaults(p.curPlan.deps, origScan.scanVisibility, nil)
-	table.initOrdering(0, &p.evalCtx)
+	_ = table.initDescDefaults(p.curPlan.deps, origScan.scanVisibility, nil /* wantedColumns */)
+	table.initOrdering(0 /* exactPrefix */, p.EvalContext())
 	table.disableBatchLimit()
 
 	colIDtoRowIndex := map[sqlbase.ColumnID]int{}
@@ -173,9 +173,9 @@ func (p *planner) makeIndexJoin(
 
 	// Ensure that the remaining indexed vars are transferred to the
 	// table scanNode fully.
-	table.filter = table.filterVars.Rebind(table.filter, true, false)
+	table.filter = table.filterVars.Rebind(table.filter, true /* alsoReset */, false /* normalizeToNonNil */)
 
-	indexScan.initOrdering(exactPrefix, &p.evalCtx)
+	indexScan.initOrdering(exactPrefix, p.EvalContext())
 
 	primaryKeyPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(table.desc, table.index.ID))
 

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -25,12 +25,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 const (
 	informationSchemaName = "information_schema"
-	pgCatalogName         = tree.PgCatalogName
+	pgCatalogName         = sessiondata.PgCatalogName
 )
 
 var informationSchema = virtualSchema{
@@ -866,7 +867,7 @@ func forEachTableDescWithTableLookupInternal(
 	}
 	sort.Strings(dbNames)
 	for _, dbName := range dbNames {
-		if !isDatabaseVisible(dbName, prefix, p.session.User) {
+		if !isDatabaseVisible(dbName, prefix, p.SessionData().User) {
 			continue
 		}
 		db := databases[dbName]

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -109,7 +109,7 @@ func (p *planner) Insert(
 	numInputColumns := len(cols)
 
 	cols, defaultExprs, err :=
-		sqlbase.ProcessDefaultColumns(cols, en.tableDesc, &p.txCtx, &p.evalCtx)
+		sqlbase.ProcessDefaultColumns(cols, en.tableDesc, &p.txCtx, p.EvalContext())
 	if err != nil {
 		return nil, err
 	}
@@ -410,7 +410,7 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 		n.defaultExprs,
 		n.run.insertColIDtoRowIndex,
 		n.insertCols,
-		*params.evalCtx,
+		*params.EvalContext(),
 		n.tableDesc,
 		n.run.rows.Values(),
 	)
@@ -421,7 +421,7 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 	if err := n.checkHelper.loadRow(n.run.insertColIDtoRowIndex, rowVals, false); err != nil {
 		return false, err
 	}
-	if err := n.checkHelper.check(params.evalCtx); err != nil {
+	if err := n.checkHelper.check(params.EvalContext()); err != nil {
 		return false, err
 	}
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -94,13 +94,13 @@ func (ie InternalExecutor) GetTableSpan(
 }
 
 func (ie InternalExecutor) initSession(p *planner) {
-	p.evalCtx.NodeID = ie.LeaseManager.LeaseStore.nodeID.Get()
+	p.extendedEvalCtx.NodeID = ie.LeaseManager.LeaseStore.nodeID.Get()
 	p.session.tables.leaseMgr = ie.LeaseManager
 }
 
 // getTableID retrieves the table ID for the specified table.
 func getTableID(ctx context.Context, p *planner, tn *tree.TableName) (sqlbase.ID, error) {
-	if err := tn.QualifyWithDatabase(p.session.Database); err != nil {
+	if err := tn.QualifyWithDatabase(p.SessionData().Database); err != nil {
 		return 0, err
 	}
 

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -541,7 +541,7 @@ func (n *joinNode) Next(params runParams) (res bool, err error) {
 		// on condition, if the on condition passes we add it to the buffer.
 		foundMatch := false
 		for idx, rrow := range b.Rows() {
-			passesOnCond, err := n.pred.eval(params.evalCtx, n.run.output, lrow, rrow)
+			passesOnCond, err := n.pred.eval(params.EvalContext(), n.run.output, lrow, rrow)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -37,7 +37,7 @@ func newTestScanNode(kvDB *client.DB, tableName string) (*scanNode, error) {
 	if err != nil {
 		return nil, err
 	}
-	scan.initOrdering(0, &p.evalCtx)
+	scan.initOrdering(0 /* exactPrefix */, p.EvalContext())
 	return scan, nil
 }
 

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -57,7 +57,7 @@ func (p *planner) Limit(ctx context.Context, n *tree.Limit) (*limitNode, error) 
 	for _, datum := range data {
 		if datum.src != nil {
 			if err := p.txCtx.AssertNoAggregationOrWindowing(
-				datum.src, datum.name, p.session.SearchPath,
+				datum.src, datum.name, p.SessionData().SearchPath,
 			); err != nil {
 				return nil, err
 			}
@@ -78,7 +78,7 @@ type limitRun struct {
 }
 
 func (n *limitNode) startExec(params runParams) error {
-	return n.evalLimit(params.evalCtx)
+	return n.evalLimit(params.EvalContext())
 }
 
 func (n *limitNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -39,6 +39,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 
 	"github.com/pkg/errors"
 
@@ -887,11 +888,11 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 		); err != nil {
 			t.Fatal(err)
 		}
-		wantedMode := sql.DistSQLExecModeFromString(cfg.overrideDistSQLMode) // off => 0, etc
+		wantedMode := sessiondata.DistSQLExecModeFromString(cfg.overrideDistSQLMode) // off => 0, etc
 		// Wait until all servers are aware of the setting.
 		testutils.SucceedsSoon(t.t, func() error {
 			for i := 0; i < t.cluster.NumServers(); i++ {
-				var m sql.DistSQLExecMode
+				var m sessiondata.DistSQLExecMode
 				err := t.cluster.ServerConn(i % t.cluster.NumServers()).QueryRow(
 					"SHOW CLUSTER SETTING sql.defaults.distsql",
 				).Scan(&m)

--- a/pkg/sql/logictest/parallel_test.go
+++ b/pkg/sql/logictest/parallel_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -196,7 +197,7 @@ func (t *parallelTest) setup(spec *parTestSpec) {
 
 	for i := 0; i < t.cluster.NumServers(); i++ {
 		server := t.cluster.Server(i)
-		mode := sql.DistSQLOff
+		mode := sessiondata.DistSQLOff
 		st := server.ClusterSettings()
 		st.Manual.Store(true)
 		sql.DistSQLClusterExecMode.Override(&st.SV, int64(mode))

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -729,14 +729,15 @@ func (p *planner) addJoinFilter(
 	//     on the equality columns (see expandOnCond).
 	//  4. Propagate the filter and ON condition depending on the join type.
 	numLeft := len(n.left.info.sourceColumns)
-	extraFilter = n.pred.iVarHelper.Rebind(extraFilter, true, false)
+	extraFilter = n.pred.iVarHelper.Rebind(
+		extraFilter, true /* alsoReset */, false /* normalizeToNonNil */)
 
-	onAndExprs := splitAndExpr(&p.evalCtx, n.pred.onCond, nil)
+	onAndExprs := splitAndExpr(p.EvalContext(), n.pred.onCond, nil /* exprs */)
 
 	// Step 1: for inner joins, incorporate the filter into the ON condition.
 	if n.joinType == joinTypeInner {
 		// Split the filter into conjunctions and append them to onAndExprs.
-		onAndExprs = splitAndExpr(&p.evalCtx, extraFilter, onAndExprs)
+		onAndExprs = splitAndExpr(p.EvalContext(), extraFilter, onAndExprs)
 		extraFilter = nil
 	}
 
@@ -753,7 +754,7 @@ func (p *planner) addJoinFilter(
 	// constraints can be pushed down. This is not useful for FULL OUTER
 	// joins, where nothing can be pushed down.
 	if n.joinType != joinTypeFullOuter {
-		onCond = expandOnCond(n, onCond, &p.evalCtx)
+		onCond = expandOnCond(n, onCond, p.EvalContext())
 	}
 
 	// Step 4: propagate the filter and ON conditions as allowed by the join type.

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -86,15 +86,15 @@ func (p *planner) selectIndex(
 ) (planNode, error) {
 	if s.desc.IsEmpty() {
 		// No table.
-		s.initOrdering(0, &p.evalCtx)
+		s.initOrdering(0 /* exactPrefix */, p.EvalContext())
 		return s, nil
 	}
 
 	if s.filter == nil && analyzeOrdering == nil && s.specifiedIndex == nil {
 		// No where-clause, no ordering, and no specified index.
-		s.initOrdering(0, &p.evalCtx)
+		s.initOrdering(0 /* exactPrefix */, p.EvalContext())
 		var err error
-		s.spans, err = makeSpans(&p.evalCtx, nil /* constraints */, s.desc, s.index)
+		s.spans, err = makeSpans(p.EvalContext(), nil /* constraints */, s.desc, s.index)
 		if err != nil {
 			return nil, errors.Wrapf(err, "table ID = %d, index ID = %d", s.desc.ID, s.index.ID)
 		}
@@ -128,12 +128,14 @@ func (p *planner) selectIndex(
 
 	if useExperimentalIndexConstraints {
 		if s.filter != nil {
-			filterExpr, err := opt.BuildScalarExpr(s.filter, &p.evalCtx)
+			filterExpr, err := opt.BuildScalarExpr(s.filter, p.EvalContext())
 			if err != nil {
 				return nil, err
 			}
 			for _, c := range candidates {
-				if err := c.makeIndexConstraintsExperimental(filterExpr, &p.evalCtx); err != nil {
+				if err := c.makeIndexConstraintsExperimental(
+					filterExpr, p.EvalContext(),
+				); err != nil {
 					return nil, err
 				}
 				if spans, ok := c.ic.Spans(); ok && len(spans) == 0 {
@@ -150,7 +152,7 @@ func (p *planner) selectIndex(
 		// Removes any unnecessary IS NOT NULL filters on non-nullable columns.
 		s.filter = trimUselessIsDistinctFromNullFilter(s, p)
 
-		exprs, equivalent := decomposeExpr(&p.evalCtx, s.filter)
+		exprs, equivalent := decomposeExpr(p.EvalContext(), s.filter)
 		if log.V(2) {
 			log.Infof(ctx, "analyzeExpr: %s -> %s [equivalent=%v]", s.filter, exprs, equivalent)
 		}
@@ -186,7 +188,7 @@ func (p *planner) selectIndex(
 		// use.
 
 		for _, c := range candidates {
-			c.analyzeExprs(&p.evalCtx, exprs)
+			c.analyzeExprs(p.EvalContext(), exprs)
 		}
 	}
 
@@ -216,10 +218,10 @@ func (p *planner) selectIndex(
 		if !useExperimentalIndexConstraints {
 			// Compute the prefix of the index for which we have exact constraints. This
 			// prefix is inconsequential for ordering because the values are identical.
-			c.exactPrefix = c.constraints.exactPrefix(&p.evalCtx)
+			c.exactPrefix = c.constraints.exactPrefix(p.EvalContext())
 		}
 		if analyzeOrdering != nil {
-			c.analyzeOrdering(ctx, s, analyzeOrdering, preferOrderMatching, &p.evalCtx)
+			c.analyzeOrdering(ctx, s, analyzeOrdering, preferOrderMatching, p.EvalContext())
 		}
 	}
 
@@ -248,7 +250,7 @@ func (p *planner) selectIndex(
 		}
 	} else {
 		var err error
-		s.spans, err = makeSpans(&p.evalCtx, c.constraints, c.desc, c.index)
+		s.spans, err = makeSpans(p.EvalContext(), c.constraints, c.desc, c.index)
 		if err != nil {
 			return nil, errors.Wrapf(err, "constraints = %v, table ID = %d, index ID = %d",
 				c.constraints, s.desc.ID, s.index.ID)
@@ -265,14 +267,14 @@ func (p *planner) selectIndex(
 		if useExperimentalIndexConstraints {
 			s.filter = c.ic.RemainingFilter(&s.filterVars)
 		} else {
-			s.filter = applyIndexConstraints(&p.evalCtx, s.filter, c.constraints)
+			s.filter = applyIndexConstraints(p.EvalContext(), s.filter, c.constraints)
 		}
 
 		// Constraint propagation may have produced new constant sub-expressions.
 		// Propagate them and check if s.filter can be applied prematurely.
 		if s.filter != nil {
 			var err error
-			s.filter, err = p.evalCtx.NormalizeExpr(s.filter)
+			s.filter, err = p.extendedEvalCtx.NormalizeExpr(s.filter)
 			if err != nil {
 				return nil, err
 			}
@@ -290,7 +292,7 @@ func (p *planner) selectIndex(
 
 	var plan planNode
 	if c.covering {
-		s.initOrdering(c.exactPrefix, &p.evalCtx)
+		s.initOrdering(c.exactPrefix, p.EvalContext())
 		plan = s
 	} else {
 		// Note: makeIndexJoin destroys s and returns a new index scan
@@ -312,7 +314,7 @@ func (p *planner) selectIndex(
 // Removes any unnecessary IS DISTINCT FROM NULL filters on non-nullable columns.
 func trimUselessIsDistinctFromNullFilter(sn *scanNode, p *planner) tree.TypedExpr {
 	var newFilter tree.TypedExpr = tree.DBoolTrue
-	andExprs := splitAndExpr(&p.evalCtx, sn.filter, nil)
+	andExprs := splitAndExpr(p.EvalContext(), sn.filter, nil /* exprs */)
 	for _, e := range andExprs {
 		if c, cok := e.(*tree.ComparisonExpr); cok &&
 			c.Operator == tree.IsDistinctFrom && c.Right == tree.DNull {

--- a/pkg/sql/opt_index_selection_test.go
+++ b/pkg/sql/opt_index_selection_test.go
@@ -170,14 +170,14 @@ func makeConstraints(
 	sel *renderNode,
 ) (orIndexConstraints, tree.TypedExpr) {
 	expr := parseAndNormalizeExpr(t, p, sql, sel)
-	exprs, equiv := decomposeExpr(&p.evalCtx, expr)
+	exprs, equiv := decomposeExpr(p.EvalContext(), expr)
 
 	c := &indexInfo{
 		desc:     desc,
 		index:    index,
 		covering: true,
 	}
-	c.analyzeExprs(&p.evalCtx, exprs)
+	c.analyzeExprs(p.EvalContext(), exprs)
 	if equiv && len(exprs) == 1 {
 		expr = joinAndExprs(exprs[0])
 	}
@@ -331,8 +331,8 @@ func TestMakeConstraints(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.evalCtx = tree.MakeTestingEvalContext()
-			defer p.evalCtx.Stop(context.Background())
+			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, _ := makeConstraints(t, p, d.expr, desc, index, sel)
@@ -545,8 +545,8 @@ func TestMakeSpans(t *testing.T) {
 				} else {
 					expected = d.expectedDesc
 				}
-				p.evalCtx = tree.MakeTestingEvalContext()
-				defer p.evalCtx.Stop(context.Background())
+				p.extendedEvalCtx = makeTestingExtendedEvalContext()
+				defer p.extendedEvalCtx.Stop(context.Background())
 				sel := makeSelectNode(t, p)
 				columns := strings.Split(d.columns, ",")
 				dirs := make([]encoding.Direction, 0, len(columns))
@@ -555,7 +555,7 @@ func TestMakeSpans(t *testing.T) {
 				}
 				desc, index := makeTestIndex(t, columns, dirs)
 				constraints, _ := makeConstraints(t, p, d.expr, desc, index, sel)
-				spans, err := makeSpans(&p.evalCtx, constraints, desc, index)
+				spans, err := makeSpans(p.EvalContext(), constraints, desc, index)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -597,12 +597,12 @@ func TestMakeSpans(t *testing.T) {
 
 	for _, d := range testData2 {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.evalCtx = tree.MakeTestingEvalContext()
-			defer p.evalCtx.Stop(context.Background())
+			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, _ := makeConstraints(t, p, d.expr, desc, index, sel)
-			spans, err := makeSpans(&p.evalCtx, constraints, desc, index)
+			spans, err := makeSpans(p.EvalContext(), constraints, desc, index)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -692,12 +692,12 @@ func TestExactPrefix(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(fmt.Sprintf("%s~%d", d.expr, d.expected), func(t *testing.T) {
-			p.evalCtx = tree.MakeTestingEvalContext()
-			defer p.evalCtx.Stop(context.Background())
+			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, _ := makeConstraints(t, p, d.expr, desc, index, sel)
-			prefix := constraints.exactPrefix(&p.evalCtx)
+			prefix := constraints.exactPrefix(p.EvalContext())
 			if d.expected != prefix {
 				t.Errorf("%s: expected %d, but found %d", d.expr, d.expected, prefix)
 			}
@@ -774,12 +774,12 @@ func TestApplyConstraints(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.evalCtx = tree.MakeTestingEvalContext()
-			defer p.evalCtx.Stop(context.Background())
+			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			desc, index := makeTestIndexFromStr(t, d.columns)
 			constraints, expr := makeConstraints(t, p, d.expr, desc, index, sel)
-			expr2 := applyIndexConstraints(&p.evalCtx, expr, constraints)
+			expr2 := applyIndexConstraints(p.EvalContext(), expr, constraints)
 			if s := fmt.Sprint(expr2); d.expected != s {
 				t.Errorf("%s: expected %s, but found %s (constraints %s)", d.expr, d.expected, s, constraints)
 			}

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
 // HelpMessage describes a contextual help message.
@@ -88,7 +89,7 @@ func helpWith(sqllex sqlLexer, helpText string) int {
 // "in error", with the error set to a contextual help message about
 // the current built-in function.
 func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
-	d, err := f.Resolve(tree.SearchPath{})
+	d, err := f.Resolve(sessiondata.SearchPath{})
 	if err != nil {
 		return 1
 	}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1428,7 +1428,7 @@ CREATE TABLE pg_catalog.pg_settings (
 	populate: func(_ context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
 		for _, vName := range varNames {
 			gen := varGen[vName]
-			value := gen.Get(p.session)
+			value := gen.Get(&p.extendedEvalCtx)
 			valueDatum := tree.NewDString(value)
 			if err := addRow(
 				tree.NewDString(strings.ToLower(vName)), // name

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -1363,9 +1363,9 @@ func (c *v3Conn) AddRow(ctx context.Context, row tree.Datums) error {
 		}
 		switch fmtCode {
 		case formatText:
-			c.writeBuf.writeTextDatum(ctx, col, c.session.Location)
+			c.writeBuf.writeTextDatum(ctx, col, c.session.Location())
 		case formatBinary:
-			c.writeBuf.writeBinaryDatum(ctx, col, c.session.Location)
+			c.writeBuf.writeBinaryDatum(ctx, col, c.session.Location())
 		default:
 			c.writeBuf.setError(errors.Errorf("unsupported format code %s", fmtCode))
 		}

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -149,8 +149,8 @@ func insertNodeWithValuesSpans(
 	// Importantly, we only Reset the valuesNode, instead of Closing it when
 	// completed, so that the values don't need to be computed again during
 	// plan execution.
-	rowAcc := params.evalCtx.Mon.MakeBoundAccount()
-	params.evalCtx.ActiveMemAcc = &rowAcc
+	rowAcc := params.extendedEvalCtx.Mon.MakeBoundAccount()
+	params.extendedEvalCtx.ActiveMemAcc = &rowAcc
 	defer rowAcc.Close(params.ctx)
 
 	defer v.Reset(params.ctx)

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -62,7 +63,8 @@ var wrappedPlanHooks []wrappedPlanHookFn
 // interface as we find we need them, to avoid churn in the planHookFn sig and
 // the hooks that implement it.
 type PlanHookState interface {
-	EvalContext() tree.EvalContext
+	ExtendedEvalContext() extendedEvalContext
+	SessionData() *sessiondata.SessionData
 	ExecCfg() *ExecutorConfig
 	DistLoader() *DistLoader
 	TypeAsString(e tree.Expr, op string) (func() (string, error), error)

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -33,7 +33,7 @@ var errEmptyColumnName = errors.New("empty column name")
 //          mysql requires ALTER, CREATE, INSERT on the table.
 func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planNode, error) {
 	// Check if table exists.
-	tn, err := n.Table.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := n.Table.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -33,11 +33,11 @@ import (
 //          mysql requires ALTER, DROP on the original table, and CREATE, INSERT
 //          on the new table (and does not copy privileges over).
 func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNode, error) {
-	oldTn, err := n.Name.NormalizeWithDatabaseName(p.session.Database)
+	oldTn, err := n.Name.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}
-	newTn, err := n.NewName.NormalizeWithDatabaseName(p.session.Database)
+	newTn, err := n.NewName.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -71,7 +71,7 @@ func (p *planner) newReturningHelper(
 
 	for _, e := range rExprs {
 		if err := p.txCtx.AssertNoAggregationOrWindowing(
-			e.Expr, "RETURNING", p.session.SearchPath,
+			e.Expr, "RETURNING", p.SessionData().SearchPath,
 		); err != nil {
 			return nil, err
 		}
@@ -107,8 +107,8 @@ func (rh *returningHelper) cookResultRow(rowVals tree.Datums) (tree.Datums, erro
 	rh.curSourceRow = rowVals
 	resRow := make(tree.Datums, len(rh.exprs))
 	for i, e := range rh.exprs {
-		rh.p.evalCtx.IVarHelper = &rh.ivarHelper
-		d, err := e.Eval(&rh.p.evalCtx)
+		rh.p.extendedEvalCtx.IVarHelper = &rh.ivarHelper
+		d, err := e.Eval(rh.p.EvalContext())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -186,8 +186,8 @@ func (n *scanNode) Next(params runParams) (bool, error) {
 		if err != nil || n.run.row == nil {
 			return false, err
 		}
-		params.evalCtx.IVarHelper = &n.filterVars
-		passesFilter, err := sqlbase.RunFilter(n.filter, params.evalCtx)
+		params.extendedEvalCtx.IVarHelper = &n.filterVars
+		passesFilter, err := sqlbase.RunFilter(n.filter, params.EvalContext())
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -78,7 +78,7 @@ func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error
 			if err != nil {
 				return nil, err
 			}
-			fromVals[i], err = typedExpr.Eval(&p.evalCtx)
+			fromVals[i], err = typedExpr.Eval(p.EvalContext())
 			if err != nil {
 				return nil, err
 			}
@@ -91,7 +91,7 @@ func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error
 			if err != nil {
 				return nil, err
 			}
-			toVals[i], err = typedExpr.Eval(&p.evalCtx)
+			toVals[i], err = typedExpr.Eval(p.EvalContext())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -101,11 +101,11 @@ type scrubRun struct {
 func (n *scrubNode) startExec(params runParams) error {
 	switch n.n.Typ {
 	case tree.ScrubTable:
-		tableName, err := n.n.Table.NormalizeWithDatabaseName(params.p.session.Database)
+		tableName, err := n.n.Table.NormalizeWithDatabaseName(params.SessionData().Database)
 		if err != nil {
 			return err
 		}
-		if err := tableName.QualifyWithDatabase(params.p.session.Database); err != nil {
+		if err := tableName.QualifyWithDatabase(params.SessionData().Database); err != nil {
 			return err
 		}
 		// If the tableName provided refers to a view and error will be
@@ -553,7 +553,7 @@ func scrubRunDistSQL(
 	columnTypes []sqlbase.ColumnType,
 ) (*sqlbase.RowContainer, error) {
 	ci := sqlbase.ColTypeInfoFromColTypes(columnTypes)
-	rows := sqlbase.NewRowContainer(*p.evalCtx.ActiveMemAcc, ci, 0)
+	rows := sqlbase.NewRowContainer(*p.extendedEvalCtx.ActiveMemAcc, ci, 0 /* rowCapacity */)
 	rowResultWriter := NewRowResultWriter(tree.Rows, rows)
 	recv := makeDistSQLReceiver(
 		ctx,
@@ -566,7 +566,7 @@ func scrubRunDistSQL(
 		},
 	)
 
-	if err := p.session.distSQLPlanner.Run(planCtx, p.txn, plan, &recv, p.evalCtx); err != nil {
+	if err := p.session.distSQLPlanner.Run(planCtx, p.txn, plan, &recv, &p.extendedEvalCtx); err != nil {
 		return rows, err
 	} else if recv.err != nil {
 		return rows, recv.err

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -125,7 +125,7 @@ func (o *sqlCheckConstraintCheckOperation) Start(params runParams) error {
 func (o *sqlCheckConstraintCheckOperation) Next(params runParams) (tree.Datums, error) {
 	row := o.run.rows.Values()
 	timestamp := tree.MakeDTimestamp(
-		params.evalCtx.GetStmtTimestamp(), time.Nanosecond)
+		params.extendedEvalCtx.GetStmtTimestamp(), time.Nanosecond)
 
 	// Start the next unit of work. This is required so during the next
 	// call to Done() it is known whether there are any rows left.

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -109,7 +109,7 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 		o.colIDToRowIdx[id] = i
 	}
 
-	planCtx := params.p.session.distSQLPlanner.newPlanningCtx(ctx, params.evalCtx, params.p.txn)
+	planCtx := params.p.session.distSQLPlanner.newPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
 	physPlan, err := scrubPlanDistSQL(ctx, &planCtx, params.p, plan)
 	if err != nil {
 		return err
@@ -188,7 +188,7 @@ func (o *sqlForeignKeyCheckOperation) Next(params runParams) (tree.Datums, error
 		tree.NewDString(o.tableName.Database()),
 		tree.NewDString(o.tableName.Table()),
 		tree.NewDString(primaryKeyDatums.String()),
-		tree.MakeDTimestamp(params.evalCtx.GetStmtTimestamp(), time.Nanosecond),
+		tree.MakeDTimestamp(params.extendedEvalCtx.GetStmtTimestamp(), time.Nanosecond),
 		tree.DBoolFalse,
 		detailsJSON,
 	}, nil

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -118,7 +118,7 @@ func (o *indexCheckOperation) Start(params runParams) error {
 	}
 	defer plan.Close(ctx)
 
-	planCtx := params.p.session.distSQLPlanner.newPlanningCtx(ctx, params.evalCtx, params.p.txn)
+	planCtx := params.p.session.distSQLPlanner.newPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
 	physPlan, err := scrubPlanDistSQL(ctx, &planCtx, params.p, plan)
 	if err != nil {
 		return err
@@ -186,7 +186,7 @@ func (o *indexCheckOperation) Next(params runParams) (tree.Datums, error) {
 	}
 	primaryKey := tree.NewDString(primaryKeyDatums.String())
 	timestamp := tree.MakeDTimestamp(
-		params.p.evalCtx.GetStmtTimestamp(), time.Nanosecond)
+		params.extendedEvalCtx.GetStmtTimestamp(), time.Nanosecond)
 
 	details := make(map[string]interface{})
 	rowDetails := make(map[string]interface{})

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -135,7 +135,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	span := o.tableDesc.IndexSpan(o.indexDesc.ID)
 	spans := []roachpb.Span{span}
 
-	planCtx := params.p.session.distSQLPlanner.newPlanningCtx(ctx, params.evalCtx, params.p.txn)
+	planCtx := params.p.session.distSQLPlanner.newPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
 	physPlan, err := params.p.session.distSQLPlanner.createScrubPhysicalCheck(
 		&planCtx, scan, *o.tableDesc, *o.indexDesc, spans, params.p.ExecCfg().Clock.Now())
 	if err != nil {
@@ -159,7 +159,7 @@ func (o *physicalCheckOperation) Next(params runParams) (tree.Datums, error) {
 	o.run.rowIndex++
 
 	timestamp := tree.MakeDTimestamp(
-		params.evalCtx.GetStmtTimestamp(), time.Nanosecond)
+		params.extendedEvalCtx.GetStmtTimestamp(), time.Nanosecond)
 
 	details, ok := row[2].(*tree.DJSON)
 	if !ok {

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
 // invalidSrcIdx is the srcIdx value returned by findColumn() when there is no match.
@@ -36,7 +37,7 @@ type nameResolutionVisitor struct {
 	err        error
 	sources    multiSourceInfo
 	iVarHelper tree.IndexedVarHelper
-	searchPath tree.SearchPath
+	searchPath sessiondata.SearchPath
 
 	// foundDependentVars is set to true during the analysis if an
 	// expression was found which can change values between rows of the
@@ -224,7 +225,7 @@ func (p *planner) resolveNames(
 		err:                nil,
 		sources:            sources,
 		iVarHelper:         ivarHelper,
-		searchPath:         p.session.SearchPath,
+		searchPath:         p.SessionData().SearchPath,
 		foundDependentVars: false,
 	}
 	colOffset := 0

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2063,10 +2063,10 @@ CockroachDB supports the following flags:
 			ReturnType: tree.FixedReturnType(types.String),
 			Category:   categorySystemInfo,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				if len(ctx.Database) == 0 {
+				if len(ctx.SessionData.Database) == 0 {
 					return tree.DNull, nil
 				}
-				return tree.NewDString(ctx.Database), nil
+				return tree.NewDString(ctx.SessionData.Database), nil
 			},
 			Info: "Returns the current database.",
 		},
@@ -2078,10 +2078,10 @@ CockroachDB supports the following flags:
 			ReturnType: tree.FixedReturnType(types.String),
 			Category:   categorySystemInfo,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				if len(ctx.Database) == 0 {
+				if len(ctx.SessionData.Database) == 0 {
 					return tree.DNull, nil
 				}
-				return tree.NewDString(ctx.Database), nil
+				return tree.NewDString(ctx.SessionData.Database), nil
 			},
 			Info: "Returns the current schema. This function is provided for " +
 				"compatibility with PostgreSQL. For a new CockroachDB application, " +
@@ -2100,19 +2100,19 @@ CockroachDB supports the following flags:
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				includePgCatalog := *(args[0].(*tree.DBool))
 				schemas := tree.NewDArray(types.String)
-				if len(ctx.Database) != 0 {
-					if err := schemas.Append(tree.NewDString(ctx.Database)); err != nil {
+				if len(ctx.SessionData.Database) != 0 {
+					if err := schemas.Append(tree.NewDString(ctx.SessionData.Database)); err != nil {
 						return nil, err
 					}
 				}
 				var iter func() (string, bool)
 				if includePgCatalog {
-					iter = ctx.SearchPath.Iter()
+					iter = ctx.SessionData.SearchPath.Iter()
 				} else {
-					iter = ctx.SearchPath.IterWithoutImplicitPGCatalog()
+					iter = ctx.SessionData.SearchPath.IterWithoutImplicitPGCatalog()
 				}
 				for p, ok := iter(); ok; p, ok = iter() {
-					if p == ctx.Database {
+					if p == ctx.SessionData.Database {
 						continue
 					}
 					if err := schemas.Append(tree.NewDString(p)); err != nil {
@@ -2131,10 +2131,10 @@ CockroachDB supports the following flags:
 			ReturnType: tree.FixedReturnType(types.String),
 			Category:   categorySystemInfo,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				if len(ctx.User) == 0 {
+				if len(ctx.SessionData.User) == 0 {
 					return tree.DNull, nil
 				}
-				return tree.NewDString(ctx.User), nil
+				return tree.NewDString(ctx.SessionData.User), nil
 			},
 			Info: "Returns the current user. This function is provided for " +
 				"compatibility with PostgreSQL.",

--- a/pkg/sql/sem/transform/aggregates.go
+++ b/pkg/sql/sem/transform/aggregates.go
@@ -17,13 +17,14 @@ package transform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
 // IsAggregateVisitor checks if walked expressions contain aggregate functions.
 type IsAggregateVisitor struct {
 	Aggregated bool
 	// searchPath is used to search for unqualified function names.
-	searchPath tree.SearchPath
+	searchPath sessiondata.SearchPath
 }
 
 var _ tree.Visitor = &IsAggregateVisitor{}

--- a/pkg/sql/sem/transform/expr_transform.go
+++ b/pkg/sql/sem/transform/expr_transform.go
@@ -17,6 +17,7 @@ package transform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
 // ExprTransformContext supports the methods that test expression
@@ -47,7 +48,9 @@ func (t *ExprTransformContext) NormalizeExpr(
 }
 
 // AggregateInExpr determines if an Expr contains an aggregate function.
-func (t *ExprTransformContext) AggregateInExpr(expr tree.Expr, searchPath tree.SearchPath) bool {
+func (t *ExprTransformContext) AggregateInExpr(
+	expr tree.Expr, searchPath sessiondata.SearchPath,
+) bool {
 	if expr == nil {
 		return false
 	}
@@ -60,7 +63,9 @@ func (t *ExprTransformContext) AggregateInExpr(expr tree.Expr, searchPath tree.S
 
 // IsAggregate determines if the given SelectClause contains an
 // aggregate function.
-func (t *ExprTransformContext) IsAggregate(n *tree.SelectClause, searchPath tree.SearchPath) bool {
+func (t *ExprTransformContext) IsAggregate(
+	n *tree.SelectClause, searchPath sessiondata.SearchPath,
+) bool {
 	if n.Having != nil || len(n.GroupBy) > 0 {
 		return true
 	}
@@ -87,7 +92,7 @@ func (t *ExprTransformContext) IsAggregate(n *tree.SelectClause, searchPath tree
 // AssertNoAggregationOrWindowing checks if the provided expression contains either
 // aggregate functions or window functions, returning an error in either case.
 func (t *ExprTransformContext) AssertNoAggregationOrWindowing(
-	expr tree.Expr, op string, searchPath tree.SearchPath,
+	expr tree.Expr, op string, searchPath sessiondata.SearchPath,
 ) error {
 	if t.AggregateInExpr(expr, searchPath) {
 		return pgerror.NewErrorf(pgerror.CodeGroupingError, "aggregate functions are not allowed in %s", op)

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
 // FunctionDefinition implements a reference to the (possibly several)
@@ -63,7 +64,9 @@ func (fd *FunctionDefinition) Format(ctx *FmtCtx) {
 func (fd *FunctionDefinition) String() string { return AsString(fd) }
 
 // ResolveFunction transforms an UnresolvedName to a FunctionDefinition.
-func (n *UnresolvedName) ResolveFunction(searchPath SearchPath) (*FunctionDefinition, error) {
+func (n *UnresolvedName) ResolveFunction(
+	searchPath sessiondata.SearchPath,
+) (*FunctionDefinition, error) {
 	fn, err := n.normalizeFunctionName()
 	if err != nil {
 		return nil, err

--- a/pkg/sql/sem/tree/function_name.go
+++ b/pkg/sql/sem/tree/function_name.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
 // Function names are used in expressions in the FuncExpr node.
@@ -44,7 +45,9 @@ func (fn *ResolvableFunctionReference) String() string { return AsString(fn) }
 
 // Resolve checks if the function name is already resolved and
 // resolves it as necessary.
-func (fn *ResolvableFunctionReference) Resolve(searchPath SearchPath) (*FunctionDefinition, error) {
+func (fn *ResolvableFunctionReference) Resolve(
+	searchPath sessiondata.SearchPath,
+) (*FunctionDefinition, error) {
 	switch t := fn.FunctionReference.(type) {
 	case *FunctionDefinition:
 		return t, nil

--- a/pkg/sql/sem/tree/function_name_test.go
+++ b/pkg/sql/sem/tree/function_name_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 )
 
@@ -37,7 +38,7 @@ func TestResolveFunction(t *testing.T) {
 		{`foo.*`, ``, `invalid function name: foo.*`},
 	}
 
-	searchPath := tree.MakeSearchPath([]string{"pg_catalog"})
+	searchPath := sessiondata.MakeSearchPath([]string{"pg_catalog"})
 	for _, tc := range testCases {
 		stmt, err := parser.ParseOne("SELECT " + tc.in + "(1)")
 		if err != nil {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
 // SemaContext defines the context in which to perform semantic analysis on an
@@ -41,7 +42,7 @@ type SemaContext struct {
 	// SearchPath indicates where to search for unqualified function
 	// names. The path elements must be normalized via Name.Normalize()
 	// already.
-	SearchPath SearchPath
+	SearchPath sessiondata.SearchPath
 
 	// privileged, if true, enables "unsafe" builtins, e.g. those
 	// from the crdb_internal namespace. Must be set only for
@@ -453,7 +454,7 @@ var (
 
 // TypeCheck implements the Expr interface.
 func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, error) {
-	var searchPath SearchPath
+	var searchPath sessiondata.SearchPath
 	if ctx != nil {
 		searchPath = ctx.SearchPath
 	}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -89,57 +90,11 @@ var DistSQLClusterExecMode = settings.RegisterEnumSetting(
 	"Default distributed SQL execution mode",
 	"Auto",
 	map[int64]string{
-		int64(DistSQLOff):  "Off",
-		int64(DistSQLAuto): "Auto",
-		int64(DistSQLOn):   "On",
+		int64(sessiondata.DistSQLOff):  "Off",
+		int64(sessiondata.DistSQLAuto): "Auto",
+		int64(sessiondata.DistSQLOn):   "On",
 	},
 )
-
-// DistSQLExecMode controls if and when the Executor uses DistSQL.
-type DistSQLExecMode int64
-
-const (
-	// DistSQLOff means that we never use distSQL.
-	DistSQLOff DistSQLExecMode = iota
-	// DistSQLAuto means that we automatically decide on a case-by-case basis if
-	// we use distSQL.
-	DistSQLAuto
-	// DistSQLOn means that we use distSQL for queries that are supported.
-	DistSQLOn
-	// DistSQLAlways means that we only use distSQL; unsupported queries fail.
-	DistSQLAlways
-)
-
-func (m DistSQLExecMode) String() string {
-	switch m {
-	case DistSQLOff:
-		return "off"
-	case DistSQLAuto:
-		return "auto"
-	case DistSQLOn:
-		return "on"
-	case DistSQLAlways:
-		return "always"
-	default:
-		return fmt.Sprintf("invalid (%d)", m)
-	}
-}
-
-// DistSQLExecModeFromString converts a string into a DistSQLExecMode
-func DistSQLExecModeFromString(val string) DistSQLExecMode {
-	switch strings.ToUpper(val) {
-	case "OFF":
-		return DistSQLOff
-	case "AUTO":
-		return DistSQLAuto
-	case "ON":
-		return DistSQLOn
-	case "ALWAYS":
-		return DistSQLAlways
-	default:
-		panic(fmt.Sprintf("unknown DistSQL mode %s", val))
-	}
-}
 
 // queryPhase represents a phase during a query's execution.
 type queryPhase int
@@ -184,41 +139,14 @@ func (q *queryMeta) cancel() {
 // Session contains the state of a SQL client connection.
 // Create instances using NewSession().
 type Session struct {
-	//
-	// Session parameters, user-configurable.
-	//
-
-	// Database indicates the "current" database for the purpose of
-	// resolving names. See searchAndQualifyDatabase() for details.
-	Database string
-	// DefaultIsolationLevel indicates the default isolation level of
-	// newly created transactions.
-	DefaultIsolationLevel enginepb.IsolationType
-	// DefaultReadOnly indicates the default read-only status of
-	// newly created transactions.
-	DefaultReadOnly bool
-	// DistSQLMode indicates whether to run queries using the distributed
-	// execution engine.
-	DistSQLMode DistSQLExecMode
-	// Location indicates the current time zone.
-	Location *time.Location
-	// SearchPath is a list of databases that will be searched for a table name
-	// before the database. Currently, this is used only for SELECTs.
-	// Names in the search path must have been normalized already.
-	SearchPath tree.SearchPath
-	// User is the name of the user logged into the session.
-	User string
-	// SafeUpdates causes errors when the client
-	// sends syntax that may have unwanted side effects.
-	SafeUpdates bool
+	// data contains user-configurable session-scoped variables. This is the
+	// authoritative copy of these variables; a planner's evalCtx gets a copy.
+	data        sessiondata.SessionData
+	dataMutator sessionDataMutator
 
 	//
 	// Session parameters, non-user-configurable.
 	//
-
-	// defaults is used to restore default configuration values into
-	// SET ... TO DEFAULT statements.
-	defaults sessionDefaults
 
 	// ClientAddr is the client's IP address and port.
 	ClientAddr string
@@ -371,7 +299,7 @@ type Session struct {
 }
 
 // sessionDefaults mirrors fields in Session, for restoring default
-// configuration values in SET ... TO DEFAULT statements.
+// configuration values in SET ... TO DEFAULT (or RESET ...) statements.
 type sessionDefaults struct {
 	applicationName string
 	database        string
@@ -420,7 +348,7 @@ func (r *SessionRegistry) CancelQuery(queryIDStr string, username string) (bool,
 	defer r.Unlock()
 
 	for session := range r.store {
-		if !(username == security.RootUser || username == session.User) {
+		if !(username == security.RootUser || username == session.data.User) {
 			// Skip this session.
 			continue
 		}
@@ -458,31 +386,39 @@ func NewSession(
 	ctx context.Context, args SessionArgs, e *Executor, remote net.Addr, memMetrics *MemoryMetrics,
 ) *Session {
 	ctx = e.AnnotateCtx(ctx)
-	distSQLMode := DistSQLExecMode(DistSQLClusterExecMode.Get(&e.cfg.Settings.SV))
+	distSQLMode := sessiondata.DistSQLExecMode(DistSQLClusterExecMode.Get(&e.cfg.Settings.SV))
 
 	s := &Session{
-		Database:         args.Database,
-		DistSQLMode:      distSQLMode,
-		SearchPath:       sqlbase.DefaultSearchPath,
-		Location:         time.UTC,
-		User:             args.User,
+		data: sessiondata.SessionData{
+			Database:    args.Database,
+			DistSQLMode: distSQLMode,
+			SearchPath:  sqlbase.DefaultSearchPath,
+			Location:    time.UTC,
+			User:        args.User,
+		},
 		virtualSchemas:   e.virtualSchemas,
 		execCfg:          &e.cfg,
 		distSQLPlanner:   e.distSQLPlanner,
 		parallelizeQueue: MakeParallelizeQueue(NewSpanBasedDependencyAnalyzer()),
 		memMetrics:       memMetrics,
 		sqlStats:         &e.sqlStats,
-		defaults: sessionDefaults{
-			applicationName: args.ApplicationName,
-			database:        args.Database,
-		},
 		tables: TableCollection{
 			leaseMgr:      e.cfg.LeaseManager,
 			databaseCache: e.getDatabaseCache(),
 		},
 	}
+	s.dataMutator = sessionDataMutator{
+		data: &s.data,
+		s:    s,
+		defaults: sessionDefaults{
+			applicationName: args.ApplicationName,
+			database:        args.Database,
+		},
+		settings:       e.cfg.Settings,
+		curTxnReadOnly: &s.TxnState.readOnly,
+	}
 	s.phaseTimes[sessionInit] = timeutil.Now()
-	s.resetApplicationName(args.ApplicationName)
+	s.dataMutator.SetApplicationName(args.ApplicationName)
 	s.PreparedStatements = makePreparedStatements(s)
 	s.PreparedPortals = makePreparedPortals(s)
 	s.Tracing.session = s
@@ -633,17 +569,19 @@ func (s *Session) resetPlanner(p *planner, e *Executor, txn *client.Txn) {
 	p.stmt = nil
 	p.cancelChecker = sqlbase.NewCancelChecker(s.Ctx())
 
-	p.semaCtx = tree.MakeSemaContext(s.User == security.RootUser)
-	p.semaCtx.Location = &s.Location
-	p.semaCtx.SearchPath = s.SearchPath
+	p.semaCtx = tree.MakeSemaContext(s.data.User == security.RootUser)
+	p.semaCtx.Location = &s.data.Location
+	p.semaCtx.SearchPath = s.data.SearchPath
 
-	p.evalCtx = s.evalCtx()
-	p.evalCtx.Planner = p
+	p.extendedEvalCtx = s.extendedEvalCtx()
+	p.extendedEvalCtx.Planner = p
 	if e != nil {
-		p.evalCtx.ClusterID = e.cfg.ClusterID()
-		p.evalCtx.NodeID = e.cfg.NodeID.Get()
-		p.evalCtx.ReCache = e.reCache
+		p.extendedEvalCtx.ClusterID = e.cfg.ClusterID()
+		p.extendedEvalCtx.NodeID = e.cfg.NodeID.Get()
+		p.extendedEvalCtx.ReCache = e.reCache
 	}
+
+	p.sessionDataMutator = s.dataMutator
 
 	p.setTxn(txn)
 }
@@ -680,8 +618,9 @@ func (s *Session) newPlanner(e *Executor, txn *client.Txn) *planner {
 	return p
 }
 
-// evalCtx creates a tree.EvalContext from the Session's current configuration.
-func (s *Session) evalCtx() tree.EvalContext {
+// extendedEvalCtx creates an evaluation context from the Session's current
+// configuration.
+func (s *Session) extendedEvalCtx() extendedEvalContext {
 	var evalContextTestingKnobs tree.EvalContextTestingKnobs
 	var st *cluster.Settings
 	if s.execCfg != nil {
@@ -690,15 +629,19 @@ func (s *Session) evalCtx() tree.EvalContext {
 		// Perhaps `*Settings` should live somewhere else.
 		st = s.execCfg.Settings
 	}
-	return tree.EvalContext{
-		Settings:     st,
-		Location:     &s.Location,
-		Database:     s.Database,
-		User:         s.User,
-		SearchPath:   s.SearchPath,
-		CtxProvider:  s,
-		Mon:          &s.TxnState.mon,
-		TestingKnobs: evalContextTestingKnobs,
+	return extendedEvalContext{
+		EvalContext: tree.EvalContext{
+			SessionData:     s.data,
+			ApplicationName: s.dataMutator.ApplicationName(),
+			TxnState:        getTransactionState(&s.TxnState),
+			TxnReadOnly:     s.TxnState.readOnly,
+			Settings:        st,
+			CtxProvider:     s,
+			Mon:             &s.TxnState.mon,
+			TestingKnobs:    evalContextTestingKnobs,
+		},
+		VirtualSchemas: &s.virtualSchemas,
+		Tracing:        &s.Tracing,
 	}
 }
 
@@ -874,7 +817,7 @@ func (s *Session) serialize() serverpb.Session {
 	}
 
 	return serverpb.Session{
-		Username:        s.User,
+		Username:        s.data.User,
 		ClientAddress:   s.ClientAddr,
 		ApplicationName: s.mu.ApplicationName,
 		Start:           s.phaseTimes[sessionInit].UTC(),
@@ -1411,7 +1354,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 		sc.distSQLPlanner = e.distSQLPlanner
 		for r := retry.Start(base.DefaultRetryOptions()); r.Next(); {
 			evalCtx := createSchemaChangeEvalCtx(e.cfg.Clock.Now())
-			if err := sc.exec(ctx, true /* inSession */, evalCtx); err != nil {
+			if err := sc.exec(ctx, true /* inSession */, &evalCtx); err != nil {
 				if shouldLogSchemaChangeError(err) {
 					log.Warningf(ctx, "error executing schema change: %s", err)
 				}
@@ -1511,6 +1454,11 @@ func (s *Session) maybeRecover(action, stmts string) {
 		// Propagate the (sanitized) panic further.
 		panic(safeErr)
 	}
+}
+
+// Location exports the location session variable.
+func (s *Session) Location() *time.Location {
+	return s.data.Location
 }
 
 // SessionTracing holds the state used by SET TRACING {ON,OFF,LOCAL} statements in
@@ -1902,4 +1850,71 @@ type spanWithIndex struct {
 	// txnIdx is the 0-based index of the transaction in which this span was
 	// recorded.
 	txnIdx int
+}
+
+// sessionDataMutator is the interface used by sessionVars to change the session
+// state. It mostly mutates the Session's SessionData, but not exclusively (e.g.
+// see curTxnReadOnly).
+type sessionDataMutator struct {
+	data     *sessiondata.SessionData
+	s        *Session
+	defaults sessionDefaults
+	settings *cluster.Settings
+	// curTxnReadOnly is a value to be mutated through SET transaction_read_only = ...
+	curTxnReadOnly *bool
+}
+
+// SetApplicationName initializes both Session.mu.ApplicationName and
+// the cached pointer to per-application statistics. It is meant to be
+// used upon session initialization and upon SET APPLICATION_NAME.
+func (m *sessionDataMutator) SetApplicationName(appName string) {
+	s := m.s
+	s.mu.Lock()
+	s.mu.ApplicationName = appName
+	s.mu.Unlock()
+	if s.sqlStats != nil {
+		s.appStats = s.sqlStats.getStatsForApplication(appName)
+	}
+}
+
+// ApplicationName returns the session's "application_name" variable. This is
+// not a setter method, but the method is here nevertheless because
+// ApplicationName is not part of SessionData because accessing it needs
+// locking.
+func (m *sessionDataMutator) ApplicationName() string {
+	m.s.mu.RLock()
+	defer m.s.mu.RUnlock()
+	return m.s.mu.ApplicationName
+}
+
+func (m *sessionDataMutator) SetDatabase(dbName string) {
+	m.data.Database = dbName
+}
+
+func (m *sessionDataMutator) SetDefaultIsolationLevel(iso enginepb.IsolationType) {
+	m.data.DefaultIsolationLevel = iso
+}
+
+func (m *sessionDataMutator) SetDefaultReadOnly(val bool) {
+	m.data.DefaultReadOnly = val
+}
+
+func (m *sessionDataMutator) SetDistSQLMode(val sessiondata.DistSQLExecMode) {
+	m.data.DistSQLMode = val
+}
+
+func (m *sessionDataMutator) SetSafeUpdates(val bool) {
+	m.data.SafeUpdates = val
+}
+
+func (m *sessionDataMutator) SetSearchPath(val sessiondata.SearchPath) {
+	m.data.SearchPath = val
+}
+
+func (m *sessionDataMutator) SetLocation(loc *time.Location) {
+	m.data.Location = loc
+}
+
+func (m *sessionDataMutator) SetReadOnly(val bool) {
+	*m.curTxnReadOnly = val
 }

--- a/pkg/sql/sessiondata/search_path.go
+++ b/pkg/sql/sessiondata/search_path.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tree
+package sessiondata
 
 import (
 	"strings"

--- a/pkg/sql/sessiondata/search_path_test.go
+++ b/pkg/sql/sessiondata/search_path_test.go
@@ -12,7 +12,7 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package tree
+package sessiondata
 
 import (
 	"reflect"

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -1,0 +1,97 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sessiondata
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+)
+
+// SessionData contains session parameters. They are all user-configurable.
+// A SQL Session changes fields in SessionData through sql.sessionDataMutator.
+type SessionData struct {
+	// Database indicates the "current" database for the purpose of
+	// resolving names. See searchAndQualifyDatabase() for details.
+	Database string
+	// DefaultIsolationLevel indicates the default isolation level of
+	// newly created transactions.
+	DefaultIsolationLevel enginepb.IsolationType
+	// DefaultReadOnly indicates the default read-only status of newly created
+	// transactions.
+	DefaultReadOnly bool
+	// DistSQLMode indicates whether to run queries using the distributed
+	// execution engine.
+	DistSQLMode DistSQLExecMode
+	// Location indicates the current time zone.
+	Location *time.Location
+	// SearchPath is a list of databases that will be searched for a table name
+	// before the database. Currently, this is used only for SELECTs.
+	// Names in the search path must have been normalized already.
+	SearchPath SearchPath
+	// User is the name of the user logged into the session.
+	User string
+	// SafeUpdates causes errors when the client
+	// sends syntax that may have unwanted side effects.
+	SafeUpdates bool
+}
+
+// DistSQLExecMode controls if and when the Executor uses DistSQL.
+type DistSQLExecMode int64
+
+const (
+	// DistSQLOff means that we never use distSQL.
+	DistSQLOff DistSQLExecMode = iota
+	// DistSQLAuto means that we automatically decide on a case-by-case basis if
+	// we use distSQL.
+	DistSQLAuto
+	// DistSQLOn means that we use distSQL for queries that are supported.
+	DistSQLOn
+	// DistSQLAlways means that we only use distSQL; unsupported queries fail.
+	DistSQLAlways
+)
+
+func (m DistSQLExecMode) String() string {
+	switch m {
+	case DistSQLOff:
+		return "off"
+	case DistSQLAuto:
+		return "auto"
+	case DistSQLOn:
+		return "on"
+	case DistSQLAlways:
+		return "always"
+	default:
+		return fmt.Sprintf("invalid (%d)", m)
+	}
+}
+
+// DistSQLExecModeFromString converts a string into a DistSQLExecMode
+func DistSQLExecModeFromString(val string) DistSQLExecMode {
+	switch strings.ToUpper(val) {
+	case "OFF":
+		return DistSQLOff
+	case "AUTO":
+		return DistSQLAuto
+	case "ON":
+		return DistSQLOn
+	case "ALWAYS":
+		return DistSQLAlways
+	default:
+		panic(fmt.Sprintf("unknown DistSQL mode %s", val))
+	}
+}

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -129,12 +129,12 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 		params.p.txn,
 		EventLogSetClusterSetting,
 		0, /* no target */
-		int32(params.evalCtx.NodeID),
+		int32(params.extendedEvalCtx.NodeID),
 		struct {
 			SettingName string
 			Value       string
 			User        string
-		}{n.name, reportedValue, params.p.session.User},
+		}{n.name, reportedValue, params.p.session.data.User},
 	)
 }
 
@@ -150,7 +150,7 @@ func (p *planner) toSettingString(
 	setting settings.Setting,
 	val tree.TypedExpr,
 ) (string, error) {
-	d, err := val.Eval(&p.evalCtx)
+	d, err := val.Eval(p.EvalContext())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sql/set_default_isolation.go
+++ b/pkg/sql/set_default_isolation.go
@@ -27,9 +27,9 @@ func (p *planner) SetSessionCharacteristics(n *tree.SetSessionCharacteristics) (
 	// Ensure both versions stay in sync.
 	switch n.Modes.Isolation {
 	case tree.SerializableIsolation:
-		p.session.DefaultIsolationLevel = enginepb.SERIALIZABLE
+		p.sessionDataMutator.SetDefaultIsolationLevel(enginepb.SERIALIZABLE)
 	case tree.SnapshotIsolation:
-		p.session.DefaultIsolationLevel = enginepb.SNAPSHOT
+		p.sessionDataMutator.SetDefaultIsolationLevel(enginepb.SNAPSHOT)
 	case tree.UnspecifiedIsolation:
 	default:
 		return nil, fmt.Errorf("unsupported default isolation level: %s", n.Modes.Isolation)
@@ -37,9 +37,9 @@ func (p *planner) SetSessionCharacteristics(n *tree.SetSessionCharacteristics) (
 
 	switch n.Modes.ReadWriteMode {
 	case tree.ReadOnly:
-		p.session.DefaultReadOnly = true
+		p.sessionDataMutator.SetDefaultReadOnly(true)
 	case tree.ReadWrite:
-		p.session.DefaultReadOnly = false
+		p.sessionDataMutator.SetDefaultReadOnly(false)
 	case tree.UnspecifiedReadWriteMode:
 	default:
 		return nil, fmt.Errorf("unsupported default read write mode: %s", n.Modes.ReadWriteMode)

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -100,24 +100,25 @@ func (p *planner) SetVar(ctx context.Context, n *tree.SetVar) (planNode, error) 
 func (n *setVarNode) startExec(params runParams) error {
 	if n.typedValues != nil {
 		for i, v := range n.typedValues {
-			d, err := v.Eval(params.evalCtx)
+			d, err := v.Eval(params.EvalContext())
 			if err != nil {
 				return err
 			}
 			n.typedValues[i] = d
 		}
-		return n.v.Set(params.ctx, params.p.session, n.typedValues)
+		return n.v.Set(
+			params.ctx, params.p.sessionDataMutator,
+			params.extendedEvalCtx, n.typedValues)
 	}
-	return n.v.Reset(params.p.session)
+	return n.v.Reset(params.p.sessionDataMutator)
 }
 
 func (n *setVarNode) Next(_ runParams) (bool, error) { return false, nil }
 func (n *setVarNode) Values() tree.Datums            { return nil }
 func (n *setVarNode) Close(_ context.Context)        {}
 
-func datumAsString(session *Session, name string, value tree.TypedExpr) (string, error) {
-	evalCtx := session.evalCtx()
-	val, err := value.Eval(&evalCtx)
+func datumAsString(evalCtx *tree.EvalContext, name string, value tree.TypedExpr) (string, error) {
+	val, err := value.Eval(evalCtx)
 	if err != nil {
 		return "", err
 	}
@@ -129,26 +130,27 @@ func datumAsString(session *Session, name string, value tree.TypedExpr) (string,
 	return string(s), nil
 }
 
-func getStringVal(session *Session, name string, values []tree.TypedExpr) (string, error) {
+func getStringVal(evalCtx *tree.EvalContext, name string, values []tree.TypedExpr) (string, error) {
 	if len(values) != 1 {
 		return "", fmt.Errorf("set %s: requires a single string value", name)
 	}
-	return datumAsString(session, name, values[0])
+	return datumAsString(evalCtx, name, values[0])
 }
 
-func setTimeZone(_ context.Context, session *Session, values []tree.TypedExpr) error {
+func setTimeZone(
+	_ context.Context, m sessionDataMutator, evalCtx *extendedEvalContext, values []tree.TypedExpr,
+) error {
 	if len(values) != 1 {
 		return errors.New("set time zone requires a single argument")
 	}
-	evalCtx := session.evalCtx()
-	d, err := values[0].Eval(&evalCtx)
+	d, err := values[0].Eval(&evalCtx.EvalContext)
 	if err != nil {
 		return err
 	}
 
 	var loc *time.Location
 	var offset int64
-	switch v := tree.UnwrapDatum(&evalCtx, d).(type) {
+	switch v := tree.UnwrapDatum(&evalCtx.EvalContext, d).(type) {
 	case *tree.DString:
 		location := string(*v)
 		loc, err = timeutil.LoadLocation(location)
@@ -191,6 +193,6 @@ func setTimeZone(_ context.Context, session *Session, values []tree.TypedExpr) e
 	if loc == nil {
 		loc = timeutil.FixedOffsetTimeZoneToLocation(int(offset), d.String())
 	}
-	session.Location = loc
+	m.SetLocation(loc)
 	return nil
 }

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -58,7 +58,7 @@ type setZoneConfigRun struct {
 
 func (n *setZoneConfigNode) startExec(params runParams) error {
 	var yamlConfig *string
-	datum, err := n.yamlConfig.Eval(params.evalCtx)
+	datum, err := n.yamlConfig.Eval(params.EvalContext())
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,8 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 		}
 	}
 
-	targetID, err := resolveZone(params.ctx, params.p.txn, &n.zoneSpecifier, params.p.session.Database)
+	targetID, err := resolveZone(
+		params.ctx, params.p.txn, &n.zoneSpecifier, params.SessionData().Database)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/show_constraints.go
+++ b/pkg/sql/show_constraints.go
@@ -29,7 +29,7 @@ import (
 //   Notes: postgres does not have a SHOW CONSTRAINTS statement.
 //          mysql requires some privilege for any column.
 func (p *planner) ShowConstraints(ctx context.Context, n *tree.ShowConstraints) (planNode, error) {
-	tn, err := n.Table.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := n.Table.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -54,7 +54,7 @@ type showFingerprintsNode struct {
 func (p *planner) ShowFingerprints(
 	ctx context.Context, n *tree.ShowFingerprints,
 ) (planNode, error) {
-	tn, err := n.Table.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := n.Table.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_grants.go
+++ b/pkg/sql/show_grants.go
@@ -92,7 +92,7 @@ func (p *planner) ShowGrants(ctx context.Context, n *tree.ShowGrants) (planNode,
 					return nil, err
 				}
 				tables, err := expandTableGlob(ctx, p.txn, p.getVirtualTabler(),
-					p.session.Database, tableGlob)
+					p.SessionData().Database, tableGlob)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -37,7 +37,7 @@ var showTableStatsColumns = sqlbase.ResultColumns{
 // ShowTableStats returns a SHOW STATISTICS statement for the specified table.
 // Privileges: Any privilege on table.
 func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (planNode, error) {
-	tn, err := n.Table.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := n.Table.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_table.go
+++ b/pkg/sql/show_table.go
@@ -33,7 +33,7 @@ import (
 func (p *planner) showTableDetails(
 	ctx context.Context, showType string, t tree.NormalizableTableName, query string,
 ) (planNode, error) {
-	tn, err := t.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := t.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_tables.go
+++ b/pkg/sql/show_tables.go
@@ -27,7 +27,7 @@ import (
 //   Notes: postgres does not have a SHOW TABLES statement.
 //          mysql only returns tables you have privileges on.
 func (p *planner) ShowTables(ctx context.Context, n *tree.ShowTables) (planNode, error) {
-	name := p.session.Database
+	name := p.SessionData().Database
 	if n.Database != "" {
 		name = string(n.Database)
 	}

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -81,7 +81,8 @@ func (n *showZoneConfigNode) startExec(params runParams) error {
 		}
 	}
 
-	targetID, err := resolveZone(params.ctx, params.p.txn, &n.zoneSpecifier, params.p.session.Database)
+	targetID, err := resolveZone(
+		params.ctx, params.p.txn, &n.zoneSpecifier, params.SessionData().Database)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -222,7 +222,7 @@ func (n *sortNode) Next(params runParams) (bool, error) {
 			v := &sortValues{
 				ordering: n.ordering,
 				rows:     vn.rows,
-				evalCtx:  params.evalCtx,
+				evalCtx:  params.EvalContext(),
 			}
 			n.run.sortStrategy = newSortAllStrategy(v)
 			n.run.sortStrategy.Finish(params.ctx, cancelChecker)
@@ -699,7 +699,7 @@ func (p *planner) newSortValues(
 			sqlbase.ColTypeInfoFromResCols(columns),
 			capacity,
 		),
-		evalCtx: &p.evalCtx,
+		evalCtx: p.EvalContext(),
 	}
 }
 

--- a/pkg/sql/sqlbase/constants.go
+++ b/pkg/sql/sqlbase/constants.go
@@ -14,10 +14,10 @@
 
 package sqlbase
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+import "github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 
 // DefaultSearchPath is the search path used by virgin sessions.
-var DefaultSearchPath = tree.SearchPath{}
+var DefaultSearchPath = sessiondata.SearchPath{}
 
 // AdminRole is the default (and non-droppable) role with superuser privileges.
 var AdminRole = "admin"

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -113,9 +113,9 @@ func (s *subquery) doEval(ctx context.Context, p *planner) (result tree.Datum, e
 	defer func() { s.plan.Close(ctx); s.plan = nil }()
 
 	params := runParams{
-		ctx:     ctx,
-		evalCtx: &p.evalCtx,
-		p:       p,
+		ctx:             ctx,
+		extendedEvalCtx: &p.extendedEvalCtx,
+		p:               p,
 	}
 	switch s.execMode {
 	case execModeExists:
@@ -163,7 +163,7 @@ func (s *subquery) doEval(ctx context.Context, p *planner) (result tree.Datum, e
 			rows.SetSorted()
 		}
 		if s.execMode == execModeAllRowsNormalized {
-			rows.Normalize(&p.evalCtx)
+			rows.Normalize(p.EvalContext())
 		}
 		result = &rows
 

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -40,7 +40,7 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	params := runParams{ctx: context.TODO(), p: p}
+	params := runParams{ctx: context.TODO(), p: p, extendedEvalCtx: &p.extendedEvalCtx}
 	if err := startPlan(params, plan); !testutils.IsError(err, `forced`) {
 		t.Fatalf("expected error from force_error(), got: %v", err)
 	}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -591,7 +591,7 @@ func (p *planner) getAliasedTableName(n tree.TableExpr) (*tree.TableName, *tree.
 	if !ok {
 		return nil, nil, errors.Errorf("TODO(pmattis): unsupported FROM: %s", n)
 	}
-	tn, err := table.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := table.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -645,7 +645,7 @@ func (p *planner) notifySchemaChange(
 	sc := SchemaChanger{
 		tableID:              tableDesc.GetID(),
 		mutationID:           mutationID,
-		nodeID:               p.evalCtx.NodeID,
+		nodeID:               p.extendedEvalCtx.NodeID,
 		leaseMgr:             p.LeaseMgr(),
 		jobRegistry:          p.ExecCfg().JobRegistry,
 		leaseHolderCache:     p.ExecCfg().LeaseHolderCache,
@@ -725,8 +725,8 @@ func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *tree.TableNa
 		descFunc = getTableOrViewDesc
 	}
 
-	if p.session.Database != "" {
-		t.DatabaseName = tree.Name(p.session.Database)
+	if p.SessionData().Database != "" {
+		t.DatabaseName = tree.Name(p.SessionData().Database)
 		desc, err := descFunc(ctx, p.txn, p.getVirtualTabler(), &t)
 		if err != nil && !sqlbase.IsUndefinedRelationError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
 			return err
@@ -740,7 +740,7 @@ func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *tree.TableNa
 
 	// Not found using the current session's database, so try
 	// the search path instead.
-	iter := p.session.SearchPath.Iter()
+	iter := p.SessionData().SearchPath.Iter()
 	for database, ok := iter(); ok; database, ok = iter() {
 		t.DatabaseName = tree.Name(database)
 		desc, err := descFunc(ctx, p.txn, p.getVirtualTabler(), &t)
@@ -829,7 +829,7 @@ func (p *planner) findTableContainingIndex(
 func (p *planner) expandIndexName(
 	ctx context.Context, index *tree.TableNameWithIndex, requireTable bool,
 ) (*tree.TableName, error) {
-	tn, err := index.Table.NormalizeWithDatabaseName(p.session.Database)
+	tn, err := index.Table.NormalizeWithDatabaseName(p.SessionData().Database)
 	if err != nil {
 		return nil, err
 	}
@@ -879,7 +879,7 @@ func (p *planner) getTableAndIndex(
 	var err error
 	if tableWithIndex == nil {
 		// Variant: ALTER TABLE
-		tn, err = table.NormalizeWithDatabaseName(p.session.Database)
+		tn, err = table.NormalizeWithDatabaseName(p.SessionData().Database)
 	} else {
 		// Variant: ALTER INDEX
 		tn, err = p.expandIndexName(ctx, tableWithIndex, true /* requireTable */)

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -39,7 +39,7 @@ func (p *planner) computeRender(
 	// column name, we determine the name before we perform any manipulations to
 	// the expression.
 	if outputName == autoGenerateRenderOutputName {
-		if outputName, err = getRenderColName(p.session.SearchPath, target, &ivarHelper); err != nil {
+		if outputName, err = getRenderColName(p.SessionData().SearchPath, target, &ivarHelper); err != nil {
 			return sqlbase.ResultColumn{}, nil, err
 		}
 	}

--- a/pkg/sql/tests/monotonic_insert_test.go
+++ b/pkg/sql/tests/monotonic_insert_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -81,14 +82,16 @@ func TestMonotonicInserts(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)
 
-	for _, distSQLMode := range []sql.DistSQLExecMode{sql.DistSQLOff, sql.DistSQLOn} {
+	for _, distSQLMode := range []sessiondata.DistSQLExecMode{
+		sessiondata.DistSQLOff, sessiondata.DistSQLOn,
+	} {
 		t.Run(fmt.Sprintf("distsql=%s", distSQLMode), func(t *testing.T) {
 			testMonotonicInserts(t, distSQLMode)
 		})
 	}
 }
 
-func testMonotonicInserts(t *testing.T, distSQLMode sql.DistSQLExecMode) {
+func testMonotonicInserts(t *testing.T, distSQLMode sessiondata.DistSQLExecMode) {
 	defer leaktest.AfterTest(t)()
 
 	if testing.Short() {

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -54,3 +54,9 @@ func CreateTestTableDescriptor(
 		&evalCtx,
 	)
 }
+
+func makeTestingExtendedEvalContext() extendedEvalContext {
+	return extendedEvalContext{
+		EvalContext: tree.MakeTestingEvalContext(),
+	}
+}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -48,7 +48,7 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 		if err != nil {
 			return nil, err
 		}
-		if err := tn.QualifyWithDatabase(p.session.Database); err != nil {
+		if err := tn.QualifyWithDatabase(p.SessionData().Database); err != nil {
 			return nil, err
 		}
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -54,7 +54,7 @@ type updateNode struct {
 func (p *planner) Update(
 	ctx context.Context, n *tree.Update, desiredTypes []types.T,
 ) (planNode, error) {
-	if n.Where == nil && p.session.SafeUpdates {
+	if n.Where == nil && p.SessionData().SafeUpdates {
 		return nil, pgerror.NewDangerousStatementErrorf("UPDATE without WHERE clause")
 	}
 	resetter, err := p.initWith(ctx, n.With)
@@ -98,7 +98,8 @@ func (p *planner) Update(
 		return nil, err
 	}
 
-	defaultExprs, err := sqlbase.MakeDefaultExprs(updateCols, &p.txCtx, &p.evalCtx)
+	defaultExprs, err := sqlbase.MakeDefaultExprs(
+		updateCols, &p.txCtx, p.EvalContext())
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +305,7 @@ func (u *updateNode) Next(params runParams) (bool, error) {
 	if err := u.checkHelper.loadRow(u.updateColsIdx, updateValues, true); err != nil {
 		return false, err
 	}
-	if err := u.checkHelper.check(params.evalCtx); err != nil {
+	if err := u.checkHelper.check(params.EvalContext()); err != nil {
 		return false, err
 	}
 

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -90,7 +90,8 @@ func (p *planner) makeUpsertHelper(
 	upsertConflictIndex *sqlbase.IndexDescriptor,
 	whereClause *tree.Where,
 ) (*upsertHelper, error) {
-	defaultExprs, err := sqlbase.MakeDefaultExprs(updateCols, &p.txCtx, &p.evalCtx)
+	defaultExprs, err := sqlbase.MakeDefaultExprs(
+		updateCols, &p.txCtx, p.EvalContext())
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +152,7 @@ func (p *planner) makeUpsertHelper(
 		// Make sure there are no aggregation/window functions in the filter
 		// (after subqueries have been expanded).
 		if err := p.txCtx.AssertNoAggregationOrWindowing(
-			whereExpr, "WHERE", p.session.SearchPath,
+			whereExpr, "WHERE", p.SessionData().SearchPath,
 		); err != nil {
 			return nil, err
 		}
@@ -176,10 +177,10 @@ func (uh *upsertHelper) eval(insertRow tree.Datums, existingRow tree.Datums) (tr
 
 	var err error
 	ret := make([]tree.Datum, len(uh.evalExprs))
-	uh.p.evalCtx.IVarHelper = uh.ivarHelper
-	defer func() { uh.p.evalCtx.IVarHelper = nil }()
+	uh.p.extendedEvalCtx.IVarHelper = uh.ivarHelper
+	defer func() { uh.p.extendedEvalCtx.IVarHelper = nil }()
 	for i, evalExpr := range uh.evalExprs {
-		ret[i], err = evalExpr.Eval(&uh.p.evalCtx)
+		ret[i], err = evalExpr.Eval(uh.p.EvalContext())
 		if err != nil {
 			return nil, err
 		}
@@ -193,9 +194,9 @@ func (uh *upsertHelper) shouldUpdate(insertRow tree.Datums, existingRow tree.Dat
 	uh.curSourceRow = existingRow
 	uh.curExcludedRow = insertRow
 
-	uh.p.evalCtx.IVarHelper = uh.ivarHelper
-	defer func() { uh.p.evalCtx.IVarHelper = nil }()
-	return sqlbase.RunFilter(uh.whereExpr, &uh.p.evalCtx)
+	uh.p.extendedEvalCtx.IVarHelper = uh.ivarHelper
+	defer func() { uh.p.extendedEvalCtx.IVarHelper = nil }()
+	return sqlbase.RunFilter(uh.whereExpr, uh.p.EvalContext())
 }
 
 // upsertExprsAndIndex returns the upsert conflict index and the (possibly

--- a/pkg/sql/value_generator.go
+++ b/pkg/sql/value_generator.go
@@ -43,7 +43,9 @@ type valueGenerator struct {
 // makeGenerator creates a valueGenerator instance that wraps a call to a
 // generator function.
 func (p *planner) makeGenerator(ctx context.Context, t *tree.FuncExpr) (planNode, error) {
-	if err := p.txCtx.AssertNoAggregationOrWindowing(t, "FROM", p.session.SearchPath); err != nil {
+	if err := p.txCtx.AssertNoAggregationOrWindowing(
+		t, "FROM", p.SessionData().SearchPath,
+	); err != nil {
 		return nil, err
 	}
 
@@ -80,7 +82,7 @@ type valueGeneratorRun struct {
 }
 
 func (n *valueGenerator) startExec(params runParams) error {
-	expr, err := n.expr.Eval(params.evalCtx)
+	expr, err := n.expr.Eval(params.EvalContext())
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -73,7 +73,7 @@ func (p *planner) Values(
 
 		for i, expr := range tuple.Exprs {
 			if err := p.txCtx.AssertNoAggregationOrWindowing(
-				expr, "VALUES", p.session.SearchPath,
+				expr, "VALUES", p.SessionData().SearchPath,
 			); err != nil {
 				return nil, err
 			}
@@ -141,7 +141,7 @@ func (n *valuesNode) startExec(params runParams) error {
 	// from other planNodes), so its expressions need evaluting.
 	// This may run subqueries.
 	n.rows = sqlbase.NewRowContainer(
-		params.evalCtx.Mon.MakeBoundAccount(),
+		params.extendedEvalCtx.Mon.MakeBoundAccount(),
 		sqlbase.ColTypeInfoFromResCols(n.columns),
 		len(n.n.Tuples),
 	)
@@ -153,7 +153,7 @@ func (n *valuesNode) startExec(params runParams) error {
 				row[i] = tree.DNull
 			} else {
 				var err error
-				row[i], err = typedExpr.Eval(params.evalCtx)
+				row[i], err = typedExpr.Eval(params.EvalContext())
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -137,7 +137,7 @@ func TestValues(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%d: unexpected error in optimizePlan: %v", i, err)
 			}
-			params := runParams{ctx: ctx, p: p, evalCtx: &p.evalCtx}
+			params := runParams{ctx: ctx, p: p, extendedEvalCtx: &p.extendedEvalCtx}
 			if err := startPlan(params, plan); err != nil {
 				t.Fatalf("%d: unexpected error in Start: %v", i, err)
 			}

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -174,7 +174,7 @@ func (n *windowNode) Next(params runParams) (bool, error) {
 		}
 		if !next {
 			n.run.populated = true
-			if err := n.computeWindows(params.ctx, params.evalCtx); err != nil {
+			if err := n.computeWindows(params.ctx, params.EvalContext()); err != nil {
 				return false, err
 			}
 			n.run.values.rows = sqlbase.NewRowContainer(
@@ -182,7 +182,7 @@ func (n *windowNode) Next(params runParams) (bool, error) {
 				sqlbase.ColTypeInfoFromResCols(n.run.values.columns),
 				n.run.wrappedRenderVals.Len(),
 			)
-			if err := n.populateValues(params.ctx, params.evalCtx); err != nil {
+			if err := n.populateValues(params.ctx, params.EvalContext()); err != nil {
 				return false, err
 			}
 			break


### PR DESCRIPTION
Our SQL execution code accesses the Session object all over the place
through planner.session. This is a problem for my rewriting of the
session execution code, because Session is going away. Besides that,
having all the planNodes access the Session seems wrong; they shouldn't
need such a heavy framework for being able to run.
The largest class of accesses were for reading session variables (e.g.
the current database or the timezone). This patch groups the session
variables into a dedicated struct, SessionData, and the planner gets a
copy of that. SessionData is not put in the planner directly; instead I
put it in tree.EvalContext, because the EvalContext was already
duplicating a bunch of the variables.
So the idea is that now planNodes use the EvalContext for read-access to
the variables. For write access I've created a dedicated interface so
that we can easily grep for who'se modifying them.

release notes: none