### PR TITLE
client: reconcile inconsistent RangeLookup results or retry, never fatal

### DIFF
--- a/pkg/internal/client/range_lookup.go
+++ b/pkg/internal/client/range_lookup.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 )
 
 // RangeLookup is used to look up RangeDescriptors - a RangeDescriptor is a
@@ -165,63 +167,95 @@ func RangeLookup(
 	prefetchNum int64,
 	prefetchReverse bool,
 ) (rs, preRs []roachpb.RangeDescriptor, err error) {
-	// Determine the "Range Metadata Key" for the provided key.
-	rkey, err := addrForDir(prefetchReverse)(key)
-	if err != nil {
-		return nil, nil, err
+	// RangeLookup scans can span multiple ranges, as discussed above.
+	// Traditionally, in order to see a fully-consistent snapshot of multiple
+	// ranges, a scan needs to operate in a Txn with a fixed timestamp. Without
+	// this, the scan may read results from different ranges at different times,
+	// resulting in an inconsistent view. This is why DistSender returns
+	// OpRequiresTxnError for consistent scans outside of Txns that span
+	// multiple ranges.
+	//
+	// For RangeLookups, a consistent but outdated result is just as useless as
+	// an inconsistent result. Because of this, we allow both inconsistent scans
+	// and consistent scans outside of Txns for RangeLookups, and attempt to
+	// reconcile any inconsistencies due to races, rescanning if this is not
+	// possible.
+	//
+	// The retry options are set to be very aggressive because we should only
+	// need to retry if a scan races with a split which is writing its new
+	// RangeDescriptors across two different meta2 ranges. Because these meta2
+	// writes are transactional, performing the entire scan again immediately
+	// will not run into the same race.
+	opts := retry.Options{
+		InitialBackoff: 1 * time.Millisecond,
+		MaxBackoff:     500 * time.Millisecond,
+		Multiplier:     2,
 	}
 
-	descs, intentDescs, err := lookupRangeFwdScan(ctx, sender, rkey, rc, prefetchNum, prefetchReverse)
-	if err != nil {
-		return nil, nil, err
-	}
-	if prefetchReverse {
-		descs, intentDescs, err = lookupRangeRevScan(ctx, sender, rkey, rc, prefetchNum,
-			prefetchReverse, descs, intentDescs)
+	for r := retry.StartWithCtx(ctx, opts); r.Next(); {
+		// Determine the "Range Metadata Key" for the provided key.
+		rkey, err := addrForDir(prefetchReverse)(key)
 		if err != nil {
 			return nil, nil, err
 		}
-	}
 
-	desiredDesc := containsForDir(prefetchReverse, rkey)
-	var matchingRanges []roachpb.RangeDescriptor
-	var prefetchedRanges []roachpb.RangeDescriptor
-	for _, desc := range descs {
-		if desiredDesc(desc) {
-			if len(matchingRanges) == 0 {
-				matchingRanges = append(matchingRanges, desc)
-			} else {
-				if rc == roachpb.CONSISTENT {
-					matchingRanges = append(matchingRanges, desc)
-					log.Fatalf(ctx, "range lookup of key %s found two matching committed ranges: %v",
-						key, matchingRanges)
-				}
-
-				// Since we support scanning inconsistently, it's possible that
-				// we pick up both the pre- and post-split descriptor for a
-				// range. In this case, we can detect the newer version of the
-				// descriptor by selecting the smaller range.
-				if desc.EndKey.Less(matchingRanges[0].EndKey) {
-					matchingRanges[0] = desc
-				}
+		descs, intentDescs, err := lookupRangeFwdScan(ctx, sender, rkey, rc, prefetchNum, prefetchReverse)
+		if err != nil {
+			return nil, nil, err
+		}
+		if prefetchReverse {
+			descs, intentDescs, err = lookupRangeRevScan(ctx, sender, rkey, rc, prefetchNum,
+				prefetchReverse, descs, intentDescs)
+			if err != nil {
+				return nil, nil, err
 			}
-		} else {
-			// If this is not the desired descriptor, it must be a prefetched
-			// descriptor.
-			prefetchedRanges = append(prefetchedRanges, desc)
 		}
-	}
-	for _, desc := range intentDescs {
-		if desiredDesc(desc) {
-			matchingRanges = append(matchingRanges, desc)
-			// We only want up to one intent descriptor.
-			break
+
+		desiredDesc := containsForDir(prefetchReverse, rkey)
+		var matchingRanges []roachpb.RangeDescriptor
+		var prefetchedRanges []roachpb.RangeDescriptor
+		for _, desc := range descs {
+			if desiredDesc(desc) {
+				if len(matchingRanges) == 0 {
+					matchingRanges = append(matchingRanges, desc)
+				} else {
+					// Since we support scanning non-transactionally, it's possible
+					// that we pick up both the pre- and post-split descriptor for a
+					// range. In this case, we can detect the newer version of the
+					// descriptor by selecting the smaller range. This is possible
+					// by simply looking at the descriptors' EndKeys, which can never
+					// be the same or the two options would have been stored at the
+					// same key.
+					if desc.EndKey.Less(matchingRanges[0].EndKey) {
+						matchingRanges[0] = desc
+					}
+				}
+			} else {
+				// If this is not the desired descriptor, it must be a prefetched
+				// descriptor.
+				prefetchedRanges = append(prefetchedRanges, desc)
+			}
 		}
+		for _, desc := range intentDescs {
+			if desiredDesc(desc) {
+				matchingRanges = append(matchingRanges, desc)
+				// We only want up to one intent descriptor.
+				break
+			}
+		}
+		if len(matchingRanges) > 0 {
+			return matchingRanges, prefetchedRanges, nil
+		}
+
+		log.Warningf(ctx, "range lookup of key %s found only non-matching ranges %v; retrying",
+			key, prefetchedRanges)
 	}
-	if len(matchingRanges) == 0 {
-		log.Fatalf(ctx, "range lookup of key %s found only non-matching ranges", key)
+
+	ctxErr := ctx.Err()
+	if ctxErr == nil {
+		log.Fatalf(ctx, "retry loop broke before context expired")
 	}
-	return matchingRanges, prefetchedRanges, nil
+	return nil, nil, ctxErr
 }
 
 func lookupRangeFwdScan(
@@ -416,7 +450,7 @@ func lookupRangeRevScan(
 // lies within the bounds of that range. But notice that the range descriptor
 // containing `d` lies in range 2. This means that no matching RangeDescriptors
 // will be found on range 1 and returned from the first RangeLookup. In fact, a
-// RangeLookup for any key between ['c','d') will create this scenerio.
+// RangeLookup for any key between ['c','d') will create this scenario.
 //
 // Our solution (RangeLookup) is to deprecate RangeLookupRequest and instead use
 // a ScanRequest over the entire MetaScanBounds. DistSender will properly scan

--- a/pkg/internal/client/range_lookup.go
+++ b/pkg/internal/client/range_lookup.go
@@ -298,6 +298,9 @@ func lookupRangeFwdScan(
 		// TODO(nvanbenschoten): remove in version 2.1.
 		DeprecatedReturnIntents: rc == roachpb.INCONSISTENT,
 	})
+	if !TestingIsRangeLookup(ba) {
+		log.Fatalf(ctx, "BatchRequest %v not detectable as RangeLookup", ba)
+	}
 
 	br, pErr := sender.Send(ctx, ba)
 	if pErr != nil {
@@ -366,6 +369,9 @@ func lookupRangeRevScan(
 		// See explanation above in lookupRangeFwdScan.
 		DeprecatedReturnIntents: rc == roachpb.INCONSISTENT,
 	})
+	if !TestingIsRangeLookup(ba) {
+		log.Fatalf(ctx, "BatchRequest %v not detectable as RangeLookup", ba)
+	}
 
 	br, pErr := sender.Send(ctx, ba)
 	if pErr != nil {
@@ -521,6 +527,18 @@ func TestingIsRangeLookup(ba roachpb.BatchRequest) bool {
 	return false
 }
 
+// These spans bounds the start and end keys of the spans returned from
+// MetaScanBounds and MetaReverseScanBounds. Next is called on each span's
+// EndKey to make it end-inclusive so that ContainsKey works as expected.
+var rangeLookupStartKeyBounds = roachpb.Span{
+	Key:    keys.Meta1Prefix,
+	EndKey: keys.Meta2KeyMax.Next(),
+}
+var rangeLookupEndKeyBounds = roachpb.Span{
+	Key:    keys.Meta1Prefix.Next(),
+	EndKey: keys.SystemPrefix.Next(),
+}
+
 // TestingIsRangeLookupRequest returns if the provided Request looks like a single
 // RangeLookup scan. It can return false positives and should only be used in
 // tests.
@@ -532,5 +550,6 @@ func TestingIsRangeLookupRequest(req roachpb.Request) bool {
 		return false
 	}
 	s := req.Header()
-	return s.Key.Compare(keys.Meta2KeyMax) <= 0 && s.EndKey.Compare(keys.MetaMax) <= 0
+	return rangeLookupStartKeyBounds.ContainsKey(s.Key) &&
+		rangeLookupEndKeyBounds.ContainsKey(s.EndKey)
 }

--- a/pkg/internal/client/range_lookup.go
+++ b/pkg/internal/client/range_lookup.go
@@ -279,7 +279,7 @@ func lookupRangeFwdScan(
 		Span: bounds.AsRawSpanWithNoLocals(),
 		// NOTE (subtle): we want the scan to return intents as well as values
 		// when scanning inconsistently. The reason is because it's not clear
-		// whether the intent or the previous value point to the correct
+		// whether the intent or the previous value points to the correct
 		// location of the Range. It gets even more complicated when there are
 		// split-related intents or a txn record co-located with a replica
 		// involved in the split. Since we cannot know the correct answer, we
@@ -290,6 +290,12 @@ func lookupRangeFwdScan(
 		// same descriptor. In other words, both the current live descriptor and
 		// a potentially valid descriptor from observed intents could be
 		// returned.
+		//
+		// We don't need to set this when rc == roachpb.READ_UNCOMMITTED
+		// because all read_uncommitted requests will return intents, which
+		// is why this option is now deprecated.
+		//
+		// TODO(nvanbenschoten): remove in version 2.1.
 		DeprecatedReturnIntents: rc == roachpb.INCONSISTENT,
 	})
 
@@ -357,6 +363,7 @@ func lookupRangeRevScan(
 	ba.MaxSpanRequestKeys = maxKeys
 	ba.Add(&roachpb.ReverseScanRequest{
 		Span: revBounds.AsRawSpanWithNoLocals(),
+		// See explanation above in lookupRangeFwdScan.
 		DeprecatedReturnIntents: rc == roachpb.INCONSISTENT,
 	})
 

--- a/pkg/internal/client/range_lookup_test.go
+++ b/pkg/internal/client/range_lookup_test.go
@@ -1,0 +1,189 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package client
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// TestRangeLookupRace tests that a RangeLookup will retry its scanning process
+// if it sees inconsistent results. This is possible because RangeLookup scans
+// are not required to be consistent or within a transaction, meaning that they
+// may race with splits.
+func TestRangeLookupRaceSplits(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	desc1BeforeSplit := roachpb.RangeDescriptor{
+		RangeID:  1,
+		StartKey: roachpb.RKey("j"),
+		EndKey:   roachpb.RKey("p"),
+	}
+	desc1AfterSplit := roachpb.RangeDescriptor{
+		RangeID:  1,
+		StartKey: roachpb.RKey("j"),
+		EndKey:   roachpb.RKey("m"),
+	}
+	desc2AfterSplit := roachpb.RangeDescriptor{
+		RangeID:  2,
+		StartKey: roachpb.RKey("m"),
+		EndKey:   roachpb.RKey("p"),
+	}
+
+	lookupKey := roachpb.Key("k")
+	assertRangeLookupScan := func(ba roachpb.BatchRequest) {
+		if len(ba.Requests) != 1 {
+			t.Fatalf("expected single request, found %v", ba)
+		}
+		scan, ok := ba.Requests[0].GetInner().(*roachpb.ScanRequest)
+		if !ok {
+			t.Fatalf("expected single scan request, found %v", ba)
+		}
+		expStartKey := keys.RangeMetaKey(roachpb.RKey(lookupKey)).Next()
+		if !scan.Key.Equal(expStartKey.AsRawKey()) {
+			t.Fatalf("expected scan start key %v, found %v", expStartKey, scan.Key)
+		}
+	}
+
+	// The test simulates a RangeLookup that experiences inconsistent results
+	// twice before eventually seeing consistent results. It is expected that it
+	// will continue to retry until the results are consistent and a matching
+	// RangeDescriptor is found.
+	//
+	// The scenario is modeled after:
+	// https://github.com/cockroachdb/cockroach/issues/19147#issuecomment-336741791
+	// See that comment for a description of why a non-transactional scan starting
+	// at /meta2/k may only see desc2AfterSplit when racing with a split, assuming
+	// there is a range boundary at /meta2/n.
+	t.Run("MissingDescriptor", func(t *testing.T) {
+		badRes := newScanRespFromRangeDescriptors(&desc2AfterSplit)
+		goodRes := newScanRespFromRangeDescriptors(&desc1AfterSplit)
+
+		attempt := 0
+		sender := SenderFunc(func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			// Increment the attempt counter after each attempt.
+			defer func() {
+				attempt++
+			}()
+
+			assertRangeLookupScan(ba)
+			switch attempt {
+			case 0:
+				// Return an inconsistent result.
+				return badRes, nil
+			case 1:
+				// For the sake of testing, return the same inconsistent result. In
+				// reality, it shouldn't be possible to see the same race twice.
+				return badRes, nil
+			case 2:
+				return goodRes, nil
+			default:
+				t.Fatalf("unexpected range lookup attempt #%d, %v", attempt, ba)
+				return nil, nil
+			}
+		})
+
+		rs, preRs, err := RangeLookup(
+			context.Background(),
+			sender,
+			lookupKey,
+			roachpb.READ_UNCOMMITTED,
+			0,     /* prefetchNum */
+			false, /* prefetchReverse */
+		)
+		if err != nil {
+			t.Fatalf("RangeLookup returned error: %v", err)
+		}
+		if len(preRs) != 0 {
+			t.Fatalf("RangeLookup returned unexpected prefetched descriptors: %v", preRs)
+		}
+		expRs := []roachpb.RangeDescriptor{desc1AfterSplit}
+		if !reflect.DeepEqual(expRs, rs) {
+			t.Fatalf("expected RangeLookup to return %v, found %v", expRs, rs)
+		}
+	})
+
+	// This scenario is similar to the previous one, but assumes that a scan
+	// sees two descriptors that match its desired key, one from before a split
+	// and one from after. The can occur both with inconsistent scans and with
+	// non-transactional scans that span ranges. This situation is easier to
+	// handle because we can figure out which descriptor is stale without
+	// needing to perform another scan.
+	t.Run("ExtraDescriptor", func(t *testing.T) {
+		// It doesn't matter which descriptor comes first in the response.
+		testutils.RunTrueAndFalse(t, "staleFirst", func(t *testing.T, staleFirst bool) {
+			goodRes := newScanRespFromRangeDescriptors(&desc1AfterSplit, &desc1BeforeSplit)
+			if staleFirst {
+				goodRes = newScanRespFromRangeDescriptors(&desc1BeforeSplit, &desc1AfterSplit)
+			}
+
+			attempt := 0
+			sender := SenderFunc(func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				// Increment the attempt counter after each attempt.
+				defer func() {
+					attempt++
+				}()
+
+				assertRangeLookupScan(ba)
+				switch attempt {
+				case 0:
+					return goodRes, nil
+				default:
+					t.Fatalf("unexpected range lookup attempt #%d, %v", attempt, ba)
+					return nil, nil
+				}
+			})
+
+			rs, preRs, err := RangeLookup(
+				context.Background(),
+				sender,
+				lookupKey,
+				roachpb.READ_UNCOMMITTED,
+				0,     /* prefetchNum */
+				false, /* prefetchReverse */
+			)
+			if err != nil {
+				t.Fatalf("RangeLookup returned error: %v", err)
+			}
+			if len(preRs) != 0 {
+				t.Fatalf("RangeLookup returned unexpected prefetched descriptors: %v", preRs)
+			}
+			expRs := []roachpb.RangeDescriptor{desc1AfterSplit}
+			if !reflect.DeepEqual(expRs, rs) {
+				t.Fatalf("expected RangeLookup to return %v, found %v", expRs, rs)
+			}
+		})
+	})
+}
+
+func newScanRespFromRangeDescriptors(descs ...*roachpb.RangeDescriptor) *roachpb.BatchResponse {
+	br := &roachpb.BatchResponse{}
+	r := &roachpb.ScanResponse{}
+	for _, desc := range descs {
+		var kv roachpb.KeyValue
+		if err := kv.Value.SetProto(desc); err != nil {
+			panic(err)
+		}
+		r.Rows = append(r.Rows, kv)
+	}
+	br.Add(r)
+	return br
+}

--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -873,9 +873,6 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 			// case where we don't need to re-run is if the read
 			// consistency is not required.
 			if ba.Txn == nil && ba.IsPossibleTransaction() && ba.ReadConsistency == roachpb.CONSISTENT {
-				// TODO(nvanbenschoten): if this becomes an issue for RangeLookup
-				// scans, we could look into changing IsPossibleTransaction for
-				// ScanRequest/ReverseScanRequest to detect RangeLookups.
 				responseCh <- response{pErr: roachpb.NewError(&roachpb.OpRequiresTxnError{})}
 				return
 			}

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -302,7 +302,7 @@ func TestReportUsage(t *testing.T) {
 		"diagnostics.reporting.send_crash_reports": "false",
 		"server.time_until_store_dead":             "20s",
 		"trace.debug.enable":                       "false",
-		"version":                                  "1.1-12",
+		"version":                                  "1.1-13",
 	} {
 		if got, ok := r.last.AlteredSettings[key]; !ok {
 			t.Fatalf("expected report of altered setting %q", key)

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -44,6 +44,7 @@ const (
 	VersionRecomputeStats
 	VersionNoRaftProposalKeys
 	VersionTxnSpanRefresh
+	VersionReadUncommittedRangeLookups
 
 	// Add new versions here (step one of two).
 
@@ -163,6 +164,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionTxnSpanRefresh is https://github.com/cockroachdb/cockroach/pull/21140.
 		Key:     VersionTxnSpanRefresh,
 		Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 12},
+	},
+	{
+		// VersionReadUncommittedRangeLookups is https://github.com/cockroachdb/cockroach/pull/21276.
+		Key:     VersionReadUncommittedRangeLookups,
+		Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 13},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -209,7 +209,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-1.1-12
+1.1-13
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -291,4 +291,4 @@ select * from crdb_internal.kv_store_status
 query T
 select crdb_internal.node_executable_version()
 ----
-1.1-12
+1.1-13

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -687,7 +687,7 @@ DELETE FROM t.test3;
 								// could lead to a deadlock where a retry is blocked trying to push
 								// the previous incarnation of the meta record.
 								//
-								// In real scenerios (not injected test errors), a TransactionAbortedError
+								// In real scenarios (not injected test errors), a TransactionAbortedError
 								// will never be seen unless the txn record is actually aborted, so
 								// this isn't a concern. We are simply trying to mirror that behavior
 								// here.

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -2520,7 +2520,7 @@ func TestRangeLookupAsyncResolveIntent(t *testing.T) {
 	}
 
 	// Get original meta2 descriptor.
-	rs, _, err := client.RangeLookup(ctx, rg1(store), key, roachpb.INCONSISTENT, 0, false)
+	rs, _, err := client.RangeLookup(ctx, rg1(store), key, roachpb.READ_UNCOMMITTED, 0, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -2493,7 +2493,7 @@ func TestRangeLookupAsyncResolveIntent(t *testing.T) {
 
 	// Disable async tasks in the intent resolver. All tasks will be synchronous.
 	cfg := storage.TestStoreConfig(nil)
-	cfg.IntentResolverTaskLimit = -1
+	cfg.TestingKnobs.ForceSyncIntentResolution = true
 	cfg.TestingKnobs.DisableSplitQueue = true
 	cfg.TestingKnobs.TestingProposalFilter =
 		func(args storagebase.ProposalFilterArgs) *roachpb.Error {

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -2482,6 +2482,134 @@ func TestRangeLookupAfterMeta2Split(t *testing.T) {
 	})
 }
 
+// TestStoreSplitRangeLookupRace verifies that a RangeLookup scanning across
+// multiple meta2 ranges that races with a split and misses all matching
+// descriptors will retry its scan until it succeeds.
+//
+// This test creates a series of events that result in the injected range
+// lookup scan response we see in TestRangeLookupRaceSplits/MissingDescriptor.
+// It demonstrates how it is possible for an inconsistent range lookup scan
+// that spans multiple ranges to completely miss its desired descriptor.
+func TestStoreSplitRangeLookupRace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// The scenario is modeled after:
+	// https://github.com/cockroachdb/cockroach/issues/19147#issuecomment-336741791
+	// See that comment for a description of why a non-transactional scan
+	// starting at "/meta2/k" may only see non-matching descriptors when racing
+	// with a split.
+	//
+	// To simulate this situation, we first perform splits at "/meta2/n", "j",
+	// and "p". This creates the following structure, where the descriptor for
+	// range [j, p) is stored on the second meta2 range:
+	//
+	//   [/meta2/a,/meta2/n), [/meta2/n,/meta2/z)
+	//                     -----^
+	//       ...      [j, p)      ...
+	//
+	// We then initiate a range lookup for key "k". This lookup will begin
+	// scanning on the first meta2 range but won't find its desired desriptor. Normally,
+	// it would continue scanning onto the second meta2 range and find the descriptor
+	// for range [j, p) at "/meta2/p" (see TestRangeLookupAfterMeta2Split). However,
+	// because RangeLookup scans are non-transactional, this can race with a split.
+	// Here, we split at key "m", which creates the structure:
+	//
+	//   [/meta2/a,/meta2/n), [/meta2/n,/meta2/z)
+	//             ^--        ---^
+	//       ...   [j,m), [m,p)      ...
+	//
+	// If the second half of the RangeLookup scan sees the second meta2 range after
+	// this split, it will miss the old descriptor for [j, p) and the new descriptor
+	// for [j, m). In this case, the RangeLookup should retry.
+	lookupKey := roachpb.Key("k")
+	bounds, err := keys.MetaScanBounds(keys.RangeMetaKey(roachpb.RKey(lookupKey)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The following filter and set of channels is used to block the RangeLookup
+	// scan for key "k" after it has scanned over the first meta2 range but not
+	// the second.
+	blockRangeLookups := make(chan struct{})
+	rangeLookupIsBlocked := make(chan struct{}, 1)
+	unblockRangeLookups := make(chan struct{})
+	respFilter := func(ba roachpb.BatchRequest, _ *roachpb.BatchResponse) *roachpb.Error {
+		select {
+		case <-blockRangeLookups:
+			if client.TestingIsRangeLookup(ba) &&
+				ba.Requests[0].GetInner().(*roachpb.ScanRequest).Key.Equal(bounds.Key.AsRawKey()) {
+
+				select {
+				case rangeLookupIsBlocked <- struct{}{}:
+				default:
+				}
+				<-unblockRangeLookups
+			}
+		default:
+		}
+		return nil
+	}
+
+	srv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &storage.StoreTestingKnobs{
+				DisableSplitQueue:         true,
+				ForceSyncIntentResolution: true,
+				TestingResponseFilter:     respFilter,
+			},
+		},
+	})
+	s := srv.(*server.TestServer)
+	defer s.Stopper().Stop(context.Background())
+	store, err := s.Stores().GetStore(s.GetFirstStoreID())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mustSplit := func(splitKey roachpb.Key) {
+		args := adminSplitArgs(splitKey)
+
+		// Don't use s.DistSender() so that we don't disturb the RangeDescriptorCache.
+		rangeID := store.LookupReplica(roachpb.RKey(splitKey), nil).RangeID
+		_, pErr := client.SendWrappedWith(context.Background(), store, roachpb.Header{
+			RangeID: rangeID,
+		}, args)
+		if pErr != nil {
+			t.Fatal(pErr)
+		}
+	}
+
+	// Perform the initial splits. See above.
+	mustSplit(keys.SystemPrefix)
+	mustSplit(keys.RangeMetaKey(roachpb.RKey("n")).AsRawKey())
+	mustSplit(roachpb.Key("j"))
+	mustSplit(roachpb.Key("p"))
+
+	// Launch a goroutine to perform a range lookup for key "k" that will race
+	// with a split at key "m".
+	rangeLookupErr := make(chan error)
+	go func() {
+		close(blockRangeLookups)
+		s.DistSender().RangeDescriptorCache().Clear()
+
+		_, err := s.DB().Get(context.Background(), lookupKey)
+		rangeLookupErr <- err
+	}()
+
+	// Wait until the range lookup is blocked after performing a scan of the
+	// first range [/meta2/a,/meta2/n) but before performing a scan of the
+	// second range [/meta2/n,/meta2/z). Then split at key "m". Finally, let the
+	// range lookup finish. The lookup will fail because it won't get consistent
+	// results but will eventually succeed after retrying.
+	<-rangeLookupIsBlocked
+	mustSplit(roachpb.Key("m"))
+	close(unblockRangeLookups)
+
+	if err := <-rangeLookupErr; err != nil {
+		t.Fatalf("unexpected range lookup error %v", err)
+	}
+}
+
 // Verify that range lookup operations do not synchronously perform intent
 // resolution as doing so can deadlock with the RangeDescriptorCache. See
 // #17760.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -2463,9 +2463,9 @@ func TestReplicaCommandQueueCancellationRandom(t *testing.T) {
 	}
 }
 
-// TestReplicaCommandQueueCancellationLocal tests various cancellation scenerios
+// TestReplicaCommandQueueCancellationLocal tests various cancellation scenarios
 // surrounding EndTxnReqs, PushTxnReqs, and HeartbeatTxnReqs. One of these
-// scenerios was the cause of #16266.
+// scenarios was the cause of #16266.
 func TestReplicaCommandQueueCancellationLocal(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -743,6 +743,10 @@ type StoreTestingKnobs struct {
 	// path (but leaves synchronous resolution). This can avoid some
 	// edge cases in tests that start and stop servers.
 	DisableAsyncIntentResolution bool
+	// ForceSyncIntentResolution forces all asynchronous intent resolution to be
+	// performed synchronously. It is equivalent to setting IntentResolverTaskLimit
+	// to -1.
+	ForceSyncIntentResolution bool
 	// DisableLeaseCapacityGossip disables the ability of a changing number of
 	// leases to trigger the store to gossip its capacity. With this enabled,
 	// only changes in the number of replicas can cause the store to gossip its
@@ -782,10 +786,10 @@ func (sc *StoreConfig) SetDefaults() {
 	if sc.RaftEntryCacheSize == 0 {
 		sc.RaftEntryCacheSize = defaultRaftEntryCacheSize
 	}
-	if sc.IntentResolverTaskLimit == 0 {
-		sc.IntentResolverTaskLimit = defaultIntentResolverTaskLimit
-	} else if sc.IntentResolverTaskLimit == -1 {
+	if sc.IntentResolverTaskLimit == -1 || sc.TestingKnobs.ForceSyncIntentResolution {
 		sc.IntentResolverTaskLimit = 0
+	} else if sc.IntentResolverTaskLimit == 0 {
+		sc.IntentResolverTaskLimit = defaultIntentResolverTaskLimit
 	}
 	if sc.concurrentSnapshotApplyLimit == 0 {
 		// NB: setting this value higher than 1 is likely to degrade client

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -1145,7 +1145,7 @@ func assertRatchet(t *testing.T, before, after cacheValue) {
 
 // TestIntervalSklMaxEncodedSize ensures that we do not enter an infinite page
 // rotation loop for ranges that are too large to fit in a single page. Instead,
-// we detect this scenerio early and panic.
+// we detect this scenario early and panic.
 func TestIntervalSklMaxEncodedSize(t *testing.T) {
 	ts := makeTS(200, 0)
 	val := makeVal(ts, "1")


### PR DESCRIPTION
Fixes #19147.

RangeLookup scans can span multiple ranges (#18970). Traditionally, in order to
see a fully-consistent snapshot of multiple ranges, a scan needs to operate in a
Txn with a fixed timestamp. Without this, the scan may read results from
different ranges at different times, resulting in an inconsistent view. This is
why `DistSender` returns `OpRequiresTxnError` for consistent scans outside of
Txns that span multiple ranges.

For `RangeLookups`, a consistent but outdated result is just as useless as an
inconsistent result. Because of this, we allow both inconsistent scans and
consistent scans outside of Txns for `RangeLookups`. In doing so, we need to
make sure that we either reconcile any inconsistencies due to races or retry the
scan if this is not possible. This is necessary because inconsistent results are
possible if `RangeLookups` race with splits. This change ensures that we handle
these races correctly.

It also introduces a consistency-elevation scheme so that an INCONSISTENT scan
is elevated to a CONSISTENT scan if the first `RangeLookups` fails. This
improves the chance that the second `RangeLookups` gets consistent results and
ensures that we don't continue sending requests to an out-of-date follower. This
is something we can revisit when we have a proper follower-read implementation.

Release note: None