### PR TITLE
sql: fix the memory account used by the COPY protocol

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -75,7 +75,7 @@ func (p *planner) Copy(ctx context.Context, n *tree.CopyFrom) (planNode, error) 
 	for i, c := range cols {
 		cn.resultColumns[i] = sqlbase.ResultColumn{Typ: c.Type.ToDatumType()}
 	}
-	cn.rowsMemAcc = p.session.mon.MakeBoundAccount()
+	cn.rowsMemAcc = p.evalCtx.Mon.MakeBoundAccount()
 	return cn, nil
 }
 
@@ -336,7 +336,7 @@ func (p *planner) CopyData(ctx context.Context, n CopyDataBlock) (planNode, erro
 		},
 		Returning: tree.AbsentReturningClause,
 	}
-	return p.Insert(ctx, &in, nil)
+	return p.Insert(ctx, &in, nil /* desiredTypes */)
 }
 
 // Format implements the NodeFormatter interface.

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -674,7 +674,7 @@ func (e *Executor) execPrepared(
 	}
 	// Send the Request for SQL execution and set the application-level error
 	// for each result in the reply.
-	return e.execParsed(session, stmts, pinfo, copyMsgNone)
+	return e.execParsed(session, stmts, pinfo)
 }
 
 // CopyData adds data to the COPY buffer and executes if there are enough rows.
@@ -741,7 +741,7 @@ func (e *Executor) execRequest(
 		}
 		return err
 	}
-	return e.execParsed(session, stmts, pinfo, copymsg)
+	return e.execParsed(session, stmts, pinfo)
 }
 
 // RecordError is called by the common error handling routine in pgwire. Since
@@ -761,7 +761,7 @@ func (e *Executor) RecordError(err error) {
 // execParsed executes a batch of statements received as a unit from the client
 // and returns query execution errors and communication errors.
 func (e *Executor) execParsed(
-	session *Session, stmts StatementList, pinfo *tree.PlaceholderInfo, copymsg copyMsg,
+	session *Session, stmts StatementList, pinfo *tree.PlaceholderInfo,
 ) error {
 	var avoidCachedDescriptors bool
 	var asOfSystemTime bool


### PR DESCRIPTION
It used to be session.mon, which is never supposed to be used directly.
Switched to the current txn's account.

Release note: None