### PR TITLE
sql/distsqlrun: relax semantics of Consumer{Done,Closed}

### DIFF
--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -153,10 +153,6 @@ func (m *mergeJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 				continue
 			}
 		case DrainRequested:
-			// TODO(peter): Could we be calling ConsumerDone twice on the inputs?
-			// Looks like it can happen here and in response to
-			// mergeJoiner.ConsumerDone(). This also affects distinct and
-			// noopProcessor.
 			m.leftSource.ConsumerDone()
 			m.rightSource.ConsumerDone()
 			continue

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"math"
 	"sync"
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -435,21 +436,19 @@ type rowSourceBase struct {
 	consumerStatus ConsumerStatus
 }
 
-// consumerDone helps processors RowSource.ConsumerDone.
+// consumerDone helps processors implement RowSource.ConsumerDone.
 func (rb *rowSourceBase) consumerDone(name string) {
-	if rb.consumerStatus != NeedMoreRows {
-		log.Fatalf(context.Background(), "%s already done or closed: %d",
-			name, rb.consumerStatus)
-	}
-	rb.consumerStatus = DrainRequested
+	atomic.CompareAndSwapUint32((*uint32)(&rb.consumerStatus),
+		uint32(NeedMoreRows), uint32(DrainRequested))
 }
 
-// consumerDone helps processors RowSource.ConsumerClosed.
+// consumerDone helps processors implement RowSource.ConsumerClosed.
 func (rb *rowSourceBase) consumerClosed(name string) {
-	if rb.consumerStatus == ConsumerClosed {
+	status := ConsumerStatus(atomic.LoadUint32((*uint32)(&rb.consumerStatus)))
+	if status == ConsumerClosed {
 		log.Fatalf(context.Background(), "%s already closed", name)
 	}
-	rb.consumerStatus = ConsumerClosed
+	atomic.StoreUint32((*uint32)(&rb.consumerStatus), uint32(ConsumerClosed))
 }
 
 // noopProcessor is a processor that simply passes rows through from the


### PR DESCRIPTION
Previously, `RowSource.Consumer{Done,Closed}` would fatal if they were
called more than once or if the RowSource was in the wrong state. This
required maintaining additional checks for the caller that they weren't
invoking this methods incorrectly, but these methods are only setting
atomic variables so there wasn't a particular need for this strictness.

Release note: None