### PR TITLE
sql: Interval operator symmetry

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -32,10 +32,13 @@
 </thead><tbody>
 <tr><td><a href="decimal.html">decimal</a> <code>*</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
 <tr><td><a href="decimal.html">decimal</a> <code>*</code> <a href="int.html">int</a></td><td><a href="decimal.html">decimal</a></td></tr>
+<tr><td><a href="decimal.html">decimal</a> <code>*</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval</a></td></tr>
 <tr><td><a href="float.html">float</a> <code>*</code> <a href="float.html">float</a></td><td><a href="float.html">float</a></td></tr>
+<tr><td><a href="float.html">float</a> <code>*</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>*</code> <a href="decimal.html">decimal</a></td><td><a href="decimal.html">decimal</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>*</code> <a href="int.html">int</a></td><td><a href="int.html">int</a></td></tr>
 <tr><td><a href="int.html">int</a> <code>*</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval</a></td></tr>
+<tr><td><a href="interval.html">interval</a> <code>*</code> <a href="decimal.html">decimal</a></td><td><a href="interval.html">interval</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>*</code> <a href="float.html">float</a></td><td><a href="interval.html">interval</a></td></tr>
 <tr><td><a href="interval.html">interval</a> <code>*</code> <a href="int.html">int</a></td><td><a href="interval.html">interval</a></td></tr>
 </tbody></table>

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -877,6 +877,41 @@ var BinOps = map[BinaryOperator]binOpOverload{
 				return &DInterval{Duration: left.(*DInterval).Duration.MulFloat(r)}, nil
 			},
 		},
+		BinOp{
+			LeftType:   types.Float,
+			RightType:  types.Interval,
+			ReturnType: types.Interval,
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				l := float64(*left.(*DFloat))
+				return &DInterval{Duration: right.(*DInterval).Duration.MulFloat(l)}, nil
+			},
+		},
+		BinOp{
+			LeftType:   types.Decimal,
+			RightType:  types.Interval,
+			ReturnType: types.Interval,
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				l := &left.(*DDecimal).Decimal
+				t, err := l.Float64()
+				if err != nil {
+					return nil, err
+				}
+				return &DInterval{Duration: right.(*DInterval).Duration.MulFloat(t)}, nil
+			},
+		},
+		BinOp{
+			LeftType:   types.Interval,
+			RightType:  types.Decimal,
+			ReturnType: types.Interval,
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				r := &right.(*DDecimal).Decimal
+				t, err := r.Float64()
+				if err != nil {
+					return nil, err
+				}
+				return &DInterval{Duration: left.(*DInterval).Duration.MulFloat(t)}, nil
+			},
+		},
 	},
 
 	Div: {

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -922,6 +922,12 @@ func TestEval(t *testing.T) {
 		{`'3 hours'::interval / 2`, `'1h30m'`},
 		{`'3 hours'::interval * 2.5`, `'7h30m'`},
 		{`'3 hours'::interval / 2.5`, `'1h12m'`},
+		{`'1h2m'::interval * 4.5`, `'4h39m'`},
+		{`4.5 * '1h2m'::interval`, `'4h39m'`},
+		{`5.0 * '1h2m'::interval`, `'5h10m'`},
+		{`'1h2m'::interval * 5.0`, `'5h10m'`},
+		{`'1h2m'::interval * 0.0`, `'0s'`},
+		{`00.0 * '1h2m'::interval`, `'0s'`},
 		// Conditional expressions.
 		{`IF(true, 1, 2/0)`, `1`},
 		{`IF(false, 1/0, 2)`, `2`},


### PR DESCRIPTION
Fixes #21145.

The * operator for multiplying an interval by a scalar
was defined inconsistently for floats. For other
types like integers the operands can be in either order,
but for floats, the interval must be the first argument.
Also supported multiply Interval by Decimal type.
Updated generated docs. Added Tests.
  