### PR TITLE
libroach: fix "debug compact"

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -1689,9 +1689,9 @@ DBStatus DBSyncWAL(DBEngine* db) {
 #endif
 }
 
-DBStatus DBCompact(DBEngine* db) { return DBCompactRange(db, DBKey(), DBKey()); }
+DBStatus DBCompact(DBEngine* db) { return DBCompactRange(db, DBSlice(), DBSlice()); }
 
-DBStatus DBCompactRange(DBEngine* db, DBKey start, DBKey end) {
+DBStatus DBCompactRange(DBEngine* db, DBSlice start, DBSlice end) {
   rocksdb::CompactRangeOptions options;
   // By default, RocksDB doesn't recompact the bottom level (unless
   // there is a compaction filter, which we don't use). However,
@@ -1710,14 +1710,14 @@ DBStatus DBCompactRange(DBEngine* db, DBKey start, DBKey end) {
   std::vector<rocksdb::LiveFileMetaData> metadata;
   db->rep->GetLiveFilesMetaData(&all_metadata);
 
-  const std::string start_key(EncodeKey(start));
-  const std::string end_key(EncodeKey(end));
+  const std::string start_key(ToString(start));
+  const std::string end_key(ToString(end));
 
   int max_level = 0;
   for (int i = 0; i < all_metadata.size(); i++) {
     // Skip any SSTables which fall outside the specified range, if a
     // range was specified.
-    if ((!start_key.empty() > 0 && all_metadata[i].largestkey < start_key) ||
+    if ((!start_key.empty() && all_metadata[i].largestkey < start_key) ||
         (!end_key.empty() && all_metadata[i].smallestkey >= end_key)) {
       continue;
     }

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -112,7 +112,7 @@ DBStatus DBCompact(DBEngine* db);
 // Forces an immediate compaction over keys in the specified range.
 // Note that if start is empty, it indicates the start of the database.
 // If end is empty, it indicates the end of the database.
-DBStatus DBCompactRange(DBEngine* db, DBKey start, DBKey end);
+DBStatus DBCompactRange(DBEngine* db, DBSlice start, DBSlice end);
 
 // Stores the approximate on-disk size of the given key range into the
 // supplied uint64.

--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -306,10 +306,7 @@ func (c *Compactor) processCompaction(
 	if shouldProcess {
 		startTime := timeutil.Now()
 		log.Eventf(ctx, "processing compaction %s", aggr)
-		if err := c.eng.CompactRange(
-			engine.MVCCKey{Key: aggr.StartKey},
-			engine.MVCCKey{Key: aggr.EndKey},
-		); err != nil {
+		if err := c.eng.CompactRange(aggr.StartKey, aggr.EndKey); err != nil {
 			return 0, errors.Wrapf(err, "unable to compact range %+v", aggr)
 		}
 		c.Metrics.BytesCompacted.Inc(aggr.Bytes)

--- a/pkg/storage/compactor/compactor_test.go
+++ b/pkg/storage/compactor/compactor_test.go
@@ -73,11 +73,11 @@ func (we *wrappedEngine) GetSSTables() engine.SSTableInfos {
 	return ssti
 }
 
-func (we *wrappedEngine) CompactRange(start, end engine.MVCCKey) error {
+func (we *wrappedEngine) CompactRange(start, end roachpb.Key) error {
 	we.mu.Lock()
 	defer we.mu.Unlock()
 	time.Sleep(testCompactionLatency)
-	we.mu.compactions = append(we.mu.compactions, roachpb.Span{Key: start.Key, EndKey: end.Key})
+	we.mu.compactions = append(we.mu.compactions, roachpb.Span{Key: start, EndKey: end})
 	return nil
 }
 

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -235,7 +235,7 @@ type Engine interface {
 	ApproximateDiskBytes(from, to roachpb.Key) (uint64, error)
 	// CompactRange ensures that the specified range of key value pairs is
 	// optimized for space efficiency.
-	CompactRange(start, end MVCCKey) error
+	CompactRange(start, end roachpb.Key) error
 }
 
 // WithSSTables extends the Engine interface with a method to get info

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -848,8 +848,8 @@ func (r *RocksDB) Compact() error {
 }
 
 // CompactRange forces compaction over a specified range of keys in the database.
-func (r *RocksDB) CompactRange(start, end MVCCKey) error {
-	return statusToError(C.DBCompactRange(r.rdb, goToCKey(start), goToCKey(end)))
+func (r *RocksDB) CompactRange(start, end roachpb.Key) error {
+	return statusToError(C.DBCompactRange(r.rdb, goToCSlice(start), goToCSlice(end)))
 }
 
 // ApproximateDiskBytes returns the approximate on-disk size of the specified key range.


### PR DESCRIPTION
`DBCompact` was accidentally broken by recent changes because encoding
the empty "mvcc" key actually encodes to the string "\0". This was then
failing to cover the most of the sstables. The root problem here was
passing `DBKey` to `DBCompactRange` instead of the more correct
`DBSlice`.

Release note (bug fix): Fix the "debug compact" command to compact all
sstables.