### PR TITLE
storage: use *replicaHash in consistency checker

### DIFF
--- a/pkg/storage/replica_consistency.go
+++ b/pkg/storage/replica_consistency.go
@@ -305,12 +305,14 @@ func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (ReplicaChecksu
 // computeChecksumDone adds the computed checksum, sets a deadline for GCing the
 // checksum, and sends out a notification.
 func (r *Replica) computeChecksumDone(
-	ctx context.Context, id uuid.UUID, result replicaHash, snapshot *roachpb.RaftSnapshotData,
+	ctx context.Context, id uuid.UUID, result *replicaHash, snapshot *roachpb.RaftSnapshotData,
 ) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if c, ok := r.mu.checksums[id]; ok {
-		c.Checksum = result.SHA512[:]
+		if result != nil {
+			c.Checksum = result.SHA512[:]
+		}
 		c.gcTimestamp = timeutil.Now().Add(batcheval.ReplicaChecksumGCInterval)
 		c.Snapshot = snapshot
 		r.mu.checksums[id] = c

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -167,14 +167,14 @@ func (r *Replica) computeChecksumPostApply(
 		result, err := r.sha512(ctx, desc, snap, snapshot)
 		if err != nil {
 			log.Errorf(ctx, "%v", err)
-			result = &replicaHash{}
+			result = nil
 		}
-		r.computeChecksumDone(ctx, id, *result, snapshot)
+		r.computeChecksumDone(ctx, id, result, snapshot)
 	}); err != nil {
 		defer snap.Close()
 		log.Error(ctx, errors.Wrapf(err, "could not run async checksum computation (ID = %s)", id))
 		// Set checksum to nil.
-		r.computeChecksumDone(ctx, id, replicaHash{}, nil)
+		r.computeChecksumDone(ctx, id, nil, nil)
 	}
 }
 


### PR DESCRIPTION
This also fixes the buglet referenced below - when a computation failed (for
example due to the node shutting down) this was getting reported as an all-zero
sha, instead of no sha.

Fixes #21284.
Fixes #21285.
Fixes #21255.
Fixes #21277.
Fixes #21225.

Release note: None