### PR TITLE
storage: use resume span to set ts cache

### DIFF
--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -1287,7 +1287,7 @@ func TestStopAtRangeBoundary(t *testing.T) {
 					},
 					satisfied: []int{0, 2},
 				},
-				// scanning [<where we left of>,inf)
+				// scanning [<where we left off>,inf)
 				{
 					expResults: map[int][]string{
 						1: {"b1"},

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -1465,6 +1465,15 @@ func scanArgs(start, end []byte) roachpb.ScanRequest {
 	}
 }
 
+func reverseScanArgs(start, end []byte) roachpb.ReverseScanRequest {
+	return roachpb.ReverseScanRequest{
+		Span: roachpb.Span{
+			Key:    start,
+			EndKey: end,
+		},
+	}
+}
+
 func beginTxnArgs(
 	key []byte, txn *roachpb.Transaction,
 ) (roachpb.BeginTransactionRequest, roachpb.Header) {


### PR DESCRIPTION
Previously, we were updating the timestamp cache based on the rows
returned during scans and reverse scans. However, not only was this
inconsistent with how we gather intent spans for resolving on end
transaction, it was actually out of step with results actually
read, meaning we were not setting the timestamp cache properly to
reflect results read and returned. Consider the following scenario:
- Scan from "a" to "d", max results stops at "b".
- Current MVCCScan will seek past "b", find next key (let's say "c")
  and return resume span "c" - "d"
- However, we were updating timestamp cache for the span "a" - "b".Next().
- That leaves all of the keys from "b".Next() - "c" unprotected by
  the timestamp cache, so history can be rewritten under the span
  on successive resumes at the same timestamp.

Now, we correctly use the resume span to update the timestamp cache,
which is both consistent with other uses and correctly updates the
timestamp cache based on results actually read.

Release note: None
  