### PR TITLE
sql: improve the handling of subqueries

### DIFF
--- a/docs/tech-notes/life_of_a_query.md
+++ b/docs/tech-notes/life_of_a_query.md
@@ -378,7 +378,7 @@ which initiates the processing, and
 which is called repeatedly to produce the next row.
 
 To tie this to the [SQL Executor](#sql-executor) section above,
-[`executor.execClassic()`](https://github.com/cockroachdb/cockroach/blob/33c18ad1bcdb37ed6ed428b7527148977a8c566a/pkg/sql/executor.go#L1251),
+`executor.execLocal()`,
 the method responsible for executing one statement, calls
 `plan.Next()` repeatedly and accumulates the results.
 

--- a/pkg/sql/analyze_expr.go
+++ b/pkg/sql/analyze_expr.go
@@ -43,7 +43,7 @@ func (p *planner) analyzeExpr(
 	// is expected. Tell this to replaceSubqueries.  (See UPDATE for a
 	// counter-example; cases where a subquery is an operand of a
 	// comparison are handled specially in the subqueryVisitor already.)
-	replaced, err := p.replaceSubqueries(ctx, raw, 1 /* one value expected */)
+	replaced, err := p.analyzeSubqueries(ctx, raw, 1 /* one value expected */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -154,7 +154,7 @@ func (v *distSQLExprCheckVisitor) VisitPre(expr tree.Expr) (recurse bool, newExp
 		return false, expr
 	}
 	switch t := expr.(type) {
-	case *subquery, *tree.Subquery:
+	case *tree.Subquery:
 		v.err = newQueryNotSupportedError("subqueries not supported yet")
 		return false, expr
 

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -2063,15 +2063,14 @@ func (e *Executor) execLocal(
 		rowResultWriter.IncrementRowsAffected(count)
 
 	case tree.Rows:
-		err := forEachRow(params, plan, func(values tree.Datums) error {
-			for _, val := range values {
-				if err := checkResultType(val.ResolvedType()); err != nil {
-					return err
-				}
+		for _, c := range planColumns(plan) {
+			if err := checkResultType(c.Typ); err != nil {
+				return err
 			}
+		}
+		if err := forEachRow(params, plan, func(values tree.Datums) error {
 			return rowResultWriter.AddRow(ctx, values)
-		})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -548,20 +548,20 @@ func (e *Executor) Prepare(
 		}
 	}
 
-	plan, err := planner.prepare(session.Ctx(), stmt.AST)
-	if err != nil {
+	if err := planner.prepare(session.Ctx(), stmt.AST); err != nil {
 		return nil, err
 	}
-	if plan == nil {
+	if planner.curPlan.plan == nil {
+		// The statement cannot be prepared. Nothing to do.
 		return prepared, nil
 	}
 	defer func() {
-		plan.Close(session.Ctx())
+		planner.curPlan.close(session.Ctx())
 		// NB: if we start caching the plan, we'll want to keep around the memory
 		// account used for the plan, rather than clearing it.
 		prepared.memAcc.Clear(session.Ctx())
 	}()
-	prepared.Columns = planColumns(plan)
+	prepared.Columns = planner.curPlan.columns()
 	for _, c := range prepared.Columns {
 		if err := checkResultType(c.Typ); err != nil {
 			return nil, err
@@ -2007,10 +2007,10 @@ func commitSQLTransaction(
 	return transition
 }
 
-// exectDistSQL converts a classic plan to a distributed SQL physical plan and
-// runs it.
+// exectDistSQL converts the current logical plan to a distributed SQL
+// physical plan and runs it.
 func (e *Executor) execDistSQL(
-	planner *planner, tree planNode, rowResultWriter StatementResult,
+	planner *planner, plan planNode, rowResultWriter StatementResult,
 ) error {
 	ctx := planner.EvalContext().Ctx()
 	recv := makeDistSQLReceiver(
@@ -2022,7 +2022,7 @@ func (e *Executor) execDistSQL(
 		},
 	)
 	if err := e.distSQLPlanner.PlanAndRun(
-		ctx, planner.txn, tree, &recv, &planner.extendedEvalCtx,
+		ctx, planner.txn, plan, &recv, &planner.extendedEvalCtx,
 	); err != nil {
 		return err
 	}
@@ -2050,7 +2050,7 @@ func (e *Executor) execLocal(
 		p:               planner,
 	}
 
-	if err := startPlan(params, plan); err != nil {
+	if err := planner.curPlan.start(params); err != nil {
 		return err
 	}
 
@@ -2063,12 +2063,12 @@ func (e *Executor) execLocal(
 		rowResultWriter.IncrementRowsAffected(count)
 
 	case tree.Rows:
-		for _, c := range planColumns(plan) {
+		for _, c := range planner.curPlan.columns() {
 			if err := checkResultType(c.Typ); err != nil {
 				return err
 			}
 		}
-		if err := forEachRow(params, plan, func(values tree.Datums) error {
+		if err := forEachRow(params, planner.curPlan.plan, func(values tree.Datums) error {
 			return rowResultWriter.AddRow(ctx, values)
 		}); err != nil {
 			return err
@@ -2112,8 +2112,8 @@ func countRowsAffected(params runParams, p planNode) (int, error) {
 	return count, err
 }
 
-// shouldUseDistSQL determines whether we should use DistSQL for a plan, based
-// on the session settings.
+// shouldUseDistSQL determines whether we should use DistSQL for the
+// given logical plan, based on the session settings.
 func shouldUseDistSQL(
 	ctx context.Context,
 	distSQLMode sessiondata.DistSQLExecMode,
@@ -2124,6 +2124,7 @@ func shouldUseDistSQL(
 	if distSQLMode == sessiondata.DistSQLOff {
 		return false, nil
 	}
+
 	// Don't try to run empty nodes (e.g. SET commands) with distSQL.
 	if _, ok := plan.(*zeroNode); ok {
 		return false, nil
@@ -2189,31 +2190,32 @@ func (e *Executor) execStmt(
 	session := planner.session
 	ctx := session.Ctx()
 
+	// Perform logical planning and measure the duration of that phase.
 	planner.phaseTimes[plannerStartLogicalPlan] = timeutil.Now()
-	plan, err := planner.makePlan(ctx, stmt)
+	err := planner.makePlan(ctx, stmt)
 	planner.phaseTimes[plannerEndLogicalPlan] = timeutil.Now()
 	if err != nil {
 		return err
 	}
+	defer planner.curPlan.close(ctx)
 
-	defer plan.Close(ctx)
-
+	// Prepare the result set, and determine the execution parameters.
 	var cols sqlbase.ResultColumns
 	if stmt.AST.StatementType() == tree.Rows {
-		cols = planColumns(plan)
+		cols = planColumns(planner.curPlan.plan)
 	}
 	err = initStatementResult(res, stmt, cols)
 	if err != nil {
 		return err
 	}
 
-	useDistSQL, err := shouldUseDistSQL(
-		session.Ctx(), session.data.DistSQLMode, e.distSQLPlanner, planner, plan,
-	)
+	useDistSQL, err := shouldUseDistSQL(session.Ctx(),
+		session.data.DistSQLMode, e.distSQLPlanner, planner, planner.curPlan.plan)
 	if err != nil {
 		return err
 	}
 
+	// Start execution.
 	if e.cfg.TestingKnobs.BeforeExecute != nil {
 		e.cfg.TestingKnobs.BeforeExecute(ctx, stmt.String(), false /* isParallel */)
 	}
@@ -2221,11 +2223,14 @@ func (e *Executor) execStmt(
 	planner.phaseTimes[plannerStartExecStmt] = timeutil.Now()
 	session.setQueryExecutionMode(stmt.queryID, useDistSQL, false /* isParallel */)
 	if useDistSQL {
-		err = e.execDistSQL(planner, plan, res)
+		err = e.execDistSQL(planner, planner.curPlan.plan, res)
 	} else {
-		err = e.execLocal(planner, plan, res)
+		err = e.execLocal(planner, planner.curPlan.plan, res)
 	}
 	planner.phaseTimes[plannerEndExecStmt] = timeutil.Now()
+
+	// Complete execution: record results and optionally run the test
+	// hook.
 	recordStatementSummary(
 		planner, stmt, useDistSQL, automaticRetryCount, res, err, &e.EngineMetrics,
 	)
@@ -2260,20 +2265,19 @@ func (e *Executor) execStmtInParallel(
 		p:               planner,
 	}
 
-	plan, err := planner.makePlan(ctx, stmt)
-	if err != nil {
+	if err := planner.makePlan(ctx, stmt); err != nil {
 		return nil, err
 	}
 	var cols sqlbase.ResultColumns
 	if stmt.AST.StatementType() == tree.Rows {
-		cols = planColumns(plan)
+		cols = planner.curPlan.columns()
 	}
 
 	// This ensures we don't unintentionally clean up the queryMeta object when we
 	// send the mock result back to the client.
 	session.setQueryExecutionMode(stmt.queryID, false /* isDistributed */, true /* isParallel */)
 
-	if err := session.parallelizeQueue.Add(params, plan, func(plan planNode) error {
+	if err := session.parallelizeQueue.Add(params, func() error {
 		// TODO(andrei): this should really be a result writer implementation that
 		// does nothing.
 		bufferedWriter := newBufferedWriter(session.makeBoundAccount())
@@ -2287,7 +2291,7 @@ func (e *Executor) execStmtInParallel(
 		}
 
 		planner.phaseTimes[plannerStartExecStmt] = timeutil.Now()
-		err = e.execLocal(planner, plan, bufferedWriter)
+		err = e.execLocal(planner, planner.curPlan.plan, bufferedWriter)
 		planner.phaseTimes[plannerEndExecStmt] = timeutil.Now()
 		recordStatementSummary(planner, stmt, false, 0, bufferedWriter, err, &e.EngineMetrics)
 		if e.cfg.TestingKnobs.AfterExecute != nil {

--- a/pkg/sql/executor_opt_interface.go
+++ b/pkg/sql/executor_opt_interface.go
@@ -101,13 +101,18 @@ func (en *execNode) Explain() ([]tree.Datums, error) {
 		showExprs:    true,
 		qualifyNames: true,
 	}
-	explainNode := execNode{
-		execFactory: en.execFactory,
-		plan: en.planner.makeExplainPlanNode(
-			flags, false /* expanded */, false /* optimized */, en.plan,
-		),
+	explainNode, err := en.planner.makeExplainPlanNodeWithPlan(
+		context.TODO(), flags, false /* expanded */, false /* optimized */, en.plan,
+	)
+	if err != nil {
+		return nil, err
 	}
-	return explainNode.Run()
+	// Run the node.
+	explainExecNode := execNode{
+		execFactory: en.execFactory,
+		plan:        explainNode,
+	}
+	return explainExecNode.Run()
 }
 
 // Run is part of the opt.ExecNode interface.

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -117,6 +117,7 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 		mode = explainPlan
 	}
 
+	defer func(save bool) { p.extendedEvalCtx.SkipNormalize = save }(p.extendedEvalCtx.SkipNormalize)
 	p.extendedEvalCtx.SkipNormalize = !normalizeExprs
 
 	plan, err := p.newPlan(ctx, n.Statement, nil)

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -120,12 +120,12 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 	defer func(save bool) { p.extendedEvalCtx.SkipNormalize = save }(p.extendedEvalCtx.SkipNormalize)
 	p.extendedEvalCtx.SkipNormalize = !normalizeExprs
 
-	plan, err := p.newPlan(ctx, n.Statement, nil)
-	if err != nil {
-		return nil, err
-	}
 	switch mode {
 	case explainDistSQL:
+		plan, err := p.newPlan(ctx, n.Statement, nil)
+		if err != nil {
+			return nil, err
+		}
 		return &explainDistSQLNode{
 			plan: plan,
 		}, nil
@@ -133,7 +133,7 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 	case explainPlan:
 		// We may want to show placeholder types, so allow missing values.
 		p.semaCtx.Placeholders.PermitUnassigned()
-		return p.makeExplainPlanNode(flags, expanded, optimized, plan), nil
+		return p.makeExplainPlanNode(ctx, flags, expanded, optimized, n.Statement)
 
 	default:
 		return nil, fmt.Errorf("unsupported EXPLAIN mode: %d", mode)

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -131,8 +131,7 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 		}, nil
 
 	case explainPlan:
-		// We may want to show placeholder types, so ensure no values
-		// are missing.
+		// We may want to show placeholder types, so allow missing values.
 		p.semaCtx.Placeholders.PermitUnassigned()
 		return p.makeExplainPlanNode(flags, expanded, optimized, plan), nil
 

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -32,6 +32,9 @@ type explainPlanNode struct {
 	// plan is the sub-node being explained.
 	plan planNode
 
+	// subqueryPlans contains the subquery plans for the explained query.
+	subqueryPlans []subquery
+
 	// expanded indicates whether to invoke expandPlan() on the sub-node.
 	expanded bool
 
@@ -69,8 +72,26 @@ var explainPlanVerboseColumns = sqlbase.ResultColumns{
 
 // newExplainPlanNode instantiates a planNode that runs an EXPLAIN query.
 func (p *planner) makeExplainPlanNode(
-	flags explainFlags, expanded, optimized bool, plan planNode,
-) planNode {
+	ctx context.Context, flags explainFlags, expanded, optimized bool, origStmt tree.Statement,
+) (planNode, error) {
+	// Build the plan for the query being explained.  We want to capture
+	// all the analyzed sub-queries in the explain node, so we are going
+	// to override the planner's subquery plan slice.
+	defer func(s []subquery) { p.curPlan.subqueryPlans = s }(p.curPlan.subqueryPlans)
+	p.curPlan.subqueryPlans = nil
+
+	plan, err := p.newPlan(ctx, origStmt, nil)
+	if err != nil {
+		return nil, err
+	}
+	return p.makeExplainPlanNodeWithPlan(ctx, flags, expanded, optimized, plan)
+}
+
+// newExplainPlanNodeWithPlan instantiates a planNode that EXPLAINs an
+// underlying plan.
+func (p *planner) makeExplainPlanNodeWithPlan(
+	ctx context.Context, flags explainFlags, expanded, optimized bool, plan planNode,
+) (planNode, error) {
 	columns := explainPlanColumns
 
 	if flags.showMetadata {
@@ -80,7 +101,7 @@ func (p *planner) makeExplainPlanNode(
 	e := explainer{explainFlags: flags}
 
 	noPlaceholderFlags := tree.FmtExpr(
-		tree.FmtSimple, flags.showTypes, flags.symbolicVars, flags.qualifyNames,
+		tree.FmtSymbolicSubqueries, flags.showTypes, flags.symbolicVars, flags.qualifyNames,
 	)
 	e.fmtFlags = noPlaceholderFlags
 	e.showPlaceholderValues = func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
@@ -100,15 +121,16 @@ func (p *planner) makeExplainPlanNode(
 	}
 
 	node := &explainPlanNode{
-		explainer: e,
-		expanded:  expanded,
-		optimized: optimized,
-		plan:      plan,
+		explainer:     e,
+		expanded:      expanded,
+		optimized:     optimized,
+		plan:          plan,
+		subqueryPlans: p.curPlan.subqueryPlans,
 		run: explainPlanRun{
 			results: p.newContainerValuesNode(columns, 0),
 		},
 	}
-	return node
+	return node, nil
 }
 
 // explainPlanRun is the run-time state of explainPlanNode during local execution.
@@ -118,7 +140,21 @@ type explainPlanRun struct {
 }
 
 func (e *explainPlanNode) startExec(params runParams) error {
-	return params.p.populateExplain(params.ctx, &e.explainer, e.run.results, e.plan)
+	// The sub-plan's subqueries have been captured local to the EXPLAIN
+	// node so that they would not be automatically started for
+	// execution by planTop.start(). But this also means they were not
+	// yet processed by makePlan()/optimizePlan(). Do it here.
+	for i := range e.subqueryPlans {
+		if err := params.p.optimizeSubquery(params.ctx, &e.subqueryPlans[i]); err != nil {
+			return err
+		}
+
+		// Trigger limit propagation. This would be done otherwise when
+		// starting the plan. However we do not want to start the plan.
+		params.p.setUnlimited(e.subqueryPlans[i].plan)
+	}
+
+	return params.p.populateExplain(params.ctx, &e.explainer, e.run.results, e.plan, e.subqueryPlans)
 }
 
 func (e *explainPlanNode) Next(params runParams) (bool, error) { return e.run.results.Next(params) }
@@ -126,6 +162,9 @@ func (e *explainPlanNode) Values() tree.Datums                 { return e.run.re
 
 func (e *explainPlanNode) Close(ctx context.Context) {
 	e.plan.Close(ctx)
+	for i := range e.subqueryPlans {
+		e.subqueryPlans[i].plan.Close(ctx)
+	}
 	e.run.results.Close(ctx)
 }
 
@@ -184,11 +223,12 @@ type explainer struct {
 var emptyString = tree.NewDString("")
 
 // populateExplain walks the plan and generates rows in a valuesNode.
+// The subquery plans, if any are known to the planner, are printed
+// at the bottom.
 func (p *planner) populateExplain(
-	ctx context.Context, e *explainer, v *valuesNode, plan planNode,
+	ctx context.Context, e *explainer, v *valuesNode, plan planNode, subqueryPlans []subquery,
 ) error {
-	e.entries = nil
-	_ = walkPlan(ctx, plan, e.observer())
+	e.populateEntries(ctx, plan, subqueryPlans)
 
 	tp := treeprinter.New()
 	// n keeps track of the current node on each level.
@@ -238,17 +278,51 @@ func (p *planner) populateExplain(
 	return nil
 }
 
-// planToString uses walkPlan() to build a string representation of the planNode.
-func planToString(ctx context.Context, plan planNode) string {
+func (e *explainer) populateEntries(ctx context.Context, plan planNode, subqueryPlans []subquery) {
+	e.entries = nil
+	observer := e.observer()
+
+	// If there are any subqueries in the plan, we enclose both the main
+	// plan and the sub-queries as children of a virtual "root"
+	// node. This is not introduced in the common case where there are
+	// no subqueries.
+	if len(subqueryPlans) > 0 {
+		_, _ = e.enterNode(ctx, "root", plan)
+	}
+
+	// Explain the main plan.
+	_ = walkPlan(ctx, plan, observer)
+
+	// Explain the subqueries.
+	for i := range subqueryPlans {
+		_, _ = e.enterNode(ctx, "subquery", plan)
+		e.attr("subquery", "id", fmt.Sprintf("@S%d", i+1))
+		e.attr("subquery", "sql", subqueryPlans[i].subquery.String())
+		e.attr("subquery", "exec mode", execModeNames[subqueryPlans[i].execMode])
+		if subqueryPlans[i].plan != nil {
+			_ = walkPlan(ctx, subqueryPlans[i].plan, observer)
+		} else if subqueryPlans[i].started {
+			e.expr("subquery", "result", -1, subqueryPlans[i].result)
+		}
+		_ = e.leaveNode("subquery", subqueryPlans[i].plan)
+	}
+
+	if len(subqueryPlans) > 0 {
+		_ = e.leaveNode("root", plan)
+	}
+}
+
+// planToString uses explain() to build a string representation of the planNode.
+func planToString(ctx context.Context, plan planNode, subqueryPlans []subquery) string {
 	e := explainer{
 		explainFlags: explainFlags{
 			showMetadata: true,
 			showExprs:    true,
 			showTypes:    true,
 		},
-		fmtFlags: tree.FmtExpr(tree.FmtSimple, true, true, true),
+		fmtFlags: tree.FmtExpr(tree.FmtSymbolicSubqueries, true, true, true),
 	}
-	_ = walkPlan(ctx, plan, e.observer())
+	e.populateEntries(ctx, plan, subqueryPlans)
 	var buf bytes.Buffer
 	for _, e := range e.entries {
 		field := e.field

--- a/pkg/sql/expr_filter.go
+++ b/pkg/sql/expr_filter.go
@@ -73,7 +73,7 @@ func (v *varConvertVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree
 	if varExpr, ok := expr.(tree.VariableExpr); ok {
 		// Ignore sub-queries and placeholders
 		switch expr.(type) {
-		case *subquery, *tree.Placeholder:
+		case *tree.Subquery, *tree.Placeholder:
 			return false, expr
 		}
 

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -93,13 +93,17 @@ nosort                   0  nosort    ·      ·   (x)  x=CONST
 query TITTTTT
 EXPLAIN (METADATA) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
 ----
-render                        0  render    ·           ·  (y)  y=CONST
- │                            0  ·         subqueries  1  ·    ·
- ├── limit                    1  limit     ·           ·  (y)  y=CONST
- │    └── render              2  render    ·           ·  (y)  y=CONST
- │         └── render         3  render    ·           ·  (y)  y=CONST
- │              └── emptyrow  4  emptyrow  ·           ·  (y)  y=CONST
- └── emptyrow                 1  emptyrow  ·           ·  (y)  y=CONST
+root                               0  root      ·          ·                                     (y)  y=CONST
+ ├── render                        1  render    ·          ·                                     (y)  y=CONST
+ │    └── emptyrow                 2  emptyrow  ·          ·                                     (y)  y=CONST
+ └── subquery                      1  subquery  ·          ·                                     (y)  y=CONST
+      │                            1  ·         id         @S1                                   ·    ·
+      │                            1  ·         sql        (SELECT 2 AS x FROM (SELECT 3 AS s))  ·    ·
+      │                            1  ·         exec mode  one row                               ·    ·
+      └── limit                    2  limit     ·          ·                                     (y)  y=CONST
+           └── render              3  render    ·          ·                                     (y)  y=CONST
+                └── render         4  render    ·          ·                                     (y)  y=CONST
+                     └── emptyrow  5  emptyrow  ·          ·                                     (y)  y=CONST
 
 # Propagation through table scans.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -160,13 +160,17 @@ INSERT INTO abc VALUES (1, 2, 3), (4, 5, 6)
 query TTT
 EXPLAIN ALTER TABLE abc SPLIT AT VALUES ((SELECT 42))
 ----
-split                         ·           ·
- └── values                   ·           ·
-      │                       size        1 column, 1 row
-      │                       subqueries  1
-      └── limit               ·           ·
-           └── render         ·           ·
-                └── emptyrow  ·           ·
+root                          ·          ·
+ ├── split                    ·          ·
+ │    └── values              ·          ·
+ │                            size       1 column, 1 row
+ └── subquery                 ·          ·
+      │                       id         @S1
+      │                       sql        (SELECT 42)
+      │                       exec mode  one row
+      └── limit               ·          ·
+           └── render         ·          ·
+                └── emptyrow  ·          ·
 
 statement ok
 ALTER TABLE abc SPLIT AT VALUES ((SELECT 1))
@@ -193,14 +197,19 @@ SELECT (SELECT a FROM abc)
 query TTT
 EXPLAIN SELECT EXISTS (SELECT a FROM abc)
 ----
-render               ·           ·
- │                   subqueries  1
- ├── limit           ·           ·
- │    └── render     ·           ·
- │         └── scan  ·           ·
- │                   table       abc@primary
- │                   spans       ALL
- └── emptyrow        ·           ·
+root                      ·          ·
+ ├── render               ·          ·
+ │    └── emptyrow        ·          ·
+ └── subquery             ·          ·
+      │                   id         @S1
+      │                   sql        EXISTS (SELECT a FROM abc)
+      │                   exec mode  exists
+      └── limit           ·          ·
+           └── render     ·          ·
+                └── scan  ·          ·
+·                         table      abc@primary
+·                         spans      ALL
+·                         limit      1
 
 query I
 SELECT (SELECT a FROM abc WHERE false)
@@ -457,15 +466,19 @@ true
 query TITTTTT
 EXPLAIN (METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
 ----
-render               0  render  ·           ·            (x)  x!=NULL; key(x)
- └── scan            1  scan    ·           ·            (x)  x!=NULL; key(x)
-      │              1  ·       table       xyz@primary  ·    ·
-      │              1  ·       spans       ALL          ·    ·
-      │              1  ·       subqueries  1            ·    ·
-      └── render     2  render  ·           ·            (x)  x!=NULL; key(x)
-           └── scan  3  scan    ·           ·            (x)  x!=NULL; key(x)
-·                    3  ·       table       xyz@primary  ·    ·
-·                    3  ·       spans       ALL          ·    ·
+root                 0  root      ·          ·                    (x)  x!=NULL; key(x)
+ ├── render          1  render    ·          ·                    (x)  x!=NULL; key(x)
+ │    └── scan       2  scan      ·          ·                    (x)  x!=NULL; key(x)
+ │                   2  ·         table      xyz@primary          ·    ·
+ │                   2  ·         spans      ALL                  ·    ·
+ └── subquery        1  subquery  ·          ·                    (x)  x!=NULL; key(x)
+      │              1  ·         id         @S1                  ·    ·
+      │              1  ·         sql        (SELECT x FROM xyz)  ·    ·
+      │              1  ·         exec mode  all rows normalized  ·    ·
+      └── render     2  render    ·          ·                    (x)  x!=NULL; key(x)
+           └── scan  3  scan      ·          ·                    (x)  x!=NULL; key(x)
+·                    3  ·         table      xyz@primary          ·    ·
+·                    3  ·         spans      ALL                  ·    ·
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not
@@ -486,12 +499,16 @@ SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col
 query TTT
 EXPLAIN SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
 ----
-render               ·           ·
- └── scan            ·           ·
-      │              table       tab4@primary
-      │              spans       ALL
-      │              subqueries  1
-      └── render     ·           ·
-           └── scan  ·           ·
-·                    table       tab4@primary
-·                    spans       ALL
+root                 ·          ·
+ ├── render          ·          ·
+ │    └── scan       ·          ·
+ │                   table      tab4@primary
+ │                   spans      ALL
+ └── subquery        ·          ·
+      │              id         @S1
+      │              sql        (SELECT col1 FROM tab4 WHERE col1 > 8.27)
+      │              exec mode  all rows normalized
+      └── render     ·          ·
+           └── scan  ·          ·
+·                    table      tab4@primary
+·                    spans      ALL

--- a/pkg/sql/logictest/testdata/logic_test/values
+++ b/pkg/sql/logictest/testdata/logic_test/values
@@ -31,9 +31,13 @@ VALUES ((SELECT 1)), ((SELECT 2))
 query TTT
 EXPLAIN VALUES (1), ((SELECT 2))
 ----
-values                   ·           ·
- │                       size        1 column, 2 rows
- │                       subqueries  1
- └── limit               ·           ·
-      └── render         ·           ·
-           └── emptyrow  ·           ·
+root                          ·          ·
+ ├── values                   ·          ·
+ │                            size       1 column, 2 rows
+ └── subquery                 ·          ·
+      │                       id         @S1
+      │                       sql        (SELECT 2)
+      │                       exec mode  one row
+      └── limit               ·          ·
+           └── render         ·          ·
+                └── emptyrow  ·          ·

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -361,7 +361,7 @@ func (p *planner) triggerFilterPropagation(ctx context.Context, plan planNode) (
 
 	if !isFilterTrue(remainingFilter) {
 		panic(fmt.Sprintf("propagateFilters on \n%s\n spilled a non-trivial remaining filter: %s",
-			planToString(ctx, plan), remainingFilter))
+			planToString(ctx, plan, nil), remainingFilter))
 	}
 
 	return newPlan, nil

--- a/pkg/sql/optimize.go
+++ b/pkg/sql/optimize.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // optimizePlan transforms the query plan into its final form.  This
@@ -52,58 +53,45 @@ func (p *planner) optimizePlan(
 	// the needed columns are properly computed for newly expanded nodes.
 	setNeededColumns(newPlan, needed)
 
-	// Now do the same work for all sub-queries.
-	i := &subqueryInitializer{p: p}
-	observer := planObserver{
-		subqueryNode: i.subqueryNode,
-		enterNode:    i.enterNode,
-	}
-	if err := walkPlan(ctx, newPlan, observer); err != nil {
-		return plan, err
-	}
 	return newPlan, nil
 }
 
-// subqueryInitializer ensures that initNeededColumns() and
-// optimizeFilters() is called on the planNodes of all sub-query
-// expressions.
-type subqueryInitializer struct {
-	p *planner
-}
-
-// subqueryNode implements the planObserver interface.
-func (i *subqueryInitializer) subqueryNode(ctx context.Context, sq *subquery) error {
-	if sq.plan != nil && !sq.expanded {
-		if sq.execMode == execModeExists || sq.execMode == execModeOneRow {
-			numRows := tree.DInt(1)
-			if sq.execMode == execModeOneRow {
-				// When using a sub-query in a scalar context, we must
-				// appropriately reject sub-queries that return more than 1
-				// row.
-				numRows = 2
-			}
-
-			sq.plan = &limitNode{plan: sq.plan, countExpr: tree.NewDInt(numRows)}
-		}
-
-		needed := make([]bool, len(planColumns(sq.plan)))
-		if sq.execMode != execModeExists {
-			// EXISTS does not need values; the rest does.
-			for i := range needed {
-				needed[i] = true
-			}
-		}
-
-		var err error
-		sq.plan, err = i.p.optimizePlan(ctx, sq.plan, needed)
-		if err != nil {
-			return err
-		}
-		sq.expanded = true
+// optimizeSubquery ensures plan optimization has been perfomed on the given subquery.
+func (p *planner) optimizeSubquery(ctx context.Context, sq *subquery) error {
+	if sq.expanded {
+		// Already processed. Nothing to do.
+		return nil
 	}
-	return nil
-}
 
-func (i *subqueryInitializer) enterNode(_ context.Context, _ string, _ planNode) (bool, error) {
-	return true, nil
+	if log.V(2) {
+		log.Infof(ctx, "optimizing subquery %d (%q)", sq.subquery.Idx, sq.subquery)
+	}
+
+	if sq.execMode == execModeExists || sq.execMode == execModeOneRow {
+		numRows := tree.DInt(1)
+		if sq.execMode == execModeOneRow {
+			// When using a sub-query in a scalar context, we must
+			// appropriately reject sub-queries that return more than 1
+			// row.
+			numRows = 2
+		}
+
+		sq.plan = &limitNode{plan: sq.plan, countExpr: tree.NewDInt(numRows)}
+	}
+
+	needed := make([]bool, len(planColumns(sq.plan)))
+	if sq.execMode != execModeExists {
+		// EXISTS does not need values; the rest does.
+		for i := range needed {
+			needed[i] = true
+		}
+	}
+
+	var err error
+	sq.plan, err = p.optimizePlan(ctx, sq.plan, needed)
+	if err != nil {
+		return err
+	}
+	sq.expanded = true
+	return nil
 }

--- a/pkg/sql/parallel_stmts.go
+++ b/pkg/sql/parallel_stmts.go
@@ -72,15 +72,18 @@ func MakeParallelizeQueue(analyzer DependencyAnalyzer) ParallelizeQueue {
 	}
 }
 
-// Add inserts a new plan in the queue and executes the provided function when
-// all plans that it depends on have completed successfully, obeying the guarantees
-// made by the ParallelizeQueue above. The exec function should be used to run the
-// planNode and return any error observed during its execution.
+// Add inserts the current plan in the queue and executes the provided
+// function when all plans that it depends on have completed
+// successfully, obeying the guarantees made by the ParallelizeQueue
+// above.
 //
 // Add should not be called concurrently with Wait. See Wait's comment for more
 // details.
-func (pq *ParallelizeQueue) Add(params runParams, plan planNode, exec func(planNode) error) error {
-	prereqs, finishLocked, err := pq.insertInQueue(params, plan)
+func (pq *ParallelizeQueue) Add(params runParams, exec func() error) error {
+	// plan is used as a hash key in the data structures, we don't
+	// consider it further here.
+	plan := params.p.curPlan.plan
+	prereqs, finishLocked, err := pq.insertInQueue(params)
 	if err != nil {
 		plan.Close(params.ctx)
 		return err
@@ -89,7 +92,10 @@ func (pq *ParallelizeQueue) Add(params runParams, plan planNode, exec func(planN
 	pq.runningGroup.Add(1)
 	go func() {
 		defer pq.runningGroup.Done()
-		defer plan.Close(params.ctx)
+		// Be careful to close the planner's top-level node, and not just
+		// the hash key retrieved above -- there may be more work done by
+		// this close() method than plan.Close().
+		defer params.p.curPlan.close(params.ctx)
 
 		// Block on the execution of each prerequisite plan blocking us.
 		for _, prereq := range prereqs {
@@ -110,7 +116,10 @@ func (pq *ParallelizeQueue) Add(params runParams, plan planNode, exec func(planN
 		}
 
 		// Execute the plan.
-		err := exec(plan)
+		// No need to give it the plan it needs to operate on -- it will
+		// know about the current plan from its captured planner
+		// reference.
+		err := exec()
 
 		pq.mu.Lock()
 		if err != nil {
@@ -126,19 +135,18 @@ func (pq *ParallelizeQueue) Add(params runParams, plan planNode, exec func(planN
 // channels of prerequisite blocking the new plan from executing. It also returns a
 // function to call when the new plan has finished executing. This function must be
 // called while pq.mu is held.
-func (pq *ParallelizeQueue) insertInQueue(
-	params runParams, newPlan planNode,
-) ([]doneChan, func(), error) {
+func (pq *ParallelizeQueue) insertInQueue(params runParams) ([]doneChan, func(), error) {
 	pq.mu.Lock()
 	defer pq.mu.Unlock()
 
 	// Determine the set of prerequisite plans.
-	prereqs, err := pq.prereqsForPlanLocked(params, newPlan)
+	prereqs, err := pq.prereqsForPlanLocked(params)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// Insert newPlan in running set.
+	// Insert the current plan in running set.
+	newPlan := params.p.curPlan.plan
 	newDoneChan := make(doneChan)
 	pq.plans[newPlan] = newDoneChan
 	finish := func() {
@@ -158,18 +166,17 @@ func (pq *ParallelizeQueue) insertInQueue(
 // that a new plan is dependent on. It returns a slice of doneChans for each plan
 // in this set. Returns a nil slice if the plan has no prerequisites and can be run
 // immediately.
-func (pq *ParallelizeQueue) prereqsForPlanLocked(
-	params runParams, newPlan planNode,
-) ([]doneChan, error) {
+func (pq *ParallelizeQueue) prereqsForPlanLocked(params runParams) ([]doneChan, error) {
 	// First, submit the planNode to the analyzer for analysis. This assures
 	// that the analysis takes place before the plan is executed, even if
 	// no calls to analyzer.Independent are necessary at this time.
-	if err := pq.analyzer.Analyze(params, newPlan); err != nil {
+	if err := pq.analyzer.Analyze(params); err != nil {
 		return nil, err
 	}
 
 	// Add all plans from the plan set that this new plan is dependent on.
 	var prereqs []doneChan
+	newPlan := params.p.curPlan.plan
 	for plan, doneChan := range pq.plans {
 		if !pq.analyzer.Independent(plan, newPlan) {
 			prereqs = append(prereqs, doneChan)
@@ -224,11 +231,11 @@ func (pq *ParallelizeQueue) Errs() []error {
 // goroutines concurrently.
 type DependencyAnalyzer interface {
 	// Analyze collects any upfront analysis that is necessary to make future
-	// independence decisions about the planNode. It must be called before
-	// calling Independent for each planNode, and the planNode provided must
+	// independence decisions about the current plan. It must be called before
+	// calling Independent for each planNode, and the current plan provided must
 	// not be running when Analyze is called. Analyze is allowed to mutate the
 	// provided planner if necessary.
-	Analyze(runParams, planNode) error
+	Analyze(runParams) error
 	// Independent determines if the provided planNodess are independent from
 	// one another. Either planNode may be running when Independent is called,
 	// so the method will not modify the plans in any way. Implementations of
@@ -251,8 +258,8 @@ func (f dependencyAnalyzerFunc) Independent(p1 planNode, p2 planNode) bool {
 	return f(p1, p2)
 }
 
-func (f dependencyAnalyzerFunc) Analyze(_ runParams, _ planNode) error { return nil }
-func (f dependencyAnalyzerFunc) Clear(_ planNode)                      {}
+func (f dependencyAnalyzerFunc) Analyze(_ runParams) error { return nil }
+func (f dependencyAnalyzerFunc) Clear(_ planNode)          {}
 
 // NoDependenciesAnalyzer is a DependencyAnalyzer that performs no analysis on
 // planNodes and asserts that all plans are independent.
@@ -287,7 +294,8 @@ func NewSpanBasedDependencyAnalyzer() DependencyAnalyzer {
 	}
 }
 
-func (a *spanBasedDependencyAnalyzer) Analyze(params runParams, p planNode) error {
+func (a *spanBasedDependencyAnalyzer) Analyze(params runParams) error {
+	p := params.p.curPlan.plan
 	readSpans, writeSpans, err := collectSpans(params, p)
 	if err != nil {
 		return err

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -68,14 +68,15 @@ func waitAndAssertEmpty(t *testing.T, pq *ParallelizeQueue) {
 	}
 }
 
-func (pq *ParallelizeQueue) MustAdd(t *testing.T, plan planNode, exec func(planNode) error) {
+func (pq *ParallelizeQueue) MustAdd(t *testing.T, plan planNode, exec func() error) {
 	p := makeTestPlanner()
 	params := runParams{
 		ctx:             context.TODO(),
 		p:               p,
 		extendedEvalCtx: &p.extendedEvalCtx,
 	}
-	if err := pq.Add(params, plan, exec); err != nil {
+	params.p.curPlan.plan = plan
+	if err := pq.Add(params, exec); err != nil {
 		t.Fatalf("ParallelizeQueue.Add failed: %v", err)
 	}
 }
@@ -91,20 +92,20 @@ func TestParallelizeQueueNoDependencies(t *testing.T) {
 
 	// Executes: plan3 -> plan1 -> plan2.
 	pq := MakeParallelizeQueue(NoDependenciesAnalyzer)
-	pq.MustAdd(t, newPlanNode(), func(plan planNode) error {
+	pq.MustAdd(t, newPlanNode(), func() error {
 		<-run1
 		res = append(res, 1)
 		assertLen(t, &pq, 3)
 		close(run3)
 		return nil
 	})
-	pq.MustAdd(t, newPlanNode(), func(plan planNode) error {
+	pq.MustAdd(t, newPlanNode(), func() error {
 		<-run2
 		res = append(res, 2)
 		assertLenEventually(t, &pq, 1)
 		return nil
 	})
-	pq.MustAdd(t, newPlanNode(), func(plan planNode) error {
+	pq.MustAdd(t, newPlanNode(), func() error {
 		<-run3
 		res = append(res, 3)
 		assertLenEventually(t, &pq, 2)
@@ -134,18 +135,18 @@ func TestParallelizeQueueAllDependent(t *testing.T) {
 
 	// Executes: plan1 -> plan2 -> plan3.
 	pq := MakeParallelizeQueue(analyzer)
-	pq.MustAdd(t, newPlanNode(), func(plan planNode) error {
+	pq.MustAdd(t, newPlanNode(), func() error {
 		<-run
 		res = append(res, 1)
 		assertLen(t, &pq, 3)
 		return nil
 	})
-	pq.MustAdd(t, newPlanNode(), func(plan planNode) error {
+	pq.MustAdd(t, newPlanNode(), func() error {
 		res = append(res, 2)
 		assertLen(t, &pq, 2)
 		return nil
 	})
-	pq.MustAdd(t, newPlanNode(), func(plan planNode) error {
+	pq.MustAdd(t, newPlanNode(), func() error {
 		res = append(res, 3)
 		assertLen(t, &pq, 1)
 		return nil
@@ -178,18 +179,18 @@ func TestParallelizeQueueSingleDependency(t *testing.T) {
 
 	// Executes: plan3 -> plan1 -> plan2.
 	pq := MakeParallelizeQueue(analyzer)
-	pq.MustAdd(t, plan1, func(plan planNode) error {
+	pq.MustAdd(t, plan1, func() error {
 		<-run1
 		res = append(res, 1)
 		assertLenEventually(t, &pq, 2)
 		return nil
 	})
-	pq.MustAdd(t, plan2, func(plan planNode) error {
+	pq.MustAdd(t, plan2, func() error {
 		res = append(res, 2)
 		assertLen(t, &pq, 1)
 		return nil
 	})
-	pq.MustAdd(t, plan3, func(plan planNode) error {
+	pq.MustAdd(t, plan3, func() error {
 		<-run3
 		res = append(res, 3)
 		assertLen(t, &pq, 3)
@@ -224,19 +225,19 @@ func TestParallelizeQueueError(t *testing.T) {
 
 	// Executes: plan3 -> plan1 (error!) -> plan2 (dropped).
 	pq := MakeParallelizeQueue(analyzer)
-	pq.MustAdd(t, plan1, func(plan planNode) error {
+	pq.MustAdd(t, plan1, func() error {
 		<-run1
 		res = append(res, 1)
 		assertLenEventually(t, &pq, 2)
 		return planErr
 	})
-	pq.MustAdd(t, plan2, func(plan planNode) error {
+	pq.MustAdd(t, plan2, func() error {
 		// Should never be called. We assert this using the res slice, because
 		// we can't call t.Fatalf in a different goroutine.
 		res = append(res, 2)
 		return nil
 	})
-	pq.MustAdd(t, plan3, func(plan planNode) error {
+	pq.MustAdd(t, plan3, func() error {
 		<-run3
 		res = append(res, 3)
 		assertLen(t, &pq, 3)
@@ -269,7 +270,7 @@ func TestParallelizeQueueAddAfterError(t *testing.T) {
 
 	// Executes: plan1 (error!) -> plan2 (dropped) -> plan3.
 	pq := MakeParallelizeQueue(NoDependenciesAnalyzer)
-	pq.MustAdd(t, plan1, func(plan planNode) error {
+	pq.MustAdd(t, plan1, func() error {
 		res = append(res, 1)
 		assertLen(t, &pq, 1)
 		return planErr
@@ -283,7 +284,7 @@ func TestParallelizeQueueAddAfterError(t *testing.T) {
 		return nil
 	})
 
-	pq.MustAdd(t, plan2, func(plan planNode) error {
+	pq.MustAdd(t, plan2, func() error {
 		// Should never be called. We assert this using the res slice, because
 		// we can't call t.Fatalf in a different goroutine.
 		res = append(res, 2)
@@ -297,7 +298,7 @@ func TestParallelizeQueueAddAfterError(t *testing.T) {
 		t.Fatalf("expected plan1 to throw error %v, found %v", planErr, resErrs)
 	}
 
-	pq.MustAdd(t, plan3, func(plan planNode) error {
+	pq.MustAdd(t, plan3, func() error {
 		// Will be called, because the error is cleared when Wait is called.
 		res = append(res, 3)
 		assertLen(t, &pq, 1)
@@ -311,9 +312,7 @@ func TestParallelizeQueueAddAfterError(t *testing.T) {
 	}
 }
 
-func planQuery(
-	t *testing.T, s serverutils.TestServerInterface, sql string,
-) (*planner, planNode, func()) {
+func planQuery(t *testing.T, s serverutils.TestServerInterface, sql string) (*planner, func()) {
 	kvDB := s.KVClient().(*client.DB)
 	now := s.Clock().Now()
 	physicalNow := s.Clock().PhysicalTime()
@@ -337,12 +336,11 @@ func planQuery(
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	plan, err := p.makePlan(context.TODO(), Statement{AST: stmt})
-	if err != nil {
+	if err := p.makePlan(context.TODO(), Statement{AST: stmt}); err != nil {
 		t.Fatal(err)
 	}
-	return p, plan, func() {
-		plan.Close(context.TODO())
+	return p, func() {
+		p.curPlan.close(context.TODO())
 		finishInternalPlanner(p)
 	}
 }
@@ -465,20 +463,20 @@ func TestSpanBasedDependencyAnalyzer(t *testing.T) {
 				da := NewSpanBasedDependencyAnalyzer()
 
 				planAndAnalyze := func(q string) (planNode, func()) {
-					p, plan, finish := planQuery(t, s, q)
+					p, finish := planQuery(t, s, q)
 					params := runParams{
 						ctx:             context.TODO(),
 						extendedEvalCtx: &p.extendedEvalCtx,
 						p:               p,
 					}
 
-					if err := da.Analyze(params, plan); err != nil {
+					if err := da.Analyze(params); err != nil {
 						t.Fatalf("plan analysis failed: %v", err)
 					}
 
-					return plan, func() {
+					return p.curPlan.plan, func() {
 						finish()
-						da.Clear(plan)
+						da.Clear(p.curPlan.plan)
 					}
 				}
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -493,7 +493,7 @@ func TestParse(t *testing.T) {
 		{`SELECT true = false`},
 		{`SELECT (true = false)`},
 		{`SELECT (ARRAY['a', 'b'])[2]`},
-		{`SELECT (ARRAY(VALUES (1), (2)))[1]`},
+		{`SELECT (ARRAY (VALUES (1), (2)))[1]`},
 		{`SELECT (SELECT 1)`},
 		{`SELECT ((SELECT 1))`},
 		{`SELECT (SELECT ARRAY['a', 'b'])[2]`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6196,7 +6196,7 @@ c_expr:
 | case_expr
 | EXISTS select_with_parens
   {
-    $$.val = &tree.ExistsExpr{Subquery: &tree.Subquery{Select: $2.selectStmt()}}
+    $$.val = &tree.Subquery{Select: $2.selectStmt(), Exists: true}
   }
 
 // Productions that can be followed by a postfix operator.

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -46,19 +46,14 @@ type planMaker interface {
 	) (planNode, error)
 
 	// makePlan prepares the query plan for a single SQL statement.  it
-	// calls newPlan() then optimizePlan() on the result.  Execution must
-	// start by calling Start() first and then iterating using Next()
-	// and Values() in order to retrieve matching rows.
+	// calls newPlan() then optimizePlan() on the result.
+	// The logical plan is stored in the planner's curPlan field.
 	//
-	// makePlan starts preparing the query plan for a single SQL
-	// statement.
-	// It performs as many early checks as possible on the structure of
-	// the SQL statement, including verifying permissions and type checking.
-	// The returned plan object is ready to execute. Execution
-	// must start by calling Start() first and then iterating using
-	// Next() and Values() in order to retrieve matching
-	// rows.
-	makePlan(ctx context.Context, stmt Statement) (planNode, error)
+	// Execution must start by calling curPlan.start() first and then
+	// iterating using curPlan.plan.Next() and curPlan.plan.Values() in
+	// order to retrieve matching rows. Finally, the plan must be closed
+	// with curPlan.close().
+	makePlan(ctx context.Context, stmt Statement) error
 
 	// prepare does the same checks as makePlan but skips building some
 	// data structures necessary for execution, based on the assumption
@@ -67,7 +62,8 @@ type planMaker interface {
 	// SQL statement and determine types for placeholders. However it is
 	// not appropriate to call optimizePlan(), Next() or Values() on a plan
 	// object created with prepare().
-	prepare(ctx context.Context, stmt tree.Statement) (planNode, error)
+	// The plan should still be closed with p.curPlan.close() though.
+	prepare(ctx context.Context, stmt tree.Statement) error
 }
 
 var _ planMaker = &planner{}
@@ -103,7 +99,7 @@ func (r *runParams) SessionData() *sessiondata.SessionData {
 // for each type; they thus need to be extended when adding/removing
 // planNode instances:
 // - planMaker.newPlan()
-// - planMaker.prepare()
+// - planMaker.doPrepare()
 // - planMaker.setNeededColumns()  (needed_columns.go)
 // - planMaker.expandPlan()        (expand_plan.go)
 // - planVisitor.visit()           (walk.go)
@@ -211,21 +207,63 @@ var _ planNodeFastPath = &deleteNode{}
 var _ planNodeFastPath = &DropUserNode{}
 var _ planNodeFastPath = &setZoneConfigNode{}
 
-// makePlan implements the Planner interface.
-func (p *planner) makePlan(ctx context.Context, stmt Statement) (planNode, error) {
-	plan, err := p.newPlan(ctx, stmt.AST, nil /* desiredTypes */)
+// planTop is the struct that collects the properties
+// of an entire plan.
+// Note: some additional per-statement state is also stored in
+// semaCtx (placeholders).
+// TODO(jordan): investigate whether/how per-plan state like
+// placeholder data can be concentrated in a single struct.
+type planTop struct {
+	// plan is the top-level node of the logical plan.
+	plan planNode
+
+	// deps, if non-nil, collects the table/view dependencies for this query.
+	// Any planNode constructors that resolves a table name or reference in the query
+	// to a descriptor must register this descriptor into planDeps.
+	// This is (currently) used by CREATE VIEW.
+	// TODO(knz): Remove this in favor of a better encapsulated mechanism.
+	deps planDependencies
+
+	// cteNameEnvironment collects the mapping from common table expression alias
+	// to the planNodes that represent their source.
+	cteNameEnvironment cteNameEnvironment
+
+	// hasStar collects whether any star expansion has occurred during
+	// logical plan construction. This is used by CREATE VIEW until
+	// #10028 is addressed.
+	hasStar bool
+	// hasSubqueries collects whether any subqueries expansion has
+	// occurred during logical plan construction.
+	hasSubqueries bool
+	// plannedExecute is true if this planner has planned an EXECUTE statement.
+	plannedExecute bool
+}
+
+// makePlan implements the Planner interface. It populates the
+// planner's curPlan field.
+//
+// The caller is responsible for populating the placeholders
+// beforehand (currently in semaCtx.Placeholders).
+//
+// After makePlan(), the caller should be careful to also call
+// p.curPlan.Close().
+func (p *planner) makePlan(ctx context.Context, stmt Statement) error {
+	// Reinitialize.
+	p.curPlan = planTop{}
+
+	plan, err := p.newPlan(ctx, stmt.AST, nil /*desiredTypes*/)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	cols := planColumns(plan)
 	if stmt.ExpectedTypes != nil {
 		if !stmt.ExpectedTypes.TypesEqual(cols) {
-			return nil, pgerror.NewError(pgerror.CodeFeatureNotSupportedError,
+			return pgerror.NewError(pgerror.CodeFeatureNotSupportedError,
 				"cached plan must not change result type")
 		}
 	}
 	if err := p.semaCtx.Placeholders.AssertAllAssigned(); err != nil {
-		return nil, err
+		return err
 	}
 
 	// Ensure that any hidden result column is effectively hidden.
@@ -234,7 +272,7 @@ func (p *planner) makePlan(ctx context.Context, stmt Statement) (planNode, error
 	plan, err = p.hideHiddenColumns(ctx, plan, cols)
 	if err != nil {
 		plan.Close(ctx)
-		return nil, err
+		return err
 	}
 
 	needed := allColumns(plan)
@@ -243,13 +281,17 @@ func (p *planner) makePlan(ctx context.Context, stmt Statement) (planNode, error
 		// Once the plan has undergone optimization, it may contain
 		// monitor-registered memory, even in case of error.
 		plan.Close(ctx)
-		return nil, err
+		return err
 	}
 
 	if log.V(3) {
 		log.Infof(ctx, "statement %s compiled to:\n%s", stmt, planToString(ctx, plan))
 	}
-	return plan, nil
+
+	// Store the plan for later use.
+	p.curPlan.plan = plan
+
+	return nil
 }
 
 // hideHiddenColumn ensures that if the plan is returning some hidden
@@ -281,7 +323,22 @@ func (p *planner) hideHiddenColumns(
 	return newPlan, nil
 }
 
-// startPlan starts the plan and all its sub-query nodes.
+// close ensures that the plan's resources have been deallocated.
+func (p *planTop) close(ctx context.Context) {
+	p.plan.Close(ctx)
+}
+
+// start starts the plan.
+func (p *planTop) start(params runParams) error {
+	return startPlan(params, p.plan)
+}
+
+// columns retrieves the plan's columns.
+func (p *planTop) columns() sqlbase.ResultColumns {
+	return planColumns(p.plan)
+}
+
+// startPlan starts the given plan and all its sub-query nodes.
 func startPlan(params runParams, plan planNode) error {
 	if err := startExec(params, plan); err != nil {
 		return err
@@ -634,7 +691,24 @@ func (p *planner) newPlan(
 // needed both to type placeholders and to inform pgwire of the types
 // of the result columns. All statements that either support
 // placeholders or have result columns must be handled here.
-func (p *planner) prepare(ctx context.Context, stmt tree.Statement) (planNode, error) {
+// The resulting plan is stored in p.curPlan.
+func (p *planner) prepare(ctx context.Context, stmt tree.Statement) error {
+	// Reinitialize.
+	p.curPlan = planTop{}
+
+	// Prepare the plan.
+	plan, err := p.doPrepare(ctx, stmt)
+	if err != nil {
+		return err
+	}
+
+	// Store the plan for later use.
+	p.curPlan.plan = plan
+
+	return nil
+}
+
+func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode, error) {
 	if plan, err := p.maybePlanHook(ctx, stmt); plan != nil || err != nil {
 		return plan, err
 	}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -159,33 +159,7 @@ type planner struct {
 	// curPlan collects the properties of the current plan being prepared. This state
 	// is undefined at the beginning of the planning of each new statement, and cannot
 	// be reused for an old prepared statement after a new statement has been prepared.
-	//
-	// Note: some additional per-statement state is also stored in
-	// semaCtx (placeholders).
-	// TODO(jordan): investigate whether/how per-plan state like
-	// placeholder data can be concentrated in a single struct.
-	curPlan struct {
-		// deps, if non-nil, collects the table/view dependencies for this query.
-		// Any planNode constructors that resolves a table name or reference in the query
-		// to a descriptor must register this descriptor into planDeps.
-		// This is (currently) used by CREATE VIEW.
-		// TODO(knz): Remove this in favor of a better encapsulated mechanism.
-		deps planDependencies
-
-		// cteNameEnvironment collects the mapping from common table expression alias
-		// to the planNodes that represent their source.
-		cteNameEnvironment cteNameEnvironment
-
-		// hasStar collects whether any star expansion has occurred during
-		// logical plan construction. This is used by CREATE VIEW until
-		// #10028 is addressed.
-		hasStar bool
-		// hasSubqueries collects whether any subqueries expansion has
-		// occurred during logical plan construction.
-		hasSubqueries bool
-		// plannedExecute is true if this planner has planned an EXECUTE statement.
-		plannedExecute bool
-	}
+	curPlan planTop
 
 	// Avoid allocations by embedding commonly used objects and visitors.
 	parser                parser.Parser
@@ -314,16 +288,15 @@ func (p *planner) DistLoader() *DistLoader {
 	return &DistLoader{distSQLPlanner: p.extendedEvalCtx.DistSQLPlanner}
 }
 
-// makeInternalPlan initializes a planNode from a SQL statement string.
-// Close() must be called on the returned planNode after use.
+// makeInternalPlan initializes a plan from a SQL statement string.
+// This clobbers p.curPlan.
+// p.curPlan.Close() must be called after use.
 // This function changes the planner's placeholder map. It is the caller's
 // responsibility to save and restore the old map if desired.
 // This function is not suitable for use in the planNode constructors directly:
 // the returned planNode has already been optimized.
 // Consider also (*planner).delegateQuery(...).
-func (p *planner) makeInternalPlan(
-	ctx context.Context, sql string, args ...interface{},
-) (planNode, error) {
+func (p *planner) makeInternalPlan(ctx context.Context, sql string, args ...interface{}) error {
 	if log.V(2) {
 		log.Infof(ctx, "internal query: %s", sql)
 		if len(args) > 0 {
@@ -332,7 +305,7 @@ func (p *planner) makeInternalPlan(
 	}
 	stmt, err := parser.ParseOne(sql)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	golangFillQueryArguments(&p.semaCtx.Placeholders, args)
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
@@ -373,25 +346,28 @@ func (p *planner) QueryRow(
 func (p *planner) queryRows(
 	ctx context.Context, sql string, args ...interface{},
 ) ([]tree.Datums, error) {
-	oldPlaceholders := p.semaCtx.Placeholders
-	defer func() { p.semaCtx.Placeholders = oldPlaceholders }()
+	// makeInternalPlan() clobbers p.curplan and the placeholder info
+	// map, so we have to save/restore them here.
+	defer func(psave planTop, pisave tree.PlaceholderInfo) {
+		p.semaCtx.Placeholders = pisave
+		p.curPlan = psave
+	}(p.curPlan, p.semaCtx.Placeholders)
 
-	plan, err := p.makeInternalPlan(ctx, sql, args...)
-	if err != nil {
+	if err := p.makeInternalPlan(ctx, sql, args...); err != nil {
 		return nil, err
 	}
-	defer plan.Close(ctx)
+	defer p.curPlan.close(ctx)
 
 	params := runParams{
 		ctx:             ctx,
 		extendedEvalCtx: &p.extendedEvalCtx,
 		p:               p,
 	}
-	if err := startPlan(params, plan); err != nil {
+	if err := p.curPlan.start(params); err != nil {
 		return nil, err
 	}
 	var rows []tree.Datums
-	if err = forEachRow(params, plan, func(values tree.Datums) error {
+	if err := forEachRow(params, p.curPlan.plan, func(values tree.Datums) error {
 		if values != nil {
 			valCopy := append(tree.Datums(nil), values...)
 			rows = append(rows, valCopy)
@@ -406,23 +382,27 @@ func (p *planner) queryRows(
 // exec executes a SQL query string and returns the number of rows
 // affected.
 func (p *planner) exec(ctx context.Context, sql string, args ...interface{}) (int, error) {
-	oldPlaceholders := p.semaCtx.Placeholders
-	defer func() { p.semaCtx.Placeholders = oldPlaceholders }()
-	plan, err := p.makeInternalPlan(ctx, sql, args...)
-	if err != nil {
+	// makeInternalPlan() clobbers p.curplan and the placeholder info
+	// map, so we have to save/restore them here.
+	defer func(psave planTop, pisave tree.PlaceholderInfo) {
+		p.semaCtx.Placeholders = pisave
+		p.curPlan = psave
+	}(p.curPlan, p.semaCtx.Placeholders)
+
+	if err := p.makeInternalPlan(ctx, sql, args...); err != nil {
 		return 0, err
 	}
-	defer plan.Close(ctx)
+	defer p.curPlan.close(ctx)
 
 	params := runParams{
 		ctx:             ctx,
 		extendedEvalCtx: &p.extendedEvalCtx,
 		p:               p,
 	}
-	if err := startPlan(params, plan); err != nil {
+	if err := p.curPlan.start(params); err != nil {
 		return 0, err
 	}
-	return countRowsAffected(params, plan)
+	return countRowsAffected(params, p.curPlan.plan)
 }
 
 func (p *planner) lookupFKTable(

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1993,6 +1993,9 @@ type EvalPlanner interface {
 
 	// SetSequenceValue sets the sequence's value.
 	SetSequenceValue(ctx context.Context, seqName *TableName, newVal int64) error
+
+	// EvalSubquery returns the Datum for the given subquery node.
+	EvalSubquery(expr *Subquery) (Datum, error)
 }
 
 // CtxProvider is anything that can return a Context.
@@ -3274,6 +3277,11 @@ func (t *Array) Eval(ctx *EvalContext) (Datum, error) {
 		}
 	}
 	return array, nil
+}
+
+// Eval implements the TypedExpr interface.
+func (expr *Subquery) Eval(ctx *EvalContext) (Datum, error) {
+	return ctx.Planner.EvalSubquery(expr)
 }
 
 // Eval implements the TypedExpr interface.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3032,12 +3032,6 @@ func (expr *ComparisonExpr) Eval(ctx *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
-func (t *ExistsExpr) Eval(ctx *EvalContext) (Datum, error) {
-	// Exists expressions are handled during subquery expansion.
-	return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unhandled type %T", t)
-}
-
-// Eval implements the TypedExpr interface.
 func (expr *FuncExpr) Eval(ctx *EvalContext) (Datum, error) {
 	args := NewDTupleWithCap(len(expr.Exprs))
 	for _, e := range expr.Exprs {

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -777,7 +777,7 @@ type ArrayFlatten struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ArrayFlatten) Format(ctx *FmtCtx) {
-	ctx.WriteString("ARRAY")
+	ctx.WriteString("ARRAY ")
 	exprFmtWithParen(ctx, node.Subquery)
 }
 

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -557,19 +557,6 @@ func (node *IsOfTypeExpr) Format(ctx *FmtCtx) {
 	ctx.WriteByte(')')
 }
 
-// ExistsExpr represents an EXISTS expression.
-type ExistsExpr struct {
-	Subquery Expr
-
-	typeAnnotation
-}
-
-// Format implements the NodeFormatter interface.
-func (node *ExistsExpr) Format(ctx *FmtCtx) {
-	ctx.WriteString("EXISTS ")
-	exprFmtWithParen(ctx, node.Subquery)
-}
-
 // IfExpr represents an IF expression.
 type IfExpr struct {
 	Cond Expr
@@ -825,6 +812,7 @@ func (node *TypedExprs) String() string {
 // Subquery represents a subquery.
 type Subquery struct {
 	Select SelectStatement
+	Exists bool
 }
 
 // Variable implements the VariableExpr interface.
@@ -832,6 +820,9 @@ func (*Subquery) Variable() {}
 
 // Format implements the NodeFormatter interface.
 func (node *Subquery) Format(ctx *FmtCtx) {
+	if node.Exists {
+		ctx.WriteString("EXISTS ")
+	}
 	ctx.FormatNode(node.Select)
 }
 
@@ -1406,7 +1397,6 @@ func (node *DArray) String() string           { return AsString(node) }
 func (node *DTable) String() string           { return AsString(node) }
 func (node *DOid) String() string             { return AsString(node) }
 func (node *DOidWrapper) String() string      { return AsString(node) }
-func (node *ExistsExpr) String() string       { return AsString(node) }
 func (node *Exprs) String() string            { return AsString(node) }
 func (node *ArrayFlatten) String() string     { return AsString(node) }
 func (node *FuncExpr) String() string         { return AsString(node) }

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -77,6 +77,10 @@ const (
 	// FmtShowTableAliases reveals the table aliases.
 	FmtShowTableAliases
 
+	// FmtSymbolicSubqueries indicates that subqueries must be pretty-printed
+	// using numeric notation (@S123).
+	FmtSymbolicSubqueries
+
 	// If set, strings will be formatted for being contents of ARRAYs.
 	// Used internally in combination with FmtArrays defined below.
 	fmtWithinArray
@@ -150,12 +154,6 @@ func MakeFmtCtx(buf *bytes.Buffer, f FmtFlags) FmtCtx {
 func (ctx *FmtCtx) WithReformatTableNames(fn func(*FmtCtx, *NormalizableTableName)) *FmtCtx {
 	ctx.tableNameFormatter = fn
 	return ctx
-}
-
-// StripTypeFormatting removes the flag that extracts types from the format flags,
-// so as to enable rendering expressions for which types have not been computed yet.
-func (ctx *FmtCtx) StripTypeFormatting() {
-	ctx.flags &= ^FmtShowTypes
 }
 
 // CopyWithFlags creates a new FmtCtx with different formatting flags

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -701,8 +701,9 @@ func (expr *RangeCond) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, 
 }
 
 // TypeCheck implements the Expr interface.
-func (expr *Subquery) TypeCheck(_ *SemaContext, desired types.T) (TypedExpr, error) {
-	panic("subquery nodes must be replaced before type checking")
+func (expr *Subquery) TypeCheck(_ *SemaContext, _ types.T) (TypedExpr, error) {
+	expr.assertTyped()
+	return expr, nil
 }
 
 // TypeCheck implements the Expr interface.

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -432,17 +432,6 @@ func (expr *ComparisonExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedE
 	return expr, err
 }
 
-// TypeCheck implements the Expr interface.
-func (expr *ExistsExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, error) {
-	subqueryTyped, err := expr.Subquery.TypeCheck(ctx, types.Any)
-	if err != nil {
-		return nil, err
-	}
-	expr.Subquery = subqueryTyped
-	expr.typ = types.Bool
-	return expr, nil
-}
-
 var (
 	errOrderByIndexInWindow = pgerror.NewError(pgerror.CodeFeatureNotSupportedError, "ORDER BY INDEX in window definition is not supported")
 	errFilterWithinWindow   = pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "FILTER within a window function call is not yet supported")

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -183,17 +183,6 @@ func (expr *ComparisonExpr) Walk(v Visitor) Expr {
 	return expr
 }
 
-// Walk implements the Expr interface.
-func (expr *ExistsExpr) Walk(v Visitor) Expr {
-	e, changed := WalkExpr(v, expr.Subquery)
-	if changed {
-		exprCopy := *expr
-		exprCopy.Subquery = e
-		return &exprCopy
-	}
-	return expr
-}
-
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (expr *FuncExpr) CopyNode() *FuncExpr {
 	exprCopy := *expr

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -402,7 +402,9 @@ func (expr *RangeCond) Walk(v Visitor) Expr {
 func (expr *Subquery) Walk(v Visitor) Expr {
 	sel, changed := WalkStmt(v, expr.Select)
 	if changed {
-		return &Subquery{sel.(SelectStatement)}
+		exprCopy := *expr
+		exprCopy.Select = sel.(SelectStatement)
+		return &exprCopy
 	}
 	return expr
 }

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -160,9 +160,9 @@ WHERE message LIKE 'fetched: %'
 
 	// We failed to substitute; this is an internal error.
 	err = pgerror.NewErrorf(pgerror.CodeInternalError,
-		"invalid logical plan structure:\n%s", planToString(ctx, plan),
+		"invalid logical plan structure:\n%s", planToString(ctx, plan, nil),
 	).SetDetailf(
-		"while inserting:\n%s", planToString(ctx, tracePlan))
+		"while inserting:\n%s", planToString(ctx, tracePlan, nil))
 	plan.Close(ctx)
 	stmtPlan.Close(ctx)
 	tracePlan.Close(ctx)

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -44,9 +44,10 @@ type subquery struct {
 type subqueryExecMode int
 
 const (
+	execModeUnknown subqueryExecMode = iota
 	// Subquery is argument to EXISTS. Only 0 or 1 row is expected.
 	// Result type is Bool.
-	execModeExists subqueryExecMode = iota
+	execModeExists
 	// Subquery is argument to IN, ANY, SOME, or ALL. Any number of rows
 	// expected. Result type is tuple of rows. As a special case, if
 	// there is only one column selected, the result is a tuple of the

--- a/pkg/sql/subquery_test.go
+++ b/pkg/sql/subquery_test.go
@@ -36,12 +36,12 @@ func TestStartSubqueriesReturnsError(t *testing.T) {
 		t.Fatalf("expected to parse 1 statement, got: %d", len(stmts))
 	}
 	stmt := stmts[0]
-	plan, err := p.makePlan(context.TODO(), Statement{AST: stmt})
-	if err != nil {
+	if err := p.makePlan(context.TODO(), Statement{AST: stmt}); err != nil {
 		t.Fatal(err)
 	}
 	params := runParams{ctx: context.TODO(), p: p, extendedEvalCtx: &p.extendedEvalCtx}
-	if err := startPlan(params, plan); !testutils.IsError(err, `forced`) {
+	if err := p.curPlan.start(params); !testutils.IsError(err, `forced`) {
 		t.Fatalf("expected error from force_error(), got: %v", err)
 	}
+	p.curPlan.close(context.TODO())
 }

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -83,8 +83,8 @@ func (p *planner) Update(
 
 	setExprs := make([]*tree.UpdateExpr, len(n.Exprs))
 	for i, expr := range n.Exprs {
-		// Replace the sub-query nodes.
-		newExpr, err := p.replaceSubqueries(ctx, expr.Expr, len(expr.Names))
+		// Analyze the sub-query nodes.
+		newExpr, err := p.analyzeSubqueries(ctx, expr.Expr, len(expr.Names))
 		if err != nil {
 			return nil, err
 		}
@@ -184,7 +184,7 @@ func (p *planner) Update(
 
 					currentUpdateIdx++
 				}
-			case *subquery:
+			case *tree.Subquery:
 				selectExpr := tree.SelectExpr{Expr: t}
 				desiredTupleType := make(types.TTuple, len(setExpr.Names))
 				for i := range setExpr.Names {
@@ -512,8 +512,8 @@ func (p *planner) namesForExprs(exprs tree.UpdateExprs) (tree.UnresolvedNames, e
 		if expr.Tuple {
 			n := -1
 			switch t := expr.Expr.(type) {
-			case *subquery:
-				if tup, ok := t.typ.(types.TTuple); ok {
+			case *tree.Subquery:
+				if tup, ok := t.ResolvedType().(types.TTuple); ok {
 					n = len(tup)
 				}
 			case *tree.Tuple:

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -59,8 +59,7 @@ func (p *planner) Values(
 
 	v.columns = make(sqlbase.ResultColumns, 0, numCols)
 
-	defer func(prev bool) { p.curPlan.hasSubqueries = prev }(p.curPlan.hasSubqueries)
-	p.curPlan.hasSubqueries = false
+	lastKnownSubqueryIndex := len(p.curPlan.subqueryPlans)
 
 	for num, tuple := range n.Tuples {
 		if a, e := len(tuple.Exprs), numCols; a != e {
@@ -106,7 +105,7 @@ func (p *planner) Values(
 	// that it must always be called unless an error is returned from a planNode
 	// constructor. This would simplify the Close contract, but would make some
 	// code (like in planner.SelectClause) more messy.
-	v.isConst = !p.curPlan.hasSubqueries
+	v.isConst = (len(p.curPlan.subqueryPlans) == lastKnownSubqueryIndex)
 	return v, nil
 }
 

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -43,10 +43,6 @@ type planObserver struct {
 
 	// leaveNode is invoked upon leaving a tree node.
 	leaveNode func(nodeName string, plan planNode) error
-
-	// subqueryNode is invoked for each sub-query node. It can return
-	// an error to stop the recursion entirely.
-	subqueryNode func(ctx context.Context, sq *subquery) error
 }
 
 // walkPlan performs a depth-first traversal of the plan given as
@@ -62,10 +58,6 @@ func walkPlan(ctx context.Context, plan planNode, observer planObserver) error {
 type planVisitor struct {
 	observer planObserver
 	ctx      context.Context
-
-	// subplans is a temporary accumulator array used when collecting
-	// sub-query plans at each planNode.
-	subplans []planNode
 	err      error
 }
 
@@ -119,24 +111,25 @@ func (v *planVisitor) visit(plan planNode) {
 			v.observer.attr(name, "size", description)
 		}
 
-		var subplans []planNode
-		for i, tuple := range n.tuples {
-			for j, expr := range tuple {
-				if n.columns[j].Omitted {
-					continue
+		if v.observer.expr != nil {
+			for i, tuple := range n.tuples {
+				for j, expr := range tuple {
+					if n.columns[j].Omitted {
+						continue
+					}
+					var fieldName string
+					if v.observer.attr != nil {
+						fieldName = fmt.Sprintf("row %d, expr", i)
+					}
+					v.expr(name, fieldName, j, expr)
 				}
-				var fieldName string
-				if v.observer.attr != nil {
-					fieldName = fmt.Sprintf("row %d, expr", i)
-				}
-				subplans = v.expr(name, fieldName, j, expr, subplans)
 			}
 		}
-		v.subqueries(name, subplans)
 
 	case *valueGenerator:
-		subplans := v.expr(name, "expr", -1, n.expr, nil)
-		v.subqueries(name, subplans)
+		if v.observer.expr != nil {
+			v.expr(name, "expr", -1, n.expr)
+		}
 
 	case *scanNode:
 		if v.observer.attr != nil {
@@ -158,20 +151,22 @@ func (v *planVisitor) visit(plan planNode) {
 				v.observer.attr(name, "limit", fmt.Sprintf("%d", n.hardLimit))
 			}
 		}
-		subplans := v.expr(name, "filter", -1, n.filter, nil)
-		v.subqueries(name, subplans)
+		if v.observer.expr != nil {
+			v.expr(name, "filter", -1, n.filter)
+		}
 
 	case *filterNode:
-		subplans := v.expr(name, "filter", -1, n.filter, nil)
-		v.subqueries(name, subplans)
+		if v.observer.expr != nil {
+			v.expr(name, "filter", -1, n.filter)
+		}
 		v.visit(n.source.plan)
 
 	case *renderNode:
-		var subplans []planNode
-		for i, r := range n.render {
-			subplans = v.expr(name, "render", i, r, subplans)
+		if v.observer.expr != nil {
+			for i, r := range n.render {
+				v.expr(name, "render", i, r)
+			}
 		}
-		v.subqueries(name, subplans)
 		v.visit(n.source.plan)
 
 	case *indexJoinNode:
@@ -218,15 +213,17 @@ func (v *planVisitor) visit(plan planNode) {
 				v.observer.attr(name, "mergeJoinOrder", order.AsString(eqCols))
 			}
 		}
-		subplans := v.expr(name, "pred", -1, n.pred.onCond, nil)
-		v.subqueries(name, subplans)
+		if v.observer.expr != nil {
+			v.expr(name, "pred", -1, n.pred.onCond)
+		}
 		v.visit(n.left.plan)
 		v.visit(n.right.plan)
 
 	case *limitNode:
-		subplans := v.expr(name, "count", -1, n.countExpr, nil)
-		subplans = v.expr(name, "offset", -1, n.offsetExpr, subplans)
-		v.subqueries(name, subplans)
+		if v.observer.expr != nil {
+			v.expr(name, "count", -1, n.countExpr)
+			v.expr(name, "offset", -1, n.offsetExpr)
+		}
 		v.visit(n.plan)
 
 	case *distinctNode:
@@ -287,9 +284,10 @@ func (v *planVisitor) visit(plan planNode) {
 		v.visit(n.plan)
 
 	case *groupNode:
-		var subplans []planNode
-		for i, agg := range n.funcs {
-			subplans = v.expr(name, "aggregate", i, agg.expr, subplans)
+		if v.observer.expr != nil {
+			for i, agg := range n.funcs {
+				v.expr(name, "aggregate", i, agg.expr)
+			}
 		}
 		if v.observer.attr != nil && n.numGroupCols > 0 {
 			v.observer.attr(name, "group by", fmt.Sprintf("@1-@%d", n.numGroupCols))
@@ -298,14 +296,14 @@ func (v *planVisitor) visit(plan planNode) {
 		v.visit(n.plan)
 
 	case *windowNode:
-		var subplans []planNode
-		for i, agg := range n.funcs {
-			subplans = v.expr(name, "window", i, agg.expr, subplans)
+		if v.observer.expr != nil {
+			for i, agg := range n.funcs {
+				v.expr(name, "window", i, agg.expr)
+			}
+			for i, rexpr := range n.windowRender {
+				v.expr(name, "render", i, rexpr)
+			}
 		}
-		for i, rexpr := range n.windowRender {
-			subplans = v.expr(name, "render", i, rexpr, subplans)
-		}
-		v.subqueries(name, subplans)
 		v.visit(n.plan)
 
 	case *unionNode:
@@ -333,20 +331,20 @@ func (v *planVisitor) visit(plan planNode) {
 			v.observer.attr(name, "into", buf.String())
 		}
 
-		var subplans []planNode
-		for i, dexpr := range n.defaultExprs {
-			subplans = v.expr(name, "default", i, dexpr, subplans)
+		if v.observer.expr != nil {
+			for i, dexpr := range n.defaultExprs {
+				v.expr(name, "default", i, dexpr)
+			}
+			for i, cexpr := range n.checkHelper.exprs {
+				v.expr(name, "check", i, cexpr)
+			}
+			for i, rexpr := range n.rh.exprs {
+				v.expr(name, "returning", i, rexpr)
+			}
+			n.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
+				v.expr(name, d, i, e)
+			})
 		}
-		for i, cexpr := range n.checkHelper.exprs {
-			subplans = v.expr(name, "check", i, cexpr, subplans)
-		}
-		for i, rexpr := range n.rh.exprs {
-			subplans = v.expr(name, "returning", i, rexpr, subplans)
-		}
-		n.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
-			subplans = v.expr(name, d, i, e, subplans)
-		})
-		v.subqueries(name, subplans)
 		v.visit(n.run.rows)
 
 	case *updateNode:
@@ -363,28 +361,28 @@ func (v *planVisitor) visit(plan planNode) {
 				v.observer.attr(name, "set", buf.String())
 			}
 		}
-		var subplans []planNode
-		for i, rexpr := range n.rh.exprs {
-			subplans = v.expr(name, "returning", i, rexpr, subplans)
+		if v.observer.expr != nil {
+			for i, rexpr := range n.rh.exprs {
+				v.expr(name, "returning", i, rexpr)
+			}
+			n.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
+				v.expr(name, d, i, e)
+			})
 		}
-		n.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
-			subplans = v.expr(name, d, i, e, subplans)
-		})
-		v.subqueries(name, subplans)
 		v.visit(n.run.rows)
 
 	case *deleteNode:
 		if v.observer.attr != nil {
 			v.observer.attr(name, "from", n.tableDesc.Name)
 		}
-		var subplans []planNode
-		for i, rexpr := range n.rh.exprs {
-			subplans = v.expr(name, "returning", i, rexpr, subplans)
+		if v.observer.expr != nil {
+			for i, rexpr := range n.rh.exprs {
+				v.expr(name, "returning", i, rexpr)
+			}
+			n.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
+				v.expr(name, d, i, e)
+			})
 		}
-		n.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
-			subplans = v.expr(name, d, i, e, subplans)
-		})
-		v.subqueries(name, subplans)
 		v.visit(n.run.rows)
 
 	case *createTableNode:
@@ -398,16 +396,15 @@ func (v *planVisitor) visit(plan planNode) {
 		}
 
 	case *setVarNode:
-		var subplans []planNode
-		for i, texpr := range n.typedValues {
-			subplans = v.expr(name, "value", i, texpr, subplans)
+		if v.observer.expr != nil {
+			for i, texpr := range n.typedValues {
+				v.expr(name, "value", i, texpr)
+			}
 		}
-		v.subqueries(name, subplans)
 
 	case *setClusterSettingNode:
-		if n.value != nil {
-			subplans := v.expr(name, "value", -1, n.value, nil)
-			v.subqueries(name, subplans)
+		if v.observer.expr != nil && n.value != nil {
+			v.expr(name, "value", -1, n.value)
 		}
 
 	case *delayedNode:
@@ -437,81 +434,25 @@ func (v *planVisitor) visit(plan planNode) {
 		v.visit(n.plan)
 
 	case *cancelQueryNode:
-		subplans := v.expr(name, "queryID", -1, n.queryID, nil)
-		v.subqueries(name, subplans)
+		if v.observer.expr != nil {
+			v.expr(name, "queryID", -1, n.queryID)
+		}
 
 	case *controlJobNode:
-		subplans := v.expr(name, "jobID", -1, n.jobID, nil)
-		v.subqueries(name, subplans)
-	}
-}
-
-// subqueries informs the observer that the following sub-plans are
-// for sub-queries.
-func (v *planVisitor) subqueries(nodeName string, subplans []planNode) {
-	if len(subplans) == 0 || v.err != nil {
-		return
-	}
-	if v.observer.attr != nil {
-		v.observer.attr(nodeName, "subqueries", strconv.Itoa(len(subplans)))
-	}
-	for _, p := range subplans {
-		v.visit(p)
+		if v.observer.expr != nil {
+			v.expr(name, "jobID", -1, n.jobID)
+		}
 	}
 }
 
 // expr wraps observer.expr() and provides it with the current node's
-// name. It also collects the plans for the sub-queries.
-func (v *planVisitor) expr(
-	nodeName string, fieldName string, n int, expr tree.Expr, subplans []planNode,
-) []planNode {
+// name.
+func (v *planVisitor) expr(nodeName string, fieldName string, n int, expr tree.Expr) {
 	if v.err != nil {
-		return subplans
+		return
 	}
-
-	if v.observer.expr != nil {
-		v.observer.expr(nodeName, fieldName, n, expr)
-	}
-
-	if expr != nil {
-		// Note: the recursion through WalkExprConst does nothing else
-		// than calling observer.subqueryNode() and collect subplans in
-		// v.subplans, in particular it does not recurse into the
-		// collected subplans (this recursion is performed by visit() only
-		// after all the subplans have been collected). Therefore, there
-		// is no risk that v.subplans will be clobbered by a recursion
-		// into visit().
-		v.subplans = subplans
-		tree.WalkExprConst(v, expr)
-		subplans = v.subplans
-		v.subplans = nil
-	}
-	return subplans
+	v.observer.expr(nodeName, fieldName, n, expr)
 }
-
-// planVisitor is also an Expr visitor whose task is to collect
-// sub-query plans for the surrounding planNode.
-var _ tree.Visitor = &planVisitor{}
-
-func (v *planVisitor) VisitPre(expr tree.Expr) (bool, tree.Expr) {
-	if v.err != nil {
-		return false, expr
-	}
-	if sq, ok := expr.(*subquery); ok {
-		if v.observer.subqueryNode != nil {
-			if err := v.observer.subqueryNode(v.ctx, sq); err != nil {
-				v.err = err
-				return false, expr
-			}
-		}
-		if sq.plan != nil {
-			v.subplans = append(v.subplans, sq.plan)
-		}
-		return false, expr
-	}
-	return true, expr
-}
-func (v *planVisitor) VisitPost(expr tree.Expr) tree.Expr { return expr }
 
 // nodeName returns the name of the given planNode as string.  The
 // node's current state is taken into account, e.g. sortNode has


### PR DESCRIPTION
This work is the final part of the "SQL leaf data" RFC which can be implemented for the 2.0 release. It also makes a step forward towards plan caching.

Fixes #21218.
Fixes #21300.
Informs #20298.

cc @RaduBerinde.

There are really two commits of note in here:

### sql: reify logical plans into a dedicated struct

Prior to this patch, most of the `sql` package was written under the
assumption that there is nothing more to a logical plan than a
reference to its root `planNode`. The various APIs were passing
`planNode` references to each other or as return values, as if that
was sufficient to "communicate a logical plan" from one place to
another.

Alas, in reality this is not so: a logical plan is really composed of
(at least) the following things:

- the placeholder information (currently in `planner.semaCtx.Placeholders`)
- the various computed properties of the logical plan in `planner.curPlan`
  (including e.g. `hasStar`, its `cteNameEnvironment`, etc.)
- in the future, the set of its sub-query plans (these currently hang
  off the scalar expression trees, but that's clearly not their place.
  They belong to a data structure alongside the root tree reference).

It is incorrect to move a `planNode` reference to the root of a logical
plan from one place to another without also preserving these various
other things.

The code happened to "mostly work" because most of it didn't truly
move the `planNode` root from one place to another -- despite the
agitation of moving that root reference from one point to another,
most of the code happened to always be working on "the current plan"
for the current planner, that is, the plan that was most recently
compiled.

In that story, `makePlan` produces two things: an explicit `planNode`
reference and an implicit set of other things annotated in the
`planner` object. The explicit thing navigates around the code,
although its true meaning cannot be dissociated from the silent things
laying in `planner`. However its true meaning is not lost, for every
where the `planNode` reference is finally "consumed", the silent
things also get picked up from the `planner` for consumption alongside
it.

One should not expect however that having dissociated state didn't
really matter, or was a mere discomfort.

There was at least one bug which I found while working on that
dissociative disorder: the function `makeInternalPlan()`, meant for
use "within a plan" to compute a sub-result, was documented to
"clobber its placeholder information". Alas, this is not the only
thing it was clobbering: by virtue of calling `makePlan`, it was also
clobbering *everything* associated to the "current plan" -- all the
things computed for the sub-plan, in fact, including the placeholder
information but also the other computed properties. Fortunately, I was
unable to trace a code path that would suggest this bug exhibits
itself in the wild, but it was very much alive nonetheless.

So, what happens in this patch is that all the state associated with a
logical plan is given a name: `planTop`. It is now a struct defined
in `plan.go`.

The implicit state captured in the `planner` is not implicit any more:
the `planner`'s `curPlan` member is now an instance of `planTop`.
Also, the root `planNode` reference is now also stored in `planTop`.

Consequently:

- `makePlan` is now defined to compile the logical plan in
  `planner.curPlan`. It does not "return a logical plan" any more; it
  *prepares the logical plan in the area of the `planner struct`
  (`curPlan`) dedicated to hold the logical plan details.

  `makePlan` is now also clearly documented as clobbering the entire
  `planner.curPlan` field.

- the aforementioned bug is fixed by ensuring that the places
  where "the current logical plan state must be saved" save the entire
  `planTop` struct, not just the placeholder information.

- the ritualistic, but mistakenly dissociated, passing around of
  `planNode` root references is removed throughout most of the code,
  in favor of clearer and more deliberate naming of the "current
  logical plan" via explicit accesses to `p.curPlan`.

There are two APIs that could have been modified accordingly, but were
not in this patch, considering a potential future optimization:
`execDistSQL` and `execClassic`. These could also operate "on the
current logical plan" and pick up the tree root from `planner.curPlan`
like the rest. However I chose not to do this in this patch, because I
foresee that these methods could be called on individual sub-query
plans in a later patch.

### sql, sem/tree: avoid storing sub-query plans inside scalar expressions 

Prior to this patch, logical planning for (uncorrelated) subqueries
would work more-or-less like this:

- a first recursion would traverse all scalar expressions (`tree.Expr`) and
  replace any `tree.Subquery` by a `sql.subquery` object.
  It would also recursively create a logical plan and store it inside
  the `sql.subquery` object for later use.
- during logical planning, another recursion would traverse all scalar
  expressions and perform logical planning optimizations in turn
  on each found `sql.subquery` object.
- finally just before execution, another recursion would traverse  all
  scalar expressions (again!) to start the sub-query plans and compute
  their (datum) results.

This patch changes this according to the RFC on "SQL leaf data"
(`docs/RFCS/20170926_sql_aux_data.md`): the initial traversal now
*extracts* the subquery details into a top-level slice maintained for
the entire logical plan. Further processing that needs to "operate on
all subqueries" can find the sub-query plans, if any, using the
top-level slice. No further traversal of all scalar expressions is
needed.

Salient changes:

- the slice of sub-query objects (`sql.subquery`) is stored in the new
  `planTop` struct recently introduced. That object is responsible for
  closing the sub-query plans when its own `close()` method is called.

- because recursion to all expressions is not needed any more to
  collect subquery plan, the code in `walk.go` is greatly simplified.

- the `tree.Subquery` node is extended so that it can remain in the
  scalar expression tree up to final evaluation. To achieve this, the
  index into the top-level slice, as well as the computed `types.T`,
  is now stored in the `tree.Subquery`. Its `Eval` method, which now
  needs to be functional, retrieves the computed subquery datum using
  a new `EvalSubquery` method on the `evalCtx.Planner` object.

- the code for EXPLAIN(PLAN) needs to be able to observe sub-queries
  locally without running them, so now it needs to prevent the
  sub-queries of the plan being observed from being stored in the
  top-level slice (previously, it didn't need to prevent anything --
  its sub-query plans were simply those present in scalar expression
  trees of its observed plan). It achieves this by temporarily
  overriding the sub-query slice while the explainPlanNode is being
  built.

- the code for EXPLAIN is extended to show the sub-queries at the top
  of the logical plan by introducing a new virtual "root" node when
  there are subqueries present.

  In addition, the subquery execution mode is now also displayed in
  the EXPLAIN output, to aid troubleshooting.

  Also, the link/relationship between the
  `tree.Subquery` nodes in scalar expressions and the top-level slice
  of subquery is now revealed in the output of EXPLAIN by using
  symbolic identiifers for the subqueries.

  For example:

```
root@:26257/> explain(exprs) select 123+(select 1);
+-------------------------+-----------+-------------+
|          Tree           |   Field   | Description |
+-------------------------+-----------+-------------+
| root                    |           |             |
|  ├── render             |           |             |
|  │    │                 | render 0  | 123 + @S1   |
|  │    └── emptyrow      |           |             |
|  └── subquery           |           |             |
|       │                 | id        | @S1         |
|       │                 | sql       | (SELECT 1)  |
|       │                 | exec mode | one row     |
|       └── render        |           |             |
|            │            | render 0  |           1 |
|            └── emptyrow |           |             |
+-------------------------+-----------+-------------+

root@:26257/> explain(exprs) select 123+(select 1 from (select 456+(select 2) from t.kv));
+--------------------------+-----------+-----------------------------------------------------+
|           Tree           |   Field   |                     Description                     |
+--------------------------+-----------+-----------------------------------------------------+
| root                     |           |                                                     |
|  ├── render              |           |                                                     |
|  │    │                  | render 0  | 123 + @S2                                           |
|  │    └── emptyrow       |           |                                                     |
|  ├── subquery            |           |                                                     |
|  │    │                  | id        | @S1                                                 |
|  │    │                  | sql       | (SELECT 2)                                          |
|  │    │                  | exec mode | one row                                             |
|  │    └── render         |           |                                                     |
|  │         │             | render 0  |                                                   2 |
|  │         └── emptyrow  |           |                                                     |
|  └── subquery            |           |                                                     |
|       │                  | id        | @S2                                                 |
|       │                  | sql       | (SELECT 1 FROM (SELECT 456 + (SELECT 2) FROM t.kv)) |
|       │                  | exec mode | one row                                             |
|       └── render         |           |                                                     |
|            │             | render 0  |                                                   1 |
|            └── render    |           |                                                     |
|                 │        | render 0  | NULL                                                |
|                 └── scan |           |                                                     |
|                          | table     | kv@primary                                          |
|                          | spans     | ALL                                                 |
+--------------------------+-----------+-----------------------------------------------------+
```
  
  