### PR TITLE
sql: expose partitions in crdb_internal vtable

### DIFF
--- a/pkg/ccl/sqlccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/sqlccl/logictestccl/testdata/logic_test/crdb_internal
@@ -1,0 +1,48 @@
+# LogicTest: default
+
+query IITTI colnames
+SELECT * FROM crdb_internal.partitions
+----
+table_id  index_id  parent_name  name  columns
+
+statement ok
+CREATE TABLE t1 (
+  a INT,
+  b INT,
+  c INT,
+  PRIMARY KEY (a, b, c),
+  INDEX (a, b) PARTITION BY LIST (a, b) (
+    PARTITION p00 VALUES IN ((0, 0))
+  )
+) PARTITION BY LIST (a) (
+    PARTITION p12 VALUES IN (1, 2) PARTITION BY LIST (b) (
+        PARTITION p12p3 VALUES IN (3) PARTITION BY LIST (c) (
+            PARTITION p12p3p8 VALUES IN (8)
+        ),
+        PARTITION pd VALUES IN (DEFAULT)
+    ),
+    PARTITION p6 VALUES IN (6) PARTITION BY RANGE (b) (
+        PARTITION p6p7 VALUES FROM (MINVALUE) TO (7),
+        PARTITION p6p8 VALUES FROM (7) TO (8),
+        PARTITION p6px VALUES FROM (8) TO (MAXVALUE)
+    )
+)
+
+statement ok
+CREATE table t2 (a STRING PRIMARY KEY) PARTITION BY LIST (a) (
+  PARTITION pfoo VALUES IN ('foo')
+)
+
+query IITTI
+SELECT * FROM crdb_internal.partitions ORDER BY table_id, index_id, name
+----
+51  1  NULL  p12      1
+51  1  p12   p12p3    1
+51  1  p12p3 p12p3p8  1
+51  1  NULL  p6       1
+51  1  p6    p6p7     1
+51  1  p6    p6p8     1
+51  1  p6    p6px     1
+51  1  p12   pd       1
+51  2  NULL  p00      2
+52  1  NULL  pfoo     1

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -165,7 +165,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   5 columns, 84 rows
+·                      size   5 columns, 85 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -222,7 +222,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      16 columns, 712 rows
+                     │                     size      16 columns, 717 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -223,6 +223,7 @@ crdb_internal       node_queries
 crdb_internal       node_runtime_info
 crdb_internal       node_sessions
 crdb_internal       node_statement_statistics
+crdb_internal       partitions
 crdb_internal       ranges
 crdb_internal       schema_changes
 crdb_internal       session_trace
@@ -395,6 +396,7 @@ def            crdb_internal       node_queries               SYSTEM VIEW  1
 def            crdb_internal       node_runtime_info          SYSTEM VIEW  1
 def            crdb_internal       node_sessions              SYSTEM VIEW  1
 def            crdb_internal       node_statement_statistics  SYSTEM VIEW  1
+def            crdb_internal       partitions                 SYSTEM VIEW  1
 def            crdb_internal       ranges                     SYSTEM VIEW  1
 def            crdb_internal       schema_changes             SYSTEM VIEW  1
 def            crdb_internal       session_trace              SYSTEM VIEW  1


### PR DESCRIPTION
All but the last commit are split into #21263 and #21299.

---

Provide a structured means of accessing a table's partitioning scheme by
exposing a new virtual table, crdb_internal.partitions.

Every PARTITION that appears in a PARTITIONING scheme corresponds to
exactly one row in the new table. With some care, partition boundaries
can be extracted from the list_values, range_from, and range_to fields,
which are string-encoded versions of the boundary datums. (We can't
provide type-safe versions, as the types of the boundary datums depend
on the types of the partitioned index.)

Fixes (half of) #20891.

Release note: None