### PR TITLE
sql: disallow a column being backfilled in an expression

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -143,7 +143,7 @@ func (p *planner) validateCheckExpr(
 		return err
 	}
 	sel := &tree.SelectClause{
-		Exprs: sqlbase.ColumnsSelectors(tableDesc.Columns),
+		Exprs: sqlbase.ColumnsSelectors(tableDesc.Columns, false /* forUpdateOrDelete */),
 		From:  &tree.From{Tables: tree.TableExprs{tableName}},
 		Where: &tree.Where{Expr: &tree.NotExpr{Expr: expr}},
 	}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -100,7 +100,7 @@ func (p *planner) Delete(
 	// performs index selection. We cannot perform index selection
 	// properly until the placeholder values are known.
 	rows, err := p.SelectClause(ctx, &tree.SelectClause{
-		Exprs: sqlbase.ColumnsSelectors(rd.FetchCols),
+		Exprs: sqlbase.ColumnsSelectors(rd.FetchCols, true /* forUpdateOrDelete */),
 		From:  &tree.From{Tables: []tree.TableExpr{n.Table}},
 		Where: n.Where,
 	}, n.OrderBy, n.Limit, nil, nil, publicAndNonPublicColumns)

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -640,6 +640,22 @@ CREATE INDEX allidx ON t.test (k, v);
 					}
 				}
 
+				// Using the mutation column as an index expression is disallowed.
+				_, err := sqlDB.Exec(`UPDATE t.test SET v = 'u' WHERE i < 'a'`)
+				if !testutils.IsError(err, `column "i" is being backfilled`) {
+					t.Error(err)
+				}
+				// TODO(vivek): Fix this error to return the same is being
+				// backfilled error.
+				_, err = sqlDB.Exec(`UPDATE t.test SET i = 'u' WHERE k = 'a'`)
+				if !testutils.IsError(err, `column "i" does not exist`) {
+					t.Error(err)
+				}
+				_, err = sqlDB.Exec(`DELETE FROM t.test WHERE i < 'a'`)
+				if !testutils.IsError(err, `column "i" is being backfilled`) {
+					t.Error(err)
+				}
+
 				// Update a row without specifying  mutation column "i".
 				if useUpsert {
 					mTest.Exec(t, `UPSERT INTO t.test VALUES ('a', 'u')`)

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -66,6 +66,10 @@ type scanNode struct {
 	// Map used to get the index for columns in cols.
 	colIdxMap map[sqlbase.ColumnID]int
 
+	// The number of backfill columns among cols. These backfill
+	// columns are always the last columns within cols.
+	numBackfillColumns int
+
 	spans   []roachpb.Span
 	reverse bool
 	props   physicalProps
@@ -110,7 +114,10 @@ type scanNode struct {
 type scanVisibility int
 
 const (
-	publicColumns             scanVisibility = 0
+	publicColumns scanVisibility = 0
+	// Use this to request mutation columns that are currently being
+	// backfilled. These columns are needed to correctly update/delete
+	// a row by correctly constructing ColumnFamilies and Indexes.
 	publicAndNonPublicColumns scanVisibility = 1
 )
 
@@ -400,6 +407,9 @@ func (n *scanNode) initDescDefaults(
 	}
 
 	// Set up the rest of the scanNode.
+	if n.numBackfillColumns != 0 {
+		panic(fmt.Sprintf("%d backfill columns, already initialized", n.numBackfillColumns))
+	}
 	switch scanVisibility {
 	case publicColumns:
 		// Mutations are invisible.
@@ -411,9 +421,11 @@ func (n *scanNode) initDescDefaults(
 				// middle of a schema change.
 				col.Nullable = true
 				n.cols = append(n.cols, col)
+				n.numBackfillColumns++
 			}
 		}
 	}
+
 	n.resultColumns = sqlbase.ResultColumnsFromColDescs(n.cols)
 	n.colIdxMap = make(map[sqlbase.ColumnID]int, len(n.cols))
 	for i, c := range n.cols {

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -77,7 +77,7 @@ func (o *sqlCheckConstraintCheckOperation) Start(params runParams) error {
 	}
 	normalizableTableName := &tree.NormalizableTableName{TableNameReference: o.tableName}
 	sel := &tree.SelectClause{
-		Exprs: sqlbase.ColumnsSelectors(o.tableDesc.Columns),
+		Exprs: sqlbase.ColumnsSelectors(o.tableDesc.Columns, false /* forUpdateOrDelete */),
 		From: &tree.From{
 			Tables: tree.TableExprs{normalizableTableName},
 		},

--- a/pkg/sql/sem/tree/var_name.go
+++ b/pkg/sql/sem/tree/var_name.go
@@ -145,6 +145,12 @@ type ColumnItem struct {
 	// Selector defines which sub-part of the variable is being
 	// accessed.
 	Selector NameParts
+
+	// This column is a selector column expression used in a SELECT
+	// for an UPDATE/DELETE.
+	// TODO(vivek): Do not artificially create such expressions
+	// when scanning columns for an UPDATE/DELETE.
+	ForUpdateOrDelete bool
 }
 
 // Format implements the NodeFormatter interface.

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2015,11 +2015,12 @@ func (desc *TableDescriptor) ColumnTypes() []ColumnType {
 }
 
 // ColumnsSelectors generates Select expressions for cols.
-func ColumnsSelectors(cols []ColumnDescriptor) tree.SelectExprs {
+func ColumnsSelectors(cols []ColumnDescriptor, forUpdateOrDelete bool) tree.SelectExprs {
 	exprs := make(tree.SelectExprs, len(cols))
 	colItems := make([]tree.ColumnItem, len(cols))
 	for i, col := range cols {
 		colItems[i].ColumnName = tree.Name(col.Name)
+		colItems[i].ForUpdateOrDelete = forUpdateOrDelete
 		exprs[i].Expr = &colItems[i]
 	}
 	return exprs

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -132,7 +132,7 @@ func (p *planner) Update(
 	// We construct a query containing the columns being updated, and then later merge the values
 	// they are being updated with into that renderNode to ideally reuse some of the queries.
 	rows, err := p.SelectClause(ctx, &tree.SelectClause{
-		Exprs: sqlbase.ColumnsSelectors(ru.FetchCols),
+		Exprs: sqlbase.ColumnsSelectors(ru.FetchCols, true /* forUpdateOrDelete */),
 		From:  &tree.From{Tables: []tree.TableExpr{n.Table}},
 		Where: n.Where,
 	}, n.OrderBy, n.Limit, nil /* with */, nil /*desiredTypes*/, publicAndNonPublicColumns)


### PR DESCRIPTION
Before this change a column being backfilled could be used
in any arbitrary expression and the system would panic when
it used such a column in an index constraint expression.

fixes #18316

Release note (bug fix): fix crash when using a column being
backfilled in an index constraint