### PR TITLE
ts: Enable disabling timeseries storage

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -94,6 +94,7 @@ sql.trace.log_statement_execute                    false          b     set to t
 sql.trace.session_eventlog.enabled                 false          b     set to true to enable session tracing
 sql.trace.txn.enable_threshold                     0s             d     duration beyond which all transactions are traced (set to 0 to disable)
 timeseries.resolution_10s.storage_duration         720h0m0s       d     the amount of time to store timeseries data
+timeseries.storage.enabled                         true           b     if set, periodic timeseries data is stored within the cluster; disabling is not recommended unless you are storing the data elsewhere
 trace.debug.enable                                 false          b     if set, traces for recent requests can be seen in the /debug page
 trace.lightstep.token                              ·              s     if set, traces go to Lightstep using this token
 trace.zipkin.collector                             ·              s     if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.

--- a/pkg/ts/db.go
+++ b/pkg/ts/db.go
@@ -33,6 +33,14 @@ var (
 	resolution10sDefaultPruneThreshold = 30 * 24 * time.Hour
 )
 
+// TimeseriesStorageEnabled controls whether to store timeseries data to disk.
+var TimeseriesStorageEnabled = settings.RegisterBoolSetting(
+	"timeseries.storage.enabled",
+	"if set, periodic timeseries data is stored within the cluster; disabling is not recommended "+
+		"unless you are storing the data elsewhere",
+	true,
+)
+
 // Resolution10StoreDuration defines the amount of time to store internal metrics
 var Resolution10StoreDuration = settings.RegisterDurationSetting(
 	"timeseries.resolution_10s.storage_duration",
@@ -43,6 +51,7 @@ var Resolution10StoreDuration = settings.RegisterDurationSetting(
 // DB provides Cockroach's Time Series API.
 type DB struct {
 	db *client.DB
+	st *cluster.Settings
 
 	// pruneAgeByResolution maintains a suggested maximum age per resolution; data
 	// which is older than the given threshold for a resolution is considered
@@ -58,6 +67,7 @@ func NewDB(db *client.DB, settings *cluster.Settings) *DB {
 	}
 	return &DB{
 		db: db,
+		st: settings,
 		pruneThresholdByResolution: pruneThresholdByResolution,
 	}
 }
@@ -122,6 +132,10 @@ func (p *poller) start() {
 // poll retrieves data from the underlying DataSource a single time, storing any
 // returned time series data on the server.
 func (p *poller) poll() {
+	if !TimeseriesStorageEnabled.Get(&p.db.st.SV) {
+		return
+	}
+
 	bgCtx := p.AnnotateCtx(context.Background())
 	if err := p.stopper.RunTask(bgCtx, "ts.poller: poll", func(bgCtx context.Context) {
 		data := p.source.GetTimeSeriesData()
@@ -143,6 +157,10 @@ func (p *poller) poll() {
 // StoreData writes the supplied time series data to the cockroach server.
 // Stored data will be sampled at the supplied resolution.
 func (db *DB) StoreData(ctx context.Context, r Resolution, data []tspb.TimeSeriesData) error {
+	if !TimeseriesStorageEnabled.Get(&db.st.SV) {
+		return nil
+	}
+
 	var kvs []roachpb.KeyValue
 
 	// Process data collection: data is converted to internal format, and a key

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -161,6 +161,10 @@ func (tm *testModel) assertKeyCount(expected int) {
 }
 
 func (tm *testModel) storeInModel(r Resolution, data tspb.TimeSeriesData) {
+	if !TimeseriesStorageEnabled.Get(&tm.Cfg.Settings.SV) {
+		return
+	}
+
 	// Note the source, used to construct keys for model queries.
 	tm.seenSources[data.Source] = struct{}{}
 
@@ -403,6 +407,78 @@ func TestPollSource(t *testing.T) {
 		t.Errorf("testSource was called %d times, expected %d", a, e)
 	}
 	tm.assertKeyCount(3)
+	tm.assertModelCorrect()
+}
+
+// TestDisableStorage verifies that disabling timeseries storage via the cluster
+// setting works properly.
+func TestDisableStorage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tm := newTestModel(t)
+	tm.Start()
+	defer tm.Stop()
+	TimeseriesStorageEnabled.Override(&tm.Cfg.Settings.SV, false)
+
+	// Basic storage operation: one data point.
+	tm.storeTimeSeriesData(Resolution10s, []tspb.TimeSeriesData{
+		{
+			Name: "test.metric",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				datapoint(-446061360000000000, 100),
+			},
+		},
+	})
+	tm.assertKeyCount(0)
+	tm.assertModelCorrect()
+
+	testSource := modelDataSource{
+		model:   tm,
+		r:       Resolution10s,
+		stopper: stop.NewStopper(),
+		datasets: [][]tspb.TimeSeriesData{
+			{
+				{
+					Name:   "test.metric.float",
+					Source: "cpu01",
+					Datapoints: []tspb.TimeSeriesDatapoint{
+						datapoint(1428713843000000000, 100.0),
+						datapoint(1428713843000000001, 50.2),
+						datapoint(1428713843000000002, 90.9),
+					},
+				},
+				{
+					Name:   "test.metric.float",
+					Source: "cpu02",
+					Datapoints: []tspb.TimeSeriesDatapoint{
+						datapoint(1428713843000000000, 900.8),
+						datapoint(1428713843000000001, 30.12),
+						datapoint(1428713843000000002, 72.324),
+					},
+				},
+			},
+			{
+				{
+					Name: "test.metric",
+					Datapoints: []tspb.TimeSeriesDatapoint{
+						datapoint(-446061360000000000, 100),
+					},
+				},
+			},
+		},
+	}
+
+	ambient := log.AmbientContext{Tracer: tracing.NewTracer()}
+	tm.DB.PollSource(ambient, &testSource, time.Millisecond, Resolution10s, testSource.stopper)
+	select {
+	case <-testSource.stopper.IsStopped():
+		t.Error("testSource data exhausted when polling should have been enabled")
+	case <-time.After(50 * time.Millisecond):
+		testSource.stopper.Stop(context.Background())
+	}
+	if a, e := testSource.calledCount, 0; a != e {
+		t.Errorf("testSource was called %d times, expected %d", a, e)
+	}
+	tm.assertKeyCount(0)
 	tm.assertModelCorrect()
 }
 


### PR DESCRIPTION
This doesn't create a big warning sign in the UI or anything, but it does show up as a cluster event ("Cluster Setting Changed: User root set timeseries.storage.enabled to false").

Fixes #12675

Release note: Storage of timeseries data within the cluster can be
disabled by setting the new timeseries.storage.enabled to false.
This is not recommended, though, unless you are scraping the metrics
from the cluster and storing them somewhere else yourself.