### PR TITLE
cloud: Switch from alpha storage class annotation to actual field

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -226,11 +226,10 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes:
         - "ReadWriteOnce"
+      storageClassName: anything
       resources:
         requests:
           storage: 1Gi

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -120,11 +120,10 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes:
         - "ReadWriteOnce"
+      storageClassName: anything
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
The alpha annotation has been phased out and doesn't work on the most
recent version of Kubernetes. The real field works as far back as v1.6,
which is all we currently support anyways.

Release note: None

We don't truly need to include this field anymore -- as of v1.6 volumes can be provisioned automatically without it -- but I kind of like having it there so that anyone who has defined a different storage class in their cluster (e.g pd-ssd on GCE) can easily see where to plug it in. Let me know if you feel differently, though.