### PR TITLE
sql: regression tests for index constraints issues

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -883,3 +883,16 @@ SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY 
 ----
 1  NULL  1  NULL
 1  NULL  5  NULL
+
+# Regression test for #3548: verify we create constraints on implicit columns.
+statement ok
+CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY(a,b), INDEX(c))
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT c FROM abc WHERE c = 1 and a = 3
+----
+render     0  render  ·         ·              (c)  c=CONST
+ │         0  ·       render 0  test.abc.c     ·    ·
+ └── scan  1  scan    ·         ·              (c)  c=CONST
+·          1  ·       table     abc@abc_c_idx  ·    ·
+·          1  ·       spans     /1/3-/1/4      ·    ·

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -896,3 +896,14 @@ render     0  render  ·         ·              (c)  c=CONST
  └── scan  1  scan    ·         ·              (c)  c=CONST
 ·          1  ·       table     abc@abc_c_idx  ·    ·
 ·          1  ·       spans     /1/3-/1/4      ·    ·
+
+# Regression test for #20504.
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT a, b FROM abc WHERE (a, b) BETWEEN (1, 2) AND (3, 4)
+----
+render     0  render  ·         ·            (a, b)  a!=NULL; b!=NULL; key(a,b)
+ │         0  ·       render 0  test.abc.a   ·       ·
+ │         0  ·       render 1  test.abc.b   ·       ·
+ └── scan  1  scan    ·         ·            (a, b)  a!=NULL; b!=NULL; key(a,b)
+·          1  ·       table     abc@primary  ·       ·
+·          1  ·       spans     /1/2-/3/4/#  ·       ·

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -648,3 +648,19 @@ render           0  render      ·         ·                      (a, b, c)  ·
       └── scan   2  scan        ·         ·                      (a, b, c)  ·
 ·                2  ·           table     abc@primary            ·          ·
 ·                2  ·           filter    (a, b, c) > (1, 2, 3)  ·          ·
+
+statement ok
+DROP TABLE abc;
+CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b DESC, c))
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3)
+----
+render     0  render  ·         ·                      (a, b, c)  ·
+ │         0  ·       render 0  test.abc.a             ·          ·
+ │         0  ·       render 1  test.abc.b             ·          ·
+ │         0  ·       render 2  test.abc.c             ·          ·
+ └── scan  1  scan    ·         ·                      (a, b, c)  ·
+·          1  ·       table     abc@abc_a_b_c_idx      ·          ·
+·          1  ·       spans     /1-                    ·          ·
+·          1  ·       filter    (a, b, c) > (1, 2, 3)  ·          ·

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -627,3 +627,24 @@ SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
 1  3     1
 1  3     2
 1  3     3
+
+
+# Regression test for #6390.
+statement ok
+CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b))
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3);
+----
+render           0  render      ·         ·                      (a, b, c)  ·
+ │               0  ·           render 0  test.abc.a             ·          ·
+ │               0  ·           render 1  test.abc.b             ·          ·
+ │               0  ·           render 2  test.abc.c             ·          ·
+ └── index-join  1  index-join  ·         ·                      (a, b, c)  ·
+      ├── scan   2  scan        ·         ·                      (a, b, c)  ·
+      │          2  ·           table     abc@abc_a_b_idx        ·          ·
+      │          2  ·           spans     /1/2-                  ·          ·
+      │          2  ·           filter    (a, b) >= (1, 2)       ·          ·
+      └── scan   2  scan        ·         ·                      (a, b, c)  ·
+·                2  ·           table     abc@primary            ·          ·
+·                2  ·           filter    (a, b, c) > (1, 2, 3)  ·          ·

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -1112,3 +1112,9 @@ build-scalar,index-constraints vars=(int, int) index=(@1, @2)
 ----
 [/4/5 - ]
 Remaining filter: @2 = 5
+
+# Regression test for #3472.
+build-scalar,index-constraints vars=(int, int) index=(@1, @2)
+(@1,@2) IN ((1, 2)) AND @1 = 1
+----
+[/1/2 - /1/2]

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -1190,7 +1190,7 @@ func spansFromLogicalSpans(
 	index *sqlbase.IndexDescriptor,
 ) (roachpb.Spans, error) {
 	spans := make(roachpb.Spans, len(logicalSpans))
-	interstices := make([][]byte, len(index.ColumnDirections)+len(index.ExtraColumnIDs)+1)
+	interstices := make([][]byte, len(index.ColumnDirections)+1)
 	interstices[0] = sqlbase.MakeIndexKeyPrefix(tableDesc, index.ID)
 	if len(index.Interleave.Ancestors) > 0 {
 		// TODO(eisen): too much of this code is copied from EncodePartialIndexKey.
@@ -2062,7 +2062,7 @@ func (v *indexInfo) makeIndexConstraintsExperimental(
 func (v *indexInfo) spansFromLogicalSpansExperimental(
 	tableDesc *sqlbase.TableDescriptor, index *sqlbase.IndexDescriptor,
 ) (roachpb.Spans, error) {
-	interstices := make([][]byte, len(index.ColumnDirections)+1)
+	interstices := make([][]byte, len(index.ColumnDirections)+len(index.ExtraColumnIDs)+1)
 	interstices[0] = sqlbase.MakeIndexKeyPrefix(tableDesc, index.ID)
 	if len(index.Interleave.Ancestors) > 0 {
 		// TODO(eisen): too much of this code is copied from EncodePartialIndexKey.


### PR DESCRIPTION
The new index constraints code addresses a bunch of issues that are referenced in #6346. Adding regression tests for these issues.

#### opt: regression test for `(a, b) IN ((1, 2)) AND a = 1`

Fixes #3472.

Release note: None

#### sql: add logic tests for tuple inequality truncation

Fixes #6390.

Release note: None

#### sql: fix bug when generating constraints on implicit columns

The new index constraints code supports generating constraints on
implicit columns. The key `interstices` were extended to accommodate
this, but it was done in the wrong place (in the old code path).

Fixing and adding regression test for this case.

Release note: None

Fixes #3548.

#### sql: add regression test for tuple BETWEEN constraint

Fixes #20504.

Release note: None