### PR TITLE
sql/distsqlrun: make RowBuffer.ConsumerClosed enforce RowSource semantics

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -307,7 +307,7 @@ func (ag *aggregator) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 
 // ConsumerDone is part of the RowSource interface.
 func (ag *aggregator) ConsumerDone() {
-	ag.consumerDone("aggregator")
+	ag.consumerDone()
 	ag.input.ConsumerDone()
 }
 

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -372,7 +372,7 @@ func (tr *tableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 
 // ConsumerDone is part of the RowSource interface.
 func (tr *tableReader) ConsumerDone() {
-	tr.consumerDone("tableReader")
+	tr.consumerDone()
 }
 
 // ConsumerClosed is part of the RowSource interface.

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -147,7 +147,7 @@ func (v *valuesProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 
 // ConsumerDone is part of the RowSource interface.
 func (v *valuesProcessor) ConsumerDone() {
-	v.consumerDone("values")
+	v.consumerDone()
 }
 
 // ConsumerClosed is part of the RowSource interface.


### PR DESCRIPTION
Make RowBuffer.ConsumerClosed die if that method is called more than
once. Miscellenous cleanup.

Release note: None