### PR TITLE
opt: better simplification for OR expressions

### DIFF
--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -967,14 +967,12 @@ build-scalar,normalize,index-constraints vars=(int) index=(@1)
 ----
 [/1 - /1]
 [/2 - /2]
-Remaining filter: (@1 = 1) OR (@1 = 2)
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1 IS NULL OR @1 = 1
 ----
 [/NULL - /NULL]
 [/1 - /1]
-Remaining filter: (@1 IS NULL) OR (@1 = 1)
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 (@1 >= 1 AND @1 <= 5) OR (@1 >= 2 AND @1 <= 8)
@@ -1015,7 +1013,6 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 [/1 - /1]
 [/4/5/6 - /4/5/6]
 [/7/8/9 - /7/8/9]
-Remaining filter: (@1 = 1) OR ((@1, @2, @3) IN ((4, 5, 6), (7, 8, 9)))
 
 build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 @1 = 1 OR (@1 = 2 AND (@2, @3) IN ((4, 5), (6, 7))) OR (@1 = 3)


### PR DESCRIPTION
We now keep track of whether all expressions inside an OR are "tight",
and if they are, we know that there is no remaining filter necessary.

Release note: None