### PR TITLE
sql: add support for ON UPDATE CASCADE for foreign key references

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -583,9 +583,18 @@ func convertRecord(
 			if err != nil {
 				return errors.Wrapf(err, "generate insert row: %s: row %d", batch.file, rowNum)
 			}
-			if err := ri.InsertRow(ctx, inserter(func(kv roachpb.KeyValue) {
-				kvBatch = append(kvBatch, kv)
-			}), row, true /* ignoreConflicts */, false /* traceKV */); err != nil {
+			// TODO(bram): Is the checking of FKs here required? If not, turning them
+			// off may provide a speed boost.
+			if err := ri.InsertRow(
+				ctx,
+				inserter(func(kv roachpb.KeyValue) {
+					kvBatch = append(kvBatch, kv)
+				}),
+				row,
+				true, /* ignoreConflicts */
+				sqlbase.CheckFKs,
+				false, /* traceKV */
+			); err != nil {
 				return errors.Wrapf(err, "insert row: %s: row %d", batch.file, rowNum)
 			}
 			if len(kvBatch) >= kvBatchSize {

--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -302,7 +302,9 @@ func insertStmtToKVs(
 		if err != nil {
 			return errors.Wrapf(err, "process insert %q", row)
 		}
-		if err := ri.InsertRow(ctx, b, row, true, false /* traceKV */); err != nil {
+		// TODO(bram): Is the checking of FKs here required? If not, turning them
+		// off may provide a speed boost.
+		if err := ri.InsertRow(ctx, b, row, true, sqlbase.CheckFKs, false /* traceKV */); err != nil {
 			return errors.Wrapf(err, "insert %q", row)
 		}
 	}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -285,12 +285,16 @@ func (sc *SchemaChanger) truncateIndexes(
 					return err
 				}
 
-				rd, err := sqlbase.MakeRowDeleter(txn, tableDesc, nil, nil, false, alloc)
+				rd, err := sqlbase.MakeRowDeleter(
+					txn, tableDesc, nil, nil, sqlbase.SkipFKs, nil /* *tree.EvalContext */, alloc,
+				)
 				if err != nil {
 					return err
 				}
 				td := tableDeleter{rd: rd, alloc: alloc}
-				if err := td.init(txn, nil /* *mon.BytesMonitor */); err != nil {
+				if err := td.init(
+					txn, nil /* *mon.BytesMonitor */, nil, /* *tree.EvalContext */
+				); err != nil {
 					return err
 				}
 				resume, err = td.deleteIndex(

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -268,7 +268,7 @@ func (n *createTableNode) FastPathResults() (int, bool) {
 //    CREATE TABLE foo (a INT, b INT, CHECK (a < 1))
 //
 // Note some SQL databases require that a constraint attached to a column to
-// refer only to the column it is attached to. We follow Postgres's behavior,
+// refer only to the column it is attached to. We follow Postgres' behavior,
 // however, in omitting this restriction by blindly hoisting all column
 // constraints. For example, the following table definition is accepted in
 // CockroachDB and Postgres, but not necessarily other SQL databases:
@@ -469,7 +469,8 @@ func resolveFK(
 		return pgerror.Unimplemented(feature, feature)
 	}
 	if d.Actions.Update != tree.NoAction &&
-		d.Actions.Update != tree.Restrict {
+		d.Actions.Update != tree.Restrict &&
+		d.Actions.Update != tree.Cascade {
 		feature := fmt.Sprintf("unsupported: ON UPDATE %s", d.Actions.Update)
 		return pgerror.Unimplemented(feature, feature)
 	}

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -176,8 +176,14 @@ func (cb *columnBackfiller) runChunk(
 		requestedCols = append(requestedCols, tableDesc.Columns...)
 		requestedCols = append(requestedCols, cb.added...)
 		ru, err := sqlbase.MakeRowUpdater(
-			txn, &tableDesc, fkTables, cb.updateCols, requestedCols,
-			sqlbase.RowUpdaterOnlyColumns, &cb.alloc,
+			txn,
+			&tableDesc,
+			fkTables,
+			cb.updateCols,
+			requestedCols,
+			sqlbase.RowUpdaterOnlyColumns,
+			&cb.flowCtx.EvalCtx,
+			&cb.alloc,
 		)
 		if err != nil {
 			return err
@@ -239,7 +245,7 @@ func (cb *columnBackfiller) runChunk(
 				}
 			}
 			if _, err := ru.UpdateRow(
-				ctx, b, oldValues, updateValues, nil /* mon.BytesMonitor */, false, /* traceKV */
+				ctx, b, oldValues, updateValues, nil /* mon.BytesMonitor */, sqlbase.CheckFKs, false, /* traceKV */
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -320,7 +320,8 @@ func (n *insertNode) startExec(params runParams) error {
 		return err
 	}
 
-	return n.run.tw.init(params.p.txn, params.EvalContext().Mon)
+	evalCtx := params.EvalContext()
+	return n.run.tw.init(params.p.txn, evalCtx.Mon, evalCtx)
 }
 
 func (n *insertNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1,12 +1,12 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default
 
 subtest DeleteCascade_Basic
 ### Basic Delete Cascade
 #     a
 #    / \
 #   b1 b2
-#  / \
-# c1  c2
+#  / \   \
+# c1  c2  c3
 
 statement ok
 CREATE TABLE a (
@@ -38,63 +38,85 @@ CREATE TABLE c2 (
 );
 
 statement ok
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY REFERENCES b2 ON DELETE CASCADE
+);
+
+statement ok
 INSERT INTO a VALUES ('a-pk1');
-
-statement ok
-INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1');
-
-statement ok
-INSERT INTO b1 VALUES ('b1-pk2', 'a-pk1');
-
-statement ok
-INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1');
-
-statement ok
-INSERT INTO b2 VALUES ('b2-pk2', 'a-pk1');
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk1-b1-pk1', 'b1-pk1');
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk2-b1-pk1', 'b1-pk1');
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk3-b1-pk2', 'b1-pk2');
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk4-b1-pk2', 'b1-pk2');
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk1-b1-pk1', 'b1-pk1');
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk2-b1-pk1', 'b1-pk1');
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk3-b1-pk2', 'b1-pk2');
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk4-b1-pk2', 'b1-pk2');
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1'), ('b1-pk2', 'a-pk1');
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1'), ('b2-pk2', 'a-pk1');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'b1-pk1')
+ ,('c1-pk2-b1-pk1', 'b1-pk1')
+ ,('c1-pk3-b1-pk2', 'b1-pk2')
+ ,('c1-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'b1-pk1')
+ ,('c2-pk2-b1-pk1', 'b1-pk1')
+ ,('c2-pk3-b1-pk2', 'b1-pk2')
+ ,('c2-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c3 VALUES ('b2-pk1'), ('b2-pk2');
 
 # ON DELETE CASCADE
 statement ok
 DELETE FROM a WHERE id = 'a-pk1';
 
+query IIIIII
+SELECT
+  (SELECT COUNT(*) FROM a)
+ ,(SELECT COUNT(*) FROM b1)
+ ,(SELECT COUNT(*) FROM b2)
+ ,(SELECT COUNT(*) FROM c1)
+ ,(SELECT COUNT(*) FROM c2)
+ ,(SELECT COUNT(*) FROM c3)
+;
+----
+0 0 0 0 0 0
+
+# Perform the same operation but with show trace.
+statement ok
+INSERT INTO a VALUES ('a-pk1');
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1'), ('b1-pk2', 'a-pk1');
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1'), ('b2-pk2', 'a-pk1');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'b1-pk1')
+ ,('c1-pk2-b1-pk1', 'b1-pk1')
+ ,('c1-pk3-b1-pk2', 'b1-pk2')
+ ,('c1-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'b1-pk1')
+ ,('c2-pk2-b1-pk1', 'b1-pk1')
+ ,('c2-pk3-b1-pk2', 'b1-pk2')
+ ,('c2-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c3 VALUES ('b2-pk1'), ('b2-pk2');
+
+query I
+SELECT COUNT(*) FROM [
+  SHOW KV TRACE FOR DELETE FROM a WHERE id = 'a-pk1'
+] WHERE message LIKE 'cascading %';
+----
+5
+
+query IIIIII
+SELECT
+  (SELECT COUNT(*) FROM a)
+ ,(SELECT COUNT(*) FROM b1)
+ ,(SELECT COUNT(*) FROM b2)
+ ,(SELECT COUNT(*) FROM c1)
+ ,(SELECT COUNT(*) FROM c2)
+ ,(SELECT COUNT(*) FROM c3)
+;
+----
+0 0 0 0 0 0
+
 # Clean up after the test.
 statement ok
-DROP TABLE c2;
-
-statement ok
-DROP TABLE c1;
-
-statement ok
-DROP TABLE b2;
-
-statement ok
-DROP TABLE b1;
-
-statement ok
-DROP TABLE a;
+DROP TABLE c3, c2, c1, b2, b1, a;
 
 subtest DeleteCascade_PrimaryKeys
 ### Basic Delete Cascade using primary keys
@@ -131,38 +153,29 @@ CREATE TABLE c2 (
 
 statement ok
 INSERT INTO a VALUES ('pk1');
-
-statement ok
 INSERT INTO b1 VALUES ('pk1');
-
-statement ok
 INSERT INTO b2 VALUES ('pk1');
-
-statement ok
 INSERT INTO c1 VALUES ('pk1');
-
-statement ok
 INSERT INTO c2 VALUES ('pk1');
 
 # ON DELETE CASCADE
 statement ok
 DELETE FROM a WHERE id = 'pk1';
 
+query IIIII
+SELECT
+  (SELECT COUNT(*) FROM a)
+ ,(SELECT COUNT(*) FROM b1)
+ ,(SELECT COUNT(*) FROM b2)
+ ,(SELECT COUNT(*) FROM c1)
+ ,(SELECT COUNT(*) FROM c2)
+;
+----
+0 0 0 0 0
+
 # Clean up after the test.
 statement ok
-DROP TABLE c2;
-
-statement ok
-DROP TABLE c1;
-
-statement ok
-DROP TABLE b2;
-
-statement ok
-DROP TABLE b1;
-
-statement ok
-DROP TABLE a;
+DROP TABLE c2, c1, b2, b1, a;
 
 subtest DeleteCascade_CompositeFKs
 ### Basic Delete Cascade with composite FKs
@@ -219,62 +232,39 @@ CREATE TABLE c2 (
 
 statement ok
 INSERT INTO a VALUES ('a-pk1', 1);
-
-statement ok
-INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1', 1, 1);
-
-statement ok
-INSERT INTO b1 VALUES ('b1-pk2', 'a-pk1', 1, 2);
-
-statement ok
-INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1', 1, 1);
-
-statement ok
-INSERT INTO b2 VALUES ('b2-pk2', 'a-pk1', 1, 2);
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk1-b1-pk1', 'b1-pk1', 1);
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk2-b1-pk1', 'b1-pk1', 1);
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk3-b1-pk2', 'b1-pk2', 1);
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk4-b1-pk2', 'b1-pk2', 1);
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk1-b1-pk1', 'b1-pk1', 1);
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk2-b1-pk1', 'b1-pk1', 1);
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk3-b1-pk2', 'b1-pk2', 1);
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk4-b1-pk2', 'b1-pk2', 1);
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1', 1, 1), ('b1-pk2', 'a-pk1', 1, 2);
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1', 1, 1), ('b2-pk2', 'a-pk1', 1, 2);
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'b1-pk1', 1)
+ ,('c1-pk2-b1-pk1', 'b1-pk1', 1)
+ ,('c1-pk3-b1-pk2', 'b1-pk2', 1)
+ ,('c1-pk4-b1-pk2', 'b1-pk2', 1)
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'b1-pk1', 1)
+ ,('c2-pk2-b1-pk1', 'b1-pk1', 1)
+ ,('c2-pk3-b1-pk2', 'b1-pk2', 1)
+ ,('c2-pk4-b1-pk2', 'b1-pk2', 1)
+;
 
 # ON DELETE CASCADE
 statement ok
 DELETE FROM a WHERE id = 'a-pk1';
 
+query IIIII
+SELECT
+  (SELECT COUNT(*) FROM a)
+ ,(SELECT COUNT(*) FROM b1)
+ ,(SELECT COUNT(*) FROM b2)
+ ,(SELECT COUNT(*) FROM c1)
+ ,(SELECT COUNT(*) FROM c2)
+;
+----
+0 0 0 0 0
+
 # Clean up after the test.
 statement ok
-DROP TABLE c2;
-
-statement ok
-DROP TABLE c1;
-
-statement ok
-DROP TABLE b2;
-
-statement ok
-DROP TABLE b1;
-
-statement ok
-DROP TABLE a;
+DROP TABLE c2, c1, b2, b1, a;
 
 subtest DeleteCascade_Restrict
 ### Basic Delete Cascade with Restrict
@@ -323,44 +313,20 @@ CREATE TABLE d (
 
 statement ok
 INSERT INTO a VALUES ('a-pk1');
-
-statement ok
-INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1');
-
-statement ok
-INSERT INTO b1 VALUES ('b1-pk2', 'a-pk1');
-
-statement ok
-INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1');
-
-statement ok
-INSERT INTO b2 VALUES ('b2-pk2', 'a-pk1');
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk1-b1-pk1', 'b1-pk1');
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk2-b1-pk1', 'b1-pk1');
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk3-b1-pk2', 'b1-pk2');
-
-statement ok
-INSERT INTO c1 VALUES ('c1-pk4-b1-pk2', 'b1-pk2');
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk1-b1-pk1', 'b1-pk1');
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk2-b1-pk1', 'b1-pk1');
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk3-b1-pk2', 'b1-pk2');
-
-statement ok
-INSERT INTO c2 VALUES ('c2-pk4-b1-pk2', 'b1-pk2');
-
-statement ok
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1'), ('b1-pk2', 'a-pk1');
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1'), ('b2-pk2', 'a-pk1');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'b1-pk1')
+ ,('c1-pk2-b1-pk1', 'b1-pk1')
+ ,('c1-pk3-b1-pk2', 'b1-pk2')
+ ,('c1-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'b1-pk1')
+ ,('c2-pk2-b1-pk1', 'b1-pk1')
+ ,('c2-pk3-b1-pk2', 'b1-pk2')
+ ,('c2-pk4-b1-pk2', 'b1-pk2')
+;
 INSERT INTO d VALUES ('d-pk1-c2-pk4-b1-pk2', 'c2-pk4-b1-pk2');
 
 # ON DELETE CASCADE
@@ -369,22 +335,7 @@ DELETE FROM a WHERE id = 'a-pk1';
 
 # Clean up after the test.
 statement ok
-DROP TABLE d;
-
-statement ok
-DROP TABLE c2;
-
-statement ok
-DROP TABLE c1;
-
-statement ok
-DROP TABLE b2;
-
-statement ok
-DROP TABLE b1;
-
-statement ok
-DROP TABLE a;
+DROP TABLE d, c2, c1, b2, b1, a;
 
 subtest DeleteCascade_Interleaved
 ### Basic Delete Cascade with Interleaved Tables
@@ -426,48 +377,63 @@ CREATE TABLE c3 (
 
 statement ok
 INSERT INTO a VALUES ('pk1'), ('pk2');
-
-statement ok
 INSERT INTO b1 VALUES ('pk1'), ('pk2');
-
-statement ok
 INSERT INTO b2 VALUES ('pk1'), ('pk2');
-
-statement ok
 INSERT INTO c1 VALUES ('pk1'), ('pk2');
-
-statement ok
 INSERT INTO c2 VALUES ('pk1'), ('pk2');
-
-statement ok
 INSERT INTO c3 VALUES ('pk1'), ('pk2');
 
 # ON DELETE CASCADE from b1 downward
 statement ok
 DELETE FROM b1 WHERE id = 'pk2';
 
+query IIIIII
+SELECT
+  (SELECT COUNT(*) FROM a)
+ ,(SELECT COUNT(*) FROM b1)
+ ,(SELECT COUNT(*) FROM b2)
+ ,(SELECT COUNT(*) FROM c1)
+ ,(SELECT COUNT(*) FROM c2)
+ ,(SELECT COUNT(*) FROM c3)
+;
+----
+2 1 2 1 1 2
+
 # ON DELETE CASCADE
 statement ok
 DELETE FROM a WHERE id = 'pk1';
 
+query IIIIII
+SELECT
+  (SELECT COUNT(*) FROM a)
+ ,(SELECT COUNT(*) FROM b1)
+ ,(SELECT COUNT(*) FROM b2)
+ ,(SELECT COUNT(*) FROM c1)
+ ,(SELECT COUNT(*) FROM c2)
+ ,(SELECT COUNT(*) FROM c3)
+;
+----
+1 0 1 0 0 1
+
+# ON DELETE CASCADE for the rest
+statement ok
+DELETE FROM a WHERE id = 'pk2';
+
+query IIIIII
+SELECT
+  (SELECT COUNT(*) FROM a)
+ ,(SELECT COUNT(*) FROM b1)
+ ,(SELECT COUNT(*) FROM b2)
+ ,(SELECT COUNT(*) FROM c1)
+ ,(SELECT COUNT(*) FROM c2)
+ ,(SELECT COUNT(*) FROM c3)
+;
+----
+0 0 0 0 0 0
+
 # Clean up after the test.
 statement ok
-DROP TABLE c3;
-
-statement ok
-DROP TABLE c2;
-
-statement ok
-DROP TABLE c1;
-
-statement ok
-DROP TABLE b2;
-
-statement ok
-DROP TABLE b1;
-
-statement ok
-DROP TABLE a;
+DROP TABLE c3, c2, c1, b2, b1, a;
 
 subtest DeleteCascade_InterleavedRestrict
 ### Basic Delete Cascade with Interleaved Tables To Restrict
@@ -512,25 +478,27 @@ CREATE TABLE c3 (
 
 statement ok
 INSERT INTO a VALUES ('pk1'), ('pk2');
-
-statement ok
 INSERT INTO b1 VALUES ('pk1'), ('pk2');
-
-statement ok
 INSERT INTO b2 VALUES ('pk1'), ('pk2');
-
-statement ok
 INSERT INTO c1 VALUES ('pk1'), ('pk2');
-
-statement ok
 INSERT INTO c2 VALUES ('pk1'), ('pk2');
-
-statement ok
 INSERT INTO c3 VALUES ('pk1'), ('pk2');
 
 # ON DELETE CASCADE from b1 downward
 statement ok
 DELETE FROM b1 WHERE id = 'pk2';
+
+query IIIIII
+SELECT
+  (SELECT COUNT(*) FROM a)
+ ,(SELECT COUNT(*) FROM b1)
+ ,(SELECT COUNT(*) FROM b2)
+ ,(SELECT COUNT(*) FROM c1)
+ ,(SELECT COUNT(*) FROM c2)
+ ,(SELECT COUNT(*) FROM c3)
+;
+----
+2 1 2 1 1 2
 
 # ON DELETE CASCADE
 statement error pq: foreign key violation: values \['pk1'\] in columns \[id\] referenced in table "c3"
@@ -538,22 +506,7 @@ DELETE FROM a WHERE id = 'pk1';
 
 # Clean up after the test.
 statement ok
-DROP TABLE c3;
-
-statement ok
-DROP TABLE c2;
-
-statement ok
-DROP TABLE c1;
-
-statement ok
-DROP TABLE b2;
-
-statement ok
-DROP TABLE b1;
-
-statement ok
-DROP TABLE a;
+DROP TABLE c3, c2, c1, b2, b1, a;
 
 subtest DeleteCascade_SelfReference
 ### Self Reference Delete Cascade
@@ -567,22 +520,21 @@ CREATE TABLE self (
 
 statement ok
 INSERT INTO self VALUES (1, NULL);
-
-statement ok
 INSERT INTO self VALUES (2, 1);
-
-statement ok
 INSERT INTO self VALUES (3, 2);
-
-statement ok
 INSERT INTO self VALUES (4, 3);
 
 statement ok
 DELETE FROM self WHERE id = 1;
 
+query I
+SELECT COUNT(*) FROM self
+----
+0
+
 # Clean up after the test.
 statement ok
-DROP TABLE self CASCADE;
+DROP TABLE self;
 
 subtest DeleteCascade_SelfReferenceCycle
 ### Self Reference Delete Cascade Cycle
@@ -596,14 +548,8 @@ CREATE TABLE self (
 
 statement ok
 INSERT INTO self VALUES (1, NULL);
-
-statement ok
 INSERT INTO self VALUES (2, 1);
-
-statement ok
 INSERT INTO self VALUES (3, 2);
-
-statement ok
 INSERT INTO self VALUES (4, 3);
 
 statement ok
@@ -612,9 +558,14 @@ UPDATE self SET other_id = 4 WHERE id = 1;
 statement ok
 DELETE FROM self WHERE id = 1;
 
+query I
+SELECT COUNT(*) FROM self
+----
+0
+
 # Clean up after the test.
 statement ok
-DROP TABLE self CASCADE;
+DROP TABLE self;
 
 subtest DeleteCascade_TwoTableLoop
 ### Delete cascade loop between two tables
@@ -641,20 +592,10 @@ ALTER TABLE loop_a ADD CONSTRAINT cascade_delete_constraint
 
 statement ok
 INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk1', NULL);
-
-statement ok
 INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk1', 'loop_a-pk1');
-
-statement ok
 INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk2', 'loop_b-pk1');
-
-statement ok
 INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk2', 'loop_a-pk2');
-
-statement ok
 INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk3', 'loop_b-pk2');
-
-statement ok
 INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk3', 'loop_a-pk3');
 
 statement ok
@@ -663,12 +604,17 @@ UPDATE loop_a SET cascade_delete = 'loop_b-pk3' WHERE id = 'loop_a-pk1';
 statement ok
 DELETE FROM loop_a WHERE id = 'loop_a-pk1';
 
+query II
+SELECT
+  (SELECT COUNT(*) FROM loop_a)
+ ,(SELECT COUNT(*) FROM loop_b)
+;
+----
+0 0
+
 # Clean up after the test.
 statement ok
-DROP TABLE loop_a CASCADE;
-
-statement ok
-DROP TABLE loop_b;
+DROP TABLE loop_a, loop_b;
 
 subtest DeleteCascade_TwoTableLoopCycle
 ### Delete cascade loop between two tables with cycle
@@ -695,31 +641,26 @@ ALTER TABLE loop_a ADD CONSTRAINT cascade_delete_constraint
 
 statement ok
 INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk1', NULL);
-
-statement ok
 INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk1', 'loop_a-pk1');
-
-statement ok
 INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk2', 'loop_b-pk1');
-
-statement ok
 INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk2', 'loop_a-pk2');
-
-statement ok
 INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk3', 'loop_b-pk2');
-
-statement ok
 INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk3', 'loop_a-pk3');
 
 statement ok
 DELETE FROM loop_a WHERE id = 'loop_a-pk1';
 
+query II
+SELECT
+  (SELECT COUNT(*) FROM loop_a)
+ ,(SELECT COUNT(*) FROM loop_b)
+;
+----
+0 0
+
 # Clean up after the test.
 statement ok
-DROP TABLE loop_a CASCADE;
-
-statement ok
-DROP TABLE loop_b;
+DROP TABLE loop_a, loop_b;
 
 subtest DeleteCascade_DoubleSelfReference
 ### Delete cascade double self reference
@@ -731,25 +672,26 @@ CREATE TABLE self_x2 (
   x STRING PRIMARY KEY
  ,y STRING UNIQUE REFERENCES self_x2(x) ON DELETE CASCADE
  ,z STRING REFERENCES self_x2(y) ON DELETE CASCADE
- ,INDEX(z)
 );
 
 statement ok
 INSERT INTO self_x2 (x, y, z) VALUES ('pk1', NULL, NULL);
-
-statement ok
 INSERT INTO self_x2 (x, y, z) VALUES ('pk2', 'pk1', NULL);
-
-statement ok
 INSERT INTO self_x2 (x, y, z) VALUES ('pk3', 'pk2', 'pk1');
 
 statement ok
 DELETE FROM self_x2 WHERE x = 'pk1';
 
+query I
+SELECT COUNT(*) FROM self_x2
+----
+0
+
 # Clean up after the test.
 statement ok
 DROP TABLE self_x2;
 
+subtest DeleteCascade_Race
 ## Delete cascade race
 #         a
 #        / \
@@ -790,34 +732,888 @@ CREATE TABLE e (
 
 statement ok
 INSERT INTO a (id) VALUES ('a1');
-
-statement ok
 INSERT INTO b (id, a_id) VALUES ('b1', 'a1');
-
-statement ok
 INSERT INTO c (id, a_id) VALUES ('c1', 'a1');
-
-statement ok
 INSERT INTO d (id, c_id) VALUES ('d1', 'c1');
-
-statement ok
 INSERT INTO e (id, b_id, d_id) VALUES ('e1', 'b1', 'd1');
 
 statement ok
 DELETE FROM a WHERE id = 'a1';
 
+query IIIII
+SELECT
+  (SELECT COUNT(*) FROM a)
+ ,(SELECT COUNT(*) FROM b)
+ ,(SELECT COUNT(*) FROM c)
+ ,(SELECT COUNT(*) FROM d)
+ ,(SELECT COUNT(*) FROM e)
+;
+----
+0 0 0 0 0
+
 # Clean up after the test.
 statement ok
-DROP TABLE e;
+DROP TABLE e, d, c, b, a;
+
+subtest UpdateCascade_Basic
+### Basic Update Cascade
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
 
 statement ok
-DROP TABLE d;
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
 
 statement ok
-DROP TABLE c;
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL UNIQUE REFERENCES a ON UPDATE CASCADE
+);
 
 statement ok
-DROP TABLE b;
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL UNIQUE REFERENCES a ON UPDATE CASCADE
+);
 
 statement ok
-DROP TABLE a;
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL REFERENCES b1 (update_cascade) ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL REFERENCES b1 (update_cascade) ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY REFERENCES b2(update_cascade) ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO a VALUES ('original');
+INSERT INTO b1 VALUES ('b1-pk1', 'original');
+INSERT INTO b2 VALUES ('b2-pk1', 'original');
+INSERT INTO c1 VALUES
+  ('c1-pk1', 'original')
+ ,('c1-pk2', 'original')
+ ,('c1-pk3', 'original')
+ ,('c1-pk4', 'original')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1', 'original')
+ ,('c2-pk2', 'original')
+ ,('c2-pk3', 'original')
+ ,('c2-pk4', 'original')
+;
+INSERT INTO c3 VALUES ('original');
+
+# ON UPDATE CASCADE
+statement ok
+UPDATE a SET id = 'updated' WHERE id = 'original';
+
+query T
+SELECT * FROM a;
+----
+updated
+
+query TT
+SELECT * FROM b1;
+----
+b1-pk1 updated
+
+query TT
+SELECT * FROM b2;
+----
+b2-pk1 updated
+
+query TT rowsort
+SELECT * FROM c1;
+----
+c1-pk1 updated
+c1-pk2 updated
+c1-pk3 updated
+c1-pk4 updated
+
+query TT rowsort
+SELECT * FROM c2;
+----
+c2-pk1 updated
+c2-pk2 updated
+c2-pk3 updated
+c2-pk4 updated
+
+# Update again but this time check show trace
+statement ok
+
+query I
+SELECT COUNT(*) FROM [
+  SHOW KV TRACE FOR UPDATE a SET id = 'updated2' WHERE id = 'updated'
+] WHERE message LIKE 'cascading %';
+----
+5
+
+query T
+SELECT * FROM a;
+----
+updated2
+
+query TT
+SELECT * FROM b1;
+----
+b1-pk1 updated2
+
+query TT
+SELECT * FROM b2;
+----
+b2-pk1 updated2
+
+query TT rowsort
+SELECT * FROM c1;
+----
+c1-pk1 updated2
+c1-pk2 updated2
+c1-pk3 updated2
+c1-pk4 updated2
+
+query TT rowsort
+SELECT * FROM c2;
+----
+c2-pk1 updated2
+c2-pk2 updated2
+c2-pk3 updated2
+c2-pk4 updated2
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+subtest UpdateCascade_PrimaryKeys
+### Basic Update Cascade using only primary keys
+#     a
+#    / \
+#   b1 b2
+#  / \
+# c1  c2
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY REFERENCES a ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY REFERENCES a ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY REFERENCES b1 ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY REFERENCES b1 ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO a VALUES ('original');
+INSERT INTO b1 VALUES ('original');
+INSERT INTO b2 VALUES ('original');
+INSERT INTO c1 VALUES ('original');
+INSERT INTO c2 VALUES ('original');
+
+# ON UPDATE CASCADE
+statement ok
+UPDATE a SET id = 'updated' WHERE id = 'original';
+
+query TTTTT
+SELECT
+  (SELECT id FROM a)
+ ,(SELECT id FROM b1)
+ ,(SELECT id FROM b2)
+ ,(SELECT id FROM c1)
+ ,(SELECT id FROM c2)
+;
+----
+updated updated updated updated updated
+
+# Clean up after the test.
+statement ok
+DROP TABLE c2, c1, b2, b1, a;
+
+subtest UpdateCascade_CompositeFKs
+### Basic Update Cascade with composite FKs
+#     a
+#    / \
+#   b1 b2
+#  / \
+# c1  c2
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+ ,x INT
+ ,UNIQUE (id, x)
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,a_id STRING
+ ,x INT
+ ,y INT
+ ,INDEX (a_id, x, y)
+ ,FOREIGN KEY (a_id, x) REFERENCES a (id, x) ON UPDATE CASCADE
+ ,UNIQUE (id, x)
+);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,a_id STRING
+ ,x INT
+ ,y INT
+ ,INDEX (a_id, x, y)
+ ,FOREIGN KEY (a_id, x) REFERENCES a (id, x) ON UPDATE CASCADE
+ ,UNIQUE (id, x)
+);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,b_id STRING
+ ,x INT
+ ,FOREIGN KEY (b_id, x) REFERENCES b1 (id, x) ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,b_id STRING
+ ,x INT
+ ,FOREIGN KEY (b_id, x) REFERENCES b1 (id, x) ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO a VALUES ('a-pk1', 1);
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1', 1, 1), ('b1-pk2', 'a-pk1', 1, 2);
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1', 1, 1), ('b2-pk2', 'a-pk1', 1, 2);
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'b1-pk1', 1)
+ ,('c1-pk2-b1-pk1', 'b1-pk1', 1)
+ ,('c1-pk3-b1-pk2', 'b1-pk2', 1)
+ ,('c1-pk4-b1-pk2', 'b1-pk2', 1)
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'b1-pk1', 1)
+ ,('c2-pk2-b1-pk1', 'b1-pk1', 1)
+ ,('c2-pk3-b1-pk2', 'b1-pk2', 1)
+ ,('c2-pk4-b1-pk2', 'b1-pk2', 1)
+;
+
+# ON UPDATE CASCADE
+statement ok
+UPDATE a SET x = 2 WHERE x = 1;
+
+query TI
+SELECT * FROM a;
+----
+a-pk1 2
+
+query TTII rowsort
+SELECT * FROM b1;
+----
+b1-pk1  a-pk1  2  1
+b1-pk2  a-pk1  2  2
+
+query TTII rowsort
+SELECT * FROM b2;
+----
+b2-pk1  a-pk1  2  1
+b2-pk2  a-pk1  2  2
+
+query TTI rowsort
+SELECT * FROM c1;
+----
+c1-pk1-b1-pk1  b1-pk1  2
+c1-pk2-b1-pk1  b1-pk1  2
+c1-pk3-b1-pk2  b1-pk2  2
+c1-pk4-b1-pk2  b1-pk2  2
+
+query TTI rowsort
+SELECT * FROM c2;
+----
+c2-pk1-b1-pk1  b1-pk1  2
+c2-pk2-b1-pk1  b1-pk1  2
+c2-pk3-b1-pk2  b1-pk2  2
+c2-pk4-b1-pk2  b1-pk2  2
+
+# Clean up after the test.
+statement ok
+DROP TABLE c2, c1, b2, b1, a;
+
+subtest UpdateCascade_Restrict
+### Basic Update Cascade with Restrict
+# This test has a restrict on both d tables and tests both.
+# c3 and d2 use primary keys to match while the rest use non-primary keys.
+# Both restricts are tested.
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+#     |    |
+#     d1  d2
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL UNIQUE REFERENCES a ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL UNIQUE REFERENCES a ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL REFERENCES b1 (update_cascade) ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING NOT NULL UNIQUE REFERENCES b1 (update_cascade) ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY REFERENCES b2(update_cascade) ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE d1 (
+  id STRING PRIMARY KEY
+ ,update_restrict STRING NOT NULL REFERENCES c2 (update_cascade) ON UPDATE RESTRICT
+);
+
+statement ok
+CREATE TABLE d2 (
+  id STRING PRIMARY KEY REFERENCES c3 ON UPDATE RESTRICT
+);
+
+statement ok
+INSERT INTO a VALUES ('original');
+INSERT INTO b1 VALUES ('b1-pk1', 'original');
+INSERT INTO b2 VALUES ('b2-pk1', 'original');
+INSERT INTO c1 VALUES
+  ('c1-pk1', 'original')
+ ,('c1-pk2', 'original')
+ ,('c1-pk3', 'original')
+ ,('c1-pk4', 'original')
+;
+INSERT INTO c2 VALUES ('c2-pk1', 'original');
+INSERT INTO c3 VALUES ('original');
+
+# Test non-primary key restrict.
+statement ok
+INSERT INTO d1 VALUES ('d1-pk1', 'original');
+
+# ON UPDATE CASCADE
+statement error foreign key violation: values \['original'\] in columns \[update_cascade\] referenced in table "d1"
+UPDATE a SET id = 'updated' WHERE id = 'original';
+
+statement ok
+DELETE FROM d1 WHERE id = 'd1-pk1';
+
+# Test a primary key restrict.
+statement ok
+INSERT INTO d2 VALUES ('original');
+
+# ON UPDATE CASCADE
+statement error foreign key violation: values \['original'\] in columns \[id\] referenced in table "d2"
+UPDATE a SET id = 'updated' WHERE id = 'original';
+
+# Clean up after the test.
+statement ok
+DROP TABLE d2, d1, c3, c2, c1, b2, b1, a;
+
+subtest UpdateCascade_Interleaved
+### Basic Update Cascade with Interleaved Tables
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY REFERENCES a ON UPDATE CASCADE
+) INTERLEAVE IN PARENT a (id);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY REFERENCES a ON UPDATE CASCADE
+) INTERLEAVE IN PARENT a (id);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY REFERENCES b1 ON UPDATE CASCADE
+) INTERLEAVE IN PARENT b1 (id);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY REFERENCES b1 ON UPDATE CASCADE
+) INTERLEAVE IN PARENT b1 (id);
+
+statement ok
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY REFERENCES b2 ON UPDATE CASCADE
+) INTERLEAVE IN PARENT b2 (id);
+
+statement ok
+INSERT INTO a VALUES ('original'), ('updated');
+INSERT INTO b1 VALUES ('original');
+INSERT INTO b2 VALUES ('original');
+INSERT INTO c1 VALUES ('original');
+INSERT INTO c2 VALUES ('original');
+INSERT INTO c3 VALUES ('original');
+
+# ON UPDATE CASCADE from b1 downward
+statement ok
+UPDATE b1 SET id = 'updated' WHERE id = 'original';
+
+query T rowsort
+SELECT * FROM a;
+----
+original
+updated
+
+query TTTTT
+SELECT
+  (SELECT id FROM b1)
+ ,(SELECT id FROM b2)
+ ,(SELECT id FROM c1)
+ ,(SELECT id FROM c2)
+ ,(SELECT id FROM c3)
+;
+----
+updated original updated updated original
+
+# ON UPDATE CASCADE from a downward
+statement ok
+UPDATE a SET id = 'updated2' WHERE id = 'original';
+
+query T rowsort
+SELECT * FROM a;
+----
+updated
+updated2
+
+query TTTTT
+SELECT
+  (SELECT id FROM b1)
+ ,(SELECT id FROM b2)
+ ,(SELECT id FROM c1)
+ ,(SELECT id FROM c2)
+ ,(SELECT id FROM c3)
+;
+----
+updated updated2 updated updated updated2
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+subtest UpdateCascade_InterleavedRestrict
+### Basic Update Cascade with Interleaved Tables To Restrict
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY REFERENCES a ON UPDATE CASCADE
+) INTERLEAVE IN PARENT a (id);
+
+statement ok
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY REFERENCES a ON UPDATE CASCADE
+) INTERLEAVE IN PARENT a (id);
+
+statement ok
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY REFERENCES b1 ON UPDATE CASCADE
+) INTERLEAVE IN PARENT b1 (id);
+
+statement ok
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY REFERENCES b1 ON UPDATE CASCADE
+) INTERLEAVE IN PARENT b1 (id);
+
+statement ok
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY REFERENCES b2 ON UPDATE RESTRICT
+) INTERLEAVE IN PARENT b2 (id);
+
+statement ok
+INSERT INTO a VALUES ('original'), ('updated');
+INSERT INTO b1 VALUES ('original');
+INSERT INTO b2 VALUES ('original');
+INSERT INTO c1 VALUES ('original');
+INSERT INTO c2 VALUES ('original');
+INSERT INTO c3 VALUES ('original');
+
+# ON UPDATE CASCADE from b1 downward
+statement ok
+UPDATE b1 SET id = 'updated' WHERE id = 'original';
+
+query T rowsort
+SELECT * FROM a;
+----
+original
+updated
+
+query TTTTT
+SELECT
+  (SELECT id FROM b1)
+ ,(SELECT id FROM b2)
+ ,(SELECT id FROM c1)
+ ,(SELECT id FROM c2)
+ ,(SELECT id FROM c3)
+;
+----
+updated original updated updated original
+
+# ON UPDATE CASCADE from a downward
+statement error foreign key violation: values \['original'\] in columns \[id\] referenced in table "c3"
+UPDATE a SET id = 'updated2' WHERE id = 'original';
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+subtest UpdateCascade_SelfReference
+### Self Reference Update Cascade
+# self <- self
+
+statement ok
+CREATE TABLE self (
+  id INT PRIMARY KEY
+ ,other_id INT REFERENCES self ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO self VALUES (1, NULL);
+INSERT INTO self VALUES (2, 1);
+INSERT INTO self VALUES (3, 2);
+
+query II rowsort
+SELECT * FROM self;
+----
+1 NULL
+2 1
+3 2
+
+statement ok
+UPDATE self SET id = 4 WHERE id = 2;
+
+query II rowsort
+SELECT * FROM self;
+----
+1 NULL
+4 1
+3 4
+
+# Clean up after the test.
+statement ok
+DROP TABLE self;
+
+subtest UpdateCascade_TwoTableLoop
+### Delete cascade loop between two tables
+# loop_a <- loop_b
+# loop_b <- loop_a
+
+statement ok
+CREATE TABLE loop_a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE loop_b (
+  id STRING PRIMARY KEY REFERENCES loop_a ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO loop_a VALUES ('original');
+INSERT INTO loop_b VALUES ('original');
+
+statement ok
+ALTER TABLE loop_a ADD CONSTRAINT cascade_update_constraint
+  FOREIGN KEY (id) REFERENCES loop_b
+  ON UPDATE CASCADE;
+
+query TT
+SELECT
+  (SELECT id FROM loop_a)
+ ,(SELECT id FROM loop_b)
+;
+----
+original original
+
+statement ok
+UPDATE loop_a SET id = 'updated' WHERE id = 'original';
+
+query TT
+SELECT
+  (SELECT id FROM loop_a)
+ ,(SELECT id FROM loop_b)
+;
+----
+updated updated
+
+statement ok
+UPDATE loop_b SET id = 'updated2' WHERE id = 'updated';
+
+query TT
+SELECT
+  (SELECT id FROM loop_a)
+ ,(SELECT id FROM loop_b)
+;
+----
+updated2 updated2
+
+# Clean up after the test.
+statement ok
+DROP TABLE loop_a, loop_b;
+
+subtest UpdateCascade_DoubleSelfReference
+### Update cascade double self reference
+# self_x2 (x) <- (y)
+# self_x2 (y) <- (z)
+
+statement ok
+CREATE TABLE self_x2 (
+  x STRING PRIMARY KEY
+ ,y STRING UNIQUE REFERENCES self_x2(x) ON UPDATE CASCADE
+ ,z STRING REFERENCES self_x2(y) ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO self_x2 (x, y, z) VALUES ('pk1', NULL, NULL);
+INSERT INTO self_x2 (x, y, z) VALUES ('pk2', 'pk1', NULL);
+INSERT INTO self_x2 (x, y, z) VALUES ('pk3', 'pk2', 'pk1');
+
+# ON UPDATE CASCADE
+statement ok
+UPDATE self_x2 SET x = 'pk1-updated' WHERE x = 'pk1';
+
+statement ok
+UPDATE self_x2 SET x = 'pk2-updated' WHERE x = 'pk2';
+
+statement ok
+UPDATE self_x2 SET x = 'pk3-updated' WHERE x = 'pk3';
+
+query TTT rowsort
+SELECT * FROM self_x2
+----
+pk1-updated NULL NULL
+pk2-updated pk1-updated NULL
+pk3-updated pk2-updated pk1-updated
+
+# Clean up after the test.
+statement ok
+DROP TABLE self_x2;
+
+subtest UpdateCascade_TwoUpdates
+## Update cascade two updates to the same table, then both of those cascade to
+# yet another table
+#         a
+#        / \
+#       b   c
+#       |   |
+#       |   d
+#        \ /
+#         e
+#         |
+#         f
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b (
+  id STRING PRIMARY KEY REFERENCES a ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c (
+  id STRING PRIMARY KEY REFERENCES a ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE d (
+  id STRING PRIMARY KEY REFERENCES c ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE e (
+  b_id STRING PRIMARY KEY REFERENCES b ON UPDATE CASCADE
+ ,d_id STRING UNIQUE REFERENCES d ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE f (
+  e_b_id STRING PRIMARY KEY REFERENCES e (b_id) ON UPDATE CASCADE
+ ,e_d_id STRING REFERENCES e (d_id) ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO a (id) VALUES ('original');
+INSERT INTO b (id) VALUES ('original');
+INSERT INTO c (id) VALUES ('original');
+INSERT INTO d (id) VALUES ('original');
+INSERT INTO e (b_id, d_id) VALUES ('original', 'original');
+INSERT INTO f (e_b_id, e_d_id) VALUES ('original', 'original');
+
+statement ok
+UPDATE a SET id = 'updated' WHERE id = 'original';
+
+query TTTT
+SELECT
+  (SELECT id FROM a)
+ ,(SELECT id FROM b)
+ ,(SELECT id FROM c)
+ ,(SELECT id FROM d)
+;
+----
+updated updated updated updated
+
+query TT
+SELECT * FROM e
+----
+updated updated
+
+query TT
+SELECT * FROM f
+----
+updated updated
+
+# Clean up after the test.
+statement ok
+DROP TABLE f, e, d, c, b, a;
+
+subtest UpdateCascade_TwoUpdatesReverse
+## Update cascade two updates to the same table, then both of those cascade to
+# yet another table.
+# This is a similar test to UpdateCascade_TwoUpdates, but table d is now between
+# b and e instead of c and e.
+#         a
+#        / \
+#       b   c
+#       |   |
+#       d   |
+#        \ /
+#         e
+#         |
+#         f
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b (
+  id STRING PRIMARY KEY REFERENCES a ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE c (
+  id STRING PRIMARY KEY REFERENCES a ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE d (
+  id STRING PRIMARY KEY REFERENCES b ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE e (
+  d_id STRING PRIMARY KEY REFERENCES d ON UPDATE CASCADE
+ ,c_id STRING UNIQUE REFERENCES c ON UPDATE CASCADE
+);
+
+statement ok
+CREATE TABLE f (
+  e_d_id STRING PRIMARY KEY REFERENCES e (d_id) ON UPDATE CASCADE
+ ,e_c_id STRING REFERENCES e (c_id) ON UPDATE CASCADE
+);
+
+statement ok
+INSERT INTO a (id) VALUES ('original');
+INSERT INTO b (id) VALUES ('original');
+INSERT INTO c (id) VALUES ('original');
+INSERT INTO d (id) VALUES ('original');
+INSERT INTO e (d_id, c_id) VALUES ('original', 'original');
+INSERT INTO f (e_d_id, e_c_id) VALUES ('original', 'original');
+
+statement ok
+UPDATE a SET id = 'updated' WHERE id = 'original';
+
+query TTTT
+SELECT
+  (SELECT id FROM a)
+ ,(SELECT id FROM b)
+ ,(SELECT id FROM c)
+ ,(SELECT id FROM d)
+;
+----
+updated updated updated updated
+
+query TT
+SELECT * FROM e
+----
+updated updated
+
+query TT
+SELECT * FROM f
+----
+updated updated
+
+# Clean up after the test.
+statement ok
+DROP TABLE f, e, d, c, b, a;

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -83,8 +83,11 @@ ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON DELETE CASCA
 statement ok
 ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
 
-statement error pq: unsupported: ON UPDATE CASCADE
+statement ok
 ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON UPDATE CASCADE
+
+statement ok
+ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
 
 statement error pq: unsupported: ON DELETE SET NULL
 ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON DELETE SET NULL

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -162,6 +162,27 @@ func (d *Datums) Format(ctx *FmtCtx) {
 	ctx.WriteByte(')')
 }
 
+// IsDistinctFrom checks to see if two datums are distinct from each other. Any
+// change in value is considered distinct, however, a NULL value is NOT
+// considered disctinct from another NULL value.
+func (d Datums) IsDistinctFrom(evalCtx *EvalContext, other Datums) bool {
+	if len(d) != len(other) {
+		return true
+	}
+	for i, val := range d {
+		if val == DNull {
+			if other[i] != DNull {
+				return true
+			}
+		} else {
+			if val.Compare(evalCtx, other[i]) != 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // CompositeDatum is a Datum that may require composite encoding in
 // indexes. Any Datum implementing this interface must also add itself to
 // sqlbase/HasCompositeKeyEncoding.

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -16,7 +16,9 @@ package tree_test
 
 import (
 	"context"
+	"fmt"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -574,5 +576,101 @@ func TestMakeDJSON(t *testing.T) {
 	}
 	if j1.Compare(tree.NewTestingEvalContext(), j2) != -1 {
 		t.Fatal("expected JSON 1 < 2")
+	}
+}
+
+func TestIsDistinctFrom(t *testing.T) {
+	testData := []struct {
+		a        string // comma separated list of strings, `NULL` is converted to a NULL
+		b        string // same as a
+		expected bool
+	}{
+		{"a", "a", false},
+		{"a", "b", true},
+		{"b", "b", false},
+		{"a,a", "a,a", false},
+		{"a,a", "a,b", true},
+		{"a,a", "b,a", true},
+		{"a,a,a", "a,a,a", false},
+		{"a,a,a", "a,a,b", true},
+		{"a,a,a", "a,b,a", true},
+		{"a,a,a", "a,b,b", true},
+		{"a,a,a", "b,a,a", true},
+		{"a,a,a", "b,a,b", true},
+		{"a,a,a", "b,b,a", true},
+		{"a,a,a", "b,b,b", true},
+		{"NULL", "NULL", false},
+		{"a", "NULL", true},
+		{"a,a", "a,NULL", true},
+		{"a,a", "NULL,a", true},
+		{"a,a", "NULL,NULL", true},
+		{"a,NULL", "a,a", true},
+		{"a,NULL", "a,NULL", false},
+		{"a,NULL", "NULL,a", true},
+		{"a,NULL", "NULL,NULL", true},
+		{"NULL,a", "a,a", true},
+		{"NULL,a", "a,NULL", true},
+		{"NULL,a", "NULL,a", false},
+		{"NULL,a", "NULL,NULL", true},
+		{"NULL,NULL", "a,a", true},
+		{"NULL,NULL", "a,NULL", true},
+		{"NULL,NULL", "NULL,a", true},
+		{"NULL,NULL", "NULL,NULL", false},
+		{"a,a,a", "a,a,NULL", true},
+		{"a,a,a", "a,NULL,a", true},
+		{"a,a,a", "a,NULL,NULL", true},
+		{"a,a,a", "NULL,a,a", true},
+		{"a,a,a", "NULL,a,NULL", true},
+		{"a,a,a", "NULL,NULL,a", true},
+		{"a,a,a", "NULL,NULL,NULL", true},
+		{"a,NULL,a", "a,a,a", true},
+		{"a,NULL,a", "a,a,NULL", true},
+		{"a,NULL,a", "a,NULL,a", false},
+		{"a,NULL,a", "a,NULL,NULL", true},
+		{"a,NULL,a", "NULL,a,a", true},
+		{"a,NULL,a", "NULL,a,NULL", true},
+		{"a,NULL,a", "NULL,NULL,a", true},
+		{"a,NULL,a", "NULL,NULL,NULL", true},
+		{"NULL,a,NULL", "a,a,a", true},
+		{"NULL,a,NULL", "a,a,NULL", true},
+		{"NULL,a,NULL", "a,NULL,a", true},
+		{"NULL,a,NULL", "a,NULL,NULL", true},
+		{"NULL,a,NULL", "NULL,a,a", true},
+		{"NULL,a,NULL", "NULL,a,NULL", false},
+		{"NULL,a,NULL", "NULL,NULL,a", true},
+		{"NULL,a,NULL", "NULL,NULL,NULL", true},
+		{"NULL,NULL,NULL", "a,a,a", true},
+		{"NULL,NULL,NULL", "a,a,NULL", true},
+		{"NULL,NULL,NULL", "a,NULL,a", true},
+		{"NULL,NULL,NULL", "a,NULL,NULL", true},
+		{"NULL,NULL,NULL", "NULL,a,a", true},
+		{"NULL,NULL,NULL", "NULL,a,NULL", true},
+		{"NULL,NULL,NULL", "NULL,NULL,a", true},
+		{"NULL,NULL,NULL", "NULL,NULL,NULL", false},
+	}
+	convert := func(s string) tree.Datums {
+		splits := strings.Split(s, ",")
+		result := make(tree.Datums, len(splits))
+		for i, value := range splits {
+			if value == "NULL" {
+				result[i] = tree.DNull
+				continue
+			}
+			result[i] = tree.NewDString(value)
+		}
+		return result
+	}
+	for _, td := range testData {
+		t.Run(fmt.Sprintf("%s to %s", td.a, td.b), func(t *testing.T) {
+			datumsA := convert(td.a)
+			datumsB := convert(td.b)
+			if e, a := td.expected, datumsA.IsDistinctFrom(&tree.EvalContext{}, datumsB); e != a {
+				if e {
+					t.Errorf("expected %s to be distinct from %s, but got %t", datumsA, datumsB, e)
+				} else {
+					t.Errorf("expected %s to not be distinct from %s, but got %t", datumsA, datumsB, e)
+				}
+			}
+		})
 	}
 }

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -94,6 +94,7 @@ WHERE message LIKE 'fetched: %'
    OR message LIKE 'output row: %'
    OR message LIKE 'execution failed: %'
    OR message LIKE 'r%: sending batch %'
+   OR message LIKE 'cascading %'
 `
 	}
 

--- a/pkg/sql/sqlbase/cascader.go
+++ b/pkg/sql/sqlbase/cascader.go
@@ -29,29 +29,158 @@ import (
 
 // cascader is used to handle all referential integrity cascading actions.
 type cascader struct {
-	txn                *client.Txn
-	tablesByID         TableLookupsByID                   // TablesDescriptors by Table ID
-	indexRowFetchers   map[ID]map[IndexID]MultiRowFetcher // RowFetchers by Table ID and Index ID
-	rowDeleters        map[ID]RowDeleter                  // RowDeleters by Table ID
-	deleterRowFetchers map[ID]MultiRowFetcher             // RowFetchers for rowDeleters by Table ID
-	rowsChanged        map[ID]*RowContainer               // Rows that have been altered by Table ID
-	alloc              *DatumAlloc
+	txn        *client.Txn
+	tablesByID TableLookupsByID // TablesDescriptors by Table ID
+	alloc      *DatumAlloc
+	evalCtx    *tree.EvalContext
+
+	indexPKRowFetchers map[ID]map[IndexID]MultiRowFetcher // PK RowFetchers by Table ID and Index ID
+
+	// Row Deleters
+	rowDeleters        map[ID]RowDeleter      // RowDeleters by Table ID
+	deleterRowFetchers map[ID]MultiRowFetcher // RowFetchers for rowDeleters by Table ID
+	deletedRows        map[ID]*RowContainer   // Rows that have been deleted by Table ID
+
+	// Row Updaters
+	rowUpdaters        map[ID]RowUpdater      // RowUpdaters by Table ID
+	updaterRowFetchers map[ID]MultiRowFetcher // RowFetchers for rowUpdaters by Table ID
+	originalRows       map[ID]*RowContainer   // Original values for rows that have been updated by Table ID
+	updatedRows        map[ID]*RowContainer   // New values for rows that have been updated by Table ID
 }
 
-func makeCascader(txn *client.Txn, tablesByID TableLookupsByID, alloc *DatumAlloc) *cascader {
+// makeDeleteCascader only creates a cascader if there is a chance that there is
+// a possible cascade. It returns a cascader if one is required and nil if not.
+func makeDeleteCascader(
+	txn *client.Txn,
+	table *TableDescriptor,
+	tablesByID TableLookupsByID,
+	evalCtx *tree.EvalContext,
+	alloc *DatumAlloc,
+) (*cascader, error) {
+	var required bool
+Outer:
+	for _, referencedIndex := range table.AllNonDropIndexes() {
+		for _, ref := range referencedIndex.ReferencedBy {
+			referencingTable, ok := tablesByID[ref.Table]
+			if !ok {
+				return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
+					"programming error: could not find table:%d in table descriptor map", ref.Table,
+				)
+			}
+			if referencingTable.IsAdding {
+				// We can assume that a table being added but not yet public is empty,
+				// and thus does not need to be checked for cascading.
+				continue
+			}
+			referencingIndex, err := referencingTable.Table.FindIndexByID(ref.Index)
+			if err != nil {
+				return nil, err
+			}
+			if referencingIndex.ForeignKey.OnDelete == ForeignKeyReference_CASCADE ||
+				referencingIndex.ForeignKey.OnDelete == ForeignKeyReference_SET_DEFAULT ||
+				referencingIndex.ForeignKey.OnDelete == ForeignKeyReference_SET_NULL {
+				required = true
+				break Outer
+			}
+		}
+	}
+	if !required {
+		return nil, nil
+	}
 	return &cascader{
 		txn:                txn,
 		tablesByID:         tablesByID,
-		indexRowFetchers:   make(map[ID]map[IndexID]MultiRowFetcher),
+		indexPKRowFetchers: make(map[ID]map[IndexID]MultiRowFetcher),
 		rowDeleters:        make(map[ID]RowDeleter),
 		deleterRowFetchers: make(map[ID]MultiRowFetcher),
-		rowsChanged:        make(map[ID]*RowContainer),
+		deletedRows:        make(map[ID]*RowContainer),
+		rowUpdaters:        make(map[ID]RowUpdater),
+		updaterRowFetchers: make(map[ID]MultiRowFetcher),
+		originalRows:       make(map[ID]*RowContainer),
+		updatedRows:        make(map[ID]*RowContainer),
+		evalCtx:            evalCtx,
 		alloc:              alloc,
+	}, nil
+}
+
+// makeUpdateCascader only creates a cascader if there is a chance that there is
+// a possible cascade. It returns a cascader if one is required and nil if not.
+func makeUpdateCascader(
+	txn *client.Txn,
+	table *TableDescriptor,
+	tablesByID TableLookupsByID,
+	updateCols []ColumnDescriptor,
+	evalCtx *tree.EvalContext,
+	alloc *DatumAlloc,
+) (*cascader, error) {
+	var required bool
+	colIDs := make(map[ColumnID]struct{})
+	for _, col := range updateCols {
+		colIDs[col.ID] = struct{}{}
 	}
+Outer:
+	for _, referencedIndex := range table.AllNonDropIndexes() {
+		var match bool
+		for _, colID := range referencedIndex.ColumnIDs {
+			if _, exists := colIDs[colID]; exists {
+				match = true
+				break
+			}
+		}
+		if !match {
+			continue
+		}
+		for _, ref := range referencedIndex.ReferencedBy {
+			referencingTable, ok := tablesByID[ref.Table]
+			if !ok {
+				return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
+					"programming error: could not find table:%d in table descriptor map", ref.Table,
+				)
+			}
+			if referencingTable.IsAdding {
+				// We can assume that a table being added but not yet public is empty,
+				// and thus does not need to be checked for cascading.
+				continue
+			}
+			referencingIndex, err := referencingTable.Table.FindIndexByID(ref.Index)
+			if err != nil {
+				return nil, err
+			}
+			if referencingIndex.ForeignKey.OnUpdate == ForeignKeyReference_CASCADE ||
+				referencingIndex.ForeignKey.OnUpdate == ForeignKeyReference_SET_DEFAULT ||
+				referencingIndex.ForeignKey.OnUpdate == ForeignKeyReference_SET_NULL {
+				required = true
+				break Outer
+			}
+		}
+	}
+	if !required {
+		return nil, nil
+	}
+	return &cascader{
+		txn:                txn,
+		tablesByID:         tablesByID,
+		indexPKRowFetchers: make(map[ID]map[IndexID]MultiRowFetcher),
+		rowDeleters:        make(map[ID]RowDeleter),
+		deleterRowFetchers: make(map[ID]MultiRowFetcher),
+		deletedRows:        make(map[ID]*RowContainer),
+		rowUpdaters:        make(map[ID]RowUpdater),
+		updaterRowFetchers: make(map[ID]MultiRowFetcher),
+		originalRows:       make(map[ID]*RowContainer),
+		updatedRows:        make(map[ID]*RowContainer),
+		evalCtx:            evalCtx,
+		alloc:              alloc,
+	}, nil
 }
 
 func (c *cascader) close(ctx context.Context) {
-	for _, container := range c.rowsChanged {
+	for _, container := range c.deletedRows {
+		container.Close(ctx)
+	}
+	for _, container := range c.originalRows {
+		container.Close(ctx)
+	}
+	for _, container := range c.updatedRows {
 		container.Close(ctx)
 	}
 }
@@ -78,14 +207,16 @@ func spanForIndexValues(
 }
 
 // batchRequestForIndexValues creates a batch request against an index to
-// extract the primary keys needed for cascading.
+// extract the primary keys needed for cascading. It also returns the
+// colIDtoRowIndex that will map the columns that have been retrieved as part of
+// the request to the referencing table.
 func batchRequestForIndexValues(
 	ctx context.Context,
 	referencedIndex *IndexDescriptor,
 	referencingTable *TableDescriptor,
 	referencingIndex *IndexDescriptor,
 	values cascadeQueueElement,
-) (roachpb.BatchRequest, error) {
+) (roachpb.BatchRequest, map[ColumnID]int, error) {
 
 	//TODO(bram): consider caching some of these values
 	keyPrefix := MakeIndexKeyPrefix(referencingTable, referencingIndex.ID)
@@ -93,12 +224,13 @@ func batchRequestForIndexValues(
 	if len(referencedIndex.ColumnIDs) < prefixLen {
 		prefixLen = len(referencedIndex.ColumnIDs)
 	}
-	indexColIDs := make(map[ColumnID]int, len(referencedIndex.ColumnIDs))
+
+	colIDtoRowIndex := make(map[ColumnID]int, len(referencedIndex.ColumnIDs))
 	for i, referencedColID := range referencedIndex.ColumnIDs[:prefixLen] {
 		if found, ok := values.colIDtoRowIndex[referencedColID]; ok {
-			indexColIDs[referencingIndex.ColumnIDs[i]] = found
+			colIDtoRowIndex[referencingIndex.ColumnIDs[i]] = found
 		} else {
-			return roachpb.BatchRequest{}, pgerror.NewErrorf(pgerror.CodeForeignKeyViolationError,
+			return roachpb.BatchRequest{}, nil, pgerror.NewErrorf(pgerror.CodeForeignKeyViolationError,
 				"missing value for column %q in multi-part foreign key", referencedIndex.ColumnNames[i],
 			)
 		}
@@ -107,14 +239,19 @@ func batchRequestForIndexValues(
 	var req roachpb.BatchRequest
 	for i := values.startIndex; i < values.endIndex; i++ {
 		span, err := spanForIndexValues(
-			referencingTable, referencingIndex, prefixLen, indexColIDs, values.values.At(i), keyPrefix,
+			referencingTable,
+			referencingIndex,
+			prefixLen,
+			colIDtoRowIndex,
+			values.originalValues.At(i),
+			keyPrefix,
 		)
 		if err != nil {
-			return roachpb.BatchRequest{}, err
+			return roachpb.BatchRequest{}, nil, err
 		}
 		req.Add(&roachpb.ScanRequest{Span: span})
 	}
-	return req, nil
+	return req, colIDtoRowIndex, nil
 }
 
 // spanForPKValues creates a span against the primary index of a table and is
@@ -148,21 +285,21 @@ func batchRequestForPKValues(
 	return req, nil
 }
 
-// addIndexRowFetch will create or load a cached row fetcher on an index to
+// addIndexPKRowFetch will create or load a cached row fetcher on an index to
 // fetch the primary keys of the rows that will be affected by a cascading
 // action.
-func (c *cascader) addIndexRowFetcher(
+func (c *cascader) addIndexPKRowFetcher(
 	table *TableDescriptor, index *IndexDescriptor,
 ) (MultiRowFetcher, error) {
 	// Is there a cached row fetcher?
-	rowFetchersForTable, exists := c.indexRowFetchers[table.ID]
+	rowFetchersForTable, exists := c.indexPKRowFetchers[table.ID]
 	if exists {
 		rowFetcher, exists := rowFetchersForTable[index.ID]
 		if exists {
 			return rowFetcher, nil
 		}
 	} else {
-		c.indexRowFetchers[table.ID] = make(map[IndexID]MultiRowFetcher)
+		c.indexPKRowFetchers[table.ID] = make(map[IndexID]MultiRowFetcher)
 	}
 
 	// Create a new row fetcher. Only the primary key columns are required.
@@ -195,7 +332,7 @@ func (c *cascader) addIndexRowFetcher(
 		return MultiRowFetcher{}, err
 	}
 	// Cache the row fetcher.
-	c.indexRowFetchers[table.ID][index.ID] = rowFetcher
+	c.indexPKRowFetchers[table.ID][index.ID] = rowFetcher
 	return rowFetcher, nil
 }
 
@@ -203,17 +340,24 @@ func (c *cascader) addIndexRowFetcher(
 func (c *cascader) addRowDeleter(table *TableDescriptor) (RowDeleter, MultiRowFetcher, error) {
 	// Is there a cached row fetcher and deleter?
 	if rowDeleter, exists := c.rowDeleters[table.ID]; exists {
-		return rowDeleter, c.deleterRowFetchers[table.ID], nil
+		rowFetcher, existsFetcher := c.deleterRowFetchers[table.ID]
+		if !existsFetcher {
+			return RowDeleter{}, MultiRowFetcher{}, pgerror.NewErrorf(pgerror.CodeInternalError,
+				"programming error: no corresponding row fetcher for the row deleter for table: (%d)%s",
+				table.ID, table.Name,
+			)
+		}
+		return rowDeleter, rowFetcher, nil
 	}
 
 	// Create the row deleter. The row deleter is needed prior to the row fetcher
 	// as it will dictate what columns are required in the row fetcher.
-	rowDeleter, err := MakeRowDeleter(
+	rowDeleter, err := makeRowDeleterWithoutCascader(
 		c.txn,
 		table,
 		c.tablesByID,
-		nil,  /* requestedCol */
-		true, /* checkFKs */
+		nil, /* requestedCol */
+		CheckFKs,
 		c.alloc,
 	)
 	if err != nil {
@@ -249,6 +393,65 @@ func (c *cascader) addRowDeleter(table *TableDescriptor) (RowDeleter, MultiRowFe
 	return rowDeleter, rowFetcher, nil
 }
 
+// addRowUpdater creates the row updater and primary index row fetcher.
+func (c *cascader) addRowUpdater(table *TableDescriptor) (RowUpdater, MultiRowFetcher, error) {
+	// Is there a cached updater?
+	rowUpdater, existsUpdater := c.rowUpdaters[table.ID]
+	if existsUpdater {
+		rowFetcher, existsFetcher := c.updaterRowFetchers[table.ID]
+		if !existsFetcher {
+			return RowUpdater{}, MultiRowFetcher{}, pgerror.NewErrorf(pgerror.CodeInternalError,
+				"programming error: no corresponding row fetcher for the row updater for table: (%d)%s",
+				table.ID, table.Name,
+			)
+		}
+		return rowUpdater, rowFetcher, nil
+	}
+
+	// Create the row updater. The row updater requires all the columns in the
+	// table.
+	rowUpdater, err := makeRowUpdaterWithoutCascader(
+		c.txn,
+		table,
+		c.tablesByID,
+		table.Columns,
+		nil, /* requestedCol */
+		RowUpdaterDefault,
+		c.alloc,
+	)
+	if err != nil {
+		return RowUpdater{}, MultiRowFetcher{}, err
+	}
+
+	// Create the row fetcher that will retrive the rows and columns needed for
+	// deletion.
+	var valNeededForCol util.FastIntSet
+	valNeededForCol.AddRange(0, len(rowUpdater.FetchCols)-1)
+	tableArgs := MultiRowFetcherTableArgs{
+		Desc:             table,
+		Index:            &table.PrimaryIndex,
+		ColIdxMap:        rowUpdater.FetchColIDtoRowIndex,
+		IsSecondaryIndex: false,
+		Cols:             rowUpdater.FetchCols,
+		ValNeededForCol:  valNeededForCol,
+	}
+	var rowFetcher MultiRowFetcher
+	if err := rowFetcher.Init(
+		false, /* reverse */
+		false, /* returnRangeInfo */
+		false, /* isCheck */
+		c.alloc,
+		tableArgs,
+	); err != nil {
+		return RowUpdater{}, MultiRowFetcher{}, err
+	}
+
+	// Cache the updater and the fetcher.
+	c.rowUpdaters[table.ID] = rowUpdater
+	c.updaterRowFetchers[table.ID] = rowFetcher
+	return rowUpdater, rowFetcher, nil
+}
+
 // deleteRows performs row deletions on a single table for all rows that match
 // the values. Returns the values of the rows that were deleted. This deletion
 // happens in a single batch.
@@ -265,12 +468,11 @@ func (c *cascader) deleteRows(
 	// TODO(bram): This initial index lookup can be skipped if the index is the
 	// primary index.
 	if traceKV {
-		log.VEventf(ctx, 2,
-			"cascading delete from refIndex:%s, into table:%s, using index:%s for values:%+v",
-			referencedIndex.Name, referencingTable.Name, referencingIndex.Name, values.values.chunks,
+		log.VEventf(ctx, 2, "cascading delete into table: %d using index: %d",
+			referencingTable.ID, referencingIndex.ID,
 		)
 	}
-	req, err := batchRequestForIndexValues(
+	req, _, err := batchRequestForIndexValues(
 		ctx, referencedIndex, referencingTable, referencingIndex, values,
 	)
 	if err != nil {
@@ -281,30 +483,32 @@ func (c *cascader) deleteRows(
 		return nil, nil, 0, roachErr.GoError()
 	}
 
-	// Create or retrieve the index row fetcher.
-	indexRowFetcher, err := c.addIndexRowFetcher(referencingTable, referencingIndex)
+	// Create or retrieve the index pk row fetcher.
+	indexPKRowFetcher, err := c.addIndexPKRowFetcher(referencingTable, referencingIndex)
 	if err != nil {
 		return nil, nil, 0, err
 	}
 
 	// Fetch all the primary keys that need to be deleted.
 	// TODO(Bram): consider chunking this into n, primary keys, perhaps 100.
-	pkColTypeInfo, err := makeColTypeInfo(referencingTable, indexRowFetcher.tables[0].colIdxMap)
+	pkColTypeInfo, err := makeColTypeInfo(referencingTable, indexPKRowFetcher.tables[0].colIdxMap)
 	if err != nil {
 		return nil, nil, 0, err
 	}
-	primaryKeysToDelete := NewRowContainer(mon.MakeBoundAccount(), pkColTypeInfo, values.values.Len())
+	primaryKeysToDelete := NewRowContainer(
+		mon.MakeBoundAccount(), pkColTypeInfo, values.originalValues.Len(),
+	)
 	defer primaryKeysToDelete.Close(ctx)
 
 	for _, resp := range br.Responses {
 		fetcher := spanKVFetcher{
 			kvs: resp.GetInner().(*roachpb.ScanResponse).Rows,
 		}
-		if err := indexRowFetcher.StartScanFrom(ctx, &fetcher); err != nil {
+		if err := indexPKRowFetcher.StartScanFrom(ctx, &fetcher); err != nil {
 			return nil, nil, 0, err
 		}
-		for !indexRowFetcher.kvEnd {
-			primaryKey, _, _, err := indexRowFetcher.NextRowDecoded(ctx)
+		for !indexPKRowFetcher.kvEnd {
+			primaryKey, _, _, err := indexPKRowFetcher.NextRowDecoded(ctx)
 			if err != nil {
 				return nil, nil, 0, err
 			}
@@ -340,21 +544,21 @@ func (c *cascader) deleteRows(
 	}
 
 	// Add the values to be checked for constraint violations after all cascading
-	// changes have completed. Here either fetch or create the rowContainer for
-	// the table. This rowContainer for the table is also used by the queue to
-	// avoid having to double the memory used.
-	if _, exists := c.rowsChanged[referencingTable.ID]; !exists {
+	// changes have completed. Here either fetch or create the deleted rows
+	// rowContainer for the table. This rowContainer for the table is also used by
+	// the queue to avoid having to double the memory used.
+	if _, exists := c.deletedRows[referencingTable.ID]; !exists {
 		// Fetch the rows for deletion and store them in a container.
 		colTypeInfo, err := makeColTypeInfo(referencingTable, rowDeleter.FetchColIDtoRowIndex)
 		if err != nil {
 			return nil, nil, 0, err
 		}
-		c.rowsChanged[referencingTable.ID] = NewRowContainer(
+		c.deletedRows[referencingTable.ID] = NewRowContainer(
 			mon.MakeBoundAccount(), colTypeInfo, primaryKeysToDelete.Len(),
 		)
 	}
-	rowsChanged := c.rowsChanged[referencingTable.ID]
-	deletedRowsStartIndex := rowsChanged.Len()
+	deletedRows := c.deletedRows[referencingTable.ID]
+	deletedRowsStartIndex := deletedRows.Len()
 
 	// Delete all the rows in a new batch.
 	deleteBatch := c.txn.NewBatch()
@@ -373,12 +577,14 @@ func (c *cascader) deleteRows(
 			}
 
 			// Add the row to be checked for consistency changes.
-			if _, err := rowsChanged.AddRow(ctx, rowToDelete); err != nil {
+			if _, err := deletedRows.AddRow(ctx, rowToDelete); err != nil {
 				return nil, nil, 0, err
 			}
 
 			// Delete the row.
-			if err := rowDeleter.deleteRowNoCascade(ctx, deleteBatch, rowToDelete, traceKV); err != nil {
+			if err := rowDeleter.DeleteRow(
+				ctx, deleteBatch, rowToDelete, nil /*mon.BytesMonitor */, SkipFKs, traceKV,
+			); err != nil {
 				return nil, nil, 0, err
 			}
 		}
@@ -389,13 +595,209 @@ func (c *cascader) deleteRows(
 		return nil, nil, 0, err
 	}
 
-	return rowsChanged, rowDeleter.FetchColIDtoRowIndex, deletedRowsStartIndex, nil
+	return deletedRows, rowDeleter.FetchColIDtoRowIndex, deletedRowsStartIndex, nil
+}
+
+// updateRows performs row updates on a single table for all rows that match
+// the values. Returns both the values of the rows that were updated and their
+// new values. This update happens in a single batch.
+func (c *cascader) updateRows(
+	ctx context.Context,
+	referencedIndex *IndexDescriptor,
+	referencingTable *TableDescriptor,
+	referencingIndex *IndexDescriptor,
+	values cascadeQueueElement,
+	mon *mon.BytesMonitor,
+	traceKV bool,
+) (*RowContainer, *RowContainer, map[ColumnID]int, int, error) {
+	// Create the span to search for index values.
+	if traceKV {
+		log.VEventf(ctx, 2, "cascading update into table: %d using index: %d",
+			referencingTable.ID, referencingIndex.ID,
+		)
+	}
+
+	// Create or retrieve the row updater and row fetcher.
+	rowUpdater, rowFetcher, err := c.addRowUpdater(referencingTable)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	// Add the values to be checked for constraint violations after all cascading
+	// changes have completed. Here either fetch or create the rowContainers for
+	// both the original and updated values for the table and index combo. These
+	// rowContainers for are also used by the queue to avoid having to double the
+	// memory used.
+	if _, exists := c.originalRows[referencingTable.ID]; !exists {
+		colTypeInfo, err := makeColTypeInfo(referencingTable, rowUpdater.FetchColIDtoRowIndex)
+		if err != nil {
+			return nil, nil, nil, 0, err
+		}
+		c.originalRows[referencingTable.ID] = NewRowContainer(
+			mon.MakeBoundAccount(), colTypeInfo, values.originalValues.Len(),
+		)
+		c.updatedRows[referencingTable.ID] = NewRowContainer(
+			mon.MakeBoundAccount(), colTypeInfo, values.originalValues.Len(),
+		)
+	}
+	originalRows := c.originalRows[referencingTable.ID]
+	updatedRows := c.updatedRows[referencingTable.ID]
+	startIndex := originalRows.Len()
+
+	// Update all the rows in a new batch.
+	batch := c.txn.NewBatch()
+
+	// Sadly, this operation cannot be batched the same way as deletes, as the
+	// values being updated will change based on both the original and updated
+	// values.
+	for i := values.startIndex; i < values.endIndex; i++ {
+		// Extract a single value to update at a time.
+		req, valueColIDtoRowIndex, err := batchRequestForIndexValues(
+			ctx, referencedIndex, referencingTable, referencingIndex, cascadeQueueElement{
+				startIndex:      i,
+				endIndex:        i + 1,
+				originalValues:  values.originalValues,
+				updatedValues:   values.updatedValues,
+				table:           values.table,
+				colIDtoRowIndex: values.colIDtoRowIndex,
+			},
+		)
+		if err != nil {
+			return nil, nil, nil, 0, err
+		}
+		br, roachErr := c.txn.Send(ctx, req)
+		if roachErr != nil {
+			return nil, nil, nil, 0, roachErr.GoError()
+		}
+
+		// Create or retrieve the index pk row fetcher.
+		indexPKRowFetcher, err := c.addIndexPKRowFetcher(referencingTable, referencingIndex)
+		if err != nil {
+			return nil, nil, nil, 0, err
+		}
+
+		// Fetch all the primary keys for rows that will be updated.
+		// TODO(Bram): consider chunking this into n, primary keys, perhaps 100.
+		pkColTypeInfo, err := makeColTypeInfo(referencingTable, indexPKRowFetcher.tables[0].colIdxMap)
+		if err != nil {
+			return nil, nil, nil, 0, err
+		}
+		primaryKeysToUpdate := NewRowContainer(
+			mon.MakeBoundAccount(), pkColTypeInfo, values.originalValues.Len(),
+		)
+		defer primaryKeysToUpdate.Close(ctx)
+
+		for _, resp := range br.Responses {
+			fetcher := spanKVFetcher{
+				kvs: resp.GetInner().(*roachpb.ScanResponse).Rows,
+			}
+			if err := indexPKRowFetcher.StartScanFrom(ctx, &fetcher); err != nil {
+				return nil, nil, nil, 0, err
+			}
+			for !indexPKRowFetcher.kvEnd {
+				primaryKey, _, _, err := indexPKRowFetcher.NextRowDecoded(ctx)
+				if err != nil {
+					return nil, nil, nil, 0, err
+				}
+				if _, err := primaryKeysToUpdate.AddRow(ctx, primaryKey); err != nil {
+					return nil, nil, nil, 0, err
+				}
+			}
+		}
+
+		// Early exit if no rows need to be updated.
+		if primaryKeysToUpdate.Len() == 0 {
+			continue
+		}
+
+		// Create a batch request to get all the spans of the primary keys that need
+		// to be updated.
+		pkLookupReq, err := batchRequestForPKValues(
+			referencingTable, rowUpdater.FetchColIDtoRowIndex, primaryKeysToUpdate,
+		)
+		if err != nil {
+			return nil, nil, nil, 0, err
+		}
+		primaryKeysToUpdate.Clear(ctx)
+		pkResp, roachErr := c.txn.Send(ctx, pkLookupReq)
+		if roachErr != nil {
+			return nil, nil, nil, 0, roachErr.GoError()
+		}
+
+		for _, resp := range pkResp.Responses {
+			fetcher := spanKVFetcher{
+				kvs: resp.GetInner().(*roachpb.ScanResponse).Rows,
+			}
+			if err := rowFetcher.StartScanFrom(ctx, &fetcher); err != nil {
+				return nil, nil, nil, 0, err
+			}
+			for !rowFetcher.kvEnd {
+				rowToUpdate, _, _, err := rowFetcher.NextRowDecoded(ctx)
+				if err != nil {
+					return nil, nil, nil, 0, err
+				}
+
+				// Create the updateRow based on the passed in updated values and from
+				// the retrieved row as a fallback.
+				updateRow := make(tree.Datums, len(rowUpdater.updateColIDtoRowIndex))
+				currentUpdatedValue := values.updatedValues.At(i)
+				for colID, rowIndex := range rowUpdater.updateColIDtoRowIndex {
+					if valueRowIndex, exists := valueColIDtoRowIndex[colID]; exists {
+						updateRow[rowIndex] = currentUpdatedValue[valueRowIndex]
+						continue
+					}
+					if fetchRowIndex, exists := rowUpdater.FetchColIDtoRowIndex[colID]; exists {
+						updateRow[rowIndex] = rowToUpdate[fetchRowIndex]
+						continue
+					}
+					return nil, nil, nil, 0, pgerror.NewErrorf(pgerror.CodeInternalError,
+						"could find find colID %d in either updated columns or the fetched row",
+						colID,
+					)
+				}
+
+				// Is there something to update?  If not, skip it.
+				if !rowToUpdate.IsDistinctFrom(c.evalCtx, updateRow) {
+					continue
+				}
+
+				updatedRow, err := rowUpdater.UpdateRow(
+					ctx,
+					batch,
+					rowToUpdate,
+					updateRow,
+					mon,
+					SkipFKs,
+					traceKV,
+				)
+				if err != nil {
+					return nil, nil, nil, 0, err
+				}
+				if _, err := originalRows.AddRow(ctx, rowToUpdate); err != nil {
+					return nil, nil, nil, 0, err
+				}
+				if _, err := updatedRows.AddRow(ctx, updatedRow); err != nil {
+					return nil, nil, nil, 0, err
+				}
+			}
+		}
+	}
+	if err := c.txn.Run(ctx, batch); err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	return originalRows, updatedRows, rowUpdater.FetchColIDtoRowIndex, startIndex, nil
 }
 
 type cascadeQueueElement struct {
-	table  *TableDescriptor
-	values *RowContainer // This row container is actually defined elsewhere and
-	// its memory is not managed by the queue.
+	table *TableDescriptor
+	// These row containers are defined elsewhere and their memory is not managed
+	// by the queue. The updated values can be nil for deleted rows. If it does
+	// exist, every row in originalValues must have a corresponding row in
+	// updatedValues at the exact same index. They also must have the exact same
+	// rank.
+	originalValues  *RowContainer
+	updatedValues   *RowContainer
 	colIDtoRowIndex map[ColumnID]int
 	startIndex      int // Start of the range of rows in the row container.
 	endIndex        int // End of the range of rows (exclusive) in the row container.
@@ -411,16 +813,18 @@ type cascadeQueue []cascadeQueueElement
 func (q *cascadeQueue) enqueue(
 	ctx context.Context,
 	table *TableDescriptor,
-	rowContainer *RowContainer,
+	originalValues *RowContainer,
+	updatedValues *RowContainer,
 	colIDtoRowIndex map[ColumnID]int,
 	startIndex int,
 ) error {
 	*q = append(*q, cascadeQueueElement{
 		table:           table,
-		values:          rowContainer,
+		originalValues:  originalValues,
+		updatedValues:   updatedValues,
 		colIDtoRowIndex: colIDtoRowIndex,
 		startIndex:      startIndex,
-		endIndex:        rowContainer.Len(),
+		endIndex:        originalValues.Len(),
 	})
 	return nil
 }
@@ -440,12 +844,12 @@ func (c *cascader) cascadeAll(
 	ctx context.Context,
 	table *TableDescriptor,
 	originalValues tree.Datums,
+	updatedValues tree.Datums,
 	colIDtoRowIndex map[ColumnID]int,
 	mon *mon.BytesMonitor,
 	traceKV bool,
 ) error {
 	defer c.close(ctx)
-	// Perform all the required cascading operations.
 	var cascadeQ cascadeQueue
 
 	// Enqueue the first values.
@@ -458,7 +862,17 @@ func (c *cascader) cascadeAll(
 	if _, err := originalRowContainer.AddRow(ctx, originalValues); err != nil {
 		return err
 	}
-	if err := cascadeQ.enqueue(ctx, table, originalRowContainer, colIDtoRowIndex, 0); err != nil {
+	var updatedRowContainer *RowContainer
+	if updatedValues != nil {
+		updatedRowContainer = NewRowContainer(mon.MakeBoundAccount(), colTypeInfo, len(updatedValues))
+		defer updatedRowContainer.Close(ctx)
+		if _, err := updatedRowContainer.AddRow(ctx, updatedValues); err != nil {
+			return err
+		}
+	}
+	if err := cascadeQ.enqueue(
+		ctx, table, originalRowContainer, updatedRowContainer, colIDtoRowIndex, 0,
+	); err != nil {
 		return err
 	}
 	for {
@@ -470,9 +884,6 @@ func (c *cascader) cascadeAll(
 		elem, exists := cascadeQ.dequeue()
 		if !exists {
 			break
-		}
-		if traceKV {
-			log.VEventf(ctx, 2, "cascading into %s for values:%s", elem.table.Name, elem.values.chunks)
 		}
 		for _, referencedIndex := range elem.table.AllNonDropIndexes() {
 			for _, ref := range referencedIndex.ReferencedBy {
@@ -491,25 +902,64 @@ func (c *cascader) cascadeAll(
 				if err != nil {
 					return err
 				}
-				if referencingIndex.ForeignKey.OnDelete == ForeignKeyReference_CASCADE {
-					returnedValuesContainer, colIDtoRowIndex, startIndex, err := c.deleteRows(
-						ctx,
-						&referencedIndex,
-						referencingTable.Table,
-						referencingIndex,
-						elem,
-						mon,
-						traceKV,
-					)
-					if err != nil {
-						return err
-					}
-					if returnedValuesContainer != nil && returnedValuesContainer.Len() > startIndex {
-						// If a row was deleted, add the table to the queue.
-						if err := cascadeQ.enqueue(
-							ctx, referencingTable.Table, returnedValuesContainer, colIDtoRowIndex, startIndex,
-						); err != nil {
+				if elem.updatedValues == nil {
+					// Deleting a row.
+					switch referencingIndex.ForeignKey.OnDelete {
+					case ForeignKeyReference_CASCADE:
+						deletedRows, colIDtoRowIndex, startIndex, err := c.deleteRows(
+							ctx,
+							&referencedIndex,
+							referencingTable.Table,
+							referencingIndex,
+							elem,
+							mon,
+							traceKV,
+						)
+						if err != nil {
 							return err
+						}
+						if deletedRows != nil && deletedRows.Len() > startIndex {
+							// If a row was deleted, add the table to the queue.
+							if err := cascadeQ.enqueue(
+								ctx,
+								referencingTable.Table,
+								deletedRows,
+								nil, /* updatedValues */
+								colIDtoRowIndex,
+								startIndex,
+							); err != nil {
+								return err
+							}
+						}
+					}
+				} else {
+					// Updating a row.
+					switch referencingIndex.ForeignKey.OnUpdate {
+					case ForeignKeyReference_CASCADE:
+						originalAffectedRows, updatedAffectedRows, colIDtoRowIndex, startIndex, err := c.updateRows(
+							ctx,
+							&referencedIndex,
+							referencingTable.Table,
+							referencingIndex,
+							elem,
+							mon,
+							traceKV,
+						)
+						if err != nil {
+							return err
+						}
+						if originalAffectedRows != nil && originalAffectedRows.Len() > startIndex {
+							// A row was updated, so let's add it to the queue.
+							if err := cascadeQ.enqueue(
+								ctx,
+								referencingTable.Table,
+								originalAffectedRows,
+								updatedAffectedRows,
+								colIDtoRowIndex,
+								startIndex,
+							); err != nil {
+								return err
+							}
 						}
 					}
 				}
@@ -517,9 +967,12 @@ func (c *cascader) cascadeAll(
 		}
 	}
 
-	// Check all values to ensure there are no orphans.
-	for tableID, removedRowContainer := range c.rowsChanged {
-		if removedRowContainer.Len() == 0 {
+	// Check all foreign key constraints that have been affected by the cascading
+	// operation.
+
+	// Check all deleted rows to ensure there are no orphans.
+	for tableID, deletedRows := range c.deletedRows {
+		if deletedRows.Len() == 0 {
 			continue
 		}
 		rowDeleter, exists := c.rowDeleters[tableID]
@@ -528,12 +981,81 @@ func (c *cascader) cascadeAll(
 				"programming error: could not find row deleter for table %d", tableID,
 			)
 		}
-		for removedRowContainer.Len() > 0 {
+		for deletedRows.Len() > 0 {
 			// TODO(bram): Can these be batched?
-			if err := rowDeleter.Fks.checkAll(ctx, removedRowContainer.At(0)); err != nil {
+			if err := rowDeleter.Fks.checkAll(ctx, deletedRows.At(0)); err != nil {
 				return err
 			}
-			removedRowContainer.PopFirst()
+			deletedRows.PopFirst()
+		}
+	}
+
+	// Check all updated rows for orphans.
+	// TODO(bram): This is running more checks than needed and may be a bit
+	// brittle. All of these checks can be done selectively by storing a list of
+	// checks to perform for each updated row which can be compiled while
+	// cascading and performing them directly without relying on the rowUpdater.
+	// There is also an opportunity to batch more of these checks together.
+	for tableID, rowUpdater := range c.rowUpdaters {
+		// Fetch the original and updated rows for the updater.
+		originalRows, originalRowsExists := c.originalRows[tableID]
+		if !originalRowsExists {
+			return pgerror.NewErrorf(pgerror.CodeInternalError,
+				"programming error: could not find original rows for table %d", tableID,
+			)
+		}
+		totalRows := originalRows.Len()
+		if totalRows == 0 {
+			continue
+		}
+
+		updatedRows, updatedRowsExists := c.updatedRows[tableID]
+		if !updatedRowsExists {
+			return pgerror.NewErrorf(pgerror.CodeInternalError,
+				"programming error: could not find updated rows for table %d", tableID,
+			)
+		}
+
+		if totalRows != updatedRows.Len() {
+			return pgerror.NewErrorf(pgerror.CodeInternalError,
+				"programming error: original rows length:%d not equal to updated rows length:%d for table %d",
+				totalRows, updatedRows.Len(), tableID,
+			)
+		}
+
+		if totalRows == 1 {
+			// If there's only a single change, which is quite often the case, there
+			// is no need to worry about intermediate states.  Just run the check and
+			// avoid a bunch of allocations.
+			if err := rowUpdater.Fks.runIndexChecks(ctx, originalRows.At(0), updatedRows.At(0)); err != nil {
+				return err
+			}
+			continue
+		}
+
+		skipList := make(map[int]struct{}) // A map of already checked indices.
+		for i := 0; i < totalRows; i++ {
+			if _, exists := skipList[i]; exists {
+				continue
+			}
+
+			// Is this the final update for this row? Intermediate states will always
+			// fail these checks so only check the original and final update for the
+			// row.
+			finalRow := updatedRows.At(i)
+			for j := i + 1; j < totalRows; j++ {
+				if _, exists := skipList[j]; exists {
+					continue
+				}
+				if !originalRows.At(j).IsDistinctFrom(c.evalCtx, finalRow) {
+					// The row has been updated again.
+					finalRow = updatedRows.At(j)
+					skipList[j] = struct{}{}
+				}
+			}
+			if err := rowUpdater.Fks.runIndexChecks(ctx, originalRows.At(i), finalRow); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -65,7 +65,7 @@ type FKCheck int
 
 const (
 	// CheckDeletes checks if rows reference a changed value.
-	CheckDeletes = iota
+	CheckDeletes FKCheck = iota
 	// CheckInserts checks if a new value references an existing row.
 	CheckInserts
 	// CheckUpdates checks all references (CheckDeletes+CheckInserts).
@@ -322,6 +322,7 @@ func (f *fkBatchChecker) runCheck(
 			// If we're inserting, then there's a violation if the scan found nothing.
 			if fk.rf.kvEnd {
 				fkValues := make(tree.Datums, fk.prefixLen)
+
 				for valueIdx, colID := range fk.searchIdx.ColumnIDs[:fk.prefixLen] {
 					fkValues[valueIdx] = newRow[fk.ids[colID]]
 				}
@@ -349,6 +350,7 @@ func (f *fkBatchChecker) runCheck(
 			log.Fatalf(ctx, "impossible case: baseFKHelper has dir=%v", fk.dir)
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/sql/sqlbase/rowwriter.go
+++ b/pkg/sql/sqlbase/rowwriter.go
@@ -33,11 +33,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
+type checkFKConstraints bool
+
 const (
 	// CheckFKs can be passed to row writers to check fk validity.
-	CheckFKs = true
+	CheckFKs checkFKConstraints = true
 	// SkipFKs can be passed to row writer to skip fk validity checks.
-	SkipFKs = false
+	SkipFKs checkFKConstraints = false
 )
 
 // rowHelper has the common methods for table row manipulations.
@@ -183,7 +185,7 @@ func MakeRowInserter(
 	tableDesc *TableDescriptor,
 	fkTables TableLookupsByID,
 	insertCols []ColumnDescriptor,
-	checkFKs bool,
+	checkFKs checkFKConstraints,
 	alloc *DatumAlloc,
 ) (RowInserter, error) {
 	indexes := tableDesc.Indexes
@@ -210,7 +212,7 @@ func MakeRowInserter(
 		}
 	}
 
-	if checkFKs {
+	if checkFKs == CheckFKs {
 		var err error
 		if ri.Fks, err = makeFKInsertHelper(txn, *tableDesc, fkTables,
 			ri.InsertColIDtoRowIndex, alloc); err != nil {
@@ -251,7 +253,12 @@ type putter interface {
 // InsertRow adds to the batch the kv operations necessary to insert a table row
 // with the given values.
 func (ri *RowInserter) InsertRow(
-	ctx context.Context, b putter, values []tree.Datum, ignoreConflicts bool, traceKV bool,
+	ctx context.Context,
+	b putter,
+	values []tree.Datum,
+	ignoreConflicts bool,
+	checkFKs checkFKConstraints,
+	traceKV bool,
 ) error {
 	if len(values) != len(ri.InsertCols) {
 		return errors.Errorf("got %d values but expected %d", len(values), len(ri.InsertCols))
@@ -273,8 +280,10 @@ func (ri *RowInserter) InsertRow(
 		}
 	}
 
-	if err := ri.Fks.checkAll(ctx, values); err != nil {
-		return err
+	if checkFKs == CheckFKs {
+		if err := ri.Fks.checkAll(ctx, values); err != nil {
+			return err
+		}
 	}
 
 	primaryIndexKey, secondaryIndexEntries, err := ri.Helper.encodeIndexes(ri.InsertColIDtoRowIndex, values)
@@ -391,7 +400,8 @@ type RowUpdater struct {
 	rd RowDeleter
 	ri RowInserter
 
-	Fks fkUpdateHelper
+	Fks      fkUpdateHelper
+	cascader *cascader
 
 	// For allocation avoidance.
 	marshaled       []roachpb.Value
@@ -423,6 +433,33 @@ const (
 // expectation of which values are passed as oldValues to UpdateRow. Any column
 // passed in requestedCols will be included in FetchCols.
 func MakeRowUpdater(
+	txn *client.Txn,
+	tableDesc *TableDescriptor,
+	fkTables TableLookupsByID,
+	updateCols []ColumnDescriptor,
+	requestedCols []ColumnDescriptor,
+	updateType rowUpdaterType,
+	evalCtx *tree.EvalContext,
+	alloc *DatumAlloc,
+) (RowUpdater, error) {
+	rowUpdater, err := makeRowUpdaterWithoutCascader(
+		txn, tableDesc, fkTables, updateCols, requestedCols, updateType, alloc,
+	)
+	if err != nil {
+		return RowUpdater{}, err
+	}
+	rowUpdater.cascader, err = makeUpdateCascader(
+		txn, tableDesc, fkTables, updateCols, evalCtx, alloc,
+	)
+	if err != nil {
+		return RowUpdater{}, err
+	}
+	return rowUpdater, nil
+}
+
+// makeRowUpdaterWithoutCascader is the same function as MakeRowUpdated but does not
+// create a cascader.
+func makeRowUpdaterWithoutCascader(
 	txn *client.Txn,
 	tableDesc *TableDescriptor,
 	fkTables TableLookupsByID,
@@ -515,8 +552,9 @@ func MakeRowUpdater(
 		// When changing the primary key, we delete the old values and reinsert
 		// them, so request them all.
 		var err error
-		if ru.rd, err = MakeRowDeleter(txn, tableDesc, fkTables,
-			tableCols, SkipFKs, alloc); err != nil {
+		if ru.rd, err = makeRowDeleterWithoutCascader(
+			txn, tableDesc, fkTables, tableCols, SkipFKs, alloc,
+		); err != nil {
 			return RowUpdater{}, err
 		}
 		ru.FetchCols = ru.rd.FetchCols
@@ -589,8 +627,14 @@ func (ru *RowUpdater) UpdateRow(
 	oldValues []tree.Datum,
 	updateValues []tree.Datum,
 	mon *mon.BytesMonitor,
+	checkFKs checkFKConstraints,
 	traceKV bool,
 ) ([]tree.Datum, error) {
+	batch := b
+	if ru.cascader != nil {
+		batch = ru.cascader.txn.NewBatch()
+	}
+
 	if len(oldValues) != len(ru.FetchCols) {
 		return nil, errors.Errorf("got %d values but expected %d", len(oldValues), len(ru.FetchCols))
 	}
@@ -643,24 +687,48 @@ func (ru *RowUpdater) UpdateRow(
 	}
 
 	if rowPrimaryKeyChanged {
+		if err := ru.rd.DeleteRow(ctx, batch, oldValues, mon, SkipFKs, traceKV); err != nil {
+			return nil, err
+		}
+		if err := ru.ri.InsertRow(
+			ctx, batch, ru.newValues, false /* ignoreConflicts */, SkipFKs, traceKV,
+		); err != nil {
+			return nil, err
+		}
+
 		ru.Fks.addCheckForIndex(ru.Helper.TableDesc.PrimaryIndex.ID)
 		for i := range newSecondaryIndexEntries {
 			if !bytes.Equal(newSecondaryIndexEntries[i].Key, secondaryIndexEntries[i].Key) {
 				ru.Fks.addCheckForIndex(ru.Helper.Indexes[i].ID)
 			}
 		}
-		if err := ru.Fks.runIndexChecks(ctx, oldValues, ru.newValues); err != nil {
-			return nil, err
+
+		if ru.cascader != nil {
+			if err := ru.cascader.txn.Run(ctx, batch); err != nil {
+				return nil, err
+			}
+			if mon == nil {
+				return nil, errors.New("programming error: bytes monitor is nil")
+			}
+			if err := ru.cascader.cascadeAll(
+				ctx,
+				ru.Helper.TableDesc,
+				tree.Datums(oldValues),
+				tree.Datums(ru.newValues),
+				ru.FetchColIDtoRowIndex,
+				mon,
+				traceKV,
+			); err != nil {
+				return nil, err
+			}
 		}
 
-		if err := ru.rd.DeleteRow(ctx, b, oldValues, mon, traceKV); err != nil {
-			return nil, err
+		if checkFKs == CheckFKs {
+			if err := ru.Fks.runIndexChecks(ctx, oldValues, ru.newValues); err != nil {
+				return nil, err
+			}
 		}
-		if err := ru.ri.InsertRow(
-			ctx, b, ru.newValues, false /* ignoreConflicts */, traceKV,
-		); err != nil {
-			return nil, err
-		}
+
 		return ru.newValues, nil
 	}
 
@@ -700,7 +768,7 @@ func (ru *RowUpdater) UpdateRow(
 			if traceKV {
 				log.VEventf(ctx, 2, "Put %s -> %v", keys.PrettyPrint(ru.Helper.primIndexValDirs, ru.key), ru.marshaled[idx].PrettyPrint())
 			}
-			b.Put(&ru.key, &ru.marshaled[idx])
+			batch.Put(&ru.key, &ru.marshaled[idx])
 			ru.key = nil
 
 			continue
@@ -749,13 +817,13 @@ func (ru *RowUpdater) UpdateRow(
 				log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.Helper.primIndexValDirs, ru.key))
 			}
 
-			b.Del(&ru.key)
+			batch.Del(&ru.key)
 		} else {
 			ru.value.SetTuple(ru.valueBuf)
 			if traceKV {
 				log.VEventf(ctx, 2, "Put %s -> %v", keys.PrettyPrint(ru.Helper.primIndexValDirs, ru.key), ru.value.PrettyPrint())
 			}
-			b.Put(&ru.key, &ru.value)
+			batch.Put(&ru.key, &ru.value)
 		}
 
 		ru.key = nil
@@ -770,7 +838,7 @@ func (ru *RowUpdater) UpdateRow(
 			if traceKV {
 				log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.Helper.secIndexValDirs[i], secondaryIndexEntry.Key))
 			}
-			b.Del(secondaryIndexEntry.Key)
+			batch.Del(secondaryIndexEntry.Key)
 		} else if !bytes.Equal(newSecondaryIndexEntry.Value.RawBytes, secondaryIndexEntry.Value.RawBytes) {
 			expValue = &secondaryIndexEntry.Value
 		} else {
@@ -781,11 +849,34 @@ func (ru *RowUpdater) UpdateRow(
 			if traceKV {
 				log.VEventf(ctx, 2, "CPut %s -> %v", keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newSecondaryIndexEntry.Key), newSecondaryIndexEntry.Value.PrettyPrint())
 			}
-			b.CPut(newSecondaryIndexEntry.Key, &newSecondaryIndexEntry.Value, expValue)
+			batch.CPut(newSecondaryIndexEntry.Key, &newSecondaryIndexEntry.Value, expValue)
 		}
 	}
-	if err := ru.Fks.runIndexChecks(ctx, oldValues, ru.newValues); err != nil {
-		return nil, err
+
+	if ru.cascader != nil {
+		if mon == nil {
+			return nil, errors.New("programming error: bytes monitor is nil")
+		}
+		if err := ru.cascader.txn.Run(ctx, batch); err != nil {
+			return nil, err
+		}
+		if err := ru.cascader.cascadeAll(
+			ctx,
+			ru.Helper.TableDesc,
+			tree.Datums(oldValues),
+			tree.Datums(ru.newValues),
+			ru.FetchColIDtoRowIndex,
+			mon,
+			traceKV,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	if checkFKs == CheckFKs {
+		if err := ru.Fks.runIndexChecks(ctx, oldValues, ru.newValues); err != nil {
+			return nil, err
+		}
 	}
 
 	return ru.newValues, nil
@@ -825,7 +916,8 @@ func MakeRowDeleter(
 	tableDesc *TableDescriptor,
 	fkTables TableLookupsByID,
 	requestedCols []ColumnDescriptor,
-	checkFKs bool,
+	checkFKs checkFKConstraints,
+	evalCtx *tree.EvalContext,
 	alloc *DatumAlloc,
 ) (RowDeleter, error) {
 	rowDeleter, err := makeRowDeleterWithoutCascader(
@@ -834,8 +926,12 @@ func MakeRowDeleter(
 	if err != nil {
 		return RowDeleter{}, err
 	}
-	if checkFKs {
-		rowDeleter.cascader = makeCascader(txn, fkTables, alloc)
+	if checkFKs == CheckFKs {
+		var err error
+		rowDeleter.cascader, err = makeDeleteCascader(txn, tableDesc, fkTables, evalCtx, alloc)
+		if err != nil {
+			return RowDeleter{}, err
+		}
 	}
 	return rowDeleter, nil
 }
@@ -847,7 +943,7 @@ func makeRowDeleterWithoutCascader(
 	tableDesc *TableDescriptor,
 	fkTables TableLookupsByID,
 	requestedCols []ColumnDescriptor,
-	checkFKs bool,
+	checkFKs checkFKConstraints,
 	alloc *DatumAlloc,
 ) (RowDeleter, error) {
 	indexes := tableDesc.Indexes
@@ -895,7 +991,7 @@ func makeRowDeleterWithoutCascader(
 		FetchCols:            fetchCols,
 		FetchColIDtoRowIndex: fetchColIDtoRowIndex,
 	}
-	if checkFKs {
+	if checkFKs == CheckFKs {
 		var err error
 		if rd.Fks, err = makeFKDeleteHelper(txn, *tableDesc, fkTables,
 			fetchColIDtoRowIndex, alloc); err != nil {
@@ -911,29 +1007,12 @@ func makeRowDeleterWithoutCascader(
 // orphaned rows. The bytesMonitor is only used if cascading/fk checking and can
 // be nil if not.
 func (rd *RowDeleter) DeleteRow(
-	ctx context.Context, b *client.Batch, values []tree.Datum, mon *mon.BytesMonitor, traceKV bool,
-) error {
-	if err := rd.deleteRowNoCascade(ctx, b, values, traceKV); err != nil {
-		return err
-	}
-	if rd.cascader != nil {
-		if mon == nil {
-			return pgerror.NewError(pgerror.CodeInternalError, "programming error: bytes monitor is nil")
-		}
-		if err := rd.cascader.cascadeAll(
-			ctx, rd.Helper.TableDesc, tree.Datums(values), rd.FetchColIDtoRowIndex, mon, traceKV,
-		); err != nil {
-			return err
-		}
-	}
-	return rd.Fks.checkAll(ctx, values)
-}
-
-// deleteRowNoCascade adds to the batch the kv operations necessary to delete a
-// table row but does not perform any cascading operations or foreign key
-// checks.
-func (rd *RowDeleter) deleteRowNoCascade(
-	ctx context.Context, b *client.Batch, values []tree.Datum, traceKV bool,
+	ctx context.Context,
+	b *client.Batch,
+	values []tree.Datum,
+	mon *mon.BytesMonitor,
+	checkFKs checkFKConstraints,
+	traceKV bool,
 ) error {
 	primaryIndexKey, secondaryIndexEntries, err := rd.Helper.encodeIndexes(rd.FetchColIDtoRowIndex, values)
 	if err != nil {
@@ -963,6 +1042,25 @@ func (rd *RowDeleter) deleteRowNoCascade(
 	b.DelRange(&rd.startKey, &rd.endKey, false /* returnKeys */)
 	rd.startKey, rd.endKey = nil, nil
 
+	if rd.cascader != nil {
+		if mon == nil {
+			return pgerror.NewError(pgerror.CodeInternalError, "programming error: bytes monitor is nil")
+		}
+		if err := rd.cascader.cascadeAll(
+			ctx,
+			rd.Helper.TableDesc,
+			tree.Datums(values),
+			nil, /* updatedValues */
+			rd.FetchColIDtoRowIndex,
+			mon,
+			traceKV,
+		); err != nil {
+			return err
+		}
+	}
+	if checkFKs == CheckFKs {
+		return rd.Fks.checkAll(ctx, values)
+	}
 	return nil
 }
 

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -348,12 +348,14 @@ func truncateTableInChunks(
 			log.VEventf(ctx, 2, "table %s truncate at row: %d, span: %s", tableDesc.Name, row, resume)
 		}
 		if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-			rd, err := sqlbase.MakeRowDeleter(txn, tableDesc, nil, nil, false, alloc)
+			rd, err := sqlbase.MakeRowDeleter(
+				txn, tableDesc, nil, nil, sqlbase.SkipFKs, nil /* *tree.EvalContext */, alloc,
+			)
 			if err != nil {
 				return err
 			}
 			td := tableDeleter{rd: rd, alloc: alloc}
-			if err := td.init(txn, nil /* *mon.BytesMonitor */); err != nil {
+			if err := td.init(txn, nil /* *mon.BytesMonitor */, nil /* *tree.EvalContext */); err != nil {
 				return err
 			}
 			resume, err = td.deleteAllRows(ctx, resumeAt, chunkSize, noAutoCommit, traceKV)

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -121,8 +121,16 @@ func (p *planner) Update(
 	if err != nil {
 		return nil, err
 	}
-	ru, err := sqlbase.MakeRowUpdater(p.txn, en.tableDesc, fkTables, updateCols,
-		requestedCols, sqlbase.RowUpdaterDefault, &p.alloc)
+	ru, err := sqlbase.MakeRowUpdater(
+		p.txn,
+		en.tableDesc,
+		fkTables,
+		updateCols,
+		requestedCols,
+		sqlbase.RowUpdaterDefault,
+		p.EvalContext(),
+		&p.alloc,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +274,8 @@ func (u *updateNode) startExec(params runParams) error {
 	if err := u.run.startEditNode(params, &u.editNodeBase); err != nil {
 		return err
 	}
-	return u.run.tw.init(params.p.txn, params.EvalContext().Mon)
+	evalCtx := params.EvalContext()
+	return u.run.tw.init(params.p.txn, evalCtx.Mon, evalCtx)
 }
 
 func (u *updateNode) Next(params runParams) (bool, error) {


### PR DESCRIPTION
Enables the addition of the ON UPDATE CASCADE action for foreign keys references.

Major changes in `rowwriter.go`:
* Added a quick check to see if a cascader is required at all (this code is in `cascader.go`). And if not, the normal path is followed.
* When a cascader is required, UpdateRow can only use a single batch per row. Unless we can read from batches without running them, this will be a requirement going forward.
* Added the ability to skip foreign key checks for `InsertRow`.
* Merge the `DeleteRow()` And `deleteRowWithoutCascade()` functions.

Major changes in `cascader.go`:
* Added the new `makeCascader` functions that check to see if a cascader is required at all.
* Of course, added `updateRows()`, which performs all the updates.
* Added the checking of foreign key constraints at the end of a `cascadeAll()` call. This of course

Unlike with deletes, there is more to keep track of when looking for orphaned rows. In the wost case, rows can be updated multiple times. So row A -> B, then B -> C, then C -> D. But we don't want to test the middle states for foreign key violations, and we only want to test A -> D. So this accomplished by storing all transitions and looking forward through these updates to find if a row was updated again. There is potential to improve this using a map of some sort, but that can be done in a further update. The normal case is that there is only a single update and there is a quick path to only check that.

There is also a need to compare the contents two rows. Using the example above, say after A -> B and then B -> C, there needs to be a way to determine that the first B is the equivalent of the second B. To accomplish this, a new function on `tree.Datums` `IsDistinctFrom()` was added that treats nulls as equivalent.

Release note (SQL): ON UPDATE CASCADE foreign key constraints are fully supported