### PR TITLE
ui: expandable job descriptions

### DIFF
--- a/pkg/ui/src/views/jobs/index.tsx
+++ b/pkg/ui/src/views/jobs/index.tsx
@@ -11,6 +11,7 @@ import { AdminUIState } from "src/redux/state";
 import { TimestampToMoment } from "src/util/convert";
 import docsURL from "src/util/docs";
 import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
+import { ExpandableString } from "src/views/shared/components/expandableString";
 import Loading from "src/views/shared/components/loading";
 import { PageConfig, PageConfigItem } from "src/views/shared/components/pageconfig";
 import { SortSetting } from "src/views/shared/components/sortabletable";
@@ -126,7 +127,7 @@ const jobsTableColumns: ColumnDescriptor<Job>[] = [
   },
   {
     title: "Description",
-    cell: job => job.description,
+    cell: job => <ExpandableString long={job.description} />,
     sort: job => job.description,
     className: "jobs-table__cell--description",
   },

--- a/pkg/ui/src/views/shared/components/expandableString/index.tsx
+++ b/pkg/ui/src/views/shared/components/expandableString/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+
+interface ExpandableStringProps {
+  short?: string;
+  long: string;
+}
+
+interface ExpandableStringState {
+  expanded: boolean;
+}
+
+// ExpandableString displays a short string with a clickable ellipsis. When
+// clicked, the component displays long. If short is not specified, it uses
+// the first 50 chars of long.
+export class ExpandableString extends React.Component<ExpandableStringProps, ExpandableStringState> {
+  state: ExpandableStringState = {
+    expanded: false,
+  };
+  onClick = (ev: any) => {
+    ev.preventDefault();
+    this.setState({ expanded: true });
+  }
+  render() {
+    const truncateLength = 50;
+    if (this.state.expanded || this.props.long.length <= truncateLength + 2) {
+      return <span>{this.props.long}</span>;
+    }
+    const short = this.props.short || this.props.long.substr(0, truncateLength).trim();
+    return (
+      <span>
+        {short}
+        <a href="#" onClick={this.onClick}>
+          &hellip;
+        </a>
+      </span>
+    );
+  }
+}


### PR DESCRIPTION
Release note: None

Job descriptions are very long, and generally not that useful. Truncate
them with an expandable ellipsis to show the full description.

![ss](https://user-images.githubusercontent.com/41181/34698958-e328d808-f4a8-11e7-9473-3b7155818c3e.png)