### PR TITLE
rsg: disallow read only in syntax tests

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -106,6 +106,9 @@ func TestRandomSyntaxGeneration(t *testing.T) {
 		if strings.HasPrefix(s, "SET SESSION CHARACTERISTICS AS TRANSACTION") {
 			return errors.New("setting session characteristics is unsupported")
 		}
+		if strings.Contains(s, "READ ONLY") || strings.Contains(s, "read_only") {
+			return errors.New("READ ONLY settings are unsupported")
+		}
 		// Recreate the database on every run in case it was dropped or renamed in
 		// a previous run. Should always succeed.
 		if err := db.exec(`CREATE DATABASE IF NOT EXISTS ident`); err != nil {


### PR DESCRIPTION
Release note: None

Fixes #20605