### PR TITLE
sql: introduce CCL-only statements: `GRANT|REVOKE <role>`

### DIFF
--- a/docs/generated/sql/bnf/grant_stmt.bnf
+++ b/docs/generated/sql/bnf/grant_stmt.bnf
@@ -1,2 +1,4 @@
 grant_stmt ::=
-	'GRANT' ( 'ALL' | ( ( ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( ( table_name ) ( ( ',' table_name ) )* ) | 'TABLE' ( ( table_name ) ( ( ',' table_name ) )* ) | 'DATABASE' ( ( name ) ( ( ',' name ) )* ) ) 'TO' ( ( name ) ( ( ',' name ) )* )
+	'GRANT' ( 'ALL' | ( ( ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* ) ) 'ON' ( ( ( table_name ) ( ( ',' table_name ) )* ) | 'TABLE' ( ( table_name ) ( ( ',' table_name ) )* ) | 'DATABASE' ( ( name ) ( ( ',' name ) )* ) ) 'TO' ( ( name ) ( ( ',' name ) )* )
+	| 'GRANT' ( ( ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* ) 'TO' ( ( name ) ( ( ',' name ) )* )
+	| 'GRANT' ( ( ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* ) 'TO' ( ( name ) ( ( ',' name ) )* ) 'WITH' 'ADMIN' 'OPTION'

--- a/docs/generated/sql/bnf/revoke_stmt.bnf
+++ b/docs/generated/sql/bnf/revoke_stmt.bnf
@@ -1,25 +1,24 @@
 revoke_stmt ::=
-	'REVOKE' 'ALL' 'ON' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'ALL' 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'ALL' 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'CREATE' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'CREATE' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'CREATE' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'DROP' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'DROP' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'DROP' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'GRANT' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'GRANT' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'GRANT' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'SELECT' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'SELECT' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'SELECT' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'INSERT' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'INSERT' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'INSERT' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'DELETE' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'DELETE' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'DELETE' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'UPDATE' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'UPDATE' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' name ( ( ',' name ) )*
-	| 'REVOKE' 'UPDATE' ( ( ',' ( 'CREATE' | 'DROP' | 'GRANT' | 'SELECT' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' name ( ( ',' name ) )*
+	'REVOKE' 'ALL' 'ON' table_name ( ',' table_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'ALL' 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'ALL' 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' name ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' name ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' name ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'CREATE' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'CREATE' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'CREATE' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'GRANT' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'GRANT' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'GRANT' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'SELECT' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' table_name ( ',' table_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'SELECT' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' 'TABLE' table_name ( ',' table_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'SELECT' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'ON' 'DATABASE' database_name ( ',' database_name )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' name ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'CREATE' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'GRANT' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'SELECT' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'ADMIN' 'OPTION' 'FOR' name ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'ADMIN' 'OPTION' 'FOR' 'CREATE' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'ADMIN' 'OPTION' 'FOR' 'GRANT' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'FROM' database_name ( ',' database_name )*
+	| 'REVOKE' 'ADMIN' 'OPTION' 'FOR' 'SELECT' ( ( ',' ( name | 'CREATE' | 'GRANT' | 'SELECT' ) ) )* 'FROM' database_name ( ',' database_name )*

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -85,7 +85,9 @@ explain_stmt ::=
 	| 'EXPLAIN' '(' explain_option_list ')' explainable_stmt
 
 grant_stmt ::=
-	'GRANT' privileges 'ON' targets 'TO' grantee_list
+	'GRANT' privileges 'ON' targets 'TO' name_list
+	| 'GRANT' privilege_list 'TO' name_list
+	| 'GRANT' privilege_list 'TO' name_list 'WITH' 'ADMIN' 'OPTION'
 
 insert_stmt ::=
 	opt_with_clause 'INSERT' 'INTO' insert_target insert_rest returning_clause
@@ -109,7 +111,9 @@ resume_stmt ::=
 	'RESUME' 'JOB' a_expr
 
 revoke_stmt ::=
-	'REVOKE' privileges 'ON' targets 'FROM' grantee_list
+	'REVOKE' privileges 'ON' targets 'FROM' name_list
+	| 'REVOKE' privilege_list 'FROM' name_list
+	| 'REVOKE' 'ADMIN' 'OPTION' 'FOR' privilege_list 'FROM' name_list
 
 savepoint_stmt ::=
 	'SAVEPOINT' name
@@ -300,8 +304,11 @@ privileges ::=
 	'ALL'
 	| privilege_list
 
-grantee_list ::=
+name_list ::=
 	( name ) ( ( ',' name ) )*
+
+privilege_list ::=
+	( privilege ) ( ( ',' privilege ) )*
 
 insert_target ::=
 	qualified_name
@@ -536,9 +543,6 @@ alter_user_password_stmt ::=
 table_pattern_list ::=
 	( table_pattern ) ( ( ',' table_pattern ) )*
 
-name_list ::=
-	( name ) ( ( ',' name ) )*
-
 non_reserved_word_or_sconst ::=
 	non_reserved_word
 	| 'SCONST'
@@ -582,6 +586,7 @@ unreserved_keyword ::=
 	'ABORT'
 	| 'ACTION'
 	| 'ADD'
+	| 'ADMIN'
 	| 'ALTER'
 	| 'AT'
 	| 'BACKUP'
@@ -666,6 +671,7 @@ unreserved_keyword ::=
 	| 'OF'
 	| 'OFF'
 	| 'OID'
+	| 'OPTION'
 	| 'OPTIONS'
 	| 'ORDINALITY'
 	| 'OVER'
@@ -868,8 +874,11 @@ expr_list ::=
 explain_option_name ::=
 	non_reserved_word
 
-privilege_list ::=
-	( privilege ) ( ( ',' privilege ) )*
+privilege ::=
+	name
+	| 'CREATE'
+	| 'GRANT'
+	| 'SELECT'
 
 opt_conf_expr ::=
 	'(' name_list ')' where_clause
@@ -988,7 +997,7 @@ on_privilege_target_clause ::=
 	| 
 
 for_grantee_clause ::=
-	'FOR' grantee_list
+	'FOR' name_list
 	| 
 
 opt_compact ::=
@@ -1180,15 +1189,6 @@ table_name_with_index_list ::=
 
 table_name_list ::=
 	( any_name ) ( ( ',' any_name ) )*
-
-privilege ::=
-	'CREATE'
-	| 'DROP'
-	| 'GRANT'
-	| 'SELECT'
-	| 'INSERT'
-	| 'DELETE'
-	| 'UPDATE'
 
 column_def ::=
 	name typename col_qual_list

--- a/pkg/ccl/sqlccl/logictestccl/testdata/logic_test/role
+++ b/pkg/ccl/sqlccl/logictestccl/testdata/logic_test/role
@@ -100,3 +100,286 @@ DROP ROLE IF EXISTS rolec, roled, rolee
 
 statement ok
 DROP ROLE rolea, roleb
+
+query T colnames
+SHOW ROLES
+----
+username
+admin
+
+statement ok
+CREATE USER testuser2
+
+statement ok
+CREATE ROLE testrole
+
+# Test that only roles are grantable.
+statement error pq: role testuser does not exist
+GRANT testuser TO testrole
+
+statement error pq: user or role unknownuser does not exist
+GRANT testrole TO unknownuser
+
+statement error pq: role unknownrole does not exist
+GRANT unknownrole TO testuser
+
+# Test role "grant" and WITH ADMIN option.
+user testuser
+
+statement error pq: testuser is not a superuser or role admin for role testrole
+GRANT testrole TO testuser2
+
+user root
+
+statement ok
+GRANT testrole TO testuser
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role      member    isAdmin
+admin     root      true
+testrole  testuser  false
+
+user testuser
+
+statement error pq: testuser is not a superuser or role admin for role testrole
+GRANT testrole TO testuser2
+
+user root
+
+statement ok
+GRANT testrole TO testuser WITH ADMIN OPTION
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role      member    isAdmin
+admin     root      true
+testrole  testuser  true
+
+user testuser
+
+statement ok
+GRANT testrole TO testuser2 WITH ADMIN OPTION
+
+user root
+
+statement ok
+GRANT admin TO testuser
+
+# Dropping users/roles deletes all their memberships.
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role      member     isAdmin
+admin     root       true
+admin     testuser   false
+testrole  testuser   true
+testrole  testuser2  true
+
+statement ok
+DROP USER testuser
+
+statement ok
+CREATE USER testuser
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role      member     isAdmin
+admin     root       true
+testrole  testuser2  true
+
+statement ok
+DROP ROLE testrole
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role      member     isAdmin
+admin     root       true
+
+# Test cycle detection.
+statement error pq: admin cannot be a member of itself
+GRANT admin TO admin
+
+statement ok
+CREATE ROLE rolea
+
+statement ok
+CREATE ROLE roleb
+
+statement ok
+CREATE ROLE rolec
+
+statement ok
+CREATE ROLE roled
+
+statement ok
+GRANT rolea TO roleb
+
+statement error pq: making rolea a member of roleb would create a cycle
+GRANT roleb TO rolea
+
+statement ok
+GRANT roleb TO rolec
+
+statement ok
+GRANT rolec TO roled
+
+statement error pq: rolea cannot be a member of itself
+GRANT rolea TO rolea
+
+statement error pq: making rolea a member of roleb would create a cycle
+GRANT roleb TO rolea
+
+statement error pq: making rolea a member of rolec would create a cycle
+GRANT rolec TO rolea
+
+statement error pq: making rolea a member of roled would create a cycle
+GRANT roled TO rolea
+
+statement ok
+CREATE ROLE rolee
+
+# Test inherited ADMIN OPTION.
+statement ok
+GRANT roled TO testuser
+
+statement ok
+GRANT rolea TO roleb WITH ADMIN OPTION
+
+user testuser
+
+statement error pq: testuser is not a superuser or role admin for role roled
+GRANT roled TO rolee
+
+statement error pq: testuser is not a superuser or role admin for role rolec
+GRANT rolec TO rolee
+
+statement error pq: testuser is not a superuser or role admin for role roleb
+GRANT roleb TO rolee
+
+statement ok
+GRANT rolea TO rolee
+
+user root
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role   member    isAdmin
+admin  root      true
+rolea  roleb     true
+rolea  rolee     false
+roleb  rolec     false
+rolec  roled     false
+roled  testuser  false
+
+statement ok
+DROP ROLE rolea
+
+statement ok
+DROP ROLE rolec
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role   member    isAdmin
+admin  root      true
+roled  testuser false
+
+query T
+SHOW ROLES
+----
+admin
+roleb
+roled
+rolee
+
+statement ok
+DROP ROLE roleb
+
+statement ok
+DROP ROLE roled
+
+statement ok
+DROP ROLE rolee
+
+statement error pq: user root cannot be removed from role admin or lose the ADMIN OPTION
+REVOKE admin FROM root
+
+statement error pq: user root cannot be removed from role admin or lose the ADMIN OPTION
+REVOKE ADMIN OPTION FOR admin FROM root
+
+statement error pq: user or role unknownuser does not exist
+REVOKE ADMIN OPTION FOR admin FROM unknownuser
+
+statement error pq: role unknownrole does not exist
+REVOKE ADMIN OPTION FOR unknownrole FROM root
+
+statement ok
+CREATE ROLE rolea
+
+statement ok
+CREATE ROLE roleb
+
+statement ok
+GRANT rolea,roleb TO testuser WITH ADMIN OPTION
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role   member    isAdmin
+admin  root      true
+rolea  testuser  true
+roleb  testuser  true
+
+user testuser
+
+statement ok
+GRANT rolea,roleb TO root WITH ADMIN OPTION
+
+user root
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role   member    isAdmin
+admin  root      true
+rolea  root      true
+rolea  testuser  true
+roleb  root      true
+roleb  testuser  true
+
+user testuser
+
+statement ok
+REVOKE ADMIN OPTION FOR rolea FROM testuser
+
+statement error pq: testuser is not a superuser or role admin for role rolea
+REVOKE ADMIN OPTION FOR rolea FROM root
+
+statement ok
+REVOKE roleb FROM root
+
+user root
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role   member    isAdmin
+admin  root      true
+rolea  root      true
+rolea  testuser  false
+roleb  testuser  true
+
+statement ok
+REVOKE rolea, roleb FROM testuser, root
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role   member    isAdmin
+admin  root      true

--- a/pkg/ccl/sqlccl/role.go
+++ b/pkg/ccl/sqlccl/role.go
@@ -12,8 +12,11 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 func createRolePlanHook(
@@ -54,7 +57,212 @@ func dropRolePlanHook(
 	return p.DropUserNode(ctx, dropRole.Names, dropRole.IfExists, true /* isRole */, "DROP ROLE")
 }
 
+func grantRolePlanHook(
+	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
+) (sql.PlanNode, error) {
+	grant, ok := stmt.(*tree.GrantRole)
+	if !ok {
+		return nil, nil
+	}
+
+	if err := utilccl.CheckEnterpriseEnabled(
+		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "GRANT <role>",
+	); err != nil {
+		return nil, err
+	}
+
+	if err := p.RequireSuperUser("grant role"); err != nil {
+		// Not a superuser: check permissions on each role.
+		allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range grant.Roles {
+			if isAdmin, ok := allRoles[string(r)]; !ok || !isAdmin {
+				return nil, pgerror.NewErrorf(pgerror.CodeInsufficientPrivilegeError,
+					"%s is not a superuser or role admin for role %s", p.User(), r)
+			}
+		}
+	}
+
+	// Check that users and roles exist.
+	// TODO(mberhault): just like GRANT/REVOKE privileges, we fetch the list of all users.
+	// This is wasteful when we have a LOT of users compared to the number of users being operated on.
+	users, err := p.GetAllUsersAndRoles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check roles: these have to be roles.
+	for _, r := range grant.Roles {
+		if isRole, ok := users[string(r)]; !ok || !isRole {
+			return nil, pgerror.NewErrorf(pgerror.CodeUndefinedObjectError, "role %s does not exist", r)
+		}
+	}
+
+	// Check grantees: these can be users or roles.
+	for _, m := range grant.Members {
+		if _, ok := users[string(m)]; !ok {
+			return nil, pgerror.NewErrorf(pgerror.CodeUndefinedObjectError, "user or role %s does not exist", m)
+		}
+	}
+
+	// Given an acyclic directed membership graph, adding a new edge (grant.Member ∈ grant.Role)
+	// means checking whether we have an expanded relationship (grant.Role ∈ ... ∈ grant.Member)
+	// For each grant.Role, we lookup all the roles it is a member of.
+	// After adding a given edge (grant.Member ∈ grant.Role), we add the edge to the list as well.
+	allRoleMemberships := make(map[string]map[string]bool)
+	for _, rawR := range grant.Roles {
+		r := string(rawR)
+		allRoles, err := p.MemberOfWithAdminOption(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		allRoleMemberships[r] = allRoles
+	}
+
+	// Since we perform no queries here, check all role/member pairs for cycles.
+	// Only if there are no errors do we proceed to write them.
+	for _, rawR := range grant.Roles {
+		r := string(rawR)
+		for _, rawM := range grant.Members {
+			m := string(rawM)
+			if r == m {
+				// self-cycle.
+				return nil, pgerror.NewErrorf(pgerror.CodeInvalidGrantOperationError, "%s cannot be a member of itself", m)
+			}
+			// Check if grant.Role ∈ ... ∈ grant.Member
+			if memberOf, ok := allRoleMemberships[r]; ok {
+				if _, ok = memberOf[m]; ok {
+					return nil, pgerror.NewErrorf(pgerror.CodeInvalidGrantOperationError,
+						"making %s a member of %s would create a cycle", m, r)
+				}
+			}
+			// Add the new membership. We don't care about the actual bool value.
+			if _, ok := allRoleMemberships[m]; !ok {
+				allRoleMemberships[m] = make(map[string]bool)
+			}
+			allRoleMemberships[m][r] = false
+		}
+	}
+
+	// Add memberships. Existing memberships are allowed.
+	// If admin option is false, we do not remove it from existing memberships.
+	memberStmt := `INSERT INTO system.role_members ("role", "member", "isAdmin") VALUES ($1, $2, $3) ON CONFLICT ("role", "member")`
+	if grant.AdminOption {
+		// admin option: true, set "isAdmin" even if the membership exists.
+		memberStmt += ` DO UPDATE SET "isAdmin" = true`
+	} else {
+		// admin option: false, do not clear it from existing memberships.
+		memberStmt += ` DO NOTHING`
+	}
+
+	internalExecutor := sql.InternalExecutor{LeaseManager: p.LeaseMgr()}
+	for _, r := range grant.Roles {
+		for _, m := range grant.Members {
+			_, err := internalExecutor.ExecuteStatementInTransaction(
+				ctx,
+				"grant-role",
+				p.Txn(),
+				memberStmt,
+				r, m, grant.AdminOption,
+			)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &sql.ZeroNode{}, nil
+}
+
+func revokeRolePlanHook(
+	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
+) (sql.PlanNode, error) {
+	revoke, ok := stmt.(*tree.RevokeRole)
+	if !ok {
+		return nil, nil
+	}
+
+	if err := utilccl.CheckEnterpriseEnabled(
+		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "REVOKE <role>",
+	); err != nil {
+		return nil, err
+	}
+
+	if err := p.RequireSuperUser("revoke role"); err != nil {
+		// Not a superuser: check permissions on each role.
+		allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range revoke.Roles {
+			if isAdmin, ok := allRoles[string(r)]; !ok || !isAdmin {
+				return nil, pgerror.NewErrorf(pgerror.CodeInsufficientPrivilegeError,
+					"%s is not a superuser or role admin for role %s", p.User(), r)
+			}
+		}
+	}
+
+	// Check that users and roles exist.
+	// TODO(mberhault): just like GRANT/REVOKE privileges, we fetch the list of all users.
+	// This is wasteful when we have a LOT of users compared to the number of users being operated on.
+	users, err := p.GetAllUsersAndRoles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check roles: these have to be roles.
+	for _, r := range revoke.Roles {
+		if isRole, ok := users[string(r)]; !ok || !isRole {
+			return nil, pgerror.NewErrorf(pgerror.CodeUndefinedObjectError, "role %s does not exist", r)
+		}
+	}
+
+	// Check members: these can be users or roles.
+	for _, m := range revoke.Members {
+		if _, ok := users[string(m)]; !ok {
+			return nil, pgerror.NewErrorf(pgerror.CodeUndefinedObjectError, "user or role %s does not exist", m)
+		}
+	}
+
+	var memberStmt string
+	if revoke.AdminOption {
+		// ADMIN OPTION FOR is specified, we don't remove memberships just remove the admin option.
+		memberStmt = `UPDATE system.role_members SET "isAdmin" = false WHERE "role" = $1 AND "member" = $2`
+	} else {
+		// Admin option not specified: remove membership if it exists.
+		memberStmt = `DELETE FROM system.role_members WHERE "role" = $1 AND "member" = $2`
+	}
+
+	internalExecutor := sql.InternalExecutor{LeaseManager: p.LeaseMgr()}
+	for _, r := range revoke.Roles {
+		for _, m := range revoke.Members {
+			if string(r) == sqlbase.AdminRole && string(m) == security.RootUser {
+				// We use CodeObjectInUseError which is what happens if you tried to delete the current user in pg.
+				return nil, pgerror.NewErrorf(pgerror.CodeObjectInUseError,
+					"user %s cannot be removed from role %s or lose the ADMIN OPTION",
+					security.RootUser, sqlbase.AdminRole)
+			}
+			_, err := internalExecutor.ExecuteStatementInTransaction(
+				ctx,
+				"revoke-role",
+				p.Txn(),
+				memberStmt,
+				r, m,
+			)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return &sql.ZeroNode{}, nil
+}
+
 func init() {
 	sql.AddWrappedPlanHook(createRolePlanHook)
 	sql.AddWrappedPlanHook(dropRolePlanHook)
+	sql.AddWrappedPlanHook(grantRolePlanHook)
+	sql.AddWrappedPlanHook(revokeRolePlanHook)
 }

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -521,7 +521,7 @@ var specs = []stmtSpec{
 	{name: "family_def", inline: []string{"opt_name", "name_list"}},
 	{
 		name:    "grant_stmt",
-		inline:  []string{"privileges", "privilege_list", "privilege", "targets", "grantee_list", "table_pattern_list", "name_list"},
+		inline:  []string{"privileges", "privilege_list", "privilege", "targets", "table_pattern_list", "name_list"},
 		replace: map[string]string{"table_pattern": "table_name", "'DATABASE' ( name ( ',' name )* )": "'DATABASE' ( database_name ( ',' database_name )* )", "'TO' ( name ( ',' name )* )": "'TO' ( user_name ( ',' user_name )* )"},
 		unlink:  []string{"table_name", "database_name", "user_name"},
 		nosplit: true,
@@ -587,7 +587,7 @@ var specs = []stmtSpec{
 	},
 	{
 		name:   "revoke_stmt",
-		inline: []string{"privileges", "privilege_list", "privilege", "targets", "grantee_list"},
+		inline: []string{"privileges", "privilege_list", "privilege", "targets"},
 		replace: map[string]string{
 			"table_pattern_list":        "table_name ( ',' table_name )*",
 			"name_list":                 "database_name ( ',' database_name )*",
@@ -677,7 +677,7 @@ var specs = []stmtSpec{
 	{
 		name:   "show_grants",
 		stmt:   "show_stmt",
-		inline: []string{"on_privilege_target_clause", "targets", "for_grantee_clause", "grantee_list", "table_pattern_list", "name_list"},
+		inline: []string{"on_privilege_target_clause", "targets", "for_grantee_clause", "table_pattern_list", "name_list"},
 		match:  []*regexp.Regexp{regexp.MustCompile("'SHOW' 'GRANTS'")},
 		replace: map[string]string{
 			"table_pattern":                 "table_name",

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -15,14 +15,17 @@
 package sql
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 // AuthorizationAccessor for checking authorization (e.g. desc privileges).
+// TODO(mberhault): expand role membership for Check* and RequireSuperUser.
 type AuthorizationAccessor interface {
 	// CheckPrivilege verifies that the user has `privilege` on `descriptor`.
 	CheckPrivilege(
@@ -35,6 +38,10 @@ type AuthorizationAccessor interface {
 	// RequiresSuperUser errors if the session user isn't a super-user (i.e. root
 	// or node). Includes the named action in the error message.
 	RequireSuperUser(action string) error
+
+	// MemberOfWithAdminOption looks up all the roles (direct and indirect) that 'member' is a member
+	// of and returns a map of role -> isAdmin.
+	MemberOfWithAdminOption(ctx context.Context, member string) (map[string]bool, error)
 }
 
 var _ AuthorizationAccessor = &planner{}
@@ -77,4 +84,55 @@ func (p *planner) RequireSuperUser(action string) error {
 		return fmt.Errorf("only %s is allowed to %s", security.RootUser, action)
 	}
 	return nil
+}
+
+// MemberOfWithAdminOption looks up all the roles 'member' belongs to (direct and indirect) and
+// returns a map of "role" -> "isAdmin".
+// The "isAdmin" flag applies to both direct and indirect members.
+func (p *planner) MemberOfWithAdminOption(
+	ctx context.Context, member string,
+) (map[string]bool, error) {
+	ret := map[string]bool{}
+
+	// Keep track of members we looked up.
+	visited := map[string]struct{}{}
+
+	toVisit := []string{member}
+
+	lookupRolesStmt := `SELECT "role", "isAdmin" FROM system.role_members WHERE "member" = $1`
+
+	internalExecutor := InternalExecutor{LeaseManager: p.LeaseMgr()}
+
+	for len(toVisit) > 0 {
+		// Pop first element.
+		m := toVisit[0]
+		toVisit = toVisit[1:]
+		if _, ok := visited[m]; ok {
+			continue
+		}
+		visited[m] = struct{}{}
+
+		rows, err := internalExecutor.QueryRowsInTransaction(
+			ctx,
+			"expand-roles",
+			p.Txn(),
+			lookupRolesStmt,
+			m,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, row := range rows {
+			roleName := tree.MustBeDString(row[0])
+			isAdmin := row[1].(*tree.DBool)
+
+			ret[string(roleName)] = bool(*isAdmin)
+
+			// We need to expand this role. Let the "pop" worry about already-visited elements.
+			toVisit = append(toVisit, string(roleName))
+		}
+	}
+
+	return ret, nil
 }

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -60,13 +60,13 @@ func (p *planner) changePrivileges(
 	changePrivilege func(*sqlbase.PrivilegeDescriptor, string),
 ) (planNode, error) {
 	// Check whether grantees exists
-	users, err := GetAllUsers(ctx, p)
+	users, err := p.GetAllUsersAndRoles(ctx)
 	if err != nil {
 		return nil, err
 	}
 	for _, grantee := range grantees {
 		if _, ok := users[string(grantee)]; !ok {
-			return nil, errors.Errorf("user %s does not exist", &grantee)
+			return nil, errors.Errorf("user or role %s does not exist", &grantee)
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/ccl
+++ b/pkg/sql/logictest/testdata/logic_test/ccl
@@ -13,3 +13,9 @@ CREATE ROLE foo
 
 statement error pq: unknown statement type: \*tree\.DropRole
 DROP ROLE foo
+
+statement error pq: unknown statement type: \*tree\.GrantRole
+GRANT foo TO testuser
+
+statement error pq: unknown statement type: \*tree\.RevokeRole
+REVOKE foo FROM testuser

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -16,7 +16,7 @@ REVOKE SELECT ON DATABASE a FROM root
 statement ok
 CREATE USER readwrite
 
-statement error pq: user "test-user" does not exist
+statement error pq: user or role "test-user" does not exist
 GRANT ALL ON DATABASE a TO readwrite, "test-user"
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -451,7 +451,7 @@ CREATE TABLE c.t (id INT PRIMARY KEY)
 statement ok
 SET DATABASE = "b"
 
-statement error pq: user vanilli does not exist
+statement error pq: user or role vanilli does not exist
 GRANT ALL ON * TO Vanilli
 
 statement ok

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -426,6 +426,8 @@ func TestParse(t *testing.T) {
 		{`GRANT SELECT, INSERT ON DATABASE bar TO foo, bar, baz`},
 		{`GRANT SELECT, INSERT ON DATABASE db1, db2 TO foo, bar, baz`},
 		{`GRANT SELECT, INSERT ON DATABASE db1, db2 TO "test-user"`},
+		{`GRANT rolea, roleb TO usera, userb`},
+		{`GRANT rolea, roleb TO usera, userb WITH ADMIN OPTION`},
 
 		// Tables are the default, but can also be specified with
 		// REVOKE x ON TABLE y. However, the stringer does not output TABLE.
@@ -435,6 +437,8 @@ func TestParse(t *testing.T) {
 		{`REVOKE ALL ON DATABASE foo FROM root, test`},
 		{`REVOKE SELECT, INSERT ON DATABASE bar FROM foo, bar, baz`},
 		{`REVOKE SELECT, INSERT ON DATABASE db1, db2 FROM foo, bar, baz`},
+		{`REVOKE rolea, roleb FROM usera, userb`},
+		{`REVOKE ADMIN OPTION FOR rolea, roleb FROM usera, userb`},
 
 		{`INSERT INTO a VALUES (1)`},
 		{`INSERT INTO a.b VALUES (1)`},

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -17,6 +17,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -67,11 +68,13 @@ type PlanHookState interface {
 	SessionData() *sessiondata.SessionData
 	ExecCfg() *ExecutorConfig
 	DistLoader() *DistLoader
+	LeaseMgr() *LeaseManager
 	TypeAsString(e tree.Expr, op string) (func() (string, error), error)
 	TypeAsStringArray(e tree.Exprs, op string) (func() ([]string, error), error)
 	TypeAsStringOpts(
 		opts tree.KVOptions, valuelessOpts map[string]bool,
 	) (func() (map[string]string, error), error)
+	Txn() *client.Txn
 	User() string
 	AuthorizationAccessor
 	// The role create/drop call into OSS code to reuse plan nodes.
@@ -82,6 +85,7 @@ type PlanHookState interface {
 	DropUserNode(
 		ctx context.Context, namesE tree.Exprs, ifExists bool, isRole bool, opName string,
 	) (*DropUserNode, error)
+	GetAllUsersAndRoles(ctx context.Context) (map[string]bool, error)
 }
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -299,6 +299,10 @@ func (p *planner) LeaseMgr() *LeaseManager {
 	return p.Tables().leaseMgr
 }
 
+func (p *planner) Txn() *client.Txn {
+	return p.txn
+}
+
 func (p *planner) User() string {
 	return p.SessionData().User
 }

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 //go:generate stringer -type=Kind
@@ -55,6 +57,18 @@ func (k Kind) Mask() uint32 {
 // ByValue is just an array of privilege kinds sorted by value.
 var ByValue = [...]Kind{
 	ALL, CREATE, DROP, GRANT, SELECT, INSERT, DELETE, UPDATE,
+}
+
+// ByName is a map of string -> kind value.
+var ByName = map[string]Kind{
+	"ALL":    ALL,
+	"CREATE": CREATE,
+	"DROP":   DROP,
+	"GRANT":  GRANT,
+	"SELECT": SELECT,
+	"INSERT": INSERT,
+	"DELETE": DELETE,
+	"UPDATE": UPDATE,
 }
 
 // List is a list of privileges.
@@ -136,6 +150,21 @@ func ListFromBitField(m uint32) List {
 		}
 	}
 	return ret
+}
+
+// ListFromStrings takes a list of strings and attempts to build a list of Kind.
+// We convert each string to uppercase and search for it in the ByName map.
+// If an entry is not found in ByName, an error is returned.
+func ListFromStrings(strs []string) (List, error) {
+	ret := make(List, len(strs))
+	for i, s := range strs {
+		k, ok := ByName[strings.ToUpper(s)]
+		if !ok {
+			return nil, errors.Errorf("not a valid privilege: %q", s)
+		}
+		ret[i] = k
+	}
+	return ret, nil
 }
 
 // Lists is a list of privilege lists

--- a/pkg/sql/sem/tree/grant.go
+++ b/pkg/sql/sem/tree/grant.go
@@ -82,3 +82,21 @@ func (node *Grant) Format(ctx *FmtCtx) {
 	ctx.WriteString(" TO ")
 	ctx.FormatNode(&node.Grantees)
 }
+
+// GrantRole represents a GRANT <role> statement.
+type GrantRole struct {
+	Roles       NameList
+	Members     NameList
+	AdminOption bool
+}
+
+// Format implements the NodeFormatter interface.
+func (node *GrantRole) Format(ctx *FmtCtx) {
+	ctx.WriteString("GRANT ")
+	ctx.FormatNode(&node.Roles)
+	ctx.WriteString(" TO ")
+	ctx.FormatNode(&node.Members)
+	if node.AdminOption {
+		ctx.WriteString(" WITH ADMIN OPTION")
+	}
+}

--- a/pkg/sql/sem/tree/revoke.go
+++ b/pkg/sql/sem/tree/revoke.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 )
 
-// Revoke represents a REVOKE statements.
+// Revoke represents a REVOKE statement.
 // PrivilegeList and TargetList are defined in grant.go
 type Revoke struct {
 	Privileges privilege.List
@@ -43,4 +43,22 @@ func (node *Revoke) Format(ctx *FmtCtx) {
 	ctx.FormatNode(&node.Targets)
 	ctx.WriteString(" FROM ")
 	ctx.FormatNode(&node.Grantees)
+}
+
+// RevokeRole represents a REVOKE <role> statement.
+type RevokeRole struct {
+	Roles       NameList
+	Members     NameList
+	AdminOption bool
+}
+
+// Format implements the NodeFormatter interface.
+func (node *RevokeRole) Format(ctx *FmtCtx) {
+	ctx.WriteString("REVOKE ")
+	if node.AdminOption {
+		ctx.WriteString("ADMIN OPTION FOR ")
+	}
+	ctx.FormatNode(&node.Roles)
+	ctx.WriteString(" FROM ")
+	ctx.FormatNode(&node.Members)
 }

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -387,6 +387,14 @@ func (*Grant) StatementTag() string { return "GRANT" }
 func (*Grant) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
+func (*GrantRole) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*GrantRole) StatementTag() string { return "GRANT" }
+
+func (*GrantRole) hiddenFromStats() {}
+
+// StatementType implements the Statement interface.
 func (n *Insert) StatementType() StatementType { return n.Returning.statementType() }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -484,6 +492,14 @@ func (*Revoke) StatementType() StatementType { return DDL }
 func (*Revoke) StatementTag() string { return "REVOKE" }
 
 func (*Revoke) hiddenFromStats() {}
+
+// StatementType implements the Statement interface.
+func (*RevokeRole) StatementType() StatementType { return DDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*RevokeRole) StatementTag() string { return "REVOKE" }
+
+func (*RevokeRole) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
 func (*RollbackToSavepoint) StatementType() StatementType { return Ack }
@@ -855,6 +871,7 @@ func (n *DropUser) String() string                  { return AsString(n) }
 func (n *Execute) String() string                   { return AsString(n) }
 func (n *Explain) String() string                   { return AsString(n) }
 func (n *Grant) String() string                     { return AsString(n) }
+func (n *GrantRole) String() string                 { return AsString(n) }
 func (n *Insert) String() string                    { return AsString(n) }
 func (n *Import) String() string                    { return AsString(n) }
 func (n *ParenSelect) String() string               { return AsString(n) }
@@ -869,6 +886,7 @@ func (n *RenameTable) String() string               { return AsString(n) }
 func (n *Restore) String() string                   { return AsString(n) }
 func (n *ResumeJob) String() string                 { return AsString(n) }
 func (n *Revoke) String() string                    { return AsString(n) }
+func (n *RevokeRole) String() string                { return AsString(n) }
 func (n *RollbackToSavepoint) String() string       { return AsString(n) }
 func (n *RollbackTransaction) String() string       { return AsString(n) }
 func (n *Savepoint) String() string                 { return AsString(n) }

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -57,19 +57,21 @@ func GetUserHashedPassword(
 	return exists, hashedPassword, err
 }
 
-// GetAllUsers returns all the usernames in system.users.
-func GetAllUsers(ctx context.Context, plan *planner) (map[string]bool, error) {
-	query := `SELECT username FROM system.users`
-	p := makeInternalPlanner("get-all-user", plan.txn, security.RootUser, plan.extendedEvalCtx.MemMetrics)
-	defer finishInternalPlanner(p)
-	rows, err := p.queryRows(ctx, query)
+// The map value is true if the map key is a role, false if it is a user.
+func (p *planner) GetAllUsersAndRoles(ctx context.Context) (map[string]bool, error) {
+	query := `SELECT username,"isRole"  FROM system.users`
+	newPlanner := makeInternalPlanner("get-all-users-and-roles", p.txn, security.RootUser, p.extendedEvalCtx.MemMetrics)
+	defer finishInternalPlanner(newPlanner)
+	rows, err := newPlanner.queryRows(ctx, query)
 	if err != nil {
 		return nil, err
 	}
 
 	users := make(map[string]bool)
 	for _, row := range rows {
-		users[string(tree.MustBeDString(row[0]))] = true
+		username := tree.MustBeDString(row[0])
+		isRole := row[1].(*tree.DBool)
+		users[string(username)] = bool(*isRole)
 	}
 	return users, nil
 }

--- a/pkg/sql/zero.go
+++ b/pkg/sql/zero.go
@@ -20,6 +20,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
+// ZeroNode is the exported alias for zeroNode. Used by CCL.
+type ZeroNode = zeroNode
+
 // zeroNode is a planNode with no columns and no rows and is used for nodes that
 // have no results. (e.g. a table for which the filtering condition has a
 // contradiction)


### PR DESCRIPTION
Release note (sql change): introduce experimental statements
`GRANT|REVOKE <role>` to grant/revoke role memberships.

Part of [role-based access control](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20171220_sql_role_based_access_control.md).

`GRANT <roles> TO <users or roles> [WITH ADMIN OPTION]` adds `users or roles` as members of `roles` or adds the ADMIN
OPTION if they already exist.

`REVOKE [ADMIN OPTION FOR] <roles> FROM <users or roles>` removes the
ADMIN OPTION or the entire membership.

`ADMIN OPTION` allows the member to modify this role's memberships, it is
inherited. It can be added/removed for a given membership if the
relationship exists.

The help message for `GRANT` and `REVOKE` cover both privileges and roles as we don't have a good way to split them.

See [RFC](https://github.com/cockroachdb/cockroach/blob/master/docs/RFCS/20171220_sql_role_based_access_control.md#grant-role) for behavior details.