### PR TITLE
cli/start: log uid/gid details in the log file

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -761,6 +761,13 @@ func reportConfiguration(ctx context.Context) {
 	if envVarsUsed := envutil.GetEnvVarsUsed(); len(envVarsUsed) > 0 {
 		log.Infof(ctx, "using local environment variables: %s", strings.Join(envVarsUsed, ", "))
 	}
+	// If a user ever reports "bad things have happened", any
+	// troubleshooting steps will want to rule out that the user was
+	// running as root in a multi-user environment, or using different
+	// uid/gid across runs in the same data directory. To determine
+	// this, it's easier if the information appears in the log file.
+	log.Infof(ctx, "process identity: uid %d euid %d gid %d egid %d",
+		syscall.Getuid(), syscall.Geteuid(), syscall.Getgid(), syscall.Getegid())
 }
 
 func maybeWarnMemorySizes(ctx context.Context) {


### PR DESCRIPTION
Fixes #21342.
(I used a non-obtrusive, non-prescriptive solution since root processes are used in containers.)

In troubleshooting scenarios where users report "I am encountering
permission errors" or "I can't seem to access files", etc., we will
want to check that they are running with consistent uid/gid
information. So log them upon start up.

In addition, an informative disclaimer is also logged if the process
happens to be running as root, for example:

```
W180109 17:28:31.252473 1 cli/start.go:773  process is starting as root.
DISCLAIMER: CockroachDB running as root can pose a security risk to the rest of the system unless securely contained.
```

Release note: None