### PR TITLE
acceptance: update IsSQLRetryableError

### DIFF
--- a/pkg/testutils/error.go
+++ b/pkg/testutils/error.go
@@ -63,7 +63,7 @@ func IsPError(pErr *roachpb.Error, re string) bool {
 func IsSQLRetryableError(err error) bool {
 	// Don't forget to update the corresponding test when making adjustments
 	// here.
-	return IsError(err, "(connection reset by peer|connection refused|failed to send RPC|EOF|result is ambiguous)")
+	return IsError(err, "(connection reset by peer|connection refused|failed to send RPC|EOF|result is ambiguous|connection is unavailable)")
 }
 
 // Caller returns filename and line number info for the specified stack


### PR DESCRIPTION
Saw a test flake with

```
zchaos_test.go:152: pq: rpc error: code = Unavailable desc = grpc: the connection is unavailable
```

Release note: None