### PR TITLE
sql: remove vestigial partition zone configs on repartitioning

### DIFF
--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -68,9 +68,13 @@ func (n *alterIndexNode) startExec(params runParams) error {
 				&n.indexDesc.Partitioning,
 				&partitioning,
 			)
+			err = deleteRemovedPartitionZoneConfigs(
+				params.ctx, params.p.txn, params.p.ExecCfg().Settings, params.p.ExecCfg().LeaseManager,
+				n.tableDesc, &n.tableDesc.PrimaryIndex, &n.tableDesc.PrimaryIndex.Partitioning, &partitioning)
+			if err != nil {
+				return err
+			}
 			n.indexDesc.Partitioning = partitioning
-			// TODO(dan): Remove zone configs which no longer point at a
-			// partition.
 		default:
 			return fmt.Errorf("unsupported alter command: %T", cmd)
 		}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -477,9 +477,13 @@ func (n *alterTableNode) startExec(params runParams) error {
 				&n.tableDesc.PrimaryIndex.Partitioning,
 				&partitioning,
 			)
+			err = deleteRemovedPartitionZoneConfigs(
+				params.ctx, params.p.txn, params.p.ExecCfg().Settings, params.p.ExecCfg().LeaseManager,
+				n.tableDesc, &n.tableDesc.PrimaryIndex, &n.tableDesc.PrimaryIndex.Partitioning, &partitioning)
+			if err != nil {
+				return err
+			}
 			n.tableDesc.PrimaryIndex.Partitioning = partitioning
-			// TODO(dan): Remove zone configs which no longer point at a
-			// partition. This also needs to be done for indexes.
 		default:
 			return fmt.Errorf("unsupported alter command: %T", cmd)
 		}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2446,3 +2446,27 @@ func (desc *TableDescriptor) NumColumns() int {
 func (desc *TableDescriptor) Column(i int) optbase.Column {
 	return &desc.Columns[i]
 }
+
+// PartitionNames returns a slice containing the name of every partition and
+// subpartition in an arbitrary order.
+func (desc *TableDescriptor) PartitionNames() []string {
+	var names []string
+	for _, index := range desc.AllNonDropIndexes() {
+		names = append(names, index.Partitioning.PartitionNames()...)
+	}
+	return names
+}
+
+// PartitionNames returns a slice containing the name of every partition and
+// subpartition in an arbitrary order.
+func (desc *PartitioningDescriptor) PartitionNames() []string {
+	var names []string
+	for _, l := range desc.List {
+		names = append(names, l.Name)
+		names = append(names, l.Subpartitioning.PartitionNames()...)
+	}
+	for _, r := range desc.Range {
+		names = append(names, r.Name)
+	}
+	return names
+}

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -227,4 +228,38 @@ func resolveSubzone(
 		return table, index, partitionName, nil
 	}
 	return table, nil, "", nil
+}
+
+func deleteRemovedPartitionZoneConfigs(
+	ctx context.Context,
+	txn *client.Txn,
+	settings *cluster.Settings,
+	leaseMgr *LeaseManager,
+	tableDesc *sqlbase.TableDescriptor,
+	idxDesc *sqlbase.IndexDescriptor,
+	oldPartDesc *sqlbase.PartitioningDescriptor,
+	newPartDesc *sqlbase.PartitioningDescriptor,
+) error {
+	newNames := map[string]struct{}{}
+	for _, n := range newPartDesc.PartitionNames() {
+		newNames[n] = struct{}{}
+	}
+	removedNames := []string{}
+	for _, n := range oldPartDesc.PartitionNames() {
+		if _, exists := newNames[n]; !exists {
+			removedNames = append(removedNames, n)
+		}
+	}
+	if len(removedNames) == 0 {
+		return nil
+	}
+	zone, err := getZoneConfigRaw(ctx, txn, tableDesc.ID)
+	if err != nil {
+		return err
+	}
+	for _, n := range removedNames {
+		zone.DeleteSubzone(uint32(idxDesc.ID), n)
+	}
+	_, err = writeZoneConfig(ctx, txn, settings, leaseMgr, tableDesc.ID, tableDesc, zone)
+	return err
 }


### PR DESCRIPTION
When a repartitioning removes partitions, delete zone configs for those
removed partitions.