### PR TITLE
server,licenseccl: post license type to reg server

### DIFF
--- a/pkg/ccl/utilccl/license_check.go
+++ b/pkg/ccl/utilccl/license_check.go
@@ -56,6 +56,7 @@ func CheckEnterpriseEnabled(st *cluster.Settings, cluster uuid.UUID, org, featur
 
 func init() {
 	server.LicenseCheckFn = CheckEnterpriseEnabled
+	server.LicenseTypeFn = getLicenseType
 }
 
 func checkEnterpriseEnabledAt(
@@ -71,4 +72,16 @@ func checkEnterpriseEnabledAt(
 		}
 	}
 	return lic.Check(at, cluster, org, feature)
+}
+
+func getLicenseType(st *cluster.Settings) (string, error) {
+	str := enterpriseLicense.Get(&st.SV)
+	if str == "" {
+		return "None", nil
+	}
+	lic, err := licenseccl.Decode(str)
+	if err != nil {
+		return "", err
+	}
+	return lic.Type.String(), nil
 }

--- a/pkg/ccl/utilccl/license_check_test.go
+++ b/pkg/ccl/utilccl/license_check_test.go
@@ -69,6 +69,46 @@ func TestSettingAndCheckingLicense(t *testing.T) {
 	}
 }
 
+func TestGetLicenseTypePresent(t *testing.T) {
+	for _, tc := range []struct {
+		licenseType licenseccl.License_Type
+		expected    string
+	}{
+		{licenseccl.License_NonCommercial, "NonCommercial"},
+		{licenseccl.License_Enterprise, "Enterprise"},
+		{licenseccl.License_Evaluation, "Evaluation"},
+	} {
+		st := cluster.MakeTestingClusterSettings()
+		updater := st.MakeUpdater()
+		lic, _ := licenseccl.License{
+			ClusterID:         []uuid.UUID{},
+			Type:              tc.licenseType,
+			ValidUntilUnixSec: 0,
+		}.Encode()
+		if err := updater.Set("enterprise.license", lic, "s"); err != nil {
+			t.Fatal(err)
+		}
+		actual, err := getLicenseType(st)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if actual != tc.expected {
+			t.Fatalf("expected license type %s, got %s", tc.expected, actual)
+		}
+	}
+}
+
+func TestGetLicenseTypeAbsent(t *testing.T) {
+	expected := "None"
+	actual, err := getLicenseType(cluster.MakeTestingClusterSettings())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual != expected {
+		t.Fatalf("expected license type %s, got %s", expected, actual)
+	}
+}
+
 func TestSettingBadLicenseStrings(t *testing.T) {
 	for _, tc := range []struct{ lic, err string }{
 		{"blah", "invalid license string"},

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -96,6 +96,13 @@ var (
 	) error {
 		return errors.New("OSS build does not include Enterprise features")
 	}
+
+	// LicenseTypeFn returns what type of license the cluster is running with, or
+	// "OSS" if it is an OSS build. This function is overridden by an init hook in
+	// CCL builds.
+	LicenseTypeFn = func(st *cluster.Settings) (string, error) {
+		return "OSS", nil
+	}
 )
 
 // Server is the cockroach server node.

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -77,6 +77,10 @@ func TestCheckVersion(t *testing.T) {
 	if expected, actual := build.GetInfo().Tag, r.last.version; expected != actual {
 		t.Errorf("expected version tag %v, got %v", expected, actual)
 	}
+
+	if expected, actual := "OSS", r.last.licenseType; expected != actual {
+		t.Errorf("expected license type %v, got %v", expected, actual)
+	}
 }
 
 func TestReportUsage(t *testing.T) {
@@ -323,8 +327,9 @@ type mockRecorder struct {
 	syncutil.Mutex
 	requests int
 	last     struct {
-		uuid    string
-		version string
+		uuid        string
+		version     string
+		licenseType string
 		diagnosticspb.DiagnosticReport
 		rawReportBody string
 	}
@@ -342,6 +347,7 @@ func makeMockRecorder(t *testing.T) *mockRecorder {
 		rec.requests++
 		rec.last.uuid = r.URL.Query().Get("uuid")
 		rec.last.version = r.URL.Query().Get("version")
+		rec.last.licenseType = r.URL.Query().Get("licensetype")
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Registration server requests now include a `licensetype` URL parameter
which specifies what type of license the cluster has, if any. Possible
values are `None`, `OSS`, `NonCommercial`, `Enterprise`, `Evaluation`.

Fixes #21320.

Release note: None