### PR TITLE
sql: better error message for ambiguous columns

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -850,13 +850,37 @@ func (src *dataSourceInfo) checkDatabaseName(tn tree.TableName) (tree.TableName,
 }
 
 func findColHelper(
-	src *dataSourceInfo, c *tree.ColumnItem, colName string, iSrc, srcIdx, colIdx, idx int,
+	sources multiSourceInfo,
+	src *dataSourceInfo,
+	c *tree.ColumnItem,
+	colName string,
+	iSrc, srcIdx, colIdx, idx int,
 ) (int, int, error) {
 	col := src.sourceColumns[idx]
 	if col.Name == colName {
 		if colIdx != invalidColIdx {
+			colString := tree.ErrString(c)
+			var msgBuf bytes.Buffer
+			sep := ""
+			fmtCandidate := func(alias *sourceAlias) {
+				name := tree.ErrString(&alias.name.TableName)
+				if len(name) == 0 {
+					name = "<anonymous>"
+				}
+				fmt.Fprintf(&msgBuf, "%s%s.%s", sep, name, colString)
+			}
+			for i := range src.sourceAliases {
+				fmtCandidate(&src.sourceAliases[i])
+				sep = ", "
+			}
+			if iSrc != srcIdx {
+				for i := range sources[srcIdx].sourceAliases {
+					fmtCandidate(&sources[srcIdx].sourceAliases[i])
+					sep = ", "
+				}
+			}
 			return invalidSrcIdx, invalidColIdx, pgerror.NewErrorf(pgerror.CodeAmbiguousColumnError,
-				"column reference %q is ambiguous", tree.ErrString(c))
+				"column reference %q is ambiguous (candidates: %s)", colString, msgBuf.String())
 		}
 		srcIdx = iSrc
 		colIdx = idx
@@ -897,7 +921,7 @@ func (sources multiSourceInfo) findColumn(c *tree.ColumnItem) (srcIdx int, colId
 			continue
 		}
 		for idx, ok := colSet.Next(0); ok; idx, ok = colSet.Next(idx + 1) {
-			srcIdx, colIdx, err = findColHelper(src, c, colName, iSrc, srcIdx, colIdx, idx)
+			srcIdx, colIdx, err = findColHelper(sources, src, c, colName, iSrc, srcIdx, colIdx, idx)
 			if err != nil {
 				return srcIdx, colIdx, err
 			}
@@ -909,7 +933,7 @@ func (sources multiSourceInfo) findColumn(c *tree.ColumnItem) (srcIdx int, colId
 		// columns, not just columns of the anonymous table.
 		for iSrc, src := range sources {
 			for idx := 0; idx < len(src.sourceColumns); idx++ {
-				srcIdx, colIdx, err = findColHelper(src, c, colName, iSrc, srcIdx, colIdx, idx)
+				srcIdx, colIdx, err = findColHelper(sources, src, c, colName, iSrc, srcIdx, colIdx, idx)
 				if err != nil {
 					return srcIdx, colIdx, err
 				}

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -24,7 +24,7 @@ NULL    42
   42    42
 
 # Check that name resolution chokes on ambiguity when it needs to.
-query error column reference "x" is ambiguous
+query error column reference "x" is ambiguous \(candidates: a.x, b.x\)
 SELECT x FROM onecolumn AS a, onecolumn AS b
 
 # Check that name resolution does not choke on ambiguity if an
@@ -607,10 +607,10 @@ SELECT x FROM (onecolumn JOIN othercolumn USING (x)) JOIN (onecolumn AS a JOIN o
 42
 
 # Check that multiple anonymous sources cause proper ambiguity errors.
-query error column reference "x" is ambiguous
+query error column reference "x" is ambiguous \(candidates: <anonymous>\.x\)
 SELECT x FROM (SELECT * FROM onecolumn), (SELECT * FROM onecolumn)
 
-query error column reference "x" is ambiguous
+query error column reference "x" is ambiguous \(candidates: a\.x, b\.x\)
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON x > 32)
 
 query error column name "a\.y" not found

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -25,7 +25,7 @@ UPSERT INTO kv VALUES (7, 7), (3, 8), (9, 9)
 statement ok
 INSERT INTO kv VALUES (1, 10) ON CONFLICT (k) DO UPDATE SET v = (SELECT CAST(SUM(k) AS INT) FROM kv)
 
-statement error column reference "v" is ambiguous
+statement error column reference "v" is ambiguous \(candidates: excluded.v, kv.v\)
 INSERT INTO kv VALUES (4, 10) ON CONFLICT (k) DO UPDATE SET v = v + 1
 
 statement ok


### PR DESCRIPTION
Fixes #21249.

Release note (sql change): improved error message when a column
reference is ambiguous.