### PR TITLE
acceptanceccl: fix backup store directory

### DIFF
--- a/pkg/ccl/acceptanceccl/backup_test.go
+++ b/pkg/ccl/acceptanceccl/backup_test.go
@@ -109,7 +109,7 @@ func (bt *benchmarkTest) Start(ctx context.Context) {
 			go func(nodeNum int) {
 				errors <- bt.f.Exec(nodeNum,
 					fmt.Sprintf("find %[1]s -type f -delete && curl -sfSL %s/store%d.tgz | tar -C %[1]s -zx",
-						"/mnt/data0", acceptance.FixtureURL(bt.storeFixture), nodeNum+1,
+						"/mnt/data0/cockroach-data", acceptance.FixtureURL(bt.storeFixture), nodeNum+1,
 					),
 				)
 			}(i)


### PR DESCRIPTION
A recent commit (b7c50d4f) changed the store directory for acceptance
tests, but the backup tests were still downloading stores into the old
location.

Release note: None