### PR TITLE
pkg/cli: ensure consistent defaults regardless of TESTFLAGS=-v

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -140,6 +140,18 @@ func newCLITest(params cliTestParams) cliTest {
 	return c
 }
 
+// setCLIDefaultsForTests invokes initCLIDefaults but pretends the
+// output is not a terminal, even if it happens to be. This ensures
+// e.g. that tests ran with -v have the same output as those without.
+func setCLIDefaultsForTests() {
+	initCLIDefaults()
+	cliCtx.terminalOutput = false
+	cliCtx.showTimes = false
+	// Even though we pretend there is no terminal, most tests want
+	// pretty tables.
+	cliCtx.tableDisplayFormat = tableDisplayPretty
+}
+
 // stopServer stops the test server.
 func (c *cliTest) stopServer() {
 	if c.TestServer != nil {

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -60,9 +60,11 @@ func initCLIDefaults() {
 	// other client commands are non-interactive, regardless of whether
 	// the standard input is a terminal.
 	cliCtx.isInteractive = false
+	// See also setCLIDefaultForTests() in cli_test.go.
 	cliCtx.terminalOutput = isatty.IsTerminal(os.Stdout.Fd())
 	cliCtx.tableDisplayFormat = tableDisplayTSV
 	if cliCtx.terminalOutput {
+		// See also setCLIDefaultForTests() in cli_test.go.
 		cliCtx.tableDisplayFormat = tableDisplayPretty
 	}
 	cliCtx.showTimes = false

--- a/pkg/cli/sql_test.go
+++ b/pkg/cli/sql_test.go
@@ -98,8 +98,7 @@ select '''
 		},
 	}
 
-	// Some other tests (TestDumpRow) mess with this, so make sure it's set.
-	cliCtx.tableDisplayFormat = tableDisplayPretty
+	setCLIDefaultsForTests()
 
 	// We need a temporary file with a name guaranteed to be available.
 	// So open a dummy file.

--- a/pkg/cli/sql_util_test.go
+++ b/pkg/cli/sql_util_test.go
@@ -98,10 +98,9 @@ func TestRunQuery(t *testing.T) {
 	conn := makeSQLConn(url.String())
 	defer conn.Close()
 
-	// Use a buffer as the io.Writer.
-	var b bytes.Buffer
+	setCLIDefaultsForTests()
 
-	cliCtx.tableDisplayFormat = tableDisplayPretty
+	var b bytes.Buffer
 
 	// Non-query statement.
 	if err := runQueryAndFormatResults(conn, &b, makeQuery(`SET DATABASE=system`)); err != nil {


### PR DESCRIPTION
Fixes #21355.
Fix suggested by @tamird.

Prior to this patch, CLI tests using the interactive code path
from `sql.go` would see different results depending on whether
the tests were run with `-v` or not, because the interactive
code path likes its defaults to differ based on whether the
output happens to go to a terminal.

This makes it hard to expect a fixed output in tests regardless
of the test parameters -- in fact, two tests were failing
because of this.

To alleviate this, this patch introduces a new helper function
`setCLIDefaultsForTests` to be used by tests that wish to
call into the interactive code path of `cockroach sql`.

Note: tests calling into `cockroach sql` with `RunWithArgs`
cannot utilize this function. To ensure stable test output,
these tests can use e.g. `cockroach sql -e` which currently
happens to determine the same parameter defaults regardless
of the terminal environment.

Release note: None