### PR TITLE
sqlccl: correctly handle errors during dist csv import

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -1428,7 +1428,6 @@ func (sp *sstWriter) Run(wg *sync.WaitGroup) {
 		defer wg.Done()
 	}
 
-	defer distsqlrun.DrainAndForwardMetadata(ctx, sp.input, sp.output)
 	err := func() error {
 		// Sort incoming KVs, which will be from multiple spans, into a single
 		// RocksDB instance.
@@ -1533,12 +1532,7 @@ func (sp *sstWriter) Run(wg *sync.WaitGroup) {
 		}
 		return nil
 	}()
-	if err != nil {
-		distsqlrun.DrainAndClose(ctx, sp.output, err)
-		return
-	}
-
-	sp.out.Close()
+	distsqlrun.DrainAndClose(ctx, sp.output, err, sp.input)
 }
 
 // extractSSTSpan creates an SST from the iterator, excluding keys >= end.


### PR DESCRIPTION
A customer reported an error during a large distributed CSV import. The
stack trace showed that the defered DrainAndForwardMetadata was
getting called after DrainAndClose and then panicing because there
were still rows in the inputs. DrainAndClose can also take inputs,
and calls DrainAndForwardMetadata on them. We can thus remove all
of the error handling and closing here since everything is correctly
managed in DrainAndClose.

Sadly the root cause of how this happened is unknown (i.e., what
the error was). We already have test cases that generate duplicate
primary keys which fail this function and took the error path. So
I'm not sure how to make a test that both returns an error and also
still has rows in the input sources.

Release note: None