### PR TITLE
opt: improvements for inverted index constraints

### DIFF
--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -730,7 +730,7 @@ func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
 		for _, child := range e.children {
 			sp, ok, _ := c.makeInvertedIndexSpansForExpr(child)
 			if ok {
-				// TODO(radu, masha): for now, the beset we can do is to generate
+				// TODO(radu, masha): for now, the best we can do is to generate
 				// constraints for at most one "contains" op in the disjunction; the
 				// rest are remaining filters.
 				//

--- a/pkg/sql/opt/scalar.go
+++ b/pkg/sql/opt/scalar.go
@@ -55,7 +55,7 @@ func init() {
 		isOp:                {name: "is"},
 		isNotOp:             {name: "is-not"},
 		containsOp:          {name: "contains"},
-		containedByOp:       {name: "contained-by"},
+		containedByOp:       {name: "contained-by", normalizeFn: normalizeContainedByOp},
 		anyOp:               {name: "any"},
 		someOp:              {name: "some"},
 		allOp:               {name: "all"},
@@ -329,4 +329,13 @@ func normalizeEqOp(e *Expr) {
 		// NormalizeExpr, but we may be creating new such expressions above.
 		e.children[0], e.children[1] = rhs, lhs
 	}
+}
+
+func normalizeContainedByOp(e *Expr) {
+	if e.op != containedByOp {
+		panic(fmt.Sprintf("invalid call on %s", e))
+	}
+	// Flip the condition to "contains".
+	e.op = containsOp
+	e.children[0], e.children[1] = e.children[1], e.children[0]
 }

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -1116,15 +1116,20 @@ build-scalar,index-constraints vars=(int, int) index=(@1, @2)
 ----
 [/1/2 - /1/2]
 
-build-scalar,index-constraints vars=(jsonb) inverted-index=@1
+build-scalar,normalize,index-constraints vars=(jsonb) inverted-index=@1
 @1 @> '{"a":1}'
 ----
 [/'{"a":1}' - /'{"a":1}']
 
-# We currently don't support conjunctions or disjunctions with
-# inverted indexes.
-build-scalar,index-constraints vars=(jsonb) inverted-index=@1
+# Currently we only generate spans from one of the @> expressions.
+build-scalar,normalize,index-constraints vars=(jsonb) inverted-index=@1
 @1 @> '{"a":1}' AND @1 @> '{"b":1}'
 ----
-[ - ]
-Remaining filter: (@1 @> '{"a":1}') AND (@1 @> '{"b":1}')
+[/'{"a":1}' - /'{"a":1}']
+Remaining filter: @1 @> '{"b":1}'
+
+build-scalar,normalize,index-constraints vars=(jsonb, int) inverted-index=@1
+@2 = 1 AND @1 @> '{"a":1}' AND @1 @> '{"b":1}'
+----
+[/'{"a":1}' - /'{"a":1}']
+Remaining filter: (@2 = 1) AND (@1 @> '{"b":1}')

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -1121,9 +1121,20 @@ build-scalar,normalize,index-constraints vars=(jsonb) inverted-index=@1
 ----
 [/'{"a":1}' - /'{"a":1}']
 
+build-scalar,normalize,index-constraints vars=(jsonb) inverted-index=@1
+'{"a":1}' <@ @1
+----
+[/'{"a":1}' - /'{"a":1}']
+
 # Currently we only generate spans from one of the @> expressions.
 build-scalar,normalize,index-constraints vars=(jsonb) inverted-index=@1
 @1 @> '{"a":1}' AND @1 @> '{"b":1}'
+----
+[/'{"a":1}' - /'{"a":1}']
+Remaining filter: @1 @> '{"b":1}'
+
+build-scalar,normalize,index-constraints vars=(jsonb) inverted-index=@1
+'{"a":1}' <@ @1 AND '{"b":1}' <@ @1
 ----
 [/'{"a":1}' - /'{"a":1}']
 Remaining filter: @1 @> '{"b":1}'

--- a/pkg/sql/opt/testdata/normalize
+++ b/pkg/sql/opt/testdata/normalize
@@ -348,3 +348,23 @@ is-not (type: bool)
  ├── variable (0) (type: int)
  └── variable (1) (type: int)
 @1 IS DISTINCT FROM @2
+
+build-scalar,normalize,semtree-expr vars=(jsonb)
+'{"a":1}' <@ @1
+----
+contains (type: bool)
+ ├── variable (0) (type: jsonb)
+ └── const ('{"a":1}') (type: jsonb)
+@1 @> '{"a":1}'
+
+build-scalar,normalize,semtree-expr vars=(jsonb, int)
+@2 = 2 AND '{"a":1}' <@ @1
+----
+and (type: bool)
+ ├── eq (type: bool)
+ │    ├── variable (1) (type: int)
+ │    └── const (2) (type: int)
+ └── contains (type: bool)
+      ├── variable (0) (type: jsonb)
+      └── const ('{"a":1}') (type: jsonb)
+(@2 = 2) AND (@1 @> '{"a":1}')


### PR DESCRIPTION
#### opt: partial support for conjunctions in inverted index

We now generate the spans from at most one of the "contains"
conditions in a conjunction. The rest of the conditions are in the
remaining filter.

Release note: None

#### opt: normalize containedByOp

Flip containedByOp to containsOp (which is supported by index
constraints).

Release note: None