### PR TITLE
sqlccl: test partitions of descending indexes

### DIFF
--- a/pkg/config/zone.pb.go
+++ b/pkg/config/zone.pb.go
@@ -133,7 +133,9 @@ func (*ZoneConfig) ProtoMessage()               {}
 func (*ZoneConfig) Descriptor() ([]byte, []int) { return fileDescriptorZone, []int{3} }
 
 type Subzone struct {
-	// IndexID is the ID of the SQL table index that the subzone represents.
+	// IndexID is the ID of the SQL table index that the subzone represents. It
+	// must always be set even though partition names are unique across all of a
+	// table's indices.
 	IndexID uint32 `protobuf:"varint,1,opt,name=index_id,json=indexId" json:"index_id"`
 	// PartitionName is the partition of the SQL table index that the subzone
 	// represents. It is empty when the subzone represents the entire index.

--- a/pkg/config/zone.proto
+++ b/pkg/config/zone.proto
@@ -96,7 +96,9 @@ message ZoneConfig {
 message Subzone {
   option (gogoproto.equal) = true;
 
-  // IndexID is the ID of the SQL table index that the subzone represents.
+  // IndexID is the ID of the SQL table index that the subzone represents. It
+  // must always be set even though partition names are unique across all of a
+  // table's indices.
   optional uint32 index_id = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "IndexID"];
 
   // PartitionName is the partition of the SQL table index that the subzone


### PR DESCRIPTION
Turns out these work with the code as-written, but we definitely want to
test them to prevent regressions. MINVALUE and MAXVALUE are very
confusing when used with descending indexes, but it doesn't seem like we
can do anything to resolve the confusion; see the comment within for
details.

Release note: None