### PR TITLE
Kubernetes config updates

### DIFF
--- a/cloud/kubernetes/client-secure.yaml
+++ b/cloud/kubernetes/client-secure.yaml
@@ -31,7 +31,7 @@ spec:
       mountPath: /cockroach-certs
   containers:
   - name: cockroachdb-client
-    image: cockroachdb/cockroach:v1.1.3
+    image: cockroachdb/cockroach:v1.1.4
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/cloud/kubernetes/cluster-init-secure.yaml
+++ b/cloud/kubernetes/cluster-init-secure.yaml
@@ -33,7 +33,7 @@ spec:
           mountPath: /cockroach-certs
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v1.1.3
+        image: cockroachdb/cockroach:v1.1.4
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: client-certs

--- a/cloud/kubernetes/cluster-init.yaml
+++ b/cloud/kubernetes/cluster-init.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
       - name: cluster-init
-        image: cockroachdb/cockroach:v1.1.3
+        image: cockroachdb/cockroach:v1.1.4
         imagePullPolicy: IfNotPresent
         command:
           - "/cockroach/cockroach"

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -211,7 +211,8 @@ spec:
           - "-ecx"
           # The use of qualified `hostname -f` is crucial:
           # Other nodes aren't able to look up the unqualified hostname.
-          - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --advertise-host $(hostname -f) --http-host 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
+          # Once 2.0 is out, we should be able to switch from --host to --advertise-host to make port-forwarding work to the main port.
+          - "exec /cockroach/cockroach start --logtostderr --certs-dir /cockroach/cockroach-certs --host $(hostname -f) --http-host 0.0.0.0 --join cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb --cache 25% --max-sql-memory 25%"
       # No pre-stop hook is required, a SIGTERM plus some time is all that's
       # needed for graceful shutdown of a node.
       terminationGracePeriodSeconds: 60

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -230,7 +230,6 @@ spec:
     spec:
       accessModes:
         - "ReadWriteOnce"
-      storageClassName: anything
       resources:
         requests:
           storage: 1Gi

--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -194,7 +194,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v1.1.3
+        image: cockroachdb/cockroach:v1.1.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -123,7 +123,6 @@ spec:
     spec:
       accessModes:
         - "ReadWriteOnce"
-      storageClassName: anything
       resources:
         requests:
           storage: 1Gi

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -92,7 +92,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v1.1.3
+        image: cockroachdb/cockroach:v1.1.4
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257


### PR DESCRIPTION
**cloud: Fix port-forwarding to UI of secure cluster.**

https://forum.cockroachlabs.com/t/accessing-admin-ui-on-docker-swarm/770/8

**cloud: Remove storageClassName from Kubernetes configs**

It worked fine on GKE, but is failing to provision a volume on
minikube. Just get rid of it since it isn't necessary.

**cloud: Bump Kubernetes configs from v1.1.3 to v1.1.4**

Looks like this got missed as part of the release process.