### PR TITLE
sql: Add overloads to ARRAY_AGG

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -1,7 +1,33 @@
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
-<tr><td><code>array_agg(arg1: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+<tr><td><code>array_agg(arg1: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="bytes.html">bytes</a>) &rarr; <a href="bytes.html">bytes</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="date.html">date</a>) &rarr; <a href="date.html">date</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="inet.html">inet</a>) &rarr; <a href="inet.html">inet</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="interval.html">interval</a>) &rarr; <a href="interval.html">interval</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="time.html">time</a>) &rarr; <a href="time.html">time</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="timestamp.html">timestamp</a>) &rarr; <a href="timestamp.html">timestamp</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="timestamp.html">timestamptz</a>) &rarr; <a href="timestamp.html">timestamptz</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: <a href="uuid.html">uuid</a>) &rarr; <a href="uuid.html">uuid</a>[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
+</span></td></tr>
+<tr><td><code>array_agg(arg1: oid) &rarr; oid[]</code></td><td><span class="funcdesc"><p>Aggregates the selected values into an array.</p>
 </span></td></tr>
 <tr><td><code>avg(arg1: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the average of the selected values.</p>
 </span></td></tr>

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -72,19 +72,20 @@ func initAggregateBuiltins() {
 // execution.
 // Exported for use in documentation.
 var Aggregates = map[string][]tree.Builtin{
-	"array_agg": {
-		makeAggBuiltinWithReturnType(
-			[]types.T{types.Any},
+	"array_agg": arrayBuiltin(func(t types.T) tree.Builtin {
+		return makeAggBuiltinWithReturnType(
+			[]types.T{t},
 			func(args []tree.TypedExpr) types.T {
 				if len(args) == 0 {
-					return tree.UnknownReturnType
+					return types.TArray{Typ: t}
 				}
+				// Whenever possible, use the expression's type, so we can properly
+				// handle aliased types that don't explicitly have overloads.
 				return types.TArray{Typ: args[0].ResolvedType()}
 			},
 			newArrayAggregate,
-			"Aggregates the selected values into an array.",
-		),
-	},
+			"Aggregates the selected values into an array.")
+	}),
 
 	"avg": {
 		makeAggBuiltin([]types.T{types.Int}, types.Decimal, newIntAvgAggregate,


### PR DESCRIPTION
As referenced in #15939, ARRAY_AGG erroneously returns `anyelement` as its fixed return type. This follows the convention of existing array builtin functions to have overloads for all non-array types, which allows the fixed return type to be known for each overload.

Release note (bug fix): None