### PR TITLE
ui: updates for license checking

### DIFF
--- a/pkg/ui/ccl/src/redux/license.ts
+++ b/pkg/ui/ccl/src/redux/license.ts
@@ -1,0 +1,13 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+import { AdminUIState } from "src/redux/state";
+
+export function selectEnterpriseEnabled(state: AdminUIState) {
+  return state.cachedData.cluster.valid && state.cachedData.cluster.data.enterprise_enabled;
+}

--- a/pkg/ui/ccl/src/views/shared/components/licenseSwap/index.tsx
+++ b/pkg/ui/ccl/src/views/shared/components/licenseSwap/index.tsx
@@ -1,0 +1,57 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+import React from "react";
+
+// Some of the type magic is adapted from @types/react-redux.
+// Some of the code is adapted from react-redux.
+
+type ComponentClass<P> = React.ComponentClass<P>;
+type StatelessComponent<P> = React.StatelessComponent<P>;
+type Component<P> = ComponentClass<P> | StatelessComponent<P>;
+
+function getComponentName<P>(wrappedComponent: Component<P>) {
+  return wrappedComponent.displayName
+    || wrappedComponent.name
+    || "Component";
+}
+
+function combineNames(a: string, b: string) {
+  if (a === b) {
+    return a;
+  }
+
+  return a + "," + b;
+}
+
+/**
+ * LicenseSwap is a higher-order component that swaps out two components based
+ * on the current license status.
+ */
+export default function swapByLicense<TProps>(
+  // tslint:disable:variable-name
+  OSSComponent: Component<TProps>,
+  CCLComponent: Component<TProps>,
+  // tslint:enable:variable-name
+) {
+  const ossName = getComponentName(OSSComponent);
+  const cclName = getComponentName(CCLComponent);
+
+  class LicenseSwap extends React.Component<TProps, {}> {
+    public static displayName = `LicenseSwap(${combineNames(ossName, cclName)})`;
+
+    render() {
+      if (location.hash.indexOf("pretend-license-expired") !== -1) {
+        return <OSSComponent {...this.props} />;
+      }
+      return <CCLComponent {...this.props} />;
+    }
+  }
+
+  return LicenseSwap;
+}

--- a/pkg/ui/ccl/src/views/shared/components/licenseType/index.tsx
+++ b/pkg/ui/ccl/src/views/shared/components/licenseType/index.tsx
@@ -8,7 +8,7 @@
 
 import React from "react";
 
-import swapByLicense from "src/views/shared/components/licenseSwap";
+import swapByLicense from "src/views/shared/containers/licenseSwap";
 import OSSLicenseType from "oss/src/views/shared/components/licenseType";
 
 class CCLLicenseType extends React.Component<{}, {}> {

--- a/pkg/ui/ccl/src/views/shared/components/licenseType/index.tsx
+++ b/pkg/ui/ccl/src/views/shared/components/licenseType/index.tsx
@@ -6,17 +6,13 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
-import OSSLicenseType from "oss/src/views/shared/components/licenseType";
 import React from "react";
 
-/**
- * LicenseType is an indicator showing the current build license.
- */
-export default class LicenseType extends React.Component<{}, {}> {
+import swapByLicense from "src/views/shared/components/licenseSwap";
+import OSSLicenseType from "oss/src/views/shared/components/licenseType";
+
+class CCLLicenseType extends React.Component<{}, {}> {
   render() {
-    if (location.hash.indexOf("pretend-license-expired") !== -1) {
-      return <OSSLicenseType/>;
-    }
     return (
       <div>
         <h3>License type: CCL</h3>
@@ -24,3 +20,11 @@ export default class LicenseType extends React.Component<{}, {}> {
     );
   }
 }
+
+/**
+ * LicenseType is an indicator showing the current build license.
+ */
+// tslint:disable-next-line:variable-name
+const LicenseType = swapByLicense(OSSLicenseType, CCLLicenseType);
+
+export default LicenseType;

--- a/pkg/ui/ccl/src/views/shared/containers/licenseSwap/index.tsx
+++ b/pkg/ui/ccl/src/views/shared/containers/licenseSwap/index.tsx
@@ -6,7 +6,12 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
+import _ from "lodash";
 import React from "react";
+import { connect } from "react-redux";
+
+import { selectEnterpriseEnabled } from "src/redux/license";
+import { AdminUIState } from "src/redux/state";
 
 // Some of the type magic is adapted from @types/react-redux.
 // Some of the code is adapted from react-redux.
@@ -29,6 +34,16 @@ function combineNames(a: string, b: string) {
   return a + "," + b;
 }
 
+interface OwnProps {
+  enterpriseEnabled: boolean;
+}
+
+function mapStateToProps(state: AdminUIState) {
+  return {
+    enterpriseEnabled: selectEnterpriseEnabled(state),
+  };
+}
+
 /**
  * LicenseSwap is a higher-order component that swaps out two components based
  * on the current license status.
@@ -42,16 +57,18 @@ export default function swapByLicense<TProps>(
   const ossName = getComponentName(OSSComponent);
   const cclName = getComponentName(CCLComponent);
 
-  class LicenseSwap extends React.Component<TProps, {}> {
+  class LicenseSwap extends React.Component<TProps & OwnProps, {}> {
     public static displayName = `LicenseSwap(${combineNames(ossName, cclName)})`;
 
     render() {
-      if (location.hash.indexOf("pretend-license-expired") !== -1) {
-        return <OSSComponent {...this.props} />;
+      const props = _.omit(this.props, ["enterpriseEnabled"]);
+
+      if (!this.props.enterpriseEnabled) {
+        return <OSSComponent {...props} />;
       }
-      return <CCLComponent {...this.props} />;
+      return <CCLComponent {...props} />;
     }
   }
 
-  return LicenseSwap;
+  return connect(mapStateToProps)(LicenseSwap);
 }


### PR DESCRIPTION
This is two little updates to the UI license check code.  The first commit extracts the pattern established for the example component into a higher-order component to make it easier to consistently swap out OSS and CCL implementations of a feature.  The second updates the code to actually use the server-side license status, rather than faking it with a URL parameter.