### PR TITLE
sqlccl: avoid the use of "prefix" in partition error messages

### DIFF
--- a/pkg/ccl/sqlccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/sqlccl/logictestccl/testdata/logic_test/partitioning
@@ -11,36 +11,36 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN ()
 )
 
-# NB: This table gets the automatic, hidden unique_rowid PK, so `a` is not a prefix.
-statement error declared partition columns \(a\) are not a prefix of index being partitioned \(rowid\)
+# NB: This table gets the automatic, hidden unique_rowid PK.
+statement error declared partition columns \(a\) do not match first 1 columns in index being partitioned \(rowid\)
 CREATE TABLE t (a INT, b INT, c INT) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (0)
 )
 
-statement error declared partition columns \(a, b, c\) are not a prefix of index being partitioned \(a, b\)
+statement error declared partition columns \(a, b, c\) exceed the number of columns in index being partitioned \(a, b\)
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a, b, c) (
     PARTITION p1 VALUES IN (0)
 )
 
-statement error declared partition columns \(b\) are not a prefix of index being partitioned \(a, b\)
+statement error declared partition columns \(b\) do not match first 1 columns in index being partitioned \(a\)
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (b) (
     PARTITION p1 VALUES IN (0)
 )
 
-statement error declared partition columns \(c\) are not a prefix of index being partitioned \(a, b\)
+statement error declared partition columns \(c\) do not match first 1 columns in index being partitioned \(a\)
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (c) (
     PARTITION p1 VALUES IN (0)
 )
 
-statement error declared partition columns \(a, a\) are not a prefix of index being partitioned \(a, b\)
+statement error declared partition columns \(a, a\) do not match first 2 columns in index being partitioned \(a, b\)
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (0) PARTITION BY LIST (a) (
         PARTITION p1_1 VALUES IN (0)
     )
 )
 
-statement error declared partition columns \(a, c\) are not a prefix of index being partitioned \(a, b\)
-CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
+statement error declared partition columns \(a, c\) do not match first 2 columns in index being partitioned \(a, b\)
+CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b, c)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (0) PARTITION BY LIST (c) (
         PARTITION p1_1 VALUES IN (0)
     )


### PR DESCRIPTION
The language "partition columns are not a prefix of index being
partitioned" was deemed confusing by both the author of the error
message (me) and our test buddy. Avoid using this confusing term by
being more specific in our error messages. Either the partitioning has
too many columns or the columns do not match, so now we just say so
directly.

Fix #20960.

Release note: None