### PR TITLE
sql: Move SequenceState to SessionData

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1019,7 +1019,7 @@ CockroachDB supports the following flags:
 			Category:   categorySequences,
 			Impure:     true,
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				val, err := evalCtx.Planner.GetLastSequenceValue(evalCtx.Ctx())
+				val, err := evalCtx.SessionData.SequenceState.GetLastValue()
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1991,10 +1991,6 @@ type EvalPlanner interface {
 	// nextval() for the given sequence in this session.
 	GetLatestValueInSessionForSequence(ctx context.Context, seqName *TableName) (int64, error)
 
-	// GetLastSequenceValue returns the last sequence value obtained with nextval()
-	// in the current session.
-	GetLastSequenceValue(ctx context.Context) (int64, error)
-
 	// SetSequenceValue sets the sequence's value.
 	SetSequenceValue(ctx context.Context, seqName *TableName, newVal int64) error
 }

--- a/pkg/sql/sessiondata/sequence_state.go
+++ b/pkg/sql/sessiondata/sequence_state.go
@@ -1,0 +1,84 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sessiondata
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// SequenceState stores session-scoped state used by sequence builtins.
+//
+// All public methods of SequenceState are thread-safe, as the structure is
+// meant to be shared by statements executing in parallel on a session.
+type SequenceState struct {
+	mu struct {
+		syncutil.Mutex
+		// latestValues stores the last value obtained by nextval() in this session
+		// by descriptor id.
+		latestValues map[uint32]int64
+
+		// lastSequenceIncremented records the descriptor id of the last sequence
+		// nextval() was called on in this session.
+		lastSequenceIncremented uint32
+	}
+}
+
+// NewSequenceState creates a SequenceState.
+func NewSequenceState() *SequenceState {
+	ss := SequenceState{}
+	ss.mu.latestValues = make(map[uint32]int64)
+	return &ss
+}
+
+// NextVal ever called returns true if a sequence has ever been incremented on
+// this session.
+func (ss *SequenceState) nextValEverCalledLocked() bool {
+	return len(ss.mu.latestValues) > 0
+}
+
+// RecordValue records the latest manipulation of a sequence done by a session.
+func (ss *SequenceState) RecordValue(seqID uint32, val int64) {
+	ss.mu.Lock()
+	ss.mu.lastSequenceIncremented = seqID
+	ss.mu.latestValues[seqID] = val
+	ss.mu.Unlock()
+}
+
+// GetLastValue returns the value most recently obtained by
+// nextval() for the last sequence for which RecordLatestVal() was called.
+func (ss *SequenceState) GetLastValue() (int64, error) {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	if !ss.nextValEverCalledLocked() {
+		return 0, pgerror.NewError(
+			pgerror.CodeObjectNotInPrerequisiteStateError, "lastval is not yet defined in this session")
+	}
+
+	return ss.mu.latestValues[ss.mu.lastSequenceIncremented], nil
+}
+
+// GetLastValueByID returns the value most recently obtained by nextval() for
+// the given sequence in this session.
+// The bool retval is false if RecordLatestVal() was never called on the
+// requested sequence.
+func (ss *SequenceState) GetLastValueByID(seqID uint32) (int64, bool) {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	val, ok := ss.mu.latestValues[seqID]
+	return val, ok
+}

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -48,6 +48,9 @@ type SessionData struct {
 	// SafeUpdates causes errors when the client
 	// sends syntax that may have unwanted side effects.
 	SafeUpdates bool
+	// SequenceState gives access to the SQL sequences that have been manipulated
+	// by the session.
+	SequenceState *SequenceState
 }
 
 // DistSQLExecMode controls if and when the Executor uses DistSQL.


### PR DESCRIPTION
SequenceState used to hang from a Session, but it belongs better in
SessionData so that sql execution doesn't depend on a session.
I've also made SequenceState be thread-safe so that it doesn't share the
session mutex with unrelated fields.

Release note: None