### PR TITLE
storage: Reject preemptive snapshots for N seconds after raft snapshots

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -927,11 +927,6 @@ func (m *multiTestContext) restartStoreWithoutHeartbeat(i int) {
 			log.Warning(ctx, err)
 		}
 	})
-
-	// Normally, the newly restarted store would not be able to accept rebalances
-	// until the election timeout passed. But we're using a manual clock which
-	// won't advance the time properly, so manually enable incoming rebalances.
-	m.stores[i].SetIncomingRebalancesDisabled(false)
 }
 
 // restartStore restarts a store previously stopped with StopStore.

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -22,7 +22,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -192,14 +191,6 @@ func (s *Store) GetOrCreateReplica(
 	creatingReplica *roachpb.ReplicaDescriptor,
 ) (*Replica, bool, error) {
 	return s.getOrCreateReplica(ctx, rangeID, replicaID, creatingReplica)
-}
-
-func (s *Store) SetIncomingRebalancesDisabled(v bool) {
-	var i int32
-	if v {
-		i = 1
-	}
-	atomic.StoreInt32(&s.incomingRebalancesDisabled, i)
 }
 
 // EnqueueRaftUpdateCheck enqueues the replica for a Raft update check, forcing

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -297,9 +297,6 @@ var (
 	metaRaftLogFollowerBehindCount = metric.Metadata{
 		Name: "raftlog.behind",
 		Help: "Number of Raft log entries followers on other stores are behind"}
-	metaRaftLogSelfBehindCount = metric.Metadata{
-		Name: "raftlog.selfbehind",
-		Help: "Number of Raft log entries followers on this store are behind"}
 	metaRaftLogTruncated = metric.Metadata{
 		Name: "raftlog.truncated",
 		Help: "Number of Raft log entries truncated"}
@@ -579,7 +576,6 @@ type StoreMetrics struct {
 
 	// Raft log metrics.
 	RaftLogFollowerBehindCount *metric.Gauge
-	RaftLogSelfBehindCount     *metric.Gauge
 	RaftLogTruncated           *metric.Counter
 
 	// A map for conveniently finding the appropriate metric. The individual
@@ -772,7 +768,6 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 
 		// Raft log metrics.
 		RaftLogFollowerBehindCount: metric.NewGauge(metaRaftLogFollowerBehindCount),
-		RaftLogSelfBehindCount:     metric.NewGauge(metaRaftLogSelfBehindCount),
 		RaftLogTruncated:           metric.NewCounter(metaRaftLogTruncated),
 
 		// Replica queue metrics.

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8510,7 +8510,6 @@ func TestReplicaMetrics(t *testing.T) {
 				RangeCounter:    false,
 				Unavailable:     false,
 				Underreplicated: false,
-				SelfBehindCount: 5,
 			}},
 		// Both replicas of a 2-replica range are live, but follower is behind.
 		{2, 1, desc(1, 2), status(1, progress(2, 1)), live(1, 2),
@@ -8601,7 +8600,6 @@ func TestReplicaMetrics(t *testing.T) {
 				RangeCounter:    true,
 				Unavailable:     false,
 				Underreplicated: false,
-				SelfBehindCount: 15,
 			}},
 		// Range has no leader, local replica is the range counter.
 		{3, 3, desc(3, 2, 1), status(0, progress(2, 2, 2)), live(1, 2, 3),
@@ -8610,7 +8608,6 @@ func TestReplicaMetrics(t *testing.T) {
 				RangeCounter:    true,
 				Unavailable:     false,
 				Underreplicated: false,
-				SelfBehindCount: 16,
 			}},
 		// Range has no leader, local replica is not the range counter.
 		{3, 2, desc(1, 2, 3), status(0, progress(2, 2, 2)), live(1, 2, 3),
@@ -8619,7 +8616,6 @@ func TestReplicaMetrics(t *testing.T) {
 				RangeCounter:    false,
 				Unavailable:     false,
 				Underreplicated: false,
-				SelfBehindCount: 17,
 			}},
 		// Range has no leader, local replica is not the range counter.
 		{3, 3, desc(1, 2, 3), status(0, progress(2, 2, 2)), live(1, 2, 3),
@@ -8628,7 +8624,6 @@ func TestReplicaMetrics(t *testing.T) {
 				RangeCounter:    false,
 				Unavailable:     false,
 				Underreplicated: false,
-				SelfBehindCount: 18,
 			}},
 	}
 	for i, c := range testCases {
@@ -8642,7 +8637,7 @@ func TestReplicaMetrics(t *testing.T) {
 			metrics := calcReplicaMetrics(
 				context.Background(), hlc.Timestamp{}, config.SystemConfig{},
 				c.liveness, &c.desc, c.raftStatus, LeaseStatus{},
-				c.storeID, c.expected.Quiescent, int64(i+1), CommandQueueMetrics{}, CommandQueueMetrics{})
+				c.storeID, c.expected.Quiescent, CommandQueueMetrics{}, CommandQueueMetrics{})
 			if c.expected != metrics {
 				t.Fatalf("unexpected metrics:\n%s", pretty.Diff(c.expected, metrics))
 			}


### PR DESCRIPTION
This serves as a replacement for the broken estimatedCommitIndex
mechanism originally added by #13043, which is removed by the first commit.

Consider this an alternative to the other option discussed in #21261, which is just to block preemptive snapshots after restart for some amount of time.