### PR TITLE
sql: towards removing the planner.session field

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -244,7 +244,7 @@ func dumpStmtStats(ctx context.Context, appName string, stats map[stmtKey]*stmtS
 	log.Info(ctx, buf.String())
 }
 
-func scrubStmtStatKey(vt virtualSchemaHolder, key string) (string, bool) {
+func scrubStmtStatKey(vt VirtualTabler, key string) (string, bool) {
 	// Re-parse the statement to obtain its AST.
 	stmt, err := parser.ParseOne(key)
 	if err != nil {
@@ -288,7 +288,7 @@ func (e *Executor) GetScrubbedStmtStats() []roachpb.CollectedStatementStatistics
 		hashedApp := HashAppName(appName)
 		a.Lock()
 		for q, stats := range a.stmts {
-			scrubbed, ok := scrubStmtStatKey(vt, q.stmt)
+			scrubbed, ok := scrubStmtStatKey(&vt, q.stmt)
 			if ok {
 				k := roachpb.StatementStatisticsKey{
 					Query:   scrubbed,

--- a/pkg/sql/cancel_query.go
+++ b/pkg/sql/cancel_query.go
@@ -50,7 +50,7 @@ func (p *planner) CancelQuery(ctx context.Context, n *tree.CancelQuery) (planNod
 }
 
 func (n *cancelQueryNode) startExec(params runParams) error {
-	statusServer := params.p.session.execCfg.StatusServer
+	statusServer := params.extendedEvalCtx.StatusServer
 
 	queryIDDatum, err := n.queryID.Eval(params.EvalContext())
 	if err != nil {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -389,7 +389,7 @@ CREATE TABLE crdb_internal.jobs (
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		p = makeInternalPlanner("jobs", p.txn, p.SessionData().User, p.session.memMetrics)
+		p = makeInternalPlanner("jobs", p.txn, p.SessionData().User, p.extendedEvalCtx.MemMetrics)
 		defer finishInternalPlanner(p)
 		rows, err := p.queryRows(ctx, `SELECT id, status, created, payload FROM system.jobs`)
 		if err != nil {
@@ -1465,7 +1465,7 @@ CREATE TABLE crdb_internal.zones (
 			return 0, "", fmt.Errorf("object with ID %d does not exist", id)
 		}
 
-		p = makeInternalPlanner("zones", p.txn, p.SessionData().User, p.session.memMetrics)
+		p = makeInternalPlanner("zones", p.txn, p.SessionData().User, p.extendedEvalCtx.MemMetrics)
 		defer finishInternalPlanner(p)
 		rows, err := p.queryRows(ctx, `SELECT id, config FROM system.zones`)
 		if err != nil {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -674,7 +674,7 @@ var crdbInternalLocalQueriesTable = virtualSchemaTable{
 	schema: fmt.Sprintf(queriesSchemaPattern, "node_queries"),
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
 		req := serverpb.ListSessionsRequest{Username: p.SessionData().User}
-		response, err := p.session.execCfg.StatusServer.ListLocalSessions(ctx, &req)
+		response, err := p.extendedEvalCtx.StatusServer.ListLocalSessions(ctx, &req)
 		if err != nil {
 			return err
 		}
@@ -688,7 +688,7 @@ var crdbInternalClusterQueriesTable = virtualSchemaTable{
 	schema: fmt.Sprintf(queriesSchemaPattern, "cluster_queries"),
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
 		req := serverpb.ListSessionsRequest{Username: p.SessionData().User}
-		response, err := p.session.execCfg.StatusServer.ListSessions(ctx, &req)
+		response, err := p.extendedEvalCtx.StatusServer.ListSessions(ctx, &req)
 		if err != nil {
 			return err
 		}
@@ -767,7 +767,7 @@ var crdbInternalLocalSessionsTable = virtualSchemaTable{
 	schema: fmt.Sprintf(sessionsSchemaPattern, "node_sessions"),
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
 		req := serverpb.ListSessionsRequest{Username: p.SessionData().User}
-		response, err := p.session.execCfg.StatusServer.ListLocalSessions(ctx, &req)
+		response, err := p.extendedEvalCtx.StatusServer.ListLocalSessions(ctx, &req)
 		if err != nil {
 			return err
 		}
@@ -781,7 +781,7 @@ var crdbInternalClusterSessionsTable = virtualSchemaTable{
 	schema: fmt.Sprintf(sessionsSchemaPattern, "cluster_sessions"),
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
 		req := serverpb.ListSessionsRequest{Username: p.SessionData().User}
-		response, err := p.session.execCfg.StatusServer.ListSessions(ctx, &req)
+		response, err := p.extendedEvalCtx.StatusServer.ListSessions(ctx, &req)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -620,7 +620,7 @@ CREATE TABLE crdb_internal.cluster_settings (
 			setting, _ := settings.Lookup(k)
 			if err := addRow(
 				tree.NewDString(k),
-				tree.NewDString(setting.String(&p.session.execCfg.Settings.SV)),
+				tree.NewDString(setting.String(&p.ExecCfg().Settings.SV)),
 				tree.NewDString(setting.Typ()),
 				tree.NewDString(setting.Description()),
 			); err != nil {
@@ -1560,7 +1560,7 @@ CREATE TABLE crdb_internal.gossip_nodes (
 			return err
 		}
 
-		g := p.session.execCfg.Gossip
+		g := p.ExecCfg().Gossip
 		var descriptors []roachpb.NodeDescriptor
 		if err := g.IterateInfos(gossip.KeyNodeIDPrefix, func(key string, i gossip.Info) error {
 			bytes, err := i.Value.GetBytes()
@@ -1619,7 +1619,7 @@ CREATE TABLE crdb_internal.gossip_liveness (
 			return err
 		}
 
-		g := p.session.execCfg.Gossip
+		g := p.ExecCfg().Gossip
 		var livenesses []storage.Liveness
 		if err := g.IterateInfos(gossip.KeyNodeLivenessPrefix, func(key string, i gossip.Info) error {
 			bytes, err := i.Value.GetBytes()

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -588,7 +588,7 @@ CREATE TABLE crdb_internal.session_trace (
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		rows, err := p.session.Tracing.generateSessionTraceVTable()
+		rows, err := p.ExtendedEvalContext().Tracing.generateSessionTraceVTable()
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -519,7 +519,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 			// Now retrieve the per-stmt stats proper.
 			for _, stmtKey := range stmtKeys {
 				anonymized := tree.DNull
-				anonStr, ok := scrubStmtStatKey(p.session.virtualSchemas, stmtKey.stmt)
+				anonStr, ok := scrubStmtStatKey(p.getVirtualTabler(), stmtKey.stmt)
 				if ok {
 					anonymized = tree.NewDString(anonStr)
 				}

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -96,7 +96,7 @@ func (n *createDatabaseNode) startExec(params runParams) error {
 		); err != nil {
 			return err
 		}
-		params.p.session.tables.addUncommittedDatabase(
+		params.extendedEvalCtx.Tables.addUncommittedDatabase(
 			desc.Name, desc.ID, false /* dropped */)
 	}
 	return nil

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -64,7 +64,7 @@ func (n *createSequenceNode) startExec(params runParams) error {
 		return err
 	}
 
-	id, err := GenerateUniqueDescID(params.ctx, params.p.session.execCfg.DB)
+	id, err := GenerateUniqueDescID(params.ctx, params.p.ExecCfg().DB)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -113,7 +113,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		return err
 	}
 
-	id, err := GenerateUniqueDescID(params.ctx, params.p.session.execCfg.DB)
+	id, err := GenerateUniqueDescID(params.ctx, params.extendedEvalCtx.ExecCfg.DB)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -337,7 +337,7 @@ func (p *planner) resolveFK(
 	backrefs map[sqlbase.ID]*sqlbase.TableDescriptor,
 	mode sqlbase.ConstraintValidity,
 ) error {
-	return resolveFK(ctx, p.txn, &p.session.virtualSchemas, tbl, d, backrefs, mode)
+	return resolveFK(ctx, p.txn, p.getVirtualTabler(), tbl, d, backrefs, mode)
 }
 
 // resolveFK looks up the tables and columns mentioned in a `REFERENCES`
@@ -602,7 +602,7 @@ func (p *planner) addInterleave(
 	interleave *tree.InterleaveDef,
 ) error {
 	return addInterleave(
-		ctx, p.txn, &p.session.virtualSchemas, desc, index,
+		ctx, p.txn, p.getVirtualTabler(), desc, index,
 		interleave, p.SessionData().Database)
 }
 
@@ -1034,7 +1034,7 @@ func (p *planner) makeTableDesc(
 	return MakeTableDesc(
 		ctx,
 		p.txn,
-		&p.session.virtualSchemas,
+		p.getVirtualTabler(),
 		p.ExecCfg().Settings,
 		n,
 		parentID,

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -121,7 +121,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		return err
 	}
 
-	id, err := GenerateUniqueDescID(params.ctx, params.p.session.execCfg.DB)
+	id, err := GenerateUniqueDescID(params.ctx, params.extendedEvalCtx.ExecCfg.DB)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -476,7 +476,7 @@ func (p *planner) QualifyWithDatabase(
 func (p *planner) getTableDescByID(
 	ctx context.Context, tableID sqlbase.ID,
 ) (*sqlbase.TableDescriptor, error) {
-	descFunc := p.session.tables.getTableVersionByID
+	descFunc := p.Tables().getTableVersionByID
 	if p.avoidCachedDescriptors {
 		descFunc = sqlbase.GetTableDescFromID
 	}
@@ -597,7 +597,7 @@ func (p *planner) getTableDesc(
 		return MustGetTableOrViewDesc(
 			ctx, p.txn, p.getVirtualTabler(), tn, false /*allowAdding*/)
 	}
-	return p.session.tables.getTableVersion(ctx, p.txn, p.getVirtualTabler(), tn)
+	return p.Tables().getTableVersion(ctx, p.txn, p.getVirtualTabler(), tn)
 }
 
 func (p *planner) getPlanForDesc(

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -271,7 +271,7 @@ func (p *planner) getSources(
 func (p *planner) getVirtualDataSource(
 	ctx context.Context, tn *tree.TableName,
 ) (planDataSource, bool, error) {
-	virtual, err := p.session.virtualSchemas.getVirtualTableEntry(tn)
+	virtual, err := p.getVirtualTabler().getVirtualTableEntry(tn)
 	if err != nil {
 		return planDataSource{}, false, err
 	}

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -307,7 +307,7 @@ func (dc *databaseCache) getDatabaseID(
 func (p *planner) createDatabase(
 	ctx context.Context, desc *sqlbase.DatabaseDescriptor, ifNotExists bool,
 ) (bool, error) {
-	if p.session.virtualSchemas.isVirtualDatabase(desc.Name) {
+	if p.getVirtualTabler().isVirtualDatabase(desc.Name) {
 		if ifNotExists {
 			// Noop.
 			return false, nil
@@ -325,7 +325,7 @@ func (p *planner) renameDatabase(
 		return fmt.Errorf("the new database name %q already exists", newName)
 	}
 
-	if p.session.virtualSchemas.isVirtualDatabase(newName) {
+	if p.getVirtualTabler().isVirtualDatabase(newName) {
 		return onAlreadyExists()
 	}
 

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -342,7 +342,7 @@ func (p *planner) renameDatabase(
 	descDesc := sqlbase.WrapDescriptor(oldDesc)
 
 	b := &client.Batch{}
-	if p.session.Tracing.KVTracingEnabled() {
+	if p.ExtendedEvalContext().Tracing.KVTracingEnabled() {
 		log.VEventf(ctx, 2, "CPut %s -> %d", newKey, descID)
 		log.VEventf(ctx, 2, "Put %s -> %s", descKey, descDesc)
 		log.VEventf(ctx, 2, "Del %s", oldKey)

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -351,9 +351,9 @@ func (p *planner) renameDatabase(
 	b.Put(descKey, descDesc)
 	b.Del(oldKey)
 
-	p.session.tables.addUncommittedDatabase(
+	p.Tables().addUncommittedDatabase(
 		oldName, descID, true /* dropped */)
-	p.session.tables.addUncommittedDatabase(
+	p.Tables().addUncommittedDatabase(
 		newName, descID, false /* dropped */)
 
 	if err := p.txn.Run(ctx, b); err != nil {

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -363,7 +363,7 @@ func (p *planner) renameDatabase(
 		return err
 	}
 
-	p.session.setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
+	p.testingVerifyMetadata().setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
 		if err := expectDescriptorID(systemConfig, newKey, descID); err != nil {
 			return err
 		}

--- a/pkg/sql/deallocate.go
+++ b/pkg/sql/deallocate.go
@@ -25,9 +25,9 @@ import (
 // See https://www.postgresql.org/docs/current/static/sql-deallocate.html for details.
 func (p *planner) Deallocate(ctx context.Context, s *tree.Deallocate) (planNode, error) {
 	if s.Name == "" {
-		p.session.PreparedStatements.DeleteAll(ctx)
+		p.preparedStatements.DeleteAll(ctx)
 	} else {
-		if found := p.session.PreparedStatements.Delete(ctx, string(s.Name)); !found {
+		if found := p.preparedStatements.Delete(ctx, string(s.Name)); !found {
 			return nil, pgerror.NewErrorf(pgerror.CodeInvalidSQLStatementNameError,
 				"prepared statement %q does not exist", s.Name)
 		}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -148,7 +148,7 @@ func (d *deleteNode) startExec(params runParams) error {
 		return d.fastDelete(params, scan)
 	}
 
-	return d.run.tw.init(d.p.txn, &params.p.session.TxnState.mon)
+	return d.run.tw.init(d.p.txn, params.EvalContext().Mon)
 }
 
 func (d *deleteNode) Next(params runParams) (bool, error) {
@@ -236,13 +236,14 @@ func (d *deleteNode) fastDelete(params runParams, scan *scanNode) error {
 		return err
 	}
 
-	if err := d.tw.init(params.p.txn, &params.p.session.TxnState.mon); err != nil {
+	if err := d.tw.init(params.p.txn, params.EvalContext().Mon); err != nil {
 		return err
 	}
 	if err := params.p.cancelChecker.Check(); err != nil {
 		return err
 	}
-	rowCount, err := d.tw.fastDelete(params.ctx, scan, params.p.session.Tracing.KVTracingEnabled())
+	rowCount, err := d.tw.fastDelete(
+		params.ctx, scan, params.extendedEvalCtx.Tracing.KVTracingEnabled())
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -156,7 +156,7 @@ func (d *deleteNode) Next(params runParams) (bool, error) {
 		return false, nil
 	}
 
-	traceKV := d.p.session.Tracing.KVTracingEnabled()
+	traceKV := d.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
 
 	next, err := d.run.rows.Next(params)
 	if !next {

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -151,7 +151,7 @@ func (p *planner) createDescriptorWithID(
 	})
 
 	if desc, ok := descriptor.(*sqlbase.TableDescriptor); ok {
-		p.session.tables.addUncommittedTable(*desc)
+		p.Tables().addUncommittedTable(*desc)
 	}
 
 	return p.txn.Run(ctx, b)

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -101,7 +101,7 @@ func (p *planner) createDescriptor(
 		return false, err
 	}
 
-	id, err := GenerateUniqueDescID(ctx, p.session.execCfg.DB)
+	id, err := GenerateUniqueDescID(ctx, p.ExecCfg().DB)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -143,7 +143,7 @@ func (p *planner) createDescriptorWithID(
 	b.CPut(idKey, descID, nil)
 	b.CPut(descKey, descDesc, nil)
 
-	p.session.setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
+	p.testingVerifyMetadata().setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
 		if err := expectDescriptorID(systemConfig, idKey, descID); err != nil {
 			return err
 		}

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -136,7 +136,7 @@ func (p *planner) createDescriptorWithID(
 	b := &client.Batch{}
 	descID := descriptor.GetID()
 	descDesc := sqlbase.WrapDescriptor(descriptor)
-	if p.session.Tracing.KVTracingEnabled() {
+	if p.ExtendedEvalContext().Tracing.KVTracingEnabled() {
 		log.VEventf(ctx, 2, "CPut %s -> %d", idKey, descID)
 		log.VEventf(ctx, 2, "CPut %s -> %s", descKey, descDesc)
 	}

--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -41,7 +41,7 @@ func (p *planner) Discard(ctx context.Context, s *tree.Discard) (planNode, error
 		}
 
 		// DEALLOCATE ALL
-		p.session.PreparedStatements.DeleteAll(ctx)
+		p.preparedStatements.DeleteAll(ctx)
 	default:
 		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
 			"unknown mode for DISCARD: %d", s.Mode)

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -198,8 +198,8 @@ type distinctRun struct {
 }
 
 func (n *distinctNode) startExec(params runParams) error {
-	n.run.prefixMemAcc = params.p.session.TxnState.mon.MakeBoundAccount()
-	n.run.suffixMemAcc = params.p.session.TxnState.mon.MakeBoundAccount()
+	n.run.prefixMemAcc = params.EvalContext().Mon.MakeBoundAccount()
+	n.run.suffixMemAcc = params.EvalContext().Mon.MakeBoundAccount()
 	n.run.suffixSeen = make(map[string]struct{})
 	return nil
 }

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -150,14 +150,15 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 	// Delete the zone config entry for this database.
 	b.DelRange(zoneKeyPrefix, zoneKeyPrefix.PrefixEnd(), false /* returnKeys */)
 
-	p.session.setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
-		for _, key := range [...]roachpb.Key{descKey, nameKey, zoneKey} {
-			if err := expectDeleted(systemConfig, key); err != nil {
-				return err
+	params.extendedEvalCtx.TestingVerifyMetadata.setTestingVerifyMetadata(
+		func(systemConfig config.SystemConfig) error {
+			for _, key := range [...]roachpb.Key{descKey, nameKey, zoneKey} {
+				if err := expectDeleted(systemConfig, key); err != nil {
+					return err
+				}
 			}
-		}
-		return nil
-	})
+			return nil
+		})
 
 	p.Tables().addUncommittedDatabase(n.dbDesc.Name, n.dbDesc.ID, true /*dropped*/)
 

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -140,7 +140,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 	zoneKeyPrefix := config.MakeZoneKeyPrefix(uint32(n.dbDesc.ID))
 
 	b := &client.Batch{}
-	if p.session.Tracing.KVTracingEnabled() {
+	if p.ExtendedEvalContext().Tracing.KVTracingEnabled() {
 		log.VEventf(ctx, 2, "Del %s", descKey)
 		log.VEventf(ctx, 2, "Del %s", nameKey)
 		log.VEventf(ctx, 2, "DelRange %s", zoneKeyPrefix)

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -159,7 +159,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		return nil
 	})
 
-	p.session.tables.addUncommittedDatabase(n.dbDesc.Name, n.dbDesc.ID, true /*dropped*/)
+	p.Tables().addUncommittedDatabase(n.dbDesc.Name, n.dbDesc.ID, true /*dropped*/)
 
 	if err := p.txn.Run(ctx, b); err != nil {
 		return err

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -109,9 +109,10 @@ func (p *planner) dropSequenceImpl(
 		return err
 	}
 
-	p.session.setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
-		return verifyDropTableMetadata(systemConfig, seqDesc.ID, "sequence")
-	})
+	p.testingVerifyMetadata().setTestingVerifyMetadata(
+		func(systemConfig config.SystemConfig) error {
+			return verifyDropTableMetadata(systemConfig, seqDesc.ID, "sequence")
+		})
 
 	return nil
 }

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -302,9 +302,10 @@ func (p *planner) dropTableImpl(
 		return droppedViews, err
 	}
 
-	p.session.setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
-		return verifyDropTableMetadata(systemConfig, tableDesc.ID, "table")
-	})
+	p.testingVerifyMetadata().setTestingVerifyMetadata(
+		func(systemConfig config.SystemConfig) error {
+			return verifyDropTableMetadata(systemConfig, tableDesc.ID, "table")
+		})
 	return droppedViews, nil
 }
 

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -225,9 +225,10 @@ func (p *planner) dropViewImpl(
 		return cascadeDroppedViews, err
 	}
 
-	p.session.setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
-		return verifyDropTableMetadata(systemConfig, viewDesc.ID, "view")
-	})
+	p.testingVerifyMetadata().setTestingVerifyMetadata(
+		func(systemConfig config.SystemConfig) error {
+			return verifyDropTableMetadata(systemConfig, viewDesc.ID, "view")
+		})
 	return cascadeDroppedViews, nil
 }
 

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -2002,7 +2002,7 @@ func commitSQLTransaction(
 func (e *Executor) execDistSQL(
 	planner *planner, tree planNode, rowResultWriter StatementResult,
 ) error {
-	ctx := planner.session.Ctx()
+	ctx := planner.EvalContext().Ctx()
 	recv := makeDistSQLReceiver(
 		ctx, rowResultWriter,
 		e.cfg.RangeDescriptorCache, e.cfg.LeaseHolderCache,
@@ -2027,7 +2027,7 @@ func (e *Executor) execDistSQL(
 func (e *Executor) execClassic(
 	planner *planner, plan planNode, rowResultWriter StatementResult,
 ) error {
-	ctx := planner.session.Ctx()
+	ctx := planner.EvalContext().Ctx()
 
 	// Create a BoundAccount to track the memory usage of each row.
 	rowAcc := planner.extendedEvalCtx.Mon.MakeBoundAccount()

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -142,7 +142,7 @@ func recordStatementSummary(
 		sessionAge := phaseTimes[plannerEndExecStmt].
 			Sub(phaseTimes[sessionInit]).Seconds()
 
-		log.Infof(planner.session.Ctx(),
+		log.Infof(planner.EvalContext().Ctx(),
 			"query stats: %d rows, %d retries, "+
 				"parse %.2fµs (%.1f%%), "+
 				"plan %.2fµs (%.1f%%), "+

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -46,7 +46,7 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 	// Trigger limit propagation.
 	params.p.setUnlimited(n.plan)
 
-	distSQLPlanner := params.p.session.distSQLPlanner
+	distSQLPlanner := params.extendedEvalCtx.DistSQLPlanner
 
 	auto, err := distSQLPlanner.CheckSupport(n.plan)
 	if err != nil {

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -586,7 +586,7 @@ func (v *extractAggregatesVisitor) VisitPre(expr tree.Expr) (recurse bool, newEx
 			groupIdx,
 			true, /* ident */
 			builtins.NewIdentAggregate,
-			v.planner.session.TxnState.makeBoundAccount(),
+			v.planner.EvalContext().Mon.MakeBoundAccount(),
 		)
 
 		return false, v.addAggregation(f)
@@ -604,7 +604,7 @@ func (v *extractAggregatesVisitor) VisitPre(expr tree.Expr) (recurse bool, newEx
 					noRenderIdx,
 					false, /* not ident */
 					agg,
-					v.planner.session.TxnState.makeBoundAccount(),
+					v.planner.EvalContext().Mon.MakeBoundAccount(),
 				)
 
 			case 1:
@@ -632,7 +632,7 @@ func (v *extractAggregatesVisitor) VisitPre(expr tree.Expr) (recurse bool, newEx
 					argRenderIdx,
 					false, /* not ident */
 					agg,
-					v.planner.session.TxnState.makeBoundAccount(),
+					v.planner.EvalContext().Mon.MakeBoundAccount(),
 				)
 
 			default:

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -677,7 +677,7 @@ func forEachDatabaseDesc(
 	}
 
 	// Handle virtual schemas.
-	for _, schema := range p.session.virtualSchemas.entries {
+	for _, schema := range p.getVirtualTabler().getEntries() {
 		dbDescs = append(dbDescs, schema.desc)
 	}
 
@@ -835,7 +835,7 @@ func forEachTableDescWithTableLookupInternal(
 	}
 
 	// Handle virtual schemas.
-	for dbName, schema := range p.session.virtualSchemas.entries {
+	for dbName, schema := range p.getVirtualTabler().getEntries() {
 		dbTables := make(map[string]*sqlbase.TableDescriptor, len(schema.tables))
 		for tableName, entry := range schema.tables {
 			dbTables[tableName] = entry.desc

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -941,7 +941,8 @@ func forEachRole(
 	ctx context.Context, origPlanner *planner, fn func(username string, isRole tree.DBool) error,
 ) error {
 	query := `SELECT username, "isRole" FROM system.users`
-	p := makeInternalPlanner("for-each-role", origPlanner.txn, security.RootUser, origPlanner.session.memMetrics)
+	p := makeInternalPlanner(
+		"for-each-role", origPlanner.txn, security.RootUser, origPlanner.extendedEvalCtx.MemMetrics)
 	defer finishInternalPlanner(p)
 	rows, err := p.queryRows(ctx, query)
 	if err != nil {

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -317,7 +317,7 @@ func (n *insertNode) startExec(params runParams) error {
 		return err
 	}
 
-	return n.run.tw.init(params.p.txn, &params.p.session.TxnState.mon)
+	return n.run.tw.init(params.p.txn, params.EvalContext().Mon)
 }
 
 func (n *insertNode) Next(params runParams) (bool, error) {
@@ -387,7 +387,7 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 
 			if n.run.isUpsertReturning {
 				n.run.rowsUpserted = sqlbase.NewRowContainer(
-					params.p.session.TxnState.makeBoundAccount(),
+					params.EvalContext().Mon.MakeBoundAccount(),
 					sqlbase.ColTypeInfoFromResCols(n.rh.columns),
 					rows.Len(),
 				)

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -379,7 +379,8 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 				return false, err
 			}
 			// We're done. Finish the batch.
-			rows, err := n.tw.finalize(params.ctx, params.p.session.Tracing.KVTracingEnabled())
+			rows, err := n.tw.finalize(
+				params.ctx, params.extendedEvalCtx.Tracing.KVTracingEnabled())
 			if err != nil {
 				return false, err
 			}
@@ -425,7 +426,7 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 		return false, err
 	}
 
-	_, err = n.tw.row(params.ctx, rowVals, params.p.session.Tracing.KVTracingEnabled())
+	_, err = n.tw.row(params.ctx, rowVals, params.extendedEvalCtx.Tracing.KVTracingEnabled())
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -104,7 +104,7 @@ func getTableID(ctx context.Context, p *planner, tn *tree.TableName) (sqlbase.ID
 		return 0, err
 	}
 
-	virtual, err := p.session.virtualSchemas.getVirtualTableDesc(tn)
+	virtual, err := p.getVirtualTabler().getVirtualTableDesc(tn)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -95,7 +95,7 @@ func (ie InternalExecutor) GetTableSpan(
 
 func (ie InternalExecutor) initSession(p *planner) {
 	p.extendedEvalCtx.NodeID = ie.LeaseManager.LeaseStore.nodeID.Get()
-	p.session.tables.leaseMgr = ie.LeaseManager
+	p.extendedEvalCtx.Tables.leaseMgr = ie.LeaseManager
 }
 
 // getTableID retrieves the table ID for the specified table.
@@ -116,7 +116,7 @@ func getTableID(ctx context.Context, p *planner, tn *tree.TableName) (sqlbase.ID
 		return retryable(ctx, p.txn)
 	}
 
-	dbID, err := p.session.tables.databaseCache.getDatabaseID(ctx, txnRunner, p.getVirtualTabler(), tn.Database())
+	dbID, err := p.Tables().databaseCache.getDatabaseID(ctx, txnRunner, p.getVirtualTabler(), tn.Database())
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -144,15 +144,15 @@ func (p *planner) makeJoin(
 
 	n.run.buffer = &RowBuffer{
 		RowContainer: sqlbase.NewRowContainer(
-			p.session.TxnState.makeBoundAccount(), sqlbase.ColTypeInfoFromResCols(planColumns(n)), 0,
+			p.EvalContext().Mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(planColumns(n)), 0,
 		),
 	}
 
-	n.run.bucketsMemAcc = p.session.TxnState.mon.MakeBoundAccount()
+	n.run.bucketsMemAcc = p.EvalContext().Mon.MakeBoundAccount()
 	n.run.buckets = buckets{
 		buckets: make(map[string]*bucket),
 		rowContainer: sqlbase.NewRowContainer(
-			p.session.TxnState.makeBoundAccount(),
+			p.EvalContext().Mon.MakeBoundAccount(),
 			sqlbase.ColTypeInfoFromResCols(planColumns(n.right.plan)),
 			0,
 		),

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -64,6 +64,10 @@ type extendedEvalContext struct {
 	DistSQLPlanner *DistSQLPlanner
 
 	TestingVerifyMetadata testingVerifyMetadata
+
+	TxnModesSetter txnModesSetter
+
+	SchemaChangers *schemaChangerCollection
 }
 
 type testingVerifyMetadata interface {
@@ -572,4 +576,10 @@ func (p *planner) SessionData() *sessiondata.SessionData {
 
 func (p *planner) testingVerifyMetadata() testingVerifyMetadata {
 	return p.extendedEvalCtx.TestingVerifyMetadata
+}
+
+// txnModesSetter is an interface used by SQL execution to influence the current
+// transaction.
+type txnModesSetter interface {
+	setTransactionModes(modes tree.TransactionModes) error
 }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -55,6 +55,8 @@ type extendedEvalContext struct {
 
 	// Tables points to the Session's table collection.
 	Tables *TableCollection
+
+	ExecCfg *ExecutorConfig
 }
 
 // planner is the centerpiece of SQL statement execution combining session
@@ -266,7 +268,7 @@ func (p *planner) Tables() *TableCollection {
 
 // ExecCfg implements the PlanHookState interface.
 func (p *planner) ExecCfg() *ExecutorConfig {
-	return p.session.execCfg
+	return p.extendedEvalCtx.ExecCfg
 }
 
 func (p *planner) LeaseMgr() *LeaseManager {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -86,6 +86,10 @@ type planner struct {
 	// session is the Session on whose behalf this planner is working.
 	session *Session
 
+	// preparedStatements points to the Session's collection of prepared
+	// statements.
+	preparedStatements *PreparedStatements
+
 	// Reference to the corresponding sql Statement for this query.
 	stmt *Statement
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -59,6 +59,17 @@ type extendedEvalContext struct {
 	ExecCfg *ExecutorConfig
 
 	DistSQLPlanner *DistSQLPlanner
+
+	TestingVerifyMetadata testingVerifyMetadata
+}
+
+type testingVerifyMetadata interface {
+	// setTestingVerifyMetadata sets a callback to be called after the Session
+	// is done executing the current SQL statement. It can be used to verify
+	// assumptions about how metadata will be asynchronously updated.
+	// Note that this can overwrite a previous callback that was waiting to be
+	// verified, which is not ideal.
+	setTestingVerifyMetadata(fn func(config.SystemConfig) error)
 }
 
 // planner is the centerpiece of SQL statement execution combining session
@@ -550,4 +561,8 @@ func (p *planner) TypeAsStringArray(exprs tree.Exprs, op string) (func() ([]stri
 // SessionData is part of the PlanHookState interface.
 func (p *planner) SessionData() *sessiondata.SessionData {
 	return &p.EvalContext().SessionData
+}
+
+func (p *planner) testingVerifyMetadata() testingVerifyMetadata {
+	return p.extendedEvalCtx.TestingVerifyMetadata
 }

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -48,6 +48,10 @@ type extendedEvalContext struct {
 
 	// StatusServer gives access to the Status service. Used to cancel queries.
 	StatusServer serverpb.StatusServer
+
+	// MemMetrics represent the group of metrics to which execution should
+	// contribute.
+	MemMetrics *MemoryMetrics
 }
 
 // planner is the centerpiece of SQL statement execution combining session

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -57,6 +57,8 @@ type extendedEvalContext struct {
 	Tables *TableCollection
 
 	ExecCfg *ExecutorConfig
+
+	DistSQLPlanner *DistSQLPlanner
 }
 
 // planner is the centerpiece of SQL statement execution combining session
@@ -283,7 +285,7 @@ func (p *planner) User() string {
 // this is the right abstraction. We could also export DistSQLPlanner, for
 // example. Revisit.
 func (p *planner) DistLoader() *DistLoader {
-	return &DistLoader{distSQLPlanner: p.session.distSQLPlanner}
+	return &DistLoader{distSQLPlanner: p.extendedEvalCtx.DistSQLPlanner}
 }
 
 // setTxn resets the current transaction in the planner and

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
@@ -44,6 +45,9 @@ type extendedEvalContext struct {
 
 	// Tracing provides access to the session's tracing interface.
 	Tracing *SessionTracing
+
+	// StatusServer gives access to the Status service. Used to cancel queries.
+	StatusServer serverpb.StatusServer
 }
 
 // planner is the centerpiece of SQL statement execution combining session

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -35,15 +35,18 @@ import (
 	"github.com/pkg/errors"
 )
 
-// extendedEvalCtx extends 	ree.EvalContext with fields that are just needed in
+// extendedEvalCtx extends tree.EvalContext with fields that are just needed in
 // the sql package.
 type extendedEvalContext struct {
 	tree.EvalContext
 
+	SessionMutator sessionDataMutator
+
 	// VirtualSchemas can be used to access virtual tables.
 	VirtualSchemas VirtualTabler
 
-	// Tracing provides access to the session's tracing interface.
+	// Tracing provides access to the session's tracing interface. Changes to the
+	// tracing state should be done through the sessionDataMutator.
 	Tracing *SessionTracing
 
 	// StatusServer gives access to the Status service. Used to cancel queries.

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -154,12 +154,13 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	}
 	p.notifySchemaChange(tableDesc, sqlbase.InvalidMutationID)
 
-	p.session.setTestingVerifyMetadata(func(systemConfig config.SystemConfig) error {
-		if err := expectDescriptorID(systemConfig, newTbKey, descID); err != nil {
-			return err
-		}
-		return expectDescriptor(systemConfig, descKey, descDesc)
-	})
+	p.testingVerifyMetadata().setTestingVerifyMetadata(
+		func(systemConfig config.SystemConfig) error {
+			if err := expectDescriptorID(systemConfig, newTbKey, descID); err != nil {
+				return err
+			}
+			return expectDescriptor(systemConfig, descKey, descDesc)
+		})
 
 	return &zeroNode{}, nil
 }

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -139,7 +139,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	// old name to the id, so that the name is not reused until the schema changer
 	// has made sure it's not in use any more.
 	b := &client.Batch{}
-	if p.session.Tracing.KVTracingEnabled() {
+	if p.extendedEvalCtx.Tracing.KVTracingEnabled() {
 		log.VEventf(ctx, 2, "Put %s -> %s", descKey, descDesc)
 		log.VEventf(ctx, 2, "CPut %s -> %d", newTbKey, descID)
 	}

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -220,7 +220,7 @@ func (n *scanNode) initScan(params runParams) error {
 		n.spans,
 		!n.disableBatchLimits,
 		limitHint,
-		params.p.session.Tracing.KVTracingEnabled(),
+		params.p.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -532,14 +532,14 @@ func createConstraintCheckOperations(
 
 // scrubPlanDistSQL will prepare and run the plan in distSQL.
 func scrubPlanDistSQL(
-	ctx context.Context, planCtx *planningCtx, p *planner, plan planNode,
+	ctx context.Context, planCtx *planningCtx, plan planNode,
 ) (*physicalPlan, error) {
 	log.VEvent(ctx, 1, "creating DistSQL plan")
-	physPlan, err := p.session.distSQLPlanner.createPlanForNode(planCtx, plan)
+	physPlan, err := planCtx.extendedEvalCtx.DistSQLPlanner.createPlanForNode(planCtx, plan)
 	if err != nil {
 		return nil, err
 	}
-	p.session.distSQLPlanner.FinalizePlan(planCtx, &physPlan)
+	planCtx.extendedEvalCtx.DistSQLPlanner.FinalizePlan(planCtx, &physPlan)
 	return &physPlan, nil
 }
 
@@ -566,7 +566,7 @@ func scrubRunDistSQL(
 		},
 	)
 
-	if err := p.session.distSQLPlanner.Run(planCtx, p.txn, plan, &recv, &p.extendedEvalCtx); err != nil {
+	if err := p.extendedEvalCtx.DistSQLPlanner.Run(planCtx, p.txn, plan, &recv, &p.extendedEvalCtx); err != nil {
 		return rows, err
 	} else if recv.err != nil {
 		return rows, recv.err

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -109,8 +109,8 @@ func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 		o.colIDToRowIdx[id] = i
 	}
 
-	planCtx := params.p.session.distSQLPlanner.newPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
-	physPlan, err := scrubPlanDistSQL(ctx, &planCtx, params.p, plan)
+	planCtx := params.extendedEvalCtx.DistSQLPlanner.newPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
+	physPlan, err := scrubPlanDistSQL(ctx, &planCtx, plan)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -118,8 +118,8 @@ func (o *indexCheckOperation) Start(params runParams) error {
 	}
 	defer plan.Close(ctx)
 
-	planCtx := params.p.session.distSQLPlanner.newPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
-	physPlan, err := scrubPlanDistSQL(ctx, &planCtx, params.p, plan)
+	planCtx := params.extendedEvalCtx.DistSQLPlanner.newPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
+	physPlan, err := scrubPlanDistSQL(ctx, &planCtx, plan)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -135,8 +135,8 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	span := o.tableDesc.IndexSpan(o.indexDesc.ID)
 	spans := []roachpb.Span{span}
 
-	planCtx := params.p.session.distSQLPlanner.newPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
-	physPlan, err := params.p.session.distSQLPlanner.createScrubPhysicalCheck(
+	planCtx := params.extendedEvalCtx.DistSQLPlanner.newPlanningCtx(ctx, params.extendedEvalCtx, params.p.txn)
+	physPlan, err := params.extendedEvalCtx.DistSQLPlanner.createScrubPhysicalCheck(
 		&planCtx, scan, *o.tableDesc, *o.indexDesc, spans, params.p.ExecCfg().Clock.Now())
 	if err != nil {
 		return err

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -623,11 +623,13 @@ func (s *Session) newPlanner(e *Executor, txn *client.Txn) *planner {
 func (s *Session) extendedEvalCtx() extendedEvalContext {
 	var evalContextTestingKnobs tree.EvalContextTestingKnobs
 	var st *cluster.Settings
+	var statusServer serverpb.StatusServer
 	if s.execCfg != nil {
 		evalContextTestingKnobs = s.execCfg.EvalContextTestingKnobs
 		// TODO(tschottdorf): it looks like this should always be provided.
 		// Perhaps `*Settings` should live somewhere else.
 		st = s.execCfg.Settings
+		statusServer = s.execCfg.StatusServer
 	}
 	return extendedEvalContext{
 		EvalContext: tree.EvalContext{
@@ -642,6 +644,7 @@ func (s *Session) extendedEvalCtx() extendedEvalContext {
 		},
 		VirtualSchemas: &s.virtualSchemas,
 		Tracing:        &s.Tracing,
+		StatusServer:   statusServer,
 	}
 }
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -644,6 +644,7 @@ func (s *Session) extendedEvalCtx() extendedEvalContext {
 		Tracing:        &s.Tracing,
 		StatusServer:   statusServer,
 		MemMetrics:     s.memMetrics,
+		Tables:         &s.tables,
 	}
 }
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -640,13 +640,14 @@ func (s *Session) extendedEvalCtx() extendedEvalContext {
 			Mon:             &s.TxnState.mon,
 			TestingKnobs:    evalContextTestingKnobs,
 		},
-		VirtualSchemas: &s.virtualSchemas,
-		Tracing:        &s.Tracing,
-		StatusServer:   statusServer,
-		MemMetrics:     s.memMetrics,
-		Tables:         &s.tables,
-		ExecCfg:        s.execCfg,
-		DistSQLPlanner: s.distSQLPlanner,
+		VirtualSchemas:        &s.virtualSchemas,
+		Tracing:               &s.Tracing,
+		StatusServer:          statusServer,
+		MemMetrics:            s.memMetrics,
+		Tables:                &s.tables,
+		ExecCfg:               s.execCfg,
+		DistSQLPlanner:        s.distSQLPlanner,
+		TestingVerifyMetadata: s,
 	}
 }
 
@@ -658,11 +659,7 @@ func (s *Session) resetForBatch(e *Executor) {
 	s.TxnState.schemaChangers.curGroupNum++
 }
 
-// setTestingVerifyMetadata sets a callback to be called after the Session
-// is done executing the current SQL statement. It can be used to verify
-// assumptions about how metadata will be asynchronously updated.
-// Note that this can overwrite a previous callback that was waiting to be
-// verified, which is not ideal.
+// setTestingVerifyMetadata implements the testingVerifyMetadata interface.
 func (s *Session) setTestingVerifyMetadata(fn func(config.SystemConfig) error) {
 	s.testingVerifyMetadataFn = fn
 	s.verifyFnCheckedOnce = false

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -163,10 +163,8 @@ type Session struct {
 	PreparedStatements PreparedStatements
 	PreparedPortals    PreparedPortals
 	// virtualSchemas aliases Executor.virtualSchemas.
-	// It is duplicated in Session to provide easier access to
-	// the various methods that need this reference.
-	// TODO(knz): place this in an executionContext parameter-passing
-	// structure.
+	// It is duplicated in Session so that it can find its way to the planners'
+	// EvalContext.
 	virtualSchemas virtualSchemaHolder
 
 	// planner is the "default planner" on a session, to save planner allocations

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -645,6 +645,7 @@ func (s *Session) extendedEvalCtx() extendedEvalContext {
 		StatusServer:   statusServer,
 		MemMetrics:     s.memMetrics,
 		Tables:         &s.tables,
+		ExecCfg:        s.execCfg,
 	}
 }
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -645,6 +645,7 @@ func (s *Session) extendedEvalCtx() extendedEvalContext {
 		VirtualSchemas: &s.virtualSchemas,
 		Tracing:        &s.Tracing,
 		StatusServer:   statusServer,
+		MemMetrics:     s.memMetrics,
 	}
 }
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -651,6 +651,8 @@ func (s *Session) extendedEvalCtx() extendedEvalContext {
 		ExecCfg:               s.execCfg,
 		DistSQLPlanner:        s.distSQLPlanner,
 		TestingVerifyMetadata: s,
+		TxnModesSetter:        &s.TxnState,
+		SchemaChangers:        &s.TxnState.schemaChangers,
 	}
 }
 

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -580,6 +580,7 @@ func (s *Session) resetPlanner(p *planner, e *Executor, txn *client.Txn) {
 	}
 
 	p.sessionDataMutator = s.dataMutator
+	p.preparedStatements = &s.PreparedStatements
 
 	p.setTxn(txn)
 }

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -646,6 +646,7 @@ func (s *Session) extendedEvalCtx() extendedEvalContext {
 		MemMetrics:     s.memMetrics,
 		Tables:         &s.tables,
 		ExecCfg:        s.execCfg,
+		DistSQLPlanner: s.distSQLPlanner,
 	}
 }
 

--- a/pkg/sql/session_mem_usage.go
+++ b/pkg/sql/session_mem_usage.go
@@ -75,7 +75,3 @@ func (s *Session) deriveAndStartMonitors() {
 func (s *Session) makeBoundAccount() mon.BoundAccount {
 	return s.sessionMon.MakeBoundAccount()
 }
-
-func (ts *txnState) makeBoundAccount() mon.BoundAccount {
-	return ts.mon.MakeBoundAccount()
-}

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -134,7 +134,7 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 			SettingName string
 			Value       string
 			User        string
-		}{n.name, reportedValue, params.p.session.data.User},
+		}{n.name, reportedValue, params.SessionData().User},
 	)
 }
 

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -47,7 +47,7 @@ func (p *planner) SetClusterSetting(
 	}
 
 	name := strings.ToLower(tree.AsStringWithFlags(n.Name, tree.FmtBareIdentifiers))
-	st := p.session.execCfg.Settings
+	st := p.EvalContext().Settings
 	setting, ok := settings.Lookup(name)
 	if !ok {
 		return nil, errors.Errorf("unknown cluster setting '%s'", name)

--- a/pkg/sql/set_transaction.go
+++ b/pkg/sql/set_transaction.go
@@ -20,5 +20,5 @@ import (
 
 // SetTransaction sets a transaction's isolation level
 func (p *planner) SetTransaction(n *tree.SetTransaction) (planNode, error) {
-	return &zeroNode{}, p.session.TxnState.setTransactionModes(n.Modes)
+	return &zeroNode{}, p.extendedEvalCtx.TxnModesSetter.setTransactionModes(n.Modes)
 }

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -43,7 +43,7 @@ func (p *planner) ShowClusterSetting(
 			"TABLE crdb_internal.cluster_settings", nil, nil)
 	}
 
-	st := p.session.execCfg.Settings
+	st := p.ExecCfg().Settings
 	val, ok := settings.Lookup(name)
 	if !ok {
 		return nil, errors.Errorf("unknown setting: %q", name)

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -113,7 +113,7 @@ func (p *planner) printForeignKeyConstraint(
 	if !fk.IsSet() {
 		return nil
 	}
-	fkTable, err := p.session.tables.getTableVersionByID(ctx, p.txn, fk.Table)
+	fkTable, err := p.Tables().getTableVersionByID(ctx, p.txn, fk.Table)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -196,10 +196,10 @@ type traceRun struct {
 }
 
 func (n *showTraceNode) startExec(params runParams) error {
-	if params.p.session.Tracing.Enabled() {
+	if params.extendedEvalCtx.Tracing.Enabled() {
 		return errTracingAlreadyEnabled
 	}
-	if err := params.p.session.Tracing.StartTracing(
+	if err := params.extendedEvalCtx.Tracing.StartTracing(
 		tracing.SnowballRecording, n.kvTracingEnabled,
 	); err != nil {
 		return err
@@ -261,7 +261,7 @@ func (n *showTraceNode) Next(params runParams) (bool, error) {
 		n.run.stopTracing = nil
 
 		var err error
-		n.run.traceRows, err = params.p.session.Tracing.generateSessionTraceVTable()
+		n.run.traceRows, err = params.extendedEvalCtx.Tracing.generateSessionTraceVTable()
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -695,7 +695,7 @@ func (p *planner) newSortValues(
 	return &sortValues{
 		ordering: ordering,
 		rows: sqlbase.NewRowContainer(
-			p.session.TxnState.makeBoundAccount(),
+			p.EvalContext().Mon.MakeBoundAccount(),
 			sqlbase.ColTypeInfoFromResCols(columns),
 			capacity,
 		),

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -112,7 +112,7 @@ func (n *splitNode) Next(params runParams) (bool, error) {
 		return false, err
 	}
 
-	if err := params.p.session.execCfg.DB.AdminSplit(params.ctx, rowKey, rowKey); err != nil {
+	if err := params.extendedEvalCtx.ExecCfg.DB.AdminSplit(params.ctx, rowKey, rowKey); err != nil {
 		return false, err
 	}
 

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -113,7 +113,7 @@ type SchemaAccessor interface {
 var _ SchemaAccessor = &planner{}
 
 func (p *planner) getVirtualTabler() VirtualTabler {
-	return &p.session.virtualSchemas
+	return p.extendedEvalCtx.VirtualSchemas
 }
 
 // getTableOrViewDesc returns a table descriptor for either a table or view,

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -665,7 +665,7 @@ func (p *planner) writeTableDesc(ctx context.Context, tableDesc *sqlbase.TableDe
 	// have written, but if they are followed by other statements that modify
 	// the descriptor the verification of the overwritten descriptor cannot be
 	// done.
-	p.session.setTestingVerifyMetadata(nil)
+	p.testingVerifyMetadata().setTestingVerifyMetadata(nil)
 
 	p.Tables().addUncommittedTable(*tableDesc)
 

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -653,7 +653,7 @@ func (p *planner) notifySchemaChange(
 		clock:                p.ExecCfg().Clock,
 		settings:             p.ExecCfg().Settings,
 	}
-	p.session.TxnState.schemaChangers.queueSchemaChanger(sc)
+	p.extendedEvalCtx.SchemaChangers.queueSchemaChanger(sc)
 }
 
 // writeTableDesc implements the SchemaAccessor interface.

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -667,7 +667,7 @@ func (p *planner) writeTableDesc(ctx context.Context, tableDesc *sqlbase.TableDe
 	// done.
 	p.session.setTestingVerifyMetadata(nil)
 
-	p.session.tables.addUncommittedTable(*tableDesc)
+	p.Tables().addUncommittedTable(*tableDesc)
 
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
 	descVal := sqlbase.WrapDescriptor(tableDesc)
@@ -720,7 +720,7 @@ func expandTableGlob(
 func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *tree.TableName) error {
 	t := *tn
 
-	descFunc := p.session.tables.getTableVersion
+	descFunc := p.Tables().getTableVersion
 	if p.avoidCachedDescriptors {
 		descFunc = getTableOrViewDesc
 	}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -671,7 +671,7 @@ func (p *planner) writeTableDesc(ctx context.Context, tableDesc *sqlbase.TableDe
 
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
 	descVal := sqlbase.WrapDescriptor(tableDesc)
-	if p.session.Tracing.KVTracingEnabled() {
+	if p.extendedEvalCtx.Tracing.KVTracingEnabled() {
 		log.VEventf(ctx, 2, "Put %s -> %s", descKey, descVal)
 	}
 	return p.txn.Put(ctx, descKey, descVal)

--- a/pkg/sql/testing_relocate.go
+++ b/pkg/sql/testing_relocate.go
@@ -153,7 +153,9 @@ func (n *testingRelocateNode) Next(params runParams) (bool, error) {
 			// Lookup the store in gossip.
 			var storeDesc roachpb.StoreDescriptor
 			gossipStoreKey := gossip.MakeStoreKey(storeID)
-			if err := params.p.session.execCfg.Gossip.GetInfoProto(gossipStoreKey, &storeDesc); err != nil {
+			if err := params.extendedEvalCtx.ExecCfg.Gossip.GetInfoProto(
+				gossipStoreKey, &storeDesc,
+			); err != nil {
 				return false, errors.Wrapf(err, "error looking up store %d", storeID)
 			}
 			nodeID = storeDesc.Node.NodeID
@@ -171,7 +173,7 @@ func (n *testingRelocateNode) Next(params runParams) (bool, error) {
 	}
 	rowKey = keys.MakeFamilyKey(rowKey, 0)
 
-	rangeDesc, err := lookupRangeDescriptor(params.ctx, params.p.session.execCfg.DB, rowKey)
+	rangeDesc, err := lookupRangeDescriptor(params.ctx, params.extendedEvalCtx.ExecCfg.DB, rowKey)
 	if err != nil {
 		return false, errors.Wrap(err, "error looking up range descriptor")
 	}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -110,7 +110,7 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 	}
 
 	// TODO(knz): move truncate logic to Start/Next so it can be used with SHOW TRACE FOR.
-	traceKV := p.session.Tracing.KVTracingEnabled()
+	traceKV := p.extendedEvalCtx.Tracing.KVTracingEnabled()
 	for id := range toTruncate {
 		if err := p.truncateTable(p.session.Ctx(), id, traceKV); err != nil {
 			return nil, err

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -112,7 +112,7 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 	// TODO(knz): move truncate logic to Start/Next so it can be used with SHOW TRACE FOR.
 	traceKV := p.extendedEvalCtx.Tracing.KVTracingEnabled()
 	for id := range toTruncate {
-		if err := p.truncateTable(p.session.Ctx(), id, traceKV); err != nil {
+		if err := p.truncateTable(p.EvalContext().Ctx(), id, traceKV); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -152,7 +152,7 @@ func (p *planner) truncateTable(ctx context.Context, id sqlbase.ID, traceKV bool
 		return err
 	}
 
-	newID, err := GenerateUniqueDescID(ctx, p.session.execCfg.DB)
+	newID, err := GenerateUniqueDescID(ctx, p.ExecCfg().DB)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -265,7 +265,7 @@ func (u *updateNode) startExec(params runParams) error {
 	if err := u.run.startEditNode(params, &u.editNodeBase); err != nil {
 		return err
 	}
-	return u.run.tw.init(params.p.txn, &params.p.session.TxnState.mon)
+	return u.run.tw.init(params.p.txn, params.EvalContext().Mon)
 }
 
 func (u *updateNode) Next(params runParams) (bool, error) {
@@ -276,7 +276,7 @@ func (u *updateNode) Next(params runParams) (bool, error) {
 				return false, err
 			}
 			// We're done. Finish the batch.
-			_, err = u.tw.finalize(params.ctx, params.p.extendedEvalCtx.Tracing.KVTracingEnabled())
+			_, err = u.tw.finalize(params.ctx, params.extendedEvalCtx.Tracing.KVTracingEnabled())
 		}
 		return false, err
 	}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -365,7 +365,7 @@ type editNodeBase struct {
 func (p *planner) makeEditNode(
 	ctx context.Context, tn *tree.TableName, priv privilege.Kind,
 ) (editNodeBase, error) {
-	tableDesc, err := p.session.tables.getTableVersion(ctx, p.txn, p.getVirtualTabler(), tn)
+	tableDesc, err := p.Tables().getTableVersion(ctx, p.txn, p.getVirtualTabler(), tn)
 	if err != nil {
 		return editNodeBase{}, err
 	}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -276,7 +276,7 @@ func (u *updateNode) Next(params runParams) (bool, error) {
 				return false, err
 			}
 			// We're done. Finish the batch.
-			_, err = u.tw.finalize(params.ctx, params.p.session.Tracing.KVTracingEnabled())
+			_, err = u.tw.finalize(params.ctx, params.p.extendedEvalCtx.Tracing.KVTracingEnabled())
 		}
 		return false, err
 	}
@@ -325,7 +325,7 @@ func (u *updateNode) Next(params runParams) (bool, error) {
 
 	// Update the row values.
 	newValues, err := u.tw.row(
-		params.ctx, append(oldValues, updateValues...), params.p.session.Tracing.KVTracingEnabled(),
+		params.ctx, append(oldValues, updateValues...), params.p.extendedEvalCtx.Tracing.KVTracingEnabled(),
 	)
 	if err != nil {
 		return false, err

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -60,7 +60,7 @@ func GetUserHashedPassword(
 // GetAllUsers returns all the usernames in system.users.
 func GetAllUsers(ctx context.Context, plan *planner) (map[string]bool, error) {
 	query := `SELECT username FROM system.users`
-	p := makeInternalPlanner("get-all-user", plan.txn, security.RootUser, plan.session.memMetrics)
+	p := makeInternalPlanner("get-all-user", plan.txn, security.RootUser, plan.extendedEvalCtx.MemMetrics)
 	defer finishInternalPlanner(p)
 	rows, err := p.queryRows(ctx, query)
 	if err != nil {

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -116,7 +116,7 @@ func (p *planner) newContainerValuesNode(columns sqlbase.ResultColumns, capacity
 		isConst: true,
 		valuesRun: valuesRun{
 			rows: sqlbase.NewRowContainer(
-				p.session.TxnState.makeBoundAccount(), sqlbase.ColTypeInfoFromResCols(columns), capacity,
+				p.EvalContext().Mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(columns), capacity,
 			),
 		},
 	}

--- a/pkg/sql/views.go
+++ b/pkg/sql/views.go
@@ -114,7 +114,7 @@ func RecomputeViewDependencies(ctx context.Context, txn *client.Txn, e *Executor
 	// We run as NodeUser because we may update system descriptors.
 	p := makeInternalPlanner("recompute-view-dependencies", txn, security.NodeUser, lm.memMetrics)
 	defer finishInternalPlanner(p)
-	p.session.tables.leaseMgr = lm
+	p.Tables().leaseMgr = lm
 
 	log.VEventf(ctx, 2, "recomputing view dependencies")
 

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -201,7 +201,13 @@ func initVirtualTableDesc(
 	return p.makeTableDesc(ctx, create, 0, keys.VirtualDescriptorID, hlc.Timestamp{}, emptyPrivileges, nil)
 }
 
+// entries is part of the VirtualTabler interface.
+func (vs *virtualSchemaHolder) getEntries() map[string]virtualSchemaEntry {
+	return vs.entries
+}
+
 // getVirtualSchemaEntry retrieves a virtual schema entry given a database name.
+// getVirtualSchemaEntry is part of the VirtualTabler interface.
 func (vs *virtualSchemaHolder) getVirtualSchemaEntry(name string) (virtualSchemaEntry, bool) {
 	if vs == nil {
 		return virtualSchemaEntry{}, false
@@ -220,6 +226,7 @@ func (vs *virtualSchemaHolder) getVirtualDatabaseDesc(name string) *sqlbase.Data
 }
 
 // isVirtualDatabase checks if the provided name corresponds to a virtual database.
+// isVirtualDatabase is part of the VirtualTabler interface.
 func (vs *virtualSchemaHolder) isVirtualDatabase(name string) bool {
 	_, ok := vs.getVirtualSchemaEntry(name)
 	return ok
@@ -235,6 +242,7 @@ func (e *Executor) IsVirtualDatabase(name string) bool {
 // pair. The function will return the table's virtual table entry if the name matches
 // a specific table. It will return an error if the name references a virtual database
 // but the table is non-existent.
+// getVirtualTableEntry is part of the VirtualTabler interface.
 func (vs *virtualSchemaHolder) getVirtualTableEntry(tn *tree.TableName) (virtualTableEntry, error) {
 	if db, ok := vs.getVirtualSchemaEntry(string(tn.DatabaseName)); ok {
 		if t, ok := db.tables[string(tn.TableName)]; ok {
@@ -250,10 +258,14 @@ type VirtualTabler interface {
 	getVirtualTableDesc(tn *tree.TableName) (*sqlbase.TableDescriptor, error)
 	getVirtualDatabaseDesc(name string) *sqlbase.DatabaseDescriptor
 	getVirtualSchemaEntry(name string) (virtualSchemaEntry, bool)
+	getVirtualTableEntry(tn *tree.TableName) (virtualTableEntry, error)
+	isVirtualDatabase(name string) bool
+	getEntries() map[string]virtualSchemaEntry
 }
 
 // getVirtualTableDesc checks if the provided name matches a virtual database/table
 // pair, and returns its descriptor if it does.
+// getVirtualTableDesc is part of the VirtualTabler interface.
 func (vs *virtualSchemaHolder) getVirtualTableDesc(
 	tn *tree.TableName,
 ) (*sqlbase.TableDescriptor, error) {
@@ -287,4 +299,16 @@ func (nilVirtualTabler) getVirtualDatabaseDesc(name string) *sqlbase.DatabaseDes
 
 func (nilVirtualTabler) getVirtualSchemaEntry(name string) (virtualSchemaEntry, bool) {
 	return virtualSchemaEntry{}, false
+}
+
+func (nilVirtualTabler) getVirtualTableEntry(tn *tree.TableName) (virtualTableEntry, error) {
+	return virtualTableEntry{}, nil
+}
+
+func (nilVirtualTabler) isVirtualDatabase(name string) bool {
+	return false
+}
+
+func (nilVirtualTabler) getEntries() map[string]virtualSchemaEntry {
+	return nil
 }

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -119,7 +119,7 @@ func (p *planner) window(
 
 	window.replaceIndexVarsAndAggFuncs(s)
 
-	acc := p.session.TxnState.makeBoundAccount()
+	acc := p.EvalContext().Mon.MakeBoundAccount()
 	window.run.wrappedRenderVals = sqlbase.NewRowContainer(
 		acc, sqlbase.ColTypeInfoFromResCols(s.columns), 0,
 	)
@@ -158,7 +158,7 @@ type windowRun struct {
 }
 
 func (n *windowNode) startExec(params runParams) error {
-	n.run.windowsAcc = params.p.session.TxnState.makeBoundAccount()
+	n.run.windowsAcc = params.EvalContext().Mon.MakeBoundAccount()
 	return nil
 }
 
@@ -178,7 +178,7 @@ func (n *windowNode) Next(params runParams) (bool, error) {
 				return false, err
 			}
 			n.run.values.rows = sqlbase.NewRowContainer(
-				params.p.session.TxnState.makeBoundAccount(),
+				params.EvalContext().Mon.MakeBoundAccount(),
 				sqlbase.ColTypeInfoFromResCols(n.run.values.columns),
 				n.run.wrappedRenderVals.Len(),
 			)


### PR DESCRIPTION
This sequence of patches makes the vast majority of planning and sql execution stop depending on the `Session` object. The `Session` is too heavy of a framework for the planning and execution modules to depend on. Also, `Session` itself is going away, to be replaced with newer code.
Instead, various narrow interfaces are extracted and various things are made accessible through the `extendedEvalContext` and/or through the `sessionDataMutator`.
Individual commits are quite small.

There's still a few stragglers before the `planner.session` field can go away; work continues.

Release note: none