### PR TITLE
sql, opt: interface between sql and opt for plan execution

### DIFF
--- a/pkg/sql/executor_opt_interface.go
+++ b/pkg/sql/executor_opt_interface.go
@@ -1,0 +1,103 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+var _ opt.ExecBuilderFactory = &Executor{}
+
+// NewExecBuilder is part of the opt.ExecBuilderFactory interface.
+func (e *Executor) NewExecBuilder() opt.ExecBuilder {
+	metrics := MakeMemMetrics("opt", time.Second)
+	session := NewSession(context.TODO(), SessionArgs{User: "root"}, e, nil /* remote */, &metrics)
+	txn := client.NewTxn(e.cfg.DB, e.cfg.NodeID.Get())
+	return &execBuilder{
+		planner: session.newPlanner(e, txn),
+	}
+}
+
+type execBuilder struct {
+	planner *planner
+}
+
+var _ opt.ExecBuilder = &execBuilder{}
+
+// Scan is part of the opt.ExecBuilder interface.
+func (eb *execBuilder) Scan(table optbase.Table) (opt.ExecNode, error) {
+	desc := table.(*sqlbase.TableDescriptor)
+
+	columns := make([]tree.ColumnID, len(desc.Columns))
+	for i := range columns {
+		columns[i] = tree.ColumnID(desc.Columns[i].ID)
+	}
+	// Create a scanNode.
+	scan := eb.planner.Scan()
+	if err := scan.initTable(eb.planner, desc, nil /* hints */, publicColumns, columns); err != nil {
+		return nil, err
+	}
+	var err error
+	scan.spans, err = makeSpans(
+		eb.planner.EvalContext(), nil /* constraints */, desc, &desc.PrimaryIndex,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &execNode{
+		execBuilder: *eb,
+		plan:        scan,
+	}, nil
+}
+
+type execNode struct {
+	execBuilder
+
+	plan planNode
+}
+
+var _ opt.ExecNode = &execNode{}
+
+// Run is part of the opt.ExecNode interface.
+func (en *execNode) Run() ([]tree.Datums, error) {
+	params := runParams{
+		ctx:             context.TODO(),
+		extendedEvalCtx: &en.planner.extendedEvalCtx,
+		p:               en.planner,
+	}
+	if err := startPlan(params, en.plan); err != nil {
+		return nil, err
+	}
+	var res []tree.Datums
+	for {
+		ok, err := en.plan.Next(params)
+		if err != nil {
+			return res, nil
+		}
+		if !ok {
+			break
+		}
+		res = append(res, append(tree.Datums(nil), en.plan.Values()...))
+	}
+	en.plan.Close(context.TODO())
+	return res, nil
+}

--- a/pkg/sql/opt/exec.go
+++ b/pkg/sql/opt/exec.go
@@ -1,0 +1,52 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package opt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/pkg/errors"
+)
+
+// ExecNode represents a node in the execution tree (currently maps to a
+// sql.planNode).
+type ExecNode interface {
+	// Run() executes the plan and returns the results as a Datum table.
+	Run() ([]tree.Datums, error)
+}
+
+// ExecBuilder is an interface used by the opt package to build an execution
+// plan (currently a sql.planNode tree).
+type ExecBuilder interface {
+	// Scan returns an ExecNode that represents a scan of the given table.
+	// TODO(radu): support list of columns, index, index constraints
+	Scan(table optbase.Table) (ExecNode, error)
+}
+
+// ExecBuilderFactory is an interface used to generate an ExecBuilder.
+type ExecBuilderFactory interface {
+	// New returns an ExecBuilder.
+	NewExecBuilder() ExecBuilder
+}
+
+// makeExec uses an ExecBuilder to build an execution tree.
+func makeExec(e *Expr, bld ExecBuilder) (ExecNode, error) {
+	switch e.op {
+	case scanOp:
+		return bld.Scan(e.private.(optbase.Table))
+	default:
+		return nil, errors.Errorf("unsupported op %s", e.op)
+	}
+}

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -309,10 +309,6 @@ func (c testCatalog) FindTable(ctx context.Context, name *tree.TableName) (optba
 
 func TestOpt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	ctx := context.Background()
-	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(ctx)
-	catalog := testCatalog{kvDB: kvDB}
 
 	paths, err := filepath.Glob(*logicTestData)
 	if err != nil {
@@ -324,6 +320,11 @@ func TestOpt(t *testing.T) {
 
 	for _, path := range paths {
 		t.Run(filepath.Base(path), func(t *testing.T) {
+			ctx := context.Background()
+			s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+			defer s.Stopper().Stop(ctx)
+			catalog := testCatalog{kvDB: kvDB}
+
 			runTest(t, path, func(d *testdata) string {
 				var e *Expr
 				var varTypes []types.T

--- a/pkg/sql/opt/testdata/exec
+++ b/pkg/sql/opt/testdata/exec
@@ -4,23 +4,18 @@ CREATE DATABASE t
 exec-raw
 CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)
 
+exec-raw
+INSERT INTO t.a VALUES (1, 1.0), (2, 2.0), (3, 3.0)
+
 build
 SELECT * FROM t.a
 ----
 scan [out=(0,1)]
  └── columns: a.x:int:0 a.y:float,null:1
 
-build
-SELECT * FROM t.b
+build,exec
+SELECT * FROM t.a
 ----
-error: table missing
-
-build
-SELECT * FROM b
-----
-error: database missing
-
-build
-SELECT * FROM u.a
-----
-error: database missing
+1  1.0
+2  2.0
+3  3.0

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2417,6 +2417,8 @@ var ForeignKeyReferenceActionValue = [...]ForeignKeyReference_Action{
 	tree.Cascade:    ForeignKeyReference_CASCADE,
 }
 
+var _ optbase.Column = &ColumnDescriptor{}
+
 // IsNullable is part of the optbase.Column interface.
 func (desc *ColumnDescriptor) IsNullable() bool {
 	return desc.Nullable
@@ -2431,6 +2433,8 @@ func (desc *ColumnDescriptor) ColName() string {
 func (desc *ColumnDescriptor) DatumType() types.T {
 	return desc.Type.ToDatumType()
 }
+
+var _ optbase.Table = &TableDescriptor{}
 
 // TabName is part of the optbase.Table interface.
 func (desc *TableDescriptor) TabName() string {


### PR DESCRIPTION
We want to be able to convert an optimizer expression to a planNode
tree (for testing).

This commit proposes an abstract interface that is implemented by sql
and is used by opt to generate planNode trees. Currently only (full)
table scans are supported.

The Executor implements the top-level interface, with all the relevant
code in a separate file.

Renaming opt test directive `exec` to `exec-raw`; adding `exec`
directive which uses the new interface to execute a plan.

I will look into adding an Explain function so we can see the details
of the generated plan as well.

Release note: None