### PR TITLE
storage/engine: reimplement MVCC{Scan,Get} in C++

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -2540,6 +2540,11 @@ template <bool reverse> class mvccScanner {
   //
   // This also highlights the expense of keeping old versions inline
   // with the most recent version.
+  //
+  // It might be possible to make the number of iterations adaptive:
+  // decrease the number by one whenever we're forced to
+  // seek. Increase the number by one whenever the optimization hits
+  // (up to this maximum).
   static const int kMaxItersBeforeSeek = 10;
 
  public:

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -2797,8 +2797,8 @@ template <bool reverse> class mvccScanner {
   }
 
   // prevKey backs up the iterator to point to the prev MVCC key less
-  // than key. Returns false if the iterator is exhausted or an error
-  // occurs.
+  // than the specified key. Returns false if the iterator is
+  // exhausted or an error occurs.
   bool prevKey(const rocksdb::Slice& key) {
     key_buf_.assign(key.data(), key.size());
 
@@ -2885,7 +2885,7 @@ template <bool reverse> class mvccScanner {
   // larger than our read timestamp results in an uncertainty error.
   //
   // TODO(peter): Passing check_uncertainty as a boolean is a bit
-  // ungainly because it makes the subsequent comparion with
+  // ungainly because it makes the subsequent comparison with
   // timestamp_ a bit subtle. Consider passing a
   // uncertainAboveTimestamp parameter. Or better, templatize this
   // method and pass a "check" functor.
@@ -2993,8 +2993,7 @@ template <bool reverse> class mvccScanner {
 };
 
 typedef mvccScanner<false> mvccForwardScanner;
-typedef mvccScanner<true> mvccReverse
-Scanner;
+typedef mvccScanner<true> mvccReverseScanner;
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
                       bool consistent) {

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -237,6 +237,12 @@ DBTimestamp PrevTimestamp(DBTimestamp ts) {
   return ts;
 }
 
+inline bool operator==(const DBTimestamp& a, const DBTimestamp& b) {
+  return a.wall_time == b.wall_time && a.logical == b.logical;
+}
+
+inline bool operator!=(const DBTimestamp& a, const DBTimestamp& b) { return !(a == b); }
+
 inline bool operator<(const DBTimestamp& a, const DBTimestamp& b) {
   return a.wall_time < b.wall_time || (a.wall_time == b.wall_time && a.logical < b.logical);
 }
@@ -2516,7 +2522,11 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
   return kSuccess;
 }
 
-class mvccScanner {
+// mvccScanner implements the MVCCGet, MVCCScan and MVCCReverseScan
+// operations. Parameterizing the code on whether a forward or reverse
+// scan is performed allows the different code paths to be compiled
+// efficiently while still reusing the common code without difficulty.
+template <bool reverse> class mvccScanner {
   // kMaxItersBeforeSeek is the number of calls to iter->Next() to
   // perform when looking for the next key or a particular version
   // before calling iter->Seek().
@@ -2576,7 +2586,7 @@ class mvccScanner {
   // timestamp (the value @ T2). We then iterate to the next key and
   // discover the intent at B. What happens with the intent depends on
   // the mode we're reading in and the timestamp of the intent. In
-  // this case, the intent as at our read timestamp. If we're
+  // this case, the intent is at our read timestamp. If we're
   // performing an inconsistent read we'll return the intent and read
   // at the instant of time just before the intent (for only that
   // key). If we're reading consistently, we'll either return the
@@ -2602,16 +2612,23 @@ class mvccScanner {
     // auto micros = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
     // printf("seek %d: %s\n", int(micros), pctx->ToString(true).c_str());
 
-    if (!iterSeek(EncodeKey(start_key_, 0, 0))) {
-      return results_;
-    }
-
-    for (;;) {
-      if (cur_key_.compare(end_key_) >= 0) {
-        break;
+    if (reverse) {
+      if (!iterSeekReverse(EncodeKey(start_key_, 0, 0))) {
+        return results_;
       }
-      if (!getAndAdvance()) {
-        break;
+      for (; cur_key_.compare(end_key_) >= 0;) {
+        if (!getAndAdvance()) {
+          break;
+        }
+      }
+    } else {
+      if (!iterSeek(EncodeKey(start_key_, 0, 0))) {
+        return results_;
+      }
+      for (; cur_key_.compare(end_key_) < 0;) {
+        if (!getAndAdvance()) {
+          break;
+        }
       }
     }
 
@@ -2640,15 +2657,20 @@ class mvccScanner {
     return false;
   }
 
+  bool setStatus(const DBStatus& status) {
+    results_.status = status;
+    return false;
+  }
+
   bool getAndAdvance() {
-    const bool is_value = (cur_timestamp_.wall_time != 0 || cur_timestamp_.logical != 0);
+    const bool is_value = cur_timestamp_ != kZeroTimestamp;
     const rocksdb::Slice key = iter_rep_->key();
     const rocksdb::Slice value = iter_rep_->value();
 
     if (is_value) {
       if (timestamp_ >= cur_timestamp_) {
         // 1. Fast path: there is no intent and our read timestamp is
-        // newer than the value's timestamp.
+        // newer than the most recent version's timestamp.
         return addAndAdvance(value);
       }
 
@@ -2659,6 +2681,8 @@ class mvccScanner {
         if (txn_max_timestamp_ >= cur_timestamp_) {
           return uncertaintyError(cur_timestamp_);
         }
+        // Delegate to seekVersion to return a clock uncertainty error
+        // if there are any more versions above txn_max_timestamp_.
         return seekVersion(txn_max_timestamp_, true);
       }
 
@@ -2671,8 +2695,7 @@ class mvccScanner {
     }
 
     if (!meta_.ParseFromArray(value.data(), value.size())) {
-      results_.status = FmtStatus("unable to decode MVCCMetadata");
-      return false;
+      return setStatus(FmtStatus("unable to decode MVCCMetadata"));
     }
 
     if (meta_.has_raw_bytes()) {
@@ -2681,8 +2704,7 @@ class mvccScanner {
     }
 
     if (!meta_.has_txn()) {
-      results_.status = FmtStatus("intent without transaction");
-      return false;
+      return setStatus(FmtStatus("intent without transaction"));
     }
 
     const bool own_intent = (meta_.txn().id() == txn_id_);
@@ -2709,10 +2731,12 @@ class mvccScanner {
 
     if (!own_intent) {
       // 7. The key contains an intent which was not written by our
-      // transaction and our read timestamp is newer than when the
-      // intent was written.
+      // transaction and our read timestamp is newer than that of the
+      // intent. Note that this will trigger an error on the Go
+      // side. We continue scanning so that we can return all of the
+      // intents in the scan range.
       intents_->Put(key, value);
-      return nextKey();
+      return advanceKey();
     }
 
     if (txn_epoch_ == meta_.txn().epoch()) {
@@ -2725,13 +2749,11 @@ class mvccScanner {
 
     if (txn_epoch_ < meta_.txn().epoch()) {
       // 9. We're reading our own txn's intent but the current txn has
-      // an earlier epoch than the intent. Return an error so that
+      // an earlier epoch than the intent. Return an error so that the
       // earlier incarnation of our transaction aborts (presumably
       // this is some operation that was retried).
-      results_.status =
-          FmtStatus("failed to read with epoch %u due to a write intent with epoch %u", txn_epoch_,
-                    meta_.txn().epoch());
-      return false;
+      return setStatus(FmtStatus("failed to read with epoch %u due to a write intent with epoch %u",
+                                 txn_epoch_, meta_.txn().epoch()));
     }
 
     // 10. We're reading our own txn's intent but the current txn has a
@@ -2742,17 +2764,19 @@ class mvccScanner {
     return seekVersion(PrevTimestamp(ToDBTimestamp(meta_.timestamp())), false);
   }
 
-  // nextKey advances the iterator to point the next MVCC key greater
-  // than cur_key_. Returns false if the iterator is exhausted or an
-  // error occurs.
+  // nextKey advances the iterator to point to the next MVCC key
+  // greater than cur_key_. Returns false if the iterator is exhausted
+  // or an error occurs.
   bool nextKey() {
-    // Check to see if the next key is the end key.
+    // Check to see if the next key is the end key. This avoids
+    // advancing the iterator unnecessarily. For example, SQL can take
+    // advantage of this when doing single row reads with an
+    // appropriately set end key.
     if (cur_key_.size() + 1 == end_key_.size() && end_key_.starts_with(cur_key_) &&
         end_key_[cur_key_.size()] == '\0') {
       return false;
     }
 
-    // Now seek to next key.
     key_buf_.assign(cur_key_.data(), cur_key_.size());
 
     for (int i = 0; i < kMaxItersBeforeSeek; ++i) {
@@ -2772,6 +2796,74 @@ class mvccScanner {
     return iterSeek(key_buf_);
   }
 
+  // prevKey backs up the iterator to point to the prev MVCC key less
+  // than key. Returns false if the iterator is exhausted or an error
+  // occurs.
+  bool prevKey(const rocksdb::Slice& key) {
+    key_buf_.assign(key.data(), key.size());
+
+    for (int i = 0; i < kMaxItersBeforeSeek; ++i) {
+      if (!iterPrev()) {
+        return false;
+      }
+      if (cur_key_ != key_buf_) {
+        // TODO(peter): This really stinks for performance. We
+        // iterated to the previous key, but in order to find the
+        // latest version of the key we need to seek. An alternative
+        // approach would be to keep calling iterPrev() until we get
+        // to another different key and then call iterNext() to get
+        // back to this key. A quick test of this approach showed the
+        // benefit was in the single-digit percentages. A final
+        // thought: perhaps we can add a wrapper or abstraction around
+        // rocksdb::Iterator that maintains a window of keys. The
+        // window could possibly be small. For example, an
+        // iter->PeekPrevKey() method might be sufficient.
+        key_buf_.assign(cur_key_.data(), cur_key_.size());
+        key_buf_.append("\0", 1);
+        return iterSeek(key_buf_);
+      }
+    }
+
+    key_buf_.append("\0", 1);
+    return iterSeekReverse(key_buf_);
+  }
+
+  // advanceKey advances the iterator to point to the next MVCC
+  // key. Returns false if the iterator is exhausted or an error
+  // occurs.
+  bool advanceKey() {
+    if (reverse) {
+      return prevKey(cur_key_);
+    } else {
+      return nextKey();
+    }
+  }
+
+  bool advanceKeyAtEnd() {
+    if (reverse) {
+      // Iterating to the next key might have caused the iterator to
+      // reach the end of the key space. If that happens, back up to
+      // the very last key.
+      iter_rep_->SeekToLast();
+      return advanceKey();
+    } else {
+      // We've reached the end of the iterator and there is nothing
+      // left to do.
+      return false;
+    }
+  }
+
+  bool advanceKeyAtNewKey(const rocksdb::Slice& key) {
+    if (reverse) {
+      // We've advanced to the next key but need to move back to the
+      // previous key.
+      return prevKey(key);
+    } else {
+      // We're already at the new key so there is nothing to do.
+      return true;
+    }
+  }
+
   bool addAndAdvance(const rocksdb::Slice& value) {
     if (value.size() > 0) {
       kvs_->Put(iter_rep_->key(), value);
@@ -2779,25 +2871,35 @@ class mvccScanner {
         return false;
       }
     }
-    return nextKey();
+    return advanceKey();
   }
 
   // seekVersion advances the iterator to point to an MVCC version for
   // the specified key that is earlier than <ts_wall_time,
   // ts_logical>. Returns false if the iterator is exhausted or an
   // error occurs. On success, advances the iterator to the next key.
-  bool seekVersion(DBTimestamp timestamp, bool check_uncertainty) {
+  //
+  // If the iterator is exhausted in the process or an error occurs,
+  // return false, and true otherwise. If check_uncertainty is true,
+  // then observing any version of the desired key with a timestamp
+  // larger than our read timestamp results in an uncertainty error.
+  //
+  // TODO(peter): Passing check_uncertainty as a boolean is a bit
+  // ungainly because it makes the subsequent comparion with
+  // timestamp_ a bit subtle. Consider passing a
+  // uncertainAboveTimestamp parameter. Or better, templatize this
+  // method and pass a "check" functor.
+  bool seekVersion(DBTimestamp desired_timestamp, bool check_uncertainty) {
     key_buf_.assign(cur_key_.data(), cur_key_.size());
 
     for (int i = 0; i < kMaxItersBeforeSeek; ++i) {
       if (!iterNext()) {
-        return false;
+        return advanceKeyAtEnd();
       }
       if (cur_key_ != key_buf_) {
-        // We've iterated to the next MVCC key.
-        return true;
+        return advanceKeyAtNewKey(key_buf_);
       }
-      if (timestamp >= cur_timestamp_) {
+      if (desired_timestamp >= cur_timestamp_) {
         if (check_uncertainty && timestamp_ < cur_timestamp_) {
           return uncertaintyError(cur_timestamp_);
         }
@@ -2805,20 +2907,19 @@ class mvccScanner {
       }
     }
 
-    if (!iterSeek(EncodeKey(key_buf_, timestamp.wall_time, timestamp.logical))) {
-      return false;
+    if (!iterSeek(EncodeKey(key_buf_, desired_timestamp.wall_time, desired_timestamp.logical))) {
+      return advanceKeyAtEnd();
     }
     if (cur_key_ != key_buf_) {
-      // We've seeked to the next MVCC key.
-      return true;
+      return advanceKeyAtNewKey(key_buf_);
     }
-    if (timestamp >= cur_timestamp_) {
+    if (desired_timestamp >= cur_timestamp_) {
       if (check_uncertainty && timestamp_ < cur_timestamp_) {
         return uncertaintyError(cur_timestamp_);
       }
       return addAndAdvance(iter_rep_->value());
     }
-    return nextKey();
+    return advanceKey();
   }
 
   bool updateCurrent() {
@@ -2827,19 +2928,46 @@ class mvccScanner {
     }
     cur_timestamp_ = kZeroTimestamp;
     if (!DecodeKey(iter_rep_->key(), &cur_key_, &cur_timestamp_)) {
-      results_.status = FmtStatus("failed to split mvcc key");
-      return false;
+      return setStatus(FmtStatus("failed to split mvcc key"));
     }
     return true;
   }
 
+  // iterSeek positions the iterator at the first key that is greater
+  // than or equal to key.
   bool iterSeek(const rocksdb::Slice& key) {
     iter_rep_->Seek(key);
     return updateCurrent();
   }
 
+  // iterSeekReverse positions the iterator at the last key that is
+  // less than key.
+  bool iterSeekReverse(const rocksdb::Slice& key) {
+    // SeekForPrev positions the iterator at the key that is less than
+    // key. NB: the doc comment on SeekForPrev suggests it positions
+    // less than or equal, but this is a lie.
+    iter_rep_->SeekForPrev(key);
+    if (!updateCurrent()) {
+      return false;
+    }
+    if (cur_timestamp_ == kZeroTimestamp) {
+      // We landed on an intent or inline value.
+      return true;
+    }
+    // We landed on a versioned value, we need back up to find the
+    // latest version.
+    key_buf_.assign(cur_key_.data(), cur_key_.size());
+    key_buf_.append("\0", 1);
+    return iterSeek(key_buf_);
+  }
+
   bool iterNext() {
     iter_rep_->Next();
+    return updateCurrent();
+  }
+
+  bool iterPrev() {
+    iter_rep_->Prev();
     return updateCurrent();
   }
 
@@ -2864,22 +2992,34 @@ class mvccScanner {
   DBTimestamp cur_timestamp_;
 };
 
+typedef mvccScanner<false> mvccForwardScanner;
+typedef mvccScanner<true> mvccReverse
+Scanner;
+
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
                       bool consistent) {
   // Get is implemented as a scan where we retrieve a single key. Note
   // that the semantics of max_keys is that we retrieve one more key
   // than is specified in order to maintain the existing semantics of
   // resume span. See storage/engine/mvcc.go:MVCCScan.
+  //
+  // We specify an empty key for the end key which will ensure we
+  // don't retrieve a key different than the start key. This is a bit
+  // of a hack.
   const DBSlice end = {0, 0};
-  mvccScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent);
+  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent);
   return scanner.get();
 }
 
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
                        int64_t max_keys, DBTxn txn, bool consistent, bool reverse) {
-  // TODO(peter): Support reverse iteration.
-  mvccScanner scanner(iter, start, end, timestamp, max_keys, txn, consistent);
-  return scanner.scan();
+  if (reverse) {
+    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent);
+    return scanner.scan();
+  } else {
+    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, consistent);
+    return scanner.scan();
+  }
 }
 
 // DBGetStats queries the given DBEngine for various operational stats and

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -274,25 +274,6 @@ func (v Value) Verify(key []byte) error {
 	return nil
 }
 
-// VerifyValues verifies the checksums for the key/value pairs. The first error
-// encountered is returned.
-func VerifyValues(kvs []KeyValue) error {
-	crc := crc32Pool.Get().(hash.Hash32)
-	var err error
-	for i := range kvs {
-		kv := &kvs[i]
-		if sum := kv.Value.checksum(); sum != 0 {
-			if computedSum := computeChecksum(kv.Key, kv.Value.RawBytes, crc); computedSum != sum {
-				err = fmt.Errorf("%s: invalid checksum (%x) value [% x]",
-					kv.Key, computedSum, kv.Value.RawBytes)
-				break
-			}
-		}
-	}
-	crc32Pool.Put(crc)
-	return err
-}
-
 // ShallowClone returns a shallow clone of the receiver.
 func (v *Value) ShallowClone() *Value {
 	if v == nil {

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -484,7 +484,7 @@ func (r *RocksDBBatchReader) Next() bool {
 
 	r.offset++
 	if len(r.repr) == 0 {
-		if r.offset < int(r.count) {
+		if r.offset < r.count {
 			r.err = errors.Errorf("invalid batch: expected %d entries but found %d", r.count, r.offset)
 		}
 		return false

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -54,7 +54,23 @@ func BenchmarkMVCCScan_RocksDB(b *testing.B) {
 				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
 					for _, valueSize := range []int{8, 64, 512} {
 						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
-							runMVCCScan(setupMVCCRocksDB, numRows, numVersions, valueSize, b)
+							runMVCCScan(setupMVCCRocksDB, numRows, numVersions, valueSize, false /* reverse */, b)
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkMVCCReverseScan_RocksDB(b *testing.B) {
+	for _, numRows := range []int{1, 10, 100, 1000} {
+		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
+			for _, numVersions := range []int{1, 2, 10, 100} {
+				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {
+					for _, valueSize := range []int{8, 64, 512} {
+						b.Run(fmt.Sprintf("valueSize=%d", valueSize), func(b *testing.B) {
+							runMVCCScan(setupMVCCRocksDB, numRows, numVersions, valueSize, true /* reverse */, b)
 						})
 					}
 				})

--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -25,12 +25,15 @@ import (
 )
 
 func setupMVCCRocksDB(b testing.TB, dir string) Engine {
+	cache := NewRocksDBCache(1 << 30 /* 1GB */)
+	defer cache.Release()
+
 	rocksdb, err := NewRocksDB(
 		RocksDBConfig{
 			Settings: cluster.MakeTestingClusterSettings(),
 			Dir:      dir,
 		},
-		RocksDBCache{},
+		cache,
 	)
 	if err != nil {
 		b.Fatalf("could not create new rocksdb db instance at %s: %v", dir, err)

--- a/pkg/storage/engine/bench_test.go
+++ b/pkg/storage/engine/bench_test.go
@@ -151,17 +151,29 @@ func runMVCCScan(emk engineMaker, numRows, numVersions, valueSize int, b *testin
 	eng, _ := setupMVCCData(emk, numVersions, numKeys, valueSize, b)
 	defer eng.Close()
 
+	{
+		// Pull all of the sstables into the RocksDB cache in order to make the
+		// timings more stable. Otherwise, the first run will be penalized pulling
+		// data into the cache while later runs will not.
+		iter := eng.NewIterator(false)
+		_, _ = iter.ComputeStats(MakeMVCCMetadataKey(roachpb.KeyMin), MakeMVCCMetadataKey(roachpb.KeyMax), 0)
+		iter.Close()
+	}
+
 	b.SetBytes(int64(numRows * valueSize))
 	b.ResetTimer()
 
-	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
+	startKeyBuf := append(make([]byte, 0, 64), []byte("key-")...)
+	endKeyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 	for i := 0; i < b.N; i++ {
 		// Choose a random key to start scan.
 		keyIdx := rand.Int31n(int32(numKeys - numRows))
-		startKey := roachpb.Key(encoding.EncodeUvarintAscending(keyBuf[:4], uint64(keyIdx)))
+		startKey := roachpb.Key(encoding.EncodeUvarintAscending(startKeyBuf[:4], uint64(keyIdx)))
+		endKey := roachpb.Key(encoding.EncodeUvarintAscending(endKeyBuf[:4], uint64(keyIdx+int32(numRows)-1)))
+		endKey = endKey.Next()
 		walltime := int64(5 * (rand.Int31n(int32(numVersions)) + 1))
 		ts := hlc.Timestamp{WallTime: walltime}
-		kvs, _, _, err := MVCCScan(context.Background(), eng, startKey, keyMax, int64(numRows), ts, true, nil)
+		kvs, _, _, err := MVCCScan(context.Background(), eng, startKey, endKey, int64(numRows), ts, true, nil)
 		if err != nil {
 			b.Fatalf("failed scan: %s", err)
 		}
@@ -176,10 +188,11 @@ func runMVCCScan(emk engineMaker, numRows, numVersions, valueSize int, b *testin
 // runMVCCGet first creates test data (and resets the benchmarking
 // timer). It then performs b.N MVCCGets.
 func runMVCCGet(emk engineMaker, numVersions, valueSize int, b *testing.B) {
-	const targetSize = 512 << 20 // 512 MB
-	// Adjust the number of keys so that each test has approximately the same
-	// amount of data.
-	numKeys := targetSize / ((overhead + valueSize) * (1 + (numVersions-1)/2))
+	// Use the same number of keys for all of the mvcc scan
+	// benchmarks. Using a different number of keys per test gives
+	// preferential treatment to tests with fewer keys. Note that the
+	// datasets all fit in cache and the cache is pre-warmed.
+	const numKeys = 100000
 
 	eng, _ := setupMVCCData(emk, numVersions, numKeys, valueSize, b)
 	defer eng.Close()

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -101,6 +101,20 @@ type Iterator interface {
 	//
 	// TODO: remove allowMeta2Splits in version 1.3.
 	FindSplitKey(start, end, minSplitKey MVCCKey, targetSize int64, allowMeta2Splits bool) (MVCCKey, error)
+	// MVCCGet retrieves the value for the key at the specified timestamp. The
+	// value is returned in batch repr format with the key being present as the
+	// empty string. If an intent exists at the specified key, it will be
+	// returned in batch repr format in the separate intent return value.
+	MVCCGet(key roachpb.Key, timestamp hlc.Timestamp,
+		txn *roachpb.Transaction, consistent bool,
+	) (kv []byte, intent []byte, err error)
+	// MVCCScan scans the underlying engine from start to end keys and returns
+	// key/value pairs which have a timestamp less than or equal to the supplied
+	// timestamp, up to a max rows. The key/value pairs are returned in the batch
+	// repr format and can be iterated over using RocksDBBatchReader.
+	MVCCScan(start, end roachpb.Key, max int64, timestamp hlc.Timestamp,
+		txn *roachpb.Transaction, consistent, reverse bool,
+	) (kvs []byte, intents []byte, err error)
 }
 
 // Reader is the read interface to an engine's data.

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -107,7 +107,7 @@ type Iterator interface {
 	// returned in batch repr format in the separate intent return value.
 	MVCCGet(key roachpb.Key, timestamp hlc.Timestamp,
 		txn *roachpb.Transaction, consistent bool,
-	) (kv []byte, intent []byte, err error)
+	) (*roachpb.Value, []roachpb.Intent, error)
 	// MVCCScan scans the underlying engine from start to end keys and returns
 	// key/value pairs which have a timestamp less than or equal to the supplied
 	// timestamp, up to a max rows. The key/value pairs are returned in the batch

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -592,10 +592,27 @@ func MVCCGet(
 	consistent bool,
 	txn *roachpb.Transaction,
 ) (*roachpb.Value, []roachpb.Intent, error) {
-	iter := engine.NewIterator(true)
-	defer iter.Close()
+	// TODO(peter): delete the old code.
+	if false {
+		iter := engine.NewIterator(true)
+		defer iter.Close()
+		return mvccGetUsingIter(ctx, iter, key, timestamp, consistent, txn)
+	}
 
-	return mvccGetUsingIter(ctx, iter, key, timestamp, consistent, txn)
+	iter := engine.NewIterator(true)
+	kvData, intentData, err := iter.MVCCGet(key, timestamp, txn, consistent)
+	iter.Close()
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	kvs, _, intents, err := buildScanResults(kvData, intentData, math.MaxInt64, consistent)
+	var value *roachpb.Value
+	if len(kvs) > 0 {
+		value = &kvs[0].Value
+	}
+	return value, intents, err
 }
 
 func mvccGetUsingIter(
@@ -1635,6 +1652,90 @@ func mvccScanInternal(
 	return res, resumeSpan, intents, nil
 }
 
+func buildScanIntents(data []byte) ([]roachpb.Intent, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	reader, err := NewRocksDBBatchReader(data)
+	if err != nil {
+		return nil, err
+	}
+
+	intents := make([]roachpb.Intent, 0, reader.Count())
+	var meta enginepb.MVCCMetadata
+	for reader.Next() {
+		key, err := reader.MVCCKey()
+		if err != nil {
+			return nil, err
+		}
+		if err := protoutil.Unmarshal(reader.Value(), &meta); err != nil {
+			return nil, err
+		}
+		intents = append(intents, roachpb.Intent{
+			Span:   roachpb.Span{Key: key.Key},
+			Status: roachpb.PENDING,
+			Txn:    *meta.Txn,
+		})
+	}
+
+	if err := reader.Error(); err != nil {
+		return nil, err
+	}
+	return intents, nil
+}
+
+func buildScanResults(
+	kvData, intentData []byte, max int64, consistent bool,
+) ([]roachpb.KeyValue, roachpb.Key, []roachpb.Intent, error) {
+	intents, err := buildScanIntents(intentData)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if consistent && len(intents) > 0 {
+		return nil, nil, nil, &roachpb.WriteIntentError{Intents: intents}
+	}
+	if len(kvData) == 0 {
+		return nil, nil, intents, nil
+	}
+
+	reader, err := NewRocksDBBatchReader(kvData)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	kvs := make([]roachpb.KeyValue, 0, reader.Count())
+	var resumeKey roachpb.Key
+	for reader.Next() {
+		key, err := reader.MVCCKey()
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if int64(len(kvs)) == max {
+			resumeKey = key.Key
+			break
+		}
+		kvs = append(kvs, roachpb.KeyValue{
+			Key:   key.Key,
+			Value: roachpb.Value{RawBytes: reader.Value(), Timestamp: key.Timestamp},
+		})
+	}
+
+	if err := reader.Error(); err != nil {
+		return nil, nil, nil, err
+	}
+
+	// TODO(peter): The checksum verification causes a 10-20% slowdown for large
+	// scans. See what we can do about that. Perhaps move the verification into
+	// C++. Perhaps use a faster implementation of CRC32. Or switch to CRC32c.
+	if err := roachpb.VerifyValues(kvs); err != nil {
+		return nil, nil, nil, err
+	}
+
+	return kvs, resumeKey, intents, nil
+
+}
+
 // MVCCScan scans the key range [key,endKey) key up to some maximum number of
 // results in ascending order. If it hits max, it returns a span to be used in
 // the next call to this function. Use MaxInt64 for not limit. If the limit is
@@ -1650,8 +1751,31 @@ func MVCCScan(
 	consistent bool,
 	txn *roachpb.Transaction,
 ) ([]roachpb.KeyValue, *roachpb.Span, []roachpb.Intent, error) {
-	return mvccScanInternal(ctx, engine, key, endKey, max, timestamp,
-		consistent, txn, false /* reverse */)
+	// TODO(peter): delete the old code.
+	if false {
+		return mvccScanInternal(ctx, engine, key, endKey, max, timestamp,
+			consistent, txn, false /* reverse */)
+	}
+
+	if max == 0 {
+		return nil, &roachpb.Span{Key: key, EndKey: endKey}, nil, nil
+	}
+
+	iter := engine.NewIterator(false)
+	kvData, intentData, err := iter.MVCCScan(
+		key, endKey, max, timestamp, txn, consistent, false /* reverse */)
+	iter.Close()
+
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	kvs, resumeKey, intents, err := buildScanResults(kvData, intentData, max, consistent)
+	var resumeSpan *roachpb.Span
+	if resumeKey != nil {
+		resumeSpan = &roachpb.Span{Key: resumeKey, EndKey: endKey}
+	}
+	return kvs, resumeSpan, intents, err
 }
 
 // MVCCReverseScan scans the key range [start,end) key up to some maximum
@@ -1667,6 +1791,7 @@ func MVCCReverseScan(
 	consistent bool,
 	txn *roachpb.Transaction,
 ) ([]roachpb.KeyValue, *roachpb.Span, []roachpb.Intent, error) {
+	// TODO(peter): Support reverse scans.
 	return mvccScanInternal(ctx, engine, key, endKey, max, timestamp,
 		consistent, txn, true /* reverse */)
 }

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1761,12 +1761,6 @@ func buildScanResults(
 		resumeKey = key.Key
 	}
 
-	// TODO(peter): The checksum verification causes a 10-20% slowdown for large
-	// scans. See what we can do about that. Perhaps move the verification into
-	// C++. Perhaps use a faster implementation of CRC32. Or switch to CRC32c.
-	if err := roachpb.VerifyValues(kvs); err != nil {
-		return nil, nil, nil, err
-	}
 	return kvs, resumeKey, intents, nil
 }
 

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2005,9 +2005,6 @@ func (r *rocksDBIterator) MVCCGet(
 		Timestamp: mvccKey.Timestamp,
 	}
 	copy(value.RawBytes, rawValue)
-	if err := value.Verify(mvccKey.Key); err != nil {
-		return nil, nil, err
-	}
 	return value, intents, nil
 }
 

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1326,6 +1326,24 @@ func (r *rocksDBBatchIterator) FindSplitKey(
 	return r.iter.FindSplitKey(start, end, minSplitKey, targetSize, allowMeta2Splits)
 }
 
+func (r *rocksDBBatchIterator) MVCCGet(
+	key roachpb.Key, timestamp hlc.Timestamp, txn *roachpb.Transaction, consistent bool,
+) (kv []byte, intent []byte, err error) {
+	r.batch.flushMutations()
+	return r.iter.MVCCGet(key, timestamp, txn, consistent)
+}
+
+func (r *rocksDBBatchIterator) MVCCScan(
+	start, end roachpb.Key,
+	max int64,
+	timestamp hlc.Timestamp,
+	txn *roachpb.Transaction,
+	consistent, reverse bool,
+) (kvs []byte, intents []byte, err error) {
+	r.batch.flushMutations()
+	return r.iter.MVCCScan(start, end, max, timestamp, txn, consistent, reverse)
+}
+
 func (r *rocksDBBatchIterator) Key() MVCCKey {
 	return r.iter.Key()
 }
@@ -1931,6 +1949,69 @@ func (r *rocksDBIterator) FindSplitKey(
 	return MVCCKey{Key: cStringToGoBytes(splitKey)}, nil
 }
 
+func (r *rocksDBIterator) MVCCGet(
+	key roachpb.Key, timestamp hlc.Timestamp, txn *roachpb.Transaction, consistent bool,
+) (kv []byte, intent []byte, err error) {
+	if !consistent && txn != nil {
+		return nil, nil, errors.Errorf("cannot allow inconsistent reads within a transaction")
+	}
+	if len(key) == 0 {
+		return nil, nil, emptyKeyError()
+	}
+
+	state := C.MVCCGet(
+		r.iter, goToCSlice(key), goToCTimestamp(timestamp),
+		goToCTxn(txn), C.bool(consistent),
+	)
+
+	if err := statusToError(state.status); err != nil {
+		return nil, nil, err
+	}
+	if state.uncertainty_timestamp.wall_time != 0 || state.uncertainty_timestamp.logical != 0 {
+		return nil, nil, roachpb.NewReadWithinUncertaintyIntervalError(
+			timestamp, hlc.Timestamp{
+				WallTime: int64(state.uncertainty_timestamp.wall_time),
+				Logical:  int32(state.uncertainty_timestamp.logical),
+			},
+			txn)
+	}
+	return cSliceToGoBytes(state.data), cSliceToGoBytes(state.intents), nil
+}
+
+func (r *rocksDBIterator) MVCCScan(
+	start, end roachpb.Key,
+	max int64,
+	timestamp hlc.Timestamp,
+	txn *roachpb.Transaction,
+	consistent, reverse bool,
+) (kvs []byte, intents []byte, err error) {
+	if !consistent && txn != nil {
+		return nil, nil, errors.Errorf("cannot allow inconsistent reads within a transaction")
+	}
+	if len(end) == 0 {
+		return nil, nil, emptyKeyError()
+	}
+
+	state := C.MVCCScan(
+		r.iter, goToCSlice(start), goToCSlice(end),
+		goToCTimestamp(timestamp), C.int64_t(max),
+		goToCTxn(txn), C.bool(consistent), C.bool(reverse),
+	)
+
+	if err := statusToError(state.status); err != nil {
+		return nil, nil, err
+	}
+	if state.uncertainty_timestamp.wall_time != 0 || state.uncertainty_timestamp.logical != 0 {
+		return nil, nil, roachpb.NewReadWithinUncertaintyIntervalError(
+			timestamp, hlc.Timestamp{
+				WallTime: int64(state.uncertainty_timestamp.wall_time),
+				Logical:  int32(state.uncertainty_timestamp.logical),
+			},
+			txn)
+	}
+	return cSliceToGoBytes(state.data), cSliceToGoBytes(state.intents), nil
+}
+
 func cStatsToGoStats(stats C.MVCCStatsResult, nowNanos int64) (enginepb.MVCCStats, error) {
 	ms := enginepb.MVCCStats{}
 	if err := statusToError(stats.status); err != nil {
@@ -2046,6 +2127,16 @@ func goToCTimestamp(ts hlc.Timestamp) C.DBTimestamp {
 		wall_time: C.int64_t(ts.WallTime),
 		logical:   C.int32_t(ts.Logical),
 	}
+}
+
+func goToCTxn(txn *roachpb.Transaction) C.DBTxn {
+	var r C.DBTxn
+	if txn != nil {
+		r.id = goToCSlice(txn.ID.GetBytes())
+		r.epoch = C.uint32_t(txn.Epoch)
+		r.max_timestamp = goToCTimestamp(txn.MaxTimestamp)
+	}
+	return r
 }
 
 func statusToError(s C.DBStatus) error {

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -47,7 +47,7 @@ func NewIterator(iter engine.Iterator, spans *SpanSet) *Iterator {
 	}
 }
 
-// Close implements engine.Iterator.
+// Close is part of the engine.Iterator interface.
 func (s *Iterator) Close() {
 	s.i.Close()
 }
@@ -57,7 +57,7 @@ func (s *Iterator) Iterator() engine.Iterator {
 	return s.i
 }
 
-// Seek implements engine.Iterator.
+// Seek is part of the engine.Iterator interface.
 func (s *Iterator) Seek(key engine.MVCCKey) {
 	s.err = s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key})
 	if s.err == nil {
@@ -66,7 +66,7 @@ func (s *Iterator) Seek(key engine.MVCCKey) {
 	s.i.Seek(key)
 }
 
-// SeekReverse implements engine.Iterator.
+// SeekReverse is part of the engine.Iterator interface.
 func (s *Iterator) SeekReverse(key engine.MVCCKey) {
 	s.err = s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key})
 	if s.err == nil {
@@ -75,7 +75,7 @@ func (s *Iterator) SeekReverse(key engine.MVCCKey) {
 	s.i.SeekReverse(key)
 }
 
-// Valid implements engine.Iterator.
+// Valid is part of the engine.Iterator interface.
 func (s *Iterator) Valid() (bool, error) {
 	if s.err != nil {
 		return false, s.err
@@ -87,7 +87,7 @@ func (s *Iterator) Valid() (bool, error) {
 	return ok && !s.invalid, nil
 }
 
-// Next implements engine.Iterator.
+// Next is part of the engine.Iterator interface.
 func (s *Iterator) Next() {
 	s.i.Next()
 	if s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: s.UnsafeKey().Key}) != nil {
@@ -95,7 +95,7 @@ func (s *Iterator) Next() {
 	}
 }
 
-// Prev implements engine.Iterator.
+// Prev is part of the engine.Iterator interface.
 func (s *Iterator) Prev() {
 	s.i.Prev()
 	if s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: s.UnsafeKey().Key}) != nil {
@@ -103,7 +103,7 @@ func (s *Iterator) Prev() {
 	}
 }
 
-// NextKey implements engine.Iterator.
+// NextKey is part of the engine.Iterator interface.
 func (s *Iterator) NextKey() {
 	s.i.NextKey()
 	if s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: s.UnsafeKey().Key}) != nil {
@@ -111,7 +111,7 @@ func (s *Iterator) NextKey() {
 	}
 }
 
-// PrevKey implements engine.Iterator.
+// PrevKey is part of the engine.Iterator interface.
 func (s *Iterator) PrevKey() {
 	s.i.PrevKey()
 	if s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: s.UnsafeKey().Key}) != nil {
@@ -119,37 +119,37 @@ func (s *Iterator) PrevKey() {
 	}
 }
 
-// Key implements engine.Iterator.
+// Key is part of the engine.Iterator interface.
 func (s *Iterator) Key() engine.MVCCKey {
 	return s.i.Key()
 }
 
-// Value implements engine.Iterator.
+// Value is part of the engine.Iterator interface.
 func (s *Iterator) Value() []byte {
 	return s.i.Value()
 }
 
-// ValueProto implements engine.Iterator.
+// ValueProto is part of the engine.Iterator interface.
 func (s *Iterator) ValueProto(msg protoutil.Message) error {
 	return s.i.ValueProto(msg)
 }
 
-// UnsafeKey implements engine.Iterator.
+// UnsafeKey is part of the engine.Iterator interface.
 func (s *Iterator) UnsafeKey() engine.MVCCKey {
 	return s.i.UnsafeKey()
 }
 
-// UnsafeValue implements engine.Iterator.
+// UnsafeValue is part of the engine.Iterator interface.
 func (s *Iterator) UnsafeValue() []byte {
 	return s.i.UnsafeValue()
 }
 
-// Less implements engine.Iterator.
+// Less is part of the engine.Iterator interface.
 func (s *Iterator) Less(key engine.MVCCKey) bool {
 	return s.i.Less(key)
 }
 
-// ComputeStats implements engine.Iterator.
+// ComputeStats is part of the engine.Iterator interface.
 func (s *Iterator) ComputeStats(
 	start, end engine.MVCCKey, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
@@ -159,7 +159,7 @@ func (s *Iterator) ComputeStats(
 	return s.i.ComputeStats(start, end, nowNanos)
 }
 
-// FindSplitKey implements engine.Iterator.
+// FindSplitKey is part of the engine.Iterator interface.
 func (s *Iterator) FindSplitKey(
 	start, end, minSplitKey engine.MVCCKey, targetSize int64, allowMeta2Splits bool,
 ) (engine.MVCCKey, error) {
@@ -167,6 +167,30 @@ func (s *Iterator) FindSplitKey(
 		return engine.MVCCKey{}, err
 	}
 	return s.i.FindSplitKey(start, end, minSplitKey, targetSize, allowMeta2Splits)
+}
+
+// MVCCGet is part of the engine.Iterator interface.
+func (s *Iterator) MVCCGet(
+	key roachpb.Key, timestamp hlc.Timestamp, txn *roachpb.Transaction, consistent bool,
+) (kv []byte, intent []byte, err error) {
+	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key}); err != nil {
+		return nil, nil, err
+	}
+	return s.i.MVCCGet(key, timestamp, txn, consistent)
+}
+
+// MVCCScan is part of the engine.Iterator interface.
+func (s *Iterator) MVCCScan(
+	start, end roachpb.Key,
+	max int64,
+	timestamp hlc.Timestamp,
+	txn *roachpb.Transaction,
+	consistent, reverse bool,
+) (kvs []byte, intents []byte, err error) {
+	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
+		return nil, nil, err
+	}
+	return s.i.MVCCScan(start, end, max, timestamp, txn, consistent, reverse)
 }
 
 type spanSetReader struct {

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -172,7 +172,7 @@ func (s *Iterator) FindSplitKey(
 // MVCCGet is part of the engine.Iterator interface.
 func (s *Iterator) MVCCGet(
 	key roachpb.Key, timestamp hlc.Timestamp, txn *roachpb.Transaction, consistent bool,
-) (kv []byte, intent []byte, err error) {
+) (*roachpb.Value, []roachpb.Intent, error) {
 	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key}); err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Reimplement `MVCC{Scan,Get}` in C++. The general strategy is for the C++
version of `MVCC{Scan,Get}` to return key/values in the RocksDB batch
repr format which we can iterate over in Go using
`RocksDBBatchReader`. Intents are returned in a separate batch which Go
code translates into either a `WriteIntentError` or returns the intents
to the caller (depending on the `consistent` and `txn` settings).

`SELECT COUNT(*) FROM test.vk` where `test.kv` contains 5m rows reduced
from 4.3s to 2.3s (a 46% speedup) on a local single-node cluster.

The `versions=100` benchmarks have regressed because of the optimization
to call `iter->Next()` up to 10 times vs only a single time in the old
code (see `DBIterNext`). This hurts the `versions=100` benchmarks, but
significantly helps the `versions=2` and `versions=10` benchmarks.

The C++ version of `MVCCGet` is implemented in terms of `MVCCScan` which
likely accounts for the performance drop in the `MVCCGet` benchmarks. It
should be possible to recover this performance difference with
specialization of the C++ code.

```
name                                                   old time/op    new time/op     delta
MVCCScan_RocksDB/rows=1/versions=1/valueSize=8-8         5.96µs ± 2%     5.81µs ± 2%    -2.51%  (p=0.000 n=9+10)
MVCCScan_RocksDB/rows=1/versions=2/valueSize=8-8         6.95µs ± 2%     5.86µs ± 2%   -15.60%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=1/versions=10/valueSize=8-8        8.27µs ± 1%     6.21µs ± 2%   -24.94%  (p=0.000 n=8+10)
MVCCScan_RocksDB/rows=1/versions=100/valueSize=8-8       9.44µs ± 2%     7.59µs ± 2%   -19.61%  (p=0.000 n=8+9)
MVCCScan_RocksDB/rows=10/versions=1/valueSize=8-8        12.7µs ± 5%      9.3µs ± 2%   -26.83%  (p=0.000 n=9+9)
MVCCScan_RocksDB/rows=10/versions=2/valueSize=8-8        20.0µs ± 1%     10.8µs ±16%   -45.89%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=10/versions=10/valueSize=8-8       31.2µs ± 2%     14.1µs ± 2%   -54.66%  (p=0.000 n=9+8)
MVCCScan_RocksDB/rows=10/versions=100/valueSize=8-8      37.1µs ± 1%     38.8µs ± 1%    +4.63%  (p=0.000 n=9+8)
MVCCScan_RocksDB/rows=100/versions=1/valueSize=8-8       71.6µs ± 1%     39.9µs ± 2%   -44.29%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=100/versions=2/valueSize=8-8        139µs ± 2%       47µs ± 2%   -66.27%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=100/versions=10/valueSize=8-8       246µs ± 5%       85µs ± 2%   -65.32%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=100/versions=100/valueSize=8-8      300µs ± 1%      335µs ± 2%   +11.77%  (p=0.000 n=8+10)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=8-8       635µs ± 1%      335µs ± 1%   -47.28%  (p=0.000 n=9+10)
MVCCScan_RocksDB/rows=1000/versions=2/valueSize=8-8      1.30ms ± 2%     0.40ms ± 1%   -69.41%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=1000/versions=10/valueSize=8-8     2.39ms ± 6%     0.80ms ±10%   -66.37%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=1000/versions=100/valueSize=8-8    3.12ms ± 1%     3.27ms ± 3%    +4.61%  (p=0.000 n=7+9)
MVCCGet_RocksDB/versions=1/valueSize=8-8                 5.63µs ± 3%     5.93µs ± 3%    +5.49%  (p=0.000 n=9+10)
MVCCGet_RocksDB/versions=10/valueSize=8-8                6.73µs ±13%     6.51µs ± 2%      ~     (p=0.190 n=10+10)
MVCCGet_RocksDB/versions=100/valueSize=8-8               11.1µs ± 8%     11.5µs ± 3%      ~     (p=0.089 n=10+10)
```

Fixes #21334

Release note (performance improvement): Reimplement low-level scan
operations in C++, doubling performance for scans of contiguous
keys/rows.