### PR TITLE
opt: explain execution plans

### DIFF
--- a/pkg/sql/executor_opt_interface.go
+++ b/pkg/sql/executor_opt_interface.go
@@ -77,7 +77,7 @@ var _ opt.ExecNode = &execNode{}
 // Explain is part of the opt.ExecNode interface.
 func (en *execNode) Explain() ([]tree.Datums, error) {
 	// Add an explain node to the plan and run that.
-	explainer := explainer{
+	flags := explainFlags{
 		showMetadata: true,
 		showExprs:    true,
 		qualifyNames: true,
@@ -85,7 +85,7 @@ func (en *execNode) Explain() ([]tree.Datums, error) {
 	explainNode := execNode{
 		execBuilder: en.execBuilder,
 		plan: en.planner.makeExplainPlanNode(
-			explainer, false /* expanded */, false /* optimized */, en.plan,
+			flags, false /* expanded */, false /* optimized */, en.plan,
 		),
 	}
 	return explainNode.Run()

--- a/pkg/sql/executor_opt_interface.go
+++ b/pkg/sql/executor_opt_interface.go
@@ -16,7 +16,6 @@ package sql
 
 import (
 	"context"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -29,11 +28,9 @@ var _ opt.ExecBuilderFactory = &Executor{}
 
 // NewExecBuilder is part of the opt.ExecBuilderFactory interface.
 func (e *Executor) NewExecBuilder() opt.ExecBuilder {
-	metrics := MakeMemMetrics("opt", time.Second)
-	session := NewSession(context.TODO(), SessionArgs{User: "root"}, e, nil /* remote */, &metrics)
 	txn := client.NewTxn(e.cfg.DB, e.cfg.NodeID.Get())
 	return &execBuilder{
-		planner: session.newPlanner(e, txn),
+		planner: makeInternalPlanner("opt", txn, "root", &MemoryMetrics{}),
 	}
 }
 
@@ -76,6 +73,23 @@ type execNode struct {
 }
 
 var _ opt.ExecNode = &execNode{}
+
+// Explain is part of the opt.ExecNode interface.
+func (en *execNode) Explain() ([]tree.Datums, error) {
+	// Add an explain node to the plan and run that.
+	explainer := explainer{
+		showMetadata: true,
+		showExprs:    true,
+		qualifyNames: true,
+	}
+	explainNode := execNode{
+		execBuilder: en.execBuilder,
+		plan: en.planner.makeExplainPlanNode(
+			explainer, false /* expanded */, false /* optimized */, en.plan,
+		),
+	}
+	return explainNode.Run()
+}
 
 // Run is part of the opt.ExecNode interface.
 func (en *execNode) Run() ([]tree.Datums, error) {

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -48,7 +48,7 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 	optimized := true
 	expanded := true
 	normalizeExprs := true
-	explainer := explainer{
+	flags := explainFlags{
 		showMetadata: false,
 		showExprs:    false,
 		showTypes:    false,
@@ -68,30 +68,30 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 			switch optLower {
 			case "types":
 				newMode = explainPlan
-				explainer.showExprs = true
-				explainer.showTypes = true
+				flags.showExprs = true
+				flags.showTypes = true
 				// TYPES implies METADATA.
-				explainer.showMetadata = true
+				flags.showMetadata = true
 
 			case "symvars":
-				explainer.symbolicVars = true
+				flags.symbolicVars = true
 
 			case "metadata":
-				explainer.showMetadata = true
+				flags.showMetadata = true
 
 			case "qualify":
-				explainer.qualifyNames = true
+				flags.qualifyNames = true
 
 			case "verbose":
 				// VERBOSE implies EXPRS.
-				explainer.showExprs = true
+				flags.showExprs = true
 				// VERBOSE implies QUALIFY.
-				explainer.qualifyNames = true
+				flags.qualifyNames = true
 				// VERBOSE implies METADATA.
-				explainer.showMetadata = true
+				flags.showMetadata = true
 
 			case "exprs":
-				explainer.showExprs = true
+				flags.showExprs = true
 
 			case "noexpand":
 				expanded = false
@@ -133,7 +133,7 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 		// We may want to show placeholder types, so ensure no values
 		// are missing.
 		p.semaCtx.Placeholders.PermitUnassigned()
-		return p.makeExplainPlanNode(explainer, expanded, optimized, plan), nil
+		return p.makeExplainPlanNode(flags, expanded, optimized, plan), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported EXPLAIN mode: %d", mode)

--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -133,7 +133,7 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 		// We may want to show placeholder types, so ensure no values
 		// are missing.
 		p.semaCtx.Placeholders.PermitUnassigned()
-		return p.makeExplainPlanNode(explainer, expanded, optimized, n.Statement, plan), nil
+		return p.makeExplainPlanNode(explainer, expanded, optimized, plan), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported EXPLAIN mode: %d", mode)

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -69,7 +69,7 @@ var explainPlanVerboseColumns = sqlbase.ResultColumns{
 
 // newExplainPlanNode instantiates a planNode that runs an EXPLAIN query.
 func (p *planner) makeExplainPlanNode(
-	explainer explainer, expanded, optimized bool, origStmt tree.Statement, plan planNode,
+	explainer explainer, expanded, optimized bool, plan planNode,
 ) planNode {
 	columns := explainPlanColumns
 

--- a/pkg/sql/opt/exec.go
+++ b/pkg/sql/opt/exec.go
@@ -25,6 +25,10 @@ import (
 type ExecNode interface {
 	// Run() executes the plan and returns the results as a Datum table.
 	Run() ([]tree.Datums, error)
+
+	// Explain() executes EXPLAIN (VERBOSE) on the given plan and returns the
+	// results as a Datum table.
+	Explain() ([]tree.Datums, error)
 }
 
 // ExecBuilder is an interface used by the opt package to build an execution

--- a/pkg/sql/opt/testdata/exec
+++ b/pkg/sql/opt/testdata/exec
@@ -13,6 +13,13 @@ SELECT * FROM t.a
 scan [out=(0,1)]
  └── columns: a.x:int:0 a.y:float,null:1
 
+build,exec-explain
+SELECT * FROM t.a
+----
+scan  0  scan  ·      ·          (x, y)  ·
+·     0  ·     table  a@primary  ·       ·
+·     0  ·     spans  ALL        ·       ·
+
 build,exec
 SELECT * FROM t.a
 ----


### PR DESCRIPTION
Adding support for returning the EXPLAIN of a generated execution
plan. This can be used with the `exec-explain` test directive.

Also fixing the planner setup to use an internal planner.

Release note: None