### PR TITLE
opt: cosmetic improvements to the exec interfaces

### DIFF
--- a/pkg/sql/opt/exec.go
+++ b/pkg/sql/opt/exec.go
@@ -31,25 +31,20 @@ type ExecNode interface {
 	Explain() ([]tree.Datums, error)
 }
 
-// ExecBuilder is an interface used by the opt package to build an execution
-// plan (currently a sql.planNode tree).
-type ExecBuilder interface {
-	// Scan returns an ExecNode that represents a scan of the given table.
+// ExecFactory is an interface used by the opt package to build
+// an execution plan (currently a sql.planNode tree).
+type ExecFactory interface {
+	// ConstructScan returns an ExecNode that represents a scan of the given
+	// table.
 	// TODO(radu): support list of columns, index, index constraints
-	Scan(table optbase.Table) (ExecNode, error)
+	ConstructScan(table optbase.Table) (ExecNode, error)
 }
 
-// ExecBuilderFactory is an interface used to generate an ExecBuilder.
-type ExecBuilderFactory interface {
-	// New returns an ExecBuilder.
-	NewExecBuilder() ExecBuilder
-}
-
-// makeExec uses an ExecBuilder to build an execution tree.
-func makeExec(e *Expr, bld ExecBuilder) (ExecNode, error) {
+// makeExec uses an ExecFactory to build an execution tree.
+func makeExec(e *Expr, bld ExecFactory) (ExecNode, error) {
 	switch e.op {
 	case scanOp:
-		return bld.Scan(e.private.(optbase.Table))
+		return bld.ConstructScan(e.private.(optbase.Table))
 	default:
 		return nil, errors.Errorf("unsupported op %s", e.op)
 	}

--- a/pkg/sql/opt/main_test.go
+++ b/pkg/sql/opt/main_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
@@ -31,6 +33,10 @@ func TestMain(m *testing.M) {
 	security.SetAssetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
+
+	opt.NewExecFactory = func(s serverutils.TestServerInterface) opt.ExecFactory {
+		return s.Executor().(*sql.Executor).NewExecFactory()
+	}
 
 	os.Exit(m.Run())
 }

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -101,6 +101,11 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 )
 
+// NewExecFactory returns an ExecFactory that can be used to create
+// an execution plan. The implementation is in sql so this is an opaque
+// function that is initialized in TestMain.
+var NewExecFactory func(s serverutils.TestServerInterface) ExecFactory
+
 var (
 	logicTestData    = flag.String("d", "testdata/[^.]*", "test data glob")
 	rewriteTestFiles = flag.Bool(
@@ -414,8 +419,7 @@ func TestOpt(t *testing.T) {
 						if e == nil {
 							d.fatalf(t, "no expression for exec")
 						}
-						bld := s.Executor().(ExecBuilderFactory).NewExecBuilder()
-						n, err := makeExec(e, bld)
+						n, err := makeExec(e, NewExecFactory(s))
 						if err != nil {
 							d.fatalf(t, "MakeExec: %v", err)
 						}


### PR DESCRIPTION
 - rename ExecBuilder to ExecFactory
 - remove the ExecBuilderFactory interface and replace it with a
   function that is initialized in TestMain
 - rename Scan to ConstructScan

Release note: None

CC @andy-kimball