### PR TITLE
storage: automatically split ranges based on load

### DIFF
--- a/pkg/storage/split/split.go
+++ b/pkg/storage/split/split.go
@@ -1,0 +1,137 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package split
+
+import (
+	"bytes"
+	"math"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// Load-based splitting.
+//
+// Until merging is implemented, this mechanism is active only when the
+// whole system contains 1,000 or fewer ranges, to prevent runaway range
+// growth.
+//
+// - Engage split for ranges:
+//  - With size exceeding min-range-bytes
+//  - with reqs/s rate over a threshold
+// - Disengage when a range no longer meets the criteria
+// - During split:
+//  - Record start time
+//  - Keep a sample of 10 keys
+//   - Each sample contains two counters: left and right.
+//   - On each span, increment the left and/or right counters, depending
+//     on whether the span falls entirely to the left, to the right, or
+//     overlaps the key. If exactly on the key, increment neither.
+//   - When a sample is replaced, discard its counters.
+//  - If a range is on for more than a threshold interval:
+//   - Examine sample for the smallest diff between left and right counters,
+//     excluding any whose counters are not sufficiently advanced;
+//     If not less than some constant threshold, skip split.
+//   - If this point is reached, add range to split queue with the chosen
+//     key as split key, and provide hint to scatter the replicas.
+
+const (
+	durationThreshold  = 10 * time.Second // 10s
+	splitKeySampleSize = 20               // size of split key sample
+	splitKeyMinCounter = 200              // min aggregate counters before consideration
+	splitKeyThreshold  = 0.25             // 25% difference between left/right counters
+)
+
+type sample struct {
+	key         roachpb.Key
+	left, right int
+}
+
+type Split struct {
+	startNanos int64
+	samples    [splitKeySampleSize]sample
+	count      int
+}
+
+func New(startNanos int64) *Split {
+	return &Split{
+		startNanos: startNanos,
+	}
+}
+
+func (s *Split) Ready(nowNanos int64) bool {
+	return time.Duration(nowNanos-s.startNanos) > durationThreshold
+}
+
+func (s *Split) Record(span roachpb.Span, intNFn func(int) int) {
+	if s == nil {
+		return
+	}
+
+	var idx int
+	count := s.count
+	s.count++
+	if count < splitKeySampleSize {
+		idx = count
+	} else if idx = intNFn(count); idx >= splitKeySampleSize {
+		// Increment all existing keys' counters.
+		for i, sa := range s.samples {
+			if span.ContainsKey(sa.key) {
+				sa.left++
+				sa.right++
+			} else {
+				if comp := bytes.Compare(sa.key, span.Key); comp < 0 {
+					sa.right++
+				} else if comp > 0 {
+					sa.left++
+				}
+			}
+			s.samples[i] = sa
+		}
+		return
+	}
+
+	// Note we always use the start key of the span. We could
+	// take the average of the byte slices, but that seems
+	// unnecessarily complex for practical usage.
+	s.samples[idx] = sample{key: span.Key}
+}
+
+func (s *Split) Key() (bool, roachpb.Key) {
+	if s == nil {
+		return false, nil
+	}
+
+	var bestIdx int = -1
+	var bestScore float64 = 1
+	for i, s := range s.samples {
+		if s.left+s.right < splitKeyMinCounter {
+			continue
+		}
+		score := math.Abs(float64(s.left-s.right)) / float64(s.left+s.right)
+		if score >= splitKeyThreshold {
+			continue
+		}
+		if score < bestScore {
+			bestIdx = i
+			bestScore = score
+		}
+	}
+
+	if bestIdx == -1 {
+		return false, nil
+	}
+	return true, s.samples[bestIdx].key
+}

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -271,6 +271,18 @@ func (sp *StorePool) String() string {
 	return buf.String()
 }
 
+// totalRanges returns the total count of ranges in the system.
+// TODO(spencer): improve performance here.
+func (sp *StorePool) totalRanges() int64 {
+	sp.detailsMu.RLock()
+	defer sp.detailsMu.RUnlock()
+	var count int64
+	for _, detail := range sp.detailsMu.storeDetails {
+		count += int64(detail.desc.Capacity.RangeCount)
+	}
+	return count
+}
+
 // storeGossipUpdate is the gossip callback used to keep the StorePool up to date.
 func (sp *StorePool) storeGossipUpdate(_ string, content roachpb.Value) {
 	var storeDesc roachpb.StoreDescriptor


### PR DESCRIPTION
Currently, you have to wait for a decent amount of data to be inserted into
CockroachDB before you'll have enough ranges to make use of a big cluster.
This is inconvenient for POC testing and although the `ALTER TABLE SPLIT AT`
SQL command is available to manually pre-split ranges, its use is difficult
because it requires users to understand some of the architecture and the
nature of their data model.

This change splits ranges opportunistically if they exhibit required load
characteristics, up to a total of 1000 cluster-wide ranges. That limit is
arbitrary, and was chosen to avoid significant range creation before we've
implemented merging of ranges.

The algorithm is pretty simple: once a range exceeds the load threshold, we
begin tracking spans which it's servicing in requests. We use a reservoir
sample, inserting `span.Key`. If a sample doesn't replace an entry in the
reservoir, we take the opportunity instead to increment one or both of two
counters each reservoir sample maintains: left & right. The left counter is
incremented if the span falls to the left of the reservoir entry's key,
right, to the right. If the span overlaps the entry's key, then both counters
are incremented.

When a range has seen sustained load over the threshold rate for a threshold
duration, the key from the reservoir sample containing the most even balance
of left and right values is chosen for the split. There is again a threshold
to prevent poor choices in the event that load is sequentially writing keys
or otherwise making a good choice for the split key impossible.

Release note: None