### PR TITLE
storage: Shrink allocator details strings in system.rangelog entries

### DIFF
--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -97,22 +97,62 @@ func (bd balanceDimensions) String() string {
 		bd.totalScore(), int(bd.ranges), bd.bytes, bd.writes)
 }
 
+func (bd balanceDimensions) compactString(options scorerOptions) string {
+	if !options.statsBasedRebalancingEnabled {
+		return fmt.Sprintf("%d", bd.ranges)
+	}
+	return bd.String()
+}
+
 // candidate store for allocation.
 type candidate struct {
-	store           roachpb.StoreDescriptor
-	valid           bool
-	constraintScore float64
-	convergesScore  int
-	balanceScore    balanceDimensions
-	rangeCount      int
-	details         string
+	store          roachpb.StoreDescriptor
+	valid          bool
+	diversityScore float64
+	preferredScore int
+	convergesScore int
+	balanceScore   balanceDimensions
+	rangeCount     int
+	details        string
+}
+
+func (c candidate) constraintScore() float64 {
+	return c.diversityScore + float64(c.preferredScore)
 }
 
 func (c candidate) String() string {
-	return fmt.Sprintf("s%d, valid:%t, constraint:%.2f, converges:%d, balance:%s, rangeCount:%d, "+
-		"logicalBytes:%s, writesPerSecond:%.2f, details:(%s)",
-		c.store.StoreID, c.valid, c.constraintScore, c.convergesScore, c.balanceScore, c.rangeCount,
-		humanizeutil.IBytes(c.store.Capacity.LogicalBytes), c.store.Capacity.WritesPerSecond, c.details)
+	str := fmt.Sprintf("s%d, valid:%t, constraint:%.2f, converges:%d, balance:%s, rangeCount:%d, "+
+		"logicalBytes:%s, writesPerSecond:%.2f",
+		c.store.StoreID, c.valid, c.constraintScore(), c.convergesScore, c.balanceScore, c.rangeCount,
+		humanizeutil.IBytes(c.store.Capacity.LogicalBytes), c.store.Capacity.WritesPerSecond)
+	if c.details != "" {
+		return fmt.Sprintf("%s, details:(%s)", str, c.details)
+	}
+	return str
+}
+
+func (c candidate) compactString(options scorerOptions) string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "s%d", c.store.StoreID)
+	if !c.valid {
+		fmt.Fprintf(&buf, ", valid:%t", c.valid)
+	}
+	if c.diversityScore != 0 {
+		fmt.Fprintf(&buf, ", diversity:%.2f", c.diversityScore)
+	}
+	if c.preferredScore != 0 {
+		fmt.Fprintf(&buf, ", preferred:%d", c.preferredScore)
+	}
+	fmt.Fprintf(&buf, ", converges:%d, balance:%s, rangeCount:%d",
+		c.convergesScore, c.balanceScore.compactString(options), c.rangeCount)
+	if options.statsBasedRebalancingEnabled {
+		fmt.Fprintf(&buf, ", logicalBytes:%s, writesPerSecond:%.2f",
+			humanizeutil.IBytes(c.store.Capacity.LogicalBytes), c.store.Capacity.WritesPerSecond)
+	}
+	if c.details != "" {
+		fmt.Fprintf(&buf, ", details:(%s)", c.details)
+	}
+	return buf.String()
 }
 
 // less returns true if o is a better fit for some range than c is.
@@ -123,8 +163,8 @@ func (c candidate) less(o candidate) bool {
 	if !c.valid {
 		return true
 	}
-	if c.constraintScore != o.constraintScore {
-		return c.constraintScore < o.constraintScore
+	if c.constraintScore() != o.constraintScore() {
+		return c.constraintScore() < o.constraintScore()
 	}
 	if c.convergesScore != o.convergesScore {
 		return c.convergesScore < o.convergesScore
@@ -144,8 +184,8 @@ func (c candidate) worthRebalancingTo(o candidate, options scorerOptions) bool {
 	if !c.valid {
 		return true
 	}
-	if c.constraintScore != o.constraintScore {
-		return c.constraintScore < o.constraintScore
+	if c.constraintScore() != o.constraintScore() {
+		return c.constraintScore() < o.constraintScore()
 	}
 	if c.convergesScore != o.convergesScore {
 		return c.convergesScore < o.convergesScore
@@ -186,6 +226,20 @@ func (cl candidateList) String() string {
 	return buffer.String()
 }
 
+func (cl candidateList) compactString(options scorerOptions) string {
+	if len(cl) == 0 {
+		return "[]"
+	}
+	var buffer bytes.Buffer
+	buffer.WriteRune('[')
+	for _, c := range cl {
+		buffer.WriteRune('\n')
+		buffer.WriteString(c.compactString(options))
+	}
+	buffer.WriteRune(']')
+	return buffer.String()
+}
+
 // byScore implements sort.Interface to sort by scores.
 type byScore candidateList
 
@@ -202,7 +256,7 @@ var _ sort.Interface = byScoreAndID(nil)
 
 func (c byScoreAndID) Len() int { return len(c) }
 func (c byScoreAndID) Less(i, j int) bool {
-	if c[i].constraintScore == c[j].constraintScore &&
+	if c[i].constraintScore() == c[j].constraintScore() &&
 		c[i].convergesScore == c[j].convergesScore &&
 		c[i].balanceScore.totalScore() == c[j].balanceScore.totalScore() &&
 		c[i].rangeCount == c[j].rangeCount &&
@@ -232,8 +286,8 @@ func (cl candidateList) best() candidateList {
 		return cl
 	}
 	for i := 1; i < len(cl); i++ {
-		if cl[i].constraintScore < cl[0].constraintScore ||
-			(cl[i].constraintScore == cl[len(cl)-1].constraintScore &&
+		if cl[i].constraintScore() < cl[0].constraintScore() ||
+			(cl[i].constraintScore() == cl[len(cl)-1].constraintScore() &&
 				cl[i].convergesScore < cl[len(cl)-1].convergesScore) {
 			return cl[:i]
 		}
@@ -257,8 +311,8 @@ func (cl candidateList) worst() candidateList {
 	}
 	// Find the worst constraint values.
 	for i := len(cl) - 2; i >= 0; i-- {
-		if cl[i].constraintScore > cl[len(cl)-1].constraintScore ||
-			(cl[i].constraintScore == cl[len(cl)-1].constraintScore &&
+		if cl[i].constraintScore() > cl[len(cl)-1].constraintScore() ||
+			(cl[i].constraintScore() == cl[len(cl)-1].constraintScore() &&
 				cl[i].convergesScore > cl[len(cl)-1].convergesScore) {
 			return cl[i+1:]
 		}
@@ -358,12 +412,12 @@ func allocateCandidates(
 		diversityScore := diversityAllocateScore(s, existingNodeLocalities)
 		balanceScore := balanceScore(sl, s.Capacity, rangeInfo, options)
 		candidates = append(candidates, candidate{
-			store:           s,
-			valid:           true,
-			constraintScore: diversityScore + float64(preferredMatched),
-			balanceScore:    balanceScore,
-			rangeCount:      int(s.Capacity.RangeCount),
-			details:         fmt.Sprintf("diversity=%.2f, preferred=%d", diversityScore, preferredMatched),
+			store:          s,
+			valid:          true,
+			diversityScore: diversityScore,
+			preferredScore: preferredMatched,
+			balanceScore:   balanceScore,
+			rangeCount:     int(s.Capacity.RangeCount),
 		})
 	}
 	if options.deterministic {
@@ -415,13 +469,13 @@ func removeCandidates(
 			convergesScore = 1
 		}
 		candidates = append(candidates, candidate{
-			store:           s,
-			valid:           true,
-			constraintScore: diversityScore + float64(preferredMatched),
-			convergesScore:  convergesScore,
-			balanceScore:    balanceScore,
-			rangeCount:      int(s.Capacity.RangeCount),
-			details:         fmt.Sprintf("diversity=%.2f, preferred=%d", diversityScore, preferredMatched),
+			store:          s,
+			valid:          true,
+			diversityScore: diversityScore,
+			preferredScore: preferredMatched,
+			convergesScore: convergesScore,
+			balanceScore:   balanceScore,
+			rangeCount:     int(s.Capacity.RangeCount),
 		})
 	}
 	if options.deterministic {
@@ -527,13 +581,13 @@ func rebalanceCandidates(
 				convergesScore = 1
 			}
 			existingCandidates = append(existingCandidates, candidate{
-				store:           s,
-				valid:           true,
-				constraintScore: diversityScore + float64(storeInfo.matched),
-				convergesScore:  convergesScore,
-				balanceScore:    balanceScore,
-				rangeCount:      int(s.Capacity.RangeCount),
-				details:         fmt.Sprintf("diversity=%.2f, preferred=%d", diversityScore, storeInfo.matched),
+				store:          s,
+				valid:          true,
+				diversityScore: diversityScore,
+				preferredScore: storeInfo.matched,
+				convergesScore: convergesScore,
+				balanceScore:   balanceScore,
+				rangeCount:     int(s.Capacity.RangeCount),
 			})
 		} else {
 			if !storeInfo.ok || !maxCapacityOK {
@@ -555,13 +609,13 @@ func rebalanceCandidates(
 			}
 			diversityScore := diversityRebalanceScore(s, existingNodeLocalities)
 			candidates = append(candidates, candidate{
-				store:           s,
-				valid:           true,
-				constraintScore: diversityScore + float64(storeInfo.matched),
-				convergesScore:  convergesScore,
-				balanceScore:    balanceScore,
-				rangeCount:      int(s.Capacity.RangeCount),
-				details:         fmt.Sprintf("diversity=%.2f, preferred=%d", diversityScore, storeInfo.matched),
+				store:          s,
+				valid:          true,
+				diversityScore: diversityScore,
+				preferredScore: storeInfo.matched,
+				convergesScore: convergesScore,
+				balanceScore:   balanceScore,
+				rangeCount:     int(s.Capacity.RangeCount),
 			})
 		}
 	}

--- a/pkg/storage/allocator_scorer_test.go
+++ b/pkg/storage/allocator_scorer_test.go
@@ -92,7 +92,7 @@ func TestCandidateSelection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	type scoreTuple struct {
-		constraint int
+		diversity  int
 		rangeCount int
 	}
 	genCandidates := func(scores []scoreTuple, idShift int) candidateList {
@@ -102,9 +102,9 @@ func TestCandidateSelection(t *testing.T) {
 				store: roachpb.StoreDescriptor{
 					StoreID: roachpb.StoreID(i + idShift),
 				},
-				constraintScore: float64(score.constraint),
-				rangeCount:      score.rangeCount,
-				valid:           true,
+				diversityScore: float64(score.diversity),
+				rangeCount:     score.rangeCount,
+				valid:          true,
 			})
 		}
 		sort.Sort(sort.Reverse(byScore(cl)))
@@ -117,7 +117,7 @@ func TestCandidateSelection(t *testing.T) {
 			if i != 0 {
 				buffer.WriteRune(',')
 			}
-			buffer.WriteString(fmt.Sprintf("%d:%d", int(c.constraintScore), c.rangeCount))
+			buffer.WriteString(fmt.Sprintf("%d:%d", int(c.diversityScore), c.rangeCount))
 		}
 		return buffer.String()
 	}
@@ -202,7 +202,7 @@ func TestCandidateSelection(t *testing.T) {
 			if good == nil {
 				t.Fatalf("no good candidate found")
 			}
-			actual := scoreTuple{int(good.constraintScore), good.rangeCount}
+			actual := scoreTuple{int(good.diversityScore), good.rangeCount}
 			if actual != tc.good {
 				t.Errorf("expected:%v actual:%v", tc.good, actual)
 			}
@@ -212,7 +212,7 @@ func TestCandidateSelection(t *testing.T) {
 			if bad == nil {
 				t.Fatalf("no bad candidate found")
 			}
-			actual := scoreTuple{int(bad.constraintScore), bad.rangeCount}
+			actual := scoreTuple{int(bad.diversityScore), bad.rangeCount}
 			if actual != tc.bad {
 				t.Errorf("expected:%v actual:%v", tc.bad, actual)
 			}
@@ -225,59 +225,59 @@ func TestBetterThan(t *testing.T) {
 
 	testCandidateList := candidateList{
 		{
-			valid:           true,
-			constraintScore: 1,
-			rangeCount:      0,
+			valid:          true,
+			diversityScore: 1,
+			rangeCount:     0,
 		},
 		{
-			valid:           true,
-			constraintScore: 1,
-			rangeCount:      0,
+			valid:          true,
+			diversityScore: 1,
+			rangeCount:     0,
 		},
 		{
-			valid:           true,
-			constraintScore: 1,
-			rangeCount:      1,
+			valid:          true,
+			diversityScore: 1,
+			rangeCount:     1,
 		},
 		{
-			valid:           true,
-			constraintScore: 1,
-			rangeCount:      1,
+			valid:          true,
+			diversityScore: 1,
+			rangeCount:     1,
 		},
 		{
-			valid:           true,
-			constraintScore: 0,
-			rangeCount:      0,
+			valid:          true,
+			diversityScore: 0,
+			rangeCount:     0,
 		},
 		{
-			valid:           true,
-			constraintScore: 0,
-			rangeCount:      0,
+			valid:          true,
+			diversityScore: 0,
+			rangeCount:     0,
 		},
 		{
-			valid:           true,
-			constraintScore: 0,
-			rangeCount:      1,
+			valid:          true,
+			diversityScore: 0,
+			rangeCount:     1,
 		},
 		{
-			valid:           true,
-			constraintScore: 0,
-			rangeCount:      1,
+			valid:          true,
+			diversityScore: 0,
+			rangeCount:     1,
 		},
 		{
-			valid:           false,
-			constraintScore: 1,
-			rangeCount:      0,
+			valid:          false,
+			diversityScore: 1,
+			rangeCount:     0,
 		},
 		{
-			valid:           false,
-			constraintScore: 0,
-			rangeCount:      0,
+			valid:          false,
+			diversityScore: 0,
+			rangeCount:     0,
 		},
 		{
-			valid:           false,
-			constraintScore: 0,
-			rangeCount:      1,
+			valid:          false,
+			diversityScore: 0,
+			rangeCount:     1,
 		},
 	}
 


### PR DESCRIPTION
There's a whole bunch of stuff that we typically don't need to print.
Omit all such fields when we can.

Up-replicate details go from:
"Details":"{\"Target\":\"s6, valid:true, constraint:0.00, converges:0, balance:0.00(ranges=0, bytes=0.00, writes=0.00), rangeCount:10, logicalBytes:1.1 KiB, writesPerSecond:1.08, details:(diversity=0.00, preferred=0)\",\"RangeBytes\":204200,\"RangeWritesPerSecond\":321.0712073249542}"

to:
"Details":"{\"Target\":\"s4, converges:0, balance:1, rangeCount:10\"}"}

Down-replicate details go from:
"Details":"{\"Target\":\"s1, valid:true, constraint:0.00, converges:0, balance:-1.00(ranges=-1, bytes=0.00, writes=0.00), rangeCount:15, logicalBytes:257 MiB, writesPerSecond:1205.47, details:(diversity=0.00, preferred=0)\",\"RangeBytes\":33938441,\"RangeWritesPerSecond\":150.7858082120157}"

to:
"Details":"{\"Target\":\"s2, converges:1, balance:0, rangeCount:20\"}"

Rebalance details go from:
"Details":"{\"Target\":\"s6, valid:true, constraint:0.00, converges:1, balance:1.00(ranges=1, bytes=0.00, writes=0.00), rangeCount:12, logicalBytes:23 MiB, writesPerSecond:254.01, details:(diversity=0.00, preferred=0)\",\"Existing\":\"[\\ns5, valid:true, constraint:0.00, converges:0, balance:0.00(ranges=0, bytes=0.00, writes=0.00), rangeCount:15, logicalBytes:256 MiB, writesPerSecond:1207.65, details:(diversity=0.00, preferred=0)\\ns1, valid:true, constraint:0.00, converges:0, balance:-1.00(ranges=-1, bytes=0.00, writes=0.00), rangeCount:16, logicalBytes:280 MiB, writesPerSecond:1458.49, details:(diversity=0.00, preferred=0)\\ns2, valid:true, constraint:0.00, converges:0, balance:-1.00(ranges=-1, bytes=0.00, writes=0.00), rangeCount:16, logicalBytes:280 MiB, writesPerSecond:1459.74, details:(diversity=0.00, preferred=0)]\",\"RangeBytes\":33629514,\"RangeWritesPerSecond\":150.8107606862368}"

To:
"Details":"{\"Target\":\"s2, converges:1, balance:1, rangeCount:14\",\"Existing\":\"[\\ns4, converges:1, balance:1, rangeCount:13\\ns3, converges:1, balance:1, rangeCount:13\\ns1, converges:0, balance:-1, rangeCount:20]\"}"}

Touches #21260, but there's still more that can likely be shrunk down,
as described on the issue.

Release note (sql change): Reduce size of system.rangelog entries to
save disk space.