### PR TITLE
ui: add graphs for clock offset mean and stddev

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -121,5 +121,14 @@ export default function (props: GraphDashboardProps) {
         }
       </Axis>
     </LineGraph>,
+
+    <LineGraph title="Clock Offset" sources={nodeSources}
+    tooltip={`Mean and Standard deviation of the clock offset across the cluster`}>
+      <Axis label="offset" units={AxisUnits.Duration}>
+        <Metric name="cr.node.clock-offset.meannanos" title="Mean" />
+        <Metric name="cr.node.clock-offset.stddevnanos" title="Standard Deviation" />
+      </Axis>
+    </LineGraph>,
+
   ];
 }


### PR DESCRIPTION
This PR doesn't work. I'm obviously doing something wrong. I'll also point out that node heartbeat latency metrics on the "distributed" page are also not working.

Release note: None