### PR TITLE
sqlbase,encoding: a few small optimizations

### DIFF
--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -74,7 +74,7 @@ func (ed *EncDatum) String(typ *ColumnType) string {
 // value. The encoded value is stored as a shallow copy, so the caller must
 // make sure the slice is not modified for the lifetime of the EncDatum.
 // SetEncoded wipes the underlying Datum.
-func EncDatumFromEncoded(typ *ColumnType, enc DatumEncoding, encoded []byte) EncDatum {
+func EncDatumFromEncoded(enc DatumEncoding, encoded []byte) EncDatum {
 	if len(encoded) == 0 {
 		panic(fmt.Sprintf("empty encoded value"))
 	}
@@ -99,14 +99,14 @@ func EncDatumFromBuffer(typ *ColumnType, enc DatumEncoding, buf []byte) (EncDatu
 		if err != nil {
 			return EncDatum{}, nil, err
 		}
-		ed := EncDatumFromEncoded(typ, enc, buf[:encLen])
+		ed := EncDatumFromEncoded(enc, buf[:encLen])
 		return ed, buf[encLen:], nil
 	case DatumEncoding_VALUE:
 		typeOffset, encLen, err := encoding.PeekValueLength(buf)
 		if err != nil {
 			return EncDatum{}, nil, err
 		}
-		ed := EncDatumFromEncoded(typ, enc, buf[typeOffset:encLen])
+		ed := EncDatumFromEncoded(enc, buf[typeOffset:encLen])
 		return ed, buf[encLen:], nil
 	default:
 		panic(fmt.Sprintf("unknown encoding %s", enc))

--- a/pkg/sql/sqlbase/encoded_datum_test.go
+++ b/pkg/sql/sqlbase/encoded_datum_test.go
@@ -62,7 +62,7 @@ func TestEncDatum(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	y := EncDatumFromEncoded(&typeInt, DatumEncoding_ASCENDING_KEY, encoded)
+	y := EncDatumFromEncoded(DatumEncoding_ASCENDING_KEY, encoded)
 	check(y)
 
 	if enc, ok := y.Encoding(); !ok {
@@ -88,7 +88,7 @@ func TestEncDatum(t *testing.T) {
 	} else if enc != DatumEncoding_ASCENDING_KEY {
 		t.Errorf("invalid encoding %d", enc)
 	}
-	z := EncDatumFromEncoded(&typeInt, DatumEncoding_DESCENDING_KEY, enc2)
+	z := EncDatumFromEncoded(DatumEncoding_DESCENDING_KEY, enc2)
 	if enc, ok := z.Encoding(); !ok {
 		t.Error("no encoding")
 	} else if enc != DatumEncoding_DESCENDING_KEY {
@@ -139,7 +139,7 @@ func TestEncDatumNull(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			b := EncDatumFromEncoded(&typ, DatumEncoding(enc), encoded)
+			b := EncDatumFromEncoded(DatumEncoding(enc), encoded)
 			if a.IsNull() != b.IsNull() {
 				t.Errorf("before: %s (null=%t) after: %s (null=%t)",
 					a.String(&typeInt), a.IsNull(), b.String(&typeInt), b.IsNull())
@@ -169,9 +169,9 @@ func checkEncDatumCmp(
 	if err != nil {
 		t.Fatal(err)
 	}
-	dec1 := EncDatumFromEncoded(&typ, enc1, buf1)
+	dec1 := EncDatumFromEncoded(enc1, buf1)
 
-	dec2 := EncDatumFromEncoded(&typ, enc2, buf2)
+	dec2 := EncDatumFromEncoded(enc2, buf2)
 
 	evalCtx := tree.NewTestingEvalContext()
 	defer evalCtx.Stop(context.Background())

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1799,41 +1799,50 @@ func PeekValueLength(b []byte) (typeOffset int, length int, err error) {
 	if err != nil {
 		return 0, 0, err
 	}
+	length, err = PeekValueLengthWithOffsetsAndType(b, dataOffset, typ)
+	return typeOffset, length, err
+}
+
+// PeekValueLengthWithOffsetsAndType is the same as PeekValueLength, except it
+// expects a dataOffset and typ value from a previous call to DecodeValueTag
+// on its input byte slice. Use this if you've already called DecodeValueTag
+// on the input for another reason, to avoid it getting called twice.
+func PeekValueLengthWithOffsetsAndType(b []byte, dataOffset int, typ Type) (length int, err error) {
 	b = b[dataOffset:]
 	switch typ {
 	case Null:
-		return typeOffset, dataOffset, nil
+		return dataOffset, nil
 	case True, False:
-		return typeOffset, dataOffset, nil
+		return dataOffset, nil
 	case Int:
 		_, n, _, err := DecodeNonsortingStdlibVarint(b)
-		return typeOffset, dataOffset + n, err
+		return dataOffset + n, err
 	case Float:
-		return typeOffset, dataOffset + floatValueEncodedLength, nil
+		return dataOffset + floatValueEncodedLength, nil
 	case Bytes, Array, JSON:
 		_, n, i, err := DecodeNonsortingUvarint(b)
-		return typeOffset, dataOffset + n + int(i), err
+		return dataOffset + n + int(i), err
 	case Decimal:
 		_, n, i, err := DecodeNonsortingStdlibUvarint(b)
-		return typeOffset, dataOffset + n + int(i), err
+		return dataOffset + n + int(i), err
 	case Time:
 		n, err := getMultiNonsortingVarintLen(b, 2)
-		return typeOffset, dataOffset + n, err
+		return dataOffset + n, err
 	case Duration:
 		n, err := getMultiNonsortingVarintLen(b, 3)
-		return typeOffset, dataOffset + n, err
+		return dataOffset + n, err
 	case UUID:
-		return typeOffset, dataOffset + uuidValueEncodedLength, err
+		return dataOffset + uuidValueEncodedLength, err
 	case IPAddr:
 		family := ipaddr.IPFamily(b[0])
 		if family == ipaddr.IPv4family {
-			return typeOffset, dataOffset + ipaddr.IPv4size, err
+			return dataOffset + ipaddr.IPv4size, err
 		} else if family == ipaddr.IPv6family {
-			return typeOffset, dataOffset + ipaddr.IPv6size, err
+			return dataOffset + ipaddr.IPv6size, err
 		}
-		return 0, 0, errors.Errorf("got invalid INET IP family: %d", family)
+		return 0, errors.Errorf("got invalid INET IP family: %d", family)
 	default:
-		return 0, 0, errors.Errorf("unknown type %s", typ)
+		return 0, errors.Errorf("unknown type %s", typ)
 	}
 }
 

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1320,11 +1320,11 @@ func EncodeNonsortingUvarint(appendTo []byte, x uint64) []byte {
 func DecodeNonsortingUvarint(buf []byte) (remaining []byte, length int, value uint64, err error) {
 	// TODO(dan): Handle overflow.
 	for i, b := range buf {
-		value <<= 7
 		value += uint64(b & 0x7f)
 		if b < 0x80 {
 			return buf[i+1:], i + 1, value, nil
 		}
+		value <<= 7
 	}
 	return buf, 0, 0, nil
 }

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1547,6 +1547,22 @@ func BenchmarkDecodeNonsortingUvarint(b *testing.B) {
 	}
 }
 
+func BenchmarkDecodeOneByteNonsortingUvarint(b *testing.B) {
+	buf := make([]byte, 0, b.N*NonsortingUvarintMaxLen)
+	rng, _ := randutil.NewPseudoRand()
+	for i := 0; i < b.N; i++ {
+		buf = EncodeNonsortingUvarint(buf, uint64(rng.Int63()%(1<<7)))
+	}
+	var err error
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf, _, _, err = DecodeNonsortingUvarint(buf)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func BenchmarkPeekLengthNonsortingUvarint(b *testing.B) {
 	buf := make([]byte, 0, b.N*NonsortingUvarintMaxLen)
 	rng, _ := randutil.NewPseudoRand()


### PR DESCRIPTION
A few small optimizations in sqlbase and encoding that I noticed when profiling TPCC.

- Make 1-byte uvarint decodes a little quicker by skipping a pointless bitshift
- Don't decode value tags twice during row decode