### PR TITLE
build: only require a minimum version of Go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,16 +261,14 @@ $(call make-lazy,yellow)
 $(call make-lazy,cyan)
 $(call make-lazy,term-reset)
 
-# We used to check the Go version in a .PHONY .go-version target, but the error
-# message, if any, would get mixed in with noise from other targets if Make was
-# executed in parallel job mode. This check, by contrast, is guaranteed to print
-# its error message before any noisy output.
-#
-# Note that word boundary markers (\b, \<, [[:<:]]) are not portable, but `grep
-# -w`, though not required by POSIX, exists on all tested platforms.
-GOVERS := go1\.9.*
-ifeq ($(shell $(GO) version | grep -qwE '$(GOVERS)' && echo y),)
-$(error "$(GOVERS) required (see CONTRIBUTING.md): $(shell $(GO) version); use `make GOVERS=.*` for experiments")
+# We used to check the Go version in a .PHONY target, but the error message, if
+# any, would get mixed in with noise from other targets when Make was executed
+# in parallel job mode. This check, by contrast, is guaranteed to print its
+# error message before any noisy output.
+IGNORE_GOVERS :=
+go-version-check := $(if $(IGNORE_GOVERS),,$(shell build/go-version-check.sh $(GO)))
+ifneq "$(go-version-check)" ""
+$(error $(go-version-check). Disable this check with IGNORE_GOVERS=1)
 endif
 
 # Print an error if the user specified any variables on the command line that

--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Detect whether the installed version of Go can build this version of
+# CockroachDB.
+#
+# To bump the required version of Go, edit the last conditional appropriately.
+#
+# Note: this script is invoked by Make, so it has odd error reporting semantics.
+# Errors are printed to stdout; the Go version is compatible iff nothing is
+# printed to stdout. The exit code is meaningless.
+
+# Ensure stray error messages are printed to stdout, or they'll go unnoticed by
+# Make.
+exec 2>&1
+
+go=${1-go}
+
+if ! raw_version=$("$go" version 2>&1); then
+  echo "unable to detect go version: $raw_version"
+  exit
+fi
+
+if ! version=$(grep -oE "[0-9]+\.[0-9]+" <<< "$raw_version"); then
+  echo "unable to parse go version '$raw_version'"
+  exit
+fi
+
+version_major=$(cut -f1 -d. <<< "$version")
+version_minor=$(cut -f2 -d. <<< "$version")
+if (( version_major != 1 )) || (( version_minor < 9 )); then
+  echo "go1.9+ required (detected go$version)"
+  exit
+fi

--- a/build/variables.mk
+++ b/build/variables.mk
@@ -56,7 +56,6 @@ define VALID_VARS
   GOGO_PROTOBUF_PATH
   GOPATH
   GORACE
-  GOVERS
   GO_INSTALL
   GO_PROTOS
   GO_PROTOS_TARGET
@@ -69,6 +68,7 @@ define VALID_VARS
   GW_SOURCES
   GW_TS_PROTOS
   HOST_TRIPLE
+  IGNORE_GOVERS
   INSTALL
   ISDARWIN
   JEMALLOC_DIR
@@ -146,6 +146,7 @@ define VALID_VARS
   YARN_INSTALLED_TARGET
   bindir
   cyan
+  go-version-check
   prefix
   space
   term-reset


### PR DESCRIPTION
Instead of requiring a specific version (or versions) of Go, enforce a
minimum version of Go. This means we'll no longer need to adjust the
rule whenever a new version of Go comes out.

This means it's now possible to build CockroachDB with a Go 1.10 beta
without explicitly disabling the version check.

Fix #19431.

Release note (build change): The build system now enforces a minimum
version of Go, rather than enforcing a specific version of Go. Since the
Go 1.x series has strict backwards compatibility guarantees, the old
rule was unnecessarily restrictive.