### PR TITLE
sql: make sure planner.autocommit gets reset

### DIFF
--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -578,6 +578,7 @@ func (s *Session) resetPlanner(p *planner, e *Executor, txn *client.Txn) {
 
 	p.sessionDataMutator = s.dataMutator
 	p.preparedStatements = &s.PreparedStatements
+	p.autoCommit = false
 
 	p.setTxn(txn)
 }


### PR DESCRIPTION
The method in charge of resetting planners in between statements was not
resetting this field. I think it was inconsequential since we were
always explicitly setting planner.autocommit afterwards, but not doing
the safe thing when resetting is... dangerous.

Release note: None