### PR TITLE
storage: fix StoreList.filter to validate constraints properly

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -291,15 +291,6 @@ func (sc StoreCapacity) FractionUsed() float64 {
 	return float64(sc.Used) / float64(sc.Available+sc.Used)
 }
 
-// CombinedAttrs returns the full list of attributes for the store, including
-// both the node and store attributes.
-func (s StoreDescriptor) CombinedAttrs() *Attributes {
-	var a []string
-	a = append(a, s.Node.Attrs.Attrs...)
-	a = append(a, s.Attrs.Attrs...)
-	return &Attributes{Attrs: a}
-}
-
 // String returns a string representation of the Tier.
 func (t Tier) String() string {
 	return fmt.Sprintf("%s=%s", t.Key, t.Value)

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -528,20 +528,11 @@ func (sl StoreList) filter(constraints config.Constraints) StoreList {
 		return sl
 	}
 	var filteredDescs []roachpb.StoreDescriptor
-storeLoop:
 	for _, store := range sl.stores {
-		m := map[string]struct{}{}
-		for _, s := range store.CombinedAttrs().Attrs {
-			m[s] = struct{}{}
+		if ok, _ := constraintCheck(store, constraints); ok {
+			filteredDescs = append(filteredDescs, store)
 		}
-		for _, c := range constraints.Constraints {
-			if _, ok := m[c.Value]; !ok {
-				continue storeLoop
-			}
-		}
-		filteredDescs = append(filteredDescs, store)
 	}
-
 	return makeStoreList(filteredDescs)
 }
 

--- a/pkg/storage/store_pool_test.go
+++ b/pkg/storage/store_pool_test.go
@@ -17,11 +17,13 @@ package storage
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"sort"
 	"testing"
 	"time"
 
+	"github.com/kr/pretty"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -179,7 +181,12 @@ func TestStorePoolGetStoreList(t *testing.T) {
 		TestTimeUntilStoreDead, false /* deterministic */, NodeLivenessStatus_DEAD)
 	defer stopper.Stop(context.TODO())
 	sg := gossiputil.NewStoreGossiper(g)
-	constraints := config.Constraints{Constraints: []config.Constraint{{Value: "ssd"}, {Value: "dc"}}}
+	constraints := config.Constraints{
+		Constraints: []config.Constraint{
+			{Type: config.Constraint_REQUIRED, Value: "ssd"},
+			{Type: config.Constraint_REQUIRED, Value: "dc"},
+		},
+	}
 	required := []string{"ssd", "dc"}
 	// Nothing yet.
 	sl, _, _ := sp.getStoreList(roachpb.RangeID(0), storeFilterNone)
@@ -319,6 +326,98 @@ func TestStorePoolGetStoreList(t *testing.T) {
 		/* expectedThrottledStoreCount */ 1,
 	); err != nil {
 		t.Error(err)
+	}
+}
+
+// TestStoreListFilter ensures that the store list constraint filtering works
+// properly.
+func TestStoreListFilter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	constraints := config.Constraints{
+		Constraints: []config.Constraint{
+			{Type: config.Constraint_REQUIRED, Key: "region", Value: "us-west"},
+			{Type: config.Constraint_REQUIRED, Value: "MustMatch"},
+			{Type: config.Constraint_POSITIVE, Value: "MatchingOptional"},
+			{Type: config.Constraint_PROHIBITED, Value: "MustNotMatch"},
+		},
+	}
+
+	stores := []struct {
+		attributes []string
+		locality   []roachpb.Tier
+		expected   bool
+	}{
+		{
+			expected: false,
+		},
+		{
+			attributes: []string{"MustMatch"},
+			expected:   false,
+		},
+		{
+			locality: []roachpb.Tier{{Key: "region", Value: "us-west"}},
+			expected: false,
+		},
+		{
+			attributes: []string{"MustMatch"},
+			locality:   []roachpb.Tier{{Key: "region", Value: "us-west"}},
+			expected:   true,
+		},
+		{
+			attributes: []string{"a", "MustMatch"},
+			locality:   []roachpb.Tier{{Key: "a", Value: "b"}, {Key: "region", Value: "us-west"}},
+			expected:   true,
+		},
+		{
+			attributes: []string{"a", "b", "MustMatch", "c"},
+			locality:   []roachpb.Tier{{Key: "region", Value: "us-west"}, {Key: "c", Value: "d"}},
+			expected:   true,
+		},
+		{
+			attributes: []string{"MustMatch", "MustNotMatch"},
+			locality:   []roachpb.Tier{{Key: "region", Value: "us-west"}},
+			expected:   false,
+		},
+		{
+			attributes: []string{"MustMatch"},
+			locality:   []roachpb.Tier{{Key: "region", Value: "us-west"}, {Key: "MustNotMatch", Value: "b"}},
+			expected:   true,
+		},
+		{
+			attributes: []string{"MustMatch"},
+			locality:   []roachpb.Tier{{Key: "region", Value: "us-west"}, {Key: "a", Value: "MustNotMatch"}},
+			expected:   true,
+		},
+	}
+
+	var sl StoreList
+	var expected []roachpb.StoreDescriptor
+	for i, s := range stores {
+		storeDesc := roachpb.StoreDescriptor{
+			StoreID: roachpb.StoreID(i + 1),
+			Node: roachpb.NodeDescriptor{
+				Locality: roachpb.Locality{
+					Tiers: s.locality,
+				},
+			},
+		}
+		// Randomly stick the attributes in either the node or the store to get
+		// code coverage of both locations.
+		if rand.Intn(2) == 0 {
+			storeDesc.Attrs.Attrs = s.attributes
+		} else {
+			storeDesc.Node.Attrs.Attrs = s.attributes
+		}
+		sl.stores = append(sl.stores, storeDesc)
+		if s.expected {
+			expected = append(expected, storeDesc)
+		}
+	}
+
+	filtered := sl.filter(constraints)
+	if !reflect.DeepEqual(expected, filtered.stores) {
+		t.Errorf("did not get expected stores %s", pretty.Diff(expected, filtered.stores))
 	}
 }
 


### PR DESCRIPTION
It was preposterously broken. It was only validating values, not
keys (when present); was requiring positive constraints; and, worst of
all, was requiring prohibited constraints instead of prohibiting them.

Luckily it was only used by TransferLeaseTarget and ShouldTransferLease,
so its damage was contained -- we wouldn't ever put a replica on a node
that we shouldn't, we'd just never choose to transfer the lease for an
affected range. The relative lack of use of positive and prohibited
constraints also helped us from ever seeing this in the wild.

Release note (bug fix): Fix incorrect logic in lease rebalancing that
prevented leases from being transferred

I think this would be a reasonable candidate for inclusion if we end up doing any more v1.1 patch releases.