### PR TITLE
libroach: optimize MVCC reverse scans

### DIFF
--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -2314,7 +2314,7 @@ func TestMVCCReverseScan(t *testing.T) {
 		!bytes.Equal(kvs[1].Key, testKey2) ||
 		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) ||
 		!bytes.Equal(kvs[1].Value.RawBytes, value3.RawBytes) {
-		t.Errorf("unexpected value: %v", kvs)
+		t.Fatalf("unexpected value: %v", kvs)
 	}
 	if resumeSpan != nil {
 		t.Fatalf("resumeSpan = %+v", resumeSpan)
@@ -2328,7 +2328,7 @@ func TestMVCCReverseScan(t *testing.T) {
 	if len(kvs) != 1 ||
 		!bytes.Equal(kvs[0].Key, testKey3) ||
 		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
-		t.Errorf("unexpected value: %v", kvs)
+		t.Fatalf("unexpected value: %v", kvs)
 	}
 	if expected := (roachpb.Span{Key: testKey2, EndKey: testKey2.Next()}); !resumeSpan.EqualValue(expected) {
 		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
@@ -2340,7 +2340,7 @@ func TestMVCCReverseScan(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(kvs) != 0 {
-		t.Errorf("unexpected value: %v", kvs)
+		t.Fatalf("unexpected value: %v", kvs)
 	}
 	if expected := (roachpb.Span{Key: testKey2, EndKey: testKey4}); !resumeSpan.EqualValue(expected) {
 		t.Fatalf("expected = %+v, resumeSpan = %+v", expected, resumeSpan)
@@ -2369,7 +2369,19 @@ func TestMVCCReverseScan(t *testing.T) {
 	if len(kvs) != 1 ||
 		!bytes.Equal(kvs[0].Key, testKey4) ||
 		!bytes.Equal(kvs[0].Value.RawBytes, value2.RawBytes) {
-		t.Errorf("unexpected value: %v", kvs)
+		t.Fatalf("unexpected value: %v", kvs)
+	}
+
+	// Scan only the first key in the key space.
+	kvs, _, _, err = MVCCReverseScan(context.Background(), engine,
+		testKey1, testKey1.Next(), 1, hlc.Timestamp{WallTime: 1}, true, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(kvs) != 1 ||
+		!bytes.Equal(kvs[0].Key, testKey1) ||
+		!bytes.Equal(kvs[0].Value.RawBytes, value1.RawBytes) {
+		t.Fatalf("unexpected value: %v", kvs)
 	}
 }
 


### PR DESCRIPTION
The previous reverse scan code was performing a seek between every
key. This is very slow. The new code maintains a one element buffer
allowing it to "peek" at the previous key.

```
name                                                          old time/op    new time/op     delta
MVCCReverseScan_RocksDB/rows=1/versions=1/valueSize=8-8         10.9µs ± 9%      7.4µs ± 2%   -32.01%  (p=0.000 n=10+10)
MVCCReverseScan_RocksDB/rows=1/versions=2/valueSize=8-8         10.8µs ± 2%      8.1µs ± 2%   -24.74%  (p=0.000 n=10+10)
MVCCReverseScan_RocksDB/rows=1/versions=10/valueSize=8-8        11.7µs ± 3%     10.5µs ± 2%   -10.02%  (p=0.000 n=10+10)
MVCCReverseScan_RocksDB/rows=1/versions=100/valueSize=8-8       14.7µs ± 1%     17.5µs ± 3%   +19.32%  (p=0.000 n=8+9)
MVCCReverseScan_RocksDB/rows=10/versions=1/valueSize=8-8        27.4µs ± 2%     11.6µs ± 3%   -57.71%  (p=0.000 n=10+10)
MVCCReverseScan_RocksDB/rows=10/versions=2/valueSize=8-8        28.6µs ± 2%     15.9µs ± 2%   -44.30%  (p=0.000 n=9+9)
MVCCReverseScan_RocksDB/rows=10/versions=10/valueSize=8-8       33.7µs ± 2%     32.3µs ± 2%    -4.07%  (p=0.000 n=10+10)
MVCCReverseScan_RocksDB/rows=10/versions=100/valueSize=8-8      57.0µs ± 2%     72.9µs ± 2%   +27.91%  (p=0.000 n=10+10)
MVCCReverseScan_RocksDB/rows=100/versions=1/valueSize=8-8        187µs ± 4%       44µs ± 1%   -76.23%  (p=0.000 n=10+9)
MVCCReverseScan_RocksDB/rows=100/versions=2/valueSize=8-8        192µs ± 4%       84µs ± 1%   -56.50%  (p=0.000 n=10+10)
MVCCReverseScan_RocksDB/rows=100/versions=10/valueSize=8-8       237µs ± 1%      233µs ± 2%    -1.53%  (p=0.000 n=9+10)
MVCCReverseScan_RocksDB/rows=100/versions=100/valueSize=8-8      457µs ± 3%      606µs ± 1%   +32.56%  (p=0.000 n=10+10)
MVCCReverseScan_RocksDB/rows=1000/versions=1/valueSize=8-8      1.75ms ± 3%     0.36ms ± 2%   -79.50%  (p=0.000 n=10+10)
MVCCReverseScan_RocksDB/rows=1000/versions=2/valueSize=8-8      1.79ms ± 2%     0.73ms ± 1%   -59.11%  (p=0.000 n=10+9)
MVCCReverseScan_RocksDB/rows=1000/versions=10/valueSize=8-8     2.31ms ± 7%     2.23ms ± 2%    -3.27%  (p=0.035 n=10+10)
MVCCReverseScan_RocksDB/rows=1000/versions=100/valueSize=8-8    4.58ms ± 6%     5.92ms ± 5%   +29.39%  (p=0.000 n=9+10)
```

Release note (performance improvement): Improve low-level reverse scan
throughput by up almost 4x when there are a few versions per key.