### PR TITLE
sqlbase: a few more optimizations on the fetch path

### DIFF
--- a/pkg/sql/distsqlrun/disk_row_container.go
+++ b/pkg/sql/distsqlrun/disk_row_container.go
@@ -182,14 +182,14 @@ func (d *diskRowContainer) keyValToRow(k []byte, v []byte) (sqlbase.EncDatumRow,
 		}
 		var err error
 		col := orderInfo.ColIdx
-		d.scratchEncRow[col], k, err = sqlbase.EncDatumFromBuffer(&d.types[col], d.encodings[i], k)
+		d.scratchEncRow[col], k, err = sqlbase.EncDatumFromBuffer(d.encodings[i], k)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to decode row")
 		}
 	}
 	for _, i := range d.valueIdxs {
 		var err error
-		d.scratchEncRow[i], v, err = sqlbase.EncDatumFromBuffer(&d.types[i], sqlbase.DatumEncoding_VALUE, v)
+		d.scratchEncRow[i], v, err = sqlbase.EncDatumFromBuffer(sqlbase.DatumEncoding_VALUE, v)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to decode row")
 		}

--- a/pkg/sql/distsqlrun/sample_aggregator_test.go
+++ b/pkg/sql/distsqlrun/sample_aggregator_test.go
@@ -217,7 +217,7 @@ func TestSampleAggregator(t *testing.T) {
 
 			for _, b := range h.Buckets {
 				ed, _, err := sqlbase.EncDatumFromBuffer(
-					&intType, sqlbase.DatumEncoding_ASCENDING_KEY, b.UpperBound,
+					sqlbase.DatumEncoding_ASCENDING_KEY, b.UpperBound,
 				)
 				if err != nil {
 					t.Fatal(err)

--- a/pkg/sql/distsqlrun/stream_decoder.go
+++ b/pkg/sql/distsqlrun/stream_decoder.go
@@ -155,9 +155,7 @@ func (sd *StreamDecoder) GetRow(
 	}
 	for i := range rowBuf {
 		var err error
-		rowBuf[i], sd.data, err = sqlbase.EncDatumFromBuffer(
-			&sd.typing[i].Type, sd.typing[i].Encoding, sd.data,
-		)
+		rowBuf[i], sd.data, err = sqlbase.EncDatumFromBuffer(sd.typing[i].Encoding, sd.data)
 		if err != nil {
 			// Reset sd because it is no longer usable.
 			*sd = StreamDecoder{}

--- a/pkg/sql/show_histogram.go
+++ b/pkg/sql/show_histogram.go
@@ -101,9 +101,7 @@ func (p *planner) ShowHistogram(ctx context.Context, n *tree.ShowHistogram) (pla
 
 			v := p.newContainerValuesNode(showHistogramColumns, 0)
 			for _, b := range histogram.Buckets {
-				ed, _, err := sqlbase.EncDatumFromBuffer(
-					&colDesc.Type, sqlbase.DatumEncoding_ASCENDING_KEY, b.UpperBound,
-				)
+				ed, _, err := sqlbase.EncDatumFromBuffer(sqlbase.DatumEncoding_ASCENDING_KEY, b.UpperBound)
 				if err != nil {
 					v.Close(ctx)
 					return nil, err

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -89,7 +89,7 @@ func EncDatumFromEncoded(enc DatumEncoding, encoded []byte) EncDatum {
 // possibly followed by other data. Similar to EncDatumFromEncoded,
 // except that this function figures out where the encoding stops and returns a
 // slice for the rest of the buffer.
-func EncDatumFromBuffer(typ *ColumnType, enc DatumEncoding, buf []byte) (EncDatum, []byte, error) {
+func EncDatumFromBuffer(enc DatumEncoding, buf []byte) (EncDatum, []byte, error) {
 	if len(buf) == 0 {
 		return EncDatum{}, nil, errors.New("empty encoded value")
 	}

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -113,6 +113,22 @@ func EncDatumFromBuffer(enc DatumEncoding, buf []byte) (EncDatum, []byte, error)
 	}
 }
 
+// EncDatumValueFromBufferWithOffsetsAndType is just like calling
+// EncDatumFromBuffer with DatumEncoding_VALUE, except it expects that you pass
+// in the result of calling DecodeValueTag on the input buf. Use this if you've
+// already called DecodeValueTag on buf already, to avoid it getting called
+// more than necessary.
+func EncDatumValueFromBufferWithOffsetsAndType(
+	buf []byte, typeOffset int, dataOffset int, typ encoding.Type,
+) (EncDatum, []byte, error) {
+	encLen, err := encoding.PeekValueLengthWithOffsetsAndType(buf, dataOffset, typ)
+	if err != nil {
+		return EncDatum{}, nil, err
+	}
+	ed := EncDatumFromEncoded(DatumEncoding_VALUE, buf[typeOffset:encLen])
+	return ed, buf[encLen:], nil
+}
+
 // DatumToEncDatum initializes an EncDatum with the given Datum.
 func DatumToEncDatum(ctyp ColumnType, d tree.Datum) EncDatum {
 	if d == nil {

--- a/pkg/sql/sqlbase/encoded_datum_test.go
+++ b/pkg/sql/sqlbase/encoded_datum_test.go
@@ -302,7 +302,7 @@ func TestEncDatumFromBuffer(t *testing.T) {
 				t.Fatal("buffer ended early")
 			}
 			var decoded EncDatum
-			decoded, b, err = EncDatumFromBuffer(&types[i], enc[i], b)
+			decoded, b, err = EncDatumFromBuffer(enc[i], b)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sqlbase/multirowfetcher.go
+++ b/pkg/sql/sqlbase/multirowfetcher.go
@@ -772,8 +772,7 @@ func (mrf *MultiRowFetcher) processValueBytes(
 		}
 
 		var encValue EncDatum
-		encValue, valueBytes, err =
-			EncDatumFromBuffer(&table.cols[idx].Type, DatumEncoding_VALUE, valueBytes)
+		encValue, valueBytes, err = EncDatumFromBuffer(DatumEncoding_VALUE, valueBytes)
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/sql/sqlbase/multirowfetcher.go
+++ b/pkg/sql/sqlbase/multirowfetcher.go
@@ -744,10 +744,10 @@ func (mrf *MultiRowFetcher) processValueBytes(
 
 	var colIDDiff uint32
 	var lastColID ColumnID
-	var dataOffset int
+	var typeOffset, dataOffset int
 	var typ encoding.Type
 	for len(valueBytes) > 0 {
-		_, dataOffset, colIDDiff, typ, err = encoding.DecodeValueTag(valueBytes)
+		typeOffset, dataOffset, colIDDiff, typ, err = encoding.DecodeValueTag(valueBytes)
 		if err != nil {
 			return "", "", err
 		}
@@ -772,7 +772,7 @@ func (mrf *MultiRowFetcher) processValueBytes(
 		}
 
 		var encValue EncDatum
-		encValue, valueBytes, err = EncDatumFromBuffer(DatumEncoding_VALUE, valueBytes)
+		encValue, valueBytes, err = EncDatumValueFromBufferWithOffsetsAndType(valueBytes, typeOffset, dataOffset, typ)
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -839,7 +839,7 @@ func DecodeKeyVals(
 			enc = DatumEncoding_DESCENDING_KEY
 		}
 		var err error
-		vals[j], key, err = EncDatumFromBuffer(&types[j], enc, key)
+		vals[j], key, err = EncDatumFromBuffer(enc, key)
 		if err != nil {
 			return nil, err
 		}

--- a/scripts/bench
+++ b/scripts/bench
@@ -16,6 +16,6 @@ echo "Writing to ${dest}"
 
 for branch in "${2}" "${1}"; do
   git checkout "${branch}"
-  (set -x; make bench PKG="${PKG}" BENCHTIMEOUT="${BENCHTIMEOUT}" BENCHES="${BENCHES}" TESTFLAGS="-count 10 -benchmem" > "${dest}/bench.${branch}" 2> "${dest}/log.txt")
+  (set -x; make bench PKG="${PKG}" BENCHTIMEOUT="${BENCHTIMEOUT:-5m}" BENCHES="${BENCHES}" TESTFLAGS="-count 10 -benchmem" > "${dest}/bench.${branch}" 2> "${dest}/log.txt")
 done
 benchstat "${dest}/bench.$1" "${dest}/bench.$2"


### PR DESCRIPTION
- Add a sql benchmark for COUNT(*)
- Remove an unused parameter from EncDatumFromBuffer
- Remove another duplicate call to DecodeValueTag for column value decoding

Surprisingly, removing the unused parameter moves the dial on COUNT(*) by almost 5 percent:

```
name                 old time/op    new time/op  delta
Count/Cockroach-8    55.7ms ± 5%    53.4ms ± 1%  -4.03%  (p=0.010 n=9+10)
```