### PR TITLE
[WIP] sql: define a first version of plan rewinding

### DIFF
--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -62,6 +62,11 @@ type alterUserSetPasswordRun struct {
 	rowsAffected int
 }
 
+func (n *alterUserSetPasswordNode) rewindExec(params runParams) error {
+	n.run.rowsAffected = 0
+	return nil
+}
+
 func (n *alterUserSetPasswordNode) startExec(params runParams) error {
 	normalizedUsername, hashedPassword, err := n.userAuthInfo.resolve()
 	if err != nil {

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -197,6 +197,11 @@ type distinctRun struct {
 	suffixMemAcc mon.BoundAccount
 }
 
+func (n *distinctNode) rewindExec(params runParams) error {
+	n.run.prefixSeen = nil
+	return nil
+}
+
 func (n *distinctNode) startExec(params runParams) error {
 	n.run.prefixMemAcc = params.EvalContext().Mon.MakeBoundAccount()
 	n.run.suffixMemAcc = params.EvalContext().Mon.MakeBoundAccount()

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -74,6 +74,11 @@ type dropUserRun struct {
 	numDeleted int
 }
 
+func (n *DropUserNode) rewindExec(params runParams) error {
+	n.run.numDeleted = 0
+	return nil
+}
+
 func (n *DropUserNode) startExec(params runParams) error {
 	var entryType string
 	if n.isRole {

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -42,6 +42,11 @@ type explainDistSQLRun struct {
 	done bool
 }
 
+func (n *explainDistSQLNode) rewindExec(params runParams) error {
+	n.run.done = false
+	return nil
+}
+
 func (n *explainDistSQLNode) startExec(params runParams) error {
 	// Trigger limit propagation.
 	params.p.setUnlimited(n.plan)

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -135,23 +135,31 @@ func (p *planner) makeExplainPlanNodeWithPlan(
 
 // explainPlanRun is the run-time state of explainPlanNode during local execution.
 type explainPlanRun struct {
+	// subqueriesAlreadyOptimized indicates whether the sub-plans
+	// have already been processed by startExec. Needed to
+	// make the plan rewindable.
+	subqueriesAlreadyOptimized bool
+
 	// results is the container for EXPLAIN's output.
 	results *valuesNode
 }
 
 func (e *explainPlanNode) startExec(params runParams) error {
-	// The sub-plan's subqueries have been captured local to the EXPLAIN
-	// node so that they would not be automatically started for
-	// execution by planTop.start(). But this also means they were not
-	// yet processed by makePlan()/optimizePlan(). Do it here.
-	for i := range e.subqueryPlans {
-		if err := params.p.optimizeSubquery(params.ctx, &e.subqueryPlans[i]); err != nil {
-			return err
-		}
+	if !e.run.subqueriesAlreadyOptimized {
+		// The sub-plan's subqueries have been captured local to the EXPLAIN
+		// node so that they would not be automatically started for
+		// execution by planTop.start(). But this also means they were not
+		// yet processed by makePlan()/optimizePlan(). Do it here.
+		for i := range e.subqueryPlans {
+			if err := params.p.optimizeSubquery(params.ctx, &e.subqueryPlans[i]); err != nil {
+				return err
+			}
 
-		// Trigger limit propagation. This would be done otherwise when
-		// starting the plan. However we do not want to start the plan.
-		params.p.setUnlimited(e.subqueryPlans[i].plan)
+			// Trigger limit propagation. This would be done otherwise when
+			// starting the plan. However we do not want to start the plan.
+			params.p.setUnlimited(e.subqueryPlans[i].plan)
+		}
+		e.run.subqueriesAlreadyOptimized = true
 	}
 
 	return params.p.populateExplain(params.ctx, &e.explainer, e.run.results, e.plan, e.subqueryPlans)

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -804,3 +804,24 @@ func (a *aggregateFuncHolder) add(
 
 	return impl.Add(ctx, d)
 }
+
+func (n *groupNode) rewindExec(params runParams) error {
+	n.run.populated = false
+	n.run.values = nil
+	n.run.gotOneRow = false
+	// TODO(peter): This memory isn't being accounted for.
+	// See similar code in the constructor.
+	n.run.buckets = make(map[string]struct{})
+
+	for _, f := range n.funcs {
+		if f.run.seen != nil {
+			// The function had the DISTINCT modifier. Reset that.
+			f.run.seen = make(map[string]struct{})
+		}
+		f.run.buckets = make(map[string]tree.AggregateFunc)
+		f.run.bucketsMemAcc.Close(params.ctx)
+		f.run.bucketsMemAcc = params.p.EvalContext().Mon.MakeBoundAccount()
+	}
+
+	return nil
+}

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -93,6 +93,11 @@ type ordinalityRun struct {
 	curCnt int64
 }
 
+func (o *ordinalityNode) rewindExec(params runParams) error {
+	o.run.curCnt = 0
+	return nil
+}
+
 func (o *ordinalityNode) Next(params runParams) (bool, error) {
 	hasNext, err := o.source.Next(params)
 	if !hasNext || err != nil {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -53,6 +53,9 @@ type planMaker interface {
 	// iterating using curPlan.plan.Next() and curPlan.plan.Values() in
 	// order to retrieve matching rows. Finally, the plan must be closed
 	// with curPlan.close().
+	//
+	// A plan for each isRewindable() is true can also be reused without
+	// curPlan.close() by calling curPlan.restart().
 	makePlan(ctx context.Context, stmt Statement) error
 
 	// prepare does the same checks as makePlan but skips building some
@@ -356,6 +359,16 @@ func (p *planTop) start(params runParams) error {
 	return startPlan(params, p.plan)
 }
 
+// restart restarts the plan.
+// The caller must ensure that isRewindable is true beforehand.
+func (p *planTop) restart(params runParams) error {
+	if len(p.subqueryPlans) > 0 {
+		return pgerror.NewErrorf(pgerror.CodeInternalError,
+			"programming error: subquery rewind is not supported yet")
+	}
+	return restartPlan(params, p.plan)
+}
+
 // columns retrieves the plan's columns.
 func (p *planTop) columns() sqlbase.ResultColumns {
 	return planColumns(p.plan)
@@ -364,7 +377,7 @@ func (p *planTop) columns() sqlbase.ResultColumns {
 // startPlan starts the given plan and all its sub-query nodes.
 func startPlan(params runParams, plan planNode) error {
 	// Now start execution.
-	if err := startExec(params, plan); err != nil {
+	if err := startExec(params, plan, false); err != nil {
 		return err
 	}
 
@@ -373,6 +386,12 @@ func startPlan(params runParams, plan planNode) error {
 	params.p.setUnlimited(plan)
 
 	return nil
+}
+
+// restartPlan restarts the given plan and all its sub-query nodes.
+// The caller must ensure that isRewindable() is true on the plan.
+func restartPlan(params runParams, plan planNode) error {
+	return startExec(params, plan, true)
 }
 
 // execStartable is implemented by planNodes that have an initial
@@ -397,13 +416,21 @@ type autoCommitNode interface {
 	enableAutoCommit()
 }
 
+// planNodeRequiresExplicitRewind is to be implemented by planNode
+// that need an explicit method call to be properly rewinded.
+// The rewindExec() method is called just before startExec(), but
+// after the children, if any, have been rewound/restarted already.
+type planNodeRequiresExplicitRewind interface {
+	rewindExec(params runParams) error
+}
+
 // startExec calls startExec() on each planNode that supports
 // execStartable using a depth-first, post-order traversal.
 // The subqueries, if any, are also started.
 //
 // Reminder: walkPlan() ensures that subqueries and sub-plans are
 // started before startExec() is called.
-func startExec(params runParams, plan planNode) error {
+func startExec(params runParams, plan planNode, rewind bool) error {
 	o := planObserver{
 		enterNode: func(ctx context.Context, _ string, p planNode) (bool, error) {
 			switch p.(type) {
@@ -419,6 +446,13 @@ func startExec(params runParams, plan planNode) error {
 			return true, nil
 		},
 		leaveNode: func(_ string, n planNode) error {
+			if rewind {
+				if r, ok := n.(planNodeRequiresExplicitRewind); ok {
+					if err := r.rewindExec(params); err != nil {
+						return err
+					}
+				}
+			}
 			if s, ok := n.(execStartable); ok {
 				return s.startExec(params)
 			}

--- a/pkg/sql/rewind.go
+++ b/pkg/sql/rewind.go
@@ -1,0 +1,153 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// isRewindable returns true iff the plan can be re-used for multiple
+// executions, by calling startExec/Next/Values multiple times without
+// intervening Close and re-planning. If it returns true, the
+// startExec() call after the first must have the rewind parameter set
+// to true.
+//
+// To determine this, this function checks the planNodeNotRewindable
+// interface predicate on all planNodes in the tree. If any are found,
+// the plan is considered not rewindable.
+func isRewindable(ctx context.Context, plan planNode) (bool, error) {
+	o := planObserver{
+		enterNode: func(_ context.Context, _ string, p planNode) (bool, error) {
+			if _, ok := p.(planNodeNotRewindable); ok {
+				return false, errNotRewindableMarker
+			}
+			return true, nil
+		},
+	}
+	if err := walkPlan(ctx, plan, o); err != nil {
+		if err == errNotRewindableMarker {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// planNodeNotRewindable is to be implemented by those specific
+// planNodes that cannot be rewinded and reused for multiple
+// execution. The list is defined below.
+type planNodeNotRewindable interface {
+	cannotRewind()
+}
+
+var errNotRewindableMarker = errors.New("not rewindable")
+
+// alterIndexNode is rewindable. Note: holds descriptors.
+// alterTableNode is rewindable. Note: holds descriptors.
+// alterSequenceNode is rewindable. Note: holds descriptors.
+
+// alterUserSetPasswordNode is rewindable.
+// FIXME(knz/jordan): check that the name resolution closure is robust wrt reuses.
+
+// cancelQueryNode is rewindable.
+// controlJobNode is rewindable.
+
+func (*copyNode) cannotRewind() {}
+
+// createDatabaseNode is rewindable.
+
+// createIndexNode is rewindable. Note: holds descriptors.
+// createTableNode is rewindable. Note: holds descriptors.
+// CreateUserNode is rewindable. Note: holds descriptors.
+// createViewNode is rewindable. Note: holds descriptors.
+// createSequenceNode is rewindable. Note: holds descriptors.
+// createStatsNode is rewindable. Note: holds descriptors.
+
+// delayedNode is rewindable.
+
+func (*deleteNode) cannotRewind() {}
+
+// distinctNode is rewindable.
+
+// dropDatabaseNode is rewindable. Note: holds descriptors.
+
+// dropIndexNode is rewindable.
+
+func (*dropTableNode) cannotRewind()    {}
+func (*dropViewNode) cannotRewind()     {}
+func (*dropSequenceNode) cannotRewind() {}
+
+// DropUserNode is rewindable.
+// FIXME(knz/jordan): check that the name resolution closure is robust wrt reuses.
+
+// explainDistSQLNode is rewindable.
+// explainPlanNode is rewindable.
+
+// FIXME(knz/jordan): there's something funky about show trace, I don't get it.
+func (*showTraceNode) cannotRewind() {}
+
+// filterNode is rewindable.
+// groupNode is rewindable.
+// unaryNode is rewindable.
+
+func (*hookFnNode) cannotRewind() {}
+
+// indexJoinNode is rewindable.
+
+func (*insertNode) cannotRewind() {}
+
+// joinNode is rewindable.
+// limitNode is rewindable.
+// ordinalityNode is rewindable.
+
+func (*testingRelocateNode) cannotRewind() {}
+
+// renderNode is rewindable.
+
+// FIXME(knz/jordan) scanNode should really be rewindable.
+func (*scanNode) cannotRewind() {}
+
+// scatterNode is rewindable.
+// scrubNode is rewindable.
+
+// setVarNode is rewindable.
+// setClusterSettingNode is rewindable.
+// setZoneConfigNode is rewindable.
+// showZoneConfigNode is rewindable.
+// showRangesNode is rewindable.
+
+// showFingerprintsNode is rewindable. Note: holds descriptors.
+
+// FIXME(knz/jordan) sortNode should really be rewindable.
+func (*sortNode) cannotRewind() {}
+
+// splitNode is rewindable.
+
+// FIXME(knz/jordan) make unionNode rewindable. This may be complicated
+// by the wish to close/clear/release the left plan once it has been
+// read fully.
+func (*unionNode) cannotRewind() {}
+
+func (*updateNode) cannotRewind() {}
+
+// valueGenerator is rewindable.
+// valuesNode is rewindable.
+
+// FIXME(knz/jordan) windowNode should probably be rewindable.
+func (*windowNode) cannotRewind() {}
+
+// zeroNode is rewindable.

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -160,6 +160,11 @@ type scanRun struct {
 	fetcher sqlbase.MultiRowFetcher
 }
 
+func (n *scanNode) rewindExec(params runParams) error {
+	// TODO(knz): Do this.
+	return nil
+}
+
 func (n *scanNode) startExec(params runParams) error {
 	tableArgs := sqlbase.MultiRowFetcherTableArgs{
 		Desc:             n.desc,

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -98,6 +98,11 @@ type scrubRun struct {
 	row        tree.Datums
 }
 
+func (n *scrubNode) rewindExec(params runParams) error {
+	n.run = scrubRun{}
+	return nil
+}
+
 func (n *scrubNode) startExec(params runParams) error {
 	switch n.n.Typ {
 	case tree.ScrubTable:

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -99,16 +99,20 @@ func (p *planner) SetVar(ctx context.Context, n *tree.SetVar) (planNode, error) 
 
 func (n *setVarNode) startExec(params runParams) error {
 	if n.typedValues != nil {
+		// TODO(knz): Weird, why are these Eval()uated here?
+		// Every Set() method that uses the expressions seems to
+		// also evaluate. Maybe this is not needed.
+		evaluatedExprs := make([]tree.TypedExpr, len(n.typedValues))
 		for i, v := range n.typedValues {
 			d, err := v.Eval(params.EvalContext())
 			if err != nil {
 				return err
 			}
-			n.typedValues[i] = d
+			evaluatedExprs[i] = d
 		}
 		return n.v.Set(
 			params.ctx, params.p.sessionDataMutator,
-			params.extendedEvalCtx, n.typedValues)
+			params.extendedEvalCtx, evaluatedExprs)
 	}
 	return n.v.Reset(params.p.sessionDataMutator)
 }

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -56,6 +56,11 @@ type setZoneConfigRun struct {
 	numAffected int
 }
 
+func (n *setZoneConfigNode) rewindExec(params runParams) error {
+	n.run.numAffected = 0
+	return nil
+}
+
 func (n *setZoneConfigNode) startExec(params runParams) error {
 	var yamlConfig *string
 	datum, err := n.yamlConfig.Eval(params.EvalContext())

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -88,6 +88,11 @@ type showFingerprintsRun struct {
 	values []tree.Datum
 }
 
+func (n *showFingerprintsNode) rewindExec(params runParams) error {
+	n.run = showFingerprintsRun{}
+	return nil
+}
+
 func (n *showFingerprintsNode) startExec(params runParams) error {
 	n.run.values = []tree.Datum{tree.DNull, tree.DNull}
 	return nil

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -96,6 +96,11 @@ type showRangesRun struct {
 	values []tree.Datum
 }
 
+func (n *showRangesNode) rewindExec(params runParams) error {
+	n.run.rowIdx = 0
+	return nil
+}
+
 func (n *showRangesNode) startExec(params runParams) error {
 	var err error
 	n.run.descriptorKVs, err = scanMetaKVs(params.ctx, params.p.txn, n.span)

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -201,6 +201,19 @@ type traceRun struct {
 	stopTracing func() error
 }
 
+func (n *showTraceNode) rewindExec(params runParams) error {
+	if n.run.stopTracing != nil {
+		if err := n.run.stopTracing(); err != nil {
+			log.Errorf(params.ctx, "error stopping tracing when rewinding SHOW TRACE FOR: %v", err)
+		}
+		n.run.stopTracing = nil
+	}
+	n.run.execDone = false
+	n.run.traceRows = nil
+	n.run.curRow = 0
+	return nil
+}
+
 func (n *showTraceNode) startExec(params runParams) error {
 	if params.extendedEvalCtx.Tracing.Enabled() {
 		return errTracingAlreadyEnabled
@@ -215,7 +228,8 @@ func (n *showTraceNode) startExec(params runParams) error {
 	startCtx, sp := tracing.ChildSpan(params.ctx, "starting plan")
 	defer sp.Finish()
 	params.ctx = startCtx
-	return startExec(params, n.plan)
+	// FIXME(knz/jordan): This will not work with rewinding.
+	return startExec(params, n.plan, false)
 }
 
 func (n *showTraceNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -73,6 +73,11 @@ type showZoneConfigRun struct {
 	done         bool
 }
 
+func (n *showZoneConfigNode) rewindExec(params runParams) error {
+	n.run = showZoneConfigRun{}
+	return nil
+}
+
 func (n *showZoneConfigNode) startExec(params runParams) error {
 	if n.zoneSpecifier.TargetsIndex() {
 		_, err := params.p.expandIndexName(params.ctx, &n.zoneSpecifier.TableOrIndex, true /* requireTable */)

--- a/pkg/sql/unary.go
+++ b/pkg/sql/unary.go
@@ -32,6 +32,11 @@ type unaryRun struct {
 	consumed bool
 }
 
+func (u *unaryNode) rewindExec() error {
+	u.run.consumed = false
+	return nil
+}
+
 func (*unaryNode) Values() tree.Datums { return nil }
 
 func (u *unaryNode) Next(runParams) (bool, error) {

--- a/pkg/sql/value_generator.go
+++ b/pkg/sql/value_generator.go
@@ -81,6 +81,14 @@ type valueGeneratorRun struct {
 	gen tree.ValueGenerator
 }
 
+func (n *valueGenerator) rewindExec(params runParams) error {
+	if n.run.gen != nil {
+		n.run.gen.Close()
+	}
+	n.run.gen = nil
+	return nil
+}
+
 func (n *valueGenerator) startExec(params runParams) error {
 	expr, err := n.expr.Eval(params.EvalContext())
 	if err != nil {

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -37,6 +37,8 @@ type valuesNode struct {
 	// isConst = true can serve its values multiple times. See valuesNode.Reset.
 	isConst bool
 
+	containerOnly bool
+	capacity      int
 	valuesRun
 }
 
@@ -111,8 +113,10 @@ func (p *planner) Values(
 
 func (p *planner) newContainerValuesNode(columns sqlbase.ResultColumns, capacity int) *valuesNode {
 	return &valuesNode{
-		columns: columns,
-		isConst: true,
+		columns:       columns,
+		isConst:       true,
+		containerOnly: true,
+		capacity:      capacity,
 		valuesRun: valuesRun{
 			rows: sqlbase.NewRowContainer(
 				p.EvalContext().Mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(columns), capacity,
@@ -125,6 +129,17 @@ func (p *planner) newContainerValuesNode(columns sqlbase.ResultColumns, capacity
 type valuesRun struct {
 	rows    *sqlbase.RowContainer
 	nextRow int // The index of the next row.
+}
+
+func (n *valuesNode) rewindExec(params runParams) error {
+	if n.containerOnly {
+		n.valuesRun.rows.Close(params.ctx)
+		n.valuesRun.rows = sqlbase.NewRowContainer(
+			params.p.EvalContext().Mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromResCols(n.columns), n.capacity,
+		)
+	}
+	n.valuesRun.nextRow = 0
+	return nil
 }
 
 func (n *valuesNode) startExec(params runParams) error {


### PR DESCRIPTION
Note: all commits but the last belong to #21305. Will rebase when that merges.

tl;dr: this patch is a 70% solution to enable reuse of logical plans
(planNode hierarchies) for multiple executions.

Prior to this patch, the planNode interface had been designed with the
assumption that a planNode tree would only be executed once, and
subsequently close()d. This assumption expresses itself in multiple
code paths that modify planNodes in-place and "consume" them (destroy
information), effectively preventing multiple reuse.

This is an obstacle to the caching of logical plans.

This patch advances the roadmap toward plan caching by changing the
interface and adding infrastructure so that *some* plans can be
"rewound" and brought back to a point where they can be executed
again.

This is achieved as follows:

- a predicate `isRewindable()` is defined, aiming to return true iff a
  plan can be reused multiple times.

  Its existence is motivated by the assumption that not every plan can
  actually be reused. In fact, during the implementation of this
  patch I encountered significant hurdles trying to make DML
  statements and the windowNode rewindable, and this interface allows
  me to side-step these hurdles and release this patch with support
  for the most common read-only queries.

- nodes that qualify as "rewindable" by `isRewindable()` can be either
  implicitly rewound (i.e. there is nothing particular to do other
  than call `startExec` again before restarting execution), or
  *explicitly* rewound where a new method `rewindExec` must be called.

  A top-level function `(*planTop).restart()` and accompanying
  `restartPlan()` is introduced that automate the call to `rewindExec`
  across a planNode tree.

This patch, once complete, will be merely a "70% solution" because:

- not every planNode can be rewound.
- this approach repeats initialization of some fields between the
  planNode constructor and the `rewindExec` method. A more future
  proof (but more costly in terms of engineering time) would be to
  factor the initialization of data structures into a single place.
- any schema descriptors captured in a planNode are left captured and
  not re-initialized/re-read upon rewind, thereby kicking the can of
  plan invalidation upon schema updates down the road.

Nevertheless, a "70% solution" should be considered acceptable at this
point because it unlocks further progress on the implementation of
plan caching.

----

Work in progress--the following concerns must be addressed before this
patch is complete:

- the rewinding must be extended to support common node types
  which we'd really want to support even in the first version
  (e.g. scans!)
- the rewinding must be extended to support subqueries.
- the distsql physical planning must be audited to ensure that it does
  not modify planNodes in-place and can be run multiple times.