### PR TITLE
sqlbase: multirowfetcher stops decoding a row when it doesn't need more data

### DIFF
--- a/pkg/sql/sqlbase/multirowfetcher.go
+++ b/pkg/sql/sqlbase/multirowfetcher.go
@@ -532,7 +532,6 @@ func (mrf *MultiRowFetcher) ReadIndexKey(key roachpb.Key) (remaining []byte, ok 
 	// when processing the index key. The column values are at the
 	// front of the key.
 	if key, err = DecodeKeyVals(
-		mrf.currentTable.keyValTypes,
 		mrf.currentTable.keyVals,
 		mrf.currentTable.indexColumnDirs,
 		key,
@@ -627,7 +626,6 @@ func (mrf *MultiRowFetcher) processKV(
 			// column values from the value.
 			var err error
 			valueBytes, err = DecodeKeyVals(
-				table.extraTypes,
 				table.extraVals,
 				nil,
 				valueBytes,

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -785,7 +785,7 @@ func DecodeIndexKey(
 			}
 
 			length := int(ancestor.SharedPrefixLen)
-			key, err = DecodeKeyVals(types[:length], vals[:length], colDirs[:length], key)
+			key, err = DecodeKeyVals(vals[:length], colDirs[:length], key)
 			if err != nil {
 				return nil, false, err
 			}
@@ -808,7 +808,7 @@ func DecodeIndexKey(
 		return nil, false, nil
 	}
 
-	key, err = DecodeKeyVals(types, vals, colDirs, key)
+	key, err = DecodeKeyVals(vals, colDirs, key)
 	if err != nil {
 		return nil, false, err
 	}
@@ -826,9 +826,7 @@ func DecodeIndexKey(
 // DecodeKeyVals decodes the values that are part of the key. The decoded
 // values are stored in the vals. If this slice is nil, the direction
 // used will default to encoding.Ascending.
-func DecodeKeyVals(
-	types []ColumnType, vals []EncDatum, directions []encoding.Direction, key []byte,
-) ([]byte, error) {
+func DecodeKeyVals(vals []EncDatum, directions []encoding.Direction, key []byte) ([]byte, error) {
 	if directions != nil && len(directions) != len(vals) {
 		return nil, errors.Errorf("encoding directions doesn't parallel vals: %d vs %d.",
 			len(directions), len(vals))
@@ -893,7 +891,7 @@ func ExtractIndexKey(
 			return nil, errors.Errorf("descriptor did not match key")
 		}
 	} else {
-		key, err = DecodeKeyVals(indexTypes, values, dirs, key)
+		key, err = DecodeKeyVals(values, dirs, key)
 		if err != nil {
 			return nil, err
 		}
@@ -917,7 +915,7 @@ func ExtractIndexKey(
 			return nil, err
 		}
 	}
-	_, err = DecodeKeyVals(extraTypes, extraValues, dirs, extraKey)
+	_, err = DecodeKeyVals(extraValues, dirs, extraKey)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, if the row fetcher needed any of the columns from the value
portion of the keys in a row, it would iterate over the whole value
column by column, decoding the needed columns and skipping unneeded
columns by reading their length. This would occur even after all of the
needed columns were decoded.

This is inefficient for certain kinds of tables and queries. For
example, consider a very wide table and a query that only needs values
from the beginning of the table. In that case, the row fetcher would
read the length of every column value even once it had gotten all of the
column values that it needed.

After this change, the row fetcher keeps track of the number of column
values it needs, and quits decoding early once it has read all of the
required columns. The same is done in `finalizeRow`, which now quits
early when all needed columns are set.

```
name                                old time/op    new time/op    delta
WideTableIgnoreColumns/Cockroach-8    21.5ms ± 2%    14.8ms ± 2%  -31.09%  (p=0.000 n=10+10)

name                                old alloc/op   new alloc/op   delta
WideTableIgnoreColumns/Cockroach-8    2.14MB ± 1%    2.12MB ± 0%   -1.02%  (p=0.000 n=10+9)

name                                old allocs/op  new allocs/op  delta
WideTableIgnoreColumns/Cockroach-8     1.41k ±54%     1.33k ±29%     ~     (p=0.239 n=10+10)
```

Release note (performance improvement): Queries that only need to read
part of a table with many columns are more efficient.

Fixes #21443.