### PR TITLE
sql: minor fix to show_create.go

### DIFF
--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -207,7 +207,7 @@ func (p *planner) showCreateTable(
 		idx := &allIdx[i]
 		if fk := &idx.ForeignKey; fk.IsSet() {
 			f.WriteString(",\n\tCONSTRAINT ")
-			f.WriteString(tree.NameStringP(&fk.Name))
+			f.FormatNameP(&fk.Name)
 			f.WriteString(" ")
 			if err := p.printForeignKeyConstraint(ctx, f.Buffer, dbPrefix, idx); err != nil {
 				return "", err


### PR DESCRIPTION
I had mistakenly let this slip during my review of  #21118.

Release note: none