### PR TITLE
gossip: create SystemConfigDeltaFilter, use in SchemaChangeManager and LeaseManager

### DIFF
--- a/pkg/gossip/util.go
+++ b/pkg/gossip/util.go
@@ -1,0 +1,97 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package gossip
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// SystemConfigDeltaFilter keeps track of SystemConfig values so that unmodified
+// values can be filtered out from a SystemConfig update. This can prevent
+// repeatedly unmarshaling and processing the same SystemConfig values.
+//
+// A SystemConfigDeltaFilter is not safe for concurrent use by multiple
+// goroutines.
+type SystemConfigDeltaFilter struct {
+	keyPrefix roachpb.Key
+	lastVals  map[string]*filterVal
+	epoch     bool
+}
+
+type filterVal struct {
+	epoch bool
+	val   roachpb.Value
+}
+
+// MakeSystemConfigDeltaFilter creates a new SystemConfigDeltaFilter. The filter
+// will ignore all key-values without the specified key prefix, if one is
+// provided.
+func MakeSystemConfigDeltaFilter(keyPrefix roachpb.Key) SystemConfigDeltaFilter {
+	return SystemConfigDeltaFilter{
+		keyPrefix: keyPrefix,
+		lastVals:  make(map[string]*filterVal),
+	}
+}
+
+// ForModified calls the provided function for all SystemConfig kvs that were modified
+// since the last call to this method.
+func (df *SystemConfigDeltaFilter) ForModified(
+	cfg config.SystemConfig, fn func(kv roachpb.KeyValue),
+) {
+	// Invert epoch counter so we can detect which kvs were removed from the
+	// map after updating all those that remain.
+	df.epoch = !df.epoch
+	for _, kv := range cfg.Values {
+		// Skip unimportant kvs.
+		if df.keyPrefix != nil && !bytes.HasPrefix(kv.Key, df.keyPrefix) {
+			continue
+		}
+
+		keySlice := kv.Key[len(df.keyPrefix):]
+		keyStr := string(keySlice)
+		prevVal, ok := df.lastVals[keyStr]
+		if !ok || !bytes.Equal(kv.Value.RawBytes, prevVal.val.RawBytes) {
+			// The key is new or the value changed.
+			fn(kv)
+		}
+
+		newVal := filterVal{epoch: df.epoch, val: kv.Value}
+		if ok {
+			*prevVal = newVal
+		} else {
+			// Both of these variables are split from a copy in the outer scope.
+			// The first is so that all uses of keyStr can take advantage of
+			// https://github.com/golang/go/wiki/CompilerOptimizations#string-and-byte.
+			// The second is so that newVal doesn't escape onto the heap. Look
+			// at memory benchmarks when making any changes here.
+			keyStrAlloc := string(keySlice)
+			newValAlloc := newVal
+			df.lastVals[keyStrAlloc] = &newValAlloc
+		}
+	}
+
+	// Delete the kvs that no longer exist in the system config from the map.
+	//
+	// We can expose the kvs that are being removed in this loop, if we ever
+	// need to.
+	for key, val := range df.lastVals {
+		if val.epoch != df.epoch {
+			delete(df.lastVals, key)
+		}
+	}
+}

--- a/pkg/gossip/util_test.go
+++ b/pkg/gossip/util_test.go
@@ -1,0 +1,184 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package gossip
+
+import (
+	"math/rand"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/config"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func keyFromInt(i int) roachpb.Key {
+	return roachpb.Key(strconv.Itoa(i))
+}
+
+// addKV adds a random value for the specified key to the system config.
+func addKV(rng *rand.Rand, cfg *config.SystemConfig, key int) {
+	newKey := keyFromInt(key)
+	modified := false
+	for _, oldKV := range cfg.Values {
+		if !oldKV.Key.Equal(newKey) {
+			modified = true
+			break
+		}
+	}
+	newKVs := cfg.Values
+	if modified {
+		newKVs = make([]roachpb.KeyValue, 0, len(cfg.Values))
+		for _, oldKV := range cfg.Values {
+			if !oldKV.Key.Equal(newKey) {
+				newKVs = append(newKVs, oldKV)
+			}
+		}
+	}
+	newKVs = append(newKVs, roachpb.KeyValue{
+		Key: newKey,
+		Value: roachpb.Value{
+			RawBytes: randutil.RandBytes(rng, 100),
+		},
+	})
+	cfg.Values = newKVs
+}
+
+// assertModified asserts that the specified keys will be considered "modified"
+// when passing the new system config through the filter.
+func assertModified(
+	t *testing.T, df *SystemConfigDeltaFilter, cfg config.SystemConfig, keys ...int,
+) {
+	t.Helper()
+	var modified []int
+	df.ForModified(cfg, func(kv roachpb.KeyValue) {
+		key, err := strconv.Atoi(string(kv.Key))
+		if err != nil {
+			t.Fatal(err)
+		}
+		modified = append(modified, key)
+	})
+	if !reflect.DeepEqual(modified, keys) {
+		t.Errorf("expected keys modified=%v, found %v", keys, modified)
+	}
+}
+
+// assertSize asserts that the filter has the specified number of kvs stored.
+func assertSize(t *testing.T, df SystemConfigDeltaFilter, size int) {
+	t.Helper()
+	if l := len(df.lastVals); l != size {
+		t.Errorf("expected map size=%d, found %d", size, l)
+	}
+}
+
+func TestSystemConfigDeltaFilter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	rng, _ := randutil.NewPseudoRand()
+
+	df := MakeSystemConfigDeltaFilter(nil)
+	cfg := config.SystemConfig{}
+
+	// Add one key.
+	addKV(rng, &cfg, 1)
+	assertModified(t, &df, cfg, 1)
+	assertSize(t, df, 1)
+
+	// Add two keys.
+	addKV(rng, &cfg, 2)
+	addKV(rng, &cfg, 3)
+	assertModified(t, &df, cfg, 2, 3)
+	assertSize(t, df, 3)
+
+	// Modify a key.
+	addKV(rng, &cfg, 2)
+	assertModified(t, &df, cfg, 2)
+	assertSize(t, df, 3)
+
+	// Remove the first key.
+	cfg.Values = cfg.Values[1:]
+	assertModified(t, &df, cfg)
+	assertSize(t, df, 2)
+}
+
+func TestSystemConfigDeltaFilterWithKeyPrefix(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	rng, _ := randutil.NewPseudoRand()
+
+	df := MakeSystemConfigDeltaFilter(keyFromInt(12))
+	cfg := config.SystemConfig{}
+
+	// Add one non-matching key.
+	addKV(rng, &cfg, 1)
+	assertModified(t, &df, cfg)
+	assertSize(t, df, 0)
+
+	// Add one matching key.
+	addKV(rng, &cfg, 123)
+	assertModified(t, &df, cfg, 123)
+	assertSize(t, df, 1)
+
+	// Add two keys, one matching, one non-matching.
+	addKV(rng, &cfg, 125)
+	addKV(rng, &cfg, 135)
+	assertModified(t, &df, cfg, 125)
+	assertSize(t, df, 2)
+
+	// Modify two keys, one matching, one non-matching.
+	addKV(rng, &cfg, 1)
+	addKV(rng, &cfg, 123)
+	assertModified(t, &df, cfg, 123)
+	assertSize(t, df, 2)
+}
+
+func BenchmarkSystemConfigDeltaFilter(b *testing.B) {
+	df := MakeSystemConfigDeltaFilter(keyFromInt(1))
+	rng, _ := randutil.NewPseudoRand()
+
+	// Create two configs.
+	var cfg1, cfg2 config.SystemConfig
+	for i := 0; i < 1000; i++ {
+		key := i + 100000 // +100000 to match filter
+		addKV(rng, &cfg1, key)
+	}
+	for i := 0; i < 200; i++ {
+		key := i + 200000 // +200000 to avoid matching filter
+		addKV(rng, &cfg1, key)
+	}
+	// Copy to cfg2 so that most kvs are shared.
+	cfg2.Values = append([]roachpb.KeyValue(nil), cfg1.Values...)
+
+	// Make a few modifications to cfg2.
+	for i := 0; i < 20; i++ {
+		key := i + 1000000 // +1000000 to match filter and first group
+		addKV(rng, &cfg2, key)
+	}
+	for i := 0; i < 20; i++ {
+		key := i + 10000 // +10000 to match filter
+		addKV(rng, &cfg2, key)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cfg := cfg1
+		if i%2 == 1 {
+			cfg = cfg2
+		}
+		df.ForModified(cfg, func(kv roachpb.KeyValue) {
+			_ = kv
+		})
+	}
+}

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -1460,15 +1461,16 @@ func (m *LeaseManager) findTableState(tableID sqlbase.ID, create bool) *tableSta
 
 // RefreshLeases starts a goroutine that refreshes the lease manager
 // leases for tables received in the latest system configuration via gossip.
-func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gossip.Gossip) {
+func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, g *gossip.Gossip) {
 	ctx := context.TODO()
 	s.RunWorker(ctx, func(ctx context.Context) {
 		descKeyPrefix := keys.MakeTablePrefix(uint32(sqlbase.DescriptorTable.ID))
-		gossipUpdateC := gossip.RegisterSystemConfigChannel()
+		cfgFilter := gossip.MakeSystemConfigDeltaFilter(descKeyPrefix)
+		gossipUpdateC := g.RegisterSystemConfigChannel()
 		for {
 			select {
 			case <-gossipUpdateC:
-				cfg, _ := gossip.GetSystemConfig()
+				cfg, _ := g.GetSystemConfig()
 				if m.testingKnobs.GossipUpdateEvent != nil {
 					m.testingKnobs.GossipUpdateEvent(cfg)
 				}
@@ -1477,16 +1479,12 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 					log.Info(ctx, "received a new config; will refresh leases")
 				}
 
-				// Loop through the configuration to find all the tables.
-				for _, kv := range cfg.Values {
-					if !bytes.HasPrefix(kv.Key, descKeyPrefix) {
-						continue
-					}
+				cfgFilter.ForModified(cfg, func(kv roachpb.KeyValue) {
 					// Attempt to unmarshal config into a table/database descriptor.
 					var descriptor sqlbase.Descriptor
 					if err := kv.Value.GetProto(&descriptor); err != nil {
 						log.Warningf(ctx, "%s: unable to unmarshal descriptor %v", kv.Key, kv.Value)
-						continue
+						return
 					}
 					switch union := descriptor.Union.(type) {
 					case *sqlbase.Descriptor_Table:
@@ -1494,7 +1492,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 						table.MaybeUpgradeFormatVersion()
 						if err := table.ValidateTable(); err != nil {
 							log.Errorf(ctx, "%s: received invalid table descriptor: %v", kv.Key, table)
-							continue
+							return
 						}
 						if log.V(2) {
 							log.Infof(ctx, "%s: refreshing lease table: %d (%s), version: %d, dropped: %t",
@@ -1511,7 +1509,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, gossip *gos
 					case *sqlbase.Descriptor_Database:
 						// Ignore.
 					}
-				}
+				})
 				if m.testingKnobs.TestingLeasesRefreshedEvent != nil {
 					m.testingKnobs.TestingLeasesRefreshedEvent(cfg)
 				}


### PR DESCRIPTION
SystemConfigDeltaFilter keeps track of SystemConfig values so that unmodified
values can be filtered out from a SystemConfig update. This can prevent
repeatedly unmarshaling and processing the same SystemConfig values.

The change then uses the newly introduces `SystemConfigDeltaFilter` in the
gossip workers for the `SchemaChangeManager` and the `LeaseManager`.

This is one of the proposed improvements from https://github.com/cockroachdb/cockroach/issues/20753#issuecomment-357371903.

Release note: None