### PR TITLE
ui: remove decomssioned nodes from UI graphs

### DIFF
--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -207,5 +207,29 @@ export const nodesSummarySelector = createSelector(
   },
 );
 
+/**
+ * nodesSummarySelector returns a directory object containing a variety of
+ * computed information based on the current nodes. This object is easy to
+ * connect to components on child pages.
+ */
+export const commissionedNodesSummarySelector = createSelector(
+  nodesSummarySelector,
+  (nodesSummary) => {
+    const commisionedNodeIds = _.keys(_.filter(nodesSummary.livenessStatusByNodeID, (livenessStatus) => {
+        return (livenessStatus !== LivenessStatus.DECOMMISSIONED)
+      }
+    ));
+
+    return {
+      nodeStatuses: nodesSummary.nodeStatuses,
+      nodeIDs: _.filter(nodesSummary.nodeIDs, (_, nodeID) => (commisionedNodeIds.indexOf(nodeID.toString()) != -1)),
+      nodeStatusByID: nodesSummary.nodeStatusByID,
+      nodeSums: nodesSummary.nodeSums,
+      livenessStatusByNodeID: nodesSummary.livenessStatusByNodeID,
+      livenessByNodeID: nodesSummary.livenessByNodeID,
+    };
+  },
+);
+
 const nodesSummaryType = nullOfReturnType(nodesSummarySelector);
 export type NodesSummary = typeof nodesSummaryType;

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -17,7 +17,7 @@ import ClusterSummaryBar from "./summaryBar";
 import { AdminUIState } from "src/redux/state";
 import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
 import { hoverStateSelector, HoverState, hoverOn, hoverOff } from "src/redux/hover";
-import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
+import { commissionedNodesSummarySelector, NodesSummary } from "src/redux/nodes";
 import Alerts from "src/views/shared/containers/alerts";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
 
@@ -230,7 +230,7 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
 export default connect(
   (state: AdminUIState) => {
     return {
-      nodesSummary: nodesSummarySelector(state),
+      nodesSummary: commissionedNodesSummarySelector(state),
       nodesQueryValid: state.cachedData.nodes.valid,
       livenessQueryValid: state.cachedData.nodes.valid,
       hoverState: hoverStateSelector(state),


### PR DESCRIPTION
Before we were showing decomissioned and dead nodes on various graphs
in the admin UI indefinitely.

Now we will remove decomissioned and dead node from the graphs.

closes: #19541

Release note(admin UI): We'll stop showing decomissioned dead nodes in
graphs.