### PR TITLE
sql: stop plumbing the bytes monitor down into the cascader

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -292,9 +292,7 @@ func (sc *SchemaChanger) truncateIndexes(
 					return err
 				}
 				td := tableDeleter{rd: rd, alloc: alloc}
-				if err := td.init(
-					txn, nil /* *mon.BytesMonitor */, nil, /* *tree.EvalContext */
-				); err != nil {
+				if err := td.init(txn, nil /* *tree.EvalContext */); err != nil {
 					return err
 				}
 				resume, err = td.deleteIndex(

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -149,8 +149,7 @@ func (d *deleteNode) startExec(params runParams) error {
 		return d.fastDelete(params, scan)
 	}
 
-	evalCtx := params.EvalContext()
-	return d.run.tw.init(d.p.txn, evalCtx.Mon, evalCtx)
+	return d.run.tw.init(d.p.txn, params.EvalContext())
 }
 
 func (d *deleteNode) Next(params runParams) (bool, error) {
@@ -238,8 +237,7 @@ func (d *deleteNode) fastDelete(params runParams, scan *scanNode) error {
 		return err
 	}
 
-	evalCtx := params.EvalContext()
-	if err := d.tw.init(params.p.txn, evalCtx.Mon, evalCtx); err != nil {
+	if err := d.tw.init(params.p.txn, params.EvalContext()); err != nil {
 		return err
 	}
 	if err := params.p.cancelChecker.Check(); err != nil {

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -245,7 +245,7 @@ func (cb *columnBackfiller) runChunk(
 				}
 			}
 			if _, err := ru.UpdateRow(
-				ctx, b, oldValues, updateValues, nil /* mon.BytesMonitor */, sqlbase.CheckFKs, false, /* traceKV */
+				ctx, b, oldValues, updateValues, sqlbase.CheckFKs, false, /* traceKV */
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -320,8 +320,7 @@ func (n *insertNode) startExec(params runParams) error {
 		return err
 	}
 
-	evalCtx := params.EvalContext()
-	return n.run.tw.init(params.p.txn, evalCtx.Mon, evalCtx)
+	return n.run.tw.init(params.p.txn, params.EvalContext())
 }
 
 func (n *insertNode) Next(params runParams) (bool, error) {

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -355,7 +355,7 @@ func truncateTableInChunks(
 				return err
 			}
 			td := tableDeleter{rd: rd, alloc: alloc}
-			if err := td.init(txn, nil /* *mon.BytesMonitor */, nil /* *tree.EvalContext */); err != nil {
+			if err := td.init(txn, nil /* *tree.EvalContext */); err != nil {
 				return err
 			}
 			resume, err = td.deleteAllRows(ctx, resumeAt, chunkSize, noAutoCommit, traceKV)

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -274,8 +274,7 @@ func (u *updateNode) startExec(params runParams) error {
 	if err := u.run.startEditNode(params, &u.editNodeBase); err != nil {
 		return err
 	}
-	evalCtx := params.EvalContext()
-	return u.run.tw.init(params.p.txn, evalCtx.Mon, evalCtx)
+	return u.run.tw.init(params.p.txn, params.EvalContext())
 }
 
 func (u *updateNode) Next(params runParams) (bool, error) {


### PR DESCRIPTION
The cascader requires an EvalContext and that includes a bytes
monitor. So there is no need for both of them.

Release note: None