### PR TITLE
sqlccl: disallow bulk IO statements in txn

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -870,18 +870,6 @@ func importPlanHook(
 		return nil, nil, nil
 	}
 
-	if !importCSVEnabled.Get(&p.ExecCfg().Settings.SV) {
-		return nil, nil, errors.Errorf(
-			`IMPORT is an experimental feature and is disabled by default; `+
-				`enable by executing: SET CLUSTER SETTING %s = true`,
-			importCSVEnabledSetting,
-		)
-	}
-
-	if err := p.RequireSuperUser("IMPORT"); err != nil {
-		return nil, nil, err
-	}
-
 	filesFn, err := p.TypeAsStringArray(importStmt.Files, "IMPORT")
 	if err != nil {
 		return nil, nil, err
@@ -909,11 +897,27 @@ func importPlanHook(
 	// Currently, it "uses" distsql to compute an int and this method returns
 	// it.
 	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
-		walltime := timeutil.Now().UnixNano()
-
 		// TODO(dan): Move this span into sql.
 		ctx, span := tracing.ChildSpan(ctx, importStmt.StatementTag())
 		defer tracing.FinishSpan(span)
+
+		walltime := timeutil.Now().UnixNano()
+
+		if !importCSVEnabled.Get(&p.ExecCfg().Settings.SV) {
+			return errors.Errorf(
+				`IMPORT is an experimental feature and is disabled by default; `+
+					`enable by executing: SET CLUSTER SETTING %s = true`,
+				importCSVEnabledSetting,
+			)
+		}
+
+		if err := p.RequireSuperUser("IMPORT"); err != nil {
+			return err
+		}
+
+		if !p.ExtendedEvalContext().TxnImplicit {
+			return errors.Errorf("IMPORT cannot be used inside a transaction")
+		}
 
 		opts, err := optsFn()
 		if err != nil {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -222,7 +222,7 @@ func makeInternalPlanner(
 
 	s := &Session{
 		data:     data,
-		TxnState: txnState{Ctx: ctx},
+		TxnState: txnState{Ctx: ctx, implicitTxn: true},
 		context:  ctx,
 		tables:   TableCollection{databaseCache: newDatabaseCache(config.SystemConfig{})},
 	}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2058,6 +2058,7 @@ type EvalContext struct {
 	TxnState string
 	// TxnReadOnly specifies if the current transaction is read-only.
 	TxnReadOnly bool
+	TxnImplicit bool
 
 	Settings  *cluster.Settings
 	ClusterID uuid.UUID

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -642,6 +642,9 @@ func (s *Session) extendedEvalCtx(
 	if txn != nil {
 		clusterTs = txn.OrigTimestamp()
 	}
+
+	log.Warningf(context.TODO(), "*!*!*!*!*! extendedEvalCtx TXN %+v", s.TxnState.implicitTxn)
+
 	return extendedEvalContext{
 		EvalContext: tree.EvalContext{
 			Txn:              txn,
@@ -649,6 +652,7 @@ func (s *Session) extendedEvalCtx(
 			ApplicationName:  s.dataMutator.ApplicationName(),
 			TxnState:         getTransactionState(&s.TxnState),
 			TxnReadOnly:      s.TxnState.readOnly,
+			TxnImplicit:      s.TxnState.implicitTxn,
 			Settings:         st,
 			CtxProvider:      s,
 			Mon:              &s.TxnState.mon,


### PR DESCRIPTION
These aren't transactional, so don't let them pretend they are.

Fixes #17498.

Release note: disallow non-transactional bulk IO statements inside transactions.