### PR TITLE
distsql: add row batching to simple aggregations

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -232,21 +232,37 @@ func (ag *aggregator) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	}
 
 	if ag.accumulating {
+		inputBatchSource, batching := ag.input.(RowBatchSource)
+		var batch RowBatch
+		var row sqlbase.EncDatumRow
+		var meta *ProducerMetadata
 		for {
-			row, meta := ag.input.Next()
+			if batching {
+				batch, meta = inputBatchSource.NextBatch()
+			} else {
+				row, meta = ag.input.Next()
+			}
 			if meta != nil {
 				if meta.Err != nil {
 					return nil, ag.producerMeta(meta.Err)
 				}
 				return nil, meta
 			}
-			if row == nil {
+			if row == nil && batch == nil {
 				break
 			}
 			if ag.closed || ag.consumerStatus != NeedMoreRows {
 				continue
 			}
-			if err := ag.accumulateRow(row); err != nil {
+			if batch != nil {
+				// TODO(asubiotto): Make aggregator take better advantage of
+				// these batches.
+				for _, r := range batch {
+					if err := ag.accumulateRow(r); err != nil {
+						return nil, ag.producerMeta(err)
+					}
+				}
+			} else if err := ag.accumulateRow(row); err != nil {
 				return nil, ag.producerMeta(err)
 			}
 		}

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -47,6 +47,14 @@ type columns []uint32
 // producer of a consumer's state.
 type ConsumerStatus uint32
 
+// RowBatch is a batch of rows. The underlying representation is currently
+// inefficient.
+type RowBatch sqlbase.EncDatumRows
+
+// RowBatchSize is the maximum size of a RowBatch. This number is based on the
+// batch size of the kv fetcher.
+const RowBatchSize = 10000
+
 const (
 	// NeedMoreRows indicates that the consumer is still expecting more rows.
 	NeedMoreRows ConsumerStatus = iota
@@ -146,6 +154,14 @@ type RowSource interface {
 	// ConsumerClosed() must be called; it is a no-op to call these methods after
 	// all the rows were consumed (i.e. after Next() returned an empty row).
 	ConsumerClosed()
+}
+
+// RowBatchSource is a RowSource that can produce batches of records.
+type RowBatchSource interface {
+	RowSource
+	// NextBatch returns the next batch from the source. The semantics of
+	// NextBatch are the same as Next.
+	NextBatch() (RowBatch, *ProducerMetadata)
 }
 
 // Run reads records from the source and outputs them to the receiver, properly

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -71,10 +71,14 @@ type tableReader struct {
 	// trailingMetadata contains producer metadata that is sent once the consumer
 	// status is not NeedMoreRows.
 	trailingMetadata []ProducerMetadata
+
+	// pendingMetadata contains producer metadata that was not sent as soon as
+	// it was received. It is used only in NextBatch.
+	pendingMetadata *ProducerMetadata
 }
 
 var _ Processor = &tableReader{}
-var _ RowSource = &tableReader{}
+var _ RowBatchSource = &tableReader{}
 
 // newTableReader creates a tableReader.
 func newTableReader(
@@ -367,6 +371,42 @@ func (tr *tableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			continue
 		}
 		return nil, tr.producerMeta(err)
+	}
+}
+
+// NextBatch is part of the RowBatchSource interface.
+func (tr *tableReader) NextBatch() (RowBatch, *ProducerMetadata) {
+	batch := make(RowBatch, 0, RowBatchSize)
+	var row sqlbase.EncDatumRow
+	var meta *ProducerMetadata
+	for {
+		// Metadata received in the last call to NextBatch is stored in
+		// pendingMetadata if there was an in-progress batch at the time the
+		// metadata was received.
+		if tr.pendingMetadata != nil {
+			meta = tr.pendingMetadata
+			tr.pendingMetadata = nil
+			return nil, meta
+		}
+		if len(batch) == RowBatchSize {
+			return batch, nil
+		}
+		row, meta = tr.Next()
+		if row != nil {
+			batch = append(batch, row)
+			continue
+		}
+		if meta != nil {
+			if len(batch) > 0 {
+				tr.pendingMetadata = meta
+				return batch, nil
+			}
+			return nil, meta
+		}
+		if len(batch) > 0 {
+			return batch, nil
+		}
+		return nil, nil
 	}
 }
 


### PR DESCRIPTION
This change does not provide any performance improvements since there are no changes to improve processor efficiency given batches of rows rather than single rows as input. The RowChannel overhead discussed in #20555 was removed in https://github.com/cockroachdb/cockroach/pull/21254 so does not play a factor in this change. The plan is to continue incrementally changing all the processors to send/receive batches of rows and to tackle possible performance improvements within processors later.

I have made some changes to `RowChannel`, `outbox`, and `stream{encoder,decoder}` but will hold off on submitting them until necessary for these changes to be digestible.