### PR TITLE
storage: handle lease inversion due to non-commutative lease equivalency

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -712,6 +712,7 @@ func TestLeaseReplicaNotInDesc(t *testing.T) {
 
 	lease, _ := tc.repl.GetLease()
 	invalidLease := lease
+	invalidLease.Sequence++
 	invalidLease.Replica.StoreID += 12345
 
 	raftCmd := storagebase.RaftCommand{


### PR DESCRIPTION
Fixes #21283.

`Lease.Equivalent` is not symmetric during lease extensions. This has the effect
that if two lease extensions are in-flight at the same time, they can both be
considered `Equivalent` to the previous lease by not `Equivalent` to each other.
This was causing an assertion to fail because we were not properly detecting two
concurrent lease extensions that would create an expiration timestamps inversion
if applied in a certain order. We now detect cases like this and return a
`LeaseRejectedError`, as expected.

Release note: None