### PR TITLE
libroach: add missing destructor (in parent class)

### DIFF
--- a/c-deps/libroach/ccl/key_manager.cc
+++ b/c-deps/libroach/ccl/key_manager.cc
@@ -154,6 +154,7 @@ rocksdb::Status GenerateDataKey(rocksdb::Env* env, enginepbccl::DataKeysRegistry
 
 };  // namespace KeyManagerUtils
 
+KeyManager::~KeyManager() {}
 FileKeyManager::~FileKeyManager() {}
 
 rocksdb::Status FileKeyManager::LoadKeys() {

--- a/c-deps/libroach/ccl/key_manager.cc
+++ b/c-deps/libroach/ccl/key_manager.cc
@@ -175,6 +175,21 @@ rocksdb::Status FileKeyManager::LoadKeys() {
   return rocksdb::Status::OK();
 }
 
+std::unique_ptr<enginepbccl::SecretKey> FileKeyManager::CurrentKey() {
+  return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*active_key_.get()));
+}
+
+std::unique_ptr<enginepbccl::SecretKey> FileKeyManager::GetKey(const std::string& id) {
+  if (active_key_ != nullptr && active_key_->info().key_id() == id) {
+    return std::unique_ptr<enginepbccl::SecretKey>(
+        new enginepbccl::SecretKey(*active_key_.get()));
+  }
+  if (old_key_ != nullptr && old_key_->info().key_id() == id) {
+    return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*old_key_.get()));
+  }
+  return nullptr;
+}
+
 DataKeyManager::~DataKeyManager() {}
 
 DataKeyManager::DataKeyManager(rocksdb::Env* env, const std::string& db_dir,

--- a/c-deps/libroach/ccl/key_manager.h
+++ b/c-deps/libroach/ccl/key_manager.h
@@ -51,7 +51,7 @@ class KeyManager {
 
   // CurrentKeyInfo returns the KeyInfo about the active key.
   // It does NOT include the key itself and can be logged, displayed, and stored.
-  virtual std::unique_ptr<enginepbccl::KeyInfo> CurrentKeyInfo() {
+  std::unique_ptr<enginepbccl::KeyInfo> CurrentKeyInfo() {
     auto key = CurrentKey();
     if (key == nullptr) {
       return nullptr;
@@ -65,7 +65,7 @@ class KeyManager {
 
   // GetKeyInfo returns the KeyInfo about the key the requested `id`.
   // It does NOT include the key itself and can be logged, displayed, and stored.
-  virtual std::unique_ptr<enginepbccl::KeyInfo> GetKeyInfo(const std::string& id) {
+  std::unique_ptr<enginepbccl::KeyInfo> GetKeyInfo(const std::string& id) {
     auto key = GetKey(id);
     if (key == nullptr) {
       return nullptr;

--- a/c-deps/libroach/ccl/key_manager.h
+++ b/c-deps/libroach/ccl/key_manager.h
@@ -93,20 +93,8 @@ class FileKeyManager : public KeyManager {
   // On error, existing keys held by the object are not overwritten.
   rocksdb::Status LoadKeys();
 
-  virtual std::unique_ptr<enginepbccl::SecretKey> CurrentKey() override {
-    return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*active_key_.get()));
-  }
-
-  virtual std::unique_ptr<enginepbccl::SecretKey> GetKey(const std::string& id) override {
-    if (active_key_ != nullptr && active_key_->info().key_id() == id) {
-      return std::unique_ptr<enginepbccl::SecretKey>(
-          new enginepbccl::SecretKey(*active_key_.get()));
-    }
-    if (old_key_ != nullptr && old_key_->info().key_id() == id) {
-      return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*old_key_.get()));
-    }
-    return nullptr;
-  }
+  virtual std::unique_ptr<enginepbccl::SecretKey> CurrentKey() override;
+  virtual std::unique_ptr<enginepbccl::SecretKey> GetKey(const std::string& id) override;
 
  private:
   rocksdb::Env* env_;

--- a/c-deps/libroach/ccl/key_manager.h
+++ b/c-deps/libroach/ccl/key_manager.h
@@ -47,6 +47,8 @@ rocksdb::Status GenerateDataKey(rocksdb::Env* env, enginepbccl::DataKeysRegistry
 // Specific subclasses will provide different methods of accessing keys.
 class KeyManager {
  public:
+  virtual ~KeyManager();
+
   // CurrentKeyInfo returns the KeyInfo about the active key.
   // It does NOT include the key itself and can be logged, displayed, and stored.
   virtual std::unique_ptr<enginepbccl::KeyInfo> CurrentKeyInfo() {


### PR DESCRIPTION
I think this is slightly better future-proof (you can carry `unique_ptr<KeyManager>` with this)