### PR TITLE
sql: don't decode the first key TableID/IndexID

### DIFF
--- a/pkg/sql/sqlbase/multirowfetcher.go
+++ b/pkg/sql/sqlbase/multirowfetcher.go
@@ -161,6 +161,8 @@ type MultiRowFetcher struct {
 	// decoding values in that row.
 	neededValueCols int
 
+	knownPrefixLength int
+
 	// returnRangeInfo, if set, causes the underlying kvFetcher to return
 	// information about the ranges descriptors/leases uses in servicing the
 	// requests. This has some cost, so it's only enabled by DistSQL when this
@@ -290,6 +292,8 @@ func (mrf *MultiRowFetcher) Init(
 		if !mrf.mustDecodeIndexKey && (!table.neededCols.Empty() || len(table.index.InterleavedBy) > 0 || len(table.index.Interleave.Ancestors) > 0) {
 			mrf.mustDecodeIndexKey = true
 		}
+
+		mrf.knownPrefixLength = len(MakeIndexKeyPrefix(table.desc, table.index.ID))
 
 		var indexColumnIDs []ColumnID
 		indexColumnIDs, table.indexColumnDirs = table.index.FullColumnIDs()
@@ -490,13 +494,13 @@ func (mrf *MultiRowFetcher) ReadIndexKey(key roachpb.Key) (remaining []byte, ok 
 	// If there is only one table to check keys for, there is no need
 	// to go through the equivalence signature checks.
 	if len(mrf.tables) == 1 {
-		return DecodeIndexKey(
+		return DecodeIndexKeyWithoutTableIDIndexIDPrefix(
 			mrf.currentTable.desc,
 			mrf.currentTable.index,
 			mrf.currentTable.keyValTypes,
 			mrf.currentTable.keyVals,
 			mrf.currentTable.indexColumnDirs,
-			key,
+			key[mrf.knownPrefixLength:],
 		)
 	}
 

--- a/pkg/sql/sqlbase/multirowfetcher_test.go
+++ b/pkg/sql/sqlbase/multirowfetcher_test.go
@@ -159,7 +159,7 @@ func TestNextRowSingle(t *testing.T) {
 			if err := mrf.StartScan(
 				context.TODO(),
 				client.NewTxn(kvDB, 0),
-				roachpb.Spans{tableDesc.TableSpan()},
+				roachpb.Spans{tableDesc.IndexSpan(tableDesc.PrimaryIndex.ID)},
 				false, /*limitBatches*/
 				0,     /*limitHint*/
 				false, /*traceKV*/
@@ -333,7 +333,7 @@ func TestNextRowSecondaryIndex(t *testing.T) {
 			if err := mrf.StartScan(
 				context.TODO(),
 				client.NewTxn(kvDB, 0),
-				roachpb.Spans{tableDesc.TableSpan()},
+				roachpb.Spans{tableDesc.IndexSpan(tableDesc.Indexes[0].ID)},
 				false, /*limitBatches*/
 				0,     /*limitHint*/
 				false, /*traceKV*/


### PR DESCRIPTION
The RowFetcher is never called on a span that includes more than one
top-level index, so it's safe to staticly determine the length of the
keys' table id / index id prefix and skip it during index key decode.

```
name                                old time/op    new time/op    delta
WideTableIgnoreColumns/Cockroach-8    15.2ms ± 1%    15.0ms ± 1%  -1.28%  (p=0.002 n=10+10)
```

Partial solution to #21425.

Release note (performance improvement): do less work during key decode