### PR TITLE
storage/engine: reimplement MVCCDeleteRange in terms of MVCCScan

### DIFF
--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -1640,7 +1640,7 @@ func TestMVCCDeleteRangeReturnKeys(t *testing.T) {
 		t.Fatal(err)
 	}
 	if deleted != nil {
-		t.Fatal("the value should be empty")
+		t.Fatalf("the value should be empty: %s", deleted)
 	}
 	if num != 0 {
 		t.Fatalf("incorrect number of keys deleted: %d", num)


### PR DESCRIPTION
Reimplementing MVCCDeleteRange in terms of MVCCScan instead of
MVCCIterate. This takes advantage of the faster MVCCScan
implementation. MVCCIterate will be reimplemented in terms of MVCCScan
soon as well, but this usage seemed more natural.

```
name                                     old time/op    new time/op     delta
MVCCDeleteRange_RocksDB/valueSize=8-8      77.0ms ± 7%     66.6ms ± 4%   -13.43%  (p=0.000 n=10+10)
MVCCDeleteRange_RocksDB/valueSize=32-8     54.1ms ± 2%     47.4ms ± 3%   -12.32%  (p=0.000 n=10+10)
MVCCDeleteRange_RocksDB/valueSize=256-8    16.3ms ± 1%     13.7ms ± 1%   -15.75%  (p=0.000 n=8+10)
```

Release note (performance improvement): Speed up the performance of
low-level delete operations.