### PR TITLE
util: data structure for small int-to-int mappings

### DIFF
--- a/pkg/util/fast_int_map.go
+++ b/pkg/util/fast_int_map.go
@@ -1,0 +1,154 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+// FastIntMap is a replacement for map[int]int which is more efficient when the
+// values are small. It can be passed by value (but Copy must be used for
+// independent modification of copies).
+type FastIntMap struct {
+	small [numWords]uint64
+	large map[int]int
+}
+
+// Copy returns a FastIntMap that can be independently modified.
+func (m FastIntMap) Copy() FastIntMap {
+	if m.large == nil {
+		return FastIntMap{small: m.small}
+	}
+	largeCopy := make(map[int]int, len(m.large))
+	for k, v := range m.large {
+		largeCopy[k] = v
+	}
+	return FastIntMap{large: largeCopy}
+}
+
+// Set maps a key to the given value.
+func (m *FastIntMap) Set(key, val int) {
+	if m.large == nil {
+		if key >= 0 && key < numVals && val >= 0 && val <= maxValue {
+			m.setSmallVal(uint32(key), int32(val))
+			return
+		}
+		m.large = m.toLarge()
+		m.small = [numWords]uint64{}
+	}
+	m.large[key] = val
+}
+
+// Unset unmaps the given key.
+func (m *FastIntMap) Unset(key int) {
+	if m.large == nil {
+		if key < 0 || key >= numVals {
+			return
+		}
+		m.setSmallVal(uint32(key), -1)
+	}
+	delete(m.large, key)
+}
+
+// Get returns the current value mapped to key, or ok=false if the
+// key is unmapped.
+func (m FastIntMap) Get(key int) (value int, ok bool) {
+	if m.large == nil {
+		if key < 0 || key >= numVals {
+			return -1, false
+		}
+		val := m.getSmallVal(uint32(key))
+		return int(val), (val != -1)
+	}
+	value, ok = m.large[key]
+	return value, ok
+}
+
+// MaxKey returns the maximum key that is in the map. If the map
+// is empty, returns ok=false.
+func (m FastIntMap) MaxKey() (_ int, ok bool) {
+	if m.large == nil {
+		// TODO(radu): we could skip words that are 0
+		// and use bits.LeadingZeros64.
+		for i := numVals - 1; i >= 0; i-- {
+			if m.getSmallVal(uint32(i)) != -1 {
+				return i, true
+			}
+		}
+		return 0, false
+	}
+	max, ok := 0, false
+	for k := range m.large {
+		if !ok || max < k {
+			max, ok = k, true
+		}
+	}
+	return max, ok
+}
+
+// ForEach calls the given function for each key/value pair in the map (in
+// arbitrary order).
+func (m FastIntMap) ForEach(fn func(key, val int)) {
+	if m.large == nil {
+		for i := 0; i < numVals; i++ {
+			if val := m.getSmallVal(uint32(i)); val != -1 {
+				fn(i, int(val))
+			}
+		}
+	} else {
+		for k, v := range m.large {
+			fn(k, v)
+		}
+	}
+}
+
+// These constants determine the "small" representation: we pack <numVals>
+// values of <numBits> bits into <numWords> 64-bit words. Each value is 0 if the
+// corresponding key is not set, otherwise it is the value+1.
+//
+// It's desirable for efficiency that numBits, numValsPerWord are powers of two.
+//
+// The current settings support a map from keys in [0, 31] to values in [0, 14].
+// Note that one value is reserved to indicate an unmapped element.
+const (
+	numWords       = 2
+	numBits        = 4
+	numValsPerWord = 64 / numBits              // 16
+	numVals        = numWords * numValsPerWord // 32
+	mask           = (1 << numBits) - 1
+	maxValue       = mask - 1
+)
+
+// Returns -1 if the value is unmapped.
+func (m FastIntMap) getSmallVal(idx uint32) int32 {
+	word := idx / numValsPerWord
+	pos := (idx % numValsPerWord) * numBits
+	return int32((m.small[word]>>pos)&mask) - 1
+}
+
+func (m *FastIntMap) setSmallVal(idx uint32, val int32) {
+	word := idx / numValsPerWord
+	pos := (idx % numValsPerWord) * numBits
+	// Clear out any previous value
+	m.small[word] &= ^(mask << pos)
+	m.small[word] |= uint64(val+1) << pos
+}
+
+func (m *FastIntMap) toLarge() map[int]int {
+	res := make(map[int]int, numVals)
+	for i := 0; i < numVals; i++ {
+		val := m.getSmallVal(uint32(i))
+		if val != -1 {
+			res[i] = int(val)
+		}
+	}
+	return res
+}

--- a/pkg/util/fast_int_map_test.go
+++ b/pkg/util/fast_int_map_test.go
@@ -1,0 +1,200 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package util
+
+import (
+	fmt "fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestFastIntMap(t *testing.T) {
+	cases := []struct {
+		keyRange, valRange int
+	}{
+		{keyRange: 10, valRange: 10},
+		{keyRange: numVals, valRange: maxValue + 1},
+		{keyRange: numVals + 1, valRange: maxValue + 1},
+		{keyRange: numVals, valRange: maxValue + 2},
+		{keyRange: 100, valRange: 100},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%d-%d", tc.keyRange, tc.valRange), func(t *testing.T) {
+			t.Parallel()
+			rng, _ := randutil.NewPseudoRand()
+			var fm FastIntMap
+			m := make(map[int]int)
+			for i := 0; i < 1000; i++ {
+				// Check the entire key range.
+				max, maxOk := 0, false
+				for k := 0; k < tc.keyRange; k++ {
+					v, ok := fm.Get(k)
+					expV, expOk := m[k]
+					if ok != expOk || (ok && v != expV) {
+						t.Fatalf(
+							"incorrect result for key %d: (%d, %t), expected (%d, %t)",
+							k, v, ok, expV, expOk,
+						)
+					}
+					if ok {
+						max, maxOk = k, true
+					}
+				}
+				if m, ok := fm.MaxKey(); ok != maxOk || m != max {
+					t.Fatalf("incorrect MaxKey (%d, %t), expected (%d, %t)", m, ok, max, maxOk)
+				}
+				// Check ForEach
+				num := 0
+				fm.ForEach(func(key, val int) {
+					num++
+					if m[key] != val {
+						t.Fatalf("incorrect ForEach %d,%d", key, val)
+					}
+				})
+				if num != len(m) {
+					t.Fatalf("ForEach reported %d keys, expected %d", num, len(m))
+				}
+				k := rng.Intn(tc.keyRange)
+				if rng.Intn(2) == 0 {
+					v := rng.Intn(tc.valRange)
+					fm.Set(k, v)
+					m[k] = v
+				} else {
+					fm.Unset(k)
+					delete(m, k)
+				}
+				if rng.Intn(10) == 0 {
+					// Verify Copy. The next iteration will verify that the copy contains
+					// the right data.
+					old := fm
+					fm = fm.Copy()
+					old.Set(1, 1)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkFastIntMap(b *testing.B) {
+	cases := []struct {
+		keyRange, valRange, ops int
+	}{
+		{keyRange: 4, valRange: 4, ops: 4},
+		{keyRange: 10, valRange: 10, ops: 4},
+		{keyRange: numVals, valRange: maxValue + 1, ops: 10},
+		{keyRange: 100, valRange: 100, ops: 50},
+		{keyRange: 1000, valRange: 1000, ops: 500},
+	}
+	for _, tc := range cases {
+		b.Run(fmt.Sprintf("%dx%d-%d", tc.keyRange, tc.valRange, tc.ops), func(b *testing.B) {
+			rng, _ := randutil.NewPseudoRand()
+			inserts := make([][2]int, tc.ops)
+			for i := range inserts {
+				inserts[i] = [2]int{rng.Intn(tc.keyRange), rng.Intn(tc.valRange)}
+			}
+			probes := make([]int, tc.ops)
+			for i := range probes {
+				probes[i] = rng.Intn(tc.keyRange)
+			}
+
+			b.Run("fastintmap", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					var fm FastIntMap
+					for _, x := range inserts {
+						fm.Set(x[0], x[1])
+					}
+					hash := 0
+					for _, x := range probes {
+						val, ok := fm.Get(x)
+						if ok {
+							hash ^= val
+						}
+					}
+				}
+			})
+			b.Run("map", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					m := make(map[int]int)
+					for _, x := range inserts {
+						m[x[0]] = x[1]
+					}
+					hash := 0
+					for _, x := range probes {
+						val, ok := m[x]
+						if ok {
+							hash ^= val
+						}
+					}
+				}
+			})
+			b.Run("map-sized", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					m := make(map[int]int, tc.keyRange)
+					for _, x := range inserts {
+						m[x[0]] = x[1]
+					}
+					hash := 0
+					for _, x := range probes {
+						val, ok := m[x]
+						if ok {
+							hash ^= val
+						}
+					}
+				}
+			})
+			b.Run("slice", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					var m []int
+					for _, x := range inserts {
+						for len(m) <= x[0] {
+							m = append(m, -1)
+						}
+						m[x[0]] = x[1]
+					}
+					hash := 0
+					for _, x := range probes {
+						if x < len(m) {
+							val := m[x]
+							if val != -1 {
+								hash ^= val
+							}
+						}
+					}
+				}
+			})
+			b.Run("slice-sized", func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					m := make([]int, tc.keyRange)
+					for i := range m {
+						m[i] = -1
+					}
+					for _, x := range inserts {
+						m[x[0]] = x[1]
+					}
+					hash := 0
+					for _, x := range probes {
+						val := m[x]
+						if val != -1 {
+							hash ^= val
+						}
+					}
+				}
+			})
+
+		})
+	}
+
+}


### PR DESCRIPTION
This change implements `FastIntMap`, which is intended as a
replacement for `map[int]int` when we expect the keys and values to be
small.

The benchmark compares it to a few implementations based on a map or a
slice, with or without upfront information about the key range.

```
name                                    time/op
FastIntMap/4x4-4/fastintmap-8           29.2ns ± 1%
FastIntMap/4x4-4/map-8                   177ns ± 0%
FastIntMap/4x4-4/map-sized-8             178ns ± 1%
FastIntMap/4x4-4/slice-8                 117ns ± 2%
FastIntMap/4x4-4/slice-sized-8          39.7ns ± 7%
FastIntMap/10x10-4/fastintmap-8         29.0ns ± 1%
FastIntMap/10x10-4/map-8                 158ns ± 1%
FastIntMap/10x10-4/map-sized-8           300ns ± 2%
FastIntMap/10x10-4/slice-8               232ns ±11%
FastIntMap/10x10-4/slice-sized-8        52.6ns ±11%
FastIntMap/32x15-10/fastintmap-8        70.0ns ± 1%
FastIntMap/32x15-10/map-8                377ns ± 0%
FastIntMap/32x15-10/map-sized-8          868ns ± 7%
FastIntMap/32x15-10/slice-8              326ns ± 6%
FastIntMap/32x15-10/slice-sized-8       99.3ns ± 1%
FastIntMap/100x100-50/fastintmap-8      3.76µs ± 1%
FastIntMap/100x100-50/map-8             5.94µs ± 1%
FastIntMap/100x100-50/map-sized-8       4.15µs ± 8%
FastIntMap/100x100-50/slice-8            878ns ±14%
FastIntMap/100x100-50/slice-sized-8      336ns ± 4%
FastIntMap/1000x1000-500/fastintmap-8   56.3µs ± 5%
FastIntMap/1000x1000-500/map-8          57.7µs ± 3%
FastIntMap/1000x1000-500/map-sized-8    50.0µs ±11%
FastIntMap/1000x1000-500/slice-8        6.55µs ±36%
FastIntMap/1000x1000-500/slice-sized-8  3.06µs ± 3%

name                                    alloc/op
FastIntMap/4x4-4/fastintmap-8            0.00B
FastIntMap/4x4-4/map-8                   0.00B
FastIntMap/4x4-4/map-sized-8             0.00B
FastIntMap/4x4-4/slice-8                 56.0B ± 0%
FastIntMap/4x4-4/slice-sized-8           32.0B ± 0%
FastIntMap/10x10-4/fastintmap-8          0.00B
FastIntMap/10x10-4/map-8                 0.00B
FastIntMap/10x10-4/map-sized-8            288B ± 0%
FastIntMap/10x10-4/slice-8                248B ± 0%
FastIntMap/10x10-4/slice-sized-8         80.0B ± 0%
FastIntMap/32x15-10/fastintmap-8         0.00B
FastIntMap/32x15-10/map-8                0.00B
FastIntMap/32x15-10/map-sized-8         1.15kB ± 0%
FastIntMap/32x15-10/slice-8               504B ± 0%
FastIntMap/32x15-10/slice-sized-8         256B ± 0%
FastIntMap/100x100-50/fastintmap-8      1.27kB ± 0%
FastIntMap/100x100-50/map-8             2.28kB ± 0%
FastIntMap/100x100-50/map-sized-8       2.72kB ± 0%
FastIntMap/100x100-50/slice-8           2.04kB ± 0%
FastIntMap/100x100-50/slice-sized-8       896B ± 0%
FastIntMap/1000x1000-500/fastintmap-8   21.4kB ± 0%
FastIntMap/1000x1000-500/map-8          22.4kB ± 0%
FastIntMap/1000x1000-500/map-sized-8    41.0kB ± 0%
FastIntMap/1000x1000-500/slice-8        16.4kB ± 0%
FastIntMap/1000x1000-500/slice-sized-8  8.19kB ± 0%

name                                    allocs/op
FastIntMap/4x4-4/fastintmap-8             0.00
FastIntMap/4x4-4/map-8                    0.00
FastIntMap/4x4-4/map-sized-8              0.00
FastIntMap/4x4-4/slice-8                  3.00 ± 0%
FastIntMap/4x4-4/slice-sized-8            1.00 ± 0%
FastIntMap/10x10-4/fastintmap-8           0.00
FastIntMap/10x10-4/map-8                  0.00
FastIntMap/10x10-4/map-sized-8            1.00 ± 0%
FastIntMap/10x10-4/slice-8                5.00 ± 0%
FastIntMap/10x10-4/slice-sized-8          1.00 ± 0%
FastIntMap/32x15-10/fastintmap-8          0.00
FastIntMap/32x15-10/map-8                 0.00
FastIntMap/32x15-10/map-sized-8           1.00 ± 0%
FastIntMap/32x15-10/slice-8               6.00 ± 0%
FastIntMap/32x15-10/slice-sized-8         1.00 ± 0%
FastIntMap/100x100-50/fastintmap-8        3.00 ± 0%
FastIntMap/100x100-50/map-8               7.00 ± 0%
FastIntMap/100x100-50/map-sized-8         2.00 ± 0%
FastIntMap/100x100-50/slice-8             8.00 ± 0%
FastIntMap/100x100-50/slice-sized-8       1.00 ± 0%
FastIntMap/1000x1000-500/fastintmap-8     32.0 ± 0%
FastIntMap/1000x1000-500/map-8            36.0 ± 0%
FastIntMap/1000x1000-500/map-sized-8      2.00 ± 0%
FastIntMap/1000x1000-500/slice-8          11.0 ± 0%
FastIntMap/1000x1000-500/slice-sized-8    1.00 ± 0%
```

Release note: None

----
I'm surprised that `map[int]int` doesn't allocate for the small cases.. I wonder what's going on. It's still much slower though.