### PR TITLE
scripts: add a script to extract release notes

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -1,0 +1,487 @@
+#! /usr/bin/env python3
+#
+# Show a compact release note summary of a range of Git commits.
+#
+# Example use: release-notes.py --help
+#
+# Note: the first commit in the range is excluded!
+#
+# Requires: GitPython https://pypi.python.org/pypi/GitPython/
+#
+# Disclaimer: this program is provided without warranties of any kind,
+# including suitability for any purpose. The author(s) will not be
+# responsible if this script eats your left sock.
+#
+# Known limitations:
+#
+# - if different people with the same name contribute, this script
+#   will be confused. (it will merge their work under one entry).
+# - the list of aliases below must be manually modified when
+#   contributors change their git name and/or email address.
+
+import sys
+import itertools
+import re
+import os
+import datetime
+import subprocess
+from git import Repo
+from optparse import OptionParser
+
+### Global behavior constants ###
+
+# minimum sha length to disambiguate
+shamin = 9
+
+# FIXME(knz): This probably needs to use the .mailmap.
+author_aliases = {
+    'dianasaur323': "Diana Hsieh",
+    'kena': "Raphael 'kena' Poss",
+    'vivekmenezes': "Vivek Menezes",
+    'RaduBerinde': "Radu Berinde",
+    'Andy Kimball': "Andrew Kimball",
+    'marc': "Marc Berhault",
+    'MBerhault': "Marc Berhault",
+    'Nate': "Nathaniel Stewart",
+    'a6802739': "Song Hao",
+    'Abhemailk abhi.madan01@gmail.com': "Abhishek Madan",
+    'rytaft': "Rebecca Taft",
+    'songhao': "Song Hao",
+    'solongordon': "Solon Gordon",
+}
+
+# FIXME(knz): This too.
+crdb_folk = set([
+    "Abhishek Madan",
+    "Alex Robinson",
+    "Alfonso Subiotto Marqués",
+    "Amruta Ranade",
+    "Andrei Matei",
+    "Andrew Couch",
+    "Andrew Kimball",
+    "Andy Woods",
+    "Arjun Narayan",
+    "Ben Darnell",
+    "Bram Gruneir",
+    "Daniel Harrison",
+    "David Taylor",
+    "Diana Hsieh",
+    "Jesse Seldess",
+    "Jessica Edwards",
+    "Joey Pereira",
+    "Jordan Lewis",
+    "Justin Jaffray",
+    "Kuan Luo",
+    "Marc Berhault",
+    "Masha Schneider",
+    "Matt Jibson",
+    "Matt Tracy",
+    "Nathan VanBenschoten",
+    "Nathaniel Stewart",
+    "Nikhil Benesch",
+    "Paul Bardea",
+    "Pete Vilter",
+    "Peter Mattis",
+    "Radu Berinde",
+    "Raphael 'kena' Poss",
+    "Rebecca Taft",
+    "Richard Wu",
+    "Sean Loiselle",
+    "Solon Gordon",
+    "Spencer Kimball",
+    "Tamir Duberstein",
+    "Tobias Schottdorf",
+    "Vivek Menezes",
+])
+
+
+# Section titles for release notes.
+relnotetitles = {
+    'cli change': "Command-Line Changes",
+    'sql change': "SQL Language Changes",
+    'admin ui change': "Admin UI Changes",
+    'general change': "General Changes",
+    'build change': "Build Changes",
+    'enterprise change': "Enterprise Changes",
+    'backward-incompatible change': "Backward-Incompatible Changes",
+    'performance improvement': "Performance Improvements",
+    'bug fix': "Bug Fixes",
+}
+
+# Order in which to show the sections.
+relnote_sec_order = [
+    'backward-incompatible change',
+    'general change',
+    'enterprise change',
+    'sql change',
+    'cli change',
+    'admin ui change',
+    'core change',
+    'bug fix',
+    'performance improvement',
+    'build change',
+    ]
+
+# Release note category common misspellings.
+cat_misspells = {
+    'sql' : 'sql change',
+    'general': 'general change',
+    'core change': 'general change',
+    'bugfix': 'bug fix',
+    'performance change' : 'performance improvement',
+    'ui' : 'admin ui change',
+    'backwards-incompatible change': 'backward-incompatible change',
+    }
+
+## Release note format ##
+
+# The following release note formats have been seen in the wild:
+#
+# Release note (xxx): yyy    <- canonical
+# Release Notes: None
+# Release note (xxx): yyy
+# Release note (xxx) : yyy
+# Release note: (xxx): yyy
+# Release note: xxx: yyy
+# Release note: (xxx) yyy
+# Release note: yyy (no category)
+# Release note (xxx, zzz): yyy
+norelnote = re.compile(r'^[rR]elease [nN]otes?: *[Nn]one', flags=re.M)
+# Captures :? (xxx) ?: yyy
+form1 = r':? *\((?P<cat1>[^)]*)\) *:?'
+# Captures : xxx: yyy - this must be careful not to capture too much, we just accept one word
+form2 = r': *(?P<cat2>[^ ]*) *:'
+# Captures : yyy - no category
+form3 = r':(?P<cat3>)'
+relnote = re.compile(r'(?:^|[\n\r])[rR]elease [nN]otes? *(?:' + form1 + '|' + form2 + '|' + form3 + r') *(?P<note>.*)$', flags=re.S)
+
+### Initialization / option parsing ###
+
+parser = OptionParser()
+parser.add_option("-k", "--sort-key", dest="sort_key", default="title",
+                  help="sort by KEY (pr, title, insertions, deletions, files, sha; default: title)", metavar="KEY")
+parser.add_option("-r", "--reverse", action="store_true", dest="reverse_sort", default=False,
+                  help="reverse sort")
+parser.add_option("-f", "--from", dest="from_commit",
+                  help="list history from COMMIT. Note: the first commit is excluded.", metavar="COMMIT")
+parser.add_option("-t", "--until", dest="until_commit", default="HEAD",
+                  help="list history up and until COMMIT (default: HEAD)", metavar="COMMIT")
+parser.add_option("--hide-unambiguous-shas", action="store_true", dest="hide_shas", default=False,
+                  help="omit commit SHAs in the release notes and per-contributor sections")
+
+(options, args) = parser.parse_args()
+
+sortkey = options.sort_key
+revsort = options.reverse_sort
+hideshas = options.hide_shas
+
+repo = Repo('.')
+heads = repo.heads
+
+firstCommit = repo.commit(options.from_commit)
+commit = repo.commit(options.until_commit)
+
+if commit == firstCommit:
+    print("Commit range is empty!", file=sys.stderr)
+    print(parser.get_usage(), file=sys.stderr)
+    print("Example use:", file=sys.stderr)
+    print("  %s --help" % sys.argv[0], file=sys.stderr)
+    print("  %s --from xxx >output.md" % sys.argv[0], file=sys.stderr)
+    print("  %s --from xxx --until yyy >output.md" % sys.argv[0], file=sys.stderr)
+    print("Note: the first commit is excluded. Use e.g.: --from <prev-release-tag> --until <new-release-candidate-sha>", file=sys.stderr)
+    exit(0)
+
+### Reading data from repository ###
+
+# Is the first commit reachable from the current one?
+check = commit
+while check != firstCommit:
+    if len(check.parents) == 0:
+        print("error: origin commit %s not in history of %s" %( options.from_commit, options.until_commit))
+        exit(1)
+    check = check.parents[0]
+
+print("Changes %s ... %s" % (firstCommit, commit), file=sys.stderr)
+
+release_notes = {}
+missing_release_notes = []
+
+def extract_release_notes(pr, title, commit):
+    if norelnote.search(commit.message) is not None:
+        # Explicitly no release note. Nothing to do.
+        return
+
+    item = {'author': (commit.author.name, commit.author.email),
+            'sha': commit.hexsha[:shamin],
+            'pr': pr,
+            'prtitle': title,
+            'note': None}
+
+    m = relnote.search(commit.message)
+    if m is None:
+        # Missing release note. Keep track for later.
+        missing_release_notes.append(item)
+        return
+    item['note'] = m.group('note').strip()
+    if item['note'].lower() == 'none':
+        # Someone entered 'Release note (cat): None'.
+        return
+
+    cat = m.group('cat1')
+    if cat is None:
+        cat = m.group('cat2')
+    if cat is None:
+        cat = 'missing category'
+    # Normalize to tolerate various capitalizations.
+    cat = cat.lower()
+    # If there are multiple categories separated by commas or slashes, use the first as grouping key.
+    cat = cat.split(',', 1)[0]
+    cat = cat.split('/', 1)[0]
+    # If there is any misspell, correct it.
+    if cat in cat_misspells:
+        cat = cat_misspells[cat]
+    # Now collect per category.
+    catnotes = release_notes.get(cat, [])
+    catnotes.append(item)
+    release_notes[cat] = catnotes
+
+# This function groups and counts all the commits that belong to a particular PR.
+def collect_commits(pr, title, commits, author):
+    ncommits = 0
+    otherauthors = set()
+    for commit in commits:
+        if commit.message.startswith("Merge pull request"):
+            continue
+        extract_release_notes(pr, title, commit)
+
+        ncommits += 1
+        this_commits_author = author_aliases.get(commit.author.name, commit.author.name)
+        if commit.author.name != 'GitHub' and this_commits_author != author:
+            otherauthors.add(this_commits_author)
+        this_commits_committer = author_aliases.get(commit.committer.name, commit.committer.name)
+        if commit.committer.name != 'GitHub' and this_commits_committer != author:
+            otherauthors.add(this_commits_committer)
+
+        n, a = collect_commits(pr, title, list(commit.parents), author)
+        ncommits += n
+        otherauthors.update(a)
+    return ncommits, otherauthors
+
+per_author_history = {}
+individual_authors = set()
+allprs = set()
+
+spinner = itertools.cycle(['/', '-', '\\', '|'])
+counter = 0
+
+def spin():
+    global counter
+    # Display a progress bar
+    counter += 1
+    if counter % 10 == 0:
+        if counter % 100 == 0:
+            print("\b..", end='', file=sys.stderr)
+        print("\b", end='', file=sys.stderr)
+        print(next(spinner),  end='', file=sys.stderr)
+        sys.stderr.flush()
+
+while commit != firstCommit:
+    spin()
+
+    # Analyze the commit
+    if commit.message.startswith("Merge pull request"):
+        author = (author_aliases.get(commit.author.name, commit.author.name), commit.author.email)
+        lines = commit.message.split('\n', 3)
+        pr = lines[0].split(' ', 4)[3]
+        allprs.add(pr)
+        title = lines[2]
+        ncommits, otherauthors = collect_commits(pr, title, list(commit.parents), author[0])
+        individual_authors.add(author[0])
+        individual_authors.update(otherauthors)
+
+        stats = commit.stats.total
+        item = {
+            'title': title,
+            'pr': pr,
+            'sha': commit.hexsha[:shamin],
+            'ncommits': ncommits,
+            'otherauthors': otherauthors,
+            'insertions': stats['insertions'],
+            'deletions': stats['deletions'],
+            'files': stats['files'],
+            'lines': stats['lines'],
+            }
+        history = per_author_history.get(author, [])
+        history.append(item)
+        per_author_history[author] = history
+
+    if len(commit.parents) == 0:
+        break
+    commit = commit.parents[0]
+
+allauthors = list(per_author_history.keys())
+allauthors.sort(key=lambda x:x[0].lower())
+
+ext_contributors = individual_authors - crdb_folk
+firsttime_contributors = []
+for a in individual_authors:
+    # Find all aliases known for this person
+    aliases = [a]
+    for alias, name in author_aliases.items():
+        if name == a:
+            aliases.append(alias)
+    # Collect the history for every alias
+    hist = b''
+    for al in aliases:
+        spin()
+        c = subprocess.run(["git", "log", "--author=%s" % al, options.from_commit, '-n', '1'], stdout=subprocess.PIPE, check=True)
+        hist += c.stdout
+    if len(hist) == 0:
+        # No commit from that author older than the first commit
+        # selected, so that's a first-time author.
+        firsttime_contributors.append(a)
+
+print("\b\n", file=sys.stderr)
+sys.stderr.flush()
+
+### Presentation of results ###
+
+## Print the release notes.
+
+# Start with known sections.
+
+print("---")
+print("title: What&#39;s New in ", end='')
+sys.stdout.flush()
+os.system('git describe --tags ' + options.until_commit)
+print("toc: false")
+print("summary: Additions and changes in CockroachDB version ", end='')
+sys.stdout.flush()
+os.system('git describe --tags ' + options.until_commit)
+print("   since version ", end='')
+sys.stdout.flush()
+os.system('git describe --tags ' + options.from_commit)
+print("---")
+print()
+today = datetime.datetime.today()
+print("## %s %d, %d" % (today.strftime("%B"), today.day, today.year))
+print()
+
+print("This release includes %d merged PRs by %s author%s." %
+      (len(allprs),
+       len(individual_authors), (len(individual_authors) != 1 and "s" or ""),
+      ))
+
+ext_contributors = individual_authors - crdb_folk
+if len(ext_contributors) > 0:
+    ext_contributors = sorted(ext_contributors)
+    print("We would like to thank the following contributors from the CockroachDB community:")
+    print()
+    for a in ext_contributors:
+        print("-", a)
+    print()
+# Note: CRDB folk can be first-time contributors too, so
+# not part of the if ext_contributors above.
+if len(firsttime_contributors) > 0:
+    print("With special thanks to first-time contributors ", end='')
+    for i, n in enumerate(firsttime_contributors):
+        if i > 0 and i < len(firsttime_contributors)-1:
+            print(', ', end='')
+        elif i > 0:
+            print(' and ', end='')
+        print(n, end='')
+    print('.')
+print()
+
+seenshas = set()
+seenprs = set()
+def renderlinks(item):
+    ret = '[%(pr)s][%(pr)s]' % item
+    seenprs.add(item['pr'])
+    if not hideshas:
+        ret += ' [%(sha)s][%(sha)s]' % item
+        seenshas.add(item['sha'])
+    return ret
+
+for sec in relnote_sec_order:
+    r = release_notes.get(sec, None)
+    if r is None:
+        # No change in this section, nothing to print.
+        continue
+    sectitle = relnotetitles[sec]
+    print("###", sectitle)
+    print()
+
+    for item in r:
+        print("-", item['note'].replace('\n', '\n  '), renderlinks(item))
+
+    print()
+
+extrasec = set()
+for sec in release_notes:
+    if sec in relnote_sec_order:
+        # already handled above, don't do anything.
+        continue
+    extrasec.add(sec)
+if len(extrasec) > 0 or len(missing_release_notes) > 0:
+    print("### Miscellaneous")
+    print()
+if len(extrasec) > 0:
+    extrasec_sorted = sorted(list(extrasec))
+    for extrasec in extrasec_sorted:
+        print("#### %s" % extrasec.title())
+        print()
+        for item in release_notes[extrasec]:
+            print("-", item['note'].replace('\n', '\n  '), renderlinks(item))
+        print()
+
+if len(missing_release_notes) > 0:
+    print("#### Changes without release note annotation")
+    print()
+    for item in missing_release_notes:
+        author = item['author'][0]
+        author = author_aliases.get(author, author)
+        print("- [%(pr)s][%(pr)s] [%(sha)s][%(sha)s] %(prtitle)s" % item, "(%s)" % author)
+        seenshas.add(item['sha'])
+        seenprs.add(item['pr'])
+    print()
+
+## Print the per-author contribution list.
+print()
+print("### PRs merged by committer")
+print()
+if not hideshas:
+    fmt = "  - [%(pr)-6s][%(pr)s] [%(sha)s][%(sha)s] (+%(insertions)4d -%(deletions)4d ~%(lines)4d/%(files)2d) %(title)s"
+else:
+    fmt = "  - [%(pr)-6s][%(pr)s] (+%(insertions)4d -%(deletions)4d ~%(lines)4d/%(files)2d) %(title)s"
+
+for author in allauthors:
+    items = per_author_history[author]
+    print("- %s:" % author_aliases.get(author[0], author[0]))
+    items.sort(key=lambda x:x[sortkey],reverse=not revsort)
+    for item in items:
+        print(fmt % item, end='')
+        if not hideshas:
+            seenshas.add(item['sha'])
+        seenprs.add(item['pr'])
+
+        ncommits, otherauthors = item['ncommits'], item['otherauthors']
+        if ncommits > 1 or len(otherauthors) > 0:
+            print(" (", end='')
+            if ncommits > 1:
+                print("%d commits" % ncommits, end='')
+            if len(otherauthors)> 0:
+                if ncommits > 1:
+                    print(" ", end='')
+                print("w/", ', '.join(otherauthors), end='')
+            print(")", end='')
+        print()
+    print()
+print()
+
+# Link the PRs and SHAs
+for pr in sorted(list(seenprs)):
+    print("[%s]: https://github.com/cockroachdb/cockroach/pull/%s" % (pr, pr[1:]))
+for sha in seenshas:
+    print("[%s]: https://github.com/cockroachdb/cockroach/commit/%s" % (sha, sha))
+print()


### PR DESCRIPTION
Example use: 
```
$ python scripts/release-notes.py --from 64065087f53c59d1e23d32be6a8f2352b1abfa1c >example-notes.md
```

Resulting file `example-notes.md`:

## January 19, 2018

This release includes 78 merged PRs by 30 authors.
We would like to thank the following contributors from the CockroachDB community:

- Dmitry Saveliev
- Jincheng Li
- Yang Yuting
- 何羿宏

With special thanks to first-time contributors Jincheng Li, Yang Yuting, Paul Bardea, Abhishek Madan, Nathaniel Stewart and Andrew Kimball.


### General Changes

- added a mechanism to recompute range
  stats on demand. [#21345]
- CockroachDB now uses gRPC version 1.9.1 [#21398]

### Enterprise Changes

- make RESTORE cleanup resilient to
  external storage failure or removal
  
  Fixes #20261 [#21559]

### SQL Language Changes

- the output of EXPLAIN is enhanced when
  applied to statements containing scalar sub-queries. [#21305]
- Support ARRAY_AGG aggregation in distsql. [#21475]
- ON UPDATE CASCADE foreign key constraints are fully supported [#21329]
- Remove limit on transaction keys. There was
  formerly a limit of 100,000 keys. [#21078]
- improved error message when a column
  reference is ambiguous. [#21361]

### Admin UI Changes

- The command queue debug page now displays errors correctly.
  
  Fixes #21238. [#21529]
- Bug fix for the Problem Ranges debug page to again display
  all the problem ranges for the cluster.
  
  Fixes #21236. [#21522]

### Bug Fixes

- fixed incorrect columns and properties in
  EXPLAIN (VERBOSE) output. [#21527]
- fix a problem that could cause spurious GC
  activity, in particular after dropping a table. [#21407]
- Fix incorrect logic in lease rebalancing that
  prevented leases from being transferred [#21430]
- INSERT/UPDATE/DELETE ... RETURNING  ...
  statments used with the "statement data source" syntax (e.g. SELECT *
  FROM  [INSERT INTO ... RETURNING ...]) no longer ever commit the
  transaction, causing errors for the higher-level query. [#20847]

### Performance Improvements

- do less work during key decode [#21498]
- Speed up the performance of
  low-level delete operations. [#21507]
- small performance improvement to
  all scans that need to look at non-indexed columns. [#21459]
- Improve the performance of scans
  which encounter a large number of versions per key. [#21438]
- Improve low-level reverse scan
  throughput by up almost 4x when there are a few versions per key. [#21438]
- Queries on tables with many
  columns are more efficient. [#21450]
- Queries that only need to read
  part of a table with many columns are more efficient. [#21450]
- Improve low-level scan
  performance by 15-20% by disabling redundant checksums. [#21395]
- Reimplement low-level scan
  operations in C++, doubling performance for scans of contiguous
  keys/rows. [#21395]

### Build Changes

- The build system now enforces a minimum
  version of Go, rather than enforcing a specific version of Go. Since the
  Go 1.x series has strict backwards compatibility guarantees, the old
  rule was unnecessarily restrictive. [#21426]

### Miscellaneous

#### Missing Category

- disallow non-transactional bulk IO statements inside transactions. [#21488]
- ALTER TABLE SCATTER now randomizes the locations of the
  leases for all ranges in the referenced table or index. [#21431]

#### Changes without release note annotation

- [#21547] [900291e48] sql: replace MakeJSON in Concat() and AsJSON() (何羿宏)
- [#21511] [187f8e662] opt: Separate data driven testing framework from tests (Andrew Kimball)
- [#21542] [9e25aeb8a] opt: Rename Expr to ExprView. (Andrew Kimball)
- [#20915] [4f33f0239] ui: remove spider from no results job view
 (Diana Hsieh)
- [#21513] [f8cb074e2] Update readme (Nathaniel Stewart)
- [#21513] [7b6e775b9] Update readme (Nathaniel Stewart)
- [#21513] [b74ce84bc] Update readme (Nathaniel Stewart)
- [#21132] [33d1f2749] sql: add json_agg (何羿宏)
- [#21478] [2d4883c12] opt: Integrate initial versions of v4 expr, memo, and factory (Andrew Kimball)
- [#21497] [d2e5fd351] libroach: add missing destructor (in parent class) (Raphael 'kena' Poss)
- [#21019] [1b136eb86] sql: support builtin json_build_object (Jincheng Li)
- [#21404] [20aa6386e] sqlccl: include http's configured custom CA setting when using custom s3 endpoints (David Taylor)
- [#21335] [cb1d819c5] sql: add json_strip_nulls (何羿宏)
- [#21457] [ec91158ed] opt: execution for selectOp (Radu Berinde)
- [#21395] [1d487c28f] storage/engine: reimplement MVCC{Scan,Get} in C++ (Peter Mattis)
- [#21395] [6193f3f9c] storage/engine: reimplement MVCC{Scan,Get} in C++ (Peter Mattis)
- [#21395] [563c01069] storage/engine: reimplement MVCC{Scan,Get} in C++ (Peter Mattis)


### PRs merged by committer

- Abhishek Madan:
  - [#21377] (+  71 -   8 ~  79/ 3) sql: Add overloads to ARRAY_AGG
  - [#21556] (+  33 -   0 ~  33/ 1) distsql: Implement diagramCellType for AlgebraicSetOpSpec
  - [#21475] (+  22 -   8 ~  30/ 5) distsql: Add ARRAY_AGG support

- Alex Robinson:
  - [#21430] (+ 102 -  21 ~ 123/ 3) storage: fix StoreList.filter to validate constraints properly
  - [#21431] (+ 171 - 121 ~ 292/ 6) *: Randomize lease placement in ALTER TABLE SCATTER (2 commits)

- Andrei Matei:
  - [#21532] (+   0 -   2 ~   2/ 1) sql: remove debug logging
  - [#21441] (+  76 -  56 ~ 132/ 6) sql: more directly init the timestamps in EvalCtx
  - [#21428] (+   1 -   0 ~   1/ 1) sql: make sure planner.autocommit gets reset
  - [#21486] (+ 242 - 119 ~ 361/22) sql: final assault on planner.session (6 commits)
  - [#20847] (+ 188 -  79 ~ 267/13) sql: don't allow StatementSources to commit the txn  (3 commits)
  - [#21408] (+ 951 - 744 ~1695/32) sql,pgwire: rework the implementation of the Copy-in pgwire subprotocol (2 commits)

- Andrew Couch:
  - [#21524] (+  10 -   6 ~  16/ 2) ui: ensure tooltips have spaces before all inline elements

- Andrew Kimball:
  - [#21511] (+ 265 - 221 ~ 486/ 2) opt: Separate data driven testing framework from tests
  - [#21542] (+ 451 - 449 ~ 900/ 6) opt: Rename Expr to ExprView.

- Andrew Kimball:
  - [#21478] (+7338 -   1 ~7339/17) opt: Integrate initial versions of v4 expr, memo, and factory

- Ben Darnell:
  - [#21484] (+   0 - 103 ~ 103/ 1) internal/client: Remove TestCommonMethods
  - [#21398] (+ 127 - 120 ~ 247/16) build: Update grpc to 1.9.1

- Bram Gruneir:
  - [#21529] (+ 133 - 104 ~ 237/ 8) ui: a number of small debug page fixes (5 commits)
  - [#21522] (+  17 -  14 ~  31/ 3) ui: Fixes the Problem Ranges Page to again display all node's problem ranges
  - [#21481] (+  39 -  74 ~ 113/ 9) sql: stop plumbing the bytes monitor down into the cascader
  - [#21329] (+2059 - 461 ~2520/18) sql: add support for ON UPDATE CASCADE for foreign key references
  - [#21554] (+  83 -   5 ~  88/ 3) sql/sqlbase: Fix the primary index span lookup for cascading

- David Taylor:
  - [#21404] (+  22 -   8 ~  30/ 1) sqlccl: include http's configured custom CA setting when using custom s3 endpoints
  - [#21488] (+ 106 -  34 ~ 140/ 7) sqlccl: disallow bulk IO statements in txn

- Diana Hsieh:
  - [#20915] (+  25 -  31 ~  56/ 3) ui: remove spider from no results job view

- Dmitry Saveliev:
  - [#21427] (+ 270 -  18 ~ 288/ 4) cli: add internal tables to expose status server info about the cluster

- Jordan Lewis:
  - [#21555] (+ 121 - 124 ~ 245/16) sqlbase: rename multirowfetcher to rowfetcher (2 commits)
  - [#21567] (+ 165 - 165 ~ 330/ 2) sqlbase: rename mrf to rf in rowfetcher
  - [#21450] (+ 101 -  47 ~ 148/ 3) sqlbase: multirowfetcher stops decoding a row when it doesn't need more data (4 commits)
  - [#21459] (+  15 -  10 ~  25/ 1) sqlbase: don't decode column family if unnecessary
  - [#21439] (+  70 -  17 ~  87/10) sqlbase: a few more optimizations on the fetch path (4 commits)
  - [#21422] (+  53 -  26 ~  79/ 5) sqlbase,encoding: a few small optimizations (4 commits)
  - [#21498] (+  44 -  18 ~  62/ 3) sql: don't decode the first key TableID/IndexID
  - [#21436] (+   4 -   4 ~   8/ 1) sql: deflake show_trace_replica logic test
  - [#21361] (+  32 -   8 ~  40/ 3) sql: better error message for ambiguous columns

- Justin Jaffray:
  - [#21019] (+ 128 -   0 ~ 128/ 3) sql: support builtin json_build_object (w/ Jincheng Li)
  - [#21547] (+  36 -   9 ~  45/ 3) sql: replace MakeJSON in Concat() and AsJSON() (w/ 何羿宏)
  - [#21519] (+ 102 -  38 ~ 140/ 2) sql: refactor check constraint validation
  - [#21335] (+ 296 -   0 ~ 296/ 6) sql: add json_strip_nulls (w/ 何羿宏)
  - [#21132] (+ 144 -   2 ~ 146/ 8) sql: add json_agg (w/ 何羿宏)

- Marc Berhault:
  - [#21469] (+   7 -   1 ~   8/ 2) libroach: add missing destructor.

- Matt Jibson:
  - [#21559] (+  15 -  16 ~  31/ 3) sqlccl: remove external storage dependency on RESTORE cleanup

- Matt Tracy:
  - [#21405] (+ 174 - 221 ~ 395/ 1) ts: Iterator Test Improvements.
  - [#21449] (+ 230 - 161 ~ 391/ 2) ts: Interpolation Max Distance (2 commits)
  - [#21491] (+ 144 -  30 ~ 174/ 4) ts: Interpolation Limit

- Nathan VanBenschoten:
  - [#21493] (+  39 -  11 ~  50/ 3) storage: handle lease inversion due to non-commutative lease equivalency
  - [#21533] (+  34 -   6 ~  40/ 2) retry: allow immediate retry from NextCh when isReset is true
  - [#21473] (+ 297 -  32 ~ 329/ 4) gossip: create SystemConfigDeltaFilter, use in SchemaChangeManager and LeaseManager (2 commits)

- Nathaniel Stewart:
  - [#21513] (+  16 -  83 ~  99/ 2) Update readme (3 commits)

- Nikhil Benesch:
  - [#21448] (+   7 -   1 ~   8/ 1) storage: suppress consistency logspam when quiescing
  - [#21392] (+  24 -  28 ~  52/ 1) sqlccl: speed up partitioning tests
  - [#21557] (+  27 -  25 ~  52/ 9) libroach,storage: make interval bounds on time-bound iterators sane
  - [#21426] (+  43 -  11 ~  54/ 3) build: only require a minimum version of Go

- Paul Bardea:
  - [#21520] (+   4 -   3 ~   7/ 1) docs: link to pprof wiki page from contributing.md
  - [#21479] (+ 361 -  26 ~ 387/ 7) distsql: add support for semijoins in HashJoiner

- Pete Vilter:
  - [#21517] (+   6 -   4 ~  10/ 1) ui: tweak capacity tooltip (spaces were missing)
  - [#21568] (+  13 -   0 ~  13/ 2) ui: teach event list about sequence event types
  - [#21541] (+ 134 -   6 ~ 140/ 6) sql: sequences: add setval(name, value, is_called) builtin
  - [#21540] (+ 153 -   8 ~ 161/ 9) sql: allow SELECTing from a sequence

- Peter Mattis:
  - [#21395] (+1108 - 119 ~1227/11) storage/engine: reimplement MVCC{Scan,Get} in C++ (5 commits)
  - [#21507] (+  61 -  25 ~  86/ 2) storage/engine: reimplement MVCCDeleteRange in terms of MVCCScan
  - [#21438] (+ 185 -  58 ~ 243/ 2) libroach: optimize MVCC reverse scans (3 commits)

- Radu Berinde:
  - [#21512] (+ 354 -   0 ~ 354/ 2) util: data structure for small int-to-int mappings
  - [#21527] (+1810 -1810 ~3620/29) sql: fix EXPLAIN (VERBOSE) output
  - [#21457] (+ 400 - 220 ~ 620/16) opt: execution for selectOp (5 commits)

- Raphael 'kena' Poss:
  - [#21118] (+  76 -  49 ~ 125/ 1) sql: reduce allocations in show_create.go (w/ Yang Yuting)
  - [#21472] (+   1 -   1 ~   2/ 1) sql: minor fix to show_create.go
  - [#21305] (+ 741 - 623 ~1364/30) sql: improve the handling of subqueries (10 commits)
  - [#21497] (+  22 -  16 ~  38/ 2) libroach: add missing destructor (in parent class) (3 commits)

- Rebecca Taft:
  - [#21352] (+ 525 - 129 ~ 654/11) opt: Add support for building filters in the `Expr` tree

- Spencer Kimball:
  - [#21078] (+ 930 - 344 ~1274/36) storage, kv: remove the max intent limit

- Tobias Schottdorf:
  - [#21345] (+ 711 - 135 ~ 846/23) storage: recompute and adjust stats via consistency checker (2 commits)
  - [#21407] (+ 980 - 417 ~1397/ 4) storage: fix (the semantics of) MVCCStats.GCBytesAge
  - [#21466] (+  57 -   0 ~  57/ 6) storage: don't panic on unknown (batch) request

- Vivek Menezes:
  - [#21550] (+  17 -   7 ~  24/ 2) util/mon: improve memory budget exceeded error message
  - [#21411] (+   9 -   0 ~   9/ 1) ui: add graphs for clock offset mean and stddev
  - [#21418] (+   3 -   2 ~   5/ 1) sql: fix SCRUB double call to RowContainer.Close()
  - [#21546] (+  27 -  30 ~  57/ 3) sql: do not pass testing.T to RunScrub()


[#20847]: https://github.com/cockroachdb/cockroach/pull/20847
[#20915]: https://github.com/cockroachdb/cockroach/pull/20915
[#21019]: https://github.com/cockroachdb/cockroach/pull/21019
[#21078]: https://github.com/cockroachdb/cockroach/pull/21078
[#21118]: https://github.com/cockroachdb/cockroach/pull/21118
[#21132]: https://github.com/cockroachdb/cockroach/pull/21132
[#21305]: https://github.com/cockroachdb/cockroach/pull/21305
[#21329]: https://github.com/cockroachdb/cockroach/pull/21329
[#21335]: https://github.com/cockroachdb/cockroach/pull/21335
[#21345]: https://github.com/cockroachdb/cockroach/pull/21345
[#21352]: https://github.com/cockroachdb/cockroach/pull/21352
[#21361]: https://github.com/cockroachdb/cockroach/pull/21361
[#21377]: https://github.com/cockroachdb/cockroach/pull/21377
[#21392]: https://github.com/cockroachdb/cockroach/pull/21392
[#21395]: https://github.com/cockroachdb/cockroach/pull/21395
[#21398]: https://github.com/cockroachdb/cockroach/pull/21398
[#21404]: https://github.com/cockroachdb/cockroach/pull/21404
[#21405]: https://github.com/cockroachdb/cockroach/pull/21405
[#21407]: https://github.com/cockroachdb/cockroach/pull/21407
[#21408]: https://github.com/cockroachdb/cockroach/pull/21408
[#21411]: https://github.com/cockroachdb/cockroach/pull/21411
[#21418]: https://github.com/cockroachdb/cockroach/pull/21418
[#21422]: https://github.com/cockroachdb/cockroach/pull/21422
[#21426]: https://github.com/cockroachdb/cockroach/pull/21426
[#21427]: https://github.com/cockroachdb/cockroach/pull/21427
[#21428]: https://github.com/cockroachdb/cockroach/pull/21428
[#21430]: https://github.com/cockroachdb/cockroach/pull/21430
[#21431]: https://github.com/cockroachdb/cockroach/pull/21431
[#21436]: https://github.com/cockroachdb/cockroach/pull/21436
[#21438]: https://github.com/cockroachdb/cockroach/pull/21438
[#21439]: https://github.com/cockroachdb/cockroach/pull/21439
[#21441]: https://github.com/cockroachdb/cockroach/pull/21441
[#21448]: https://github.com/cockroachdb/cockroach/pull/21448
[#21449]: https://github.com/cockroachdb/cockroach/pull/21449
[#21450]: https://github.com/cockroachdb/cockroach/pull/21450
[#21457]: https://github.com/cockroachdb/cockroach/pull/21457
[#21459]: https://github.com/cockroachdb/cockroach/pull/21459
[#21466]: https://github.com/cockroachdb/cockroach/pull/21466
[#21469]: https://github.com/cockroachdb/cockroach/pull/21469
[#21472]: https://github.com/cockroachdb/cockroach/pull/21472
[#21473]: https://github.com/cockroachdb/cockroach/pull/21473
[#21475]: https://github.com/cockroachdb/cockroach/pull/21475
[#21478]: https://github.com/cockroachdb/cockroach/pull/21478
[#21479]: https://github.com/cockroachdb/cockroach/pull/21479
[#21481]: https://github.com/cockroachdb/cockroach/pull/21481
[#21484]: https://github.com/cockroachdb/cockroach/pull/21484
[#21486]: https://github.com/cockroachdb/cockroach/pull/21486
[#21488]: https://github.com/cockroachdb/cockroach/pull/21488
[#21491]: https://github.com/cockroachdb/cockroach/pull/21491
[#21493]: https://github.com/cockroachdb/cockroach/pull/21493
[#21497]: https://github.com/cockroachdb/cockroach/pull/21497
[#21498]: https://github.com/cockroachdb/cockroach/pull/21498
[#21507]: https://github.com/cockroachdb/cockroach/pull/21507
[#21511]: https://github.com/cockroachdb/cockroach/pull/21511
[#21512]: https://github.com/cockroachdb/cockroach/pull/21512
[#21513]: https://github.com/cockroachdb/cockroach/pull/21513
[#21517]: https://github.com/cockroachdb/cockroach/pull/21517
[#21519]: https://github.com/cockroachdb/cockroach/pull/21519
[#21520]: https://github.com/cockroachdb/cockroach/pull/21520
[#21522]: https://github.com/cockroachdb/cockroach/pull/21522
[#21524]: https://github.com/cockroachdb/cockroach/pull/21524
[#21527]: https://github.com/cockroachdb/cockroach/pull/21527
[#21529]: https://github.com/cockroachdb/cockroach/pull/21529
[#21532]: https://github.com/cockroachdb/cockroach/pull/21532
[#21533]: https://github.com/cockroachdb/cockroach/pull/21533
[#21540]: https://github.com/cockroachdb/cockroach/pull/21540
[#21541]: https://github.com/cockroachdb/cockroach/pull/21541
[#21542]: https://github.com/cockroachdb/cockroach/pull/21542
[#21546]: https://github.com/cockroachdb/cockroach/pull/21546
[#21547]: https://github.com/cockroachdb/cockroach/pull/21547
[#21550]: https://github.com/cockroachdb/cockroach/pull/21550
[#21554]: https://github.com/cockroachdb/cockroach/pull/21554
[#21555]: https://github.com/cockroachdb/cockroach/pull/21555
[#21556]: https://github.com/cockroachdb/cockroach/pull/21556
[#21557]: https://github.com/cockroachdb/cockroach/pull/21557
[#21559]: https://github.com/cockroachdb/cockroach/pull/21559
[#21567]: https://github.com/cockroachdb/cockroach/pull/21567
[#21568]: https://github.com/cockroachdb/cockroach/pull/21568
[b74ce84bc]: https://github.com/cockroachdb/cockroach/commit/b74ce84bc
[ec91158ed]: https://github.com/cockroachdb/cockroach/commit/ec91158ed
[900291e48]: https://github.com/cockroachdb/cockroach/commit/900291e48
[cb1d819c5]: https://github.com/cockroachdb/cockroach/commit/cb1d819c5
[1b136eb86]: https://github.com/cockroachdb/cockroach/commit/1b136eb86
[6193f3f9c]: https://github.com/cockroachdb/cockroach/commit/6193f3f9c
[187f8e662]: https://github.com/cockroachdb/cockroach/commit/187f8e662
[33d1f2749]: https://github.com/cockroachdb/cockroach/commit/33d1f2749
[563c01069]: https://github.com/cockroachdb/cockroach/commit/563c01069
[2d4883c12]: https://github.com/cockroachdb/cockroach/commit/2d4883c12
[9e25aeb8a]: https://github.com/cockroachdb/cockroach/commit/9e25aeb8a
[7b6e775b9]: https://github.com/cockroachdb/cockroach/commit/7b6e775b9
[20aa6386e]: https://github.com/cockroachdb/cockroach/commit/20aa6386e
[1d487c28f]: https://github.com/cockroachdb/cockroach/commit/1d487c28f
[f8cb074e2]: https://github.com/cockroachdb/cockroach/commit/f8cb074e2
[4f33f0239]: https://github.com/cockroachdb/cockroach/commit/4f33f0239
[d2e5fd351]: https://github.com/cockroachdb/cockroach/commit/d2e5fd351

