### PR TITLE
ui: tweak capacity tooltip (spaces were missing)

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -84,18 +84,20 @@ export default function (props: GraphDashboardProps) {
             <dt>Capacity</dt>
             <dd>
               Total disk space available {tooltipSelection} to CockroachDB.
-                <em>
+              <em>
                 Control this value per node with the
-                  <code>
+                {" "}
+                <code>
                   <a
                     href={docsURL("start-a-node.html#flags")}
                     target="_blank"
                   >
                     --store
-                    </a>
+                  </a>
                 </code>
+                {" "}
                 flag.
-                </em>
+              </em>
             </dd>
             <dt>Available</dt>
             <dd>Free disk space available {tooltipSelection} to CockroachDB.</dd>


### PR DESCRIPTION
Before:
![screen shot 2018-01-17 at 12 52 03 pm](https://user-images.githubusercontent.com/7341/35058341-9c18a450-fb85-11e7-9eb5-edd9549c7fb1.png)

After:
![screen shot 2018-01-17 at 12 53 27 pm](https://user-images.githubusercontent.com/7341/35058348-a34916a6-fb85-11e7-9d1b-ccb6d4842475.png)

