### PR TITLE
sql: refactor check constraint validation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -197,3 +197,32 @@ CREATE TABLE t6 (x INT CHECK (x = $1))
 
 statement error CHECK expression .* may not contain variable sub-expressions
 CREATE TABLE t6 (x INT CHECK (x = (SELECT 1)))
+
+# Check auto-generated constraint names.
+
+statement ok
+CREATE TABLE t7 (
+  x INT,
+  y INT,
+  z INT,
+  CHECK (x > 0),
+  CHECK (x + y > 0),
+  CHECK (y + z > 0),
+  CHECK (y + z = 0),
+  CONSTRAINT named_constraint CHECK (z = 1)
+)
+
+query TT
+SHOW CREATE TABLE t7
+----
+t7  CREATE TABLE t7 (
+      x INT NULL,
+      y INT NULL,
+      z INT NULL,
+      FAMILY "primary" (x, y, z, rowid),
+      CONSTRAINT check_x CHECK (x > 0),
+      CONSTRAINT check_x_y CHECK ((x + y) > 0),
+      CONSTRAINT check_y_z CHECK ((y + z) > 0),
+      CONSTRAINT check_y_z1 CHECK ((y + z) = 0),
+      CONSTRAINT named_constraint CHECK (z = 1)
+    )


### PR DESCRIPTION
Release note: None.

The logic of replacing vars with dummies for typechecking needs to be
reused for computed columns, so this commit pulls that functionality out
into a new function so that it can be reused.

Worthy of note is that this now requires two traversals of the
expression tree rather than one, because the dummy-replacement has been
decoupled from the name generation.