### PR TITLE
ui: Fixes the Problem Ranges Page to again display all node's problem ranges

### DIFF
--- a/pkg/ui/src/redux/apiReducers.ts
+++ b/pkg/ui/src/redux/apiReducers.ts
@@ -148,9 +148,8 @@ export const queryToID = (req: api.QueryPlanRequestMessage): string =>
 const queryPlanReducerObj = new CachedDataReducer(api.getQueryPlan, "queryPlan");
 export const refreshQueryPlan = queryPlanReducerObj.refresh;
 
-export const problemRangesRequestKey = (
-  req: api.ProblemRangesRequestMessage,
-): string => (_.isEmpty(req.node_id) ? "" : req.node_id.toString());
+export const problemRangesRequestKey = (req: api.ProblemRangesRequestMessage): string =>
+  _.isEmpty(req.node_id) ? "all" : req.node_id;
 
 const problemRangesReducerObj = new KeyedCachedDataReducer(
   api.getProblemRanges,
@@ -162,7 +161,7 @@ const problemRangesReducerObj = new KeyedCachedDataReducer(
 export const refreshProblemRanges = problemRangesReducerObj.refresh;
 
 export const certificatesRequestKey = (req: api.CertificatesRequestMessage): string =>
-  _.isEmpty(req.node_id) ? "" : req.node_id.toString();
+  _.isEmpty(req.node_id) ? "0" : req.node_id;
 
 const certificatesReducerObj = new KeyedCachedDataReducer(
   api.getCertificates,
@@ -184,9 +183,8 @@ const rangeReducerObj = new KeyedCachedDataReducer(
 );
 export const refreshRange = rangeReducerObj.refresh;
 
-export const allocatorRangeRequestKey = (
-  req: api.AllocatorRangeRequestMessage,
-): string => (_.isNil(req.range_id) ? "0" : req.range_id.toString());
+export const allocatorRangeRequestKey = (req: api.AllocatorRangeRequestMessage): string =>
+  _.isNil(req.range_id) ? "0" : req.range_id.toString();
 
 const allocatorRangeReducerObj = new KeyedCachedDataReducer(
   api.getAllocatorRange,

--- a/pkg/ui/src/redux/cachedDataReducer.ts
+++ b/pkg/ui/src/redux/cachedDataReducer.ts
@@ -224,7 +224,8 @@ export class KeyedCachedDataReducer<TRequest, TResponseMessage> {
    */
   constructor(
     protected apiEndpoint: (req: TRequest) => Promise<TResponseMessage>,
-    public actionNamespace: string, private requestToID: (req: TRequest) => string,
+    public actionNamespace: string,
+    private requestToID: (req: TRequest) => string,
     protected invalidationPeriod?: moment.Duration,
     protected requestTimeout?: moment.Duration,
   ) {

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 import { Link, RouterState } from "react-router";
 
 import * as protos from "src/js/protos";
-import { refreshProblemRanges } from "src/redux/apiReducers";
+import { problemRangesRequestKey, refreshProblemRanges } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { nodeIDAttr } from "src/util/constants";
 import { FixLong } from "src/util/fixLong";
@@ -55,6 +55,12 @@ function ProblemRangeList(props: {
   );
 }
 
+function problemRangeRequest(props: ProblemRangesProps) {
+  return new protos.cockroach.server.serverpb.ProblemRangesRequest({
+    node_id: props.params[nodeIDAttr],
+  });
+}
+
 /**
  * Renders the Problem Ranges page.
  *
@@ -64,9 +70,7 @@ function ProblemRangeList(props: {
  */
 class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
   refresh(props = this.props) {
-    props.refreshProblemRanges(new protos.cockroach.server.serverpb.ProblemRangesRequest({
-      node_id: props.params[nodeIDAttr],
-    }));
+    props.refreshProblemRanges(problemRangeRequest(props));
   }
 
   componentWillMount() {
@@ -160,9 +164,9 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
 
 export default connect(
   (state: AdminUIState, props: ProblemRangesProps) => {
-    const nodeID = props.params[nodeIDAttr];
+    const nodeIDKey = problemRangesRequestKey(problemRangeRequest(props));
     return {
-      problemRanges: state.cachedData.problemRanges[nodeID] && state.cachedData.problemRanges[nodeID].data,
+      problemRanges: state.cachedData.problemRanges[nodeIDKey] && state.cachedData.problemRanges[nodeIDKey].data,
     };
   },
   {


### PR DESCRIPTION
When the problem ranges page was updated in
284315a6c9c7859297fc9a41b4baca0fb8c5b17e to use a keyed cached value for each
request type (all nodes or an individual single node) instead of a single cached
value for all requests, that was causing the page to not always reload, had a
bug. Results for all nodes are stored using an empty string key, but
the lookup in ProblemRanges' component the was using an `undefined` key instead.
So even if the data was correctly returned it wouldn't update the display.

Release note (ui): Bug fix for the Problem Ranges debug page to again display
all the problem ranges for the cluster.

Fixes #21236.