### PR TITLE
ui: ensure tooltips have spaces before all inline elements

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -56,8 +56,9 @@ export default function (props: GraphDashboardProps) {
       title="Replicas per Node"
       tooltip={(
         <div>
-          The number of range replicas stored on this node.&nbsp;
-            <em>Ranges are subsets of your data, which are replicated to ensure survivability.</em>
+          The number of range replicas stored on this node.
+          {" "}
+          <em>Ranges are subsets of your data, which are replicated to ensure survivability.</em>
         </div>
       )}
     >
@@ -84,6 +85,7 @@ export default function (props: GraphDashboardProps) {
             <dt>Capacity</dt>
             <dd>
               Total disk space available {tooltipSelection} to CockroachDB.
+              {" "}
               <em>
                 Control this value per node with the
                 {" "}

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -82,8 +82,9 @@ export default function (props: GraphDashboardProps) {
       title="Service Latency: SQL, 99th percentile"
       tooltip={(
         <div>
-          Over the last minute, this node executed 99% of queries within this time.&nbsp;
-            <em>This time does not include network latency between the node and client.</em>
+          Over the last minute, this node executed 99% of queries within this time.
+          {" "}
+          <em>This time does not include network latency between the node and client.</em>
         </div>
       )}
     >
@@ -106,8 +107,9 @@ export default function (props: GraphDashboardProps) {
       title="Service Latency: SQL, 90th percentile"
       tooltip={(
         <div>
-          Over the last minute, this node executed 90% of queries within this time.&nbsp;
-            <em>This time does not include network latency between the node and client.</em>
+          Over the last minute, this node executed 90% of queries within this time.
+          {" "}
+          <em>This time does not include network latency between the node and client.</em>
         </div>
       )}
     >


### PR DESCRIPTION
Wrapping up something noticed on #21517