### PR TITLE
sql: fix EXPLAIN (VERBOSE) output

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -263,11 +263,11 @@ func (p *planner) populateExplain(
 				emptyString,                          // Ordering
 			}
 			if entry.plan != nil {
-				cols := planColumns(plan)
+				cols := planColumns(entry.plan)
 				// Columns metadata.
 				row[5] = tree.NewDString(formatColumns(cols, e.showTypes))
 				// Ordering metadata.
-				row[6] = tree.NewDString(planPhysicalProps(plan).AsString(cols))
+				row[6] = tree.NewDString(planPhysicalProps(entry.plan).AsString(cols))
 			}
 		}
 		if _, err := v.rows.AddRow(ctx, row); err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -293,15 +293,15 @@ SELECT COUNT(*), s FROM kv GROUP BY UPPER(s)
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
-group           0  group   ·            ·                      (count, "k + v")  ·
- │              0  ·       aggregate 0  count_rows()           ·                 ·
- │              0  ·       aggregate 1  test.kv.k + test.kv.v  ·                 ·
- │              0  ·       group by     @1-@1                  ·                 ·
- └── render     1  render  ·            ·                      (count, "k + v")  ·
-      │         1  ·       render 0     test.kv.k + test.kv.v  ·                 ·
-      └── scan  2  scan    ·            ·                      (count, "k + v")  ·
-·               2  ·       table        kv@primary             ·                 ·
-·               2  ·       spans        ALL                    ·                 ·
+group           0  group   ·            ·                      (count, "k + v")                ·
+ │              0  ·       aggregate 0  count_rows()           ·                               ·
+ │              0  ·       aggregate 1  test.kv.k + test.kv.v  ·                               ·
+ │              0  ·       group by     @1-@1                  ·                               ·
+ └── render     1  render  ·            ·                      ("k + v")                       ·
+      │         1  ·       render 0     test.kv.k + test.kv.v  ·                               ·
+      └── scan  2  scan    ·            ·                      (k, v, w[omitted], s[omitted])  k!=NULL; key(k)
+·               2  ·       table        kv@primary             ·                               ·
+·               2  ·       spans        ALL                    ·                               ·
 
 query II rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k+v
@@ -318,20 +318,20 @@ SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
-render               0  render  ·            ·             (count, "k + v")  ·
- │                   0  ·       render 0     count_rows    ·                 ·
- │                   0  ·       render 1     k + v         ·                 ·
- └── group           1  group   ·            ·             (count, "k + v")  ·
-      │              1  ·       aggregate 0  count_rows()  ·                 ·
-      │              1  ·       aggregate 1  test.kv.k     ·                 ·
-      │              1  ·       aggregate 2  test.kv.v     ·                 ·
-      │              1  ·       group by     @1-@2         ·                 ·
-      └── render     2  render  ·            ·             (count, "k + v")  ·
-           │         2  ·       render 0     test.kv.k     ·                 ·
-           │         2  ·       render 1     test.kv.v     ·                 ·
-           └── scan  3  scan    ·            ·             (count, "k + v")  ·
-·                    3  ·       table        kv@primary    ·                 ·
-·                    3  ·       spans        ALL           ·                 ·
+render               0  render  ·            ·             (count, "k + v")                ·
+ │                   0  ·       render 0     count_rows    ·                               ·
+ │                   0  ·       render 1     k + v         ·                               ·
+ └── group           1  group   ·            ·             (count_rows, k, v)              ·
+      │              1  ·       aggregate 0  count_rows()  ·                               ·
+      │              1  ·       aggregate 1  test.kv.k     ·                               ·
+      │              1  ·       aggregate 2  test.kv.v     ·                               ·
+      │              1  ·       group by     @1-@2         ·                               ·
+      └── render     2  render  ·            ·             (k, v)                          k!=NULL; key(k)
+           │         2  ·       render 0     test.kv.k     ·                               ·
+           │         2  ·       render 1     test.kv.v     ·                               ·
+           └── scan  3  scan    ·            ·             (k, v, w[omitted], s[omitted])  k!=NULL; key(k)
+·                    3  ·       table        kv@primary    ·                               ·
+·                    3  ·       spans        ALL           ·                               ·
 
 query II rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k, v
@@ -1207,15 +1207,15 @@ group           ·            ·
 query TITTTTT
 EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
 ----
-group           0  group   ·            ·                                                               (count int)  ·
- │              0  ·       aggregate 0  (count_rows() FILTER (WHERE ((k)[int] > (5)[int])[bool]))[int]  ·            ·
- │              0  ·       group by     @1-@1                                                           ·            ·
- └── render     1  render  ·            ·                                                               (count int)  ·
-      │         1  ·       render 0     (v)[int]                                                        ·            ·
-      │         1  ·       render 1     ((k)[int] > (5)[int])[bool]                                     ·            ·
-      └── scan  2  scan    ·            ·                                                               (count int)  ·
-·               2  ·       table        filter_test@primary                                             ·            ·
-·               2  ·       spans        ALL                                                             ·            ·
+group           0  group   ·            ·                                                               (count int)                                                    ·
+ │              0  ·       aggregate 0  (count_rows() FILTER (WHERE ((k)[int] > (5)[int])[bool]))[int]  ·                                                              ·
+ │              0  ·       group by     @1-@1                                                           ·                                                              ·
+ └── render     1  render  ·            ·                                                               (v int, "k > 5" bool)                                          ·
+      │         1  ·       render 0     (v)[int]                                                        ·                                                              ·
+      │         1  ·       render 1     ((k)[int] > (5)[int])[bool]                                     ·                                                              ·
+      └── scan  2  scan    ·            ·                                                               (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)  rowid!=NULL; key(rowid)
+·               2  ·       table        filter_test@primary                                             ·                                                              ·
+·               2  ·       spans        ALL                                                             ·                                                              ·
 
 # Tests with * inside GROUP BY.
 query TTT
@@ -1281,14 +1281,14 @@ INSERT INTO opt_test VALUES (1, NULL), (2, 10), (3, NULL), (4, 5)
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
 ----
-group           0  group   ·            ·                     (min)  ·
- │              0  ·       aggregate 0  min(test.opt_test.v)  ·      ·
- └── render     1  render  ·            ·                     (min)  ·
-      │         1  ·       render 0     test.opt_test.v       ·      ·
-      └── scan  2  scan    ·            ·                     (min)  ·
-·               2  ·       table        opt_test@v            ·      ·
-·               2  ·       spans        /!NULL-               ·      ·
-·               2  ·       limit        1                     ·      ·
+group           0  group   ·            ·                     (min)            ·
+ │              0  ·       aggregate 0  min(test.opt_test.v)  ·                ·
+ └── render     1  render  ·            ·                     (v)              v!=NULL; +v
+      │         1  ·       render 0     test.opt_test.v       ·                ·
+      └── scan  2  scan    ·            ·                     (k[omitted], v)  k!=NULL; v!=NULL; key(k,v); +v
+·               2  ·       table        opt_test@v            ·                ·
+·               2  ·       spans        /!NULL-               ·                ·
+·               2  ·       limit        1                     ·                ·
 
 # Without the "v IS NOT NULL" constraint, this result would incorrectly be NULL.
 query I
@@ -1306,14 +1306,14 @@ SELECT MIN(v) FROM opt_test@primary
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
 ----
-group           0  group   ·            ·                     (min)  ·
- │              0  ·       aggregate 0  min(test.opt_test.v)  ·      ·
- └── render     1  render  ·            ·                     (min)  ·
-      │         1  ·       render 0     test.opt_test.v       ·      ·
-      └── scan  2  scan    ·            ·                     (min)  ·
-·               2  ·       table        opt_test@v            ·      ·
-·               2  ·       spans        /!NULL-               ·      ·
-·               2  ·       filter       k != 4                ·      ·
+group           0  group   ·            ·                     (min)   ·
+ │              0  ·       aggregate 0  min(test.opt_test.v)  ·       ·
+ └── render     1  render  ·            ·                     (v)     v!=NULL; +v
+      │         1  ·       render 0     test.opt_test.v       ·       ·
+      └── scan  2  scan    ·            ·                     (k, v)  k!=NULL; v!=NULL; key(k,v); +v
+·               2  ·       table        opt_test@v            ·       ·
+·               2  ·       spans        /!NULL-               ·       ·
+·               2  ·       filter       k != 4                ·       ·
 
 query I
 SELECT MIN(v) FROM opt_test WHERE k <> 4
@@ -1326,25 +1326,25 @@ SELECT MIN(v) FROM opt_test WHERE k <> 4
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
 ----
-group           0  group   ·            ·                         (min)  ·
- │              0  ·       aggregate 0  min(test.opt_test.v + 1)  ·      ·
- └── render     1  render  ·            ·                         (min)  ·
-      │         1  ·       render 0     test.opt_test.v + 1       ·      ·
-      └── scan  2  scan    ·            ·                         (min)  ·
-·               2  ·       table        opt_test@primary          ·      ·
-·               2  ·       spans        -/3/# /5-                 ·      ·
-·               2  ·       filter       (v + 1) IS NOT NULL       ·      ·
+group           0  group   ·            ·                         (min)            ·
+ │              0  ·       aggregate 0  min(test.opt_test.v + 1)  ·                ·
+ └── render     1  render  ·            ·                         ("v + 1")        ·
+      │         1  ·       render 0     test.opt_test.v + 1       ·                ·
+      └── scan  2  scan    ·            ·                         (k[omitted], v)  k!=NULL; v!=NULL; key(k)
+·               2  ·       table        opt_test@primary          ·                ·
+·               2  ·       spans        -/3/# /5-                 ·                ·
+·               2  ·       filter       (v + 1) IS NOT NULL       ·                ·
 
 # Verify that we don't use the optimization if there is a GROUP BY.
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
 ----
-group      0  group  ·            ·                     (min)  ·
- │         0  ·      aggregate 0  min(test.opt_test.v)  ·      ·
- │         0  ·      group by     @1-@1                 ·      ·
- └── scan  1  scan   ·            ·                     (min)  ·
-·          1  ·      table        opt_test@primary      ·      ·
-·          1  ·      spans        ALL                   ·      ·
+group      0  group  ·            ·                     (min)   ·
+ │         0  ·      aggregate 0  min(test.opt_test.v)  ·       ·
+ │         0  ·      group by     @1-@1                 ·       ·
+ └── scan  1  scan   ·            ·                     (k, v)  k!=NULL; key(k)
+·          1  ·      table        opt_test@primary      ·       ·
+·          1  ·      spans        ALL                   ·       ·
 
 query I rowsort
 SELECT MIN(v) FROM opt_test GROUP BY k

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -636,14 +636,14 @@ CREATE TABLE s (k1 INT, k2 INT, v INT, PRIMARY KEY (k1,k2))
 query TITTTTT colnames
 EXPLAIN (METADATA) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
 ----
-Tree                 Level  Type    Field  Description  Columns        Ordering
-split                0      split   ·      ·            (key, pretty)  ·
- └── limit           1      limit   ·      ·            (key, pretty)  ·
-      └── render     2      render  ·      ·            (key, pretty)  ·
-           └── scan  3      scan    ·      ·            (key, pretty)  ·
-·                    3      ·       table  s@primary    ·              ·
-·                    3      ·       spans  ALL          ·              ·
-·                    3      ·       limit  3            ·              ·
+Tree                 Level  Type    Field  Description  Columns               Ordering
+split                0      split   ·      ·            (key, pretty)         ·
+ └── limit           1      limit   ·      ·            (k1, k2)              k1!=NULL; k2!=NULL; key(k1,k2); +k1
+      └── render     2      render  ·      ·            (k1, k2)              k1!=NULL; k2!=NULL; key(k1,k2); +k1
+           └── scan  3      scan    ·      ·            (k1, k2, v[omitted])  k1!=NULL; k2!=NULL; key(k1,k2); +k1
+·                    3      ·       table  s@primary    ·                     ·
+·                    3      ·       spans  ALL          ·                     ·
+·                    3      ·       limit  3            ·                     ·
 
 # Verify that impure defaults are evaluated separately on each row
 # (#14352)

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -207,10 +207,10 @@ SELECT COUNT(*) FROM (SELECT DISTINCT y FROM xyz)
 query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT x FROM xyz
 ----
-render     0  render  ·      ·            (x)  x!=NULL; key(x)
- └── scan  1  scan    ·      ·            (x)  x!=NULL; key(x)
-·          1  ·       table  xyz@primary  ·    ·
-·          1  ·       spans  ALL          ·    ·
+render     0  render  ·      ·            (x)                          x!=NULL; key(x)
+ └── scan  1  scan    ·      ·            (x, y[omitted], z[omitted])  x!=NULL; key(x)
+·          1  ·       table  xyz@primary  ·                            ·
+·          1  ·       spans  ALL          ·                            ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT x, y, z FROM xyz
@@ -232,28 +232,28 @@ CREATE TABLE abcd (
 query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT 1, d, b FROM abcd ORDER BY d, b
 ----
-render     0  render  ·      ·                  ("1", d, b)  "1"=CONST; d!=NULL; b!=NULL; key(d,b); +d,+b
- └── scan  1  scan    ·      ·                  ("1", d, b)  "1"=CONST; d!=NULL; b!=NULL; key(d,b); +d,+b
-·          1  ·       table  abcd@abcd_d_b_key  ·            ·
-·          1  ·       spans  ALL                ·            ·
+render     0  render  ·      ·                  ("1", d, b)                     "1"=CONST; d!=NULL; b!=NULL; key(d,b); +d,+b
+ └── scan  1  scan    ·      ·                  (a[omitted], b, c[omitted], d)  b!=NULL; d!=NULL; key(b,d); +d,+b
+·          1  ·       table  abcd@abcd_d_b_key  ·                               ·
+·          1  ·       spans  ALL                ·                               ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT a, b FROM abcd
 ----
-distinct        0  distinct  ·          ·             (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
- │              0  ·         order key  a, b          ·       ·
- └── render     1  render    ·          ·             (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
-      └── scan  2  scan      ·          ·             (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
-·               2  ·         table      abcd@primary  ·       ·
-·               2  ·         spans      ALL           ·       ·
+distinct        0  distinct  ·          ·             (a, b)                          a!=NULL; b!=NULL; key(a,b); +a,+b
+ │              0  ·         order key  a, b          ·                               ·
+ └── render     1  render    ·          ·             (a, b)                          a!=NULL; b!=NULL; +a,+b
+      └── scan  2  scan      ·          ·             (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b
+·               2  ·         table      abcd@primary  ·                               ·
+·               2  ·         spans      ALL           ·                               ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT a, b, c FROM abcd
 ----
-render     0  render  ·      ·             (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
- └── scan  1  scan    ·      ·             (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·          1  ·       table  abcd@primary  ·          ·
-·          1  ·       spans  ALL           ·          ·
+render     0  render  ·      ·             (a, b, c)              a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ └── scan  1  scan    ·      ·             (a, b, c, d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·          1  ·       table  abcd@primary  ·                      ·
+·          1  ·       spans  ALL           ·                      ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT a, b, c, d FROM abcd
@@ -271,13 +271,13 @@ INSERT INTO kv VALUES (1, 1), (2, 2), (3, NULL), (4, NULL), (5, 5), (6, NULL)
 query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv
 ----
-Tree            Level  Type      Field     Description  Columns  Ordering
-distinct        0      distinct  ·         ·            (v)      weak-key(v)
- └── render     1      render    ·         ·            (v)      weak-key(v)
-      │         1      ·         render 0  test.kv.v    ·        ·
-      └── scan  2      scan      ·         ·            (v)      weak-key(v)
-·               2      ·         table     kv@primary   ·        ·
-·               2      ·         spans     ALL          ·        ·
+Tree            Level  Type      Field     Description  Columns          Ordering
+distinct        0      distinct  ·         ·            (v)              weak-key(v)
+ └── render     1      render    ·         ·            (v)              ·
+      │         1      ·         render 0  test.kv.v    ·                ·
+      └── scan  2      scan      ·         ·            (k[omitted], v)  k!=NULL; key(k)
+·               2      ·         table     kv@primary   ·                ·
+·               2      ·         spans     ALL          ·                ·
 
 query I rowsort
 SELECT DISTINCT v FROM kv
@@ -291,14 +291,14 @@ NULL
 query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx
 ----
-Tree            Level  Type      Field      Description  Columns  Ordering
-distinct        0      distinct  ·          ·            (v)      weak-key(v); +v
- │              0      ·         order key  v            ·        ·
- └── render     1      render    ·          ·            (v)      weak-key(v); +v
-      │         1      ·         render 0   test.kv.v    ·        ·
-      └── scan  2      scan      ·          ·            (v)      weak-key(v); +v
-·               2      ·         table      kv@idx       ·        ·
-·               2      ·         spans      ALL          ·        ·
+Tree            Level  Type      Field      Description  Columns          Ordering
+distinct        0      distinct  ·          ·            (v)              weak-key(v); +v
+ │              0      ·         order key  v            ·                ·
+ └── render     1      render    ·          ·            (v)              weak-key(v); +v
+      │         1      ·         render 0   test.kv.v    ·                ·
+      └── scan  2      scan      ·          ·            (k[omitted], v)  weak-key(v); +v
+·               2      ·         table      kv@idx       ·                ·
+·               2      ·         spans      ALL          ·                ·
 
 query I rowsort
 SELECT DISTINCT v FROM kv@idx
@@ -312,12 +312,12 @@ NULL
 query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx WHERE v > 0
 ----
-Tree       Level  Type    Field     Description  Columns  Ordering
-render     0      render  ·         ·            (v)      v!=NULL; key(v)
- │         0      ·       render 0  test.kv.v    ·        ·
- └── scan  1      scan    ·         ·            (v)      v!=NULL; key(v)
-·          1      ·       table     kv@idx       ·        ·
-·          1      ·       spans     /1-          ·        ·
+Tree       Level  Type    Field     Description  Columns          Ordering
+render     0      render  ·         ·            (v)              v!=NULL; key(v)
+ │         0      ·       render 0  test.kv.v    ·                ·
+ └── scan  1      scan    ·         ·            (k[omitted], v)  v!=NULL; key(v)
+·          1      ·       table     kv@idx       ·                ·
+·          1      ·       spans     /1-          ·                ·
 
 query I rowsort
 SELECT DISTINCT v FROM kv@idx WHERE v > 0
@@ -333,9 +333,9 @@ CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
 query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv2@idx
 ----
-Tree       Level  Type    Field     Description  Columns  Ordering
-render     0      render  ·         ·            (v)      v!=NULL; key(v)
- │         0      ·       render 0  test.kv2.v   ·        ·
- └── scan  1      scan    ·         ·            (v)      v!=NULL; key(v)
-·          1      ·       table     kv2@idx      ·        ·
-·          1      ·       spans     ALL          ·        ·
+Tree       Level  Type    Field     Description  Columns          Ordering
+render     0      render  ·         ·            (v)              v!=NULL; key(v)
+ │         0      ·       render 0  test.kv2.v   ·                ·
+ └── scan  1      scan    ·         ·            (k[omitted], v)  v!=NULL; key(v)
+·          1      ·       table     kv2@idx      ·                ·
+·          1      ·       spans     ALL          ·                ·

--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -43,15 +43,15 @@ INSERT INTO abc VALUES
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 ----
-distinct        0  distinct  ·            ·            (x, y, z)  weak-key(x,y,z)
- │              0  ·         distinct on  x, y, z      ·          ·
- └── render     1  render    ·            ·            (x, y, z)  weak-key(x,y,z)
-      │         1  ·         render 0     test.xyz.x   ·          ·
-      │         1  ·         render 1     test.xyz.y   ·          ·
-      │         1  ·         render 2     test.xyz.z   ·          ·
-      └── scan  2  scan      ·            ·            (x, y, z)  weak-key(x,y,z)
-·               2  ·         table        xyz@primary  ·          ·
-·               2  ·         spans        ALL          ·          ·
+distinct        0  distinct  ·            ·            (x, y, z)                              weak-key(x,y,z)
+ │              0  ·         distinct on  x, y, z      ·                                      ·
+ └── render     1  render    ·            ·            (x, y, z)                              ·
+      │         1  ·         render 0     test.xyz.x   ·                                      ·
+      │         1  ·         render 1     test.xyz.y   ·                                      ·
+      │         1  ·         render 2     test.xyz.z   ·                                      ·
+      └── scan  2  scan      ·            ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               2  ·         table        xyz@primary  ·                                      ·
+·               2  ·         spans        ALL          ·                                      ·
 
 query III rowsort
 SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
@@ -66,17 +66,17 @@ SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
 ----
-render               0  render    ·            ·            (x)  ·
- │                   0  ·         render 0     x            ·    ·
- └── distinct        1  distinct  ·            ·            (x)  ·
-      │              1  ·         distinct on  x, z, y      ·    ·
-      └── render     2  render    ·            ·            (x)  ·
-           │         2  ·         render 0     test.xyz.x   ·    ·
-           │         2  ·         render 1     test.xyz.z   ·    ·
-           │         2  ·         render 2     test.xyz.y   ·    ·
-           └── scan  3  scan      ·            ·            (x)  ·
-·                    3  ·         table        xyz@primary  ·    ·
-·                    3  ·         spans        ALL          ·    ·
+render               0  render    ·            ·            (x)                                    ·
+ │                   0  ·         render 0     x            ·                                      ·
+ └── distinct        1  distinct  ·            ·            (x, z, y)                              weak-key(x,z,y)
+      │              1  ·         distinct on  x, z, y      ·                                      ·
+      └── render     2  render    ·            ·            (x, z, y)                              ·
+           │         2  ·         render 0     test.xyz.x   ·                                      ·
+           │         2  ·         render 1     test.xyz.z   ·                                      ·
+           │         2  ·         render 2     test.xyz.y   ·                                      ·
+           └── scan  3  scan      ·            ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                    3  ·         table        xyz@primary  ·                                      ·
+·                    3  ·         spans        ALL          ·                                      ·
 
 query I rowsort
 SELECT DISTINCT ON (y, x, z) x FROM xyz
@@ -105,7 +105,7 @@ render     0  render  ·         ·            (a, c, b)  a!=NULL; c!=NULL; b!=N
  │         0  ·       render 0  test.abc.a   ·          ·
  │         0  ·       render 1  test.abc.c   ·          ·
  │         0  ·       render 2  test.abc.b   ·          ·
- └── scan  1  scan    ·         ·            (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b)
+ └── scan  1  scan    ·         ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
 ·          1  ·       table     abc@primary  ·          ·
 ·          1  ·       spans     ALL          ·          ·
 
@@ -120,11 +120,11 @@ SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a FROM abc
 ----
-render     0  render  ·         ·            (a)  a!=NULL
- │         0  ·       render 0  a            ·    ·
- └── scan  1  scan    ·         ·            (a)  a!=NULL
-·          1  ·       table     abc@primary  ·    ·
-·          1  ·       spans     ALL          ·    ·
+render     0  render  ·         ·            (a)        a!=NULL
+ │         0  ·       render 0  a            ·          ·
+ └── scan  1  scan    ·         ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·          1  ·       table     abc@primary  ·          ·
+·          1  ·       spans     ALL          ·          ·
 
 
 query T rowsort
@@ -139,17 +139,17 @@ SELECT DISTINCT ON (b, c, a) a FROM abc
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 ----
-render               0  render  ·         ·            (b)  b!=NULL; +b
- │                   0  ·       render 0  b            ·    ·
- └── sort            1  sort    ·         ·            (b)  b!=NULL; +b
-      │              1  ·       order     +b           ·    ·
-      └── render     2  render  ·         ·            (b)  b!=NULL; +b
-           │         2  ·       render 0  test.abc.b   ·    ·
-           │         2  ·       render 1  NULL         ·    ·
-           │         2  ·       render 2  NULL         ·    ·
-           └── scan  3  scan    ·         ·            (b)  b!=NULL; +b
-·                    3  ·       table     abc@primary  ·    ·
-·                    3  ·       spans     ALL          ·    ·
+render               0  render  ·         ·            (b)                          b!=NULL; +b
+ │                   0  ·       render 0  b            ·                            ·
+ └── sort            1  sort    ·         ·            (b, c[omitted], a[omitted])  b!=NULL; c!=NULL; a!=NULL; key(b,c,a); +b
+      │              1  ·       order     +b           ·                            ·
+      └── render     2  render  ·         ·            (b, c[omitted], a[omitted])  b!=NULL; c!=NULL; a!=NULL; key(b,c,a)
+           │         2  ·       render 0  test.abc.b   ·                            ·
+           │         2  ·       render 1  NULL         ·                            ·
+           │         2  ·       render 2  NULL         ·                            ·
+           └── scan  3  scan    ·         ·            (a[omitted], b, c[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·                    3  ·       table     abc@primary  ·                            ·
+·                    3  ·       spans     ALL          ·                            ·
 
 
 query T rowsort
@@ -165,14 +165,14 @@ SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y) y, x FROM xyz
 ----
-distinct        0  distinct  ·            ·            (y, x)  weak-key(y,x)
- │              0  ·         distinct on  y, x         ·       ·
- └── render     1  render    ·            ·            (y, x)  weak-key(y,x)
-      │         1  ·         render 0     test.xyz.y   ·       ·
-      │         1  ·         render 1     test.xyz.x   ·       ·
-      └── scan  2  scan      ·            ·            (y, x)  weak-key(y,x)
-·               2  ·         table        xyz@primary  ·       ·
-·               2  ·         spans        ALL          ·       ·
+distinct        0  distinct  ·            ·            (y, x)                                          weak-key(y,x)
+ │              0  ·         distinct on  y, x         ·                                               ·
+ └── render     1  render    ·            ·            (y, x)                                          ·
+      │         1  ·         render 0     test.xyz.y   ·                                               ·
+      │         1  ·         render 1     test.xyz.x   ·                                               ·
+      └── scan  2  scan      ·            ·            (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               2  ·         table        xyz@primary  ·                                               ·
+·               2  ·         spans        ALL          ·                                               ·
 
 query II rowsort
 SELECT DISTINCT ON (x, y) y, x FROM xyz
@@ -186,16 +186,16 @@ SELECT DISTINCT ON (x, y) y, x FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
 ----
-render               0  render    ·            ·            (x)  ·
- │                   0  ·         render 0     x            ·    ·
- └── distinct        1  distinct  ·            ·            (x)  ·
-      │              1  ·         distinct on  x, y         ·    ·
-      └── render     2  render    ·            ·            (x)  ·
-           │         2  ·         render 0     test.xyz.x   ·    ·
-           │         2  ·         render 1     test.xyz.y   ·    ·
-           └── scan  3  scan      ·            ·            (x)  ·
-·                    3  ·         table        xyz@primary  ·    ·
-·                    3  ·         spans        ALL          ·    ·
+render               0  render    ·            ·            (x)                                             ·
+ │                   0  ·         render 0     x            ·                                               ·
+ └── distinct        1  distinct  ·            ·            (x, y)                                          weak-key(x,y)
+      │              1  ·         distinct on  x, y         ·                                               ·
+      └── render     2  render    ·            ·            (x, y)                                          ·
+           │         2  ·         render 0     test.xyz.x   ·                                               ·
+           │         2  ·         render 1     test.xyz.y   ·                                               ·
+           └── scan  3  scan      ·            ·            (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                    3  ·         table        xyz@primary  ·                                               ·
+·                    3  ·         spans        ALL          ·                                               ·
 
 query I rowsort
 SELECT DISTINCT ON (y, x) x FROM xyz
@@ -218,40 +218,40 @@ SELECT DISTINCT ON (x, y) y FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
 ----
-distinct        0  distinct  ·            ·            (x, y)  weak-key(x,y)
- │              0  ·         distinct on  x, y         ·       ·
- └── render     1  render    ·            ·            (x, y)  weak-key(x,y)
-      │         1  ·         render 0     test.xyz.x   ·       ·
-      │         1  ·         render 1     test.xyz.y   ·       ·
-      └── scan  2  scan      ·            ·            (x, y)  weak-key(x,y)
-·               2  ·         table        xyz@primary  ·       ·
-·               2  ·         spans        ALL          ·       ·
+distinct        0  distinct  ·            ·            (x, y)                                          weak-key(x,y)
+ │              0  ·         distinct on  x, y         ·                                               ·
+ └── render     1  render    ·            ·            (x, y)                                          ·
+      │         1  ·         render 0     test.xyz.x   ·                                               ·
+      │         1  ·         render 1     test.xyz.y   ·                                               ·
+      └── scan  2  scan      ·            ·            (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               2  ·         table        xyz@primary  ·                                               ·
+·               2  ·         spans        ALL          ·                                               ·
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
 ----
-distinct        0  distinct  ·            ·             (pk1, x)  pk1!=NULL; weak-key(pk1,x); +pk1
- │              0  ·         distinct on  pk1, x        ·         ·
- │              0  ·         order key    pk1           ·         ·
- └── render     1  render    ·            ·             (pk1, x)  pk1!=NULL; weak-key(pk1,x); +pk1
-      │         1  ·         render 0     test.xyz.pk1  ·         ·
-      │         1  ·         render 1     test.xyz.x    ·         ·
-      └── scan  2  scan      ·            ·             (pk1, x)  pk1!=NULL; weak-key(pk1,x); +pk1
-·               2  ·         table        xyz@primary   ·         ·
-·               2  ·         spans        ALL           ·         ·
+distinct        0  distinct  ·            ·             (pk1, x)                                        pk1!=NULL; weak-key(pk1,x); +pk1
+ │              0  ·         distinct on  pk1, x        ·                                               ·
+ │              0  ·         order key    pk1           ·                                               ·
+ └── render     1  render    ·            ·             (pk1, x)                                        pk1!=NULL; +pk1
+      │         1  ·         render 0     test.xyz.pk1  ·                                               ·
+      │         1  ·         render 1     test.xyz.x    ·                                               ·
+      └── scan  2  scan      ·            ·             (x, y[omitted], z[omitted], pk1, pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
+·               2  ·         table        xyz@primary   ·                                               ·
+·               2  ·         spans        ALL           ·                                               ·
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
 ----
-render          0  render    ·            ·            (a, b)  a!=NULL; b!=NULL; +a
- │              0  ·         render 0     a            ·       ·
- │              0  ·         render 1     b            ·       ·
- └── distinct   1  distinct  ·            ·            (a, b)  a!=NULL; b!=NULL; +a
-      │         1  ·         distinct on  a, c         ·       ·
-      │         1  ·         order key    a            ·       ·
-      └── scan  2  scan      ·            ·            (a, b)  a!=NULL; b!=NULL; +a
-·               2  ·         table        abc@primary  ·       ·
-·               2  ·         spans        ALL          ·       ·
+render          0  render    ·            ·            (a, b)     a!=NULL; b!=NULL; +a
+ │              0  ·         render 0     a            ·          ·
+ │              0  ·         render 1     b            ·          ·
+ └── distinct   1  distinct  ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,c); +a
+      │         1  ·         distinct on  a, c         ·          ·
+      │         1  ·         order key    a            ·          ·
+      └── scan  2  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
+·               2  ·         table        abc@primary  ·          ·
+·               2  ·         spans        ALL          ·          ·
 
 query TT rowsort
 SELECT DISTINCT ON (a, c) a, b FROM abc ORDER BY a, c, b
@@ -265,11 +265,11 @@ EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
 distinct        0  distinct  ·            ·            (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(c,a); +a
  │              0  ·         distinct on  c, a         ·          ·
  │              0  ·         order key    a            ·          ·
- └── render     1  render    ·            ·            (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(c,a); +a
+ └── render     1  render    ·            ·            (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(b,c,a); +a
       │         1  ·         render 0     test.abc.b   ·          ·
       │         1  ·         render 1     test.abc.c   ·          ·
       │         1  ·         render 2     test.abc.a   ·          ·
-      └── scan  2  scan      ·            ·            (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(c,a); +a
+      └── scan  2  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
 ·               2  ·         table        abc@primary  ·          ·
 ·               2  ·         spans        ALL          ·          ·
 
@@ -295,15 +295,15 @@ SELECT DISTINCT ON (y) y FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (pk1) pk1, pk2 FROM xyz
 ----
-distinct        0  distinct  ·            ·             (pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1); +pk1
- │              0  ·         distinct on  pk1           ·           ·
- │              0  ·         order key    pk1           ·           ·
- └── render     1  render    ·            ·             (pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1); +pk1
-      │         1  ·         render 0     test.xyz.pk1  ·           ·
-      │         1  ·         render 1     test.xyz.pk2  ·           ·
-      └── scan  2  scan      ·            ·             (pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1); +pk1
-·               2  ·         table        xyz@primary   ·           ·
-·               2  ·         spans        ALL           ·           ·
+distinct        0  distinct  ·            ·             (pk1, pk2)                                      pk1!=NULL; pk2!=NULL; key(pk1); +pk1
+ │              0  ·         distinct on  pk1           ·                                               ·
+ │              0  ·         order key    pk1           ·                                               ·
+ └── render     1  render    ·            ·             (pk1, pk2)                                      pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
+      │         1  ·         render 0     test.xyz.pk1  ·                                               ·
+      │         1  ·         render 1     test.xyz.pk2  ·                                               ·
+      └── scan  2  scan      ·            ·             (x[omitted], y[omitted], z[omitted], pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
+·               2  ·         table        xyz@primary   ·                                               ·
+·               2  ·         spans        ALL           ·                                               ·
 
 query T rowsort
 SELECT DISTINCT ON (c) a FROM abc
@@ -331,18 +331,18 @@ SELECT DISTINCT ON (a) a, b, c FROM abc ORDER BY a, b, c
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
 ----
-distinct             0  distinct  ·            ·            (a, c)  a!=NULL; c!=NULL; key(a); +a
- │                   0  ·         distinct on  a            ·       ·
- │                   0  ·         order key    a            ·       ·
- └── sort            1  sort      ·            ·            (a, c)  a!=NULL; c!=NULL; key(a); +a
-      │              1  ·         order        +a,-c,+b     ·       ·
-      └── render     2  render    ·            ·            (a, c)  a!=NULL; c!=NULL; key(a); +a
-           │         2  ·         render 0     test.abc.a   ·       ·
-           │         2  ·         render 1     test.abc.c   ·       ·
-           │         2  ·         render 2     test.abc.b   ·       ·
-           └── scan  3  scan      ·            ·            (a, c)  a!=NULL; c!=NULL; key(a); +a
-·                    3  ·         table        abc@primary  ·       ·
-·                    3  ·         spans        ALL          ·       ·
+distinct             0  distinct  ·            ·            (a, c)     a!=NULL; c!=NULL; key(a); +a
+ │                   0  ·         distinct on  a            ·          ·
+ │                   0  ·         order key    a            ·          ·
+ └── sort            1  sort      ·            ·            (a, c)     a!=NULL; c!=NULL; +a,-c
+      │              1  ·         order        +a,-c,+b     ·          ·
+      └── render     2  render    ·            ·            (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b); +a
+           │         2  ·         render 0     test.abc.a   ·          ·
+           │         2  ·         render 1     test.abc.c   ·          ·
+           │         2  ·         render 2     test.abc.b   ·          ·
+           └── scan  3  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
+·                    3  ·         table        abc@primary  ·          ·
+·                    3  ·         spans        ALL          ·          ·
 
 query TT
 SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
@@ -365,16 +365,16 @@ SELECT DISTINCT ON (y, z) x, y, z FROM xyz ORDER BY x
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 ----
-distinct             0  distinct  ·            ·            (x)  weak-key(x); -x
- │                   0  ·         distinct on  x            ·    ·
- │                   0  ·         order key    x            ·    ·
- └── sort            1  sort      ·            ·            (x)  weak-key(x); -x
-      │              1  ·         order        -x           ·    ·
-      └── render     2  render    ·            ·            (x)  weak-key(x); -x
-           │         2  ·         render 0     test.xyz.x   ·    ·
-           └── scan  3  scan      ·            ·            (x)  weak-key(x); -x
-·                    3  ·         table        xyz@primary  ·    ·
-·                    3  ·         spans        ALL          ·    ·
+distinct             0  distinct  ·            ·            (x)                                                      weak-key(x); -x
+ │                   0  ·         distinct on  x            ·                                                        ·
+ │                   0  ·         order key    x            ·                                                        ·
+ └── sort            1  sort      ·            ·            (x)                                                      -x
+      │              1  ·         order        -x           ·                                                        ·
+      └── render     2  render    ·            ·            (x)                                                      ·
+           │         2  ·         render 0     test.xyz.x   ·                                                        ·
+           └── scan  3  scan      ·            ·            (x, y[omitted], z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                    3  ·         table        xyz@primary  ·                                                        ·
+·                    3  ·         spans        ALL          ·                                                        ·
 
 query I
 SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
@@ -386,18 +386,18 @@ SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
 ----
-distinct             0  distinct  ·            ·            (y, z, x)  weak-key(z,x); +z
- │                   0  ·         distinct on  z, x         ·          ·
- │                   0  ·         order key    z            ·          ·
- └── sort            1  sort      ·            ·            (y, z, x)  weak-key(z,x); +z
-      │              1  ·         order        +z           ·          ·
-      └── render     2  render    ·            ·            (y, z, x)  weak-key(z,x); +z
-           │         2  ·         render 0     test.xyz.y   ·          ·
-           │         2  ·         render 1     test.xyz.z   ·          ·
-           │         2  ·         render 2     test.xyz.x   ·          ·
-           └── scan  3  scan      ·            ·            (y, z, x)  weak-key(z,x); +z
-·                    3  ·         table        xyz@primary  ·          ·
-·                    3  ·         spans        ALL          ·          ·
+distinct             0  distinct  ·            ·            (y, z, x)                              weak-key(z,x); +z
+ │                   0  ·         distinct on  z, x         ·                                      ·
+ │                   0  ·         order key    z            ·                                      ·
+ └── sort            1  sort      ·            ·            (y, z, x)                              +z
+      │              1  ·         order        +z           ·                                      ·
+      └── render     2  render    ·            ·            (y, z, x)                              ·
+           │         2  ·         render 0     test.xyz.y   ·                                      ·
+           │         2  ·         render 1     test.xyz.z   ·                                      ·
+           │         2  ·         render 2     test.xyz.x   ·                                      ·
+           └── scan  3  scan      ·            ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                    3  ·         table        xyz@primary  ·                                      ·
+·                    3  ·         spans        ALL          ·                                      ·
 
 # We add a filter to eliminate one of the rows that may be flakily returned
 # depending on parallel execution of DISTINCT ON.
@@ -413,18 +413,18 @@ SELECT DISTINCT ON (x, z) y, z, x FROM xyz WHERE (x,y,z) != (4, 1, 6) ORDER BY z
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
 ----
-distinct             0  distinct  ·            ·            (y, z, x)  weak-key(x); +x,-z,-y
- │                   0  ·         distinct on  x            ·          ·
- │                   0  ·         order key    x            ·          ·
- └── sort            1  sort      ·            ·            (y, z, x)  weak-key(x); +x,-z,-y
-      │              1  ·         order        +x,-z,-y     ·          ·
-      └── render     2  render    ·            ·            (y, z, x)  weak-key(x); +x,-z,-y
-           │         2  ·         render 0     test.xyz.y   ·          ·
-           │         2  ·         render 1     test.xyz.z   ·          ·
-           │         2  ·         render 2     test.xyz.x   ·          ·
-           └── scan  3  scan      ·            ·            (y, z, x)  weak-key(x); +x,-z,-y
-·                    3  ·         table        xyz@primary  ·          ·
-·                    3  ·         spans        ALL          ·          ·
+distinct             0  distinct  ·            ·            (y, z, x)                              weak-key(x); +x,-z,-y
+ │                   0  ·         distinct on  x            ·                                      ·
+ │                   0  ·         order key    x            ·                                      ·
+ └── sort            1  sort      ·            ·            (y, z, x)                              +x,-z,-y
+      │              1  ·         order        +x,-z,-y     ·                                      ·
+      └── render     2  render    ·            ·            (y, z, x)                              ·
+           │         2  ·         render 0     test.xyz.y   ·                                      ·
+           │         2  ·         render 1     test.xyz.z   ·                                      ·
+           │         2  ·         render 2     test.xyz.x   ·                                      ·
+           └── scan  3  scan      ·            ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                    3  ·         table        xyz@primary  ·                                      ·
+·                    3  ·         spans        ALL          ·                                      ·
 
 query III
 SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
@@ -446,19 +446,19 @@ SELECT DISTINCT ON(MAX(x), z) MIN(y) FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (MAX(y)) MAX(x) FROM xyz
 ----
-render                    0  render    ·            ·                (max)  ·
- │                        0  ·         render 0     max              ·      ·
- └── distinct             1  distinct  ·            ·                (max)  ·
-      │                   1  ·         distinct on  max              ·      ·
-      └── group           2  group     ·            ·                (max)  ·
-           │              2  ·         aggregate 0  max(test.xyz.x)  ·      ·
-           │              2  ·         aggregate 1  max(test.xyz.y)  ·      ·
-           └── render     3  render    ·            ·                (max)  ·
-                │         3  ·         render 0     test.xyz.x       ·      ·
-                │         3  ·         render 1     test.xyz.y       ·      ·
-                └── scan  4  scan      ·            ·                (max)  ·
-·                         4  ·         table        xyz@primary      ·      ·
-·                         4  ·         spans        ALL              ·      ·
+render                    0  render    ·            ·                (max)                                           ·
+ │                        0  ·         render 0     max              ·                                               ·
+ └── distinct             1  distinct  ·            ·                (max, max)                                      weak-key(max)
+      │                   1  ·         distinct on  max              ·                                               ·
+      └── group           2  group     ·            ·                (max, max)                                      ·
+           │              2  ·         aggregate 0  max(test.xyz.x)  ·                                               ·
+           │              2  ·         aggregate 1  max(test.xyz.y)  ·                                               ·
+           └── render     3  render    ·            ·                (x, y)                                          ·
+                │         3  ·         render 0     test.xyz.x       ·                                               ·
+                │         3  ·         render 1     test.xyz.y       ·                                               ·
+                └── scan  4  scan      ·            ·                (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                         4  ·         table        xyz@primary      ·                                               ·
+·                         4  ·         spans        ALL              ·                                               ·
 
 query I
 SELECT DISTINCT ON (MAX(x)) MIN(y) FROM xyz
@@ -473,18 +473,18 @@ SELECT DISTINCT ON (MIN(x)) MAX(y) FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(a) FROM abc
 ----
-render               0  render    ·            ·                (max)  ·
- │                   0  ·         render 0     max              ·      ·
- └── distinct        1  distinct  ·            ·                (max)  ·
-      │              1  ·         distinct on  min, max, min    ·      ·
-      └── group      2  group     ·            ·                (max)  ·
-           │         2  ·         aggregate 0  max(test.abc.a)  ·      ·
-           │         2  ·         aggregate 1  min(test.abc.a)  ·      ·
-           │         2  ·         aggregate 2  max(test.abc.b)  ·      ·
-           │         2  ·         aggregate 3  min(test.abc.c)  ·      ·
-           └── scan  3  scan      ·            ·                (max)  ·
-·                    3  ·         table        abc@primary      ·      ·
-·                    3  ·         spans        ALL              ·      ·
+render               0  render    ·            ·                (max)                 ·
+ │                   0  ·         render 0     max              ·                     ·
+ └── distinct        1  distinct  ·            ·                (max, min, max, min)  weak-key(min,max,min)
+      │              1  ·         distinct on  min, max, min    ·                     ·
+      └── group      2  group     ·            ·                (max, min, max, min)  ·
+           │         2  ·         aggregate 0  max(test.abc.a)  ·                     ·
+           │         2  ·         aggregate 1  min(test.abc.a)  ·                     ·
+           │         2  ·         aggregate 2  max(test.abc.b)  ·                     ·
+           │         2  ·         aggregate 3  min(test.abc.c)  ·                     ·
+           └── scan  3  scan      ·            ·                (a, b, c)             a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·                    3  ·         table        abc@primary      ·                     ·
+·                    3  ·         spans        ALL              ·                     ·
 
 query T
 SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(c) FROM abc
@@ -503,20 +503,20 @@ SELECT DISTINCT ON (x) MIN(x) FROM xyz GROUP BY y
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
 ----
-render                    0  render    ·            ·                (min)  ·
- │                        0  ·         render 0     min              ·      ·
- └── distinct             1  distinct  ·            ·                (min)  ·
-      │                   1  ·         distinct on  y                ·      ·
-      └── group           2  group     ·            ·                (min)  ·
-           │              2  ·         aggregate 0  min(test.xyz.x)  ·      ·
-           │              2  ·         aggregate 1  test.xyz.y       ·      ·
-           │              2  ·         group by     @1-@1            ·      ·
-           └── render     3  render    ·            ·                (min)  ·
-                │         3  ·         render 0     test.xyz.y       ·      ·
-                │         3  ·         render 1     test.xyz.x       ·      ·
-                └── scan  4  scan      ·            ·                (min)  ·
-·                         4  ·         table        xyz@primary      ·      ·
-·                         4  ·         spans        ALL              ·      ·
+render                    0  render    ·            ·                (min)                                           ·
+ │                        0  ·         render 0     min              ·                                               ·
+ └── distinct             1  distinct  ·            ·                (min, y)                                        weak-key(y)
+      │                   1  ·         distinct on  y                ·                                               ·
+      └── group           2  group     ·            ·                (min, y)                                        ·
+           │              2  ·         aggregate 0  min(test.xyz.x)  ·                                               ·
+           │              2  ·         aggregate 1  test.xyz.y       ·                                               ·
+           │              2  ·         group by     @1-@1            ·                                               ·
+           └── render     3  render    ·            ·                (y, x)                                          ·
+                │         3  ·         render 0     test.xyz.y       ·                                               ·
+                │         3  ·         render 1     test.xyz.x       ·                                               ·
+                └── scan  4  scan      ·            ·                (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                         4  ·         table        xyz@primary      ·                                               ·
+·                         4  ·         spans        ALL              ·                                               ·
 
 query I rowsort
 SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
@@ -528,22 +528,22 @@ SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
 ----
-distinct                       0  distinct  ·            ·                (min)  weak-key(min)
- │                             0  ·         distinct on  min              ·      ·
- └── render                    1  render    ·            ·                (min)  weak-key(min)
-      │                        1  ·         render 0     min              ·      ·
-      └── filter               2  filter    ·            ·                (min)  weak-key(min)
-           │                   2  ·         filter       min = 1          ·      ·
-           └── group           3  group     ·            ·                (min)  weak-key(min)
-                │              3  ·         aggregate 0  min(test.xyz.x)  ·      ·
-                │              3  ·         aggregate 1  min(test.xyz.x)  ·      ·
-                │              3  ·         group by     @1-@1            ·      ·
-                └── render     4  render    ·            ·                (min)  weak-key(min)
-                     │         4  ·         render 0     test.xyz.y       ·      ·
-                     │         4  ·         render 1     test.xyz.x       ·      ·
-                     └── scan  5  scan      ·            ·                (min)  weak-key(min)
-·                              5  ·         table        xyz@primary      ·      ·
-·                              5  ·         spans        ALL              ·      ·
+distinct                       0  distinct  ·            ·                (min)                                           weak-key(min)
+ │                             0  ·         distinct on  min              ·                                               ·
+ └── render                    1  render    ·            ·                (min)                                           ·
+      │                        1  ·         render 0     min              ·                                               ·
+      └── filter               2  filter    ·            ·                (min, min)                                      min=CONST
+           │                   2  ·         filter       min = 1          ·                                               ·
+           └── group           3  group     ·            ·                (min, min)                                      ·
+                │              3  ·         aggregate 0  min(test.xyz.x)  ·                                               ·
+                │              3  ·         aggregate 1  min(test.xyz.x)  ·                                               ·
+                │              3  ·         group by     @1-@1            ·                                               ·
+                └── render     4  render    ·            ·                (y, x)                                          ·
+                     │         4  ·         render 0     test.xyz.y       ·                                               ·
+                     │         4  ·         render 1     test.xyz.x       ·                                               ·
+                     └── scan  5  scan      ·            ·                (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                              5  ·         table        xyz@primary      ·                                               ·
+·                              5  ·         spans        ALL              ·                                               ·
 
 query I
 SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
@@ -557,18 +557,18 @@ SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
 ----
-render                    0  render    ·            ·                     (y)  ·
- │                        0  ·         render 0     y                     ·    ·
- └── distinct             1  distinct  ·            ·                     (y)  ·
-      │                   1  ·         distinct on  row_number            ·    ·
-      └── window          2  window    ·            ·                     (y)  ·
-           │              2  ·         window 0     row_number() OVER ()  ·    ·
-           │              2  ·         render 1     row_number() OVER ()  ·    ·
-           └── render     3  render    ·            ·                     (y)  ·
-                │         3  ·         render 0     test.xyz.y            ·    ·
-                └── scan  4  scan      ·            ·                     (y)  ·
-·                         4  ·         table        xyz@primary           ·    ·
-·                         4  ·         spans        ALL                   ·    ·
+render                    0  render    ·            ·                     (y)                                                      ·
+ │                        0  ·         render 0     y                     ·                                                        ·
+ └── distinct             1  distinct  ·            ·                     (y, row_number)                                          weak-key(row_number)
+      │                   1  ·         distinct on  row_number            ·                                                        ·
+      └── window          2  window    ·            ·                     (y, row_number)                                          ·
+           │              2  ·         window 0     row_number() OVER ()  ·                                                        ·
+           │              2  ·         render 1     row_number() OVER ()  ·                                                        ·
+           └── render     3  render    ·            ·                     (y)                                                      ·
+                │         3  ·         render 0     test.xyz.y            ·                                                        ·
+                └── scan  4  scan      ·            ·                     (x[omitted], y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                         4  ·         table        xyz@primary           ·                                                        ·
+·                         4  ·         spans        ALL                   ·                                                        ·
 
 query I rowsort
 SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
@@ -602,15 +602,15 @@ SELECT DISTINCT ON (2) x FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz
 ----
-distinct        0  distinct  ·            ·            (x, y, z)  weak-key(x)
- │              0  ·         distinct on  x            ·          ·
- └── render     1  render    ·            ·            (x, y, z)  weak-key(x)
-      │         1  ·         render 0     test.xyz.x   ·          ·
-      │         1  ·         render 1     test.xyz.y   ·          ·
-      │         1  ·         render 2     test.xyz.z   ·          ·
-      └── scan  2  scan      ·            ·            (x, y, z)  weak-key(x)
-·               2  ·         table        xyz@primary  ·          ·
-·               2  ·         spans        ALL          ·          ·
+distinct        0  distinct  ·            ·            (x, y, z)                              weak-key(x)
+ │              0  ·         distinct on  x            ·                                      ·
+ └── render     1  render    ·            ·            (x, y, z)                              ·
+      │         1  ·         render 0     test.xyz.x   ·                                      ·
+      │         1  ·         render 1     test.xyz.y   ·                                      ·
+      │         1  ·         render 2     test.xyz.z   ·                                      ·
+      └── scan  2  scan      ·            ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               2  ·         table        xyz@primary  ·                                      ·
+·               2  ·         spans        ALL          ·                                      ·
 
 query I rowsort
 SELECT DISTINCT ON (1) x FROM xyz
@@ -645,14 +645,14 @@ SELECT DISTINCT ON (1,2,3) x, y, z FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz
 ----
-distinct        0  distinct  ·            ·            (y, x)  weak-key(y)
- │              0  ·         distinct on  y            ·       ·
- └── render     1  render    ·            ·            (y, x)  weak-key(y)
-      │         1  ·         render 0     test.xyz.x   ·       ·
-      │         1  ·         render 1     test.xyz.y   ·       ·
-      └── scan  2  scan      ·            ·            (y, x)  weak-key(y)
-·               2  ·         table        xyz@primary  ·       ·
-·               2  ·         spans        ALL          ·       ·
+distinct        0  distinct  ·            ·            (y, x)                                          weak-key(y)
+ │              0  ·         distinct on  y            ·                                               ·
+ └── render     1  render    ·            ·            (y, x)                                          ·
+      │         1  ·         render 0     test.xyz.x   ·                                               ·
+      │         1  ·         render 1     test.xyz.y   ·                                               ·
+      └── scan  2  scan      ·            ·            (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               2  ·         table        xyz@primary  ·                                               ·
+·               2  ·         spans        ALL          ·                                               ·
 
 # This would be non-deterministic if we don't select y (actually x) from the
 # subquery.
@@ -667,13 +667,13 @@ SELECT y FROM (SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz)
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(x) x AS y FROM xyz
 ----
-distinct        0  distinct  ·            ·            (y)  weak-key(y)
- │              0  ·         distinct on  y            ·    ·
- └── render     1  render    ·            ·            (y)  weak-key(y)
-      │         1  ·         render 0     test.xyz.x   ·    ·
-      └── scan  2  scan      ·            ·            (y)  weak-key(y)
-·               2  ·         table        xyz@primary  ·    ·
-·               2  ·         spans        ALL          ·    ·
+distinct        0  distinct  ·            ·            (y)                                                      weak-key(y)
+ │              0  ·         distinct on  y            ·                                                        ·
+ └── render     1  render    ·            ·            (y)                                                      ·
+      │         1  ·         render 0     test.xyz.x   ·                                                        ·
+      └── scan  2  scan      ·            ·            (x, y[omitted], z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               2  ·         table        xyz@primary  ·                                                        ·
+·               2  ·         spans        ALL          ·                                                        ·
 
 query I rowsort
 SELECT DISTINCT ON(x) x AS y FROM xyz
@@ -689,14 +689,14 @@ SELECT DISTINCT ON(x) x AS y FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
 ----
-distinct        0  distinct  ·            ·            (x, y)  weak-key(x,y)
- │              0  ·         distinct on  x, y         ·       ·
- └── render     1  render    ·            ·            (x, y)  weak-key(x,y)
-      │         1  ·         render 0     test.xyz.x   ·       ·
-      │         1  ·         render 1     test.xyz.y   ·       ·
-      └── scan  2  scan      ·            ·            (x, y)  weak-key(x,y)
-·               2  ·         table        xyz@primary  ·       ·
-·               2  ·         spans        ALL          ·       ·
+distinct        0  distinct  ·            ·            (x, y)                                          weak-key(x,y)
+ │              0  ·         distinct on  x, y         ·                                               ·
+ └── render     1  render    ·            ·            (x, y)                                          ·
+      │         1  ·         render 0     test.xyz.x   ·                                               ·
+      │         1  ·         render 1     test.xyz.y   ·                                               ·
+      └── scan  2  scan      ·            ·            (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               2  ·         table        xyz@primary  ·                                               ·
+·               2  ·         spans        ALL          ·                                               ·
 
 
 query II rowsort
@@ -716,15 +716,15 @@ SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 ----
-render          0  render  ·         ·            (x, y, z)  +x,+y
- │              0  ·       render 0  x            ·          ·
- │              0  ·       render 1  y            ·          ·
- │              0  ·       render 2  z            ·          ·
- └── sort       1  sort    ·         ·            (x, y, z)  +x,+y
-      │         1  ·       order     +x,+y        ·          ·
-      └── scan  2  scan    ·         ·            (x, y, z)  +x,+y
-·               2  ·       table     xyz@primary  ·          ·
-·               2  ·       spans     ALL          ·          ·
+render          0  render  ·         ·            (x, y, z)                              +x,+y
+ │              0  ·       render 0  x            ·                                      ·
+ │              0  ·       render 1  y            ·                                      ·
+ │              0  ·       render 2  z            ·                                      ·
+ └── sort       1  sort    ·         ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +x,+y
+      │         1  ·       order     +x,+y        ·                                      ·
+      └── scan  2  scan    ·         ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               2  ·       table     xyz@primary  ·                                      ·
+·               2  ·       spans     ALL          ·                                      ·
 
 # We need to rowsort this since the ORDER BY isn't on the entire SELECT columns.
 query III rowsort
@@ -743,21 +743,21 @@ SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
 ----
-render                    0  render    ·            ·             (pk1)  pk1!=NULL
- │                        0  ·         render 0     pk1           ·      ·
- └── distinct             1  distinct  ·            ·             (pk1)  pk1!=NULL
-      │                   1  ·         distinct on  x, y, z       ·      ·
-      │                   1  ·         order key    x             ·      ·
-      └── sort            2  sort      ·            ·             (pk1)  pk1!=NULL
-           │              2  ·         order        +x            ·      ·
-           └── render     3  render    ·            ·             (pk1)  pk1!=NULL
-                │         3  ·         render 0     test.xyz.pk1  ·      ·
-                │         3  ·         render 1     test.xyz.x    ·      ·
-                │         3  ·         render 2     test.xyz.y    ·      ·
-                │         3  ·         render 3     test.xyz.z    ·      ·
-                └── scan  4  scan      ·            ·             (pk1)  pk1!=NULL
-·                         4  ·         table        xyz@primary   ·      ·
-·                         4  ·         spans        ALL           ·      ·
+render                    0  render    ·            ·             (pk1)                         pk1!=NULL
+ │                        0  ·         render 0     pk1           ·                             ·
+ └── distinct             1  distinct  ·            ·             (pk1, x, y, z)                pk1!=NULL; weak-key(x,y,z); +x
+      │                   1  ·         distinct on  x, y, z       ·                             ·
+      │                   1  ·         order key    x             ·                             ·
+      └── sort            2  sort      ·            ·             (pk1, x, y, z)                pk1!=NULL; +x
+           │              2  ·         order        +x            ·                             ·
+           └── render     3  render    ·            ·             (pk1, x, y, z)                pk1!=NULL
+                │         3  ·         render 0     test.xyz.pk1  ·                             ·
+                │         3  ·         render 1     test.xyz.x    ·                             ·
+                │         3  ·         render 2     test.xyz.y    ·                             ·
+                │         3  ·         render 3     test.xyz.z    ·                             ·
+                └── scan  4  scan      ·            ·             (x, y, z, pk1, pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                         4  ·         table        xyz@primary   ·                             ·
+·                         4  ·         spans        ALL           ·                             ·
 
 # We add a filter since there could be multiple valid pk1s otherwise for distinct
 # rows.

--- a/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
@@ -85,15 +85,15 @@ NULL             /NULL/NULL/NULL  5         {5}       5
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 ----
-distinct        0  distinct  ·            ·            (x, y, z)  weak-key(x,y,z)
- │              0  ·         distinct on  x, y, z      ·          ·
- └── render     1  render    ·            ·            (x, y, z)  weak-key(x,y,z)
-      │         1  ·         render 0     test.xyz.x   ·          ·
-      │         1  ·         render 1     test.xyz.y   ·          ·
-      │         1  ·         render 2     test.xyz.z   ·          ·
-      └── scan  2  scan      ·            ·            (x, y, z)  weak-key(x,y,z)
-·               2  ·         table        xyz@primary  ·          ·
-·               2  ·         spans        ALL          ·          ·
+distinct        0  distinct  ·            ·            (x, y, z)               weak-key(x,y,z)
+ │              0  ·         distinct on  x, y, z      ·                       ·
+ └── render     1  render    ·            ·            (x, y, z)               ·
+      │         1  ·         render 0     test.xyz.x   ·                       ·
+      │         1  ·         render 1     test.xyz.y   ·                       ·
+      │         1  ·         render 2     test.xyz.z   ·                       ·
+      └── scan  2  scan      ·            ·            (id[omitted], x, y, z)  id!=NULL; key(id)
+·               2  ·         table        xyz@primary  ·                       ·
+·               2  ·         spans        ALL          ·                       ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz]
@@ -114,18 +114,18 @@ SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 ----
-distinct             0  distinct  ·            ·            (x, y, z)  weak-key(x,y,z); +x
- │                   0  ·         distinct on  x, y, z      ·          ·
- │                   0  ·         order key    x            ·          ·
- └── sort            1  sort      ·            ·            (x, y, z)  weak-key(x,y,z); +x
-      │              1  ·         order        +x           ·          ·
-      └── render     2  render    ·            ·            (x, y, z)  weak-key(x,y,z); +x
-           │         2  ·         render 0     test.xyz.x   ·          ·
-           │         2  ·         render 1     test.xyz.y   ·          ·
-           │         2  ·         render 2     test.xyz.z   ·          ·
-           └── scan  3  scan      ·            ·            (x, y, z)  weak-key(x,y,z); +x
-·                    3  ·         table        xyz@primary  ·          ·
-·                    3  ·         spans        ALL          ·          ·
+distinct             0  distinct  ·            ·            (x, y, z)               weak-key(x,y,z); +x
+ │                   0  ·         distinct on  x, y, z      ·                       ·
+ │                   0  ·         order key    x            ·                       ·
+ └── sort            1  sort      ·            ·            (x, y, z)               +x
+      │              1  ·         order        +x           ·                       ·
+      └── render     2  render    ·            ·            (x, y, z)               ·
+           │         2  ·         render 0     test.xyz.x   ·                       ·
+           │         2  ·         render 1     test.xyz.y   ·                       ·
+           │         2  ·         render 2     test.xyz.z   ·                       ·
+           └── scan  3  scan      ·            ·            (id[omitted], x, y, z)  id!=NULL; key(id)
+·                    3  ·         table        xyz@primary  ·                       ·
+·                    3  ·         spans        ALL          ·                       ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x]
@@ -147,17 +147,17 @@ SELECT DISTINCT ON (x,y,z) x, y, z FROM xyz ORDER BY x
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x
 ----
-distinct             0  distinct  ·            ·            (x, y)  weak-key(y); +y,+x
- │                   0  ·         distinct on  y            ·       ·
- │                   0  ·         order key    y            ·       ·
- └── sort            1  sort      ·            ·            (x, y)  weak-key(y); +y,+x
-      │              1  ·         order        +y,+x        ·       ·
-      └── render     2  render    ·            ·            (x, y)  weak-key(y); +y,+x
-           │         2  ·         render 0     test.xyz.x   ·       ·
-           │         2  ·         render 1     test.xyz.y   ·       ·
-           └── scan  3  scan      ·            ·            (x, y)  weak-key(y); +y,+x
-·                    3  ·         table        xyz@primary  ·       ·
-·                    3  ·         spans        ALL          ·       ·
+distinct             0  distinct  ·            ·            (x, y)                           weak-key(y); +y,+x
+ │                   0  ·         distinct on  y            ·                                ·
+ │                   0  ·         order key    y            ·                                ·
+ └── sort            1  sort      ·            ·            (x, y)                           +y,+x
+      │              1  ·         order        +y,+x        ·                                ·
+      └── render     2  render    ·            ·            (x, y)                           ·
+           │         2  ·         render 0     test.xyz.x   ·                                ·
+           │         2  ·         render 1     test.xyz.y   ·                                ·
+           └── scan  3  scan      ·            ·            (id[omitted], x, y, z[omitted])  id!=NULL; key(id)
+·                    3  ·         table        xyz@primary  ·                                ·
+·                    3  ·         spans        ALL          ·                                ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (y) x, y FROM xyz ORDER BY y, x]
@@ -196,14 +196,14 @@ SELECT DISTINCT ON (a,b,c) a, b, c FROM abc
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c
 ----
-distinct        0  distinct  ·            ·            (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
- │              0  ·         distinct on  a, b         ·       ·
- │              0  ·         order key    a, b         ·       ·
- └── nosort     1  nosort    ·            ·            (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
-      │         1  ·         order        +a,+b,+c     ·       ·
-      └── scan  2  scan      ·            ·            (a, b)  a!=NULL; b!=NULL; key(a,b); +a,+b
-·               2  ·         table        abc@primary  ·       ·
-·               2  ·         spans        ALL          ·       ·
+distinct        0  distinct  ·            ·            (a, b)     a!=NULL; b!=NULL; key(a,b); +a,+b
+ │              0  ·         distinct on  a, b         ·          ·
+ │              0  ·         order key    a, b         ·          ·
+ └── nosort     1  nosort    ·            ·            (a, b)     a!=NULL; b!=NULL; +a,+b
+      │         1  ·         order        +a,+b,+c     ·          ·
+      └── scan  2  scan      ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b,+c
+·               2  ·         table        abc@primary  ·          ·
+·               2  ·         spans        ALL          ·          ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT ON (a, b) a, b FROM abc ORDER BY a, b, c]

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -43,49 +43,49 @@ SET CLUSTER SETTING sql.distsql.merge_joins.enabled = true;
 query TITTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data) NATURAL JOIN (SELECT a,b FROM data AS data2))
 ----
-render               0  render  ·               ·                  (a, b)  a!=NULL; b!=NULL
- │                   0  ·       render 0        a                  ·       ·
- │                   0  ·       render 1        b                  ·       ·
- └── join            1  join    ·               ·                  (a, b)  a!=NULL; b!=NULL
-      │              1  ·       type            inner              ·       ·
-      │              1  ·       equality        (a, b) = (a, b)    ·       ·
-      │              1  ·       mergeJoinOrder  +"(a=a)",+"(b=b)"  ·       ·
-      ├── render     2  render  ·               ·                  (a, b)  a!=NULL; b!=NULL
-      │    │         2  ·       render 0        test.data.a        ·       ·
-      │    │         2  ·       render 1        test.data.b        ·       ·
-      │    └── scan  3  scan    ·               ·                  (a, b)  a!=NULL; b!=NULL
-      │              3  ·       table           data@primary       ·       ·
-      │              3  ·       spans           ALL                ·       ·
-      └── render     2  render  ·               ·                  (a, b)  a!=NULL; b!=NULL
-           │         2  ·       render 0        data2.a            ·       ·
-           │         2  ·       render 1        data2.b            ·       ·
-           └── scan  3  scan    ·               ·                  (a, b)  a!=NULL; b!=NULL
-·                    3  ·       table           data@primary       ·       ·
-·                    3  ·       spans           ALL                ·       ·
+render               0  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL
+ │                   0  ·       render 0        a                  ·                               ·
+ │                   0  ·       render 1        b                  ·                               ·
+ └── join            1  join    ·               ·                  (a, b, a[omitted], b[omitted])  a=a; b=b; a!=NULL; b!=NULL
+      │              1  ·       type            inner              ·                               ·
+      │              1  ·       equality        (a, b) = (a, b)    ·                               ·
+      │              1  ·       mergeJoinOrder  +"(a=a)",+"(b=b)"  ·                               ·
+      ├── render     2  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL; +a,+b
+      │    │         2  ·       render 0        test.data.a        ·                               ·
+      │    │         2  ·       render 1        test.data.b        ·                               ·
+      │    └── scan  3  scan    ·               ·                  (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
+      │              3  ·       table           data@primary       ·                               ·
+      │              3  ·       spans           ALL                ·                               ·
+      └── render     2  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL; +a,+b
+           │         2  ·       render 0        data2.a            ·                               ·
+           │         2  ·       render 1        data2.b            ·                               ·
+           └── scan  3  scan    ·               ·                  (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
+·                    3  ·       table           data@primary       ·                               ·
+·                    3  ·       spans           ALL                ·                               ·
 
 
 # ORDER BY on the mergeJoinOrder columns should not require a SORT node
 query TITTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY c,d)
 ----
-join                 0  join    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
- │                   0  ·       type            inner              ·             ·
- │                   0  ·       equality        (a, b) = (c, d)    ·             ·
- │                   0  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·             ·
- ├── render          1  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
- │    │              1  ·       render 0        data1.a            ·             ·
- │    │              1  ·       render 1        data1.b            ·             ·
- │    └── scan       2  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
- │                   2  ·       table           data@primary       ·             ·
- │                   2  ·       spans           ALL                ·             ·
- └── sort            1  sort    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
-      │              1  ·       order           +c,+d              ·             ·
-      └── render     2  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
-           │         2  ·       render 0        data2.c            ·             ·
-           │         2  ·       render 1        data2.d            ·             ·
-           └── scan  3  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
-·                    3  ·       table           data@primary       ·             ·
-·                    3  ·       spans           ALL                ·             ·
+join                 0  join    ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
+ │                   0  ·       type            inner              ·                               ·
+ │                   0  ·       equality        (a, b) = (c, d)    ·                               ·
+ │                   0  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·                               ·
+ ├── render          1  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL; +a,+b
+ │    │              1  ·       render 0        data1.a            ·                               ·
+ │    │              1  ·       render 1        data1.b            ·                               ·
+ │    └── scan       2  scan    ·               ·                  (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
+ │                   2  ·       table           data@primary       ·                               ·
+ │                   2  ·       spans           ALL                ·                               ·
+ └── sort            1  sort    ·               ·                  (c, d)                          c!=NULL; d!=NULL; +c,+d
+      │              1  ·       order           +c,+d              ·                               ·
+      └── render     2  render  ·               ·                  (c, d)                          c!=NULL; d!=NULL
+           │         2  ·       render 0        data2.c            ·                               ·
+           │         2  ·       render 1        data2.d            ·                               ·
+           └── scan  3  scan    ·               ·                  (a[omitted], b[omitted], c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
+·                    3  ·       table           data@primary       ·                               ·
+·                    3  ·       spans           ALL                ·                               ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY c,d)]
@@ -97,24 +97,24 @@ https://cockroachdb.github.io/distsqlplan/decode.html?eJzclk1r20AQhu_9FWFOLdmCdy
 query TITTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY a,b)
 ----
-join                 0  join    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
- │                   0  ·       type            inner              ·             ·
- │                   0  ·       equality        (a, b) = (c, d)    ·             ·
- │                   0  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·             ·
- ├── render          1  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
- │    │              1  ·       render 0        data1.a            ·             ·
- │    │              1  ·       render 1        data1.b            ·             ·
- │    └── scan       2  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
- │                   2  ·       table           data@primary       ·             ·
- │                   2  ·       spans           ALL                ·             ·
- └── sort            1  sort    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
-      │              1  ·       order           +c,+d              ·             ·
-      └── render     2  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
-           │         2  ·       render 0        data2.c            ·             ·
-           │         2  ·       render 1        data2.d            ·             ·
-           └── scan  3  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +a,+b
-·                    3  ·       table           data@primary       ·             ·
-·                    3  ·       spans           ALL                ·             ·
+join                 0  join    ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
+ │                   0  ·       type            inner              ·                               ·
+ │                   0  ·       equality        (a, b) = (c, d)    ·                               ·
+ │                   0  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·                               ·
+ ├── render          1  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL; +a,+b
+ │    │              1  ·       render 0        data1.a            ·                               ·
+ │    │              1  ·       render 1        data1.b            ·                               ·
+ │    └── scan       2  scan    ·               ·                  (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
+ │                   2  ·       table           data@primary       ·                               ·
+ │                   2  ·       spans           ALL                ·                               ·
+ └── sort            1  sort    ·               ·                  (c, d)                          c!=NULL; d!=NULL; +c,+d
+      │              1  ·       order           +c,+d              ·                               ·
+      └── render     2  render  ·               ·                  (c, d)                          c!=NULL; d!=NULL
+           │         2  ·       render 0        data2.c            ·                               ·
+           │         2  ·       render 1        data2.d            ·                               ·
+           └── scan  3  scan    ·               ·                  (a[omitted], b[omitted], c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
+·                    3  ·       table           data@primary       ·                               ·
+·                    3  ·       spans           ALL                ·                               ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY a,b)]
@@ -125,26 +125,26 @@ https://cockroachdb.github.io/distsqlplan/decode.html?eJzclk1r20AQhu_9FWFOLdmCdy
 query TITTTTT
 EXPLAIN (VERBOSE) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)
 ----
-sort                      0  sort    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
- │                        0  ·       order           +b,+a              ·             ·
- └── join                 1  join    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
-      │                   1  ·       type            inner              ·             ·
-      │                   1  ·       equality        (a, b) = (c, d)    ·             ·
-      │                   1  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·             ·
-      ├── render          2  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
-      │    │              2  ·       render 0        data1.a            ·             ·
-      │    │              2  ·       render 1        data1.b            ·             ·
-      │    └── scan       3  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
-      │                   3  ·       table           data@primary       ·             ·
-      │                   3  ·       spans           ALL                ·             ·
-      └── sort            2  sort    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
-           │              2  ·       order           +c,+d              ·             ·
-           └── render     3  render  ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
-                │         3  ·       render 0        data2.c            ·             ·
-                │         3  ·       render 1        data2.d            ·             ·
-                └── scan  4  scan    ·               ·                  (a, b, c, d)  a=c; b=d; a!=NULL; b!=NULL; +b,+a
-·                         4  ·       table           data@primary       ·             ·
-·                         4  ·       spans           ALL                ·             ·
+sort                      0  sort    ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL; +b,+a
+ │                        0  ·       order           +b,+a              ·                               ·
+ └── join                 1  join    ·               ·                  (a, b, c, d)                    a=c; b=d; a!=NULL; b!=NULL
+      │                   1  ·       type            inner              ·                               ·
+      │                   1  ·       equality        (a, b) = (c, d)    ·                               ·
+      │                   1  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"  ·                               ·
+      ├── render          2  render  ·               ·                  (a, b)                          a!=NULL; b!=NULL; +a,+b
+      │    │              2  ·       render 0        data1.a            ·                               ·
+      │    │              2  ·       render 1        data1.b            ·                               ·
+      │    └── scan       3  scan    ·               ·                  (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
+      │                   3  ·       table           data@primary       ·                               ·
+      │                   3  ·       spans           ALL                ·                               ·
+      └── sort            2  sort    ·               ·                  (c, d)                          c!=NULL; d!=NULL; +c,+d
+           │              2  ·       order           +c,+d              ·                               ·
+           └── render     3  render  ·               ·                  (c, d)                          c!=NULL; d!=NULL
+                │         3  ·       render 0        data2.c            ·                               ·
+                │         3  ·       render 1        data2.d            ·                               ·
+                └── scan  4  scan    ·               ·                  (a[omitted], b[omitted], c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
+·                         4  ·       table           data@primary       ·                               ·
+·                         4  ·       spans           ALL                ·                               ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d ORDER BY b,a)]
@@ -179,34 +179,34 @@ https://cockroachdb.github.io/distsqlplan/decode.html?eJzcl1GL2kAUhd_7K5b71LJTcC
 query TITTTTT
 EXPLAIN (VERBOSE) (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d))
 ----
-render                         0  render  ·               ·                                    (a, b)  a!=NULL; b!=NULL
- │                             0  ·       render 0        data3.a                              ·       ·
- │                             0  ·       render 1        data3.b                              ·       ·
- └── join                      1  join    ·               ·                                    (a, b)  a!=NULL; b!=NULL
-      │                        1  ·       type            inner                                ·       ·
-      │                        1  ·       equality        (a, b, c, d) = (a, b, c, d)          ·       ·
-      │                        1  ·       mergeJoinOrder  +"(a=a)",+"(b=b)",+"(c=c)",+"(d=d)"  ·       ·
-      ├── scan                 2  scan    ·               ·                                    (a, b)  a!=NULL; b!=NULL
-      │                        2  ·       table           data@primary                         ·       ·
-      │                        2  ·       spans           ALL                                  ·       ·
-      └── join                 2  join    ·               ·                                    (a, b)  a!=NULL; b!=NULL
-           │                   2  ·       type            inner                                ·       ·
-           │                   2  ·       equality        (a, b) = (c, d)                      ·       ·
-           │                   2  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"                    ·       ·
-           ├── render          3  render  ·               ·                                    (a, b)  a!=NULL; b!=NULL
-           │    │              3  ·       render 0        data1.a                              ·       ·
-           │    │              3  ·       render 1        data1.b                              ·       ·
-           │    └── scan       4  scan    ·               ·                                    (a, b)  a!=NULL; b!=NULL
-           │                   4  ·       table           data@primary                         ·       ·
-           │                   4  ·       spans           ALL                                  ·       ·
-           └── sort            3  sort    ·               ·                                    (a, b)  a!=NULL; b!=NULL
-                │              3  ·       order           +c,+d                                ·       ·
-                └── render     4  render  ·               ·                                    (a, b)  a!=NULL; b!=NULL
-                     │         4  ·       render 0        data2.c                              ·       ·
-                     │         4  ·       render 1        data2.d                              ·       ·
-                     └── scan  5  scan    ·               ·                                    (a, b)  a!=NULL; b!=NULL
-·                              5  ·       table           data@primary                         ·       ·
-·                              5  ·       spans           ALL                                  ·       ·
+render                         0  render  ·               ·                                    (a, b)                                                                          a!=NULL; b!=NULL
+ │                             0  ·       render 0        data3.a                              ·                                                                               ·
+ │                             0  ·       render 1        data3.b                              ·                                                                               ·
+ └── join                      1  join    ·               ·                                    (a, b, c[omitted], d[omitted], a[omitted], b[omitted], c[omitted], d[omitted])  a=c=a=c; b=d=b=d; a!=NULL; b!=NULL
+      │                        1  ·       type            inner                                ·                                                                               ·
+      │                        1  ·       equality        (a, b, c, d) = (a, b, c, d)          ·                                                                               ·
+      │                        1  ·       mergeJoinOrder  +"(a=a)",+"(b=b)",+"(c=c)",+"(d=d)"  ·                                                                               ·
+      ├── scan                 2  scan    ·               ·                                    (a, b, c, d)                                                                    a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b,+c,+d
+      │                        2  ·       table           data@primary                         ·                                                                               ·
+      │                        2  ·       spans           ALL                                  ·                                                                               ·
+      └── join                 2  join    ·               ·                                    (a, b, c, d)                                                                    a=c; b=d; a!=NULL; b!=NULL; +a,+b
+           │                   2  ·       type            inner                                ·                                                                               ·
+           │                   2  ·       equality        (a, b) = (c, d)                      ·                                                                               ·
+           │                   2  ·       mergeJoinOrder  +"(a=c)",+"(b=d)"                    ·                                                                               ·
+           ├── render          3  render  ·               ·                                    (a, b)                                                                          a!=NULL; b!=NULL; +a,+b
+           │    │              3  ·       render 0        data1.a                              ·                                                                               ·
+           │    │              3  ·       render 1        data1.b                              ·                                                                               ·
+           │    └── scan       4  scan    ·               ·                                    (a, b, c[omitted], d[omitted])                                                  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d); +a,+b
+           │                   4  ·       table           data@primary                         ·                                                                               ·
+           │                   4  ·       spans           ALL                                  ·                                                                               ·
+           └── sort            3  sort    ·               ·                                    (c, d)                                                                          c!=NULL; d!=NULL; +c,+d
+                │              3  ·       order           +c,+d                                ·                                                                               ·
+                └── render     4  render  ·               ·                                    (c, d)                                                                          c!=NULL; d!=NULL
+                     │         4  ·       render 0        data2.c                              ·                                                                               ·
+                     │         4  ·       render 1        data2.d                              ·                                                                               ·
+                     └── scan  5  scan    ·               ·                                    (a[omitted], b[omitted], c, d)                                                  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b,c,d)
+·                              5  ·       table           data@primary                         ·                                                                               ·
+·                              5  ·       spans           ALL                                  ·                                                                               ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) (SELECT * FROM (SELECT a,b from data AS data3 NATURAL JOIN ((SELECT a,b FROM data AS data1) JOIN (SELECT c,d FROM data AS data2 ORDER BY c,d) ON a=c AND b=d)))]

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -143,21 +143,21 @@ SELECT x, str FROM NumToSquare JOIN NumToStr ON y = xsquared
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0
 ----
-render          0  render  ·               ·                    (x, str)  x!=NULL; key(x)
- │              0  ·       render 0        test.numtosquare.x   ·         ·
- │              0  ·       render 1        test.numtostr.str    ·         ·
- └── join       1  join    ·               ·                    (x, str)  x!=NULL; key(x)
-      │         1  ·       type            inner                ·         ·
-      │         1  ·       equality        (x) = (y)            ·         ·
-      │         1  ·       mergeJoinOrder  +"(x=y)"             ·         ·
-      ├── scan  2  scan    ·               ·                    (x, str)  x!=NULL; key(x)
-      │         2  ·       table           numtosquare@primary  ·         ·
-      │         2  ·       spans           ALL                  ·         ·
-      │         2  ·       filter          (x % 2) = 0          ·         ·
-      └── scan  2  scan    ·               ·                    (x, str)  x!=NULL; key(x)
-·               2  ·       table           numtostr@primary     ·         ·
-·               2  ·       spans           ALL                  ·         ·
-·               2  ·       filter          (y % 2) = 0          ·         ·
+render          0  render  ·               ·                    (x, str)                                 x!=NULL; key(x)
+ │              0  ·       render 0        test.numtosquare.x   ·                                        ·
+ │              0  ·       render 1        test.numtostr.str    ·                                        ·
+ └── join       1  join    ·               ·                    (x, xsquared[omitted], y[omitted], str)  x=y; x!=NULL; key(x)
+      │         1  ·       type            inner                ·                                        ·
+      │         1  ·       equality        (x) = (y)            ·                                        ·
+      │         1  ·       mergeJoinOrder  +"(x=y)"             ·                                        ·
+      ├── scan  2  scan    ·               ·                    (x, xsquared[omitted])                   x!=NULL; key(x); +x
+      │         2  ·       table           numtosquare@primary  ·                                        ·
+      │         2  ·       spans           ALL                  ·                                        ·
+      │         2  ·       filter          (x % 2) = 0          ·                                        ·
+      └── scan  2  scan    ·               ·                    (y, str)                                 y!=NULL; key(y); +y
+·               2  ·       table           numtostr@primary     ·                                        ·
+·               2  ·       spans           ALL                  ·                                        ·
+·               2  ·       filter          (y % 2) = 0          ·                                        ·
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT x, str FROM NumToSquare JOIN NumToStr ON x = y WHERE x % 2 = 0]
@@ -276,15 +276,15 @@ SELECT y, str, REPEAT('test', y) FROM NumToStr ORDER BY str LIMIT 10
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT x FROM (SELECT x, 2*x, x+1 FROM NumToSquare)
 ----
-render          0  render  ·         ·                    (x)  x!=NULL; key(x)
- │              0  ·       render 0  x                    ·    ·
- └── render     1  render  ·         ·                    (x)  x!=NULL; key(x)
-      │         1  ·       render 0  test.numtosquare.x   ·    ·
-      │         1  ·       render 1  NULL                 ·    ·
-      │         1  ·       render 2  NULL                 ·    ·
-      └── scan  2  scan    ·         ·                    (x)  x!=NULL; key(x)
-·               2  ·       table     numtosquare@primary  ·    ·
-·               2  ·       spans     ALL                  ·    ·
+render          0  render  ·         ·                    (x)                                      x!=NULL; key(x)
+ │              0  ·       render 0  x                    ·                                        ·
+ └── render     1  render  ·         ·                    (x, "2 * x"[omitted], "x + 1"[omitted])  x!=NULL; key(x)
+      │         1  ·       render 0  test.numtosquare.x   ·                                        ·
+      │         1  ·       render 1  NULL                 ·                                        ·
+      │         1  ·       render 2  NULL                 ·                                        ·
+      └── scan  2  scan    ·         ·                    (x, xsquared[omitted])                   x!=NULL; key(x)
+·               2  ·       table     numtosquare@primary  ·                                        ·
+·               2  ·       spans     ALL                  ·                                        ·
 
 # Verifies that unused renders don't cause us to do rendering instead of a
 # simple projection.

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -28,14 +28,14 @@ EXPLAIN (PLAN, METADATA) SELECT 1
 ----
 Tree           Level  Type      Field  Description  Columns  Ordering
 render         0      render    ·      ·            ("1")    "1"=CONST
- └── emptyrow  1      emptyrow  ·      ·            ("1")    "1"=CONST
+ └── emptyrow  1      emptyrow  ·      ·            ()       ·
 
 query TITTTTT colnames
 EXPLAIN (METADATA,PLAN) SELECT 1
 ----
 Tree           Level  Type      Field  Description  Columns  Ordering
 render         0      render    ·      ·            ("1")    "1"=CONST
- └── emptyrow  1      emptyrow  ·      ·            ("1")    "1"=CONST
+ └── emptyrow  1      emptyrow  ·      ·            ()       ·
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT 1]
@@ -49,7 +49,7 @@ EXPLAIN (TYPES) SELECT 1
 Tree           Level  Type      Field     Description  Columns    Ordering
 render         0      render    ·         ·            ("1" int)  "1"=CONST
  │             0      ·         render 0  (1)[int]     ·          ·
- └── emptyrow  1      emptyrow  ·         ·            ("1" int)  "1"=CONST
+ └── emptyrow  1      emptyrow  ·         ·            ()         ·
 
 statement error cannot set EXPLAIN mode more than once
 EXPLAIN (PLAN,PLAN) SELECT 1
@@ -68,22 +68,22 @@ EXPLAIN (TYPES) SELECT $1::INT
 ----
 Tree           Level  Type      Field     Description               Columns          Ordering
 render         0      render    ·         ·                         ("$1::INT" int)  "$1::INT"=CONST
-│             0      ·         render 0  (($1)[string]::INT)[int]  ·                ·
-└── emptyrow  1      emptyrow  ·         ·                         ("$1::INT" int)  "$1::INT"=CONST
+ │             0      ·         render 0  (($1)[string]::INT)[int]  ·                ·
+ └── emptyrow  1      emptyrow  ·         ·                         ()               ·
 
 # Ensure that tracing results are sorted after gathering
 query TITTTTT
 EXPLAIN (METADATA) SHOW TRACE FOR SELECT 1
 ----
-sort                                         0  sort            ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
- │                                           0  ·               order  +"timestamp"  ·                                                       ·
- └── window                                  1  window          ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
-      └── render                             2  render          ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
-           └── window                        3  window          ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
-                └── render                   4  render          ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
-                     └── show trace for      5  show trace for  ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
-                          └── render         6  render          ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
-                               └── emptyrow  7  emptyrow        ·      ·             ("timestamp", age, message, tag, loc, operation, span)  +"timestamp"
+sort                                         0  sort            ·      ·             ("timestamp", age, message, tag, loc, operation, span)                                 +"timestamp"
+ │                                           0  ·               order  +"timestamp"  ·                                                                                      ·
+ └── window                                  1  window          ·      ·             ("timestamp", age, message, tag, loc, operation, span)                                 ·
+      └── render                             2  render          ·      ·             ("timestamp", """timestamp""", message, tag, loc, operation, span)                     "timestamp"="""timestamp"""
+           └── window                        3  window          ·      ·             ("timestamp", message, tag, loc, operation, span)                                      ·
+                └── render                   4  render          ·      ·             ("timestamp", message, tag, loc, operation, span, txn_idx, span_idx, message_idx)      ·
+                     └── show trace for      5  show trace for  ·      ·             (txn_idx, span_idx, message_idx, "timestamp", duration, operation, loc, tag, message)  ·
+                          └── render         6  render          ·      ·             ("1")                                                                                  "1"=CONST
+                               └── emptyrow  7  emptyrow        ·      ·             ()                                                                                     ·
 
 # Ensure that all relevant statement types can be explained
 query TTT

--- a/pkg/sql/logictest/testdata/logic_test/explain_plan
+++ b/pkg/sql/logictest/testdata/logic_test/explain_plan
@@ -132,12 +132,12 @@ CREATE TABLE tc (a INT, b INT, INDEX c(a))
 query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-sort                  0  sort        ·      ·           (a, b)  a=CONST; +b
- │                    0  ·           order  +b          ·       ·
- └── render           1  render      ·      ·           (a, b)  a=CONST; +b
-      └── index-join  2  index-join  ·      ·           (a, b)  a=CONST; +b
-           ├── scan   3  scan        ·      ·           (a, b)  a=CONST; +b
-           │          3  ·           table  tc@c        ·       ·
-           │          3  ·           spans  /10-/11     ·       ·
-           └── scan   3  scan        ·      ·           (a, b)  a=CONST; +b
-·                     3  ·           table  tc@primary  ·       ·
+sort                  0  sort        ·      ·           (a, b)                                   a=CONST; +b
+ │                    0  ·           order  +b          ·                                        ·
+ └── render           1  render      ·      ·           (a, b)                                   a=CONST
+      └── index-join  2  index-join  ·      ·           (a, b, rowid[hidden,omitted])            a=CONST; rowid!=NULL; key(rowid)
+           ├── scan   3  scan        ·      ·           (a[omitted], b[omitted], rowid[hidden])  a=CONST; rowid!=NULL; key(rowid)
+           │          3  ·           table  tc@c        ·                                        ·
+           │          3  ·           spans  /10-/11     ·                                        ·
+           └── scan   3  scan        ·      ·           (a, b, rowid[hidden,omitted])            ·
+·                     3  ·           table  tc@primary  ·                                        ·

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -9,13 +9,13 @@ CREATE TABLE t (
 query TITTTTT colnames
 EXPLAIN (TYPES) INSERT INTO t VALUES (1, 2)
 ----
-Tree         Level  Type    Field          Description       Columns  Ordering
-insert       0      insert  ·              ·                 ()       ·
- │           0      ·       into           t(k, v)           ·        ·
- └── values  1      values  ·              ·                 ()       ·
-·            1      ·       size           2 columns, 1 row  ·        ·
-·            1      ·       row 0, expr 0  (1)[int]          ·        ·
-·            1      ·       row 0, expr 1  (2)[int]          ·        ·
+Tree         Level  Type    Field          Description       Columns                     Ordering
+insert       0      insert  ·              ·                 ()                          ·
+ │           0      ·       into           t(k, v)           ·                           ·
+ └── values  1      values  ·              ·                 (column1 int, column2 int)  ·
+·            1      ·       size           2 columns, 1 row  ·                           ·
+·            1      ·       row 0, expr 0  (1)[int]          ·                           ·
+·            1      ·       row 0, expr 1  (2)[int]          ·                           ·
 
 statement ok
 INSERT INTO t VALUES (1, 2)
@@ -25,7 +25,7 @@ EXPLAIN (TYPES) SELECT 42
 ----
 render         0  render    ·         ·          ("42" int)  "42"=CONST
  │             0  ·         render 0  (42)[int]  ·           ·
- └── emptyrow  1  emptyrow  ·         ·          ("42" int)  "42"=CONST
+ └── emptyrow  1  emptyrow  ·         ·          ()          ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT * FROM t
@@ -37,20 +37,20 @@ scan  0  scan  ·      ·          (k int, v int)  k!=NULL; key(k)
 query TITTTTT
 EXPLAIN (TYPES,SYMVARS) SELECT k FROM t
 ----
-render     0  render  ·         ·          (k int)  k!=NULL; key(k)
- │         0  ·       render 0  (@1)[int]  ·        ·
- └── scan  1  scan    ·         ·          (k int)  k!=NULL; key(k)
-·          1  ·       table     t@primary  ·        ·
-·          1  ·       spans     ALL        ·        ·
+render     0  render  ·         ·          (k int)                  k!=NULL; key(k)
+ │         0  ·       render 0  (@1)[int]  ·                        ·
+ └── scan  1  scan    ·         ·          (k int, v[omitted] int)  k!=NULL; key(k)
+·          1  ·       table     t@primary  ·                        ·
+·          1  ·       spans     ALL        ·                        ·
 
 query TITTTTT
 EXPLAIN (TYPES,QUALIFY) SELECT k FROM t
 ----
-render     0  render  ·         ·                (k int)  k!=NULL; key(k)
- │         0  ·       render 0  (test.t.k)[int]  ·        ·
- └── scan  1  scan    ·         ·                (k int)  k!=NULL; key(k)
-·          1  ·       table     t@primary        ·        ·
-·          1  ·       spans     ALL              ·        ·
+render     0  render  ·         ·                (k int)                  k!=NULL; key(k)
+ │         0  ·       render 0  (test.t.k)[int]  ·                        ·
+ └── scan  1  scan    ·         ·                (k int, v[omitted] int)  k!=NULL; key(k)
+·          1  ·       table     t@primary        ·                        ·
+·          1  ·       spans     ALL              ·                        ·
 
 query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM t WHERE v > 123
@@ -85,98 +85,98 @@ values  0  values  ·              ·                  (column1 int, column2 int
 query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND COUNT(k)>1
 ----
-render                    0  render  ·            ·                                                                          (z int, v int)  ·
- │                        0  ·       render 0     ((2)[int] * (count)[int])[int]                                             ·               ·
- │                        0  ·       render 1     (v)[int]                                                                   ·               ·
- └── filter               1  filter  ·            ·                                                                          (z int, v int)  ·
-      │                   1  ·       filter       ((count)[int] > (1)[int])[bool]                                            ·               ·
-      └── group           2  group   ·            ·                                                                          (z int, v int)  ·
-           │              2  ·       aggregate 0  (v)[int]                                                                   ·               ·
-           │              2  ·       aggregate 1  (count((k)[int]))[int]                                                     ·               ·
-           │              2  ·       aggregate 2  (count((k)[int]))[int]                                                     ·               ·
-           │              2  ·       aggregate 3  (v)[int]                                                                   ·               ·
-           │              2  ·       group by     @1-@1                                                                      ·               ·
-           └── render     3  render  ·            ·                                                                          (z int, v int)  ·
-                │         3  ·       render 0     (v)[int]                                                                   ·               ·
-                │         3  ·       render 1     (k)[int]                                                                   ·               ·
-                └── scan  4  scan    ·            ·                                                                          (z int, v int)  ·
-·                         4  ·       table        t@primary                                                                  ·               ·
-·                         4  ·       filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]  ·               ·
+render                    0  render  ·            ·                                                                          (z int, v int)                        ·
+ │                        0  ·       render 0     ((2)[int] * (count)[int])[int]                                             ·                                     ·
+ │                        0  ·       render 1     (v)[int]                                                                   ·                                     ·
+ └── filter               1  filter  ·            ·                                                                          (v int, count int, count int, v int)  ·
+      │                   1  ·       filter       ((count)[int] > (1)[int])[bool]                                            ·                                     ·
+      └── group           2  group   ·            ·                                                                          (v int, count int, count int, v int)  ·
+           │              2  ·       aggregate 0  (v)[int]                                                                   ·                                     ·
+           │              2  ·       aggregate 1  (count((k)[int]))[int]                                                     ·                                     ·
+           │              2  ·       aggregate 2  (count((k)[int]))[int]                                                     ·                                     ·
+           │              2  ·       aggregate 3  (v)[int]                                                                   ·                                     ·
+           │              2  ·       group by     @1-@1                                                                      ·                                     ·
+           └── render     3  render  ·            ·                                                                          (v int, k int)                        ·
+                │         3  ·       render 0     (v)[int]                                                                   ·                                     ·
+                │         3  ·       render 1     (k)[int]                                                                   ·                                     ·
+                └── scan  4  scan    ·            ·                                                                          (k int, v int)                        ·
+·                         4  ·       table        t@primary                                                                  ·                                     ·
+·                         4  ·       filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]  ·                                     ·
 
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT 2*COUNT(k) as z, v FROM t WHERE v>123 GROUP BY v HAVING v<2 AND COUNT(k)>1
 ----
-render                    0  render  ·            ·                                                                          (z int, v int)  ·
- │                        0  ·       render 0     ((2)[int] * (count)[int])[int]                                             ·               ·
- │                        0  ·       render 1     (v)[int]                                                                   ·               ·
- └── filter               1  filter  ·            ·                                                                          (z int, v int)  ·
-      │                   1  ·       filter       ((count)[int] > (1)[int])[bool]                                            ·               ·
-      └── group           2  group   ·            ·                                                                          (z int, v int)  ·
-           │              2  ·       aggregate 0  (v)[int]                                                                   ·               ·
-           │              2  ·       aggregate 1  (count((k)[int]))[int]                                                     ·               ·
-           │              2  ·       aggregate 2  (count((k)[int]))[int]                                                     ·               ·
-           │              2  ·       aggregate 3  (v)[int]                                                                   ·               ·
-           │              2  ·       group by     @1-@1                                                                      ·               ·
-           └── render     3  render  ·            ·                                                                          (z int, v int)  ·
-                │         3  ·       render 0     (v)[int]                                                                   ·               ·
-                │         3  ·       render 1     (k)[int]                                                                   ·               ·
-                └── scan  4  scan    ·            ·                                                                          (z int, v int)  ·
-·                         4  ·       table        t@primary                                                                  ·               ·
-·                         4  ·       spans        ALL                                                                        ·               ·
-·                         4  ·       filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]  ·               ·
+render                    0  render  ·            ·                                                                          (z int, v int)                        ·
+ │                        0  ·       render 0     ((2)[int] * (count)[int])[int]                                             ·                                     ·
+ │                        0  ·       render 1     (v)[int]                                                                   ·                                     ·
+ └── filter               1  filter  ·            ·                                                                          (v int, count int, count int, v int)  count!=NULL
+      │                   1  ·       filter       ((count)[int] > (1)[int])[bool]                                            ·                                     ·
+      └── group           2  group   ·            ·                                                                          (v int, count int, count int, v int)  ·
+           │              2  ·       aggregate 0  (v)[int]                                                                   ·                                     ·
+           │              2  ·       aggregate 1  (count((k)[int]))[int]                                                     ·                                     ·
+           │              2  ·       aggregate 2  (count((k)[int]))[int]                                                     ·                                     ·
+           │              2  ·       aggregate 3  (v)[int]                                                                   ·                                     ·
+           │              2  ·       group by     @1-@1                                                                      ·                                     ·
+           └── render     3  render  ·            ·                                                                          (v int, k int)                        v!=NULL; k!=NULL; key(k)
+                │         3  ·       render 0     (v)[int]                                                                   ·                                     ·
+                │         3  ·       render 1     (k)[int]                                                                   ·                                     ·
+                └── scan  4  scan    ·            ·                                                                          (k int, v int)                        k!=NULL; v!=NULL; key(k)
+·                         4  ·       table        t@primary                                                                  ·                                     ·
+·                         4  ·       spans        ALL                                                                        ·                                     ·
+·                         4  ·       filter       ((((v)[int] > (123)[int])[bool]) AND (((v)[int] < (2)[int])[bool]))[bool]  ·                                     ·
 
 query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1
 ----
-delete          0  delete  ·         ·                            ()  ·
- │              0  ·       from      t                            ·   ·
- └── render     1  render  ·         ·                            ()  ·
-      │         1  ·       render 0  (k)[int]                     ·   ·
-      └── scan  2  scan    ·         ·                            ()  ·
-·               2  ·       table     t@primary                    ·   ·
-·               2  ·       filter    ((v)[int] > (1)[int])[bool]  ·   ·
+delete          0  delete  ·         ·                            ()              ·
+ │              0  ·       from      t                            ·               ·
+ └── render     1  render  ·         ·                            (k int)         ·
+      │         1  ·       render 0  (k)[int]                     ·               ·
+      └── scan  2  scan    ·         ·                            (k int, v int)  ·
+·               2  ·       table     t@primary                    ·               ·
+·               2  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
 
 query TITTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-delete          0  delete  ·         ·                            ()  ·
- │              0  ·       from      t                            ·   ·
- └── render     1  render  ·         ·                            ()  ·
-      │         1  ·       render 0  (k)[int]                     ·   ·
-      └── scan  2  scan    ·         ·                            ()  ·
-·               2  ·       table     t@primary                    ·   ·
-·               2  ·       spans     ALL                          ·   ·
-·               2  ·       filter    ((v)[int] > (1)[int])[bool]  ·   ·
+delete          0  delete  ·         ·                            ()              ·
+ │              0  ·       from      t                            ·               ·
+ └── render     1  render  ·         ·                            (k int)         k!=NULL; key(k)
+      │         1  ·       render 0  (k)[int]                     ·               ·
+      └── scan  2  scan    ·         ·                            (k int, v int)  k!=NULL; v!=NULL; key(k)
+·               2  ·       table     t@primary                    ·               ·
+·               2  ·       spans     ALL                          ·               ·
+·               2  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
 
 query TITTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-update          0  update  ·         ·                              ()  ·
- │              0  ·       table     t                              ·   ·
- │              0  ·       set       v                              ·   ·
- └── render     1  render  ·         ·                              ()  ·
-      │         1  ·       render 0  (k)[int]                       ·   ·
-      │         1  ·       render 1  (v)[int]                       ·   ·
-      │         1  ·       render 2  ((k)[int] + (1)[int])[int]     ·   ·
-      └── scan  2  scan    ·         ·                              ()  ·
-·               2  ·       table     t@primary                      ·   ·
-·               2  ·       spans     ALL                            ·   ·
-·               2  ·       filter    ((v)[int] > (123)[int])[bool]  ·   ·
+update          0  update  ·         ·                              ()                           ·
+ │              0  ·       table     t                              ·                            ·
+ │              0  ·       set       v                              ·                            ·
+ └── render     1  render  ·         ·                              (k int, v int, "k + 1" int)  k!=NULL; v!=NULL; key(k)
+      │         1  ·       render 0  (k)[int]                       ·                            ·
+      │         1  ·       render 1  (v)[int]                       ·                            ·
+      │         1  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
+      └── scan  2  scan    ·         ·                              (k int, v int)               k!=NULL; v!=NULL; key(k)
+·               2  ·       table     t@primary                      ·                            ·
+·               2  ·       spans     ALL                            ·                            ·
+·               2  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
 
 query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-update          0  update  ·         ·                              ()  ·
- │              0  ·       table     t                              ·   ·
- │              0  ·       set       v                              ·   ·
- └── render     1  render  ·         ·                              ()  ·
-      │         1  ·       render 0  (k)[int]                       ·   ·
-      │         1  ·       render 1  (v)[int]                       ·   ·
-      │         1  ·       render 2  ((k)[int] + (1)[int])[int]     ·   ·
-      └── scan  2  scan    ·         ·                              ()  ·
-·               2  ·       table     t@primary                      ·   ·
-·               2  ·       filter    ((v)[int] > (123)[int])[bool]  ·   ·
+update          0  update  ·         ·                              ()                           ·
+ │              0  ·       table     t                              ·                            ·
+ │              0  ·       set       v                              ·                            ·
+ └── render     1  render  ·         ·                              (k int, v int, "k + 1" int)  ·
+      │         1  ·       render 0  (k)[int]                       ·                            ·
+      │         1  ·       render 1  (v)[int]                       ·                            ·
+      │         1  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
+      └── scan  2  scan    ·         ·                              (k int, v int)               ·
+·               2  ·       table     t@primary                      ·                            ·
+·               2  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
 
 query TITTTTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)
@@ -192,63 +192,63 @@ union        0  union   ·              ·                (column1 int)  ·
 query TITTTTT
 EXPLAIN (TYPES) SELECT DISTINCT k FROM t
 ----
-render     0  render  ·         ·          (k int)  k!=NULL; key(k)
- │         0  ·       render 0  (k)[int]   ·        ·
- └── scan  1  scan    ·         ·          (k int)  k!=NULL; key(k)
-·          1  ·       table     t@primary  ·        ·
-·          1  ·       spans     ALL        ·        ·
+render     0  render  ·         ·          (k int)                  k!=NULL; key(k)
+ │         0  ·       render 0  (k)[int]   ·                        ·
+ └── scan  1  scan    ·         ·          (k int, v[omitted] int)  k!=NULL; key(k)
+·          1  ·       table     t@primary  ·                        ·
+·          1  ·       spans     ALL        ·                        ·
 
 query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT DISTINCT k FROM t
 ----
-distinct        0  distinct  ·         ·          (k int)  weak-key(k)
- └── render     1  render    ·         ·          (k int)  weak-key(k)
-      │         1  ·         render 0  (k)[int]   ·        ·
-      └── scan  2  scan      ·         ·          (k int)  weak-key(k)
-·               2  ·         table     t@primary  ·        ·
+distinct        0  distinct  ·         ·          (k int)                  weak-key(k)
+ └── render     1  render    ·         ·          (k int)                  ·
+      │         1  ·         render 0  (k)[int]   ·                        ·
+      └── scan  2  scan      ·         ·          (k int, v[omitted] int)  ·
+·               2  ·         table     t@primary  ·                        ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT v FROM t ORDER BY v
 ----
-sort            0  sort    ·         ·          (v int)  +v
- │              0  ·       order     +v         ·        ·
- └── render     1  render  ·         ·          (v int)  +v
-      │         1  ·       render 0  (v)[int]   ·        ·
-      └── scan  2  scan    ·         ·          (v int)  +v
-·               2  ·       table     t@primary  ·        ·
-·               2  ·       spans     ALL        ·        ·
+sort            0  sort    ·         ·          (v int)                  +v
+ │              0  ·       order     +v         ·                        ·
+ └── render     1  render  ·         ·          (v int)                  ·
+      │         1  ·       render 0  (v)[int]   ·                        ·
+      └── scan  2  scan    ·         ·          (k[omitted] int, v int)  k!=NULL; key(k)
+·               2  ·       table     t@primary  ·                        ·
+·               2  ·       spans     ALL        ·                        ·
 
 query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t ORDER BY v
 ----
-nosort          0  nosort  ·         ·          (v int)  ·
- │              0  ·       order     +v         ·        ·
- └── render     1  render  ·         ·          (v int)  ·
-      │         1  ·       render 0  (v)[int]   ·        ·
-      └── scan  2  scan    ·         ·          (v int)  ·
-·               2  ·       table     t@primary  ·        ·
+nosort          0  nosort  ·         ·          (v int)                  ·
+ │              0  ·       order     +v         ·                        ·
+ └── render     1  render  ·         ·          (v int)                  ·
+      │         1  ·       render 0  (v)[int]   ·                        ·
+      └── scan  2  scan    ·         ·          (k[omitted] int, v int)  ·
+·               2  ·       table     t@primary  ·                        ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT v FROM t LIMIT 1
 ----
-limit           0  limit   ·         ·          (v int)  ·
- │              0  ·       count     (1)[int]   ·        ·
- └── render     1  render  ·         ·          (v int)  ·
-      │         1  ·       render 0  (v)[int]   ·        ·
-      └── scan  2  scan    ·         ·          (v int)  ·
-·               2  ·       table     t@primary  ·        ·
-·               2  ·       spans     ALL        ·        ·
-·               2  ·       limit     1          ·        ·
+limit           0  limit   ·         ·          (v int)                  ·
+ │              0  ·       count     (1)[int]   ·                        ·
+ └── render     1  render  ·         ·          (v int)                  ·
+      │         1  ·       render 0  (v)[int]   ·                        ·
+      └── scan  2  scan    ·         ·          (k[omitted] int, v int)  k!=NULL; key(k)
+·               2  ·       table     t@primary  ·                        ·
+·               2  ·       spans     ALL        ·                        ·
+·               2  ·       limit     1          ·                        ·
 
 query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT v FROM t LIMIT 1
 ----
-limit           0  limit   ·         ·          (v int)  ·
- │              0  ·       count     (1)[int]   ·        ·
- └── render     1  render  ·         ·          (v int)  ·
-      │         1  ·       render 0  (v)[int]   ·        ·
-      └── scan  2  scan    ·         ·          (v int)  ·
-·               2  ·       table     t@primary  ·        ·
+limit           0  limit   ·         ·          (v int)                  ·
+ │              0  ·       count     (1)[int]   ·                        ·
+ └── render     1  render  ·         ·          (v int)                  ·
+      │         1  ·       render 0  (v)[int]   ·                        ·
+      └── scan  2  scan    ·         ·          (k[omitted] int, v int)  ·
+·               2  ·       table     t@primary  ·                        ·
 
 statement ok
 CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
@@ -256,47 +256,47 @@ CREATE TABLE tt (x INT, y INT, INDEX a(x), INDEX b(y))
 query TITTTTT
 EXPLAIN (TYPES) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-render           0  render      ·         ·                             (x int, y int)  x!=NULL; y!=NULL
- │               0  ·           render 0  (x)[int]                      ·               ·
- │               0  ·           render 1  (y)[int]                      ·               ·
- └── index-join  1  index-join  ·         ·                             (x int, y int)  x!=NULL; y!=NULL
-      ├── scan   2  scan        ·         ·                             (x int, y int)  x!=NULL; y!=NULL
-      │          2  ·           table     tt@a                          ·               ·
-      │          2  ·           spans     /!NULL-/10                    ·               ·
-      └── scan   2  scan        ·         ·                             (x int, y int)  x!=NULL; y!=NULL
-·                2  ·           table     tt@primary                    ·               ·
-·                2  ·           filter    ((y)[int] > (10)[int])[bool]  ·               ·
+render           0  render      ·         ·                             (x int, y int)                                       x!=NULL; y!=NULL
+ │               0  ·           render 0  (x)[int]                      ·                                                    ·
+ │               0  ·           render 1  (y)[int]                      ·                                                    ·
+ └── index-join  1  index-join  ·         ·                             (x int, y int, rowid[hidden,omitted] int)            x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
+      ├── scan   2  scan        ·         ·                             (x[omitted] int, y[omitted] int, rowid[hidden] int)  x!=NULL; y!=NULL; rowid!=NULL; key(x,rowid)
+      │          2  ·           table     tt@a                          ·                                                    ·
+      │          2  ·           spans     /!NULL-/10                    ·                                                    ·
+      └── scan   2  scan        ·         ·                             (x int, y int, rowid[hidden,omitted] int)            ·
+·                2  ·           table     tt@primary                    ·                                                    ·
+·                2  ·           filter    ((y)[int] > (10)[int])[bool]  ·                                                    ·
 
 query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) SELECT * FROM tt WHERE x < 10 AND y > 10
 ----
-render     0  render  ·         ·                                                                          (x int, y int)  ·
- │         0  ·       render 0  (x)[int]                                                                   ·               ·
- │         0  ·       render 1  (y)[int]                                                                   ·               ·
- └── scan  1  scan    ·         ·                                                                          (x int, y int)  ·
-·          1  ·       table     tt@primary                                                                 ·               ·
-·          1  ·       filter    ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·               ·
+render     0  render  ·         ·                                                                          (x int, y int)                             ·
+ │         0  ·       render 0  (x)[int]                                                                   ·                                          ·
+ │         0  ·       render 1  (y)[int]                                                                   ·                                          ·
+ └── scan  1  scan    ·         ·                                                                          (x int, y int, rowid[hidden,omitted] int)  ·
+·          1  ·       table     tt@primary                                                                 ·                                          ·
+·          1  ·       filter    ((((x)[int] < (10)[int])[bool]) AND (((y)[int] > (10)[int])[bool]))[bool]  ·                                          ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT $1 + 2 AS a
 ----
 render         0  render    ·         ·                            (a int)  a=CONST
  │             0  ·         render 0  (($1)[int] + (2)[int])[int]  ·        ·
- └── emptyrow  1  emptyrow  ·         ·                            (a int)  a=CONST
+ └── emptyrow  1  emptyrow  ·         ·                            ()       ·
 
 query TITTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT ABS(2-3) AS a
 ----
 render         0  render    ·         ·                      (a int)  a=CONST
  │             0  ·         render 0  (abs((-1)[int]))[int]  ·        ·
- └── emptyrow  1  emptyrow  ·         ·                      (a int)  a=CONST
+ └── emptyrow  1  emptyrow  ·         ·                      ()       ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT ABS(2-3) AS a
 ----
 render         0  render    ·         ·         (a int)  a=CONST
  │             0  ·         render 0  (1)[int]  ·        ·
- └── emptyrow  1  emptyrow  ·         ·         (a int)  a=CONST
+ └── emptyrow  1  emptyrow  ·         ·         ()       ·
 
 # Check array subscripts (#13811)
 query TITTTTT
@@ -304,6 +304,6 @@ EXPLAIN (TYPES) SELECT x[1] FROM (SELECT ARRAY[1,2,3] AS x)
 ----
 render              0  render    ·         ·                                           ("x[1]" int)  ·
  │                  0  ·         render 0  ((x)[int[]][(1)[int]])[int]                 ·             ·
- └── render         1  render    ·         ·                                           ("x[1]" int)  ·
+ └── render         1  render    ·         ·                                           (x int[])     x=CONST
       │             1  ·         render 0  (ARRAY[(1)[int],(2)[int],(3)[int]])[int[]]  ·             ·
-      └── emptyrow  2  emptyrow  ·         ·                                           ("x[1]" int)  ·
+      └── emptyrow  2  emptyrow  ·         ·                                           ()            ·

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -623,75 +623,75 @@ CREATE TABLE s(x INT); INSERT INTO s(x) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(
 query TITTTTT
 EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
-render          0  render  ·      ·                  (x, y)  ·
- └── join       1  join    ·      ·                  (x, y)  ·
-      │         1  ·       type   cross              ·       ·
-      ├── scan  2  scan    ·      ·                  (x, y)  ·
-      │         2  ·       table  twocolumn@primary  ·       ·
-      │         2  ·       spans  ALL                ·       ·
-      └── scan  2  scan    ·      ·                  (x, y)  ·
-·               2  ·       table  twocolumn@primary  ·       ·
-·               2  ·       spans  ALL                ·       ·
+render          0  render  ·      ·                  (x, y)                                                                        ·
+ └── join       1  join    ·      ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
+      │         1  ·       type   cross              ·                                                                             ·
+      ├── scan  2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                        rowid!=NULL; key(rowid)
+      │         2  ·       table  twocolumn@primary  ·                                                                             ·
+      │         2  ·       spans  ALL                ·                                                                             ·
+      └── scan  2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                        rowid!=NULL; key(rowid)
+·               2  ·       table  twocolumn@primary  ·                                                                             ·
+·               2  ·       spans  ALL                ·                                                                             ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
-render          0  render  ·         ·                  (y)  ·
- └── join       1  join    ·         ·                  (y)  ·
-      │         1  ·       type      inner              ·    ·
-      │         1  ·       equality  (x) = (x)          ·    ·
-      ├── scan  2  scan    ·         ·                  (y)  ·
-      │         2  ·       table     twocolumn@primary  ·    ·
-      │         2  ·       spans     ALL                ·    ·
-      └── scan  2  scan    ·         ·                  (y)  ·
-·               2  ·       table     twocolumn@primary  ·    ·
-·               2  ·       spans     ALL                ·    ·
+render          0  render  ·         ·                  (y)                                                                                    ·
+ └── join       1  join    ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
+      │         1  ·       type      inner              ·                                                                                      ·
+      │         1  ·       equality  (x) = (x)          ·                                                                                      ·
+      ├── scan  2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
+      │         2  ·       table     twocolumn@primary  ·                                                                                      ·
+      │         2  ·       spans     ALL                ·                                                                                      ·
+      └── scan  2  scan    ·         ·                  (x, y, rowid[hidden,omitted])                                                          rowid!=NULL; key(rowid)
+·               2  ·       table     twocolumn@primary  ·                                                                                      ·
+·               2  ·       spans     ALL                ·                                                                                      ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
-render          0  render  ·         ·                  (y)  ·
- └── join       1  join    ·         ·                  (y)  ·
-      │         1  ·       type      inner              ·    ·
-      │         1  ·       equality  (x) = (x)          ·    ·
-      ├── scan  2  scan    ·         ·                  (y)  ·
-      │         2  ·       table     twocolumn@primary  ·    ·
-      │         2  ·       spans     ALL                ·    ·
-      └── scan  2  scan    ·         ·                  (y)  ·
-·               2  ·       table     twocolumn@primary  ·    ·
-·               2  ·       spans     ALL                ·    ·
+render          0  render  ·         ·                  (y)                                                                                    ·
+ └── join       1  join    ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
+      │         1  ·       type      inner              ·                                                                                      ·
+      │         1  ·       equality  (x) = (x)          ·                                                                                      ·
+      ├── scan  2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
+      │         2  ·       table     twocolumn@primary  ·                                                                                      ·
+      │         2  ·       spans     ALL                ·                                                                                      ·
+      └── scan  2  scan    ·         ·                  (x, y, rowid[hidden,omitted])                                                          rowid!=NULL; key(rowid)
+·               2  ·       table     twocolumn@primary  ·                                                                                      ·
+·               2  ·       spans     ALL                ·                                                                                      ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
-render          0  render  ·      ·                  (x)  ·
- └── join       1  join    ·      ·                  (x)  ·
-      │         1  ·       type   inner              ·    ·
-      ├── scan  2  scan    ·      ·                  (x)  ·
-      │         2  ·       table  twocolumn@primary  ·    ·
-      │         2  ·       spans  ALL                ·    ·
-      └── scan  2  scan    ·      ·                  (x)  ·
-·               2  ·       table  twocolumn@primary  ·    ·
-·               2  ·       spans  ALL                ·    ·
+render          0  render  ·      ·                  (x)                                                                                    ·
+ └── join       1  join    ·      ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
+      │         1  ·       type   inner              ·                                                                                      ·
+      ├── scan  2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
+      │         2  ·       table  twocolumn@primary  ·                                                                                      ·
+      │         2  ·       spans  ALL                ·                                                                                      ·
+      └── scan  2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
+·               2  ·       table  twocolumn@primary  ·                                                                                      ·
+·               2  ·       spans  ALL                ·                                                                                      ·
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
                 INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
-sort                             0  sort    ·         ·                  (k, u, w)  +u
- │                               0  ·       order     +u                 ·          ·
- └── render                      1  render  ·         ·                  (k, u, w)  +u
-      └── render                 2  render  ·         ·                  (k, u, w)  +u
-           └── join              3  join    ·         ·                  (k, u, w)  +u
-                │                3  ·       type      inner              ·          ·
-                │                3  ·       equality  (k) = (k)          ·          ·
-                ├── sort         4  sort    ·         ·                  (k, u, w)  +u
-                │    │           4  ·       order     +k                 ·          ·
-                │    └── values  5  values  ·         ·                  (k, u, w)  +u
-                │                5  ·       size      2 columns, 2 rows  ·          ·
-                └── values       4  values  ·         ·                  (k, u, w)  +u
-·                                4  ·       size      2 columns, 2 rows  ·          ·
+sort                             0  sort    ·         ·                  (k, u, w)                     +u
+ │                               0  ·       order     +u                 ·                             ·
+ └── render                      1  render  ·         ·                  (k, u, w)                     ·
+      └── render                 2  render  ·         ·                  (k, u, k[hidden,omitted], w)  ·
+           └── join              3  join    ·         ·                  (u, k, k[omitted], w)         ·
+                │                3  ·       type      inner              ·                             ·
+                │                3  ·       equality  (k) = (k)          ·                             ·
+                ├── sort         4  sort    ·         ·                  (u, k)                        +k
+                │    │           4  ·       order     +k                 ·                             ·
+                │    └── values  5  values  ·         ·                  (u, k)                        ·
+                │                5  ·       size      2 columns, 2 rows  ·                             ·
+                └── values       4  values  ·         ·                  (column1, column2)            ·
+·                                4  ·       size      2 columns, 2 rows  ·                             ·
 
 # Ensure that large cross-joins are optimized somehow (#10633)
 statement ok
@@ -940,20 +940,20 @@ SELECT * FROM pairs, square WHERE pairs.b = square.n
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 ----
-render          0  render  ·         ·                                               (a, b, n, sq)  ·
- │              0  ·       render 0  test.pairs.a                                    ·              ·
- │              0  ·       render 1  test.pairs.b                                    ·              ·
- │              0  ·       render 2  test.square.n                                   ·              ·
- │              0  ·       render 3  test.square.sq                                  ·              ·
- └── join       1  join    ·         ·                                               (a, b, n, sq)  ·
-      │         1  ·       type      inner                                           ·              ·
-      │         1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·              ·
-      ├── scan  2  scan    ·         ·                                               (a, b, n, sq)  ·
-      │         2  ·       table     pairs@primary                                   ·              ·
-      │         2  ·       spans     ALL                                             ·              ·
-      └── scan  2  scan    ·         ·                                               (a, b, n, sq)  ·
-·               2  ·       table     square@primary                                  ·              ·
-·               2  ·       spans     ALL                                             ·              ·
+render          0  render  ·         ·                                               (a, b, n, sq)                         ·
+ │              0  ·       render 0  test.pairs.a                                    ·                                     ·
+ │              0  ·       render 1  test.pairs.b                                    ·                                     ·
+ │              0  ·       render 2  test.square.n                                   ·                                     ·
+ │              0  ·       render 3  test.square.sq                                  ·                                     ·
+ └── join       1  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
+      │         1  ·       type      inner                                           ·                                     ·
+      │         1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
+      ├── scan  2  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
+      │         2  ·       table     pairs@primary                                   ·                                     ·
+      │         2  ·       spans     ALL                                             ·                                     ·
+      └── scan  2  scan    ·         ·                                               (n, sq)                               n!=NULL; key(n)
+·               2  ·       table     square@primary                                  ·                                     ·
+·               2  ·       spans     ALL                                             ·                                     ·
 
 query IIII rowsort
 SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
@@ -968,27 +968,27 @@ SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
 ----
-render                    0  render  ·         ·                            (a, b, n, sq)  sq!=NULL
- │                        0  ·       render 0  a                            ·              ·
- │                        0  ·       render 1  b                            ·              ·
- │                        0  ·       render 2  n                            ·              ·
- │                        0  ·       render 3  sq                           ·              ·
- └── filter               1  filter  ·         ·                            (a, b, n, sq)  sq!=NULL
-      │                   1  ·       filter    sum = sq                     ·              ·
-      └── render          2  render  ·         ·                            (a, b, n, sq)  sq!=NULL
-           │              2  ·       render 0  test.pairs.a                 ·              ·
-           │              2  ·       render 1  test.pairs.b                 ·              ·
-           │              2  ·       render 2  test.pairs.a + test.pairs.b  ·              ·
-           │              2  ·       render 3  test.square.n                ·              ·
-           │              2  ·       render 4  test.square.sq               ·              ·
-           └── join       3  join    ·         ·                            (a, b, n, sq)  sq!=NULL
-                │         3  ·       type      cross                        ·              ·
-                ├── scan  4  scan    ·         ·                            (a, b, n, sq)  sq!=NULL
-                │         4  ·       table     pairs@primary                ·              ·
-                │         4  ·       spans     ALL                          ·              ·
-                └── scan  4  scan    ·         ·                            (a, b, n, sq)  sq!=NULL
-·                         4  ·       table     square@primary               ·              ·
-·                         4  ·       spans     ALL                          ·              ·
+render                    0  render  ·         ·                            (a, b, n, sq)                         sq!=NULL
+ │                        0  ·       render 0  a                            ·                                     ·
+ │                        0  ·       render 1  b                            ·                                     ·
+ │                        0  ·       render 2  n                            ·                                     ·
+ │                        0  ·       render 3  sq                           ·                                     ·
+ └── filter               1  filter  ·         ·                            (a, b, sum, n, sq)                    sum=sq; sum!=NULL; sq!=NULL
+      │                   1  ·       filter    sum = sq                     ·                                     ·
+      └── render          2  render  ·         ·                            (a, b, sum, n, sq)                    ·
+           │              2  ·       render 0  test.pairs.a                 ·                                     ·
+           │              2  ·       render 1  test.pairs.b                 ·                                     ·
+           │              2  ·       render 2  test.pairs.a + test.pairs.b  ·                                     ·
+           │              2  ·       render 3  test.square.n                ·                                     ·
+           │              2  ·       render 4  test.square.sq               ·                                     ·
+           └── join       3  join    ·         ·                            (a, b, rowid[hidden,omitted], n, sq)  ·
+                │         3  ·       type      cross                        ·                                     ·
+                ├── scan  4  scan    ·         ·                            (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
+                │         4  ·       table     pairs@primary                ·                                     ·
+                │         4  ·       spans     ALL                          ·                                     ·
+                └── scan  4  scan    ·         ·                            (n, sq)                               n!=NULL; key(n)
+·                         4  ·       table     square@primary               ·                                     ·
+·                         4  ·       spans     ALL                          ·                                     ·
 
 query IIII rowsort
 SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
@@ -1001,20 +1001,20 @@ SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WH
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
-render          0  render  ·         ·                                               (a, b, n, sq)  ·
- │              0  ·       render 0  test.pairs.a                                    ·              ·
- │              0  ·       render 1  test.pairs.b                                    ·              ·
- │              0  ·       render 2  test.square.n                                   ·              ·
- │              0  ·       render 3  test.square.sq                                  ·              ·
- └── join       1  join    ·         ·                                               (a, b, n, sq)  ·
-      │         1  ·       type      full outer                                      ·              ·
-      │         1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·              ·
-      ├── scan  2  scan    ·         ·                                               (a, b, n, sq)  ·
-      │         2  ·       table     pairs@primary                                   ·              ·
-      │         2  ·       spans     ALL                                             ·              ·
-      └── scan  2  scan    ·         ·                                               (a, b, n, sq)  ·
-·               2  ·       table     square@primary                                  ·              ·
-·               2  ·       spans     ALL                                             ·              ·
+render          0  render  ·         ·                                               (a, b, n, sq)                         ·
+ │              0  ·       render 0  test.pairs.a                                    ·                                     ·
+ │              0  ·       render 1  test.pairs.b                                    ·                                     ·
+ │              0  ·       render 2  test.square.n                                   ·                                     ·
+ │              0  ·       render 3  test.square.sq                                  ·                                     ·
+ └── join       1  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
+      │         1  ·       type      full outer                                      ·                                     ·
+      │         1  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
+      ├── scan  2  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
+      │         2  ·       table     pairs@primary                                   ·                                     ·
+      │         2  ·       spans     ALL                                             ·                                     ·
+      └── scan  2  scan    ·         ·                                               (n, sq)                               n!=NULL; key(n)
+·               2  ·       table     square@primary                                  ·                                     ·
+·               2  ·       spans     ALL                                             ·                                     ·
 
 query IIII rowsort
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
@@ -1042,22 +1042,22 @@ NULL  NULL  6     36
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
-render               0  render  ·         ·                                               (a, b, n, sq)  b!=NULL; sq!=NULL
- │                   0  ·       render 0  test.pairs.a                                    ·              ·
- │                   0  ·       render 1  test.pairs.b                                    ·              ·
- │                   0  ·       render 2  test.square.n                                   ·              ·
- │                   0  ·       render 3  test.square.sq                                  ·              ·
- └── filter          1  filter  ·         ·                                               (a, b, n, sq)  b!=NULL; sq!=NULL
-      │              1  ·       filter    (test.pairs.b % 2) != (test.square.sq % 2)      ·              ·
-      └── join       2  join    ·         ·                                               (a, b, n, sq)  b!=NULL; sq!=NULL
-           │         2  ·       type      full outer                                      ·              ·
-           │         2  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·              ·
-           ├── scan  3  scan    ·         ·                                               (a, b, n, sq)  b!=NULL; sq!=NULL
-           │         3  ·       table     pairs@primary                                   ·              ·
-           │         3  ·       spans     ALL                                             ·              ·
-           └── scan  3  scan    ·         ·                                               (a, b, n, sq)  b!=NULL; sq!=NULL
-·                    3  ·       table     square@primary                                  ·              ·
-·                    3  ·       spans     ALL                                             ·              ·
+render               0  render  ·         ·                                               (a, b, n, sq)                         b!=NULL; sq!=NULL
+ │                   0  ·       render 0  test.pairs.a                                    ·                                     ·
+ │                   0  ·       render 1  test.pairs.b                                    ·                                     ·
+ │                   0  ·       render 2  test.square.n                                   ·                                     ·
+ │                   0  ·       render 3  test.square.sq                                  ·                                     ·
+ └── filter          1  filter  ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  b!=NULL; sq!=NULL
+      │              1  ·       filter    (test.pairs.b % 2) != (test.square.sq % 2)      ·                                     ·
+      └── join       2  join    ·         ·                                               (a, b, rowid[hidden,omitted], n, sq)  ·
+           │         2  ·       type      full outer                                      ·                                     ·
+           │         2  ·       pred      (test.pairs.a + test.pairs.b) = test.square.sq  ·                                     ·
+           ├── scan  3  scan    ·         ·                                               (a, b, rowid[hidden,omitted])         rowid!=NULL; key(rowid)
+           │         3  ·       table     pairs@primary                                   ·                                     ·
+           │         3  ·       spans     ALL                                             ·                                     ·
+           └── scan  3  scan    ·         ·                                               (n, sq)                               n!=NULL; key(n)
+·                    3  ·       table     square@primary                                  ·                                     ·
+·                    3  ·       spans     ALL                                             ·                                     ·
 
 query IIII rowsort
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
@@ -1250,32 +1250,32 @@ SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
-render                    0  render  ·         ·                (x)  ·
- │                        0  ·       render 0  test.t1.x        ·    ·
- └── render               1  render  ·         ·                (x)  ·
-      │                   1  ·       render 0  test.t1.x        ·    ·
-      │                   1  ·       render 1  NULL             ·    ·
-      │                   1  ·       render 2  NULL             ·    ·
-      │                   1  ·       render 3  NULL             ·    ·
-      │                   1  ·       render 4  NULL             ·    ·
-      │                   1  ·       render 5  NULL             ·    ·
-      │                   1  ·       render 6  NULL             ·    ·
-      │                   1  ·       render 7  NULL             ·    ·
-      │                   1  ·       render 8  NULL             ·    ·
-      └── join            2  join    ·         ·                (x)  ·
-           │              2  ·       type      inner            ·    ·
-           │              2  ·       equality  (x, y) = (x, y)  ·    ·
-           ├── scan       3  scan    ·         ·                (x)  ·
-           │              3  ·       table     t1@primary       ·    ·
-           │              3  ·       spans     ALL              ·    ·
-           └── render     3  render  ·         ·                (x)  ·
-                │         3  ·       render 0  NULL             ·    ·
-                │         3  ·       render 1  test.t2.y        ·    ·
-                │         3  ·       render 2  test.t2.x        ·    ·
-                │         3  ·       render 3  NULL             ·    ·
-                └── scan  4  scan    ·         ·                (x)  ·
-·                         4  ·       table     t2@primary       ·    ·
-·                         4  ·       spans     ALL              ·    ·
+render                    0  render  ·         ·                (x)                                                                                                                                       ·
+ │                        0  ·       render 0  test.t1.x        ·                                                                                                                                         ·
+ └── render               1  render  ·         ·                (x, y[omitted], col1[omitted], col2[omitted], rowid[hidden,omitted], col3[omitted], y[hidden,omitted], x[hidden,omitted], col4[omitted])  ·
+      │                   1  ·       render 0  test.t1.x        ·                                                                                                                                         ·
+      │                   1  ·       render 1  NULL             ·                                                                                                                                         ·
+      │                   1  ·       render 2  NULL             ·                                                                                                                                         ·
+      │                   1  ·       render 3  NULL             ·                                                                                                                                         ·
+      │                   1  ·       render 4  NULL             ·                                                                                                                                         ·
+      │                   1  ·       render 5  NULL             ·                                                                                                                                         ·
+      │                   1  ·       render 6  NULL             ·                                                                                                                                         ·
+      │                   1  ·       render 7  NULL             ·                                                                                                                                         ·
+      │                   1  ·       render 8  NULL             ·                                                                                                                                         ·
+      └── join            2  join    ·         ·                (col1[omitted], x, col2[omitted], y[omitted], rowid[hidden,omitted], col3[omitted], y[omitted], x[omitted], col4[omitted])                ·
+           │              2  ·       type      inner            ·                                                                                                                                         ·
+           │              2  ·       equality  (x, y) = (x, y)  ·                                                                                                                                         ·
+           ├── scan       3  scan    ·         ·                (col1[omitted], x, col2[omitted], y, rowid[hidden,omitted])                                                                               rowid!=NULL; key(rowid)
+           │              3  ·       table     t1@primary       ·                                                                                                                                         ·
+           │              3  ·       spans     ALL              ·                                                                                                                                         ·
+           └── render     3  render  ·         ·                (col3[omitted], y, x, col4[omitted])                                                                                                      ·
+                │         3  ·       render 0  NULL             ·                                                                                                                                         ·
+                │         3  ·       render 1  test.t2.y        ·                                                                                                                                         ·
+                │         3  ·       render 2  test.t2.x        ·                                                                                                                                         ·
+                │         3  ·       render 3  NULL             ·                                                                                                                                         ·
+                └── scan  4  scan    ·         ·                (col3[omitted], y, x, col4[omitted], rowid[hidden,omitted])                                                                               rowid!=NULL; key(rowid)
+·                         4  ·       table     t2@primary       ·                                                                                                                                         ·
+·                         4  ·       spans     ALL              ·                                                                                                                                         ·
 
 # Tests for merge join ordering information.
 statement ok
@@ -1297,51 +1297,51 @@ join       0  join  ·               ·                      (a, b, c, d, a, b, 
  │         0  ·     type            inner                  ·                         ·
  │         0  ·     equality        (a, b, c) = (a, b, c)  ·                         ·
  │         0  ·     mergeJoinOrder  +"(b=b)"               ·                         ·
- ├── scan  1  scan  ·               ·                      (a, b, c, d, a, b, c, d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b); key(b,c)
+ ├── scan  1  scan  ·               ·                      (a, b, c, d)              a!=NULL; b!=NULL; key(a,b); +b
  │         1  ·     table           pkba@primary           ·                         ·
  │         1  ·     spans           ALL                    ·                         ·
- └── scan  1  scan  ·               ·                      (a, b, c, d, a, b, c, d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b); key(b,c)
+ └── scan  1  scan  ·               ·                      (a, b, c, d)              b!=NULL; c!=NULL; key(b,c); +b
 ·          1  ·     table           pkbc@primary           ·                         ·
 ·          1  ·     spans           ALL                    ·                         ·
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
-render          0  render  ·               ·                            (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
- │              0  ·       render 0        test.pkba.a                  ·             ·
- │              0  ·       render 1        test.pkba.b                  ·             ·
- │              0  ·       render 2        test.pkba.c                  ·             ·
- │              0  ·       render 3        test.pkba.d                  ·             ·
- └── join       1  join    ·               ·                            (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
-      │         1  ·       type            inner                        ·             ·
-      │         1  ·       equality        (a, b, c, d) = (a, b, c, d)  ·             ·
-      │         1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(d=d)"   ·             ·
-      ├── scan  2  scan    ·               ·                            (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
-      │         2  ·       table           pkba@primary                 ·             ·
-      │         2  ·       spans           ALL                          ·             ·
-      └── scan  2  scan    ·               ·                            (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
-·               2  ·       table           pkbad@primary                ·             ·
-·               2  ·       spans           ALL                          ·             ·
+render          0  render  ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
+ │              0  ·       render 0        test.pkba.a                  ·                                                             ·
+ │              0  ·       render 1        test.pkba.b                  ·                                                             ·
+ │              0  ·       render 2        test.pkba.c                  ·                                                             ·
+ │              0  ·       render 3        test.pkba.d                  ·                                                             ·
+ └── join       1  join    ·               ·                            (a, b, c, d, a[omitted], b[omitted], c[omitted], d[omitted])  a=a; b=b; c=c; d=d; a!=NULL; b!=NULL; c!=NULL; d!=NULL; key(a,b)
+      │         1  ·       type            inner                        ·                                                             ·
+      │         1  ·       equality        (a, b, c, d) = (a, b, c, d)  ·                                                             ·
+      │         1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(d=d)"   ·                                                             ·
+      ├── scan  2  scan    ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; key(a,b); +b,+a
+      │         2  ·       table           pkba@primary                 ·                                                             ·
+      │         2  ·       spans           ALL                          ·                                                             ·
+      └── scan  2  scan    ·               ·                            (a, b, c, d)                                                  a!=NULL; b!=NULL; d!=NULL; key(a,b,d); +b,+a,+d
+·               2  ·       table           pkbad@primary                ·                                                             ·
+·               2  ·       spans           ALL                          ·                                                             ·
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
-render          0  render  ·               ·                           (a, b, c, d, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
- │              0  ·       render 0        l.a                         ·                ·
- │              0  ·       render 1        l.b                         ·                ·
- │              0  ·       render 2        l.c                         ·                ·
- │              0  ·       render 3        l.d                         ·                ·
- │              0  ·       render 4        r.d                         ·                ·
- └── join       1  join    ·               ·                           (a, b, c, d, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-      │         1  ·       type            inner                       ·                ·
-      │         1  ·       equality        (a, b, c) = (a, b, c)       ·                ·
-      │         1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                ·
-      ├── scan  2  scan    ·               ·                           (a, b, c, d, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-      │         2  ·       table           pkbac@primary               ·                ·
-      │         2  ·       spans           ALL                         ·                ·
-      └── scan  2  scan    ·               ·                           (a, b, c, d, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·               2  ·       table           pkbac@primary               ·                ·
-·               2  ·       spans           ALL                         ·                ·
+render          0  render  ·               ·                           (a, b, c, d, d)                                      a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ │              0  ·       render 0        l.a                         ·                                                    ·
+ │              0  ·       render 1        l.b                         ·                                                    ·
+ │              0  ·       render 2        l.c                         ·                                                    ·
+ │              0  ·       render 3        l.d                         ·                                                    ·
+ │              0  ·       render 4        r.d                         ·                                                    ·
+ └── join       1  join    ·               ·                           (a, b, c, d, a[omitted], b[omitted], c[omitted], d)  a=a; b=b; c=c; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+      │         1  ·       type            inner                       ·                                                    ·
+      │         1  ·       equality        (a, b, c) = (a, b, c)       ·                                                    ·
+      │         1  ·       mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=c)"  ·                                                    ·
+      ├── scan  2  scan    ·               ·                           (a, b, c, d)                                         a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
+      │         2  ·       table           pkbac@primary               ·                                                    ·
+      │         2  ·       spans           ALL                         ·                                                    ·
+      └── scan  2  scan    ·               ·                           (a, b, c, d)                                         a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
+·               2  ·       table           pkbac@primary               ·                                                    ·
+·               2  ·       spans           ALL                         ·                                                    ·
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
@@ -1350,10 +1350,10 @@ join       0  join  ·               ·                           (a, b, c, d, a
  │         0  ·     type            inner                       ·                         ·
  │         0  ·     equality        (c, a, b) = (d, a, b)       ·                         ·
  │         0  ·     mergeJoinOrder  +"(b=b)",+"(a=a)",+"(c=d)"  ·                         ·
- ├── scan  1  scan  ·               ·                           (a, b, c, d, a, b, c, d)  a=a; b=b; c=d; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ ├── scan  1  scan  ·               ·                           (a, b, c, d)              a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +b,+a,+c
  │         1  ·     table           pkbac@primary               ·                         ·
  │         1  ·     spans           ALL                         ·                         ·
- └── scan  1  scan  ·               ·                           (a, b, c, d, a, b, c, d)  a=a; b=b; c=d; a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ └── scan  1  scan  ·               ·                           (a, b, c, d)              a!=NULL; b!=NULL; d!=NULL; key(a,b,d); +b,+a,+d
 ·          1  ·     table           pkbad@primary               ·                         ·
 ·          1  ·     spans           ALL                         ·                         ·
 
@@ -1373,24 +1373,24 @@ INSERT INTO str2 VALUES (1, 'A' COLLATE en_u_ks_level1), (2, 'B' COLLATE en_u_ks
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
 ----
-render               0  render  ·         ·             (s, s, s)  s=s
- │                   0  ·       render 0  test.str1.s   ·          ·
- │                   0  ·       render 1  test.str1.s   ·          ·
- │                   0  ·       render 2  test.str2.s   ·          ·
- └── render          1  render  ·         ·             (s, s, s)  s=s
-      │              1  ·       render 0  test.str1.s   ·          ·
-      │              1  ·       render 1  NULL          ·          ·
-      │              1  ·       render 2  NULL          ·          ·
-      │              1  ·       render 3  test.str2.s   ·          ·
-      └── join       2  join    ·         ·             (s, s, s)  s=s
-           │         2  ·       type      inner         ·          ·
-           │         2  ·       equality  (s) = (s)     ·          ·
-           ├── scan  3  scan    ·         ·             (s, s, s)  s=s
-           │         3  ·       table     str1@primary  ·          ·
-           │         3  ·       spans     ALL           ·          ·
-           └── scan  3  scan    ·         ·             (s, s, s)  s=s
-·                    3  ·       table     str2@primary  ·          ·
-·                    3  ·       spans     ALL           ·          ·
+render               0  render  ·         ·             (s, s, s)                               s=s
+ │                   0  ·       render 0  test.str1.s   ·                                       ·
+ │                   0  ·       render 1  test.str1.s   ·                                       ·
+ │                   0  ·       render 2  test.str2.s   ·                                       ·
+ └── render          1  render  ·         ·             (s, a[omitted], a[omitted], s[hidden])  ·
+      │              1  ·       render 0  test.str1.s   ·                                       ·
+      │              1  ·       render 1  NULL          ·                                       ·
+      │              1  ·       render 2  NULL          ·                                       ·
+      │              1  ·       render 3  test.str2.s   ·                                       ·
+      └── join       2  join    ·         ·             (a[omitted], s, a[omitted], s)          ·
+           │         2  ·       type      inner         ·                                       ·
+           │         2  ·       equality  (s) = (s)     ·                                       ·
+           ├── scan  3  scan    ·         ·             (a[omitted], s)                         a!=NULL; key(a)
+           │         3  ·       table     str1@primary  ·                                       ·
+           │         3  ·       spans     ALL           ·                                       ·
+           └── scan  3  scan    ·         ·             (a[omitted], s)                         a!=NULL; key(a)
+·                    3  ·       table     str2@primary  ·                                       ·
+·                    3  ·       spans     ALL           ·                                       ·
 
 query TTT rowsort
 SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
@@ -1402,24 +1402,24 @@ c  c  C
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
 ----
-render               0  render  ·         ·             (s, s, s)  s=s
- │                   0  ·       render 0  test.str1.s   ·          ·
- │                   0  ·       render 1  test.str1.s   ·          ·
- │                   0  ·       render 2  test.str2.s   ·          ·
- └── render          1  render  ·         ·             (s, s, s)  s=s
-      │              1  ·       render 0  test.str1.s   ·          ·
-      │              1  ·       render 1  NULL          ·          ·
-      │              1  ·       render 2  NULL          ·          ·
-      │              1  ·       render 3  test.str2.s   ·          ·
-      └── join       2  join    ·         ·             (s, s, s)  s=s
-           │         2  ·       type      left outer    ·          ·
-           │         2  ·       equality  (s) = (s)     ·          ·
-           ├── scan  3  scan    ·         ·             (s, s, s)  s=s
-           │         3  ·       table     str1@primary  ·          ·
-           │         3  ·       spans     ALL           ·          ·
-           └── scan  3  scan    ·         ·             (s, s, s)  s=s
-·                    3  ·       table     str2@primary  ·          ·
-·                    3  ·       spans     ALL           ·          ·
+render               0  render  ·         ·             (s, s, s)                               s=s
+ │                   0  ·       render 0  test.str1.s   ·                                       ·
+ │                   0  ·       render 1  test.str1.s   ·                                       ·
+ │                   0  ·       render 2  test.str2.s   ·                                       ·
+ └── render          1  render  ·         ·             (s, a[omitted], a[omitted], s[hidden])  ·
+      │              1  ·       render 0  test.str1.s   ·                                       ·
+      │              1  ·       render 1  NULL          ·                                       ·
+      │              1  ·       render 2  NULL          ·                                       ·
+      │              1  ·       render 3  test.str2.s   ·                                       ·
+      └── join       2  join    ·         ·             (a[omitted], s, a[omitted], s)          ·
+           │         2  ·       type      left outer    ·                                       ·
+           │         2  ·       equality  (s) = (s)     ·                                       ·
+           ├── scan  3  scan    ·         ·             (a[omitted], s)                         a!=NULL; key(a)
+           │         3  ·       table     str1@primary  ·                                       ·
+           │         3  ·       spans     ALL           ·                                       ·
+           └── scan  3  scan    ·         ·             (a[omitted], s)                         a!=NULL; key(a)
+·                    3  ·       table     str2@primary  ·                                       ·
+·                    3  ·       spans     ALL           ·                                       ·
 
 query TTT rowsort
 SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
@@ -1432,25 +1432,25 @@ D  D  NULL
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
 ----
-render               0  render  ·         ·                                 (s, s, s)  ·
- │                   0  ·       render 0  s                                 ·          ·
- │                   0  ·       render 1  test.str1.s                       ·          ·
- │                   0  ·       render 2  test.str2.s                       ·          ·
- └── render          1  render  ·         ·                                 (s, s, s)  ·
-      │              1  ·       render 0  IFNULL(test.str1.s, test.str2.s)  ·          ·
-      │              1  ·       render 1  NULL                              ·          ·
-      │              1  ·       render 2  test.str1.s                       ·          ·
-      │              1  ·       render 3  NULL                              ·          ·
-      │              1  ·       render 4  test.str2.s                       ·          ·
-      └── join       2  join    ·         ·                                 (s, s, s)  ·
-           │         2  ·       type      right outer                       ·          ·
-           │         2  ·       equality  (s) = (s)                         ·          ·
-           ├── scan  3  scan    ·         ·                                 (s, s, s)  ·
-           │         3  ·       table     str1@primary                      ·          ·
-           │         3  ·       spans     ALL                               ·          ·
-           └── scan  3  scan    ·         ·                                 (s, s, s)  ·
-·                    3  ·       table     str2@primary                      ·          ·
-·                    3  ·       spans     ALL                               ·          ·
+render               0  render  ·         ·                                 (s, s, s)                                          ·
+ │                   0  ·       render 0  s                                 ·                                                  ·
+ │                   0  ·       render 1  test.str1.s                       ·                                                  ·
+ │                   0  ·       render 2  test.str2.s                       ·                                                  ·
+ └── render          1  render  ·         ·                                 (s, a[omitted], s[hidden], a[omitted], s[hidden])  ·
+      │              1  ·       render 0  IFNULL(test.str1.s, test.str2.s)  ·                                                  ·
+      │              1  ·       render 1  NULL                              ·                                                  ·
+      │              1  ·       render 2  test.str1.s                       ·                                                  ·
+      │              1  ·       render 3  NULL                              ·                                                  ·
+      │              1  ·       render 4  test.str2.s                       ·                                                  ·
+      └── join       2  join    ·         ·                                 (a[omitted], s, a[omitted], s)                     ·
+           │         2  ·       type      right outer                       ·                                                  ·
+           │         2  ·       equality  (s) = (s)                         ·                                                  ·
+           ├── scan  3  scan    ·         ·                                 (a[omitted], s)                                    a!=NULL; key(a)
+           │         3  ·       table     str1@primary                      ·                                                  ·
+           │         3  ·       spans     ALL                               ·                                                  ·
+           └── scan  3  scan    ·         ·                                 (a[omitted], s)                                    a!=NULL; key(a)
+·                    3  ·       table     str2@primary                      ·                                                  ·
+·                    3  ·       spans     ALL                               ·                                                  ·
 
 
 query TTT rowsort
@@ -1465,25 +1465,25 @@ E  NULL  E
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
 ----
-render               0  render  ·         ·                                 (s, s, s)  ·
- │                   0  ·       render 0  s                                 ·          ·
- │                   0  ·       render 1  test.str1.s                       ·          ·
- │                   0  ·       render 2  test.str2.s                       ·          ·
- └── render          1  render  ·         ·                                 (s, s, s)  ·
-      │              1  ·       render 0  IFNULL(test.str1.s, test.str2.s)  ·          ·
-      │              1  ·       render 1  NULL                              ·          ·
-      │              1  ·       render 2  test.str1.s                       ·          ·
-      │              1  ·       render 3  NULL                              ·          ·
-      │              1  ·       render 4  test.str2.s                       ·          ·
-      └── join       2  join    ·         ·                                 (s, s, s)  ·
-           │         2  ·       type      full outer                        ·          ·
-           │         2  ·       equality  (s) = (s)                         ·          ·
-           ├── scan  3  scan    ·         ·                                 (s, s, s)  ·
-           │         3  ·       table     str1@primary                      ·          ·
-           │         3  ·       spans     ALL                               ·          ·
-           └── scan  3  scan    ·         ·                                 (s, s, s)  ·
-·                    3  ·       table     str2@primary                      ·          ·
-·                    3  ·       spans     ALL                               ·          ·
+render               0  render  ·         ·                                 (s, s, s)                                          ·
+ │                   0  ·       render 0  s                                 ·                                                  ·
+ │                   0  ·       render 1  test.str1.s                       ·                                                  ·
+ │                   0  ·       render 2  test.str2.s                       ·                                                  ·
+ └── render          1  render  ·         ·                                 (s, a[omitted], s[hidden], a[omitted], s[hidden])  ·
+      │              1  ·       render 0  IFNULL(test.str1.s, test.str2.s)  ·                                                  ·
+      │              1  ·       render 1  NULL                              ·                                                  ·
+      │              1  ·       render 2  test.str1.s                       ·                                                  ·
+      │              1  ·       render 3  NULL                              ·                                                  ·
+      │              1  ·       render 4  test.str2.s                       ·                                                  ·
+      └── join       2  join    ·         ·                                 (a[omitted], s, a[omitted], s)                     ·
+           │         2  ·       type      full outer                        ·                                                  ·
+           │         2  ·       equality  (s) = (s)                         ·                                                  ·
+           ├── scan  3  scan    ·         ·                                 (a[omitted], s)                                    a!=NULL; key(a)
+           │         3  ·       table     str1@primary                      ·                                                  ·
+           │         3  ·       spans     ALL                               ·                                                  ·
+           └── scan  3  scan    ·         ·                                 (a[omitted], s)                                    a!=NULL; key(a)
+·                    3  ·       table     str2@primary                      ·                                                  ·
+·                    3  ·       spans     ALL                               ·                                                  ·
 
 query TTT rowsort
 SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
@@ -1500,25 +1500,25 @@ B  NULL  B
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 ----
-render               0  render  ·               ·                                 (a, s)  ·
- │                   0  ·       render 0        test.str2.a                       ·       ·
- │                   0  ·       render 1        s                                 ·       ·
- └── render          1  render  ·               ·                                 (a, s)  ·
-      │              1  ·       render 0        test.str2.a                       ·       ·
-      │              1  ·       render 1        IFNULL(test.str1.s, test.str2.s)  ·       ·
-      │              1  ·       render 2        NULL                              ·       ·
-      │              1  ·       render 3        NULL                              ·       ·
-      │              1  ·       render 4        NULL                              ·       ·
-      └── join       2  join    ·               ·                                 (a, s)  ·
-           │         2  ·       type            right outer                       ·       ·
-           │         2  ·       equality        (a, s) = (a, s)                   ·       ·
-           │         2  ·       mergeJoinOrder  +"(a=a)"                          ·       ·
-           ├── scan  3  scan    ·               ·                                 (a, s)  ·
-           │         3  ·       table           str1@primary                      ·       ·
-           │         3  ·       spans           ALL                               ·       ·
-           └── scan  3  scan    ·               ·                                 (a, s)  ·
-·                    3  ·       table           str2@primary                      ·       ·
-·                    3  ·       spans           ALL                               ·       ·
+render               0  render  ·               ·                                 (a, s)                                                           ·
+ │                   0  ·       render 0        test.str2.a                       ·                                                                ·
+ │                   0  ·       render 1        s                                 ·                                                                ·
+ └── render          1  render  ·               ·                                 (a, s, a[hidden,omitted], s[hidden,omitted], s[hidden,omitted])  ·
+      │              1  ·       render 0        test.str2.a                       ·                                                                ·
+      │              1  ·       render 1        IFNULL(test.str1.s, test.str2.s)  ·                                                                ·
+      │              1  ·       render 2        NULL                              ·                                                                ·
+      │              1  ·       render 3        NULL                              ·                                                                ·
+      │              1  ·       render 4        NULL                              ·                                                                ·
+      └── join       2  join    ·               ·                                 (a[omitted], s, a, s)                                            ·
+           │         2  ·       type            right outer                       ·                                                                ·
+           │         2  ·       equality        (a, s) = (a, s)                   ·                                                                ·
+           │         2  ·       mergeJoinOrder  +"(a=a)"                          ·                                                                ·
+           ├── scan  3  scan    ·               ·                                 (a, s)                                                           a!=NULL; key(a); +a
+           │         3  ·       table           str1@primary                      ·                                                                ·
+           │         3  ·       spans           ALL                               ·                                                                ·
+           └── scan  3  scan    ·               ·                                 (a, s)                                                           a!=NULL; key(a); +a
+·                    3  ·       table           str2@primary                      ·                                                                ·
+·                    3  ·       spans           ALL                               ·                                                                ·
 
 
 statement ok
@@ -1536,21 +1536,21 @@ INSERT INTO xyv VALUES (1, 1, 1), (2, 2, 2), (3, 1, 31), (3, 3, 33), (5, 5, 55)
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render          0  render  ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
- │              0  ·       render 0        test.xyu.x         ·             ·
- │              0  ·       render 1        test.xyu.y         ·             ·
- │              0  ·       render 2        test.xyu.u         ·             ·
- │              0  ·       render 3        test.xyv.v         ·             ·
- └── join       1  join    ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
-      │         1  ·       type            inner              ·             ·
-      │         1  ·       equality        (x, y) = (x, y)    ·             ·
-      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
-      ├── scan  2  scan    ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
-      │         2  ·       table           xyu@primary        ·             ·
-      │         2  ·       spans           /3-                ·             ·
-      └── scan  2  scan    ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
-·               2  ·       table           xyv@primary        ·             ·
-·               2  ·       spans           /3-                ·             ·
+render          0  render  ·               ·                  (x, y, u, v)                          x!=NULL; y!=NULL
+ │              0  ·       render 0        test.xyu.x         ·                                     ·
+ │              0  ·       render 1        test.xyu.y         ·                                     ·
+ │              0  ·       render 2        test.xyu.u         ·                                     ·
+ │              0  ·       render 3        test.xyv.v         ·                                     ·
+ └── join       1  join    ·               ·                  (x, y, u, x[omitted], y[omitted], v)  x=x; y=y; x!=NULL; y!=NULL
+      │         1  ·       type            inner              ·                                     ·
+      │         1  ·       equality        (x, y) = (x, y)    ·                                     ·
+      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
+      ├── scan  2  scan    ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+      │         2  ·       table           xyu@primary        ·                                     ·
+      │         2  ·       spans           /3-                ·                                     ·
+      └── scan  2  scan    ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·               2  ·       table           xyv@primary        ·                                     ·
+·               2  ·       spans           /3-                ·                                     ·
 
 query IIII
 SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
@@ -1560,21 +1560,21 @@ SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render          0  render  ·               ·                  (x, y, u, v)  ·
- │              0  ·       render 0        test.xyu.x         ·             ·
- │              0  ·       render 1        test.xyu.y         ·             ·
- │              0  ·       render 2        test.xyu.u         ·             ·
- │              0  ·       render 3        test.xyv.v         ·             ·
- └── join       1  join    ·               ·                  (x, y, u, v)  ·
-      │         1  ·       type            left outer         ·             ·
-      │         1  ·       equality        (x, y) = (x, y)    ·             ·
-      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
-      ├── scan  2  scan    ·               ·                  (x, y, u, v)  ·
-      │         2  ·       table           xyu@primary        ·             ·
-      │         2  ·       spans           /3-                ·             ·
-      └── scan  2  scan    ·               ·                  (x, y, u, v)  ·
-·               2  ·       table           xyv@primary        ·             ·
-·               2  ·       spans           /3-                ·             ·
+render          0  render  ·               ·                  (x, y, u, v)                          ·
+ │              0  ·       render 0        test.xyu.x         ·                                     ·
+ │              0  ·       render 1        test.xyu.y         ·                                     ·
+ │              0  ·       render 2        test.xyu.u         ·                                     ·
+ │              0  ·       render 3        test.xyv.v         ·                                     ·
+ └── join       1  join    ·               ·                  (x, y, u, x[omitted], y[omitted], v)  ·
+      │         1  ·       type            left outer         ·                                     ·
+      │         1  ·       equality        (x, y) = (x, y)    ·                                     ·
+      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
+      ├── scan  2  scan    ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+      │         2  ·       table           xyu@primary        ·                                     ·
+      │         2  ·       spans           /3-                ·                                     ·
+      └── scan  2  scan    ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·               2  ·       table           xyv@primary        ·                                     ·
+·               2  ·       spans           /3-                ·                                     ·
 
 query IIII rowsort
 SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -1586,28 +1586,28 @@ SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render               0  render  ·               ·                  (x, y, u, v)  ·
- │                   0  ·       render 0        test.xyv.x         ·             ·
- │                   0  ·       render 1        test.xyv.y         ·             ·
- │                   0  ·       render 2        test.xyu.u         ·             ·
- │                   0  ·       render 3        test.xyv.v         ·             ·
- └── render          1  render  ·               ·                  (x, y, u, v)  ·
-      │              1  ·       render 0        test.xyv.x         ·             ·
-      │              1  ·       render 1        test.xyv.y         ·             ·
-      │              1  ·       render 2        NULL               ·             ·
-      │              1  ·       render 3        NULL               ·             ·
-      │              1  ·       render 4        test.xyu.u         ·             ·
-      │              1  ·       render 5        test.xyv.v         ·             ·
-      └── join       2  join    ·               ·                  (x, y, u, v)  ·
-           │         2  ·       type            right outer        ·             ·
-           │         2  ·       equality        (x, y) = (x, y)    ·             ·
-           │         2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
-           ├── scan  3  scan    ·               ·                  (x, y, u, v)  ·
-           │         3  ·       table           xyu@primary        ·             ·
-           │         3  ·       spans           /3-                ·             ·
-           └── scan  3  scan    ·               ·                  (x, y, u, v)  ·
-·                    3  ·       table           xyv@primary        ·             ·
-·                    3  ·       spans           /3-                ·             ·
+render               0  render  ·               ·                  (x, y, u, v)                                        ·
+ │                   0  ·       render 0        test.xyv.x         ·                                                   ·
+ │                   0  ·       render 1        test.xyv.y         ·                                                   ·
+ │                   0  ·       render 2        test.xyu.u         ·                                                   ·
+ │                   0  ·       render 3        test.xyv.v         ·                                                   ·
+ └── render          1  render  ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, v)  ·
+      │              1  ·       render 0        test.xyv.x         ·                                                   ·
+      │              1  ·       render 1        test.xyv.y         ·                                                   ·
+      │              1  ·       render 2        NULL               ·                                                   ·
+      │              1  ·       render 3        NULL               ·                                                   ·
+      │              1  ·       render 4        test.xyu.u         ·                                                   ·
+      │              1  ·       render 5        test.xyv.v         ·                                                   ·
+      └── join       2  join    ·               ·                  (x[omitted], y[omitted], u, x, y, v)                ·
+           │         2  ·       type            right outer        ·                                                   ·
+           │         2  ·       equality        (x, y) = (x, y)    ·                                                   ·
+           │         2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                   ·
+           ├── scan  3  scan    ·               ·                  (x, y, u)                                           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+           │         3  ·       table           xyu@primary        ·                                                   ·
+           │         3  ·       spans           /3-                ·                                                   ·
+           └── scan  3  scan    ·               ·                  (x, y, v)                                           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                    3  ·       table           xyv@primary        ·                                                   ·
+·                    3  ·       spans           /3-                ·                                                   ·
 
 query IIII rowsort
 SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -1619,32 +1619,32 @@ SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
-render                    0  render  ·               ·                               (x, y, u, v)  x!=NULL
- │                        0  ·       render 0        x                               ·             ·
- │                        0  ·       render 1        y                               ·             ·
- │                        0  ·       render 2        test.xyu.u                      ·             ·
- │                        0  ·       render 3        test.xyv.v                      ·             ·
- └── filter               1  filter  ·               ·                               (x, y, u, v)  x!=NULL
-      │                   1  ·       filter          x > 2                           ·             ·
-      └── render          2  render  ·               ·                               (x, y, u, v)  x!=NULL
-           │              2  ·       render 0        IFNULL(test.xyu.x, test.xyv.x)  ·             ·
-           │              2  ·       render 1        IFNULL(test.xyu.y, test.xyv.y)  ·             ·
-           │              2  ·       render 2        NULL                            ·             ·
-           │              2  ·       render 3        NULL                            ·             ·
-           │              2  ·       render 4        test.xyu.u                      ·             ·
-           │              2  ·       render 5        NULL                            ·             ·
-           │              2  ·       render 6        NULL                            ·             ·
-           │              2  ·       render 7        test.xyv.v                      ·             ·
-           └── join       3  join    ·               ·                               (x, y, u, v)  x!=NULL
-                │         3  ·       type            full outer                      ·             ·
-                │         3  ·       equality        (x, y) = (x, y)                 ·             ·
-                │         3  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"               ·             ·
-                ├── scan  4  scan    ·               ·                               (x, y, u, v)  x!=NULL
-                │         4  ·       table           xyu@primary                     ·             ·
-                │         4  ·       spans           ALL                             ·             ·
-                └── scan  4  scan    ·               ·                               (x, y, u, v)  x!=NULL
-·                         4  ·       table           xyv@primary                     ·             ·
-·                         4  ·       spans           ALL                             ·             ·
+render                    0  render  ·               ·                               (x, y, u, v)                                                                              x!=NULL
+ │                        0  ·       render 0        x                               ·                                                                                         ·
+ │                        0  ·       render 1        y                               ·                                                                                         ·
+ │                        0  ·       render 2        test.xyu.u                      ·                                                                                         ·
+ │                        0  ·       render 3        test.xyv.v                      ·                                                                                         ·
+ └── filter               1  filter  ·               ·                               (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  x!=NULL
+      │                   1  ·       filter          x > 2                           ·                                                                                         ·
+      └── render          2  render  ·               ·                               (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
+           │              2  ·       render 0        IFNULL(test.xyu.x, test.xyv.x)  ·                                                                                         ·
+           │              2  ·       render 1        IFNULL(test.xyu.y, test.xyv.y)  ·                                                                                         ·
+           │              2  ·       render 2        NULL                            ·                                                                                         ·
+           │              2  ·       render 3        NULL                            ·                                                                                         ·
+           │              2  ·       render 4        test.xyu.u                      ·                                                                                         ·
+           │              2  ·       render 5        NULL                            ·                                                                                         ·
+           │              2  ·       render 6        NULL                            ·                                                                                         ·
+           │              2  ·       render 7        test.xyv.v                      ·                                                                                         ·
+           └── join       3  join    ·               ·                               (x, y, u, x, y, v)                                                                        ·
+                │         3  ·       type            full outer                      ·                                                                                         ·
+                │         3  ·       equality        (x, y) = (x, y)                 ·                                                                                         ·
+                │         3  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"               ·                                                                                         ·
+                ├── scan  4  scan    ·               ·                               (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+                │         4  ·       table           xyu@primary                     ·                                                                                         ·
+                │         4  ·       spans           ALL                             ·                                                                                         ·
+                └── scan  4  scan    ·               ·                               (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                         4  ·       table           xyv@primary                     ·                                                                                         ·
+·                         4  ·       spans           ALL                             ·                                                                                         ·
 
 query IIII rowsort
 SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -1663,10 +1663,10 @@ join       0  join  ·               ·                  (x, y, u, x, y, v)  x=x
  │         0  ·     type            inner              ·                   ·
  │         0  ·     equality        (x, y) = (x, y)    ·                   ·
  │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan  1  scan  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+ ├── scan  1  scan  ·               ·                  (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
  │         1  ·     table           xyu@primary        ·                   ·
  │         1  ·     spans           /1-/1/10           ·                   ·
- └── scan  1  scan  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+ └── scan  1  scan  ·               ·                  (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
 ·          1  ·     table           xyv@primary        ·                   ·
 ·          1  ·     spans           /1-/1/10           ·                   ·
 
@@ -1682,10 +1682,10 @@ join       0  join  ·               ·                  (x, y, u, x, y, v)  x=x
  │         0  ·     type            inner              ·                   ·
  │         0  ·     equality        (x, y) = (x, y)    ·                   ·
  │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                   ·
- ├── scan  1  scan  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+ ├── scan  1  scan  ·               ·                  (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
  │         1  ·     table           xyu@primary        ·                   ·
  │         1  ·     spans           /1-/1/10           ·                   ·
- └── scan  1  scan  ·               ·                  (x, y, u, x, y, v)  x=x; y=y; x=CONST; y!=NULL
+ └── scan  1  scan  ·               ·                  (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
 ·          1  ·     table           xyv@primary        ·                   ·
 ·          1  ·     spans           /1-/1/10           ·                   ·
 
@@ -1702,10 +1702,10 @@ join       0  join  ·               ·                                       (x
  │         0  ·     equality        (x, y) = (x, y)                         ·                   ·
  │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"                       ·                   ·
  │         0  ·     pred            (test.xyu.x = 1) AND (test.xyu.y < 10)  ·                   ·
- ├── scan  1  scan  ·               ·                                       (x, y, u, x, y, v)  ·
+ ├── scan  1  scan  ·               ·                                       (x, y, u)           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
  │         1  ·     table           xyu@primary                             ·                   ·
  │         1  ·     spans           ALL                                     ·                   ·
- └── scan  1  scan  ·               ·                                       (x, y, u, x, y, v)  ·
+ └── scan  1  scan  ·               ·                                       (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
 ·          1  ·     table           xyv@primary                             ·                   ·
 ·          1  ·     spans           /1-/1/10                                ·                   ·
 
@@ -1726,10 +1726,10 @@ join       0  join  ·               ·                                       (x
  │         0  ·     equality        (x, y) = (x, y)                         ·                   ·
  │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"                       ·                   ·
  │         0  ·     pred            (test.xyv.x = 1) AND (test.xyv.y < 10)  ·                   ·
- ├── scan  1  scan  ·               ·                                       (x, y, u, x, y, v)  ·
+ ├── scan  1  scan  ·               ·                                       (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
  │         1  ·     table           xyu@primary                             ·                   ·
  │         1  ·     spans           /1-/1/10                                ·                   ·
- └── scan  1  scan  ·               ·                                       (x, y, u, x, y, v)  ·
+ └── scan  1  scan  ·               ·                                       (x, y, v)           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
 ·          1  ·     table           xyv@primary                             ·                   ·
 ·          1  ·     spans           ALL                                     ·                   ·
 
@@ -1748,21 +1748,21 @@ NULL  NULL  NULL  2  2  2
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-render          0  render  ·               ·                  (x, y, u, v)  ·
- │              0  ·       render 0        xyu.x              ·             ·
- │              0  ·       render 1        xyu.y              ·             ·
- │              0  ·       render 2        xyu.u              ·             ·
- │              0  ·       render 3        xyv.v              ·             ·
- └── join       1  join    ·               ·                  (x, y, u, v)  ·
-      │         1  ·       type            left outer         ·             ·
-      │         1  ·       equality        (x, y) = (x, y)    ·             ·
-      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
-      ├── scan  2  scan    ·               ·                  (x, y, u, v)  ·
-      │         2  ·       table           xyu@primary        ·             ·
-      │         2  ·       spans           /3-                ·             ·
-      └── scan  2  scan    ·               ·                  (x, y, u, v)  ·
-·               2  ·       table           xyv@primary        ·             ·
-·               2  ·       spans           /3-                ·             ·
+render          0  render  ·               ·                  (x, y, u, v)                          ·
+ │              0  ·       render 0        xyu.x              ·                                     ·
+ │              0  ·       render 1        xyu.y              ·                                     ·
+ │              0  ·       render 2        xyu.u              ·                                     ·
+ │              0  ·       render 3        xyv.v              ·                                     ·
+ └── join       1  join    ·               ·                  (x, y, u, x[omitted], y[omitted], v)  ·
+      │         1  ·       type            left outer         ·                                     ·
+      │         1  ·       equality        (x, y) = (x, y)    ·                                     ·
+      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
+      ├── scan  2  scan    ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+      │         2  ·       table           xyu@primary        ·                                     ·
+      │         2  ·       spans           /3-                ·                                     ·
+      └── scan  2  scan    ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·               2  ·       table           xyv@primary        ·                                     ·
+·               2  ·       spans           /3-                ·                                     ·
 
 query IIII rowsort
 SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
@@ -1774,28 +1774,28 @@ SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT *
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-render               0  render  ·               ·                  (x, y, u, v)  ·
- │                   0  ·       render 0        xyv.x              ·             ·
- │                   0  ·       render 1        xyv.y              ·             ·
- │                   0  ·       render 2        xyu.u              ·             ·
- │                   0  ·       render 3        xyv.v              ·             ·
- └── render          1  render  ·               ·                  (x, y, u, v)  ·
-      │              1  ·       render 0        xyv.x              ·             ·
-      │              1  ·       render 1        xyv.y              ·             ·
-      │              1  ·       render 2        NULL               ·             ·
-      │              1  ·       render 3        NULL               ·             ·
-      │              1  ·       render 4        xyu.u              ·             ·
-      │              1  ·       render 5        xyv.v              ·             ·
-      └── join       2  join    ·               ·                  (x, y, u, v)  ·
-           │         2  ·       type            right outer        ·             ·
-           │         2  ·       equality        (x, y) = (x, y)    ·             ·
-           │         2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
-           ├── scan  3  scan    ·               ·                  (x, y, u, v)  ·
-           │         3  ·       table           xyu@primary        ·             ·
-           │         3  ·       spans           /3-                ·             ·
-           └── scan  3  scan    ·               ·                  (x, y, u, v)  ·
-·                    3  ·       table           xyv@primary        ·             ·
-·                    3  ·       spans           /3-                ·             ·
+render               0  render  ·               ·                  (x, y, u, v)                                        ·
+ │                   0  ·       render 0        xyv.x              ·                                                   ·
+ │                   0  ·       render 1        xyv.y              ·                                                   ·
+ │                   0  ·       render 2        xyu.u              ·                                                   ·
+ │                   0  ·       render 3        xyv.v              ·                                                   ·
+ └── render          1  render  ·               ·                  (x, y, x[hidden,omitted], y[hidden,omitted], u, v)  ·
+      │              1  ·       render 0        xyv.x              ·                                                   ·
+      │              1  ·       render 1        xyv.y              ·                                                   ·
+      │              1  ·       render 2        NULL               ·                                                   ·
+      │              1  ·       render 3        NULL               ·                                                   ·
+      │              1  ·       render 4        xyu.u              ·                                                   ·
+      │              1  ·       render 5        xyv.v              ·                                                   ·
+      └── join       2  join    ·               ·                  (x[omitted], y[omitted], u, x, y, v)                ·
+           │         2  ·       type            right outer        ·                                                   ·
+           │         2  ·       equality        (x, y) = (x, y)    ·                                                   ·
+           │         2  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                                   ·
+           ├── scan  3  scan    ·               ·                  (x, y, u)                                           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+           │         3  ·       table           xyu@primary        ·                                                   ·
+           │         3  ·       spans           /3-                ·                                                   ·
+           └── scan  3  scan    ·               ·                  (x, y, v)                                           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                    3  ·       table           xyv@primary        ·                                                   ·
+·                    3  ·       spans           /3-                ·                                                   ·
 
 query IIII rowsort
 SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
@@ -1807,32 +1807,32 @@ SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
-render                    0  render  ·               ·                     (x, y, u, v)  x!=NULL
- │                        0  ·       render 0        x                     ·             ·
- │                        0  ·       render 1        y                     ·             ·
- │                        0  ·       render 2        xyu.u                 ·             ·
- │                        0  ·       render 3        xyv.v                 ·             ·
- └── filter               1  filter  ·               ·                     (x, y, u, v)  x!=NULL
-      │                   1  ·       filter          x > 2                 ·             ·
-      └── render          2  render  ·               ·                     (x, y, u, v)  x!=NULL
-           │              2  ·       render 0        IFNULL(xyu.x, xyv.x)  ·             ·
-           │              2  ·       render 1        IFNULL(xyu.y, xyv.y)  ·             ·
-           │              2  ·       render 2        NULL                  ·             ·
-           │              2  ·       render 3        NULL                  ·             ·
-           │              2  ·       render 4        xyu.u                 ·             ·
-           │              2  ·       render 5        NULL                  ·             ·
-           │              2  ·       render 6        NULL                  ·             ·
-           │              2  ·       render 7        xyv.v                 ·             ·
-           └── join       3  join    ·               ·                     (x, y, u, v)  x!=NULL
-                │         3  ·       type            full outer            ·             ·
-                │         3  ·       equality        (x, y) = (x, y)       ·             ·
-                │         3  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"     ·             ·
-                ├── scan  4  scan    ·               ·                     (x, y, u, v)  x!=NULL
-                │         4  ·       table           xyu@primary           ·             ·
-                │         4  ·       spans           ALL                   ·             ·
-                └── scan  4  scan    ·               ·                     (x, y, u, v)  x!=NULL
-·                         4  ·       table           xyv@primary           ·             ·
-·                         4  ·       spans           ALL                   ·             ·
+render                    0  render  ·               ·                     (x, y, u, v)                                                                              x!=NULL
+ │                        0  ·       render 0        x                     ·                                                                                         ·
+ │                        0  ·       render 1        y                     ·                                                                                         ·
+ │                        0  ·       render 2        xyu.u                 ·                                                                                         ·
+ │                        0  ·       render 3        xyv.v                 ·                                                                                         ·
+ └── filter               1  filter  ·               ·                     (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  x!=NULL
+      │                   1  ·       filter          x > 2                 ·                                                                                         ·
+      └── render          2  render  ·               ·                     (x, y, x[hidden,omitted], y[hidden,omitted], u, x[hidden,omitted], y[hidden,omitted], v)  ·
+           │              2  ·       render 0        IFNULL(xyu.x, xyv.x)  ·                                                                                         ·
+           │              2  ·       render 1        IFNULL(xyu.y, xyv.y)  ·                                                                                         ·
+           │              2  ·       render 2        NULL                  ·                                                                                         ·
+           │              2  ·       render 3        NULL                  ·                                                                                         ·
+           │              2  ·       render 4        xyu.u                 ·                                                                                         ·
+           │              2  ·       render 5        NULL                  ·                                                                                         ·
+           │              2  ·       render 6        NULL                  ·                                                                                         ·
+           │              2  ·       render 7        xyv.v                 ·                                                                                         ·
+           └── join       3  join    ·               ·                     (x, y, u, x, y, v)                                                                        ·
+                │         3  ·       type            full outer            ·                                                                                         ·
+                │         3  ·       equality        (x, y) = (x, y)       ·                                                                                         ·
+                │         3  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"     ·                                                                                         ·
+                ├── scan  4  scan    ·               ·                     (x, y, u)                                                                                 x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+                │         4  ·       table           xyu@primary           ·                                                                                         ·
+                │         4  ·       spans           ALL                   ·                                                                                         ·
+                └── scan  4  scan    ·               ·                     (x, y, v)                                                                                 x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·                         4  ·       table           xyv@primary           ·                                                                                         ·
+·                         4  ·       spans           ALL                   ·                                                                                         ·
 
 query IIII rowsort
 SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
@@ -1851,10 +1851,10 @@ join       0  join  ·               ·                             (x, y, u, x,
  │         0  ·     equality        (x, y) = (x, y)               ·                   ·
  │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"             ·                   ·
  │         0  ·     pred            (xyu.x = 1) AND (xyu.y < 10)  ·                   ·
- ├── scan  1  scan  ·               ·                             (x, y, u, x, y, v)  ·
+ ├── scan  1  scan  ·               ·                             (x, y, u)           x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
  │         1  ·     table           xyu@primary                   ·                   ·
  │         1  ·     spans           ALL                           ·                   ·
- └── scan  1  scan  ·               ·                             (x, y, u, x, y, v)  ·
+ └── scan  1  scan  ·               ·                             (x, y, v)           x=CONST; y!=NULL; v!=NULL; key(y,v); +y
 ·          1  ·     table           xyv@primary                   ·                   ·
 ·          1  ·     spans           /1-/1/10                      ·                   ·
 
@@ -1875,10 +1875,10 @@ join       0  join  ·               ·                             (x, y, u, x,
  │         0  ·     equality        (x, y) = (x, y)               ·                   ·
  │         0  ·     mergeJoinOrder  +"(x=x)",+"(y=y)"             ·                   ·
  │         0  ·     pred            (xyv.x = 1) AND (xyv.y < 10)  ·                   ·
- ├── scan  1  scan  ·               ·                             (x, y, u, x, y, v)  ·
+ ├── scan  1  scan  ·               ·                             (x, y, u)           x=CONST; y!=NULL; u!=NULL; key(y,u); +y
  │         1  ·     table           xyu@primary                   ·                   ·
  │         1  ·     spans           /1-/1/10                      ·                   ·
- └── scan  1  scan  ·               ·                             (x, y, u, x, y, v)  ·
+ └── scan  1  scan  ·               ·                             (x, y, v)           x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
 ·          1  ·     table           xyv@primary                   ·                   ·
 ·          1  ·     spans           ALL                           ·                   ·
 
@@ -1895,21 +1895,21 @@ NULL  NULL  NULL  2  2  2
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
-render          0  render  ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
- │              0  ·       render 0        test.xyu.x         ·             ·
- │              0  ·       render 1        test.xyu.y         ·             ·
- │              0  ·       render 2        test.xyu.u         ·             ·
- │              0  ·       render 3        test.xyv.v         ·             ·
- └── join       1  join    ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
-      │         1  ·       type            inner              ·             ·
-      │         1  ·       equality        (x, y) = (x, y)    ·             ·
-      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·             ·
-      ├── scan  2  scan    ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
-      │         2  ·       table           xyu@primary        ·             ·
-      │         2  ·       spans           /1/2/4-            ·             ·
-      └── scan  2  scan    ·               ·                  (x, y, u, v)  x!=NULL; y!=NULL
-·               2  ·       table           xyv@primary        ·             ·
-·               2  ·       spans           /1/2-              ·             ·
+render          0  render  ·               ·                  (x, y, u, v)                          x!=NULL; y!=NULL
+ │              0  ·       render 0        test.xyu.x         ·                                     ·
+ │              0  ·       render 1        test.xyu.y         ·                                     ·
+ │              0  ·       render 2        test.xyu.u         ·                                     ·
+ │              0  ·       render 3        test.xyv.v         ·                                     ·
+ └── join       1  join    ·               ·                  (x, y, u, x[omitted], y[omitted], v)  x=x; y=y; x!=NULL; y!=NULL
+      │         1  ·       type            inner              ·                                     ·
+      │         1  ·       equality        (x, y) = (x, y)    ·                                     ·
+      │         1  ·       mergeJoinOrder  +"(x=x)",+"(y=y)"  ·                                     ·
+      ├── scan  2  scan    ·               ·                  (x, y, u)                             x!=NULL; y!=NULL; u!=NULL; key(x,y,u); +x,+y
+      │         2  ·       table           xyu@primary        ·                                     ·
+      │         2  ·       spans           /1/2/4-            ·                                     ·
+      └── scan  2  scan    ·               ·                  (x, y, v)                             x!=NULL; y!=NULL; v!=NULL; key(x,y,v); +x,+y
+·               2  ·       table           xyv@primary        ·                                     ·
+·               2  ·       spans           /1/2-              ·                                     ·
 
 
 # Regression test for #20858.
@@ -1923,18 +1923,18 @@ CREATE TABLE r (a INT PRIMARY KEY)
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-render          0  render  ·               ·           (a)  ·
- │              0  ·       render 0        test.l.a    ·    ·
- └── join       1  join    ·               ·           (a)  ·
-      │         1  ·       type            left outer  ·    ·
-      │         1  ·       equality        (a) = (a)   ·    ·
-      │         1  ·       mergeJoinOrder  +"(a=a)"    ·    ·
-      ├── scan  2  scan    ·               ·           (a)  ·
-      │         2  ·       table           l@primary   ·    ·
-      │         2  ·       spans           /3-/3/#     ·    ·
-      └── scan  2  scan    ·               ·           (a)  ·
-·               2  ·       table           r@primary   ·    ·
-·               2  ·       spans           /3-/3/#     ·    ·
+render          0  render  ·               ·           (a)              ·
+ │              0  ·       render 0        test.l.a    ·                ·
+ └── join       1  join    ·               ·           (a, a[omitted])  ·
+      │         1  ·       type            left outer  ·                ·
+      │         1  ·       equality        (a) = (a)   ·                ·
+      │         1  ·       mergeJoinOrder  +"(a=a)"    ·                ·
+      ├── scan  2  scan    ·               ·           (a)              a=CONST; key()
+      │         2  ·       table           l@primary   ·                ·
+      │         2  ·       spans           /3-/3/#     ·                ·
+      └── scan  2  scan    ·               ·           (a)              a=CONST; key()
+·               2  ·       table           r@primary   ·                ·
+·               2  ·       spans           /3-/3/#     ·                ·
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
@@ -1943,31 +1943,31 @@ join       0  join  ·               ·           (a, a)  ·
  │         0  ·     type            left outer  ·       ·
  │         0  ·     equality        (a) = (a)   ·       ·
  │         0  ·     mergeJoinOrder  +"(a=a)"    ·       ·
- ├── scan  1  scan  ·               ·           (a, a)  ·
+ ├── scan  1  scan  ·               ·           (a)     a=CONST; key()
  │         1  ·     table           l@primary   ·       ·
  │         1  ·     spans           /3-/3/#     ·       ·
- └── scan  1  scan  ·               ·           (a, a)  ·
+ └── scan  1  scan  ·               ·           (a)     a=CONST; key()
 ·          1  ·     table           r@primary   ·       ·
 ·          1  ·     spans           /3-/3/#     ·       ·
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3;
 ----
-render               0  render  ·               ·            (a)  ·
- │                   0  ·       render 0        test.r.a     ·    ·
- └── render          1  render  ·               ·            (a)  ·
-      │              1  ·       render 0        test.r.a     ·    ·
-      │              1  ·       render 1        NULL         ·    ·
-      └── join       2  join    ·               ·            (a)  ·
-           │         2  ·       type            right outer  ·    ·
-           │         2  ·       equality        (a) = (a)    ·    ·
-           │         2  ·       mergeJoinOrder  +"(a=a)"     ·    ·
-           ├── scan  3  scan    ·               ·            (a)  ·
-           │         3  ·       table           l@primary    ·    ·
-           │         3  ·       spans           /3-/3/#      ·    ·
-           └── scan  3  scan    ·               ·            (a)  ·
-·                    3  ·       table           r@primary    ·    ·
-·                    3  ·       spans           /3-/3/#      ·    ·
+render               0  render  ·               ·            (a)                     ·
+ │                   0  ·       render 0        test.r.a     ·                       ·
+ └── render          1  render  ·               ·            (a, a[hidden,omitted])  ·
+      │              1  ·       render 0        test.r.a     ·                       ·
+      │              1  ·       render 1        NULL         ·                       ·
+      └── join       2  join    ·               ·            (a[omitted], a)         ·
+           │         2  ·       type            right outer  ·                       ·
+           │         2  ·       equality        (a) = (a)    ·                       ·
+           │         2  ·       mergeJoinOrder  +"(a=a)"     ·                       ·
+           ├── scan  3  scan    ·               ·            (a)                     a=CONST; key()
+           │         3  ·       table           l@primary    ·                       ·
+           │         3  ·       spans           /3-/3/#      ·                       ·
+           └── scan  3  scan    ·               ·            (a)                     a=CONST; key()
+·                    3  ·       table           r@primary    ·                       ·
+·                    3  ·       spans           /3-/3/#      ·                       ·
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
@@ -1976,10 +1976,10 @@ join       0  join  ·               ·            (a, a)  ·
  │         0  ·     type            right outer  ·       ·
  │         0  ·     equality        (a) = (a)    ·       ·
  │         0  ·     mergeJoinOrder  +"(a=a)"     ·       ·
- ├── scan  1  scan  ·               ·            (a, a)  ·
+ ├── scan  1  scan  ·               ·            (a)     a=CONST; key()
  │         1  ·     table           l@primary    ·       ·
  │         1  ·     spans           /3-/3/#      ·       ·
- └── scan  1  scan  ·               ·            (a, a)  ·
+ └── scan  1  scan  ·               ·            (a)     a=CONST; key()
 ·          1  ·     table           r@primary    ·       ·
 ·          1  ·     spans           /3-/3/#      ·       ·
 

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -60,16 +60,16 @@ SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
 query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE v > 4 AND w > 30 ORDER BY v LIMIT 2
 ----
-Tree             Level  Type        Field   Description  Columns    Ordering
-limit            0      limit       ·       ·            (k, v, w)  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
- │               0      ·           count   2            ·          ·
- └── index-join  1      index-join  ·       ·            (k, v, w)  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
-      ├── scan   2      scan        ·       ·            (k, v, w)  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
-      │          2      ·           table   t@t_v_idx    ·          ·
-      │          2      ·           spans   /5-          ·          ·
-      └── scan   2      scan        ·       ·            (k, v, w)  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
-·                2      ·           table   t@primary    ·          ·
-·                2      ·           filter  w > 30       ·          ·
+Tree             Level  Type        Field   Description  Columns                      Ordering
+limit            0      limit       ·       ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+ │               0      ·           count   2            ·                            ·
+ └── index-join  1      index-join  ·       ·            (k, v, w)                    k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+      ├── scan   2      scan        ·       ·            (k, v[omitted], w[omitted])  k!=NULL; v!=NULL; w!=NULL; key(k,v); +v
+      │          2      ·           table   t@t_v_idx    ·                            ·
+      │          2      ·           spans   /5-          ·                            ·
+      └── scan   2      scan        ·       ·            (k, v, w)                    ·
+·                2      ·           table   t@primary    ·                            ·
+·                2      ·           filter  w > 30       ·                            ·
 
 # This kind of query can be used to work around memory usage limits. We need to
 # choose the "hard" limit of 100 over the "soft" limit of 25 (with the hard
@@ -77,18 +77,18 @@ limit            0      limit       ·       ·            (k, v, w)  k!=NULL; v
 query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT w FROM (SELECT w FROM t ORDER BY w LIMIT 100) ORDER BY w LIMIT 25
 ----
-Tree                           Level  Type      Field      Description  Columns  Ordering
-limit                          0      limit     ·          ·            (w)      weak-key(w); +w
- │                             0      ·         count      25           ·        ·
- └── distinct                  1      distinct  ·          ·            (w)      weak-key(w); +w
-      │                        1      ·         order key  w            ·        ·
-      └── limit                2      limit     ·          ·            (w)      weak-key(w); +w
-           │                   2      ·         count      100          ·        ·
-           └── sort            3      sort      ·          ·            (w)      weak-key(w); +w
-                │              3      ·         order      +w           ·        ·
-                │              3      ·         strategy   top 100      ·        ·
-                └── render     4      render    ·          ·            (w)      weak-key(w); +w
-                     │         4      ·         render 0   test.t.w     ·        ·
-                     └── scan  5      scan      ·          ·            (w)      weak-key(w); +w
-·                              5      ·         table      t@primary    ·        ·
-·                              5      ·         spans      ALL          ·        ·
+Tree                           Level  Type      Field      Description  Columns                      Ordering
+limit                          0      limit     ·          ·            (w)                          weak-key(w); +w
+ │                             0      ·         count      25           ·                            ·
+ └── distinct                  1      distinct  ·          ·            (w)                          weak-key(w); +w
+      │                        1      ·         order key  w            ·                            ·
+      └── limit                2      limit     ·          ·            (w)                          +w
+           │                   2      ·         count      100          ·                            ·
+           └── sort            3      sort      ·          ·            (w)                          +w
+                │              3      ·         order      +w           ·                            ·
+                │              3      ·         strategy   top 100      ·                            ·
+                └── render     4      render    ·          ·            (w)                          ·
+                     │         4      ·         render 0   test.t.w     ·                            ·
+                     └── scan  5      scan      ·          ·            (k[omitted], v[omitted], w)  k!=NULL; key(k)
+·                              5      ·         table      t@primary    ·                            ·
+·                              5      ·         spans      ALL          ·                            ·

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -4,106 +4,106 @@ query TITTTTT
 EXPLAIN (METADATA,NOOPTIMIZE) SELECT 1 FROM (SELECT 2 AS s)
 ----
 render              0  render    ·  ·  ("1")  "1"=CONST
- └── render         1  render    ·  ·  ("1")  "1"=CONST
-      └── emptyrow  2  emptyrow  ·  ·  ("1")  "1"=CONST
+ └── render         1  render    ·  ·  (s)    s=CONST
+      └── emptyrow  2  emptyrow  ·  ·  ()     ·
 
 # Propagation to data sources.
 query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s)
 ----
-render              0  render    ·  ·  ("1")  "1"=CONST
- └── render         1  render    ·  ·  ("1")  "1"=CONST
-      └── emptyrow  2  emptyrow  ·  ·  ("1")  "1"=CONST
+render              0  render    ·  ·  ("1")         "1"=CONST
+ └── render         1  render    ·  ·  (s[omitted])  ·
+      └── emptyrow  2  emptyrow  ·  ·  ()            ·
 
 # Propagation through CREATE TABLE.
 query TITTTTT
 EXPLAIN (METADATA) CREATE TABLE t AS SELECT 1 FROM (SELECT 2 AS s)
 ----
-create table             0  create table  ·  ·  ()  ·
- └── render              1  render        ·  ·  ()  ·
-      └── render         2  render        ·  ·  ()  ·
-           └── emptyrow  3  emptyrow      ·  ·  ()  ·
+create table             0  create table  ·  ·  ()            ·
+ └── render              1  render        ·  ·  ("1")         "1"=CONST
+      └── render         2  render        ·  ·  (s[omitted])  ·
+           └── emptyrow  3  emptyrow      ·  ·  ()            ·
 
 # Propagation through LIMIT.
 query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s) LIMIT 1
 ----
-limit                    0  limit     ·  ·  ("1")  "1"=CONST
- └── render              1  render    ·  ·  ("1")  "1"=CONST
-      └── render         2  render    ·  ·  ("1")  "1"=CONST
-           └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
+limit                    0  limit     ·  ·  ("1")         "1"=CONST
+ └── render              1  render    ·  ·  ("1")         "1"=CONST
+      └── render         2  render    ·  ·  (s[omitted])  ·
+           └── emptyrow  3  emptyrow  ·  ·  ()            ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s LIMIT 1)
 ----
-render                   0  render    ·  ·  ("1")  "1"=CONST
- └── limit               1  limit     ·  ·  ("1")  "1"=CONST
-      └── render         2  render    ·  ·  ("1")  "1"=CONST
-           └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
+render                   0  render    ·  ·  ("1")         "1"=CONST
+ └── limit               1  limit     ·  ·  (s[omitted])  ·
+      └── render         2  render    ·  ·  (s[omitted])  ·
+           └── emptyrow  3  emptyrow  ·  ·  ()            ·
 
 # Propagation through UNION.
 query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION SELECT 2 AS s)
 ----
 render                   0  render    ·  ·  ("1")  "1"=CONST
- └── union               1  union     ·  ·  ("1")  "1"=CONST
-      ├── render         2  render    ·  ·  ("1")  "1"=CONST
-      │    └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
-      └── render         2  render    ·  ·  ("1")  "1"=CONST
-           └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
+ └── union               1  union     ·  ·  (s)    ·
+      ├── render         2  render    ·  ·  (s)    s=CONST
+      │    └── emptyrow  3  emptyrow  ·  ·  ()     ·
+      └── render         2  render    ·  ·  (s)    s=CONST
+           └── emptyrow  3  emptyrow  ·  ·  ()     ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION ALL SELECT 2 AS s)
 ----
-render                   0  render    ·  ·  ("1")  "1"=CONST
- └── append              1  append    ·  ·  ("1")  "1"=CONST
-      ├── render         2  render    ·  ·  ("1")  "1"=CONST
-      │    └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
-      └── render         2  render    ·  ·  ("1")  "1"=CONST
-           └── emptyrow  3  emptyrow  ·  ·  ("1")  "1"=CONST
+render                   0  render    ·  ·  ("1")         "1"=CONST
+ └── append              1  append    ·  ·  (s[omitted])  ·
+      ├── render         2  render    ·  ·  (s[omitted])  ·
+      │    └── emptyrow  3  emptyrow  ·  ·  ()            ·
+      └── render         2  render    ·  ·  (s[omitted])  ·
+           └── emptyrow  3  emptyrow  ·  ·  ()            ·
 
 # Propagation through WITH ORDINALITY.
 query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s) WITH ORDINALITY
 ----
-render                   0  render      ·  ·  ("1")  "1"=CONST
- └── ordinality          1  ordinality  ·  ·  ("1")  "1"=CONST
-      └── render         2  render      ·  ·  ("1")  "1"=CONST
-           └── emptyrow  3  emptyrow    ·  ·  ("1")  "1"=CONST
+render                   0  render      ·  ·  ("1")                       "1"=CONST
+ └── ordinality          1  ordinality  ·  ·  (s[omitted], "ordinality")  weak-key("ordinality")
+      └── render         2  render      ·  ·  (s[omitted])                ·
+           └── emptyrow  3  emptyrow    ·  ·  ()                          ·
 
 # Propagation through sort, when the sorting column is in the results.
 query TITTTTT
 EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y) ORDER BY x
 ----
-render              0  render    ·  ·  (x)  x=CONST
- └── render         1  render    ·  ·  (x)  x=CONST
-      └── emptyrow  2  emptyrow  ·  ·  (x)  x=CONST
+render              0  render    ·  ·  (x)              x=CONST
+ └── render         1  render    ·  ·  (x, y[omitted])  x=CONST
+      └── emptyrow  2  emptyrow  ·  ·  ()               ·
 
 # Propagation through sort, when the sorting column is not in the results.
 query TITTTTT
 EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y, 3 AS z) ORDER BY y
 ----
-nosort                   0  nosort    ·      ·   (x)  x=CONST
- │                       0  ·         order  +y  ·    ·
- └── render              1  render    ·      ·   (x)  x=CONST
-      └── render         2  render    ·      ·   (x)  x=CONST
-           └── emptyrow  3  emptyrow  ·      ·   (x)  x=CONST
+nosort                   0  nosort    ·      ·   (x)                 x=CONST
+ │                       0  ·         order  +y  ·                   ·
+ └── render              1  render    ·      ·   (x, y)              x=CONST; y=CONST
+      └── render         2  render    ·      ·   (x, y, z[omitted])  x=CONST; y=CONST
+           └── emptyrow  3  emptyrow  ·      ·   ()                  ·
 
 # Propagation to sub-queries.
 query TITTTTT
 EXPLAIN (METADATA) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
 ----
-root                               0  root      ·          ·                                     (y)  y=CONST
- ├── render                        1  render    ·          ·                                     (y)  y=CONST
- │    └── emptyrow                 2  emptyrow  ·          ·                                     (y)  y=CONST
- └── subquery                      1  subquery  ·          ·                                     (y)  y=CONST
-      │                            1  ·         id         @S1                                   ·    ·
-      │                            1  ·         sql        (SELECT 2 AS x FROM (SELECT 3 AS s))  ·    ·
-      │                            1  ·         exec mode  one row                               ·    ·
-      └── limit                    2  limit     ·          ·                                     (y)  y=CONST
-           └── render              3  render    ·          ·                                     (y)  y=CONST
-                └── render         4  render    ·          ·                                     (y)  y=CONST
-                     └── emptyrow  5  emptyrow  ·          ·                                     (y)  y=CONST
+root                               0  root      ·          ·                                     (y)           y=CONST
+ ├── render                        1  render    ·          ·                                     (y)           y=CONST
+ │    └── emptyrow                 2  emptyrow  ·          ·                                     ()            ·
+ └── subquery                      1  subquery  ·          ·                                     (y)           y=CONST
+      │                            1  ·         id         @S1                                   ·             ·
+      │                            1  ·         sql        (SELECT 2 AS x FROM (SELECT 3 AS s))  ·             ·
+      │                            1  ·         exec mode  one row                               ·             ·
+      └── limit                    2  limit     ·          ·                                     (x)           x=CONST
+           └── render              3  render    ·          ·                                     (x)           x=CONST
+                └── render         4  render    ·          ·                                     (s[omitted])  ·
+                     └── emptyrow  5  emptyrow  ·          ·                                     ()            ·
 
 # Propagation through table scans.
 statement ok
@@ -112,64 +112,64 @@ CREATE TABLE kv(k INT PRIMARY KEY, v INT)
 query TITTTTT
 EXPLAIN (METADATA) SELECT 1 FROM kv
 ----
-render     0  render  ·      ·           ("1")  "1"=CONST
- └── scan  1  scan    ·      ·           ("1")  "1"=CONST
-·          1  ·       table  kv@primary  ·      ·
-·          1  ·       spans  ALL         ·      ·
+render     0  render  ·      ·           ("1")                     "1"=CONST
+ └── scan  1  scan    ·      ·           (k[omitted], v[omitted])  k!=NULL; key(k)
+·          1  ·       table  kv@primary  ·                         ·
+·          1  ·       spans  ALL         ·                         ·
 
 # Propagation through DISTINCT.
 query TITTTTT
 EXPLAIN (METADATA) SELECT DISTINCT v FROM kv
 ----
-distinct        0  distinct  ·      ·           (v)  weak-key(v)
- └── render     1  render    ·      ·           (v)  weak-key(v)
-      └── scan  2  scan      ·      ·           (v)  weak-key(v)
-·               2  ·         table  kv@primary  ·    ·
-·               2  ·         spans  ALL         ·    ·
+distinct        0  distinct  ·      ·           (v)              weak-key(v)
+ └── render     1  render    ·      ·           (v)              ·
+      └── scan  2  scan      ·      ·           (k[omitted], v)  k!=NULL; key(k)
+·               2  ·         table  kv@primary  ·                ·
+·               2  ·         spans  ALL         ·                ·
 
 # Propagation through INSERT.
 query TITTTTT
 EXPLAIN (METADATA) INSERT INTO kv(k, v) SELECT 1, 2 FROM (SELECT 3 AS x, 4 AS y)
 ----
-insert                   0  insert    ·     ·         ()  ·
- │                       0  ·         into  kv(k, v)  ·   ·
- └── render              1  render    ·     ·         ()  ·
-      └── render         2  render    ·     ·         ()  ·
-           └── emptyrow  3  emptyrow  ·     ·         ()  ·
+insert                   0  insert    ·     ·         ()                        ·
+ │                       0  ·         into  kv(k, v)  ·                         ·
+ └── render              1  render    ·     ·         ("1", "2")                "1"=CONST; "2"=CONST
+      └── render         2  render    ·     ·         (x[omitted], y[omitted])  ·
+           └── emptyrow  3  emptyrow  ·     ·         ()                        ·
 
 # Propagation through DELETE.
 query TITTTTT
 EXPLAIN (METADATA) DELETE FROM kv WHERE k = 3
 ----
-delete          0  delete  ·      ·           ()  ·
- │              0  ·       from   kv          ·   ·
- └── render     1  render  ·      ·           ()  ·
-      └── scan  2  scan    ·      ·           ()  ·
-·               2  ·       table  kv@primary  ·   ·
-·               2  ·       spans  /3-/3/#     ·   ·
+delete          0  delete  ·      ·           ()               ·
+ │              0  ·       from   kv          ·                ·
+ └── render     1  render  ·      ·           (k)              k=CONST; key()
+      └── scan  2  scan    ·      ·           (k, v[omitted])  k=CONST; key()
+·               2  ·       table  kv@primary  ·                ·
+·               2  ·       spans  /3-/3/#     ·                ·
 
 # Ensure that propagations through a render node removes the renders
 # and properly propagates the remaining needed columns.
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT x FROM (SELECT 1 AS x, y FROM (SELECT 2 AS y))
 ----
-render                   0  render    ·         ·     (x)  x=CONST
- │                       0  ·         render 0  x     ·    ·
- └── render              1  render    ·         ·     (x)  x=CONST
-      │                  1  ·         render 0  1     ·    ·
-      │                  1  ·         render 1  NULL  ·    ·
-      └── render         2  render    ·         ·     (x)  x=CONST
-           │             2  ·         render 0  NULL  ·    ·
-           └── emptyrow  3  emptyrow  ·         ·     (x)  x=CONST
+render                   0  render    ·         ·     (x)              x=CONST
+ │                       0  ·         render 0  x     ·                ·
+ └── render              1  render    ·         ·     (x, y[omitted])  x=CONST
+      │                  1  ·         render 0  1     ·                ·
+      │                  1  ·         render 1  NULL  ·                ·
+      └── render         2  render    ·         ·     (y[omitted])     ·
+           │             2  ·         render 0  NULL  ·                ·
+           └── emptyrow  3  emptyrow  ·         ·     ()               ·
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT k+1 AS x, v-2 AS y FROM kv)
 ----
-render     0  render  ·         ·           ("1")  "1"=CONST
- │         0  ·       render 0  1           ·      ·
- └── scan  1  scan    ·         ·           ("1")  "1"=CONST
-·          1  ·       table     kv@primary  ·      ·
-·          1  ·       spans     ALL         ·      ·
+render     0  render  ·         ·           ("1")                     "1"=CONST
+ │         0  ·       render 0  1           ·                         ·
+ └── scan  1  scan    ·         ·           (k[omitted], v[omitted])  k!=NULL; key(k)
+·          1  ·       table     kv@primary  ·                         ·
+·          1  ·       spans     ALL         ·                         ·
 
 statement ok
 CREATE TABLE a ("name" string, age int);
@@ -177,15 +177,15 @@ CREATE TABLE a ("name" string, age int);
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM (SELECT "name", age FROM a);
 ----
-group                0  group   ·            ·             (count)  ·
- │                   0  ·       aggregate 0  count_rows()  ·        ·
- └── render          1  render  ·            ·             (count)  ·
-      └── render     2  render  ·            ·             (count)  ·
-           │         2  ·       render 0     NULL          ·        ·
-           │         2  ·       render 1     NULL          ·        ·
-           └── scan  3  scan    ·            ·             (count)  ·
-·                    3  ·       table        a@primary     ·        ·
-·                    3  ·       spans        ALL           ·        ·
+group                0  group   ·            ·             (count)                                                 ·
+ │                   0  ·       aggregate 0  count_rows()  ·                                                       ·
+ └── render          1  render  ·            ·             ()                                                      ·
+      └── render     2  render  ·            ·             ("name"[omitted], age[omitted])                         ·
+           │         2  ·       render 0     NULL          ·                                                       ·
+           │         2  ·       render 1     NULL          ·                                                       ·
+           └── scan  3  scan    ·            ·             ("name"[omitted], age[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
+·                    3  ·       table        a@primary     ·                                                       ·
+·                    3  ·       spans        ALL           ·                                                       ·
 
 # Ensure that variables within filter conditions are omitted (not decoded) if
 # the filter condition is replaced by an index search.
@@ -196,9 +196,9 @@ CREATE TABLE ab (a INT, b INT, PRIMARY KEY (a, b));
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT count(*) FROM ab WHERE a=1
 ----
-group           0  group   ·            ·             (count)  ·
- │              0  ·       aggregate 0  count_rows()  ·        ·
- └── render     1  render  ·            ·             (count)  ·
-      └── scan  2  scan    ·            ·             (count)  ·
-·               2  ·       table        ab@primary    ·        ·
-·               2  ·       spans        /1-/2         ·        ·
+group           0  group   ·            ·             (count)                   ·
+ │              0  ·       aggregate 0  count_rows()  ·                         ·
+ └── render     1  render  ·            ·             ()                        ·
+      └── scan  2  scan    ·            ·             (a[omitted], b[omitted])  a=CONST; b!=NULL; key(b)
+·               2  ·       table        ab@primary    ·                         ·
+·               2  ·       spans        /1-/2         ·                         ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -95,18 +95,18 @@ SELECT a, b FROM t ORDER BY b DESC LIMIT 2
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT c FROM t ORDER BY b LIMIT 2
 ----
-limit                     0  limit     ·         ·          (c)  weak-key(c)
- │                        0  ·         count     2          ·    ·
- └── distinct             1  distinct  ·         ·          (c)  weak-key(c)
-      └── sort            2  sort      ·         ·          (c)  weak-key(c)
-           │              2  ·         order     +b         ·    ·
-           │              2  ·         strategy  iterative  ·    ·
-           └── render     3  render    ·         ·          (c)  weak-key(c)
-                │         3  ·         render 0  test.t.c   ·    ·
-                │         3  ·         render 1  test.t.b   ·    ·
-                └── scan  4  scan      ·         ·          (c)  weak-key(c)
-·                         4  ·         table     t@primary  ·    ·
-·                         4  ·         spans     ALL        ·    ·
+limit                     0  limit     ·         ·          (c)                 weak-key(c)
+ │                        0  ·         count     2          ·                   ·
+ └── distinct             1  distinct  ·         ·          (c)                 weak-key(c)
+      └── sort            2  sort      ·         ·          (c)                 ·
+           │              2  ·         order     +b         ·                   ·
+           │              2  ·         strategy  iterative  ·                   ·
+           └── render     3  render    ·         ·          (c, b)              ·
+                │         3  ·         render 0  test.t.c   ·                   ·
+                │         3  ·         render 1  test.t.b   ·                   ·
+                └── scan  4  scan      ·         ·          (a[omitted], b, c)  a!=NULL; key(a)
+·                         4  ·         table     t@primary  ·                   ·
+·                         4  ·         spans     ALL        ·                   ·
 
 query B
 SELECT DISTINCT c FROM t ORDER BY b DESC LIMIT 2
@@ -201,7 +201,7 @@ EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, t.*)
 ----
 sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
  │         0  ·     order  +b,+a,+c   ·          ·
- └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+ └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a)
 ·          1  ·     table  t@primary  ·          ·
 ·          1  ·     spans  ALL        ·          ·
 
@@ -210,7 +210,7 @@ EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, a), c
 ----
 sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
  │         0  ·     order  +b,+a,+c   ·          ·
- └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+ └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a)
 ·          1  ·     table  t@primary  ·          ·
 ·          1  ·     spans  ALL        ·          ·
 
@@ -219,7 +219,7 @@ EXPLAIN(METADATA) SELECT * FROM t ORDER BY b, (a, c)
 ----
 sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
  │         0  ·     order  +b,+a,+c   ·          ·
- └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+ └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a)
 ·          1  ·     table  t@primary  ·          ·
 ·          1  ·     spans  ALL        ·          ·
 
@@ -228,7 +228,7 @@ EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, (a, c))
 ----
 sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
  │         0  ·     order  +b,+a,+c   ·          ·
- └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
+ └── scan  1  scan  ·      ·          (a, b, c)  a!=NULL; key(a)
 ·          1  ·     table  t@primary  ·          ·
 ·          1  ·     spans  ALL        ·          ·
 
@@ -377,34 +377,34 @@ nosort          ·      ·
 query TITTTTT
 EXPLAIN (METADATA) SELECT b+2 FROM t ORDER BY b+2
 ----
-sort            0  sort    ·      ·          ("b + 2")  +"b + 2"
- │              0  ·       order  +"b + 2"   ·          ·
- └── render     1  render  ·      ·          ("b + 2")  +"b + 2"
-      └── scan  2  scan    ·      ·          ("b + 2")  +"b + 2"
-·               2  ·       table  t@primary  ·          ·
-·               2  ·       spans  ALL        ·          ·
+sort            0  sort    ·      ·          ("b + 2")                    +"b + 2"
+ │              0  ·       order  +"b + 2"   ·                            ·
+ └── render     1  render  ·      ·          ("b + 2")                    ·
+      └── scan  2  scan    ·      ·          (a[omitted], b, c[omitted])  a!=NULL; key(a)
+·               2  ·       table  t@primary  ·                            ·
+·               2  ·       spans  ALL        ·                            ·
 
 # Check that the sort picks up a renamed render properly.
 query TITTTTT
 EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY y
 ----
-sort            0  sort    ·      ·          (y)  +y
- │              0  ·       order  +y         ·    ·
- └── render     1  render  ·      ·          (y)  +y
-      └── scan  2  scan    ·      ·          (y)  +y
-·               2  ·       table  t@primary  ·    ·
-·               2  ·       spans  ALL        ·    ·
+sort            0  sort    ·      ·          (y)                          +y
+ │              0  ·       order  +y         ·                            ·
+ └── render     1  render  ·      ·          (y)                          ·
+      └── scan  2  scan    ·      ·          (a[omitted], b, c[omitted])  a!=NULL; key(a)
+·               2  ·       table  t@primary  ·                            ·
+·               2  ·       spans  ALL        ·                            ·
 
 # Check that the sort reuses a render behind a rename properly.
 query TITTTTT
 EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
 ----
-sort            0  sort    ·      ·          (y)  +y
- │              0  ·       order  +y         ·    ·
- └── render     1  render  ·      ·          (y)  +y
-      └── scan  2  scan    ·      ·          (y)  +y
-·               2  ·       table  t@primary  ·    ·
-·               2  ·       spans  ALL        ·    ·
+sort            0  sort    ·      ·          (y)                          +y
+ │              0  ·       order  +y         ·                            ·
+ └── render     1  render  ·      ·          (y)                          ·
+      └── scan  2  scan    ·      ·          (a[omitted], b, c[omitted])  a!=NULL; key(a)
+·               2  ·       table  t@primary  ·                            ·
+·               2  ·       spans  ALL        ·                            ·
 
 statement ok
 CREATE TABLE abc (
@@ -511,15 +511,15 @@ nosort          ·      ·
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
-nosort          0  nosort  ·         ·           (a, b)  b!=NULL; +b
- │              0  ·       order     +b,+c       ·       ·
- └── render     1  render  ·         ·           (a, b)  b!=NULL; +b
-      │         1  ·       render 0  test.abc.a  ·       ·
-      │         1  ·       render 1  test.abc.b  ·       ·
-      │         1  ·       render 2  test.abc.c  ·       ·
-      └── scan  2  scan    ·         ·           (a, b)  b!=NULL; +b
-·               2  ·       table     abc@bc      ·       ·
-·               2  ·       spans     ALL         ·       ·
+nosort          0  nosort  ·         ·           (a, b)                 b!=NULL; +b
+ │              0  ·       order     +b,+c       ·                      ·
+ └── render     1  render  ·         ·           (a, b, c)              b!=NULL; c!=NULL; key(b,c); +b,+c
+      │         1  ·       render 0  test.abc.a  ·                      ·
+      │         1  ·       render 1  test.abc.b  ·                      ·
+      │         1  ·       render 2  test.abc.c  ·                      ·
+      └── scan  2  scan    ·         ·           (a, b, c, d[omitted])  b!=NULL; c!=NULL; key(b,c); +b,+c
+·               2  ·       table     abc@bc      ·                      ·
+·               2  ·       spans     ALL         ·                      ·
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c, a
@@ -614,12 +614,12 @@ render        ·      ·
 query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-nosort          0  nosort  ·      ·            (b, c)  b!=NULL; c!=NULL; key(b,c); +b,+c
- │              0  ·       order  +b,+c        ·       ·
- └── render     1  render  ·      ·            (b, c)  b!=NULL; c!=NULL; key(b,c); +b,+c
-      └── scan  2  scan    ·      ·            (b, c)  b!=NULL; c!=NULL; key(b,c); +b,+c
-·               2  ·       table  abc@primary  ·       ·
-·               2  ·       spans  /1-/2        ·       ·
+nosort          0  nosort  ·      ·            (b, c)                          b!=NULL; c!=NULL; key(b,c); +b,+c
+ │              0  ·       order  +b,+c        ·                               ·
+ └── render     1  render  ·      ·            (b, c, a[omitted])              a=CONST; b!=NULL; c!=NULL; key(b,c); +b,+c
+      └── scan  2  scan    ·      ·            (a[omitted], b, c, d[omitted])  a=CONST; b!=NULL; c!=NULL; key(b,c); +b,+c
+·               2  ·       table  abc@primary  ·                               ·
+·               2  ·       spans  /1-/2        ·                               ·
 
 statement ok
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
@@ -632,7 +632,7 @@ EXPLAIN (METADATA) SELECT * FROM bar ORDER BY baz, id
 ----
 sort       0  sort  ·      ·          (id, baz)  weak-key(baz); +baz,+id
  │         0  ·     order  +baz,+id   ·          ·
- └── scan  1  scan  ·      ·          (id, baz)  weak-key(baz); +baz,+id
+ └── scan  1  scan  ·      ·          (id, baz)  weak-key(baz); +baz
 ·          1  ·     table  bar@i_bar  ·          ·
 ·          1  ·     spans  ALL        ·          ·
 
@@ -710,7 +710,7 @@ EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS 
 ----
 sort         0  sort    ·      ·                 (x)  +x
  │           0  ·       order  +x                ·    ·
- └── values  1  values  ·      ·                 (x)  +x
+ └── values  1  values  ·      ·                 (x)  ·
 ·            1  ·       size   1 column, 3 rows  ·    ·
 
 query TTT
@@ -733,46 +733,46 @@ query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
 ordinality   0  ordinality  ·     ·                 (x, "ordinality")  weak-key("ordinality")
- └── values  1  values      ·     ·                 (x, "ordinality")  weak-key("ordinality")
+ └── values  1  values      ·     ·                 (x)                ·
 ·            1  ·           size  1 column, 3 rows  ·                  ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
 ordinality        0  ordinality  ·      ·                 (x, "ordinality")  weak-key("ordinality")
- └── sort         1  sort        ·      ·                 (x, "ordinality")  weak-key("ordinality")
+ └── sort         1  sort        ·      ·                 (x)                +x
       │           1  ·           order  +x                ·                  ·
-      └── values  2  values      ·      ·                 (x, "ordinality")  weak-key("ordinality")
+      └── values  2  values      ·      ·                 (x)                ·
 ·                 2  ·           size   1 column, 3 rows  ·                  ·
 
 # Check that the ordering of the source does not propagate blindly to RETURNING.
 query TITTTTT
 EXPLAIN (METADATA) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 ----
-insert              0  insert    ·     ·        (b)  ·
- │                  0  ·         into  t(a, b)  ·    ·
- └── render         1  render    ·     ·        (b)  ·
-      └── emptyrow  2  emptyrow  ·     ·        (b)  ·
+insert              0  insert    ·     ·        (b)     ·
+ │                  0  ·         into  t(a, b)  ·       ·
+ └── render         1  render    ·     ·        (x, y)  x=CONST; y=CONST
+      └── emptyrow  2  emptyrow  ·     ·        ()      ·
 
 query TITTTTT
 EXPLAIN (METADATA) DELETE FROM t WHERE a = 3 RETURNING b
 ----
-delete     0  delete  ·      ·          (b)  ·
- │         0  ·       from   t          ·    ·
- └── scan  1  scan    ·      ·          (b)  ·
-·          1  ·       table  t@primary  ·    ·
-·          1  ·       spans  /3-/3/#    ·    ·
+delete     0  delete  ·      ·          (b)        ·
+ │         0  ·       from   t          ·          ·
+ └── scan  1  scan    ·      ·          (a, b, c)  a=CONST; key()
+·          1  ·       table  t@primary  ·          ·
+·          1  ·       spans  /3-/3/#    ·          ·
 
 query TITTTTT
 EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b
 ----
-update          0  update  ·      ·          (b)  ·
- │              0  ·       table  t          ·    ·
- │              0  ·       set    c          ·    ·
- └── render     1  render  ·      ·          (b)  ·
-      └── scan  2  scan    ·      ·          (b)  ·
-·               2  ·       table  t@primary  ·    ·
-·               2  ·       spans  ALL        ·    ·
+update          0  update  ·      ·          (b)                ·
+ │              0  ·       table  t          ·                  ·
+ │              0  ·       set    c          ·                  ·
+ └── render     1  render  ·      ·          (a, b, c, "true")  "true"=CONST; a!=NULL; key(a)
+      └── scan  2  scan    ·      ·          (a, b, c)          a!=NULL; key(a)
+·               2  ·       table  t@primary  ·                  ·
+·               2  ·       spans  ALL        ·                  ·
 
 statement ok
 CREATE TABLE uvwxyz (
@@ -791,10 +791,10 @@ CREATE TABLE uvwxyz (
 query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
-render     0  render  ·      ·            (y, w, x)  y=CONST; +w,+x
- └── scan  1  scan    ·      ·            (y, w, x)  y=CONST; +w,+x
-·          1  ·       table  uvwxyz@ywxz  ·          ·
-·          1  ·       spans  /1-/2        ·          ·
+render     0  render  ·      ·            (y, w, x)                                                             y=CONST; +w,+x
+ └── scan  1  scan    ·      ·            (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  y=CONST; rowid!=NULL; weak-key(u,v,w,x,z,rowid); +w,+x
+·          1  ·       table  uvwxyz@ywxz  ·                                                                     ·
+·          1  ·       spans  /1-/2        ·                                                                     ·
 
 
 statement ok
@@ -811,9 +811,9 @@ CREATE TABLE blocks (
 query TITTTTT
 EXPLAIN (METADATA) SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
 ----
-limit           0  limit   ·      ·               (block_id, writer_id, block_num, block_id)  block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
- └── render     1  render  ·      ·               (block_id, writer_id, block_num, block_id)  block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
-      └── scan  2  scan    ·      ·               (block_id, writer_id, block_num, block_id)  block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
-·               2  ·       table  blocks@primary  ·                                           ·
-·               2  ·       spans  ALL             ·                                           ·
-·               2  ·       limit  1               ·                                           ·
+limit           0  limit   ·      ·               (block_id, writer_id, block_num, block_id)            block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+ └── render     1  render  ·      ·               (block_id, writer_id, block_num, block_id)            block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+      └── scan  2  scan    ·      ·               (block_id, writer_id, block_num, raw_bytes[omitted])  block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+·               2  ·       table  blocks@primary  ·                                                     ·
+·               2  ·       spans  ALL             ·                                                     ·
+·               2  ·       limit  1               ·                                                     ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -6,78 +6,78 @@ CREATE TABLE kv(k INT PRIMARY KEY, v INT); CREATE INDEX foo ON kv(v DESC)
 query TITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv
 ----
-nosort          0  nosort  ·      ·           (v)  ·
- │              0  ·       order  +k          ·    ·
- └── render     1  render  ·      ·           (v)  ·
-      └── scan  2  scan    ·      ·           (v)  ·
-·               2  ·       table  kv@primary  ·    ·
-·               2  ·       spans  ALL         ·    ·
+nosort          0  nosort  ·      ·           (v)     ·
+ │              0  ·       order  +k          ·       ·
+ └── render     1  render  ·      ·           (v, k)  k!=NULL; key(k); +k
+      └── scan  2  scan    ·      ·           (k, v)  k!=NULL; key(k); +k
+·               2  ·       table  kv@primary  ·       ·
+·               2  ·       spans  ALL         ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
 ----
-nosort          0  nosort  ·      ·           (v)  ·
- │              0  ·       order  +k          ·    ·
- └── render     1  render  ·      ·           (v)  ·
-      └── scan  2  scan    ·      ·           (v)  ·
-·               2  ·       table  kv@primary  ·    ·
-·               2  ·       spans  ALL         ·    ·
+nosort          0  nosort  ·      ·           (v)     ·
+ │              0  ·       order  +k          ·       ·
+ └── render     1  render  ·      ·           (v, k)  k!=NULL; key(k); +k
+      └── scan  2  scan    ·      ·           (k, v)  k!=NULL; key(k); +k
+·               2  ·       table  kv@primary  ·       ·
+·               2  ·       spans  ALL         ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
 ----
-nosort             0  nosort   ·      ·           (v)  ·
- │                 0  ·        order  -k          ·    ·
- └── render        1  render   ·      ·           (v)  ·
-      └── revscan  2  revscan  ·      ·           (v)  ·
-·                  2  ·        table  kv@primary  ·    ·
-·                  2  ·        spans  ALL         ·    ·
+nosort             0  nosort   ·      ·           (v)     ·
+ │                 0  ·        order  -k          ·       ·
+ └── render        1  render   ·      ·           (v, k)  k!=NULL; key(k); -k
+      └── revscan  2  revscan  ·      ·           (k, v)  k!=NULL; key(k); -k
+·                  2  ·        table  kv@primary  ·       ·
+·                  2  ·        spans  ALL         ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
 ----
-sort               0  sort     ·      ·               (k)  k!=NULL
- │                 0  ·        order  +v,+k,+"v - 2"  ·    ·
- └── render        1  render   ·      ·               (k)  k!=NULL
-      └── revscan  2  revscan  ·      ·               (k)  k!=NULL
-·                  2  ·        table  kv@foo          ·    ·
-·                  2  ·        spans  ALL             ·    ·
+sort               0  sort     ·      ·               (k)              k!=NULL
+ │                 0  ·        order  +v,+k,+"v - 2"  ·                ·
+ └── render        1  render   ·      ·               (k, v, "v - 2")  k!=NULL; weak-key(k,v); +v
+      └── revscan  2  revscan  ·      ·               (k, v)           k!=NULL; weak-key(k,v); +v
+·                  2  ·        table  kv@foo          ·                ·
+·                  2  ·        spans  ALL             ·                ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
-nosort     0  nosort  ·      ·       (k)  k!=NULL
- │         0  ·       order  -v      ·    ·
- └── scan  1  scan    ·      ·       (k)  k!=NULL
-·          1  ·       table  kv@foo  ·    ·
-·          1  ·       spans  ALL     ·    ·
+nosort     0  nosort  ·      ·       (k)     k!=NULL
+ │         0  ·       order  -v      ·       ·
+ └── scan  1  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
+·          1  ·       table  kv@foo  ·       ·
+·          1  ·       spans  ALL     ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
-nosort     0  nosort  ·      ·       (k)  k!=NULL
- │         0  ·       order  -v      ·    ·
- └── scan  1  scan    ·      ·       (k)  k!=NULL
-·          1  ·       table  kv@foo  ·    ·
-·          1  ·       spans  ALL     ·    ·
+nosort     0  nosort  ·      ·       (k)     k!=NULL
+ │         0  ·       order  -v      ·       ·
+ └── scan  1  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v
+·          1  ·       table  kv@foo  ·       ·
+·          1  ·       spans  ALL     ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
-nosort        0  nosort   ·      ·       (k)  k!=NULL
- │            0  ·        order  +v      ·    ·
- └── revscan  1  revscan  ·      ·       (k)  k!=NULL
-·             1  ·        table  kv@foo  ·    ·
-·             1  ·        spans  ALL     ·    ·
+nosort        0  nosort   ·      ·       (k)     k!=NULL
+ │            0  ·        order  +v      ·       ·
+ └── revscan  1  revscan  ·      ·       (k, v)  k!=NULL; weak-key(k,v); +v
+·             1  ·        table  kv@foo  ·       ·
+·             1  ·        spans  ALL     ·       ·
 
 query TITTTTT
 EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
-nosort     0  nosort  ·      ·       (k)  k!=NULL
- │         0  ·       order  -v,+k   ·    ·
- └── scan  1  scan    ·      ·       (k)  k!=NULL
-·          1  ·       table  kv@foo  ·    ·
-·          1  ·       spans  ALL     ·    ·
+nosort     0  nosort  ·      ·       (k)     k!=NULL
+ │         0  ·       order  -v,+k   ·       ·
+ └── scan  1  scan    ·      ·       (k, v)  k!=NULL; weak-key(k,v); -v,+k
+·          1  ·       table  kv@foo  ·       ·
+·          1  ·       spans  ALL     ·       ·
 
 # Check the syntax can be used with joins.
 #
@@ -88,52 +88,52 @@ nosort     0  nosort  ·      ·       (k)  k!=NULL
 query TITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv JOIN (VALUES (1,2)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
-sort                   0  sort    ·         ·                 (k)  ·
- │                     0  ·       order     -v                ·    ·
- └── render            1  render  ·         ·                 (k)  ·
-      └── join         2  join    ·         ·                 (k)  ·
-           │           2  ·       type      inner             ·    ·
-           │           2  ·       equality  (k) = (a)         ·    ·
-           ├── scan    3  scan    ·         ·                 (k)  ·
-           │           3  ·       table     kv@primary        ·    ·
-           │           3  ·       spans     ALL               ·    ·
-           └── values  3  values  ·         ·                 (k)  ·
-·                      3  ·       size      2 columns, 1 row  ·    ·
+sort                   0  sort    ·         ·                 (k)                             ·
+ │                     0  ·       order     -v                ·                               ·
+ └── render            1  render  ·         ·                 (k, v)                          ·
+      └── join         2  join    ·         ·                 (k, v, a[omitted], b[omitted])  ·
+           │           2  ·       type      inner             ·                               ·
+           │           2  ·       equality  (k) = (a)         ·                               ·
+           ├── scan    3  scan    ·         ·                 (k, v)                          k!=NULL; key(k)
+           │           3  ·       table     kv@primary        ·                               ·
+           │           3  ·       spans     ALL               ·                               ·
+           └── values  3  values  ·         ·                 (column1, column2[omitted])     ·
+·                      3  ·       size      2 columns, 1 row  ·                               ·
 
 query TITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-sort                 0  sort    ·               ·                (k)  k!=NULL; key(k)
- │                   0  ·       order           -v               ·    ·
- └── render          1  render  ·               ·                (k)  k!=NULL; key(k)
-      └── join       2  join    ·               ·                (k)  k!=NULL; key(k)
-           │         2  ·       type            inner            ·    ·
-           │         2  ·       equality        (k, v) = (k, v)  ·    ·
-           │         2  ·       mergeJoinOrder  +"(k=k)"         ·    ·
-           ├── scan  3  scan    ·               ·                (k)  k!=NULL; key(k)
-           │         3  ·       table           kv@primary       ·    ·
-           │         3  ·       spans           ALL              ·    ·
-           └── scan  3  scan    ·               ·                (k)  k!=NULL; key(k)
-·                    3  ·       table           kv@primary       ·    ·
-·                    3  ·       spans           ALL              ·    ·
+sort                 0  sort    ·               ·                (k)                             k!=NULL; key(k)
+ │                   0  ·       order           -v               ·                               ·
+ └── render          1  render  ·               ·                (k, v)                          k!=NULL; v!=NULL; key(k)
+      └── join       2  join    ·               ·                (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; key(k)
+           │         2  ·       type            inner            ·                               ·
+           │         2  ·       equality        (k, v) = (k, v)  ·                               ·
+           │         2  ·       mergeJoinOrder  +"(k=k)"         ·                               ·
+           ├── scan  3  scan    ·               ·                (k, v)                          k!=NULL; key(k); +k
+           │         3  ·       table           kv@primary       ·                               ·
+           │         3  ·       spans           ALL              ·                               ·
+           └── scan  3  scan    ·               ·                (k, v)                          k!=NULL; key(k); +k
+·                    3  ·       table           kv@primary       ·                               ·
+·                    3  ·       spans           ALL              ·                               ·
 
 # The underlying index can be forced manually, of course.
 query TITTTTT
 EXPLAIN(METADATA) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@foo
 ----
-nosort               0  nosort  ·               ·                  (k)  k!=NULL
- │                   0  ·       order           -v                 ·    ·
- └── render          1  render  ·               ·                  (k)  k!=NULL
-      └── join       2  join    ·               ·                  (k)  k!=NULL
-           │         2  ·       type            inner              ·    ·
-           │         2  ·       equality        (k, v) = (k, v)    ·    ·
-           │         2  ·       mergeJoinOrder  -"(v=v)",+"(k=k)"  ·    ·
-           ├── scan  3  scan    ·               ·                  (k)  k!=NULL
-           │         3  ·       table           kv@foo             ·    ·
-           │         3  ·       spans           ALL                ·    ·
-           └── scan  3  scan    ·               ·                  (k)  k!=NULL
-·                    3  ·       table           kv@foo             ·    ·
-·                    3  ·       spans           ALL                ·    ·
+nosort               0  nosort  ·               ·                  (k)                             k!=NULL
+ │                   0  ·       order           -v                 ·                               ·
+ └── render          1  render  ·               ·                  (k, v)                          k!=NULL; v!=NULL; -v
+      └── join       2  join    ·               ·                  (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; -v
+           │         2  ·       type            inner              ·                               ·
+           │         2  ·       equality        (k, v) = (k, v)    ·                               ·
+           │         2  ·       mergeJoinOrder  -"(v=v)",+"(k=k)"  ·                               ·
+           ├── scan  3  scan    ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
+           │         3  ·       table           kv@foo             ·                               ·
+           │         3  ·       spans           ALL                ·                               ·
+           └── scan  3  scan    ·               ·                  (k, v)                          k!=NULL; weak-key(k,v); -v,+k
+·                    3  ·       table           kv@foo             ·                               ·
+·                    3  ·       spans           ALL                ·                               ·
 
 # Check the extended syntax cannot be used in case of renames.
 statement error source name "kv" not found in FROM clause

--- a/pkg/sql/logictest/testdata/logic_test/ordinal_references
+++ b/pkg/sql/logictest/testdata/logic_test/ordinal_references
@@ -50,14 +50,14 @@ a 3
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT b, a FROM foo ORDER BY @1
 ----
-sort            0  sort    ·         ·            (b, a)  +a
- │              0  ·       order     +a           ·       ·
- └── render     1  render  ·         ·            (b, a)  +a
-      │         1  ·       render 0  test.foo.b   ·       ·
-      │         1  ·       render 1  test.foo.a   ·       ·
-      └── scan  2  scan    ·         ·            (b, a)  +a
-·               2  ·       table     foo@primary  ·       ·
-·               2  ·       spans     ALL          ·       ·
+sort            0  sort    ·         ·            (b, a)                         +a
+ │              0  ·       order     +a           ·                              ·
+ └── render     1  render  ·         ·            (b, a)                         ·
+      │         1  ·       render 0  test.foo.b   ·                              ·
+      │         1  ·       render 1  test.foo.a   ·                              ·
+      └── scan  2  scan    ·         ·            (a, b, rowid[hidden,omitted])  rowid!=NULL; key(rowid)
+·               2  ·       table     foo@primary  ·                              ·
+·               2  ·       spans     ALL          ·                              ·
 
 statement ok
 INSERT INTO foo(a, b) VALUES (4, 'c'), (5, 'c'), (6, 'c')
@@ -83,27 +83,27 @@ SELECT SUM(a) AS s FROM foo GROUP BY @2 ORDER BY s
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
-group           0  group   ·            ·                (m)  ·
- │              0  ·       aggregate 0  min(test.foo.a)  ·    ·
- │              0  ·       group by     @1-@1            ·    ·
- └── render     1  render  ·            ·                (m)  ·
-      │         1  ·       render 0     test.foo.a       ·    ·
-      └── scan  2  scan    ·            ·                (m)  ·
-·               2  ·       table        foo@primary      ·    ·
-·               2  ·       spans        ALL              ·    ·
+group           0  group   ·            ·                (m)                                     ·
+ │              0  ·       aggregate 0  min(test.foo.a)  ·                                       ·
+ │              0  ·       group by     @1-@1            ·                                       ·
+ └── render     1  render  ·            ·                (a)                                     ·
+      │         1  ·       render 0     test.foo.a       ·                                       ·
+      └── scan  2  scan    ·            ·                (a, b[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
+·               2  ·       table        foo@primary      ·                                       ·
+·               2  ·       spans        ALL              ·                                       ·
 
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 ----
-group           0  group   ·            ·                (m)  ·
- │              0  ·       aggregate 0  min(test.foo.a)  ·    ·
- │              0  ·       group by     @1-@1            ·    ·
- └── render     1  render  ·            ·                (m)  ·
-      │         1  ·       render 0     test.foo.b       ·    ·
-      │         1  ·       render 1     test.foo.a       ·    ·
-      └── scan  2  scan    ·            ·                (m)  ·
-·               2  ·       table        foo@primary      ·    ·
-·               2  ·       spans        ALL              ·    ·
+group           0  group   ·            ·                (m)                            ·
+ │              0  ·       aggregate 0  min(test.foo.a)  ·                              ·
+ │              0  ·       group by     @1-@1            ·                              ·
+ └── render     1  render  ·            ·                (b, a)                         ·
+      │         1  ·       render 0     test.foo.b       ·                              ·
+      │         1  ·       render 1     test.foo.a       ·                              ·
+      └── scan  2  scan    ·            ·                (a, b, rowid[hidden,omitted])  rowid!=NULL; key(rowid)
+·               2  ·       table        foo@primary      ·                              ·
+·               2  ·       spans        ALL              ·                              ·
 
 statement error column reference @1 not allowed in this context
 INSERT INTO foo(a, b) VALUES (@1, @2)

--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -86,7 +86,7 @@ query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
 ----
 ordinality  0  ordinality  ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
- └── scan   1  scan        ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
+ └── scan   1  scan        ·      ·            (x)                x!=NULL; key(x)
 ·           1  ·           table  foo@primary  ·                  ·
 ·           1  ·           spans  /"a\x00"-    ·                  ·
 
@@ -97,6 +97,6 @@ EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
 ----
 filter           0  filter      ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
  └── ordinality  1  ordinality  ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
-      └── scan   2  scan        ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
+      └── scan   2  scan        ·      ·            (x)                x!=NULL; key(x)
 ·                2  ·           table  foo@primary  ·                  ·
 ·                2  ·           spans  ALL          ·                  ·

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -53,7 +53,7 @@ EXPLAIN (TYPES) SELECT 'pg_constraint'::REGCLASS
 ----
 render         0  render    ·         ·                          ("'pg_constraint'::REGCLASS" regclass)  "'pg_constraint'::REGCLASS"=CONST
  │             0  ·         render 0  (pg_constraint)[regclass]  ·                                       ·
- └── emptyrow  1  emptyrow  ·         ·                          ("'pg_constraint'::REGCLASS" regclass)  "'pg_constraint'::REGCLASS"=CONST
+ └── emptyrow  1  emptyrow  ·         ·                          ()                                      ·
 
 query OO
 SELECT '"pg_constraint"'::REGCLASS, '  "pg_constraint" '::REGCLASS

--- a/pkg/sql/logictest/testdata/logic_test/physical_props
+++ b/pkg/sql/logictest/testdata/logic_test/physical_props
@@ -71,7 +71,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE 
 Tree         Level  Type    Field          Description        Columns    Ordering
 filter       0      filter  ·              ·                  (a, b, c)  a=CONST
  │           0      ·       filter         x.a = 1            ·          ·
- └── values  1      values  ·              ·                  (a, b, c)  a=CONST
+ └── values  1      values  ·              ·                  (a, b, c)  ·
 ·            1      ·       size           3 columns, 2 rows  ·          ·
 ·            1      ·       row 0, expr 0  1                  ·          ·
 ·            1      ·       row 0, expr 1  2                  ·          ·
@@ -86,7 +86,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE 
 Tree         Level  Type    Field          Description        Columns    Ordering
 filter       0      filter  ·              ·                  (a, b, c)  a=b; a!=NULL; b!=NULL
  │           0      ·       filter         x.a = x.b          ·          ·
- └── values  1      values  ·              ·                  (a, b, c)  a=b; a!=NULL; b!=NULL
+ └── values  1      values  ·              ·                  (a, b, c)  ·
 ·            1      ·       size           3 columns, 2 rows  ·          ·
 ·            1      ·       row 0, expr 0  1                  ·          ·
 ·            1      ·       row 0, expr 1  2                  ·          ·
@@ -101,7 +101,7 @@ EXPLAIN (VERBOSE) SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS x(a,b,c) WHERE 
 Tree         Level  Type    Field          Description                Columns    Ordering
 filter       0      filter  ·              ·                          (a, b, c)  a=b; a=CONST; b!=NULL
  │           0      ·       filter         (x.a = x.b) AND (x.b = 1)  ·          ·
- └── values  1      values  ·              ·                          (a, b, c)  a=b; a=CONST; b!=NULL
+ └── values  1      values  ·              ·                          (a, b, c)  ·
 ·            1      ·       size           3 columns, 2 rows          ·          ·
 ·            1      ·       row 0, expr 0  1                          ·          ·
 ·            1      ·       row 0, expr 1  2                          ·          ·
@@ -122,10 +122,10 @@ join       0      join  ·               ·             (a, b, c, d, e, f, g)  a
  │         0      ·     type            inner         ·                      ·
  │         0      ·     equality        (a) = (e)     ·                      ·
  │         0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
- ├── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST; key()
+ ├── scan  1      scan  ·               ·             (a, b, c, d)           a=CONST; key()
  │         1      ·     table           abcd@primary  ·                      ·
  │         1      ·     spans           /1-/1/#       ·                      ·
- └── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; a=CONST; key()
+ └── scan  1      scan  ·               ·             (e, f, g)              f=g; e=CONST; f!=NULL; g!=NULL; key()
 ·          1      ·     table           efg@primary   ·                      ·
 ·          1      ·     spans           /1-/1/#       ·                      ·
 ·          1      ·     filter          f = g         ·                      ·
@@ -138,11 +138,11 @@ join       0      join  ·               ·             (a, b, c, d, e, f, g)  a
  │         0      ·     type            inner         ·                      ·
  │         0      ·     equality        (a) = (e)     ·                      ·
  │         0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
- ├── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; b=CONST; a!=NULL; key(a)
+ ├── scan  1      scan  ·               ·             (a, b, c, d)           b=CONST; a!=NULL; key(a); +a
  │         1      ·     table           abcd@primary  ·                      ·
  │         1      ·     spans           ALL           ·                      ·
  │         1      ·     filter          b = 1         ·                      ·
- └── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; f=g; b=CONST; a!=NULL; key(a)
+ └── scan  1      scan  ·               ·             (e, f, g)              f=g; e!=NULL; f!=NULL; g!=NULL; key(e); +e
 ·          1      ·     table           efg@primary   ·                      ·
 ·          1      ·     spans           ALL           ·                      ·
 ·          1      ·     filter          f = g         ·                      ·
@@ -155,10 +155,10 @@ join       0      join  ·               ·             (a, b, c, d, e, f, g)  a
  │         0      ·     type            inner         ·                      ·
  │         0      ·     equality        (a) = (e)     ·                      ·
  │         0      ·     mergeJoinOrder  +"(a=e)"      ·                      ·
- ├── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; a!=NULL; key(a)
+ ├── scan  1      scan  ·               ·             (a, b, c, d)           a!=NULL; key(a); +a
  │         1      ·     table           abcd@primary  ·                      ·
  │         1      ·     spans           ALL           ·                      ·
- └── scan  1      scan  ·               ·             (a, b, c, d, e, f, g)  a=e; a!=NULL; key(a)
+ └── scan  1      scan  ·               ·             (e, f, g)              e!=NULL; key(e); +e
 ·          1      ·     table           efg@primary   ·                      ·
 ·          1      ·     spans           ALL           ·                      ·
 
@@ -170,10 +170,10 @@ Tree       Level  Type  Field     Description   Columns                Ordering
 join       0      join  ·         ·             (a, b, c, d, e, f, g)  ·
  │         0      ·     type      inner         ·                      ·
  │         0      ·     equality  (a) = (f)     ·                      ·
- ├── scan  1      scan  ·         ·             (a, b, c, d, e, f, g)  ·
+ ├── scan  1      scan  ·         ·             (a, b, c, d)           a!=NULL; key(a)
  │         1      ·     table     abcd@primary  ·                      ·
  │         1      ·     spans     ALL           ·                      ·
- └── scan  1      scan  ·         ·             (a, b, c, d, e, f, g)  ·
+ └── scan  1      scan  ·         ·             (e, f, g)              e!=NULL; key(e)
 ·          1      ·     table     efg@primary   ·                      ·
 ·          1      ·     spans     ALL           ·                      ·
 
@@ -186,10 +186,10 @@ join             0      join        ·               ·             (a, b, c, d,
  │               0      ·           type            inner         ·                                    ·
  │               0      ·           equality        (a) = (e)     ·                                    ·
  │               0      ·           mergeJoinOrder  +"(a=e)"      ·                                    ·
- ├── scan        1      scan        ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; a!=NULL; key(a); weak-key("ordinality")
+ ├── scan        1      scan        ·               ·             (a, b, c, d)                         a!=NULL; key(a); +a
  │               1      ·           table           abcd@primary  ·                                    ·
  │               1      ·           spans           ALL           ·                                    ·
- └── ordinality  1      ordinality  ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; a!=NULL; key(a); weak-key("ordinality")
-      └── scan   2      scan        ·               ·             (a, b, c, d, e, f, g, "ordinality")  a=e; a!=NULL; key(a); weak-key("ordinality")
+ └── ordinality  1      ordinality  ·               ·             (e, f, g, "ordinality")              e!=NULL; key(e); weak-key("ordinality"); +e
+      └── scan   2      scan        ·               ·             (e, f, g)                            e!=NULL; key(e); +e
 ·                2      ·           table           efg@primary   ·                                    ·
 ·                2      ·           spans           ALL           ·                                    ·

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -112,14 +112,14 @@ NULL       /8       {1}       1
 query TITTTTT colnames
 EXPLAIN (METADATA) ALTER TABLE t SPLIT AT SELECT k1,k2 FROM t ORDER BY k1 LIMIT 3
 ----
-Tree                 Level  Type    Field  Description  Columns        Ordering
-split                0      split   ·      ·            (key, pretty)  ·
- └── limit           1      limit   ·      ·            (key, pretty)  ·
-      └── render     2      render  ·      ·            (key, pretty)  ·
-           └── scan  3      scan    ·      ·            (key, pretty)  ·
-·                    3      ·       table  t@primary    ·              ·
-·                    3      ·       spans  ALL          ·              ·
-·                    3      ·       limit  3            ·              ·
+Tree                 Level  Type    Field  Description  Columns                           Ordering
+split                0      split   ·      ·            (key, pretty)                     ·
+ └── limit           1      limit   ·      ·            (k1, k2)                          k1!=NULL; k2!=NULL; key(k1,k2); +k1
+      └── render     2      render  ·      ·            (k1, k2)                          k1!=NULL; k2!=NULL; key(k1,k2); +k1
+           └── scan  3      scan    ·      ·            (k1, k2, v[omitted], w[omitted])  k1!=NULL; k2!=NULL; key(k1,k2); +k1
+·                    3      ·       table  t@primary    ·                                 ·
+·                    3      ·       spans  ALL          ·                                 ·
+·                    3      ·       limit  3            ·                                 ·
 
 # -- Tests with interleaved tables --
 

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -540,12 +540,12 @@ CREATE TABLE tab0(
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
 ----
-render     0  render  ·         ·                                     (k)  k!=NULL; key(k)
- │         0  ·       render 0  test.tab0.k                           ·    ·
- └── scan  1  scan    ·         ·                                     (k)  k!=NULL; key(k)
-·          1  ·       table     tab0@primary                          ·    ·
-·          1  ·       spans     ALL                                   ·    ·
-·          1  ·       filter    ((a IN (6)) AND (a > 6)) OR (b >= 4)  ·    ·
+render     0  render  ·         ·                                     (k)        k!=NULL; key(k)
+ │         0  ·       render 0  test.tab0.k                           ·          ·
+ └── scan  1  scan    ·         ·                                     (k, a, b)  k!=NULL; key(k)
+·          1  ·       table     tab0@primary                          ·          ·
+·          1  ·       spans     ALL                                   ·          ·
+·          1  ·       filter    ((a IN (6)) AND (a > 6)) OR (b >= 4)  ·          ·
 
 query I
 SELECT k FROM tab0 WHERE (a IN (6) AND a > 6) OR b >= 4
@@ -797,14 +797,14 @@ INSERT INTO abcd VALUES
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b > 5
 ----
-render     0  render  ·         ·               (a, b, c, d)  a=CONST; b!=NULL
- │         0  ·       render 0  test.abcd.a     ·             ·
- │         0  ·       render 1  test.abcd.b     ·             ·
- │         0  ·       render 2  test.abcd.c     ·             ·
- │         0  ·       render 3  test.abcd.d     ·             ·
- └── scan  1  scan    ·         ·               (a, b, c, d)  a=CONST; b!=NULL
-·          1  ·       table     abcd@abcd       ·             ·
-·          1  ·       spans     /NULL/6-/!NULL  ·             ·
+render     0  render  ·         ·               (a, b, c, d)                         a=CONST; b!=NULL
+ │         0  ·       render 0  test.abcd.a     ·                                    ·
+ │         0  ·       render 1  test.abcd.b     ·                                    ·
+ │         0  ·       render 2  test.abcd.c     ·                                    ·
+ │         0  ·       render 3  test.abcd.d     ·                                    ·
+ └── scan  1  scan    ·         ·               (a, b, c, d, rowid[hidden,omitted])  a=CONST; b!=NULL; rowid!=NULL; weak-key(b,c,d,rowid)
+·          1  ·       table     abcd@abcd       ·                                    ·
+·          1  ·       spans     /NULL/6-/!NULL  ·                                    ·
 
 query IIII rowsort
 SELECT * FROM abcd@abcd WHERE a IS NULL AND b > 5
@@ -817,14 +817,14 @@ NULL  10  10    NULL
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL AND b < 5
 ----
-render     0  render  ·         ·                    (a, b, c, d)  a=CONST; b!=NULL
- │         0  ·       render 0  test.abcd.a          ·             ·
- │         0  ·       render 1  test.abcd.b          ·             ·
- │         0  ·       render 2  test.abcd.c          ·             ·
- │         0  ·       render 3  test.abcd.d          ·             ·
- └── scan  1  scan    ·         ·                    (a, b, c, d)  a=CONST; b!=NULL
-·          1  ·       table     abcd@abcd            ·             ·
-·          1  ·       spans     /NULL/!NULL-/NULL/5  ·             ·
+render     0  render  ·         ·                    (a, b, c, d)                         a=CONST; b!=NULL
+ │         0  ·       render 0  test.abcd.a          ·                                    ·
+ │         0  ·       render 1  test.abcd.b          ·                                    ·
+ │         0  ·       render 2  test.abcd.c          ·                                    ·
+ │         0  ·       render 3  test.abcd.d          ·                                    ·
+ └── scan  1  scan    ·         ·                    (a, b, c, d, rowid[hidden,omitted])  a=CONST; b!=NULL; rowid!=NULL; weak-key(b,c,d,rowid)
+·          1  ·       table     abcd@abcd            ·                                    ·
+·          1  ·       spans     /NULL/!NULL-/NULL/5  ·                                    ·
 
 query IIII rowsort
 SELECT * FROM abcd@abcd WHERE a IS NULL AND b < 5
@@ -837,14 +837,14 @@ NULL  1  10    NULL
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a IS NULL ORDER BY b
 ----
-render     0  render  ·         ·             (a, b, c, d)  a=CONST; +b
- │         0  ·       render 0  test.abcd.a   ·             ·
- │         0  ·       render 1  test.abcd.b   ·             ·
- │         0  ·       render 2  test.abcd.c   ·             ·
- │         0  ·       render 3  test.abcd.d   ·             ·
- └── scan  1  scan    ·         ·             (a, b, c, d)  a=CONST; +b
-·          1  ·       table     abcd@abcd     ·             ·
-·          1  ·       spans     /NULL-/!NULL  ·             ·
+render     0  render  ·         ·             (a, b, c, d)                         a=CONST; +b
+ │         0  ·       render 0  test.abcd.a   ·                                    ·
+ │         0  ·       render 1  test.abcd.b   ·                                    ·
+ │         0  ·       render 2  test.abcd.c   ·                                    ·
+ │         0  ·       render 3  test.abcd.d   ·                                    ·
+ └── scan  1  scan    ·         ·             (a, b, c, d, rowid[hidden,omitted])  a=CONST; rowid!=NULL; weak-key(b,c,d,rowid); +b
+·          1  ·       table     abcd@abcd     ·                                    ·
+·          1  ·       spans     /NULL-/!NULL  ·                                    ·
 
 query IIII partialsort(1,2)
 SELECT * FROM abcd@abcd WHERE a IS NULL ORDER BY b
@@ -869,14 +869,14 @@ NULL  10    10    NULL
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c
 ----
-render     0  render  ·         ·                     (a, b, c, d)  a=CONST; b=CONST; c!=NULL; +c
- │         0  ·       render 0  test.abcd.a           ·             ·
- │         0  ·       render 1  test.abcd.b           ·             ·
- │         0  ·       render 2  test.abcd.c           ·             ·
- │         0  ·       render 3  test.abcd.d           ·             ·
- └── scan  1  scan    ·         ·                     (a, b, c, d)  a=CONST; b=CONST; c!=NULL; +c
-·          1  ·       table     abcd@abcd             ·             ·
-·          1  ·       spans     /1/NULL/1-/1/NULL/10  ·             ·
+render     0  render  ·         ·                     (a, b, c, d)                         a=CONST; b=CONST; c!=NULL; +c
+ │         0  ·       render 0  test.abcd.a           ·                                    ·
+ │         0  ·       render 1  test.abcd.b           ·                                    ·
+ │         0  ·       render 2  test.abcd.c           ·                                    ·
+ │         0  ·       render 3  test.abcd.d           ·                                    ·
+ └── scan  1  scan    ·         ·                     (a, b, c, d, rowid[hidden,omitted])  a=CONST; b=CONST; c!=NULL; rowid!=NULL; weak-key(c,d,rowid); +c
+·          1  ·       table     abcd@abcd             ·                                    ·
+·          1  ·       spans     /1/NULL/1-/1/NULL/10  ·                                    ·
 
 query IIII 
 SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c
@@ -891,19 +891,19 @@ CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY(a,b), INDEX(c))
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT c FROM abc WHERE c = 1 and a = 3
 ----
-render     0  render  ·         ·              (c)  c=CONST
- │         0  ·       render 0  test.abc.c     ·    ·
- └── scan  1  scan    ·         ·              (c)  c=CONST
-·          1  ·       table     abc@abc_c_idx  ·    ·
-·          1  ·       spans     /1/3-/1/4      ·    ·
+render     0  render  ·         ·              (c)                          c=CONST
+ │         0  ·       render 0  test.abc.c     ·                            ·
+ └── scan  1  scan    ·         ·              (a[omitted], b[omitted], c)  a=CONST; c=CONST; b!=NULL; key(b)
+·          1  ·       table     abc@abc_c_idx  ·                            ·
+·          1  ·       spans     /1/3-/1/4      ·                            ·
 
 # Regression test for #20504.
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT a, b FROM abc WHERE (a, b) BETWEEN (1, 2) AND (3, 4)
 ----
-render     0  render  ·         ·            (a, b)  a!=NULL; b!=NULL; key(a,b)
- │         0  ·       render 0  test.abc.a   ·       ·
- │         0  ·       render 1  test.abc.b   ·       ·
- └── scan  1  scan    ·         ·            (a, b)  a!=NULL; b!=NULL; key(a,b)
-·          1  ·       table     abc@primary  ·       ·
-·          1  ·       spans     /1/2-/3/4/#  ·       ·
+render     0  render  ·         ·            (a, b)              a!=NULL; b!=NULL; key(a,b)
+ │         0  ·       render 0  test.abc.a   ·                   ·
+ │         0  ·       render 1  test.abc.b   ·                   ·
+ └── scan  1  scan    ·         ·            (a, b, c[omitted])  a!=NULL; b!=NULL; key(a,b)
+·          1  ·       table     abc@primary  ·                   ·
+·          1  ·       spans     /1/2-/3/4/#  ·                   ·

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
@@ -72,12 +72,12 @@ SELECT * FROM t WHERE c = 7
 query TITTTTT
 EXPLAIN (METADATA) SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 ----
-index-join    0  index-join  ·      ·          (a, b, c, d)  c!=NULL; key(c); -c
- ├── revscan  1  revscan     ·      ·          (a, b, c, d)  c!=NULL; key(c); -c
- │            1  ·           table  t@c        ·             ·
- │            1  ·           spans  /1-        ·             ·
- └── scan     1  scan        ·      ·          (a, b, c, d)  c!=NULL; key(c); -c
-·             1  ·           table  t@primary  ·             ·
+index-join    0  index-join  ·      ·          (a, b, c, d)                             c!=NULL; key(c); -c
+ ├── revscan  1  revscan     ·      ·          (a, b[omitted], c[omitted], d[omitted])  c!=NULL; key(c); -c
+ │            1  ·           table  t@c        ·                                        ·
+ │            1  ·           spans  /1-        ·                                        ·
+ └── scan     1  scan        ·      ·          (a, b, c, d)                             ·
+·             1  ·           table  t@primary  ·                                        ·
 
 query IIII
 SELECT * FROM t WHERE c > 0 ORDER BY c DESC

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
@@ -134,14 +134,14 @@ output row: [9 3 3 '33']
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
 ----
-render           0  render      ·         ·          (a)  a!=NULL
- │               0  ·           render 0  test.t.a   ·    ·
- └── index-join  1  index-join  ·         ·          (a)  a!=NULL
-      ├── scan   2  scan        ·         ·          (a)  a!=NULL
-      │          2  ·           table     t@bc       ·    ·
-      │          2  ·           spans     /2-/3      ·    ·
-      └── scan   2  scan        ·         ·          (a)  a!=NULL
-·                2  ·           table     t@primary  ·    ·
+render           0  render      ·         ·          (a)                                      a!=NULL
+ │               0  ·           render 0  test.t.a   ·                                        ·
+ └── index-join  1  index-join  ·         ·          (a, b[omitted], c[omitted], s[omitted])  b=CONST; a!=NULL; weak-key(a,c)
+      ├── scan   2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  b=CONST; a!=NULL; weak-key(a,c)
+      │          2  ·           table     t@bc       ·                                        ·
+      │          2  ·           spans     /2-/3      ·                                        ·
+      └── scan   2  scan        ·         ·          (a, b[omitted], c[omitted], s[omitted])  ·
+·                2  ·           table     t@primary  ·                                        ·
 
 query I rowsort
 SELECT a FROM t WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))

--- a/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
+++ b/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
@@ -28,18 +28,18 @@ SELECT COUNT(DISTINCT x.*) FROM a x, a y
 query TITTTTT
 EXPLAIN(VERBOSE) SELECT COUNT(DISTINCT x.*) FROM a x, a y
 ----
-group                0  group   ·            ·                           (count)  ·
- │                   0  ·       aggregate 0  count(DISTINCT (x.x, x.y))  ·        ·
- └── render          1  render  ·            ·                           (count)  ·
-      │              1  ·       render 0     (x.x, x.y)                  ·        ·
-      └── join       2  join    ·            ·                           (count)  ·
-           │         2  ·       type         cross                       ·        ·
-           ├── scan  3  scan    ·            ·                           (count)  ·
-           │         3  ·       table        a@primary                   ·        ·
-           │         3  ·       spans        ALL                         ·        ·
-           └── scan  3  scan    ·            ·                           (count)  ·
-·                    3  ·       table        a@primary                   ·        ·
-·                    3  ·       spans        ALL                         ·        ·
+group                0  group   ·            ·                           (count)                                                                       ·
+ │                   0  ·       aggregate 0  count(DISTINCT (x.x, x.y))  ·                                                                             ·
+ └── render          1  render  ·            ·                           ("(x, y)")                                                                    ·
+      │              1  ·       render 0     (x.x, x.y)                  ·                                                                             ·
+      └── join       2  join    ·            ·                           (x, y, rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
+           │         2  ·       type         cross                       ·                                                                             ·
+           ├── scan  3  scan    ·            ·                           (x, y, rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
+           │         3  ·       table        a@primary                   ·                                                                             ·
+           │         3  ·       spans        ALL                         ·                                                                             ·
+           └── scan  3  scan    ·            ·                           (x[omitted], y[omitted], rowid[hidden,omitted])                               rowid!=NULL; key(rowid)
+·                    3  ·       table        a@primary                   ·                                                                             ·
+·                    3  ·       spans        ALL                         ·                                                                             ·
 
 query TTT
 EXPLAIN(EXPRS) SELECT * FROM a ORDER BY a.*

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -466,19 +466,19 @@ true
 query TITTTTT
 EXPLAIN (METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
 ----
-root                 0  root      ·          ·                    (x)  x!=NULL; key(x)
- ├── render          1  render    ·          ·                    (x)  x!=NULL; key(x)
- │    └── scan       2  scan      ·          ·                    (x)  x!=NULL; key(x)
- │                   2  ·         table      xyz@primary          ·    ·
- │                   2  ·         spans      ALL                  ·    ·
- └── subquery        1  subquery  ·          ·                    (x)  x!=NULL; key(x)
-      │              1  ·         id         @S1                  ·    ·
-      │              1  ·         sql        (SELECT x FROM xyz)  ·    ·
-      │              1  ·         exec mode  all rows normalized  ·    ·
-      └── render     2  render    ·          ·                    (x)  x!=NULL; key(x)
-           └── scan  3  scan      ·          ·                    (x)  x!=NULL; key(x)
-·                    3  ·         table      xyz@primary          ·    ·
-·                    3  ·         spans      ALL                  ·    ·
+root                 0  root      ·          ·                    (x)                          x!=NULL; key(x)
+ ├── render          1  render    ·          ·                    (x)                          x!=NULL; key(x)
+ │    └── scan       2  scan      ·          ·                    (x, y[omitted], z[omitted])  x!=NULL; key(x)
+ │                   2  ·         table      xyz@primary          ·                            ·
+ │                   2  ·         spans      ALL                  ·                            ·
+ └── subquery        1  subquery  ·          ·                    (x)                          x!=NULL; key(x)
+      │              1  ·         id         @S1                  ·                            ·
+      │              1  ·         sql        (SELECT x FROM xyz)  ·                            ·
+      │              1  ·         exec mode  all rows normalized  ·                            ·
+      └── render     2  render    ·          ·                    (x)                          x!=NULL; key(x)
+           └── scan  3  scan      ·          ·                    (x, y[omitted], z[omitted])  x!=NULL; key(x)
+·                    3  ·         table      xyz@primary          ·                            ·
+·                    3  ·         spans      ALL                  ·                            ·
 
 # This test checks that the double sub-query plan expansion caused by a
 # sub-expression being shared by two or more plan nodes does not

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -310,13 +310,13 @@ NULL  3     3
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                  (u, v, w)  +u,+v,+w
- │         0  ·       render 0  test.uvw.u         ·          ·
- │         0  ·       render 1  test.uvw.v         ·          ·
- │         0  ·       render 2  test.uvw.w         ·          ·
- └── scan  1  scan    ·         ·                  (u, v, w)  +u,+v,+w
-·          1  ·       table     uvw@uvw_u_v_w_idx  ·          ·
-·          1  ·       spans     /1/2/3-            ·          ·
+render     0  render  ·         ·                  (u, v, w)                         +u,+v,+w
+ │         0  ·       render 0  test.uvw.u         ·                                 ·
+ │         0  ·       render 1  test.uvw.v         ·                                 ·
+ │         0  ·       render 2  test.uvw.w         ·                                 ·
+ └── scan  1  scan    ·         ·                  (u, v, w, rowid[hidden,omitted])  rowid!=NULL; weak-key(u,v,w,rowid); +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx  ·                                 ·
+·          1  ·       spans     /1/2/3-            ·                                 ·
 
 query III
 SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
@@ -362,13 +362,13 @@ SELECT * FROM uvw WHERE (u, v, w) >= (1, 2, 3) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                  (u, v, w)  +u,+v,+w
- │         0  ·       render 0  test.uvw.u         ·          ·
- │         0  ·       render 1  test.uvw.v         ·          ·
- │         0  ·       render 2  test.uvw.w         ·          ·
- └── scan  1  scan    ·         ·                  (u, v, w)  +u,+v,+w
-·          1  ·       table     uvw@uvw_u_v_w_idx  ·          ·
-·          1  ·       spans     /2/1/2-            ·          ·
+render     0  render  ·         ·                  (u, v, w)                         +u,+v,+w
+ │         0  ·       render 0  test.uvw.u         ·                                 ·
+ │         0  ·       render 1  test.uvw.v         ·                                 ·
+ │         0  ·       render 2  test.uvw.w         ·                                 ·
+ └── scan  1  scan    ·         ·                  (u, v, w, rowid[hidden,omitted])  rowid!=NULL; weak-key(u,v,w,rowid); +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx  ·                                 ·
+·          1  ·       spans     /2/1/2-            ·                                 ·
 
 query III
 SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
@@ -403,14 +403,14 @@ SELECT * FROM uvw WHERE (u, v, w) > (2, 1, 1) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                       (u, v, w)  +u,+v,+w
- │         0  ·       render 0  test.uvw.u              ·          ·
- │         0  ·       render 1  test.uvw.v              ·          ·
- │         0  ·       render 2  test.uvw.w              ·          ·
- └── scan  1  scan    ·         ·                       (u, v, w)  +u,+v,+w
-·          1  ·       table     uvw@uvw_u_v_w_idx       ·          ·
-·          1  ·       spans     /!NULL-/2/3/2           ·          ·
-·          1  ·       filter    (u, v, w) <= (2, 3, 1)  ·          ·
+render     0  render  ·         ·                       (u, v, w)                         +u,+v,+w
+ │         0  ·       render 0  test.uvw.u              ·                                 ·
+ │         0  ·       render 1  test.uvw.v              ·                                 ·
+ │         0  ·       render 2  test.uvw.w              ·                                 ·
+ └── scan  1  scan    ·         ·                       (u, v, w, rowid[hidden,omitted])  rowid!=NULL; weak-key(u,v,w,rowid); +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx       ·                                 ·
+·          1  ·       spans     /!NULL-/2/3/2           ·                                 ·
+·          1  ·       filter    (u, v, w) <= (2, 3, 1)  ·                                 ·
 
 query III
 SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
@@ -444,14 +444,14 @@ SELECT * FROM uvw WHERE (u, v, w) <= (2, 3, 1) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                      (u, v, w)  +u,+v,+w
- │         0  ·       render 0  test.uvw.u             ·          ·
- │         0  ·       render 1  test.uvw.v             ·          ·
- │         0  ·       render 2  test.uvw.w             ·          ·
- └── scan  1  scan    ·         ·                      (u, v, w)  +u,+v,+w
-·          1  ·       table     uvw@uvw_u_v_w_idx      ·          ·
-·          1  ·       spans     /!NULL-/2/2/2          ·          ·
-·          1  ·       filter    (u, v, w) < (2, 2, 2)  ·          ·
+render     0  render  ·         ·                      (u, v, w)                         +u,+v,+w
+ │         0  ·       render 0  test.uvw.u             ·                                 ·
+ │         0  ·       render 1  test.uvw.v             ·                                 ·
+ │         0  ·       render 2  test.uvw.w             ·                                 ·
+ └── scan  1  scan    ·         ·                      (u, v, w, rowid[hidden,omitted])  rowid!=NULL; weak-key(u,v,w,rowid); +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx      ·                                 ·
+·          1  ·       spans     /!NULL-/2/2/2          ·                                 ·
+·          1  ·       filter    (u, v, w) < (2, 2, 2)  ·                                 ·
 
 query III
 SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
@@ -481,14 +481,14 @@ SELECT * FROM uvw WHERE (u, v, w) < (2, 2, 2) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                       (u, v, w)  +u,+v,+w
- │         0  ·       render 0  test.uvw.u              ·          ·
- │         0  ·       render 1  test.uvw.v              ·          ·
- │         0  ·       render 2  test.uvw.w              ·          ·
- └── scan  1  scan    ·         ·                       (u, v, w)  +u,+v,+w
-·          1  ·       table     uvw@uvw_u_v_w_idx       ·          ·
-·          1  ·       spans     -/1/2/3 /1/2/4-         ·          ·
-·          1  ·       filter    (u, v, w) != (1, 2, 3)  ·          ·
+render     0  render  ·         ·                       (u, v, w)                         +u,+v,+w
+ │         0  ·       render 0  test.uvw.u              ·                                 ·
+ │         0  ·       render 1  test.uvw.v              ·                                 ·
+ │         0  ·       render 2  test.uvw.w              ·                                 ·
+ └── scan  1  scan    ·         ·                       (u, v, w, rowid[hidden,omitted])  rowid!=NULL; weak-key(u,v,w,rowid); +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx       ·                                 ·
+·          1  ·       spans     -/1/2/3 /1/2/4-         ·                                 ·
+·          1  ·       filter    (u, v, w) != (1, 2, 3)  ·                                 ·
 
 query III
 SELECT * FROM uvw WHERE (u, v, w) != (1, 2, 3) ORDER BY u, v, w
@@ -553,13 +553,13 @@ NULL  3     3
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                  (u, v, w)  +u,+v,+w
- │         0  ·       render 0  test.uvw.u         ·          ·
- │         0  ·       render 1  test.uvw.v         ·          ·
- │         0  ·       render 2  test.uvw.w         ·          ·
- └── scan  1  scan    ·         ·                  (u, v, w)  +u,+v,+w
-·          1  ·       table     uvw@uvw_u_v_w_idx  ·          ·
-·          1  ·       spans     /2-                ·          ·
+render     0  render  ·         ·                  (u, v, w)                         +u,+v,+w
+ │         0  ·       render 0  test.uvw.u         ·                                 ·
+ │         0  ·       render 1  test.uvw.v         ·                                 ·
+ │         0  ·       render 2  test.uvw.w         ·                                 ·
+ └── scan  1  scan    ·         ·                  (u, v, w, rowid[hidden,omitted])  rowid!=NULL; weak-key(u,v,w,rowid); +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx  ·                                 ·
+·          1  ·       spans     /2-                ·                                 ·
 
 query III
 SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
@@ -600,13 +600,13 @@ SELECT * FROM uvw WHERE (u, v, w) >= (1, NULL, 3) ORDER BY u, v, w
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
 ----
-render     0  render  ·         ·                  (u, v, w)  +u,+v,+w
- │         0  ·       render 0  test.uvw.u         ·          ·
- │         0  ·       render 1  test.uvw.v         ·          ·
- │         0  ·       render 2  test.uvw.w         ·          ·
- └── scan  1  scan    ·         ·                  (u, v, w)  +u,+v,+w
-·          1  ·       table     uvw@uvw_u_v_w_idx  ·          ·
-·          1  ·       spans     /!NULL-/2          ·          ·
+render     0  render  ·         ·                  (u, v, w)                         +u,+v,+w
+ │         0  ·       render 0  test.uvw.u         ·                                 ·
+ │         0  ·       render 1  test.uvw.v         ·                                 ·
+ │         0  ·       render 2  test.uvw.w         ·                                 ·
+ └── scan  1  scan    ·         ·                  (u, v, w, rowid[hidden,omitted])  rowid!=NULL; weak-key(u,v,w,rowid); +u,+v,+w
+·          1  ·       table     uvw@uvw_u_v_w_idx  ·                                 ·
+·          1  ·       spans     /!NULL-/2          ·                                 ·
 
 query III
 SELECT * FROM uvw WHERE (u, v, w) < (2, NULL, 3) ORDER BY u, v, w
@@ -636,18 +636,18 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b))
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3);
 ----
-render           0  render      ·         ·                      (a, b, c)  ·
- │               0  ·           render 0  test.abc.a             ·          ·
- │               0  ·           render 1  test.abc.b             ·          ·
- │               0  ·           render 2  test.abc.c             ·          ·
- └── index-join  1  index-join  ·         ·                      (a, b, c)  ·
-      ├── scan   2  scan        ·         ·                      (a, b, c)  ·
-      │          2  ·           table     abc@abc_a_b_idx        ·          ·
-      │          2  ·           spans     /1/2-                  ·          ·
-      │          2  ·           filter    (a, b) >= (1, 2)       ·          ·
-      └── scan   2  scan        ·         ·                      (a, b, c)  ·
-·                2  ·           table     abc@primary            ·          ·
-·                2  ·           filter    (a, b, c) > (1, 2, 3)  ·          ·
+render           0  render      ·         ·                      (a, b, c)                          ·
+ │               0  ·           render 0  test.abc.a             ·                                  ·
+ │               0  ·           render 1  test.abc.b             ·                                  ·
+ │               0  ·           render 2  test.abc.c             ·                                  ·
+ └── index-join  1  index-join  ·         ·                      (a, b, c, rowid[hidden,omitted])   rowid!=NULL; weak-key(a,b,rowid)
+      ├── scan   2  scan        ·         ·                      (a, b, c[omitted], rowid[hidden])  rowid!=NULL; weak-key(a,b,rowid)
+      │          2  ·           table     abc@abc_a_b_idx        ·                                  ·
+      │          2  ·           spans     /1/2-                  ·                                  ·
+      │          2  ·           filter    (a, b) >= (1, 2)       ·                                  ·
+      └── scan   2  scan        ·         ·                      (a, b, c, rowid[hidden,omitted])   ·
+·                2  ·           table     abc@primary            ·                                  ·
+·                2  ·           filter    (a, b, c) > (1, 2, 3)  ·                                  ·
 
 statement ok
 DROP TABLE abc;
@@ -656,11 +656,11 @@ CREATE TABLE abc (a INT, b INT, c INT, INDEX(a, b DESC, c))
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * FROM abc WHERE (a, b, c) > (1, 2, 3)
 ----
-render     0  render  ·         ·                      (a, b, c)  ·
- │         0  ·       render 0  test.abc.a             ·          ·
- │         0  ·       render 1  test.abc.b             ·          ·
- │         0  ·       render 2  test.abc.c             ·          ·
- └── scan  1  scan    ·         ·                      (a, b, c)  ·
-·          1  ·       table     abc@abc_a_b_c_idx      ·          ·
-·          1  ·       spans     /1-                    ·          ·
-·          1  ·       filter    (a, b, c) > (1, 2, 3)  ·          ·
+render     0  render  ·         ·                      (a, b, c)                         ·
+ │         0  ·       render 0  test.abc.a             ·                                 ·
+ │         0  ·       render 1  test.abc.b             ·                                 ·
+ │         0  ·       render 2  test.abc.c             ·                                 ·
+ └── scan  1  scan    ·         ·                      (a, b, c, rowid[hidden,omitted])  rowid!=NULL; weak-key(a,b,c,rowid)
+·          1  ·       table     abc@abc_a_b_c_idx      ·                                 ·
+·          1  ·       spans     /1-                    ·                                 ·
+·          1  ·       filter    (a, b, c) > (1, 2, 3)  ·                                 ·

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -346,34 +346,34 @@ update     ·      ·
 query TITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (1, 2)
 ----
-update          0  update  ·      ·            ()  ·
- │              0  ·       table  xyz          ·   ·
- │              0  ·       set    x, y         ·   ·
- └── render     1  render  ·      ·            ()  ·
-      └── scan  2  scan    ·      ·            ()  ·
-·               2  ·       table  xyz@primary  ·   ·
-·               2  ·       spans  ALL          ·   ·
+update          0  update  ·      ·            ()                   ·
+ │              0  ·       table  xyz          ·                    ·
+ │              0  ·       set    x, y         ·                    ·
+ └── render     1  render  ·      ·            (x, y, z, "1", "2")  "1"=CONST; "2"=CONST; x!=NULL; key(x)
+      └── scan  2  scan    ·      ·            (x, y, z)            x!=NULL; key(x)
+·               2  ·       table  xyz@primary  ·                    ·
+·               2  ·       spans  ALL          ·                    ·
 
 query TITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (y, x)
 ----
-update     0  update  ·      ·            ()  ·
- │         0  ·       table  xyz          ·   ·
- │         0  ·       set    x, y         ·   ·
- └── scan  1  scan    ·      ·            ()  ·
-·          1  ·       table  xyz@primary  ·   ·
-·          1  ·       spans  ALL          ·   ·
+update     0  update  ·      ·            ()         ·
+ │         0  ·       table  xyz          ·          ·
+ │         0  ·       set    x, y         ·          ·
+ └── scan  1  scan    ·      ·            (x, y, z)  x!=NULL; key(x)
+·          1  ·       table  xyz@primary  ·          ·
+·          1  ·       spans  ALL          ·          ·
 
 query TITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (2, 2)
 ----
-update          0  update  ·      ·            ()  ·
- │              0  ·       table  xyz          ·   ·
- │              0  ·       set    x, y         ·   ·
- └── render     1  render  ·      ·            ()  ·
-      └── scan  2  scan    ·      ·            ()  ·
-·               2  ·       table  xyz@primary  ·   ·
-·               2  ·       spans  ALL          ·   ·
+update          0  update  ·      ·            ()              ·
+ │              0  ·       table  xyz          ·               ·
+ │              0  ·       set    x, y         ·               ·
+ └── render     1  render  ·      ·            (x, y, z, "2")  "2"=CONST; x!=NULL; key(x)
+      └── scan  2  scan    ·      ·            (x, y, z)       x!=NULL; key(x)
+·               2  ·       table  xyz@primary  ·               ·
+·               2  ·       spans  ALL          ·               ·
 
 statement ok
 CREATE TABLE lots (

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -563,137 +563,137 @@ output row: [8 3.5355339059327376220]
 query TITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER w FROM kv WINDOW w as (PARTITION BY v) ORDER BY variance(d) OVER w, k
 ----
-sort                 0  sort    ·         ·                                         (k int, stddev decimal)  ·
- │                   0  ·       order     +variance,+k                              ·                        ·
- └── window          1  window  ·         ·                                         (k int, stddev decimal)  ·
-      │              1  ·       window 0  (stddev((d)[decimal]) OVER w)[decimal]    ·                        ·
-      │              1  ·       window 1  (variance((d)[decimal]) OVER w)[decimal]  ·                        ·
-      │              1  ·       render 1  (stddev((d)[decimal]) OVER w)[decimal]    ·                        ·
-      │              1  ·       render 2  (variance((d)[decimal]) OVER w)[decimal]  ·                        ·
-      └── render     2  render  ·         ·                                         (k int, stddev decimal)  ·
-           │         2  ·       render 0  (k)[int]                                  ·                        ·
-           │         2  ·       render 1  (d)[decimal]                              ·                        ·
-           │         2  ·       render 2  (d)[decimal]                              ·                        ·
-           │         2  ·       render 3  (v)[int]                                  ·                        ·
-           └── scan  3  scan    ·         ·                                         (k int, stddev decimal)  ·
-·                    3  ·       table     kv@primary                                ·                        ·
-·                    3  ·       spans     ALL                                       ·                        ·
+sort                 0  sort    ·         ·                                         (k int, stddev decimal)                                                                          ·
+ │                   0  ·       order     +variance,+k                              ·                                                                                                ·
+ └── window          1  window  ·         ·                                         (k int, stddev decimal, variance decimal)                                                        ·
+      │              1  ·       window 0  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
+      │              1  ·       window 1  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
+      │              1  ·       render 1  (stddev((d)[decimal]) OVER w)[decimal]    ·                                                                                                ·
+      │              1  ·       render 2  (variance((d)[decimal]) OVER w)[decimal]  ·                                                                                                ·
+      └── render     2  render  ·         ·                                         (k int, d decimal, d decimal, v int)                                                             d=d; k!=NULL; key(k)
+           │         2  ·       render 0  (k)[int]                                  ·                                                                                                ·
+           │         2  ·       render 1  (d)[decimal]                              ·                                                                                                ·
+           │         2  ·       render 2  (d)[decimal]                              ·                                                                                                ·
+           │         2  ·       render 3  (v)[int]                                  ·                                                                                                ·
+           └── scan  3  scan    ·         ·                                         (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+·                    3  ·       table     kv@primary                                ·                                                                                                ·
+·                    3  ·       spans     ALL                                       ·                                                                                                ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-sort                 0  sort    ·         ·                                                                            (k int, stddev decimal)  ·
- │                   0  ·       order     +variance,+k                                                                 ·                        ·
- └── window          1  window  ·         ·                                                                            (k int, stddev decimal)  ·
-      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                        ·
-      │              1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                        ·
-      │              1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                        ·
-      │              1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                        ·
-      └── render     2  render  ·         ·                                                                            (k int, stddev decimal)  ·
-           │         2  ·       render 0  (k)[int]                                                                     ·                        ·
-           │         2  ·       render 1  (d)[decimal]                                                                 ·                        ·
-           │         2  ·       render 2  (d)[decimal]                                                                 ·                        ·
-           │         2  ·       render 3  (v)[int]                                                                     ·                        ·
-           │         2  ·       render 4  ('a')[string]                                                                ·                        ·
-           │         2  ·       render 5  (100)[int]                                                                   ·                        ·
-           └── scan  3  scan    ·         ·                                                                            (k int, stddev decimal)  ·
-·                    3  ·       table     kv@primary                                                                   ·                        ·
-·                    3  ·       spans     ALL                                                                          ·                        ·
+sort                 0  sort    ·         ·                                                                            (k int, stddev decimal)                                                                          ·
+ │                   0  ·       order     +variance,+k                                                                 ·                                                                                                ·
+ └── window          1  window  ·         ·                                                                            (k int, stddev decimal, variance decimal)                                                        ·
+      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+      │              1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                ·
+      │              1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+      │              1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]   ·                                                                                                ·
+      └── render     2  render  ·         ·                                                                            (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                    d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
+           │         2  ·       render 0  (k)[int]                                                                     ·                                                                                                ·
+           │         2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                ·
+           │         2  ·       render 2  (d)[decimal]                                                                 ·                                                                                                ·
+           │         2  ·       render 3  (v)[int]                                                                     ·                                                                                                ·
+           │         2  ·       render 4  ('a')[string]                                                                ·                                                                                                ·
+           │         2  ·       render 5  (100)[int]                                                                   ·                                                                                                ·
+           └── scan  3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+·                    3  ·       table     kv@primary                                                                   ·                                                                                                ·
+·                    3  ·       spans     ALL                                                                          ·                                                                                                ·
 
 query TITTTTT
 EXPLAIN (TYPES,NONORMALIZE) SELECT k, stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY k
 ----
-sort                 0  sort    ·         ·                                                                            (k int, stddev decimal)  +k
- │                   0  ·       order     +k                                                                           ·                        ·
- └── window          1  window  ·         ·                                                                            (k int, stddev decimal)  +k
-      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                        ·
-      │              1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                        ·
-      └── render     2  render  ·         ·                                                                            (k int, stddev decimal)  +k
-           │         2  ·       render 0  (k)[int]                                                                     ·                        ·
-           │         2  ·       render 1  (d)[decimal]                                                                 ·                        ·
-           │         2  ·       render 2  (v)[int]                                                                     ·                        ·
-           │         2  ·       render 3  ('a')[string]                                                                ·                        ·
-           └── scan  3  scan    ·         ·                                                                            (k int, stddev decimal)  +k
-·                    3  ·       table     kv@primary                                                                   ·                        ·
-·                    3  ·       spans     ALL                                                                          ·                        ·
+sort                 0  sort    ·         ·                                                                            (k int, stddev decimal)                                                                          +k
+ │                   0  ·       order     +k                                                                           ·                                                                                                ·
+ └── window          1  window  ·         ·                                                                            (k int, stddev decimal)                                                                          ·
+      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+      │              1  ·       render 1  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+      └── render     2  render  ·         ·                                                                            (k int, d decimal, v int, "'a'" string)                                                          "'a'"=CONST; k!=NULL; key(k)
+           │         2  ·       render 0  (k)[int]                                                                     ·                                                                                                ·
+           │         2  ·       render 1  (d)[decimal]                                                                 ·                                                                                                ·
+           │         2  ·       render 2  (v)[int]                                                                     ·                                                                                                ·
+           │         2  ·       render 3  ('a')[string]                                                                ·                                                                                                ·
+           └── scan  3  scan    ·         ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+·                    3  ·       table     kv@primary                                                                   ·                                                                                                ·
+·                    3  ·       spans     ALL                                                                          ·                                                                                                ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT k, k + stddev(d) OVER (PARTITION BY v, 'a') FROM kv ORDER BY variance(d) OVER (PARTITION BY v, 100), k
 ----
-sort                 0  sort    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
- │                   0  ·       order     +variance,+k                                                                                       ·                                                            ·
- └── window          1  window  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
-      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                        ·                                                            ·
-      │              1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                            ·
-      │              1  ·       render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                            ·
-      │              1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                            ·
-      └── render     2  render  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
-           │         2  ·       render 0  (k)[int]                                                                                           ·                                                            ·
-           │         2  ·       render 1  (d)[decimal]                                                                                       ·                                                            ·
-           │         2  ·       render 2  (d)[decimal]                                                                                       ·                                                            ·
-           │         2  ·       render 3  (v)[int]                                                                                           ·                                                            ·
-           │         2  ·       render 4  ('a')[string]                                                                                      ·                                                            ·
-           │         2  ·       render 5  (100)[int]                                                                                         ·                                                            ·
-           └── scan  3  scan    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
-·                    3  ·       table     kv@primary                                                                                         ·                                                            ·
-·                    3  ·       spans     ALL                                                                                                ·                                                            ·
+sort                 0  sort    ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                                      ·
+ │                   0  ·       order     +variance,+k                                                                                       ·                                                                                                ·
+ └── window          1  window  ·         ·                                                                                                  (k int, "k + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)                    ·
+      │              1  ·       window 0  (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                        ·                                                                                                ·
+      │              1  ·       window 1  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                ·
+      │              1  ·       render 1  ((k)[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                ·
+      │              1  ·       render 2  (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                         ·                                                                                                ·
+      └── render     2  render  ·         ·                                                                                                  (k int, d decimal, d decimal, v int, "'a'" string, "100" int)                                    d=d; "'a'"=CONST; "100"=CONST; k!=NULL; key(k)
+           │         2  ·       render 0  (k)[int]                                                                                           ·                                                                                                ·
+           │         2  ·       render 1  (d)[decimal]                                                                                       ·                                                                                                ·
+           │         2  ·       render 2  (d)[decimal]                                                                                       ·                                                                                                ·
+           │         2  ·       render 3  (v)[int]                                                                                           ·                                                                                                ·
+           │         2  ·       render 4  ('a')[string]                                                                                      ·                                                                                                ·
+           │         2  ·       render 5  (100)[int]                                                                                         ·                                                                                                ·
+           └── scan  3  scan    ·         ·                                                                                                  (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+·                    3  ·       table     kv@primary                                                                                         ·                                                                                                ·
+·                    3  ·       spans     ALL                                                                                                ·                                                                                                ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT max(k), max(k) + stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY variance(d) OVER (PARTITION BY v, 100)
 ----
-sort                           0  sort    ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
- │                             0  ·       order        +variance                                                                                                      ·                                                                   ·
- └── window                    1  window  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
-      │                        1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                                    ·                                                                   ·
-      │                        1  ·       window 1     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                   ·
-      │                        1  ·       render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                   ·
-      │                        1  ·       render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                   ·
-      └── render               2  render  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
-           │                   2  ·       render 0     (max)[int]                                                                                                     ·                                                                   ·
-           │                   2  ·       render 1     (d)[decimal]                                                                                                   ·                                                                   ·
-           │                   2  ·       render 2     (d)[decimal]                                                                                                   ·                                                                   ·
-           │                   2  ·       render 3     (v)[int]                                                                                                       ·                                                                   ·
-           │                   2  ·       render 4     ('a')[string]                                                                                                  ·                                                                   ·
-           │                   2  ·       render 5     (100)[int]                                                                                                     ·                                                                   ·
-           └── group           3  group   ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
-                │              3  ·       aggregate 0  (max((k)[int]))[int]                                                                                           ·                                                                   ·
-                │              3  ·       aggregate 1  (d)[decimal]                                                                                                   ·                                                                   ·
-                │              3  ·       aggregate 2  (d)[decimal]                                                                                                   ·                                                                   ·
-                │              3  ·       aggregate 3  (v)[int]                                                                                                       ·                                                                   ·
-                │              3  ·       group by     @1-@2                                                                                                          ·                                                                   ·
-                └── render     4  render  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
-                     │         4  ·       render 0     (d)[decimal]                                                                                                   ·                                                                   ·
-                     │         4  ·       render 1     (v)[int]                                                                                                       ·                                                                   ·
-                     │         4  ·       render 2     (k)[int]                                                                                                       ·                                                                   ·
-                     └── scan  5  scan    ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)  ·
-·                              5  ·       table        kv@primary                                                                                                     ·                                                                   ·
-·                              5  ·       spans        ALL                                                                                                            ·                                                                   ·
+sort                           0  sort    ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal)                               ·
+ │                             0  ·       order        +variance                                                                                                      ·                                                                                                ·
+ └── window                    1  window  ·            ·                                                                                                              (max int, "max(k) + stddev(d) OVER (PARTITION BY v, 'a')" decimal, variance decimal)             ·
+      │                        1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]                                    ·                                                                                                ·
+      │                        1  ·       window 1     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                ·
+      │                        1  ·       render 1     ((max((k)[int]))[int] + (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal])[decimal]  ·                                                                                                ·
+      │                        1  ·       render 2     (variance((d)[decimal]) OVER (PARTITION BY (v)[int], (100)[int]))[decimal]                                     ·                                                                                                ·
+      └── render               2  render  ·            ·                                                                                                              (max int, d decimal, d decimal, v int, "'a'" string, "100" int)                                  "'a'"=CONST; "100"=CONST
+           │                   2  ·       render 0     (max)[int]                                                                                                     ·                                                                                                ·
+           │                   2  ·       render 1     (d)[decimal]                                                                                                   ·                                                                                                ·
+           │                   2  ·       render 2     (d)[decimal]                                                                                                   ·                                                                                                ·
+           │                   2  ·       render 3     (v)[int]                                                                                                       ·                                                                                                ·
+           │                   2  ·       render 4     ('a')[string]                                                                                                  ·                                                                                                ·
+           │                   2  ·       render 5     (100)[int]                                                                                                     ·                                                                                                ·
+           └── group           3  group   ·            ·                                                                                                              (max int, d decimal, d decimal, v int)                                                           ·
+                │              3  ·       aggregate 0  (max((k)[int]))[int]                                                                                           ·                                                                                                ·
+                │              3  ·       aggregate 1  (d)[decimal]                                                                                                   ·                                                                                                ·
+                │              3  ·       aggregate 2  (d)[decimal]                                                                                                   ·                                                                                                ·
+                │              3  ·       aggregate 3  (v)[int]                                                                                                       ·                                                                                                ·
+                │              3  ·       group by     @1-@2                                                                                                          ·                                                                                                ·
+                └── render     4  render  ·            ·                                                                                                              (d decimal, v int, k int)                                                                        k!=NULL; key(k)
+                     │         4  ·       render 0     (d)[decimal]                                                                                                   ·                                                                                                ·
+                     │         4  ·       render 1     (v)[int]                                                                                                       ·                                                                                                ·
+                     │         4  ·       render 2     (k)[int]                                                                                                       ·                                                                                                ·
+                     └── scan  5  scan    ·            ·                                                                                                              (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+·                              5  ·       table        kv@primary                                                                                                     ·                                                                                                ·
+·                              5  ·       spans        ALL                                                                                                            ·                                                                                                ·
 
 query TITTTTT
 EXPLAIN (TYPES) SELECT MAX(k), stddev(d) OVER (PARTITION BY v, 'a') FROM kv GROUP BY d, v ORDER BY 1
 ----
-sort                           0  sort    ·            ·                                                                            (max int, stddev decimal)  +max
- │                             0  ·       order        +max                                                                         ·                          ·
- └── window                    1  window  ·            ·                                                                            (max int, stddev decimal)  +max
-      │                        1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                          ·
-      │                        1  ·       render 1     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                          ·
-      └── render               2  render  ·            ·                                                                            (max int, stddev decimal)  +max
-           │                   2  ·       render 0     (max)[int]                                                                   ·                          ·
-           │                   2  ·       render 1     (d)[decimal]                                                                 ·                          ·
-           │                   2  ·       render 2     (v)[int]                                                                     ·                          ·
-           │                   2  ·       render 3     ('a')[string]                                                                ·                          ·
-           └── group           3  group   ·            ·                                                                            (max int, stddev decimal)  +max
-                │              3  ·       aggregate 0  (max((k)[int]))[int]                                                         ·                          ·
-                │              3  ·       aggregate 1  (d)[decimal]                                                                 ·                          ·
-                │              3  ·       aggregate 2  (v)[int]                                                                     ·                          ·
-                │              3  ·       group by     @1-@2                                                                        ·                          ·
-                └── render     4  render  ·            ·                                                                            (max int, stddev decimal)  +max
-                     │         4  ·       render 0     (d)[decimal]                                                                 ·                          ·
-                     │         4  ·       render 1     (v)[int]                                                                     ·                          ·
-                     │         4  ·       render 2     (k)[int]                                                                     ·                          ·
-                     └── scan  5  scan    ·            ·                                                                            (max int, stddev decimal)  +max
-·                              5  ·       table        kv@primary                                                                   ·                          ·
-·                              5  ·       spans        ALL                                                                          ·                          ·
+sort                           0  sort    ·            ·                                                                            (max int, stddev decimal)                                                                        +max
+ │                             0  ·       order        +max                                                                         ·                                                                                                ·
+ └── window                    1  window  ·            ·                                                                            (max int, stddev decimal)                                                                        ·
+      │                        1  ·       window 0     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+      │                        1  ·       render 1     (stddev((d)[decimal]) OVER (PARTITION BY (v)[int], ('a')[string]))[decimal]  ·                                                                                                ·
+      └── render               2  render  ·            ·                                                                            (max int, d decimal, v int, "'a'" string)                                                        "'a'"=CONST
+           │                   2  ·       render 0     (max)[int]                                                                   ·                                                                                                ·
+           │                   2  ·       render 1     (d)[decimal]                                                                 ·                                                                                                ·
+           │                   2  ·       render 2     (v)[int]                                                                     ·                                                                                                ·
+           │                   2  ·       render 3     ('a')[string]                                                                ·                                                                                                ·
+           └── group           3  group   ·            ·                                                                            (max int, d decimal, v int)                                                                      ·
+                │              3  ·       aggregate 0  (max((k)[int]))[int]                                                         ·                                                                                                ·
+                │              3  ·       aggregate 1  (d)[decimal]                                                                 ·                                                                                                ·
+                │              3  ·       aggregate 2  (v)[int]                                                                     ·                                                                                                ·
+                │              3  ·       group by     @1-@2                                                                        ·                                                                                                ·
+                └── render     4  render  ·            ·                                                                            (d decimal, v int, k int)                                                                        k!=NULL; key(k)
+                     │         4  ·       render 0     (d)[decimal]                                                                 ·                                                                                                ·
+                     │         4  ·       render 1     (v)[int]                                                                     ·                                                                                                ·
+                     │         4  ·       render 2     (k)[int]                                                                     ·                                                                                                ·
+                     └── scan  5  scan    ·            ·                                                                            (k int, v int, w[omitted] int, f[omitted] float, d decimal, s[omitted] string, b[omitted] bool)  k!=NULL; key(k)
+·                              5  ·       table        kv@primary                                                                   ·                                                                                                ·
+·                              5  ·       spans        ALL                                                                          ·                                                                                                ·
 
 statement OK
 INSERT INTO kv VALUES


### PR DESCRIPTION
We were printing the columns and properties for the root instead of
each node. This is a regression caused by the change to display the
tree.

Release note (bug fix): fixed incorrect columns and properties in
EXPLAIN (VERBOSE) output.

----
Kind of alarming that I (and the reviewers) didn't notice this egregious bug in #20697.