### PR TITLE
ui: a number of small debug page fixes

### DIFF
--- a/pkg/ui/src/redux/apiReducers.ts
+++ b/pkg/ui/src/redux/apiReducers.ts
@@ -154,7 +154,7 @@ const problemRangesReducerObj = new KeyedCachedDataReducer(
 export const refreshProblemRanges = problemRangesReducerObj.refresh;
 
 export const certificatesRequestKey = (req: api.CertificatesRequestMessage): string =>
-  _.isEmpty(req.node_id) ? "0" : req.node_id;
+  _.isEmpty(req.node_id) ? "none" : req.node_id;
 
 const certificatesReducerObj = new KeyedCachedDataReducer(
   api.getCertificates,
@@ -165,7 +165,7 @@ const certificatesReducerObj = new KeyedCachedDataReducer(
 export const refreshCertificates = certificatesReducerObj.refresh;
 
 export const rangeRequestKey = (req: api.RangeRequestMessage): string =>
-  _.isNil(req.range_id) ? "0" : req.range_id.toString();
+  _.isNil(req.range_id) ? "none" : req.range_id.toString();
 
 const rangeReducerObj = new KeyedCachedDataReducer(
   api.getRange,
@@ -177,7 +177,7 @@ const rangeReducerObj = new KeyedCachedDataReducer(
 export const refreshRange = rangeReducerObj.refresh;
 
 export const allocatorRangeRequestKey = (req: api.AllocatorRangeRequestMessage): string =>
-  _.isNil(req.range_id) ? "0" : req.range_id.toString();
+  _.isNil(req.range_id) ? "none" : req.range_id.toString();
 
 const allocatorRangeReducerObj = new KeyedCachedDataReducer(
   api.getAllocatorRange,
@@ -189,7 +189,7 @@ const allocatorRangeReducerObj = new KeyedCachedDataReducer(
 export const refreshAllocatorRange = allocatorRangeReducerObj.refresh;
 
 export const rangeLogRequestKey = (req: api.RangeLogRequestMessage): string =>
-  _.isNil(req.range_id) ? "0" : req.range_id.toString();
+  _.isNil(req.range_id) ? "none" : req.range_id.toString();
 
 const rangeLogReducerObj = new KeyedCachedDataReducer(
   api.getRangeLog,
@@ -201,7 +201,7 @@ const rangeLogReducerObj = new KeyedCachedDataReducer(
 export const refreshRangeLog = rangeLogReducerObj.refresh;
 
 export const commandQueueRequestKey = (req: api.CommandQueueRequestMessage): string =>
-  _.isNil(req.range_id) ? "0" : req.range_id.toString();
+  _.isNil(req.range_id) ? "none" : req.range_id.toString();
 
 const commandQueueReducerObj = new KeyedCachedDataReducer(
   api.getCommandQueue,

--- a/pkg/ui/src/redux/apiReducers.ts
+++ b/pkg/ui/src/redux/apiReducers.ts
@@ -122,14 +122,8 @@ export const livenessReducerObj = new CachedDataReducer(
 );
 export const refreshLiveness = livenessReducerObj.refresh;
 
-export const jobsKey = (
-  status: string,
-  type: protos.cockroach.sql.jobs.Type,
-  limit: number,
-) =>
-  `${encodeURIComponent(status)}/${encodeURIComponent(
-    type.toString(),
-  )}/${encodeURIComponent(limit.toString())}`;
+export const jobsKey = (status: string, type: protos.cockroach.sql.jobs.Type, limit: number) =>
+  `${encodeURIComponent(status)}/${encodeURIComponent(type.toString())}/${encodeURIComponent(limit.toString())}`;
 
 const jobsRequestKey = (req: api.JobsRequestMessage): string =>
   jobsKey(req.status, req.type, req.limit);
@@ -142,8 +136,7 @@ const jobsReducerObj = new KeyedCachedDataReducer(
 );
 export const refreshJobs = jobsReducerObj.refresh;
 
-export const queryToID = (req: api.QueryPlanRequestMessage): string =>
-  req.query;
+export const queryToID = (req: api.QueryPlanRequestMessage): string => req.query;
 
 const queryPlanReducerObj = new CachedDataReducer(api.getQueryPlan, "queryPlan");
 export const refreshQueryPlan = queryPlanReducerObj.refresh;

--- a/pkg/ui/src/views/reports/containers/certificates/index.tsx
+++ b/pkg/ui/src/views/reports/containers/certificates/index.tsx
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { RouterState } from "react-router";
 
 import * as protos from "src/js/protos";
-import { refreshCertificates } from "src/redux/apiReducers";
+import { certificatesRequestKey, refreshCertificates } from "src/redux/apiReducers";
 import { AdminUIState } from "src/redux/state";
 import { nodeIDAttr } from "src/util/constants";
 import { LongToMoment } from "src/util/convert";
@@ -26,14 +26,18 @@ const emptyRow = (
   </tr>
 );
 
+function certificatesRequestFromProps(props: CertificatesProps) {
+  return new protos.cockroach.server.serverpb.CertificatesRequest({
+    node_id: props.params[nodeIDAttr],
+  });
+}
+
 /**
  * Renders the Certificate Report page.
  */
 class Certificates extends React.Component<CertificatesProps, {}> {
   refresh(props = this.props) {
-    props.refreshCertificates(new protos.cockroach.server.serverpb.CertificatesRequest({
-      node_id: props.params[nodeIDAttr],
-    }));
+    props.refreshCertificates(certificatesRequestFromProps(props));
   }
 
   componentWillMount() {
@@ -184,10 +188,10 @@ class Certificates extends React.Component<CertificatesProps, {}> {
 }
 
 function mapStateToProps(state: AdminUIState, props: CertificatesProps) {
-  const nodeID = props.params[nodeIDAttr];
+  const nodeIDKey = certificatesRequestKey(certificatesRequestFromProps(props));
   return {
-    certificates: state.cachedData.certificates[nodeID] && state.cachedData.certificates[nodeID].data,
-    lastError: state.cachedData.certificates[nodeID] && state.cachedData.certificates[nodeID].lastError,
+    certificates: state.cachedData.certificates[nodeIDKey] && state.cachedData.certificates[nodeIDKey].data,
+    lastError: state.cachedData.certificates[nodeIDKey] && state.cachedData.certificates[nodeIDKey].lastError,
   };
 }
 

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -55,7 +55,7 @@ function ProblemRangeList(props: {
   );
 }
 
-function problemRangeRequest(props: ProblemRangesProps) {
+function problemRangeRequestFromProps(props: ProblemRangesProps) {
   return new protos.cockroach.server.serverpb.ProblemRangesRequest({
     node_id: props.params[nodeIDAttr],
   });
@@ -70,7 +70,7 @@ function problemRangeRequest(props: ProblemRangesProps) {
  */
 class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
   refresh(props = this.props) {
-    props.refreshProblemRanges(problemRangeRequest(props));
+    props.refreshProblemRanges(problemRangeRequestFromProps(props));
   }
 
   componentWillMount() {
@@ -164,7 +164,7 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
 
 export default connect(
   (state: AdminUIState, props: ProblemRangesProps) => {
-    const nodeIDKey = problemRangesRequestKey(problemRangeRequest(props));
+    const nodeIDKey = problemRangesRequestKey(problemRangeRequestFromProps(props));
     return {
       problemRanges: state.cachedData.problemRanges[nodeIDKey] && state.cachedData.problemRanges[nodeIDKey].data,
     };

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -16,6 +16,7 @@ type NodeProblems$Properties = protos.cockroach.server.serverpb.ProblemRangesRes
 
 interface ProblemRangesOwnProps {
   problemRanges: ProblemRangesResponse;
+  lastError: Error;
   refreshProblemRanges: typeof refreshProblemRanges;
 }
 
@@ -86,6 +87,20 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
 
   render() {
     const { problemRanges } = this.props;
+    if (!_.isNil(this.props.lastError)) {
+      let errorText: string;
+      if (_.isEmpty(this.props.params[nodeIDAttr])) {
+        errorText = `Error loading Problem Ranges on the Cluster`;
+      } else {
+        errorText = `Error loading Problem Range for node n${this.props.params[nodeIDAttr]}`;
+      }
+      return (
+        <div className="section">
+          <h1>Problem Ranges Report</h1>
+          <h2>{errorText}</h2>
+        </div>
+      );
+    }
     if (!problemRanges) {
       return (
         <div className="section">
@@ -167,6 +182,7 @@ export default connect(
     const nodeIDKey = problemRangesRequestKey(problemRangeRequestFromProps(props));
     return {
       problemRanges: state.cachedData.problemRanges[nodeIDKey] && state.cachedData.problemRanges[nodeIDKey].data,
+      lastError: state.cachedData.problemRanges[nodeIDKey] && state.cachedData.problemRanges[nodeIDKey].lastError,
     };
   },
   {

--- a/pkg/ui/src/views/reports/containers/range/allocator.tsx
+++ b/pkg/ui/src/views/reports/containers/range/allocator.tsx
@@ -41,7 +41,7 @@ export default class AllocatorOutput extends React.Component<AllocatorOutputProp
 
     return (
       <div>
-        <h2>Simulated Allocator Output {fromNodeID}</h2>
+        <h2>Simulated Allocator Output{fromNodeID}</h2>
         <Loading
           loading={!allocator || allocator.inFlight}
           className="loading-image loading-image__spinner-left"

--- a/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/connectionsTable.tsx
@@ -14,16 +14,13 @@ interface ConnectionsTableProps {
 
 export default function ConnectionsTable(props: ConnectionsTableProps) {
   const { range } = props;
-  if (!range || _.isNil(range.data)) {
-    return null;
-  }
-  const ids = _.chain(_.keys(range.data.responses_by_node_id))
-    .map(id => parseInt(id, 10))
-    .sortBy(id => id)
-    .value();
-
+  let ids: number[];
   let viaNodeID = "";
-  if (range && !_.isEmpty(range.data)) {
+  if (range && !range.inFlight && !_.isNil(range.data)) {
+    ids = _.chain(_.keys(range.data.responses_by_node_id))
+      .map(id => parseInt(id, 10))
+      .sortBy(id => id)
+      .value();
     viaNodeID = ` (via n${range.data.node_id.toString()})`;
   }
 

--- a/pkg/ui/src/views/reports/containers/range/logTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/logTable.tsx
@@ -66,10 +66,7 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
   ) {
     return (
       <ul className="log-entries-list">
-        {this.renderLogInfoDescriptor(
-          "Updated Range Descriptor",
-          info.updated_desc,
-        )}
+        {this.renderLogInfoDescriptor("Updated Range Descriptor", info.updated_desc)}
         {this.renderLogInfoDescriptor("New Range Descriptor", info.new_desc)}
         {this.renderLogInfoDescriptor("Added Replica", info.added_replica)}
         {this.renderLogInfoDescriptor("Removed Replica", info.removed_replica)}
@@ -110,24 +107,12 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
           <table className="log-table">
             <tbody>
               <tr className="log-table__row log-table__row--header">
-                <th className="log-table__cell log-table__cell--header">
-                  Timestamp
-                </th>
-                <th className="log-table__cell log-table__cell--header">
-                  Store
-                </th>
-                <th className="log-table__cell log-table__cell--header">
-                  Event Type
-                </th>
-                <th className="log-table__cell log-table__cell--header">
-                  Range
-                </th>
-                <th className="log-table__cell log-table__cell--header">
-                  Other Range
-                </th>
-                <th className="log-table__cell log-table__cell--header">
-                  Info
-                </th>
+                <th className="log-table__cell log-table__cell--header">Timestamp</th>
+                <th className="log-table__cell log-table__cell--header">Store</th>
+                <th className="log-table__cell log-table__cell--header">Event Type</th>
+                <th className="log-table__cell log-table__cell--header">Range</th>
+                <th className="log-table__cell log-table__cell--header">Other Range</th>
+                <th className="log-table__cell log-table__cell--header">Info</th>
               </tr>
               {_.map(events, (event, key) => (
                 <tr key={key} className="log-table__row">
@@ -135,18 +120,10 @@ export default class LogTable extends React.Component<LogTableProps, {}> {
                     {Print.Timestamp(event.event.timestamp)}
                   </td>
                   <td className="log-table__cell">s{event.event.store_id}</td>
-                  <td className="log-table__cell">
-                    {printLogEventType(event.event.event_type)}
-                  </td>
-                  <td className="log-table__cell">
-                    {this.renderRangeID(event.event.range_id)}
-                  </td>
-                  <td className="log-table__cell">
-                    {this.renderRangeID(event.event.other_range_id)}
-                  </td>
-                  <td className="log-table__cell">
-                    {this.renderLogInfo(event.pretty_info)}
-                  </td>
+                  <td className="log-table__cell">{printLogEventType(event.event.event_type)}</td>
+                  <td className="log-table__cell">{this.renderRangeID(event.event.range_id)}</td>
+                  <td className="log-table__cell">{this.renderRangeID(event.event.other_range_id)}</td>
+                  <td className="log-table__cell">{this.renderLogInfo(event.pretty_info)}</td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
This is a follow up to the post merge comments left on #20828 and some fixes
that clean up how the keyed caches are used.

The biggest change is that is it a bad idea to create keys in two different
places. This fixes that for all debug page KeyedCachedDataReducers.

Also, in the command queue page, this adds a loading spinner and an error page.

Also this addresses some of the more egregious formatting changes from the PR
that were caused by prettier.

It would be nice to use prettier, but the defaults are clearly just wrong for
us.

Release note (ui): The command queue debug page now displays errors correctly.

Fixes #21238.