### PR TITLE
retry: allow immediate retry from NextCh when isReset is true

### DIFF
--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -127,11 +127,20 @@ func (r *Retry) Next() bool {
 	}
 }
 
+// closedC is returned from Retry.NextCh whenever a retry
+// can begin immediately.
+var closedC = func() chan time.Time {
+	c := make(chan time.Time)
+	close(c)
+	return c
+}()
+
 // NextCh returns a channel which will receive when the next retry
 // interval has expired.
 func (r *Retry) NextCh() <-chan time.Time {
 	if r.isReset {
 		r.isReset = false
+		return closedC
 	}
 	r.currentAttempt++
 	if r.opts.MaxRetries > 0 && r.currentAttempt > r.opts.MaxRetries {

--- a/pkg/util/retry/retry_test.go
+++ b/pkg/util/retry/retry_test.go
@@ -108,18 +108,37 @@ func TestRetryStop(t *testing.T) {
 func TestRetryNextCh(t *testing.T) {
 	var attempts int
 
-	for r := Start(Options{MaxRetries: 1}); attempts < 2; attempts++ {
+	opts := Options{
+		InitialBackoff: time.Millisecond,
+		Multiplier:     2,
+		MaxRetries:     1,
+	}
+	for r := Start(opts); attempts < 3; attempts++ {
+		c := r.NextCh()
 		if r.currentAttempt != attempts {
 			t.Errorf("expected attempt=%d; got %d", attempts, r.currentAttempt)
 		}
-		if attempts == 0 {
-			if r.NextCh() == nil {
+		switch attempts {
+		case 0:
+			if c == nil {
 				t.Errorf("expected non-nil NextCh() on first attempt")
 			}
-		} else if attempts == 1 {
-			if r.NextCh() != nil {
-				t.Errorf("expected nil NextCh() on second attempt")
+			if _, ok := <-c; ok {
+				t.Errorf("expected closed (immediate) NextCh() on first attempt")
 			}
+		case 1:
+			if c == nil {
+				t.Errorf("expected non-nil NextCh() on second attempt")
+			}
+			if _, ok := <-c; !ok {
+				t.Errorf("expected open (delayed) NextCh() on first attempt")
+			}
+		case 2:
+			if c != nil {
+				t.Errorf("expected nil NextCh() on third attempt")
+			}
+		default:
+			t.Fatalf("unexpected attempt %d", attempts)
 		}
 	}
 }


### PR DESCRIPTION
Found in #21483.

`Retry.Next` returns immediately when `r.isReset` so that retry loops
begin without any initial delay. However, before this change,
`Retry.NextCh` returned a channel that did not allow an immediate
attempt even with `r.isReset`. This had the effect that uses of
`NextCh` were an iteration "ahead" of uses of `Retry.Next`. We now
return a closed channel so that it mirrors `Retry.Next's` behavior.


Release note: None