### PR TITLE
storage/engine: delete a bunch of the Go MVCC read code

### DIFF
--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -1415,6 +1415,9 @@ func TestMVCCScanInconsistent(t *testing.T) {
 		{Span: roachpb.Span{Key: testKey3}, Txn: txn2.TxnMeta},
 	}
 	kvs, _, intents, err := MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, hlc.Timestamp{WallTime: 7}, false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !reflect.DeepEqual(intents, expIntents) {
 		t.Fatalf("expected %v, but found %v", expIntents, intents)
 	}

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -1008,7 +1008,7 @@ func TestMVCCScanWriteIntentError(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(intents, scan.expIntents) {
-			t.Errorf("%s(%d): expected intents:\n%+v;\n got\n%+v", cStr, i, scan.expIntents, intents)
+			t.Fatalf("%s(%d): expected intents:\n%+v;\n got\n%+v", cStr, i, scan.expIntents, intents)
 		}
 
 		if !reflect.DeepEqual(kvs, scan.expValues) {
@@ -1046,7 +1046,7 @@ func TestMVCCGetInconsistent(t *testing.T) {
 			}
 		} else {
 			if len(intents) == 0 || !intents[0].Key.Equal(testKey1) {
-				t.Fatal(err)
+				t.Fatalf("expected %v, but got %v", testKey1, intents)
 			}
 		}
 		if !bytes.Equal(val.RawBytes, value1.RawBytes) {
@@ -1416,7 +1416,7 @@ func TestMVCCScanInconsistent(t *testing.T) {
 	}
 	kvs, _, intents, err := MVCCScan(context.Background(), engine, testKey1, testKey4.Next(), math.MaxInt64, hlc.Timestamp{WallTime: 7}, false, nil)
 	if !reflect.DeepEqual(intents, expIntents) {
-		t.Fatal(err)
+		t.Fatalf("expected %v, but found %v", expIntents, intents)
 	}
 
 	makeTimestampedValue := func(v roachpb.Value, ts hlc.Timestamp) roachpb.Value {


### PR DESCRIPTION
Delete a bunch of the Go MVCC code with the caveat that
`mvccGetInternal` remains to avoid a regression in the performance of
`MVCCConditionalPut`. This is very unfortunate and will need to be fixed
ASAP as the duplicated code is likely to diverge.

Reimplement MVCCIterate in terms of MVCCScan. This is prep work for
getting rid of large chunks of the Go MVCC read code.

Release note: none