### PR TITLE
sql: allow SELECTing from a sequence

### DIFF
--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -252,6 +252,7 @@ func doExpandPlan(
 	case *unaryNode:
 	case *hookFnNode:
 	case *valueGenerator:
+	case *sequenceSelectNode:
 	case *setVarNode:
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:
@@ -639,6 +640,7 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 	case *unaryNode:
 	case *hookFnNode:
 	case *valueGenerator:
+	case *sequenceSelectNode:
 	case *setVarNode:
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -133,9 +133,41 @@ TRUNCATE foo
 statement error pgcode 42809 "foo" is not a table
 DROP TABLE foo
 
-# TODO(vilterp): match PG (returns a single row with the sequence settings and value)
-statement error pgcode 42809 pq: cannot SELECT from a sequence
-SELECT * FROM foo
+# You can select from a sequence to get its value.
+
+statement ok
+CREATE SEQUENCE select_test
+
+query IIB colnames
+SELECT * FROM select_test
+----
+last_value log_cnt is_called
+0          0       true
+
+# Test selecting just last_value.
+query I
+SELECT last_value FROM select_test
+----
+0
+
+statement ok
+SELECT nextval('select_test')
+
+query I
+SELECT last_value FROM select_test
+----
+1
+
+# Since this is a custom plan node, verify that column validation works.
+statement error pq: column name "foo" not found
+SELECT foo from select_test
+
+query TTT colnames
+EXPLAIN SELECT * FROM select_test
+----
+Tree                  Field  Description
+render                ·      ·
+ └── sequence select  ·      ·
 
 # USING THE `nextval` AND `currval` FUNCTIONS
 

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -336,6 +336,7 @@ func (p *planner) propagateFilters(
 	case *hookFnNode:
 	case *valueGenerator:
 	case *valuesNode:
+	case *sequenceSelectNode:
 	case *setVarNode:
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -187,6 +187,7 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *unaryNode:
 	case *hookFnNode:
 	case *valueGenerator:
+	case *sequenceSelectNode:
 	case *setVarNode:
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -213,6 +213,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *unaryNode:
 	case *hookFnNode:
 	case *valueGenerator:
+	case *sequenceSelectNode:
 	case *setVarNode:
 	case *setClusterSettingNode:
 	case *setZoneConfigNode:

--- a/pkg/sql/sequence_select.go
+++ b/pkg/sql/sequence_select.go
@@ -1,0 +1,67 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/pkg/errors"
+)
+
+type sequenceSelectNode struct {
+	desc *sqlbase.TableDescriptor
+
+	val  int64
+	done bool
+}
+
+var _ planNode = &sequenceSelectNode{}
+
+func (p *planner) SequenceSelectNode(desc *sqlbase.TableDescriptor) (planNode, error) {
+	if desc.SequenceOpts == nil {
+		return nil, errors.New("descriptor is not a sequence")
+	}
+	return &sequenceSelectNode{
+		desc: desc,
+	}, nil
+}
+
+func (ss *sequenceSelectNode) Next(params runParams) (bool, error) {
+	if ss.done {
+		return false, nil
+	}
+	val, err := params.p.GetSequenceValue(params.ctx, ss.desc)
+	if err != nil {
+		return false, err
+	}
+	ss.val = val
+	ss.done = true
+	return true, nil
+}
+
+func (ss *sequenceSelectNode) Values() tree.Datums {
+	valDatum := tree.DInt(ss.val)
+	cntDatum := tree.DInt(0)
+	calledDatum := tree.DBoolTrue
+	return []tree.Datum{
+		&valDatum,
+		&cntDatum,
+		calledDatum,
+	}
+}
+
+func (ss *sequenceSelectNode) Close(ctx context.Context) {}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -527,6 +527,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&scanNode{}):                 "scan",
 	reflect.TypeOf(&scatterNode{}):              "scatter",
 	reflect.TypeOf(&scrubNode{}):                "scrub",
+	reflect.TypeOf(&sequenceSelectNode{}):       "sequence select",
 	reflect.TypeOf(&setVarNode{}):               "set",
 	reflect.TypeOf(&setClusterSettingNode{}):    "set cluster setting",
 	reflect.TypeOf(&setZoneConfigNode{}):        "configure zone",


### PR DESCRIPTION
Mimic postgres behavior. As in Postgres, this is the only way to get the value of a sequence without incrementing it, since the `currval` builtin returns the last value obtained by calling nextval *in the current session*, and the vtables (`information_schema.sequences` and `pg_catalog.sequences`) don't expose the value, only the settings.

Needed by Symfony (#19337), and to implement `cockroach dump`.

Note that there are minor differences with PG because of #21564

Fixes #21499

Release note: None