### PR TITLE
sql: sequences: add setval(name, value, is_called) builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -568,7 +568,9 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>nextval(sequence_name: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Advances the given sequence and returns its new value.</p>
 </span></td></tr>
-<tr><td><code>setval(sequence_name: <a href="string.html">string</a>, value: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Set the given sequence’s current value.</p>
+<tr><td><code>setval(sequence_name: <a href="string.html">string</a>, value: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Set the given sequence’s current value. The next call to nextval will return <code>value + Increment</code></p>
+</span></td></tr>
+<tr><td><code>setval(sequence_name: <a href="string.html">string</a>, value: <a href="int.html">int</a>, is_called: <a href="bool.html">bool</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Set the given sequence’s current value. If is_called is false, the next call to nextval will return <code>value</code>; otherwise <code>value + Increment</code>.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -356,6 +356,76 @@ SELECT setval('setval_bounds_test', 0)
 statement error pgcode 42P01 relation "nonexistent_seq" does not exist
 SELECT nextval('nonexistent_seq')
 
+# The three-argument variant of setval lets you set the next value to be retrieved from nextval().
+
+statement ok
+CREATE SEQUENCE setval_is_called_test
+
+query I
+SELECT setval('setval_is_called_test', 10, false)
+----
+10
+
+query I
+SELECT nextval('setval_is_called_test')
+----
+10
+
+query I
+SELECT nextval('setval_is_called_test')
+----
+11
+
+query I
+SELECT setval('setval_is_called_test', 20, true)
+----
+20
+
+query I
+SELECT nextval('setval_is_called_test')
+----
+21
+
+query I
+SELECT nextval('setval_is_called_test')
+----
+22
+
+# You can use setval to reset to minvalue.
+
+statement ok
+CREATE SEQUENCE setval_minval_test MINVALUE 10
+
+query I
+SELECT nextval('setval_minval_test')
+----
+10
+
+query I
+SELECT nextval('setval_minval_test')
+----
+11
+
+query I
+SELECT setval('setval_minval_test', 10, false)
+----
+10
+
+query I
+SELECT nextval('setval_minval_test')
+----
+10
+
+query I
+SELECT setval('setval_minval_test', 10, true)
+----
+10
+
+query I
+SELECT nextval('setval_minval_test')
+----
+11
+
 # BEHAVIOR UPON HITTING LIMITS (minvalue, maxvalue)
 
 statement ok

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -205,6 +205,27 @@ func MakeDBool(d DBool) *DBool {
 	return DBoolFalse
 }
 
+// MustBeDBool attempts to retrieve a DBool from an Expr, panicking if the
+// assertion fails.
+func MustBeDBool(e Expr) DBool {
+	b, ok := AsDBool(e)
+	if !ok {
+		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "expected *DBool, found %T", e))
+	}
+	return b
+}
+
+// AsDBool attempts to retrieve a *DBool from an Expr, returning a *DBool and
+// a flag signifying whether the assertion was successful. The function should
+// be used instead of direct type assertions.
+func AsDBool(e Expr) (DBool, bool) {
+	switch t := e.(type) {
+	case *DBool:
+		return *t, true
+	}
+	return false, false
+}
+
 // makeParseError returns a parse error using the provided string and type. An
 // optional error can be provided, which will be appended to the end of the
 // error string.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1992,7 +1992,10 @@ type EvalPlanner interface {
 	GetLatestValueInSessionForSequence(ctx context.Context, seqName *TableName) (int64, error)
 
 	// SetSequenceValue sets the sequence's value.
-	SetSequenceValue(ctx context.Context, seqName *TableName, newVal int64) error
+	// If isCalled is false, the sequence is set such that the next time nextval() is called,
+	// `newVal` is returned. Otherwise, the next call to nextval will return
+	// `newVal + seqOpts.Increment`.
+	SetSequenceValue(ctx context.Context, seqName *TableName, newVal int64, isCalled bool) error
 
 	// EvalSubquery returns the Datum for the given subquery node.
 	EvalSubquery(expr *Subquery) (Datum, error)

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -97,7 +97,7 @@ func (p *planner) GetLatestValueInSessionForSequence(
 
 // SetSequenceValue implements the tree.EvalPlanner interface.
 func (p *planner) SetSequenceValue(
-	ctx context.Context, seqName *tree.TableName, newVal int64,
+	ctx context.Context, seqName *tree.TableName, newVal int64, isCalled bool,
 ) error {
 	if p.session.TxnState.readOnly {
 		return readOnlyError("setval()")
@@ -113,6 +113,9 @@ func (p *planner) SetSequenceValue(
 			`value %d is out of bounds for sequence "%s" (%d..%d)`,
 			newVal, descriptor.Name, opts.MinValue, opts.MaxValue,
 		)
+	}
+	if !isCalled {
+		newVal = newVal - descriptor.SequenceOpts.Increment
 	}
 	seqValueKey := keys.MakeSequenceKey(uint32(descriptor.ID))
 	// TODO(vilterp): not supposed to mix usage of Inc and Put on a key,


### PR DESCRIPTION
Fixes #20410

Note that there are minor differences with PG because of #21564 

Release note: None