### PR TITLE
sql: split Close/Clear; remove Close() from the planNode interface

### DIFF
--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -133,4 +133,3 @@ func (n *alterIndexNode) startExec(params runParams) error {
 
 func (n *alterIndexNode) Next(runParams) (bool, error) { return false, nil }
 func (n *alterIndexNode) Values() tree.Datums          { return tree.Datums{} }
-func (n *alterIndexNode) Close(context.Context)        {}

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -89,4 +89,3 @@ func (n *alterSequenceNode) startExec(params runParams) error {
 
 func (n *alterSequenceNode) Next(runParams) (bool, error) { return false, nil }
 func (n *alterSequenceNode) Values() tree.Datums          { return tree.Datums{} }
-func (n *alterSequenceNode) Close(context.Context)        {}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -553,7 +553,6 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 func (n *alterTableNode) Next(runParams) (bool, error) { return false, nil }
 func (n *alterTableNode) Values() tree.Datums          { return tree.Datums{} }
-func (n *alterTableNode) Close(context.Context)        {}
 
 func applyColumnMutation(
 	col *sqlbase.ColumnDescriptor,

--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -93,7 +93,6 @@ func (n *alterUserSetPasswordNode) startExec(params runParams) error {
 
 func (*alterUserSetPasswordNode) Next(runParams) (bool, error) { return false, nil }
 func (*alterUserSetPasswordNode) Values() tree.Datums          { return tree.Datums{} }
-func (*alterUserSetPasswordNode) Close(context.Context)        {}
 
 func (n *alterUserSetPasswordNode) FastPathResults() (int, bool) {
 	return n.run.rowsAffected, true

--- a/pkg/sql/cancel_query.go
+++ b/pkg/sql/cancel_query.go
@@ -86,4 +86,3 @@ func (n *cancelQueryNode) startExec(params runParams) error {
 
 func (n *cancelQueryNode) Next(runParams) (bool, error) { return false, nil }
 func (*cancelQueryNode) Values() tree.Datums            { return nil }
-func (*cancelQueryNode) Close(context.Context)          {}

--- a/pkg/sql/control_job.go
+++ b/pkg/sql/control_job.go
@@ -114,4 +114,3 @@ func (n *controlJobNode) startExec(params runParams) error {
 
 func (n *controlJobNode) Next(runParams) (bool, error) { return false, nil }
 func (*controlJobNode) Values() tree.Datums            { return nil }
-func (*controlJobNode) Close(context.Context)          {}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -92,8 +92,8 @@ func (n *copyNode) startExec(params runParams) error {
 func (*copyNode) Next(runParams) (bool, error) { return false, nil }
 func (*copyNode) Values() tree.Datums          { return nil }
 
-func (n *copyNode) Close(ctx context.Context) {
-	n.rowsMemAcc.Close(ctx)
+func (n *copyNode) Clear(ctx context.Context) {
+	n.rowsMemAcc.Clear(ctx)
 }
 
 // CopyDataBlock represents a data block of a COPY FROM statement.

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -15,7 +15,6 @@
 package sql
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -104,4 +103,3 @@ func (n *createDatabaseNode) startExec(params runParams) error {
 
 func (*createDatabaseNode) Next(runParams) (bool, error) { return false, nil }
 func (*createDatabaseNode) Values() tree.Datums          { return tree.Datums{} }
-func (*createDatabaseNode) Close(context.Context)        {}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -154,4 +154,3 @@ func (n *createIndexNode) startExec(params runParams) error {
 
 func (*createIndexNode) Next(runParams) (bool, error) { return false, nil }
 func (*createIndexNode) Values() tree.Datums          { return tree.Datums{} }
-func (*createIndexNode) Close(context.Context)        {}

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -118,7 +118,6 @@ func (n *createSequenceNode) startExec(params runParams) error {
 
 func (*createSequenceNode) Next(runParams) (bool, error) { return false, nil }
 func (*createSequenceNode) Values() tree.Datums          { return tree.Datums{} }
-func (*createSequenceNode) Close(context.Context)        {}
 
 func (n *createSequenceNode) makeSequenceTableDesc(
 	params runParams,

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -69,5 +69,4 @@ func (p *planner) CreateStatistics(ctx context.Context, n *tree.CreateStats) (pl
 }
 
 func (*createStatsNode) Next(runParams) (bool, error) { panic("not implemented") }
-func (*createStatsNode) Close(context.Context)        {}
 func (*createStatsNode) Values() tree.Datums          { panic("not implemented") }

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -235,13 +235,6 @@ func (n *createTableNode) startExec(params runParams) error {
 func (*createTableNode) Next(runParams) (bool, error) { return false, nil }
 func (*createTableNode) Values() tree.Datums          { return tree.Datums{} }
 
-func (n *createTableNode) Close(ctx context.Context) {
-	if n.sourcePlan != nil {
-		n.sourcePlan.Close(ctx)
-		n.sourcePlan = nil
-	}
-}
-
 func (n *createTableNode) FastPathResults() (int, bool) {
 	if n.n.As() {
 		return n.run.rowsAffected, true

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -139,9 +139,6 @@ func (*CreateUserNode) Next(runParams) (bool, error) { return false, nil }
 // Values implements the planNode interface.
 func (*CreateUserNode) Values() tree.Datums { return tree.Datums{} }
 
-// Close implements the planNode interface.
-func (*CreateUserNode) Close(context.Context) {}
-
 // FastPathResults implements the planNodeFastPath interface.
 func (n *CreateUserNode) FastPathResults() (int, bool) { return n.run.rowsAffected, true }
 

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -197,7 +197,6 @@ func (n *createViewNode) startExec(params runParams) error {
 
 func (*createViewNode) Next(runParams) (bool, error) { return false, nil }
 func (*createViewNode) Values() tree.Datums          { return tree.Datums{} }
-func (n *createViewNode) Close(ctx context.Context)  {}
 
 // makeViewTableDesc returns the table descriptor for a new view.
 //

--- a/pkg/sql/delayed.go
+++ b/pkg/sql/delayed.go
@@ -39,13 +39,6 @@ type nodeConstructor func(context.Context, *planner) (planNode, error)
 func (d *delayedNode) Next(params runParams) (bool, error) { return d.plan.Next(params) }
 func (d *delayedNode) Values() tree.Datums                 { return d.plan.Values() }
 
-func (d *delayedNode) Close(ctx context.Context) {
-	if d.plan != nil {
-		d.plan.Close(ctx)
-		d.plan = nil
-	}
-}
-
 // enableAutoCommit is part of the autoCommitNode interface.
 func (d *delayedNode) enableAutoCommit() {
 	if ac, ok := d.plan.(autoCommitNode); ok {

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -191,8 +191,11 @@ func (d *deleteNode) Values() tree.Datums {
 	return d.run.resultRow
 }
 
+func (d *deleteNode) Clear(ctx context.Context) {
+	d.tw.clear(ctx)
+}
+
 func (d *deleteNode) Close(ctx context.Context) {
-	d.run.rows.Close(ctx)
 	d.tw.close(ctx)
 	*d = deleteNode{}
 	deleteNodePool.Put(d)

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -265,12 +265,11 @@ func (n *distinctNode) Values() tree.Datums {
 	return n.plan.Values()
 }
 
-func (n *distinctNode) Close(ctx context.Context) {
-	n.plan.Close(ctx)
+func (n *distinctNode) Clear(ctx context.Context) {
 	n.run.prefixSeen = nil
-	n.run.prefixMemAcc.Close(ctx)
+	n.run.prefixMemAcc.Clear(ctx)
 	n.run.suffixSeen = nil
-	n.run.suffixMemAcc.Close(ctx)
+	n.run.suffixMemAcc.Clear(ctx)
 }
 
 func (n *distinctNode) addSuffixSeen(

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -184,7 +184,6 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 }
 
 func (*dropDatabaseNode) Next(runParams) (bool, error) { return false, nil }
-func (*dropDatabaseNode) Close(context.Context)        {}
 func (*dropDatabaseNode) Values() tree.Datums          { return tree.Datums{} }
 
 // filterCascadedTables takes a list of table descriptors and removes any

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -94,7 +94,6 @@ func (n *dropIndexNode) startExec(params runParams) error {
 
 func (*dropIndexNode) Next(runParams) (bool, error) { return false, nil }
 func (*dropIndexNode) Values() tree.Datums          { return tree.Datums{} }
-func (*dropIndexNode) Close(context.Context)        {}
 
 type fullIndexName struct {
 	tn      *tree.TableName

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -99,7 +99,6 @@ func (n *dropSequenceNode) startExec(params runParams) error {
 
 func (*dropSequenceNode) Next(runParams) (bool, error) { return false, nil }
 func (*dropSequenceNode) Values() tree.Datums          { return tree.Datums{} }
-func (*dropSequenceNode) Close(context.Context)        {}
 
 func (p *planner) dropSequenceImpl(
 	ctx context.Context, seqDesc *sqlbase.TableDescriptor, behavior tree.DropBehavior,

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -138,7 +138,6 @@ func (n *dropTableNode) startExec(params runParams) error {
 
 func (*dropTableNode) Next(runParams) (bool, error) { return false, nil }
 func (*dropTableNode) Values() tree.Datums          { return tree.Datums{} }
-func (*dropTableNode) Close(context.Context)        {}
 
 // dropTableOrViewPrepare/dropTableImpl is used to drop a single table by
 // name, which can result from a DROP TABLE, DROP VIEW, DROP SEQUENCE,

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -200,8 +200,5 @@ func (*DropUserNode) Next(runParams) (bool, error) { return false, nil }
 // Values implements the planNode interface.
 func (*DropUserNode) Values() tree.Datums { return tree.Datums{} }
 
-// Close implements the planNode interface.
-func (*DropUserNode) Close(context.Context) {}
-
 // FastPathResults implements the planNodeFastPath interface.
 func (n *DropUserNode) FastPathResults() (int, bool) { return n.run.numDeleted, true }

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -120,7 +120,6 @@ func (n *dropViewNode) startExec(params runParams) error {
 
 func (*dropViewNode) Next(runParams) (bool, error) { return false, nil }
 func (*dropViewNode) Values() tree.Datums          { return tree.Datums{} }
-func (*dropViewNode) Close(context.Context)        {}
 
 func descInSlice(descID sqlbase.ID, td []*sqlbase.TableDescriptor) bool {
 	for _, desc := range td {

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -15,8 +15,6 @@
 package sql
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -81,8 +79,7 @@ func (n *explainDistSQLNode) Next(runParams) (bool, error) {
 	return true, nil
 }
 
-func (n *explainDistSQLNode) Values() tree.Datums       { return n.run.values }
-func (n *explainDistSQLNode) Close(ctx context.Context) { n.plan.Close(ctx) }
+func (n *explainDistSQLNode) Values() tree.Datums { return n.run.values }
 
 var explainDistSQLColumns = sqlbase.ResultColumns{
 	{Name: "Automatic", Typ: types.Bool},

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -160,12 +160,18 @@ func (e *explainPlanNode) startExec(params runParams) error {
 func (e *explainPlanNode) Next(params runParams) (bool, error) { return e.run.results.Next(params) }
 func (e *explainPlanNode) Values() tree.Datums                 { return e.run.results.Values() }
 
-func (e *explainPlanNode) Close(ctx context.Context) {
-	e.plan.Close(ctx)
+func (e *explainPlanNode) Clear(ctx context.Context) {
 	for i := range e.subqueryPlans {
-		e.subqueryPlans[i].plan.Close(ctx)
+		clearPlan(ctx, e.subqueryPlans[i].plan)
 	}
-	e.run.results.Close(ctx)
+	e.run.results.clear(ctx)
+}
+
+func (e *explainPlanNode) Close(ctx context.Context) {
+	for i := range e.subqueryPlans {
+		closePlan(ctx, e.subqueryPlans[i].plan)
+	}
+	e.run.results.clear(ctx)
 }
 
 // explainEntry is a representation of the info that makes it into an output row

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -15,8 +15,6 @@
 package sql
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -71,8 +69,7 @@ func (f *filterNode) Next(params runParams) (bool, error) {
 	}
 }
 
-func (f *filterNode) Values() tree.Datums       { return f.source.plan.Values() }
-func (f *filterNode) Close(ctx context.Context) { f.source.plan.Close(ctx) }
+func (f *filterNode) Values() tree.Datums { return f.source.plan.Values() }
 
 func (f *filterNode) computePhysicalProps(evalCtx *tree.EvalContext) {
 	f.props = planPhysicalProps(f.source.plan)

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -15,7 +15,6 @@
 package sql
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -267,9 +266,4 @@ func (n *indexJoinNode) Next(params runParams) (bool, error) {
 
 func (n *indexJoinNode) Values() tree.Datums {
 	return n.table.Values()
-}
-
-func (n *indexJoinNode) Close(ctx context.Context) {
-	n.index.Close(ctx)
-	n.table.Close(ctx)
 }

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -331,14 +331,15 @@ func (n *insertNode) Next(params runParams) (bool, error) {
 	return n.internalNext(params)
 }
 
+func (n *insertNode) Clear(ctx context.Context) {
+	n.tw.clear(ctx)
+	if n.run.rowsUpserted != nil {
+		n.run.rowsUpserted.Clear(ctx)
+	}
+}
+
 func (n *insertNode) Close(ctx context.Context) {
 	n.tw.close(ctx)
-	n.run.rows.Close(ctx)
-	n.run.rows = nil
-	if n.run.rowsUpserted != nil {
-		n.run.rowsUpserted.Close(ctx)
-		n.run.rowsUpserted = nil
-	}
 	switch t := n.tw.(type) {
 	case *tableInserter:
 		*t = tableInserter{}

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -604,15 +604,11 @@ func (n *joinNode) Values() tree.Datums {
 	return n.run.buffer.Values()
 }
 
-// Close implements the planNode interface.
-func (n *joinNode) Close(ctx context.Context) {
-	n.run.buffer.Close(ctx)
-	n.run.buffer = nil
+// Clear implements the planNode interface.
+func (n *joinNode) Clear(ctx context.Context) {
+	n.run.buffer.Clear(ctx)
 	n.run.buckets.Close(ctx)
-	n.run.bucketsMemAcc.Close(ctx)
-
-	n.right.plan.Close(ctx)
-	n.left.plan.Close(ctx)
+	n.run.bucketsMemAcc.Clear(ctx)
 }
 
 // bucket here is the set of rows for a given group key (comprised of
@@ -688,9 +684,8 @@ func (b *buckets) InitSeen(ctx context.Context, acc *mon.BoundAccount) error {
 	return nil
 }
 
-func (b *buckets) Close(ctx context.Context) {
-	b.rowContainer.Close(ctx)
-	b.rowContainer = nil
+func (b *buckets) Clear(ctx context.Context) {
+	b.rowContainer.Clear(ctx)
 	b.buckets = nil
 }
 

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -106,10 +106,6 @@ func (n *limitNode) Next(params runParams) (bool, error) {
 
 func (n *limitNode) Values() tree.Datums { return n.plan.Values() }
 
-func (n *limitNode) Close(ctx context.Context) {
-	n.plan.Close(ctx)
-}
-
 // estimateLimit pre-computes the count and offset fields if they are constants,
 // otherwise predefines them to be MaxInt64, 0. Used by index selection.
 // This must be called after type checking and constant folding.

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -15,8 +15,6 @@
 package sql
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -106,8 +104,7 @@ func (o *ordinalityNode) Next(params runParams) (bool, error) {
 	return true, nil
 }
 
-func (o *ordinalityNode) Values() tree.Datums       { return o.run.row }
-func (o *ordinalityNode) Close(ctx context.Context) { o.source.Close(ctx) }
+func (o *ordinalityNode) Values() tree.Datums { return o.run.row }
 
 // restrictOrdering transforms an ordering requirement on the output
 // of an ordinalityNode into an ordering requirement on its input.

--- a/pkg/sql/plan_cleanup.go
+++ b/pkg/sql/plan_cleanup.go
@@ -1,0 +1,63 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+)
+
+type planClearable interface {
+	// Clear is meant to release as many resources taken by a plan as
+	// possible but leave the plan "alive", not losing information so
+	// that future re-execution remains possible.
+	// This includes clearing memory monitor accounts, clearing
+	// row containers, etc.
+	Clear(ctx context.Context)
+}
+type planClosable interface {
+	// Close is meant to release all the resources not released by
+	// Clear(). This includes e.g. releasing a plan node to a sync.Pool.
+	// After Close, a plan is fully unusable.
+	Close(ctx context.Context)
+}
+
+func clearPlan(ctx context.Context, plan planNode) { return cleanupPlan(ctx, plan, true, false) }
+func closePlan(ctx context.Context, plan planNode) { return cleanupPlan(ctx, plan, true, true) }
+
+func cleanupPlan(ctx context.Context, plan planNode, doClear, doClose bool) {
+	o := planObserver{
+		leaveNode: func(_ string, n planNode) error {
+			if doClear {
+				if c, ok := n.(planClearable); ok {
+					c.Clear(params.ctx)
+				}
+			}
+			if doClose {
+				if c, ok := n.(planClosable); ok {
+					c.Close(params.ctx)
+				}
+			}
+			return nil
+		},
+	}
+	if err := walkPlan(params.ctx, plan, o); err != nil {
+		// walkPlan should never error out. If it does, don't drop the
+		// error on the floor.
+		log.Errorf(params.ctx, errors.Wrapf("error while closing plan: %v", err))
+	}
+}

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -132,4 +132,3 @@ func (f *hookFnNode) Next(params runParams) (bool, error) {
 	}
 }
 func (f *hookFnNode) Values() tree.Datums { return f.run.row }
-func (*hookFnNode) Close(context.Context) {}

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -347,8 +347,7 @@ func (r *renderNode) Next(params runParams) (bool, error) {
 	return err == nil, err
 }
 
-func (r *renderNode) Values() tree.Datums       { return r.run.row }
-func (r *renderNode) Close(ctx context.Context) { r.source.plan.Close(ctx) }
+func (r *renderNode) Values() tree.Datums { return r.run.row }
 
 // initFrom initializes the table node, given the parsed select expression
 func (p *planner) initFrom(

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -166,5 +166,3 @@ func (n *scatterNode) Values() tree.Datums {
 		tree.NewDString(keys.PrettyPrint(nil /* valDirs */, r.Span.Key)),
 	}
 }
-
-func (*scatterNode) Close(ctx context.Context) {}

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -161,12 +161,12 @@ func (n *scrubNode) Values() tree.Datums {
 	return n.run.row
 }
 
-func (n *scrubNode) Close(ctx context.Context) {
+func (n *scrubNode) Clear(ctx context.Context) {
 	// Close any iterators which have not been completed.
-	for len(n.run.checkQueue) > 0 {
-		n.run.checkQueue[0].Close(ctx)
-		n.run.checkQueue = n.run.checkQueue[1:]
+	for _, c := range n.run.checkQueue {
+		c.Clear(ctx)
 	}
+	n.run.checkQueue = nil
 }
 
 // startScrubDatabase prepares a scrub check for each of the tables in

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -175,9 +175,9 @@ func (o *sqlCheckConstraintCheckOperation) Done(ctx context.Context) bool {
 	return o.run.rows == nil || !o.run.hasRowsLeft
 }
 
-// Close implements the checkOperation interface.
-func (o *sqlCheckConstraintCheckOperation) Close(ctx context.Context) {
+// Clear implements the checkOperation interface.
+func (o *sqlCheckConstraintCheckOperation) Clear(ctx context.Context) {
 	if o.run.rows != nil {
-		o.run.rows.Close(ctx)
+		o.run.rows.Clear(ctx)
 	}
 }

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -204,10 +204,10 @@ func (o *sqlForeignKeyCheckOperation) Done(ctx context.Context) bool {
 	return o.run.rows == nil || o.run.rowIndex >= o.run.rows.Len()
 }
 
-// Close implements the checkOperation interface.
-func (o *sqlForeignKeyCheckOperation) Close(ctx context.Context) {
+// Clear implements the checkOperation interface.
+func (o *sqlForeignKeyCheckOperation) Clear(ctx context.Context) {
 	if o.run.rows != nil {
-		o.run.rows.Close(ctx)
+		o.run.rows.Clear(ctx)
 	}
 }
 

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -237,10 +237,10 @@ func (o *indexCheckOperation) Done(ctx context.Context) bool {
 	return o.run.rows == nil || o.run.rowIndex >= o.run.rows.Len()
 }
 
-// Close4 implements the checkOperation interface.
-func (o *indexCheckOperation) Close(ctx context.Context) {
+// Clear implements the checkOperation interface.
+func (o *indexCheckOperation) Clear(ctx context.Context) {
 	if o.run.rows != nil {
-		o.run.rows.Close(ctx)
+		o.run.rows.Clear(ctx)
 	}
 }
 

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -163,9 +163,6 @@ func makeKeywordsGenerator(_ *tree.EvalContext, _ tree.Datums) (tree.ValueGenera
 // ResolvedType implements the tree.ValueGenerator interface.
 func (*keywordsValueGenerator) ResolvedType() types.TTable { return keywordsValueGeneratorType }
 
-// Close implements the tree.ValueGenerator interface.
-func (*keywordsValueGenerator) Close() {}
-
 // Start implements the tree.ValueGenerator interface.
 func (k *keywordsValueGenerator) Start() error {
 	k.curKeyword = -1
@@ -327,9 +324,6 @@ func (s *seriesValueGenerator) ResolvedType() types.TTable {
 // Start implements the tree.ValueGenerator interface.
 func (s *seriesValueGenerator) Start() error { return nil }
 
-// Close implements the tree.ValueGenerator interface.
-func (s *seriesValueGenerator) Close() {}
-
 // Next implements the tree.ValueGenerator interface.
 func (s *seriesValueGenerator) Next() (bool, error) {
 	return s.next(s)
@@ -367,9 +361,6 @@ func (s *arrayValueGenerator) Start() error {
 	s.nextIndex = -1
 	return nil
 }
-
-// Close implements the tree.ValueGenerator interface.
-func (s *arrayValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
 func (s *arrayValueGenerator) Next() (bool, error) {
@@ -409,9 +400,6 @@ func (*unaryValueGenerator) ResolvedType() types.TTable { return unaryValueGener
 
 // Start implements the tree.ValueGenerator interface.
 func (s *unaryValueGenerator) Start() error { return nil }
-
-// Close implements the tree.ValueGenerator interface.
-func (s *unaryValueGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
 func (s *unaryValueGenerator) Next() (bool, error) {
@@ -516,9 +504,6 @@ func (g *jsonArrayGenerator) Start() error {
 	return nil
 }
 
-// Close implements the tree.ValueGenerator interface.
-func (g *jsonArrayGenerator) Close() {}
-
 // Next implements the tree.ValueGenerator interface.
 func (g *jsonArrayGenerator) Next() (bool, error) {
 	g.nextIndex++
@@ -586,9 +571,6 @@ func (g *jsonObjectKeysGenerator) ResolvedType() types.TTable {
 
 // Start implements the tree.ValueGenerator interface.
 func (g *jsonObjectKeysGenerator) Start() error { return nil }
-
-// Close implements the tree.ValueGenerator interface.
-func (g *jsonObjectKeysGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
 func (g *jsonObjectKeysGenerator) Next() (bool, error) {
@@ -674,9 +656,6 @@ func (g *jsonEachGenerator) ResolvedType() types.TTable {
 
 // Start implements the tree.ValueGenerator interface.
 func (g *jsonEachGenerator) Start() error { return nil }
-
-// Close implements the tree.ValueGenerator interface.
-func (g *jsonEachGenerator) Close() {}
 
 // Next implements the tree.ValueGenerator interface.
 func (g *jsonEachGenerator) Next() (bool, error) {

--- a/pkg/sql/sem/tree/generators.go
+++ b/pkg/sql/sem/tree/generators.go
@@ -62,9 +62,4 @@ type ValueGenerator interface {
 
 	// Values retrieves the current row of data.
 	Values() Datums
-
-	// Close must be called after Start() before disposing of the
-	// ValueGenerator. It does not need to be called if Start() has not
-	// been called yet.
-	Close()
 }

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -140,7 +140,6 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 
 func (n *setClusterSettingNode) Next(_ runParams) (bool, error) { return false, nil }
 func (n *setClusterSettingNode) Values() tree.Datums            { return nil }
-func (n *setClusterSettingNode) Close(_ context.Context)        {}
 
 func (p *planner) toSettingString(
 	ctx context.Context,

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -115,7 +115,6 @@ func (n *setVarNode) startExec(params runParams) error {
 
 func (n *setVarNode) Next(_ runParams) (bool, error) { return false, nil }
 func (n *setVarNode) Values() tree.Datums            { return nil }
-func (n *setVarNode) Close(_ context.Context)        {}
 
 func datumAsString(evalCtx *tree.EvalContext, name string, value tree.TypedExpr) (string, error) {
 	val, err := value.Eval(evalCtx)

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -158,7 +158,6 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 
 func (n *setZoneConfigNode) Next(runParams) (bool, error) { return false, nil }
 func (n *setZoneConfigNode) Values() tree.Datums          { return nil }
-func (*setZoneConfigNode) Close(context.Context)          {}
 
 func (n *setZoneConfigNode) FastPathResults() (int, bool) { return n.run.numAffected, true }
 

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -162,5 +162,4 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	return true, nil
 }
 
-func (n *showFingerprintsNode) Values() tree.Datums     { return n.run.values }
-func (n *showFingerprintsNode) Close(_ context.Context) {}
+func (n *showFingerprintsNode) Values() tree.Datums { return n.run.values }

--- a/pkg/sql/show_ranges.go
+++ b/pkg/sql/show_ranges.go
@@ -181,7 +181,7 @@ func (n *showRangesNode) Values() tree.Datums {
 	return n.run.values
 }
 
-func (n *showRangesNode) Close(_ context.Context) {
+func (n *showRangesNode) Clear(_ context.Context) {
 	n.run.descriptorKVs = nil
 }
 

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -284,15 +284,13 @@ func (n *showTraceNode) Values() tree.Datums {
 	return n.run.traceRows[n.run.curRow-1][:]
 }
 
-func (n *showTraceNode) Close(ctx context.Context) {
-	if n.plan != nil {
-		n.plan.Close(ctx)
-	}
+func (n *showTraceNode) Clear(ctx context.Context) {
 	n.run.traceRows = nil
 	if n.run.stopTracing != nil {
 		if err := n.run.stopTracing(); err != nil {
 			log.Errorf(ctx, "error stopping tracing at end of SHOW TRACE FOR: %v", err)
 		}
+		n.run.stopTracing = nil
 	}
 }
 

--- a/pkg/sql/show_trace_replica.go
+++ b/pkg/sql/show_trace_replica.go
@@ -120,10 +120,6 @@ func (n *showTraceReplicaNode) Values() tree.Datums {
 	return n.run.values
 }
 
-func (n *showTraceReplicaNode) Close(ctx context.Context) {
-	n.plan.Close(ctx)
-}
-
 var showTraceReplicaColumns = sqlbase.ResultColumns{
 	{
 		Name: `timestamp`,

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -140,8 +140,6 @@ func (n *showZoneConfigNode) Values() tree.Datums {
 	}
 }
 
-func (*showZoneConfigNode) Close(context.Context) {}
-
 // ascendZoneSpecifier logically ascends the zone hierarchy for the zone
 // specified by (zs, resolvedID) until the zone matching actualID is found, and
 // returns that zone's specifier. Results are undefined if actualID is not in

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -281,13 +281,13 @@ func (n *sortNode) Values() tree.Datums {
 	return n.run.valueIter.Values()[:len(n.columns)]
 }
 
-func (n *sortNode) Close(ctx context.Context) {
-	n.plan.Close(ctx)
+func (n *sortNode) Clear(ctx context.Context) {
 	if n.run.sortStrategy != nil {
-		n.run.sortStrategy.Close(ctx)
+		n.run.sortStrategy.Clear(ctx)
 	}
 	// n.run.valueIter points to either n.plan or n.run.sortStrategy and thus has already
 	// been closed.
+	n.run.valueIter = nil
 }
 
 func ensureColumnOrderable(c sqlbase.ResultColumn) error {

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -128,10 +128,6 @@ func (n *splitNode) Values() tree.Datums {
 	}
 }
 
-func (n *splitNode) Close(ctx context.Context) {
-	n.rows.Close(ctx)
-}
-
 // getRowKey generates a key that corresponds to a row (or prefix of a row) in a table or index.
 // Both tableDesc and index are required (index can be the primary index).
 func getRowKey(

--- a/pkg/sql/testing_relocate.go
+++ b/pkg/sql/testing_relocate.go
@@ -193,10 +193,6 @@ func (n *testingRelocateNode) Values() tree.Datums {
 	}
 }
 
-func (n *testingRelocateNode) Close(ctx context.Context) {
-	n.rows.Close(ctx)
-}
-
 func lookupRangeDescriptor(
 	ctx context.Context, db *client.DB, rowKey []byte,
 ) (roachpb.RangeDescriptor, error) {

--- a/pkg/sql/unary.go
+++ b/pkg/sql/unary.go
@@ -15,8 +15,6 @@
 package sql
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -39,5 +37,3 @@ func (u *unaryNode) Next(runParams) (bool, error) {
 	u.run.consumed = true
 	return r, nil
 }
-
-func (*unaryNode) Close(context.Context) {}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -353,8 +353,11 @@ func (u *updateNode) Values() tree.Datums {
 	return u.run.resultRow
 }
 
+func (u *updateNode) Clear(ctx context.Context) {
+	u.tw.clear(ctx)
+}
+
 func (u *updateNode) Close(ctx context.Context) {
-	u.run.rows.Close(ctx)
 	u.tw.close(ctx)
 	*u = updateNode{}
 	updateNodePool.Put(u)

--- a/pkg/sql/value_generator.go
+++ b/pkg/sql/value_generator.go
@@ -109,9 +109,3 @@ func (n *valueGenerator) Next(params runParams) (bool, error) {
 	return n.run.gen.Next()
 }
 func (n *valueGenerator) Values() tree.Datums { return n.run.gen.Values() }
-
-func (n *valueGenerator) Close(context.Context) {
-	if n.run.gen != nil {
-		n.run.gen.Close()
-	}
-}

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -188,10 +188,9 @@ func (n *valuesNode) Values() tree.Datums {
 	return n.rows.At(n.nextRow - 1)
 }
 
-func (n *valuesNode) Close(ctx context.Context) {
+func (n *valuesNode) Clear(ctx context.Context) {
 	if n.rows != nil {
-		n.rows.Close(ctx)
-		n.rows = nil
+		n.rows.Clear(ctx)
 	}
 }
 

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -201,17 +201,16 @@ func (n *windowNode) Values() tree.Datums {
 	return n.run.values.Values()
 }
 
-func (n *windowNode) Close(ctx context.Context) {
-	n.plan.Close(ctx)
+func (n *windowNode) Clear(ctx context.Context) {
 	if n.run.wrappedRenderVals != nil {
-		n.run.wrappedRenderVals.Close(ctx)
+		n.run.wrappedRenderVals.Clear(ctx)
 		n.run.wrappedRenderVals = nil
 	}
 	if n.run.windowValues != nil {
 		n.run.windowValues = nil
-		n.run.windowsAcc.Close(ctx)
+		n.run.windowsAcc.Clear(ctx)
 	}
-	n.run.values.Close(ctx)
+	clearPlan(ctx, n.run.values)
 }
 
 // extractWindowFunctions loops over the render expressions and extracts any window functions.

--- a/pkg/sql/zero.go
+++ b/pkg/sql/zero.go
@@ -15,8 +15,6 @@
 package sql
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -37,4 +35,3 @@ type zeroNode struct {
 
 func (z *zeroNode) Next(runParams) (bool, error) { return false, nil }
 func (*zeroNode) Values() tree.Datums            { return nil }
-func (*zeroNode) Close(context.Context)          {}


### PR DESCRIPTION
Needed as prerequisite for #21446.

This work is motivated by the desire to cache logical plans; a method
was needed to clear the resources used by a plan in a way that keeps
the plan reusable.

To achieve this, this patch introduces a new API called `Clear()`. It is
meant to be called in-between reuses of a resources: planNode,
rowContainer, etc, to de-allocate memory or other resources it may be
consuming while retaining its configuration for possible later reuse.

This API is then implemented as follows: for every planNode, the part
of the `Close` method that is only concern with reusable resource
deallocation was split away into the new `Clear` method.

The new `Clear()` method is meant to *complement* `Close()`, so as to
avoid code duplication between them. To fully tear down a plan, both
must be called (in that order). The existing `planTop.close()` method
is also modified in this patch to do just that, so that users of
logical plans needn't be concerned about this distinction.

Meanwhile, in addition to achieving the goal of splitting Close and
Clear, this patch achieves something else: the removal of the
`Close()` method from the `planNode` interface. Instead, a new
`cleanupPlan` method is in charge of using the existing `walkPlan`
recursive function to invoke `Clear()` and/or `Close()` *on those node
types that support them*. Nodes that do not have anything to do on
`Clear`, or `Close`, are skipped transparently. This simplification
reduces the `planNode` interface to just `Values` and `Next`.

Release note: None