### PR TITLE
sql: replace MakeJSON in Concat() and AsJSON()

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -3510,8 +3510,9 @@ func asJSON(d tree.Datum) (json.JSON, error) {
 		return json.FromString(tree.AsStringWithFlags(t, tree.FmtBareStrings)), nil
 	default:
 		if d == tree.DNull {
-			return json.MakeJSON(nil)
+			return json.NullJSONValue, nil
 		}
+
 		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected type %T for asJSON", d)
 	}
 }

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -1000,16 +1000,16 @@ func scalarConcat(left, other JSON) (JSON, error) {
 			return nil, err
 		}
 		right := decoded.(jsonArray)
-		result := make([]interface{}, len(right)+1)
+		result := make(jsonArray, len(right)+1)
 		result[0] = left
 		for i := range right {
 			result[i+1] = right[i]
 		}
-		return MakeJSON(result)
+		return result, nil
 	case ObjectJSONType:
 		return nil, errInvalidConcat
 	default:
-		return MakeJSON([]interface{}{left, other})
+		return jsonArray{left, other}, nil
 	}
 }
 
@@ -1028,21 +1028,21 @@ func (j jsonArray) Concat(other JSON) (JSON, error) {
 			return nil, err
 		}
 		right := decoded.(jsonArray)
-		result := make([]interface{}, len(left)+len(right))
+		result := make(jsonArray, len(left)+len(right))
 		for i := range left {
 			result[i] = left[i]
 		}
 		for i := range right {
 			result[len(left)+i] = right[i]
 		}
-		return MakeJSON(result)
+		return result, nil
 	default:
-		result := make([]interface{}, len(left)+1)
-		result[len(result)-1] = other
+		result := make(jsonArray, len(left)+1)
 		for i := range left {
 			result[i] = left[i]
 		}
-		return MakeJSON(result)
+		result[len(left)] = other
+		return result, nil
 	}
 }
 

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1539,6 +1539,32 @@ func BenchmarkBuildJSONObject(b *testing.B) {
 	}
 }
 
+func BenchmarkArrayConcat(b *testing.B) {
+	for _, arraySize := range []int{1, 10, 100, 1000, 10000} {
+		b.Run(fmt.Sprintf("concat two arrays with size %d", arraySize), func(b *testing.B) {
+			arr := make([]interface{}, arraySize)
+			for i := 0; i < arraySize; i++ {
+				arr[i] = i
+			}
+			left, err := MakeJSON(arr)
+			if err != nil {
+				b.Fatal(err)
+			}
+			right, err := MakeJSON(arr)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err = left.Concat(right)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkObjectStripNulls(b *testing.B) {
 	for _, objectSize := range []int{1, 10, 100, 1000} {
 		b.Run(fmt.Sprintf("object size %d no need to strip", objectSize), func(b *testing.B) {


### PR DESCRIPTION
@justinj, using MakeJSON in these function seems to be less efficient. In [Concat()](https://github.com/cockroachdb/cockroach/blob/master/pkg/util/json/json.go#L1038), the code makes two array, one is result and one is in MakeJSON which can be avoided. In [AsJSON()](https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/sem/builtins/builtins.go#L3513), the code could use json.NullJSONValue to avoid function call.