### PR TITLE
distsql: allow right cols in onCond for semijoins

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -661,6 +661,35 @@ func TestHashJoiner(t *testing.T) {
 				{v[2], v[2]},
 			},
 		},
+		{
+			// Ensure that semi joins respect OnExprs on both inputs.
+			spec: HashJoinerSpec{
+				LeftEqColumns:  []uint32{0},
+				RightEqColumns: []uint32{0},
+				Type:           JoinType_LEFT_SEMI,
+				OnExpr:         Expression{Expr: "@4 > 4 and @2 + @4 = 8"},
+				// Implicit @1 = @3 constraint.
+			},
+			outCols:   []uint32{0, 1},
+			leftTypes: twoIntCols,
+			leftInput: sqlbase.EncDatumRows{
+				{v[0], v[4]},
+				{v[1], v[1]},
+				{v[2], v[1]},
+				{v[2], v[2]},
+			},
+			rightTypes: twoIntCols,
+			rightInput: sqlbase.EncDatumRows{
+				{v[0], v[4]},
+				{v[0], v[4]},
+				{v[2], v[5]},
+				{v[2], v[6]},
+				{v[3], v[3]},
+			},
+			expected: sqlbase.EncDatumRows{
+				{v[2], v[2]},
+			},
+		},
 	}
 
 	ctx := context.Background()

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -68,13 +68,10 @@ func (jb *joinerBase) init(
 	jb.eqCols[rightSide] = columns(rightEqColumns)
 	jb.numMergedEqualityColumns = int(numMergedColumns)
 
-	size := len(leftTypes) + jb.numMergedEqualityColumns
-	if shouldIncludeRight(jb.joinType) {
-		size += len(rightTypes)
-	}
+	size := len(leftTypes) + jb.numMergedEqualityColumns + len(rightTypes)
 	jb.combinedRow = make(sqlbase.EncDatumRow, size)
 
-	types := make([]sqlbase.ColumnType, 0, size)
+	condTypes := make([]sqlbase.ColumnType, 0, size)
 	for idx := 0; idx < jb.numMergedEqualityColumns; idx++ {
 		ltype := leftTypes[jb.eqCols[leftSide][idx]]
 		rtype := rightTypes[jb.eqCols[rightSide][idx]]
@@ -84,18 +81,23 @@ func (jb *joinerBase) init(
 		} else {
 			ctype = rtype
 		}
-		types = append(types, ctype)
+		condTypes = append(condTypes, ctype)
 	}
-	types = append(types, leftTypes...)
-	if shouldIncludeRight(jb.joinType) {
-		types = append(types, rightTypes...)
+	condTypes = append(condTypes, leftTypes...)
+	condTypes = append(condTypes, rightTypes...)
+
+	outputSize := len(leftTypes) + jb.numMergedEqualityColumns
+	// Semi-joins do not include the right columns in their output.
+	if jb.joinType != leftSemiJoin {
+		outputSize += len(rightTypes)
 	}
+	outputTypes := condTypes[:outputSize]
 
 	evalCtx := flowCtx.NewEvalCtx()
-	if err := jb.onCond.init(onExpr, types, evalCtx); err != nil {
+	if err := jb.onCond.init(onExpr, condTypes, evalCtx); err != nil {
 		return err
 	}
-	return jb.processorBase.init(post, types, flowCtx, evalCtx, output)
+	return jb.processorBase.init(post, outputTypes, flowCtx, evalCtx, output)
 }
 
 type joinSide uint8
@@ -130,11 +132,6 @@ func (jb *joinerBase) renderUnmatchedRow(
 	jb.combinedRow = append(jb.combinedRow, lrow...)
 	jb.combinedRow = append(jb.combinedRow, rrow...)
 	return jb.combinedRow
-}
-
-// Certain types of joins only emit the left columns.
-func shouldIncludeRight(joinType joinType) bool {
-	return joinType != leftSemiJoin
 }
 
 // shouldEmitUnmatchedRow determines if we should emit am ummatched row (with
@@ -191,9 +188,7 @@ func (jb *joinerBase) render(lrow, rrow sqlbase.EncDatumRow) (sqlbase.EncDatumRo
 		jb.combinedRow[i] = lrow[jb.eqCols[leftSide][i]]
 	}
 	copy(jb.combinedRow[n:], lrow)
-	if shouldIncludeRight(jb.joinType) {
-		copy(jb.combinedRow[n+len(lrow):], rrow)
-	}
+	copy(jb.combinedRow[n+len(lrow):], rrow)
 
 	if jb.onCond.expr != nil {
 		res, err := jb.onCond.evalFilter(jb.combinedRow)


### PR DESCRIPTION
Semi-joins that references a column from the right input in the onCond
expression didn't work. Added a tests and fixed the issue. This also
reduces the semi-join specific login in `joinerbase`.

Release note: None