### PR TITLE
sql/sqlbase: Fix the primary index span lookup for cascading

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1,5 +1,81 @@
 # LogicTest: default
 
+subtest AllCascadingActions
+### A test of all cascading actions in their most basic form.
+# A
+# |
+# B
+
+statement ok
+CREATE TABLE a (
+  id INT PRIMARY KEY
+);
+
+statement ok
+CREATE TABLE b (
+  delete_no_action INT NOT NULL REFERENCES a ON DELETE NO ACTION
+ ,update_no_action INT NOT NULL REFERENCES a ON UPDATE NO ACTION
+ ,delete_restrict INT NOT NULL REFERENCES a ON DELETE RESTRICT
+ ,update_restrict INT NOT NULL REFERENCES a ON UPDATE RESTRICT
+ ,delete_cascade INT NOT NULL REFERENCES a ON DELETE CASCADE
+ ,update_cascade INT NOT NULL REFERENCES a ON UPDATE CASCADE
+ ,delete_null INT REFERENCES a
+ ,update_null INT REFERENCES a
+ ,delete_default INT DEFAULT 100 REFERENCES a
+ ,update_default INT DEFAULT 100 REFERENCES a
+);
+
+statement ok
+INSERT INTO a (id) VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10), (100);
+INSERT INTO b VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+query IIIIIIIIII
+SELECT * FROM b;
+----
+1 2 3 4 5 6 7 8 9 10
+
+# 1. ON DELETE NO ACTION
+statement error pq: foreign key violation: values \[1\] in columns \[id\] referenced in table "b"
+DELETE FROM a WHERE id = 1;
+
+# 2. ON UPDATE NO ACTION
+statement error pq: foreign key violation: values \[2\] in columns \[id\] referenced in table "b"
+UPDATE a SET id = 1000 WHERE id = 2;
+
+# 3. ON DELETE RESTRICT
+statement error pq: foreign key violation: values \[3\] in columns \[id\] referenced in table "b"
+DELETE FROM a WHERE id = 3;
+
+# 4. ON UPDATE RESTRICT
+statement error pq: foreign key violation: values \[4\] in columns \[id\] referenced in table "b"
+UPDATE a SET id = 1000 WHERE id = 4;
+
+# 5. ON DELETE CASCADE
+statement ok
+DELETE FROM a WHERE id = 5;
+
+query I
+SELECT COUNT(*) FROM b;
+----
+0
+
+statement ok
+INSERT INTO a VALUES (5);
+INSERT INTO b VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+# 6. ON UPDATE CASCADE
+statement ok
+UPDATE a SET id = 1000 WHERE id = 6;
+
+query IIIIIIIIII
+SELECT * FROM b;
+----
+1 2 3 4 5 1000 7 8 9 10
+
+# Post Test Clean up
+statement ok
+DROP TABLE b, a;
+
 subtest DeleteCascade_Basic
 ### Basic Delete Cascade
 #     a

--- a/pkg/sql/sqlbase/cascader.go
+++ b/pkg/sql/sqlbase/cascader.go
@@ -492,10 +492,11 @@ func (c *cascader) deleteRows(
 	if err != nil {
 		return nil, nil, 0, err
 	}
+	indexPKRowFetcherColIDToRowIndex := indexPKRowFetcher.tables[0].colIdxMap
 
 	// Fetch all the primary keys that need to be deleted.
 	// TODO(Bram): consider chunking this into n, primary keys, perhaps 100.
-	pkColTypeInfo, err := makeColTypeInfo(referencingTable, indexPKRowFetcher.tables[0].colIdxMap)
+	pkColTypeInfo, err := makeColTypeInfo(referencingTable, indexPKRowFetcherColIDToRowIndex)
 	if err != nil {
 		return nil, nil, 0, err
 	}
@@ -536,7 +537,7 @@ func (c *cascader) deleteRows(
 	// Create a batch request to get all the spans of the primary keys that need
 	// to be deleted.
 	pkLookupReq, err := batchRequestForPKValues(
-		referencingTable, rowDeleter.FetchColIDtoRowIndex, primaryKeysToDelete,
+		referencingTable, indexPKRowFetcherColIDToRowIndex, primaryKeysToDelete,
 	)
 	if err != nil {
 		return nil, nil, 0, err
@@ -676,10 +677,11 @@ func (c *cascader) updateRows(
 		if err != nil {
 			return nil, nil, nil, 0, err
 		}
+		indexPKRowFetcherColIDToRowIndex := indexPKRowFetcher.tables[0].colIdxMap
 
 		// Fetch all the primary keys for rows that will be updated.
 		// TODO(Bram): consider chunking this into n, primary keys, perhaps 100.
-		pkColTypeInfo, err := makeColTypeInfo(referencingTable, indexPKRowFetcher.tables[0].colIdxMap)
+		pkColTypeInfo, err := makeColTypeInfo(referencingTable, indexPKRowFetcherColIDToRowIndex)
 		if err != nil {
 			return nil, nil, nil, 0, err
 		}
@@ -714,7 +716,7 @@ func (c *cascader) updateRows(
 		// Create a batch request to get all the spans of the primary keys that need
 		// to be updated.
 		pkLookupReq, err := batchRequestForPKValues(
-			referencingTable, rowUpdater.FetchColIDtoRowIndex, primaryKeysToUpdate,
+			referencingTable, indexPKRowFetcherColIDToRowIndex, primaryKeysToUpdate,
 		)
 		if err != nil {
 			return nil, nil, nil, 0, err

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -2479,7 +2479,7 @@ func TableEquivSignatures(
 }
 
 // maxKeyTokens returns the maximum number of key tokens in an index's key,
-// including the table ID, index ID, and index column values (ncluding extra
+// including the table ID, index ID, and index column values (including extra
 // columns that may be stored in the key).
 // It requires knowledge of whether the key will or might contain a NULL value:
 // if uncertain, pass in true to 'overestimate' the maxKeyTokens.


### PR DESCRIPTION
The wrong col ID to row map was being used when scanning for a primary
key causing a panic.

Release note: None