### PR TITLE
libroach,storage: make interval bounds on time-bound iterators sane

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -2207,10 +2207,8 @@ DBIterator* DBNewTimeBoundIter(DBEngine* db, DBTimestamp min_ts, DBTimestamp max
       return true;
     }
     // If the timestamp range of the table overlaps with the timestamp range we
-    // want to iterate, the table might contain timestamps we care about. For
-    // consistency with engineccl.MVCCIncrementalIterator, the min_ts bound is
-    // exclusive, but the max_ts bound is inclusive.
-    return max.compare(tbl_min->second) >= 0 && min.compare(tbl_max->second) < 0;
+    // want to iterate, the table might contain timestamps we care about.
+    return max.compare(tbl_min->second) >= 0 && min.compare(tbl_max->second) <= 0;
   };
   return db->NewIter(&opts);
 }

--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -62,7 +62,11 @@ func NewMVCCIncrementalIterator(
 	e engine.Reader, startTime, endTime hlc.Timestamp,
 ) *MVCCIncrementalIterator {
 	return &MVCCIncrementalIterator{
-		iter:      e.NewTimeBoundIterator(startTime, endTime),
+		// The call to startTime.Next() converts our half-open (start, end] time
+		// interval into the fully-inclusive [start, end] interval that
+		// NewTimeBoundIterator expects. This is strictly a performance
+		// optimization; omitting the call would still return correct results.
+		iter:      e.NewTimeBoundIterator(startTime.Next(), endTime),
 		startTime: startTime,
 		endTime:   endTime,
 	}

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -869,9 +869,9 @@ func (t *Transaction) BumpEpoch() {
 	t.Epoch++
 }
 
-// TimeBounds returns the start and end timestamps which inclusively
-// cover all intents which were written as part of this transaction.
-func (t *Transaction) TimeBounds() (hlc.Timestamp, hlc.Timestamp) {
+// InclusiveTimeBounds returns start and end timestamps such that all intents written as
+// part of this transaction have a timestamp in the interval [start, end].
+func (t *Transaction) InclusiveTimeBounds() (hlc.Timestamp, hlc.Timestamp) {
 	min := t.OrigTimestamp
 	max := t.Timestamp
 	if t.Epoch != 0 {
@@ -880,7 +880,7 @@ func (t *Transaction) TimeBounds() (hlc.Timestamp, hlc.Timestamp) {
 		}
 		min = t.EpochZeroTimestamp
 	}
-	return min, max.Next() // Next() makes the end of the interval closed
+	return min, max
 }
 
 // Update ratchets priority, timestamp and original timestamp values (among

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -335,21 +335,21 @@ func TestTransactionBumpEpoch(t *testing.T) {
 	}
 }
 
-func TestTransactionTimeBounds(t *testing.T) {
+func TestTransactionInclusiveTimeBounds(t *testing.T) {
 	verify := func(txn Transaction, expMin, expMax hlc.Timestamp) {
-		if min, max := txn.TimeBounds(); min != expMin || max != expMax {
+		if min, max := txn.InclusiveTimeBounds(); min != expMin || max != expMax {
 			t.Errorf("expected (%s-%s); got (%s-%s)", expMin, expMax, min, max)
 		}
 	}
 	origNow := makeTS(1, 1)
 	txn := MakeTransaction("test", Key("a"), 1, enginepb.SERIALIZABLE, origNow, 0)
-	verify(txn, origNow, origNow.Next())
+	verify(txn, origNow, origNow)
 	txn.Timestamp.Forward(makeTS(1, 2))
-	verify(txn, origNow, makeTS(1, 3))
+	verify(txn, origNow, makeTS(1, 2))
 	txn.Restart(1, 1, makeTS(2, 1))
-	verify(txn, origNow, makeTS(2, 2))
+	verify(txn, origNow, makeTS(2, 1))
 	txn.Timestamp.Forward(makeTS(3, 1))
-	verify(txn, origNow, makeTS(3, 2))
+	verify(txn, origNow, makeTS(3, 1))
 }
 
 // TestTransactionObservedTimestamp verifies that txn.{Get,Update}ObservedTimestamp work as

--- a/pkg/storage/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_range.go
@@ -56,7 +56,7 @@ func ResolveIntentRange(
 	// Use a time-bounded iterator as an optimization if indicated.
 	var iterAndBuf engine.IterAndBuf
 	if args.MinTimestamp != (hlc.Timestamp{}) {
-		iter := batch.NewTimeBoundIterator(args.MinTimestamp, args.IntentTxn.Timestamp.Next())
+		iter := batch.NewTimeBoundIterator(args.MinTimestamp, args.IntentTxn.Timestamp)
 		iterAndBuf = engine.GetBufUsingIter(iter)
 	} else {
 		iterAndBuf = engine.GetIterAndBuf(batch)

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -151,7 +151,12 @@ type Reader interface {
 	NewIterator(prefix bool) Iterator
 	// NewTimeBoundIterator is like NewIterator, but the underlying iterator will
 	// efficiently skip over SSTs that contain no MVCC keys in the time range
-	// (start, end].
+	// [start, end].
+	//
+	// Note that time-bound iterators are strictly a performance optimization, and
+	// will frequently return keys outside of the [start, end] time range. If you
+	// must guarantee that you never see a key outside of the time bounds, perform
+	// your own filtering.
 	NewTimeBoundIterator(start, end hlc.Timestamp) Iterator
 }
 

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -739,12 +739,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 		}
 		// Set a high Timestamp to make sure it does not matter. Only
 		// OrigTimestamp (and heartbeat) are used for GC decisions.
-		// Note that we can't simply use hlc.MaxTimestamp because when
-		// we attempt to resolve a range of intents, the method
-		// Transaction.TimeBound() makes a call to hlc.Timestamp.Next()
-		// in order to create a closed interval on the range for a time
-		// bounded iterator to discover the new intents.
-		txn.Timestamp.Forward(hlc.MaxTimestamp.Prev())
+		txn.Timestamp.Forward(hlc.MaxTimestamp)
 		txns[strKey] = *txn
 		for _, addrKey := range []roachpb.Key{baseKey, outsideKey} {
 			key := keys.TransactionKey(addrKey, txn.ID)

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -491,7 +491,7 @@ func (ir *intentResolver) cleanupFinishedTxnIntents(
 	ctx context.Context, txn *roachpb.Transaction, intents []roachpb.Intent, now hlc.Timestamp,
 ) error {
 	// Resolve intents.
-	min, _ := txn.TimeBounds()
+	min, _ := txn.InclusiveTimeBounds()
 	opts := ResolveOptions{Wait: true, Poison: false, MinTimestamp: min}
 	if err := ir.resolveIntents(ctx, intents, opts); err != nil {
 		return errors.Wrapf(err, "failed to resolve intents")

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -487,7 +487,7 @@ func resolveLocalIntents(
 		desc = &mergeTrigger.LeftDesc
 	}
 
-	min, max := txn.TimeBounds()
+	min, max := txn.InclusiveTimeBounds()
 	iter := batch.NewTimeBoundIterator(min, max)
 	iterAndBuf := engine.GetBufUsingIter(iter)
 	defer iterAndBuf.Cleanup()


### PR DESCRIPTION
dfece65 adjusted time-bound iterators to use backwards half-open
intervals, (start, end], as, at the time, the only consumer of the
feature, MVCCIncrementalIterator, used backwards half-open intervals.

This change has proven to be maximally confusing, as other intervals in
the system are typically fully closed [start, end] or forwards half-open
[start, end). When intent resolution was optimized with time-bound
iterators (e510316), the new code erroneously but understandably assumed
that time-bound iterators used forwards half-open intervals. This
off-by-one error could cause major correctness problems: if the upper
bound of an SST exactly matched the start time of a transaction, the
intents in that SST would be invisible to the intent resolver and never
get cleaned up, but the transaction record would get GC'd. At that
point, the intents would become abortable, and the writes from a
committed transaction would get lost.

So, change time-bound iterators to use fully-closed intervals [start,
end]. This effectively prevents off-by-one errors, as even when a more
restrictive interval, like (start, end] or [start, end) is desired,
time-bound iterators will now return too much data instead of too
little. (The consumer has always been required to filter data down to
the desired bounds, since time-bound iterators are only an optimization
and do not guarantee that only data within the provided bounds will be
returned.)

There is a potential performance cost if a scan over (t2, t3] needs to
scan an SST that includes keys in [t1, t2], but this is easily remedied
by transforming scans over (t2, t3] to scans over [t2.Next(), t3].

Writing a targeted test for this is difficult. Our smart compaction
logic makes it hard to create SSTs with specific time bounds to exercise
the bug. Revisit when #21294 is fixed. For now, at least,
TestInitialPartitioning routinely triggers this bug under stress.

Fixes #21539.
Fixes #21538.
Fixes #21526.
Fixes #21514.
Fixes #21501.
Fixes #21500.
Fixes #21494.

Release note: None