### PR TITLE
storage: allow queues to process replicas in parallel, increase splitQueue's concurrency

### DIFF
--- a/pkg/storage/client_raft_log_queue_test.go
+++ b/pkg/storage/client_raft_log_queue_test.go
@@ -21,12 +21,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
@@ -85,28 +82,21 @@ func TestRaftLogQueue(t *testing.T) {
 		}
 	}
 
-	// Sadly, occasionally the queue has a race with the force processing so
-	// this succeeds within will captures those rare cases.
-	var afterTruncationIndex uint64
-	testutils.SucceedsSoon(t, func() error {
-		// Force a truncation check.
-		for _, store := range mtc.stores {
-			store.ForceRaftLogScanAndProcess()
-		}
+	// Force a truncation check.
+	for _, store := range mtc.stores {
+		store.ForceRaftLogScanAndProcess()
+	}
 
-		// Ensure that firstIndex has increased indicating that the log
-		// truncation has occurred.
-		var err error
-		afterTruncationIndex, err = raftLeaderRepl.GetFirstIndex()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if afterTruncationIndex <= originalIndex {
-			return errors.Errorf("raft log has not been truncated yet, afterTruncationIndex:%d originalIndex:%d",
-				afterTruncationIndex, originalIndex)
-		}
-		return nil
-	})
+	// Ensure that firstIndex has increased indicating that the log
+	// truncation has occurred.
+	afterTruncationIndex, err := raftLeaderRepl.GetFirstIndex()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if afterTruncationIndex <= originalIndex {
+		t.Fatalf("raft log has not been truncated yet, afterTruncationIndex:%d originalIndex:%d",
+			afterTruncationIndex, originalIndex)
+	}
 
 	// Force a truncation check again to ensure that attempting to truncate an
 	// already truncated log has no effect. This check, unlike in the last

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -79,7 +79,7 @@ func forceScanAndProcess(s *Store, q *baseQueue) {
 		return true
 	})
 
-	q.DrainQueue(s.cfg.Clock)
+	q.DrainQueue()
 }
 
 // ForceReplicationScanAndProcess iterates over all ranges and

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -79,7 +79,7 @@ func forceScanAndProcess(s *Store, q *baseQueue) {
 		return true
 	})
 
-	q.DrainQueue()
+	q.DrainQueue(s.stopper)
 }
 
 // ForceReplicationScanAndProcess iterates over all ranges and

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -923,17 +923,6 @@ func (bq *baseQueue) removeFromReplicaSetLocked(rangeID roachpb.RangeID) {
 // DrainQueue locks the queue and processes the remaining queued replicas. It
 // processes the replicas in the order they're queued in, one at a time.
 // Exposed for testing only.
-//
-// TODO(nvanbenschoten): this can be addressed now.
-// TODO(bdarnell): this method may race with the call to bq.pop() in
-// the main loop, in which case it does not guarantee that all
-// replicas have been processed by the time it returns. This is most
-// noticeable with ForceReplicaGCScanAndProcess, since the replica GC
-// queue has many event-driven triggers. This should synchronize
-// somehow with processLoop so we wait for anything being handled
-// there to finish too. When that's done, the SucceedsSoon at the end
-// of TestRemoveRangeWithoutGC (and perhaps others) can be replaced
-// with a one-time check.
 func (bq *baseQueue) DrainQueue(stopper *stop.Stopper) {
 	// Lock processing while draining. This prevents the main process
 	// loop from racing with this method and ensures that any replicas

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -18,7 +18,7 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
-	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -54,12 +54,29 @@ type purgatoryError interface {
 	purgatoryErrorMarker() // dummy method for unique interface
 }
 
-// A replicaItem holds a replica and its priority for use with a priority queue.
+// A replicaItem holds a replica and metadata about its queue state and
+// processing state.
 type replicaItem struct {
-	value    roachpb.RangeID
+	value roachpb.RangeID
+
+	// fields used when a replicaItem is enqueued in a priority queue.
 	priority float64
-	// The index is needed by update and is maintained by the heap.Interface methods.
-	index int // The index of the item in the heap.
+	index    int // The index of the item in the heap, maintained by the heap.Interface methods
+
+	// fields used when a replicaItem is processing.
+	processing bool
+	requeue    bool // enqueue again after processing?
+
+	// TODO(nvanbenschoten): we can hang callbacks off here so clients can
+	// register for notifications of processing completion. This can be
+	// used for writes to wait on ongoing splits to create split backpressure.
+}
+
+// setProcessing moves the item from an enqueued state to a processing state.
+func (i *replicaItem) setProcessing() {
+	i.priority = 0
+	i.index = 0
+	i.processing = true
 }
 
 // A priorityQueue implements heap.Interface and holds replicaItems.
@@ -149,7 +166,8 @@ type queueImpl interface {
 
 	// timer returns a duration to wait between processing the next item
 	// from the queue. The duration of the last processing of a replica
-	// is supplied as an argument.
+	// is supplied as an argument. If no replicas have finished processing
+	// yet, this can be 0.
 	timer(time.Duration) time.Duration
 
 	// purgatoryChan returns a channel that is signaled when it's time
@@ -162,6 +180,9 @@ type queueImpl interface {
 type queueConfig struct {
 	// maxSize is the maximum number of replicas to queue.
 	maxSize int
+	// maxConcurrency is the maximum number of replicas that can be processed
+	// concurrently. If not set, defaults to 1.
+	maxConcurrency int
 	// needsLease controls whether this queue requires the range lease to
 	// operate on a replica.
 	needsLease bool
@@ -221,22 +242,18 @@ type baseQueue struct {
 	store  *Store
 	gossip *gossip.Gossip
 	queueConfig
-	incoming chan struct{} // Channel signaled when a new replica is added to the queue.
-	mu       struct {
-		sync.Locker                                  // Protects all variables in the mu struct
-		priorityQ   priorityQueue                    // The priority queue
-		replicas    map[roachpb.RangeID]*replicaItem // Map from RangeID to replicaItem (for updating priority)
-		purgatory   map[roachpb.RangeID]error        // Map of replicas to processing errors
-		stopped     bool
+	incoming   chan struct{} // Channel signaled when a new replica is added to the queue.
+	processSem chan struct{}
+	processDur int64 // accessed atomically
+	mu         struct {
+		syncutil.Mutex                                  // Protects all variables in the mu struct
+		replicas       map[roachpb.RangeID]*replicaItem // Map from RangeID to replicaItem
+		priorityQ      priorityQueue                    // The priority queue
+		purgatory      map[roachpb.RangeID]error        // Map of replicas to processing errors
+		stopped        bool
 		// Some tests in this package disable queues.
 		disabled bool
 	}
-
-	// processMu synchronizes execution of processing for a single queue,
-	// ensuring that we never process more than a single replica at a time. This
-	// is needed because both the main processing loop and the purgatory loop can
-	// process replicas.
-	processMu sync.Locker
 }
 
 // newBaseQueue returns a new instance of baseQueue with the specified
@@ -251,6 +268,9 @@ func newBaseQueue(
 	// Use the default process timeout if none specified.
 	if cfg.processTimeout == 0 {
 		cfg.processTimeout = defaultProcessTimeout
+	}
+	if cfg.maxConcurrency == 0 {
+		cfg.maxConcurrency = 1
 	}
 
 	ambient := store.cfg.AmbientCtx
@@ -269,10 +289,9 @@ func newBaseQueue(
 		gossip:         gossip,
 		queueConfig:    cfg,
 		incoming:       make(chan struct{}, 1),
+		processSem:     make(chan struct{}, cfg.maxConcurrency),
 	}
-	bq.mu.Locker = new(syncutil.Mutex)
 	bq.mu.replicas = map[roachpb.RangeID]*replicaItem{}
-	bq.processMu = new(syncutil.Mutex)
 
 	return &bq
 }
@@ -307,9 +326,26 @@ func (bq *baseQueue) Disabled() bool {
 
 // SetProcessTimeout sets the timeout for processing a replica.
 func (bq *baseQueue) SetProcessTimeout(dur time.Duration) {
-	bq.processMu.Lock()
+	defer bq.lockProcessing()()
 	bq.processTimeout = dur
-	bq.processMu.Unlock()
+}
+
+// lockProcessing locks all processing in the baseQueue. It returns
+// a function to unlock processing.
+func (bq *baseQueue) lockProcessing() func() {
+	semCount := cap(bq.processSem)
+
+	// Drain process semaphore.
+	for i := 0; i < semCount; i++ {
+		bq.processSem <- struct{}{}
+	}
+
+	return func() {
+		// Populate process semaphore.
+		for i := 0; i < semCount; i++ {
+			<-bq.processSem
+		}
+	}
 }
 
 // Start launches a goroutine to process entries in the queue. The
@@ -329,7 +365,7 @@ func (bq *baseQueue) Add(repl *Replica, priority float64) (bool, error) {
 	bq.mu.Lock()
 	defer bq.mu.Unlock()
 	ctx := repl.AnnotateCtx(bq.AnnotateCtx(context.TODO()))
-	return bq.addInternal(ctx, repl.Desc(), true, priority)
+	return bq.addInternalLocked(ctx, repl.Desc(), true, priority)
 }
 
 // MaybeAdd adds the specified replica if bq.shouldQueue specifies it
@@ -386,7 +422,7 @@ func (bq *baseQueue) MaybeAdd(repl *Replica, now hlc.Timestamp) {
 	}
 
 	should, priority := bq.impl.shouldQueue(ctx, now, repl, cfg)
-	if _, err := bq.addInternal(ctx, repl.Desc(), should, priority); !isExpectedQueueError(err) {
+	if _, err := bq.addInternalLocked(ctx, repl.Desc(), should, priority); !isExpectedQueueError(err) {
 		log.Errorf(ctx, "unable to add: %s", err)
 	}
 }
@@ -405,10 +441,10 @@ func (bq *baseQueue) requiresSplit(cfg config.SystemConfig, repl *Replica) bool 
 	return cfg.NeedsSplit(desc.StartKey, desc.EndKey)
 }
 
-// addInternal adds the replica the queue with specified priority. If
+// addInternalLocked adds the replica the queue with specified priority. If
 // the replica is already queued at a lower priority, updates the existing
 // priority. Expects the queue lock to be held by caller.
-func (bq *baseQueue) addInternal(
+func (bq *baseQueue) addInternalLocked(
 	ctx context.Context, desc *roachpb.RangeDescriptor, should bool, priority float64,
 ) (bool, error) {
 	if bq.mu.stopped {
@@ -442,6 +478,17 @@ func (bq *baseQueue) addInternal(
 
 	item, ok := bq.mu.replicas[desc.RangeID]
 	if ok {
+		// Replica is already processing. Mark to be requeued and bump requeue
+		// priority if necessary.
+		if item.processing {
+			wasRequeued := item.requeue
+			item.requeue = true
+			if priority > item.priority {
+				item.priority = priority
+			}
+			return !wasRequeued, nil
+		}
+
 		// Replica has already been added but at a lower priority; update priority.
 		// Don't lower it since the previous queuer may have known more than this
 		// one does.
@@ -458,12 +505,12 @@ func (bq *baseQueue) addInternal(
 		log.Infof(ctx, "adding: priority=%0.3f", priority)
 	}
 	item = &replicaItem{value: desc.RangeID, priority: priority}
-	bq.add(item)
+	bq.addLocked(item)
 
 	// If adding this replica has pushed the queue past its maximum size,
 	// remove the lowest priority element.
 	if pqLen := bq.mu.priorityQ.Len(); pqLen > bq.maxSize {
-		bq.remove(bq.mu.priorityQ[pqLen-1])
+		bq.removeLocked(bq.mu.priorityQ[pqLen-1])
 	}
 	// Signal the processLoop that a replica has been added.
 	select {
@@ -488,7 +535,7 @@ func (bq *baseQueue) MaybeRemove(rangeID roachpb.RangeID) {
 		if log.V(3) {
 			log.Infof(ctx, "%s: removing", item.value)
 		}
-		bq.remove(item)
+		bq.removeLocked(item)
 	}
 }
 
@@ -529,44 +576,65 @@ func (bq *baseQueue) processLoop(stopper *stop.Stopper) {
 				}
 			// Process replicas as the timer expires.
 			case <-nextTime:
+				// Acquire from the process semaphore.
+				bq.processSem <- struct{}{}
+
 				repl := bq.pop()
-				var duration time.Duration
 				if repl != nil {
 					annotatedCtx := repl.AnnotateCtx(ctx)
-					if stopper.RunTask(
+					if stopper.RunAsyncTask(
 						annotatedCtx, fmt.Sprintf("storage.%s: processing replica", bq.name),
 						func(annotatedCtx context.Context) {
+							// Release semaphore when finished processing.
+							defer func() { <-bq.processSem }()
+
 							start := timeutil.Now()
-							if err := bq.processReplica(annotatedCtx, repl); err != nil {
-								// Maybe add failing replica to purgatory if the queue supports it.
-								bq.maybeAddToPurgatory(annotatedCtx, stopper, repl, err)
-							}
-							duration = timeutil.Since(start)
-							if log.V(2) {
-								log.Infof(annotatedCtx, "done %s", duration)
-							}
-							bq.processingNanos.Inc(duration.Nanoseconds())
+							err := bq.processReplica(annotatedCtx, repl)
+
+							duration := timeutil.Since(start)
+							bq.recordProcessDuration(annotatedCtx, duration)
+
+							bq.finishProcessingReplica(annotatedCtx, stopper, repl, err)
 						}) != nil {
+						// Release semaphore on task failure.
+						<-bq.processSem
 						return
 					}
+				} else {
+					// Release semaphore if no replicas were available.
+					<-bq.processSem
 				}
+
 				if bq.Length() == 0 {
 					nextTime = nil
 				} else {
-					nextTime = time.After(bq.impl.timer(duration))
+					// lastDur will be 0 after the first processing attempt.
+					lastDur := bq.lastProcessDuration()
+					nextTime = time.After(bq.impl.timer(lastDur))
 				}
 			}
 		}
 	})
 }
 
+// lastProcessDuration returns the duration of the last processing attempt.
+func (bq *baseQueue) lastProcessDuration() time.Duration {
+	return time.Duration(atomic.LoadInt64(&bq.processDur))
+}
+
+// recordProcessDuration records the duration of a processing run.
+func (bq *baseQueue) recordProcessDuration(ctx context.Context, dur time.Duration) {
+	if log.V(2) {
+		log.Infof(ctx, "done %s", dur)
+	}
+	bq.processingNanos.Inc(dur.Nanoseconds())
+	atomic.StoreInt64(&bq.processDur, int64(dur))
+}
+
 // processReplica processes a single replica. This should not be
 // called externally to the queue. bq.mu.Lock must not be held
 // while calling this method.
 func (bq *baseQueue) processReplica(queueCtx context.Context, repl *Replica) error {
-	bq.processMu.Lock()
-	defer bq.processMu.Unlock()
-
 	// Load the system config if it's needed.
 	var cfg config.SystemConfig
 	var cfgOk bool
@@ -648,29 +716,49 @@ func (bq *baseQueue) processReplica(queueCtx context.Context, repl *Replica) err
 	return nil
 }
 
-// maybeAddToPurgatory possibly adds the specified replica to the
-// purgatory queue, which holds replicas which have failed
+// finishProcessingReplica handles the completion of a replica process attempt.
+// It removes the replica from the replica set and may re-enqueue the replica or
+// add it to purgatory.
+func (bq *baseQueue) finishProcessingReplica(
+	ctx context.Context, stopper *stop.Stopper, repl *Replica, err error,
+) {
+	if err != nil {
+		// Increment failures metric here to capture all error returns from
+		// process().
+		bq.failures.Inc(1)
+	}
+
+	bq.mu.Lock()
+	defer bq.mu.Unlock()
+
+	// Remove item from replica set completely. We may add it
+	// back in down below.
+	item := bq.mu.replicas[repl.RangeID]
+	bq.removeFromReplicaSetLocked(repl.RangeID)
+
+	if item.requeue {
+		_, qErr := bq.addInternalLocked(ctx, repl.Desc(), true /* should */, item.priority)
+		if !isExpectedQueueError(qErr) {
+			log.Errorf(ctx, "unable to requeue: %s", qErr)
+		}
+	} else if err != nil {
+		// Maybe add failing replica to purgatory if the queue supports it.
+		bq.maybeAddToPurgatoryLocked(ctx, stopper, repl, err)
+	}
+}
+
+// maybeAddToPurgatoryLocked possibly adds the specified replica
+// to the purgatory queue, which holds replicas which have failed
 // processing. To be added, the failing error must implement
 // purgatoryError and the queue implementation must have its own
 // mechanism for signaling re-processing of replicas held in
 // purgatory.
-func (bq *baseQueue) maybeAddToPurgatory(
+func (bq *baseQueue) maybeAddToPurgatoryLocked(
 	ctx context.Context, stopper *stop.Stopper, repl *Replica, triggeringErr error,
 ) {
-	// Increment failures metric here to capture all error returns from
-	// process().
-	bq.failures.Inc(1)
-
 	// Check whether the failure is a purgatory error and whether the queue supports it.
 	if _, ok := errors.Cause(triggeringErr).(purgatoryError); !ok || bq.impl.purgatoryChan() == nil {
 		log.Error(ctx, triggeringErr)
-		return
-	}
-	bq.mu.Lock()
-	defer bq.mu.Unlock()
-
-	// First, check whether the replica has already been re-added to queue.
-	if _, ok := bq.mu.replicas[repl.RangeID]; ok {
 		return
 	}
 
@@ -702,32 +790,41 @@ func (bq *baseQueue) maybeAddToPurgatory(
 		for {
 			select {
 			case <-bq.impl.purgatoryChan():
-				// Remove all items from purgatory into a copied slice.
-				bq.mu.Lock()
-				ranges := make([]roachpb.RangeID, 0, len(bq.mu.purgatory))
-				for rangeID := range bq.mu.purgatory {
-					item := bq.mu.replicas[rangeID]
-					ranges = append(ranges, item.value)
-					bq.remove(item)
-				}
-				bq.mu.Unlock()
-				for _, id := range ranges {
-					repl, err := bq.store.GetReplica(id)
-					if err != nil {
-						log.Errorf(ctx, "range %s no longer exists on store: %s", id, err)
-						return
+				func() {
+					// Acquire from the process semaphore, release when done.
+					bq.processSem <- struct{}{}
+					defer func() { <-bq.processSem }()
+
+					// Remove all items from purgatory into a copied slice.
+					bq.mu.Lock()
+					ranges := make([]roachpb.RangeID, 0, len(bq.mu.purgatory))
+					for rangeID := range bq.mu.purgatory {
+						item := bq.mu.replicas[rangeID]
+						item.setProcessing()
+						ranges = append(ranges, item.value)
+						bq.removeFromPurgatoryLocked(item)
 					}
-					annotatedCtx := repl.AnnotateCtx(ctx)
-					if stopper.RunTask(
-						annotatedCtx, fmt.Sprintf("storage.%s: purgatory processing replica", bq.name),
-						func(annotatedCtx context.Context) {
-							if err := bq.processReplica(annotatedCtx, repl); err != nil {
-								bq.maybeAddToPurgatory(annotatedCtx, stopper, repl, err)
-							}
-						}) != nil {
-						return
+					bq.mu.Unlock()
+
+					for _, id := range ranges {
+						repl, err := bq.store.GetReplica(id)
+						if err != nil {
+							log.Errorf(ctx, "range %s no longer exists on store: %s", id, err)
+							continue
+						}
+						annotatedCtx := repl.AnnotateCtx(ctx)
+						if stopper.RunTask(
+							annotatedCtx, fmt.Sprintf("storage.%s: purgatory processing replica", bq.name),
+							func(annotatedCtx context.Context) {
+								err := bq.processReplica(annotatedCtx, repl)
+								bq.finishProcessingReplica(annotatedCtx, stopper, repl, err)
+							}) != nil {
+							return
+						}
 					}
-				}
+				}()
+
+				// Clean up purgatory, if empty.
 				bq.mu.Lock()
 				if len(bq.mu.purgatory) == 0 {
 					log.Infof(ctx, "purgatory is now empty")
@@ -754,50 +851,80 @@ func (bq *baseQueue) maybeAddToPurgatory(
 	})
 }
 
-// pop dequeues the highest priority replica, if any, in the queue. Expects
-// mutex to be locked.
+// pop dequeues the highest priority replica, if any, in the queue. The
+// replicaItem corresponding to the returned Replica will be moved to the
+// "processing" state and should be cleaned up by calling
+// finishProcessingReplica once the Replica has finished processing.
 func (bq *baseQueue) pop() *Replica {
-	var repl *Replica
-	for repl == nil {
-		bq.mu.Lock()
-
+	bq.mu.Lock()
+	for {
 		if bq.mu.priorityQ.Len() == 0 {
 			bq.mu.Unlock()
 			return nil
 		}
 		item := heap.Pop(&bq.mu.priorityQ).(*replicaItem)
+		item.setProcessing()
 		bq.pending.Update(int64(bq.mu.priorityQ.Len()))
-		delete(bq.mu.replicas, item.value)
 		bq.mu.Unlock()
-		repl, _ = bq.store.GetReplica(item.value)
+
+		repl, _ := bq.store.GetReplica(item.value)
+		if repl != nil {
+			return repl
+		}
+
+		// Replica not found, remove from set and try again.
+		bq.mu.Lock()
+		bq.removeFromReplicaSetLocked(item.value)
 	}
-	return repl
 }
 
-// add adds an element to the priority queue. Caller must hold mutex.
-func (bq *baseQueue) add(item *replicaItem) {
+// addLocked adds an element to the priority queue. Caller must hold mutex.
+func (bq *baseQueue) addLocked(item *replicaItem) {
 	heap.Push(&bq.mu.priorityQ, item)
 	bq.pending.Update(int64(bq.mu.priorityQ.Len()))
 	bq.mu.replicas[item.value] = item
 }
 
-// remove removes an element from purgatory (if it's experienced an
+// removeLocked removes an element from purgatory (if it's experienced an
 // error) or from the priority queue by index. Caller must hold mutex.
-func (bq *baseQueue) remove(item *replicaItem) {
-	if _, ok := bq.mu.purgatory[item.value]; ok {
-		delete(bq.mu.purgatory, item.value)
-		bq.purgatory.Update(int64(len(bq.mu.purgatory)))
+func (bq *baseQueue) removeLocked(item *replicaItem) {
+	if item.processing {
+		// The item is processing. We can't intererupt the processing
+		// or remove it from the replica set yet, but we can make sure
+		// it doesn't get requeued.
+		item.requeue = false
 	} else {
-		heap.Remove(&bq.mu.priorityQ, item.index)
-		bq.pending.Update(int64(bq.mu.priorityQ.Len()))
+		if _, ok := bq.mu.purgatory[item.value]; ok {
+			bq.removeFromPurgatoryLocked(item)
+		} else {
+			bq.removeFromQueueLocked(item)
+		}
+		bq.removeFromReplicaSetLocked(item.value)
 	}
-	delete(bq.mu.replicas, item.value)
+}
+
+// Caller must hold mutex.
+func (bq *baseQueue) removeFromPurgatoryLocked(item *replicaItem) {
+	delete(bq.mu.purgatory, item.value)
+	bq.purgatory.Update(int64(len(bq.mu.purgatory)))
+}
+
+// Caller must hold mutex.
+func (bq *baseQueue) removeFromQueueLocked(item *replicaItem) {
+	heap.Remove(&bq.mu.priorityQ, item.index)
+	bq.pending.Update(int64(bq.mu.priorityQ.Len()))
+}
+
+// Caller must hold mutex.
+func (bq *baseQueue) removeFromReplicaSetLocked(rangeID roachpb.RangeID) {
+	delete(bq.mu.replicas, rangeID)
 }
 
 // DrainQueue locks the queue and processes the remaining queued replicas. It
 // processes the replicas in the order they're queued in, one at a time.
 // Exposed for testing only.
 //
+// TODO(nvanbenschoten): this can be addressed now.
 // TODO(bdarnell): this method may race with the call to bq.pop() in
 // the main loop, in which case it does not guarantee that all
 // replicas have been processed by the time it returns. This is most
@@ -807,13 +934,17 @@ func (bq *baseQueue) remove(item *replicaItem) {
 // there to finish too. When that's done, the SucceedsSoon at the end
 // of TestRemoveRangeWithoutGC (and perhaps others) can be replaced
 // with a one-time check.
-func (bq *baseQueue) DrainQueue() {
+func (bq *baseQueue) DrainQueue(stopper *stop.Stopper) {
+	// Lock processing while draining. This prevents the main process
+	// loop from racing with this method and ensures that any replicas
+	// queued up when this method was called will be processed by the
+	// time it returns.
+	defer bq.lockProcessing()()
+
 	ctx := bq.AnnotateCtx(context.TODO())
 	for repl := bq.pop(); repl != nil; repl = bq.pop() {
 		annotatedCtx := repl.AnnotateCtx(ctx)
-		if err := bq.processReplica(annotatedCtx, repl); err != nil {
-			bq.failures.Inc(1)
-			log.Error(annotatedCtx, err)
-		}
+		err := bq.processReplica(annotatedCtx, repl)
+		bq.finishProcessingReplica(annotatedCtx, stopper, repl, err)
 	}
 }

--- a/pkg/storage/queue_test.go
+++ b/pkg/storage/queue_test.go
@@ -337,7 +337,7 @@ func TestBaseQueueProcess(t *testing.T) {
 		},
 	}
 	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{maxSize: 2})
-	bq.Start(tc.Clock(), stopper)
+	bq.Start(stopper)
 
 	bq.MaybeAdd(r1, hlc.Timestamp{})
 	bq.MaybeAdd(r2, hlc.Timestamp{})
@@ -407,9 +407,7 @@ func TestBaseQueueAddRemove(t *testing.T) {
 		},
 	}
 	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{maxSize: 2})
-	mc := hlc.NewManualClock(123)
-	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
-	bq.Start(clock, stopper)
+	bq.Start(stopper)
 
 	bq.MaybeAdd(r, hlc.Timestamp{})
 	bq.MaybeRemove(r.RangeID)
@@ -462,10 +460,7 @@ func TestNeedsSystemConfig(t *testing.T) {
 		maxSize:              1,
 	})
 
-	mc := hlc.NewManualClock(123)
-	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
-	bqNeedsSysCfg.Start(clock, stopper)
-
+	bqNeedsSysCfg.Start(stopper)
 	bqNeedsSysCfg.MaybeAdd(r, hlc.Timestamp{})
 	if queueFnCalled != 0 {
 		t.Fatalf("expected shouldQueueFn not to be called without valid system config, got %d calls", queueFnCalled)
@@ -490,7 +485,7 @@ func TestNeedsSystemConfig(t *testing.T) {
 		acceptsUnsplitRanges: true,
 		maxSize:              1,
 	})
-	bqNoSysCfg.Start(clock, stopper)
+	bqNoSysCfg.Start(stopper)
 	bqNoSysCfg.MaybeAdd(r, hlc.Timestamp{})
 	if queueFnCalled != 1 {
 		t.Fatalf("expected shouldQueueFn to be called even without valid system config, got %d calls", queueFnCalled)
@@ -552,7 +547,7 @@ func TestAcceptsUnsplitRanges(t *testing.T) {
 	}
 
 	bq := makeTestBaseQueue("test", testQueue, s, s.cfg.Gossip, queueConfig{maxSize: 2})
-	bq.Start(s.cfg.Clock, stopper)
+	bq.Start(stopper)
 
 	// Check our config.
 	var sysCfg config.SystemConfig
@@ -667,7 +662,7 @@ func TestBaseQueuePurgatory(t *testing.T) {
 
 	replicaCount := 10
 	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{maxSize: replicaCount})
-	bq.Start(tc.Clock(), stopper)
+	bq.Start(stopper)
 
 	for i := 1; i <= replicaCount; i++ {
 		r := createReplica(tc.store, roachpb.RangeID(i+1000),
@@ -815,7 +810,7 @@ func TestBaseQueueProcessTimeout(t *testing.T) {
 			processTimeout:       time.Millisecond,
 			acceptsUnsplitRanges: true,
 		})
-	bq.Start(tc.Clock(), stopper)
+	bq.Start(stopper)
 	bq.MaybeAdd(r, hlc.Timestamp{})
 
 	if l := bq.Length(); l != 1 {
@@ -871,7 +866,7 @@ func TestBaseQueueTimeMetric(t *testing.T) {
 			processTimeout:       time.Millisecond,
 			acceptsUnsplitRanges: true,
 		})
-	bq.Start(tc.Clock(), stopper)
+	bq.Start(stopper)
 	bq.MaybeAdd(r, hlc.Timestamp{})
 
 	testutils.SucceedsSoon(t, func() error {
@@ -938,9 +933,7 @@ func TestBaseQueueDisable(t *testing.T) {
 		},
 	}
 	bq := makeTestBaseQueue("test", testQueue, tc.store, tc.gossip, queueConfig{maxSize: 2})
-	mc := hlc.NewManualClock(123)
-	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
-	bq.Start(clock, stopper)
+	bq.Start(stopper)
 
 	bq.SetDisabled(true)
 	bq.MaybeAdd(r, hlc.Timestamp{})

--- a/pkg/storage/raft_snapshot_queue.go
+++ b/pkg/storage/raft_snapshot_queue.go
@@ -40,14 +40,11 @@ const (
 // replica up with a snapshot to their range.
 type raftSnapshotQueue struct {
 	*baseQueue
-	clock *hlc.Clock
 }
 
 // newRaftSnapshotQueue returns a new instance of raftSnapshotQueue.
-func newRaftSnapshotQueue(store *Store, g *gossip.Gossip, clock *hlc.Clock) *raftSnapshotQueue {
-	rq := &raftSnapshotQueue{
-		clock: clock,
-	}
+func newRaftSnapshotQueue(store *Store, g *gossip.Gossip) *raftSnapshotQueue {
+	rq := &raftSnapshotQueue{}
 	rq.baseQueue = newBaseQueue(
 		"raftsnapshot", rq, store, g,
 		queueConfig{

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -31,6 +31,11 @@ import (
 const (
 	// splitQueueTimerDuration is the duration between splits of queued ranges.
 	splitQueueTimerDuration = 0 // zero duration to process splits greedily.
+
+	// splits should be relatively isolated, other than requiring expensive
+	// RocksDB scans over part of the splitting range to recompute stats. We
+	// allow a limitted number of splits to be processed at once.
+	splitQueueConcurrency = 4
 )
 
 // splitQueue manages a queue of ranges slated to be split due to size
@@ -49,6 +54,7 @@ func newSplitQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *splitQue
 		"split", sq, store, gossip,
 		queueConfig{
 			maxSize:              defaultQueueMaxSize,
+			maxConcurrency:       splitQueueConcurrency,
 			needsLease:           true,
 			needsSystemConfig:    true,
 			acceptsUnsplitRanges: true,

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -2373,7 +2373,7 @@ type fakeRangeQueue struct {
 	maybeRemovedRngs chan roachpb.RangeID
 }
 
-func (fq *fakeRangeQueue) Start(_ *hlc.Clock, _ *stop.Stopper) {
+func (fq *fakeRangeQueue) Start(_ *stop.Stopper) {
 	// Do nothing
 }
 


### PR DESCRIPTION
Up until this point, `baseQueue` has always made the assumption that only one
replica will be processed at any given time. This has been fine until now, but
there are valid cases where we may want to allow a bounded amount of concurrency
within the queues. An example of this is the `splitQueue`, where we may want to
allow a few replicas to be processed in parallel.

This change adds a `maxConcurrency` option to `queueConfig`. `baseQueue` then
changes to work off a process semaphore instead of the previous `processMu`. The
handling of `processMu` was pretty awkward before, so this change also allows us
to clean up some code, remove race conditions that allowed for poorly specified
behavior, and address a TODO.

One of the auxiliary reasons for prioritizing this change is that until now,
queues have always removed their handle to replicas completely once they began
processing. This meant that it was impossible to determine which replicas were
processing at any given time. It was also impossible to register a callback for
the completion of a processing attempt. Both of these were things I wanted to do
in relation to back-pressuring writes on splits (#21357).

Splits should be relatively isolated, other than requiring expensive RocksDB
scans over part of the splitting range to recompute stats. Because of this, a
later commit allows a limited number of splits to be processed at once. This
prevents slowsplits from stalling all other splits from ever running and also
improves the splitQueue's ability to keep up with heavy load.

Release note: None