### PR TITLE
ui: teach event list about sequence event types

### DIFF
--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -26,6 +26,12 @@ export const ALTER_INDEX = "alter_index";
 export const CREATE_VIEW = "create_view";
 // Recorded when a view is dropped.
 export const DROP_VIEW = "drop_view";
+// Recorded when a sequence is created.
+export const CREATE_SEQUENCE = "create_sequence";
+// Recorded when a sequence is altered.
+export const ALTER_SEQUENCE = "alter_sequence";
+// Recorded when a sequence is dropped.
+export const DROP_SEQUENCE = "drop_sequence";
 // Recorded when an in-progress schema change encounters a problem and is
 // reversed.
 export const REVERSE_SCHEMA_CHANGE = "reverse_schema_change";

--- a/pkg/ui/src/util/events.ts
+++ b/pkg/ui/src/util/events.ts
@@ -17,6 +17,7 @@ export function getEventDescription(e: Event$Properties): string {
     TableName: string,
     User: string,
     ViewName: string,
+    SequenceName: string,
     SettingName: string,
     Value: string,
   } = protobuf.util.isset(e, "info") ? JSON.parse(e.info) : {};
@@ -50,6 +51,12 @@ export function getEventDescription(e: Event$Properties): string {
       return `View Created: User ${info.User} created view ${info.ViewName}`;
     case eventTypes.DROP_VIEW:
       return `View Dropped: User ${info.User} dropped view ${info.ViewName}`;
+    case eventTypes.CREATE_SEQUENCE:
+      return `Sequence Created: User ${info.User} created sequence ${info.SequenceName}`;
+    case eventTypes.ALTER_SEQUENCE:
+      return `Sequence Altered: User ${info.User} altered sequence ${info.SequenceName}`;
+    case eventTypes.DROP_SEQUENCE:
+      return `Sequence Dropped: User ${info.User} dropped sequence ${info.SequenceName}`;
     case eventTypes.REVERSE_SCHEMA_CHANGE:
       return `Schema Change Reversed: Schema change with ID ${info.MutationID} was reversed.`;
     case eventTypes.FINISH_SCHEMA_CHANGE:


### PR DESCRIPTION
Previously: said "unknown event type".
Now:
![screen shot 2018-01-18 at 6 13 22 pm](https://user-images.githubusercontent.com/7341/35126485-975f9c24-fc7b-11e7-83d9-d9be5ddcc643.png)


Fixes #20962

Release note: None