### PR TITLE
sqlmigrations: set system.jobs TTL to 10m

### DIFF
--- a/pkg/ccl/cliccl/cli_test.go
+++ b/pkg/ccl/cliccl/cli_test.go
@@ -171,6 +171,7 @@ func Example_cclzone() {
 	// .meta
 	// db.t.p1
 	// db.t@primary
+	// system.jobs
 	// zone rm db.t@primary
 	// CONFIGURE ZONE 1
 	// zone get db.t.p0
@@ -194,6 +195,7 @@ func Example_cclzone() {
 	// .liveness
 	// .meta
 	// db.t.p1
+	// system.jobs
 	// zone rm db.t.p0
 	// CONFIGURE ZONE 0
 	// zone rm db.t.p1
@@ -202,4 +204,5 @@ func Example_cclzone() {
 	// .default
 	// .liveness
 	// .meta
+	// system.jobs
 }

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -470,6 +470,7 @@ func Example_zone() {
 	// .default
 	// .liveness
 	// .meta
+	// system.jobs
 	// zone set system --file=./testdata/zone_attrs.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 67108864
@@ -482,6 +483,7 @@ func Example_zone() {
 	// .liveness
 	// .meta
 	// system
+	// system.jobs
 	// zone get .liveness
 	// .liveness
 	// range_min_bytes: 1048576
@@ -535,6 +537,7 @@ func Example_zone() {
 	// .default
 	// .liveness
 	// .meta
+	// system.jobs
 	// zone rm .default
 	// pq: cannot remove default zone
 	// zone set .liveness --file=./testdata/zone_range_max_bytes.yaml
@@ -579,6 +582,7 @@ func Example_zone() {
 	// .meta
 	// .system
 	// .timeseries
+	// system.jobs
 	// zone set .default --file=./testdata/zone_range_max_bytes.yaml
 	// range_min_bytes: 1048576
 	// range_max_bytes: 134217728
@@ -618,10 +622,12 @@ func Example_zone() {
 	// zone ls
 	// .default
 	// .timeseries
+	// system.jobs
 	// zone rm .timeseries
 	// CONFIGURE ZONE 1
 	// zone ls
 	// .default
+	// system.jobs
 	// zone rm .liveness
 	// CONFIGURE ZONE 0
 	// zone rm .meta

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -174,6 +174,7 @@ query IT
 SELECT id, cli_specifier FROM crdb_internal.zones ORDER BY id
 ----
 0   .default
+15  system.jobs
 16  .meta
 17  .system
 18  .timeseries

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -154,6 +154,10 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		name:   "remove cluster setting `kv.transaction.max_intents`",
 		workFn: purgeClusterSettingKVTransactionMaxIntents,
 	},
+	{
+		name:   "add default system.jobs zone config",
+		workFn: addDefaultSystemJobsZoneConfig,
+	},
 }
 
 // migrationDescriptor describes a single migration hook that's used to modify
@@ -598,7 +602,7 @@ func addDefaultMetaAndLivenessZoneConfigs(ctx context.Context, r runner) error {
 	defaultTTLSeconds := config.DefaultZoneConfig().GC.TTLSeconds
 
 	// Retrieve the existing .meta zone config.
-	metaZone, err := getZoneConfig(ctx, r, keys.MetaRangesID)
+	metaZone, err := getZoneConfig(ctx, r, "RANGE meta")
 	if err != nil {
 		return err
 	}
@@ -612,7 +616,7 @@ func addDefaultMetaAndLivenessZoneConfigs(ctx context.Context, r runner) error {
 
 	// The liveness range was previously covered by the ".system" zone. Grab the
 	// existing ".system" zone (if any) for modification.
-	livenessZone, err := getZoneConfig(ctx, r, keys.SystemRangesID)
+	livenessZone, err := getZoneConfig(ctx, r, "RANGE system")
 	if err != nil {
 		return err
 	}
@@ -655,11 +659,10 @@ func upsertZoneConfig(ctx context.Context, r runner, id uint32, zone config.Zone
 	return err
 }
 
-func getZoneConfig(ctx context.Context, r runner, id uint32) (config.ZoneConfig, error) {
+func getZoneConfig(ctx context.Context, r runner, stmtFor string) (config.ZoneConfig, error) {
 	stmt := fmt.Sprintf(
-		`SELECT config_proto FROM [EXPERIMENTAL SHOW ZONE CONFIGURATION FOR RANGE %s]`,
-		config.NamedZonesByID[id])
-
+		`SELECT config_proto FROM [EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s]`,
+		stmtFor)
 	session := r.newRootSession(ctx)
 	defer session.Finish(r.sqlExecutor)
 
@@ -671,8 +674,8 @@ func getZoneConfig(ctx context.Context, r runner, id uint32) (config.ZoneConfig,
 		var res sql.StatementResults
 		res, err = r.sqlExecutor.ExecuteStatementsBuffered(session, stmt, nil, 1)
 		if err != nil {
-			log.Warningf(ctx, "failed attempt to retrieve .%s zone config: %s",
-				config.NamedZonesByID[id], err)
+			log.Warningf(ctx, "failed attempt to retrieve %s zone config: %s",
+				stmtFor, err)
 			continue
 		}
 		defer res.Close(ctx)
@@ -696,8 +699,8 @@ func getZoneConfig(ctx context.Context, r runner, id uint32) (config.ZoneConfig,
 		return zone, nil
 	}
 
-	err = fmt.Errorf("failed attempt to retrieve .%s zone config: %v",
-		config.NamedZonesByID[id], err)
+	err = fmt.Errorf("failed attempt to retrieve %s zone config: %v",
+		stmtFor, err)
 	return config.ZoneConfig{}, err
 }
 
@@ -935,4 +938,18 @@ func purgeClusterSettingKVGCBatchSize(ctx context.Context, r runner) error {
 func purgeClusterSettingKVTransactionMaxIntents(ctx context.Context, r runner) error {
 	// This cluster setting has been removed.
 	return runStmtAsRootWithRetry(ctx, r, `DELETE FROM SYSTEM.SETTINGS WHERE name='kv.transaction.max_intents'`)
+}
+
+func addDefaultSystemJobsZoneConfig(ctx context.Context, r runner) error {
+	defaultTTLSeconds := config.DefaultZoneConfig().GC.TTLSeconds
+
+	jobsZone, err := getZoneConfig(ctx, r, "TABLE system.jobs")
+	if err != nil {
+		return err
+	}
+	// Only update the TTL seconds if it is still at the default setting.
+	if jobsZone.GC.TTLSeconds == defaultTTLSeconds {
+		jobsZone.GC.TTLSeconds = 10 * 60 // 10m
+	}
+	return upsertZoneConfig(ctx, r, keys.JobsTableID, jobsZone)
 }

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -673,16 +673,14 @@ CREATE INDEX y ON test.x(x);
 	}
 }
 
-func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	ctx := context.Background()
-
-	mt := makeIsolatedMigrationTest(ctx, t, "add default .meta and .liveness zone configs")
-	defer mt.close(ctx)
+func testZoneConfigMigration(
+	t *testing.T, name string, ids ...uint32,
+) (ctx context.Context, mt isolatedMigrationTest, cleanup func()) {
+	ctx = context.Background()
+	mt = makeIsolatedMigrationTest(ctx, t, name)
 
 	mt.start(t, base.TestServerArgs{})
 
-	ids := []uint32{keys.MetaRangesID, keys.LivenessRangesID}
 	for _, id := range ids {
 		var s string
 		err := mt.sqlDB.DB.QueryRow(`SELECT config FROM system.zones WHERE id = $1`, id).Scan(&s)
@@ -695,93 +693,132 @@ func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
 	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
+	return ctx, mt, func() { mt.close(ctx) }
+}
 
-	checkZoneConfig := func(id int, expected config.ZoneConfig) {
-		t.Helper()
+func checkZoneConfig(t *testing.T, sqlDB *sqlutils.SQLRunner, id int, expected config.ZoneConfig) {
+	t.Helper()
 
-		var s string
-		mt.sqlDB.QueryRow(t, `SELECT config FROM system.zones WHERE id = $1`, id).Scan(&s)
-		var zone config.ZoneConfig
-		if err := protoutil.Unmarshal([]byte(s), &zone); err != nil {
-			t.Fatal(err)
-		}
-		if !reflect.DeepEqual(expected, zone) {
-			t.Fatalf("unexpected .meta zone config: %s", pretty.Diff(expected, zone))
-		}
+	var s string
+	sqlDB.QueryRow(t, `SELECT config FROM system.zones WHERE id = $1`, id).Scan(&s)
+	var zone config.ZoneConfig
+	if err := protoutil.Unmarshal([]byte(s), &zone); err != nil {
+		t.Fatal(err)
 	}
+	if !reflect.DeepEqual(expected, zone) {
+		t.Fatalf("unexpected zone config: %s", pretty.Diff(expected, zone))
+	}
+}
+
+func deleteZoneConfig(t *testing.T, sqlDB *sqlutils.SQLRunner, id int) {
+	sqlDB.Exec(t, `DELETE FROM system.zones WHERE id=$1`, id)
+}
+
+func setZoneConfig(t *testing.T, sqlDB *sqlutils.SQLRunner, id int, zone config.ZoneConfig) {
+	buf, err := protoutil.Marshal(&zone)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.Exec(t, `UPSERT INTO system.zones (id, config) VALUES ($1, $2)`, id, buf)
+}
+
+func TestAddDefaultMetaZoneConfigMigration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx, mt, cleanup := testZoneConfigMigration(t, "add default .meta and .liveness zone configs", keys.MetaRangesID, keys.LivenessRangesID)
+	defer cleanup()
 
 	expectedMeta := config.DefaultZoneConfig()
 	expectedMeta.GC.TTLSeconds = 60 * 60
-	checkZoneConfig(keys.MetaRangesID, expectedMeta)
+	checkZoneConfig(t, mt.sqlDB, keys.MetaRangesID, expectedMeta)
 	expectedLiveness := config.DefaultZoneConfig()
 	expectedLiveness.GC.TTLSeconds = 10 * 60
-	checkZoneConfig(keys.LivenessRangesID, expectedLiveness)
-
-	deleteZoneConfig := func(id int) {
-		mt.sqlDB.Exec(t, `DELETE FROM system.zones WHERE id=$1`, id)
-	}
-
-	setZoneConfig := func(id int, zone config.ZoneConfig) {
-		buf, err := protoutil.Marshal(&zone)
-		if err != nil {
-			t.Fatal(err)
-		}
-		mt.sqlDB.Exec(t, `UPSERT INTO system.zones (id, config) VALUES ($1, $2)`, id, buf)
-	}
+	checkZoneConfig(t, mt.sqlDB, keys.LivenessRangesID, expectedLiveness)
 
 	// Set configs for the .meta and .system zones and clear the zone config for
 	// .liveness.
 	testZone := config.DefaultZoneConfig()
 	testZone.GC.TTLSeconds = 819
-	setZoneConfig(keys.MetaRangesID, testZone)
-	setZoneConfig(keys.SystemRangesID, testZone)
-	deleteZoneConfig(keys.LivenessRangesID)
+	setZoneConfig(t, mt.sqlDB, keys.MetaRangesID, testZone)
+	setZoneConfig(t, mt.sqlDB, keys.SystemRangesID, testZone)
+	deleteZoneConfig(t, mt.sqlDB, keys.LivenessRangesID)
 	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
-	checkZoneConfig(keys.MetaRangesID, testZone)
-	checkZoneConfig(keys.LivenessRangesID, testZone)
-	checkZoneConfig(keys.SystemRangesID, testZone)
+	checkZoneConfig(t, mt.sqlDB, keys.MetaRangesID, testZone)
+	checkZoneConfig(t, mt.sqlDB, keys.LivenessRangesID, testZone)
+	checkZoneConfig(t, mt.sqlDB, keys.SystemRangesID, testZone)
 
 	// Set configs for the .meta and .liveness zones and clear the zone config
 	// for .system.
 	testZone.GC.TTLSeconds = 834
-	setZoneConfig(keys.MetaRangesID, testZone)
-	setZoneConfig(keys.SystemRangesID, testZone)
-	deleteZoneConfig(keys.LivenessRangesID)
+	setZoneConfig(t, mt.sqlDB, keys.MetaRangesID, testZone)
+	setZoneConfig(t, mt.sqlDB, keys.SystemRangesID, testZone)
+	deleteZoneConfig(t, mt.sqlDB, keys.LivenessRangesID)
 	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
-	checkZoneConfig(keys.MetaRangesID, testZone)
-	checkZoneConfig(keys.LivenessRangesID, testZone)
+	checkZoneConfig(t, mt.sqlDB, keys.MetaRangesID, testZone)
+	checkZoneConfig(t, mt.sqlDB, keys.LivenessRangesID, testZone)
 	// NB: The .system zone config still doesn't exist.
 
 	// Verify that we'll update the meta/liveness zone config TTLs by migrating
 	// from the default/system zone configs.
 	testZone.RangeMaxBytes *= 2
 	testZone.GC.TTLSeconds = config.DefaultZoneConfig().GC.TTLSeconds
-	setZoneConfig(keys.RootNamespaceID, testZone)
-	setZoneConfig(keys.SystemRangesID, testZone)
-	deleteZoneConfig(keys.MetaRangesID)
-	deleteZoneConfig(keys.LivenessRangesID)
+	setZoneConfig(t, mt.sqlDB, keys.RootNamespaceID, testZone)
+	setZoneConfig(t, mt.sqlDB, keys.SystemRangesID, testZone)
+	deleteZoneConfig(t, mt.sqlDB, keys.MetaRangesID)
+	deleteZoneConfig(t, mt.sqlDB, keys.LivenessRangesID)
 	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 	testZone.GC.TTLSeconds = 60 * 60
-	checkZoneConfig(keys.MetaRangesID, testZone)
+	checkZoneConfig(t, mt.sqlDB, keys.MetaRangesID, testZone)
 	testZone.GC.TTLSeconds = 10 * 60
-	checkZoneConfig(keys.LivenessRangesID, testZone)
+	checkZoneConfig(t, mt.sqlDB, keys.LivenessRangesID, testZone)
 
 	// Verify that we'll update the meta zone config even if it already exists as
 	// long as it has the default TTL.
 	testZone.RangeMaxBytes = 863
 	testZone.GC.TTLSeconds = config.DefaultZoneConfig().GC.TTLSeconds
-	setZoneConfig(keys.MetaRangesID, testZone)
+	setZoneConfig(t, mt.sqlDB, keys.MetaRangesID, testZone)
 	if err := mt.runMigration(ctx); err != nil {
 		t.Fatal(err)
 	}
 	testZone.GC.TTLSeconds = 60 * 60
-	checkZoneConfig(keys.MetaRangesID, testZone)
+	checkZoneConfig(t, mt.sqlDB, keys.MetaRangesID, testZone)
+}
+
+func TestAddSystemJobsMigration(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx, mt, cleanup := testZoneConfigMigration(t, "add default system.jobs zone config", keys.JobsTableID)
+	defer cleanup()
+
+	expected := config.DefaultZoneConfig()
+	expected.GC.TTLSeconds = 10 * 60
+	checkZoneConfig(t, mt.sqlDB, keys.JobsTableID, expected)
+
+	// Verify we migrate from the .default zone config.
+	testZone := config.DefaultZoneConfig()
+	testZone.RangeMaxBytes = 264
+	setZoneConfig(t, mt.sqlDB, keys.RootNamespaceID, testZone)
+	deleteZoneConfig(t, mt.sqlDB, keys.JobsTableID)
+	if err := mt.runMigration(ctx); err != nil {
+		t.Fatal(err)
+	}
+	testZone.GC.TTLSeconds = 10 * 60
+	checkZoneConfig(t, mt.sqlDB, keys.JobsTableID, testZone)
+
+	// Verify that we'll update even if it already exists as long as it has the
+	// default TTL.
+	testZone.RangeMaxBytes = 863
+	testZone.GC.TTLSeconds = config.DefaultZoneConfig().GC.TTLSeconds
+	setZoneConfig(t, mt.sqlDB, keys.JobsTableID, testZone)
+	if err := mt.runMigration(ctx); err != nil {
+		t.Fatal(err)
+	}
+	testZone.GC.TTLSeconds = 10 * 60
+	checkZoneConfig(t, mt.sqlDB, keys.JobsTableID, testZone)
 }
 
 func TestAdminUserExists(t *testing.T) {


### PR DESCRIPTION
Some jobs have multiple updates per minute, take hours to run,
and have a large payload because they are coordination distributed
progress among nodes. These issues taken together can result in a
single row taking up a large amount of space due MVCC. Shorten the
TTL of the system.jobs table so the old updates are cleaned up. This
should prevent the jobs table from splitting due to progress updates
on a single row, and should prevent a single row from ever getting
excessively large.

Do some refactoring to make some of this reusable.

Release note (performance): prevent the jobs table from growing too
large while updating.

See #21561