### PR TITLE
libroach: clean up includes

### DIFF
--- a/c-deps/libroach/ccl/key_manager.cc
+++ b/c-deps/libroach/ccl/key_manager.cc
@@ -181,8 +181,7 @@ std::unique_ptr<enginepbccl::SecretKey> FileKeyManager::CurrentKey() {
 
 std::unique_ptr<enginepbccl::SecretKey> FileKeyManager::GetKey(const std::string& id) {
   if (active_key_ != nullptr && active_key_->info().key_id() == id) {
-    return std::unique_ptr<enginepbccl::SecretKey>(
-        new enginepbccl::SecretKey(*active_key_.get()));
+    return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*active_key_.get()));
   }
   if (old_key_ != nullptr && old_key_->info().key_id() == id) {
     return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*old_key_.get()));

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -15,7 +15,6 @@
 #include "db.h"
 #include <algorithm>
 #include <chrono>
-#include <google/protobuf/stubs/stringprintf.h>
 #include <mutex>
 #include <rocksdb/cache.h>
 #include <rocksdb/db.h>
@@ -30,6 +29,7 @@
 #include <rocksdb/statistics.h>
 #include <rocksdb/table.h>
 #include <rocksdb/utilities/write_batch_with_index.h>
+#include <stdarg.h>
 #include "encoding.h"
 #include "env_switching.h"
 #include "eventlistener.h"

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -3041,7 +3041,7 @@ template <bool reverse> class mvccScanner {
 
   // iterPeekPrev "peeks" at the previous key before the current
   // iterator position.
-  bool iterPeekPrev(rocksdb::Slice *peeked_key) {
+  bool iterPeekPrev(rocksdb::Slice* peeked_key) {
     if (!peeked_) {
       peeked_ = true;
       // We need to save a copy of the current iterator key and value

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -259,11 +259,10 @@ typedef struct {
   DBTimestamp uncertainty_timestamp;
 } DBScanResults;
 
-DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp,
-                      DBTxn txn, bool consistent);
-DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end,
-                       DBTimestamp timestamp, int64_t max_keys,
-                       DBTxn txn, bool consistent, bool reverse);
+DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
+                      bool consistent);
+DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
+                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse);
 
 // DBStatsResult contains various runtime stats for RocksDB.
 typedef struct {


### PR DESCRIPTION
The stringprintf import has the unappealing side effect that it confuses
VSCode's IntelliSense into believing that va_args is defined in

`c-deps/protobuf/src/google/protobuf/stubs/stringprintf.cc`

```
// Define va_copy for MSVC. This is a hack, assuming va_list is simply a
// pointer into the stack and is safe to copy.
```

(which is not reasonable seeing that this definition is sufficiently
guarded).

Since it's not needed in `db.cc`, remove it.

Release note: None