### PR TITLE
githooks: enhance the release note linter.

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -1,11 +1,26 @@
-#!/bin/sh
+#!/usr/bin/env bash
+#
+# -u: we want the variables to be properly assigned.
+# -o pipefail: we want to test the result of pipes.
+# No -e because we have failing commands and that's OK.
+set -uo pipefail
 
-red=$(tput setaf 1 2>/dev/null)
-reset=$(tput sgr0 2>/dev/null)
+# Support both terminfo and termcap.
+# We want to check whether stderr is a terminal (to enable
+# printing colors). We want this test to work even if stdin is
+# redirected (e.g. when run from git commit) or stdout is
+# redirected (e.g. in the var assignments below).
+red=$([ -t 2 ] && { tput setaf 1 || tput AF 1; } 2>/dev/null)
+reset=$([ -t 2 ] && { tput sgr0 || tput me; } 2>/dev/null)
+warn() {
+    echo >&2
+    echo "${red}$*${reset}" >&2
+}
+
+# First lint test: give a friendly reminder on long lines.
 
 if grep -qE '.{80,}' "$1"; then
-    echo >&2
-    echo "${red}Long line(s) detected:${reset}" >&2
+    warn "Long line(s) detected:"
     grep -E ".{80,}" "$1" | sed -e 's/^/   /g' >&2
     echo >&2
     echo "Please amend and wrap long lines." >&2
@@ -13,9 +28,112 @@ if grep -qE '.{80,}' "$1"; then
     echo >&2
 fi
 
-if ! grep -qE '^Release note( \([^)]+\))?: ' "$1" ; then
-    echo >&2
-    echo "${red}Warning: no release note specified!${reset}" >&2
-    echo "Please amend and add a 'Release note:' line." >&2
-    echo >&2
+# Lint the release notes.
+#
+# It's OK to have multiple entries per commit
+# (e.g. changes in different categories). But that means we need to
+# extract them separately for analysis.
+#
+saveIFS=$IFS
+IFS='
+'
+notes=($(grep -iE '^release note' "$1"))
+IFS=$saveIFS
+
+
+informed=
+inform() {
+    if [ -z "$informed" ]; then
+        info=${rnote:0:40}
+        if [ "$info" != "$rnote" ]; then info="$info..."; fi
+        warn "Warning: malformed release note entry: $info"
+    fi
+    informed=1
+}
+hint() {
+    inform
+    echo "- $*" >&2
+}
+
+if [ 0 = ${#notes[*]} ]; then
+    warn "No release note specified."
+    echo "Try: 'Release note (...): ...'" >&2
+else
+    for rnote in "${notes[@]}"; do
+        informed=
+        if echo "$rnote" | grep -qiE '^release note' && ! echo "$rnote" | grep -qE '^Release note'; then
+            hint "case matters! Try '${rnote:0:12}' -> 'Release note'"
+        fi
+        if echo "$rnote" | grep -qiE '^release notes'; then
+            hint "singular please. Use multiple entries if there are multiple notes. Try '${rnote:0:13}' -> 'Release note'"
+        fi
+        if echo "$rnote" | grep -qiE '^release notes? *: *\('; then
+            entered=$(echo "$rnote" | cut -d')' -f1)\); entered=${entered:0:40}
+            cat=$(echo "$rnote" | cut -d'(' -f2 | cut -d')' -f1)
+            hint "place the category before the colon. Try '$entered' -> 'Release note ($cat):'"
+        fi
+        if echo "$rnote" | grep -qiE '^release notes? *: *[^ ]* *:'; then
+            cat=$(echo "$rnote" | sed -e 's/^[^:]*: *//g;s/ *:.*$//g')
+            entered=$(echo "$rnote" | cut -d: -f1-2)
+            hint "place category within parentheses. Try '$entered:' -> 'Release note ($cat):'"
+        fi
+        if echo "$rnote" | grep -qiE '^release notes?[^:]*: *none' && ! echo "$rnote" | grep -qE '^Release note: [nN]one'; then
+            entered=$(echo "$rnote" | sed -e 's/none.*/none/ig')
+            hint "for no release notes use 'none' with no category. Try '$entered' -> 'Release note: none'"
+        fi
+        if ! echo "$rnote" | grep -qiE '^release notes? *: *none' && echo "$rnote" | grep -qiE '^release notes? *: *[^( ]'; then
+            entered=$(echo "$rnote" | cut -d: -f2-); entered=${entered:0:40}
+            hint "category missing (can only be omitted if note is 'none'). Try 'Release note (category):$entered'"
+        fi
+        if echo "$rnote" | grep -qiE '^release notes?[^:]*:([^ ]|   *)' || \
+                echo "$rnote" | grep -qiE '^release notes?(|  +)\(' || \
+                echo "$rnote" | grep -qiE '^release notes? *\( +' || \
+                echo "$rnote" | grep -qiE '^release notes? *\( *[^)]* +\)' ; then
+            entered=${rnote:0:40}
+            body=$(echo "$rnote"| cut -d: -f2-|cut -c1-40|sed -e 's/^ *//g')
+            cat=$(echo "$rnote" | cut -d'(' -f2 |cut -d')' -f1|sed -e 's/^ *//g;s/ *$//g')
+            if test -z "$cat"; then cat=...; fi
+            hint "some space problem. Try '$entered' -> 'Release note ($cat): $body'"
+        fi
+        # Now prune the category
+        if echo "$rnote" | grep -qiE '^release notes? *\([^)]*\)'; then
+            cat=$(echo "$rnote" | cut -d'(' -f2|cut -d')' -f1|sed -e 's/^ *//g;s/ *$//g')
+            lower=$(echo "$cat"|tr A-Z a-z)
+            if [ "$cat" != "$lower" ]; then
+                hint "categories in lowercase. Try 'Release note ($cat)' -> 'Release note ($lower)'"
+            fi
+            if echo "$rnote" | grep -qiE '^release notes? *\([^)/]*/'; then
+                repl=$(echo "$lower"|sed -e 's| */ *|, |g')
+                hint "use commas to separate categories. Try '($lower)' -> '($repl)'"
+                lower=$repl
+            fi
+            saveIFS=$IFS
+            IFS='
+'
+            cats=($(echo "$lower" | tr ',' '\n' | sed -e 's/^ *//g'))
+            IFS=$saveIFS
+            for lcat in "${cats[@]}"; do
+                case $lcat in
+                    "cli change") ;;
+                    "sql change") ;;
+                    "admin ui change") ;;
+                    "general change") ;;
+                    "build change") ;;
+                    "enterprise change") ;;
+                    "backward-incompatible change") ;;
+                    "performance improvement") ;;
+                    "bug fix") ;;
+                    bugfix)
+                        hint "Try 'Release note (bugfix)' -> 'Release note (bug fix)'" ;;
+                    sql*)
+                        hint "Try 'Release note ($lcat)' -> 'Release note (sql change)'" ;;
+                    "backwards-incompatible"*|"backward incompatible"*)
+                        hint "Try '$lcat' -> 'backward-incompatible change'" ;;
+                    *) hint "unknown category '$lcat'" ;;
+                esac
+            done
+        fi
+    done
 fi
+echo >&2
+


### PR DESCRIPTION
The linter supports multiple release note entries per commit message
and will lint them separately.

With the following commit message:

```
release note: foo
Release notes: sql: foo
release note: (bug fix): blix
release note: nOne
Release note (bugfix): nOne
Release note: bug fix
Release note  (bug fix): blix
Release note(bug fix): blix
Release note (bug fix):  blix
Release note (bug fix):blix
Release note (bug fix ): blix
Release note ( bug fix): blix
Release note (Bug fix): blix
Release note (unknown): blix
Release note (bug fix / general change): blix
```

The linter now complains:

```
Warning: malformed release note entry: release note: foo
- case matters! Try 'release note' -> 'Release note'
- category missing (can only be omitted if note is 'none'). Try 'Release note (category): foo'

Warning: malformed release note entry: Release notes: sql: foo
- singular please. Use multiple entries if there are multiple notes. Try 'Release notes' -> 'Release note'
- place category within parentheses. Try 'Release notes: sql:' -> 'Release note (sql):'
- category missing (can only be omitted if note is 'none'). Try 'Release note (category): sql: foo'

Warning: malformed release note entry: release note: (bug fix): blix
- case matters! Try 'release note' -> 'Release note'
- place the category before the colon. Try 'release note: (bug fix)' -> 'Release note (bug fix):'

Warning: malformed release note entry: release note: nOne
- case matters! Try 'release note' -> 'Release note'
- for no release notes use 'none' with no category. Try 'release note: none' -> 'Release note: none'

Warning: malformed release note entry: Release note (bugfix): nOne
- for no release notes use 'none' with no category. Try 'Release note (bugfix): none' -> 'Release note: none'
- Try 'Release note (bugfix)' -> 'Release note (bug fix)'

Warning: malformed release note entry: Release note: bug fix
- category missing (can only be omitted if note is 'none'). Try 'Release note (category): bug fix'

Warning: malformed release note entry: Release note  (bug fix): blix
- some space problem. Try 'Release note  (bug fix): blix' -> 'Release note (bug fix): blix'

Warning: malformed release note entry: Release note(bug fix): blix
- some space problem. Try 'Release note(bug fix): blix' -> 'Release note (bug fix): blix'

Warning: malformed release note entry: Release note (bug fix):  blix
- some space problem. Try 'Release note (bug fix):  blix' -> 'Release note (bug fix): blix'

Warning: malformed release note entry: Release note (bug fix):blix
- some space problem. Try 'Release note (bug fix):blix' -> 'Release note (bug fix): blix'

Warning: malformed release note entry: Release note (bug fix ): blix
- some space problem. Try 'Release note (bug fix ): blix' -> 'Release note (bug fix): blix'

Warning: malformed release note entry: Release note ( bug fix): blix
- some space problem. Try 'Release note ( bug fix): blix' -> 'Release note (bug fix): blix'

Warning: malformed release note entry: Release note (Bug fix): blix
- categories in lowercase. Try 'Release note (Bug fix)' -> 'Release note (bug fix)'

Warning: malformed release note entry: Release note (unknown): blix
- unknown category 'unknown'

Warning: malformed release note entry: Release note (bug fix / general change):...
- use commas to separate categories. Try '(bug fix / general change)' -> '(bug fix, general change)'
```

Release note: None