### PR TITLE
client: remove the redundant roachpb.Transaction from client.Txn

### DIFF
--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -867,7 +867,10 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 		func(ctx context.Context, txn *client.Txn, _ *client.TxnExecOptions) error {
 			// Set a deadline, then set a higher commit timestamp for the txn.
 			txn.UpdateDeadlineMaybe(ctx, s.Clock().Now())
-			txn.Proto().Timestamp.Forward(s.Clock().Now())
+			// This is a big hack.
+			txn.Sender().SetTxn(func(proto *roachpb.Transaction) {
+				proto.Timestamp.Forward(s.Clock().Now())
+			})
 			_, err := txn.Get(ctx, "k")
 			return err
 		}); !testutils.IsError(err, "txn aborted") {

--- a/pkg/internal/client/db_test.go
+++ b/pkg/internal/client/db_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -345,7 +346,9 @@ func TestDebugName(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		txn.Proto().ID = uuid
+		txn.Sender().SetTxn(func(proto *roachpb.Transaction) {
+			proto.ID = uuid
+		})
 
 		expected := fmt.Sprintf("unnamed (id: %s)", id)
 		if txn.DebugName() != expected {

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -799,7 +799,7 @@ func TestUpdateDeadlineMaybe(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	mc := hlc.NewManualClock(1)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
-	db := NewDB(TxnSenderFactoryFunc(func(_ TxnType) TxnSender { return nil }), clock)
+	db := NewDB(TxnSenderFactoryFunc(func(_ TxnType) TxnSender { return TxnSenderFunc(nil) }), clock)
 	txn := NewTxn(db, 0 /* gatewayNodeID */, RootTxn)
 
 	if txn.deadline != nil {

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -249,6 +249,20 @@ func (tcf *TxnCoordSenderFactory) New(typ client.TxnType) client.TxnSender {
 	}
 }
 
+// GetTxn is part of the TxnSender interface.
+func (tc *TxnCoordSender) GetTxn() roachpb.Transaction {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	return tc.mu.meta.Txn.Clone()
+}
+
+// SetTxn is part of the TxnSender interface.
+func (tc *TxnCoordSender) SetTxn(f func(txn *roachpb.Transaction)) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	f(&tc.mu.meta.Txn)
+}
+
 // GetMeta is part of the client.TxnSender interface.
 func (tc *TxnCoordSender) GetMeta() roachpb.TxnCoordMeta {
 	tc.mu.Lock()

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -249,15 +249,8 @@ func (tcf *TxnCoordSenderFactory) New(typ client.TxnType) client.TxnSender {
 	}
 }
 
-// GetTxn is part of the TxnSender interface.
-func (tc *TxnCoordSender) GetTxn() roachpb.Transaction {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-	return tc.mu.meta.Txn.Clone()
-}
-
-// SetTxn is part of the TxnSender interface.
-func (tc *TxnCoordSender) SetTxn(f func(txn *roachpb.Transaction)) {
+// WithTxn is part of the TxnSender interface.
+func (tc *TxnCoordSender) WithTxn(f func(txn *roachpb.Transaction)) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 	f(&tc.mu.meta.Txn)

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -226,7 +226,9 @@ func TestTxnCoordSenderBeginTransactionMinPriority(t *testing.T) {
 	// Put request will create a new transaction.
 	key := roachpb.Key("key")
 	txn.InternalSetPriority(10)
-	txn.Proto().Priority = 11
+	txn.Sender().SetTxn(func(proto *roachpb.Transaction) {
+		proto.Priority = 11
+	})
 	if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Now we instead reuse the `TxnCoordSender`'s `roachpb.Transaction`

Release note: None