### PR TITLE
sql: initialize the InternalExecutor more fully

### DIFF
--- a/pkg/ccl/sqlccl/role.go
+++ b/pkg/ccl/sqlccl/role.go
@@ -157,7 +157,7 @@ func grantRolePlanHook(
 		memberStmt += ` DO NOTHING`
 	}
 
-	internalExecutor := sql.InternalExecutor{LeaseManager: p.LeaseMgr()}
+	internalExecutor := sql.InternalExecutor{ExecCfg: p.ExecCfg()}
 	for _, r := range grant.Roles {
 		for _, m := range grant.Members {
 			_, err := internalExecutor.ExecuteStatementInTransaction(
@@ -235,7 +235,7 @@ func revokeRolePlanHook(
 		memberStmt = `DELETE FROM system.role_members WHERE "role" = $1 AND "member" = $2`
 	}
 
-	internalExecutor := sql.InternalExecutor{LeaseManager: p.LeaseMgr()}
+	internalExecutor := sql.InternalExecutor{ExecCfg: p.ExecCfg()}
 	for _, r := range revoke.Roles {
 		for _, m := range revoke.Members {
 			if string(r) == sqlbase.AdminRole && string(m) == security.RootUser {

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -57,18 +57,16 @@ var webSessionTimeout = settings.RegisterNonNegativeDurationSetting(
 
 type authenticationServer struct {
 	server     *Server
-	executor   sql.InternalExecutor
+	executor   *sql.InternalExecutor
 	memMetrics *sql.MemoryMetrics
 }
 
 // newAuthenticationServer allocates and returns a new REST server for
 // authentication APIs.
-func newAuthenticationServer(s *Server) *authenticationServer {
+func newAuthenticationServer(s *Server, ie *sql.InternalExecutor) *authenticationServer {
 	return &authenticationServer{
-		server: s,
-		executor: sql.InternalExecutor{
-			LeaseManager: s.leaseMgr,
-		},
+		server:     s,
+		executor:   ie,
 		memMetrics: &s.adminMemMetrics,
 	}
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -254,15 +254,23 @@ func (e *duplicateBootstrapError) Error() string {
 }
 
 // NewNode returns a new instance of Node.
+//
+// execCfg can be nil to help bootstrapping of a Server (the Node is created
+// before the ExecutorConfig is initialized). In that case, InitLogger() needs
+// to be called before the Node is used.
 func NewNode(
 	cfg storage.StoreConfig,
 	recorder *status.MetricsRecorder,
 	reg *metric.Registry,
 	stopper *stop.Stopper,
 	txnMetrics kv.TxnMetrics,
-	eventLogger sql.EventLogger,
+	execCfg *sql.ExecutorConfig,
 	clusterID *base.ClusterIDContainer,
 ) *Node {
+	var eventLogger sql.EventLogger
+	if execCfg != nil {
+		eventLogger = sql.MakeEventLogger(execCfg)
+	}
 	n := &Node{
 		storeCfg:    cfg,
 		stopper:     stopper,
@@ -275,6 +283,11 @@ func NewNode(
 	}
 	n.storesServer = storage.MakeServer(&n.Descriptor, n.stores)
 	return n
+}
+
+// InitLogger needs to be called if a nil execCfg was passed to NewNode().
+func (n *Node) InitLogger(execCfg *sql.ExecutorConfig) {
+	n.eventLogger = sql.MakeEventLogger(execCfg)
 }
 
 // String implements fmt.Stringer.

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -118,7 +117,7 @@ func createTestNode(
 	)
 	metricsRecorder := status.NewMetricsRecorder(cfg.Clock, cfg.NodeLiveness, nodeRPCContext, cfg.Gossip, st)
 	node := NewNode(cfg, metricsRecorder, metric.NewRegistry(), stopper,
-		kv.MakeTxnMetrics(metric.TestSampleInterval), sql.MakeEventLogger(nil),
+		kv.MakeTxnMetrics(metric.TestSampleInterval), nil, /* execCfg */
 		&nodeRPCContext.ClusterID)
 	roachpb.RegisterInternalServer(grpcServer, node)
 	ln, err := netutil.ListenAndServeGRPC(stopper, grpcServer, addr)

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -545,7 +545,7 @@ func (ts *TestServer) Executor() interface{} {
 
 // InternalExecutor is part of TestServerInterface.
 func (ts *TestServer) InternalExecutor() interface{} {
-	return sql.InternalExecutor{LeaseManager: ts.leaseMgr}
+	return &sql.InternalExecutor{ExecCfg: ts.execCfg}
 }
 
 // GetNode exposes the Server's Node.

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -71,8 +71,11 @@ func (n *alterIndexNode) startExec(params runParams) error {
 				&partitioning,
 			)
 			err = deleteRemovedPartitionZoneConfigs(
-				params.ctx, params.p.txn, params.p.ExecCfg().Settings, params.p.ExecCfg().LeaseManager,
-				n.tableDesc, &n.tableDesc.PrimaryIndex, &n.tableDesc.PrimaryIndex.Partitioning, &partitioning)
+				params.ctx, params.p.txn,
+				n.tableDesc, &n.tableDesc.PrimaryIndex,
+				&n.tableDesc.PrimaryIndex.Partitioning, &partitioning,
+				params.extendedEvalCtx.ExecCfg,
+			)
 			if err != nil {
 				return err
 			}
@@ -106,7 +109,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 	// Record this index alteration in the event log. This is an auditable log
 	// event and is recorded in the same transaction as the table descriptor
 	// update.
-	if err := MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+	if err := MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		params.ctx,
 		params.p.txn,
 		EventLogAlterIndex,

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -67,7 +67,7 @@ func (n *alterSequenceNode) startExec(params runParams) error {
 	// Record this sequence alteration in the event log. This is an auditable log
 	// event and is recorded in the same transaction as the table descriptor
 	// update.
-	if err := MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+	if err := MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		params.ctx,
 		params.p.txn,
 		EventLogAlterSequence,

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -484,8 +484,10 @@ func (n *alterTableNode) startExec(params runParams) error {
 				&partitioning,
 			)
 			err = deleteRemovedPartitionZoneConfigs(
-				params.ctx, params.p.txn, params.p.ExecCfg().Settings, params.p.ExecCfg().LeaseManager,
-				n.tableDesc, &n.tableDesc.PrimaryIndex, &n.tableDesc.PrimaryIndex.Partitioning, &partitioning)
+				params.ctx, params.p.txn,
+				n.tableDesc, &n.tableDesc.PrimaryIndex, &n.tableDesc.PrimaryIndex.Partitioning,
+				&partitioning, params.extendedEvalCtx.ExecCfg,
+			)
 			if err != nil {
 				return err
 			}
@@ -529,7 +531,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 	// Record this table alteration in the event log. This is an auditable log
 	// event and is recorded in the same transaction as the table descriptor
 	// update.
-	if err := MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+	if err := MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		params.ctx,
 		params.p.txn,
 		EventLogAlterTable,

--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -73,7 +73,7 @@ func (n *alterUserSetPasswordNode) startExec(params runParams) error {
 		return errors.Errorf("user %s cannot use password authentication", security.RootUser)
 	}
 
-	internalExecutor := InternalExecutor{LeaseManager: params.p.LeaseMgr()}
+	internalExecutor := InternalExecutor{ExecCfg: params.extendedEvalCtx.ExecCfg}
 	n.run.rowsAffected, err = internalExecutor.ExecuteStatementInTransaction(
 		params.ctx,
 		"create-user",

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -278,7 +278,7 @@ func scrubStmtStatKey(vt VirtualTabler, key string) (string, bool) {
 // scrubbed will be omitted from the returned map.
 func (e *Executor) GetScrubbedStmtStats() []roachpb.CollectedStatementStatistics {
 	var ret []roachpb.CollectedStatementStatistics
-	vt := e.virtualSchemas
+	vt := e.cfg.VirtualSchemas
 	e.sqlStats.Lock()
 	for appName, a := range e.sqlStats.apps {
 		if cap(ret) == 0 {
@@ -288,7 +288,7 @@ func (e *Executor) GetScrubbedStmtStats() []roachpb.CollectedStatementStatistics
 		hashedApp := HashAppName(appName)
 		a.Lock()
 		for q, stats := range a.stmts {
-			scrubbed, ok := scrubStmtStatKey(&vt, q.stmt)
+			scrubbed, ok := scrubStmtStatKey(vt, q.stmt)
 			if ok {
 				k := roachpb.StatementStatisticsKey{
 					Query:   scrubbed,

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -101,7 +101,7 @@ func (p *planner) MemberOfWithAdminOption(
 
 	lookupRolesStmt := `SELECT "role", "isAdmin" FROM system.role_members WHERE "member" = $1`
 
-	internalExecutor := InternalExecutor{LeaseManager: p.LeaseMgr()}
+	internalExecutor := InternalExecutor{ExecCfg: p.ExecCfg()}
 
 	for len(toVisit) > 0 {
 		// Pop first element.

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -233,7 +233,7 @@ func (sc *SchemaChanger) removeIndexZoneConfigs(
 			zone.DeleteIndexSubzones(uint32(indexDesc.ID))
 		}
 
-		_, err = writeZoneConfig(ctx, txn, sc.settings, sc.leaseMgr, sc.tableID, tableDesc, zone)
+		_, err = writeZoneConfig(ctx, txn, sc.tableID, tableDesc, zone, sc.execCfg)
 		if sqlbase.IsCCLRequiredError(err) {
 			return sqlbase.NewCCLRequiredError(fmt.Errorf("schema change requires a CCL binary "+
 				"because table %q has at least one remaining index or partition with a zone config",

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -82,7 +82,7 @@ func (n *createDatabaseNode) startExec(params runParams) error {
 	if created {
 		// Log Create Database event. This is an auditable log event and is
 		// recorded in the same transaction as the table descriptor update.
-		if err := MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+		if err := MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 			params.ctx,
 			params.p.txn,
 			EventLogCreateDatabase,

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -129,7 +129,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 	// Record index creation in the event log. This is an auditable log
 	// event and is recorded in the same transaction as the table descriptor
 	// update.
-	if err := MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+	if err := MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		params.ctx,
 		params.p.txn,
 		EventLogCreateIndex,

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -102,7 +102,7 @@ func (n *createSequenceNode) startExec(params runParams) error {
 
 	// Log Create Sequence event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
-	return MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		params.ctx,
 		params.p.txn,
 		EventLogCreateSequence,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -175,7 +175,7 @@ func (n *createTableNode) startExec(params runParams) error {
 
 	// Log Create Table event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
-	if err := MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+	if err := MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		params.ctx,
 		params.p.txn,
 		EventLogCreateTable,
@@ -815,6 +815,16 @@ func makeTableDescIfAs(
 }
 
 // MakeTableDesc creates a table descriptor from a CreateTable statement.
+//
+// txn and vt can be nil if the table to be created does not contain references
+// to other tables (e.g. foreign keys or interleaving). This is useful at
+// bootstrap when creating descriptors for virtual tables.
+//
+// evalCtx can be nil if the table to be created has no default expression for
+// any of the columns and no partitioning expression.
+//
+// semaCtx can be nil if the table to be created has no default expression on
+// any of the columns and no check constraints.
 func MakeTableDesc(
 	ctx context.Context,
 	txn *client.Txn,

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -81,7 +81,7 @@ func (n *CreateUserNode) startExec(params runParams) error {
 		opName = "create-user"
 	}
 
-	internalExecutor := InternalExecutor{LeaseManager: params.p.LeaseMgr()}
+	internalExecutor := InternalExecutor{ExecCfg: params.extendedEvalCtx.ExecCfg}
 	n.run.rowsAffected, err = internalExecutor.ExecuteStatementInTransaction(
 		params.ctx,
 		opName,

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -181,7 +181,7 @@ func (n *createViewNode) startExec(params runParams) error {
 
 	// Log Create View event. This is an auditable log event and is
 	// recorded in the same transaction as the table descriptor update.
-	return MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		params.ctx,
 		params.p.txn,
 		EventLogCreateView,

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -168,7 +168,7 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 
 	// Log Drop Database event. This is an auditable log event and is recorded
 	// in the same transaction as the table descriptor update.
-	return MakeEventLogger(p.LeaseMgr()).InsertEventRecord(
+	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		ctx,
 		p.txn,
 		EventLogDropDatabase,

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -223,7 +223,7 @@ func (p *planner) dropIndexByName(
 	// Record index drop in the event log. This is an auditable log event
 	// and is recorded in the same transaction as the table descriptor
 	// update.
-	if err := MakeEventLogger(p.LeaseMgr()).InsertEventRecord(
+	if err := MakeEventLogger(p.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		ctx,
 		p.txn,
 		EventLogDropIndex,

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -79,7 +79,7 @@ func (n *dropSequenceNode) startExec(params runParams) error {
 		// Log a Drop Sequence event for this table. This is an auditable log event
 		// and is recorded in the same transaction as the table descriptor
 		// update.
-		if err := MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+		if err := MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 			ctx,
 			params.p.txn,
 			EventLogDropSequence,

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -117,7 +117,7 @@ func (n *dropTableNode) startExec(params runParams) error {
 		// Log a Drop Table event for this table. This is an auditable log event
 		// and is recorded in the same transaction as the table descriptor
 		// update.
-		if err := MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+		if err := MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 			ctx,
 			params.p.txn,
 			EventLogDropTable,

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -158,7 +158,7 @@ func (n *DropUserNode) startExec(params runParams) error {
 			return errors.Errorf("user %s cannot be dropped", security.RootUser)
 		}
 
-		internalExecutor := InternalExecutor{LeaseManager: params.p.LeaseMgr()}
+		internalExecutor := InternalExecutor{ExecCfg: params.extendedEvalCtx.ExecCfg}
 		rowsAffected, err := internalExecutor.ExecuteStatementInTransaction(
 			params.ctx,
 			"drop-user",

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -99,7 +99,7 @@ func (n *dropViewNode) startExec(params runParams) error {
 		// Log a Drop View event for this table. This is an auditable log event
 		// and is recorded in the same transaction as the table descriptor
 		// update.
-		if err := MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+		if err := MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 			ctx,
 			params.p.txn,
 			EventLogDropView,

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -93,11 +93,10 @@ type EventLogger struct {
 	InternalExecutor
 }
 
-// MakeEventLogger constructs a new EventLogger. A LeaseManager is required in
-// order to correctly execute SQL statements.
-func MakeEventLogger(leaseMgr *LeaseManager) EventLogger {
+// MakeEventLogger constructs a new EventLogger.
+func MakeEventLogger(execCfg *ExecutorConfig) EventLogger {
 	return EventLogger{InternalExecutor{
-		LeaseManager: leaseMgr,
+		ExecCfg: execCfg,
 	}}
 }
 

--- a/pkg/sql/executor_opt_interface.go
+++ b/pkg/sql/executor_opt_interface.go
@@ -27,7 +27,7 @@ import (
 // NewExecFactory is used from opt tests to create and execute plans.
 func (e *Executor) NewExecFactory() opt.ExecFactory {
 	txn := client.NewTxn(e.cfg.DB, e.cfg.NodeID.Get(), client.RootTxn)
-	p, cleanup := newInternalPlanner("opt", txn, "root", &MemoryMetrics{})
+	p, cleanup := newInternalPlanner("opt", txn, "root", &MemoryMetrics{}, &e.cfg)
 	return &execFactory{
 		planner: p,
 		cleanup: cleanup,

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -117,14 +117,14 @@ func validateInformationSchemaTable(table *sqlbase.TableDescriptor) error {
 var informationSchemaColumnPrivileges = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.column_privileges (
-	GRANTOR STRING NOT NULL DEFAULT '',
-	GRANTEE STRING NOT NULL DEFAULT '',
-	TABLE_CATALOG STRING NOT NULL DEFAULT '',
-	TABLE_SCHEMA STRING NOT NULL DEFAULT '',
-	TABLE_NAME STRING NOT NULL DEFAULT '',
-	COLUMN_NAME STRING NOT NULL DEFAULT '',
-	PRIVILEGE_TYPE STRING NOT NULL DEFAULT '',
-	IS_GRANTABLE STRING NOT NULL DEFAULT ''
+	GRANTOR STRING NOT NULL,
+	GRANTEE STRING NOT NULL,
+	TABLE_CATALOG STRING NOT NULL,
+	TABLE_SCHEMA STRING NOT NULL,
+	TABLE_NAME STRING NOT NULL,
+	COLUMN_NAME STRING NOT NULL,
+	PRIVILEGE_TYPE STRING NOT NULL,
+	IS_GRANTABLE STRING NOT NULL
 );
 `,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
@@ -158,14 +158,14 @@ CREATE TABLE information_schema.column_privileges (
 var informationSchemaColumnsTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.columns (
-	TABLE_CATALOG STRING NOT NULL DEFAULT '',
-	TABLE_SCHEMA STRING NOT NULL DEFAULT '',
-	TABLE_NAME STRING NOT NULL DEFAULT '',
-	COLUMN_NAME STRING NOT NULL DEFAULT '',
-	ORDINAL_POSITION INT NOT NULL DEFAULT 0,
+	TABLE_CATALOG STRING NOT NULL,
+	TABLE_SCHEMA STRING NOT NULL,
+	TABLE_NAME STRING NOT NULL,
+	COLUMN_NAME STRING NOT NULL,
+	ORDINAL_POSITION INT NOT NULL,
 	COLUMN_DEFAULT STRING,
-	IS_NULLABLE STRING NOT NULL DEFAULT '',
-	DATA_TYPE STRING NOT NULL DEFAULT '',
+	IS_NULLABLE STRING NOT NULL,
+	DATA_TYPE STRING NOT NULL,
 	CHARACTER_MAXIMUM_LENGTH INT,
 	CHARACTER_OCTET_LENGTH INT,
 	NUMERIC_PRECISION INT,
@@ -229,14 +229,14 @@ func datetimePrecision(colType sqlbase.ColumnType) tree.Datum {
 var informationSchemaKeyColumnUsageTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.key_column_usage (
-	CONSTRAINT_CATALOG STRING DEFAULT '',
-	CONSTRAINT_SCHEMA STRING DEFAULT '',
-	CONSTRAINT_NAME STRING DEFAULT '',
-	TABLE_CATALOG STRING NOT NULL DEFAULT '',
-	TABLE_SCHEMA STRING NOT NULL DEFAULT '',
-	TABLE_NAME STRING NOT NULL DEFAULT '',
-	COLUMN_NAME STRING NOT NULL DEFAULT '',
-	ORDINAL_POSITION INT NOT NULL DEFAULT 0,
+	CONSTRAINT_CATALOG STRING,
+	CONSTRAINT_SCHEMA STRING,
+	CONSTRAINT_NAME STRING,
+	TABLE_CATALOG STRING NOT NULL,
+	TABLE_SCHEMA STRING NOT NULL,
+	TABLE_NAME STRING NOT NULL,
+	COLUMN_NAME STRING NOT NULL,
+	ORDINAL_POSITION INT NOT NULL,
 	POSITION_IN_UNIQUE_CONSTRAINT INT
 );`,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
@@ -289,9 +289,9 @@ CREATE TABLE information_schema.key_column_usage (
 var informationSchemaSchemataTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.schemata (
-	CATALOG_NAME STRING NOT NULL DEFAULT '',
-	SCHEMA_NAME STRING NOT NULL DEFAULT '',
-	DEFAULT_CHARACTER_SET_NAME STRING NOT NULL DEFAULT '',
+	CATALOG_NAME STRING NOT NULL,
+	SCHEMA_NAME STRING NOT NULL,
+	DEFAULT_CHARACTER_SET_NAME STRING NOT NULL,
 	SQL_PATH STRING
 );`,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
@@ -309,11 +309,11 @@ CREATE TABLE information_schema.schemata (
 var informationSchemaSchemataTablePrivileges = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.schema_privileges (
-	GRANTEE STRING NOT NULL DEFAULT '',
-	TABLE_CATALOG STRING NOT NULL DEFAULT '',
-	TABLE_SCHEMA STRING NOT NULL DEFAULT '',
-	PRIVILEGE_TYPE STRING NOT NULL DEFAULT '',
-	IS_GRANTABLE STRING NOT NULL DEFAULT ''
+	GRANTEE STRING NOT NULL,
+	TABLE_CATALOG STRING NOT NULL,
+	TABLE_SCHEMA STRING NOT NULL,
+	PRIVILEGE_TYPE STRING NOT NULL,
+	IS_GRANTABLE STRING NOT NULL
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
@@ -356,18 +356,18 @@ func dStringForIndexDirection(dir sqlbase.IndexDescriptor_Direction) tree.Datum 
 var informationSchemaSequences = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.sequences (
-    SEQUENCE_CATALOG STRING NOT NULL DEFAULT '',
-    SEQUENCE_SCHEMA STRING NOT NULL DEFAULT '',
-    SEQUENCE_NAME STRING NOT NULL DEFAULT '',
-    DATA_TYPE STRING NOT NULL DEFAULT '',
-    NUMERIC_PRECISION INT NOT NULL DEFAULT 0,
-    NUMERIC_PRECISION_RADIX INT NOT NULL DEFAULT 0,
-    NUMERIC_SCALE INT NOT NULL DEFAULT 0,
-    START_VALUE STRING NOT NULL DEFAULT '',
-    MINIMUM_VALUE STRING NOT NULL DEFAULT '',
-    MAXIMUM_VALUE STRING NOT NULL DEFAULT '',
-    INCREMENT STRING NOT NULL DEFAULT '',
-    CYCLE_OPTION STRING NOT NULL DEFAULT 'NO'
+    SEQUENCE_CATALOG STRING NOT NULL,
+    SEQUENCE_SCHEMA STRING NOT NULL,
+    SEQUENCE_NAME STRING NOT NULL,
+    DATA_TYPE STRING NOT NULL,
+    NUMERIC_PRECISION INT NOT NULL,
+    NUMERIC_PRECISION_RADIX INT NOT NULL,
+    NUMERIC_SCALE INT NOT NULL,
+    START_VALUE STRING NOT NULL,
+    MINIMUM_VALUE STRING NOT NULL,
+    MAXIMUM_VALUE STRING NOT NULL,
+    INCREMENT STRING NOT NULL,
+    CYCLE_OPTION STRING NOT NULL
 );`,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
@@ -395,19 +395,19 @@ CREATE TABLE information_schema.sequences (
 var informationSchemaStatisticsTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.statistics (
-	TABLE_CATALOG STRING NOT NULL DEFAULT '',
-	TABLE_SCHEMA STRING NOT NULL DEFAULT '',
-	TABLE_NAME STRING NOT NULL DEFAULT '',
-	NON_UNIQUE STRING NOT NULL DEFAULT '',
-	INDEX_SCHEMA STRING NOT NULL DEFAULT '',
-	INDEX_NAME STRING NOT NULL DEFAULT '',
-	SEQ_IN_INDEX INT NOT NULL DEFAULT 0,
-	COLUMN_NAME STRING NOT NULL DEFAULT '',
-	"COLLATION" STRING NOT NULL DEFAULT '',
-	CARDINALITY INT NOT NULL DEFAULT 0,
-	DIRECTION STRING NOT NULL DEFAULT '',
-	STORING STRING NOT NULL DEFAULT '',
-	IMPLICIT STRING NOT NULL DEFAULT ''
+	TABLE_CATALOG STRING NOT NULL,
+	TABLE_SCHEMA STRING NOT NULL,
+	TABLE_NAME STRING NOT NULL,
+	NON_UNIQUE STRING NOT NULL,
+	INDEX_SCHEMA STRING NOT NULL,
+	INDEX_NAME STRING NOT NULL,
+	SEQ_IN_INDEX INT NOT NULL,
+	COLUMN_NAME STRING NOT NULL,
+	"COLLATION" STRING NOT NULL,
+	CARDINALITY INT NOT NULL,
+	DIRECTION STRING NOT NULL,
+	STORING STRING NOT NULL,
+	IMPLICIT STRING NOT NULL
 );`,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
@@ -487,15 +487,15 @@ CREATE TABLE information_schema.statistics (
 var informationSchemaTableConstraintTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.table_constraints (
-	CONSTRAINT_CATALOG STRING NOT NULL DEFAULT '',
-	CONSTRAINT_SCHEMA STRING NOT NULL DEFAULT '',
-	CONSTRAINT_NAME STRING NOT NULL DEFAULT '',
-	TABLE_CATALOG STRING NOT NULL DEFAULT '',
-	TABLE_SCHEMA STRING NOT NULL DEFAULT '',
-	TABLE_NAME STRING NOT NULL DEFAULT '',
-	CONSTRAINT_TYPE STRING NOT NULL DEFAULT '',
-	IS_DEFERRABLE STRING NOT NULL DEFAULT '',
-	INITIALLY_DEFERRED STRING NOT NULL DEFAULT ''
+	CONSTRAINT_CATALOG STRING NOT NULL,
+	CONSTRAINT_SCHEMA STRING NOT NULL,
+	CONSTRAINT_NAME STRING NOT NULL,
+	TABLE_CATALOG STRING NOT NULL,
+	TABLE_SCHEMA STRING NOT NULL,
+	TABLE_NAME STRING NOT NULL,
+	CONSTRAINT_TYPE STRING NOT NULL,
+	IS_DEFERRABLE STRING NOT NULL,
+	INITIALLY_DEFERRED STRING NOT NULL
 );`,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
 		return forEachTableDescWithTableLookup(ctx, p, prefix, func(
@@ -531,10 +531,10 @@ CREATE TABLE information_schema.table_constraints (
 var informationSchemaUserPrivileges = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.user_privileges (
-	GRANTEE STRING NOT NULL DEFAULT '',
-	TABLE_CATALOG STRING NOT NULL DEFAULT '',
-	PRIVILEGE_TYPE STRING NOT NULL DEFAULT '',
-	IS_GRANTABLE STRING NOT NULL DEFAULT ''
+	GRANTEE STRING NOT NULL,
+	TABLE_CATALOG STRING NOT NULL,
+	PRIVILEGE_TYPE STRING NOT NULL,
+	IS_GRANTABLE STRING NOT NULL
 );`,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
 		for _, u := range []string{security.RootUser, sqlbase.AdminRole} {
@@ -557,14 +557,14 @@ CREATE TABLE information_schema.user_privileges (
 var informationSchemaTablePrivileges = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.table_privileges (
-	GRANTOR STRING NOT NULL DEFAULT '',
-	GRANTEE STRING NOT NULL DEFAULT '',
-	TABLE_CATALOG STRING NOT NULL DEFAULT '',
-	TABLE_SCHEMA STRING NOT NULL DEFAULT '',
-	TABLE_NAME STRING NOT NULL DEFAULT '',
-	PRIVILEGE_TYPE STRING NOT NULL DEFAULT '',
-	IS_GRANTABLE STRING NOT NULL DEFAULT '',
-	WITH_HIERARCHY STRING NOT NULL DEFAULT ''
+	GRANTOR STRING NOT NULL,
+	GRANTEE STRING NOT NULL,
+	TABLE_CATALOG STRING NOT NULL,
+	TABLE_SCHEMA STRING NOT NULL,
+	TABLE_NAME STRING NOT NULL,
+	PRIVILEGE_TYPE STRING NOT NULL,
+	IS_GRANTABLE STRING NOT NULL,
+	WITH_HIERARCHY STRING NOT NULL
 );
 `,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
@@ -599,10 +599,10 @@ var (
 var informationSchemaTablesTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.tables (
-	TABLE_CATALOG STRING NOT NULL DEFAULT '',
-	TABLE_SCHEMA STRING NOT NULL DEFAULT '',
-	TABLE_NAME STRING NOT NULL DEFAULT '',
-	TABLE_TYPE STRING NOT NULL DEFAULT '',
+	TABLE_CATALOG STRING NOT NULL,
+	TABLE_SCHEMA STRING NOT NULL,
+	TABLE_NAME STRING NOT NULL,
+	TABLE_TYPE STRING NOT NULL,
 	VERSION INT
 );`,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
@@ -630,16 +630,16 @@ CREATE TABLE information_schema.tables (
 var informationSchemaViewsTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.views (
-    TABLE_CATALOG STRING NOT NULL DEFAULT '',
-    TABLE_SCHEMA STRING NOT NULL DEFAULT '',
-    TABLE_NAME STRING NOT NULL DEFAULT '',
-    VIEW_DEFINITION STRING NOT NULL DEFAULT '',
-    CHECK_OPTION STRING NOT NULL DEFAULT '',
-    IS_UPDATABLE STRING NOT NULL DEFAULT '',
-    IS_INSERTABLE_INTO STRING NOT NULL DEFAULT '',
-    IS_TRIGGER_UPDATABLE STRING NOT NULL DEFAULT '',
-    IS_TRIGGER_DELETABLE STRING NOT NULL DEFAULT '',
-    IS_TRIGGER_INSERTABLE_INTO STRING NOT NULL DEFAULT ''
+    TABLE_CATALOG STRING NOT NULL,
+    TABLE_SCHEMA STRING NOT NULL,
+    TABLE_NAME STRING NOT NULL,
+    VIEW_DEFINITION STRING NOT NULL,
+    CHECK_OPTION STRING NOT NULL,
+    IS_UPDATABLE STRING NOT NULL,
+    IS_INSERTABLE_INTO STRING NOT NULL,
+    IS_TRIGGER_UPDATABLE STRING NOT NULL,
+    IS_TRIGGER_DELETABLE STRING NOT NULL,
+    IS_TRIGGER_INSERTABLE_INTO STRING NOT NULL
 );`,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
 		return forEachTableDesc(ctx, p, prefix, func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
@@ -956,7 +956,9 @@ func forEachRole(
 ) error {
 	query := `SELECT username, "isRole" FROM system.users`
 	p, cleanup := newInternalPlanner(
-		"for-each-role", origPlanner.txn, security.RootUser, origPlanner.extendedEvalCtx.MemMetrics)
+		"for-each-role", origPlanner.txn, security.RootUser,
+		origPlanner.extendedEvalCtx.MemMetrics, origPlanner.ExecCfg(),
+	)
 	defer cleanup()
 	rows, err := p.queryRows(ctx, query)
 	if err != nil {

--- a/pkg/sql/jobs/registry_external_test.go
+++ b/pkg/sql/jobs/registry_external_test.go
@@ -76,7 +76,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	db := s.DB()
-	ex := sql.InternalExecutor{LeaseManager: s.LeaseManager().(*sql.LeaseManager)}
+	ex := &sql.InternalExecutor{ExecCfg: s.InternalExecutor().(*sql.InternalExecutor).ExecCfg}
 	gossip := s.Gossip()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	nodeLiveness := jobs.NewFakeNodeLiveness(clock, 4)

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -396,7 +396,8 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 	// Populate the name cache.
 	ctx := context.TODO()
-	table, _, err := leaseManager.AcquireByName(ctx, leaseManager.clock.Now(), tableDesc.ParentID, "test")
+	table, _, err := leaseManager.AcquireByName(
+		ctx, leaseManager.execCfg.Clock.Now(), tableDesc.ParentID, "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,7 +426,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	}()
 
 	for i := 0; i < 50; i++ {
-		timestamp := leaseManager.clock.Now()
+		timestamp := leaseManager.execCfg.Clock.Now()
 		ctx := context.TODO()
 		table, _, err := leaseManager.AcquireByName(ctx, timestamp, tableDesc.ParentID, "test")
 		if err != nil {
@@ -600,7 +601,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 		m *LeaseManager,
 		acquireChan chan Result,
 	) {
-		table, e, err := m.Acquire(ctx, m.clock.Now(), descID)
+		table, e, err := m.Acquire(ctx, m.execCfg.Clock.Now(), descID)
 		acquireChan <- Result{err: err, exp: e, table: table}
 	}
 

--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -196,10 +196,13 @@ func (t *leaseTest) node(nodeID uint32) *sql.LeaseManager {
 	if mgr == nil {
 		nc := &base.NodeIDContainer{}
 		nc.Set(context.TODO(), roachpb.NodeID(nodeID))
+		// Hack the ExecutorConfig that we pass to the LeaseManager to have a
+		// different node id.
+		cfgCpy := *t.server.InternalExecutor().(*sql.InternalExecutor).ExecCfg
+		cfgCpy.NodeInfo.NodeID = nc
 		mgr = sql.NewLeaseManager(
 			log.AmbientContext{Tracer: tracing.NewTracer()},
-			nc, *t.kvDB,
-			t.server.Clock(),
+			&cfgCpy,
 			t.leaseManagerTestingKnobs,
 			t.server.Stopper(),
 			&sql.MemoryMetrics{},

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -125,22 +125,22 @@ SHOW CREATE TABLE information_schema.tables
 ----
 Table                      CreateTable
 information_schema.tables  CREATE TABLE tables (
-                           table_catalog STRING NOT NULL DEFAULT '':::STRING,
-                           table_schema STRING NOT NULL DEFAULT '':::STRING,
-                           table_name STRING NOT NULL DEFAULT '':::STRING,
-                           table_type STRING NOT NULL DEFAULT '':::STRING,
+                           table_catalog STRING NOT NULL,
+                           table_schema STRING NOT NULL,
+                           table_name STRING NOT NULL,
+                           table_type STRING NOT NULL,
                            version INT NULL
 )
 
 query TTBTT colnames
 SHOW COLUMNS FROM information_schema.tables
 ----
-Field            Type       Null   Default     Indices
-table_catalog    STRING     false  '':::STRING {}
-table_schema     STRING     false  '':::STRING {}
-table_name       STRING     false  '':::STRING {}
-table_type       STRING     false  '':::STRING {}
-version          INT        true   NULL        {}
+Field          Type    Null   Default  Indices
+table_catalog  STRING  false  NULL     {}
+table_schema   STRING  false  NULL     {}
+table_name     STRING  false  NULL     {}
+table_type     STRING  false  NULL     {}
+version        INT     true   NULL     {}
 
 query TTBITTBB colnames
 SHOW INDEXES FROM information_schema.tables
@@ -1114,15 +1114,15 @@ DROP DATABASE other_db CASCADE
 query TTBTT colnames
 SHOW COLUMNS FROM information_schema.column_privileges
 ----
-Field           Type    Null   Default      Indices
-grantor         STRING  false  '':::STRING  {}
-grantee         STRING  false  '':::STRING  {}
-table_catalog   STRING  false  '':::STRING  {}
-table_schema    STRING  false  '':::STRING  {}
-table_name      STRING  false  '':::STRING  {}
-column_name     STRING  false  '':::STRING  {}
-privilege_type  STRING  false  '':::STRING  {}
-is_grantable    STRING  false  '':::STRING  {}
+Field           Type    Null   Default  Indices
+grantor         STRING  false  NULL     {}
+grantee         STRING  false  NULL     {}
+table_catalog   STRING  false  NULL     {}
+table_schema    STRING  false  NULL     {}
+table_name      STRING  false  NULL     {}
+column_name     STRING  false  NULL     {}
+privilege_type  STRING  false  NULL     {}
+is_grantable    STRING  false  NULL     {}
 
 
 query TTTTTTTT colnames

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -315,7 +315,8 @@ func TestParallelizeQueueAddAfterError(t *testing.T) {
 func planQuery(t *testing.T, s serverutils.TestServerInterface, sql string) (*planner, func()) {
 	kvDB := s.DB()
 	txn := client.NewTxn(kvDB, s.NodeID(), client.RootTxn)
-	p, cleanup := newInternalPlanner("plan", txn, security.RootUser, &MemoryMetrics{})
+	p, cleanup := newInternalPlanner(
+		"plan", txn, security.RootUser, &MemoryMetrics{}, &s.Executor().(*Executor).cfg)
 	p.extendedEvalCtx.Tables.leaseMgr = s.LeaseManager().(*LeaseManager)
 	// HACK: we're mutating the SessionData directly, without going through the
 	// SessionDataMutator. We're not really supposed to do that, but were we to go

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -186,7 +186,7 @@ var noteworthyInternalMemoryUsageBytes = envutil.EnvOrDefaultInt64("COCKROACH_NO
 // Returns a cleanup function that must be called once the caller is done with
 // the planner.
 func newInternalPlanner(
-	opName string, txn *client.Txn, user string, memMetrics *MemoryMetrics,
+	opName string, txn *client.Txn, user string, memMetrics *MemoryMetrics, execCfg *ExecutorConfig,
 ) (*planner, func()) {
 	// init with an empty session. We can't leave this nil because too much code
 	// looks in the session for the current database.
@@ -202,6 +202,7 @@ func newInternalPlanner(
 		TxnState: txnState{Ctx: ctx, implicitTxn: true},
 		context:  ctx,
 		tables:   TableCollection{databaseCache: newDatabaseCache(config.SystemConfig{})},
+		execCfg:  execCfg,
 	}
 	s.dataMutator = sessionDataMutator{
 		data: &s.data,

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -97,7 +97,7 @@ func (p *planner) SetClusterSetting(
 }
 
 func (n *setClusterSettingNode) startExec(params runParams) error {
-	ie := InternalExecutor{LeaseManager: params.p.LeaseMgr()}
+	ie := InternalExecutor{ExecCfg: params.extendedEvalCtx.ExecCfg}
 
 	var reportedValue string
 	if n.value == nil {
@@ -124,7 +124,7 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 		reportedValue = tree.AsStringWithFlags(n.value, tree.FmtBareStrings)
 	}
 
-	return MakeEventLogger(params.p.LeaseMgr()).InsertEventRecord(
+	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
 		params.ctx,
 		params.p.txn,
 		EventLogSetClusterSetting,

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -86,9 +86,7 @@ func SanitizeVarFreeExpr(
 	return typedExpr, nil
 }
 
-func populateTypeAttrs(
-	base ColumnType, typ coltypes.T, semaCtx *tree.SemaContext,
-) (ColumnType, error) {
+func populateTypeAttrs(base ColumnType, typ coltypes.T) (ColumnType, error) {
 	// Set other attributes of col.Type and perform type-specific verification.
 	switch t := typ.(type) {
 	case *coltypes.TBool:
@@ -135,7 +133,7 @@ func populateTypeAttrs(
 	case *coltypes.TArray:
 		base.ArrayDimensions = t.Bounds
 		var err error
-		base, err = populateTypeAttrs(base, t.ParamType, semaCtx)
+		base, err = populateTypeAttrs(base, t.ParamType)
 		if err != nil {
 			return ColumnType{}, err
 		}
@@ -152,7 +150,9 @@ func populateTypeAttrs(
 
 // MakeColumnDefDescs creates the column descriptor for a column, as well as the
 // index descriptor if the column is a primary key or unique.
-// The search path is used for name resolution for DEFAULT expressions.
+//
+// semaCtx and evalCtx can be nil if no default expression is used for the
+// column.
 func MakeColumnDefDescs(
 	d *tree.ColumnTableDef, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext,
 ) (*ColumnDescriptor, *IndexDescriptor, error) {
@@ -168,7 +168,7 @@ func MakeColumnDefDescs(
 		return nil, nil, err
 	}
 
-	col.Type, err = populateTypeAttrs(colTyp, d.Type, semaCtx)
+	col.Type, err = populateTypeAttrs(colTyp, d.Type)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/sql/sqlutil/internal_executor.go
+++ b/pkg/sql/sqlutil/internal_executor.go
@@ -24,7 +24,7 @@ import (
 // InternalExecutor is meant to be used by layers below SQL in the system that
 // nevertheless want to execute SQL queries (presumably against system tables).
 // It is extracted in this "sql/util" package to avoid circular references and
-// is implemented by sql.InternalExecutor.
+// is implemented by *sql.InternalExecutor.
 type InternalExecutor interface {
 	// ExecuteStatementInTransaction executes the supplied SQL statement as part of
 	// the supplied transaction. Statements are currently executed as the root user.

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -352,7 +352,7 @@ func (tc *TableCollection) getTableVersion(
 	if dbID == 0 {
 		// Resolve the database from the database cache when the transaction
 		// hasn't modified the database.
-		dbID, err = tc.databaseCache.getDatabaseID(ctx, tc.leaseMgr.LeaseStore.db.Txn, vt, tn.Database())
+		dbID, err = tc.databaseCache.getDatabaseID(ctx, tc.leaseMgr.execCfg.DB.Txn, vt, tn.Database())
 		if err != nil {
 			return nil, err
 		}
@@ -652,6 +652,7 @@ func (p *planner) notifySchemaChange(
 		rangeDescriptorCache: p.ExecCfg().RangeDescriptorCache,
 		clock:                p.ExecCfg().Clock,
 		settings:             p.ExecCfg().Settings,
+		execCfg:              p.ExecCfg(),
 	}
 	p.extendedEvalCtx.SchemaChangers.queueSchemaChanger(sc)
 }

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -38,7 +38,8 @@ func GetUserHashedPassword(
 	var hashedPassword []byte
 	var exists bool
 	err := executor.cfg.DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		p, cleanup := newInternalPlanner("get-pwd", txn, security.RootUser, metrics)
+		p, cleanup := newInternalPlanner(
+			"get-pwd", txn, security.RootUser, metrics, &executor.cfg)
 		defer cleanup()
 		const getHashedPassword = `SELECT "hashedPassword" FROM system.users ` +
 			`WHERE username=$1 AND "isRole" = false`
@@ -61,8 +62,7 @@ func GetUserHashedPassword(
 func (p *planner) GetAllUsersAndRoles(ctx context.Context) (map[string]bool, error) {
 	query := `SELECT username,"isRole"  FROM system.users`
 	newPlanner, cleanup := newInternalPlanner(
-		"get-all-users-and-roles", p.txn, security.RootUser, p.extendedEvalCtx.MemMetrics,
-	)
+		"get-all-users-and-roles", p.txn, security.RootUser, p.extendedEvalCtx.MemMetrics, p.ExecCfg())
 	defer cleanup()
 	rows, err := newPlanner.queryRows(ctx, query)
 	if err != nil {

--- a/pkg/sql/views.go
+++ b/pkg/sql/views.go
@@ -113,7 +113,7 @@ func RecomputeViewDependencies(ctx context.Context, txn *client.Txn, e *Executor
 	lm := e.cfg.LeaseManager
 	// We run as NodeUser because we may update system descriptors.
 	p, cleanup := newInternalPlanner(
-		"recompute-view-dependencies", txn, security.NodeUser, lm.memMetrics,
+		"recompute-view-dependencies", txn, security.NodeUser, lm.memMetrics, &e.cfg,
 	)
 	defer cleanup()
 	p.Tables().leaseMgr = lm

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/pkg/errors"
 
@@ -65,13 +66,13 @@ var virtualSchemas = []virtualSchema{
 // SQL-layer interface to work with virtual schemas.
 //
 
-// virtualSchemaHolder is a type used to provide convenient access to virtual
-// database and table descriptors. virtualSchemaHolder, virtualSchemaEntry,
+// VirtualSchemaHolder is a type used to provide convenient access to virtual
+// database and table descriptors. VirtualSchemaHolder, virtualSchemaEntry,
 // and virtualTableEntry make up the generated data structure which the
 // virtualSchemas slice is mapped to. Because of this, they should not be
 // created directly, but instead will be populated in a post-startup hook
 // on an Executor.
-type virtualSchemaHolder struct {
+type VirtualSchemaHolder struct {
 	entries      map[string]virtualSchemaEntry
 	orderedNames []string
 }
@@ -144,8 +145,11 @@ func (e virtualTableEntry) getPlanInfo(
 	return columns, constructor
 }
 
-func (vs *virtualSchemaHolder) init(ctx context.Context, p *planner) error {
-	*vs = virtualSchemaHolder{
+// NewVirtualSchemaHolder creates a new VirtualSchemaHolder.
+func NewVirtualSchemaHolder(
+	ctx context.Context, st *cluster.Settings,
+) (*VirtualSchemaHolder, error) {
+	vs := &VirtualSchemaHolder{
 		entries:      make(map[string]virtualSchemaEntry, len(virtualSchemas)),
 		orderedNames: make([]string, len(virtualSchemas)),
 	}
@@ -155,13 +159,13 @@ func (vs *virtualSchemaHolder) init(ctx context.Context, p *planner) error {
 		tables := make(map[string]virtualTableEntry, len(schema.tables))
 		orderedTableNames := make([]string, 0, len(schema.tables))
 		for _, table := range schema.tables {
-			tableDesc, err := initVirtualTableDesc(ctx, p, table)
+			tableDesc, err := initVirtualTableDesc(ctx, table, st)
 			if err != nil {
-				return err
+				return nil, errors.Wrapf(err, "failed to initialize %s", table.schema)
 			}
 			if schema.tableValidator != nil {
 				if err := schema.tableValidator(&tableDesc); err != nil {
-					return errors.Wrap(err, "programmer error")
+					return nil, errors.Wrap(err, "programmer error")
 				}
 			}
 			tables[tableDesc.Name] = virtualTableEntry{
@@ -179,7 +183,7 @@ func (vs *virtualSchemaHolder) init(ctx context.Context, p *planner) error {
 		vs.orderedNames[i] = dbName
 	}
 	sort.Strings(vs.orderedNames)
-	return nil
+	return vs, nil
 }
 
 // Virtual databases and tables each have an empty set of privileges. In practice,
@@ -198,34 +202,45 @@ func initVirtualDatabaseDesc(name string) *sqlbase.DatabaseDescriptor {
 }
 
 func initVirtualTableDesc(
-	ctx context.Context, p *planner, t virtualSchemaTable,
+	ctx context.Context, t virtualSchemaTable, st *cluster.Settings,
 ) (sqlbase.TableDescriptor, error) {
 	stmt, err := parser.ParseOne(t.schema)
 	if err != nil {
 		return sqlbase.TableDescriptor{}, err
 	}
 	create := stmt.(*tree.CreateTable)
-	return p.makeTableDesc(ctx, create, 0, keys.VirtualDescriptorID, hlc.Timestamp{}, emptyPrivileges, nil)
+	return MakeTableDesc(
+		ctx,
+		nil, /* txn */
+		nil, /* vt */
+		st,
+		create,
+		0, /* parentID */
+		keys.VirtualDescriptorID,
+		hlc.Timestamp{}, /* creationTime */
+		emptyPrivileges,
+		nil, /* affected */
+		"",  /* sessionDB */
+		nil, /* semaCtx */
+		nil, /* evalCtx */
+	)
 }
 
 // entries is part of the VirtualTabler interface.
-func (vs *virtualSchemaHolder) getEntries() map[string]virtualSchemaEntry {
+func (vs *VirtualSchemaHolder) getEntries() map[string]virtualSchemaEntry {
 	return vs.entries
 }
 
 // getVirtualSchemaEntry retrieves a virtual schema entry given a database name.
 // getVirtualSchemaEntry is part of the VirtualTabler interface.
-func (vs *virtualSchemaHolder) getVirtualSchemaEntry(name string) (virtualSchemaEntry, bool) {
-	if vs == nil {
-		return virtualSchemaEntry{}, false
-	}
+func (vs *VirtualSchemaHolder) getVirtualSchemaEntry(name string) (virtualSchemaEntry, bool) {
 	e, ok := vs.entries[name]
 	return e, ok
 }
 
 // getVirtualDatabaseDesc checks if the provided name matches a virtual database,
 // and if so, returns that database's descriptor.
-func (vs *virtualSchemaHolder) getVirtualDatabaseDesc(name string) *sqlbase.DatabaseDescriptor {
+func (vs *VirtualSchemaHolder) getVirtualDatabaseDesc(name string) *sqlbase.DatabaseDescriptor {
 	if e, ok := vs.getVirtualSchemaEntry(name); ok {
 		return e.desc
 	}
@@ -234,7 +249,7 @@ func (vs *virtualSchemaHolder) getVirtualDatabaseDesc(name string) *sqlbase.Data
 
 // isVirtualDatabase checks if the provided name corresponds to a virtual database.
 // isVirtualDatabase is part of the VirtualTabler interface.
-func (vs *virtualSchemaHolder) isVirtualDatabase(name string) bool {
+func (vs *VirtualSchemaHolder) isVirtualDatabase(name string) bool {
 	_, ok := vs.getVirtualSchemaEntry(name)
 	return ok
 }
@@ -242,7 +257,7 @@ func (vs *virtualSchemaHolder) isVirtualDatabase(name string) bool {
 // IsVirtualDatabase checks if the provided name corresponds to a virtual database,
 // exposing this information on the Executor object itself.
 func (e *Executor) IsVirtualDatabase(name string) bool {
-	return e.virtualSchemas.isVirtualDatabase(name)
+	return e.cfg.VirtualSchemas.isVirtualDatabase(name)
 }
 
 // getVirtualTableEntry checks if the provided name matches a virtual database/table
@@ -250,7 +265,7 @@ func (e *Executor) IsVirtualDatabase(name string) bool {
 // a specific table. It will return an error if the name references a virtual database
 // but the table is non-existent.
 // getVirtualTableEntry is part of the VirtualTabler interface.
-func (vs *virtualSchemaHolder) getVirtualTableEntry(tn *tree.TableName) (virtualTableEntry, error) {
+func (vs *VirtualSchemaHolder) getVirtualTableEntry(tn *tree.TableName) (virtualTableEntry, error) {
 	if db, ok := vs.getVirtualSchemaEntry(string(tn.DatabaseName)); ok {
 		if t, ok := db.tables[string(tn.TableName)]; ok {
 			return t, nil
@@ -273,7 +288,7 @@ type VirtualTabler interface {
 // getVirtualTableDesc checks if the provided name matches a virtual database/table
 // pair, and returns its descriptor if it does.
 // getVirtualTableDesc is part of the VirtualTabler interface.
-func (vs *virtualSchemaHolder) getVirtualTableDesc(
+func (vs *VirtualSchemaHolder) getVirtualTableDesc(
 	tn *tree.TableName,
 ) (*sqlbase.TableDescriptor, error) {
 	t, err := vs.getVirtualTableEntry(tn)

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -233,12 +232,11 @@ func resolveSubzone(
 func deleteRemovedPartitionZoneConfigs(
 	ctx context.Context,
 	txn *client.Txn,
-	settings *cluster.Settings,
-	leaseMgr *LeaseManager,
 	tableDesc *sqlbase.TableDescriptor,
 	idxDesc *sqlbase.IndexDescriptor,
 	oldPartDesc *sqlbase.PartitioningDescriptor,
 	newPartDesc *sqlbase.PartitioningDescriptor,
+	execCfg *ExecutorConfig,
 ) error {
 	newNames := map[string]struct{}{}
 	for _, n := range newPartDesc.PartitionNames() {
@@ -260,6 +258,6 @@ func deleteRemovedPartitionZoneConfigs(
 	for _, n := range removedNames {
 		zone.DeleteSubzone(uint32(idxDesc.ID), n)
 	}
-	_, err = writeZoneConfig(ctx, txn, settings, leaseMgr, tableDesc.ID, tableDesc, zone)
+	_, err = writeZoneConfig(ctx, txn, tableDesc.ID, tableDesc, zone, execCfg)
 	return err
 }

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -73,7 +73,7 @@ type TestServerInterface interface {
 	// Executor() returns the *sql.Executor as an interface{}.
 	Executor() interface{}
 
-	// InternalExecutor returns a sqlutil.InternalExecutor as an interface{}.
+	// InternalExecutor returns a *sqlutil.InternalExecutor as an interface{}.
 	InternalExecutor() interface{}
 
 	// Gossip returns the gossip used by the TestServer.


### PR DESCRIPTION
Before this patch, attempting to use the InternalExecutor to resolve
virtual tables names didn't work because the VirtualSchemas member of
the extendedEvalCtx wasn't properly initialized because, in turn, the
dummy session we were constructing for the InternalExecutor was not
properly initialized (sql/internal.go,sql/planner.go).
I started pulling from there...

I've taken VirtualSchemas out of the Session and made it a singleton -
no point in all the sessions having a copy of the thing. Instead,
VirtualSchemas now hangs from the ExecutorConfig - a bag of server-wide
references to top-level objects. InternalExecutor and planner
construction now take in an ExecutorConfig (which was already needed by
the planner but we were hackily supporting nil references).

I've had to dig a bit into the bootstrapping of all of a server's
components in server.go. Since an InternalExecutor now needs an
ExecutorConfig, and the ExecutorConfig is only initialized once many
other things that need an InternalExecutor have been created, there's a
circular dependency that was handled by making everybody share an
InternalExecutor instance (whose initialization is deferred), rather
than having different components have their own InternalExecutor. That's
probably a good thing; this InternalExecutor feels like a singleton.

Another area that needed a little digging was the bootstrapping of the
descriptors of virtual tables. It used to be that one needed a planner
to create one of these descriptors. Since the planner now needs an
ExecutorConfig that doesn't exist yet during this bootstrapping, I've
made the creation of descriptors not need a planner and a
semaCtx/evalCtx that come with it. But this imposes some restrictions on
the definitions of the virtual tables - they can't reference other
tables (FKs) and they can't have expressions to be evaluated (DEFAULT
expressions). The FKs were not a problem. Some of the tables had
defaults, which I removed - defaults for virtual tables that you can't
insert into don't make sense anyway.

Fixes #21593

Release note: None