### PR TITLE
sql: cache all DescriptorProtos for virtual tables in TableCollection

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -193,7 +193,7 @@ CREATE TABLE crdb_internal.tables (
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		descs, err := GetAllDescriptors(ctx, p.txn)
+		descs, err := p.Tables().getAllDescriptors(ctx, p.txn)
 		if err != nil {
 			return err
 		}
@@ -269,7 +269,7 @@ CREATE TABLE crdb_internal.schema_changes (
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		descs, err := GetAllDescriptors(ctx, p.txn)
+		descs, err := p.Tables().getAllDescriptors(ctx, p.txn)
 		if err != nil {
 			return err
 		}
@@ -1358,7 +1358,7 @@ CREATE TABLE crdb_internal.ranges (
 		if err := p.RequireSuperUser("read crdb_internal.ranges"); err != nil {
 			return err
 		}
-		descs, err := GetAllDescriptors(ctx, p.txn)
+		descs, err := p.Tables().getAllDescriptors(ctx, p.txn)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -221,25 +221,6 @@ func (dc *databaseCache) getCachedDatabaseDescByID(
 	return database, database.Validate()
 }
 
-// getAllDatabaseDescs looks up and returns all available database
-// descriptors.
-func getAllDatabaseDescs(
-	ctx context.Context, txn *client.Txn,
-) ([]*sqlbase.DatabaseDescriptor, error) {
-	descs, err := GetAllDescriptors(ctx, txn)
-	if err != nil {
-		return nil, err
-	}
-
-	var dbDescs []*sqlbase.DatabaseDescriptor
-	for _, desc := range descs {
-		if dbDesc, ok := desc.(*sqlbase.DatabaseDescriptor); ok {
-			dbDescs = append(dbDescs, dbDesc)
-		}
-	}
-	return dbDescs, nil
-}
-
 // getDatabaseDesc returns the database descriptor given its name
 // if it exists in the cache, otherwise falls back to KV operations.
 func (dc *databaseCache) getDatabaseDesc(

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -35,24 +35,6 @@ var (
 	errNoTable           = errors.New("no table specified")
 )
 
-// DescriptorAccessor provides helper methods for using descriptors
-// to SQL objects.
-type DescriptorAccessor interface {
-	// createDescriptor takes a Table or Database descriptor and creates it if
-	// needed, incrementing the descriptor counter. Returns true if the descriptor
-	// is actually created, false if it already existed, or an error if one was encountered.
-	// The ifNotExists flag is used to declare if the "already existed" state should be an
-	// error (false) or a no-op (true).
-	createDescriptor(
-		ctx context.Context,
-		plainKey sqlbase.DescriptorKey,
-		descriptor sqlbase.DescriptorProto,
-		ifNotExists bool,
-	) (bool, error)
-}
-
-var _ DescriptorAccessor = &planner{}
-
 type descriptorAlreadyExistsErr struct {
 	desc sqlbase.DescriptorProto
 	name string
@@ -74,7 +56,11 @@ func GenerateUniqueDescID(ctx context.Context, db *client.DB) (sqlbase.ID, error
 	return sqlbase.ID(newVal - 1), nil
 }
 
-// createDescriptor implements the DescriptorAccessor interface.
+// createDescriptor takes a Table or Database descriptor and creates it if
+// needed, incrementing the descriptor counter. Returns true if the descriptor
+// is actually created, false if it already existed, or an error if one was
+// encountered. The ifNotExists flag is used to declare if the "already existed"
+// state should be an error (false) or a no-op (true).
 func (p *planner) createDescriptor(
 	ctx context.Context,
 	plainKey sqlbase.DescriptorKey,

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -670,10 +670,18 @@ func (dbs sortedDBDescs) Less(i, j int) bool { return dbs[i].Name < dbs[j].Name 
 func forEachDatabaseDesc(
 	ctx context.Context, p *planner, fn func(*sqlbase.DatabaseDescriptor) error,
 ) error {
-	// Handle real schemas
-	dbDescs, err := getAllDatabaseDescs(ctx, p.txn)
+	// Handle real schemas.
+	descs, err := p.Tables().getAllDescriptors(ctx, p.txn)
 	if err != nil {
 		return err
+	}
+
+	// Ignore table descriptors.
+	var dbDescs []*sqlbase.DatabaseDescriptor
+	for _, desc := range descs {
+		if dbDesc, ok := desc.(*sqlbase.DatabaseDescriptor); ok {
+			dbDescs = append(dbDescs, dbDesc)
+		}
 	}
 
 	// Handle virtual schemas.
@@ -797,7 +805,7 @@ func forEachTableDescWithTableLookupInternal(
 	databases := make(map[string]dbDescTables)
 
 	// Handle real schemas.
-	descs, err := GetAllDescriptors(ctx, p.txn)
+	descs, err := p.Tables().getAllDescriptors(ctx, p.txn)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -95,23 +95,6 @@ type tableVersionID struct {
 	version sqlbase.DescriptorVersion
 }
 
-// SchemaAccessor provides helper methods for using the SQL schema.
-type SchemaAccessor interface {
-	// NB: one can use GetTableDescFromID() to retrieve a descriptor for
-	// a table from a transaction using its ID, assuming it was loaded
-	// in the transaction already.
-
-	// notifySchemaChange notifies that an outstanding schema change
-	// exists for the table.
-	notifySchemaChange(tableDesc *sqlbase.TableDescriptor, mutationID sqlbase.MutationID)
-
-	// writeTableDesc effectively writes a table descriptor to the
-	// database within the current planner transaction.
-	writeTableDesc(ctx context.Context, tableDesc *sqlbase.TableDescriptor) error
-}
-
-var _ SchemaAccessor = &planner{}
-
 func (p *planner) getVirtualTabler() VirtualTabler {
 	return p.extendedEvalCtx.VirtualSchemas
 }
@@ -638,7 +621,8 @@ func (p *planner) createSchemaChangeJob(
 	return mutationID, nil
 }
 
-// notifySchemaChange implements the SchemaAccessor interface.
+// notifySchemaChange notifies that an outstanding schema change
+// exists for the table.
 func (p *planner) notifySchemaChange(
 	tableDesc *sqlbase.TableDescriptor, mutationID sqlbase.MutationID,
 ) {
@@ -656,7 +640,8 @@ func (p *planner) notifySchemaChange(
 	p.extendedEvalCtx.SchemaChangers.queueSchemaChanger(sc)
 }
 
-// writeTableDesc implements the SchemaAccessor interface.
+// writeTableDesc effectively writes a table descriptor to the
+// database within the current planner transaction.
 func (p *planner) writeTableDesc(ctx context.Context, tableDesc *sqlbase.TableDescriptor) error {
 	if isVirtualDescriptor(tableDesc) {
 		panic(fmt.Sprintf("Virtual Descriptors cannot be stored, found: %v", tableDesc))


### PR DESCRIPTION
Related to #20753.

Until now, the population of most virtual tables (information_schema,
pg_catalog, crdb_internal) has required a kv scan over all descriptors.
This became expensive for complex introspection queries that joined
multiple virtual tables together, since each would require their own
scan to collect the descriptors. To make this worse, certain workloads
like adding and dropping table repeatedly could generate lots of
descriptors, making each of these scans take a significant amount of
time.

This was pretty bad because we knew that each scan would return the same
results when inside the same query. In fact, we knew that even across
statements but within the same transaction, the results would almost
always be the same unless the transaction itself had done a schema
change.

To address this issue, this change now caches all DescriptorProtos in
TableCollection, clearing them only when necessary. TableCollection
already managed the caching of descriptor-related state like this and
made sure to purge the cache on schema changes and txn restarts, so it
was a natural place for this extra bit of caching to live.

Following up on the analysis from #20753, here is a plot of the introspective
query from that issue before and after this change:

![pg_catalog](https://user-images.githubusercontent.com/5438456/35188862-9e9fd7a0-fe0c-11e7-87b5-9d9ac4f31703.png)

Release note (performance improvement): information_schema and
pg_catalog should be faster to query.