### PR TITLE
sql: remove BOOL columns from information_schema, add schema validator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1015,16 +1015,16 @@ user root
 statement ok
 CREATE TABLE other_db.teststatics(id INT PRIMARY KEY, c INT, d INT, e STRING, INDEX idx_c(c), UNIQUE INDEX idx_cd(c,d))
 
-query TTTBTTITIITBB colnames
+query TTTTTTITIITTT colnames
 SELECT * FROM information_schema.statistics WHERE table_schema='other_db' AND table_name='teststatics' ORDER BY INDEX_SCHEMA,INDEX_NAME,SEQ_IN_INDEX
 ----
 table_catalog  table_schema  table_name   non_unique  index_schema  index_name  seq_in_index  column_name  COLLATION  cardinality  direction  storing  implicit
-def            other_db      teststatics  true        other_db      idx_c       1             c            NULL       NULL         ASC        false    false
-def            other_db      teststatics  true        other_db      idx_c       2             id           NULL       NULL         ASC        false    true
-def            other_db      teststatics  false       other_db      idx_cd      1             c            NULL       NULL         ASC        false    false
-def            other_db      teststatics  false       other_db      idx_cd      2             d            NULL       NULL         ASC        false    false
-def            other_db      teststatics  false       other_db      idx_cd      3             id           NULL       NULL         ASC        false    true
-def            other_db      teststatics  false       other_db      primary     1             id           NULL       NULL         ASC        false    false
+def            other_db      teststatics  YES         other_db      idx_c       1             c            NULL       NULL         ASC        NO       NO
+def            other_db      teststatics  YES         other_db      idx_c       2             id           NULL       NULL         ASC        NO       YES
+def            other_db      teststatics  NO          other_db      idx_cd      1             c            NULL       NULL         ASC        NO       NO
+def            other_db      teststatics  NO          other_db      idx_cd      2             d            NULL       NULL         ASC        NO       NO
+def            other_db      teststatics  NO          other_db      idx_cd      3             id           NULL       NULL         ASC        NO       YES
+def            other_db      teststatics  NO          other_db      primary     1             id           NULL       NULL         ASC        NO       NO
 
 # Verify information_schema.views
 statement ok
@@ -1122,7 +1122,7 @@ table_schema    STRING  false  '':::STRING  {}
 table_name      STRING  false  '':::STRING  {}
 column_name     STRING  false  '':::STRING  {}
 privilege_type  STRING  false  '':::STRING  {}
-is_grantable    BOOL    false  false        {}
+is_grantable    STRING  false  '':::STRING  {}
 
 
 query TTTTTTTT colnames

--- a/pkg/sql/show_index.go
+++ b/pkg/sql/show_index.go
@@ -29,12 +29,12 @@ func (p *planner) ShowIndex(ctx context.Context, n *tree.ShowIndex) (planNode, e
 				SELECT
 					TABLE_NAME AS "Table",
 					INDEX_NAME AS "Name",
-					NOT NON_UNIQUE AS "Unique",
+					NOT NON_UNIQUE::BOOL AS "Unique",
 					SEQ_IN_INDEX AS "Seq",
 					COLUMN_NAME AS "Column",
 					DIRECTION AS "Direction",
-					STORING AS "Storing",
-					IMPLICIT AS "Implicit"
+					STORING::BOOL AS "Storing",
+					IMPLICIT::BOOL AS "Implicit"
 				FROM "".information_schema.statistics
 				WHERE TABLE_SCHEMA=%[1]s AND TABLE_NAME=%[2]s`
 	return p.showTableDetails(ctx, "SHOW INDEX", n.Table, getIndexes)

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -39,8 +40,9 @@ import (
 // and tables in that their descriptors are not distributed, but instead live statically
 // in code. This means that they are accessed separately from standard descriptors.
 type virtualSchema struct {
-	name   string
-	tables []virtualSchemaTable
+	name           string
+	tables         []virtualSchemaTable
+	tableValidator func(*sqlbase.TableDescriptor) error // optional
 }
 
 // virtualSchemaTable represents a table within a virtualSchema.
@@ -156,6 +158,11 @@ func (vs *virtualSchemaHolder) init(ctx context.Context, p *planner) error {
 			tableDesc, err := initVirtualTableDesc(ctx, p, table)
 			if err != nil {
 				return err
+			}
+			if schema.tableValidator != nil {
+				if err := schema.tableValidator(&tableDesc); err != nil {
+					return errors.Wrap(err, "programmer error")
+				}
 			}
 			tables[tableDesc.Name] = virtualTableEntry{
 				tableDef: table,


### PR DESCRIPTION
As described in the comment about `yesOrNoDatum`, `information_schema`
was introduced before the BOOLEAN data type was added to the SQL
specification. Because of this, the data type is not used in any
`information_schema` tables (confirmed in MySQL and PostgreSQL).
Instead, the strings `"YES"` and `"NO"` are used, which can be cast
to booleans.

This change removes the few BOOL columns that had slipped into
our implementation of `information_schema` and adds a validator
function to `virtualSchema` definitions so that we can verify
that no BOOL columns are added in the future. The validator can
also be used to make other assertions about compiled schemas, if
we find other needs like this.

Release note (sql change): All BOOL columns in information_schema
have been replaced with STRING columns, per the specification.