### PR TITLE
sql: Add information_schema.referential_constraints table

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -17,10 +17,9 @@ package sql
 import (
 	"context"
 	"sort"
+	"strconv"
 
 	"github.com/pkg/errors"
-
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -114,6 +113,8 @@ func validateInformationSchemaTable(table *sqlbase.TableDescriptor) error {
 	return nil
 }
 
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-column-privileges.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/column-privileges-table.html
 var informationSchemaColumnPrivileges = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.column_privileges (
@@ -155,6 +156,8 @@ CREATE TABLE information_schema.column_privileges (
 	},
 }
 
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-columns.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/columns-table.html
 var informationSchemaColumnsTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.columns (
@@ -226,6 +229,8 @@ func datetimePrecision(colType sqlbase.ColumnType) tree.Datum {
 	return tree.DNull
 }
 
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-key-column-usage.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/key-column-usage-table.html
 var informationSchemaKeyColumnUsageTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.key_column_usage (
@@ -286,6 +291,8 @@ CREATE TABLE information_schema.key_column_usage (
 	},
 }
 
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-schemata.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/schemata-table.html
 var informationSchemaSchemataTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.schemata (
@@ -306,6 +313,8 @@ CREATE TABLE information_schema.schemata (
 	},
 }
 
+// Postgres: missing
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/schema-privileges-table.html
 var informationSchemaSchemataTablePrivileges = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.schema_privileges (
@@ -352,7 +361,8 @@ func dStringForIndexDirection(dir sqlbase.IndexDescriptor_Direction) tree.Datum 
 	panic("unreachable")
 }
 
-// https://www.postgresql.org/docs/9.6/static/infoschema-sequences.html
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-sequences.html
+// MySQL:    missing
 var informationSchemaSequences = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.sequences (
@@ -382,16 +392,18 @@ CREATE TABLE information_schema.sequences (
 				tree.NewDInt(64),                 // numeric precision
 				tree.NewDInt(2),                  // numeric precision radix
 				tree.NewDInt(0),                  // numeric scale
-				tree.NewDString(fmt.Sprintf("%d", table.SequenceOpts.Start)),     // start value
-				tree.NewDString(fmt.Sprintf("%d", table.SequenceOpts.MinValue)),  // min value
-				tree.NewDString(fmt.Sprintf("%d", table.SequenceOpts.MaxValue)),  // max value
-				tree.NewDString(fmt.Sprintf("%d", table.SequenceOpts.Increment)), // increment
+				tree.NewDString(strconv.FormatInt(table.SequenceOpts.Start, 10)),     // start value
+				tree.NewDString(strconv.FormatInt(table.SequenceOpts.MinValue, 10)),  // min value
+				tree.NewDString(strconv.FormatInt(table.SequenceOpts.MaxValue, 10)),  // max value
+				tree.NewDString(strconv.FormatInt(table.SequenceOpts.Increment, 10)), // increment
 				noString, // cycle
 			)
 		})
 	},
 }
 
+// Postgres: missing
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/statistics-table.html
 var informationSchemaStatisticsTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.statistics (
@@ -484,6 +496,8 @@ CREATE TABLE information_schema.statistics (
 	},
 }
 
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-table-constraints.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/table-constraints-table.html
 var informationSchemaTableConstraintTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.table_constraints (
@@ -528,6 +542,8 @@ CREATE TABLE information_schema.table_constraints (
 	},
 }
 
+// Postgres: missing
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/user-privileges-table.html
 var informationSchemaUserPrivileges = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.user_privileges (
@@ -554,6 +570,8 @@ CREATE TABLE information_schema.user_privileges (
 	},
 }
 
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-table-privileges.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/table-privileges-table.html
 var informationSchemaTablePrivileges = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.table_privileges (
@@ -596,6 +614,8 @@ var (
 	tableTypeView       = tree.NewDString("VIEW")
 )
 
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-tables.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/tables-table.html
 var informationSchemaTablesTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.tables (
@@ -627,6 +647,8 @@ CREATE TABLE information_schema.tables (
 	},
 }
 
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-views.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/views-table.html
 var informationSchemaViewsTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE information_schema.views (

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -165,7 +165,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   5 columns, 87 rows
+·                      size   5 columns, 88 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -222,7 +222,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      16 columns, 751 rows
+                     │                     size      16 columns, 762 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -110,6 +110,7 @@ SHOW TABLES FROM information_schema
 column_privileges
 columns
 key_column_usage
+referential_constraints
 schema_privileges
 schemata
 sequences
@@ -237,6 +238,7 @@ crdb_internal       zones
 information_schema  column_privileges
 information_schema  columns
 information_schema  key_column_usage
+information_schema  referential_constraints
 information_schema  schema_privileges
 information_schema  schemata
 information_schema  sequences
@@ -412,6 +414,7 @@ def            crdb_internal       zones                      SYSTEM VIEW  1
 def            information_schema  column_privileges          SYSTEM VIEW  1
 def            information_schema  columns                    SYSTEM VIEW  1
 def            information_schema  key_column_usage           SYSTEM VIEW  1
+def            information_schema  referential_constraints    SYSTEM VIEW  1
 def            information_schema  schema_privileges          SYSTEM VIEW  1
 def            information_schema  schemata                   SYSTEM VIEW  1
 def            information_schema  sequences                  SYSTEM VIEW  1
@@ -741,6 +744,7 @@ statement ok
 DROP TABLE num_prec
 
 ## information_schema.key_column_usage
+## information_schema.referential_constraints
 
 statement ok
 CREATE DATABASE constraint_column
@@ -757,14 +761,14 @@ CREATE TABLE constraint_column.t1 (
 statement ok
 CREATE TABLE constraint_column.t2 (
     t1_ID INT PRIMARY KEY,
-    CONSTRAINT fk FOREIGN KEY (t1_ID) REFERENCES constraint_column.t1(a)
+    CONSTRAINT fk FOREIGN KEY (t1_ID) REFERENCES constraint_column.t1(a) ON DELETE RESTRICT
 )
 
 statement ok
 CREATE TABLE constraint_column.t3 (
     a INT,
     b INT,
-    CONSTRAINT fk FOREIGN KEY (a, b) REFERENCES constraint_column.t1(b, c),
+    CONSTRAINT fk2 FOREIGN KEY (a, b) REFERENCES constraint_column.t1(b, c) ON UPDATE CASCADE,
     INDEX (a, b)
 )
 
@@ -781,8 +785,15 @@ def                 constraint_column  primary          def            constrain
 def                 constraint_column  t1_a_key         def            constraint_column  t1          a            1                 NULL
 def                 constraint_column  fk               def            constraint_column  t2          t1_id        1                 1
 def                 constraint_column  primary          def            constraint_column  t2          t1_id        1                 NULL
-def                 constraint_column  fk               def            constraint_column  t3          a            1                 1
-def                 constraint_column  fk               def            constraint_column  t3          b            2                 2
+def                 constraint_column  fk2              def            constraint_column  t3          a            1                 1
+def                 constraint_column  fk2              def            constraint_column  t3          b            2                 2
+
+query TTTTTTTTTTT colnames
+SELECT * FROM information_schema.referential_constraints WHERE constraint_schema = 'constraint_column' ORDER BY TABLE_NAME, CONSTRAINT_NAME
+----
+constraint_catalog  constraint_schema  constraint_name  unique_constraint_catalog  unique_constraint_schema  unique_constraint_name  match_option  update_rule  delete_rule  table_name  referenced_table_name
+def                 constraint_column  fk               def                        constraint_column         t1_a_key                FULL          NO ACTION    RESTRICT     t2          t1
+def                 constraint_column  fk2              def                        constraint_column         index_key               FULL          CASCADE      NO ACTION    t3          t1
 
 statement ok
 DROP DATABASE constraint_column CASCADE


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach/issues/8675.
Related to https://github.com/cockroachdb/cockroach/issues/13787.
Related to https://github.com/diesel-rs/diesel/issues/1134.

The `referential_constraints` table contains all foreign key constraints
in the current database.

Release note (sql change): Added referential_constraints table to the
information_schema.