### PR TITLE
ts: Time series memory monitoring

### DIFF
--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -58,17 +60,27 @@ type testModel struct {
 	modelData   map[string]roachpb.Value
 	seenSources map[string]struct{}
 	*localtestcluster.LocalTestCluster
-	DB *DB
+	DB         *DB
+	memMonitor *mon.BytesMonitor
 }
 
 // newTestModel creates a new testModel instance. The Start() method must
 // be called before using it.
 func newTestModel(t *testing.T) testModel {
+	monitor := mon.MakeUnlimitedMonitor(
+		context.Background(),
+		"timeseries-testmodel",
+		mon.MemoryResource,
+		nil,
+		nil,
+		queryMemoryMax/10,
+	)
 	return testModel{
 		t:                t,
 		modelData:        make(map[string]roachpb.Value),
 		seenSources:      make(map[string]struct{}),
 		LocalTestCluster: &localtestcluster.LocalTestCluster{},
+		memMonitor:       &monitor,
 	}
 }
 

--- a/pkg/ts/query_test.go
+++ b/pkg/ts/query_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"math"
 	"reflect"
+	"runtime"
 	"sort"
 	"testing"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 )
@@ -656,9 +658,20 @@ func (tm *testModel) assertQuery(
 		Derivative:       derivative,
 		Sources:          sources,
 	}
+
+	account := tm.memMonitor.MakeBoundAccount()
+	defer account.Close(context.TODO())
 	actualDatapoints, actualSources, err := tm.DB.Query(
-		context.TODO(), q, r, sampleDuration, start, end, interpolationLimit,
+		context.TODO(),
+		q,
+		r,
+		sampleDuration,
+		start,
+		end,
+		interpolationLimit,
+		&account,
 	)
+
 	if err != nil {
 		tm.t.Fatal(err)
 	}
@@ -966,8 +979,13 @@ func TestQueryDownsampling(t *testing.T) {
 	tm.Start()
 	defer tm.Stop()
 
+	account := tm.memMonitor.MakeBoundAccount()
+	defer account.Close(context.TODO())
+
 	// Query with sampleDuration that is too small, expect error.
-	_, _, err := tm.DB.Query(context.TODO(), tspb.Query{}, Resolution10s, 1, 0, 10000, 0)
+	_, _, err := tm.DB.Query(
+		context.TODO(), tspb.Query{}, Resolution10s, 1, 0, 10000, 0, &account,
+	)
 	if err == nil {
 		t.Fatal("expected query to fail with sampleDuration less than resolution allows.")
 	}
@@ -978,7 +996,14 @@ func TestQueryDownsampling(t *testing.T) {
 
 	// Query with sampleDuration which is not an even multiple of the resolution.
 	_, _, err = tm.DB.Query(
-		context.TODO(), tspb.Query{}, Resolution10s, Resolution10s.SampleDuration()+1, 0, 10000, 0,
+		context.TODO(),
+		tspb.Query{},
+		Resolution10s,
+		Resolution10s.SampleDuration()+1,
+		0,
+		10000,
+		0,
+		&account,
 	)
 	if err == nil {
 		t.Fatal("expected query to fail with sampleDuration not an even multiple of the query resolution.")
@@ -1113,4 +1138,89 @@ func TestInterpolationLimit(t *testing.T) {
 	tm.assertQuery("metric.innergaps", []string{"source1", "source2"}, nil, nil, nil, resolution1ns, 1, 0, 9, 2, 9, 2)
 	tm.assertQuery("metric.innergaps", []string{"source1", "source2"}, nil, nil, nil, resolution1ns, 1, 0, 9, 3, 9, 2)
 	tm.assertQuery("metric.innergaps", []string{"source1", "source2"}, nil, nil, nil, resolution1ns, 1, 0, 9, 10, 9, 2)
+}
+
+func TestQueryMemoryAccounting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tm := newTestModel(t)
+
+	memoryBudget := int64(100 * 1024)
+
+	// Swap model's memory monitor to install a limit.
+	unlimitedMon := tm.memMonitor
+	limitedMon := mon.MakeMonitorWithLimit(
+		"timeseries-test-limited",
+		mon.MemoryResource,
+		memoryBudget,
+		nil,
+		nil,
+		100,
+		100,
+	)
+	tm.memMonitor = &limitedMon
+	tm.memMonitor.Start(context.TODO(), unlimitedMon, mon.BoundAccount{})
+	defer tm.memMonitor.Stop(context.TODO())
+
+	tm.Start()
+	defer tm.Stop()
+
+	tm.storeTimeSeriesData(resolution1ns, []tspb.TimeSeriesData{
+		{
+			Name: "test.metric",
+			Datapoints: []tspb.TimeSeriesDatapoint{
+				datapoint(1, 100),
+				datapoint(5, 200),
+				datapoint(15, 300),
+				datapoint(16, 400),
+				datapoint(17, 500),
+				datapoint(22, 600),
+				datapoint(52, 900),
+			},
+		},
+	})
+	tm.assertKeyCount(4)
+	tm.assertModelCorrect()
+
+	// Assert correctness with no memory pressure.
+	tm.assertQuery("test.metric", nil, nil, nil, nil, resolution1ns, 1, 0, 60, 0, 7, 1)
+
+	// Assert failure with memory pressure.
+	acc := limitedMon.MakeBoundAccount()
+	if err := acc.Grow(context.TODO(), memoryBudget-1); err != nil {
+		t.Fatal(err)
+	}
+
+	queryAcc := limitedMon.MakeBoundAccount()
+	defer queryAcc.Close(context.TODO())
+	_, _, err := tm.DB.Query(
+		context.TODO(), tspb.Query{Name: "test.metric"}, resolution1ns, 1, 0, 10000, 0, &queryAcc,
+	)
+	if errorStr := "memory budget exceeded"; !testutils.IsError(err, errorStr) {
+		t.Fatalf("bad query got error %q, wanted to match %q", err.Error(), errorStr)
+	}
+
+	// Assert success again with memory pressure released.
+	acc.Close(context.TODO())
+	tm.assertQuery("test.metric", nil, nil, nil, nil, resolution1ns, 1, 0, 60, 0, 7, 1)
+
+	// Start/Stop limited monitor to reset maximum allocation.
+	tm.memMonitor.Stop(context.TODO())
+	tm.memMonitor.Start(context.TODO(), unlimitedMon, mon.BoundAccount{})
+
+	var (
+		memStatsBefore runtime.MemStats
+		memStatsAfter  runtime.MemStats
+	)
+	runtime.ReadMemStats(&memStatsBefore)
+
+	_, _, err = tm.DB.Query(
+		context.TODO(), tspb.Query{Name: "test.metric"}, resolution1ns, 1, 0, 10000, 0, &queryAcc,
+	)
+	if err != nil {
+		t.Fatalf("expected no error from query, got %v", err)
+	}
+
+	runtime.ReadMemStats(&memStatsAfter)
+	t.Logf("total allocations for query: %d\n", memStatsAfter.TotalAlloc-memStatsBefore.TotalAlloc)
+	t.Logf("maximum allocations for query monitor: %d\n", limitedMon.MaximumBytes())
 }

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -267,6 +267,10 @@ func TestBoundAccount(t *testing.T) {
 		t.Fatal("closing spans leaves bytes in monitor")
 	}
 
+	if m2 := a1.Monitor(); m2 != &m {
+		t.Fatalf("a1.Monitor() returned %v, wanted %v", m2, &m)
+	}
+
 	m.Stop(ctx)
 }
 
@@ -297,6 +301,9 @@ func TestBytesMonitor(t *testing.T) {
 	}
 	if m.mu.maxAllocated != 100 {
 		t.Fatalf("incorrect max allocation: got %d, expected %d", m.mu.maxAllocated, 100)
+	}
+	if m.MaximumBytes() != 100 {
+		t.Fatalf("incorrect MaximumBytes(): got %d, expected %d", m.mu.maxAllocated, 100)
 	}
 
 	m.releaseBytes(ctx, 10) // Should succeed without panic.


### PR DESCRIPTION
Outfit the time series query system with memory monitoring.

+ TS Server creates an unlimited memory monitor. Incoming requests
create monitors using the top-level monitor as a pool.
+ TS server passes a BoundAccount to each invocation of DB.Query.
+ DB.Query method applies its major sources of memory growth to
BoundAccount.Grow().

The TS Server monitor is currently unlimited, but a limit will be
applied once resource governing is in place.

Release note: None