### PR TITLE
libroach: teach CTest about individual tests

### DIFF
--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -90,6 +90,9 @@ add_subdirectory(../googletest/googletest
                  ${CMAKE_BINARY_DIR}/googletest
                  EXCLUDE_FROM_ALL)
 
+# TODO(benesch): make this required when CMake 3.9 is widely deployed.
+include(GoogleTest OPTIONAL)
+
 # Iterate over all test sources.
 foreach(tsrc ${tests})
   # Build target name from filename (eg: ccl_db_test.cc for ccl/db_test.cc).
@@ -141,6 +144,14 @@ foreach(tsrc ${tests})
   )
 
   # Add the executable to the set of tests run by the "check" target.
-  add_test(${tname} ${tname})
+  if(COMMAND gtest_discover_tests)
+    # gtest_discover_tests, introduced in CMake 3.10, teaches CTest about the
+    # actual test cases within the test binary.
+    gtest_discover_tests(${tname})
+  else()
+    # In earlier versions, just tell CTest to treat the test binary as a black
+    # box that returns an exit code.
+    add_test(${tname} ${tname})
+  endif()
   add_dependencies(check ${tname})
 endforeach(tsrc)


### PR DESCRIPTION
CMake 3.10 introduced support for introspecting gtest binaries to
discover the tests within. This makes using CTest more pleasant, as you
select a single unit test to run, whereas before you had to select an
entire test binary to run.

Release note: None