### PR TITLE
storage/engine: ensure test coverage for mvccGetInternal

### DIFF
--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1293,9 +1293,11 @@ func mvccPutInternal(
 	} else {
 		// There is no existing value for this key. Even if the new value is
 		// nil write a deletion tombstone for the key.
-		if value, err = maybeGetValue(
-			ctx, iter, metaKey, value, ok, timestamp, txn, buf, valueFn); err != nil {
-			return err
+		if valueFn != nil {
+			value, err = valueFn(nil)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	{


### PR DESCRIPTION
Removing `mvccGetInternal` has proved difficult because the usage from
`mvccPutInternal` touches optimizations which allow the Go version to
not perform additional Cgo crossings. I haven't figured out a way to use
the C++ version of `MVCCGet` from `mvccPutInternal` without taking a
significant performance hit (20-40%) on
`BenchmarkMVCCConditionalPut_RocksDB/Replace`. The short term solution
is to accept the duplicated code and ensure we're testing both
implementations.

Release note: None