### PR TITLE
distsql: tests force stored side in HashJoiner

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -94,6 +94,9 @@ type hashJoiner struct {
 	// stream we store fully and build the hashRowContainer from.
 	storedSide joinSide
 
+	// Used by tests to force a storedSide.
+	forcedStoredSide *joinSide
+
 	// testingKnobMemFailPoint specifies a phase in which the hashJoiner will
 	// fail at a random point during this phase.
 	testingKnobMemFailPoint hashJoinPhase
@@ -445,6 +448,10 @@ func (h *hashJoiner) bufferPhase(
 		side := rightSide
 		if leftUsage < rightUsage {
 			side = leftSide
+		}
+
+		if h.forcedStoredSide != nil {
+			side = *h.forcedStoredSide
 		}
 
 		row, earlyExit, err := h.receiveRow(ctx, srcs[side], side)


### PR DESCRIPTION
The HashJoiner should work regardless of which side it chooses to store
in the hashmap. Both sides should be tested for every test case. This
allows tests to force a specific side and updates the HashJoiner tests
so they run all the tests with both the left and right sides stored.

Release note: None