### PR TITLE
sql: rename 'DBNameOriginallyOmitted' to 'OmitDBNameDuringFormatting'

### DIFF
--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -75,7 +75,7 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 					return
 				}
 				// Persist the database prefix expansion.
-				tn.DBNameOriginallyOmitted = false
+				tn.OmitDBNameDuringFormatting = false
 			},
 		)
 		f.FormatNode(n.AsSource)

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -505,7 +505,7 @@ func (p *planner) getTableScanByRef(
 		// So instead, we mark the "database name as originally omitted"
 		// so as to prevent pretty-printing a potentially confusing empty
 		// database name in error messages (we want `foo` not `"".foo`).
-		DBNameOriginallyOmitted: true,
+		OmitDBNameDuringFormatting: true,
 	}
 
 	src, err := p.getPlanForDesc(ctx, desc, &tn, hints, scanVisibility, tref.Columns)
@@ -769,7 +769,7 @@ func (src *dataSourceInfo) expandStar(
 		}
 	}
 
-	tableName := tree.TableName{DBNameOriginallyOmitted: true}
+	tableName := tree.TableName{OmitDBNameDuringFormatting: true}
 	if a, ok := v.(*tree.AllColumnsSelector); ok {
 		tableName = a.TableName
 	}

--- a/pkg/sql/opt/scope.go
+++ b/pkg/sql/opt/scope.go
@@ -72,7 +72,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 					// TODO(peter): what is this doing?
 					if tblName == "" && col.table != "" {
 						t.TableName.TableName = tree.Name(col.table)
-						t.TableName.DBNameOriginallyOmitted = true
+						t.TableName.OmitDBNameDuringFormatting = true
 					}
 					return false, col
 				}

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -99,12 +99,12 @@ type TableName struct {
 	DatabaseName Name
 	TableName    Name
 
-	// DBNameOriginallyOmitted, when set to true, causes the
+	// OmitDBNameDuringFormatting, when set to true, causes the
 	// String()/Format() methods to omit the database name even if one
 	// is set. This is used to ensure that pretty-printing
 	// a TableName normalized from a parser input yields back
 	// the original syntax.
-	DBNameOriginallyOmitted bool
+	OmitDBNameDuringFormatting bool
 
 	// PrefixOriginallySpecified indicates whether a prefix was
 	// explicitly indicated in the input syntax.
@@ -114,7 +114,7 @@ type TableName struct {
 // Format implements the NodeFormatter interface.
 func (t *TableName) Format(ctx *FmtCtx) {
 	f := ctx.flags
-	if !t.DBNameOriginallyOmitted ||
+	if !t.OmitDBNameDuringFormatting ||
 		f.HasFlags(FmtAlwaysQualifyTableNames) || ctx.tableNameFormatter != nil {
 		if t.PrefixOriginallySpecified {
 			ctx.FormatNode(&t.PrefixName)
@@ -163,7 +163,7 @@ func (n *UnresolvedName) normalizeTableNameAsValue() (res TableName, err error) 
 		return res, NewInvalidNameErrorf("empty table name: %q", ErrString(n))
 	}
 
-	res = TableName{TableName: *name, DBNameOriginallyOmitted: true}
+	res = TableName{TableName: *name, OmitDBNameDuringFormatting: true}
 
 	if len(*n) > 1 {
 		ndb, ok := (*n)[len(*n)-2].(*Name)
@@ -176,7 +176,7 @@ func (n *UnresolvedName) normalizeTableNameAsValue() (res TableName, err error) 
 			return res, NewInvalidNameErrorf("empty database name: %q", ErrString(n))
 		}
 
-		res.DBNameOriginallyOmitted = false
+		res.OmitDBNameDuringFormatting = false
 
 		if len(*n) > 2 {
 			pn, ok := (*n)[len(*n)-3].(*Name)
@@ -206,7 +206,7 @@ func (n *UnresolvedName) NormalizeTableName() (*TableName, error) {
 // table       -> database.table
 // table@index -> database.table@index
 func (t *TableName) QualifyWithDatabase(database string) error {
-	if !t.DBNameOriginallyOmitted {
+	if !t.OmitDBNameDuringFormatting {
 		return nil
 	}
 	if database == "" {

--- a/pkg/sql/sem/tree/table_name_test.go
+++ b/pkg/sql/sem/tree/table_name_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func resetRepr(tn *tree.TableName) {
-	tn.DBNameOriginallyOmitted = false
+	tn.OmitDBNameDuringFormatting = false
 }
 
 func TestNormalizeTableName(t *testing.T) {

--- a/pkg/sql/sem/tree/var_name.go
+++ b/pkg/sql/sem/tree/var_name.go
@@ -113,7 +113,7 @@ type AllColumnsSelector struct {
 
 // Format implements the NodeFormatter interface.
 func (a *AllColumnsSelector) Format(ctx *FmtCtx) {
-	if !a.TableName.DBNameOriginallyOmitted {
+	if !a.TableName.OmitDBNameDuringFormatting {
 		ctx.FormatNode(&a.TableName.DatabaseName)
 		ctx.WriteByte('.')
 	}
@@ -156,7 +156,7 @@ type ColumnItem struct {
 // Format implements the NodeFormatter interface.
 func (c *ColumnItem) Format(ctx *FmtCtx) {
 	if c.TableName.TableName != "" {
-		if !c.TableName.DBNameOriginallyOmitted {
+		if !c.TableName.OmitDBNameDuringFormatting {
 			ctx.FormatNode(&c.TableName.DatabaseName)
 			ctx.WriteByte('.')
 		}

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -126,9 +126,9 @@ func (p *planner) printForeignKeyConstraint(
 		return err
 	}
 	fkTableName := tree.TableName{
-		DatabaseName:            tree.Name(fkDb.Name),
-		TableName:               tree.Name(fkTable.Name),
-		DBNameOriginallyOmitted: fkDb.Name == dbPrefix,
+		DatabaseName:               tree.Name(fkDb.Name),
+		TableName:                  tree.Name(fkTable.Name),
+		OmitDBNameDuringFormatting: fkDb.Name == dbPrefix,
 	}
 	fmtCtx := tree.MakeFmtCtx(buf, tree.FmtSimple)
 	buf.WriteString("FOREIGN KEY (")
@@ -303,9 +303,9 @@ func (p *planner) showCreateInterleave(
 		return err
 	}
 	parentName := tree.TableName{
-		DatabaseName:            tree.Name(parentDbDesc.Name),
-		TableName:               tree.Name(parentTable.Name),
-		DBNameOriginallyOmitted: parentDbDesc.Name == dbPrefix,
+		DatabaseName:               tree.Name(parentDbDesc.Name),
+		TableName:                  tree.Name(parentTable.Name),
+		OmitDBNameDuringFormatting: parentDbDesc.Name == dbPrefix,
 	}
 	var sharedPrefixLen int
 	for _, ancestor := range intl.Ancestors {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -566,9 +566,9 @@ func getTableNames(
 			return nil, err
 		}
 		tn := tree.TableName{
-			DatabaseName:            tree.Name(dbDesc.Name),
-			TableName:               tree.Name(tableName),
-			DBNameOriginallyOmitted: dbNameOriginallyOmitted,
+			DatabaseName:               tree.Name(dbDesc.Name),
+			TableName:                  tree.Name(tableName),
+			OmitDBNameDuringFormatting: dbNameOriginallyOmitted,
 		}
 		tableNames = append(tableNames, tn)
 	}
@@ -704,7 +704,7 @@ func expandTableGlob(
 		return nil, err
 	}
 
-	tableNames, err := getTableNames(ctx, txn, vt, dbDesc, glob.DBNameOriginallyOmitted)
+	tableNames, err := getTableNames(ctx, txn, vt, dbDesc, glob.OmitDBNameDuringFormatting)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -86,9 +86,9 @@ func (e virtualSchemaEntry) tableNames(dbNameOriginallyOmitted bool) tree.TableN
 	var res tree.TableNames
 	for _, tableName := range e.orderedTableNames {
 		tn := tree.TableName{
-			DatabaseName:            tree.Name(e.desc.Name),
-			TableName:               tree.Name(tableName),
-			DBNameOriginallyOmitted: dbNameOriginallyOmitted,
+			DatabaseName:               tree.Name(e.desc.Name),
+			TableName:                  tree.Name(tableName),
+			OmitDBNameDuringFormatting: dbNameOriginallyOmitted,
 		}
 		res = append(res, tn)
 	}


### PR DESCRIPTION
This clarifies its meaning and makes reading the corresponding code
easier.

Change requested by @andreimatei.

Release note: None

Fixes #17374.