### PR TITLE
sql: dedup inverted index keys

### DIFF
--- a/pkg/ccl/sqlccl/load.go
+++ b/pkg/ccl/sqlccl/load.go
@@ -324,6 +324,13 @@ func (i inserter) Put(key, value interface{}) {
 	})
 }
 
+func (i inserter) InitPut(key, value interface{}, failOnTombstones bool) {
+	i(roachpb.KeyValue{
+		Key:   *key.(*roachpb.Key),
+		Value: *value.(*roachpb.Value),
+	})
+}
+
 // isEndOfStatement returns true if stmt ends with a semicolon.
 func isEndOfStatement(stmt string) bool {
 	sc := parser.MakeScanner(stmt)

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -115,9 +115,6 @@ INSERT INTO d VALUES(16, '{}')
 statement error pq: attempted access to empty key
 INSERT INTO d VALUES(16, '[]')
 
-statement error pq: duplicate key value \(b\)=\(NULL\) violates unique constraint "foo_inv"
-INSERT INTO d VALUES (20, '["a", "a"]')
-
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a":"b"}'
 ----
@@ -269,3 +266,35 @@ SELECT * from d where b @> '{}' ORDER BY a;
 
 statement error pq: constraints = , table ID = 53, index ID = 2: can't look up empty JSON
 SELECT * from d where b @> '[]' ORDER BY a;
+
+statement ok
+INSERT INTO d VALUES (20, '["a", "a"]')
+
+query IT
+SELECT * from d where b @> '["a"]' ORDER BY a;
+----
+20  ["a","a"]
+
+statement ok
+INSERT INTO d VALUES (21, '[{"a":"a"}, {"a":"a"}]')
+
+query IT
+SELECT * from d where b @> '[{"a":"a"}]' ORDER BY a;
+----
+21  [{"a":"a"},{"a":"a"}]
+
+statement ok
+INSERT INTO d VALUES (22,  '[[[["a"]]],[[["a"]]]]')
+
+query IT
+SELECT * from d where b @> '[[[["a"]]]]' ORDER BY a;
+----
+22  [[[["a"]]],[[["a"]]]]
+
+statement ok
+INSERT INTO d VALUES (23,  '[1,2,3,1]')
+
+query IT
+SELECT * from d where b @> '[[[["a"]]]]' ORDER BY a;
+----
+22  [[[["a"]]],[[["a"]]]]

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -122,7 +122,7 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^
 (0,1)  starting plan  querying next range at /Table/3/1/1/2/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
-(0,1)  starting plan  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+(0,1)  starting plan  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 (0,1)  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> gc_deadline:0 >
 (0,1)  starting plan  querying next range at /Table/3/1/52/2/1
 (0,1)  starting plan  r1: sending batch 1 Put to (n1,s1):1
@@ -142,29 +142,26 @@ query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
 (0,0)  sql txn implicit  CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-(0,0)  sql txn implicit  CPut /Table/52/2/2/0 -> /BYTES/‰
 (0,2)  consuming rows    output row: []
 (0,0)  sql txn implicit  querying next range at /Table/52/1/1/0
-(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
 (0,0)  sql txn implicit  CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-(0,0)  sql txn implicit  CPut /Table/52/2/2/0 -> /BYTES/‰
 (0,2)  consuming rows    output row: []
 (0,0)  sql txn implicit  querying next range at /Table/52/1/1/0
-(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 (0,2)  consuming rows    execution failed: duplicate key value (k)=(1) violates unique constraint "primary"
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (2,2)]
 ----
 (0,0)  sql txn implicit  CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
-(0,0)  sql txn implicit  CPut /Table/52/2/2/0 -> /BYTES/Š
 (0,2)  consuming rows    output row: []
 (0,0)  sql txn implicit  querying next range at /Table/52/1/2/0
-(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 (0,2)  consuming rows    execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
 query TTT
@@ -175,9 +172,8 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) V
 (0,0)  sql txn implicit  querying next range at /Table/52/1/2
 (0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
 (0,0)  sql txn implicit  CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/3
-(0,0)  sql txn implicit  CPut /Table/52/2/3/0 -> /BYTES/Š
 (0,0)  sql txn implicit  querying next range at /Table/52/1/2/0
-(0,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+(0,0)  sql txn implicit  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (1,2)]
@@ -342,7 +338,7 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^
 (0,1)  starting plan  querying next range at /Table/3/1/1/2/1
 (0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
 (0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
-(0,1)  starting plan  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+(0,1)  starting plan  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 (0,1)  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:4 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> gc_deadline:0 >
 (0,1)  starting plan  querying next range at /Table/3/1/52/2/1
 (0,1)  starting plan  r1: sending batch 1 Put to (n1,s1):1


### PR DESCRIPTION
Before if we added a JSON columns with a duplicate key, for example
["a", "a"] the insertion would fail because index key generated
would be the same for both values resulting in a duplicate key error.

Now the whole set of keys generated for a JSON object will be deduped
so we will be able to insert and lookup JSON object with duplicate
paths.

Release note: None