### PR TITLE
distsql: add anti join to MergeJoiner

### DIFF
--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -180,6 +180,9 @@ func (m *mergeJoiner) nextRow() (sqlbase.EncDatumRow, *ProducerMetadata) {
 				}
 				if renderedRow != nil {
 					m.matchedRightCount++
+					if m.joinType == leftAntiJoin {
+						break
+					}
 					if m.emitUnmatchedRight {
 						m.matchedRight.Add(ridx)
 					}
@@ -204,7 +207,7 @@ func (m *mergeJoiner) nextRow() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			m.leftIdx++
 
 			// If we didn't match any rows on the right-side of the batch and this is
-			// a left or full outer join, emit an unmatched left-side row.
+			// a left, full outer or anti join, emit an unmatched left-side row.
 			if m.matchedRightCount == 0 && shouldEmitUnmatchedRow(leftSide, m.joinType) {
 				return m.renderUnmatchedRow(lrow, leftSide), nil
 			}


### PR DESCRIPTION
Anti-join is an operation which given a left and right relation L and R,
returns 'only those tuples in L for which there is no tuple in R that is
equal on their common attribute names.'[1]

[1] https://en.wikipedia.org/wiki/Relational_algebra#Antijoin

It would be used for queries such as:
```
CREATE t1 (a int, b int); CREATE t2 (c int, d int);
SELECT a FROM t1 WHERE a NOT IN (SELECT c FROM t2);
```
which would translate to something like `antiJoin(t1, t2, ON a = c)`

Last of the merge/anti hash/merge joiner combinations for #19450

Release note: None