### PR TITLE
opt: use FastIntMap during exec

### DIFF
--- a/pkg/sql/opt/exec.go
+++ b/pkg/sql/opt/exec.go
@@ -73,19 +73,18 @@ type ExecFactory interface {
 type execNodeSchema struct {
 	// outputCols maps columns in the output set of the relational expression to
 	// indices in the result columns of the ExecNode.
-	outputCols  map[columnIndex]int
+	outputCols  columnMap
 	outputTypes []types.T
 }
 
 func getSchema(props *relationalProps) execNodeSchema {
 	s := execNodeSchema{
-		outputCols:  make(map[columnIndex]int, props.outputCols.Len()),
 		outputTypes: make([]types.T, 0, props.outputCols.Len()),
 	}
 
 	for i := range props.columns {
 		if props.outputCols.Contains(props.columns[i].index) {
-			s.outputCols[props.columns[i].index] = i
+			s.outputCols.Set(props.columns[i].index, i)
 			s.outputTypes = append(s.outputTypes, props.columns[i].typ)
 		}
 	}

--- a/pkg/sql/opt/relational_props.go
+++ b/pkg/sql/opt/relational_props.go
@@ -27,6 +27,7 @@ import (
 type tableName string
 type columnName string
 type columnSet = util.FastIntSet
+type columnMap = util.FastIntMap
 type columnIndex = int
 
 // queryState holds per-query state.

--- a/pkg/sql/opt/typed_expr.go
+++ b/pkg/sql/opt/typed_expr.go
@@ -90,7 +90,7 @@ type typedExprConvCtx struct {
 
 	// varToIndexedVar is a map used when converting a variableOp into an
 	// IndexedVar. It is optional: if it is nil, a 1-to-1 mapping is assumed.
-	varToIndexedVar map[columnIndex]int
+	varToIndexedVar columnMap
 }
 
 func constOpToTypedExpr(c *typedExprConvCtx, e *Expr) tree.TypedExpr {
@@ -100,11 +100,11 @@ func constOpToTypedExpr(c *typedExprConvCtx, e *Expr) tree.TypedExpr {
 func variableOpToTypedExpr(c *typedExprConvCtx, e *Expr) tree.TypedExpr {
 	col := e.private.(*columnProps)
 	var idx int
-	if c.varToIndexedVar == nil {
+	if c.varToIndexedVar.Empty() {
 		idx = col.index
 	} else {
 		var ok bool
-		idx, ok = c.varToIndexedVar[col.index]
+		idx, ok = c.varToIndexedVar.Get(col.index)
 		if !ok {
 			panic(fmt.Sprintf("missing variable-IndexedVar mapping for %d", col.index))
 		}

--- a/pkg/util/fast_int_map.go
+++ b/pkg/util/fast_int_map.go
@@ -22,6 +22,11 @@ type FastIntMap struct {
 	large map[int]int
 }
 
+// Empty returns true if the map is empty.
+func (m FastIntMap) Empty() bool {
+	return m.small == [numWords]uint64{} && len(m.large) == 0
+}
+
 // Copy returns a FastIntMap that can be independently modified.
 func (m FastIntMap) Copy() FastIntMap {
 	if m.large == nil {


### PR DESCRIPTION
Changing `map[columnIndex]int` to `util.FastIntMap`.

Release note: None