### PR TITLE
opt: Add preliminary support for building a memo

### DIFF
--- a/pkg/sql/opt/build/builder.go
+++ b/pkg/sql/opt/build/builder.go
@@ -1,0 +1,664 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package build
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+type unaryFactoryFunc func(f *xform.Factory, input xform.GroupID) xform.GroupID
+type binaryFactoryFunc func(f *xform.Factory, left, right xform.GroupID) xform.GroupID
+
+// Map from tree.ComparisonOperator to Factory constructor function.
+var comparisonOpMap = [...]binaryFactoryFunc{
+	tree.EQ:                (*xform.Factory).ConstructEq,
+	tree.LT:                (*xform.Factory).ConstructLt,
+	tree.GT:                (*xform.Factory).ConstructGt,
+	tree.LE:                (*xform.Factory).ConstructLe,
+	tree.GE:                (*xform.Factory).ConstructGe,
+	tree.NE:                (*xform.Factory).ConstructNe,
+	tree.In:                (*xform.Factory).ConstructIn,
+	tree.NotIn:             (*xform.Factory).ConstructNotIn,
+	tree.Like:              (*xform.Factory).ConstructLike,
+	tree.NotLike:           (*xform.Factory).ConstructNotLike,
+	tree.ILike:             (*xform.Factory).ConstructILike,
+	tree.NotILike:          (*xform.Factory).ConstructNotILike,
+	tree.SimilarTo:         (*xform.Factory).ConstructSimilarTo,
+	tree.NotSimilarTo:      (*xform.Factory).ConstructNotSimilarTo,
+	tree.RegMatch:          (*xform.Factory).ConstructRegMatch,
+	tree.NotRegMatch:       (*xform.Factory).ConstructNotRegMatch,
+	tree.RegIMatch:         (*xform.Factory).ConstructRegIMatch,
+	tree.NotRegIMatch:      (*xform.Factory).ConstructNotRegIMatch,
+	tree.IsDistinctFrom:    (*xform.Factory).ConstructIsDistinctFrom,
+	tree.IsNotDistinctFrom: (*xform.Factory).ConstructIsNotDistinctFrom,
+	tree.Any:               (*xform.Factory).ConstructAny,
+	tree.Some:              (*xform.Factory).ConstructSome,
+	tree.All:               (*xform.Factory).ConstructAll,
+}
+
+// Map from tree.BinaryOperator to Factory constructor function.
+var binaryOpMap = [...]binaryFactoryFunc{
+	tree.Bitand:   (*xform.Factory).ConstructBitand,
+	tree.Bitor:    (*xform.Factory).ConstructBitor,
+	tree.Bitxor:   (*xform.Factory).ConstructBitxor,
+	tree.Plus:     (*xform.Factory).ConstructPlus,
+	tree.Minus:    (*xform.Factory).ConstructMinus,
+	tree.Mult:     (*xform.Factory).ConstructMult,
+	tree.Div:      (*xform.Factory).ConstructDiv,
+	tree.FloorDiv: (*xform.Factory).ConstructFloorDiv,
+	tree.Mod:      (*xform.Factory).ConstructMod,
+	tree.Pow:      (*xform.Factory).ConstructPow,
+	tree.Concat:   (*xform.Factory).ConstructConcat,
+	tree.LShift:   (*xform.Factory).ConstructLShift,
+	tree.RShift:   (*xform.Factory).ConstructRShift,
+}
+
+// Map from tree.UnaryOperator to Factory constructor function.
+var unaryOpMap = [...]unaryFactoryFunc{
+	tree.UnaryPlus:       (*xform.Factory).ConstructUnaryPlus,
+	tree.UnaryMinus:      (*xform.Factory).ConstructUnaryMinus,
+	tree.UnaryComplement: (*xform.Factory).ConstructUnaryComplement,
+}
+
+// Builder holds the context needed for building a memo structure from a SQL
+// statement. Builder.Build() is the top-level function to perform this build
+// process. As part of the build process, it performs name resolution and
+// type checking on the expressions within Builder.stmt.
+//
+// The memo structure is the primary data structure used for query
+// optimization, so building the memo is the first step required to
+// optimize a query. The memo is maintained inside Builder.factory,
+// which exposes methods to construct expression groups inside the memo.
+//
+// A memo is essentially a compact representation of a forest of logically-
+// equivalent query trees. Each tree is either a logical or a physical plan
+// for executing the SQL query. After the build process is complete, the memo
+// forest will contain exactly one tree: the logical query plan corresponding
+// to the AST of the original SQL statement with some number of "normalization"
+// transformations applied. Normalization transformations include heuristics
+// such as predicate push-down that should always be applied. They do not
+// include "exploration" transformations whose benefit must be evaluated with
+// the optimizer's cost model (e.g., join reordering).
+//
+// See factory.go and memo.go inside the opt/xform package for more details
+// about the memo structure.
+type Builder struct {
+	factory *xform.Factory
+	stmt    tree.Statement
+	semaCtx tree.SemaContext
+	ctx     context.Context
+
+	// Skip index 0 in order to reserve it to indicate the "unknown" column.
+	colMap []columnProps
+}
+
+// NewBuilder creates a new Builder structure initialized with the given
+// Context, Factory, and parsed SQL statement.
+func NewBuilder(ctx context.Context, factory *xform.Factory, stmt tree.Statement) *Builder {
+	b := &Builder{factory: factory, stmt: stmt, colMap: make([]columnProps, 1), ctx: ctx}
+
+	ivarHelper := tree.MakeIndexedVarHelper(b, 0)
+	b.semaCtx.IVarHelper = &ivarHelper
+	b.semaCtx.Placeholders = tree.MakePlaceholderInfo()
+
+	return b
+}
+
+// Build is the top-level function to build the memo structure inside
+// Builder.factory from the parsed SQL statement in Builder.stmt. See the
+// comment above the Builder type declaration for details.
+//
+// The first return value `root` is the group ID of the root memo group.
+// The second return value `required` is the set of physical properties
+// (e.g., row and column ordering) that are required of the root memo group.
+// If any subroutines panic with a builderError as part of the build process,
+// the panic is caught here and returned as an error.
+func (b *Builder) Build() (root xform.GroupID, required *xform.PhysicalProps, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			// This code allows us to propagate builder errors without adding
+			// lots of checks for `if err != nil` throughout the code. This is
+			// only possible because the code does not update shared state and does
+			// not manipulate locks.
+			if _, ok := r.(builderError); ok {
+				err = r.(builderError)
+			} else {
+				panic(r)
+			}
+		}
+	}()
+
+	out, _ := b.buildStmt(b.stmt, &scope{builder: b})
+	root = out
+
+	// TODO(rytaft): Add physical properties that are required of the root memo
+	// group.
+	required = &xform.PhysicalProps{}
+	return
+}
+
+// builderError is used for semantic errors that occur during the build process
+// and is passed as an argument to panic. These panics are caught and converted
+// back to errors inside Builder.Build.
+type builderError error
+
+// errorf formats according to a format specifier and returns the
+// string as a builderError.
+func errorf(format string, a ...interface{}) builderError {
+	return fmt.Errorf(format, a...)
+}
+
+// buildStmt builds a set of memo groups that represent the given SQL
+// statement.
+//
+// NOTE: The following description of the inScope parameter and return values
+//       applies for all buildXXX() functions in this file.
+//
+// inScope   This parameter contains the name bindings that are visible for this
+//           statement/expression (e.g., passed in from an enclosing statement).
+//
+// out       This return value corresponds to the top-level memo group ID for
+//           this statement/expression.
+//
+// outScope  This return value contains the newly bound variables that will be
+//           visible to enclosing statements, as well as a pointer to any
+//           "parent" scope that is still visible.
+func (b *Builder) buildStmt(
+	stmt tree.Statement, inScope *scope,
+) (out xform.GroupID, outScope *scope) {
+	// NB: The case statements are sorted lexicographically.
+	switch stmt := stmt.(type) {
+	case *tree.ParenSelect:
+		return b.buildSelect(stmt.Select, inScope)
+
+	case *tree.Select:
+		return b.buildSelect(stmt, inScope)
+
+	default:
+		panic(errorf("unexpected statement: %T", stmt))
+	}
+}
+
+// buildTable builds a set of memo groups that represent the given table
+// expression. For example, if the tree.TableExpr consists of a single table,
+// the resulting set of memo groups will consist of a single group with a
+// scanOp operator. Joins will result in the construction of several groups,
+// including two for the left and right table scans, at least one for the join
+// condition, and one for the join itself.
+// TODO(rytaft): Add support for function and join table expressions.
+//
+// See Builder.buildStmt above for a description of the remaining input and
+// return values.
+func (b *Builder) buildTable(
+	texpr tree.TableExpr, inScope *scope,
+) (out xform.GroupID, outScope *scope) {
+	// NB: The case statements are sorted lexicographically.
+	switch source := texpr.(type) {
+	case *tree.AliasedTableExpr:
+		out, outScope = b.buildTable(source.Expr, inScope)
+
+		// Overwrite output properties with any alias information.
+		if source.As.Alias != "" {
+			if n := len(source.As.Cols); n > 0 && n != len(outScope.cols) {
+				panic(errorf("rename specified %d columns, but table contains %d", n, len(outScope.cols)))
+			}
+
+			for i := range outScope.cols {
+				outScope.cols[i].table = optbase.TableName(source.As.Alias)
+				if i < len(source.As.Cols) {
+					outScope.cols[i].name = optbase.ColumnName(source.As.Cols[i])
+				}
+			}
+		}
+
+		return
+
+	case *tree.NormalizableTableName:
+		tn, err := source.Normalize()
+		if err != nil {
+			panic(builderError(err))
+		}
+		tbl, err := b.factory.Metadata().Catalog().FindTable(b.ctx, tn)
+		if err != nil {
+			panic(builderError(err))
+		}
+
+		return b.buildScan(tbl, inScope)
+
+	case *tree.ParenTableExpr:
+		return b.buildTable(source.Expr, inScope)
+
+	case *tree.Subquery:
+		return b.buildStmt(source.Select, inScope)
+
+	default:
+		panic(errorf("not yet implemented: table expr: %T", texpr))
+	}
+}
+
+// buildScan builds a memo group for a scanOp expression on the given table.
+//
+// See Builder.buildStmt above for a description of the remaining input and
+// return values.
+func (b *Builder) buildScan(
+	tbl optbase.Table, inScope *scope,
+) (out xform.GroupID, outScope *scope) {
+	tblIndex := b.factory.Metadata().AddTable(tbl)
+
+	outScope = inScope.push()
+	for i := 0; i < tbl.NumColumns(); i++ {
+		col := tbl.Column(i)
+		colIndex := b.factory.Metadata().TableColumn(tblIndex, i)
+		colProps := columnProps{
+			index:  colIndex,
+			name:   col.ColName(),
+			table:  tbl.TabName(),
+			typ:    col.DatumType(),
+			hidden: col.IsHidden(),
+		}
+
+		b.colMap = append(b.colMap, colProps)
+		outScope.cols = append(outScope.cols, colProps)
+	}
+
+	return b.factory.ConstructScan(b.factory.InternPrivate(tblIndex)), outScope
+}
+
+// buildScalar builds a set of memo groups that represent the given scalar
+// expression.
+//
+// inScope contains the name bindings that are visible for this scalar
+// expression (e.g., passed in from an enclosing statement).
+// The return value corresponds to the top-level memo group ID for this scalar
+// expression.
+func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) xform.GroupID {
+	switch t := scalar.(type) {
+	case *columnProps:
+		return b.factory.ConstructVariable(b.factory.InternPrivate(t.index))
+
+	case *tree.AndExpr:
+		return b.factory.ConstructAnd(
+			b.buildScalar(t.TypedLeft(), inScope),
+			b.buildScalar(t.TypedRight(), inScope),
+		)
+
+	case *tree.BinaryExpr:
+		return binaryOpMap[t.Operator](b.factory,
+			b.buildScalar(t.TypedLeft(), inScope),
+			b.buildScalar(t.TypedRight(), inScope),
+		)
+
+	case *tree.ComparisonExpr:
+		// TODO(rytaft): remove this check when we are confident that all operators
+		// are included in comparisonOpMap.
+		if comparisonOpMap[t.Operator] == nil {
+			panic(errorf("not yet implemented: operator %s", t.Operator.String()))
+		}
+
+		// TODO(peter): handle t.SubOperator.
+		return comparisonOpMap[t.Operator](b.factory,
+			b.buildScalar(t.TypedLeft(), inScope),
+			b.buildScalar(t.TypedRight(), inScope),
+		)
+
+	case *tree.DTuple:
+		list := make([]xform.GroupID, len(t.D))
+		for i := range t.D {
+			list[i] = b.buildScalar(t.D[i], inScope)
+		}
+		return b.factory.ConstructTuple(b.factory.StoreList(list))
+
+	case *tree.IndexedVar:
+		colProps := b.synthesizeColumn(inScope, fmt.Sprintf("@%d", t.Idx+1), t.ResolvedType())
+		return b.factory.ConstructVariable(b.factory.InternPrivate(colProps.index))
+
+	case *tree.NotExpr:
+		return b.factory.ConstructNot(b.buildScalar(t.TypedInnerExpr(), inScope))
+
+	case *tree.OrExpr:
+		return b.factory.ConstructOr(
+			b.buildScalar(t.TypedLeft(), inScope),
+			b.buildScalar(t.TypedRight(), inScope),
+		)
+
+	case *tree.ParenExpr:
+		return b.buildScalar(t.TypedInnerExpr(), inScope)
+
+	case *tree.Placeholder:
+		return b.factory.ConstructPlaceholder(b.factory.InternPrivate(t))
+
+	case *tree.Tuple:
+		list := make([]xform.GroupID, len(t.Exprs))
+		for i := range t.Exprs {
+			list[i] = b.buildScalar(t.Exprs[i].(tree.TypedExpr), inScope)
+		}
+		return b.factory.ConstructTuple(b.factory.StoreList(list))
+
+	case *tree.UnaryExpr:
+		return unaryOpMap[t.Operator](b.factory, b.buildScalar(t.TypedInnerExpr(), inScope))
+
+	// NB: this is the exception to the sorting of the case statements. The
+	// tree.Datum case needs to occur after *tree.Placeholder which implements
+	// Datum.
+	case tree.Datum:
+		return b.factory.ConstructConst(b.factory.InternPrivate(t))
+
+	default:
+		panic(errorf("not yet implemented: scalar expr: %T", scalar))
+	}
+}
+
+// buildSelect builds a set of memo groups that represent the given select
+// statement.
+//
+// See Builder.buildStmt above for a description of the remaining input and
+// return values.
+func (b *Builder) buildSelect(
+	stmt *tree.Select, inScope *scope,
+) (out xform.GroupID, outScope *scope) {
+	// NB: The case statements are sorted lexicographically.
+	switch t := stmt.Select.(type) {
+	case *tree.ParenSelect:
+		return b.buildSelect(t.Select, inScope)
+
+	case *tree.SelectClause:
+		return b.buildSelectClause(stmt, inScope)
+
+	// TODO(rytaft): Add support for union clause and values clause.
+
+	default:
+		panic(errorf("not yet implemented: select statement: %T", stmt.Select))
+	}
+
+	// TODO(rytaft): Add support for order by expression.
+	// TODO(peter): stmt.Limit
+}
+
+// buildSelectClause builds a set of memo groups that represent the given
+// select clause. We pass the entire select statement rather than just the
+// select clause in order to handle ORDER BY scoping rules. ORDER BY can sort
+// results using columns from the FROM/GROUP BY clause and/or from the
+// projection list.
+// TODO(rytaft): Add support for groupings, having, order by, and distinct.
+//
+// See Builder.buildStmt above for a description of the remaining input and
+// return values.
+func (b *Builder) buildSelectClause(
+	stmt *tree.Select, inScope *scope,
+) (out xform.GroupID, outScope *scope) {
+	sel := stmt.Select.(*tree.SelectClause)
+	if (sel.GroupBy != nil && len(sel.GroupBy) > 0) || stmt.OrderBy != nil || sel.Distinct {
+		panic(errorf("complex queries not yet supported: %s", sel.String()))
+	}
+
+	out, outScope = b.buildFrom(sel.From, sel.Where, inScope)
+
+	// If the projection is empty or a simple pass-through, then
+	// buildProjectionList will return nil values.
+	projections, projectionsScope := b.buildProjectionList(sel.Exprs, outScope)
+
+	// Wrap with project operator if it exists.
+	if projections != nil {
+		out = b.factory.ConstructProject(out, b.constructProjectionList(projections, projectionsScope.cols))
+		outScope = projectionsScope
+	}
+
+	return
+}
+
+// buildFrom builds a set of memo groups that represent the given FROM statement
+// and WHERE clause.
+//
+// See Builder.buildStmt above for a description of the remaining input and
+// return values.
+func (b *Builder) buildFrom(
+	from *tree.From, where *tree.Where, inScope *scope,
+) (out xform.GroupID, outScope *scope) {
+	var left, right xform.GroupID
+
+	for _, table := range from.Tables {
+		var rightScope *scope
+		right, rightScope = b.buildTable(table, inScope)
+
+		if left == 0 {
+			left = right
+			outScope = rightScope
+			continue
+		}
+
+		outScope.appendColumns(rightScope)
+
+		left = b.factory.ConstructInnerJoin(left, right, b.factory.ConstructTrue())
+	}
+
+	if left == 0 {
+		// TODO(peter): This should be a table with 1 row and 0 columns to match
+		// current cockroach behavior.
+		rows := []xform.GroupID{b.factory.ConstructTuple(b.factory.StoreList(nil))}
+		out = b.factory.ConstructValues(b.factory.StoreList(rows), b.factory.InternPrivate(&xform.ColSet{}))
+		outScope = inScope
+	} else {
+		out = left
+	}
+
+	if where != nil {
+		// All "from" columns are visible to the filter expression.
+		texpr := outScope.resolveType(where.Expr, types.Bool)
+		filter := b.buildScalar(texpr, outScope)
+		out = b.factory.ConstructSelect(out, filter)
+	}
+
+	return
+}
+
+// buildProjectionList builds a set of memo groups that represent the given
+// select expressions.
+//
+// The first return value `projections` is an ordered list of top-level memo
+// groups corresponding to each select expression. See Builder.buildStmt above
+// for a description of the remaining input and return values.
+func (b *Builder) buildProjectionList(
+	selects tree.SelectExprs, inScope *scope,
+) (projections []xform.GroupID, outScope *scope) {
+	if len(selects) == 0 {
+		return nil, nil
+	}
+
+	outScope = inScope.push()
+	projections = make([]xform.GroupID, 0, len(selects))
+	for _, e := range selects {
+		end := len(outScope.cols)
+		subset := b.buildProjection(e.Expr, string(e.As), inScope, outScope)
+		projections = append(projections, subset...)
+
+		// Update the name of the column if there is an alias defined.
+		if e.As != "" {
+			for i := range outScope.cols[end:] {
+				outScope.cols[i].name = optbase.ColumnName(e.As)
+			}
+		}
+	}
+
+	if len(outScope.cols) == len(inScope.cols) {
+		matches := true
+		for i := range inScope.cols {
+			if inScope.cols[i].index != outScope.cols[i].index {
+				matches = false
+				break
+			}
+		}
+
+		if matches {
+			return nil, nil
+		}
+	}
+
+	return
+}
+
+// buildProjection builds a set of memo groups that represent the given
+// projection expression. If a new column is synthesized (e.g., for a scalar
+// expression), it will be labeled with the given label.
+//
+// The first return value `projections` is an ordered list of top-level memo
+// groups corresponding to the expression. The list generally consists of a
+// single memo group except in the case of "*", where the expression is
+// expanded to multiple columns.
+//
+// See Builder.buildStmt above for a description of the remaining input and
+// return values (outScope is passed as a parameter here rather than a return
+// value because the newly bound variables are appended to a growing list to be
+// returned by buildProjectionList).
+func (b *Builder) buildProjection(
+	projection tree.Expr, label string, inScope, outScope *scope,
+) (projections []xform.GroupID) {
+	// We only have to handle "*" and "<name>.*" in the switch below. Other names
+	// will be handled by scope.resolveType().
+	//
+	// NB: The case statements are sorted lexicographically.
+	switch t := projection.(type) {
+	case *tree.AllColumnsSelector:
+		tableName := optbase.TableName(t.TableName.Table())
+		for _, col := range inScope.cols {
+			if col.table == tableName && !col.hidden {
+				v := b.factory.ConstructVariable(b.factory.InternPrivate(col.index))
+				projections = append(projections, v)
+				outScope.cols = append(outScope.cols, col)
+			}
+		}
+		if len(projections) == 0 {
+			panic(errorf("unknown table %s", t))
+		}
+		return
+
+	case tree.UnqualifiedStar:
+		for _, col := range inScope.cols {
+			if !col.hidden {
+				v := b.factory.ConstructVariable(b.factory.InternPrivate(col.index))
+				projections = append(projections, v)
+				outScope.cols = append(outScope.cols, col)
+			}
+		}
+		if len(projections) == 0 {
+			panic(errorf("failed to expand *"))
+		}
+		return
+
+	case *tree.UnresolvedName:
+		vn, err := t.NormalizeVarName()
+		if err != nil {
+			panic(builderError(err))
+		}
+		return b.buildProjection(vn, label, inScope, outScope)
+
+	default:
+		texpr := inScope.resolveType(projection, types.Any)
+		return []xform.GroupID{b.buildScalarProjection(texpr, label, inScope, outScope)}
+	}
+}
+
+// buildScalarProjection builds a set of memo groups that represent the given
+// scalar expression. If a new column is synthesized, it will be labeled with
+// the given label. For example, the query `SELECT (x + 1) AS "x_incr" FROM t`
+// has a projection with a synthesized column "x_incr".
+//
+// The return value corresponds to the top-level memo group ID for this scalar
+// expression.
+//
+// See Builder.buildStmt above for a description of the remaining input and
+// return values (outScope is passed as a parameter here rather than a return
+// value because the newly bound variables are appended to a growing list to be
+// returned by buildProjectionList).
+func (b *Builder) buildScalarProjection(
+	texpr tree.TypedExpr, label string, inScope, outScope *scope,
+) xform.GroupID {
+	// NB: The case statements are sorted lexicographically.
+	switch t := texpr.(type) {
+	case *columnProps:
+		out := b.factory.ConstructVariable(b.factory.InternPrivate(t.index))
+		outScope.cols = append(outScope.cols, b.colMap[t.index])
+		return out
+
+	case *tree.ParenExpr:
+		return b.buildScalarProjection(t.TypedInnerExpr(), label, inScope, outScope)
+
+	default:
+		out := b.buildScalar(texpr, inScope)
+		b.synthesizeColumn(outScope, label, texpr.ResolvedType())
+		return out
+	}
+}
+
+// synthesizeColumn is used to synthesize new columns. This is needed for
+// operations such as projection of scalar expressions and aggregations. For
+// example, the query `SELECT (x + 1) AS "x_incr" FROM t` has a projection with
+// a synthesized column "x_incr".
+//
+// scope is passed in so it can can be updated with the newly bound variable.
+// label is an optional label for the new column (e.g., if specified with the
+// AS keyword), and typ is the type of the column. The new column is returned
+// as a columnProps object.
+func (b *Builder) synthesizeColumn(scope *scope, label string, typ types.T) *columnProps {
+	if label == "" {
+		label = fmt.Sprintf("column%d", len(scope.cols)+1)
+	}
+
+	colIndex := b.factory.Metadata().AddColumn(label)
+	col := columnProps{typ: typ, index: colIndex}
+	b.colMap = append(b.colMap, col)
+	scope.cols = append(scope.cols, col)
+	return &scope.cols[len(scope.cols)-1]
+}
+
+func (b *Builder) constructProjectionList(items []xform.GroupID, cols []columnProps) xform.GroupID {
+	return b.factory.ConstructProjections(b.factory.StoreList(items), b.factory.InternPrivate(makeColSet(cols)))
+}
+
+// Builder implements the IndexedVarContainer interface so it can be
+// used as the container inside an IndexedVarHelper (specifically
+// Builder.semaCtx.IVarHelper). This allows tree.TypeCheck to determine the
+// correct type for any IndexedVars in Builder.stmt. These types are maintained
+// inside the Builder.colMap.
+var _ tree.IndexedVarContainer = &Builder{}
+
+// IndexedVarEval is part of the IndexedVarContainer interface.
+func (b *Builder) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum, error) {
+	panic("unimplemented: Builder.IndexedVarEval")
+}
+
+// IndexedVarResolvedType is part of the IndexedVarContainer interface.
+func (b *Builder) IndexedVarResolvedType(idx int) types.T {
+	return b.colMap[xform.ColumnIndex(idx)].typ
+}
+
+// IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
+func (b *Builder) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
+	panic("unimplemented: Builder.IndexedVarNodeFormatter")
+}
+
+func makeColSet(cols []columnProps) *xform.ColSet {
+	// Create column index list parameter to the ProjectionList op.
+	var colSet xform.ColSet
+	for i := range cols {
+		colSet.Add(int(cols[i].index))
+	}
+	return &colSet
+}

--- a/pkg/sql/opt/build/builder_test.go
+++ b/pkg/sql/opt/build/builder_test.go
@@ -1,0 +1,207 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package build
+
+// This file is home to TestBuilder, which is similar to the logic tests, except it
+// is used for optimizer builder-specific testcases.
+//
+// Each testfile contains testcases of the form
+//   <command>
+//   <SQL statement or expression>
+//   ----
+//   <expected results>
+//
+// The supported commands are:
+//
+//  - exec-raw
+//
+//    Runs the given SQL expression. It does not produce any output.
+//
+//  - build
+//
+//    Builds a memo structure from a SQL query and outputs a representation
+//    of the "expression view" of the memo structure.
+//
+
+import (
+	"context"
+	"flag"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+
+	"strings"
+
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+)
+
+var (
+	testDataGlob = flag.String("d", "testdata/[^.]*", "test data glob")
+)
+
+// testCatalog implements the sqlbase.Catalog interface.
+type testCatalog struct {
+	kvDB *client.DB
+}
+
+// FindTable implements the sqlbase.Catalog interface.
+func (c testCatalog) FindTable(ctx context.Context, name *tree.TableName) (optbase.Table, error) {
+	return sqlbase.GetTableDescriptor(c.kvDB, string(name.DatabaseName), string(name.TableName)), nil
+}
+
+func TestBuilder(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	paths, err := filepath.Glob(*testDataGlob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) == 0 {
+		t.Fatalf("no testfiles found matching: %s", *testDataGlob)
+	}
+
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			ctx := context.Background()
+			s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+			defer s.Stopper().Stop(ctx)
+			catalog := testCatalog{kvDB: kvDB}
+
+			testutils.RunDataDrivenTest(t, path, func(d *testutils.TestData) string {
+				var varTypes []types.T
+				var iVarHelper tree.IndexedVarHelper
+
+				for _, arg := range d.CmdArgs {
+					key := arg
+					val := ""
+					if pos := strings.Index(key, "="); pos >= 0 {
+						key = arg[:pos]
+						val = arg[pos+1:]
+					}
+					if len(val) > 2 && val[0] == '(' && val[len(val)-1] == ')' {
+						val = val[1 : len(val)-1]
+					}
+					vals := strings.Split(val, ",")
+					switch key {
+					case "vars":
+						varTypes, err = testutils.ParseTypes(vals)
+						if err != nil {
+							d.Fatalf(t, "%v", err)
+						}
+
+						iVarHelper = tree.MakeTypesOnlyIndexedVarHelper(varTypes)
+
+					default:
+						d.Fatalf(t, "unknown argument: %s", key)
+					}
+				}
+
+				switch d.Cmd {
+				case "exec-raw":
+					_, err := sqlDB.Exec(d.Input)
+					if err != nil {
+						d.Fatalf(t, "%v", err)
+					}
+					return ""
+
+				case "build":
+					stmt, err := parser.ParseOne(d.Input)
+					if err != nil {
+						d.Fatalf(t, "%v", err)
+					}
+
+					f := xform.NewFactory(catalog, 0 /* maxSteps */)
+					b := NewBuilder(ctx, f, stmt)
+					root, _, err := build(b)
+					if err != nil {
+						return fmt.Sprintf("error: %v\n", err)
+					}
+					exprView := f.ExprView(root)
+					return (&exprView).String()
+
+				case "build-scalar":
+					typedExpr, err := testutils.ParseScalarExpr(d.Input, &iVarHelper)
+					if err != nil {
+						d.Fatalf(t, "%v", err)
+					}
+
+					f := xform.NewFactory(catalog, 0 /* maxSteps */)
+					b := newScalarBuilder(f, &iVarHelper)
+
+					group, err := buildScalar(b, typedExpr)
+					if err != nil {
+						return fmt.Sprintf("error: %v\n", err)
+					}
+					exprView := f.ExprView(group)
+					return (&exprView).String()
+
+				default:
+					d.Fatalf(t, "unsupported command: %s", d.Cmd)
+					return ""
+				}
+			})
+		})
+	}
+}
+
+// newScalarBuilder constructs a Builder to be used for building scalar
+// expressions.
+func newScalarBuilder(factory *xform.Factory, ivh *tree.IndexedVarHelper) *Builder {
+	b := &Builder{factory: factory, colMap: make([]columnProps, 1)}
+
+	b.semaCtx.IVarHelper = ivh
+	b.semaCtx.Placeholders = tree.MakePlaceholderInfo()
+
+	return b
+}
+
+// buildScalar is a wrapper for Builder.buildScalar which catches panics and
+// converts them to errors.
+func buildScalar(b *Builder, typedExpr tree.TypedExpr) (group xform.GroupID, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+
+	group = b.buildScalar(typedExpr, &scope{builder: b})
+	return
+}
+
+// build is a wrapper for Builder.Build which catches panics and
+// converts them to errors.
+func build(b *Builder) (root xform.GroupID, required *xform.PhysicalProps, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("%v", r)
+		}
+	}()
+
+	root, required, err = b.Build()
+	return
+}

--- a/pkg/sql/opt/build/column_props.go
+++ b/pkg/sql/opt/build/column_props.go
@@ -1,0 +1,95 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package build
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// columnProps holds per-column information that is scoped to a particular
+// relational expression. Note that columnProps implements the tree.TypedExpr
+// interface. During name resolution, unresolved column names in the AST are
+// replaced with a columnProps.
+type columnProps struct {
+	name  optbase.ColumnName
+	table optbase.TableName
+	typ   types.T
+
+	// index is an identifier for this column, which is unique across all the
+	// columns in the query.
+	index  xform.ColumnIndex
+	hidden bool
+}
+
+var _ tree.Expr = &columnProps{}
+var _ tree.TypedExpr = &columnProps{}
+var _ tree.VariableExpr = &columnProps{}
+
+func (c columnProps) String() string {
+	if c.table == "" {
+		return tree.NameString(string(c.name))
+	}
+	return fmt.Sprintf("%s.%s",
+		tree.NameString(string(c.table)), tree.NameString(string(c.name)))
+}
+
+// matches returns true if:
+// (a) the provided table name and column name match the corresponding names
+//     in the columnProps, or
+// (b) the provided column name matches the name in columnProps and the
+//     provided table name is empty.
+func (c columnProps) matches(tblName optbase.TableName, colName optbase.ColumnName) bool {
+	if colName != c.name {
+		return false
+	}
+	if tblName == "" {
+		return true
+	}
+	return c.table == tblName
+}
+
+// Format is part of the tree.Expr interface.
+func (c *columnProps) Format(ctx *tree.FmtCtx) {
+	ctx.Printf("@%d", c.index+1)
+}
+
+// Walk is part of the tree.Expr interface.
+func (c *columnProps) Walk(v tree.Visitor) tree.Expr {
+	return c
+}
+
+// TypeCheck is part of the tree.Expr interface.
+func (c *columnProps) TypeCheck(_ *tree.SemaContext, desired types.T) (tree.TypedExpr, error) {
+	return c, nil
+}
+
+// ResolvedType is part of the tree.TypedExpr interface.
+func (c *columnProps) ResolvedType() types.T {
+	return c.typ
+}
+
+// Eval is part of the tree.TypedExpr interface.
+func (*columnProps) Eval(_ *tree.EvalContext) (tree.Datum, error) {
+	panic(fmt.Errorf("columnProps must be replaced before evaluation"))
+}
+
+// Variable is part of the tree.VariableExpr interface. This prevents the
+// column from being evaluated during normalization.
+func (*columnProps) Variable() {}

--- a/pkg/sql/opt/build/main_test.go
+++ b/pkg/sql/opt/build/main_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package build_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	os.Exit(m.Run())
+}

--- a/pkg/sql/opt/build/scope.go
+++ b/pkg/sql/opt/build/scope.go
@@ -1,0 +1,106 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package build
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// scope is used for the build process and maintains the variables that have
+// been bound within the current scope as columnProps. Variables bound in the
+// parent scope are also visible in this scope.
+//
+// See builder.go for more details.
+type scope struct {
+	builder *Builder
+	parent  *scope
+	cols    []columnProps
+	// TODO(rytaft): Add group by and ordering to scope.
+}
+
+// push creates a new scope with this scope as its parent.
+func (s *scope) push() *scope {
+	return &scope{builder: s.builder, parent: s}
+}
+
+// appendColumns adds newly bound variables to this scope.
+func (s *scope) appendColumns(src *scope) {
+	s.cols = append(s.cols, src.cols...)
+}
+
+// resolveType converts the given expr to a tree.TypedExpr. As part of the
+// conversion, it performs name resolution and replaces unresolved column names
+// with columnProps.
+func (s *scope) resolveType(expr tree.Expr, desired types.T) tree.TypedExpr {
+	expr, _ = tree.WalkExpr(s, expr)
+	texpr, err := tree.TypeCheck(expr, &s.builder.semaCtx, desired)
+	if err != nil {
+		panic(err)
+	}
+
+	return texpr
+}
+
+// scope implements the tree.Visitor interface so that it can walk through
+// a tree.Expr tree, perform name resolution, and replace unresolved column
+// names with a columnProps. The info stored in columnProps is necessary for
+// Builder.buildScalar to construct a "variable" memo expression.
+var _ tree.Visitor = &scope{}
+
+// VisitPre is part of the Visitor interface.
+//
+// NB: This code is adapted from sql/select_name_resolution.go and
+// sql/subquery.go.
+func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
+	switch t := expr.(type) {
+	case *tree.UnresolvedName:
+		vn, err := t.NormalizeVarName()
+		if err != nil {
+			panic(err)
+		}
+		return s.VisitPre(vn)
+
+	case *tree.ColumnItem:
+		tblName := optbase.TableName(t.TableName.Table())
+		colName := optbase.ColumnName(t.ColumnName)
+
+		for curr := s; curr != nil; curr = curr.parent {
+			for i := range curr.cols {
+				col := &curr.cols[i]
+				if col.matches(tblName, colName) {
+					if tblName == "" && col.table != "" {
+						// TODO(andy): why is this necessary??
+						t.TableName.TableName = tree.Name(col.table)
+						t.TableName.OmitDBNameDuringFormatting = true
+					}
+					return false, col
+				}
+			}
+		}
+
+		panic(errorf("unknown column %s", columnProps{name: colName, table: tblName}))
+
+		// TODO(rytaft): Implement function expressions and subquery replacement.
+	}
+
+	return true, expr
+}
+
+// VisitPost is part of the Visitor interface.
+func (*scope) VisitPost(expr tree.Expr) tree.Expr {
+	return expr
+}

--- a/pkg/sql/opt/build/testdata/build-inner-join
+++ b/pkg/sql/opt/build/testdata/build-inner-join
@@ -1,0 +1,85 @@
+exec-raw
+CREATE DATABASE t
+
+exec-raw
+CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)
+
+exec-raw
+CREATE TABLE t.b (x INT, y FLOAT)
+
+exec-raw
+CREATE TABLE t.c (x INT, y FLOAT, z VARCHAR, CONSTRAINT fk_x_ref_a FOREIGN KEY (x) REFERENCES t.a (x))
+
+build
+SELECT * FROM t.a, t.b
+----
+project
+ ├── columns: a.x:1 a.y:null:2 b.x:null:3 b.y:null:4
+ ├── inner-join
+ │    ├── columns: a.x:1 a.y:null:2 b.x:null:3 b.y:null:4 b.rowid:5
+ │    ├── scan
+ │    │    └── columns: a.x:1 a.y:null:2
+ │    ├── scan
+ │    │    └── columns: b.x:null:3 b.y:null:4 b.rowid:5
+ │    └── true
+ └── projections
+      ├── variable: a.x
+      ├── variable: a.y
+      ├── variable: b.x
+      └── variable: b.y
+
+build
+SELECT a.x, b.y FROM t.a, t.b WHERE a.x = b.x
+----
+project
+ ├── columns: a.x:1 b.y:null:4
+ ├── select
+ │    ├── columns: a.x:1 a.y:null:2 b.x:null:3 b.y:null:4 b.rowid:5
+ │    ├── inner-join
+ │    │    ├── columns: a.x:1 a.y:null:2 b.x:null:3 b.y:null:4 b.rowid:5
+ │    │    ├── scan
+ │    │    │    └── columns: a.x:1 a.y:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: b.x:null:3 b.y:null:4 b.rowid:5
+ │    │    └── true
+ │    └── eq
+ │         ├── variable: a.x
+ │         └── variable: b.x
+ └── projections
+      ├── variable: a.x
+      └── variable: b.y
+
+build
+SELECT * FROM t.c, t.b, t.a WHERE c.x = a.x AND b.x = a.x
+----
+project
+ ├── columns: c.x:null:1 c.y:null:2 c.z:null:3 b.x:null:5 b.y:null:6 a.x:8 a.y:null:9
+ ├── select
+ │    ├── columns: c.x:null:1 c.y:null:2 c.z:null:3 c.rowid:4 b.x:null:5 b.y:null:6 b.rowid:7 a.x:8 a.y:null:9
+ │    ├── inner-join
+ │    │    ├── columns: c.x:null:1 c.y:null:2 c.z:null:3 c.rowid:4 b.x:null:5 b.y:null:6 b.rowid:7 a.x:8 a.y:null:9
+ │    │    ├── inner-join
+ │    │    │    ├── columns: c.x:null:1 c.y:null:2 c.z:null:3 c.rowid:4 b.x:null:5 b.y:null:6 b.rowid:7
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: c.x:null:1 c.y:null:2 c.z:null:3 c.rowid:4
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: b.x:null:5 b.y:null:6 b.rowid:7
+ │    │    │    └── true
+ │    │    ├── scan
+ │    │    │    └── columns: a.x:8 a.y:null:9
+ │    │    └── true
+ │    └── and
+ │         ├── eq
+ │         │    ├── variable: c.x
+ │         │    └── variable: a.x
+ │         └── eq
+ │              ├── variable: b.x
+ │              └── variable: a.x
+ └── projections
+      ├── variable: c.x
+      ├── variable: c.y
+      ├── variable: c.z
+      ├── variable: b.x
+      ├── variable: b.y
+      ├── variable: a.x
+      └── variable: a.y

--- a/pkg/sql/opt/build/testdata/build-project
+++ b/pkg/sql/opt/build/testdata/build-project
@@ -1,0 +1,107 @@
+exec-raw
+CREATE DATABASE t
+
+exec-raw
+CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)
+
+exec-raw
+CREATE TABLE t.b (x INT, y FLOAT)
+
+build
+SELECT 5
+----
+project
+ ├── columns: column1:null:1
+ ├── values
+ │    └── tuple
+ └── projections
+      └── const: 5
+
+build
+SELECT a.x FROM t.a
+----
+project
+ ├── columns: a.x:1
+ ├── scan
+ │    └── columns: a.x:1 a.y:null:2
+ └── projections
+      └── variable: a.x
+
+build
+SELECT a.x, a.y FROM t.a
+----
+scan
+ └── columns: a.x:1 a.y:null:2
+
+build
+SELECT a.y, a.x FROM t.a
+----
+project
+ ├── columns: a.x:1 a.y:null:2
+ ├── scan
+ │    └── columns: a.x:1 a.y:null:2
+ └── projections
+      ├── variable: a.y
+      └── variable: a.x
+
+build
+SELECT * FROM t.a
+----
+scan
+ └── columns: a.x:1 a.y:null:2
+
+# Note that an explicit projection operator is added for table b (unlike for
+# table a) to avoid projecting the hidden rowid column.
+build
+SELECT * FROM t.b
+----
+project
+ ├── columns: b.x:null:1 b.y:null:2
+ ├── scan
+ │    └── columns: b.x:null:1 b.y:null:2 b.rowid:3
+ └── projections
+      ├── variable: b.x
+      └── variable: b.y
+
+build
+SELECT (a.x + 3) AS "X", false AS "Y" FROM t.a
+----
+project
+ ├── columns: X:null:3 Y:null:4
+ ├── scan
+ │    └── columns: a.x:1 a.y:null:2
+ └── projections
+      ├── plus
+      │    ├── variable: a.x
+      │    └── const: 3
+      └── const: false
+
+build
+SELECT *, ((x < y) OR x > 1000) FROM t.a
+----
+project
+ ├── columns: a.x:1 a.y:null:2 column3:null:3
+ ├── scan
+ │    └── columns: a.x:1 a.y:null:2
+ └── projections
+      ├── variable: a.x
+      ├── variable: a.y
+      └── or
+           ├── lt
+           │    ├── variable: a.x
+           │    └── variable: a.y
+           └── gt
+                ├── variable: a.x
+                └── const: 1000
+
+build
+SELECT a.*, true FROM t.a
+----
+project
+ ├── columns: a.x:1 a.y:null:2 column3:null:3
+ ├── scan
+ │    └── columns: a.x:1 a.y:null:2
+ └── projections
+      ├── variable: a.x
+      ├── variable: a.y
+      └── const: true

--- a/pkg/sql/opt/build/testdata/build-scalar
+++ b/pkg/sql/opt/build/testdata/build-scalar
@@ -1,0 +1,214 @@
+build-scalar
+1
+----
+const: 1
+
+build-scalar
+1 + 2
+----
+plus
+ ├── const: 1
+ └── const: 2
+
+build-scalar vars=(string)
+@1
+----
+variable: @1
+
+build-scalar vars=(int)
+@1 + 2
+----
+plus
+ ├── variable: @1
+ └── const: 2
+
+build-scalar vars=(int, int)
+@1 >= 5 AND @1 <= 10 AND @2 < 4
+----
+and
+ ├── and
+ │    ├── ge
+ │    │    ├── variable: @1
+ │    │    └── const: 5
+ │    └── le
+ │         ├── variable: @1
+ │         └── const: 10
+ └── lt
+      ├── variable: @2
+      └── const: 4
+
+build-scalar vars=(int, int)
+(@1, @2) = (1, 2)
+----
+eq
+ ├── tuple
+ │    ├── variable: @1
+ │    └── variable: @2
+ └── tuple
+      ├── const: 1
+      └── const: 2
+
+build-scalar vars=(int)
+@1 IN (1, 2)
+----
+in
+ ├── variable: @1
+ └── tuple
+      ├── const: 1
+      └── const: 2
+
+build-scalar vars=(int, int)
+(@1, @2) IN ((1, 2), (3, 4))
+----
+in
+ ├── tuple
+ │    ├── variable: @1
+ │    └── variable: @2
+ └── tuple
+      ├── tuple
+      │    ├── const: 1
+      │    └── const: 2
+      └── tuple
+           ├── const: 3
+           └── const: 4
+
+build-scalar vars=(int, int, int, int)
+(@1, @2 + @3, 5 + @4 * 2) = (@2 + @3, 8, @1 - @4)
+----
+eq
+ ├── tuple
+ │    ├── variable: @1
+ │    ├── plus
+ │    │    ├── variable: @2
+ │    │    └── variable: @3
+ │    └── plus
+ │         ├── const: 5
+ │         └── mult
+ │              ├── variable: @4
+ │              └── const: 2
+ └── tuple
+      ├── plus
+      │    ├── variable: @2
+      │    └── variable: @3
+      ├── const: 8
+      └── minus
+           ├── variable: @1
+           └── variable: @4
+
+build-scalar vars=(int, int, int, int)
+((@1, @2), (@3, @4)) = ((1, 2), (3, 4))
+----
+eq
+ ├── tuple
+ │    ├── tuple
+ │    │    ├── variable: @1
+ │    │    └── variable: @2
+ │    └── tuple
+ │         ├── variable: @3
+ │         └── variable: @4
+ └── tuple
+      ├── tuple
+      │    ├── const: 1
+      │    └── const: 2
+      └── tuple
+           ├── const: 3
+           └── const: 4
+
+build-scalar vars=(int, int, int, string)
+(@1, (@2, 'a'), (@3, 'b', 5)) = (9, (@1 + @3, @4), (5, @4, @1))
+----
+eq
+ ├── tuple
+ │    ├── variable: @1
+ │    ├── tuple
+ │    │    ├── variable: @2
+ │    │    └── const: 'a'
+ │    └── tuple
+ │         ├── variable: @3
+ │         ├── const: 'b'
+ │         └── const: 5
+ └── tuple
+      ├── const: 9
+      ├── tuple
+      │    ├── plus
+      │    │    ├── variable: @1
+      │    │    └── variable: @3
+      │    └── variable: @4
+      └── tuple
+           ├── const: 5
+           ├── variable: @4
+           └── variable: @1
+
+build-scalar vars=(int, int)
+@1 IS NULL
+----
+is-not-distinct-from
+ ├── variable: @1
+ └── const: NULL
+
+build-scalar vars=(int, int)
+@1 IS NOT DISTINCT FROM NULL
+----
+is-not-distinct-from
+ ├── variable: @1
+ └── const: NULL
+
+build-scalar vars=(int, int)
+@1 IS NOT DISTINCT FROM @2
+----
+is-not-distinct-from
+ ├── variable: @1
+ └── variable: @2
+
+build-scalar vars=(int, int)
+@1 IS NOT NULL
+----
+is-distinct-from
+ ├── variable: @1
+ └── const: NULL
+
+build-scalar vars=(int, int)
+@1 IS DISTINCT FROM NULL
+----
+is-distinct-from
+ ├── variable: @1
+ └── const: NULL
+
+build-scalar vars=(int, int)
+@1 IS DISTINCT FROM @2
+----
+is-distinct-from
+ ├── variable: @1
+ └── variable: @2
+
+build-scalar vars=(int, int)
++ @1 + (- @2)
+----
+plus
+ ├── unary-plus
+ │    └── variable: @1
+ └── unary-minus
+      └── variable: @2
+
+build-scalar vars=(int, int)
+CASE WHEN @1 = 2 THEN 1 ELSE 2 END
+----
+error: not yet implemented: scalar expr: *tree.CaseExpr
+
+
+build-scalar vars=(string)
+LENGTH(@1) = 2
+----
+error: not yet implemented: scalar expr: *tree.FuncExpr
+
+
+build-scalar vars=(jsonb)
+@1 @> '{"a":1}'
+----
+error: not yet implemented: operator @>
+
+
+build-scalar vars=(jsonb)
+'{"a":1}' <@ @1
+----
+error: not yet implemented: operator <@

--- a/pkg/sql/opt/build/testdata/build-select
+++ b/pkg/sql/opt/build/testdata/build-select
@@ -1,0 +1,79 @@
+exec-raw
+CREATE DATABASE t
+
+exec-raw
+CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)
+
+build
+SELECT * FROM t.a
+----
+scan
+ └── columns: a.x:1 a.y:null:2
+
+build
+SELECT * FROM t.b
+----
+error: table missing
+
+
+build
+SELECT * FROM b
+----
+error: database missing
+
+
+build
+SELECT * FROM u.a
+----
+error: database missing
+
+
+build
+SELECT * FROM t.a WHERE x > 10
+----
+select
+ ├── columns: a.x:1 a.y:null:2
+ ├── scan
+ │    └── columns: a.x:1 a.y:null:2
+ └── gt
+      ├── variable: a.x
+      └── const: 10
+
+build
+SELECT * FROM t.a WHERE (x > 10 AND (x < 20 AND x != 13))
+----
+select
+ ├── columns: a.x:1 a.y:null:2
+ ├── scan
+ │    └── columns: a.x:1 a.y:null:2
+ └── and
+      ├── gt
+      │    ├── variable: a.x
+      │    └── const: 10
+      └── and
+           ├── lt
+           │    ├── variable: a.x
+           │    └── const: 20
+           └── ne
+                ├── variable: a.x
+                └── const: 13
+
+build
+SELECT * FROM t.a WHERE x IN (1, 2, 3)
+----
+select
+ ├── columns: a.x:1 a.y:null:2
+ ├── scan
+ │    └── columns: a.x:1 a.y:null:2
+ └── in
+      ├── variable: a.x
+      └── tuple
+           ├── const: 1
+           ├── const: 2
+           └── const: 3
+
+build
+SELECT * FROM t.a AS A(X, Y)
+----
+scan
+ └── columns: a.x:1 a.y:null:2

--- a/pkg/sql/opt/index_constraints_test.go
+++ b/pkg/sql/opt/index_constraints_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -59,7 +60,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
-			varTypes, err := parseTypes(strings.Split(tc.varTypes, ", "))
+			varTypes, err := testutils.ParseTypes(strings.Split(tc.varTypes, ", "))
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -70,7 +71,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 
 			iVarHelper := tree.MakeTypesOnlyIndexedVarHelper(varTypes)
 
-			typedExpr, err := parseScalarExpr(tc.expr, &iVarHelper)
+			typedExpr, err := testutils.ParseScalarExpr(tc.expr, &iVarHelper)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/sql/opt/testutils/utils.go
+++ b/pkg/sql/opt/testutils/utils.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testutils
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// ParseType parses a string describing a type.
+func ParseType(typeStr string) (types.T, error) {
+	colType, err := parser.ParseType(typeStr)
+	if err != nil {
+		return nil, err
+	}
+	return coltypes.CastTargetToDatumType(colType), nil
+}
+
+// ParseTypes parses a list of types.
+func ParseTypes(colStrs []string) ([]types.T, error) {
+	res := make([]types.T, len(colStrs))
+	for i, s := range colStrs {
+		var err error
+		res[i], err = ParseType(s)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+// ParseScalarExpr parses a scalar expression and converts it to a
+// tree.TypedExpr.
+func ParseScalarExpr(sql string, ivh *tree.IndexedVarHelper) (tree.TypedExpr, error) {
+	expr, err := parser.ParseExpr(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	sema := tree.MakeSemaContext(false /* privileged */)
+	sema.IVarHelper = ivh
+
+	return expr.TypeCheck(&sema, types.Any)
+}

--- a/pkg/sql/opt/xform/factory.go
+++ b/pkg/sql/opt/xform/factory.go
@@ -14,6 +14,8 @@
 
 package xform
 
+import "github.com/cockroachdb/cockroach/pkg/sql/optbase"
+
 // Factory constructs a normalized expression tree within the memo. As each
 // kind of expression is constructed by the factory, it transitively runs
 // normalization transformations defined for that expression type. This may
@@ -38,9 +40,17 @@ type Factory struct {
 	maxSteps int
 }
 
-func newFactory(mem *memo, maxSteps int) *Factory {
-	f := &Factory{mem: mem, maxSteps: maxSteps}
-	return f
+// NewFactory returns a new Factory structure with a new, blank memo
+// structure inside.
+func NewFactory(catalog optbase.Catalog, maxSteps int) *Factory {
+	return &Factory{mem: newMemo(catalog), maxSteps: maxSteps}
+}
+
+// ExprView returns the "expression view" of the memo in this factory
+// (i.e., a view of the designated lowest cost tree in the memo forest)
+// with the given top level group ID.
+func (f *Factory) ExprView(group GroupID) ExprView {
+	return makeExprView(f.mem, group, minPhysPropsID)
 }
 
 // Metadata returns the query-specific metadata, which includes information

--- a/pkg/sql/opt/xform/factory_test.go
+++ b/pkg/sql/opt/xform/factory_test.go
@@ -23,9 +23,8 @@ type testFactory struct {
 
 func newTestFactory() *testFactory {
 	cat := &testCatalog{}
-	mem := newMemo(cat)
 	f := &testFactory{cat: cat}
-	f.Factory = *newFactory(mem, 0 /* maxSteps */)
+	f.Factory = *NewFactory(cat, 0 /* maxSteps */)
 	return f
 }
 

--- a/pkg/sql/opt/xform/metadata.go
+++ b/pkg/sql/opt/xform/metadata.go
@@ -117,7 +117,7 @@ func (md *Metadata) AddTable(tbl optbase.Table) TableIndex {
 	for i := 0; i < tbl.NumColumns(); i++ {
 		col := tbl.Column(i)
 		if tbl.TabName() == "" {
-			md.AddColumn(col.ColName())
+			md.AddColumn(string(col.ColName()))
 		} else {
 			md.AddColumn(fmt.Sprintf("%s.%s", tbl.TabName(), col.ColName()))
 		}

--- a/pkg/sql/opt/xform/metadata_test.go
+++ b/pkg/sql/opt/xform/metadata_test.go
@@ -37,13 +37,18 @@ func (c *testColumn) IsNullable() bool {
 }
 
 // ColName is part of the optbase.Column interface.
-func (c *testColumn) ColName() string {
-	return c.colName
+func (c *testColumn) ColName() optbase.ColumnName {
+	return optbase.ColumnName(c.colName)
 }
 
 // DatumType is part of the optbase.Column interface.
 func (c *testColumn) DatumType() types.T {
 	return c.datumType
+}
+
+// IsHidden is part of the optbase.Column interface.
+func (c *testColumn) IsHidden() bool {
+	return false
 }
 
 type testTable struct {
@@ -54,8 +59,8 @@ type testTable struct {
 var _ optbase.Table = &testTable{}
 
 // TabName is part of the optbase.Table interface.
-func (t *testTable) TabName() string {
-	return t.tabName
+func (t *testTable) TabName() optbase.TableName {
+	return optbase.TableName(t.tabName)
 }
 
 // NumColumns is part of the optbase.Table interface.

--- a/pkg/sql/optbase/catalog.go
+++ b/pkg/sql/optbase/catalog.go
@@ -24,6 +24,12 @@ import (
 // This file contains interfaces that are used by the query optimizer to avoid
 // including specifics of sqlbase structures in the opt code.
 
+// ColumnName is the type of a column name.
+type ColumnName string
+
+// TableName is the type of a table name.
+type TableName string
+
 // Column is an interface to a table column, exposing only the information
 // needed by the query optimizer.
 type Column interface {
@@ -31,17 +37,21 @@ type Column interface {
 	IsNullable() bool
 
 	// ColName returns the name of the column.
-	ColName() string
+	ColName() ColumnName
 
 	// DatumType returns the data type of the column.
 	DatumType() types.T
+
+	// IsHidden returns true if the column is hidden (e.g., there is always a
+	// hidden column called rowid if there is no primary key on the table).
+	IsHidden() bool
 }
 
 // Table is an interface to a database table, exposing only the information
 // needed by the query optimizer.
 type Table interface {
 	// TabName returns the name of the table.
-	TabName() string
+	TabName() TableName
 
 	// NumColumns returns the number of columns in the table.
 	NumColumns() int

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2489,8 +2489,8 @@ func (desc *ColumnDescriptor) IsNullable() bool {
 }
 
 // ColName is part of the optbase.Column interface.
-func (desc *ColumnDescriptor) ColName() string {
-	return desc.Name
+func (desc *ColumnDescriptor) ColName() optbase.ColumnName {
+	return optbase.ColumnName(desc.Name)
 }
 
 // DatumType is part of the optbase.Column interface.
@@ -2498,11 +2498,16 @@ func (desc *ColumnDescriptor) DatumType() types.T {
 	return desc.Type.ToDatumType()
 }
 
+// IsHidden is part of the optbase.Column interface.
+func (desc *ColumnDescriptor) IsHidden() bool {
+	return desc.Hidden
+}
+
 var _ optbase.Table = &TableDescriptor{}
 
 // TabName is part of the optbase.Table interface.
-func (desc *TableDescriptor) TabName() string {
-	return desc.GetName()
+func (desc *TableDescriptor) TabName() optbase.TableName {
+	return optbase.TableName(desc.GetName())
 }
 
 // NumColumns is part of the optbase.Table interface.


### PR DESCRIPTION
This is the first commit of several needed to build a "memo"
structure from a parsed SQL query.  The memo is the primary data
structure in the query optimizer, used for maintaining the forest of
query plan trees that the optimizer considers as part of its search
for the optimal plan.

This commit includes support for building a memo for simple queries
with select, project, and/or inner join operators. It also
includes support for most scalar expressions, which are the building
blocks of scalar projections and filters in the `WHERE` clause.

This commit also includes a struct for maintaining scope, which
is essentially a list of the variable bindings that are visible to
a particular expression in the query tree. This implementation of
scope also enables name resolution and type checking for the parsed
SQL query. As part of the name resolution process, unresolved column
names in the AST are replaced with a `columnProps` object, which is a
unique representation of a column in the query tree.

Future commits will add support for other relational operators
including aggregations and complex joins.

This code is based on code originally written by @petermattis and
@andy-kimball in the opttoy project.

Release note: None