### PR TITLE
sql: use binary search to fetch in JSON objects

### DIFF
--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1700,6 +1700,9 @@ func BenchmarkFetchKey(b *testing.B) {
 
 			b.Run("fetch key by decoding and then reading", func(b *testing.B) {
 				for i := 0; i < b.N; i++ {
+					// This is a hack to get around the decoded caching.
+					encoded.mu.cachedDecoded = nil
+
 					decoded, err := encoded.shallowDecode()
 					if err != nil {
 						b.Fatal(err)


### PR DESCRIPTION
Release note: None.

This is an 80% solution - it could be optimized more but this gets us
most of the benefit and is not too onerous.
```
  name                                                                old time/op    new time/op    delta
  FetchKey/object_size_1/fetch_key-8                                    51.1ns ± 4%    51.6ns ± 2%     ~     (p=0.115 n=10+9)
  FetchKey/object_size_1/fetch_key_by_decoding_and_then_reading-8        476ns ± 1%     467ns ± 2%   -1.91%  (p=0.000 n=10+10)
  FetchKey/object_size_1/fetch_key_encoded-8                             208ns ± 1%     226ns ± 2%   +8.85%  (p=0.000 n=10+10)
  FetchKey/object_size_10/fetch_key-8                                   93.3ns ± 1%    93.5ns ± 1%     ~     (p=0.433 n=10+9)
  FetchKey/object_size_10/fetch_key_by_decoding_and_then_reading-8      1.66µs ± 1%    1.67µs ± 1%   +0.43%  (p=0.014 n=10+9)
  FetchKey/object_size_10/fetch_key_encoded-8                            544ns ± 1%     457ns ± 1%  -15.97%  (p=0.000 n=10+9)
  FetchKey/object_size_100/fetch_key-8                                   143ns ± 2%     142ns ± 3%     ~     (p=0.168 n=10+10)
  FetchKey/object_size_100/fetch_key_by_decoding_and_then_reading-8     13.1µs ± 1%    13.4µs ± 1%   +2.51%  (p=0.000 n=9+9)
  FetchKey/object_size_100/fetch_key_encoded-8                          3.68µs ± 1%    1.22µs ± 2%  -66.80%  (p=0.000 n=10+10)
  FetchKey/object_size_1000/fetch_key-8                                  198ns ± 1%     197ns ± 1%   -0.73%  (p=0.008 n=9+9)
  FetchKey/object_size_1000/fetch_key_by_decoding_and_then_reading-8     125µs ± 1%     126µs ± 1%   +0.45%  (p=0.043 n=10+10)
  FetchKey/object_size_1000/fetch_key_encoded-8                         35.1µs ± 2%     1.9µs ± 1%  -94.49%  (p=0.000 n=10+9)

  name                                                                old alloc/op   new alloc/op   delta
  FetchKey/object_size_1/fetch_key-8                                     0.00B          0.00B          ~     (all equal)
  FetchKey/object_size_1/fetch_key_by_decoding_and_then_reading-8         196B ± 0%      196B ± 0%     ~     (all equal)
  FetchKey/object_size_1/fetch_key_encoded-8                             47.6B ± 1%     47.6B ± 1%     ~     (p=1.000 n=10+10)
  FetchKey/object_size_10/fetch_key-8                                    0.00B          0.00B          ~     (all equal)
  FetchKey/object_size_10/fetch_key_by_decoding_and_then_reading-8      1.38kB ± 0%    1.38kB ± 0%     ~     (all equal)
  FetchKey/object_size_10/fetch_key_encoded-8                            47.5B ± 1%     47.5B ± 1%     ~     (p=1.000 n=10+10)
  FetchKey/object_size_100/fetch_key-8                                   0.00B          0.00B          ~     (all equal)
  FetchKey/object_size_100/fetch_key_by_decoding_and_then_reading-8     13.4kB ± 0%    13.4kB ± 0%     ~     (all equal)
  FetchKey/object_size_100/fetch_key_encoded-8                           47.4B ± 1%     47.6B ± 1%     ~     (p=0.656 n=10+10)
  FetchKey/object_size_1000/fetch_key-8                                  0.00B          0.00B          ~     (all equal)
  FetchKey/object_size_1000/fetch_key_by_decoding_and_then_reading-8     137kB ± 0%     137kB ± 0%     ~     (all equal)
  FetchKey/object_size_1000/fetch_key_encoded-8                          47.6B ± 1%     47.4B ± 1%     ~     (p=0.656 n=10+10)

  name                                                                old allocs/op  new allocs/op  delta
  FetchKey/object_size_1/fetch_key-8                                      0.00           0.00          ~     (all equal)
  FetchKey/object_size_1/fetch_key_by_decoding_and_then_reading-8         5.00 ± 0%      5.00 ± 0%     ~     (all equal)
  FetchKey/object_size_1/fetch_key_encoded-8                              0.00           0.00          ~     (all equal)
  FetchKey/object_size_10/fetch_key-8                                     0.00           0.00          ~     (all equal)
  FetchKey/object_size_10/fetch_key_by_decoding_and_then_reading-8        23.0 ± 0%      23.0 ± 0%     ~     (all equal)
  FetchKey/object_size_10/fetch_key_encoded-8                             0.00           0.00          ~     (all equal)
  FetchKey/object_size_100/fetch_key-8                                    0.00           0.00          ~     (all equal)
  FetchKey/object_size_100/fetch_key_by_decoding_and_then_reading-8        203 ± 0%       203 ± 0%     ~     (all equal)
  FetchKey/object_size_100/fetch_key_encoded-8                            0.00           0.00          ~     (all equal)
  FetchKey/object_size_1000/fetch_key-8                                   0.00           0.00          ~     (all equal)
  FetchKey/object_size_1000/fetch_key_by_decoding_and_then_reading-8     2.00k ± 0%     2.00k ± 0%     ~     (all equal)
  FetchKey/object_size_1000/fetch_key_encoded-8                           0.00           0.00          ~     (all equal)
```
This also fixes a bug in the fetch benchmark that was introduced when we
started caching the results of decoded values.