### PR TITLE
 githooks: avoid hitting a bug in OSX grep 

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -5,6 +5,10 @@
 # No -e because we have failing commands and that's OK.
 set -uo pipefail
 
+grep=${GREP:-grep}
+awk=${AWK:-awk}
+sed=${SED:-sed}
+
 # Support both terminfo and termcap.
 # We want to check whether stderr is a terminal (to enable
 # printing colors). We want this test to work even if stdin is
@@ -19,10 +23,10 @@ warn() {
 
 # First lint test: give a friendly reminder on long lines.
 
-longlines=$(awk '/^# --* >8 --*/ {exit} /^[^#]/ { if (length() >= 80) print }' <"$1")
+longlines=$($awk '/^# --* >8 --*/ {exit} /^[^#]/ { if (length() >= 80) print }' <"$1")
 if test -n "$longlines"; then
     warn "Long line(s) detected:"
-    echo "$longlines" | sed -e 's/^/   /g' >&2
+    echo "$longlines" | $sed -e 's/^/   /g' >&2
     echo >&2
     echo "Please amend and wrap long lines." >&2
     echo "(Long lines are OK if inside a preformatted block or a table.)" >&2
@@ -38,7 +42,7 @@ fi
 saveIFS=$IFS
 IFS='
 '
-notes=($(grep -iE '^release note' "$1"))
+notes=($($grep -iE '^release note' "$1"))
 IFS=$saveIFS
 
 
@@ -63,56 +67,56 @@ if [ 0 = ${#notes[*]} ]; then
 else
     for rnote in "${notes[@]}"; do
         informed=
-        if echo "$rnote" | grep -qiE '^release note' && ! echo "$rnote" | grep -qE '^Release note'; then
+        if echo "$rnote" | $grep -qiE '^release note' && ! echo "$rnote" | $grep -qE '^Release note'; then
             hint "case matters! Try '${rnote:0:12}' -> 'Release note'"
         fi
-        if echo "$rnote" | grep -qiE '^release notes'; then
+        if echo "$rnote" | $grep -qiE '^release notes'; then
             hint "singular please. Use multiple entries if there are multiple notes. Try '${rnote:0:13}' -> 'Release note'"
         fi
-        if echo "$rnote" | grep -qiE '^release notes? *: *\('; then
+        if echo "$rnote" | $grep -qiE '^release notes? *: *\('; then
             entered=$(echo "$rnote" | cut -d')' -f1)\); entered=${entered:0:40}
             cat=$(echo "$rnote" | cut -d'(' -f2 | cut -d')' -f1)
             hint "place the category before the colon. Try '$entered' -> 'Release note ($cat):'"
         fi
-        if echo "$rnote" | grep -qiE '^release notes? *: *[^ ]* *:'; then
-            cat=$(echo "$rnote" | sed -e 's/^[^:]*: *//g;s/ *:.*$//g')
+        if echo "$rnote" | $grep -qiE '^release notes? *: *[^ ]* *:'; then
+            cat=$(echo "$rnote" | $sed -e 's/^[^:]*: *//g;s/ *:.*$//g')
             entered=$(echo "$rnote" | cut -d: -f1-2)
             hint "place category within parentheses. Try '$entered:' -> 'Release note ($cat):'"
         fi
-        if echo "$rnote" | grep -qiE '^release notes?[^:]*: *none' && ! echo "$rnote" | grep -qE '^Release note: [nN]one'; then
-            entered=$(echo "$rnote" | sed -e 's/none.*/none/ig')
+        if echo "$rnote" | $grep -qiE '^release notes?[^:]*: *none' && ! echo "$rnote" | $grep -qE '^Release note: [nN]one'; then
+            entered=$(echo "$rnote" | $sed -e 's/none.*/none/ig')
             hint "for no release notes use 'none' with no category. Try '$entered' -> 'Release note: none'"
         fi
-        if ! echo "$rnote" | grep -qiE '^release notes? *: *none' && echo "$rnote" | grep -qiE '^release notes? *: *[^( ]'; then
+        if ! echo "$rnote" | $grep -qiE '^release notes? *: *none' && echo "$rnote" | $grep -qiE '^release notes? *: *[^( ]'; then
             entered=$(echo "$rnote" | cut -d: -f2-); entered=${entered:0:40}
             hint "category missing (can only be omitted if note is 'none'). Try 'Release note (category):$entered'"
         fi
-        if echo "$rnote" | grep -qiE '^release notes?[^:]*:([^ ]|   *)' || \
-                echo "$rnote" | grep -qiE '^release notes?(|  +)\(' || \
-                echo "$rnote" | grep -qiE '^release notes? *\( +' || \
-                echo "$rnote" | grep -qiE '^release notes? *\( *[^)]* +\)' ; then
+        if echo "$rnote" | $grep -qiE '^release notes?[^:]*:([^ ]|   *)' || \
+                echo "$rnote" | $grep -qiE '^release notes?(|  +)\(' || \
+                echo "$rnote" | $grep -qiE '^release notes? *\( +' || \
+                echo "$rnote" | $grep -qiE '^release notes? *\( *[^)]* +\)' ; then
             entered=${rnote:0:40}
-            body=$(echo "$rnote"| cut -d: -f2-|cut -c1-40|sed -e 's/^ *//g')
-            cat=$(echo "$rnote" | cut -d'(' -f2 |cut -d')' -f1|sed -e 's/^ *//g;s/ *$//g')
+            body=$(echo "$rnote"| cut -d: -f2-|cut -c1-40|$sed -e 's/^ *//g')
+            cat=$(echo "$rnote" | cut -d'(' -f2 |cut -d')' -f1|$sed -e 's/^ *//g;s/ *$//g')
             if test -z "$cat"; then cat=...; fi
             hint "some space problem. Try '$entered' -> 'Release note ($cat): $body'"
         fi
         # Now prune the category
-        if echo "$rnote" | grep -qiE '^release notes? *\([^)]*\)'; then
-            cat=$(echo "$rnote" | cut -d'(' -f2|cut -d')' -f1|sed -e 's/^ *//g;s/ *$//g')
+        if echo "$rnote" | $grep -qiE '^release notes? *\([^)]*\)'; then
+            cat=$(echo "$rnote" | cut -d'(' -f2|cut -d')' -f1|$sed -e 's/^ *//g;s/ *$//g')
             lower=$(echo "$cat"|tr A-Z a-z)
             if [ "$cat" != "$lower" ]; then
                 hint "categories in lowercase. Try 'Release note ($cat)' -> 'Release note ($lower)'"
             fi
-            if echo "$rnote" | grep -qiE '^release notes? *\([^)/]*/'; then
-                repl=$(echo "$lower"|sed -e 's| */ *|, |g')
+            if echo "$rnote" | $grep -qiE '^release notes? *\([^)/]*/'; then
+                repl=$(echo "$lower"|$sed -e 's| */ *|, |g')
                 hint "use commas to separate categories. Try '($lower)' -> '($repl)'"
                 lower=$repl
             fi
             saveIFS=$IFS
             IFS='
 '
-            cats=($(echo "$lower" | tr ',' '\n' | sed -e 's/^ *//g'))
+            cats=($(echo "$lower" | tr ',' '\n' | $sed -e 's/^ *//g'))
             IFS=$saveIFS
             for lcat in "${cats[@]}"; do
                 case $lcat in

--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -92,7 +92,7 @@ else
             hint "category missing (can only be omitted if note is 'none'). Try 'Release note (category):$entered'"
         fi
         if echo "$rnote" | $grep -qiE '^release notes?[^:]*:([^ ]|   *)' || \
-                echo "$rnote" | $grep -qiE '^release notes?(|  +)\(' || \
+                echo "$rnote" | $grep -qiE '^release notes?(\(|  +\()' || \
                 echo "$rnote" | $grep -qiE '^release notes? *\( +' || \
                 echo "$rnote" | $grep -qiE '^release notes? *\( *[^)]* +\)' ; then
             entered=${rnote:0:40}


### PR DESCRIPTION
OSX grep doesn't know how to handle an alternation with an empty
operand. Work around this by including the suffix in the alternation.

Found by @petermattis 

Also this patch makes sed/awk/grep overridable, which will facilitate
troubleshooting of further issues of this kind.

Release note: None