### PR TITLE
server: Signal readiness before waiting for the init command.

### DIFF
--- a/pkg/cli/interactive_tests/test_init_command.tcl
+++ b/pkg/cli/interactive_tests/test_init_command.tcl
@@ -1,0 +1,43 @@
+#! /usr/bin/env expect -f
+#
+source [file join [file dirnam $argv0] common.tcl]
+
+# Start a server with a --join flag so the init command is required
+# (even though we have no intention of starting a second node). Even
+# though the cluster is uninitialized, --background causes it to
+# return once we have bound our ports. Note that unlike other
+# expect-based tests, this one doesn't use a fifo for --pid_file
+# because we don't want reads from that fifo to change the outcome.
+system "$argv start --insecure --pid-file=server_pid --background -s=path=logs/db --join=localhost:26258 >>logs/expect-cmd.log 2>&1"
+
+# Start a shell and send a command. The shell should block at startup,
+# so we don't "expect" anything yet. The point of this test is to
+# verify that the command will succeed after blocking instead of
+# erroring out.
+spawn $argv sql
+send "show databases;\r"
+
+# Now initialize the one-node cluster. This will unblock the pending
+# SQL connection. This also verifies that the blocked connection using
+# the pgwire listener does not block the grpc listener used for the
+# init command.
+system $argv init
+
+# The command should now succeed, without logging any errors or
+# warnings.
+expect {
+    "information_schema" {}
+    # Hopefully this broad regex will match any errors we log
+    # (Currently, everything I've seen begins with "Error:")
+    -re "(?i)err|warn" {
+        set prefix $expect_out(buffer)
+        # Read next line to finish the error message.
+        # TODO(bdarnell): Surely there's a smarter way to do this.
+        expect "\n"
+        report "ERROR LOGGED:\n$prefix$expect_out(buffer)"
+        exit 1
+    }
+    timeout { handle_timeout "information_schema" }
+}
+
+stop_server $argv


### PR DESCRIPTION
It was awkward to use the init command previously because there was no
way to wait for the server to become ready enough to serve it. You'd
need to fully background the process (& instead of --background) and
either use arbitrary sleeps or retry the init command.

With this change, the --background process will exit after the ports
are bound but before the server is fully initialized, so the
controlling process can issue the init command. SQL queries cannot be
served in this state, but they will be queued up in the cmux listener
to be served once we are initialized (previously they would fail with
a protocol error, since there was an HTTP server but not a pgwire
server bound on the port).

Fixes #18938

Release note (CLI change): `cockroach start --background` now returns
earlier for nodes awaiting the `cockroach init` command, facilitating
use from automated scripts.