### PR TITLE
keys, sql: change sequence key format so backup/restore works

### DIFF
--- a/docs/RFCS/20171102_sql_sequences.md
+++ b/docs/RFCS/20171102_sql_sequences.md
@@ -196,8 +196,12 @@ discussion of alternate approaches.
 Each sequence value will be stored in its own range, with a key in this format:
 
 ```
-/Table/<DescriptorID>/SequenceValue
+/Table/<DescriptorID>/1/0/1
 ```
+
+Where the numbers are dummy values for the index ID, primary key value, and
+column family ID, respectively. This mimics the structure of a normal table
+key, so backup/restore can work without modification.
 
 Reads and writes to the sequence value (via the functions `nextval`, `currval`,
 etc.), will be implemented by direct calls to the KV layer's `Get`, `Inc`, and

--- a/docs/tech-notes/encoding.md
+++ b/docs/tech-notes/encoding.md
@@ -103,6 +103,20 @@ alternative for datum encoding types greater than 14, `encodeValueTag`
 sets the low four bits to `SentinelType` (15) and emits the actual datum
 encoding type next.
 
+**Note:** Values for sequences are a special case: the sequence value is
+encoded as if the sequence were a one-row, one-column table, with the
+key structured in the usual way: `/Table/<id>/<index>/<pk val>/<family>`.
+However, the value is a bare int64; it doesn't use the encoding
+specified here. This is because it is incremented using the KV
+`Increment` operation so that the increment can be done in one
+roundtrip, not a read followed by a write as would be required by a
+normal SQL `UPDATE`.
+
+An alternative design would be to teach the KV Inc operation to
+understand SQL value encoding so that the sequence could be encoded
+consistently with tables, but that would break the KV/SQL abstraction
+barrier.
+
 ### Sentinel KV pairs
 
 The column family with ID 0 is special because it contains the primary

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -372,6 +372,15 @@ func rewriteTableDescs(tables []*sqlbase.TableDescriptor, tableRewrites tableRew
 			}
 		}
 
+		// Rewrite sequence references in column descriptors.
+		for _, col := range table.Columns {
+			newSeqRefs := make([]sqlbase.ID, len(col.UsesSequenceIds))
+			for idx, ref := range col.UsesSequenceIds {
+				newSeqRefs[idx] = tableRewrites[ref].TableID
+			}
+			col.UsesSequenceIds = newSeqRefs
+		}
+
 		// since this is a "new" table in eyes of new cluster, any leftover change
 		// lease is obviously bogus (plus the nodeID is relative to backup cluster).
 		table.Lease = nil

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -44,13 +44,15 @@ import (
 type tableRewriteMap map[sqlbase.ID]*jobs.RestoreDetails_TableRewrite
 
 const (
-	restoreOptIntoDB         = "into_db"
-	restoreOptSkipMissingFKs = "skip_missing_foreign_keys"
+	restoreOptIntoDB               = "into_db"
+	restoreOptSkipMissingFKs       = "skip_missing_foreign_keys"
+	restoreOptSkipMissingSequences = "skip_missing_sequences"
 )
 
 var restoreOptionExpectValues = map[string]bool{
-	restoreOptIntoDB:         true,
-	restoreOptSkipMissingFKs: false,
+	restoreOptIntoDB:               true,
+	restoreOptSkipMissingFKs:       false,
+	restoreOptSkipMissingSequences: false,
 }
 
 func loadBackupDescs(
@@ -140,6 +142,7 @@ func allocateTableRewrites(
 
 	// Fail fast if the tables to restore are incompatible with the specified
 	// options.
+	// Check that foreign key targets exist.
 	for _, table := range tablesByID {
 		if renaming && table.IsView() {
 			return nil, errors.Errorf("cannot restore view when using %q option", restoreOptIntoDB)
@@ -160,6 +163,20 @@ func allocateTableRewrites(
 			return nil
 		}); err != nil {
 			return nil, err
+		}
+
+		// Check that referenced sequences exist.
+		for _, col := range table.Columns {
+			for _, seqID := range col.UsesSequenceIds {
+				if _, ok := tablesByID[seqID]; !ok {
+					if _, ok := opts[restoreOptSkipMissingSequences]; !ok {
+						return nil, errors.Errorf(
+							"cannot restore table %q without referenced sequence %d (or %q option)",
+							table.Name, seqID, restoreOptSkipMissingSequences,
+						)
+					}
+				}
+			}
 		}
 	}
 
@@ -373,12 +390,23 @@ func rewriteTableDescs(tables []*sqlbase.TableDescriptor, tableRewrites tableRew
 		}
 
 		// Rewrite sequence references in column descriptors.
-		for _, col := range table.Columns {
-			newSeqRefs := make([]sqlbase.ID, len(col.UsesSequenceIds))
-			for idx, ref := range col.UsesSequenceIds {
-				newSeqRefs[idx] = tableRewrites[ref].TableID
+		for idx, col := range table.Columns {
+			var newSeqRefs []sqlbase.ID
+			for _, seqID := range col.UsesSequenceIds {
+				if rewrite, ok := tableRewrites[seqID]; ok {
+					newSeqRefs = append(newSeqRefs, rewrite.TableID)
+				} else {
+					// The referenced sequence isn't being restored.
+					// Strip the DEFAULT expression and sequence references.
+					// To get here, the user must have specified 'skip_missing_sequences' --
+					// otherwise, would have errored out in allocateTableRewrites.
+					newSeqRefs = []sqlbase.ID{}
+					col.DefaultExpr = nil
+					break
+				}
 			}
 			col.UsesSequenceIds = newSeqRefs
+			table.Columns[idx] = col
 		}
 
 		// since this is a "new" table in eyes of new cluster, any leftover change

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -253,9 +253,6 @@ var (
 	// TimeseriesPrefix is the key prefix for all timeseries data.
 	TimeseriesPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("tsd")))
 
-	// SequenceSuffix is used in the key which stores the value of a user-created SQL sequence.
-	SequenceSuffix = roachpb.RKey("seqval")
-
 	// TableDataMin is the start of the range of table data keys.
 	TableDataMin = roachpb.Key(encoding.EncodeVarintAscending(nil, 0))
 	// TableDataMin is the end of the range of table data keys.

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -674,9 +674,22 @@ func MakeFamilyKey(key []byte, famID uint32) []byte {
 	return encoding.EncodeUvarintAscending(key, uint64(len(key)-size))
 }
 
+const (
+	// SequenceIndexID is the ID of the single index on each special single-column,
+	// single-row sequence table.
+	SequenceIndexID = 1
+	// SequenceColumnFamilyID is the ID of the column family on each special single-column,
+	// single-row sequence table.
+	SequenceColumnFamilyID = 0
+)
+
 // MakeSequenceKey returns the key used to store the value of a sequence.
 func MakeSequenceKey(tableID uint32) []byte {
-	return makeKey(MakeTablePrefix(tableID), SequenceSuffix)
+	key := MakeTablePrefix(tableID)
+	key = encoding.EncodeUvarintAscending(key, SequenceIndexID)        // Index id
+	key = encoding.EncodeUvarintAscending(key, 0)                      // Primary key value
+	key = encoding.EncodeUvarintAscending(key, SequenceColumnFamilyID) // Column family
+	return key
 }
 
 // GetRowPrefixLength returns the length of the row prefix of the key. A table

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -243,7 +243,7 @@ func TestUserKey(t *testing.T) {
 
 func TestSequenceKey(t *testing.T) {
 	actual := MakeSequenceKey(55)
-	expected := []byte("\xbfseqval")
+	expected := []byte("\xbf\x89\x88\x88")
 	if !bytes.Equal(actual, expected) {
 		t.Errorf("expected %q (len %d), got %q (len %d)", expected, len(expected), actual, len(actual))
 	}

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -155,7 +155,7 @@ func TestPrettyPrint(t *testing.T) {
 			"/Table/42/-2mon-2d743h59m58s999ms999µs999ns"},
 
 		// sequence
-		{MakeSequenceKey(55), `/Table/55/"seqval"`},
+		{MakeSequenceKey(55), `/Table/55/1/0/0`},
 
 		// others
 		{makeKey([]byte("")), "/Min"},

--- a/pkg/sql/logictest/testdata/logic_test/scrub
+++ b/pkg/sql/logictest/testdata/logic_test/scrub
@@ -119,3 +119,20 @@ EXPERIMENTAL SCRUB TABLE xz AS OF SYSTEM TIME '2017' WITH OPTIONS INDEX ALL
 
 statement error database "test" does not exist
 EXPERIMENTAL SCRUB TABLE xz AS OF SYSTEM TIME '2017' WITH OPTIONS CONSTRAINT ALL
+
+# Test scrubbing sequences.
+
+statement ok
+CREATE DATABASE seq_db
+
+statement ok
+CREATE SEQUENCE seq_db.my_seq
+
+statement ok
+CREATE TABLE seq_db.my_tbl (id INT PRIMARY KEY DEFAULT nextval('seq_db.my_seq'))
+
+statement ok
+EXPERIMENTAL SCRUB DATABASE seq_db
+
+statement error pq: "seq_db.my_seq" is not a table
+EXPERIMENTAL SCRUB TABLE seq_db.my_seq

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -115,6 +115,9 @@ SHOW CREATE SEQUENCE show_create_test
 Sequence         CreateSequence
 show_create_test CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1
 
+statement error pq: test.show_create_test is not a table
+SHOW CREATE TABLE show_create_test
+
 # DML ERRORS
 
 statement error pgcode 42809 cannot run INSERT on sequence "foo" - sequences are not updateable

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -340,6 +340,13 @@ CREATE TABLE pg_catalog.pg_class (
 				return err
 			}
 
+			// Skip adding indexes for sequences (their table descriptors hav a primary
+			// index to make them comprehensible to backup/restore, but PG doesn't include
+			// an index in pg_class).
+			if table.IsSequence() {
+				return nil
+			}
+
 			// Indexes.
 			return forEachIndexInTable(table, func(index *sqlbase.IndexDescriptor) error {
 				return addRow(

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -390,8 +390,10 @@ func (desc *TableDescriptor) IsVirtualTable() bool {
 // physical Table that needs to be stored in the kv layer, as opposed to a
 // different resource like a view or a virtual table. Physical tables have
 // primary keys, column families, and indexes (unlike virtual tables).
+// Sequences count as physical tables because their values are stored in
+// the KV layer.
 func (desc *TableDescriptor) IsPhysicalTable() bool {
-	return desc.IsTable() && !desc.IsVirtualTable()
+	return desc.IsSequence() || (desc.IsTable() && !desc.IsVirtualTable())
 }
 
 // KeysPerRow returns the maximum number of keys used to encode a row for the


### PR DESCRIPTION
Before, a sequence's key was of the format `/Table/55/seqval`. Now, it's `/Table/55/0/0/0`. This mimics the structure of a table key, allowing backup/restore to work without special casing for sequences.

Keeping the original key format would have required special casing sequences in the restore implementation's keyrewriter code, which is already complicated; this approach seems to minimize complexity.

Fixes: #21354

Release note: None