### PR TITLE
sql, distsql: fix mismatches between needed and plan columns in opt_needed

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -120,11 +120,11 @@ SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a FROM abc
 ----
-render     0  render  ·         ·            (a)        a!=NULL
- │         0  ·       render 0  a            ·          ·
- └── scan  1  scan    ·         ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·          1  ·       table     abc@primary  ·          ·
-·          1  ·       spans     ALL          ·          ·
+render     0  render  ·         ·            (a)                          a!=NULL
+ │         0  ·       render 0  a            ·                            ·
+ └── scan  1  scan    ·         ·            (a, b[omitted], c[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·          1  ·       table     abc@primary  ·                            ·
+·          1  ·       spans     ALL          ·                            ·
 
 
 query T rowsort


### PR DESCRIPTION
[The comment](https://github.com/cockroachdb/cockroach/blob/master/pkg/sql/data_source.go#L119-L121) mentions that sourceColumns match the plan.Columns() 1-to-1. But current code doesn't satisfy this assumption. It seems that the length of sourceColumns may not be equal to the length plan.Columns(). If that's the case, for fixing such mismatch, we should use plan.Columns() to calculate sourceNeeded.

Release note (bug fix): fixed mismatches between needed and plan columns
in opt_needed for joinNode, filterNode and renderNode