### PR TITLE
workload: maybe fix test flake

### DIFF
--- a/pkg/testutils/workload/workload_test.go
+++ b/pkg/testutils/workload/workload_test.go
@@ -52,7 +52,7 @@ func TestSetup(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: `test`})
 	defer s.Stopper().Stop(ctx)
 
 	for _, test := range tests {
@@ -60,7 +60,6 @@ func TestSetup(t *testing.T) {
 			sqlDB := sqlutils.MakeSQLRunner(db)
 			sqlDB.Exec(t, `DROP DATABASE IF EXISTS test`)
 			sqlDB.Exec(t, `CREATE DATABASE test`)
-			sqlDB.Exec(t, `USE test`)
 
 			gen := bank.FromRows(test.rows)
 			tables := gen.Tables()


### PR DESCRIPTION
	workload_test.go:68: pq: relation "bank" does not exist

There's no concurrency here, so it's not clear why gosql.DB would be
creating a new connection and losing the session database, but I can't
seem to reproduce this with gceworkers stress, so taking a stab in the
dark: use the `UseDatabase` option to TestServer to set the session
database, so it gets put in the connection string which causes it to be
set on every connection.

For #21618.

Release note: None