### PR TITLE
opt: fix panic caused by NULL placeholder

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -385,3 +385,32 @@ query B
 EXECUTE selectin2(1, 5, 1)
 ----
 true
+
+# Regression tests for #21701.
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO kv VALUES (1, 1), (2, 2), (3, 3)
+
+statement ok
+PREPARE x21701a AS SELECT * FROM kv WHERE k = $1
+
+query II
+EXECUTE x21701a(NULL)
+----
+
+statement ok
+PREPARE x21701b AS SELECT * FROM kv WHERE k IS DISTINCT FROM $1
+
+# This is broken (#21704).
+query II
+EXECUTE x21701b(NULL)
+----
+
+statement ok
+PREPARE x21701c AS SELECT * FROM kv WHERE k IS NOT DISTINCT FROM $1
+
+query II
+EXECUTE x21701c(NULL)
+----

--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -93,9 +93,10 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 	if datum == tree.DNull {
 		switch op {
 		case eqOp, ltOp, gtOp, leOp, geOp, neOp:
-			// This expression should have been converted to NULL during
-			// type checking.
-			panic("comparison with NULL")
+			// The result of this expression is always NULL. Normally, this expression
+			// should have been converted to NULL during type checking; but if the
+			// NULL is coming from a placeholder, that doesn't happen.
+			return LogicalSpans{}, true, true
 
 		case isOp:
 			if !c.colInfos[offset].Nullable {
@@ -128,9 +129,6 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 		return LogicalSpans{sp}, true, true
 
 	case neOp, isNotOp:
-		if datum == tree.DNull {
-			panic("comparison with NULL")
-		}
 		spans := LogicalSpans{c.makeNotNullSpan(offset), c.makeNotNullSpan(offset)}
 		spans[0].End = LogicalKey{Vals: tree.Datums{datum}, Inclusive: false}
 		spans[1].Start = LogicalKey{Vals: tree.Datums{datum}, Inclusive: false}


### PR DESCRIPTION
The index constraints code assumes that an expression like `a > NULL`
is simplified to `NULL`. However, this does not happen when the
expression is actually `a > $1` and `$1` happens to be `NULL`. Fixing
this by returning no spans in this case.

The tests expose another problem, filed #21704.

Fixes #21701.

Release note (bug fix): fixed a crash caused by NULL placeholder in
comparison expression.