### PR TITLE
storage: Allow stack depth of more than 100 calls in track_raft_proto

### DIFF
--- a/pkg/storage/track_raft_protos.go
+++ b/pkg/storage/track_raft_protos.go
@@ -81,7 +81,7 @@ func TrackRaftProtos() func() []reflect.Type {
 			return
 		}
 
-		var pcs [100]uintptr
+		var pcs [256]uintptr
 		if numCallers := runtime.Callers(0, pcs[:]); numCallers == len(pcs) {
 			panic(fmt.Sprintf("number of callers %d might have exceeded slice size %d", numCallers, len(pcs)))
 		}


### PR DESCRIPTION
As far as I can tell this was an arbitrary limit, but we recently hit
it, so try increasing it.

Fixes #21695

Release note: None