### PR TITLE
sql: fix discrepancy with Postgres BYTES arrays

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -35,6 +35,11 @@ SELECT ARRAY['a,', 'b{', 'c}', 'd', 'e f']
 ----
 {"a,","b{","c}","d","e f"}
 
+query T
+SELECT ARRAY['1}'::BYTES]
+----
+{"\\x317d"}
+
 # TODO(jordan): #16487
 # query T
 # SELECT ARRAY[e'g\x10h']
@@ -619,7 +624,7 @@ INSERT INTO a VALUES (ARRAY['foo','bar','baz'])
 query T
 SELECT b FROM a
 ----
-{'\x666f6f','\x626172','\x62617a'}
+{"\\x666f6f","\\x626172","\\x62617a"}
 
 statement ok
 DROP TABLE a


### PR DESCRIPTION
Fixes #21697, though will require a slightly involved cherry-pick
because the way we do this formatting has changed.

Release note (bug fix): fixed an issue with the wire-formatting of BYTES
arrays.