### PR TITLE
ui: fix spacing on new version alert

### DIFF
--- a/pkg/ui/src/views/shared/components/alertBox/alertbox.styl
+++ b/pkg/ui/src/views/shared/components/alertBox/alertbox.styl
@@ -3,9 +3,9 @@
 .alert-box
   clearfix()
   display flex
-  width calc(100% - 48px)
+  width 100%
   float left
-  margin 0 6px 10px
+  margin 0 0 10px
   padding 20px
   border 1px solid $headings-color
   border-radius 5px


### PR DESCRIPTION
The new version alert box was misaligned with the summary below, this fixes it.

Fixes: #18480
Release note: None

Old:
<img width="464" alt="screen shot 2018-01-23 at 3 13 50 pm" src="https://user-images.githubusercontent.com/793969/35298398-1574e93e-0050-11e8-8b9a-67d05ab051fc.png">

New:
<img width="489" alt="screen shot 2018-01-23 at 3 14 59 pm" src="https://user-images.githubusercontent.com/793969/35298444-3caf760e-0050-11e8-96ab-b2926759f01a.png">
