### PR TITLE
sqlbase: add support for ON DELETE SET NULL actions on foreign key references

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -19,7 +19,7 @@ CREATE TABLE b (
  ,update_restrict INT NOT NULL REFERENCES a ON UPDATE RESTRICT
  ,delete_cascade INT NOT NULL REFERENCES a ON DELETE CASCADE
  ,update_cascade INT NOT NULL REFERENCES a ON UPDATE CASCADE
- ,delete_null INT REFERENCES a
+ ,delete_null INT REFERENCES a ON DELETE SET NULL
  ,update_null INT REFERENCES a
  ,delete_default INT DEFAULT 100 REFERENCES a
  ,update_default INT DEFAULT 100 REFERENCES a
@@ -71,6 +71,15 @@ query IIIIIIIIII
 SELECT * FROM b;
 ----
 1 2 3 4 5 1000 7 8 9 10
+
+# 7. ON DELETE SET NULL
+statement ok
+DELETE FROM a WHERE id = 7;
+
+query IIIIIIIIII
+SELECT * FROM b;
+----
+1 2 3 4 5 1000 NULL 8 9 10
 
 # Post Test Clean up
 statement ok
@@ -1693,3 +1702,353 @@ updated updated
 # Clean up after the test.
 statement ok
 DROP TABLE f, e, d, c, b, a;
+
+subtest DeleteNull_Basic1
+### Basic Delete Set Null
+#        a
+#      // \\
+#    / |  |  \
+#   b1 b2 b3 b4
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+);
+CREATE TABLE b3 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+);
+CREATE TABLE b4 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES a ON DELETE SET NULL
+);
+
+statement ok
+INSERT INTO a VALUES ('delete_me'), ('untouched');
+INSERT INTO b1 VALUES ('b1-pk1', 'untouched'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'untouched'), ('b2-pk2', 'delete_me');
+INSERT INTO b3 VALUES ('b3-pk1', 'delete_me'), ('b3-pk2', 'untouched');
+INSERT INTO b4 VALUES ('b4-pk1', 'delete_me'), ('b4-pk2', 'delete_me');
+
+# ON DELETE CASCADE
+statement ok
+DELETE FROM a WHERE id = 'delete_me';
+
+query TT rowsort
+  SELECT id, delete_set_null FROM b1
+UNION ALL
+  SELECT id, delete_set_null FROM b2
+UNION ALL
+  SELECT id, delete_set_null FROM b3
+UNION ALL
+  SELECT id, delete_set_null FROM b4
+;
+----
+b1-pk1 untouched
+b1-pk2 untouched
+b2-pk1 untouched
+b2-pk2 NULL
+b3-pk1 NULL
+b3-pk2 untouched
+b4-pk1 NULL
+b4-pk2 NULL
+
+# Perform the same operation but with show trace.
+statement ok
+TRUNCATE a, b1, b2, b3, b4;
+
+statement ok
+INSERT INTO a VALUES ('delete_me'), ('untouched');
+INSERT INTO b1 VALUES ('b1-pk1', 'untouched'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'untouched'), ('b2-pk2', 'delete_me');
+INSERT INTO b3 VALUES ('b3-pk1', 'delete_me'), ('b3-pk2', 'untouched');
+INSERT INTO b4 VALUES ('b4-pk1', 'delete_me'), ('b4-pk2', 'delete_me');
+
+# Ensure that show trace adds a cascade message for each of the tables that is
+# cascaded into.
+query I
+SELECT COUNT(*) FROM [
+  SHOW KV TRACE FOR DELETE FROM a WHERE id = 'delete_me'
+] WHERE message LIKE 'cascading %';
+----
+4
+
+query TT rowsort
+  SELECT id, delete_set_null FROM b1
+UNION ALL
+  SELECT id, delete_set_null FROM b2
+UNION ALL
+  SELECT id, delete_set_null FROM b3
+UNION ALL
+  SELECT id, delete_set_null FROM b4
+;
+----
+b1-pk1 untouched
+b1-pk2 untouched
+b2-pk1 untouched
+b2-pk2 NULL
+b3-pk1 NULL
+b3-pk2 untouched
+b4-pk1 NULL
+b4-pk2 NULL
+
+# Clean up after the test.
+statement ok
+DROP TABLE b4, b3, b2, b1, a;
+
+subtest DeleteNull_Basic2
+### Basic Delete Set Null
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,delete_cascade STRING NOT NULL REFERENCES a ON DELETE CASCADE
+);
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES b1 ON DELETE SET NULL
+);
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES b1 ON DELETE SET NULL
+);
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY
+ ,delete_set_null STRING REFERENCES b2 ON DELETE SET NULL
+);
+
+statement ok
+INSERT INTO a VALUES ('a-pk1');
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1'), ('b1-pk2', 'a-pk1');
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1'), ('b2-pk2', 'a-pk1');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'b1-pk1')
+ ,('c1-pk2-b1-pk1', 'b1-pk1')
+ ,('c1-pk3-b1-pk2', 'b1-pk2')
+ ,('c1-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'b1-pk1')
+ ,('c2-pk2-b1-pk1', 'b1-pk1')
+ ,('c2-pk3-b1-pk2', 'b1-pk2')
+ ,('c2-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c3 VALUES
+  ('c3-pk1-b2-pk1', 'b2-pk1')
+ ,('c3-pk2-b2-pk1', 'b2-pk1')
+ ,('c3-pk3-b2-pk2', 'b2-pk2')
+ ,('c3-pk4-b2-pk2', 'b2-pk2')
+;
+
+# This query expects to cascade the deletion in a into b1 and b2, but not into
+# the c tables which have ON DELETE SET NULL instead.
+statement ok
+DELETE FROM a WHERE id = 'a-pk1';
+
+query TT rowsort
+  SELECT id, 'empty' FROM a
+UNION ALL
+  SELECT id, delete_cascade FROM b1
+UNION ALL
+  SELECT id, delete_cascade FROM b2
+UNION ALL
+  SELECT id, delete_set_null FROM c1
+UNION ALL
+  SELECT id, delete_set_null FROM c2
+UNION ALL
+  SELECT id, delete_set_null FROM c3
+;
+----
+c1-pk1-b1-pk1  NULL
+c1-pk2-b1-pk1  NULL
+c1-pk3-b1-pk2  NULL
+c1-pk4-b1-pk2  NULL
+c2-pk1-b1-pk1  NULL
+c2-pk2-b1-pk1  NULL
+c2-pk3-b1-pk2  NULL
+c2-pk4-b1-pk2  NULL
+c3-pk1-b2-pk1  NULL
+c3-pk2-b2-pk1  NULL
+c3-pk3-b2-pk2  NULL
+c3-pk4-b2-pk2  NULL
+
+statement ok
+TRUNCATE c3, c2, c1, b2, b1, a;
+
+# Perform the same operation but with show trace.
+statement ok
+INSERT INTO a VALUES ('a-pk1');
+INSERT INTO b1 VALUES ('b1-pk1', 'a-pk1'), ('b1-pk2', 'a-pk1');
+INSERT INTO b2 VALUES ('b2-pk1', 'a-pk1'), ('b2-pk2', 'a-pk1');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'b1-pk1')
+ ,('c1-pk2-b1-pk1', 'b1-pk1')
+ ,('c1-pk3-b1-pk2', 'b1-pk2')
+ ,('c1-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'b1-pk1')
+ ,('c2-pk2-b1-pk1', 'b1-pk1')
+ ,('c2-pk3-b1-pk2', 'b1-pk2')
+ ,('c2-pk4-b1-pk2', 'b1-pk2')
+;
+INSERT INTO c3 VALUES
+  ('c3-pk1-b2-pk1', 'b2-pk1')
+ ,('c3-pk2-b2-pk1', 'b2-pk1')
+ ,('c3-pk3-b2-pk2', 'b2-pk2')
+ ,('c3-pk4-b2-pk2', 'b2-pk2')
+;
+
+query I
+SELECT COUNT(*) FROM [
+  SHOW KV TRACE FOR DELETE FROM a WHERE id = 'a-pk1'
+] WHERE message LIKE 'cascading %';
+----
+5
+
+query TT rowsort
+  SELECT id, 'empty' FROM a
+UNION ALL
+  SELECT id, delete_cascade FROM b1
+UNION ALL
+  SELECT id, delete_cascade FROM b2
+UNION ALL
+  SELECT id, delete_set_null FROM c1
+UNION ALL
+  SELECT id, delete_set_null FROM c2
+UNION ALL
+  SELECT id, delete_set_null FROM c3
+;
+----
+c1-pk1-b1-pk1  NULL
+c1-pk2-b1-pk1  NULL
+c1-pk3-b1-pk2  NULL
+c1-pk4-b1-pk2  NULL
+c2-pk1-b1-pk1  NULL
+c2-pk2-b1-pk1  NULL
+c2-pk3-b1-pk2  NULL
+c2-pk4-b1-pk2  NULL
+c3-pk1-b2-pk1  NULL
+c3-pk2-b2-pk1  NULL
+c3-pk3-b2-pk2  NULL
+c3-pk4-b2-pk2  NULL
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+subtest DeleteNull_ToUpdateCascade
+# Cascade a delete in table a, to set null in table b, to an on update cascade
+# of that null into table c
+# a
+# |
+# b
+# |
+# c
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b (
+  id STRING PRIMARY KEY
+ ,a_id STRING UNIQUE REFERENCES a ON DELETE SET NULL
+);
+CREATE TABLE c (
+  id STRING PRIMARY KEY
+ ,b_a_id STRING REFERENCES b(a_id) ON UPDATE CASCADE
+);
+
+statement oK
+INSERT INTO a VALUES ('delete-me'), ('untouched');
+INSERT INTO b VALUES ('b1', 'delete-me'), ('b2', 'untouched');
+INSERT INTO c VALUES
+  ('c1-b1', 'delete-me')
+ ,('c2-b1', 'delete-me')
+ ,('c3-b2', 'untouched')
+ ,('c4-b2', 'untouched')
+;
+
+statement ok
+DELETE FROM a WHERE id = 'delete-me';
+
+query I
+SELECT COUNT(*) FROM a;
+----
+1
+
+query TT rowsort
+  SELECT id, a_id FROM b
+UNION ALL
+  SELECT id, b_a_id FROM c
+;
+----
+b1     NULL
+b2     untouched
+c1-b1  NULL
+c2-b1  NULL
+c3-b2  untouched
+c4-b2  untouched
+
+# Clean up after the test.
+statement ok
+DROP TABLE c, b, a;
+
+subtest DeleteNull_ToUpdateCascadeNotNull
+# Cascade a delete in table a, to set null in table b, to an on update cascade
+# of that null into table c, but table c's column is NOT NULL
+# a
+# |
+# b
+# |
+# c
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b (
+  id STRING PRIMARY KEY
+ ,a_id STRING UNIQUE REFERENCES a ON DELETE SET NULL
+);
+CREATE TABLE c (
+  id STRING PRIMARY KEY
+ ,b_a_id STRING NOT NULL REFERENCES b(a_id) ON UPDATE CASCADE
+);
+
+statement oK
+INSERT INTO a VALUES ('delete-me'), ('untouched');
+INSERT INTO b VALUES ('b1', 'delete-me'), ('b2', 'untouched');
+INSERT INTO c VALUES
+  ('c1-b1', 'delete-me')
+ ,('c2-b1', 'delete-me')
+ ,('c3-b2', 'untouched')
+ ,('c4-b2', 'untouched')
+;
+
+statement error pq: cannot cascade a null value into "test.c.b_a_id" as it violates a NOT NULL constraint
+DELETE FROM a WHERE id = 'delete-me';
+
+# Clean up after the test.
+statement ok
+DROP TABLE c, b, a;

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -89,8 +89,11 @@ ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON UPDATE CASCA
 statement ok
 ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
 
-statement error pq: unsupported: ON DELETE SET NULL
+statement ok
 ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON DELETE SET NULL
+
+statement ok
+ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
 
 statement error pq: unsupported: ON UPDATE SET NULL
 ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON UPDATE SET NULL
@@ -1094,3 +1097,108 @@ ALTER TABLE b ADD CONSTRAINT delete_check CHECK (update_cascade_composite1 > 0);
 # Clean up after the test.
 statement ok
 DROP TABLE b, a;
+
+subtest DeleteNull_NotNullConstraint
+### Make sure that one cannot add a set null action on a NOT NULL column.
+
+statement ok
+CREATE TABLE a (
+  id INT PRIMARY KEY
+);
+
+# Create a table with a NOT NULL column and a SET NULL action.
+statement error pq: cannot add a SET NULL cascading action on column \"delete_not_nullable\" which has a NOT NULL constraint
+CREATE TABLE not_null_table (
+  id INT PRIMARY KEY
+ ,delete_not_nullable INT NOT NULL REFERENCES a ON DELETE SET NULL
+);
+
+# Create a table where the primary key has a SET NULL action.
+statement error pq: cannot add a SET NULL cascading action on column \"id\" which has a NOT NULL constraint
+CREATE TABLE primary_key_table (
+  id INT PRIMARY KEY REFERENCES a ON DELETE SET NULL
+);
+
+# Add a SET NULL action after the fact with a NOT NULL column.
+statement ok
+CREATE TABLE not_null_table (
+  id INT PRIMARY KEY
+ ,delete_not_nullable INT NOT NULL
+);
+
+statement error pq: cannot add a SET NULL cascading action on column \"delete_not_nullable\" which has a NOT NULL constraint
+ALTER TABLE not_null_table ADD CONSTRAINT not_null_set_null
+  FOREIGN KEY (delete_not_nullable) REFERENCES a (id)
+  ON DELETE SET NULL;
+
+# Add a SET NULL action after the fact with a primary key column.
+statement ok
+CREATE TABLE primary_key_table (
+  id INT PRIMARY KEY
+);
+
+statement error pq: cannot add a SET NULL cascading action on column \"id\" which has a NOT NULL constraint
+ALTER TABLE primary_key_table ADD CONSTRAINT not_null_set_null
+  FOREIGN KEY (id) REFERENCES a (id)
+  ON DELETE SET NULL;
+
+# Clean up the tables so far.
+statement ok
+DROP TABLE primary_key_table, not_null_table, a;
+
+# Now test composite foreign keys
+statement ok
+CREATE TABLE a (
+  id1 INT
+ ,id2 INT
+ ,PRIMARY KEY (id2, id1)
+);
+
+# Create a table with a NOT NULL column and a SET NULL action.
+statement error pq: cannot add a SET NULL cascading action on column \"ref1\" which has a NOT NULL constraint
+CREATE TABLE not_null_table (
+  id INT PRIMARY KEY
+ ,ref1 INT NOT NULL
+ ,ref2 INT NOT NULL
+ ,INDEX (ref1, ref2)
+ ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET NULL
+);
+
+statement error pq: cannot add a SET NULL cascading action on column \"ref1\" which has a NOT NULL constraint
+CREATE TABLE not_null_table (
+  id INT PRIMARY KEY
+ ,ref1 INT NOT NULL
+ ,ref2 INT
+ ,INDEX (ref1, ref2)
+ ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET NULL
+);
+
+statement error pq: cannot add a SET NULL cascading action on column \"ref2\" which has a NOT NULL constraint
+CREATE TABLE not_null_table (
+  id INT PRIMARY KEY
+ ,ref1 INT
+ ,ref2 INT NOT NULL
+ ,INDEX (ref1, ref2)
+ ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET NULL
+);
+
+# Create a table where the primary key has a SET NULL action.
+statement error pq: cannot add a SET NULL cascading action on column \"ref1\" which has a NOT NULL constraint
+CREATE TABLE primary_key_table (
+  ref1 INT
+ ,ref2 INT
+ ,PRIMARY KEY (ref2, ref1)
+ ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET NULL
+);
+
+statement error pq: cannot add a SET NULL cascading action on column \"ref2\" which has a NOT NULL constraint
+CREATE TABLE primary_key_table (
+  ref1 INT
+ ,ref2 INT
+ ,PRIMARY KEY (ref2, ref1)
+ ,FOREIGN KEY (ref2, ref1) REFERENCES a (id2, id1) ON DELETE SET NULL
+);
+
+# Clean up after the test.
+statement ok
+DROP TABLE a;


### PR DESCRIPTION
This PR takes a similar path to that of ON UPDATE CASCADE.  As much of the
groundwork was already laid, it was more a matter of adding in the requisite
tests to ensure that it indeed does perform as expected.  In doing so, it
became clear that there is a conflict between check constraints and cascading
updates, which prompted the creation of #21688.

Almost all the work in this PR is limited to the cascader itself.  By updating
the updateRows function to take in the action that is being performed, so that
instead of cascading the update directly, it simply adds NULL values into the
cascading columns.

During this work, I found that it was possible to cascade via an ON UPDATE
CASCADE after a SET NULL into a NOT NULL column, so a check (and test) for that
was added.

Adding in ON UPDATE SET NULL should be relatively simple after this, but as
always the testing is where the real work needs to be done. However, I am
confident in this implementation.

Release note (sql change): ON DELETE SET NULL foreign key constraints actions
are now fully supported