### PR TITLE
storage: prevent reuse of time bounded iterators

### DIFF
--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -1559,17 +1559,14 @@ func (r *rocksDBBatch) NewTimeBoundIterator(start, end hlc.Timestamp) Iterator {
 	if r.distinctOpen {
 		panic("distinct batch open")
 	}
-	// Used the cached iterator, creating it on first access.
-	iter := &r.normalIter
-	if iter.iter.iter == nil {
-		r.ensureBatch()
-		iter.iter.initTimeBound(r.batch, start, end, r)
-	}
-	if iter.batch != nil {
-		panic("iterator already in use")
-	}
+
+	// Don't cache these iterators; we're unlikely to get many calls for the same
+	// time bounds.
+	r.ensureBatch()
+	var iter rocksDBBatchIterator
+	iter.iter.initTimeBound(r.batch, start, end, r)
 	iter.batch = r
-	return iter
+	return &iter
 }
 
 func (r *rocksDBBatch) Commit(syncCommit bool) error {


### PR DESCRIPTION
`(*rocksDBBatch).NewTimeboundedIterator` was caching the iterator in a
way that would return the iterator in future calls to
`(*rocksDBBatch).NewIterator`, which was a correctness problem.

Luckily, the fallout was somewhat limited by the fact that we only use
time bounded iterators when resolving an intent, and that is usually
(but not always) the last operation carried out on the batch.

This was introduced in #21078, which landed around Jan 15 2018, so
the bug has not made it into a release yet, though we'll have to bump
our alpha (https://github.com/cockroachdb/cockroach/issues/21657).

Release note: None