### PR TITLE
storage: add (disabled) post-split assertion

### DIFF
--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -527,6 +527,9 @@ func resolveLocalIntents(
 			if inSpan != nil {
 				intent.Span = *inSpan
 				num, resumeSpan, err := engine.MVCCResolveWriteIntentRangeUsingIter(ctx, batch, iterAndBuf, ms, intent, resolveAllowance)
+				if err != nil {
+					return err
+				}
 				if knobs.NumKeysEvaluatedForRangeIntentResolution != nil {
 					atomic.AddInt64(knobs.NumKeysEvaluatedForRangeIntentResolution, num)
 				}
@@ -537,7 +540,7 @@ func resolveLocalIntents(
 					}
 					externalIntents = append(externalIntents, *resumeSpan)
 				}
-				return err
+				return nil
 			}
 			return nil
 		}(); err != nil {


### PR DESCRIPTION
I have written variations on these assertions a handful of times now, and
prefer not to have to do it again in the future.

Release note: None