### PR TITLE
storage: adjust options for manual RocksDB compaction

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -112,7 +112,7 @@ DBStatus DBCompact(DBEngine* db);
 // Forces an immediate compaction over keys in the specified range.
 // Note that if start is empty, it indicates the start of the database.
 // If end is empty, it indicates the end of the database.
-DBStatus DBCompactRange(DBEngine* db, DBSlice start, DBSlice end);
+DBStatus DBCompactRange(DBEngine* db, DBSlice start, DBSlice end, bool force_bottommost);
 
 // Stores the approximate on-disk size of the given key range into the
 // supplied uint64.

--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -306,7 +306,7 @@ func (c *Compactor) processCompaction(
 	if shouldProcess {
 		startTime := timeutil.Now()
 		log.Eventf(ctx, "processing compaction %s", aggr)
-		if err := c.eng.CompactRange(aggr.StartKey, aggr.EndKey); err != nil {
+		if err := c.eng.CompactRange(aggr.StartKey, aggr.EndKey, false /* forceBottommost */); err != nil {
 			return 0, errors.Wrapf(err, "unable to compact range %+v", aggr)
 		}
 		c.Metrics.BytesCompacted.Inc(aggr.Bytes)
@@ -397,9 +397,9 @@ func (c *Compactor) examineQueue(ctx context.Context) (int64, error) {
 	return totalBytes, nil
 }
 
-// SuggestCompaction writes the specified compaction to persistent
-// storage and pings the processing goroutine.
-func (c *Compactor) SuggestCompaction(ctx context.Context, sc storagebase.SuggestedCompaction) {
+// Suggest writes the specified compaction to persistent storage and
+// pings the processing goroutine.
+func (c *Compactor) Suggest(ctx context.Context, sc storagebase.SuggestedCompaction) {
 	log.VEventf(ctx, 2, "suggested compaction from %s - %s: %+v", sc.StartKey, sc.EndKey, sc.Compaction)
 
 	// Check whether a suggested compaction already exists for this key span.

--- a/pkg/storage/compactor/compactor_test.go
+++ b/pkg/storage/compactor/compactor_test.go
@@ -73,7 +73,7 @@ func (we *wrappedEngine) GetSSTables() engine.SSTableInfos {
 	return ssti
 }
 
-func (we *wrappedEngine) CompactRange(start, end roachpb.Key) error {
+func (we *wrappedEngine) CompactRange(start, end roachpb.Key, forceBottommost bool) error {
 	we.mu.Lock()
 	defer we.mu.Unlock()
 	time.Sleep(testCompactionLatency)
@@ -435,7 +435,7 @@ func TestCompactorThresholds(t *testing.T) {
 			compactor.opts.CompactionMinInterval = time.Millisecond
 
 			for _, sc := range test.suggestions {
-				compactor.SuggestCompaction(context.Background(), sc)
+				compactor.Suggest(context.Background(), sc)
 			}
 
 			// If we expect no compaction, pause to ensure test will fail if
@@ -507,7 +507,7 @@ func TestCompactorProcessingInitialization(t *testing.T) {
 	// Add a suggested compaction -- this won't get processed by this
 	// compactor for an hour.
 	compactor.opts.CompactionMinInterval = time.Hour
-	compactor.SuggestCompaction(context.Background(), storagebase.SuggestedCompaction{
+	compactor.Suggest(context.Background(), storagebase.SuggestedCompaction{
 		StartKey: key("a"), EndKey: key("b"),
 		Compaction: storagebase.Compaction{
 			Bytes:            defaultThresholdBytes,
@@ -548,7 +548,7 @@ func TestCompactorCleansUpOldRecords(t *testing.T) {
 
 	// Add a suggested compaction that won't get processed because it's
 	// not over any of the thresholds.
-	compactor.SuggestCompaction(context.Background(), storagebase.SuggestedCompaction{
+	compactor.Suggest(context.Background(), storagebase.SuggestedCompaction{
 		StartKey: key("a"), EndKey: key("b"),
 		Compaction: storagebase.Compaction{
 			Bytes:            defaultThresholdBytes - 1,

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -258,8 +258,10 @@ type Engine interface {
 	// ApproximateDiskBytes returns an approximation of the on-disk size for the given key span.
 	ApproximateDiskBytes(from, to roachpb.Key) (uint64, error)
 	// CompactRange ensures that the specified range of key value pairs is
-	// optimized for space efficiency.
-	CompactRange(start, end roachpb.Key) error
+	// optimized for space efficiency. The forceBottommost parameter ensures
+	// that the key range is compacted all the way to the bottommost level of
+	// SSTables, which is necessary to pick up changes to bloom filters.
+	CompactRange(start, end roachpb.Key, forceBottommost bool) error
 }
 
 // WithSSTables extends the Engine interface with a method to get info

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -853,8 +853,8 @@ func (r *RocksDB) Compact() error {
 }
 
 // CompactRange forces compaction over a specified range of keys in the database.
-func (r *RocksDB) CompactRange(start, end roachpb.Key) error {
-	return statusToError(C.DBCompactRange(r.rdb, goToCSlice(start), goToCSlice(end)))
+func (r *RocksDB) CompactRange(start, end roachpb.Key, forceBottommost bool) error {
+	return statusToError(C.DBCompactRange(r.rdb, goToCSlice(start), goToCSlice(end), C.bool(forceBottommost)))
 }
 
 // ApproximateDiskBytes returns the approximate on-disk size of the specified key range.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -780,7 +780,7 @@ func (r *Replica) destroyDataRaftMuLocked(
 	clearTime := timeutil.Now()
 
 	// Suggest the cleared range to the compactor queue.
-	r.store.compactor.SuggestCompaction(ctx, storagebase.SuggestedCompaction{
+	r.store.compactor.Suggest(ctx, storagebase.SuggestedCompaction{
 		StartKey: roachpb.Key(desc.StartKey),
 		EndKey:   roachpb.Key(desc.EndKey),
 		Compaction: storagebase.Compaction{

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -660,7 +660,7 @@ func (r *Replica) handleReplicatedEvalResult(
 	}
 
 	for _, sc := range rResult.SuggestedCompactions {
-		r.store.compactor.SuggestCompaction(ctx, sc)
+		r.store.compactor.Suggest(ctx, sc)
 	}
 	rResult.SuggestedCompactions = nil
 


### PR DESCRIPTION
Two options have been modified when using manual compactions:
- Specification of the `exclusive_manual_compaction=false` flag when manually
      compacting RocksDB key spans, which changes the default to avoid having
      manual compactions stall concurrent, automatic compactions. This avoids
      jamming up the system once the L0 SSTables need to be compacted to L1
      SSTables.
- A new "forceBottommost" parameter has been plumbed through `storage.Engine`
      for `CompactRange` in order to allow callers to avoid forcing compaction
      to L6. This is now in use by the compactor queue to avoid unnecessarily
      expensive rewrites.

Fixes #21528