### PR TITLE
kv: fix non-nil rejectErr assertion in TxnCoordSender

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -629,7 +629,7 @@ func (tc *TxnCoordSender) cleanupTxnLocked(ctx context.Context, state txnCoordSt
 		// rejectErr is guaranteed to be non-nil because state is done or
 		// aborted on cleanup.
 		rejectErr := tc.maybeRejectClientLocked(ctx, tc.mu.meta.Txn.ID).GetDetail()
-		if rejectErr != nil {
+		if rejectErr == nil {
 			log.Fatalf(ctx, "expected non-nil rejectErr on txn coord state %v", state)
 		}
 		tc.mu.onFinishFn(rejectErr)


### PR DESCRIPTION
Fixes #21664.
Fixes #21715.
Fixes #21719.
Fixes #21726.
Fixes #21727.
Fixes #21728.
Fixes #21734.
Fixes #21735.
Fixes #21743.
Fixes #21745.
Fixes #21747.
Fixes #21749.
Fixes #21751.

Release note: None