### PR TITLE
server,sql: add the DistSQLPlanner to the ExecutorConfig

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -106,7 +106,12 @@ var planMergeJoins = settings.RegisterBoolSetting(
 	true,
 )
 
-// NewDistSQLPlanner initializes a DistSQLPlanner
+// NewDistSQLPlanner initializes a DistSQLPlanner.
+//
+// nodeDesc is the descriptor of the node on which this planner runs. It is used
+// to favor itself and other close-by nodes when planning. An empty descriptor
+// can be passed to aid bootstrapping, but then SetNodeDesc() needs to be called
+// before this planner is used.
 func NewDistSQLPlanner(
 	ctx context.Context,
 	planVersion distsqlrun.DistSQLVersion,
@@ -119,7 +124,6 @@ func NewDistSQLPlanner(
 	stopper *stop.Stopper,
 	testingKnobs DistSQLPlannerTestingKnobs,
 ) *DistSQLPlanner {
-	log.Infof(ctx, "creating DistSQLPlanner with address %s", nodeDesc.Address)
 	dsp := &DistSQLPlanner{
 		planVersion:  planVersion,
 		st:           st,
@@ -133,6 +137,11 @@ func NewDistSQLPlanner(
 	}
 	dsp.initRunners()
 	return dsp
+}
+
+// SetNodeDesc sets the planner's node descriptor.
+func (dsp *DistSQLPlanner) SetNodeDesc(desc roachpb.NodeDescriptor) {
+	dsp.nodeDesc = desc
 }
 
 // setSpanResolver switches to a different SpanResolver. It is the caller's

--- a/pkg/sql/distsqlrun/flow_registry.go
+++ b/pkg/sql/distsqlrun/flow_registry.go
@@ -163,7 +163,7 @@ func (fr *flowRegistry) RegisterFlow(
 	entry := fr.getEntryLocked(id)
 	if entry.flow != nil {
 		return errors.Errorf(
-			"flow already registered: current node ID: %d flowID: %d.\n"+
+			"flow already registered: current node ID: %d flowID: %s.\n"+
 				"Current flow: %+v\nExisting flow: %+v",
 			fr.nodeID, f.spec.FlowID, f.spec, entry.flow.spec)
 	}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -274,6 +274,7 @@ type ExecutorConfig struct {
 	SessionRegistry *SessionRegistry
 	JobRegistry     *jobs.Registry
 	VirtualSchemas  *VirtualSchemaHolder
+	DistSQLPlanner  *DistSQLPlanner
 
 	TestingKnobs              *ExecutorTestingKnobs
 	SchemaChangerTestingKnobs *SchemaChangerTestingKnobs

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -198,11 +198,12 @@ func newInternalPlanner(
 	}
 
 	s := &Session{
-		data:     data,
-		TxnState: txnState{Ctx: ctx, implicitTxn: true},
-		context:  ctx,
-		tables:   TableCollection{databaseCache: newDatabaseCache(config.SystemConfig{})},
-		execCfg:  execCfg,
+		data:           data,
+		TxnState:       txnState{Ctx: ctx, implicitTxn: true},
+		context:        ctx,
+		tables:         TableCollection{databaseCache: newDatabaseCache(config.SystemConfig{})},
+		execCfg:        execCfg,
+		distSQLPlanner: execCfg.DistSQLPlanner,
 	}
 	s.dataMutator = sessionDataMutator{
 		data: &s.data,


### PR DESCRIPTION
ExecutorConfig has become the grab-bag of server-wide objects that sql
has access to for interacting with its environment. As such,
DistSQLPlanner belongs in there too. This allows the InternalExecutor to
get it too; before this patch it hackily had a nil planner.
This causes a little bit of a bootstrapping problem since the
DistSQLPlanner needs a NodeDescriptor, but that is available only after
Server creation. As in other cases, this was resolved by splitting the
initialization of the DistSQLPlanner into two parts.

Release note: None