### PR TITLE
workload: require a separate init phase

### DIFF
--- a/pkg/cmd/workload/run.go
+++ b/pkg/cmd/workload/run.go
@@ -44,26 +44,34 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-const crdbDefaultURI = `postgres://root@localhost:26257/test?sslmode=disable`
+const crdbDefaultURI = `postgres://root@localhost:26257?sslmode=disable`
 
 var runCmd = &cobra.Command{
 	Use:   `run`,
 	Short: `Run a workload's operations against a cluster`,
 }
 
-var rootFlags = pflag.NewFlagSet(`workload`, pflag.ContinueOnError)
-var concurrency = rootFlags.Int(
+var runFlags = pflag.NewFlagSet(`run`, pflag.ContinueOnError)
+var concurrency = runFlags.Int(
 	"concurrency", 2*runtime.NumCPU(), "Number of concurrent writers inserting blocks")
-var tolerateErrors = rootFlags.Bool("tolerate-errors", false, "Keep running on error")
-var maxRate = rootFlags.Float64(
+var tolerateErrors = runFlags.Bool("tolerate-errors", false, "Keep running on error")
+var maxRate = runFlags.Float64(
 	"max-rate", 0, "Maximum frequency of operations (reads/writes). If 0, no limit.")
-var maxOps = rootFlags.Uint64("max-ops", 0, "Maximum number of operations to run")
-var duration = rootFlags.Duration("duration", 0, "The duration to run. If 0, run forever.")
-var drop = rootFlags.Bool("drop", false, "Clear the existing data before starting.")
+var maxOps = runFlags.Uint64("max-ops", 0, "Maximum number of operations to run")
+var duration = runFlags.Duration("duration", 0, "The duration to run. If 0, run forever.")
+var doInit = runFlags.Bool("init", false, "Automatically run init")
+
+var initCmd = &cobra.Command{
+	Use:   `init`,
+	Short: `Set up tables for a workload`,
+}
+
+var initFlags = pflag.NewFlagSet(`init`, pflag.ContinueOnError)
+var drop = initFlags.Bool("drop", false, "Drop the existing database, if it exists")
 
 // Output in HdrHistogram Plotter format. See
 // https://hdrhistogram.github.io/HdrHistogram/plotFiles.html
-var histFile = rootFlags.String(
+var histFile = runFlags.String(
 	"hist-file", "",
 	"Write histogram data to file for HdrHistogram Plotter, or stdout if - is specified.")
 
@@ -73,10 +81,29 @@ func init() {
 		genFlags := gen.Flags()
 		genHooks := gen.Hooks()
 
-		genCmd := &cobra.Command{Use: meta.Name, Short: meta.Description}
-		genCmd.Flags().AddFlagSet(rootFlags)
-		genCmd.Flags().AddFlagSet(genFlags)
-		genCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		genInitCmd := &cobra.Command{Use: meta.Name, Short: meta.Description}
+		genInitCmd.Flags().AddFlagSet(initFlags)
+		genInitCmd.Flags().AddFlagSet(genFlags)
+		genInitCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			if genHooks.Validate != nil {
+				if err := genHooks.Validate(); err != nil {
+					return err
+				}
+			}
+			return runInit(gen, args)
+		}
+		initCmd.AddCommand(genInitCmd)
+
+		genRunCmd := &cobra.Command{Use: meta.Name, Short: meta.Description}
+		genRunCmd.Flags().AddFlagSet(runFlags)
+		genRunCmd.Flags().AddFlagSet(genFlags)
+		initFlags.VisitAll(func(initFlag *pflag.Flag) {
+			// Every init flag is a valid run flag that implies the --init option.
+			f := *initFlag
+			f.Usage += ` (implies --init)`
+			genRunCmd.Flags().AddFlag(&f)
+		})
+		genRunCmd.RunE = func(cmd *cobra.Command, args []string) error {
 			if genHooks.Validate != nil {
 				if err := genHooks.Validate(); err != nil {
 					return err
@@ -84,9 +111,9 @@ func init() {
 			}
 			return runRun(gen, args)
 		}
-
-		runCmd.AddCommand(genCmd)
+		runCmd.AddCommand(genRunCmd)
 	}
+	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(runCmd)
 }
 
@@ -160,57 +187,78 @@ func (w *worker) run(
 	}
 }
 
+func sanitizeDBURL(dbURL string) (string, error) {
+	parsedURL, err := url.Parse(dbURL)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimPrefix(parsedURL.Path, "/") != "" {
+		return "", fmt.Errorf(
+			`database URL specifies database %q, but database "test" is always used`, parsedURL.Path)
+	}
+	parsedURL.Path = "test"
+
+	switch parsedURL.Scheme {
+	case "postgres", "postgresql":
+		return parsedURL.String(), nil
+	default:
+		return "", fmt.Errorf("unsupported database: %s", parsedURL.Scheme)
+	}
+}
+
 func setupCockroach(dbURLs []string) (*gosql.DB, error) {
+	if len(dbURLs) == 0 {
+		dbURLs = []string{crdbDefaultURI}
+	}
+
+	var sanitizedURLs = make([]string, len(dbURLs))
+	for i, dbURL := range dbURLs {
+		var err error
+		sanitizedURLs[i], err = sanitizeDBURL(dbURL)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// Open connection to server and create a database.
-	db, dbErr := gosql.Open("cockroach", strings.Join(dbURLs, " "))
-	if dbErr != nil {
-		return nil, dbErr
+	db, err := gosql.Open("cockroach", strings.Join(sanitizedURLs, " "))
+	if err != nil {
+		return nil, err
 	}
 
 	// Allow a maximum of concurrency+1 connections to the database.
 	db.SetMaxOpenConns(*concurrency + 1)
 	db.SetMaxIdleConns(*concurrency + 1)
 
-	if *drop {
-		if _, err := db.Exec(`DROP DATABASE IF EXISTS test`); err != nil {
-			return nil, err
-		}
-	}
-	if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS test"); err != nil {
-		return nil, err
-	}
-	if _, err := db.Exec("USE test"); err != nil {
-		return nil, err
-	}
-
 	return db, nil
 }
 
-// setupDatabase performs initial setup for the example, creating a database and
-// with a single table. If the desired table already exists on the cluster, the
-// existing table will be dropped.
-func setupDatabase(dbURLs []string) (*gosql.DB, error) {
-	parsedURL, err := url.Parse(dbURLs[0])
+func runInit(gen workload.Generator, args []string) error {
+	db, err := setupCockroach(args)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	parsedURL.Path = "test"
 
-	switch parsedURL.Scheme {
-	case "postgres", "postgresql":
-		return setupCockroach(dbURLs)
-	default:
-		return nil, fmt.Errorf("unsupported database: %s", parsedURL.Scheme)
+	return runInitImpl(gen, db)
+}
+
+func runInitImpl(gen workload.Generator, db *gosql.DB) error {
+	if *drop {
+		if _, err := db.Exec(`DROP DATABASE IF EXISTS test`); err != nil {
+			return err
+		}
 	}
+	if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		return err
+	}
+
+	const batchSize = -1
+	_, err := workload.Setup(db, gen, batchSize)
+	return err
 }
 
 func runRun(gen workload.Generator, args []string) error {
 	ctx := context.Background()
-
-	dbURLs := []string{crdbDefaultURI}
-	if len(args) >= 1 {
-		dbURLs = args
-	}
 
 	if *concurrency < 1 {
 		return errors.Errorf(
@@ -220,8 +268,8 @@ func runRun(gen workload.Generator, args []string) error {
 	var db *gosql.DB
 	{
 		var err error
-		for err == nil || *tolerateErrors {
-			db, err = setupDatabase(dbURLs)
+		for {
+			db, err = setupCockroach(args)
 			if err == nil {
 				break
 			}
@@ -230,9 +278,18 @@ func runRun(gen workload.Generator, args []string) error {
 			}
 		}
 	}
-	const batchSize = -1
-	if _, err := workload.Setup(db, gen, batchSize); err != nil {
-		return err
+
+	if *doInit || *drop {
+		var err error
+		for {
+			err = runInitImpl(gen, db)
+			if err == nil {
+				break
+			}
+			if !*tolerateErrors {
+				return err
+			}
+		}
 	}
 
 	var limiter *rate.Limiter


### PR DESCRIPTION
Currently, `workload run` will create any necessary databases and
tables, loaded with any necessary data. This works well when workload
only runs on one machine, but is untenable when workload needs to be run
on multiple machines at once, e.g. for testing partitioning.

Ignore the first two commits; those are #21762.

@petermattis, @danhhz and I are curious to know if this would impede your perf testing workload. (Assuming a world where you use `workload run kv` instead of `kv` directly.)