### PR TITLE
sql, ccl: make backup/restore work for sequences

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2437,6 +2437,15 @@ func (desc *TableDescriptor) IndexSpan(indexID IndexID) roachpb.Span {
 	return roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
 }
 
+// SequenceSpan returns a span that covers the single key of a sequence (which stores its value).
+func (desc *TableDescriptor) SequenceSpan() roachpb.Span {
+	seqKey := roachpb.Key(keys.MakeSequenceKey(uint32(desc.ID)))
+	return roachpb.Span{
+		Key:    seqKey,
+		EndKey: seqKey.Next(),
+	}
+}
+
 // TableSpan returns the Span that corresponds to the entire table.
 func (desc *TableDescriptor) TableSpan() roachpb.Span {
 	prefix := roachpb.Key(keys.MakeTablePrefix(uint32(desc.ID)))


### PR DESCRIPTION
For each sequence, add its key to the spans being backed up.

On the restore side, teach the key rewriter (which rewrites old table descriptor ids to new ones) how to rewrite sequence keys.

This is an alternate approach to #21684, which changes sequences' key format to make backup restore work without changes. I think I prefer the current format, `/Table/<id>/"seqval"`, to the new format in that PR, `/Table/<id>/0/0/0` (dummy index id, PK value, and family id), since it's more clear that it's a sequence just from looking at the key.

Release note (enterprise change): make backup/restore work for sequences