### PR TITLE
sql: add support for ON UPDATE SET NULL actions on foreign key references

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -473,7 +473,7 @@ func resolveFK(
 		feature := fmt.Sprintf("unsupported: ON DELETE %s", d.Actions.Delete)
 		return pgerror.Unimplemented(feature, feature)
 	}
-	if d.Actions.Update == tree.SetNull || d.Actions.Update == tree.SetDefault {
+	if d.Actions.Update == tree.SetDefault {
 		feature := fmt.Sprintf("unsupported: ON UPDATE %s", d.Actions.Update)
 		return pgerror.Unimplemented(feature, feature)
 	}
@@ -526,6 +526,7 @@ func resolveFK(
 			}
 		}
 	}
+
 	ref := sqlbase.ForeignKeyReference{
 		Table:           target.ID,
 		Index:           targetIdxID,

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -20,7 +20,7 @@ CREATE TABLE b (
  ,delete_cascade INT NOT NULL REFERENCES a ON DELETE CASCADE
  ,update_cascade INT NOT NULL REFERENCES a ON UPDATE CASCADE
  ,delete_null INT REFERENCES a ON DELETE SET NULL
- ,update_null INT REFERENCES a
+ ,update_null INT REFERENCES a ON UPDATE SET NULL
  ,delete_default INT DEFAULT 100 REFERENCES a
  ,update_default INT DEFAULT 100 REFERENCES a
 );
@@ -65,12 +65,12 @@ INSERT INTO b VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
 # 6. ON UPDATE CASCADE
 statement ok
-UPDATE a SET id = 1000 WHERE id = 6;
+UPDATE a SET id = 1006 WHERE id = 6;
 
 query IIIIIIIIII
 SELECT * FROM b;
 ----
-1 2 3 4 5 1000 7 8 9 10
+1  2  3  4  5  1006  7  8  9  10
 
 # 7. ON DELETE SET NULL
 statement ok
@@ -79,7 +79,16 @@ DELETE FROM a WHERE id = 7;
 query IIIIIIIIII
 SELECT * FROM b;
 ----
-1 2 3 4 5 1000 NULL 8 9 10
+1  2  3  4  5  1006  NULL  8  9  10
+
+# 8. ON UPDATE SET NULL
+statement ok
+UPDATE a SET id = 1008 WHERE id = 8;
+
+query IIIIIIIIII
+SELECT * FROM b;
+----
+1  2  3  4  5  1006  NULL  NULL  9  10
 
 # Post Test Clean up
 statement ok
@@ -2048,6 +2057,355 @@ INSERT INTO c VALUES
 
 statement error pq: cannot cascade a null value into "test.c.b_a_id" as it violates a NOT NULL constraint
 DELETE FROM a WHERE id = 'delete-me';
+
+# Clean up after the test.
+statement ok
+DROP TABLE c, b, a;
+
+subtest UpdateNull_Basic1
+### Basic Update Set Null
+#        a
+#      // \\
+#    / |  |  \
+#   b1 b2 b3 b4
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES a ON UPDATE SET NULL
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES a ON UPDATE SET NULL
+);
+CREATE TABLE b3 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES a ON UPDATE SET NULL
+);
+CREATE TABLE b4 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES a ON UPDATE SET NULL
+);
+
+statement ok
+INSERT INTO a VALUES ('original'), ('untouched');
+INSERT INTO b1 VALUES ('b1-pk1', 'untouched'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'untouched'), ('b2-pk2', 'original');
+INSERT INTO b3 VALUES ('b3-pk1', 'original'), ('b3-pk2', 'untouched');
+INSERT INTO b3 VALUES ('b4-pk1', 'original'), ('b4-pk2', 'original');
+
+# ON UPDATE CASCADE
+statement ok
+UPDATE a SET id = 'updated' WHERE id = 'original';
+
+query TT rowsort
+  SELECT id, update_set_null FROM b1
+UNION ALL
+  SELECT id, update_set_null FROM b2
+UNION ALL
+  SELECT id, update_set_null FROM b3
+UNION ALL
+  SELECT id, update_set_null FROM b4
+;
+----
+b1-pk1 untouched
+b1-pk2 untouched
+b2-pk1 untouched
+b2-pk2 NULL
+b3-pk1 NULL
+b3-pk2 untouched
+b4-pk1 NULL
+b4-pk2 NULL
+
+# Perform the same operation but with show trace.
+statement ok
+TRUNCATE a, b1, b2, b3, b4;
+
+statement ok
+INSERT INTO a VALUES ('original'), ('untouched');
+INSERT INTO b1 VALUES ('b1-pk1', 'untouched'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'untouched'), ('b2-pk2', 'original');
+INSERT INTO b3 VALUES ('b3-pk1', 'original'), ('b3-pk2', 'untouched');
+INSERT INTO b3 VALUES ('b4-pk1', 'original'), ('b4-pk2', 'original');
+
+# Ensure that show trace adds a cascade message for each of the tables that is
+# cascaded into.
+query I
+SELECT COUNT(*) FROM [
+  SHOW KV TRACE FOR UPDATE a SET id = 'updated' WHERE id = 'original'
+] WHERE message LIKE 'cascading %';
+----
+4
+
+query TT rowsort
+  SELECT id, update_set_null FROM b1
+UNION ALL
+  SELECT id, update_set_null FROM b2
+UNION ALL
+  SELECT id, update_set_null FROM b3
+UNION ALL
+  SELECT id, update_set_null FROM b4
+;
+----
+b1-pk1 untouched
+b1-pk2 untouched
+b2-pk1 untouched
+b2-pk2 NULL
+b3-pk1 NULL
+b3-pk2 untouched
+b4-pk1 NULL
+b4-pk2 NULL
+
+# Clean up after the test.
+statement ok
+DROP TABLE b4, b3, b2, b1, a;
+
+subtest UpdateNull_Basic2
+### Basic Update Set Null
+#     a
+#    / \
+#   b1 b2
+#  / \   \
+# c1  c2  c3
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b1 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING UNIQUE NOT NULL REFERENCES a ON UPDATE CASCADE
+);
+CREATE TABLE b2 (
+  id STRING PRIMARY KEY
+ ,update_cascade STRING UNIQUE NOT NULL REFERENCES a ON UPDATE CASCADE
+);
+CREATE TABLE c1 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES b1(update_cascade) ON UPDATE SET NULL
+);
+CREATE TABLE c2 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES b1(update_cascade) ON UPDATE SET NULL
+);
+CREATE TABLE c3 (
+  id STRING PRIMARY KEY
+ ,update_set_null STRING REFERENCES b1(update_cascade) ON UPDATE SET NULL
+);
+
+statement ok
+INSERT INTO a VALUES ('original'), ('untouched');
+INSERT INTO b1 VALUES ('b1-pk1', 'original'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'original'), ('b2-pk2', 'untouched');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'original')
+ ,('c1-pk2-b1-pk1', 'original')
+ ,('c1-pk3-b1-pk2', 'untouched')
+ ,('c1-pk4-b1-pk2', 'untouched')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'original')
+ ,('c2-pk2-b1-pk1', 'original')
+ ,('c2-pk3-b1-pk2', 'untouched')
+ ,('c2-pk4-b1-pk2', 'untouched')
+;
+INSERT INTO c3 VALUES
+  ('c3-pk1-b2-pk1', 'original')
+ ,('c3-pk2-b2-pk1', 'original')
+ ,('c3-pk3-b2-pk2', 'untouched')
+ ,('c3-pk4-b2-pk2', 'untouched')
+;
+
+# ON UPDATE CASCADE
+statement ok
+UPDATE a SET id = 'updated' WHERE id = 'original';
+
+query TT rowsort
+  SELECT id, update_cascade FROM b1
+UNION ALL
+  SELECT id, update_cascade FROM b2
+UNION ALL
+  SELECT id, update_set_null FROM c1
+UNION ALL
+  SELECT id, update_set_null FROM c2
+UNION ALL
+  SELECT id, update_set_null FROM c3
+;
+----
+b1-pk1         updated
+b1-pk2         untouched
+b2-pk1         updated
+b2-pk2         untouched
+c1-pk1-b1-pk1  NULL
+c1-pk2-b1-pk1  NULL
+c1-pk3-b1-pk2  untouched
+c1-pk4-b1-pk2  untouched
+c2-pk1-b1-pk1  NULL
+c2-pk2-b1-pk1  NULL
+c2-pk3-b1-pk2  untouched
+c2-pk4-b1-pk2  untouched
+c3-pk1-b2-pk1  NULL
+c3-pk2-b2-pk1  NULL
+c3-pk3-b2-pk2  untouched
+c3-pk4-b2-pk2  untouched
+
+# Perform the same operation but with show trace.
+statement ok
+TRUNCATE c3, c2, c1, b2, b1, a;
+
+statement ok
+INSERT INTO a VALUES ('original'), ('untouched');
+INSERT INTO b1 VALUES ('b1-pk1', 'original'), ('b1-pk2', 'untouched');
+INSERT INTO b2 VALUES ('b2-pk1', 'original'), ('b2-pk2', 'untouched');
+INSERT INTO c1 VALUES
+  ('c1-pk1-b1-pk1', 'original')
+ ,('c1-pk2-b1-pk1', 'original')
+ ,('c1-pk3-b1-pk2', 'untouched')
+ ,('c1-pk4-b1-pk2', 'untouched')
+;
+INSERT INTO c2 VALUES
+  ('c2-pk1-b1-pk1', 'original')
+ ,('c2-pk2-b1-pk1', 'original')
+ ,('c2-pk3-b1-pk2', 'untouched')
+ ,('c2-pk4-b1-pk2', 'untouched')
+;
+INSERT INTO c3 VALUES
+  ('c3-pk1-b2-pk1', 'original')
+ ,('c3-pk2-b2-pk1', 'original')
+ ,('c3-pk3-b2-pk2', 'untouched')
+ ,('c3-pk4-b2-pk2', 'untouched')
+;
+
+# Ensure that show trace adds a cascade message for each of the tables that is
+# cascaded into.
+query I
+SELECT COUNT(*) FROM [
+  SHOW KV TRACE FOR UPDATE a SET id = 'updated' WHERE id = 'original'
+] WHERE message LIKE 'cascading %';
+----
+5
+
+query TT rowsort
+  SELECT id, update_cascade FROM b1
+UNION ALL
+  SELECT id, update_cascade FROM b2
+UNION ALL
+  SELECT id, update_set_null FROM c1
+UNION ALL
+  SELECT id, update_set_null FROM c2
+UNION ALL
+  SELECT id, update_set_null FROM c3
+;
+----
+b1-pk1         updated
+b1-pk2         untouched
+b2-pk1         updated
+b2-pk2         untouched
+c1-pk1-b1-pk1  NULL
+c1-pk2-b1-pk1  NULL
+c1-pk3-b1-pk2  untouched
+c1-pk4-b1-pk2  untouched
+c2-pk1-b1-pk1  NULL
+c2-pk2-b1-pk1  NULL
+c2-pk3-b1-pk2  untouched
+c2-pk4-b1-pk2  untouched
+c3-pk1-b2-pk1  NULL
+c3-pk2-b2-pk1  NULL
+c3-pk3-b2-pk2  untouched
+c3-pk4-b2-pk2  untouched
+
+# Clean up after the test.
+statement ok
+DROP TABLE c3, c2, c1, b2, b1, a;
+
+subtest UpdateNull_ToUpdateCascade
+# Cascade an update in table a, to set null in table b, to an on update cascade
+# of that null into table c
+# a
+# |
+# b
+# |
+# c
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b (
+  id STRING PRIMARY KEY
+ ,a_id STRING UNIQUE REFERENCES a ON UPDATE SET NULL
+);
+CREATE TABLE c (
+  id STRING PRIMARY KEY
+ ,b_a_id STRING REFERENCES b(a_id) ON UPDATE CASCADE
+);
+
+statement oK
+INSERT INTO a VALUES ('original'), ('untouched');
+INSERT INTO b VALUES ('b1', 'original'), ('b2', 'untouched');
+INSERT INTO c VALUES
+  ('c1-b1', 'original')
+ ,('c2-b1', 'original')
+ ,('c3-b2', 'untouched')
+ ,('c4-b2', 'untouched')
+;
+
+statement ok
+UPDATE a SET id = 'updated' WHERE id = 'original';
+
+query TT rowsort
+  SELECT id, a_id FROM b
+UNION ALL
+  SELECT id, b_a_id FROM c
+----
+b1     NULL
+b2     untouched
+c1-b1  NULL
+c2-b1  NULL
+c3-b2  untouched
+c4-b2  untouched
+
+# Clean up after the test.
+statement ok
+DROP TABLE c, b, a;
+
+subtest UpdateNull_ToUpdateCascadeNotNull
+# Cascade a delete in table a, to set null in table b, to an on update cascade
+# of that null into table c, but table c's column is NOT NULL
+# a
+# |
+# b
+# |
+# c
+
+statement ok
+CREATE TABLE a (
+  id STRING PRIMARY KEY
+);
+CREATE TABLE b (
+  id STRING PRIMARY KEY
+ ,a_id STRING UNIQUE REFERENCES a ON UPDATE SET NULL
+);
+CREATE TABLE c (
+  id STRING PRIMARY KEY
+ ,b_a_id STRING NOT NULL REFERENCES b(a_id) ON UPDATE CASCADE
+);
+
+statement oK
+INSERT INTO a VALUES ('original'), ('untouched');
+INSERT INTO b VALUES ('b1', 'original'), ('b2', 'untouched');
+INSERT INTO c VALUES
+  ('c1-b1', 'original')
+ ,('c2-b1', 'original')
+ ,('c3-b2', 'untouched')
+ ,('c4-b2', 'untouched')
+;
+
+statement error pq: cannot cascade a null value into "test.c.b_a_id" as it violates a NOT NULL constraint
+UPDATE a SET id = 'updated' WHERE id = 'original';
 
 # Clean up after the test.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -95,8 +95,11 @@ ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON DELETE SET N
 statement ok
 ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
 
-statement error pq: unsupported: ON UPDATE SET NULL
+statement ok
 ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON UPDATE SET NULL
+
+statement ok
+ALTER TABLE orders DROP CONSTRAINT fk_product_ref_products
 
 statement error pq: unsupported: ON DELETE SET DEFAULT
 ALTER TABLE orders ADD FOREIGN KEY (product) REFERENCES products ON DELETE SET DEFAULT
@@ -1098,7 +1101,7 @@ ALTER TABLE b ADD CONSTRAINT delete_check CHECK (update_cascade_composite1 > 0);
 statement ok
 DROP TABLE b, a;
 
-subtest DeleteNull_NotNullConstraint
+subtest SetNullWithNotNullConstraint
 ### Make sure that one cannot add a set null action on a NOT NULL column.
 
 statement ok
@@ -1113,10 +1116,21 @@ CREATE TABLE not_null_table (
  ,delete_not_nullable INT NOT NULL REFERENCES a ON DELETE SET NULL
 );
 
+statement error pq: cannot add a SET NULL cascading action on column \"update_not_nullable\" which has a NOT NULL constraint
+CREATE TABLE not_null_table (
+  id INT PRIMARY KEY
+ ,update_not_nullable INT NOT NULL REFERENCES a ON UPDATE SET NULL
+);
+
 # Create a table where the primary key has a SET NULL action.
 statement error pq: cannot add a SET NULL cascading action on column \"id\" which has a NOT NULL constraint
 CREATE TABLE primary_key_table (
   id INT PRIMARY KEY REFERENCES a ON DELETE SET NULL
+);
+
+statement error pq: cannot add a SET NULL cascading action on column \"id\" which has a NOT NULL constraint
+CREATE TABLE primary_key_table (
+  id INT PRIMARY KEY REFERENCES a ON UPDATE SET NULL
 );
 
 # Add a SET NULL action after the fact with a NOT NULL column.
@@ -1124,12 +1138,22 @@ statement ok
 CREATE TABLE not_null_table (
   id INT PRIMARY KEY
  ,delete_not_nullable INT NOT NULL
+ ,update_not_nullable INT NOT NULL
 );
 
 statement error pq: cannot add a SET NULL cascading action on column \"delete_not_nullable\" which has a NOT NULL constraint
-ALTER TABLE not_null_table ADD CONSTRAINT not_null_set_null
+ALTER TABLE not_null_table ADD CONSTRAINT not_null_delete_set_null
   FOREIGN KEY (delete_not_nullable) REFERENCES a (id)
   ON DELETE SET NULL;
+
+statement error pq: cannot add a SET NULL cascading action on column \"update_not_nullable\" which has a NOT NULL constraint
+ALTER TABLE not_null_table ADD CONSTRAINT not_null_update_set_null
+  FOREIGN KEY (update_not_nullable) REFERENCES a (id)
+  ON UPDATE SET NULL;
+
+# Clean up so far,
+statement ok
+DROP TABLE not_null_table;
 
 # Add a SET NULL action after the fact with a primary key column.
 statement ok
@@ -1142,9 +1166,14 @@ ALTER TABLE primary_key_table ADD CONSTRAINT not_null_set_null
   FOREIGN KEY (id) REFERENCES a (id)
   ON DELETE SET NULL;
 
-# Clean up the tables so far.
+statement error pq: cannot add a SET NULL cascading action on column \"id\" which has a NOT NULL constraint
+ALTER TABLE primary_key_table ADD CONSTRAINT not_null_set_null
+  FOREIGN KEY (id) REFERENCES a (id)
+  ON UPDATE SET NULL;
+
+# Clean up the tables used so far.
 statement ok
-DROP TABLE primary_key_table, not_null_table, a;
+DROP TABLE primary_key_table, a;
 
 # Now test composite foreign keys
 statement ok
@@ -1168,9 +1197,28 @@ statement error pq: cannot add a SET NULL cascading action on column \"ref1\" wh
 CREATE TABLE not_null_table (
   id INT PRIMARY KEY
  ,ref1 INT NOT NULL
+ ,ref2 INT NOT NULL
+ ,INDEX (ref1, ref2)
+ ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON UPDATE SET NULL
+);
+
+statement error pq: cannot add a SET NULL cascading action on column \"ref1\" which has a NOT NULL constraint
+CREATE TABLE not_null_table (
+  id INT PRIMARY KEY
+ ,ref1 INT NOT NULL
  ,ref2 INT
  ,INDEX (ref1, ref2)
  ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET NULL
+);
+
+
+statement error pq: cannot add a SET NULL cascading action on column \"ref1\" which has a NOT NULL constraint
+CREATE TABLE not_null_table (
+  id INT PRIMARY KEY
+ ,ref1 INT NOT NULL
+ ,ref2 INT
+ ,INDEX (ref1, ref2)
+ ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON UPDATE SET NULL
 );
 
 statement error pq: cannot add a SET NULL cascading action on column \"ref2\" which has a NOT NULL constraint
@@ -1182,6 +1230,15 @@ CREATE TABLE not_null_table (
  ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET NULL
 );
 
+statement error pq: cannot add a SET NULL cascading action on column \"ref2\" which has a NOT NULL constraint
+CREATE TABLE not_null_table (
+  id INT PRIMARY KEY
+ ,ref1 INT
+ ,ref2 INT NOT NULL
+ ,INDEX (ref1, ref2)
+ ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON UPDATE SET NULL
+);
+
 # Create a table where the primary key has a SET NULL action.
 statement error pq: cannot add a SET NULL cascading action on column \"ref1\" which has a NOT NULL constraint
 CREATE TABLE primary_key_table (
@@ -1191,12 +1248,29 @@ CREATE TABLE primary_key_table (
  ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON DELETE SET NULL
 );
 
+# Create a table where the primary key has a SET NULL action.
+statement error pq: cannot add a SET NULL cascading action on column \"ref1\" which has a NOT NULL constraint
+CREATE TABLE primary_key_table (
+  ref1 INT
+ ,ref2 INT
+ ,PRIMARY KEY (ref2, ref1)
+ ,FOREIGN KEY (ref1, ref2) REFERENCES a (id2, id1) ON UPDATE SET NULL
+);
+
 statement error pq: cannot add a SET NULL cascading action on column \"ref2\" which has a NOT NULL constraint
 CREATE TABLE primary_key_table (
   ref1 INT
  ,ref2 INT
  ,PRIMARY KEY (ref2, ref1)
  ,FOREIGN KEY (ref2, ref1) REFERENCES a (id2, id1) ON DELETE SET NULL
+);
+
+statement error pq: cannot add a SET NULL cascading action on column \"ref2\" which has a NOT NULL constraint
+CREATE TABLE primary_key_table (
+  ref1 INT
+ ,ref2 INT
+ ,PRIMARY KEY (ref2, ref1)
+ ,FOREIGN KEY (ref2, ref1) REFERENCES a (id2, id1) ON UPDATE SET NULL
 );
 
 # Clean up after the test.

--- a/pkg/sql/sqlbase/cascader.go
+++ b/pkg/sql/sqlbase/cascader.go
@@ -1018,14 +1018,14 @@ func (c *cascader) cascadeAll(
 				} else {
 					// Updating a row.
 					switch referencingIndex.ForeignKey.OnUpdate {
-					case ForeignKeyReference_CASCADE:
+					case ForeignKeyReference_CASCADE, ForeignKeyReference_SET_NULL:
 						originalAffectedRows, updatedAffectedRows, colIDtoRowIndex, startIndex, err := c.updateRows(
 							ctx,
 							&referencedIndex,
 							referencingTable.Table,
 							referencingIndex,
 							elem,
-							ForeignKeyReference_CASCADE,
+							referencingIndex.ForeignKey.OnUpdate,
 							traceKV,
 						)
 						if err != nil {


### PR DESCRIPTION
This PR is very similar to #21716 and this adds in ON UPDATE CASCADE. Almost
all of the work in this PR was adding in tests and a small adjustment to allow
the cascading action in the cascader.

Release note (sql change): ON UPDATE SET NULL foreign key constraints actions
are now fully supported

-----

The first commit can be ignored and is already awaiting review as #21716.  This should NOT be merged until after that PR has been merged.