### PR TITLE
storage: fix tombstone handling in applySnapshot

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -790,6 +790,10 @@ func (r *Replica) destroyDataRaftMuLocked(
 	})
 
 	// Save a tombstone to ensure that replica IDs never get reused.
+	//
+	// NB: Legacy tombstones (which are in the replicated key space) are wiped
+	// in clearRangeData, but that's OK since we're writing a new one in the same
+	// batch (and in particular, sequenced *after* the wipe).
 	if err := r.setTombstoneKey(ctx, batch, &consistentDesc); err != nil {
 		return err
 	}

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -762,6 +762,25 @@ func (r *Replica) applySnapshot(
 	batch := r.store.Engine().NewWriteOnlyBatch()
 	defer batch.Close()
 
+	// Before clearing out the range, grab any existing legacy Raft tombstone
+	// since we have to write it back later.
+	var existingLegacyTombstone *roachpb.RaftTombstone
+	{
+		legacyTombstoneKey := keys.RaftTombstoneIncorrectLegacyKey(r.RangeID)
+		var tomb roachpb.RaftTombstone
+		// Intentionally read from the engine to avoid the write-only batch (this is
+		// allowed since raftMu is held).
+		ok, err := engine.MVCCGetProto(
+			ctx, r.store.Engine(), legacyTombstoneKey, hlc.Timestamp{}, true /* consistent */, nil, /* txn */
+			&tomb)
+		if err != nil {
+			return err
+		}
+		if ok {
+			existingLegacyTombstone = &tomb
+		}
+	}
+
 	// Delete everything in the range and recreate it from the snapshot.
 	// We need to delete any old Raft log entries here because any log entries
 	// that predate the snapshot will be orphaned and never truncated or GC'd.
@@ -777,14 +796,33 @@ func (r *Replica) applySnapshot(
 		}
 	}
 
-	// Nodes before v2.0 may send an incorrect Raft tombstone (see #12154) that was supposed
-	// to be unreplicated. Simply remove it.
+	// Nodes before v2.0 may send an incorrect Raft tombstone (see #12154) that
+	// was supposed to be unreplicated. Simply remove it, but note how we go
+	// through some trouble to ensure that our potential own tombstone survives
+	// the snapshot application: we can't have a preemptive snapshot (which may
+	// not be followed by a corresponding replication change) wipe out our Raft
+	// tombstone.
 	//
-	// NB: this can be removed in v2.1. This is because when we are running a binary at
-	// v2.1, we know that peers are at least running v2.0, which will never send out these
-	// snapshots.
+	// NB: this can be removed in v2.1. This is because when we are running a
+	// binary at v2.1, we know that peers are at least running v2.0, which will
+	// never send out these snapshots.
 	if err := clearLegacyTombstone(batch, r.RangeID); err != nil {
 		return errors.Wrap(err, "while clearing legacy tombstone key")
+	}
+
+	// If before this snapshot there was a legacy tombstone, it was removed and
+	// we must issue a replacement. Note that we *could* check the cluster version
+	// and write a new-style tombstone here, but that is more complicated as we'd
+	// need to incorporate any existing new-style tombstone in the update. It's
+	// more straightforward to propagate the legacy tombstone; there's no
+	// requirement that snapshots participate in the migration.
+	if existingLegacyTombstone != nil {
+		err := engine.MVCCPutProto(
+			ctx, batch, nil /* ms */, keys.RaftTombstoneIncorrectLegacyKey(r.RangeID), hlc.Timestamp{}, nil /* txn */, existingLegacyTombstone,
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	// The log entries are all written to distinct keys so we can use a


### PR DESCRIPTION
`applySnapshot` had no special-casing of the unintentionally replicated
legacy Raft tombstone key. As a consequence of this, applying a snapshot
would wipe any existing tombstone. This must have been a bug for a long
time, but it became painfully obvious after #21120, which migrates the
Raft tombstone to the unreplicated keyspace, and in the process added
an explicit removal of the legacy tombstone during snapshot application
plus corresponding testing (which caught this bug).

This commit makes sure that when a snapshot is applied, any legacy
tombstone is propagated (i.e. preserved), and removes some unrelated
flakes in the failing test: the test was laying down tombstones
without synchronizing with the running nodes, prompting Raft panics
(due to rewinding the tombstone's NextReplicaID); it was also not
taking into account a situation in which a legacy tombstone could
actually be rewritten into a new-style tombstone (after replicaGC).

Fixes #21367.

Release note(bug fix): fixed a bug that could lead to a crash (which in
turn would require that the node be reinitialized).