### PR TITLE
cli: add sequences to `cockroach dump` output

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -65,7 +66,7 @@ func runDump(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	byID := make(map[int64]tableMetadata)
+	byID := make(map[int64]basicMetadata)
 	for _, md := range mds {
 		byID[md.ID] = md
 	}
@@ -109,18 +110,26 @@ func runDump(cmd *cobra.Command, args []string) error {
 	}
 	if dumpCtx.dumpMode != dumpSchemaOnly {
 		for _, md := range mds {
-			if md.isView {
+			switch md.kind {
+			case "table":
+				if err := dumpTableData(w, conn, ts, md); err != nil {
+					return err
+				}
+			case "sequence":
+				if err := dumpSequenceData(w, conn, ts, md); err != nil {
+					return err
+				}
+			case "view":
 				continue
-			}
-			if err := dumpTableData(w, conn, ts, md); err != nil {
-				return err
+			default:
+				panic("unknown descriptor type: " + md.kind)
 			}
 		}
 	}
 	return nil
 }
 
-func collect(tid int64, byID map[int64]tableMetadata, seen map[int64]bool, collected *[]int64) {
+func collect(tid int64, byID map[int64]basicMetadata, seen map[int64]bool, collected *[]int64) {
 	// has this table already been collected previously?
 	if seen[tid] {
 		return
@@ -135,15 +144,20 @@ func collect(tid int64, byID map[int64]tableMetadata, seen map[int64]bool, colle
 	*collected = append(*collected, tid)
 }
 
+type basicMetadata struct {
+	ID         int64
+	name       *tree.TableName
+	createStmt string
+	dependsOn  []int64
+	kind       string // "string", "table", or "view"
+}
+
 // tableMetadata describes one table to dump.
 type tableMetadata struct {
-	ID          int64
-	name        *tree.TableName
+	basicMetadata
+
 	columnNames string
 	columnTypes map[string]string
-	createStmt  string
-	dependsOn   []int64
-	isView      bool
 }
 
 // getDumpMetadata retrieves the table information for the specified table(s).
@@ -151,7 +165,7 @@ type tableMetadata struct {
 // retrieved.
 func getDumpMetadata(
 	conn *sqlConn, dbName string, tableNames []string, asOf string,
-) (mds []tableMetadata, clusterTS string, err error) {
+) (mds []basicMetadata, clusterTS string, err error) {
 	if asOf == "" {
 		vals, err := conn.QueryRow("SELECT cluster_logical_timestamp()", nil)
 		if err != nil {
@@ -173,13 +187,13 @@ func getDumpMetadata(
 		}
 	}
 
-	mds = make([]tableMetadata, len(tableNames))
+	mds = make([]basicMetadata, len(tableNames))
 	for i, tableName := range tableNames {
-		md, err := getMetadataForTable(conn, dbName, tableName, clusterTS)
+		basicMD, err := getBasicMetadata(conn, dbName, tableName, clusterTS)
 		if err != nil {
 			return nil, "", err
 		}
-		mds[i] = md
+		mds[i] = basicMD
 	}
 
 	return mds, clusterTS, nil
@@ -188,10 +202,10 @@ func getDumpMetadata(
 // getTableNames retrieves all tables names in the given database.
 func getTableNames(conn *sqlConn, dbName string, ts string) (tableNames []string, err error) {
 	rows, err := conn.Query(fmt.Sprintf(`
-		SELECT TABLE_NAME
-		FROM "".information_schema.tables
+		SELECT descriptor_name
+		FROM "".crdb_internal.create_statements
 		AS OF SYSTEM TIME '%s'
-		WHERE TABLE_SCHEMA = $1
+		WHERE database_name = $1
 		`, ts), []driver.Value{dbName})
 	if err != nil {
 		return nil, err
@@ -219,28 +233,81 @@ func getTableNames(conn *sqlConn, dbName string, ts string) (tableNames []string
 	return tableNames, nil
 }
 
-func getMetadataForTable(
-	conn *sqlConn, dbName, tableName string, ts string,
-) (tableMetadata, error) {
-	name := &tree.TableName{DatabaseName: tree.Name(dbName), TableName: tree.Name(tableName)}
-
-	// Fetch table ID.
-	dbNameStr := tree.NameString(dbName)
+func getBasicMetadata(conn *sqlConn, dbName, tableName string, ts string) (basicMetadata, error) {
+	// Get id, create statement, and kind.
+	dbNameEscaped := tree.NameString(dbName)
 	vals, err := conn.QueryRow(fmt.Sprintf(`
-		SELECT table_id
-		FROM %s.crdb_internal.tables
+		SELECT
+			descriptor_id,
+			create_statement,
+			descriptor_type
+		FROM %s.crdb_internal.create_statements
 		AS OF SYSTEM TIME '%s'
-		WHERE DATABASE_NAME = $1
-			AND NAME = $2
-		`, dbNameStr, ts), []driver.Value{dbName, tableName})
+		WHERE database_name = $1
+			AND descriptor_name = $2
+	`, dbNameEscaped, ts), []driver.Value{dbName, tableName})
 	if err != nil {
 		if err == io.EOF {
-			return tableMetadata{}, errors.Errorf("relation %s does not exist", name)
+			tn := tree.TableName{DatabaseName: tree.Name(dbName), TableName: tree.Name(tableName)}
+			return basicMetadata{}, errors.Wrap(
+				errors.Errorf("relation %s does not exist", tree.ErrString(&tn)),
+				"getBasicMetadata",
+			)
 		}
-		return tableMetadata{}, err
+		return basicMetadata{}, errors.Wrap(err, "getBasicMetadata")
 	}
-	tableID := vals[0].(int64)
+	idI := vals[0]
+	id, ok := idI.(int64)
+	if !ok {
+		return basicMetadata{}, fmt.Errorf("unexpected value: %T", idI)
+	}
+	createStatementI := vals[1]
+	createStatement, ok := createStatementI.(string)
+	if !ok {
+		return basicMetadata{}, fmt.Errorf("unexpected value: %T", createStatementI)
+	}
+	kindI := vals[2]
+	kind, ok := kindI.(string)
+	if !ok {
+		return basicMetadata{}, fmt.Errorf("unexpected value: %T", kindI)
+	}
 
+	// Get dependencies.
+	rows, err := conn.Query(fmt.Sprintf(`
+		SELECT dependson_id
+		FROM %s.crdb_internal.backward_dependencies
+		AS OF SYSTEM TIME '%s'
+		WHERE descriptor_id = $1
+		`, dbNameEscaped, ts), []driver.Value{id})
+	if err != nil {
+		return basicMetadata{}, err
+	}
+	vals = make([]driver.Value, 1)
+
+	var refs []int64
+	for {
+		if err := rows.Next(vals); err == io.EOF {
+			break
+		} else if err != nil {
+			return basicMetadata{}, err
+		}
+		id := vals[0].(int64)
+		refs = append(refs, id)
+	}
+	if err := rows.Close(); err != nil {
+		return basicMetadata{}, err
+	}
+
+	return basicMetadata{
+		ID:         id,
+		name:       &tree.TableName{DatabaseName: tree.Name(dbName), TableName: tree.Name(tableName)},
+		createStmt: createStatement,
+		dependsOn:  refs,
+		kind:       kind,
+	}, nil
+}
+
+func getMetadataForTable(conn *sqlConn, md basicMetadata, ts string) (tableMetadata, error) {
 	// Fetch column types.
 	rows, err := conn.Query(fmt.Sprintf(`
 		SELECT COLUMN_NAME, DATA_TYPE
@@ -248,11 +315,11 @@ func getMetadataForTable(
 		AS OF SYSTEM TIME '%s'
 		WHERE TABLE_SCHEMA = $1
 			AND TABLE_NAME = $2
-		`, ts), []driver.Value{dbName, tableName})
+		`, ts), []driver.Value{md.name.Database(), md.name.Table()})
 	if err != nil {
 		return tableMetadata{}, err
 	}
-	vals = make([]driver.Value, 2)
+	vals := make([]driver.Value, 2)
 	coltypes := make(map[string]string)
 	colnames := tree.NewFmtCtxWithBuf(tree.FmtSimple)
 	defer colnames.Close()
@@ -281,57 +348,16 @@ func getMetadataForTable(
 		return tableMetadata{}, err
 	}
 
-	vals, err = conn.QueryRow(fmt.Sprintf(`
-		SELECT create_statement, descriptor_type = 'view'
-		FROM %s.crdb_internal.create_statements
-		AS OF SYSTEM TIME '%s'
-		WHERE descriptor_name = $1
-			AND database_name = $2
-		`, dbNameStr, ts), []driver.Value{tableName, dbName})
-	if err != nil {
-		return tableMetadata{}, err
-	}
-	create := vals[0].(string)
-	descType := vals[1].(bool)
-
-	rows, err = conn.Query(fmt.Sprintf(`
-		SELECT dependson_id
-		FROM %s.crdb_internal.backward_dependencies
-		AS OF SYSTEM TIME '%s'
-		WHERE descriptor_id = $1
-		`, dbNameStr, ts), []driver.Value{tableID})
-	if err != nil {
-		return tableMetadata{}, err
-	}
-	vals = make([]driver.Value, 1)
-
-	var refs []int64
-	for {
-		if err := rows.Next(vals); err == io.EOF {
-			break
-		} else if err != nil {
-			return tableMetadata{}, err
-		}
-		id := vals[0].(int64)
-		refs = append(refs, id)
-	}
-	if err := rows.Close(); err != nil {
-		return tableMetadata{}, err
-	}
-
 	return tableMetadata{
-		ID:          tableID,
-		name:        name,
+		basicMetadata: md,
+
 		columnNames: colnames.String(),
 		columnTypes: coltypes,
-		createStmt:  create,
-		dependsOn:   refs,
-		isView:      descType,
 	}, nil
 }
 
 // dumpCreateTable dumps the CREATE statement of the specified table to w.
-func dumpCreateTable(w io.Writer, md tableMetadata) error {
+func dumpCreateTable(w io.Writer, md basicMetadata) error {
 	if _, err := w.Write([]byte(md.createStmt)); err != nil {
 		return err
 	}
@@ -346,8 +372,32 @@ const (
 	insertRows = 100
 )
 
+func dumpSequenceData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetadata) error {
+	vals, err := conn.QueryRow(fmt.Sprintf(
+		"SELECT last_value FROM %s AS OF SYSTEM TIME %s",
+		bmd.name, clusterTS,
+	), nil)
+	if err != nil {
+		return err
+	}
+
+	seqVal := vals[0].(int64)
+
+	fmt.Fprintln(w)
+	fmt.Fprintf(
+		w, "SELECT setval(%s, %d);\n", lex.EscapeSQLString(tree.NameString(bmd.name.Table())), seqVal,
+	)
+
+	return nil
+}
+
 // dumpTableData dumps the data of the specified table to w.
-func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, md tableMetadata) error {
+func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetadata) error {
+	md, err := getMetadataForTable(conn, bmd, clusterTS)
+	if err != nil {
+		return err
+	}
+
 	bs := fmt.Sprintf("SELECT * FROM %s AS OF SYSTEM TIME '%s' ORDER BY PRIMARY KEY %[1]s",
 		md.name,
 		clusterTS,
@@ -510,8 +560,8 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, md tableMetadat
 	return g.Wait()
 }
 
-func writeInserts(w io.Writer, md tableMetadata, inserts []string) {
-	fmt.Fprintf(w, "\nINSERT INTO %s (%s) VALUES", &md.name.TableName, md.columnNames)
+func writeInserts(w io.Writer, tmd tableMetadata, inserts []string) {
+	fmt.Fprintf(w, "\nINSERT INTO %s (%s) VALUES", &tmd.name.TableName, tmd.columnNames)
 	for idx, values := range inserts {
 		if idx > 0 {
 			fmt.Fprint(w, ",")

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -681,6 +681,11 @@ INSERT INTO f VALUES (1, 1);
 INSERT INTO e VALUES (1);
 INSERT INTO d VALUES (1, 1, 1);
 INSERT INTO c VALUES (1);
+
+-- Test a table that uses a sequence to make sure the sequence is dumped first.
+CREATE SEQUENCE s;
+CREATE TABLE s_tbl (id INT PRIMARY KEY DEFAULT nextval('s'), v INT);
+INSERT INTO s_tbl (v) VALUES (10), (11);
 `
 	if out, err := c.RunWithCaptureArgs([]string{"sql", "-e", create}); err != nil {
 		t.Fatal(err)
@@ -747,6 +752,15 @@ CREATE TABLE c (
 	FAMILY "primary" (i, rowid)
 );
 
+CREATE SEQUENCE s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+
+CREATE TABLE s_tbl (
+	id INT NOT NULL DEFAULT nextval('s':::STRING),
+	v INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	FAMILY "primary" (id, v)
+);
+
 INSERT INTO b (i) VALUES
 	(1);
 
@@ -767,6 +781,12 @@ INSERT INTO d (i, e, f) VALUES
 
 INSERT INTO c (i) VALUES
 	(1);
+
+SELECT setval('s', 2);
+
+INSERT INTO s_tbl (id, v) VALUES
+	(1, 10),
+	(2, 11);
 `
 
 	if out != expectDump {
@@ -873,6 +893,74 @@ func TestDumpView(t *testing.T) {
 
 	const expect = `dump d
 CREATE VIEW bar ("1") AS SELECT 1;
+`
+
+	if out != expect {
+		t.Fatalf("expected: %s\ngot: %s", expect, out)
+	}
+}
+
+func TestDumpSequence(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest(cliTestParams{t: t})
+	defer c.cleanup()
+
+	const create = `
+	CREATE DATABASE d;
+	CREATE SEQUENCE d.bar;
+`
+	if out, err := c.RunWithCaptureArgs([]string{"sql", "-e", create}); err != nil {
+		t.Fatal(err)
+	} else {
+		t.Log(out)
+	}
+
+	out, err := c.RunWithCaptureArgs([]string{"dump", "d"})
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		t.Log(out)
+	}
+
+	const expect = `dump d
+CREATE SEQUENCE bar MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+
+SELECT setval('bar', 0);
+`
+
+	if out != expect {
+		t.Fatalf("expected: %s\ngot: %s", expect, out)
+	}
+}
+
+func TestDumpSequenceEscaping(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest(cliTestParams{t: t})
+	defer c.cleanup()
+
+	const create = `
+	CREATE DATABASE "'";
+	CREATE SEQUENCE "'"."'";
+`
+	if out, err := c.RunWithCaptureArgs([]string{"sql", "-e", create}); err != nil {
+		t.Fatal(err)
+	} else {
+		t.Log(out)
+	}
+
+	out, err := c.RunWithCaptureArgs([]string{"dump", "'"})
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		t.Log(out)
+	}
+
+	const expect = `dump '
+CREATE SEQUENCE "'" MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+
+SELECT setval(e'"\'"', 0);
 `
 
 	if out != expect {


### PR DESCRIPTION
- Output `CREATE SEQUENCE` statements (before tables that use them)
- Output calls to `setval` (in schema+data mode)

Fixes #21574

Release note (sql change): Add sequences to `cockroach dump` output