### PR TITLE
RFCS: update readme

### DIFF
--- a/docs/RFCS/PROTOTYPING.md
+++ b/docs/RFCS/PROTOTYPING.md
@@ -1,0 +1,70 @@
+# Prototyping and RFCs
+
+There is a puzzle at the heart of writing an RFC: if you understand a
+project well enough to write an RFC, then an RFC may not be
+necessary. Certainly you may write an RFC to communicate your
+knowledge to others, but how does an RFC get written by an individual
+who doesn't understand the problem fully?
+
+The idealistic view of writing an RFC involves an engineer starting
+with a blank document and filling in the pieces from start to
+finish. For anyone who has written an RFC, this fairy tale depiction
+is clearly not accurate. The writing is iterative. You might first
+write down a few bullet points and then start thinking about the
+details of one area, fleshing out the document incrementally and in an
+unordered fashion. There are very likely many (many) iterations of the
+document before anyone else takes a look at it.
+
+The iterative writing of an RFC described above is often insufficient
+because simply thinking deeply about a problem is frequently not the
+most efficient path to fully understanding the problem. At the very
+least you will be consulting the existing code base to understand how
+the proposed change fits. And you might discuss the problem in front
+of a whiteboard with a colleague. It is very likely you should be
+prototyping.
+
+Prototyping involves exploring a problem space in order to better
+understand it. The primary value of a prototype is in the learning it
+provides, not the code. As such, the emphasis during prototyping
+should be on speed of learning. The prototype code does not need to
+meet any particular quality metric. Error handling? Ignore it while
+you're trying to learn. Comments? Only if you, the prototype author,
+need them. The real focus of the prototype is exploring the unseen
+corners of the problem space in order to reveal where the dragons are
+lurking. The goal is to de-risk the problem space by thoroughly
+understanding the hardest problems.
+
+The acts of prototyping and writing an RFC should be iterative. Many
+engineers want to write down their thoughts before coding and it is
+common to want to discuss an approach before embarking on it. Both
+approaches are useful, yet neither should be confused for an RFC. It
+is useful to write down a few bullet points for areas to be covered in
+a prototype. Then work on the code. Then add more bullet points. At
+some point, the prototype will be fleshed out enough that you feel
+ready to write the RFC. Alternately, it is very common for the
+prototype to run into a significant stumbling block that you can't
+overcome yourself. The benefit of the prototype truly shines when this
+happens and you'll have a deep understanding of the problem which you
+can use to have a focused discussion with other engineers. Share your
+failed prototypes. The failure implies learning and that learning
+deserves to be shared, both in words and in code. Your failed
+prototype might be close to success with the aid of another engineer's
+experience. At the very least, a failed prototype indicates to other
+engineers that an idea has been explored.
+
+An RFC is a high-level description which does not require formal
+correctness. There is utility in conciseness. Do not overspecify the
+details in the RFC as doing so can bury the reader in minutiae. The
+prototype can be of assistance here as it can help highlight the
+tricky areas that deserve mention in a high-level description. If the
+details are relevant, the RFC can include a link to the prototype
+(which may necessitate cleaning up some of the prototype code at the
+reviewer's request). Note that one of the significant benefits of an
+RFC is that it forces bigger picture thinking which readers can then
+disect. In this respect an RFC is complimentary to a prototype which
+forces details to be considered.
+
+Writing an RFC is not a necessary outcome for a successful
+prototype. If the prototype is simple enough, it can be translated
+directly into a PR or series of PRs along with explanatory comments
+and commit messages.

--- a/docs/RFCS/README.md
+++ b/docs/RFCS/README.md
@@ -1,209 +1,103 @@
-# About this directory
+# About This Directory
 
-This directory contains RFCs (design documents) that describe
-proposed major changes to cockroach.
+This directory contains RFCs (design documents) that describe proposed
+major changes to CockroachDB.
 
-# Why and when to send a RFC?
+# The Why of RFCs
 
-Before making major changes, consider sending an RFC for discussion.
-This is a lightweight design-document process that is inspired by the
-[process used by the rust project](https://github.com/rust-lang/rfcs).
+An RFC provides a high-level description of a major change or
+enhancement to Cockroach. The high-level description allows a reviewer
+to critique and poke holes in a design without getting lost in the
+particulars of code.
 
-What is a major change?
+An RFC is a form of communication aimed at both spreading and
+gathering knowledge, though it is not the sole means of accomplishing
+either task. Prototypes, tech notes, github issues, comments in code,
+commit messages and in-person discussions are valid alternatives
+depending on the situation.
 
-A change is "major" and requires a RFC when any of the following
-conditions apply:
+At its best, an RFC clearly and concisely describes the high-level
+architecture of a project giving confidence to all involved. At its
+worst, an RFC focuses on unimportant details, fosters discussion that
+stymies progress, or demoralizes the author with the complexity of
+their undertaking.
 
-- completing the change will cost you more than two weeks of work.
-- reviewers from more than one team are needed to review the change.
-- users will need to change the way they use CockroachDB as a result.
-- other CockroachDB contributors will need to change the way
-  they work as a result.
-- the architecture of the software or the project changes in a way visible
-  to more than a handful of developers.
-- the change impacts the cost model of CockroachDB (how much time and
-  how much memory is used for common operations) in a way that's
-  noticeable by users.
+# The When and How of RFCs
 
-# RFC process
+When to write an RFC is nuanced and there are no firm rules. General
+guidance is to write an RFC before embarking on a significant or
+complex project that will be spread over multiple pull requests (PRs),
+and when multiple alternatives need to be considered and there is no
+obvious best approach. A project involving multiple people is a good
+signal an RFC is warranted. (Similarly, a project worthy of an RFC
+often requires multiple engineers worth of effort). Note that this
+guidance is intentionally vague. Many complex projects spread over
+multiple PRs do not require an RFC, though they do require adequate
+communication and discussion.<sup>[1](#sql-syntax)</sup>
 
-1. Before embarking on the RFC ensure that there is a relevant issue
-   where the major change has been discussed, and you have identified the
-   reviewers for your project. If the scope of the RFC is
-   [large](https://www.cockroachlabs.com/docs/stable/contribute-to-cockroachdb.html),
-   there should be at least two designated reviewers from the RFC's
-   expertise area. Assign the issue to yourself and notify the reviewers
-   that you are writing an RFC.
+It is encouraged to develop a [prototype](PROTOTYPING.md) concurrently
+with writing the RFC. One of the significant benefits of an RFC is
+that it forces bigger picture thinking which reviewers can then
+disect. In contrast, a prototype forces the details to be considered,
+shedding light on the unknown unknowns and helping to ensure that the
+RFC focuses on the important design considerations.
 
-2. If you have been working on CockroachDB for less than 6 months, you
-   will need an experienced co-author on the RFC who will act as the
-   shepherd. The shepherd is someone to bounce ideas off.
-   When the RFC is in review you can expect a number of questions to
-   be asked, the shepherd will help you channel the different concerns
-   to experts and move the discussion along. You, as an inexperienced
-   developer on CockroachDB, should not feel alone in addressing all
-   the concerns brought up.
+An RFC should be a high-level description which does not require
+formal correctness. There is utility in conciseness. Do not
+overspecify the details in the RFC as doing so can bury the reviewer
+in minutiae.<sup>[1](#sql-syntax)</sup> If you've never written an RFC
+before consider partnering with a more experienced engineer for
+guidance and to help shepherd your RFC through the process.
 
-3. Copy `00000000_template.md` to a new file and fill in the details. Commit
-   this version in your own fork of the repository or a branch.
+# RFC Process
 
-4. Submit a pull request (PR) to add your new file to the main repository.
-   Each RFC should get its own pull request; do not combine RFCs with
-   other files.
+1. Every RFC should have a dedicated reviewer familiar with the RFC's
+   subject area.
 
-   Ideally, an RFC sent out for review for the first time will ask a
-   number of questions, soliciting answers/advice from experts.
+2. Copy `00000000_template.md` to a new file and fill in the
+   details. Commit this version in your own fork of the repository or
+   a branch.
 
-   Note: you can submit a PR before the RFC is complete, to solicit
-   input about what to write in the RFC. In this case, include the word
-   "WIP" in the PR title and use the label do-not-merge, until
-   you are confident the RFC is complete and can be reviewed.
+3. Submit a pull request (PR) to add your new file to the main
+   repository. Each RFC should get its own pull request; do not
+   combine RFCs with other files.
 
-   **Before you consider the RFC ready to be reviewed, give extra
-   attention to the section "Rationale and Alternatives". It's
-   important for the reviewers to understand why the solution chosen
-   was right. It is an unfortunate fact that often a solution is
-   determined first and the RFC is then written to support that
-   solution, without much consideration being given to the
-   alternatives. You should be mindful of this when it happens and
-   attempt to compensate by a serious review of alternatives.**
+   Note: you can send a PR before the RFC is complete in order to
+   solicit input about what to write in the RFC. In this case, include
+   the term "[WIP]" (work in progress) in the PR title and use the
+   label `do-not-merge`, until you are confident the RFC is complete
+   and can be reviewed.
 
-5. Go through the PR review, iterating on the RFC to answer questions
-   and concerns from the reviewer(s). This process can last several
-   weeks, depending on the complexity of the proposal. The PR must
-   remain open for at least one week, to allow collaborators sufficient
-   time to review the RFC.
+4. Go through the PR review, iterating on the RFC to answer questions
+   and concerns from the reviewer(s). The duration of this process
+   should be related to the complexity of the project. If you or the
+   reviewers seem to be at an impasse, consider in-person discussions
+   or a prototype. There is no minimum time required to leave an RFC
+   open for review. There is also no prohibition about halting or
+   reversing work on an accepted RFC if a problem is discovered during
+   implementation.
 
-   If it becomes apparent that the proposal is acceptable during
-   review within a few days, you need not go through the RFC process.
-   Update the relevant issue with the proposal, and get the reviewer
-   to sign off on the proposal in the issue. Both the reviewer
-   and you should feel confident that the implementation is going to take
-   less than two weeks, or else defer back to the RFC process. Start
-   implementing and accept that someone might disagree later on during the
-   review of the implementation. Disagreement on such a code review can
-   often get channelled back into an RFC; that is perfectly fine!
+   Reviewers should be conscious of their own limitations and ask for
+   other engineers to look at specific areas if necessary.
 
-6. At some point, the author(s) and/or shepherd will seek to
-   decide that the "dust has settled".
-
-   The author(s) and/or shepherd can move this process along
-   by pushing to conclude open discussions one way or another. This
-   includes, but is not limited to:
-
-   - answering unanswered questions themselves,
-   - seeking participation from other engineers to answer open questions,
-   - reducing the scope of the RFC so that open questions become out of scope,
-   - postponing a decision or answer to a later implementation phase,
-   - organize a meeting where open concerns are discussed orally,
-   - postponing/cancelling the work altogether.
-
-   In either case, the process to push for conclusion should seek
-   approval to conclude from the reviewer(s) who have opened the
-   discussions so far, allowing sufficient time for them to evaluate
-   the proposed conclusion.
-
-   Often disagreement on an RFC can be resolved by holding a meeting
-   between the interested parties to achieve consensus. The meeting notes
-   or a summary should be added to the RFC comments.
-
-7. At the point where the author(s) and/or shepherd
-   estimate there is consensus to proceed with the project, begin the
-   final comment period (FCP) by posting a comment on the PR.
-   For RFCs with lengthy discussion, the motion to FCP is usually preceded
-   by a summary comment laying out the current state of the
-   discussion and major tradeoffs/points of disagreement. The FCP
-   should last a minimum of two working days to allow collaborators
-   to voice any last-minute concerns.
-
-   In most cases, the FCP period is quiet, and the RFC is merged.
-   However, sometimes substantial new arguments or ideas are raised,
-   the FCP is canceled, and the RFC goes back into development mode.
-
-8. If there is still consensus to proceed after the FCP:
+5. Once discussion has settled and the RFC has received an LGTM from
+   the reviewer(s):
 
    - change the `Status` field of the document to `in-progress`;
    - rename the RFC document to prefix it with the current date (`YYYYMMDD_`);
    - update the `RFC PR` field;
    - and merge the PR.
 
-   If the project is rejected, either abandon the PR or merge it
-   with a status of `rejected` (depending on whether the document and
-   discussion are worth preserving for posterity). The project may
-   receive a status of `postponed` rather than `rejected` if
-   it is likely to be implemented in the future.
+6. Once the changes in the RFC have been implemented and merged,
+   change the `Status` field of the document from `in-progress` to
+   `completed`. If subsequent developments render an RFC obsolete,
+   change its status to `obsolete`. When you mark a RFC as obsolete,
+   ensure that its text references the other RFCs or PRs that make it
+   obsolete.
 
-   Note that it is possible for an RFC to receive discussion after it
-   has been approved and its PR merged, e.g. during implementation.
-   While this is undesirable and should generally be avoided, such
-   discussion should still be addressed by the initiator (or
-   implementer) of the RFC. For instance, this can happen when an
-   expert is not available during the initial review (e.g. because she
-   is on vacation).
+# Footnotes
 
-9. Once the changes described in the RFC have been made, change the
-   status of the PR from `in-progress` to `completed`. If subsequent
-   developments render an RFC obsolete, set its status to `obsolete`.
-
-   When you mark a RFC as obsolete, ensure that its text references the
-   other RFCs or PRs that make it obsolete.
-
-# Overhead of the RFC process
-
-There is a trade-off between the impetus to make
-more time for decision-making and consensus-reaching, mandating
-minimum wait times to let every participant evaluate the work, and
-the impetus to move fast and often discover/fix problems later.
-
-At the time of this writing (2017), this RFC process is biased towards
-moving faster, correspondingly spelling out a minumum delay of only
-one week in the RFC process with a 1-2 working day FCP.
-
-# RFC Status
-
-During its lifetime an RFC can have the following status:
-
-- Draft
-
-  A newly minted RFC has this status, until either the proposal is
-  accepted (next possible status: in-progress), deferred (next possible
-  status: postponed) or that it is DOA (next possible status: rejected).
-
-- Rejected
-
-  A RFC receives this status when the PR discussions have concluded
-  the proposal should not be implemented.
-
-  Next possible status: none. If you want to ressucitate an idea, make
-  a new RFC.
-
-- In-progress
-
-  A RFC receives this status when the PR discussions have concluded
-  the proposal should be implemented, and the RFC is ready to commit
-  (merge) to the main repository.
-
-  Next possible status: completed (when the work is done), rejected
-  (proposal not implemented/implementable after all), obsolete (some
-  subsequent work removes the need for the feature).
-
-- Completed
-
-  A RFC receives this status when the described feature has been
-  implemented. It may stay with this status indefinitely or until made
-  obsolete.
-
-- Obsolete
-
-  A RFC receives this status when the described feature has been
-  superseded.
-
-- Postponed
-
-  A RFC receives this status when the PR discussions have concluded that
-  due to implementation complexity, lack of customer demand, or other
-  issues with the proposal, the work should be postponed to a later date.
-
-  Next possible status: draft (the decision has been made to reconsider
-  this proposal), rejected (proposal not implemented/implementable after all),
-  obsolete (some subsequent work removes the need for the feature).
+<a name="sql-syntax">1<a>: An exception to the general guidance on
+when an RFC is warranted is that anything more than trivial changes
+and extensions to SQL syntax require discussion within an
+RFC. Additionally, SQL syntax is a detail that an RFC should mention.


### PR DESCRIPTION
Add initial sections that go into more detail of the when and how of
RFCs and mention the benefits of prototyping. Add a separate
PROTOTYPING.md doc that goes into more details.

Trim the "RFC Process" section, replacing the FCP with the judgment of
the author and reviewers. Trim the "RFC Status" section as that level of
formalism seems like overkill. The template lists the states and
mistakes here aren't really a problem.

Release note: none