### PR TITLE
libroach: fix the windows build

### DIFF
--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(roach
   env_switching.cc
   eventlistener.cc
   getter.cc
+  godefs.cc
   ldb.cc
   merge.cc
   mvcc.cc

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -26,6 +26,7 @@
 #include "env_switching.h"
 #include "fmt.h"
 #include "getter.h"
+#include "godefs.h"
 #include "iterator.h"
 #include "merge.h"
 #include "options.h"
@@ -33,22 +34,6 @@
 #include "status.h"
 
 using namespace cockroach;
-
-extern "C" {
-static void __attribute__((noreturn)) die_missing_symbol(const char* name) {
-  fprintf(stderr, "%s symbol missing; expected to be supplied by Go\n", name);
-  abort();
-}
-
-// These are Go functions exported by storage/engine. We provide these stubs,
-// which simply panic if called, to to allow intermediate build products to link
-// successfully. Otherwise, when building ccl/storageccl/engineccl, Go will
-// complain that these symbols are undefined. Because these stubs are marked
-// "weak", they will be replaced by their proper implementation in
-// storage/engine when the final cockroach binary is linked.
-void __attribute__((weak)) rocksDBLog(char*, int) { die_missing_symbol(__func__); }
-char* __attribute__((weak)) prettyPrintKey(DBKey) { die_missing_symbol(__func__); }
-}  // extern "C"
 
 namespace cockroach {
 

--- a/c-deps/libroach/godefs.cc
+++ b/c-deps/libroach/godefs.cc
@@ -1,0 +1,33 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include "godefs.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+extern "C" {
+static void __attribute__((noreturn)) die_missing_symbol(const char* name) {
+  fprintf(stderr, "%s symbol missing; expected to be supplied by Go\n", name);
+  abort();
+}
+
+// These are Go functions exported by storage/engine. We provide these stubs,
+// which simply panic if called, to to allow intermediate build products to link
+// successfully. Otherwise, when building ccl/storageccl/engineccl, Go will
+// complain that these symbols are undefined. Because these stubs are marked
+// "weak", they will be replaced by their proper implementation in
+// storage/engine when the final cockroach binary is linked.
+void __attribute__((weak)) rocksDBLog(char*, int) { die_missing_symbol(__func__); }
+char* __attribute__((weak)) prettyPrintKey(DBKey) { die_missing_symbol(__func__); }
+}  // extern "C"

--- a/c-deps/libroach/godefs.h
+++ b/c-deps/libroach/godefs.h
@@ -1,0 +1,22 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+#pragma once
+
+#include <libroach.h>
+
+extern "C" {
+void __attribute__((weak)) rocksDBLog(char*, int);
+char* __attribute__((weak)) prettyPrintKey(DBKey);
+}  // extern "C"

--- a/c-deps/libroach/options.cc
+++ b/c-deps/libroach/options.cc
@@ -19,11 +19,8 @@
 #include "cache.h"
 #include "comparator.h"
 #include "encoding.h"
+#include "godefs.h"
 #include "merge.h"
-
-extern "C" {
-void rocksDBLog(char*, int);
-}  // extern "C"
 
 namespace cockroach {
 


### PR DESCRIPTION
The second declaration of `rocksDBLog` was not marked `weak` which broke
the build with the Windows linker. Move the weak go symbols into
`godefs.{cc,h}`.

Release note (bug fix): Fix Windows release builds.