### PR TITLE
 sql: plumb context through authorization methods 

### DIFF
--- a/pkg/ccl/sqlccl/backup.go
+++ b/pkg/ccl/sqlccl/backup.go
@@ -610,7 +610,7 @@ func verifyUsableExportTarget(
 }
 
 func backupPlanHook(
-	stmt tree.Statement, p sql.PlanHookState,
+	_ context.Context, stmt tree.Statement, p sql.PlanHookState,
 ) (func(context.Context, chan<- tree.Datums) error, sqlbase.ResultColumns, error) {
 	backupStmt, ok := stmt.(*tree.Backup)
 	if !ok {
@@ -651,7 +651,7 @@ func backupPlanHook(
 			return err
 		}
 
-		if err := p.RequireSuperUser("BACKUP"); err != nil {
+		if err := p.RequireSuperUser(ctx, "BACKUP"); err != nil {
 			return err
 		}
 
@@ -713,12 +713,12 @@ func backupPlanHook(
 		var tables []*sqlbase.TableDescriptor
 		for _, desc := range targetDescs {
 			if dbDesc := desc.GetDatabase(); dbDesc != nil {
-				if err := p.CheckPrivilege(dbDesc, privilege.SELECT); err != nil {
+				if err := p.CheckPrivilege(ctx, dbDesc, privilege.SELECT); err != nil {
 					return err
 				}
 			}
 			if tableDesc := desc.GetTable(); tableDesc != nil {
-				if err := p.CheckPrivilege(tableDesc, privilege.SELECT); err != nil {
+				if err := p.CheckPrivilege(ctx, tableDesc, privilege.SELECT); err != nil {
 					return err
 				}
 				tables = append(tables, tableDesc)
@@ -950,7 +950,7 @@ func backupResumeHook(typ jobs.Type, settings *cluster.Settings) jobs.Resumer {
 }
 
 func showBackupPlanHook(
-	stmt tree.Statement, p sql.PlanHookState,
+	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
 ) (func(context.Context, chan<- tree.Datums) error, sqlbase.ResultColumns, error) {
 	backup, ok := stmt.(*tree.ShowBackup)
 	if !ok {
@@ -963,7 +963,7 @@ func showBackupPlanHook(
 		return nil, nil, err
 	}
 
-	if err := p.RequireSuperUser("SHOW BACKUP"); err != nil {
+	if err := p.RequireSuperUser(ctx, "SHOW BACKUP"); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -862,7 +862,7 @@ var importCSVEnabled = settings.RegisterBoolSetting(
 )
 
 func importPlanHook(
-	stmt tree.Statement, p sql.PlanHookState,
+	_ context.Context, stmt tree.Statement, p sql.PlanHookState,
 ) (func(context.Context, chan<- tree.Datums) error, sqlbase.ResultColumns, error) {
 	importStmt, ok := stmt.(*tree.Import)
 	if !ok {
@@ -910,7 +910,7 @@ func importPlanHook(
 			)
 		}
 
-		if err := p.RequireSuperUser("IMPORT"); err != nil {
+		if err := p.RequireSuperUser(ctx, "IMPORT"); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/sqlccl/restore.go
+++ b/pkg/ccl/sqlccl/restore.go
@@ -234,7 +234,7 @@ func allocateTableRewrites(
 						return errors.Wrapf(err, "failed to lookup parent DB %d", parentID)
 					}
 
-					if err := p.CheckPrivilege(parentDB, privilege.CREATE); err != nil {
+					if err := p.CheckPrivilege(ctx, parentDB, privilege.CREATE); err != nil {
 						return err
 					}
 				}
@@ -756,7 +756,7 @@ func restoreTableDescs(
 					return errors.Wrapf(err, "failed to lookup parent DB %d", table.ParentID)
 				}
 				// TODO(mberhault): CheckPrivilege wants a planner.
-				if err := sql.CheckPrivilegeForUser(user, parentDB, privilege.CREATE); err != nil {
+				if err := sql.CheckPrivilegeForUser(ctx, user, parentDB, privilege.CREATE); err != nil {
 					return err
 				}
 				// Default is to copy privs from restoring parent db, like CREATE TABLE.
@@ -1025,7 +1025,7 @@ var restoreHeader = sqlbase.ResultColumns{
 }
 
 func restorePlanHook(
-	stmt tree.Statement, p sql.PlanHookState,
+	_ context.Context, stmt tree.Statement, p sql.PlanHookState,
 ) (func(context.Context, chan<- tree.Datums) error, sqlbase.ResultColumns, error) {
 	restoreStmt, ok := stmt.(*tree.Restore)
 	if !ok {
@@ -1053,7 +1053,7 @@ func restorePlanHook(
 			return err
 		}
 
-		if err := p.RequireSuperUser("RESTORE"); err != nil {
+		if err := p.RequireSuperUser(ctx, "RESTORE"); err != nil {
 			return err
 		}
 

--- a/pkg/ccl/sqlccl/role.go
+++ b/pkg/ccl/sqlccl/role.go
@@ -71,7 +71,7 @@ func grantRolePlanHook(
 		return nil, err
 	}
 
-	if err := p.RequireSuperUser("grant role"); err != nil {
+	if err := p.RequireSuperUser(ctx, "grant role"); err != nil {
 		// Not a superuser: check permissions on each role.
 		allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
 		if err != nil {
@@ -190,7 +190,7 @@ func revokeRolePlanHook(
 		return nil, err
 	}
 
-	if err := p.RequireSuperUser("revoke role"); err != nil {
+	if err := p.RequireSuperUser(ctx, "revoke role"); err != nil {
 		// Not a superuser: check permissions on each role.
 		allRoles, err := p.MemberOfWithAdminOption(ctx, p.User())
 		if err != nil {

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -45,7 +45,7 @@ func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (pla
 		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}
 
-	if err := p.CheckPrivilege(seqDesc, privilege.CREATE); err != nil {
+	if err := p.CheckPrivilege(ctx, seqDesc, privilege.CREATE); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -55,7 +55,7 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}
 
-	if err := p.CheckPrivilege(tableDesc, privilege.CREATE); err != nil {
+	if err := p.CheckPrivilege(ctx, tableDesc, privilege.CREATE); err != nil {
 		return nil, err
 	}
 	return &alterTableNode{n: n, tableDesc: tableDesc}, nil

--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -41,7 +41,7 @@ func (p *planner) AlterUserSetPassword(
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(tDesc, privilege.UPDATE); err != nil {
+	if err := p.CheckPrivilege(ctx, tDesc, privilege.UPDATE); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -125,8 +125,8 @@ CREATE TABLE crdb_internal.node_runtime_info (
   value     STRING NOT NULL
 );
 `,
-	populate: func(_ context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser("access the node runtime information"); err != nil {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
+		if err := p.RequireSuperUser(ctx, "access the node runtime information"); err != nil {
 			return err
 		}
 
@@ -209,7 +209,7 @@ CREATE TABLE crdb_internal.tables (
 		// include added and dropped descriptors.
 		for _, desc := range descs {
 			table, ok := desc.(*sqlbase.TableDescriptor)
-			if !ok || p.CheckAnyPrivilege(table) != nil {
+			if !ok || p.CheckAnyPrivilege(ctx, table) != nil {
 				continue
 			}
 			dbName := dbNames[table.GetParentID()]
@@ -277,7 +277,7 @@ CREATE TABLE crdb_internal.schema_changes (
 		// include added and dropped descriptors.
 		for _, desc := range descs {
 			table, ok := desc.(*sqlbase.TableDescriptor)
-			if !ok || p.CheckAnyPrivilege(table) != nil {
+			if !ok || p.CheckAnyPrivilege(ctx, table) != nil {
 				continue
 			}
 			tableID := tree.NewDInt(tree.DInt(int64(table.ID)))
@@ -326,7 +326,7 @@ CREATE TABLE crdb_internal.leases (
   deleted     BOOL NOT NULL
 );
 `,
-	populate: func(_ context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
 		leaseMgr := p.LeaseMgr()
 		nodeID := tree.NewDInt(tree.DInt(int64(leaseMgr.execCfg.NodeID.Get())))
 
@@ -343,7 +343,7 @@ CREATE TABLE crdb_internal.leases (
 				dropped := tree.MakeDBool(tree.DBool(ts.mu.dropped))
 
 				for _, state := range ts.mu.active.data {
-					if p.CheckAnyPrivilege(&state.TableDescriptor) != nil {
+					if p.CheckAnyPrivilege(ctx, &state.TableDescriptor) != nil {
 						continue
 					}
 
@@ -485,8 +485,8 @@ CREATE TABLE crdb_internal.node_statement_statistics (
   overhead_lat_var    FLOAT NOT NULL
 );
 `,
-	populate: func(_ context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser("access application statistics"); err != nil {
+	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
+		if err := p.RequireSuperUser(ctx, "access application statistics"); err != nil {
 			return err
 		}
 
@@ -618,7 +618,7 @@ CREATE TABLE crdb_internal.cluster_settings (
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ string, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser("read crdb_internal.cluster_settings"); err != nil {
+		if err := p.RequireSuperUser(ctx, "read crdb_internal.cluster_settings"); err != nil {
 			return err
 		}
 		for _, k := range settings.Keys() {
@@ -1398,7 +1398,7 @@ CREATE TABLE crdb_internal.ranges (
 )
 `,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser("read crdb_internal.ranges"); err != nil {
+		if err := p.RequireSuperUser(ctx, "read crdb_internal.ranges"); err != nil {
 			return err
 		}
 		descs, err := GetAllDescriptors(ctx, p.txn)
@@ -1612,7 +1612,7 @@ CREATE TABLE crdb_internal.gossip_nodes (
 )
 	`,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser("read crdb_internal.gossip_nodes"); err != nil {
+		if err := p.RequireSuperUser(ctx, "read crdb_internal.gossip_nodes"); err != nil {
 			return err
 		}
 
@@ -1676,7 +1676,7 @@ CREATE TABLE crdb_internal.gossip_liveness (
 )
 	`,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser("read crdb_internal.gossip_liveness"); err != nil {
+		if err := p.RequireSuperUser(ctx, "read crdb_internal.gossip_liveness"); err != nil {
 			return err
 		}
 
@@ -1813,7 +1813,7 @@ CREATE TABLE crdb_internal.kv_node_status (
 )
 	`,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser("read crdb_internal.kv_node_status"); err != nil {
+		if err := p.RequireSuperUser(ctx, "read crdb_internal.kv_node_status"); err != nil {
 			return err
 		}
 
@@ -1918,7 +1918,7 @@ CREATE TABLE crdb_internal.kv_store_status (
 )
 	`,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
-		if err := p.RequireSuperUser("read crdb_internal.kv_store_status"); err != nil {
+		if err := p.RequireSuperUser(ctx, "read crdb_internal.kv_store_status"); err != nil {
 			return err
 		}
 

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -30,7 +30,7 @@ type createDatabaseNode struct {
 // Privileges: superuser.
 //   Notes: postgres requires superuser or "CREATEDB".
 //          mysql uses the mysqladmin command.
-func (p *planner) CreateDatabase(n *tree.CreateDatabase) (planNode, error) {
+func (p *planner) CreateDatabase(ctx context.Context, n *tree.CreateDatabase) (planNode, error) {
 	if n.Name == "" {
 		return nil, errEmptyDatabaseName
 	}
@@ -65,7 +65,7 @@ func (p *planner) CreateDatabase(n *tree.CreateDatabase) (planNode, error) {
 		}
 	}
 
-	if err := p.RequireSuperUser("CREATE DATABASE"); err != nil {
+	if err := p.RequireSuperUser(ctx, "CREATE DATABASE"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -44,7 +44,7 @@ func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNod
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(tableDesc, privilege.CREATE); err != nil {
+	if err := p.CheckPrivilege(ctx, tableDesc, privilege.CREATE); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -40,7 +40,7 @@ func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (p
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(dbDesc, privilege.CREATE); err != nil {
+	if err := p.CheckPrivilege(ctx, dbDesc, privilege.CREATE); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -44,7 +44,7 @@ func (p *planner) CreateStatistics(ctx context.Context, n *tree.CreateStats) (pl
 		return nil, errors.Errorf("cannot create statistics on virtual tables")
 	}
 
-	if err := p.CheckPrivilege(tableDesc, privilege.SELECT); err != nil {
+	if err := p.CheckPrivilege(ctx, tableDesc, privilege.SELECT); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -58,7 +58,7 @@ func (p *planner) CreateTable(ctx context.Context, n *tree.CreateTable) (planNod
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(dbDesc, privilege.CREATE); err != nil {
+	if err := p.CheckPrivilege(ctx, dbDesc, privilege.CREATE); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -52,7 +52,7 @@ func (p *planner) CreateUserNode(
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(tDesc, privilege.INSERT); err != nil {
+	if err := p.CheckPrivilege(ctx, tDesc, privilege.INSERT); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -53,7 +53,7 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(dbDesc, privilege.CREATE); err != nil {
+	if err := p.CheckPrivilege(ctx, dbDesc, privilege.CREATE); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -302,7 +302,7 @@ func (p *planner) getVirtualDataSource(
 		prefix := string(tn.PrefixName)
 		if !tn.PrefixOriginallySpecified {
 			prefix = p.SessionData().Database
-			if prefix == "" && p.RequireSuperUser("access virtual tables across all databases") != nil {
+			if prefix == "" && p.RequireSuperUser(ctx, "access virtual tables across all databases") != nil {
 				prefix = sqlbase.SystemDB.Name
 			}
 		}
@@ -627,7 +627,7 @@ func (p *planner) getPlanForDesc(
 
 	// This name designates a real table.
 	scan := p.Scan()
-	if err := scan.initTable(p, desc, hints, scanVisibility, wantedColumns); err != nil {
+	if err := scan.initTable(ctx, p, desc, hints, scanVisibility, wantedColumns); err != nil {
 		return planDataSource{}, err
 	}
 
@@ -660,7 +660,7 @@ func (p *planner) getViewPlan(
 	// SELECT privileges on the view, which is intended to allow for exposing
 	// some subset of a restricted table's data to less privileged users.
 	if !p.skipSelectPrivilegeChecks {
-		if err := p.CheckPrivilege(desc, privilege.SELECT); err != nil {
+		if err := p.CheckPrivilege(ctx, desc, privilege.SELECT); err != nil {
 			return planDataSource{}, err
 		}
 		p.skipSelectPrivilegeChecks = true

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -61,7 +61,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		return nil, sqlbase.NewUndefinedDatabaseError(string(n.Name))
 	}
 
-	if err := p.CheckPrivilege(dbDesc, privilege.DROP); err != nil {
+	if err := p.CheckPrivilege(ctx, dbDesc, privilege.DROP); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -58,7 +58,7 @@ func (p *planner) DropIndex(ctx context.Context, n *tree.DropIndex) (planNode, e
 			return nil, err
 		}
 
-		if err := p.CheckPrivilege(tableDesc, privilege.CREATE); err != nil {
+		if err := p.CheckPrivilege(ctx, tableDesc, privilege.CREATE); err != nil {
 			return nil, err
 		}
 

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -163,7 +163,7 @@ func (p *planner) dropTableOrViewPrepare(
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(tableDesc, privilege.DROP); err != nil {
+	if err := p.CheckPrivilege(ctx, tableDesc, privilege.DROP); err != nil {
 		return nil, err
 	}
 	return tableDesc, nil
@@ -179,7 +179,7 @@ func (p *planner) canRemoveFK(
 	if behavior != tree.DropCascade {
 		return nil, fmt.Errorf("%q is referenced by foreign key from table %q", from, table.Name)
 	}
-	if err := p.CheckPrivilege(table, privilege.CREATE); err != nil {
+	if err := p.CheckPrivilege(ctx, table, privilege.CREATE); err != nil {
 		return nil, err
 	}
 	return table, nil
@@ -202,7 +202,7 @@ func (p *planner) canRemoveInterleave(
 		return pgerror.UnimplementedWithIssueErrorf(
 			8036, "%q is interleaved by table %q", from, table.Name)
 	}
-	return p.CheckPrivilege(table, privilege.CREATE)
+	return p.CheckPrivilege(ctx, table, privilege.CREATE)
 }
 
 func (p *planner) removeFK(

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -52,7 +52,7 @@ func (p *planner) DropUserNode(
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(tDesc, privilege.DELETE); err != nil {
+	if err := p.CheckPrivilege(ctx, tDesc, privilege.DELETE); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -152,7 +152,7 @@ func (p *planner) canRemoveDependentViewGeneric(
 	if err != nil {
 		return err
 	}
-	if err := p.CheckPrivilege(viewDesc, privilege.DROP); err != nil {
+	if err := p.CheckPrivilege(ctx, viewDesc, privilege.DROP); err != nil {
 		return err
 	}
 	// If this view is depended on by other views, we have to check them as well.

--- a/pkg/sql/executor_opt_interface.go
+++ b/pkg/sql/executor_opt_interface.go
@@ -56,7 +56,7 @@ func (ef *execFactory) ConstructScan(table optbase.Table) (opt.ExecNode, error) 
 	}
 	// Create a scanNode.
 	scan := ef.planner.Scan()
-	if err := scan.initTable(ef.planner, desc, nil /* hints */, publicColumns, columns); err != nil {
+	if err := scan.initTable(context.TODO(), ef.planner, desc, nil /* hints */, publicColumns, columns); err != nil {
 		return nil, err
 	}
 	var err error

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -77,7 +77,7 @@ func (p *planner) changePrivileges(
 	}
 
 	for _, descriptor := range descriptors {
-		if err := p.CheckPrivilege(descriptor, privilege.GRANT); err != nil {
+		if err := p.CheckPrivilege(ctx, descriptor, privilege.GRANT); err != nil {
 			return nil, err
 		}
 		privileges := descriptor.GetPrivileges()

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -808,7 +808,7 @@ func forEachDatabaseDesc(
 
 	sort.Sort(sortedDBDescs(dbDescs))
 	for _, db := range dbDescs {
-		if userCanSeeDatabase(p, db) {
+		if userCanSeeDatabase(ctx, p, db) {
 			if err := fn(db); err != nil {
 				return err
 			}
@@ -1003,7 +1003,7 @@ func forEachTableDescWithTableLookupInternal(
 		sort.Strings(dbTableNames)
 		for _, tableName := range dbTableNames {
 			tableDesc := db.tables[tableName]
-			if userCanSeeTable(p, tableDesc, allowAdding) {
+			if userCanSeeTable(ctx, p, tableDesc, allowAdding) {
 				if err := fn(db.desc, tableDesc, tableLookup); err != nil {
 					return err
 				}
@@ -1090,14 +1090,16 @@ func forEachRole(
 	return nil
 }
 
-func userCanSeeDatabase(p *planner, db *sqlbase.DatabaseDescriptor) bool {
-	return p.CheckAnyPrivilege(db) == nil
+func userCanSeeDatabase(ctx context.Context, p *planner, db *sqlbase.DatabaseDescriptor) bool {
+	return p.CheckAnyPrivilege(ctx, db) == nil
 }
 
-func userCanSeeTable(p *planner, table *sqlbase.TableDescriptor, allowAdding bool) bool {
+func userCanSeeTable(
+	ctx context.Context, p *planner, table *sqlbase.TableDescriptor, allowAdding bool,
+) bool {
 	if !(table.State == sqlbase.TableDescriptor_PUBLIC ||
 		(allowAdding && table.State == sqlbase.TableDescriptor_ADD)) {
 		return false
 	}
-	return p.CheckAnyPrivilege(table) == nil
+	return p.CheckAnyPrivilege(ctx, table) == nil
 }

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -90,7 +90,7 @@ func (p *planner) Insert(
 	isUpsertReturning := false
 	if n.OnConflict != nil {
 		if !n.OnConflict.DoNothing {
-			if err := p.CheckPrivilege(en.tableDesc, privilege.UPDATE); err != nil {
+			if err := p.CheckPrivilege(ctx, en.tableDesc, privilege.UPDATE); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/sql/logictest/main_test.go
+++ b/pkg/sql/logictest/main_test.go
@@ -38,7 +38,7 @@ import (
 // 'planhook'.
 func init() {
 	testingPlanHook := func(
-		stmt tree.Statement, state sql.PlanHookState,
+		_ context.Context, stmt tree.Statement, state sql.PlanHookState,
 	) (func(context.Context, chan<- tree.Datums) error, sqlbase.ResultColumns, error) {
 		show, ok := stmt.(*tree.ShowVar)
 		if !ok || show.Name != "planhook" {

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -434,7 +434,7 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 	// upcoming IR work will provide unique numeric type tags, which will
 	// elegantly solve this.
 	for _, planHook := range planHooks {
-		if fn, header, err := planHook(stmt, p); err != nil {
+		if fn, header, err := planHook(ctx, stmt, p); err != nil {
 			return nil, err
 		} else if fn != nil {
 			return &hookFnNode{f: fn, header: header}, nil
@@ -552,7 +552,7 @@ func (p *planner) newPlan(
 	case *tree.Scrub:
 		return p.Scrub(ctx, n)
 	case *tree.CreateDatabase:
-		return p.CreateDatabase(n)
+		return p.CreateDatabase(ctx, n)
 	case *tree.CreateIndex:
 		return p.CreateIndex(ctx, n)
 	case *tree.CreateTable:

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -46,7 +46,7 @@ type hookFnNode struct {
 // a blocking channel, so implementors should be careful to only use blocking
 // sends on it when necessary.
 type planHookFn func(
-	tree.Statement, PlanHookState,
+	context.Context, tree.Statement, PlanHookState,
 ) (fn func(context.Context, chan<- tree.Datums) error, header sqlbase.ResultColumns, err error)
 
 var planHooks []planHookFn

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -50,7 +50,7 @@ func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planN
 		return nil, fmt.Errorf("table %q does not exist", tn.Table())
 	}
 
-	if err := p.CheckPrivilege(tableDesc, privilege.CREATE); err != nil {
+	if err := p.CheckPrivilege(ctx, tableDesc, privilege.CREATE); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -33,7 +33,7 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 		return nil, errEmptyDatabaseName
 	}
 
-	if err := p.RequireSuperUser("ALTER DATABASE ... RENAME"); err != nil {
+	if err := p.RequireSuperUser(ctx, "ALTER DATABASE ... RENAME"); err != nil {
 		return nil, err
 	}
 
@@ -42,7 +42,7 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(dbDesc, privilege.DROP); err != nil {
+	if err := p.CheckPrivilege(ctx, dbDesc, privilege.DROP); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -51,7 +51,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNod
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(tableDesc, privilege.CREATE); err != nil {
+	if err := p.CheckPrivilege(ctx, tableDesc, privilege.CREATE); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -82,7 +82,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 		return nil, sqlbase.NewUndefinedRelationError(oldTn)
 	}
 
-	if err := p.CheckPrivilege(tableDesc, privilege.DROP); err != nil {
+	if err := p.CheckPrivilege(ctx, tableDesc, privilege.DROP); err != nil {
 		return nil, err
 	}
 
@@ -101,7 +101,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(targetDbDesc, privilege.CREATE); err != nil {
+	if err := p.CheckPrivilege(ctx, targetDbDesc, privilege.CREATE); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -256,6 +256,7 @@ func (n *scanNode) limitHint() int64 {
 // Initializes a scanNode with a table descriptor.
 // wantedColumns is optional.
 func (n *scanNode) initTable(
+	ctx context.Context,
 	p *planner,
 	desc *sqlbase.TableDescriptor,
 	indexHints *tree.IndexHints,
@@ -265,7 +266,7 @@ func (n *scanNode) initTable(
 	n.desc = desc
 
 	if !p.skipSelectPrivilegeChecks {
-		if err := p.CheckPrivilege(n.desc, privilege.SELECT); err != nil {
+		if err := p.CheckPrivilege(ctx, n.desc, privilege.SELECT); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -75,7 +75,7 @@ type checkOperation interface {
 // Scrub checks the database.
 // Privileges: superuser.
 func (p *planner) Scrub(ctx context.Context, n *tree.Scrub) (planNode, error) {
-	if err := p.RequireSuperUser("SCRUB"); err != nil {
+	if err := p.RequireSuperUser(ctx, "SCRUB"); err != nil {
 		return nil, err
 	}
 	return &scrubNode{n: n}, nil

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -110,7 +110,7 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	scan := params.p.Scan()
 	scan.run.isCheck = true
 	if err := scan.initTable(
-		params.p, o.tableDesc, indexHints, publicColumns, columnIDs,
+		ctx, params.p, o.tableDesc, indexHints, publicColumns, columnIDs,
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -42,7 +42,7 @@ type setClusterSettingNode struct {
 func (p *planner) SetClusterSetting(
 	ctx context.Context, n *tree.SetClusterSetting,
 ) (planNode, error) {
-	if err := p.RequireSuperUser("SET CLUSTER SETTING"); err != nil {
+	if err := p.RequireSuperUser(ctx, "SET CLUSTER SETTING"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -32,7 +32,7 @@ func (p *planner) ShowClusterSetting(
 	ctx context.Context, n *tree.ShowClusterSetting,
 ) (planNode, error) {
 
-	if err := p.RequireSuperUser("SHOW CLUSTER SETTINGS"); err != nil {
+	if err := p.RequireSuperUser(ctx, "SHOW CLUSTER SETTINGS"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/show_constraints.go
+++ b/pkg/sql/show_constraints.go
@@ -38,7 +38,7 @@ func (p *planner) ShowConstraints(ctx context.Context, n *tree.ShowConstraints) 
 	if err != nil {
 		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}
-	if err := p.CheckAnyPrivilege(desc); err != nil {
+	if err := p.CheckAnyPrivilege(ctx, desc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -65,7 +65,7 @@ func (p *planner) ShowFingerprints(
 		return nil, err
 	}
 
-	if err := p.CheckPrivilege(tableDesc, privilege.SELECT); err != nil {
+	if err := p.CheckPrivilege(ctx, tableDesc, privilege.SELECT); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -46,7 +46,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 	if err != nil {
 		return nil, err
 	}
-	if err := p.CheckAnyPrivilege(desc); err != nil {
+	if err := p.CheckAnyPrivilege(ctx, desc); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/show_table.go
+++ b/pkg/sql/show_table.go
@@ -47,7 +47,7 @@ func (p *planner) showTableDetails(
 		if err != nil {
 			return err
 		}
-		return p.CheckAnyPrivilege(desc)
+		return p.CheckAnyPrivilege(ctx, desc)
 	}
 
 	return p.delegateQuery(ctx, showType,

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -52,11 +52,11 @@ func NoLookup(_ context.Context, _ ID) (TableLookup, error) {
 
 // CheckPrivilegeFunction is the function type used by TablesNeededForFKs that will
 // check the privileges of the current user to access specific tables.
-type CheckPrivilegeFunction func(DescriptorProto, privilege.Kind) error
+type CheckPrivilegeFunction func(context.Context, DescriptorProto, privilege.Kind) error
 
 // NoCheckPrivilege can be used to not perform any privilege checks during a
 // TablesNeededForFKs function call.
-func NoCheckPrivilege(_ DescriptorProto, _ privilege.Kind) error {
+func NoCheckPrivilege(_ context.Context, _ DescriptorProto, _ privilege.Kind) error {
 	return nil
 }
 
@@ -94,7 +94,7 @@ func (q *tableLookupQueue) getTable(ctx context.Context, tableID ID) (TableLooku
 		return TableLookup{}, err
 	}
 	if !tableLookup.IsAdding && tableLookup.Table != nil {
-		if err := q.checkPrivilege(tableLookup.Table, privilege.SELECT); err != nil {
+		if err := q.checkPrivilege(ctx, tableLookup.Table, privilege.SELECT); err != nil {
 			return TableLookup{}, err
 		}
 	}
@@ -129,11 +129,11 @@ func (q *tableLookupQueue) enqueue(ctx context.Context, tableID ID, usage FKChec
 	switch usage {
 	// Insert has already been checked when the table is fetched.
 	case CheckDeletes:
-		if err := q.checkPrivilege(tableLookup.Table, privilege.DELETE); err != nil {
+		if err := q.checkPrivilege(ctx, tableLookup.Table, privilege.DELETE); err != nil {
 			return err
 		}
 	case CheckUpdates:
-		if err := q.checkPrivilege(tableLookup.Table, privilege.UPDATE); err != nil {
+		if err := q.checkPrivilege(ctx, tableLookup.Table, privilege.UPDATE); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -895,7 +895,7 @@ func (p *planner) getTableAndIndex(
 	if tableDesc == nil {
 		return nil, nil, sqlbase.NewUndefinedRelationError(tn)
 	}
-	if err := p.CheckPrivilege(tableDesc, privilege); err != nil {
+	if err := p.CheckPrivilege(ctx, tableDesc, privilege); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/sql/tests/planhook.go
+++ b/pkg/sql/tests/planhook.go
@@ -28,7 +28,7 @@ import (
 // 'planhook'.
 func init() {
 	testingPlanHook := func(
-		stmt tree.Statement, state sql.PlanHookState,
+		_ context.Context, stmt tree.Statement, state sql.PlanHookState,
 	) (func(context.Context, chan<- tree.Datums) error, sqlbase.ResultColumns, error) {
 		show, ok := stmt.(*tree.ShowVar)
 		if !ok || show.Name != "planhook" {

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -66,7 +66,7 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 				tableDesc.Kind(), tn, tableDesc.Kind())
 		}
 
-		if err := p.CheckPrivilege(tableDesc, privilege.DROP); err != nil {
+		if err := p.CheckPrivilege(ctx, tableDesc, privilege.DROP); err != nil {
 			return nil, err
 		}
 
@@ -95,7 +95,7 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 				if n.DropBehavior != tree.DropCascade {
 					return nil, errors.Errorf("%q is referenced by foreign key from table %q", tableDesc.Name, other.Name)
 				}
-				if err := p.CheckPrivilege(other, privilege.DROP); err != nil {
+				if err := p.CheckPrivilege(ctx, other, privilege.DROP); err != nil {
 					return nil, err
 				}
 				toTruncate[other.ID] = struct{}{}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -399,7 +399,7 @@ func (p *planner) makeEditNode(
 		}
 	}
 
-	if err := p.CheckPrivilege(tableDesc, priv); err != nil {
+	if err := p.CheckPrivilege(ctx, tableDesc, priv); err != nil {
 		return editNodeBase{}, err
 	}
 


### PR DESCRIPTION
Plumb a context through all authorization methods.

This will be needed to expand role memberships.

Two exceptions exist:
* ccl restore.go:restoreTableDescs calls `CheckPrivilegeForUser` due to the lack of a planner
* executor_opt_interface calls `initTable` with a `context.TODO`

Release note: None