### PR TITLE
cherry-pick 1.1: fix discrepancy with Postgres BYTES arrays

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -35,6 +35,11 @@ SELECT ARRAY['a,', 'b{', 'c}', 'd', 'e f']
 ----
 {"a,","b{","c}","d","e f"}
 
+query T
+SELECT ARRAY['1}'::BYTES]
+----
+{"\\x317d"}
+
 # TODO(jordan): #16487
 # query T
 # SELECT ARRAY[e'g\x10h']
@@ -565,7 +570,7 @@ INSERT INTO a VALUES (ARRAY['foo','bar','baz'])
 query T
 SELECT b FROM a
 ----
-{b'foo',b'bar',b'baz'}
+{"\\x666f6f","\\x626172","\\x62617a"}
 
 statement ok
 DROP TABLE a

--- a/pkg/sql/parser/datum.go
+++ b/pkg/sql/parser/datum.go
@@ -1000,9 +1000,27 @@ func (d *DBytes) max() (Datum, bool) {
 // AmbiguousFormat implements the Datum interface.
 func (*DBytes) AmbiguousFormat() bool { return false }
 
+var hexDigits = [16]byte{
+	'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f',
+}
+
+func writeAsHexString(buf *bytes.Buffer, d *DBytes) {
+	b := string(*d)
+	for i := 0; i < len(b); i++ {
+		buf.WriteByte(hexDigits[b[i]/16])
+		buf.WriteByte(hexDigits[b[i]%16])
+	}
+}
+
 // Format implements the NodeFormatter interface.
 func (d *DBytes) Format(buf *bytes.Buffer, f FmtFlags) {
-	encodeSQLBytes(buf, string(*d))
+	if f.withinArray {
+		buf.WriteString(`"\\x`)
+		writeAsHexString(buf, d)
+		buf.WriteString(`"`)
+	} else {
+		encodeSQLBytes(buf, string(*d))
+	}
 }
 
 // Size implements the Datum interface.


### PR DESCRIPTION
Fixes #21697. "Cherry-pick" of #21712.

This is a bit of an obnoxious fix to be making - we change the way we
format BYTES within arrays here without changing the way we format them
outside of arrays (which is different than master).

This should be a strict compatibility improvement, and it strikes me as
the smallest possible change to be making to fix the issue, but open to
suggestions if people disagree.

Release note (bug fix): fixed an issue with the wire-formatting of BYTES
arrays.

cc @cockroachdb/release 
cc @glerchundi