### PR TITLE
build,cmd/workload: add support for teamcity nightly tests

### DIFF
--- a/build/nightly-workload.sh
+++ b/build/nightly-workload.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -ex
+
+go get -u github.com/cockroachlabs/roachprod
+
+# TODO(dan): Using my fork for rapid prototyping while I figure out what the
+# roachperf changes should even look like. Switch this to the official fork.
+go get -u github.com/danhhz/roachperf
+
+make bin/workload
+
+curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-182.0.0-linux-x86_64.tar.gz
+tar -zxf google-cloud-sdk-182.0.0-linux-x86_64.tar.gz
+yes "" | ./google-cloud-sdk/install.sh
+source google-cloud-sdk/path.bash.inc
+
+# This `set +x`/paren magic turns off the `set -x` so we don't leak secrets.
+(set +x; echo $GOOGLE_CREDENTIALS > creds.json)
+gcloud auth activate-service-account --key-file=creds.json
+eval $(ssh-agent)
+ssh-keygen -f ~/.ssh/google_compute_engine -N ''
+ssh-add ~/.ssh/google_compute_engine
+
+# teamcity-nightlies assumes cockroach and workload are the cwd.
+cp cockroach-linux-2.6.32-gnu-amd64 cockroach
+cp bin/workload .
+
+# teamcity-nightlies puts the arg we give into the name of every cluster it
+# creates, so this should let us match up clusters to invocations of this build.
+./workload teamcity-nightlies ${TC_BUILD_ID}
+cp -R workload-test* artifacts/
+
+# Currently broken because of s3 auth. Copied from the "Roachperf Nightly"
+# build, where it is also currently broken.
+roachperf upload workload-test* || true

--- a/build/teamcity-nightly-workload.sh
+++ b/build/teamcity-nightly-workload.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+mkdir -p artifacts
+
+# Build the cockroach binary (which uses docker) before hopping into docker for
+# the nightly-workload.sh script.
+pkg/acceptance/prepare.sh
+
+docker run \
+    --workdir=/go/src/github.com/cockroachdb/cockroach \
+    --volume="${GOPATH%%:*}/src":/go/src \
+    --env="AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
+    --env="AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
+    --env="GOOGLE_CREDENTIALS=${GOOGLE_CREDENTIALS}" \
+    --env="TC_BUILD_ID=${TC_BUILD_ID}" \
+    --rm \
+    cockroachdb/builder:20171004-085709 ./build/nightly-workload.sh


### PR DESCRIPTION
This adds simple plumbing for a nightly teamcity job to set up clusters
using roachprod and then use roachperf to run workloads on them.

Still TODO is running them in parallel and roachprod cluster
configurations other than the default (such as geodistributed).

Release note: None