### PR TITLE
sqlbase: Allow the cascader to be reused within the same statement.

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -849,6 +849,35 @@ SELECT
 statement ok
 DROP TABLE e, d, c, b, a;
 
+subtest DeleteCascade_Multi
+# Ensures that the cascader can be reused. See #21563.
+
+statement ok
+CREATE TABLE a (
+  id INT PRIMARY KEY
+);
+CREATE TABLE b (
+  id INT PRIMARY KEY
+ ,a_id INT REFERENCES a ON DELETE CASCADE
+)
+
+statement ok
+INSERT INTO a VALUES (1), (2), (3);
+INSERT INTO b VALUES (1, 1), (2, NULL), (3, 2), (4, 1), (5, NULL);
+
+statement ok
+DELETE FROM a;
+
+query II
+SELECT id, a_id FROM b;
+----
+2  NULL
+5  NULL
+
+# Clean up.
+statement ok
+DROP TABLE b, a;
+
 subtest UpdateCascade_Basic
 ### Basic Update Cascade
 #     a
@@ -1711,6 +1740,38 @@ updated updated
 # Clean up after the test.
 statement ok
 DROP TABLE f, e, d, c, b, a;
+
+subtest UpdateCascade_Multi
+# Ensures that the cascader can be reused. See #21563.
+
+statement ok
+CREATE TABLE a (
+  id INT PRIMARY KEY
+);
+CREATE TABLE b (
+  id INT PRIMARY KEY
+ ,a_id INT REFERENCES a ON UPDATE CASCADE
+)
+
+statement ok
+INSERT INTO a VALUES (1), (2), (3);
+INSERT INTO b VALUES (1, 1), (2, NULL), (3, 2), (4, 1), (5, NULL);
+
+statement ok
+UPDATE a SET id = id + 10;
+
+query II
+SELECT id, a_id FROM b;
+----
+1  11
+2  NULL
+3  12
+4  11
+5  NULL
+
+# Clean up.
+statement ok
+DROP TABLE b, a;
 
 subtest DeleteNull_Basic1
 ### Basic Delete Set Null

--- a/pkg/sql/sqlbase/cascader.go
+++ b/pkg/sql/sqlbase/cascader.go
@@ -178,15 +178,15 @@ Outer:
 	}, nil
 }
 
-func (c *cascader) close(ctx context.Context) {
+func (c *cascader) clear(ctx context.Context) {
 	for _, container := range c.deletedRows {
-		container.Close(ctx)
+		container.Clear(ctx)
 	}
 	for _, container := range c.originalRows {
-		container.Close(ctx)
+		container.Clear(ctx)
 	}
 	for _, container := range c.updatedRows {
-		container.Close(ctx)
+		container.Clear(ctx)
 	}
 }
 
@@ -903,7 +903,7 @@ func (c *cascader) cascadeAll(
 	colIDtoRowIndex map[ColumnID]int,
 	traceKV bool,
 ) error {
-	defer c.close(ctx)
+	defer c.clear(ctx)
 	var cascadeQ cascadeQueue
 
 	// Enqueue the first values.


### PR DESCRIPTION
If more than one row is being cascaded, the cascader was not reusable.

For example, we have this setup:
```sql
CREATE TABLE a (
  id INT PRIMARY KEY
);
CREATE TABLE b (
  id INT PRIMARY KEY
 ,a_id INT REFERENCES a ON DELETE CASCADE
)
```

And then we insert a bunch of values into tables a and b.

So far, all the tests were doing a single delete, as in
`DELETE FROM a WHERE id = 1`

But `DELETE FROM a WHERE id > 0` would fail. Or even `DELETE FROM a`.

This fixes that issue.

The root cause was the fact that the cascader was being reused but the row
containers used for tracking deletes and updates were closed preventing further
use. The panic in #21563 was caused by trying to close the already closed row
container. But if there was another key to cascade a delete, it would have been
disasterous as well.

Fixes #21563.

Release note (sql change): Fixed a bug in cascading foreign reference actions
such that which more than one cascading operation can occur per statement. As
in, cascading from multiple deletes now works.