### PR TITLE
cherrypick-1.1: util/log: Avoid infinite recursion out of disk errors cause an exit

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -889,10 +889,20 @@ var logExitFunc func(error)
 // point in hanging around. l.mu is held.
 func (l *loggingT) exitLocked(err error) {
 	l.mu.AssertHeld()
+
 	// Either stderr or our log file is broken. Try writing the error to both
 	// streams in the hope that one still works or else the user will have no idea
 	// why we crashed.
-	for _, w := range []io.Writer{OrigStderr, l.file} {
+	outputs := make([]io.Writer, 2)
+	outputs[0] = OrigStderr
+	if f, ok := l.file.(*syncBuffer); ok {
+		// Don't call syncBuffer's Write method, because it can call back into
+		// exitLocked. Go directly to syncBuffer's underlying writer.
+		outputs[1] = f.Writer
+	} else {
+		outputs[1] = l.file
+	}
+	for _, w := range outputs {
 		if w == nil {
 			continue
 		}

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -28,6 +28,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -773,6 +774,36 @@ func TestFileSeverityFilter(t *testing.T) {
 	if strings.Contains(string(contents), "test1") {
 		t.Errorf("info text was not filtered out of log\n%s", contents)
 	}
+}
+
+type outOfSpaceWriter struct{}
+
+func (w *outOfSpaceWriter) Write([]byte) (int, error) {
+	return 0, fmt.Errorf("no space left on device")
+}
+
+func TestExitOnFullDisk(t *testing.T) {
+	oldLogExitFunc := logExitFunc
+	logExitFunc = nil
+	defer func() { logExitFunc = oldLogExitFunc }()
+
+	var exited sync.WaitGroup
+	exited.Add(1)
+	l := &loggingT{
+		exitFunc: func(int) {
+			exited.Done()
+		},
+	}
+	l.file = &syncBuffer{
+		logger: l,
+		Writer: bufio.NewWriterSize(&outOfSpaceWriter{}, 1),
+	}
+
+	l.mu.Lock()
+	l.exitLocked(fmt.Errorf("out of space"))
+	l.mu.Unlock()
+
+	exited.Wait()
 }
 
 func BenchmarkHeader(b *testing.B) {


### PR DESCRIPTION
Trying to write to a file when we're out of disk will trigger
exitLocked, but exitLocked tries to write to its file one last time in
order to help users understand why the process is exiting. This is very
valuable most of the time, when the problem isn't that the machine is
out of disk, but shouldn't cause a stack overflow when the machine is
out of space.

Fixes #21756

Release note (bug fix): fix a stack overflow in the code for shutting
down a server when out of disk space