### PR TITLE
ts: Disable time series memory monitor log

### DIFF
--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -16,6 +16,7 @@ package ts
 
 import (
 	"context"
+	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 
@@ -80,7 +81,7 @@ func MakeServer(
 			mon.MemoryResource,
 			nil,
 			nil,
-			queryMemoryMax/10,
+			math.MaxInt64,
 		),
 		workerSem: make(chan struct{}, queryWorkerMax),
 	}
@@ -127,7 +128,7 @@ func (s *Server) Query(
 		nil,
 		nil,
 		0,
-		0,
+		math.MaxInt64,
 	)
 	monitor.Start(ctx, &s.memMonitor, mon.BoundAccount{})
 	defer monitor.Stop(ctx)


### PR DESCRIPTION
Set "noteworthy" bytes to MaxInt64 so that it does not log. We will set
the limit lower once resource governance is installed.

Fixes #21806

Release note: None