### PR TITLE
sqlccl: remove sstsize option from IMPORT CSV

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -45,7 +44,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -59,7 +57,6 @@ const (
 	importOptionLocal     = "local"
 	importOptionNullIf    = "nullif"
 	importOptionTransform = "transform"
-	importOptionSSTSize   = "sstsize"
 )
 
 var importOptionExpectValues = map[string]bool{
@@ -68,7 +65,6 @@ var importOptionExpectValues = map[string]bool{
 	importOptionLocal:     false,
 	importOptionNullIf:    true,
 	importOptionTransform: true,
-	importOptionSSTSize:   true,
 	restoreOptIntoDB:      true,
 }
 
@@ -989,15 +985,6 @@ func importPlanHook(
 			nullif = &override
 		}
 
-		sstSize := config.DefaultZoneConfig().RangeMaxBytes / 2
-		if override, ok := opts[importOptionSSTSize]; ok {
-			sz, err := humanizeutil.ParseBytes(override)
-			if err != nil {
-				return err
-			}
-			sstSize = sz
-		}
-
 		var create *tree.CreateTable
 		if importStmt.CreateDefs != nil {
 			normName := tree.NormalizableTableName{TableNameReference: &importStmt.Table}
@@ -1069,12 +1056,12 @@ func importPlanHook(
 			importErr = doDistributedCSVTransform(
 				ctx, job, files, p, parentID, tableDesc, transform,
 				comma, comment, nullif, walltime,
-				sstSize,
 			)
 		} else {
 			if transform == "" {
 				return errors.Errorf("%s option required for local import", importOptionTransform)
 			}
+			sstSize := storageccl.MaxImportBatchSize(p.ExecCfg().Settings)
 			_, _, _, importErr = doLocalCSVTransform(
 				ctx, job, parentID, tableDesc, transform, files,
 				comma, comment, nullif, sstSize,
@@ -1129,7 +1116,6 @@ func doDistributedCSVTransform(
 	comma, comment rune,
 	nullif *string,
 	walltime int64,
-	sstSize int64,
 ) error {
 	evalCtx := p.ExtendedEvalContext()
 
@@ -1171,7 +1157,6 @@ func doDistributedCSVTransform(
 		comma, comment,
 		nullif,
 		walltime,
-		sstSize,
 	); err != nil {
 		// If the job was canceled, any of the distsql processors could have been
 		// the first to encounter the .Progress error. This error's string is sent

--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -520,20 +520,11 @@ func TestImportStmt(t *testing.T) {
 			"",
 		},
 		{
-			// Force some SST splits.
-			"schema-in-file-sstsize",
-			`IMPORT TABLE t CREATE USING $1 CSV DATA (%s) WITH sstsize = '10K'`,
-			schema,
-			files,
-			`WITH sstsize = '10K'`,
-			"",
-		},
-		{
 			"schema-in-query-local",
 			`IMPORT TABLE t (a INT PRIMARY KEY, b STRING, INDEX (b), INDEX (a, b)) CSV DATA (%s) WITH local, transform = $1`,
 			nil,
 			files,
-			`WITH local, transform = 'nodelocal:///6'`,
+			`WITH local, transform = 'nodelocal:///5'`,
 			"",
 		},
 		{
@@ -541,7 +532,7 @@ func TestImportStmt(t *testing.T) {
 			`IMPORT TABLE t (a INT PRIMARY KEY, b STRING, INDEX (b), INDEX (a, b)) CSV DATA (%s) WITH local, delimiter = '|', comment = '#', nullif='', transform = $1`,
 			nil,
 			filesWithOpts,
-			`WITH comment = '#', delimiter = '|', local, "nullif" = '', transform = 'nodelocal:///7'`,
+			`WITH comment = '#', delimiter = '|', local, "nullif" = '', transform = 'nodelocal:///6'`,
 			"",
 		},
 		{
@@ -549,7 +540,7 @@ func TestImportStmt(t *testing.T) {
 			`IMPORT TABLE t (a INT PRIMARY KEY, b STRING, INDEX (b), INDEX (a, b)) CSV DATA (%s) WITH delimiter = '|', comment = '#', nullif='', transform = $1`,
 			nil,
 			filesWithOpts,
-			`WITH comment = '#', delimiter = '|', "nullif" = '', transform = 'nodelocal:///8'`,
+			`WITH comment = '#', delimiter = '|', "nullif" = '', transform = 'nodelocal:///7'`,
 			"",
 		},
 		{
@@ -573,7 +564,7 @@ func TestImportStmt(t *testing.T) {
 			`IMPORT TABLE t CREATE USING $1 CSV DATA (%s) WITH local, transform = $2`,
 			schema,
 			empty,
-			`WITH local, transform = 'nodelocal:///11'`,
+			`WITH local, transform = 'nodelocal:///10'`,
 			"",
 		},
 		{
@@ -581,7 +572,7 @@ func TestImportStmt(t *testing.T) {
 			`IMPORT TABLE t CREATE USING $1 CSV DATA (%s) WITH local, transform = $2`,
 			schema,
 			append(empty, files...),
-			`WITH local, transform = 'nodelocal:///12'`,
+			`WITH local, transform = 'nodelocal:///11'`,
 			"",
 		},
 		// NB: successes above, failures below, because we check the i-th job.
@@ -725,8 +716,8 @@ func TestImportStmt(t *testing.T) {
 				t.Fatalf("expected %d rows, got %d", expectedNulls, result)
 			}
 
-			// Verify sstsize created > 1 SST files.
-			if tc.name == "schema-in-file-sstsize-dist" {
+			// Verify that small kv.import.batch_size setting created > 1 SST files.
+			if hasTransform {
 				pattern := filepath.Join(dir, fmt.Sprintf("%d", i), "*.sst")
 				matches, err := filepath.Glob(pattern)
 				if err != nil {


### PR DESCRIPTION
See included comment. Instead of using the poor distribution of the
sampling size and its associated high standard deviation, rely on
sst chunker to create optimally-sized ranges during import. This has
the side effect of reducing the size and search time of the distsql
range router.

Release note (enterprise change): Remove sstsize option from IMPORT CSV.