### PR TITLE
sql: use role memberships in permissions checks.

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -2070,12 +2070,12 @@ func TestBackupRestorePermissions(t *testing.T) {
 
 	t.Run("root-only", func(t *testing.T) {
 		if _, err := testuser.Exec(backupStmt); !testutils.IsError(
-			err, "only root is allowed to BACKUP",
+			err, "only superusers are allowed to BACKUP",
 		) {
 			t.Fatal(err)
 		}
 		if _, err := testuser.Exec(`RESTORE blah FROM 'blah'`); !testutils.IsError(
-			err, "only root is allowed to RESTORE",
+			err, "only superusers are allowed to RESTORE",
 		) {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/sqlccl/logictestccl/testdata/logic_test/role
+++ b/pkg/ccl/sqlccl/logictestccl/testdata/logic_test/role
@@ -383,3 +383,121 @@ SELECT * FROM system.role_members
 ----
 role   member    isAdmin
 admin  root      true
+
+# Test privilege checks.
+
+statement ok
+CREATE DATABASE db1
+
+user testuser
+
+statement error only superusers are allowed to CREATE DATABASE
+CREATE DATABASE db2
+
+statement error user testuser does not have DROP privilege on database db1
+DROP DATABASE db1
+
+statement error testuser is not a superuser or role admin for role admin
+GRANT admin TO testuser
+
+user root
+
+statement ok
+CREATE ROLE newgroup
+
+statement ok
+GRANT newgroup TO testuser
+
+statement ok
+GRANT admin TO newgroup
+
+user testuser
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role      member    isAdmin
+admin     newgroup  false
+admin     root      true
+newgroup  testuser  false
+
+statement ok
+CREATE DATABASE db2
+
+statement ok
+DROP DATABASE db1
+
+# Revoke admin privileges. 'newgroup' does not have any privileges.
+statement ok
+REVOKE admin FROM newgroup
+
+statement error user testuser does not have SELECT privilege on relation role_members
+SELECT * FROM system.role_members
+
+statement error user testuser does not have CREATE privilege on database db2
+CREATE TABLE db2.foo (k int);
+
+user root
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role      member    isAdmin
+admin     root      true
+newgroup  testuser  false
+
+statement ok
+GRANT ALL ON DATABASE db2 TO newgroup
+
+user testuser
+
+query TTT colnames
+SHOW GRANTS ON DATABASE db2
+----
+Database   User       Privileges
+db2        admin      ALL
+db2        newgroup   ALL
+db2        root       ALL
+
+statement ok
+CREATE TABLE db2.foo (k int);
+
+statement ok
+INSERT INTO db2.foo VALUES (1),(2),(3);
+
+statement ok
+SELECT * FROM db2.foo
+
+# We may be in the 'newgroup', but we don't have the admin option.
+statement error testuser is not a superuser or role admin for role newgroup
+GRANT newgroup TO testuser2
+
+statement error testuser is not a superuser or role admin for role newgroup
+REVOKE newgroup FROM testuser
+
+statement error testuser is not a superuser or role admin for role newgroup
+GRANT newgroup TO testuser WITH ADMIN OPTION
+
+user root
+
+# The user does not have direct privileges on anything, so we can drop it.
+statement ok
+DROP USER testuser
+
+query TTB colnames
+SELECT * FROM system.role_members
+----
+role      member    isAdmin
+admin     root      true
+
+statement error cannot drop user or role newgroup: grants still exist on db2, db2.foo
+DROP ROLE newgroup
+
+statement ok
+REVOKE ALL ON db2.* FROM newgroup
+
+statement ok
+REVOKE ALL ON DATABASE db2 FROM newgroup
+
+statement ok
+DROP ROLE newgroup

--- a/pkg/server/settingsworker_test.go
+++ b/pkg/server/settingsworker_test.go
@@ -301,22 +301,22 @@ func TestSettingsSetAndShow(t *testing.T) {
 	defer testuser.Close()
 
 	if _, err := testuser.Exec(`SET CLUSTER SETTING foo = 'bar'`); !testutils.IsError(err,
-		`only root is allowed to SET CLUSTER SETTING`,
+		`only superusers are allowed to SET CLUSTER SETTING`,
 	) {
 		t.Fatal(err)
 	}
 	if _, err := testuser.Exec(`SHOW CLUSTER SETTING foo`); !testutils.IsError(err,
-		`only root is allowed to SHOW CLUSTER SETTINGS`,
+		`only superusers are allowed to SHOW CLUSTER SETTINGS`,
 	) {
 		t.Fatal(err)
 	}
 	if _, err := testuser.Exec(`SHOW ALL CLUSTER SETTINGS`); !testutils.IsError(err,
-		`only root is allowed to SHOW CLUSTER SETTINGS`,
+		`only superusers are allowed to SHOW CLUSTER SETTINGS`,
 	) {
 		t.Fatal(err)
 	}
 	if _, err := testuser.Exec(`SELECT * FROM crdb_internal.cluster_settings`); !testutils.IsError(err,
-		`only root is allowed to read crdb_internal.cluster_settings`,
+		`only superusers are allowed to read crdb_internal.cluster_settings`,
 	) {
 		t.Fatal(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/cluster_version
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_version
@@ -12,7 +12,7 @@ SELECT crdb_internal.node_executable_version()
 
 user testuser
 
-statement error only root is allowed to SET CLUSTER SETTING
+statement error only superusers are allowed to SET CLUSTER SETTING
 SET CLUSTER SETTING version = '2.0'
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -269,22 +269,22 @@ select crdb_internal.force_log_fatal('foo')
 query error pq: insufficient privilege
 select crdb_internal.set_vmodule('')
 
-query error pq: only root is allowed to access the node runtime information
+query error pq: only superusers are allowed to access the node runtime information
 select * from crdb_internal.node_runtime_info
 
-query error pq: only root is allowed to read crdb_internal.ranges
+query error pq: only superusers are allowed to read crdb_internal.ranges
 select * from crdb_internal.ranges
 
-query error pq: only root is allowed to read crdb_internal.gossip_nodes
+query error pq: only superusers are allowed to read crdb_internal.gossip_nodes
 select * from crdb_internal.gossip_nodes
 
-query error pq: only root is allowed to read crdb_internal.gossip_liveness
+query error pq: only superusers are allowed to read crdb_internal.gossip_liveness
 select * from crdb_internal.gossip_liveness
 
-query error pq: only root is allowed to read crdb_internal.kv_node_status
+query error pq: only superusers are allowed to read crdb_internal.kv_node_status
 select * from crdb_internal.kv_node_status
 
-query error pq: only root is allowed to read crdb_internal.kv_store_status
+query error pq: only superusers are allowed to read crdb_internal.kv_store_status
 select * from crdb_internal.kv_store_status
 
 # Anyone can see the executable version.

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -150,7 +150,7 @@ SELECT * FROM b.a
 
 user testuser
 
-statement error only root is allowed to CREATE DATABASE
+statement error only superusers are allowed to CREATE DATABASE
 CREATE DATABASE privs
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/privileges_database
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_database
@@ -38,7 +38,7 @@ REVOKE ALL ON DATABASE a FROM bar
 # Switch to a user without any privileges.
 user testuser
 
-statement error only root is allowed to CREATE DATABASE
+statement error only superusers are allowed to CREATE DATABASE
 CREATE DATABASE b
 
 statement error user testuser does not have DROP privilege on database a
@@ -73,7 +73,7 @@ GRANT SELECT ON DATABASE a TO testuser
 
 user testuser
 
-statement error only root is allowed to CREATE DATABASE
+statement error only superusers are allowed to CREATE DATABASE
 CREATE DATABASE b
 
 statement error user testuser does not have DROP privilege on database a
@@ -108,7 +108,7 @@ GRANT ALL ON DATABASE a TO testuser
 
 user testuser
 
-statement error only root is allowed to CREATE DATABASE
+statement error only superusers are allowed to CREATE DATABASE
 CREATE DATABASE b
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -88,7 +88,7 @@ GRANT ALL ON DATABASE t TO testuser
 
 user testuser
 
-statement error only root is allowed to ALTER DATABASE ... RENAME
+statement error only superusers are allowed to ALTER DATABASE ... RENAME
 ALTER DATABASE t RENAME TO v
 
 query T


### PR DESCRIPTION
Release note (sql change): consider role memberships in permission checks