### PR TITLE
sql: report schema change error with txn commit

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -388,6 +388,9 @@ func (sc *SchemaChanger) maybeAddDropRename(
 // Execute the entire schema change in steps.
 // inSession is set to false when this is called from the asynchronous
 // schema change execution path.
+//
+// If the txn that queued the schema changer did not commit, this will be a
+// no-op, as we'll fail to find the job for our mutation in the jobs registry.
 func (sc *SchemaChanger) exec(
 	ctx context.Context, inSession bool, evalCtx *extendedEvalContext,
 ) error {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -624,6 +624,9 @@ func (p *planner) getAliasedTableName(n tree.TableExpr) (*tree.TableName, *tree.
 // descriptor and creates a schema change job in the system.jobs table.
 // The identifiers of the mutations and newly-created job are written to a new
 // MutationJob in the table descriptor.
+//
+// The job creation is done within the planner's txn. This is important - if the
+// txn ends up rolling back, the job needs to go away.
 func (p *planner) createSchemaChangeJob(
 	ctx context.Context, tableDesc *sqlbase.TableDescriptor, stmt string,
 ) (sqlbase.MutationID, error) {


### PR DESCRIPTION
Before this change, an error encountered by a schema change queued up by
a statement in an explicit transaction would not be reported to the
client unless the statement was part of the same query string as the
COMMIT statement. So, generally speaking, schema change errors queued up
in transactions would not be reported :).
This occurs because of remnants of code of code that tried to associate
Before 1.1 I think we used to have code that either associated the error
with the statement that queued the change (if it still had access to its
result) or associated it with the commit otherwise. That broke when we
introduced results streaming. Or maybe it was always broken.

Besides this bug, there's an outstanding issue that the way in which
these errors are reported is no conformant to the pgwire protocol, and
also that these errors confusingly suggest to someone that the
transaction has not been committed. This commit does nothing to address
either of these. These issues are discussed in this Cockroach Labs
internal thread: https://groups.google.com/a/cockroachlabs.com/forum/#!topic/eng/Jc61hd6Pv2US

I will cherry-pick this into a 1.1 release.

Fixes #21822

Release note(sql): Fix reporting of errors from transactional schema
changes: errors from DDL statements sent by a client as part of a
transaction, but in a different query string than the final commit used
to be silently swallowed.