### PR TITLE
workload: support per-table range splits

### DIFF
--- a/pkg/ccl/testutilsccl/workloadccl/fixture.go
+++ b/pkg/ccl/testutilsccl/workloadccl/fixture.go
@@ -209,6 +209,12 @@ func RestoreFixture(ctx context.Context, sqlDB *gosql.DB, fixture Fixture, datab
 			return err
 		}
 	}
+	const splitConcurrency = 384 // TODO(dan): Don't hardcode this.
+	for _, table := range fixture.Generator.Tables() {
+		if err := workload.Split(ctx, sqlDB, table, splitConcurrency); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/cmd/workload/run.go
+++ b/pkg/cmd/workload/run.go
@@ -234,6 +234,11 @@ func runRun(gen workload.Generator, args []string) error {
 	if _, err := workload.Setup(db, gen, batchSize); err != nil {
 		return err
 	}
+	for _, table := range gen.Tables() {
+		if err := workload.Split(ctx, db, table, *concurrency); err != nil {
+			return err
+		}
+	}
 
 	var limiter *rate.Limiter
 	if *maxRate > 0 {

--- a/pkg/cmd/workload/teamcity-nightlies.go
+++ b/pkg/cmd/workload/teamcity-nightlies.go
@@ -39,11 +39,9 @@ func init() {
 // clusters (# of machines in each locality) are going to generalize. For now,
 // just hardcode what we had before.
 var singleDCTests = map[string]string{
-	// TODO(dan): Enable the final list once splits are supported in the `kv`
-	// workload.
-	// `kv0`: `./workload run kv --read-percent=0 --splits=1000 --concurrency=384 --duration=10m`,
-	// `kv95`: `./workload run kv --read-percent=95 --splits=1000 --concurrency=384 --duration=10m`,
-	`kv95`: `./workload run kv --read-percent=95 --concurrency=384 --duration=10m`,
+	`kv0`:    `./workload run kv --read-percent=0 --splits=1000 --concurrency=384 --duration=10m`,
+	`kv95`:   `./workload run kv --read-percent=95 --splits=1000 --concurrency=384 --duration=10m`,
+	`splits`: `./workload run kv --read-percent=0 --splits=100000 --concurrency=384 --max-ops=1`,
 }
 
 func runTeamcityNightlies(_ *cobra.Command, args []string) error {

--- a/pkg/sql/logictest/testdata/logic_test/scatter
+++ b/pkg/sql/logictest/testdata/logic_test/scatter
@@ -1,0 +1,8 @@
+# LogicTest: default
+
+statement ok
+CREATE TABLE t (a INT PRIMARY KEY)
+
+# Regression check that FROM == TO doesn't error
+statement ok
+ALTER TABLE t SCATTER FROM (1) TO (1)

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -107,8 +107,12 @@ func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error
 		}
 		// Tolerate reversing FROM and TO; this can be useful for descending
 		// indexes.
-		if span.Key.Compare(span.EndKey) > 0 {
+		if cmp := span.Key.Compare(span.EndKey); cmp > 0 {
 			span.Key, span.EndKey = span.EndKey, span.Key
+		} else if cmp == 0 {
+			// Key==EndKey is invalid, so special-case when the user's FROM and
+			// TO are the same tuple.
+			span.EndKey = span.EndKey.Next()
 		}
 	}
 

--- a/pkg/testutils/workload/bank/bank.go
+++ b/pkg/testutils/workload/bank/bank.go
@@ -122,6 +122,12 @@ func (b *bank) Tables() []workload.Table {
 				`'` + initialPrefix + bytes + `'`, // payload
 			}
 		},
+		SplitCount: b.ranges - 1,
+		SplitFn: func(splitIdx int) []string {
+			return []string{
+				strconv.Itoa((splitIdx + 1) * (b.rows / b.ranges)),
+			}
+		},
 	}
 	return []workload.Table{table}
 }

--- a/pkg/testutils/workload/kv/kv.go
+++ b/pkg/testutils/workload/kv/kv.go
@@ -46,6 +46,7 @@ type kv struct {
 	readPercent                          int
 	writeSeq, seed                       int64
 	sequential                           bool
+	splits                               int
 }
 
 func init() {
@@ -67,6 +68,7 @@ var kvMeta = workload.Meta{
 		g.flags.Int64Var(&g.writeSeq, `write-seq`, 0, `Initial write sequence value.`)
 		g.flags.Int64Var(&g.seed, `seed`, 1, `Key hash seed.`)
 		g.flags.BoolVar(&g.sequential, `sequential`, false, `Pick keys sequentially instead of randomly.`)
+		g.flags.IntVar(&g.splits, `splits`, 0, `Number of splits to perform before starting normal operations`)
 		return g
 	},
 }
@@ -87,22 +89,29 @@ func (w *kv) Hooks() workload.Hooks {
 				return errors.Errorf("Value of 'max-block-bytes' (%d) must be greater than or equal to value of 'min-block-bytes' (%d)",
 					w.maxBlockSizeBytes, w.minBlockSizeBytes)
 			}
-			// TODO(dan): Re-enable this check when splits are supported.
-			// if w.sequential && w.splits > 0 {
-			// 	return errors.Errorf("'sequential' and 'splits' cannot both be enabled")
-			// }
+			if w.sequential && w.splits > 0 {
+				return errors.New("'sequential' and 'splits' cannot both be enabled")
+			}
 			return nil
 		},
 	}
 }
 
 // Tables implements the Generator interface.
-func (*kv) Tables() []workload.Table {
+func (w *kv) Tables() []workload.Table {
 	table := workload.Table{
-		Name:            `kv`,
-		Schema:          kvSchema,
-		InitialRowCount: 0,
+		Name:   `kv`,
+		Schema: kvSchema,
 		// TODO(dan): Support initializing kv with data.
+		InitialRowCount: 0,
+		SplitCount:      w.splits,
+		SplitFn: func(splitIdx int) []string {
+			rng := rand.New(rand.NewSource(w.seed + int64(splitIdx)))
+			g := newHashGenerator(&sequence{config: w, val: w.writeSeq})
+			return []string{
+				fmt.Sprintf("%d", g.hash(rng.Int63())),
+			}
+		},
 	}
 	return []workload.Table{table}
 }

--- a/pkg/testutils/workload/stringstring_test.go
+++ b/pkg/testutils/workload/stringstring_test.go
@@ -1,0 +1,47 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package workload
+
+import (
+	"math/rand"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestStringStringSort(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	sorted := [][]string{
+		{},
+		{``},
+		{`a`},
+		{`a`, `b`},
+		{`a`, `c`},
+	}
+
+	// Create a shuffled version of sorted.
+	actual := make([][]string, len(sorted))
+	for i, v := range rand.Perm(len(actual)) {
+		actual[v] = sorted[i]
+	}
+
+	sort.Sort(stringStringSlice(actual))
+	if !reflect.DeepEqual(actual, sorted) {
+		t.Fatalf(`got %v expected %v`, actual, sorted)
+	}
+}

--- a/pkg/testutils/workload/workload_test.go
+++ b/pkg/testutils/workload/workload_test.go
@@ -76,3 +76,38 @@ func TestSetup(t *testing.T) {
 		})
 	}
 }
+
+func TestSplits(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const rows, payloadBytes, concurrency = 10, 0, 10
+	tests := []int{1, 2, 3, 4, 10}
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: `test`})
+	defer s.Stopper().Stop(ctx)
+
+	for _, ranges := range tests {
+		t.Run(fmt.Sprintf("ranges=%d", ranges), func(t *testing.T) {
+			sqlDB := sqlutils.MakeSQLRunner(db)
+			sqlDB.Exec(t, `DROP DATABASE IF EXISTS test`)
+			sqlDB.Exec(t, `CREATE DATABASE test`)
+
+			gen := bank.FromConfig(rows, payloadBytes, ranges)
+			table := gen.Tables()[0]
+			sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE test.%s %s`, table.Name, table.Schema))
+
+			if err := workload.Split(ctx, sqlDB.DB, table, concurrency); err != nil {
+				t.Fatalf("%+v", err)
+			}
+
+			var actual int
+			sqlDB.QueryRow(
+				t, `SELECT COUNT(*) FROM [SHOW TESTING_RANGES FROM TABLE test.bank]`,
+			).Scan(&actual)
+			if ranges != actual {
+				t.Errorf(`expected %d got %d`, ranges, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Plumb this from the `kv` workload to the `workload` cmd.

Release note: None