### PR TITLE
sql: only check tables for indexes during DROP INDEX

### DIFF
--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -50,7 +51,9 @@ func (p *planner) DropIndex(ctx context.Context, n *tree.DropIndex) (planNode, e
 				continue
 			}
 			// Index does not exist, but we want it to error out.
-			return nil, fmt.Errorf("index %q not found", index.Index)
+			return nil, pgerror.NewErrorf(
+				pgerror.CodeUndefinedObjectError, "index %q does not exist", index.Index,
+			)
 		}
 
 		tableDesc, err := MustGetTableDesc(ctx, p.txn, p.getVirtualTabler(), tn, true /*allowAdding*/)

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -201,3 +201,20 @@ users  primary  true    1    id      ASC        false    false
 
 statement ok
 DROP INDEX IF EXISTS baz
+
+# Test that presence of a view or sequence doesn't break DROP INDEX (#21834)
+
+statement ok
+CREATE DATABASE view_test
+
+statement ok
+SET DATABASE = view_test
+
+statement ok
+CREATE TABLE t (id INT)
+
+statement ok
+CREATE VIEW v AS SELECT id FROM t
+
+statement error pgcode 42704 pq: index "nonexistent_index" does not exist
+DROP INDEX nonexistent_index

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -218,3 +218,15 @@ CREATE VIEW v AS SELECT id FROM t
 
 statement error pgcode 42704 pq: index "nonexistent_index" does not exist
 DROP INDEX nonexistent_index
+
+statement ok
+CREATE DATABASE sequence_test
+
+statement ok
+SET DATABASE = sequence_test
+
+statement ok
+CREATE SEQUENCE s
+
+statement error pgcode 42704 pq: index "nonexistent_index" does not exist
+DROP INDEX nonexistent_index

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -821,12 +821,15 @@ func (p *planner) findTableContainingIndex(
 	result = nil
 	for i := range tns {
 		tn := &tns[i]
-		tableDesc, err := MustGetTableDesc(
-			ctx, p.txn, p.getVirtualTabler(), tn, true, /*allowAdding*/
-		)
+		tableDesc, err := getTableOrViewDesc(ctx, txn, vt, tn)
 		if err != nil {
 			return nil, err
 		}
+
+		if !tableDesc.IsTable() {
+			continue
+		}
+
 		_, dropped, err := tableDesc.FindIndexByName(string(idxName))
 		if err != nil || dropped {
 			continue


### PR DESCRIPTION
Previously, DROP INDEX was returning a nonsensical error message when a
view or sequence was present in the database, because it was
iterating over all TableDescriptors in the database, and asserting that
each one was a table before moving on to search it for indexes.

Instead, skip TableDescriptors that are not tables (views or sequences).

Fixes #21834

Release note: None