### PR TITLE
server: truncate query string in stmtstats

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -290,6 +290,9 @@ func (e *Executor) GetScrubbedStmtStats() []roachpb.CollectedStatementStatistics
 		for q, stats := range a.stmts {
 			scrubbed, ok := scrubStmtStatKey(vt, q.stmt)
 			if ok {
+				if len(scrubbed) >= 10000 {
+					scrubbed = scrubbed[:10000]
+				}
 				k := roachpb.StatementStatisticsKey{
 					Query:   scrubbed,
 					DistSQL: q.distSQLUsed,


### PR DESCRIPTION
This PR truncates a query string in stmtstats if it is greater than 10K characters. The length is arbitrary, but prevents the unfortunate scenario of having too large an entry in a primary key.

Addresses https://github.com/cockroachlabs/registration/issues/83